### PR TITLE
Add VEX exclusions for CVEs in `fleetdm/wix`

### DIFF
--- a/security/status.md
+++ b/security/status.md
@@ -819,6 +819,14 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2026-05-26 10:42:11
 
+### [CVE-2026-40355](https://nvd.nist.gov/vuln/detail/CVE-2026-40355)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not use Kerberos when using fleetdm/wix to generate msi installers.
+- **Products:** `wix`,`pkg:deb/debian/libgssapi-krb5-2`,`pkg:deb/debian/libk5crypto3`,`pkg:deb/debian/libkrb5-3`,`pkg:deb/debian/libkrb5support0`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-07-10 11:44:26
+
 ### [CVE-2026-3833](https://nvd.nist.gov/vuln/detail/CVE-2026-3833)
 - **Author:** @lucasmrod
 - **Status:** `not_affected`
@@ -946,6 +954,14 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Products:** `wix`,`pkg:deb/debian/libc6`,`pkg:deb/debian/libc-bin`
 - **Justification:** `vulnerable_code_cannot_be_controlled_by_adversary`
 - **Timestamp:** 2026-03-24 12:18:16
+
+### [CVE-2025-70103](https://nvd.nist.gov/vuln/detail/CVE-2025-70103)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not process image files when using fleetdm/wix to generate MSI packages.
+- **Products:** `wix`,`pkg:deb/debian/libjxl0.11`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-07-10 11:44:26
 
 ### [CVE-2025-66293](https://nvd.nist.gov/vuln/detail/CVE-2025-66293)
 - **Author:** @lucasmrod

--- a/security/vex/wix/CVE-2025-70103.vex.json
+++ b/security/vex/wix/CVE-2025-70103.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-6d3fec9fdd5fe72bfc3027cc69b78b614f2b7bff5c10bc39081f159224c863c3",
+  "author": "@lucasmrod",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-70103"
+      },
+      "products": [
+        {
+          "@id": "wix"
+        },
+        {
+          "@id": "pkg:deb/debian/libjxl0.11"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not process image files when using fleetdm/wix to generate MSI packages",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "timestamp": "2026-07-10T11:44:26.35637Z"
+    }
+  ],
+  "timestamp": "2026-07-10T11:44:26Z"
+}

--- a/security/vex/wix/CVE-2026-40355.vex.json
+++ b/security/vex/wix/CVE-2026-40355.vex.json
@@ -1,0 +1,35 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-9cfb888e893790252f67c394cbfe26ed6a6a9518fb9840a0e9fda5ee0963ab18",
+  "author": "@lucasmrod",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-40355"
+      },
+      "products": [
+        {
+          "@id": "wix"
+        },
+        {
+          "@id": "pkg:deb/debian/libgssapi-krb5-2"
+        },
+        {
+          "@id": "pkg:deb/debian/libk5crypto3"
+        },
+        {
+          "@id": "pkg:deb/debian/libkrb5-3"
+        },
+        {
+          "@id": "pkg:deb/debian/libkrb5support0"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not use Kerberos when using fleetdm/wix to generate msi installers",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "timestamp": "2026-07-10T11:44:26.339536Z"
+    }
+  ],
+  "timestamp": "2026-07-10T11:44:26Z"
+}


### PR DESCRIPTION
Fixes: https://github.com/fleetdm/fleet/actions/runs/29075556043.

New run: https://github.com/fleetdm/fleet/actions/runs/29090472465.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added vulnerability assessments for CVE-2025-70103 and CVE-2026-40355.
  * Documented the affected Wix-related components as not affected because the vulnerable code is not executed in the relevant workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->