### PR TITLE
SAAD: User channel + DDM assets for osquery-perf

### DIFF
--- a/cmd/osquery-perf/README.md
+++ b/cmd/osquery-perf/README.md
@@ -116,6 +116,10 @@ Example of running the agent with MDM. Note that `enroll_secret` is not needed f
 go run agent.go --os_templates ipad_13.18,iphone_14.6 --host_count 10 --mdm_scep_challenge 0d53306e-6d7a-9d14-a372-f9e53f9d62db
 ```
 
+`mdm_prob` determines the probability of MDM enrollment for each host. The default is 0.5 (50%). You can set it to 1.0 to ensure all hosts enroll in MDM.
+
+`mdm_user_prob` determines the probability of MDM user enrollment for each host. The default is 0.5 (50%). You can set it to 1.0 to ensure all hosts enroll in MDM user enrollment. This probability stacks with `mdm_prob`. So this probability is based on the hosts who end up MDM enrolling.
+
 ## Installing software
 
 The agent can install software for "macos", "ubuntu", and "windows" OSs when running with orbit agent. The following options control the installation behavior:

--- a/cmd/osquery-perf/README.md
+++ b/cmd/osquery-perf/README.md
@@ -116,9 +116,9 @@ Example of running the agent with MDM. Note that `enroll_secret` is not needed f
 go run agent.go --os_templates ipad_13.18,iphone_14.6 --host_count 10 --mdm_scep_challenge 0d53306e-6d7a-9d14-a372-f9e53f9d62db
 ```
 
-`mdm_prob` determines the probability of MDM enrollment for each host. The default is 0.5 (50%). You can set it to 1.0 to ensure all hosts enroll in MDM.
+`mdm_prob` determines the probability of MDM enrollment for each host. The default is 0 (0%). You can set it to 1.0 to ensure all hosts enroll in MDM.
 
-`mdm_user_prob` determines the probability of MDM user enrollment for each host. The default is 0.5 (50%). You can set it to 1.0 to ensure all hosts enroll in MDM user enrollment. This probability stacks with `mdm_prob`. So this probability is based on the hosts who end up MDM enrolling.
+`mdm_user_prob` determines the probability of MDM user enrollment for each host. The default is 0 (0%). You can set it to 1.0 to ensure all hosts enroll in MDM user enrollment. This probability stacks with `mdm_prob`. So this probability is based on the hosts who end up MDM enrolling.
 
 ## Installing software
 

--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -863,7 +863,7 @@ func (a *agent) runLoop(i int, onlyAlreadyEnrolled bool) {
 		if rand.Float64() < a.mdmUserProb {
 			if err := a.macMDMClient.UserEnroll(); err != nil {
 				log.Printf("macOS MDM user enroll failed: %s", err)
-				a.stats.IncrementMDMErrors()
+				a.stats.IncrementMDMUserErrors()
 				return
 			}
 			a.setMDMUserEnrolled()

--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -462,6 +462,8 @@ type agent struct {
 	macMDMClient *mdmtest.TestAppleMDMClient
 	winMDMClient *mdmtest.TestWindowsMDMClient
 
+	mdmUserProb float64
+
 	// winMDMWake signals the Windows MDM loop to start an OMA-DM session on demand (in response to the server's
 	// WindowsMDMSyncRequest notification), mirroring real fleetd waking the device. Buffered with capacity 1, sent
 	// non-blocking, so coalesced wakes never block the orbit config loop. Non-nil only for Windows MDM agents.
@@ -472,6 +474,9 @@ type agent struct {
 	// isEnrolledToMDMMu protects isEnrolledToMDM.
 	isEnrolledToMDMMu sync.Mutex
 
+	isMDMUserEnrolled   bool
+	isMDMUserEnrolledMu sync.Mutex
+
 	// Note that the following ddm variables do not need a mutex because they are only
 	// accessed in the MDM goroutine (and then only in the DDM handling function), and never
 	// read/written concurrently.
@@ -480,6 +485,11 @@ type agent struct {
 	ddmGlobalToken string
 	// ddmDeclTokens caches per-declaration tokens (identifier → serverToken).
 	ddmDeclTokens map[string]string
+
+	// ddmUserGlobalToken is the cached global DeclarationsToken from the tokens endpoint.
+	ddmUserGlobalToken string
+	// ddmUserDeclTokens caches per-declaration tokens (identifier → serverToken).
+	ddmUserDeclTokens map[string]string
 
 	disableScriptExec   bool
 	disableFleetDesktop bool
@@ -622,6 +632,7 @@ func newAgent(
 	emptySerialProb float64,
 	defaultSerialProb float64,
 	mdmProb float64,
+	mdmUserProb float64,
 	mdmSCEPChallenge string,
 	liveQueryFailProb float64,
 	liveQueryNoResultsProb float64,
@@ -724,6 +735,7 @@ func newAgent(
 
 		macMDMClient:  macMDMClient,
 		winMDMClient:  winMDMClient,
+		mdmUserProb:   mdmUserProb,
 		ddmDeclTokens: make(map[string]string),
 
 		disableScriptExec:        disableScriptExec,
@@ -847,6 +859,17 @@ func (a *agent) runLoop(i int, onlyAlreadyEnrolled bool) {
 		}
 		a.setMDMEnrolled()
 		a.stats.IncrementMDMEnrollments()
+
+		if rand.Float64() < a.mdmUserProb {
+			if err := a.macMDMClient.UserEnroll(); err != nil {
+				log.Printf("macOS MDM user enroll failed: %s", err)
+				a.stats.IncrementMDMErrors()
+				return
+			}
+			a.setMDMUserEnrolled()
+			a.stats.IncrementMDMUserEnrollments()
+		}
+
 		go a.runMacosMDMLoop()
 	}
 
@@ -1253,7 +1276,31 @@ func (a *agent) runMacosMDMLoop() {
 				}
 				// Note: Declarative management could happen async while other MDM commands proceed. This is a potential enhancement.
 				// (iff a real device does process DDM in parallel with traditional MDM commands).
-				a.doDeclarativeManagement(mdmCommandPayload)
+				a.doDeclarativeManagement(mdmCommandPayload, ddmMethods{
+					getGlobalToken: func() string {
+						return a.ddmGlobalToken
+					},
+					setGlobalToken: func(token string) {
+						a.ddmGlobalToken = token
+					},
+					getDeclTokens: func() map[string]string {
+						return a.ddmDeclTokens
+					},
+					setDeclTokens: func(tokens map[string]string) {
+						a.ddmDeclTokens = tokens
+					},
+					DeclarativeManagement:            a.macMDMClient.DeclarativeManagement,
+					IncrementTokensErrors:            a.stats.IncrementDDMTokensErrors,
+					IncrementTokensSuccess:           a.stats.IncrementDDMTokensSuccess,
+					IncrementDeclarationItemsErrors:  a.stats.IncrementDDMDeclarationItemsErrors,
+					IncrementDeclarationItemsSuccess: a.stats.IncrementDDMDeclarationItemsSuccess,
+					IncrementConfigurationErrors:     a.stats.IncrementDDMConfigurationErrors,
+					IncrementConfigurationSuccess:    a.stats.IncrementDDMConfigurationSuccess,
+					IncrementActivationErrors:        a.stats.IncrementDDMActivationErrors,
+					IncrementActivationSuccess:       a.stats.IncrementDDMActivationSuccess,
+					IncrementStatusErrors:            a.stats.IncrementDDMStatusErrors,
+					IncrementStatusSuccess:           a.stats.IncrementDDMStatusSuccess,
+				})
 				mdmCommandPayload = nextMdmCommandPayload
 
 			case "InstalledApplicationList":
@@ -1345,220 +1392,94 @@ func (a *agent) runMacosMDMLoop() {
 				}
 			}
 		}
-	}
-}
 
-func (a *agent) doDeclarativeManagement(cmd *mdm.Command) {
-	const maxAttempts = 3
+		// MDM User checkin
+		if a.mdmUserEnrolled() {
+			mdmCommandPayload, err = a.macMDMClient.UserIdle()
+			if err != nil {
+				log.Printf("MDM Idle request failed: %s", err)
+				a.stats.IncrementMDMUserErrors()
+				continue
+			}
+			a.stats.IncrementMDMUserSessions()
 
-	// prevToken starts as the last-applied global token. On each iteration,
-	// a tokens fetch is compared to it: if it matches, the server has settled
-	// (or nothing changed on the first pass). If it differs, we sync
-	// declaration-items and fetch changed declarations, then loop to check
-	// again (mimicking the real device behavior, see
-	// https://github.com/fleetdm/fleet/issues/43050#issuecomment-4252241277).
-	prevToken := a.ddmGlobalToken
-	var items *fleet.MDMAppleDDMDeclarationItemsResponse
-	var currentTokens map[string]string
-	changed := false
+		INNER_FOR_LOOP_USER:
+			for mdmCommandPayload != nil {
+				a.stats.IncrementMDMUserCommandsReceived()
 
-	for range maxAttempts {
-		// Fetch tokens — on the first pass this is the initial check against
-		// the cached token; on subsequent passes it is the convergence check
-		// for the previous iteration's sync.
-		globalToken, err := a.ddmFetchTokens()
-		if err != nil {
-			return
-		}
-		if globalToken == prevToken {
-			break // nothing changed, or server has settled
-		}
+				switch mdmCommandPayload.Command.RequestType {
+				case "InstallProfile":
+					if a.mdmProfileFailureProb > 0.0 && rand.Float64() <= a.mdmProfileFailureProb {
+						errChain := []mdm.ErrorChain{
+							{
+								ErrorCode:            89,
+								ErrorDomain:          "ErrorDomain",
+								LocalizedDescription: "The profile did not install",
+							},
+						}
+						mdmCommandPayload, err = a.macMDMClient.UserChannelErr(mdmCommandPayload.CommandUUID, errChain)
+						if err != nil {
+							log.Printf("MDM Error request failed: %s", err)
+							a.stats.IncrementMDMUserErrors()
+							break INNER_FOR_LOOP_USER
+						}
+					} else {
+						mdmCommandPayload, err = a.macMDMClient.UserAcknowledge(mdmCommandPayload.CommandUUID)
+						if err != nil {
+							log.Printf("MDM Acknowledge request failed: %s", err)
+							a.stats.IncrementMDMUserErrors()
+							break INNER_FOR_LOOP_USER
+						}
+					}
 
-		// Fetch declaration-items manifest
-		items, err = a.ddmFetchDeclarationItems()
-		if err != nil {
-			return
-		}
+				case "DeclarativeManagement":
+					// Device immediately responds with Acknowledged status and then contacts the Declarations endpoints.
+					nextMdmCommandPayload, err := a.macMDMClient.UserAcknowledge(mdmCommandPayload.CommandUUID)
+					if err != nil {
+						log.Printf("MDM Acknowledge request failed: %s", err)
+						a.stats.IncrementMDMUserErrors()
+						break INNER_FOR_LOOP_USER
+					}
+					// Note: Declarative management could happen async while other MDM commands proceed. This is a potential enhancement.
+					// (iff a real device does process DDM in parallel with traditional MDM commands).
+					a.doDeclarativeManagement(mdmCommandPayload, ddmMethods{
+						getGlobalToken: func() string {
+							return a.ddmUserGlobalToken
+						},
+						setGlobalToken: func(token string) {
+							a.ddmUserGlobalToken = token
+						},
+						getDeclTokens: func() map[string]string {
+							return a.ddmUserDeclTokens
+						},
+						setDeclTokens: func(tokens map[string]string) {
+							a.ddmUserDeclTokens = tokens
+						},
+						DeclarativeManagement:            a.macMDMClient.UserDeclarativeManagement,
+						IncrementTokensErrors:            a.stats.IncrementUserDDMTokensErrors,
+						IncrementTokensSuccess:           a.stats.IncrementUserDDMTokensSuccess,
+						IncrementDeclarationItemsErrors:  a.stats.IncrementUserDDMDeclarationItemsErrors,
+						IncrementDeclarationItemsSuccess: a.stats.IncrementUserDDMDeclarationItemsSuccess,
+						IncrementConfigurationErrors:     a.stats.IncrementUserDDMConfigurationErrors,
+						IncrementConfigurationSuccess:    a.stats.IncrementUserDDMConfigurationSuccess,
+						IncrementActivationErrors:        a.stats.IncrementUserDDMActivationErrors,
+						IncrementActivationSuccess:       a.stats.IncrementUserDDMActivationSuccess,
+						IncrementStatusErrors:            a.stats.IncrementUserDDMStatusErrors,
+						IncrementStatusSuccess:           a.stats.IncrementUserDDMStatusSuccess,
+					})
+					mdmCommandPayload = nextMdmCommandPayload
 
-		// Check each manifest item against cached tokens, fetch changed ones.
-		currentTokens = make(map[string]string, len(items.Declarations.Activations)+len(items.Declarations.Configurations))
-		for _, d := range items.Declarations.Activations {
-			currentTokens[d.Identifier] = d.ServerToken
-			if a.ddmDeclTokens[d.Identifier] != d.ServerToken {
-				if err := a.ddmFetchDeclaration("activation", d.Identifier); err != nil {
-					return
+				default:
+					mdmCommandPayload, err = a.macMDMClient.UserAcknowledge(mdmCommandPayload.CommandUUID)
+					if err != nil {
+						log.Printf("MDM Acknowledge request failed: %s", err)
+						a.stats.IncrementMDMUserErrors()
+						break INNER_FOR_LOOP_USER
+					}
 				}
-				changed = true
 			}
 		}
-
-		for _, d := range items.Declarations.Configurations {
-			currentTokens[d.Identifier] = d.ServerToken
-			if a.ddmDeclTokens[d.Identifier] != d.ServerToken {
-				if err := a.ddmFetchDeclaration("configuration", d.Identifier); err != nil {
-					return
-				}
-				changed = true
-			}
-		}
-
-		// Check for removed items (in cache but not in manifest) - no need to check if changes are
-		// already detected, as the whole set of declaration tokens will get replaced with the current ones.
-		// This is just to detect the case where the only change is a removal.
-		if !changed {
-			for id := range a.ddmDeclTokens {
-				if _, ok := currentTokens[id]; !ok {
-					changed = true
-					break
-				}
-			}
-		}
-
-		prevToken = globalToken
 	}
-
-	if !changed || items == nil {
-		return
-	}
-
-	// Server has settled (or max attempts exhausted) and declarations
-	// changed — send a single consolidated status report and update cache.
-	if err := a.ddmSendStatus(items); err != nil {
-		return
-	}
-	a.ddmGlobalToken = prevToken
-	a.ddmDeclTokens = currentTokens
-}
-
-func (a *agent) ddmFetchTokens() (string, error) {
-	r, err := a.macMDMClient.DeclarativeManagement("tokens")
-	if err != nil {
-		log.Printf("DDM tokens request failed: %s", err)
-		a.stats.IncrementDDMTokensErrors()
-		return "", err
-	}
-	defer r.Body.Close()
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		log.Printf("DDM tokens read body failed: %s", err)
-		a.stats.IncrementDDMTokensErrors()
-		return "", err
-	}
-	var resp fleet.MDMAppleDDMTokensResponse
-	if err := json.Unmarshal(body, &resp); err != nil {
-		log.Printf("DDM tokens unmarshal failed: %s", err)
-		a.stats.IncrementDDMTokensErrors()
-		return "", err
-	}
-	a.stats.IncrementDDMTokensSuccess()
-	return resp.SyncTokens.DeclarationsToken, nil
-}
-
-func (a *agent) ddmFetchDeclarationItems() (*fleet.MDMAppleDDMDeclarationItemsResponse, error) {
-	r, err := a.macMDMClient.DeclarativeManagement("declaration-items")
-	if err != nil {
-		log.Printf("DDM declaration-items request failed: %s", err)
-		a.stats.IncrementDDMDeclarationItemsErrors()
-		return nil, err
-	}
-	defer r.Body.Close()
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		log.Printf("DDM declaration-items read body failed: %s", err)
-		a.stats.IncrementDDMDeclarationItemsErrors()
-		return nil, err
-	}
-	var items fleet.MDMAppleDDMDeclarationItemsResponse
-	if err := json.Unmarshal(body, &items); err != nil {
-		log.Printf("DDM declaration-items unmarshal failed: %s", err)
-		a.stats.IncrementDDMDeclarationItemsErrors()
-		return nil, err
-	}
-	a.stats.IncrementDDMDeclarationItemsSuccess()
-	return &items, nil
-}
-
-func (a *agent) ddmFetchDeclaration(kind, identifier string) error {
-	path := fmt.Sprintf("declaration/%s/%s", kind, identifier)
-	r, err := a.macMDMClient.DeclarativeManagement(path)
-	if err != nil {
-		log.Printf("DDM %s request failed: %s", path, err)
-		a.ddmIncrementDeclError(kind)
-		return err
-	}
-	defer r.Body.Close()
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		log.Printf("DDM %s read body failed: %s", path, err)
-		a.ddmIncrementDeclError(kind)
-		return err
-	}
-	switch kind {
-	case "activation":
-		var act fleet.MDMAppleDDMActivation
-		if err := json.Unmarshal(body, &act); err != nil {
-			log.Printf("DDM %s unmarshal failed: %s", path, err)
-			a.ddmIncrementDeclError(kind)
-			return err
-		}
-		a.stats.IncrementDDMActivationSuccess()
-	case "configuration":
-		var decl fleet.MDMAppleDeclaration
-		if err := json.Unmarshal(body, &decl); err != nil {
-			log.Printf("DDM %s unmarshal failed: %s", path, err)
-			a.ddmIncrementDeclError(kind)
-			return err
-		}
-		a.stats.IncrementDDMConfigurationSuccess()
-	}
-	return nil
-}
-
-func (a *agent) ddmIncrementDeclError(kind string) {
-	switch kind {
-	case "activation":
-		a.stats.IncrementDDMActivationErrors()
-	case "configuration":
-		a.stats.IncrementDDMConfigurationErrors()
-	}
-}
-
-func (a *agent) ddmSendStatus(items *fleet.MDMAppleDDMDeclarationItemsResponse) error {
-	report := fleet.MDMAppleDDMStatusReport{}
-	for _, d := range items.Declarations.Activations {
-		report.StatusItems.Management.Declarations.Activations = append(
-			report.StatusItems.Management.Declarations.Activations,
-			fleet.MDMAppleDDMStatusDeclaration{
-				Active: true, Valid: fleet.MDMAppleDeclarationValid,
-				Identifier: d.Identifier, ServerToken: d.ServerToken,
-			},
-		)
-	}
-	for _, d := range items.Declarations.Configurations {
-		report.StatusItems.Management.Declarations.Configurations = append(
-			report.StatusItems.Management.Declarations.Configurations,
-			fleet.MDMAppleDDMStatusDeclaration{
-				Active: true, Valid: fleet.MDMAppleDeclarationValid,
-				Identifier: d.Identifier, ServerToken: d.ServerToken,
-			},
-		)
-	}
-
-	r, err := a.macMDMClient.DeclarativeManagement("status", report)
-	if err != nil {
-		log.Printf("DDM status request failed: %s", err)
-		a.stats.IncrementDDMStatusErrors()
-		return err
-	}
-	defer r.Body.Close()
-	_, _ = io.Copy(io.Discard, r.Body)
-	if r.StatusCode != http.StatusOK {
-		log.Printf("DDM status response unexpected: %d", r.StatusCode)
-		a.stats.IncrementDDMStatusErrors()
-		return fmt.Errorf("unexpected status code: %d", r.StatusCode)
-	}
-	a.stats.IncrementDDMStatusSuccess()
-	return nil
 }
 
 func (a *agent) runWindowsMDMLoop() {
@@ -2696,6 +2617,20 @@ func (a *agent) setMDMEnrolled() {
 	a.isEnrolledToMDM = true
 }
 
+func (a *agent) setMDMUserEnrolled() {
+	a.isMDMUserEnrolledMu.Lock()
+	defer a.isMDMUserEnrolledMu.Unlock()
+
+	a.isMDMUserEnrolled = true
+}
+
+func (a *agent) mdmUserEnrolled() bool {
+	a.isMDMUserEnrolledMu.Lock()
+	defer a.isMDMUserEnrolledMu.Unlock()
+
+	return a.isMDMUserEnrolled
+}
+
 func (a *agent) mdmWindows() []map[string]string {
 	if !a.mdmEnrolled() {
 		return []map[string]string{
@@ -3751,6 +3686,7 @@ func main() {
 			"Probability of osquery returning a default (-1) serial number. See: #19789")
 
 		mdmProb               = flag.Float64("mdm_prob", 0.0, "Probability of a host enrolling via Fleet MDM (applies for macOS and Windows hosts, implies orbit enrollment on Windows) [0, 1]")
+		mdmUserProb           = flag.Float64("mdm_user_prob", 0.0, "Probability of a host having an MDM user enrollment (compounds on mdm_prob) [0, 1]")
 		mdmSCEPChallenge      = flag.String("mdm_scep_challenge", "", "SCEP challenge to use when running macOS MDM enroll")
 		mdmProfileFailureProb = flag.Float64("mdm_profile_failure_prob", 0.0, "Probability of an MDM profile to fail install [0, 1]")
 
@@ -3980,6 +3916,7 @@ func main() {
 			*emptySerialProb,
 			*defaultSerialProb,
 			*mdmProb,
+			*mdmUserProb,
 			*mdmSCEPChallenge,
 			*liveQueryFailProb,
 			*liveQueryNoResultsProb,

--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -1300,6 +1300,8 @@ func (a *agent) runMacosMDMLoop() {
 					IncrementActivationSuccess:       a.stats.IncrementDDMActivationSuccess,
 					IncrementStatusErrors:            a.stats.IncrementDDMStatusErrors,
 					IncrementStatusSuccess:           a.stats.IncrementDDMStatusSuccess,
+					IncrementAssetErrors:             a.stats.IncrementDDMAssetErrors,
+					IncrementAssetSuccess:            a.stats.IncrementDDMAssetSuccess,
 				})
 				mdmCommandPayload = nextMdmCommandPayload
 
@@ -1466,6 +1468,8 @@ func (a *agent) runMacosMDMLoop() {
 						IncrementActivationSuccess:       a.stats.IncrementUserDDMActivationSuccess,
 						IncrementStatusErrors:            a.stats.IncrementUserDDMStatusErrors,
 						IncrementStatusSuccess:           a.stats.IncrementUserDDMStatusSuccess,
+						IncrementAssetErrors:             a.stats.IncrementUserDDMAssetErrors,
+						IncrementAssetSuccess:            a.stats.IncrementUserDDMAssetSuccess,
 					})
 					mdmCommandPayload = nextMdmCommandPayload
 

--- a/cmd/osquery-perf/ddm.go
+++ b/cmd/osquery-perf/ddm.go
@@ -26,6 +26,9 @@ type ddmMethods struct {
 	IncrementActivationErrors  func()
 	IncrementActivationSuccess func()
 
+	IncrementAssetErrors  func()
+	IncrementAssetSuccess func()
+
 	IncrementStatusErrors  func()
 	IncrementStatusSuccess func()
 
@@ -69,11 +72,21 @@ func (a *agent) doDeclarativeManagement(cmd *mdm.Command, methods ddmMethods) {
 		}
 
 		// Check each manifest item against cached tokens, fetch changed ones.
-		currentTokens = make(map[string]string, len(items.Declarations.Activations)+len(items.Declarations.Configurations))
+		currentTokens = make(map[string]string, len(items.Declarations.Activations)+len(items.Declarations.Configurations)+len(items.Declarations.Assets))
 		for _, d := range items.Declarations.Activations {
 			currentTokens[d.Identifier] = d.ServerToken
 			if methods.getDeclTokens()[d.Identifier] != d.ServerToken {
 				if err := a.ddmFetchDeclaration("activation", d.Identifier, methods); err != nil {
+					return
+				}
+				changed = true
+			}
+		}
+
+		for _, d := range items.Declarations.Assets {
+			currentTokens[d.Identifier] = d.ServerToken
+			if methods.getDeclTokens()[d.Identifier] != d.ServerToken {
+				if err := a.ddmFetchDeclaration("asset", d.Identifier, methods); err != nil {
 					return
 				}
 				changed = true
@@ -198,6 +211,14 @@ func (a *agent) ddmFetchDeclaration(kind, identifier string, methods ddmMethods)
 			return err
 		}
 		methods.IncrementConfigurationSuccess()
+	case "asset":
+		var asset fleet.RawDDMAsset
+		if err := json.Unmarshal(body, &asset); err != nil {
+			log.Printf("DDM %s unmarshal failed: %s", path, err)
+			a.ddmIncrementDeclError(kind, methods)
+			return err
+		}
+		methods.IncrementAssetSuccess()
 	}
 	return nil
 }
@@ -208,6 +229,8 @@ func (a *agent) ddmIncrementDeclError(kind string, methods ddmMethods) {
 		methods.IncrementActivationErrors()
 	case "configuration":
 		methods.IncrementConfigurationErrors()
+	case "asset":
+		methods.IncrementAssetErrors()
 	}
 }
 
@@ -216,6 +239,15 @@ func (a *agent) ddmSendStatus(items *fleet.MDMAppleDDMDeclarationItemsResponse, 
 	for _, d := range items.Declarations.Activations {
 		report.StatusItems.Management.Declarations.Activations = append(
 			report.StatusItems.Management.Declarations.Activations,
+			fleet.MDMAppleDDMStatusDeclaration{
+				Active: true, Valid: fleet.MDMAppleDeclarationValid,
+				Identifier: d.Identifier, ServerToken: d.ServerToken,
+			},
+		)
+	}
+	for _, d := range items.Declarations.Assets {
+		report.StatusItems.Management.Declarations.Assets = append(
+			report.StatusItems.Management.Declarations.Assets,
 			fleet.MDMAppleDDMStatusDeclaration{
 				Active: true, Valid: fleet.MDMAppleDeclarationValid,
 				Identifier: d.Identifier, ServerToken: d.ServerToken,

--- a/cmd/osquery-perf/ddm.go
+++ b/cmd/osquery-perf/ddm.go
@@ -264,7 +264,7 @@ func (a *agent) ddmSendStatus(items *fleet.MDMAppleDDMDeclarationItemsResponse, 
 		)
 	}
 
-	r, err := a.macMDMClient.DeclarativeManagement("status", report)
+	r, err := methods.DeclarativeManagement("status", report)
 	if err != nil {
 		log.Printf("DDM status request failed: %s", err)
 		methods.IncrementStatusErrors()

--- a/cmd/osquery-perf/ddm.go
+++ b/cmd/osquery-perf/ddm.go
@@ -1,0 +1,250 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/mdm"
+)
+
+// ddmMethods is a helper struct to abstract method calls into their respective user/device methods.
+type ddmMethods struct {
+	DeclarativeManagement func(endpoint string, data ...fleet.MDMAppleDDMStatusReport) (*http.Response, error)
+
+	IncrementTokensErrors            func()
+	IncrementTokensSuccess           func()
+	IncrementDeclarationItemsErrors  func()
+	IncrementDeclarationItemsSuccess func()
+
+	IncrementConfigurationErrors  func()
+	IncrementConfigurationSuccess func()
+
+	IncrementActivationErrors  func()
+	IncrementActivationSuccess func()
+
+	IncrementStatusErrors  func()
+	IncrementStatusSuccess func()
+
+	getGlobalToken func() string
+	setGlobalToken func(token string)
+
+	getDeclTokens func() map[string]string
+	setDeclTokens func(tokens map[string]string)
+}
+
+func (a *agent) doDeclarativeManagement(cmd *mdm.Command, methods ddmMethods) {
+	const maxAttempts = 3
+
+	// prevToken starts as the last-applied global token. On each iteration,
+	// a tokens fetch is compared to it: if it matches, the server has settled
+	// (or nothing changed on the first pass). If it differs, we sync
+	// declaration-items and fetch changed declarations, then loop to check
+	// again (mimicking the real device behavior, see
+	// https://github.com/fleetdm/fleet/issues/43050#issuecomment-4252241277).
+	prevToken := methods.getGlobalToken()
+	var items *fleet.MDMAppleDDMDeclarationItemsResponse
+	var currentTokens map[string]string
+	changed := false
+
+	for range maxAttempts {
+		// Fetch tokens — on the first pass this is the initial check against
+		// the cached token; on subsequent passes it is the convergence check
+		// for the previous iteration's sync.
+		globalToken, err := a.ddmFetchTokens(methods)
+		if err != nil {
+			return
+		}
+		if globalToken == prevToken {
+			break // nothing changed, or server has settled
+		}
+
+		// Fetch declaration-items manifest
+		items, err = a.ddmFetchDeclarationItems(methods)
+		if err != nil {
+			return
+		}
+
+		// Check each manifest item against cached tokens, fetch changed ones.
+		currentTokens = make(map[string]string, len(items.Declarations.Activations)+len(items.Declarations.Configurations))
+		for _, d := range items.Declarations.Activations {
+			currentTokens[d.Identifier] = d.ServerToken
+			if methods.getDeclTokens()[d.Identifier] != d.ServerToken {
+				if err := a.ddmFetchDeclaration("activation", d.Identifier, methods); err != nil {
+					return
+				}
+				changed = true
+			}
+		}
+
+		for _, d := range items.Declarations.Configurations {
+			currentTokens[d.Identifier] = d.ServerToken
+			if methods.getDeclTokens()[d.Identifier] != d.ServerToken {
+				if err := a.ddmFetchDeclaration("configuration", d.Identifier, methods); err != nil {
+					return
+				}
+				changed = true
+			}
+		}
+
+		// Check for removed items (in cache but not in manifest) - no need to check if changes are
+		// already detected, as the whole set of declaration tokens will get replaced with the current ones.
+		// This is just to detect the case where the only change is a removal.
+		if !changed {
+			for id := range methods.getDeclTokens() {
+				if _, ok := currentTokens[id]; !ok {
+					changed = true
+					break
+				}
+			}
+		}
+
+		prevToken = globalToken
+	}
+
+	if !changed || items == nil {
+		return
+	}
+
+	// Server has settled (or max attempts exhausted) and declarations
+	// changed — send a single consolidated status report and update cache.
+	if err := a.ddmSendStatus(items, methods); err != nil {
+		return
+	}
+	methods.setGlobalToken(prevToken)
+	methods.setDeclTokens(currentTokens)
+}
+
+func (a *agent) ddmFetchTokens(methods ddmMethods) (string, error) {
+	r, err := methods.DeclarativeManagement("tokens")
+	if err != nil {
+		log.Printf("DDM tokens request failed: %s", err)
+		methods.IncrementTokensErrors()
+		return "", err
+	}
+	defer r.Body.Close()
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		log.Printf("DDM tokens read body failed: %s", err)
+		methods.IncrementTokensErrors()
+		return "", err
+	}
+	var resp fleet.MDMAppleDDMTokensResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		log.Printf("DDM tokens unmarshal failed: %s", err)
+		methods.IncrementTokensErrors()
+		return "", err
+	}
+	methods.IncrementTokensSuccess()
+	return resp.SyncTokens.DeclarationsToken, nil
+}
+
+func (a *agent) ddmFetchDeclarationItems(methods ddmMethods) (*fleet.MDMAppleDDMDeclarationItemsResponse, error) {
+	r, err := methods.DeclarativeManagement("declaration-items")
+	if err != nil {
+		log.Printf("DDM declaration-items request failed: %s", err)
+		methods.IncrementDeclarationItemsErrors()
+		return nil, err
+	}
+	defer r.Body.Close()
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		log.Printf("DDM declaration-items read body failed: %s", err)
+		methods.IncrementDeclarationItemsErrors()
+		return nil, err
+	}
+	var items fleet.MDMAppleDDMDeclarationItemsResponse
+	if err := json.Unmarshal(body, &items); err != nil {
+		log.Printf("DDM declaration-items unmarshal failed: %s", err)
+		methods.IncrementDeclarationItemsErrors()
+		return nil, err
+	}
+	methods.IncrementDeclarationItemsSuccess()
+	return &items, nil
+}
+
+func (a *agent) ddmFetchDeclaration(kind, identifier string, methods ddmMethods) error {
+	path := fmt.Sprintf("declaration/%s/%s", kind, identifier)
+	r, err := methods.DeclarativeManagement(path)
+	if err != nil {
+		log.Printf("DDM %s request failed: %s", path, err)
+		a.ddmIncrementDeclError(kind, methods)
+		return err
+	}
+	defer r.Body.Close()
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		log.Printf("DDM %s read body failed: %s", path, err)
+		a.ddmIncrementDeclError(kind, methods)
+		return err
+	}
+	switch kind {
+	case "activation":
+		var act fleet.MDMAppleDDMActivation
+		if err := json.Unmarshal(body, &act); err != nil {
+			log.Printf("DDM %s unmarshal failed: %s", path, err)
+			a.ddmIncrementDeclError(kind, methods)
+			return err
+		}
+		methods.IncrementActivationSuccess()
+	case "configuration":
+		var decl fleet.MDMAppleDeclaration
+		if err := json.Unmarshal(body, &decl); err != nil {
+			log.Printf("DDM %s unmarshal failed: %s", path, err)
+			a.ddmIncrementDeclError(kind, methods)
+			return err
+		}
+		methods.IncrementConfigurationSuccess()
+	}
+	return nil
+}
+
+func (a *agent) ddmIncrementDeclError(kind string, methods ddmMethods) {
+	switch kind {
+	case "activation":
+		methods.IncrementActivationErrors()
+	case "configuration":
+		methods.IncrementConfigurationErrors()
+	}
+}
+
+func (a *agent) ddmSendStatus(items *fleet.MDMAppleDDMDeclarationItemsResponse, methods ddmMethods) error {
+	report := fleet.MDMAppleDDMStatusReport{}
+	for _, d := range items.Declarations.Activations {
+		report.StatusItems.Management.Declarations.Activations = append(
+			report.StatusItems.Management.Declarations.Activations,
+			fleet.MDMAppleDDMStatusDeclaration{
+				Active: true, Valid: fleet.MDMAppleDeclarationValid,
+				Identifier: d.Identifier, ServerToken: d.ServerToken,
+			},
+		)
+	}
+	for _, d := range items.Declarations.Configurations {
+		report.StatusItems.Management.Declarations.Configurations = append(
+			report.StatusItems.Management.Declarations.Configurations,
+			fleet.MDMAppleDDMStatusDeclaration{
+				Active: true, Valid: fleet.MDMAppleDeclarationValid,
+				Identifier: d.Identifier, ServerToken: d.ServerToken,
+			},
+		)
+	}
+
+	r, err := a.macMDMClient.DeclarativeManagement("status", report)
+	if err != nil {
+		log.Printf("DDM status request failed: %s", err)
+		methods.IncrementStatusErrors()
+		return err
+	}
+	defer r.Body.Close()
+	_, _ = io.Copy(io.Discard, r.Body)
+	if r.StatusCode != http.StatusOK {
+		log.Printf("DDM status response unexpected: %d", r.StatusCode)
+		methods.IncrementStatusErrors()
+		return fmt.Errorf("unexpected status code: %d", r.StatusCode)
+	}
+	methods.IncrementStatusSuccess()
+	return nil
+}

--- a/cmd/osquery-perf/osquery_perf/stats.go
+++ b/cmd/osquery-perf/osquery_perf/stats.go
@@ -34,20 +34,24 @@ type Stats struct {
 	ddmDeclarationItemsErrors      int
 	ddmConfigurationErrors         int
 	ddmActivationErrors            int
+	ddmAssetErrors                 int
 	ddmStatusErrors                int
 	ddmDeclarationItemsSuccess     int
 	ddmConfigurationSuccess        int
 	ddmActivationSuccess           int
+	ddmAssetSuccess                int
 	ddmStatusSuccess               int
 	ddmUserTokensErrors            int
 	ddmUserTokensSuccess           int
 	ddmUserDeclarationItemsErrors  int
 	ddmUserConfigurationErrors     int
 	ddmUserActivationErrors        int
+	ddmUserAssetErrors             int
 	ddmUserStatusErrors            int
 	ddmUserDeclarationItemsSuccess int
 	ddmUserConfigurationSuccess    int
 	ddmUserActivationSuccess       int
+	ddmUserAssetSuccess            int
 	ddmUserStatusSuccess           int
 	desktopErrors                  int
 	distributedReadErrors          int
@@ -220,6 +224,12 @@ func (s *Stats) IncrementDDMActivationErrors() {
 	s.ddmActivationErrors++
 }
 
+func (s *Stats) IncrementDDMAssetErrors() {
+	s.l.Lock()
+	defer s.l.Unlock()
+	s.ddmAssetErrors++
+}
+
 func (s *Stats) IncrementDDMStatusErrors() {
 	s.l.Lock()
 	defer s.l.Unlock()
@@ -242,6 +252,12 @@ func (s *Stats) IncrementDDMActivationSuccess() {
 	s.l.Lock()
 	defer s.l.Unlock()
 	s.ddmActivationSuccess++
+}
+
+func (s *Stats) IncrementDDMAssetSuccess() {
+	s.l.Lock()
+	defer s.l.Unlock()
+	s.ddmAssetSuccess++
 }
 
 func (s *Stats) IncrementDDMStatusSuccess() {
@@ -280,6 +296,12 @@ func (s *Stats) IncrementUserDDMActivationErrors() {
 	s.ddmUserActivationErrors++
 }
 
+func (s *Stats) IncrementUserDDMAssetErrors() {
+	s.l.Lock()
+	defer s.l.Unlock()
+	s.ddmUserAssetErrors++
+}
+
 func (s *Stats) IncrementUserDDMStatusErrors() {
 	s.l.Lock()
 	defer s.l.Unlock()
@@ -302,6 +324,12 @@ func (s *Stats) IncrementUserDDMActivationSuccess() {
 	s.l.Lock()
 	defer s.l.Unlock()
 	s.ddmUserActivationSuccess++
+}
+
+func (s *Stats) IncrementUserDDMAssetSuccess() {
+	s.l.Lock()
+	defer s.l.Unlock()
+	s.ddmUserAssetSuccess++
 }
 
 func (s *Stats) IncrementUserDDMStatusSuccess() {
@@ -372,7 +400,7 @@ func (s *Stats) Log() {
 	defer s.l.Unlock()
 
 	log.Printf(
-		"uptime: %s, error rate: %.2f, osquery enrolls: %d, orbit enrolls: %d, mdm enrolls: %d, mdm user enrolls: %d, distributed/reads: %d, distributed/writes: %d, config requests: %d, result log requests: %d, mdm sessions initiated: %d, mdm user sessions initiated: %d, mdm on-demand syncs: %d, mdm commands received: %d, mdm user commands received: %d, config errors: %d, distributed/read errors: %d, distributed/write errors: %d, log result errors: %d, orbit errors: %d, desktop errors: %d, mdm errors: %d, mdm user errors: %d, mdm scep requests: %d, mdm scep success: %d, mdm scep errors: %d, ddm tokens success: %d, ddm user tokens success: %d, ddm tokens errors: %d, ddm user tokens errors: %d, ddm declaration items success: %d, ddm user declaration items success: %d, ddm declaration items errors: %d, ddm user declaration items errors: %d, ddm activation success: %d, ddm user activation success: %d, ddm activation errors: %d, ddm user activation errors: %d, ddm configuration success: %d, ddm user configuration success: %d, ddm configuration errors: %d, ddm user configuration errors: %d, ddm status success: %d, ddm user status success: %d, ddm status errors: %d, ddm user status errors: %d, buffered logs: %d, script execs (errs): %d (%d), software installs (errs): %d (%d)",
+		"uptime: %s, error rate: %.2f, osquery enrolls: %d, orbit enrolls: %d, mdm enrolls: %d, mdm user enrolls: %d, distributed/reads: %d, distributed/writes: %d, config requests: %d, result log requests: %d, mdm sessions initiated: %d, mdm user sessions initiated: %d, mdm on-demand syncs: %d, mdm commands received: %d, mdm user commands received: %d, config errors: %d, distributed/read errors: %d, distributed/write errors: %d, log result errors: %d, orbit errors: %d, desktop errors: %d, mdm errors: %d, mdm user errors: %d, mdm scep requests: %d, mdm scep success: %d, mdm scep errors: %d, ddm tokens success: %d, ddm user tokens success: %d, ddm tokens errors: %d, ddm user tokens errors: %d, ddm declaration items success: %d, ddm user declaration items success: %d, ddm declaration items errors: %d, ddm user declaration items errors: %d, ddm activation success: %d, ddm user activation success: %d, ddm activation errors: %d, ddm user activation errors: %d, ddm configuration success: %d, ddm user configuration success: %d, ddm configuration errors: %d, ddm user configuration errors: %d, ddm asset success: %d, ddm user asset success: %d, ddm asset errors: %d, ddm user asset errors: %d, ddm status success: %d, ddm user status success: %d, ddm status errors: %d, ddm user status errors: %d, buffered logs: %d, script execs (errs): %d (%d), software installs (errs): %d (%d)",
 		time.Since(s.StartTime).Round(time.Second),
 		float64(s.errors)/float64(s.osqueryEnrollments),
 		s.osqueryEnrollments,
@@ -415,6 +443,10 @@ func (s *Stats) Log() {
 		s.ddmUserConfigurationSuccess,
 		s.ddmConfigurationErrors,
 		s.ddmUserConfigurationErrors,
+		s.ddmAssetSuccess,
+		s.ddmUserAssetSuccess,
+		s.ddmAssetErrors,
+		s.ddmUserAssetErrors,
 		s.ddmStatusSuccess,
 		s.ddmUserStatusSuccess,
 		s.ddmStatusErrors,

--- a/cmd/osquery-perf/osquery_perf/stats.go
+++ b/cmd/osquery-perf/osquery_perf/stats.go
@@ -7,43 +7,57 @@ import (
 )
 
 type Stats struct {
-	StartTime                  time.Time
-	errors                     int
-	osqueryEnrollments         int
-	orbitEnrollments           int
-	mdmEnrollments             int
-	mdmSessions                int
-	mdmOnDemandSyncs           int
-	distributedWrites          int
-	mdmCommandsReceived        int
-	mdmSCEPRequests            int
-	mdmSCEPSuccess             int
-	mdmSCEPErrors              int
-	distributedReads           int
-	configRequests             int
-	configErrors               int
-	resultLogRequests          int
-	orbitErrors                int
-	mdmErrors                  int
-	ddmTokensErrors            int
-	ddmTokensSuccess           int
-	ddmDeclarationItemsErrors  int
-	ddmConfigurationErrors     int
-	ddmActivationErrors        int
-	ddmStatusErrors            int
-	ddmDeclarationItemsSuccess int
-	ddmConfigurationSuccess    int
-	ddmActivationSuccess       int
-	ddmStatusSuccess           int
-	desktopErrors              int
-	distributedReadErrors      int
-	distributedWriteErrors     int
-	resultLogErrors            int
-	bufferedLogs               int
-	scriptExecs                int
-	scriptExecErrs             int
-	softwareInstalls           int
-	softwareInstallErrs        int
+	StartTime                      time.Time
+	errors                         int
+	osqueryEnrollments             int
+	orbitEnrollments               int
+	mdmEnrollments                 int
+	mdmUserEnrollments             int
+	mdmSessions                    int
+	mdmUserSessions                int
+	mdmOnDemandSyncs               int
+	distributedWrites              int
+	mdmCommandsReceived            int
+	mdmUserCommandsReceived        int
+	mdmSCEPRequests                int
+	mdmSCEPSuccess                 int
+	mdmSCEPErrors                  int
+	distributedReads               int
+	configRequests                 int
+	configErrors                   int
+	resultLogRequests              int
+	orbitErrors                    int
+	mdmErrors                      int
+	mdmUserErrors                  int
+	ddmTokensErrors                int
+	ddmTokensSuccess               int
+	ddmDeclarationItemsErrors      int
+	ddmConfigurationErrors         int
+	ddmActivationErrors            int
+	ddmStatusErrors                int
+	ddmDeclarationItemsSuccess     int
+	ddmConfigurationSuccess        int
+	ddmActivationSuccess           int
+	ddmStatusSuccess               int
+	ddmUserTokensErrors            int
+	ddmUserTokensSuccess           int
+	ddmUserDeclarationItemsErrors  int
+	ddmUserConfigurationErrors     int
+	ddmUserActivationErrors        int
+	ddmUserStatusErrors            int
+	ddmUserDeclarationItemsSuccess int
+	ddmUserConfigurationSuccess    int
+	ddmUserActivationSuccess       int
+	ddmUserStatusSuccess           int
+	desktopErrors                  int
+	distributedReadErrors          int
+	distributedWriteErrors         int
+	resultLogErrors                int
+	bufferedLogs                   int
+	scriptExecs                    int
+	scriptExecErrs                 int
+	softwareInstalls               int
+	softwareInstallErrs            int
 
 	l sync.Mutex
 }
@@ -72,10 +86,22 @@ func (s *Stats) IncrementMDMEnrollments() {
 	s.mdmEnrollments++
 }
 
+func (s *Stats) IncrementMDMUserEnrollments() {
+	s.l.Lock()
+	defer s.l.Unlock()
+	s.mdmUserEnrollments++
+}
+
 func (s *Stats) IncrementMDMSessions() {
 	s.l.Lock()
 	defer s.l.Unlock()
 	s.mdmSessions++
+}
+
+func (s *Stats) IncrementMDMUserSessions() {
+	s.l.Lock()
+	defer s.l.Unlock()
+	s.mdmUserSessions++
 }
 
 // IncrementMDMOnDemandSyncs counts Windows MDM sessions that were triggered by an on-demand wake
@@ -96,6 +122,12 @@ func (s *Stats) IncrementMDMCommandsReceived() {
 	s.l.Lock()
 	defer s.l.Unlock()
 	s.mdmCommandsReceived++
+}
+
+func (s *Stats) IncrementMDMUserCommandsReceived() {
+	s.l.Lock()
+	defer s.l.Unlock()
+	s.mdmUserCommandsReceived++
 }
 
 func (s *Stats) IncrementDistributedReads() {
@@ -132,6 +164,12 @@ func (s *Stats) IncrementMDMErrors() {
 	s.l.Lock()
 	defer s.l.Unlock()
 	s.mdmErrors++
+}
+
+func (s *Stats) IncrementMDMUserErrors() {
+	s.l.Lock()
+	defer s.l.Unlock()
+	s.mdmUserErrors++
 }
 
 func (s *Stats) IncrementMDMSCEPRequests() {
@@ -212,6 +250,66 @@ func (s *Stats) IncrementDDMStatusSuccess() {
 	s.ddmStatusSuccess++
 }
 
+func (s *Stats) IncrementUserDDMTokensErrors() {
+	s.l.Lock()
+	defer s.l.Unlock()
+	s.ddmUserTokensErrors++
+}
+
+func (s *Stats) IncrementUserDDMTokensSuccess() {
+	s.l.Lock()
+	defer s.l.Unlock()
+	s.ddmUserTokensSuccess++
+}
+
+func (s *Stats) IncrementUserDDMDeclarationItemsErrors() {
+	s.l.Lock()
+	defer s.l.Unlock()
+	s.ddmUserDeclarationItemsErrors++
+}
+
+func (s *Stats) IncrementUserDDMConfigurationErrors() {
+	s.l.Lock()
+	defer s.l.Unlock()
+	s.ddmUserConfigurationErrors++
+}
+
+func (s *Stats) IncrementUserDDMActivationErrors() {
+	s.l.Lock()
+	defer s.l.Unlock()
+	s.ddmUserActivationErrors++
+}
+
+func (s *Stats) IncrementUserDDMStatusErrors() {
+	s.l.Lock()
+	defer s.l.Unlock()
+	s.ddmUserStatusErrors++
+}
+
+func (s *Stats) IncrementUserDDMDeclarationItemsSuccess() {
+	s.l.Lock()
+	defer s.l.Unlock()
+	s.ddmUserDeclarationItemsSuccess++
+}
+
+func (s *Stats) IncrementUserDDMConfigurationSuccess() {
+	s.l.Lock()
+	defer s.l.Unlock()
+	s.ddmUserConfigurationSuccess++
+}
+
+func (s *Stats) IncrementUserDDMActivationSuccess() {
+	s.l.Lock()
+	defer s.l.Unlock()
+	s.ddmUserActivationSuccess++
+}
+
+func (s *Stats) IncrementUserDDMStatusSuccess() {
+	s.l.Lock()
+	defer s.l.Unlock()
+	s.ddmUserStatusSuccess++
+}
+
 func (s *Stats) IncrementDesktopErrors() {
 	s.l.Lock()
 	defer s.l.Unlock()
@@ -274,19 +372,22 @@ func (s *Stats) Log() {
 	defer s.l.Unlock()
 
 	log.Printf(
-		"uptime: %s, error rate: %.2f, osquery enrolls: %d, orbit enrolls: %d, mdm enrolls: %d, distributed/reads: %d, distributed/writes: %d, config requests: %d, result log requests: %d, mdm sessions initiated: %d, mdm on-demand syncs: %d, mdm commands received: %d, config errors: %d, distributed/read errors: %d, distributed/write errors: %d, log result errors: %d, orbit errors: %d, desktop errors: %d, mdm errors: %d, mdm scep requests: %d, mdm scep success: %d, mdm scep errors: %d, ddm tokens success: %d, ddm tokens errors: %d, ddm declaration items success: %d, ddm declaration items errors: %d, ddm activation success: %d, ddm activation errors: %d, ddm configuration success: %d, ddm configuration errors: %d, ddm status success: %d, ddm status errors: %d, buffered logs: %d, script execs (errs): %d (%d), software installs (errs): %d (%d)",
+		"uptime: %s, error rate: %.2f, osquery enrolls: %d, orbit enrolls: %d, mdm enrolls: %d, mdm user enrolls: %d, distributed/reads: %d, distributed/writes: %d, config requests: %d, result log requests: %d, mdm sessions initiated: %d, mdm user sessions initiated: %d, mdm on-demand syncs: %d, mdm commands received: %d, mdm user commands received: %d, config errors: %d, distributed/read errors: %d, distributed/write errors: %d, log result errors: %d, orbit errors: %d, desktop errors: %d, mdm errors: %d, mdm user errors: %d, mdm scep requests: %d, mdm scep success: %d, mdm scep errors: %d, ddm tokens success: %d, ddm user tokens success: %d, ddm tokens errors: %d, ddm user tokens errors: %d, ddm declaration items success: %d, ddm user declaration items success: %d, ddm declaration items errors: %d, ddm user declaration items errors: %d, ddm activation success: %d, ddm user activation success: %d, ddm activation errors: %d, ddm user activation errors: %d, ddm configuration success: %d, ddm user configuration success: %d, ddm configuration errors: %d, ddm user configuration errors: %d, ddm status success: %d, ddm user status success: %d, ddm status errors: %d, ddm user status errors: %d, buffered logs: %d, script execs (errs): %d (%d), software installs (errs): %d (%d)",
 		time.Since(s.StartTime).Round(time.Second),
 		float64(s.errors)/float64(s.osqueryEnrollments),
 		s.osqueryEnrollments,
 		s.orbitEnrollments,
 		s.mdmEnrollments,
+		s.mdmUserEnrollments,
 		s.distributedReads,
 		s.distributedWrites,
 		s.configRequests,
 		s.resultLogRequests,
 		s.mdmSessions,
+		s.mdmUserSessions,
 		s.mdmOnDemandSyncs,
 		s.mdmCommandsReceived,
+		s.mdmUserCommandsReceived,
 		s.configErrors,
 		s.distributedReadErrors,
 		s.distributedWriteErrors,
@@ -294,19 +395,30 @@ func (s *Stats) Log() {
 		s.orbitErrors,
 		s.desktopErrors,
 		s.mdmErrors,
+		s.mdmUserErrors,
 		s.mdmSCEPRequests,
 		s.mdmSCEPSuccess,
 		s.mdmSCEPErrors,
 		s.ddmTokensSuccess,
+		s.ddmUserTokensSuccess,
 		s.ddmTokensErrors,
+		s.ddmUserTokensErrors,
 		s.ddmDeclarationItemsSuccess,
+		s.ddmUserDeclarationItemsSuccess,
 		s.ddmDeclarationItemsErrors,
+		s.ddmUserDeclarationItemsErrors,
 		s.ddmActivationSuccess,
+		s.ddmUserActivationSuccess,
 		s.ddmActivationErrors,
+		s.ddmUserActivationErrors,
 		s.ddmConfigurationSuccess,
+		s.ddmUserConfigurationSuccess,
 		s.ddmConfigurationErrors,
+		s.ddmUserConfigurationErrors,
 		s.ddmStatusSuccess,
+		s.ddmUserStatusSuccess,
 		s.ddmStatusErrors,
+		s.ddmUserStatusErrors,
 		s.bufferedLogs,
 		s.scriptExecs,
 		s.scriptExecErrs,


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #48573

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information. In another PR

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for macOS MDM user enrollment simulation, configurable via enrollment probability.
  * Implemented user-scoped Declarative Device Management handling for tokens, declarations, configurations, assets, and status reporting.
  * Added new performance metrics for MDM user activity and DDM user activity (including tokens, items, and status outcomes).

* **Bug Fixes**
  * Improved DDM synchronization by detecting declaration changes/removals and consolidating status updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->