### PR TITLE
Tooltips not always showing for full name (IdP)

### DIFF
--- a/changes/48125-tooltip-not-showing-idp
+++ b/changes/48125-tooltip-not-showing-idp
@@ -1,0 +1,1 @@
+- Fixed an issue where tooltips for full name did not always show.

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -804,8 +804,6 @@ const DeviceUserPage = ({
                   className={fullWidthCardClass}
                   canWriteEndUser={false}
                   endUsers={host.end_users ?? []}
-                  disableFullNameTooltip
-                  disableGroupsTooltip
                 />
                 {isAppleHost && !!deviceCertificates?.certificates.length && (
                   <CertificatesCard

--- a/frontend/pages/hosts/details/cards/User/User.tests.tsx
+++ b/frontend/pages/hosts/details/cards/User/User.tests.tsx
@@ -1,12 +1,15 @@
 import React from "react";
-import { screen, render } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import { noop } from "lodash";
+import { createCustomRenderer } from "test/test-utils";
 
 import { createMockHostEndUser } from "__mocks__/hostMock";
 
 import User from ".";
 
 describe("User card", () => {
+  const render = createCustomRenderer();
+
   describe("IdP data", () => {
     it("renders the username, full name, groups, and department fields", () => {
       const endUsers = [createMockHostEndUser()];
@@ -44,6 +47,30 @@ describe("User card", () => {
       );
       expect(screen.queryByText("Add user")).toBeNull();
       expect(screen.getByText("Edit user")).toBeInTheDocument();
+    });
+
+    describe("Tooltips", () => {
+      it.each([
+        [
+          "Full name (IdP)",
+          'This is the "givenName + familyName" from your IdP.',
+        ],
+        [
+          "Department (IdP)",
+          'This is the "department" collected from your IdP.',
+        ],
+      ])("always renders the tooltip for %s", async (field, tooltipContent) => {
+        const { user } = render(
+          <User endUsers={[]} onClickUpdateUser={noop} />
+        );
+
+        await user.hover(screen.getByText(field));
+        await waitFor(() => {
+          const tooltip = screen.getByRole("tooltip");
+          expect(tooltip).toBeInTheDocument();
+          expect(tooltip.textContent).toBe(tooltipContent);
+        });
+      });
     });
   });
 

--- a/frontend/pages/hosts/details/cards/User/User.tsx
+++ b/frontend/pages/hosts/details/cards/User/User.tsx
@@ -103,19 +103,23 @@ const User = ({
 
         <DataSet
           title={
-            <TooltipWrapper tipContent='This is the "givenName + familyName" from your IdP.'>
+            <TooltipWrapper
+              tipContent={`This is the "givenName + familyName" from your IdP.`}
+            >
               Full name (IdP)
             </TooltipWrapper>
           }
           value={<UserValue values={generateFullNameValues(endUsers)} />}
         />
         <DataSet
-          title={"Groups (IdP)"}
+          title="Groups (IdP)"
           value={<UserValue values={generateGroupsValues(endUsers)} />}
         />
         <DataSet
           title={
-            <TooltipWrapper tipContent='This is the "department" collected from your IdP.'>
+            <TooltipWrapper
+              tipContent={`This is the "department" collected from your IdP.`}
+            >
               Department (IdP)
             </TooltipWrapper>
           }

--- a/frontend/pages/hosts/details/cards/User/User.tsx
+++ b/frontend/pages/hosts/details/cards/User/User.tsx
@@ -14,9 +14,7 @@ import UserValue from "./components/UserValue";
 import {
   generateChromeProfilesValues,
   generateUsernameValues,
-  generateFullNameTipContent,
   generateFullNameValues,
-  generateGroupsTipContent,
   generateGroupsValues,
   generateOtherEmailsValues,
 } from "./helpers";
@@ -28,8 +26,6 @@ interface IUserProps {
   endUsers: IHostEndUser[];
   canWriteEndUser?: boolean;
   canViewMyDeviceLink?: boolean;
-  disableFullNameTooltip?: boolean;
-  disableGroupsTooltip?: boolean;
   className?: string;
   onClickUpdateUser?: (
     e:
@@ -47,8 +43,6 @@ const User = ({
   endUsers,
   canWriteEndUser = false,
   canViewMyDeviceLink = false,
-  disableFullNameTooltip = false,
-  disableGroupsTooltip = false,
   className,
   onClickUpdateUser,
   onClickMyDevice,
@@ -71,7 +65,6 @@ const User = ({
   if (endUser?.idp_department) {
     userDepartment.push(endUser.idp_department);
   }
-  const groupsTipContent = generateGroupsTipContent(endUsers);
 
   return (
     <Card
@@ -110,26 +103,14 @@ const User = ({
 
         <DataSet
           title={
-            disableFullNameTooltip ? (
-              "Full name (IdP)"
-            ) : (
-              <TooltipWrapper tipContent={generateFullNameTipContent(endUsers)}>
-                Full name (IdP)
-              </TooltipWrapper>
-            )
+            <TooltipWrapper tipContent='This is the "givenName + familyName" from your IdP.'>
+              Full name (IdP)
+            </TooltipWrapper>
           }
           value={<UserValue values={generateFullNameValues(endUsers)} />}
         />
         <DataSet
-          title={
-            disableGroupsTooltip || !groupsTipContent ? (
-              "Groups (IdP)"
-            ) : (
-              <TooltipWrapper tipContent={groupsTipContent}>
-                <>Groups (IdP)</>
-              </TooltipWrapper>
-            )
-          }
+          title={"Groups (IdP)"}
           value={<UserValue values={generateGroupsValues(endUsers)} />}
         />
         <DataSet

--- a/frontend/pages/hosts/details/cards/User/helpers.tsx
+++ b/frontend/pages/hosts/details/cards/User/helpers.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import { IHostEndUser } from "interfaces/host";
 
 export const generateUsernameValues = (endUsers: IHostEndUser[]) => {
@@ -69,40 +67,4 @@ export const generateOtherEmailsValues = (endUsers: IHostEndUser[]) => {
     }
     return acc;
   }, []);
-};
-
-export const generateFullNameTipContent = (endUsers: IHostEndUser[]) => {
-  if (endUsers.length === 0) return null;
-
-  if (endUsers[0].idp_info_updated_at === null) {
-    return (
-      <>
-        Connect your identity provider to Fleet on the{" "}
-        <b>
-          Settings {">"} Integrations {">"} IdP
-        </b>{" "}
-        page.
-      </>
-    );
-  }
-
-  return <>This is the {'"givenName + familyName"'} from your IdP.</>;
-};
-
-export const generateGroupsTipContent = (endUsers: IHostEndUser[]) => {
-  if (endUsers.length === 0) return null;
-
-  if (endUsers[0].idp_info_updated_at === null) {
-    return (
-      <>
-        Connect your identity provider to Fleet on the{" "}
-        <b>
-          Settings {">"} Integrations {">"} IdP
-        </b>{" "}
-        page.
-      </>
-    );
-  }
-
-  return null;
 };


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #48125

Side effect is that we will no longer show the "Connect IdP" tooltip.

https://github.com/user-attachments/assets/303836fb-a1c3-4d5e-9c2b-3fddd0dfb4d1


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue in the device Details → Users area where tooltips for a person’s full name and related IdP fields could fail to appear.
  * Tooltips now render reliably and show the correct help text when hovering the affected fields.

* **Tests**
  * Expanded automated coverage to confirm tooltip visibility and the displayed tooltip content for the user details card.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->