### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/aws-vpn-client/windows.json
+++ b/ee/maintained-apps/outputs/aws-vpn-client/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "5.4.0",
+      "version": "5.4.1",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'AWS VPN Client' AND publisher = 'Amazon';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'AWS VPN Client' AND publisher = 'Amazon' AND version_compare(version, '5.4.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'AWS VPN Client' AND publisher = 'Amazon' AND version_compare(version, '5.4.1') < 0);"
       },
-      "installer_url": "https://d20adtppz83p9s.cloudfront.net/WPF/5.4.0/AWS_VPN_Client.msi",
+      "installer_url": "https://d20adtppz83p9s.cloudfront.net/WPF/5.4.1/AWS_VPN_Client.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "ff441c4a",
-      "sha256": "a373d0494f153b700701451cdac70a371b6456d0e05aa1fe6c14ef87d63b5c6d",
+      "sha256": "010278c7e8cfefaac0bc7ab17d51a80693b10388344d5e46b313e41f279e2863",
       "default_categories": [
         "Productivity"
       ],

--- a/ee/maintained-apps/outputs/brave-browser/windows.json
+++ b/ee/maintained-apps/outputs/brave-browser/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "150.1.92.134",
+      "version": "150.1.92.139",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Brave' AND publisher = 'Brave Software Inc';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Brave' AND publisher = 'Brave Software Inc' AND version_compare(version, '150.1.92.134') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Brave' AND publisher = 'Brave Software Inc' AND version_compare(version, '150.1.92.139') < 0);"
       },
-      "installer_url": "https://github.com/brave/brave-browser/releases/download/v1.92.134/BraveBrowserStandaloneSilentSetup.exe",
+      "installer_url": "https://github.com/brave/brave-browser/releases/download/v1.92.139/BraveBrowserStandaloneSilentSetup.exe",
       "install_script_ref": "9a0c2b15",
       "uninstall_script_ref": "30c77f69",
-      "sha256": "4726e28a23da1b0b253efb63736efc9b20a580f26017f93f72ebdacf471c657a",
+      "sha256": "0e63b0614431c9ee276d7d8aa0f4a0afcb3741663ea60f47f7adf6d46167037c",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/cursor/darwin.json
+++ b/ee/maintained-apps/outputs/cursor/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.10.20",
+      "version": "3.11.13",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92' AND version_compare(bundle_short_version, '3.10.20') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92' AND version_compare(bundle_short_version, '3.11.13') < 0);"
       },
-      "installer_url": "https://downloads.cursor.com/production/23b9fb205fe595ea2be29da7214e19762d037fc3/darwin/arm64/Cursor-darwin-arm64.zip",
+      "installer_url": "https://downloads.cursor.com/production/3f21b08f0b436a07be29fbfe00b304fa15553353/darwin/arm64/Cursor-darwin-arm64.zip",
       "install_script_ref": "5147ff0b",
       "uninstall_script_ref": "9d80ae1c",
-      "sha256": "be7e47daf36087404a15e49509bd8690db5c1a5ad388cb89dd408f33d068246a",
+      "sha256": "c4416be422f654e5bc9b0ad3ff024376029af95074af58489f94b29230eded03",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/daisydisk/darwin.json
+++ b/ee/maintained-apps/outputs/daisydisk/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "4.34.1",
+      "version": "4.34.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.daisydiskapp.DaisyDiskStandAlone';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.daisydiskapp.DaisyDiskStandAlone' AND version_compare(bundle_short_version, '4.34.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.daisydiskapp.DaisyDiskStandAlone' AND version_compare(bundle_short_version, '4.34.2') < 0);"
       },
       "installer_url": "https://daisydiskapp.com/download/DaisyDisk.zip",
       "install_script_ref": "af1b217c",

--- a/ee/maintained-apps/outputs/figma/windows.json
+++ b/ee/maintained-apps/outputs/figma/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "126.6.12",
+      "version": "126.6.14",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Figma' AND publisher = 'Figma, Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Figma' AND publisher = 'Figma, Inc.' AND version_compare(version, '126.6.12') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Figma' AND publisher = 'Figma, Inc.' AND version_compare(version, '126.6.14') < 0);"
       },
-      "installer_url": "https://desktop.figma.com/win/build/Figma-126.6.12.exe",
+      "installer_url": "https://desktop.figma.com/win/build/Figma-126.6.14.exe",
       "install_script_ref": "442d71b3",
       "uninstall_script_ref": "e33afd6b",
-      "sha256": "371ddadf46485dd23b8b9f526988fbf2fa37e57ef1ee710e780961396cac14ca",
+      "sha256": "5e9fc18f0145ec914b9ec82f18264f680b77d32366948b33b3d7b16b2c7685b0",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/grammarly-desktop/darwin.json
+++ b/ee/maintained-apps/outputs/grammarly-desktop/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.173.1",
+      "version": "1.173.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama' AND version_compare(bundle_short_version, '1.173.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama' AND version_compare(bundle_short_version, '1.173.2') < 0);"
       },
-      "installer_url": "https://download-mac.grammarly.com/versions/1.173.1.0/Grammarly.dmg",
+      "installer_url": "https://download-mac.grammarly.com/versions/1.173.2.0/Grammarly.dmg",
       "install_script_ref": "df3d0525",
       "uninstall_script_ref": "e14b2d61",
-      "sha256": "8962481209b3547873e211bf75c315fc1d54590f185778d1096c876eddbfc889",
+      "sha256": "9420f44f794352fbd571365f5b5f8fef303321051f7b815ed4885c2f9477fcf6",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/kiro/windows.json
+++ b/ee/maintained-apps/outputs/kiro/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.0.89",
+      "version": "1.0.116",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Kiro (User)' AND publisher = 'Amazon Web Services';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Kiro (User)' AND publisher = 'Amazon Web Services' AND version_compare(version, '1.0.89') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Kiro (User)' AND publisher = 'Amazon Web Services' AND version_compare(version, '1.0.116') < 0);"
       },
-      "installer_url": "https://prod.download.desktop.kiro.dev/releases/stable/win32-x64/signed/1.0.89/kiro-ide-1.0.89-stable-win32-x64.exe",
+      "installer_url": "https://prod.download.desktop.kiro.dev/releases/stable/win32-x64/signed/1.0.116/kiro-ide-1.0.116-stable-win32-x64.exe",
       "install_script_ref": "c5bc3c21",
       "uninstall_script_ref": "afe8f2fa",
-      "sha256": "65b5325c887522dcf9179c181015b9777960d7c6fdcc9d593abd261dcd637e0e",
+      "sha256": "49eef30b675ee3d0fd74e822a96c1da196d570539a83c055087e264cf7b04f46",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/microsoft-edge/windows.json
+++ b/ee/maintained-apps/outputs/microsoft-edge/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "150.0.4078.48",
+      "version": "150.0.4078.65",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Microsoft Edge' AND publisher = 'Microsoft Corporation';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Microsoft Edge' AND publisher = 'Microsoft Corporation' AND version_compare(version, '150.0.4078.48') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Microsoft Edge' AND publisher = 'Microsoft Corporation' AND version_compare(version, '150.0.4078.65') < 0);"
       },
-      "installer_url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/6476e2cb-803c-4ed9-b91f-60caaa21dbfd/MicrosoftEdgeEnterpriseX64.msi",
+      "installer_url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/0870b5f5-cf08-4f24-8383-f362a669fcd8/MicrosoftEdgeEnterpriseX64.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "e12e9902",
-      "sha256": "94a406cdc1ab9c1c8ac8aa48b42d89e4e35cee68622cda718b301e5e3ed93b49",
+      "sha256": "037340dc31dc0d2dd6c0d7e7627064b3f34b03656d37a7cab499f4e8a1697882",
       "default_categories": [
         "Browsers"
       ],

--- a/ee/maintained-apps/outputs/nordvpn/windows.json
+++ b/ee/maintained-apps/outputs/nordvpn/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "8.4.3.0",
+      "version": "8.5.1.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'NordVPN %' AND publisher = 'Nord Security';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'NordVPN %' AND publisher = 'Nord Security' AND version_compare(version, '8.4.3.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'NordVPN %' AND publisher = 'Nord Security' AND version_compare(version, '8.5.1.0') < 0);"
       },
-      "installer_url": "https://downloads.nordcdn.com/apps/windows/NordVPN/8.4.3.0/NordVPNInstall.exe",
+      "installer_url": "https://downloads.nordcdn.com/apps/windows/NordVPN/8.5.1.0/NordVPNInstall.exe",
       "install_script_ref": "61026ed8",
       "uninstall_script_ref": "b5dba69c",
-      "sha256": "aab8c8eacab4a71762ade6b49e646b6888d74c536c1d7b95d6b74b16bc0721f8",
+      "sha256": "b000fe1ccd6ac286b25fc4d0023f0f43938c6c81ddfcb64762bc4705a1b0fdd6",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/notepadexe/darwin.json
+++ b/ee/maintained-apps/outputs/notepadexe/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.4.1925",
+      "version": "1.4.1929",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'best.swift.Notepad';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'best.swift.Notepad' AND version_compare(bundle_short_version, '1.4.1925') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'best.swift.Notepad' AND version_compare(bundle_short_version, '1.4.1929') < 0);"
       },
-      "installer_url": "https://github.com/notepadhq/notepadexe-public/releases/download/1.4.1925/Notepad.zip",
+      "installer_url": "https://github.com/notepadhq/notepadexe-public/releases/download/1.4.1929/Notepad.zip",
       "install_script_ref": "17716d6a",
       "uninstall_script_ref": "abe56690",
-      "sha256": "e835d68eb7c7ea1d8ee9d54fbae1240d268452043b7e9eaebbf693e89ff82a1d",
+      "sha256": "e37521b7a498cdd93c2794eebc11f11d45ac9e7b1182bafead44e87699734229",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/ocenaudio/darwin.json
+++ b/ee/maintained-apps/outputs/ocenaudio/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "3.19.5",
+      "version": "3.20.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.ocenaudio';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.ocenaudio' AND version_compare(bundle_short_version, '3.19.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.ocenaudio' AND version_compare(bundle_short_version, '3.20.0') < 0);"
       },
       "installer_url": "https://www.ocenaudio.com/downloads/index.php/ocenaudio_universal.dmg",
       "install_script_ref": "0c2240cf",

--- a/ee/maintained-apps/outputs/pdfsam-basic/darwin.json
+++ b/ee/maintained-apps/outputs/pdfsam-basic/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "6.0.1",
+      "version": "6.0.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.pdfsam.modules';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.pdfsam.modules' AND version_compare(bundle_short_version, '6.0.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.pdfsam.modules' AND version_compare(bundle_short_version, '6.0.3') < 0);"
       },
-      "installer_url": "https://github.com/torakiki/pdfsam/releases/download/v6.0.1/pdfsam-basic-6.0.1-macos-arm64.dmg",
+      "installer_url": "https://github.com/torakiki/pdfsam/releases/download/v6.0.3/pdfsam-basic-6.0.3-macos-arm64.dmg",
       "install_script_ref": "d9faca4d",
       "uninstall_script_ref": "4ae3e223",
-      "sha256": "b05830681fdf81698acffb45f3f5d46dc5a7ee4c64d2afd39e8332eaecdf83e6",
+      "sha256": "eb3551b848004ec30372a08a2bc5ce8448a9d5bf4727dfe15259078ba2f6f7f0",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/pdfsam-basic/windows.json
+++ b/ee/maintained-apps/outputs/pdfsam-basic/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "6.0.1.0",
+      "version": "6.0.3.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'PDFsam Basic' AND publisher = 'Sober Lemur S.r.l.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'PDFsam Basic' AND publisher = 'Sober Lemur S.r.l.' AND version_compare(version, '6.0.1.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'PDFsam Basic' AND publisher = 'Sober Lemur S.r.l.' AND version_compare(version, '6.0.3.0') < 0);"
       },
-      "installer_url": "https://github.com/torakiki/pdfsam/releases/download/v6.0.1/pdfsam-basic-6.0.1-windows-x64.msi",
+      "installer_url": "https://github.com/torakiki/pdfsam/releases/download/v6.0.3/pdfsam-basic-6.0.3-windows-x64.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "e9918859",
-      "sha256": "03ff98e2a920e55543bf8957523f57ee8aaaffa220364df8f0480d299c07de60",
+      "sha256": "01401f5756c3f65bbd782993a1ba86651b62664a9e253cc8299085a40d57d237",
       "default_categories": [
         "Productivity"
       ],

--- a/ee/maintained-apps/outputs/postman/windows.json
+++ b/ee/maintained-apps/outputs/postman/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.18.4",
+      "version": "12.18.5",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.18.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.18.5') < 0);"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.18.4/windows_64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.18.5/windows_64",
       "install_script_ref": "8594f0bc",
       "uninstall_script_ref": "fd59d029",
-      "sha256": "b500525301a0bdcecb810883ea4f69120b9d586176c78c7539e7af6764d3ed5c",
+      "sha256": "40097cfb35450c965cc665090793cd8d4f49870ab7286e1690885d38de60f488",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/reqable/darwin.json
+++ b/ee/maintained-apps/outputs/reqable/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.2.6",
+      "version": "3.2.7",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.reqable.macosx';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.reqable.macosx' AND version_compare(bundle_short_version, '3.2.6') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.reqable.macosx' AND version_compare(bundle_short_version, '3.2.7') < 0);"
       },
-      "installer_url": "https://github.com/reqable/reqable-app/releases/download/3.2.6/reqable-app-macos-arm64.dmg",
+      "installer_url": "https://github.com/reqable/reqable-app/releases/download/3.2.7/reqable-app-macos-arm64.dmg",
       "install_script_ref": "5d84816f",
       "uninstall_script_ref": "3319d75e",
-      "sha256": "18635d9cdbf0742a0ca4225c294a04bf0fcba97a07b0861a55455e1c6a27496a",
+      "sha256": "9c6bc39c9a12dd329a380522677abba33f1d1bb296e4253d91c7d9b72cff6761",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/reqable/windows.json
+++ b/ee/maintained-apps/outputs/reqable/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.2.6",
+      "version": "3.2.7",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Reqable' AND publisher = 'Reqqable Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Reqable' AND publisher = 'Reqqable Inc.' AND version_compare(version, '3.2.6') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Reqable' AND publisher = 'Reqqable Inc.' AND version_compare(version, '3.2.7') < 0);"
       },
-      "installer_url": "https://github.com/reqable/reqable-app/releases/download/3.2.6/reqable-app-windows-x86_64.exe",
+      "installer_url": "https://github.com/reqable/reqable-app/releases/download/3.2.7/reqable-app-windows-x86_64.exe",
       "install_script_ref": "d2ffec58",
       "uninstall_script_ref": "b33fc442",
-      "sha256": "f3cce9a6203cd433437678083d2349e11361ed9365464039e764c6ec45aac84f",
+      "sha256": "9631a8d59820808d05ccc1a645b5a6aa99044c5df83489a7bcbb59c2dac747ac",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/rocket-chat/darwin.json
+++ b/ee/maintained-apps/outputs/rocket-chat/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.15.2",
+      "version": "4.15.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'chat.rocket';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'chat.rocket' AND version_compare(bundle_short_version, '4.15.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'chat.rocket' AND version_compare(bundle_short_version, '4.15.3') < 0);"
       },
-      "installer_url": "https://github.com/RocketChat/Rocket.Chat.Electron/releases/download/4.15.2/rocketchat-4.15.2-mac.dmg",
+      "installer_url": "https://github.com/RocketChat/Rocket.Chat.Electron/releases/download/4.15.3/rocketchat-4.15.3-mac.dmg",
       "install_script_ref": "8a2921c9",
       "uninstall_script_ref": "36b46743",
-      "sha256": "4c74d234fbda7711551aaecb6bfda12d76984c1a8123d2bab831f9e6e742ffc9",
+      "sha256": "2e8b7519c710227c806f8faa6777b16fe88a66e25fba81f7b42c9126d4d7c21b",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/session/darwin.json
+++ b/ee/maintained-apps/outputs/session/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.18.0",
+      "version": "1.18.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.loki-project.messenger-desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.loki-project.messenger-desktop' AND version_compare(bundle_short_version, '1.18.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.loki-project.messenger-desktop' AND version_compare(bundle_short_version, '1.18.1') < 0);"
       },
-      "installer_url": "https://github.com/session-foundation/session-desktop/releases/download/v1.18.0/session-desktop-mac-arm64-1.18.0.dmg",
+      "installer_url": "https://github.com/session-foundation/session-desktop/releases/download/v1.18.1/session-desktop-mac-arm64-1.18.1.dmg",
       "install_script_ref": "6dd0a6e0",
       "uninstall_script_ref": "406e17c9",
-      "sha256": "8b2fcaf4d9d559dfb9650d53613cc38dbbc1b2ad7b893c7ca9979ec6f0b7d3ff",
+      "sha256": "c07fd0d944de540f5e6a408cea351b82579edde28dd49ffa79ceabd82c134080",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/vivaldi/windows.json
+++ b/ee/maintained-apps/outputs/vivaldi/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "8.0.4033.57",
+      "version": "8.1.4087.48",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Vivaldi' AND publisher = 'Vivaldi Technologies AS.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Vivaldi' AND publisher = 'Vivaldi Technologies AS.' AND version_compare(version, '8.0.4033.57') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Vivaldi' AND publisher = 'Vivaldi Technologies AS.' AND version_compare(version, '8.1.4087.48') < 0);"
       },
-      "installer_url": "https://downloads.vivaldi.com/stable/Vivaldi.8.0.4033.57.x64.exe",
+      "installer_url": "https://downloads.vivaldi.com/stable/Vivaldi.8.1.4087.48.x64.exe",
       "install_script_ref": "d5d49757",
       "uninstall_script_ref": "4e1acf1b",
-      "sha256": "d12c511ebe3f99f15fee95933641b36dd49557e3f4fec756afc3dd02da11d141",
+      "sha256": "739376485a31813093e4379dd0983dba07911481eb058156503d141c7c82a787",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/warp/darwin.json
+++ b/ee/maintained-apps/outputs/warp/darwin.json
@@ -1,12 +1,12 @@
 {
   "versions": [
     {
-      "version": "0.2026.07.01.09.21.01",
+      "version": "0.2026.07.08.17.54.01",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable' AND version_compare(bundle_short_version, '0.2026.07.01.09.21.01') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable' AND version_compare(bundle_short_version, '0.2026.07.08.17.54.01') < 0);"
       },
-      "installer_url": "https://releases.warp.dev/stable/v0.2026.07.01.09.21.stable_01/Warp.dmg",
+      "installer_url": "https://releases.warp.dev/stable/v0.2026.07.08.17.54.stable_01/Warp.dmg",
       "install_script_ref": "007bc795",
       "uninstall_script_ref": "932356de",
       "sha256": "no_check",

--- a/ee/maintained-apps/outputs/webex/darwin.json
+++ b/ee/maintained-apps/outputs/webex/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "46.6.1.35236",
+      "version": "46.7.0.35381",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'Cisco-Systems.Spark';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'Cisco-Systems.Spark' AND version_compare(bundle_short_version, '46.6.1.35236') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'Cisco-Systems.Spark' AND version_compare(bundle_short_version, '46.7.0.35381') < 0);"
       },
       "installer_url": "https://binaries.webex.com/webex-macos-apple-silicon/Webex.dmg",
       "install_script_ref": "d105863f",

--- a/ee/maintained-apps/outputs/wechat/darwin.json
+++ b/ee/maintained-apps/outputs/wechat/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.1.11.53",
+      "version": "4.1.11.54",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.tencent.xinWeChat';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.tencent.xinWeChat' AND version_compare(bundle_short_version, '4.1.11.53') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.tencent.xinWeChat' AND version_compare(bundle_short_version, '4.1.11.54') < 0);"
       },
-      "installer_url": "https://dldir1.qq.com/weixin/Universal/Mac/xWeChatMac_universal_4.1.11.53_41748.dmg",
+      "installer_url": "https://dldir1.qq.com/weixin/Universal/Mac/xWeChatMac_universal_4.1.11.54_41754.dmg",
       "install_script_ref": "57f30b74",
       "uninstall_script_ref": "18d6be1e",
-      "sha256": "ea80413fca0ea09eb4241e333a8f09862d33c6c967e6ab66244fd474e6ab4115",
+      "sha256": "846b59743d009a8d5f57eaf4d5b57e2199656a6642639df9de2b9dccc9c04bb3",
       "default_categories": [
         "Communication"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated Windows releases for AWS VPN Client (5.4.1), Brave Browser (150.1.92.139), Figma (126.6.14), Kiro (1.0.116), Microsoft Edge (150.0.4078.65), NordVPN (8.5.1.0), PDFsam Basic (6.0.3.0), Postman (12.18.5), Reqable (3.2.7), and Vivaldi (8.1.4087.48).
  - Updated macOS releases for Cursor, DaisyDisk, Grammarly, Notepad, Ocenaudio, PDFsam Basic, Reqable, Rocket.Chat, Session, Warp, Webex, and WeChat.
  - Refreshed installer links, version detection, and checksums where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->