### PR TITLE
Stop premium calls on Fleet free

### DIFF
--- a/changes/47943-premium-calls-on-fleet-free
+++ b/changes/47943-premium-calls-on-fleet-free
@@ -1,0 +1,1 @@
+- Fixed an issue where premium MDM calls was being made on a Fleet Free license.

--- a/frontend/components/App/App.tsx
+++ b/frontend/components/App/App.tsx
@@ -92,6 +92,7 @@ const App = ({ children, location, router }: IAppProps): JSX.Element => {
     setVppExpiry,
     setSandboxExpiry,
     setNoSandboxHosts,
+    isPremiumTier,
   } = useContext(AppContext);
 
   const [isLoading, setIsLoading] = useState(false);
@@ -125,7 +126,10 @@ const App = ({ children, location, router }: IAppProps): JSX.Element => {
     () => mdmAppleBMAPI.getTokens(),
     {
       ...DEFAULT_USE_QUERY_OPTIONS,
-      enabled: !!isGlobalAdmin && !!config?.mdm.enabled_and_configured,
+      enabled:
+        !!isGlobalAdmin &&
+        !!config?.mdm.enabled_and_configured &&
+        !!isPremiumTier,
       onSuccess: ({ ab_tokens }) => {
         ab_tokens.length &&
           setABMExpiry({
@@ -163,7 +167,10 @@ const App = ({ children, location, router }: IAppProps): JSX.Element => {
     () => mdmAppleAPI.getVppTokens(),
     {
       ...DEFAULT_USE_QUERY_OPTIONS,
-      enabled: !!isGlobalAdmin && !!config?.mdm.enabled_and_configured,
+      enabled:
+        !!isGlobalAdmin &&
+        !!config?.mdm.enabled_and_configured &&
+        !!isPremiumTier,
       onSuccess: ({ vpp_tokens }) => {
         vpp_tokens.length && setVppExpiry(getEarliestExpiry(vpp_tokens));
       },


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #47943

It no longer calls `ab_tokens` and `vpp_tokens` on fleet free
<img width="1317" height="561" alt="image" src="https://github.com/user-attachments/assets/6556f91e-a7e4-487c-9961-3a22104329d3" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where Fleet Free accounts could trigger premium MDM calls.
  * Restricted premium token retrieval to eligible premium-tier accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->