### PR TITLE
inconsistent font size tooltip

### DIFF
--- a/changes/48229-inconsistent-font-size-tooltip
+++ b/changes/48229-inconsistent-font-size-tooltip
@@ -1,0 +1,1 @@
+- Fixed an issue with the tooltip size of "Require BitLocker Pin" was bigger than normal.

--- a/changes/48229-inconsistent-font-size-tooltip
+++ b/changes/48229-inconsistent-font-size-tooltip
@@ -1,1 +1,1 @@
-- Fixed an issue with the tooltip size of "Require BitLocker Pin" was bigger than normal.
+- Fixed an issue with the tooltip size of "Require BitLocker PIN" was bigger than normal.

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/DiskEncryption.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/DiskEncryption.tsx
@@ -248,15 +248,15 @@ const DiskEncryption = ({
               <TooltipWrapper
                 tipContent={
                   <div>
-                    <p>
+                    <>
                       If enabled, end users on Windows hosts will be required to
                       set a BitLocker PIN.
-                    </p>
+                    </>
                     <br />
-                    <p>
+                    <>
                       When the PIN is set, it&rsquo;s required to unlock Windows
                       hosts during startup.
-                    </p>
+                    </>
                   </div>
                 }
               >


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #48229

<img width="465" height="151" alt="image" src="https://github.com/user-attachments/assets/af282c1a-af0d-4184-831d-cb7a98fc6bc8" />



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the “Require BitLocker PIN” tooltip could render with an inconsistent font size.
  * Kept the Windows instructions content the same while adjusting the tooltip layout/line breaks for consistent display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->