### PR TITLE
Send browser User-Agent when downloading FMA installers

### DIFF
--- a/changes/fma-download-browser-user-agent
+++ b/changes/fma-download-browser-user-agent
@@ -1,1 +1,0 @@
-- Fixed Fleet-maintained app installer downloads failing with HTTP 403 on vendor hosts (such as dl.dell.com and www.crestron.com) that reject non-browser User-Agents, by sending a browser-like User-Agent when downloading installers.

--- a/changes/fma-download-browser-user-agent
+++ b/changes/fma-download-browser-user-agent
@@ -1,0 +1,1 @@
+- Fixed Fleet-maintained app installer downloads failing with HTTP 403 on vendor hosts (such as dl.dell.com and www.crestron.com) that reject non-browser User-Agents, by sending a browser-like User-Agent when downloading installers.

--- a/server/mdm/maintainedapps/installers.go
+++ b/server/mdm/maintainedapps/installers.go
@@ -17,6 +17,10 @@ import (
 // InstallerTimeout is the timeout duration for downloading and adding a maintained app.
 const InstallerTimeout = 15 * time.Minute
 
+// browserUserAgent is sent when downloading installers. Some vendor hosts (e.g.
+// dl.dell.com, www.crestron.com) return HTTP 403 to Go's default User-Agent.
+const browserUserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+
 // DownloadInstaller downloads the maintained app installer located at the given URL.
 func DownloadInstaller(ctx context.Context, installerURL string, client *http.Client) (*fleet.TempFileReader, string, error) {
 	// validate the URL before doing the request
@@ -32,6 +36,7 @@ func DownloadInstaller(ctx context.Context, installerURL string, client *http.Cl
 	if err != nil {
 		return nil, "", ctxerr.Wrapf(ctx, err, "creating request for URL %s", installerURL)
 	}
+	req.Header.Set("User-Agent", browserUserAgent)
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/server/mdm/maintainedapps/installers_test.go
+++ b/server/mdm/maintainedapps/installers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -46,4 +47,26 @@ func TestInstallerFilenameExtraction(t *testing.T) {
 	_, filename, err = DownloadInstaller(context.Background(), srv.URL+"/not_compliant", client)
 	require.NoError(t, err)
 	require.Equal(t, "not_compliant.pkg", filename)
+}
+
+func TestInstallerBrowserUserAgent(t *testing.T) {
+	// Mimic vendor hosts that 403 Go's default User-Agent: the download only
+	// succeeds if DownloadInstaller sends a browser-like User-Agent.
+	var gotUserAgent string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUserAgent = r.UserAgent()
+		if gotUserAgent == "" || strings.HasPrefix(gotUserAgent, "Go-http-client") {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		w.Header().Set("Content-Disposition", `attachment; filename="vendor.exe"`)
+		_, _ = w.Write([]byte("vendor installer"))
+	}))
+	defer srv.Close()
+
+	client := fleethttp.NewClient(fleethttp.WithTimeout(time.Second))
+	_, filename, err := DownloadInstaller(context.Background(), srv.URL+"/vendor.exe", client)
+	require.NoError(t, err)
+	require.Equal(t, "vendor.exe", filename)
+	require.Equal(t, browserUserAgent, gotUserAgent)
 }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** N/A

## What changed

`DownloadInstaller` (`server/mdm/maintainedapps/installers.go`) now sets a browser-like `User-Agent` header (a current desktop Chrome string) on the download request instead of letting Go send its default `Go-http-client/1.1`.

## Why

Several legitimate vendor download hosts return HTTP 403 to non-browser User-Agents, which blocked Fleet from downloading their installers **and** blocked the FMA CI validator (`cmd/maintained-apps/validate`). Confirmed cases:

- `dl.dell.com` — used by Dell Display and Peripheral Manager
- `www.crestron.com` — used by Crestron AirMedia / AirMedia Peripherals

Both were dropped from the Windows FMA batches (letter C #48969, letter D #49086) solely for this reason. This change unblocks re-adding them (and Dell products generally) as FMAs in a follow-up.

## Reviewer notes

- **Single choke point:** all three download paths route through `DownloadInstaller` — runtime install (`ee/server/service/maintained_apps.go`), auto-update (`ee/server/service/maintained_apps_auto_update.go`), and the CI validator (`cmd/maintained-apps/validate/main.go`). The validator has no separate downloader, so the one change covers every path.
- **Client conventions unchanged:** callers still build their client via `fleethttp.NewClient()` / `http.DefaultClient`; the header is set per-request.
- **Ingester unaffected:** the winget ingester reads `InstallerSha256` from the winget manifest rather than downloading the installer, so JSON generation was never blocked — only the download paths were.
- **No impact on existing downloads:** hosts that ignore the User-Agent (S3, GitHub releases) behave identically. The pre-existing filename-extraction test (redirects + fallback) still passes.

# Checklist for submitter

- [ ] Changes file added for user-visible changes in `changes/`.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

Added `TestInstallerBrowserUserAgent`: a server that returns 403 to an empty or `Go-http-client` User-Agent (mimicking the vendor hosts); the download succeeds only because `DownloadInstaller` sends a browser-like User-Agent, and the test asserts the sent value matches the `browserUserAgent` constant. The existing `TestInstallerFilenameExtraction` still passes, confirming no regression for UA-agnostic hosts.
