### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/drofus/windows.json
+++ b/ee/maintained-apps/outputs/drofus/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.18.10.0",
+      "version": "2.18.11.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'dRofus %' AND publisher = 'dRofus AS';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'dRofus %' AND publisher = 'dRofus AS' AND version_compare(version, '2.18.10.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'dRofus %' AND publisher = 'dRofus AS' AND version_compare(version, '2.18.11.0') < 0);"
       },
-      "installer_url": "https://deploy.drofus.com/stable/drofus-setup-2.18.10.msi",
+      "installer_url": "https://deploy.drofus.com/stable/drofus-setup-2.18.11.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "72356dd1",
-      "sha256": "0bbc6cf4f50bae855c2ca3a686b5f1996d472e7c327ad01e5bf36f3ac3011cc6",
+      "sha256": "dd723ea583803fa971b2a6f0cf1fa3a3f92b0f999c39728e6b8faada1edeed22",
       "default_categories": [
         "Productivity"
       ],

--- a/ee/maintained-apps/outputs/whatsapp/darwin.json
+++ b/ee/maintained-apps/outputs/whatsapp/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "26.27.19",
+      "version": "26.27.21",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp' AND version_compare(bundle_short_version, '26.27.19') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp' AND version_compare(bundle_short_version, '26.27.21') < 0);"
       },
       "installer_url": "https://web.whatsapp.com/desktop/mac_native/release/?configuration=Release&src=whatsapp_downloads_page",
       "install_script_ref": "157dabb3",

--- a/ee/maintained-apps/outputs/zed/darwin.json
+++ b/ee/maintained-apps/outputs/zed/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.10.1",
+      "version": "1.10.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed' AND version_compare(bundle_short_version, '1.10.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed' AND version_compare(bundle_short_version, '1.10.2') < 0);"
       },
-      "installer_url": "https://zed.dev/api/releases/stable/1.10.1/Zed-aarch64.dmg",
+      "installer_url": "https://zed.dev/api/releases/stable/1.10.2/Zed-aarch64.dmg",
       "install_script_ref": "ad597b79",
       "uninstall_script_ref": "2a2c7eb8",
-      "sha256": "7fe05f335c249db08c893ddb064ad5387bf69fb21dc02e5969acadfa3ac28279",
+      "sha256": "28853c50ca221ed14d84ddec2f9ea44f1afe6bfda83265a5f2a52c250b5bfb0d",
       "default_categories": [
         "Developer tools"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated the Windows release of drofus to version 2.18.11.0.
  - Updated WhatsApp for macOS to version 26.27.21.
  - Updated Zed for macOS to version 1.10.2, including the latest installer package and integrity verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->