### PR TITLE
handle client error decoding errors in ACME urls

### DIFF
--- a/changes/46282-handle-client-error-decoding-errors
+++ b/changes/46282-handle-client-error-decoding-errors
@@ -1,0 +1,1 @@
+- Fixed an issue where ACME urls would throw a 500 error on malformed URL's.

--- a/changes/46282-handle-client-error-decoding-errors
+++ b/changes/46282-handle-client-error-decoding-errors
@@ -1,1 +1,1 @@
-- Fixed an issue where ACME urls would throw a 500 error on malformed URL's.
+- Fixed an issue where ACME urls would throw a 500 error on malformed URLs.

--- a/server/mdm/acme/internal/service/endpoint_utils.go
+++ b/server/mdm/acme/internal/service/endpoint_utils.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -13,6 +14,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/mdm/acme/api"
 	"github.com/fleetdm/fleet/v4/server/mdm/acme/internal/types"
 	eu "github.com/fleetdm/fleet/v4/server/platform/endpointer"
+	platform_errors "github.com/fleetdm/fleet/v4/server/platform/errors"
 	platform_http "github.com/fleetdm/fleet/v4/server/platform/http"
 	"github.com/go-kit/kit/endpoint"
 	kithttp "github.com/go-kit/kit/transport/http"
@@ -34,10 +36,17 @@ func encodeResponse(ctx context.Context, w http.ResponseWriter, response any) er
 func acmeErrorEncoder(ctx context.Context, err error, w http.ResponseWriter) {
 	var acmeErr *types.ACMEError
 	if !errors.As(err, &acmeErr) {
-		// TODO: If we can get access to a logger, we can log the details here, to help troubleshoot service errors.
-		// if it's not already an ACME error, it is because it is an internal server
-		// error (or a dev error, for 4xx we should always return ACMEError).
-		acmeErr = types.InternalServerError("") // not passing err.Error() as we don't want to leak internal details
+
+		// Check if it's a client error, if so then return a MalformedError to avoid returning a 500.
+		var clientErr platform_errors.ErrWithIsClientError
+		if errors.As(err, &clientErr) && clientErr.IsClientError() {
+			acmeErr = types.MalformedError(fmt.Sprintf("The request was malformed: %s", clientErr.Error()))
+		} else {
+			// TODO: If we can get access to a logger, we can log the details here, to help troubleshoot service errors.
+			// if it's not a client error, it is because it is an internal server
+			// error (or a dev error, for 4xx we should always return ACMEError).
+			acmeErr = types.InternalServerError("") // not passing err.Error() as we don't want to leak internal details
+		}
 	}
 
 	w.Header().Set("Content-Type", "application/problem+json")

--- a/server/mdm/acme/internal/tests/integration_test.go
+++ b/server/mdm/acme/internal/tests/integration_test.go
@@ -30,6 +30,7 @@ func TestIntegration(t *testing.T) {
 		{"GetAuthorization", testGetAuthorization},
 		{"FinalizeOrder", testFinalizeOrder},
 		{"DoChallengeDeviceAttestation", testDoChallengeDeviceAttestation},
+		{"InvalidPathIDs", testInvalidPathIDs},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -1206,6 +1207,35 @@ func testListAccountOrders(t *testing.T, s *integrationTestSuite) {
 		require.Contains(t, acmeErr.Type, "badNonce")
 		require.NotEmpty(t, resp.Header.Get("Replay-Nonce"))
 	})
+}
+
+// testInvalidPathIDs exercises the account and order id decoding to return a malformed request error rather than internal server error.
+func testInvalidPathIDs(t *testing.T, s *integrationTestSuite) {
+	// A valid enrollment is not required: the invalid ID fails to decode before
+	// the request ever reaches the service layer, so any path identifier works.
+	const pathID = "some-identifier"
+
+	cases := []struct {
+		desc string
+		url  string
+	}{
+		{"order id", fmt.Sprintf("%s/api/mdm/acme/%s/orders/not-a-uint", s.server.URL, pathID)},
+		{"account id", fmt.Sprintf("%s/api/mdm/acme/%s/accounts/not-a-uint/orders", s.server.URL, pathID)},
+		{"certificate order id", fmt.Sprintf("%s/api/mdm/acme/%s/orders/not-a-uint/certificate", s.server.URL, pathID)},
+		{"authorization id", fmt.Sprintf("%s/api/mdm/acme/%s/authorizations/not-a-uint", s.server.URL, pathID)},
+		{"challenge id", fmt.Sprintf("%s/api/mdm/acme/%s/challenges/not-a-uint", s.server.URL, pathID)},
+		{"finalize order id", fmt.Sprintf("%s/api/mdm/acme/%s/orders/not-a-uint/finalize", s.server.URL, pathID)},
+		{"negative order id", fmt.Sprintf("%s/api/mdm/acme/%s/orders/-1", s.server.URL, pathID)},
+	}
+
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			_, acmeErr, resp := doACMERequest[struct{}](t, http.MethodPost, c.url, []byte("{}"))
+			require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+			require.NotNil(t, acmeErr)
+			require.Contains(t, acmeErr.Type, "malformed")
+		})
+	}
 }
 
 func testGetCertificate(t *testing.T, s *integrationTestSuite) {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #46282

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Malformed ACME URLs and resource identifiers now return a clear **400 Bad Request** response instead of a **500 Internal Server Error**.
  * Error details were improved to more accurately distinguish malformed client requests.
* **Tests**
  * Added an integration test covering invalid ACME endpoint path IDs across resource types, verifying **400** responses with the expected malformed error type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->