### PR TITLE
Batch extension label-membership checks in GetOrbitConfig

### DIFF
--- a/changes/batch-extension-label-check
+++ b/changes/batch-extension-label-check
@@ -1,0 +1,1 @@
+- Improved performance of Orbit config endpoint by batching extension label-membership checks into a single database query.

--- a/server/datastore/mysql/labels.go
+++ b/server/datastore/mysql/labels.go
@@ -1745,7 +1745,7 @@ func (ds *Datastore) HostMemberOfAllLabels(ctx context.Context, hostID uint, lab
 
 // HostMembershipForLabels returns the set of label names (from the provided list) that the host is a member of.
 // Labels that do not exist are not included in the result.
-func (ds *Datastore) HostMembershipForLabels(ctx context.Context, hostID uint, labelNames []string) (map[string]bool, error) {
+func (ds *Datastore) HostMembershipForLabels(ctx context.Context, hostID uint, labelNames []string) (map[string]struct{}, error) {
 	if len(labelNames) == 0 {
 		return nil, nil
 	}
@@ -1765,9 +1765,9 @@ func (ds *Datastore) HostMembershipForLabels(ctx context.Context, hostID uint, l
 		return nil, ctxerr.Wrap(ctx, err, "get host label membership")
 	}
 
-	result := make(map[string]bool, len(names))
+	result := make(map[string]struct{}, len(names))
 	for _, n := range names {
-		result[n] = true
+		result[n] = struct{}{}
 	}
 	return result, nil
 }

--- a/server/datastore/mysql/labels.go
+++ b/server/datastore/mysql/labels.go
@@ -1743,6 +1743,35 @@ func (ds *Datastore) HostMemberOfAllLabels(ctx context.Context, hostID uint, lab
 	return ok, nil
 }
 
+// HostMembershipForLabels returns the set of label names (from the provided list) that the host is a member of.
+// Labels that do not exist are not included in the result.
+func (ds *Datastore) HostMembershipForLabels(ctx context.Context, hostID uint, labelNames []string) (map[string]bool, error) {
+	if len(labelNames) == 0 {
+		return nil, nil
+	}
+
+	sqlStatement := `
+		SELECT l.name FROM labels l
+		JOIN label_membership lm ON l.id = lm.label_id
+		WHERE lm.host_id = ? AND l.name IN (?)
+	`
+	sql, args, err := sqlx.In(sqlStatement, hostID, labelNames)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "building query for host label membership")
+	}
+
+	var names []string
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &names, sql, args...); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "get host label membership")
+	}
+
+	result := make(map[string]bool, len(names))
+	for _, n := range names {
+		result[n] = true
+	}
+	return result, nil
+}
+
 // AddLabelsToHost skips auth as it's only used in tests, and where label teams have already been validated.
 func (ds *Datastore) AddLabelsToHost(ctx context.Context, hostID uint, labelIDs []uint) error {
 	if len(labelIDs) == 0 {

--- a/server/datastore/mysql/labels.go
+++ b/server/datastore/mysql/labels.go
@@ -1715,41 +1715,10 @@ func (ds *Datastore) LabelsSummary(ctx context.Context, filter fleet.TeamFilter)
 	return labelsSummary, nil
 }
 
-// HostMemberOfAllLabels returns whether the given host is a member of all the provided labels.
-// If the labels do not exist, then the host is considered not a member of the provided labels.
-// A host will always be a member of an empty label set, so this method returns (true, nil)
-// if labelNames is empty.
-func (ds *Datastore) HostMemberOfAllLabels(ctx context.Context, hostID uint, labelNames []string) (bool, error) {
-	if len(labelNames) == 0 {
-		return true, nil
-	}
-
-	sqlStatement := `
-		SELECT COUNT(*) = ? FROM labels l
-		LEFT JOIN (SELECT label_id FROM label_membership WHERE host_id = ?) lm
-		ON l.id = lm.label_id
-		WHERE l.name IN (?) AND lm.label_id IS NOT NULL;
-	`
-	sql, args, err := sqlx.In(sqlStatement, len(labelNames), hostID, labelNames)
-	if err != nil {
-		return false, ctxerr.Wrap(ctx, err, "building query to get label IDs")
-	}
-
-	var ok bool
-	if err := sqlx.GetContext(ctx, ds.reader(ctx), &ok, sql, args...); err != nil {
-		return false, ctxerr.Wrap(ctx, err, "get label IDs")
-	}
-
-	return ok, nil
-}
-
 // HostMembershipForLabels returns the set of label names (from the provided list) that the host is a member of.
-// Labels that do not exist are not included in the result.
+// Labels that do not exist are not included in the result. The returned map is keyed by the
+// requested label names (preserving the caller's casing), not the DB-stored names.
 func (ds *Datastore) HostMembershipForLabels(ctx context.Context, hostID uint, labelNames []string) (map[string]struct{}, error) {
-	if len(labelNames) == 0 {
-		return nil, nil
-	}
-
 	sqlStatement := `
 		SELECT l.name FROM labels l
 		JOIN label_membership lm ON l.id = lm.label_id
@@ -1760,14 +1729,22 @@ func (ds *Datastore) HostMembershipForLabels(ctx context.Context, hostID uint, l
 		return nil, ctxerr.Wrap(ctx, err, "building query for host label membership")
 	}
 
-	var names []string
-	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &names, sql, args...); err != nil {
+	var dbNames []string
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &dbNames, sql, args...); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "get host label membership")
 	}
 
-	result := make(map[string]struct{}, len(names))
-	for _, n := range names {
-		result[n] = struct{}{}
+	// The DB may return names with different casing than requested (utf8mb4_unicode_ci),
+	// so map DB names back to the caller's requested names for case-sensitive Go map lookups.
+	dbNameSet := make(map[string]struct{}, len(dbNames))
+	for _, n := range dbNames {
+		dbNameSet[strings.ToLower(n)] = struct{}{}
+	}
+	result := make(map[string]struct{}, len(dbNames))
+	for _, req := range labelNames {
+		if _, ok := dbNameSet[strings.ToLower(req)]; ok {
+			result[req] = struct{}{}
+		}
 	}
 	return result, nil
 }

--- a/server/datastore/mysql/labels_test.go
+++ b/server/datastore/mysql/labels_test.go
@@ -2147,8 +2147,8 @@ func testHostMembershipForLabels(t *testing.T, ds *Datastore) {
 			LabelUpdatedAt:  time.Now(),
 			PolicyUpdatedAt: time.Now(),
 			SeenTime:        time.Now(),
-			OsqueryHostID:   ptr.String(name),
-			NodeKey:         ptr.String(name),
+			OsqueryHostID:   new(name),
+			NodeKey:         new(name),
 			UUID:            name,
 			Hostname:        "foo.local" + name,
 		})
@@ -2161,14 +2161,14 @@ func testHostMembershipForLabels(t *testing.T, ds *Datastore) {
 	h3 := newHostFunc("h3")
 
 	err = ds.RecordLabelQueryExecutions(ctx, h1, map[uint]*bool{
-		allHostsLabel.ID: ptr.Bool(true),
-		foobarLabel.ID:   ptr.Bool(true),
-		zoobarLabel.ID:   ptr.Bool(true),
+		allHostsLabel.ID: new(true),
+		foobarLabel.ID:   new(true),
+		zoobarLabel.ID:   new(true),
 	}, time.Now(), false)
 	require.NoError(t, err)
 	err = ds.RecordLabelQueryExecutions(ctx, h2, map[uint]*bool{
-		allHostsLabel.ID: ptr.Bool(true),
-		foobarLabel.ID:   ptr.Bool(true),
+		allHostsLabel.ID: new(true),
+		foobarLabel.ID:   new(true),
 	}, time.Now(), false)
 	require.NoError(t, err)
 
@@ -2176,7 +2176,7 @@ func testHostMembershipForLabels(t *testing.T, ds *Datastore) {
 		name           string
 		hostID         uint
 		labelNames     []string
-		expectedResult map[string]bool
+		expectedResult map[string]struct{}
 	}{
 		{
 			name:           "empty label names returns nil",
@@ -2188,31 +2188,31 @@ func testHostMembershipForLabels(t *testing.T, ds *Datastore) {
 			name:           "h1 is member of all three labels",
 			hostID:         h1.ID,
 			labelNames:     []string{allHostsLabel.Name, foobarLabel.Name, zoobarLabel.Name},
-			expectedResult: map[string]bool{allHostsLabel.Name: true, foobarLabel.Name: true, zoobarLabel.Name: true},
+			expectedResult: map[string]struct{}{allHostsLabel.Name: {}, foobarLabel.Name: {}, zoobarLabel.Name: {}},
 		},
 		{
 			name:           "h2 is member of some but not all labels",
 			hostID:         h2.ID,
 			labelNames:     []string{allHostsLabel.Name, foobarLabel.Name, zoobarLabel.Name},
-			expectedResult: map[string]bool{allHostsLabel.Name: true, foobarLabel.Name: true},
+			expectedResult: map[string]struct{}{allHostsLabel.Name: {}, foobarLabel.Name: {}},
 		},
 		{
 			name:           "nonexistent labels are not included",
 			hostID:         h1.ID,
 			labelNames:     []string{allHostsLabel.Name, "nonexistent-label"},
-			expectedResult: map[string]bool{allHostsLabel.Name: true},
+			expectedResult: map[string]struct{}{allHostsLabel.Name: {}},
 		},
 		{
 			name:           "nonexistent host returns empty result",
 			hostID:         999,
 			labelNames:     []string{allHostsLabel.Name},
-			expectedResult: map[string]bool{},
+			expectedResult: map[string]struct{}{},
 		},
 		{
 			name:           "h3 is member of no labels",
 			hostID:         h3.ID,
 			labelNames:     []string{allHostsLabel.Name, foobarLabel.Name},
-			expectedResult: map[string]bool{},
+			expectedResult: map[string]struct{}{},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/server/datastore/mysql/labels_test.go
+++ b/server/datastore/mysql/labels_test.go
@@ -96,6 +96,7 @@ func TestLabels(t *testing.T) {
 		{"ListHostsInLabelIssues", testListHostsInLabelIssues},
 		{"ListHostsInLabelDiskEncryptionStatus", testListHostsInLabelDiskEncryptionStatus},
 		{"HostMemberOfAllLabels", testHostMemberOfAllLabels},
+		{"HostMembershipForLabels", testHostMembershipForLabels},
 		{"ListHostsInLabelOSSettings", testLabelsListHostsInLabelOSSettings},
 		{"AddDeleteLabelsToFromHost", testAddDeleteLabelsToFromHost},
 		{"ApplyLabelSpecSerialUUID", testApplyLabelSpecsForSerialUUID},
@@ -2102,6 +2103,126 @@ func testHostMemberOfAllLabels(t *testing.T, ds *Datastore) {
 			v, err := ds.HostMemberOfAllLabels(ctx, tc.hostID, tc.labelNames)
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedResult, v)
+		})
+	}
+}
+
+func testHostMembershipForLabels(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+
+	//
+	// Setup test
+	// - h1 member of 'All hosts', 'Foobar' and 'Zoobar'
+	// - h2 member of 'All hosts' and 'Foobar'
+	// - h3 member of no labels
+	//
+
+	allHostsLabel, err := ds.NewLabel(ctx,
+		&fleet.Label{
+			Name:                "All hosts",
+			Query:               "SELECT 1",
+			LabelType:           fleet.LabelTypeBuiltIn,
+			LabelMembershipType: fleet.LabelMembershipTypeDynamic,
+		},
+	)
+	require.NoError(t, err)
+	foobarLabel, err := ds.NewLabel(ctx, &fleet.Label{
+		Name:                "Foobar",
+		Query:               "SELECT 1;",
+		LabelType:           fleet.LabelTypeRegular,
+		LabelMembershipType: fleet.LabelMembershipTypeDynamic,
+	})
+	require.NoError(t, err)
+	zoobarLabel, err := ds.NewLabel(ctx, &fleet.Label{
+		Name:                "Zoobar",
+		Query:               "SELECT 2;",
+		LabelType:           fleet.LabelTypeRegular,
+		LabelMembershipType: fleet.LabelMembershipTypeDynamic,
+	})
+	require.NoError(t, err)
+
+	newHostFunc := func(name string) *fleet.Host {
+		h, err := ds.NewHost(ctx, &fleet.Host{
+			DetailUpdatedAt: time.Now(),
+			LabelUpdatedAt:  time.Now(),
+			PolicyUpdatedAt: time.Now(),
+			SeenTime:        time.Now(),
+			OsqueryHostID:   ptr.String(name),
+			NodeKey:         ptr.String(name),
+			UUID:            name,
+			Hostname:        "foo.local" + name,
+		})
+		require.NoError(t, err)
+		return h
+	}
+
+	h1 := newHostFunc("h1")
+	h2 := newHostFunc("h2")
+	h3 := newHostFunc("h3")
+
+	err = ds.RecordLabelQueryExecutions(ctx, h1, map[uint]*bool{
+		allHostsLabel.ID: ptr.Bool(true),
+		foobarLabel.ID:   ptr.Bool(true),
+		zoobarLabel.ID:   ptr.Bool(true),
+	}, time.Now(), false)
+	require.NoError(t, err)
+	err = ds.RecordLabelQueryExecutions(ctx, h2, map[uint]*bool{
+		allHostsLabel.ID: ptr.Bool(true),
+		foobarLabel.ID:   ptr.Bool(true),
+	}, time.Now(), false)
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name           string
+		hostID         uint
+		labelNames     []string
+		expectedResult map[string]bool
+	}{
+		{
+			name:           "empty label names returns nil",
+			hostID:         h1.ID,
+			labelNames:     nil,
+			expectedResult: nil,
+		},
+		{
+			name:           "h1 is member of all three labels",
+			hostID:         h1.ID,
+			labelNames:     []string{allHostsLabel.Name, foobarLabel.Name, zoobarLabel.Name},
+			expectedResult: map[string]bool{allHostsLabel.Name: true, foobarLabel.Name: true, zoobarLabel.Name: true},
+		},
+		{
+			name:           "h2 is member of some but not all labels",
+			hostID:         h2.ID,
+			labelNames:     []string{allHostsLabel.Name, foobarLabel.Name, zoobarLabel.Name},
+			expectedResult: map[string]bool{allHostsLabel.Name: true, foobarLabel.Name: true},
+		},
+		{
+			name:           "nonexistent labels are not included",
+			hostID:         h1.ID,
+			labelNames:     []string{allHostsLabel.Name, "nonexistent-label"},
+			expectedResult: map[string]bool{allHostsLabel.Name: true},
+		},
+		{
+			name:           "nonexistent host returns empty result",
+			hostID:         999,
+			labelNames:     []string{allHostsLabel.Name},
+			expectedResult: map[string]bool{},
+		},
+		{
+			name:           "h3 is member of no labels",
+			hostID:         h3.ID,
+			labelNames:     []string{allHostsLabel.Name, foobarLabel.Name},
+			expectedResult: map[string]bool{},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := ds.HostMembershipForLabels(ctx, tc.hostID, tc.labelNames)
+			require.NoError(t, err)
+			if tc.expectedResult == nil {
+				require.Nil(t, result)
+			} else {
+				require.Equal(t, tc.expectedResult, result)
+			}
 		})
 	}
 }

--- a/server/datastore/mysql/labels_test.go
+++ b/server/datastore/mysql/labels_test.go
@@ -95,7 +95,6 @@ func TestLabels(t *testing.T) {
 		{"LabelsSummaryAndListTeamFiltering", testLabelsSummaryAndListTeamFiltering},
 		{"ListHostsInLabelIssues", testListHostsInLabelIssues},
 		{"ListHostsInLabelDiskEncryptionStatus", testListHostsInLabelDiskEncryptionStatus},
-		{"HostMemberOfAllLabels", testHostMemberOfAllLabels},
 		{"HostMembershipForLabels", testHostMembershipForLabels},
 		{"ListHostsInLabelOSSettings", testLabelsListHostsInLabelOSSettings},
 		{"AddDeleteLabelsToFromHost", testAddDeleteLabelsToFromHost},
@@ -1925,190 +1924,8 @@ func testListHostsInLabelDiskEncryptionStatus(t *testing.T, ds *Datastore) {
 	listHostsCheckCount(t, ds, fleet.TeamFilter{User: test.UserAdmin}, fleet.HostListOptions{MacOSSettingsDiskEncryptionFilter: fleet.DiskEncryptionRemovingEnforcement}, 1)
 }
 
-func testHostMemberOfAllLabels(t *testing.T, ds *Datastore) {
-	ctx := context.Background()
-
-	//
-	// Setup test
-	// - h1 member of 'All hosts', 'Foobar' and 'Zoobar'
-	// - h2 member of 'All hosts' and 'Foobar'
-	// - h3 member of 'All hosts' and 'Zoobar'
-	// - h4 member of 'All hosts'
-	// - h5 member of no labels
-	//
-
-	allHostsLabel, err := ds.NewLabel(ctx,
-		&fleet.Label{
-			Name:                "All hosts",
-			Query:               "SELECT 1",
-			LabelType:           fleet.LabelTypeBuiltIn,
-			LabelMembershipType: fleet.LabelMembershipTypeDynamic,
-		},
-	)
-	require.NoError(t, err)
-	foobarLabel, err := ds.NewLabel(ctx, &fleet.Label{
-		Name:                "Foobar",
-		Query:               "SELECT 1;",
-		LabelType:           fleet.LabelTypeRegular,
-		LabelMembershipType: fleet.LabelMembershipTypeDynamic,
-	})
-	require.NoError(t, err)
-	zoobarLabel, err := ds.NewLabel(ctx, &fleet.Label{
-		Name:                "Zoobar",
-		Query:               "SELECT 2;",
-		LabelType:           fleet.LabelTypeRegular,
-		LabelMembershipType: fleet.LabelMembershipTypeDynamic,
-	})
-	require.NoError(t, err)
-
-	newHostFunc := func(name string) *fleet.Host {
-		h, err := ds.NewHost(ctx, &fleet.Host{
-			DetailUpdatedAt: time.Now(),
-			LabelUpdatedAt:  time.Now(),
-			PolicyUpdatedAt: time.Now(),
-			SeenTime:        time.Now(),
-			OsqueryHostID:   ptr.String(name),
-			NodeKey:         ptr.String(name),
-			UUID:            name,
-			Hostname:        "foo.local" + name,
-		})
-		require.NoError(t, err)
-		return h
-	}
-
-	h1 := newHostFunc("h1")
-	h2 := newHostFunc("h2")
-	h3 := newHostFunc("h3")
-	h4 := newHostFunc("h4")
-	h5 := newHostFunc("h5")
-	_ = h5
-
-	err = ds.RecordLabelQueryExecutions(ctx, h1, map[uint]*bool{
-		allHostsLabel.ID: ptr.Bool(true),
-		foobarLabel.ID:   ptr.Bool(true),
-		zoobarLabel.ID:   ptr.Bool(true),
-	}, time.Now(), false)
-	require.NoError(t, err)
-	err = ds.RecordLabelQueryExecutions(ctx, h2, map[uint]*bool{
-		allHostsLabel.ID: ptr.Bool(true),
-		foobarLabel.ID:   ptr.Bool(true),
-	}, time.Now(), false)
-	require.NoError(t, err)
-	err = ds.RecordLabelQueryExecutions(ctx, h3, map[uint]*bool{
-		allHostsLabel.ID: ptr.Bool(true),
-		zoobarLabel.ID:   ptr.Bool(true),
-	}, time.Now(), false)
-	require.NoError(t, err)
-	err = ds.RecordLabelQueryExecutions(ctx, h4, map[uint]*bool{
-		allHostsLabel.ID: ptr.Bool(true),
-	}, time.Now(), false)
-	require.NoError(t, err)
-
-	//
-	// Run tests for HostMemberOfAllLabels
-	//
-
-	for _, tc := range []struct {
-		name           string
-		hostID         uint
-		labelNames     []string
-		expectedResult bool
-	}{
-		{
-			name:           "nonexistent host",
-			hostID:         999,
-			labelNames:     []string{allHostsLabel.Name},
-			expectedResult: false,
-		},
-		{
-			name:           "h1 does not belong to nonexistent label",
-			hostID:         h1.ID,
-			labelNames:     []string{"Non existent label"},
-			expectedResult: false,
-		},
-		{
-			name:           "h1 does not belong to All hosts + nonexistent label",
-			hostID:         h1.ID,
-			labelNames:     []string{allHostsLabel.Name, "Non existent label"},
-			expectedResult: false,
-		},
-		{
-			name:           "h1 belongs to the given subset of labels",
-			hostID:         h1.ID,
-			labelNames:     []string{allHostsLabel.Name, foobarLabel.Name},
-			expectedResult: true,
-		},
-		{
-			name:           "h1 belongs to all the given labels",
-			hostID:         h1.ID,
-			labelNames:     []string{allHostsLabel.Name, foobarLabel.Name, zoobarLabel.Name},
-			expectedResult: true,
-		},
-		{
-			name:           "h1 member of empty label set",
-			hostID:         h1.ID,
-			labelNames:     []string{},
-			expectedResult: true,
-		},
-		{
-			name:           "h2 belongs to all the given labels",
-			hostID:         h2.ID,
-			labelNames:     []string{allHostsLabel.Name, foobarLabel.Name},
-			expectedResult: true,
-		},
-		{
-			name:           "h2 does not belongs to all the given labels",
-			hostID:         h2.ID,
-			labelNames:     []string{allHostsLabel.Name, foobarLabel.Name, zoobarLabel.Name},
-			expectedResult: false,
-		},
-		{
-			name:           "h2 belongs to the given label",
-			hostID:         h2.ID,
-			labelNames:     []string{foobarLabel.Name},
-			expectedResult: true,
-		},
-		{
-			name:           "h2 does not belong to the given label",
-			hostID:         h2.ID,
-			labelNames:     []string{zoobarLabel.Name},
-			expectedResult: false,
-		},
-		{
-			name:           "h3 belongs to all the given labels",
-			hostID:         h3.ID,
-			labelNames:     []string{allHostsLabel.Name, zoobarLabel.Name},
-			expectedResult: true,
-		},
-		{
-			name:           "h4 belongs to all the given labels",
-			hostID:         h4.ID,
-			labelNames:     []string{allHostsLabel.Name},
-			expectedResult: true,
-		},
-		{
-			name:           "h4 does not belong to the given labels",
-			hostID:         h4.ID,
-			labelNames:     []string{foobarLabel.Name},
-			expectedResult: false,
-		},
-		{
-			name:           "h5 does not belong to the given labels",
-			hostID:         h5.ID,
-			labelNames:     []string{allHostsLabel.Name},
-			expectedResult: false,
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			v, err := ds.HostMemberOfAllLabels(ctx, tc.hostID, tc.labelNames)
-			require.NoError(t, err)
-			require.Equal(t, tc.expectedResult, v)
-		})
-	}
-}
-
 func testHostMembershipForLabels(t *testing.T, ds *Datastore) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	//
 	// Setup test
@@ -2179,16 +1996,16 @@ func testHostMembershipForLabels(t *testing.T, ds *Datastore) {
 		expectedResult map[string]struct{}
 	}{
 		{
-			name:           "empty label names returns nil",
-			hostID:         h1.ID,
-			labelNames:     nil,
-			expectedResult: nil,
-		},
-		{
 			name:           "h1 is member of all three labels",
 			hostID:         h1.ID,
 			labelNames:     []string{allHostsLabel.Name, foobarLabel.Name, zoobarLabel.Name},
 			expectedResult: map[string]struct{}{allHostsLabel.Name: {}, foobarLabel.Name: {}, zoobarLabel.Name: {}},
+		},
+		{
+			name:           "h1 is member of a subset of labels",
+			hostID:         h1.ID,
+			labelNames:     []string{allHostsLabel.Name, foobarLabel.Name},
+			expectedResult: map[string]struct{}{allHostsLabel.Name: {}, foobarLabel.Name: {}},
 		},
 		{
 			name:           "h2 is member of some but not all labels",
@@ -2201,6 +2018,12 @@ func testHostMembershipForLabels(t *testing.T, ds *Datastore) {
 			hostID:         h1.ID,
 			labelNames:     []string{allHostsLabel.Name, "nonexistent-label"},
 			expectedResult: map[string]struct{}{allHostsLabel.Name: {}},
+		},
+		{
+			name:           "case-insensitive match preserves requested casing",
+			hostID:         h1.ID,
+			labelNames:     []string{"foobar", "ZOOBAR"},
+			expectedResult: map[string]struct{}{"foobar": {}, "ZOOBAR": {}},
 		},
 		{
 			name:           "nonexistent host returns empty result",

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -339,7 +339,7 @@ type Datastore interface {
 
 	// HostMembershipForLabels returns the set of label names (from the provided list) that the host is a member of.
 	// Labels that do not exist are not included in the result.
-	HostMembershipForLabels(ctx context.Context, hostID uint, labelNames []string) (map[string]bool, error)
+	HostMembershipForLabels(ctx context.Context, hostID uint, labelNames []string) (map[string]struct{}, error)
 
 	// TODO JUAN: Refactor this to use the Operating System type instead.
 	// HostIDsByOSVersion retrieves the IDs of all host matching osVersion

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -337,6 +337,10 @@ type Datastore interface {
 	// if labelNames is empty.
 	HostMemberOfAllLabels(ctx context.Context, hostID uint, labelNames []string) (bool, error)
 
+	// HostMembershipForLabels returns the set of label names (from the provided list) that the host is a member of.
+	// Labels that do not exist are not included in the result.
+	HostMembershipForLabels(ctx context.Context, hostID uint, labelNames []string) (map[string]bool, error)
+
 	// TODO JUAN: Refactor this to use the Operating System type instead.
 	// HostIDsByOSVersion retrieves the IDs of all host matching osVersion
 	HostIDsByOSVersion(ctx context.Context, osVersion OSVersion, offset int, limit int) ([]uint, error)

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -331,14 +331,9 @@ type Datastore interface {
 	// HostIDsByOSID retrieves the IDs of all host for the given OS ID
 	HostIDsByOSID(ctx context.Context, osID uint, offset int, limit int) ([]uint, error)
 
-	// HostMemberOfAllLabels returns whether the given host is a member of all the provided labels.
-	// If a label name does not exist, then the host is considered not a member of the provided label.
-	// A host will always be a member of an empty label set, so this method returns (true, nil)
-	// if labelNames is empty.
-	HostMemberOfAllLabels(ctx context.Context, hostID uint, labelNames []string) (bool, error)
-
 	// HostMembershipForLabels returns the set of label names (from the provided list) that the host is a member of.
-	// Labels that do not exist are not included in the result.
+	// Labels that do not exist are not included in the result. The returned map is keyed by the
+	// requested label names (preserving the caller's casing), not the DB-stored names.
 	HostMembershipForLabels(ctx context.Context, hostID uint, labelNames []string) (map[string]struct{}, error)
 
 	// TODO JUAN: Refactor this to use the Operating System type instead.

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -256,6 +256,8 @@ type HostIDsByOSIDFunc func(ctx context.Context, osID uint, offset int, limit in
 
 type HostMemberOfAllLabelsFunc func(ctx context.Context, hostID uint, labelNames []string) (bool, error)
 
+type HostMembershipForLabelsFunc func(ctx context.Context, hostID uint, labelNames []string) (map[string]bool, error)
+
 type HostIDsByOSVersionFunc func(ctx context.Context, osVersion fleet.OSVersion, offset int, limit int) ([]uint, error)
 
 type HostByIdentifierFunc func(ctx context.Context, identifier string) (*fleet.Host, error)
@@ -2506,6 +2508,9 @@ type DataStore struct {
 
 	HostMemberOfAllLabelsFunc        HostMemberOfAllLabelsFunc
 	HostMemberOfAllLabelsFuncInvoked bool
+
+	HostMembershipForLabelsFunc        HostMembershipForLabelsFunc
+	HostMembershipForLabelsFuncInvoked bool
 
 	HostIDsByOSVersionFunc        HostIDsByOSVersionFunc
 	HostIDsByOSVersionFuncInvoked bool
@@ -6173,6 +6178,13 @@ func (s *DataStore) HostMemberOfAllLabels(ctx context.Context, hostID uint, labe
 	s.HostMemberOfAllLabelsFuncInvoked = true
 	s.mu.Unlock()
 	return s.HostMemberOfAllLabelsFunc(ctx, hostID, labelNames)
+}
+
+func (s *DataStore) HostMembershipForLabels(ctx context.Context, hostID uint, labelNames []string) (map[string]bool, error) {
+	s.mu.Lock()
+	s.HostMembershipForLabelsFuncInvoked = true
+	s.mu.Unlock()
+	return s.HostMembershipForLabelsFunc(ctx, hostID, labelNames)
 }
 
 func (s *DataStore) HostIDsByOSVersion(ctx context.Context, osVersion fleet.OSVersion, offset int, limit int) ([]uint, error) {

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -256,7 +256,7 @@ type HostIDsByOSIDFunc func(ctx context.Context, osID uint, offset int, limit in
 
 type HostMemberOfAllLabelsFunc func(ctx context.Context, hostID uint, labelNames []string) (bool, error)
 
-type HostMembershipForLabelsFunc func(ctx context.Context, hostID uint, labelNames []string) (map[string]bool, error)
+type HostMembershipForLabelsFunc func(ctx context.Context, hostID uint, labelNames []string) (map[string]struct{}, error)
 
 type HostIDsByOSVersionFunc func(ctx context.Context, osVersion fleet.OSVersion, offset int, limit int) ([]uint, error)
 
@@ -6180,7 +6180,7 @@ func (s *DataStore) HostMemberOfAllLabels(ctx context.Context, hostID uint, labe
 	return s.HostMemberOfAllLabelsFunc(ctx, hostID, labelNames)
 }
 
-func (s *DataStore) HostMembershipForLabels(ctx context.Context, hostID uint, labelNames []string) (map[string]bool, error) {
+func (s *DataStore) HostMembershipForLabels(ctx context.Context, hostID uint, labelNames []string) (map[string]struct{}, error) {
 	s.mu.Lock()
 	s.HostMembershipForLabelsFuncInvoked = true
 	s.mu.Unlock()

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -254,8 +254,6 @@ type HostIDsByIdentifierFunc func(ctx context.Context, filter fleet.TeamFilter, 
 
 type HostIDsByOSIDFunc func(ctx context.Context, osID uint, offset int, limit int) ([]uint, error)
 
-type HostMemberOfAllLabelsFunc func(ctx context.Context, hostID uint, labelNames []string) (bool, error)
-
 type HostMembershipForLabelsFunc func(ctx context.Context, hostID uint, labelNames []string) (map[string]struct{}, error)
 
 type HostIDsByOSVersionFunc func(ctx context.Context, osVersion fleet.OSVersion, offset int, limit int) ([]uint, error)
@@ -2505,9 +2503,6 @@ type DataStore struct {
 
 	HostIDsByOSIDFunc        HostIDsByOSIDFunc
 	HostIDsByOSIDFuncInvoked bool
-
-	HostMemberOfAllLabelsFunc        HostMemberOfAllLabelsFunc
-	HostMemberOfAllLabelsFuncInvoked bool
 
 	HostMembershipForLabelsFunc        HostMembershipForLabelsFunc
 	HostMembershipForLabelsFuncInvoked bool
@@ -6171,13 +6166,6 @@ func (s *DataStore) HostIDsByOSID(ctx context.Context, osID uint, offset int, li
 	s.HostIDsByOSIDFuncInvoked = true
 	s.mu.Unlock()
 	return s.HostIDsByOSIDFunc(ctx, osID, offset, limit)
-}
-
-func (s *DataStore) HostMemberOfAllLabels(ctx context.Context, hostID uint, labelNames []string) (bool, error) {
-	s.mu.Lock()
-	s.HostMemberOfAllLabelsFuncInvoked = true
-	s.mu.Unlock()
-	return s.HostMemberOfAllLabelsFunc(ctx, hostID, labelNames)
 }
 
 func (s *DataStore) HostMembershipForLabels(ctx context.Context, hostID uint, labelNames []string) (map[string]struct{}, error) {

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -971,17 +971,39 @@ func (svc *Service) filterExtensionsForHost(ctx context.Context, extensions json
 
 	// Filter the extensions by labels (premium only feature).
 	if license, _ := license.FromContext(ctx); license != nil && license.IsPremium() {
-		for extensionName, extensionInfo := range extensionsInfo {
-			hostIsMemberOfAllLabels, err := svc.ds.HostMemberOfAllLabels(ctx, host.ID, extensionInfo.Labels)
-			if err != nil {
-				return nil, ctxerr.Wrap(ctx, err, "check host labels")
+		// Collect all unique label names across all extensions.
+		allLabels := make(map[string]struct{})
+		for _, extInfo := range extensionsInfo {
+			for _, l := range extInfo.Labels {
+				allLabels[l] = struct{}{}
 			}
-			if hostIsMemberOfAllLabels {
-				// Do not filter out, but there's no need to send the label names to the devices.
-				extensionInfo.Labels = nil
-				extensionsInfo[extensionName] = extensionInfo
-			} else {
-				delete(extensionsInfo, extensionName)
+		}
+
+		if len(allLabels) > 0 {
+			labelNames := make([]string, 0, len(allLabels))
+			for l := range allLabels {
+				labelNames = append(labelNames, l)
+			}
+
+			memberOf, err := svc.ds.HostMembershipForLabels(ctx, host.ID, labelNames)
+			if err != nil {
+				return nil, ctxerr.Wrap(ctx, err, "check host label membership")
+			}
+
+			for extensionName, extensionInfo := range extensionsInfo {
+				allMatch := true
+				for _, l := range extensionInfo.Labels {
+					if !memberOf[l] {
+						allMatch = false
+						break
+					}
+				}
+				if allMatch {
+					extensionInfo.Labels = nil
+					extensionsInfo[extensionName] = extensionInfo
+				} else {
+					delete(extensionsInfo, extensionName)
+				}
 			}
 		}
 	}

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -993,7 +993,7 @@ func (svc *Service) filterExtensionsForHost(ctx context.Context, extensions json
 			for extensionName, extensionInfo := range extensionsInfo {
 				allMatch := true
 				for _, l := range extensionInfo.Labels {
-					if !memberOf[l] {
+					if _, ok := memberOf[l]; !ok {
 						allMatch = false
 						break
 					}


### PR DESCRIPTION
**Related issue:** Resolves #45320

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Summary

`filterExtensionsForHost` (called on every Orbit config fetch, ~30s per host) had an N+1 query pattern: it called `HostMemberOfAllLabels` once per extension in a loop, issuing a separate DB query for each.

This PR replaces the N queries with a single batch query via a new `HostMembershipForLabels` datastore method that returns which labels (from a given list) the host belongs to. Extension filtering then happens in-memory.

### Changes

- **New datastore method** `HostMembershipForLabels(ctx, hostID, labelNames) -> map[string]bool` -- single `SELECT l.name FROM labels l JOIN label_membership` query
- **Updated `filterExtensionsForHost`** in `server/service/orbit.go` -- collects all unique label names across extensions, calls the new method once, filters in-memory
- **No API, UI, CLI, agent, or schema changes** -- purely server-side internal optimization. Full backward compatibility: old agents work with new servers and vice versa (no protocol change).

## Benchmark

Ran a local end-to-end benchmark against the live `POST /api/fleet/orbit/config` endpoint to measure the real-world impact.

**Setup:**
- MacBook (Fleet server + Docker MySQL 8.0 + Redis, all localhost)
- 50 enrolled Orbit hosts (darwin), 5 label-scoped extensions, all hosts members of all 5 labels
- 500 requests at concurrency 10, cycling through all 50 orbit_node_keys
- Built Fleet binary from `main` (before) and this PR branch (after), same database and test data

**Results:**

| Metric | Before (main) | After (this PR) | Improvement |
|--------|:---:|:---:|:---:|
| Avg latency | 25.33 ms | 17.46 ms | **-31%, 1.45x faster** |
| P50 latency | 24.55 ms | 16.52 ms | **-33%, 1.49x faster** |
| P95 latency | 34.42 ms | 27.53 ms | **-20%, 1.25x faster** |
| Throughput | 390.6 req/s | 564.2 req/s | **+44%** |

### Extrapolation to 100,000 hosts

At 100k hosts with a 30-second check-in interval (3,333 req/s steady state):

| Metric | Before | After |
|--------|--------|-------|
| Server host capacity (measured MacBook) | 11,718 | 16,926 (+44%) |
| Label-check DB queries/sec | **16,665** (5/req) | **3,333** (1/req) |
| **DB queries eliminated** | | **13,332/sec (80% reduction)** |

The improvement scales linearly with extension count:

| Extensions | DB queries eliminated/sec | Reduction |
|:---:|---:|:---:|
| 5 | 13,332 | 80% |
| 10 | 29,997 | 90% |
| 15 | 46,662 | 93% |
| 20 | 63,327 | 95% |

> **Note:** These are conservative localhost numbers. In production, where each DB round-trip includes real network latency, the per-request latency improvement would be more pronounced because each eliminated query saves a network hop.

## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

### Automated

- New `testHostMembershipForLabels` MySQL integration test covering: empty input, full membership, partial membership, nonexistent labels, nonexistent host, host with no memberships
- Existing `testHostMemberOfAllLabels` unchanged and unaffected

### Manual QA

1. Fleet Premium instance with 2+ Orbit-enrolled hosts
2. Configure 3+ osquery extensions with different label scoping
3. Verify each host receives only the extensions whose label requirements it meets
4. Verify extensions with no label scoping are included for all hosts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved Orbit configuration loading by batching host label membership checks into a single query for extension label filtering.
* **Behavior**
  * Extension availability and filtering behavior remains the same, with more efficient processing when multiple extensions use labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->