### PR TITLE
48917 Show a deleted state instead of a generic error for stale MDM command (#49012) -> v4.89.0

### DIFF
--- a/changes/48917-command-details-modal-reenrolled-host
+++ b/changes/48917-command-details-modal-reenrolled-host
@@ -1,0 +1,1 @@
+- Fixed the MDM command details modal showing a generic error, instead of a clear message, for a command sent to a host that was later wiped and re-enrolled.

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityFeed.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityFeed.tsx
@@ -160,6 +160,8 @@ const ActivityFeed = ({
     host_uuid?: string;
     command_uuid: string;
     actor_full_name?: string;
+    host_display_name?: string;
+    request_type?: string;
   } | null>(null);
 
   const [searchQuery, setSearchQuery] = useState("");
@@ -337,6 +339,8 @@ const ActivityFeed = ({
           command_uuid: details.command_uuid,
           host_uuid: details?.host_uuid,
           actor_full_name,
+          host_display_name: details?.host_display_name,
+          request_type: details?.request_type,
         });
         break;
       }
@@ -513,15 +517,52 @@ const ActivityFeed = ({
         <MdmCommandDetailsModal
           command={mdmCommandActivityDetails}
           contentBody={(cls, result) => {
+            const isDeleted = result.status === "Deleted";
             const isPending = getIconName(result.status) === "pending-outline";
             const cmdDisplayName = getMdmCommandDisplayName(
-              result.request_type
+              isDeleted
+                ? mdmCommandActivityDetails.request_type
+                : result.request_type
             );
             const timeAgo = result.updated_at
               ? ` (${formatDistanceToNow(new Date(result.updated_at), {
                   addSuffix: true,
                 })})`
               : "";
+
+            if (isDeleted) {
+              // no result -- likely the host was wiped and re-enrolled since.
+              // Use the activity's own details, captured at click-time,
+              // instead of the (empty) fetched result. Both fields are
+              // optional on that captured state, so guard against a leading
+              // "ran ..." with no actor and a bare "on ." with no hostname.
+              const {
+                actor_full_name: actorText,
+                host_display_name: hostText,
+              } = mdmCommandActivityDetails;
+              return (
+                <>
+                  <IconStatusMessage
+                    className={`${cls}__status-message`}
+                    iconName="info-outline"
+                    message={
+                      <span>
+                        {actorText && <b>{actorText}</b>}
+                        {actorText ? " ran " : "Ran "}
+                        {formatMdmCommandNameForActivityItem(
+                          mdmCommandActivityDetails.request_type
+                        )}
+                        {" on "}
+                        {hostText ? <b>{hostText}</b> : "this host"}
+                        {"."}
+                      </span>
+                    }
+                  />
+                  <div>This command has been deleted.</div>
+                </>
+              );
+            }
+
             return (
               <IconStatusMessage
                 className={`${cls}__status-message`}

--- a/frontend/pages/hosts/components/CommandDetailsModal/CommandDetailsModal.tests.tsx
+++ b/frontend/pages/hosts/components/CommandDetailsModal/CommandDetailsModal.tests.tsx
@@ -1,4 +1,11 @@
-import { getIconName, getVerbForCommandStatus } from "./CommandDetailsModal";
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import {
+  getIconName,
+  getVerbForCommandStatus,
+  ModalContent,
+} from "./CommandDetailsModal";
 
 describe("getIconName", () => {
   it("returns error for Apple Error status", () => {
@@ -65,5 +72,20 @@ describe("getVerbForCommandStatus", () => {
 
   it("returns 'sent' for an unknown status", () => {
     expect(getVerbForCommandStatus("unknown")).toEqual("sent");
+  });
+});
+
+describe("ModalContent", () => {
+  it("renders normally, not as an error, when the API returns a 200 with no results (e.g. host re-enrolled since the command was sent)", () => {
+    render(
+      <ModalContent data={{ results: [] }} isLoading={false} error={null} />
+    );
+
+    expect(
+      screen.getByText("This command has been deleted.")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/something's gone wrong/i)
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/pages/hosts/components/CommandDetailsModal/CommandDetailsModal.tsx
+++ b/frontend/pages/hosts/components/CommandDetailsModal/CommandDetailsModal.tsx
@@ -33,6 +33,10 @@ export const getIconName = (status: string): IconNames => {
     case "Pending":
     case "NotNow":
       return "pending-outline";
+    // sentinel used when the command results API returns a 200 with no
+    // results (e.g. the host it was sent to was wiped and re-enrolled since)
+    case "Deleted":
+      return "info-outline";
     default:
       break;
   }
@@ -113,6 +117,9 @@ const getStatusMessage = (result: ICommandResult): React.ReactNode => {
         </span>
       );
 
+    case "Deleted":
+      return <span>This command has been deleted.</span>;
+
     default:
       // FIXME: update for other platforms and design appropriate default handling for unknown
       // statuses; for now, just fallback to status string
@@ -128,7 +135,7 @@ const defaultModalContentBody = (baseclass: string, result: ICommandResult) => (
   />
 );
 
-const ModalContent = ({
+export const ModalContent = ({
   data,
   isLoading,
   error,
@@ -148,9 +155,29 @@ const ModalContent = ({
   }
 
   if (!data?.results?.[0]) {
-    // this should not happen, but just in case
-    console.error("No results found in MDM command results data");
-    return <DataError description="Close this modal and try again." />;
+    // a 200 with no results means the command no longer has anything to show --
+    // most commonly because the host it was sent to was wiped and re-enrolled
+    // since. Render the modal normally (via the caller's contentBody, same as a
+    // real result) rather than as an error, since nothing actually went wrong.
+    // The "Deleted" sentinel status lets the caller render its own copy for
+    // this case using the activity's own details, since there's no real
+    // result to pull hostname/request_type from.
+    const deletedCommandResult: ICommandResult = {
+      host_uuid: "",
+      command_uuid: "",
+      status: "Deleted",
+      updated_at: "",
+      request_type: "",
+      hostname: "",
+      payload: "",
+      result: "",
+      name: null,
+    };
+    return (
+      <div className={`${baseClass}__modal-content`}>
+        {contentBody(baseClass, deletedCommandResult)}
+      </div>
+    );
   }
 
   if (data.results.length > 1) {


### PR DESCRIPTION
Cherrypick https://github.com/fleetdm/fleet/pull/49012

**Related issue:** Resolves #48917

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
See [Changes
files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
* The MDM command details modal now shows **“This command has been deleted.”** instead of a generic error when a command result is removed after the host is wiped and re-enrolled.
* The modal now uses additional stored activity context (like host display name and request type) to render more accurate, host-specific details for deleted commands.

* **Tests**
* Updated and added coverage to confirm the deleted-message UI and that the generic error text no longer appears.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
