### PR TITLE
Add 4.89.0 baseline and migration loadtest results

### DIFF
--- a/tools/loadtest/metrics/runs/baseline/489loadtest/489loadtest-2026-07-10-210313Z-18h.json
+++ b/tools/loadtest/metrics/runs/baseline/489loadtest/489loadtest-2026-07-10-210313Z-18h.json
@@ -1,0 +1,670 @@
+{
+  "metadata": {
+    "workspace": "489loadtest",
+    "collected_at": "2026-07-10T21:03:13Z",
+    "region": "us-east-2",
+    "interval": "18h",
+    "time_window": {
+      "start": "2026-07-10T03:03:13Z",
+      "end": "2026-07-10T21:03:13Z"
+    }
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 60.37,
+      "Minimum": 58.46,
+      "Maximum": 62.52,
+      "Unit": "Percent",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 4.89,
+      "Minimum": 4.44,
+      "Maximum": 6.48,
+      "Unit": "Percent",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 25,
+      "desiredCount": 25
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 2.92,
+      "Minimum": 2.87,
+      "Maximum": 3,
+      "Unit": "Percent",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 2.32,
+      "Minimum": 2.17,
+      "Maximum": 2.38,
+      "Unit": "Percent",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 50,
+      "desiredCount": 50
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Timestamp": "2026-07-09T22:03:00-05:00",
+      "Average": 21.55,
+      "Minimum": 15.91,
+      "Maximum": 36.19,
+      "Unit": "Percent",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "database_connections": {
+      "Timestamp": "2026-07-09T22:03:00-05:00",
+      "Average": 181.22,
+      "Minimum": 66,
+      "Maximum": 260,
+      "Unit": "Count",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "read_iops": {
+      "Timestamp": "2026-07-09T22:03:00-05:00",
+      "Average": 0,
+      "Maximum": 0.02,
+      "Unit": "Count/Second",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "write_iops": {
+      "Timestamp": "2026-07-09T22:03:00-05:00",
+      "Average": 2324.6,
+      "Maximum": 3241.09,
+      "Unit": "Count/Second",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "deadlocks": {
+      "Timestamp": "2026-07-09T22:03:00-05:00",
+      "Average": 0,
+      "Sum": 0.13,
+      "Maximum": 0.02,
+      "Unit": "Count/Second",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    }
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-07-09T22:03:00-05:00",
+        "Average": 17.04,
+        "Minimum": 8.36,
+        "Maximum": 39.06,
+        "Unit": "Percent",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-07-09T22:03:00-05:00",
+        "Average": 106.65,
+        "Minimum": 63,
+        "Maximum": 155,
+        "Unit": "Count",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-07-09T22:03:00-05:00",
+        "Average": 5.14,
+        "Maximum": 223.05,
+        "Unit": "Count/Second",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-07-09T22:03:00-05:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      }
+    },
+    {
+      "instance": "reader-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-07-09T22:03:00-05:00",
+        "Average": 17.56,
+        "Minimum": 8.48,
+        "Maximum": 36.17,
+        "Unit": "Percent",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-07-09T22:03:00-05:00",
+        "Average": 103.25,
+        "Minimum": 57,
+        "Maximum": 139,
+        "Unit": "Count",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-07-09T22:03:00-05:00",
+        "Average": 4.52,
+        "Maximum": 355.25,
+        "Unit": "Count/Second",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-07-09T22:03:00-05:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "rds_performance_insights": {
+    "writer": [
+      {
+        "rank": 1,
+        "sql": "COMMIT",
+        "load_avg": 0.73
+      },
+      {
+        "rank": 2,
+        "sql": "INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... */ , ( ?, ... ",
+        "load_avg": 0.43
+      },
+      {
+        "rank": 3,
+        "sql": "SELECT `id` , NAME , SOURCE , `extension_for` , `bundle_identifier` , `upgrade_code` , `application_id` FROM `software_titles` WHERE ( COALESCE ( `bundle_identifier` , NAME ) , SOURCE , `extension_for` , COALESCE ( `bundle_identifier` , ? ) ) IN ( (...) ) ",
+        "load_avg": 0.27
+      },
+      {
+        "rank": 4,
+        "sql": "SELECT `s` . `id` FROM `software` `s` LEFT JOIN `software_host_counts` `shc` ON `s` . `id` = `shc` . `software_id` WHERE `shc` . `software_id` IS NULL AND NOT EXISTS ( SELECT ? FROM `host_software` `hsw` WHERE `hsw` . `software_id` = `s` . `id` ) LIMIT ? ",
+        "load_avg": 0.21
+      },
+      {
+        "rank": 5,
+        "sql": "SELECT `id` , NAME , SOURCE , `extension_for` , `bundle_identifier` , `upgrade_code` , `application_id` FROM `software_titles` WHERE ( COALESCE ( `bundle_identifier` , NAME ) , SOURCE , `extension_for` , COALESCE ( `bundle_identifier` , ? ) ) IN ( (...) /* , ... */ ) ",
+        "load_avg": 0.06
+      }
+    ],
+    "readers": [
+      {
+        "instance": "reader-1",
+        "top_sql": [
+          {
+            "rank": 1,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` IS NULL AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` .",
+            "load_avg": 0.37
+          },
+          {
+            "rank": 2,
+            "sql": "SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` JOIN `label_membership` `lm` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . `target_id` = `lm` . `label_id` AND `pt` . TYPE = ? ) WHERE `lm` . `host_id` = ? AND NOT `p` . `disabled` AND `p` . `pack_type` IS NULL ) UNION ALL ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . TYPE = ? AND `pt` . `target_id` = ? ) WHERE `p` . `pack_type` IS NULL ) UNI",
+            "load_avg": 0.3
+          },
+          {
+            "rank": 3,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` = ? AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` . `id",
+            "load_avg": 0.23
+          },
+          {
+            "rank": 4,
+            "sql": "SELECT `sc` . `cve` , `hs` . `host_id` FROM `software_cve` `sc` JOIN `host_software` `hs` ON `hs` . `software_id` = `sc` . `software_id` WHERE `sc` . `cve` IN ( ?, ... ",
+            "load_avg": 0.07
+          },
+          {
+            "rank": 5,
+            "sql": "SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `updated_at` , `h` . `detail_updated_at` , `h` . `node_key` , `h` . `hostname` , `h` . `uuid` , `h` . `platform` , `h` . `osquery_version` , `h` . `os_version` , `h` . `build` , `h` . `platform_like` , `h` . `code_name` , `h` . `uptime` , `h` . MEMORY , `h` . `cpu_type` , `h` . `cpu_subtype` , `h` . `cpu_brand` , `h` . `cpu_physical_cores` , `h` . `cpu_logical_cores` , `h` . `hardware_vendor` , `h` . `hardware_model` , `h` ",
+            "load_avg": 0.07
+          }
+        ]
+      },
+      {
+        "instance": "reader-2",
+        "top_sql": [
+          {
+            "rank": 1,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` IS NULL AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` .",
+            "load_avg": 0.38
+          },
+          {
+            "rank": 2,
+            "sql": "SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` JOIN `label_membership` `lm` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . `target_id` = `lm` . `label_id` AND `pt` . TYPE = ? ) WHERE `lm` . `host_id` = ? AND NOT `p` . `disabled` AND `p` . `pack_type` IS NULL ) UNION ALL ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . TYPE = ? AND `pt` . `target_id` = ? ) WHERE `p` . `pack_type` IS NULL ) UNI",
+            "load_avg": 0.31
+          },
+          {
+            "rank": 3,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` = ? AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` . `id",
+            "load_avg": 0.23
+          },
+          {
+            "rank": 4,
+            "sql": "SELECT `h` . `team_id` AS `team_id` , ? AS `global_stats` , `combined_results` . `cve` , COUNT ( * ) AS `host_count` FROM ( SELECT `sc` . `cve` , `hs` . `host_id` FROM `software_cve` `sc` INNER JOIN `host_software` `hs` ON `sc` . `software_id` = `hs` . `software_id` WHERE `sc` . `cve` IN (...) UNION SELECT `osv` . `cve` , `hos` . `host_id` FROM `operating_system_vulnerabilities` `osv` INNER JOIN `host_operating_system` `hos` ON `hos` . `os_id` = `osv` . `operating_system_id` WHERE `osv` . `cve` ",
+            "load_avg": 0.08
+          },
+          {
+            "rank": 5,
+            "sql": "SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `updated_at` , `h` . `detail_updated_at` , `h` . `node_key` , `h` . `hostname` , `h` . `uuid` , `h` . `platform` , `h` . `osquery_version` , `h` . `os_version` , `h` . `build` , `h` . `platform_like` , `h` . `code_name` , `h` . `uptime` , `h` . MEMORY , `h` . `cpu_type` , `h` . `cpu_subtype` , `h` . `cpu_brand` , `h` . `cpu_physical_cores` , `h` . `cpu_logical_cores` , `h` . `hardware_vendor` , `h` . `hardware_model` , `h` ",
+            "load_avg": 0.07
+          }
+        ]
+      }
+    ]
+  },
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-07-09T22:03:00-05:00",
+        "Average": 45.38,
+        "Minimum": 44.89,
+        "Maximum": 49.51,
+        "Unit": "Percent",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-07-09T22:03:00-05:00",
+        "Average": 4.72,
+        "Minimum": 4.71,
+        "Maximum": 4.81,
+        "Unit": "Percent",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-07-09T22:03:00-05:00",
+        "Average": 4.31,
+        "Minimum": 4.1,
+        "Maximum": 4.42,
+        "Unit": "Percent",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-07-09T22:03:00-05:00",
+        "Average": 4.67,
+        "Minimum": 4.66,
+        "Maximum": 4.67,
+        "Unit": "Percent",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-3",
+      "cpu_utilization": {
+        "Timestamp": "2026-07-09T22:03:00-05:00",
+        "Average": 4.27,
+        "Minimum": 4.08,
+        "Maximum": 4.42,
+        "Unit": "Percent",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-07-09T22:03:00-05:00",
+        "Average": 4.67,
+        "Minimum": 4.66,
+        "Maximum": 4.67,
+        "Unit": "Percent",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "alb": {
+    "target_response_time": {
+      "Timestamp": "2026-07-09T22:03:00-05:00",
+      "Average": 0,
+      "Minimum": 0,
+      "Maximum": 13.1,
+      "Unit": "Seconds",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "http_5xx_count": null,
+    "request_count": {
+      "Timestamp": "2026-07-09T22:03:00-05:00",
+      "Sum": 865804458,
+      "Unit": "Count",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "processed_bytes": {
+      "Timestamp": "2026-07-09T22:03:00-05:00",
+      "Sum": 939694730459,
+      "Unit": "Bytes",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    }
+  },
+  "fleet_server_errors": {
+    "error_count": 0.0,
+    "sample_messages": []
+  },
+  "rds_writer_extended": {
+    "freeable_memory": {
+      "Timestamp": "2026-07-09T22:03:00-05:00",
+      "Average": 29675321313.66,
+      "Minimum": 28820205568,
+      "Unit": "Bytes",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "buffer_cache_hit_ratio": {
+      "Timestamp": "2026-07-09T22:03:00-05:00",
+      "Average": 100,
+      "Minimum": 100,
+      "Unit": "Percent",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "volume_bytes_used": {
+      "Timestamp": "2026-07-09T22:03:00-05:00",
+      "Average": 27006399235.71,
+      "Maximum": 28506226688,
+      "Unit": "Bytes",
+      "data_points": 207,
+      "max_points": 216,
+      "data_coverage": 0.96
+    },
+    "select_latency": {
+      "Timestamp": "2026-07-09T22:03:00-05:00",
+      "Average": 7.82,
+      "Maximum": 56.95,
+      "Unit": "Milliseconds",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "insert_latency": {
+      "Timestamp": "2026-07-09T22:03:00-05:00",
+      "Average": 3.49,
+      "Maximum": 12.19,
+      "Unit": "Milliseconds",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "dml_latency": {
+      "Timestamp": "2026-07-09T22:03:00-05:00",
+      "Average": 1.71,
+      "Maximum": 5.33,
+      "Unit": "Milliseconds",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "threads_running": {
+      "average": 2.14,
+      "maximum": 4.03,
+      "vcpus": 16
+    },
+    "iops_utilization": {
+      "instance_class": "db.r6g.4xlarge",
+      "max_iops": 20000,
+      "read_iops_avg": 0,
+      "write_iops_avg": 2324.6,
+      "total_iops_avg": 2324.6,
+      "utilization_pct": 11.62
+    }
+  },
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-07-09T22:03:00-05:00",
+        "Average": 7.12,
+        "Maximum": 37,
+        "Unit": "Milliseconds",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-07-09T22:03:00-05:00",
+        "Average": 30726316054.76,
+        "Minimum": 30437801984,
+        "Unit": "Bytes",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-07-09T22:03:00-05:00",
+        "Average": 100,
+        "Minimum": 99.89,
+        "Unit": "Percent",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-07-09T22:03:00-05:00",
+        "Average": 0.47,
+        "Maximum": 4.5,
+        "Unit": "Milliseconds",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "iops_utilization": {
+        "instance_class": "db.r6g.4xlarge",
+        "max_iops": 20000,
+        "read_iops_avg": 5.14,
+        "write_iops_avg": 0,
+        "total_iops_avg": 5.14,
+        "utilization_pct": 0.03
+      },
+      "threads_running": {
+        "average": 1.31,
+        "maximum": 3.52,
+        "vcpus": 16
+      }
+    },
+    {
+      "instance": "reader-2",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-07-09T22:03:00-05:00",
+        "Average": 6.38,
+        "Maximum": 25,
+        "Unit": "Milliseconds",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-07-09T22:03:00-05:00",
+        "Average": 30687344347.97,
+        "Minimum": 30426927104,
+        "Unit": "Bytes",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-07-09T22:03:00-05:00",
+        "Average": 100,
+        "Minimum": 99.9,
+        "Unit": "Percent",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-07-09T22:03:00-05:00",
+        "Average": 0.52,
+        "Maximum": 4.69,
+        "Unit": "Milliseconds",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "iops_utilization": {
+        "instance_class": "db.r6g.4xlarge",
+        "max_iops": 20000,
+        "read_iops_avg": 4.52,
+        "write_iops_avg": 0,
+        "total_iops_avg": 4.52,
+        "utilization_pct": 0.02
+      },
+      "threads_running": {
+        "average": 1.42,
+        "maximum": 4.37,
+        "vcpus": 16
+      }
+    }
+  ],
+  "redis_extended": [
+    {
+      "node": "redis-1",
+      "curr_connections": {
+        "Timestamp": "2026-07-09T22:03:00-05:00",
+        "Average": 183.28,
+        "Maximum": 1588,
+        "Unit": "Count",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-07-09T22:03:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": {
+        "Timestamp": "2026-07-09T22:03:00-05:00",
+        "Average": 50.86,
+        "Minimum": 50.76,
+        "Unit": "Percent",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "curr_connections": {
+        "Timestamp": "2026-07-09T22:03:00-05:00",
+        "Average": 5.6,
+        "Maximum": 7,
+        "Unit": "Count",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-07-09T22:03:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    },
+    {
+      "node": "redis-3",
+      "curr_connections": {
+        "Timestamp": "2026-07-09T22:03:00-05:00",
+        "Average": 5.09,
+        "Maximum": 7,
+        "Unit": "Count",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-07-09T22:03:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 216,
+        "max_points": 216,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    }
+  ],
+  "network": {
+    "network_rx_bytes": {
+      "Timestamp": "2026-07-09T22:03:00-05:00",
+      "Average": 1063558.34,
+      "Sum": 28718202364,
+      "Unit": "Bytes/Second",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    },
+    "network_tx_bytes": {
+      "Timestamp": "2026-07-09T22:03:00-05:00",
+      "Average": 453159.98,
+      "Sum": 12236225671,
+      "Unit": "Bytes/Second",
+      "data_points": 216,
+      "max_points": 216,
+      "data_coverage": 1
+    }
+  },
+  "container_health": {
+    "abnormal_stops": 0,
+    "running_tasks": 50,
+    "oldest_start": null,
+    "newest_start": null,
+    "start_spread_min": null,
+    "start_spread_alert": false,
+    "tasks": []
+  }
+}

--- a/tools/loadtest/metrics/runs/baseline/489loadtest/489loadtest-2026-07-10-210313Z-18h.md
+++ b/tools/loadtest/metrics/runs/baseline/489loadtest/489loadtest-2026-07-10-210313Z-18h.md
@@ -1,0 +1,56 @@
+# Metrics Synopsis: 489loadtest
+
+- **Collected:** 2026-07-10T21:03:13Z
+- **Interval:** 18h
+- **Window:** 2026-07-10T03:03:13Z to 2026-07-10T21:03:13Z
+
+## Summary (18h averages)
+
+```
+Fleet Server:  CPU=60.37%  Mem=4.89%  Containers=25
+Loadtest:      CPU=2.92%  Mem=2.32%  Containers=50
+RDS Writer:    CPU=21.55%  Connections=181.22  Deadlocks=0.13
+RDS reader-1:  CPU=17.04%  Connections=106.65
+RDS reader-2:  CPU=17.56%  Connections=103.25
+Redis:         CPU=45.38%  Mem=4.72%
+
+Top SQL (writer):
+  #1 load=0.73  COMMIT
+  #2 load=0.43  INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... 
+  #3 load=0.27  SELECT `id` , NAME , SOURCE , `extension_for` , `bundle_identifier` , `upgrade_c
+  #4 load=0.21  SELECT `s` . `id` FROM `software` `s` LEFT JOIN `software_host_counts` `shc` ON 
+  #5 load=0.06  SELECT `id` , NAME , SOURCE , `extension_for` , `bundle_identifier` , `upgrade_c
+
+Top SQL (reader-1):
+  #1 load=0.37  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #2 load=0.3  SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pa
+  #3 load=0.23  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #4 load=0.07  SELECT `sc` . `cve` , `hs` . `host_id` FROM `software_cve` `sc` JOIN `host_softw
+  #5 load=0.07  SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `update
+
+Top SQL (reader-2):
+  #1 load=0.38  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #2 load=0.31  SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pa
+  #3 load=0.23  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #4 load=0.08  SELECT `h` . `team_id` AS `team_id` , ? AS `global_stats` , `combined_results` .
+  #5 load=0.07  SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `update
+ALB:           Latency=0s  5xx=0  Requests=865804458  Traffic=896162.73MB
+Fleet Errors:  Count=0.0
+RDS Writer:    FreeMem=27.64GB  CacheHit=100%  Disk=25.15GB  Threads=2.14  IOPS=11.62%
+               SelectLat=7.82ms  InsertLat=3.49ms
+RDS reader-1: FreeMem=28.62GB  CacheHit=100%  ReplicaLag=7.12ms  Threads=1.31  IOPS=0.03%
+               SelectLat=0.47ms
+RDS reader-2: FreeMem=28.58GB  CacheHit=100%  ReplicaLag=6.38ms  Threads=1.42  IOPS=0.02%
+               SelectLat=0.52ms
+Redis:         Connections=183.28  Evictions=0  CacheHit=50.86%
+Network:       RX=27387.81MB  TX=11669.37MB
+Containers:    Running=50  AbnormalStops=0  StartSpread=N/Amin
+```
+
+## Threshold Checks
+
+```
+  🔴 ALERT: RDS Writer Deadlocks = 0.13 (expected 0)
+
+  ⚠ 1 alert(s) detected
+```

--- a/tools/loadtest/metrics/runs/migration/487to489mig/487to489mig-2026-07-10-162812Z-1h.json
+++ b/tools/loadtest/metrics/runs/migration/487to489mig/487to489mig-2026-07-10-162812Z-1h.json
@@ -1,0 +1,670 @@
+{
+  "metadata": {
+    "workspace": "487to489mig",
+    "collected_at": "2026-07-10T16:28:12Z",
+    "region": "us-east-2",
+    "interval": "1h",
+    "time_window": {
+      "start": "2026-07-10T15:28:12Z",
+      "end": "2026-07-10T16:28:12Z"
+    }
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 60.63,
+      "Minimum": 59.98,
+      "Maximum": 61.91,
+      "Unit": "Percent",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 4.48,
+      "Minimum": 4.18,
+      "Maximum": 4.7,
+      "Unit": "Percent",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 25,
+      "desiredCount": 25
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 2.88,
+      "Minimum": 2.79,
+      "Maximum": 2.93,
+      "Unit": "Percent",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 2.06,
+      "Minimum": 1.96,
+      "Maximum": 2.11,
+      "Unit": "Percent",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 50,
+      "desiredCount": 50
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Timestamp": "2026-07-10T10:28:00-05:00",
+      "Average": 32.25,
+      "Minimum": 27.46,
+      "Maximum": 39.96,
+      "Unit": "Percent",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "database_connections": {
+      "Timestamp": "2026-07-10T10:28:00-05:00",
+      "Average": 219.53,
+      "Minimum": 103,
+      "Maximum": 259,
+      "Unit": "Count",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "read_iops": {
+      "Timestamp": "2026-07-10T10:28:00-05:00",
+      "Average": 0,
+      "Maximum": 0.02,
+      "Unit": "Count/Second",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "write_iops": {
+      "Timestamp": "2026-07-10T10:28:00-05:00",
+      "Average": 2506.45,
+      "Maximum": 3143.84,
+      "Unit": "Count/Second",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "deadlocks": {
+      "Timestamp": "2026-07-10T10:28:00-05:00",
+      "Average": 0,
+      "Sum": 0,
+      "Maximum": 0,
+      "Unit": "Count/Second",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    }
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-07-10T10:28:00-05:00",
+        "Average": 15.25,
+        "Minimum": 10.87,
+        "Maximum": 21.59,
+        "Unit": "Percent",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-07-10T10:28:00-05:00",
+        "Average": 92.1,
+        "Minimum": 70,
+        "Maximum": 117,
+        "Unit": "Count",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-07-10T10:28:00-05:00",
+        "Average": 35.01,
+        "Maximum": 365.49,
+        "Unit": "Count/Second",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-07-10T10:28:00-05:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      }
+    },
+    {
+      "instance": "reader-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-07-10T10:28:00-05:00",
+        "Average": 20.93,
+        "Minimum": 16.16,
+        "Maximum": 26.72,
+        "Unit": "Percent",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-07-10T10:28:00-05:00",
+        "Average": 99.35,
+        "Minimum": 78,
+        "Maximum": 116,
+        "Unit": "Count",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-07-10T10:28:00-05:00",
+        "Average": 68.01,
+        "Maximum": 711.53,
+        "Unit": "Count/Second",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-07-10T10:28:00-05:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "rds_performance_insights": {
+    "writer": [
+      {
+        "rank": 1,
+        "sql": "SELECT `id` , NAME , SOURCE , `extension_for` , `bundle_identifier` , `upgrade_code` , `application_id` FROM `software_titles` WHERE ( COALESCE ( `bundle_identifier` , NAME ) , SOURCE , `extension_for` , COALESCE ( `bundle_identifier` , ? ) ) IN ( (...) /* , ... */ ) ",
+        "load_avg": 1.38
+      },
+      {
+        "rank": 2,
+        "sql": "COMMIT",
+        "load_avg": 1.3
+      },
+      {
+        "rank": 3,
+        "sql": "SELECT `id` , NAME , SOURCE , `extension_for` , `bundle_identifier` , `upgrade_code` , `application_id` FROM `software_titles` WHERE ( COALESCE ( `bundle_identifier` , NAME ) , SOURCE , `extension_for` , COALESCE ( `bundle_identifier` , ? ) ) IN ( (...) ) ",
+        "load_avg": 0.95
+      },
+      {
+        "rank": 4,
+        "sql": "INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... */ , ( ?, ... ",
+        "load_avg": 0.89
+      },
+      {
+        "rank": 5,
+        "sql": "INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... */ , ( ? ",
+        "load_avg": 0.11
+      }
+    ],
+    "readers": [
+      {
+        "instance": "reader-1",
+        "top_sql": [
+          {
+            "rank": 1,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` IS NULL AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` .",
+            "load_avg": 0.33
+          },
+          {
+            "rank": 2,
+            "sql": "SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` JOIN `label_membership` `lm` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . `target_id` = `lm` . `label_id` AND `pt` . TYPE = ? ) WHERE `lm` . `host_id` = ? AND NOT `p` . `disabled` AND `p` . `pack_type` IS NULL ) UNION ALL ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . TYPE = ? AND `pt` . `target_id` = ? ) WHERE `p` . `pack_type` IS NULL ) UNI",
+            "load_avg": 0.28
+          },
+          {
+            "rank": 3,
+            "sql": "SELECT `h` . `team_id` AS `team_id` , ? AS `global_stats` , `combined_results` . `cve` , COUNT ( * ) AS `host_count` FROM ( SELECT `sc` . `cve` , `hs` . `host_id` FROM `software_cve` `sc` INNER JOIN `host_software` `hs` ON `sc` . `software_id` = `hs` . `software_id` WHERE `sc` . `cve` IN (...) UNION SELECT `osv` . `cve` , `hos` . `host_id` FROM `operating_system_vulnerabilities` `osv` INNER JOIN `host_operating_system` `hos` ON `hos` . `os_id` = `osv` . `operating_system_id` WHERE `osv` . `cve` ",
+            "load_avg": 0.2
+          },
+          {
+            "rank": 4,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` = ? AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` . `id",
+            "load_avg": 0.19
+          },
+          {
+            "rank": 5,
+            "sql": "SELECT ? AS `team_id` , ? AS `global_stats` , `combined_results` . `cve` , COUNT ( * ) AS `host_count` FROM ( SELECT `sc` . `cve` , `hs` . `host_id` FROM `software_cve` `sc` INNER JOIN `host_software` `hs` ON `sc` . `software_id` = `hs` . `software_id` WHERE `sc` . `cve` IN (...) UNION SELECT `osv` . `cve` , `hos` . `host_id` FROM `operating_system_vulnerabilities` `osv` INNER JOIN `host_operating_system` `hos` ON `hos` . `os_id` = `osv` . `operating_system_id` WHERE `osv` . `cve` IN (...) ) AS ",
+            "load_avg": 0.08
+          }
+        ]
+      },
+      {
+        "instance": "reader-2",
+        "top_sql": [
+          {
+            "rank": 1,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` IS NULL AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` .",
+            "load_avg": 0.34
+          },
+          {
+            "rank": 2,
+            "sql": "SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` JOIN `label_membership` `lm` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . `target_id` = `lm` . `label_id` AND `pt` . TYPE = ? ) WHERE `lm` . `host_id` = ? AND NOT `p` . `disabled` AND `p` . `pack_type` IS NULL ) UNION ALL ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . TYPE = ? AND `pt` . `target_id` = ? ) WHERE `p` . `pack_type` IS NULL ) UNI",
+            "load_avg": 0.28
+          },
+          {
+            "rank": 3,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` = ? AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` . `id",
+            "load_avg": 0.2
+          },
+          {
+            "rank": 4,
+            "sql": "SELECT COUNT ( DISTINCTROW `hs` . `host_id` ) , ? AS `team_id` , ? AS `global_stats` , `st` . `id` AS `software_title_id` FROM `software_titles` `st` JOIN `software` `s` ON `s` . `title_id` = `st` . `id` JOIN `host_software` `hs` ON `hs` . `software_id` = `s` . `id` GROUP BY `st` . `id`",
+            "load_avg": 0.14
+          },
+          {
+            "rank": 5,
+            "sql": "SELECT COUNT ( DISTINCTROW `hs` . `host_id` ) , `h` . `team_id` , ? AS `global_stats` , `st` . `id` AS `software_title_id` FROM `software_titles` `st` JOIN `software` `s` ON `s` . `title_id` = `st` . `id` JOIN `host_software` `hs` ON `hs` . `software_id` = `s` . `id` INNER JOIN HOSTS `h` ON `hs` . `host_id` = `h` . `id` WHERE `h` . `team_id` IS NOT NULL AND `hs` . `software_id` > ? GROUP BY `st` . `id` , `h` . `team_id`",
+            "load_avg": 0.11
+          }
+        ]
+      }
+    ]
+  },
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-07-10T10:28:00-05:00",
+        "Average": 33.87,
+        "Minimum": 32.97,
+        "Maximum": 34.9,
+        "Unit": "Percent",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-07-10T10:28:00-05:00",
+        "Average": 4.7,
+        "Minimum": 4.49,
+        "Maximum": 4.73,
+        "Unit": "Percent",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-07-10T10:28:00-05:00",
+        "Average": 4.34,
+        "Minimum": 4.22,
+        "Maximum": 4.43,
+        "Unit": "Percent",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-07-10T10:28:00-05:00",
+        "Average": 4.65,
+        "Minimum": 4.4,
+        "Maximum": 4.67,
+        "Unit": "Percent",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-3",
+      "cpu_utilization": {
+        "Timestamp": "2026-07-10T10:28:00-05:00",
+        "Average": 4.44,
+        "Minimum": 4.34,
+        "Maximum": 4.52,
+        "Unit": "Percent",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-07-10T10:28:00-05:00",
+        "Average": 4.65,
+        "Minimum": 4.4,
+        "Maximum": 4.67,
+        "Unit": "Percent",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "alb": {
+    "target_response_time": {
+      "Timestamp": "2026-07-10T10:28:00-05:00",
+      "Average": 0,
+      "Minimum": 0,
+      "Maximum": 1.48,
+      "Unit": "Seconds",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "http_5xx_count": null,
+    "request_count": {
+      "Timestamp": "2026-07-10T10:28:00-05:00",
+      "Sum": 47893823,
+      "Unit": "Count",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "processed_bytes": {
+      "Timestamp": "2026-07-10T10:28:00-05:00",
+      "Sum": 52083573221,
+      "Unit": "Bytes",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    }
+  },
+  "fleet_server_errors": {
+    "error_count": 0.0,
+    "sample_messages": []
+  },
+  "rds_writer_extended": {
+    "freeable_memory": {
+      "Timestamp": "2026-07-10T10:28:00-05:00",
+      "Average": 29844820377.6,
+      "Minimum": 29183442944,
+      "Unit": "Bytes",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "buffer_cache_hit_ratio": {
+      "Timestamp": "2026-07-10T10:28:00-05:00",
+      "Average": 100,
+      "Minimum": 100,
+      "Unit": "Percent",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "volume_bytes_used": {
+      "Timestamp": "2026-07-10T10:28:00-05:00",
+      "Average": 20673560576,
+      "Maximum": 20673560576,
+      "Unit": "Bytes",
+      "data_points": 6,
+      "max_points": 12,
+      "data_coverage": 0.5
+    },
+    "select_latency": {
+      "Timestamp": "2026-07-10T10:28:00-05:00",
+      "Average": 21.9,
+      "Maximum": 41.04,
+      "Unit": "Milliseconds",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "insert_latency": {
+      "Timestamp": "2026-07-10T10:28:00-05:00",
+      "Average": 3.82,
+      "Maximum": 8.81,
+      "Unit": "Milliseconds",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "dml_latency": {
+      "Timestamp": "2026-07-10T10:28:00-05:00",
+      "Average": 1.99,
+      "Maximum": 4.29,
+      "Unit": "Milliseconds",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "threads_running": {
+      "average": 4.73,
+      "maximum": 6.07,
+      "vcpus": 16
+    },
+    "iops_utilization": {
+      "instance_class": "db.r6g.4xlarge",
+      "max_iops": 20000,
+      "read_iops_avg": 0,
+      "write_iops_avg": 2506.45,
+      "total_iops_avg": 2506.45,
+      "utilization_pct": 12.53
+    }
+  },
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-07-10T10:28:00-05:00",
+        "Average": 6.32,
+        "Maximum": 16,
+        "Unit": "Milliseconds",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-07-10T10:28:00-05:00",
+        "Average": 30874394624,
+        "Minimum": 30779183104,
+        "Unit": "Bytes",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-07-10T10:28:00-05:00",
+        "Average": 99.99,
+        "Minimum": 99.91,
+        "Unit": "Percent",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-07-10T10:28:00-05:00",
+        "Average": 0.49,
+        "Maximum": 1.09,
+        "Unit": "Milliseconds",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "iops_utilization": {
+        "instance_class": "db.r6g.4xlarge",
+        "max_iops": 20000,
+        "read_iops_avg": 35.01,
+        "write_iops_avg": 0,
+        "total_iops_avg": 35.01,
+        "utilization_pct": 0.18
+      },
+      "threads_running": {
+        "average": 1.2,
+        "maximum": 2.05,
+        "vcpus": 16
+      }
+    },
+    {
+      "instance": "reader-2",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-07-10T10:28:00-05:00",
+        "Average": 6.62,
+        "Maximum": 16,
+        "Unit": "Milliseconds",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-07-10T10:28:00-05:00",
+        "Average": 30838940740.27,
+        "Minimum": 30732890112,
+        "Unit": "Bytes",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-07-10T10:28:00-05:00",
+        "Average": 99.98,
+        "Minimum": 99.7,
+        "Unit": "Percent",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-07-10T10:28:00-05:00",
+        "Average": 0.51,
+        "Maximum": 3.42,
+        "Unit": "Milliseconds",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "iops_utilization": {
+        "instance_class": "db.r6g.4xlarge",
+        "max_iops": 20000,
+        "read_iops_avg": 68.01,
+        "write_iops_avg": 0,
+        "total_iops_avg": 68.01,
+        "utilization_pct": 0.34
+      },
+      "threads_running": {
+        "average": 1.61,
+        "maximum": 2.18,
+        "vcpus": 16
+      }
+    }
+  ],
+  "redis_extended": [
+    {
+      "node": "redis-1",
+      "curr_connections": {
+        "Timestamp": "2026-07-10T10:28:00-05:00",
+        "Average": 156.18,
+        "Maximum": 174,
+        "Unit": "Count",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-07-10T10:28:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": {
+        "Timestamp": "2026-07-10T10:28:00-05:00",
+        "Average": 89.06,
+        "Minimum": 87.92,
+        "Unit": "Percent",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "curr_connections": {
+        "Timestamp": "2026-07-10T10:28:00-05:00",
+        "Average": 5.03,
+        "Maximum": 6,
+        "Unit": "Count",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-07-10T10:28:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    },
+    {
+      "node": "redis-3",
+      "curr_connections": {
+        "Timestamp": "2026-07-10T10:28:00-05:00",
+        "Average": 5.05,
+        "Maximum": 6,
+        "Unit": "Count",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-07-10T10:28:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    }
+  ],
+  "network": {
+    "network_rx_bytes": {
+      "Timestamp": "2026-07-10T10:28:00-05:00",
+      "Average": 1038994.15,
+      "Sum": 1558491219,
+      "Unit": "Bytes/Second",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "network_tx_bytes": {
+      "Timestamp": "2026-07-10T10:28:00-05:00",
+      "Average": 428516.7,
+      "Sum": 642775051,
+      "Unit": "Bytes/Second",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    }
+  },
+  "container_health": {
+    "abnormal_stops": 0,
+    "running_tasks": 50,
+    "oldest_start": null,
+    "newest_start": null,
+    "start_spread_min": null,
+    "start_spread_alert": false,
+    "tasks": []
+  }
+}

--- a/tools/loadtest/metrics/runs/migration/487to489mig/487to489mig-2026-07-10-162812Z-1h.md
+++ b/tools/loadtest/metrics/runs/migration/487to489mig/487to489mig-2026-07-10-162812Z-1h.md
@@ -1,0 +1,54 @@
+# Metrics Synopsis: 487to489mig
+
+- **Collected:** 2026-07-10T16:28:12Z
+- **Interval:** 1h
+- **Window:** 2026-07-10T15:28:12Z to 2026-07-10T16:28:12Z
+
+## Summary (1h averages)
+
+```
+Fleet Server:  CPU=60.63%  Mem=4.48%  Containers=25
+Loadtest:      CPU=2.88%  Mem=2.06%  Containers=50
+RDS Writer:    CPU=32.25%  Connections=219.53  Deadlocks=0
+RDS reader-1:  CPU=15.25%  Connections=92.1
+RDS reader-2:  CPU=20.93%  Connections=99.35
+Redis:         CPU=33.87%  Mem=4.7%
+
+Top SQL (writer):
+  #1 load=1.38  SELECT `id` , NAME , SOURCE , `extension_for` , `bundle_identifier` , `upgrade_c
+  #2 load=1.3  COMMIT
+  #3 load=0.95  SELECT `id` , NAME , SOURCE , `extension_for` , `bundle_identifier` , `upgrade_c
+  #4 load=0.89  INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... 
+  #5 load=0.11  INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... 
+
+Top SQL (reader-1):
+  #1 load=0.33  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #2 load=0.28  SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pa
+  #3 load=0.2  SELECT `h` . `team_id` AS `team_id` , ? AS `global_stats` , `combined_results` .
+  #4 load=0.19  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #5 load=0.08  SELECT ? AS `team_id` , ? AS `global_stats` , `combined_results` . `cve` , COUNT
+
+Top SQL (reader-2):
+  #1 load=0.34  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #2 load=0.28  SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pa
+  #3 load=0.2  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #4 load=0.14  SELECT COUNT ( DISTINCTROW `hs` . `host_id` ) , ? AS `team_id` , ? AS `global_st
+  #5 load=0.11  SELECT COUNT ( DISTINCTROW `hs` . `host_id` ) , `h` . `team_id` , ? AS `global_s
+ALB:           Latency=0s  5xx=0  Requests=47893823  Traffic=49670.77MB
+Fleet Errors:  Count=0.0
+RDS Writer:    FreeMem=27.8GB  CacheHit=100%  Disk=19.25GB  Threads=4.73  IOPS=12.53%
+               SelectLat=21.9ms  InsertLat=3.82ms
+RDS reader-1: FreeMem=28.75GB  CacheHit=99.99%  ReplicaLag=6.32ms  Threads=1.2  IOPS=0.18%
+               SelectLat=0.49ms
+RDS reader-2: FreeMem=28.72GB  CacheHit=99.98%  ReplicaLag=6.62ms  Threads=1.61  IOPS=0.34%
+               SelectLat=0.51ms
+Redis:         Connections=156.18  Evictions=0  CacheHit=89.06%
+Network:       RX=1486.29MB  TX=613MB
+Containers:    Running=50  AbnormalStops=0  StartSpread=N/Amin
+```
+
+## Threshold Checks
+
+```
+  ✅ All metrics within expected thresholds
+```

--- a/tools/loadtest/metrics/runs/migration/487to489mig/487to489mig-2026-07-10-192738Z-130m.json
+++ b/tools/loadtest/metrics/runs/migration/487to489mig/487to489mig-2026-07-10-192738Z-130m.json
@@ -1,0 +1,670 @@
+{
+  "metadata": {
+    "workspace": "487to489mig",
+    "collected_at": "2026-07-10T19:27:38Z",
+    "region": "us-east-2",
+    "interval": "130m",
+    "time_window": {
+      "start": "2026-07-10T17:17:38Z",
+      "end": "2026-07-10T19:27:38Z"
+    }
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 62.34,
+      "Minimum": 58.97,
+      "Maximum": 72.59,
+      "Unit": "Percent",
+      "data_points": 26,
+      "max_points": 26,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 5.68,
+      "Minimum": 5.21,
+      "Maximum": 6.86,
+      "Unit": "Percent",
+      "data_points": 26,
+      "max_points": 26,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 25,
+      "desiredCount": 25
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 2.93,
+      "Minimum": 2.87,
+      "Maximum": 3.15,
+      "Unit": "Percent",
+      "data_points": 26,
+      "max_points": 26,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 2.37,
+      "Minimum": 2.33,
+      "Maximum": 2.4,
+      "Unit": "Percent",
+      "data_points": 26,
+      "max_points": 26,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 50,
+      "desiredCount": 50
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Timestamp": "2026-07-10T12:17:00-05:00",
+      "Average": 22.69,
+      "Minimum": 7.04,
+      "Maximum": 95.77,
+      "Unit": "Percent",
+      "data_points": 26,
+      "max_points": 26,
+      "data_coverage": 1
+    },
+    "database_connections": {
+      "Timestamp": "2026-07-10T12:17:00-05:00",
+      "Average": 153.88,
+      "Minimum": 78,
+      "Maximum": 255,
+      "Unit": "Count",
+      "data_points": 26,
+      "max_points": 26,
+      "data_coverage": 1
+    },
+    "read_iops": {
+      "Timestamp": "2026-07-10T12:17:00-05:00",
+      "Average": 0,
+      "Maximum": 0.02,
+      "Unit": "Count/Second",
+      "data_points": 26,
+      "max_points": 26,
+      "data_coverage": 1
+    },
+    "write_iops": {
+      "Timestamp": "2026-07-10T12:17:00-05:00",
+      "Average": 1998.6,
+      "Maximum": 3524.97,
+      "Unit": "Count/Second",
+      "data_points": 26,
+      "max_points": 26,
+      "data_coverage": 1
+    },
+    "deadlocks": {
+      "Timestamp": "2026-07-10T12:17:00-05:00",
+      "Average": 0,
+      "Sum": 0.08,
+      "Maximum": 0.05,
+      "Unit": "Count/Second",
+      "data_points": 26,
+      "max_points": 26,
+      "data_coverage": 1
+    }
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-07-10T12:17:00-05:00",
+        "Average": 17.55,
+        "Minimum": 11.85,
+        "Maximum": 31.67,
+        "Unit": "Percent",
+        "data_points": 26,
+        "max_points": 26,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-07-10T12:17:00-05:00",
+        "Average": 88.43,
+        "Minimum": 51,
+        "Maximum": 144,
+        "Unit": "Count",
+        "data_points": 26,
+        "max_points": 26,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-07-10T12:17:00-05:00",
+        "Average": 8.46,
+        "Maximum": 78.66,
+        "Unit": "Count/Second",
+        "data_points": 26,
+        "max_points": 26,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-07-10T12:17:00-05:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 26,
+        "max_points": 26,
+        "data_coverage": 1
+      }
+    },
+    {
+      "instance": "reader-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-07-10T12:17:00-05:00",
+        "Average": 19.07,
+        "Minimum": 12.93,
+        "Maximum": 29.41,
+        "Unit": "Percent",
+        "data_points": 26,
+        "max_points": 26,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-07-10T12:17:00-05:00",
+        "Average": 77.42,
+        "Minimum": 46,
+        "Maximum": 144,
+        "Unit": "Count",
+        "data_points": 26,
+        "max_points": 26,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-07-10T12:17:00-05:00",
+        "Average": 19.52,
+        "Maximum": 310.14,
+        "Unit": "Count/Second",
+        "data_points": 26,
+        "max_points": 26,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-07-10T12:17:00-05:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 26,
+        "max_points": 26,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "rds_performance_insights": {
+    "writer": [
+      {
+        "rank": 1,
+        "sql": "COMMIT",
+        "load_avg": 2.21
+      },
+      {
+        "rank": 2,
+        "sql": "SELECT `id` , NAME , SOURCE , `extension_for` , `bundle_identifier` , `upgrade_code` , `application_id` FROM `software_titles` WHERE ( COALESCE ( `bundle_identifier` , NAME ) , SOURCE , `extension_for` , COALESCE ( `bundle_identifier` , ? ) ) IN ( (...) ) ",
+        "load_avg": 0.64
+      },
+      {
+        "rank": 3,
+        "sql": "INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... */ , ( ?, ... ",
+        "load_avg": 0.61
+      },
+      {
+        "rank": 4,
+        "sql": "SELECT `id` , NAME , SOURCE , `extension_for` , `bundle_identifier` , `upgrade_code` , `application_id` FROM `software_titles` WHERE ( COALESCE ( `bundle_identifier` , NAME ) , SOURCE , `extension_for` , COALESCE ( `bundle_identifier` , ? ) ) IN ( (...) /* , ... */ ) ",
+        "load_avg": 0.4
+      },
+      {
+        "rank": 5,
+        "sql": "INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... */ , ( ? ",
+        "load_avg": 0.08
+      }
+    ],
+    "readers": [
+      {
+        "instance": "reader-1",
+        "top_sql": [
+          {
+            "rank": 1,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` IS NULL AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` .",
+            "load_avg": 0.41
+          },
+          {
+            "rank": 2,
+            "sql": "SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` JOIN `label_membership` `lm` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . `target_id` = `lm` . `label_id` AND `pt` . TYPE = ? ) WHERE `lm` . `host_id` = ? AND NOT `p` . `disabled` AND `p` . `pack_type` IS NULL ) UNION ALL ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . TYPE = ? AND `pt` . `target_id` = ? ) WHERE `p` . `pack_type` IS NULL ) UNI",
+            "load_avg": 0.34
+          },
+          {
+            "rank": 3,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` = ? AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` . `id",
+            "load_avg": 0.25
+          },
+          {
+            "rank": 4,
+            "sql": "SELECT `s` . `id` , `s` . NAME , `s` . `version` , `s` . SOURCE , `s` . `bundle_identifier` , `s` . RELEASE , `s` . `arch` , `s` . `vendor` , `s` . `extension_for` , `s` . `extension_id` , `s` . `title_id` , COALESCE ( `sc` . `cpe` , ? ) AS `generated_cpe` FROM `software` `s` LEFT JOIN `software_cpe` `sc` ON ( `s` . `id` = `sc` . `software_id` ) WHERE `s` . SOURCE NOT IN (...) ",
+            "load_avg": 0.08
+          },
+          {
+            "rank": 5,
+            "sql": "SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `updated_at` , `h` . `detail_updated_at` , `h` . `node_key` , `h` . `hostname` , `h` . `uuid` , `h` . `platform` , `h` . `osquery_version` , `h` . `os_version` , `h` . `build` , `h` . `platform_like` , `h` . `code_name` , `h` . `uptime` , `h` . MEMORY , `h` . `cpu_type` , `h` . `cpu_subtype` , `h` . `cpu_brand` , `h` . `cpu_physical_cores` , `h` . `cpu_logical_cores` , `h` . `hardware_vendor` , `h` . `hardware_model` , `h` ",
+            "load_avg": 0.07
+          }
+        ]
+      },
+      {
+        "instance": "reader-2",
+        "top_sql": [
+          {
+            "rank": 1,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` IS NULL AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` .",
+            "load_avg": 0.36
+          },
+          {
+            "rank": 2,
+            "sql": "SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` JOIN `label_membership` `lm` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . `target_id` = `lm` . `label_id` AND `pt` . TYPE = ? ) WHERE `lm` . `host_id` = ? AND NOT `p` . `disabled` AND `p` . `pack_type` IS NULL ) UNION ALL ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . TYPE = ? AND `pt` . `target_id` = ? ) WHERE `p` . `pack_type` IS NULL ) UNI",
+            "load_avg": 0.3
+          },
+          {
+            "rank": 3,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` = ? AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` . `id",
+            "load_avg": 0.22
+          },
+          {
+            "rank": 4,
+            "sql": "SELECT `h` . `team_id` AS `team_id` , ? AS `global_stats` , `combined_results` . `cve` , COUNT ( * ) AS `host_count` FROM ( SELECT `sc` . `cve` , `hs` . `host_id` FROM `software_cve` `sc` INNER JOIN `host_software` `hs` ON `sc` . `software_id` = `hs` . `software_id` WHERE `sc` . `cve` IN (...) UNION SELECT `osv` . `cve` , `hos` . `host_id` FROM `operating_system_vulnerabilities` `osv` INNER JOIN `host_operating_system` `hos` ON `hos` . `os_id` = `osv` . `operating_system_id` WHERE `osv` . `cve` ",
+            "load_avg": 0.16
+          },
+          {
+            "rank": 5,
+            "sql": "SELECT COUNT ( DISTINCTROW `hs` . `host_id` ) , `h` . `team_id` , ? AS `global_stats` , `st` . `id` AS `software_title_id` FROM `software_titles` `st` JOIN `software` `s` ON `s` . `title_id` = `st` . `id` JOIN `host_software` `hs` ON `hs` . `software_id` = `s` . `id` INNER JOIN HOSTS `h` ON `hs` . `host_id` = `h` . `id` WHERE `h` . `team_id` IS NOT NULL AND `hs` . `software_id` > ? GROUP BY `st` . `id` , `h` . `team_id`",
+            "load_avg": 0.09
+          }
+        ]
+      }
+    ]
+  },
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-07-10T12:17:00-05:00",
+        "Average": 46.68,
+        "Minimum": 44.98,
+        "Maximum": 52.64,
+        "Unit": "Percent",
+        "data_points": 26,
+        "max_points": 26,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-07-10T12:17:00-05:00",
+        "Average": 4.73,
+        "Minimum": 4.61,
+        "Maximum": 4.93,
+        "Unit": "Percent",
+        "data_points": 26,
+        "max_points": 26,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-07-10T12:17:00-05:00",
+        "Average": 4.36,
+        "Minimum": 3.55,
+        "Maximum": 6.08,
+        "Unit": "Percent",
+        "data_points": 26,
+        "max_points": 26,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-07-10T12:17:00-05:00",
+        "Average": 4.67,
+        "Minimum": 4.5,
+        "Maximum": 4.69,
+        "Unit": "Percent",
+        "data_points": 26,
+        "max_points": 26,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-3",
+      "cpu_utilization": {
+        "Timestamp": "2026-07-10T12:17:00-05:00",
+        "Average": 4.46,
+        "Minimum": 3.52,
+        "Maximum": 6.3,
+        "Unit": "Percent",
+        "data_points": 26,
+        "max_points": 26,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-07-10T12:17:00-05:00",
+        "Average": 4.67,
+        "Minimum": 4.5,
+        "Maximum": 4.69,
+        "Unit": "Percent",
+        "data_points": 26,
+        "max_points": 26,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "alb": {
+    "target_response_time": {
+      "Timestamp": "2026-07-10T12:17:00-05:00",
+      "Average": 0.01,
+      "Minimum": 0,
+      "Maximum": 13.29,
+      "Unit": "Seconds",
+      "data_points": 26,
+      "max_points": 26,
+      "data_coverage": 1
+    },
+    "http_5xx_count": null,
+    "request_count": {
+      "Timestamp": "2026-07-10T12:17:00-05:00",
+      "Sum": 104397605,
+      "Unit": "Count",
+      "data_points": 26,
+      "max_points": 26,
+      "data_coverage": 1
+    },
+    "processed_bytes": {
+      "Timestamp": "2026-07-10T12:17:00-05:00",
+      "Sum": 113648159671,
+      "Unit": "Bytes",
+      "data_points": 26,
+      "max_points": 26,
+      "data_coverage": 1
+    }
+  },
+  "fleet_server_errors": {
+    "error_count": 0.0,
+    "sample_messages": []
+  },
+  "rds_writer_extended": {
+    "freeable_memory": {
+      "Timestamp": "2026-07-10T12:17:00-05:00",
+      "Average": 29481596486.89,
+      "Minimum": 28846559232,
+      "Unit": "Bytes",
+      "data_points": 26,
+      "max_points": 26,
+      "data_coverage": 1
+    },
+    "buffer_cache_hit_ratio": {
+      "Timestamp": "2026-07-10T12:17:00-05:00",
+      "Average": 100,
+      "Minimum": 100,
+      "Unit": "Percent",
+      "data_points": 26,
+      "max_points": 26,
+      "data_coverage": 1
+    },
+    "volume_bytes_used": {
+      "Timestamp": "2026-07-10T12:17:00-05:00",
+      "Average": 24425238528,
+      "Maximum": 24552013824,
+      "Unit": "Bytes",
+      "data_points": 16,
+      "max_points": 26,
+      "data_coverage": 0.62
+    },
+    "select_latency": {
+      "Timestamp": "2026-07-10T12:17:00-05:00",
+      "Average": 8.72,
+      "Maximum": 65.68,
+      "Unit": "Milliseconds",
+      "data_points": 26,
+      "max_points": 26,
+      "data_coverage": 1
+    },
+    "insert_latency": {
+      "Timestamp": "2026-07-10T12:17:00-05:00",
+      "Average": 17.49,
+      "Maximum": 71.56,
+      "Unit": "Milliseconds",
+      "data_points": 26,
+      "max_points": 26,
+      "data_coverage": 1
+    },
+    "dml_latency": {
+      "Timestamp": "2026-07-10T12:17:00-05:00",
+      "Average": 9.52,
+      "Maximum": 40.07,
+      "Unit": "Milliseconds",
+      "data_points": 26,
+      "max_points": 26,
+      "data_coverage": 1
+    },
+    "threads_running": {
+      "average": 3.43,
+      "maximum": 24.93,
+      "vcpus": 16
+    },
+    "iops_utilization": {
+      "instance_class": "db.r6g.4xlarge",
+      "max_iops": 20000,
+      "read_iops_avg": 0,
+      "write_iops_avg": 1998.6,
+      "total_iops_avg": 1998.6,
+      "utilization_pct": 9.99
+    }
+  },
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-07-10T12:17:00-05:00",
+        "Average": 7.47,
+        "Maximum": 23,
+        "Unit": "Milliseconds",
+        "data_points": 26,
+        "max_points": 26,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-07-10T12:17:00-05:00",
+        "Average": 30772519006.52,
+        "Minimum": 30658592768,
+        "Unit": "Bytes",
+        "data_points": 26,
+        "max_points": 26,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-07-10T12:17:00-05:00",
+        "Average": 100,
+        "Minimum": 99.99,
+        "Unit": "Percent",
+        "data_points": 26,
+        "max_points": 26,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-07-10T12:17:00-05:00",
+        "Average": 0.46,
+        "Maximum": 3.35,
+        "Unit": "Milliseconds",
+        "data_points": 26,
+        "max_points": 26,
+        "data_coverage": 1
+      },
+      "iops_utilization": {
+        "instance_class": "db.r6g.4xlarge",
+        "max_iops": 20000,
+        "read_iops_avg": 8.46,
+        "write_iops_avg": 0,
+        "total_iops_avg": 8.46,
+        "utilization_pct": 0.04
+      },
+      "threads_running": {
+        "average": 1.33,
+        "maximum": 2.71,
+        "vcpus": 16
+      }
+    },
+    {
+      "instance": "reader-2",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-07-10T12:17:00-05:00",
+        "Average": 7.39,
+        "Maximum": 22,
+        "Unit": "Milliseconds",
+        "data_points": 26,
+        "max_points": 26,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-07-10T12:17:00-05:00",
+        "Average": 30710527212.31,
+        "Minimum": 30556516352,
+        "Unit": "Bytes",
+        "data_points": 26,
+        "max_points": 26,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-07-10T12:17:00-05:00",
+        "Average": 99.99,
+        "Minimum": 99.81,
+        "Unit": "Percent",
+        "data_points": 26,
+        "max_points": 26,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-07-10T12:17:00-05:00",
+        "Average": 0.57,
+        "Maximum": 2.78,
+        "Unit": "Milliseconds",
+        "data_points": 26,
+        "max_points": 26,
+        "data_coverage": 1
+      },
+      "iops_utilization": {
+        "instance_class": "db.r6g.4xlarge",
+        "max_iops": 20000,
+        "read_iops_avg": 19.52,
+        "write_iops_avg": 0,
+        "total_iops_avg": 19.52,
+        "utilization_pct": 0.1
+      },
+      "threads_running": {
+        "average": 1.56,
+        "maximum": 2.4,
+        "vcpus": 16
+      }
+    }
+  ],
+  "redis_extended": [
+    {
+      "node": "redis-1",
+      "curr_connections": {
+        "Timestamp": "2026-07-10T12:17:00-05:00",
+        "Average": 191.26,
+        "Maximum": 863,
+        "Unit": "Count",
+        "data_points": 26,
+        "max_points": 26,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-07-10T12:17:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 26,
+        "max_points": 26,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": {
+        "Timestamp": "2026-07-10T12:17:00-05:00",
+        "Average": 50.86,
+        "Minimum": 49.94,
+        "Unit": "Percent",
+        "data_points": 26,
+        "max_points": 26,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "curr_connections": {
+        "Timestamp": "2026-07-10T12:17:00-05:00",
+        "Average": 6,
+        "Maximum": 6,
+        "Unit": "Count",
+        "data_points": 26,
+        "max_points": 26,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-07-10T12:17:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 26,
+        "max_points": 26,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    },
+    {
+      "node": "redis-3",
+      "curr_connections": {
+        "Timestamp": "2026-07-10T12:17:00-05:00",
+        "Average": 5.05,
+        "Maximum": 6,
+        "Unit": "Count",
+        "data_points": 26,
+        "max_points": 26,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-07-10T12:17:00-05:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 26,
+        "max_points": 26,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    }
+  ],
+  "network": {
+    "network_rx_bytes": {
+      "Timestamp": "2026-07-10T12:17:00-05:00",
+      "Average": 1072848.66,
+      "Sum": 3495340949,
+      "Unit": "Bytes/Second",
+      "data_points": 26,
+      "max_points": 26,
+      "data_coverage": 1
+    },
+    "network_tx_bytes": {
+      "Timestamp": "2026-07-10T12:17:00-05:00",
+      "Average": 457735.23,
+      "Sum": 1491301393,
+      "Unit": "Bytes/Second",
+      "data_points": 26,
+      "max_points": 26,
+      "data_coverage": 1
+    }
+  },
+  "container_health": {
+    "abnormal_stops": 0,
+    "running_tasks": 50,
+    "oldest_start": null,
+    "newest_start": null,
+    "start_spread_min": null,
+    "start_spread_alert": false,
+    "tasks": []
+  }
+}

--- a/tools/loadtest/metrics/runs/migration/487to489mig/487to489mig-2026-07-10-192738Z-130m.md
+++ b/tools/loadtest/metrics/runs/migration/487to489mig/487to489mig-2026-07-10-192738Z-130m.md
@@ -1,0 +1,56 @@
+# Metrics Synopsis: 487to489mig
+
+- **Collected:** 2026-07-10T19:27:38Z
+- **Interval:** 130m
+- **Window:** 2026-07-10T17:17:38Z to 2026-07-10T19:27:38Z
+
+## Summary (130m averages)
+
+```
+Fleet Server:  CPU=62.34%  Mem=5.68%  Containers=25
+Loadtest:      CPU=2.93%  Mem=2.37%  Containers=50
+RDS Writer:    CPU=22.69%  Connections=153.88  Deadlocks=0.08
+RDS reader-1:  CPU=17.55%  Connections=88.43
+RDS reader-2:  CPU=19.07%  Connections=77.42
+Redis:         CPU=46.68%  Mem=4.73%
+
+Top SQL (writer):
+  #1 load=2.21  COMMIT
+  #2 load=0.64  SELECT `id` , NAME , SOURCE , `extension_for` , `bundle_identifier` , `upgrade_c
+  #3 load=0.61  INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... 
+  #4 load=0.4  SELECT `id` , NAME , SOURCE , `extension_for` , `bundle_identifier` , `upgrade_c
+  #5 load=0.08  INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... 
+
+Top SQL (reader-1):
+  #1 load=0.41  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #2 load=0.34  SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pa
+  #3 load=0.25  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #4 load=0.08  SELECT `s` . `id` , `s` . NAME , `s` . `version` , `s` . SOURCE , `s` . `bundle_
+  #5 load=0.07  SELECT `h` . `id` , `h` . `osquery_host_id` , `h` . `created_at` , `h` . `update
+
+Top SQL (reader-2):
+  #1 load=0.36  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #2 load=0.3  SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pa
+  #3 load=0.22  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #4 load=0.16  SELECT `h` . `team_id` AS `team_id` , ? AS `global_stats` , `combined_results` .
+  #5 load=0.09  SELECT COUNT ( DISTINCTROW `hs` . `host_id` ) , `h` . `team_id` , ? AS `global_s
+ALB:           Latency=0.01s  5xx=0  Requests=104397605  Traffic=108383.33MB
+Fleet Errors:  Count=0.0
+RDS Writer:    FreeMem=27.46GB  CacheHit=100%  Disk=22.75GB  Threads=3.43  IOPS=9.99%
+               SelectLat=8.72ms  InsertLat=17.49ms
+RDS reader-1: FreeMem=28.66GB  CacheHit=100%  ReplicaLag=7.47ms  Threads=1.33  IOPS=0.04%
+               SelectLat=0.46ms
+RDS reader-2: FreeMem=28.6GB  CacheHit=99.99%  ReplicaLag=7.39ms  Threads=1.56  IOPS=0.1%
+               SelectLat=0.57ms
+Redis:         Connections=191.26  Evictions=0  CacheHit=50.86%
+Network:       RX=3333.42MB  TX=1422.22MB
+Containers:    Running=50  AbnormalStops=0  StartSpread=N/Amin
+```
+
+## Threshold Checks
+
+```
+  🔴 ALERT: RDS Writer Deadlocks = 0.08 (expected 0)
+
+  ⚠ 1 alert(s) detected
+```


### PR DESCRIPTION
## Summary

Adds the **4.89.0** load test metrics artifacts, following the existing `tools/loadtest/metrics/runs/` conventions.

### Baseline — `runs/baseline/489loadtest/`
18h run on a fresh RC instance (no data).
- `489loadtest-2026-07-10-210313Z-18h.json` / `.md`

### Migration — `runs/migration/487to489mig/`
4.87 → 4.89 migration, before vs. after.
- `487to489mig-2026-07-10-162812Z-1h.{json,md}` — pre-migration (1h window)
- `487to489mig-2026-07-10-192738Z-130m.{json,md}` — post-migration (130m window)

## Results

| Run | Fleet errors | ALB 5xx | Abnormal stops | Threshold checks |
|-----|:---:|:---:|:---:|---|
| Baseline (18h) | 0 | 0 | 0 | RDS Writer Deadlocks avg 0.13 (occasional, retried) |
| Migration pre (1h) | 0 | 0 | 0 | ✅ all within thresholds |
| Migration post (130m) | 0 | 0 | 0 | RDS Writer Deadlocks avg 0.08 (occasional, retried) |

The only flag is a near-zero average of occasional RDS writer deadlocks (MySQL retries these); everything else is within expected range and holds steady across the migration. Full per-metric comparison (`compare-metrics.sh`) is posted on the release QA issue.

Data only — no code changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added baseline and migration load-test performance reports.
  * Included infrastructure, database, Redis, load balancer, network, container health, error, and SQL performance metrics.
  * Added reports covering multiple test durations and migration intervals for improved performance analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->