### PR TITLE
Document risks of VPP app installs during setup experience

### DIFF
--- a/articles/setup-experience.md
+++ b/articles/setup-experience.md
@@ -264,6 +264,25 @@ When this feature is enabled, any failed software will immediately end the setup
 
 End users won't continue through setup experience unless they press Command (⌘) + Shift + X.
 
+### Risks of App Store (VPP) apps
+
+App Store (VPP) apps install differently than custom packages and Fleet-maintained apps. Fleet installs custom packages and Fleet-maintained apps locally through Fleet's agent (fleetd). App Store (VPP) apps are installed by Apple: Fleet sends an `InstallApplication` MDM command, and the device downloads and installs the app from the App Store. As a result, VPP installs during setup depend on Apple's services and the device's connection to the App Store while it's still in Setup Assistant.
+
+Keep this in mind when adding VPP apps to setup experience:
+
+- **Setup can be delayed or blocked.** During macOS setup, Fleet holds the device in Setup Assistant until every setup experience item finishes. Software installs one at a time, in alphabetical order, so a slow or hung VPP install makes the end user wait at the Setup Assistant screen. Fleet waits for each install to verify (10 minutes by default) and retries a failed VPP install up to 4 times (1 initial attempt + 3 retries), so a single failing app can hold setup for a long time before Fleet marks it failed. On iOS and iPadOS, only VPP apps run during setup, so a hung install delays the device's release.
+
+- **VPP installs depend on Apple.** Because Apple performs the install, problems outside Fleet can cause installs to fail or hang for every enrolling host at once: an App Store or Apple Business (AB) outage, Apple throttling `InstallApplication` commands during a large rollout, an expired or missing VPP token, too few available licenses, or an app that isn't available in the device's region. Fleet retries, but retries don't help while Apple is unavailable.
+
+To reduce these risks:
+
+- Only add apps that end users need before their first login. Deliver everything else after enrollment using [automatic install](https://fleetdm.com/guides/automatic-software-install-in-fleet), which runs in the background and doesn't hold the device in Setup Assistant.
+- Keep the setup experience software list short. Each item extends setup time.
+- Before a large rollout, confirm your VPP token is valid and you have enough available licenses for the apps you're installing.
+- Decide how you want failures handled with the ["Cancel setup if software install fails"](#stop-setup-on-failed-software-installs) option. When it's off, a failed VPP install lets the end user through once Fleet finishes retrying. When it's on, the first failed install ends setup and asks the end user to restart.
+
+If a host gets stuck, you can send the [`DeviceConfigured`](https://developer.apple.com/documentation/devicemanagement/device-configured-command) command using Fleet's [Run MDM command](https://fleetdm.com/docs/rest-api/rest-api#run-mdm-command) API to let the end user through.
+
 ## Run script
 
 To configure a script to run during setup experience:

--- a/articles/setup-experience.md
+++ b/articles/setup-experience.md
@@ -264,22 +264,19 @@ When this feature is enabled, any failed software will immediately end the setup
 
 End users won't continue through setup experience unless they press Command (⌘) + Shift + X.
 
-### Risks of App Store (VPP) apps
+### App Store (VPP) apps in setup experience
 
-App Store (VPP) apps install differently than custom packages and Fleet-maintained apps. Fleet installs custom packages and Fleet-maintained apps locally through Fleet's agent (fleetd). App Store (VPP) apps are installed by Apple: Fleet sends an `InstallApplication` MDM command, and the device downloads and installs the app from the App Store. As a result, VPP installs during setup depend on Apple's services and the device's connection to the App Store while it's still in Setup Assistant.
+App Store (VPP) apps are installed by Apple. Fleet sends an [InstallApplication](https://developer.apple.com/documentation/devicemanagement/install-application-command) MDM command, and the device downloads and installs the app from the App Store. As a result, VPP installs during setup depend on Apple's services and the device's connection to the App Store while it's still in Setup Assistant.
 
-Keep this in mind when adding VPP apps to setup experience:
 
-- **Setup can be delayed or blocked.** During macOS setup, Fleet holds the device in Setup Assistant until every setup experience item finishes. Software installs one at a time, in alphabetical order, so a slow or hung VPP install makes the end user wait at the Setup Assistant screen. Fleet waits for each install to verify (10 minutes by default) and retries a failed VPP install up to 4 times (1 initial attempt + 3 retries), so a single failing app can hold setup for a long time before Fleet marks it failed. On iOS and iPadOS, only VPP apps run during setup, so a hung install delays the device's release.
-
-- **VPP installs depend on Apple.** Because Apple performs the install, problems outside Fleet can cause installs to fail or hang for every enrolling host at once: an App Store or Apple Business (AB) outage, Apple throttling `InstallApplication` commands during a large rollout, an expired or missing VPP token, too few available licenses, or an app that isn't available in the device's region. Fleet retries, but retries don't help while Apple is unavailable.
+Because Apple performs the install, things outside Fleet's control, such as an App Store or Apple Business outage, `InstallApplication` throttling, an expired VPP token, or too few licenses, can cause installs to fail or hang for every host at once. Fleet retries automatically (up to 4 attempts, waiting 10 minutes each time to verify), but retries won’t help while Apple itself is unavailable, and until an install finishes, the end user waits at the Setup Assistant screen.
 
 To reduce these risks:
 
 - Only add apps that end users need before their first login. Deliver everything else after enrollment using [automatic install](https://fleetdm.com/guides/automatic-software-install-in-fleet), which runs in the background and doesn't hold the device in Setup Assistant.
 - Keep the setup experience software list short. Each item extends setup time.
 - Before a large rollout, confirm your VPP token is valid and you have enough available licenses for the apps you're installing.
-- Decide how you want failures handled with the ["Cancel setup if software install fails"](#stop-setup-on-failed-software-installs) option. When it's off, a failed VPP install lets the end user through once Fleet finishes retrying. When it's on, the first failed install ends setup and asks the end user to restart.
+- If available, choose Fleet-maintained app over App Store (VPP) app for better control
 
 If a host gets stuck, you can send the [`DeviceConfigured`](https://developer.apple.com/documentation/devicemanagement/device-configured-command) command using Fleet's [Run MDM command](https://fleetdm.com/docs/rest-api/rest-api#run-mdm-command) API to let the end user through.
 

--- a/articles/setup-experience.md
+++ b/articles/setup-experience.md
@@ -268,7 +268,6 @@ End users won't continue through setup experience unless they press Command (⌘
 
 App Store (VPP) apps are installed by Apple. Fleet sends an [InstallApplication](https://developer.apple.com/documentation/devicemanagement/install-application-command) MDM command, and the device downloads and installs the app from the App Store. As a result, VPP installs during setup depend on Apple's services and the device's connection to the App Store while it's still in Setup Assistant.
 
-
 Because Apple performs the install, things outside Fleet's control, such as an App Store or Apple Business outage, `InstallApplication` throttling, an expired VPP token, or too few licenses, can cause installs to fail or hang for every host at once. Fleet retries automatically (up to 4 attempts, waiting 10 minutes each time to verify), but retries won’t help while Apple itself is unavailable, and until an install finishes, the end user waits at the Setup Assistant screen.
 
 To reduce these risks:


### PR DESCRIPTION
**Related issue:** Resolves #47179

# Checklist for submitter

- [x] QA'd all new/changed functionality manually

## Description

Documents the risks of installing App Store (VPP) apps during the macOS/iOS/iPadOS setup experience, as an action item from the incident #23 postmortem.

Adds a "Risks of App Store (VPP) apps" subsection to the Setup experience guide (`articles/setup-experience.md`) under **Install software**, covering:

- **Setup can be delayed or blocked** — Fleet holds the device in Setup Assistant until every item finishes; VPP installs run one at a time, each waiting for verification (10 min default) and retrying up to 4 times, so one failing app can hold setup a long time. On iOS/iPadOS only VPP apps run, so a hung install delays release.
- **VPP installs depend on Apple** — because Apple performs the install, an App Store/ABM outage, `InstallApplication` throttling during large rollouts, an expired/missing VPP token, too few licenses, or a region-unavailable app can fail or hang every enrolling host at once.
- Mitigations: keep the setup list to must-have-before-first-login apps and defer the rest to background automatic install, verify token/licenses before rollouts, choose the "Cancel setup if software install fails" behavior deliberately, and the `DeviceConfigured` escape hatch for stuck hosts.

Docs-only change (no code, tests, migrations, or config settings).
