### PR TITLE
Update block-and-monitor-edr-freeze-on-macos-with-santa-and-fleet.md

### DIFF
--- a/articles/block-and-monitor-edr-freeze-on-macos-with-santa-and-fleet.md
+++ b/articles/block-and-monitor-edr-freeze-on-macos-with-santa-and-fleet.md
@@ -1,6 +1,6 @@
 # Block and monitor EDR Freeze on macOS with Santa and Fleet
 
-*EDR Freeze suspends a security tool instead of killing it, so the process looks healthy while it quietly stops working. Santa 2026.3 can block it on macOS, and Fleet lets you ship the fix and watch for the attack across every host.*
+*EDR Freeze suspends a security tool instead of killing it, so the process looks healthy while it quietly stops working. Thanks to the team at [North Pole Security](https://northpole.security/), Santa 2026.3 can block it on macOS, and Fleet lets you ship the fix and watch for the attack across every host.*
 
 ## Key takeaways
 
@@ -15,11 +15,11 @@
 
 EDR Freeze started life on Windows — pause a security product so it stops alerting or responding, without crashing or uninstalling it. The same idea works on macOS: anything built on Apple's Endpoint Security framework can be frozen with the `pid_suspend` system call, and a suspended agent still looks healthy in every monitoring tool while an attacker slips actions past its checks or floods its event queue.
 
-The good news is that the fix is well understood, and you can ship and monitor it through Fleet today. Santa, the open-source binary authorization agent for macOS, added the `AntiSuspendSigningIDs` configuration key in version 2026.3, and Fleet gives you the delivery pipeline and the visibility to go with it. Here's how the attack works and how to close it.
+The good news is that the fix is well understood, and you can ship and monitor it through Fleet today. Santa, the open-source binary authorization agent for macOS maintained by [North Pole Security](https://northpole.security/), added the `AntiSuspendSigningIDs` configuration key in version 2026.3, and Fleet gives you the delivery pipeline and the visibility to go with it. Here's how the attack works and how to close it.
 
 ## How EDR Freeze works on macOS
 
-`pid_suspend` is a long-standing macOS system call. It has been around since Snow Leopard 10.6 and predates the Endpoint Security framework, so it isn't going anywhere. It works at the Mach task level, beneath the BSD process layer that most software deals with. Called against a process, the kernel freezes every thread in the underlying task and pauses scheduling until something calls `pid_resume`.
+North Pole Security, the maintainers of Santa, [broke down the macOS variant of EDR Freeze in detail](https://northpole.security/blog/edr-freeze). The short version: `pid_suspend` is a long-standing macOS system call. It has been around since Snow Leopard 10.6 and predates the Endpoint Security framework, so it isn't going anywhere. It works at the Mach task level, beneath the BSD process layer that most software deals with. Called against a process, the kernel freezes every thread in the underlying task and pauses scheduling until something calls `pid_resume`.
 
 A suspended security agent can't pull events off its queue or respond to them, because its threads aren't running. Yet `ps` and Activity Monitor still list the process as present, so from the outside everything looks normal.
 
@@ -184,6 +184,8 @@ The fastest path is to work through the [Santa deployment series](https://fleetd
 - [santa_denied table](https://fleetdm.com/tables/santa_denied)
 - [santa_allowed table](https://fleetdm.com/tables/santa_allowed)
 - [Santa on GitHub](https://github.com/northpolesec/santa)
+- [North Pole Security's EDR Freeze breakdown](https://northpole.security/blog/edr-freeze)
+- [North Pole Security blog](https://northpole.security/blog)
 
 <meta name="articleTitle" value="Block and monitor EDR Freeze on macOS with Santa and Fleet">
 <meta name="authorFullName" value="Dhruv Majumdar">


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
