### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/apidog/darwin.json
+++ b/ee/maintained-apps/outputs/apidog/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.8.37",
+      "version": "2.8.38",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.apidog.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.apidog.app' AND version_compare(bundle_short_version, '2.8.37') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.apidog.app' AND version_compare(bundle_short_version, '2.8.38') < 0);"
       },
-      "installer_url": "https://file-assets.apidog.com/download/2.8.37/legacy-Apidog-macOS-arm64-2.8.37.dmg",
+      "installer_url": "https://file-assets.apidog.com/download/2.8.38/legacy-Apidog-macOS-arm64-2.8.38.dmg",
       "install_script_ref": "164bc8ef",
       "uninstall_script_ref": "b51190cf",
-      "sha256": "751577934586b4fe5cc3a45f111049e99d2fb5eaf79a832b5e670d9d56a9f562",
+      "sha256": "e72f4050401e19a1c7bccbb434170b9867067f4088bc885d32873028a315d09e",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/claude/darwin.json
+++ b/ee/maintained-apps/outputs/claude/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.20186.0",
+      "version": "1.20186.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.20186.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.20186.1') < 0);"
       },
-      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.20186.0/Claude-d7731e7f42fb72db87a6488ad8c1357b1cf971f7.zip",
+      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.20186.1/Claude-df1d8a339dfabcf359af7144fe142b59ff7d9a0f.zip",
       "install_script_ref": "8b957973",
       "uninstall_script_ref": "421baa98",
-      "sha256": "34fe29eb3d7acc63fe8e7320986e8aee12304bb347e4d03beace6d7d6279ee4c",
+      "sha256": "250629ea95cc95c0db46962ac33095c3f20b1a776aaae4df7aa51f96171e7866",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/cmake-app/windows.json
+++ b/ee/maintained-apps/outputs/cmake-app/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.3.4",
+      "version": "4.4.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'CMake' AND publisher = 'Kitware';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'CMake' AND publisher = 'Kitware' AND version_compare(version, '4.3.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'CMake' AND publisher = 'Kitware' AND version_compare(version, '4.4.0') < 0);"
       },
-      "installer_url": "https://github.com/Kitware/CMake/releases/download/v4.3.4/cmake-4.3.4-windows-x86_64.msi",
+      "installer_url": "https://github.com/Kitware/CMake/releases/download/v4.4.0/cmake-4.4.0-windows-x86_64.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "6ac3efbc",
-      "sha256": "6f54ab92a19bf7d6695a40f3a774a8d1a54e90730c726fad8afb44544db892da",
+      "sha256": "82db53fcb8f38be541a26093489f39d5ed79b71b53cd121fc32a022a6bf310b1",
       "default_categories": [
         "Productivity"
       ],

--- a/ee/maintained-apps/outputs/codexbar/darwin.json
+++ b/ee/maintained-apps/outputs/codexbar/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.41.0",
+      "version": "0.42.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.steipete.codexbar';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.steipete.codexbar' AND version_compare(bundle_short_version, '0.41.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.steipete.codexbar' AND version_compare(bundle_short_version, '0.42.0') < 0);"
       },
-      "installer_url": "https://github.com/steipete/CodexBar/releases/download/v0.41.0/CodexBar-macos-universal-0.41.0.zip",
+      "installer_url": "https://github.com/steipete/CodexBar/releases/download/v0.42.0/CodexBar-macos-universal-0.42.0.zip",
       "install_script_ref": "aea54a4e",
       "uninstall_script_ref": "efcab822",
-      "sha256": "3378b4e58bb5e6e4cb77f6cee44e5b61e9f7758a35893108ff3efe571785858d",
+      "sha256": "47997847d139eb8a7d20b155e40e59ca841c78b84473590bda1e9e07b84898e5",
       "default_categories": [
         "Utilities"
       ]

--- a/ee/maintained-apps/outputs/cursor/windows.json
+++ b/ee/maintained-apps/outputs/cursor/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.10.11",
+      "version": "3.10.20",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Cursor' AND publisher = 'Anysphere';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Cursor' AND publisher = 'Anysphere' AND version_compare(version, '3.10.11') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Cursor' AND publisher = 'Anysphere' AND version_compare(version, '3.10.20') < 0);"
       },
-      "installer_url": "https://downloads.cursor.com/production/4ef9fe3d055f8c4523179a090f14eb835bc3c94e/win32/x64/system-setup/CursorSetup-x64-3.10.11.exe",
+      "installer_url": "https://downloads.cursor.com/production/23b9fb205fe595ea2be29da7214e19762d037fc3/win32/x64/system-setup/CursorSetup-x64-3.10.20.exe",
       "install_script_ref": "03589b5e",
       "uninstall_script_ref": "6c8096c5",
-      "sha256": "b9bffc722d2c944ef76d6bb51f9a13d45c4b9fed498c2e0c568b35ef2d789ed1",
+      "sha256": "67c0b38c006f25964b9b7a8ab749f1334d48a3fe3aaa5b44585bd481a7cdb4fc",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/datagrip/darwin.json
+++ b/ee/maintained-apps/outputs/datagrip/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.1.3",
+      "version": "2026.1.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.datagrip';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.datagrip' AND version_compare(bundle_short_version, '2026.1.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.datagrip' AND version_compare(bundle_short_version, '2026.1.4') < 0);"
       },
-      "installer_url": "https://download.jetbrains.com/datagrip/datagrip-2026.1.3-aarch64.dmg",
+      "installer_url": "https://download.jetbrains.com/datagrip/datagrip-2026.1.4-aarch64.dmg",
       "install_script_ref": "d84722a4",
       "uninstall_script_ref": "1c2e1bad",
-      "sha256": "2b2b777d83d7cf04d5c4f15529df9ab621d66ff8bb82319a873d4c278897c72f",
+      "sha256": "02c3d9b78fe4bb9e792674aa9c38c27c0de1bd976749354bb1e78e753617a1ab",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/datagrip/windows.json
+++ b/ee/maintained-apps/outputs/datagrip/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.1.3",
+      "version": "2026.1.4",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'DataGrip %' AND publisher = 'JetBrains s.r.o.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'DataGrip %' AND publisher = 'JetBrains s.r.o.' AND version_compare(version, '261.24374.56') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'DataGrip %' AND publisher = 'JetBrains s.r.o.' AND version_compare(version, '261.26222.86') < 0);"
       },
-      "installer_url": "https://download.jetbrains.com/datagrip/datagrip-2026.1.3.exe",
+      "installer_url": "https://download.jetbrains.com/datagrip/datagrip-2026.1.4.exe",
       "install_script_ref": "0897461e",
       "uninstall_script_ref": "020465dd",
-      "sha256": "661bccdea8cb29aa482a23365395c086acfbd1ac55d8220d660a522a6fd43287",
+      "sha256": "81ff4e511b492c5652734022ac2444003fcc1bb66a1b17d0e4a440611fefe1fb",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/downie/darwin.json
+++ b/ee/maintained-apps/outputs/downie/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.12.9",
+      "version": "4.12.10",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.charliemonroe.Downie-4';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.charliemonroe.Downie-4' AND version_compare(bundle_short_version, '4.12.9') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.charliemonroe.Downie-4' AND version_compare(bundle_short_version, '4.12.10') < 0);"
       },
-      "installer_url": "https://software.charliemonroe.net/trial/downie/v4/Downie_4_5205.dmg",
+      "installer_url": "https://software.charliemonroe.net/trial/downie/v4/Downie_4_5210.dmg",
       "install_script_ref": "1468a553",
       "uninstall_script_ref": "24e71e3c",
-      "sha256": "e8d52f5c96440ce52c49960751af0252f5700a2bf2d92a1c7998a970e91d8f68",
+      "sha256": "d01ac070ae778745984b7bde6fd01d445c8f914641425f663a94c51464a57b69",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/hive-app/darwin.json
+++ b/ee/maintained-apps/outputs/hive-app/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.2.15",
+      "version": "1.2.16",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app' AND version_compare(bundle_short_version, '1.2.15') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app' AND version_compare(bundle_short_version, '1.2.16') < 0);"
       },
-      "installer_url": "https://github.com/morapelker/hive/releases/download/v1.2.15/Hive-1.2.15-arm64.dmg",
+      "installer_url": "https://github.com/morapelker/hive/releases/download/v1.2.16/Hive-1.2.16-arm64.dmg",
       "install_script_ref": "6b39e7ad",
       "uninstall_script_ref": "78bb4e43",
-      "sha256": "9d196fee3eb7d78ccf439b17adf84ccd44fd387d99ab22cab2cfdd938ba21346",
+      "sha256": "d18070a3aaa8149a3a4fd493037366ee3c03c9fac8f214d619ca4fc8a3e502fa",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/jitsi-meet/darwin.json
+++ b/ee/maintained-apps/outputs/jitsi-meet/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.6.0",
+      "version": "2026.7.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.jitsi.jitsi-meet';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.jitsi.jitsi-meet' AND version_compare(bundle_short_version, '2026.6.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.jitsi.jitsi-meet' AND version_compare(bundle_short_version, '2026.7.0') < 0);"
       },
-      "installer_url": "https://github.com/jitsi/jitsi-meet-electron/releases/download/v2026.6.0/jitsi-meet.dmg",
+      "installer_url": "https://github.com/jitsi/jitsi-meet-electron/releases/download/v2026.7.0/jitsi-meet.dmg",
       "install_script_ref": "61536dfb",
       "uninstall_script_ref": "ed2d9125",
-      "sha256": "d47288330b863e92ab98bd5d127fe5eaed086bdff0dd5f1a50878e9414497f84",
+      "sha256": "b52316e73317effeb324f8a085dace1827ba6fd9440f4d0e32d46aef21589690",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/linearmouse/darwin.json
+++ b/ee/maintained-apps/outputs/linearmouse/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.11.2",
+      "version": "0.11.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.lujjjh.LinearMouse';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.lujjjh.LinearMouse' AND version_compare(bundle_short_version, '0.11.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.lujjjh.LinearMouse' AND version_compare(bundle_short_version, '0.11.3') < 0);"
       },
-      "installer_url": "https://dl.linearmouse.org/v0.11.2/LinearMouse.dmg",
+      "installer_url": "https://dl.linearmouse.org/v0.11.3/LinearMouse.dmg",
       "install_script_ref": "dc040262",
       "uninstall_script_ref": "dcd89a8c",
-      "sha256": "f7fa320b8f74e3cd293e29ae469e6899419d1edb9e7e40141fbdc7e3ecfa44a7",
+      "sha256": "8db843f475ceb2d0ac786c21bae308b19ae8baab35e5ce7feafe98493df2c0da",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/netron/darwin.json
+++ b/ee/maintained-apps/outputs/netron/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "9.1.4",
+      "version": "9.1.5",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.lutzroeder.netron';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.lutzroeder.netron' AND version_compare(bundle_short_version, '9.1.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.lutzroeder.netron' AND version_compare(bundle_short_version, '9.1.5') < 0);"
       },
-      "installer_url": "https://github.com/lutzroeder/netron/releases/download/v9.1.4/Netron-9.1.4-mac.zip",
+      "installer_url": "https://github.com/lutzroeder/netron/releases/download/v9.1.5/Netron-9.1.5-mac.zip",
       "install_script_ref": "4929401f",
       "uninstall_script_ref": "acbbb0d7",
-      "sha256": "19fe41fc71c44508bf15fe2790506e1ca439b6ddc0a91db79d90670fdaf47ab7",
+      "sha256": "7d201c378b710b4b2a97907aa161ee665170bf7f2d8c275563c08355f252e445",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/notepadexe/darwin.json
+++ b/ee/maintained-apps/outputs/notepadexe/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.4.1929",
+      "version": "1.4.1945",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'best.swift.Notepad';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'best.swift.Notepad' AND version_compare(bundle_short_version, '1.4.1929') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'best.swift.Notepad' AND version_compare(bundle_short_version, '1.4.1945') < 0);"
       },
-      "installer_url": "https://github.com/notepadhq/notepadexe-public/releases/download/1.4.1929/Notepad.zip",
+      "installer_url": "https://github.com/notepadhq/notepadexe-public/releases/download/1.4.1945/Notepad.zip",
       "install_script_ref": "17716d6a",
       "uninstall_script_ref": "abe56690",
-      "sha256": "e37521b7a498cdd93c2794eebc11f11d45ac9e7b1182bafead44e87699734229",
+      "sha256": "ea6e3029790feaa2f000cfa1916f2de94a64835d480fbfab4480bfbfdbe0e041",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/ocenaudio/windows.json
+++ b/ee/maintained-apps/outputs/ocenaudio/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.19.5",
+      "version": "3.20.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'ocenaudio' AND publisher = 'Ocenaudio Team';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'ocenaudio' AND publisher = 'Ocenaudio Team' AND version_compare(version, '3.19.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'ocenaudio' AND publisher = 'Ocenaudio Team' AND version_compare(version, '3.20.0') < 0);"
       },
       "installer_url": "https://www.ocenaudio.com/downloads/index.php/ocenaudio_windows64.exe",
       "install_script_ref": "ebf8794b",
       "uninstall_script_ref": "7264fb50",
-      "sha256": "0ddb35b5275d8091fb03a9c21f3a0f5b4b2fea624478896fd90bd948db3ccfc3",
+      "sha256": "ada197609bb284de1362c0e09628b2b22a2a07d4f22e6d358163d2ff43857870",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/onedrive/windows.json
+++ b/ee/maintained-apps/outputs/onedrive/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.108.0607.0002",
+      "version": "26.113.0614.0004",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Microsoft OneDrive' AND publisher = 'Microsoft Corporation';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Microsoft OneDrive' AND publisher = 'Microsoft Corporation' AND version_compare(version, '26.108.0607.0002') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Microsoft OneDrive' AND publisher = 'Microsoft Corporation' AND version_compare(version, '26.113.0614.0004') < 0);"
       },
-      "installer_url": "https://oneclient.sfx.ms/Win/Installers/26.108.0607.0002/amd64/OneDriveSetup.exe",
+      "installer_url": "https://oneclient.sfx.ms/Win/Installers/26.113.0614.0004/amd64/OneDriveSetup.exe",
       "install_script_ref": "ab0b56ab",
       "uninstall_script_ref": "374be511",
-      "sha256": "9509d072ed5e1108e8d91d2a54840029ea1de1ee3d67f2b172f2146ef89a9b50",
+      "sha256": "b1c63da9ee9a34ccdb35d8c8c26cfca970048091f1f138a48ab3318dacdae990",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/unity-hub/darwin.json
+++ b/ee/maintained-apps/outputs/unity-hub/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.19.4",
+      "version": "3.19.5",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.unity3d.unityhub';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.unity3d.unityhub' AND version_compare(bundle_short_version, '3.19.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.unity3d.unityhub' AND version_compare(bundle_short_version, '3.19.5') < 0);"
       },
-      "installer_url": "https://public-cdn.cloud.unity3d.com/hub/prod/3.19.4/UnityHubSetup-3.19.4-arm64.dmg",
+      "installer_url": "https://public-cdn.cloud.unity3d.com/hub/prod/3.19.5/UnityHubSetup-3.19.5-arm64.dmg",
       "install_script_ref": "c26804cb",
       "uninstall_script_ref": "5b95ff58",
-      "sha256": "8314a09f37a8ca1ac089c1561df20797c7dc871074a82d7cef69dbed4b42e59d",
+      "sha256": "da6773add1f638d8bd00615a47661408d1de4a3c94e7efb5a37f1e7131e63272",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/wireshark/windows.json
+++ b/ee/maintained-apps/outputs/wireshark/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.6.6",
+      "version": "4.6.7",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Wireshark' AND publisher = 'The Wireshark developer community, https://www.wireshark.org';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Wireshark' AND publisher = 'The Wireshark developer community, https://www.wireshark.org' AND version_compare(version, '4.6.6') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Wireshark' AND publisher = 'The Wireshark developer community, https://www.wireshark.org' AND version_compare(version, '4.6.7') < 0);"
       },
-      "installer_url": "https://2.na.dl.wireshark.org/win64/all-versions/Wireshark-4.6.6-x64.msi",
+      "installer_url": "https://2.na.dl.wireshark.org/win64/all-versions/Wireshark-4.6.7-x64.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "dc2e795d",
-      "sha256": "90104f6eae9b1fb4b1c8ebf6313d73e42f34ee274d3bc26bdc86741d47466c9d",
+      "sha256": "ca156a40791ed9803e6028a413fe05ec22d723b09ac5f727534ede3f5f1d0423",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/wispr-flow/darwin.json
+++ b/ee/maintained-apps/outputs/wispr-flow/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.5.1146",
+      "version": "1.6.7",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.wispr-flow';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.wispr-flow' AND version_compare(bundle_short_version, '1.5.1146') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.wispr-flow' AND version_compare(bundle_short_version, '1.6.7') < 0);"
       },
-      "installer_url": "https://dl.wisprflow.com/wispr-flow/darwin/arm64/dmgs/Flow-v1.5.1146.dmg",
+      "installer_url": "https://dl.wisprflow.com/wispr-flow/darwin/arm64/dmgs/Flow-v1.6.7.dmg",
       "install_script_ref": "3a49fcfd",
       "uninstall_script_ref": "e0cf2e96",
-      "sha256": "a3db6bb7468c0a0dbb7f161ceff640cbe5422a59e08e3fdfad26b4c09669458c",
+      "sha256": "9bc84506abf094a545d0943c611ce83858ab8c18a196ffcd3b2fcf87c3cea506",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/zed/windows.json
+++ b/ee/maintained-apps/outputs/zed/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.10.1",
+      "version": "1.10.2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Zed' AND publisher = 'Zed Industries';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Zed' AND publisher = 'Zed Industries' AND version_compare(version, '1.10.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Zed' AND publisher = 'Zed Industries' AND version_compare(version, '1.10.2') < 0);"
       },
-      "installer_url": "https://github.com/zed-industries/zed/releases/download/v1.10.1/Zed-x86_64.exe",
+      "installer_url": "https://github.com/zed-industries/zed/releases/download/v1.10.2/Zed-x86_64.exe",
       "install_script_ref": "e5193bc1",
       "uninstall_script_ref": "3b164442",
-      "sha256": "2142cf0f860268cbcb874c981617e4b339594ed41055d6b9d8957c923c2903e9",
+      "sha256": "b23b6bce1e6319238326e8f8a630f454a3ab83aab043ad0868705921dbe0bd97",
       "default_categories": [
         "Developer tools"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated installer availability and metadata for 18 maintained applications across macOS and Windows.
  * New releases include Apidog 2.8.38, Claude 1.20186.1, CMake 4.4.0, CodexBar 0.42.0, Cursor 3.10.20, DataGrip 2026.1.4, and Downie 4.12.10.
  * Additional updates include Hive, Jitsi Meet, LinearMouse, Netron, Notepad, ocenaudio, OneDrive, Unity Hub, Wireshark, Wispr Flow, and Zed.
  * Download links, version detection, and installer checksums now correspond to each latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->