### PR TITLE
Upgrade query-generator SQL step to Claude Sonnet 5

### DIFF
--- a/website/api/controllers/query-generator/get-llm-generated-sql.js
+++ b/website/api/controllers/query-generator/get-llm-generated-sql.js
@@ -175,7 +175,7 @@ module.exports = {
 
     // Effort is set to "low" because the schema was already narrowed down to relevant tables by the
     // schema-filtration step above -- the model doesn't need to spend much effort re-deriving that context.
-    let sqlReport = await sails.helpers.ai.prompt.with({prompt:sqlPrompt, baseModel:'claude-sonnet-5', expectJson: true, systemPromptForQueryGeneration, effort: 'low'})
+    let sqlReport = await sails.helpers.ai.prompt.with({prompt:sqlPrompt, baseModel:'claude-sonnet-5', expectJson: true, systemPrompt: systemPromptForQueryGeneration, effort: 'low'})
     .intercept((err)=>{
       if(this.req.isSocket){
         // If this request was from a socket and an error occurs, broadcast an 'error' event and unsubscribe the socket from this room.

--- a/website/api/controllers/query-generator/get-llm-generated-sql.js
+++ b/website/api/controllers/query-generator/get-llm-generated-sql.js
@@ -173,7 +173,9 @@ module.exports = {
       "couldNotGenerateQueries": true
     }`;
 
-    let sqlReport = await sails.helpers.ai.prompt.with({prompt:sqlPrompt, baseModel:'claude-sonnet-4-6', expectJson: true, systemPromptForQueryGeneration})
+    // Effort is set to "low" because the schema was already narrowed down to relevant tables by the
+    // schema-filtration step above -- the model doesn't need to spend much effort re-deriving that context.
+    let sqlReport = await sails.helpers.ai.prompt.with({prompt:sqlPrompt, baseModel:'claude-sonnet-5', expectJson: true, systemPromptForQueryGeneration, effort: 'low'})
     .intercept((err)=>{
       if(this.req.isSocket){
         // If this request was from a socket and an error occurs, broadcast an 'error' event and unsubscribe the socket from this room.

--- a/website/api/helpers/ai/prompt.js
+++ b/website/api/helpers/ai/prompt.js
@@ -35,6 +35,11 @@ module.exports = {
     },
     expectJson: { type: 'boolean', defaultsTo: false },
     systemPrompt: { type: 'string', example: 'Here is data about each computer, as JSON: ```[ … ]```' },
+    effort: {
+      type: 'string',
+      description: 'Optional effort level for adaptive thinking (controls thinking depth vs. token/latency cost).  Only supported on Anthropic models with output_config.effort support (e.g. Claude Sonnet 5, Claude Opus 4.6+).  Ignored for models that don\'t support it (e.g. Claude Haiku 4.5, OpenAI models).',
+      example: 'low'
+    },
   },
 
 
@@ -54,7 +59,7 @@ module.exports = {
   },
 
 
-  fn: async function ({prompt, baseModel, expectJson, systemPrompt}) {
+  fn: async function ({prompt, baseModel, expectJson, systemPrompt, effort}) {
 
     // TODO: Write a comprehensive test suite that prompts hundreds of times in parallel to see which combo
     //       of JSON prompt suffix + base model works the best, through actual experimentation.  Then document
@@ -79,13 +84,18 @@ Please do not add any text outside of the JSON or wrap it in a code fence.  Neve
 
       let requestData = {
         model: baseModel,
-        max_tokens: 4096,// eslint-disable-line camelcase
+        // Bumped from 4096 so that models with adaptive thinking on by default (e.g. Claude Sonnet 5)
+        // have enough headroom for thinking tokens without truncating the actual response.
+        max_tokens: 8192,// eslint-disable-line camelcase
         messages: [
           { role: 'user', content: prompt+(expectJson? JSON_PROMPT_SUFFIX : '') }
         ]
       };
       if (systemPrompt) {
         requestData.system = systemPrompt;
+      }
+      if (effort) {
+        requestData.output_config = { effort };// eslint-disable-line camelcase
       }
 
       let anthropicResponse = await sails.helpers.http.post('https://api.anthropic.com/v1/messages', requestData, {

--- a/website/api/helpers/ai/prompt.js
+++ b/website/api/helpers/ai/prompt.js
@@ -95,7 +95,14 @@ Please do not add any text outside of the JSON or wrap it in a code fence.  Neve
         requestData.system = systemPrompt;
       }
       if (effort) {
-        requestData.output_config = { effort };// eslint-disable-line camelcase
+        // output_config.effort (adaptive thinking) is only supported on some Anthropic models.
+        // Claude Haiku 4.5, for example, does not accept it, so attaching it would cause a 4xx
+        // from Anthropic.  Ignore the input for models that don't support it.
+        if (baseModel.startsWith('claude-haiku')) {
+          sails.log.warn(`The prompt helper received an "effort" input, but the specified baseModel (${baseModel}) does not support output_config.effort. This input will be ignored in this LLM generation.`);
+        } else {
+          requestData.output_config = { effort };// eslint-disable-line camelcase
+        }
       }
 
       let anthropicResponse = await sails.helpers.http.post('https://api.anthropic.com/v1/messages', requestData, {
@@ -110,7 +117,14 @@ Please do not add any text outside of the JSON or wrap it in a code fence.  Neve
         return new Error('Failed to generate result.  Error communicating with LLM: '+err.stack);
       });
 
-      rawPromptResponse = anthropicResponse.content[0].text;
+      // With adaptive thinking enabled, the first content block can be a `thinking` (or
+      // `redacted_thinking`) block rather than the actual answer, so scan for the first `text`
+      // block instead of assuming it is at index 0.
+      let textBlock = _.find(anthropicResponse.content, { type: 'text' });
+      if (!textBlock) {
+        throw new Error('The LLM responded, but its response did not contain a text block.  Full response content: '+require('util').inspect(anthropicResponse.content, {depth: 3}));
+      }
+      rawPromptResponse = textBlock.text;
     } else {
       // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
       // OpenAI API  [?]: https://platform.openai.com/docs/api-reference/chat/create


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** N/A

## What this does

The `/query-generator` page's osquery-SQL-generation step ([get-llm-generated-sql.js](website/api/controllers/query-generator/get-llm-generated-sql.js)) was on `claude-sonnet-4-6`, which is now one generation behind. This PR:

- Bumps that call to `claude-sonnet-5`. The schema-filtration step stays on `claude-haiku-4-5`, which is already the latest Haiku release, so no change needed there.
- Adds `effort` support to the shared [`ai.prompt` helper](website/api/helpers/ai/prompt.js), forwarded as `output_config.effort` on Anthropic requests, and sets it to `"low"` for the SQL-generation call. Effort controls how much the model deliberates (and how many tokens/how much latency that costs). `"low"` was chosen because the Haiku pre-filtering step already narrows the osquery schema down to relevant tables, so the Sonnet step isn't starting from scratch and doesn't need to spend much effort re-deriving that context.
- Bumps `max_tokens` in the Anthropic branch of the helper from 4096 to 8192. Claude Sonnet 5 turns on adaptive thinking by default when the `thinking` param is omitted (which this helper does), and `max_tokens` is a hard cap on *total* output including thinking tokens — at 4096 there was a real risk of thinking tokens eating into the budget and truncating the JSON response the SQL step needs to return.
- **Fixes a pre-existing bug found while making the above changes:** the `sqlReport` call passed the system prompt as a bare object-shorthand key named `systemPromptForQueryGeneration`, but the `ai.prompt` helper's declared input is `systemPrompt`. Sails silently drops unrecognized keys passed to `.with(...)`, so the "Return ONLY a raw JSON object..." system prompt was never actually reaching the model for this call. This has been broken since the query generator was switched to Anthropic (`f7c20c4731`); the sibling `filteredTables` call above it was unaffected since it passes `systemPrompt` positionally. Now fixed to `systemPrompt: systemPromptForQueryGeneration`.

## Why

Claude Sonnet 5 follows structured/constrained instructions (don't alias tables, use `LIKE` with wildcards, only reference documented columns, etc.) more literally than 4.6, which should make the generated SQL more reliable. It's priced the same or cheaper than 4.6 during the current introductory period.

## Trade-offs called out for review

- Thinking being on by default adds some latency versus the old (thinking-off) behavior on 4.6. This call is not currently streamed (`sails.helpers.http.post`, single blocking call over a socket), so any added thinking time is invisible wait time for the user rather than a visible "thinking" indicator. `effort: "low"` should keep this modest, but worth confirming with a manual QA pass on a few representative questions before merging.
- Only the SQL-generation call was migrated. The schema-filtration call also runs on an Anthropic model, but Haiku 4.5 doesn't support `output_config.effort` (added `effort` is a no-op if passed to it), so it was left as-is.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved AI-generated SQL responses with an updated language model.
  * Added adaptive effort controls for supported AI requests.
  * Increased response capacity to support more detailed generated results.
  * Improved handling of AI responses to provide more reliable results when content includes different response formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->