### PR TITLE
Fuzzy-match Zoom Workplace program name in Windows FMA install and patch query

### DIFF
--- a/changes/zoom-windows-fma-fuzzy-match
+++ b/changes/zoom-windows-fma-fuzzy-match
@@ -1,1 +1,0 @@
-- Fixed the Windows Zoom Fleet-maintained app's `exists`/`patched` queries only matching hosts with the exact `Zoom Workplace (X64)` program name, causing installs registered under other names (e.g. Zoom's self-updating per-user client, or ARM64 builds) to be silently invisible to the patch policy. The exists query now fuzzy-matches on `Zoom Workplace%`.

--- a/changes/zoom-windows-fma-fuzzy-match
+++ b/changes/zoom-windows-fma-fuzzy-match
@@ -1,0 +1,1 @@
+- Fixed the Windows Zoom Fleet-maintained app's `exists`/`patched` queries only matching hosts with the exact `Zoom Workplace (X64)` program name, causing installs registered under other names (e.g. Zoom's self-updating per-user client, or ARM64 builds) to be silently invisible to the patch policy. The exists query now fuzzy-matches on `Zoom Workplace%`.

--- a/ee/maintained-apps/inputs/winget/zoom.json
+++ b/ee/maintained-apps/inputs/winget/zoom.json
@@ -3,6 +3,7 @@
   "slug": "zoom/windows",
   "package_identifier": "Zoom.Zoom",
   "unique_identifier": "Zoom Workplace (X64)",
+  "fuzzy_match_name": "Zoom Workplace%",
   "installer_arch": "x64",
   "installer_type": "msi",
   "installer_scope": "machine",

--- a/ee/maintained-apps/outputs/zoom/windows.json
+++ b/ee/maintained-apps/outputs/zoom/windows.json
@@ -3,8 +3,8 @@
     {
       "version": "7.1.41345",
       "queries": {
-        "exists": "SELECT 1 FROM programs WHERE name = 'Zoom Workplace (X64)' AND publisher = 'Zoom';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Zoom Workplace (X64)' AND publisher = 'Zoom' AND version_compare(version, '7.1.41345') < 0);"
+        "exists": "SELECT 1 FROM programs WHERE name LIKE 'Zoom Workplace%' AND publisher = 'Zoom';",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Zoom Workplace%' AND publisher = 'Zoom' AND version_compare(version, '7.1.41345') < 0);"
       },
       "installer_url": "https://zoom.us/client/7.1.0.41345/ZoomInstallerFull.msi?archType=x64",
       "install_script_ref": "8959087b",


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** N/A

## Summary

The Windows Zoom Fleet-maintained app's `exists`/`patched` queries used an exact match on `programs.name = 'Zoom Workplace (X64)'`. Real-world Zoom installs frequently register under a different name:

- Winget's own package name for `Zoom.Zoom` is `Zoom Workplace` (no arch suffix).
- Zoom ships a separate, per-user, self-updating installer (`Zoom.Zoom.EXE`, ProductCode `ZoomUMX`) that many end users get via Zoom's in-app auto-updater, which registers differently than the MSI-based entry Fleet's FMA targets (see [microsoft/winget-pkgs#151467](https://github.com/microsoft/winget-pkgs/issues/151467)).
- ARM64 builds exist and would register as e.g. `Zoom Workplace (ARM64)`.

Since the `patched` query is generated directly from the `exists` query, any host with Zoom installed under one of these other names was invisible to the patch policy — it would never show as needing (or having received) an update.

- `ee/maintained-apps/inputs/winget/zoom.json`: added `"fuzzy_match_name": "Zoom Workplace%"` (following the existing precedent used by ~97 other Windows FMAs, e.g. `cinc.json`'s custom fuzzy pattern).
- `ee/maintained-apps/outputs/zoom/windows.json`: regenerated via `go run cmd/maintained-apps/main.go --slug="zoom/windows" --debug`. Only the `exists`/`patched` query strings changed (now `name LIKE 'Zoom Workplace%'` instead of `name = 'Zoom Workplace (X64)'`); version, install/uninstall scripts, and refs are untouched.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`

## Testing

- [x] Verified the regenerated output only changes the exists/patched query strings (`git diff`)
- [ ] QA'd all new/changed functionality manually (needs a live Windows host with Zoom installed under a non-`(X64)` name to fully confirm)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Zoom Workplace detection across supported Windows installations.
  * Added support for matching Zoom Workplace name variations while preserving publisher and version checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->