### PR TITLE
Bum dependency-review action

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -27,4 +27,4 @@ jobs:
           persist-credentials: false
 
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@da24556b548a50705dd671f47852072ea4c105d9 # v4.7.1
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0


### PR DESCRIPTION
Fixes the following warning
<img width="902" height="121" alt="Screenshot 2026-07-13 at 5 29 40 AM" src="https://github.com/user-attachments/assets/6e0272ad-ff4e-4dd0-afdc-6a4f0259c60c" />
found in the following run: https://github.com/fleetdm/fleet/actions/runs/29234677374/job/86766507782

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency review checks to use the latest workflow action version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->