### PR TITLE
Add VEX exclusions for WiX

### DIFF
--- a/security/status.md
+++ b/security/status.md
@@ -707,6 +707,22 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2026-07-01 13:31:34
 
+### [CVE-2026-6276](https://nvd.nist.gov/vuln/detail/CVE-2026-6276)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not use libcurl when using fleetdm/wix to generate msi installers.
+- **Products:** `wix`,`pkg:deb/debian/libcurl4t64`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-07-13 12:01:46
+
+### [CVE-2026-5773](https://nvd.nist.gov/vuln/detail/CVE-2026-5773)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not use libcurl when using fleetdm/wix to generate msi installers.
+- **Products:** `wix`,`pkg:deb/debian/libcurl4t64`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-07-13 12:01:46
+
 ### [CVE-2026-55200](https://nvd.nist.gov/vuln/detail/CVE-2026-55200)
 - **Author:** @lucasmrod
 - **Status:** `not_affected`

--- a/security/vex/wix/CVE-2026-5773.vex.json
+++ b/security/vex/wix/CVE-2026-5773.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-a145ac8c54f53dbc6ce1b69e8e8532acaade786105dba8aae226615db5ff6e6d",
+  "author": "@lucasmrod",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-5773"
+      },
+      "products": [
+        {
+          "@id": "wix"
+        },
+        {
+          "@id": "pkg:deb/debian/libcurl4t64"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not use libcurl when using fleetdm/wix to generate msi installers",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "timestamp": "2026-07-13T12:01:46.019541Z"
+    }
+  ],
+  "timestamp": "2026-07-13T12:01:46Z"
+}

--- a/security/vex/wix/CVE-2026-6276.vex.json
+++ b/security/vex/wix/CVE-2026-6276.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-14d938e1a8b69d00986faf05467bd0a5834baef6f5807e0a2767215596759967",
+  "author": "@lucasmrod",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-6276"
+      },
+      "products": [
+        {
+          "@id": "wix"
+        },
+        {
+          "@id": "pkg:deb/debian/libcurl4t64"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not use libcurl when using fleetdm/wix to generate msi installers",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "timestamp": "2026-07-13T12:01:46.040769Z"
+    }
+  ],
+  "timestamp": "2026-07-13T12:01:46Z"
+}


### PR DESCRIPTION
Fixes: https://github.com/fleetdm/fleet/actions/runs/29230539238

New run: https://github.com/fleetdm/fleet/actions/runs/29248404917 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added vulnerability assessment records for CVE-2026-5773 and CVE-2026-6276.
  * Documented that the affected libcurl component is not used in the relevant installer-generation execution path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->