### PR TITLE
Skip live-query reverse-index read when no reverse queries are active

### DIFF
--- a/server/live_query/redis_live_query.go
+++ b/server/live_query/redis_live_query.go
@@ -145,6 +145,16 @@ func (r *redisLiveQuery) isReverse(campaignID string) bool {
 	return found
 }
 
+// hasReverseActiveQueries is a thread-safe method that reports whether any
+// active query uses the reverse per-host index. It gates the per-host reverse
+// read on the checkin path so that, when no reverse query is active, a checkin
+// does not issue a SMEMBERS for a key that does not exist.
+func (r *redisLiveQuery) hasReverseActiveQueries() bool {
+	r.cache.mu.RLock()
+	defer r.cache.mu.RUnlock()
+	return len(r.cache.reverseActiveCache) > 0
+}
+
 // NewRedisLiveQuery creates a new Redis implementation of the live query store
 // using the provided Redis connection pool.
 //
@@ -295,8 +305,11 @@ func (r *redisLiveQuery) QueriesForHost(hostID uint) (map[string]string, error) 
 	}
 
 	// Reverse (small-target) queries: a single read of this host's own set.
-	if err := r.collectReverseQueriesForHost(hostID, queries); err != nil {
-		return nil, err
+	// Skip it entirely when no active query uses the reverse model.
+	if r.hasReverseActiveQueries() {
+		if err := r.collectReverseQueriesForHost(hostID, queries); err != nil {
+			return nil, err
+		}
 	}
 
 	return queries, nil

--- a/server/live_query/redis_live_query_test.go
+++ b/server/live_query/redis_live_query_test.go
@@ -3,6 +3,7 @@ package live_query
 import (
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/fleetdm/fleet/v4/server/datastore/redis"
 	"github.com/fleetdm/fleet/v4/server/datastore/redis/redistest"
@@ -267,8 +268,38 @@ func TestReverseIndexCleanupInactiveQueries(t *testing.T) {
 	}
 }
 
-// TestReverseIndexKillSwitch verifies that a threshold of 0 disables the reverse
-// index and forces the legacy bitfield model even for single-host queries.
+func TestReverseIndexReadSkippedWhenNoReverseQueries(t *testing.T) {
+	// commandstats is reset and read per node via CONFIG RESETSTAT / INFO, so this
+	// runs against standalone Redis only.
+	pool := redistest.SetupRedis(t, "*livequery", false, true, true)
+	// A non-zero cache TTL so the warm-up call below keeps the cache valid for the
+	// measured call, which would otherwise reload it and issue its own SMEMBERS on
+	// the active sets, confounding the assertion.
+	store := NewRedisLiveQuery(pool, slog.New(slog.DiscardHandler), time.Minute, 2)
+
+	// A broadcast (above-threshold) query: there is active work to serve, but no
+	// query uses the reverse per-host index.
+	require.NoError(t, store.RunQuery("b", "SELECT 1", []uint{1, 2, 3}))
+
+	// Warm the in-memory cache so the measured call below does not reload it.
+	_, err := store.QueriesForHost(1)
+	require.NoError(t, err)
+
+	conn := redis.ConfigureDoer(pool, pool.Get())
+	defer conn.Close()
+	_, err = conn.Do("CONFIG", "RESETSTAT")
+	require.NoError(t, err)
+
+	queries, err := store.QueriesForHost(1)
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{"b": "SELECT 1"}, queries)
+
+	info, err := redigo.String(conn.Do("INFO", "commandstats"))
+	require.NoError(t, err)
+	assert.NotContains(t, info, "cmdstat_smembers",
+		"no SMEMBERS should be issued on checkin when no reverse queries are active")
+}
+
 func TestReverseIndexKillSwitch(t *testing.T) {
 	for _, cluster := range []bool{false, true} {
 		clusterName := "standalone"


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
Relates to #42441

Small-target live queries are stored in a per-host reverse index (livequery:host:{hostID}) that QueriesForHost reads once per checkin via SMEMBERS. That read was issued unconditionally on every host checkin — even when no active query used the reverse model — so every checkin probed a per-host key that did not exist and acquired an extra Redis connection.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

## Testing

- [X] Added/updated automated tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved live query host-check processing by avoiding unnecessary reverse-index lookups when no reverse-model queries are active.
  * Reduced Redis reads during host checks without changing query results or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->