### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/duckduckgo/darwin.json
+++ b/ee/maintained-apps/outputs/duckduckgo/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.197.0",
+      "version": "1.198.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.duckduckgo.macos.browser';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.duckduckgo.macos.browser' AND version_compare(bundle_short_version, '1.197.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.duckduckgo.macos.browser' AND version_compare(bundle_short_version, '1.198.0') < 0);"
       },
-      "installer_url": "https://staticcdn.duckduckgo.com/macos-desktop-browser/duckduckgo-1.197.0.754.dmg",
+      "installer_url": "https://staticcdn.duckduckgo.com/macos-desktop-browser/duckduckgo-1.198.0.759.dmg",
       "install_script_ref": "c6bf9cce",
       "uninstall_script_ref": "b6f097db",
-      "sha256": "50c440046e052fa875fc436d4f18c27a68227527d3bcda63337a30f181bcdc74",
+      "sha256": "e37b38f720468b884951c9c6d063f5734b133aabe29c7820b5bc18dd99fb202b",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/electrum/darwin.json
+++ b/ee/maintained-apps/outputs/electrum/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.7.2",
+      "version": "4.8.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.org.pythonmac.unspecified.Electrum';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.org.pythonmac.unspecified.Electrum' AND version_compare(bundle_short_version, '4.7.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.org.pythonmac.unspecified.Electrum' AND version_compare(bundle_short_version, '4.8.0') < 0);"
       },
-      "installer_url": "https://download.electrum.org/4.7.2/electrum-4.7.2.dmg",
+      "installer_url": "https://download.electrum.org/4.8.0/electrum-4.8.0.dmg",
       "install_script_ref": "e38e6800",
       "uninstall_script_ref": "da5c25af",
-      "sha256": "3370b3fea652c4bc707e5ec913ae42a03602083ff05482c3eae0d2a00bf3b842",
+      "sha256": "f99c566b44852dc80437ad845d9f4669a8c76a6338714fd6ffdc91939cfc5d84",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/notepadexe/darwin.json
+++ b/ee/maintained-apps/outputs/notepadexe/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.5.0",
+      "version": "1.5.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'best.swift.Notepad';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'best.swift.Notepad' AND version_compare(bundle_short_version, '1.5.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'best.swift.Notepad' AND version_compare(bundle_short_version, '1.5.1') < 0);"
       },
-      "installer_url": "https://github.com/notepadhq/notepadexe-public/releases/download/1.5.0/Notepad.zip",
+      "installer_url": "https://github.com/notepadhq/notepadexe-public/releases/download/1.5.1/Notepad.zip",
       "install_script_ref": "17716d6a",
       "uninstall_script_ref": "abe56690",
-      "sha256": "36aa2b22d7a08338e480dfe4f84b2032ce5243458ae68046a060f1bcc0d1b837",
+      "sha256": "d54b31e839142ee8ed6bb68e19dd3e3f0443be5916db88c09d62caa57db46b38",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/remote-desktop-manager/darwin.json
+++ b/ee/maintained-apps/outputs/remote-desktop-manager/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.2.2.1",
+      "version": "2026.2.3.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.devolutions.remotedesktopmanager';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.devolutions.remotedesktopmanager' AND version_compare(bundle_short_version, '2026.2.2.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.devolutions.remotedesktopmanager' AND version_compare(bundle_short_version, '2026.2.3.1') < 0);"
       },
-      "installer_url": "https://cdn.devolutions.net/download/Mac/Devolutions.RemoteDesktopManager.Mac.2026.2.2.1.dmg",
+      "installer_url": "https://cdn.devolutions.net/download/Mac/Devolutions.RemoteDesktopManager.Mac.2026.2.3.1.dmg",
       "install_script_ref": "4607770f",
       "uninstall_script_ref": "4fd2b3fa",
-      "sha256": "9e49b286af97487f594e269aacd714d0576fa1244b3a2e0abea996e98553d8fc",
+      "sha256": "5f7691eca5d433f63805c752fa6a1c3c14001685591b525b423a6089e3ff2f70",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated macOS app metadata for DuckDuckGo, Electrum, NotepadExe, and Remote Desktop Manager.
  - Added support for the latest releases: DuckDuckGo 1.198.0, Electrum 4.8.0, NotepadExe 1.5.1, and Remote Desktop Manager 2026.2.3.1.
  - Refreshed installer download links, version detection, and package checksums to match the updated releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->