### PR TITLE
Android managed config insert job with empty err vs null err

### DIFF
--- a/server/datastore/mysql/scim.go
+++ b/server/datastore/mysql/scim.go
@@ -1507,8 +1507,8 @@ func queueManagedConfigResendJobs(ctx context.Context, tx sqlx.ExtContext, hostI
 
 	// Insert a job for each affected app config.
 	const insertJob = `
-	INSERT INTO jobs (name, args, state)
-	VALUES (?, ?, 'queued')
+	INSERT INTO jobs (name, args, state, error)
+	VALUES (?, ?, 'queued', '')
 `
 	for _, app := range apps {
 		args, err := json.Marshal(map[string]any{


### PR DESCRIPTION
**Related issue:** Resolves #49210

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when queuing managed configuration resend jobs by ensuring newly created jobs start with a consistent empty error state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->