### PR TITLE
Website: move analytics script tag

### DIFF
--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -114,8 +114,6 @@
     <noscript>
       <img height="1" width="1" style="display:none;" alt="" src="https://px.ads.linkedin.com/collect/?pid=4365817&fmt=gif" />
     </noscript>
-    <% /* Clay */ %>
-      <script src="https://static.claydar.com/init.v1.js?id=cwiBCPLMlD"></script>
     <% /* Qualified */ %>
     <% if(!disableChatbotAndIndexing) {%>
       <script>
@@ -1156,7 +1154,9 @@
       vgo('setAccount', '652899825');
       vgo('setTrackByDefault', true);
       vgo('process');
-    </script>      
+    </script>
+    <% /* Clay */ %>
+    <script src="https://static.claydar.com/init.v1.js?id=cwiBCPLMlD"></script>
    <% } %>
     <% /* Remove query params from the page URLs after the page is fully loaded. */ %>
     <script>

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -94,7 +94,7 @@
     // End Rollbar Snippet
     </script>
    
-    <% /* Google Analytics, Google Tag Manager, Clay etc. */ %>
+    <% /* Google Analytics, Google Tag Manager, Qualified etc. */ %>
 
     <%/* LinkedIn insight tag*/%>
     <script type="text/javascript">


### PR DESCRIPTION
Changes:
- Moved the clay analytics script tag in the website's `<head>` to the end of the `<body>` tag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production analytics configuration.
  * Adjusted the placement of an analytics initialization script to support more consistent tracking behavior.
  * Refined internal analytics labeling without changing the visible website experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->