### PR TITLE
Fleet UI: Handle long fleet names across the Fleets UI

### DIFF
--- a/changes/47290-long-fleet-name-ui
+++ b/changes/47290-long-fleet-name-ui
@@ -1,0 +1,3 @@
+- Fixed long fleet names overflowing the fleets table, fleet detail page header, teams dropdown, and manage enroll secrets modal. Fleet name inputs now cap at 255 characters (matching the database column), and the API and GitOps now return a clear validation error instead of a raw "Data too long" MySQL error when a longer name is submitted.
+- Added 255-character caps to additional user-supplied name and description inputs (API user, custom variable, certificate, label, pack, certificate authority forms) to prevent the same class of overflow bug.
+- Fixed long label names overflowing the Labels card on the host details page.

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"unicode/utf8"
 
 	"golang.org/x/text/unicode/norm"
 
@@ -96,7 +97,7 @@ func (svc *Service) NewTeam(ctx context.Context, p fleet.TeamPayload) (*fleet.Te
 	if *p.Name == "" {
 		return nil, fleet.NewInvalidArgumentError("name", "may not be empty")
 	}
-	if len(*p.Name) > fleet.MaxTeamNameLength {
+	if utf8.RuneCountInString(*p.Name) > fleet.MaxTeamNameLength {
 		return nil, fleet.NewInvalidArgumentError("name", fmt.Sprintf("may not exceed %d characters", fleet.MaxTeamNameLength))
 	}
 	if fleet.IsReservedTeamName(*p.Name) {
@@ -187,7 +188,7 @@ func (svc *Service) ModifyTeam(ctx context.Context, teamID uint, payload fleet.T
 		if *payload.Name == "" {
 			return nil, fleet.NewInvalidArgumentError("name", "may not be empty")
 		}
-		if len(*payload.Name) > fleet.MaxTeamNameLength {
+		if utf8.RuneCountInString(*payload.Name) > fleet.MaxTeamNameLength {
 			return nil, fleet.NewInvalidArgumentError("name", fmt.Sprintf("may not exceed %d characters", fleet.MaxTeamNameLength))
 		}
 		if fleet.IsReservedTeamName(*payload.Name) {
@@ -1332,7 +1333,7 @@ func (svc *Service) ApplyTeamSpecs(ctx context.Context, specs []*fleet.TeamSpec,
 		if spec.Name == "" {
 			return nil, fleet.NewInvalidArgumentError("name", "name may not be empty")
 		}
-		if len(spec.Name) > fleet.MaxTeamNameLength {
+		if utf8.RuneCountInString(spec.Name) > fleet.MaxTeamNameLength {
 			return nil, fleet.NewInvalidArgumentError("name", fmt.Sprintf("may not exceed %d characters", fleet.MaxTeamNameLength))
 		}
 		if fleet.IsReservedTeamName(spec.Name) {

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -96,6 +96,9 @@ func (svc *Service) NewTeam(ctx context.Context, p fleet.TeamPayload) (*fleet.Te
 	if *p.Name == "" {
 		return nil, fleet.NewInvalidArgumentError("name", "may not be empty")
 	}
+	if len(*p.Name) > fleet.MaxTeamNameLength {
+		return nil, fleet.NewInvalidArgumentError("name", fmt.Sprintf("may not exceed %d characters", fleet.MaxTeamNameLength))
+	}
 	if fleet.IsReservedTeamName(*p.Name) {
 		return nil, fleet.NewInvalidArgumentError("name", fmt.Sprintf("%q is a reserved fleet name", *p.Name))
 	}
@@ -183,6 +186,9 @@ func (svc *Service) ModifyTeam(ctx context.Context, teamID uint, payload fleet.T
 		*payload.Name = strings.TrimSpace(*payload.Name)
 		if *payload.Name == "" {
 			return nil, fleet.NewInvalidArgumentError("name", "may not be empty")
+		}
+		if len(*payload.Name) > fleet.MaxTeamNameLength {
+			return nil, fleet.NewInvalidArgumentError("name", fmt.Sprintf("may not exceed %d characters", fleet.MaxTeamNameLength))
 		}
 		if fleet.IsReservedTeamName(*payload.Name) {
 			return nil, fleet.NewInvalidArgumentError("name", fmt.Sprintf("%q is a reserved fleet name", *payload.Name))
@@ -1325,6 +1331,9 @@ func (svc *Service) ApplyTeamSpecs(ctx context.Context, specs []*fleet.TeamSpec,
 		spec.Name = strings.TrimSpace(spec.Name)
 		if spec.Name == "" {
 			return nil, fleet.NewInvalidArgumentError("name", "name may not be empty")
+		}
+		if len(spec.Name) > fleet.MaxTeamNameLength {
+			return nil, fleet.NewInvalidArgumentError("name", fmt.Sprintf("may not exceed %d characters", fleet.MaxTeamNameLength))
 		}
 		if fleet.IsReservedTeamName(spec.Name) {
 			return nil, fleet.NewInvalidArgumentError("name", fmt.Sprintf("%q is a reserved fleet name", spec.Name))

--- a/ee/server/service/teams_test.go
+++ b/ee/server/service/teams_test.go
@@ -145,6 +145,13 @@ func TestNewTeamNameValidation(t *testing.T) {
 			teamName: new(strings.Repeat("a", fleet.MaxTeamNameLength+1)),
 			wantErr:  fmt.Sprintf("may not exceed %d characters", fleet.MaxTeamNameLength),
 		},
+		{
+			// Guards against regressing to byte-based length checks, which
+			// would reject multibyte names that fit within the character cap.
+			name:     "multibyte name at max character length is accepted",
+			teamName: new(strings.Repeat("日", fleet.MaxTeamNameLength)),
+			wantName: strings.Repeat("日", fleet.MaxTeamNameLength),
+		},
 	}
 
 	for _, tc := range testCases {
@@ -278,6 +285,11 @@ func TestModifyTeamNameValidation(t *testing.T) {
 			teamName: new(strings.Repeat("a", fleet.MaxTeamNameLength+1)),
 			wantErr:  fmt.Sprintf("may not exceed %d characters", fleet.MaxTeamNameLength),
 		},
+		{
+			name:     "multibyte name at max character length is accepted",
+			teamName: new(strings.Repeat("日", fleet.MaxTeamNameLength)),
+			wantName: strings.Repeat("日", fleet.MaxTeamNameLength),
+		},
 	}
 
 	for _, tc := range testCases {
@@ -397,6 +409,11 @@ func TestApplyTeamSpecsNameValidation(t *testing.T) {
 			name:     "name over max length is rejected",
 			teamName: strings.Repeat("a", fleet.MaxTeamNameLength+1),
 			wantErr:  fmt.Sprintf("may not exceed %d characters", fleet.MaxTeamNameLength),
+		},
+		{
+			name:     "multibyte name at max character length is accepted",
+			teamName: strings.Repeat("日", fleet.MaxTeamNameLength),
+			wantName: strings.Repeat("日", fleet.MaxTeamNameLength),
 		},
 	}
 

--- a/ee/server/service/teams_test.go
+++ b/ee/server/service/teams_test.go
@@ -137,12 +137,12 @@ func TestNewTeamNameValidation(t *testing.T) {
 		},
 		{
 			name:     "name at max length is accepted",
-			teamName: ptr.String(strings.Repeat("a", fleet.MaxTeamNameLength)),
+			teamName: new(strings.Repeat("a", fleet.MaxTeamNameLength)),
 			wantName: strings.Repeat("a", fleet.MaxTeamNameLength),
 		},
 		{
 			name:     "name over max length is rejected",
-			teamName: ptr.String(strings.Repeat("a", fleet.MaxTeamNameLength+1)),
+			teamName: new(strings.Repeat("a", fleet.MaxTeamNameLength+1)),
 			wantErr:  fmt.Sprintf("may not exceed %d characters", fleet.MaxTeamNameLength),
 		},
 	}
@@ -270,12 +270,12 @@ func TestModifyTeamNameValidation(t *testing.T) {
 		},
 		{
 			name:     "name at max length is accepted",
-			teamName: ptr.String(strings.Repeat("a", fleet.MaxTeamNameLength)),
+			teamName: new(strings.Repeat("a", fleet.MaxTeamNameLength)),
 			wantName: strings.Repeat("a", fleet.MaxTeamNameLength),
 		},
 		{
 			name:     "name over max length is rejected",
-			teamName: ptr.String(strings.Repeat("a", fleet.MaxTeamNameLength+1)),
+			teamName: new(strings.Repeat("a", fleet.MaxTeamNameLength+1)),
 			wantErr:  fmt.Sprintf("may not exceed %d characters", fleet.MaxTeamNameLength),
 		},
 	}

--- a/ee/server/service/teams_test.go
+++ b/ee/server/service/teams_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"strings"
 	"testing"
@@ -134,6 +135,16 @@ func TestNewTeamNameValidation(t *testing.T) {
 			teamName: ptr.String("Engineering"),
 			wantName: "Engineering",
 		},
+		{
+			name:     "name at max length is accepted",
+			teamName: ptr.String(strings.Repeat("a", fleet.MaxTeamNameLength)),
+			wantName: strings.Repeat("a", fleet.MaxTeamNameLength),
+		},
+		{
+			name:     "name over max length is rejected",
+			teamName: ptr.String(strings.Repeat("a", fleet.MaxTeamNameLength+1)),
+			wantErr:  fmt.Sprintf("may not exceed %d characters", fleet.MaxTeamNameLength),
+		},
 	}
 
 	for _, tc := range testCases {
@@ -257,6 +268,16 @@ func TestModifyTeamNameValidation(t *testing.T) {
 			teamName: ptr.String("my team"),
 			wantName: "my team",
 		},
+		{
+			name:     "name at max length is accepted",
+			teamName: ptr.String(strings.Repeat("a", fleet.MaxTeamNameLength)),
+			wantName: strings.Repeat("a", fleet.MaxTeamNameLength),
+		},
+		{
+			name:     "name over max length is rejected",
+			teamName: ptr.String(strings.Repeat("a", fleet.MaxTeamNameLength+1)),
+			wantErr:  fmt.Sprintf("may not exceed %d characters", fleet.MaxTeamNameLength),
+		},
 	}
 
 	for _, tc := range testCases {
@@ -366,6 +387,16 @@ func TestApplyTeamSpecsNameValidation(t *testing.T) {
 			name:     "leading and trailing spaces are trimmed",
 			teamName: "  Engineering  ",
 			wantName: "Engineering",
+		},
+		{
+			name:     "name at max length is accepted",
+			teamName: strings.Repeat("a", fleet.MaxTeamNameLength),
+			wantName: strings.Repeat("a", fleet.MaxTeamNameLength),
+		},
+		{
+			name:     "name over max length is rejected",
+			teamName: strings.Repeat("a", fleet.MaxTeamNameLength+1),
+			wantErr:  fmt.Sprintf("may not exceed %d characters", fleet.MaxTeamNameLength),
 		},
 	}
 

--- a/frontend/components/EnrollSecrets/EnrollSecretModal/_styles.scss
+++ b/frontend/components/EnrollSecrets/EnrollSecretModal/_styles.scss
@@ -8,6 +8,11 @@
     color: $ui-error;
   }
 
+  &__description {
+    min-width: 0;
+    overflow-wrap: anywhere;
+  }
+
   .empty-table__container {
     margin: $pad-large auto $pad-medium;
     gap: $pad-medium;

--- a/frontend/components/forms/packs/EditPackForm/EditPackForm.tsx
+++ b/frontend/components/forms/packs/EditPackForm/EditPackForm.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import useDeepEffect from "hooks/useDeepEffect";
 
+import { MAX_ENTITY_NAME_LENGTH } from "utilities/constants";
 import Button from "components/buttons/Button";
 
 import { IQuery } from "interfaces/query";
@@ -111,6 +112,7 @@ const EditPackForm = ({
         name="name"
         error={errors.name}
         inputWrapperClass={`${baseClass}__pack-title`}
+        inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
       />
       <InputField
         onChange={onChangePackDescription}
@@ -120,6 +122,7 @@ const EditPackForm = ({
         name="description"
         placeholder="Add a description of your pack"
         type="textarea"
+        inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
       />
       <SelectTargetsDropdown
         label="Select pack targets"

--- a/frontend/components/forms/packs/EditPackForm/EditPackForm.tsx
+++ b/frontend/components/forms/packs/EditPackForm/EditPackForm.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import useDeepEffect from "hooks/useDeepEffect";
 
-import { MAX_ENTITY_NAME_LENGTH } from "utilities/constants";
+import { MAX_ENTITY_CHAR_LENGTH } from "utilities/constants";
 import Button from "components/buttons/Button";
 
 import { IQuery } from "interfaces/query";
@@ -112,7 +112,7 @@ const EditPackForm = ({
         name="name"
         error={errors.name}
         inputWrapperClass={`${baseClass}__pack-title`}
-        inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
+        inputOptions={{ maxLength: MAX_ENTITY_CHAR_LENGTH }}
       />
       <InputField
         onChange={onChangePackDescription}
@@ -122,7 +122,7 @@ const EditPackForm = ({
         name="description"
         placeholder="Add a description of your pack"
         type="textarea"
-        inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
+        inputOptions={{ maxLength: MAX_ENTITY_CHAR_LENGTH }}
       />
       <SelectTargetsDropdown
         label="Select pack targets"

--- a/frontend/components/forms/packs/NewPackForm/NewPackForm.tsx
+++ b/frontend/components/forms/packs/NewPackForm/NewPackForm.tsx
@@ -6,7 +6,7 @@ import { IQuery } from "interfaces/query";
 import { ITarget, ITargetsAPIResponse } from "interfaces/target";
 import { IEditPackFormData } from "interfaces/pack";
 import PATHS from "router/paths";
-import { MAX_ENTITY_NAME_LENGTH } from "utilities/constants";
+import { MAX_ENTITY_CHAR_LENGTH } from "utilities/constants";
 
 import InputField from "components/forms/fields/InputField";
 import BackButton from "components/BackButton";
@@ -94,7 +94,7 @@ const NewPackForm = ({
           error={errors.name}
           inputWrapperClass={`${baseClass}__pack-title`}
           autofocus
-          inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
+          inputOptions={{ maxLength: MAX_ENTITY_CHAR_LENGTH }}
         />
         <InputField
           onChange={onChangePackDescription}
@@ -104,7 +104,7 @@ const NewPackForm = ({
           name="description"
           placeholder="Add a description of your pack"
           type="textarea"
-          inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
+          inputOptions={{ maxLength: MAX_ENTITY_CHAR_LENGTH }}
         />
         <SelectTargetsDropdown
           label="Select pack targets"

--- a/frontend/components/forms/packs/NewPackForm/NewPackForm.tsx
+++ b/frontend/components/forms/packs/NewPackForm/NewPackForm.tsx
@@ -6,6 +6,7 @@ import { IQuery } from "interfaces/query";
 import { ITarget, ITargetsAPIResponse } from "interfaces/target";
 import { IEditPackFormData } from "interfaces/pack";
 import PATHS from "router/paths";
+import { MAX_ENTITY_NAME_LENGTH } from "utilities/constants";
 
 import InputField from "components/forms/fields/InputField";
 import BackButton from "components/BackButton";
@@ -93,6 +94,7 @@ const NewPackForm = ({
           error={errors.name}
           inputWrapperClass={`${baseClass}__pack-title`}
           autofocus
+          inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
         />
         <InputField
           onChange={onChangePackDescription}
@@ -102,6 +104,7 @@ const NewPackForm = ({
           name="description"
           placeholder="Add a description of your pack"
           type="textarea"
+          inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
         />
         <SelectTargetsDropdown
           label="Select pack targets"

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/AddCertificateModal/AddCertificateModal.tests.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/AddCertificateModal/AddCertificateModal.tests.tsx
@@ -10,7 +10,6 @@ import {
   CA_REQUIRED_MSG,
   INVALID_NAME_MSG,
   NAME_REQUIRED_MSG,
-  NAME_TOO_LONG_MSG,
   SUBJECT_NAME_REQUIRED_MSG,
 } from "./helpers";
 
@@ -174,16 +173,13 @@ describe("AddCertModal", () => {
     });
   });
 
-  it("shows inline error for Name longer than 255 characters as user types", async () => {
-    const { user } = await renderModal();
+  it("caps the Name input at 255 characters (matches DB varchar(255))", async () => {
+    await renderModal();
 
-    // Paste rather than type to keep the test fast (256 simulated keypresses is slow).
-    await user.click(screen.getByPlaceholderText(NAME_PLACEHOLDER));
-    await user.paste("a".repeat(256));
-
-    await waitFor(() => {
-      expect(screen.getByText(NAME_TOO_LONG_MSG)).toBeInTheDocument();
-    });
+    const nameInput = screen.getByPlaceholderText(
+      NAME_PLACEHOLDER
+    ) as HTMLInputElement;
+    expect(nameInput.maxLength).toBe(255);
   });
 
   it("submits successfully without SAN (field omitted from request body)", async () => {

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/AddCertificateModal/AddCertificateModal.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/AddCertificateModal/AddCertificateModal.tsx
@@ -4,7 +4,7 @@ import { SingleValue } from "react-select-5";
 
 import {
   DEFAULT_USE_QUERY_OPTIONS,
-  MAX_ENTITY_NAME_LENGTH,
+  MAX_ENTITY_CHAR_LENGTH,
 } from "utilities/constants";
 
 import paths from "router/paths";
@@ -206,7 +206,7 @@ const AddCertModal = ({
           helpText="Letters, numbers, spaces, dashes, and underscores only. Name can be used as certificate alias to reference in configuration profiles."
           parseTarget
           placeholder="VPN certificate"
-          inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
+          inputOptions={{ maxLength: MAX_ENTITY_CHAR_LENGTH }}
         />
         <InputField
           name="subjectName"

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/AddCertificateModal/AddCertificateModal.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/AddCertificateModal/AddCertificateModal.tsx
@@ -2,7 +2,10 @@ import React, { useMemo, useState } from "react";
 import { useQuery } from "react-query";
 import { SingleValue } from "react-select-5";
 
-import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
+import {
+  DEFAULT_USE_QUERY_OPTIONS,
+  MAX_ENTITY_NAME_LENGTH,
+} from "utilities/constants";
 
 import paths from "router/paths";
 
@@ -203,6 +206,7 @@ const AddCertModal = ({
           helpText="Letters, numbers, spaces, dashes, and underscores only. Name can be used as certificate alias to reference in configuration profiles."
           parseTarget
           placeholder="VPN certificate"
+          inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
         />
         <InputField
           name="subjectName"

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/AddCertificateModal/helpers.ts
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/AddCertificateModal/helpers.ts
@@ -10,7 +10,6 @@ export interface IAddCertFormValidation {
 
 export const INVALID_NAME_MSG =
   "Invalid characters. Only letters, numbers, spaces, dashes, and underscores allowed.";
-export const NAME_TOO_LONG_MSG = "Name is too long. Maximum is 255 characters.";
 export const NAME_REQUIRED_MSG = "Name must be completed.";
 export const CA_REQUIRED_MSG = "Certificate authority must be completed.";
 export const SUBJECT_NAME_REQUIRED_MSG = "Subject name must be completed.";
@@ -51,13 +50,6 @@ export const generateFormValidations = (): IFormValidations => {
             return /^[a-zA-Z0-9 \-_]+$/.test(formData.name);
           },
           message: INVALID_NAME_MSG,
-        },
-        {
-          name: "maxLength",
-          isValid: (formData: IAddCertFormData) => {
-            return formData.name.length <= 255;
-          },
-          message: NAME_TOO_LONG_MSG,
         },
       ],
     },

--- a/frontend/pages/ManageControlsPage/Variables/cards/GlobalVariables/GlobalVariables.tests.tsx
+++ b/frontend/pages/ManageControlsPage/Variables/cards/GlobalVariables/GlobalVariables.tests.tsx
@@ -315,17 +315,9 @@ describe("Custom variables", () => {
           expect(saveButton).toBeDisabled();
         });
       });
-      it("does not allow saving very long name", async () => {
-        const { nameInput, valueInput, saveButton } = await getAddVariableUI();
-        await user.type(nameInput, new Array(256).fill("A").join("")); // Invalid name
-        await user.type(valueInput, "a value");
-        await user.click(saveButton);
-        await waitFor(() => {
-          expect(
-            screen.getByText("Name may not exceed 255 characters")
-          ).toBeInTheDocument();
-          expect(saveButton).toBeDisabled();
-        });
+      it("caps the name input at 255 characters (matches DB varchar(255))", async () => {
+        const { nameInput } = await getAddVariableUI();
+        expect((nameInput as HTMLInputElement).maxLength).toBe(255);
       });
     });
 

--- a/frontend/pages/ManageControlsPage/Variables/components/AddCustomVariableModal/AddCustomVariableModal.tsx
+++ b/frontend/pages/ManageControlsPage/Variables/components/AddCustomVariableModal/AddCustomVariableModal.tsx
@@ -6,7 +6,7 @@ import { hasStatusKey, getErrorReason } from "interfaces/errors";
 import variablesAPI from "services/entities/variables";
 import {
   LEARN_MORE_ABOUT_BASE_LINK,
-  MAX_ENTITY_NAME_LENGTH,
+  MAX_ENTITY_CHAR_LENGTH,
 } from "utilities/constants";
 import { notify } from "components/ToastNotification";
 import CustomLink from "components/CustomLink";
@@ -120,7 +120,7 @@ const AddCustomVariableModal = ({
             </span>
           }
           error={formValidation.name?.message}
-          inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
+          inputOptions={{ maxLength: MAX_ENTITY_CHAR_LENGTH }}
         />
         <InputField
           onChange={onInputChange}

--- a/frontend/pages/ManageControlsPage/Variables/components/AddCustomVariableModal/AddCustomVariableModal.tsx
+++ b/frontend/pages/ManageControlsPage/Variables/components/AddCustomVariableModal/AddCustomVariableModal.tsx
@@ -4,7 +4,10 @@ import Button from "components/buttons/Button";
 import { IVariableFormData } from "interfaces/variables";
 import { hasStatusKey, getErrorReason } from "interfaces/errors";
 import variablesAPI from "services/entities/variables";
-import { LEARN_MORE_ABOUT_BASE_LINK } from "utilities/constants";
+import {
+  LEARN_MORE_ABOUT_BASE_LINK,
+  MAX_ENTITY_NAME_LENGTH,
+} from "utilities/constants";
 import { notify } from "components/ToastNotification";
 import CustomLink from "components/CustomLink";
 import InputField from "components/forms/fields/InputField";
@@ -117,6 +120,7 @@ const AddCustomVariableModal = ({
             </span>
           }
           error={formValidation.name?.message}
+          inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
         />
         <InputField
           onChange={onInputChange}

--- a/frontend/pages/ManageControlsPage/Variables/components/AddCustomVariableModal/helpers.ts
+++ b/frontend/pages/ManageControlsPage/Variables/components/AddCustomVariableModal/helpers.ts
@@ -48,13 +48,6 @@ const FORM_VALIDATIONS: IFormValidations = {
           "Name may only include uppercase letters, numbers, and underscores",
       },
       {
-        name: "notTooLong",
-        isValid: (formData: IAddCustomVariableFormData) => {
-          return formData.name.length <= 255;
-        },
-        message: "Name may not exceed 255 characters",
-      },
-      {
         name: "doesNotIncludePrefix",
         isValid: (formData: IAddCustomVariableFormData) => {
           return !formData.name.match(/^FLEET_SECRET_/);

--- a/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/AddCategoryModal/AddCategoryModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/AddCategoryModal/AddCategoryModal.tsx
@@ -2,13 +2,13 @@ import React, { useState } from "react";
 
 import selfServiceCategoriesAPI from "services/entities/self_service_categories";
 import { hasStatusKey } from "interfaces/errors";
+import { MAX_ENTITY_NAME_LENGTH } from "utilities/constants";
 
 import Button from "components/buttons/Button";
 import InputField from "components/forms/fields/InputField";
 import Modal from "components/Modal";
 
 const baseClass = "add-category-modal";
-const NAME_MAX_LENGTH = 255;
 
 interface IAddCategoryModalProps {
   fleetId: number;
@@ -27,7 +27,7 @@ const AddCategoryModal = ({
 
   const trimmedName = name.trim();
   const isInvalid =
-    trimmedName.length === 0 || trimmedName.length > NAME_MAX_LENGTH;
+    trimmedName.length === 0 || trimmedName.length > MAX_ENTITY_NAME_LENGTH;
   const isDisabled = isInvalid || isSubmitting;
 
   const onNameChange = (value: string) => {
@@ -74,7 +74,7 @@ const AddCategoryModal = ({
           error={error}
           autofocus
           ignore1password
-          inputOptions={{ maxLength: NAME_MAX_LENGTH }}
+          inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
         />
         <div className="modal-cta-wrap">
           <Button type="submit" disabled={isDisabled} isLoading={isSubmitting}>

--- a/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/AddCategoryModal/AddCategoryModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/AddCategoryModal/AddCategoryModal.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 
 import selfServiceCategoriesAPI from "services/entities/self_service_categories";
 import { hasStatusKey } from "interfaces/errors";
-import { MAX_ENTITY_NAME_LENGTH } from "utilities/constants";
+import { MAX_ENTITY_CHAR_LENGTH } from "utilities/constants";
 
 import Button from "components/buttons/Button";
 import InputField from "components/forms/fields/InputField";
@@ -72,7 +72,7 @@ const AddCategoryModal = ({
           error={error}
           autofocus
           ignore1password
-          inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
+          inputOptions={{ maxLength: MAX_ENTITY_CHAR_LENGTH }}
         />
         <div className="modal-cta-wrap">
           <Button type="submit" disabled={isDisabled} isLoading={isSubmitting}>

--- a/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/AddCategoryModal/AddCategoryModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/AddCategoryModal/AddCategoryModal.tsx
@@ -26,9 +26,7 @@ const AddCategoryModal = ({
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const trimmedName = name.trim();
-  const isInvalid =
-    trimmedName.length === 0 || trimmedName.length > MAX_ENTITY_NAME_LENGTH;
-  const isDisabled = isInvalid || isSubmitting;
+  const isDisabled = trimmedName.length === 0 || isSubmitting;
 
   const onNameChange = (value: string) => {
     setName(value);

--- a/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/EditCategoryModal/EditCategoryModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/EditCategoryModal/EditCategoryModal.tsx
@@ -27,10 +27,8 @@ const EditCategoryModal = ({
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const trimmedName = name.trim();
-  const isInvalid =
-    trimmedName.length === 0 || trimmedName.length > MAX_ENTITY_NAME_LENGTH;
   const isUnchanged = trimmedName === category.name;
-  const isDisabled = isInvalid || isUnchanged || isSubmitting;
+  const isDisabled = trimmedName.length === 0 || isUnchanged || isSubmitting;
 
   const onNameChange = (value: string) => {
     setName(value);

--- a/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/EditCategoryModal/EditCategoryModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/EditCategoryModal/EditCategoryModal.tsx
@@ -3,13 +3,13 @@ import React, { useState } from "react";
 import selfServiceCategoriesAPI from "services/entities/self_service_categories";
 import { hasStatusKey } from "interfaces/errors";
 import { ISelfServiceCategory } from "interfaces/self_service_category";
+import { MAX_ENTITY_NAME_LENGTH } from "utilities/constants";
 
 import Button from "components/buttons/Button";
 import InputField from "components/forms/fields/InputField";
 import Modal from "components/Modal";
 
 const baseClass = "edit-category-modal";
-const NAME_MAX_LENGTH = 255;
 
 interface IEditCategoryModalProps {
   category: ISelfServiceCategory;
@@ -28,7 +28,7 @@ const EditCategoryModal = ({
 
   const trimmedName = name.trim();
   const isInvalid =
-    trimmedName.length === 0 || trimmedName.length > NAME_MAX_LENGTH;
+    trimmedName.length === 0 || trimmedName.length > MAX_ENTITY_NAME_LENGTH;
   const isUnchanged = trimmedName === category.name;
   const isDisabled = isInvalid || isUnchanged || isSubmitting;
 
@@ -75,7 +75,7 @@ const EditCategoryModal = ({
           error={error}
           autofocus
           ignore1password
-          inputOptions={{ maxLength: NAME_MAX_LENGTH }}
+          inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
         />
         <div className="modal-cta-wrap">
           <Button type="submit" disabled={isDisabled} isLoading={isSubmitting}>

--- a/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/EditCategoryModal/EditCategoryModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/EditCategoryModal/EditCategoryModal.tsx
@@ -3,7 +3,7 @@ import React, { useState } from "react";
 import selfServiceCategoriesAPI from "services/entities/self_service_categories";
 import { hasStatusKey } from "interfaces/errors";
 import { ISelfServiceCategory } from "interfaces/self_service_category";
-import { MAX_ENTITY_NAME_LENGTH } from "utilities/constants";
+import { MAX_ENTITY_CHAR_LENGTH } from "utilities/constants";
 
 import Button from "components/buttons/Button";
 import InputField from "components/forms/fields/InputField";
@@ -73,7 +73,7 @@ const EditCategoryModal = ({
           error={error}
           autofocus
           ignore1password
-          inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
+          inputOptions={{ maxLength: MAX_ENTITY_CHAR_LENGTH }}
         />
         <div className="modal-cta-wrap">
           <Button type="submit" disabled={isDisabled} isLoading={isSubmitting}>

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CustomESTForm/CustomESTForm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CustomESTForm/CustomESTForm.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from "react";
 
 import { ICertificateAuthorityPartial } from "interfaces/certificates";
+import { MAX_ENTITY_NAME_LENGTH } from "utilities/constants";
 
 import InputField from "components/forms/fields/InputField";
 import Button from "components/buttons/Button";
@@ -63,6 +64,7 @@ const CustomESTForm = ({
         parseTarget
         placeholder="WIFI_CERTIFICATE"
         helpText="Letters, numbers, and underscores only."
+        inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
       />
       <InputField
         label="URL"

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CustomESTForm/CustomESTForm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CustomESTForm/CustomESTForm.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
 
 import { ICertificateAuthorityPartial } from "interfaces/certificates";
-import { MAX_ENTITY_NAME_LENGTH } from "utilities/constants";
+import { MAX_ENTITY_CHAR_LENGTH } from "utilities/constants";
 
 import InputField from "components/forms/fields/InputField";
 import Button from "components/buttons/Button";
@@ -64,7 +64,7 @@ const CustomESTForm = ({
         parseTarget
         placeholder="WIFI_CERTIFICATE"
         helpText="Letters, numbers, and underscores only."
-        inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
+        inputOptions={{ maxLength: MAX_ENTITY_CHAR_LENGTH }}
       />
       <InputField
         label="URL"

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CustomSCEPForm/CustomSCEPForm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CustomSCEPForm/CustomSCEPForm.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState } from "react";
 
 import { ICertificateAuthorityPartial } from "interfaces/certificates";
-import { MAX_ENTITY_NAME_LENGTH } from "utilities/constants";
+import { MAX_ENTITY_CHAR_LENGTH } from "utilities/constants";
 
 import InputField from "components/forms/fields/InputField";
 import Button from "components/buttons/Button";
@@ -81,7 +81,7 @@ const CustomSCEPForm = ({
         parseTarget
         placeholder="WIFI_CERTIFICATE"
         helpText="Letters, numbers, and underscores only. Fleet will create configuration profile variables with the name as suffix (e.g. $FLEET_VAR_CUSTOM_SCEP_CHALLENGE_WIFI_CERTIFICATE)."
-        inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
+        inputOptions={{ maxLength: MAX_ENTITY_CHAR_LENGTH }}
       />
       <InputField
         label="SCEP URL"

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CustomSCEPForm/CustomSCEPForm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CustomSCEPForm/CustomSCEPForm.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from "react";
 
 import { ICertificateAuthorityPartial } from "interfaces/certificates";
+import { MAX_ENTITY_NAME_LENGTH } from "utilities/constants";
 
 import InputField from "components/forms/fields/InputField";
 import Button from "components/buttons/Button";
@@ -80,6 +81,7 @@ const CustomSCEPForm = ({
         parseTarget
         placeholder="WIFI_CERTIFICATE"
         helpText="Letters, numbers, and underscores only. Fleet will create configuration profile variables with the name as suffix (e.g. $FLEET_VAR_CUSTOM_SCEP_CHALLENGE_WIFI_CERTIFICATE)."
+        inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
       />
       <InputField
         label="SCEP URL"

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DigicertForm/DigicertForm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DigicertForm/DigicertForm.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState } from "react";
 
 import { ICertificateAuthorityPartial } from "interfaces/certificates";
-import { MAX_ENTITY_NAME_LENGTH } from "utilities/constants";
+import { MAX_ENTITY_CHAR_LENGTH } from "utilities/constants";
 
 import InputField from "components/forms/fields/InputField";
 import Button from "components/buttons/Button";
@@ -93,7 +93,7 @@ const DigicertForm = ({
         helpText="Letters, numbers, and underscores only. Fleet will create configuration profile variables with the name as suffix (e.g. $FLEET_VAR_DIGICERT_DATA_WIFI_CERTIFICATE)."
         parseTarget
         placeholder="WIFI_CERTIFICATE"
-        inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
+        inputOptions={{ maxLength: MAX_ENTITY_CHAR_LENGTH }}
       />
       <InputField
         name="url"

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DigicertForm/DigicertForm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DigicertForm/DigicertForm.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from "react";
 
 import { ICertificateAuthorityPartial } from "interfaces/certificates";
+import { MAX_ENTITY_NAME_LENGTH } from "utilities/constants";
 
 import InputField from "components/forms/fields/InputField";
 import Button from "components/buttons/Button";
@@ -92,6 +93,7 @@ const DigicertForm = ({
         helpText="Letters, numbers, and underscores only. Fleet will create configuration profile variables with the name as suffix (e.g. $FLEET_VAR_DIGICERT_DATA_WIFI_CERTIFICATE)."
         parseTarget
         placeholder="WIFI_CERTIFICATE"
+        inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
       />
       <InputField
         name="url"

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/HydrantForm/HydrantForm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/HydrantForm/HydrantForm.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState } from "react";
 
 import { ICertificateAuthorityPartial } from "interfaces/certificates";
-import { MAX_ENTITY_NAME_LENGTH } from "utilities/constants";
+import { MAX_ENTITY_CHAR_LENGTH } from "utilities/constants";
 
 import InputField from "components/forms/fields/InputField";
 import Button from "components/buttons/Button";
@@ -81,7 +81,7 @@ const HydrantForm = ({
         helpText="Letters, numbers, and underscores only. Fleet will create configuration profile variables with the name as suffix (e.g. $FLEET_VAR_HYDRANT_DATA_WIFI_CERTIFICATE)."
         parseTarget
         placeholder="WIFI_CERTIFICATE"
-        inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
+        inputOptions={{ maxLength: MAX_ENTITY_CHAR_LENGTH }}
       />
       <InputField
         name="url"

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/HydrantForm/HydrantForm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/HydrantForm/HydrantForm.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from "react";
 
 import { ICertificateAuthorityPartial } from "interfaces/certificates";
+import { MAX_ENTITY_NAME_LENGTH } from "utilities/constants";
 
 import InputField from "components/forms/fields/InputField";
 import Button from "components/buttons/Button";
@@ -80,6 +81,7 @@ const HydrantForm = ({
         helpText="Letters, numbers, and underscores only. Fleet will create configuration profile variables with the name as suffix (e.g. $FLEET_VAR_HYDRANT_DATA_WIFI_CERTIFICATE)."
         parseTarget
         placeholder="WIFI_CERTIFICATE"
+        inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
       />
       <InputField
         name="url"

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/SmallstepForm/SmallstepForm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/SmallstepForm/SmallstepForm.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
 
 import { ICertificateAuthorityPartial } from "interfaces/certificates";
-import { MAX_ENTITY_NAME_LENGTH } from "utilities/constants";
+import { MAX_ENTITY_CHAR_LENGTH } from "utilities/constants";
 
 import InputField from "components/forms/fields/InputField";
 import Button from "components/buttons/Button";
@@ -66,7 +66,7 @@ const SmallstepForm = ({
         parseTarget
         placeholder="WIFI_CERTIFICATE"
         helpText="Letters, numbers, and underscores only. Fleet will create configuration profile variables with the name as suffix (e.g. $FLEET_VAR_SMALLSTEP_DATA_WIFI_CERTIFICATE)."
-        inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
+        inputOptions={{ maxLength: MAX_ENTITY_CHAR_LENGTH }}
       />
       <InputField
         label="SCEP URL"

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/SmallstepForm/SmallstepForm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/SmallstepForm/SmallstepForm.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from "react";
 
 import { ICertificateAuthorityPartial } from "interfaces/certificates";
+import { MAX_ENTITY_NAME_LENGTH } from "utilities/constants";
 
 import InputField from "components/forms/fields/InputField";
 import Button from "components/buttons/Button";
@@ -65,6 +66,7 @@ const SmallstepForm = ({
         parseTarget
         placeholder="WIFI_CERTIFICATE"
         helpText="Letters, numbers, and underscores only. Fleet will create configuration profile variables with the name as suffix (e.g. $FLEET_VAR_SMALLSTEP_DATA_WIFI_CERTIFICATE)."
+        inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
       />
       <InputField
         label="SCEP URL"

--- a/frontend/pages/admin/ManageFleetsPage/FleetTableConfig.tsx
+++ b/frontend/pages/admin/ManageFleetsPage/FleetTableConfig.tsx
@@ -63,8 +63,10 @@ const generateTableHeaders = (
       accessor: "name",
       Cell: (cellProps: ICellProps) => (
         <LinkCell
+          className="w400"
           value={cellProps.cell.value}
           path={PATHS.FLEET_DETAILS_USERS(cellProps.row.original.id)}
+          tooltipTruncate
         />
       ),
     },

--- a/frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/_styles.scss
+++ b/frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/_styles.scss
@@ -10,13 +10,30 @@
   &__team-header {
     display: flex;
     justify-content: space-between;
+    align-items: center;
+    gap: $pad-medium;
   }
 
   &__team-details {
     display: flex;
     align-items: center;
+    min-width: 0;
+    flex: 1;
+    h1 {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      min-width: 0;
+    }
     .form-field--dropdown {
       margin-bottom: 0;
+    }
+  }
+
+  .action-buttons {
+    flex-shrink: 0;
+    button {
+      white-space: nowrap;
     }
   }
 

--- a/frontend/pages/admin/ManageFleetsPage/components/CreateFleetModal/CreateFleetModal.tests.tsx
+++ b/frontend/pages/admin/ManageFleetsPage/components/CreateFleetModal/CreateFleetModal.tests.tsx
@@ -80,6 +80,13 @@ describe("CreateFleetModal", () => {
     expect(screen.getByText("Team name already exists")).toBeInTheDocument();
   });
 
+  it("caps the fleet name input at 255 characters (matches DB varchar(255))", () => {
+    render(<CreateFleetModal {...defaultProps} />);
+
+    const nameInput = screen.getByLabelText("Fleet name") as HTMLInputElement;
+    expect(nameInput.maxLength).toBe(255);
+  });
+
   it("clears errors when user types in the input", async () => {
     const props = {
       ...defaultProps,

--- a/frontend/pages/admin/ManageFleetsPage/components/CreateFleetModal/CreateFleetModal.tsx
+++ b/frontend/pages/admin/ManageFleetsPage/components/CreateFleetModal/CreateFleetModal.tsx
@@ -2,7 +2,7 @@ import React, { useState, useCallback, useEffect } from "react";
 
 import { ITeamFormData as IFleetFormData } from "services/entities/teams";
 
-import { MAX_ENTITY_NAME_LENGTH } from "utilities/constants";
+import { MAX_ENTITY_CHAR_LENGTH } from "utilities/constants";
 import Modal from "components/Modal";
 import Button from "components/buttons/Button";
 
@@ -68,7 +68,7 @@ const CreateFleetModal = ({
           placeholder="Workstations"
           value={name}
           error={errors.name}
-          inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
+          inputOptions={{ maxLength: MAX_ENTITY_CHAR_LENGTH }}
         />
         <div className="modal-cta-wrap">
           <Button

--- a/frontend/pages/admin/ManageFleetsPage/components/CreateFleetModal/CreateFleetModal.tsx
+++ b/frontend/pages/admin/ManageFleetsPage/components/CreateFleetModal/CreateFleetModal.tsx
@@ -2,6 +2,7 @@ import React, { useState, useCallback, useEffect } from "react";
 
 import { ITeamFormData as IFleetFormData } from "services/entities/teams";
 
+import { MAX_ENTITY_NAME_LENGTH } from "utilities/constants";
 import Modal from "components/Modal";
 import Button from "components/buttons/Button";
 
@@ -67,6 +68,7 @@ const CreateFleetModal = ({
           placeholder="Workstations"
           value={name}
           error={errors.name}
+          inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
         />
         <div className="modal-cta-wrap">
           <Button

--- a/frontend/pages/admin/ManageFleetsPage/components/RenameFleetModal/RenameFleetModal.tests.tsx
+++ b/frontend/pages/admin/ManageFleetsPage/components/RenameFleetModal/RenameFleetModal.tests.tsx
@@ -61,6 +61,13 @@ describe("RenameFleetModal", () => {
     expect(defaultProps.onSubmit).toHaveBeenCalledWith({ name: "New Name" });
   });
 
+  it("caps the fleet name input at 255 characters (matches DB varchar(255))", () => {
+    render(<RenameFleetModal {...defaultProps} />);
+
+    const nameInput = screen.getByLabelText("Fleet name") as HTMLInputElement;
+    expect(nameInput.maxLength).toBe(255);
+  });
+
   it("does not call onSubmit when name is whitespace-only", async () => {
     render(<RenameFleetModal {...defaultProps} />);
 

--- a/frontend/pages/admin/ManageFleetsPage/components/RenameFleetModal/RenameFleetModal.tsx
+++ b/frontend/pages/admin/ManageFleetsPage/components/RenameFleetModal/RenameFleetModal.tsx
@@ -2,7 +2,7 @@ import React, { useState, useCallback, useEffect } from "react";
 
 import { ITeamFormData as IFleetFormData } from "services/entities/teams";
 
-import { MAX_ENTITY_NAME_LENGTH } from "utilities/constants";
+import { MAX_ENTITY_CHAR_LENGTH } from "utilities/constants";
 import Modal from "components/Modal";
 import InputField from "components/forms/fields/InputField";
 import Button from "components/buttons/Button";
@@ -64,7 +64,7 @@ const RenameFleetModal = ({
           placeholder="Fleet name"
           value={name}
           error={errors.name}
-          inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
+          inputOptions={{ maxLength: MAX_ENTITY_CHAR_LENGTH }}
         />
         <div className="modal-cta-wrap">
           <Button

--- a/frontend/pages/admin/ManageFleetsPage/components/RenameFleetModal/RenameFleetModal.tsx
+++ b/frontend/pages/admin/ManageFleetsPage/components/RenameFleetModal/RenameFleetModal.tsx
@@ -2,6 +2,7 @@ import React, { useState, useCallback, useEffect } from "react";
 
 import { ITeamFormData as IFleetFormData } from "services/entities/teams";
 
+import { MAX_ENTITY_NAME_LENGTH } from "utilities/constants";
 import Modal from "components/Modal";
 import InputField from "components/forms/fields/InputField";
 import Button from "components/buttons/Button";
@@ -63,6 +64,7 @@ const RenameFleetModal = ({
           placeholder="Fleet name"
           value={name}
           error={errors.name}
+          inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
         />
         <div className="modal-cta-wrap">
           <Button

--- a/frontend/pages/admin/ManageUsersPage/components/ApiUserForm/ApiUserForm.tsx
+++ b/frontend/pages/admin/ManageUsersPage/components/ApiUserForm/ApiUserForm.tsx
@@ -3,6 +3,7 @@ import React, { FormEvent, useState } from "react";
 import { IApiEndpointRef } from "interfaces/api_endpoint";
 import { ITeam } from "interfaces/team";
 import { IUserFormErrors, UserRole } from "interfaces/user";
+import { MAX_ENTITY_NAME_LENGTH } from "utilities/constants";
 
 import { SingleValue } from "react-select-5";
 import Button from "components/buttons/Button";
@@ -243,6 +244,7 @@ const ApiUserForm = ({
             onBlur={onInputBlur}
             error={formErrors.name}
             autofocus
+            inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
           />
           {isPremiumTier ? renderPermissions() : renderGlobalRoleForm()}
           {isPremiumTier && (

--- a/frontend/pages/admin/ManageUsersPage/components/ApiUserForm/ApiUserForm.tsx
+++ b/frontend/pages/admin/ManageUsersPage/components/ApiUserForm/ApiUserForm.tsx
@@ -3,7 +3,7 @@ import React, { FormEvent, useState } from "react";
 import { IApiEndpointRef } from "interfaces/api_endpoint";
 import { ITeam } from "interfaces/team";
 import { IUserFormErrors, UserRole } from "interfaces/user";
-import { MAX_ENTITY_NAME_LENGTH } from "utilities/constants";
+import { MAX_ENTITY_CHAR_LENGTH } from "utilities/constants";
 
 import { SingleValue } from "react-select-5";
 import Button from "components/buttons/Button";
@@ -244,7 +244,7 @@ const ApiUserForm = ({
             onBlur={onInputBlur}
             error={formErrors.name}
             autofocus
-            inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
+            inputOptions={{ maxLength: MAX_ENTITY_CHAR_LENGTH }}
           />
           {isPremiumTier ? renderPermissions() : renderGlobalRoleForm()}
           {isPremiumTier && (

--- a/frontend/pages/hosts/details/cards/Labels/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Labels/_styles.scss
@@ -13,6 +13,8 @@
 
   &__list-item {
     margin-bottom: 0;
+    max-width: 100%;
+    min-width: 0;
   }
 
   .button,
@@ -21,5 +23,9 @@
     .__react_component_tooltip {
       font-weight: $regular;
     }
+  }
+
+  &__list-button {
+    max-width: 300px;
   }
 }

--- a/frontend/pages/hosts/details/cards/Labels/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Labels/_styles.scss
@@ -25,7 +25,7 @@
     }
   }
 
-  &__list-button {
+  .button.host-labels-card__list-button {
     max-width: 300px;
   }
 }

--- a/frontend/pages/labels/NewLabelPage/NewLabelPage.tsx
+++ b/frontend/pages/labels/NewLabelPage/NewLabelPage.tsx
@@ -302,7 +302,6 @@ const NewLabelPage = ({
 
       // start from previous errors
       if (prev.name) next.name = prev.name;
-      if (prev.description) next.description = prev.description;
       if (prev.labelQuery) next.labelQuery = prev.labelQuery;
       if (prev.criteria) next.criteria = prev.criteria;
 
@@ -311,22 +310,13 @@ const NewLabelPage = ({
         if (prev.name && fullValidation.name?.isValid) {
           next.name = undefined;
         }
-      } else if (fieldName === "description") {
-        if (prev.description && fullValidation.description?.isValid) {
-          next.description = undefined;
-        }
       } else if (fieldName === "vitalValue") {
         if (prev.criteria && fullValidation.criteria?.isValid) {
           next.criteria = undefined;
         }
       }
 
-      const fields = [
-        next.name,
-        next.description,
-        next.labelQuery,
-        next.criteria,
-      ];
+      const fields = [next.name, next.labelQuery, next.criteria];
       next.isValid = fields.every((f) => !f || f.isValid);
 
       return next;
@@ -354,7 +344,6 @@ const NewLabelPage = ({
       const next: INewLabelFormValidation = { ...prev, isValid: true };
 
       if (prev.name) next.name = prev.name;
-      if (prev.description) next.description = prev.description;
       if (prev.labelQuery) next.labelQuery = prev.labelQuery;
       if (prev.criteria && fullValidation.criteria?.isValid) {
         next.criteria = undefined;
@@ -362,12 +351,7 @@ const NewLabelPage = ({
         next.criteria = prev.criteria;
       }
 
-      const fields = [
-        next.name,
-        next.description,
-        next.labelQuery,
-        next.criteria,
-      ];
+      const fields = [next.name, next.labelQuery, next.criteria];
       next.isValid = fields.every((f) => !f || f.isValid);
 
       return next;
@@ -398,19 +382,12 @@ const NewLabelPage = ({
       const next: INewLabelFormValidation = { ...prev, isValid: true };
 
       if (prev.name) next.name = fullValidation.name ?? prev.name;
-      if (prev.description)
-        next.description = fullValidation.description ?? prev.description;
       if (prev.labelQuery)
         next.labelQuery = fullValidation.labelQuery ?? prev.labelQuery;
       if (prev.criteria)
         next.criteria = fullValidation.criteria ?? prev.criteria;
 
-      const fields = [
-        next.name,
-        next.description,
-        next.labelQuery,
-        next.criteria,
-      ];
+      const fields = [next.name, next.labelQuery, next.criteria];
       next.isValid = fields.every((f) => !f || f.isValid);
 
       return next;
@@ -467,7 +444,6 @@ const NewLabelPage = ({
       const next: INewLabelFormValidation = { ...prev, isValid: true };
 
       if (prev.name) next.name = prev.name;
-      if (prev.description) next.description = prev.description;
       if (prev.labelQuery) next.labelQuery = prev.labelQuery;
       if (prev.criteria) next.criteria = prev.criteria;
 
@@ -475,12 +451,7 @@ const NewLabelPage = ({
         next.labelQuery = undefined;
       }
 
-      const fields = [
-        next.name,
-        next.description,
-        next.labelQuery,
-        next.criteria,
-      ];
+      const fields = [next.name, next.labelQuery, next.criteria];
       next.isValid = fields.every((f) => !f || f.isValid);
 
       return next;
@@ -652,7 +623,6 @@ const NewLabelPage = ({
         inputOptions={{ maxLength: MAX_ENTITY_CHAR_LENGTH }}
       />
       <InputField
-        error={formErrors.description?.message}
         name="description"
         onChange={onInputChange}
         onBlur={onInputBlur}

--- a/frontend/pages/labels/NewLabelPage/NewLabelPage.tsx
+++ b/frontend/pages/labels/NewLabelPage/NewLabelPage.tsx
@@ -16,7 +16,7 @@ import customHostVitalsAPI, {
 
 import {
   DEFAULT_USE_QUERY_OPTIONS,
-  MAX_ENTITY_NAME_LENGTH,
+  MAX_ENTITY_CHAR_LENGTH,
 } from "utilities/constants";
 // TODO - move this table config near here once expanded this logic to encompass editing and
 // therefore not longer needed anywhere else
@@ -649,7 +649,7 @@ const NewLabelPage = ({
         label="Name"
         placeholder="Label name"
         parseTarget
-        inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
+        inputOptions={{ maxLength: MAX_ENTITY_CHAR_LENGTH }}
       />
       <InputField
         error={formErrors.description?.message}
@@ -662,7 +662,7 @@ const NewLabelPage = ({
         type="textarea"
         placeholder="Label description (optional)"
         parseTarget
-        inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
+        inputOptions={{ maxLength: MAX_ENTITY_CHAR_LENGTH }}
       />
       <div className="form-field type-field">
         <div className="form-field__label">Type</div>

--- a/frontend/pages/labels/NewLabelPage/NewLabelPage.tsx
+++ b/frontend/pages/labels/NewLabelPage/NewLabelPage.tsx
@@ -14,7 +14,10 @@ import customHostVitalsAPI, {
   IListCustomHostVitalsApiParams,
 } from "services/entities/custom_host_vitals";
 
-import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
+import {
+  DEFAULT_USE_QUERY_OPTIONS,
+  MAX_ENTITY_NAME_LENGTH,
+} from "utilities/constants";
 // TODO - move this table config near here once expanded this logic to encompass editing and
 // therefore not longer needed anywhere else
 import { generateTableHeaders } from "pages/labels/components/ManualLabelForm/LabelHostTargetTableConfig";
@@ -646,6 +649,7 @@ const NewLabelPage = ({
         label="Name"
         placeholder="Label name"
         parseTarget
+        inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
       />
       <InputField
         error={formErrors.description?.message}
@@ -658,6 +662,7 @@ const NewLabelPage = ({
         type="textarea"
         placeholder="Label description (optional)"
         parseTarget
+        inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
       />
       <div className="form-field type-field">
         <div className="form-field__label">Type</div>

--- a/frontend/pages/labels/NewLabelPage/helpers.ts
+++ b/frontend/pages/labels/NewLabelPage/helpers.ts
@@ -2,7 +2,6 @@ import {
   CUSTOM_HOST_VITAL_CRITERION,
   LabelHostVitalsCriterion,
 } from "interfaces/label";
-import { MAX_ENTITY_NAME_LENGTH } from "utilities/constants";
 
 import { INewLabelFormData } from "./NewLabelPage";
 
@@ -55,9 +54,6 @@ export interface INewLabelFormValidation {
   criteria?: { isValid: boolean; message?: string };
 }
 
-// Matches DB
-const MAX_DESCRIPTION_LENGTH = 255;
-
 type IMessageFunc = (formData: INewLabelFormData) => string;
 type IValidationMessage = string | IMessageFunc;
 type IFormValidationKey = keyof Pick<
@@ -87,23 +83,10 @@ const FORM_VALIDATIONS: IFormValidations = {
         isValid: (formData) => formData.name.trim().length > 0,
         message: "Label name must be present",
       },
-      {
-        name: "notTooLong",
-        isValid: (formData) => formData.name.length <= MAX_ENTITY_NAME_LENGTH,
-        message: `Name may not exceed ${MAX_ENTITY_NAME_LENGTH} characters`,
-      },
     ],
   },
   description: {
-    validations: [
-      {
-        name: "notTooLong",
-        isValid: (formData) =>
-          !formData.description ||
-          formData.description.length <= MAX_DESCRIPTION_LENGTH,
-        message: `Description may not exceed ${MAX_DESCRIPTION_LENGTH} characters`,
-      },
-    ],
+    validations: [],
   },
   labelQuery: {
     validations: [

--- a/frontend/pages/labels/NewLabelPage/helpers.ts
+++ b/frontend/pages/labels/NewLabelPage/helpers.ts
@@ -49,7 +49,6 @@ export const getCriterionHelpText = (vital: LabelHostVitalsCriterion) => {
 export interface INewLabelFormValidation {
   isValid: boolean;
   name?: { isValid: boolean; message?: string };
-  description?: { isValid: boolean; message?: string };
   labelQuery?: { isValid: boolean; message?: string };
   criteria?: { isValid: boolean; message?: string };
 }

--- a/frontend/pages/labels/NewLabelPage/helpers.ts
+++ b/frontend/pages/labels/NewLabelPage/helpers.ts
@@ -58,7 +58,7 @@ type IMessageFunc = (formData: INewLabelFormData) => string;
 type IValidationMessage = string | IMessageFunc;
 type IFormValidationKey = keyof Pick<
   INewLabelFormData,
-  "name" | "description" | "labelQuery" | "vitalValue"
+  "name" | "labelQuery" | "vitalValue"
 >;
 
 interface IValidation {
@@ -84,9 +84,6 @@ const FORM_VALIDATIONS: IFormValidations = {
         message: "Label name must be present",
       },
     ],
-  },
-  description: {
-    validations: [],
   },
   labelQuery: {
     validations: [
@@ -157,9 +154,6 @@ export const validateNewLabelFormData = (
         case "name":
           formValidation.name = { isValid: true };
           break;
-        case "description":
-          formValidation.description = { isValid: true };
-          break;
         case "labelQuery":
           formValidation.labelQuery = { isValid: true };
           break;
@@ -176,9 +170,6 @@ export const validateNewLabelFormData = (
       switch (objKey) {
         case "name":
           formValidation.name = { isValid: false, message };
-          break;
-        case "description":
-          formValidation.description = { isValid: false, message };
           break;
         case "labelQuery":
           formValidation.labelQuery = { isValid: false, message };

--- a/frontend/pages/labels/NewLabelPage/helpers.ts
+++ b/frontend/pages/labels/NewLabelPage/helpers.ts
@@ -2,6 +2,7 @@ import {
   CUSTOM_HOST_VITAL_CRITERION,
   LabelHostVitalsCriterion,
 } from "interfaces/label";
+import { MAX_ENTITY_NAME_LENGTH } from "utilities/constants";
 
 import { INewLabelFormData } from "./NewLabelPage";
 
@@ -55,7 +56,6 @@ export interface INewLabelFormValidation {
 }
 
 // Matches DB
-const MAX_LABEL_NAME_LENGTH = 255;
 const MAX_DESCRIPTION_LENGTH = 255;
 
 type IMessageFunc = (formData: INewLabelFormData) => string;
@@ -89,8 +89,8 @@ const FORM_VALIDATIONS: IFormValidations = {
       },
       {
         name: "notTooLong",
-        isValid: (formData) => formData.name.length <= MAX_LABEL_NAME_LENGTH,
-        message: `Name may not exceed ${MAX_LABEL_NAME_LENGTH} characters`,
+        isValid: (formData) => formData.name.length <= MAX_ENTITY_NAME_LENGTH,
+        message: `Name may not exceed ${MAX_ENTITY_NAME_LENGTH} characters`,
       },
     ],
   },

--- a/frontend/pages/labels/components/LabelForm/LabelForm.tsx
+++ b/frontend/pages/labels/components/LabelForm/LabelForm.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode, useState } from "react";
 
-import { MAX_ENTITY_NAME_LENGTH } from "utilities/constants";
+import { MAX_ENTITY_CHAR_LENGTH } from "utilities/constants";
 
 import InputField from "components/forms/fields/InputField";
 import Button from "components/buttons/Button";
@@ -152,7 +152,7 @@ const LabelForm = ({
         inputClassName={`${baseClass}__label-title`}
         label="Name"
         placeholder="Label name"
-        inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
+        inputOptions={{ maxLength: MAX_ENTITY_CHAR_LENGTH }}
       />
       <InputField
         error={formValidation.description?.message}
@@ -165,7 +165,7 @@ const LabelForm = ({
         label="Description"
         type="textarea"
         placeholder="Label description (optional)"
-        inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
+        inputOptions={{ maxLength: MAX_ENTITY_CHAR_LENGTH }}
       />
       {immutableFields.length > 0 ? (
         <span className={`${baseClass}__help-text`}>

--- a/frontend/pages/labels/components/LabelForm/LabelForm.tsx
+++ b/frontend/pages/labels/components/LabelForm/LabelForm.tsx
@@ -90,7 +90,6 @@ const LabelForm = ({
 
       // start from previous errors
       if (prev.name) next.name = prev.name;
-      if (prev.description) next.description = prev.description;
 
       // ONLY CLEAR existing error on this field if it is now valid.
       // Do NOT set a new error if there wasn't one before.
@@ -98,15 +97,10 @@ const LabelForm = ({
         if (prev.name && fullValidation.name?.isValid) {
           next.name = undefined; // clear existing name error
         }
-      } else if (fieldName === "description") {
-        if (prev.description && fullValidation.description?.isValid) {
-          next.description = undefined; // clear existing description error
-        }
       }
 
       // recompute isValid from remaining errors
-      const fields = [next.name, next.description];
-      next.isValid = fields.every((f) => !f || f.isValid);
+      next.isValid = !next.name || next.name.isValid;
 
       return next;
     });
@@ -155,7 +149,6 @@ const LabelForm = ({
         inputOptions={{ maxLength: MAX_ENTITY_CHAR_LENGTH }}
       />
       <InputField
-        error={formValidation.description?.message}
         parseTarget
         name="description"
         onChange={onFormChange}

--- a/frontend/pages/labels/components/LabelForm/LabelForm.tsx
+++ b/frontend/pages/labels/components/LabelForm/LabelForm.tsx
@@ -1,5 +1,7 @@
 import React, { ReactNode, useState } from "react";
 
+import { MAX_ENTITY_NAME_LENGTH } from "utilities/constants";
+
 import InputField from "components/forms/fields/InputField";
 import Button from "components/buttons/Button";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
@@ -150,6 +152,7 @@ const LabelForm = ({
         inputClassName={`${baseClass}__label-title`}
         label="Name"
         placeholder="Label name"
+        inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
       />
       <InputField
         error={formValidation.description?.message}
@@ -162,6 +165,7 @@ const LabelForm = ({
         label="Description"
         type="textarea"
         placeholder="Label description (optional)"
+        inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
       />
       {immutableFields.length > 0 ? (
         <span className={`${baseClass}__help-text`}>

--- a/frontend/pages/labels/components/LabelForm/helpers.ts
+++ b/frontend/pages/labels/components/LabelForm/helpers.ts
@@ -1,5 +1,3 @@
-import { MAX_ENTITY_NAME_LENGTH } from "utilities/constants";
-
 import { ILabelFormData } from "./LabelForm";
 
 export interface ILabelFormValidation {
@@ -7,9 +5,6 @@ export interface ILabelFormValidation {
   name?: { isValid: boolean; message?: string };
   description?: { isValid: boolean; message?: string };
 }
-
-// Matches length in DB
-const MAX_LABEL_DESCRIPTION_LENGTH = 255;
 
 type IMessageFunc = (formData: ILabelFormData) => string;
 type IValidationMessage = string | IMessageFunc;
@@ -37,23 +32,10 @@ const FORM_VALIDATIONS: IFormValidations = {
         isValid: (formData) => formData.name.trim().length > 0,
         message: "Label name must be present",
       },
-      {
-        name: "notTooLong",
-        isValid: (formData) => formData.name.length <= MAX_ENTITY_NAME_LENGTH,
-        message: `Name may not exceed ${MAX_ENTITY_NAME_LENGTH} characters`,
-      },
     ],
   },
   description: {
-    validations: [
-      {
-        name: "notTooLong",
-        isValid: (formData) =>
-          !formData.description ||
-          formData.description.length <= MAX_LABEL_DESCRIPTION_LENGTH,
-        message: `Description may not exceed ${MAX_LABEL_DESCRIPTION_LENGTH} characters`,
-      },
-    ],
+    validations: [],
   },
 };
 

--- a/frontend/pages/labels/components/LabelForm/helpers.ts
+++ b/frontend/pages/labels/components/LabelForm/helpers.ts
@@ -1,3 +1,5 @@
+import { MAX_ENTITY_NAME_LENGTH } from "utilities/constants";
+
 import { ILabelFormData } from "./LabelForm";
 
 export interface ILabelFormValidation {
@@ -7,7 +9,6 @@ export interface ILabelFormValidation {
 }
 
 // Matches length in DB
-const MAX_LABEL_NAME_LENGTH = 255;
 const MAX_LABEL_DESCRIPTION_LENGTH = 255;
 
 type IMessageFunc = (formData: ILabelFormData) => string;
@@ -38,8 +39,8 @@ const FORM_VALIDATIONS: IFormValidations = {
       },
       {
         name: "notTooLong",
-        isValid: (formData) => formData.name.length <= MAX_LABEL_NAME_LENGTH,
-        message: `Name may not exceed ${MAX_LABEL_NAME_LENGTH} characters`,
+        isValid: (formData) => formData.name.length <= MAX_ENTITY_NAME_LENGTH,
+        message: `Name may not exceed ${MAX_ENTITY_NAME_LENGTH} characters`,
       },
     ],
   },

--- a/frontend/pages/labels/components/LabelForm/helpers.ts
+++ b/frontend/pages/labels/components/LabelForm/helpers.ts
@@ -3,12 +3,11 @@ import { ILabelFormData } from "./LabelForm";
 export interface ILabelFormValidation {
   isValid: boolean;
   name?: { isValid: boolean; message?: string };
-  description?: { isValid: boolean; message?: string };
 }
 
 type IMessageFunc = (formData: ILabelFormData) => string;
 type IValidationMessage = string | IMessageFunc;
-type IFormValidationKey = Extract<keyof ILabelFormData, "name">;
+type IFormValidationKey = "name";
 
 interface IValidation {
   name: string;

--- a/frontend/pages/labels/components/LabelForm/helpers.ts
+++ b/frontend/pages/labels/components/LabelForm/helpers.ts
@@ -8,7 +8,7 @@ export interface ILabelFormValidation {
 
 type IMessageFunc = (formData: ILabelFormData) => string;
 type IValidationMessage = string | IMessageFunc;
-type IFormValidationKey = keyof ILabelFormData;
+type IFormValidationKey = Extract<keyof ILabelFormData, "name">;
 
 interface IValidation {
   name: string;
@@ -33,9 +33,6 @@ const FORM_VALIDATIONS: IFormValidations = {
         message: "Label name must be present",
       },
     ],
-  },
-  description: {
-    validations: [],
   },
 };
 
@@ -64,9 +61,6 @@ export const validateLabelFormData = (
         case "name":
           formValidation.name = { isValid: true };
           break;
-        case "description":
-          formValidation.description = { isValid: true };
-          break;
         default: {
           const _exhaustiveCheck: never = objKey;
           break;
@@ -78,9 +72,6 @@ export const validateLabelFormData = (
       switch (objKey) {
         case "name":
           formValidation.name = { isValid: false, message };
-          break;
-        case "description":
-          formValidation.description = { isValid: false, message };
           break;
         default: {
           const _exhaustiveCheck: never = objKey;

--- a/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tsx
@@ -29,7 +29,10 @@ import {
   POLICY_TARGET_EMPTY_STATE_DESCRIPTION,
 } from "pages/policies/constants";
 
-import { LEARN_MORE_ABOUT_BASE_LINK } from "utilities/constants";
+import {
+  LEARN_MORE_ABOUT_BASE_LINK,
+  MAX_ENTITY_NAME_LENGTH,
+} from "utilities/constants";
 
 import SQLEditor from "components/SQLEditor";
 import {
@@ -63,8 +66,6 @@ import {
 import SaveNewPolicyModal from "../SaveNewPolicyModal";
 
 const baseClass = "policy-form";
-
-const NAME_MAX_LENGTH = 255;
 
 interface IPolicyFormProps {
   router: InjectedRouter;
@@ -520,7 +521,7 @@ const PolicyForm = ({
           error={errors && errors.name}
           onChange={(value: string) => setLastEditedQueryName(value)}
           disabled={gitOpsModeEnabled}
-          inputOptions={{ maxLength: NAME_MAX_LENGTH }}
+          inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
         />
       );
     }

--- a/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tsx
@@ -31,7 +31,7 @@ import {
 
 import {
   LEARN_MORE_ABOUT_BASE_LINK,
-  MAX_ENTITY_NAME_LENGTH,
+  MAX_ENTITY_CHAR_LENGTH,
 } from "utilities/constants";
 
 import SQLEditor from "components/SQLEditor";
@@ -521,7 +521,7 @@ const PolicyForm = ({
           error={errors && errors.name}
           onChange={(value: string) => setLastEditedQueryName(value)}
           disabled={gitOpsModeEnabled}
-          inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
+          inputOptions={{ maxLength: MAX_ENTITY_CHAR_LENGTH }}
         />
       );
     }

--- a/frontend/pages/policies/edit/components/SaveNewPolicyModal/SaveNewPolicyModal.tsx
+++ b/frontend/pages/policies/edit/components/SaveNewPolicyModal/SaveNewPolicyModal.tsx
@@ -20,6 +20,7 @@ import { IPolicy, IPolicyFormData } from "interfaces/policy";
 import { CommaSeparatedPlatformString } from "interfaces/platform";
 import { ITeamConfig } from "interfaces/team";
 import useDeepEffect from "hooks/useDeepEffect";
+import { MAX_ENTITY_NAME_LENGTH } from "utilities/constants";
 
 import configAPI from "services/entities/config";
 import teamPoliciesAPI from "services/entities/team_policies";
@@ -38,8 +39,6 @@ import PolicyAutomationsFields, {
 } from "pages/policies/components/PolicyAutomationsFields";
 import { usePolicyLabelTargets } from "pages/policies/hooks";
 import { POLICY_TARGET_EMPTY_STATE_DESCRIPTION } from "pages/policies/constants";
-
-const NAME_MAX_LENGTH = 255;
 
 export interface ISaveNewPolicyModalProps {
   baseClass: string;
@@ -344,7 +343,7 @@ const SaveNewPolicyModal = ({
           label="Name"
           autofocus
           disabled={disableForm}
-          inputOptions={{ maxLength: NAME_MAX_LENGTH }}
+          inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
         />
         <InputField
           name="description"

--- a/frontend/pages/policies/edit/components/SaveNewPolicyModal/SaveNewPolicyModal.tsx
+++ b/frontend/pages/policies/edit/components/SaveNewPolicyModal/SaveNewPolicyModal.tsx
@@ -20,7 +20,7 @@ import { IPolicy, IPolicyFormData } from "interfaces/policy";
 import { CommaSeparatedPlatformString } from "interfaces/platform";
 import { ITeamConfig } from "interfaces/team";
 import useDeepEffect from "hooks/useDeepEffect";
-import { MAX_ENTITY_NAME_LENGTH } from "utilities/constants";
+import { MAX_ENTITY_CHAR_LENGTH } from "utilities/constants";
 
 import configAPI from "services/entities/config";
 import teamPoliciesAPI from "services/entities/team_policies";
@@ -343,7 +343,7 @@ const SaveNewPolicyModal = ({
           label="Name"
           autofocus
           disabled={disableForm}
-          inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
+          inputOptions={{ maxLength: MAX_ENTITY_CHAR_LENGTH }}
         />
         <InputField
           name="description"

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -25,7 +25,7 @@ import {
   MIN_OSQUERY_VERSION_OPTIONS,
   LOGGING_TYPE_OPTIONS,
   DEFAULT_USE_QUERY_OPTIONS,
-  MAX_ENTITY_NAME_LENGTH,
+  MAX_ENTITY_CHAR_LENGTH,
 } from "utilities/constants";
 import { getPathWithQueryParams } from "utilities/url";
 
@@ -465,7 +465,7 @@ const EditQueryForm = ({
             setLastEditedQueryName(lastEditedQueryName.trim());
           }}
           disabled={gitOpsModeEnabled}
-          inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
+          inputOptions={{ maxLength: MAX_ENTITY_CHAR_LENGTH }}
         />
       );
     }

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -25,6 +25,7 @@ import {
   MIN_OSQUERY_VERSION_OPTIONS,
   LOGGING_TYPE_OPTIONS,
   DEFAULT_USE_QUERY_OPTIONS,
+  MAX_ENTITY_NAME_LENGTH,
 } from "utilities/constants";
 import { getPathWithQueryParams } from "utilities/url";
 
@@ -75,8 +76,6 @@ import DiscardDataOption from "../DiscardDataOption";
 import SaveAsNewQueryModal from "../SaveAsNewQueryModal";
 
 const baseClass = "edit-query-form";
-
-const NAME_MAX_LENGTH = 255;
 
 interface IEditQueryFormProps {
   router: InjectedRouter;
@@ -466,7 +465,7 @@ const EditQueryForm = ({
             setLastEditedQueryName(lastEditedQueryName.trim());
           }}
           disabled={gitOpsModeEnabled}
-          inputOptions={{ maxLength: NAME_MAX_LENGTH }}
+          inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
         />
       );
     }

--- a/frontend/pages/queries/edit/components/SaveNewQueryModal/SaveNewQueryModal.tsx
+++ b/frontend/pages/queries/edit/components/SaveNewQueryModal/SaveNewQueryModal.tsx
@@ -18,6 +18,7 @@ import {
   LOGGING_TYPE_OPTIONS,
   MIN_OSQUERY_VERSION_OPTIONS,
   DEFAULT_USE_QUERY_OPTIONS,
+  MAX_ENTITY_NAME_LENGTH,
 } from "utilities/constants";
 
 import { CommaSeparatedPlatformString } from "interfaces/platform";
@@ -47,8 +48,6 @@ import labelsAPI, {
 import DiscardDataOption from "../DiscardDataOption";
 
 const baseClass = "save-query-modal";
-
-const NAME_MAX_LENGTH = 255;
 
 export interface ISaveNewQueryModalProps {
   queryValue: string;
@@ -241,7 +240,7 @@ const SaveNewQueryModal = ({
           inputClassName={`${baseClass}__name`}
           label="Name"
           autofocus
-          inputOptions={{ maxLength: NAME_MAX_LENGTH }}
+          inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
         />
         <InputField
           name="description"

--- a/frontend/pages/queries/edit/components/SaveNewQueryModal/SaveNewQueryModal.tsx
+++ b/frontend/pages/queries/edit/components/SaveNewQueryModal/SaveNewQueryModal.tsx
@@ -18,7 +18,7 @@ import {
   LOGGING_TYPE_OPTIONS,
   MIN_OSQUERY_VERSION_OPTIONS,
   DEFAULT_USE_QUERY_OPTIONS,
-  MAX_ENTITY_NAME_LENGTH,
+  MAX_ENTITY_CHAR_LENGTH,
 } from "utilities/constants";
 
 import { CommaSeparatedPlatformString } from "interfaces/platform";
@@ -240,7 +240,7 @@ const SaveNewQueryModal = ({
           inputClassName={`${baseClass}__name`}
           label="Name"
           autofocus
-          inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}
+          inputOptions={{ maxLength: MAX_ENTITY_CHAR_LENGTH }}
         />
         <InputField
           name="description"

--- a/frontend/utilities/constants.tsx
+++ b/frontend/utilities/constants.tsx
@@ -90,9 +90,9 @@ export const MAX_OSQUERY_SCHEDULED_QUERY_INTERVAL = 604800;
 
 // Max character length for most user-supplied free-text fields (name, title,
 // description) — matches the varchar(255) column shared across policies,
-// reports, teams (fleets), labels, scripts, software categories, custom
-// variables, certificate authorities, etc. Use on any `InputField` bound to
-// such a column: `inputOptions={{ maxLength: MAX_ENTITY_CHAR_LENGTH }}`.
+// reports, teams (fleets), labels, software categories, custom variables,
+// certificate authorities, etc. Use on any `InputField` bound to such a
+// column: `inputOptions={{ maxLength: MAX_ENTITY_CHAR_LENGTH }}`.
 export const MAX_ENTITY_CHAR_LENGTH = 255;
 
 export const MIN_OSQUERY_VERSION_OPTIONS = [

--- a/frontend/utilities/constants.tsx
+++ b/frontend/utilities/constants.tsx
@@ -88,6 +88,12 @@ export const LOGGING_TYPE_OPTIONS = [
 
 export const MAX_OSQUERY_SCHEDULED_QUERY_INTERVAL = 604800;
 
+// Max character length for most user-supplied name/title fields — matches the
+// varchar(255) column shared across policies, reports, teams (fleets), labels,
+// scripts, software categories, custom variables, certificate authorities, etc.
+// Use on any `InputField` bound to a `name`/`title` column: `inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}`.
+export const MAX_ENTITY_NAME_LENGTH = 255;
+
 export const MIN_OSQUERY_VERSION_OPTIONS = [
   { label: "All", value: "" },
   { label: "5.23.1 +", value: "5.23.1" },

--- a/frontend/utilities/constants.tsx
+++ b/frontend/utilities/constants.tsx
@@ -88,11 +88,12 @@ export const LOGGING_TYPE_OPTIONS = [
 
 export const MAX_OSQUERY_SCHEDULED_QUERY_INTERVAL = 604800;
 
-// Max character length for most user-supplied name/title fields — matches the
-// varchar(255) column shared across policies, reports, teams (fleets), labels,
-// scripts, software categories, custom variables, certificate authorities, etc.
-// Use on any `InputField` bound to a `name`/`title` column: `inputOptions={{ maxLength: MAX_ENTITY_NAME_LENGTH }}`.
-export const MAX_ENTITY_NAME_LENGTH = 255;
+// Max character length for most user-supplied free-text fields (name, title,
+// description) — matches the varchar(255) column shared across policies,
+// reports, teams (fleets), labels, scripts, software categories, custom
+// variables, certificate authorities, etc. Use on any `InputField` bound to
+// such a column: `inputOptions={{ maxLength: MAX_ENTITY_CHAR_LENGTH }}`.
+export const MAX_ENTITY_CHAR_LENGTH = 255;
 
 export const MIN_OSQUERY_VERSION_OPTIONS = [
   { label: "All", value: "" },

--- a/server/fleet/teams.go
+++ b/server/fleet/teams.go
@@ -34,6 +34,11 @@ const (
 	DisplayNameAllTeams = "All fleets"
 )
 
+// MaxTeamNameLength matches the varchar(255) size of teams.name in MySQL.
+// Enforce this before insert/update so callers get an InvalidArgumentError
+// instead of a raw "Data too long" MySQL error.
+const MaxTeamNameLength = 255
+
 // IsReservedTeamName checks if the name provided is a reserved fleet name (case-insensitive).
 // Both old names ("No team", "All teams") and new display names ("Unassigned", "All fleets")
 // are reserved to prevent creating teams with any of these names.


### PR DESCRIPTION
## Issue
Closes #47290

Also implements the "Cap free-text `maxLength` to the backend column length" pattern established in [#49041 (patterns.md thread)](https://github.com/fleetdm/fleet/pull/49041/files#r3572648691).

## Description
Fleet name inputs had no `maxLength` cap and no service-layer length check, so a name >255 chars failed with a raw MySQL `Data too long` error, and several UI surfaces didn't handle long names gracefully. This PR fixes all four manifestations called out in the bug, plus a related label-overflow case on the host details page, and hardens adjacent name inputs across the app.

**Frontend fixes for #47290:**
- Create/Rename fleet name inputs now cap at 255 characters (matches `teams.name varchar(255)`).
- Fleets table Name column uses `LinkCell` with `tooltipTruncate` + `className="w400"` so long names truncate with an ellipsis and full-name tooltip instead of overflowing across the Hosts/Users columns.
- Fleet-detail page header (`.team-details__team-header`): h1 gets `overflow: hidden; text-overflow: ellipsis; white-space: nowrap;`, `__team-details` gets `min-width: 0; flex: 1`, and `.action-buttons` gets `flex-shrink: 0` + `white-space: nowrap` on buttons so *Manage enroll secrets / Rename / Delete* no longer wrap to a second line when the fleet name is long.
- Manage enroll secrets modal body — `__description` gets `overflow-wrap: anywhere; min-width: 0` so a long `<b>{fleet name}</b>` wraps within the modal instead of spilling out the right edge.

**Backend fixes for #47290:**
- New `fleet.MaxTeamNameLength = 255` constant.
- `NewTeam`, `ModifyTeam`, and `ApplyTeamSpecs` now return `fleet.NewInvalidArgumentError("name", "may not exceed 255 characters")` instead of surfacing a raw `Data too long` MySQL error. Covers UI, API, and GitOps entry points.

**Broader consistency pass (per [#49041 thread](https://github.com/fleetdm/fleet/pull/49041/files#r3572648691)):**
- New shared `MAX_ENTITY_CHAR_LENGTH = 255` constant in `frontend/utilities/constants.tsx`.
- Refactored 8 existing files that had ad-hoc `NAME_MAX_LENGTH = 255` / `MAX_LABEL_NAME_LENGTH = 255` locals to use it.
- Slotted it into 16 additional `InputField` name/description inputs that were missing a cap (API user, custom variable, certificate, label name + description, pack name + description, and all 5 CA forms — CustomEST, CustomSCEP, Smallstep, Digicert, Hydrant).
- Pruned dead FE length validators that can no longer fire now that the DOM cap enforces the limit (certificate modal, custom variable modal, both label helpers, both category modals). Unusual/shorter caps (e.g. `varchar(64)`, custom business rules) still keep their inline validators — silent truncation is only appropriate for the common 255-char norm.

**Bonus:** fixed the long-label overflow on the host details Labels card by capping the pill button `max-width` at 300px.

## Screenrecording


https://github.com/user-attachments/assets/b917b72e-7437-4d0c-a1a1-c49b4b1c28ba


https://github.com/user-attachments/assets/3a3efbb2-09d8-4f47-9fd4-f158b3453b9e


https://github.com/user-attachments/assets/73e5e022-dc93-4381-82b3-be9549d050e6

Latest - max width 300px long label:

<img width="1106" height="262" alt="Screenshot 2026-07-23 at 11 29 24 AM" src="https://github.com/user-attachments/assets/741fddbd-f78d-4578-a025-bddf64a81c25" />


## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

Test coverage:
- `CreateFleetModal.tests.tsx`, `RenameFleetModal.tests.tsx` — new case per file asserting the name input's `maxLength === 255`.
- `AddCertificateModal.tests.tsx`, `Variables.tests.tsx` — the existing "shows too-long error when pasting 256 chars" tests are now unreachable via the DOM cap; converted to `maxLength === 255` assertions.
- `ee/server/service/teams_test.go` — `TestNewTeamNameValidation`, `TestModifyTeamNameValidation`, and `TestApplyTeamSpecsNameValidation` each get two new cases (accepts at the limit, rejects one over with the expected error message).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Limited fleet, team, and other user-entered names and descriptions to 255 characters.
  * Replaced database errors for oversized names with clear validation messages.
  * Prevented long fleet and label names from overflowing tables, headers, modals, and host details.
  * Improved modal and dropdown layouts for long text.
* **Tests**
  * Added coverage for character limits, boundary values, and multibyte names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
