### PR TITLE
Ensure that the options and copy for both Add hosts - Android and iOS/iPadOS are the same

### DIFF
--- a/frontend/components/AddHostsModal/AddHostsModal.tests.tsx
+++ b/frontend/components/AddHostsModal/AddHostsModal.tests.tsx
@@ -160,7 +160,14 @@ describe("AddHostsModal", () => {
     await user.click(screen.getByRole("tab", { name: "iOS & iPadOS" }));
     expect(screen.queryByText(/Enrollment instructions:/i)).toBeInTheDocument();
     expect(screen.getByLabelText("Personal (BYOD)")).toBeInTheDocument();
-    expect(screen.getByLabelText("Company-owned")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Company-owned (fully-managed)")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "When the end user navigates to this URL, the enrollment profile will download in their browser. End users will have to install the profile to enroll to Fleet."
+      )
+    ).toBeInTheDocument();
   });
 
   it("renders enroll url input for android if android mdm is enabled", async () => {
@@ -186,6 +193,15 @@ describe("AddHostsModal", () => {
 
     await user.click(screen.getByRole("tab", { name: "Android" }));
     expect(screen.queryByText(/Enrollment instructions:/i)).toBeInTheDocument();
+    expect(screen.getByLabelText("Personal (BYOD)")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Company-owned (fully-managed)")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "When the end user navigates to this URL, the enrollment profile will download in their browser. End users will have to install the profile to enroll to Fleet."
+      )
+    ).toBeInTheDocument();
   });
 
   it("renders installer with secret", async () => {

--- a/frontend/components/AddHostsModal/PlatformWrapper/AndroidPanel/AndroidPanel.tsx
+++ b/frontend/components/AddHostsModal/PlatformWrapper/AndroidPanel/AndroidPanel.tsx
@@ -39,6 +39,11 @@ const AndroidPanel = ({ enrollSecret }: IAndroidPanelProps) => {
     "workProfile"
   );
 
+  const helpText =
+    "When the end user navigates to this URL, the enrollment profile " +
+    "will download in their browser. End users will have to install the profile " +
+    "to enroll to Fleet.";
+
   if (!config) return null;
 
   if (!isAndroidMdmEnabledAndConfigured) {
@@ -88,6 +93,7 @@ const AndroidPanel = ({ enrollSecret }: IAndroidPanelProps) => {
           inputWrapperClass={`${baseClass}__enroll-link`}
           name="enroll-link"
           value={url}
+          helpText={helpText}
         />
       </form>
     </div>

--- a/frontend/components/AddHostsModal/PlatformWrapper/IosIpadosPanel/IosIpadosPanel.tsx
+++ b/frontend/components/AddHostsModal/PlatformWrapper/IosIpadosPanel/IosIpadosPanel.tsx
@@ -67,7 +67,7 @@ const IosIpadosPanel = ({ enrollSecret }: IosIpadosPanelProps) => {
           <Radio
             name="iosIpadosEnrollmentType"
             id="iosIpadosCompanyOwned"
-            label="Company-owned"
+            label="Company-owned (fully-managed)"
             value="companyOwned"
             checked={enrollmentType === "companyOwned"}
             onChange={() => setEnrollmentType("companyOwned")}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #42721

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated iOS/iPadOS enrollment labeling to clarify the fully managed company-owned option.
  * Added enrollment guidance explaining that users must download the profile in their browser and install it to enroll in Fleet.
* **Tests**
  * Expanded coverage to verify the updated enrollment option and instructions on iOS/iPadOS and Android.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->