### PR TITLE
Fleet UI: Remove blue click flash on clickable table rows

### DIFF
--- a/changes/47530-my-device-policy-click-highlight
+++ b/changes/47530-my-device-policy-click-highlight
@@ -1,0 +1,1 @@
+- Removed the blue active-state background flash when clicking a row in a single-select data table (e.g., **My device > Policies**).

--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -283,9 +283,6 @@ $shadow-transition-width: 16px;
         &:hover {
           cursor: pointer;
         }
-        &:active {
-          background-color: $ui-vibrant-blue-10;
-        }
       }
 
       .clickable-row {

--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -261,7 +261,7 @@ $shadow-transition-width: 16px;
           background-color: $ui-off-white-opaque; // opaque needed for horizontal scroll shadow
         }
         &:focus-visible {
-          outline: 2px solid $core-focused-outline;
+          outline: 1px solid $core-focused-outline;
           background: $ui-off-white;
           border-radius: $border-radius;
         }


### PR DESCRIPTION
## Issue
Closes #47530

## Description
- Bug fix (root cause): `.single-row:active` set `background-color: $ui-vibrant-blue-10`, so clicking a row (e.g., a policy on **My device > Policies**) briefly flashed a pale purple/blue background in light mode and a dark navy in dark mode. It read as a stuck default/un-themed selected state.
- Dropped the `:active` rule. Hover still shows `cursor: pointer` and the off-white row background, so click affordance is preserved without the mis-themed flash.
- Thinned the row `:focus-visible` outline from 2px to 1px so keyboard focus on clickable rows matches the outline width used elsewhere (link mixin's `:focus-visible`).

## Screenrecording
- Clicking a policy on My device > Policies in light and dark mode.



https://github.com/user-attachments/assets/db7c9076-b73c-4e14-88da-ccc646554978

https://github.com/user-attachments/assets/81b94cf5-c109-4cb0-b55c-cd219c139308


## Testing


- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the blue active-state “flash” when clicking a row in single-select data tables (e.g., **My device > Policies**).
  * Kept the existing hover behavior and pointer cursor for clickable rows.
  * Reduced the table row focus-visible outline thickness for a subtler focus indicator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->