### PR TITLE
Fleet UI: Show tooltip for truncated vulnerabilities list in Update details modal

### DIFF
--- a/changes/48987-vulnerabilities-tooltip
+++ b/changes/48987-vulnerabilities-tooltip
@@ -1,0 +1,1 @@
+- Fixed an issue where the truncated vulnerabilities list in the Update details modal did not show a tooltip listing the remaining CVEs.

--- a/frontend/components/TruncatedTextList/TruncatedTextList.tsx
+++ b/frontend/components/TruncatedTextList/TruncatedTextList.tsx
@@ -119,10 +119,6 @@ const renderVisibleRow = ({
 
   const isTruncatedFirst = visibleCount === 0;
   const content = isTruncatedFirst ? truncatedFirstContent : standardContent;
-  const rowStyle: React.CSSProperties = {
-    whiteSpace: "nowrap",
-    overflow: "hidden",
-  };
   const rowClass = classnames(`${baseClass}__visible`, {
     [`${baseClass}__visible--truncated`]: isTruncatedFirst,
   });
@@ -130,16 +126,12 @@ const renderVisibleRow = ({
   if (onClick) {
     return (
       <Button variant="link" className={rowClass} onClick={onClick}>
-        <span style={rowStyle}>{content}</span>
+        <span>{content}</span>
       </Button>
     );
   }
 
-  return (
-    <span className={rowClass} style={rowStyle}>
-      {content}
-    </span>
-  );
+  return <span className={rowClass}>{content}</span>;
 };
 
 const TruncatedTextList = ({
@@ -207,24 +199,9 @@ const TruncatedTextList = ({
   const hidden = items.slice(visibleCount);
 
   return (
-    <div
-      ref={containerRef}
-      className={classnames(baseClass, className)}
-      style={{ position: "relative", minWidth: 0 }}
-    >
+    <div ref={containerRef} className={classnames(baseClass, className)}>
       {/* Hidden measurement layer — same font/size as the visible row */}
-      <div
-        className={`${baseClass}__measure`}
-        aria-hidden
-        style={{
-          position: "absolute",
-          top: 0,
-          left: 0,
-          visibility: "hidden",
-          pointerEvents: "none",
-          whiteSpace: "nowrap",
-        }}
-      >
+      <div className={`${baseClass}__measure`} aria-hidden>
         {items.map((item, i) => (
           <span
             // eslint-disable-next-line react/no-array-index-key

--- a/frontend/pages/hosts/details/components/InventoryVersions/InventoryVersions.tsx
+++ b/frontend/pages/hosts/details/components/InventoryVersions/InventoryVersions.tsx
@@ -14,20 +14,7 @@ import {
 import Card from "components/Card";
 import DataSet from "components/DataSet";
 import TooltipWrapper from "components/TooltipWrapper";
-
-const generateVulnerabilitiesValue = (vulnerabilities: string[]) => {
-  const first3 = vulnerabilities.slice(0, 3);
-  const rest = vulnerabilities.slice(3);
-
-  const first3Text = first3.join(", ");
-  const restText = `, +${rest.length} more`;
-
-  return (
-    <>
-      <span>{`${first3Text}${rest.length > 0 ? restText : ""}`}</span>
-    </>
-  );
-};
+import TruncatedTextList from "components/TruncatedTextList";
 
 const baseClass = "inventory-versions";
 
@@ -97,15 +84,14 @@ const InventoryVersion = ({
             textOnly
           />
         )}
-      </div>
-      {vulnerabilities && vulnerabilities.length !== 0 && (
-        <div className={`${baseClass}__row`}>
+        {vulnerabilities && vulnerabilities.length !== 0 && (
           <DataSet
+            className={`${baseClass}__vulnerabilities`}
             title="Vulnerabilities"
-            value={generateVulnerabilitiesValue(vulnerabilities)}
+            value={<TruncatedTextList items={vulnerabilities} />}
           />
-        </div>
-      )}
+        )}
+      </div>
       {!!installedPaths?.length &&
         installedPaths.map((path) => {
           // Find the signature info for this path

--- a/frontend/pages/hosts/details/components/InventoryVersions/_styles.scss
+++ b/frontend/pages/hosts/details/components/InventoryVersions/_styles.scss
@@ -3,8 +3,8 @@
   flex-direction: column;
   gap: $pad-small;
 
-  .data-set dd {
-    white-space: initial;
+  dt {
+    white-space: nowrap;
   }
 
   &__versions {
@@ -20,7 +20,20 @@
   }
   &__row {
     display: flex;
+    flex-wrap: wrap;
     gap: $pad-xxlarge;
+  }
+
+  // Fill the row so TruncatedTextList has a bounded width to measure against.
+  &__vulnerabilities {
+    flex: 1;
+    min-width: 0;
+
+    // dd is display:flex, so TruncatedTextList's outer div would size to its
+    // content by default and truncate too early. Stretch it to fill.
+    .truncated-text-list {
+      min-width: 100%;
+    }
   }
 
   &__sig-info {

--- a/frontend/pages/hosts/details/modals/InventoryVersionsModal/InventoryVersionsModal.tests.tsx
+++ b/frontend/pages/hosts/details/modals/InventoryVersionsModal/InventoryVersionsModal.tests.tsx
@@ -39,8 +39,9 @@ describe("SoftwareDetailsModal", () => {
     expect(screen.getByText("Hash:")).toBeVisible();
     expect(screen.getByText("mockhashhere")).toBeVisible();
 
-    // Vulnerabilities
-    expect(screen.getByText(/CVE-2020-0001/)).toBeVisible();
+    // Vulnerabilities — TruncatedTextList renders items in both a hidden
+    // measure layer and the visible row, so match all occurrences.
+    expect(screen.getAllByText(/CVE-2020-0001/).length).toBeGreaterThan(0);
 
     // Close button
     expect(screen.getByRole("button", { name: "Close" })).toBeVisible();


### PR DESCRIPTION
## Issue

Resolves #48987
Resolves #48984

## Description

The truncated vulnerabilities list in the Update details modal (e.g. `CVE-…, CVE-…, CVE-…, +8 more`) had no way to see the hidden CVEs. Swapped the ad-hoc first-3-plus-count renderer in `InventoryVersions` for the shared `TruncatedTextList` component, which shows all remaining CVEs in a tooltip on hover of the `+N more` pill.

Also tightened the surrounding row layout so DataSet fields no longer wrap text mid-value by accident — the row now flex-wraps as a whole (fixes #48984: \"Last opened\" and other DataSets drop cleanly to a new line when there isn't room, instead of the label breaking mid-word), and long values collapse into the `+N more` pill instead of breaking onto a second line.

Follow-up: #49237 tracks making the CVEs themselves clickable (out of scope here — needs a design decision on per-CVE links vs. pill-opens-modal).

## Screenshot

<img width="1158" height="659" alt="Screenshot 2026-07-13 at 12 29 24 PM" src="https://github.com/user-attachments/assets/14269157-f775-4804-820e-4bf1177c3c85" />


## Testing

- [x] Open a host's Update details / versions modal for a package with 10+ CVEs
- [x] Hover the \`+N more\` pill and confirm the tooltip lists every remaining CVE
- [x] Resize the modal / narrow the viewport and confirm the vulnerabilities row wraps to its own line and shows more CVEs before collapsing
- [x] Confirm rows with 1–3 vulnerabilities still render inline without a \`+N more\` pill
- [x] Confirm Version / Type / Bundle identifier / Last opened values stay on a single line and don't wrap mid-value; when the modal narrows, the whole DataSet wraps to the next line instead

- [x] QA'd all new/changed functionality manually