### PR TITLE
Host vitals label built on a custom host vital (BE + FE)

### DIFF
--- a/frontend/interfaces/label.ts
+++ b/frontend/interfaces/label.ts
@@ -25,14 +25,39 @@ export const LabelMembershipTypeToDisplayCopy: Record<
   host_vitals: "Host vitals",
 };
 
-export type LabelHostVitalsCriterion =
+export type LabelHostVitalsIdpCriterion =
   | "end_user_idp_group"
-  | "end_user_idp_department"; // for now, may expand to be configurable
+  | "end_user_idp_department";
 
-export type LabelLeafCriterion = {
-  vital: LabelHostVitalsCriterion;
+// A custom host vital is selected as a label criterion by referencing its
+// definition id. The IdP enum values self-identify their vital; the custom path
+// is a single sentinel, so the id (below) is what distinguishes one custom vital
+// from another.
+export const CUSTOM_HOST_VITAL_CRITERION = "custom_host_vital" as const;
+export type LabelHostVitalsCustomCriterion = typeof CUSTOM_HOST_VITAL_CRITERION;
+
+export type LabelHostVitalsCriterion =
+  | LabelHostVitalsIdpCriterion
+  | LabelHostVitalsCustomCriterion;
+
+// An IdP-based leaf: the vital enum self-identifies which vital, so no id.
+type LabelIdpLeafCriterion = {
+  vital: LabelHostVitalsIdpCriterion;
   value: string; // from user input
+  custom_host_vital_id?: never;
 };
+
+// A custom-host-vital leaf: the sentinel `vital` alone doesn't identify which
+// vital, so `custom_host_vital_id` is required.
+type LabelCustomLeafCriterion = {
+  vital: LabelHostVitalsCustomCriterion;
+  value: string; // from user input
+  custom_host_vital_id: number;
+};
+
+export type LabelLeafCriterion =
+  | LabelIdpLeafCriterion
+  | LabelCustomLeafCriterion;
 
 type LabelAndCriterion = {
   and: LabelHostVitalsCriteria[];

--- a/frontend/pages/labels/NewLabelPage/NewLabelPage.tsx
+++ b/frontend/pages/labels/NewLabelPage/NewLabelPage.tsx
@@ -10,6 +10,9 @@ import PATHS from "router/paths";
 import targetsAPI, { ITargetsSearchResponse } from "services/entities/targets";
 import idpAPI from "services/entities/idp";
 import labelsAPI from "services/entities/labels";
+import customHostVitalsAPI, {
+  IListCustomHostVitalsApiParams,
+} from "services/entities/custom_host_vitals";
 
 import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
 // TODO - move this table config near here once expanded this logic to encompass editing and
@@ -27,6 +30,7 @@ import useToggleSidePanel from "hooks/useToggleSidePanel";
 
 import { RouteComponentProps } from "react-router";
 import {
+  CUSTOM_HOST_VITAL_CRITERION,
   LabelHostVitalsCriterion,
   LabelMembershipType,
 } from "interfaces/label";
@@ -47,12 +51,23 @@ import Icon from "components/Icon";
 import TargetsInput from "components/TargetsInput";
 import Radio from "components/forms/fields/Radio";
 import PlatformField from "../components/PlatformField";
-import { validateNewLabelFormData, INewLabelFormValidation } from "./helpers";
+import {
+  validateNewLabelFormData,
+  INewLabelFormValidation,
+  buildCriterionOptionValue,
+  parseCriterionOptionValue,
+  getVitalValuePlaceholder,
+} from "./helpers";
 
-const availableCriteria: {
+interface ICriterionOption {
   label: string;
-  value: LabelHostVitalsCriterion;
-}[] = [
+  // Dropdown value: an IdP criterion's stable enum value, or a synthetic
+  // `custom_host_vital:<id>` value for a custom host vital (see
+  // buildCriterionOptionValue / parseCriterionOptionValue).
+  value: string;
+}
+
+const IDP_CRITERIA: ICriterionOption[] = [
   { label: "Identity provider (IdP) group", value: "end_user_idp_group" },
   { label: "IdP department", value: "end_user_idp_department" },
 ];
@@ -81,6 +96,9 @@ export interface INewLabelFormData {
   // host vitals
   vital: LabelHostVitalsCriterion; // TODO - make use of recursive `LabelHostVitalsCriteria` type in future iterations to support logical combinations of different criteria
   vitalValue: string;
+  // Set only when `vital === CUSTOM_HOST_VITAL_CRITERION`; identifies the
+  // selected custom host vital definition.
+  customHostVitalId?: number;
 
   // manual
   targetedHosts: IHost[];
@@ -143,6 +161,7 @@ const NewLabelPage = ({
     platform,
     vital,
     vitalValue,
+    customHostVitalId,
     targetedHosts,
   } = formData;
 
@@ -205,28 +224,42 @@ const NewLabelPage = ({
   );
   const idpConfigured = !!scimIdPDetails?.last_request?.requested_at;
 
+  // Custom host vitals are a Fleet Free feature, so this query runs on all
+  // tiers. We fetch the full list (no search/pagination) to both gate the
+  // "Host vitals" label type and populate the criteria selector.
+  const customHostVitalsParams: IListCustomHostVitalsApiParams = {};
+  const { data: customHostVitalsData } = useQuery(
+    ["custom_host_vitals", customHostVitalsParams],
+    () => customHostVitalsAPI.getCustomHostVitals(customHostVitalsParams),
+    {
+      ...DEFAULT_USE_QUERY_OPTIONS,
+    }
+  );
+  const customHostVitals = customHostVitalsData?.custom_host_vitals ?? [];
+  const hasCustomHostVitals = customHostVitals.length > 0;
+
+  // Host vitals labels can be based on IdP groups/departments (Premium, once an
+  // IdP is configured) OR custom host vitals (any tier). The type is disabled
+  // only when neither source is available.
   let hostVitalsTooltipContent: React.ReactNode;
-  if (!isPremiumTier) {
+  if (!idpConfigured && !hasCustomHostVitals) {
     hostVitalsTooltipContent = (
       <>
-        Currently, host vitals labels are based on
-        <br />
-        identity provider (IdP) groups or departments.
-        <br />
-        IdP integration available in Fleet Premium.
-      </>
-    );
-  } else if (!idpConfigured) {
-    hostVitalsTooltipContent = (
-      <>
-        Currently, host vitals labels are based on
-        <br />
-        identity provider (IdP) groups or departments.
-        <br />
-        IdP has not been configured in integration settings.
+        To use host vitals labels, configure your IdP in integration settings or
+        add a custom host vital.
       </>
     );
   }
+
+  // Each custom host vital becomes its own selectable criterion. IdP criteria
+  // only appear when an IdP is configured.
+  const criterionOptions: ICriterionOption[] = [
+    ...(idpConfigured ? IDP_CRITERIA : []),
+    ...customHostVitals.map((customHostVital) => ({
+      label: customHostVital.name,
+      value: buildCriterionOptionValue(customHostVital.id),
+    })),
+  ];
 
   useEffect(() => {
     if (location.pathname.includes("dynamic")) {
@@ -289,11 +322,63 @@ const NewLabelPage = ({
     });
   };
 
-  const onTypeChange = (value: string): void => {
-    const newFormData = {
+  // The criteria dropdown carries a synthetic value for custom host vitals, so
+  // it can't reuse the generic `onInputChange` (which would set `vital` to the
+  // encoded string). Decode it back into `vital` + `customHostVitalId`.
+  const onCriterionChange = (optionValue: string): void => {
+    const {
+      vital: nextVital,
+      customHostVitalId: nextId,
+    } = parseCriterionOptionValue(optionValue);
+
+    const newFormData: INewLabelFormData = {
       ...formData,
-      type: value as LabelMembershipType,
+      vital: nextVital,
+      customHostVitalId: nextId,
     };
+    setFormData(newFormData);
+
+    const fullValidation = validateNewLabelFormData(newFormData);
+    setFormErrors((prev) => {
+      const next: INewLabelFormValidation = { ...prev, isValid: true };
+
+      if (prev.name) next.name = prev.name;
+      if (prev.description) next.description = prev.description;
+      if (prev.labelQuery) next.labelQuery = prev.labelQuery;
+      if (prev.criteria && fullValidation.criteria?.isValid) {
+        next.criteria = undefined;
+      } else if (prev.criteria) {
+        next.criteria = prev.criteria;
+      }
+
+      const fields = [
+        next.name,
+        next.description,
+        next.labelQuery,
+        next.criteria,
+      ];
+      next.isValid = fields.every((f) => !f || f.isValid);
+
+      return next;
+    });
+  };
+
+  const onTypeChange = (value: string): void => {
+    const nextType = value as LabelMembershipType;
+    const newFormData: INewLabelFormData = {
+      ...formData,
+      type: nextType,
+    };
+
+    // When switching to "host vitals", ensure the selected criterion is one the
+    // dropdown actually offers: the default `end_user_idp_group` is invalid when
+    // no IdP is configured (custom-host-vital-only case), so fall back to the
+    // first custom host vital.
+    if (nextType === "host_vitals" && !idpConfigured && hasCustomHostVitals) {
+      newFormData.vital = CUSTOM_HOST_VITAL_CRITERION;
+      newFormData.customHostVitalId = customHostVitals[0].id;
+    }
+
     setFormData(newFormData);
 
     const fullValidation = validateNewLabelFormData(newFormData);
@@ -474,7 +559,18 @@ const NewLabelPage = ({
           </>
         );
 
-      case "host_vitals":
+      case "host_vitals": {
+        // The selected criterion is identified by the dropdown's string value:
+        // IdP criteria use their stable enum value; each custom host vital uses
+        // a synthetic `custom_host_vital:<id>` value so multiple custom vitals
+        // are distinguishable in a single dropdown.
+        const selectedCriterionValue =
+          vital === CUSTOM_HOST_VITAL_CRITERION && customHostVitalId != null
+            ? buildCriterionOptionValue(customHostVitalId)
+            : vital;
+
+        const isCustomVitalSelected = vital === CUSTOM_HOST_VITAL_CRITERION;
+
         return (
           <div className={`${baseClass}__host_vitals-fields`}>
             <label className="form-field__label" htmlFor="criterion-and-value">
@@ -483,11 +579,10 @@ const NewLabelPage = ({
             <span id="criterion-and-value">
               <Dropdown
                 name="vital"
-                onChange={onInputChange}
-                parseTarget
-                value={vital}
+                onChange={onCriterionChange}
+                value={selectedCriterionValue}
                 error={formErrors.criteria?.message}
-                options={availableCriteria}
+                options={criterionOptions}
                 classname={`${baseClass}__criteria-dropdown`}
                 wrapperClassName={`${baseClass}__form-field ${baseClass}__form-field--criteria`}
               />
@@ -499,17 +594,18 @@ const NewLabelPage = ({
                 onBlur={onInputBlur}
                 value={vitalValue}
                 inputClassName={`${baseClass}__vital-value`}
-                placeholder={
-                  vital === "end_user_idp_group" ? "IT admins" : "Engineering"
-                }
+                placeholder={getVitalValuePlaceholder(vital)}
                 parseTarget
               />
             </span>
             <span className="form-field__help-text">
-              Currently, label criteria can be IdP group or department.
+              {isCustomVitalSelected
+                ? "Label criteria is based on the selected custom host vital."
+                : "Currently, label criteria can be IdP group, department, or a custom host vital."}
             </span>
           </div>
         );
+      }
 
       case "manual":
         return (

--- a/frontend/pages/labels/NewLabelPage/NewLabelPage.tsx
+++ b/frontend/pages/labels/NewLabelPage/NewLabelPage.tsx
@@ -57,6 +57,7 @@ import {
   buildCriterionOptionValue,
   parseCriterionOptionValue,
   getVitalValuePlaceholder,
+  getCriterionHelpText,
 } from "./helpers";
 
 interface ICriterionOption {
@@ -569,8 +570,6 @@ const NewLabelPage = ({
             ? buildCriterionOptionValue(customHostVitalId)
             : vital;
 
-        const isCustomVitalSelected = vital === CUSTOM_HOST_VITAL_CRITERION;
-
         return (
           <div className={`${baseClass}__host_vitals-fields`}>
             <label className="form-field__label" htmlFor="criterion-and-value">
@@ -599,9 +598,7 @@ const NewLabelPage = ({
               />
             </span>
             <span className="form-field__help-text">
-              {isCustomVitalSelected
-                ? "Label criteria is based on the selected custom host vital."
-                : "Currently, label criteria can be IdP group, department, or a custom host vital."}
+              {getCriterionHelpText(vital)}
             </span>
           </div>
         );

--- a/frontend/pages/labels/NewLabelPage/NewLabelPage.tsx
+++ b/frontend/pages/labels/NewLabelPage/NewLabelPage.tsx
@@ -244,10 +244,17 @@ const NewLabelPage = ({
   // only when neither source is available.
   let hostVitalsTooltipContent: React.ReactNode;
   if (!idpConfigured && !hasCustomHostVitals) {
-    hostVitalsTooltipContent = (
+    // IdP criteria are Premium-only, so a Free-tier admin can't "configure your
+    // IdP" — point them at the custom host vital path instead.
+    hostVitalsTooltipContent = isPremiumTier ? (
       <>
         To use host vitals labels, configure your IdP in integration settings or
         add a custom host vital.
+      </>
+    ) : (
+      <>
+        To use host vitals labels, add a custom host vital. Identity provider
+        (IdP) group and department criteria are available in Fleet Premium.
       </>
     );
   }

--- a/frontend/pages/labels/NewLabelPage/helpers.tests.ts
+++ b/frontend/pages/labels/NewLabelPage/helpers.tests.ts
@@ -4,6 +4,7 @@ import {
   buildCriterionOptionValue,
   parseCriterionOptionValue,
   getVitalValuePlaceholder,
+  getCriterionHelpText,
 } from "./helpers";
 
 describe("NewLabelPage helpers", () => {
@@ -54,6 +55,20 @@ describe("NewLabelPage helpers", () => {
     it("returns a generic placeholder for custom host vitals", () => {
       expect(getVitalValuePlaceholder(CUSTOM_HOST_VITAL_CRITERION)).toBe(
         "Value"
+      );
+    });
+  });
+
+  describe("getCriterionHelpText", () => {
+    it("is specific to the selected criterion", () => {
+      expect(getCriterionHelpText("end_user_idp_group")).toBe(
+        "Label criteria is based on the end user's IdP group."
+      );
+      expect(getCriterionHelpText("end_user_idp_department")).toBe(
+        "Label criteria is based on the end user's IdP department."
+      );
+      expect(getCriterionHelpText(CUSTOM_HOST_VITAL_CRITERION)).toBe(
+        "Label criteria is based on the selected custom host vital."
       );
     });
   });

--- a/frontend/pages/labels/NewLabelPage/helpers.tests.ts
+++ b/frontend/pages/labels/NewLabelPage/helpers.tests.ts
@@ -1,0 +1,60 @@
+import { CUSTOM_HOST_VITAL_CRITERION } from "interfaces/label";
+
+import {
+  buildCriterionOptionValue,
+  parseCriterionOptionValue,
+  getVitalValuePlaceholder,
+} from "./helpers";
+
+describe("NewLabelPage helpers", () => {
+  describe("buildCriterionOptionValue / parseCriterionOptionValue", () => {
+    it("encodes a custom host vital id into the option value", () => {
+      expect(buildCriterionOptionValue(5)).toBe("custom_host_vital:5");
+    });
+
+    it("decodes a custom host vital option value back to vital + id", () => {
+      expect(parseCriterionOptionValue("custom_host_vital:5")).toEqual({
+        vital: CUSTOM_HOST_VITAL_CRITERION,
+        customHostVitalId: 5,
+      });
+    });
+
+    it("decodes an IdP option value with no custom id", () => {
+      expect(parseCriterionOptionValue("end_user_idp_group")).toEqual({
+        vital: "end_user_idp_group",
+      });
+      expect(parseCriterionOptionValue("end_user_idp_department")).toEqual({
+        vital: "end_user_idp_department",
+      });
+    });
+
+    it("round-trips any custom host vital id", () => {
+      [1, 42, 1000, 999999].forEach((id) => {
+        const parsed = parseCriterionOptionValue(buildCriterionOptionValue(id));
+        expect(parsed.vital).toBe(CUSTOM_HOST_VITAL_CRITERION);
+        expect(parsed.customHostVitalId).toBe(id);
+      });
+    });
+
+    it("does not treat an IdP value as a custom vital", () => {
+      const parsed = parseCriterionOptionValue("end_user_idp_group");
+      expect(parsed.vital).toBe("end_user_idp_group");
+      expect(parsed.customHostVitalId).toBeUndefined();
+    });
+  });
+
+  describe("getVitalValuePlaceholder", () => {
+    it("returns IdP-specific placeholders", () => {
+      expect(getVitalValuePlaceholder("end_user_idp_group")).toBe("IT admins");
+      expect(getVitalValuePlaceholder("end_user_idp_department")).toBe(
+        "Engineering"
+      );
+    });
+
+    it("returns a generic placeholder for custom host vitals", () => {
+      expect(getVitalValuePlaceholder(CUSTOM_HOST_VITAL_CRITERION)).toBe(
+        "Value"
+      );
+    });
+  });
+});

--- a/frontend/pages/labels/NewLabelPage/helpers.ts
+++ b/frontend/pages/labels/NewLabelPage/helpers.ts
@@ -33,6 +33,16 @@ export const getVitalValuePlaceholder = (vital: LabelHostVitalsCriterion) => {
   return "Value";
 };
 
+export const getCriterionHelpText = (vital: LabelHostVitalsCriterion) => {
+  if (vital === "end_user_idp_group") {
+    return "Label criteria is based on the end user's IdP group.";
+  }
+  if (vital === "end_user_idp_department") {
+    return "Label criteria is based on the end user's IdP department.";
+  }
+  return "Label criteria is based on the selected custom host vital.";
+};
+
 export interface INewLabelFormValidation {
   isValid: boolean;
   name?: { isValid: boolean; message?: string };

--- a/frontend/pages/labels/NewLabelPage/helpers.ts
+++ b/frontend/pages/labels/NewLabelPage/helpers.ts
@@ -1,4 +1,37 @@
+import {
+  CUSTOM_HOST_VITAL_CRITERION,
+  LabelHostVitalsCriterion,
+} from "interfaces/label";
+
 import { INewLabelFormData } from "./NewLabelPage";
+
+// The criteria dropdown needs a single string per option, but custom host
+// vitals all share the `custom_host_vital` criterion value, so the definition
+// id is encoded into the option value and decoded on selection.
+export const buildCriterionOptionValue = (customHostVitalId: number) =>
+  `${CUSTOM_HOST_VITAL_CRITERION}:${customHostVitalId}`;
+
+export const parseCriterionOptionValue = (
+  optionValue: string
+): { vital: LabelHostVitalsCriterion; customHostVitalId?: number } => {
+  if (optionValue.startsWith(`${CUSTOM_HOST_VITAL_CRITERION}:`)) {
+    return {
+      vital: CUSTOM_HOST_VITAL_CRITERION,
+      customHostVitalId: Number(optionValue.split(":")[1]),
+    };
+  }
+  return { vital: optionValue as LabelHostVitalsCriterion };
+};
+
+export const getVitalValuePlaceholder = (vital: LabelHostVitalsCriterion) => {
+  if (vital === "end_user_idp_group") {
+    return "IT admins";
+  }
+  if (vital === "end_user_idp_department") {
+    return "Engineering";
+  }
+  return "Value";
+};
 
 export interface INewLabelFormValidation {
   isValid: boolean;
@@ -82,6 +115,20 @@ const FORM_VALIDATIONS: IFormValidations = {
             return true;
           }
           return formData.vitalValue.trim().length > 0;
+        },
+        message: "Label criteria must be completed",
+      },
+      {
+        // A custom-vital criterion is incomplete without a selected definition id.
+        name: "customVitalRequiresId",
+        isValid: (formData) => {
+          if (
+            formData.type !== "host_vitals" ||
+            formData.vital !== CUSTOM_HOST_VITAL_CRITERION
+          ) {
+            return true;
+          }
+          return formData.customHostVitalId != null;
         },
         message: "Label criteria must be completed",
       },

--- a/frontend/services/entities/labels.ts
+++ b/frontend/services/entities/labels.ts
@@ -2,7 +2,11 @@
 import sendRequest from "services";
 import endpoints from "utilities/endpoints";
 import helpers from "utilities/helpers";
-import { ILabel, ILabelSummary } from "interfaces/label";
+import {
+  CUSTOM_HOST_VITAL_CRITERION,
+  ILabel,
+  ILabelSummary,
+} from "interfaces/label";
 import { IDynamicLabelFormData } from "pages/labels/components/DynamicLabelForm/DynamicLabelForm";
 import { IManualLabelFormData } from "pages/labels/components/ManualLabelForm/ManualLabelForm";
 import { IHost } from "interfaces/host";
@@ -66,9 +70,14 @@ const generateCreateLabelBody = (formData: INewLabelFormData) => {
       return {
         name: formData.name,
         description: formData.description,
+        // `custom_host_vital_id` is only sent for the custom-vital path
         criteria: {
           vital: formData.vital,
           value: formData.vitalValue,
+          ...(formData.vital === CUSTOM_HOST_VITAL_CRITERION &&
+          formData.customHostVitalId != null
+            ? { custom_host_vital_id: formData.customHostVitalId }
+            : {}),
         },
       };
     default:

--- a/server/datastore/mysql/custom_host_vitals.go
+++ b/server/datastore/mysql/custom_host_vitals.go
@@ -3,6 +3,7 @@ package mysql
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -118,7 +119,7 @@ func (ds *Datastore) DeleteCustomHostVital(ctx context.Context, id uint) (name s
 		}
 
 		// Refuse to delete a definition still referenced by a script/profile.
-		if usedByInfo, err := customHostVitalUsedBy(ctx, tx, id, name); err != nil {
+		if usedByInfo, err := ds.customHostVitalUsedBy(ctx, tx, id, name); err != nil {
 			return ctxerr.Wrap(ctx, err, "checking custom host vital references")
 		} else if usedByInfo != nil {
 			return ctxerr.Wrap(ctx, &fleet.CustomHostVitalUsedError{CustomHostVitalUsedInfo: *usedByInfo}, "found custom host vital in use")
@@ -154,7 +155,7 @@ type customHostVitalRefEntity struct {
 // vital id. It returns a *fleet.CustomHostVitalUsedInfo describing the first
 // referencing entity found, or nil if unreferenced. Mirrors the scan structure
 // of DeleteSecretVariable. The second return is a real DB error.
-func customHostVitalUsedBy(ctx context.Context, tx sqlx.ExtContext, id uint, name string) (*fleet.CustomHostVitalUsedInfo, error) {
+func (ds *Datastore) customHostVitalUsedBy(ctx context.Context, tx sqlx.ExtContext, id uint, name string) (*fleet.CustomHostVitalUsedInfo, error) {
 	// The token embeds the numeric id (survives renames), so match by id, not name.
 	token := fmt.Sprintf("%s%d", fleet.CustomHostVitalPrefix, id)
 
@@ -227,12 +228,49 @@ func customHostVitalUsedBy(ctx context.Context, tx sqlx.ExtContext, id uint, nam
 					CustomHostVitalID:   id,
 					CustomHostVitalName: name,
 					Entity: fleet.EntityUsingCustomHostVital{
-						Type:      e.Type,
+						Type:      fleet.CustomHostVitalEntity(e.Type),
 						Name:      e.Name,
 						FleetName: e.FleetName,
 					},
 				}, nil
 			}
+		}
+	}
+
+	// Host-vitals labels reference the vital by id inside their criteria JSON
+	// (not by the $FLEET_HOST_VITAL_<id> token), so they need a structured check
+	// rather than the content-token scan above.
+	var labels []struct {
+		Name     string          `db:"name"`
+		FleetName string         `db:"team_name"`
+		Criteria json.RawMessage `db:"criteria"`
+	}
+	labelStmt := `SELECT l.name, COALESCE(t.name, 'Unassigned') AS team_name, l.criteria
+		FROM labels l
+		LEFT JOIN teams t ON t.id = l.team_id
+		WHERE l.label_membership_type = ? AND l.criteria IS NOT NULL`
+	if err := sqlx.SelectContext(ctx, tx, &labels, labelStmt, fleet.LabelMembershipTypeHostVitals); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "get host vitals label criteria")
+	}
+	for _, l := range labels {
+		var criteria fleet.HostVitalCriteria
+		// A label with malformed criteria is already broken; skip it rather than
+		// block the delete on it.
+		if err := json.Unmarshal(l.Criteria, &criteria); err != nil {
+			ds.logger.WarnContext(ctx, "skipping host vitals label with unparseable criteria during custom host vital delete-protection scan",
+				"label", l.Name, "error", err)
+			continue
+		}
+		if criteria.CustomHostVitalID != nil && *criteria.CustomHostVitalID == id {
+			return &fleet.CustomHostVitalUsedInfo{
+				CustomHostVitalID:   id,
+				CustomHostVitalName: name,
+				Entity: fleet.EntityUsingCustomHostVital{
+					Type:      fleet.CustomHostVitalEntityLabel,
+					Name:      l.Name,
+					FleetName: l.FleetName,
+				},
+			}, nil
 		}
 	}
 

--- a/server/datastore/mysql/custom_host_vitals.go
+++ b/server/datastore/mysql/custom_host_vitals.go
@@ -241,9 +241,9 @@ func (ds *Datastore) customHostVitalUsedBy(ctx context.Context, tx sqlx.ExtConte
 	// (not by the $FLEET_HOST_VITAL_<id> token), so they need a structured check
 	// rather than the content-token scan above.
 	var labels []struct {
-		Name     string          `db:"name"`
-		FleetName string         `db:"team_name"`
-		Criteria json.RawMessage `db:"criteria"`
+		Name      string          `db:"name"`
+		FleetName string          `db:"team_name"`
+		Criteria  json.RawMessage `db:"criteria"`
 	}
 	labelStmt := `SELECT l.name, COALESCE(t.name, 'Unassigned') AS team_name, l.criteria
 		FROM labels l

--- a/server/datastore/mysql/custom_host_vitals_test.go
+++ b/server/datastore/mysql/custom_host_vitals_test.go
@@ -271,7 +271,7 @@ func testDeleteUsedCustomHostVital(t *testing.T, ds *Datastore) {
 		require.ErrorAs(t, err, &useErr)
 		require.Equal(t, id, useErr.CustomHostVitalID)
 		require.Equal(t, "FUNCTION", useErr.CustomHostVitalName)
-		require.Equal(t, "apple_profile", useErr.Entity.Type)
+		require.Equal(t, fleet.CustomHostVitalEntityAppleProfile, useErr.Entity.Type)
 		require.Equal(t, "Name0", useErr.Entity.Name)
 		require.Equal(t, "Unassigned", useErr.Entity.FleetName)
 
@@ -299,7 +299,7 @@ func testDeleteUsedCustomHostVital(t *testing.T, ds *Datastore) {
 		require.ErrorAs(t, err, &useErr)
 		require.Equal(t, id, useErr.CustomHostVitalID)
 		require.Equal(t, "FUNCTION", useErr.CustomHostVitalName)
-		require.Equal(t, "apple_declaration", useErr.Entity.Type)
+		require.Equal(t, fleet.CustomHostVitalEntityAppleDeclaration, useErr.Entity.Type)
 		require.Equal(t, "decl-1", useErr.Entity.Name)
 		require.Equal(t, "Foobar", useErr.Entity.FleetName)
 
@@ -319,7 +319,7 @@ func testDeleteUsedCustomHostVital(t *testing.T, ds *Datastore) {
 		require.ErrorAs(t, err, &useErr)
 		require.Equal(t, id, useErr.CustomHostVitalID)
 		require.Equal(t, "FUNCTION", useErr.CustomHostVitalName)
-		require.Equal(t, "windows_profile", useErr.Entity.Type)
+		require.Equal(t, fleet.CustomHostVitalEntityWindowsProfile, useErr.Entity.Type)
 		require.Equal(t, "zoo", useErr.Entity.Name)
 		require.Equal(t, "Unassigned", useErr.Entity.FleetName)
 
@@ -340,7 +340,7 @@ func testDeleteUsedCustomHostVital(t *testing.T, ds *Datastore) {
 		require.ErrorAs(t, err, &useErr)
 		require.Equal(t, id, useErr.CustomHostVitalID)
 		require.Equal(t, "FUNCTION", useErr.CustomHostVitalName)
-		require.Equal(t, "script", useErr.Entity.Type)
+		require.Equal(t, fleet.CustomHostVitalEntityScript, useErr.Entity.Type)
 		require.Equal(t, "collect.sh", useErr.Entity.Name)
 		require.Equal(t, "Foobar", useErr.Entity.FleetName)
 
@@ -372,7 +372,7 @@ func testDeleteUsedCustomHostVital(t *testing.T, ds *Datastore) {
 		require.ErrorAs(t, err, &useErr)
 		require.Equal(t, id, useErr.CustomHostVitalID)
 		require.Equal(t, "FUNCTION", useErr.CustomHostVitalName)
-		require.Equal(t, "software_installer", useErr.Entity.Type)
+		require.Equal(t, fleet.CustomHostVitalEntitySoftwareInstaller, useErr.Entity.Type)
 		require.Equal(t, "chv-del-title", useErr.Entity.Name)
 		require.Equal(t, "Foobar", useErr.Entity.FleetName)
 
@@ -392,11 +392,41 @@ func testDeleteUsedCustomHostVital(t *testing.T, ds *Datastore) {
 		require.ErrorAs(t, err, &useErr)
 		require.Equal(t, id, useErr.CustomHostVitalID)
 		require.Equal(t, "FUNCTION", useErr.CustomHostVitalName)
-		require.Equal(t, "setup_experience_script", useErr.Entity.Type)
+		require.Equal(t, fleet.CustomHostVitalEntitySetupExperienceScript, useErr.Entity.Type)
 		require.Equal(t, "setup.sh", useErr.Entity.Name)
 		require.Equal(t, "Foobar", useErr.Entity.FleetName)
 
 		require.NoError(t, ds.DeleteSetupExperienceScript(ctx, &foobarTeam.ID))
+	})
+
+	t.Run("host vitals labels", func(t *testing.T) {
+		// A host-vitals label references the vital by id in its criteria JSON,
+		// not via the $FLEET_HOST_VITAL_<id> token.
+		criteria, err := json.Marshal(&fleet.HostVitalCriteria{
+			Vital:             new("custom_host_vital"),
+			Value:             new("Engineering"),
+			CustomHostVitalID: &id,
+		})
+		require.NoError(t, err)
+		label, err := ds.NewLabel(ctx, &fleet.Label{
+			Name:                "chv-del-label",
+			LabelType:           fleet.LabelTypeRegular,
+			LabelMembershipType: fleet.LabelMembershipTypeHostVitals,
+			HostVitalsCriteria:  new(json.RawMessage(criteria)),
+		})
+		require.NoError(t, err)
+
+		_, err = ds.DeleteCustomHostVital(ctx, id)
+		require.Error(t, err)
+		var useErr *fleet.CustomHostVitalUsedError
+		require.ErrorAs(t, err, &useErr)
+		require.Equal(t, id, useErr.CustomHostVitalID)
+		require.Equal(t, "FUNCTION", useErr.CustomHostVitalName)
+		require.Equal(t, fleet.CustomHostVitalEntityLabel, useErr.Entity.Type)
+		require.Equal(t, "chv-del-label", useErr.Entity.Name)
+		require.Equal(t, "Unassigned", useErr.Entity.FleetName)
+
+		require.NoError(t, ds.DeleteLabel(ctx, label.Name, fleet.TeamFilter{User: test.UserAdmin}))
 	})
 
 	// With all references removed, delete now succeeds.

--- a/server/datastore/mysql/labels_test.go
+++ b/server/datastore/mysql/labels_test.go
@@ -102,6 +102,7 @@ func TestLabels(t *testing.T) {
 		{"ApplyLabelSpecsWithPlatformChange", testApplyLabelSpecsWithPlatformChange},
 		{"UpdateLabelMembershipByHostCriteria", testUpdateLabelMembershipByHostCriteria},
 		{"UpdateLabelMembershipByHostCriteriaIDP", testUpdateLabelMembershipByHostCriteriaIDP},
+		{"UpdateLabelMembershipByHostCriteriaCustomHostVital", testUpdateLabelMembershipByHostCriteriaCustomHostVital},
 		{"TeamLabels", testTeamLabels},
 		{"UpdateLabelMembershipForTransferredHost", testUpdateLabelMembershipForTransferredHost},
 		{"SetAsideLabels", testSetAsideLabels},
@@ -3010,6 +3011,105 @@ func testUpdateLabelMembershipByHostCriteriaIDP(t *testing.T, ds *Datastore) {
 	require.ElementsMatch(t, []uint{hosts[0].ID}, hostIDs(team1Hosts))
 
 	_ = team2 // team2 is used only to give host2 an out-of-team membership.
+}
+
+// testUpdateLabelMembershipByHostCriteriaCustomHostVital exercises the real
+// custom-host-vital query path: membership is a host's stored value for a
+// specific custom_host_vital_id matching the criterion value. It verifies
+// multi-host isolation (one host's value doesn't leak to another), that the
+// criterion is scoped to its vital id (a matching value on a different vital
+// does not count), and that team-scoped labels only include in-team hosts.
+func testUpdateLabelMembershipByHostCriteriaCustomHostVital(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	team1, err := ds.NewTeam(ctx, &fleet.Team{Name: "chv-team1"})
+	require.NoError(t, err)
+	team2, err := ds.NewTeam(ctx, &fleet.Team{Name: "chv-team2"})
+	require.NoError(t, err)
+
+	// host1 -> team1, host2 -> team2, host3 -> global, host4 -> global.
+	hosts := make([]*fleet.Host, 4)
+	teamIDs := []*uint{&team1.ID, &team2.ID, nil, nil}
+	for i := range 4 {
+		host, err := ds.NewHost(ctx, &fleet.Host{
+			OsqueryHostID:  new(fmt.Sprintf("chv-%d", i)),
+			NodeKey:        new(fmt.Sprintf("chv-%d", i)),
+			UUID:           fmt.Sprintf("chv-uuid%d", i),
+			Hostname:       fmt.Sprintf("chv-host%d.local", i),
+			HardwareSerial: fmt.Sprintf("chv-hwd%d", i),
+			Platform:       "darwin",
+			TeamID:         teamIDs[i],
+		})
+		require.NoError(t, err)
+		hosts[i] = host
+	}
+
+	vitalA, err := ds.CreateCustomHostVital(ctx, "Department")
+	require.NoError(t, err)
+	vitalB, err := ds.CreateCustomHostVital(ctx, "Function")
+	require.NoError(t, err)
+
+	// host1 & host4: vitalA = "Engineering" (should match).
+	// host2: vitalA = "Sales" (wrong value -> excluded).
+	// host3: vitalB = "Engineering" (right value but wrong vital -> excluded),
+	//        and vitalA = "Sales" so it also has a value for the target vital.
+	require.NoError(t, ds.SetHostCustomHostVitalValue(ctx, hosts[0].ID, vitalA.ID, "Engineering"))
+	require.NoError(t, ds.SetHostCustomHostVitalValue(ctx, hosts[3].ID, vitalA.ID, "Engineering"))
+	require.NoError(t, ds.SetHostCustomHostVitalValue(ctx, hosts[1].ID, vitalA.ID, "Sales"))
+	require.NoError(t, ds.SetHostCustomHostVitalValue(ctx, hosts[2].ID, vitalA.ID, "Sales"))
+	require.NoError(t, ds.SetHostCustomHostVitalValue(ctx, hosts[2].ID, vitalB.ID, "Engineering"))
+
+	criteria, err := json.Marshal(&fleet.HostVitalCriteria{
+		Vital:             new("custom_host_vital"),
+		Value:             new("Engineering"),
+		CustomHostVitalID: &vitalA.ID,
+	})
+	require.NoError(t, err)
+
+	newCHVLabel := func(name string, teamID *uint) *fleet.Label {
+		lbl, err := ds.NewLabel(ctx, &fleet.Label{
+			Name:                name,
+			TeamID:              teamID,
+			LabelType:           fleet.LabelTypeRegular,
+			LabelMembershipType: fleet.LabelMembershipTypeHostVitals,
+			HostVitalsCriteria:  new(json.RawMessage(criteria)),
+		})
+		require.NoError(t, err)
+		return lbl
+	}
+
+	filter := fleet.TeamFilter{User: test.UserAdmin}
+
+	// Global label: host1 and host4 (vitalA = "Engineering"). host2 has the
+	// wrong value, host3 matches the value only on vitalB.
+	globalLabel := newCHVLabel("chv-global", nil)
+	updated, err := ds.UpdateLabelMembershipByHostCriteria(ctx, globalLabel)
+	require.NoError(t, err)
+	require.Equal(t, 2, updated.HostCount)
+	globalHosts, err := ds.ListHostsInLabel(ctx, filter, globalLabel.ID, fleet.HostListOptions{})
+	require.NoError(t, err)
+	require.ElementsMatch(t, []uint{hosts[0].ID, hosts[3].ID}, hostIDs(globalHosts))
+
+	// Team1 label: only host1, even though host4 also matches (it's global).
+	team1Label := newCHVLabel("chv-team1-label", &team1.ID)
+	updated, err = ds.UpdateLabelMembershipByHostCriteria(ctx, team1Label)
+	require.NoError(t, err)
+	require.Equal(t, 1, updated.HostCount)
+	team1Hosts, err := ds.ListHostsInLabel(ctx, filter, team1Label.ID, fleet.HostListOptions{})
+	require.NoError(t, err)
+	require.ElementsMatch(t, []uint{hosts[0].ID}, hostIDs(team1Hosts))
+
+	// Changing a host's value re-computes membership: host4 leaves, host2 joins.
+	require.NoError(t, ds.SetHostCustomHostVitalValue(ctx, hosts[3].ID, vitalA.ID, "Sales"))
+	require.NoError(t, ds.SetHostCustomHostVitalValue(ctx, hosts[1].ID, vitalA.ID, "Engineering"))
+	updated, err = ds.UpdateLabelMembershipByHostCriteria(ctx, globalLabel)
+	require.NoError(t, err)
+	require.Equal(t, 2, updated.HostCount)
+	globalHosts, err = ds.ListHostsInLabel(ctx, filter, globalLabel.ID, fleet.HostListOptions{})
+	require.NoError(t, err)
+	require.ElementsMatch(t, []uint{hosts[0].ID, hosts[1].ID}, hostIDs(globalHosts))
+
+	_ = team2 // team2 only gives host2 an out-of-team membership.
 }
 
 func hostIDs(hosts []*fleet.Host) []uint {

--- a/server/fleet/custom_host_vitals.go
+++ b/server/fleet/custom_host_vitals.go
@@ -97,11 +97,22 @@ func (e MissingCustomHostVitalValueError) Error() string {
 	return fmt.Sprintf("Couldn't populate custom host vital%s %s: no value set for this host", plural, strings.Join(tokens, ", "))
 }
 
+// CustomHostVitalEntity identifies the kind of entity that can reference a custom host vital.
+type CustomHostVitalEntity string
+
+const (
+	CustomHostVitalEntityScript                CustomHostVitalEntity = "script"
+	CustomHostVitalEntityAppleProfile          CustomHostVitalEntity = "apple_profile"
+	CustomHostVitalEntityAppleDeclaration      CustomHostVitalEntity = "apple_declaration"
+	CustomHostVitalEntityWindowsProfile        CustomHostVitalEntity = "windows_profile"
+	CustomHostVitalEntitySoftwareInstaller     CustomHostVitalEntity = "software_installer"
+	CustomHostVitalEntitySetupExperienceScript CustomHostVitalEntity = "setup_experience_script"
+	CustomHostVitalEntityLabel                 CustomHostVitalEntity = "label"
+)
+
 // Describes an entity that references a custom host vital.
 type EntityUsingCustomHostVital struct {
-	// "script", "apple_profile", "apple_declaration", "windows_profile",
-	// "software_installer", or "setup_experience_script".
-	Type string
+	Type CustomHostVitalEntity
 	// Name is the name of the entity.
 	Name string
 	// FleetName is the name of the fleet (team) the entity belongs to.
@@ -119,12 +130,14 @@ type CustomHostVitalUsedInfo struct {
 func (i CustomHostVitalUsedInfo) Message() string {
 	noun, action := "configuration profile", "Please delete the configuration profile and try again."
 	switch i.Entity.Type {
-	case "script":
+	case CustomHostVitalEntityScript:
 		noun, action = "script", "Please edit or delete the script and try again."
-	case "software_installer":
+	case CustomHostVitalEntitySoftwareInstaller:
 		noun, action = "software", "Please edit or delete the software and try again."
-	case "setup_experience_script":
+	case CustomHostVitalEntitySetupExperienceScript:
 		noun, action = "setup experience script", "Please edit or delete the setup experience script and try again."
+	case CustomHostVitalEntityLabel:
+		noun, action = "label", "Please edit or delete the label and try again."
 	}
 	return fmt.Sprintf(
 		"Custom host vital %q (used as $%s%d) is used by the %q %s in the %q fleet. %s",

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -485,6 +485,7 @@ const (
 	HostVitalTypeDomestic   HostVitalType = iota // Domestic vitals are those that are stored in the host table
 	HostVitalTypeForeign                         // Foreign vitals are those that are stored in a separate table and joined to the host table
 	HostVitalTypeAdditional                      // Additional vitals are those that are stored in the host_additional table as a JSON blob
+	HostVitalTypeCustom                          // Custom vitals are stored per-host in host_custom_host_vitals, scoped by a custom_host_vital_id
 )
 
 type HostVital struct {
@@ -527,6 +528,15 @@ var hostVitals = map[string]HostVital{
 		DataType:          "string",
 		ForeignVitalGroup: ptr.String("idp"),
 		Path:              "scim_users.department",
+	},
+	// custom_host_vital does not self-identify which vital (unlike the IDP enum
+	// values); the criterion's custom_host_vital_id selects it and scopes the
+	// per-host value join built in parseHostVitalCriteria.
+	"custom_host_vital": {
+		Name:      "Custom host vital",
+		VitalType: HostVitalTypeCustom,
+		DataType:  "string",
+		Path:      "host_custom_host_vitals.value",
 	},
 }
 

--- a/server/fleet/labels.go
+++ b/server/fleet/labels.go
@@ -31,11 +31,14 @@ const (
 )
 
 type HostVitalCriteria struct {
-	Vital    *string             `json:"vital,omitempty"`
-	Value    *string             `json:"value,omitempty"`
-	Operator *HostVitalOperator  `json:"operator,omitempty"`
-	And      []HostVitalCriteria `json:"and,omitempty"`
-	Or       []HostVitalCriteria `json:"or,omitempty"`
+	Vital    *string            `json:"vital,omitempty"`
+	Value    *string            `json:"value,omitempty"`
+	Operator *HostVitalOperator `json:"operator,omitempty"`
+	// CustomHostVitalID is required when Vital is "custom_host_vital": that name
+	// alone doesn't identify which custom vital to match, so the id selects it.
+	CustomHostVitalID *uint               `json:"custom_host_vital_id,omitempty"`
+	And               []HostVitalCriteria `json:"and,omitempty"`
+	Or                []HostVitalCriteria `json:"or,omitempty"`
 }
 
 type LabelPayload struct {
@@ -497,13 +500,30 @@ func parseHostVitalCriteria(criteria *HostVitalCriteria, foreignVitalsGroups map
 	if !ok {
 		return "", fmt.Errorf("unknown vital %s", *criteria.Vital)
 	}
-	// If the vital is a foreign vitals group, add it to the list of foreign vitals groups.
-	if vital.VitalType == HostVitalTypeForeign {
+	switch vital.VitalType {
+	case HostVitalTypeForeign:
+		// If the vital is a foreign vitals group, add it to the list of foreign vitals groups.
 		foreignVitalsGroup, ok := hostForeignVitalGroups[*vital.ForeignVitalGroup]
 		if !ok {
 			return "", fmt.Errorf("unknown foreign vital group %s", *vital.ForeignVitalGroup)
 		}
 		foreignVitalsGroups[&foreignVitalsGroup] = struct{}{}
+	case HostVitalTypeCustom:
+		if criteria.CustomHostVitalID == nil {
+			return "", errors.New("custom_host_vital criteria must have a custom_host_vital_id")
+		}
+		// Join only this vital's per-host rows. The id is appended to values
+		// before the criterion value below because the join is concatenated
+		// ahead of the WHERE clause in CalculateHostVitalsQuery, so its
+		// placeholder must bind first. A fresh group per call is fine: only a
+		// single criterion is supported (And/Or are rejected above), so at most
+		// one parameterized join exists.
+		group := HostForeignVitalGroup{
+			Name:  "custom_host_vital",
+			Query: "JOIN host_custom_host_vitals ON (hosts.id = host_custom_host_vitals.host_id AND host_custom_host_vitals.custom_host_vital_id = ?)",
+		}
+		foreignVitalsGroups[&group] = struct{}{}
+		*values = append(*values, *criteria.CustomHostVitalID)
 	}
 	*values = append(*values, *criteria.Value)
 

--- a/server/service/labels.go
+++ b/server/service/labels.go
@@ -80,6 +80,9 @@ func (svc *Service) NewLabel(ctx context.Context, p fleet.LabelPayload) (*fleet.
 		if err != nil {
 			return nil, nil, fleet.NewInvalidArgumentError("criteria", fmt.Sprintf("invalid criteria: %s", err.Error()))
 		}
+		if err := svc.validateCustomHostVitalCriteria(ctx, label.HostVitalsCriteria); err != nil {
+			return nil, nil, err
+		}
 	} else {
 		if p.Query != "" && (len(p.Hosts) > 0 || len(p.HostIDs) > 0) {
 			return nil, nil, fleet.NewInvalidArgumentError("query", `Only one of "criteria", "query" or "hosts/host_ids" can be included in the request.`)
@@ -147,6 +150,33 @@ func (svc *Service) NewLabel(ctx context.Context, p fleet.LabelPayload) (*fleet.
 		return svc.ds.UpdateLabelMembershipByHostIDs(ctx, *label, manualHostIDs, filter)
 	}
 	return label, nil, nil
+}
+
+// validateCustomHostVitalCriteria verifies that a custom_host_vital criterion
+// references a custom host vital that actually exists. Without this a label
+// could be created against a stale or made-up id, which would silently match
+// zero hosts (the membership join finds no rows) instead of erroring.
+func (svc *Service) validateCustomHostVitalCriteria(ctx context.Context, raw *json.RawMessage) error {
+	if raw == nil {
+		return nil
+	}
+	var criteria fleet.HostVitalCriteria
+	if err := json.Unmarshal(*raw, &criteria); err != nil {
+		return fleet.NewInvalidArgumentError("criteria", fmt.Sprintf("invalid criteria: %s", err.Error()))
+	}
+	if criteria.CustomHostVitalID == nil {
+		return nil
+	}
+	id := *criteria.CustomHostVitalID
+
+	existing, err := svc.ds.GetCustomHostVitals(ctx, []uint{id})
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "validate custom host vital criteria")
+	}
+	if len(existing) == 0 {
+		return fleet.NewInvalidArgumentError("criteria", fmt.Sprintf("custom host vital %d does not exist", id))
+	}
+	return nil
 }
 
 // authorizeWriteLabelOnHosts verifies that the caller is authorized to write
@@ -680,6 +710,18 @@ func (svc *Service) ApplyLabelSpecs(ctx context.Context, specs []*fleet.LabelSpe
 		// Validate mutually exclusive field combinations per label membership type
 		if err := fleet.ValidateLabelMembershipFields(spec); err != nil {
 			return err.WithStatus(http.StatusUnprocessableEntity)
+		}
+		// Validate host vitals criteria structurally (unknown vital, missing
+		// custom_host_vital_id, etc.) and that any referenced custom vital
+		// exists, mirroring the checks in NewLabel so a bad spec fails at apply
+		// rather than silently matching no hosts at cron evaluation time.
+		if spec.LabelMembershipType == fleet.LabelMembershipTypeHostVitals {
+			if _, _, err := (&fleet.Label{HostVitalsCriteria: spec.HostVitalsCriteria}).CalculateHostVitalsQuery(); err != nil {
+				return fleet.NewInvalidArgumentError("criteria", fmt.Sprintf("invalid criteria: %s", err.Error())).WithStatus(http.StatusUnprocessableEntity)
+			}
+			if err := svc.validateCustomHostVitalCriteria(ctx, spec.HostVitalsCriteria); err != nil {
+				return err
+			}
 		}
 		if spec.LabelType == fleet.LabelTypeBuiltIn {
 			// We allow specs to contain built-in labels as long as they are not being modified.

--- a/server/service/labels_test.go
+++ b/server/service/labels_test.go
@@ -530,6 +530,46 @@ func TestApplyLabelSpecsWithBuiltInLabels(t *testing.T) {
 	assert.ErrorIs(t, err, assert.AnError)
 }
 
+func TestApplyLabelSpecsCustomHostVitalCriteria(t *testing.T) {
+	t.Parallel()
+	ds := new(mock.Store)
+	svc, ctx := newTestService(t, ds, nil, nil)
+	ctx = viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{ID: 1, GlobalRole: new(fleet.RoleAdmin)}})
+
+	specWithCriteria := func(criteria fleet.HostVitalCriteria) *fleet.LabelSpec {
+		raw, err := json.Marshal(&criteria)
+		require.NoError(t, err)
+		return &fleet.LabelSpec{
+			Name:                "custom-vital-spec",
+			LabelType:           fleet.LabelTypeRegular,
+			LabelMembershipType: fleet.LabelMembershipTypeHostVitals,
+			HostVitalsCriteria:  new(json.RawMessage(raw)),
+		}
+	}
+
+	// A custom_host_vital criterion without an id fails structural validation
+	// before any datastore call.
+	err := svc.ApplyLabelSpecs(ctx, []*fleet.LabelSpec{specWithCriteria(fleet.HostVitalCriteria{
+		Vital: new("custom_host_vital"),
+		Value: new("Engineering"),
+	})}, nil, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "custom_host_vital_id")
+
+	// A criterion referencing a non-existent custom vital is rejected.
+	ds.GetCustomHostVitalsFunc = func(ctx context.Context, ids []uint) ([]fleet.CustomHostVital, error) {
+		return nil, nil
+	}
+	err = svc.ApplyLabelSpecs(ctx, []*fleet.LabelSpec{specWithCriteria(fleet.HostVitalCriteria{
+		Vital:             new("custom_host_vital"),
+		Value:             new("Engineering"),
+		CustomHostVitalID: new(uint(999)),
+	})}, nil, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not exist")
+	require.True(t, ds.GetCustomHostVitalsFuncInvoked)
+}
+
 func TestLabelsWithReplica(t *testing.T) {
 	opts := &testing_utils.DatastoreTestOptions{DummyReplica: true}
 	ds := mysqltest.CreateMySQLDSWithOptions(t, opts)
@@ -1211,6 +1251,60 @@ func TestNewHostVitalsLabel(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "SELECT %s FROM %s JOIN host_scim_user ON (hosts.id = host_scim_user.host_id) JOIN scim_users ON (host_scim_user.scim_user_id = scim_users.id) LEFT JOIN scim_user_group ON (host_scim_user.scim_user_id = scim_user_group.scim_user_id) LEFT JOIN scim_groups ON (scim_user_group.group_id = scim_groups.id) WHERE scim_groups.display_name = ? GROUP BY hosts.id", query)
 		assert.Equal(t, `["admin"]`, string(queryValuesJson))
+	})
+
+	t.Run("create custom host vital label", func(t *testing.T) {
+		ds.GetCustomHostVitalsFunc = func(ctx context.Context, ids []uint) ([]fleet.CustomHostVital, error) {
+			return []fleet.CustomHostVital{{ID: 7, Name: "Department"}}, nil
+		}
+		ds.GetCustomHostVitalsFuncInvoked = false
+
+		lbl, _, err := svc.NewLabel(ctx, fleet.LabelPayload{
+			Name: "custom-vital-label",
+			Criteria: &fleet.HostVitalCriteria{
+				Vital:             new("custom_host_vital"),
+				Value:             new("Engineering"),
+				CustomHostVitalID: new(uint(7)),
+			},
+		})
+		require.NoError(t, err)
+		assert.True(t, ds.GetCustomHostVitalsFuncInvoked)
+		assert.Equal(t, fleet.LabelMembershipTypeHostVitals, lbl.LabelMembershipType)
+
+		query, queryValues, err := lbl.CalculateHostVitalsQuery()
+		require.NoError(t, err)
+		queryValuesJson, err := json.Marshal(queryValues)
+		require.NoError(t, err)
+		assert.Equal(t, "SELECT %s FROM %s JOIN host_custom_host_vitals ON (hosts.id = host_custom_host_vitals.host_id AND host_custom_host_vitals.custom_host_vital_id = ?) WHERE host_custom_host_vitals.value = ? GROUP BY hosts.id", query)
+		assert.JSONEq(t, `[7,"Engineering"]`, string(queryValuesJson))
+	})
+
+	t.Run("custom host vital label missing id is rejected", func(t *testing.T) {
+		_, _, err := svc.NewLabel(ctx, fleet.LabelPayload{
+			Name: "custom-vital-no-id",
+			Criteria: &fleet.HostVitalCriteria{
+				Vital: new("custom_host_vital"),
+				Value: new("Engineering"),
+			},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "custom_host_vital_id")
+	})
+
+	t.Run("custom host vital label with unknown id is rejected", func(t *testing.T) {
+		ds.GetCustomHostVitalsFunc = func(ctx context.Context, ids []uint) ([]fleet.CustomHostVital, error) {
+			return nil, nil
+		}
+		_, _, err := svc.NewLabel(ctx, fleet.LabelPayload{
+			Name: "custom-vital-bad-id",
+			Criteria: &fleet.HostVitalCriteria{
+				Vital:             new("custom_host_vital"),
+				Value:             new("Engineering"),
+				CustomHostVitalID: new(uint(999)),
+			},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "does not exist")
 	})
 }
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #48582

Host-vitals labels can currently only be keyed on IdP group/department, so admins can't build a label from a custom host vital. This adds a `custom_host_vital` label criterion — a host is a member when its stored value for the selected vital equals the criterion value — wired through label create, batch/GitOps validation, membership evaluation, and delete-protection, plus the New label UI. Targets the `44954-custom-host-vitals` feature branch.

# Checklist for submitter


- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

Will be added in feature branch.

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually

Created `Test label 1` label with criteria: "Department = Engineering" (`Department` is a custom host vital).

<img width="1396" height="658" alt="Screenshot 2026-07-13 at 11 15 17 PM" src="https://github.com/user-attachments/assets/38434ee8-302b-4293-af5e-f59e62189fd7" />

Set the host vital value to Engineering in two hosts:


<img width="1458" height="634" alt="Screenshot 2026-07-13 at 11 14 42 PM" src="https://github.com/user-attachments/assets/48a28794-22b3-4d99-b3f5-93b86dc930d9" />
<img width="1459" height="631" alt="Screenshot 2026-07-13 at 11 14 47 PM" src="https://github.com/user-attachments/assets/50653f8c-2d83-4827-88b9-d18b2e2e75e4" />

Verified label membership contains those two hosts:

<img width="1481" height="336" alt="Screenshot 2026-07-13 at 11 14 28 PM" src="https://github.com/user-attachments/assets/7a4a0124-c3d2-4a46-a1d3-e7273f581714" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating host-vitals labels using custom host vitals.
  * Custom host vital criteria now support filtering, label membership updates, and label specification application.
  * Added clearer value prompts and validation for selected custom vitals.

* **Bug Fixes**
  * Prevented deletion of custom host vitals referenced by labels.
  * Invalid or unknown custom vital references are now rejected during label creation and application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->