### PR TITLE
Fleet UI: Multi-package follow-ups — target section, banner icons, display-name save, observer download

### DIFF
--- a/frontend/components/InfoBanner/InfoBanner.tests.tsx
+++ b/frontend/components/InfoBanner/InfoBanner.tests.tsx
@@ -38,4 +38,19 @@ describe("InfoBanner - component", () => {
     const { container } = render(<InfoBanner icon="info" />);
     expect(container.firstChild).toHaveClass("info-banner__icon");
   });
+
+  it("uses the icon's default color when iconColor is omitted", () => {
+    // `info-outline` defaults to ui-fleet-black-75 per InfoOutline.tsx.
+    const { container } = render(<InfoBanner icon="info-outline" />);
+    const path = container.querySelector(".info-banner__leading-icon path");
+    expect(path?.getAttribute("fill")).toMatch(/ui-fleet-black-75/);
+  });
+
+  it("forwards iconColor to the leading Icon's fill", () => {
+    const { container } = render(
+      <InfoBanner icon="info-outline" iconColor="ui-fleet-black-50" />
+    );
+    const path = container.querySelector(".info-banner__leading-icon path");
+    expect(path?.getAttribute("fill")).toMatch(/ui-fleet-black-50/);
+  });
 });

--- a/frontend/components/InfoBanner/InfoBanner.tsx
+++ b/frontend/components/InfoBanner/InfoBanner.tsx
@@ -5,6 +5,7 @@ import Icon from "components/Icon";
 import Button from "components/buttons/Button";
 import { IconNames } from "components/icons";
 import Card from "components/Card";
+import { Colors } from "styles/var/colors";
 
 const baseClass = "info-banner";
 
@@ -24,6 +25,8 @@ export interface IInfoBannerProps {
    * switches from `space-between` to a left-aligned flex layout so the icon
    * groups with the text rather than getting pushed to the opposite edge. */
   icon?: IconNames;
+  /** Overrides the icon's default color when `icon` is set. */
+  iconColor?: Colors;
 }
 
 const InfoBanner = ({
@@ -35,6 +38,7 @@ const InfoBanner = ({
   cta,
   closable,
   icon,
+  iconColor,
 }: IInfoBannerProps) => {
   const wrapperClasses = classNames(
     baseClass,
@@ -49,7 +53,13 @@ const InfoBanner = ({
 
   const content = (
     <>
-      {icon && <Icon name={icon} className={`${baseClass}__leading-icon`} />}
+      {icon && (
+        <Icon
+          name={icon}
+          color={iconColor}
+          className={`${baseClass}__leading-icon`}
+        />
+      )}
       <div className={`${baseClass}__info`}>{children}</div>
 
       {(cta || closable) && (

--- a/frontend/components/SoftwareInstallPolicyBadges/SoftwareInstallPolicyBadges.tsx
+++ b/frontend/components/SoftwareInstallPolicyBadges/SoftwareInstallPolicyBadges.tsx
@@ -36,6 +36,7 @@ const SoftwareInstallPolicyBadges = ({ policyType }: IPatchBadgesProps) => {
       position="top"
       showArrow
       underline={false}
+      fixedPositionStrategy
     >
       <Icon name="refresh" color="ui-fleet-black-75" />
     </TooltipWrapper>

--- a/frontend/components/SoftwareInstallPolicyBadges/_styles.scss
+++ b/frontend/components/SoftwareInstallPolicyBadges/_styles.scss
@@ -1,0 +1,8 @@
+.software-install-policy-badges {
+  &__dynamic-policy-tooltip {
+    .component__tooltip-wrapper__element {
+      display: inline-flex;
+      align-items: center;
+    }
+  }
+}

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareCustomPackage/SoftwareCustomPackage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareCustomPackage/SoftwareCustomPackage.tsx
@@ -36,7 +36,11 @@ const baseClass = "software-custom-package";
 /** Shared GitOps-mode banner for the custom-package flows. Rendered by this
  * page (single-package add) and by `PackageForm`'s multi-package Add modal. */
 export const GitOpsCustomPackageBanner = () => (
-  <InfoBanner icon="error-outline" borderRadius="medium">
+  <InfoBanner
+    icon="info-outline"
+    iconColor="ui-fleet-black-50"
+    borderRadius="medium"
+  >
     Add custom packages in GitOps mode so Fleet can host your software. After
     adding, copy its SHA-256 hash into your YAML so the next GitOps workflow
     doesn&apos;t delete it.{" "}

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditIconModal/EditIconModal.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditIconModal/EditIconModal.tests.tsx
@@ -118,6 +118,9 @@ describe("EditIconModal", () => {
 
       expect(editSoftwarePackageSpy).toHaveBeenCalledWith({
         data: { displayName: "New Name" }, // whitespace was trimmed
+        // Multi-package titles require installer_id on every PATCH; the modal
+        // targets `software_package` (mirror of `packages[0]`).
+        installerId: softwarePackage.installer_id,
         softwareId: 123,
         teamId: 456,
       });
@@ -151,9 +154,38 @@ describe("EditIconModal", () => {
 
       expect(editSoftwarePackageSpy).toHaveBeenCalledWith({
         data: { displayName: "" },
+        installerId: softwarePackage.installer_id,
         softwareId: 123,
         teamId: 456,
       });
+    });
+
+    it("forwards the software package's installer_id on display-name save (#49239)", async () => {
+      // Regression guard for the multi-package Edit-appearance flow: the
+      // backend rejects display-name PATCHes without installer_id on titles
+      // with multiple packages, so the modal must always send the id of the
+      // package it's targeting (software_package == packages[0]).
+      const editSoftwarePackageSpy = jest
+        .spyOn(softwareAPI, "editSoftwarePackage")
+        .mockResolvedValue({});
+
+      const MULTI_PACKAGE_PROPS = {
+        ...MOCK_PROPS,
+        software: createMockSoftwarePackage({ installer_id: 42 }),
+      };
+
+      const render = createCustomRenderer({ withBackendMock: true });
+      const { user } = render(<EditIconModal {...MULTI_PACKAGE_PROPS} />);
+
+      const displayNameInput = screen.getByLabelText("Display name");
+      await user.type(displayNameInput, "Custom label");
+
+      const saveButton = screen.getByRole("button", { name: "Save" });
+      await user.click(saveButton);
+
+      expect(editSoftwarePackageSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ installerId: 42 })
+      );
     });
 
     it("handles name update error properly", async () => {

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditIconModal/EditIconModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditIconModal/EditIconModal.tsx
@@ -681,6 +681,10 @@ const EditIconModal = ({
             ? softwareAPI.editSoftwarePackage({
                 data: { displayName: trimmedDisplayName },
                 softwareId,
+                // Multi-package titles require `installer_id` on any edit; display_name
+                // is title-level, so target the first-added package (`software` is
+                // `software_package`, which mirrors `packages[0]`).
+                installerId: (software as ISoftwarePackage).installer_id,
                 teamId: teamIdForApi,
               })
             : softwareAPI.editAppStoreApp(softwareId, teamIdForApi, {

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
@@ -24,7 +24,10 @@ import {
   NO_VERSION_OR_HOST_DATA_SOURCES,
 } from "interfaces/software";
 import { APP_CONTEXT_NO_TEAM_ID } from "interfaces/team";
-import { canWriteSoftware } from "utilities/permissions/permissions";
+import {
+  canDownloadSoftwareInstaller,
+  canWriteSoftware,
+} from "utilities/permissions/permissions";
 import softwareAPI, {
   ISoftwareTitleResponse,
   IGetSoftwareTitleQueryKey,
@@ -56,7 +59,7 @@ import AddPackageModal from "./AddPackageModal";
 import PoliciesModal from "./PoliciesModal";
 import VersionsModal from "./VersionsModal";
 import { getDisplayedSoftwareName, mergePolicies } from "../helpers";
-import { buildLibraryVersionRows } from "./helpers";
+import { buildLibraryVersionRows, canDownloadInstallerRow } from "./helpers";
 import TitleVersionsTable from "./TitleVersionsTable";
 
 const baseClass = "software-title-details-page";
@@ -109,6 +112,10 @@ const SoftwareTitleDetailsPage = ({
   });
 
   const canEditSoftware = canWriteSoftware(currentUser, currentTeamId ?? null);
+  const canDownloadInstaller = canDownloadSoftwareInstaller(
+    currentUser,
+    currentTeamId ?? null
+  );
 
   const [showLibraryEditModal, setShowLibraryEditModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
@@ -373,7 +380,10 @@ const SoftwareTitleDetailsPage = ({
           pendingPath={statusPath("pending")}
           failedPath={statusPath("failed")}
           hashSha256={row.isActive ? pkg.hash_sha256 ?? null : null}
-          canDownload={row.isActive}
+          canDownload={canDownloadInstallerRow(
+            row.isActive,
+            canDownloadInstaller
+          )}
           onBadgeClick={
             isFma && canEditSoftware
               ? () => setShowVersionsModal(true)

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/helpers.tests.ts
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/helpers.tests.ts
@@ -1,5 +1,9 @@
 import { ISoftwareTitleDetails } from "interfaces/software";
-import { buildLibraryVersionRows, getInstallerCardInfo } from "./helpers";
+import {
+  buildLibraryVersionRows,
+  canDownloadInstallerRow,
+  getInstallerCardInfo,
+} from "./helpers";
 
 const v = (id: number, version: string) => ({
   id,
@@ -189,6 +193,28 @@ describe("SoftwareTitleDetailsPage helpers", () => {
         isScriptPackage: false,
         isSelfService: false,
       });
+    });
+  });
+
+  describe("canDownloadInstallerRow", () => {
+    // Guards the observer-download regression: the button must stay hidden
+    // for any role that lacks installer read permission, even on the active
+    // row. Backend rejects observers with 403 (policy.rego installable_entity
+    // read), so the UI shouldn't offer the click.
+    it("shows the button only when the row is active AND the user has permission", () => {
+      expect(canDownloadInstallerRow(true, true)).toBe(true);
+    });
+
+    it("hides the button when the user lacks installer permission (e.g., observer)", () => {
+      expect(canDownloadInstallerRow(true, false)).toBe(false);
+    });
+
+    it("hides the button on inactive (rollback / older) rows even for authorized users", () => {
+      expect(canDownloadInstallerRow(false, true)).toBe(false);
+    });
+
+    it("hides the button when both conditions fail", () => {
+      expect(canDownloadInstallerRow(false, false)).toBe(false);
     });
   });
 });

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/helpers.ts
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/helpers.ts
@@ -11,6 +11,16 @@ import { getDisplayedSoftwareName } from "../helpers";
 import { deriveAccordionRowState } from "./LibraryItemAccordion/helpers";
 import { LibraryItemBadgeState } from "./LibraryItemAccordion/LibraryItemAccordion";
 
+/** Row-level gate for the LibraryItemAccordion download button: shown only
+ * when the row is the active (currently-serving) version AND the user has
+ * installer read permission. Observers and any role excluded from
+ * `installable_entity` read in policy.rego return `false` here so the button
+ * is hidden rather than clicked into a backend 403. */
+export const canDownloadInstallerRow = (
+  rowIsActive: boolean,
+  hasInstallerReadPermission: boolean
+): boolean => rowIsActive && hasInstallerReadPermission;
+
 export interface InstallerCardInfo {
   softwareTitleName: string;
   softwareDisplayName: string;

--- a/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tests.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tests.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+
+import { createCustomRenderer } from "test/test-utils";
+import { createMockSoftwarePackage } from "__mocks__/softwareMock";
+
+import PackageForm from "./PackageForm";
+
+const BASE_PROPS = {
+  labels: [],
+  onCancel: jest.fn(),
+  onSubmit: jest.fn(),
+  onClickPreviewEndUserExperience: jest.fn(),
+};
+
+const renderForm = (
+  overrides: Partial<React.ComponentProps<typeof PackageForm>> = {}
+) => {
+  const render = createCustomRenderer({
+    withBackendMock: true,
+    context: {
+      app: {
+        isPremiumTier: true,
+        isGlobalAdmin: true,
+      },
+    },
+  });
+  return render(<PackageForm {...BASE_PROPS} {...overrides} />);
+};
+
+const TARGET_BANNER_COPY = /If multiple packages of the same software target the same host, Fleet will install the one that was added first\./i;
+
+describe("PackageForm", () => {
+  describe("Target section on the single-package Add flow", () => {
+    it("hides the Target section before a file is selected", () => {
+      renderForm();
+      // Target selector and its info banner should be absent until upload.
+      expect(screen.queryByText(TARGET_BANNER_COPY)).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("All hosts")).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("Custom")).not.toBeInTheDocument();
+    });
+
+    it("renders the Target section with the first-added banner once a file is selected", () => {
+      // `defaultSoftware` seeds initialFormData.software (the form casts it to
+      // File internally), which is the same signal the Add flow raises when
+      // the user picks a file. Uses the ISoftwarePackage mock to satisfy the
+      // prop's declared type.
+      renderForm({ defaultSoftware: createMockSoftwarePackage() });
+      expect(screen.getByText(TARGET_BANNER_COPY)).toBeInTheDocument();
+      expect(screen.getByLabelText("All hosts")).toBeInTheDocument();
+      expect(screen.getByLabelText("Custom")).toBeInTheDocument();
+    });
+
+    it("omits the first-added banner on the Edit flow", () => {
+      renderForm({
+        isEditingSoftware: true,
+        defaultSoftware: createMockSoftwarePackage(),
+      });
+      // Target selector is present on Edit, but the banner is not — the
+      // install-order copy only applies to Add flows.
+      expect(screen.queryByText(TARGET_BANNER_COPY)).not.toBeInTheDocument();
+      expect(screen.getByLabelText("All hosts")).toBeInTheDocument();
+      expect(screen.getByLabelText("Custom")).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
@@ -403,13 +403,14 @@ const PackageForm = ({
   );
 
   // GitOps mode hides SoftwareOptionsSelector and TargetLabelSelector.
-  // 4.83 removed option/targets from the (single-package) Add page; the
-  // multi-package Add modal reintroduces the targets selector only, since
-  // each package on a multi-package title needs its own label scope. The
-  // options selector (self-service + categories) stays edit-only.
+  // Options selector (self-service + categories) stays edit-only. The target
+  // selector shows whenever a package is being staged — on Edit, in the
+  // multi-package Add modal, and on the single-package Add page once a file
+  // is chosen — because every package on a title needs its own label scope.
   const showSoftwareOptionsSelector = !gitOpsModeEnabled && isEditingSoftware;
   const showTargetLabelSelector =
-    !gitOpsModeEnabled && (isEditingSoftware || multiPackageContext);
+    !gitOpsModeEnabled &&
+    (isEditingSoftware || multiPackageContext || !!formData.software);
 
   const renderSoftwareOptionsSelector = () => (
     <SoftwareOptionsSelector
@@ -426,9 +427,10 @@ const PackageForm = ({
 
   const renderTargetLabelSelector = () => (
     <>
-      {multiPackageContext && (
+      {!isEditingSoftware && (
         <InfoBanner
-          icon="error-outline"
+          icon="info-outline"
+          iconColor="ui-fleet-black-50"
           className={`${baseClass}__multi-package-banner`}
           borderRadius="medium"
         >

--- a/frontend/pages/SoftwarePage/components/forms/PackageForm/_styles.scss
+++ b/frontend/pages/SoftwarePage/components/forms/PackageForm/_styles.scss
@@ -1,6 +1,4 @@
 .package-form {
-  container-type: inline-size;
-
   // TODO: Refactor InfoBanner to not have default margin so we don't have to override it
   // Flex gaps should be handling spacing around all InfoBanner
   .info-banner {
@@ -21,14 +19,6 @@
       gap: 12px;
       flex: 1 0 0;
       align-self: stretch;
-    }
-  }
-
-  @container (min-width: 926px) {
-    // 990px $break-md - 64px padding = 926px
-    // @container does not have access to variables outside their scope
-    &__form-frame {
-      flex-direction: row;
     }
   }
 

--- a/frontend/utilities/permissions/permissions.tests.ts
+++ b/frontend/utilities/permissions/permissions.tests.ts
@@ -175,3 +175,64 @@ describe("permissions - canWriteSoftware", () => {
     expect(permissions.canWriteSoftware(user, TEAM_ID)).toBe(false);
   });
 });
+
+describe("permissions - canDownloadSoftwareInstaller", () => {
+  // Mirrors backend READ on `installable_entity` (policy.rego L837-865):
+  // admin | maintainer | technician | gitops are allowed at both global and
+  // team scope. Observer / observer+ are excluded. Guards the download button
+  // in the UI so observers don't see it and hit the backend 403.
+  const TEAM_ID = 1;
+
+  it("returns false when there is no user", () => {
+    expect(permissions.canDownloadSoftwareInstaller(null, TEAM_ID)).toBe(false);
+  });
+
+  it.each([
+    ["admin", "admin"],
+    ["maintainer", "maintainer"],
+    ["technician", "technician"],
+  ] as const)("allows a global %s", (_label, role) => {
+    const user = createMockUser({ global_role: role, teams: [] });
+    expect(permissions.canDownloadSoftwareInstaller(user, TEAM_ID)).toBe(true);
+    expect(permissions.canDownloadSoftwareInstaller(user, null)).toBe(true);
+  });
+
+  it.each([
+    ["admin", "admin"],
+    ["maintainer", "maintainer"],
+    ["technician", "technician"],
+  ] as const)("allows a team %s on their team", (_label, role) => {
+    const user = createMockUser({
+      global_role: null,
+      teams: [{ id: TEAM_ID, name: "Team 1", role }],
+    });
+    expect(permissions.canDownloadSoftwareInstaller(user, TEAM_ID)).toBe(true);
+  });
+
+  it("denies a team technician on a different team", () => {
+    const user = createMockUser({
+      global_role: null,
+      teams: [{ id: 2, name: "Team 2", role: "technician" }],
+    });
+    expect(permissions.canDownloadSoftwareInstaller(user, TEAM_ID)).toBe(false);
+  });
+
+  it.each([
+    ["observer", "observer"],
+    ["observer_plus", "observer_plus"],
+  ] as const)("denies a global %s", (_label, role) => {
+    const user = createMockUser({ global_role: role, teams: [] });
+    expect(permissions.canDownloadSoftwareInstaller(user, TEAM_ID)).toBe(false);
+  });
+
+  it.each([
+    ["observer", "observer"],
+    ["observer_plus", "observer_plus"],
+  ] as const)("denies a team %s on their team", (_label, role) => {
+    const user = createMockUser({
+      global_role: null,
+      teams: [{ id: TEAM_ID, name: "Team 1", role }],
+    });
+    expect(permissions.canDownloadSoftwareInstaller(user, TEAM_ID)).toBe(false);
+  });
+});

--- a/frontend/utilities/permissions/permissions.ts
+++ b/frontend/utilities/permissions/permissions.ts
@@ -208,6 +208,25 @@ export const canWriteSoftware = (
   );
 };
 
+// Mirrors backend READ on `installable_entity` (rego: admin | maintainer |
+// technician | gitops). Use to gate the installer-download affordance — the
+// backend rejects observers with 403, so the button shouldn't be surfaced to
+// them.
+export const canDownloadSoftwareInstaller = (
+  user: IUser | null,
+  teamId: number | null
+): boolean => {
+  if (!user) return false;
+  return (
+    isGlobalAdmin(user) ||
+    isGlobalMaintainer(user) ||
+    isGlobalTechnician(user) ||
+    isTeamAdmin(user, teamId) ||
+    isTeamMaintainer(user, teamId) ||
+    isTeamTechnician(user, teamId)
+  );
+};
+
 export default {
   isSandboxMode,
   isFreeTier,
@@ -236,4 +255,5 @@ export default {
   isObserverPlus,
   isNoAccess,
   canWriteSoftware,
+  canDownloadSoftwareInstaller,
 };

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -9082,7 +9082,7 @@ func testApplyPolicySpecFirstAddedInstaller(t *testing.T, ds *Datastore) {
 	})
 	require.NoError(t, err)
 
-	policies, _, err := ds.ListTeamPolicies(ctx, team.ID, fleet.ListOptions{}, fleet.ListOptions{}, "")
+	policies, _, err := ds.ListTeamPolicies(ctx, team.ID, fleet.ListOptions{}, fleet.ListOptions{}, "", "")
 	require.NoError(t, err)
 	require.Len(t, policies, 1)
 	require.NotNil(t, policies[0].SoftwareInstallerID)


### PR DESCRIPTION
## Issue
Follow-up UI fixes on top of #48520 / #49079 (parent story #28108). Companion backend/full-stack PR: #49263.

## Description
Frontend polish caught during multi-package testing.

### Frontend fixes

- 1 **Dynamic-policy tooltip** (`SoftwareInstallPolicyBadges`): refresh icon flex-centered inside `.component__tooltip-wrapper__element`; tooltip uses `fixedPositionStrategy` so `position="top"` isn't flipped by the `InstallerPoliciesTable`'s overflow container.
- 2 **Target section on the single-package Add flow** (`PackageForm`): once a file is selected on `/software/add`, we now render the same Target section (with the "first-added wins" info banner) as the multi-package modal. Edit continues to skip the banner.
- 3 **InfoBanner API**: new optional `iconColor?: Colors` prop forwarded to the leading `<Icon>`.
- 4 **Banner icons**: both the multi-package "first-added wins" banner (`PackageForm`) and `GitOpsCustomPackageBanner` (`SoftwareCustomPackage`) switched from `error-outline` (red) to `info-outline` with `iconColor="ui-fleet-black-50"`.
- 5 **`EditIconModal` display-name save**: sends `installer_id` from `software_package` (which mirrors `packages[0]`) so multi-package titles no longer 400 with `installer_id is required when the title has multiple packages.` when saving Edit appearance.

### Released bug found while testing this feature (predates multi-package)

- 11 **Observer download button**: `SoftwareTitleDetailsPage` gates the accordion's `canDownload` on a new `canDownloadSoftwareInstaller` helper (admin/maintainer/technician + team equivalents; mirrors the rego `installable_entity` read policy at `server/authz/policy.rego:837-865`, tested at `server/authz/policy_test.go:801-869`). Observers previously saw the download button and hit a backend 403 — this mismatch already ships on `main`, wasn't introduced here.

### CI fix

`server/datastore/mysql/policies_test.go:9085` was calling `ds.ListTeamPolicies` with 5 args after the signature was extended to require a `platform` string, blocking `test-go (mysql, ...)` on the feature branch. Bumped the call to pass `""` for `platform`. Same fix is on #49263 so both branches' CI can pass independently.

### Screenshots

1
<img width="837" height="475" alt="Screenshot 2026-07-13 at 4 39 44 PM" src="https://github.com/user-attachments/assets/c2a72ddf-299b-473a-bc75-a192cd4964f0" />

2 3 4 (icon in the add software flow)

https://github.com/user-attachments/assets/675fa9a7-ed9e-4d45-8617-ccd50d919f12

3 4 icon in the modal

<img width="1186" height="724" alt="Screenshot 2026-07-13 at 4 43 08 PM" src="https://github.com/user-attachments/assets/105c1798-b129-4614-96ca-bf1d19a61f4a" />

5

https://github.com/user-attachments/assets/534a8e7c-c8eb-48b7-9458-c2c3f87501dd

11


https://github.com/user-attachments/assets/c0236e5e-1a81-4745-adef-4dcaefefda2b



### Tests

- `canDownloadSoftwareInstaller` — 12 new unit tests covering the allow/deny matrix (global + team, observer/observer+ denied).
- `InfoBanner` — `iconColor` prop forwards to the leading `<Icon>`'s fill; default color still applies when omitted.
- `EditIconModal` — updated existing display-name-save asserts to expect `installerId`, added a new case with a distinct id to guard the multi-package path.
- New `PackageForm.tests.tsx` — Target section hidden pre-selection on Add, visible + banner post-selection on Add, visible + no banner on Edit.
- `canDownloadInstallerRow` — row-level gate helper (active + installer read permission), including the observer-hidden case.

## Screenrecording


## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually