### PR TITLE
Verify checksums of osquery and WiX downloads in CI release path

### DIFF
--- a/.github/workflows/build-fleetctl-msi.yml
+++ b/.github/workflows/build-fleetctl-msi.yml
@@ -136,6 +136,8 @@ jobs:
         run: |
           curl -fSL -o wix314-binaries.zip \
             https://github.com/wixtoolset/wix3/releases/download/wix3141rtm/wix314-binaries.zip
+          # Pin the known-good WiX release bytes (wix3141rtm publishes no signed checksum).
+          echo "6ac824e1642d6f7277d0ed7ea09411a508f6116ba6fae0aa5f2c7daa2ff43d31  wix314-binaries.zip" | sha256sum --check --strict -
           mkdir -p "$RUNNER_TEMP/wix"
           unzip -q wix314-binaries.zip -d "$RUNNER_TEMP/wix"
           echo "$RUNNER_TEMP/wix" >> $GITHUB_PATH

--- a/.github/workflows/generate-osqueryd-targets.yml
+++ b/.github/workflows/generate-osqueryd-targets.yml
@@ -25,6 +25,14 @@ defaults:
 
 env:
   OSQUERY_VERSION: 5.23.1
+  # SHA256 checksums of the pinned osquery release assets downloaded below. osquery does
+  # not publish signed checksums, so these pin the known-good bytes to detect tampering or
+  # MITM of the GitHub release download before the binary is attested and shipped via TUF.
+  # These MUST be updated whenever OSQUERY_VERSION changes.
+  OSQUERY_SHA256_LINUX_AMD64: 1431a9a6394657eba3cdd3476a462a6fe9721fc3664a70f23efcf7e37816787a
+  OSQUERY_SHA256_LINUX_ARM64: 062df9b6432ca1b374e80b24b54f027e224f1300d8bf6338182ec40f41b7975d
+  OSQUERY_SHA256_WINDOWS_X64_MSI: bb3adc9f32f257147855404d24bceebcd8baf6e65f4d4ca43e186f4a85fa6ed3
+  OSQUERY_SHA256_WINDOWS_ARM64_ZIP: 0913d05cc3fc92dd9253c945caacde10a776408f267cc1cc853a05de24dba900
 
 # Least-privilege default; each build job grants id-token/attestations at the job level.
 permissions:
@@ -94,6 +102,7 @@ jobs:
       - name: Download and extract osqueryd for linux
         run: |
           curl -L https://github.com/osquery/osquery/releases/download/${{ env.OSQUERY_VERSION }}/osquery_${{ env.OSQUERY_VERSION }}-1.linux_amd64.deb --output osquery.deb
+          echo "${OSQUERY_SHA256_LINUX_AMD64}  osquery.deb" | sha256sum --check --strict -
           ar x osquery.deb
           tar xf data.tar.gz
           chmod +x ./opt/osquery/bin/osqueryd
@@ -135,6 +144,7 @@ jobs:
       - name: Download and extract osqueryd for linux-arm64
         run: |
           curl -L https://github.com/osquery/osquery/releases/download/${{ env.OSQUERY_VERSION }}/osquery_${{ env.OSQUERY_VERSION }}-1.linux_arm64.deb --output osquery.deb
+          echo "${OSQUERY_SHA256_LINUX_ARM64}  osquery.deb" | sha256sum --check --strict -
           ar x osquery.deb
           tar xf data.tar.gz
           chmod +x ./opt/osquery/bin/osqueryd
@@ -172,6 +182,7 @@ jobs:
       - name: Download osquery msi for Windows
         run: |
           curl -L https://github.com/osquery/osquery/releases/download/${{ env.OSQUERY_VERSION }}/osquery-${{ env.OSQUERY_VERSION }}.msi --output osquery-${{ env.OSQUERY_VERSION }}.msi
+          echo "${OSQUERY_SHA256_WINDOWS_X64_MSI}  osquery-${{ env.OSQUERY_VERSION }}.msi" | sha256sum --check --strict -
 
       - name: Extract osqueryd.exe for Windows
         shell: cmd
@@ -211,6 +222,7 @@ jobs:
       - name: Download osquery msi for Windows
         run: |
           curl -L https://github.com/osquery/osquery/releases/download/${{ env.OSQUERY_VERSION }}/osquery-${{ env.OSQUERY_VERSION }}.windows_arm64.zip --output osquery-${{ env.OSQUERY_VERSION }}.windows_arm64.zip
+          echo "${OSQUERY_SHA256_WINDOWS_ARM64_ZIP}  osquery-${{ env.OSQUERY_VERSION }}.windows_arm64.zip" | sha256sum --check --strict -
 
       - name: Install file
         run: |

--- a/.github/workflows/goreleaser-fleet.yaml
+++ b/.github/workflows/goreleaser-fleet.yaml
@@ -330,6 +330,8 @@ jobs:
         run: |
           curl -fSL -o wix314-binaries.zip \
             https://github.com/wixtoolset/wix3/releases/download/wix3141rtm/wix314-binaries.zip
+          # Pin the known-good WiX release bytes (wix3141rtm publishes no signed checksum).
+          echo "6ac824e1642d6f7277d0ed7ea09411a508f6116ba6fae0aa5f2c7daa2ff43d31  wix314-binaries.zip" | sha256sum --check --strict -
           mkdir -p "$RUNNER_TEMP/wix"
           unzip -q wix314-binaries.zip -d "$RUNNER_TEMP/wix"
           echo "$RUNNER_TEMP/wix" >> $GITHUB_PATH


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** NA (found via Aikido SAST triage of the CI release path)

## What changed

Three CI workflows download release binaries over HTTPS and use them without verifying integrity. On the **customer artifact path** this is a real supply-chain gap: `generate-osqueryd-targets.yml` downloads osquery binaries that are attested and shipped to managed endpoints via TUF, and `actions/attest-build-provenance` signs whatever bytes were downloaded, so it does not detect a tampered/MITM'd upstream asset. The WiX toolset used to build and sign the customer-facing fleetctl MSI has the same gap.

This adds SHA256 verification of the pinned downloads before they are extracted, attested, or used:

- **`generate-osqueryd-targets.yml`** — pins the SHA256 of the four `curl`-downloaded osquery `5.23.1` assets (linux amd64/arm64 `.deb`, windows x64 `.msi`, windows arm64 `.zip`) as `env` vars and verifies each with `sha256sum --check --strict` right after download. The macOS job builds from source via `make` (no download) and is unaffected.
- **`build-fleetctl-msi.yml`** and **`goreleaser-fleet.yaml`** — pin and verify the SHA256 of `wix314-binaries.zip` (WiX `wix3141rtm`).

osquery and WiX do not publish signed checksum files (verified against their GitHub releases), so the checksums are pinned inline. Each was computed directly from the currently-published pinned asset. **The osquery checksums must be updated whenever `OSQUERY_VERSION` changes** — a comment in the `env` block notes this. This mirrors the existing verified pattern already used for the `rcodesign` download in `goreleaser-fleet.yaml`.

Pinned checksums in this change:
- `osquery_5.23.1-1.linux_amd64.deb` = `1431a9a6394657eba3cdd3476a462a6fe9721fc3664a70f23efcf7e37816787a`
- `osquery_5.23.1-1.linux_arm64.deb` = `062df9b6432ca1b374e80b24b54f027e224f1300d8bf6338182ec40f41b7975d`
- `osquery-5.23.1.msi` = `bb3adc9f32f257147855404d24bceebcd8baf6e65f4d4ca43e186f4a85fa6ed3`
- `osquery-5.23.1.windows_arm64.zip` = `0913d05cc3fc92dd9253c945caacde10a776408f267cc1cc853a05de24dba900`
- `wix314-binaries.zip` (wix3141rtm) = `6ac824e1642d6f7277d0ed7ea09411a508f6116ba6fae0aa5f2c7daa2ff43d31`

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Verified each pinned checksum matches the currently-published upstream asset (downloaded and hashed locally).
- [x] Validated all three workflow YAML files parse.
- [ ] Confirmed that the fix is not expected to adversely impact load test results (CI-only change; no runtime impact).

A green run of `generate-osqueryd-targets.yml` (triggered by this change touching the workflow file) confirms the osquery checksums match on the actual runners.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Reliability**
  * Added strict SHA-256 verification for downloaded WiX installer binaries.
  * Added integrity checks for osquery packages and archives across supported Linux and Windows platforms.
  * Prevents extraction of downloads that do not match their expected checksums.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->