### PR TITLE
Fix intermittent Windows ESP Account setup hang (user-scope 405 race)

### DIFF
--- a/changes/49134-windows-esp-user-scope-405
+++ b/changes/49134-windows-esp-user-scope-405
@@ -1,0 +1,1 @@
+- Fixed intermittent Windows Autopilot enrollments hanging on the Enrollment Status Page "Account setup" screen when the host was linked before the ESP hold commands ran, by recreating the user-scope DMClient node during ESP release so the completion signal is no longer rejected.

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -9413,14 +9413,27 @@ func (s *integrationMDMTestSuite) TestWindowsAutopilotESPCommands() {
 	cmds, err = d.StartManagementSession()
 	require.NoError(t, err)
 
-	var foundRelease bool
+	// This test links host_uuid (UpdateMDMWindowsEnrollmentsHostUUID above) BEFORE the first management session, so
+	// handleESPHoldOrTransition transitioned straight Pending -> Active without ever sending the hold-phase Adds that
+	// create the user-scope DMClient Provider node. The release must therefore recreate that node inline (its
+	// ordering before the user-scope ServerHasFinishedProvisioning Replace is asserted deterministically in
+	// TestPBT_HandleESPRelease), or the Replace lands on a nonexistent node and returns SyncML 405 -- hanging the
+	// device on the ESP "Account setup" screen (issue #49134).
+	var foundUserRelease, foundProviderAdd, foundFirstSyncAdd bool
 	for _, c := range cmds {
-		if c.Verb == fleet.CmdReplace && strings.Contains(c.Cmd.GetTargetURI(), "ServerHasFinishedProvisioning") {
-			foundRelease = true
-			break
+		uri := c.Cmd.GetTargetURI()
+		switch {
+		case c.Verb == fleet.CmdReplace && strings.Contains(uri, "/User/") && strings.Contains(uri, "ServerHasFinishedProvisioning"):
+			foundUserRelease = true
+		case c.Verb == fleet.CmdAdd && strings.HasSuffix(uri, "/DMClient/Provider/"+syncml.DocProvisioningAppProviderID):
+			foundProviderAdd = true
+		case c.Verb == fleet.CmdAdd && strings.HasSuffix(uri, "/DMClient/Provider/"+syncml.DocProvisioningAppProviderID+"/FirstSyncStatus") && strings.Contains(uri, "/User/"):
+			foundFirstSyncAdd = true
 		}
 	}
-	require.True(t, foundRelease, "should release device with ServerHasFinishedProvisioning")
+	require.True(t, foundUserRelease, "should release device with user-scope ServerHasFinishedProvisioning")
+	require.True(t, foundProviderAdd, "release must recreate the user-scope Provider node (issue #49134)")
+	require.True(t, foundFirstSyncAdd, "release must recreate the user-scope FirstSyncStatus node (issue #49134)")
 
 	enrolledDevice, err = s.ds.MDMWindowsGetEnrolledDeviceWithDeviceID(ctx, d.DeviceID)
 	require.NoError(t, err)

--- a/server/service/microsoft_mdm.go
+++ b/server/service/microsoft_mdm.go
@@ -1885,6 +1885,16 @@ func handleResendingAlreadyExistsCommands(ctx context.Context, svc *Service, alr
 			continue
 		}
 
+		// Container-node Adds (format=node, no <Data>) create an interior tree node that has no value. A 418 on one
+		// just means the node already exists, and there is nothing to Replace -- rewriting it to a Replace on the
+		// container URI produces an undefined command the device rejects. Leaf Adds (profiles, DMClient settings)
+		// carry <Data> and a value format, so their 418 -> Replace conversion still runs. The ESP release path
+		// (buildESPReleaseCommands) persists two such container Adds for the dropped-response retry, so without this
+		// guard every successful finalization would emit spurious failing container Replaces post-ESP.
+		if strings.Contains(string(cmd.RawCommand), "node</Format>") {
+			continue
+		}
+
 		// Copy value, and avoid referencing the old values
 		newCmd := &fleet.MDMWindowsCommand{
 			CommandUUID:  cmd.CommandUUID,
@@ -2751,8 +2761,10 @@ func buildESPReleaseCommands(provID string) []*mdm_types.SyncMLCmd {
 // CmdIDs as the inline commands: when the device acks the inline send,
 // MDMWindowsSaveResponse will match those CmdRefs against the persisted
 // rows and clear them, so the backup is only resent if delivery actually
-// failed. All commands are idempotent Replaces, so even a duplicate delivery
-// is safe.
+// failed. The commands are idempotent Replaces plus the two user-scope
+// container-node Adds from buildESPReleaseCommands, so even a duplicate
+// delivery is safe: the Replaces re-write the same value and the Adds return
+// a harmless 418 (Already Exists) when the node already exists.
 func (svc *Service) persistESPFinalCommands(ctx context.Context, hostUUID string, cmds []*mdm_types.SyncMLCmd) error {
 	persistCmds := make([]*fleet.MDMWindowsCommand, 0, len(cmds))
 	for _, cmd := range cmds {

--- a/server/service/microsoft_mdm.go
+++ b/server/service/microsoft_mdm.go
@@ -2725,6 +2725,17 @@ func buildESPReleaseCommands(provID string) []*mdm_types.SyncMLCmd {
 			fmt.Sprintf("./Device/Vendor/MSFT/EnrollmentStatusTracking/DevicePreparation/PolicyProviders/%s/InstallationState", provID), "3"),
 		newSyncMLCmdBool(fleet.CmdReplace,
 			fmt.Sprintf("./Device/Vendor/MSFT/DMClient/Provider/%s/FirstSyncStatus/ServerHasFinishedProvisioning", provID), "true"),
+		// Recreate the user-scope DMClient Provider tree immediately before the user-scope Replace. The hold phase only
+		// sends these Adds while host_uuid is empty (handleESPHoldOrTransition); if host_uuid is linked -- by orbit
+		// enroll, the DevDetail/SMBIOS reply, or the osquery backstop -- before the first Pending-phase hold session
+		// runs, the Adds are skipped and the user-scope node is never created. The release-phase Replace then lands on a
+		// nonexistent node and returns SyncML 405, hanging the device on the Account setup ("Working on it...") ESP
+		// phase until the 3-hour timeout. Sending the Adds here makes the release self-sufficient regardless of who wins
+		// the host_uuid linking race: SyncML processes commands in message order, so these run before the Replace below,
+		// and when the node already exists (the common case) they return a harmless 418 (Already Exists) that does not
+		// fail the session.
+		newSyncMLCmdNode(fleet.CmdAdd, fmt.Sprintf("./User/Vendor/MSFT/DMClient/Provider/%s", provID)),
+		newSyncMLCmdNode(fleet.CmdAdd, fmt.Sprintf("./User/Vendor/MSFT/DMClient/Provider/%s/FirstSyncStatus", provID)),
 		newSyncMLCmdBool(fleet.CmdReplace,
 			fmt.Sprintf("./User/Vendor/MSFT/DMClient/Provider/%s/FirstSyncStatus/ServerHasFinishedProvisioning", provID), "true"),
 	}

--- a/server/service/microsoft_mdm_property_test.go
+++ b/server/service/microsoft_mdm_property_test.go
@@ -31,8 +31,8 @@ import (
 //     (block: reason-specific static text; warn: dynamic failed-software list).
 //   - Release path command shape: Device-scope AND User-scope ServerHasFinishedProvisioning plus
 //     PolicyProviders InstallationState=3; NO CustomErrorText, NO BlockInStatusPage. The user-scope
-//     Provider node is created during the hold phase via Add commands so the user-scope SHFP write
-//     lands instead of being 405-rejected.
+//     Provider node Adds are re-sent inline, ordered before the user-scope SHFP Replace, so the write
+//     lands instead of being 405-rejected even when the hold-phase Adds were skipped (issue #49134).
 //   - Persisted CommandUUIDs equal inline CmdID.Value (the ack-clearing invariant).
 //   - Persist runs as a single batched call (a regression that loops single inserts would split CustomErrorText
 //     and the block flags across multiple TX boundaries).
@@ -342,17 +342,29 @@ func TestPBT_HandleESPRelease(t *testing.T) {
 				"release path must NOT include CustomErrorText")
 			// Release writes ServerHasFinishedProvisioning at BOTH Device and User scope. Device scope completes
 			// the Device setup phase; User scope completes Account setup. The User-scope write requires the
-			// user-scope DMClient Provider node to have been created earlier via the hold-phase Add commands.
+			// user-scope DMClient Provider node to exist; the release recreates it inline via Add commands so the
+			// write lands even when the hold-phase Adds were skipped (host_uuid linked before the first hold session).
 			shfpDeviceFound, shfpUserFound := false, false
-			for _, c := range cmds {
+			userProviderAddIdx, userFirstSyncAddIdx, userSHFPIdx := -1, -1, -1
+			for i, c := range cmds {
 				uri := c.GetTargetURI()
-				if !strings.Contains(uri, "ServerHasFinishedProvisioning") {
+				if strings.Contains(uri, "ServerHasFinishedProvisioning") {
+					if strings.Contains(uri, "/Device/") {
+						shfpDeviceFound = true
+					} else if strings.Contains(uri, "/User/") {
+						shfpUserFound = true
+						userSHFPIdx = i
+					}
 					continue
 				}
-				if strings.Contains(uri, "/Device/") {
-					shfpDeviceFound = true
-				} else if strings.Contains(uri, "/User/") {
-					shfpUserFound = true
+				// The user-scope Provider node Add and its FirstSyncStatus child Add (idempotent; 418 when the node
+				// already exists). Match on the /User/ Provider tree, distinguishing the parent from the child.
+				if c.XMLName.Local == fleet.CmdAdd && strings.Contains(uri, "/User/Vendor/MSFT/DMClient/Provider/") {
+					if strings.HasSuffix(uri, "/FirstSyncStatus") {
+						userFirstSyncAddIdx = i
+					} else {
+						userProviderAddIdx = i
+					}
 				}
 			}
 			assert.Truef(rt, shfpDeviceFound,
@@ -361,6 +373,14 @@ func TestPBT_HandleESPRelease(t *testing.T) {
 				"release path must include User-scope ServerHasFinishedProvisioning so Account setup completes; "+
 					"omitting it hangs the device on 'Working on it...' indefinitely on Win11 26200 when Account "+
 					"setup has been displayed")
+			// The user-scope node Adds must be present AND ordered before the user-scope Replace, otherwise the
+			// Replace 405s on a nonexistent node (issue #49134). SyncML processes commands in message order.
+			require.Truef(rt, userProviderAddIdx >= 0 && userFirstSyncAddIdx >= 0,
+				"release path must Add the user-scope Provider node and FirstSyncStatus child before the "+
+					"user-scope ServerHasFinishedProvisioning Replace (issue #49134)")
+			assert.Truef(rt, userProviderAddIdx < userSHFPIdx && userFirstSyncAddIdx < userSHFPIdx,
+				"user-scope node Adds must precede the user-scope ServerHasFinishedProvisioning Replace so the "+
+					"Replace lands on an existing node (issue #49134)")
 			assert.Nilf(rt, pbtFindCmdByLocURI(cmds, "BlockInStatusPage"),
 				"release path must NOT include BlockInStatusPage")
 		}

--- a/server/service/microsoft_mdm_test.go
+++ b/server/service/microsoft_mdm_test.go
@@ -1604,6 +1604,51 @@ func TestRekeyWindowsDevice(t *testing.T) {
 		"refresh should run when no non-poll commands are pending, even with a poll-schedule command still queued")
 }
 
+// TestHandleResendingAlreadyExistsCommands verifies the 418 ("Already Exists") -> Replace rewrite converts
+// leaf-value Adds (profiles, DMClient settings) but skips container-node Adds (format=node), which have no value to
+// Replace. The ESP release path persists two such container Adds for its dropped-response retry, so without the skip
+// every successful finalization would re-queue undefined container Replaces post-ESP (issue #49134).
+func TestHandleResendingAlreadyExistsCommands(t *testing.T) {
+	ds := new(mock.Store)
+	svc := &Service{ds: ds, logger: testutils.TestLogger(t)}
+
+	const deviceID = "test-device-id"
+
+	rawOf := func(c *fleet.SyncMLCmd) []byte {
+		b, err := xml.Marshal(c)
+		require.NoError(t, err)
+		return b
+	}
+
+	leafAdd := newSyncMLCmdBool(fleet.CmdAdd, "./Vendor/MSFT/Policy/Config/Foo/Bar", "true")
+	nodeAdd := newSyncMLCmdNode(fleet.CmdAdd, "./User/Vendor/MSFT/DMClient/Provider/Fleet")
+	replaceCmd := newSyncMLCmdBool(fleet.CmdReplace, "./Vendor/MSFT/Policy/Config/Foo/Baz", "false")
+
+	ds.GetWindowsMDMCommandsForResendingFunc = func(ctx context.Context, gotDeviceID string, cmdUUIDs []string) ([]*fleet.MDMWindowsCommand, error) {
+		require.Equal(t, deviceID, gotDeviceID)
+		return []*fleet.MDMWindowsCommand{
+			{CommandUUID: "leaf-add-uuid", TargetLocURI: leafAdd.GetTargetURI(), RawCommand: rawOf(leafAdd)},
+			{CommandUUID: "node-add-uuid", TargetLocURI: nodeAdd.GetTargetURI(), RawCommand: rawOf(nodeAdd)},
+			{CommandUUID: "replace-uuid", TargetLocURI: replaceCmd.GetTargetURI(), RawCommand: rawOf(replaceCmd)},
+		}, nil
+	}
+
+	var resent []string
+	ds.ResendWindowsMDMCommandFunc = func(ctx context.Context, mdmDeviceID string, newCmd, oldCmd *fleet.MDMWindowsCommand) error {
+		resent = append(resent, oldCmd.TargetLocURI)
+		return nil
+	}
+
+	topLevel, err := handleResendingAlreadyExistsCommands(t.Context(), svc,
+		[]string{"leaf-add-uuid", "node-add-uuid", "replace-uuid"}, deviceID)
+	require.NoError(t, err)
+
+	// Only the leaf Add is rewritten to a Replace; the container-node Add (format=node) and the plain Replace are
+	// skipped, so the finalize does not emit spurious container Replaces.
+	require.Equal(t, []string{leafAdd.GetTargetURI()}, resent)
+	require.Len(t, topLevel, 1)
+}
+
 func hashMDMCredentials(username, password, nonce string) []byte {
 	credsHash := md5.Sum([]byte(username + ":" + password)) //nolint:gosec // Windows MDM Auth uses MD5
 	encodedCreds := base64.StdEncoding.EncodeToString(credsHash[:])


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #49134

## Background for reviewers new to Windows MDM

<details>
<summary>Expand for a plain-language primer on ESP, node scopes, and SyncML Add/Replace</summary>

**What's the ESP?** When a Windows device is set up through Autopilot (the out-of-box "Account setup" flow you see on a brand-new work laptop), Windows shows an **Enrollment Status Page (ESP)** — the "Working on it…" spinner — and blocks the user from reaching the desktop until the MDM server (Fleet) says setup is done. There are two sub-phases: **Device setup** (before anyone logs in) and **Account setup** (after the user's profile starts loading).

**How does Fleet tell Windows "you're done"?** Windows MDM is a protocol called **SyncML/OMA-DM**. The device holds a tree of configuration nodes (think of a filesystem of settings). Fleet sends commands to that tree:
- **`Add`** = create a node (like `mkdir`).
- **`Replace`** = set a node's value (like writing to a file).

To release the ESP, Fleet sets a node called `ServerHasFinishedProvisioning` to `true`. Crucially, this node exists in **two separate places** in the tree:
- **Device scope** (`./Device/...`) — completes the "Device setup" phase. This node exists by default.
- **User scope** (`./User/...`) — completes the "Account setup" phase. This node does **not** exist by default; Fleet has to create it first with `Add`.

**What went wrong?** Fleet created the user-scope node only during an early "hold" phase, and only while it hadn't yet matched the device to a Fleet host record (`host_uuid`). Once fleetd installs during setup, that match happens — sometimes *before* the hold phase ever ran. In that case the `Add` was skipped, the user-scope node was never created, and when Fleet later sent the `Replace` to release the device, it hit a node that doesn't exist. The device answered with SyncML status **405** ("not allowed" / no such target), the "Account setup" phase never completed, and the machine sat on "Working on it…" until a 3-hour timeout. Because it was a timing race, it happened only *sometimes* — which is what made it hard to pin down.

**The fix in one sentence:** send the `Add` again as part of the release itself, right before the `Replace`, so the node is guaranteed to exist regardless of timing. Re-adding a node that already exists is harmless — the device just replies **418** ("Already Exists"), which SyncML ignores.

</details>

## Summary

Windows Autopilot / Entra OOBE enrollments intermittently hung on the Enrollment Status Page at **"Account setup → Working on it…"** until the 3-hour ESP timeout. Fleet had run the ESP lifecycle to completion, but the **user-scope** release command (`./User/.../DMClient/Provider/Fleet/FirstSyncStatus/ServerHasFinishedProvisioning`) failed on-device with SyncML **405**, so the user ("Account setup") phase never got its completion signal.

**Root cause (a race, latent since the ESP feature shipped in 4.86.0):** the user-scope DMClient Provider node is created by `Add` commands sent *only* while `host_uuid == ""` in the Pending/hold phase (`handleESPHoldOrTransition`). The release phase (`buildESPReleaseCommands`) then writes the user-scope `Replace` **unconditionally**, with no `Add`. When `host_uuid` is linked — by orbit enroll, the DevDetail/SMBIOS reply, or the osquery backstop — *before* the first Pending-phase hold session runs, the `Add`s are skipped, the user node is never created, and the release `Replace` lands on a nonexistent node → 405 → hang.

The intermittency ("sometimes a host goes through, sometimes it doesn't") is whichever wins between the ~1-minute ESP hold poll and `host_uuid` linking. The window has been progressively narrowed by changes that link `host_uuid` earlier (#46268 DevDetail-at-first-session linking in 4.87.0; fleetd install-ordering changes in the 4.89.0 RC), which is why it now surfaces as a P1.

## Fix

- **`buildESPReleaseCommands`**: prepend two idempotent `Add`s for the user-scope Provider node and its `FirstSyncStatus` child, ordered before the user-scope `Replace`. SyncML processes commands in message order, so the node exists by the time the `Replace` runs; when it already exists the `Add`s return a harmless `418` (Already Exists). This makes the release self-sufficient regardless of who wins the `host_uuid` linking race.
- **`handleResendingAlreadyExistsCommands`**: skip container-node Adds (`format=node`, no `<Data>`) in the 418→Replace rewrite. The release now persists two such Adds for its dropped-response retry; without this guard, the common-case `418` (node already exists) would rewrite them into undefined container `Replace` commands that the device rejects, emitting spurious failures post-ESP. Leaf-value Adds (profiles, DMClient settings) still convert to Replace.

Deferred as a follow-up (#49252): gating `awaiting_configuration = None` on the user-scope Replace acking `200`, so an unrelated future failure of that command can't silently strand a device. Not required for this P1.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops

## Testing

- [x] Added/updated automated tests
  - `TestPBT_HandleESPRelease` (property-based): asserts the release path includes the user-scope node Adds **and** that they are ordered before the user-scope `ServerHasFinishedProvisioning` Replace.
  - `TestHandleResendingAlreadyExistsCommands` (unit): container-node Adds are skipped in the 418 rewrite while leaf-value Adds still convert to Replace.
  - `TestWindows...ESP` integration test (already simulates the `host_uuid`-linked-before-hold race): asserts the node Adds reach the wire in the release session.
- [x] Where appropriate, automated tests simulate multiple hosts and test for host isolation.
- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results (adds two idempotent SyncML commands to the one-time ESP release message; no new DB calls, no steady-state impact)
- [ ] Alerted the release DRI if additional load testing is needed
