### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/bruno/windows.json
+++ b/ee/maintained-apps/outputs/bruno/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.5.1",
+      "version": "3.5.2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Bruno' AND publisher = 'Anoop M D';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Bruno' AND publisher = 'Anoop M D' AND version_compare(version, '3.5.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Bruno' AND publisher = 'Anoop M D' AND version_compare(version, '3.5.2') < 0);"
       },
-      "installer_url": "https://github.com/usebruno/bruno/releases/download/v3.5.1/bruno_3.5.1_x64_win.msi",
+      "installer_url": "https://github.com/usebruno/bruno/releases/download/v3.5.2/bruno_3.5.2_x64_win.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "bfadc5e4",
-      "sha256": "e38ff57fc95bfa773d9cbc12666353977f744c2fff20b7361f56d838b21609d3",
+      "sha256": "721392a25fd83f3d11d87f11df5cb23327c9276215510b1c5e4a7794143f5a41",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/discord/windows.json
+++ b/ee/maintained-apps/outputs/discord/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.0.9245",
+      "version": "1.0.9246",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Discord' AND publisher = 'Discord Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Discord' AND publisher = 'Discord Inc.' AND version_compare(version, '1.0.9245') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Discord' AND publisher = 'Discord Inc.' AND version_compare(version, '1.0.9246') < 0);"
       },
-      "installer_url": "https://stable.dl2.discordapp.net/distro/app/stable/win/x64/1.0.9245/DiscordSetup.exe",
+      "installer_url": "https://stable.dl2.discordapp.net/distro/app/stable/win/x64/1.0.9246/DiscordSetup.exe",
       "install_script_ref": "fd04e860",
       "uninstall_script_ref": "73fc6eff",
-      "sha256": "83b721bff992e92ba4efae31c3a4d57b5d739c892448fdf4857d32d44cbf3a14",
+      "sha256": "23577e5a8aa89e28d10aad913edb2fac2f7aa39a4ce0e6327e8482af90802053",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/docker/windows.json
+++ b/ee/maintained-apps/outputs/docker/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.81.0",
+      "version": "4.82.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Docker Desktop' AND publisher = 'Docker Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Docker Desktop' AND publisher = 'Docker Inc.' AND version_compare(version, '4.81.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Docker Desktop' AND publisher = 'Docker Inc.' AND version_compare(version, '4.82.0') < 0);"
       },
-      "installer_url": "https://desktop.docker.com/win/main/amd64/232925/Docker%20Desktop%20Installer.exe",
+      "installer_url": "https://desktop.docker.com/win/main/amd64/233772/Docker%20Desktop%20Installer.exe",
       "install_script_ref": "b06042dd",
       "uninstall_script_ref": "0b74af50",
-      "sha256": "8635cd74c10e5a37ed0efa7dc55abcecf7997815cb77df6fb2488ec3eb42646d",
+      "sha256": "a5b5837542f2f57fadbb09db90a60c84f8efc0a65f8d6dcd2e5b9fca3a2b87e6",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/drawio/windows.json
+++ b/ee/maintained-apps/outputs/drawio/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "30.2.6",
+      "version": "30.3.6",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'draw.io' AND publisher = 'JGraph';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'draw.io' AND publisher = 'JGraph' AND version_compare(version, '30.2.6') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'draw.io' AND publisher = 'JGraph' AND version_compare(version, '30.3.6') < 0);"
       },
-      "installer_url": "https://github.com/jgraph/drawio-desktop/releases/download/v30.2.6/draw.io-30.2.6-windows-installer.exe",
+      "installer_url": "https://github.com/jgraph/drawio-desktop/releases/download/v30.3.6/draw.io-30.3.6-windows-installer.exe",
       "install_script_ref": "51038703",
       "uninstall_script_ref": "63a061f9",
-      "sha256": "3888e64403569f778bcf44752921790010b9de308d524c5855c5bff29df59b0e",
+      "sha256": "f4be779073073b9748b838ffc234a982cbad22279cabd2cd11438ca6cfc62f9b",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/front/darwin.json
+++ b/ee/maintained-apps/outputs/front/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.73.0",
+      "version": "3.76.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.frontapp.Front';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.frontapp.Front' AND version_compare(bundle_short_version, '3.73.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.frontapp.Front' AND version_compare(bundle_short_version, '3.76.3') < 0);"
       },
-      "installer_url": "https://dl.frontapp.com/desktop/builds/3.73.0/Front-3.73.0-arm64.zip",
+      "installer_url": "https://dl.frontapp.com/desktop/builds/3.76.3/Front-3.76.3-arm64.zip",
       "install_script_ref": "42b34fcd",
       "uninstall_script_ref": "e3bc7035",
-      "sha256": "69eaaa0d6db43abd55144c324e1bfc6491b25ab4796f063a843581f6e5974496",
+      "sha256": "ec0964c226a252d4342fcc3cec5d653dc54c131cf3c1e5c68ad4810838089a1a",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/gog-galaxy/windows.json
+++ b/ee/maintained-apps/outputs/gog-galaxy/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.0.100.1",
+      "version": "2.1.6.29",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'GOG GALAXY' AND publisher = 'GOG.com';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'GOG GALAXY' AND publisher = 'GOG.com' AND version_compare(version, '2.0.100.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'GOG GALAXY' AND publisher = 'GOG.com' AND version_compare(version, '2.1.6.29') < 0);"
       },
-      "installer_url": "https://content-system.gog.com/open_link/download?path=/open/galaxy/client/setup_galaxy_2.0.100.1.exe",
+      "installer_url": "https://content-system.gog.com/open_link/download?path=/open/galaxy/client/setup_galaxy_2.1.6.29.exe",
       "install_script_ref": "e1c78c6b",
       "uninstall_script_ref": "824492ce",
-      "sha256": "d04645ef5e4ada875f48d74828edd62222b2787eff09cb6e1c48e591949fd8f6",
+      "sha256": "c2888e0a1425823e47ed04c26e2d3c81cb14564a8e92d9c9628c3ed77a9d87bc",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/granola/windows.json
+++ b/ee/maintained-apps/outputs/granola/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.394.2",
+      "version": "7.394.3",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Granola %' AND publisher = 'Granola';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Granola %' AND publisher = 'Granola' AND version_compare(version, '7.394.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Granola %' AND publisher = 'Granola' AND version_compare(version, '7.394.3') < 0);"
       },
-      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.394.2/Granola-7.394.2-win-x64.exe",
+      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.394.3/Granola-7.394.3-win-x64.exe",
       "install_script_ref": "3f66ac53",
       "uninstall_script_ref": "a4fab3f5",
-      "sha256": "e1ea74204caf6597737b73efcf4e2ef8069c6a4b7607bd05bae41ba35c91f08a",
+      "sha256": "56b685bb20c47f1b0ee1a1ff70277ed0516e53f0060affcc7e4410f6d0d2ea2c",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/notepadexe/darwin.json
+++ b/ee/maintained-apps/outputs/notepadexe/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.5.1",
+      "version": "1.5.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'best.swift.Notepad';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'best.swift.Notepad' AND version_compare(bundle_short_version, '1.5.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'best.swift.Notepad' AND version_compare(bundle_short_version, '1.5.2') < 0);"
       },
-      "installer_url": "https://github.com/notepadhq/notepadexe-public/releases/download/1.5.1/Notepad.zip",
+      "installer_url": "https://github.com/notepadhq/notepadexe-public/releases/download/1.5.2/Notepad.zip",
       "install_script_ref": "17716d6a",
       "uninstall_script_ref": "abe56690",
-      "sha256": "d54b31e839142ee8ed6bb68e19dd3e3f0443be5916db88c09d62caa57db46b38",
+      "sha256": "f28a306b89fa29c764d2f5e004d0333ca460cd07fe555146500d54ca9f99ed6c",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/notion/windows.json
+++ b/ee/maintained-apps/outputs/notion/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.25.1",
+      "version": "7.26.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Notion %' AND publisher = 'Notion Labs, Inc';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Notion %' AND publisher = 'Notion Labs, Inc' AND version_compare(version, '7.25.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Notion %' AND publisher = 'Notion Labs, Inc' AND version_compare(version, '7.26.0') < 0);"
       },
-      "installer_url": "https://desktop-release.notion-static.com/Notion%20Setup%207.25.1.exe",
+      "installer_url": "https://desktop-release.notion-static.com/Notion%20Setup%207.26.0.exe",
       "install_script_ref": "0803ad8c",
       "uninstall_script_ref": "a8fdd9b7",
-      "sha256": "1da03f754a274faac7d90cdb3ed20aadcccc59660c1f851fa119dce5ac1fc794",
+      "sha256": "91ab6dc764fa71ba9cb1cfdf6206f8ff0a28b4acba0ccedb3e934dbf7ec240ad",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/ollama/darwin.json
+++ b/ee/maintained-apps/outputs/ollama/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.31.2",
+      "version": "0.32.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.ollama';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.ollama' AND version_compare(bundle_short_version, '0.31.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.ollama' AND version_compare(bundle_short_version, '0.32.0') < 0);"
       },
-      "installer_url": "https://github.com/ollama/ollama/releases/download/v0.31.2/Ollama-darwin.zip",
+      "installer_url": "https://github.com/ollama/ollama/releases/download/v0.32.0/Ollama-darwin.zip",
       "install_script_ref": "9f174559",
       "uninstall_script_ref": "bf40e2d5",
-      "sha256": "e8e7ad9e312b2dff11da2c1f3b18401e2096afaaa9ac8abbf01c64e67bad802d",
+      "sha256": "0762f0a5c086f77a5fceda3ec1e6a0d96500a114a8adc82856224bbc8f3a9d7f",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/opencode-desktop/darwin.json
+++ b/ee/maintained-apps/outputs/opencode-desktop/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.17.18",
+      "version": "1.17.20",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'ai.opencode.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'ai.opencode.desktop' AND version_compare(bundle_short_version, '1.17.18') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'ai.opencode.desktop' AND version_compare(bundle_short_version, '1.17.20') < 0);"
       },
-      "installer_url": "https://github.com/anomalyco/opencode/releases/download/v1.17.18/opencode-desktop-mac-arm64.dmg",
+      "installer_url": "https://github.com/anomalyco/opencode/releases/download/v1.17.20/opencode-desktop-mac-arm64.dmg",
       "install_script_ref": "727dc41e",
       "uninstall_script_ref": "ad62b190",
-      "sha256": "b52c4dcc27a0b91e98270476aad34cee265bbbc5993ee4cbfb30e35340ffffb7",
+      "sha256": "d539b03facca25ae876216465b9081b29d6a72280b6abf0bc9308652baa4aab3",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/superwhisper/darwin.json
+++ b/ee/maintained-apps/outputs/superwhisper/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.16.3",
+      "version": "2.16.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.superduper.superwhisper';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.superduper.superwhisper' AND version_compare(bundle_short_version, '2.16.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.superduper.superwhisper' AND version_compare(bundle_short_version, '2.16.4') < 0);"
       },
-      "installer_url": "https://builds.superwhisper.com/v2.16.3/superwhisper.zip",
+      "installer_url": "https://builds.superwhisper.com/v2.16.4/superwhisper.zip",
       "install_script_ref": "06338cb4",
       "uninstall_script_ref": "27ca9133",
-      "sha256": "e65246b88331d505673d99c575c1048d7d08d7d97874b22d2e7c3787a307905e",
+      "sha256": "8dbebd6eebd61106984e82809c757f771b86e18bd9ad8a6b6c499a24052d9cc0",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/syncovery/darwin.json
+++ b/ee/maintained-apps/outputs/syncovery/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "11.15.15",
+      "version": "11.15.16",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.company.Syncovery';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.company.Syncovery' AND version_compare(bundle_short_version, '11.15.15') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.company.Syncovery' AND version_compare(bundle_short_version, '11.15.16') < 0);"
       },
-      "installer_url": "https://www.syncovery.com/release/SyncoveryMac11.15.15-Apple.dmg",
+      "installer_url": "https://www.syncovery.com/release/SyncoveryMac11.15.16-Apple.dmg",
       "install_script_ref": "618d4067",
       "uninstall_script_ref": "04c1cc55",
-      "sha256": "d4ef0b5947dbe4545fdc8f65beb9e09b68b41e63f83e9c0f8761becfef5cfcbb",
+      "sha256": "0a5a000216756f830348b881fdacd4f51e96bdac1f4a0e3f5a17c190e7593d0d",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/wealthfolio/darwin.json
+++ b/ee/maintained-apps/outputs/wealthfolio/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.6.1",
+      "version": "3.6.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.teymz.wealthfolio';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.teymz.wealthfolio' AND version_compare(bundle_short_version, '3.6.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.teymz.wealthfolio' AND version_compare(bundle_short_version, '3.6.2') < 0);"
       },
-      "installer_url": "https://github.com/afadil/wealthfolio/releases/download/v3.6.1/Wealthfolio_3.6.1_aarch64.dmg",
+      "installer_url": "https://github.com/afadil/wealthfolio/releases/download/v3.6.2/Wealthfolio_3.6.2_aarch64.dmg",
       "install_script_ref": "161e063d",
       "uninstall_script_ref": "cd049db6",
-      "sha256": "214ea7b9060a114324ab5d1e214ab8d69c89ff6bd68aea638e1b16fe18aec602",
+      "sha256": "a2e2f58f2cbdfc52cdf46979bcc699a6ba03273f62fe05ea0cb5b6cba9776c11",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the latest releases of 15 maintained desktop applications across Windows and macOS.
  * Updated installable versions, download sources, and verification data for Bruno, Discord, Docker Desktop, Draw.io, Front, GOG Galaxy, Granola, Notepad.exe, Notion, Ollama, Opencode Desktop, Superwhisper, Syncovery, and Wealthfolio.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->