### PR TITLE
Fleet: Pin installer download token to a specific package (#49239)

### DIFF
--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -1295,22 +1295,25 @@ func (svc *Service) DownloadSoftwareInstaller(ctx context.Context, skipAuthz boo
 	// When installerID is set, target the specific package on a multi-package
 	// title. Nil falls back to the first-added default (single-package titles
 	// and pre-multi-package callers).
+	var meta *fleet.SoftwareInstaller
+	var err error
 	if installerID != nil {
 		if !skipAuthz {
 			if err := svc.authz.Authorize(ctx, &fleet.SoftwareInstaller{TeamID: teamID}, fleet.ActionRead); err != nil {
 				return nil, err
 			}
 		}
-		meta, err := svc.ds.GetSoftwareInstallerMetadataByTeamTitleAndInstallerID(ctx, teamID, titleID, *installerID, false)
+		// withScriptContents=false: only StorageID and Name are used below, so
+		// skip the script_contents join.
+		meta, err = svc.ds.GetSoftwareInstallerMetadataByTeamTitleAndInstallerID(ctx, teamID, titleID, *installerID, false)
 		if err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "getting pinned software installer metadata")
 		}
-		return svc.getSoftwareInstallerBinary(ctx, meta.StorageID, meta.Name)
-	}
-
-	meta, err := svc.GetSoftwareInstallerMetadata(ctx, skipAuthz, titleID, teamID)
-	if err != nil {
-		return nil, err
+	} else {
+		meta, err = svc.GetSoftwareInstallerMetadata(ctx, skipAuthz, titleID, teamID)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return svc.getSoftwareInstallerBinary(ctx, meta.StorageID, meta.Name)

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -1201,7 +1201,7 @@ func (svc *Service) GetSoftwareInstallerMetadata(ctx context.Context, skipAuthz 
 	return meta, nil
 }
 
-func (svc *Service) GenerateSoftwareInstallerToken(ctx context.Context, alt string, titleID uint, teamID *uint) (string, error) {
+func (svc *Service) GenerateSoftwareInstallerToken(ctx context.Context, alt string, titleID uint, teamID *uint, installerID *uint) (string, error) {
 	downloadRequested := alt == "media"
 	if !downloadRequested {
 		svc.authz.SkipAuthorization(ctx)
@@ -1220,6 +1220,11 @@ func (svc *Service) GenerateSoftwareInstallerToken(ctx context.Context, alt stri
 	meta := fleet.SoftwareInstallerTokenMetadata{
 		TitleID: titleID,
 		TeamID:  *teamID,
+	}
+	// Nil installerID means "no per-package pin" — the token consumer falls
+	// back to the first-added package. Preserves single-package back-compat.
+	if installerID != nil {
+		meta.InstallerID = *installerID
 	}
 	metaByte, err := json.Marshal(meta)
 	if err != nil {
@@ -1274,7 +1279,7 @@ func (svc *Service) GetSoftwareInstallerTokenMetadata(ctx context.Context, token
 }
 
 func (svc *Service) DownloadSoftwareInstaller(ctx context.Context, skipAuthz bool, alt string, titleID uint,
-	teamID *uint,
+	teamID *uint, installerID *uint,
 ) (*fleet.DownloadSoftwareInstallerPayload, error) {
 	downloadRequested := alt == "media"
 	if !downloadRequested {
@@ -1285,6 +1290,22 @@ func (svc *Service) DownloadSoftwareInstaller(ctx context.Context, skipAuthz boo
 	if teamID == nil {
 		svc.authz.SkipAuthorization(ctx)
 		return nil, fleet.NewInvalidArgumentError("fleet_id", "is required")
+	}
+
+	// When installerID is set, target the specific package on a multi-package
+	// title. Nil falls back to the first-added default (single-package titles
+	// and pre-multi-package callers).
+	if installerID != nil {
+		if !skipAuthz {
+			if err := svc.authz.Authorize(ctx, &fleet.SoftwareInstaller{TeamID: teamID}, fleet.ActionRead); err != nil {
+				return nil, err
+			}
+		}
+		meta, err := svc.ds.GetSoftwareInstallerMetadataByTeamTitleAndInstallerID(ctx, teamID, titleID, *installerID, false)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "getting pinned software installer metadata")
+		}
+		return svc.getSoftwareInstallerBinary(ctx, meta.StorageID, meta.Name)
 	}
 
 	meta, err := svc.GetSoftwareInstallerMetadata(ctx, skipAuthz, titleID, teamID)

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
@@ -34,8 +34,6 @@ import softwareAPI, {
 } from "services/entities/software";
 
 import { getPathWithQueryParams } from "utilities/url";
-import endpoints from "utilities/endpoints";
-import URL_PREFIX from "router/url_prefix";
 import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
 
 import { notify } from "components/ToastNotification";
@@ -59,7 +57,12 @@ import AddPackageModal from "./AddPackageModal";
 import PoliciesModal from "./PoliciesModal";
 import VersionsModal from "./VersionsModal";
 import { getDisplayedSoftwareName, mergePolicies } from "../helpers";
-import { buildLibraryVersionRows, canDownloadInstallerRow } from "./helpers";
+import {
+  buildInstallerDownloadUrl,
+  buildLibraryVersionRows,
+  canDownloadInstallerRow,
+  resolveDownloadTarget,
+} from "./helpers";
 import TitleVersionsTable from "./TitleVersionsTable";
 
 const baseClass = "software-title-details-page";
@@ -203,33 +206,38 @@ const SoftwareTitleDetailsPage = ({
     );
   }, [queryClient, refetchSoftwareTitle, router, softwareTitle, teamIdForApi]);
 
-  // Mints a one-shot download token and triggers the browser download via a
-  // synthetic `<a download>` click. The token-based URL is unauthenticated;
-  // we must build it client-side rather than redirecting.
-  const onDownloadInstaller = useCallback(async () => {
-    const pkg = softwareTitle?.software_package;
-    if (!pkg || typeof teamIdForApi !== "number") return;
-    try {
-      const resp = await softwareAPI.getSoftwarePackageToken(
-        softwareId,
-        teamIdForApi
+  // Mints a one-shot download token pinned to the clicked package and triggers
+  // the browser download via a synthetic `<a download>` click. The token-based
+  // URL is unauthenticated; we must build it client-side rather than
+  // redirecting. Falls back to the title's first-added `software_package` when
+  // no per-row pkg is supplied (single-package titles / legacy callers).
+  const onDownloadInstaller = useCallback(
+    async (pkg?: ISoftwarePackage) => {
+      const target = resolveDownloadTarget(
+        pkg,
+        softwareTitle?.software_package
       );
-      if (!resp.token) {
-        throw new Error("No download token returned");
+      if (!target || typeof teamIdForApi !== "number") return;
+      try {
+        const resp = await softwareAPI.getSoftwarePackageToken(
+          softwareId,
+          teamIdForApi,
+          target.installer_id
+        );
+        if (!resp.token) {
+          throw new Error("No download token returned");
+        }
+        const a = document.createElement("a");
+        a.href = buildInstallerDownloadUrl(softwareId, resp.token);
+        a.download = target.name;
+        a.click();
+        a.remove();
+      } catch (e) {
+        notify.error("Couldn't download. Please try again.");
       }
-      const { origin } = global.window.location;
-      const url = `${origin}${URL_PREFIX}/api${endpoints.SOFTWARE_PACKAGE_TOKEN(
-        softwareId
-      )}/${resp.token}`;
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = pkg.name;
-      a.click();
-      a.remove();
-    } catch (e) {
-      notify.error("Couldn't download. Please try again.");
-    }
-  }, [softwareId, softwareTitle, teamIdForApi]);
+    },
+    [softwareId, softwareTitle, teamIdForApi]
+  );
 
   const onTeamChange = useCallback(
     (teamId: number) => {
@@ -391,7 +399,7 @@ const SoftwareTitleDetailsPage = ({
           }
           onLabelCountClick={() => openEditModal(pkg.installer_id)}
           onLabelsClick={() => openEditModal(pkg.installer_id)}
-          onDownloadClick={onDownloadInstaller}
+          onDownloadClick={() => onDownloadInstaller(pkg)}
           onTrashClick={() => openDeleteModal(pkg.installer_id)}
           onSelfServiceClick={() => openEditModal(pkg.installer_id)}
           onAutoInstallClick={() => {

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/helpers.tests.ts
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/helpers.tests.ts
@@ -1,8 +1,11 @@
+import { createMockSoftwarePackage } from "__mocks__/softwareMock";
 import { ISoftwareTitleDetails } from "interfaces/software";
 import {
+  buildInstallerDownloadUrl,
   buildLibraryVersionRows,
   canDownloadInstallerRow,
   getInstallerCardInfo,
+  resolveDownloadTarget,
 } from "./helpers";
 
 const v = (id: number, version: string) => ({
@@ -215,6 +218,42 @@ describe("SoftwareTitleDetailsPage helpers", () => {
 
     it("hides the button when both conditions fail", () => {
       expect(canDownloadInstallerRow(false, false)).toBe(false);
+    });
+  });
+
+  describe("resolveDownloadTarget", () => {
+    // Guards the multi-package download flow: clicking a specific row must
+    // pin the download to that row's package, not the title's first-added.
+    const first = createMockSoftwarePackage({
+      installer_id: 1,
+      name: "acme-1.pkg",
+    });
+    const second = createMockSoftwarePackage({
+      installer_id: 2,
+      name: "acme-2.pkg",
+    });
+
+    it("returns the clicked package when both are provided (#49239)", () => {
+      expect(resolveDownloadTarget(second, first)).toBe(second);
+    });
+
+    it("falls back to the title's software_package when no row pkg is passed", () => {
+      expect(resolveDownloadTarget(undefined, first)).toBe(first);
+    });
+
+    it("returns null when neither is available", () => {
+      expect(resolveDownloadTarget(undefined, null)).toBeNull();
+      expect(resolveDownloadTarget(undefined, undefined)).toBeNull();
+    });
+  });
+
+  describe("buildInstallerDownloadUrl", () => {
+    it("assembles the token-based download URL for the given title id", () => {
+      expect(
+        buildInstallerDownloadUrl(42, "abc123", "https://fleet.example.com")
+      ).toBe(
+        "https://fleet.example.com/api/latest/fleet/software/titles/42/package/token/abc123"
+      );
     });
   });
 });

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/helpers.ts
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/helpers.ts
@@ -7,6 +7,8 @@ import {
   ISoftwarePackage,
   IFleetMaintainedVersion,
 } from "interfaces/software";
+import endpoints from "utilities/endpoints";
+import URL_PREFIX from "router/url_prefix";
 import { getDisplayedSoftwareName } from "../helpers";
 import { deriveAccordionRowState } from "./LibraryItemAccordion/helpers";
 import { LibraryItemBadgeState } from "./LibraryItemAccordion/LibraryItemAccordion";
@@ -20,6 +22,26 @@ export const canDownloadInstallerRow = (
   rowIsActive: boolean,
   hasInstallerReadPermission: boolean
 ): boolean => rowIsActive && hasInstallerReadPermission;
+
+/** Resolves which package to download: the explicitly-clicked row on a
+ * multi-package title, or the title's first-added `software_package` for
+ * single-package callers. Returns null when neither is available (e.g.,
+ * an app-store title with no `software_package`). */
+export const resolveDownloadTarget = (
+  clicked: ISoftwarePackage | undefined,
+  fallback: ISoftwarePackage | null | undefined
+): ISoftwarePackage | null => clicked ?? fallback ?? null;
+
+/** Builds the unauthenticated token-based download URL that the browser hits
+ * via a synthetic `<a download>` click. */
+export const buildInstallerDownloadUrl = (
+  softwareTitleId: number,
+  token: string,
+  origin: string = global.window.location.origin
+): string =>
+  `${origin}${URL_PREFIX}/api${endpoints.SOFTWARE_PACKAGE_TOKEN(
+    softwareTitleId
+  )}/${token}`;
 
 export interface InstallerCardInfo {
   softwareTitleName: string;

--- a/frontend/services/entities/software.tests.ts
+++ b/frontend/services/entities/software.tests.ts
@@ -1,0 +1,37 @@
+import sendRequest from "services";
+import softwareAPI from "./software";
+
+jest.mock("services", () => ({
+  __esModule: true,
+  default: jest.fn(),
+  sendRequestWithHeaders: jest.fn(),
+  sendRequestWithProgressAndHeaders: jest.fn(),
+}));
+
+const mockSendRequest = sendRequest as jest.MockedFunction<typeof sendRequest>;
+
+describe("softwareAPI.getSoftwarePackageToken", () => {
+  beforeEach(() => {
+    mockSendRequest.mockReset();
+    mockSendRequest.mockResolvedValue({ token: "test-token" });
+  });
+
+  it("omits installer_id from the query when undefined (single-package back-compat)", async () => {
+    await softwareAPI.getSoftwarePackageToken(42, 7);
+
+    const [method, path] = mockSendRequest.mock.calls[0];
+    expect(method).toBe("POST");
+    expect(path).toContain("/software/titles/42/package/token");
+    expect(path).toContain("alt=media");
+    expect(path).toContain("fleet_id=7");
+    expect(path).not.toContain("installer_id");
+  });
+
+  it("forwards installer_id as a query param when provided (#49239)", async () => {
+    await softwareAPI.getSoftwarePackageToken(42, 7, 99);
+
+    const [, path] = mockSendRequest.mock.calls[0];
+    expect(path).toContain("installer_id=99");
+    expect(path).toContain("fleet_id=7");
+  });
+});

--- a/frontend/services/entities/software.tests.ts
+++ b/frontend/services/entities/software.tests.ts
@@ -4,8 +4,6 @@ import softwareAPI from "./software";
 jest.mock("services", () => ({
   __esModule: true,
   default: jest.fn(),
-  sendRequestWithHeaders: jest.fn(),
-  sendRequestWithProgressAndHeaders: jest.fn(),
 }));
 
 const mockSendRequest = sendRequest as jest.MockedFunction<typeof sendRequest>;

--- a/frontend/services/entities/software.ts
+++ b/frontend/services/entities/software.ts
@@ -789,11 +789,18 @@ export default {
 
   getSoftwarePackageToken: (
     softwareTitleId: number,
-    teamId: number
+    teamId: number,
+    /** Pins the token to a specific package on a multi-package title. Omit for
+     * single-package titles to fall back to the first-added package. */
+    installerId?: number
   ): Promise<ISoftwareInstallTokenResponse> => {
     const path = `${endpoints.SOFTWARE_PACKAGE_TOKEN(
       softwareTitleId
-    )}?${buildQueryStringFromParams({ alt: "media", fleet_id: teamId })}`;
+    )}?${buildQueryStringFromParams({
+      alt: "media",
+      fleet_id: teamId,
+      installer_id: installerId,
+    })}`;
 
     return sendRequest("POST", path);
   },

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -1389,11 +1389,11 @@ type Service interface {
 	UploadSoftwareInstaller(ctx context.Context, payload *UploadSoftwareInstallerPayload) (*SoftwareInstaller, error)
 	UpdateSoftwareInstaller(ctx context.Context, payload *UpdateSoftwareInstallerPayload) (*SoftwareInstaller, error)
 	DeleteSoftwareInstaller(ctx context.Context, titleID uint, teamID *uint, installerID *uint) error
-	GenerateSoftwareInstallerToken(ctx context.Context, alt string, titleID uint, teamID *uint) (string, error)
+	GenerateSoftwareInstallerToken(ctx context.Context, alt string, titleID uint, teamID *uint, installerID *uint) (string, error)
 	GetSoftwareInstallerTokenMetadata(ctx context.Context, token string, titleID uint) (*SoftwareInstallerTokenMetadata, error)
 	GetSoftwareInstallerMetadata(ctx context.Context, skipAuthz bool, titleID uint, teamID *uint) (*SoftwareInstaller, error)
 	DownloadSoftwareInstaller(ctx context.Context, skipAuthz bool, alt string, titleID uint,
-		teamID *uint) (*DownloadSoftwareInstallerPayload, error)
+		teamID *uint, installerID *uint) (*DownloadSoftwareInstallerPayload, error)
 	OrbitDownloadSoftwareInstaller(ctx context.Context, installerID uint) (*DownloadSoftwareInstallerPayload, error)
 
 	/////////////////////////////////////////////////////////////////////////////////

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -1177,6 +1177,10 @@ const (
 type SoftwareInstallerTokenMetadata struct {
 	TitleID uint `json:"title_id"`
 	TeamID  uint `json:"team_id" renameto:"fleet_id"`
+	// InstallerID pins the token to a specific package on a multi-package
+	// title. Zero means "fall back to the first-added package" so single-package
+	// titles and pre-multi-package callers keep working.
+	InstallerID uint `json:"installer_id,omitempty"`
 }
 
 const SoftwareInstallerURLMaxLength = 4000

--- a/server/mock/service/service_mock.go
+++ b/server/mock/service/service_mock.go
@@ -838,13 +838,13 @@ type UpdateSoftwareInstallerFunc func(ctx context.Context, payload *fleet.Update
 
 type DeleteSoftwareInstallerFunc func(ctx context.Context, titleID uint, teamID *uint, installerID *uint) error
 
-type GenerateSoftwareInstallerTokenFunc func(ctx context.Context, alt string, titleID uint, teamID *uint) (string, error)
+type GenerateSoftwareInstallerTokenFunc func(ctx context.Context, alt string, titleID uint, teamID *uint, installerID *uint) (string, error)
 
 type GetSoftwareInstallerTokenMetadataFunc func(ctx context.Context, token string, titleID uint) (*fleet.SoftwareInstallerTokenMetadata, error)
 
 type GetSoftwareInstallerMetadataFunc func(ctx context.Context, skipAuthz bool, titleID uint, teamID *uint) (*fleet.SoftwareInstaller, error)
 
-type DownloadSoftwareInstallerFunc func(ctx context.Context, skipAuthz bool, alt string, titleID uint, teamID *uint) (*fleet.DownloadSoftwareInstallerPayload, error)
+type DownloadSoftwareInstallerFunc func(ctx context.Context, skipAuthz bool, alt string, titleID uint, teamID *uint, installerID *uint) (*fleet.DownloadSoftwareInstallerPayload, error)
 
 type OrbitDownloadSoftwareInstallerFunc func(ctx context.Context, installerID uint) (*fleet.DownloadSoftwareInstallerPayload, error)
 
@@ -5247,11 +5247,11 @@ func (s *Service) DeleteSoftwareInstaller(ctx context.Context, titleID uint, tea
 	return s.DeleteSoftwareInstallerFunc(ctx, titleID, teamID, installerID)
 }
 
-func (s *Service) GenerateSoftwareInstallerToken(ctx context.Context, alt string, titleID uint, teamID *uint) (string, error) {
+func (s *Service) GenerateSoftwareInstallerToken(ctx context.Context, alt string, titleID uint, teamID *uint, installerID *uint) (string, error) {
 	s.mu.Lock()
 	s.GenerateSoftwareInstallerTokenFuncInvoked = true
 	s.mu.Unlock()
-	return s.GenerateSoftwareInstallerTokenFunc(ctx, alt, titleID, teamID)
+	return s.GenerateSoftwareInstallerTokenFunc(ctx, alt, titleID, teamID, installerID)
 }
 
 func (s *Service) GetSoftwareInstallerTokenMetadata(ctx context.Context, token string, titleID uint) (*fleet.SoftwareInstallerTokenMetadata, error) {
@@ -5268,11 +5268,11 @@ func (s *Service) GetSoftwareInstallerMetadata(ctx context.Context, skipAuthz bo
 	return s.GetSoftwareInstallerMetadataFunc(ctx, skipAuthz, titleID, teamID)
 }
 
-func (s *Service) DownloadSoftwareInstaller(ctx context.Context, skipAuthz bool, alt string, titleID uint, teamID *uint) (*fleet.DownloadSoftwareInstallerPayload, error) {
+func (s *Service) DownloadSoftwareInstaller(ctx context.Context, skipAuthz bool, alt string, titleID uint, teamID *uint, installerID *uint) (*fleet.DownloadSoftwareInstallerPayload, error) {
 	s.mu.Lock()
 	s.DownloadSoftwareInstallerFuncInvoked = true
 	s.mu.Unlock()
-	return s.DownloadSoftwareInstallerFunc(ctx, skipAuthz, alt, titleID, teamID)
+	return s.DownloadSoftwareInstallerFunc(ctx, skipAuthz, alt, titleID, teamID, installerID)
 }
 
 func (s *Service) OrbitDownloadSoftwareInstaller(ctx context.Context, installerID uint) (*fleet.DownloadSoftwareInstallerPayload, error) {

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -17468,6 +17468,51 @@ func (s *integrationEnterpriseTestSuite) TestSoftwareMultiplePackagesPerTitle() 
 		require.False(t, hasLastUninstall, "list packages[] must omit last_uninstall")
 	}
 
+	// --- Download token: installer_id pins the token to a specific package (#49239) ---
+	// Bug: the token endpoint ignored installer_id and always dispatched
+	// first-added, so the UI download button on any row of a multi-package title
+	// fetched A regardless of which row the user clicked.
+	readAllAndClose := func(t *testing.T, r *http.Response) []byte {
+		t.Helper()
+		defer r.Body.Close()
+		b, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		return b
+	}
+	tokenDownload := func(t *testing.T, args ...string) []byte {
+		t.Helper()
+		var tok getSoftwareInstallerTokenResponse
+		s.DoJSON("POST",
+			fmt.Sprintf("/api/latest/fleet/software/titles/%d/package/token?alt=media", titleID),
+			nil, http.StatusOK, &tok, args...)
+		require.NotEmpty(t, tok.Token)
+		r := s.DoRawNoAuth("GET",
+			fmt.Sprintf("/api/latest/fleet/software/titles/%d/package/token/%s", titleID, tok.Token),
+			nil, http.StatusOK)
+		return readAllAndClose(t, r)
+	}
+	teamArg := []string{"team_id", fmt.Sprintf("%d", team.ID)}
+	// Omitting installer_id falls back to first-added (A), preserving single-package back-compat.
+	require.Equal(t, contentA, string(tokenDownload(t, teamArg...)),
+		"no installer_id defaults to first-added (A)")
+	// Explicit installer_id=A resolves to A.
+	require.Equal(t, contentA,
+		string(tokenDownload(t, append(teamArg, "installer_id", fmt.Sprintf("%d", installerA))...)),
+		"installer_id=A returns A's content")
+	// Explicit installer_id=B resolves to B (the fix).
+	require.Equal(t, contentB,
+		string(tokenDownload(t, append(teamArg, "installer_id", fmt.Sprintf("%d", installerB))...)),
+		"installer_id=B returns B's content, not first-added")
+
+	// Direct (non-token) download endpoint honors installer_id too.
+	rDirect := s.Do("GET",
+		fmt.Sprintf("/api/latest/fleet/software/titles/%d/package?alt=media", titleID),
+		nil, http.StatusOK,
+		"team_id", fmt.Sprintf("%d", team.ID),
+		"installer_id", fmt.Sprintf("%d", installerB))
+	require.Equal(t, contentB, string(readAllAndClose(t, rDirect)),
+		"direct download with installer_id=B returns B")
+
 	// --- Edit without installer_id on a multi-package title -> 400 ---
 	s.updateSoftwareInstaller(t, &fleet.UpdateSoftwareInstallerPayload{
 		TitleID:     titleID,

--- a/server/service/software_installers.go
+++ b/server/service/software_installers.go
@@ -552,9 +552,15 @@ func (svc *Service) DeleteSoftwareInstaller(ctx context.Context, titleID uint, t
 }
 
 type getSoftwareInstallerRequest struct {
-	Alt     string `query:"alt,optional"`
-	TeamID  *uint  `query:"team_id" renameto:"fleet_id"`
-	TitleID uint   `url:"title_id"`
+	Alt string `query:"alt,optional"`
+	// TeamID is required. Kept as *uint so a missing query parameter returns a
+	// validation error instead of matching team 0.
+	TeamID  *uint `query:"team_id" renameto:"fleet_id"`
+	TitleID uint  `url:"title_id"`
+	// InstallerID pins the download to a specific package on a multi-package
+	// title. Omit for single-package titles or to fall back to the first-added
+	// package.
+	InstallerID *uint `query:"installer_id,optional"`
 }
 
 type downloadSoftwareInstallerRequest struct {
@@ -565,7 +571,7 @@ type downloadSoftwareInstallerRequest struct {
 func getSoftwareInstallerEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (fleet.Errorer, error) {
 	req := request.(*getSoftwareInstallerRequest)
 
-	payload, err := svc.DownloadSoftwareInstaller(ctx, false, req.Alt, req.TitleID, req.TeamID)
+	payload, err := svc.DownloadSoftwareInstaller(ctx, false, req.Alt, req.TitleID, req.TeamID, req.InstallerID)
 	if err != nil {
 		return orbitDownloadSoftwareInstallerResponse{Err: err}, nil
 	}
@@ -576,7 +582,7 @@ func getSoftwareInstallerEndpoint(ctx context.Context, request interface{}, svc 
 func getSoftwareInstallerTokenEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (fleet.Errorer, error) {
 	req := request.(*getSoftwareInstallerRequest)
 
-	token, err := svc.GenerateSoftwareInstallerToken(ctx, req.Alt, req.TitleID, req.TeamID)
+	token, err := svc.GenerateSoftwareInstallerToken(ctx, req.Alt, req.TitleID, req.TeamID, req.InstallerID)
 	if err != nil {
 		return getSoftwareInstallerTokenResponse{Err: err}, nil
 	}
@@ -591,7 +597,13 @@ func downloadSoftwareInstallerEndpoint(ctx context.Context, request interface{},
 		return orbitDownloadSoftwareInstallerResponse{Err: err}, nil
 	}
 
-	payload, err := svc.DownloadSoftwareInstaller(ctx, true, "media", meta.TitleID, &meta.TeamID)
+	// Zero InstallerID means the token was minted without a specific pin — fall
+	// back to first-added by passing nil.
+	var installerID *uint
+	if meta.InstallerID != 0 {
+		installerID = &meta.InstallerID
+	}
+	payload, err := svc.DownloadSoftwareInstaller(ctx, true, "media", meta.TitleID, &meta.TeamID, installerID)
 	if err != nil {
 		return orbitDownloadSoftwareInstallerResponse{Err: err}, nil
 	}
@@ -599,7 +611,7 @@ func downloadSoftwareInstallerEndpoint(ctx context.Context, request interface{},
 	return orbitDownloadSoftwareInstallerResponse{payload: payload}, nil
 }
 
-func (svc *Service) GenerateSoftwareInstallerToken(ctx context.Context, _ string, _ uint, _ *uint) (string, error) {
+func (svc *Service) GenerateSoftwareInstallerToken(ctx context.Context, _ string, _ uint, _ *uint, _ *uint) (string, error) {
 	// skipauth: No authorization check needed due to implementation returning
 	// only license error.
 	svc.authz.SkipAuthorization(ctx)
@@ -663,7 +675,7 @@ func (r orbitDownloadSoftwareInstallerResponse) HijackRender(ctx context.Context
 }
 
 func (svc *Service) DownloadSoftwareInstaller(ctx context.Context, _ bool, _ string, _ uint,
-	_ *uint) (*fleet.DownloadSoftwareInstallerPayload,
+	_ *uint, _ *uint) (*fleet.DownloadSoftwareInstallerPayload,
 	error,
 ) {
 	// skipauth: No authorization check needed due to implementation returning

--- a/server/service/software_installers_test.go
+++ b/server/service/software_installers_test.go
@@ -183,7 +183,7 @@ func TestSoftwareInstallersAuth(t *testing.T) {
 				return map[fleet.MDMAssetName]fleet.MDMConfigAsset{}, nil
 			}
 
-			_, err = svc.DownloadSoftwareInstaller(ctx, false, "media", 1, tt.teamID)
+			_, err = svc.DownloadSoftwareInstaller(ctx, false, "media", 1, tt.teamID, nil)
 			if tt.teamID == nil {
 				require.Error(t, err)
 			} else {


### PR DESCRIPTION
## Issue
Resolves #49239. Companion FE-only follow-up: #49244.

## Description
The `POST /api/fleet/software/titles/:id/package/token` endpoint didn't accept `installer_id`, so on a multi-package title the download button on any row always fetched the first-added package regardless of which row the user clicked.

### Backend

- `getSoftwareInstallerRequest` gains optional `InstallerID` (query param).
- `SoftwareInstallerTokenMetadata` stores `InstallerID` alongside title/team so the token consumer can re-target the pinned package after the redirect.
- `GenerateSoftwareInstallerToken` and `DownloadSoftwareInstaller` take an optional `installerID *uint`; free-tier stubs match. When set, `DownloadSoftwareInstaller` fetches meta via `GetSoftwareInstallerMetadataByTeamTitleAndInstallerID` (with an explicit read authz) instead of the first-added default; nil preserves single-package back-compat.
- Regenerated service mock.

### Frontend

- `getSoftwarePackageToken` accepts an optional `installerId` and forwards it as `installer_id` in the query string.
- `onDownloadInstaller` now accepts a package argument (defaulting to `software_package` for single-package callers), sends `installer_id`, and uses the clicked package's name for the browser download filename.
- Extracted `resolveDownloadTarget` + `buildInstallerDownloadUrl` into `SoftwareTitleDetailsPage/helpers.ts` so the download-target / URL logic is unit-testable without a full-page render.

### CI fix

`server/datastore/mysql/policies_test.go:9085` was calling `ds.ListTeamPolicies` with 5 args after the signature was extended to require a `platform` string, blocking `test-go (mysql, ...)` on the feature branch. Bumped the call to pass `""` for `platform`. Same fix is on #49244 so both branches' CI can pass independently.

## Screenrecording


https://github.com/user-attachments/assets/b6c48b2b-ae0f-4882-9bca-14658e182c79


## Testing

- Extended `TestSoftwareMultiplePackagesPerTitle` (integration): token minted with `installer_id=N` returns that specific installer's file on both the token endpoint and the direct download endpoint; no `installer_id` still falls back to first-added.
- New `frontend/services/entities/software.tests.ts`: `getSoftwarePackageToken` adds `installer_id` to the query string only when provided.
- `SoftwareTitleDetailsPage/helpers.tests.ts`: unit tests for `resolveDownloadTarget` (clicked row wins over first-added) and `buildInstallerDownloadUrl`.

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually