### PR TITLE
Fix mismatched package upload creating a new title instead of erroring

### DIFF
--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -9082,7 +9082,7 @@ func testApplyPolicySpecFirstAddedInstaller(t *testing.T, ds *Datastore) {
 	})
 	require.NoError(t, err)
 
-	policies, _, err := ds.ListTeamPolicies(ctx, team.ID, fleet.ListOptions{}, fleet.ListOptions{}, "")
+	policies, _, err := ds.ListTeamPolicies(ctx, team.ID, fleet.ListOptions{}, fleet.ListOptions{}, "", "")
 	require.NoError(t, err)
 	require.Len(t, policies, 1)
 	require.NotNil(t, policies[0].SoftwareInstallerID)

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -4371,10 +4371,16 @@ func (ds *Datastore) checkSoftwareConflictsByIdentifier(ctx context.Context, pay
 	if payload.FleetMaintainedAppID == nil {
 		titleID, err := ds.getExistingSoftwareInstallerTitleID(ctx, payload)
 		if fleet.IsNotFound(err) {
+			if payload.TitleID != nil {
+				return &fleet.BadRequestError{Message: fmt.Sprintf(fleet.SoftwarePackageTitleMismatchMessage, payload.Filename)}
+			}
 			return nil
 		}
 		if err != nil {
 			return err
+		}
+		if payload.TitleID != nil && titleID != *payload.TitleID {
+			return &fleet.BadRequestError{Message: fmt.Sprintf(fleet.SoftwarePackageTitleMismatchMessage, payload.Filename)}
 		}
 
 		// A package can't repeat the same bytes within its title. Scripts also dedupe

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -71,6 +71,7 @@ func TestSoftwareInstallers(t *testing.T) {
 		{"CustomToFMAInstallerReplacement", testCustomToFMAInstallerReplacement},
 		{"GetInstallerByTeamAndURL", testGetInstallerByTeamAndURL},
 		{"BatchSetFMACancelsPendingOnActiveRow", testBatchSetFMACancelsPendingOnActiveRow},
+		{"SoftwareInstallerTitleIDValidation", testSoftwareInstallerTitleIDValidation},
 		{"MatchOrCreateSoftwareInstallerDuplicateConflicts", testMatchOrCreateSoftwareInstallerDuplicateConflicts},
 		{"SetHostSoftwareInstallResultResolvesOrphanedActivity", testSetHostSoftwareInstallResultResolvesOrphanedActivity},
 		{"GetSoftwareTitlesForInstallAll", testGetSoftwareTitlesForInstallAll},
@@ -6055,6 +6056,78 @@ func testBatchSetFMACancelsPendingOnActiveRow(t *testing.T, ds *Datastore) {
 		`, v2ID)
 	})
 	require.Zero(t, pending, "re-submitting the active FMA version must cancel its pending installs")
+}
+
+func testSoftwareInstallerTitleIDValidation(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+	user := test.NewUser(t, ds, "Alice", "alice@example.com", true)
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: t.Name()})
+	require.NoError(t, err)
+
+	payload := func(title, bundleID, filename, storageID string) *fleet.UploadSoftwareInstallerPayload {
+		return &fleet.UploadSoftwareInstallerPayload{
+			StorageID:        storageID,
+			Filename:         filename,
+			Title:            title,
+			BundleIdentifier: bundleID,
+			Extension:        "pkg",
+			Source:           "apps",
+			Platform:         "darwin",
+			Version:          "1.0",
+			UserID:           user.ID,
+			ValidatedLabels:  &fleet.LabelIdentsWithScope{},
+			TeamID:           &team.ID,
+		}
+	}
+
+	_, targetTitleID, err := ds.MatchOrCreateSoftwareInstaller(ctx, payload("Target", "com.example.target", "target.pkg", "target-v1"))
+	require.NoError(t, err)
+	_, otherTitleID, err := ds.MatchOrCreateSoftwareInstaller(ctx, payload("Other", "com.example.other", "other.pkg", "other-v1"))
+	require.NoError(t, err)
+
+	matching := payload("Target", "com.example.target", "target-v2.pkg", "target-v2")
+	matching.TitleID = &targetTitleID
+	_, gotTitleID, err := ds.MatchOrCreateSoftwareInstaller(ctx, matching)
+	require.NoError(t, err)
+	require.Equal(t, targetTitleID, gotTitleID)
+
+	rowCounts := func() (titles, installers int) {
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			if err := sqlx.GetContext(ctx, q, &titles, `SELECT COUNT(*) FROM software_titles`); err != nil {
+				return err
+			}
+			return sqlx.GetContext(ctx, q, &installers, `SELECT COUNT(*) FROM software_installers`)
+		})
+		return titles, installers
+	}
+
+	assertRejectedWithoutWrites := func(p *fleet.UploadSoftwareInstallerPayload) {
+		t.Helper()
+		beforeTitles, beforeInstallers := rowCounts()
+		_, _, err := ds.MatchOrCreateSoftwareInstaller(ctx, p)
+		require.ErrorContains(t, err, fmt.Sprintf(fleet.SoftwarePackageTitleMismatchMessage, p.Filename))
+		afterTitles, afterInstallers := rowCounts()
+		require.Equal(t, beforeTitles, afterTitles)
+		require.Equal(t, beforeInstallers, afterInstallers)
+	}
+
+	mismatching := payload("Target", "com.example.target", "target-mismatch.pkg", "target-mismatch")
+	mismatching.TitleID = &otherTitleID
+	assertRejectedWithoutWrites(mismatching)
+
+	nonexistentTitleID := uint(999999)
+	nonexistent := payload("Target", "com.example.target", "target-nonexistent.pkg", "target-nonexistent")
+	nonexistent.TitleID = &nonexistentTitleID
+	assertRejectedWithoutWrites(nonexistent)
+
+	noResolvedTitle := payload("New", "com.example.new", "new.pkg", "new")
+	noResolvedTitle.TitleID = &targetTitleID
+	assertRejectedWithoutWrites(noResolvedTitle)
+
+	withoutTitleID := payload("Unspecified", "com.example.unspecified", "unspecified.pkg", "unspecified")
+	_, newTitleID, err := ds.MatchOrCreateSoftwareInstaller(ctx, withoutTitleID)
+	require.NoError(t, err)
+	require.NotZero(t, newTitleID)
 }
 
 func testMatchOrCreateSoftwareInstallerDuplicateConflicts(t *testing.T, ds *Datastore) {

--- a/server/fleet/errors.go
+++ b/server/fleet/errors.go
@@ -38,6 +38,7 @@ var (
 	CantResendAppleDeclarationProfilesMessage    = "Can't resend declaration (DDM) profiles. Unlike configuration profiles (.mobileconfig), the host automatically checks in to get the latest DDM profiles."
 	CantAddSoftwareConflictMessage               = "Couldn't add software. %s already has an installer available for the %s fleet."
 	SoftwarePackageHashConflictMessage           = "%s package is already added (same SHA-256 hash)."
+	SoftwarePackageTitleMismatchMessage          = "Couldn't add. %s doesn't match the software title. To add it, go to Software and add it as new software."
 	SoftwareAlreadyHasVPPAppMessage              = "%s already has an Apple App Store (VPP) on the %s fleet."
 	SoftwareAlreadyHasFleetMaintainedAppMessage  = "%s already has a Fleet-maintained app on the %s fleet."
 	SoftwareAlreadyHasPackageMessage             = "%s already has a software package on the %s fleet."

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -564,6 +564,7 @@ func (s *HostSoftwareInstallerResultAuthz) AuthzType() string {
 
 type UploadSoftwareInstallerPayload struct {
 	TeamID               *uint
+	TitleID              *uint
 	InstallScript        string
 	PreInstallQuery      string
 	PostInstallScript    string

--- a/server/service/integration_software_titles_test.go
+++ b/server/service/integration_software_titles_test.go
@@ -795,6 +795,106 @@ func (s *integrationMDMTestSuite) TestListSoftwareTitlesByHashAndName() {
 	require.GreaterOrEqual(t, len(respAll.SoftwareTitles), 2) // At least the two packages we uploaded
 }
 
+func (s *integrationMDMTestSuite) TestSoftwarePackageTitleValidation() {
+	t := s.T()
+	ctx := t.Context()
+
+	var teamResp teamResponse
+	s.DoJSON("POST", "/api/latest/fleet/teams", &createTeamRequest{TeamPayload: fleet.TeamPayload{Name: new("team_" + t.Name())}}, http.StatusOK, &teamResp)
+	team := teamResp.Team
+
+	type counts struct {
+		titles     int
+		installers int
+		activities int
+	}
+	rowCounts := func() counts {
+		var got counts
+		mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+			if err := sqlx.GetContext(ctx, q, &got.titles, `SELECT COUNT(*) FROM software_titles`); err != nil {
+				return err
+			}
+			if err := sqlx.GetContext(ctx, q, &got.installers, `SELECT COUNT(*) FROM software_installers`); err != nil {
+				return err
+			}
+			return sqlx.GetContext(ctx, q, &got.activities, `SELECT COUNT(*) FROM activity_past`)
+		})
+		return got
+	}
+	softwareTitleID := func(filename string) uint {
+		var titleID uint
+		mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+			return sqlx.GetContext(ctx, q, &titleID,
+				`SELECT title_id FROM software_installers WHERE global_or_team_id = ? AND filename = ?`, team.ID, filename)
+		})
+		return titleID
+	}
+	assertRejectedWithoutWrites := func(payload *fleet.UploadSoftwareInstallerPayload) {
+		t.Helper()
+		before := rowCounts()
+		s.uploadSoftwareInstaller(t, payload, http.StatusBadRequest, fmt.Sprintf(fleet.SoftwarePackageTitleMismatchMessage, payload.Filename))
+		require.Equal(t, before, rowCounts())
+	}
+
+	s.uploadSoftwareInstaller(t, &fleet.UploadSoftwareInstallerPayload{
+		Filename: "ruby.deb",
+		TeamID:   &team.ID,
+	}, http.StatusOK, "")
+	rubyTitleID := softwareTitleID("ruby.deb")
+	require.NotZero(t, rubyTitleID)
+
+	assertRejectedWithoutWrites(&fleet.UploadSoftwareInstallerPayload{
+		Filename: "EchoApp.pkg",
+		TeamID:   &team.ID,
+		TitleID:  &rubyTitleID,
+	})
+
+	// dummy_installer.pkg resolves to its own title, so claiming it belongs to Ruby is rejected.
+	s.uploadSoftwareInstaller(t, &fleet.UploadSoftwareInstallerPayload{
+		Filename: "dummy_installer.pkg",
+		TeamID:   &team.ID,
+	}, http.StatusOK, "")
+	assertRejectedWithoutWrites(&fleet.UploadSoftwareInstallerPayload{
+		Filename: "dummy_installer.pkg",
+		TeamID:   &team.ID,
+		TitleID:  &rubyTitleID,
+	})
+
+	nonexistentTitleID := uint(999999)
+	assertRejectedWithoutWrites(&fleet.UploadSoftwareInstallerPayload{
+		Filename: "ruby_arm64.deb",
+		TeamID:   &team.ID,
+		TitleID:  &nonexistentTitleID,
+	})
+
+	uploadScript := func(filename, contents string, titleID *uint, expectedStatus int, expectedError string) {
+		t.Helper()
+		fr, err := fleet.NewTempFileReader(strings.NewReader(contents), t.TempDir)
+		require.NoError(t, err)
+		defer fr.Close()
+		s.uploadSoftwareInstaller(t, &fleet.UploadSoftwareInstallerPayload{
+			Filename:      filename,
+			InstallerFile: fr,
+			TeamID:        &team.ID,
+			TitleID:       titleID,
+		}, expectedStatus, expectedError)
+	}
+
+	uploadScript("deploy.sh", "#!/bin/sh\necho first\n", nil, http.StatusOK, "")
+	deployTitleID := softwareTitleID("deploy.sh")
+	beforeMatching := rowCounts()
+	uploadScript("deploy.sh", "#!/bin/sh\necho second\n", &deployTitleID, http.StatusOK, "")
+	afterMatching := rowCounts()
+	require.Equal(t, beforeMatching.titles, afterMatching.titles)
+	require.Equal(t, beforeMatching.installers+1, afterMatching.installers)
+	require.Equal(t, beforeMatching.activities+1, afterMatching.activities)
+
+	beforeScriptMismatch := rowCounts()
+	uploadScript("other.sh", "#!/bin/sh\necho other\n", &deployTitleID, http.StatusBadRequest,
+		fmt.Sprintf(fleet.SoftwarePackageTitleMismatchMessage, "other.sh"))
+	require.Equal(t, beforeScriptMismatch, rowCounts())
+}
+
 func (s *integrationMDMTestSuite) TestListHostsSoftwareTitleIDFilter() {
 	t := s.T()
 	ctx := context.Background()

--- a/server/service/software_installers.go
+++ b/server/service/software_installers.go
@@ -28,6 +28,7 @@ import (
 type uploadSoftwareInstallerRequest struct {
 	File              *multipart.FileHeader
 	TeamID            *uint
+	TitleID           *uint
 	InstallScript     string
 	PreInstallQuery   string
 	PostInstallScript string
@@ -366,6 +367,14 @@ func (uploadSoftwareInstallerRequest) DecodeRequest(ctx context.Context, r *http
 		decoded.TeamID = ptr.Uint(uint(fleetID))
 	}
 
+	if v, ok := r.MultipartForm.Value["software_title_id"]; ok && len(v) > 0 && v[0] != "" {
+		id, err := strconv.ParseUint(v[0], 10, 32)
+		if err != nil {
+			return nil, &fleet.BadRequestError{Message: fmt.Sprintf("Invalid software_title_id: %s", v[0])}
+		}
+		decoded.TitleID = new(uint(id))
+	}
+
 	val, ok = r.MultipartForm.Value["install_script"]
 	if ok && len(val) > 0 {
 		decoded.InstallScript = val[0]
@@ -480,6 +489,7 @@ func uploadSoftwareInstallerEndpoint(ctx context.Context, request interface{}, s
 
 	payload := &fleet.UploadSoftwareInstallerPayload{
 		TeamID:            req.TeamID,
+		TitleID:           req.TitleID,
 		InstallScript:     req.InstallScript,
 		PreInstallQuery:   req.PreInstallQuery,
 		PostInstallScript: req.PostInstallScript,

--- a/server/service/software_installers_test.go
+++ b/server/service/software_installers_test.go
@@ -1,10 +1,12 @@
 package service
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
 	"log/slog"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -17,6 +19,7 @@ import (
 	eeservice "github.com/fleetdm/fleet/v4/ee/server/service"
 	"github.com/fleetdm/fleet/v4/pkg/optjson"
 	authz_ctx "github.com/fleetdm/fleet/v4/server/contexts/authz"
+	"github.com/fleetdm/fleet/v4/server/contexts/installersize"
 	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
 	"github.com/fleetdm/fleet/v4/server/datastore/filesystem"
 	"github.com/fleetdm/fleet/v4/server/dev_mode"
@@ -27,6 +30,45 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/require"
 )
+
+func TestUploadSoftwareInstallerDecodeTitleID(t *testing.T) {
+	testCases := []struct {
+		name      string
+		value     *string
+		want      *uint
+		wantError string
+	}{
+		{name: "omitted"},
+		{name: "valid", value: new("42"), want: new(uint(42))},
+		{name: "invalid", value: new("invalid"), wantError: "Invalid software_title_id: invalid"},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			var body bytes.Buffer
+			writer := multipart.NewWriter(&body)
+			file, err := writer.CreateFormFile("software", "test.sh")
+			require.NoError(t, err)
+			_, err = file.Write([]byte("#!/bin/sh\n"))
+			require.NoError(t, err)
+			if tt.value != nil {
+				require.NoError(t, writer.WriteField("software_title_id", *tt.value))
+			}
+			require.NoError(t, writer.Close())
+
+			request := httptest.NewRequest(http.MethodPost, "/api/latest/fleet/software/package", &body)
+			request.Header.Set("Content-Type", writer.FormDataContentType())
+			ctx := installersize.NewContext(t.Context(), int64(body.Len()))
+			decoded, err := (uploadSoftwareInstallerRequest{}).DecodeRequest(ctx, request)
+			if tt.wantError != "" {
+				require.ErrorContains(t, err, tt.wantError)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, decoded.(*uploadSoftwareInstallerRequest).TitleID)
+		})
+	}
+}
 
 func TestSoftwareInstallersAuth(t *testing.T) {
 	ds := new(mock.Store)

--- a/server/service/testing_client_test.go
+++ b/server/service/testing_client_test.go
@@ -878,6 +878,9 @@ func (ts *withServer) uploadSoftwareInstallerWithErrorNameReason(
 	if payload.TeamID != nil {
 		require.NoError(t, w.WriteField("team_id", fmt.Sprintf("%d", *payload.TeamID)))
 	}
+	if payload.TitleID != nil {
+		require.NoError(t, w.WriteField("software_title_id", fmt.Sprintf("%d", *payload.TitleID)))
+	}
 	// add the remaining fields
 	require.NoError(t, w.WriteField("install_script", payload.InstallScript))
 	require.NoError(t, w.WriteField("pre_install_query", payload.PreInstallQuery))


### PR DESCRIPTION
**Related issue:** Resolves #49209

Adding a package to an existing software title (`POST /software/package` with `software_title_id`) now validates that the uploaded installer actually belongs to that title. Previously the `software_title_id` sent by the title page's "Add package" flow was ignored, so uploading mismatched software (e.g. a 1Password package onto a Zoom title) silently created a new separate title instead of erroring. It now returns a 400 with a clear message and writes nothing. When `software_title_id` is omitted (general "Add software" flow, GitOps), behavior is unchanged.

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually
