### PR TITLE
Keep tools up to date

### DIFF
--- a/.github/workflows/test-tools.yml
+++ b/.github/workflows/test-tools.yml
@@ -1,4 +1,4 @@
-name: Test dibble
+name: Test tools
 
 on:
   push:
@@ -6,18 +6,20 @@ on:
       - main
     paths:
       - 'tools/dibble/**'
-      # dibble pins the parent module via `replace github.com/fleetdm/fleet/v4 => ../..`, so a change to the
-      # root module's dependency graph can leave tools/dibble/go.mod and go.sum out of sync. Trigger on the
-      # root go.mod/go.sum too, so the same change that bumps a root dependency is forced to re-tidy dibble.
+      - 'tools/upgrade/**'
+      # dibble and upgrade pin the parent module via `replace github.com/fleetdm/fleet/v4 => ../..`, so a
+      # change to the root module's dependency graph can leave their go.mod and go.sum out of sync. Trigger on
+      # the root go.mod/go.sum too, so the same change that bumps a root dependency is forced to re-tidy them.
       - 'go.mod'
       - 'go.sum'
-      - '.github/workflows/test-dibble.yml'
+      - '.github/workflows/test-tools.yml'
   pull_request:
     paths:
       - 'tools/dibble/**'
+      - 'tools/upgrade/**'
       - 'go.mod'
       - 'go.sum'
-      - '.github/workflows/test-dibble.yml'
+      - '.github/workflows/test-tools.yml'
   workflow_dispatch: # Manual
 
 # This allows a subsequently queued workflow run to interrupt previous runs
@@ -35,9 +37,21 @@ permissions:
 
 jobs:
   test:
-    name: Test
+    name: Test ${{ matrix.tool }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # run_tests is false for tools whose tests need external infra (e.g. upgrade needs docker-compose and
+          # version inputs); for those we still verify the module is tidy and builds.
+          - tool: dibble
+            dir: tools/dibble
+            run_tests: true
+          - tool: upgrade
+            dir: tools/upgrade
+            run_tests: false
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -52,21 +66,22 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version-file: 'tools/dibble/go.mod'
+          go-version-file: '${{ matrix.dir }}/go.mod'
 
       - name: Verify go.mod and go.sum are tidy
-        working-directory: tools/dibble
+        working-directory: ${{ matrix.dir }}
         run: |
           go mod tidy
           if ! git diff --exit-code -- go.mod go.sum; then
-            echo "::error::tools/dibble/go.mod or go.sum is out of sync with the root module. Run 'cd tools/dibble && go mod tidy' and commit the result."
+            echo "::error::${{ matrix.dir }}/go.mod or go.sum is out of sync with the root module. Run 'make tidy-tool-modules' (or 'cd ${{ matrix.dir }} && go mod tidy') and commit the result."
             exit 1
           fi
 
       - name: Build
-        working-directory: tools/dibble
+        working-directory: ${{ matrix.dir }}
         run: go build ./...
 
       - name: Run tests
-        working-directory: tools/dibble
+        if: matrix.run_tests
+        working-directory: ${{ matrix.dir }}
         run: go test -race -count=1 ./...

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build clean clean-assets e2e-reset-db e2e-serve e2e-setup changelog db-reset db-backup db-restore check-go-cloner update-go-cloner check-no-testing-in-prod dibble help
+.PHONY: build clean clean-assets e2e-reset-db e2e-serve e2e-setup changelog db-reset db-backup db-restore check-go-cloner update-go-cloner check-no-testing-in-prod dibble tidy-tool-modules help
 
 export GO111MODULE=on
 
@@ -149,6 +149,19 @@ fdm:
 	@echo "Builds the dibble test-data seeder (binary lands at tools/dibble/dibble)"
 dibble:
 	cd tools/dibble && go build -o dibble ./cmd/dibble
+
+.help-short--tidy-tool-modules:
+	@echo "Re-tidy tool modules that pin the parent fleet module (run after bumping the root go.mod)"
+# Tool modules under tools/ that pin the parent via `replace github.com/fleetdm/fleet/v4 => ../..`
+# mirror the root module's transitive dependency graph, so a root go.mod/go.sum bump leaves their
+# go.mod/go.sum out of sync. This discovers those modules and re-tidies each one.
+tidy-tool-modules:
+	@mods=$$(grep -rlF --include=go.mod 'replace github.com/fleetdm/fleet/v4 =>' tools); \
+	for mod in $$mods; do \
+		dir=$$(dirname $$mod); \
+		echo "==> go mod tidy in $$dir"; \
+		(cd $$dir && go mod tidy) || exit 1; \
+	done
 
 .help-short--serve:
 	@echo "Start the fleet server"


### PR DESCRIPTION
This is needed to keep tools up to date with latest go.mod. Goal is for these tools to have separate go.mod to reduce tool dependency on production/main `go.mod`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded automated validation to cover both tool modules, including builds, dependency tidiness checks, and applicable tests.
  * Added a `make tidy-tool-modules` command to tidy supported tool dependencies automatically.
  * Added validation for tool changes and root Go module updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->