### PR TITLE
Android: fold security patch level into OS version

### DIFF
--- a/changes/47334-android-os-version-security-patch-level
+++ b/changes/47334-android-os-version-security-patch-level
@@ -1,0 +1,1 @@
+- Android hosts now report their OS version folded with the security patch level (e.g. "Android 16 (2026-05-01)"), so distinct patch levels appear as separate OS versions in the Software > OS aggregation and host filters. Devices that do not report a patch level fall back to the bare major version.

--- a/changes/47334-android-os-version-security-patch-level
+++ b/changes/47334-android-os-version-security-patch-level
@@ -1,1 +1,0 @@
-- Android hosts now report their OS version folded with the security patch level (e.g. "Android 16 (2026-05-01)"), so distinct patch levels appear as separate OS versions in the Software > OS aggregation and host filters. Devices that do not report a patch level fall back to the bare major version.

--- a/server/mdm/android/service/pubsub.go
+++ b/server/mdm/android/service/pubsub.go
@@ -736,7 +736,7 @@ func (svc *Service) updateHost(ctx context.Context, device *androidmanagement.De
 	host.Host.ComputerName = computerName
 	host.Host.Hostname = computerName
 	host.Host.Platform = "android"
-	host.Host.OSVersion = "Android " + device.SoftwareInfo.AndroidVersion
+	host.Host.OSVersion = androidHostOSVersion(device.SoftwareInfo)
 	host.Host.Build = device.SoftwareInfo.AndroidBuildNumber
 	host.Host.Memory = device.MemoryInfo.TotalRam
 
@@ -823,6 +823,30 @@ func (svc *Service) updateHost(ctx context.Context, device *androidmanagement.De
 	return nil
 }
 
+// androidOSVersion folds the Android version with the security patch level when
+// present, e.g. "16 (2026-05-01)", falling back to the bare version ("16") when
+// the device does not report a patch level (older devices may not). The major
+// version + security patch level pair is the vulnerability-relevant granularity
+// for Android (AMAPI exposes no "minor" version).
+func androidOSVersion(sw *androidmanagement.SoftwareInfo) string {
+	if sw.AndroidVersion == "" || sw.SecurityPatchLevel == "" {
+		return sw.AndroidVersion
+	}
+	return fmt.Sprintf("%s (%s)", sw.AndroidVersion, sw.SecurityPatchLevel)
+}
+
+// androidHostOSVersion returns the value stored in hosts.os_version, e.g.
+// "Android 16 (2026-05-01)". All SoftwareInfo fields are optional per the
+// Android Management API, so a device may report no version at all; in that
+// case we store "Android" without a dangling space or patch level.
+func androidHostOSVersion(sw *androidmanagement.SoftwareInfo) string {
+	version := androidOSVersion(sw)
+	if version == "" {
+		return "Android"
+	}
+	return "Android " + version
+}
+
 // updateHostOperatingSystem upserts the host's OS into the operating_systems
 // and host_operating_system tables. Without this, Android hosts cannot be
 // filtered via the os_name/os_version host list parameters and do not appear
@@ -833,7 +857,7 @@ func (svc *Service) updateHostOperatingSystem(ctx context.Context, hostID uint, 
 	}
 	if err := svc.fleetDS.UpdateHostOperatingSystem(ctx, hostID, fleet.OperatingSystem{
 		Name:     "Android",
-		Version:  device.SoftwareInfo.AndroidVersion,
+		Version:  androidOSVersion(device.SoftwareInfo),
 		Platform: "android",
 	}); err != nil {
 		return ctxerr.Wrap(ctx, err, "update Android host operating system")
@@ -864,6 +888,14 @@ func setAndroidHostUUID(host *fleet.AndroidHost, device *androidmanagement.Devic
 }
 
 func (svc *Service) addNewHost(ctx context.Context, device *androidmanagement.Device) error {
+	// Validate before dereferencing device.SoftwareInfo/MemoryInfo/HardwareInfo
+	// below. enrollHost already validates before dispatching here, but this keeps
+	// addNewHost self-contained so it cannot panic if called from another path,
+	// matching updateHost.
+	if err := svc.validateDevice(ctx, device); err != nil {
+		return err
+	}
+
 	var enrollmentTokenRequest enrollmentTokenRequest
 	err := json.Unmarshal([]byte(device.EnrollmentTokenData), &enrollmentTokenRequest)
 	if err != nil {
@@ -903,7 +935,7 @@ func (svc *Service) addNewHost(ctx context.Context, device *androidmanagement.De
 			ComputerName:              computerName,
 			Hostname:                  computerName,
 			Platform:                  "android",
-			OSVersion:                 "Android " + device.SoftwareInfo.AndroidVersion,
+			OSVersion:                 androidHostOSVersion(device.SoftwareInfo),
 			Build:                     device.SoftwareInfo.AndroidBuildNumber,
 			Memory:                    device.MemoryInfo.TotalRam,
 			GigsTotalDiskSpace:        gigsTotalDiskSpace,

--- a/server/mdm/android/service/pubsub.go
+++ b/server/mdm/android/service/pubsub.go
@@ -829,6 +829,9 @@ func (svc *Service) updateHost(ctx context.Context, device *androidmanagement.De
 // version + security patch level pair is the vulnerability-relevant granularity
 // for Android (AMAPI exposes no "minor" version).
 func androidOSVersion(sw *androidmanagement.SoftwareInfo) string {
+	if sw == nil {
+		return ""
+	}
 	if sw.AndroidVersion == "" || sw.SecurityPatchLevel == "" {
 		return sw.AndroidVersion
 	}

--- a/server/mdm/android/service/pubsub_test.go
+++ b/server/mdm/android/service/pubsub_test.go
@@ -1066,6 +1066,12 @@ func TestAndroidOSVersion(t *testing.T) {
 			expected:     "",
 			expectedHost: "Android",
 		},
+		{
+			name:         "nil software info does not panic",
+			sw:           nil,
+			expected:     "",
+			expectedHost: "Android",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			require.Equal(t, tc.expected, androidOSVersion(tc.sw))

--- a/server/mdm/android/service/pubsub_test.go
+++ b/server/mdm/android/service/pubsub_test.go
@@ -268,7 +268,9 @@ func TestPubSubEnrollment(t *testing.T) {
 			}
 
 			expectedHostID := uint(99)
+			var capturedOSVersion string
 			mockDS.NewAndroidHostFunc = func(ctx context.Context, host *fleet.AndroidHost, companyOwned bool) (*fleet.AndroidHost, error) {
+				capturedOSVersion = host.Host.OSVersion
 				return &fleet.AndroidHost{Host: &fleet.Host{ID: expectedHostID}}, nil
 			}
 			var capturedHostID uint
@@ -288,12 +290,14 @@ func TestPubSubEnrollment(t *testing.T) {
 			}
 			enrollmentMessage := createEnrollmentMessage(t, deviceInfo)
 			// createEnrollmentMessage sets AndroidVersion="1"; override to a more
-			// realistic version so we verify it's passed through unchanged.
+			// realistic version and add a security patch level so we verify the
+			// version is folded into "16 (2026-05-01)".
 			data, err := base64.StdEncoding.DecodeString(enrollmentMessage.Data)
 			require.NoError(t, err)
 			var decoded androidmanagement.Device
 			require.NoError(t, json.Unmarshal(data, &decoded))
 			decoded.SoftwareInfo.AndroidVersion = "16"
+			decoded.SoftwareInfo.SecurityPatchLevel = "2026-05-01"
 			reEncoded, err := json.Marshal(decoded)
 			require.NoError(t, err)
 			enrollmentMessage.Data = base64.StdEncoding.EncodeToString(reEncoded)
@@ -304,8 +308,9 @@ func TestPubSubEnrollment(t *testing.T) {
 			require.True(t, mockDS.UpdateHostOperatingSystemFuncInvoked)
 			require.Equal(t, expectedHostID, capturedHostID)
 			require.Equal(t, "Android", capturedOS.Name)
-			require.Equal(t, "16", capturedOS.Version)
+			require.Equal(t, "16 (2026-05-01)", capturedOS.Version)
 			require.Equal(t, "android", capturedOS.Platform)
+			require.Equal(t, "Android 16 (2026-05-01)", capturedOSVersion)
 		})
 
 		t.Run("creates device as company-owned if specified in enrollment message", func(t *testing.T) {
@@ -971,7 +976,9 @@ func TestStatusReportPopulatesOperatingSystem(t *testing.T) {
 			},
 		}, nil
 	}
+	var capturedOSVersion string
 	mockDS.UpdateAndroidHostFunc = func(ctx context.Context, host *fleet.AndroidHost, fromEnroll, companyOwned bool) error {
+		capturedOSVersion = host.Host.OSVersion
 		return nil
 	}
 	mockDS.ScimUserByHostIDFunc = func(ctx context.Context, hostID uint) (*fleet.ScimUser, error) {
@@ -1000,7 +1007,8 @@ func TestStatusReportPopulatesOperatingSystem(t *testing.T) {
 			Model:                "Pixel 8a",
 		},
 		SoftwareInfo: &androidmanagement.SoftwareInfo{
-			AndroidVersion: "16",
+			AndroidVersion:     "16",
+			SecurityPatchLevel: "2026-05-01",
 		},
 		MemoryInfo: &androidmanagement.MemoryInfo{
 			TotalRam: int64(8 * 1024 * 1024 * 1024),
@@ -1020,8 +1028,50 @@ func TestStatusReportPopulatesOperatingSystem(t *testing.T) {
 	require.True(t, mockDS.UpdateHostOperatingSystemFuncInvoked)
 	require.Equal(t, expectedHostID, capturedHostID)
 	require.Equal(t, "Android", capturedOS.Name)
-	require.Equal(t, "16", capturedOS.Version)
+	require.Equal(t, "16 (2026-05-01)", capturedOS.Version)
 	require.Equal(t, "android", capturedOS.Platform)
+	require.Equal(t, "Android 16 (2026-05-01)", capturedOSVersion)
+}
+
+func TestAndroidOSVersion(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		sw   *androidmanagement.SoftwareInfo
+		// expected is the operating_systems.version value (androidOSVersion).
+		expected string
+		// expectedHost is the hosts.os_version value (androidHostOSVersion).
+		expectedHost string
+	}{
+		{
+			name:         "version with security patch level",
+			sw:           &androidmanagement.SoftwareInfo{AndroidVersion: "16", SecurityPatchLevel: "2026-05-01"},
+			expected:     "16 (2026-05-01)",
+			expectedHost: "Android 16 (2026-05-01)",
+		},
+		{
+			name:         "version without security patch level falls back to bare version",
+			sw:           &androidmanagement.SoftwareInfo{AndroidVersion: "16"},
+			expected:     "16",
+			expectedHost: "Android 16",
+		},
+		{
+			name:         "empty version with security patch level does not emit a dangling patch level",
+			sw:           &androidmanagement.SoftwareInfo{SecurityPatchLevel: "2026-05-01"},
+			expected:     "",
+			expectedHost: "Android",
+		},
+		{
+			name:         "no software info reported at all",
+			sw:           &androidmanagement.SoftwareInfo{},
+			expected:     "",
+			expectedHost: "Android",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, androidOSVersion(tc.sw))
+			require.Equal(t, tc.expectedHost, androidHostOSVersion(tc.sw))
+		})
+	}
 }
 
 func TestHostPayloadUUIDForFrontend(t *testing.T) {
@@ -1206,6 +1256,7 @@ func TestUpdateHost(t *testing.T) {
 			SoftwareInfo: &androidmanagement.SoftwareInfo{
 				AndroidBuildNumber: "updated-build",
 				AndroidVersion:     "15",
+				SecurityPatchLevel: "2026-05-01",
 			},
 			MemoryInfo: &androidmanagement.MemoryInfo{
 				TotalRam:             int64(16 * 1024 * 1024 * 1024),  // 16GB RAM
@@ -1240,7 +1291,7 @@ func TestUpdateHost(t *testing.T) {
 		require.Equal(t, "Updatedbrand UpdatedModel", capturedHost.Host.ComputerName)
 		require.Equal(t, "Updatedbrand UpdatedModel", capturedHost.Host.Hostname)
 		require.Equal(t, "Updatedbrand UpdatedModel", capturedHost.Host.HardwareModel)
-		require.Equal(t, "Android 15", capturedHost.Host.OSVersion)
+		require.Equal(t, "Android 15 (2026-05-01)", capturedHost.Host.OSVersion)
 	})
 
 	t.Run("UUID is set from EnterpriseSpecificId", func(t *testing.T) {

--- a/server/mdm/android/tests/integration_os_version_test.go
+++ b/server/mdm/android/tests/integration_os_version_test.go
@@ -1,0 +1,164 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/server/datastore/mysql/mysqltest"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mdm/android"
+	"github.com/fleetdm/fleet/v4/server/mdm/android/service"
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/api/androidmanagement/v1"
+)
+
+func TestServiceOSVersion(t *testing.T) {
+	testingSuite := new(osVersionTestSuite)
+	suite.Run(t, testingSuite)
+}
+
+type osVersionTestSuite struct {
+	WithServer
+}
+
+func (s *osVersionTestSuite) SetupSuite() {
+	s.WithServer.SetupSuite(s.T(), "androidOSVersionTestSuite")
+	s.Token = "testtoken"
+}
+
+// TestAndroidOSVersionSecurityPatchLevel verifies end-to-end (against real MySQL)
+// that an Android device's security patch level is folded into the host's OS
+// version, that distinct patch levels produce distinct operating_systems rows,
+// and that a device reporting no patch level falls back to the bare version.
+func (s *osVersionTestSuite) TestAndroidOSVersionSecurityPatchLevel() {
+	ctx := context.Background()
+	t := s.T()
+
+	// Create enterprise.
+	var signupResp android.EnterpriseSignupResponse
+	s.DoJSON("GET", "/api/v1/fleet/android_enterprise/signup_url", nil, http.StatusOK, &signupResp)
+	assert.Equal(t, EnterpriseSignupURL, signupResp.Url)
+
+	s.FleetSvc.On("NewActivity", mock.Anything, mock.Anything, mock.AnythingOfType("fleet.ActivityTypeEnabledAndroidMDM")).Return(nil)
+	const enterpriseToken = "enterpriseToken"
+	s.Do("GET", s.ProxyCallbackURL, nil, http.StatusOK, "enterpriseToken", enterpriseToken)
+
+	s.AndroidAPIClient.EnterprisesListFunc = func(_ context.Context, _ string) ([]*androidmanagement.Enterprise, error) {
+		return []*androidmanagement.Enterprise{{Name: "enterprises/" + EnterpriseID}}, nil
+	}
+
+	resp := android.GetEnterpriseResponse{}
+	s.DoJSON("GET", "/api/v1/fleet/android_enterprise", nil, http.StatusOK, &resp)
+	assert.Equal(t, EnterpriseID, resp.EnterpriseID)
+
+	s.AppConfig.MDM.AndroidEnabledAndConfigured = true
+
+	require.NoError(t, s.DS.ApplyEnrollSecrets(ctx, nil, []*fleet.EnrollSecret{{Secret: "enrollsecret"}}))
+	secrets, err := s.DS.Datastore.GetEnrollSecrets(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, secrets, 1)
+
+	assets, err := s.DS.Datastore.GetAllMDMConfigAssetsByName(ctx, []fleet.MDMAssetName{fleet.MDMAssetAndroidPubSubToken}, nil)
+	require.NoError(t, err)
+	pubsubToken := assets[fleet.MDMAssetAndroidPubSubToken]
+	require.NotEmpty(t, pubsubToken.Value)
+
+	esi := strings.ToUpper(uuid.New().String())
+
+	// Enroll the device. The enrollment helper reports version "1" and no patch
+	// level, so the host starts with a bare version.
+	enrollmentMessage := enrollmentMessageWithEnterpriseSpecificID(
+		t,
+		androidmanagement.Device{
+			Name:                createAndroidDeviceID("test-os-version"),
+			EnrollmentTokenData: fmt.Sprintf(`{"EnrollSecret": "%s"}`, secrets[0].Secret),
+		},
+		esi,
+	)
+	s.Do("POST", "/api/v1/fleet/android_enterprise/pubsub", &service.PubSubPushRequest{PubSubMessage: *enrollmentMessage}, http.StatusOK, "token", string(pubsubToken.Value))
+
+	assertOSVersion := func(wantHostOSVersion, wantOSRowVersion string) {
+		t.Helper()
+		mysqltest.ExecAdhocSQL(t, s.DS.Datastore, func(q sqlx.ExtContext) error {
+			var hostOSVersion string
+			require.NoError(t, sqlx.GetContext(ctx, q, &hostOSVersion, "SELECT os_version FROM hosts WHERE uuid = ?", esi))
+			assert.Equal(t, wantHostOSVersion, hostOSVersion)
+
+			var osRow struct {
+				Name    string `db:"name"`
+				Version string `db:"version"`
+			}
+			require.NoError(t, sqlx.GetContext(ctx, q, &osRow,
+				`SELECT os.name, os.version
+				 FROM operating_systems os
+				 JOIN host_operating_system hos ON hos.os_id = os.id
+				 JOIN hosts h ON h.id = hos.host_id
+				 WHERE h.uuid = ?`, esi))
+			assert.Equal(t, "Android", osRow.Name)
+			assert.Equal(t, wantOSRowVersion, osRow.Version)
+			return nil
+		})
+	}
+
+	// Status report with a security patch level folds it into the version.
+	s.Do("POST", "/api/v1/fleet/android_enterprise/pubsub",
+		&service.PubSubPushRequest{PubSubMessage: osVersionStatusReportMessage(t, esi, "16", "2026-05-01")},
+		http.StatusOK, "token", string(pubsubToken.Value))
+	assertOSVersion("Android 16 (2026-05-01)", "16 (2026-05-01)")
+
+	// A newer patch level for the same major version produces a distinct
+	// operating_systems row; the host now points at the new one.
+	s.Do("POST", "/api/v1/fleet/android_enterprise/pubsub",
+		&service.PubSubPushRequest{PubSubMessage: osVersionStatusReportMessage(t, esi, "16", "2026-06-01")},
+		http.StatusOK, "token", string(pubsubToken.Value))
+	assertOSVersion("Android 16 (2026-06-01)", "16 (2026-06-01)")
+
+	mysqltest.ExecAdhocSQL(t, s.DS.Datastore, func(q sqlx.ExtContext) error {
+		var versions []string
+		require.NoError(t, sqlx.SelectContext(ctx, q, &versions,
+			"SELECT version FROM operating_systems WHERE name = 'Android' ORDER BY version"))
+		// "1" is the bare version from enrollment (now orphaned; the cleanup cron
+		// that removes unreferenced rows does not run in this test). The two folded
+		// versions confirm each security patch level is a distinct row.
+		assert.Equal(t, []string{"1", "16 (2026-05-01)", "16 (2026-06-01)"}, versions,
+			"each security patch level should be a distinct operating_systems row")
+		return nil
+	})
+
+	// A device that does not report a patch level falls back to the bare version.
+	s.Do("POST", "/api/v1/fleet/android_enterprise/pubsub",
+		&service.PubSubPushRequest{PubSubMessage: osVersionStatusReportMessage(t, esi, "16", "")},
+		http.StatusOK, "token", string(pubsubToken.Value))
+	assertOSVersion("Android 16", "16")
+}
+
+func osVersionStatusReportMessage(t *testing.T, esi, androidVersion, securityPatchLevel string) android.PubSubMessage {
+	return createStatusReportMessageFromDevice(t, androidmanagement.Device{
+		Name: createAndroidDeviceID("test-os-version"),
+		HardwareInfo: &androidmanagement.HardwareInfo{
+			EnterpriseSpecificId: esi,
+			Brand:                "TestBrand",
+			Model:                "TestModel",
+			SerialNumber:         "test-serial",
+			Hardware:             "test-hardware",
+		},
+		SoftwareInfo: &androidmanagement.SoftwareInfo{
+			AndroidBuildNumber: "test-build",
+			AndroidVersion:     androidVersion,
+			SecurityPatchLevel: securityPatchLevel,
+		},
+		MemoryInfo: &androidmanagement.MemoryInfo{
+			TotalRam:             int64(8 * 1024 * 1024 * 1024),
+			TotalInternalStorage: int64(64 * 1024 * 1024 * 1024),
+		},
+		LastStatusReportTime: "2024-01-01T12:00:00Z",
+	})
+}


### PR DESCRIPTION
Relates to #47334

Capture SoftwareInfo.securityPatchLevel from the Android Management API device report and fold it into the host's OS version, so Android versions read as "Android 16 (2026-05-01)" instead of just "Android 16". This makes the operating_systems row distinct per patch level, which is the vulnerability-relevant granularity for Android (AMAPI exposes no minor version).

Both the enroll path (addNewHost) and the detail-report path (updateHost), plus the operating_systems upsert, now go through a shared androidOSVersion helper. Devices that don't report a patch level fall back to the bare major version, so they still enroll without error.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests