### PR TITLE
Add GitOps support for custom host vital definitions

### DIFF
--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -84,6 +84,7 @@ type generateGitopsClient interface {
 	GetPolicies(teamID *uint) ([]*fleet.Policy, error)
 	GetQueries(teamID *uint, name *string) ([]fleet.Query, error)
 	GetLabels(teamID uint) ([]*fleet.LabelSpec, error)
+	ListCustomHostVitals(query string) ([]fleet.CustomHostVital, error)
 	Me() (*fleet.User, error)
 	GetSetupExperienceSoftware(platform string, teamID uint) ([]fleet.SoftwareTitleListResult, error)
 	GetBootstrapPackageMetadata(teamID uint, forUpdate bool) (*fleet.MDMAppleBootstrapPackage, error)
@@ -520,6 +521,13 @@ func (cmd *GenerateGitopsCommand) Run() error {
 			}
 
 			cmd.FilesToWrite[fileName].(map[string]interface{})["agent_options"] = cmd.AppConfig.AgentOptions
+
+			customHostVitals, err := cmd.generateCustomHostVitals()
+			if err != nil {
+				fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error generating custom host vitals: %s\n", err)
+				return ErrGeneric
+			}
+			cmd.FilesToWrite[fileName].(map[string]any)["custom_host_vitals"] = customHostVitals
 		} else {
 			// Generate team settings and agent options for the team (including "No team" with ID 0).
 			teamSettings, err := cmd.generateTeamSettings(fileName, team)
@@ -2348,6 +2356,35 @@ func (cmd *GenerateGitopsCommand) generateLabels(team *fleet.Team) ([]map[string
 		}
 
 		result = append(result, labelSpec)
+	}
+	return result, nil
+}
+
+// generateCustomHostVitals emits the existing custom host vital definitions
+// (names only; per-host values are never part of GitOps) so a round-trip
+// (apply -> generate -> re-apply) is a no-op. Global-only, like the
+// `custom_host_vitals:` GitOps key itself.
+func (cmd *GenerateGitopsCommand) generateCustomHostVitals() ([]map[string]any, error) {
+	const perPage = 1000
+	var vitals []fleet.CustomHostVital
+	for page := 0; ; page++ {
+		query := fmt.Sprintf("per_page=%d&page=%d", perPage, page)
+		pageVitals, err := cmd.Client.ListCustomHostVitals(query)
+		if err != nil {
+			fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error getting custom host vitals: %s\n", err)
+			return nil, err
+		}
+		vitals = append(vitals, pageVitals...)
+		if len(pageVitals) < perPage {
+			break
+		}
+	}
+	t := reflect.TypeFor[spec.GitOpsCustomHostVital]()
+	result := make([]map[string]any, 0, len(vitals))
+	for _, vital := range vitals {
+		result = append(result, map[string]any{
+			jsonFieldName(t, "Name"): vital.Name,
+		})
 	}
 	return result, nil
 }

--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -714,6 +714,13 @@ func (MockClient) GetLabels(teamID uint) ([]*fleet.LabelSpec, error) {
 	}}, nil
 }
 
+func (MockClient) ListCustomHostVitals(query string) ([]fleet.CustomHostVital, error) {
+	return []fleet.CustomHostVital{
+		{ID: 1, Name: "Asset tag"},
+		{ID: 2, Name: "Department"},
+	}, nil
+}
+
 func (MockClient) Me() (*fleet.User, error) {
 	return &fleet.User{
 		ID:         1,

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_free/default.yml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_free/default.yml
@@ -30,6 +30,9 @@ controls:
     - labels_include_any:
       - Label D
       path: ./lib/profiles/global-windows-profile.xml
+custom_host_vitals:
+- name: Asset tag
+- name: Department
 labels:
 - description: Label A description
   label_membership_type: dynamic

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/default.yml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/default.yml
@@ -12,6 +12,9 @@ agent_options:
       logger_tls_endpoint: /api/osquery/log
       logger_tls_period: 10
       pack_delimiter: /
+custom_host_vitals:
+- name: Asset tag
+- name: Department
 labels:
 - description: Label A description
   label_membership_type: dynamic

--- a/cmd/fleetctl/fleetctl/testing_utils/testing_utils.go
+++ b/cmd/fleetctl/fleetctl/testing_utils/testing_utils.go
@@ -50,6 +50,14 @@ const (
 // NOTE: Assumes the current session is always from the admin user (see ds.SessionByKeyFunc below).
 func RunServerWithMockedDS(t *testing.T, opts ...*service.TestServerOpts) (*httptest.Server, *mock.Store) {
 	ds := new(mock.Store)
+	// Custom host vitals are declarative and global-only, so every `fleetctl gitops`
+	// run against a global config calls these, even when custom_host_vitals: is absent.
+	ds.ListCustomHostVitalsFunc = func(ctx context.Context, opt fleet.ListOptions) ([]fleet.CustomHostVital, *fleet.PaginationMetadata, int, error) {
+		return nil, &fleet.PaginationMetadata{}, 0, nil
+	}
+	ds.UpsertCustomHostVitalsFunc = func(ctx context.Context, vitals []fleet.CustomHostVital) ([]fleet.CustomHostVital, []fleet.CustomHostVital, error) {
+		return nil, nil, nil
+	}
 	var users []*fleet.User
 	var admin *fleet.User
 	ds.NewUserFunc = func(ctx context.Context, user *fleet.User) (*fleet.User, error) {

--- a/cmd/fleetctl/integrationtest/gitops/gitops_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_integration_test.go
@@ -350,6 +350,15 @@ func (s *integrationGitopsTestSuite) TestFleetGitopsCustomHostVitals() {
 		}
 	}
 
+	// A dry run still sends the request to the server (with DryRun set), so
+	// server-side validation -- like the collation-aware duplicate-name check,
+	// which is not enforced by the local diff -- is still exercised without
+	// persisting.
+	globalFileDupe := s.customHostVitalsGlobalYAML("  - name: Asset tag\n  - name: asset tag\n")
+	_, err := fleetctltest.RunAppNoChecks([]string{"gitops", "--config", fleetctlConfig.Name(), "-f", globalFileDupe, "--dry-run"})
+	require.ErrorContains(t, err, "duplicate custom host vital names")
+	require.ElementsMatch(t, []string{"Asset tag", "Role"}, names(listVitals()))
+
 	// A script referencing $FLEET_HOST_VITAL_<id> for "Asset tag" blocks its
 	// removal: applying a config that drops it from custom_host_vitals errors
 	// the whole run, and no vitals are removed.

--- a/cmd/fleetctl/integrationtest/gitops/gitops_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_integration_test.go
@@ -263,3 +263,116 @@ queries:
 	_, err = fleetctltest.RunAppNoChecks([]string{"gitops", "--config", fleetctlConfig.Name(), "-f", globalFile.Name()})
 	require.ErrorContains(t, err, "missing or invalid license")
 }
+
+// customHostVitalsGlobalYAML writes a minimal global GitOps file with the
+// given `custom_host_vitals:` body (e.g. "- name: Foo\n- name: Bar", or ""
+// to omit the key entirely, which is the declarative clear-all case).
+func (s *integrationGitopsTestSuite) customHostVitalsGlobalYAML(customHostVitalsBody string) string {
+	t := s.T()
+	f, err := os.CreateTemp(t.TempDir(), "*.yml")
+	require.NoError(t, err)
+	customHostVitalsKey := ""
+	if customHostVitalsBody != "" {
+		customHostVitalsKey = "custom_host_vitals:\n" + customHostVitalsBody
+	}
+	_, err = f.WriteString(fmt.Sprintf(`
+policies:
+queries:
+agent_options:
+controls:
+org_settings:
+  server_settings:
+    server_url: $FLEET_URL
+  org_info:
+    org_name: Fleet
+  secrets:
+%s
+`, customHostVitalsKey))
+	require.NoError(t, err)
+	return f.Name()
+}
+
+func (s *integrationGitopsTestSuite) TestFleetGitopsCustomHostVitals() {
+	t := s.T()
+	ctx := t.Context()
+	fleetctlConfig := s.createFleetctlConfig()
+	t.Setenv("FLEET_URL", s.Server.URL)
+
+	listVitals := func() []fleet.CustomHostVital {
+		vitals, _, _, err := s.DS.ListCustomHostVitals(ctx, fleet.ListOptions{})
+		require.NoError(t, err)
+		return vitals
+	}
+	names := func(vitals []fleet.CustomHostVital) []string {
+		out := make([]string, 0, len(vitals))
+		for _, v := range vitals {
+			out = append(out, v.Name)
+		}
+		return out
+	}
+
+	// Ensure a clean slate: this is global state shared across the suite's tests.
+	defer func() {
+		globalFile := s.customHostVitalsGlobalYAML("")
+		fleetctltest.RunAppForTest(t, []string{"gitops", "--config", fleetctlConfig.Name(), "-f", globalFile})
+		require.Empty(t, listVitals())
+	}()
+
+	// Dry run validates without persisting, and logs what would've been created.
+	globalFileV1 := s.customHostVitalsGlobalYAML("  - name: Asset tag\n  - name: Department\n")
+	out := fleetctltest.RunAppForTest(t, []string{"gitops", "--config", fleetctlConfig.Name(), "-f", globalFileV1, "--dry-run"})
+	assert.Contains(t, out, "[+] would've created 2 custom host vitals")
+	assert.Contains(t, out, "gitops dry run succeeded")
+	assert.Empty(t, listVitals())
+
+	// Real run creates both, and logs what it created.
+	out = fleetctltest.RunAppForTest(t, []string{"gitops", "--config", fleetctlConfig.Name(), "-f", globalFileV1})
+	assert.Contains(t, out, "[+] creating 2 custom host vitals")
+	assert.Contains(t, out, "gitops succeeded")
+	require.ElementsMatch(t, []string{"Asset tag", "Department"}, names(listVitals()))
+
+	byName := make(map[string]uint)
+	for _, v := range listVitals() {
+		byName[v.Name] = v.ID
+	}
+	assetTagID := byName["Asset tag"]
+
+	// Re-applying with "Department" dropped and "Role" added: Department is
+	// deleted, Role is created, Asset tag is retained with the same ID.
+	globalFileV2 := s.customHostVitalsGlobalYAML("  - name: Asset tag\n  - name: Role\n")
+	out = fleetctltest.RunAppForTest(t, []string{"gitops", "--config", fleetctlConfig.Name(), "-f", globalFileV2})
+	assert.Contains(t, out, "[-] deleting custom host vital 'Department'")
+	assert.Contains(t, out, "[+] creating 1 custom host vital")
+	require.ElementsMatch(t, []string{"Asset tag", "Role"}, names(listVitals()))
+	for _, v := range listVitals() {
+		if v.Name == "Asset tag" {
+			require.Equal(t, assetTagID, v.ID)
+		}
+	}
+
+	// A script referencing $FLEET_HOST_VITAL_<id> for "Asset tag" blocks its
+	// removal: applying a config that drops it from custom_host_vitals errors
+	// the whole run, and no vitals are removed.
+	script, err := s.DS.NewScript(ctx, &fleet.Script{
+		Name:           "collect-asset-tag.sh",
+		ScriptContents: fmt.Sprintf("echo $%s%d", fleet.CustomHostVitalPrefix, assetTagID),
+	})
+	require.NoError(t, err)
+
+	globalFileV3 := s.customHostVitalsGlobalYAML("  - name: Role\n")
+	_, err = fleetctltest.RunAppNoChecks([]string{"gitops", "--config", fleetctlConfig.Name(), "-f", globalFileV3})
+	require.ErrorContains(t, err, "Couldn't delete")
+	require.ErrorContains(t, err, "Asset tag")
+	require.ElementsMatch(t, []string{"Asset tag", "Role"}, names(listVitals()))
+
+	require.NoError(t, s.DS.DeleteScript(ctx, script.ID))
+
+	// With the reference gone, the same config now succeeds.
+	fleetctltest.RunAppForTest(t, []string{"gitops", "--config", fleetctlConfig.Name(), "-f", globalFileV3})
+	require.ElementsMatch(t, []string{"Role"}, names(listVitals()))
+
+	// An absent `custom_host_vitals:` key is a declarative clear-all.
+	globalFileAbsent := s.customHostVitalsGlobalYAML("")
+	fleetctltest.RunAppForTest(t, []string{"gitops", "--config", fleetctlConfig.Name(), "-f", globalFileAbsent})
+	require.Empty(t, listVitals())
+}

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -375,6 +375,10 @@ type GitOps struct {
 	Labels              []*fleet.LabelSpec
 	LabelChangesSummary LabelChangesSummary
 
+	// CustomHostVitals are the custom host vital definitions (names only; per-host
+	// values are never set via GitOps). Global-only: cannot be set on a team/fleet file.
+	CustomHostVitals []fleet.CustomHostVital
+
 	// Software is only allowed on teams, not on global config.
 	Software GitOpsSoftware
 	// FleetSecrets is a map of secret names to their values, extracted from FLEET_SECRET_ environment variables used in profiles and scripts.
@@ -386,6 +390,15 @@ type GitOps struct {
 	SoftwarePresent bool
 	// SecretsPresent indicates that the `secrets:` key was explicitly present in the YAML file.
 	SecretsPresent bool
+	// CustomHostVitalsPresent indicates that the `custom_host_vitals:` key was explicitly present in the YAML file.
+	CustomHostVitalsPresent bool
+}
+
+// GitOpsCustomHostVital defines the valid keys for an item in the top-level
+// `custom_host_vitals:` list. Definitions only (a name) -- per-host values are
+// never set via GitOps.
+type GitOpsCustomHostVital struct {
+	Name string `json:"name"`
 }
 
 type GitOpsSoftware struct {
@@ -459,7 +472,7 @@ func GitOpsFromFile(filePath, baseDir string, appConfig *fleet.EnrichedAppConfig
 	result := &GitOps{}
 	result.FleetSecrets = make(map[string]string)
 
-	topKeys := []string{"name", "settings", "org_settings", "agent_options", "controls", "policies", "reports", "software", "labels"}
+	topKeys := []string{"name", "settings", "org_settings", "agent_options", "controls", "policies", "reports", "software", "labels", "custom_host_vitals"}
 	for k := range top {
 		if !slices.Contains(topKeys, k) {
 			multiError = multierror.Append(multiError, fmt.Errorf("unknown top-level field: %s", k))
@@ -522,9 +535,10 @@ func GitOpsFromFile(filePath, baseDir string, appConfig *fleet.EnrichedAppConfig
 
 	for _, topKey := range topKeys {
 		// "name" is handled later with special logic based on the filename.
-		// "labels" and "software" are special cases where omitting may be a no-op (based on exception settings),
-		// rather than a directive to clear settings. settings keys were handled above.
-		if topKey == "name" || topKey == "labels" || topKey == "software" || topKey == "settings" || topKey == "org_settings" {
+		// "labels", "software", and "custom_host_vitals" are special cases where omitting may be a
+		// no-op (based on exception settings), rather than a directive to clear settings. settings
+		// keys were handled above.
+		if topKey == "name" || topKey == "labels" || topKey == "software" || topKey == "custom_host_vitals" || topKey == "settings" || topKey == "org_settings" {
 			continue
 		}
 		// "controls" can be set on _either_ global or "no team" file, and we can't say which it is if both
@@ -551,6 +565,11 @@ func GitOpsFromFile(filePath, baseDir string, appConfig *fleet.EnrichedAppConfig
 		} else {
 			multiError = parseLabels(top, result, baseDir, logFn, filePath, multiError)
 		}
+	}
+	// Get the custom host vitals. CustomHostVitalsPresent tracks whether the key was in the YAML.
+	if _, ok := top["custom_host_vitals"]; ok {
+		result.CustomHostVitalsPresent = true
+		multiError = parseCustomHostVitals(top, result, filePath, multiError)
 	}
 	// Get other top-level entities.
 	multiError = parseControls(top, result, logFn, filePath, multiError)
@@ -1058,6 +1077,40 @@ func parseSecrets(result *GitOps, multiError *multierror.Error) *multierror.Erro
 	} else {
 		result.TeamSettings["secrets"] = enrollSecrets
 	}
+	return multiError
+}
+
+// parseCustomHostVitals parses the top-level `custom_host_vitals:` key.
+// Global-only: custom host vital definitions aren't team-scoped, so the key
+// isn't valid on a team file. An empty (or explicitly null) list is a
+// declarative clear-all, same as an absent secrets/yara_rules list.
+func parseCustomHostVitals(top map[string]json.RawMessage, result *GitOps, filePath string, multiError *multierror.Error) *multierror.Error {
+	raw := top["custom_host_vitals"]
+
+	if !result.global() {
+		return multierror.Append(multiError, errors.New("'custom_host_vitals' cannot be set on a team file"))
+	}
+
+	result.CustomHostVitals = []fleet.CustomHostVital{}
+	if len(raw) == 0 || string(raw) == "null" {
+		return multiError
+	}
+
+	var vitals []GitOpsCustomHostVital
+	if err := json.Unmarshal(raw, &vitals); err != nil {
+		return multierror.Append(multiError, MaybeParseTypeError(filePath, []string{"custom_host_vitals"}, err))
+	}
+	// Validate unknown keys in the custom_host_vitals section.
+	multiError = multierror.Append(multiError, validateRawKeys(raw, reflect.TypeFor[[]GitOpsCustomHostVital](), filePath, []string{"custom_host_vitals"})...)
+
+	for _, v := range vitals {
+		if err := fleet.ValidateCustomHostVitalName(v.Name); err != nil {
+			multiError = multierror.Append(multiError, fmt.Errorf("'custom_host_vitals': %w", err))
+			continue
+		}
+		result.CustomHostVitals = append(result.CustomHostVitals, fleet.CustomHostVital{Name: v.Name})
+	}
+
 	return multiError
 }
 

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -535,9 +535,11 @@ func GitOpsFromFile(filePath, baseDir string, appConfig *fleet.EnrichedAppConfig
 
 	for _, topKey := range topKeys {
 		// "name" is handled later with special logic based on the filename.
-		// "labels", "software", and "custom_host_vitals" are special cases where omitting may be a
-		// no-op (based on exception settings), rather than a directive to clear settings. settings
-		// keys were handled above.
+		// "labels" and "software" are special cases where omitting may be a no-op (based on
+		// exception settings), rather than a directive to clear settings.
+		// "custom_host_vitals" has no exception setting -- omitting it always means clear-all -- but still needs its own
+		// presence tracking (parseCustomHostVitals below), so it's excluded from the generic
+		// null-default handling too. settings keys were handled above.
 		if topKey == "name" || topKey == "labels" || topKey == "software" || topKey == "custom_host_vitals" || topKey == "settings" || topKey == "org_settings" {
 			continue
 		}

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -4818,6 +4818,88 @@ name: TestTeam
 		require.NoError(t, err)
 		assert.False(t, gitops.SoftwarePresent)
 	})
+
+	t.Run("custom host vitals present", func(t *testing.T) {
+		gitops, err := gitOpsFromString(t, `
+org_settings:
+  server_settings:
+    server_url: https://example.com
+  org_info:
+    org_name: Test
+custom_host_vitals:
+  - name: Asset tag
+  - name: Department
+`)
+		require.NoError(t, err)
+		assert.True(t, gitops.CustomHostVitalsPresent)
+		assert.ElementsMatch(t, []fleet.CustomHostVital{{Name: "Asset tag"}, {Name: "Department"}}, gitops.CustomHostVitals)
+	})
+
+	t.Run("custom host vitals absent", func(t *testing.T) {
+		gitops, err := gitOpsFromString(t, `
+org_settings:
+  server_settings:
+    server_url: https://example.com
+  org_info:
+    org_name: Test
+`)
+		require.NoError(t, err)
+		assert.False(t, gitops.CustomHostVitalsPresent)
+		assert.Nil(t, gitops.CustomHostVitals, "absent custom_host_vitals should be nil")
+	})
+
+	t.Run("custom host vitals present but empty", func(t *testing.T) {
+		gitops, err := gitOpsFromString(t, `
+org_settings:
+  server_settings:
+    server_url: https://example.com
+  org_info:
+    org_name: Test
+custom_host_vitals:
+`)
+		require.NoError(t, err)
+		assert.True(t, gitops.CustomHostVitalsPresent)
+		assert.Empty(t, gitops.CustomHostVitals)
+	})
+}
+
+func TestGitOpsCustomHostVitals(t *testing.T) {
+	t.Run("rejected on a team file", func(t *testing.T) {
+		path, basePath := createTempFile(t, "", `
+name: TestTeam
+custom_host_vitals:
+  - name: Asset tag
+`)
+		_, err := GitOpsFromFile(path, basePath, nil, nopLogf)
+		require.ErrorContains(t, err, "'custom_host_vitals' cannot be set on a team file")
+	})
+
+	t.Run("rejects an invalid name", func(t *testing.T) {
+		_, err := gitOpsFromString(t, `
+org_settings:
+  server_settings:
+    server_url: https://example.com
+  org_info:
+    org_name: Test
+custom_host_vitals:
+  - name: " Asset tag"
+`)
+		require.ErrorContains(t, err, "custom host vital name cannot have leading or trailing whitespace")
+	})
+
+	t.Run("rejects an unknown key", func(t *testing.T) {
+		_, err := gitOpsFromString(t, `
+org_settings:
+  server_settings:
+    server_url: https://example.com
+  org_info:
+    org_name: Test
+custom_host_vitals:
+  - name: Asset tag
+    id: 1
+`)
+		require.Error(t, err)
+	})
 }
 
 func TestGitOpsFMACategoriesPresence(t *testing.T) {

--- a/server/datastore/mysql/custom_host_vitals.go
+++ b/server/datastore/mysql/custom_host_vitals.go
@@ -547,3 +547,75 @@ func (ds *Datastore) GetCustomHostVitals(ctx context.Context, ids []uint) ([]fle
 	}
 	return vitals, nil
 }
+
+func (ds *Datastore) UpsertCustomHostVitals(ctx context.Context, vitals []fleet.CustomHostVital) (created []fleet.CustomHostVital, deleted []fleet.CustomHostVital, err error) {
+	incomingNames := make(map[string]struct{}, len(vitals))
+	for _, v := range vitals {
+		incomingNames[v.Name] = struct{}{}
+	}
+
+	err = ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
+		created, deleted = nil, nil
+
+		var existing []fleet.CustomHostVital
+		if err := sqlx.SelectContext(ctx, tx, &existing, `SELECT id, name FROM custom_host_vitals`); err != nil {
+			return ctxerr.Wrap(ctx, err, "list existing custom host vitals")
+		}
+
+		existingNames := make(map[string]struct{}, len(existing))
+		for _, e := range existing {
+			existingNames[e.Name] = struct{}{}
+			if _, ok := incomingNames[e.Name]; !ok {
+				deleted = append(deleted, e)
+			}
+		}
+
+		var toInsert []string
+		for _, v := range vitals {
+			if _, ok := existingNames[v.Name]; !ok {
+				toInsert = append(toInsert, v.Name)
+			}
+		}
+
+		for _, v := range deleted {
+			usedByInfo, err := ds.customHostVitalUsedBy(ctx, tx, v.ID, v.Name)
+			if err != nil {
+				return ctxerr.Wrap(ctx, err, "checking custom host vital references")
+			}
+			if usedByInfo != nil {
+				return ctxerr.Wrap(ctx, &fleet.CustomHostVitalUsedError{CustomHostVitalUsedInfo: *usedByInfo}, "found custom host vital in use")
+			}
+		}
+
+		if len(deleted) > 0 {
+			ids := make([]uint, 0, len(deleted))
+			for _, v := range deleted {
+				ids = append(ids, v.ID)
+			}
+			stmt, args, err := sqlx.In(`DELETE FROM custom_host_vitals WHERE id IN (?)`, ids)
+			if err != nil {
+				return ctxerr.Wrap(ctx, err, "build delete custom host vitals query")
+			}
+			if _, err := tx.ExecContext(ctx, stmt, args...); err != nil {
+				return ctxerr.Wrap(ctx, err, "delete custom host vitals")
+			}
+		}
+
+		// Inserted one at a time (rather than a single multi-row INSERT) so each
+		// row's LastInsertId can be captured for the returned `created` list.
+		for _, name := range toInsert {
+			res, err := tx.ExecContext(ctx, `INSERT INTO custom_host_vitals (name) VALUES (?)`, name)
+			if err != nil {
+				return ctxerr.Wrap(ctx, err, "insert custom host vital")
+			}
+			id, _ := res.LastInsertId()
+			created = append(created, fleet.CustomHostVital{ID: uint(id), Name: name}) //nolint:gosec // dismiss G115
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return created, deleted, nil
+}

--- a/server/datastore/mysql/custom_host_vitals_test.go
+++ b/server/datastore/mysql/custom_host_vitals_test.go
@@ -22,6 +22,7 @@ func TestCustomHostVitals(t *testing.T) {
 		fn   func(t *testing.T, ds *Datastore)
 	}{
 		{"CreateCustomHostVital", testCreateCustomHostVital},
+		{"UpsertCustomHostVitals", testUpsertCustomHostVitals},
 		{"ListCustomHostVitals", testListCustomHostVitals},
 		{"UpdateCustomHostVital", testUpdateCustomHostVital},
 		{"SetAndGetHostCustomHostVitals", testSetAndGetHostCustomHostVitals},
@@ -61,6 +62,90 @@ func testCreateCustomHostVital(t *testing.T, ds *Datastore) {
 	var aee fleet.AlreadyExistsError
 	require.ErrorAs(t, err, &aee)
 	require.Zero(t, dup.ID)
+}
+
+// vitalNames is a test helper that extracts the Name of each vital, for use with require.ElementsMatch.
+func vitalNames(vitals []fleet.CustomHostVital) []string {
+	out := make([]string, 0, len(vitals))
+	for _, v := range vitals {
+		out = append(out, v.Name)
+	}
+	return out
+}
+
+func testUpsertCustomHostVitals(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	list := func() []fleet.CustomHostVital {
+		vitals, _, _, err := ds.ListCustomHostVitals(ctx, fleet.ListOptions{})
+		require.NoError(t, err)
+		return vitals
+	}
+
+	// Empty incoming set against no existing definitions is a no-op.
+	created, deleted, err := ds.UpsertCustomHostVitals(ctx, nil)
+	require.NoError(t, err)
+	require.Empty(t, created)
+	require.Empty(t, deleted)
+	require.Empty(t, list())
+
+	// Initial apply creates all named vitals.
+	created, deleted, err = ds.UpsertCustomHostVitals(ctx, []fleet.CustomHostVital{{Name: "Function"}, {Name: "Department"}})
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"Function", "Department"}, vitalNames(created))
+	require.Empty(t, deleted)
+	require.ElementsMatch(t, []string{"Function", "Department"}, vitalNames(list()))
+
+	byName := make(map[string]uint)
+	for _, v := range list() {
+		byName[v.Name] = v.ID
+	}
+	funcID := byName["Function"]
+
+	// Re-applying the same set keeps the existing rows (matched by name), not
+	// recreated, and reports no created/deleted vitals.
+	created, deleted, err = ds.UpsertCustomHostVitals(ctx, []fleet.CustomHostVital{{Name: "Function"}, {Name: "Department"}})
+	require.NoError(t, err)
+	require.Empty(t, created)
+	require.Empty(t, deleted)
+	for _, v := range list() {
+		if v.Name == "Function" {
+			require.Equal(t, funcID, v.ID)
+		}
+	}
+
+	// A name absent from the incoming set ("Department") is deleted; a new name
+	// ("Role") is inserted.
+	created, deleted, err = ds.UpsertCustomHostVitals(ctx, []fleet.CustomHostVital{{Name: "Function"}, {Name: "Role"}})
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"Role"}, vitalNames(created))
+	require.ElementsMatch(t, []string{"Department"}, vitalNames(deleted))
+	require.ElementsMatch(t, []string{"Function", "Role"}, vitalNames(list()))
+
+	// Dropping a still-referenced name errors the whole call and leaves state unchanged.
+	script, err := ds.NewScript(ctx, &fleet.Script{
+		Name:           "collect.sh",
+		ScriptContents: fmt.Sprintf("echo $%s%d", fleet.CustomHostVitalPrefix, funcID),
+	})
+	require.NoError(t, err)
+
+	_, _, err = ds.UpsertCustomHostVitals(ctx, []fleet.CustomHostVital{{Name: "Role"}})
+	require.Error(t, err)
+	var useErr *fleet.CustomHostVitalUsedError
+	require.ErrorAs(t, err, &useErr)
+	require.Equal(t, funcID, useErr.CustomHostVitalID)                      //nolint:nilaway // cannot be nil due to require.ErrorAs above
+	require.Equal(t, "Function", useErr.CustomHostVitalName)                //nolint:nilaway // cannot be nil due to require.ErrorAs above
+	require.Equal(t, fleet.CustomHostVitalEntityScript, useErr.Entity.Type) //nolint:nilaway // cannot be nil due to require.ErrorAs above
+	require.ElementsMatch(t, []string{"Function", "Role"}, vitalNames(list()))
+
+	require.NoError(t, ds.DeleteScript(ctx, script.ID))
+
+	// An empty incoming set (the absent-key GitOps case) clears all definitions.
+	created, deleted, err = ds.UpsertCustomHostVitals(ctx, nil)
+	require.NoError(t, err)
+	require.Empty(t, created)
+	require.ElementsMatch(t, []string{"Function", "Role"}, vitalNames(deleted))
+	require.Empty(t, list())
 }
 
 func testListCustomHostVitals(t *testing.T, ds *Datastore) {

--- a/server/fleet/api_custom_host_vitals.go
+++ b/server/fleet/api_custom_host_vitals.go
@@ -80,3 +80,18 @@ type SetHostCustomHostVitalValueResponse struct {
 }
 
 func (r SetHostCustomHostVitalValueResponse) Error() error { return r.Err }
+
+//////////////////////////////////////////////////////////////////////////////////
+// Upsert custom host vitals (spec)
+//////////////////////////////////////////////////////////////////////////////////
+
+type UpsertCustomHostVitalsRequest struct {
+	DryRun           bool              `json:"dry_run"`
+	CustomHostVitals []CustomHostVital `json:"custom_host_vitals"`
+}
+
+type UpsertCustomHostVitalsResponse struct {
+	Err error `json:"error,omitempty"`
+}
+
+func (r UpsertCustomHostVitalsResponse) Error() error { return r.Err }

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -3147,6 +3147,8 @@ type Datastore interface {
 	// for the host.
 	ExpandCustomHostVitals(ctx context.Context, hostID uint, document string) (string, error)
 
+	UpsertCustomHostVitals(ctx context.Context, vitals []CustomHostVital) (created []CustomHostVital, deleted []CustomHostVital, err error)
+
 	// /////////////////////////////////////////////////////////////////////////////
 	// Android
 

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -1498,6 +1498,9 @@ type Service interface {
 	UpdateCustomHostVital(ctx context.Context, id uint, name string) (*CustomHostVital, error)
 	DeleteCustomHostVital(ctx context.Context, id uint) error
 	SetHostCustomHostVitalValue(ctx context.Context, hostID uint, vitalID uint, value string) error
+	// UpsertCustomHostVitals declaratively reconciles custom host vital definitions (GitOps):
+	// names present are upserted, names absent from customHostVitals are deleted.
+	UpsertCustomHostVitals(ctx context.Context, customHostVitals []CustomHostVital, dryRun bool) error
 
 	// ListAPIEndpoints returns all API endpoints
 	ListAPIEndpoints(ctx context.Context) (endpoints []APIEndpoint, err error)

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1822,8 +1822,6 @@ type UpdateCustomHostVitalFunc func(ctx context.Context, id uint, name string) (
 
 type DeleteCustomHostVitalFunc func(ctx context.Context, id uint) (name string, err error)
 
-type UpsertCustomHostVitalsFunc func(ctx context.Context, vitals []fleet.CustomHostVital) (created []fleet.CustomHostVital, deleted []fleet.CustomHostVital, err error)
-
 type SetHostCustomHostVitalValueFunc func(ctx context.Context, hostID uint, vitalID uint, value string) error
 
 type GetHostCustomHostVitalsFunc func(ctx context.Context, hostID uint) ([]fleet.HostCustomHostVital, error)
@@ -1833,6 +1831,8 @@ type GetCustomHostVitalsFunc func(ctx context.Context, ids []uint) ([]fleet.Cust
 type ValidateReferencedCustomHostVitalsFunc func(ctx context.Context, documents []string) error
 
 type ExpandCustomHostVitalsFunc func(ctx context.Context, hostID uint, document string) (string, error)
+
+type UpsertCustomHostVitalsFunc func(ctx context.Context, vitals []fleet.CustomHostVital) (created []fleet.CustomHostVital, deleted []fleet.CustomHostVital, err error)
 
 type CreateEnterpriseFunc func(ctx context.Context, userID uint) (uint, error)
 
@@ -4856,9 +4856,6 @@ type DataStore struct {
 	DeleteCustomHostVitalFunc        DeleteCustomHostVitalFunc
 	DeleteCustomHostVitalFuncInvoked bool
 
-	UpsertCustomHostVitalsFunc        UpsertCustomHostVitalsFunc
-	UpsertCustomHostVitalsFuncInvoked bool
-
 	SetHostCustomHostVitalValueFunc        SetHostCustomHostVitalValueFunc
 	SetHostCustomHostVitalValueFuncInvoked bool
 
@@ -4873,6 +4870,9 @@ type DataStore struct {
 
 	ExpandCustomHostVitalsFunc        ExpandCustomHostVitalsFunc
 	ExpandCustomHostVitalsFuncInvoked bool
+
+	UpsertCustomHostVitalsFunc        UpsertCustomHostVitalsFunc
+	UpsertCustomHostVitalsFuncInvoked bool
 
 	CreateEnterpriseFunc        CreateEnterpriseFunc
 	CreateEnterpriseFuncInvoked bool
@@ -11656,13 +11656,6 @@ func (s *DataStore) DeleteCustomHostVital(ctx context.Context, id uint) (name st
 	return s.DeleteCustomHostVitalFunc(ctx, id)
 }
 
-func (s *DataStore) UpsertCustomHostVitals(ctx context.Context, vitals []fleet.CustomHostVital) (created []fleet.CustomHostVital, deleted []fleet.CustomHostVital, err error) {
-	s.mu.Lock()
-	s.UpsertCustomHostVitalsFuncInvoked = true
-	s.mu.Unlock()
-	return s.UpsertCustomHostVitalsFunc(ctx, vitals)
-}
-
 func (s *DataStore) SetHostCustomHostVitalValue(ctx context.Context, hostID uint, vitalID uint, value string) error {
 	s.mu.Lock()
 	s.SetHostCustomHostVitalValueFuncInvoked = true
@@ -11696,6 +11689,13 @@ func (s *DataStore) ExpandCustomHostVitals(ctx context.Context, hostID uint, doc
 	s.ExpandCustomHostVitalsFuncInvoked = true
 	s.mu.Unlock()
 	return s.ExpandCustomHostVitalsFunc(ctx, hostID, document)
+}
+
+func (s *DataStore) UpsertCustomHostVitals(ctx context.Context, vitals []fleet.CustomHostVital) (created []fleet.CustomHostVital, deleted []fleet.CustomHostVital, err error) {
+	s.mu.Lock()
+	s.UpsertCustomHostVitalsFuncInvoked = true
+	s.mu.Unlock()
+	return s.UpsertCustomHostVitalsFunc(ctx, vitals)
 }
 
 func (s *DataStore) CreateEnterprise(ctx context.Context, userID uint) (uint, error) {

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1822,6 +1822,8 @@ type UpdateCustomHostVitalFunc func(ctx context.Context, id uint, name string) (
 
 type DeleteCustomHostVitalFunc func(ctx context.Context, id uint) (name string, err error)
 
+type UpsertCustomHostVitalsFunc func(ctx context.Context, vitals []fleet.CustomHostVital) (created []fleet.CustomHostVital, deleted []fleet.CustomHostVital, err error)
+
 type SetHostCustomHostVitalValueFunc func(ctx context.Context, hostID uint, vitalID uint, value string) error
 
 type GetHostCustomHostVitalsFunc func(ctx context.Context, hostID uint) ([]fleet.HostCustomHostVital, error)
@@ -4853,6 +4855,9 @@ type DataStore struct {
 
 	DeleteCustomHostVitalFunc        DeleteCustomHostVitalFunc
 	DeleteCustomHostVitalFuncInvoked bool
+
+	UpsertCustomHostVitalsFunc        UpsertCustomHostVitalsFunc
+	UpsertCustomHostVitalsFuncInvoked bool
 
 	SetHostCustomHostVitalValueFunc        SetHostCustomHostVitalValueFunc
 	SetHostCustomHostVitalValueFuncInvoked bool
@@ -11649,6 +11654,13 @@ func (s *DataStore) DeleteCustomHostVital(ctx context.Context, id uint) (name st
 	s.DeleteCustomHostVitalFuncInvoked = true
 	s.mu.Unlock()
 	return s.DeleteCustomHostVitalFunc(ctx, id)
+}
+
+func (s *DataStore) UpsertCustomHostVitals(ctx context.Context, vitals []fleet.CustomHostVital) (created []fleet.CustomHostVital, deleted []fleet.CustomHostVital, err error) {
+	s.mu.Lock()
+	s.UpsertCustomHostVitalsFuncInvoked = true
+	s.mu.Unlock()
+	return s.UpsertCustomHostVitalsFunc(ctx, vitals)
 }
 
 func (s *DataStore) SetHostCustomHostVitalValue(ctx context.Context, hostID uint, vitalID uint, value string) error {

--- a/server/mock/service/service_mock.go
+++ b/server/mock/service/service_mock.go
@@ -920,6 +920,8 @@ type DeleteCustomHostVitalFunc func(ctx context.Context, id uint) error
 
 type SetHostCustomHostVitalValueFunc func(ctx context.Context, hostID uint, vitalID uint, value string) error
 
+type UpsertCustomHostVitalsFunc func(ctx context.Context, customHostVitals []fleet.CustomHostVital, dryRun bool) error
+
 type ListAPIEndpointsFunc func(ctx context.Context) (endpoints []fleet.APIEndpoint, err error)
 
 type ScimDetailsFunc func(ctx context.Context) (fleet.ScimDetails, error)
@@ -2304,6 +2306,9 @@ type Service struct {
 
 	SetHostCustomHostVitalValueFunc        SetHostCustomHostVitalValueFunc
 	SetHostCustomHostVitalValueFuncInvoked bool
+
+	UpsertCustomHostVitalsFunc        UpsertCustomHostVitalsFunc
+	UpsertCustomHostVitalsFuncInvoked bool
 
 	ListAPIEndpointsFunc        ListAPIEndpointsFunc
 	ListAPIEndpointsFuncInvoked bool
@@ -5507,6 +5512,13 @@ func (s *Service) SetHostCustomHostVitalValue(ctx context.Context, hostID uint, 
 	s.SetHostCustomHostVitalValueFuncInvoked = true
 	s.mu.Unlock()
 	return s.SetHostCustomHostVitalValueFunc(ctx, hostID, vitalID, value)
+}
+
+func (s *Service) UpsertCustomHostVitals(ctx context.Context, customHostVitals []fleet.CustomHostVital, dryRun bool) error {
+	s.mu.Lock()
+	s.UpsertCustomHostVitalsFuncInvoked = true
+	s.mu.Unlock()
+	return s.UpsertCustomHostVitalsFunc(ctx, customHostVitals, dryRun)
 }
 
 func (s *Service) ListAPIEndpoints(ctx context.Context) (endpoints []fleet.APIEndpoint, err error) {

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -2077,6 +2077,10 @@ func (c *Client) DoGitOps(
 			}
 		}
 
+		if err := c.doGitOpsCustomHostVitals(incoming, logFn, dryRun); err != nil {
+			return nil, err
+		}
+
 		// Features
 		var features any
 		var ok bool
@@ -3032,6 +3036,72 @@ func (c *Client) doGitOpsLabels(
 	}
 	logFn("[+] applying %s (%d new and %d updated)\n", numberWithPluralization(len(config.Labels), "label", "labels"), nToAdd, nToUpdate)
 	return c.ApplyLabels(config.Labels, config.TeamID, namesToMove)
+}
+
+// doGitOpsCustomHostVitals reconciles custom host vital definitions against
+// config.CustomHostVitals (an absent key clears all, per parseCustomHostVitals).
+// Global-only, so this is a no-op on a team file (config.CustomHostVitals is
+// always empty there).
+func (c *Client) doGitOpsCustomHostVitals(config *spec.GitOps, logFn func(format string, args ...any), dryRun bool) error {
+	if config.TeamName != nil {
+		return nil
+	}
+
+	desired := config.CustomHostVitals
+	if !config.CustomHostVitalsPresent {
+		desired = []fleet.CustomHostVital{}
+	}
+
+	existing, err := c.listAllCustomHostVitals()
+	if err != nil {
+		return err
+	}
+
+	existingNames := make(map[string]struct{}, len(existing))
+	for _, v := range existing {
+		existingNames[v.Name] = struct{}{}
+	}
+	desiredNames := make(map[string]struct{}, len(desired))
+	for _, v := range desired {
+		desiredNames[v.Name] = struct{}{}
+	}
+
+	var toDelete []string
+	for _, v := range existing {
+		if _, ok := desiredNames[v.Name]; !ok {
+			toDelete = append(toDelete, v.Name)
+		}
+	}
+	var toAdd []string
+	for _, v := range desired {
+		if _, ok := existingNames[v.Name]; !ok {
+			toAdd = append(toAdd, v.Name)
+		}
+	}
+
+	if dryRun {
+		if len(toDelete) > 0 {
+			logFn("[-] would've deleted %s\n", numberWithPluralization(len(toDelete), "custom host vital", "custom host vitals"))
+		}
+		for _, name := range toDelete {
+			logFn("[-] would've deleted custom host vital '%s'\n", name)
+		}
+		if len(toAdd) > 0 {
+			logFn("[+] would've created %s\n", numberWithPluralization(len(toAdd), "custom host vital", "custom host vitals"))
+		}
+		return nil
+	}
+
+	if len(toDelete) > 0 {
+		logFn("[-] deleting %s\n", numberWithPluralization(len(toDelete), "custom host vital", "custom host vitals"))
+	}
+	for _, name := range toDelete {
+		logFn("[-] deleting custom host vital '%s'\n", name)
+	}
+	if len(toAdd) > 0 {
+		logFn("[+] creating %s\n", numberWithPluralization(len(toAdd), "custom host vital", "custom host vitals"))
+	}
+	return c.SaveCustomHostVitals(desired, false)
 }
 
 // resolvePolicySoftwareTitleID attempts to resolve the software title ID for a

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -3093,7 +3093,7 @@ func (c *Client) doGitOpsCustomHostVitals(config *spec.GitOps, logFn func(format
 		if len(toAdd) > 0 {
 			logFn("[+] would've created %s\n", numberWithPluralization(len(toAdd), "custom host vital", "custom host vitals"))
 		}
-		return nil
+		return c.SaveCustomHostVitals(desired, true)
 	}
 
 	if len(toDelete) > 0 {

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -2077,10 +2077,6 @@ func (c *Client) DoGitOps(
 			}
 		}
 
-		if err := c.doGitOpsCustomHostVitals(incoming, logFn, dryRun); err != nil {
-			return nil, err
-		}
-
 		// Features
 		var features any
 		var ok bool
@@ -2297,6 +2293,14 @@ func (c *Client) DoGitOps(
 			if err != nil {
 				return nil, err
 			}
+		}
+
+		// Custom host vitals are global-only and fully declarative: an absent
+		// `custom_host_vitals:` key clears all existing definitions. Runs last in
+		// this branch, after all local-only validation above, since it fetches
+		// current server state over the network to compute the diff.
+		if err := c.doGitOpsCustomHostVitals(incoming, logFn, dryRun); err != nil {
+			return nil, err
 		}
 
 	} else if !incoming.IsNoTeam() {

--- a/server/service/client_custom_host_vitals.go
+++ b/server/service/client_custom_host_vitals.go
@@ -1,0 +1,44 @@
+package service
+
+import (
+	"fmt"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+)
+
+func (c *Client) SaveCustomHostVitals(customHostVitals []fleet.CustomHostVital, dryRun bool) error {
+	verb, path := "PUT", "/api/latest/fleet/spec/custom_host_vitals"
+	params := fleet.UpsertCustomHostVitalsRequest{
+		CustomHostVitals: customHostVitals,
+		DryRun:           dryRun,
+	}
+	var responseBody fleet.UpsertCustomHostVitalsResponse
+	return c.authenticatedRequest(params, verb, path, &responseBody)
+}
+
+// ListCustomHostVitals returns a page of custom host vital definitions.
+func (c *Client) ListCustomHostVitals(query string) ([]fleet.CustomHostVital, error) {
+	verb, path := "GET", "/api/latest/fleet/custom_host_vitals"
+	var responseBody fleet.ListCustomHostVitalsResponse
+	err := c.authenticatedRequestWithQuery(nil, verb, path, &responseBody, query)
+	if err != nil {
+		return nil, err
+	}
+	return responseBody.CustomHostVitals, nil
+}
+
+// listAllCustomHostVitals pages through ListCustomHostVitals to return every definition.
+func (c *Client) listAllCustomHostVitals() ([]fleet.CustomHostVital, error) {
+	const perPage = 1000
+	var all []fleet.CustomHostVital
+	for page := 0; ; page++ {
+		pageVitals, err := c.ListCustomHostVitals(fmt.Sprintf("per_page=%d&page=%d", perPage, page))
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, pageVitals...)
+		if len(pageVitals) < perPage {
+			return all, nil
+		}
+	}
+}

--- a/server/service/custom_host_vitals.go
+++ b/server/service/custom_host_vitals.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/fleetdm/fleet/v4/server/authz"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	common_mysql "github.com/fleetdm/fleet/v4/server/platform/mysql"
+	"golang.org/x/text/unicode/norm"
 )
 
 //////////////////////////////////////////////////////////////////////////////////
@@ -245,15 +247,21 @@ func (svc *Service) UpsertCustomHostVitals(ctx context.Context, customHostVitals
 		return err
 	}
 
-	seen := make(map[string]struct{}, len(customHostVitals))
+	// Names are unique in the database under the utf8mb4_unicode_ci collation
+	// (case-insensitive), so dedupe on that same basis rather than exact string
+	// equality -- otherwise two names differing only by case would pass this
+	// check and then fail as a raw DB duplicate-key error at insert time.
+	seen := make(map[string]string, len(customHostVitals)) // collation key -> original name
 	for _, vital := range customHostVitals {
 		if err := fleet.ValidateCustomHostVitalName(vital.Name); err != nil {
 			return ctxerr.Wrap(ctx, err, "validate custom host vital name")
 		}
-		if _, ok := seen[vital.Name]; ok {
-			return ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("custom_host_vitals", fmt.Sprintf("duplicate custom host vital name: %q", vital.Name)))
+		key := norm.NFC.String(strings.ToLower(vital.Name))
+		if prev, ok := seen[key]; ok {
+			return ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("custom_host_vitals",
+				fmt.Sprintf("duplicate custom host vital names: %q and %q must differ by more than letter case", prev, vital.Name)))
 		}
-		seen[vital.Name] = struct{}{}
+		seen[key] = vital.Name
 	}
 
 	if dryRun {

--- a/server/service/custom_host_vitals.go
+++ b/server/service/custom_host_vitals.go
@@ -229,3 +229,72 @@ func (svc *Service) customHostVitalByID(ctx context.Context, id uint) (*fleet.Cu
 	}
 	return &vitals[0], nil
 }
+
+//////////////////////////////////////////////////////////////////////////////////
+// Upsert custom host vitals (spec)
+//////////////////////////////////////////////////////////////////////////////////
+
+func upsertCustomHostVitalsEndpoint(ctx context.Context, request any, svc fleet.Service) (fleet.Errorer, error) {
+	req := request.(*fleet.UpsertCustomHostVitalsRequest)
+	err := svc.UpsertCustomHostVitals(ctx, req.CustomHostVitals, req.DryRun)
+	return fleet.UpsertCustomHostVitalsResponse{Err: err}, nil
+}
+
+func (svc *Service) UpsertCustomHostVitals(ctx context.Context, customHostVitals []fleet.CustomHostVital, dryRun bool) error {
+	if err := svc.authz.Authorize(ctx, &fleet.CustomHostVital{}, fleet.ActionWrite); err != nil {
+		return err
+	}
+
+	seen := make(map[string]struct{}, len(customHostVitals))
+	for _, vital := range customHostVitals {
+		if err := fleet.ValidateCustomHostVitalName(vital.Name); err != nil {
+			return ctxerr.Wrap(ctx, err, "validate custom host vital name")
+		}
+		if _, ok := seen[vital.Name]; ok {
+			return ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("custom_host_vitals", fmt.Sprintf("duplicate custom host vital name: %q", vital.Name)))
+		}
+		seen[vital.Name] = struct{}{}
+	}
+
+	if dryRun {
+		return nil
+	}
+
+	created, deleted, err := svc.ds.UpsertCustomHostVitals(ctx, customHostVitals)
+	if err != nil {
+		if usedErr, ok := errors.AsType[*fleet.CustomHostVitalUsedError](err); ok {
+			return ctxerr.Wrap(ctx, &fleet.ConflictError{
+				Message: fmt.Sprintf("Couldn't delete. %s", usedErr.Error()),
+			}, "upsert custom host vitals")
+		}
+		return ctxerr.Wrap(ctx, err, "upsert custom host vitals")
+	}
+
+	user := authz.UserFromContext(ctx)
+	for _, vital := range created {
+		if err := svc.NewActivity(
+			ctx,
+			user,
+			fleet.ActivityTypeCreatedCustomHostVital{
+				CustomHostVitalID:   vital.ID,
+				CustomHostVitalName: vital.Name,
+			},
+		); err != nil {
+			return ctxerr.Wrap(ctx, err, "create activity for custom host vital creation")
+		}
+	}
+	for _, vital := range deleted {
+		if err := svc.NewActivity(
+			ctx,
+			user,
+			fleet.ActivityTypeDeletedCustomHostVital{
+				CustomHostVitalID:   vital.ID,
+				CustomHostVitalName: vital.Name,
+			},
+		); err != nil {
+			return ctxerr.Wrap(ctx, err, "create activity for custom host vital deletion")
+		}
+	}
+
+	return nil
+}

--- a/server/service/custom_host_vitals_test.go
+++ b/server/service/custom_host_vitals_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	activity_api "github.com/fleetdm/fleet/v4/server/activity/api"
 	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mock"
@@ -37,6 +38,9 @@ func TestCustomHostVitalsAuth(t *testing.T) {
 	ds.HostLiteFunc = func(ctx context.Context, id uint) (*fleet.Host, error) {
 		return &fleet.Host{ID: id}, nil
 	}
+	ds.UpsertCustomHostVitalsFunc = func(ctx context.Context, vitals []fleet.CustomHostVital) ([]fleet.CustomHostVital, []fleet.CustomHostVital, error) {
+		return nil, nil, nil
+	}
 
 	globalRoles := []struct {
 		name    string
@@ -69,6 +73,9 @@ func TestCustomHostVitalsAuth(t *testing.T) {
 			checkAuthErr(t, !tt.writeOK, err)
 
 			err = svc.DeleteCustomHostVital(ctx, 1)
+			checkAuthErr(t, !tt.writeOK, err)
+
+			err = svc.UpsertCustomHostVitals(ctx, []fleet.CustomHostVital{{Name: "Asset tag"}}, false)
 			checkAuthErr(t, !tt.writeOK, err)
 		})
 	}
@@ -180,4 +187,70 @@ func TestCustomHostVitalNameValidation(t *testing.T) {
 			require.NotNil(t, vital)
 		})
 	}
+}
+
+func TestUpsertCustomHostVitals(t *testing.T) {
+	t.Parallel()
+	ds := new(mock.Store)
+	opts := &TestServerOpts{}
+	svc, ctx := newTestService(t, ds, nil, nil, opts)
+	ctx = viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{ID: 1, GlobalRole: new(fleet.RoleAdmin)}})
+
+	t.Run("rejects invalid names without persisting", func(t *testing.T) {
+		ds.UpsertCustomHostVitalsFunc = func(ctx context.Context, vitals []fleet.CustomHostVital) ([]fleet.CustomHostVital, []fleet.CustomHostVital, error) {
+			t.Fatal("UpsertCustomHostVitals should not be called for an invalid name")
+			return nil, nil, nil
+		}
+		err := svc.UpsertCustomHostVitals(ctx, []fleet.CustomHostVital{{Name: " bad"}}, false)
+		require.Error(t, err)
+	})
+
+	t.Run("rejects duplicate names within the same payload without persisting", func(t *testing.T) {
+		ds.UpsertCustomHostVitalsFunc = func(ctx context.Context, vitals []fleet.CustomHostVital) ([]fleet.CustomHostVital, []fleet.CustomHostVital, error) {
+			t.Fatal("UpsertCustomHostVitals should not be called for a duplicate name")
+			return nil, nil, nil
+		}
+		err := svc.UpsertCustomHostVitals(ctx, []fleet.CustomHostVital{{Name: "Function"}, {Name: "Function"}}, false)
+		require.Error(t, err)
+	})
+
+	t.Run("dry run validates without persisting", func(t *testing.T) {
+		ds.UpsertCustomHostVitalsFunc = func(ctx context.Context, vitals []fleet.CustomHostVital) ([]fleet.CustomHostVital, []fleet.CustomHostVital, error) {
+			t.Fatal("UpsertCustomHostVitals should not be called on a dry run")
+			return nil, nil, nil
+		}
+		err := svc.UpsertCustomHostVitals(ctx, []fleet.CustomHostVital{{Name: "Function"}}, true)
+		require.NoError(t, err)
+	})
+
+	t.Run("emits an activity per created and deleted vital", func(t *testing.T) {
+		ds.UpsertCustomHostVitalsFunc = func(ctx context.Context, vitals []fleet.CustomHostVital) ([]fleet.CustomHostVital, []fleet.CustomHostVital, error) {
+			require.Equal(t, []fleet.CustomHostVital{{Name: "Function"}}, vitals)
+			return []fleet.CustomHostVital{{ID: 2, Name: "Function"}}, []fleet.CustomHostVital{{ID: 1, Name: "Department"}}, nil
+		}
+		var activities []activity_api.ActivityDetails
+		opts.ActivityMock.NewActivityFunc = func(_ context.Context, _ *activity_api.User, activity activity_api.ActivityDetails) error {
+			activities = append(activities, activity)
+			return nil
+		}
+		err := svc.UpsertCustomHostVitals(ctx, []fleet.CustomHostVital{{Name: "Function"}}, false)
+		require.NoError(t, err)
+		require.Len(t, activities, 2)
+		require.IsType(t, fleet.ActivityTypeCreatedCustomHostVital{}, activities[0])
+		require.IsType(t, fleet.ActivityTypeDeletedCustomHostVital{}, activities[1])
+	})
+
+	t.Run("surfaces a still-referenced vital as a conflict", func(t *testing.T) {
+		ds.UpsertCustomHostVitalsFunc = func(ctx context.Context, vitals []fleet.CustomHostVital) ([]fleet.CustomHostVital, []fleet.CustomHostVital, error) {
+			return nil, nil, &fleet.CustomHostVitalUsedError{CustomHostVitalUsedInfo: fleet.CustomHostVitalUsedInfo{
+				CustomHostVitalID:   1,
+				CustomHostVitalName: "Department",
+				Entity:              fleet.EntityUsingCustomHostVital{Type: fleet.CustomHostVitalEntityScript, Name: "collect.sh", FleetName: "Unassigned"},
+			}}
+		}
+		err := svc.UpsertCustomHostVitals(ctx, nil, false)
+		require.Error(t, err)
+		var conflictErr *fleet.ConflictError
+		require.ErrorAs(t, err, &conflictErr)
+	})
 }

--- a/server/service/custom_host_vitals_test.go
+++ b/server/service/custom_host_vitals_test.go
@@ -214,6 +214,15 @@ func TestUpsertCustomHostVitals(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	t.Run("rejects names that are duplicates under the case-insensitive collation", func(t *testing.T) {
+		ds.UpsertCustomHostVitalsFunc = func(ctx context.Context, vitals []fleet.CustomHostVital) ([]fleet.CustomHostVital, []fleet.CustomHostVital, error) {
+			t.Fatal("UpsertCustomHostVitals should not be called for a case-only duplicate name")
+			return nil, nil, nil
+		}
+		err := svc.UpsertCustomHostVitals(ctx, []fleet.CustomHostVital{{Name: "Function"}, {Name: "function"}}, false)
+		require.Error(t, err)
+	})
+
 	t.Run("dry run validates without persisting", func(t *testing.T) {
 		ds.UpsertCustomHostVitalsFunc = func(ctx context.Context, vitals []fleet.CustomHostVital) ([]fleet.CustomHostVital, []fleet.CustomHostVital, error) {
 			t.Fatal("UpsertCustomHostVitals should not be called on a dry run")

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -612,6 +612,7 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	ue.PATCH("/api/_version_/fleet/custom_host_vitals/{id:[0-9]+}", updateCustomHostVitalEndpoint, fleet.UpdateCustomHostVitalRequest{})
 	ue.DELETE("/api/_version_/fleet/custom_host_vitals/{id:[0-9]+}", deleteCustomHostVitalEndpoint, fleet.DeleteCustomHostVitalRequest{})
 	ue.PUT("/api/_version_/fleet/hosts/{host_id:[0-9]+}/custom_host_vitals/{id:[0-9]+}", setHostCustomHostVitalValueEndpoint, fleet.SetHostCustomHostVitalValueRequest{})
+	ue.PUT("/api/_version_/fleet/spec/custom_host_vitals", upsertCustomHostVitalsEndpoint, fleet.UpsertCustomHostVitalsRequest{})
 
 	// API end-points
 	ue.GET("/api/_version_/fleet/rest_api", listAPIEndpointsEndpoint, listAPIEndpointsRequest{})


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #48558

- Adds a `custom_host_vitals` GitOps key, letting `fleetctl gitops` create, update, and remove custom host vital definitions.
- Introduces a new `PUT /spec/custom_host_vitals` server endpoint that reconciles the full set of definitions in one call
- Extends `fleetctl generate-gitops` to emit existing vitals so a GitOps repo can capture and round-trip this configuration.

# Checklist for submitter

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

Will be added in the feature branch.

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GitOps support for a `custom_host_vitals` section in global YAML to declare, reconcile, and report custom host vitals.
  * Added a custom host vitals API that validates names, supports dry-run, and provides create/delete feedback.
  * Supports clearing vitals by explicitly providing an empty list (or `null`), while omitting the key leaves current vitals unchanged.
* **Bug Fixes**
  * Prevents deleting vitals that are still referenced by scripts or other resources.
  * Preserves existing vital IDs when vital definitions are unchanged and rejects invalid/duplicate vital names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->