### PR TITLE
Fleet UI: Fix Controls tab firing wrong-team requests on refresh

### DIFF
--- a/frontend/pages/ManageControlsPage/OSSettings/OSSettings.tests.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/OSSettings.tests.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import { waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+
+import mdmAPI from "services/entities/mdm";
+import mockServer from "test/mock-server";
+import {
+  baseUrl,
+  createCustomRenderer,
+  createMockRouter,
+} from "test/test-utils";
+
+import OSSettings from "./OSSettings";
+
+const baseProps = {
+  router: createMockRouter(),
+  currentPage: 0,
+  params: { section: "disk-encryption" },
+  location: { search: "?fleet_id=5" },
+};
+
+// Verifies the gate that keeps OSSettings from firing team-scoped queries
+// against the wrong fleet on refresh, before useTeamIdParam in the parent
+// has resolved the URL to an available fleet.
+describe("OSSettings", () => {
+  const render = createCustomRenderer({
+    withBackendMock: true,
+    context: {
+      app: {
+        isPremiumTier: true,
+        isGlobalAdmin: true,
+        config: { mdm: { enabled_and_configured: true } },
+      },
+    },
+  });
+
+  // The DiskEncryption card (default section) hits /fleets/:id — return an
+  // empty team config so MSW doesn't log unhandled-request warnings.
+  beforeEach(() => {
+    mockServer.use(
+      http.get(baseUrl("/fleets/:id"), () =>
+        HttpResponse.json({ team: { mdm: {} } })
+      )
+    );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("does not fetch the profile status summary while teamIdForApi is undefined", async () => {
+    const summarySpy = jest
+      .spyOn(mdmAPI, "getProfilesStatusSummary")
+      .mockResolvedValue({ verified: 0, verifying: 0, pending: 0, failed: 0 });
+
+    render(<OSSettings {...baseProps} teamIdForApi={undefined} />);
+
+    // Give react-query a tick — a premature fetch would kick off here.
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(summarySpy).not.toHaveBeenCalled();
+  });
+
+  it("fetches the profile status summary for the passed teamIdForApi", async () => {
+    const summarySpy = jest
+      .spyOn(mdmAPI, "getProfilesStatusSummary")
+      .mockResolvedValue({ verified: 0, verifying: 0, pending: 0, failed: 0 });
+
+    render(<OSSettings {...baseProps} teamIdForApi={5} />);
+
+    await waitFor(() => {
+      expect(summarySpy).toHaveBeenCalledWith(5);
+    });
+    expect(summarySpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/pages/ManageControlsPage/OSSettings/OSSettings.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/OSSettings.tsx
@@ -17,10 +17,9 @@ interface IOSSettingsProps {
   params: Params;
   router: InjectedRouter;
   currentPage: number;
-  // Injected by ManageControlsPage via React.cloneElement; undefined for one
-  // render on refresh while useTeamIdParam reconciles the URL against
-  // availableTeams. Rendering during that window fires queries against the
-  // wrong fleet.
+  // Undefined until the URL's fleet id resolves to an available fleet.
+  // Gate team-scoped queries on this being defined — anything fired during
+  // that window targets the wrong fleet.
   teamIdForApi?: number;
   location: {
     search: string;
@@ -81,9 +80,8 @@ const OSSettings = ({
 
   const CurrentCard = currentFormSection.Card;
 
-  // Hold render until useTeamIdParam in the parent has reconciled the URL
-  // fleet against availableTeams. Mounting cards with an undefined/coerced
-  // team id fires API requests against the wrong fleet.
+  // Wait for the fleet id to resolve before mounting children — they fire
+  // team-scoped queries eagerly.
   if (teamIdForApi === undefined) {
     return <Spinner />;
   }

--- a/frontend/pages/ManageControlsPage/OSSettings/OSSettings.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/OSSettings.tsx
@@ -5,7 +5,7 @@ import { useQuery } from "react-query";
 import { AppContext } from "context/app";
 import SideNav from "pages/admin/components/SideNav";
 import PageDescription from "components/PageDescription";
-import { API_NO_TEAM_ID, APP_CONTEXT_NO_TEAM_ID } from "interfaces/team";
+import Spinner from "components/Spinner";
 import mdmAPI from "services/entities/mdm";
 
 import getOSSettingsNavItems from "./OSSettingsNavItems";
@@ -17,6 +17,11 @@ interface IOSSettingsProps {
   params: Params;
   router: InjectedRouter;
   currentPage: number;
+  // Injected by ManageControlsPage via React.cloneElement; undefined for one
+  // render on refresh while useTeamIdParam reconciles the URL against
+  // availableTeams. Rendering during that window fires queries against the
+  // wrong fleet.
+  teamIdForApi?: number;
   location: {
     search: string;
   };
@@ -25,19 +30,12 @@ interface IOSSettingsProps {
 const OSSettings = ({
   router,
   currentPage,
+  teamIdForApi,
   location: { search: queryString },
   params,
 }: IOSSettingsProps) => {
   const { section } = params;
-  const { currentTeam, isTeamTechnician, isGlobalTechnician } = useContext(
-    AppContext
-  );
-
-  // TODO: consider using useTeamIdParam hook here instead in the future
-  const teamId =
-    currentTeam?.id === undefined || currentTeam.id < APP_CONTEXT_NO_TEAM_ID
-      ? API_NO_TEAM_ID // coerce undefined and -1 to 0 for 'No team'
-      : currentTeam.id;
+  const { isTeamTechnician, isGlobalTechnician } = useContext(AppContext);
 
   const {
     data: aggregateProfileStatusData,
@@ -45,9 +43,10 @@ const OSSettings = ({
     isError: isErrorAggregateProfileStatus,
     isLoading: isLoadingAggregateProfileStatus,
   } = useQuery(
-    ["aggregateProfileStatuses", teamId],
-    () => mdmAPI.getProfilesStatusSummary(teamId),
+    ["aggregateProfileStatuses", teamIdForApi],
+    () => mdmAPI.getProfilesStatusSummary(teamIdForApi as number),
     {
+      enabled: teamIdForApi !== undefined,
       refetchOnWindowFocus: false,
       retry: false,
     }
@@ -82,6 +81,13 @@ const OSSettings = ({
 
   const CurrentCard = currentFormSection.Card;
 
+  // Hold render until useTeamIdParam in the parent has reconciled the URL
+  // fleet against availableTeams. Mounting cards with an undefined/coerced
+  // team id fires API requests against the wrong fleet.
+  if (teamIdForApi === undefined) {
+    return <Spinner />;
+  }
+
   return (
     <div className={baseClass}>
       <PageDescription
@@ -91,7 +97,7 @@ const OSSettings = ({
       <ProfileStatusAggregate
         isLoading={isLoadingAggregateProfileStatus}
         isError={isErrorAggregateProfileStatus}
-        teamId={teamId}
+        teamId={teamIdForApi}
         aggregateProfileStatusData={aggregateProfileStatusData}
       />
       <SideNav
@@ -103,8 +109,8 @@ const OSSettings = ({
         activeItem={currentFormSection.urlSection}
         CurrentCard={
           <CurrentCard
-            key={teamId}
-            currentTeamId={teamId}
+            key={teamIdForApi}
+            currentTeamId={teamIdForApi}
             onMutation={refetchAggregateProfileStatus}
             router={router}
             currentPage={currentPage}

--- a/frontend/pages/ManageControlsPage/Scripts/Scripts.tsx
+++ b/frontend/pages/ManageControlsPage/Scripts/Scripts.tsx
@@ -3,13 +3,12 @@ import { InjectedRouter, Params } from "react-router/lib/Router";
 
 import useTeamIdParam from "hooks/useTeamIdParam";
 
-import { API_NO_TEAM_ID } from "interfaces/team";
-
 import { FLEET_WEBSITE_URL } from "utilities/constants";
 
 import SideNav from "pages/admin/components/SideNav";
 import CustomLink from "components/CustomLink";
 import PageDescription from "components/PageDescription";
+import Spinner from "components/Spinner";
 
 import useScriptNavItems from "./ScriptsNavItems";
 
@@ -61,6 +60,13 @@ const Scripts = ({ router, location, params }: IScriptsProps) => {
 
   const CurrentCard = currentFormSection.Card;
 
+  // Hold render until useTeamIdParam has reconciled the URL fleet against
+  // availableTeams. Coercing undefined to API_NO_TEAM_ID caused the cards
+  // to fire team-0 requests before the correct fleet was known.
+  if (teamIdForApi === undefined) {
+    return <Spinner />;
+  }
+
   return (
     <div className={baseClass}>
       <PageDescription
@@ -83,10 +89,8 @@ const Scripts = ({ router, location, params }: IScriptsProps) => {
         activeItem={currentFormSection.urlSection}
         CurrentCard={
           <CurrentCard
-            // potential undefined for teamIdForApi is an implemenation artifact - it can be assumed
-            // to always be defined here
-            key={teamIdForApi ?? API_NO_TEAM_ID}
-            teamId={teamIdForApi ?? API_NO_TEAM_ID} // Scripts must be scoped to a team
+            key={teamIdForApi}
+            teamId={teamIdForApi}
             router={router}
             location={location}
           />

--- a/frontend/pages/ManageControlsPage/Scripts/Scripts.tsx
+++ b/frontend/pages/ManageControlsPage/Scripts/Scripts.tsx
@@ -1,8 +1,6 @@
 import React from "react";
 import { InjectedRouter, Params } from "react-router/lib/Router";
 
-import useTeamIdParam from "hooks/useTeamIdParam";
-
 import { FLEET_WEBSITE_URL } from "utilities/constants";
 
 import SideNav from "pages/admin/components/SideNav";
@@ -28,17 +26,14 @@ interface IScriptsProps {
   params: Params;
   router: InjectedRouter;
   location: ScriptsLocation;
+  // Undefined until the URL's fleet id resolves to an available fleet.
+  // Gate team-scoped queries on this being defined — anything fired during
+  // that window targets the wrong fleet.
+  teamIdForApi?: number;
 }
 
-const Scripts = ({ router, location, params }: IScriptsProps) => {
+const Scripts = ({ router, location, params, teamIdForApi }: IScriptsProps) => {
   const { section } = params;
-
-  const { teamIdForApi } = useTeamIdParam({
-    location,
-    router,
-    includeAllTeams: false,
-    includeNoTeam: true,
-  });
 
   const SCRIPTS_NAV_ITEMS = useScriptNavItems(teamIdForApi);
 
@@ -60,9 +55,8 @@ const Scripts = ({ router, location, params }: IScriptsProps) => {
 
   const CurrentCard = currentFormSection.Card;
 
-  // Hold render until useTeamIdParam has reconciled the URL fleet against
-  // availableTeams. Coercing undefined to API_NO_TEAM_ID caused the cards
-  // to fire team-0 requests before the correct fleet was known.
+  // Wait for the fleet id to resolve before mounting children — they fire
+  // team-scoped queries eagerly.
   if (teamIdForApi === undefined) {
     return <Spinner />;
   }


### PR DESCRIPTION
## Issue
Closes #49066

## Description
- Bug fix (root cause): `OSSettings` read `AppContext.currentTeam` and coerced `undefined → API_NO_TEAM_ID (0)`, firing `getProfilesStatusSummary(0)` — plus 5 cards' worth of team-scoped queries — against the "unassigned" fleet before `useTeamIdParam` reconciled the URL's `fleet_id` param against `availableTeams`. Users without access to unassigned saw a 403 flash on every refresh; users with access silently loaded the wrong data before the correct request landed. Now consumes the `teamIdForApi` prop that `ManageControlsPage` already injects via `React.cloneElement`, gates the aggregate query on `teamIdForApi !== undefined`, and short-circuits render to a spinner until it's defined so cards don't mount with a coerced id.
- Bug fix (root cause): `Scripts` had the same coercion at its child-card boundary (`teamId={teamIdForApi ?? API_NO_TEAM_ID}`) with an inline comment claiming `teamIdForApi` is always defined — it isn't on refresh. Dropped the fallback and gated render on the same spinner.
- No changes to the leaky OS Settings cards (`ConfigurationProfiles`, `Certificates`, `AssetsTab` have no `enabled` gate on team id). They're protected transitively because their parent now waits before mounting them.

## Screenrecording

### Before

<img width="496" height="934" alt="Screenshot 2026-07-14 at 11 39 23 AM" src="https://github.com/user-attachments/assets/0dc5892b-1a0b-4909-8c6b-2e5c2a6f56af" />


### After

- Refresh under `/controls/os-settings?fleet_id=<any>` — no more `team_id=0` request in the network tab

https://github.com/user-attachments/assets/6a8f64c4-fc37-4bde-9613-5ec862c1cb30


## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented team-scoped settings and script data from loading before the applicable team is resolved.
  * Added loading indicators while team information is unavailable.
  * Ensured profile and script details use the correct team context once available.

* **Tests**
  * Added coverage confirming requests are skipped without a team ID and made once the ID is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->