### PR TITLE
Fleet UI: Remove elevated background on loading spinner

### DIFF
--- a/changes/34984-spinner-elevated-background
+++ b/changes/34984-spinner-elevated-background
@@ -1,0 +1,1 @@
+- Removed the elevated white background container from the loading spinner for a flatter, more consistent look.

--- a/frontend/components/LiveQuery/SelectTargets.tsx
+++ b/frontend/components/LiveQuery/SelectTargets.tsx
@@ -482,7 +482,6 @@ const SelectTargets = ({
         <>
           <Spinner
             size="x-small"
-            includeContainer={false}
             centered={false}
             className={`${baseClass}__count-spinner`}
           />

--- a/frontend/components/Spinner/Spinner.tsx
+++ b/frontend/components/Spinner/Spinner.tsx
@@ -12,8 +12,6 @@ interface ISpinnerProps {
   size?: Size;
   /** The size of the spinner padding. `"medium"` 120px (default), `"small"` 60px */
   verticalPadding?: PaddingSize;
-  /** Include the background container styling for the spinner. defaults: `true` */
-  includeContainer?: boolean;
   /** Center the spinner in its parent. defaults: `true` */
   centered?: boolean;
   className?: string;
@@ -34,7 +32,6 @@ const Spinner = ({
   white,
   size = "medium",
   verticalPadding = "medium",
-  includeContainer = true,
   centered = true,
   className,
   variant = undefined,
@@ -56,7 +53,6 @@ const Spinner = ({
     white,
     centered,
     "small-padding": verticalPadding === "small",
-    "include-container": includeContainer && variant !== "mobile",
     "mobile-view": variant === "mobile",
   });
   return (

--- a/frontend/components/Spinner/_styles.scss
+++ b/frontend/components/Spinner/_styles.scss
@@ -16,14 +16,6 @@
     height: 100vh;
   }
 
-  &.include-container {
-    background-color: $core-fleet-white;
-    box-shadow: 0px 4px 16px rgba(0, 0, 0, 0.1);
-    border-radius: 8px;
-    width: 48px;
-    height: 48px;
-  }
-
   .loader {
     position: relative;
     margin: 0 auto;

--- a/frontend/components/TableContainer/DataTable/SetupScriptStatusCell/SetupScriptStatusCell.tsx
+++ b/frontend/components/TableContainer/DataTable/SetupScriptStatusCell/SetupScriptStatusCell.tsx
@@ -36,7 +36,7 @@ const SetupScriptStatusCell = ({ status }: ISetupScriptStatusCell) => {
     <div className={baseClass}>
       <div className={`${baseClass}__icon`}>
         {icon === "spinner" ? (
-          <Spinner size="x-small" includeContainer={false} delay={0} />
+          <Spinner size="x-small" delay={0} />
         ) : (
           <Icon name={icon} />
         )}

--- a/frontend/components/TableContainer/DataTable/SetupSoftwareStatusCell/SetupSoftwareStatusCell.tsx
+++ b/frontend/components/TableContainer/DataTable/SetupSoftwareStatusCell/SetupSoftwareStatusCell.tsx
@@ -36,7 +36,7 @@ const SetupSoftwareStatusCell = ({ status }: ISetupSoftwareStatusCell) => {
     <div className={baseClass}>
       <div className={`${baseClass}__icon`}>
         {icon === "spinner" ? (
-          <Spinner size="x-small" includeContainer={false} delay={0} />
+          <Spinner size="x-small" delay={0} />
         ) : (
           <Icon name={icon} />
         )}

--- a/frontend/components/queries/LiveResults/LiveResultsHeading/LiveResultsHeading.tsx
+++ b/frontend/components/queries/LiveResults/LiveResultsHeading/LiveResultsHeading.tsx
@@ -142,7 +142,6 @@ const LiveResultsHeading = ({
             <Spinner
               size="x-small"
               centered={false}
-              includeContainer={false}
               className={`${baseClass}__responding-spinner`}
             />
           )}

--- a/frontend/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/pages/DashboardPage/DashboardPage.tsx
@@ -968,7 +968,7 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
         <div className={`${baseClass}__host-sections`}>
           {isHostSummaryFetching ? (
             <Card paddingSize="medium">
-              <Spinner includeContainer={false} verticalPadding="small" />
+              <Spinner verticalPadding="small" />
             </Card>
           ) : (
             HostCountCards

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
@@ -397,7 +397,7 @@ const ChartCard = ({
       );
     }
     if (isLoading) {
-      return <Spinner includeContainer={false} verticalPadding="small" />;
+      return <Spinner verticalPadding="small" />;
     }
     if (error) {
       return <DataError />;

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditIconModal/EditIconModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditIconModal/EditIconModal.tsx
@@ -766,11 +766,7 @@ const EditIconModal = ({
       title="Edit appearance"
       onExit={onExitEditIconModal}
     >
-      {isFirstLoadWithCustomIcon ? (
-        <Spinner includeContainer={false} />
-      ) : (
-        renderForm()
-      )}
+      {isFirstLoadWithCustomIcon ? <Spinner /> : renderForm()}
       <ModalFooter
         primaryButtons={
           <Button

--- a/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/LabelFilterSelect.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/LabelFilterSelect.tsx
@@ -78,7 +78,7 @@ const LoadingMenu = (
   return (
     <components.Menu {...props}>
       <div className={`${baseClass}__menu-loading`}>
-        <Spinner includeContainer={false} />
+        <Spinner />
       </div>
     </components.Menu>
   );

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -951,7 +951,7 @@ const DeviceUserPage = ({
               <div className="site-nav-item__logo-wrapper">
                 <div className="site-nav-item__logo">
                   {isLoadingDupDetails ? (
-                    <Spinner includeContainer={false} centered={false} />
+                    <Spinner centered={false} />
                   ) : (
                     <OrgLogoIcon className="logo" src={orgLogoURL} />
                   )}

--- a/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
+++ b/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
@@ -575,12 +575,7 @@ const InstallStatusCell = ({
       >
         {(isSelfService || isHostOnline) &&
         displayConfig.iconName === "pending-outline" ? (
-          <Spinner
-            size="x-small"
-            includeContainer={false}
-            centered={false}
-            delay={0}
-          />
+          <Spinner size="x-small" centered={false} delay={0} />
         ) : (
           displayConfig?.iconName && (
             <Icon

--- a/frontend/pages/hosts/details/cards/Software/SelfService/components/TileActionStatus/TileActionStatus.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/components/TileActionStatus/TileActionStatus.tsx
@@ -96,12 +96,7 @@ const TileActionStatus = ({
   const renderActiveActionStatus = () => {
     return (
       <>
-        <Spinner
-          size="x-small"
-          includeContainer={false}
-          centered={false}
-          delay={0}
-        />
+        <Spinner size="x-small" centered={false} delay={0} />
         {getPendingOrRunningLabel(software.ui_status)}
       </>
     );

--- a/frontend/pages/hosts/details/cards/Software/SelfService/components/UpdatesCard/UpdateSoftwareItem/UpdateSoftwareItem.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/components/UpdatesCard/UpdateSoftwareItem/UpdateSoftwareItem.tsx
@@ -118,12 +118,7 @@ const InstallerStatus = ({
       >
         <div className={`${baseClass}__status-with-tooltip`}>
           {displayConfig.iconName === "pending-outline" && (
-            <Spinner
-              size="x-small"
-              includeContainer={false}
-              centered={false}
-              delay={0}
-            />
+            <Spinner size="x-small" centered={false} delay={0} />
           )}
           {last_install && displayConfig.displayText === "Failed" && (
             <span data-testid={`${baseClass}__status--test`}>
@@ -176,13 +171,7 @@ const InstallerStatusAction = ({
     if (ui_status === "updating") {
       return (
         <>
-          <Spinner
-            size="x-small"
-            includeContainer={false}
-            centered={false}
-            delay={0}
-          />{" "}
-          Updating...{" "}
+          <Spinner size="x-small" centered={false} delay={0} /> Updating...{" "}
         </>
       );
     }


### PR DESCRIPTION
## Issue
Closes #34984

## Description
- UX: Loading spinner no longer renders inside an elevated white chip (box-shadow + rounded 48×48 container), matching the Figma design system update for a flatter, more consistent look.
- Refactor: Removed the `includeContainer` prop from `Spinner` and dropped `includeContainer={false}` from all 13 callsites — most callers were already opting out, and the few default consumers (Dashboard chart card, host summary card, `EditIconModal`, `LabelFilterSelect`) now render flat.

## Screenrecording
- Spinner rendering across host summary card, dashboard chart card, edit icon modal, and label filter dropdown


https://github.com/user-attachments/assets/352954b9-bb17-46f2-9f30-28c9dd20e8d1


https://github.com/user-attachments/assets/80e91381-a705-4f5a-b02e-1478c2c75703




## Testing

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated loading spinners throughout the app to use a flatter, more consistent appearance.
  * Removed elevated backgrounds, shadows, rounded corners, and fixed container sizing from spinner displays.
  * Preserved existing spinner animations, sizing, positioning, and loading behavior across affected screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->