### PR TITLE
Assets and user-scoped decleration (DDM) profiles are coming in 4.90

### DIFF
--- a/articles/wwdc-2026-what-it-admins-need-to-know.md
+++ b/articles/wwdc-2026-what-it-admins-need-to-know.md
@@ -31,7 +31,7 @@ Apple published [support article 126655 ("Prepare your network environment for s
 
 ## New and migrated declarative configurations
 
-> Enable the [`mdm.allow​_all​_declarations` feature flag](https://fleetdm.com/docs/configuration/fleet-server-configuration#mdm-allow-all-declarations) to deploy any device-scoped, configuration [declaration (DDM profile)](https://developer.apple.com/documentation/devicemanagement/devicemanagement-declarations) with Fleet. Assets and user-scoped declarations are [coming in Fleet 4.89](https://github.com/fleetdm/fleet/issues/38986). At the same time, Fleet will enable this feature flag out-of-the-box.
+> Enable the [`mdm.allow​_all​_declarations` feature flag](https://fleetdm.com/docs/configuration/fleet-server-configuration#mdm-allow-all-declarations) to deploy any device-scoped, configuration [declaration (DDM profile)](https://developer.apple.com/documentation/devicemanagement/devicemanagement-declarations) with Fleet. Assets and user-scoped declarations are [coming in Fleet 4.90](https://github.com/fleetdm/fleet/issues/38986). At the same time, Fleet will enable this feature flag out-of-the-box.
 
 Apple keeps expanding what DDM can express. Here's what's new in OS 27.
 


### PR DESCRIPTION
- This was called out in Mac Admins Slack: https://macadmins.slack.com/archives/C0214NELAE7/p1783715058927419?thread_ts=1783714431.274959&cid=C0214NELAE7
- Fleet shipped an early, small 4.88 which bump 4.89 => 4.90
- GitHub issue: https://github.com/fleetdm/fleet/issues/38986
