### PR TITLE
Fix NDES invalid credentials error to point to correct settings location

### DIFF
--- a/changes/46380-ndes-error-location
+++ b/changes/46380-ndes-error-location
@@ -1,0 +1,1 @@
+- Updated the invalid NDES admin credentials SCEP error message to point to the correct UI location (Settings > Integrations > Certificate enrollment).

--- a/ee/server/service/scep/scep_proxy.go
+++ b/ee/server/service/scep/scep_proxy.go
@@ -783,7 +783,7 @@ func NDESChallengeErrorToDetail(err error) string {
 	switch {
 	case errors.As(err, &NDESInvalidError{}):
 		return fmt.Sprintf("Invalid NDES admin credentials. Fleet couldn't populate %s. "+
-			"Please update credentials in Settings > Integrations > Mobile Device Management > Simple Certificate Enrollment Protocol.", varName)
+			"Please update credentials in Settings > Integrations > Certificate enrollment.", varName)
 	case errors.As(err, &NDESPasswordCacheFullError{}):
 		return fmt.Sprintf("The NDES password cache is full. Fleet couldn't populate %s. "+
 			"Please increase the number of cached passwords in NDES and try again.", varName)

--- a/ee/server/service/scep/scep_proxy_test.go
+++ b/ee/server/service/scep/scep_proxy_test.go
@@ -1250,3 +1250,47 @@ func TestRecordWindowsSCEPProxyFailure(t *testing.T) {
 		})
 	}
 }
+
+func TestNDESChallengeErrorToDetail(t *testing.T) {
+	varName := fleet.FleetVarNDESSCEPChallenge.WithPrefix()
+
+	for _, tc := range []struct {
+		name            string
+		err             error
+		wantContains    []string
+		wantNotContains []string
+	}{
+		{
+			name:         "invalid credentials points to Certificate enrollment",
+			err:          NewNDESInvalidError("invalid admin URL or credentials"),
+			wantContains: []string{"Invalid NDES admin credentials", varName, "Settings > Integrations > Certificate enrollment."},
+			// Regression guard: must not point to the renamed/removed UI location (#46380).
+			wantNotContains: []string{"Mobile Device Management", "Simple Certificate Enrollment Protocol", "Certificate authorities"},
+		},
+		{
+			name:         "password cache full",
+			err:          NewNDESPasswordCacheFullError("the password cache is full"),
+			wantContains: []string{"The NDES password cache is full", varName, "increase the number of cached passwords"},
+		},
+		{
+			name:         "insufficient permissions",
+			err:          NewNDESInsufficientPermissionsError("account lacks permissions"),
+			wantContains: []string{"does not have sufficient permissions to enroll with SCEP", varName, "NDES SCEP enroll permissions"},
+		},
+		{
+			name:         "unknown error falls through to default",
+			err:          errors.New("some unexpected failure"),
+			wantContains: []string{varName, "some unexpected failure"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			detail := NDESChallengeErrorToDetail(tc.err)
+			for _, want := range tc.wantContains {
+				assert.Contains(t, detail, want)
+			}
+			for _, notWant := range tc.wantNotContains {
+				assert.NotContains(t, detail, notWant)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Related issue:** Resolves #46380

## Summary

The "Invalid NDES admin credentials" SCEP profile error message directed admins to a UI location that no longer exists: *"Settings > Integrations > Mobile Device Management > Simple Certificate Enrollment Protocol."*

This updates the message to point to the current, correct location: **"Settings > Integrations > Certificate enrollment."**

Note: the issue text says to point to "Certificate authorities", but that section was renamed to "Certificate enrollment" on 2026-07-10 (PR #47655, after the issue was filed). Using the issue's literal wording would recreate the same bug, so this uses the current UI label — confirmed against `frontend/pages/admin/IntegrationsPage/IntegrationNavItems.tsx` and `CertificateAuthorities.tsx`.

## Changes

- `ee/server/service/scep/scep_proxy.go` — updated the remediation location in the `NDESInvalidError` branch of `NDESChallengeErrorToDetail`.
- `ee/server/service/scep/scep_proxy_test.go` — added `TestNDESChallengeErrorToDetail` covering all four branches, with a regression guard against the removed nav path.
- `changes/46380-ndes-error-location` — changelog entry.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [x] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually

### Manual test plan

1. Configure an NDES CA under Settings > Integrations > Certificate enrollment with invalid admin credentials.
2. Assign a SCEP profile using `$FLEET_VAR_NDES_SCEP_CHALLENGE` to a host (Apple or Windows).
3. Observe the profile failure detail reads: *"Invalid NDES admin credentials. Fleet couldn't populate $FLEET_VAR_NDES_SCEP_CHALLENGE. Please update credentials in Settings > Integrations > Certificate enrollment."* and that the path exists in the UI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the invalid NDES administrator credentials error message with the correct navigation path: **Settings > Integrations > Certificate enrollment**.
  * Improved guidance for other certificate enrollment errors, including password cache and permissions issues.
  * Added safeguards to prevent outdated navigation instructions from appearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->