### PR TITLE
Add Entra client ID to default controls

### DIFF
--- a/.github/workflows/dogfood-gitops.yml
+++ b/.github/workflows/dogfood-gitops.yml
@@ -91,6 +91,7 @@ jobs:
           DOGFOOD_ENTRA_TENANT_ID: ${{ secrets.DOGFOOD_ENTRA_TENANT_ID }}
           DOGFOOD_OKTA_METADATA_URL_ADMINS: ${{ secrets.DOGFOOD_OKTA_METADATA_URL_ADMINS }}
           DOGFOOD_OKTA_METADATA_URL_END_USERS: ${{ secrets.DOGFOOD_OKTA_METADATA_URL_END_USERS }}
+          DOGFOOD_ENTRA_CLIENT_ID: ${{ secrets.DOGFOOD_ENTRA_CLIENT_ID }}
 
       - name: Notify on Gitops failure
         if: failure() && github.ref_name == 'main'

--- a/it-and-security/default.yml
+++ b/it-and-security/default.yml
@@ -97,6 +97,8 @@ controls:
   windows_enabled_and_configured: true
   windows_entra_tenant_ids:
     - $DOGFOOD_ENTRA_TENANT_ID
+  windows_entra_client_ids:
+    - $DOGFOOD_ENTRA_CLIENT_ID
   windows_migration_enabled: true
 labels:
   - path: ./lib/all/labels/arm-based-windows-hosts.yml


### PR DESCRIPTION
Update `it-and-security/default.yml` to include `windows_entra_client_ids` with `$DOGFOOD_ENTRA_CLIENT_ID` alongside the existing Entra tenant ID setting. This ensures default Windows Entra configuration includes both required identifiers for migration/auth setup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Added support for supplying the Entra client ID in the Windows Entra integration configuration.
  * Updated the deployment workflow to pass the configured client ID through automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->