### PR TITLE
Support all Apple declaration (DDM) profiles and assets: Copy change

### DIFF
--- a/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/AddAssetModal/AddAssetModal.tests.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/AddAssetModal/AddAssetModal.tests.tsx
@@ -29,7 +29,7 @@ describe("AddAssetModal", () => {
 
     expect(
       screen.getByText(
-        /only asset declarations \(com\.apple\.asset\) are supported/i
+        /only json files with com\.apple\.asset\.\* are supported/i
       )
     ).toBeInTheDocument();
     expect(screen.getByText("Upload asset")).toBeInTheDocument();

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/AddAssetModal/AddAssetModal.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/AddAssetModal/AddAssetModal.tsx
@@ -32,8 +32,8 @@ const FileChooser = ({ isLoading, onFileOpen }: IFileChooserProps) => {
       <Graphic name="file-json" className={`${baseClass}__graphic`} />
       <span className={`${baseClass}__file-chooser--title`}>Upload asset</span>
       <span className={`${baseClass}__file-chooser--message`}>
-        Currently, only asset declarations (com.apple.asset) are supported. All
-        other assets must be user hosted.{" "}
+        Only JSON files with com.apple.asset.* are supported. Referenced data
+        (Reference.DataURL) must be self-hosted.{" "}
         <CustomLink newTab text="Learn more" url={LEARN_MORE_URL} />
       </span>
       <Button


### PR DESCRIPTION
For the following story:
- https://github.com/fleetdm/fleet/issues/38986


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Experience**
  * Updated configuration profile upload guidance to clarify that only JSON files supporting `com.apple.asset.*` are accepted.
  * Clarified that referenced `Reference.DataURL` data must be self-hosted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->