### PR TITLE
Website: Sync users with Vanta before gathering host data

### DIFF
--- a/website/scripts/send-data-to-vanta.js
+++ b/website/scripts/send-data-to-vanta.js
@@ -126,6 +126,37 @@ module.exports = {
         usersToSyncWithVanta.push(userToSyncWithVanta);
       }
 
+      //  ┌─┐┬ ┬┌┐┌┌─┐  ┬ ┬┌─┐┌─┐┬─┐┌─┐  ┬ ┬┬┌┬┐┬ ┬  ╦  ╦┌─┐┌┐┌┌┬┐┌─┐
+      //  └─┐└┬┘││││    │ │└─┐├┤ ├┬┘└─┐  ││││ │ ├─┤  ╚╗╔╝├─┤│││ │ ├─┤
+      //  └─┘ ┴ ┘└┘└─┘  └─┘└─┘└─┘┴└─└─┘  └┴┘┴ ┴ ┴ ┴   ╚╝ ┴ ┴┘└┘ ┴ ┴ ┴
+      // Note: Users are synced with Vanta before any host information is gathered. Vanta marks user accounts that are
+      // missing from this list as deactivated, so this request is sent first to make sure that users who are removed
+      // from a Fleet instance are deactivated in Vanta, even if an error occurs while gathering host information.
+      // See https://github.com/fleetdm/fleet/issues/45371 for more information.
+      // Note: this request is in a try-catch block so we can handle errors sent from the retry() method
+      try {
+        await sails.helpers.http.sendHttpRequest.with({
+          method: 'PUT',
+          url: 'https://api.vanta.com/v1/resources/user_account/sync_all',
+          body: {
+            sourceId: vantaConnection.vantaSourceId,
+            resourceId: '63868a88d436911435a94035',
+            resources: usersToSyncWithVanta,
+          },
+          headers: {
+            'accept': 'application/json',
+            'authorization': 'Bearer '+updatedRecord.vantaAuthToken,
+            'content-type': 'application/json',
+          },
+        })
+        .retry();
+      } catch(error) {
+        errorReportById[connectionIdAsString] = new Error(`vantaError: When sending a PUT request to the Vanta's '/user_account/sync_all' endpoint for a Vanta connection (id: ${connectionIdAsString}), an error occurred: ${util.inspect(error.raw)}`);
+      }
+
+      if(errorReportById[connectionIdAsString]){// If an error occured in the previous request, we'll bail early for this connection.
+        return;
+      }
 
       //  ┌─┐┌─┐┌┬┐  ┬ ┬┌─┐┌─┐┌┬┐┌─┐
       //  │ ┬├┤  │   ├─┤│ │└─┐ │ └─┐
@@ -149,7 +180,7 @@ module.exports = {
         pageNumberForPossiblePaginatedResults++;
         // If we recieved less results than we requested, we've reached the last page of the results.
         return getHostsResponse.hosts.length !== numberOfHostsPerRequest;
-      }, 30000)
+      }, 300000)// This timeout is the budget for requesting every page of hosts from a Fleet instance. (Larger Fleet instances with many hosts need more than 30 seconds to return every page of results)
       .tolerate(()=>{// If an error occurs while sending a request to the Fleet instance, we'll add the error to the errorReportById object, with this connections ID set as the key.
         errorReportById[connectionIdAsString] = new Error(`When requesting all hosts from a Fleet instance for a VantaConnection (id: ${connectionIdAsString}), the Fleet instance did not respond with all of it's hosts in the set amount of time.`);
       });
@@ -380,34 +411,6 @@ module.exports = {
         }
       }//∞ After every batch of 25 Windows hosts
 
-      //  ┌─┐┬ ┬┌┐┌┌─┐  ┬ ┬┌─┐┌─┐┬─┐┌─┐  ┬ ┬┬┌┬┐┬ ┬  ╦  ╦┌─┐┌┐┌┌┬┐┌─┐
-      //  └─┐└┬┘││││    │ │└─┐├┤ ├┬┘└─┐  ││││ │ ├─┤  ╚╗╔╝├─┤│││ │ ├─┤
-      //  └─┘ ┴ ┘└┘└─┘  └─┘└─┘└─┘┴└─└─┘  └┴┘┴ ┴ ┴ ┴   ╚╝ ┴ ┴┘└┘ ┴ ┴ ┴
-      // Note: this request is in a try-catch block so we can handle errors sent from the retry() method
-      try {
-        await sails.helpers.http.sendHttpRequest.with({
-          method: 'PUT',
-          url: 'https://api.vanta.com/v1/resources/user_account/sync_all',
-          body: {
-            sourceId: vantaConnection.sourceId,
-            resourceId: '63868a88d436911435a94035',
-            resources: usersToSyncWithVanta,
-          },
-          headers: {
-            'accept': 'application/json',
-            'authorization': 'Bearer '+updatedRecord.vantaAuthToken,
-            'content-type': 'application/json',
-          },
-        })
-        .retry();
-      } catch(error) {
-        errorReportById[connectionIdAsString] = new Error(`vantaError: When sending a PUT request to the Vanta's '/user_account/sync_all' endpoint for a Vanta connection (id: ${connectionIdAsString}), an error occurred: ${util.inspect(error.raw)}`);
-      }
-
-      if(errorReportById[connectionIdAsString]){// If an error occured in the previous request, we'll bail early for this connection.
-        return;
-      }
-
       //  ╔═╗┬ ┬┌┐┌┌─┐  ┌┬┐┌─┐┌─┐╔═╗╔═╗  ┬ ┬┌─┐┌─┐┌┬┐┌─┐  ┬ ┬┬┌┬┐┬ ┬  ╦  ╦┌─┐┌┐┌┌┬┐┌─┐
       //  ╚═╗└┬┘││││    │││├─┤│  ║ ║╚═╗  ├─┤│ │└─┐ │ └─┐  ││││ │ ├─┤  ╚╗╔╝├─┤│││ │ ├─┤
       //  ╚═╝ ┴ ┘└┘└─┘  ┴ ┴┴ ┴└─┘╚═╝╚═╝  ┴ ┴└─┘└─┘ ┴ └─┘  └┴┘┴ ┴ ┴ ┴   ╚╝ ┴ ┴┘└┘ ┴ ┴ ┴
@@ -457,7 +460,7 @@ module.exports = {
         })
         .retry();
       } catch (error) {
-        errorReportById[connectionIdAsString] = new Error(`vantaError: When sending a PUT request to the Vanta's '/macos_user_computer/sync_all' endpoint for a Vanta connection (id: ${connectionIdAsString}), an error occurred: ${util.inspect(error.raw)}`);
+        errorReportById[connectionIdAsString] = new Error(`vantaError: When sending a PUT request to the Vanta's '/windows_user_computer/sync_all' endpoint for a Vanta connection (id: ${connectionIdAsString}), an error occurred: ${util.inspect(error.raw)}`);
       }
 
       if(errorReportById[connectionIdAsString]){// If an error occured in the previous request, we'll bail early for this connection.


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Related to #45371 (hardening found during the investigation — see note below; this PR alone is not expected to resolve the reported behavior)

## Note on root cause (updated)

[This comment on the issue](https://github.com/fleetdm/fleet/issues/45371#issuecomment-4983925037) shows that a manually created/deleted test user propagates to Vanta correctly (created, then fully removed by omission), which proves the hourly sync pipeline for the dogfood connection is healthy end-to-end. Meanwhile the same screenshots show a SCIM-deleted user's `user_account` resource lingering in Vanta, and **two "Vanta integration" user-account resources with the identical uniqueId (140)** — which shouldn't be possible within a single source under `sync_all`'s state-of-the-world semantics.

The current leading theory is that Vanta holds a second, **frozen set of dogfood resources under an older source/credential** (e.g., from a re-created connection). The hourly sync only replaces the live source's resources, so departed employees' frozen copies stay "active" and fail the offboarding SLA. That needs to be confirmed and cleaned up on the Vanta side (inventory the Fleet integration's credentials, remove the stale one) and in the fleetdm.com `VantaConnection` records — it is not fixable in this script alone.

The Fleet server behaves correctly: SCIM-deleted users are removed from the `users` table and no longer appear in the "List users" API response.

## Changes (hardening)

Users removed from a Fleet instance are deactivated in Vanta **by omission**: the hourly `send-data-to-vanta` script sends the full user list to Vanta's `user_account/sync_all` endpoint, and Vanta removes any previously-synced account missing from the list. The script only sent that request **after** gathering all host data, so any host-phase error (e.g., the 30-second budget for paginating every host on a large instance) silently prevented user deactivation from reaching Vanta for that run.

- Send the `user_account/sync_all` request to Vanta **immediately after fetching users, before any host data is gathered**, so user deactivation (the compliance-critical signal) is never blocked by host-inventory failures. There is no data dependency between the two phases.
- Fix `sourceId: vantaConnection.sourceId` (undefined — the model attribute is `vantaSourceId`) in the user sync request. The host sync requests already used the correct attribute.
  - ⚠️ **Deploy caveat:** the user sync has sent no `sourceId` since 2022, and Vanta has been inferring the source (presumably from the OAuth token, which is bound to a `source_id` at authorization time). Before deploying, confirm each connection's stored `vantaSourceId` matches the source its token is bound to in Vanta — if any mismatch exists, sending an explicit `sourceId` could re-scope resources under a different source and orphan the previously synced set (the same failure mode suspected in #45371).
- Raise the all-hosts pagination budget from 30 seconds to 300 seconds so large Fleet instances can list all hosts without timing out.
- Fix a copy-pasted endpoint name in the Windows hosts sync error message (said `/macos_user_computer/sync_all`).

## Suggested verification

1. In Vanta, list the Fleet integration's credentials/sources — confirm whether a stale credential exists holding the frozen resource set (duplicate uniqueId 140 "Vanta integration" accounts, lingering departed-user accounts).
2. Check the `VantaConnection` table for all dogfood-related records (id, `vantaSourceId`, `isConnectedToVanta`, created date) and confirm the active connection's id — the script's team-exclusion filter is hardcoded to `vantaConnection.id === 64` and silently stops applying if the connection was re-created under a new id.
3. Run the script against the test Vanta connection; confirm user create/delete still propagates and host inventory still syncs after the reordering.

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops

## Testing

- [ ] QA'd all new/changed functionality manually (needs a run against the test Vanta connection — see suggested verification above)
