### PR TITLE
Fleet UI: Multi-package add-conflict error copy (#49309)

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareCustomPackage/SoftwareCustomPackage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareCustomPackage/SoftwareCustomPackage.tsx
@@ -164,7 +164,9 @@ const SoftwareCustomPackage = ({
         )
       );
     } catch (e) {
-      notify.error(getErrorMessage(e), { response: e });
+      notify.error(getErrorMessage(e, formData.software?.name), {
+        response: e,
+      });
     }
     setUploadDetails(null);
   };

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareCustomPackage/helpers.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareCustomPackage/helpers.tsx
@@ -14,10 +14,11 @@ import {
   REQUEST_TIMEOUT_ERROR_MESSAGE,
   ensurePeriod,
   formatAlreadyAvailableInstallMessage,
+  formatDifferentFileTypeMessage,
 } from "../helpers";
 
 // eslint-disable-next-line import/prefer-default-export
-export const getErrorMessage = (err: unknown) => {
+export const getErrorMessage = (err: unknown, softwareTitle?: string) => {
   const isTimeout =
     isAxiosError(err) &&
     (err.response?.status === 504 || err.response?.status === 408);
@@ -34,6 +35,14 @@ export const getErrorMessage = (err: unknown) => {
     if (alreadyAvailableMessage) {
       return alreadyAvailableMessage;
     }
+  }
+
+  const differentFileTypeMessage = formatDifferentFileTypeMessage(
+    reason,
+    softwareTitle
+  );
+  if (differentFileTypeMessage) {
+    return differentFileTypeMessage;
   }
 
   if (reason.includes("Secret variable")) {

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/helpers.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/helpers.tests.tsx
@@ -4,8 +4,9 @@ import { render } from "@testing-library/react";
 import {
   ensurePeriod,
   formatAlreadyAvailableInstallMessage,
+  formatDifferentFileTypeMessage,
   ADD_SOFTWARE_ERROR_PREFIX,
-} from "./helpers"; // Adjust path as needed
+} from "./helpers";
 
 // --- ensurePeriod tests ---
 
@@ -30,48 +31,126 @@ describe("ensurePeriod", () => {
 // --- formatAlreadyAvailableInstallMessage tests ---
 
 describe("formatAlreadyAvailableInstallMessage", () => {
-  it("returns a React fragment with the correct text and team when the string matches the regex", () => {
-    // Example input: "Couldn't add. MyApp already has an installer available for the Marketing fleet."
-    const msg = `${ADD_SOFTWARE_ERROR_PREFIX} MyApp already has an installer available for the Marketing fleet.`;
-    const result = formatAlreadyAvailableInstallMessage(msg);
-
-    // Render for querying text
-    const { container } = render(<>{result}</>);
-
-    expect(container.textContent).toContain("Couldn't add.");
-    expect(container.textContent).toContain("MyApp");
-    expect(container.textContent).toContain("Marketing fleet");
-  });
-
-  it("returns React with correct text and fleet when the string matches the package exists regex", () => {
-    const msg = `SoftwareInstaller "MyApp" already exists with fleet "Marketing".`;
-    const result = formatAlreadyAvailableInstallMessage(msg);
-
-    const { container } = render(<>{result}</>);
-    expect(container.textContent).toContain("Couldn't add.");
-    expect(container.textContent).toContain("MyApp");
-    expect(container.textContent).toContain(
-      "already has an installer available"
+  it("formats the Fleet-maintained app conflict with bolded title and fleet", () => {
+    const msg =
+      "Zoom already has a Fleet-maintained app on the Testing & QA fleet.";
+    const { container } = render(
+      <>{formatAlreadyAvailableInstallMessage(msg)}</>
     );
+    expect(container.textContent).toBe(
+      "Couldn't add. Zoom already has a Fleet-maintained app on the Testing & QA fleet."
+    );
+    const bolds = container.querySelectorAll("b");
+    expect(bolds).toHaveLength(2);
+    expect(bolds[0].textContent).toBe("Zoom");
+    expect(bolds[1].textContent).toBe("Testing & QA");
+  });
+
+  it("formats the Apple App Store (VPP) conflict with bolded title and fleet", () => {
+    const msg =
+      "Zoom already has an Apple App Store (VPP) on the Testing & QA fleet.";
+    const { container } = render(
+      <>{formatAlreadyAvailableInstallMessage(msg)}</>
+    );
+    expect(container.textContent).toBe(
+      "Couldn't add. Zoom already has an Apple App Store (VPP) on the Testing & QA fleet."
+    );
+    const bolds = container.querySelectorAll("b");
+    expect(bolds).toHaveLength(2);
+    expect(bolds[0].textContent).toBe("Zoom");
+    expect(bolds[1].textContent).toBe("Testing & QA");
+  });
+
+  it("formats the software package conflict with bolded title and fleet", () => {
+    const msg =
+      "Zoom already has a software package on the Testing & QA fleet.";
+    const { container } = render(
+      <>{formatAlreadyAvailableInstallMessage(msg)}</>
+    );
+    expect(container.textContent).toBe(
+      "Couldn't add. Zoom already has a software package on the Testing & QA fleet."
+    );
+  });
+
+  it("formats the package-limit conflict with bolded title and preserved count", () => {
+    const msg =
+      "Fleet osquery already has 10 packages. Before adding, delete one you no longer use.";
+    const { container } = render(
+      <>{formatAlreadyAvailableInstallMessage(msg)}</>
+    );
+    expect(container.textContent).toBe(
+      "Couldn't add. Fleet osquery already has 10 packages. Before adding, delete one you no longer use."
+    );
+    const bolds = container.querySelectorAll("b");
+    expect(bolds).toHaveLength(1);
+    expect(bolds[0].textContent).toBe("Fleet osquery");
+  });
+
+  it("falls back to the legacy 'installer available' copy when the backend still emits it", () => {
+    const msg = `${ADD_SOFTWARE_ERROR_PREFIX} MyApp already has an installer available for the Marketing fleet.`;
+    const { container } = render(
+      <>{formatAlreadyAvailableInstallMessage(msg)}</>
+    );
+    expect(container.textContent).toContain("Couldn't add.");
+    expect(container.textContent).toContain("MyApp");
     expect(container.textContent).toContain("Marketing fleet");
   });
 
-  it("returns null if the string does not match the expected pattern", () => {
-    const msg = "Random error message not matching pattern";
+  it("strips the legacy 'Couldn't add software.' prefix before matching", () => {
+    const msg = `Couldn't add software. Zoom already has a Fleet-maintained app on the Testing & QA fleet.`;
     const result = formatAlreadyAvailableInstallMessage(msg);
-    expect(result).toBeNull();
-  });
-
-  it("works for different app names and fleet names", () => {
-    const msg = `${ADD_SOFTWARE_ERROR_PREFIX} Zoom already has an installer available for the Engineering fleet.`;
-    const result = formatAlreadyAvailableInstallMessage(msg);
-
     const { container } = render(<>{result}</>);
-    expect(container.textContent).toContain("Zoom");
-    expect(container.textContent).toContain("Engineering fleet");
+    expect(container.textContent).toBe(
+      "Couldn't add. Zoom already has a Fleet-maintained app on the Testing & QA fleet."
+    );
   });
 
-  it("returns null if the input is empty", () => {
+  it("handles the legacy quote-style 'SoftwareInstaller/In-house app ... already exists with fleet' format", () => {
+    const msg = `SoftwareInstaller "MyApp" already exists with fleet "Marketing".`;
+    const { container } = render(
+      <>{formatAlreadyAvailableInstallMessage(msg)}</>
+    );
+    expect(container.textContent).toContain("Couldn't add.");
+    expect(container.textContent).toContain("MyApp");
+    expect(container.textContent).toContain("Marketing fleet");
+  });
+
+  it("returns null when the string doesn't match any known pattern", () => {
+    expect(
+      formatAlreadyAvailableInstallMessage("Random error not matching pattern")
+    ).toBeNull();
+  });
+
+  it("returns null on an empty string", () => {
     expect(formatAlreadyAvailableInstallMessage("")).toBeNull();
+  });
+});
+
+// --- formatDifferentFileTypeMessage tests ---
+
+describe("formatDifferentFileTypeMessage", () => {
+  it("formats the different-file-type message with the provided title bolded", () => {
+    const msg = "The selected package is for a different file type.";
+    const { container } = render(
+      <>{formatDifferentFileTypeMessage(msg, "Zoom")}</>
+    );
+    expect(container.textContent).toBe(
+      "Couldn't add. Zoom already has an installer of a different file type."
+    );
+    const bolds = container.querySelectorAll("b");
+    expect(bolds).toHaveLength(1);
+    expect(bolds[0].textContent).toBe("Zoom");
+  });
+
+  it("returns null when no software title is provided", () => {
+    const msg = "The selected package is for a different file type.";
+    expect(formatDifferentFileTypeMessage(msg, undefined)).toBeNull();
+    expect(formatDifferentFileTypeMessage(msg, "")).toBeNull();
+  });
+
+  it("returns null when the reason doesn't include the sentinel", () => {
+    expect(
+      formatDifferentFileTypeMessage("Some other error", "Zoom")
+    ).toBeNull();
   });
 });

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/helpers.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/helpers.tsx
@@ -4,6 +4,9 @@ export const ADD_SOFTWARE_ERROR_PREFIX = "Couldn't add.";
 export const DEFAULT_ADD_SOFTWARE_ERROR_MESSAGE = `${ADD_SOFTWARE_ERROR_PREFIX} Please try again.`;
 export const REQUEST_TIMEOUT_ERROR_MESSAGE = `${ADD_SOFTWARE_ERROR_PREFIX} Request timeout. Please make sure your server and load balancer timeout is long enough.`;
 
+export const DIFFERENT_FILE_TYPE_MESSAGE =
+  "The selected package is for a different file type.";
+
 /**
  * Ensures that a string ends with a period.
  * If the string is empty or already ends with a period, it is returned unchanged.
@@ -16,36 +19,111 @@ export const ensurePeriod = (str: string) => {
 };
 
 /**
- *  Matches API messages after the fixed Couldn't add software. prefix,
- * and renders just the part about what is available for install.
- * Returns a formatted React element if matched; otherwise, returns null. */
+ * Renders backend "already has ..." conflicts as flash-message JSX, bolding
+ * the software title and fleet name per design. Returns null if the reason
+ * doesn't match a known pattern so callers can fall back to generic handling.
+ */
 export const formatAlreadyAvailableInstallMessage = (msg: string) => {
-  // Remove prefix (with or without trailing space)
+  // Strip the legacy "Couldn't add software." prefix if present.
   const cleaned = msg.replace(/^Couldn't add software\.?\s*/, "");
 
-  // New regex for "<package> already has an installer available for the <fleet> fleet."
-  const installerExistsRegex = /^(.+?) already.+the (.+?) fleet\./;
-  let match = cleaned.match(installerExistsRegex);
-  if (match) {
+  const fmaMatch = cleaned.match(
+    /^(.+?) already has a Fleet-maintained app on the (.+?) fleet\./
+  );
+  if (fmaMatch) {
     return (
       <>
-        {ADD_SOFTWARE_ERROR_PREFIX} <b>{match[1]}</b> already has an installer
-        available for the <b>{match[2]}</b> fleet.{" "}
+        {ADD_SOFTWARE_ERROR_PREFIX} <b>{fmaMatch[1]}</b> already has a
+        Fleet-maintained app on the <b>{fmaMatch[2]}</b> fleet.
       </>
     );
   }
 
-  // New regex for "SoftwareInstaller <package> already exists with fleet <fleet>."
-  // or "In-house app <package> already exists with fleet <fleet>."
-  const packageExistsRegex = /^(?:SoftwareInstaller|In-house app) "(.+?)" already.+ fleet "(.+?)"\./;
-  match = cleaned.match(packageExistsRegex);
-  if (match) {
+  const vppMatch = cleaned.match(
+    /^(.+?) already has an Apple App Store \(VPP\) on the (.+?) fleet\./
+  );
+  if (vppMatch) {
     return (
       <>
-        {ADD_SOFTWARE_ERROR_PREFIX} <b>{match[1]}</b> already has an installer
-        available for the <b>{match[2]}</b> fleet.{" "}
+        {ADD_SOFTWARE_ERROR_PREFIX} <b>{vppMatch[1]}</b> already has an Apple
+        App Store (VPP) on the <b>{vppMatch[2]}</b> fleet.
       </>
     );
   }
+
+  const packageMatch = cleaned.match(
+    /^(.+?) already has a software package on the (.+?) fleet\./
+  );
+  if (packageMatch) {
+    return (
+      <>
+        {ADD_SOFTWARE_ERROR_PREFIX} <b>{packageMatch[1]}</b> already has a
+        software package on the <b>{packageMatch[2]}</b> fleet.
+      </>
+    );
+  }
+
+  const limitMatch = cleaned.match(
+    /^(.+?) already has (\d+) packages\. Before adding, delete one you no longer use\./
+  );
+  if (limitMatch) {
+    return (
+      <>
+        {ADD_SOFTWARE_ERROR_PREFIX} <b>{limitMatch[1]}</b> already has{" "}
+        {limitMatch[2]} packages. Before adding, delete one you no longer use.
+      </>
+    );
+  }
+
+  // Legacy generic conflict — kept as a fallback in case a code path still
+  // emits it. Matches "<title> already has an installer available for the
+  // <fleet> fleet."
+  const legacyInstallerMatch = cleaned.match(
+    /^(.+?) already has an installer available for the (.+?) fleet\./
+  );
+  if (legacyInstallerMatch) {
+    return (
+      <>
+        {ADD_SOFTWARE_ERROR_PREFIX} <b>{legacyInstallerMatch[1]}</b> already has
+        an installer available for the <b>{legacyInstallerMatch[2]}</b> fleet.
+      </>
+    );
+  }
+
+  // Legacy quote-style: `SoftwareInstaller "X" already exists with fleet "Y".`
+  // or `In-house app "X" already exists with fleet "Y".` (emitted by
+  // `alreadyExists(...).WithTeamName(...)` in the mysql layer).
+  const legacyQuotedMatch = cleaned.match(
+    /^(?:SoftwareInstaller|In-house app) "(.+?)" already.+ fleet "(.+?)"\./
+  );
+  if (legacyQuotedMatch) {
+    return (
+      <>
+        {ADD_SOFTWARE_ERROR_PREFIX} <b>{legacyQuotedMatch[1]}</b> already has an
+        installer available for the <b>{legacyQuotedMatch[2]}</b> fleet.
+      </>
+    );
+  }
+
   return null;
+};
+
+/**
+ * Format the backend "different file type" error using the software title
+ * from the calling flow's context. Returns null if the reason doesn't match
+ * or no title is provided so callers can fall back.
+ */
+export const formatDifferentFileTypeMessage = (
+  msg: string,
+  softwareTitle?: string
+) => {
+  if (!softwareTitle || !msg.includes(DIFFERENT_FILE_TYPE_MESSAGE)) {
+    return null;
+  }
+  return (
+    <>
+      {ADD_SOFTWARE_ERROR_PREFIX} <b>{softwareTitle}</b> already has an
+      installer of a different file type.
+    </>
+  );
 };

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/AddPackageModal/AddPackageModal.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/AddPackageModal/AddPackageModal.tests.tsx
@@ -7,6 +7,7 @@ import AddPackageModal from "./AddPackageModal";
 
 const BASE_PROPS = {
   softwareTitleId: 42,
+  softwareTitleName: "GlobalProtect",
   teamId: 1,
   existingPackageName: "GlobalProtect-v6.3.2.pkg",
   onExit: jest.fn(),

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/AddPackageModal/AddPackageModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/AddPackageModal/AddPackageModal.tsx
@@ -29,6 +29,9 @@ interface IAddPackageModalProps {
    * flow). The POST carries this as `software_title_id` so the new package
    * attaches to an existing title instead of creating a new one. */
   softwareTitleId: number;
+  /** Display name of the software title — used to interpolate the title into
+   * backend conflict/error messages that don't carry it themselves. */
+  softwareTitleName: string;
   teamId: number;
   /** File name of the title's first-added package — used to derive the
    * platform/file-type restriction so the new upload matches the existing
@@ -42,6 +45,7 @@ interface IAddPackageModalProps {
 
 const AddPackageModal = ({
   softwareTitleId,
+  softwareTitleName,
   teamId,
   existingPackageName,
   onExit,
@@ -115,7 +119,7 @@ const AddPackageModal = ({
 
       onSuccess();
     } catch (e) {
-      notify.error(getErrorMessage(e), { response: e });
+      notify.error(getErrorMessage(e, softwareTitleName), { response: e });
     }
     setUploadDetails(null);
   };

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
@@ -620,6 +620,10 @@ const SoftwareTitleDetailsPage = ({
     return (
       <AddPackageModal
         softwareTitleId={softwareId}
+        softwareTitleName={getDisplayedSoftwareName(
+          title.name,
+          title.display_name
+        )}
         teamId={teamIdForApi}
         existingPackageName={existingPackageName}
         onExit={() => setShowAddPackageModal(false)}


### PR DESCRIPTION
## Issue

Resolves #49309.

## Description

The frontend collapses every backend `"already ..."` conflict into the generic `"installer available"` flash, wiping the FMA / VPP / package-limit specificity from the design. This routes each backend message to its design-specific copy (title + fleet bolded), and handles the `"different file type"` error at the two Custom Package callsites by prepending the title from form context.

Also plumbs the software title through `SoftwareTitleDetailsPage` → `AddPackageModal` so the multi-package modal can produce the same design copy.

## Screenrecording

<img width="1187" height="864" alt="Screenshot 2026-07-15 at 7 31 43 AM" src="https://github.com/user-attachments/assets/8d2413b1-e8fb-4c3f-a91d-de4f54fe3f18" />


## Testing

- [x] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually