### PR TITLE
Support custom (secret) variables in host name templates

### DIFF
--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -327,7 +327,7 @@ func (svc *Service) ModifyTeam(ctx context.Context, teamID uint, payload fleet.T
 		if payload.MDM.HostNameTemplate.Set {
 			nameTemplate := payload.MDM.HostNameTemplate.Value
 			if nameTemplate != "" {
-				validated, err := fleet.ValidateHostNameTemplate(nameTemplate)
+				validated, err := fleet.ValidateHostNameTemplateWithSecrets(ctx, svc.ds, nameTemplate)
 				if err != nil {
 					return nil, ctxerr.Wrap(ctx, err)
 				}
@@ -1525,7 +1525,7 @@ func (svc *Service) createTeamFromSpec(
 
 	nameTemplate := spec.MDM.HostNameTemplate.Value
 	if nameTemplate != "" {
-		validated, err := fleet.ValidateHostNameTemplate(nameTemplate)
+		validated, err := fleet.ValidateHostNameTemplateWithSecrets(ctx, svc.ds, nameTemplate)
 		if err != nil {
 			return nil, ctxerr.Wrap(ctx, err)
 		}
@@ -1811,7 +1811,7 @@ func (svc *Service) editTeamFromSpec(
 	if spec.MDM.HostNameTemplate.Set {
 		nameTemplate := spec.MDM.HostNameTemplate.Value
 		if nameTemplate != "" {
-			validated, err := fleet.ValidateHostNameTemplate(nameTemplate)
+			validated, err := fleet.ValidateHostNameTemplateWithSecrets(ctx, svc.ds, nameTemplate)
 			if err != nil {
 				return ctxerr.Wrap(ctx, err)
 			}

--- a/server/datastore/mysql/secret_variables.go
+++ b/server/datastore/mysql/secret_variables.go
@@ -311,6 +311,41 @@ func (ds *Datastore) DeleteSecretVariable(ctx context.Context, id uint) (secretN
 			}
 		}
 
+		// 5. Check if the secret variable is used in a host name template, on a
+		// team or on "No team" (the global app config). The template is stored as
+		// the unexpanded $FLEET_SECRET_* placeholder in the config JSON.
+		var nameTemplateContents []entity
+		if err := sqlx.SelectContext(ctx, tx,
+			&nameTemplateContents,
+			// A team's name_template is a plain string that always serializes into
+			// the config JSON (as "" when unset), and the No-team template is an
+			// optjson that serializes to null when unset, so filter both on a
+			// non-empty resolved value rather than IS NOT NULL.
+			`SELECT 'host_name_template' AS entity, 'Host name' AS name,
+			t.name AS team_name, t.config->>'$.mdm.name_template' AS contents
+			FROM teams t
+			WHERE COALESCE(t.config->>'$.mdm.name_template', '') != ''
+			UNION ALL
+			SELECT 'host_name_template' AS entity, 'Host name' AS name,
+			'No team' AS team_name, json_value->>'$.mdm.name_template' AS contents
+			FROM app_config_json
+			WHERE COALESCE(json_value->>'$.mdm.name_template', '') != '';`,
+		); err != nil {
+			return ctxerr.Wrap(ctx, err, "get host name template contents")
+		}
+		for _, c := range nameTemplateContents {
+			if fleet.ContainsVar(c.Contents, fleet.ServerSecretPrefix+secretName) {
+				return ctxerr.Wrap(ctx, &fleet.SecretUsedError{
+					SecretName: secretName,
+					Entity: fleet.EntityUsingSecret{
+						Type:     c.Type,
+						Name:     c.Name,
+						TeamName: c.TeamName,
+					},
+				}, "found secret in use")
+			}
+		}
+
 		if _, err := tx.ExecContext(ctx, `DELETE FROM secret_variables WHERE id = ?`, id); err != nil {
 			return ctxerr.Wrap(ctx, err, "delete secret variable")
 		}

--- a/server/datastore/mysql/secret_variables_test.go
+++ b/server/datastore/mysql/secret_variables_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fleetdm/fleet/v4/pkg/optjson"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mdm/apple/psso/regtoken"
 	"github.com/fleetdm/fleet/v4/server/ptr"
@@ -807,6 +808,46 @@ func testDeleteUsedSecretVariable(t *testing.T, ds *Datastore) {
 
 		err = ds.DeleteScript(ctx, script.ID)
 		require.NoError(t, err)
+	})
+
+	t.Run("host name templates", func(t *testing.T) {
+		// Set a team host name template that uses the variable.
+		foobarTeam.Config.MDM.HostNameTemplate = "iPad $FLEET_SECRET_FOOBAR"
+		_, err := ds.SaveTeam(ctx, foobarTeam)
+		require.NoError(t, err)
+
+		// Attempt to delete the variable, should fail.
+		_, err = ds.DeleteSecretVariable(ctx, id)
+		require.Error(t, err)
+		s := &fleet.SecretUsedError{}
+		require.ErrorAs(t, err, &s)
+		require.Equal(t, "FOOBAR", s.SecretName)
+		require.Equal(t, "host_name_template", s.Entity.Type)
+		require.Equal(t, "Foobar", s.Entity.TeamName)
+
+		// Clear the team template.
+		foobarTeam.Config.MDM.HostNameTemplate = ""
+		_, err = ds.SaveTeam(ctx, foobarTeam)
+		require.NoError(t, err)
+
+		// Set a "No team" (global) host name template that uses the variable.
+		ac, err := ds.AppConfig(ctx)
+		require.NoError(t, err)
+		ac.MDM.HostNameTemplate = optjson.SetString("iPad ${FLEET_SECRET_FOOBAR}")
+		require.NoError(t, ds.SaveAppConfig(ctx, ac))
+
+		// Attempt to delete the variable, should fail.
+		_, err = ds.DeleteSecretVariable(ctx, id)
+		require.Error(t, err)
+		s = &fleet.SecretUsedError{}
+		require.ErrorAs(t, err, &s)
+		require.Equal(t, "FOOBAR", s.SecretName)
+		require.Equal(t, "host_name_template", s.Entity.Type)
+		require.Equal(t, "No team", s.Entity.TeamName)
+
+		// Clear the "No team" template.
+		ac.MDM.HostNameTemplate = optjson.SetString("")
+		require.NoError(t, ds.SaveAppConfig(ctx, ac))
 	})
 
 	// Finally attempt to delete the secret again now that no entity is using it.

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -3976,6 +3976,12 @@ func (c *SecretUsedError) Error() string {
 			c.SecretName, c.Entity.Name, c.Entity.TeamName,
 		)
 	}
+	if c.Entity.Type == "host_name_template" {
+		return fmt.Sprintf(
+			"%s is used by the host name template in the %q team. Please edit or clear the host name template and try again.",
+			c.SecretName, c.Entity.TeamName,
+		)
+	}
 	return fmt.Sprintf(
 		"%s is used by the %q configuration profile in the %q team. Please delete the configuration profile and try again.",
 		c.SecretName, c.Entity.Name, c.Entity.TeamName,

--- a/server/fleet/name_template.go
+++ b/server/fleet/name_template.go
@@ -1,6 +1,7 @@
 package fleet
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"slices"
@@ -41,6 +42,11 @@ var nameTemplateVarRegexp = func() *regexp.Regexp {
 	return regexp.MustCompile(fmt.Sprintf(`\$FLEET_VAR_(%[1]s)\b|\$\{FLEET_VAR_(%[1]s)\}`, alt))
 }()
 
+// nameTemplateSecretRegexp matches a $FLEET_SECRET_NAME / ${FLEET_SECRET_NAME}
+// custom (secret) variable token. Secret values are only known at resolve time
+// so this is used to strip secret tokens out of a template when computing its fixed-text byte floor.
+var nameTemplateSecretRegexp = regexp.MustCompile(`\$` + ServerSecretPrefix + `\w+|\$\{` + ServerSecretPrefix + `\w+\}`)
+
 // ValidateHostNameTemplate validates a host name template and returns the
 // normalized (trimmed) template that callers should persist.
 func ValidateHostNameTemplate(tmpl string) (string, error) {
@@ -63,12 +69,7 @@ func ValidateHostNameTemplate(tmpl string) (string, error) {
 		}
 	}
 
-	// Secret variables ($FLEET_SECRET_*) are never allowed in name templates.
-	if len(ContainsPrefixVars(tmpl, ServerSecretPrefix)) > 0 {
-		return "", NewInvalidArgumentError("name_template", "Secret variables aren't supported in host name templates.")
-	}
-
-	// Every Fleet variable used must be in the allow-list.
+	// Every built-in Fleet variable used must be in the allow-list.
 	for _, v := range variables.Find(tmpl) {
 		if !slices.Contains(fleetVarsSupportedInHostNameTemplates, FleetVarName(v)) {
 			return "", NewInvalidArgumentError("name_template",
@@ -78,16 +79,45 @@ func ValidateHostNameTemplate(tmpl string) (string, error) {
 
 	// The resolved name must fit Apple's device name limit. Stripping the
 	// variables yields the shortest a resolved name can be (a variable may
-	// resolve to an empty value), so if the fixed text alone exceeds the limit no
-	// host can ever get a valid name — reject it now rather than silently failing
-	// every host at resolve time. Per-host overflow from variable expansion is
+	// resolve to an empty value — including a secret, which can be set to an
+	// empty string), so if the fixed text alone exceeds the limit no host can
+	// ever get a valid name — reject it now rather than silently failing every
+	// host at resolve time. Per-host overflow from variable/secret expansion is
 	// still caught by the cron when it resolves against a host's actual values.
-	if literal := nameTemplateVarRegexp.ReplaceAllString(tmpl, ""); len(literal) > MaxResolvedHostNameBytes {
+	literal := nameTemplateVarRegexp.ReplaceAllString(tmpl, "")
+	literal = nameTemplateSecretRegexp.ReplaceAllString(literal, "")
+	if len(literal) > MaxResolvedHostNameBytes {
 		return "", NewInvalidArgumentError("name_template",
 			fmt.Sprintf("Host name template's fixed text can't be longer than %d bytes (the device name limit).", MaxResolvedHostNameBytes))
 	}
 
 	return tmpl, nil
+}
+
+// ValidateHostNameTemplateWithSecrets validates a host name template
+// syntactically (see ValidateHostNameTemplate) and additionally verifies that
+// every custom (secret, $FLEET_SECRET_*) variable it references is defined in
+// the datastore, mirroring how scripts and profiles validate embedded secrets at
+// save time. It returns the normalized template to persist.
+func ValidateHostNameTemplateWithSecrets(ctx context.Context, ds Datastore, tmpl string) (string, error) {
+	validated, err := ValidateHostNameTemplate(tmpl)
+	if err != nil {
+		return "", err
+	}
+	if len(ContainsPrefixVars(validated, ServerSecretPrefix)) > 0 {
+		if err := ds.ValidateEmbeddedSecrets(ctx, []string{validated}); err != nil {
+			// A referenced-but-undefined secret is a user input error (422); surface
+			// the underlying message (which names the missing secret) as an
+			// invalid-argument error. Any other error (e.g. a DB failure) is an
+			// infrastructure problem and must propagate as-is (500), not be
+			// misreported as invalid input.
+			if IsMissingSecretsError(err) {
+				return "", NewInvalidArgumentError("name_template", err.Error())
+			}
+			return "", err
+		}
+	}
+	return validated, nil
 }
 
 // hostNameTemplatePlatformDisplayNames maps a host's osquery platform to the

--- a/server/fleet/name_template_test.go
+++ b/server/fleet/name_template_test.go
@@ -43,15 +43,21 @@ func TestValidateHostNameTemplate(t *testing.T) {
 			tmpl:    "$FLEET_VAR_HOST_UUID_EXTRA",
 			wantErr: "Fleet variable $FLEET_VAR_HOST_UUID_EXTRA is not supported in host name templates.",
 		},
+		// Custom (secret) variables are allowed syntactically; their existence is
+		// checked separately (needs the datastore).
+		{name: "secret var", tmpl: "$FLEET_SECRET_FOO", wantNorm: "$FLEET_SECRET_FOO"},
+		{name: "secret var braced", tmpl: "${FLEET_SECRET_FOO}", wantNorm: "${FLEET_SECRET_FOO}"},
 		{
-			name:    "secret var",
-			tmpl:    "$FLEET_SECRET_FOO",
-			wantErr: "Secret variables aren't supported in host name templates.",
+			name:     "built-in and secret vars mixed",
+			tmpl:     "WS-$FLEET_VAR_HOST_HARDWARE_SERIAL-$FLEET_SECRET_SITE",
+			wantNorm: "WS-$FLEET_VAR_HOST_HARDWARE_SERIAL-$FLEET_SECRET_SITE",
 		},
 		{
-			name:    "secret var braced",
-			tmpl:    "${FLEET_SECRET_FOO}",
-			wantErr: "Secret variables aren't supported in host name templates.",
+			// A long secret token doesn't count toward the fixed-text byte floor,
+			// since the secret can resolve to an empty value.
+			name:     "long secret token doesn't hit byte floor",
+			tmpl:     "WS-${FLEET_SECRET_" + strings.Repeat("A", 80) + "}",
+			wantNorm: "WS-${FLEET_SECRET_" + strings.Repeat("A", 80) + "}",
 		},
 		{name: "tab control char", tmpl: "bad\tname", wantErr: "control characters"},
 		{name: "rtl override format char", tmpl: "bad\u202ename", wantErr: "control characters"},

--- a/server/fleet/secrets.go
+++ b/server/fleet/secrets.go
@@ -1,6 +1,7 @@
 package fleet
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -51,4 +52,12 @@ func (e MissingSecretsError) Error() string {
 		plural = "s"
 	}
 	return fmt.Sprintf("Couldn't add. Secret variable%s %s missing from database", plural, strings.Join(secretVars, ", "))
+}
+
+// IsMissingSecretsError reports whether err is (or wraps) a MissingSecretsError,
+// i.e. a reference to a secret variable that doesn't exist.
+func IsMissingSecretsError(err error) bool {
+	var valErr MissingSecretsError
+	var ptrErr *MissingSecretsError
+	return errors.As(err, &valErr) || errors.As(err, &ptrErr)
 }

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -1900,7 +1900,7 @@ func (svc *Service) validateMDM(
 	if mdm.HostNameTemplate.Value != "" && oldMdm.HostNameTemplate.Value != mdm.HostNameTemplate.Value {
 		if !lic.IsPremium() {
 			invalid.Append("mdm.name_template", ErrMissingLicense.Error())
-		} else if validated, err := fleet.ValidateHostNameTemplate(mdm.HostNameTemplate.Value); err != nil {
+		} else if validated, err := fleet.ValidateHostNameTemplateWithSecrets(ctx, svc.ds, mdm.HostNameTemplate.Value); err != nil {
 			invalid.Append("mdm.name_template", err.Error())
 		} else {
 			mdm.HostNameTemplate = optjson.SetString(validated)

--- a/server/service/apple_device_names.go
+++ b/server/service/apple_device_names.go
@@ -18,6 +18,14 @@ import (
 // var (not const) so tests can override it.
 var reconcileHostDeviceNamesBatchSize = 500
 
+// secretExpansion memoizes the result of expanding the custom (secret) variables
+// in a host name template. err is set (e.g. fleet.MissingSecretsError) when a
+// referenced secret is undefined.
+type secretExpansion struct {
+	value string
+	err   error
+}
+
 // ReconcileHostDeviceNames runs one pass of host-name template enforcement:
 // for each host whose enforcement row is queued (status NULL), it resolves
 // the host's team name template and either enqueues a Settings/DeviceName
@@ -60,7 +68,12 @@ func ReconcileHostDeviceNames(
 
 	noTeamTemplate := appConfig.MDM.HostNameTemplate.Value
 	templates := make(map[uint]string) // team ID → name template
-	var notify []string                // hosts with a freshly-enqueued command to push
+	// secretsExpanded caches the result of expanding $FLEET_SECRET_* custom
+	// variables for a given raw template. Secret values are global (name-keyed,
+	// host-independent), so the same template expands to the same string for
+	// every host — expand once per distinct template rather than per host.
+	secretsExpanded := make(map[string]secretExpansion)
+	var notify []string // hosts with a freshly-enqueued command to push
 	for _, host := range pending {
 		var tmpl string
 		if host.TeamID == nil {
@@ -90,7 +103,41 @@ func ReconcileHostDeviceNames(
 			continue
 		}
 
-		resolved := fleet.ResolveHostNameTemplate(tmpl, &fleet.Host{
+		// Expand any custom (secret, $FLEET_SECRET_*) variables before resolving
+		// the built-in host variables. Secret values are global and
+		// host-independent, so this is memoized per distinct template.
+		expandedTmpl := tmpl
+		if len(fleet.ContainsPrefixVars(tmpl, fleet.ServerSecretPrefix)) > 0 {
+			exp, ok := secretsExpanded[tmpl]
+			if !ok {
+				value, expandErr := ds.ExpandEmbeddedSecrets(ctx, tmpl)
+				exp = secretExpansion{value: value, err: expandErr}
+				secretsExpanded[tmpl] = exp
+			}
+			if exp.err != nil {
+				if !fleet.IsMissingSecretsError(exp.err) {
+					// A transient failure (e.g. a DB error while fetching/decrypting
+					// the secret). Abort the batch so the next cron tick retries,
+					// exactly like the team-config lookup error above — don't
+					// permanently fail rows that a retry would resolve (failed rows
+					// aren't re-picked until a manual resend).
+					return ctxerr.Wrap(ctx, exp.err, "expand host name template secrets")
+				}
+				// A referenced secret is genuinely undefined (e.g. deleted). Save-time
+				// validation and the delete guard normally prevent this, so it's a
+				// defensive path: fail the row with the reason and don't send a
+				// command. On a write error, log and move on rather than aborting the
+				// batch, consistent with the other outcomes below.
+				if err := ds.SetHostDeviceNameStatus(ctx, host.HostUUID, fleet.MDMDeliveryFailed, nil, "",
+					exp.err.Error()); err != nil {
+					logger.ErrorContext(ctx, "mark device name row failed for missing secret", "host_uuid", host.HostUUID, "err", err)
+				}
+				continue
+			}
+			expandedTmpl = exp.value
+		}
+
+		resolved := fleet.ResolveHostNameTemplate(expandedTmpl, &fleet.Host{
 			UUID:           host.HostUUID,
 			HardwareSerial: host.HardwareSerial,
 			Platform:       host.Platform,

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -4016,7 +4016,6 @@ func TestUpdateMDMHostNameTemplate(t *testing.T) {
 	t.Run("invalid templates are rejected", func(t *testing.T) {
 		for _, tc := range []struct{ name, tmpl string }{
 			{"unsupported variable", "WS-$FLEET_VAR_HOST_END_USER_IDP_GROUPS"},
-			{"secret variable", "WS-$FLEET_SECRET_FOO"},
 			{"control characters", "WS-\x07"},
 			{"too long", strings.Repeat("a", 256)},
 		} {
@@ -4030,6 +4029,52 @@ func TestUpdateMDMHostNameTemplate(t *testing.T) {
 				require.False(t, svcOpts.ActivityMock.NewActivityFuncInvoked)
 			})
 		}
+	})
+
+	t.Run("custom (secret) variables", func(t *testing.T) {
+		// Restore the permissive default after each subtest overrides it.
+		defaultValidate := ds.ValidateEmbeddedSecretsFunc
+		defer func() { ds.ValidateEmbeddedSecretsFunc = defaultValidate }()
+
+		t.Run("undefined secret is rejected as invalid argument", func(t *testing.T) {
+			resetInvoked()
+			ds.ValidateEmbeddedSecretsFunc = func(context.Context, []string) error {
+				return &fleet.MissingSecretsError{MissingSecrets: []string{"FOO"}}
+			}
+			err := svc.UpdateMDMHostNameTemplate(premiumAdminCtx(), new(uint(1)), "WS-$FLEET_SECRET_FOO")
+			require.Error(t, err)
+			var invalid *fleet.InvalidArgumentError
+			require.ErrorAs(t, err, &invalid)
+			require.Contains(t, err.Error(), "missing from database")
+			require.False(t, ds.SaveTeamFuncInvoked)
+			require.False(t, svcOpts.ActivityMock.NewActivityFuncInvoked)
+		})
+
+		t.Run("datastore error propagates as a server error, not 422", func(t *testing.T) {
+			resetInvoked()
+			ds.ValidateEmbeddedSecretsFunc = func(context.Context, []string) error {
+				return errors.New("database is down")
+			}
+			err := svc.UpdateMDMHostNameTemplate(premiumAdminCtx(), new(uint(1)), "WS-$FLEET_SECRET_FOO")
+			require.Error(t, err)
+			var invalid *fleet.InvalidArgumentError
+			require.NotErrorAs(t, err, &invalid, "a DB error must not be reported as invalid input")
+			require.False(t, ds.SaveTeamFuncInvoked)
+		})
+
+		t.Run("defined secret is accepted and saved", func(t *testing.T) {
+			resetInvoked()
+			currentTemplate = ""
+			ds.ValidateEmbeddedSecretsFunc = func(context.Context, []string) error { return nil }
+			err := svc.UpdateMDMHostNameTemplate(premiumAdminCtx(), new(uint(1)), "WS-$FLEET_SECRET_FOO")
+			require.NoError(t, err)
+			require.True(t, ds.SaveTeamFuncInvoked)
+			require.True(t, ds.BulkUpsertHostDeviceNameEnforcementFuncInvoked)
+			require.True(t, svcOpts.ActivityMock.NewActivityFuncInvoked)
+			// the unexpanded placeholder is what gets persisted, never the value
+			require.NotNil(t, savedTeam)
+			require.Equal(t, "WS-$FLEET_SECRET_FOO", savedTeam.Config.MDM.HostNameTemplate)
+		})
 	})
 
 	t.Run("setting a template saves, emits activity and queues rows", func(t *testing.T) {

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -25855,8 +25855,11 @@ func (s *integrationMDMTestSuite) TestHostNameTemplateEndToEnd() {
 	res := s.Do("POST", "/api/latest/fleet/host_name_template",
 		updateHostNameTemplateRequest{FleetID: &team.ID, HostNameTemplate: "WS-$FLEET_VAR_HOST_END_USER_IDP_GROUPS"}, http.StatusUnprocessableEntity)
 	require.Contains(t, extractServerErrorText(res.Body), "not supported in host name templates")
-	s.Do("POST", "/api/latest/fleet/host_name_template",
-		updateHostNameTemplateRequest{FleetID: &team.ID, HostNameTemplate: "WS-$FLEET_SECRET_TOKEN"}, http.StatusUnprocessableEntity)
+	// A custom (secret) variable is allowed, but an undefined one is rejected at
+	// save time with the missing-secret error.
+	res = s.Do("POST", "/api/latest/fleet/host_name_template",
+		updateHostNameTemplateRequest{FleetID: &team.ID, HostNameTemplate: "WS-$FLEET_SECRET_UNDEFINED"}, http.StatusUnprocessableEntity)
+	require.Contains(t, extractServerErrorText(res.Body), "missing from database")
 	s.Do("POST", "/api/latest/fleet/host_name_template",
 		updateHostNameTemplateRequest{FleetID: &team.ID, HostNameTemplate: "WS-\x07"}, http.StatusUnprocessableEntity)
 	// fixed text alone longer than the 63-byte device-name limit is rejected up front
@@ -26085,6 +26088,52 @@ func (s *integrationMDMTestSuite) TestHostNameTemplateEndToEnd() {
 	unchangedMac, err := s.ds.Host(ctx, macHost.ID)
 	require.NoError(t, err)
 	require.Equal(t, "WS-"+macHost.HardwareSerial, unchangedMac.ComputerName)
+
+	// --- custom (secret) variable: expanded into the resolved name ---
+	secretID, err := s.ds.CreateSecretVariable(ctx, "SITE", "HQ")
+	require.NoError(t, err)
+	const secretTmpl = "${FLEET_SECRET_SITE}-$FLEET_VAR_HOST_HARDWARE_SERIAL" //nolint:gosec // G101: name template string, not a credential
+	s.Do("POST", "/api/latest/fleet/host_name_template",
+		updateHostNameTemplateRequest{FleetID: &team.ID, HostNameTemplate: secretTmpl}, http.StatusNoContent)
+	// the activity records the unexpanded template (the secret placeholder is
+	// never stored expanded)
+	s.lastActivityMatches("edited_host_name_template",
+		fmt.Sprintf(`{"fleet_id": %d, "fleet_name": %q, "name_template": %q}`, team.ID, team.Name, secretTmpl), 0)
+
+	requireRowStatus(macHost.UUID, nil)
+	runDeviceNameCron()
+	secretRow := requireRowStatus(macHost.UUID, &fleet.MDMDeliveryPending)
+	require.NotNil(t, secretRow.ExpectedDeviceName)
+	// the secret value ("HQ") is expanded alongside the built-in serial variable
+	require.Equal(t, "HQ-"+macHost.HardwareSerial, *secretRow.ExpectedDeviceName)
+	cmd, err = macDevice.Idle()
+	require.NoError(t, err)
+	require.NotNil(t, cmd)
+	require.Equal(t, "Settings", cmd.Command.RequestType)
+	var secretSettingsCmd struct {
+		Command struct {
+			Settings []struct {
+				Item       string
+				DeviceName string
+			}
+		}
+	}
+	require.NoError(t, plist.Unmarshal(cmd.Raw, &secretSettingsCmd))
+	require.Len(t, secretSettingsCmd.Command.Settings, 1)
+	require.Equal(t, "HQ-"+macHost.HardwareSerial, secretSettingsCmd.Command.Settings[0].DeviceName)
+
+	// the secret can't be deleted while a host name template references it
+	_, err = s.ds.DeleteSecretVariable(ctx, secretID)
+	require.Error(t, err)
+	var secretUsed *fleet.SecretUsedError
+	require.ErrorAs(t, err, &secretUsed)
+	require.Equal(t, "host_name_template", secretUsed.Entity.Type)
+
+	// clearing the template releases the secret for deletion
+	s.Do("POST", "/api/latest/fleet/host_name_template",
+		updateHostNameTemplateRequest{FleetID: &team.ID, HostNameTemplate: ""}, http.StatusNoContent)
+	_, err = s.ds.DeleteSecretVariable(ctx, secretID)
+	require.NoError(t, err)
 }
 
 func (s *integrationMDMTestSuite) TestHostNameTemplateNoTeamEndToEnd() {

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -3104,7 +3104,7 @@ func (svc *Service) UpdateMDMHostNameTemplate(ctx context.Context, fleetID *uint
 	}
 
 	if nameTemplate != "" {
-		validated, err := fleet.ValidateHostNameTemplate(nameTemplate)
+		validated, err := fleet.ValidateHostNameTemplateWithSecrets(ctx, svc.ds, nameTemplate)
 		if err != nil {
 			return ctxerr.Wrap(ctx, err)
 		}


### PR DESCRIPTION
Relates to #38806

Host name templates previously accepted only built-in $FLEET_VAR_* variables and rejected custom $FLEET_SECRET_* (secret) variables. Allow secret variables so admins can embed an org-wide custom value in an Apple host's name.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Host name templates can now include Fleet secret variables alongside standard host variables.
  - Secret values are expanded when generating Apple device names.
  - Templates using valid, existing secrets are accepted while preserving the configured placeholder.

- **Bug Fixes**
  - Invalid or missing secrets now produce clear validation errors.
  - Secrets cannot be deleted while referenced by a team or global host name template.
  - Device-name processing handles missing secrets without blocking unrelated hosts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->