### PR TITLE
Bump FMA validator download timeout to 5 minutes

### DIFF
--- a/cmd/maintained-apps/validate/main.go
+++ b/cmd/maintained-apps/validate/main.go
@@ -403,7 +403,7 @@ func appFromJson(manifest *maintained_apps.FMAManifestFile) (fleet.MaintainedApp
 }
 
 func DownloadMaintainedApp(cfg *Config, app fleet.MaintainedApp) (*fleet.TempFileReader, string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
 	cfg.logger.InfoContext(ctx, "Downloading...")


### PR DESCRIPTION
**Related issue:** NA

## What & why

The FMA validator (`cmd/maintained-apps/validate`) downloads each app's installer with a hardcoded 2-minute context timeout. Large installers can't finish in that window — e.g. Android Studio (Windows) is ~1.39 GB, which needs ~12.4 MB/s sustained to complete in 2 minutes. When the runner is slower, the download aborts with `context deadline exceeded`, failing validation with a misleading error that looks URL-related.

This bumps the validator timeout from 2 to 5 minutes. (For reference, the production download path already uses `InstallerTimeout = 15 * time.Minute`.)

# Checklist for submitter

- [x] Timeouts are implemented and retries are limited to avoid infinite loops

## Testing

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the installer download timeout to five minutes, improving reliability for slower downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->