### PR TITLE
Cherry-pick 4.88.0 and 4.88.1 version and changelog into 4.89.0 RC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## Fleet 4.88.0 (Jul 01, 2026)
+
+### Bug fixes
+
+- Added support for personal (BYOD) Apple MDM enrollment, tracking per-host enrollment permissions so that personal devices cannot be remotely wiped or locked, and preserving those permissions across SCEP/ACME certificate renewal.
+- Fixed an issue where fleetd could intermittently fail to install during Windows MDM enrollment, which could cause the Windows Autopilot Enrollment Status Page to hang.
+
+## Fleet 4.87.1 (Jun 26, 2026)
+
+### Bug fixes
+
+- Fixed a bug where an Apple SCEP certificate profile backed by NDES could be marked "failed" and consume one of the host's limited profile retry attempts when its challenge password expired, instead of being automatically resent with a fresh challenge.
+- Fixed GitOps runs failing with a `software_categories` duplicate-entry error when a software category's name differed only by characters MySQL's collation treats as equal (such as the Unicode variation selector in default categories like "🖥️ Productivity").
+- Fixed the **My device > Software** tab appending a `macos_applications` query parameter to the URL when paginating, even though that page has no /Applications filter.
+
 ## Fleet 4.87.0 (Jun 19, 2026)
 
 ### IT Admins

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Fleet 4.88.1 (Jul 09, 2026)
+
+### Bug fixes
+
+- Fixed an issue where a configuration profile could be enqueued multiple times for a single host.
+- Fixed recovery lock password being enforced on personally-owned (BYOD) macOS hosts, where it would always fail because personal enrollments have device lock rights stripped. These hosts are now skipped.
+- Fixed a bug where a user's BYOD selection was not persisted through IdP authentication
+- Fixed a bug where installing App Store (VPP) or in-house apps on an iOS/iPadOS host enrolled with the manual (profile-driven) BYOD enrollment profile failed while trying to look up a VPP user. These device-channel hosts now install apps to the device, the same as company-owned manual enrollment; user-scoped licensing is reserved for Account-Driven User Enrollment.
+
 ## Fleet 4.88.0 (Jul 01, 2026)
 
 ### Bug fixes

--- a/changes/23242-apple-byod-enrollment-permissions
+++ b/changes/23242-apple-byod-enrollment-permissions
@@ -1,1 +1,0 @@
-- Added support for personal (BYOD) Apple MDM enrollment, tracking per-host enrollment permissions so that personal devices cannot be remotely wiped or locked, and preserving those permissions across SCEP/ACME certificate renewal.

--- a/changes/47683-windows-mdm-fleetd-install-ordering
+++ b/changes/47683-windows-mdm-fleetd-install-ordering
@@ -1,1 +1,0 @@
-* Fixed an issue where fleetd could intermittently fail to install during Windows MDM enrollment, which could cause the Windows Autopilot Enrollment Status Page to hang.

--- a/charts/fleet/Chart.yaml
+++ b/charts/fleet/Chart.yaml
@@ -4,11 +4,11 @@ name: fleet
 keywords:
   - fleet
   - osquery
-version: v7.0.10
+version: v7.0.11
 home: https://github.com/fleetdm/fleet
 sources:
   - https://github.com/fleetdm/fleet.git
-appVersion: v4.88.0
+appVersion: v4.88.1
 dependencies:
   - name: mysql
     condition: mysql.enabled

--- a/charts/fleet/Chart.yaml
+++ b/charts/fleet/Chart.yaml
@@ -4,11 +4,11 @@ name: fleet
 keywords:
   - fleet
   - osquery
-version: v7.0.8
+version: v7.0.10
 home: https://github.com/fleetdm/fleet
 sources:
   - https://github.com/fleetdm/fleet.git
-appVersion: v4.87.0
+appVersion: v4.88.0
 dependencies:
   - name: mysql
     condition: mysql.enabled

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -4,7 +4,7 @@ hostName: fleet.localhost
 replicas: 3 # The number of Fleet instances to deploy
 revisionHistoryLimit: 10 # Number of old ReplicaSets for Fleet deployment to retain for rollback (set to 0 for unlimited)
 imageRepository: fleetdm/fleet
-imageTag: v4.87.0 # Version of Fleet to deploy
+imageTag: v4.88.0 # Version of Fleet to deploy
 # imagePullPolicy is optional. If unset, Kubernetes defaults to IfNotPresent
 # for tagged images and Always for the :latest tag. Valid values: Always,
 # IfNotPresent, Never.

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -4,7 +4,7 @@ hostName: fleet.localhost
 replicas: 3 # The number of Fleet instances to deploy
 revisionHistoryLimit: 10 # Number of old ReplicaSets for Fleet deployment to retain for rollback (set to 0 for unlimited)
 imageRepository: fleetdm/fleet
-imageTag: v4.88.0 # Version of Fleet to deploy
+imageTag: v4.88.1 # Version of Fleet to deploy
 # imagePullPolicy is optional. If unset, Kubernetes defaults to IfNotPresent
 # for tagged images and Always for the :latest tag. Valid values: Always,
 # IfNotPresent, Never.

--- a/infrastructure/dogfood/terraform/aws/variables.tf
+++ b/infrastructure/dogfood/terraform/aws/variables.tf
@@ -56,7 +56,7 @@ variable "database_name" {
 
 variable "fleet_image" {
   description = "the name of the container image to run"
-  default     = "fleetdm/fleet:v4.88.0"
+  default     = "fleetdm/fleet:v4.88.1"
 }
 
 variable "software_inventory" {

--- a/infrastructure/dogfood/terraform/aws/variables.tf
+++ b/infrastructure/dogfood/terraform/aws/variables.tf
@@ -56,7 +56,7 @@ variable "database_name" {
 
 variable "fleet_image" {
   description = "the name of the container image to run"
-  default     = "fleetdm/fleet:v4.87.0"
+  default     = "fleetdm/fleet:v4.88.0"
 }
 
 variable "software_inventory" {

--- a/infrastructure/dogfood/terraform/gcp/variables.tf
+++ b/infrastructure/dogfood/terraform/gcp/variables.tf
@@ -68,7 +68,7 @@ variable "redis_mem" {
 }
 
 variable "image" {
-  default = "fleetdm/fleet:v4.87.0"
+  default = "fleetdm/fleet:v4.88.0"
 }
 
 variable "software_installers_bucket_name" {

--- a/infrastructure/dogfood/terraform/gcp/variables.tf
+++ b/infrastructure/dogfood/terraform/gcp/variables.tf
@@ -68,7 +68,7 @@ variable "redis_mem" {
 }
 
 variable "image" {
-  default = "fleetdm/fleet:v4.88.0"
+  default = "fleetdm/fleet:v4.88.1"
 }
 
 variable "software_installers_bucket_name" {

--- a/tools/fleetctl-npm/package.json
+++ b/tools/fleetctl-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fleetctl",
-  "version": "v4.88.0",
+  "version": "v4.88.1",
   "description": "Installer for the fleetctl CLI tool",
   "bin": {
     "fleetctl": "./run.js"

--- a/tools/fleetctl-npm/package.json
+++ b/tools/fleetctl-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fleetctl",
-  "version": "v4.87.0",
+  "version": "v4.88.0",
   "description": "Installer for the fleetctl CLI tool",
   "bin": {
     "fleetctl": "./run.js"
@@ -18,7 +18,7 @@
   "dependencies": {
     "axios": "1.16.1",
     "rimraf": "6.1.2",
-    "tar": "7.5.16"
+    "tar": "7.5.11"
   },
   "keywords": [
     "osquery",


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** N/A

Cherry-picks the version and changelog commits for the shipped 4.88.0 and 4.88.1 releases into the 4.89.0 RC branch, so the RC carries the 4.87.1, 4.88.0, and 4.88.1 changelog sections and version bumps.

- #48445 — Adding changes for Fleet v4.88.0
- #49037 — Adding changes for Fleet v4.88.1

# Checklist for submitter

- [x] QA'd all new/changed functionality manually (changelog/version bump only, no code changes)

Conflict resolution notes:
- `CHANGELOG.md`: inserted the 4.88.0 and 4.87.1 sections above 4.87.0 (RC was branched at 4.87.0 and was missing both).
- Version files (`charts/fleet/Chart.yaml`, `charts/fleet/values.yaml`, `tools/fleetctl-npm/package.json`, dogfood terraform variables): took the incoming bumps, ending at v4.88.1 (Chart v7.0.11).
