### PR TITLE
Update ai_tools schema doc to match shipped v0.3.0 table

### DIFF
--- a/schema/osquery_fleet_schema.json
+++ b/schema/osquery_fleet_schema.json
@@ -230,19 +230,19 @@
   },
   {
     "name": "ai_tools",
-    "description": "Surfaces AI tools on the host: MCP servers, AI agent CLIs, AI desktop apps, IDE plugins, live AI/MCP network sockets, and agent instruction files. Every row is an AI tool. Type-specific extras live in a compact JSON `detail` column.",
+    "description": "Surfaces AI tools on the host: MCP servers, AI agent CLIs, AI desktop apps, IDE plugins, live AI/MCP network sockets, agent instruction files, and browser extensions. Every row is an AI tool. Type-specific extras live in a compact JSON `detail` column.",
     "platforms": [
       "darwin",
       "windows",
       "linux"
     ],
     "evented": false,
-    "examples": "Count AI tools per type on the host.\n\n```\nSELECT type, count(*) FROM ai_tools GROUP BY type;\n```\n\nList outbound AI/MCP connections to see where data is going.\n\n```\nSELECT name, endpoint FROM ai_tools WHERE type = 'sockets' AND location = 'remote';\n```\n\nList running MCP servers and their transport.\n\n```\nSELECT name, source AS client, location, running, pid FROM ai_tools WHERE type = 'mcp_server' AND running = 1;\n```\n\nFind anything carrying a security risk flag across every type.\n\n```\nSELECT type, name, risk_flags, path FROM ai_tools WHERE risk_flags != '';\n```\n\nList AI editor plugins with versions.\n\n```\nSELECT name, identifier, version, category FROM ai_tools WHERE type = 'ide_plugins';\n```",
+    "examples": "Count AI tools per type on the host.\n\n```\nSELECT type, count(*) FROM ai_tools GROUP BY type;\n```\n\nList outbound AI/MCP connections to see where data is going.\n\n```\nSELECT name, endpoint FROM ai_tools WHERE type = 'sockets' AND location = 'remote';\n```\n\nList running MCP servers and their transport.\n\n```\nSELECT name, source AS client, location, running, pid FROM ai_tools WHERE type = 'mcp_server' AND running = 1;\n```\n\nFind anything carrying a security risk flag across every type.\n\n```\nSELECT type, name, risk_flags, path FROM ai_tools WHERE risk_flags != '';\n```\n\nList AI editor plugins with versions.\n\n```\nSELECT name, identifier, version, category FROM ai_tools WHERE type = 'ide_plugins';\n```\n\nList AI browser extensions and their risk flags.\n\n```\nSELECT name, identifier, source, risk_flags FROM ai_tools WHERE type = 'browser_extension';\n```",
     "notes": "The extension enumerates all home directories on the host (`/Users/*`, `/home/*`, `/root`, `C:\\Users\\*`), not just the daemon account's. Running as root provides full visibility across all users.",
     "columns": [
       {
         "name": "type",
-        "description": "Options are `mcp_server`, `ide_plugins`, `agents`, `apps`, `sockets`, or `agent_instruction`.",
+        "description": "Options are `mcp_server`, `ide_plugins`, `agents`, `apps`, `sockets`, `agent_instruction`, or `browser_extension`.",
         "type": "text",
         "required": false
       },
@@ -314,7 +314,7 @@
       },
       {
         "name": "risk_flags",
-        "description": "Comma-separated security risk tokens (empty string = none). Possible values: `remote_fetch_exec`, `unpinned_dependency`, `mcp_shell_exec`, `mcp_fs_write`, `plaintext_secret`, `bypass_permissions`, `injection_markers`, `hidden_unicode`.",
+        "description": "Comma-separated security risk tokens (empty string = none). Possible values: `remote_fetch_exec`, `unpinned_dependency`, `mcp_shell_exec`, `mcp_fs_write`, `plaintext_secret`, `world_readable_config`, `cleartext_endpoint`, `bypass_permissions`, `auto_accept_edits`, `skip_permissions_runtime`, `injection_markers`, `hidden_unicode`, `world_writable`, `broad_host_permissions`, `sideloaded_unverified`.",
         "type": "text",
         "required": false
       },

--- a/schema/tables/ai_tools.yml
+++ b/schema/tables/ai_tools.yml
@@ -1,6 +1,6 @@
 name: ai_tools
 description: |-
-  Surfaces AI tools on the host: MCP servers, AI agent CLIs, AI desktop apps, IDE plugins, live AI/MCP network sockets, and agent instruction files. Every row is an AI tool. Type-specific extras live in a compact JSON `detail` column.
+  Surfaces AI tools on the host: MCP servers, AI agent CLIs, AI desktop apps, IDE plugins, live AI/MCP network sockets, agent instruction files, and browser extensions. Every row is an AI tool. Type-specific extras live in a compact JSON `detail` column.
 platforms:
   - darwin
   - windows
@@ -36,10 +36,16 @@ examples: |-
   ```
   SELECT name, identifier, version, category FROM ai_tools WHERE type = 'ide_plugins';
   ```
+
+  List AI browser extensions and their risk flags.
+
+  ```
+  SELECT name, identifier, source, risk_flags FROM ai_tools WHERE type = 'browser_extension';
+  ```
 notes: The extension enumerates all home directories on the host (`/Users/*`, `/home/*`, `/root`, `C:\Users\*`), not just the daemon account's. Running as root provides full visibility across all users.
 columns:
   - name: type
-    description: "Options are `mcp_server`, `ide_plugins`, `agents`, `apps`, `sockets`, or `agent_instruction`."
+    description: "Options are `mcp_server`, `ide_plugins`, `agents`, `apps`, `sockets`, `agent_instruction`, or `browser_extension`."
     type: text
     required: false
   - name: name
@@ -87,7 +93,7 @@ columns:
     type: integer
     required: false
   - name: risk_flags
-    description: "Comma-separated security risk tokens (empty string = none). Possible values: `remote_fetch_exec`, `unpinned_dependency`, `mcp_shell_exec`, `mcp_fs_write`, `plaintext_secret`, `bypass_permissions`, `injection_markers`, `hidden_unicode`."
+    description: "Comma-separated security risk tokens (empty string = none). Possible values: `remote_fetch_exec`, `unpinned_dependency`, `mcp_shell_exec`, `mcp_fs_write`, `plaintext_secret`, `world_readable_config`, `cleartext_endpoint`, `bypass_permissions`, `auto_accept_edits`, `skip_permissions_runtime`, `injection_markers`, `hidden_unicode`, `world_writable`, `broad_host_permissions`, `sideloaded_unverified`."
     type: text
     required: false
   - name: sha256


### PR DESCRIPTION
**Related issue:** Resolves #47619 (docs reconciliation)

Updates the `ai_tools` table schema doc so it matches the extension actually shipped in fleetd.

The doc (originally #47641) was generated from a pre-v0.3.0 snapshot of `karmine05/agentic-detector` and predates two things that landed in v0.3.0 — the version vendored into fleetd in #49243:

- the **`browser_extension`** row type (added upstream *after* the doc was written);
- several **`risk_flags`** the collectors emit.

### Changes
- Add `browser_extension` to the `type` column options, the table description, and a new example query.
- List the full set of 15 `risk_flags` the collectors produce (was 8).
- Regenerate `schema/osquery_fleet_schema.json` via `cd website && ./node_modules/sails/bin/sails.js run generate-merged-schema`.

This brings the published schema in line with the vendored code in #49243 (which ships 7 row types and 15 risk flags). No other tables are touched.

# Checklist for submitter

- [x] Documentation updated to match shipped behavior (schema table doc).
- [x] Regenerated `schema/osquery_fleet_schema.json` (the automated-doc CI check runs the same generator).
