### PR TITLE
Fleet UI: Show vulnerabilities for Android OS versions

### DIFF
--- a/frontend/interfaces/platform.ts
+++ b/frontend/interfaces/platform.ts
@@ -259,11 +259,11 @@ export const VULN_SUPPORTED_PLATFORMS: Platform[] = [
   "darwin",
   "windows",
   "linux", // Added 4.73
+  "android",
 ];
 export const VULN_UNSUPPORTED_PLATFORMS: Platform[] = [
   "ipados",
   "ios",
-  "android",
   "chrome",
 ];
 

--- a/frontend/pages/SoftwarePage/SoftwareOS/SoftwareOSTable/SoftwareOSTable.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareOS/SoftwareOSTable/SoftwareOSTable.tests.tsx
@@ -2,7 +2,11 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import { createMockRouter } from "test/test-utils";
 
-import { createMockOSVersionsResponse } from "__mocks__/softwareMock";
+import {
+  createMockOSVersion,
+  createMockOSVersionsResponse,
+  createMockSoftwareVulnerability,
+} from "__mocks__/softwareMock";
 
 import SoftwareOSTable from "./SoftwareOSTable";
 
@@ -55,5 +59,40 @@ describe("Software operating systems table", () => {
     expect(screen.getByText("All platforms")).toBeInTheDocument();
     expect(screen.queryByText("Search")).toBeNull();
     expect(screen.queryByText("Updated")).toBeNull();
+  });
+
+  it("Renders Android rows with their vulnerabilities, not a 'Not supported' state", () => {
+    render(
+      <SoftwareOSTable
+        router={mockRouter}
+        isSoftwareEnabled
+        data={createMockOSVersionsResponse({
+          count: 1,
+          os_versions: [
+            createMockOSVersion({
+              os_version_id: 3,
+              name: "Android 16 (2026-05-01)",
+              name_only: "Android",
+              version: "16 (2026-05-01)",
+              platform: "android",
+              hosts_count: 189,
+              vulnerabilities: [
+                createMockSoftwareVulnerability({ cve: "CVE-2026-0073" }),
+              ],
+            }),
+          ],
+        })}
+        perPage={20}
+        orderDirection="asc"
+        orderKey="hosts_count"
+        currentPage={0}
+        teamId={1}
+        isLoading={false}
+      />
+    );
+
+    expect(screen.getByText("16 (2026-05-01)")).toBeInTheDocument();
+    expect(screen.getByText("CVE-2026-0073")).toBeInTheDocument();
+    expect(screen.queryByText("Not supported")).toBeNull();
   });
 });

--- a/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/SoftwareOSDetailsPage.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/SoftwareOSDetailsPage.tests.tsx
@@ -52,6 +52,26 @@ describe("VulnerabilitiesCard", () => {
     expect(screen.getByText("Unavailable")).toBeInTheDocument(); // No created_at date
   });
 
+  it("renders vulnerability table for Android versions", () => {
+    render(
+      <VulnerabilitiesCard
+        osVersion={createMockOSVersion({
+          name: "Android 16 (2026-05-01)",
+          name_only: "Android",
+          version: "16 (2026-05-01)",
+          platform: "android",
+        })}
+        isLoading={false}
+        router={mockRouter}
+        teamIdForApi={1}
+      />
+    );
+
+    expect(screen.getByText("Vulnerabilities")).toBeInTheDocument();
+    expect(screen.getByText("Detected")).toBeInTheDocument();
+    expect(screen.getByText("CVE-2020-0001")).toBeInTheDocument();
+  });
+
   it("renders 'not supported' empty state if platform doesn't support vulns", () => {
     render(
       <VulnerabilitiesCard


### PR DESCRIPTION
Relates to #47337

Mark android as a vulnerability-supported platform so the Software > OS experience surfaces Android CVEs instead of a "Not supported" state.


https://github.com/user-attachments/assets/336375f9-7281-44ed-8473-a4984466acc2


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually