### PR TITLE
Document version pinning in the Fleet-maintained apps guide

### DIFF
--- a/articles/fleet-maintained-apps.md
+++ b/articles/fleet-maintained-apps.md
@@ -87,6 +87,26 @@ To manage Fleet-maintained apps using Fleet's best practice GitOps, check out `f
 
 > Note: with GitOps enabled, any Fleet-maintained apps added using the web UI will not persist if not also added in YAML.
 
+### Pin an app to a specific version
+
+By default, Fleet updates each Fleet-maintained app to the latest version in the [software catalog](https://fleetdm.com/software-catalog) when GitOps runs. To control which version Fleet installs, set the `version` field for the app under `fleet_maintained_apps`. Wrap the value in quotes so Fleet reads it as a string.
+
+You can pin a version two ways:
+
+- **Exact version.** Set `version` to a full version number, like `"147.0.1"`, to install that specific release. Available versions are listed in the Fleet UI under **Actions > Edit software**.
+- **Major version.** Set `version` to a caret (`^`) constraint, like `"^147"`, to install the latest release within that major version. Fleet keeps installing patches and minor updates until the app reaches 148.0, which it won't install until you update the constraint.
+
+Pinning to a major version keeps hosts patched without jumping to a new major release you haven't tested or licensed:
+
+```yaml
+software:
+  fleet_maintained_apps:
+    - slug: firefox/darwin
+      version: "^147"
+```
+
+Version pinning is available in GitOps today. Pinning in the Fleet UI is [coming soon](https://github.com/fleetdm/fleet/issues/38504).
+
 ## How does Fleet maintain these apps?
 
 Fleet:


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Related to #31252 (pin Fleet-maintained apps to a major version)

## Description

Documents version pinning for Fleet-maintained apps in the [Fleet-maintained apps guide](https://fleetdm.com/guides/fleet-maintained-apps). The feature shipped in GitOps (Fleet 4.84.0 / 4.85.0) but the guide's "Manage apps with GitOps" section only linked to the YAML reference without explaining it.

Adds a "Pin an app to a specific version" subsection covering:

- The default behavior (Fleet installs the latest catalog version on each GitOps run).
- Exact-version pinning (`"147.0.1"`).
- Major-version pinning with a caret constraint (`"^147"`), with a YAML example.
- A note that pinning is GitOps-only today, with UI pinning coming soon (#38504).

Docs-only change. No code, tests, migrations, or configuration settings affected.

# Checklist for submitter

- [x] QA'd all new/changed functionality manually (rendered/reviewed content, verified the `firefox/darwin` slug and caret example against `ee/maintained-apps/outputs/apps.json` and the GitOps YAML reference).
