### PR TITLE
Fleet UI: Restore dashboard cards hidden despite the API returning their data

### DIFF
--- a/changes/49297-free-tier-linux-summary-cards
+++ b/changes/49297-free-tier-linux-summary-cards
@@ -1,0 +1,2 @@
+- Fixed the "Missing hosts" summary card not showing on the Fleet Free dashboard when a platform other than "All" was selected.
+- Added an "Operating systems" card to the dashboard when Linux or Android is selected.

--- a/frontend/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/pages/DashboardPage/DashboardPage.tsx
@@ -242,8 +242,12 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
       select: (data: IHostSummary) => data,
       onSuccess: (data: IHostSummary) => {
         setLabels(data.builtin_labels);
+        setMissingCount(data.missing_30_days_count || 0);
+        // low_disk_space_count and dep_assign_error_count are Premium-only.
+        // The backend nulls out low_disk_space_count for non-Premium callers,
+        // and the linked filters (`?low_disk_space=`, ABM issue filters) are
+        // also Premium-gated, so their cards stay hidden on Free.
         if (isPremiumTier) {
-          setMissingCount(data.missing_30_days_count || 0);
           setLowDiskSpaceCount(data.low_disk_space_count || 0);
           setAbmIssueCount(data.dep_assign_error_count || 0);
         }
@@ -806,7 +810,11 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
       {showMdmCard && <div className={`${baseClass}__section`}>{MDMCard}</div>}
     </>
   );
-  const linuxLayout = () => null;
+  const linuxLayout = () => (
+    <>
+      <div className={`${baseClass}__section`}>{OperatingSystemsCard}</div>
+    </>
+  );
 
   const chromeLayout = () => (
     <>
@@ -830,6 +838,7 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
 
   const androidLayout = () => (
     <>
+      <div className={`${baseClass}__section`}>{OperatingSystemsCard}</div>
       {showMdmCard && <div className={`${baseClass}__section`}>{MDMCard}</div>}
     </>
   );

--- a/frontend/pages/DashboardPage/cards/OperatingSystems/OSTable.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/OperatingSystems/OSTable.tests.tsx
@@ -54,4 +54,69 @@ describe("Dashboard OS table", () => {
     expect(screen.getByText("4.5.6")).toBeInTheDocument();
     expect(screen.getByText("567")).toBeInTheDocument();
   });
+
+  it("does not render a Name column for non-Linux platforms", () => {
+    render(
+      <OSTable
+        currentTeamId={undefined}
+        osVersions={[
+          {
+            os_version_id: 1,
+            hosts_count: 234,
+            name: "Microsoft Windows 11 Enterprise 22H2 10.0.22621",
+            name_only: "Microsoft Windows 11 Enterprise 22H2",
+            version: "1.2.3",
+            platform: "windows",
+            kernels: [],
+            vulnerabilities: [],
+          },
+        ]}
+        selectedPlatform="windows"
+        isLoading={false}
+      />
+    );
+
+    expect(screen.queryByText("Name")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Microsoft Windows 11 Enterprise 22H2")
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders a Name column showing the distro name on Linux", () => {
+    render(
+      <OSTable
+        currentTeamId={undefined}
+        osVersions={[
+          {
+            os_version_id: 10,
+            hosts_count: 12,
+            name: "Ubuntu 24.04.1 LTS",
+            name_only: "Ubuntu",
+            version: "24.04.1",
+            platform: "ubuntu",
+            kernels: [],
+            vulnerabilities: [],
+          },
+          {
+            os_version_id: 11,
+            hosts_count: 3,
+            name: "Debian GNU/Linux 13.4",
+            name_only: "Debian GNU/Linux",
+            version: "13.4",
+            platform: "debian",
+            kernels: [],
+            vulnerabilities: [],
+          },
+        ]}
+        selectedPlatform="linux"
+        isLoading={false}
+      />
+    );
+
+    expect(screen.getByText("Name")).toBeInTheDocument();
+    expect(screen.getByText("Ubuntu")).toBeInTheDocument();
+    expect(screen.getByText("Debian GNU/Linux")).toBeInTheDocument();
+    expect(screen.getByText("24.04.1")).toBeInTheDocument();
+    expect(screen.getByText("13.4")).toBeInTheDocument();
+  });
 });

--- a/frontend/pages/DashboardPage/cards/OperatingSystems/OSTable.tsx
+++ b/frontend/pages/DashboardPage/cards/OperatingSystems/OSTable.tsx
@@ -40,8 +40,14 @@ const OSTable = ({
   isLoading,
 }: IOSTableProps) => {
   const columnConfigs = useMemo(
-    () => generateTableHeaders(currentTeamId, undefined),
-    [currentTeamId]
+    // Linux is the only platform where the distro name ("Ubuntu", "Debian",
+    // ...) isn't obvious from the Version column alone, so it gets the extra
+    // Name column that other platforms don't need.
+    () =>
+      generateTableHeaders(currentTeamId, undefined, {
+        includeName: selectedPlatform === "linux",
+      }),
+    [currentTeamId, selectedPlatform]
   );
 
   const showPaginationControls = osVersions.length > PAGE_SIZE;

--- a/frontend/pages/DashboardPage/sections/MetricsHostCounts/MetricsHostCounts.tests.tsx
+++ b/frontend/pages/DashboardPage/sections/MetricsHostCounts/MetricsHostCounts.tests.tsx
@@ -1,0 +1,219 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import { PlatformValueOptions } from "utilities/constants";
+
+import MetricsHostCounts from "./MetricsHostCounts";
+
+// Render react-router's <Link> as a plain anchor so the summary cards
+// (which wrap themselves in a linkable <Card>) can render without a
+// surrounding <Router>.
+jest.mock("react-router", () => ({
+  Link: ({ to, children }: { to: string; children: React.ReactNode }) => (
+    <a href={to}>{children}</a>
+  ),
+}));
+
+const TOTAL_HOSTS_TITLE = "Total hosts";
+const MISSING_HOSTS_TITLE = "Missing hosts";
+const LOW_DISK_SPACE_TITLE = "Low disk space hosts";
+const ABM_ISSUE_TITLE = "AB issue";
+
+interface IRenderCase {
+  platform: PlatformValueOptions;
+  totalHosts: boolean;
+  missingHosts: boolean;
+  lowDiskSpaceHosts: boolean;
+}
+
+const renderMetrics = ({
+  platform,
+  isPremiumTier,
+  abmIssueCount = 0,
+}: {
+  platform: PlatformValueOptions;
+  isPremiumTier: boolean;
+  abmIssueCount?: number;
+}) =>
+  render(
+    <MetricsHostCounts
+      currentTeamId={undefined}
+      selectedPlatform={platform}
+      totalHostCount={42}
+      isPremiumTier={isPremiumTier}
+      missingCount={3}
+      lowDiskSpaceCount={5}
+      abmIssueCount={abmIssueCount}
+      selectedPlatformLabelId={undefined}
+    />
+  );
+
+const expectCards = ({
+  totalHosts,
+  missingHosts,
+  lowDiskSpaceHosts,
+}: Omit<IRenderCase, "platform">) => {
+  expect(!!screen.queryByText(TOTAL_HOSTS_TITLE)).toBe(totalHosts);
+  expect(!!screen.queryByText(MISSING_HOSTS_TITLE)).toBe(missingHosts);
+  expect(!!screen.queryByText(LOW_DISK_SPACE_TITLE)).toBe(lowDiskSpaceHosts);
+};
+
+// Missing hosts renders on both tiers; Low disk space is Premium-only.
+// Both are hidden on iOS, iPadOS, and Android (no missing/low-disk-space
+// data model for those platforms). Total hosts renders only on "all".
+describe("MetricsHostCounts", () => {
+  describe("Premium tier", () => {
+    const premiumCases: IRenderCase[] = [
+      {
+        platform: "all",
+        totalHosts: true,
+        missingHosts: true,
+        lowDiskSpaceHosts: true,
+      },
+      {
+        platform: "darwin",
+        totalHosts: false,
+        missingHosts: true,
+        lowDiskSpaceHosts: true,
+      },
+      {
+        platform: "windows",
+        totalHosts: false,
+        missingHosts: true,
+        lowDiskSpaceHosts: true,
+      },
+      {
+        platform: "linux",
+        totalHosts: false,
+        missingHosts: true,
+        lowDiskSpaceHosts: true,
+      },
+      {
+        platform: "chrome",
+        totalHosts: false,
+        missingHosts: true,
+        lowDiskSpaceHosts: true,
+      },
+      {
+        platform: "ios",
+        totalHosts: false,
+        missingHosts: false,
+        lowDiskSpaceHosts: false,
+      },
+      {
+        platform: "ipados",
+        totalHosts: false,
+        missingHosts: false,
+        lowDiskSpaceHosts: false,
+      },
+      {
+        platform: "android",
+        totalHosts: false,
+        missingHosts: false,
+        lowDiskSpaceHosts: false,
+      },
+    ];
+
+    it.each(premiumCases)(
+      "$platform: shows Total=$totalHosts, Missing=$missingHosts, LowDisk=$lowDiskSpaceHosts",
+      ({ platform, ...expected }) => {
+        renderMetrics({ platform, isPremiumTier: true });
+        expectCards(expected);
+      }
+    );
+  });
+
+  describe("Free tier", () => {
+    // Free never shows Low disk space (Premium-only). Missing hosts renders
+    // on the same platforms as Premium.
+    const freeCases: IRenderCase[] = [
+      {
+        platform: "all",
+        totalHosts: true,
+        missingHosts: true,
+        lowDiskSpaceHosts: false,
+      },
+      {
+        platform: "darwin",
+        totalHosts: false,
+        missingHosts: true,
+        lowDiskSpaceHosts: false,
+      },
+      {
+        platform: "windows",
+        totalHosts: false,
+        missingHosts: true,
+        lowDiskSpaceHosts: false,
+      },
+      {
+        platform: "linux",
+        totalHosts: false,
+        missingHosts: true,
+        lowDiskSpaceHosts: false,
+      },
+      {
+        platform: "chrome",
+        totalHosts: false,
+        missingHosts: true,
+        lowDiskSpaceHosts: false,
+      },
+      {
+        platform: "ios",
+        totalHosts: false,
+        missingHosts: false,
+        lowDiskSpaceHosts: false,
+      },
+      {
+        platform: "ipados",
+        totalHosts: false,
+        missingHosts: false,
+        lowDiskSpaceHosts: false,
+      },
+      {
+        platform: "android",
+        totalHosts: false,
+        missingHosts: false,
+        lowDiskSpaceHosts: false,
+      },
+    ];
+
+    it.each(freeCases)(
+      "$platform: shows Total=$totalHosts, Missing=$missingHosts, LowDisk=$lowDiskSpaceHosts",
+      ({ platform, ...expected }) => {
+        renderMetrics({ platform, isPremiumTier: false });
+        expectCards(expected);
+      }
+    );
+  });
+
+  describe("ABM issue card", () => {
+    it("renders on Premium when abmIssueCount > 0", () => {
+      renderMetrics({
+        platform: "darwin",
+        isPremiumTier: true,
+        abmIssueCount: 2,
+      });
+      expect(screen.getByText(ABM_ISSUE_TITLE)).toBeInTheDocument();
+    });
+
+    it("does not render when abmIssueCount is 0", () => {
+      renderMetrics({
+        platform: "darwin",
+        isPremiumTier: true,
+        abmIssueCount: 0,
+      });
+      expect(screen.queryByText(ABM_ISSUE_TITLE)).not.toBeInTheDocument();
+    });
+
+    // DashboardPage never sets abmIssueCount on Free, but the component
+    // itself doesn't tier-gate this card — protecting that invariant here.
+    it("guards purely on count, not tier (Free with count > 0 would render, but the parent never populates it)", () => {
+      renderMetrics({
+        platform: "darwin",
+        isPremiumTier: false,
+        abmIssueCount: 2,
+      });
+      expect(screen.getByText(ABM_ISSUE_TITLE)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/pages/DashboardPage/sections/MetricsHostCounts/MetricsHostCounts.tsx
+++ b/frontend/pages/DashboardPage/sections/MetricsHostCounts/MetricsHostCounts.tsx
@@ -67,18 +67,19 @@ const MetricsHostCounts = ({
     />
   ) : null;
 
+  const showMissingAndLowDiskHosts =
+    selectedPlatform !== "ios" &&
+    selectedPlatform !== "ipados" &&
+    selectedPlatform !== "android";
+
   return (
     <div className={baseClass}>
       {selectedPlatform === "all" && TotalHostsCard}
-      {isPremiumTier &&
-        selectedPlatform !== "ios" &&
-        selectedPlatform !== "ipados" &&
-        selectedPlatform !== "android" && (
-          <>
-            {MissingHostsCard}
-            {LowDiskSpaceHostsCard}
-          </>
-        )}
+      {showMissingAndLowDiskHosts && MissingHostsCard}
+      {/* Low disk space is Premium-only: `low_disk_space_count` is null for
+          non-Premium callers and the linked filter is Premium-gated. */}
+      {isPremiumTier && showMissingAndLowDiskHosts && LowDiskSpaceHostsCard}
+      {/* ABM issue count is only populated on Premium (see DashboardPage). */}
       {ABMIssueHostsCard}
     </div>
   );

--- a/frontend/services/entities/operating_systems.ts
+++ b/frontend/services/entities/operating_systems.ts
@@ -9,6 +9,7 @@ import { buildQueryStringFromParams } from "utilities/url";
 export const OS_VERSIONS_API_SUPPORTED_PLATFORMS = [
   "darwin",
   "windows",
+  "linux",
   "chrome",
   "ios",
   "ipados",


### PR DESCRIPTION
## Issue
Resolves #49297

## Description
Three independent gaps on the dashboard where cards weren't rendering even though the API returned their data:

- **Free tier Missing hosts card** (see screenshot 1). `MetricsHostCounts` gated both `MissingHostsCard` and `LowDiskSpaceHostsCard` on `isPremiumTier`, but only Low disk space is genuinely Premium-only. `missing_30_days_count` is computed by `GenerateHostStatusStatistics` for both tiers and the linked `/hosts?status=missing` filter isn't Premium-gated. Split the gate: Missing hosts now renders on both tiers (still hidden on iOS/iPadOS/Android); Low disk space stays Premium-only. `DashboardPage` also now calls `setMissingCount` outside the Premium block.
- **Linux Operating systems card** (see screenshots 1 and 4). `linuxLayout()` returned `null`, and `OS_VERSIONS_API_SUPPORTED_PLATFORMS` (added in Aug 2022 for a Windows/macOS-only enhancement) never included `"linux"`. Backend `/api/v1/fleet/os_versions?platform=linux` has always worked — `/software/os?platform=linux` uses it via the app-wide `QueryablePlatform` type. Added `"linux"` to the constant and swapped `linuxLayout()` to render `OperatingSystemsCard`. The Linux OS card also renders a Name column in addition to Version — a bare version string ("24.04.1") is meaningless without knowing the distro next to it, whereas macOS/Windows versions are already unambiguous under the platform selection.
- **Android Operating systems card** (see screenshots 2 and 3). `"android"` was already in `OS_VERSIONS_API_SUPPORTED_PLATFORMS` and Android hosts have OS versions populated as `"Android <version>"` by the MDM pubsub handler. `androidLayout()` (added with the Android MDM feature) just never wired up `OperatingSystemsCard`. Added it above `MDMCard`, matching iOS/iPadOS.

Also added small in-code comments in `MetricsHostCounts.tsx` and `DashboardPage.tsx` calling out that Low disk space and ABM issue count are Premium-only.

### After: which cards render where

| Section | Card | When it renders |
|---|---|---|
| Charts row | Hosts enrolled + Hosts online chart | All tiers, all platforms |
| Metrics row | Total hosts | All tiers, platform = "all" |
|  | Missing hosts | Both tiers, all except iOS/iPadOS/Android (skipped due to #46243) |
|  | Low disk space hosts | Premium only, all except iOS/iPadOS/Android (Premium-only in backend); "Not supported" chip on Chrome |
|  | ABM issue hosts | Premium only, when count > 0 |
| Content | Software + Activity + MDM | Platform = "all" (global) |
|  | Operating systems | darwin, windows, linux ✓, chrome, ios, ipados, android ✓ (all supported) |
|  | MDM | All except linux + chrome (Fleet doesn't manage those via MDM) |
|  | Munki | darwin only (macOS-specific tool) |

## Screenshots

#### 1. Free tier + Linux: Missing hosts card and Operating systems card
<img width="1152" height="845" alt="Screenshot 2026-07-15 at 10 23 00 AM" src="https://github.com/user-attachments/assets/32a804e1-5644-4bda-8cd8-13eed4726af9" />

#### 2. Free tier + Android: Operating systems card
<img width="1146" height="873" alt="Screenshot 2026-07-15 at 10 22 42 AM" src="https://github.com/user-attachments/assets/978a6483-02c4-4bc7-981e-e09b3b7b3ad0" />

#### 3. Premium tier + Android Operating systems card
<img width="1154" height="958" alt="Screenshot 2026-07-15 at 10 20 50 AM" src="https://github.com/user-attachments/assets/839d5fb1-d2ba-41de-b3ec-af5cfcfa59eb" />

#### 4. Premium tier + Linux: Missing hosts, Low disk space hosts, and Operating systems card

https://github.com/user-attachments/assets/f9b363af-c7ba-4d2e-9cb4-a721612224f5


## Testing

New `MetricsHostCounts.tests.tsx` covers the truth table for the four summary cards:

- 8 platforms × Premium tier: Total (only on "all"), Missing (all except iOS/iPadOS/Android), Low disk space (all except iOS/iPadOS/Android)
- 8 platforms × Free tier: Total (only on "all"), Missing (all except iOS/iPadOS/Android), Low disk space (never)
- ABM issue card: renders when count > 0, hidden at 0, guards purely on count (not tier) — parent sets it to 0 on Free

19 tests, all pass. `yarn lint` reports 0 errors (pre-existing warnings only).

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an “Operating systems” summary card for Linux and Android dashboard views.
  - Linux views now display distribution names and version details.
  - Added Linux support for operating-system version data.

- **Bug Fixes**
  - Fixed the “Missing hosts” card not appearing for non-“All” platform selections.
  - Preserved Premium-only visibility for the “Low disk space hosts” card.

- **Tests**
  - Added coverage for platform- and tier-specific card visibility and operating-system table content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->