### PR TITLE
Fix installer edit rejecting same-software new versions

### DIFF
--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -524,29 +524,49 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 		if existingInstaller.FleetMaintainedAppID != nil {
 			return nil, &fleet.BadRequestError{
 				Message:     "Couldn't update. The package can't be changed for Fleet-maintained apps.",
-				InternalErr: ctxerr.Wrap(ctx, err, "installer file changed for fleet maintained app installer"),
+				InternalErr: ctxerr.New(ctx, "installer file changed for fleet maintained app installer"),
 			}
 		}
 
 		if newInstallerExtension != existingInstaller.Extension {
 			return nil, &fleet.BadRequestError{
 				Message:     "The selected package is for a different file type.",
-				InternalErr: ctxerr.Wrap(ctx, err, "installer extension mismatch"),
+				InternalErr: ctxerr.New(ctx, "installer extension mismatch"),
 			}
 		}
 
-		// Reject only when the replacement neither resolves to this title by identity nor keeps the
-		// same name. The name fallback avoids rejecting a same-named new version when identity can't
-		// confirm it (e.g. a Windows MSI whose upgrade_code changed between versions).
-		resolvedTitleID, err := svc.ds.MatchSoftwareTitleIDForInstaller(ctx, payloadForNewInstallerFile)
-		if err != nil && !fleet.IsNotFound(err) {
-			return nil, ctxerr.Wrap(ctx, err, "resolving title for updated installer")
-		}
-		identityMatches := err == nil && resolvedTitleID == payload.TitleID
-		if !identityMatches && payloadForNewInstallerFile.Title != software.Name {
-			return nil, &fleet.BadRequestError{
-				Message:     "The selected package is for different software.",
-				InternalErr: ctxerr.Wrap(ctx, err, "installer software title mismatch"),
+		// The replacement must be the same software as the installer being edited. Its extracted
+		// identity (bundle id for apps, upgrade code for Windows, else name) must point at this title.
+		// A bare name match is accepted only when no title claims the identity — so a re-keyed MSI or
+		// re-bundled pkg still edits — while another app's package, which resolves to a different title,
+		// is rejected even when the names coincide. A package that changes both its name and its
+		// upgrade code at once can't be tied to the edited installer, so it is rejected (as before).
+		switch {
+		case payloadForNewInstallerFile.UpgradeCode != "" && payloadForNewInstallerFile.UpgradeCode == existingInstaller.UpgradeCode:
+			// Same Windows product as the edited installer (a sibling MSI whose upgrade code can differ
+			// from the title's); trusted fast path, skip the title lookup entirely.
+		default:
+			resolvedTitleID, err := svc.ds.GetExistingSoftwareInstallerTitleID(ctx, payloadForNewInstallerFile)
+			if err != nil && !fleet.IsNotFound(err) {
+				return nil, ctxerr.Wrap(ctx, err, "resolving title for updated installer")
+			}
+			switch {
+			case err == nil && resolvedTitleID == payload.TitleID:
+				// Identity resolves to this title.
+			case err == nil && (payloadForNewInstallerFile.BundleIdentifier != "" || payloadForNewInstallerFile.UpgradeCode != ""):
+				// A strong identifier (bundle id / upgrade code) resolves to a different existing title:
+				// different software, even if the names coincide. Name-only matches are excluded here
+				// because the resolver's name branch can match multiple same-named titles ambiguously.
+				return nil, &fleet.BadRequestError{
+					Message:     "The selected package is for different software.",
+					InternalErr: ctxerr.Errorf(ctx, "installer resolves to title %d, editing title %d", resolvedTitleID, payload.TitleID),
+				}
+			case payloadForNewInstallerFile.Title != software.Name:
+				// No authoritative identity claims this package and the name does not match either.
+				return nil, &fleet.BadRequestError{
+					Message:     "The selected package is for different software.",
+					InternalErr: ctxerr.New(ctx, "installer identity not found and name mismatch"),
+				}
 			}
 		}
 

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -519,6 +519,15 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 			return nil, ctxerr.Wrap(ctx, err, "extracting updated installer metadata")
 		}
 
+		// Fleet-maintained apps can't have their package replaced; return the FMA message before the
+		// extension and identity checks so it isn't masked by a more generic error.
+		if existingInstaller.FleetMaintainedAppID != nil {
+			return nil, &fleet.BadRequestError{
+				Message:     "Couldn't update. The package can't be changed for Fleet-maintained apps.",
+				InternalErr: ctxerr.Wrap(ctx, err, "installer file changed for fleet maintained app installer"),
+			}
+		}
+
 		if newInstallerExtension != existingInstaller.Extension {
 			return nil, &fleet.BadRequestError{
 				Message:     "The selected package is for a different file type.",
@@ -526,7 +535,15 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 			}
 		}
 
-		if payloadForNewInstallerFile.Title != software.Name {
+		// Reject only when the replacement neither resolves to this title by identity nor keeps the
+		// same name. The name fallback avoids rejecting a same-named new version when identity can't
+		// confirm it (e.g. a Windows MSI whose upgrade_code changed between versions).
+		resolvedTitleID, err := svc.ds.MatchSoftwareTitleIDForInstaller(ctx, payloadForNewInstallerFile)
+		if err != nil && !fleet.IsNotFound(err) {
+			return nil, ctxerr.Wrap(ctx, err, "resolving title for updated installer")
+		}
+		identityMatches := err == nil && resolvedTitleID == payload.TitleID
+		if !identityMatches && payloadForNewInstallerFile.Title != software.Name {
 			return nil, &fleet.BadRequestError{
 				Message:     "The selected package is for different software.",
 				InternalErr: ctxerr.Wrap(ctx, err, "installer software title mismatch"),
@@ -563,13 +580,6 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 		} else { // noop if uploaded installer is identical to previous installer
 			payloadForNewInstallerFile = nil
 			payload.InstallerFile = nil
-		}
-
-		if existingInstaller.FleetMaintainedAppID != nil {
-			return nil, &fleet.BadRequestError{
-				Message:     "Couldn't update. The package can't be changed for Fleet-maintained apps.",
-				InternalErr: ctxerr.Wrap(ctx, err, "installer file changed for fleet maintained app installer"),
-			}
 		}
 	}
 

--- a/ee/server/service/software_installers_test.go
+++ b/ee/server/service/software_installers_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
@@ -23,6 +24,7 @@ import (
 	"github.com/fleetdm/fleet/v4/pkg/file"
 	"github.com/fleetdm/fleet/v4/server/authz"
 	"github.com/fleetdm/fleet/v4/server/config"
+	authz_ctx "github.com/fleetdm/fleet/v4/server/contexts/authz"
 	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
 	"github.com/fleetdm/fleet/v4/server/datastore/s3"
 	"github.com/fleetdm/fleet/v4/server/dev_mode"
@@ -30,6 +32,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/mock"
 	redismock "github.com/fleetdm/fleet/v4/server/mock/redis"
 	svcmock "github.com/fleetdm/fleet/v4/server/mock/service"
+	mocksoftware "github.com/fleetdm/fleet/v4/server/mock/software"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -751,6 +754,335 @@ func newTestServiceWithMock(t *testing.T, ds fleet.Datastore) (*Service, *svcmoc
 		ds:      ds,
 	}
 	return svc, baseSvc
+}
+
+func TestUpdateSoftwareInstallerMatchesSoftwareIdentity(t *testing.T) {
+	const (
+		titleID           = uint(42)
+		targetInstallerID = uint(2)
+	)
+
+	type testState struct {
+		svc       *Service
+		ds        *mock.Store
+		ctx       context.Context
+		installer *fleet.SoftwareInstaller
+		teamID    uint
+	}
+
+	setup := func(t *testing.T, storedTitleName, filename, extension, platform, storageID string, packageIDs []string, multiplePackages bool) testState {
+		t.Helper()
+		ds := new(mock.Store)
+		svc, baseSvc := newTestServiceWithMock(t, ds)
+		teamID := uint(0)
+		installer := &fleet.SoftwareInstaller{
+			TeamID:          &teamID,
+			TitleID:         new(titleID),
+			Name:            filename,
+			Extension:       extension,
+			Version:         "0.9.0",
+			Platform:        platform,
+			PackageIDList:   strings.Join(packageIDs, ","),
+			InstallerID:     targetInstallerID,
+			InstallScript:   "install",
+			UninstallScript: "uninstall",
+			StorageID:       storageID,
+			SoftwareTitle:   storedTitleName,
+		}
+
+		installerCount := 1
+		firstInstaller := installer
+		if multiplePackages {
+			installerCount = 2
+			firstInstaller = &fleet.SoftwareInstaller{
+				TeamID:        &teamID,
+				TitleID:       new(titleID),
+				Name:          filename,
+				Extension:     extension,
+				Platform:      platform,
+				InstallerID:   1,
+				StorageID:     "first-installer-storage-id",
+				SoftwareTitle: storedTitleName,
+			}
+			ds.GetSoftwarePackagesByTeamAndTitleIDFunc = func(ctx context.Context, gotTeamID *uint, gotTitleID uint) ([]*fleet.SoftwareInstaller, error) {
+				require.Equal(t, &teamID, gotTeamID)
+				require.Equal(t, titleID, gotTitleID)
+				return []*fleet.SoftwareInstaller{firstInstaller, installer}, nil
+			}
+		}
+
+		ds.ValidateEmbeddedSecretsFunc = func(context.Context, []string) error { return nil }
+		ds.SoftwareTitleByIDFunc = func(ctx context.Context, gotTitleID uint, gotTeamID *uint, _ fleet.TeamFilter) (*fleet.SoftwareTitle, error) {
+			require.Equal(t, titleID, gotTitleID)
+			require.Equal(t, &teamID, gotTeamID)
+			return &fleet.SoftwareTitle{
+				ID:                      titleID,
+				Name:                    storedTitleName,
+				SoftwareInstallersCount: installerCount,
+			}, nil
+		}
+		ds.GetSoftwareInstallerMetadataByTeamAndTitleIDFunc = func(ctx context.Context, gotTeamID *uint, gotTitleID uint, withScripts bool) (*fleet.SoftwareInstaller, error) {
+			require.Equal(t, &teamID, gotTeamID)
+			require.Equal(t, titleID, gotTitleID)
+			require.True(t, withScripts)
+			return firstInstaller, nil
+		}
+		ds.GetSoftwareInstallerMetadataByTeamTitleAndInstallerIDFunc = func(ctx context.Context, gotTeamID *uint, gotTitleID, gotInstallerID uint, withScripts bool) (*fleet.SoftwareInstaller, error) {
+			require.Equal(t, &teamID, gotTeamID)
+			require.Equal(t, titleID, gotTitleID)
+			require.Equal(t, targetInstallerID, gotInstallerID)
+			require.True(t, withScripts)
+			return installer, nil
+		}
+		ds.SaveInstallerUpdatesFunc = func(ctx context.Context, payload *fleet.UpdateSoftwareInstallerPayload) error {
+			require.Equal(t, targetInstallerID, payload.InstallerID)
+			installer.Name = payload.Filename
+			installer.Version = payload.Version
+			installer.PackageIDList = strings.Join(payload.PackageIDs, ",")
+			installer.UpgradeCode = payload.UpgradeCode
+			installer.StorageID = payload.StorageID
+			return nil
+		}
+		ds.ProcessInstallerUpdateSideEffectsFunc = func(ctx context.Context, installerID uint, metadataUpdated, packageUpdated bool) error {
+			require.Equal(t, targetInstallerID, installerID)
+			require.True(t, metadataUpdated)
+			require.True(t, packageUpdated)
+			return nil
+		}
+		ds.GetSummaryHostSoftwareInstallsFunc = func(ctx context.Context, installerID uint) (*fleet.SoftwareInstallerStatusSummary, error) {
+			require.Equal(t, targetInstallerID, installerID)
+			return nil, nil
+		}
+		baseSvc.NewActivityFunc = func(context.Context, *fleet.User, fleet.ActivityDetails) error { return nil }
+
+		store := &mocksoftware.SoftwareInstallerStore{
+			ExistsFunc: func(context.Context, string) (bool, error) { return false, nil },
+			PutFunc:    func(context.Context, string, io.ReadSeeker) error { return nil },
+		}
+		svc.softwareInstallStore = store
+
+		ctx := authz_ctx.NewContext(t.Context(), &authz_ctx.AuthorizationContext{})
+		ctx = viewer.NewContext(ctx, viewer.Viewer{
+			User: &fleet.User{ID: 1, GlobalRole: new(fleet.RoleAdmin)},
+		})
+		return testState{svc: svc, ds: ds, ctx: ctx, installer: installer, teamID: teamID}
+	}
+
+	readInstaller := func(t *testing.T, path string) ([]byte, string) {
+		t.Helper()
+		contents, err := os.ReadFile(path)
+		require.NoError(t, err)
+		sum := sha256.Sum256(contents)
+		return contents, hex.EncodeToString(sum[:])
+	}
+
+	newReplacement := func(t *testing.T, contents []byte) *fleet.TempFileReader {
+		t.Helper()
+		// XAR and MSI readers ignore trailing data, giving this test a distinct package hash
+		// while preserving the installer's extracted software identity.
+		replacement := append(bytes.Clone(contents), '\n')
+		tfr, err := fleet.NewTempFileReader(bytes.NewReader(replacement), t.TempDir)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, tfr.Close()) })
+		return tfr
+	}
+
+	t.Run("bundle identifier allows a different title name on a targeted package", func(t *testing.T) {
+		contents, storageID := readInstaller(t, "testdata/dummy_installer.pkg")
+		state := setup(t, "Dummy App", "dummy_installer.pkg", "pkg", "darwin", storageID, []string{"com.example.dummy"}, true)
+		state.ds.MatchSoftwareTitleIDForInstallerFunc = func(ctx context.Context, payload *fleet.UploadSoftwareInstallerPayload) (uint, error) {
+			require.Equal(t, "DummyApp", payload.Title)
+			require.Equal(t, "apps", payload.Source)
+			require.Equal(t, "com.example.dummy", payload.BundleIdentifier)
+			return titleID, nil
+		}
+
+		updated, err := state.svc.UpdateSoftwareInstaller(state.ctx, &fleet.UpdateSoftwareInstallerPayload{
+			TitleID:       titleID,
+			TeamID:        &state.teamID,
+			InstallerID:   targetInstallerID,
+			Filename:      "dummy_installer.pkg",
+			InstallerFile: newReplacement(t, contents),
+		})
+		require.NoError(t, err)
+		require.Equal(t, targetInstallerID, updated.InstallerID)
+		require.NotEqual(t, storageID, updated.StorageID)
+		require.Equal(t, "1.0.0", updated.Version)
+		require.True(t, state.ds.SaveInstallerUpdatesFuncInvoked)
+	})
+
+	t.Run("upgrade code allows a different title name", func(t *testing.T) {
+		contents, storageID := readInstaller(t, "../../../server/service/testdata/software-installers/fleet-osquery.msi")
+		state := setup(t, "Fleet agent", "fleet-osquery.msi", "msi", "windows", storageID, []string{"{70A53353-01E5-424B-8819-ED882B3805D9}"}, false)
+		state.ds.MatchSoftwareTitleIDForInstallerFunc = func(ctx context.Context, payload *fleet.UploadSoftwareInstallerPayload) (uint, error) {
+			require.Equal(t, "Fleet osquery", payload.Title)
+			require.Equal(t, "programs", payload.Source)
+			require.NotEmpty(t, payload.UpgradeCode)
+			return titleID, nil
+		}
+
+		updated, err := state.svc.UpdateSoftwareInstaller(state.ctx, &fleet.UpdateSoftwareInstallerPayload{
+			TitleID:       titleID,
+			TeamID:        &state.teamID,
+			Filename:      "fleet-osquery.msi",
+			InstallerFile: newReplacement(t, contents),
+		})
+		require.NoError(t, err)
+		require.NotEqual(t, storageID, updated.StorageID)
+		require.Equal(t, "1.0.0", updated.Version)
+	})
+
+	for _, tt := range []struct {
+		name            string
+		resolvedTitleID uint
+		resolveErr      error
+	}{
+		{name: "not found", resolveErr: &notFoundError{}},
+		{name: "different title", resolvedTitleID: titleID + 1},
+	} {
+		t.Run("different software is rejected when "+tt.name, func(t *testing.T) {
+			contents, storageID := readInstaller(t, "testdata/dummy_installer.pkg")
+			state := setup(t, "Dummy App", "dummy_installer.pkg", "pkg", "darwin", storageID, []string{"com.example.dummy"}, false)
+			state.ds.MatchSoftwareTitleIDForInstallerFunc = func(context.Context, *fleet.UploadSoftwareInstallerPayload) (uint, error) {
+				return tt.resolvedTitleID, tt.resolveErr
+			}
+
+			_, err := state.svc.UpdateSoftwareInstaller(state.ctx, &fleet.UpdateSoftwareInstallerPayload{
+				TitleID:       titleID,
+				TeamID:        &state.teamID,
+				Filename:      "dummy_installer.pkg",
+				InstallerFile: newReplacement(t, contents),
+			})
+			require.ErrorContains(t, err, "The selected package is for different software.")
+			require.False(t, state.ds.SaveInstallerUpdatesFuncInvoked)
+			require.Equal(t, storageID, state.installer.StorageID)
+		})
+	}
+
+	t.Run("different upgrade code is rejected", func(t *testing.T) {
+		contents, storageID := readInstaller(t, "../../../server/service/testdata/software-installers/fleet-osquery.msi")
+		state := setup(t, "Fleet agent", "fleet-osquery.msi", "msi", "windows", storageID, []string{"{70A53353-01E5-424B-8819-ED882B3805D9}"}, false)
+		state.ds.MatchSoftwareTitleIDForInstallerFunc = func(ctx context.Context, payload *fleet.UploadSoftwareInstallerPayload) (uint, error) {
+			require.NotEmpty(t, payload.UpgradeCode)
+			return 0, &notFoundError{}
+		}
+
+		_, err := state.svc.UpdateSoftwareInstaller(state.ctx, &fleet.UpdateSoftwareInstallerPayload{
+			TitleID:       titleID,
+			TeamID:        &state.teamID,
+			Filename:      "fleet-osquery.msi",
+			InstallerFile: newReplacement(t, contents),
+		})
+		require.ErrorContains(t, err, "The selected package is for different software.")
+		require.False(t, state.ds.SaveInstallerUpdatesFuncInvoked)
+		require.Equal(t, storageID, state.installer.StorageID)
+	})
+
+	t.Run("extension mismatch takes precedence", func(t *testing.T) {
+		_, storageID := readInstaller(t, "testdata/dummy_installer.pkg")
+		msiContents, _ := readInstaller(t, "../../../server/service/testdata/software-installers/fleet-osquery.msi")
+		state := setup(t, "Dummy App", "dummy_installer.pkg", "pkg", "darwin", storageID, []string{"com.example.dummy"}, false)
+		state.ds.MatchSoftwareTitleIDForInstallerFunc = func(context.Context, *fleet.UploadSoftwareInstallerPayload) (uint, error) {
+			t.Fatal("identity resolver must not run before the extension check")
+			return 0, nil
+		}
+
+		_, err := state.svc.UpdateSoftwareInstaller(state.ctx, &fleet.UpdateSoftwareInstallerPayload{
+			TitleID:       titleID,
+			TeamID:        &state.teamID,
+			Filename:      "fleet-osquery.msi",
+			InstallerFile: newReplacement(t, msiContents),
+		})
+		require.ErrorContains(t, err, "The selected package is for a different file type.")
+		require.False(t, state.ds.MatchSoftwareTitleIDForInstallerFuncInvoked)
+	})
+
+	t.Run("non-file edit does not resolve identity", func(t *testing.T) {
+		_, storageID := readInstaller(t, "testdata/dummy_installer.pkg")
+		state := setup(t, "Dummy App", "dummy_installer.pkg", "pkg", "darwin", storageID, []string{"com.example.dummy"}, false)
+		state.ds.MatchSoftwareTitleIDForInstallerFunc = func(context.Context, *fleet.UploadSoftwareInstallerPayload) (uint, error) {
+			t.Fatal("identity resolver must not run without a replacement file")
+			return 0, nil
+		}
+		state.ds.UpdateInstallerSelfServiceFlagFunc = func(ctx context.Context, selfService bool, installerID uint) error {
+			require.True(t, selfService)
+			require.Equal(t, targetInstallerID, installerID)
+			state.installer.SelfService = selfService
+			return nil
+		}
+
+		updated, err := state.svc.UpdateSoftwareInstaller(state.ctx, &fleet.UpdateSoftwareInstallerPayload{
+			TitleID:     titleID,
+			TeamID:      &state.teamID,
+			SelfService: new(true),
+		})
+		require.NoError(t, err)
+		require.Equal(t, targetInstallerID, updated.InstallerID)
+		require.True(t, updated.SelfService)
+		require.False(t, state.ds.MatchSoftwareTitleIDForInstallerFuncInvoked)
+	})
+
+	t.Run("same-named package with an unresolved identity is accepted via the name fallback", func(t *testing.T) {
+		// A same-named Windows MSI whose upgrade_code changed resolves to not-found by identity; the
+		// name fallback must still accept it.
+		contents, storageID := readInstaller(t, "../../../server/service/testdata/software-installers/fleet-osquery.msi")
+		state := setup(t, "Fleet osquery", "fleet-osquery.msi", "msi", "windows", storageID, []string{"{70A53353-01E5-424B-8819-ED882B3805D9}"}, false)
+		state.ds.MatchSoftwareTitleIDForInstallerFunc = func(ctx context.Context, payload *fleet.UploadSoftwareInstallerPayload) (uint, error) {
+			require.Equal(t, "Fleet osquery", payload.Title)
+			return 0, &notFoundError{}
+		}
+
+		updated, err := state.svc.UpdateSoftwareInstaller(state.ctx, &fleet.UpdateSoftwareInstallerPayload{
+			TitleID:       titleID,
+			TeamID:        &state.teamID,
+			Filename:      "fleet-osquery.msi",
+			InstallerFile: newReplacement(t, contents),
+		})
+		require.NoError(t, err)
+		require.NotEqual(t, storageID, updated.StorageID)
+		require.True(t, state.ds.SaveInstallerUpdatesFuncInvoked)
+	})
+
+	t.Run("different software is rejected on a targeted multi-package installer", func(t *testing.T) {
+		contents, storageID := readInstaller(t, "testdata/dummy_installer.pkg")
+		state := setup(t, "Different Osquery Name", "dummy_installer.pkg", "pkg", "darwin", storageID, []string{"com.example.dummy"}, true)
+		state.ds.MatchSoftwareTitleIDForInstallerFunc = func(context.Context, *fleet.UploadSoftwareInstallerPayload) (uint, error) {
+			return titleID + 1, nil // resolves to a different title
+		}
+
+		_, err := state.svc.UpdateSoftwareInstaller(state.ctx, &fleet.UpdateSoftwareInstallerPayload{
+			TitleID:       titleID,
+			TeamID:        &state.teamID,
+			InstallerID:   targetInstallerID,
+			Filename:      "dummy_installer.pkg",
+			InstallerFile: newReplacement(t, contents),
+		})
+		require.ErrorContains(t, err, "The selected package is for different software.")
+		require.True(t, state.ds.GetSoftwarePackagesByTeamAndTitleIDFuncInvoked)
+		require.False(t, state.ds.SaveInstallerUpdatesFuncInvoked)
+		require.Equal(t, storageID, state.installer.StorageID)
+	})
+
+	t.Run("fleet-maintained app rejects a file change with the FMA message before identity resolution", func(t *testing.T) {
+		contents, storageID := readInstaller(t, "../../../server/service/testdata/software-installers/EchoApp.pkg")
+		state := setup(t, "Dummy App", "dummy_installer.pkg", "pkg", "darwin", storageID, []string{"com.example.dummy"}, false)
+		fmaID := uint(7)
+		state.installer.FleetMaintainedAppID = &fmaID
+		state.ds.MatchSoftwareTitleIDForInstallerFunc = func(context.Context, *fleet.UploadSoftwareInstallerPayload) (uint, error) {
+			t.Fatal("identity resolver must not run for a fleet-maintained app")
+			return 0, nil
+		}
+
+		_, err := state.svc.UpdateSoftwareInstaller(state.ctx, &fleet.UpdateSoftwareInstallerPayload{
+			TitleID:       titleID,
+			TeamID:        &state.teamID,
+			Filename:      "echoapp.pkg",
+			InstallerFile: newReplacement(t, contents),
+		})
+		require.ErrorContains(t, err, "The package can't be changed for Fleet-maintained apps.")
+		require.False(t, state.ds.MatchSoftwareTitleIDForInstallerFuncInvoked)
+		require.False(t, state.ds.SaveInstallerUpdatesFuncInvoked)
+	})
 }
 
 func TestAddScriptPackageMetadata(t *testing.T) {

--- a/ee/server/service/software_installers_test.go
+++ b/ee/server/service/software_installers_test.go
@@ -890,7 +890,7 @@ func TestUpdateSoftwareInstallerMatchesSoftwareIdentity(t *testing.T) {
 	t.Run("bundle identifier allows a different title name on a targeted package", func(t *testing.T) {
 		contents, storageID := readInstaller(t, "testdata/dummy_installer.pkg")
 		state := setup(t, "Dummy App", "dummy_installer.pkg", "pkg", "darwin", storageID, []string{"com.example.dummy"}, true)
-		state.ds.MatchSoftwareTitleIDForInstallerFunc = func(ctx context.Context, payload *fleet.UploadSoftwareInstallerPayload) (uint, error) {
+		state.ds.GetExistingSoftwareInstallerTitleIDFunc = func(ctx context.Context, payload *fleet.UploadSoftwareInstallerPayload) (uint, error) {
 			require.Equal(t, "DummyApp", payload.Title)
 			require.Equal(t, "apps", payload.Source)
 			require.Equal(t, "com.example.dummy", payload.BundleIdentifier)
@@ -914,7 +914,7 @@ func TestUpdateSoftwareInstallerMatchesSoftwareIdentity(t *testing.T) {
 	t.Run("upgrade code allows a different title name", func(t *testing.T) {
 		contents, storageID := readInstaller(t, "../../../server/service/testdata/software-installers/fleet-osquery.msi")
 		state := setup(t, "Fleet agent", "fleet-osquery.msi", "msi", "windows", storageID, []string{"{70A53353-01E5-424B-8819-ED882B3805D9}"}, false)
-		state.ds.MatchSoftwareTitleIDForInstallerFunc = func(ctx context.Context, payload *fleet.UploadSoftwareInstallerPayload) (uint, error) {
+		state.ds.GetExistingSoftwareInstallerTitleIDFunc = func(ctx context.Context, payload *fleet.UploadSoftwareInstallerPayload) (uint, error) {
 			require.Equal(t, "Fleet osquery", payload.Title)
 			require.Equal(t, "programs", payload.Source)
 			require.NotEmpty(t, payload.UpgradeCode)
@@ -943,7 +943,7 @@ func TestUpdateSoftwareInstallerMatchesSoftwareIdentity(t *testing.T) {
 		t.Run("different software is rejected when "+tt.name, func(t *testing.T) {
 			contents, storageID := readInstaller(t, "testdata/dummy_installer.pkg")
 			state := setup(t, "Dummy App", "dummy_installer.pkg", "pkg", "darwin", storageID, []string{"com.example.dummy"}, false)
-			state.ds.MatchSoftwareTitleIDForInstallerFunc = func(context.Context, *fleet.UploadSoftwareInstallerPayload) (uint, error) {
+			state.ds.GetExistingSoftwareInstallerTitleIDFunc = func(context.Context, *fleet.UploadSoftwareInstallerPayload) (uint, error) {
 				return tt.resolvedTitleID, tt.resolveErr
 			}
 
@@ -962,7 +962,7 @@ func TestUpdateSoftwareInstallerMatchesSoftwareIdentity(t *testing.T) {
 	t.Run("different upgrade code is rejected", func(t *testing.T) {
 		contents, storageID := readInstaller(t, "../../../server/service/testdata/software-installers/fleet-osquery.msi")
 		state := setup(t, "Fleet agent", "fleet-osquery.msi", "msi", "windows", storageID, []string{"{70A53353-01E5-424B-8819-ED882B3805D9}"}, false)
-		state.ds.MatchSoftwareTitleIDForInstallerFunc = func(ctx context.Context, payload *fleet.UploadSoftwareInstallerPayload) (uint, error) {
+		state.ds.GetExistingSoftwareInstallerTitleIDFunc = func(ctx context.Context, payload *fleet.UploadSoftwareInstallerPayload) (uint, error) {
 			require.NotEmpty(t, payload.UpgradeCode)
 			return 0, &notFoundError{}
 		}
@@ -982,7 +982,7 @@ func TestUpdateSoftwareInstallerMatchesSoftwareIdentity(t *testing.T) {
 		_, storageID := readInstaller(t, "testdata/dummy_installer.pkg")
 		msiContents, _ := readInstaller(t, "../../../server/service/testdata/software-installers/fleet-osquery.msi")
 		state := setup(t, "Dummy App", "dummy_installer.pkg", "pkg", "darwin", storageID, []string{"com.example.dummy"}, false)
-		state.ds.MatchSoftwareTitleIDForInstallerFunc = func(context.Context, *fleet.UploadSoftwareInstallerPayload) (uint, error) {
+		state.ds.GetExistingSoftwareInstallerTitleIDFunc = func(context.Context, *fleet.UploadSoftwareInstallerPayload) (uint, error) {
 			t.Fatal("identity resolver must not run before the extension check")
 			return 0, nil
 		}
@@ -994,13 +994,13 @@ func TestUpdateSoftwareInstallerMatchesSoftwareIdentity(t *testing.T) {
 			InstallerFile: newReplacement(t, msiContents),
 		})
 		require.ErrorContains(t, err, "The selected package is for a different file type.")
-		require.False(t, state.ds.MatchSoftwareTitleIDForInstallerFuncInvoked)
+		require.False(t, state.ds.GetExistingSoftwareInstallerTitleIDFuncInvoked)
 	})
 
 	t.Run("non-file edit does not resolve identity", func(t *testing.T) {
 		_, storageID := readInstaller(t, "testdata/dummy_installer.pkg")
 		state := setup(t, "Dummy App", "dummy_installer.pkg", "pkg", "darwin", storageID, []string{"com.example.dummy"}, false)
-		state.ds.MatchSoftwareTitleIDForInstallerFunc = func(context.Context, *fleet.UploadSoftwareInstallerPayload) (uint, error) {
+		state.ds.GetExistingSoftwareInstallerTitleIDFunc = func(context.Context, *fleet.UploadSoftwareInstallerPayload) (uint, error) {
 			t.Fatal("identity resolver must not run without a replacement file")
 			return 0, nil
 		}
@@ -1019,7 +1019,7 @@ func TestUpdateSoftwareInstallerMatchesSoftwareIdentity(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, targetInstallerID, updated.InstallerID)
 		require.True(t, updated.SelfService)
-		require.False(t, state.ds.MatchSoftwareTitleIDForInstallerFuncInvoked)
+		require.False(t, state.ds.GetExistingSoftwareInstallerTitleIDFuncInvoked)
 	})
 
 	t.Run("same-named package with an unresolved identity is accepted via the name fallback", func(t *testing.T) {
@@ -1027,7 +1027,7 @@ func TestUpdateSoftwareInstallerMatchesSoftwareIdentity(t *testing.T) {
 		// name fallback must still accept it.
 		contents, storageID := readInstaller(t, "../../../server/service/testdata/software-installers/fleet-osquery.msi")
 		state := setup(t, "Fleet osquery", "fleet-osquery.msi", "msi", "windows", storageID, []string{"{70A53353-01E5-424B-8819-ED882B3805D9}"}, false)
-		state.ds.MatchSoftwareTitleIDForInstallerFunc = func(ctx context.Context, payload *fleet.UploadSoftwareInstallerPayload) (uint, error) {
+		state.ds.GetExistingSoftwareInstallerTitleIDFunc = func(ctx context.Context, payload *fleet.UploadSoftwareInstallerPayload) (uint, error) {
 			require.Equal(t, "Fleet osquery", payload.Title)
 			return 0, &notFoundError{}
 		}
@@ -1046,7 +1046,7 @@ func TestUpdateSoftwareInstallerMatchesSoftwareIdentity(t *testing.T) {
 	t.Run("different software is rejected on a targeted multi-package installer", func(t *testing.T) {
 		contents, storageID := readInstaller(t, "testdata/dummy_installer.pkg")
 		state := setup(t, "Different Osquery Name", "dummy_installer.pkg", "pkg", "darwin", storageID, []string{"com.example.dummy"}, true)
-		state.ds.MatchSoftwareTitleIDForInstallerFunc = func(context.Context, *fleet.UploadSoftwareInstallerPayload) (uint, error) {
+		state.ds.GetExistingSoftwareInstallerTitleIDFunc = func(context.Context, *fleet.UploadSoftwareInstallerPayload) (uint, error) {
 			return titleID + 1, nil // resolves to a different title
 		}
 
@@ -1068,7 +1068,7 @@ func TestUpdateSoftwareInstallerMatchesSoftwareIdentity(t *testing.T) {
 		state := setup(t, "Dummy App", "dummy_installer.pkg", "pkg", "darwin", storageID, []string{"com.example.dummy"}, false)
 		fmaID := uint(7)
 		state.installer.FleetMaintainedAppID = &fmaID
-		state.ds.MatchSoftwareTitleIDForInstallerFunc = func(context.Context, *fleet.UploadSoftwareInstallerPayload) (uint, error) {
+		state.ds.GetExistingSoftwareInstallerTitleIDFunc = func(context.Context, *fleet.UploadSoftwareInstallerPayload) (uint, error) {
 			t.Fatal("identity resolver must not run for a fleet-maintained app")
 			return 0, nil
 		}
@@ -1080,8 +1080,90 @@ func TestUpdateSoftwareInstallerMatchesSoftwareIdentity(t *testing.T) {
 			InstallerFile: newReplacement(t, contents),
 		})
 		require.ErrorContains(t, err, "The package can't be changed for Fleet-maintained apps.")
-		require.False(t, state.ds.MatchSoftwareTitleIDForInstallerFuncInvoked)
+		require.False(t, state.ds.GetExistingSoftwareInstallerTitleIDFuncInvoked)
 		require.False(t, state.ds.SaveInstallerUpdatesFuncInvoked)
+	})
+
+	t.Run("identity resolving to a different title is rejected even when the name matches", func(t *testing.T) {
+		// Guards the wrong-software overwrite: the title name equals the uploaded package's extracted
+		// name ("DummyApp"), but its identity resolves to a different title, so it must be rejected.
+		contents, storageID := readInstaller(t, "testdata/dummy_installer.pkg")
+		state := setup(t, "DummyApp", "dummy_installer.pkg", "pkg", "darwin", storageID, []string{"com.example.dummy"}, false)
+		state.ds.GetExistingSoftwareInstallerTitleIDFunc = func(context.Context, *fleet.UploadSoftwareInstallerPayload) (uint, error) {
+			return titleID + 1, nil // resolves to a different existing title
+		}
+
+		_, err := state.svc.UpdateSoftwareInstaller(state.ctx, &fleet.UpdateSoftwareInstallerPayload{
+			TitleID:       titleID,
+			TeamID:        &state.teamID,
+			Filename:      "dummy_installer.pkg",
+			InstallerFile: newReplacement(t, contents),
+		})
+		require.ErrorContains(t, err, "The selected package is for different software.")
+		require.False(t, state.ds.SaveInstallerUpdatesFuncInvoked)
+		require.Equal(t, storageID, state.installer.StorageID)
+	})
+
+	t.Run("targeted installer upgrade code accepts a renamed title without a title lookup", func(t *testing.T) {
+		// A sibling MSI whose own upgrade_code differs from the title's: the title lookup can't see it
+		// (returns not-found), and the title was renamed so the name fallback also fails — but the
+		// edited installer's own upgrade_code matches, so the fast path accepts without hitting the DB.
+		contents, storageID := readInstaller(t, "../../../server/service/testdata/software-installers/fleet-osquery.msi")
+		state := setup(t, "Renamed osquery title", "fleet-osquery.msi", "msi", "windows", storageID, []string{"{70A53353-01E5-424B-8819-ED882B3805D9}"}, false)
+		state.installer.UpgradeCode = "{B681CB20-107E-428A-9B14-2D3C1AFED244}" // fleet-osquery.msi's own upgrade code
+		state.ds.GetExistingSoftwareInstallerTitleIDFunc = func(context.Context, *fleet.UploadSoftwareInstallerPayload) (uint, error) {
+			t.Fatal("title lookup must be skipped when the upgrade code fast path matches")
+			return 0, nil
+		}
+
+		updated, err := state.svc.UpdateSoftwareInstaller(state.ctx, &fleet.UpdateSoftwareInstallerPayload{
+			TitleID:       titleID,
+			TeamID:        &state.teamID,
+			Filename:      "fleet-osquery.msi",
+			InstallerFile: newReplacement(t, contents),
+		})
+		require.NoError(t, err)
+		require.NotEqual(t, storageID, updated.StorageID)
+		require.False(t, state.ds.GetExistingSoftwareInstallerTitleIDFuncInvoked)
+		require.True(t, state.ds.SaveInstallerUpdatesFuncInvoked)
+	})
+
+	t.Run("a datastore error resolving identity is propagated", func(t *testing.T) {
+		contents, storageID := readInstaller(t, "testdata/dummy_installer.pkg")
+		state := setup(t, "Dummy App", "dummy_installer.pkg", "pkg", "darwin", storageID, []string{"com.example.dummy"}, false)
+		state.ds.GetExistingSoftwareInstallerTitleIDFunc = func(context.Context, *fleet.UploadSoftwareInstallerPayload) (uint, error) {
+			return 0, errors.New("datastore boom")
+		}
+
+		_, err := state.svc.UpdateSoftwareInstaller(state.ctx, &fleet.UpdateSoftwareInstallerPayload{
+			TitleID:       titleID,
+			TeamID:        &state.teamID,
+			Filename:      "dummy_installer.pkg",
+			InstallerFile: newReplacement(t, contents),
+		})
+		require.ErrorContains(t, err, "resolving title for updated installer")
+		require.False(t, state.ds.SaveInstallerUpdatesFuncInvoked)
+	})
+
+	t.Run("name-only package resolving to a different title falls through to the name check", func(t *testing.T) {
+		// A name-only package (no bundle id / upgrade code): the resolver's name branch has no
+		// LIMIT/ORDER BY and can match multiple same-named titles ambiguously, so a "different title"
+		// result must not reject on its own — it falls through to the name check, which matches here.
+		contents, storageID := readInstaller(t, "../../../server/service/testdata/software-installers/vim.deb")
+		state := setup(t, "vim", "vim.deb", "deb", "linux", storageID, []string{"vim"}, false)
+		state.ds.GetExistingSoftwareInstallerTitleIDFunc = func(context.Context, *fleet.UploadSoftwareInstallerPayload) (uint, error) {
+			return titleID + 1, nil // ambiguous name-only match returns another same-named title
+		}
+
+		updated, err := state.svc.UpdateSoftwareInstaller(state.ctx, &fleet.UpdateSoftwareInstallerPayload{
+			TitleID:       titleID,
+			TeamID:        &state.teamID,
+			Filename:      "vim.deb",
+			InstallerFile: newReplacement(t, contents),
+		})
+		require.NoError(t, err)
+		require.NotEqual(t, storageID, updated.StorageID)
+		require.True(t, state.ds.SaveInstallerUpdatesFuncInvoked)
 	})
 }
 

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -506,7 +506,9 @@ func softwareInstallerTitleSelect(payload *fleet.UploadSoftwareInstallerPayload)
 	}
 }
 
-func (ds *Datastore) getExistingSoftwareInstallerTitleID(ctx context.Context, payload *fleet.UploadSoftwareInstallerPayload) (uint, error) {
+// GetExistingSoftwareInstallerTitleID resolves the software title an installer payload identifies
+// (by bundle_identifier / upgrade_code / name+source). Returns a NotFound error if none matches.
+func (ds *Datastore) GetExistingSoftwareInstallerTitleID(ctx context.Context, payload *fleet.UploadSoftwareInstallerPayload) (uint, error) {
 	stmt, args := softwareInstallerTitleSelect(payload)
 	var titleID uint
 	switch err := sqlx.GetContext(ctx, ds.reader(ctx), &titleID, stmt, args...); {
@@ -517,10 +519,6 @@ func (ds *Datastore) getExistingSoftwareInstallerTitleID(ctx context.Context, pa
 	default:
 		return 0, ctxerr.Wrap(ctx, err, "get existing software installer title id")
 	}
-}
-
-func (ds *Datastore) MatchSoftwareTitleIDForInstaller(ctx context.Context, payload *fleet.UploadSoftwareInstallerPayload) (uint, error) {
-	return ds.getExistingSoftwareInstallerTitleID(ctx, payload)
 }
 
 func (ds *Datastore) getOrGenerateSoftwareInstallerTitleID(ctx context.Context, tx sqlx.ExtContext, payload *fleet.UploadSoftwareInstallerPayload) (uint, error) {
@@ -4373,7 +4371,7 @@ func (ds *Datastore) checkSoftwareConflictsByIdentifier(ctx context.Context, pay
 	}
 
 	if payload.FleetMaintainedAppID == nil {
-		titleID, err := ds.getExistingSoftwareInstallerTitleID(ctx, payload)
+		titleID, err := ds.GetExistingSoftwareInstallerTitleID(ctx, payload)
 		if fleet.IsNotFound(err) {
 			if payload.TitleID != nil {
 				return &fleet.BadRequestError{Message: fmt.Sprintf(fleet.SoftwarePackageTitleMismatchMessage, payload.Filename)}

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -519,6 +519,10 @@ func (ds *Datastore) getExistingSoftwareInstallerTitleID(ctx context.Context, pa
 	}
 }
 
+func (ds *Datastore) MatchSoftwareTitleIDForInstaller(ctx context.Context, payload *fleet.UploadSoftwareInstallerPayload) (uint, error) {
+	return ds.getExistingSoftwareInstallerTitleID(ctx, payload)
+}
+
 func (ds *Datastore) getOrGenerateSoftwareInstallerTitleID(ctx context.Context, tx sqlx.ExtContext, payload *fleet.UploadSoftwareInstallerPayload) (uint, error) {
 	selectStmt, selectArgs := softwareInstallerTitleSelect(payload)
 	insertStmt := `INSERT INTO software_titles (name, source, extension_for) VALUES (?, ?, '')`

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -86,6 +86,87 @@ func TestSoftwareInstallers(t *testing.T) {
 	}
 }
 
+func TestMatchSoftwareTitleIDForInstaller(t *testing.T) {
+	ds := CreateMySQLDS(t)
+	defer TruncateTables(t, ds)
+	ctx := t.Context()
+
+	insertTitle := func(name, source string, bundleIdentifier, upgradeCode any) uint {
+		t.Helper()
+		var titleID uint
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			if _, err := q.ExecContext(ctx,
+				`INSERT INTO software_titles (name, source, bundle_identifier, upgrade_code, extension_for) VALUES (?, ?, ?, ?, '')`,
+				name, source, bundleIdentifier, upgradeCode); err != nil {
+				return err
+			}
+			return sqlx.GetContext(ctx, q, &titleID, `SELECT id FROM software_titles WHERE name = ? AND source = ?`, name, source)
+		})
+		return titleID
+	}
+
+	bundleTitleID := insertTitle("Stored App Name", "apps", "com.example.app", nil)
+	upgradeTitleID := insertTitle("Stored Windows Name", "programs", nil, "{EXAMPLE-UPGRADE-CODE}")
+	nameTitleID := insertTitle("Stored Package Name", "deb_packages", nil, nil)
+
+	t.Run("bundle identifier", func(t *testing.T) {
+		titleID, err := ds.MatchSoftwareTitleIDForInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+			Title:            "Different Installer Name",
+			Source:           "apps",
+			BundleIdentifier: "com.example.app",
+		})
+		require.NoError(t, err)
+		require.Equal(t, bundleTitleID, titleID)
+	})
+
+	t.Run("upgrade code", func(t *testing.T) {
+		titleID, err := ds.MatchSoftwareTitleIDForInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+			Title:       "Different Installer Name",
+			Source:      "programs",
+			UpgradeCode: "{EXAMPLE-UPGRADE-CODE}",
+		})
+		require.NoError(t, err)
+		require.Equal(t, upgradeTitleID, titleID)
+	})
+
+	t.Run("name and source", func(t *testing.T) {
+		titleID, err := ds.MatchSoftwareTitleIDForInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+			Title:  "Stored Package Name",
+			Source: "deb_packages",
+		})
+		require.NoError(t, err)
+		require.Equal(t, nameTitleID, titleID)
+	})
+
+	for _, tt := range []struct {
+		name    string
+		payload *fleet.UploadSoftwareInstallerPayload
+	}{
+		{
+			name: "bundle identifier not found",
+			payload: &fleet.UploadSoftwareInstallerPayload{
+				Title:            "Unknown App",
+				Source:           "apps",
+				BundleIdentifier: "com.example.unknown",
+			},
+		},
+		{
+			name: "upgrade code not found",
+			payload: &fleet.UploadSoftwareInstallerPayload{
+				Title:       "Unknown Windows App",
+				Source:      "programs",
+				UpgradeCode: "{UNKNOWN-UPGRADE-CODE}",
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ds.MatchSoftwareTitleIDForInstaller(ctx, tt.payload)
+			require.Error(t, err)
+			require.True(t, fleet.IsNotFound(err))
+		})
+	}
+}
+
 func testListPendingSoftwareInstalls(t *testing.T, ds *Datastore) {
 	ctx := context.Background()
 	t.Cleanup(func() { ds.testActivateSpecificNextActivities = nil })

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -86,7 +86,7 @@ func TestSoftwareInstallers(t *testing.T) {
 	}
 }
 
-func TestMatchSoftwareTitleIDForInstaller(t *testing.T) {
+func TestGetExistingSoftwareInstallerTitleID(t *testing.T) {
 	ds := CreateMySQLDS(t)
 	defer TruncateTables(t, ds)
 	ctx := t.Context()
@@ -110,7 +110,7 @@ func TestMatchSoftwareTitleIDForInstaller(t *testing.T) {
 	nameTitleID := insertTitle("Stored Package Name", "deb_packages", nil, nil)
 
 	t.Run("bundle identifier", func(t *testing.T) {
-		titleID, err := ds.MatchSoftwareTitleIDForInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+		titleID, err := ds.GetExistingSoftwareInstallerTitleID(ctx, &fleet.UploadSoftwareInstallerPayload{
 			Title:            "Different Installer Name",
 			Source:           "apps",
 			BundleIdentifier: "com.example.app",
@@ -120,7 +120,7 @@ func TestMatchSoftwareTitleIDForInstaller(t *testing.T) {
 	})
 
 	t.Run("upgrade code", func(t *testing.T) {
-		titleID, err := ds.MatchSoftwareTitleIDForInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+		titleID, err := ds.GetExistingSoftwareInstallerTitleID(ctx, &fleet.UploadSoftwareInstallerPayload{
 			Title:       "Different Installer Name",
 			Source:      "programs",
 			UpgradeCode: "{EXAMPLE-UPGRADE-CODE}",
@@ -130,7 +130,7 @@ func TestMatchSoftwareTitleIDForInstaller(t *testing.T) {
 	})
 
 	t.Run("name and source", func(t *testing.T) {
-		titleID, err := ds.MatchSoftwareTitleIDForInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+		titleID, err := ds.GetExistingSoftwareInstallerTitleID(ctx, &fleet.UploadSoftwareInstallerPayload{
 			Title:  "Stored Package Name",
 			Source: "deb_packages",
 		})
@@ -160,7 +160,7 @@ func TestMatchSoftwareTitleIDForInstaller(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := ds.MatchSoftwareTitleIDForInstaller(ctx, tt.payload)
+			_, err := ds.GetExistingSoftwareInstallerTitleID(ctx, tt.payload)
 			require.Error(t, err)
 			require.True(t, fleet.IsNotFound(err))
 		})

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2713,6 +2713,9 @@ type Datastore interface {
 
 	// MatchOrCreateSoftwareInstaller matches or creates a new software installer.
 	MatchOrCreateSoftwareInstaller(ctx context.Context, payload *UploadSoftwareInstallerPayload) (installerID, titleID uint, err error)
+	// MatchSoftwareTitleIDForInstaller resolves the software title an installer payload identifies
+	// (by bundle_identifier / upgrade_code / name+source). Returns a NotFound error if none matches.
+	MatchSoftwareTitleIDForInstaller(ctx context.Context, payload *UploadSoftwareInstallerPayload) (uint, error)
 
 	// GetSoftwareInstallerMetadataByID returns the software installer corresponding to the installer id.
 	GetSoftwareInstallerMetadataByID(ctx context.Context, id uint) (*SoftwareInstaller, error)

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2713,9 +2713,9 @@ type Datastore interface {
 
 	// MatchOrCreateSoftwareInstaller matches or creates a new software installer.
 	MatchOrCreateSoftwareInstaller(ctx context.Context, payload *UploadSoftwareInstallerPayload) (installerID, titleID uint, err error)
-	// MatchSoftwareTitleIDForInstaller resolves the software title an installer payload identifies
+	// GetExistingSoftwareInstallerTitleID resolves the software title an installer payload identifies
 	// (by bundle_identifier / upgrade_code / name+source). Returns a NotFound error if none matches.
-	MatchSoftwareTitleIDForInstaller(ctx context.Context, payload *UploadSoftwareInstallerPayload) (uint, error)
+	GetExistingSoftwareInstallerTitleID(ctx context.Context, payload *UploadSoftwareInstallerPayload) (uint, error)
 
 	// GetSoftwareInstallerMetadataByID returns the software installer corresponding to the installer id.
 	GetSoftwareInstallerMetadataByID(ctx context.Context, id uint) (*SoftwareInstaller, error)

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1582,6 +1582,8 @@ type GetHostLastInstallDataFunc func(ctx context.Context, hostID uint, installer
 
 type MatchOrCreateSoftwareInstallerFunc func(ctx context.Context, payload *fleet.UploadSoftwareInstallerPayload) (installerID uint, titleID uint, err error)
 
+type MatchSoftwareTitleIDForInstallerFunc func(ctx context.Context, payload *fleet.UploadSoftwareInstallerPayload) (uint, error)
+
 type GetSoftwareInstallerMetadataByIDFunc func(ctx context.Context, id uint) (*fleet.SoftwareInstaller, error)
 
 type ValidateOrbitSoftwareInstallerAccessFunc func(ctx context.Context, hostID uint, installerID uint) (bool, error)
@@ -4523,6 +4525,9 @@ type DataStore struct {
 
 	MatchOrCreateSoftwareInstallerFunc        MatchOrCreateSoftwareInstallerFunc
 	MatchOrCreateSoftwareInstallerFuncInvoked bool
+
+	MatchSoftwareTitleIDForInstallerFunc        MatchSoftwareTitleIDForInstallerFunc
+	MatchSoftwareTitleIDForInstallerFuncInvoked bool
 
 	GetSoftwareInstallerMetadataByIDFunc        GetSoftwareInstallerMetadataByIDFunc
 	GetSoftwareInstallerMetadataByIDFuncInvoked bool
@@ -10884,6 +10889,13 @@ func (s *DataStore) MatchOrCreateSoftwareInstaller(ctx context.Context, payload 
 	s.MatchOrCreateSoftwareInstallerFuncInvoked = true
 	s.mu.Unlock()
 	return s.MatchOrCreateSoftwareInstallerFunc(ctx, payload)
+}
+
+func (s *DataStore) MatchSoftwareTitleIDForInstaller(ctx context.Context, payload *fleet.UploadSoftwareInstallerPayload) (uint, error) {
+	s.mu.Lock()
+	s.MatchSoftwareTitleIDForInstallerFuncInvoked = true
+	s.mu.Unlock()
+	return s.MatchSoftwareTitleIDForInstallerFunc(ctx, payload)
 }
 
 func (s *DataStore) GetSoftwareInstallerMetadataByID(ctx context.Context, id uint) (*fleet.SoftwareInstaller, error) {

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1582,7 +1582,7 @@ type GetHostLastInstallDataFunc func(ctx context.Context, hostID uint, installer
 
 type MatchOrCreateSoftwareInstallerFunc func(ctx context.Context, payload *fleet.UploadSoftwareInstallerPayload) (installerID uint, titleID uint, err error)
 
-type MatchSoftwareTitleIDForInstallerFunc func(ctx context.Context, payload *fleet.UploadSoftwareInstallerPayload) (uint, error)
+type GetExistingSoftwareInstallerTitleIDFunc func(ctx context.Context, payload *fleet.UploadSoftwareInstallerPayload) (uint, error)
 
 type GetSoftwareInstallerMetadataByIDFunc func(ctx context.Context, id uint) (*fleet.SoftwareInstaller, error)
 
@@ -4526,8 +4526,8 @@ type DataStore struct {
 	MatchOrCreateSoftwareInstallerFunc        MatchOrCreateSoftwareInstallerFunc
 	MatchOrCreateSoftwareInstallerFuncInvoked bool
 
-	MatchSoftwareTitleIDForInstallerFunc        MatchSoftwareTitleIDForInstallerFunc
-	MatchSoftwareTitleIDForInstallerFuncInvoked bool
+	GetExistingSoftwareInstallerTitleIDFunc        GetExistingSoftwareInstallerTitleIDFunc
+	GetExistingSoftwareInstallerTitleIDFuncInvoked bool
 
 	GetSoftwareInstallerMetadataByIDFunc        GetSoftwareInstallerMetadataByIDFunc
 	GetSoftwareInstallerMetadataByIDFuncInvoked bool
@@ -10891,11 +10891,11 @@ func (s *DataStore) MatchOrCreateSoftwareInstaller(ctx context.Context, payload 
 	return s.MatchOrCreateSoftwareInstallerFunc(ctx, payload)
 }
 
-func (s *DataStore) MatchSoftwareTitleIDForInstaller(ctx context.Context, payload *fleet.UploadSoftwareInstallerPayload) (uint, error) {
+func (s *DataStore) GetExistingSoftwareInstallerTitleID(ctx context.Context, payload *fleet.UploadSoftwareInstallerPayload) (uint, error) {
 	s.mu.Lock()
-	s.MatchSoftwareTitleIDForInstallerFuncInvoked = true
+	s.GetExistingSoftwareInstallerTitleIDFuncInvoked = true
 	s.mu.Unlock()
-	return s.MatchSoftwareTitleIDForInstallerFunc(ctx, payload)
+	return s.GetExistingSoftwareInstallerTitleIDFunc(ctx, payload)
 }
 
 func (s *DataStore) GetSoftwareInstallerMetadataByID(ctx context.Context, id uint) (*fleet.SoftwareInstaller, error) {


### PR DESCRIPTION
**Related issue:** Resolves #49234

Editing a software installer to a new version failed with "The selected package is for different software" when the title's stored (osquery-reported) name differed from the installer's extracted name. The edit now validates by software identity (bundle identifier / upgrade code / name) instead of an exact name match.

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually
