### PR TITLE
Extend support for all built-in

### DIFF
--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -7434,14 +7434,32 @@ software:
 		require.Contains(t, err.Error(), "is not supported in host name templates")
 	})
 
-	// 4b. A secret variable is rejected at the GitOps env-expansion layer (before
-	// the server), since $FLEET_SECRET_* is only allowed in profiles and scripts.
-	t.Run("secret variable rejected at expansion", func(t *testing.T) {
+	// 4b. A custom (secret) variable is allowed in name_template: GitOps preserves
+	// the placeholder (does not expand it) for the server to validate/expand, and
+	// uploads the referenced secret like any other GitOps secret.
+	t.Run("secret variable allowed and preserved", func(t *testing.T) {
+		t.Setenv("FLEET_SECRET_FOO", "someValue")
+		// The base mock provides ValidateEmbeddedSecretsFunc (used by scripts/batch),
+		// so leave it alone; only the secret-upload func needs a stub here.
+		ds.UpsertSecretVariablesFunc = func(ctx context.Context, secretVariables []fleet.SecretVariable) error { return nil }
+		ds.UpsertSecretVariablesFuncInvoked = false
+
 		yml := writeYAML(t, teamYAML(`  name_template: "iPad $FLEET_SECRET_FOO"`))
+		_ = runAppForTest(t, []string{"gitops", "-f", yml})
+
+		// the placeholder is stored on the team (not the expanded value)
+		require.Equal(t, "iPad $FLEET_SECRET_FOO", savedTeam.Config.MDM.HostNameTemplate)
+		// the referenced secret was collected from the env and uploaded
+		require.True(t, ds.UpsertSecretVariablesFuncInvoked)
+	})
+
+	// 4c. A secret referenced in name_template that isn't set in the environment
+	// fails during GitOps parsing (same as profiles/scripts).
+	t.Run("secret variable missing from env is rejected", func(t *testing.T) {
+		yml := writeYAML(t, teamYAML(`  name_template: "iPad $FLEET_SECRET_NOT_SET"`))
 		_, err := runAppNoChecks([]string{"gitops", "-f", yml})
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "FLEET_SECRET_")
-		require.Contains(t, err.Error(), "only allowed in profiles and scripts")
+		require.Contains(t, err.Error(), "FLEET_SECRET_NOT_SET")
 	})
 
 	// 5. name_template in org-level controls sets the global ("No team") template.

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -7428,7 +7428,7 @@ software:
 
 	// 4. An invalid variable surfaces the server's 422 validation message through fleetctl.
 	t.Run("invalid variable rejected", func(t *testing.T) {
-		yml := writeYAML(t, teamYAML(`  name_template: "$FLEET_VAR_HOST_END_USER_IDP_GROUPS"`))
+		yml := writeYAML(t, teamYAML(`  name_template: "$FLEET_VAR_NDES_SCEP_CHALLENGE"`))
 		_, err := runAppNoChecks([]string{"gitops", "-f", yml})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "is not supported in host name templates")
@@ -7517,7 +7517,7 @@ software:
 		noTeamPath := filepath.Join(t.TempDir(), "no-team.yml")
 		require.NoError(t, os.WriteFile(noTeamPath, []byte(`
 controls:
-  name_template: "$FLEET_VAR_HOST_END_USER_IDP_GROUPS"
+  name_template: "$FLEET_VAR_NDES_SCEP_CHALLENGE"
 policies:
 name: No team
 software:

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -326,7 +326,9 @@ func (svc *Service) ModifyTeam(ctx context.Context, teamID uint, payload fleet.T
 
 		if payload.MDM.HostNameTemplate.Set {
 			nameTemplate := payload.MDM.HostNameTemplate.Value
-			if nameTemplate != "" {
+			// Only validate (a DB round-trip to confirm referenced secrets exist)
+			// when the template actually changed, mirroring the app-config path.
+			if nameTemplate != "" && nameTemplate != team.Config.MDM.HostNameTemplate {
 				validated, err := fleet.ValidateHostNameTemplateWithSecrets(ctx, svc.ds, nameTemplate)
 				if err != nil {
 					return nil, ctxerr.Wrap(ctx, err)
@@ -1810,7 +1812,9 @@ func (svc *Service) editTeamFromSpec(
 	var didUpdateHostNameTemplate bool
 	if spec.MDM.HostNameTemplate.Set {
 		nameTemplate := spec.MDM.HostNameTemplate.Value
-		if nameTemplate != "" {
+		// Only validate (a DB round-trip to confirm referenced secrets exist) when
+		// the template actually changed — GitOps re-applies the spec on every run.
+		if nameTemplate != "" && nameTemplate != team.Config.MDM.HostNameTemplate {
 			validated, err := fleet.ValidateHostNameTemplateWithSecrets(ctx, svc.ds, nameTemplate)
 			if err != nil {
 				return ctxerr.Wrap(ctx, err)

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -1188,10 +1188,14 @@ func parseControls(top map[string]json.RawMessage, result *GitOps, logFn Logf, y
 		}
 	}
 
-	// Validate that name_template, if present, is a string.
+	// Validate that name_template, if present, is a string, and collect any
+	// $FLEET_SECRET_ it references so GitOps uploads it (its placeholder is left
+	// in the template for the server to validate and expand).
 	if result.Controls.NameTemplate != nil {
-		if _, ok := result.Controls.NameTemplate.(string); !ok {
+		if tmpl, ok := result.Controls.NameTemplate.(string); !ok {
 			multiError = multierror.Append(multiError, fmt.Errorf("'controls.name_template' must be a string in %s", controlsFilePath))
+		} else if err := LookupEnvSecrets(tmpl, result.FleetSecrets); err != nil {
+			multiError = multierror.Append(multiError, err)
 		}
 	}
 

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -320,6 +320,10 @@ func expandEnv(s string, secretMode secretHandling) (string, error) {
 
 	s = escapeString(s, preventEscapingPrefix)
 	exclusionZones := getExclusionZones(s)
+	// Zones where a $FLEET_SECRET_ reference is allowed and must be preserved (not
+	// rejected, not expanded) so the server can validate and expand it — currently
+	// the host name template (controls.name_template).
+	fleetSecretAllowedZones := getFleetSecretAllowedZones(s)
 	trimmed := strings.TrimSpace(s)
 	documentIsXML := strings.HasPrefix(trimmed, "<") // We need to be more aggressive here, to also escape XML in Windows profiles which does not begin with <?xml
 	documentIsJSON := strings.HasPrefix(trimmed, "{")
@@ -365,6 +369,13 @@ func expandEnv(s string, secretMode secretHandling) (string, error) {
 				// If secret not found, leave as-is for server to handle
 				return "", false
 			case secretsReject:
+				for _, z := range fleetSecretAllowedZones {
+					if startPos >= z[0] && endPos <= z[1] {
+						// Allowed here (e.g. controls.name_template): leave the
+						// placeholder for the server to validate and expand.
+						return "", false
+					}
+				}
 				err = multierror.Append(err, fmt.Errorf("environment variables with %q prefix are only allowed in profiles and scripts: %q",
 					fleet.ServerSecretPrefix, env))
 				return "", false
@@ -511,6 +522,24 @@ func getExclusionZones(s string) [][2]int {
 		for _, r := range result {
 			zones = append(zones, [2]int{r[0], r[1]})
 		}
+	}
+	return zones
+}
+
+// fleetSecretAllowedKeyPattern matches the single-line YAML value(s) where a
+// $FLEET_SECRET_ reference may appear in the main spec (outside profiles/scripts)
+// and must be preserved for the server rather than rejected. Currently only the
+// host name template (controls.name_template) qualifies.
+var fleetSecretAllowedKeyPattern = regexp.MustCompile(`(?m)^\s*name_template:.*$`)
+
+// getFleetSecretAllowedZones returns the byte ranges of values where a
+// $FLEET_SECRET_ reference is allowed and left as-is (the server validates and
+// expands it). The zones are matched against the same (escaped) string
+// expandEnv operates on, so callers can compare token positions directly.
+func getFleetSecretAllowedZones(s string) [][2]int {
+	var zones [][2]int
+	for _, r := range fleetSecretAllowedKeyPattern.FindAllStringIndex(s, -1) {
+		zones = append(zones, [2]int{r[0], r[1]})
 	}
 	return zones
 }

--- a/server/datastore/mysql/apple_device_names.go
+++ b/server/datastore/mysql/apple_device_names.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
@@ -309,6 +310,43 @@ func (ds *Datastore) ResendHostDeviceName(ctx context.Context, hostUUID string) 
 	if rows, _ := res.RowsAffected(); rows == 0 {
 		// this should never happen, log for debugging
 		ds.logger.DebugContext(ctx, "resend device name status not updated", "host_uuid", hostUUID)
+	}
+	return nil
+}
+
+// resendDeviceNamesForSecretChange re-queues host-name enforcement rows for the
+// scopes whose template references any of the given changed custom (secret)
+// variables, so the device-name cron re-resolves with the new secret value and
+// enqueues a fresh DeviceName command.
+func (ds *Datastore) resendDeviceNamesForSecretChange(ctx context.Context, changedSecretNames []string) error {
+	if len(changedSecretNames) == 0 {
+		return nil
+	}
+	pattern := "FLEET_SECRET_(" + strings.Join(changedSecretNames, "|") + `)\b`
+
+	// Teams whose template references a changed secret.
+	var teamIDs []uint
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &teamIDs,
+		`SELECT id FROM teams WHERE COALESCE(config->>'$.mdm.name_template', '') REGEXP ?`, pattern); err != nil {
+		return ctxerr.Wrap(ctx, err, "select teams using changed secret in device name template")
+	}
+
+	// The "No team" (global) template.
+	var noTeamMatches bool
+	if err := sqlx.GetContext(ctx, ds.reader(ctx), &noTeamMatches,
+		`SELECT COALESCE(`+deviceNameNoTeamTemplateExpr+`, '') REGEXP ?`, pattern); err != nil {
+		return ctxerr.Wrap(ctx, err, "check no-team device name template for changed secret")
+	}
+
+	for _, teamID := range teamIDs {
+		if err := ds.BulkUpsertHostDeviceNameEnforcement(ctx, &teamID); err != nil {
+			return err
+		}
+	}
+	if noTeamMatches {
+		if err := ds.BulkUpsertHostDeviceNameEnforcement(ctx, nil); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/server/datastore/mysql/scim.go
+++ b/server/datastore/mysql/scim.go
@@ -1563,7 +1563,62 @@ func triggerResendProfilesUsingVariables(ctx context.Context, tx sqlx.ExtContext
 		return ctxerr.Wrap(ctx, err, "queue managed config resend jobs")
 	}
 
+	// Re-enqueue host name templates that use an affected IdP variable.
+	if err := triggerResendDeviceNamesForIDPChange(ctx, tx, hostIDs, affectedVars); err != nil {
+		return ctxerr.Wrap(ctx, err, "resend host name templates for idp change")
+	}
+
 	return nil
+}
+
+// triggerResendDeviceNamesForIDPChange re-queues host-name enforcement rows so the
+// device-name cron re-resolves with the updated IdP value and enqueues a fresh
+// DeviceName command.
+func triggerResendDeviceNamesForIDPChange(ctx context.Context, tx sqlx.ExtContext, hostIDs []uint, affectedVars []fleet.FleetVarName) error {
+	if len(hostIDs) == 0 {
+		return nil
+	}
+
+	// Restrict to the affected variables that are actually supported in host name
+	// templates.
+	varNames := make([]string, 0, len(affectedVars))
+	for _, v := range affectedVars {
+		if fleet.IsHostNameTemplateIDPVar(string(v)) {
+			varNames = append(varNames, string(v))
+		}
+	}
+	if len(varNames) == 0 {
+		return nil
+	}
+
+	// A host's governing template is its team template, or the global "No team"
+	// template when it has no team. Match it against the changed variables with a
+	// single alternation (the names are [A-Z_], safe to embed in the pattern); the
+	// pattern value is bound as a parameter.
+	const selectStmt = `
+		SELECT h.id
+		FROM hosts h
+		LEFT JOIN teams t ON t.id = h.team_id
+		WHERE h.id IN (?)
+			AND COALESCE(CASE WHEN h.team_id IS NULL
+				THEN ` + deviceNameNoTeamTemplateExpr + `
+				ELSE t.config->>'$.mdm.name_template' END, '') REGEXP ?`
+
+	// The trailing word boundary keeps a changed HOST_END_USER_IDP_USERNAME from
+	// matching a template that only uses HOST_END_USER_IDP_USERNAME_LOCAL_PART, the
+	// same guard the secret-change path uses.
+	stmt, args, err := sqlx.In(selectStmt, hostIDs, "FLEET_VAR_("+strings.Join(varNames, "|")+`)\b`)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "build select device name hosts for idp change")
+	}
+	var affectedHostIDs []uint
+	if err := sqlx.SelectContext(ctx, tx, &affectedHostIDs, stmt, args...); err != nil {
+		return ctxerr.Wrap(ctx, err, "select device name hosts for idp change")
+	}
+	if len(affectedHostIDs) == 0 {
+		return nil
+	}
+	return reconcileHostDeviceNamesForHostsDB(ctx, tx, affectedHostIDs)
 }
 
 // queueManagedConfigResendJobs finds android app configs that reference any of

--- a/server/datastore/mysql/secret_variables.go
+++ b/server/datastore/mysql/secret_variables.go
@@ -96,6 +96,16 @@ func (ds *Datastore) UpsertSecretVariables(ctx context.Context, secretVariables 
 				return ctxerr.Wrap(ctx, err, "update secret variables")
 			}
 		}
+
+		// A changed secret value changes the resolved name of any host whose host
+		// name template references it, so re-queue those hosts' enforcement rows.
+		changedNames := make([]string, 0, len(variablesToUpdate))
+		for _, secretVariable := range variablesToUpdate {
+			changedNames = append(changedNames, secretVariable.Name)
+		}
+		if err := ds.resendDeviceNamesForSecretChange(ctx, changedNames); err != nil {
+			return ctxerr.Wrap(ctx, err, "resend device names for secret change")
+		}
 	}
 
 	return nil
@@ -327,7 +337,7 @@ func (ds *Datastore) DeleteSecretVariable(ctx context.Context, id uint) (secretN
 			WHERE COALESCE(t.config->>'$.mdm.name_template', '') != ''
 			UNION ALL
 			SELECT 'host_name_template' AS entity, 'Host name' AS name,
-			'No team' AS team_name, json_value->>'$.mdm.name_template' AS contents
+			'Unassigned' AS team_name, json_value->>'$.mdm.name_template' AS contents
 			FROM app_config_json
 			WHERE COALESCE(json_value->>'$.mdm.name_template', '') != '';`,
 		); err != nil {

--- a/server/datastore/mysql/secret_variables_test.go
+++ b/server/datastore/mysql/secret_variables_test.go
@@ -830,7 +830,7 @@ func testDeleteUsedSecretVariable(t *testing.T, ds *Datastore) {
 		_, err = ds.SaveTeam(ctx, foobarTeam)
 		require.NoError(t, err)
 
-		// Set a "No team" (global) host name template that uses the variable.
+		// Set an "Unassigned" (global) host name template that uses the variable.
 		ac, err := ds.AppConfig(ctx)
 		require.NoError(t, err)
 		ac.MDM.HostNameTemplate = optjson.SetString("iPad ${FLEET_SECRET_FOOBAR}")
@@ -843,9 +843,9 @@ func testDeleteUsedSecretVariable(t *testing.T, ds *Datastore) {
 		require.ErrorAs(t, err, &s)
 		require.Equal(t, "FOOBAR", s.SecretName)
 		require.Equal(t, "host_name_template", s.Entity.Type)
-		require.Equal(t, "No team", s.Entity.TeamName)
+		require.Equal(t, "Unassigned", s.Entity.TeamName)
 
-		// Clear the "No team" template.
+		// Clear the "Unassigned" template.
 		ac.MDM.HostNameTemplate = optjson.SetString("")
 		require.NoError(t, ds.SaveAppConfig(ctx, ac))
 	})

--- a/server/fleet/name_template.go
+++ b/server/fleet/name_template.go
@@ -20,27 +20,53 @@ const maxHostNameTemplateLength = 255
 // text alone already exceeds it.
 const MaxResolvedHostNameBytes = 63
 
-// fleetVarsSupportedInHostNameTemplates is the allow-list of Fleet variables that
-// may be used in a host name template.
-var fleetVarsSupportedInHostNameTemplates = []FleetVarName{
+// hostIdentityVarsInNameTemplates are the built-in variables resolved purely from
+// the in-memory host struct.
+var hostIdentityVarsInNameTemplates = []FleetVarName{
 	FleetVarHostHardwareSerial,
 	FleetVarHostUUID,
 	FleetVarHostPlatform,
 }
 
-// nameTemplateVarRegexp matches every supported name-template variable in both
-// its $FLEET_VAR_NAME and ${FLEET_VAR_NAME} forms, in a single pattern. It is
-// derived from fleetVarsSupportedInHostNameTemplates so it stays in sync with the
-// allow-list. The unbraced form uses a trailing word boundary so that an
-// unsupported longer name (e.g. HOST_UUID_EXTRA) is not partially matched.
-var nameTemplateVarRegexp = func() *regexp.Regexp {
-	alts := make([]string, len(fleetVarsSupportedInHostNameTemplates))
-	for i, v := range fleetVarsSupportedInHostNameTemplates {
+// idpVarsInNameTemplates are the built-in IdP end-user variables.
+var idpVarsInNameTemplates = []FleetVarName{
+	FleetVarHostEndUserIDPUsername,
+	FleetVarHostEndUserIDPUsernameLocalPart,
+	FleetVarHostEndUserIDPGroups,
+	FleetVarHostEndUserIDPDepartment,
+	FleetVarHostEndUserIDPFullname,
+}
+
+// fleetVarsSupportedInHostNameTemplates is the allow-list of built-in Fleet
+// variables that may be used in a host name template.
+var fleetVarsSupportedInHostNameTemplates = slices.Concat(hostIdentityVarsInNameTemplates, idpVarsInNameTemplates)
+
+// nameTemplateVarRegexp matches every supported built-in name-template variable
+// (identity + IdP) in both its $FLEET_VAR_NAME and ${FLEET_VAR_NAME} forms.
+var nameTemplateVarRegexp = varAlternationRegexp(fleetVarsSupportedInHostNameTemplates)
+
+// nameTemplateIdentityVarRegexp matches only the host-identity variables.
+// ResolveHostNameTemplate uses it so it substitutes identity variables and leaves
+// IdP tokens untouched for the service-layer resolver.
+var nameTemplateIdentityVarRegexp = varAlternationRegexp(hostIdentityVarsInNameTemplates)
+
+// IsHostNameTemplateIDPVar reports whether name (a built-in variable name without
+// the FLEET_VAR_ prefix, as returned by variables.Find) is an IdP end-user
+// variable supported in host name templates.
+func IsHostNameTemplateIDPVar(name string) bool {
+	return slices.Contains(idpVarsInNameTemplates, FleetVarName(name))
+}
+
+// varAlternationRegexp builds a regexp matching any of the given variables in both
+// the $FLEET_VAR_NAME and ${FLEET_VAR_NAME} forms.
+func varAlternationRegexp(vars []FleetVarName) *regexp.Regexp {
+	alts := make([]string, len(vars))
+	for i, v := range vars {
 		alts[i] = regexp.QuoteMeta(string(v))
 	}
 	alt := strings.Join(alts, "|")
 	return regexp.MustCompile(fmt.Sprintf(`\$FLEET_VAR_(%[1]s)\b|\$\{FLEET_VAR_(%[1]s)\}`, alt))
-}()
+}
 
 // nameTemplateSecretRegexp matches a $FLEET_SECRET_NAME / ${FLEET_SECRET_NAME}
 // custom (secret) variable token. Secret values are only known at resolve time
@@ -131,9 +157,10 @@ var hostNameTemplatePlatformDisplayNames = map[string]string{
 	"ipados": "iPadOS",
 }
 
-// ResolveHostNameTemplate resolves a host name template against a host by
-// substituting the supported host-identity Fleet variables with the host's
-// values.
+// ResolveHostNameTemplate substitutes the host-identity built-in variables
+// ($FLEET_VAR_HOST_HARDWARE_SERIAL, _HOST_UUID, _HOST_PLATFORM) with the host's
+// values. IdP end-user variables are left untouched — they require a datastore
+// lookup and are resolved separately in the service layer.
 func ResolveHostNameTemplate(tmpl string, host *Host) string {
 	if host == nil {
 		return tmpl
@@ -150,8 +177,8 @@ func ResolveHostNameTemplate(tmpl string, host *Host) string {
 		FleetVarHostPlatform:       platform,
 	}
 
-	return nameTemplateVarRegexp.ReplaceAllStringFunc(tmpl, func(match string) string {
-		groups := nameTemplateVarRegexp.FindStringSubmatch(match)
+	return nameTemplateIdentityVarRegexp.ReplaceAllStringFunc(tmpl, func(match string) string {
+		groups := nameTemplateIdentityVarRegexp.FindStringSubmatch(match)
 		// Exactly one of the two capture groups (unbraced/braced) is populated.
 		name := groups[1]
 		if name == "" {

--- a/server/fleet/name_template_test.go
+++ b/server/fleet/name_template_test.go
@@ -20,6 +20,12 @@ func TestValidateHostNameTemplate(t *testing.T) {
 		{name: "hardware serial", tmpl: "$FLEET_VAR_HOST_HARDWARE_SERIAL", wantNorm: "$FLEET_VAR_HOST_HARDWARE_SERIAL"},
 		{name: "uuid braced", tmpl: "${FLEET_VAR_HOST_UUID}", wantNorm: "${FLEET_VAR_HOST_UUID}"},
 		{name: "platform", tmpl: "$FLEET_VAR_HOST_PLATFORM", wantNorm: "$FLEET_VAR_HOST_PLATFORM"},
+		// IdP end-user variables are supported.
+		{name: "idp username", tmpl: "$FLEET_VAR_HOST_END_USER_IDP_USERNAME", wantNorm: "$FLEET_VAR_HOST_END_USER_IDP_USERNAME"},
+		{name: "idp groups braced", tmpl: "${FLEET_VAR_HOST_END_USER_IDP_GROUPS}", wantNorm: "${FLEET_VAR_HOST_END_USER_IDP_GROUPS}"},
+		{name: "idp full name", tmpl: "$FLEET_VAR_HOST_END_USER_IDP_FULL_NAME", wantNorm: "$FLEET_VAR_HOST_END_USER_IDP_FULL_NAME"},
+		{name: "idp department", tmpl: "$FLEET_VAR_HOST_END_USER_IDP_DEPARTMENT", wantNorm: "$FLEET_VAR_HOST_END_USER_IDP_DEPARTMENT"},
+		{name: "idp username local part", tmpl: "$FLEET_VAR_HOST_END_USER_IDP_USERNAME_LOCAL_PART", wantNorm: "$FLEET_VAR_HOST_END_USER_IDP_USERNAME_LOCAL_PART"},
 		{
 			name:     "mixed",
 			tmpl:     "mac-$FLEET_VAR_HOST_HARDWARE_SERIAL-${FLEET_VAR_HOST_UUID}",
@@ -34,9 +40,19 @@ func TestValidateHostNameTemplate(t *testing.T) {
 		{name: "empty", tmpl: "", wantErr: "can't be empty"},
 		{name: "whitespace only", tmpl: "   ", wantErr: "can't be empty"},
 		{
-			name:    "unsupported var",
-			tmpl:    "$FLEET_VAR_HOST_END_USER_IDP_GROUPS",
-			wantErr: "Fleet variable $FLEET_VAR_HOST_END_USER_IDP_GROUPS is not supported in host name templates.",
+			name:    "unsupported CA variable",
+			tmpl:    "$FLEET_VAR_NDES_SCEP_CHALLENGE",
+			wantErr: "Fleet variable $FLEET_VAR_NDES_SCEP_CHALLENGE is not supported in host name templates.",
+		},
+		{
+			name:    "unsupported DigiCert variable",
+			tmpl:    "$FLEET_VAR_DIGICERT_DATA_MYCA",
+			wantErr: "is not supported in host name templates.",
+		},
+		{
+			name:    "deprecated legacy idp email var is not supported",
+			tmpl:    "$FLEET_VAR_HOST_END_USER_EMAIL_IDP",
+			wantErr: "is not supported in host name templates.",
 		},
 		{
 			name:    "supported var with unsupported suffix",
@@ -127,6 +143,15 @@ func TestResolveHostNameTemplate(t *testing.T) {
 			tmpl: "$FLEET_VAR_HOST_PLATFORM-$FLEET_VAR_HOST_HARDWARE_SERIAL-${FLEET_VAR_HOST_HARDWARE_SERIAL}",
 			host: host,
 			want: "macOS-C02ABC123-C02ABC123",
+		},
+		{
+			// IdP variables need a datastore lookup, so ResolveHostNameTemplate must
+			// leave them untouched (they're resolved separately in the service layer)
+			// while still resolving the identity variables around them.
+			name: "idp tokens left untouched, identity resolved",
+			tmpl: "u=$FLEET_VAR_HOST_END_USER_IDP_USERNAME;lp=${FLEET_VAR_HOST_END_USER_IDP_USERNAME_LOCAL_PART};s=$FLEET_VAR_HOST_HARDWARE_SERIAL",
+			host: host,
+			want: "u=$FLEET_VAR_HOST_END_USER_IDP_USERNAME;lp=${FLEET_VAR_HOST_END_USER_IDP_USERNAME_LOCAL_PART};s=C02ABC123",
 		},
 		{
 			// Non-Apple platforms fall back to the raw value (the feature only

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -1901,6 +1901,13 @@ func (svc *Service) validateMDM(
 		if !lic.IsPremium() {
 			invalid.Append("mdm.name_template", ErrMissingLicense.Error())
 		} else if validated, err := fleet.ValidateHostNameTemplateWithSecrets(ctx, svc.ds, mdm.HostNameTemplate.Value); err != nil {
+			// A validation or missing-secret error is invalid user input (422); any
+			// other error (e.g. a datastore failure while checking secrets) must
+			// propagate as a server error rather than be misreported as invalid input.
+			var argErr *fleet.InvalidArgumentError
+			if !errors.As(err, &argErr) {
+				return ctxerr.Wrap(ctx, err, "validating host name template")
+			}
 			invalid.Append("mdm.name_template", err.Error())
 		} else {
 			mdm.HostNameTemplate = optjson.SetString(validated)

--- a/server/service/appconfig_test.go
+++ b/server/service/appconfig_test.go
@@ -1054,6 +1054,53 @@ func TestModifyAppConfigHostNameTemplateDowngrade(t *testing.T) {
 	}
 }
 
+// TestModifyAppConfigHostNameTemplateSecretErrors verifies that when the "No team"
+// host name template references a secret variable, a missing secret is reported as
+// invalid input (422) while a datastore failure propagates as a server error rather
+// than being misclassified as invalid input.
+func TestModifyAppConfigHostNameTemplateSecretErrors(t *testing.T) {
+	admin := &fleet.User{GlobalRole: new(fleet.RoleAdmin)}
+
+	newSvc := func(t *testing.T, validateErr error) (fleet.Service, context.Context, *mock.Store) {
+		ds := new(mock.Store)
+		svc, ctx := newTestService(t, ds, nil, nil, &TestServerOpts{License: &fleet.LicenseInfo{Tier: fleet.TierPremium}})
+		ctx = viewer.NewContext(ctx, viewer.Viewer{User: admin})
+
+		dsAppConfig := &fleet.AppConfig{
+			OrgInfo:        fleet.OrgInfo{OrgName: "Test"},
+			ServerSettings: fleet.ServerSettings{ServerURL: "https://example.org"},
+		}
+		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) { return dsAppConfig, nil }
+		ds.SaveAppConfigFunc = func(ctx context.Context, conf *fleet.AppConfig) error { *dsAppConfig = *conf; return nil }
+		ds.SaveABMTokenFunc = func(ctx context.Context, tok *fleet.ABMToken) error { return nil }
+		ds.ListVPPTokensFunc = func(ctx context.Context) ([]*fleet.VPPTokenDB, error) { return []*fleet.VPPTokenDB{}, nil }
+		ds.ListABMTokensFunc = func(ctx context.Context) ([]*fleet.ABMToken, error) { return []*fleet.ABMToken{}, nil }
+		ds.ValidateEmbeddedSecretsFunc = func(ctx context.Context, documents []string) error { return validateErr }
+		return svc, ctx, ds
+	}
+
+	// A change to a template that references a secret, so validation runs.
+	body := []byte(`{"mdm":{"name_template":"WS-$FLEET_SECRET_TOKEN"}}`)
+
+	t.Run("missing secret is invalid input (422)", func(t *testing.T) {
+		svc, ctx, ds := newSvc(t, &fleet.MissingSecretsError{MissingSecrets: []string{"TOKEN"}})
+		_, err := svc.ModifyAppConfig(ctx, body, fleet.ApplySpecOptions{})
+		require.Error(t, err)
+		var argErr *fleet.InvalidArgumentError
+		require.ErrorAs(t, err, &argErr)
+		require.False(t, ds.SaveAppConfigFuncInvoked)
+	})
+
+	t.Run("datastore error propagates as a server error, not 422", func(t *testing.T) {
+		svc, ctx, ds := newSvc(t, errors.New("database is down"))
+		_, err := svc.ModifyAppConfig(ctx, body, fleet.ApplySpecOptions{})
+		require.Error(t, err)
+		var argErr *fleet.InvalidArgumentError
+		require.NotErrorAs(t, err, &argErr, "a datastore error must not be reported as invalid input")
+		require.False(t, ds.SaveAppConfigFuncInvoked)
+	})
+}
+
 // TestTransparencyURLDowngradeLicense tests scenarios where a transparency url value has previously
 // been stored (for example, if a licensee downgraded without manually resetting the transparency url)
 func TestTransparencyURLDowngradeLicense(t *testing.T) {

--- a/server/service/apple_device_names.go
+++ b/server/service/apple_device_names.go
@@ -3,11 +3,15 @@ package service
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
+	"regexp"
+	"strings"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
+	"github.com/fleetdm/fleet/v4/server/variables"
 	"github.com/google/uuid"
 )
 
@@ -142,6 +146,28 @@ func ReconcileHostDeviceNames(
 			HardwareSerial: host.HardwareSerial,
 			Platform:       host.Platform,
 		})
+
+		// Resolve IdP end-user variables (if any). These need a per-host datastore
+		// lookup and fail the same way configuration profiles do when the data is
+		// missing.
+		resolvedWithIDP, idpFailDetail, idpErr := resolveHostNameIDPVars(ctx, ds, resolved, host.HostID)
+		if idpErr != nil {
+			// A datastore failure; abort the batch so the next cron tick retries
+			// rather than permanently failing rows a retry would resolve.
+			return idpErr
+		}
+		if idpFailDetail != "" {
+			// The host is missing IdP data the template needs; fail the row with the
+			// profile-style detail. On a write error, log and move on rather than
+			// aborting the batch, consistent with the other outcomes below.
+			if err := ds.SetHostDeviceNameStatus(ctx, host.HostUUID, fleet.MDMDeliveryFailed, nil, "",
+				idpFailDetail); err != nil {
+				logger.ErrorContext(ctx, "mark device name row failed for idp resolution", "host_uuid", host.HostUUID, "err", err)
+			}
+			continue
+		}
+		resolved = resolvedWithIDP
+
 		switch {
 		case len(resolved) > fleet.MaxResolvedHostNameBytes:
 			// The resolved name is not stored: it can exceed the column width,
@@ -205,4 +231,99 @@ func ReconcileHostDeviceNames(
 		}
 	}
 	return nil
+}
+
+// resolveHostNameIDPVars substitutes the IdP end-user built-in variables in name
+// for the given host, with the same value mapping and fail-hard messages as
+// configuration profiles (server/mdm/profiles.ResolveHostEndUserIDPValue). It
+// fetches the host's end user once (all IdP variables in a template resolve from
+// the same user), so a template using several IdP variables needs a single
+// GetEndUsers call. It returns:
+//   - the resolved name, when every IdP variable is populated;
+//   - a non-empty failDetail (and empty name) when an IdP variable can't be
+//     populated for this host — the caller marks the host's row Failed with it,
+//     exactly as a profile install would fail;
+//   - an error only for a datastore failure, which the caller treats as transient.
+func resolveHostNameIDPVars(ctx context.Context, ds fleet.Datastore, name string, hostID uint) (resolved string, failDetail string, err error) {
+	// Collect the IdP variables used, longest-first (variables.Find sorts that way)
+	// so ..._IDP_USERNAME_LOCAL_PART is substituted before ..._IDP_USERNAME, whose
+	// regexps have no trailing boundary — matching the profile processor's order.
+	var idpVars []string
+	for _, v := range variables.Find(name) {
+		if fleet.IsHostNameTemplateIDPVar(v) {
+			idpVars = append(idpVars, v)
+		}
+	}
+	if len(idpVars) == 0 {
+		return name, "", nil
+	}
+
+	users, err := fleet.GetEndUsers(ctx, ds, hostID)
+	if err != nil {
+		return "", "", ctxerr.Wrap(ctx, err, "get end users for device name")
+	}
+	var user *fleet.HostEndUser
+	if len(users) > 0 && users[0].IdpUserName != "" {
+		user = &users[0]
+	}
+
+	for _, v := range idpVars {
+		value, rx, ok, detail := resolveHostNameIDPValue(user, v)
+		if !ok {
+			return "", detail, nil
+		}
+		name = rx.ReplaceAllLiteralString(name, value)
+	}
+	return name, "", nil
+}
+
+// resolveHostNameIDPValue mirrors server/mdm/profiles.ResolveHostEndUserIDPValue's
+// value mapping and fail-hard detail messages, but works from an already-fetched
+// end user (nil when the host has no IdP user) so the caller can resolve every IdP
+// variable in a template from a single GetEndUsers call. On success it returns the
+// value and the variable's regexp; otherwise ok is false and detail carries the
+// profile-style failure message.
+func resolveHostNameIDPValue(user *fleet.HostEndUser, fleetVar string) (value string, rx *regexp.Regexp, ok bool, detail string) {
+	noGroupsErr := fmt.Sprintf("There are no IdP groups for this host. Fleet couldn't populate $FLEET_VAR_%s.", fleet.FleetVarHostEndUserIDPGroups)
+	noDepartmentErr := fmt.Sprintf("There is no IdP department for this host. Fleet couldn't populate $FLEET_VAR_%s.", fleet.FleetVarHostEndUserIDPDepartment)
+	noFullnameErr := fmt.Sprintf("There is no IdP full name for this host. Fleet couldn't populate $FLEET_VAR_%s.", fleet.FleetVarHostEndUserIDPFullname)
+
+	if user == nil {
+		switch fleetVar {
+		case string(fleet.FleetVarHostEndUserIDPGroups):
+			return "", nil, false, noGroupsErr
+		case string(fleet.FleetVarHostEndUserIDPDepartment):
+			return "", nil, false, noDepartmentErr
+		case string(fleet.FleetVarHostEndUserIDPFullname):
+			return "", nil, false, noFullnameErr
+		default:
+			return "", nil, false, fmt.Sprintf("There is no IdP username for this host. Fleet couldn't populate $FLEET_VAR_%s.", fleetVar)
+		}
+	}
+
+	switch fleetVar {
+	case string(fleet.FleetVarHostEndUserIDPUsername):
+		return user.IdpUserName, fleet.FleetVarHostEndUserIDPUsernameRegexp, true, ""
+	case string(fleet.FleetVarHostEndUserIDPUsernameLocalPart):
+		localPart, _, _ := strings.Cut(user.IdpUserName, "@")
+		return localPart, fleet.FleetVarHostEndUserIDPUsernameLocalPartRegexp, true, ""
+	case string(fleet.FleetVarHostEndUserIDPGroups):
+		if len(user.IdpGroups) == 0 {
+			return "", nil, false, noGroupsErr
+		}
+		return strings.Join(user.IdpGroups, ","), fleet.FleetVarHostEndUserIDPGroupsRegexp, true, ""
+	case string(fleet.FleetVarHostEndUserIDPDepartment):
+		if user.Department == "" {
+			return "", nil, false, noDepartmentErr
+		}
+		return user.Department, fleet.FleetVarHostEndUserIDPDepartmentRegexp, true, ""
+	case string(fleet.FleetVarHostEndUserIDPFullname):
+		fullName := strings.TrimSpace(user.IdpFullName)
+		if fullName == "" {
+			return "", nil, false, noFullnameErr
+		}
+		return fullName, fleet.FleetVarHostEndUserIDPFullnameRegexp, true, ""
+	default:
+		return "", nil, false, fmt.Sprintf("Fleet couldn't populate $FLEET_VAR_%s.", fleetVar)
+	}
 }

--- a/server/service/apple_device_names_test.go
+++ b/server/service/apple_device_names_test.go
@@ -1,0 +1,72 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveHostNameIDPVars(t *testing.T) {
+	ds := new(mock.Store)
+	var scimCalls int
+	ds.ScimUserByHostIDFunc = func(_ context.Context, _ uint) (*fleet.ScimUser, error) {
+		scimCalls++
+		return &fleet.ScimUser{
+			ID:         1,
+			UserName:   "jdoe@corp.com",
+			GivenName:  new("Jane"),
+			FamilyName: new("Doe"),
+			Department: new("Eng"),
+			Groups:     []fleet.ScimUserGroup{{DisplayName: "Admins"}, {DisplayName: "Eng"}},
+		}, nil
+	}
+	ds.ListHostDeviceMappingFunc = func(_ context.Context, _ uint) ([]*fleet.HostDeviceMapping, error) {
+		return nil, nil
+	}
+
+	t.Run("multiple IdP vars resolve from a single fetch", func(t *testing.T) {
+		scimCalls = 0
+		// The template repeats and mixes IdP vars, including _USERNAME and its
+		// longer _USERNAME_LOCAL_PART sibling, to exercise the longest-first
+		// substitution order.
+		name, detail, err := resolveHostNameIDPVars(t.Context(), ds,
+			"u=$FLEET_VAR_HOST_END_USER_IDP_USERNAME;lp=${FLEET_VAR_HOST_END_USER_IDP_USERNAME_LOCAL_PART};d=$FLEET_VAR_HOST_END_USER_IDP_DEPARTMENT;g=$FLEET_VAR_HOST_END_USER_IDP_GROUPS",
+			42)
+		require.NoError(t, err)
+		require.Empty(t, detail)
+		require.Equal(t, "u=jdoe@corp.com;lp=jdoe;d=Eng;g=Admins,Eng", name)
+		require.Equal(t, 1, scimCalls, "end users must be fetched once regardless of the number of IdP variables")
+	})
+
+	t.Run("no IdP vars needs no fetch and leaves other tokens untouched", func(t *testing.T) {
+		scimCalls = 0
+		name, detail, err := resolveHostNameIDPVars(t.Context(), ds, "WS-$FLEET_VAR_HOST_HARDWARE_SERIAL", 42)
+		require.NoError(t, err)
+		require.Empty(t, detail)
+		// identity variables are resolved elsewhere, so they're passed through here
+		require.Equal(t, "WS-$FLEET_VAR_HOST_HARDWARE_SERIAL", name)
+		require.Zero(t, scimCalls, "no datastore fetch when the template has no IdP variables")
+	})
+
+	t.Run("missing IdP field fails with the profile-style detail", func(t *testing.T) {
+		ds.ScimUserByHostIDFunc = func(_ context.Context, _ uint) (*fleet.ScimUser, error) {
+			return &fleet.ScimUser{ID: 1, UserName: "jdoe@corp.com"}, nil // no department
+		}
+		name, detail, err := resolveHostNameIDPVars(t.Context(), ds, "$FLEET_VAR_HOST_END_USER_IDP_DEPARTMENT", 42)
+		require.NoError(t, err)
+		require.Empty(t, name)
+		require.Contains(t, detail, "no IdP department for this host")
+	})
+
+	t.Run("no IdP user fails with the username detail", func(t *testing.T) {
+		ds.ScimUserByHostIDFunc = func(_ context.Context, _ uint) (*fleet.ScimUser, error) {
+			return nil, nil // no SCIM user mapped
+		}
+		_, detail, err := resolveHostNameIDPVars(t.Context(), ds, "$FLEET_VAR_HOST_END_USER_IDP_USERNAME", 42)
+		require.NoError(t, err)
+		require.Contains(t, detail, "no IdP username for this host")
+	})
+}

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -4015,7 +4015,7 @@ func TestUpdateMDMHostNameTemplate(t *testing.T) {
 
 	t.Run("invalid templates are rejected", func(t *testing.T) {
 		for _, tc := range []struct{ name, tmpl string }{
-			{"unsupported variable", "WS-$FLEET_VAR_HOST_END_USER_IDP_GROUPS"},
+			{"unsupported CA variable", "WS-$FLEET_VAR_NDES_SCEP_CHALLENGE"},
 			{"control characters", "WS-\x07"},
 			{"too long", strings.Repeat("a", 256)},
 		} {

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -25853,7 +25853,7 @@ func (s *integrationMDMTestSuite) TestHostNameTemplateEndToEnd() {
 	// (An omitted fleet_id targets "No team", covered by
 	// TestHostNameTemplateNoTeamEndToEnd; this test drives the team scope.)
 	res := s.Do("POST", "/api/latest/fleet/host_name_template",
-		updateHostNameTemplateRequest{FleetID: &team.ID, HostNameTemplate: "WS-$FLEET_VAR_HOST_END_USER_IDP_GROUPS"}, http.StatusUnprocessableEntity)
+		updateHostNameTemplateRequest{FleetID: &team.ID, HostNameTemplate: "WS-$FLEET_VAR_NDES_SCEP_CHALLENGE"}, http.StatusUnprocessableEntity)
 	require.Contains(t, extractServerErrorText(res.Body), "not supported in host name templates")
 	// A custom (secret) variable is allowed, but an undefined one is rejected at
 	// save time with the missing-secret error.
@@ -26121,6 +26121,32 @@ func (s *integrationMDMTestSuite) TestHostNameTemplateEndToEnd() {
 	require.NoError(t, plist.Unmarshal(cmd.Raw, &secretSettingsCmd))
 	require.Len(t, secretSettingsCmd.Command.Settings, 1)
 	require.Equal(t, "HQ-"+macHost.HardwareSerial, secretSettingsCmd.Command.Settings[0].DeviceName)
+	_, err = macDevice.Acknowledge(cmd.CommandUUID)
+	require.NoError(t, err)
+	requireRowStatus(macHost.UUID, &fleet.MDMDeliveryVerifying)
+
+	// --- changing the secret value re-enqueues a fresh command ---
+	require.NoError(t, s.ds.UpsertSecretVariables(ctx, []fleet.SecretVariable{{Name: "SITE", Value: "NYC"}}))
+	// the secret change reset the enforcement row back to queued
+	requireRowStatus(macHost.UUID, nil)
+	runDeviceNameCron()
+	changedSecretRow := requireRowStatus(macHost.UUID, &fleet.MDMDeliveryPending)
+	require.NotNil(t, changedSecretRow.ExpectedDeviceName)
+	require.Equal(t, "NYC-"+macHost.HardwareSerial, *changedSecretRow.ExpectedDeviceName)
+	cmd, err = macDevice.Idle()
+	require.NoError(t, err)
+	require.NotNil(t, cmd)
+	var changedSecretCmd struct {
+		Command struct {
+			Settings []struct {
+				Item       string
+				DeviceName string
+			}
+		}
+	}
+	require.NoError(t, plist.Unmarshal(cmd.Raw, &changedSecretCmd))
+	require.Len(t, changedSecretCmd.Command.Settings, 1)
+	require.Equal(t, "NYC-"+macHost.HardwareSerial, changedSecretCmd.Command.Settings[0].DeviceName)
 
 	// the secret can't be deleted while a host name template references it
 	_, err = s.ds.DeleteSecretVariable(ctx, secretID)
@@ -26175,7 +26201,7 @@ func (s *integrationMDMTestSuite) TestHostNameTemplateNoTeamEndToEnd() {
 	// --- set the No-team template (nil fleet_id) ---
 	// An invalid variable is still rejected on the No-team path.
 	res := s.Do("POST", "/api/latest/fleet/host_name_template",
-		updateHostNameTemplateRequest{HostNameTemplate: "WS-$FLEET_VAR_HOST_END_USER_IDP_GROUPS"}, http.StatusUnprocessableEntity)
+		updateHostNameTemplateRequest{HostNameTemplate: "WS-$FLEET_VAR_NDES_SCEP_CHALLENGE"}, http.StatusUnprocessableEntity)
 	require.Contains(t, extractServerErrorText(res.Body), "not supported in host name templates")
 
 	const tmpl = "WS-$FLEET_VAR_HOST_HARDWARE_SERIAL"
@@ -26275,6 +26301,451 @@ func (s *integrationMDMTestSuite) TestHostNameTemplateNoTeamEndToEnd() {
 	s.lastActivityMatches("edited_host_name_template",
 		`{"fleet_id": null, "fleet_name": null, "name_template": null}`, 0)
 	requireNoRow(macHost.UUID)
+}
+
+func (s *integrationMDMTestSuite) TestHostNameTemplateIDPVariables() {
+	t := s.T()
+	ctx := t.Context()
+
+	team, err := s.ds.NewTeam(ctx, &fleet.Team{Name: t.Name()})
+	require.NoError(t, err)
+
+	setFleetMDMData := func(hostID uint) {
+		require.NoError(t, s.ds.SetOrUpdateMDMData(ctx, hostID, false, true, s.server.URL, false, fleet.WellKnownMDMFleet, "", false))
+	}
+
+	// A host mapped to an IdP user.
+	idpHost, idpDevice := createHostThenEnrollMDM(s.ds, s.server.URL, t)
+	setFleetMDMData(idpHost.ID)
+	scimUserID, err := s.ds.CreateScimUser(ctx, &fleet.ScimUser{
+		UserName:   "jdoe@example.com",
+		GivenName:  new("Jane"),
+		FamilyName: new("Doe"),
+		Department: new("Engineering"),
+	})
+	require.NoError(t, err)
+	_, err = s.ds.SetOrUpdateHostSCIMUserMapping(ctx, idpHost.ID, scimUserID)
+	require.NoError(t, err)
+
+	// A host with no IdP user mapped.
+	noIDPHost, _ := createHostThenEnrollMDM(s.ds, s.server.URL, t)
+	setFleetMDMData(noIDPHost.ID)
+
+	require.NoError(t, s.ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&team.ID,
+		[]uint{idpHost.ID, noIDPHost.ID})))
+
+	requireRowStatus := func(hostUUID string, want *fleet.MDMDeliveryStatus) *fleet.HostDeviceNameEnforcement {
+		row, err := s.ds.GetHostDeviceNameEnforcement(ctx, hostUUID)
+		require.NoError(t, err)
+		if want == nil {
+			require.Nil(t, row.Status)
+		} else {
+			require.NotNil(t, row.Status)
+			require.Equal(t, *want, *row.Status)
+		}
+		return row
+	}
+	runDeviceNameCron := func() {
+		require.NoError(t, ReconcileHostDeviceNames(ctx, s.ds, s.mdmCommander, s.logger))
+	}
+	deviceNameFromCmd := func(raw []byte) string {
+		var sc struct {
+			Command struct {
+				Settings []struct {
+					Item       string
+					DeviceName string
+				}
+			}
+		}
+		require.NoError(t, plist.Unmarshal(raw, &sc))
+		require.Len(t, sc.Command.Settings, 1)
+		require.Equal(t, "DeviceName", sc.Command.Settings[0].Item)
+		return sc.Command.Settings[0].DeviceName
+	}
+
+	// --- set a template that uses an IdP variable ---
+	const tmpl = "WS-$FLEET_VAR_HOST_END_USER_IDP_USERNAME"
+	s.Do("POST", "/api/latest/fleet/host_name_template",
+		updateHostNameTemplateRequest{FleetID: &team.ID, HostNameTemplate: tmpl}, http.StatusNoContent)
+
+	// --- cron: resolves the IdP value for the mapped host; fails the unmapped one ---
+	runDeviceNameCron()
+
+	idpRow := requireRowStatus(idpHost.UUID, &fleet.MDMDeliveryPending)
+	require.NotNil(t, idpRow.ExpectedDeviceName)
+	require.Equal(t, "WS-jdoe@example.com", *idpRow.ExpectedDeviceName)
+
+	// a host with no IdP user fails exactly like a profile would, with the same detail
+	noIDPRow := requireRowStatus(noIDPHost.UUID, &fleet.MDMDeliveryFailed)
+	require.Contains(t, noIDPRow.Detail, "no IdP username for this host")
+
+	// the mapped host received the DeviceName command carrying the resolved IdP value
+	cmd, err := idpDevice.Idle()
+	require.NoError(t, err)
+	require.NotNil(t, cmd)
+	require.Equal(t, "Settings", cmd.Command.RequestType)
+	require.Equal(t, "WS-jdoe@example.com", deviceNameFromCmd(cmd.Raw))
+	_, err = idpDevice.Acknowledge(cmd.CommandUUID)
+	require.NoError(t, err)
+	requireRowStatus(idpHost.UUID, &fleet.MDMDeliveryVerifying)
+
+	// A host in another team with an identity-only template, mapped to the *same*
+	// IdP user, driven to a settled (verifying) state. An IdP change must NOT
+	// re-enqueue it — its resolved name can't depend on IdP data.
+	identityTeam, err := s.ds.NewTeam(ctx, &fleet.Team{Name: t.Name() + "-identity"})
+	require.NoError(t, err)
+	identityHost, identityDevice := createHostThenEnrollMDM(s.ds, s.server.URL, t)
+	setFleetMDMData(identityHost.ID)
+	_, err = s.ds.SetOrUpdateHostSCIMUserMapping(ctx, identityHost.ID, scimUserID)
+	require.NoError(t, err)
+	require.NoError(t, s.ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&identityTeam.ID, []uint{identityHost.ID})))
+	s.Do("POST", "/api/latest/fleet/host_name_template",
+		updateHostNameTemplateRequest{FleetID: &identityTeam.ID, HostNameTemplate: "SN-$FLEET_VAR_HOST_HARDWARE_SERIAL"}, http.StatusNoContent)
+	runDeviceNameCron()
+	requireRowStatus(identityHost.UUID, &fleet.MDMDeliveryPending)
+	icmd, err := identityDevice.Idle()
+	require.NoError(t, err)
+	require.NotNil(t, icmd)
+	_, err = identityDevice.Acknowledge(icmd.CommandUUID)
+	require.NoError(t, err)
+	requireRowStatus(identityHost.UUID, &fleet.MDMDeliveryVerifying)
+
+	// --- changing the IdP value re-enqueues a fresh command (mirrors profile resend) ---
+	_, err = s.ds.ReplaceScimUser(ctx, &fleet.ScimUser{
+		ID:         scimUserID,
+		UserName:   "jsmith@example.com",
+		GivenName:  new("Jane"),
+		FamilyName: new("Smith"),
+		Department: new("Engineering"),
+	})
+	require.NoError(t, err)
+
+	// the IdP-template host's row was reset back to queued...
+	requireRowStatus(idpHost.UUID, nil)
+	// ...but the identity-only-template host mapped to the same IdP user is untouched.
+	requireRowStatus(identityHost.UUID, &fleet.MDMDeliveryVerifying)
+
+	runDeviceNameCron()
+	changedRow := requireRowStatus(idpHost.UUID, &fleet.MDMDeliveryPending)
+	require.NotNil(t, changedRow.ExpectedDeviceName)
+	require.Equal(t, "WS-jsmith@example.com", *changedRow.ExpectedDeviceName)
+	cmd, err = idpDevice.Idle()
+	require.NoError(t, err)
+	require.NotNil(t, cmd)
+	require.Equal(t, "WS-jsmith@example.com", deviceNameFromCmd(cmd.Raw))
+}
+
+// TestHostNameTemplateIDPResolution covers resolving a template that mixes
+// identity, IdP, and custom (secret) variables in one string, the
+// username-local-part variable, and the fail-hard behavior when a referenced IdP
+// field is empty for a host (matching how configuration profiles treat it).
+func (s *integrationMDMTestSuite) TestHostNameTemplateIDPResolution() {
+	t := s.T()
+	ctx := t.Context()
+
+	team, err := s.ds.NewTeam(ctx, &fleet.Team{Name: t.Name()})
+	require.NoError(t, err)
+
+	setFleetMDMData := func(hostID uint) {
+		require.NoError(t, s.ds.SetOrUpdateMDMData(ctx, hostID, false, true, s.server.URL, false, fleet.WellKnownMDMFleet, "", false))
+	}
+
+	// A host whose IdP user has a username and a department.
+	fullHost, fullDevice := createHostThenEnrollMDM(s.ds, s.server.URL, t)
+	setFleetMDMData(fullHost.ID)
+	fullUserID, err := s.ds.CreateScimUser(ctx, &fleet.ScimUser{
+		UserName:   "jdoe@corp.com",
+		GivenName:  new("Jane"),
+		FamilyName: new("Doe"),
+		Department: new("Eng"),
+	})
+	require.NoError(t, err)
+	_, err = s.ds.SetOrUpdateHostSCIMUserMapping(ctx, fullHost.ID, fullUserID)
+	require.NoError(t, err)
+
+	// A host whose IdP user has a username but no department.
+	noDeptHost, _ := createHostThenEnrollMDM(s.ds, s.server.URL, t)
+	setFleetMDMData(noDeptHost.ID)
+	noDeptUserID, err := s.ds.CreateScimUser(ctx, &fleet.ScimUser{UserName: "nodept@corp.com"})
+	require.NoError(t, err)
+	_, err = s.ds.SetOrUpdateHostSCIMUserMapping(ctx, noDeptHost.ID, noDeptUserID)
+	require.NoError(t, err)
+
+	require.NoError(t, s.ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&team.ID,
+		[]uint{fullHost.ID, noDeptHost.ID})))
+
+	requireRowStatus := func(hostUUID string, want *fleet.MDMDeliveryStatus) *fleet.HostDeviceNameEnforcement {
+		row, err := s.ds.GetHostDeviceNameEnforcement(ctx, hostUUID)
+		require.NoError(t, err)
+		if want == nil {
+			require.Nil(t, row.Status)
+		} else {
+			require.NotNil(t, row.Status)
+			require.Equal(t, *want, *row.Status)
+		}
+		return row
+	}
+	deviceNameFromCmd := func(raw []byte) string {
+		var sc struct {
+			Command struct {
+				Settings []struct {
+					Item       string
+					DeviceName string
+				}
+			}
+		}
+		require.NoError(t, plist.Unmarshal(raw, &sc))
+		require.Len(t, sc.Command.Settings, 1)
+		require.Equal(t, "DeviceName", sc.Command.Settings[0].Item)
+		return sc.Command.Settings[0].DeviceName
+	}
+
+	// A single template mixing a custom (secret) variable, an identity variable, the
+	// username-local-part IdP variable, and the department IdP variable.
+	secretID, err := s.ds.CreateSecretVariable(ctx, "SITE", "HQ")
+	require.NoError(t, err)
+	const tmpl = "${FLEET_SECRET_SITE}-${FLEET_VAR_HOST_END_USER_IDP_USERNAME_LOCAL_PART}-$FLEET_VAR_HOST_END_USER_IDP_DEPARTMENT" //nolint:gosec // G101: name template string, not a credential
+	s.Do("POST", "/api/latest/fleet/host_name_template",
+		updateHostNameTemplateRequest{FleetID: &team.ID, HostNameTemplate: tmpl}, http.StatusNoContent)
+
+	require.NoError(t, ReconcileHostDeviceNames(ctx, s.ds, s.mdmCommander, s.logger))
+
+	// the fully-populated host resolves all three variable kinds: secret "HQ", the
+	// local part of the username ("jdoe"), and the department ("Eng").
+	fullRow := requireRowStatus(fullHost.UUID, &fleet.MDMDeliveryPending)
+	require.NotNil(t, fullRow.ExpectedDeviceName)
+	require.Equal(t, "HQ-jdoe-Eng", *fullRow.ExpectedDeviceName)
+	cmd, err := fullDevice.Idle()
+	require.NoError(t, err)
+	require.NotNil(t, cmd)
+	require.Equal(t, "HQ-jdoe-Eng", deviceNameFromCmd(cmd.Raw))
+
+	// the host whose IdP user has no department fails the same way a profile would —
+	// an empty IdP field is treated like a missing one.
+	noDeptRow := requireRowStatus(noDeptHost.UUID, &fleet.MDMDeliveryFailed)
+	require.Contains(t, noDeptRow.Detail, "no IdP department for this host")
+
+	// cleanup: clearing the template releases the secret for deletion.
+	s.Do("POST", "/api/latest/fleet/host_name_template",
+		updateHostNameTemplateRequest{FleetID: &team.ID, HostNameTemplate: ""}, http.StatusNoContent)
+	_, err = s.ds.DeleteSecretVariable(ctx, secretID)
+	require.NoError(t, err)
+}
+
+// TestHostNameTemplateSecretReenqueue covers the secret-value change trigger: it
+// re-queues teams and "No team" whose template references the changed secret,
+// leaves scopes referencing a similarly-named secret (SITE vs SITE_CODE) alone, and
+// is a no-op when a secret is re-upserted with an unchanged value.
+func (s *integrationMDMTestSuite) TestHostNameTemplateSecretReenqueue() {
+	t := s.T()
+	ctx := t.Context()
+
+	setFleetMDMData := func(hostID uint) {
+		require.NoError(t, s.ds.SetOrUpdateMDMData(ctx, hostID, false, true, s.server.URL, false, fleet.WellKnownMDMFleet, "", false))
+	}
+	requireRowStatus := func(hostUUID string, want *fleet.MDMDeliveryStatus) {
+		row, err := s.ds.GetHostDeviceNameEnforcement(ctx, hostUUID)
+		require.NoError(t, err)
+		if want == nil {
+			require.Nil(t, row.Status)
+		} else {
+			require.NotNil(t, row.Status)
+			require.Equal(t, *want, *row.Status)
+		}
+	}
+
+	_, err := s.ds.CreateSecretVariable(ctx, "SITE", "HQ")
+	require.NoError(t, err)
+	_, err = s.ds.CreateSecretVariable(ctx, "SITE_CODE", "C1")
+	require.NoError(t, err)
+
+	// A team whose template uses $FLEET_SECRET_SITE.
+	siteTeam, err := s.ds.NewTeam(ctx, &fleet.Team{Name: t.Name() + "-site"})
+	require.NoError(t, err)
+	siteHost, siteDevice := createHostThenEnrollMDM(s.ds, s.server.URL, t)
+	setFleetMDMData(siteHost.ID)
+	require.NoError(t, s.ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&siteTeam.ID, []uint{siteHost.ID})))
+
+	// A team whose template uses the similarly-named $FLEET_SECRET_SITE_CODE.
+	codeTeam, err := s.ds.NewTeam(ctx, &fleet.Team{Name: t.Name() + "-code"})
+	require.NoError(t, err)
+	codeHost, codeDevice := createHostThenEnrollMDM(s.ds, s.server.URL, t)
+	setFleetMDMData(codeHost.ID)
+	require.NoError(t, s.ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&codeTeam.ID, []uint{codeHost.ID})))
+
+	// A "No team" host whose global template uses $FLEET_SECRET_SITE.
+	noTeamHost, noTeamDevice := createHostThenEnrollMDM(s.ds, s.server.URL, t)
+	setFleetMDMData(noTeamHost.ID)
+	require.Nil(t, noTeamHost.TeamID)
+
+	s.Do("POST", "/api/latest/fleet/host_name_template",
+		updateHostNameTemplateRequest{FleetID: &siteTeam.ID, HostNameTemplate: "${FLEET_SECRET_SITE}-x"}, http.StatusNoContent) //nolint:gosec // G101: template
+	s.Do("POST", "/api/latest/fleet/host_name_template",
+		updateHostNameTemplateRequest{FleetID: &codeTeam.ID, HostNameTemplate: "${FLEET_SECRET_SITE_CODE}-x"}, http.StatusNoContent) //nolint:gosec // G101: template
+	s.Do("POST", "/api/latest/fleet/host_name_template",
+		updateHostNameTemplateRequest{HostNameTemplate: "${FLEET_SECRET_SITE}-y"}, http.StatusNoContent) //nolint:gosec // G101: template
+
+	// Drive all three to a settled (verifying) state.
+	require.NoError(t, ReconcileHostDeviceNames(ctx, s.ds, s.mdmCommander, s.logger))
+	for _, d := range []*mdmtest.TestAppleMDMClient{siteDevice, codeDevice, noTeamDevice} {
+		cmd, err := d.Idle()
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+		require.Equal(t, "Settings", cmd.Command.RequestType)
+		_, err = d.Acknowledge(cmd.CommandUUID)
+		require.NoError(t, err)
+	}
+	requireRowStatus(siteHost.UUID, &fleet.MDMDeliveryVerifying)
+	requireRowStatus(codeHost.UUID, &fleet.MDMDeliveryVerifying)
+	requireRowStatus(noTeamHost.UUID, &fleet.MDMDeliveryVerifying)
+
+	// Re-upserting SITE with its current value changes nothing → no re-queue.
+	require.NoError(t, s.ds.UpsertSecretVariables(ctx, []fleet.SecretVariable{{Name: "SITE", Value: "HQ"}}))
+	requireRowStatus(siteHost.UUID, &fleet.MDMDeliveryVerifying)
+	requireRowStatus(noTeamHost.UUID, &fleet.MDMDeliveryVerifying)
+
+	// Changing SITE re-queues the SITE team and the No-team host, but not the
+	// SITE_CODE team (the trailing word boundary prevents SITE from matching
+	// SITE_CODE).
+	require.NoError(t, s.ds.UpsertSecretVariables(ctx, []fleet.SecretVariable{{Name: "SITE", Value: "NYC"}}))
+	requireRowStatus(siteHost.UUID, nil)
+	requireRowStatus(noTeamHost.UUID, nil)
+	requireRowStatus(codeHost.UUID, &fleet.MDMDeliveryVerifying)
+}
+
+// TestHostNameTemplateIDPGroupChange covers the SCIM group-change re-enqueue path:
+// renaming a group re-queues hosts whose template uses the groups variable, but not
+// a host (mapped to the same user) whose template uses only the username variable.
+func (s *integrationMDMTestSuite) TestHostNameTemplateIDPGroupChange() {
+	t := s.T()
+	ctx := t.Context()
+
+	setFleetMDMData := func(hostID uint) {
+		require.NoError(t, s.ds.SetOrUpdateMDMData(ctx, hostID, false, true, s.server.URL, false, fleet.WellKnownMDMFleet, "", false))
+	}
+	requireRowStatus := func(hostUUID string, want *fleet.MDMDeliveryStatus) *fleet.HostDeviceNameEnforcement {
+		row, err := s.ds.GetHostDeviceNameEnforcement(ctx, hostUUID)
+		require.NoError(t, err)
+		if want == nil {
+			require.Nil(t, row.Status)
+		} else {
+			require.NotNil(t, row.Status)
+			require.Equal(t, *want, *row.Status)
+		}
+		return row
+	}
+	deviceNameFromCmd := func(raw []byte) string {
+		var sc struct {
+			Command struct {
+				Settings []struct {
+					Item       string
+					DeviceName string
+				}
+			}
+		}
+		require.NoError(t, plist.Unmarshal(raw, &sc))
+		require.Len(t, sc.Command.Settings, 1)
+		return sc.Command.Settings[0].DeviceName
+	}
+
+	// A user who belongs to a SCIM group. (Usernames/group names are unique per
+	// test — the integration suite shares one DB and scim_users.user_name is unique.)
+	userID, err := s.ds.CreateScimUser(ctx, &fleet.ScimUser{UserName: "jdoe@group.example.com"})
+	require.NoError(t, err)
+	groupID, err := s.ds.CreateScimGroup(ctx, &fleet.ScimGroup{DisplayName: "GCAdmins", ScimUsers: []uint{userID}})
+	require.NoError(t, err)
+
+	// A team whose template uses the groups variable.
+	groupTeam, err := s.ds.NewTeam(ctx, &fleet.Team{Name: t.Name() + "-groups"})
+	require.NoError(t, err)
+	groupHost, groupDevice := createHostThenEnrollMDM(s.ds, s.server.URL, t)
+	setFleetMDMData(groupHost.ID)
+	_, err = s.ds.SetOrUpdateHostSCIMUserMapping(ctx, groupHost.ID, userID)
+	require.NoError(t, err)
+	require.NoError(t, s.ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&groupTeam.ID, []uint{groupHost.ID})))
+
+	// A team whose template uses only the username variable, with a host mapped to
+	// the *same* user.
+	userTeam, err := s.ds.NewTeam(ctx, &fleet.Team{Name: t.Name() + "-user"})
+	require.NoError(t, err)
+	userHost, userDevice := createHostThenEnrollMDM(s.ds, s.server.URL, t)
+	setFleetMDMData(userHost.ID)
+	_, err = s.ds.SetOrUpdateHostSCIMUserMapping(ctx, userHost.ID, userID)
+	require.NoError(t, err)
+	require.NoError(t, s.ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&userTeam.ID, []uint{userHost.ID})))
+
+	s.Do("POST", "/api/latest/fleet/host_name_template",
+		updateHostNameTemplateRequest{FleetID: &groupTeam.ID, HostNameTemplate: "G-$FLEET_VAR_HOST_END_USER_IDP_GROUPS"}, http.StatusNoContent)
+	s.Do("POST", "/api/latest/fleet/host_name_template",
+		updateHostNameTemplateRequest{FleetID: &userTeam.ID, HostNameTemplate: "U-$FLEET_VAR_HOST_END_USER_IDP_USERNAME"}, http.StatusNoContent)
+
+	// Drive both to a settled (verifying) state.
+	require.NoError(t, ReconcileHostDeviceNames(ctx, s.ds, s.mdmCommander, s.logger))
+	groupRow := requireRowStatus(groupHost.UUID, &fleet.MDMDeliveryPending)
+	require.NotNil(t, groupRow.ExpectedDeviceName)
+	require.Equal(t, "G-GCAdmins", *groupRow.ExpectedDeviceName)
+	for _, d := range []*mdmtest.TestAppleMDMClient{groupDevice, userDevice} {
+		cmd, err := d.Idle()
+		require.NoError(t, err)
+		require.NotNil(t, cmd)
+		_, err = d.Acknowledge(cmd.CommandUUID)
+		require.NoError(t, err)
+	}
+	requireRowStatus(groupHost.UUID, &fleet.MDMDeliveryVerifying)
+	requireRowStatus(userHost.UUID, &fleet.MDMDeliveryVerifying)
+
+	// Renaming the group re-queues the groups-template host (its resolved name
+	// changes) but leaves the username-template host — mapped to the same user —
+	// untouched.
+	require.NoError(t, s.ds.ReplaceScimGroup(ctx, &fleet.ScimGroup{ID: groupID, DisplayName: "GCSupers", ScimUsers: []uint{userID}}))
+	requireRowStatus(groupHost.UUID, nil)
+	requireRowStatus(userHost.UUID, &fleet.MDMDeliveryVerifying)
+
+	require.NoError(t, ReconcileHostDeviceNames(ctx, s.ds, s.mdmCommander, s.logger))
+	newRow := requireRowStatus(groupHost.UUID, &fleet.MDMDeliveryPending)
+	require.NotNil(t, newRow.ExpectedDeviceName)
+	require.Equal(t, "G-GCSupers", *newRow.ExpectedDeviceName)
+	cmd, err := groupDevice.Idle()
+	require.NoError(t, err)
+	require.NotNil(t, cmd)
+	require.Equal(t, "G-GCSupers", deviceNameFromCmd(cmd.Raw))
+}
+
+// TestHostNameTemplateTeamSpecSecret covers the team-spec (GitOps) apply path with a
+// template referencing a custom (secret) variable: it validates on create and edit,
+// is idempotent on re-apply, and rejects an undefined secret.
+func (s *integrationMDMTestSuite) TestHostNameTemplateTeamSpecSecret() {
+	t := s.T()
+	ctx := t.Context()
+
+	_, err := s.ds.CreateSecretVariable(ctx, "SPECSITE", "HQ")
+	require.NoError(t, err)
+
+	teamName := t.Name()
+	applySpec := func(tmpl string, wantStatus int) *http.Response {
+		return s.Do("POST", "/api/latest/fleet/spec/teams", applyTeamSpecsRequest{Specs: []*fleet.TeamSpec{{
+			Name: teamName,
+			MDM:  fleet.TeamSpecMDM{HostNameTemplate: optjson.SetString(tmpl)},
+		}}}, wantStatus)
+	}
+
+	// Create the team via spec with a valid secret template — the team-spec path
+	// (createTeamFromSpec) validates the referenced secret and stores the template.
+	applySpec("iPad ${FLEET_SECRET_SPECSITE}", http.StatusOK) //nolint:gosec // G101: template
+	team, err := s.ds.TeamByName(ctx, teamName)
+	require.NoError(t, err)
+	require.Equal(t, "iPad ${FLEET_SECRET_SPECSITE}", team.Config.MDM.HostNameTemplate)
+
+	// Re-applying the identical spec succeeds and is idempotent — the change-gate
+	// skips re-validation and leaves the stored template unchanged.
+	applySpec("iPad ${FLEET_SECRET_SPECSITE}", http.StatusOK) //nolint:gosec // G101: template
+	teamAfter, err := s.ds.TeamByName(ctx, teamName)
+	require.NoError(t, err)
+	require.Equal(t, "iPad ${FLEET_SECRET_SPECSITE}", teamAfter.Config.MDM.HostNameTemplate)
+
+	// A spec referencing an undefined secret is rejected.
+	res := applySpec("iPad ${FLEET_SECRET_NOPE}", http.StatusUnprocessableEntity) //nolint:gosec // G101: template
+	require.Contains(t, extractServerErrorText(res.Body), "missing from database")
 }
 
 func (s *integrationMDMTestSuite) TestHostNameTemplateTransferTeamToNoTeam() {


### PR DESCRIPTION
Relates to #38806

Extend host name templates beyond the three host-identity variables to also accept the IdP end-user variables, and re-enqueue the rename when a referenced variable's value changes.

Re-enqueue on value change:
- An IdP data change (SCIM user/group create/update/delete) re-queues only the affected hosts whose template uses the changed IdP variable — IdP values are per host, so the scope is the specific hosts mapped to that user/group.
- A custom (secret) value change re-queues every eligible host in each team / "No team" whose template references the changed secret — secret values are global, so the scope is the whole team/No-team.

Built-in variables intentionally NOT supported:
- Certificate/CA variables — $FLEET_VAR_NDES_SCEP_CHALLENGE, _NDES_SCEP_PROXY_URL, _CUSTOM_SCEP_CHALLENGE_*, _CUSTOM_SCEP_PROXY_URL_*, _SMALLSTEP_SCEP_CHALLENGE_*, _SMALLSTEP_SCEP_PROXY_URL_*, _DIGICERT_DATA_*, _DIGICERT_PASSWORD_*, _SCEP_WINDOWS_CERTIFICATE_ID, _CERTIFICATE_RENEWAL_ID (and legacy _SCEP_RENEWAL_ID), _PSSO_DEVICE_REGISTRATION_TOKEN. These resolve to one-time SCEP challenges, proxy URLs, base64 PKCS12 cert data, or Fleet-minted tokens — meaningless as a device name, and resolving them has side effects (issuing certificates, consuming one-time challenges) and would leak secrets into a name that's broadcast on-device, in osquery, and in the UI.
- Legacy $FLEET_VAR_HOST_END_USER_EMAIL_IDP — deprecated ("avoid in new replacements") and not a documented built-in variable, so it's excluded in favor of the supported IDP_USERNAME variables.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

## Testing

- [X] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Host name templates now support additional identity-provider attributes (username, groups, full name, department, username local part).
  - Apple host device-name reconciliation now resolves identity-provider variables when generating device names.
- **Bug Fixes**
  - Device-name enforcement is re-queued when referenced secret values or supported identity-provider variables change, with correct scoping and retry behavior.
  - Host name template validation and MDM error classification are improved (secret-related issues treated as user input where appropriate).
  - Global template usage errors are now labeled **“Unassigned”**.
  - GitOps team-spec handling for `name_template` better supports secret placeholders and preserves them for server-side processing.
- **Tests**
  - Expanded unit and integration coverage for identity-provider, secret-variable, and re-enqueue scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->