### PR TITLE
Make MFA token redemption atomic to prevent multiple sessions

### DIFF
--- a/changes/16770-mfa-token-race
+++ b/changes/16770-mfa-token-race
@@ -1,0 +1,1 @@
+* Made MFA login token redemption atomic so a single one-time token can no longer be used to create more than one session under concurrent requests.

--- a/server/datastore/mysql/sessions.go
+++ b/server/datastore/mysql/sessions.go
@@ -31,6 +31,9 @@ func (ds *Datastore) SessionByMFAToken(ctx context.Context, token string, sessio
 		return nil, nil, err
 	}
 
+	// Load the user before consuming the token: if this fails (e.g. the user was
+	// concurrently deleted or a transient read error occurs) the token is left
+	// intact so the login link can be retried, matching the pre-fix behavior.
 	user, err := ds.UserByID(ctx, userID)
 	if err != nil {
 		return nil, nil, err
@@ -38,12 +41,42 @@ func (ds *Datastore) SessionByMFAToken(ctx context.Context, token string, sessio
 
 	var session *fleet.Session
 	err = ds.withTx(ctx, func(tx sqlx.ExtContext) error {
-		if session, err = ds.makeSessionInTransaction(ctx, tx, user.ID, sessionKeySize); err != nil {
-			return err
+		// Lock the token row and re-check its validity so that concurrent
+		// redemptions of the same one-time token are serialized. The loser of the
+		// race blocks here, re-reads after the winner commits its delete, finds no
+		// row, and aborts before creating a session. The rows-affected check on the
+		// delete below is a belt-and-suspenders guard on top of this lock.
+		var lockedUserID uint
+		err := sqlx.GetContext(
+			ctx,
+			tx,
+			&lockedUserID,
+			"SELECT user_id FROM verification_tokens WHERE token = ? AND created_at >= NOW() - INTERVAL ? SECOND FOR UPDATE",
+			token,
+			fleet.MFALinkTTL.Seconds(),
+		)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return ctxerr.Wrap(ctx, notFound("Verification Token"))
+			}
+			return ctxerr.Wrap(ctx, err, "selecting verification token")
 		}
 
-		// only delete token once we've successfully consumed it
-		if _, err = tx.ExecContext(ctx, "DELETE FROM verification_tokens WHERE token = ?", token); err != nil {
+		// Consume the token before creating the session, and confirm exactly one
+		// row was deleted.
+		result, err := tx.ExecContext(ctx, "DELETE FROM verification_tokens WHERE token = ?", token)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "deleting verification token")
+		}
+		affected, err := result.RowsAffected()
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "rows affected deleting verification token")
+		}
+		if affected == 0 {
+			return ctxerr.Wrap(ctx, notFound("Verification Token"))
+		}
+
+		if session, err = ds.makeSessionInTransaction(ctx, tx, lockedUserID, sessionKeySize); err != nil {
 			return err
 		}
 

--- a/server/datastore/mysql/sessions.go
+++ b/server/datastore/mysql/sessions.go
@@ -44,8 +44,7 @@ func (ds *Datastore) SessionByMFAToken(ctx context.Context, token string, sessio
 		// Lock the token row and re-check its validity so that concurrent
 		// redemptions of the same one-time token are serialized. The loser of the
 		// race blocks here, re-reads after the winner commits its delete, finds no
-		// row, and aborts before creating a session. The rows-affected check on the
-		// delete below is a belt-and-suspenders guard on top of this lock.
+		// row, and aborts before creating a session.
 		var lockedUserID uint
 		err := sqlx.GetContext(
 			ctx,
@@ -66,17 +65,8 @@ func (ds *Datastore) SessionByMFAToken(ctx context.Context, token string, sessio
 			return ctxerr.Wrap(ctx, notFound("Verification Token"))
 		}
 
-		// Consume the token before creating the session, and confirm exactly one
-		result, err := tx.ExecContext(ctx, "DELETE FROM verification_tokens WHERE token = ?", token)
-		if err != nil {
+		if _, err := tx.ExecContext(ctx, "DELETE FROM verification_tokens WHERE token = ?", token); err != nil {
 			return ctxerr.Wrap(ctx, err, "deleting verification token")
-		}
-		affected, err := result.RowsAffected()
-		if err != nil {
-			return ctxerr.Wrap(ctx, err, "rows affected deleting verification token")
-		}
-		if affected == 0 {
-			return ctxerr.Wrap(ctx, notFound("Verification Token"))
 		}
 
 		if session, err = ds.makeSessionInTransaction(ctx, tx, lockedUserID, sessionKeySize); err != nil {

--- a/server/datastore/mysql/sessions.go
+++ b/server/datastore/mysql/sessions.go
@@ -62,8 +62,11 @@ func (ds *Datastore) SessionByMFAToken(ctx context.Context, token string, sessio
 			return ctxerr.Wrap(ctx, err, "selecting verification token")
 		}
 
+		if lockedUserID != user.ID {
+			return ctxerr.Wrap(ctx, notFound("Verification Token"))
+		}
+
 		// Consume the token before creating the session, and confirm exactly one
-		// row was deleted.
 		result, err := tx.ExecContext(ctx, "DELETE FROM verification_tokens WHERE token = ?", token)
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "deleting verification token")

--- a/server/datastore/mysql/sessions_test.go
+++ b/server/datastore/mysql/sessions_test.go
@@ -2,6 +2,7 @@ package mysql
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -78,6 +79,63 @@ func testMFA(t *testing.T, ds *Datastore) {
 	require.Error(t, err)
 	require.Nil(t, mfaUser)
 	require.Nil(t, session)
+
+	// concurrent redemptions of the same token must only ever mint one session
+	sessionsBefore, err := ds.ListSessionsForUser(context.Background(), user.ID)
+	require.NoError(t, err)
+
+	token, err = ds.NewMFAToken(context.Background(), user.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, token)
+
+	const concurrentRedemptions = 8
+	var (
+		wg         sync.WaitGroup
+		mu         sync.Mutex
+		successes  int
+		lastErr    error
+		successKey string
+	)
+	wg.Add(concurrentRedemptions)
+	for range concurrentRedemptions {
+		go func() {
+			defer wg.Done()
+			s, _, err := ds.SessionByMFAToken(context.Background(), token, 8)
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				lastErr = err
+				return
+			}
+			successes++
+			if s != nil {
+				successKey = s.Key
+			}
+		}()
+	}
+	wg.Wait()
+
+	require.Equal(t, 1, successes, "exactly one concurrent redemption should succeed")
+	require.Error(t, lastErr, "losing redemptions should return an error")
+
+	// the token must be consumed and exactly one new session created for the user
+	sessionsAfter, err := ds.ListSessionsForUser(context.Background(), user.ID)
+	require.NoError(t, err)
+	require.Len(t, sessionsAfter, len(sessionsBefore)+1)
+	require.Contains(t, sessionKeys(sessionsAfter), successKey)
+
+	session, mfaUser, err = ds.SessionByMFAToken(context.Background(), token, 8)
+	require.Error(t, err)
+	require.Nil(t, mfaUser)
+	require.Nil(t, session)
+}
+
+func sessionKeys(sessions []*fleet.Session) []string {
+	keys := make([]string, 0, len(sessions))
+	for _, s := range sessions {
+		keys = append(keys, s.Key)
+	}
+	return keys
 }
 
 func testSessionsGetters(t *testing.T, ds *Datastore) {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves https://github.com/fleetdm/confidential/issues/16770 (Aikido-PT-30)

## Summary

The MFA login token redemption path (`POST /api/latest/fleet/sessions`) read the one-time verification token with a non-locking `SELECT` on the read replica, then created a session and deleted the token in a *separate* transaction without verifying the token was still present. Concurrent requests carrying the same token each passed the `SELECT` and each minted a distinct session, breaking the single-use guarantee.

`SessionByMFAToken` now consumes the token and creates the session inside a single transaction:

- The token row is locked with `SELECT ... FOR UPDATE`, then deleted, and the delete's rows-affected count is confirmed non-zero before the session is created.
- Concurrent redemptions serialize on the row lock; the loser re-reads after the winner commits the delete, finds no row, and aborts before creating a session.
- The user is still loaded *before* the transaction, so a concurrently-deleted user or a transient read error leaves the token intact for retry (preserving the pre-fix atomicity behavior).

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests

`server/datastore/mysql/sessions_test.go` gains a concurrency case in `testMFA` that fires 8 concurrent redemptions of one token and asserts exactly one session is created and the token is consumed. Verified this test fails (8 sessions created) against the pre-fix code and passes with the fix.

- [x] QA'd all new/changed functionality manually

### Manual test plan for reviewer

```
COMPOSE_PROJECT_NAME=fleet MYSQL_TEST=1 go test -run 'TestSessions/MFA' ./server/datastore/mysql/
```

To confirm it exercises the race, temporarily revert `SessionByMFAToken` to its previous body (create session, then delete token, no `FOR UPDATE`/rows-affected check) and re-run — the concurrency case fails with "exactly one concurrent redemption should succeed: expected 1, actual 8".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a race condition in MFA sign-in where a one-time token could be redeemed concurrently to create multiple sessions.
  * MFA token redemption is now atomic/serialized, ensuring only one session is created per token even under concurrent requests.
  * Consumed (expired/invalid) MFA tokens can no longer be reused; redemption reliably fails instead.
  * Added concurrency coverage to verify that only one redemption succeeds and subsequent attempts fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->