### PR TITLE
Fleet UI: Hide My device button on unusable hosts

### DIFF
--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -141,7 +141,7 @@ import {
 } from "../helpers";
 import WipeModal from "./modals/WipeModal";
 import { parseHostSoftwareQueryParams } from "../cards/Software/HostSoftware";
-import { getErrorMessage } from "./helpers";
+import { canShowMyDeviceButton, getErrorMessage } from "./helpers";
 import CancelActivityModal from "./modals/CancelActivityModal";
 import CertificateDetailsModal from "../modals/CertificateDetailsModal";
 import HostHeader from "../cards/HostHeader";
@@ -1312,10 +1312,9 @@ const HostDetailsPage = ({
 
   // "My device" link points to that host's end-user My device page. The URL
   // embeds the device auth token so it acts as a credential, hence global
-  // admin only. The endpoint guarantees a valid link on every fetch — it
-  // refreshes an expired token or generates one for a host that has never
-  // had one — so we don't gate visibility on orbit/MDM state.
-  const canViewMyDeviceLink = isGlobalAdmin;
+  // admin only. Also hide it on hosts that have no live end-user surface —
+  // no Fleet Desktop (so no token, and no page to load) or wiped.
+  const canViewMyDeviceLink = isGlobalAdmin && canShowMyDeviceButton(host);
 
   const showSoftwareLibraryTab = isPremiumTier;
   const showReportsEmptyState = host.mdm?.enrollment_status === "Pending";

--- a/frontend/pages/hosts/details/HostDetailsPage/helpers.tests.ts
+++ b/frontend/pages/hosts/details/HostDetailsPage/helpers.tests.ts
@@ -1,0 +1,34 @@
+import createMockHost from "__mocks__/hostMock";
+
+import { canShowMyDeviceButton } from "./helpers";
+
+describe("canShowMyDeviceButton", () => {
+  it("returns true when Fleet Desktop is installed and the host is not wiped", () => {
+    const host = createMockHost({
+      fleet_desktop_version: "1.22.1",
+      mdm: { ...createMockHost().mdm, device_status: "unlocked" },
+    });
+    expect(canShowMyDeviceButton(host)).toBe(true);
+  });
+
+  it("returns true for a locked host that still has Fleet Desktop", () => {
+    const host = createMockHost({
+      fleet_desktop_version: "1.22.1",
+      mdm: { ...createMockHost().mdm, device_status: "locked" },
+    });
+    expect(canShowMyDeviceButton(host)).toBe(true);
+  });
+
+  it("returns false when Fleet Desktop is not installed", () => {
+    const host = createMockHost({ fleet_desktop_version: null });
+    expect(canShowMyDeviceButton(host)).toBe(false);
+  });
+
+  it("returns false when the host has been wiped", () => {
+    const host = createMockHost({
+      fleet_desktop_version: "1.22.1",
+      mdm: { ...createMockHost().mdm, device_status: "wiped" },
+    });
+    expect(canShowMyDeviceButton(host)).toBe(false);
+  });
+});

--- a/frontend/pages/hosts/details/HostDetailsPage/helpers.tests.ts
+++ b/frontend/pages/hosts/details/HostDetailsPage/helpers.tests.ts
@@ -43,4 +43,18 @@ describe("canShowMyDeviceButton", () => {
     });
     expect(canShowMyDeviceButton(host)).toBe(false);
   });
+
+  // Only wipe-related states hide the button. Other transient states leave the
+  // end-user page reachable, so the button stays visible.
+  it("returns true for non-wipe transient states like clear_passcode", () => {
+    const host = createMockHost({
+      fleet_desktop_version: "1.22.1",
+      mdm: {
+        ...createMockHost().mdm,
+        device_status: "unlocked",
+        pending_action: "clear_passcode",
+      },
+    });
+    expect(canShowMyDeviceButton(host)).toBe(true);
+  });
 });

--- a/frontend/pages/hosts/details/HostDetailsPage/helpers.tests.ts
+++ b/frontend/pages/hosts/details/HostDetailsPage/helpers.tests.ts
@@ -31,4 +31,16 @@ describe("canShowMyDeviceButton", () => {
     });
     expect(canShowMyDeviceButton(host)).toBe(false);
   });
+
+  it("returns false when the host has a wipe in flight", () => {
+    const host = createMockHost({
+      fleet_desktop_version: "1.22.1",
+      mdm: {
+        ...createMockHost().mdm,
+        device_status: "unlocked",
+        pending_action: "wipe",
+      },
+    });
+    expect(canShowMyDeviceButton(host)).toBe(false);
+  });
 });

--- a/frontend/pages/hosts/details/HostDetailsPage/helpers.ts
+++ b/frontend/pages/hosts/details/HostDetailsPage/helpers.ts
@@ -1,8 +1,8 @@
 import { getErrorReason } from "interfaces/errors";
+import { IHost } from "interfaces/host";
 
 const DEFAULT_ERROR_MESSAGE = "refetch error.";
 
-// eslint-disable-next-line import/prefer-default-export
 export const getErrorMessage = (e: unknown, hostName: string) => {
   let errorMessage = getErrorReason(e, {
     reasonIncludes: "Host does not have MDM turned on",
@@ -14,3 +14,11 @@ export const getErrorMessage = (e: unknown, hostName: string) => {
 
   return `Host "${hostName}" ${errorMessage}`;
 };
+
+// The "My device" link opens the end-user page authed by the host's device
+// auth token. Fleet Desktop is what mints that token on orbit check-in, so a
+// host missing fleet_desktop_version is also missing a token and has no live
+// end-user surface. A wiped host has no end-user session to review either.
+export const canShowMyDeviceButton = (
+  host: Pick<IHost, "fleet_desktop_version" | "mdm">
+) => !!host.fleet_desktop_version && host.mdm.device_status !== "wiped";

--- a/frontend/pages/hosts/details/HostDetailsPage/helpers.ts
+++ b/frontend/pages/hosts/details/HostDetailsPage/helpers.ts
@@ -1,6 +1,8 @@
 import { getErrorReason } from "interfaces/errors";
 import { IHost } from "interfaces/host";
 
+import { getHostDeviceStatusUIState } from "../helpers";
+
 const DEFAULT_ERROR_MESSAGE = "refetch error.";
 
 export const getErrorMessage = (e: unknown, hostName: string) => {
@@ -18,7 +20,15 @@ export const getErrorMessage = (e: unknown, hostName: string) => {
 // The "My device" link opens the end-user page authed by the host's device
 // auth token. Fleet Desktop is what mints that token on orbit check-in, so a
 // host missing fleet_desktop_version is also missing a token and has no live
-// end-user surface. A wiped host has no end-user session to review either.
+// end-user surface. Hide the button on wiped hosts and on hosts with a wipe
+// in flight — the device is about to have no end-user session to review.
 export const canShowMyDeviceButton = (
   host: Pick<IHost, "fleet_desktop_version" | "mdm">
-) => !!host.fleet_desktop_version && host.mdm.device_status !== "wiped";
+) => {
+  if (!host.fleet_desktop_version) return false;
+  const uiState = getHostDeviceStatusUIState(
+    host.mdm.device_status,
+    host.mdm.pending_action
+  );
+  return uiState !== "wiped" && uiState !== "wiping";
+};


### PR DESCRIPTION
## Issue
Closes #47882

## Description
- Bug fix (root cause): `canViewMyDeviceLink` was `isGlobalAdmin` only, so the "My device" button showed on every host regardless of whether the target had a live end-user surface — including unenrolled hosts, hosts without Fleet Desktop, and wiped hosts.
- Gate visibility on `fleet_desktop_version` (Fleet Desktop is what mints the device auth token, so its absence covers "not enrolled / no token / no page to load") and on `mdm.device_status !== "wiped"`. Global-admin restriction unchanged.
- Extracted the check into `canShowMyDeviceButton` in `HostDetailsPage/helpers.ts` so it's covered by a unit test.

## Screenrecording
- Host details "User" card with the button hidden on a wiped / no-Fleet-Desktop host and shown on a healthy enrolled host


<!-- recording -->


## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved visibility of the “My device” link on host details.
  * The link is now hidden when Fleet Desktop is unavailable or the device has been wiped or is currently being wiped.
  * The link remains available for supported device states, including locked devices and non-wipe actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->