### PR TITLE
Fix patch policy for swiftDialog to not pick up orbit installation

### DIFF
--- a/ee/maintained-apps/ingesters/homebrew/ingester.go
+++ b/ee/maintained-apps/ingesters/homebrew/ingester.go
@@ -147,6 +147,15 @@ func (i *brewIngester) ingestOne(ctx context.Context, input inputApp) (*maintain
 	out.UniqueIdentifier = input.UniqueIdentifier
 	out.SHA256 = cask.SHA256
 	out.Queries = maintained_apps.FMAQueries{Exists: fmt.Sprintf("SELECT 1 FROM apps WHERE bundle_identifier = '%s';", out.UniqueIdentifier)}
+	if input.Token == "swiftdialog" {
+		// Orbit installs swiftDialog v2.5.6 for setup experience, MDM migration, or enrollment
+		// profile renewal; don't treat orbit's copy as the installed app for install or patch status.
+		// The patch policy generated below inherits this exclusion.
+		out.Queries.Exists = fmt.Sprintf(
+			"SELECT 1 FROM apps WHERE bundle_identifier = '%s' AND path != '/opt/orbit/bin/swiftDialog/macos/stable/Dialog.app';",
+			out.UniqueIdentifier,
+		)
+	}
 	out.Slug = input.Slug
 	out.DefaultCategories = input.DefaultCategories
 
@@ -213,7 +222,6 @@ func (i *brewIngester) ingestOne(ctx context.Context, input inputApp) (*maintain
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "creating patch policy")
 	}
-
 	if input.Token == "docker-desktop" {
 		// Docker's updater can leave Docker.app.back; do not treat it as the installed app for patch status.
 		out.Queries.Patched = fmt.Sprintf(
@@ -228,13 +236,6 @@ func (i *brewIngester) ingestOne(ctx context.Context, input inputApp) (*maintain
 		// patch status reflects the actual installed build.
 		out.Queries.Patched = fmt.Sprintf(
 			"SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = '%s' AND version_compare(bundle_version, '%s') < 0);",
-			out.UniqueIdentifier, out.Version,
-		)
-	}
-	if input.Token == "swiftdialog" {
-		// Orbit installs swiftDialog v2.5.6 for setup experience, MDM migration, or enrollment profile renewal; do not consider it for patch status.
-		out.Queries.Patched = fmt.Sprintf(
-			"SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = '%s' AND version_compare(bundle_short_version, '%s') < 0 AND path != '/opt/orbit/bin/swiftDialog/macos/stable/Dialog.app');",
 			out.UniqueIdentifier, out.Version,
 		)
 	}

--- a/ee/maintained-apps/ingesters/homebrew/ingester.go
+++ b/ee/maintained-apps/ingesters/homebrew/ingester.go
@@ -234,7 +234,7 @@ func (i *brewIngester) ingestOne(ctx context.Context, input inputApp) (*maintain
 	if input.Token == "swiftdialog" {
 		// Orbit installs swiftDialog v2.5.6 for setup experience, MDM migration, or enrollment profile renewal; do not consider it for patch status.
 		out.Queries.Patched = fmt.Sprintf(
-			"SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = '%s' AND version_compare(bundle_short_version, '%s') < 0 AND path NOT LIKE '/opt/orbit/bin/%%');",
+			"SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = '%s' AND version_compare(bundle_short_version, '%s') < 0 AND path != '/opt/orbit/bin/swiftDialog/macos/stable/Dialog.app');",
 			out.UniqueIdentifier, out.Version,
 		)
 	}

--- a/ee/maintained-apps/ingesters/homebrew/ingester.go
+++ b/ee/maintained-apps/ingesters/homebrew/ingester.go
@@ -213,6 +213,7 @@ func (i *brewIngester) ingestOne(ctx context.Context, input inputApp) (*maintain
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "creating patch policy")
 	}
+
 	if input.Token == "docker-desktop" {
 		// Docker's updater can leave Docker.app.back; do not treat it as the installed app for patch status.
 		out.Queries.Patched = fmt.Sprintf(
@@ -227,6 +228,13 @@ func (i *brewIngester) ingestOne(ctx context.Context, input inputApp) (*maintain
 		// patch status reflects the actual installed build.
 		out.Queries.Patched = fmt.Sprintf(
 			"SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = '%s' AND version_compare(bundle_version, '%s') < 0);",
+			out.UniqueIdentifier, out.Version,
+		)
+	}
+	if input.Token == "swiftdialog" {
+		// Orbit installs swiftDialog v2.5.6 when mdm migration is enabled, do not consider it for patch status.
+		out.Queries.Patched = fmt.Sprintf(
+			"SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = '%s' AND version_compare(bundle_short_version, '%s') < 0 AND path NOT LIKE '/opt/orbit/bin/%%');",
 			out.UniqueIdentifier, out.Version,
 		)
 	}

--- a/ee/maintained-apps/ingesters/homebrew/ingester.go
+++ b/ee/maintained-apps/ingesters/homebrew/ingester.go
@@ -232,7 +232,7 @@ func (i *brewIngester) ingestOne(ctx context.Context, input inputApp) (*maintain
 		)
 	}
 	if input.Token == "swiftdialog" {
-		// Orbit installs swiftDialog v2.5.6 when mdm migration is enabled, do not consider it for patch status.
+		// Orbit installs swiftDialog v2.5.6 for setup experience, MDM migration, or enrollment profile renewal; do not consider it for patch status.
 		out.Queries.Patched = fmt.Sprintf(
 			"SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = '%s' AND version_compare(bundle_short_version, '%s') < 0 AND path NOT LIKE '/opt/orbit/bin/%%');",
 			out.UniqueIdentifier, out.Version,

--- a/ee/maintained-apps/ingesters/homebrew/ingester_test.go
+++ b/ee/maintained-apps/ingesters/homebrew/ingester_test.go
@@ -153,19 +153,20 @@ func TestIngestValidations(t *testing.T) {
 				require.Equal(t, testUninstallScriptContents, out.UninstallScript)
 			}
 
-			if c.inputApp.Token == "docker-desktop" {
+			switch c.inputApp.Token {
+			case "docker-desktop":
 				require.Equal(t, "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.dockerdesktop';", out.Queries.Exists)
 				require.Equal(t,
 					"SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.dockerdesktop' AND path NOT LIKE '%.back' AND version_compare(bundle_short_version, '1.0') < 0);",
 					out.Queries.Patched,
 				)
-			} else if c.inputApp.Token == "swiftdialog" {
+			case "swiftdialog":
 				require.Equal(t, "SELECT 1 FROM apps WHERE bundle_identifier = 'au.csiro.dialog';", out.Queries.Exists)
 				require.Equal(t,
 					"SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'au.csiro.dialog' AND version_compare(bundle_short_version, '1.0') < 0 AND path NOT LIKE '/opt/orbit/bin/%');",
 					out.Queries.Patched,
 				)
-			} else {
+			default:
 				require.Equal(t,
 					fmt.Sprintf("SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = '%s' AND version_compare(bundle_short_version, '%s') < 0);", c.inputApp.UniqueIdentifier, out.Version),
 					out.Queries.Patched,

--- a/ee/maintained-apps/ingesters/homebrew/ingester_test.go
+++ b/ee/maintained-apps/ingesters/homebrew/ingester_test.go
@@ -163,7 +163,7 @@ func TestIngestValidations(t *testing.T) {
 			case "swiftdialog":
 				require.Equal(t, "SELECT 1 FROM apps WHERE bundle_identifier = 'au.csiro.dialog';", out.Queries.Exists)
 				require.Equal(t,
-					"SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'au.csiro.dialog' AND version_compare(bundle_short_version, '1.0') < 0 AND path NOT LIKE '/opt/orbit/bin/%');",
+					"SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'au.csiro.dialog' AND version_compare(bundle_short_version, '1.0') < 0 AND path != '/opt/orbit/bin/swiftDialog/macos/stable/Dialog.app');",
 					out.Queries.Patched,
 				)
 			default:

--- a/ee/maintained-apps/ingesters/homebrew/ingester_test.go
+++ b/ee/maintained-apps/ingesters/homebrew/ingester_test.go
@@ -161,9 +161,9 @@ func TestIngestValidations(t *testing.T) {
 					out.Queries.Patched,
 				)
 			case "swiftdialog":
-				require.Equal(t, "SELECT 1 FROM apps WHERE bundle_identifier = 'au.csiro.dialog';", out.Queries.Exists)
+				require.Equal(t, "SELECT 1 FROM apps WHERE bundle_identifier = 'au.csiro.dialog' AND path != '/opt/orbit/bin/swiftDialog/macos/stable/Dialog.app';", out.Queries.Exists)
 				require.Equal(t,
-					"SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'au.csiro.dialog' AND version_compare(bundle_short_version, '1.0') < 0 AND path != '/opt/orbit/bin/swiftDialog/macos/stable/Dialog.app');",
+					"SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'au.csiro.dialog' AND path != '/opt/orbit/bin/swiftDialog/macos/stable/Dialog.app' AND version_compare(bundle_short_version, '1.0') < 0);",
 					out.Queries.Patched,
 				)
 			default:

--- a/ee/maintained-apps/ingesters/homebrew/ingester_test.go
+++ b/ee/maintained-apps/ingesters/homebrew/ingester_test.go
@@ -87,7 +87,7 @@ func TestIngestValidations(t *testing.T) {
 				Version: "1.0",
 			}
 
-		case "ok", "docker-desktop", "install_script_path", "uninstall_script_path", "uninstall_script_path_with_pre", "uninstall_script_path_with_post", "patch_policy_path":
+		case "ok", "docker-desktop", "swiftdialog", "install_script_path", "uninstall_script_path", "uninstall_script_path_with_pre", "uninstall_script_path_with_post", "patch_policy_path":
 			cask = brewCask{
 				Token:   appToken,
 				Name:    []string{appToken},
@@ -121,6 +121,7 @@ func TestIngestValidations(t *testing.T) {
 		{"parse URL for cask invalidurl", inputApp{Token: "invalidurl", UniqueIdentifier: "abc", InstallerFormat: "pkg"}},
 		{"", inputApp{Token: "ok", UniqueIdentifier: "abc", InstallerFormat: "pkg"}},
 		{"", inputApp{Token: "docker-desktop", UniqueIdentifier: "com.electron.dockerdesktop", InstallerFormat: "dmg", Name: "Docker Desktop", Slug: "docker-desktop/darwin"}},
+		{"", inputApp{Token: "swiftdialog", UniqueIdentifier: "au.csiro.dialog", InstallerFormat: "pkg", Name: "swiftDialog", Slug: "swiftdialog/darwin"}},
 		{"", inputApp{Token: "install_script_path", UniqueIdentifier: "abc", InstallerFormat: "pkg", InstallScriptPath: path.Join(tempDir, "install_script.sh")}},
 		{"", inputApp{Token: "uninstall_script_path", UniqueIdentifier: "abc", InstallerFormat: "pkg", UninstallScriptPath: path.Join(tempDir, "uninstall_script.sh")}},
 		{"cannot provide pre-uninstall scripts if uninstall script is provided", inputApp{Token: "uninstall_script_path_with_pre", UniqueIdentifier: "abc", InstallerFormat: "pkg", UninstallScriptPath: path.Join(tempDir, "uninstall_script.sh"), PreUninstallScripts: []string{"foo", "bar"}}},
@@ -156,6 +157,12 @@ func TestIngestValidations(t *testing.T) {
 				require.Equal(t, "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.dockerdesktop';", out.Queries.Exists)
 				require.Equal(t,
 					"SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.dockerdesktop' AND path NOT LIKE '%.back' AND version_compare(bundle_short_version, '1.0') < 0);",
+					out.Queries.Patched,
+				)
+			} else if c.inputApp.Token == "swiftdialog" {
+				require.Equal(t, "SELECT 1 FROM apps WHERE bundle_identifier = 'au.csiro.dialog';", out.Queries.Exists)
+				require.Equal(t,
+					"SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'au.csiro.dialog' AND version_compare(bundle_short_version, '1.0') < 0 AND path NOT LIKE '/opt/orbit/bin/%');",
 					out.Queries.Patched,
 				)
 			} else {

--- a/ee/maintained-apps/outputs/swiftdialog/darwin.json
+++ b/ee/maintained-apps/outputs/swiftdialog/darwin.json
@@ -3,8 +3,8 @@
     {
       "version": "3.1.0",
       "queries": {
-        "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'au.csiro.dialog';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'au.csiro.dialog' AND version_compare(bundle_short_version, '3.1.0') < 0 AND path != '/opt/orbit/bin/swiftDialog/macos/stable/Dialog.app');"
+        "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'au.csiro.dialog' AND path != '/opt/orbit/bin/swiftDialog/macos/stable/Dialog.app';",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'au.csiro.dialog' AND path != '/opt/orbit/bin/swiftDialog/macos/stable/Dialog.app' AND version_compare(bundle_short_version, '3.1.0') < 0);"
       },
       "installer_url": "https://github.com/swiftDialog/swiftDialog/releases/download/v3.1.0/dialog-3.1.0-4994.pkg",
       "install_script_ref": "2b532b1c",

--- a/ee/maintained-apps/outputs/swiftdialog/darwin.json
+++ b/ee/maintained-apps/outputs/swiftdialog/darwin.json
@@ -4,7 +4,7 @@
       "version": "3.1.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'au.csiro.dialog';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'au.csiro.dialog' AND version_compare(bundle_short_version, '3.1.0') < 0 AND path NOT LIKE '/opt/orbit/bin/%');"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'au.csiro.dialog' AND version_compare(bundle_short_version, '3.1.0') < 0 AND path != '/opt/orbit/bin/swiftDialog/macos/stable/Dialog.app');"
       },
       "installer_url": "https://github.com/swiftDialog/swiftDialog/releases/download/v3.1.0/dialog-3.1.0-4994.pkg",
       "install_script_ref": "2b532b1c",

--- a/ee/maintained-apps/outputs/swiftdialog/darwin.json
+++ b/ee/maintained-apps/outputs/swiftdialog/darwin.json
@@ -4,7 +4,7 @@
       "version": "3.1.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'au.csiro.dialog';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'au.csiro.dialog' AND version_compare(bundle_short_version, '3.1.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'au.csiro.dialog' AND version_compare(bundle_short_version, '3.1.0') < 0 AND path NOT LIKE '/opt/orbit/bin/%');"
       },
       "installer_url": "https://github.com/swiftDialog/swiftDialog/releases/download/v3.1.0/dialog-3.1.0-4994.pkg",
       "install_script_ref": "2b532b1c",


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #48667
Changes:
Adds `AND path NOT LIKE '/opt/orbit/bin/%` to the path policy to not pick up the swiftDialog version orbit installs in `/opt/orbit/bin/swiftDialog/macos/stable/Dialog.app`. 
I kept it pretty open, but something like `AND path != '/opt/orbit/bin/swiftDialog/macos/stable/Dialog.app'` would also work.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
  - No changefile because this is a live change to an FMA manifest

## Testing

- [x] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually
<img width="2084" height="424" alt="image" src="https://github.com/user-attachments/assets/b69a6681-5018-4365-8a6c-4e962864c1c3" />
<img width="2084" height="554" alt="image" src="https://github.com/user-attachments/assets/75d97663-d44f-4691-aa53-7eb931093fb7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected SwiftDialog patch-status detection by ensuring Orbit-installed copies are excluded from patch/exists checks.
  * Tightened SwiftDialog query logic to require both bundle identifier match and a path exclusion, preventing incorrect outdated alerts.
* **Tests**
  * Expanded validation coverage for SwiftDialog Homebrew ingestions, including assertions for the updated exists/patched query conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->