### PR TITLE
Fix infinite spinner on Controls > OS settings and Scripts on Fleet Free

### DIFF
--- a/changes/49376-controls-free-tier-spinner.md
+++ b/changes/49376-controls-free-tier-spinner.md
@@ -1,1 +1,0 @@
-- Fixed Controls > OS settings and Controls > Scripts showing an infinite loading spinner on Fleet Free.

--- a/changes/49376-controls-free-tier-spinner.md
+++ b/changes/49376-controls-free-tier-spinner.md
@@ -1,0 +1,1 @@
+- Fixed Controls > OS settings and Controls > Scripts showing an infinite loading spinner on Fleet Free.

--- a/frontend/pages/ManageControlsPage/ManageControlsPage.tests.tsx
+++ b/frontend/pages/ManageControlsPage/ManageControlsPage.tests.tsx
@@ -22,7 +22,7 @@ const TestSubPage = ({ teamIdForApi }: { teamIdForApi?: number }) => (
 );
 
 const renderPage = (
-  isPremiumTier: boolean,
+  isPremiumTier: boolean | undefined,
   teamIdForApi: number | undefined
 ) => {
   mockUseTeamIdParam.mockReturnValue({
@@ -69,5 +69,12 @@ describe("ManageControlsPage - teamIdForApi forwarded to sub-pages", () => {
   it("forwards the resolved teamIdForApi on premium", () => {
     renderPage(true, 5);
     expect(screen.getByTestId("sub-page")).toHaveTextContent("teamIdForApi=5");
+  });
+
+  it("does not coerce to 'No team' while the tier is still unknown (config not loaded yet), to avoid premium users firing No-team queries on boot", () => {
+    renderPage(undefined, undefined);
+    expect(screen.getByTestId("sub-page")).toHaveTextContent(
+      "teamIdForApi=undefined"
+    );
   });
 });

--- a/frontend/pages/ManageControlsPage/ManageControlsPage.tests.tsx
+++ b/frontend/pages/ManageControlsPage/ManageControlsPage.tests.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+
+import PATHS from "router/paths";
+import { createCustomRenderer, createMockRouter } from "test/test-utils";
+
+import ManageControlsPage from "./ManageControlsPage";
+
+// Drive teamIdForApi directly so we can assert how ManageControlsPage forwards
+// it to its sub-pages. On free tier useTeamIdParam yields `undefined` (Controls
+// runs as "All teams", which it doesn't support); the page must coerce that to
+// "No team" (0) so sub-pages don't spin forever.
+const mockUseTeamIdParam = jest.fn();
+jest.mock("hooks/useTeamIdParam", () => ({
+  __esModule: true,
+  default: () => mockUseTeamIdParam(),
+}));
+
+// A stand-in Controls sub-page that surfaces the teamIdForApi it's handed.
+const TestSubPage = ({ teamIdForApi }: { teamIdForApi?: number }) => (
+  <div data-testid="sub-page">teamIdForApi={String(teamIdForApi)}</div>
+);
+
+const renderPage = (
+  isPremiumTier: boolean,
+  teamIdForApi: number | undefined
+) => {
+  mockUseTeamIdParam.mockReturnValue({
+    currentTeamId: teamIdForApi,
+    userTeams: [],
+    teamIdForApi,
+    handleTeamChange: jest.fn(),
+  });
+
+  const render = createCustomRenderer({
+    withBackendMock: true,
+    context: { app: { isPremiumTier, isGlobalAdmin: true } },
+  });
+
+  return render(
+    <ManageControlsPage
+      location={{
+        pathname: PATHS.CONTROLS_OS_SETTINGS,
+        search: "",
+        query: {},
+      }}
+      router={createMockRouter()}
+    >
+      <TestSubPage />
+    </ManageControlsPage>
+  );
+};
+
+describe("ManageControlsPage - teamIdForApi forwarded to sub-pages", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it("coerces undefined teamIdForApi to 'No team' (0) on free tier so sub-pages don't spin forever", () => {
+    renderPage(false, undefined);
+    expect(screen.getByTestId("sub-page")).toHaveTextContent("teamIdForApi=0");
+  });
+
+  it("keeps teamIdForApi undefined on premium while the selected fleet resolves (preserves the loading gate)", () => {
+    renderPage(true, undefined);
+    expect(screen.getByTestId("sub-page")).toHaveTextContent(
+      "teamIdForApi=undefined"
+    );
+  });
+
+  it("forwards the resolved teamIdForApi on premium", () => {
+    renderPage(true, 5);
+    expect(screen.getByTestId("sub-page")).toHaveTextContent("teamIdForApi=5");
+  });
+});

--- a/frontend/pages/ManageControlsPage/ManageControlsPage.tsx
+++ b/frontend/pages/ManageControlsPage/ManageControlsPage.tsx
@@ -119,9 +119,13 @@ const ManageControlsPage = ({
   // Controls pages don't support "All teams". On free tier the page runs as
   // "All teams", so teamIdForApi is undefined and the sub-pages (which gate
   // their render on it being defined) would spin forever. Free tier has only
-  // "No team", so coerce to it. On premium, undefined is transient (it
-  // resolves once the selected fleet loads), so keep gating on it there.
-  const teamIdForApiToUse = isPremiumTier ? teamIdForApi : API_NO_TEAM_ID;
+  // "No team", so coerce to it — but only once we've confirmed the tier is Free
+  // (isPremiumTier === false). While the tier is still unknown (undefined during
+  // config load) or premium, pass teamIdForApi through untouched so the
+  // sub-pages keep waiting instead of firing "No team" queries before the tier
+  // is known (which would flash wrong-team data for premium users on boot).
+  const teamIdForApiToUse =
+    isPremiumTier === false ? API_NO_TEAM_ID : teamIdForApi;
 
   const permittedControlsSubNav = useMemo(() => {
     let renderedSubNav = controlsSubNav;

--- a/frontend/pages/ManageControlsPage/ManageControlsPage.tsx
+++ b/frontend/pages/ManageControlsPage/ManageControlsPage.tsx
@@ -4,6 +4,7 @@ import { InjectedRouter } from "react-router";
 
 import PATHS from "router/paths";
 import { AppContext } from "context/app";
+import { API_NO_TEAM_ID } from "interfaces/team";
 import useTeamIdParam from "hooks/useTeamIdParam";
 
 import TabNav from "components/TabNav";
@@ -115,6 +116,13 @@ const ManageControlsPage = ({
     },
   });
 
+  // Controls pages don't support "All teams". On free tier the page runs as
+  // "All teams", so teamIdForApi is undefined and the sub-pages (which gate
+  // their render on it being defined) would spin forever. Free tier has only
+  // "No team", so coerce to it. On premium, undefined is transient (it
+  // resolves once the selected fleet loads), so keep gating on it there.
+  const teamIdForApiToUse = isPremiumTier ? teamIdForApi : API_NO_TEAM_ID;
+
   const permittedControlsSubNav = useMemo(() => {
     let renderedSubNav = controlsSubNav;
     if (isTeamTechnician || isGlobalTechnician) {
@@ -189,7 +197,7 @@ const ManageControlsPage = ({
         <div className="tab-nav-routed-content">
           <div key={currentTabIndex} className="tab-nav-routed-content__fade">
             {React.cloneElement(children, {
-              teamIdForApi,
+              teamIdForApi: teamIdForApiToUse,
               currentPage: page,
               queryParams: parseOSUpdatesCurrentVersionsQueryParams(
                 location.query


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #49376

Fixes an issue where, on Fleet Free, Controls > OS settings and Controls > Scripts rendered an infinite loading spinner.

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually

### Before


https://github.com/user-attachments/assets/96ad3406-101d-4310-83e2-430331e0f854



### After


https://github.com/user-attachments/assets/6a83adf3-1110-49b1-bb65-401cb8df3c61



For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how Controls sub-pages receive the selected team for free-tier accounts by normalizing unresolved values to a dedicated “no team” ID.
  * Avoided triggering “no team” lookups during initial config loading when the tier is still unknown.
  * Kept premium-tier forwarding behavior unchanged so unresolved team IDs continue to wait as before.
* **Tests**
  * Added coverage to verify the forwarded team ID behavior across free, premium, and unknown-tier scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->