### PR TITLE
Windows MDM: accept discovery RequestVersion >= 4.0 (#49329)

### DIFF
--- a/changes/49329-windows-discovery-request-version
+++ b/changes/49329-windows-discovery-request-version
@@ -1,0 +1,4 @@
+- Fixed a bug where fresh Windows 11 25H2 (and other recent builds) failed MDM enrollment with error
+  80180006 because the device's discovery `RequestVersion` (e.g. "9.0") was rejected by an exact-match
+  allow-list. Fleet now accepts any MS-MDE2 discovery `RequestVersion` at or above the minimum supported
+  version ("4.0").

--- a/server/fleet/microsoft_mdm.go
+++ b/server/fleet/microsoft_mdm.go
@@ -193,7 +193,7 @@ func (req *SoapRequest) IsValidDiscoveryMsg() error {
 	// advertise higher versions (e.g. "9.0") must not be rejected by an exact-match allow-list.
 	atLeastMin, err := enrollmentVersionAtLeast(req.Body.Discover.Request.RequestVersion, syncml.MinSupportedEnrollmentVersion)
 	if err != nil {
-		return fmt.Errorf("invalid discover message: Request.RequestVersion=%q is not a valid version: %s",
+		return fmt.Errorf("invalid discover message: Request.RequestVersion=%q is not a valid version: %w",
 			req.Body.Discover.Request.RequestVersion, err)
 	}
 	if !atLeastMin {

--- a/server/fleet/microsoft_mdm.go
+++ b/server/fleet/microsoft_mdm.go
@@ -136,6 +136,40 @@ func (req *SoapRequest) isValidBody() error {
 	return nil
 }
 
+// enrollmentVersionAtLeast reports whether the dotted MS-MDE2 version string v (e.g. "9.0") is
+// greater than or equal to minVersion (e.g. "4.0"). Components are compared numerically so that
+// "10.0" is correctly ordered above "9.0". It returns an error if v is empty or contains a
+// non-numeric component.
+func enrollmentVersionAtLeast(v, minVersion string) (bool, error) {
+	if v == "" {
+		return false, errors.New("version is empty")
+	}
+
+	vParts := strings.Split(v, ".")
+	minParts := strings.Split(minVersion, ".")
+
+	for i := 0; i < len(vParts) || i < len(minParts); i++ {
+		var vNum, minNum int
+		if i < len(vParts) {
+			n, err := strconv.Atoi(vParts[i])
+			if err != nil {
+				return false, fmt.Errorf("invalid version component %q", vParts[i])
+			}
+			vNum = n
+		}
+		if i < len(minParts) {
+			// minVersion is a compile-time constant we control, so it is assumed well-formed.
+			minNum, _ = strconv.Atoi(minParts[i])
+		}
+		if vNum != minNum {
+			return vNum > minNum, nil
+		}
+	}
+
+	// All compared components are equal.
+	return true, nil
+}
+
 // IsValidDiscoveryMsg checks for required fields in the Discover message
 func (req *SoapRequest) IsValidDiscoveryMsg() error {
 	if err := req.isValidHeader(); err != nil {
@@ -154,17 +188,17 @@ func (req *SoapRequest) IsValidDiscoveryMsg() error {
 		return errors.New("invalid discover message: XMLNS")
 	}
 
-	// Check if the request version is one of the defined enrollment versions
-	versionFound := false
-	for _, v := range syncml.SupportedEnrollmentVersions {
-		if req.Body.Discover.Request.RequestVersion == v {
-			versionFound = true
-			break
-		}
+	// Accept any RequestVersion >= the minimum supported version. The discovery response pins the
+	// protocol to EnrollmentVersionV4 and the client negotiates down, so newer Windows builds that
+	// advertise higher versions (e.g. "9.0") must not be rejected by an exact-match allow-list.
+	atLeastMin, err := enrollmentVersionAtLeast(req.Body.Discover.Request.RequestVersion, syncml.MinSupportedEnrollmentVersion)
+	if err != nil {
+		return fmt.Errorf("invalid discover message: Request.RequestVersion=%q is not a valid version: %s",
+			req.Body.Discover.Request.RequestVersion, err)
 	}
-	if !versionFound {
-		return fmt.Errorf("invalid discover message: Request.RequestVersion=%q not in supported versions %v",
-			req.Body.Discover.Request.RequestVersion, syncml.SupportedEnrollmentVersions)
+	if !atLeastMin {
+		return fmt.Errorf("invalid discover message: Request.RequestVersion=%q is below the minimum supported version %q",
+			req.Body.Discover.Request.RequestVersion, syncml.MinSupportedEnrollmentVersion)
 	}
 
 	// Traverse the AuthPolicies slice and check for valid values

--- a/server/fleet/microsoft_mdm.go
+++ b/server/fleet/microsoft_mdm.go
@@ -158,8 +158,12 @@ func enrollmentVersionAtLeast(v, minVersion string) (bool, error) {
 			vNum = n
 		}
 		if i < len(minParts) {
-			// minVersion is a compile-time constant we control, so it is assumed well-formed.
-			minNum, _ = strconv.Atoi(minParts[i])
+			// minVersion is expected to be well-formed, but validate it so we don't silently accept bad values.
+			n, err := strconv.Atoi(minParts[i])
+			if err != nil {
+				return false, fmt.Errorf("invalid minVersion component %q", minParts[i])
+			}
+			minNum = n
 		}
 		if vNum != minNum {
 			return vNum > minNum, nil

--- a/server/fleet/microsoft_mdm_test.go
+++ b/server/fleet/microsoft_mdm_test.go
@@ -968,7 +968,7 @@ func TestIsFleetInternalCmdID(t *testing.T) {
 }
 
 func TestEnrollmentVersionAtLeast(t *testing.T) {
-	const min = syncml.MinSupportedEnrollmentVersion // "4.0"
+	const minVersion = syncml.MinSupportedEnrollmentVersion // "4.0"
 
 	for _, tc := range []struct {
 		name    string
@@ -991,7 +991,7 @@ func TestEnrollmentVersionAtLeast(t *testing.T) {
 		{"non-numeric minor", "4.x", false, `invalid version component "x"`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := enrollmentVersionAtLeast(tc.version, min)
+			got, err := enrollmentVersionAtLeast(tc.version, minVersion)
 			if tc.wantErr != "" {
 				require.ErrorContains(t, err, tc.wantErr)
 				return

--- a/server/fleet/microsoft_mdm_test.go
+++ b/server/fleet/microsoft_mdm_test.go
@@ -966,3 +966,38 @@ func TestIsFleetInternalCmdID(t *testing.T) {
 		})
 	}
 }
+
+func TestEnrollmentVersionAtLeast(t *testing.T) {
+	const min = syncml.MinSupportedEnrollmentVersion // "4.0"
+
+	for _, tc := range []struct {
+		name    string
+		version string
+		want    bool
+		wantErr string
+	}{
+		{"minimum version", "4.0", true, ""},
+		{"historically supported 5.0", "5.0", true, ""},
+		{"historically supported 7.0", "7.0", true, ""},
+		{"newer 8.0", "8.0", true, ""},
+		{"windows 11 25H2 9.0", "9.0", true, ""},
+		{"double-digit major 10.0 above 9.0", "10.0", true, ""},
+		{"below minimum 3.0", "3.0", false, ""},
+		{"below minimum 3.9", "3.9", false, ""},
+		{"higher minor same major", "4.1", true, ""},
+		{"major only equal", "4", true, ""},
+		{"empty", "", false, "version is empty"},
+		{"non-numeric", "abc", false, `invalid version component "abc"`},
+		{"non-numeric minor", "4.x", false, `invalid version component "x"`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := enrollmentVersionAtLeast(tc.version, min)
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/server/mdm/microsoft/syncml/syncml.go
+++ b/server/mdm/microsoft/syncml/syncml.go
@@ -179,8 +179,14 @@ const (
 	DiskEncryptionProfileRestrictionErrMsg = "Couldn't add. The configuration profile can't include BitLocker settings."
 )
 
-// Supported MS-MDE2 enrollment versions
-var SupportedEnrollmentVersions = []string{"4.0", "5.0", "6.0", "7.0"}
+// MinSupportedEnrollmentVersion is the lowest MS-MDE2 discovery RequestVersion Fleet accepts.
+//
+// The discovery response pins the protocol to EnrollmentVersionV4 ("4.0") and the client
+// negotiates down from whatever version it advertised, so Fleet accepts any RequestVersion >= 4.0
+// rather than an exact-match allow-list. This keeps enrollment working on newer Windows builds
+// that advertise higher versions (e.g. Windows 11 25H2 sends "9.0") without requiring a code
+// change for each Windows release.
+const MinSupportedEnrollmentVersion = EnrollmentVersionV4
 
 // MS-MDE2 Message constants
 const (

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -8371,8 +8371,10 @@ func (s *integrationMDMTestSuite) TestOrbitConfigNudgeSettings() {
 
 func (s *integrationMDMTestSuite) TestValidDiscoveryRequest() {
 	t := s.T()
-	// Preparing the Discovery Request message. We are testing all versions Fleet claims to support
-	for _, requestVersion := range syncml.SupportedEnrollmentVersions {
+	// Preparing the Discovery Request message. We test the historically-supported versions plus
+	// newer ones (e.g. Windows 11 25H2 advertises "9.0") to confirm any version >= the minimum is
+	// accepted.
+	for _, requestVersion := range []string{"4.0", "5.0", "6.0", "7.0", "8.0", "9.0", "10.0"} {
 		requestBytes := []byte(`
 		 <s:Envelope xmlns:a="http://www.w3.org/2005/08/addressing" xmlns:s="http://www.w3.org/2003/05/soap-envelope">
 		   <s:Header>


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #49329

## What & why

Fresh **Windows 11 25H2** (build 10.0.26200) devices failed Microsoft Entra / Autopilot MDM auto-enrollment during OOBE with error **80180006**. The device advertises an MS-MDE2 discovery `RequestVersion` of `"9.0"`, and Fleet's `IsValidDiscoveryMsg()` rejected it via an exact-match allow-list (`{"4.0","5.0","6.0","7.0"}`) that could only be changed by rebuilding the server.

The discovery **response** already pins the protocol to `EnrollmentVersionV4` (`"4.0"`) and the client negotiates down, so the exact-match check was the only blocker. This PR implements the issue's preferred fix: **accept any `RequestVersion >= 4.0`**, which is forward-compatible with future Windows version bumps.

- `server/mdm/microsoft/syncml/syncml.go`: replaced the `SupportedEnrollmentVersions` allow-list var with a `MinSupportedEnrollmentVersion` constant.
- `server/fleet/microsoft_mdm.go`: added `enrollmentVersionAtLeast` (numeric component-wise compare, so `"10.0" > "9.0"`) and changed discovery validation to accept any version at or above the minimum.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed MDM enrollment failures on fresh Windows 11 25H2 and other recent builds.
  * Discovery requests now accept supported MDE2 `RequestVersion` values at or above the minimum supported version (instead of requiring an exact match).
  * Invalid or outdated discovery versions now return more specific validation errors.
* **Tests**
  * Added unit test coverage for minimum, equal, newer, and invalid enrollment version comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->