### PR TITLE
Fix self-service .py install on macOS hosts

### DIFF
--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -3545,8 +3545,8 @@ func (svc *Service) SelfServiceInstallSoftwareTitle(ctx context.Context, host *f
 		}
 
 		if host.FleetPlatform() != requiredPlatform {
-			// Allow .sh scripts for any unix-like platform (linux and darwin)
-			if !(ext == ".sh" && fleet.IsUnixLike(host.Platform)) {
+			// Allow .sh and .py scripts for any unix-like platform (linux and darwin)
+			if !((ext == ".sh" || ext == ".py") && fleet.IsUnixLike(host.Platform)) {
 				return &fleet.BadRequestError{
 					Message: fmt.Sprintf("Package (%s) can be installed only on %s hosts.", ext, requiredPlatform),
 					InternalErr: ctxerr.WrapWithData(

--- a/ee/server/service/software_installers_test.go
+++ b/ee/server/service/software_installers_test.go
@@ -1445,6 +1445,55 @@ func TestInstallPyScriptOnWindowsFails(t *testing.T) {
 	require.Contains(t, bre.Message, "can be installed only on linux hosts")
 }
 
+// .py packages are stored with platform='linux'; the self-service install path
+// must still allow them on darwin hosts via the unix-like exception.
+func TestSelfServiceInstallPyScriptOnUnixLike(t *testing.T) {
+	t.Parallel()
+
+	for _, platform := range []string{"linux", "darwin"} {
+		t.Run(platform, func(t *testing.T) {
+			t.Parallel()
+			ds := new(mock.Store)
+			svc := newTestService(t, ds)
+
+			ds.GetSoftwareInstallerMetadataByTeamAndTitleIDFunc = func(ctx context.Context, teamID *uint, titleID uint, withScriptContents bool) (*fleet.SoftwareInstaller, error) {
+				return &fleet.SoftwareInstaller{
+					InstallerID: 10,
+					Name:        "script.py",
+					Extension:   "py",
+					Platform:    "linux",
+					TeamID:      new(uint(1)),
+					TitleID:     new(uint(100)),
+					SelfService: true,
+				}, nil
+			}
+
+			ds.IsSoftwareInstallerLabelScopedFunc = func(ctx context.Context, installerID, hostID uint) (bool, error) {
+				return true, nil
+			}
+
+			ds.ResetNonPolicyInstallAttemptsFunc = func(ctx context.Context, hostID uint, softwareInstallerID uint) error {
+				return nil
+			}
+
+			ds.InsertSoftwareInstallRequestFunc = func(ctx context.Context, hostID uint, softwareInstallerID uint, opts fleet.HostSoftwareInstallOptions) (string, error) {
+				return "install-uuid", nil
+			}
+
+			host := &fleet.Host{
+				ID:           1,
+				OrbitNodeKey: new("orbit_key"),
+				Platform:     platform,
+				TeamID:       new(uint(1)),
+			}
+
+			err := svc.SelfServiceInstallSoftwareTitle(context.Background(), host, 100)
+			require.NoError(t, err, ".py self-service install on %s should succeed", platform)
+			require.True(t, ds.InsertSoftwareInstallRequestFuncInvoked, "install request should be created")
+		})
+	}
+}
+
 func TestSelfServiceInstallSoftwareTitleAllowsPersonallyEnrolledDevices(t *testing.T) {
 	t.Parallel()
 	ds := new(mock.Store)


### PR DESCRIPTION
**Related issue:** Resolves #49369

Self-service install of a `.py` script-only package was rejected on macOS hosts (`Package (.py) can be installed only on linux hosts.`) because `SelfServiceInstallSoftwareTitle` only allowed `.sh` in the unix-like (linux + darwin) exception. Now allows `.py` too, matching the admin install path (`installSoftwareTitleUsingInstaller`).

# Checklist for submitter

- [x] Changes file: N/A — unreleased fix on the `#41470` feature branch; the feature PR (#49070) carries the changes file.
- [x] Input data is properly validated (platform-gate fix only; no new input handling, SQL, or shell interpolation).

## Testing

- [x] Added/updated automated tests — `TestSelfServiceInstallPyScriptOnUnixLike` (linux + darwin); confirmed it fails without the fix and passes with it.
- [x] QA'd all new/changed functionality manually — live on a macOS host: self-service `.py` install went from HTTP 400 → 202 → `installed` (script executed), with no regression to `.sh`/Linux/Windows behavior.
