### PR TITLE
Accept .py path-referenced packages in GitOps

### DIFF
--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -283,7 +283,7 @@ type SoftwarePackage struct {
 }
 
 func (spec SoftwarePackage) HydrateToPackageLevel(packageLevel fleet.SoftwarePackageSpec, ext string) (fleet.SoftwarePackageSpec, error) {
-	isScript := ext == ".sh" || ext == ".ps1"
+	isScript := fleet.IsScriptPackage(ext)
 
 	// Script-only packages are configured inline in the team YAML, so their
 	// uninstall/post-install scripts and pre-install query are allowed here;
@@ -299,7 +299,7 @@ func (spec SoftwarePackage) HydrateToPackageLevel(packageLevel fleet.SoftwarePac
 
 	// Icon should be allowed at the team level yaml for script packages which must be specified as a path
 	if spec.Icon.Path != "" {
-		if ext != ".sh" && ext != ".ps1" {
+		if !fleet.IsScriptPackage(ext) {
 			return packageLevel, fmt.Errorf("the software package defined in %s must not have icons, scripts, queries, URL, or hash specified at the team level", *spec.Path)
 		}
 	}
@@ -2209,8 +2209,8 @@ func parseSoftware(top map[string]json.RawMessage, result *GitOps, baseDir strin
 			}
 
 			ext := strings.ToLower(filepath.Ext(resolvedPath))
-			switch ext {
-			case ".sh", ".ps1":
+			switch {
+			case fleet.IsScriptPackage(ext):
 				// Script files: only gather FLEET_SECRET_ variables, don't expand
 				// regular env vars (they are shell variables meant for the endpoint).
 				if err := gatherFileSecrets(result, resolvedPath); err != nil {
@@ -2238,7 +2238,7 @@ func parseSoftware(top map[string]json.RawMessage, result *GitOps, baseDir strin
 				}
 				softwarePackageSpecs = append(softwarePackageSpecs, &scriptSpec)
 
-			case ".yml", ".yaml":
+			case ext == ".yml" || ext == ".yaml":
 				// Replace $var and ${var} with env values in YAML files only.
 				fileBytes, err = ExpandEnvBytes(fileBytes)
 				if err != nil {
@@ -2282,7 +2282,7 @@ func parseSoftware(top map[string]json.RawMessage, result *GitOps, baseDir strin
 				}
 
 			default:
-				multiError = multierror.Append(multiError, fmt.Errorf("software package path %s has unsupported extension %q; only .yml, .yaml, .sh, or .ps1 files are supported", *teamLevelPackage.Path, ext))
+				multiError = multierror.Append(multiError, fmt.Errorf("software package path %s has unsupported extension %q; only .yml, .yaml, .sh, .ps1, or .py files are supported", *teamLevelPackage.Path, ext))
 				continue
 			}
 		} else {

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -2246,6 +2246,59 @@ software:
 	assert.Equal(t, filepath.Join(basePath, "foo", "bar.png"), gitops.Software.Packages[0].Icon.Path)
 }
 
+// A path-referenced .py is a script-only package: it must be accepted and
+// treated like .sh/.ps1, not rejected as an unsupported extension.
+func TestScriptOnlyPackagesPathPy(t *testing.T) {
+	t.Parallel()
+	config := getTeamConfig([]string{"software"})
+	config += `
+software:
+  packages:
+    - path: software/script-only.py
+      self_service: true
+      icon:
+        path: ./foo/bar.png
+      uninstall_script:
+        path: software/uninstall.sh
+      post_install_script:
+        path: software/post-install.sh
+      pre_install_query:
+        path: software/preinstall-query.yml
+`
+
+	path, basePath := createTempFile(t, "", config)
+
+	copies := []struct{ src, dst string }{
+		{filepath.Join("testdata", "software", "script-only.py"), filepath.Join(basePath, "software", "script-only.py")},
+		{filepath.Join("testdata", "software", "install-app.sh"), filepath.Join(basePath, "software", "uninstall.sh")},
+		{filepath.Join("testdata", "software", "install-app.sh"), filepath.Join(basePath, "software", "post-install.sh")},
+	}
+	for _, c := range copies {
+		require.NoError(t, file.Copy(c.src, c.dst, os.FileMode(0o755)))
+	}
+	require.NoError(t, file.Copy(
+		filepath.Join("testdata", "lib", "preinstall-query.yml"),
+		filepath.Join(basePath, "software", "preinstall-query.yml"),
+		os.FileMode(0o644),
+	))
+
+	appConfig := fleet.EnrichedAppConfig{}
+	appConfig.License = &fleet.LicenseInfo{
+		Tier: fleet.TierPremium,
+	}
+	gitops, err := GitOpsFromFile(path, basePath, &appConfig, nopLogf)
+	require.NoError(t, err)
+	require.Len(t, gitops.Software.Packages, 1)
+
+	pkg := gitops.Software.Packages[0]
+	assert.Equal(t, filepath.Join(basePath, "software", "script-only.py"), pkg.InstallScript.Path)
+	assert.Equal(t, filepath.Join(basePath, "foo", "bar.png"), pkg.Icon.Path)
+	assert.Equal(t, filepath.Join(basePath, "software", "uninstall.sh"), pkg.UninstallScript.Path)
+	assert.Equal(t, filepath.Join(basePath, "software", "post-install.sh"), pkg.PostInstallScript.Path)
+	assert.Equal(t, filepath.Join(basePath, "software", "preinstall-query.yml"), pkg.PreInstallQuery.Path)
+	assert.True(t, pkg.SelfService)
+}
+
 func TestScriptOnlyPackagesWithAdvancedOptions(t *testing.T) {
 	t.Parallel()
 	config := getTeamConfig([]string{"software"})
@@ -4488,7 +4541,7 @@ software:
 
 		_, err = GitOpsFromFile(path, basePath, appConfig, nopLogf)
 		assert.ErrorContains(t, err, "unsupported extension")
-		assert.ErrorContains(t, err, "only .yml, .yaml, .sh, or .ps1 files are supported")
+		assert.ErrorContains(t, err, "only .yml, .yaml, .sh, .ps1, or .py files are supported")
 	})
 
 	t.Run("script_with_team_options", func(t *testing.T) {

--- a/pkg/spec/testdata/software/script-only.py
+++ b/pkg/spec/testdata/software/script-only.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python3
+
+print("hello world")


### PR DESCRIPTION
**Related issue:** Resolves #49370

`fleetctl gitops` rejected a local `path:`-referenced `.py` software package client-side with `unsupported extension ".py"`, even though a `url:`-referenced `.py` worked end-to-end. The package-path `switch` and the two `HydrateToPackageLevel` gates (team-level advanced options + icon) only recognized `.sh`/`.ps1`. They now use `fleet.IsScriptPackage`, so `.py` is accepted — and future script types won't drift out of sync.

# Checklist for submitter

- [x] Changes file: N/A — unreleased fix on the `#41470` feature branch; the feature PR (#49070) carries the changes file.
- [x] Input data is properly validated (extension-gating fix only; no new input handling, SQL, or shell interpolation).

## Testing

- [x] Added/updated automated tests — `TestScriptOnlyPackagesPathPy` (path `.py` with team-level self-service, uninstall/post-install scripts, pre-install query, and icon); confirmed it fails without the fix and passes with it. Also updated a sibling test's error-string assertion.
- [x] QA'd all new/changed functionality manually — live before/after with the real `fleetctl` binary: unfixed → `unsupported extension ".py"`; fixed → `gitops dry run succeeded`, and a real apply persisted the package with `source: py_packages`.
