### PR TITLE
Add py/python keywords to Add custom package palette entry

### DIFF
--- a/frontend/components/CommandPalette/groups/commands.ts
+++ b/frontend/components/CommandPalette/groups/commands.ts
@@ -291,6 +291,8 @@ const buildCommandsItems = (
                     "tar.gz",
                     "tarballs",
                     "sh",
+                    "py",
+                    "python",
                   ],
                 },
                 {

--- a/frontend/components/CommandPalette/helpers.tests.ts
+++ b/frontend/components/CommandPalette/helpers.tests.ts
@@ -327,6 +327,19 @@ describe("CommandPalette helpers", () => {
       expect(keywords).not.toContain("sso");
     });
 
+    it("surfaces Add custom package when searching py / python (.py is an accepted upload type)", () => {
+      const items = buildPaletteItems({
+        ...BASE_CONTEXT,
+        hasTeamSelected: true,
+        currentTeam: { id: 1, name: "Engineering" },
+      });
+      const addCustomPackage = items.find((i) => i.id === "add-custom-package");
+      expect(addCustomPackage).toBeDefined();
+      const keywords = addCustomPackage?.keywords ?? [];
+      expect(keywords).toContain("py");
+      expect(keywords).toContain("python");
+    });
+
     it("hides calendar keywords on Unassigned (Calendar section is disabled there) but keeps conditional access", () => {
       const items = buildPaletteItems({
         ...BASE_CONTEXT,


### PR DESCRIPTION
**Related issue:** Resolves #49371

Typing `py` (or `python`) in the command palette didn't surface **Add custom package**, even though `.py` is now an accepted custom-package upload type. The `add-custom-package` entry's `keywords` list enumerated every other extension (`pkg`, `ipa`, `msi`, `exe`, `ps1`, `deb`, `rpm`, `tar.gz`, `sh`) but omitted `py`. Added `py` and `python`.

# Checklist for submitter

- [x] Changes file: N/A — unreleased fix on the `#41470` feature branch; the feature PR (#49070) carries the changes file.

## Testing

- [x] Added/updated automated tests — new `helpers.tests.ts` case asserting the `add-custom-package` entry surfaces on `py`/`python`; confirmed it fails without the fix and passes with it.
- [x] QA'd all new/changed functionality manually — live in the browser: with a team selected, searching `py` in the command palette now lists **Add custom package**.

<img width="1914" height="518" alt="Screenshot 2026-07-15 at 20 35 23" src="https://github.com/user-attachments/assets/bd764e9a-0389-4f29-a77f-5f77b5090677" />

