### PR TITLE
Fix query editor syntax-highlighting colors and visual bugs

### DIFF
--- a/website/assets/js/pages/docs/app-details.page.js
+++ b/website/assets/js/pages/docs/app-details.page.js
@@ -44,7 +44,7 @@ parasails.registerPage('app-details', {
 
           for(let keywordInExample of columnNamesToHighlight) {
             let regexForThisExample = new RegExp(keywordInExample, 'g');
-            replacementHMTL = replacementHMTL.replace(regexForThisExample, '<span class="hljs-string">'+_.trim(keywordInExample)+'</span>');
+            replacementHMTL = replacementHMTL.replace(regexForThisExample, '<span class="hljs-attr-column">'+_.trim(keywordInExample)+'</span>');
           }
           $(block).html(replacementHMTL);
           window.hljs.highlightElement(block);

--- a/website/assets/js/pages/docs/osquery-table-details.page.js
+++ b/website/assets/js/pages/docs/osquery-table-details.page.js
@@ -87,7 +87,7 @@ parasails.registerPage('osquery-table-details', {
         // let replacementHMTL = block.innerHTML;
         for(let keywordInExample of columnNamesToHighlight) {
           let regexForThisExample = new RegExp(keywordInExample, 'g');
-          replacementHMTL = replacementHMTL.replace(regexForThisExample, '<span class="hljs-string">'+keywordInExample+'</span>');
+          replacementHMTL = replacementHMTL.replace(regexForThisExample, '<span class="hljs-attr-column">'+keywordInExample+'</span>');
         }
         $(block).html(replacementHMTL);
         // After we've highlighted our keywords, we'll highlight the rest of the codeblock

--- a/website/assets/js/pages/docs/policy-details.page.js
+++ b/website/assets/js/pages/docs/policy-details.page.js
@@ -57,7 +57,7 @@ parasails.registerPage('policy-details', {
 
           for(let keywordInExample of columnNamesToHighlight) {
             let regexForThisExample = new RegExp(keywordInExample, 'g');
-            replacementHMTL = replacementHMTL.replace(regexForThisExample, '<span class="hljs-string">'+_.trim(keywordInExample)+'</span>');
+            replacementHMTL = replacementHMTL.replace(regexForThisExample, '<span class="hljs-attr-column">'+_.trim(keywordInExample)+'</span>');
           }
           $(block).html(replacementHMTL);
           window.hljs.highlightElement(block);

--- a/website/assets/js/pages/docs/report-details.page.js
+++ b/website/assets/js/pages/docs/report-details.page.js
@@ -58,7 +58,7 @@ parasails.registerPage('report-details', {
 
         for(let keywordInExample of columnNamesToHighlight) {
           let regexForThisExample = new RegExp(keywordInExample, 'g');
-          replacementHMTL = replacementHMTL.replace(regexForThisExample, '<span class="hljs-string">'+_.trim(keywordInExample)+'</span>');
+          replacementHMTL = replacementHMTL.replace(regexForThisExample, '<span class="hljs-attr-column">'+_.trim(keywordInExample)+'</span>');
         }
         $(block).html(replacementHMTL);
         window.hljs.highlightElement(block);

--- a/website/assets/js/pages/docs/vital-details.page.js
+++ b/website/assets/js/pages/docs/vital-details.page.js
@@ -70,7 +70,7 @@ parasails.registerPage('vital-details', {
             continue;
           }
           let regexForThisExample = new RegExp(keywordInExample, 'g');
-          replacementHMTL = replacementHMTL.replace(regexForThisExample, '<span class="hljs-string">'+_.trim(keywordInExample)+'</span>');
+          replacementHMTL = replacementHMTL.replace(regexForThisExample, '<span class="hljs-attr-column">'+_.trim(keywordInExample)+'</span>');
         }
         $(block).html(replacementHMTL);
         window.hljs.highlightElement(block);

--- a/website/assets/styles/pages/admin/query-generator.less
+++ b/website/assets/styles/pages/admin/query-generator.less
@@ -228,7 +228,7 @@
       .hljs-addition,
       .hljs-variable,
       .hljs-template-variable {
-        color: #4fd061;
+        color: @core-vibrant-green;
       }
       .hljs-comment,
       .hljs-deletion,
@@ -272,12 +272,12 @@
         }
       }
       .hljs-number {
-        color: #4fd061;
+        color: @core-vibrant-green;
       }
       .hljs-string { // For words wrapped in quotation marks
-        color: #4fd061;
+        color: @core-vibrant-green;
         .hljs-keyword {
-          color: #4fd061;
+          color: @core-vibrant-green;
         }
       }
       background-color: @ui-off-white;

--- a/website/assets/styles/pages/admin/query-generator.less
+++ b/website/assets/styles/pages/admin/query-generator.less
@@ -272,7 +272,7 @@
         }
       }
       .hljs-number {
-        color: #f5871f;
+        color: #4fd061;
       }
       .hljs-string { // For words wrapped in quotation marks
         color: #4fd061;

--- a/website/assets/styles/pages/articles/basic-article.less
+++ b/website/assets/styles/pages/articles/basic-article.less
@@ -661,7 +661,7 @@
       .hljs-selector-pseudo,
       .hljs-addition,
       .hljs-template-variable {
-        color: #4fd061;
+        color: @core-vibrant-green;
       }
       .hljs-comment,
       .hljs-deletion,

--- a/website/assets/styles/pages/docs/app-details.less
+++ b/website/assets/styles/pages/docs/app-details.less
@@ -298,10 +298,10 @@
 
 
         .hljs-keyword { // SQL keywords (SELECT, FROM, WHERE, IN, etc.)
-          color: #515774;
+          color: #AE6DDF;
         }
         .hljs-operator {
-          color: #3e999f;
+          color: #515774;
         }
         .hljs-attr { // For table and column names
           .hljs-keyword {
@@ -320,13 +320,16 @@
           }
         }
         .hljs-number {
-          color: #f5871f;
+          color: #4fd061;
         }
         .hljs-string { // For words wrapped in quotation marks
           color: #4fd061;
           .hljs-keyword {
             color: #4fd061;
           }
+        }
+        .hljs-attr-column { // For recognized column names (not pilled, not a quoted string)
+          color: #515774;
         }
       }
 

--- a/website/assets/styles/pages/docs/app-details.less
+++ b/website/assets/styles/pages/docs/app-details.less
@@ -278,7 +278,7 @@
         .hljs-selector-pseudo,
         .hljs-addition,
         .hljs-template-variable {
-          color: #4fd061;
+          color: @core-vibrant-green;
         }
         .hljs-comment,
         .hljs-deletion,
@@ -320,12 +320,12 @@
           }
         }
         .hljs-number {
-          color: #4fd061;
+          color: @core-vibrant-green;
         }
         .hljs-string { // For words wrapped in quotation marks
-          color: #4fd061;
+          color: @core-vibrant-green;
           .hljs-keyword {
-            color: #4fd061;
+            color: @core-vibrant-green;
           }
         }
         .hljs-attr-column { // For recognized column names (not pilled, not a quoted string)

--- a/website/assets/styles/pages/docs/command-details.less
+++ b/website/assets/styles/pages/docs/command-details.less
@@ -418,7 +418,7 @@
         .hljs-addition,
         .hljs-variable,
         .hljs-template-variable {
-          color: #4fd061;
+          color: @core-vibrant-green;
         }
         .hljs-comment,
         .hljs-deletion,
@@ -445,12 +445,12 @@
           content: '\a';
         }
         .hljs-number {
-          color: #4fd061;
+          color: @core-vibrant-green;
         }
         .hljs-string { // For words wrapped in quotation marks
-          color: #4fd061;
+          color: @core-vibrant-green;
           .hljs-keyword {
-            color: #4fd061;
+            color: @core-vibrant-green;
           }
         }
         background-color: @ui-off-white;

--- a/website/assets/styles/pages/docs/command-details.less
+++ b/website/assets/styles/pages/docs/command-details.less
@@ -445,7 +445,7 @@
           content: '\a';
         }
         .hljs-number {
-          color: #f5871f;
+          color: #4fd061;
         }
         .hljs-string { // For words wrapped in quotation marks
           color: #4fd061;

--- a/website/assets/styles/pages/docs/osquery-table-details.less
+++ b/website/assets/styles/pages/docs/osquery-table-details.less
@@ -325,7 +325,7 @@
       margin-bottom: 0px;
       code {
         .hljs-keyword { // SQL keywords (SELECT, FROM, WHERE, IN, etc.)
-          color: #515774;
+          color: #AE6DDF;
           white-space: pre;
         }
         [purpose='line-break']:not(:first-of-type)::before {
@@ -348,16 +348,19 @@
           }
         }
         .hljs-number {
-          color: #f5871f;
+          color: #4fd061;
         }
         .hljs-operator {
-          color: #3e999f;
+          color: #515774;
         }
         .hljs-string { // For words wrapped in quotation marks
           color: #4fd061;
           .hljs-keyword {
             color: #4fd061;
           }
+        }
+        .hljs-attr-column { // For recognized column names (not pilled, not a quoted string)
+          color: #515774;
         }
         background-color: @ui-off-white;
         border: none;

--- a/website/assets/styles/pages/docs/osquery-table-details.less
+++ b/website/assets/styles/pages/docs/osquery-table-details.less
@@ -348,15 +348,15 @@
           }
         }
         .hljs-number {
-          color: #4fd061;
+          color: @core-vibrant-green;
         }
         .hljs-operator {
           color: #515774;
         }
         .hljs-string { // For words wrapped in quotation marks
-          color: #4fd061;
+          color: @core-vibrant-green;
           .hljs-keyword {
-            color: #4fd061;
+            color: @core-vibrant-green;
           }
         }
         .hljs-attr-column { // For recognized column names (not pilled, not a quoted string)

--- a/website/assets/styles/pages/docs/policy-details.less
+++ b/website/assets/styles/pages/docs/policy-details.less
@@ -236,12 +236,12 @@
           color: #515774;
         }
         .hljs-number {
-          color: #4fd061;
+          color: @core-vibrant-green;
         }
         .hljs-string { // For words wrapped in quotation marks
-          color: #4fd061;
+          color: @core-vibrant-green;
           .hljs-keyword {
-            color: #4fd061;
+            color: @core-vibrant-green;
           }
         }
         .hljs-attr-column { // For recognized column names (not pilled, not a quoted string)
@@ -365,7 +365,7 @@
       .hljs-addition,
       .hljs-variable,
       .hljs-template-variable {
-        color: #4fd061;
+        color: @core-vibrant-green;
       }
       .hljs-comment,
       .hljs-deletion,
@@ -445,12 +445,12 @@
           }
         }
         .hljs-number {
-          color: #4fd061;
+          color: @core-vibrant-green;
         }
         .hljs-string { // For words wrapped in quotation marks
-          color: #4fd061;
+          color: @core-vibrant-green;
           .hljs-keyword {
-            color: #4fd061;
+            color: @core-vibrant-green;
           }
         }
         .hljs-attr-column { // For recognized column names (not pilled, not a quoted string)

--- a/website/assets/styles/pages/docs/policy-details.less
+++ b/website/assets/styles/pages/docs/policy-details.less
@@ -211,7 +211,7 @@
         font-weight: 400;
         line-height: 150%;
         .hljs-keyword { // SQL keywords (SELECT, FROM, WHERE, IN, etc.)
-          color: #515774;
+          color: #AE6DDF;
         }
         [purpose='line-break']:not(:first-of-type)::before {
           content: '\a';
@@ -233,16 +233,19 @@
           }
         }
         .hljs-operator {
-          color: #3e999f;
+          color: #515774;
         }
         .hljs-number {
-          color: #f5871f;
+          color: #4fd061;
         }
         .hljs-string { // For words wrapped in quotation marks
           color: #4fd061;
           .hljs-keyword {
             color: #4fd061;
           }
+        }
+        .hljs-attr-column { // For recognized column names (not pilled, not a quoted string)
+          color: #515774;
         }
         background-color: @ui-off-white;
         border: none;
@@ -423,7 +426,7 @@
 
       &.sql {
         .hljs-keyword { // SQL keywords (SELECT, FROM, WHERE, IN, etc.)
-          color: #515774;
+          color: #AE6DDF;
         }
         .hljs-attr { // For table and column names
           .hljs-keyword {
@@ -442,13 +445,16 @@
           }
         }
         .hljs-number {
-          color: #f5871f;
+          color: #4fd061;
         }
         .hljs-string { // For words wrapped in quotation marks
           color: #4fd061;
           .hljs-keyword {
             color: #4fd061;
           }
+        }
+        .hljs-attr-column { // For recognized column names (not pilled, not a quoted string)
+          color: #515774;
         }
       }
 

--- a/website/assets/styles/pages/docs/report-details.less
+++ b/website/assets/styles/pages/docs/report-details.less
@@ -340,7 +340,7 @@
         .hljs-selector-pseudo,
         .hljs-addition,
         .hljs-template-variable {
-          color: #4fd061;
+          color: @core-vibrant-green;
         }
         .hljs-comment,
         .hljs-deletion,
@@ -388,12 +388,12 @@
           }
         }
         .hljs-number {
-          color: #4fd061;
+          color: @core-vibrant-green;
         }
         .hljs-string { // For words wrapped in quotation marks
-          color: #4fd061;
+          color: @core-vibrant-green;
           .hljs-keyword {
-            color: #4fd061;
+            color: @core-vibrant-green;
           }
         }
         .hljs-attr-column { // For recognized column names (not pilled, not a quoted string)

--- a/website/assets/styles/pages/docs/report-details.less
+++ b/website/assets/styles/pages/docs/report-details.less
@@ -362,13 +362,13 @@
         font-weight: 400;
         line-height: 150%;
         .hljs-keyword { // SQL keywords (SELECT, FROM, WHERE, IN, etc.)
-          color: #515774;
+          color: #AE6DDF;
         }
         [purpose='line-break']:not(:first-of-type)::before {
           content: '\a';
         }
         .hljs-operator {
-          color: #3e999f;
+          color: #515774;
         }
 
         .hljs-attr { // For table and column names
@@ -388,13 +388,16 @@
           }
         }
         .hljs-number {
-          color: #f5871f;
+          color: #4fd061;
         }
         .hljs-string { // For words wrapped in quotation marks
           color: #4fd061;
           .hljs-keyword {
             color: #4fd061;
           }
+        }
+        .hljs-attr-column { // For recognized column names (not pilled, not a quoted string)
+          color: #515774;
         }
         background-color: @ui-off-white;
         border: none;

--- a/website/assets/styles/pages/docs/script-details.less
+++ b/website/assets/styles/pages/docs/script-details.less
@@ -397,7 +397,7 @@
         font-weight: 400;
         line-height: 150%;
         .hljs-keyword { // SQL keywords (SELECT, FROM, WHERE, IN, etc.)
-          color: #515774;
+          color: #AE6DDF;
         }
         [purpose='line-break']:not(:first-of-type)::before {
           content: '\a';
@@ -419,10 +419,10 @@
           }
         }
         .hljs-number {
-          color: #f5871f;
+          color: #4fd061;
         }
         .hljs-operator {
-          color: #3e999f;
+          color: #515774;
         }
         .hljs-string { // For words wrapped in quotation marks
           color: #4fd061;

--- a/website/assets/styles/pages/docs/script-details.less
+++ b/website/assets/styles/pages/docs/script-details.less
@@ -375,7 +375,7 @@
         .hljs-selector-pseudo,
         .hljs-addition,
         .hljs-template-variable {
-          color: #4fd061;
+          color: @core-vibrant-green;
         }
         .hljs-comment,
         .hljs-deletion,
@@ -419,15 +419,15 @@
           }
         }
         .hljs-number {
-          color: #4fd061;
+          color: @core-vibrant-green;
         }
         .hljs-operator {
           color: #515774;
         }
         .hljs-string { // For words wrapped in quotation marks
-          color: #4fd061;
+          color: @core-vibrant-green;
           .hljs-keyword {
-            color: #4fd061;
+            color: @core-vibrant-green;
           }
         }
         background-color: @ui-off-white;

--- a/website/assets/styles/pages/docs/vital-details.less
+++ b/website/assets/styles/pages/docs/vital-details.less
@@ -438,7 +438,7 @@
         .hljs-addition,
         .hljs-variable,
         .hljs-template-variable {
-          color: #4fd061;
+          color: @core-vibrant-green;
         }
         .hljs-comment,
         .hljs-deletion,
@@ -485,12 +485,12 @@
           color: #515774;
         }
         .hljs-number {
-          color: #4fd061;
+          color: @core-vibrant-green;
         }
         .hljs-string { // For words wrapped in quotation marks
-          color: #4fd061;
+          color: @core-vibrant-green;
           .hljs-keyword {
-            color: #4fd061;
+            color: @core-vibrant-green;
           }
         }
         .hljs-attr-column { // For recognized column names (not pilled, not a quoted string)

--- a/website/assets/styles/pages/docs/vital-details.less
+++ b/website/assets/styles/pages/docs/vital-details.less
@@ -460,7 +460,7 @@
         font-weight: 400;
         line-height: 150%;
         .hljs-keyword { // SQL keywords (SELECT, FROM, WHERE, IN, etc.)
-          color: #515774;
+          color: #AE6DDF;
         }
         [purpose='line-break']:not(:first-of-type)::before {
           content: '\a';
@@ -482,16 +482,19 @@
           }
         }
         .hljs-operator {
-          color: #3e999f;
+          color: #515774;
         }
         .hljs-number {
-          color: #f5871f;
+          color: #4fd061;
         }
         .hljs-string { // For words wrapped in quotation marks
           color: #4fd061;
           .hljs-keyword {
             color: #4fd061;
           }
+        }
+        .hljs-attr-column { // For recognized column names (not pilled, not a quoted string)
+          color: #515774;
         }
         background-color: @ui-off-white;
         border: none;


### PR DESCRIPTION
For the following quick win:
- https://github.com/fleetdm/fleet/issues/49373


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Refined syntax highlighting across documentation code examples for more consistent visual theming.
  - Column-name matches are now highlighted with dedicated styling (separate from generic string highlighting), improving readability.
  - Updated Highlight.js token colors (keywords, operators, numbers, and strings) across docs pages to align with the shared theme palette, including new/overridden column-token styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->