### PR TITLE
Docs: setup_experience_platforms for cross-platform GitOps selection

### DIFF
--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -552,6 +552,8 @@ software:
         - "🌎 Browsers"
       self_service: true
       setup_experience: true
+    - path: ../lib/onboarding-script.sh.package.yml
+      setup_experience_platform: darwin, linux
     - path: ../lib/software-name2.package.yml
   app_store_apps:
     - app_store_id: "546505307"
@@ -604,6 +606,7 @@ software:
   - Category names support emojis and can be up to 255 characters long. The uniqueness checks ignore emojis, so `"🌎 Browsers"` and `"🔍 Browsers"` are treated as the same name.
   - For Fleet-maintained apps, if `categories` is omitted, apps get their [default categories](https://github.com/fleetdm/fleet/tree/main/ee/maintained-apps/outputs). If `categories` is empty, default categories are removed. If custom categories are specified, apps don't get their default categories unless they're specified explicitly. 
 - `setup_experience` installs the software when hosts enroll (default: `false`). On Windows and Linux hosts, if the software has associated policies, Fleet checks them first and skips the install when the host passes all of them. Learn more in the [setup experience guide](https://fleetdm.com/guides/setup-experience).
+- `setup_experience_platform` specifies which platform to target for the `.sh` script-only packages in setup experience. Choices for `platform` are `darwin` and `linux`. If not specified and `setup_experience` is `true`, Linux is the default platform.
 
 ### packages
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #43667

# Summary

Documents `setup_experience_platforms` on software packages in the GitOps yaml reference. Field selects a `.sh` script-only package for the macOS setup experience without disturbing its native Linux behavior.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Docs updated in `docs/Configuration/yaml-files.md` — field description, semantics, and an example under `software.packages`.