### PR TITLE
Refresh reports list cache after report create/update

### DIFF
--- a/changes/46077-newly-created-reports-do-not-show-up
+++ b/changes/46077-newly-created-reports-do-not-show-up
@@ -1,0 +1,1 @@
+* Fixed newly created or updated reports not appearing in the host details "Live report" modal or the reports list until a hard refresh.

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/SelectReportModal/SelectReportModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/SelectReportModal/SelectReportModal.tsx
@@ -64,7 +64,6 @@ const SelectReportModal = ({
     ],
     ({ queryKey }) => queryAPI.loadAll(queryKey[0]),
     {
-      refetchOnMount: false,
       refetchOnReconnect: false,
       refetchOnWindowFocus: false,
       retry: false,

--- a/frontend/pages/queries/edit/EditQueryPage.tsx
+++ b/frontend/pages/queries/edit/EditQueryPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useContext } from "react";
-import { useQuery } from "react-query";
+import { useQuery, useQueryClient } from "react-query";
 import { useErrorHandler } from "react-error-boundary";
 import { InjectedRouter, Params } from "react-router/lib/Router";
 import { Location } from "history";
@@ -69,6 +69,7 @@ const EditQueryPage = ({
   });
 
   const handlePageError = useErrorHandler();
+  const queryClient = useQueryClient();
   const {
     isGlobalAdmin,
     isGlobalMaintainer,
@@ -262,6 +263,7 @@ const EditQueryPage = ({
     setIsQuerySaving(true);
     try {
       const { query } = await queryAPI.create(formData);
+      queryClient.invalidateQueries({ queryKey: [{ scope: "queries" }] });
       notify.success("Report created.");
       router.push(
         getPathWithQueryParams(PATHS.REPORT_DETAILS(query.id), {
@@ -313,6 +315,7 @@ const EditQueryPage = ({
 
     try {
       await queryAPI.update(queryId, updatedQuery);
+      queryClient.invalidateQueries({ queryKey: [{ scope: "queries" }] });
       notify.success("Report updated.");
       router.push(
         getPathWithQueryParams(PATHS.REPORT_DETAILS(queryId), {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #46077

Newly created or updated reports (formerly "queries") did not appear in the host details page's "Live report" modal, or in the standalone reports list, until a hard refresh. This happened because the reports-list query cache was never invalidated after a create/update, and the host details modal additionally disabled refetch-on-mount, so it kept serving stale cached data even when reopened.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually

Premium license:

https://github.com/user-attachments/assets/b045b8da-b7d6-4ba6-b18d-b944208c75d2

Free license:

https://github.com/user-attachments/assets/974106e5-e620-4c46-b3ec-a74c955fe26d






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Newly created or updated reports now appear immediately in the host details “Live report” modal and reports list without requiring a hard refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->