### PR TITLE
Fix label membership being cleared when a label query errors

### DIFF
--- a/changes/46399-query-errors-can-cause-label-membership-unassigned.md
+++ b/changes/46399-query-errors-can-cause-label-membership-unassigned.md
@@ -1,0 +1,1 @@
+- Fixed label membership being incorrectly cleared when a label's query errors out on a host (e.g. the extension socket is unavailable) instead of returning zero rows; existing membership is now left unchanged when a label query fails.

--- a/server/datastore/mysql/labels.go
+++ b/server/datastore/mysql/labels.go
@@ -970,11 +970,16 @@ func (ds *Datastore) RecordLabelQueryExecutions(ctx context.Context, host *fleet
 	removes := []uint{}
 	for _, labelID := range orderedIDs {
 		matches := results[labelID]
-		if matches != nil && *matches {
+		switch {
+		case matches == nil:
+			// The query errored (e.g. extension socket unavailable), rather than
+			// returning a definitive 0 rows. Leave existing membership untouched.
+			continue
+		case *matches:
 			// Add/update row
 			bindvars = append(bindvars, "(?,?,?)")
 			vals = append(vals, updated, labelID, host.ID)
-		} else {
+		default:
 			// Delete row
 			removes = append(removes, labelID)
 		}

--- a/server/datastore/mysql/labels_test.go
+++ b/server/datastore/mysql/labels_test.go
@@ -91,6 +91,7 @@ func TestLabels(t *testing.T) {
 		{"Save", testLabelsSave},
 		{"QueriesForCentOSHost", testLabelsQueriesForCentOSHost},
 		{"RecordNonExistentQueryLabelExecution", testLabelsRecordNonexistentQueryLabelExecution},
+		{"RecordLabelQueryExecutionsQueryErrorKeepsMembership", testRecordLabelQueryExecutionsQueryErrorKeepsMembership},
 		{"DeleteLabel", testDeleteLabel},
 		{"LabelsSummaryAndListTeamFiltering", testLabelsSummaryAndListTeamFiltering},
 		{"ListHostsInLabelIssues", testListHostsInLabelIssues},
@@ -1261,6 +1262,44 @@ func testLabelsRecordNonexistentQueryLabelExecution(t *testing.T, db *Datastore)
 	require.Nil(t, err)
 
 	require.NoError(t, db.RecordLabelQueryExecutions(context.Background(), h1, map[uint]*bool{99999: ptr.Bool(true)}, time.Now(), false))
+}
+
+func testRecordLabelQueryExecutionsQueryErrorKeepsMembership(t *testing.T, db *Datastore) {
+	ctx := t.Context()
+	h1, err := db.NewHost(ctx, &fleet.Host{
+		DetailUpdatedAt: time.Now(),
+		LabelUpdatedAt:  time.Now(),
+		PolicyUpdatedAt: time.Now(),
+		SeenTime:        time.Now(),
+		OsqueryHostID:   new("1"),
+		NodeKey:         new("1"),
+		UUID:            "1",
+		Hostname:        "foo.local",
+	})
+	require.NoError(t, err)
+
+	l1 := &fleet.LabelSpec{
+		ID:    1,
+		Name:  "label foo",
+		Query: "query1",
+	}
+	require.NoError(t, db.ApplyLabelSpecs(ctx, []*fleet.LabelSpec{l1}))
+
+	// Host matches the label.
+	require.NoError(t, db.RecordLabelQueryExecutions(ctx, h1, map[uint]*bool{l1.ID: new(true)}, time.Now(), false))
+
+	labels, err := db.ListLabelsForHost(ctx, h1.ID)
+	require.NoError(t, err)
+	require.Len(t, labels, 1)
+
+	// The label query errors out on a later run (e.g. "extension socket not
+	// available"), reported as a nil result rather than an explicit non-match.
+	// This must not remove the host's existing label membership.
+	require.NoError(t, db.RecordLabelQueryExecutions(ctx, h1, map[uint]*bool{l1.ID: nil}, time.Now(), false))
+
+	labels, err = db.ListLabelsForHost(ctx, h1.ID)
+	require.NoError(t, err)
+	require.Len(t, labels, 1, "label membership should be unchanged when the label query errors")
 }
 
 func testDeleteLabel(t *testing.T, db *Datastore) {

--- a/server/service/async/async_label.go
+++ b/server/service/async/async_label.go
@@ -51,20 +51,29 @@ func (t *Task) RecordLabelQueryExecutions(ctx context.Context, host *fleet.Host,
 	// KEYS[2]: keyTs  (labelMembershipReportedKey)
 	// ARGV[1]: timestamp for "reported at"
 	// ARGV[2]: ttl for both keys
-	// ARGV[3..]: the arguments to ZADD to keySet
+	// ARGV[3..]: the arguments to ZADD to keySet (may be empty if every label
+	// query errored this run)
 	script := redigo.NewScript(2, `
-    redis.call('ZADD', KEYS[1], unpack(ARGV, 3))
-    redis.call('EXPIRE', KEYS[1], ARGV[2])
+    if #ARGV > 2 then
+      redis.call('ZADD', KEYS[1], unpack(ARGV, 3))
+      redis.call('EXPIRE', KEYS[1], ARGV[2])
+    end
     redis.call('SET', KEYS[2], ARGV[1])
     return redis.call('EXPIRE', KEYS[2], ARGV[2])
   `)
 
-	// convert results to ZADD arguments, store as -1 for delete, +1 for insert
+	// convert results to ZADD arguments, store as -1 for delete, +1 for insert.
+	// A nil result means the label query errored (e.g. extension socket
+	// unavailable) rather than returning a definitive 0 rows, so it is skipped
+	// entirely to leave existing membership untouched.
 	args := make(redigo.Args, 0, 4+(len(results)*2))
 	args = args.Add(keySet, keyTs, ts.Unix(), int(ttl.Seconds()))
 	for k, v := range results {
+		if v == nil {
+			continue
+		}
 		score := -1
-		if v != nil && *v {
+		if *v {
 			score = 1
 		}
 		args = args.Add(score, k)

--- a/server/service/async/async_label_test.go
+++ b/server/service/async/async_label_test.go
@@ -359,8 +359,10 @@ func testRecordLabelQueryExecutionsAsync(t *testing.T, ds *mock.Store, pool flee
 
 	res, err := redigo.IntMap(conn.Do("ZPOPMIN", keySet, 10))
 	require.NoError(t, err)
-	require.Equal(t, 4, len(res))
-	require.Equal(t, map[string]int{"1": 1, "2": 1, "3": -1, "4": -1}, res)
+	// label 4's query errored (nil result); it must be skipped rather than
+	// treated as a "delete" so that existing membership is left untouched.
+	require.Len(t, res, 3)
+	require.Equal(t, map[string]int{"1": 1, "2": 1, "3": -1}, res)
 
 	ts, err := redigo.Int64(conn.Do("GET", keyTs))
 	require.NoError(t, err)

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -8857,7 +8857,7 @@ func (s *integrationEnterpriseTestSuite) TestOrbitConfigExtensions() {
 
 	// orbitLinuxClient is no longer a member of the 'Foobar' label.
 	err = s.ds.RecordLabelQueryExecutions(ctx, orbitLinuxClient, map[uint]*bool{
-		foobarLabel.ID: nil,
+		foobarLabel.ID: new(false),
 	}, time.Now(), false)
 	require.NoError(t, err)
 

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -1667,6 +1667,29 @@ func TestLabelQueries(t *testing.T) {
 	assert.Equal(t, true, *gotResults[2])
 	assert.Equal(t, false, *gotResults[3])
 
+	mockClock.AddTime(1 * time.Second)
+
+	// A label query errors out (e.g. the extension socket is unavailable),
+	// rather than returning a definitive 0 rows. This must be recorded as an
+	// unknown (nil) result, not a non-match, so that existing label
+	// membership is left untouched (see #46399).
+	err = svc.SubmitDistributedQueryResults(
+		ctx,
+		map[string][]map[string]string{
+			hostLabelQueryPrefix + "2": {},
+		},
+		map[string]fleet.OsqueryStatus{
+			hostLabelQueryPrefix + "2": 1,
+		},
+		map[string]string{
+			hostLabelQueryPrefix + "2": "extension socket not available",
+		},
+		map[string]*fleet.Stats{},
+	)
+	require.NoError(t, err)
+	require.Len(t, gotResults, 1)
+	assert.Nil(t, gotResults[2])
+
 	// We should get no labels now.
 	host.LabelUpdatedAt = mockClock.Now()
 	ctx = hostctx.NewContext(ctx, host)


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #46399

When a label's query errors on a host (e.g. the extension socket is unavailable) instead of returning zero rows, Fleet was recording that error the same as a definitive "no match," clearing the host's existing label membership. This could unintentionally remove configuration profiles or other automations scoped to that label. The fix leaves existing label membership untouched when a label query errors.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually

**Setup:** macOS VM enrolled as a Fleet host, with a dynamic label whose query targets a real, always-present table but with a deliberately invalid `WHERE` clause, so the query fails deterministically (a `no such column` SQL error).

```sql
-- working version (label matches)
SELECT * FROM os_version;

-- broken version (query errors on every run)
SELECT * FROM os_version WHERE this_column_does_not_exist = 1;
```

### Before (bug reproduced on unpatched code)

1. Set the label's query to the working version and refetched the host — confirmed it shows up under the host's Labels.
2. Edited the label's query to the broken version.
3. Clicked **Refetch** on the host.
4. **Result:** the label disappeared from the host's Labels list — a query error incorrectly cleared existing membership.

### After (fix verified)

1. Reset the label's query to the working version and refetched — confirmed membership was restored.
2. Edited the label's query to the broken version again.
3. Clicked **Refetch** on the host.
4. **Result:** the label remained on the host's Labels list — a query error now correctly leaves existing membership untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved existing dynamic label memberships when label queries fail or yield unknown results.
  * Avoided treating unknown/failed evaluations as label removals.
  * Ensured label updates/removals are applied only when a definite match or non-match is returned.
* **Tests**
  * Expanded coverage for label query errors across datastore, async processing, and distributed execution to confirm memberships remain unchanged.
  * Updated expectations for queued async updates to skip errored labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->