### PR TITLE
Rejected empty and whitespace-only enroll secrets when creating or updating teams

### DIFF
--- a/changes/16800-reject-empty-enroll-secrets
+++ b/changes/16800-reject-empty-enroll-secrets
@@ -1,0 +1,1 @@
+- Rejected empty and whitespace-only enroll secrets when creating or updating teams.

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -113,6 +113,11 @@ func (svc *Service) NewTeam(ctx context.Context, p fleet.TeamPayload) (*fleet.Te
 		if len(p.Secrets) > fleet.MaxEnrollSecretsCount {
 			return nil, fleet.NewInvalidArgumentError("secrets", "too many secrets")
 		}
+		for _, s := range p.Secrets {
+			if s == nil || strings.TrimSpace(s.Secret) == "" {
+				return nil, fleet.NewInvalidArgumentError("secrets", "enroll secret must not be empty")
+			}
+		}
 		team.Secrets = p.Secrets
 	} else {
 		// Set up a default enroll secret
@@ -1101,6 +1106,9 @@ func (svc *Service) ModifyTeamEnrollSecrets(ctx context.Context, teamID uint, se
 
 	var newSecrets []*fleet.EnrollSecret
 	for _, secret := range secrets {
+		if strings.TrimSpace(secret.Secret) == "" {
+			return nil, fleet.NewInvalidArgumentError("secrets", "enroll secret must not be empty")
+		}
 		newSecretsValues[secret.Secret] = struct{}{}
 
 		newSecrets = append(newSecrets, &fleet.EnrollSecret{
@@ -1366,6 +1374,11 @@ func (svc *Service) ApplyTeamSpecs(ctx context.Context, specs []*fleet.TeamSpec,
 		}
 		if len(secrets) > fleet.MaxEnrollSecretsCount {
 			return nil, ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("secrets", "too many secrets"), "validate secrets")
+		}
+		for _, s := range secrets {
+			if s == nil || strings.TrimSpace(s.Secret) == "" {
+				return nil, ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("secrets", "enroll secret must not be empty"), "validate secrets")
+			}
 		}
 		// TODO: should we be we validating the other Apple platforms? if so, we should also include
 		// ValidateMDMSettingsAppleSupportedOSVersion for each platform

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -2493,8 +2493,8 @@ func (svc *Service) ApplyEnrollSecretSpec(ctx context.Context, spec *fleet.Enrol
 	}
 
 	for _, s := range spec.Secrets {
-		if s.Secret == "" {
-			return ctxerr.New(ctx, "enroll secret must not be empty")
+		if s == nil || strings.TrimSpace(s.Secret) == "" {
+			return ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("secrets", "enroll secret must not be empty"))
 		}
 	}
 

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -8855,6 +8855,14 @@ func (s *integrationTestSuite) TestAppConfig() {
 		},
 	}, http.StatusUnprocessableEntity, &applyResp)
 
+	// apply spec, empty and whitespace-only secrets are rejected
+	s.DoJSON("POST", "/api/latest/fleet/spec/enroll_secret", applyEnrollSecretSpecRequest{
+		Spec: &fleet.EnrollSecretSpec{Secrets: []*fleet.EnrollSecret{{Secret: ""}}},
+	}, http.StatusUnprocessableEntity, &applyResp)
+	s.DoJSON("POST", "/api/latest/fleet/spec/enroll_secret", applyEnrollSecretSpecRequest{
+		Spec: &fleet.EnrollSecretSpec{Secrets: []*fleet.EnrollSecret{{Secret: "   "}}},
+	}, http.StatusUnprocessableEntity, &applyResp)
+
 	// error conditions should create new activities
 	seenActivitiesIDs[s.lastActivityMatches(activityName, "", 0)] = struct{}{}
 	require.Len(t, seenActivitiesIDs, 1)

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -1728,6 +1728,11 @@ func (s *integrationEnterpriseTestSuite) TestModifyTeamEnrollSecrets() {
 	secrets := createEnrollSecrets(t, fleet.MaxEnrollSecretsCount+1)
 	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d/secrets", team.ID), json.RawMessage(`{"secrets": `+string(jsonMustMarshal(t, secrets))+`}`), http.StatusUnprocessableEntity, &resp)
 
+	// empty and whitespace-only secrets are rejected
+	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d/secrets", team.ID), json.RawMessage(`{"secrets": [{"secret": ""}]}`), http.StatusUnprocessableEntity, &resp)
+	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d/secrets", team.ID), json.RawMessage(`{"secrets": [{"secret": "   "}]}`), http.StatusUnprocessableEntity, &resp)
+	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d/secrets", team.ID), json.RawMessage(`{"secrets": [{"secret": "validSecret"},{"secret": ""}]}`), http.StatusUnprocessableEntity, &resp)
+
 	// No new activities should be generated
 	seenActivitiesIDs[s.lastActivityMatches(activityName, activityDetails, 0)] = struct{}{}
 	require.Len(t, seenActivitiesIDs, 2)
@@ -1986,6 +1991,20 @@ func (s *integrationEnterpriseTestSuite) TestTeamEndpoints() {
 	}
 	tmResp.Team = nil
 	s.DoJSON("POST", "/api/latest/fleet/teams", team3, http.StatusUnprocessableEntity, &tmResp)
+
+	// create a team with an empty enroll secret
+	tmResp.Team = nil
+	s.DoJSON("POST", "/api/latest/fleet/teams", &fleet.Team{
+		Name:    name + "empty_secret",
+		Secrets: []*fleet.EnrollSecret{{Secret: ""}},
+	}, http.StatusUnprocessableEntity, &tmResp)
+
+	// create a team with a whitespace-only enroll secret
+	tmResp.Team = nil
+	s.DoJSON("POST", "/api/latest/fleet/teams", &fleet.Team{
+		Name:    name + "whitespace_secret",
+		Secrets: []*fleet.EnrollSecret{{Secret: "   "}},
+	}, http.StatusUnprocessableEntity, &tmResp)
 
 	// create a team with invalid host expiry window
 	team4 := &fleet.TeamPayload{


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty or whitespace-only enrollment secrets are now rejected when creating or updating teams.
  * Enrollment secret configuration requests now return a validation error for blank values.
  * Batch team configuration applies the same validation consistently.

* **Tests**
  * Added coverage for invalid empty and whitespace-only enrollment secrets across relevant API endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->