### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/burp-suite/darwin.json
+++ b/ee/maintained-apps/outputs/burp-suite/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.4.3",
+      "version": "2026.6",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.install4j.9806-1938-4586-6531.70';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.install4j.9806-1938-4586-6531.70' AND version_compare(bundle_short_version, '2026.4.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.install4j.9806-1938-4586-6531.70' AND version_compare(bundle_short_version, '2026.6') < 0);"
       },
-      "installer_url": "https://portswigger-cdn.net/burp/releases/download?product=desktop&version=2026.4.3&type=MacOsArm64",
+      "installer_url": "https://portswigger-cdn.net/burp/releases/download?product=desktop&version=2026.6&type=MacOsArm64",
       "install_script_ref": "bfa4bf9a",
       "uninstall_script_ref": "6916a6a5",
-      "sha256": "86e8eda2e6ebfd2d7c5ff34bb82bf4872f814cd27beb90535460a37c892c80c2",
+      "sha256": "709a014d0398da2b840a200418e0dfe51fcfb1fb70d44ebf1465973c84e17f8b",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/dot/darwin.json
+++ b/ee/maintained-apps/outputs/dot/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.3.1",
+      "version": "2.3.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.dot.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.dot.app' AND version_compare(bundle_short_version, '2.3.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.dot.app' AND version_compare(bundle_short_version, '2.3.2') < 0);"
       },
-      "installer_url": "https://github.com/prateekkeshari/dot-releases/releases/download/v2.3.1/Dot-2.3.1.dmg",
+      "installer_url": "https://github.com/prateekkeshari/dot-releases/releases/download/v2.3.2/Dot-2.3.2.dmg",
       "install_script_ref": "2fd2fbc1",
       "uninstall_script_ref": "3e5c7f37",
-      "sha256": "1cb99909d66bc2172c3d5bedb26c49fffbd50bef64efec5c865ed7506c35c426",
+      "sha256": "c20cb6377d2fc2897f05a2ed8af2f72f26808bb1a934fb65c119ddb631f2d267",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/evernote/windows.json
+++ b/ee/maintained-apps/outputs/evernote/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "11.24.3",
+      "version": "11.25.6",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Evernote%' AND publisher = 'Evernote Corporation';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Evernote%' AND publisher = 'Evernote Corporation' AND version_compare(version, '11.24.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Evernote%' AND publisher = 'Evernote Corporation' AND version_compare(version, '11.25.6') < 0);"
       },
-      "installer_url": "https://win.desktop.evernote.com/builds/Evernote-11.24.3-win-ddl-stage-20260706102001-4d1c69555043cbd5d20be3e734a462e4281e40dd-setup.exe",
+      "installer_url": "https://win.desktop.evernote.com/builds/Evernote-11.25.6-win-ddl-stage-20260713124857-1aef7b231b1a9c80360692cc2595cae071f6c658-setup.exe",
       "install_script_ref": "5820d576",
       "uninstall_script_ref": "d4142835",
-      "sha256": "6d6307deec55f8bbf1d7cbc7228dc556295008a3d13b59a2a90e4981abe0567d",
+      "sha256": "4b79580f79d65c1b6e32f87e14b42d0bef6c566bbe6151608057b816f52a2e92",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/gdevelop/darwin.json
+++ b/ee/maintained-apps/outputs/gdevelop/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "5.6.273",
+      "version": "5.6.274",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.gdevelop-app.ide';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.gdevelop-app.ide' AND version_compare(bundle_short_version, '5.6.273') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.gdevelop-app.ide' AND version_compare(bundle_short_version, '5.6.274') < 0);"
       },
-      "installer_url": "https://github.com/4ian/GDevelop/releases/download/v5.6.273/GDevelop-5-5.6.273-universal.dmg",
+      "installer_url": "https://github.com/4ian/GDevelop/releases/download/v5.6.274/GDevelop-5-5.6.274-universal.dmg",
       "install_script_ref": "9dcf32af",
       "uninstall_script_ref": "cbcf926e",
-      "sha256": "f3aa271bb6a96278db5e2719073ca6dcce2de09116ab70c3cd39f6febc4b68fa",
+      "sha256": "7caf6448ba7e12c16de859f745a54044102836599aebc068c308c84ae60bbac8",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/kiro/darwin.json
+++ b/ee/maintained-apps/outputs/kiro/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.12.333",
+      "version": "1.0.138",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kiro.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kiro.desktop' AND version_compare(bundle_short_version, '0.12.333') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kiro.desktop' AND version_compare(bundle_short_version, '1.0.138') < 0);"
       },
-      "installer_url": "https://prod.download.desktop.kiro.dev/releases/stable/darwin-arm64/signed/0.12.333/kiro-ide-0.12.333-stable-darwin-arm64.dmg",
+      "installer_url": "https://prod.download.desktop.kiro.dev/releases/stable/darwin-arm64/signed/1.0.138/kiro-ide-1.0.138-stable-darwin-arm64.dmg",
       "install_script_ref": "28c3d1eb",
       "uninstall_script_ref": "b5d79db0",
-      "sha256": "5aee5da57ced87f4d3972de4d35f659ff707977660b52f0f7a7193cf04796fa6",
+      "sha256": "29c7541056b4ca6849d73c1062ae1d215a80a9f7fc74a8240cb2bf9b8e1fd68b",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/postman/windows.json
+++ b/ee/maintained-apps/outputs/postman/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.19.3",
+      "version": "12.19.5",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.19.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.19.5') < 0);"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.19.3/windows_64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.19.5/windows_64",
       "install_script_ref": "8594f0bc",
       "uninstall_script_ref": "fd59d029",
-      "sha256": "e2abd26839034bac8d771c442b20050111b3db68b39b4f4876c75a2e32f54675",
+      "sha256": "5c30c46a0da0202e1fe51e58571ddb333dbc2e3cea7721d4d31dcd68ae2780aa",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/power-automate/windows.json
+++ b/ee/maintained-apps/outputs/power-automate/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.69.00217.26166",
+      "version": "2.70.00187.26189",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Power Automate for desktop' AND publisher = 'Microsoft Corporation';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Power Automate for desktop' AND publisher = 'Microsoft Corporation' AND version_compare(version, '2.69.00217.26166') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Power Automate for desktop' AND publisher = 'Microsoft Corporation' AND version_compare(version, '2.70.00187.26189') < 0);"
       },
-      "installer_url": "https://download.microsoft.com/download/decfd77a-3d28-49c5-9bb8-06916e9f98ec/Setup.Microsoft.PowerAutomate.exe",
+      "installer_url": "https://download.microsoft.com/download/06ed2ff0-ec2c-45c5-abef-ea68e9956f2a/Setup.Microsoft.PowerAutomate.exe",
       "install_script_ref": "20b20659",
       "uninstall_script_ref": "d8400a71",
-      "sha256": "dae55b10d0ed7b8ef5ef531c3d1b615c729b53f11e29ddd86cf8ffa04ce2ceb5",
+      "sha256": "2e7f81be185de1e87383974b670011137392deb8a517c7d2137e8c28491b3ed4",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/spokenly/darwin.json
+++ b/ee/maintained-apps/outputs/spokenly/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.25.0",
+      "version": "2.25.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'app.spokenly';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.spokenly' AND version_compare(bundle_short_version, '2.25.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.spokenly' AND version_compare(bundle_short_version, '2.25.1') < 0);"
       },
-      "installer_url": "https://cdn.spokenly.app/releases/macos/Spokenly-2.25.0.dmg",
+      "installer_url": "https://cdn.spokenly.app/releases/macos/Spokenly-2.25.1.dmg",
       "install_script_ref": "5f8295ce",
       "uninstall_script_ref": "a5d6883d",
-      "sha256": "b3d31118bf7eda804bb5eb8cd1cfe29d5a94dd5d4ddd95de089781e7c734bfb8",
+      "sha256": "3283e9593d260584ec6df1972b880e4b0405321fd570e90910a93d33a953180b",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/vpn-tracker-365/darwin.json
+++ b/ee/maintained-apps/outputs/vpn-tracker-365/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.5",
+      "version": "26.6",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.equinux.VPNTracker365';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.equinux.VPNTracker365' AND version_compare(bundle_short_version, '26.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.equinux.VPNTracker365' AND version_compare(bundle_short_version, '26.6') < 0);"
       },
-      "installer_url": "https://download.equinux.com/files/other/VPN%20Tracker%20365%20-%2026.5.17.zip",
+      "installer_url": "https://download.equinux.com/files/other/VPN%20Tracker%20365%20-%2026.6.17.zip",
       "install_script_ref": "2656907f",
       "uninstall_script_ref": "27f1845a",
-      "sha256": "9ef8eedbe32bb544d52cb2e6f49a81a1da5f1e31a25729eff5b31a7a5ed1a281",
+      "sha256": "e12ef81cd3aa49672fd00957b4754d96008673102d9a29ddb140b93d98c0e59e",
       "default_categories": [
         "Security"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated macOS Burp Suite to version 2026.6.
  - Updated macOS Dot to version 2.3.2.
  - Updated Windows Evernote to version 11.25.6.
  - Updated macOS GDevelop to version 5.6.274.
  - Updated macOS Kiro to version 1.0.138.
  - Updated Windows Postman to version 12.19.5.
  - Updated Power Automate for desktop to version 2.70.00187.26189.
  - Updated macOS Spokenly to version 2.25.1.
  - Updated macOS VPN Tracker 365 to version 26.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->