### PR TITLE
Mask team enroll secrets in team write responses

### DIFF
--- a/changes/16771-gitops-team-secret-leak
+++ b/changes/16771-gitops-team-secret-leak
@@ -1,0 +1,1 @@
+- Fixed team write endpoints (modify team, modify team agent options, and create team) so that they no longer return plaintext enroll secrets to users who cannot read them (such as GitOps), and applied the same secret masking to the list teams response.

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -34,35 +34,42 @@ func obfuscateSecrets(user *fleet.User, teams []*fleet.Team) error {
 		return &authz.Forbidden{}
 	}
 
-	isGlobalObs := user.IsGlobalObserver()
-	isGlobalTechnician := user.GlobalRole != nil && *user.GlobalRole == fleet.RoleTechnician
+	// Only global admins/maintainers and team admins/maintainers are allowed to
+	// read enroll secrets (see the enroll_secret authorization policy). We mask
+	// the secret for every other user, including gitops, observers, observer+,
+	// and technicians, so that being able to modify a team does not imply being
+	// able to read its enroll secrets.
+	canReadGlobal := user.GlobalRole != nil &&
+		(*user.GlobalRole == fleet.RoleAdmin || *user.GlobalRole == fleet.RoleMaintainer)
 
-	teamMemberships := user.TeamMembership(func(t fleet.UserTeam) bool {
-		return true
-	})
-	obsMembership := user.TeamMembership(func(t fleet.UserTeam) bool {
-		return t.Role == fleet.RoleObserver || t.Role == fleet.RoleObserverPlus
-	})
-	isTeamTechnician := user.TeamMembership(func(t fleet.UserTeam) bool {
-		return t.Role == fleet.RoleTechnician
+	canReadTeam := user.TeamMembership(func(t fleet.UserTeam) bool {
+		return t.Role == fleet.RoleAdmin || t.Role == fleet.RoleMaintainer
 	})
 
 	for _, t := range teams {
 		if t == nil {
 			continue
 		}
-		// We mask the password for the following users:
-		// - User has no roles.
-		// - User is a global observer/observer+/technician.
-		// - User does not belong to the team or is a team observer/observer+/technician.
-		if isGlobalObs || isGlobalTechnician ||
-			user.GlobalRole == nil && (!teamMemberships[t.ID] || obsMembership[t.ID] || isTeamTechnician[t.ID]) {
-			for _, s := range t.Secrets {
-				s.Secret = fleet.MaskedPassword
-			}
+		if canReadGlobal || canReadTeam[t.ID] {
+			continue
+		}
+		for _, s := range t.Secrets {
+			s.Secret = fleet.MaskedPassword
 		}
 	}
 	return nil
+}
+
+// maskTeamSecretsForViewer masks the enroll secrets of the given teams for the
+// current viewer, unless they are allowed to read them. It is used on team
+// write endpoints so that being able to modify a team does not imply being able
+// to read its enroll secrets (e.g. gitops).
+func (svc *Service) maskTeamSecretsForViewer(ctx context.Context, teams ...*fleet.Team) error {
+	vc, ok := viewer.FromContext(ctx)
+	if !ok {
+		return fleet.ErrNoContext
+	}
+	return obfuscateSecrets(vc.User, teams)
 }
 
 func (svc *Service) NewTeam(ctx context.Context, p fleet.TeamPayload) (*fleet.Team, error) {
@@ -141,6 +148,13 @@ func (svc *Service) NewTeam(ctx context.Context, p fleet.TeamPayload) (*fleet.Te
 		},
 	); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "create activity for team creation")
+	}
+
+	// Mask enroll secrets for users that are not allowed to read them (e.g.
+	// gitops), so that creating a team does not leak the (possibly
+	// server-generated) plaintext enroll secret to a role that cannot read it.
+	if err := svc.maskTeamSecretsForViewer(ctx, team); err != nil {
+		return nil, err
 	}
 
 	return team, nil
@@ -669,6 +683,14 @@ func (svc *Service) ModifyTeam(ctx context.Context, teamID uint, payload fleet.T
 			}
 		}
 	}
+
+	// Mask enroll secrets for users that are not allowed to read them (e.g.
+	// gitops), so that the write response does not leak plaintext secrets to a
+	// role that cannot read them via the GET endpoints.
+	if err := svc.maskTeamSecretsForViewer(ctx, team); err != nil {
+		return nil, err
+	}
+
 	return team, err
 }
 
@@ -695,6 +717,11 @@ func (svc *Service) ModifyTeamAgentOptions(ctx context.Context, teamID uint, tea
 		}
 	}
 	if applyOptions.DryRun {
+		// Mask enroll secrets so the write response does not leak plaintext
+		// secrets to a role that cannot read them (e.g. gitops).
+		if err := svc.maskTeamSecretsForViewer(ctx, team); err != nil {
+			return nil, err
+		}
 		return team, nil
 	}
 
@@ -719,6 +746,12 @@ func (svc *Service) ModifyTeamAgentOptions(ctx context.Context, teamID uint, tea
 		},
 	); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "create edited agent options activity")
+	}
+
+	// Mask enroll secrets so the write response does not leak plaintext secrets
+	// to a role that cannot read them (e.g. gitops).
+	if err := svc.maskTeamSecretsForViewer(ctx, tm); err != nil {
+		return nil, err
 	}
 
 	return tm, nil

--- a/ee/server/service/teams_test.go
+++ b/ee/server/service/teams_test.go
@@ -918,6 +918,64 @@ func TestObfuscateSecrets(t *testing.T) {
 		}
 	})
 
+	t.Run("user is global gitops", func(t *testing.T) {
+		// gitops can write teams but is not allowed to read enroll secrets, so
+		// the secrets must be masked even in write responses.
+		user := &fleet.User{GlobalRole: new(fleet.RoleGitOps)}
+		teams := buildTeams(3)
+
+		err := obfuscateSecrets(user, teams)
+		require.NoError(t, err)
+
+		for _, team := range teams {
+			for _, s := range team.Secrets {
+				require.Equal(t, fleet.MaskedPassword, s.Secret)
+			}
+		}
+	})
+
+	t.Run("user is global maintainer", func(t *testing.T) {
+		user := &fleet.User{GlobalRole: new(fleet.RoleMaintainer)}
+		teams := buildTeams(3)
+
+		err := obfuscateSecrets(user, teams)
+		require.NoError(t, err)
+
+		for _, team := range teams {
+			for _, s := range team.Secrets {
+				require.NotEqual(t, fleet.MaskedPassword, s.Secret)
+			}
+		}
+	})
+
+	t.Run("user is gitops/maintainer in some teams", func(t *testing.T) {
+		teams := buildTeams(3)
+
+		// Team gitops can modify the team but must not read its enroll secrets,
+		// while team maintainer can. The user is not a member of team 0.
+		user := &fleet.User{Teams: []fleet.UserTeam{
+			{
+				Team: *teams[1],
+				Role: fleet.RoleGitOps,
+			},
+			{
+				Team: *teams[2],
+				Role: fleet.RoleMaintainer,
+			},
+		}}
+
+		err := obfuscateSecrets(user, teams)
+		require.NoError(t, err)
+
+		for i, team := range teams {
+			for _, s := range team.Secrets {
+				// Only team 2 (maintainer) should be visible; team 0 (no
+				// membership) and team 1 (gitops) must be masked.
+				require.Equal(t, fleet.MaskedPassword == s.Secret, i == 0 || i == 1)
+			}
+		}
+	})
+
 	t.Run("user is observer/technician in some teams", func(t *testing.T) {
 		teams := buildTeams(5)
 

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -2342,7 +2342,38 @@ func (s *integrationEnterpriseTestSuite) TestTeamSecretsAreObfuscated() {
 			},
 		},
 	}
-	users := []*fleet.User{global_obs, global_obs_plus, team_obs, team_obs_plus}
+	// team_gitops can modify its team but must not be able to read the team's
+	// enroll secrets (matching the enroll_secret authorization policy).
+	team_gitops := &fleet.User{
+		Name:  "Team GitOps",
+		Email: "team_gitops@example.com",
+		Teams: []fleet.UserTeam{
+			{
+				Team: *teams[0],
+				Role: fleet.RoleGitOps,
+			},
+		},
+	}
+	// team_admin can modify its team and is allowed to read enroll secrets, so
+	// it should still receive the plaintext secret in write responses.
+	team_admin := &fleet.User{
+		Name:  "Team Admin",
+		Email: "team_admin@example.com",
+		Teams: []fleet.UserTeam{
+			{
+				Team: *teams[0],
+				Role: fleet.RoleAdmin,
+			},
+		},
+	}
+	// global_gitops can create and modify any team but must not be able to read
+	// enroll secrets.
+	global_gitops := &fleet.User{
+		Name:       "Global GitOps",
+		Email:      "global_gitops@example.com",
+		GlobalRole: new(fleet.RoleGitOps),
+	}
+	users := []*fleet.User{global_obs, global_obs_plus, team_obs, team_obs_plus, team_gitops, team_admin, global_gitops}
 	for _, u := range users {
 		require.NoError(t, u.SetPassword(test.GoodPassword, 10, 10))
 		_, err := s.ds.NewUser(context.Background(), u)
@@ -2458,6 +2489,82 @@ func (s *integrationEnterpriseTestSuite) TestTeamSecretsAreObfuscated() {
 				}
 			}
 		}
+	}
+
+	// --------------------------------------------------------------------
+	// A team gitops user can modify a team but must not receive plaintext
+	// enroll secrets in the PATCH response (regression test for the write
+	// endpoint leaking secrets to a role that cannot read them).
+	// --------------------------------------------------------------------
+	s.setTokenForTest(t, team_gitops.Email, test.GoodPassword)
+
+	// gitops is forbidden from reading the team and its secrets directly.
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/teams/%d", teams[0].ID), nil, http.StatusForbidden, &getTeamResponse{})
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/teams/%d/secrets", teams[0].ID), nil, http.StatusForbidden, &teamEnrollSecretsResponse{})
+
+	// ...but the PATCH write response must mask the secret.
+	var gitopsPatchResp teamResponse
+	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", teams[0].ID),
+		fleet.TeamPayload{Description: new("patched by gitops")}, http.StatusOK, &gitopsPatchResp)
+	require.NotEmpty(t, gitopsPatchResp.Team.Secrets)
+	for _, secret := range gitopsPatchResp.Team.Secrets {
+		require.Equal(t, fleet.MaskedPassword, secret.Secret)
+	}
+
+	// The modify agent options write endpoint must mask the secret too.
+	var gitopsAgentResp teamResponse
+	s.DoJSON("POST", fmt.Sprintf("/api/latest/fleet/teams/%d/agent_options", teams[0].ID),
+		json.RawMessage(`{}`), http.StatusOK, &gitopsAgentResp)
+	require.NotEmpty(t, gitopsAgentResp.Team.Secrets)
+	for _, secret := range gitopsAgentResp.Team.Secrets {
+		require.Equal(t, fleet.MaskedPassword, secret.Secret)
+	}
+
+	// --------------------------------------------------------------------
+	// A global gitops user must not receive plaintext secrets from the
+	// PATCH response nor when creating a team (the create response can leak
+	// the server-generated enroll secret).
+	// --------------------------------------------------------------------
+	s.setTokenForTest(t, global_gitops.Email, test.GoodPassword)
+
+	var globalGitopsPatchResp teamResponse
+	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", teams[0].ID),
+		fleet.TeamPayload{Description: new("patched by global gitops")}, http.StatusOK, &globalGitopsPatchResp)
+	require.NotEmpty(t, globalGitopsPatchResp.Team.Secrets)
+	for _, secret := range globalGitopsPatchResp.Team.Secrets {
+		require.Equal(t, fleet.MaskedPassword, secret.Secret)
+	}
+
+	var gitopsCreateResp teamResponse
+	s.DoJSON("POST", "/api/latest/fleet/teams",
+		fleet.TeamPayload{Name: new("gitops-created-team")}, http.StatusOK, &gitopsCreateResp)
+	require.NotEmpty(t, gitopsCreateResp.Team.Secrets)
+	for _, secret := range gitopsCreateResp.Team.Secrets {
+		require.Equal(t, fleet.MaskedPassword, secret.Secret)
+	}
+
+	// --------------------------------------------------------------------
+	// A team admin can read enroll secrets, so the PATCH response must
+	// still contain the plaintext secret.
+	// --------------------------------------------------------------------
+	s.setTokenForTest(t, team_admin.Email, test.GoodPassword)
+
+	var adminPatchResp teamResponse
+	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", teams[0].ID),
+		fleet.TeamPayload{Description: new("patched by admin")}, http.StatusOK, &adminPatchResp)
+	require.NotEmpty(t, adminPatchResp.Team.Secrets)
+	for _, secret := range adminPatchResp.Team.Secrets {
+		require.NotEqual(t, fleet.MaskedPassword, secret.Secret)
+	}
+
+	// A global admin creating a team can read the generated secret.
+	s.token = s.getTestAdminToken()
+	var adminCreateResp teamResponse
+	s.DoJSON("POST", "/api/latest/fleet/teams",
+		fleet.TeamPayload{Name: new("admin-created-team")}, http.StatusOK, &adminCreateResp)
+	require.NotEmpty(t, adminCreateResp.Team.Secrets)
+	for _, secret := range adminCreateResp.Team.Secrets {
+		require.NotEqual(t, fleet.MaskedPassword, secret.Secret)
 	}
 }
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves https://github.com/fleetdm/confidential/issues/16771 (Aikido PT-25)

## Summary

A team-scoped or global GitOps user can modify a team but is not permitted to read its enroll secrets (per the `enroll_secret` authorization policy, only global/team admins and maintainers can read them). However, several team **write** endpoints returned the full team object with `secrets[].secret` in **plaintext**, bypassing the read restrictions enforced on the GET endpoints. A GitOps token could send a no-op `PATCH /api/latest/fleet/fleets/{id}` and read the leaked enroll secret from the response, then use it to enroll unauthorized hosts.

This applies the same secret obfuscation used by the read endpoints (`GetTeam`, `ListTeams`) to the team write responses, and extends the shared `obfuscateSecrets` helper to also mask secrets for GitOps.

### Fixed endpoints
- `PATCH /api/latest/fleet/fleets/{id}` (modify team) — the reported vector.
- `POST /api/latest/fleet/fleets/{id}/agent_options` (modify team agent options) — same class, returned existing plaintext secrets to GitOps (including on the dry-run path).
- `POST /api/latest/fleet/fleets` (create team) — returned the (possibly server-generated) plaintext enroll secret to a global GitOps creator.
- `GET /api/latest/fleet/fleets` (list teams) — the shared helper previously did not mask GitOps at all.

### Behavior
- Global/team admins and maintainers still receive plaintext secrets (they are allowed to read them).
- GitOps, observers, observer+, and technicians receive `********` (masked).
- The GitOps workflow (`fleetctl gitops`) is unaffected: it applies teams/secrets via the batch spec endpoint (`ApplyTeamSpecs`), whose response contains only team IDs, and uses `ListTeams` solely for name→ID lookup — it never reads plaintext secrets back.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented.

## Testing

- [x] Added/updated automated tests
  - Unit: `TestObfuscateSecrets` extended with global-gitops, global-maintainer, and mixed team-gitops/maintainer cases.
  - Integration: `TestTeamSecretsAreObfuscated` extended to assert masked secrets on the PATCH, agent-options, and create responses for team + global GitOps, and plaintext for team/global admin.
- [x] QA'd all new/changed functionality manually via the integration tests.

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results

## Manual test plan (for reviewer)

1. As a global admin, create a team and a team-scoped API-only user with role `gitops`.
2. As the GitOps user, confirm `GET /fleets/{id}` and `GET /fleets/{id}/secrets` are `403`.
3. As the GitOps user, `PATCH /fleets/{id}` with `{}` or `{"description":"x"}` → response `team.secrets[].secret` must be `********`.
4. As a team/global admin, the same PATCH → plaintext secret is still returned.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Team enrollment secrets are now masked in team creation and update responses for users without permission to view them.
  * Secret masking also applies to team agent options, including dry-run responses, and team listings.
  * Authorized administrators and maintainers continue to receive readable enrollment secrets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->