### PR TITLE
48792 fix actions dropdown layout shift

### DIFF
--- a/changes/48792-actions-dropdown-layout-shift
+++ b/changes/48792-actions-dropdown-layout-shift
@@ -1,1 +1,1 @@
-* Fixed the page content shifting left when opening the Actions dropdown on the last rows of a table (labels, users, fleets), and the resulting jump when a delete modal opened. The dropdown menu now flips upward when there's no room below instead of stretching the page.
+* Fixed the page content shifting left when opening the Actions dropdown on the last rows of a table (labels, users, fleets), and the resulting jump when a delete modal opened. The dropdown menu now flips upward when there's no room below the trigger.

--- a/changes/48792-actions-dropdown-layout-shift
+++ b/changes/48792-actions-dropdown-layout-shift
@@ -1,0 +1,1 @@
+* Fixed the page content shifting left when opening the Actions dropdown on the last rows of a table (labels, users, fleets), and the resulting jump when a delete modal opened. The dropdown menu now flips upward when there's no room below instead of stretching the page.

--- a/frontend/components/ActionsDropdown/ActionsDropdown.tsx
+++ b/frontend/components/ActionsDropdown/ActionsDropdown.tsx
@@ -319,6 +319,7 @@ const ActionsDropdown = ({
       zIndex: 6,
       border: 0,
       marginTop: isPrimary ? "20px" : "0",
+      marginBottom: isPrimary ? "20px" : "0",
       width: "auto",
       minWidth: "100%",
       position: "absolute",
@@ -395,7 +396,6 @@ const ActionsDropdown = ({
         classNamePrefix={`${baseClass}-select`}
         isOptionDisabled={(option) => !!option.disabled}
         menuPlacement={menuPlacement ?? (insideTable ? "auto" : "bottom")}
-        menuShouldScrollIntoView={insideTable ? false : undefined}
         menuPortalTarget={insideTable ? document.body : undefined}
         {...{ variant }} // Allows CustomDropdownIndicator to be ui-fleet-black-75 for variant: "subdued"
       />

--- a/frontend/components/ActionsDropdown/ActionsDropdown.tsx
+++ b/frontend/components/ActionsDropdown/ActionsDropdown.tsx
@@ -132,7 +132,7 @@ const ActionsDropdown = ({
   isSearchable = false,
   className,
   menuAlign = "default",
-  menuPlacement = "bottom",
+  menuPlacement,
   variant = "subdued",
   buttonLabel,
 }: IActionsDropdownProps): JSX.Element => {
@@ -394,7 +394,8 @@ const ActionsDropdown = ({
         className={dropdownClassnames}
         classNamePrefix={`${baseClass}-select`}
         isOptionDisabled={(option) => !!option.disabled}
-        menuPlacement={menuPlacement}
+        menuPlacement={menuPlacement ?? (insideTable ? "auto" : "bottom")}
+        menuShouldScrollIntoView={insideTable ? false : undefined}
         menuPortalTarget={insideTable ? document.body : undefined}
         {...{ variant }} // Allows CustomDropdownIndicator to be ui-fleet-black-75 for variant: "subdued"
       />


### PR DESCRIPTION
**Related issue:** Resolves #48792

## Summary

Default `menuPlacement` to `"auto"` inside tables so the menu flips upward when there's no room below, instead of stretching the document. Also added `marginBottom` to match the existing `marginTop: 0`, so a flipped-up menu sits flush against its trigger instead of floating 8px above it.

## Screenshot demonstrating the fix
- Labels Page:
<img width="1438" height="625" alt="image" src="https://github.com/user-attachments/assets/269faa0e-3fa4-442a-b10b-3908919db0af" />
- Users Page:
<img width="1445" height="646" alt="image" src="https://github.com/user-attachments/assets/a5a540df-6648-44a3-a557-ea45e800b4ae" />

- Fleets Page:
<img width="1449" height="642" alt="image" src="https://github.com/user-attachments/assets/92ef74e3-c7e9-43b1-92fb-8f5a7e34c612" />


# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually

### Manual QA steps

On a local dev server, with enough rows that the page content exactly fills the viewport (no scrollbar):

1. Settings → Labels (`/labels/manage`), Settings → Users (`/settings/users`), and Settings → Fleets (`/settings/fleets`)
2. Click **Actions** on the **last** row → menu opens upward; `document.documentElement.scrollHeight`, `clientWidth`, and `scrollY` are unchanged (no scrollbar, no 15px shift, no scroll jump)
3. Click **Delete** → modal opens with zero movement of the page behind it
4. Click **Actions** on a **top** row → menu still opens downward as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented horizontal content shifting when opening the Actions dropdown near the bottom of table rows.
  - Updated dropdown positioning to open upward when there isn’t enough space below, reducing visible jumps when launching delete dialogs.
  - Improved dropdown spacing to keep layout consistent across different action button variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->