### PR TITLE
Remove unused `cadvisor` from dev/test `docker-compose.yml`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,17 +131,6 @@ services:
       - "127.0.0.1:${FLEET_SAML_IDP_HTTP_PORT:-9080}:8080"
       - "127.0.0.1:${FLEET_SAML_IDP_HTTPS_PORT:-9443}:8443"
 
-  # CAdvisor container allows monitoring other containers. Useful for
-  # development.
-  cadvisor:
-    image: gcr.io/cadvisor/cadvisor:latest
-    ports:
-      - "127.0.0.1:${FLEET_CADVISOR_PORT:-5678}:8080"
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-      - /sys:/sys:ro
-      - /var/lib/docker/:/var/lib/docker:ro
-
   prometheus:
     image: prom/prometheus:latest
     ports:

--- a/docs/Contributing/getting-started/building-fleet.md
+++ b/docs/Contributing/getting-started/building-fleet.md
@@ -205,7 +205,6 @@ are unaffected.
 | smtp4dev_test | `FLEET_SMTP4DEV_WEB_PORT`, `FLEET_SMTP4DEV_SMTP_PORT` | 8028, 1027 |
 | saml_idp | `FLEET_SAML_IDP_HTTP_PORT`, `FLEET_SAML_IDP_HTTPS_PORT` | 9080, 9443 |
 | localstack | `FLEET_LOCALSTACK_PORT`, `FLEET_LOCALSTACK_LEGACY_PORT` | 4566, 4571 |
-| cadvisor | `FLEET_CADVISOR_PORT` | 5678 |
 | prometheus | `FLEET_PROMETHEUS_PORT` | 9090 |
 
 You can verify resolved ports with:


### PR DESCRIPTION
Reasons to delete:
- We are not using this docker image.
- It's polluting the `docker compose up` logs with errors, e.g.:
```
cadvisor-1            | E0716 17:14:28.835089       1 manager.go:1116] Failed to create existing container: /docker/9ac0ef6fad63613bf90dbfb80e4fcf7affc4a378bbf1c2680f9fa0a587db783f: failed to identify the read-write layer ID for container "9ac0ef6fad63613bf90dbfb80e4fcf7affc4a378bbf1c2680f9fa0a587db783f". - open /var/lib/docker/image/overlayfs/layerdb/mounts/9ac0ef6fad63613bf90dbfb80e4fcf7affc4a378bbf1c2680f9fa0a587db783f/mount-id: no such file or directory
cadvisor-1            | E0716 17:14:28.839077       1 manager.go:1116] Failed to create existing container: /docker/891666c60086c1a695860bf5ea4a1eaf4ada94d902ee7392ddfab1bfd7ed5876: failed to identify the read-write layer ID for container "891666c60086c1a695860bf5ea4a1eaf4ada94d902ee7392ddfab1bfd7ed5876". - open /var/lib/docker/image/overlayfs/layerdb/mounts/891666c60086c1a695860bf5ea4a1eaf4ada94d902ee7392ddfab1bfd7ed5876/mount-id: no such file or directory
cadvisor-1            | E0716 17:14:28.841743       1 manager.go:1116] Failed to create existing container: /docker/bbfd8df39c02cec5d4ad665f4bb23faa5fc374efd7cb1ae0ff4864474c8a1b63: failed to identify the read-write layer ID for container "bbfd8df39c02cec5d4ad665f4bb23faa5fc374efd7cb1ae0ff4864474c8a1b63". - open /var/lib/docker/image/overlayfs/layerdb/mounts/bbfd8df39c02cec5d4ad665f4bb23faa5fc374efd7cb1ae0ff4864474c8a1b63/mount-id: no such file or directory
cadvisor-1            | E0716 17:14:28.844137       1 manager.go:1116] Failed to create existing container: /docker/62cad7aa07068e9ad14319a170622c4658008fd394347aa60e84f79727a03d29: failed to identify the read-write layer ID for container "62cad7aa07068e9ad14319a170622c4658008fd394347aa60e84f79727a03d29". - open /var/lib/docker/image/overlayfs/layerdb/mounts/62cad7aa07068e9ad14319a170622c4658008fd394347aa60e84f79727a03d29/mount-id: no such file or directory
cadvisor-1            | E0716 17:14:28.846207       1 manager.go:1116] Failed to create existing container: /docker/6fc30f822f6ccf81a192b5d385b30f5ed02f162df1c9823774405e0517be3cfe: failed to identify the read-write layer ID for container "6fc30f822f6ccf81a192b5d385b30f5ed02f162df1c9823774405e0517be3cfe". - open /var/lib/docker/image/overlayfs/layerdb/mounts/6fc30f822f6ccf81a192b5d385b30f5ed02f162df1c9823774405e0517be3cfe/mount-id: no such file or directory
cadvisor-1            | E0716 17:14:28.849253       1 manager.go:1116] Failed to create existing container: /docker/a7cec691d2ba6dc8cb8b034729957e6d9bc6dca06813953288d4430cf8d82d28: failed to identify the read-write layer ID for container "a7cec691d2ba6dc8cb8b034729957e6d9bc6dca06813953288d4430cf8d82d28". - open /var/lib/docker/image/overlayfs/layerdb/mounts/a7cec691d2ba6dc8cb8b034729957e6d9bc6dca06813953288d4430cf8d82d28/mount-id: no such file or directory
cadvisor-1            | E0716 17:14:28.851095       1 manager.go:1116] Failed to create existing container: /docker/160d97ff57081d3439843b5e2fd6bea00ef3ee744de51d01be1f6c0c90dec97d: failed to identify the read-write layer ID for container "160d97ff57081d3439843b5e2fd6bea00ef3ee744de51d01be1f6c0c90dec97d". - open /var/lib/docker/image/overlayfs/layerdb/mounts/160d97ff57081d3439843b5e2fd6bea00ef3ee744de51d01be1f6c0c90dec97d/mount-id: no such file or directory
cadvisor-1            | E0716 17:14:28.853019       1 manager.go:1116] Failed to create existing container: /docker/9f5f2f98be4da013911de372e808e33ae93b8f5cb2219adb681f31ee3c1497ed: failed to identify the read-write layer ID for container "9f5f2f98be4da013911de372e808e33ae93b8f5cb2219adb681f31ee3c1497ed". - open /var/lib/docker/image/overlayfs/layerdb/mounts/9f5f2f98be4da013911de372e808e33ae93b8f5cb2219adb681f31ee3c1497ed/mount-id: no such file or directory
cadvisor-1            | E0716 17:14:28.854765       1 manager.go:1116] Failed to create existing container: /docker/c637f0bf6708caeec3fe3b9b610204e84b8b4529cf770c09d6ca2e82f5b681e3: failed to identify the read-write layer ID for container "c637f0bf6708caeec3fe3b9b610204e84b8b4529cf770c09d6ca2e82f5b681e3". - open /var/lib/docker/image/overlayfs/layerdb/mounts/c637f0bf6708caeec3fe3b9b610204e84b8b4529cf770c09d6ca2e82f5b681e3/mount-id: no such file or directory
cadvisor-1            | E0716 17:14:28.856713       1 manager.go:1116] Failed to create existing container: /docker/74953fdfba3c534515113bedef7f17ce01a7feef27ec22000d52ff4f98a538e9: failed to identify the read-write layer ID for container "74953fdfba3c534515113bedef7f17ce01a7feef27ec22000d52ff4f98a538e9". - open /var/lib/docker/image/overlayfs/layerdb/mounts/74953fdfba3c534515113bedef7f17ce01a7feef27ec22000d52ff4f98a538e9/mount-id: no such file or directory
cadvisor-1            | E0716 17:14:28.858256       1 manager.go:1116] Failed to create existing container: /docker/96e468826a675094cf686619e9560a5ed0e089bbca8f3c9c41a5d432d7e7e235: failed to identify the read-write layer ID for container "96e468826a675094cf686619e9560a5ed0e089bbca8f3c9c41a5d432d7e7e235". - open /var/lib/docker/image/overlayfs/layerdb/mounts/96e468826a675094cf686619e9560a5ed0e089bbca8f3c9c41a5d432d7e7e235/mount-id: no such file or directory
cadvisor-1            | E0716 17:14:28.859877       1 manager.go:1116] Failed to create existing container: /docker/785d4800c3249c155f6b921ef554f49851920e5d6a295e1d2ef12fb85a327935: failed to identify the read-write layer ID for container "785d4800c3249c155f6b921ef554f49851920e5d6a295e1d2ef12fb85a327935". - open /var/lib/docker/image/overlayfs/layerdb/mounts/785d4800c3249c155f6b921ef554f49851920e5d6a295e1d2ef12fb85a327935/mount-id: no such file or directory
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the cAdvisor monitoring service from the Docker Compose configuration.
  * The application no longer starts cAdvisor or exposes its monitoring endpoint by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->