### PR TITLE
Fix Okta console navigation in Platform SSO guide

### DIFF
--- a/articles/deploying-okta-platform-sso-with-fleet.md
+++ b/articles/deploying-okta-platform-sso-with-fleet.md
@@ -51,8 +51,8 @@ The recommended approach is to use Fleet as a SCEP proxy with Okta's dynamic cha
 #### Step 1: Generate your Okta SCEP credentials
 
 1. In the Okta Admin Console, go to **Security** → **Device integrations**
-2. Click the **Device Access** tab (not Endpoint management)
-3. Click **Add SCEP configuration**
+2. Click the **Endpoint management** tab
+3. Click **Add platform**
 4. Select **Desktop (Windows and macOS only)**, then click **Next**
 5. On the Add device management platform page, select:
    - **Certificate authority:** Use Okta as certificate authority
@@ -150,8 +150,8 @@ If you prefer to use a static challenge without Fleet acting as a SCEP proxy, fo
 #### Step 1: Generate SCEP URL and secret key
 
 1. In the Okta Admin Console, go to **Security** → **Device integrations**
-2. Click the **Device Access** tab (not Endpoint management)
-3. Click **Add SCEP configuration**
+2. Click the **Endpoint management** tab
+3. Click **Add platform**
 4. Select **Desktop (Windows and macOS only)**, then click **Next**
 5. On the Add device management platform page, select:
    - **Certificate authority:** Use Okta as certificate authority


### PR DESCRIPTION
The "Deploying Platform SSO with Okta Device Access" guide pointed readers to the wrong Okta Admin Console tab and button when generating SCEP credentials, so they couldn't reach the "Use Okta as certificate authority" option.

Correct both the dynamic and static SCEP sections to match Okta's current console flow (Device integrations → Endpoint management → Add platform):
- "Device Access" tab → "Endpoint management" tab
- "Add SCEP configuration" → "Add platform"