### PR TITLE
Docs: remove microsoft_compliance_partner.proxy_api_key reference

### DIFF
--- a/docs/Contributing/reference/configuration-for-contributors.md
+++ b/docs/Contributing/reference/configuration-for-contributors.md
@@ -180,20 +180,6 @@ Whether to send anonymous usage statistics. Overrides the value set by `enable_a
     enable_analytics: false
   ```
 
-### microsoft_compliance_partner.proxy_api_key
-
-For managed cloud customers only. The Fleet team sets this key.
-
-Key that allows the Fleet server to communicate to the Microsoft compliance partner proxy on fleetdm.com.
-
-- Default value: ""
-- Environment variable: `FLEET_MICROSOFT_COMPLIANCE_PARTNER_PROXY_API_KEY`
-- Config file format:
-  ```yaml
-  microsoft_compliance_partner:
-    proxy_api_key: foobar
-  ```
-
 ### mdm.enable_custom_os_updates_and_filevault
 
 Documentation for setting has moved to the [Fleet server configuration](https://fleetdm.com/docs/configuration/fleet-server-configuration#mdm-enable-custom-os-updates-and-filevault) reference.

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -1778,7 +1778,6 @@ None.
     "tier": "premium",
     "organization": "fleet",
     "device_count": 500000,
-    "managed_cloud": false,
     "expiration": "2031-10-16T00:00:00Z",
     "note": ""
   },


### PR DESCRIPTION
**Related issue:** Resolves #47699

# Checklist for submitter

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [x] QA'd all new/changed functionality manually

## What & why

Entra conditional access no longer requires the `microsoft_compliance_partner.proxy_api_key` server configuration (it's gated on the Fleet Premium license tier instead). This removes:
- the `microsoft_compliance_partner.proxy_api_key` entry from the contributor configuration reference, and
- the `managed_cloud` field from the REST API config example (the field was removed from the API).

> Split out of #49414 so the docs change can ship independently.
