### PR TITLE
Fleet UI: Keyboard focus enters, traps in, and restores from modals

### DIFF
--- a/changes/23266-modal-focus-scope
+++ b/changes/23266-modal-focus-scope
@@ -1,0 +1,2 @@
+- Improved keyboard accessibility for modals: focus moves into the modal on open, stays trapped inside while it's open, and returns to the previously focused control when the modal closes.
+- Fixed automations forms auto-submitting when their trigger button was activated with Enter and the key's autorepeat fired before the user released it.

--- a/changes/23266-modal-focus-scope
+++ b/changes/23266-modal-focus-scope
@@ -1,2 +1,2 @@
 - Improved keyboard accessibility for modals: focus moves into the modal on open, stays trapped inside while it's open, and returns to the previously focused control when the modal closes.
-- Fixed automations forms auto-submitting when their trigger button was activated with Enter and the key's autorepeat fired before the user released it.
+- Fixed a bug where holding Enter on the "Manage automations" button could auto-submit the form before the modal opened.

--- a/changes/23266-modal-focus-scope
+++ b/changes/23266-modal-focus-scope
@@ -1,2 +1,3 @@
-- Improved keyboard accessibility for modals: focus moves into the modal on open, stays trapped inside while it's open, and returns to the previously focused control when the modal closes.
+- Improved keyboard accessibility for modals: keyboard focus enters the modal on open and returns to the previously focused control when the modal closes.
 - Fixed a bug where holding Enter on the "Manage automations" button could auto-submit the form before the modal opened.
+- Fixed a bug where pressing Escape closed both modals when one was stacked on top of another.

--- a/frontend/components/Modal/Modal.tests.tsx
+++ b/frontend/components/Modal/Modal.tests.tsx
@@ -242,9 +242,9 @@ describe("Modal", () => {
       expect(modalContainer).toHaveFocus();
     });
 
-    it("skips the focusout redirect when isHidden (stacked modal on top)", async () => {
+    it("does not steal focus on mount when isHidden (stacked modal on top)", () => {
       // When another modal is stacked on top (this modal receives isHidden),
-      // that top modal owns focus. This modal must not fight for it.
+      // that top modal owns focus. This modal must not grab it on mount.
       render(
         <>
           <button type="button" data-testid="stacked">
@@ -259,13 +259,34 @@ describe("Modal", () => {
       const stacked = screen.getByTestId("stacked");
       stacked.focus();
       expect(stacked).toHaveFocus();
+    });
 
-      // Give the effect a tick — if it were going to steal focus, it would.
-      await new Promise((r) => {
-        setTimeout(r, 0);
-      });
+    it("does not refocus on focusout when isHidden", () => {
+      // The bottom modal's focusout listener also has to stand down while a
+      // stacked modal is on top; otherwise every focus movement inside the
+      // top modal would trigger a refocus on the bottom one.
+      render(
+        <>
+          <button type="button" data-testid="stacked">
+            Stacked modal control
+          </button>
+          <Modal title="Bottom" isHidden onExit={noop}>
+            <button type="button">Submit</button>
+          </Modal>
+        </>
+      );
 
-      expect(stacked).toHaveFocus();
+      const stacked = screen.getByTestId("stacked");
+      const modalContainer = document.querySelector(
+        ".modal__modal_container"
+      ) as HTMLElement;
+
+      stacked.focus();
+      // Focus moving between two elements outside the hidden modal — the
+      // hidden modal's listener must not react.
+      fireEvent.focusOut(stacked, { relatedTarget: document.body });
+
+      expect(modalContainer).not.toHaveFocus();
     });
 
     it("does not fire onEnter for autorepeated Enter keys", () => {

--- a/frontend/components/Modal/Modal.tests.tsx
+++ b/frontend/components/Modal/Modal.tests.tsx
@@ -216,6 +216,77 @@ describe("Modal", () => {
       expect(screen.getByRole("button", { name: "Submit" })).not.toHaveFocus();
     });
 
+    it("redirects focus back to the container when it tries to escape", async () => {
+      render(
+        <>
+          <button type="button" data-testid="outside">
+            Outside
+          </button>
+          <Modal title="Confirm" onExit={noop}>
+            <button type="button">Submit</button>
+          </Modal>
+        </>
+      );
+
+      const modalContainer = document.querySelector(
+        ".modal__modal_container"
+      ) as HTMLElement;
+      await waitFor(() => expect(modalContainer).toHaveFocus());
+
+      // Simulate focus escaping the modal (Tab past the last control, or a
+      // stray focus() call landing on background UI).
+      fireEvent.focusOut(modalContainer, {
+        relatedTarget: screen.getByTestId("outside"),
+      });
+
+      expect(modalContainer).toHaveFocus();
+    });
+
+    it("skips the focusout redirect when isHidden (stacked modal on top)", async () => {
+      // When another modal is stacked on top (this modal receives isHidden),
+      // that top modal owns focus. This modal must not fight for it.
+      render(
+        <>
+          <button type="button" data-testid="stacked">
+            Stacked modal control
+          </button>
+          <Modal title="Bottom" isHidden onExit={noop}>
+            <button type="button">Submit</button>
+          </Modal>
+        </>
+      );
+
+      const stacked = screen.getByTestId("stacked");
+      stacked.focus();
+      expect(stacked).toHaveFocus();
+
+      // Give the effect a tick — if it were going to steal focus, it would.
+      await new Promise((r) => {
+        setTimeout(r, 0);
+      });
+
+      expect(stacked).toHaveFocus();
+    });
+
+    it("does not fire onEnter for autorepeated Enter keys", () => {
+      const onEnter = jest.fn();
+      render(
+        <Modal title="Confirm" onEnter={onEnter} onExit={noop}>
+          <div>content</div>
+        </Modal>
+      );
+
+      // The trigger button's Enter is still down when the modal mounts and
+      // this listener attaches; the browser's autorepeat fires more keydowns
+      // with event.repeat === true. Those must not fire onEnter.
+      fireEvent.keyDown(document, { code: "Enter", repeat: true });
+      expect(onEnter).not.toHaveBeenCalled();
+
+      // A fresh Enter (repeat: false) is a real user intent — fires.
+      fireEvent.keyDown(document, { code: "Enter", repeat: false });
+      expect(onEnter).toHaveBeenCalledTimes(1);
+    });
+
     it("restores focus to the previously focused element on close", async () => {
       const Wrapper = () => {
         const [open, setOpen] = useState(false);

--- a/frontend/components/Modal/Modal.tests.tsx
+++ b/frontend/components/Modal/Modal.tests.tsx
@@ -216,35 +216,26 @@ describe("Modal", () => {
       expect(screen.getByRole("button", { name: "Submit" })).not.toHaveFocus();
     });
 
-    it("redirects focus back to the container when it tries to escape", async () => {
+    it("does not steal focus from a child that autofocused itself", async () => {
+      const Autofocused = () => {
+        const ref = React.useRef<HTMLInputElement>(null);
+        React.useEffect(() => {
+          ref.current?.focus();
+        }, []);
+        return <input ref={ref} data-testid="autofocused" />;
+      };
+
       render(
-        <>
-          <button type="button" data-testid="outside">
-            Outside
-          </button>
-          <Modal title="Confirm" onExit={noop}>
-            <button type="button">Submit</button>
-          </Modal>
-        </>
+        <Modal title="Confirm" onExit={noop}>
+          <Autofocused />
+        </Modal>
       );
 
-      const modalContainer = document.querySelector(
-        ".modal__modal_container"
-      ) as HTMLElement;
-      await waitFor(() => expect(modalContainer).toHaveFocus());
-
-      // Simulate focus escaping the modal (Tab past the last control, or a
-      // stray focus() call landing on background UI).
-      fireEvent.focusOut(modalContainer, {
-        relatedTarget: screen.getByTestId("outside"),
-      });
-
-      expect(modalContainer).toHaveFocus();
+      const autofocused = screen.getByTestId("autofocused");
+      await waitFor(() => expect(autofocused).toHaveFocus());
     });
 
     it("does not steal focus on mount when isHidden (stacked modal on top)", () => {
-      // When another modal is stacked on top (this modal receives isHidden),
-      // that top modal owns focus. This modal must not grab it on mount.
       render(
         <>
           <button type="button" data-testid="stacked">
@@ -261,32 +252,16 @@ describe("Modal", () => {
       expect(stacked).toHaveFocus();
     });
 
-    it("does not refocus on focusout when isHidden", () => {
-      // The bottom modal's focusout listener also has to stand down while a
-      // stacked modal is on top; otherwise every focus movement inside the
-      // top modal would trigger a refocus on the bottom one.
+    it("does not close on Escape while isHidden", () => {
+      const onExit = jest.fn();
       render(
-        <>
-          <button type="button" data-testid="stacked">
-            Stacked modal control
-          </button>
-          <Modal title="Bottom" isHidden onExit={noop}>
-            <button type="button">Submit</button>
-          </Modal>
-        </>
+        <Modal title="Bottom" isHidden onExit={onExit}>
+          <div>content</div>
+        </Modal>
       );
 
-      const stacked = screen.getByTestId("stacked");
-      const modalContainer = document.querySelector(
-        ".modal__modal_container"
-      ) as HTMLElement;
-
-      stacked.focus();
-      // Focus moving between two elements outside the hidden modal — the
-      // hidden modal's listener must not react.
-      fireEvent.focusOut(stacked, { relatedTarget: document.body });
-
-      expect(modalContainer).not.toHaveFocus();
+      fireEvent.keyDown(document, { key: "Escape" });
+      expect(onExit).not.toHaveBeenCalled();
     });
 
     it("does not fire onEnter for autorepeated Enter keys", () => {

--- a/frontend/components/Modal/Modal.tests.tsx
+++ b/frontend/components/Modal/Modal.tests.tsx
@@ -201,8 +201,8 @@ describe("Modal", () => {
     // timers in this block so those callbacks actually fire.
     beforeEach(() => jest.useRealTimers());
 
-    it("moves focus to the first control inside the content on open", async () => {
-      render(
+    it("focuses the modal container on open, not any interactive child", async () => {
+      const { container } = render(
         <Modal title="Confirm" onExit={noop}>
           <>
             <button type="button">Submit</button>
@@ -211,9 +211,11 @@ describe("Modal", () => {
         </Modal>
       );
 
+      const modalContainer = container.querySelector(".modal__modal_container");
       await waitFor(() => {
-        expect(screen.getByRole("button", { name: "Submit" })).toHaveFocus();
+        expect(modalContainer).toHaveFocus();
       });
+      expect(screen.getByRole("button", { name: "Submit" })).not.toHaveFocus();
     });
 
     it("keeps focus on the header close button for disabled-content modals", async () => {
@@ -261,10 +263,11 @@ describe("Modal", () => {
       expect(trigger).toHaveFocus();
 
       await user.click(trigger);
+      // Container is now focused (not the interior button).
       await waitFor(() => {
         expect(
           screen.getByRole("button", { name: "Close from inside" })
-        ).toHaveFocus();
+        ).not.toHaveFocus();
       });
 
       await user.click(

--- a/frontend/components/Modal/Modal.tests.tsx
+++ b/frontend/components/Modal/Modal.tests.tsx
@@ -1,6 +1,12 @@
-import React from "react";
+import React, { useState } from "react";
 import { noop } from "lodash";
-import { render, screen, fireEvent, act } from "@testing-library/react";
+import {
+  render,
+  screen,
+  fireEvent,
+  act,
+  waitFor,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import Modal from "./Modal";
@@ -188,5 +194,90 @@ describe("Modal", () => {
     await clickBackground(background);
     act(() => jest.runAllTimers());
     expect(onExit).not.toHaveBeenCalled();
+  });
+
+  describe("focus management", () => {
+    // Radix's FocusScope schedules autofocus with rAF/timeouts. Use real
+    // timers in this block so those callbacks actually fire.
+    beforeEach(() => jest.useRealTimers());
+
+    it("moves focus to the first control inside the content on open", async () => {
+      render(
+        <Modal title="Confirm" onExit={noop}>
+          <>
+            <button type="button">Submit</button>
+            <button type="button">Cancel</button>
+          </>
+        </Modal>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: "Submit" })).toHaveFocus();
+      });
+    });
+
+    it("keeps focus on the header close button for disabled-content modals", async () => {
+      render(
+        <Modal title="Loading" isContentDisabled onExit={noop}>
+          <button type="button">Submit</button>
+        </Modal>
+      );
+
+      // The header X is the first tabbable, so FocusScope's default keeps it.
+      const buttons = screen.getAllByRole("button");
+      await waitFor(() => {
+        expect(buttons[0]).toHaveFocus();
+      });
+      expect(screen.getByRole("button", { name: "Submit" })).not.toHaveFocus();
+    });
+
+    it("restores focus to the previously focused element on close", async () => {
+      const Wrapper = () => {
+        const [open, setOpen] = useState(false);
+        return (
+          <>
+            <button
+              type="button"
+              onClick={() => setOpen(true)}
+              data-testid="trigger"
+            >
+              Open
+            </button>
+            {open && (
+              <Modal title="Confirm" onExit={() => setOpen(false)}>
+                <button type="button" onClick={() => setOpen(false)}>
+                  Close from inside
+                </button>
+              </Modal>
+            )}
+          </>
+        );
+      };
+
+      const user = userEvent.setup();
+      render(<Wrapper />);
+      const trigger = screen.getByTestId("trigger");
+      trigger.focus();
+      expect(trigger).toHaveFocus();
+
+      await user.click(trigger);
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: "Close from inside" })
+        ).toHaveFocus();
+      });
+
+      await user.click(
+        screen.getByRole("button", { name: "Close from inside" })
+      );
+      await waitFor(() => {
+        expect(
+          screen.queryByRole("button", { name: "Close from inside" })
+        ).not.toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(trigger).toHaveFocus();
+      });
+    });
   });
 });

--- a/frontend/components/Modal/Modal.tests.tsx
+++ b/frontend/components/Modal/Modal.tests.tsx
@@ -197,8 +197,6 @@ describe("Modal", () => {
   });
 
   describe("focus management", () => {
-    // Radix's FocusScope schedules autofocus with rAF/timeouts. Use real
-    // timers in this block so those callbacks actually fire.
     beforeEach(() => jest.useRealTimers());
 
     it("focuses the modal container on open, not any interactive child", async () => {
@@ -214,21 +212,6 @@ describe("Modal", () => {
       const modalContainer = container.querySelector(".modal__modal_container");
       await waitFor(() => {
         expect(modalContainer).toHaveFocus();
-      });
-      expect(screen.getByRole("button", { name: "Submit" })).not.toHaveFocus();
-    });
-
-    it("keeps focus on the header close button for disabled-content modals", async () => {
-      render(
-        <Modal title="Loading" isContentDisabled onExit={noop}>
-          <button type="button">Submit</button>
-        </Modal>
-      );
-
-      // The header X is the first tabbable, so FocusScope's default keeps it.
-      const buttons = screen.getAllByRole("button");
-      await waitFor(() => {
-        expect(buttons[0]).toHaveFocus();
       });
       expect(screen.getByRole("button", { name: "Submit" })).not.toHaveFocus();
     });

--- a/frontend/components/Modal/Modal.tsx
+++ b/frontend/components/Modal/Modal.tsx
@@ -7,9 +7,6 @@ import Icon from "components/Icon/Icon";
 const baseClass = "modal";
 const CLOSE_ANIMATION_MS = 100;
 
-const FOCUSABLE_SELECTOR =
-  'button, [href], input:not([type="hidden"]), select, textarea, [tabindex]:not([tabindex="-1"])';
-
 type ModalWidth = "medium" | "large" | "xlarge" | "auto";
 //                  650px    800px      850px      auto
 
@@ -66,20 +63,17 @@ const Modal = ({
   const [isClosing, setIsClosing] = useState(false);
   const isClosingRef = useRef(false);
 
-  // FocusScope's default is to focus the first tabbable in the scope, which
-  // is the close X. For enabled modals, focus into the content instead so
-  // Tab lands on a control, not the dismiss button. Disabled modals keep
-  // the default so the user can still close.
+  // Focus the container (tabIndex=-1) on open rather than the first tabbable
+  // child. Matches WAI-ARIA dialog guidance and — importantly — prevents an
+  // in-flight keydown from the trigger (Enter or Space held for the browser's
+  // autorepeat window) from immediately activating a newly-focused content
+  // button like "Save". First user Tab moves into content from here.
+  // Disabled-content modals keep FocusScope's default (first tabbable = the
+  // header close X) so the user can still dismiss.
   const handleMountAutoFocus = (e: Event) => {
     if (isContentDisabled) return;
-    const contentEl = containerRef.current?.querySelector(
-      `.${baseClass}__content`
-    );
-    const first = contentEl?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
-    if (first) {
-      e.preventDefault();
-      first.focus();
-    }
+    e.preventDefault();
+    containerRef.current?.focus();
   };
 
   const handleClose = useCallback(() => {
@@ -112,6 +106,9 @@ const Modal = ({
   useEffect(() => {
     if (onEnter) {
       const closeOrSaveWithEnterKey = (event: KeyboardEvent) => {
+        // Skip autorepeated keys: the trigger button's Enter may still be
+        // held when the modal mounts and this listener attaches.
+        if (event.repeat) return;
         if (event.code === "Enter" || event.code === "NumpadEnter") {
           event.preventDefault();
           onEnter();

--- a/frontend/components/Modal/Modal.tsx
+++ b/frontend/components/Modal/Modal.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import classnames from "classnames";
 import Button from "components/buttons/Button/Button";
 import Icon from "components/Icon/Icon";
@@ -62,42 +68,31 @@ const Modal = ({
   const [isClosing, setIsClosing] = useState(false);
   const isClosingRef = useRef(false);
 
-  // Latest-value ref so the focusout listener can consult isHidden without
-  // re-running the mount effect (which would steal focus on every toggle).
-  // isHidden signals a sibling modal is stacked on top of this one; that
-  // modal owns focus, so this one should stay out of the way.
+  // Latest-value ref for document-level handlers to consult isHidden without
+  // re-running their mount effects. isHidden signals a sibling modal is
+  // stacked on top of this one; that modal owns focus and keyboard input.
   const isHiddenRef = useRef(isHidden);
-  // Writing during render is deliberate — React's canonical pattern for
-  // mirroring a prop into a ref so long-lived handlers see the latest value.
-  isHiddenRef.current = isHidden;
+  useLayoutEffect(() => {
+    isHiddenRef.current = isHidden;
+  }, [isHidden]);
 
-  // Focus the container on open so the modal is the keyboard landing point;
-  // on close, restore focus to whatever was focused before. Native Tab handles
-  // ordering inside — the focusout listener just redirects escaping focus
-  // back to the container, which effectively wraps at the modal boundary.
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return undefined;
 
     const previouslyFocused = document.activeElement as HTMLElement | null;
-    // Only take focus (and later restore it) if we're the active modal.
-    // A modal mounted with isHidden=true is stacked behind another one that
-    // already owns focus; grabbing focus on unmount would jump the user back
-    // to a stale location.
-    const tookFocus = !isHiddenRef.current;
+    // Skip if a stacked modal is on top or if a child already claimed focus
+    // (e.g. an autoFocused InputField). Restore on unmount only when we took
+    // focus and are not hidden at close time, so a stacked-then-unmount flow
+    // doesn't yank focus away from the top modal.
+    const tookFocus =
+      !isHiddenRef.current && !container.contains(document.activeElement);
     if (tookFocus) container.focus();
 
-    const handleFocusOut = (e: FocusEvent) => {
-      if (isHiddenRef.current) return;
-      const next = e.relatedTarget as Node | null;
-      if (next && !container.contains(next)) container.focus();
-    };
-    document.addEventListener("focusout", handleFocusOut);
-
     return () => {
-      document.removeEventListener("focusout", handleFocusOut);
       if (
         tookFocus &&
+        !isHiddenRef.current &&
         previouslyFocused &&
         document.body.contains(previouslyFocused)
       ) {
@@ -117,6 +112,7 @@ const Modal = ({
 
   useEffect(() => {
     const closeWithEscapeKey = (e: KeyboardEvent) => {
+      if (isHiddenRef.current) return;
       if (e.key === "Escape") {
         handleClose();
       }
@@ -246,7 +242,7 @@ const Modal = ({
       <div
         ref={containerRef}
         className={modalContainerClasses}
-        tabIndex={-1} // Make focusable as the initial keyboard landing target
+        tabIndex={-1}
         onMouseDown={handleContainerMouseDown}
         onMouseUp={handleContainerMouseUp}
         onInput={handleContainerInput}

--- a/frontend/components/Modal/Modal.tsx
+++ b/frontend/components/Modal/Modal.tsx
@@ -62,57 +62,30 @@ const Modal = ({
   const [isClosing, setIsClosing] = useState(false);
   const isClosingRef = useRef(false);
 
-  // Move focus into the modal on open and put it back when it closes. We
-  // deliberately do not intercept Tab or compute a "last tabbable" — native
-  // browser Tab ordering handles that. If focus tries to escape the modal
-  // (Tab past the last control, or a stray focus() call elsewhere), the
-  // focusout handler redirects it back inside.
+  // Focus the container on open so the modal is the keyboard landing point;
+  // on close, restore focus to whatever was focused before. Native Tab handles
+  // ordering inside — the focusout listener just redirects escaping focus
+  // back to the container, which effectively wraps at the modal boundary.
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return undefined;
 
     const previouslyFocused = document.activeElement as HTMLElement | null;
-    const lastFocusedInside: { current: HTMLElement } = { current: container };
-
-    if (isContentDisabled) {
-      // For disabled-content modals put focus on the header close X so the
-      // user can still dismiss.
-      const closeBtn = container.querySelector<HTMLElement>(
-        `.${baseClass}__ex button`
-      );
-      (closeBtn ?? container).focus();
-    } else {
-      container.focus();
-    }
-
-    const handleFocusIn = (e: FocusEvent) => {
-      const target = e.target as HTMLElement | null;
-      if (target && container.contains(target)) {
-        lastFocusedInside.current = target;
-      }
-    };
+    container.focus();
 
     const handleFocusOut = (e: FocusEvent) => {
       const next = e.relatedTarget as Node | null;
-      if (next === null) return;
-      if (container.contains(next)) return;
-      // Focus tried to leave the modal. Put it back on the container so the
-      // next Tab starts a fresh cycle from the first tabbable inside — a
-      // simple wrap that doesn't depend on computing a "last" tabbable.
-      container.focus();
+      if (next && !container.contains(next)) container.focus();
     };
-
-    document.addEventListener("focusin", handleFocusIn);
     document.addEventListener("focusout", handleFocusOut);
 
     return () => {
-      document.removeEventListener("focusin", handleFocusIn);
       document.removeEventListener("focusout", handleFocusOut);
       if (previouslyFocused && document.body.contains(previouslyFocused)) {
         previouslyFocused.focus();
       }
     };
-  }, [isContentDisabled]);
+  }, []);
 
   const handleClose = useCallback(() => {
     if (isClosingRef.current) return;

--- a/frontend/components/Modal/Modal.tsx
+++ b/frontend/components/Modal/Modal.tsx
@@ -62,6 +62,13 @@ const Modal = ({
   const [isClosing, setIsClosing] = useState(false);
   const isClosingRef = useRef(false);
 
+  // Latest-value ref so the focusout listener can consult isHidden without
+  // re-running the mount effect (which would steal focus on every toggle).
+  // isHidden signals a sibling modal is stacked on top of this one; that
+  // modal owns focus, so this one should stay out of the way.
+  const isHiddenRef = useRef(isHidden);
+  isHiddenRef.current = isHidden;
+
   // Focus the container on open so the modal is the keyboard landing point;
   // on close, restore focus to whatever was focused before. Native Tab handles
   // ordering inside — the focusout listener just redirects escaping focus
@@ -71,9 +78,10 @@ const Modal = ({
     if (!container) return undefined;
 
     const previouslyFocused = document.activeElement as HTMLElement | null;
-    container.focus();
+    if (!isHiddenRef.current) container.focus();
 
     const handleFocusOut = (e: FocusEvent) => {
+      if (isHiddenRef.current) return;
       const next = e.relatedTarget as Node | null;
       if (next && !container.contains(next)) container.focus();
     };

--- a/frontend/components/Modal/Modal.tsx
+++ b/frontend/components/Modal/Modal.tsx
@@ -78,7 +78,12 @@ const Modal = ({
     if (!container) return undefined;
 
     const previouslyFocused = document.activeElement as HTMLElement | null;
-    if (!isHiddenRef.current) container.focus();
+    // Only take focus (and later restore it) if we're the active modal.
+    // A modal mounted with isHidden=true is stacked behind another one that
+    // already owns focus; grabbing focus on unmount would jump the user back
+    // to a stale location.
+    const tookFocus = !isHiddenRef.current;
+    if (tookFocus) container.focus();
 
     const handleFocusOut = (e: FocusEvent) => {
       if (isHiddenRef.current) return;
@@ -89,7 +94,11 @@ const Modal = ({
 
     return () => {
       document.removeEventListener("focusout", handleFocusOut);
-      if (previouslyFocused && document.body.contains(previouslyFocused)) {
+      if (
+        tookFocus &&
+        previouslyFocused &&
+        document.body.contains(previouslyFocused)
+      ) {
         previouslyFocused.focus();
       }
     };
@@ -125,6 +134,8 @@ const Modal = ({
   useEffect(() => {
     if (onEnter) {
       const closeOrSaveWithEnterKey = (event: KeyboardEvent) => {
+        // Ignore Enter while a stacked modal is on top of this one.
+        if (isHiddenRef.current) return;
         // Skip autorepeated keys: the trigger button's Enter may still be
         // held when the modal mounts and this listener attaches.
         if (event.repeat) return;

--- a/frontend/components/Modal/Modal.tsx
+++ b/frontend/components/Modal/Modal.tsx
@@ -67,6 +67,8 @@ const Modal = ({
   // isHidden signals a sibling modal is stacked on top of this one; that
   // modal owns focus, so this one should stay out of the way.
   const isHiddenRef = useRef(isHidden);
+  // Writing during render is deliberate — React's canonical pattern for
+  // mirroring a prop into a ref so long-lived handlers see the latest value.
   isHiddenRef.current = isHidden;
 
   // Focus the container on open so the modal is the keyboard landing point;

--- a/frontend/components/Modal/Modal.tsx
+++ b/frontend/components/Modal/Modal.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { FocusScope } from "@radix-ui/react-focus-scope";
 import classnames from "classnames";
 import Button from "components/buttons/Button/Button";
 import Icon from "components/Icon/Icon";
@@ -63,18 +62,57 @@ const Modal = ({
   const [isClosing, setIsClosing] = useState(false);
   const isClosingRef = useRef(false);
 
-  // Focus the container (tabIndex=-1) on open rather than the first tabbable
-  // child. Matches WAI-ARIA dialog guidance and — importantly — prevents an
-  // in-flight keydown from the trigger (Enter or Space held for the browser's
-  // autorepeat window) from immediately activating a newly-focused content
-  // button like "Save". First user Tab moves into content from here.
-  // Disabled-content modals keep FocusScope's default (first tabbable = the
-  // header close X) so the user can still dismiss.
-  const handleMountAutoFocus = (e: Event) => {
-    if (isContentDisabled) return;
-    e.preventDefault();
-    containerRef.current?.focus();
-  };
+  // Move focus into the modal on open and put it back when it closes. We
+  // deliberately do not intercept Tab or compute a "last tabbable" — native
+  // browser Tab ordering handles that. If focus tries to escape the modal
+  // (Tab past the last control, or a stray focus() call elsewhere), the
+  // focusout handler redirects it back inside.
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return undefined;
+
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    const lastFocusedInside: { current: HTMLElement } = { current: container };
+
+    if (isContentDisabled) {
+      // For disabled-content modals put focus on the header close X so the
+      // user can still dismiss.
+      const closeBtn = container.querySelector<HTMLElement>(
+        `.${baseClass}__ex button`
+      );
+      (closeBtn ?? container).focus();
+    } else {
+      container.focus();
+    }
+
+    const handleFocusIn = (e: FocusEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (target && container.contains(target)) {
+        lastFocusedInside.current = target;
+      }
+    };
+
+    const handleFocusOut = (e: FocusEvent) => {
+      const next = e.relatedTarget as Node | null;
+      if (next === null) return;
+      if (container.contains(next)) return;
+      // Focus tried to leave the modal. Put it back on the container so the
+      // next Tab starts a fresh cycle from the first tabbable inside — a
+      // simple wrap that doesn't depend on computing a "last" tabbable.
+      container.focus();
+    };
+
+    document.addEventListener("focusin", handleFocusIn);
+    document.addEventListener("focusout", handleFocusOut);
+
+    return () => {
+      document.removeEventListener("focusin", handleFocusIn);
+      document.removeEventListener("focusout", handleFocusOut);
+      if (previouslyFocused && document.body.contains(previouslyFocused)) {
+        previouslyFocused.focus();
+      }
+    };
+  }, [isContentDisabled]);
 
   const handleClose = useCallback(() => {
     if (isClosingRef.current) return;
@@ -211,34 +249,32 @@ const Modal = ({
       onMouseDown={handleBackgroundMouseDown}
       onMouseUp={handleBackgroundMouseUp}
     >
-      <FocusScope asChild loop trapped onMountAutoFocus={handleMountAutoFocus}>
-        <div
-          ref={containerRef}
-          className={modalContainerClasses}
-          tabIndex={-1} // Make focusable
-          onMouseDown={handleContainerMouseDown}
-          onMouseUp={handleContainerMouseUp}
-          onInput={handleContainerInput}
-          onClick={handleContainerClick}
-        >
-          <div className={`${baseClass}__header`}>
-            <span>{title}</span>
-            {!disableClosingModal && (
-              <div className={`${baseClass}__ex`}>
-                <Button variant="subdued" onClick={handleClose}>
-                  <Icon name="close" color="core-fleet-black" size="medium" />
-                </Button>
-              </div>
-            )}
-          </div>
-          <div className={contentWrapperClasses}>
-            {isContentDisabled && (
-              <div className={`${baseClass}__disabled-overlay`} />
-            )}
-            <div className={contentClasses}>{children}</div>
-          </div>
+      <div
+        ref={containerRef}
+        className={modalContainerClasses}
+        tabIndex={-1} // Make focusable as the initial keyboard landing target
+        onMouseDown={handleContainerMouseDown}
+        onMouseUp={handleContainerMouseUp}
+        onInput={handleContainerInput}
+        onClick={handleContainerClick}
+      >
+        <div className={`${baseClass}__header`}>
+          <span>{title}</span>
+          {!disableClosingModal && (
+            <div className={`${baseClass}__ex`}>
+              <Button variant="subdued" onClick={handleClose}>
+                <Icon name="close" color="core-fleet-black" size="medium" />
+              </Button>
+            </div>
+          )}
         </div>
-      </FocusScope>
+        <div className={contentWrapperClasses}>
+          {isContentDisabled && (
+            <div className={`${baseClass}__disabled-overlay`} />
+          )}
+          <div className={contentClasses}>{children}</div>
+        </div>
+      </div>
     </div>
   );
 };

--- a/frontend/components/Modal/Modal.tsx
+++ b/frontend/components/Modal/Modal.tsx
@@ -1,10 +1,14 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
+import { FocusScope } from "@radix-ui/react-focus-scope";
 import classnames from "classnames";
 import Button from "components/buttons/Button/Button";
 import Icon from "components/Icon/Icon";
 
 const baseClass = "modal";
 const CLOSE_ANIMATION_MS = 100;
+
+const FOCUSABLE_SELECTOR =
+  'button, [href], input:not([type="hidden"]), select, textarea, [tabindex]:not([tabindex="-1"])';
 
 type ModalWidth = "medium" | "large" | "xlarge" | "auto";
 //                  650px    800px      850px      auto
@@ -56,10 +60,27 @@ const Modal = ({
   disableClosingModal = false,
   className,
 }: IModalProps): JSX.Element => {
+  const containerRef = useRef<HTMLDivElement>(null);
   const isDownOnBackgroundRef = useRef(false);
   const isFormDirtyRef = useRef(false);
   const [isClosing, setIsClosing] = useState(false);
   const isClosingRef = useRef(false);
+
+  // FocusScope's default is to focus the first tabbable in the scope, which
+  // is the close X. For enabled modals, focus into the content instead so
+  // Tab lands on a control, not the dismiss button. Disabled modals keep
+  // the default so the user can still close.
+  const handleMountAutoFocus = (e: Event) => {
+    if (isContentDisabled) return;
+    const contentEl = containerRef.current?.querySelector(
+      `.${baseClass}__content`
+    );
+    const first = contentEl?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
+    if (first) {
+      e.preventDefault();
+      first.focus();
+    }
+  };
 
   const handleClose = useCallback(() => {
     if (isClosingRef.current) return;
@@ -193,35 +214,34 @@ const Modal = ({
       onMouseDown={handleBackgroundMouseDown}
       onMouseUp={handleBackgroundMouseUp}
     >
-      <div
-        className={modalContainerClasses}
-        tabIndex={-1} // Make focusable
-        onMouseDown={handleContainerMouseDown}
-        onMouseUp={handleContainerMouseUp}
-        onInput={handleContainerInput}
-        onClick={handleContainerClick}
-      >
-        <div className={`${baseClass}__header`}>
-          <span>{title}</span>
-          {!disableClosingModal && (
-            <div className={`${baseClass}__ex`}>
-              <Button
-                variant="subdued"
-                onClick={handleClose}
-                autofocus={isContentDisabled}
-              >
-                <Icon name="close" color="core-fleet-black" size="medium" />
-              </Button>
-            </div>
-          )}
+      <FocusScope asChild loop trapped onMountAutoFocus={handleMountAutoFocus}>
+        <div
+          ref={containerRef}
+          className={modalContainerClasses}
+          tabIndex={-1} // Make focusable
+          onMouseDown={handleContainerMouseDown}
+          onMouseUp={handleContainerMouseUp}
+          onInput={handleContainerInput}
+          onClick={handleContainerClick}
+        >
+          <div className={`${baseClass}__header`}>
+            <span>{title}</span>
+            {!disableClosingModal && (
+              <div className={`${baseClass}__ex`}>
+                <Button variant="subdued" onClick={handleClose}>
+                  <Icon name="close" color="core-fleet-black" size="medium" />
+                </Button>
+              </div>
+            )}
+          </div>
+          <div className={contentWrapperClasses}>
+            {isContentDisabled && (
+              <div className={`${baseClass}__disabled-overlay`} />
+            )}
+            <div className={contentClasses}>{children}</div>
+          </div>
         </div>
-        <div className={contentWrapperClasses}>
-          {isContentDisabled && (
-            <div className={`${baseClass}__disabled-overlay`} />
-          )}
-          <div className={contentClasses}>{children}</div>
-        </div>
-      </div>
+      </FocusScope>
     </div>
   );
 };

--- a/frontend/components/Modal/_styles.scss
+++ b/frontend/components/Modal/_styles.scss
@@ -71,6 +71,14 @@
     border-radius: 8px;
     animation: scale-up 150ms ease-out;
 
+    // Container receives focus only as a landing target for keyboard users
+    // (tabIndex=-1). It's not an interactive control, so suppress the
+    // browser's focus ring on the whole modal.
+    &:focus,
+    &:focus-visible {
+      outline: none;
+    }
+
     &.modal__closing {
       animation: scale-down var(--modal-close-duration) ease-in forwards;
     }

--- a/frontend/pages/queries/ManageQueriesPage/components/ManageQueryAutomationsModal/ManageQueryAutomationsModal.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/ManageQueryAutomationsModal/ManageQueryAutomationsModal.tsx
@@ -138,31 +138,19 @@ const ManageQueryAutomationsModal = ({
     });
   };
 
-  useEffect(() => {
-    const listener = (event: KeyboardEvent) => {
-      // Skip autorepeated keys — the trigger button's Enter may still be
-      // held when this listener attaches, which would auto-submit the form.
-      if (event.repeat) return;
-      if (event.code === "Enter" || event.code === "NumpadEnter") {
-        event.preventDefault();
-        onSubmit({
-          newAutomatedQueryIds: queryItems
-            .filter((p) => p.isChecked)
-            .map((p) => p.id),
-          previousAutomatedQueryIds: automatedQueryIds,
-        });
-      }
-    };
-    document.addEventListener("keydown", listener);
-    return () => {
-      document.removeEventListener("keydown", listener);
-    };
-  });
+  const submitSelected = () =>
+    onSubmit({
+      newAutomatedQueryIds: queryItems
+        .filter((p) => p.isChecked)
+        .map((p) => p.id),
+      previousAutomatedQueryIds: automatedQueryIds,
+    });
 
   return (
     <Modal
       title="Manage automations"
       onExit={onCancel}
+      onEnter={submitSelected}
       className={baseClass}
       width="large"
       isHidden={isShowingPreviewDataModal}

--- a/frontend/pages/queries/ManageQueriesPage/components/ManageQueryAutomationsModal/ManageQueryAutomationsModal.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/ManageQueryAutomationsModal/ManageQueryAutomationsModal.tsx
@@ -140,6 +140,9 @@ const ManageQueryAutomationsModal = ({
 
   useEffect(() => {
     const listener = (event: KeyboardEvent) => {
+      // Skip autorepeated keys — the trigger button's Enter may still be
+      // held when this listener attaches, which would auto-submit the form.
+      if (event.repeat) return;
       if (event.code === "Enter" || event.code === "NumpadEnter") {
         event.preventDefault();
         onSubmit({

--- a/frontend/pages/queries/ManageQueriesPage/components/ManageQueryAutomationsModal/ManageQueryAutomationsModal.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/ManageQueryAutomationsModal/ManageQueryAutomationsModal.tsx
@@ -124,31 +124,25 @@ const ManageQueryAutomationsModal = ({
     );
   };
 
-  const submitSelected = () =>
+  const onSubmitQueryAutomations = (evt: React.FormEvent<HTMLFormElement>) => {
+    evt.preventDefault();
     onSubmit({
       newAutomatedQueryIds: queryItems
         .filter((p) => p.isChecked)
         .map((p) => p.id),
       previousAutomatedQueryIds: automatedQueryIds,
     });
-
-  const onSubmitQueryAutomations = (
-    evt: React.MouseEvent<HTMLFormElement> | KeyboardEvent
-  ) => {
-    evt.preventDefault();
-    submitSelected();
   };
 
   return (
     <Modal
       title="Manage automations"
       onExit={onCancel}
-      onEnter={submitSelected}
       className={baseClass}
       width="large"
       isHidden={isShowingPreviewDataModal}
     >
-      <div className={`${baseClass} form`}>
+      <form className={`${baseClass} form`} onSubmit={onSubmitQueryAutomations}>
         <div className={`${baseClass}__heading`}>
           Report automations let you send data gathered from macOS, Windows, and
           Linux hosts to a log destination. Data is sent according to a
@@ -222,7 +216,6 @@ const ManageQueryAutomationsModal = ({
             renderChildren={(disableChildren) => (
               <Button
                 type="submit"
-                onClick={onSubmitQueryAutomations}
                 className="save-loading"
                 isLoading={isUpdatingAutomations}
                 disabled={disableChildren}
@@ -235,7 +228,7 @@ const ManageQueryAutomationsModal = ({
             Cancel
           </Button>
         </div>
-      </div>
+      </form>
     </Modal>
   );
 };

--- a/frontend/pages/queries/ManageQueriesPage/components/ManageQueryAutomationsModal/ManageQueryAutomationsModal.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/ManageQueryAutomationsModal/ManageQueryAutomationsModal.tsx
@@ -124,20 +124,6 @@ const ManageQueryAutomationsModal = ({
     );
   };
 
-  const onSubmitQueryAutomations = (
-    evt: React.MouseEvent<HTMLFormElement> | KeyboardEvent
-  ) => {
-    evt.preventDefault();
-
-    const newQueryIds: number[] = [];
-    queryItems?.forEach((p) => p.isChecked && newQueryIds.push(p.id));
-
-    onSubmit({
-      newAutomatedQueryIds: newQueryIds,
-      previousAutomatedQueryIds: automatedQueryIds,
-    });
-  };
-
   const submitSelected = () =>
     onSubmit({
       newAutomatedQueryIds: queryItems
@@ -145,6 +131,13 @@ const ManageQueryAutomationsModal = ({
         .map((p) => p.id),
       previousAutomatedQueryIds: automatedQueryIds,
     });
+
+  const onSubmitQueryAutomations = (
+    evt: React.MouseEvent<HTMLFormElement> | KeyboardEvent
+  ) => {
+    evt.preventDefault();
+    submitSelected();
+  };
 
   return (
     <Modal

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@radix-ui/react-focus-scope": "1.1.7",
     "@sgress454/node-sql-parser": "5.4.0-fork.2",
     "@types/dompurify": "3.0.2",
     "ace-builds": "1.4.14",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@radix-ui/react-focus-scope": "1.1.7",
     "@sgress454/node-sql-parser": "5.4.0-fork.2",
     "@types/dompurify": "3.0.2",
     "ace-builds": "1.4.14",


### PR DESCRIPTION
## Issue
Part of #23266. Supersedes #25020.

## Description
- Keyboard focus enters the modal on open (container is the landing target) and returns to the previously focused control on close.
- Skips the mount focus grab if a child has already claimed focus (e.g. an `autoFocus` InputField), and skips the on-close restore if the modal is currently hidden by a stacked modal — avoids yanking focus from the top modal.
- Stacked modals honor `isHidden` for both Escape and Enter so pressing either key only affects the top modal.
- Fixes an autorepeat-Enter bug on \`Modal.onEnter\`: holding Enter to open a modal no longer fires the built-in handler on the still-pressed keydown.
- \`ManageQueryAutomationsModal\` now submits via a native \`<form onSubmit>\`, so Enter on Save submits once (not twice), Enter on Cancel or Example-data doesn't submit, and a disabled Save is respected.
- Modal container no longer shows a focus ring on itself; it's a programmatic landing target, not an interactive control.

## Screenrecording

https://github.com/user-attachments/assets/b361735c-6740-4931-bbc3-0a7a39dcb23f

## Testing
- Added focus-management tests to \`Modal.tests.tsx\` (mount focus, mount-skip when child autofocused, mount-skip when \`isHidden\`, Escape ignored when \`isHidden\`, autorepeat Enter guard, restore-on-close). All 14 Modal tests pass.
- Manually QA'd on the reports/manage automations flow (autorepeat Enter no longer auto-submits) and on the software/inventory filters modal (Tab reaches every enabled control after toggling "Vulnerable software" on).

# Checklist for submitter

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually