### PR TITLE
Clarify description for Rotate FileVault key command

### DIFF
--- a/docs/mdm-commands.yml
+++ b/docs/mdm-commands.yml
@@ -1691,7 +1691,7 @@
   platform: apple
   category: Security
   externalDocumentationUrl: https://developer.apple.com/documentation/devicemanagement/rotate-filevault-key-command
-  description: Clear the Activation Lock bypass code on a device.
+  description: Rotate the FileValt key on a device.
   supportedDeviceTypes:
     - macOS 10.9+
   command: |

--- a/docs/mdm-commands.yml
+++ b/docs/mdm-commands.yml
@@ -1691,7 +1691,7 @@
   platform: apple
   category: Security
   externalDocumentationUrl: https://developer.apple.com/documentation/devicemanagement/rotate-filevault-key-command
-  description: Rotate the FileValt key on a device.
+  description: Rotate the FileVault key on a device.
   supportedDeviceTypes:
     - macOS 10.9+
   command: |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Apple MDM documentation for the “Rotate FileVault key” command to provide the correct description (replacing an inaccurate reference).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->