### PR TITLE
Show .py script-only packages as available for install on macOS hosts

### DIFF
--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -1540,7 +1540,7 @@ func (svc *Service) resolveFirstAddedInScopeInstaller(ctx context.Context, host 
 }
 
 // installerCompatibleWithHost reports whether the installer's package can run on the host's platform.
-// Mirrors the platform gate in installSoftwareTitleUsingInstaller (.sh runs on any unix-like host).
+// Mirrors the platform gate in installSoftwareTitleUsingInstaller (.sh and .py run on any unix-like host).
 func installerCompatibleWithHost(installer *fleet.SoftwareInstaller, host *fleet.Host) bool {
 	ext, requiredPlatform := installerRequiredPlatform(installer)
 	if requiredPlatform == "" {
@@ -1549,7 +1549,7 @@ func installerCompatibleWithHost(installer *fleet.SoftwareInstaller, host *fleet
 	if host.FleetPlatform() == requiredPlatform {
 		return true
 	}
-	return ext == ".sh" && fleet.IsUnixLike(host.Platform)
+	return (ext == ".sh" || ext == ".py") && fleet.IsUnixLike(host.Platform)
 }
 
 func (svc *Service) InstallSoftwareTitle(ctx context.Context, hostID uint, softwareTitleID uint) error {

--- a/ee/server/service/software_installers_test.go
+++ b/ee/server/service/software_installers_test.go
@@ -1559,6 +1559,39 @@ func TestInstallShScriptOnDarwin(t *testing.T) {
 	require.True(t, ds.InsertSoftwareInstallRequestFuncInvoked, "install request should be created")
 }
 
+// TestInstallerCompatibleWithHost verifies that .sh and .py script packages
+// (stored as platform='linux') are compatible with any unix-like host.
+func TestInstallerCompatibleWithHost(t *testing.T) {
+	t.Parallel()
+
+	installer := func(name, platform string) *fleet.SoftwareInstaller {
+		return &fleet.SoftwareInstaller{Name: name, Platform: platform}
+	}
+	host := func(platform string) *fleet.Host { return &fleet.Host{Platform: platform} }
+
+	cases := []struct {
+		name      string
+		installer *fleet.SoftwareInstaller
+		host      *fleet.Host
+		want      bool
+	}{
+		{".py on darwin", installer("script.py", "linux"), host("darwin"), true},
+		{".py on ubuntu", installer("script.py", "linux"), host("ubuntu"), true},
+		{".py on windows", installer("script.py", "linux"), host("windows"), false},
+		{".sh on darwin", installer("script.sh", "linux"), host("darwin"), true},
+		{".sh on ubuntu", installer("script.sh", "linux"), host("ubuntu"), true},
+		{".sh on windows", installer("script.sh", "linux"), host("windows"), false},
+		{".deb on darwin", installer("installer.deb", "linux"), host("darwin"), false},
+		{".pkg on darwin", installer("app.pkg", "darwin"), host("darwin"), true},
+		{".pkg on ubuntu", installer("app.pkg", "darwin"), host("ubuntu"), false},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, installerCompatibleWithHost(tt.installer, tt.host))
+		})
+	}
+}
+
 // TestInstallZipInstallerUsesStoredPlatform tests that .zip installers use the
 // stored platform (windows or darwin) rather than inferring darwin from the extension.
 func TestInstallZipInstallerUsesStoredPlatform(t *testing.T) {

--- a/frontend/utilities/file/fileUtils.tsx
+++ b/frontend/utilities/file/fileUtils.tsx
@@ -71,7 +71,8 @@ export const getExtensionFromFileName = (fileName: string) => {
 };
 
 /** This gets the platform display name from the file.
- * Includes nuance for .sh software installers only supported on Linux
+ * Script packages (.sh, .py) map to "macOS & Linux" since they run on both;
+ * .ipa maps to iOS/iPadOS with a tooltip noting it covers both.
  */
 export const getPlatformDisplayName = (file: File) => {
   const fileExt = getExtensionFromFileName(file.name);

--- a/server/datastore/mysql/setup_experience.go
+++ b/server/datastore/mysql/setup_experience.go
@@ -541,8 +541,8 @@ VALUES %s`
 				switch {
 				case tuple.Platform == platform:
 					nativeSoftwareIDs = append(nativeSoftwareIDs, tuple.ID)
-				case platform == string(fleet.MacOSPlatform) && tuple.Platform == "linux" && tuple.Extension == "sh":
-					// .sh scripts can run on macOS; track the selection in the cross-platform table.
+				case platform == string(fleet.MacOSPlatform) && tuple.Platform == "linux" && (tuple.Extension == "sh" || tuple.Extension == "py"):
+					// .sh and .py scripts can run on macOS; track the selection in the cross-platform table.
 					crossSoftwareIDs = append(crossSoftwareIDs, tuple.ID)
 				default:
 					return ctxerr.Wrap(ctx, &fleet.BadRequestError{

--- a/server/datastore/mysql/setup_experience.go
+++ b/server/datastore/mysql/setup_experience.go
@@ -230,8 +230,8 @@ AND (
 		-- platform is 'linux', so we must check if the installer is compatible with the linux distribution.
 		OR
 		(
-			-- tar.gz and sh can be installed on any Linux distribution
-			(si.extension = 'tar.gz' OR si.extension = 'sh')
+			-- tar.gz, sh, and py can be installed on any Linux distribution
+			(si.extension IN ('tar.gz', 'sh', 'py'))
 			OR
 			(
 				-- deb packages can only be installed on Debian-based hosts.
@@ -257,8 +257,8 @@ AND %s`
 			softwareArgs = append(softwareArgs, hostUUID)
 		}
 
-		// .sh installers are stored with platform='linux' but can run on darwin too,
-		// so include any cross-selected for macOS setup experience.
+		// .sh and .py installers are stored with platform='linux' but can run on darwin
+		// too, so include any cross-selected for macOS setup experience.
 		if fleetPlatform == "darwin" {
 			crossInstallerSelect := `
 SELECT
@@ -279,7 +279,7 @@ INNER JOIN setup_experience_software_installers seti
 	ON seti.software_installer_id = si.id AND seti.platform = 'darwin' AND seti.global_or_team_id = ?
 WHERE si.is_active = TRUE
 AND si.platform = 'linux'
-AND si.extension = 'sh'
+AND si.extension IN ('sh', 'py')
 AND %s`
 			if resetFailedSetupSteps {
 				crossInstallerSelect = fmt.Sprintf(crossInstallerSelect, "si.id NOT IN (SELECT software_installer_id FROM setup_experience_status_results WHERE host_uuid = ? AND status = 'success' AND software_installer_id IS NOT NULL)")

--- a/server/datastore/mysql/setup_experience_test.go
+++ b/server/datastore/mysql/setup_experience_test.go
@@ -41,6 +41,7 @@ func TestSetupExperience(t *testing.T) {
 		{"PolicyGate", testSetupExperiencePolicyGate},
 		{"PolicyGateResultLookups", testSetupExperiencePolicyGateResultLookups},
 		{"CrossPlatformShScripts", testSetupExperienceCrossPlatformShScripts},
+		{"CrossPlatformPyScripts", testSetupExperienceCrossPlatformPyScripts},
 		{"FirstAddedPerTitleNoDoubleQueue", testEnqueueSetupExperienceFirstAddedPerTitle},
 	}
 
@@ -2747,6 +2748,103 @@ func testSetupExperienceCrossPlatformShScripts(t *testing.T, ds *Datastore) {
 
 // testEnqueueSetupExperienceFirstAddedPerTitle verifies that when a title has more than one active
 // package flagged for setup experience, only the first-added package is queued (no double-queue).
+// testSetupExperienceCrossPlatformPyScripts guards the EnqueueSetupExperienceItems predicates
+// (linux distro-agnostic clause + darwin cross-platform union) so they include .py, not just
+// .sh — a .py installer is platform='linux' but runs on both Linux and macOS.
+func testSetupExperienceCrossPlatformPyScripts(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "team-cross-plat-py"})
+	require.NoError(t, err)
+	user := test.NewUser(t, ds, "Bob", "bob-py@example.com", true)
+
+	tfrPy, err := fleet.NewTempFileReader(strings.NewReader("#!/usr/bin/env python3\nprint('hello')"), t.TempDir)
+	require.NoError(t, err)
+	_, pyTitleID, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+		InstallScript:   "#!/usr/bin/env python3\nprint('install')",
+		InstallerFile:   tfrPy,
+		StorageID:       "storage-py-cross",
+		Filename:        "cross.py",
+		Title:           "Cross Platform Py Script",
+		Version:         "1.0",
+		Source:          "py_packages",
+		UserID:          user.ID,
+		TeamID:          &team.ID,
+		Platform:        "linux",
+		Extension:       "py",
+		ValidatedLabels: &fleet.LabelIdentsWithScope{},
+	})
+	require.NoError(t, err)
+
+	t.Run("py appears in both linux and darwin listings", func(t *testing.T) {
+		for _, platform := range []string{"linux", "darwin"} {
+			titles, _, _, err := ds.ListSetupExperienceSoftwareTitles(ctx, platform, team.ID, fleet.ListOptions{})
+			require.NoError(t, err)
+			names := make([]string, 0, len(titles))
+			for _, tt := range titles {
+				if tt.SoftwarePackage != nil {
+					names = append(names, tt.SoftwarePackage.Name)
+				}
+			}
+			assert.Contains(t, names, "cross.py", "cross.py should be selectable for %s setup experience", platform)
+		}
+	})
+
+	t.Run("darwin host enqueues cross-selected .py", func(t *testing.T) {
+		err := ds.SetSetupExperienceSoftwareTitles(ctx, "darwin", team.ID, []uint{pyTitleID})
+		require.NoError(t, err)
+
+		darwinUUID := uuid.NewString()
+		_, err = ds.NewHost(ctx, &fleet.Host{
+			Hostname:      "darwin-py-" + darwinUUID,
+			UUID:          darwinUUID,
+			Platform:      "darwin",
+			TeamID:        &team.ID,
+			OsqueryHostID: new("oq-darwin-py-" + darwinUUID),
+			NodeKey:       new("nk-darwin-py-" + darwinUUID),
+		})
+		require.NoError(t, err)
+
+		enrolled, err := ds.EnqueueSetupExperienceItems(ctx, "darwin", "darwin", darwinUUID, team.ID)
+		require.NoError(t, err)
+		assert.True(t, enrolled)
+
+		var names []string
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			return sqlx.SelectContext(ctx, q, &names,
+				`SELECT name FROM setup_experience_status_results WHERE host_uuid = ?`, darwinUUID)
+		})
+		assert.Contains(t, names, "Cross Platform Py Script", "darwin host should enqueue the cross-selected .py package")
+	})
+
+	t.Run("linux host enqueues native .py", func(t *testing.T) {
+		err := ds.SetSetupExperienceSoftwareTitles(ctx, "linux", team.ID, []uint{pyTitleID})
+		require.NoError(t, err)
+
+		linuxUUID := uuid.NewString()
+		_, err = ds.NewHost(ctx, &fleet.Host{
+			Hostname:      "linux-py-" + linuxUUID,
+			UUID:          linuxUUID,
+			Platform:      "debian",
+			TeamID:        &team.ID,
+			OsqueryHostID: new("oq-linux-py-" + linuxUUID),
+			NodeKey:       new("nk-linux-py-" + linuxUUID),
+		})
+		require.NoError(t, err)
+
+		enrolled, err := ds.EnqueueSetupExperienceItems(ctx, "linux", "debian", linuxUUID, team.ID)
+		require.NoError(t, err)
+		assert.True(t, enrolled)
+
+		var names []string
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			return sqlx.SelectContext(ctx, q, &names,
+				`SELECT name FROM setup_experience_status_results WHERE host_uuid = ?`, linuxUUID)
+		})
+		assert.Contains(t, names, "Cross Platform Py Script", "linux host should enqueue the native .py package")
+	})
+}
+
 func testEnqueueSetupExperienceFirstAddedPerTitle(t *testing.T, ds *Datastore) {
 	ctx := context.Background()
 	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "se-multi-pkg"})

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -3991,7 +3991,7 @@ func (ds *Datastore) resolveFirstAddedInstallersForHost(ctx context.Context, hos
 	}
 	byTitle := make(map[uint]*candidate, len(titleIDs))
 	for _, r := range rows {
-		compat := r.Platform == hostPlatform || (r.Extension == "sh" && r.Platform == "linux" && fleet.IsUnixLike(host.Platform))
+		compat := r.Platform == hostPlatform || ((r.Extension == "sh" || r.Extension == "py") && r.Platform == "linux" && fleet.IsUnixLike(host.Platform))
 		pkg := resolvedInstaller{ID: r.InstallerID, SelfService: r.SelfService}
 		c := byTitle[r.TitleID]
 		if c == nil {
@@ -5639,10 +5639,10 @@ func (ds *Datastore) ListHostSoftware(ctx context.Context, host *fleet.Host, opt
 				software_titles st
 			LEFT OUTER JOIN
 				-- filter out software that is not available for install on the host's platform
-				-- .sh packages are available for both linux and darwin hosts
+				-- .sh and .py packages are available for both linux and darwin hosts
 				-- is_active=1 ensures fresh hosts (no install record) don't see a stale inactive
 				-- installer's labels and surface a title that the install endpoint will reject.
-				software_installers si ON st.id = si.title_id AND (si.platform = :host_compatible_platforms OR (si.extension = 'sh' AND si.platform = 'linux' AND :host_compatible_platforms = 'darwin')) AND si.extension NOT IN (:incompatible_extensions) AND si.global_or_team_id = :global_or_team_id AND si.is_active = 1
+				software_installers si ON st.id = si.title_id AND (si.platform = :host_compatible_platforms OR (si.extension IN ('sh', 'py') AND si.platform = 'linux' AND :host_compatible_platforms = 'darwin')) AND si.extension NOT IN (:incompatible_extensions) AND si.global_or_team_id = :global_or_team_id AND si.is_active = 1
 			LEFT OUTER JOIN
 				-- include VPP apps only if the host is on a supported platform
 				vpp_apps vap ON st.id = vap.title_id AND :host_platform IN (:vpp_apps_platforms)

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -3720,7 +3720,7 @@ func (ds *Datastore) HasSelfServiceSoftwareInstallers(ctx context.Context, hostP
 			SELECT 1
 			FROM software_installers
 			WHERE self_service = 1
-			  AND (platform = ? OR (extension = 'sh' AND platform = 'linux' AND ? = 'darwin'))
+			  AND (platform = ? OR (extension IN ('sh', 'py') AND platform = 'linux' AND ? = 'darwin'))
 			  AND global_or_team_id = ?
 		) OR EXISTS (
 			SELECT 1

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -2802,6 +2802,46 @@ func testHasSelfServiceSoftwareInstallers(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	assert.False(t, hasSelfService, "windows host should NOT see .sh packages")
 
+	// Create a new team for .py testing
+	teamPy, err := ds.NewTeam(ctx, &fleet.Team{Name: "team py darwin test"})
+	require.NoError(t, err)
+
+	// Initially, darwin should not see any self-service installers in this team
+	hasSelfService, err = ds.HasSelfServiceSoftwareInstallers(ctx, "darwin", &teamPy.ID)
+	require.NoError(t, err)
+	assert.False(t, hasSelfService, "darwin should not see self-service before .py is created")
+
+	// Create a self-service .py installer (stored as platform='linux', extension='py')
+	// This should be visible to darwin hosts due to the unix-like script exception
+	_, _, err = ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+		Title:           "py script for darwin",
+		Source:          "py_packages",
+		InstallScript:   "python3 installer.py",
+		TeamID:          &teamPy.ID,
+		Filename:        "script.py",
+		Platform:        "linux", // .py files are stored as linux
+		Extension:       "py",
+		SelfService:     true,
+		UserID:          user1.ID,
+		ValidatedLabels: &fleet.LabelIdentsWithScope{},
+	})
+	require.NoError(t, err)
+
+	// Darwin host should now see self-service .py package
+	hasSelfService, err = ds.HasSelfServiceSoftwareInstallers(ctx, "darwin", &teamPy.ID)
+	require.NoError(t, err)
+	assert.True(t, hasSelfService, "darwin host should see self-service .py packages")
+
+	// Linux host should also see it
+	hasSelfService, err = ds.HasSelfServiceSoftwareInstallers(ctx, "linux", &teamPy.ID)
+	require.NoError(t, err)
+	assert.True(t, hasSelfService, "linux host should see self-service .py packages")
+
+	// Windows host shouldn't see .py packages
+	hasSelfService, err = ds.HasSelfServiceSoftwareInstallers(ctx, "windows", &teamPy.ID)
+	require.NoError(t, err)
+	assert.False(t, hasSelfService, "windows host should NOT see .py packages")
+
 	// Create a self-service VPP for team/darwin
 	_, err = ds.InsertVPPAppWithTeam(ctx, &fleet.VPPApp{VPPAppTeam: fleet.VPPAppTeam{VPPAppID: fleet.VPPAppID{AdamID: "adam_vpp_3", Platform: fleet.MacOSPlatform}, SelfService: true}, Name: "vpp3", BundleIdentifier: "com.app.vpp3"}, &team.ID)
 	require.NoError(t, err)

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -11799,7 +11799,7 @@ func testListSoftwareInventoryDeletedHost(t *testing.T, ds *Datastore) {
 	require.Equal(t, titleID, software[0].ID)
 }
 
-// testListHostSoftwareShPackageForDarwin tests that .sh packages
+// testListHostSoftwareShPackageForDarwin tests that .sh and .py packages
 // (stored as platform='linux') are visible to darwin hosts
 func testListHostSoftwareShPackageForDarwin(t *testing.T, ds *Datastore) {
 	ctx := t.Context()
@@ -11832,6 +11832,24 @@ func testListHostSoftwareShPackageForDarwin(t *testing.T, ds *Datastore) {
 	})
 	require.NoError(t, err)
 
+	// Create a .py installer (platform='linux', extension='py'), also runnable on darwin
+	tfrPy, err := fleet.NewTempFileReader(strings.NewReader("print('hello')"), t.TempDir)
+	require.NoError(t, err)
+	_, pyTitleID, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+		InstallScript:   "python3 installer.py",
+		InstallerFile:   tfrPy,
+		StorageID:       "py-storage-darwin-test",
+		Filename:        "test-script.py",
+		Title:           "Test Py Script",
+		Version:         "1.0.0",
+		Source:          "py_packages",
+		Platform:        "linux", // .py files are stored as linux platform
+		Extension:       "py",
+		UserID:          user.ID,
+		ValidatedLabels: &fleet.LabelIdentsWithScope{},
+	})
+	require.NoError(t, err)
+
 	// Create a regular .deb installer (platform='linux'), shouldn't be visible to darwin
 	tfr2, err := fleet.NewTempFileReader(strings.NewReader("deb content"), t.TempDir)
 	require.NoError(t, err)
@@ -11859,19 +11877,25 @@ func testListHostSoftwareShPackageForDarwin(t *testing.T, ds *Datastore) {
 	sw, _, err := ds.ListHostSoftware(ctx, darwinHost, opts)
 	require.NoError(t, err)
 
-	// Darwin host should see the .sh package but not the .deb package
-	var foundSh, foundDeb bool
+	// Darwin host should see the .sh and .py packages but not the .deb package
+	var foundSh, foundPy, foundDeb bool
 	for _, s := range sw {
 		if s.ID == shTitleID {
 			foundSh = true
 			require.Equal(t, "Test Script", s.Name)
 			require.Equal(t, "sh_packages", s.Source)
 		}
+		if s.ID == pyTitleID {
+			foundPy = true
+			require.Equal(t, "Test Py Script", s.Name)
+			require.Equal(t, "py_packages", s.Source)
+		}
 		if s.ID == debTitleID {
 			foundDeb = true
 		}
 	}
 	require.True(t, foundSh, ".sh package should be visible to darwin host")
+	require.True(t, foundPy, ".py package should be visible to darwin host")
 	require.False(t, foundDeb, ".deb package should NOT be visible to darwin host")
 
 	// Query available software for linux host, should see both
@@ -11879,16 +11903,21 @@ func testListHostSoftwareShPackageForDarwin(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 
 	foundSh = false
+	foundPy = false
 	foundDeb = false
 	for _, s := range sw {
 		if s.ID == shTitleID {
 			foundSh = true
+		}
+		if s.ID == pyTitleID {
+			foundPy = true
 		}
 		if s.ID == debTitleID {
 			foundDeb = true
 		}
 	}
 	require.True(t, foundSh, ".sh package should be visible to linux host")
+	require.True(t, foundPy, ".py package should be visible to linux host")
 	require.True(t, foundDeb, ".deb package should be visible to linux host")
 
 	// Create a Windows host
@@ -11899,18 +11928,23 @@ func testListHostSoftwareShPackageForDarwin(t *testing.T, ds *Datastore) {
 	sw, _, err = ds.ListHostSoftware(ctx, windowsHost, opts)
 	require.NoError(t, err)
 
-	// Windows host should NOT see .sh or .deb packages
+	// Windows host should NOT see .sh, .py, or .deb packages
 	foundSh = false
+	foundPy = false
 	foundDeb = false
 	for _, s := range sw {
 		if s.ID == shTitleID {
 			foundSh = true
+		}
+		if s.ID == pyTitleID {
+			foundPy = true
 		}
 		if s.ID == debTitleID {
 			foundDeb = true
 		}
 	}
 	require.False(t, foundSh, ".sh package should NOT be visible to windows host")
+	require.False(t, foundPy, ".py package should NOT be visible to windows host")
 	require.False(t, foundDeb, ".deb package should NOT be visible to windows host")
 }
 

--- a/server/datastore/mysql/software_titles.go
+++ b/server/datastore/mysql/software_titles.go
@@ -771,7 +771,7 @@ WHERE
 		{{end}}
 		{{if and (hasTeamID $) $.Platform}}
 		  {{if and $.ForSetupExperience (isDarwinOnly $.Platform)}}
-		    {{$postfix := printf " AND (si.platform IN (%s) OR (si.extension = 'sh' AND si.platform = 'linux') OR vap.platform IN (%[1]s) OR iha.platform IN (%[1]s))" (placeholders $.Platform)}}
+		    {{$postfix := printf " AND (si.platform IN (%s) OR (si.extension IN ('sh', 'py') AND si.platform = 'linux') OR vap.platform IN (%[1]s) OR iha.platform IN (%[1]s))" (placeholders $.Platform)}}
 		    {{$additionalWhere = printf "%s %s" $additionalWhere $postfix}}
 		  {{else}}
 		    {{$postfix := printf " AND (si.platform IN (%s) OR vap.platform IN (%[1]s) OR iha.platform IN (%[1]s))" (placeholders $.Platform)}}


### PR DESCRIPTION
**Related issue:** Resolves #49455

Offer `.py` script-only packages on macOS hosts, matching `.sh`.

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Python (`.py`) installer packages are now treated as compatible alongside shell (`.sh`) installers on macOS and Linux.
  * Python installers can now appear in software availability, self-service installation, and setup experience selections.
  * Windows behavior remains unchanged (Unix-script installers are excluded).

* **Bug Fixes**
  * Improved cross-platform compatibility matching for Unix-like hosts when choosing the first eligible installer package.

* **Tests**
  * Added and expanded unit/integration coverage for `.py` installer compatibility across platforms and flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->