### PR TITLE
Fix duplicate FDE TPM keyslots not getting caught correctly

### DIFF
--- a/orbit/pkg/luks/snapd_client.go
+++ b/orbit/pkg/luks/snapd_client.go
@@ -113,11 +113,17 @@ func (e *snapdAPIError) isConflict() bool {
 	// substring match on either the kind or the message keeps us resilient to
 	// small wording drift across snapd versions while still not matching
 	// unrelated auth or transport errors.
+	//
+	// The message check uses "already exist" (no trailing s) as the prefix so
+	// it matches both the singular ("key slot X already exists") and the
+	// plural ("key slots [...] already exist") wording — snapd 2.75 returns
+	// the plural form when a name-only keyslotRef expands to both the
+	// system-data and system-save containers, which is exactly our case.
 	kind := strings.ToLower(e.Kind)
 	msg := strings.ToLower(e.Message)
 	return strings.Contains(kind, "already-exists") ||
 		strings.Contains(kind, "conflict") ||
-		strings.Contains(msg, "already exists")
+		strings.Contains(msg, "already exist")
 }
 
 // snapdChange is the relevant subset of a snapd change (GET /v2/changes/{id}).

--- a/orbit/pkg/luks/snapd_client_test.go
+++ b/orbit/pkg/luks/snapd_client_test.go
@@ -83,3 +83,39 @@ func TestSnapdErrorResponse(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "access denied")
 }
+
+func TestSnapdAPIErrorIsConflict(t *testing.T) {
+	cases := []struct {
+		name string
+		err  *snapdAPIError
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "409 status", err: &snapdAPIError{StatusCode: http.StatusConflict}, want: true},
+		{name: "kind resource-already-exists", err: &snapdAPIError{StatusCode: 400, Kind: "resource-already-exists"}, want: true},
+		{name: "kind snap-change-conflict", err: &snapdAPIError{StatusCode: 400, Kind: "snap-change-conflict"}, want: true},
+		{
+			// Regression: snapd 2.75 returns HTTP 400 with a plural-verb
+			// message when a name-only keyslotRef expands to system-data and
+			// system-save, which is our add-recovery-key case.
+			name: "message plural: key slots ... already exist",
+			err: &snapdAPIError{
+				StatusCode: 400,
+				Message:    `key slots [(container-role: "system-data", name: "fleet-escrow"), (container-role: "system-save", name: "fleet-escrow")] already exist`,
+			},
+			want: true,
+		},
+		{
+			name: "message singular: key slot ... already exists",
+			err:  &snapdAPIError{StatusCode: 400, Message: `key slot "fleet-escrow" already exists`},
+			want: true,
+		},
+		{name: "auth failure is not a conflict", err: &snapdAPIError{StatusCode: 401, Message: "access denied"}, want: false},
+		{name: "generic bad request is not a conflict", err: &snapdAPIError{StatusCode: 400, Message: "malformed request"}, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, tc.err.isConflict())
+		})
+	}
+}


### PR DESCRIPTION
**Related issue:** Resolves #44428 

Unreleased bug from #48452 caught during testing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of resource-conflict responses when wording varies, including singular and plural message formats.
  * Prevented authentication failures and unrelated bad requests from being incorrectly classified as conflicts.

* **Tests**
  * Added coverage for HTTP conflict responses, recognized conflict types, message variations, and non-conflict errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->