### PR TITLE
Add Set time and date automatically config profile

### DIFF
--- a/docs/solutions/macos/configuration-profiles/set-time-and-date-automatically.mobileconfig
+++ b/docs/solutions/macos/configuration-profiles/set-time-and-date-automatically.mobileconfig
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <dict>
+      <key>PayloadType</key>
+      <string>com.apple.MCX</string>
+      <key>PayloadIdentifier</key>
+      <string>com.fleetdm.timeserver</string>
+      <key>PayloadUUID</key>
+      <string>A1B2C3D4-E5F6-7890-ABCD-EF1234567890</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+      <key>timeServer</key>
+      <string>time.apple.com</string>
+    </dict>
+  </array>
+  <key>PayloadDisplayName</key>
+  <string>Time Server Configuration</string>
+  <key>PayloadIdentifier</key>
+  <string>com.fleetdm.timeserver.profile</string>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>B2C3D4E5-F6A7-8901-BCDE-F12345678901</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>

--- a/docs/solutions/macos/configuration-profiles/set-time-and-date-automatically.mobileconfig
+++ b/docs/solutions/macos/configuration-profiles/set-time-and-date-automatically.mobileconfig
@@ -11,7 +11,7 @@
       <key>PayloadIdentifier</key>
       <string>com.fleetdm.timeserver</string>
       <key>PayloadUUID</key>
-      <string>A1B2C3D4-E5F6-7890-ABCD-EF1234567890</string>
+      <string>0E6CD857-2B26-4B38-BF20-61DD08372CF3</string>
       <key>PayloadVersion</key>
       <integer>1</integer>
       <key>timeServer</key>

--- a/docs/solutions/macos/configuration-profiles/set-time-and-date-automatically.mobileconfig
+++ b/docs/solutions/macos/configuration-profiles/set-time-and-date-automatically.mobileconfig
@@ -25,7 +25,7 @@
   <key>PayloadType</key>
   <string>Configuration</string>
   <key>PayloadUUID</key>
-  <string>B2C3D4E5-F6A7-8901-BCDE-F12345678901</string>
+  <string>AEE78D8D-2A1E-4BE9-B133-32FE56C5F0E3</string>
   <key>PayloadVersion</key>
   <integer>1</integer>
 </dict>


### PR DESCRIPTION
This enforces NTP on macOS devices.

The "Set date and time automatically" toggle can be verified with `systemsetup - getusingnetworktime` (you can write a script to put the output of that into a file, then use the `file_lines` table in a policy), and set with `systemsetup - setusingnetworktime on` (which could be a script automation that kicks off if a device fails the policy).
If you want to prevent users from changing it, you can use the attached config profile. Note that it requires setting the NTP server, but this is most likely just the default Apple server. The `setusingnetworktime` will work even with the Ul locked.

<img width="1458" height="320" alt="Screenshot 2026-05-14 at 08 19 28" src="https://github.com/user-attachments/assets/22064715-1548-490c-b3e0-bde51dd26f12" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a macOS configuration profile that automatically configures devices to use Apple’s time server.
  * Included a human-readable profile name and standard configuration metadata for easier deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->