### PR TITLE
Don't show Turn on MDM button to users who can't turn it on

### DIFF
--- a/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/ConfigurationProfiles.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/ConfigurationProfiles.tsx
@@ -62,11 +62,15 @@ const ConfigurationProfiles = ({
   const {
     config,
     isPremiumTier,
+    isGlobalAdmin,
     isGlobalTechnician,
     isTeamTechnician,
   } = useContext(AppContext);
 
   const isTechnician = isGlobalTechnician || isTeamTechnician;
+  // The "Turn on" button links to /settings/integrations/mdm, which is
+  // gated to global admins only (AuthGlobalAdminRoutes).
+  const canTurnOnMdm = !!isGlobalAdmin;
 
   const mdmEnabled =
     config?.mdm.enabled_and_configured ||
@@ -286,13 +290,19 @@ const ConfigurationProfiles = ({
               <EmptyState
                 variant="header-list"
                 header="Additional configuration required"
-                info="MDM must be turned on to add configuration profiles."
+                info={
+                  canTurnOnMdm
+                    ? "MDM must be turned on to add configuration profiles."
+                    : "To add configuration profiles, ask your admin to turn on MDM."
+                }
                 primaryButton={
-                  <Button
-                    onClick={() => router.push(PATHS.ADMIN_INTEGRATIONS_MDM)}
-                  >
-                    Turn on
-                  </Button>
+                  canTurnOnMdm ? (
+                    <Button
+                      onClick={() => router.push(PATHS.ADMIN_INTEGRATIONS_MDM)}
+                    >
+                      Turn on
+                    </Button>
+                  ) : undefined
                 }
               />
             ) : (

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/ConfigurationProfiles.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/ConfigurationProfiles.tsx
@@ -290,11 +290,7 @@ const ConfigurationProfiles = ({
               <EmptyState
                 variant="header-list"
                 header="Additional configuration required"
-                info={
-                  canTurnOnMdm
-                    ? "MDM must be turned on to add configuration profiles."
-                    : "To add configuration profiles, ask your admin to turn on MDM."
-                }
+                info="MDM must be turned on to add configuration profiles."
                 primaryButton={
                   canTurnOnMdm ? (
                     <Button

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/AssetsTab/AssetsTab.tests.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/AssetsTab/AssetsTab.tests.tsx
@@ -97,7 +97,7 @@ describe("AssetsTab", () => {
     render(<AssetsTab currentTeamId={0} router={createMockRouter()} />);
 
     expect(
-      screen.getByText("To manage assets, ask your admin to turn on Apple MDM.")
+      screen.getByText("Supported on macOS, iOS, and iPadOS.")
     ).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "Turn on Apple MDM" })

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/AssetsTab/AssetsTab.tests.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/AssetsTab/AssetsTab.tests.tsx
@@ -40,13 +40,14 @@ describe("AssetsTab", () => {
     expect(mdmAPI.getAssets).not.toHaveBeenCalled();
   });
 
-  it("prompts to turn on Apple MDM when it is not configured", async () => {
+  it("prompts global admins to turn on Apple MDM when it is not configured", async () => {
     const router = createMockRouter();
     const render = createCustomRenderer({
       withBackendMock: true,
       context: {
         app: {
           isPremiumTier: true,
+          isGlobalAdmin: true,
           config: { mdm: { enabled_and_configured: false } } as any,
         },
       },
@@ -59,6 +60,48 @@ describe("AssetsTab", () => {
     expect(router.push).toHaveBeenCalledWith(
       PATHS.ADMIN_INTEGRATIONS_MDM_APPLE
     );
+    expect(mdmAPI.getAssets).not.toHaveBeenCalled();
+  });
+
+  it("prompts team admins to turn on Apple MDM when it is not configured", () => {
+    const render = createCustomRenderer({
+      withBackendMock: true,
+      context: {
+        app: {
+          isPremiumTier: true,
+          isAnyTeamAdmin: true,
+          config: { mdm: { enabled_and_configured: false } } as any,
+        },
+      },
+    });
+
+    render(<AssetsTab currentTeamId={0} router={createMockRouter()} />);
+
+    expect(
+      screen.getByRole("button", { name: "Turn on Apple MDM" })
+    ).toBeInTheDocument();
+  });
+
+  it("does not show the turn on Apple MDM button to technicians", () => {
+    const render = createCustomRenderer({
+      withBackendMock: true,
+      context: {
+        app: {
+          isPremiumTier: true,
+          isGlobalTechnician: true,
+          config: { mdm: { enabled_and_configured: false } } as any,
+        },
+      },
+    });
+
+    render(<AssetsTab currentTeamId={0} router={createMockRouter()} />);
+
+    expect(
+      screen.getByText("To manage assets, ask your admin to turn on Apple MDM.")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Turn on Apple MDM" })
+    ).not.toBeInTheDocument();
     expect(mdmAPI.getAssets).not.toHaveBeenCalled();
   });
 

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/AssetsTab/AssetsTab.tests.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/AssetsTab/AssetsTab.tests.tsx
@@ -63,46 +63,39 @@ describe("AssetsTab", () => {
     expect(mdmAPI.getAssets).not.toHaveBeenCalled();
   });
 
-  it("prompts team admins to turn on Apple MDM when it is not configured", () => {
-    const render = createCustomRenderer({
-      withBackendMock: true,
-      context: {
-        app: {
-          isPremiumTier: true,
-          isAnyTeamAdmin: true,
-          config: { mdm: { enabled_and_configured: false } } as any,
+  it("does not show the turn on Apple MDM button to non-global-admins", () => {
+    const nonGlobalAdminContexts = [
+      { isAnyTeamAdmin: true },
+      { isGlobalTechnician: true },
+      { isTeamTechnician: true },
+    ];
+
+    nonGlobalAdminContexts.forEach((roleContext) => {
+      const render = createCustomRenderer({
+        withBackendMock: true,
+        context: {
+          app: {
+            isPremiumTier: true,
+            ...roleContext,
+            config: { mdm: { enabled_and_configured: false } } as any,
+          },
         },
-      },
+      });
+
+      const { unmount } = render(
+        <AssetsTab currentTeamId={0} router={createMockRouter()} />
+      );
+
+      expect(
+        screen.getByText("Supported on macOS, iOS, and iPadOS.")
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Turn on Apple MDM" })
+      ).not.toBeInTheDocument();
+      expect(mdmAPI.getAssets).not.toHaveBeenCalled();
+
+      unmount();
     });
-
-    render(<AssetsTab currentTeamId={0} router={createMockRouter()} />);
-
-    expect(
-      screen.getByRole("button", { name: "Turn on Apple MDM" })
-    ).toBeInTheDocument();
-  });
-
-  it("does not show the turn on Apple MDM button to technicians", () => {
-    const render = createCustomRenderer({
-      withBackendMock: true,
-      context: {
-        app: {
-          isPremiumTier: true,
-          isGlobalTechnician: true,
-          config: { mdm: { enabled_and_configured: false } } as any,
-        },
-      },
-    });
-
-    render(<AssetsTab currentTeamId={0} router={createMockRouter()} />);
-
-    expect(
-      screen.getByText("Supported on macOS, iOS, and iPadOS.")
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: "Turn on Apple MDM" })
-    ).not.toBeInTheDocument();
-    expect(mdmAPI.getAssets).not.toHaveBeenCalled();
   });
 
   it("renders the empty state when there are no assets", async () => {

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/AssetsTab/AssetsTab.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/AssetsTab/AssetsTab.tsx
@@ -36,14 +36,14 @@ const AssetsTab = ({ currentTeamId, router }: IAssetsTabProps) => {
     config,
     isPremiumTier,
     isGlobalAdmin,
-    isAnyTeamAdmin,
     isGlobalTechnician,
     isTeamTechnician,
   } = useContext(AppContext);
 
   const isTechnician = isGlobalTechnician || isTeamTechnician;
-  // Mirrors the route guard on /settings/integrations/mdm/apple (AuthAnyAdminRoutes).
-  const canTurnOnMdm = isGlobalAdmin || isAnyTeamAdmin;
+  // Team admins can reach /settings/integrations/mdm/apple, but only global
+  // admins can actually turn on Apple MDM there.
+  const canTurnOnMdm = !!isGlobalAdmin;
   const mdmAppleEnabled = !!config?.mdm.enabled_and_configured;
 
   const [showAddAssetModal, setShowAddAssetModal] = useState(false);

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/AssetsTab/AssetsTab.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/AssetsTab/AssetsTab.tsx
@@ -35,11 +35,15 @@ const AssetsTab = ({ currentTeamId, router }: IAssetsTabProps) => {
   const {
     config,
     isPremiumTier,
+    isGlobalAdmin,
+    isAnyTeamAdmin,
     isGlobalTechnician,
     isTeamTechnician,
   } = useContext(AppContext);
 
   const isTechnician = isGlobalTechnician || isTeamTechnician;
+  // Mirrors the route guard on /settings/integrations/mdm/apple (AuthAnyAdminRoutes).
+  const canTurnOnMdm = isGlobalAdmin || isAnyTeamAdmin;
   const mdmAppleEnabled = !!config?.mdm.enabled_and_configured;
 
   const [showAddAssetModal, setShowAddAssetModal] = useState(false);
@@ -104,13 +108,19 @@ const AssetsTab = ({ currentTeamId, router }: IAssetsTabProps) => {
         <EmptyState
           variant="header-list"
           header="Manage assets"
-          info="Supported on macOS, iOS, and iPadOS."
+          info={
+            canTurnOnMdm
+              ? "Supported on macOS, iOS, and iPadOS."
+              : "To manage assets, ask your admin to turn on Apple MDM."
+          }
           primaryButton={
-            <Button
-              onClick={() => router.push(PATHS.ADMIN_INTEGRATIONS_MDM_APPLE)}
-            >
-              Turn on Apple MDM
-            </Button>
+            canTurnOnMdm ? (
+              <Button
+                onClick={() => router.push(PATHS.ADMIN_INTEGRATIONS_MDM_APPLE)}
+              >
+                Turn on Apple MDM
+              </Button>
+            ) : undefined
           }
         />
       );

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/AssetsTab/AssetsTab.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/AssetsTab/AssetsTab.tsx
@@ -108,11 +108,7 @@ const AssetsTab = ({ currentTeamId, router }: IAssetsTabProps) => {
         <EmptyState
           variant="header-list"
           header="Manage assets"
-          info={
-            canTurnOnMdm
-              ? "Supported on macOS, iOS, and iPadOS."
-              : "To manage assets, ask your admin to turn on Apple MDM."
-          }
+          info="Supported on macOS, iOS, and iPadOS."
           primaryButton={
             canTurnOnMdm ? (
               <Button


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #49462

# Checklist for submitter

If some of the following don't apply, delete the relevant line.
No changes as this is an unreleased bug
- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Apple MDM “not enabled/configuration required” empty state now adjusts the primary “Turn on” button based on viewer permissions (shown only to global admins).
  * For non-global-admin roles, the “Turn on” flow is hidden and the supported-info state is displayed instead; Apple MDM asset loading is no longer triggered.
* **Tests**
  * Updated and expanded Assets tab coverage to verify button visibility and navigation across global admin vs non-global-admin roles, including technician and team-admin-type contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->