### PR TITLE
Fix update ca certs CI check

### DIFF
--- a/orbit/pkg/packaging/certs.pem
+++ b/orbit/pkg/packaging/certs.pem
@@ -13,7 +13,7 @@
 ## It contains the certificates in PEM format and therefore
 ## can be directly used with curl / libcurl / php_curl, or with
 ## an Apache+mod_ssl webserver for SSL client authentication.
-## Just configure this file as the SSLCACertificateFile.
+## Configure this file as the SSLCACertificateFile.
 ##
 ## Conversion done with mk-ca-bundle.pl version 1.33.
 ## SHA256: 77130ef91213772844561fbd3aa31d413b25c2ac7f576fea3bc3bbff7ef93489

--- a/orbit/pkg/packaging/mk-ca-bundle.pl
+++ b/orbit/pkg/packaging/mk-ca-bundle.pl
@@ -421,7 +421,7 @@ print CRT <<EOT;
 ## It contains the certificates in ${format}PEM format and therefore
 ## can be directly used with curl / libcurl / php_curl, or with
 ## an Apache+mod_ssl webserver for SSL client authentication.
-## Just configure this file as the SSLCACertificateFile.
+## Configure this file as the SSLCACertificateFile.
 ##
 ## Conversion done with mk-ca-bundle.pl version $version.
 ## SHA256: $newhash


### PR DESCRIPTION
Fixing broken CI check after some updates on curl's mk bundle script: https://github.com/fleetdm/fleet/actions/runs/29560837606/job/87822721779

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the certificate bundle header comment with clearer configuration wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->