### PR TITLE
Website: Update create-android-signup-url error handling

### DIFF
--- a/website/api/controllers/android-proxy/create-android-signup-url.js
+++ b/website/api/controllers/android-proxy/create-android-signup-url.js
@@ -37,7 +37,12 @@ module.exports = {
     if(connectionforThisInstanceExists) {
       // Before throwing conflict, verify the enterprise still exists in Google
       // If it doesn't exist, clean up the stale proxy record and continue with signup
-      let isEnterpriseManagedByFleet = await sails.helpers.androidProxy.getIsEnterpriseManagedByFleet(connectionforThisInstanceExists.androidEnterpriseId);
+      let isEnterpriseManagedByFleet = await sails.helpers.androidProxy.getIsEnterpriseManagedByFleet(connectionforThisInstanceExists.androidEnterpriseId)
+      .intercept({status: 429}, (err)=>{
+        // If the Android management API returns a 429 response, log an additional warning that will trigger a help-p1 alert.
+        sails.log.warn(`p1: Android management API rate limit exceeded!`);
+        return new Error(`When attempting to create a singup url for a new Android enterprise, an error occurred. Error: ${err}`);
+      })
       if(isEnterpriseManagedByFleet) {
         // Enterprise still exists in Google - throw conflict
         throw 'enterpriseAlreadyExists';

--- a/website/api/controllers/android-proxy/create-android-signup-url.js
+++ b/website/api/controllers/android-proxy/create-android-signup-url.js
@@ -41,7 +41,7 @@ module.exports = {
       .intercept({status: 429}, (err)=>{
         // If the Android management API returns a 429 response, log an additional warning that will trigger a help-p1 alert.
         sails.log.warn(`p1: Android management API rate limit exceeded!`);
-        return new Error(`When attempting to create a singup url for a new Android enterprise, an error occurred. Error: ${err}`);
+        return new Error(`When attempting to create a signup url for a new Android enterprise, an error occurred. Error: ${err}`);
       });
       if(isEnterpriseManagedByFleet) {
         // Enterprise still exists in Google - throw conflict

--- a/website/api/controllers/android-proxy/create-android-signup-url.js
+++ b/website/api/controllers/android-proxy/create-android-signup-url.js
@@ -42,7 +42,7 @@ module.exports = {
         // If the Android management API returns a 429 response, log an additional warning that will trigger a help-p1 alert.
         sails.log.warn(`p1: Android management API rate limit exceeded!`);
         return new Error(`When attempting to create a singup url for a new Android enterprise, an error occurred. Error: ${err}`);
-      })
+      });
       if(isEnterpriseManagedByFleet) {
         // Enterprise still exists in Google - throw conflict
         throw 'enterpriseAlreadyExists';

--- a/website/api/controllers/microsoft-proxy/create-compliance-partner-tenant.js
+++ b/website/api/controllers/microsoft-proxy/create-compliance-partner-tenant.js
@@ -16,7 +16,7 @@ module.exports = {
 
 
   exits: {
-    success: { description: 'Details about a new Microsoft compliance tenant have been returned to a Fleet isntance' },
+    success: { description: 'Details about a new Microsoft complaince tsenant have been returned to a Fleet isntance' },
     connectionAlreadyExists: {description: 'A Microsoft compliance tenant already exists for the provided entra tenant id.', statusCode: 409},
     missingOriginHeader: { description: 'No Origin header set', responseType: 'badRequest'},
   },

--- a/website/api/controllers/microsoft-proxy/create-compliance-partner-tenant.js
+++ b/website/api/controllers/microsoft-proxy/create-compliance-partner-tenant.js
@@ -16,7 +16,7 @@ module.exports = {
 
 
   exits: {
-    success: { description: 'Details about a new Microsoft complaince tsenant have been returned to a Fleet isntance' },
+    success: { description: 'Details about a new Microsoft compliance tenant have been returned to a Fleet isntance' },
     connectionAlreadyExists: {description: 'A Microsoft compliance tenant already exists for the provided entra tenant id.', statusCode: 409},
     missingOriginHeader: { description: 'No Origin header set', responseType: 'badRequest'},
   },


### PR DESCRIPTION
Changes:
- Updated the website's Android proxy's create-android-signup-url endpoint to log a more detailed message if Google returns a 429 (rate limit exceeded) response in the get-is-enterprise-managed-by-fleet helper

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Android enterprise-management rate limits when creating signup URLs.
  * If the upstream service responds with HTTP 429, the request now fails gracefully with a clear error instead of proceeding with the normal conflict/stale-record flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->