### PR TITLE
Fix label update consistency issue

### DIFF
--- a/changes/16789-modify-label-atomic-membership
+++ b/changes/16789-modify-label-atomic-membership
@@ -1,0 +1,1 @@
+- Fixed a bug where modifying a label could silently persist a membership change without recording an audit activity when the label's metadata update failed (e.g. renaming to a name that already exists). Label metadata and membership are now saved in a single transaction, so a failed update rolls back both.

--- a/server/datastore/mysql/labels.go
+++ b/server/datastore/mysql/labels.go
@@ -412,56 +412,7 @@ func batchHostnames(hostnames []string) [][]string {
 
 func (ds *Datastore) UpdateLabelMembershipByHostIDs(ctx context.Context, label fleet.Label, hostIds []uint, teamFilter fleet.TeamFilter) (*fleet.Label, []uint, error) {
 	err := ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
-		// delete all label membership
-		sql := `
-	DELETE FROM label_membership WHERE label_id = ?
-	`
-		_, err := tx.ExecContext(ctx, sql, label.ID)
-		if err != nil {
-			return ctxerr.Wrap(ctx, err, "clear membership for ID")
-		}
-
-		if len(hostIds) == 0 {
-			return nil
-		}
-
-		// Split hostIds into batches to avoid parameter limit in MySQL.
-		for _, hostIDsBatch := range batchHostIds(hostIds) {
-			if label.TeamID != nil {
-				// Team labels can only be applied to hosts on that team.
-				if err := checkHostIdentifiersInTeam(ctx, tx,
-					*label.TeamID,
-					`id IN (?)`,
-					[]any{hostIDsBatch},
-				); err != nil {
-					return ctxerr.Wrap(ctx, err, "check host IDs in team")
-				}
-			}
-
-			// Use ignore because duplicate host IDs could appear in
-			// different batches and would result in duplicate key errors.
-			var values []any
-			var placeholders []string
-
-			for _, hostID := range hostIDsBatch {
-				values = append(values, label.ID, hostID)
-				placeholders = append(placeholders, "(?, ?)")
-			}
-
-			// Build the final SQL query with the dynamically generated placeholders
-			sql := `
-INSERT IGNORE INTO label_membership (label_id, host_id)
-VALUES ` + strings.Join(placeholders, ", ")
-			sql, args, err := sqlx.In(sql, values...)
-			if err != nil {
-				return ctxerr.Wrap(ctx, err, "build membership IN statement")
-			}
-			_, err = tx.ExecContext(ctx, sql, args...)
-			if err != nil {
-				return ctxerr.Wrap(ctx, err, "execute membership INSERT")
-			}
-		}
-		return nil
+		return replaceLabelMembershipTx(ctx, tx, label, hostIds)
 	})
 	if err != nil {
 		return nil, nil, ctxerr.Wrap(ctx, err, "UpdateLabelMembershipByHostIDs transaction")
@@ -473,6 +424,56 @@ VALUES ` + strings.Join(placeholders, ", ")
 	}
 
 	return updatedLabel.GetLabel(), hostIDs, err
+}
+
+// replaceLabelMembershipTx replaces the manual membership of the given label
+// with exactly hostIDs.
+func replaceLabelMembershipTx(ctx context.Context, tx sqlx.ExtContext, label fleet.Label, hostIDs []uint) error {
+	// delete all label membership
+	if _, err := tx.ExecContext(ctx, `DELETE FROM label_membership WHERE label_id = ?`, label.ID); err != nil {
+		return ctxerr.Wrap(ctx, err, "clear membership for ID")
+	}
+
+	if len(hostIDs) == 0 {
+		return nil
+	}
+
+	// Split hostIDs into batches to avoid parameter limit in MySQL.
+	for _, hostIDsBatch := range batchHostIds(hostIDs) {
+		if label.TeamID != nil {
+			// Team labels can only be applied to hosts on that team.
+			if err := checkHostIdentifiersInTeam(ctx, tx,
+				*label.TeamID,
+				`id IN (?)`,
+				[]any{hostIDsBatch},
+			); err != nil {
+				return ctxerr.Wrap(ctx, err, "check host IDs in team")
+			}
+		}
+
+		// Use ignore because duplicate host IDs could appear in
+		// different batches and would result in duplicate key errors.
+		var values []any
+		var placeholders []string
+
+		for _, hostID := range hostIDsBatch {
+			values = append(values, label.ID, hostID)
+			placeholders = append(placeholders, "(?, ?)")
+		}
+
+		// Build the final SQL query with the dynamically generated placeholders
+		sql := `
+INSERT IGNORE INTO label_membership (label_id, host_id)
+VALUES ` + strings.Join(placeholders, ", ")
+		sql, args, err := sqlx.In(sql, values...)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "build membership IN statement")
+		}
+		if _, err := tx.ExecContext(ctx, sql, args...); err != nil {
+			return ctxerr.Wrap(ctx, err, "execute membership INSERT")
+		}
+	}
+	return nil
 }
 
 // Update label membership for a host vitals label.
@@ -665,21 +666,40 @@ func (ds *Datastore) NewLabel(ctx context.Context, label *fleet.Label, opts ...f
 	return label, nil
 }
 
-func (ds *Datastore) SaveLabel(ctx context.Context, label *fleet.Label, teamFilter fleet.TeamFilter) (*fleet.LabelWithTeamName, []uint, error) {
-	query := `UPDATE labels SET name = ?, description = ? WHERE id = ?`
-	_, err := ds.writer(ctx).ExecContext(ctx, query, label.Name, label.Description, label.ID)
+func (ds *Datastore) SaveLabel(ctx context.Context, label *fleet.Label, hostIDs []uint, teamFilter fleet.TeamFilter) (*fleet.LabelWithTeamName, []uint, error) {
+	var (
+		saved        *fleet.LabelWithTeamName
+		savedHostIDs []uint
+	)
+	err := ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
+		if _, err := tx.ExecContext(ctx, `UPDATE labels SET name = ?, description = ? WHERE id = ?`, label.Name, label.Description, label.ID); err != nil {
+			return ctxerr.Wrap(ctx, err, "saving label")
+		}
+
+		// Update the label name in mdm_configuration_profile_labels
+		if _, err := tx.ExecContext(ctx, `UPDATE mdm_configuration_profile_labels SET label_name = ? WHERE label_id = ?`, label.Name, label.ID); err != nil {
+			return ctxerr.Wrap(ctx, err, "updating mdm configuration profile label")
+		}
+
+		// A nil hostIDs means the caller did not request a membership change.
+		if hostIDs != nil {
+			if err := replaceLabelMembershipTx(ctx, tx, *label, hostIDs); err != nil {
+				return err
+			}
+		}
+
+		var err error
+		saved, savedHostIDs, err = ds.labelDB(ctx, label.ID, teamFilter, tx)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "get label after save")
+		}
+		return nil
+	})
 	if err != nil {
-		return nil, nil, ctxerr.Wrap(ctx, err, "saving label")
+		return nil, nil, err
 	}
 
-	// Update the label name in mdm_configuration_profile_labels
-	query = `UPDATE mdm_configuration_profile_labels SET label_name = ? WHERE label_id = ?`
-	_, err = ds.writer(ctx).ExecContext(ctx, query, label.Name, label.ID)
-	if err != nil {
-		return nil, nil, ctxerr.Wrap(ctx, err, "updating mdm configuration profile label")
-	}
-
-	return ds.labelDB(ctx, label.ID, teamFilter, ds.writer(ctx))
+	return saved, savedHostIDs, nil
 }
 
 // DeleteLabel deletes a fleet.Label

--- a/server/datastore/mysql/labels_test.go
+++ b/server/datastore/mysql/labels_test.go
@@ -766,7 +766,7 @@ func testLabelsChangeDetails(t *testing.T, db *Datastore) {
 	label.Name = "changed name"
 	// ApplyLabelSpecs can't update the name -- it simply creates a new label, so we need to call SaveLabel.
 	saved.Name = label.Name
-	saved2, _, err := db.SaveLabel(context.Background(), &saved.Label, filter)
+	saved2, _, err := db.SaveLabel(context.Background(), &saved.Label, nil, filter)
 	require.NoError(t, err)
 	assert.Equal(t, label.Name, saved2.Name)
 	assert.Equal(t, label.Description, saved2.Description)
@@ -1191,7 +1191,7 @@ func testLabelsSave(t *testing.T, db *Datastore) {
 	require.NoError(t, db.RecordLabelQueryExecutions(context.Background(), h1, map[uint]*bool{label.ID: ptr.Bool(true)}, time.Now(), false))
 
 	filter := fleet.TeamFilter{User: &fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)}}
-	_, _, err = db.SaveLabel(context.Background(), label, filter)
+	_, _, err = db.SaveLabel(context.Background(), label, nil, filter)
 	require.NoError(t, err)
 	saved, _, err := db.Label(context.Background(), label.ID, filter)
 	require.NoError(t, err)

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -244,8 +244,9 @@ type Datastore interface {
 
 	NewLabel(ctx context.Context, label *Label, opts ...OptionalArg) (*Label, error)
 	// SaveLabel updates the label and returns the label and an array of host IDs
-	// members of this label, or an error.
-	SaveLabel(ctx context.Context, label *Label, teamFilter TeamFilter) (*LabelWithTeamName, []uint, error)
+	// members of this label, or an error. When hostIDs is non-nil, the label's
+	// manual membership is replaced with exactly those hosts.
+	SaveLabel(ctx context.Context, label *Label, hostIDs []uint, teamFilter TeamFilter) (*LabelWithTeamName, []uint, error)
 	DeleteLabel(ctx context.Context, name string, filter TeamFilter) error
 	LabelByName(ctx context.Context, name string, filter TeamFilter) (*Label, error)
 	// Label returns the label and an array of host IDs members of this label, or an error.

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -186,7 +186,7 @@ type UpdateLabelMembershipByHostCriteriaFunc func(ctx context.Context, hvl fleet
 
 type NewLabelFunc func(ctx context.Context, label *fleet.Label, opts ...fleet.OptionalArg) (*fleet.Label, error)
 
-type SaveLabelFunc func(ctx context.Context, label *fleet.Label, teamFilter fleet.TeamFilter) (*fleet.LabelWithTeamName, []uint, error)
+type SaveLabelFunc func(ctx context.Context, label *fleet.Label, hostIDs []uint, teamFilter fleet.TeamFilter) (*fleet.LabelWithTeamName, []uint, error)
 
 type DeleteLabelFunc func(ctx context.Context, name string, filter fleet.TeamFilter) error
 
@@ -6105,11 +6105,11 @@ func (s *DataStore) NewLabel(ctx context.Context, label *fleet.Label, opts ...fl
 	return s.NewLabelFunc(ctx, label, opts...)
 }
 
-func (s *DataStore) SaveLabel(ctx context.Context, label *fleet.Label, teamFilter fleet.TeamFilter) (*fleet.LabelWithTeamName, []uint, error) {
+func (s *DataStore) SaveLabel(ctx context.Context, label *fleet.Label, hostIDs []uint, teamFilter fleet.TeamFilter) (*fleet.LabelWithTeamName, []uint, error) {
 	s.mu.Lock()
 	s.SaveLabelFuncInvoked = true
 	s.mu.Unlock()
-	return s.SaveLabelFunc(ctx, label, teamFilter)
+	return s.SaveLabelFunc(ctx, label, hostIDs, teamFilter)
 }
 
 func (s *DataStore) DeleteLabel(ctx context.Context, name string, filter fleet.TeamFilter) error {

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -5595,6 +5595,47 @@ func (s *integrationTestSuite) TestLabels() {
 			// attempt to delete by id
 			s.DoJSON("DELETE", fmt.Sprintf("/api/latest/fleet/labels/id/%d", id), nil, http.StatusUnprocessableEntity, &delIDResp)
 		}
+
+		// A modify that changes membership but fails metadata validation (a
+		// duplicate name) must roll back as a unit: the membership change must not
+		// be committed on its own, and no edited_label activity must be recorded
+		// for the failed request.
+		createResp = fleet.CreateLabelResponse{}
+		s.DoJSON("POST", "/api/latest/fleet/labels", &fleet.LabelPayload{Name: "atomic_conflict_label"}, http.StatusOK, &createResp)
+		conflictName := createResp.Label.Name
+
+		createResp = fleet.CreateLabelResponse{}
+		s.DoJSON("POST", "/api/latest/fleet/labels",
+			&fleet.LabelPayload{Name: "atomic_target_label", HostIDs: []uint{manualHosts[0].ID, manualHosts[1].ID}}, http.StatusOK, &createResp)
+		atomicLbl := createResp.Label.Label
+		require.ElementsMatch(t, []uint{manualHosts[0].ID, manualHosts[1].ID}, createResp.Label.HostIDs)
+
+		// watermark: id of the most recent activity before the failed request
+		lastActID := s.lastActivityMatches("", "", 0)
+
+		// rename to the conflicting name while also changing membership: the
+		// duplicate name must fail the whole request with 409
+		modResp = fleet.ModifyLabelResponse{}
+		s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/labels/%d", atomicLbl.ID),
+			&fleet.ModifyLabelPayload{Name: &conflictName, HostIDs: []uint{manualHosts[2].ID}}, http.StatusConflict, &modResp)
+
+		// name and membership must be unchanged (no partial commit)
+		getResp = fleet.GetLabelResponse{}
+		s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/labels/%d", atomicLbl.ID), nil, http.StatusOK, &getResp)
+		assert.Equal(t, atomicLbl.Name, getResp.Label.Name)
+		assert.ElementsMatch(t, []uint{manualHosts[0].ID, manualHosts[1].ID}, getResp.Label.HostIDs)
+
+		// no new activity must have been recorded for the failed request
+		assert.Equal(t, lastActID, s.lastActivityMatches("", "", 0))
+
+		// a valid rename that also changes membership must commit both and record
+		// the edited_label activity
+		modResp = fleet.ModifyLabelResponse{}
+		s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/labels/%d", atomicLbl.ID),
+			&fleet.ModifyLabelPayload{Name: new("atomic_target_renamed"), HostIDs: []uint{manualHosts[2].ID}}, http.StatusOK, &modResp)
+		assert.Equal(t, "atomic_target_renamed", modResp.Label.Name)
+		assert.ElementsMatch(t, []uint{manualHosts[2].ID}, modResp.Label.HostIDs)
+		require.Greater(t, s.lastActivityOfTypeMatches(fleet.ActivityTypeEditedLabel{}.ActivityName(), "", 0), lastActID)
 	})
 
 	t.Run("IdP Labels", func(t *testing.T) {

--- a/server/service/labels.go
+++ b/server/service/labels.go
@@ -301,13 +301,7 @@ func (svc *Service) ModifyLabel(ctx context.Context, id uint, payload fleet.Modi
 		return nil, nil, err
 	}
 
-	if hostIDs != nil {
-		if _, _, err := svc.ds.UpdateLabelMembershipByHostIDs(ctx, label.Label, hostIDs, filter); err != nil {
-			return nil, nil, err
-		}
-	}
-
-	saved, savedHostIDs, err := svc.ds.SaveLabel(ctx, &label.Label, filter)
+	saved, savedHostIDs, err := svc.ds.SaveLabel(ctx, &label.Label, hostIDs, filter)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/server/service/labels_test.go
+++ b/server/service/labels_test.go
@@ -130,7 +130,7 @@ func TestLabelsAuth(t *testing.T) {
 		}
 		return lbl, nil
 	}
-	ds.SaveLabelFunc = func(ctx context.Context, lbl *fleet.Label, filter fleet.TeamFilter) (*fleet.LabelWithTeamName, []uint, error) {
+	ds.SaveLabelFunc = func(ctx context.Context, lbl *fleet.Label, hostIDs []uint, filter fleet.TeamFilter) (*fleet.LabelWithTeamName, []uint, error) {
 		return &fleet.LabelWithTeamName{Label: *lbl}, nil, nil
 	}
 	ds.DeleteLabelFunc = func(ctx context.Context, nm string, filter fleet.TeamFilter) error {
@@ -1194,32 +1194,31 @@ func TestModifyManualLabel(t *testing.T) {
 		return []uint{99, 100}, nil
 	}
 	mockListHostsLiteByIDs(ds)
-	ds.SaveLabelFunc = func(ctx context.Context, lbl *fleet.Label, filter fleet.TeamFilter) (*fleet.LabelWithTeamName, []uint, error) {
-		return &fleet.LabelWithTeamName{Label: *lbl}, nil, nil
-	}
 
 	t.Run("using hostnames", func(t *testing.T) {
-		ds.UpdateLabelMembershipByHostIDsFunc = func(ctx context.Context, label fleet.Label, hostIds []uint, teamFilter fleet.TeamFilter) (*fleet.Label, []uint, error) {
-			require.Equal(t, uint(1), label.ID)
-			require.Equal(t, []uint{99, 100}, hostIds)
-			return nil, nil, nil
+		ds.SaveLabelFunc = func(ctx context.Context, lbl *fleet.Label, hostIDs []uint, filter fleet.TeamFilter) (*fleet.LabelWithTeamName, []uint, error) {
+			require.Equal(t, uint(1), lbl.ID)
+			require.Equal(t, []uint{99, 100}, hostIDs)
+			return &fleet.LabelWithTeamName{Label: *lbl}, hostIDs, nil
 		}
 		_, _, err := svc.ModifyLabel(ctx, 1, fleet.ModifyLabelPayload{
 			Hosts: []string{"host1", "host2"},
 		})
 		require.NoError(t, err)
+		require.True(t, ds.SaveLabelFuncInvoked)
 	})
 
 	t.Run("using IDs", func(t *testing.T) {
-		ds.UpdateLabelMembershipByHostIDsFunc = func(ctx context.Context, label fleet.Label, hostIds []uint, teamFilter fleet.TeamFilter) (*fleet.Label, []uint, error) {
-			require.Equal(t, uint(1), label.ID)
-			require.Equal(t, []uint{1, 2}, hostIds)
-			return nil, nil, nil
+		ds.SaveLabelFunc = func(ctx context.Context, lbl *fleet.Label, hostIDs []uint, filter fleet.TeamFilter) (*fleet.LabelWithTeamName, []uint, error) {
+			require.Equal(t, uint(1), lbl.ID)
+			require.Equal(t, []uint{1, 2}, hostIDs)
+			return &fleet.LabelWithTeamName{Label: *lbl}, hostIDs, nil
 		}
 		_, _, err := svc.ModifyLabel(ctx, 1, fleet.ModifyLabelPayload{
 			HostIDs: []uint{1, 2},
 		})
 		require.NoError(t, err)
+		require.True(t, ds.SaveLabelFuncInvoked)
 	})
 }
 
@@ -1405,7 +1404,7 @@ func TestLabelActivities(t *testing.T) {
 				},
 			}, nil, nil
 		}
-		ds.SaveLabelFunc = func(ctx context.Context, lbl *fleet.Label, filter fleet.TeamFilter) (*fleet.LabelWithTeamName, []uint, error) {
+		ds.SaveLabelFunc = func(ctx context.Context, lbl *fleet.Label, hostIDs []uint, filter fleet.TeamFilter) (*fleet.LabelWithTeamName, []uint, error) {
 			return &fleet.LabelWithTeamName{
 				Label:    fleet.Label{ID: lbl.ID, Name: lbl.Name, TeamID: ptr.Uint(teamID)},
 				TeamName: &teamName,


### PR DESCRIPTION
Persist label metadata and membership changes together in a single transaction so a failed update can't leave a partial change behind.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [X] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated label editing so manual membership changes and label metadata updates are persisted in a single atomic save.
  * If a label update fails (for example, due to rename/name conflicts), membership changes are not partially applied.
  * Audit/label activity is now emitted only when the label save succeeds, avoiding mismatches after failed edits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->