### PR TITLE
Document custom host vitals permissions in role-based access guide

### DIFF
--- a/articles/role-based-access.md
+++ b/articles/role-based-access.md
@@ -204,7 +204,7 @@ Users can be assigned to multiple fleets, and can have different roles for each 
 | Turn off MDM for specific hosts                                                                                                  |               |                |                 | ✅              | ✅         |             |
 | View certificate authorities (CA)                                                                                                |               |                |                 | ✅              | ✅         | ✅          |
 | View [custom variables](https://fleetdm.com/docs/rest-api/rest-api#list-custom-variables)                                        | ✅            | ✅             | ✅             | ✅              | ✅         |             |
-| View custom host vitals                                                                                                          | ✅            | ✅             | ✅              | ✅              | ✅         |             |
+| View custom host vitals                                                                                                          | ✅            | ✅             | ✅              | ✅              | ✅         | ✅         |
 | Set custom host vital values on hosts                                                                                            |               |                |                 | ✅              | ✅         |             |
 
 \* Applies only to [Fleet REST API](https://fleetdm.com/docs/using-fleet/rest-api)

--- a/articles/role-based-access.md
+++ b/articles/role-based-access.md
@@ -124,6 +124,9 @@ GitOps is an API-only and write-only role that can be used on CI/CD pipelines.
 | Add Microsoft Entra tenant                                                                                                                 |          |            |            |            | ✅    |         |
 | View [custom variables](https://fleetdm.com/docs/rest-api/rest-api#list-custom-variables)                                                  | ✅       | ✅         | ✅         | ✅         | ✅    | ✅      |
 | Create, edit, and delete custom variables                                                                                                  |          |            |            | ✅         | ✅    | ✅      |
+| View custom host vitals                                                                                                                    | ✅       | ✅         | ✅         | ✅         | ✅    | ✅      |
+| Create, edit, and delete custom host vitals                                                                                                |          |            |            | ✅         | ✅    | ✅      |
+| Set custom host vital values on hosts                                                                                                      |          |            |            | ✅         | ✅    |         |
 
 \* Applies only to Fleet Premium
 
@@ -201,6 +204,8 @@ Users can be assigned to multiple fleets, and can have different roles for each 
 | Turn off MDM for specific hosts                                                                                                  |               |                |                 | ✅              | ✅         |             |
 | View certificate authorities (CA)                                                                                                |               |                |                 | ✅              | ✅         | ✅          |
 | View [custom variables](https://fleetdm.com/docs/rest-api/rest-api#list-custom-variables)                                        | ✅            | ✅             | ✅             | ✅              | ✅         |             |
+| View custom host vitals                                                                                                          | ✅            | ✅             | ✅              | ✅              | ✅         |             |
+| Set custom host vital values on hosts                                                                                            |               |                |                 | ✅              | ✅         |             |
 
 \* Applies only to [Fleet REST API](https://fleetdm.com/docs/using-fleet/rest-api)
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Relates to #44954

Documents custom host vitals permissions in the role-based access guide (the "Permissions changes" item under #44954). Adds rows to both the global and fleet-level tables, matching the backend authz (`policy.rego`): only global admin/maintainer/GitOps can create/edit/delete custom host vital definitions; global admin/maintainer and fleet-level admin/maintainer can set per-host values (fleet-level for their assigned fleets).
