### PR TITLE
Add VEX exclusions for fleetdm/fleetctl

### DIFF
--- a/security/status.md
+++ b/security/status.md
@@ -316,6 +316,14 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2026-05-19 10:35:00
 
+### [CVE-2026-6653](https://nvd.nist.gov/vuln/detail/CVE-2026-6653)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** The affected dependency (libxml2) is not utilized by fleetctl itself, but by Apple's iTMSTransporter tool, which is included in the Docker image for code signing purposes. fleetctl does not process untrusted XML input. Additionally, this CVE describes a denial-of-service (DoS) vulnerability, and fleetctl is a CLI tool, not a long-running service, and therefore is not susceptible to DoS-style exploitation.
+- **Products:** `fleetctl`,`pkg:deb/debian/libxml2`
+- **Justification:** `vulnerable_code_cannot_be_controlled_by_adversary`
+- **Timestamp:** 2026-07-17 18:43:57
+
 ### [CVE-2026-58016](https://nvd.nist.gov/vuln/detail/CVE-2026-58016)
 - **Author:** @lucasmrod
 - **Status:** `not_affected`
@@ -497,6 +505,14 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Products:** `fleetctl`,`pkg:golang/github.com/fleetdm/fleet/v4`
 - **Justification:** `component_not_present`
 - **Timestamp:** 2026-01-30 09:25:41
+
+### [CVE-2026-13221](https://nvd.nist.gov/vuln/detail/CVE-2026-13221)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** perl is not used during fleetd package generation.
+- **Products:** `fleetctl`,`pkg:deb/debian/perl-base`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-07-17 18:43:57
 
 ### [CVE-2026-0968](https://nvd.nist.gov/vuln/detail/CVE-2026-0968)
 - **Author:** @lucasmrod

--- a/security/vex/fleetctl/CVE-2026-13221.vex.json
+++ b/security/vex/fleetctl/CVE-2026-13221.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-5cc15afe16f1a37dfba48432a7f96b54d245f1645c8a9eb470a502d2537c5141",
+  "author": "@lucasmrod",
+  "timestamp": "2026-07-17T18:43:57Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-13221"
+      },
+      "timestamp": "2026-07-17T18:43:57Z",
+      "products": [
+        {
+          "@id": "fleetctl"
+        },
+        {
+          "@id": "pkg:deb/debian/perl-base"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "perl is not used during fleetd package generation",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/security/vex/fleetctl/CVE-2026-6653.vex.json
+++ b/security/vex/fleetctl/CVE-2026-6653.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-ac5fd54aca0ef96d0aac176337aa3a09e18638b8911698d011f4daf8dbf6a30d",
+  "author": "@lucasmrod",
+  "timestamp": "2026-07-17T18:43:57Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-6653"
+      },
+      "timestamp": "2026-07-17T18:43:57Z",
+      "products": [
+        {
+          "@id": "fleetctl"
+        },
+        {
+          "@id": "pkg:deb/debian/libxml2"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "The affected dependency (libxml2) is not utilized by fleetctl itself, but by Apple's iTMSTransporter tool, which is included in the Docker image for code signing purposes. fleetctl does not process untrusted XML input. Additionally, this CVE describes a denial-of-service (DoS) vulnerability, and fleetctl is a CLI tool, not a long-running service, and therefore is not susceptible to DoS-style exploitation.",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes: https://github.com/fleetdm/fleet/actions/runs/29560990071.

New run: https://github.com/fleetdm/fleet/actions/runs/29605383790.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added vulnerability status records for CVE-2026-13221 and CVE-2026-6653.
  * Documented that the reported vulnerabilities do not affect `fleetctl` because the relevant dependency code is not used during operation or package generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->