### PR TITLE
Fleet UI: show custom host vital row actions disabled with GitOps tooltip

### DIFF
--- a/frontend/pages/ManageControlsPage/Variables/cards/CustomHostVitalsTab/CustomHostVitalsTab.tsx
+++ b/frontend/pages/ManageControlsPage/Variables/cards/CustomHostVitalsTab/CustomHostVitalsTab.tsx
@@ -3,7 +3,6 @@ import { useQuery } from "react-query";
 
 import PATHS from "router/paths";
 import { AppContext } from "context/app";
-import useGitOpsMode from "hooks/useGitOpsMode";
 import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
 import { getNextLocationPath } from "utilities/helpers";
 import { ICustomHostVital } from "interfaces/custom_host_vitals";
@@ -37,7 +36,6 @@ const CustomHostVitalsTab: React.FC<IVariablesCardProps> = ({
   location,
 }) => {
   const { isGlobalAdmin, isGlobalMaintainer } = useContext(AppContext);
-  const { gitOpsModeEnabled } = useGitOpsMode();
 
   const canEdit = isGlobalAdmin || isGlobalMaintainer;
 
@@ -140,11 +138,10 @@ const CustomHostVitalsTab: React.FC<IVariablesCardProps> = ({
     () =>
       generateTableHeaders({
         canEdit: !!canEdit,
-        gitOpsModeEnabled,
         onEdit: setVitalToEdit,
         onDelete: setVitalToDelete,
       }),
-    [canEdit, gitOpsModeEnabled, setVitalToEdit, setVitalToDelete]
+    [canEdit, setVitalToEdit, setVitalToDelete]
   );
 
   const renderCount = useCallback(

--- a/frontend/pages/ManageControlsPage/Variables/cards/CustomHostVitalsTab/CustomHostVitalsTableConfig.tsx
+++ b/frontend/pages/ManageControlsPage/Variables/cards/CustomHostVitalsTab/CustomHostVitalsTableConfig.tsx
@@ -100,8 +100,6 @@ const generateTableHeaders = ({
         return (
           <div className="custom-host-vitals-tab__actions">
             <GitOpsModeTooltipWrapper
-              position="left"
-              tipOffset={8}
               renderChildren={(disableChildren) => (
                 <>
                   <Button

--- a/frontend/pages/ManageControlsPage/Variables/cards/CustomHostVitalsTab/CustomHostVitalsTableConfig.tsx
+++ b/frontend/pages/ManageControlsPage/Variables/cards/CustomHostVitalsTab/CustomHostVitalsTableConfig.tsx
@@ -98,30 +98,30 @@ const generateTableHeaders = ({
       Cell: (cellProps) => {
         const vital = cellProps.row.original;
         return (
-          <div className="custom-host-vitals-tab__actions">
-            <GitOpsModeTooltipWrapper
-              renderChildren={(disableChildren) => (
-                <>
-                  <Button
-                    variant="icon"
-                    disabled={disableChildren}
-                    onClick={() => onEdit(vital)}
-                    ariaLabel={`Edit ${vital.name}`}
-                  >
-                    <Icon name="pencil" color="ui-fleet-black-75" />
-                  </Button>
-                  <Button
-                    variant="icon"
-                    disabled={disableChildren}
-                    onClick={() => onDelete(vital)}
-                    ariaLabel={`Delete ${vital.name}`}
-                  >
-                    <Icon name="trash" color="ui-fleet-black-75" />
-                  </Button>
-                </>
-              )}
-            />
-          </div>
+          <GitOpsModeTooltipWrapper
+            position="top"
+            fixedPositionStrategy
+            renderChildren={(disableChildren) => (
+              <div className="custom-host-vitals-tab__actions">
+                <Button
+                  variant="icon"
+                  disabled={disableChildren}
+                  onClick={() => onEdit(vital)}
+                  ariaLabel={`Edit ${vital.name}`}
+                >
+                  <Icon name="pencil" color="ui-fleet-black-75" />
+                </Button>
+                <Button
+                  variant="icon"
+                  disabled={disableChildren}
+                  onClick={() => onDelete(vital)}
+                  ariaLabel={`Delete ${vital.name}`}
+                >
+                  <Icon name="trash" color="ui-fleet-black-75" />
+                </Button>
+              </div>
+            )}
+          />
         );
       },
     });

--- a/frontend/pages/ManageControlsPage/Variables/cards/CustomHostVitalsTab/CustomHostVitalsTableConfig.tsx
+++ b/frontend/pages/ManageControlsPage/Variables/cards/CustomHostVitalsTab/CustomHostVitalsTableConfig.tsx
@@ -8,6 +8,7 @@ import { HumanTimeDiffWithDateTip } from "components/HumanTimeDiffWithDateTip";
 import Button from "components/buttons/Button";
 import CopyButton from "components/buttons/CopyButton";
 import Icon from "components/Icon";
+import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
 
 export const getTokenFromVitalId = (id: number): string =>
   `$FLEET_HOST_VITAL_${id}`;
@@ -36,14 +37,12 @@ interface IDataColumn {
 
 interface IGenerateTableHeadersParams {
   canEdit: boolean;
-  gitOpsModeEnabled: boolean;
   onEdit: (vital: ICustomHostVital) => void;
   onDelete: (vital: ICustomHostVital) => void;
 }
 
 const generateTableHeaders = ({
   canEdit,
-  gitOpsModeEnabled,
   onEdit,
   onDelete,
 }: IGenerateTableHeadersParams): IDataColumn[] => {
@@ -87,8 +86,10 @@ const generateTableHeaders = ({
     },
   ];
 
-  // Non-write roles and GitOps mode don't get row actions.
-  if (canEdit && !gitOpsModeEnabled) {
+  // Non-write roles don't get row actions. In GitOps mode the actions are shown
+  // but disabled with the standard GitOps tooltip (matching the "Add vital"
+  // button), since custom host vitals are then managed via the config file.
+  if (canEdit) {
     columns.push({
       title: "Actions",
       Header: "",
@@ -98,20 +99,30 @@ const generateTableHeaders = ({
         const vital = cellProps.row.original;
         return (
           <div className="custom-host-vitals-tab__actions">
-            <Button
-              variant="icon"
-              onClick={() => onEdit(vital)}
-              ariaLabel={`Edit ${vital.name}`}
-            >
-              <Icon name="pencil" color="ui-fleet-black-75" />
-            </Button>
-            <Button
-              variant="icon"
-              onClick={() => onDelete(vital)}
-              ariaLabel={`Delete ${vital.name}`}
-            >
-              <Icon name="trash" color="ui-fleet-black-75" />
-            </Button>
+            <GitOpsModeTooltipWrapper
+              position="left"
+              tipOffset={8}
+              renderChildren={(disableChildren) => (
+                <>
+                  <Button
+                    variant="icon"
+                    disabled={disableChildren}
+                    onClick={() => onEdit(vital)}
+                    ariaLabel={`Edit ${vital.name}`}
+                  >
+                    <Icon name="pencil" color="ui-fleet-black-75" />
+                  </Button>
+                  <Button
+                    variant="icon"
+                    disabled={disableChildren}
+                    onClick={() => onDelete(vital)}
+                    ariaLabel={`Delete ${vital.name}`}
+                  >
+                    <Icon name="trash" color="ui-fleet-black-75" />
+                  </Button>
+                </>
+              )}
+            />
           </div>
         );
       },


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Relates to #44954

In GitOps mode, the Custom host vitals tab hid the row edit/delete icons entirely, while the "Add vital" button was shown disabled with the standard GitOps tooltip — an inconsistency. This makes the edit/delete icons behave like the Add button: shown but disabled with the GitOps tooltip (wrapped in `GitOpsModeTooltipWrapper`, which reads GitOps mode from context). The now-unused `gitOpsModeEnabled` prop/hook is removed.

This fixes something I've missed from the parent's story UI Test Plan section:

```
GitOps mode: add/edit/delete controls are disabled with the GitOps tooltip. Can still set individual per-host values.
```

# Checklist for submitter

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

Already added as part of the feature which is in main.


## Testing

- [x] QA'd all new/changed functionality manually

<img width="1538" height="556" alt="Screenshot 2026-07-17 at 4 31 24 PM" src="https://github.com/user-attachments/assets/393c2b08-fd2b-40eb-96e2-a22fc743d785" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Custom Host Vitals table behavior when GitOps mode is enabled.
  * Edit and delete actions now remain visible but are appropriately disabled, with guidance displayed when unavailable.
  * Preserved existing token-copy and last-updated information in the table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->