### PR TITLE
Improve Ubuntu TPM FDE errors

### DIFF
--- a/orbit/pkg/luks/snapd_client.go
+++ b/orbit/pkg/luks/snapd_client.go
@@ -114,6 +114,26 @@ func (e *snapdAPIError) Error() string {
 	return fmt.Sprintf("snapd %s returned status %d", e.Path, e.StatusCode)
 }
 
+// isUnsupportedOperation reports whether the error is snapd's
+// "this action is not supported on this system" response. That response is
+// returned regardless of snapd version when the /v2/system-volumes endpoint
+// exists but snapd does not consider itself the authoritative FDE manager on
+// this host — for example, a system with `ubuntu-fde` LUKS2 tokens where the
+// FDE state is "indeterminate" (as reported by `snap-tpmctl status`). No
+// amount of retrying against snapd will change this; the operator has to
+// resolve the underlying FDE state.
+func (e *snapdAPIError) isUnsupportedOperation() bool {
+	if e == nil {
+		return false
+	}
+	msg := strings.ToLower(e.Message)
+	kind := strings.ToLower(e.Kind)
+	// The canonical wording as of snapd 2.75 is "this action is not supported
+	// on this system"; use "not supported" as the prefix so we survive small
+	// phrasing drift while still not matching unrelated errors.
+	return strings.Contains(msg, "not supported") || strings.Contains(kind, "not-supported")
+}
+
 // isConflict reports whether the error looks like a snapd "resource already
 // exists" response, which is the only case in which the add-recovery-key
 // caller should fall back to replace-recovery-key.

--- a/orbit/pkg/luks/snapd_client.go
+++ b/orbit/pkg/luks/snapd_client.go
@@ -73,6 +73,21 @@ type snapdResponse struct {
 	Change     string          `json:"change"` // change id, set on async responses
 }
 
+// snapdSystemInfo is the relevant subset of GET /v2/system-info. Only "version"
+// is consumed today, to preflight the recovery-key management API.
+type snapdSystemInfo struct {
+	Version string `json:"version"`
+}
+
+// systemInfo fetches GET /v2/system-info and returns the parsed system info.
+func (c *snapdClient) systemInfo(ctx context.Context) (snapdSystemInfo, error) {
+	var info snapdSystemInfo
+	if err := c.requestSync(ctx, http.MethodGet, "/v2/system-info", nil, &info); err != nil {
+		return snapdSystemInfo{}, err
+	}
+	return info, nil
+}
+
 // snapdError is the shape of the "result" field when a request fails.
 type snapdError struct {
 	Message string `json:"message"`

--- a/orbit/pkg/luks/snapd_fde.go
+++ b/orbit/pkg/luks/snapd_fde.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
+	"strings"
 
 	"github.com/Masterminds/semver"
 	"github.com/rs/zerolog/log"
@@ -30,6 +32,16 @@ const systemVolumesPath = "/v2/system-volumes"
 // lets us surface a clear "your snapd is too old" error to the admin instead
 // of the raw snapd 400.
 const snapdMinVersion = "2.74.0"
+
+// ubuntuMinVersion is the earliest Ubuntu release whose installer sets up FDE
+// in a way that snapd owns end-to-end, so snapd's /v2/system-volumes actions
+// actually work. On Ubuntu 24.04 the installer writes `ubuntu-fde` LUKS2
+// tokens (so IsSnapdManaged returns true) but does not fully hand ownership
+// to snapd's secboot stack — `snap-tpmctl status` reports "the fde system is
+// indeterminate" and the API rejects the actions regardless of snapd
+// version. Preflighting the Ubuntu version lets us name the actual
+// requirement instead of pointing operators at snapd.
+const ubuntuMinVersion = "26.04"
 
 // snapd /v2/system-volumes action values.
 const (
@@ -78,7 +90,14 @@ func newSnapdSocketFDE() *snapdSocketFDE {
 // ensureFleetRecoveryKey generates a recovery key and enrolls it under the
 // dedicated Fleet-owned key slot name, returning the recovery key to escrow.
 func (s *snapdSocketFDE) ensureFleetRecoveryKey(ctx context.Context) (string, error) {
-	// Step 0: preflight snapd's version. The /v2/system-volumes actions we
+	// Step 0a: preflight the OS. On Ubuntu 24.04 the installer writes
+	// `ubuntu-fde` LUKS2 tokens but snapd never fully owns the FDE, so no
+	// snapd version can escrow a recovery key there. Fail fast with a
+	// distro-specific message before we even touch snapd.
+	if err := checkUbuntuVersion(osReleaseReader); err != nil {
+		return "", err
+	}
+	// Step 0b: preflight snapd's version. The /v2/system-volumes actions we
 	// use (generate/add/check-recovery-key) landed in snapd 2.74. Older snapd
 	// still has `ubuntu-fde` LUKS2 tokens on disk (so IsSnapdManaged returns
 	// true) but rejects the action with a 400 "not supported on this system".
@@ -183,5 +202,84 @@ func (s *snapdSocketFDE) checkSnapdVersion(ctx context.Context) error {
 		return fmt.Errorf("snapd %s does not support TPM-backed FDE recovery-key management; upgrade snapd to %s or later (Ubuntu 26.04+)", info.Version, snapdMinVersion)
 	}
 	log.Debug().Str("snapd_version", info.Version).Msg("snapd version supports recovery-key management")
+	return nil
+}
+
+// osRelease is the subset of /etc/os-release fields orbit's snapd FDE preflight
+// consults. ID is normally the distro slug (e.g. "ubuntu", "fedora") and
+// VersionID is the numeric release ("24.04", "26.04").
+type osRelease struct {
+	ID        string
+	VersionID string
+}
+
+// osReleaseReader is the package-level hook the ensureFleetRecoveryKey
+// preflight uses to load /etc/os-release. Tests swap it to drive the
+// distro-version check without touching the real filesystem, so the same
+// unit tests run identically on any CI runner regardless of distro.
+var osReleaseReader = readOSRelease
+
+// readOSRelease parses /etc/os-release into an osRelease. On systems without
+// the file (very old distros, some minimal containers) it returns a zero
+// value and no error — the caller will treat that as "unknown" and skip the
+// distro-specific check rather than misidentifying the host.
+func readOSRelease() (osRelease, error) {
+	data, err := os.ReadFile("/etc/os-release")
+	if err != nil {
+		if os.IsNotExist(err) {
+			return osRelease{}, nil
+		}
+		return osRelease{}, fmt.Errorf("reading /etc/os-release: %w", err)
+	}
+	var rel osRelease
+	for _, line := range strings.Split(string(data), "\n") {
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		// /etc/os-release values may be quoted.
+		value = strings.Trim(value, `"'`)
+		switch key {
+		case "ID":
+			rel.ID = value
+		case "VERSION_ID":
+			rel.VersionID = value
+		}
+	}
+	return rel, nil
+}
+
+// checkUbuntuVersion returns an error naming Ubuntu's minimum supported
+// release if the host is Ubuntu older than ubuntuMinVersion. On non-Ubuntu
+// hosts or when /etc/os-release cannot be read, it returns nil — the snapd
+// version check downstream will still gate access. The read function is
+// injected so tests can drive it without touching the real filesystem.
+func checkUbuntuVersion(read func() (osRelease, error)) error {
+	rel, err := read()
+	if err != nil {
+		// Log and let the flow continue; snapd's own preflight is the
+		// backstop and we don't want a missing/unreadable os-release to
+		// permanently block escrow on hosts where the feature would work.
+		log.Warn().Err(err).Msg("could not read /etc/os-release; skipping Ubuntu version preflight")
+		return nil
+	}
+	if rel.ID != "ubuntu" || rel.VersionID == "" {
+		log.Debug().Str("os_id", rel.ID).Str("os_version_id", rel.VersionID).
+			Msg("host is not Ubuntu or has no VERSION_ID; skipping Ubuntu version preflight")
+		return nil
+	}
+	got, err := semver.NewVersion(rel.VersionID)
+	if err != nil {
+		log.Warn().Err(err).Str("os_version_id", rel.VersionID).
+			Msg("could not parse Ubuntu VERSION_ID; skipping Ubuntu version preflight")
+		return nil
+	}
+	minVer := semver.MustParse(ubuntuMinVersion)
+	if got.LessThan(minVer) {
+		log.Warn().Str("ubuntu_version", rel.VersionID).Str("min_version", ubuntuMinVersion).
+			Msg("Ubuntu release does not support snapd-managed TPM-backed FDE escrow")
+		return fmt.Errorf("Ubuntu %s does not support snapd-managed TPM-backed FDE recovery-key escrow; upgrade the host to Ubuntu %s or later", rel.VersionID, ubuntuMinVersion)
+	}
+	log.Debug().Str("ubuntu_version", rel.VersionID).Msg("Ubuntu version supports snapd-managed FDE escrow")
 	return nil
 }

--- a/orbit/pkg/luks/snapd_fde.go
+++ b/orbit/pkg/luks/snapd_fde.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/Masterminds/semver"
 	"github.com/rs/zerolog/log"
 )
 
@@ -20,6 +21,15 @@ import (
 // line is 2.75.x/2.76), not just master
 // (daemon/api_system_volumes.go, overlord/fdestate/fdestate.go).
 const systemVolumesPath = "/v2/system-volumes"
+
+// snapdMinVersion is the earliest snapd version that supports the runtime
+// recovery-key management actions on /v2/system-volumes (generate/add/replace/
+// check-recovery-key). Older snapd builds have `ubuntu-fde` LUKS2 tokens on
+// disk — so IsSnapdManaged still returns true — but reject the actions with
+// "this action is not supported on this system". Preflighting the version
+// lets us surface a clear "your snapd is too old" error to the admin instead
+// of the raw snapd 400.
+const snapdMinVersion = "2.74.0"
 
 // snapd /v2/system-volumes action values.
 const (
@@ -68,6 +78,16 @@ func newSnapdSocketFDE() *snapdSocketFDE {
 // ensureFleetRecoveryKey generates a recovery key and enrolls it under the
 // dedicated Fleet-owned key slot name, returning the recovery key to escrow.
 func (s *snapdSocketFDE) ensureFleetRecoveryKey(ctx context.Context) (string, error) {
+	// Step 0: preflight snapd's version. The /v2/system-volumes actions we
+	// use (generate/add/check-recovery-key) landed in snapd 2.74. Older snapd
+	// still has `ubuntu-fde` LUKS2 tokens on disk (so IsSnapdManaged returns
+	// true) but rejects the action with a 400 "not supported on this system".
+	// Fail fast with a version-specific message so the operator sees what
+	// actually needs to change.
+	if err := s.checkSnapdVersion(ctx); err != nil {
+		return "", err
+	}
+
 	// Step 1: generate a recovery key. snapd answers synchronously with the key
 	// value and a transient id used to enroll it.
 	log.Debug().Str("action", actionGenerateRecoveryKey).Msg("requesting snapd to generate a recovery key")
@@ -124,4 +144,33 @@ func (s *snapdSocketFDE) ensureFleetRecoveryKey(ctx context.Context) (string, er
 
 	log.Info().Str("keyslot", FleetRecoveryKeyName).Msg("snapd-managed recovery key enrolled and validated")
 	return gen.RecoveryKey, nil
+}
+
+// checkSnapdVersion queries snapd's system-info and returns an error whose
+// message explicitly names the minimum required version if the running snapd
+// is older than snapdMinVersion. snapd's version string may carry a
+// distribution suffix (e.g. "2.68.5+24.04") which the Masterminds/semver
+// parser handles as a build/pre-release tag; comparison is on the numeric
+// major.minor.patch part.
+func (s *snapdSocketFDE) checkSnapdVersion(ctx context.Context) error {
+	info, err := s.client.systemInfo(ctx)
+	if err != nil {
+		return fmt.Errorf("querying snapd system info: %w", err)
+	}
+	if info.Version == "" {
+		return errors.New("snapd system-info did not return a version")
+	}
+
+	got, err := semver.NewVersion(info.Version)
+	if err != nil {
+		return fmt.Errorf("parsing snapd version %q: %w", info.Version, err)
+	}
+	minVer := semver.MustParse(snapdMinVersion)
+	if got.LessThan(minVer) {
+		log.Warn().Str("snapd_version", info.Version).Str("min_version", snapdMinVersion).
+			Msg("snapd is too old for TPM-backed FDE recovery-key management")
+		return fmt.Errorf("snapd %s does not support TPM-backed FDE recovery-key management; upgrade snapd to %s or later (Ubuntu 26.04+)", info.Version, snapdMinVersion)
+	}
+	log.Debug().Str("snapd_version", info.Version).Msg("snapd version supports recovery-key management")
+	return nil
 }

--- a/orbit/pkg/luks/snapd_fde.go
+++ b/orbit/pkg/luks/snapd_fde.go
@@ -94,6 +94,17 @@ func (s *snapdSocketFDE) ensureFleetRecoveryKey(ctx context.Context) (string, er
 	var gen generateRecoveryKeyResponse
 	if err := s.client.requestSync(ctx, http.MethodPost, systemVolumesPath,
 		generateRecoveryKeyRequest{Action: actionGenerateRecoveryKey}, &gen); err != nil {
+		// snapd rejects the action with "not supported on this system" when
+		// it sees `ubuntu-fde` tokens but does not consider itself the
+		// authoritative FDE manager (e.g. `snap-tpmctl status` reports the
+		// FDE system as indeterminate). Version-upgrading snapd does not fix
+		// this; the operator has to resolve the FDE state on the host, so
+		// surface a specific message instead of the raw snapd 400.
+		var apiErr *snapdAPIError
+		if errors.As(err, &apiErr) && apiErr.isUnsupportedOperation() {
+			log.Warn().Err(err).Msg("snapd refuses to manage recovery keys on this host; the FDE system is likely not fully snapd-managed (check `snap-tpmctl status`)")
+			return "", fmt.Errorf("snapd does not consider this host a snapd-managed FDE system, so recovery-key escrow is unavailable. Run `snap-tpmctl status` on the host — if it reports \"the fde system is indeterminate\", the LUKS2 volume is not owned by snapd's secboot stack and orbit cannot escrow a recovery key here. Underlying snapd error: %s", apiErr.Message)
+		}
 		return "", fmt.Errorf("generating snapd recovery key: %w", err)
 	}
 	if gen.RecoveryKey == "" || gen.KeyID == "" {

--- a/orbit/pkg/luks/snapd_fde_test.go
+++ b/orbit/pkg/luks/snapd_fde_test.go
@@ -126,6 +126,36 @@ func TestEnsureFleetRecoveryKeyViaSocketFallsBackToReplace(t *testing.T) {
 	assert.True(t, sawReplace, "fell back to replace-recovery-key when add reported a conflict")
 }
 
+func TestEnsureFleetRecoveryKeyReportsUnsupportedFDEState(t *testing.T) {
+	// Regression: on some hosts snapd is new enough to expose the endpoint
+	// but reports "this action is not supported on this system" because the
+	// FDE state is indeterminate (`ubuntu-fde` LUKS2 tokens exist but snapd
+	// is not the authoritative manager). The error message must call that
+	// out and point at snap-tpmctl so the admin has somewhere to look.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/v2/system-info" {
+			writeSystemInfo(w, "2.75.0")
+			return
+		}
+		req := decodeAction(t, r)
+		if req.Action == actionGenerateRecoveryKey {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"type":"error","status-code":400,"result":{"message":"this action is not supported on this system"}}`))
+			return
+		}
+		t.Errorf("did not expect action %q after generate-recovery-key failed", req.Action)
+	}))
+	defer srv.Close()
+
+	fde := &snapdSocketFDE{client: newTestSnapdClient(srv)}
+	_, err := fde.ensureFleetRecoveryKey(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "snap-tpmctl status", "error points the admin at the diagnostic command")
+	assert.Contains(t, err.Error(), "indeterminate", "error names the state operators will see")
+	assert.Contains(t, err.Error(), "not supported", "underlying snapd message is preserved for debugging")
+}
+
 func TestEnsureFleetRecoveryKeyRejectsOldSnapd(t *testing.T) {
 	// Regression: snapd < 2.74 has the /v2/system-volumes endpoint but rejects
 	// generate-recovery-key with 400 "this action is not supported on this

--- a/orbit/pkg/luks/snapd_fde_test.go
+++ b/orbit/pkg/luks/snapd_fde_test.go
@@ -5,6 +5,7 @@ package luks
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -35,7 +36,22 @@ func writeSystemInfo(w http.ResponseWriter, version string) {
 	_, _ = w.Write([]byte(`{"type":"sync","status-code":200,"result":{"version":"` + version + `"}}`))
 }
 
+// stubOSReleaseReader swaps the package-level osReleaseReader for the
+// duration of the test so ensureFleetRecoveryKey's distro preflight sees the
+// requested os-release shape regardless of the CI runner's actual distro.
+func stubOSReleaseReader(t *testing.T, rel osRelease) {
+	t.Helper()
+	original := osReleaseReader
+	osReleaseReader = func() (osRelease, error) { return rel, nil }
+	t.Cleanup(func() { osReleaseReader = original })
+}
+
+// supportedOSRelease is a canned Ubuntu 26.04 osRelease used by the socket
+// integration tests that need the distro preflight to pass.
+var supportedOSRelease = osRelease{ID: "ubuntu", VersionID: "26.04"}
+
 func TestEnsureFleetRecoveryKeyViaSocket(t *testing.T) {
+	stubOSReleaseReader(t, supportedOSRelease)
 	const wantKey = "55055-39320-64491-48436-47667-15525-36879-32875"
 	var sawGenerate, sawAdd, sawCheck bool
 
@@ -88,6 +104,7 @@ func TestEnsureFleetRecoveryKeyViaSocket(t *testing.T) {
 }
 
 func TestEnsureFleetRecoveryKeyViaSocketFallsBackToReplace(t *testing.T) {
+	stubOSReleaseReader(t, supportedOSRelease)
 	var sawReplace bool
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -126,7 +143,53 @@ func TestEnsureFleetRecoveryKeyViaSocketFallsBackToReplace(t *testing.T) {
 	assert.True(t, sawReplace, "fell back to replace-recovery-key when add reported a conflict")
 }
 
+func TestCheckUbuntuVersion(t *testing.T) {
+	// Preflight the /etc/os-release-based OS check. Only Ubuntu < 26.04 is
+	// rejected today; every other outcome (non-Ubuntu, unreadable file,
+	// unparseable version) must fall through so the snapd preflight and the
+	// real endpoint remain the source of truth.
+	cases := []struct {
+		name    string
+		rel     osRelease
+		readErr error
+		wantErr bool
+	}{
+		{name: "ubuntu 24.04 is rejected", rel: osRelease{ID: "ubuntu", VersionID: "24.04"}, wantErr: true},
+		{name: "ubuntu 22.04 is rejected", rel: osRelease{ID: "ubuntu", VersionID: "22.04"}, wantErr: true},
+		{name: "ubuntu 26.04 is accepted", rel: osRelease{ID: "ubuntu", VersionID: "26.04"}, wantErr: false},
+		{name: "ubuntu 26.10 is accepted", rel: osRelease{ID: "ubuntu", VersionID: "26.10"}, wantErr: false},
+		{name: "non-ubuntu host is not gated here", rel: osRelease{ID: "fedora", VersionID: "40"}, wantErr: false},
+		{name: "missing os-release is not gated here", readErr: errors.New("boom"), wantErr: false},
+		{name: "empty os-release is not gated here", rel: osRelease{}, wantErr: false},
+		{name: "unparseable version is not gated here", rel: osRelease{ID: "ubuntu", VersionID: "not-a-number"}, wantErr: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := checkUbuntuVersion(func() (osRelease, error) { return tc.rel, tc.readErr })
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.rel.VersionID, "error names the too-old Ubuntu version")
+				assert.Contains(t, err.Error(), ubuntuMinVersion, "error names the required minimum Ubuntu version")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestReadOSRelease(t *testing.T) {
+	// Sanity check the parser against a realistic Ubuntu 24.04 file. This
+	// hits the real /etc/os-release path only on the CI runner, which is
+	// Linux — if there's no file (edge-case container), the function returns
+	// a zero value, which is also acceptable.
+	rel, err := readOSRelease()
+	require.NoError(t, err)
+	// rel may be empty on stripped containers; that's not a failure.
+	_ = rel
+}
+
 func TestEnsureFleetRecoveryKeyReportsUnsupportedFDEState(t *testing.T) {
+	stubOSReleaseReader(t, supportedOSRelease)
 	// Regression: on some hosts snapd is new enough to expose the endpoint
 	// but reports "this action is not supported on this system" because the
 	// FDE state is indeterminate (`ubuntu-fde` LUKS2 tokens exist but snapd
@@ -157,6 +220,7 @@ func TestEnsureFleetRecoveryKeyReportsUnsupportedFDEState(t *testing.T) {
 }
 
 func TestEnsureFleetRecoveryKeyRejectsOldSnapd(t *testing.T) {
+	stubOSReleaseReader(t, supportedOSRelease)
 	// Regression: snapd < 2.74 has the /v2/system-volumes endpoint but rejects
 	// generate-recovery-key with 400 "this action is not supported on this
 	// system". Preflight the version so the operator sees a clear

--- a/orbit/pkg/luks/snapd_fde_test.go
+++ b/orbit/pkg/luks/snapd_fde_test.go
@@ -27,6 +27,14 @@ func decodeAction(t *testing.T, r *http.Request) recoveryKeyActionRequest {
 	return req
 }
 
+// writeSystemInfo returns a canned system-info response with the given snapd
+// version. Test handlers should route GET /v2/system-info to this so the
+// version preflight in ensureFleetRecoveryKey sees a version that permits the
+// rest of the flow to run.
+func writeSystemInfo(w http.ResponseWriter, version string) {
+	_, _ = w.Write([]byte(`{"type":"sync","status-code":200,"result":{"version":"` + version + `"}}`))
+}
+
 func TestEnsureFleetRecoveryKeyViaSocket(t *testing.T) {
 	const wantKey = "55055-39320-64491-48436-47667-15525-36879-32875"
 	var sawGenerate, sawAdd, sawCheck bool
@@ -36,6 +44,11 @@ func TestEnsureFleetRecoveryKeyViaSocket(t *testing.T) {
 
 		if r.URL.Path == "/v2/changes/9" {
 			_, _ = w.Write([]byte(`{"type":"sync","status-code":200,"result":{"ready":true,"status":"Done"}}`))
+			return
+		}
+
+		if r.URL.Path == "/v2/system-info" {
+			writeSystemInfo(w, "2.75.0")
 			return
 		}
 
@@ -82,6 +95,10 @@ func TestEnsureFleetRecoveryKeyViaSocketFallsBackToReplace(t *testing.T) {
 			_, _ = w.Write([]byte(`{"type":"sync","status-code":200,"result":{"ready":true,"status":"Done"}}`))
 			return
 		}
+		if r.URL.Path == "/v2/system-info" {
+			writeSystemInfo(w, "2.75.0")
+			return
+		}
 		req := decodeAction(t, r)
 		switch req.Action {
 		case actionGenerateRecoveryKey:
@@ -107,4 +124,62 @@ func TestEnsureFleetRecoveryKeyViaSocketFallsBackToReplace(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "11111-22222", key)
 	assert.True(t, sawReplace, "fell back to replace-recovery-key when add reported a conflict")
+}
+
+func TestEnsureFleetRecoveryKeyRejectsOldSnapd(t *testing.T) {
+	// Regression: snapd < 2.74 has the /v2/system-volumes endpoint but rejects
+	// generate-recovery-key with 400 "this action is not supported on this
+	// system". Preflight the version so the operator sees a clear
+	// upgrade-required message instead of the raw snapd 400.
+	cases := []struct {
+		name    string
+		version string
+		wantErr bool
+	}{
+		{name: "2.73 is too old", version: "2.73.4", wantErr: true},
+		{name: "2.68 with ubuntu suffix is too old", version: "2.68.5+24.04", wantErr: true},
+		{name: "2.74.0 exactly is accepted", version: "2.74.0", wantErr: false},
+		{name: "2.75.1 is accepted", version: "2.75.1", wantErr: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var sawGenerate bool
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if r.URL.Path == "/v2/system-info" {
+					writeSystemInfo(w, tc.version)
+					return
+				}
+				if r.URL.Path == "/v2/changes/9" {
+					_, _ = w.Write([]byte(`{"type":"sync","status-code":200,"result":{"ready":true,"status":"Done"}}`))
+					return
+				}
+				req := decodeAction(t, r)
+				switch req.Action {
+				case actionGenerateRecoveryKey:
+					sawGenerate = true
+					_, _ = w.Write([]byte(`{"type":"sync","status-code":200,"result":{"recovery-key":"55055-39320","key-id":"kid-3"}}`))
+				case actionAddRecoveryKey:
+					_, _ = w.Write([]byte(`{"type":"async","status-code":202,"change":"9"}`))
+				case actionCheckRecoveryKey:
+					_, _ = w.Write([]byte(`{"type":"sync","status-code":200,"result":null}`))
+				default:
+					t.Errorf("unexpected action %q", req.Action)
+				}
+			}))
+			defer srv.Close()
+
+			fde := &snapdSocketFDE{client: newTestSnapdClient(srv)}
+			_, err := fde.ensureFleetRecoveryKey(context.Background())
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.version, "error names the too-old version")
+				assert.Contains(t, err.Error(), snapdMinVersion, "error names the required minimum version")
+				assert.False(t, sawGenerate, "preflight fails before generate-recovery-key is called")
+			} else {
+				require.NoError(t, err)
+				assert.True(t, sawGenerate, "flow proceeds past preflight on supported versions")
+			}
+		})
+	}
 }


### PR DESCRIPTION
A host testing enrollment surfaced this:

    creating Fleet recovery key: generating snapd recovery key:
    snapd /v2/system-volumes returned 400: this action is not supported
    on this system

The host had `ubuntu-fde` LUKS2 tokens (so IsSnapdManaged returned
true), but its snapd predates the runtime recovery-key management API
that landed in 2.74. Orbit was hitting generate-recovery-key and
surfacing snapd's raw 400 in the OS-settings modal, which tells an
admin nothing.

Add a checkSnapdVersion preflight that queries GET /v2/system-info,
parses the version with Masterminds/semver, and fails fast with

    snapd 2.68.5+24.04 does not support TPM-backed FDE recovery-key
    management; upgrade snapd to 2.74.0 or later (Ubuntu 26.04+)

when snapd is older than 2.74.0. Table-driven tests cover the too-old,
old-with-distribution-suffix, exactly-2.74, and accepted-newer cases.

Also fix the isConflict substring check to match snapd's plural
"key slots [...] already exist" wording (missed by the earlier
"already exists" check when a name-only keyslotRef expands to both
system containers, which is our case).<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
