### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/brave-browser/darwin.json
+++ b/ee/maintained-apps/outputs/brave-browser/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "150.1.92.140",
+      "version": "150.1.92.141",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.brave.Browser';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.brave.Browser' AND version_compare(bundle_short_version, '150.1.92.140') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.brave.Browser' AND version_compare(bundle_short_version, '150.1.92.141') < 0);"
       },
-      "installer_url": "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/stable-arm64/192.140/Brave-Browser-arm64.dmg",
+      "installer_url": "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/stable-arm64/192.141/Brave-Browser-arm64.dmg",
       "install_script_ref": "013e53e8",
       "uninstall_script_ref": "9a376609",
-      "sha256": "a87ec4d93e4d9867cb59e344c53b873fdef6e00d8ac76dea57243e645c5c9bbc",
+      "sha256": "3469b217b19217202d03dece13e91bc7886a1cbae975a2f905e99b06af8d5d8f",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/brave-browser/windows.json
+++ b/ee/maintained-apps/outputs/brave-browser/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "150.1.92.140",
+      "version": "150.1.92.141",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Brave' AND publisher = 'Brave Software Inc';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Brave' AND publisher = 'Brave Software Inc' AND version_compare(version, '150.1.92.140') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Brave' AND publisher = 'Brave Software Inc' AND version_compare(version, '150.1.92.141') < 0);"
       },
-      "installer_url": "https://github.com/brave/brave-browser/releases/download/v1.92.140/BraveBrowserStandaloneSilentSetup.exe",
+      "installer_url": "https://github.com/brave/brave-browser/releases/download/v1.92.141/BraveBrowserStandaloneSilentSetup.exe",
       "install_script_ref": "9a0c2b15",
       "uninstall_script_ref": "30c77f69",
-      "sha256": "294bf089148b802205798cb54c5dbae688be92bfefd6c86acf8ae72ec399dfbc",
+      "sha256": "245d7c2657ec2ddf9aee5d6883e54efb6eedb13fe42978eb713db37417252930",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/codexbar/darwin.json
+++ b/ee/maintained-apps/outputs/codexbar/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.43.0",
+      "version": "0.44.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.steipete.codexbar';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.steipete.codexbar' AND version_compare(bundle_short_version, '0.43.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.steipete.codexbar' AND version_compare(bundle_short_version, '0.44.0') < 0);"
       },
-      "installer_url": "https://github.com/steipete/CodexBar/releases/download/v0.43.0/CodexBar-macos-universal-0.43.0.zip",
+      "installer_url": "https://github.com/steipete/CodexBar/releases/download/v0.44.0/CodexBar-macos-universal-0.44.0.zip",
       "install_script_ref": "aea54a4e",
       "uninstall_script_ref": "efcab822",
-      "sha256": "74aaf9ffb1f382a0d75309071a3d73e77e1e9136a3c9414d4aba60faf2bfe18c",
+      "sha256": "958c4b3fc64367d833b6e26df98d262b16384a52dcf6b8181f9b98091505671f",
       "default_categories": [
         "Utilities"
       ]

--- a/ee/maintained-apps/outputs/etrecheckpro/darwin.json
+++ b/ee/maintained-apps/outputs/etrecheckpro/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "6.8.14",
+      "version": "6.8.15",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.etresoft.EtreCheck4';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.etresoft.EtreCheck4' AND version_compare(bundle_short_version, '6.8.14') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.etresoft.EtreCheck4' AND version_compare(bundle_short_version, '6.8.15') < 0);"
       },
       "installer_url": "https://cdn.etrecheck.com/EtreCheckPro.zip",
       "install_script_ref": "30eb1ca9",

--- a/ee/maintained-apps/outputs/netron/darwin.json
+++ b/ee/maintained-apps/outputs/netron/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "9.1.5",
+      "version": "9.1.7",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.lutzroeder.netron';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.lutzroeder.netron' AND version_compare(bundle_short_version, '9.1.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.lutzroeder.netron' AND version_compare(bundle_short_version, '9.1.7') < 0);"
       },
-      "installer_url": "https://github.com/lutzroeder/netron/releases/download/v9.1.5/Netron-9.1.5-mac.zip",
+      "installer_url": "https://github.com/lutzroeder/netron/releases/download/v9.1.7/Netron-9.1.7-mac.zip",
       "install_script_ref": "4929401f",
       "uninstall_script_ref": "acbbb0d7",
-      "sha256": "7d201c378b710b4b2a97907aa161ee665170bf7f2d8c275563c08355f252e445",
+      "sha256": "38cd4ba8c79ff82a2251accff4d65853b7c831044e9a1b8db90402a3d76e99b4",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated Brave Browser for macOS and Windows to version 150.1.92.141.
  * Updated CodexBar for macOS to version 0.44.0.
  * Updated EtreCheckPro for macOS to version 6.8.15.
  * Updated Netron for macOS to version 9.1.7.
  * Refreshed download links, version checks, and installer verification data for the listed releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->