### PR TITLE
Fix Portfolio Performance FMA ingestion after winget scope correction

### DIFF
--- a/ee/maintained-apps/inputs/winget/portfolioperformance.json
+++ b/ee/maintained-apps/inputs/winget/portfolioperformance.json
@@ -5,7 +5,7 @@
   "unique_identifier": "Portfolio Performance",
   "installer_arch": "x64",
   "installer_type": "exe",
-  "installer_scope": "machine",
+  "installer_scope": "user",
   "install_script_path": "ee/maintained-apps/inputs/winget/scripts/portfolioperformance_install.ps1",
   "uninstall_script_path": "ee/maintained-apps/inputs/winget/scripts/portfolioperformance_uninstall.ps1",
   "default_categories": ["Productivity"]

--- a/ee/maintained-apps/outputs/portfolioperformance/windows.json
+++ b/ee/maintained-apps/outputs/portfolioperformance/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.85.0",
+      "version": "0.86.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Portfolio Performance' AND publisher = 'Andreas Buchen';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Portfolio Performance' AND publisher = 'Andreas Buchen' AND version_compare(version, '0.85.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Portfolio Performance' AND publisher = 'Andreas Buchen' AND version_compare(version, '0.86.0') < 0);"
       },
-      "installer_url": "https://github.com/portfolio-performance/portfolio/releases/download/0.85.0/PortfolioPerformance-0.85.0-setup.exe",
+      "installer_url": "https://github.com/portfolio-performance/portfolio/releases/download/0.86.0/PortfolioPerformance-0.86.0-setup.exe",
       "install_script_ref": "efa25f6a",
       "uninstall_script_ref": "1d78c875",
-      "sha256": "3d22e7ff997d97641a1334b61cdfad6dfe08c6e82f798448c15d0972f3f33cbb",
+      "sha256": "eb7fd19031ee54864d8d05cc98c71e63a465cf4fc9543e2b1446ae0ee6dff876",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
**Related issue:** N/A — fixes the nightly "Update Fleet-maintained apps" workflow failure on 2026-07-19 (`panic: ingesting winget app: failed to find installer for app`).

## Details

The `buchen.portfolio` 0.86.0 winget manifest (released 2026-07-16) changed the top-level `Scope` from `machine` to `user`. Our input pinned `installer_scope: machine`, so the ingester's installer-matching loop found no candidate and panicked, killing the whole nightly maintained-apps run.

The upstream change was a **correction**, not a mistake: the vendor's NSIS installer script (`portfolio-product/installer/installer.nsi`) installs to `$LOCALAPPDATA\Programs` and registers under HKCU, and is byte-identical between 0.85.0 and 0.86.0 — the installer has been user-scoped all along; prior winget manifests mislabeled it.

Changes:
- `ee/maintained-apps/inputs/winget/portfolioperformance.json`: `installer_scope` → `user` (52 other winget inputs already use user scope)
- `ee/maintained-apps/outputs/portfolioperformance/windows.json`: regenerated via `go run ./cmd/maintained-apps -slug portfolioperformance/windows` — version 0.85.0 → 0.86.0, installer URL and sha256 updated (sha256 matches the manifest's declared `InstallerSha256`)

No behavior change for hosts: the custom uninstall script already searches HKCU first, osquery's `programs` table reads per-user (HKU) uninstall keys so the exists/patched queries keep working, and the ingester's MSI-only scope branches don't apply to this exe-type app with custom scripts.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] QA'd all new/changed functionality manually — verified the 0.86.0 winget manifest and vendor NSIS script upstream, and regenerated the output locally with the ingester (previously panicking, now succeeds).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the Portfolio Performance Windows installer to version 0.86.0.
  * Refreshed the installer download details and verification checksum.
  * Adjusted the installation scope to apply to the current user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->