### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/boltai/darwin.json
+++ b/ee/maintained-apps/outputs/boltai/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.13.7",
+      "version": "2.14.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'co.podzim.boltai-mobile';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'co.podzim.boltai-mobile' AND version_compare(bundle_short_version, '2.13.7') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'co.podzim.boltai-mobile' AND version_compare(bundle_short_version, '2.14.0') < 0);"
       },
-      "installer_url": "https://updates.boltai.com/dmg/BoltAI-2.13.7.dmg",
+      "installer_url": "https://updates.boltai.com/dmg/BoltAI-2.14.0.dmg",
       "install_script_ref": "fbb1d678",
       "uninstall_script_ref": "8c3f3ae8",
-      "sha256": "60eaa14d5fb67def5a8279370f97e0320474a469ca9223a584a6f8d8d89808ad",
+      "sha256": "f5f4275b21a67685dcf12b7cd0cb6411c93aa844ce071a21ee28e6b189a7c8d7",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/claude/darwin.json
+++ b/ee/maintained-apps/outputs/claude/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.22209.0",
+      "version": "1.22209.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.22209.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.22209.3') < 0);"
       },
-      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.22209.0/Claude-77c938bac27689d6df971289c10759e512785c73.zip",
+      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.22209.3/Claude-babe11577dfefe3e209c06bd674628d862f0dbae.zip",
       "install_script_ref": "8b957973",
       "uninstall_script_ref": "421baa98",
-      "sha256": "15b467a30240c431ed82b3ee9214ecd378c7a99901f2a994fc95c5c11628f9f2",
+      "sha256": "b110e0fdb7b2601d80dfdd7893f7811de382de84c4586113e7873e28f17680fc",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/cmux/darwin.json
+++ b/ee/maintained-apps/outputs/cmux/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.64.19",
+      "version": "0.64.20",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.cmuxterm.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.cmuxterm.app' AND version_compare(bundle_short_version, '0.64.19') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.cmuxterm.app' AND version_compare(bundle_short_version, '0.64.20') < 0);"
       },
-      "installer_url": "https://github.com/manaflow-ai/cmux/releases/download/v0.64.19/cmux-macos.dmg",
+      "installer_url": "https://github.com/manaflow-ai/cmux/releases/download/v0.64.20/cmux-macos.dmg",
       "install_script_ref": "b1646f8d",
       "uninstall_script_ref": "6a4ed98f",
-      "sha256": "9e961bba9159f2d820f8e1d7f58a532d19ad8758bb75365a57fd7cdc9a7cfcf4",
+      "sha256": "a6ae6ab2f98173e5bfd4dcf46b4529fe23a9ca75fdc879310d7e6de826693e75",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/codexbar/darwin.json
+++ b/ee/maintained-apps/outputs/codexbar/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.45.0",
+      "version": "0.45.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.steipete.codexbar';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.steipete.codexbar' AND version_compare(bundle_short_version, '0.45.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.steipete.codexbar' AND version_compare(bundle_short_version, '0.45.1') < 0);"
       },
-      "installer_url": "https://github.com/steipete/CodexBar/releases/download/v0.45.0/CodexBar-macos-universal-0.45.0.zip",
+      "installer_url": "https://github.com/steipete/CodexBar/releases/download/v0.45.1/CodexBar-macos-universal-0.45.1.zip",
       "install_script_ref": "aea54a4e",
       "uninstall_script_ref": "efcab822",
-      "sha256": "02d884074eed1f973fcb53d0fe82906e4eb25d9b96ac33cd07be7da540ebf81f",
+      "sha256": "37f0df670d47e36474aecc825b3b1fac8e830200a7982bd282a78e0e85d0b5ad",
       "default_categories": [
         "Utilities"
       ]

--- a/ee/maintained-apps/outputs/cog-app/darwin.json
+++ b/ee/maintained-apps/outputs/cog-app/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3610",
+      "version": "3617",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.cogx.cog';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.cogx.cog' AND version_compare(bundle_short_version, '3610') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.cogx.cog' AND version_compare(bundle_short_version, '3617') < 0);"
       },
-      "installer_url": "https://cogcdn.cog.losno.co/Cog-15ca8320f.zip",
+      "installer_url": "https://cogcdn.cog.losno.co/Cog-65bd626a8.zip",
       "install_script_ref": "b0e36626",
       "uninstall_script_ref": "e84a8314",
-      "sha256": "39de94a2dfafdad48741ab2a3287624bd6f90f6fecbb7a5f07e1012ac48bf9db",
+      "sha256": "b30bf9b1d1b17139c23f80718215025a014f07011eff781cc5719fdbe4c5a50b",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/dockside/darwin.json
+++ b/ee/maintained-apps/outputs/dockside/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.9.22",
+      "version": "2.9.23",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.hachipoo.Dockside';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hachipoo.Dockside' AND version_compare(bundle_short_version, '2.9.22') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hachipoo.Dockside' AND version_compare(bundle_short_version, '2.9.23') < 0);"
       },
-      "installer_url": "https://github.com/PrajwalSD/Dockside/releases/download/v2.9.22/Dockside.dmg",
+      "installer_url": "https://github.com/PrajwalSD/Dockside/releases/download/v2.9.23/Dockside.dmg",
       "install_script_ref": "11c3511b",
       "uninstall_script_ref": "262fd2cc",
-      "sha256": "338eb236a49013d4e8764002beec66869d803eb475a575f315575abeda48c50f",
+      "sha256": "214968ab236f3220ca223764e849d97f70ca36de5c537f47a603c08f15cec45a",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/firefox@nightly/darwin.json
+++ b/ee/maintained-apps/outputs/firefox@nightly/darwin.json
@@ -4,12 +4,12 @@
       "version": "154.0a1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15426.7.18') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15426.7.19') < 0);"
       },
-      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/07/2026-07-18-09-07-21-mozilla-central/firefox-154.0a1.en-US.mac.dmg",
+      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/07/2026-07-19-09-17-21-mozilla-central/firefox-154.0a1.en-US.mac.dmg",
       "install_script_ref": "418c9331",
       "uninstall_script_ref": "d7c711ad",
-      "sha256": "581f5f3525f8645c6d153c4ce3195bf1dbcf40c0d6e12d9a9fcac31587162bce",
+      "sha256": "f24f6fc41dd57c59faa366f665b1b53463f5fee6f30807607db6414c20a196a4",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/notepadexe/darwin.json
+++ b/ee/maintained-apps/outputs/notepadexe/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.5.3",
+      "version": "1.5.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'best.swift.Notepad';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'best.swift.Notepad' AND version_compare(bundle_short_version, '1.5.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'best.swift.Notepad' AND version_compare(bundle_short_version, '1.5.4') < 0);"
       },
-      "installer_url": "https://github.com/notepadhq/notepadexe-public/releases/download/1.5.3/Notepad.zip",
+      "installer_url": "https://github.com/notepadhq/notepadexe-public/releases/download/1.5.4/Notepad.zip",
       "install_script_ref": "17716d6a",
       "uninstall_script_ref": "abe56690",
-      "sha256": "989b698cfbcfc6082e42d42c960951e8b3b46b127de455c568150e44efa086ba",
+      "sha256": "d067ad28fe3db4272ec561835183d3a64d494906c5a5e364faae165a480e4698",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/stats/darwin.json
+++ b/ee/maintained-apps/outputs/stats/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.0.8",
+      "version": "3.0.9",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'eu.exelban.Stats';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'eu.exelban.Stats' AND version_compare(bundle_short_version, '3.0.8') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'eu.exelban.Stats' AND version_compare(bundle_short_version, '3.0.9') < 0);"
       },
-      "installer_url": "https://github.com/exelban/stats/releases/download/v3.0.8/Stats.dmg",
+      "installer_url": "https://github.com/exelban/stats/releases/download/v3.0.9/Stats.dmg",
       "install_script_ref": "de9e4d0c",
       "uninstall_script_ref": "48380d78",
-      "sha256": "b42a3dfe0f8f8a20eef174c5a993b2ec6f1034c5fb6accb875d6d39999d20bd6",
+      "sha256": "cdbb45ab9dae5911a4ee2a7687ebcbc1431d771612ca0f54db933974ab75a66b",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/webcatalog/darwin.json
+++ b/ee/maintained-apps/outputs/webcatalog/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "77.3.4",
+      "version": "77.4.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.webcatalog.jordan';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.webcatalog.jordan' AND version_compare(bundle_short_version, '77.3.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.webcatalog.jordan' AND version_compare(bundle_short_version, '77.4.0') < 0);"
       },
-      "installer_url": "https://cdn-2.webcatalog.io/webcatalog/WebCatalog-77.3.4-universal.dmg",
+      "installer_url": "https://cdn-2.webcatalog.io/webcatalog/WebCatalog-77.4.0-universal.dmg",
       "install_script_ref": "f04928dc",
       "uninstall_script_ref": "d196a4c8",
-      "sha256": "8ac53dafd3348be2c0b97ff1a2f86ff5ca5ec4322ab36bce8d891d45bc122ae6",
+      "sha256": "82ae575121251eacef3c67390ec250fcf110b9ea69994c9a92f18dd025a33294",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Releases**
  * Updated macOS release metadata for BoltAI, Claude, CMUX, CodexBar, Cog, Dockside, Notepad, Stats, and WebCatalog.
  * Updated Firefox Nightly’s patch detection and installer checksum.
  * Installer links and checksums now match the latest available builds, enabling accurate update detection and installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->