### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/dbeaver-community/windows.json
+++ b/ee/maintained-apps/outputs/dbeaver-community/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.1.2",
+      "version": "26.1.3",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'DBeaver %' AND publisher = 'DBeaver Corp';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'DBeaver %' AND publisher = 'DBeaver Corp' AND version_compare(version, '26.1.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'DBeaver %' AND publisher = 'DBeaver Corp' AND version_compare(version, '26.1.3') < 0);"
       },
-      "installer_url": "https://github.com/dbeaver/dbeaver/releases/download/26.1.2/dbeaver-ce-26.1.2-windows-x86_64.exe",
+      "installer_url": "https://github.com/dbeaver/dbeaver/releases/download/26.1.3/dbeaver-ce-26.1.3-windows-x86_64.exe",
       "install_script_ref": "44838cfb",
       "uninstall_script_ref": "7c58ef20",
-      "sha256": "c1ec4978244ad1305c90a99e2b74741749066e105038c3621ad319de988ece74",
+      "sha256": "df3e522e3dbd4e6a7f91dcd8e422a0be13220d2e895a681b5b6732adb518297d",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/readest/darwin.json
+++ b/ee/maintained-apps/outputs/readest/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.11.18",
+      "version": "0.11.20",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.bilingify.readest';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.bilingify.readest' AND version_compare(bundle_short_version, '0.11.18') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.bilingify.readest' AND version_compare(bundle_short_version, '0.11.20') < 0);"
       },
-      "installer_url": "https://github.com/readest/readest/releases/download/v0.11.18/Readest_0.11.18_universal.dmg",
+      "installer_url": "https://github.com/readest/readest/releases/download/v0.11.20/Readest_0.11.20_universal.dmg",
       "install_script_ref": "3e736c25",
       "uninstall_script_ref": "13037b35",
-      "sha256": "227a47a3b54ea3a7e02381c718f141f8d8dcaac4006803851d27a9043e29e3e8",
+      "sha256": "c72b822e5bfe6635cebe4cc3f58876acfe04c2c44b22882bb3827940313e7d8c",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the available DBeaver Community for Windows release to version 26.1.3.
  * Updated the available Readest for macOS release to version 0.11.20.
  * Refreshed installer links and verification checksums for both applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->