### PR TITLE
Fix SCIM middleware persisting authorization failures to last_request

### DIFF
--- a/changes/16793-scim-forbidden-last-request
+++ b/changes/16793-scim-forbidden-last-request
@@ -1,0 +1,1 @@
+- Fixed the SCIM last request telemetry so that authorization failures (403 Forbidden) from unauthorized users are no longer persisted, preventing them from overwriting the admin-visible SCIM status.

--- a/ee/server/integrationtest/scim/scim_test.go
+++ b/ee/server/integrationtest/scim/scim_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/elimity-com/scim/errors"
-	"github.com/fleetdm/fleet/v4/server/authz"
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql/mysqltest"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/service"
@@ -78,14 +77,13 @@ func testAuth(t *testing.T, s *Suite) {
 	assert.Contains(t, resp["detail"], "forbidden")
 	assert.EqualValues(t, resp["schemas"], []interface{}{"urn:ietf:params:scim:api:messages:2.0:Error"})
 	s.DoJSON(t, "GET", scimPath("/details"), nil, http.StatusForbidden, &scimDetails)
-	// Make sure unauthorized response WAS saved as the last SCIM request
+	// Make sure the forbidden response wasn't saved as the last SCIM request. An
+	// authenticated-but-unauthorized user must not be able to overwrite the
+	// admin-visible SCIM telemetry with their rejected attempts.
 	s.Token = s.GetTestAdminToken(t)
 	scimDetails = contract.ScimDetailsResponse{}
 	s.DoJSON(t, "GET", scimPath("/details"), nil, http.StatusOK, &scimDetails)
-	require.NotNil(t, scimDetails.LastRequest)
-	assert.Equal(t, "error", scimDetails.LastRequest.Status)
-	assert.NotZero(t, scimDetails.LastRequest.RequestedAt)
-	assert.Equal(t, authz.ForbiddenErrorMessage, scimDetails.LastRequest.Details)
+	assert.Nil(t, scimDetails.LastRequest, "last_request should NOT be present for forbidden requests")
 
 	// Unauthorized (maintainer - no longer allowed)
 	resp = nil

--- a/ee/server/scim/scim.go
+++ b/ee/server/scim/scim.go
@@ -450,9 +450,16 @@ func LastRequestMiddleware(ds fleet.Datastore, logger *slog.Logger, next http.Ha
 		switch {
 		case multi.statusCode == 0 || (multi.statusCode >= 200 && multi.statusCode < 300):
 			status = "success"
-		case multi.statusCode == http.StatusUnauthorized:
-			// We do not save unauthenticated error details; we simply log them.
-			logger.InfoContext(r.Context(), "unauthenticated request",
+		case multi.statusCode == http.StatusUnauthorized || multi.statusCode == http.StatusForbidden:
+			// We do not save authentication (401) or authorization (403) failures; we
+			// simply log them. Otherwise an authenticated-but-unauthorized user (e.g. an
+			// observer) could overwrite the admin-visible last_request telemetry with
+			// their rejected attempts.
+			msg := "unauthenticated request"
+			if multi.statusCode == http.StatusForbidden {
+				msg = "unauthorized request"
+			}
+			logger.InfoContext(r.Context(), msg,
 				"origin", r.Header.Get("Origin"),
 				"ip", r.RemoteAddr,
 				"method", r.Method,


### PR DESCRIPTION
The LastRequestMiddleware already skipped 401 responses but not 403s, so unauthorized users could overwrite the admin-visible SCIM status. Skip both.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SCIM authorization failures from unauthorized requests are no longer saved as the latest request.
  * Admin-visible SCIM status details are protected from being overwritten by 403 Forbidden responses.
  * Unauthorized and unauthenticated requests are handled consistently in SCIM telemetry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->