### PR TITLE
create new appCfg entry on AB fleet updates if not found

### DIFF
--- a/changes/48653-empty-ab-when-only-updated-via-ui
+++ b/changes/48653-empty-ab-when-only-updated-via-ui
@@ -1,0 +1,1 @@
+- Fixed an issue where `generate-gitops` would export an empty `apple_business` section, if the AB default fleets had only been set via the UI.

--- a/ee/server/service/mdm.go
+++ b/ee/server/service/mdm.go
@@ -1635,6 +1635,11 @@ func (svc *Service) DeleteABMToken(ctx context.Context, tokenID uint) error {
 		return err
 	}
 
+	token, err := svc.ds.GetABMTokenByID(ctx, tokenID)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "getting ABM token to delete")
+	}
+
 	if err := svc.ds.DeleteABMToken(ctx, tokenID); err != nil {
 		return ctxerr.Wrap(ctx, err, "removing ABM token")
 	}
@@ -1644,18 +1649,25 @@ func (svc *Service) DeleteABMToken(ctx context.Context, tokenID uint) error {
 		return ctxerr.Wrap(ctx, err, "getting ABM token count")
 	}
 
-	if count == 0 {
-		// flip the app config flag
-		appCfg, err := svc.ds.AppConfig(ctx)
-		if err != nil {
-			return ctxerr.Wrap(ctx, err, "retrieving app config")
-		}
-
-		appCfg.MDM.AppleBMEnabledAndConfigured = false
-		return svc.ds.SaveAppConfig(ctx, appCfg)
+	appCfg, err := svc.ds.AppConfig(ctx)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "retrieving app config")
 	}
 
-	return nil
+	// remove the AB entry in appConfig
+	for i, t := range appCfg.MDM.AppleBusinessManager.Value {
+		if t.OrganizationName == token.OrganizationName {
+			appCfg.MDM.AppleBusinessManager.Value = append(appCfg.MDM.AppleBusinessManager.Value[:i], appCfg.MDM.AppleBusinessManager.Value[i+1:]...)
+			break
+		}
+	}
+
+	if count == 0 {
+		// flip the app config flag
+		appCfg.MDM.AppleBMEnabledAndConfigured = false
+	}
+
+	return svc.ds.SaveAppConfig(ctx, appCfg)
 }
 
 func (svc *Service) ListABMTokens(ctx context.Context) ([]*fleet.ABMToken, error) {
@@ -1770,6 +1782,7 @@ func (svc *Service) UpdateABMTokenTeams(ctx context.Context, tokenID uint, macOS
 		return nil, ctxerr.Wrap(ctx, err, "retrieving app config")
 	}
 
+	var found bool
 	for i, appCfgToken := range appCfg.MDM.AppleBusinessManager.Value {
 		if appCfgToken.OrganizationName == token.OrganizationName {
 
@@ -1793,11 +1806,24 @@ func (svc *Service) UpdateABMTokenTeams(ctx context.Context, tokenID uint, macOS
 
 			// update the app config with the new team names
 			appCfg.MDM.AppleBusinessManager.Value[i] = appCfgToken
-			if err := svc.ds.SaveAppConfig(ctx, appCfg); err != nil {
-				return nil, ctxerr.Wrap(ctx, err, "saving app config after ABM token team update")
-			}
+			found = true
 			break
 		}
+	}
+
+	if !found {
+		// create a new entry if app config doesn't have one.
+		appCfg.MDM.AppleBusinessManager.Value = append(appCfg.MDM.AppleBusinessManager.Value, fleet.MDMAppleABMAssignmentInfo{
+			OrganizationName: token.OrganizationName,
+			BYODTeam:         token.BYODTeam.Name,
+			MacOSTeam:        token.MacOSTeam.Name,
+			IOSTeam:          token.IOSTeam.Name,
+			IpadOSTeam:       token.IPadOSTeam.Name,
+		})
+	}
+
+	if err := svc.ds.SaveAppConfig(ctx, appCfg); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "saving app config after ABM token team update")
 	}
 
 	return token, nil

--- a/ee/server/service/mdm.go
+++ b/ee/server/service/mdm.go
@@ -1811,14 +1811,34 @@ func (svc *Service) UpdateABMTokenTeams(ctx context.Context, tokenID uint, macOS
 		}
 	}
 
+	if !appCfg.MDM.AppleBusinessManager.Set || !appCfg.MDM.AppleBusinessManager.Valid {
+		appCfg.MDM.AppleBusinessManager = optjson.SetSlice([]fleet.MDMAppleABMAssignmentInfo{})
+	}
+
 	if !found {
 		// create a new entry if app config doesn't have one.
+		byodTeam := token.BYODTeam.Name
+		if byodTeam == fleet.TeamNameNoTeam {
+			byodTeam = ""
+		}
+		macosTeam := token.MacOSTeam.Name
+		if macosTeam == fleet.TeamNameNoTeam {
+			macosTeam = ""
+		}
+		iosTeam := token.IOSTeam.Name
+		if iosTeam == fleet.TeamNameNoTeam {
+			iosTeam = ""
+		}
+		ipadosTeam := token.IPadOSTeam.Name
+		if ipadosTeam == fleet.TeamNameNoTeam {
+			ipadosTeam = ""
+		}
 		appCfg.MDM.AppleBusinessManager.Value = append(appCfg.MDM.AppleBusinessManager.Value, fleet.MDMAppleABMAssignmentInfo{
 			OrganizationName: token.OrganizationName,
-			BYODTeam:         token.BYODTeam.Name,
-			MacOSTeam:        token.MacOSTeam.Name,
-			IOSTeam:          token.IOSTeam.Name,
-			IpadOSTeam:       token.IPadOSTeam.Name,
+			BYODTeam:         byodTeam,
+			MacOSTeam:        macosTeam,
+			IOSTeam:          iosTeam,
+			IpadOSTeam:       ipadosTeam,
 		})
 	}
 

--- a/ee/server/service/mdm_test.go
+++ b/ee/server/service/mdm_test.go
@@ -579,4 +579,28 @@ func TestUpdateABMTokenTeams(t *testing.T) {
 		assert.Empty(t, appCfgToken.IOSTeam)
 		assert.Empty(t, appCfgToken.IpadOSTeam)
 	})
+
+	t.Run("updates app config with new entry if not present", func(t *testing.T) {
+		appCfg.MDM.AppleBusinessManager = optjson.SetSlice([]fleet.MDMAppleABMAssignmentInfo{})
+
+		token, err := svc.UpdateABMTokenTeams(ctx, tokenID, validTeamID, validTeamID, validTeamID, validTeamID)
+		require.NoError(t, err)
+
+		assert.Equal(t, validTeamID, token.BYODDefaultTeamID)
+		assert.Equal(t, validTeamID, token.MacOSDefaultTeamID)
+		assert.Equal(t, validTeamID, token.IOSDefaultTeamID)
+		assert.Equal(t, validTeamID, token.IPadOSDefaultTeamID)
+		require.True(t, ds.SaveAppConfigFuncInvoked)
+		var appCfgToken fleet.MDMAppleABMAssignmentInfo
+		for _, tok := range updatedAppCfg.MDM.AppleBusinessManager.Value {
+			if tok.OrganizationName == orgName {
+				appCfgToken = tok
+				break
+			}
+		}
+		assert.Equal(t, validTeamName, appCfgToken.BYODTeam)
+		assert.Equal(t, validTeamName, appCfgToken.MacOSTeam)
+		assert.Equal(t, validTeamName, appCfgToken.IOSTeam)
+		assert.Equal(t, validTeamName, appCfgToken.IpadOSTeam)
+	})
 }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #48653 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Apple Business Manager configuration handling when updating team assignments, including creating the assignment entry when it doesn’t already exist.
  - Removing an Apple Business Manager token now also removes its corresponding assignment details and properly updates configuration status when no tokens remain.
  - Prevented `generate-gitops` from exporting an empty `apple_business` section when default fleets are configured only via the UI.
- **Tests**
  - Expanded coverage for team assignment updates to validate creation of new configuration entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->