### PR TITLE
Fix SCIM deprovisioning edge case during user deactivation

### DIFF
--- a/changes/16778-scim-deprovisioning-mutated-identifiers
+++ b/changes/16778-scim-deprovisioning-mutated-identifiers
@@ -1,0 +1,1 @@
+- Fixed an edge case where deactivating a SCIM user did not deprovision the matching Fleet user if the user's identifiers were changed in the same request.

--- a/ee/server/integrationtest/scim/scim_test.go
+++ b/ee/server/integrationtest/scim/scim_test.go
@@ -32,6 +32,7 @@ func TestSCIM(t *testing.T) {
 		{"CreateUserAssociatesAllMatchingHosts", testCreateUserAssociatesAllMatchingHosts},
 		{"CreateGroup", testCreateGroup},
 		{"UpdateUser", testUpdateUser},
+		{"DeactivationDeprovisionsMutatedUser", testDeactivationDeprovisionsMutatedUser},
 		{"UpdateGroup", testUpdateGroup},
 		{"PatchUserEmails", testPatchUserEmails},
 		{"PatchUserAttributes", testPatchUserAttributes},
@@ -235,6 +236,49 @@ func createTestUser(t *testing.T, s *Suite, userName string) (string, map[string
 	assert.NotEmpty(t, userID)
 
 	return userID, createResp
+}
+
+// testDeactivationDeprovisionsMutatedUser verifies that a SCIM PATCH which
+// mutates userName/emails in the same request that sets active=false still
+// deprovisions the matching Fleet user, resolving it from the persisted
+// (pre-patch) identifiers rather than the mutated state.
+func testDeactivationDeprovisionsMutatedUser(t *testing.T, s *Suite) {
+	ctx := t.Context()
+
+	// Create an SSO-enabled Fleet user that SCIM deactivation should deprovision.
+	email := "deprovision_target@example.com"
+	role := fleet.RoleObserver
+	_, err := s.DS.NewUser(ctx, &fleet.User{
+		Password:   []byte("garbage"),
+		Salt:       "garbage",
+		Name:       "Deprovision Target",
+		Email:      email,
+		GlobalRole: &role,
+		SSOEnabled: true,
+	})
+	require.NoError(t, err)
+
+	// Create a matching SCIM user (userName and email set to the same address).
+	userID, _ := createTestUser(t, s, email)
+
+	// Deactivate while mutating identifiers in the same PATCH: rename userName to a
+	// non-email value and drop emails before setting active=false.
+	patchPayload := map[string]any{
+		"schemas": []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+		"Operations": []map[string]any{
+			{"op": "replace", "path": "userName", "value": "nondomain_user_bypass"},
+			{"op": "remove", "path": "emails"},
+			{"op": "replace", "path": "active", "value": false},
+		},
+	}
+	var patchResp map[string]any
+	s.DoJSON(t, "PATCH", scimPath("/Users/"+userID), patchPayload, http.StatusOK, &patchResp)
+	assert.Equal(t, false, patchResp["active"])
+
+	// The Fleet user must have been deprovisioned despite the mutated identifiers.
+	_, err = s.DS.UserByEmail(ctx, email)
+	require.Error(t, err)
+	require.True(t, fleet.IsNotFound(err), "expected Fleet user to be deleted, got: %v", err)
 }
 
 func testUsersBasicCRUD(t *testing.T, s *Suite) {

--- a/ee/server/scim/users.go
+++ b/ee/server/scim/users.go
@@ -462,8 +462,12 @@ func (u *UserHandler) Replace(r *http.Request, id string, attributes scim.Resour
 	user.ID = idUint
 
 	// Username is unique, so we must check if another user already exists with that username to return a clear error
-	// We also use this to get the previous active state when the username isn't changing
+	// We also use this to get the previous active state when the username isn't changing.
+	// prePatchUser captures the persisted (pre-replace) record so deactivation
+	// resolves the matching Fleet user from durable state rather than the incoming
+	// (mutated) userName/emails, which a client could clear to evade deprovisioning.
 	var previousActive *bool
+	var prePatchUser *fleet.ScimUser
 	userWithSameUsername, err := u.ds.ScimUserByUserName(ctx, user.UserName)
 	switch {
 	case err != nil && !fleet.IsNotFound(err):
@@ -475,6 +479,7 @@ func (u *UserHandler) Replace(r *http.Request, id string, attributes scim.Resour
 	case err == nil && user.ID == userWithSameUsername.ID:
 		// Same user, username not changing - use this for previous active state
 		previousActive = userWithSameUsername.Active
+		prePatchUser = userWithSameUsername
 	case fleet.IsNotFound(err):
 		// Username is being changed - need to fetch existing user by ID for previous active state
 		existingUser, err := u.ds.ScimUserByID(ctx, idUint)
@@ -487,6 +492,7 @@ func (u *UserHandler) Replace(r *http.Request, id string, attributes scim.Resour
 			return scim.Resource{}, err
 		}
 		previousActive = existingUser.Active
+		prePatchUser = existingUser
 	}
 
 	resentCerts, err := u.ds.ReplaceScimUser(ctx, user)
@@ -511,7 +517,7 @@ func (u *UserHandler) Replace(r *http.Request, id string, attributes scim.Resour
 
 	// Check if user was deactivated and delete matching Fleet user if so
 	if wasDeactivated(previousActive, user.Active) {
-		if err := u.deleteMatchingFleetUser(ctx, user); err != nil {
+		if err := u.deleteMatchingFleetUser(ctx, prePatchUser); err != nil {
 			u.logger.ErrorContext(ctx, "failed to delete fleet user on deactivation", "err", err)
 		}
 	}
@@ -576,6 +582,11 @@ func wasDeactivated(previous, current *bool) bool {
 	return previous == nil || *previous
 }
 
+// deleteMatchingFleetUser deletes the SSO Fleet user matching the given SCIM
+// user. Callers MUST pass the SCIM record's persisted (pre-mutation) state:
+// resolving from mutated PATCH/PUT state would let a client evade
+// deprovisioning by clearing userName/emails in the same request that sets
+// active=false.
 func (u *UserHandler) deleteMatchingFleetUser(ctx context.Context, scimUser *fleet.ScimUser) error {
 	// Collect unique emails from SCIM user (userName is often the email in many IdP configurations, e.g. Okta).
 	// userName is added first so it's checked first when looking up Fleet users.
@@ -678,8 +689,15 @@ func (u *UserHandler) Patch(r *http.Request, id string, operations []scim.PatchO
 		return scim.Resource{}, err
 	}
 
-	// Store previous active state before applying patches
+	// Store the previous active state and a copy of the persisted identifiers
+	// before applying patches. The operations below mutate `user` in place, so
+	// the matching Fleet user on deactivation must be resolved from this
+	// pre-patch snapshot — otherwise a client could evade deprovisioning by
+	// clearing userName/emails in the same PATCH that sets active=false. Emails
+	// is cloned because patch operations mutate its elements in place.
 	previousActive := user.Active
+	prePatchUser := *user
+	prePatchUser.Emails = slices.Clone(user.Emails)
 
 	allUnknown := true
 	for _, op := range operations {
@@ -793,7 +811,7 @@ func (u *UserHandler) Patch(r *http.Request, id string, operations []scim.PatchO
 		// least one recognized op was applied; if every op was unrecognized,
 		// user.Active equals previousActive and no deactivation can have occurred.
 		if wasDeactivated(previousActive, user.Active) {
-			if err := u.deleteMatchingFleetUser(ctx, user); err != nil {
+			if err := u.deleteMatchingFleetUser(ctx, &prePatchUser); err != nil {
 				u.logger.ErrorContext(ctx, "failed to delete fleet user on deactivation", "err", err)
 			}
 		}

--- a/ee/server/scim/users_test.go
+++ b/ee/server/scim/users_test.go
@@ -531,7 +531,7 @@ func TestUserHandlerReplaceDeactivation(t *testing.T) {
 			userName:   "user@example.com",
 			givenName:  "John",
 			familyName: "Doe",
-			emails:     []fleet.ScimUserEmail{{Email: "user@example.com", Primary: ptr.Bool(true)}},
+			emails:     []fleet.ScimUserEmail{{Email: "user@example.com", Primary: new(true)}},
 		})
 		fleetUser := newTestFleetUser(&fleetUserOpts{ssoEnabled: true})
 
@@ -570,7 +570,7 @@ func TestUserHandlerReplaceDeactivation(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPut, "/scim/v2/Users/1", nil)
 		// Replace the whole resource with a non-email userName and no emails while
 		// deactivating; deprovisioning must still resolve via pre-replace identifiers.
-		attrs := newTestAttrs("nondomain_user_bypass", ptr.Bool(false), "John", "Doe")
+		attrs := newTestAttrs("nondomain_user_bypass", new(false), "John", "Doe")
 
 		_, err := handler.Replace(req, "1", attrs)
 		require.NoError(t, err)
@@ -695,6 +695,55 @@ func TestUserHandlerReplaceDeactivation(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, scimErr.Status)
 		assert.Contains(t, scimErr.Detail, "given_name")
 	})
+
+	t.Run("deletes Fleet user when emails are dropped in a deactivating Replace with unchanged userName", func(t *testing.T) {
+		mocks := newTestMocks()
+		// userName stays the same and is not an email, so resolution can only
+		// succeed via the persisted email — exercising the same-userName branch.
+		existingScimUser := newTestScimUser(&scimUserOpts{
+			active:     new(true),
+			userName:   "someuser",
+			givenName:  "John",
+			familyName: "Doe",
+			emails:     []fleet.ScimUserEmail{{Email: "victim@example.com", Type: new("work"), Primary: new(true)}},
+		})
+		fleetUser := newTestFleetUser(&fleetUserOpts{ssoEnabled: true})
+
+		mocks.ds.ScimUserByIDFunc = func(ctx context.Context, id uint) (*fleet.ScimUser, error) {
+			return existingScimUser, nil
+		}
+		mocks.ds.ScimUserByUserNameFunc = func(ctx context.Context, userName string) (*fleet.ScimUser, error) {
+			return existingScimUser, nil
+		}
+		mocks.ds.ReplaceScimUserFunc = func(ctx context.Context, user *fleet.ScimUser) ([]fleet.ActivityTypeResentCertificate, error) {
+			return nil, nil
+		}
+		var lookedUpEmails []string
+		mocks.ds.UserByEmailFunc = func(ctx context.Context, email string) (*fleet.User, error) {
+			lookedUpEmails = append(lookedUpEmails, email)
+			if email == "victim@example.com" {
+				return fleetUser, nil
+			}
+			return nil, platform_mysql.NotFound("User")
+		}
+		mocks.ds.DeleteUserFunc = func(ctx context.Context, id uint) error {
+			assert.Equal(t, uint(100), id)
+			return nil
+		}
+		mocks.svc.NewActivityFunc = func(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails) error {
+			return nil
+		}
+
+		handler := mocks.newTestHandler()
+		// Same (non-email) userName, no emails in the incoming representation, deactivating.
+		attrs := newTestAttrs("someuser", new(false), "John", "Doe")
+
+		_, err := handler.Replace(httptest.NewRequest(http.MethodPut, "/scim/v2/Users/1", nil), "1", attrs)
+		require.NoError(t, err)
+
+		assert.Contains(t, lookedUpEmails, "victim@example.com", "expected the pre-replace email to be used for Fleet user resolution")
+		assert.True(t, mocks.ds.DeleteUserFuncInvoked)
+	})
 }
 
 func TestUserHandlerPatchDeactivation(t *testing.T) {
@@ -705,7 +754,7 @@ func TestUserHandlerPatchDeactivation(t *testing.T) {
 			userName:   "user@example.com",
 			givenName:  "John",
 			familyName: "Doe",
-			emails:     []fleet.ScimUserEmail{{Email: "user@example.com", Primary: ptr.Bool(true)}},
+			emails:     []fleet.ScimUserEmail{{Email: "user@example.com", Primary: new(true)}},
 		})
 		fleetUser := newTestFleetUser(&fleetUserOpts{ssoEnabled: true})
 
@@ -893,6 +942,115 @@ func TestUserHandlerPatchDeactivation(t *testing.T) {
 		require.True(t, ok, "expected ScimError, got %T: %v", err, err)
 		assert.Equal(t, http.StatusConflict, scimErr.Status)
 		assert.Equal(t, scimerrors.ScimTypeUniqueness, scimErr.ScimType)
+	})
+
+	t.Run("deletes Fleet user when an email is rewritten in place in the same deactivating Patch", func(t *testing.T) {
+		mocks := newTestMocks()
+		// userName is not an email, so the only lookup candidate is the email
+		// element that gets rewritten in place by the filtered-value patch. This
+		// exercises the pre-patch emails snapshot (slices.Clone).
+		existingScimUser := newTestScimUser(&scimUserOpts{
+			active:     new(true),
+			userName:   "someuser",
+			givenName:  "John",
+			familyName: "Doe",
+			emails:     []fleet.ScimUserEmail{{Email: "victim@example.com", Type: new("work"), Primary: new(true)}},
+		})
+		fleetUser := newTestFleetUser(&fleetUserOpts{ssoEnabled: true})
+
+		mocks.ds.ScimUserByIDFunc = func(ctx context.Context, id uint) (*fleet.ScimUser, error) {
+			return existingScimUser, nil
+		}
+		mocks.ds.ReplaceScimUserFunc = func(ctx context.Context, user *fleet.ScimUser) ([]fleet.ActivityTypeResentCertificate, error) {
+			return nil, nil
+		}
+		var lookedUpEmails []string
+		mocks.ds.UserByEmailFunc = func(ctx context.Context, email string) (*fleet.User, error) {
+			lookedUpEmails = append(lookedUpEmails, email)
+			if email == "victim@example.com" {
+				return fleetUser, nil
+			}
+			return nil, platform_mysql.NotFound("User")
+		}
+		mocks.ds.DeleteUserFunc = func(ctx context.Context, id uint) error {
+			assert.Equal(t, uint(100), id)
+			return nil
+		}
+		mocks.svc.NewActivityFunc = func(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails) error {
+			return nil
+		}
+
+		handler := mocks.newTestHandler()
+		req := httptest.NewRequest(http.MethodPatch, "/scim/v2/Users/1", nil)
+
+		emailValuePath, err := filter.ParsePath([]byte(`emails[type eq "work"].value`))
+		require.NoError(t, err)
+		activePath, err := filter.ParsePath([]byte("active"))
+		require.NoError(t, err)
+
+		// Rewrite the existing work email's value in place, then deactivate.
+		patchOps := []scim.PatchOperation{
+			{Op: scim.PatchOperationReplace, Path: &emailValuePath, Value: "garbage@nomatch.local"},
+			{Op: scim.PatchOperationReplace, Path: &activePath, Value: false},
+		}
+
+		_, err = handler.Patch(req, "1", patchOps)
+		require.NoError(t, err)
+
+		assert.Contains(t, lookedUpEmails, "victim@example.com", "expected the pre-patch email to be used for Fleet user resolution")
+		assert.True(t, mocks.ds.DeleteUserFuncInvoked)
+	})
+
+	t.Run("deletes Fleet user when identifiers are mutated via a pathless multi-op Patch", func(t *testing.T) {
+		mocks := newTestMocks()
+		existingScimUser := newTestScimUser(&scimUserOpts{
+			active:     new(true),
+			userName:   "user@example.com",
+			givenName:  "John",
+			familyName: "Doe",
+			emails:     []fleet.ScimUserEmail{{Email: "user@example.com", Primary: new(true)}},
+		})
+		fleetUser := newTestFleetUser(&fleetUserOpts{ssoEnabled: true})
+
+		mocks.ds.ScimUserByIDFunc = func(ctx context.Context, id uint) (*fleet.ScimUser, error) {
+			return existingScimUser, nil
+		}
+		mocks.ds.ReplaceScimUserFunc = func(ctx context.Context, user *fleet.ScimUser) ([]fleet.ActivityTypeResentCertificate, error) {
+			return nil, nil
+		}
+		var lookedUpEmails []string
+		mocks.ds.UserByEmailFunc = func(ctx context.Context, email string) (*fleet.User, error) {
+			lookedUpEmails = append(lookedUpEmails, email)
+			if email == "user@example.com" {
+				return fleetUser, nil
+			}
+			return nil, platform_mysql.NotFound("User")
+		}
+		mocks.ds.DeleteUserFunc = func(ctx context.Context, id uint) error {
+			assert.Equal(t, uint(100), id)
+			return nil
+		}
+		mocks.svc.NewActivityFunc = func(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails) error {
+			return nil
+		}
+
+		handler := mocks.newTestHandler()
+		req := httptest.NewRequest(http.MethodPatch, "/scim/v2/Users/1", nil)
+
+		// Pathless replace carrying the mutated identifiers alongside active=false.
+		patchOps := []scim.PatchOperation{
+			{Op: scim.PatchOperationReplace, Path: nil, Value: map[string]any{
+				"userName": "nondomain_user_bypass",
+				"emails":   []any{},
+				"active":   false,
+			}},
+		}
+
+		_, err := handler.Patch(req, "1", patchOps)
+		require.NoError(t, err)
+
+		assert.Contains(t, lookedUpEmails, "user@example.com", "expected the pre-patch identifier to be used for Fleet user resolution")
+		assert.True(t, mocks.ds.DeleteUserFuncInvoked)
 	})
 }
 

--- a/ee/server/scim/users_test.go
+++ b/ee/server/scim/users_test.go
@@ -528,22 +528,32 @@ func TestUserHandlerReplaceDeactivation(t *testing.T) {
 		mocks := newTestMocks()
 		existingScimUser := newTestScimUser(&scimUserOpts{
 			active:     ptr.Bool(true),
+			userName:   "user@example.com",
 			givenName:  "John",
 			familyName: "Doe",
+			emails:     []fleet.ScimUserEmail{{Email: "user@example.com", Primary: ptr.Bool(true)}},
 		})
 		fleetUser := newTestFleetUser(&fleetUserOpts{ssoEnabled: true})
 
 		mocks.ds.ScimUserByIDFunc = func(ctx context.Context, id uint) (*fleet.ScimUser, error) {
 			return existingScimUser, nil
 		}
+		// userName is changing to a non-email value, so uniqueness check misses.
 		mocks.ds.ScimUserByUserNameFunc = func(ctx context.Context, userName string) (*fleet.ScimUser, error) {
-			return existingScimUser, nil
+			return nil, platform_mysql.NotFound("ScimUser")
 		}
 		mocks.ds.ReplaceScimUserFunc = func(ctx context.Context, user *fleet.ScimUser) ([]fleet.ActivityTypeResentCertificate, error) {
 			return nil, nil
 		}
+		// Only the pre-replace identifier resolves the Fleet user; the incoming
+		// (mutated) userName/emails must not be used for lookup.
+		var lookedUpEmails []string
 		mocks.ds.UserByEmailFunc = func(ctx context.Context, email string) (*fleet.User, error) {
-			return fleetUser, nil
+			lookedUpEmails = append(lookedUpEmails, email)
+			if email == "user@example.com" {
+				return fleetUser, nil
+			}
+			return nil, platform_mysql.NotFound("User")
 		}
 		mocks.ds.DeleteUserFunc = func(ctx context.Context, id uint) error {
 			assert.Equal(t, uint(100), id)
@@ -558,11 +568,14 @@ func TestUserHandlerReplaceDeactivation(t *testing.T) {
 
 		handler := mocks.newTestHandler()
 		req := httptest.NewRequest(http.MethodPut, "/scim/v2/Users/1", nil)
-		attrs := newTestAttrs("user@example.com", ptr.Bool(false), "John", "Doe")
+		// Replace the whole resource with a non-email userName and no emails while
+		// deactivating; deprovisioning must still resolve via pre-replace identifiers.
+		attrs := newTestAttrs("nondomain_user_bypass", ptr.Bool(false), "John", "Doe")
 
 		_, err := handler.Replace(req, "1", attrs)
 		require.NoError(t, err)
 
+		assert.Contains(t, lookedUpEmails, "user@example.com", "expected the pre-replace identifier to be used for Fleet user resolution")
 		assert.True(t, mocks.ds.DeleteUserFuncInvoked)
 	})
 
@@ -689,8 +702,10 @@ func TestUserHandlerPatchDeactivation(t *testing.T) {
 		mocks := newTestMocks()
 		existingScimUser := newTestScimUser(&scimUserOpts{
 			active:     ptr.Bool(true),
+			userName:   "user@example.com",
 			givenName:  "John",
 			familyName: "Doe",
+			emails:     []fleet.ScimUserEmail{{Email: "user@example.com", Primary: ptr.Bool(true)}},
 		})
 		fleetUser := newTestFleetUser(&fleetUserOpts{ssoEnabled: true})
 
@@ -700,8 +715,15 @@ func TestUserHandlerPatchDeactivation(t *testing.T) {
 		mocks.ds.ReplaceScimUserFunc = func(ctx context.Context, user *fleet.ScimUser) ([]fleet.ActivityTypeResentCertificate, error) {
 			return nil, nil
 		}
+		// Only the pre-patch identifier resolves the Fleet user; the mutated
+		// userName/emails from the same PATCH must not be used for lookup.
+		var lookedUpEmails []string
 		mocks.ds.UserByEmailFunc = func(ctx context.Context, email string) (*fleet.User, error) {
-			return fleetUser, nil
+			lookedUpEmails = append(lookedUpEmails, email)
+			if email == "user@example.com" {
+				return fleetUser, nil
+			}
+			return nil, platform_mysql.NotFound("User")
 		}
 		mocks.ds.DeleteUserFunc = func(ctx context.Context, id uint) error {
 			assert.Equal(t, uint(100), id)
@@ -714,16 +736,26 @@ func TestUserHandlerPatchDeactivation(t *testing.T) {
 		handler := mocks.newTestHandler()
 		req := httptest.NewRequest(http.MethodPatch, "/scim/v2/Users/1", nil)
 
+		userNamePath, err := filter.ParsePath([]byte("userName"))
+		require.NoError(t, err)
+		emailsPath, err := filter.ParsePath([]byte("emails"))
+		require.NoError(t, err)
 		activePath, err := filter.ParsePath([]byte("active"))
 		require.NoError(t, err)
 
+		// Mirror the pen-test payload: rename to a non-email userName and drop
+		// emails before deactivating, all in the same PATCH. Deprovisioning must
+		// still resolve and delete the Fleet user via the pre-patch identifiers.
 		patchOps := []scim.PatchOperation{
+			{Op: scim.PatchOperationReplace, Path: &userNamePath, Value: "nondomain_user_bypass"},
+			{Op: scim.PatchOperationRemove, Path: &emailsPath},
 			{Op: scim.PatchOperationReplace, Path: &activePath, Value: false},
 		}
 
 		_, err = handler.Patch(req, "1", patchOps)
 		require.NoError(t, err)
 
+		assert.Contains(t, lookedUpEmails, "user@example.com", "expected the pre-patch identifier to be used for Fleet user resolution")
 		assert.True(t, mocks.ds.DeleteUserFuncInvoked)
 	})
 


### PR DESCRIPTION
Resolve the matching Fleet user from the persisted SCIM record rather than the incoming request state when handling deactivation, so deprovisioning still works when identifiers change in the same request.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SCIM user deactivation so Fleet user deprovisioning consistently targets the correct user, even when identifiers (such as usernames or emails) are changed in the same Replace/Patch request.
  * Updated deactivation behavior to resolve Fleet user matches using the user’s pre-change identifiers, avoiding incorrect retention caused by mutated payload data.
  * Expanded unit and integration test coverage for Replace and Patch scenarios where deactivation and identifier mutations occur together.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->