### PR TITLE
Harden password reset token handling

### DIFF
--- a/changes/16799-password-reset-token-race
+++ b/changes/16799-password-reset-token-race
@@ -1,0 +1,1 @@
+- Ensured a password reset token can only be used once.

--- a/server/datastore/mysql/password_reset.go
+++ b/server/datastore/mysql/password_reset.go
@@ -57,24 +57,40 @@ func (ds *Datastore) FindPasswordResetByToken(ctx context.Context, token string)
 	return passwordResetRequest, nil
 }
 
-func (ds *Datastore) ConsumePasswordResetRequest(ctx context.Context, token string) error {
-	res, err := ds.writer(ctx).ExecContext(ctx, `
-		DELETE FROM password_reset_requests
-		WHERE token = ? AND CURRENT_TIMESTAMP < expires_at
-	`, token)
-	if err != nil {
-		return ctxerr.Wrap(ctx, err, "consuming password reset request")
-	}
+func (ds *Datastore) ResetPassword(ctx context.Context, token string, user *fleet.User) error {
+	return ds.withTx(ctx, func(tx sqlx.ExtContext) error {
+		res, err := tx.ExecContext(ctx, `
+			DELETE FROM password_reset_requests
+			WHERE token = ? AND CURRENT_TIMESTAMP < expires_at
+		`, token)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "consuming password reset request")
+		}
+		n, err := res.RowsAffected()
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "reading affected rows for password reset request")
+		}
+		if n == 0 {
+			return ctxerr.Wrap(ctx, notFound("PasswordResetRequest"), "password reset token already used or invalid")
+		}
 
-	n, err := res.RowsAffected()
-	if err != nil {
-		return ctxerr.Wrap(ctx, err, "reading affected rows for password reset request")
-	}
-	if n == 0 {
-		return ctxerr.Wrap(ctx, notFound("PasswordResetRequest"), "password reset token already used or invalid")
-	}
+		// Persist the new (already-hashed) password.
+		if err := saveUserDB(ctx, tx, user); err != nil {
+			return ctxerr.Wrap(ctx, err, "saving changed password")
+		}
 
-	return nil
+		// Invalidate any other outstanding reset links for the user.
+		if _, err := tx.ExecContext(ctx, `DELETE FROM password_reset_requests WHERE user_id = ?`, user.ID); err != nil {
+			return ctxerr.Wrap(ctx, err, "deleting password reset requests after password change")
+		}
+
+		// Force the user to log in again by destroying all of their sessions.
+		if _, err := tx.ExecContext(ctx, `DELETE FROM sessions WHERE user_id = ?`, user.ID); err != nil {
+			return ctxerr.Wrap(ctx, err, "deleting sessions after password change")
+		}
+
+		return nil
+	})
 }
 
 func (ds *Datastore) CleanupExpiredPasswordResetRequests(ctx context.Context) error {

--- a/server/datastore/mysql/password_reset.go
+++ b/server/datastore/mysql/password_reset.go
@@ -57,6 +57,26 @@ func (ds *Datastore) FindPasswordResetByToken(ctx context.Context, token string)
 	return passwordResetRequest, nil
 }
 
+func (ds *Datastore) ConsumePasswordResetRequest(ctx context.Context, token string) error {
+	res, err := ds.writer(ctx).ExecContext(ctx, `
+		DELETE FROM password_reset_requests
+		WHERE token = ? AND CURRENT_TIMESTAMP < expires_at
+	`, token)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "consuming password reset request")
+	}
+
+	n, err := res.RowsAffected()
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "reading affected rows for password reset request")
+	}
+	if n == 0 {
+		return ctxerr.Wrap(ctx, notFound("PasswordResetRequest"), "password reset token already used or invalid")
+	}
+
+	return nil
+}
+
 func (ds *Datastore) CleanupExpiredPasswordResetRequests(ctx context.Context) error {
 	_, err := ds.writer(ctx).ExecContext(ctx, `DELETE FROM password_reset_requests
 		WHERE CURRENT_TIMESTAMP >= expires_at`)

--- a/server/datastore/mysql/password_reset_test.go
+++ b/server/datastore/mysql/password_reset_test.go
@@ -3,6 +3,7 @@ package mysql
 import (
 	"context"
 	"database/sql"
+	"sync"
 	"testing"
 	"time"
 
@@ -21,6 +22,7 @@ func TestPasswordReset(t *testing.T) {
 		{"Requests", testPasswordResetRequests},
 		{"TokenExpiration", testPasswordResetTokenExpiration},
 		{"CleanupExpiredPasswordResetRequests", testCleanupExpiredPasswordResetRequests},
+		{"ConsumeIsAtomic", testConsumePasswordResetRequestIsAtomic},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -110,6 +112,60 @@ func testPasswordResetTokenExpiration(t *testing.T, ds *Datastore) {
 			assert.WithinDuration(t, req.ExpiresAt.Truncate(time.Minute), found.ExpiresAt.Truncate(time.Minute), time.Minute)
 		}
 	}
+}
+
+func testConsumePasswordResetRequestIsAtomic(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+	createTestUsers(t, ds)
+
+	// Consuming an unknown token returns a not-found error.
+	err := ds.ConsumePasswordResetRequest(ctx, "does-not-exist")
+	require.Error(t, err)
+	require.True(t, fleet.IsNotFound(err))
+
+	// Consuming an expired token returns a not-found error (and leaves no room for reuse).
+	_, err = ds.writer(ctx).ExecContext(ctx,
+		`INSERT INTO password_reset_requests (user_id, token, expires_at) VALUES (?, ?, ?)`,
+		uint(1), "expired-token", time.Now().UTC().Add(-time.Hour))
+	require.NoError(t, err)
+	err = ds.ConsumePasswordResetRequest(ctx, "expired-token")
+	require.Error(t, err)
+	require.True(t, fleet.IsNotFound(err))
+
+	// A single valid token consumed concurrently must be claimed by exactly one caller;
+	// every other caller must get a not-found error.
+	const token = "single-use-token"
+	_, err = ds.NewPasswordResetRequest(ctx, &fleet.PasswordResetRequest{UserID: 1, Token: token})
+	require.NoError(t, err)
+
+	const n = 10
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	errs := make([]error, n)
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			errs[i] = ds.ConsumePasswordResetRequest(ctx, token)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	var claimed int
+	for i := range errs {
+		if errs[i] == nil {
+			claimed++
+		} else {
+			require.True(t, fleet.IsNotFound(errs[i]), "losers should report not found, got: %v", errs[i])
+		}
+	}
+	require.Equal(t, 1, claimed, "exactly one concurrent caller should consume a single-use token")
+
+	// The token is gone after being consumed.
+	_, err = ds.FindPasswordResetByToken(ctx, token)
+	require.ErrorIs(t, err, sql.ErrNoRows)
 }
 
 func testCleanupExpiredPasswordResetRequests(t *testing.T, ds *Datastore) {

--- a/server/datastore/mysql/password_reset_test.go
+++ b/server/datastore/mysql/password_reset_test.go
@@ -3,6 +3,7 @@ package mysql
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -22,7 +23,7 @@ func TestPasswordReset(t *testing.T) {
 		{"Requests", testPasswordResetRequests},
 		{"TokenExpiration", testPasswordResetTokenExpiration},
 		{"CleanupExpiredPasswordResetRequests", testCleanupExpiredPasswordResetRequests},
-		{"ConsumeIsAtomic", testConsumePasswordResetRequestIsAtomic},
+		{"ResetIsAtomic", testResetPasswordIsAtomic},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -114,28 +115,52 @@ func testPasswordResetTokenExpiration(t *testing.T, ds *Datastore) {
 	}
 }
 
-func testConsumePasswordResetRequestIsAtomic(t *testing.T, ds *Datastore) {
+func testResetPasswordIsAtomic(t *testing.T, ds *Datastore) {
 	ctx := t.Context()
-	createTestUsers(t, ds)
+	users := createTestUsers(t, ds)
+	require.NotEmpty(t, users)
+	user := users[0]
 
-	// Consuming an unknown token returns a not-found error.
-	err := ds.ConsumePasswordResetRequest(ctx, "does-not-exist")
-	require.Error(t, err)
-	require.True(t, fleet.IsNotFound(err))
+	// userWithPassword returns a fresh copy of the user with the given (hashed) password,
+	// mirroring what the service passes in after hashing.
+	userWithPassword := func(pw string) *fleet.User {
+		u := *user
+		require.NoError(t, u.SetPassword(pw, 10, 10))
+		return &u
+	}
 
-	// Consuming an expired token returns a not-found error (and leaves no room for reuse).
-	_, err = ds.writer(ctx).ExecContext(ctx,
+	// An unknown token returns a not-found error and changes nothing.
+	require.True(t, fleet.IsNotFound(ds.ResetPassword(ctx, "does-not-exist", userWithPassword("Unknown!Pass123"))))
+
+	// An expired token returns a not-found error.
+	_, err := ds.writer(ctx).ExecContext(ctx,
 		`INSERT INTO password_reset_requests (user_id, token, expires_at) VALUES (?, ?, ?)`,
-		uint(1), "expired-token", time.Now().UTC().Add(-time.Hour))
+		user.ID, "expired-token", time.Now().UTC().Add(-time.Hour))
 	require.NoError(t, err)
-	err = ds.ConsumePasswordResetRequest(ctx, "expired-token")
-	require.Error(t, err)
-	require.True(t, fleet.IsNotFound(err))
+	require.True(t, fleet.IsNotFound(ds.ResetPassword(ctx, "expired-token", userWithPassword("Expired!Pass123"))))
+
+	// A valid token is consumed, the new password is persisted, and the user's active
+	// sessions are destroyed.
+	const okToken = "valid-token"
+	_, err = ds.NewPasswordResetRequest(ctx, &fleet.PasswordResetRequest{UserID: user.ID, Token: okToken})
+	require.NoError(t, err)
+	_, err = ds.NewSession(ctx, user.ID, 32)
+	require.NoError(t, err)
+	require.NoError(t, ds.ResetPassword(ctx, okToken, userWithPassword("Valid!Pass1234")))
+
+	saved, err := ds.UserByID(ctx, user.ID)
+	require.NoError(t, err)
+	require.NoError(t, saved.ValidatePassword("Valid!Pass1234"), "new password should be persisted")
+	_, err = ds.FindPasswordResetByToken(ctx, okToken)
+	require.ErrorIs(t, err, sql.ErrNoRows)
+	sessions, err := ds.ListSessionsForUser(ctx, user.ID)
+	require.NoError(t, err)
+	require.Empty(t, sessions, "resetting the password should destroy the user's sessions")
 
 	// A single valid token consumed concurrently must be claimed by exactly one caller;
 	// every other caller must get a not-found error.
-	const token = "single-use-token"
-	_, err = ds.NewPasswordResetRequest(ctx, &fleet.PasswordResetRequest{UserID: 1, Token: token})
+	const raceToken = "single-use-token"
+	_, err = ds.NewPasswordResetRequest(ctx, &fleet.PasswordResetRequest{UserID: user.ID, Token: raceToken})
 	require.NoError(t, err)
 
 	const n = 10
@@ -146,8 +171,9 @@ func testConsumePasswordResetRequestIsAtomic(t *testing.T, ds *Datastore) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
+			u := userWithPassword(fmt.Sprintf("Race!Pass%d1234", i))
 			<-start
-			errs[i] = ds.ConsumePasswordResetRequest(ctx, token)
+			errs[i] = ds.ResetPassword(ctx, raceToken, u)
 		}(i)
 	}
 	close(start)
@@ -164,7 +190,7 @@ func testConsumePasswordResetRequestIsAtomic(t *testing.T, ds *Datastore) {
 	require.Equal(t, 1, claimed, "exactly one concurrent caller should consume a single-use token")
 
 	// The token is gone after being consumed.
-	_, err = ds.FindPasswordResetByToken(ctx, token)
+	_, err = ds.FindPasswordResetByToken(ctx, raceToken)
 	require.ErrorIs(t, err, sql.ErrNoRows)
 }
 

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -550,9 +550,11 @@ type Datastore interface {
 	NewPasswordResetRequest(ctx context.Context, req *PasswordResetRequest) (*PasswordResetRequest, error)
 	DeletePasswordResetRequestsForUser(ctx context.Context, userID uint) error
 	FindPasswordResetByToken(ctx context.Context, token string) (*PasswordResetRequest, error)
-	// ConsumePasswordResetRequest atomically consumes (deletes) the valid, non-expired
-	// password reset request matching the given token.
-	ConsumePasswordResetRequest(ctx context.Context, token string) error
+	// ResetPassword consumes the password reset request matching the given token and
+	// applies the new (already-hashed) password to the user, invalidating the user's
+	// other outstanding reset requests and all active sessions. A not-found error is
+	// returned when the token is unknown, expired, or already consumed.
+	ResetPassword(ctx context.Context, token string, user *User) error
 	// CleanupExpiredPasswordResetRequests deletes any password reset requests that have expired.
 	CleanupExpiredPasswordResetRequests(ctx context.Context) error
 

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -550,6 +550,9 @@ type Datastore interface {
 	NewPasswordResetRequest(ctx context.Context, req *PasswordResetRequest) (*PasswordResetRequest, error)
 	DeletePasswordResetRequestsForUser(ctx context.Context, userID uint) error
 	FindPasswordResetByToken(ctx context.Context, token string) (*PasswordResetRequest, error)
+	// ConsumePasswordResetRequest atomically consumes (deletes) the valid, non-expired
+	// password reset request matching the given token.
+	ConsumePasswordResetRequest(ctx context.Context, token string) error
 	// CleanupExpiredPasswordResetRequests deletes any password reset requests that have expired.
 	CleanupExpiredPasswordResetRequests(ctx context.Context) error
 

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -402,7 +402,7 @@ type DeletePasswordResetRequestsForUserFunc func(ctx context.Context, userID uin
 
 type FindPasswordResetByTokenFunc func(ctx context.Context, token string) (*fleet.PasswordResetRequest, error)
 
-type ConsumePasswordResetRequestFunc func(ctx context.Context, token string) error
+type ResetPasswordFunc func(ctx context.Context, token string, user *fleet.User) error
 
 type CleanupExpiredPasswordResetRequestsFunc func(ctx context.Context) error
 
@@ -2800,8 +2800,8 @@ type DataStore struct {
 	FindPasswordResetByTokenFunc        FindPasswordResetByTokenFunc
 	FindPasswordResetByTokenFuncInvoked bool
 
-	ConsumePasswordResetRequestFunc        ConsumePasswordResetRequestFunc
-	ConsumePasswordResetRequestFuncInvoked bool
+	ResetPasswordFunc        ResetPasswordFunc
+	ResetPasswordFuncInvoked bool
 
 	CleanupExpiredPasswordResetRequestsFunc        CleanupExpiredPasswordResetRequestsFunc
 	CleanupExpiredPasswordResetRequestsFuncInvoked bool
@@ -6871,11 +6871,11 @@ func (s *DataStore) FindPasswordResetByToken(ctx context.Context, token string) 
 	return s.FindPasswordResetByTokenFunc(ctx, token)
 }
 
-func (s *DataStore) ConsumePasswordResetRequest(ctx context.Context, token string) error {
+func (s *DataStore) ResetPassword(ctx context.Context, token string, user *fleet.User) error {
 	s.mu.Lock()
-	s.ConsumePasswordResetRequestFuncInvoked = true
+	s.ResetPasswordFuncInvoked = true
 	s.mu.Unlock()
-	return s.ConsumePasswordResetRequestFunc(ctx, token)
+	return s.ResetPasswordFunc(ctx, token, user)
 }
 
 func (s *DataStore) CleanupExpiredPasswordResetRequests(ctx context.Context) error {

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -402,6 +402,8 @@ type DeletePasswordResetRequestsForUserFunc func(ctx context.Context, userID uin
 
 type FindPasswordResetByTokenFunc func(ctx context.Context, token string) (*fleet.PasswordResetRequest, error)
 
+type ConsumePasswordResetRequestFunc func(ctx context.Context, token string) error
+
 type CleanupExpiredPasswordResetRequestsFunc func(ctx context.Context) error
 
 type SessionByKeyFunc func(ctx context.Context, key string) (*fleet.Session, error)
@@ -2797,6 +2799,9 @@ type DataStore struct {
 
 	FindPasswordResetByTokenFunc        FindPasswordResetByTokenFunc
 	FindPasswordResetByTokenFuncInvoked bool
+
+	ConsumePasswordResetRequestFunc        ConsumePasswordResetRequestFunc
+	ConsumePasswordResetRequestFuncInvoked bool
 
 	CleanupExpiredPasswordResetRequestsFunc        CleanupExpiredPasswordResetRequestsFunc
 	CleanupExpiredPasswordResetRequestsFuncInvoked bool
@@ -6864,6 +6869,13 @@ func (s *DataStore) FindPasswordResetByToken(ctx context.Context, token string) 
 	s.FindPasswordResetByTokenFuncInvoked = true
 	s.mu.Unlock()
 	return s.FindPasswordResetByTokenFunc(ctx, token)
+}
+
+func (s *DataStore) ConsumePasswordResetRequest(ctx context.Context, token string) error {
+	s.mu.Lock()
+	s.ConsumePasswordResetRequestFuncInvoked = true
+	s.mu.Unlock()
+	return s.ConsumePasswordResetRequestFunc(ctx, token)
 }
 
 func (s *DataStore) CleanupExpiredPasswordResetRequests(ctx context.Context) error {

--- a/server/service/users.go
+++ b/server/service/users.go
@@ -1521,6 +1521,19 @@ func (svc *Service) ResetPassword(ctx context.Context, token, password string) e
 		return fleet.NewInvalidArgumentError("new_password", "Cannot reuse old password")
 	}
 
+	// Atomically consume the token before applying the change. This is the single
+	// point that enforces one-time-use semantics: under concurrent requests with the
+	// same token, exactly one caller succeeds here and the rest are rejected, which
+	// prevents a race where several requests overwrite the password simultaneously.
+	// All validation above is read-only, so a rejected password (e.g. reused or too
+	// weak) never burns the token.
+	if err := svc.ds.ConsumePasswordResetRequest(ctx, token); err != nil {
+		if fleet.IsNotFound(err) {
+			return ctxerr.Wrap(ctx, fleet.NewAuthFailedError("invalid password reset token"), "password reset token already used")
+		}
+		return ctxerr.Wrap(ctx, err, "consuming password reset token")
+	}
+
 	// password requirements are validated as part of `setNewPassword``
 	err = svc.setNewPassword(ctx, user, password, true)
 	if err != nil {

--- a/server/service/users.go
+++ b/server/service/users.go
@@ -1521,23 +1521,25 @@ func (svc *Service) ResetPassword(ctx context.Context, token, password string) e
 		return fleet.NewInvalidArgumentError("new_password", "Cannot reuse old password")
 	}
 
-	// Atomically consume the token before applying the change. This is the single
-	// point that enforces one-time-use semantics: under concurrent requests with the
-	// same token, exactly one caller succeeds here and the rest are rejected, which
-	// prevents a race where several requests overwrite the password simultaneously.
-	// All validation above is read-only, so a rejected password (e.g. reused or too
-	// weak) never burns the token.
-	if err := svc.ds.ConsumePasswordResetRequest(ctx, token); err != nil {
+	// Hash the new password before touching the database. Hashing is the only step that
+	// can reject the password (bcrypt rejects passwords longer than its limit), and it is
+	// CPU-bound, so it must run before — and outside of — the reset transaction. Doing it
+	// here also guarantees a rejected password never consumes the token.
+	if err := user.SetPassword(password, svc.config.Auth.SaltKeySize, svc.config.Auth.BcryptCost); err != nil {
+		return ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("new_password", err.Error()))
+	}
+
+	// Consume the token and apply the password change atomically. Within a single
+	// transaction this consumes the token, saves the new password, and invalidates the
+	// user's other reset links and sessions. It enforces one-time-use semantics (exactly
+	// one concurrent request can consume a given token) and, because it is transactional,
+	// a failure in any step rolls back the token consumption so the reset link stays
+	// usable.
+	if err := svc.ds.ResetPassword(ctx, token, user); err != nil {
 		if fleet.IsNotFound(err) {
 			return ctxerr.Wrap(ctx, fleet.NewAuthFailedError("invalid password reset token"), "password reset token already used")
 		}
-		return ctxerr.Wrap(ctx, err, "consuming password reset token")
-	}
-
-	// password requirements are validated as part of `setNewPassword``
-	err = svc.setNewPassword(ctx, user, password, true)
-	if err != nil {
-		return fleet.NewInvalidArgumentError("new_password", err.Error())
+		return ctxerr.Wrap(ctx, err, "resetting password")
 	}
 
 	return nil

--- a/server/service/users_test.go
+++ b/server/service/users_test.go
@@ -1041,6 +1041,38 @@ func TestResetPasswordConcurrent(t *testing.T) {
 	require.Equal(t, 1, succeeded, "exactly one concurrent reset should succeed for a single-use token")
 }
 
+// TestResetPasswordTokenSurvivesRejection verifies that a reset request rejected by
+// validation (a password that is too weak, or a reused current password) does NOT
+// consume the token. The user can retry with the same token and a valid password.
+// This guards the deliberate ordering in ResetPassword: the token is consumed only
+// after all read-only validation has passed.
+func TestResetPasswordTokenSurvivesRejection(t *testing.T) {
+	ds := mysqltest.CreateMySQLDS(t)
+
+	svc, ctx := newTestService(t, ds, nil, nil)
+	createTestUsers(t, ds) // user ID 1's current password is test.GoodPassword
+
+	const token = "survives-rejection-token"
+	_, err := ds.NewPasswordResetRequest(t.Context(), &fleet.PasswordResetRequest{
+		ExpiresAt: time.Now().Add(time.Hour * 24),
+		UserID:    1,
+		Token:     token,
+	})
+	require.NoError(t, err)
+
+	// A password that fails the strength requirements is rejected before consuming the token.
+	require.Error(t, svc.ResetPassword(ctx, token, "short"))
+
+	// Reusing the current password is rejected before consuming the token.
+	require.Error(t, svc.ResetPassword(ctx, token, test.GoodPassword))
+
+	// The token was not burned by the rejected attempts: a valid new password succeeds.
+	require.NoError(t, svc.ResetPassword(ctx, token, test.GoodPassword2))
+
+	// After a successful reset the token is consumed and can no longer be used.
+	require.Error(t, svc.ResetPassword(ctx, token, test.GoodPassword))
+}
+
 func refreshCtx(t *testing.T, ctx context.Context, user *fleet.User, ds fleet.Datastore, session *fleet.Session) context.Context {
 	reloadedUser, err := ds.UserByEmail(ctx, user.Email)
 	require.NoError(t, err)

--- a/server/service/users_test.go
+++ b/server/service/users_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -1063,6 +1064,12 @@ func TestResetPasswordTokenSurvivesRejection(t *testing.T) {
 	// A password that fails the strength requirements is rejected before consuming the token.
 	require.Error(t, svc.ResetPassword(ctx, token, "short"))
 
+	// A password that satisfies the strength requirements but is too long for bcrypt to
+	// hash is rejected before consuming the token. Hashing happens after the strength
+	// check, so without hashing-before-consume this rejection would burn the token.
+	tooLong := "aA1!" + strings.Repeat("x", 60) // 64 chars: has a number and symbol, exceeds bcrypt's limit
+	require.Error(t, svc.ResetPassword(ctx, token, tooLong))
+
 	// Reusing the current password is rejected before consuming the token.
 	require.Error(t, svc.ResetPassword(ctx, token, test.GoodPassword))
 
@@ -1907,37 +1914,28 @@ func TestPasswordChangeClearsTokensAndSessions(t *testing.T) {
 			return nil, errors.New("user not found")
 		}
 
-		ds.SaveUserFunc = func(ctx context.Context, u *fleet.User) error {
-			return nil
-		}
-
-		ds.ConsumePasswordResetRequestFunc = func(ctx context.Context, token string) error {
-			if token == resetToken {
-				return nil
-			}
-			return errors.New("token not found")
-		}
-
-		var deletedPasswordResetForUserID uint
-		ds.DeletePasswordResetRequestsForUserFunc = func(ctx context.Context, userID uint) error {
-			deletedPasswordResetForUserID = userID
-			return nil
-		}
-
-		var destroyedSessionsForUserID uint
-		ds.DestroyAllSessionsForUserFunc = func(ctx context.Context, userID uint) error {
-			destroyedSessionsForUserID = userID
+		// Consuming the token, saving the password, and clearing the user's other reset
+		// links and sessions now happen atomically inside the datastore, so the service
+		// delegates to a single ResetPassword call.
+		var (
+			passedToken string
+			passedUser  *fleet.User
+		)
+		ds.ResetPasswordFunc = func(ctx context.Context, token string, u *fleet.User) error {
+			passedToken = token
+			passedUser = u
 			return nil
 		}
 
 		err = svc.ResetPassword(ctx, resetToken, test.GoodPassword2)
 		require.NoError(t, err)
 
-		assert.True(t, ds.DeletePasswordResetRequestsForUserFuncInvoked, "DeletePasswordResetRequestsForUser should be called")
-		assert.Equal(t, targetUser.ID, deletedPasswordResetForUserID, "should delete password reset tokens for the correct user")
-
-		assert.True(t, ds.DestroyAllSessionsForUserFuncInvoked, "DestroyAllSessionsForUser should be called")
-		assert.Equal(t, targetUser.ID, destroyedSessionsForUserID, "should destroy sessions for the correct user")
+		require.True(t, ds.ResetPasswordFuncInvoked, "ResetPassword should be called")
+		assert.Equal(t, resetToken, passedToken, "should consume the provided token")
+		require.NotNil(t, passedUser)
+		assert.Equal(t, targetUser.ID, passedUser.ID, "should reset the correct user")
+		// The password must already be hashed before it reaches the datastore transaction.
+		require.NoError(t, passedUser.ValidatePassword(test.GoodPassword2), "new password should be hashed before the reset transaction")
 	})
 
 	t.Run("PerformRequiredPasswordReset clears other sessions but keeps current", func(t *testing.T) {

--- a/server/service/users_test.go
+++ b/server/service/users_test.go
@@ -3,6 +3,8 @@ package service
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -994,6 +996,51 @@ func TestResetPassword(t *testing.T) {
 	}
 }
 
+// TestResetPasswordConcurrent verifies that a single password reset token can be
+// consumed by at most one concurrent request. Firing many requests with the same
+// valid token and distinct new passwords must result in exactly one success; the
+// rest must fail because the token has already been consumed.
+func TestResetPasswordConcurrent(t *testing.T) {
+	ds := mysqltest.CreateMySQLDS(t)
+
+	svc, ctx := newTestService(t, ds, nil, nil)
+	createTestUsers(t, ds)
+
+	const token = "concurrent-reset-token"
+	_, err := ds.NewPasswordResetRequest(t.Context(), &fleet.PasswordResetRequest{
+		ExpiresAt: time.Now().Add(time.Hour * 24),
+		UserID:    1,
+		Token:     token,
+	})
+	require.NoError(t, err)
+
+	const n = 10
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	errs := make([]error, n)
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			// Each request sets a distinct new password so none is rejected by
+			// the "cannot reuse old password" check.
+			pw := fmt.Sprintf("racePassword%d!", i)
+			<-start
+			errs[i] = svc.ResetPassword(ctx, token, pw)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	var succeeded int
+	for _, e := range errs {
+		if e == nil {
+			succeeded++
+		}
+	}
+	require.Equal(t, 1, succeeded, "exactly one concurrent reset should succeed for a single-use token")
+}
+
 func refreshCtx(t *testing.T, ctx context.Context, user *fleet.User, ds fleet.Datastore, session *fleet.Session) context.Context {
 	reloadedUser, err := ds.UserByEmail(ctx, user.Email)
 	require.NoError(t, err)
@@ -1830,6 +1877,13 @@ func TestPasswordChangeClearsTokensAndSessions(t *testing.T) {
 
 		ds.SaveUserFunc = func(ctx context.Context, u *fleet.User) error {
 			return nil
+		}
+
+		ds.ConsumePasswordResetRequestFunc = func(ctx context.Context, token string) error {
+			if token == resetToken {
+				return nil
+			}
+			return errors.New("token not found")
 		}
 
 		var deletedPasswordResetForUserID uint


### PR DESCRIPTION
Ensure a password reset token can only be used once.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Password reset tokens are now enforced as single-use and atomically consumed during reset.
  - Concurrent reset attempts with the same token are handled safely so only one succeeds.
  - Reset rejects unknown/expired/already-used tokens and, on success, invalidates outstanding reset requests and the user’s active sessions.

- **Testing**
  - Added concurrency and atomicity coverage to verify only one caller can consume a token.
  - Added checks that invalid password attempts do not consume tokens, and updated tests to mock the atomic reset behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->