### PR TITLE
Set byod_fleet for dogfood Apple Business Manager tokens

### DIFF
--- a/it-and-security/default.yml
+++ b/it-and-security/default.yml
@@ -27,10 +27,12 @@ org_settings:
         macos_fleet: "💻 Workstations"
         ios_fleet: "📱🏢 Employee-issued mobile devices"
         ipados_fleet: "📱🏢 Employee-issued mobile devices"
+        byod_fleet: "📱🔐 Personal mobile devices"
       - organization_name: Mactivate LLC
         macos_fleet: "🧪 Testing & QA"
         ios_fleet: "🧪 Testing & QA"
         ipados_fleet: "🧪 Testing & QA"
+        byod_fleet: "🧪 Testing & QA"
     volume_purchasing_program:
       - location: Fleet Device Management Inc.
         fleets:


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->

Sets the new `byod_fleet` option on both Apple Business Manager tokens in the dogfood GitOps config, so BYOD hosts appearing in Apple Business Manager are automatically added to the right fleet instead of "Unassigned":

- **Fleet Device Management Inc.** → `📱🔐 Personal mobile devices`
- **Mactivate LLC** → `🧪 Testing & QA`

Fleet names match the definitions in `it-and-security/fleets/personal-mobile-devices.yml` and `it-and-security/fleets/testing-and-qa.yml` verbatim (including emoji prefixes). The file keeps the existing `apple_business_manager` parent key (deprecated alias for `apple_business`) to match the surrounding config; the alias machinery renames the parent before resolving nested keys, so `byod_fleet` resolves correctly under it.

Note for reviewers: this only affects where *newly appearing* BYOD hosts are placed — existing BYOD hosts in "Unassigned" are not retroactively moved.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

## Testing

- [x] QA'd all new/changed functionality manually — verified the YAML parses (yaml.v3) and both ABM entries resolve to the intended fleet names; config-only change to the dogfood GitOps setup, no product code touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated device fleet mappings to correctly include BYOD devices.
  * Ensured BYOD devices are assigned to the appropriate personal mobile or testing fleet categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->