### PR TITLE
Dedupe transitive uuid to 14.0.0 (CVE-2026-41907)

### DIFF
--- a/package.json
+++ b/package.json
@@ -187,7 +187,7 @@
     "@types/react-dom": "18.2.0",
     "**/serialize-javascript": "7.0.5",
     "**/yaml": "1.10.3",
-    "**/react-tooltip/uuid": "^14.0.0"
+    "**/uuid": "^14.0.0"
   },
   "browserslist": [
     "defaults"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11924,20 +11924,10 @@ utila@~0.4:
   resolved "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz"
   integrity sha512-Z0DbgELS9/L/75wZbro8xAnT50pBVFQZ+hUEueGDU5FN51YSCYM+jdxsfCiHjwNP/4LCDD0i/graKpeBnOXKRA==
 
-uuid@14.0.0, uuid@^14.0.0, uuid@^7.0.3:
+uuid@14.0.0, uuid@^14.0.0, uuid@^7.0.3, uuid@^8.3.0, uuid@^8.3.2, uuid@^9.0.0:
   version "14.0.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.0.tgz#0af883220163d264ffe0c084f6b8a89b9666966d"
   integrity sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==
-
-uuid@^8.3.0, uuid@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
-
-uuid@^9.0.0:
-  version "9.0.1"
-  resolved "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz"
-  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
 v8-compile-cache@^2.0.3:
   version "2.4.0"


### PR DESCRIPTION
**Related issue:** Dependabot alert [#693](https://github.com/fleetdm/fleet/security/dependabot/693) (GHSA-w5hq-g745-h8pq / CVE-2026-41907)

Resolves the `uuid` medium-severity advisory (out-of-bounds write, CWE-787) flagged by Dependabot/Vanta.

Our direct `uuid` dependency was already on the patched `14.0.0`. The alert was triggered only by **transitive, development-scoped** copies pulled in by build/test tooling:

- `@storybook/addon-actions` → `uuid@9.0.1`
- `webpack-notifier` → `node-notifier` → `uuid@8.3.2`
- `@storybook/test-runner` → `jest-junit` / `jest-playwright-preset` / `nyc` → `istanbul-lib-processinfo` → `uuid@8.3.2`

None of these ship in the product bundle, so there is no runtime/production exposure. Dependabot couldn't auto-generate a PR due to the conflicting transitive constraints, hence this manual resolution.

This replaces the pre-existing narrow `"**/react-tooltip/uuid"` resolution with a broad `"**/uuid": "^14.0.0"`, deduping every `uuid` copy in `yarn.lock` down to the single safe `14.0.0`.

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] QA'd all new/changed functionality manually

Verified all affected dev consumers use v14-compatible imports (named `{ v1 }`/`{ v4 }` destructure or `uuid.v4()` namespace access — none use the removed callable default or `uuid/v4` deep imports), and confirmed at runtime that `jest-junit`, `node-notifier`, and `istanbul-lib-processinfo` load and generate UUIDs against `uuid@14.0.0`.

No changes file: dev-only dependency dedup with no user-visible change.
