### PR TITLE
Dedupe transitive uuid to 14.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -187,7 +187,12 @@
     "@types/react-dom": "18.2.0",
     "**/serialize-javascript": "7.0.5",
     "**/yaml": "1.10.3",
-    "**/uuid": "^14.0.0"
+    "**/react-tooltip/uuid": "14.0.0",
+    "**/node-notifier/uuid": "11.1.1",
+    "**/jest-junit/uuid": "11.1.1",
+    "**/jest-playwright-preset/uuid": "11.1.1",
+    "**/istanbul-lib-processinfo/uuid": "11.1.1",
+    "**/@storybook/addon-actions/uuid": "11.1.1"
   },
   "browserslist": [
     "defaults"

--- a/package.json
+++ b/package.json
@@ -187,7 +187,7 @@
     "@types/react-dom": "18.2.0",
     "**/serialize-javascript": "7.0.5",
     "**/yaml": "1.10.3",
-    "**/react-tooltip/uuid": "^14.0.0"
+    "**/uuid": "^14.0.0"
   },
   "browserslist": [
     "defaults"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11924,20 +11924,10 @@ utila@~0.4:
   resolved "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz"
   integrity sha512-Z0DbgELS9/L/75wZbro8xAnT50pBVFQZ+hUEueGDU5FN51YSCYM+jdxsfCiHjwNP/4LCDD0i/graKpeBnOXKRA==
 
-uuid@14.0.0, uuid@^14.0.0, uuid@^7.0.3:
+uuid@14.0.0, uuid@^14.0.0, uuid@^7.0.3, uuid@^8.3.0, uuid@^8.3.2, uuid@^9.0.0:
   version "14.0.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.0.tgz#0af883220163d264ffe0c084f6b8a89b9666966d"
   integrity sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==
-
-uuid@^8.3.0, uuid@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
-
-uuid@^9.0.0:
-  version "9.0.1"
-  resolved "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz"
-  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
 v8-compile-cache@^2.0.3:
   version "2.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11924,7 +11924,12 @@ utila@~0.4:
   resolved "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz"
   integrity sha512-Z0DbgELS9/L/75wZbro8xAnT50pBVFQZ+hUEueGDU5FN51YSCYM+jdxsfCiHjwNP/4LCDD0i/graKpeBnOXKRA==
 
-uuid@14.0.0, uuid@^14.0.0, uuid@^7.0.3, uuid@^8.3.0, uuid@^8.3.2, uuid@^9.0.0:
+uuid@11.1.1, uuid@^8.3.0, uuid@^8.3.2, uuid@^9.0.0:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
+  integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
+
+uuid@14.0.0, uuid@^7.0.3:
   version "14.0.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.0.tgz#0af883220163d264ffe0c084f6b8a89b9666966d"
   integrity sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==


### PR DESCRIPTION
**Related issue:** Dependabot alert [#693](https://github.com/fleetdm/fleet/security/dependabot/693) (GHSA-w5hq-g745-h8pq / CVE-2026-41907)

Resolves the `uuid` medium-severity advisory (out-of-bounds write, CWE-787) flagged by Dependabot/Vanta. Dependabot couldn't auto-generate a PR due to the conflicting transitive constraints, hence this manual resolution.

Our direct `uuid` dependency (and `react-tooltip`'s, via an existing resolution) was already on the patched `14.0.0`. The alert was triggered by older transitive copies pulled in by build/test tooling: `uuid@9.0.1` (`@storybook/addon-actions`) and `uuid@8.3.2` (`node-notifier` via `webpack-notifier`; `jest-junit`, `jest-playwright-preset`, and `nyc`→`istanbul-lib-processinfo` via `@storybook/test-runner`).

These tooling packages are CommonJS and `require('uuid')`, so they can't be bumped to `uuid@14` — **uuid dropped CommonJS support at v12 and is ESM-only from then on** (an earlier attempt at a blanket `**/uuid: ^14` broke the ESLint import resolver's require chain via `node-notifier`). The last patched version that still ships a CommonJS build is `11.1.1`.

This adds scoped `resolutions` pinning those CJS tooling packages to `uuid@11.1.1` (patched + CommonJS), while keeping runtime consumers (the app's direct dep and `react-tooltip`) on `14.0.0`. After the change every `uuid` in the tree is `>= 11.1.1` (i.e. patched), split across `14.0.0` (runtime) and `11.1.1` (dev tooling).

Note this touches the production dependency graph (`react-tooltip` → `uuid`) as well as dev tooling, but production was already on the patched `14.0.0`.

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] QA'd all new/changed functionality manually

Confirmed at runtime that `node-notifier`, `jest-junit`, and `istanbul-lib-processinfo` load and generate UUIDs against their pinned `uuid@11.1.1` (CJS build present at `dist/cjs/index.js`), and that `yarn lint` passes locally (the previously-failing `import/no-unresolved` resolver errors are gone).

No changes file: dependency resolution with no user-visible change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency resolution rules to ensure compatible versions of a UUID library are used across the application.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->