### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/adobe-creative-cloud/windows.json
+++ b/ee/maintained-apps/outputs/adobe-creative-cloud/windows.json
@@ -9,7 +9,7 @@
       "installer_url": "https://prod-rel-ffc-ccm.oobesaas.adobe.com/adobe-ffc-external/core/v1/wam/download?sapCode=KCCC&wamFeature=nuj-live",
       "install_script_ref": "a4660692",
       "uninstall_script_ref": "756b1d8c",
-      "sha256": "fdaffc59a98ff32f50b5991719310cd846742976fe1331a581b8addb41408f04",
+      "sha256": "d93547039f2838a39e1a3440eca4c486026a8a8892c35887345cd918695136bf",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/arc/darwin.json
+++ b/ee/maintained-apps/outputs/arc/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.156.0",
+      "version": "1.156.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'company.thebrowser.Browser';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'company.thebrowser.Browser' AND version_compare(bundle_short_version, '1.156.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'company.thebrowser.Browser' AND version_compare(bundle_short_version, '1.156.2') < 0);"
       },
-      "installer_url": "https://releases.arc.net/release/Arc-1.156.0-83514.zip",
+      "installer_url": "https://releases.arc.net/release/Arc-1.156.2-83780.zip",
       "install_script_ref": "bb0dd542",
       "uninstall_script_ref": "a19b04fa",
-      "sha256": "da4d222bb33271525bf3ab2e09ace061eb1daa35d92a9840d8ee42da38b38e9a",
+      "sha256": "41ddb0b021792706f9729d335ec4051ed94ce27a929ffac5c6335ae6f10fe71a",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/bruno/darwin.json
+++ b/ee/maintained-apps/outputs/bruno/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.5.2",
+      "version": "3.5.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.usebruno.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.usebruno.app' AND version_compare(bundle_short_version, '3.5.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.usebruno.app' AND version_compare(bundle_short_version, '3.5.3') < 0);"
       },
-      "installer_url": "https://github.com/usebruno/bruno/releases/download/v3.5.2/bruno_3.5.2_arm64_mac.dmg",
+      "installer_url": "https://github.com/usebruno/bruno/releases/download/v3.5.3/bruno_3.5.3_arm64_mac.dmg",
       "install_script_ref": "6aa1c49e",
       "uninstall_script_ref": "14f6d5fd",
-      "sha256": "8e8e52be8d255b35f0161f514e94d2aae2f5071ee94e0ad7bc9fd2373a430930",
+      "sha256": "89627c0fa17a53a10cdf5b3d1f7884b84cfbf2fab21aebde7a44ebcf38c859ce",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/docker-desktop/darwin.json
+++ b/ee/maintained-apps/outputs/docker-desktop/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.82.0",
+      "version": "4.83.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.dockerdesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.dockerdesktop' AND path NOT LIKE '%.back' AND version_compare(bundle_short_version, '4.82.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.dockerdesktop' AND path NOT LIKE '%.back' AND version_compare(bundle_short_version, '4.83.0') < 0);"
       },
-      "installer_url": "https://desktop.docker.com/mac/main/arm64/233772/Docker.dmg",
+      "installer_url": "https://desktop.docker.com/mac/main/arm64/234302/Docker.dmg",
       "install_script_ref": "2c3a200a",
       "uninstall_script_ref": "29483ade",
-      "sha256": "2da717ef1ca2ae0240a68458e0aaee32be9bd9fe574fd916dd43dae40f17c12c",
+      "sha256": "6d0798ee8b93bbb742e2eac5e6bab9aa95021498f73b95b9e4e9c6c6b6a71bf5",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/docker/windows.json
+++ b/ee/maintained-apps/outputs/docker/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.82.0",
+      "version": "4.83.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Docker Desktop' AND publisher = 'Docker Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Docker Desktop' AND publisher = 'Docker Inc.' AND version_compare(version, '4.82.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Docker Desktop' AND publisher = 'Docker Inc.' AND version_compare(version, '4.83.0') < 0);"
       },
-      "installer_url": "https://desktop.docker.com/win/main/amd64/233772/Docker%20Desktop%20Installer.exe",
+      "installer_url": "https://desktop.docker.com/win/main/amd64/234302/Docker%20Desktop%20Installer.exe",
       "install_script_ref": "b06042dd",
       "uninstall_script_ref": "0b74af50",
-      "sha256": "a5b5837542f2f57fadbb09db90a60c84f8efc0a65f8d6dcd2e5b9fca3a2b87e6",
+      "sha256": "d812d89da0cda66c97cdf9decb60debf17d71c358900db33c48eb9ee9604f40c",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/firefox@nightly/darwin.json
+++ b/ee/maintained-apps/outputs/firefox@nightly/darwin.json
@@ -4,12 +4,12 @@
       "version": "154.0a1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15426.7.19') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15426.7.20') < 0);"
       },
-      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/07/2026-07-19-21-13-19-mozilla-central/firefox-154.0a1.en-US.mac.dmg",
+      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/07/2026-07-20-09-21-50-mozilla-central/firefox-154.0a1.en-US.mac.dmg",
       "install_script_ref": "418c9331",
       "uninstall_script_ref": "d7c711ad",
-      "sha256": "f32f88163197b01e44dc296ee509c06f01c3ef734c2823d5607a39b4186f7ba4",
+      "sha256": "6fe0bd463bb0b26cec010ce6bd0aceb6655e120befc435f0705fb7b3d1be0ded",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/firefox@nightly/windows.json
+++ b/ee/maintained-apps/outputs/firefox@nightly/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "154.2607.1809.0",
+      "version": "154.2607.2009.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Firefox Nightly' AND publisher = 'Mozilla Corporation';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Firefox Nightly' AND publisher = 'Mozilla Corporation' AND version_compare(version, '154.2607.1809.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Firefox Nightly' AND publisher = 'Mozilla Corporation' AND version_compare(version, '154.2607.2009.0') < 0);"
       },
-      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/07/2026-07-18-09-07-21-mozilla-central/firefox-154.0a1.multi.win64.installer.msix",
+      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/07/2026-07-20-09-21-50-mozilla-central/firefox-154.0a1.multi.win64.installer.msix",
       "install_script_ref": "255e7c51",
       "uninstall_script_ref": "f0d0fed1",
-      "sha256": "b60d98f0b8e9bf9531bccae9df9ef3f289cc423b60bfe33d3099e77746e15eed",
+      "sha256": "dd09241635cdb4f82ea57dea0b32654ae2d106e9584099901f321d93a331e3f9",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/granola/darwin.json
+++ b/ee/maintained-apps/outputs/granola/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.427.3",
+      "version": "7.427.6",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app' AND version_compare(bundle_short_version, '7.427.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app' AND version_compare(bundle_short_version, '7.427.6') < 0);"
       },
-      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.427.3/Granola-7.427.3-mac-universal.dmg",
+      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.427.6/Granola-7.427.6-mac-universal.dmg",
       "install_script_ref": "89a55638",
       "uninstall_script_ref": "7b9b9d06",
-      "sha256": "ecbd2fc9b168559f5a25e43b85a9c6e456810f99940b3ea26ed581e0bed96176",
+      "sha256": "f8d01d5b83cb7cb72a9f702dacc03273d5407a0a95df6d0d3c2f6b0d38f65616",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/granola/windows.json
+++ b/ee/maintained-apps/outputs/granola/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.427.3",
+      "version": "7.427.6",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Granola %' AND publisher = 'Granola';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Granola %' AND publisher = 'Granola' AND version_compare(version, '7.427.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Granola %' AND publisher = 'Granola' AND version_compare(version, '7.427.6') < 0);"
       },
-      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.427.3/Granola-7.427.3-win-x64.exe",
+      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.427.6/Granola-7.427.6-win-x64.exe",
       "install_script_ref": "3f66ac53",
       "uninstall_script_ref": "a4fab3f5",
-      "sha256": "c7bb2fa5339512718f380d325e9f78793852661ad3c284a1753abef41092f5a3",
+      "sha256": "7e6f75100604d4a58870eb6632cb0537057f94cd05e6c34fb505f95f98502dd1",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/hive-app/darwin.json
+++ b/ee/maintained-apps/outputs/hive-app/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.2.18",
+      "version": "1.2.19",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app' AND version_compare(bundle_short_version, '1.2.18') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app' AND version_compare(bundle_short_version, '1.2.19') < 0);"
       },
-      "installer_url": "https://github.com/morapelker/hive/releases/download/v1.2.18/Hive-1.2.18-arm64.dmg",
+      "installer_url": "https://github.com/morapelker/hive/releases/download/v1.2.19/Hive-1.2.19-arm64.dmg",
       "install_script_ref": "6b39e7ad",
       "uninstall_script_ref": "78bb4e43",
-      "sha256": "919cfa556304c976234b5312b4bfd0981852896e7cd415debd6a40b7da8a4b72",
+      "sha256": "3990dc3c56c60a32a5693f3ad9b507ef56798b2bf5dec59b26d87d39eb061a1f",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/podman-desktop/darwin.json
+++ b/ee/maintained-apps/outputs/podman-desktop/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.28.2",
+      "version": "1.28.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'io.podmandesktop.PodmanDesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.podmandesktop.PodmanDesktop' AND version_compare(bundle_short_version, '1.28.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.podmandesktop.PodmanDesktop' AND version_compare(bundle_short_version, '1.28.3') < 0);"
       },
-      "installer_url": "https://github.com/containers/podman-desktop/releases/download/v1.28.2/podman-desktop-1.28.2-arm64.dmg",
+      "installer_url": "https://github.com/containers/podman-desktop/releases/download/v1.28.3/podman-desktop-1.28.3-arm64.dmg",
       "install_script_ref": "78a723c6",
       "uninstall_script_ref": "d4656e95",
-      "sha256": "d7851363cd244dfb3e77a5fd5375b37ded086d587ea921bb650e7a12ce84fc1a",
+      "sha256": "4c460dec23e9b188cf352585adae56e0a0e97440e16592bf21dd6ddddb57ce6f",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/readest/windows.json
+++ b/ee/maintained-apps/outputs/readest/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.11.18",
+      "version": "0.11.20",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Readest' AND publisher = 'bilingify';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Readest' AND publisher = 'bilingify' AND version_compare(version, '0.11.18') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Readest' AND publisher = 'bilingify' AND version_compare(version, '0.11.20') < 0);"
       },
-      "installer_url": "https://github.com/readest/readest/releases/download/v0.11.18/Readest_0.11.18_x64-setup.exe",
+      "installer_url": "https://github.com/readest/readest/releases/download/v0.11.20/Readest_0.11.20_x64-setup.exe",
       "install_script_ref": "2b4dd196",
       "uninstall_script_ref": "36b7aeaf",
-      "sha256": "4cb7200c16272291c37b1b16f70014719415551ae07bb481b68426082698d2b3",
+      "sha256": "df8c9e2763cc9ec3e453cce6320df442798d115f9127c0c6ba831b800cbdb7dd",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated maintained app releases across macOS and Windows, including Arc, Bruno, Docker Desktop, Firefox Nightly, Granola, Hive, Podman Desktop, Readest, and Adobe Creative Cloud.
  - Added the latest installer links and verified checksums for each updated release.
  - Updated version detection so installations correctly recognize the newer app versions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->