### PR TITLE
Follow up: Styling bugs on end user enrollment (BYOD) page and Add hosts modal

### DIFF
--- a/frontend/components/AddHostsModal/PlatformWrapper/MacosPanel/_styles.scss
+++ b/frontend/components/AddHostsModal/PlatformWrapper/MacosPanel/_styles.scss
@@ -1,6 +1,6 @@
 .macos-panel {
   &__enroll-link input {
     font-family: "SourceCodePro", $monospace;
-    color: $core-fleet-blue;
+    color: $core-fleet-black;
   }
 }


### PR DESCRIPTION
- @noahtalerman: Follow up for the [this bug](https://github.com/fleetdm/fleet/issues/48967) because @Brajim20 discovered we hadn't fixed the issue for macOS: https://github.com/fleetdm/fleet/pull/48968#issuecomment-5024066554




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the macOS panel enrollment link input color for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->