### PR TITLE
Bump websocket-driver to 0.7.5 in website/ (CVE-2026-54466)

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -13906,9 +13906,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "license": "Apache-2.0",
       "dependencies": {
         "http-parser-js": ">=0.5.1",

--- a/website/package.json
+++ b/website/package.json
@@ -37,7 +37,8 @@
     },
     "request": {
       "form-data": "2.5.6"
-    }
+    },
+    "websocket-driver": "0.7.5"
   },
   "scripts": {
     "custom-tests": "echo \"(No other custom tests yet.)\" && echo",


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** N/A

Bumps `websocket-driver` to `0.7.5`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a package resolution override for improved dependency compatibility.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->