### PR TITLE
Revert "[API] Document windows automatic enrollment configuration" from docs-v4.90.0

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -2151,9 +2151,6 @@ Modifies the Fleet's configuration with the supplied information.
       "lock_end_user_info": true,
       "apple_setup_assistant": "path/to/config.json"
     },
-    "windows_automatic_enrollment": {
-      "default_fleet": "123"
-    },
     "apple_server_url": "https://instance.fleet.com"
   },
   "agent_options": {
@@ -2733,7 +2730,6 @@ When updating conditional access config, all `conditional_access` fields must ei
 | apple_settings         | object  | See [`mdm.apple_settings`](#mdm-macos-settings). |
 | windows_settings         | object  | See [`mdm.windows_settings`](#mdm-windows-settings). |
 | apple_server_url         | string  | Update this URL if you're self-hosting Fleet and you want your hosts to talk to this URL for MDM features. (If not configured, hosts will use the base URL of the Fleet instance.)  |
-| windows_automatic_enrollment         | object  | See [`mdm.windows_automatic_enrollment`](#mdm-windows-automatic-enrollment). |
 
 > Note: If `apple_server_url` changes and Apple (macOS, iOS, iPadOS) hosts already have MDM turned on, the end users will have to turn MDM off and back on to use MDM features.
 
@@ -2861,16 +2857,6 @@ _Available in Fleet Premium._
 
 <br/>
 
-##### mdm.windows_automatic_enrollment
-
-`mdm.windows_automatic_enrollment` is an object with the following structure:
-
-| Name                              | Type    | Description   |
-| ---------------------             | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| default_fleet                     | string  | The id of the fleet that Windows automatically enrolled hosts will be placed in.
-
-<br/>
-
 ##### mdm.end_user_authentication
 
 `mdm.end_user_authentication` is an object with the following structure:
@@ -2951,9 +2937,6 @@ _Available in Fleet Premium._
       "enable_end_user_authentication": false,
       "lock_end_user_info": true,
       "apple_setup_assistant": "path/to/config.json"
-    },
-    "windows_automatic_enrollment": {
-      "default_fleet": "123"
     }
   }
 }
@@ -14177,9 +14160,6 @@ _Available in Fleet Premium_
         "apple_setup_assistant": "path/to/config.json",
         "enable_release_device_manually": false,
         "manual_agent_install": false
-      },
-      "windows_automatic_enrollment": {
-        "default_fleet": "123"
       }
     }
   }
@@ -14508,7 +14488,6 @@ Returned when the requested name only differs from another fleet's name by lette
 | apple_settings           | object  | See [`mdm.apple_settings`](#mdm-apple-settings2).     |
 | windows_settings         | object  | See [`mdm.windows_settings`](#mdm-windows-settings2). |
 | setup_experience         | object  | See [`mdm.setup_experience`](#mdm-setup-experience2). |
-| windows_automatic_enrollment         | object  | See [`mdm.windows_automatic_enrollment`](#mdm-windows-automatic-enrollment2). |
 
 <br/>
 
@@ -14673,9 +14652,6 @@ Returned when the requested name only differs from another fleet's name by lette
     },
     "setup_experience": {
       "enable_end_user_authentication": false
-    },
-    "windows_automatic_enrollment": {
-      "default_fleet": "123"
     }
   }
 }
@@ -14871,9 +14847,6 @@ _Available in Fleet Premium_
         "bootstrap_package": "",
         "enable_end_user_authentication": false,
         "apple_setup_assistant": "path/to/config.json"
-      },
-      "windows_automatic_enrollment": {
-        "default_fleet": "123"
       }
     },
     "users": [


### PR DESCRIPTION
Reverts #48234 from `docs-v4.90.0`. Feature is moving to `docs-v4.91.0`.

**Related:** #48234