### PR TITLE
Fix Linux uninstall script failing with a relative path

### DIFF
--- a/it-and-security/lib/linux/scripts/uninstall-fleetd-linux.sh
+++ b/it-and-security/lib/linux/scripts/uninstall-fleetd-linux.sh
@@ -47,10 +47,11 @@ else
     # Use systemd-run to spawn the removal process in a separate transient unit.
     # This ensures the process escapes the orbit.service cgroup, so when
     # orbit.service is stopped, the removal script continues running.
+    SCRIPT_PATH="$(readlink -f "$0")"
     if command -v systemd-run > /dev/null; then
-        systemd-run --quiet bash "$0" remove
+        systemd-run --quiet bash "$SCRIPT_PATH" remove
     else
         # Fallback for non-systemd systems (rare for modern Linux)
-        bash -c "bash $0 remove >/dev/null 2>/dev/null </dev/null &"
+        bash -c "bash \"$SCRIPT_PATH\" remove >/dev/null 2>/dev/null </dev/null &"
     fi
 fi

--- a/it-and-security/lib/linux/scripts/uninstall-fleetd-linux.sh
+++ b/it-and-security/lib/linux/scripts/uninstall-fleetd-linux.sh
@@ -52,6 +52,6 @@ else
         systemd-run --quiet bash "$SCRIPT_PATH" remove
     else
         # Fallback for non-systemd systems (rare for modern Linux)
-        bash -c "bash \"$SCRIPT_PATH\" remove >/dev/null 2>/dev/null </dev/null &"
+        nohup bash "$SCRIPT_PATH" remove >/dev/null 2>&1 </dev/null &
     fi
 fi


### PR DESCRIPTION
systemd-run runs the detached child as a transient unit with
WorkingDirectory=/, so a relative $0 (e.g. ./uninstall-fleetd-linux.sh
per the uninstall guide) couldn't be found and the removal silently
never ran. Resolve $0 to an absolute path before re-exec.

Fixes #49411


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the Linux uninstall process so the detached cleanup task always runs from the correct script location.
  - Enhanced compatibility between systemd-based environments and non-systemd systems.
  - Better supports script paths that include spaces or special characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->