### PR TITLE
Revert "[Activity] Document edited Windows automatic enrollment activity" from docs-v4.90.0

### DIFF
--- a/docs/Contributing/reference/audit-logs.md
+++ b/docs/Contributing/reference/audit-logs.md
@@ -3067,23 +3067,6 @@ This activity contains the following fields:
 }
 ```
 
-## edited_windows_automatic_enrollment_default_fleet
-
-Generated when the default fleet for Windows automatic enrollments is edited.
-
-This activity contains the following fields:
-- "fleet_id": The ID of the default fleet for Windows automatic enrollments, `null` if set to no fleet.
-- "fleet_name": The name of the default fleet for Windows automatic enrollments, `null` if set to no fleet.
-
-#### Example
-
-```json
-{
-  "fleet_id": 123,
-  "fleet_name": "Workstations"
-}
-```
-
 ## edited_account_provisioning
 
 Generated when settings for account provisioning are edited.
@@ -3100,6 +3083,7 @@ This activity contains the following fields:
   "fleet_name": "Workstations"
 }
 ```
+
 
 ## edited_configuration_profile
 


### PR DESCRIPTION
Reverts #48231 from `docs-v4.90.0`. Feature is moving to `docs-v4.91.0`.

**Related:** #48231