### PR TITLE
[Guide] Document default team configuration for Autopilot hosts

### DIFF
--- a/articles/windows-mdm-setup.md
+++ b/articles/windows-mdm-setup.md
@@ -219,27 +219,27 @@ Testing automatic enrollment requires creating a test user in Microsoft Entra ID
 
 2. After it's been wiped, open your workstation and follow the setup steps. On the screen in which you're asked to sign in, you should see the title "Welcome to [your organization]!" next to the logo you uploaded in step 4.
 
-### Set a default team for Autopilot-enrolled hosts
+### Set a default fleet for new hosts
 
 _Available in Fleet Premium_
 
-By default, Windows hosts enrolled via Autopilot are added to "No team." You can configure a default team so that Autopilot-enrolled hosts are automatically assigned to a specific team — similar to how [Apple Business Manager default teams](https://fleetdm.com/guides/macos-mdm-setup#set-a-default-team-for-hosts-enrolled-via-abm) work.
+By default, Windows hosts enrolled via Autopilot are added to "Unassigned". You can configure a default fleet so that new hosts enrolled into MDM are automatically assigned to a specific fleet—similar to how [Apple Business default fleets](https://fleetdm.com/guides/macos-mdm-setup#set-a-default-team-for-hosts-enrolled-via-abm) work.
 
 #### In the UI
 
-1. Head to **Settings > Integrations > MDM > Windows MDM**.
+1. Head to **Settings > Integrations > MDM > Windows MDM** and select **Edit**.
 
-2. Under **Automatic enrollment**, use the **Default team** dropdown to select the team that automatically enrolled (Windows Autopilot) hosts should be assigned to.
+2. Under **User driven enrollment**, use the **Default team** dropdown to select the fleet that new hosts enrolled into MDM should be assigned to.
 
 3. Select **Save**.
 
 #### Via GitOps (YAML)
 
-Add the `windows_automatic_enrollment` key under `mdm` in your global (org) settings YAML file:
+Add the `windows_enrollment` key under `mdm` in your global (org) settings YAML file:
 
 ```yaml
   mdm:
-    windows_automatic_enrollment:
+    windows_enrollment:
       default_fleet: "💻 Workstations"
 ```
 

--- a/articles/windows-mdm-setup.md
+++ b/articles/windows-mdm-setup.md
@@ -235,7 +235,7 @@ By default, Windows hosts enrolled via Autopilot are added to "No team." You can
 
 #### Via GitOps (YAML)
 
-Add the `windows_autopilot_default_team` key under `mdm` in your global (org) settings YAML file:
+Add the `windows_automatic_enrollment` key under `mdm` in your global (org) settings YAML file:
 
 ```yaml
   mdm:

--- a/articles/windows-mdm-setup.md
+++ b/articles/windows-mdm-setup.md
@@ -240,7 +240,7 @@ Add the `windows_automatic_enrollment` key under `mdm` in your global (org) sett
 ```yaml
   mdm:
     windows_automatic_enrollment:
-      default_fleets: "💻 Workstations"
+      default_fleet: "💻 Workstations"
 ```
 
 ## Automatic Windows MDM migration

--- a/articles/windows-mdm-setup.md
+++ b/articles/windows-mdm-setup.md
@@ -219,6 +219,29 @@ Testing automatic enrollment requires creating a test user in Microsoft Entra ID
 
 2. After it's been wiped, open your workstation and follow the setup steps. On the screen in which you're asked to sign in, you should see the title "Welcome to [your organization]!" next to the logo you uploaded in step 4.
 
+### Set a default team for Autopilot-enrolled hosts
+
+_Available in Fleet Premium_
+
+By default, Windows hosts enrolled via Autopilot are added to "No team." You can configure a default team so that Autopilot-enrolled hosts are automatically assigned to a specific team — similar to how [Apple Business Manager default teams](https://fleetdm.com/guides/macos-mdm-setup#set-a-default-team-for-hosts-enrolled-via-abm) work.
+
+#### In the UI
+
+1. Head to **Settings > Integrations > MDM > Windows MDM**.
+
+2. Under **Automatic enrollment**, use the **Default team** dropdown to select the team that automatically enrolled (Windows Autopilot) hosts should be assigned to.
+
+3. Select **Save**.
+
+#### Via GitOps (YAML)
+
+Add the `windows_autopilot_default_team` key under `mdm` in your global (org) settings YAML file:
+
+```yaml
+  mdm:
+    windows_automatic_enrollment:
+      default_fleets: "💻 Workstations"
+```
 
 ## Automatic Windows MDM migration
 

--- a/articles/windows-mdm-setup.md
+++ b/articles/windows-mdm-setup.md
@@ -258,7 +258,7 @@ A host is assigned to the default fleet only when it enrolls in MDM before Fleet
 - Hosts you moved to another fleet manually aren't moved back to the default.
 - Deleting the fleet you set as the default clears the setting, and new hosts go to "Unassigned" until you set a new one.
 
-> **Warning:** Some virtual machines report a placeholder hardware serial such as `System Serial Number` instead of a unique one. If two Windows hosts report the same serial, Fleet can link a host to the other host's MDM enrollment and assign it to the wrong fleet. This affects Windows MDM enrollment generally, not only default fleets. Configure unique serial numbers on your virtual machines.
+> **Warning:** Some virtual machines report a placeholder hardware serial such as `System Serial Number` instead of a unique one. Fleet matches a new host to its MDM enrollment by serial number. If two or more unmatched enrollments share a serial, Fleet leaves the host in "Unassigned". This affects Windows MDM enrollment generally, not only default fleets. Configure unique serial numbers on your virtual machines.
 
 ## Automatic Windows MDM migration
 

--- a/articles/windows-mdm-setup.md
+++ b/articles/windows-mdm-setup.md
@@ -223,13 +223,17 @@ Testing automatic enrollment requires creating a test user in Microsoft Entra ID
 
 _Available in Fleet Premium_
 
-By default, Windows hosts enrolled via Autopilot are added to "Unassigned". You can configure a default fleet so that new hosts enrolled into MDM are automatically assigned to a specific fleet—similar to how [Apple Business default fleets](https://fleetdm.com/guides/macos-mdm-setup#set-a-default-team-for-hosts-enrolled-via-abm) work.
+By default, Windows hosts enrolled via Autopilot are added to "Unassigned". You can configure a default fleet so that new hosts enrolled into MDM are automatically assigned to a specific fleet, similar to how [Apple Business default fleets](https://fleetdm.com/guides/macos-mdm-setup#set-a-default-team-for-hosts-enrolled-via-abm) work.
+
+> **Note:** The default fleet applies only to hosts that enroll through end user-driven enrollment (Microsoft Entra). Hosts that install Fleet's agent before enrolling in MDM keep the fleet from their enroll secret instead.
 
 #### In the UI
 
 1. Head to **Settings > Integrations > MDM > Windows MDM** and select **Edit**.
 
-2. Under **User driven enrollment**, use the **Default team** dropdown to select the fleet that new hosts enrolled into MDM should be assigned to.
+2. Under **User driven enrollment**, use the **Default fleet** dropdown to select the fleet that new hosts enrolled into MDM should be assigned to.
+
+> **Note:** The **Default fleet** dropdown is disabled until Fleet is connected to Microsoft Entra. Connect Entra first using the steps above.
 
 3. Select **Save**.
 
@@ -242,6 +246,19 @@ Add the `windows_enrollment` key under `mdm` in your global (org) settings YAML 
     windows_enrollment:
       default_fleet: "💻 Workstations"
 ```
+
+To clear the default and send new hosts to "Unassigned", set `default_fleet` to an empty string (`""`).
+
+#### How hosts are assigned
+
+A host is assigned to the default fleet only when it enrolls in MDM before Fleet's agent is installed. That's the order Autopilot uses. Fleet applies the default at the moment it links the MDM enrollment to the host record, so:
+
+- Changing the default fleet affects only hosts that enroll after the change. Hosts already in Fleet stay where they are.
+- Hosts that already exist in Fleet keep their current fleet when they re-enroll, including hosts you deliberately left in "Unassigned".
+- Hosts you moved to another fleet manually aren't moved back to the default.
+- Deleting the fleet you set as the default clears the setting, and new hosts go to "Unassigned" until you set a new one.
+
+> **Warning:** Some virtual machines report a placeholder hardware serial such as `System Serial Number` instead of a unique one. If two Windows hosts report the same serial, Fleet can link a host to the other host's MDM enrollment and assign it to the wrong fleet. This affects Windows MDM enrollment generally, not only default fleets. Configure unique serial numbers on your virtual machines.
 
 ## Automatic Windows MDM migration
 


### PR DESCRIPTION
Added instructions for setting a default team for Autopilot-enrolled hosts in Windows MDM.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #41787