### PR TITLE
Enforce ORDER BY allowlist on activity list endpoints

### DIFF
--- a/changes/15935-activity-order-key-allowlist
+++ b/changes/15935-activity-order-key-allowlist
@@ -1,0 +1,1 @@
+- Restricted the `order_key` parameter on the list activities and list host past activities endpoints to an allowlist of sortable columns, so it can no longer be used to sort by arbitrary columns.

--- a/changes/16879-debug-api-only-restriction
+++ b/changes/16879-debug-api-only-restriction
@@ -1,0 +1,1 @@
+- Enforced API-only endpoint restrictions on the debug routes so a restricted API-only token can no longer reach `/debug/*`.

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -529,7 +529,7 @@ Returns a list of the activities that have been performed in Fleet. For a compre
 |:--------------- |:------- |:----- |:------------------------------------------------------------|
 | page            | integer | query | Page number of the results to fetch.                                                                                          |
 | per_page        | integer | query | Results per page. Maximum is 10,000 records. If no pagination parameters are specified, defaults to 10,000.                    |
-| order_key       | string  | query | What to order results by. Can be any column in the `activities` table.                                                         |
+| order_key       | string  | query | What to order results by. Allowed fields are `id`, `created_at`, `activity_type`, `user_id`, `user_name`, `user_email`, `streamed`, and `fleet_initiated`. |
 | order_direction | string  | query | **Requires `order_key`**. The direction of the order given the order key. Options include `"asc"` and `"desc"`. Default is `"asc"`. |
 | after           | string  | query | The value to get results after. This needs `order_key` defined, as that's the column that would be used. |
 | query | string | query | Search query keywords. Searchable fields include `actor_full_name` and `actor_email`.

--- a/server/activity/internal/mysql/activity.go
+++ b/server/activity/internal/mysql/activity.go
@@ -39,6 +39,30 @@ func (ds *Datastore) reader(ctx context.Context) *sqlx.DB {
 // Ensure Datastore implements types.Datastore
 var _ types.Datastore = (*Datastore)(nil)
 
+// listActivitiesOrderKeys is the allowlist of order keys for ListActivities,
+// mapping the user-facing key to its qualified column. It intentionally
+// excludes columns not returned by the query (details, host_only) so that
+// clients cannot use ORDER BY as an inference oracle over those values.
+var listActivitiesOrderKeys = platform_mysql.OrderKeyAllowlist{
+	"id":              "a.id",
+	"created_at":      "a.created_at",
+	"user_id":         "a.user_id",
+	"user_name":       "a.user_name",
+	"name":            "a.user_name",
+	"user_email":      "a.user_email",
+	"activity_type":   "a.activity_type",
+	"streamed":        "a.streamed",
+	"fleet_initiated": "a.fleet_initiated",
+}
+
+// listHostPastActivitiesOrderKeys is the allowlist of order keys for
+// ListHostPastActivities. It matches the documented allowed fields.
+var listHostPastActivitiesOrderKeys = platform_mysql.OrderKeyAllowlist{
+	"id":            "a.id",
+	"created_at":    "a.created_at",
+	"activity_type": "a.activity_type",
+}
+
 // ListActivities returns a slice of activities performed across the organization.
 func (ds *Datastore) ListActivities(ctx context.Context, opt types.ListOptions) ([]*api.Activity, *api.PaginationMetadata, error) {
 	ctx, span := tracer.Start(ctx, "activity.mysql.ListActivities")
@@ -101,12 +125,15 @@ func (ds *Datastore) ListActivities(ctx context.Context, opt types.ListOptions) 
 		args = append(args, time.Now().UTC())
 	}
 
-	// Apply pagination using platform_mysql
-	activitiesQ, args = platform_mysql.AppendListOptionsWithParams(activitiesQ, args, &opt)
+	// Apply pagination using platform_mysql, validating the order key against
+	// an allowlist to prevent ORDER BY information disclosure.
+	activitiesQ, args, err := platform_mysql.AppendListOptionsWithParamsSecure(activitiesQ, args, &opt, listActivitiesOrderKeys)
+	if err != nil {
+		return nil, nil, ctxerr.Wrap(ctx, err, "append list options")
+	}
 
 	var activities []*api.Activity
-	err := sqlx.SelectContext(ctx, ds.reader(ctx), &activities, activitiesQ, args...)
-	if err != nil {
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &activities, activitiesQ, args...); err != nil {
 		return nil, nil, ctxerr.Wrap(ctx, err, "select activities")
 	}
 
@@ -176,7 +203,10 @@ func (ds *Datastore) ListHostPastActivities(ctx context.Context, hostID uint, op
 
 	args := []any{hostID}
 
-	stmt, args := platform_mysql.AppendListOptionsWithParams(listStmt, args, &opt)
+	stmt, args, err := platform_mysql.AppendListOptionsWithParamsSecure(listStmt, args, &opt, listHostPastActivitiesOrderKeys)
+	if err != nil {
+		return nil, nil, ctxerr.Wrap(ctx, err, "append list options")
+	}
 
 	var activities []*api.Activity
 	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &activities, stmt, args...); err != nil {

--- a/server/activity/internal/mysql/activity_test.go
+++ b/server/activity/internal/mysql/activity_test.go
@@ -8,6 +8,7 @@ import (
 	activityapi "github.com/fleetdm/fleet/v4/server/activity/api"
 	"github.com/fleetdm/fleet/v4/server/activity/internal/testutils"
 	"github.com/fleetdm/fleet/v4/server/activity/internal/types"
+	platform_mysql "github.com/fleetdm/fleet/v4/server/platform/mysql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -286,6 +287,15 @@ func testListActivitiesOrdering(t *testing.T, env *testEnv) {
 	require.Len(t, activities, 3)
 	assert.Less(t, activities[0].ID, activities[1].ID)
 	assert.Less(t, activities[1].ID, activities[2].ID)
+
+	// Order keys outside the allowlist (including columns not returned by the
+	// query) must be rejected rather than passed through to the SQL.
+	for _, badKey := range []string{"details", "host_only", "password"} {
+		_, _, err := env.ds.ListActivities(ctx, listOpts(withOrder(badKey, activityapi.OrderAscending)))
+		var invalidErr platform_mysql.InvalidOrderKeyError
+		require.ErrorAs(t, err, &invalidErr, "order_key %q should be rejected", badKey)
+		assert.True(t, invalidErr.IsClientError())
+	}
 }
 
 func testListActivitiesCursorPagination(t *testing.T, env *testEnv) {
@@ -402,6 +412,17 @@ func testListHostPastActivities(t *testing.T, env *testEnv) {
 				require.NotNil(t, a.Details)
 			}
 		})
+	}
+
+	// Only the documented order keys are allowed; anything else is rejected.
+	for _, goodKey := range []string{"id", "created_at", "activity_type"} {
+		_, _, err := env.ds.ListHostPastActivities(ctx, hostID, listOpts(withOrder(goodKey, activityapi.OrderAscending)))
+		require.NoError(t, err, "order_key %q should be allowed", goodKey)
+	}
+	for _, badKey := range []string{"details", "user_email", "host_only"} {
+		_, _, err := env.ds.ListHostPastActivities(ctx, hostID, listOpts(withOrder(badKey, activityapi.OrderAscending)))
+		var invalidErr platform_mysql.InvalidOrderKeyError
+		require.ErrorAs(t, err, &invalidErr, "order_key %q should be rejected", badKey)
 	}
 }
 

--- a/server/activity/internal/service/service.go
+++ b/server/activity/internal/service/service.go
@@ -123,7 +123,7 @@ func (s *Service) ListHostPastActivities(ctx context.Context, hostID uint, opt a
 		return nil, nil, err
 	}
 
-	applyListOptionsDefaults(&opt, "a.created_at")
+	applyListOptionsDefaults(&opt, "created_at")
 	// Convert public options to internal options
 	internalOpt := types.ListOptions{
 		ListOptions:     opt,

--- a/server/activity/internal/tests/integration_test.go
+++ b/server/activity/internal/tests/integration_test.go
@@ -50,6 +50,11 @@ func testListActivities(t *testing.T, s *integrationTestSuite) {
 	assert.Equal(t, "edited_pack", result.Activities[0].Type)
 	assert.Equal(t, "deleted_pack", result.Activities[1].Type)
 	assert.Equal(t, "applied_spec_pack", result.Activities[2].Type)
+
+	// An order_key outside the allowlist is rejected as a client error rather
+	// than being passed through to the SQL ORDER BY clause.
+	_, statusCode = s.getActivities(t, "order_key=details")
+	assert.Equal(t, http.StatusUnprocessableEntity, statusCode)
 }
 
 func testListActivitiesPagination(t *testing.T, s *integrationTestSuite) {
@@ -203,6 +208,11 @@ func testListHostPastActivities(t *testing.T, s *integrationTestSuite) {
 	t.Run("returns 404 for non-existent host", func(t *testing.T) {
 		_, statusCode := s.getHostPastActivities(t, 99999, "per_page=100")
 		assert.Equal(t, http.StatusNotFound, statusCode)
+	})
+
+	t.Run("rejects order_key outside allowlist", func(t *testing.T) {
+		_, statusCode := s.getHostPastActivities(t, hostA, "order_key=details")
+		assert.Equal(t, http.StatusUnprocessableEntity, statusCode)
 	})
 
 	t.Run("pagination", func(t *testing.T) {

--- a/server/service/debug_handler.go
+++ b/server/service/debug_handler.go
@@ -44,6 +44,15 @@ func (m *debugAuthenticationMiddleware) Middleware(next http.Handler) http.Handl
 			return
 		}
 
+		// Debug routes are not part of the public API catalog, so they can never appear in an
+		// API-only user's endpoint allowlist. A restricted API-only token (api_only with a
+		// non-empty api_endpoints list) must therefore be denied here, matching the least-privilege
+		// scoping that APIOnlyEndpointCheck enforces on the main API path.
+		if v.User.APIOnly && len(v.User.APIEndpoints) > 0 {
+			http.Error(w, "Unauthorized", http.StatusForbidden)
+			return
+		}
+
 		// Attach the authenticated viewer to the request context so downstream debug handlers can record who triggered an
 		// action (e.g. updating trace sampler settings).
 		next.ServeHTTP(w, r.WithContext(viewer.NewContext(r.Context(), *v)))

--- a/server/service/debug_handler_test.go
+++ b/server/service/debug_handler_test.go
@@ -99,7 +99,9 @@ func TestDebugHandlerAuthenticationFailsDueToRole(t *testing.T) {
 	}
 }
 
-func TestDebugHandlerAuthenticationSucceeds(t *testing.T) {
+func TestDebugHandlerAuthenticationFailsForRestrictedAPIOnlyUser(t *testing.T) {
+	// A global-admin API-only token scoped to an endpoint allowlist must not reach the debug
+	// routes: those routes are not in the public API catalog, so they can never be allowlisted.
 	svc := &mockService{}
 	svc.On(
 		"GetSessionByKey",
@@ -110,7 +112,11 @@ func TestDebugHandlerAuthenticationSucceeds(t *testing.T) {
 		"UserUnauthorized",
 		mock.Anything,
 		uint(42),
-	).Return(&fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)}, nil)
+	).Return(&fleet.User{
+		GlobalRole:   ptr.String(fleet.RoleAdmin),
+		APIOnly:      true,
+		APIEndpoints: []fleet.APIEndpointRef{{Method: "GET", Path: "/api/v1/fleet/hosts"}},
+	}, nil)
 
 	handler := MakeDebugHandler(svc, testConfig, nil, nil, nil)
 
@@ -119,5 +125,38 @@ func TestDebugHandlerAuthenticationSucceeds(t *testing.T) {
 	res := httptest.NewRecorder()
 
 	handler.ServeHTTP(res, req)
-	assert.Equal(t, http.StatusOK, res.Code)
+	assert.Equal(t, http.StatusForbidden, res.Code)
+}
+
+func TestDebugHandlerAuthenticationSucceeds(t *testing.T) {
+	// An unrestricted API-only admin (empty APIEndpoints) retains full access, matching the main
+	// API path where APIOnlyEndpointCheck is a no-op for tokens with no endpoint restrictions.
+	for test, user := range map[string]fleet.User{
+		"admin session":            {GlobalRole: ptr.String(fleet.RoleAdmin)},
+		"unrestricted api-only":    {GlobalRole: ptr.String(fleet.RoleAdmin), APIOnly: true},
+		"api-only empty allowlist": {GlobalRole: ptr.String(fleet.RoleAdmin), APIOnly: true, APIEndpoints: []fleet.APIEndpointRef{}},
+	} {
+		t.Run(test, func(t *testing.T) {
+			svc := &mockService{}
+			svc.On(
+				"GetSessionByKey",
+				mock.Anything,
+				"fake_session_key",
+			).Return(&fleet.Session{UserID: 42, ID: 1}, nil)
+			svc.On(
+				"UserUnauthorized",
+				mock.Anything,
+				uint(42),
+			).Return(&user, nil)
+
+			handler := MakeDebugHandler(svc, testConfig, nil, nil, nil)
+
+			req := httptest.NewRequest(http.MethodGet, "https://fleetdm.com/debug/pprof/cmdline", nil)
+			req.Header.Add("Authorization", "BEARER fake_session_key")
+			res := httptest.NewRecorder()
+
+			handler.ServeHTTP(res, req)
+			assert.Equal(t, http.StatusOK, res.Code)
+		})
+	}
 }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Addresses GHSA-rxhg-vcww-2mpw (residual call sites left by #44385)

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements).

## What & why

`#44385` migrated the deprecated `appendListOptionsWithCursorToSQL` (which sanitizes but does not allowlist the `order_key`) to the allowlist-based secure variant across the codebase. Two call sites were left behind in the activity bounded context after it was refactored to use `platform_mysql.AppendListOptionsWithParams`:

- `ListActivities` — powers `GET /api/v1/fleet/activities`
- `ListHostPastActivities` — powers `GET /api/v1/fleet/hosts/{id}/activities`

Both allowed sorting by any column name (the value was backtick-sanitized, so it was not SQL-injectable, but there was no allowlist). This migrates them to `AppendListOptionsWithParamsSecure` with an explicit `OrderKeyAllowlist`:

- List activities: `id`, `created_at`, `activity_type`, `user_id`, `user_name`, `user_email`, `streamed`, `fleet_initiated` (all columns already returned by the query).
- List host past activities: `id`, `created_at`, `activity_type` (matches the documented allowed fields).

Columns not returned by the query (`details`, `host_only`) are intentionally excluded so `order_key` cannot be used as an inference oracle. An unlisted key now returns `422 Unprocessable Entity` instead of being sorted on.

## Testing

- [x] Added/updated automated tests

  - Datastore unit tests assert unlisted keys (`details`, `host_only`, `user_email` for host activities, etc.) return `InvalidOrderKeyError`, and documented keys still succeed.
  - Integration tests assert the HTTP endpoints return `422` for an unlisted `order_key`.
- [x] QA'd via automated tests (`MYSQL_TEST=1 REDIS_TEST=1 go test ./server/activity/...`).

## Database migrations

N/A — no schema changes.

## New Fleet configuration settings

N/A.

## fleetd/orbit/Fleet Desktop

N/A.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted activity sorting to approved fields; unsupported `order_key` values now return a client validation error.
  * Corrected the default ordering for host activity history.
  * Prevented endpoint-restricted API-only access tokens from accessing debug and profiling endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->