### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/aws-cli/windows.json
+++ b/ee/maintained-apps/outputs/aws-cli/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.36.3",
+      "version": "2.36.4",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'AWS Command Line Interface v2 %' AND publisher = 'Amazon Web Services';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'AWS Command Line Interface v2 %' AND publisher = 'Amazon Web Services' AND version_compare(version, '2.36.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'AWS Command Line Interface v2 %' AND publisher = 'Amazon Web Services' AND version_compare(version, '2.36.4') < 0);"
       },
-      "installer_url": "https://awscli.amazonaws.com/AWSCLIV2-2.36.3.msi",
+      "installer_url": "https://awscli.amazonaws.com/AWSCLIV2-2.36.4.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "58bcd016",
-      "sha256": "a0b44e2273fce6a1e8a3a7787bc1aee73f17633d8b4d62c857848b1d06a52d60",
+      "sha256": "efd30424b75807bd0f4b79f090cedcec8a370fdd030e7c0d3514a42c6d9a22c7",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/aws-vpn-client/darwin.json
+++ b/ee/maintained-apps/outputs/aws-vpn-client/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "5.4.1",
+      "version": "5.4.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.amazonaws.acvc.osx';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.amazonaws.acvc.osx' AND version_compare(bundle_short_version, '5.4.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.amazonaws.acvc.osx' AND version_compare(bundle_short_version, '5.4.2') < 0);"
       },
-      "installer_url": "https://d20adtppz83p9s.cloudfront.net/OSX_ARM64/5.4.1/AWS_VPN_Client_ARM64.pkg",
+      "installer_url": "https://d20adtppz83p9s.cloudfront.net/OSX_ARM64/5.4.2/AWS_VPN_Client_ARM64.pkg",
       "install_script_ref": "53e8589e",
       "uninstall_script_ref": "695f03a0",
-      "sha256": "fc442adb7513d355de827ef3c1bece7c1a1b7bd924003a54e6821c0b832f2837",
+      "sha256": "a9778dd2ce7aff40f9b72f5d96156daf0d9049d958c6d1aeca8942a25c35debf",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/aws-vpn-client/windows.json
+++ b/ee/maintained-apps/outputs/aws-vpn-client/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "5.4.1",
+      "version": "5.4.2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'AWS VPN Client' AND publisher = 'Amazon';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'AWS VPN Client' AND publisher = 'Amazon' AND version_compare(version, '5.4.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'AWS VPN Client' AND publisher = 'Amazon' AND version_compare(version, '5.4.2') < 0);"
       },
-      "installer_url": "https://d20adtppz83p9s.cloudfront.net/WPF/5.4.1/AWS_VPN_Client.msi",
+      "installer_url": "https://d20adtppz83p9s.cloudfront.net/WPF/5.4.2/AWS_VPN_Client.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "ff441c4a",
-      "sha256": "010278c7e8cfefaac0bc7ab17d51a80693b10388344d5e46b313e41f279e2863",
+      "sha256": "de6ede73c4a8de70d6e21b5c5d54b2b0c496eab788234e981467b721dbf31c9c",
       "default_categories": [
         "Productivity"
       ],

--- a/ee/maintained-apps/outputs/typora/windows.json
+++ b/ee/maintained-apps/outputs/typora/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.13.7",
+      "version": "1.14.6",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Typora' AND publisher = 'typora.io';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Typora' AND publisher = 'typora.io' AND version_compare(version, '1.13.7') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Typora' AND publisher = 'typora.io' AND version_compare(version, '1.14.6') < 0);"
       },
-      "installer_url": "https://downloads.typora.io/windows/typora-setup-x64-1.13.7.exe",
+      "installer_url": "https://downloads.typora.io/windows/typora-setup-x64-1.14.6.exe",
       "install_script_ref": "cf428c2f",
       "uninstall_script_ref": "56e4e60f",
-      "sha256": "04dc5d0ec1ddae9ab1d405be578c2d486e48cca9295029f79d532db80032ab40",
+      "sha256": "8ba0106792bee94003c619a0e19152381904f5b35757838a9bac9c5a596d1c8e",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/wispr-flow/darwin.json
+++ b/ee/maintained-apps/outputs/wispr-flow/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.6.122",
+      "version": "1.6.168",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.wispr-flow';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.wispr-flow' AND version_compare(bundle_short_version, '1.6.122') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.wispr-flow' AND version_compare(bundle_short_version, '1.6.168') < 0);"
       },
-      "installer_url": "https://dl.wisprflow.com/wispr-flow/darwin/arm64/dmgs/Flow-v1.6.122.dmg",
+      "installer_url": "https://dl.wisprflow.com/wispr-flow/darwin/arm64/dmgs/Flow-v1.6.168.dmg",
       "install_script_ref": "3a49fcfd",
       "uninstall_script_ref": "e0cf2e96",
-      "sha256": "0762e5fcc14710c7201d2d965ef573d08b804d681d2dc0ba55b690ef7ebf6de8",
+      "sha256": "a70a7438125b9119608c4b9ee7bdb29d181a54a6ac3cb18e9a140e48d13b880a",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated AWS CLI for Windows to version 2.36.4.
  - Updated AWS VPN Client for macOS and Windows to version 5.4.2.
  - Updated Typora for Windows to version 1.14.6.
  - Updated Wispr Flow for macOS to version 1.6.168.
  - Refreshed installer download links, checksums, and version detection for each release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->