### PR TITLE
update nanodep with disown endpoint

### DIFF
--- a/server/mdm/nanodep/README.md
+++ b/server/mdm/nanodep/README.md
@@ -1,6 +1,6 @@
 # NanoDEP
 
-> The contents of this directory were copied (on February 2024) from https://github.com/fleetdm/nanomdm (the `apple-mdm` branch) which was forked from https://github.com/micromdm/nanodep. Check [UPSTREAM_COMMIT](./UPSTREAM_COMMIT) for the commit hash of the original repository the current code has.
+> The contents of this directory were copied (on February 2024) from https://github.com/fleetdm/nanomdm (the `apple-mdm` branch) which was forked from https://github.com/micromdm/nanodep. Check [UPSTREAM_COMMIT](./UPSTREAM_COMMIT) for the commit hash of the original repository the current code in this repository is on.
 
 [![Go](https://github.com/micromdm/nanodep/workflows/Go/badge.svg)](https://github.com/micromdm/nanodep/actions) [![Go Reference](https://pkg.go.dev/badge/github.com/micromdm/nanodep.svg)](https://pkg.go.dev/github.com/micromdm/nanodep)
 

--- a/server/mdm/nanodep/README.md
+++ b/server/mdm/nanodep/README.md
@@ -1,6 +1,6 @@
 # NanoDEP
 
-> The contents of this directory were copied (on February 2024) from https://github.com/fleetdm/nanomdm (the `apple-mdm` branch) which was forked from https://github.com/micromdm/nanodep.
+> The contents of this directory were copied (on February 2024) from https://github.com/fleetdm/nanomdm (the `apple-mdm` branch) which was forked from https://github.com/micromdm/nanodep. Check [UPSTREAM_COMMIT](./UPSTREAM_COMMIT) for the commit hash of the original repository the current code has.
 
 [![Go](https://github.com/micromdm/nanodep/workflows/Go/badge.svg)](https://github.com/micromdm/nanodep/actions) [![Go Reference](https://pkg.go.dev/badge/github.com/micromdm/nanodep.svg)](https://pkg.go.dev/github.com/micromdm/nanodep)
 

--- a/server/mdm/nanodep/UPSTREAM_COMMIT
+++ b/server/mdm/nanodep/UPSTREAM_COMMIT
@@ -1,0 +1,1 @@
+4c207e8ca75308fc9bcca4b6d7ea3bcf84a40d72

--- a/server/mdm/nanodep/client/transport.go
+++ b/server/mdm/nanodep/client/transport.go
@@ -221,6 +221,10 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 			sessionURL.String(),
 			nil,
 		)
+		if userAgent := req.Header.Get("User-Agent"); userAgent != "" {
+			// copy the UA from the original request to the auth request
+			sessionReq.Header.Set("User-Agent", userAgent)
+		}
 		if err != nil {
 			return nil, fmt.Errorf("transport: creating session request: %w", err)
 		}

--- a/server/mdm/nanodep/client/transport.go
+++ b/server/mdm/nanodep/client/transport.go
@@ -221,12 +221,12 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 			sessionURL.String(),
 			nil,
 		)
+		if err != nil {
+			return nil, fmt.Errorf("transport: creating session request: %w", err)
+		}
 		if userAgent := req.Header.Get("User-Agent"); userAgent != "" {
 			// copy the UA from the original request to the auth request
 			sessionReq.Header.Set("User-Agent", userAgent)
-		}
-		if err != nil {
-			return nil, fmt.Errorf("transport: creating session request: %w", err)
 		}
 
 		// use the same version header from the original request (which we

--- a/server/mdm/nanodep/godep/device.go
+++ b/server/mdm/nanodep/godep/device.go
@@ -115,6 +115,30 @@ func (c *Client) GetDeviceDetails(ctx context.Context, name, serialNumber string
 	return resp.Devices[serialNumber], nil
 }
 
+type DeviceStatusResponse struct {
+	Devices map[string]DeviceStatusResponseJsonDevicesValue `json:"devices,omitempty"`
+}
+
+type DeviceStatusResponseJsonDevicesValue string
+
+const (
+	DeviceStatusResponseJsonDevicesValueFailed        DeviceStatusResponseJsonDevicesValue = "FAILED"
+	DeviceStatusResponseJsonDevicesValueNotAccessible DeviceStatusResponseJsonDevicesValue = "NOT_ACCESSIBLE"
+	DeviceStatusResponseJsonDevicesValueSuccess       DeviceStatusResponseJsonDevicesValue = "SUCCESS"
+)
+
+// DisownDevices uses the Apple "Disown Devices" API endpoint to disown the
+// specified devices, identified by their serial numbers. Disowning a device
+// releases it from Apple Business.
+// See https://developer.apple.com/documentation/devicemanagement/disown-devices
+func (c *Client) DisownDevices(ctx context.Context, name string, serialNumbers ...string) (*DeviceStatusResponse, error) {
+	request := struct {
+		Devices []string `json:"devices"`
+	}{Devices: serialNumbers}
+	resp := new(DeviceStatusResponse)
+	return resp, c.doWithAfterHook(ctx, name, http.MethodPost, "/devices/disown", request, resp)
+}
+
 // IsCursorExhausted returns true if err is a DEP "exhausted cursor" error.
 func IsCursorExhausted(err error) bool {
 	return httpErrorContains(err, http.StatusBadRequest, "EXHAUSTED_CURSOR")

--- a/server/mdm/nanodep/godep/device.go
+++ b/server/mdm/nanodep/godep/device.go
@@ -116,15 +116,15 @@ func (c *Client) GetDeviceDetails(ctx context.Context, name, serialNumber string
 }
 
 type DeviceStatusResponse struct {
-	Devices map[string]DeviceStatusResponseJsonDevicesValue `json:"devices,omitempty"`
+	Devices map[string]DeviceStatus `json:"devices,omitempty"`
 }
 
-type DeviceStatusResponseJsonDevicesValue string
+type DeviceStatus string
 
 const (
-	DeviceStatusResponseJsonDevicesValueFailed        DeviceStatusResponseJsonDevicesValue = "FAILED"
-	DeviceStatusResponseJsonDevicesValueNotAccessible DeviceStatusResponseJsonDevicesValue = "NOT_ACCESSIBLE"
-	DeviceStatusResponseJsonDevicesValueSuccess       DeviceStatusResponseJsonDevicesValue = "SUCCESS"
+	DeviceStatusFailed        DeviceStatus = "FAILED"
+	DeviceStatusNotAccessible DeviceStatus = "NOT_ACCESSIBLE"
+	DeviceStatusSuccess       DeviceStatus = "SUCCESS"
 )
 
 // DisownDevices uses the Apple "Disown Devices" API endpoint to disown the


### PR DESCRIPTION
prep work for #49367

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for disowning Apple DEP devices, returning per-device results (successful, failed, and inaccessible).

* **Bug Fixes**
  * Improved consistency of authentication-related requests by carrying over the original `User-Agent` when it is set.

* **Chores**
  * Updated the bundled upstream dependency to a newer commit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->