### PR TITLE
Improve custom host vital missing-value error message

### DIFF
--- a/server/datastore/mysql/custom_host_vitals.go
+++ b/server/datastore/mysql/custom_host_vitals.go
@@ -444,7 +444,9 @@ func (ds *Datastore) ExpandCustomHostVitals(ctx context.Context, hostID uint, do
 	// A vital with an empty value counts as missing: we refuse to ship an empty
 	// substitution.
 	valueByID := make(map[uint]string, len(vitals))
+	nameByID := make(map[uint]string, len(vitals))
 	for _, v := range vitals {
+		nameByID[v.CustomHostVitalID] = v.Name
 		if v.Value == "" {
 			continue
 		}
@@ -452,14 +454,16 @@ func (ds *Datastore) ExpandCustomHostVitals(ctx context.Context, hostID uint, do
 	}
 
 	var missingIDs []uint
+	var missingNames []string
 	for _, id := range refIDs {
 		if _, ok := valueByID[id]; !ok {
 			missingIDs = append(missingIDs, id)
+			missingNames = append(missingNames, nameByID[id])
 		}
 	}
 	if len(missingIDs) > 0 {
 		// The vital exists (validated on upload); the host just has no value for it.
-		return "", &fleet.MissingCustomHostVitalValueError{MissingIDs: missingIDs}
+		return "", &fleet.MissingCustomHostVitalValueError{MissingIDs: missingIDs, MissingNames: missingNames}
 	}
 
 	expanded := expandDocumentVars(document, func(s string) (string, bool) {

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -224,7 +224,8 @@ func testGetSoftwareInstallDetailsCustomHostVitals(t *testing.T, ds *Datastore) 
 	_, err = ds.GetSoftwareInstallDetails(ctx, execID2)
 	var missing *fleet.MissingCustomHostVitalValueError
 	require.ErrorAs(t, err, &missing)
-	require.Equal(t, []uint{dept.ID}, missing.MissingIDs) //nolint:nilaway // cannot be nil due to require.ErrorAs above
+	require.Equal(t, []uint{dept.ID}, missing.MissingIDs)          //nolint:nilaway // cannot be nil due to require.ErrorAs above
+	require.Equal(t, []string{"Department"}, missing.MissingNames) //nolint:nilaway // cannot be nil due to require.ErrorAs above
 }
 
 func testListPendingSoftwareInstalls(t *testing.T, ds *Datastore) {

--- a/server/fleet/custom_host_vitals.go
+++ b/server/fleet/custom_host_vitals.go
@@ -83,18 +83,26 @@ func (e InvalidCustomHostVitalRefError) Error() string {
 // so the delivery failure detail shown to admins names the real cause.
 type MissingCustomHostVitalValueError struct {
 	MissingIDs []uint
+	MissingNames []string
 }
 
 func (e MissingCustomHostVitalValueError) Error() string {
 	tokens := make([]string, 0, len(e.MissingIDs))
-	for _, id := range e.MissingIDs {
-		tokens = append(tokens, fmt.Sprintf("\"$%s%d\"", CustomHostVitalPrefix, id))
+	for i, id := range e.MissingIDs {
+		var name string
+		if i < len(e.MissingNames) {
+			name = e.MissingNames[i]
+		}
+		tokens = append(tokens, fmt.Sprintf("%s ($%s%d)", name, CustomHostVitalPrefix, id))
 	}
 	plural := ""
 	if len(tokens) > 1 {
 		plural = "s"
 	}
-	return fmt.Sprintf("Couldn't populate custom host vital%s %s: no value set for this host", plural, strings.Join(tokens, ", "))
+	return fmt.Sprintf(
+		"Couldn't populate the custom host vital%s %s because there's no value set for this host.",
+		plural, strings.Join(tokens, ", "),
+	)
 }
 
 // CustomHostVitalEntity identifies the kind of entity that can reference a custom host vital.

--- a/server/fleet/custom_host_vitals.go
+++ b/server/fleet/custom_host_vitals.go
@@ -82,7 +82,7 @@ func (e InvalidCustomHostVitalRefError) Error() string {
 // Distinct from MissingCustomHostVitalsError (upload-time: the id doesn't exist)
 // so the delivery failure detail shown to admins names the real cause.
 type MissingCustomHostVitalValueError struct {
-	MissingIDs []uint
+	MissingIDs   []uint
 	MissingNames []string
 }
 

--- a/server/fleet/custom_host_vitals_test.go
+++ b/server/fleet/custom_host_vitals_test.go
@@ -46,14 +46,17 @@ func TestMissingCustomHostVitalsError(t *testing.T) {
 }
 
 func TestMissingCustomHostVitalValueError(t *testing.T) {
-	single := MissingCustomHostVitalValueError{MissingIDs: []uint{5}}
-	require.Contains(t, single.Error(), `"$FLEET_HOST_VITAL_5"`)
-	require.Contains(t, single.Error(), "no value set for this host")
+	single := MissingCustomHostVitalValueError{MissingIDs: []uint{5}, MissingNames: []string{"Asset tag"}}
+	require.Equal(
+		t,
+		"Couldn't populate the custom host vital Asset tag ($FLEET_HOST_VITAL_5) because there's no value set for this host.",
+		single.Error(),
+	)
 	// Distinct from the upload-time "is not defined" wording.
 	require.NotContains(t, single.Error(), "is not defined")
 
-	multi := MissingCustomHostVitalValueError{MissingIDs: []uint{5, 9}}
+	multi := MissingCustomHostVitalValueError{MissingIDs: []uint{5, 9}, MissingNames: []string{"Asset tag", "Department"}}
 	require.Contains(t, multi.Error(), "custom host vitals")
-	require.Contains(t, multi.Error(), `"$FLEET_HOST_VITAL_5"`)
-	require.Contains(t, multi.Error(), `"$FLEET_HOST_VITAL_9"`)
+	require.Contains(t, multi.Error(), "Asset tag ($FLEET_HOST_VITAL_5)")
+	require.Contains(t, multi.Error(), "Department ($FLEET_HOST_VITAL_9)")
 }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #44954

When a custom host vital referenced in a script or profile has no value set for a host, the delivery failure detail didn't name the vital, making it hard for admins to tell which one needed a value. The message now includes both the vital's name and its `$FLEET_HOST_VITAL_<id>` token.

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved missing custom host vital error messages by including both the vital name and its corresponding environment variable identifier.
  - Updated the wording to be clearer about why values can’t be populated when no value is set for the host.
  - Kept singular vs. plural messaging correct when one or multiple vital values are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->