### PR TITLE
Exclude non-existent host IDs from host transfer activity

### DIFF
--- a/changes/16782-host-transfer-activity-forged-ids
+++ b/changes/16782-host-transfer-activity-forged-ids
@@ -1,0 +1,1 @@
+- Fixed the host transfer activity (`transferred_hosts`) to only record host IDs that actually exist, so non-existent host IDs passed to `POST /api/latest/fleet/hosts/transfer` can no longer be injected into the audit trail. No activity is created when none of the requested hosts exist.

--- a/cmd/fleetctl/fleetctl/hosts_test.go
+++ b/cmd/fleetctl/fleetctl/hosts_test.go
@@ -65,7 +65,7 @@ func TestHostsTransferByHosts(t *testing.T) {
 	}
 
 	ds.ListHostsLiteByIDsFunc = func(ctx context.Context, ids []uint) ([]*fleet.Host, error) {
-		return nil, nil
+		return []*fleet.Host{{ID: 42}}, nil
 	}
 	ds.ListMDMAndroidUUIDsToHostIDsFunc = func(ctx context.Context, hostIDs []uint) (map[string]uint, error) {
 		return map[string]uint{}, nil

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -1363,15 +1363,24 @@ func (svc *Service) createTransferredHostsActivity(ctx context.Context, teamID *
 			hostsByID[h.ID] = h
 		}
 
+		// Derive the activity's host IDs and names exclusively from the hosts
+		// that actually exist, preserving the requested order. IDs that don't
+		// resolve to a host (e.g. non-existent IDs in the request, or a host
+		// deleted right after the transfer) are excluded so they can't be
+		// injected into the audit trail.
+		existingIDs := make([]uint, 0, len(hostIDs))
 		hostNames = make([]string, 0, len(hostIDs))
 		for _, hid := range hostIDs {
 			if h, ok := hostsByID[hid]; ok {
+				existingIDs = append(existingIDs, hid)
 				hostNames = append(hostNames, h.DisplayName())
-			} else {
-				// should not happen unless a host gets deleted just after transfer,
-				// but this ensures hostNames always matches hostIDs at the same index
-				hostNames = append(hostNames, "")
 			}
+		}
+		hostIDs = existingIDs
+
+		// If none of the requested hosts exist, there's nothing to record.
+		if len(hostIDs) == 0 {
+			return nil
 		}
 	}
 

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -4040,6 +4040,28 @@ func (s *integrationTestSuite) TestHostsAddToTeam() {
 		0,
 	)
 
+	// transferring a mix of real and non-existent host IDs must not record the
+	// fabricated IDs in the activity: only hosts that actually exist are logged.
+	nonExistentHostID := hosts[2].ID + 1000
+	s.DoJSON("POST", "/api/latest/fleet/hosts/transfer", addHostsToTeamRequest{
+		TeamID:  &tm1.ID,
+		HostIDs: []uint{hosts[0].ID, nonExistentHostID},
+	}, http.StatusOK, &addResp)
+	mixedActivityID := s.lastActivityOfTypeMatches(
+		fleet.ActivityTypeTransferredHostsToTeam{}.ActivityName(),
+		fmt.Sprintf(`{"fleet_id": %d, "fleet_name": %q, "team_id": %d, "team_name": %q, "host_ids": [%d], "host_display_names": [%q]}`,
+			tm1.ID, tm1.Name, tm1.ID, tm1.Name, hosts[0].ID, hosts[0].DisplayName()),
+		0,
+	)
+
+	// transferring only non-existent host IDs must not record any activity: the
+	// latest transferred_hosts activity is still the mixed transfer above.
+	s.DoJSON("POST", "/api/latest/fleet/hosts/transfer", addHostsToTeamRequest{
+		TeamID:  &tm1.ID,
+		HostIDs: []uint{nonExistentHostID},
+	}, http.StatusOK, &addResp)
+	s.lastActivityOfTypeMatches(fleet.ActivityTypeTransferredHostsToTeam{}.ActivityName(), "", mixedActivityID)
+
 	// check that hosts are now part of team 1
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d", hosts[0].ID), nil, http.StatusOK, &getResp)
 	require.NotNil(t, getResp.Host.TeamID)


### PR DESCRIPTION
The host transfer endpoint recorded raw requested host IDs in the transferred_hosts activity verbatim, letting an authorized user inject fabricated IDs into the audit trail. Derive the activity's host IDs and names only from hosts that actually exist, and skip the activity when none exist.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved host transfer audit trail to include only host IDs that actually exist.
  * Transfer requests containing only invalid/non-existent host IDs no longer create transfer activity.
  * Mixed requests (valid + invalid IDs) now record activity for valid hosts only.
* **Tests**
  * Added/extended coverage to confirm correct audit trail behavior for mixed and all-invalid transfer requests.
  * Updated host lookup test data to better reflect the transfer flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->