### PR TITLE
Fix Windows Autopilot ESP hang: gate release on user-scope ack (#49134) (#49542)

### DIFF
--- a/changes/49134-windows-esp-user-release-retry
+++ b/changes/49134-windows-esp-user-release-retry
@@ -1,0 +1,1 @@
+- Fixed Windows Autopilot enrollments intermittently hanging on the Enrollment Status Page at "Account setup".

--- a/server/datastore/mysql/microsoft_mdm.go
+++ b/server/datastore/mysql/microsoft_mdm.go
@@ -926,6 +926,43 @@ ORDER BY
 	return commands, nil
 }
 
+// MDMWindowsGetESPReleaseAckStatus summarizes the delivery state of ESP release commands targeting the given LocURI for
+// the enrollment. Attempts are matched on BOTH the target LocURI and the command_uuid prefix Fleet stamps on its own
+// release attempts, so an admin-enqueued raw command that happens to target the same LocURI can neither trigger the
+// resend phase nor complete the ESP.
+func (ds *Datastore) MDMWindowsGetESPReleaseAckStatus(ctx context.Context, enrollmentID uint, targetLocURI, cmdUUIDPrefix string) (*fleet.MDMWindowsESPReleaseAckStatus, error) {
+	const query = `
+SELECT
+	COUNT(*) > 0 AS attempted,
+	COALESCE(MAX(r.status_code = '200'), FALSE) AS acked200,
+	COALESCE(MAX(wmcq.acked_at IS NULL), FALSE) AS has_unacked,
+	COALESCE(SUBSTRING_INDEX(GROUP_CONCAT(r.status_code ORDER BY wmcq.acked_at DESC), ',', 1), '') AS latest_status
+FROM
+	windows_mdm_command_queue wmcq
+INNER JOIN
+	windows_mdm_commands wmc ON wmc.command_uuid = wmcq.command_uuid
+LEFT JOIN
+	windows_mdm_command_results r ON r.enrollment_id = wmcq.enrollment_id AND r.command_uuid = wmcq.command_uuid
+WHERE
+	wmcq.enrollment_id = ? AND wmc.target_loc_uri = ? AND wmc.command_uuid LIKE CONCAT(?, '%')
+`
+	var row struct {
+		Attempted    bool   `db:"attempted"`
+		Acked200     bool   `db:"acked200"`
+		HasUnacked   bool   `db:"has_unacked"`
+		LatestStatus string `db:"latest_status"`
+	}
+	if err := sqlx.GetContext(ctx, ds.reader(ctx), &row, query, enrollmentID, targetLocURI, cmdUUIDPrefix); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "get Windows ESP release ack status")
+	}
+	return &fleet.MDMWindowsESPReleaseAckStatus{
+		Attempted:    row.Attempted,
+		Acked200:     row.Acked200,
+		HasUnacked:   row.HasUnacked,
+		LatestStatus: row.LatestStatus,
+	}, nil
+}
+
 // compressWindowsMDMResponse gzip-compresses a full SyncML response envelope
 func compressWindowsMDMResponse(raw []byte) ([]byte, error) {
 	var buf bytes.Buffer

--- a/server/datastore/mysql/microsoft_mdm_test.go
+++ b/server/datastore/mysql/microsoft_mdm_test.go
@@ -43,6 +43,7 @@ func TestMDMWindows(t *testing.T) {
 		{"TestMDMWindowsBulkInsertCommands", testMDMWindowsBulkInsertCommands},
 		{"TestMDMWindowsInsertCommandAndUpsertHostProfilesForHosts", testMDMWindowsInsertCommandAndUpsertHostProfilesForHosts},
 		{"TestMDMWindowsGetPendingCommands", testMDMWindowsGetPendingCommands},
+		{"TestMDMWindowsGetESPReleaseAckStatus", testMDMWindowsGetESPReleaseAckStatus},
 		{"TestMDMWindowsCommandResults", testMDMWindowsCommandResults},
 		{"TestMDMWindowsCommandResultsWithPendingResult", testMDMWindowsCommandResultsWithPendingResult},
 		{"TestMDMWindowsProfileManagement", testMDMWindowsProfileManagement},
@@ -2179,6 +2180,93 @@ func testMDMWindowsGetHostConfigState(t *testing.T, ds *Datastore) {
 	state, err = ds.GetMDMWindowsHostConfigState(ctx, d.HostUUID)
 	require.NoError(t, err)
 	require.True(t, state.HasPendingCommands, "a non-poll pending command must still count")
+}
+
+func testMDMWindowsGetESPReleaseAckStatus(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	dev := createEnrolledDevice(t, ds)
+
+	const releaseURI = "./User/Vendor/MSFT/DMClient/Provider/Fleet/FirstSyncStatus/ServerHasFinishedProvisioning"
+	const attemptPrefix = "esp-release-"
+
+	// insertCmd enqueues a command through the production insert path.
+	insertCmd := func(t *testing.T, cmdUUID, uri string) {
+		t.Helper()
+		require.NoError(t, ds.MDMWindowsInsertCommandForHosts(ctx, []string{dev.MDMDeviceID}, &fleet.MDMWindowsCommand{
+			CommandUUID:  cmdUUID,
+			RawCommand:   []byte("<Replace/>"),
+			TargetLocURI: uri,
+		}))
+	}
+	insertAttempt := func(t *testing.T, uri string) string {
+		t.Helper()
+		cmdUUID := attemptPrefix + uuid.NewString()
+		insertCmd(t, cmdUUID, uri)
+		return cmdUUID
+	}
+	// ackAttempt mirrors MDMWindowsSaveResponse's ack transaction (result row insert + acked_at stamp) with
+	// direct inserts: the only datastore method that records results is SaveResponse itself, which needs a full
+	// SyncML envelope. Same convention as testMDMWindowsCommandResults.
+	ackAttempt := func(t *testing.T, cmdUUID, statusCode string) {
+		t.Helper()
+		compressed, err := compressWindowsMDMResponse([]byte("resp"))
+		require.NoError(t, err)
+		res, err := ds.writer(ctx).ExecContext(ctx,
+			`INSERT INTO windows_mdm_responses (enrollment_id, raw_response_gz) VALUES (?, ?)`, dev.ID, compressed)
+		require.NoError(t, err)
+		responseID, err := res.LastInsertId()
+		require.NoError(t, err)
+		_, err = ds.writer(ctx).ExecContext(ctx,
+			`INSERT INTO windows_mdm_command_results (enrollment_id, command_uuid, raw_result, response_id, status_code) VALUES (?, ?, '', ?, ?)`,
+			dev.ID, cmdUUID, responseID, statusCode)
+		require.NoError(t, err)
+		_, err = ds.writer(ctx).ExecContext(ctx,
+			`UPDATE windows_mdm_command_queue SET acked_at = NOW(6) WHERE enrollment_id = ? AND command_uuid = ?`,
+			dev.ID, cmdUUID)
+		require.NoError(t, err)
+	}
+	requireAck := func(t *testing.T, enrollmentID uint, want fleet.MDMWindowsESPReleaseAckStatus) {
+		t.Helper()
+		ack, err := ds.MDMWindowsGetESPReleaseAckStatus(ctx, enrollmentID, releaseURI, attemptPrefix)
+		require.NoError(t, err)
+		require.Equal(t, &want, ack)
+	}
+
+	// No attempts queued at all.
+	requireAck(t, dev.ID, fleet.MDMWindowsESPReleaseAckStatus{})
+
+	// Commands targeting other URIs don't count as attempts.
+	otherURIUUID := insertAttempt(t, "./Device/Vendor/MSFT/DMClient/Provider/Fleet/FirstSyncStatus/ServerHasFinishedProvisioning")
+	ackAttempt(t, otherURIUUID, "200")
+	requireAck(t, dev.ID, fleet.MDMWindowsESPReleaseAckStatus{})
+
+	// A command targeting the release URI WITHOUT the Fleet attempt prefix (e.g. an admin-enqueued raw
+	// command) doesn't count either: it must neither trigger the resend phase nor complete the ESP.
+	rawCmdUUID := uuid.NewString()
+	insertCmd(t, rawCmdUUID, releaseURI)
+	ackAttempt(t, rawCmdUUID, "200")
+	requireAck(t, dev.ID, fleet.MDMWindowsESPReleaseAckStatus{})
+
+	// One queued attempt, no response yet: in flight.
+	firstAttempt := insertAttempt(t, releaseURI)
+	requireAck(t, dev.ID, fleet.MDMWindowsESPReleaseAckStatus{Attempted: true, HasUnacked: true})
+
+	// The device rejects it with 405 (user MDM context not initialized yet).
+	ackAttempt(t, firstAttempt, "405")
+	requireAck(t, dev.ID, fleet.MDMWindowsESPReleaseAckStatus{Attempted: true, LatestStatus: "405"})
+
+	// A retry is queued: back in flight, latest acked status still the 405.
+	retryAttempt := insertAttempt(t, releaseURI)
+	requireAck(t, dev.ID, fleet.MDMWindowsESPReleaseAckStatus{Attempted: true, HasUnacked: true, LatestStatus: "405"})
+
+	// The retry acks 200: release confirmed, and the latest status reflects the newest ack.
+	ackAttempt(t, retryAttempt, "200")
+	requireAck(t, dev.ID, fleet.MDMWindowsESPReleaseAckStatus{Attempted: true, Acked200: true, LatestStatus: "200"})
+
+	// Another enrollment's attempts are invisible.
+	otherDev := createEnrolledDevice(t, ds)
+	requireAck(t, otherDev.ID, fleet.MDMWindowsESPReleaseAckStatus{})
 }
 
 func testMDMWindowsCommandResults(t *testing.T, ds *Datastore) {

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2335,6 +2335,11 @@ type Datastore interface {
 	// MDMWindowsGetPendingCommands returns all pending commands for the given enrollment.
 	MDMWindowsGetPendingCommands(ctx context.Context, enrollmentID uint) ([]*MDMWindowsCommand, error)
 
+	// MDMWindowsGetESPReleaseAckStatus summarizes the delivery state of ESP release commands targeting the given LocURI
+	// for the enrollment: whether any attempt was queued, whether any acked 200, whether one is still in flight, and the
+	// most recent acked status.
+	MDMWindowsGetESPReleaseAckStatus(ctx context.Context, enrollmentID uint, targetLocURI, cmdUUIDPrefix string) (*MDMWindowsESPReleaseAckStatus, error)
+
 	// MDMWindowsRefreshHasPendingCommands recomputes the denormalized has_pending_commands flag for the enrollment.
 	// Called at most once per OMA-DM session, when the pending-commands fetch comes back empty (the session has drained
 	// the queue and the flag may flip to 0); mid-session messages skip it since the flag provably stays 1.

--- a/server/fleet/microsoft_mdm.go
+++ b/server/fleet/microsoft_mdm.go
@@ -883,6 +883,20 @@ const (
 	WindowsMDMAwaitingConfigurationActive WindowsMDMAwaitingConfiguration = 2
 )
 
+// MDMWindowsESPReleaseAckStatus summarizes the delivery state of the ESP release command that completes the
+// Windows Autopilot "Account setup" phase (the user-scope ServerHasFinishedProvisioning Replace).
+type MDMWindowsESPReleaseAckStatus struct {
+	// Attempted is true when at least one release command targeting the URI has been queued for the enrollment.
+	Attempted bool
+	// Acked200 is true when any attempt has a recorded 200 result.
+	Acked200 bool
+	// HasUnacked is true when an attempt is still queued without any response (in flight).
+	HasUnacked bool
+	// LatestStatus is the status code of the most recently acked attempt ("405", "200", ...), empty when no
+	// attempt has a recorded result yet.
+	LatestStatus string
+}
+
 // MDMWindowsHostConfigState is the per-host Windows MDM state read in a single query on each orbit config check-in for a connected Windows
 // host: the Autopilot ESP awaiting-configuration value and whether the host's most recent Windows MDM enrollment has queued, unacknowledged
 // MDM commands. Reading both in one query keeps the hot orbit config path to a single round trip.

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1406,6 +1406,8 @@ type MDMWindowsEnqueueCommandAndUpsertHostProfilesFunc func(ctx context.Context,
 
 type MDMWindowsGetPendingCommandsFunc func(ctx context.Context, enrollmentID uint) ([]*fleet.MDMWindowsCommand, error)
 
+type MDMWindowsGetESPReleaseAckStatusFunc func(ctx context.Context, enrollmentID uint, targetLocURI string, cmdUUIDPrefix string) (*fleet.MDMWindowsESPReleaseAckStatus, error)
+
 type MDMWindowsRefreshHasPendingCommandsFunc func(ctx context.Context, enrollmentID uint) error
 
 type MDMWindowsSaveResponseFunc func(ctx context.Context, enrolledDevice *fleet.MDMWindowsEnrolledDevice, enrichedSyncML fleet.EnrichedSyncML, commandIDsBeingResent []string) (*fleet.MDMWindowsSaveResponseResult, error)
@@ -4309,6 +4311,9 @@ type DataStore struct {
 
 	MDMWindowsGetPendingCommandsFunc        MDMWindowsGetPendingCommandsFunc
 	MDMWindowsGetPendingCommandsFuncInvoked bool
+
+	MDMWindowsGetESPReleaseAckStatusFunc        MDMWindowsGetESPReleaseAckStatusFunc
+	MDMWindowsGetESPReleaseAckStatusFuncInvoked bool
 
 	MDMWindowsRefreshHasPendingCommandsFunc        MDMWindowsRefreshHasPendingCommandsFunc
 	MDMWindowsRefreshHasPendingCommandsFuncInvoked bool
@@ -10393,6 +10398,13 @@ func (s *DataStore) MDMWindowsGetPendingCommands(ctx context.Context, enrollment
 	s.MDMWindowsGetPendingCommandsFuncInvoked = true
 	s.mu.Unlock()
 	return s.MDMWindowsGetPendingCommandsFunc(ctx, enrollmentID)
+}
+
+func (s *DataStore) MDMWindowsGetESPReleaseAckStatus(ctx context.Context, enrollmentID uint, targetLocURI string, cmdUUIDPrefix string) (*fleet.MDMWindowsESPReleaseAckStatus, error) {
+	s.mu.Lock()
+	s.MDMWindowsGetESPReleaseAckStatusFuncInvoked = true
+	s.mu.Unlock()
+	return s.MDMWindowsGetESPReleaseAckStatusFunc(ctx, enrollmentID, targetLocURI, cmdUUIDPrefix)
 }
 
 func (s *DataStore) MDMWindowsRefreshHasPendingCommands(ctx context.Context, enrollmentID uint) error {

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -9351,82 +9351,136 @@ func (s *integrationMDMTestSuite) TestWindowsAutopilotESPCommands() {
 	t := s.T()
 	ctx := context.Background()
 
-	// Set up enroll secret and Entra tenant
+	// Shared setup: enroll secret, Entra tenant, and a team with no profiles or setup-experience items, so every release
+	// gate passes at the first Active checkin. The scenarios verify the state transitions (Pending -> Active -> None)
+	// without needing profile delivery.
 	err := s.ds.ApplyEnrollSecrets(ctx, nil, []*fleet.EnrollSecret{{Secret: t.Name()}})
 	require.NoError(t, err)
 	tenantID := uuid.New().String()
 	acResp := appConfigResponse{}
 	s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(`{ "mdm": { "windows_entra_tenant_ids": ["`+tenantID+`"] } }`), http.StatusOK, &acResp)
-
-	// Enroll device via Autopilot (Automatic + InOOBE -> awaiting_configuration=Pending)
-	azureMail := "esp-test@example.com"
-	d := mdmtest.NewTestMDMClientWindowsAutomatic(s.server.URL, azureMail, mdmtest.TestWindowsMDMClientWithSigningKeyAndTenantID(s.jwtSigningKey, defaultFakeJWTKeyID, tenantID))
-	require.NoError(t, d.Enroll())
-
-	// First checkin: receive fleetd install commands (and possibly ESP hold
-	// commands), ack all of them.
-	cmds, err := d.StartManagementSession()
-	require.NoError(t, err)
-	msgID, err := d.GetCurrentMsgID()
-	require.NoError(t, err)
-	for _, c := range cmds {
-		if c.Verb == "Status" {
-			continue
-		}
-		d.AppendResponse(fleet.SyncMLCmd{
-			XMLName: xml.Name{Local: fleet.CmdStatus},
-			MsgRef:  &msgID, CmdRef: &c.Cmd.CmdID.Value,
-			Cmd: &c.Verb, Data: ptr.String("200"),
-			CmdID: fleet.CmdID{Value: uuid.NewString()},
-		})
-	}
-	_, err = d.SendResponse()
-	require.NoError(t, err)
-
-	// Create a team first, then simulate fleetd installed on that team
 	tm, err := s.ds.NewTeam(ctx, &fleet.Team{Name: t.Name()})
 	require.NoError(t, err)
 
-	host := createOrbitEnrolledHost(t, "windows", "esp-h1", s.ds)
-	// Transfer host to the team via the API
-	s.DoJSON("POST", "/api/latest/fleet/hosts/transfer", addHostsToTeamRequest{
-		TeamID:  &tm.ID,
-		HostIDs: []uint{host.ID},
-	}, http.StatusOK, &addHostsToTeamResponse{})
-
-	updated, err := s.ds.UpdateMDMWindowsEnrollmentsHostUUID(ctx, host.UUID, d.DeviceID)
-	require.NoError(t, err)
-	require.True(t, updated)
-	err = s.ds.SetOrUpdateHostOrbitInfo(ctx, host.ID, "1.23", sql.NullString{}, sql.NullBool{})
-	require.NoError(t, err)
-
-	// No profiles added to the team -- the test verifies state transitions
-	// (Pending → Active → None) without needing profile delivery.
-
-	// First management checkin after orbit links: device transitions to Active.
-	_, err = d.StartManagementSession()
-	require.NoError(t, err)
-
-	enrolledDevice, err := s.ds.MDMWindowsGetEnrolledDeviceWithDeviceID(ctx, d.DeviceID)
-	require.NoError(t, err)
-	assert.Equal(t, fleet.WindowsMDMAwaitingConfigurationActive, enrolledDevice.AwaitingConfiguration)
-
-	// Second checkin: all profiles delivered, device should be released.
-	cmds, err = d.StartManagementSession()
-	require.NoError(t, err)
-
-	var foundRelease bool
-	for _, c := range cmds {
-		if c.Verb == fleet.CmdReplace && strings.Contains(c.Cmd.GetTargetURI(), "ServerHasFinishedProvisioning") {
-			foundRelease = true
-			break
+	// findUserRelease returns the user-scope ServerHasFinishedProvisioning Replace from a command batch, nil when absent.
+	findUserRelease := func(cmds map[string]fleet.ProtoCmdOperation) *fleet.ProtoCmdOperation {
+		for _, c := range cmds {
+			uri := c.Cmd.GetTargetURI()
+			if c.Verb == fleet.CmdReplace && strings.Contains(uri, "./User/") && strings.Contains(uri, "ServerHasFinishedProvisioning") {
+				return &c
+			}
 		}
+		return nil
 	}
-	require.True(t, foundRelease, "should release device with ServerHasFinishedProvisioning")
+	// ackAll acks every non-Status command in the batch with 200, except the command with statusOverrideUUID
+	// which is acked with the given status. Returns the server's response to the ack message.
+	ackAll := func(t *testing.T, d *mdmtest.TestWindowsMDMClient, cmds map[string]fleet.ProtoCmdOperation, statusOverrideUUID, overrideStatus string) map[string]fleet.ProtoCmdOperation {
+		ackMsgID, err := d.GetCurrentMsgID()
+		require.NoError(t, err)
+		for _, c := range cmds {
+			if c.Verb == "Status" {
+				continue
+			}
+			status := "200"
+			if c.Cmd.CmdID.Value == statusOverrideUUID {
+				status = overrideStatus
+			}
+			d.AppendResponse(fleet.SyncMLCmd{
+				XMLName: xml.Name{Local: fleet.CmdStatus},
+				MsgRef:  &ackMsgID, CmdRef: &c.Cmd.CmdID.Value,
+				Cmd: &c.Verb, Data: &status,
+				CmdID: fleet.CmdID{Value: uuid.NewString()},
+			})
+		}
+		resp, err := d.SendResponse()
+		require.NoError(t, err)
+		return resp
+	}
+	// awaiting returns the device's current awaiting_configuration state.
+	awaiting := func(t *testing.T, d *mdmtest.TestWindowsMDMClient) fleet.WindowsMDMAwaitingConfiguration {
+		enrolledDevice, err := s.ds.MDMWindowsGetEnrolledDeviceWithDeviceID(ctx, d.DeviceID)
+		require.NoError(t, err)
+		return enrolledDevice.AwaitingConfiguration
+	}
+	// enrollToActive enrolls a device via Autopilot (Automatic + InOOBE -> awaiting_configuration=Pending), acks the
+	// first checkin (fleetd install and ESP hold commands), simulates fleetd on the team (orbit host + host_uuid link),
+	// and advances the enrollment to Active. Returns a client ready to receive the release.
+	enrollToActive := func(t *testing.T, azureMail, hostName string) *mdmtest.TestWindowsMDMClient {
+		d := mdmtest.NewTestMDMClientWindowsAutomatic(s.server.URL, azureMail, mdmtest.TestWindowsMDMClientWithSigningKeyAndTenantID(s.jwtSigningKey, defaultFakeJWTKeyID, tenantID))
+		require.NoError(t, d.Enroll())
 
-	enrolledDevice, err = s.ds.MDMWindowsGetEnrolledDeviceWithDeviceID(ctx, d.DeviceID)
-	require.NoError(t, err)
-	assert.Equal(t, fleet.WindowsMDMAwaitingConfigurationNone, enrolledDevice.AwaitingConfiguration)
+		cmds, err := d.StartManagementSession()
+		require.NoError(t, err)
+		ackAll(t, d, cmds, "", "")
+
+		host := createOrbitEnrolledHost(t, "windows", hostName, s.ds)
+		s.DoJSON("POST", "/api/latest/fleet/hosts/transfer", addHostsToTeamRequest{
+			TeamID:  &tm.ID,
+			HostIDs: []uint{host.ID},
+		}, http.StatusOK, &addHostsToTeamResponse{})
+		updated, err := s.ds.UpdateMDMWindowsEnrollmentsHostUUID(ctx, host.UUID, d.DeviceID)
+		require.NoError(t, err)
+		require.True(t, updated)
+		err = s.ds.SetOrUpdateHostOrbitInfo(ctx, host.ID, "1.23", sql.NullString{}, sql.NullBool{})
+		require.NoError(t, err)
+
+		// First management checkin after orbit links: device transitions to Active.
+		_, err = d.StartManagementSession()
+		require.NoError(t, err)
+		require.Equal(t, fleet.WindowsMDMAwaitingConfigurationActive, awaiting(t, d))
+		return d
+	}
+
+	t.Run("user-scope release rejected with 405 then retried until acked", func(t *testing.T) {
+		d := enrollToActive(t, "esp-retry@example.com", "esp-h1")
+
+		// All release gates pass: the release commands are sent, including the user-scope ServerHasFinishedProvisioning Replace.
+		cmds, err := d.StartManagementSession()
+		require.NoError(t, err)
+		userRelease := findUserRelease(cmds)
+		require.NotNil(t, userRelease, "should release device with the user-scope ServerHasFinishedProvisioning")
+
+		// Sending the release must NOT complete the ESP on Fleet's side: during OOBE the device rejects
+		// user-scope writes with SyncML 405 until its user MDM context initializes.
+		assert.Equal(t, fleet.WindowsMDMAwaitingConfigurationActive, awaiting(t, d),
+			"enrollment must stay Active until the user-scope release is acked 200")
+
+		// The device 405s the user-scope Replace (user MDM context not ready) and acks everything else 200.
+		afterNack := ackAll(t, d, cmds, userRelease.Cmd.CmdID.Value, "405")
+		assert.Equal(t, fleet.WindowsMDMAwaitingConfigurationActive, awaiting(t, d),
+			"a 405 on the user-scope release must NOT complete the ESP")
+
+		// The server re-sends the user-scope Replace in its response to the ack: the test client enrolls without
+		// an auth-challenge round-trip, so its ack message carries MsgID 2, which is within the session-start
+		// retry gate (espRetryAllowedForMessage). Real devices observed live ack on MsgID 3+ and get the retry at
+		// the next session instead; that shape is covered by the "acked 405 mid-session" unit subtest.
+		retry := findUserRelease(afterNack)
+		require.NotNil(t, retry, "the user-scope release must be re-sent after a 405")
+
+		// The user MDM context is now up: the device accepts the retried Replace. The 200 ack completes the ESP
+		// within the same message exchange (results are recorded before the ESP handler runs).
+		ackAll(t, d, map[string]fleet.ProtoCmdOperation{retry.Cmd.CmdID.Value: *retry}, "", "")
+		assert.Equal(t, fleet.WindowsMDMAwaitingConfigurationNone, awaiting(t, d),
+			"the 200 ack of the user-scope release completes the ESP")
+	})
+
+	t.Run("user-scope release acked immediately", func(t *testing.T) {
+		// The zero-retry happy path: the device accepts the release on the first send.
+		d := enrollToActive(t, "esp-happy@example.com", "esp-h2")
+
+		cmds, err := d.StartManagementSession()
+		require.NoError(t, err)
+		require.NotNil(t, findUserRelease(cmds), "should release device with the user-scope ServerHasFinishedProvisioning")
+		assert.Equal(t, fleet.WindowsMDMAwaitingConfigurationActive, awaiting(t, d),
+			"enrollment must stay Active until the user-scope release is acked 200")
+
+		// The device acks everything 200. Completion commits within the same message exchange, and the server
+		// must not send another release attempt in its reply.
+		afterAck := ackAll(t, d, cmds, "", "")
+		assert.Nil(t, findUserRelease(afterAck), "no retry may follow a successful ack")
+		assert.Equal(t, fleet.WindowsMDMAwaitingConfigurationNone, awaiting(t, d),
+			"the 200 ack of the user-scope release completes the ESP")
+	})
 }
 
 func (s *integrationMDMTestSuite) TestWindowsAzureInitiatedBadKeys() {

--- a/server/service/microsoft_mdm.go
+++ b/server/service/microsoft_mdm.go
@@ -2048,7 +2048,7 @@ func (svc *Service) getManagementResponse(ctx context.Context, reqMsg *fleet.Syn
 		// Build ESP (Enrollment Status Page) commands for Windows Autopilot devices. Only run for trusted requests
 		// so we don't leak ESP state to unauthenticated devices.
 		if enrolledDevice.AwaitingConfiguration != fleet.WindowsMDMAwaitingConfigurationNone {
-			espCmds, err = svc.getESPCommands(ctx, enrolledDevice)
+			espCmds, err = svc.getESPCommands(ctx, enrolledDevice, reqMsg)
 			if err != nil {
 				return nil, fmt.Errorf("ESP commands error: %w", err)
 			}
@@ -2136,13 +2136,14 @@ func (svc *Service) reconcileWindowsMDMPollSchedule(ctx context.Context, device 
 // to Active once orbit links the host UUID.
 //
 // For awaiting_configuration=Active: run the wait gates (profiles + setup-experience software) and release or block
-// the device when ready, including the 3-hour timeout.
-func (svc *Service) getESPCommands(ctx context.Context, device *fleet.MDMWindowsEnrolledDevice) ([]*mdm_types.SyncMLCmd, error) {
+// the device when ready, including the 3-hour timeout. After the release is sent, the enrollment stays Active until
+// the device acks the user-scope ServerHasFinishedProvisioning Replace with a 200.
+func (svc *Service) getESPCommands(ctx context.Context, device *fleet.MDMWindowsEnrolledDevice, reqMsg *fleet.SyncML) ([]*mdm_types.SyncMLCmd, error) {
 	switch device.AwaitingConfiguration {
 	case fleet.WindowsMDMAwaitingConfigurationPending:
 		return svc.handleESPHoldOrTransition(ctx, device)
 	case fleet.WindowsMDMAwaitingConfigurationActive:
-		return svc.handleESPRelease(ctx, device)
+		return svc.handleESPRelease(ctx, device, reqMsg)
 	default:
 		return nil, nil
 	}
@@ -2235,7 +2236,7 @@ func (svc *Service) handleESPHoldOrTransition(ctx context.Context, device *fleet
 //     missing software via self-service. It lists the failed software by name when any failed, otherwise (a timeout
 //     with nothing failed) shows the timeout message. Still-pending items are cancelled only on the timeout path.
 //   - release (no failure and no timeout): the device proceeds to login.
-func (svc *Service) handleESPRelease(ctx context.Context, device *fleet.MDMWindowsEnrolledDevice) ([]*mdm_types.SyncMLCmd, error) {
+func (svc *Service) handleESPRelease(ctx context.Context, device *fleet.MDMWindowsEnrolledDevice, reqMsg *fleet.SyncML) ([]*mdm_types.SyncMLCmd, error) {
 	if device.HostUUID == "" {
 		return nil, nil
 	}
@@ -2244,6 +2245,22 @@ func (svc *Service) handleESPRelease(ctx context.Context, device *fleet.MDMWindo
 	timedOut := device.AwaitingConfigurationAt != nil && time.Since(*device.AwaitingConfigurationAt) > time.Duration(microsoft_mdm.ESPTimeoutSeconds)*time.Second
 	if timedOut {
 		svc.logger.WarnContext(ctx, "ESP: timeout reached", "device_id", device.MDMDeviceID)
+	}
+
+	// If the release has already been sent (a queued command targeting the user-scope release URI exists), the
+	// enrollment is in the resend phase: stay Active and re-send the user-scope Replace until the device acks it with a
+	// 200, then transition to None. During OOBE the device rejects user-scope writes with SyncML 405 until the user MDM
+	// context initializes.
+	//
+	// Require the primary: the ack this read must observe was recorded by MDMWindowsSaveResponse earlier in this same request.
+	ack, err := svc.ds.MDMWindowsGetESPReleaseAckStatus(ctxdb.RequirePrimary(ctx, true), device.ID,
+		espUserReleaseLocURI(syncml.DocProvisioningAppProviderID), espReleaseAttemptCmdIDPrefix)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "get ESP release ack status")
+	}
+	if ack.Attempted {
+		// re-send release or finish enrollment
+		return svc.handleESPUserReleaseRetry(ctx, device, ack, timedOut, reqMsg)
 	}
 
 	// hasSoftwareFailure tracks setup-experience software failures only.
@@ -2630,24 +2647,11 @@ func (svc *Service) handleESPRelease(ctx context.Context, device *fleet.MDMWindo
 	// The persist is a single transactional batch (MDMWindowsInsertCommandsForHost) so a partial-fail-then-retry can't
 	// leave orphan rows in the queue.
 	//
-	// On concurrent-CAS races (two checkins both reach this point) both callers persist with fresh UUIDs and only one
-	// wins the CAS. The loser's rows are delivered later by the regular command queue, the device acks them as
-	// idempotent Replaces of post-ESP-irrelevant DMClient nodes, and the queue clears -- no permanent leak, just brief
-	// extra traffic.
+	// On concurrent races (two checkins both reach this point) both callers persist with fresh UUIDs. The loser's
+	// rows are delivered later by the regular command queue, the device acks them as idempotent Replaces of
+	// post-ESP-irrelevant DMClient nodes, and the queue clears -- no permanent leak, just brief extra traffic.
 	if err := svc.persistESPFinalCommands(ctx, device.HostUUID, cmds); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "persist ESP finalization commands")
-	}
-
-	// CAS Active -> None: only one concurrent checkin commits the finalize. Cancel and persist above ran for both
-	// concurrent winners, but cancel is idempotent and persist's losers get harmlessly delivered as orphan Replaces.
-	transitioned, err := svc.ds.SetMDMWindowsAwaitingConfiguration(ctx, device.MDMDeviceID,
-		fleet.WindowsMDMAwaitingConfigurationActive, fleet.WindowsMDMAwaitingConfigurationNone)
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "set awaiting configuration to none")
-	}
-	if !transitioned {
-		// Another concurrent checkin already finalized.
-		return nil, nil
 	}
 
 	svc.logger.InfoContext(ctx, "ESP: finalizing",
@@ -2659,7 +2663,118 @@ func (svc *Service) handleESPRelease(ctx context.Context, device *fleet.MDMWindo
 		"blocking", shouldBlock,
 		"soft_blocking", shouldWarn)
 
+	// Release path. The enrollment stays Active until the device acks the user-scope ServerHasFinishedProvisioning
+	// Replace with a 200 (handleESPUserReleaseRetry, entered on later checkins via the attempt rows persisted above).
+	if !shouldBlock && !shouldWarn {
+		return cmds, nil
+	}
+
+	// Enrollment is blocked (due to software failure or timeout).
+	transitioned, err := svc.casESPActiveToNone(ctx, device, "block finalize")
+	if err != nil {
+		return nil, err
+	}
+	if !transitioned {
+		// Another concurrent checkin already finalized.
+		return nil, nil
+	}
+
 	return cmds, nil
+}
+
+// casESPActiveToNone commits the terminal ESP transition (awaiting_configuration Active -> None) via
+// compare-and-swap and reports whether this checkin won it.
+func (svc *Service) casESPActiveToNone(ctx context.Context, device *fleet.MDMWindowsEnrolledDevice, reason string) (bool, error) {
+	transitioned, err := svc.ds.SetMDMWindowsAwaitingConfiguration(ctx, device.MDMDeviceID,
+		fleet.WindowsMDMAwaitingConfigurationActive, fleet.WindowsMDMAwaitingConfigurationNone)
+	if err != nil {
+		return false, ctxerr.Wrap(ctx, err, "set awaiting configuration to none: "+reason)
+	}
+	return transitioned, nil
+}
+
+// espUserReleaseLocURI returns the LocURI of the user-scope ServerHasFinishedProvisioning node for the given provider ID.
+func espUserReleaseLocURI(provID string) string {
+	return fmt.Sprintf("./User/Vendor/MSFT/DMClient/Provider/%s/FirstSyncStatus/ServerHasFinishedProvisioning", provID)
+}
+
+// espReleaseAttemptCmdIDPrefix marks the CmdID of every user-scope ESP release attempt Fleet sends (the initial
+// finalize's Replace and each retry).
+const espReleaseAttemptCmdIDPrefix = "esp-release-"
+
+// espRetryAllowedForMessage bounds user-scope release retries to the start of an OMA-DM session (device MsgID 1 or 2; in
+// practice MsgID 1 is auth and MsgID 2 is trusted request). The device acks commands within the same session (message
+// N's commands are acked in message N+1, which runs this handler again), so retrying on every message would ping-pong a
+// failing Replace for as long as the device keeps the session open. One attempt per session is enough: the deciding
+// condition (user MDM context readiness) changes on session boundaries, not between messages of one session.
+//
+// Defaults to true on a missing/unreadable header: occasionally retrying too often is better than never.
+func espRetryAllowedForMessage(reqMsg *fleet.SyncML) bool {
+	if reqMsg == nil {
+		return true
+	}
+	msgID, err := reqMsg.GetMessageID()
+	if err != nil {
+		return true
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(msgID))
+	if err != nil {
+		return true
+	}
+	return n <= 2
+}
+
+// handleESPUserReleaseRetry handles an Active enrollment whose release commands have already been sent: the ESP is
+// finished only when the device acks the user-scope ServerHasFinishedProvisioning Replace with a 200. Until then the
+// enrollment stays Active and the Replace is re-sent once per session. Convergence is quick in practice: the device
+// polls every ~60s during the ESP, and the write starts succeeding as soon as the user MDM context initializes.
+func (svc *Service) handleESPUserReleaseRetry(ctx context.Context, device *fleet.MDMWindowsEnrolledDevice,
+	ack *fleet.MDMWindowsESPReleaseAckStatus, timedOut bool, reqMsg *fleet.SyncML,
+) ([]*mdm_types.SyncMLCmd, error) {
+	switch {
+	case ack.Acked200:
+		// Commit ESP completion, now confirmed by the device's ack. Enrollment complete.
+		transitioned, err := svc.casESPActiveToNone(ctx, device, "user-scope release ack")
+		if err != nil {
+			return nil, err
+		}
+		if transitioned {
+			svc.logger.InfoContext(ctx, "ESP: user-scope release acked, ESP complete",
+				"device_id", device.MDMDeviceID, "host_uuid", device.HostUUID)
+		}
+		return nil, nil
+
+	case timedOut:
+		// Same 3-hour bound as the pre-release path: CAS Active -> None to stop retrying and let the device's own
+		// ESP timeout handling take over.
+		svc.logger.WarnContext(ctx, "ESP: timeout waiting for user-scope release ack, finalizing without it",
+			"device_id", device.MDMDeviceID, "host_uuid", device.HostUUID, "last_status", ack.LatestStatus)
+		if _, err := svc.casESPActiveToNone(ctx, device, "user-scope release timeout"); err != nil {
+			return nil, err
+		}
+		return nil, nil
+
+	case ack.HasUnacked:
+		// An attempt is in flight: either the device hasn't responded yet, or the response was dropped and the
+		// command queue's redelivery will resend the persisted attempt.
+		svc.logger.DebugContext(ctx, "ESP: user-scope release attempt in flight, waiting for ack",
+			"device_id", device.MDMDeviceID, "host_uuid", device.HostUUID, "last_status", ack.LatestStatus)
+		return nil, nil
+
+	case !espRetryAllowedForMessage(reqMsg):
+		// The last attempt failed, but retry only at the start of the next session (see espRetryAllowedForMessage).
+		return nil, nil
+
+	default:
+		// The last attempt was acked with a non-200 (405 until the user MDM context initializes): re-send a fresh Replace.
+		svc.logger.InfoContext(ctx, "ESP: user-scope release not acked yet, retrying",
+			"device_id", device.MDMDeviceID, "host_uuid", device.HostUUID, "last_status", ack.LatestStatus)
+		cmds := []*mdm_types.SyncMLCmd{newESPUserReleaseCmd(syncml.DocProvisioningAppProviderID)}
+		if err := svc.persistESPFinalCommands(ctx, device.HostUUID, cmds); err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "persist ESP user-scope release retry")
+		}
+		return cmds, nil
+	}
 }
 
 // BlockInStatusPage values per Microsoft DMClient CSP docs (bit flags): 1=Reset PC, 2=Try Again, 4=Continue Anyway.
@@ -2725,13 +2840,19 @@ func buildESPReleaseCommands(provID string) []*mdm_types.SyncMLCmd {
 			fmt.Sprintf("./Device/Vendor/MSFT/EnrollmentStatusTracking/DevicePreparation/PolicyProviders/%s/InstallationState", provID), "3"),
 		newSyncMLCmdBool(fleet.CmdReplace,
 			fmt.Sprintf("./Device/Vendor/MSFT/DMClient/Provider/%s/FirstSyncStatus/ServerHasFinishedProvisioning", provID), "true"),
-		newSyncMLCmdBool(fleet.CmdReplace,
-			fmt.Sprintf("./User/Vendor/MSFT/DMClient/Provider/%s/FirstSyncStatus/ServerHasFinishedProvisioning", provID), "true"),
 	}
 	for _, cmd := range cmds {
 		cmd.CmdID = mdm_types.CmdID{Value: uuid.New().String()}
 	}
-	return cmds
+	// The user-scope release goes last: it is the command whose 200 ack gates the Active -> None transition to finish enrollment.
+	return append(cmds, newESPUserReleaseCmd(provID))
+}
+
+// newESPUserReleaseCmd builds the user-scope ServerHasFinishedProvisioning Replace that completes the ESP "Account setup" phase
+func newESPUserReleaseCmd(provID string) *mdm_types.SyncMLCmd {
+	cmd := newSyncMLCmdBool(fleet.CmdReplace, espUserReleaseLocURI(provID), "true")
+	cmd.CmdID = mdm_types.CmdID{Value: espReleaseAttemptCmdIDPrefix + uuid.New().String()}
+	return cmd
 }
 
 // persistESPFinalCommands stores backup copies of every finalization command

--- a/server/service/microsoft_mdm_property_test.go
+++ b/server/service/microsoft_mdm_property_test.go
@@ -30,16 +30,17 @@ import (
 //     BlockInStatusPage (block: 1 = Reset PC; warn: 5 = Reset PC + Continue Anyway) and CustomErrorText
 //     (block: reason-specific static text; warn: dynamic failed-software list).
 //   - Release path command shape: Device-scope AND User-scope ServerHasFinishedProvisioning plus
-//     PolicyProviders InstallationState=3; NO CustomErrorText, NO BlockInStatusPage. The user-scope
-//     Provider node is created during the hold phase via Add commands so the user-scope SHFP write
-//     lands instead of being 405-rejected.
+//     PolicyProviders InstallationState=3; NO CustomErrorText, NO BlockInStatusPage. The user-scope write is
+//     rejected with 405 until the device's user MDM context initializes, so the release path does NOT CAS to
+//     None: the enrollment stays Active and the Replace is re-sent until a 200 ack (handleESPUserReleaseRetry).
 //   - Persisted CommandUUIDs equal inline CmdID.Value (the ack-clearing invariant).
 //   - Persist runs as a single batched call (a regression that loops single inserts would split CustomErrorText
 //     and the block flags across multiple TX boundaries).
 //   - Cancel block fires iff (timedOut || (observedHasFailure && requireAll)); when it fires,
 //     CancelHostUpcomingActivity is called once per Pending/Running row in input. Cancel-upcoming runs strictly
-//     before cancel-status; both run strictly before persist; persist runs strictly before CAS. The warn path
-//     never cancels: all items already reached a terminal state and the user may continue.
+//     before cancel-status; both run strictly before persist; persist runs strictly before CAS on the block
+//     paths (the release path defers the CAS to the ack). The warn path never cancels: all items already
+//     reached a terminal state and the user may continue.
 //
 // Order independence is implicit: pbtESPSpec is a pure function of the multiset of statuses (no positional
 // dependency) and rapid samples many orderings, so any introduced order-dependence in production code
@@ -144,6 +145,9 @@ func newPBTESPSvc(
 		trace.callOrder = append(trace.callOrder, "cas")
 		return true, nil
 	}
+	ds.MDMWindowsGetESPReleaseAckStatusFunc = func(ctx context.Context, enrollmentID uint, targetLocURI, cmdUUIDPrefix string) (*fleet.MDMWindowsESPReleaseAckStatus, error) {
+		return &fleet.MDMWindowsESPReleaseAckStatus{}, nil
+	}
 
 	svc := &Service{ds: ds, logger: pbtESPLogger}
 	svc.SetActivityService(&mock.MockActivityService{})
@@ -232,6 +236,7 @@ func pbtFindCmdByLocURI(cmds []*fleet.SyncMLCmd, substr string) *fleet.SyncMLCmd
 	return nil
 }
 
+// TestPBT_HandleESPRelease tests releases due to software failures or timeout. It does not test the happy path (which requires an Ack from device). The happy path is covered by other tests.
 func TestPBT_HandleESPRelease(t *testing.T) {
 	statusGen := rapid.SampledFrom([]fleet.SetupExperienceStatusResultStatus{
 		fleet.SetupExperienceStatusPending,
@@ -256,7 +261,7 @@ func TestPBT_HandleESPRelease(t *testing.T) {
 			}
 		}
 		svc, device, trace := newPBTESPSvc(statuses, timedOut, requireAll)
-		cmds, err := svc.getESPCommands(t.Context(), device)
+		cmds, err := svc.getESPCommands(t.Context(), device, nil)
 		require.NoErrorf(rt, err, "statuses=%v timedOut=%v requireAll=%v", statuses, timedOut, requireAll)
 
 		if expected == pbtESPWait {
@@ -341,8 +346,8 @@ func TestPBT_HandleESPRelease(t *testing.T) {
 			assert.Nilf(rt, pbtFindCmdByLocURI(cmds, "CustomErrorText"),
 				"release path must NOT include CustomErrorText")
 			// Release writes ServerHasFinishedProvisioning at BOTH Device and User scope. Device scope completes
-			// the Device setup phase; User scope completes Account setup. The User-scope write requires the
-			// user-scope DMClient Provider node to have been created earlier via the hold-phase Add commands.
+			// the Device setup phase; User scope completes Account setup. The User-scope write is rejected with
+			// 405 until the user MDM context initializes, which is why its ack gates the Active -> None CAS.
 			shfpDeviceFound, shfpUserFound := false, false
 			for _, c := range cmds {
 				uri := c.GetTargetURI()
@@ -407,8 +412,16 @@ func TestPBT_HandleESPRelease(t *testing.T) {
 			}
 		}
 		require.NotEqualf(rt, -1, firstPersist, "persist must run for non-wait outcomes")
-		require.NotEqualf(rt, -1, firstCas, "CAS must run for non-wait outcomes")
-		require.Lessf(rt, firstPersist, firstCas, "persist must run before CAS; callOrder=%v", trace.callOrder)
+		// CAS Active -> None runs only on the block-flavored paths. The release path stays Active: the
+		// transition is deferred until the device acks the user-scope ServerHasFinishedProvisioning Replace
+		// with a 200 (handleESPUserReleaseRetry on a later checkin).
+		if expected == pbtESPRelease {
+			require.Equalf(rt, -1, firstCas,
+				"release path must NOT CAS to None before the user-scope release ack; callOrder=%v", trace.callOrder)
+		} else {
+			require.NotEqualf(rt, -1, firstCas, "CAS must run for block outcomes")
+			require.Lessf(rt, firstPersist, firstCas, "persist must run before CAS; callOrder=%v", trace.callOrder)
+		}
 		if lastCancelUpcoming != -1 && firstCancelStatus != -1 {
 			require.Lessf(rt, lastCancelUpcoming, firstCancelStatus,
 				"cancel-upcoming must run before cancel-status; callOrder=%v", trace.callOrder)

--- a/server/service/microsoft_mdm_test.go
+++ b/server/service/microsoft_mdm_test.go
@@ -1651,6 +1651,10 @@ func TestGetESPCommands(t *testing.T) {
 		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
 			return &fleet.AppConfig{}, nil
 		}
+		// No release attempt queued yet.
+		ds.MDMWindowsGetESPReleaseAckStatusFunc = func(ctx context.Context, enrollmentID uint, targetLocURI, cmdUUIDPrefix string) (*fleet.MDMWindowsESPReleaseAckStatus, error) {
+			return &fleet.MDMWindowsESPReleaseAckStatus{}, nil
+		}
 		// Finalize side-effects: default no-op success. Tests that need to capture, fail, or assert ordering
 		// install their own override.
 		ds.MDMWindowsInsertCommandsForHostFunc = func(ctx context.Context, hostUUIDOrDeviceID string, cmds []*fleet.MDMWindowsCommand) error {
@@ -1688,7 +1692,7 @@ func TestGetESPCommands(t *testing.T) {
 			AwaitingConfiguration: fleet.WindowsMDMAwaitingConfigurationNone,
 		}
 
-		cmds, err := svc.getESPCommands(t.Context(), device)
+		cmds, err := svc.getESPCommands(t.Context(), device, nil)
 		require.NoError(t, err)
 		assert.Nil(t, cmds)
 	})
@@ -1701,7 +1705,7 @@ func TestGetESPCommands(t *testing.T) {
 			AwaitingConfiguration: fleet.WindowsMDMAwaitingConfigurationPending,
 		}
 
-		cmds, err := svc.getESPCommands(t.Context(), device)
+		cmds, err := svc.getESPCommands(t.Context(), device, nil)
 		require.NoError(t, err)
 		require.NotEmpty(t, cmds, "should return hold commands")
 	})
@@ -1723,7 +1727,7 @@ func TestGetESPCommands(t *testing.T) {
 		// returns a single DevicePreparation/InstallationState=3 command to advance the ESP from the
 		// Device-setup phase to the Account-setup phase. ESP release itself is signaled later via
 		// ServerHasFinishedProvisioning from buildESPReleaseCommands.
-		cmds, err := svc.getESPCommands(t.Context(), device)
+		cmds, err := svc.getESPCommands(t.Context(), device, nil)
 		require.NoError(t, err)
 		require.Len(t, cmds, 1)
 		assert.Contains(t, cmds[0].GetTargetURI(), "DevicePreparation/PolicyProviders/")
@@ -1739,7 +1743,7 @@ func TestGetESPCommands(t *testing.T) {
 			}, nil
 		}
 
-		cmds, err := svc.getESPCommands(t.Context(), newActiveDevice())
+		cmds, err := svc.getESPCommands(t.Context(), newActiveDevice(), nil)
 		require.NoError(t, err)
 		assert.Nil(t, cmds, "should wait while profiles are pending")
 	})
@@ -1752,7 +1756,7 @@ func TestGetESPCommands(t *testing.T) {
 			}, nil
 		}
 
-		cmds, err := svc.getESPCommands(t.Context(), newActiveDevice())
+		cmds, err := svc.getESPCommands(t.Context(), newActiveDevice(), nil)
 		require.NoError(t, err)
 		assert.Nil(t, cmds, "should wait while profiles are verifying")
 	})
@@ -1790,7 +1794,7 @@ func TestGetESPCommands(t *testing.T) {
 			}, nil
 		}
 
-		cmds, err := svc.getESPCommands(t.Context(), newActiveDevice())
+		cmds, err := svc.getESPCommands(t.Context(), newActiveDevice(), nil)
 		require.NoError(t, err)
 		assert.Nil(t, cmds, "should wait while the freshly queued profile is pending")
 		require.NotEmpty(t, queued, "per-host reconcile must queue the unqueued profile")
@@ -1807,7 +1811,7 @@ func TestGetESPCommands(t *testing.T) {
 			return nil, errors.New("boom")
 		}
 
-		_, err := svc.getESPCommands(t.Context(), newActiveDevice())
+		_, err := svc.getESPCommands(t.Context(), newActiveDevice(), nil)
 		require.Error(t, err, "a reconcile failure must block the release; the next checkin retries")
 		assert.False(t, ds.GetHostMDMWindowsProfilesFuncInvoked, "should not evaluate delivery status when reconcile failed")
 	})
@@ -1830,35 +1834,135 @@ func TestGetESPCommands(t *testing.T) {
 				{ProfileUUID: "prof-1", Name: "WiFi", Status: &fleet.MDMDeliveryVerified, OperationType: fleet.MDMOperationTypeInstall},
 			}, nil
 		}
-		// Capture ordering: persist must run BEFORE the CAS so a persist failure can't leave the device finalized
-		// without the dropped-response retry safety net.
-		persisted := false
-		ds.MDMWindowsInsertCommandsForHostFunc = func(ctx context.Context, hostUUIDOrDeviceID string, cmds []*fleet.MDMWindowsCommand) error {
-			persisted = true
-			return nil
-		}
-		ds.SetMDMWindowsAwaitingConfigurationFunc = func(ctx context.Context, mdmDeviceID string, from, to fleet.WindowsMDMAwaitingConfiguration) (bool, error) {
-			require.True(t, persisted, "persist must run BEFORE CAS Active->None")
-			return true, nil
-		}
-
-		cmds, err := svc.getESPCommands(t.Context(), newActiveDevice())
+		cmds, err := svc.getESPCommands(t.Context(), newActiveDevice(), nil)
 		require.NoError(t, err)
 		require.NotEmpty(t, cmds, "should return release commands")
 		assert.True(t, ds.MDMWindowsInsertCommandsForHostFuncInvoked,
 			"release path must persist final commands as the dropped-response retry backup")
-		assert.True(t, ds.SetMDMWindowsAwaitingConfigurationFuncInvoked,
-			"should transition awaiting_configuration out of Active")
+		assert.False(t, ds.SetMDMWindowsAwaitingConfigurationFuncInvoked,
+			"release path must stay Active until the user-scope ServerHasFinishedProvisioning Replace acks 200")
 	})
 
 	t.Run("active with no profiles releases device", func(t *testing.T) {
 		ds, svc := newSvc(t)
 
-		cmds, err := svc.getESPCommands(t.Context(), newActiveDevice())
+		cmds, err := svc.getESPCommands(t.Context(), newActiveDevice(), nil)
 		require.NoError(t, err)
 		require.NotEmpty(t, cmds, "should return release commands when no profiles configured")
-		assert.True(t, ds.SetMDMWindowsAwaitingConfigurationFuncInvoked,
-			"should transition awaiting_configuration out of Active")
+		assert.False(t, ds.SetMDMWindowsAwaitingConfigurationFuncInvoked,
+			"release path must stay Active until the user-scope release is acked")
+	})
+
+	// The user-scope release retry phase: once release commands have been queued (ack.Attempted), the handler bypasses
+	// the wait gates entirely and drives the Active -> None transition off the ack of the user-scope
+	// ServerHasFinishedProvisioning Replace.
+	t.Run("user-scope release retry phase", func(t *testing.T) {
+		// newRetrySvc wires newSvc with the given ack status and fails the test if the wait gates are consulted:
+		// the retry phase must decide from the ack alone.
+		newRetrySvc := func(t *testing.T, ack fleet.MDMWindowsESPReleaseAckStatus) (*mock.Store, *Service) {
+			ds, svc := newSvc(t)
+			ds.MDMWindowsGetESPReleaseAckStatusFunc = func(ctx context.Context, enrollmentID uint, targetLocURI, cmdUUIDPrefix string) (*fleet.MDMWindowsESPReleaseAckStatus, error) {
+				require.Contains(t, targetLocURI, "./User/", "ack status must be looked up for the user-scope release URI")
+				require.Equal(t, espReleaseAttemptCmdIDPrefix, cmdUUIDPrefix, "ack status must be scoped to Fleet's own release attempts")
+				return &ack, nil
+			}
+			ds.GetHostMDMWindowsProfilesFunc = func(ctx context.Context, hUUID string) ([]fleet.HostMDMWindowsProfile, error) {
+				t.Fatal("retry phase must not re-run the profile wait gate")
+				return nil, nil
+			}
+			ds.ListSetupExperienceResultsByHostUUIDFunc = func(ctx context.Context, hUUID string, teamID uint) ([]*fleet.SetupExperienceStatusResult, error) {
+				t.Fatal("retry phase must not re-run the setup experience wait gate")
+				return nil, nil
+			}
+			return ds, svc
+		}
+		// sessionMsg builds a minimal incoming message with the given device MsgID.
+		sessionMsg := func(msgID string) *fleet.SyncML {
+			return &fleet.SyncML{SyncHdr: fleet.SyncHdr{MsgID: msgID}}
+		}
+
+		t.Run("acked 200 transitions to None", func(t *testing.T) {
+			ds, svc := newRetrySvc(t, fleet.MDMWindowsESPReleaseAckStatus{Attempted: true, Acked200: true, LatestStatus: "200"})
+			var casFrom, casTo fleet.WindowsMDMAwaitingConfiguration
+			ds.SetMDMWindowsAwaitingConfigurationFunc = func(ctx context.Context, mdmDeviceID string, from, to fleet.WindowsMDMAwaitingConfiguration) (bool, error) {
+				casFrom, casTo = from, to
+				return true, nil
+			}
+
+			cmds, err := svc.getESPCommands(t.Context(), newActiveDevice(), sessionMsg("5"))
+			require.NoError(t, err)
+			assert.Empty(t, cmds, "nothing to send once the release is acked")
+			require.True(t, ds.SetMDMWindowsAwaitingConfigurationFuncInvoked, "200 ack must commit the ESP completion")
+			assert.Equal(t, fleet.WindowsMDMAwaitingConfigurationActive, casFrom)
+			assert.Equal(t, fleet.WindowsMDMAwaitingConfigurationNone, casTo)
+		})
+
+		t.Run("attempt in flight waits", func(t *testing.T) {
+			ds, svc := newRetrySvc(t, fleet.MDMWindowsESPReleaseAckStatus{Attempted: true, HasUnacked: true})
+
+			cmds, err := svc.getESPCommands(t.Context(), newActiveDevice(), sessionMsg("2"))
+			require.NoError(t, err)
+			assert.Empty(t, cmds, "must not stack another attempt while one is in flight")
+			assert.False(t, ds.SetMDMWindowsAwaitingConfigurationFuncInvoked)
+			assert.False(t, ds.MDMWindowsInsertCommandsForHostFuncInvoked)
+		})
+
+		t.Run("acked 405 re-sends the user-scope Replace at session start", func(t *testing.T) {
+			ds, svc := newRetrySvc(t, fleet.MDMWindowsESPReleaseAckStatus{Attempted: true, LatestStatus: "405"})
+			var persistedUUIDs []string
+			ds.MDMWindowsInsertCommandsForHostFunc = func(ctx context.Context, hostUUIDOrDeviceID string, persistCmds []*fleet.MDMWindowsCommand) error {
+				for _, c := range persistCmds {
+					persistedUUIDs = append(persistedUUIDs, c.CommandUUID)
+				}
+				return nil
+			}
+
+			cmds, err := svc.getESPCommands(t.Context(), newActiveDevice(), sessionMsg("2"))
+			require.NoError(t, err)
+			require.Len(t, cmds, 1, "retry sends exactly the user-scope Replace")
+			assert.Equal(t, fleet.CmdReplace, cmds[0].XMLName.Local)
+			assert.Contains(t, cmds[0].GetTargetURI(), "./User/Vendor/MSFT/DMClient/Provider/")
+			assert.Contains(t, cmds[0].GetTargetURI(), "ServerHasFinishedProvisioning")
+			assert.True(t, strings.HasPrefix(cmds[0].CmdID.Value, espReleaseAttemptCmdIDPrefix),
+				"the retry CmdID must carry the attempt prefix or the ack-status lookup will never see its ack")
+			require.Equal(t, []string{cmds[0].CmdID.Value}, persistedUUIDs,
+				"the retry must be persisted with the inline CmdID so the ack clears the backup and is recorded in results")
+			assert.False(t, ds.SetMDMWindowsAwaitingConfigurationFuncInvoked, "must stay Active until a 200 ack")
+		})
+
+		// If we get a 405 mid-session, we do not send another retry right away but wait for the next session (typically within 60 seconds).
+		t.Run("acked 405 mid-session waits for the next session", func(t *testing.T) {
+			ds, svc := newRetrySvc(t, fleet.MDMWindowsESPReleaseAckStatus{Attempted: true, LatestStatus: "405"})
+
+			cmds, err := svc.getESPCommands(t.Context(), newActiveDevice(), sessionMsg("5"))
+			require.NoError(t, err)
+			assert.Empty(t, cmds, "a mid-session retry would ping-pong the failing Replace")
+			assert.False(t, ds.MDMWindowsInsertCommandsForHostFuncInvoked)
+		})
+
+		t.Run("nil request message still retries", func(t *testing.T) {
+			// Defensive default: a missing message must err toward retrying (never retrying wedges the device).
+			ds, svc := newRetrySvc(t, fleet.MDMWindowsESPReleaseAckStatus{Attempted: true, LatestStatus: "405"})
+
+			cmds, err := svc.getESPCommands(t.Context(), newActiveDevice(), nil)
+			require.NoError(t, err)
+			require.Len(t, cmds, 1)
+			assert.True(t, ds.MDMWindowsInsertCommandsForHostFuncInvoked)
+		})
+
+		t.Run("timeout gives up and transitions to None", func(t *testing.T) {
+			ds, svc := newRetrySvc(t, fleet.MDMWindowsESPReleaseAckStatus{Attempted: true, LatestStatus: "405"})
+			device := newActiveDevice()
+			past := time.Now().Add(-4 * time.Hour)
+			device.AwaitingConfigurationAt = &past
+
+			cmds, err := svc.getESPCommands(t.Context(), device, sessionMsg("2"))
+			require.NoError(t, err)
+			assert.Empty(t, cmds, "timeout stops the retry loop")
+			assert.True(t, ds.SetMDMWindowsAwaitingConfigurationFuncInvoked,
+				"the timeout must bound the retry loop for devices whose user context never initializes")
+			assert.False(t, ds.MDMWindowsInsertCommandsForHostFuncInvoked)
+		})
 	})
 
 	// findCmdByLocURI returns the first SyncMLCmd whose target LocURI contains
@@ -1884,7 +1988,7 @@ func TestGetESPCommands(t *testing.T) {
 		}
 		setRequireAll(ds, true)
 
-		cmds, err := svc.getESPCommands(t.Context(), newActiveDevice())
+		cmds, err := svc.getESPCommands(t.Context(), newActiveDevice(), nil)
 		require.NoError(t, err)
 		require.NotEmpty(t, cmds, "profile failure alone should release the device")
 
@@ -1918,7 +2022,7 @@ func TestGetESPCommands(t *testing.T) {
 		}
 		setRequireAll(ds, true)
 
-		cmds, err := svc.getESPCommands(t.Context(), newActiveDevice())
+		cmds, err := svc.getESPCommands(t.Context(), newActiveDevice(), nil)
 		require.NoError(t, err)
 		require.NotEmpty(t, cmds)
 
@@ -1958,7 +2062,7 @@ func TestGetESPCommands(t *testing.T) {
 		activitySvc := &mock.MockActivityService{}
 		svc.SetActivityService(activitySvc)
 
-		cmds, err := svc.getESPCommands(t.Context(), newActiveDevice())
+		cmds, err := svc.getESPCommands(t.Context(), newActiveDevice(), nil)
 		require.NoError(t, err)
 		require.NotEmpty(t, cmds)
 
@@ -2004,7 +2108,7 @@ func TestGetESPCommands(t *testing.T) {
 		device := newActiveDevice()
 		device.AwaitingConfigurationAt = &past
 
-		cmds, err := svc.getESPCommands(t.Context(), device)
+		cmds, err := svc.getESPCommands(t.Context(), device, nil)
 		require.NoError(t, err)
 		require.NotEmpty(t, cmds)
 
@@ -2044,7 +2148,7 @@ func TestGetESPCommands(t *testing.T) {
 			return nil, newNotFoundError()
 		}
 
-		_, err := svc.getESPCommands(t.Context(), device)
+		_, err := svc.getESPCommands(t.Context(), device, nil)
 		require.NoError(t, err,
 			"notFound from CancelHostUpcomingActivity must be tolerated -- otherwise mid-loop crashes loop forever on retry")
 		assert.True(t, ds.CancelPendingSetupExperienceStepsFuncInvoked,
@@ -2082,7 +2186,7 @@ func TestGetESPCommands(t *testing.T) {
 			return ac, nil
 		}
 
-		cmds, err := svc.getESPCommands(t.Context(), newActiveDevice())
+		cmds, err := svc.getESPCommands(t.Context(), newActiveDevice(), nil)
 		require.NoError(t, err)
 		require.NotEmpty(t, cmds)
 		assert.True(t, ds.TeamLiteFuncInvoked, "TeamLite must be called on the team path")
@@ -2110,7 +2214,7 @@ func TestGetESPCommands(t *testing.T) {
 			return false, nil
 		}
 
-		cmds, err := svc.getESPCommands(t.Context(), newActiveDevice())
+		cmds, err := svc.getESPCommands(t.Context(), newActiveDevice(), nil)
 		require.Error(t, err, "must return error so device retries on next session")
 		assert.Nil(t, cmds)
 		assert.False(t, ds.SetMDMWindowsAwaitingConfigurationFuncInvoked,
@@ -2141,7 +2245,7 @@ func TestGetESPCommands(t *testing.T) {
 			return false, nil
 		}
 
-		cmds, err := svc.getESPCommands(t.Context(), newActiveDevice())
+		cmds, err := svc.getESPCommands(t.Context(), newActiveDevice(), nil)
 		require.Error(t, err, "must return error so device retries on next session")
 		assert.Nil(t, cmds)
 		assert.False(t, ds.MDMWindowsInsertCommandsForHostFuncInvoked,
@@ -2160,7 +2264,7 @@ func TestGetESPCommands(t *testing.T) {
 			return nil, errors.New("transient db error")
 		}
 
-		cmds, err := svc.getESPCommands(t.Context(), newActiveDevice())
+		cmds, err := svc.getESPCommands(t.Context(), newActiveDevice(), nil)
 		require.Error(t, err, "must return error so device retries on next session")
 		assert.Nil(t, cmds)
 		assert.False(t, ds.SetMDMWindowsAwaitingConfigurationFuncInvoked,
@@ -2175,7 +2279,7 @@ func TestGetESPCommands(t *testing.T) {
 			return true, nil
 		}
 
-		cmds, err := svc.getESPCommands(t.Context(), newActiveDevice())
+		cmds, err := svc.getESPCommands(t.Context(), newActiveDevice(), nil)
 		require.NoError(t, err)
 		assert.Nil(t, cmds, "should wait for orbit to initialize setup experience")
 		// Must NOT have proceeded to the Active->None transition.


### PR DESCRIPTION
The ESP release wrote the user-scope ServerHasFinishedProvisioning Replace and immediately committed awaiting_configuration=None. During OOBE the device rejects user-scope writes with SyncML 405 until its user MDM context initializes, so the Account setup phase never received its completion signal and the device hung until the 3-hour timeout, while Fleet believed the ESP had completed (and relaxed the DMClient poll, crippling remediation).

The release path now stays Active until the device acks the user-scope Replace with a 200: a new resend phase re-sends the Replace once per session (bounded by the existing 3-hour timeout), and the Active->None transition commits only on the 200.

Live-validated on Win11 26200 on both a fresh and a re-enrolled device: the 405 reproduced at release time in both flows, and the retried Replace acked 200 one session after the user context came up, releasing the ESP.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #49134

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
See [Changes
files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Timeouts are implemented and retries are limited to avoid infinite loops

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Fixed an issue where Windows Autopilot enrollment could intermittently hang at **“Account setup”** on the Enrollment Status Page.
- Updated Enrollment Status Page release handling so enrollment **stays active until the device acknowledges** the user-scope completion command.
- When the user-scope completion is rejected or still unacknowledged, it is **retried in subsequent management sessions** until successfully acknowledged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

(cherry picked from commit e14ef67b55ba0eec9d1b55158c9f593cb75d9ae0)

