### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/bettertouchtool/darwin.json
+++ b/ee/maintained-apps/outputs/bettertouchtool/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "6.640",
+      "version": "6.651",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.hegenberg.BetterTouchTool';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hegenberg.BetterTouchTool' AND version_compare(bundle_short_version, '6.640') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hegenberg.BetterTouchTool' AND version_compare(bundle_short_version, '6.651') < 0);"
       },
-      "installer_url": "https://folivora.ai/releases/btt6.640-2026071312.zip",
+      "installer_url": "https://folivora.ai/releases/btt6.651-2026072005.zip",
       "install_script_ref": "920c563d",
       "uninstall_script_ref": "b0dc7152",
-      "sha256": "35ff9b40487910f182c06d8f25237314acdf78b7b48247a38068512e7bd667b1",
+      "sha256": "08cd2d9c9f991a0cb7242cec5ed35b2e88f2d83bf56a672898a36047d35e8d66",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/betterzip/darwin.json
+++ b/ee/maintained-apps/outputs/betterzip/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "5.4.2",
+      "version": "6.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.macitbetter.betterzip';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.macitbetter.betterzip' AND version_compare(bundle_short_version, '5.4.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.macitbetter.betterzip' AND version_compare(bundle_short_version, '6.0') < 0);"
       },
-      "installer_url": "https://macitbetter.com/dl/BetterZip-5.4.2.zip",
+      "installer_url": "https://macitbetter.com/dl/BetterZip-6.0.zip",
       "install_script_ref": "89374a40",
       "uninstall_script_ref": "84dca76c",
-      "sha256": "1009e2283222fd5cfdf527b5e78559addf143c54902001b678dd38135cebca64",
+      "sha256": "19e2bf96ca0d33be907528828b4e0d27edd6acfe8f3317431d784537ebc96723",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/downie/darwin.json
+++ b/ee/maintained-apps/outputs/downie/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.12.10",
+      "version": "4.12.11",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.charliemonroe.Downie-4';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.charliemonroe.Downie-4' AND version_compare(bundle_short_version, '4.12.10') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.charliemonroe.Downie-4' AND version_compare(bundle_short_version, '4.12.11') < 0);"
       },
-      "installer_url": "https://software.charliemonroe.net/trial/downie/v4/Downie_4_5214.dmg",
+      "installer_url": "https://software.charliemonroe.net/trial/downie/v4/Downie_4_5218.dmg",
       "install_script_ref": "1468a553",
       "uninstall_script_ref": "24e71e3c",
-      "sha256": "9eaf4b01fac061343d965d42cdff820d80fecf16c5b6aa8f2f39221fdd33112b",
+      "sha256": "96deef993f818949f038d12b34b12ef29e17ea15cff268927611eacad4d6749c",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/firefox/darwin.json
+++ b/ee/maintained-apps/outputs/firefox/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "152.0.6",
+      "version": "153.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefox';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefox' AND version_compare(bundle_short_version, '152.0.6') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefox' AND version_compare(bundle_short_version, '153.0') < 0);"
       },
-      "installer_url": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/152.0.6/mac/en-US/Firefox%20152.0.6.dmg",
+      "installer_url": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/153.0/mac/en-US/Firefox%20153.0.dmg",
       "install_script_ref": "b5e4c76e",
       "uninstall_script_ref": "b85c0267",
-      "sha256": "747002d592063e0b106de0c500b34fe6d84438b3b866621521c8e7be9ea7816c",
+      "sha256": "2f9b5a20e546e7e79e4182f8fe10353a3e251635963ab3f6d399a3f290adeb96",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/firefox@esr/darwin.json
+++ b/ee/maintained-apps/outputs/firefox@esr/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "140.12.0",
+      "version": "140.13.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefox';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefox' AND version_compare(bundle_short_version, '140.12.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefox' AND version_compare(bundle_short_version, '140.13.0') < 0);"
       },
-      "installer_url": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/140.12.0esr/mac/en-US/Firefox%20140.12.0esr.dmg",
+      "installer_url": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/140.13.0esr/mac/en-US/Firefox%20140.13.0esr.dmg",
       "install_script_ref": "b5e4c76e",
       "uninstall_script_ref": "cc27bc9d",
-      "sha256": "7d868edcee33d55d904303add39803b9b1ad91921d7a0c129d2a313db0c9f70c",
+      "sha256": "0a7c51def21ab65d295d839c270405d0a2c2a04d589e8ce92c5e238eeb3f1827",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/firefox@nightly/darwin.json
+++ b/ee/maintained-apps/outputs/firefox@nightly/darwin.json
@@ -4,12 +4,12 @@
       "version": "155.0a1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15526.7.20') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15526.7.21') < 0);"
       },
-      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/07/2026-07-20-18-01-21-mozilla-central/firefox-155.0a1.en-US.mac.dmg",
+      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/07/2026-07-21-09-46-48-mozilla-central/firefox-155.0a1.en-US.mac.dmg",
       "install_script_ref": "418c9331",
       "uninstall_script_ref": "d7c711ad",
-      "sha256": "474b81b961013e575a2c0ff8c275cb54040b343bcce9fda093b37c2291569500",
+      "sha256": "9d33b42372f73ee68c76b7c7ea3247a3ef2590ab44bed743efcbab154f525d7c",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/miro/windows.json
+++ b/ee/maintained-apps/outputs/miro/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.11.160",
+      "version": "0.11.162",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Miro' AND publisher = 'Miro';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Miro' AND publisher = 'Miro' AND version_compare(version, '0.11.160') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Miro' AND publisher = 'Miro' AND version_compare(version, '0.11.162') < 0);"
       },
       "installer_url": "https://desktop.miro.com/platforms/win32-nsis-pu/Miro-setup.exe",
       "install_script_ref": "c9d9747e",
       "uninstall_script_ref": "66f6a4de",
-      "sha256": "cfca313ba6755875619b46c1de6be5fc7c4cd759a979b39ed295c7e459505d22",
+      "sha256": "4171f42b7e96474da7074f4dbd4fd7f554a931af01d26a2fe67098890bb4a268",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/nordpass/darwin.json
+++ b/ee/maintained-apps/outputs/nordpass/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "7.8.15",
+      "version": "7.9.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.nordsec.nordpass';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.nordsec.nordpass' AND version_compare(bundle_short_version, '7.8.15') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.nordsec.nordpass' AND version_compare(bundle_short_version, '7.9.2') < 0);"
       },
       "installer_url": "https://downloads.npass.app/mac/arm/NordPass.dmg",
       "install_script_ref": "0ea9b11c",

--- a/ee/maintained-apps/outputs/royal-tsx/windows.json
+++ b/ee/maintained-apps/outputs/royal-tsx/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.4.50622.0",
+      "version": "7.4.50721.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Royal TS V7' AND publisher = 'Royal Apps GmbH';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Royal TS V7' AND publisher = 'Royal Apps GmbH' AND version_compare(version, '7.4.50622.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Royal TS V7' AND publisher = 'Royal Apps GmbH' AND version_compare(version, '7.4.50721.0') < 0);"
       },
-      "installer_url": "https://download.royalapps.com/royalts/royaltsinstaller_7.04.50622.0_x64.msi",
+      "installer_url": "https://download.royalapps.com/royalts/royaltsinstaller_7.04.50721.0_x64.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "451ca1a9",
-      "sha256": "15ab43f81302b03084438bad5c4337ca1713d8251e0d615b0e9d48b6f91cdf1e",
+      "sha256": "789ea989833a8701f3b9ba1e9349743c08abb27b21cff3285a89618e4ba9a8de",
       "default_categories": [
         "Productivity"
       ],

--- a/ee/maintained-apps/outputs/typora/windows.json
+++ b/ee/maintained-apps/outputs/typora/windows.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "1.14.1",
+      "version": "1.14.7",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Typora' AND publisher = 'typora.io';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Typora' AND publisher = 'typora.io' AND version_compare(version, '1.14.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Typora' AND publisher = 'typora.io' AND version_compare(version, '1.14.7') < 0);"
       },
       "installer_url": "https://downloads.typora.io/windows/typora-setup-x64-1.14.7.exe",
       "install_script_ref": "cf428c2f",

--- a/ee/maintained-apps/outputs/typora/windows.json
+++ b/ee/maintained-apps/outputs/typora/windows.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "1.14.7",
+      "version": "1.14.1",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Typora' AND publisher = 'typora.io';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Typora' AND publisher = 'typora.io' AND version_compare(version, '1.14.7') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Typora' AND publisher = 'typora.io' AND version_compare(version, '1.14.1') < 0);"
       },
       "installer_url": "https://downloads.typora.io/windows/typora-setup-x64-1.14.7.exe",
       "install_script_ref": "cf428c2f",


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated BetterTouchTool for macOS to 6.651.
  - Updated BetterZip for macOS to 6.0.
  - Updated Downie for macOS to 4.12.11.
  - Updated Firefox for macOS to 153.0, Firefox ESR to 140.13.0esr, and Firefox Nightly to the latest build.
  - Updated NordPass for macOS to 7.9.2.
  - Updated Miro for Windows to 0.11.162.
  - Updated Royal TS for Windows to 7.4.50721.0.
  - Updated Typora for Windows to 1.14.7.
  - Refreshed installer links and verification data for applicable applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->