### PR TITLE
Add server flag to bypass Custom SCEP Proxy challenge PrintableString check

### DIFF
--- a/changes/49659-scep-challenge-warning-not-block
+++ b/changes/49659-scep-challenge-warning-not-block
@@ -1,0 +1,1 @@
+* Added a `server.allow_scep_challenge_non_printable_chars` server config flag that, when enabled, logs a warning instead of rejecting Custom SCEP Proxy challenges containing characters that break Windows certificate enrollment.

--- a/ee/server/service/certificate_authorities.go
+++ b/ee/server/service/certificate_authorities.go
@@ -409,6 +409,24 @@ func challengeHasAllowedChars(challenge string) bool {
 	return printableStringChallengeRegexp.MatchString(challenge)
 }
 
+// challengeCharsAllowedOrWarn reports whether a Custom SCEP Proxy challenge should be accepted despite
+// containing characters outside the ASN.1 PrintableString set. By default it isn't (the caller should
+// reject), but if server.allow_scep_challenge_non_printable_chars is enabled, it logs a warning and
+// reports the challenge as allowed instead. The character restriction only matters for Windows (which
+// encodes the SCEP challenge as PrintableString); the escape hatch exists for deployments that never
+// enroll Windows hosts with the affected CA and can't change a challenge already used elsewhere.
+func (svc *Service) challengeCharsAllowedOrWarn(ctx context.Context, challenge, caName string) bool {
+	if challengeHasAllowedChars(challenge) {
+		return true
+	}
+	if !svc.config.Server.AllowSCEPChallengeNonPrintableChars {
+		return false
+	}
+	svc.logger.WarnContext(ctx, "custom SCEP proxy challenge contains characters outside the ASN.1 PrintableString set; Windows certificate enrollment may fail for hosts using this CA; allowed because server.allow_scep_challenge_non_printable_chars is enabled",
+		"name", caName)
+	return true
+}
+
 // validateCustomSCEPProxy validates a custom SCEP proxy CA payload. validateChallengeChars controls whether
 // the challenge is checked for Windows-incompatible (non-PrintableString) characters; callers should only
 // set it when the challenge is being created or changed, so that challenges stored before this validation
@@ -423,7 +441,7 @@ func (svc *Service) validateCustomSCEPProxy(ctx context.Context, customSCEP *fle
 	if customSCEP.Challenge == "" || customSCEP.Challenge == fleet.MaskedPassword {
 		return fleet.NewInvalidArgumentError("challenge", fmt.Sprintf("%sCustom SCEP Proxy challenge cannot be empty", errPrefix))
 	}
-	if validateChallengeChars && !challengeHasAllowedChars(customSCEP.Challenge) {
+	if validateChallengeChars && !svc.challengeCharsAllowedOrWarn(ctx, customSCEP.Challenge, customSCEP.Name) {
 		return fleet.NewInvalidArgumentError("challenge", fmt.Sprintf("%s%s", errPrefix, scepChallengePrintableErrMsg))
 	}
 	if err := svc.scepConfigService.ValidateSCEPURL(ctx, customSCEP.URL); err != nil {
@@ -1230,7 +1248,7 @@ func (svc *Service) UpdateCertificateAuthority(ctx context.Context, id uint, p f
 			return err
 		}
 		p.CustomSCEPProxyCAUpdatePayload.Preprocess()
-		if err := svc.validateCustomSCEPProxyUpdate(ctx, p.CustomSCEPProxyCAUpdatePayload, errPrefix); err != nil {
+		if err := svc.validateCustomSCEPProxyUpdate(ctx, p.CustomSCEPProxyCAUpdatePayload, *oldCA.Name, errPrefix); err != nil {
 			return err
 		}
 		caToUpdate.Type = string(fleet.CATypeCustomSCEPProxy)
@@ -1486,11 +1504,12 @@ func (svc *Service) validateNDESSCEPProxyUpdate(ctx context.Context, ndesSCEP *f
 	return nil
 }
 
-func (svc *Service) validateCustomSCEPProxyUpdate(ctx context.Context, customSCEP *fleet.CustomSCEPProxyCAUpdatePayload, errPrefix string) error {
+func (svc *Service) validateCustomSCEPProxyUpdate(ctx context.Context, customSCEP *fleet.CustomSCEPProxyCAUpdatePayload, caName, errPrefix string) error {
 	if customSCEP.Name != nil {
 		if err := validateCAName(*customSCEP.Name, errPrefix); err != nil {
 			return err
 		}
+		caName = *customSCEP.Name
 	}
 	if customSCEP.URL != nil {
 		if err := validateURL(*customSCEP.URL, "SCEP", errPrefix); err != nil {
@@ -1509,7 +1528,7 @@ func (svc *Service) validateCustomSCEPProxyUpdate(ctx context.Context, customSCE
 	// Only validate the challenge characters when a new challenge value is provided. A nil or masked challenge means it is unchanged,
 	// so challenges stored before this validation existed keep working.
 	if customSCEP.Challenge != nil && *customSCEP.Challenge != fleet.MaskedPassword &&
-		!challengeHasAllowedChars(*customSCEP.Challenge) {
+		!svc.challengeCharsAllowedOrWarn(ctx, *customSCEP.Challenge, caName) {
 		return &fleet.BadRequestError{Message: fmt.Sprintf("%s%s", errPrefix, scepChallengePrintableErrMsg)}
 	}
 

--- a/ee/server/service/certificate_authorities_test.go
+++ b/ee/server/service/certificate_authorities_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -426,6 +427,26 @@ func TestCreatingCertificateAuthorities(t *testing.T) {
 		_, err := svc.NewCertificateAuthority(ctx, createRequest)
 		require.ErrorContains(t, err, scepChallengePrintableErrMsg)
 		require.Empty(t, createdCAs)
+	})
+
+	t.Run("Create Custom SCEP CA - challenge with non-printable character logs a warning instead of erroring when the bypass flag is enabled", func(t *testing.T) {
+		svc, ctx := baseSetupForCATests()
+		var logBuf bytes.Buffer
+		svc.logger = slog.New(slog.NewTextHandler(&logBuf, nil))
+		svc.config.Server.AllowSCEPChallengeNonPrintableChars = true
+
+		createRequest := fleet.CertificateAuthorityPayload{
+			CustomSCEPProxy: &fleet.CustomSCEPProxyCA{
+				Name:      "CustomSCEPWIFI",
+				URL:       "https://customscep.example.com",
+				Challenge: "bad_challenge", // underscore is not a valid ASN.1 PrintableString character
+			},
+		}
+
+		_, err := svc.NewCertificateAuthority(ctx, createRequest)
+		require.EqualError(t, err, "mock error to avoid NewActivity panic")
+		require.Len(t, createdCAs, 1)
+		assert.Contains(t, logBuf.String(), "PrintableString")
 	})
 
 	t.Run("Create NDES SCEP CA - Happy path", func(t *testing.T) {
@@ -1610,6 +1631,23 @@ func TestUpdatingCertificateAuthorities(t *testing.T) {
 			require.ErrorContains(t, err, scepChallengePrintableErrMsg)
 		})
 
+		t.Run("Challenge with non-printable character logs a warning instead of erroring when the bypass flag is enabled", func(t *testing.T) {
+			svc, ctx := baseSetupForCATests()
+			var logBuf bytes.Buffer
+			svc.logger = slog.New(slog.NewTextHandler(&logBuf, nil))
+			svc.config.Server.AllowSCEPChallengeNonPrintableChars = true
+
+			payload := fleet.CertificateAuthorityUpdatePayload{
+				CustomSCEPProxyCAUpdatePayload: &fleet.CustomSCEPProxyCAUpdatePayload{
+					Challenge: new("bad_challenge"), // underscore is not a valid ASN.1 PrintableString character
+				},
+			}
+
+			err := svc.UpdateCertificateAuthority(ctx, scepID, payload)
+			require.EqualError(t, err, "mock error to avoid NewActivity panic")
+			assert.Contains(t, logBuf.String(), "PrintableString")
+		})
+
 		t.Run("Masked (unchanged) challenge skips character validation", func(t *testing.T) {
 			// Backward compatibility: an unchanged challenge is submitted as the masked placeholder, so it must
 			// not be re-validated. Otherwise editing a CA whose challenge predates this validation would break.
@@ -2060,38 +2098,51 @@ func TestChallengeHasAllowedChars(t *testing.T) {
 // TestProcessCustomSCEPProxyCAsChallengeValidation covers the GitOps/batch path, which (unlike the UI
 // update path) provides the challenge unmasked and detects "unchanged" by comparing the incoming
 // challenge to the existing one. A pre-existing challenge with otherwise-disallowed characters must keep
-// working when it is re-applied unchanged.
+// working when it is re-applied unchanged. By default, a new/changed challenge with disallowed
+// characters is rejected; when server.allow_scep_challenge_non_printable_chars is enabled, it is
+// instead logged as a warning and the batch apply proceeds.
 func TestProcessCustomSCEPProxyCAsChallengeValidation(t *testing.T) {
-	svc := &Service{
-		logger: slog.New(slog.NewTextHandler(os.Stdout, nil)),
-		scepConfigService: &scep_mock.SCEPConfigService{
-			ValidateSCEPURLFunc: func(_ context.Context, _ string) error { return nil },
-		},
-	}
 	const url = "https://customscep.example.com"
 
 	tests := []struct {
-		name     string
-		existing []fleet.CustomSCEPProxyCA
-		incoming []fleet.CustomSCEPProxyCA
-		wantErr  bool
+		name              string
+		existing          []fleet.CustomSCEPProxyCA
+		incoming          []fleet.CustomSCEPProxyCA
+		allowNonPrintable bool
+		wantErr           bool
+		wantWarning       bool
 	}{
 		{
-			name:     "new CA with disallowed challenge is rejected",
+			name:     "new CA with disallowed challenge is rejected by default",
 			incoming: []fleet.CustomSCEPProxyCA{{Name: "SCEP1", URL: url, Challenge: "bad_challenge"}},
 			wantErr:  true,
 		},
 		{
-			name:     "unchanged disallowed challenge is skipped (backward compatible)",
+			name:              "new CA with disallowed challenge logs a warning instead of erroring when the flag is enabled",
+			incoming:          []fleet.CustomSCEPProxyCA{{Name: "SCEP1", URL: url, Challenge: "bad_challenge"}},
+			allowNonPrintable: true,
+			wantErr:           false,
+			wantWarning:       true,
+		},
+		{
+			name:     "unchanged disallowed challenge is skipped by default (backward compatible)",
 			existing: []fleet.CustomSCEPProxyCA{{Name: "SCEP1", URL: url, Challenge: "legacy_challenge"}},
 			incoming: []fleet.CustomSCEPProxyCA{{Name: "SCEP1", URL: url, Challenge: "legacy_challenge"}},
 			wantErr:  false,
 		},
 		{
-			name:     "challenge changed to a disallowed value is rejected",
+			name:     "challenge changed to a disallowed value is rejected by default",
 			existing: []fleet.CustomSCEPProxyCA{{Name: "SCEP1", URL: url, Challenge: "goodchallenge"}},
 			incoming: []fleet.CustomSCEPProxyCA{{Name: "SCEP1", URL: url, Challenge: "new_bad"}},
 			wantErr:  true,
+		},
+		{
+			name:              "challenge changed to a disallowed value logs a warning instead of erroring when the flag is enabled",
+			existing:          []fleet.CustomSCEPProxyCA{{Name: "SCEP1", URL: url, Challenge: "goodchallenge"}},
+			incoming:          []fleet.CustomSCEPProxyCA{{Name: "SCEP1", URL: url, Challenge: "new_bad"}},
+			allowNonPrintable: true,
+			wantErr:           false,
+			wantWarning:       true,
 		},
 		{
 			name:     "challenge changed to an allowed value succeeds",
@@ -2102,11 +2153,24 @@ func TestProcessCustomSCEPProxyCAsChallengeValidation(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			var logBuf bytes.Buffer
+			svc := &Service{
+				logger: slog.New(slog.NewTextHandler(&logBuf, nil)),
+				scepConfigService: &scep_mock.SCEPConfigService{
+					ValidateSCEPURLFunc: func(_ context.Context, _ string) error { return nil },
+				},
+			}
+			svc.config.Server.AllowSCEPChallengeNonPrintableChars = tt.allowNonPrintable
 			err := svc.processCustomSCEPProxyCAs(t.Context(), &fleet.CertificateAuthoritiesBatchOperations{}, tt.incoming, tt.existing)
 			if tt.wantErr {
 				require.ErrorContains(t, err, scepChallengePrintableErrMsg)
 			} else {
 				require.NoError(t, err)
+			}
+			if tt.wantWarning {
+				assert.Contains(t, logBuf.String(), "PrintableString")
+			} else {
+				assert.NotContains(t, logBuf.String(), "PrintableString")
 			}
 		})
 	}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -118,30 +118,31 @@ const (
 
 // ServerConfig defines configs related to the Fleet server
 type ServerConfig struct {
-	Address                          string
-	Cert                             string
-	Key                              string
-	TLS                              bool
-	TLSProfile                       string        `yaml:"tls_compatibility"`
-	URLPrefix                        string        `yaml:"url_prefix"`
-	Keepalive                        bool          `yaml:"keepalive"`
-	SandboxEnabled                   bool          `yaml:"sandbox_enabled"`
-	WebsocketsAllowUnsafeOrigin      bool          `yaml:"websockets_allow_unsafe_origin"`
-	FrequentCleanupsEnabled          bool          `yaml:"frequent_cleanups_enabled"`
-	ForceH2C                         bool          `yaml:"force_h2c"`
-	PrivateKey                       string        `yaml:"private_key"`
-	PrivateKeySecretArn              string        `yaml:"private_key_arn"`
-	PrivateKeySecretRegion           string        `yaml:"private_key_region"`
-	PrivateKeySecretSTSAssumeRoleArn string        `yaml:"private_key_sts_assume_role_arn"`
-	PrivateKeySecretSTSExternalID    string        `yaml:"private_key_sts_external_id"`
-	VPPVerifyTimeout                 time.Duration `yaml:"vpp_verify_timeout"`
-	VPPVerifyRequestDelay            time.Duration `yaml:"vpp_verify_request_delay"`
-	CleanupDistTargetsAge            time.Duration `yaml:"cleanup_dist_targets_age"`
-	MaxInstallerSizeBytes            int64         `yaml:"max_installer_size"`
-	TrustedProxies                   string        `yaml:"trusted_proxies"`
-	GzipResponses                    bool          `yaml:"gzip_responses"`
-	DefaultMaxRequestBodySize        int64         `yaml:"default_max_request_body_size"`
-	AllowPrivateNetworkIntegrations  bool          `yaml:"allow_private_network_integrations"`
+	Address                             string
+	Cert                                string
+	Key                                 string
+	TLS                                 bool
+	TLSProfile                          string        `yaml:"tls_compatibility"`
+	URLPrefix                           string        `yaml:"url_prefix"`
+	Keepalive                           bool          `yaml:"keepalive"`
+	SandboxEnabled                      bool          `yaml:"sandbox_enabled"`
+	WebsocketsAllowUnsafeOrigin         bool          `yaml:"websockets_allow_unsafe_origin"`
+	FrequentCleanupsEnabled             bool          `yaml:"frequent_cleanups_enabled"`
+	ForceH2C                            bool          `yaml:"force_h2c"`
+	PrivateKey                          string        `yaml:"private_key"`
+	PrivateKeySecretArn                 string        `yaml:"private_key_arn"`
+	PrivateKeySecretRegion              string        `yaml:"private_key_region"`
+	PrivateKeySecretSTSAssumeRoleArn    string        `yaml:"private_key_sts_assume_role_arn"`
+	PrivateKeySecretSTSExternalID       string        `yaml:"private_key_sts_external_id"`
+	VPPVerifyTimeout                    time.Duration `yaml:"vpp_verify_timeout"`
+	VPPVerifyRequestDelay               time.Duration `yaml:"vpp_verify_request_delay"`
+	CleanupDistTargetsAge               time.Duration `yaml:"cleanup_dist_targets_age"`
+	MaxInstallerSizeBytes               int64         `yaml:"max_installer_size"`
+	TrustedProxies                      string        `yaml:"trusted_proxies"`
+	GzipResponses                       bool          `yaml:"gzip_responses"`
+	DefaultMaxRequestBodySize           int64         `yaml:"default_max_request_body_size"`
+	AllowPrivateNetworkIntegrations     bool          `yaml:"allow_private_network_integrations"`
+	AllowSCEPChallengeNonPrintableChars bool          `yaml:"allow_scep_challenge_non_printable_chars"`
 }
 
 func (s *ServerConfig) DefaultHTTPServer(ctx context.Context, handler http.Handler) *http.Server {
@@ -1412,6 +1413,7 @@ func (man Manager) addConfigs() {
 	man.addConfigBool("server.gzip_responses", false, "Enable gzip-compressed responses for supported clients")
 	man.addConfigBool("server.allow_private_network_integrations", false, "Allow integration HTTP requests to private network addresses (RFC 1918). Loopback and cloud metadata addresses are always blocked regardless of this setting.")
 	man.addConfigByteSize("server.default_max_request_body_size", installersize.Human(platform_http.MaxRequestBodySize), "Default maximum size in bytes for request bodies, certain endpoints will have higher limits (e.g. 10MiB, 500KB, 1G)")
+	man.addConfigBool("server.allow_scep_challenge_non_printable_chars", false, "Allow Custom SCEP Proxy challenges containing characters outside the ASN.1 PrintableString set (e.g. \"_\"). Such challenges work on non-Windows platforms but cause Windows certificate enrollment to fail; enabling this logs a warning instead of rejecting them.")
 
 	// Hide the sandbox flag as we don't want it to be discoverable for users for now
 	man.hideConfig("server.sandbox_enabled")
@@ -1901,30 +1903,31 @@ func (man Manager) LoadConfig() FleetConfig {
 			LiveQuerySmallTargetThreshold: man.getConfigInt("redis.live_query_small_target_threshold"),
 		},
 		Server: ServerConfig{
-			Address:                          man.getConfigString("server.address"),
-			Cert:                             man.getConfigString("server.cert"),
-			Key:                              man.getConfigString("server.key"),
-			TLS:                              man.getConfigBool("server.tls"),
-			TLSProfile:                       man.getConfigTLSProfile(),
-			URLPrefix:                        man.getConfigString("server.url_prefix"),
-			Keepalive:                        man.getConfigBool("server.keepalive"),
-			SandboxEnabled:                   man.getConfigBool("server.sandbox_enabled"),
-			WebsocketsAllowUnsafeOrigin:      man.getConfigBool("server.websockets_allow_unsafe_origin"),
-			FrequentCleanupsEnabled:          man.getConfigBool("server.frequent_cleanups_enabled"),
-			ForceH2C:                         man.getConfigBool("server.force_h2c"),
-			PrivateKey:                       man.getConfigString("server.private_key"),
-			PrivateKeySecretArn:              man.getConfigString("server.private_key_arn"),
-			PrivateKeySecretRegion:           man.getConfigString("server.private_key_region"),
-			PrivateKeySecretSTSAssumeRoleArn: man.getConfigString("server.private_key_sts_assume_role_arn"),
-			PrivateKeySecretSTSExternalID:    man.getConfigString("server.private_key_sts_external_id"),
-			VPPVerifyTimeout:                 man.getConfigDuration("server.vpp_verify_timeout"),
-			VPPVerifyRequestDelay:            man.getConfigDuration("server.vpp_verify_request_delay"),
-			CleanupDistTargetsAge:            man.getConfigDuration("server.cleanup_dist_targets_age"),
-			MaxInstallerSizeBytes:            man.getConfigByteSize("server.max_installer_size"),
-			TrustedProxies:                   man.getConfigString("server.trusted_proxies"),
-			GzipResponses:                    man.getConfigBool("server.gzip_responses"),
-			DefaultMaxRequestBodySize:        man.getConfigByteSize("server.default_max_request_body_size"),
-			AllowPrivateNetworkIntegrations:  man.getConfigBool("server.allow_private_network_integrations"),
+			Address:                             man.getConfigString("server.address"),
+			Cert:                                man.getConfigString("server.cert"),
+			Key:                                 man.getConfigString("server.key"),
+			TLS:                                 man.getConfigBool("server.tls"),
+			TLSProfile:                          man.getConfigTLSProfile(),
+			URLPrefix:                           man.getConfigString("server.url_prefix"),
+			Keepalive:                           man.getConfigBool("server.keepalive"),
+			SandboxEnabled:                      man.getConfigBool("server.sandbox_enabled"),
+			WebsocketsAllowUnsafeOrigin:         man.getConfigBool("server.websockets_allow_unsafe_origin"),
+			FrequentCleanupsEnabled:             man.getConfigBool("server.frequent_cleanups_enabled"),
+			ForceH2C:                            man.getConfigBool("server.force_h2c"),
+			PrivateKey:                          man.getConfigString("server.private_key"),
+			PrivateKeySecretArn:                 man.getConfigString("server.private_key_arn"),
+			PrivateKeySecretRegion:              man.getConfigString("server.private_key_region"),
+			PrivateKeySecretSTSAssumeRoleArn:    man.getConfigString("server.private_key_sts_assume_role_arn"),
+			PrivateKeySecretSTSExternalID:       man.getConfigString("server.private_key_sts_external_id"),
+			VPPVerifyTimeout:                    man.getConfigDuration("server.vpp_verify_timeout"),
+			VPPVerifyRequestDelay:               man.getConfigDuration("server.vpp_verify_request_delay"),
+			CleanupDistTargetsAge:               man.getConfigDuration("server.cleanup_dist_targets_age"),
+			MaxInstallerSizeBytes:               man.getConfigByteSize("server.max_installer_size"),
+			TrustedProxies:                      man.getConfigString("server.trusted_proxies"),
+			GzipResponses:                       man.getConfigBool("server.gzip_responses"),
+			DefaultMaxRequestBodySize:           man.getConfigByteSize("server.default_max_request_body_size"),
+			AllowPrivateNetworkIntegrations:     man.getConfigBool("server.allow_private_network_integrations"),
+			AllowSCEPChallengeNonPrintableChars: man.getConfigBool("server.allow_scep_challenge_non_printable_chars"),
 		},
 		Auth: AuthConfig{
 			BcryptCost:                  man.getConfigInt("auth.bcrypt_cost"),


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #49659

A Fleet instance failed a GitOps push because their long-standing Custom SCEP Proxy challenge (safely reused across their macOS/iOS/Linux Fleet instances) contains a character outside the ASN.1 PrintableString set required only for Windows SCEP enrollment (#47492). Because this was a brand-new instance, the challenge counted as "new" and hit the hard block on its very first apply, even though the instance manages zero Windows hosts and the challenge can't be changed without re-enrolling certificates across every MDM instance they run.

This is to quickly unblock users facing this issue, and would require a follow-up to get rid of this flag and introduce platform-specific checks.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually

## New Fleet configuration settings

- [x] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a server setting to allow Custom SCEP Proxy challenges containing characters incompatible with Windows certificate enrollment.
  * When enabled, these challenges are accepted and a warning is logged instead of blocking certificate authority creation or updates.

* **Bug Fixes**
  * Preserved existing validation behavior when the setting is disabled.
  * Improved handling of affected challenges during automated certificate authority processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->