### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/proton-drive/windows.json
+++ b/ee/maintained-apps/outputs/proton-drive/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.0.2",
+      "version": "3.0.3",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Proton Drive' AND publisher = 'Proton AG';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Proton Drive' AND publisher = 'Proton AG' AND version_compare(version, '3.0.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Proton Drive' AND publisher = 'Proton AG' AND version_compare(version, '3.0.3') < 0);"
       },
-      "installer_url": "https://proton.me/download/drive/windows/3.0.2/x64/Proton%20Drive%20Setup%203.0.2.exe",
+      "installer_url": "https://proton.me/download/drive/windows/3.0.3/x64/Proton%20Drive%20Setup%203.0.3.exe",
       "install_script_ref": "0bff62f0",
       "uninstall_script_ref": "7491c781",
-      "sha256": "5d12341e356eb32ff0675eb73caed3e128aeb16fb780aeb53c677fc9d6bcae14",
+      "sha256": "b71d632d81a05f53094739e7a280dead517e36dec078308e0bba7d30d35d343c",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/snagit/darwin.json
+++ b/ee/maintained-apps/outputs/snagit/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.2.0",
+      "version": "2026.3.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.TechSmith.Snagit';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.TechSmith.Snagit' AND version_compare(bundle_short_version, '2026.2.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.TechSmith.Snagit' AND version_compare(bundle_short_version, '2026.3.0') < 0);"
       },
-      "installer_url": "https://download.techsmith.com/snagitmac/releases/2026.2.0/snagit.dmg",
+      "installer_url": "https://download.techsmith.com/snagitmac/releases/2026.3.0/snagit.dmg",
       "install_script_ref": "1cd57b3a",
       "uninstall_script_ref": "b52ff2b2",
-      "sha256": "a69f6de7c0caf7c354c0f63b5cf8b1bd6093520849dacc0f85e7a3c9bf410a1e",
+      "sha256": "5be12e24ecc6e37d2ced0cf082761f296e70aa883863628f41556dad03595d27",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/tuple/darwin.json
+++ b/ee/maintained-apps/outputs/tuple/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.1.2",
+      "version": "3.1.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'app.tuple.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.tuple.app' AND version_compare(bundle_short_version, '3.1.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.tuple.app' AND version_compare(bundle_short_version, '3.1.3') < 0);"
       },
-      "installer_url": "https://d32ifkf9k9ezcg.cloudfront.net/production/sparkle/tuple-3.1.2-2026-07-13-b931d41cb7.zip",
+      "installer_url": "https://d32ifkf9k9ezcg.cloudfront.net/production/sparkle/tuple-3.1.3-2026-07-21-7b5d4785db.zip",
       "install_script_ref": "ff9821fc",
       "uninstall_script_ref": "2dba520b",
-      "sha256": "29c0bf29b22cfffc529b9ed15fe977dfb3a1e24c1de5d74cb77786d99b2ab40f",
+      "sha256": "2dd9d5463a72d37e36ea4fda1a1c8dcdc6522b06022c7de085ed65c1b36725b0",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/typora/windows.json
+++ b/ee/maintained-apps/outputs/typora/windows.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "1.14.1",
+      "version": "1.14.7",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Typora' AND publisher = 'typora.io';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Typora' AND publisher = 'typora.io' AND version_compare(version, '1.14.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Typora' AND publisher = 'typora.io' AND version_compare(version, '1.14.7') < 0);"
       },
       "installer_url": "https://downloads.typora.io/windows/typora-setup-x64-1.14.7.exe",
       "install_script_ref": "cf428c2f",


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated Proton Drive for Windows to version 3.0.3.
  - Updated Snagit for macOS to version 2026.3.0.
  - Updated Tuple for macOS to version 3.1.3.
  - Updated Typora for Windows to version 1.14.7.
  - Refreshed installer links and verification information for Proton Drive, Snagit, and Tuple to support the latest releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->