### PR TITLE
Gitops mode disables android MDM connect and turn off buttons

### DIFF
--- a/changes/48226-gitops-android-mdm-buttons
+++ b/changes/48226-gitops-android-mdm-buttons
@@ -1,0 +1,1 @@
+- Disabled the Android MDM "Connect" and "Turn off Android MDM" buttons with a GitOps tooltip when GitOps mode is enabled, matching the Windows MDM behavior.

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AndroidMdmPage/AndroidMdmPage.tests.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AndroidMdmPage/AndroidMdmPage.tests.tsx
@@ -1,0 +1,92 @@
+import React from "react";
+
+import { screen } from "@testing-library/react";
+
+import { createMockRouter, createCustomRenderer } from "test/test-utils";
+import { createMockConfig } from "__mocks__/configMock";
+import mdmAndroidAPI from "services/entities/mdm_android";
+
+import AndroidMdmPage from "./AndroidMdmPage";
+
+const createGitOpsConfig = () =>
+  createMockConfig({
+    gitops: {
+      gitops_mode_enabled: true,
+      repository_url: "https://example.com/repo",
+      exceptions: { labels: false, software: false, secrets: true },
+    },
+  });
+
+describe("AndroidMdmPage", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("disables the Connect button in GitOps mode", () => {
+    const render = createCustomRenderer({
+      withBackendMock: true,
+      context: {
+        app: {
+          isAndroidMdmEnabledAndConfigured: false,
+          config: createGitOpsConfig(),
+        },
+      },
+    });
+
+    render(<AndroidMdmPage router={createMockRouter()} />);
+
+    const connectButton = screen.getByRole("button", { name: "Connect" });
+    expect(connectButton).toBeDisabled();
+    // The button is disabled by the GitOps wrapper (which only renders its span
+    // in GitOps mode), not by some unrelated state.
+    expect(
+      connectButton.closest(".gitops-mode-tooltip-wrapper")
+    ).toBeInTheDocument();
+  });
+
+  it("enables the Connect button when not in GitOps mode", () => {
+    const render = createCustomRenderer({
+      withBackendMock: true,
+      context: {
+        app: {
+          isAndroidMdmEnabledAndConfigured: false,
+          config: createMockConfig(),
+        },
+      },
+    });
+
+    render(<AndroidMdmPage router={createMockRouter()} />);
+
+    const connectButton = screen.getByRole("button", { name: "Connect" });
+    expect(connectButton).toBeEnabled();
+    expect(
+      connectButton.closest(".gitops-mode-tooltip-wrapper")
+    ).not.toBeInTheDocument();
+  });
+
+  it("disables the Turn off Android MDM button in GitOps mode", async () => {
+    jest
+      .spyOn(mdmAndroidAPI, "getAndroidEnterprise")
+      .mockResolvedValue({ android_enterprise_id: true });
+
+    const render = createCustomRenderer({
+      withBackendMock: true,
+      context: {
+        app: {
+          isAndroidMdmEnabledAndConfigured: true,
+          config: createGitOpsConfig(),
+        },
+      },
+    });
+
+    render(<AndroidMdmPage router={createMockRouter()} />);
+
+    const turnOffButton = await screen.findByRole("button", {
+      name: "Turn off Android MDM",
+    });
+    expect(turnOffButton).toBeDisabled();
+    expect(
+      turnOffButton.closest(".gitops-mode-tooltip-wrapper")
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AndroidMdmPage/AndroidMdmPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AndroidMdmPage/AndroidMdmPage.tsx
@@ -20,6 +20,7 @@ import BackButton from "components/BackButton";
 import Button from "components/buttons/Button";
 import DataSet from "components/DataSet";
 import TooltipWrapper from "components/TooltipWrapper";
+import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
 import CustomLink from "components/CustomLink";
 import Spinner from "components/Spinner";
 import DataError from "components/DataError";
@@ -144,9 +145,18 @@ const TurnOnAndroidMdm = ({ router }: ITurnOnAndroidMdmProps) => {
           url="https://fleetdm.com/learn-more-about/how-to-connect-android-enterprise"
         />
       </div>
-      <Button isLoading={fetchingSignupUrl} onClick={onConnectMdm}>
-        Connect
-      </Button>
+      <GitOpsModeTooltipWrapper
+        tipOffset={8}
+        renderChildren={(disableChildren) => (
+          <Button
+            isLoading={fetchingSignupUrl}
+            disabled={disableChildren}
+            onClick={onConnectMdm}
+          >
+            Connect
+          </Button>
+        )}
+      />
     </>
   );
 };
@@ -197,7 +207,14 @@ const TurnOffAndroidMdm = ({ onClickTurnOff }: ITurnOffAndroidMdmProps) => {
         }
         value={data.android_enterprise_id}
       />
-      <Button onClick={onClickTurnOff}>Turn off Android MDM</Button>
+      <GitOpsModeTooltipWrapper
+        tipOffset={8}
+        renderChildren={(disableChildren) => (
+          <Button onClick={onClickTurnOff} disabled={disableChildren}>
+            Turn off Android MDM
+          </Button>
+        )}
+      />
     </>
   );
 };

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AndroidMdmPage/components/TurnOffAndroidMdmModal/TurnOffAndroidMdmModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AndroidMdmPage/components/TurnOffAndroidMdmModal/TurnOffAndroidMdmModal.tsx
@@ -9,6 +9,7 @@ import { IConfig } from "interfaces/config";
 
 import Modal from "components/Modal";
 import Button from "components/buttons/Button";
+import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
 import { notify } from "components/ToastNotification";
 
 const baseClass = "turn-off-android-mdm-modal";
@@ -65,14 +66,19 @@ const TurnOffAndroidMdmModal = ({
         their Android work partition.
       </p>
       <div className="modal-cta-wrap">
-        <Button
-          variant="alert"
-          isLoading={isDeleting}
-          disabled={isDeleting}
-          onClick={onClickConfirm}
-        >
-          Turn off
-        </Button>
+        <GitOpsModeTooltipWrapper
+          tipOffset={8}
+          renderChildren={(disableChildren) => (
+            <Button
+              variant="alert"
+              isLoading={isDeleting}
+              disabled={isDeleting || disableChildren}
+              onClick={onClickConfirm}
+            >
+              Turn off
+            </Button>
+          )}
+        />
         <Button variant="inverse-alert" disabled={isDeleting} onClick={onExit}>
           Cancel
         </Button>


### PR DESCRIPTION
**Related issue:** Resolves #48226 

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Android MDM actions are now disabled when GitOps mode is enabled.
  * Added GitOps guidance tooltips to the “Connect,” “Turn off Android MDM,” and confirmation actions.
  * Preserved existing loading and action behavior when GitOps mode is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->