### PR TITLE
Add homebrew_outdated table to fleetd

### DIFF
--- a/orbit/changes/47692-homebrew-outdated-table
+++ b/orbit/changes/47692-homebrew-outdated-table
@@ -1,0 +1,1 @@
+* Added the `homebrew_outdated` table to fleetd for querying outdated Homebrew packages (formulae and casks) on macOS, exposing installed and latest-available versions.

--- a/orbit/pkg/table/extension_darwin.go
+++ b/orbit/pkg/table/extension_darwin.go
@@ -21,6 +21,7 @@ import (
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/find_cmd"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/firmware_eficheck_integrity_check"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/firmwarepasswd"
+	"github.com/fleetdm/fleet/v4/orbit/pkg/table/homebrew_outdated"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/ioreg"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/macos_user_profiles"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/nvram_info"
@@ -74,6 +75,7 @@ func PlatformTables(opts PluginOpts) ([]osquery.OsqueryPlugin, error) {
 		table.NewPlugin("find_cmd", find_cmd.Columns(), find_cmd.Generate),
 		table.NewPlugin("macos_user_profiles", macos_user_profiles.Columns(), macos_user_profiles.Generate),
 		table.NewPlugin("disk_space", disk_space.Columns(), disk_space.Generate),
+		table.NewPlugin("homebrew_outdated", homebrew_outdated.Columns(), homebrew_outdated.Generate),
 
 		// Macadmins extension tables
 		table.NewPlugin("filevault_users", filevaultusers.FileVaultUsersColumns(), filevaultusers.FileVaultUsersGenerate),

--- a/orbit/pkg/table/homebrew_outdated/homebrew_outdated.go
+++ b/orbit/pkg/table/homebrew_outdated/homebrew_outdated.go
@@ -1,0 +1,264 @@
+// Package homebrew_outdated implements the fleetd `homebrew_outdated` osquery
+// table, which returns one row per installed version of each outdated Homebrew
+// package (formula or cask) on macOS.
+package homebrew_outdated
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/osquery/osquery-go/plugin/table"
+)
+
+const TableName = "homebrew_outdated"
+
+func Columns() []table.ColumnDefinition {
+	return []table.ColumnDefinition{
+		table.TextColumn("app_name"),
+		table.IntegerColumn("auto_updates"),
+		table.TextColumn("name"),
+		table.TextColumn("install_path"),
+		table.TextColumn("type"),
+		table.TextColumn("installed_version"),
+		table.TextColumn("current_version"),
+		table.TextColumn("pinned_version"),
+	}
+}
+
+const (
+	typeFormula = "formula"
+	typeCask    = "cask"
+)
+
+// outdatedPackage is the internal, normalized model for a single outdated
+// package occurrence: one package name paired with one installed version. A
+// brewOutdatedEntry with multiple installed versions expands into several of
+// these (see mapEntry). buildRows turns each one into an osquery result row.
+type outdatedPackage struct {
+	name             string
+	installedVersion string
+	currentVersion   string
+	pinnedVersion    string
+	pkgType          string // typeFormula or typeCask
+}
+
+// brewOutdatedEntry is one formula or cask in `brew outdated --json=v2` output.
+// A single entry can report more than one installed version (e.g. a
+// versioned/keg-only formula), hence InstalledVersions is a slice.
+type brewOutdatedEntry struct {
+	Name              string   `json:"name"`
+	InstalledVersions []string `json:"installed_versions"`
+	CurrentVersion    string   `json:"current_version"`
+	PinnedVersion     *string  `json:"pinned_version"` // null when the package is not pinned
+}
+
+// brewInfoCask is one cask in `brew info --json=v2` output. Only casks are read
+// from brew info: app_name and auto_updates are cask-only concepts used to enrich
+// the rows that `brew outdated` alone can't fully describe.
+type brewInfoCask struct {
+	Token       string   `json:"token"`        // matches the cask "name" in brew outdated
+	Name        []string `json:"name"`         // display name(s); first entry is the app name
+	AutoUpdates *bool    `json:"auto_updates"` // null/false -> cask does not auto-update
+}
+
+// nameConstraints returns the deduplicated values of any `name = <x>` equality
+// constraints in the query. Non-equality operators (LIKE, etc.)
+// are ignored — osquery still applies them to the returned rows.
+func nameConstraints(queryContext table.QueryContext) []string {
+	q, ok := queryContext.Constraints["name"]
+	if !ok {
+		return nil
+	}
+	var names []string
+	seen := make(map[string]struct{})
+	for _, c := range q.Constraints {
+		if c.Operator != table.OperatorEquals || c.Expression == "" {
+			continue
+		}
+		if _, dup := seen[c.Expression]; dup {
+			continue
+		}
+		seen[c.Expression] = struct{}{}
+		names = append(names, c.Expression)
+	}
+	return names
+}
+
+// brewRunner runs brew with the given args and returns stdout (plus any exec
+// error). It exists so outdatedPackages can be unit-tested without invoking brew.
+type brewRunner func(args ...string) ([]byte, error)
+
+// outdatedPackages runs `brew outdated` with the given name filter and
+// parses the result. When a name filter is supplied but the call produces no
+// parseable output, it falls back to a full scan this is because
+// brew aborts entirely (empty stdout) if any pushed-down name is not a known
+// formula/cask.
+func outdatedPackages(run brewRunner, names []string) ([]outdatedPackage, error) {
+	args := []string{"outdated", "--json=v2"}
+	if len(names) > 0 {
+		// "--" terminates option parsing so a pushed-down name beginning with "-"
+		// is treated as a package name rather than a brew option.
+		args = append(args, "--")
+		args = append(args, names...)
+	}
+	out, err := run(args...)
+	pkgs, perr := parseOutdated(out)
+
+	if perr != nil && len(names) > 0 {
+		out, err = run("outdated", "--json=v2")
+		pkgs, perr = parseOutdated(out)
+	}
+
+	if perr != nil {
+		if err != nil {
+			return nil, fmt.Errorf("running brew outdated: %w", err)
+		}
+		return nil, perr
+	}
+	return pkgs, nil
+}
+
+func parseOutdated(data []byte) ([]outdatedPackage, error) {
+	// `brew outdated --json=v2` splits results into formulae and casks.
+	var out struct {
+		Formulae []brewOutdatedEntry `json:"formulae"`
+		Casks    []brewOutdatedEntry `json:"casks"`
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, fmt.Errorf("parsing brew outdated output: %w", err)
+	}
+	pkgs := make([]outdatedPackage, 0, len(out.Formulae)+len(out.Casks))
+	for _, f := range out.Formulae {
+		pkgs = append(pkgs, mapEntry(f, typeFormula)...)
+	}
+	for _, c := range out.Casks {
+		pkgs = append(pkgs, mapEntry(c, typeCask)...)
+	}
+	return pkgs, nil
+}
+
+// firstExistingFile returns the first path in paths that exists and is a regular
+// file (not a directory), or "" if none match.
+func firstExistingFile(paths []string) string {
+	for _, p := range paths {
+		if fi, err := os.Stat(p); err == nil && !fi.IsDir() {
+			return p
+		}
+	}
+	return ""
+}
+
+// uniqueCaskNames returns the deduplicated names of the cask packages in pkgs,
+// preserving order. Only casks are enriched via brew info (app_name and
+// auto_updates are cask-only), so formulae are skipped; a package can also appear
+// multiple times (one row per installed version), so names are deduplicated.
+func uniqueCaskNames(pkgs []outdatedPackage) []string {
+	var names []string
+	seen := make(map[string]struct{})
+	for _, p := range pkgs {
+		if p.pkgType != typeCask {
+			continue
+		}
+		if _, ok := seen[p.name]; ok {
+			continue
+		}
+		seen[p.name] = struct{}{}
+		names = append(names, p.name)
+	}
+	return names
+}
+
+func mapEntry(e brewOutdatedEntry, pkgType string) []outdatedPackage {
+	versions := e.InstalledVersions
+	if len(versions) == 0 {
+		versions = []string{""}
+	}
+	var pinnedVersion string
+	if e.PinnedVersion != nil {
+		pinnedVersion = *e.PinnedVersion
+	}
+	pkgs := make([]outdatedPackage, 0, len(versions))
+	for _, v := range versions {
+		pkgs = append(pkgs, outdatedPackage{
+			name:             e.Name,
+			installedVersion: v,
+			currentVersion:   e.CurrentVersion,
+			pinnedVersion:    pinnedVersion,
+			pkgType:          pkgType,
+		})
+	}
+	return pkgs
+}
+
+// caskDetail is the cask-only enrichment (from brew info) applied to a row,
+// keyed by cask token in the map returned by parseCaskInfo.
+type caskDetail struct {
+	appName     string
+	autoUpdates string // "1", "0", or "" when unknown
+}
+
+func parseCaskInfo(data []byte) (map[string]caskDetail, error) {
+	var info struct {
+		Casks []brewInfoCask `json:"casks"`
+	}
+	if err := json.Unmarshal(data, &info); err != nil {
+		return nil, fmt.Errorf("parsing brew info output: %w", err)
+	}
+
+	details := make(map[string]caskDetail, len(info.Casks))
+	for _, c := range info.Casks {
+		var appName string
+		if len(c.Name) > 0 {
+			appName = c.Name[0]
+		}
+		autoUpdates := "0"
+		if c.AutoUpdates != nil && *c.AutoUpdates {
+			autoUpdates = "1"
+		}
+		details[c.Token] = caskDetail{appName: appName, autoUpdates: autoUpdates}
+	}
+	return details, nil
+}
+
+// buildRows merges outdated packages with cask enrichment details and derives the
+// install path from the Homebrew prefix, producing the final table rows.
+//
+// install_path is derived from Homebrew's standard layout under the prefix
+// (<prefix>/opt/<name> for formulae, <prefix>/Caskroom/<name> for casks). It
+// reflects the default layout; a non-default HOMEBREW_CELLAR/HOMEBREW_CASKROOM
+// relocation is not accounted for (querying brew per package to discover it would
+// be far too expensive). It is the Homebrew-managed location, not, for a cask, the
+// app's final /Applications path.
+//
+// app_name and auto_updates only apply to casks; they are empty for formulae.
+func buildRows(pkgs []outdatedPackage, casks map[string]caskDetail, prefix string) []map[string]string {
+	rows := make([]map[string]string, 0, len(pkgs))
+	for _, p := range pkgs {
+		row := map[string]string{
+			"name":              p.name,
+			"type":              p.pkgType,
+			"installed_version": p.installedVersion,
+			"current_version":   p.currentVersion,
+			"pinned_version":    p.pinnedVersion,
+			"app_name":          "",
+			"auto_updates":      "",
+		}
+		switch p.pkgType {
+		case typeFormula:
+			// <prefix>/opt/<formula> — the version-independent "opt" symlink
+			// (equivalent to `brew --prefix <formula>`).
+			row["install_path"] = filepath.Join(prefix, "opt", p.name)
+		case typeCask:
+			// <prefix>/Caskroom/<cask> (equivalent to `brew --caskroom <cask>`).
+			row["install_path"] = filepath.Join(prefix, "Caskroom", p.name)
+			if d, ok := casks[p.name]; ok {
+				row["app_name"] = d.appName
+				row["auto_updates"] = d.autoUpdates
+			}
+		}
+		rows = append(rows, row)
+	}
+	return rows
+}

--- a/orbit/pkg/table/homebrew_outdated/homebrew_outdated_darwin.go
+++ b/orbit/pkg/table/homebrew_outdated/homebrew_outdated_darwin.go
@@ -1,0 +1,162 @@
+//go:build darwin
+
+package homebrew_outdated
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"time"
+
+	tbl_common "github.com/fleetdm/fleet/v4/orbit/pkg/table/common"
+	"github.com/osquery/osquery-go/plugin/table"
+	"github.com/rs/zerolog/log"
+)
+
+// brewPaths are the well-known Homebrew binary locations: Apple Silicon first,
+// then Intel.
+var brewPaths = []string{
+	"/opt/homebrew/bin/brew",
+	"/usr/local/bin/brew",
+}
+
+// brewTimeout is the total budget shared across all brew invocations in a single
+// Generate (outdated + optional fallback + cask enrichment). `brew outdated` may
+// perform a `git fetch` of formula/cask metadata, so it is generous.
+const brewTimeout = 60 * time.Second
+
+// Generate is called to return the results for the table at query time.
+func Generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
+	// osquery runs as root, but brew refuses to run as root; resolve the console
+	// user up front so we can both run brew as them and look for a Homebrew install
+	// under their home directory.
+	uid, gid, err := tbl_common.GetConsoleUidGid()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get console user: %w", err)
+	}
+	var homeDir string
+	if uid != 0 {
+		homeDir = consoleHome(uid)
+	}
+
+	brewPath := findBrew(homeDir)
+	if brewPath == "" {
+		// Homebrew is not installed anywhere, return no rows rather than an
+		// error so the query simply yields nothing on hosts without Homebrew.
+		log.Debug().Msg("homebrew_outdated: no Homebrew installation found; returning no rows")
+		return nil, nil
+	}
+	prefix := filepath.Dir(filepath.Dir(brewPath))
+
+	if uid == 0 {
+		// Homebrew is installed system-wide, but there is no non-root console user
+		// to run it as (host at the login window or headless). brew won't run as
+		// root, so return no rows.
+		log.Debug().
+			Str("prefix", prefix).
+			Msg("homebrew_outdated: no console user available (login window or headless host); returning no rows")
+		return nil, nil
+	}
+
+	// Warn if the console user doesn't own the Homebrew install: brew can still
+	// read as a non-owner, but its auto-update git fetch may fail (the tap repos
+	// are owned by the install user), which can leave current_version stale. Stat
+	// the brew binary, not the prefix root: on Intel the prefix (/usr/local) root
+	// is root-owned even for a normal install, while the binary is owned by the
+	// installer on both Intel and Apple Silicon. Best-effort diagnostics only.
+	if fi, statErr := os.Stat(brewPath); statErr == nil {
+		if st, ok := fi.Sys().(*syscall.Stat_t); ok && st.Uid != uid {
+			log.Warn().
+				Str("brew", brewPath).
+				Uint32("owner_uid", st.Uid).
+				Uint32("console_uid", uid).
+				Msg("homebrew_outdated: console user does not own the Homebrew installation; brew auto-update may fail, so current_version could be stale")
+		}
+	}
+
+	// Build brew's environment: HOME points at the console user's home so brew
+	// reads/writes caches as that user rather than root, and the prefix's bin is on
+	// PATH so brew finds its own tooling (including for a non-standard per-user
+	// prefix).
+	env := []string{"PATH=" + prefix + "/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"}
+	if homeDir != "" {
+		env = append(env, "HOME="+homeDir)
+	}
+
+	// Bound the whole sequence of brew calls (pushdown outdated + optional fallback
+	// + cask enrichment) with a single shared deadline so cumulative latency stays
+	// capped rather than each call getting its own full timeout.
+	ctx, cancel := context.WithTimeout(ctx, brewTimeout)
+	defer cancel()
+
+	run := func(args ...string) ([]byte, error) {
+		return runBrew(ctx, brewPath, uid, gid, env, args...)
+	}
+
+	// Push `name = <x>` constraints down to brew so a query for specific packages
+	// (e.g. a policy) doesn't trigger a full `brew outdated` scan. outdatedPackages
+	// falls back to a full scan if a pushed-down name is unknown.
+	pkgs, err := outdatedPackages(run, nameConstraints(queryContext))
+	if err != nil {
+		return nil, err
+	}
+	if len(pkgs) == 0 {
+		return []map[string]string{}, nil
+	}
+
+	// Enrich casks with app_name and auto_updates via a single `brew info` call.
+	// Only cask names are passed (those are the only fields brew info supplies), so
+	// when nothing outdated is a cask we skip the call entirely.
+	casks := map[string]caskDetail{}
+	if caskNames := uniqueCaskNames(pkgs); len(caskNames) > 0 {
+		infoArgs := append([]string{"info", "--json=v2"}, caskNames...)
+		if infoOut, infoErr := runBrew(ctx, brewPath, uid, gid, env, infoArgs...); infoErr == nil {
+			if parsed, perr := parseCaskInfo(infoOut); perr == nil {
+				casks = parsed
+			}
+		}
+		// If `brew info` fails, we still return the core columns from `brew outdated`;
+		// only the cask-specific app_name/auto_updates columns will be empty.
+	}
+
+	return buildRows(pkgs, casks, prefix), nil
+}
+
+// findBrew returns the first existing Homebrew binary path, or "" if none exist.
+// The standard system prefixes are checked first; when homeDir is set, Homebrew's
+// documented per-user install location (<home>/homebrew) is checked as a fallback
+// so a user who installed brew without admin rights is still detected.
+func findBrew(homeDir string) string {
+	candidates := append([]string{}, brewPaths...)
+	if homeDir != "" {
+		candidates = append(candidates, filepath.Join(homeDir, "homebrew", "bin", "brew"))
+	}
+	return firstExistingFile(candidates)
+}
+
+// consoleHome returns the home directory of the console user, or "" if it can't
+// be resolved.
+func consoleHome(uid uint32) string {
+	u, err := user.LookupId(strconv.FormatUint(uint64(uid), 10))
+	if err != nil {
+		return ""
+	}
+	return u.HomeDir
+}
+
+// runBrew executes brew with the given args as the console user and returns
+// stdout. It honors the deadline on ctx (set once by Generate) so all brew calls
+// in a single Generate share one budget.
+func runBrew(ctx context.Context, brewPath string, uid, gid uint32, env []string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, brewPath, args...)
+	cmd.Env = env
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Credential: &syscall.Credential{Uid: uid, Gid: gid},
+	}
+	return cmd.Output()
+}

--- a/orbit/pkg/table/homebrew_outdated/homebrew_outdated_e2e_darwin_test.go
+++ b/orbit/pkg/table/homebrew_outdated/homebrew_outdated_e2e_darwin_test.go
@@ -1,0 +1,72 @@
+//go:build darwin
+
+package homebrew_outdated
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestGenerateE2E exercises the full pipeline against the real Homebrew
+// installation on the machine running the test. It runs `brew outdated` and
+// `brew info` directly (as the test user, without the console-user setuid that
+// Generate performs), then feeds the real output through the parse/build helpers
+// and asserts invariants. It is skipped when Homebrew is not installed.
+func TestGenerateE2E(t *testing.T) {
+	brewPath := findBrew("")
+	if brewPath == "" {
+		t.Skip("Homebrew is not installed; skipping e2e test")
+	}
+
+	outdatedOut, err := exec.Command(brewPath, "outdated", "--json=v2").Output()
+	require.NoError(t, err, "brew outdated should succeed")
+
+	pkgs, err := parseOutdated(outdatedOut)
+	require.NoError(t, err, "real brew outdated output should parse")
+
+	if len(pkgs) == 0 {
+		t.Log("no outdated Homebrew packages on this machine; parse of empty result verified")
+		return
+	}
+
+	// Enrich casks using real `brew info` output for the outdated packages.
+	names := make([]string, 0, len(pkgs))
+	for _, p := range pkgs {
+		names = append(names, p.name)
+	}
+	infoOut, err := exec.Command(brewPath, append([]string{"info", "--json=v2"}, names...)...).Output()
+	require.NoError(t, err, "brew info should succeed")
+	casks, err := parseCaskInfo(infoOut)
+	require.NoError(t, err, "real brew info output should parse")
+
+	prefix := brewPath[:strings.LastIndex(brewPath, "/bin/brew")]
+	rows := buildRows(pkgs, casks, prefix)
+	require.Len(t, rows, len(pkgs))
+
+	cols := Columns()
+	for _, row := range rows {
+		// Every declared column must be present in every row.
+		for _, col := range cols {
+			_, ok := row[col.Name]
+			require.Truef(t, ok, "row missing column %q: %v", col.Name, row)
+		}
+
+		require.NotEmpty(t, row["name"], "name should be populated")
+		require.Contains(t, []string{typeFormula, typeCask}, row["type"])
+		require.NotEmpty(t, row["installed_version"])
+		require.NotEmpty(t, row["current_version"])
+		require.True(t, strings.HasPrefix(row["install_path"], prefix), "install_path should be under the brew prefix")
+
+		if row["type"] == typeFormula {
+			// Formula rows carry no cask-specific enrichment.
+			require.Empty(t, row["app_name"])
+			require.Empty(t, row["auto_updates"])
+		} else {
+			// auto_updates is a boolean flag for casks.
+			require.Contains(t, []string{"0", "1"}, row["auto_updates"])
+		}
+	}
+}

--- a/orbit/pkg/table/homebrew_outdated/homebrew_outdated_test.go
+++ b/orbit/pkg/table/homebrew_outdated/homebrew_outdated_test.go
@@ -1,0 +1,277 @@
+package homebrew_outdated
+
+import (
+	_ "embed"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/osquery/osquery-go/plugin/table"
+	"github.com/stretchr/testify/require"
+)
+
+//go:embed test_data_outdated.json
+var outdatedData []byte
+
+//go:embed test_data_info.json
+var infoData []byte
+
+func TestParseOutdated(t *testing.T) {
+	pkgs, err := parseOutdated(outdatedData)
+	require.NoError(t, err)
+	// blake3 (1) + git (1) + openssl@3 (2 installed versions) + wget (1) + mitmproxy (1) + google-chrome (1)
+	require.Len(t, pkgs, 7)
+
+	require.Equal(t, outdatedPackage{
+		name:             "blake3",
+		installedVersion: "1.8.3",
+		currentVersion:   "1.8.5",
+		pkgType:          typeFormula,
+	}, pkgs[0])
+
+	// A package with multiple installed versions yields one row per version.
+	openssl := filterByName(pkgs, "openssl@3")
+	require.Len(t, openssl, 2)
+	require.Equal(t, "3.3.1", openssl[0].installedVersion)
+	require.Equal(t, "3.3.2", openssl[1].installedVersion)
+	require.Equal(t, "3.4.0", openssl[0].currentVersion)
+	require.Equal(t, "3.4.0", openssl[1].currentVersion)
+
+	// A pinned package carries its pinned_version; unpinned packages leave it empty.
+	wget := filterByName(pkgs, "wget")
+	require.Len(t, wget, 1)
+	require.Equal(t, "1.21.3", wget[0].pinnedVersion)
+	require.Empty(t, openssl[0].pinnedVersion)
+}
+
+func filterByName(pkgs []outdatedPackage, name string) []outdatedPackage {
+	var out []outdatedPackage
+	for _, p := range pkgs {
+		if p.name == name {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func TestNameConstraints(t *testing.T) {
+	qc := table.QueryContext{Constraints: map[string]table.ConstraintList{
+		"name": {Constraints: []table.Constraint{
+			{Operator: table.OperatorEquals, Expression: "ffmpeg"},
+			{Operator: table.OperatorEquals, Expression: "ffmpeg"}, // duplicate, deduped
+			{Operator: table.OperatorLike, Expression: "wg%"},      // non-equality, ignored
+			{Operator: table.OperatorEquals, Expression: ""},       // empty, ignored
+			{Operator: table.OperatorEquals, Expression: "wget"},
+		}},
+	}}
+	require.Equal(t, []string{"ffmpeg", "wget"}, nameConstraints(qc))
+
+	// No name constraint -> nil (Generate then runs a full scan).
+	require.Nil(t, nameConstraints(table.QueryContext{Constraints: map[string]table.ConstraintList{}}))
+}
+
+func TestOutdatedPackagesPushdown(t *testing.T) {
+	// Filtered call returns valid JSON -> used directly, no fallback.
+	var calls [][]string
+	run := func(args ...string) ([]byte, error) {
+		calls = append(calls, args)
+		return outdatedData, nil
+	}
+	pkgs, err := outdatedPackages(run, []string{"blake3"})
+	require.NoError(t, err)
+	require.NotEmpty(t, pkgs)
+	require.Equal(t, [][]string{{"outdated", "--json=v2", "--", "blake3"}}, calls)
+}
+
+func TestOutdatedPackagesFallbackOnUnknownName(t *testing.T) {
+	// First (pushed-down) call aborts with empty stdout because a name is unknown;
+	// we fall back to a full scan and let osquery filter the rows.
+	var calls [][]string
+	run := func(args ...string) ([]byte, error) {
+		calls = append(calls, args)
+		if len(calls) == 1 {
+			return []byte(""), errors.New("exit status 1") // brew aborted on bad name
+		}
+		return outdatedData, nil // full scan succeeds
+	}
+	pkgs, err := outdatedPackages(run, []string{"blake3", "zzzbogus"})
+	require.NoError(t, err)
+	require.NotEmpty(t, pkgs)
+	require.Equal(t, [][]string{
+		{"outdated", "--json=v2", "--", "blake3", "zzzbogus"}, // attempted pushdown
+		{"outdated", "--json=v2"},                             // fallback full scan, no names
+	}, calls)
+}
+
+func TestOutdatedPackagesExitOneWithValidJSON(t *testing.T) {
+	// `brew outdated <name>` exits non-zero when the package is outdated but still
+	// prints valid JSON. That output must be used, not treated as a failure.
+	var calls int
+	run := func(args ...string) ([]byte, error) {
+		calls++
+		return outdatedData, errors.New("exit status 1")
+	}
+	pkgs, err := outdatedPackages(run, []string{"blake3"})
+	require.NoError(t, err)
+	require.NotEmpty(t, pkgs)
+	require.Equal(t, 1, calls) // no fallback: the output parsed fine
+}
+
+func TestOutdatedPackagesEmptyResultNoFallback(t *testing.T) {
+	// A valid name that isn't installed yields empty-but-parseable JSON. Parsing
+	// succeeds, so there must be no fallback and no error.
+	var calls int
+	run := func(args ...string) ([]byte, error) {
+		calls++
+		return []byte(`{"formulae":[],"casks":[]}`), nil
+	}
+	pkgs, err := outdatedPackages(run, []string{"valid-not-installed"})
+	require.NoError(t, err)
+	require.Empty(t, pkgs)
+	require.Equal(t, 1, calls)
+}
+
+func TestOutdatedPackagesNoFallbackWithoutNames(t *testing.T) {
+	// Without a name filter the first call is already a full scan; a failure must
+	// not trigger a pointless second scan.
+	var calls int
+	run := func(args ...string) ([]byte, error) {
+		calls++
+		return []byte(""), errors.New("boom")
+	}
+	_, err := outdatedPackages(run, nil)
+	require.Error(t, err)
+	require.Equal(t, 1, calls)
+}
+
+func TestOutdatedPackagesFallbackAlsoFails(t *testing.T) {
+	// A genuine brew failure (not just a bad name) surfaces after the fallback.
+	var calls int
+	run := func(args ...string) ([]byte, error) {
+		calls++
+		return []byte(""), errors.New("boom")
+	}
+	_, err := outdatedPackages(run, []string{"x"})
+	require.Error(t, err)
+	require.Equal(t, 2, calls)
+}
+
+func TestFirstExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	brew := filepath.Join(dir, "brew")
+	require.NoError(t, os.WriteFile(brew, []byte("x"), 0o755))
+
+	// Returns the first path that exists as a regular file.
+	require.Equal(t, brew, firstExistingFile([]string{filepath.Join(dir, "missing"), brew}))
+	// None exist -> "".
+	require.Empty(t, firstExistingFile([]string{filepath.Join(dir, "missing")}))
+	// A directory is not a match.
+	require.Empty(t, firstExistingFile([]string{dir}))
+}
+
+func TestUniqueCaskNames(t *testing.T) {
+	pkgs := []outdatedPackage{
+		{name: "git", pkgType: typeFormula},              // formula: excluded
+		{name: "mitmproxy", pkgType: typeCask},
+		{name: "mitmproxy", pkgType: typeCask},           // duplicate: deduped
+		{name: "ngrok", pkgType: typeCask},
+	}
+	require.Equal(t, []string{"mitmproxy", "ngrok"}, uniqueCaskNames(pkgs))
+	require.Empty(t, uniqueCaskNames(nil))
+	// No casks -> empty, which lets Generate skip the brew info call entirely.
+	require.Empty(t, uniqueCaskNames([]outdatedPackage{{name: "git", pkgType: typeFormula}}))
+}
+
+func TestExpandEntryNoInstalledVersions(t *testing.T) {
+	// A package with no reported installed version still yields exactly one row.
+	rows := mapEntry(brewOutdatedEntry{Name: "x", CurrentVersion: "2.0"}, typeFormula)
+	require.Len(t, rows, 1)
+	require.Equal(t, "x", rows[0].name)
+	require.Empty(t, rows[0].installedVersion)
+	require.Equal(t, "2.0", rows[0].currentVersion)
+}
+
+func TestBuildRowsCaskWithoutEnrichment(t *testing.T) {
+	// When brew info is unavailable, cask rows still build with empty app_name /
+	// auto_updates but a valid Caskroom install_path.
+	pkgs := []outdatedPackage{
+		{name: "ngrok", installedVersion: "3.37.2,abc", currentVersion: "3.39.9,def", pkgType: typeCask},
+	}
+	rows := buildRows(pkgs, nil, "/opt/homebrew")
+	require.Len(t, rows, 1)
+	require.Empty(t, rows[0]["app_name"])
+	require.Empty(t, rows[0]["auto_updates"])
+	require.Equal(t, "/opt/homebrew/Caskroom/ngrok", rows[0]["install_path"])
+	require.Equal(t, "3.37.2,abc", rows[0]["installed_version"])
+}
+
+func TestParseOutdatedEmpty(t *testing.T) {
+	pkgs, err := parseOutdated([]byte(`{"formulae":[],"casks":[]}`))
+	require.NoError(t, err)
+	require.Empty(t, pkgs)
+}
+
+func TestParseCaskInfo(t *testing.T) {
+	casks, err := parseCaskInfo(infoData)
+	require.NoError(t, err)
+	require.Len(t, casks, 2)
+
+	// auto_updates: null -> "0"
+	require.Equal(t, caskDetail{appName: "mitmproxy", autoUpdates: "0"}, casks["mitmproxy"])
+	// auto_updates: true -> "1", app name taken from the first entry of the name array
+	require.Equal(t, caskDetail{appName: "Google Chrome", autoUpdates: "1"}, casks["google-chrome"])
+}
+
+func TestBuildRows(t *testing.T) {
+	pkgs, err := parseOutdated(outdatedData)
+	require.NoError(t, err)
+	casks, err := parseCaskInfo(infoData)
+	require.NoError(t, err)
+
+	rows := buildRows(pkgs, casks, "/opt/homebrew")
+	require.Len(t, rows, 7)
+
+	byName := make(map[string]map[string]string, len(rows))
+	for _, r := range rows {
+		byName[r["name"]] = r
+	}
+
+	// The multi-version formula produces two rows, one per installed version.
+	var opensslVersions []string
+	for _, r := range rows {
+		if r["name"] == "openssl@3" {
+			opensslVersions = append(opensslVersions, r["installed_version"])
+		}
+	}
+	require.ElementsMatch(t, []string{"3.3.1", "3.3.2"}, opensslVersions)
+
+	// Formula: no app_name/auto_updates, opt-based install path, unpinned.
+	require.Equal(t, map[string]string{
+		"name":              "git",
+		"type":              "formula",
+		"installed_version": "2.53.0",
+		"current_version":   "2.55.0",
+		"pinned_version":    "",
+		"app_name":          "",
+		"auto_updates":      "",
+		"install_path":      "/opt/homebrew/opt/git",
+	}, byName["git"])
+
+	// Cask: enriched with app_name/auto_updates, Caskroom-based install path.
+	require.Equal(t, map[string]string{
+		"name":              "google-chrome",
+		"type":              "cask",
+		"installed_version": "120.0",
+		"current_version":   "121.0",
+		"pinned_version":    "",
+		"app_name":          "Google Chrome",
+		"auto_updates":      "1",
+		"install_path":      "/opt/homebrew/Caskroom/google-chrome",
+	}, byName["google-chrome"])
+
+	require.Equal(t, "0", byName["mitmproxy"]["auto_updates"])
+
+	// A pinned package exposes its pinned_version.
+	require.Equal(t, "1.21.3", byName["wget"]["pinned_version"])
+}

--- a/orbit/pkg/table/homebrew_outdated/homebrew_outdated_test.go
+++ b/orbit/pkg/table/homebrew_outdated/homebrew_outdated_test.go
@@ -160,7 +160,7 @@ func TestOutdatedPackagesFallbackAlsoFails(t *testing.T) {
 func TestFirstExistingFile(t *testing.T) {
 	dir := t.TempDir()
 	brew := filepath.Join(dir, "brew")
-	require.NoError(t, os.WriteFile(brew, []byte("x"), 0o755))
+	require.NoError(t, os.WriteFile(brew, []byte("x"), 0o600))
 
 	// Returns the first path that exists as a regular file.
 	require.Equal(t, brew, firstExistingFile([]string{filepath.Join(dir, "missing"), brew}))
@@ -172,9 +172,9 @@ func TestFirstExistingFile(t *testing.T) {
 
 func TestUniqueCaskNames(t *testing.T) {
 	pkgs := []outdatedPackage{
-		{name: "git", pkgType: typeFormula},              // formula: excluded
+		{name: "git", pkgType: typeFormula}, // formula: excluded
 		{name: "mitmproxy", pkgType: typeCask},
-		{name: "mitmproxy", pkgType: typeCask},           // duplicate: deduped
+		{name: "mitmproxy", pkgType: typeCask}, // duplicate: deduped
 		{name: "ngrok", pkgType: typeCask},
 	}
 	require.Equal(t, []string{"mitmproxy", "ngrok"}, uniqueCaskNames(pkgs))

--- a/orbit/pkg/table/homebrew_outdated/test_data_info.json
+++ b/orbit/pkg/table/homebrew_outdated/test_data_info.json
@@ -1,0 +1,32 @@
+{
+  "formulae": [
+    {
+      "name": "blake3",
+      "full_name": "blake3",
+      "installed": [{ "version": "1.8.3" }],
+      "versions": { "stable": "1.8.5", "head": null, "bottle": true }
+    },
+    {
+      "name": "git",
+      "full_name": "git",
+      "installed": [{ "version": "2.53.0" }],
+      "versions": { "stable": "2.55.0", "head": null, "bottle": true }
+    }
+  ],
+  "casks": [
+    {
+      "token": "mitmproxy",
+      "name": ["mitmproxy"],
+      "version": "12.2.3",
+      "installed": "12.2.1",
+      "auto_updates": null
+    },
+    {
+      "token": "google-chrome",
+      "name": ["Google Chrome"],
+      "version": "121.0",
+      "installed": "120.0",
+      "auto_updates": true
+    }
+  ]
+}

--- a/orbit/pkg/table/homebrew_outdated/test_data_outdated.json
+++ b/orbit/pkg/table/homebrew_outdated/test_data_outdated.json
@@ -1,0 +1,48 @@
+{
+  "formulae": [
+    {
+      "name": "blake3",
+      "installed_versions": ["1.8.3"],
+      "current_version": "1.8.5",
+      "pinned": false,
+      "pinned_version": null
+    },
+    {
+      "name": "git",
+      "installed_versions": ["2.53.0"],
+      "current_version": "2.55.0",
+      "pinned": false,
+      "pinned_version": null
+    },
+    {
+      "name": "openssl@3",
+      "installed_versions": ["3.3.1", "3.3.2"],
+      "current_version": "3.4.0",
+      "pinned": false,
+      "pinned_version": null
+    },
+    {
+      "name": "wget",
+      "installed_versions": ["1.21.3"],
+      "current_version": "1.25.0",
+      "pinned": true,
+      "pinned_version": "1.21.3"
+    }
+  ],
+  "casks": [
+    {
+      "name": "mitmproxy",
+      "installed_versions": ["12.2.1"],
+      "current_version": "12.2.3",
+      "pinned": false,
+      "pinned_version": null
+    },
+    {
+      "name": "google-chrome",
+      "installed_versions": ["120.0"],
+      "current_version": "121.0",
+      "pinned": false,
+      "pinned_version": null
+    }
+  ]
+}

--- a/schema/osquery_fleet_schema.json
+++ b/schema/osquery_fleet_schema.json
@@ -12812,6 +12812,68 @@
     "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/hash.yml"
   },
   {
+    "name": "homebrew_outdated",
+    "platforms": [
+      "darwin"
+    ],
+    "description": "List Homebrew packages (formulae and casks) that have a newer version available. Returns one row per installed version of each outdated package. This table is provided by Fleet's agent (fleetd) and is only available on macOS hosts with Homebrew installed.",
+    "columns": [
+      {
+        "name": "app_name",
+        "description": "Name of the installed app (casks only).",
+        "type": "text",
+        "required": false
+      },
+      {
+        "name": "auto_updates",
+        "description": "1 if the cask auto-updates, otherwise 0. Empty for formulae.",
+        "type": "integer",
+        "required": false
+      },
+      {
+        "name": "name",
+        "description": "Package name.",
+        "type": "text",
+        "required": false
+      },
+      {
+        "name": "install_path",
+        "description": "Package install path.",
+        "type": "text",
+        "required": false
+      },
+      {
+        "name": "type",
+        "description": "Package type ('formula' or 'cask').",
+        "type": "text",
+        "required": false
+      },
+      {
+        "name": "installed_version",
+        "description": "Currently installed (linked) version.",
+        "type": "text",
+        "required": false
+      },
+      {
+        "name": "current_version",
+        "description": "Latest available version from Homebrew (not the installed version).",
+        "type": "text",
+        "required": false
+      },
+      {
+        "name": "pinned_version",
+        "description": "Version the package is pinned to, if pinned. Empty when not pinned.",
+        "type": "text",
+        "required": false
+      }
+    ],
+    "notes": "This table is not a core osquery table. It is included as part of Fleet's agent ([fleetd](https://fleetdm.com/docs/get-started/anatomy#fleetd)). It is queried as the current console (logged-in) user, so hosts with no console user (headless, or sitting at the login window) return no rows even when Homebrew is installed. It reflects a single Homebrew installation — if both a system-wide install (`/opt/homebrew` or `/usr/local`) and a per-user install (`~/homebrew`) are present, the system-wide one is used. If the console user does not own the Homebrew installation, `current_version` may be out of date because Homebrew's update step can fail for a non-owner. `install_path` assumes Homebrew's default layout; non-default `HOMEBREW_CELLAR` or `HOMEBREW_CASKROOM` locations are not reflected.",
+    "evented": false,
+    "examples": "Check the installed and latest available version of an outdated package. This\nexample checks ffmpeg, which should be replaced by the actual package you want\nto check for. This is useful for finding outdated or vulnerable installs,\nthough Fleet will detect vulnerable packages automatically.\n\n```\nSELECT installed_version, current_version FROM homebrew_outdated WHERE name = 'ffmpeg';\n```",
+    "url": "https://fleetdm.com/tables/homebrew_outdated",
+    "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/homebrew_outdated.yml"
+  },
+  {
     "name": "homebrew_packages",
     "description": "The installed homebrew package database.",
     "url": "https://fleetdm.com/tables/homebrew_packages",

--- a/schema/tables/homebrew_outdated.yml
+++ b/schema/tables/homebrew_outdated.yml
@@ -1,0 +1,48 @@
+name: homebrew_outdated
+platforms:
+  - darwin
+description: List Homebrew packages (formulae and casks) that have a newer version available. Returns one row per installed version of each outdated package. This table is provided by Fleet's agent (fleetd) and is only available on macOS hosts with Homebrew installed.
+columns:
+  - name: app_name
+    description: Name of the installed app (casks only).
+    type: text
+    required: false
+  - name: auto_updates
+    description: 1 if the cask auto-updates, otherwise 0. Empty for formulae.
+    type: integer
+    required: false
+  - name: name
+    description: Package name.
+    type: text
+    required: false
+  - name: install_path
+    description: Package install path.
+    type: text
+    required: false
+  - name: type
+    description: Package type ('formula' or 'cask').
+    type: text
+    required: false
+  - name: installed_version
+    description: Currently installed (linked) version.
+    type: text
+    required: false
+  - name: current_version
+    description: Latest available version from Homebrew (not the installed version).
+    type: text
+    required: false
+  - name: pinned_version
+    description: Version the package is pinned to, if pinned. Empty when not pinned.
+    type: text
+    required: false
+notes: This table is not a core osquery table. It is included as part of Fleet's agent ([fleetd](https://fleetdm.com/docs/get-started/anatomy#fleetd)). It is queried as the current console (logged-in) user, so hosts with no console user (headless, or sitting at the login window) return no rows even when Homebrew is installed. It reflects a single Homebrew installation — if both a system-wide install (`/opt/homebrew` or `/usr/local`) and a per-user install (`~/homebrew`) are present, the system-wide one is used. If the console user does not own the Homebrew installation, `current_version` may be out of date because Homebrew's update step can fail for a non-owner. `install_path` assumes Homebrew's default layout; non-default `HOMEBREW_CELLAR` or `HOMEBREW_CASKROOM` locations are not reflected.
+evented: false
+examples: |-
+  Check the installed and latest available version of an outdated package. This
+  example checks ffmpeg, which should be replaced by the actual package you want
+  to check for. This is useful for finding outdated or vulnerable installs,
+  though Fleet will detect vulnerable packages automatically.
+
+  ```
+  SELECT installed_version, current_version FROM homebrew_outdated WHERE name = 'ffmpeg';
+  ```


### PR DESCRIPTION
Fixes #47692

New macOS-only extension table returning outdated Homebrew packages (formulae and casks) with installed and latest-available versions, for querying out-of-date packages and driving patching policies. Runs `brew outdated`/`brew info` as the console user; auto-update left on so current_version stays accurate.

https://github.com/user-attachments/assets/9f7600fc-35f2-4398-8fd1-4d23ab380b09

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

## fleetd/orbit/Fleet Desktop

- [X] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [X] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [X] Verified that fleetd runs on macOS, Linux and Windows
- [X] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added the macOS-only `homebrew_outdated` table to report outdated Homebrew formulae and casks with installed vs latest versions, pinned versions, cask app name, and cask auto-update status.
  * Supports filtering by package name and returns installation paths appropriate to the active console user.
  * Safely returns no results when Homebrew isn’t available.

* **Documentation**
  * Added schema documentation and example queries for the new table.

* **Tests**
  * Added unit and end-to-end coverage for table parsing and row generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->