### PR TITLE
Added redirect_uri validation for Windows TOS endpoint.

### DIFF
--- a/changes/16880-windows-tos-redirect-uri-xss
+++ b/changes/16880-windows-tos-redirect-uri-xss
@@ -1,1 +1,1 @@
-- Fixed a reflected XSS vulnerability in the unauthenticated Windows MDM Terms of Service endpoint (`/api/mdm/microsoft/tos`) by validating the `redirect_uri` scheme.
+- Improved input validation for the Windows MDM enrollment flow.

--- a/changes/16880-windows-tos-redirect-uri-xss
+++ b/changes/16880-windows-tos-redirect-uri-xss
@@ -1,0 +1,1 @@
+- Fixed a reflected XSS vulnerability in the unauthenticated Windows MDM Terms of Service endpoint (`/api/mdm/microsoft/tos`) by validating the `redirect_uri` scheme.

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -8876,6 +8876,49 @@ func (s *integrationMDMTestSuite) TestValidGetTOC() {
 	require.Contains(t, resTOCcontent, "OpaqueBlob=")
 }
 
+func (s *integrationMDMTestSuite) TestGetTOCRejectsUnsafeRedirectURI() {
+	t := s.T()
+
+	// hacky check to make sure the assets were built (they require `-tags full`
+	// when building the tests otherwise this test will always fail due to a
+	// panic in server/bindata package)
+	defer func() {
+		if panicVal := recover(); panicVal != nil {
+			s, ok := panicVal.(string)
+			if ok && strings.Contains(s, "Assets may not be used when running Fleet as a library") {
+				t.Skip("skipping, test will fail due to assets not built (requires '-tags full')")
+			}
+		}
+	}()
+	_, _ = bindata.Asset("check if assets are build")
+
+	// The TOS page reflects redirect_uri into a window.location assignment, so a javascript:/data:/vbscript:
+	// redirect_uri must be rejected rather than rendered, otherwise it enables reflected XSS (issue #16880).
+	unsafeRedirectURIs := map[string]string{
+		"javascript": "javascript:console.log(424281957)//",
+		"data":       "data:text/html,<script>alert(1)</script>",
+		"vbscript":   "vbscript:msgbox(1)",
+	}
+
+	for name, redirectURI := range unsafeRedirectURIs {
+		t.Run(name, func(t *testing.T) {
+			resp := s.DoRaw("GET", microsoft_mdm.MDE2TOSPath+"?api-version=1.0&redirect_uri="+url.QueryEscape(redirectURI)+
+				"&client-request-id=f2cf3127-1e80-4d73-965d-42a3b84bdb40", nil, http.StatusOK)
+
+			resBytes, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			resContent := string(resBytes)
+
+			// The response must be a SOAP fault rather than the rendered TOS page, and must not reflect the payload.
+			require.Contains(t, resp.Header["Content-Type"], syncml.SoapContentType)
+			require.True(t, s.isXMLTagPresent("s:fault", resContent))
+			require.NotContains(t, resContent, redirectURI)
+			require.NotContains(t, resContent, "Agree and continue")
+			require.NotContains(t, resContent, "IsAccepted=true")
+		})
+	}
+}
+
 func (s *integrationMDMTestSuite) TestWindowsMDM() {
 	t := s.T()
 	orbitHost, d := createWindowsHostThenEnrollMDM(s.ds, s.server.URL, t)

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -8859,8 +8859,6 @@ func (s *integrationMDMTestSuite) TestValidGetTOC() {
 			if ok && strings.Contains(s, "Assets may not be used when running Fleet as a library") {
 				t.Skip("skipping, test will fail due to assets not built (requires '-tags full')")
 			}
-			// Re-panic anything other than the known assets-not-built panic so unexpected failures stay visible.
-			panic(panicVal)
 		}
 	}()
 	_, _ = bindata.Asset("check if assets are build")
@@ -8880,21 +8878,6 @@ func (s *integrationMDMTestSuite) TestValidGetTOC() {
 
 func (s *integrationMDMTestSuite) TestGetTOCRejectsUnsafeRedirectURI() {
 	t := s.T()
-
-	// hacky check to make sure the assets were built (they require `-tags full`
-	// when building the tests otherwise this test will always fail due to a
-	// panic in server/bindata package)
-	defer func() {
-		if panicVal := recover(); panicVal != nil {
-			s, ok := panicVal.(string)
-			if ok && strings.Contains(s, "Assets may not be used when running Fleet as a library") {
-				t.Skip("skipping, test will fail due to assets not built (requires '-tags full')")
-			}
-			// Re-panic anything other than the known assets-not-built panic so unexpected failures stay visible.
-			panic(panicVal)
-		}
-	}()
-	_, _ = bindata.Asset("check if assets are build")
 
 	// The TOS page reflects redirect_uri into a window.location assignment, so a javascript:/data:/vbscript:
 	// redirect_uri must be rejected rather than rendered, otherwise it enables reflected XSS (issue #16880).

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -8859,6 +8859,8 @@ func (s *integrationMDMTestSuite) TestValidGetTOC() {
 			if ok && strings.Contains(s, "Assets may not be used when running Fleet as a library") {
 				t.Skip("skipping, test will fail due to assets not built (requires '-tags full')")
 			}
+			// Re-panic anything other than the known assets-not-built panic so unexpected failures stay visible.
+			panic(panicVal)
 		}
 	}()
 	_, _ = bindata.Asset("check if assets are build")
@@ -8888,6 +8890,8 @@ func (s *integrationMDMTestSuite) TestGetTOCRejectsUnsafeRedirectURI() {
 			if ok && strings.Contains(s, "Assets may not be used when running Fleet as a library") {
 				t.Skip("skipping, test will fail due to assets not built (requires '-tags full')")
 			}
+			// Re-panic anything other than the known assets-not-built panic so unexpected failures stay visible.
+			panic(panicVal)
 		}
 	}()
 	_, _ = bindata.Asset("check if assets are build")

--- a/server/service/microsoft_mdm.go
+++ b/server/service/microsoft_mdm.go
@@ -1234,10 +1234,15 @@ func (svc *Service) GetMDMWindowsManagementResponse(ctx context.Context, reqSync
 	return resSyncMLmsg, nil
 }
 
-// allowedWindowsTOSRedirectSchemes is the set of URL schemes permitted for the Windows MDM TOS redirect_uri. The value
-// is reflected into a window.location assignment in the TOS page, so only schemes that cannot execute script are
-// allowed. The legitimate Autopilot/Entra enrollment flow hands control back to the native Azure AD broker via the
-// ms-appx-web scheme (e.g. ms-appx-web://Microsoft.AAD.BrokerPlugin); https covers browser-based federated flows.
+// allowedWindowsTOSRedirectSchemes is the set of URL schemes permitted for the Windows MDM enrollment Terms of Use
+// redirect_uri. Per Microsoft's "Terms of Use protocol semantics", the Windows enrollment client (not Fleet) chooses
+// this redirect_uri and Fleet only reflects it into a window.location assignment in the TOS page. We restrict it to the
+// two schemes that protocol uses:
+//   - ms-appx-web: the scheme in Microsoft's documented example, redirect_uri=ms-appx-web://<app>/ToUResponse, used by
+//     the native broker-hosted flows (Entra join from Settings > "Access work or school", and BYOD work-account add).
+//     The value seen in practice is ms-appx-web://Microsoft.AAD.BrokerPlugin (the Azure AD broker plugin package).
+//     https://learn.microsoft.com/en-us/windows/client-management/azure-active-directory-integration-with-mdm
+//   - https: the browser-based federated flow.
 var allowedWindowsTOSRedirectSchemes = map[string]struct{}{
 	"https":       {},
 	"ms-appx-web": {},

--- a/server/service/microsoft_mdm.go
+++ b/server/service/microsoft_mdm.go
@@ -1234,8 +1234,40 @@ func (svc *Service) GetMDMWindowsManagementResponse(ctx context.Context, reqSync
 	return resSyncMLmsg, nil
 }
 
+// allowedWindowsTOSRedirectSchemes is the set of URL schemes permitted for the Windows MDM TOS redirect_uri. The value
+// is reflected into a window.location assignment in the TOS page, so only schemes that cannot execute script are
+// allowed. The legitimate Autopilot/Entra enrollment flow hands control back to the native Azure AD broker via the
+// ms-appx-web scheme (e.g. ms-appx-web://Microsoft.AAD.BrokerPlugin); https covers browser-based federated flows.
+// Schemes such as javascript, data, and vbscript are rejected to prevent reflected XSS (issue #16880).
+var allowedWindowsTOSRedirectSchemes = map[string]struct{}{
+	"https":       {},
+	"ms-appx-web": {},
+}
+
+// windowsTOSRedirectURIAllowed reports whether redirectURI is safe to reflect into the Windows MDM TOS page. It parses
+// the URI and allows only the schemes in allowedWindowsTOSRedirectSchemes, rejecting script-executing schemes
+// (javascript:, data:, vbscript:) as well as malformed or scheme-less values.
+func windowsTOSRedirectURIAllowed(redirectURI string) bool {
+	parsed, err := url.Parse(redirectURI)
+	if err != nil {
+		return false
+	}
+	_, ok := allowedWindowsTOSRedirectSchemes[strings.ToLower(parsed.Scheme)]
+	return ok
+}
+
 // GetMDMWindowsTOSContent returns valid TOC content
 func (svc *Service) GetMDMWindowsTOSContent(ctx context.Context, redirectUri string, reqID string) (string, error) {
+	// skipauth: This endpoint does not use authentication
+	svc.authz.SkipAuthorization(ctx)
+
+	// redirectUri is reflected into a window.location assignment in the TOS page template, so validate its scheme to
+	// prevent reflected XSS via javascript:/data:/vbscript: URLs. The legitimate Autopilot/Entra flow uses an
+	// ms-appx-web:// broker callback, so we allow-list safe schemes rather than forcing https (issue #16880).
+	if !windowsTOSRedirectURIAllowed(redirectUri) {
+		return "", &fleet.BadRequestError{Message: "invalid redirect_uri"}
+	}
+
 	tmpl, err := server.GetTemplate("frontend/templates/windowsTOS.html", "windows-tos")
 	if err != nil {
 		return "", ctxerr.Wrap(ctx, err, "issue generating TOS content")
@@ -1246,9 +1278,6 @@ func (svc *Service) GetMDMWindowsTOSContent(ctx context.Context, redirectUri str
 	if err != nil {
 		return "", ctxerr.Wrap(ctx, err, "executing TOS template content")
 	}
-
-	// skipauth: This endpoint does not use authentication
-	svc.authz.SkipAuthorization(ctx)
 
 	return htmlBuf.String(), nil
 }

--- a/server/service/microsoft_mdm.go
+++ b/server/service/microsoft_mdm.go
@@ -1238,15 +1238,12 @@ func (svc *Service) GetMDMWindowsManagementResponse(ctx context.Context, reqSync
 // is reflected into a window.location assignment in the TOS page, so only schemes that cannot execute script are
 // allowed. The legitimate Autopilot/Entra enrollment flow hands control back to the native Azure AD broker via the
 // ms-appx-web scheme (e.g. ms-appx-web://Microsoft.AAD.BrokerPlugin); https covers browser-based federated flows.
-// Schemes such as javascript, data, and vbscript are rejected to prevent reflected XSS (issue #16880).
 var allowedWindowsTOSRedirectSchemes = map[string]struct{}{
 	"https":       {},
 	"ms-appx-web": {},
 }
 
-// windowsTOSRedirectURIAllowed reports whether redirectURI is safe to reflect into the Windows MDM TOS page. It parses
-// the URI and allows only the schemes in allowedWindowsTOSRedirectSchemes, rejecting script-executing schemes
-// (javascript:, data:, vbscript:) as well as malformed or scheme-less values.
+// windowsTOSRedirectURIAllowed reports whether redirectURI is safe to reflect into the Windows MDM TOS page.
 func windowsTOSRedirectURIAllowed(redirectURI string) bool {
 	parsed, err := url.Parse(redirectURI)
 	if err != nil {
@@ -1262,8 +1259,7 @@ func (svc *Service) GetMDMWindowsTOSContent(ctx context.Context, redirectUri str
 	svc.authz.SkipAuthorization(ctx)
 
 	// redirectUri is reflected into a window.location assignment in the TOS page template, so validate its scheme to
-	// prevent reflected XSS via javascript:/data:/vbscript: URLs. The legitimate Autopilot/Entra flow uses an
-	// ms-appx-web:// broker callback, so we allow-list safe schemes rather than forcing https (issue #16880).
+	// prevent reflected XSS via javascript:/data:/vbscript: URLs.
 	if !windowsTOSRedirectURIAllowed(redirectUri) {
 		return "", &fleet.BadRequestError{Message: "invalid redirect_uri"}
 	}

--- a/server/service/microsoft_mdm.go
+++ b/server/service/microsoft_mdm.go
@@ -1240,7 +1240,6 @@ func (svc *Service) GetMDMWindowsManagementResponse(ctx context.Context, reqSync
 // two schemes that protocol uses:
 //   - ms-appx-web: the scheme in Microsoft's documented example, redirect_uri=ms-appx-web://<app>/ToUResponse, used by
 //     the native broker-hosted flows (Entra join from Settings > "Access work or school", and BYOD work-account add).
-//     The value seen in practice is ms-appx-web://Microsoft.AAD.BrokerPlugin (the Azure AD broker plugin package).
 //     https://learn.microsoft.com/en-us/windows/client-management/azure-active-directory-integration-with-mdm
 //   - https: the browser-based federated flow.
 var allowedWindowsTOSRedirectSchemes = map[string]struct{}{

--- a/server/service/microsoft_mdm_test.go
+++ b/server/service/microsoft_mdm_test.go
@@ -395,6 +395,40 @@ func TestSyncMLCmdTextEscapesXMLMetacharacters(t *testing.T) {
 	require.NotContains(t, payload, "AT&T", "raw ampersand must not appear unescaped")
 }
 
+func TestWindowsTOSRedirectURIAllowed(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		redirectURI string
+		want        bool
+	}{
+		// Legitimate Autopilot/Entra broker callback and browser-based federated flows.
+		{"ms-appx-web broker callback", "ms-appx-web://Microsoft.AAD.BrokerPlugin", true},
+		{"ms-appx-web mixed case scheme", "MS-APPX-WEB://Microsoft.AAD.BrokerPlugin", true},
+		{"https url", "https://enroll.example.com/continue", true},
+
+		// Script-executing schemes must be rejected (issue #16880).
+		{"javascript scheme", "javascript:console.log(424281957)//", false},
+		{"javascript mixed case scheme", "JavaScript:alert(1)", false},
+		{"data scheme", "data:text/html,<script>alert(1)</script>", false},
+		{"vbscript scheme", "vbscript:msgbox(1)", false},
+
+		// Other schemes and malformed/scheme-less values are rejected by the allow-list.
+		{"http scheme", "http://enroll.example.com/continue", false},
+		{"empty", "", false},
+		{"scheme-less relative", "Microsoft.AAD.BrokerPlugin", false},
+		{"leading space before javascript", " javascript:alert(1)", false},
+		{"control character in scheme", "java\tscript:alert(1)", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, windowsTOSRedirectURIAllowed(tc.redirectURI))
+		})
+	}
+}
+
 func TestValidSyncMLCmdXml(t *testing.T) {
 	testOmaURI := "testuri"
 	testData := "testdata"


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves https://github.com/fleetdm/confidential/issues/16880

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Secured the Windows MDM Terms of Service endpoint against reflected cross-site scripting.
  * Strengthened validation for the `redirect_uri` used in Terms of Service rendering, allowing only approved `https` and `ms-appx-web` schemes.
  * Unsafe, malformed, or non-allowlisted redirect values are now rejected and not displayed.

* **Tests**
  * Added integration and unit coverage to verify unsafe redirects are blocked while valid ones continue to work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->