### PR TITLE
Show managed Android serial number on Hosts page

### DIFF
--- a/changes/48379-android-serial-hosts-page
+++ b/changes/48379-android-serial-hosts-page
@@ -1,0 +1,1 @@
+- Fixed the Hosts page so that managed Android hosts display their serial number instead of "Not supported" when one is reported.

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tests.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tests.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import { generateAvailableTableHeaders } from "./HostTableConfig";
+
+describe("HostTableConfig - Serial number column", () => {
+  const headers = generateAvailableTableHeaders({
+    isFreeTier: false,
+    isOnlyObserver: false,
+  });
+
+  const serialColumn = headers.find((h) => h.id === "hardware_serial") as any;
+
+  if (!serialColumn || typeof serialColumn.Cell !== "function") {
+    throw new Error("hardware_serial column or Cell not found");
+  }
+
+  const Cell = serialColumn.Cell as React.ElementType;
+
+  const renderCell = (
+    serial: string,
+    platform: string,
+    mdm?: { enrollment_status: string }
+  ) =>
+    render(
+      <Cell
+        cell={{ value: serial }}
+        row={{
+          original: {
+            platform,
+            hardware_serial: serial,
+            mdm,
+          },
+        }}
+      />
+    );
+
+  it("shows the serial number for a macOS host", () => {
+    renderCell("ABC123", "darwin", { enrollment_status: "On (automatic)" });
+    expect(screen.getByText("ABC123")).toBeInTheDocument();
+    expect(screen.queryByText("Not supported")).not.toBeInTheDocument();
+  });
+
+  it("shows the serial number for a managed Android host", () => {
+    renderCell("PIXEL10A", "android", { enrollment_status: "On (automatic)" });
+    expect(screen.getByText("PIXEL10A")).toBeInTheDocument();
+    expect(screen.queryByText("Not supported")).not.toBeInTheDocument();
+  });
+
+  it("shows the serial number for an Android host with no mdm data", () => {
+    // Regression guard: the cell must not crash dereferencing a missing `mdm`.
+    renderCell("PIXEL10A", "android", undefined);
+    expect(screen.getByText("PIXEL10A")).toBeInTheDocument();
+    expect(screen.queryByText("Not supported")).not.toBeInTheDocument();
+  });
+
+  it("shows the serial number for a managed (ADE) iPadOS host", () => {
+    renderCell("IPAD123", "ipados", { enrollment_status: "On (automatic)" });
+    expect(screen.getByText("IPAD123")).toBeInTheDocument();
+    expect(screen.queryByText("Not supported")).not.toBeInTheDocument();
+  });
+
+  it("shows 'Not supported' for a personal (BYOD) Android host", () => {
+    renderCell("", "android", { enrollment_status: "On (manual - personal)" });
+    expect(screen.getByText("Not supported")).toBeInTheDocument();
+  });
+
+  it("shows 'Not supported' for a personal (BYOD) iOS host", () => {
+    renderCell("", "ios", { enrollment_status: "On (manual - personal)" });
+    expect(screen.getByText("Not supported")).toBeInTheDocument();
+  });
+});

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -247,11 +247,12 @@ const allHostTableHeaders = (teamId?: number): IHostTableColumnConfig[] => [
     accessor: "hardware_serial",
     id: "hardware_serial",
     Cell: (cellProps: IHostTableStringCellProps) => {
-      // TODO(android): is iOS/iPadOS supported?
+      // Personal (BYOD) devices don't report their serial numbers, so show
+      // "Not supported" for them. All other hosts, including managed Android
+      // devices, show the reported serial number.
       if (
-        isAndroid(cellProps.row.original.platform) ||
         isBYODAccountDrivenUserEnrollment(
-          cellProps.row.original.mdm.enrollment_status
+          cellProps.row.original.mdm?.enrollment_status ?? null
         )
       ) {
         return NotSupported;


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #48379

Managed Android hosts (e.g. Pixel 10a) report a serial number, and it already shows on the host details page, but the Hosts list "Serial number" column hard-coded "Not supported" for all Android hosts. Only personal (BYOD account-driven) enrollments genuinely lack a serial, so this restricts the "Not supported" fallback to those and shows the reported serial for every other host. Frontend-only change — the backend already returns `hardware_serial` for Android in the list endpoint.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

### Manual test plan
1. Enroll a managed (non-personal) Android host that reports a serial number (e.g. Pixel 10a).
2. On the Hosts page, enable the "Serial number" column (hidden by default).
3. Confirm the Android host's serial number now appears (previously "Not supported").
4. Confirm a personal/BYOD Android or iOS host still shows "Not supported", and macOS/Windows/managed iPadOS hosts are unchanged.

### Automated tests
New `HostTableConfig.tests.tsx` covers the serial-number cell for macOS, managed Android, Android with no MDM data (nil-safety regression guard), managed iPadOS, and personal BYOD Android/iOS.
