### PR TITLE
Add clear error for Firefox / Firefox ESR conflict

### DIFF
--- a/changes/49682-firefox-esr-conflict-message
+++ b/changes/49682-firefox-esr-conflict-message
@@ -1,0 +1,1 @@
+- Added a clear error message when adding both Mozilla Firefox and Firefox ESR (which share a bundle identifier) to the same fleet, so admins understand only one of them can be added instead of seeing a generic conflict error.

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/helpers.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/helpers.tests.tsx
@@ -1,0 +1,31 @@
+import { getErrorMessage } from "./helpers";
+
+jest.mock("axios", () => {
+  const actual = jest.requireActual("axios");
+  return {
+    ...actual,
+    isAxiosError: () => true,
+  };
+});
+
+const errWithReason = (reason: string) => ({
+  response: { status: 409, data: { errors: [{ name: "Error", reason }] } },
+});
+
+describe("getErrorMessage", () => {
+  it("passes through the Firefox/ESR conflict message without doubling the prefix", () => {
+    const err = errWithReason(
+      "Couldn't add software. Only one of Mozilla Firefox or Mozilla Firefox ESR can be added to the same fleet."
+    );
+
+    expect(getErrorMessage(err)).toBe(
+      "Couldn't add software. Only one of Mozilla Firefox or Mozilla Firefox ESR can be added to the same fleet."
+    );
+  });
+
+  it("prefixes a generic reason", () => {
+    const err = errWithReason("Something went wrong");
+
+    expect(getErrorMessage(err)).toBe("Couldn't add. Something went wrong.");
+  });
+});

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/helpers.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/helpers.tsx
@@ -66,7 +66,7 @@ export const getErrorMessage = (err: unknown) => {
     return REQUEST_TIMEOUT_ERROR_MESSAGE;
   }
 
-  // The server returns a complete, user-facing message here; pass it through as-is.
+  // Server returns a complete user-facing message; pass it through as-is.
   if (reason.includes("can be added to the same fleet")) {
     return ensurePeriod(reason);
   }

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/helpers.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/helpers.tsx
@@ -66,6 +66,11 @@ export const getErrorMessage = (err: unknown) => {
     return REQUEST_TIMEOUT_ERROR_MESSAGE;
   }
 
+  // The server returns a complete, user-facing message here; pass it through as-is.
+  if (reason.includes("can be added to the same fleet")) {
+    return ensurePeriod(reason);
+  }
+
   // software is already available for install
   if (reason.toLowerCase().includes("already")) {
     const alreadyAvailableMessage = formatAlreadyAvailableInstallMessage(

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -4602,11 +4602,11 @@ func (ds *Datastore) checkFleetMaintainedAppExists(ctx context.Context, payload 
 	return exists, nil
 }
 
-// checkConflictingFleetMaintainedAppExists reports whether the team already has an installer for a
-// DIFFERENT Fleet-maintained app on the same macOS title, returning that app's name. Two FMAs that
-// share a bundle identifier (e.g. Mozilla Firefox and Firefox ESR) resolve to one title but are the
-// same inventory app, so only one can be added; multiple versions of the same app don't conflict.
-// FleetMaintainedAppID must be non-nil: a NULL bound to the != comparison matches nothing.
+// checkConflictingFleetMaintainedAppExists reports whether the team has an installer for a different
+// FMA on the same macOS title (two FMAs sharing a bundle identifier, e.g. Firefox and Firefox ESR),
+// returning that app's name. Versions of the same app don't conflict. Unlike
+// checkFleetMaintainedAppExists (custom package vs. FMA), this compares FMA IDs. FleetMaintainedAppID
+// must be non-nil — a NULL in the != comparison matches nothing.
 func (ds *Datastore) checkConflictingFleetMaintainedAppExists(ctx context.Context, payload *fleet.UploadSoftwareInstallerPayload) (string, bool, error) {
 	if payload.FleetMaintainedAppID == nil || payload.BundleIdentifier == "" {
 		return "", false, nil

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -4487,6 +4487,18 @@ func (ds *Datastore) checkSoftwareConflictsByIdentifier(ctx context.Context, pay
 		if exists {
 			return conflict(fleet.SoftwareAlreadyHasVPPAppMessage)
 		}
+
+		if payload.FleetMaintainedAppID != nil {
+			existingName, conflicts, err := ds.checkConflictingFleetMaintainedAppExists(ctx, payload)
+			if err != nil {
+				return ctxerr.Wrap(ctx, err, "check for conflicting fleet-maintained app")
+			}
+			if conflicts {
+				return ctxerr.Wrap(ctx, fleet.ConflictError{
+					Message: fmt.Sprintf(fleet.CantAddConflictingFMAMessage, existingName, payload.Title),
+				}, "different fleet-maintained app already exists on the title")
+			}
+		}
 	}
 
 	// custom packages and Fleet-maintained apps can't share a title
@@ -4588,6 +4600,38 @@ func (ds *Datastore) checkFleetMaintainedAppExists(ctx context.Context, payload 
 		return false, ctxerr.Wrap(ctx, err, "check fleet-maintained app exists")
 	}
 	return exists, nil
+}
+
+// checkConflictingFleetMaintainedAppExists reports whether the team already has an installer for a
+// DIFFERENT Fleet-maintained app on the same macOS title, returning that app's name. Two FMAs that
+// share a bundle identifier (e.g. Mozilla Firefox and Firefox ESR) resolve to one title but are the
+// same inventory app, so only one can be added; multiple versions of the same app don't conflict.
+// FleetMaintainedAppID must be non-nil: a NULL bound to the != comparison matches nothing.
+func (ds *Datastore) checkConflictingFleetMaintainedAppExists(ctx context.Context, payload *fleet.UploadSoftwareInstallerPayload) (string, bool, error) {
+	if payload.FleetMaintainedAppID == nil || payload.BundleIdentifier == "" {
+		return "", false, nil
+	}
+
+	const stmt = `
+		SELECT fma.name
+		FROM software_installers si
+		JOIN software_titles st ON st.id = si.title_id
+		JOIN fleet_maintained_apps fma ON fma.id = si.fleet_maintained_app_id
+		WHERE si.global_or_team_id = ? AND st.source = ? AND st.bundle_identifier = ?
+			AND si.fleet_maintained_app_id != ?
+		LIMIT 1`
+
+	var name string
+	err := sqlx.GetContext(ctx, ds.reader(ctx), &name, stmt,
+		ptr.ValOrZero(payload.TeamID), payload.Source, payload.BundleIdentifier, *payload.FleetMaintainedAppID)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return "", false, nil
+	case err != nil:
+		return "", false, ctxerr.Wrap(ctx, err, "check conflicting fleet-maintained app exists")
+	default:
+		return name, true, nil
+	}
 }
 
 func (ds *Datastore) GetSoftwareTitlesForInstallAll(ctx context.Context, host *fleet.Host, categoryID *uint) ([]*fleet.HostSoftwareWithInstaller, *string, error) {

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -53,6 +53,7 @@ func TestSoftwareInstallers(t *testing.T) {
 		{"GetDetailsForUninstallFromExecutionID", testGetDetailsForUninstallFromExecutionID},
 		{"GetTeamsWithInstallerByHash", testGetTeamsWithInstallerByHash},
 		{"MatchOrCreateSoftwareInstallerDuplicateHash", testMatchOrCreateSoftwareInstallerDuplicateHash},
+		{"MatchOrCreateSoftwareInstallerConflictingFMA", testMatchOrCreateSoftwareInstallerConflictingFMA},
 		{"BatchSetSoftwareInstallersSetupExperienceSideEffects", testBatchSetSoftwareInstallersSetupExperienceSideEffects},
 		{"EditDeleteSoftwareInstallersActivateNextActivity", testEditDeleteSoftwareInstallersActivateNextActivity},
 		{"BatchSetSoftwareInstallersActivateNextActivity", testBatchSetSoftwareInstallersActivateNextActivity},
@@ -5007,6 +5008,56 @@ func testMatchOrCreateSoftwareInstallerDuplicateHash(t *testing.T, ds *Datastore
 	// Same title and hash on the same team → rejected by the within-title hash check
 	_, _, err = ds.MatchOrCreateSoftwareInstaller(ctx, mkPayload(&teamA.ID, "a.sh", "title-a"))
 	require.ErrorContains(t, err, "same SHA-256 hash")
+}
+
+func testMatchOrCreateSoftwareInstallerConflictingFMA(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+	user := test.NewUser(t, ds, "Alice", "alice@example.com", true)
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: t.Name()})
+	require.NoError(t, err)
+
+	// Mozilla Firefox and Firefox ESR are distinct Fleet-maintained apps that share the macOS
+	// bundle identifier org.mozilla.firefox, so they resolve to the same software title.
+	firefox, err := ds.UpsertMaintainedApp(ctx, &fleet.MaintainedApp{
+		Name: "Mozilla Firefox", Slug: "firefox", Platform: "darwin", UniqueIdentifier: "org.mozilla.firefox",
+	})
+	require.NoError(t, err)
+	firefoxESR, err := ds.UpsertMaintainedApp(ctx, &fleet.MaintainedApp{
+		Name: "Mozilla Firefox ESR", Slug: "firefox@esr", Platform: "darwin", UniqueIdentifier: "org.mozilla.firefox",
+	})
+	require.NoError(t, err)
+
+	mkFMA := func(appID uint, title, storage, version string) *fleet.UploadSoftwareInstallerPayload {
+		tfr, err := fleet.NewTempFileReader(strings.NewReader(storage), t.TempDir)
+		require.NoError(t, err)
+		return &fleet.UploadSoftwareInstallerPayload{
+			InstallerFile:        tfr,
+			Extension:            "pkg",
+			StorageID:            storage,
+			Filename:             storage + ".pkg",
+			Title:                title,
+			Version:              version,
+			Source:               "apps",
+			Platform:             "darwin",
+			BundleIdentifier:     "org.mozilla.firefox",
+			FleetMaintainedAppID: new(appID),
+			UserID:               user.ID,
+			ValidatedLabels:      &fleet.LabelIdentsWithScope{},
+			TeamID:               &team.ID,
+		}
+	}
+
+	// Add Firefox (GA) → success.
+	_, _, err = ds.MatchOrCreateSoftwareInstaller(ctx, mkFMA(firefox.ID, "Mozilla Firefox", "ff-153", "153.0"))
+	require.NoError(t, err)
+
+	// Adding Firefox ESR (a different FMA on the same title) → rejected with the specific message.
+	_, _, err = ds.MatchOrCreateSoftwareInstaller(ctx, mkFMA(firefoxESR.ID, "Mozilla Firefox ESR", "ffesr-140", "140.13.0"))
+	require.ErrorContains(t, err, "Only one of Mozilla Firefox or Mozilla Firefox ESR can be added to the same fleet")
+
+	// A new version of the SAME FMA must still be allowed (version pinning must not regress).
+	_, _, err = ds.MatchOrCreateSoftwareInstaller(ctx, mkFMA(firefox.ID, "Mozilla Firefox", "ff-154", "154.0"))
+	require.NoError(t, err)
 }
 
 func testAddSoftwareTitleToMatchingSoftware(t *testing.T, ds *Datastore) {

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -5016,8 +5016,7 @@ func testMatchOrCreateSoftwareInstallerConflictingFMA(t *testing.T, ds *Datastor
 	team, err := ds.NewTeam(ctx, &fleet.Team{Name: t.Name()})
 	require.NoError(t, err)
 
-	// Mozilla Firefox and Firefox ESR are distinct Fleet-maintained apps that share the macOS
-	// bundle identifier org.mozilla.firefox, so they resolve to the same software title.
+	// Firefox and Firefox ESR are distinct FMAs sharing bundle id org.mozilla.firefox, so one title.
 	firefox, err := ds.UpsertMaintainedApp(ctx, &fleet.MaintainedApp{
 		Name: "Mozilla Firefox", Slug: "firefox", Platform: "darwin", UniqueIdentifier: "org.mozilla.firefox",
 	})

--- a/server/fleet/errors.go
+++ b/server/fleet/errors.go
@@ -37,7 +37,7 @@ var (
 	CantEnablePINRequiredIfDiskEncryptionEnabled = "Couldn't enable BitLocker PIN requirement, you must enable disk encryption first."
 	CantResendAppleDeclarationProfilesMessage    = "Can't resend declaration (DDM) profiles. Unlike configuration profiles (.mobileconfig), the host automatically checks in to get the latest DDM profiles."
 	CantAddSoftwareConflictMessage               = "Couldn't add software. %s already has an installer available for the %s fleet."
-	// Args: existing app name, incoming app name.
+	// Args: the two conflicting app names (order not significant).
 	CantAddConflictingFMAMessage                 = "Couldn't add software. Only one of %s or %s can be added to the same fleet."
 	SoftwarePackageHashConflictMessage           = "%s package is already added (same SHA-256 hash)."
 	SoftwarePackageTitleMismatchMessage          = "Couldn't add. %s doesn't match the software title. To add it, go to Software and add it as new software."

--- a/server/fleet/errors.go
+++ b/server/fleet/errors.go
@@ -38,7 +38,7 @@ var (
 	CantResendAppleDeclarationProfilesMessage    = "Can't resend declaration (DDM) profiles. Unlike configuration profiles (.mobileconfig), the host automatically checks in to get the latest DDM profiles."
 	CantAddSoftwareConflictMessage               = "Couldn't add software. %s already has an installer available for the %s fleet."
 	// Args: existing app name, incoming app name.
-	CantAddConflictingFMAMessage = "Couldn't add software. Only one of %s or %s can be added to the same fleet."
+	CantAddConflictingFMAMessage                 = "Couldn't add software. Only one of %s or %s can be added to the same fleet."
 	SoftwarePackageHashConflictMessage           = "%s package is already added (same SHA-256 hash)."
 	SoftwarePackageTitleMismatchMessage          = "Couldn't add. %s doesn't match the software title. To add it, go to Software and add it as new software."
 	SoftwareAlreadyHasVPPAppMessage              = "%s already has an Apple App Store (VPP) on the %s fleet."

--- a/server/fleet/errors.go
+++ b/server/fleet/errors.go
@@ -37,6 +37,8 @@ var (
 	CantEnablePINRequiredIfDiskEncryptionEnabled = "Couldn't enable BitLocker PIN requirement, you must enable disk encryption first."
 	CantResendAppleDeclarationProfilesMessage    = "Can't resend declaration (DDM) profiles. Unlike configuration profiles (.mobileconfig), the host automatically checks in to get the latest DDM profiles."
 	CantAddSoftwareConflictMessage               = "Couldn't add software. %s already has an installer available for the %s fleet."
+	// Args: existing app name, incoming app name.
+	CantAddConflictingFMAMessage = "Couldn't add software. Only one of %s or %s can be added to the same fleet."
 	SoftwarePackageHashConflictMessage           = "%s package is already added (same SHA-256 hash)."
 	SoftwarePackageTitleMismatchMessage          = "Couldn't add. %s doesn't match the software title. To add it, go to Software and add it as new software."
 	SoftwareAlreadyHasVPPAppMessage              = "%s already has an Apple App Store (VPP) on the %s fleet."

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -1282,11 +1282,16 @@ const MaxSoftwareInstallAttempts = 3
 const MaxPackagesPerTitle = 10
 
 func ValidateTitlePackages(payloads []*UploadSoftwareInstallerPayload, teamName string) error {
-	var customCount, fmaCount int
+	var customCount int
 	seenHash := make(map[string]struct{}, len(payloads))
+	seenFMA := make(map[uint]struct{}, len(payloads))
+	var fmaNames []string
 	for _, p := range payloads {
 		if p.FleetMaintainedAppID != nil {
-			fmaCount++
+			if _, seen := seenFMA[*p.FleetMaintainedAppID]; !seen {
+				seenFMA[*p.FleetMaintainedAppID] = struct{}{}
+				fmaNames = append(fmaNames, p.Title)
+			}
 			continue
 		}
 		customCount++
@@ -1295,7 +1300,12 @@ func ValidateTitlePackages(payloads []*UploadSoftwareInstallerPayload, teamName 
 		}
 		seenHash[p.StorageID] = struct{}{}
 	}
-	if fmaCount > 0 && customCount > 0 {
+	// Two FMAs that share a bundle identifier (e.g. Mozilla Firefox and Firefox ESR) resolve to one
+	// title but are the same inventory app; only one can be added.
+	if len(fmaNames) > 1 {
+		return ConflictError{Message: fmt.Sprintf(CantAddConflictingFMAMessage, fmaNames[0], fmaNames[1])}
+	}
+	if len(fmaNames) > 0 && customCount > 0 {
 		return ConflictError{Message: fmt.Sprintf(SoftwareAlreadyHasFleetMaintainedAppMessage, payloads[0].Title, teamName)}
 	}
 	if customCount > MaxPackagesPerTitle {

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -1300,8 +1300,8 @@ func ValidateTitlePackages(payloads []*UploadSoftwareInstallerPayload, teamName 
 		}
 		seenHash[p.StorageID] = struct{}{}
 	}
-	// Two FMAs that share a bundle identifier (e.g. Mozilla Firefox and Firefox ESR) resolve to one
-	// title but are the same inventory app; only one can be added.
+	// Two FMAs on one title share a bundle identifier (e.g. Firefox and Firefox ESR): same
+	// inventory app, so only one can be added.
 	if len(fmaNames) > 1 {
 		return ConflictError{Message: fmt.Sprintf(CantAddConflictingFMAMessage, fmaNames[0], fmaNames[1])}
 	}

--- a/server/fleet/software_installer_test.go
+++ b/server/fleet/software_installer_test.go
@@ -398,3 +398,56 @@ func TestHostSoftwareInstallResultPayloadStatus(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateTitlePackages(t *testing.T) {
+	fma := func(appID uint, title string) *UploadSoftwareInstallerPayload {
+		return &UploadSoftwareInstallerPayload{Title: title, FleetMaintainedAppID: new(appID)}
+	}
+	custom := func(title, storage string) *UploadSoftwareInstallerPayload {
+		return &UploadSoftwareInstallerPayload{Title: title, StorageID: storage, Filename: storage}
+	}
+
+	cases := []struct {
+		name     string
+		payloads []*UploadSoftwareInstallerPayload
+		wantErr  string
+	}{
+		{
+			name:     "two different FMAs on one title is rejected",
+			payloads: []*UploadSoftwareInstallerPayload{fma(1, "Mozilla Firefox"), fma(2, "Mozilla Firefox ESR")},
+			wantErr:  "Only one of Mozilla Firefox or Mozilla Firefox ESR can be added to the same fleet",
+		},
+		{
+			name:     "same FMA across multiple versions is allowed",
+			payloads: []*UploadSoftwareInstallerPayload{fma(1, "Mozilla Firefox"), fma(1, "Mozilla Firefox")},
+		},
+		{
+			name:     "single FMA is allowed",
+			payloads: []*UploadSoftwareInstallerPayload{fma(1, "Mozilla Firefox")},
+		},
+		{
+			name:     "mixing an FMA with a custom package is rejected",
+			payloads: []*UploadSoftwareInstallerPayload{fma(1, "Mozilla Firefox"), custom("Mozilla Firefox", "hash-1")},
+			wantErr:  "Fleet-maintained app",
+		},
+		{
+			name:     "duplicate custom-package hash is rejected",
+			payloads: []*UploadSoftwareInstallerPayload{custom("App", "same-hash"), custom("App", "same-hash")},
+			wantErr:  "same SHA-256 hash",
+		},
+		{
+			name:     "distinct custom packages are allowed",
+			payloads: []*UploadSoftwareInstallerPayload{custom("App", "hash-a"), custom("App", "hash-b")},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateTitlePackages(tc.payloads, "Workstations")
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tc.wantErr)
+		})
+	}
+}


### PR DESCRIPTION
**Related issue:** Resolves #49682

Mozilla Firefox and Firefox ESR are distinct Fleet-maintained apps that share the macOS bundle identifier `org.mozilla.firefox`, so they resolve to one software title. Adding both to a fleet previously gave a generic conflict error (or no error at all). This adds a clear message — "Only one of Mozilla Firefox or Mozilla Firefox ESR can be added to the same fleet." — on both the single-add and GitOps/batch paths. The check is general (any two FMAs sharing a bundle identifier), with the app names filled in dynamically.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements).

## Testing

- [x] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented adding both Mozilla Firefox and Firefox ESR to the same fleet when they share a bundle identifier.
  - Updated the UI to show a specific conflict message explaining that only one of the two can be added.
  - Ensured existing workflows still work for adding new versions of the already-selected app.
- **Tests**
  - Added backend and frontend test coverage for the new conflict detection and error-message formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->