### PR TITLE
Clarify which OS supports OS Updates

### DIFF
--- a/changes/48960-android-os-updates-mdm-message
+++ b/changes/48960-android-os-updates-mdm-message
@@ -1,0 +1,1 @@
+- Clarified the Controls > OS updates empty state to say "Apple or Windows MDM must be turned on" and link to MDM settings, so it no longer implies MDM is off when only Android MDM is enabled.

--- a/frontend/pages/ManageControlsPage/OSUpdates/OSUpdates.tsx
+++ b/frontend/pages/ManageControlsPage/OSUpdates/OSUpdates.tsx
@@ -124,10 +124,10 @@ const OSUpdates = ({ router, teamIdForApi, queryParams }: IOSUpdates) => {
       <div className={baseClass}>
         <EmptyState
           header="Additional configuration required"
-          info="MDM must be turned on to change settings on your hosts."
+          info="Apple or Windows MDM must be turned on to change settings on your hosts."
           primaryButton={
             <Button onClick={() => router.push(PATHS.ADMIN_INTEGRATIONS_MDM)}>
-              Turn on
+              Go to MDM settings
             </Button>
           }
         />


### PR DESCRIPTION
**Related issue:** Resolves #48960 

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified the OS updates empty-state message to specify that Apple or Windows MDM must be enabled.
  * Updated the action link to direct users to MDM settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->