### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/amazon-corretto-17/windows.json
+++ b/ee/maintained-apps/outputs/amazon-corretto-17/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "17.0.19.10",
+      "version": "17.0.20.8",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Amazon Corretto (x64)' AND publisher = 'Amazon' AND version LIKE '17.%';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Amazon Corretto (x64)' AND publisher = 'Amazon' AND version LIKE '17.%' AND version_compare(version, '17.0.19.10') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Amazon Corretto (x64)' AND publisher = 'Amazon' AND version LIKE '17.%' AND version_compare(version, '17.0.20.8') < 0);"
       },
-      "installer_url": "https://corretto.aws/downloads/resources/17.0.19.10.1/amazon-corretto-17.0.19.10.1-windows-x64.msi",
+      "installer_url": "https://corretto.aws/downloads/resources/17.0.20.8.1/amazon-corretto-17.0.20.8.1-windows-x64.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "d85741a4",
-      "sha256": "7ecbfdd4b9897eed776df131c84fb128f5091aa482dec7e41aadf1979072c93d",
+      "sha256": "ed15f0773a080771e5d183db8be7ac43eae468082d800c0563f67ce954b9a0ad",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/amazon-corretto-21/windows.json
+++ b/ee/maintained-apps/outputs/amazon-corretto-21/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "21.0.11.10",
+      "version": "21.0.12.8",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Amazon Corretto (x64)' AND publisher = 'Amazon' AND version LIKE '21.%';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Amazon Corretto (x64)' AND publisher = 'Amazon' AND version LIKE '21.%' AND version_compare(version, '21.0.11.10') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Amazon Corretto (x64)' AND publisher = 'Amazon' AND version LIKE '21.%' AND version_compare(version, '21.0.12.8') < 0);"
       },
-      "installer_url": "https://corretto.aws/downloads/resources/21.0.11.10.1/amazon-corretto-21.0.11.10.1-windows-x64.msi",
+      "installer_url": "https://corretto.aws/downloads/resources/21.0.12.8.1/amazon-corretto-21.0.12.8.1-windows-x64.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "291bae71",
-      "sha256": "df8d443f0ab1eca0d1b95177d3d45a100616ecfab93226a2f126dd1f3baafb50",
+      "sha256": "c74844499e9c234050b1fbd89027fee94f99a0139dc4648acc2b461a63d333c0",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/amazon-corretto-8/windows.json
+++ b/ee/maintained-apps/outputs/amazon-corretto-8/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.8.0.492",
+      "version": "1.8.0.502",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Amazon Corretto 8 (x64)' AND publisher = 'Amazon';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Amazon Corretto 8 (x64)' AND publisher = 'Amazon' AND version_compare(version, '1.8.0.492') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Amazon Corretto 8 (x64)' AND publisher = 'Amazon' AND version_compare(version, '1.8.0.502') < 0);"
       },
-      "installer_url": "https://corretto.aws/downloads/resources/8.492.09.2/amazon-corretto-8.492.09.2-windows-x64-jdk.msi",
+      "installer_url": "https://corretto.aws/downloads/resources/8.502.07.1/amazon-corretto-8.502.07.1-windows-x64-jdk.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "1586ea27",
-      "sha256": "b091276b5fc250597b0a940473c10f72d4f37a8aac86eca5f7cd652a45890071",
+      "sha256": "b13b5787b60715aabf0fbafe3ee18efa824c5f633ded0756c7e17a9cac48386e",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/amazon-corretto-jre-8/windows.json
+++ b/ee/maintained-apps/outputs/amazon-corretto-jre-8/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.8.0.492",
+      "version": "1.8.0.502",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Amazon Corretto JRE 8 (x64)' AND publisher = 'Amazon';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Amazon Corretto JRE 8 (x64)' AND publisher = 'Amazon' AND version_compare(version, '1.8.0.492') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Amazon Corretto JRE 8 (x64)' AND publisher = 'Amazon' AND version_compare(version, '1.8.0.502') < 0);"
       },
-      "installer_url": "https://corretto.aws/downloads/resources/8.492.09.2/amazon-corretto-8.492.09.2-windows-x64-jre.msi",
+      "installer_url": "https://corretto.aws/downloads/resources/8.502.07.1/amazon-corretto-8.502.07.1-windows-x64-jre.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "a91b27a6",
-      "sha256": "9777acb74091b23f075e0bfb98326c44c0e84e698c8d916c3582d3fdcd0cd37c",
+      "sha256": "c3cc682c34fd9cf1a50606f9185f97abc1a2ff11323456b070034357bb049063",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/aws-cli/windows.json
+++ b/ee/maintained-apps/outputs/aws-cli/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.36.4",
+      "version": "2.36.5",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'AWS Command Line Interface v2 %' AND publisher = 'Amazon Web Services';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'AWS Command Line Interface v2 %' AND publisher = 'Amazon Web Services' AND version_compare(version, '2.36.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'AWS Command Line Interface v2 %' AND publisher = 'Amazon Web Services' AND version_compare(version, '2.36.5') < 0);"
       },
-      "installer_url": "https://awscli.amazonaws.com/AWSCLIV2-2.36.4.msi",
+      "installer_url": "https://awscli.amazonaws.com/AWSCLIV2-2.36.5.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "58bcd016",
-      "sha256": "efd30424b75807bd0f4b79f090cedcec8a370fdd030e7c0d3514a42c6d9a22c7",
+      "sha256": "8e8e680058fa17e0a4c71c8dcce4c51463095f23c776a8dd6d44f00c9fe1b390",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/azul-zulu-25-jdk/windows.json
+++ b/ee/maintained-apps/outputs/azul-zulu-25-jdk/windows.json
@@ -1,22 +1,22 @@
 {
   "versions": [
     {
-      "version": "25.34.17",
+      "version": "25.36.15",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Azul Zulu JDK %' AND publisher = 'Azul Systems, Inc.' AND version LIKE '25.%';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Azul Zulu JDK %' AND publisher = 'Azul Systems, Inc.' AND version LIKE '25.%' AND version_compare(version, '25.34.17') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Azul Zulu JDK %' AND publisher = 'Azul Systems, Inc.' AND version LIKE '25.%' AND version_compare(version, '25.36.15') < 0);"
       },
-      "installer_url": "https://cdn.azul.com/zulu/bin/zulu25.34.17-ca-jdk25.0.3-win_x64.msi",
+      "installer_url": "https://cdn.azul.com/zulu/bin/zulu25.36.15-ca-jdk25.0.4-win_x64.msi",
       "install_script_ref": "8959087b",
-      "uninstall_script_ref": "a2dce35a",
-      "sha256": "e92ebafaa1166fde201e556b2885a68bba276a1837975947c0d3899b8f5b8d97",
+      "uninstall_script_ref": "86b4409e",
+      "sha256": "91a9518d9b9723d48330d52b6c149758e2d3b896542c77d3e3c2ab0fd30c9200",
       "default_categories": [
         "Developer tools"
       ]
     }
   ],
   "refs": {
-    "8959087b": "$logFile = \"${env:TEMP}/fleet-install-software.log\"\n\ntry {\n\n$installProcess = Start-Process msiexec.exe `\n  -ArgumentList \"/quiet /norestart /lv ${logFile} /i `\"${env:INSTALLER_PATH}`\"\" `\n  -PassThru -Verb RunAs -Wait\n\nGet-Content $logFile -Tail 500\n\nExit $installProcess.ExitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n",
-    "a2dce35a": "$product_code = '{78F5F8F4-405D-4479-9797-23AD3914CA77}'\n$timeoutSeconds = 300  # 5 minute timeout\n\n# Fleet uninstalls app using product code that's extracted on upload\n$process = Start-Process msiexec -ArgumentList @(\"/quiet\", \"/x\", $product_code, \"/norestart\") -PassThru\n\n# Wait for process with timeout\n$completed = $process.WaitForExit($timeoutSeconds * 1000)\n\nif (-not $completed) {\n    Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue\n    Exit 1603  # ERROR_UNINSTALL_FAILURE\n}\n\n# MSI exit codes that indicate success. 3010 = ERROR_SUCCESS_REBOOT_REQUIRED,\n# 1641 = ERROR_SUCCESS_REBOOT_INITIATED. Treat these as success rather than failure.\n$successCodes = @(0, 3010, 1641)\n\n# Check exit code and output result\nif ($successCodes -contains $process.ExitCode) {\n    Write-Output \"Exit 0\"\n    Exit 0\n} else {\n    Write-Output \"Exit $($process.ExitCode)\"\n    Exit $process.ExitCode\n}\n"
+    "86b4409e": "$product_code = '{EBD36C05-81B7-43E4-BF66-33A0F793234B}'\n$timeoutSeconds = 300  # 5 minute timeout\n\n# Fleet uninstalls app using product code that's extracted on upload\n$process = Start-Process msiexec -ArgumentList @(\"/quiet\", \"/x\", $product_code, \"/norestart\") -PassThru\n\n# Wait for process with timeout\n$completed = $process.WaitForExit($timeoutSeconds * 1000)\n\nif (-not $completed) {\n    Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue\n    Exit 1603  # ERROR_UNINSTALL_FAILURE\n}\n\n# MSI exit codes that indicate success. 3010 = ERROR_SUCCESS_REBOOT_REQUIRED,\n# 1641 = ERROR_SUCCESS_REBOOT_INITIATED. Treat these as success rather than failure.\n$successCodes = @(0, 3010, 1641)\n\n# Check exit code and output result\nif ($successCodes -contains $process.ExitCode) {\n    Write-Output \"Exit 0\"\n    Exit 0\n} else {\n    Write-Output \"Exit $($process.ExitCode)\"\n    Exit $process.ExitCode\n}\n",
+    "8959087b": "$logFile = \"${env:TEMP}/fleet-install-software.log\"\n\ntry {\n\n$installProcess = Start-Process msiexec.exe `\n  -ArgumentList \"/quiet /norestart /lv ${logFile} /i `\"${env:INSTALLER_PATH}`\"\" `\n  -PassThru -Verb RunAs -Wait\n\nGet-Content $logFile -Tail 500\n\nExit $installProcess.ExitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n"
   }
 }

--- a/ee/maintained-apps/outputs/claude/darwin.json
+++ b/ee/maintained-apps/outputs/claude/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.24012.0",
+      "version": "1.24012.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.24012.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.24012.1') < 0);"
       },
-      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.24012.0/Claude-44be967d07ffab39b371cc3297a6a71a5ef92fa9.zip",
+      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.24012.1/Claude-0adcaed55041a881be363f2c4a4729f67a8b27d7.zip",
       "install_script_ref": "8b957973",
       "uninstall_script_ref": "421baa98",
-      "sha256": "769efc63a1c91ac8a6894b453f279a1ce4a01d19aae9bc0ebf4797a6aaa4cb10",
+      "sha256": "de2833b60daabdbf0e9237d9f8f3b8102ef19418e354117b19b321d0a3a12e6f",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/claude/windows.json
+++ b/ee/maintained-apps/outputs/claude/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.22209.3",
+      "version": "1.24012.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Claude' AND publisher = 'Anthropic, PBC';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Claude' AND publisher = 'Anthropic, PBC' AND version_compare(version, '1.22209.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Claude' AND publisher = 'Anthropic, PBC' AND version_compare(version, '1.24012.0') < 0);"
       },
-      "installer_url": "https://downloads.claude.ai/releases/win32/x64/1.22209.3/Claude-babe11577dfefe3e209c06bd674628d862f0dbae.msix",
+      "installer_url": "https://downloads.claude.ai/releases/win32/x64/1.24012.0/Claude-44be967d07ffab39b371cc3297a6a71a5ef92fa9.msix",
       "install_script_ref": "16c020cc",
       "uninstall_script_ref": "03f72055",
-      "sha256": "8fbe26fea90c5077de6bfe4848748ff7ca7646475a713b6b997acf14d5a64dcd",
+      "sha256": "7600470f2e94fecf67030ae4595b116613941291dbebcebcaaf4ce0047946284",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/devolutions-launcher/windows.json
+++ b/ee/maintained-apps/outputs/devolutions-launcher/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.2.14.0",
+      "version": "2026.2.16.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Devolutions Launcher' AND publisher = 'Devolutions inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Devolutions Launcher' AND publisher = 'Devolutions inc.' AND version_compare(version, '2026.2.14.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Devolutions Launcher' AND publisher = 'Devolutions inc.' AND version_compare(version, '2026.2.16.0') < 0);"
       },
-      "installer_url": "https://cdn.devolutions.net/download/Setup.Devolutions.Launcher.2026.2.14.0.msi",
+      "installer_url": "https://cdn.devolutions.net/download/Setup.Devolutions.Launcher.2026.2.16.0.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "532bd615",
-      "sha256": "b372e0dd767dcff116ef56ef405553da836ab0843d5c018eb005e77de66ec99b",
+      "sha256": "dcc93186906171c38212fbf9540c685a831274c6085d8fd22904eb361d4d1f72",
       "default_categories": [
         "Productivity"
       ],

--- a/ee/maintained-apps/outputs/drawio/darwin.json
+++ b/ee/maintained-apps/outputs/drawio/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "30.3.14",
+      "version": "30.4.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jgraph.drawio.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jgraph.drawio.desktop' AND version_compare(bundle_short_version, '30.3.14') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jgraph.drawio.desktop' AND version_compare(bundle_short_version, '30.4.1') < 0);"
       },
-      "installer_url": "https://github.com/jgraph/drawio-desktop/releases/download/v30.3.14/draw.io-arm64-30.3.14.dmg",
+      "installer_url": "https://github.com/jgraph/drawio-desktop/releases/download/v30.4.1/draw.io-arm64-30.4.1.dmg",
       "install_script_ref": "1f3003b7",
       "uninstall_script_ref": "19c87f7a",
-      "sha256": "2d695296b4eaf90efd38aacd9110e488c18c5896e75b1fd55c6a27b09747f244",
+      "sha256": "445ef3db8ce81e3e0c337cac404baefeb4715efd47ca0b048c5deb48ad842fb9",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/figma/windows.json
+++ b/ee/maintained-apps/outputs/figma/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "126.7.6",
+      "version": "126.7.8",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Figma' AND publisher = 'Figma, Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Figma' AND publisher = 'Figma, Inc.' AND version_compare(version, '126.7.6') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Figma' AND publisher = 'Figma, Inc.' AND version_compare(version, '126.7.8') < 0);"
       },
-      "installer_url": "https://desktop.figma.com/win/build/Figma-126.7.6.exe",
+      "installer_url": "https://desktop.figma.com/win/build/Figma-126.7.8.exe",
       "install_script_ref": "442d71b3",
       "uninstall_script_ref": "e33afd6b",
-      "sha256": "d403632410e40023f32439ac660c316a3194001a0540ce91b1c2e603fd3e8b5f",
+      "sha256": "27b1550172b4e18054ae03a8e8691e786fa45d3a13fa1643b3f35ea261a9f484",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/firefox@nightly/darwin.json
+++ b/ee/maintained-apps/outputs/firefox@nightly/darwin.json
@@ -6,10 +6,10 @@
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly';",
         "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15526.7.21') < 0);"
       },
-      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/07/2026-07-21-09-46-48-mozilla-central/firefox-155.0a1.en-US.mac.dmg",
+      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/07/2026-07-21-20-23-27-mozilla-central/firefox-155.0a1.en-US.mac.dmg",
       "install_script_ref": "418c9331",
       "uninstall_script_ref": "d7c711ad",
-      "sha256": "9d33b42372f73ee68c76b7c7ea3247a3ef2590ab44bed743efcbab154f525d7c",
+      "sha256": "7aed87246486b561daa4a72dc6165acdbd1a767fdb6174d506dce10d372caadd",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/gitify/darwin.json
+++ b/ee/maintained-apps/outputs/gitify/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "6.20.0",
+      "version": "7.0.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.gitify';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.gitify' AND version_compare(bundle_short_version, '6.20.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.gitify' AND version_compare(bundle_short_version, '7.0.0') < 0);"
       },
-      "installer_url": "https://github.com/gitify-app/gitify/releases/download/v6.20.0/Gitify-6.20.0-universal-mac.zip",
+      "installer_url": "https://github.com/gitify-app/gitify/releases/download/v7.0.0/Gitify-7.0.0-universal-mac.zip",
       "install_script_ref": "4dfde5cf",
       "uninstall_script_ref": "65bf9482",
-      "sha256": "8fc383a66b7190e33b488bdd208178e35e4cbc9d22eb8bd3d3931ab9f3e77a1b",
+      "sha256": "2c6f2a64323cedc5b02edfc8798908457f93930e5e97dc80c75b557ae6dbd91b",
       "default_categories": [
         "Utilities"
       ]

--- a/ee/maintained-apps/outputs/google-chrome/windows.json
+++ b/ee/maintained-apps/outputs/google-chrome/windows.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "150.0.7871.129",
+      "version": "150.0.7871.182",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Google Chrome' AND publisher = 'Google LLC';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Google Chrome' AND publisher = 'Google LLC' AND version_compare(version, '150.0.7871.129') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Google Chrome' AND publisher = 'Google LLC' AND version_compare(version, '150.0.7871.182') < 0);"
       },
       "installer_url": "https://dl.google.com/dl/chrome/install/googlechromestandaloneenterprise64.msi",
       "install_script_ref": "8959087b",

--- a/ee/maintained-apps/outputs/kiro/darwin.json
+++ b/ee/maintained-apps/outputs/kiro/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.0.182",
+      "version": "1.0.198",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kiro.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kiro.desktop' AND version_compare(bundle_short_version, '1.0.182') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kiro.desktop' AND version_compare(bundle_short_version, '1.0.198') < 0);"
       },
-      "installer_url": "https://prod.download.desktop.kiro.dev/releases/stable/darwin-arm64/signed/1.0.182/kiro-ide-1.0.182-stable-darwin-arm64.dmg",
+      "installer_url": "https://prod.download.desktop.kiro.dev/releases/stable/darwin-arm64/signed/1.0.198/kiro-ide-1.0.198-stable-darwin-arm64.dmg",
       "install_script_ref": "28c3d1eb",
       "uninstall_script_ref": "b5d79db0",
-      "sha256": "afe063cafd94622daf9844b37572826948a096cb46754a3ce3cd4bc131bd0dea",
+      "sha256": "172605f2faf84ec4047d5e7890306fda2df5149a8ee9abd52bbd848bcc7ba556",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/kiro/windows.json
+++ b/ee/maintained-apps/outputs/kiro/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.0.182",
+      "version": "1.0.198",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Kiro (User)' AND publisher = 'Amazon Web Services';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Kiro (User)' AND publisher = 'Amazon Web Services' AND version_compare(version, '1.0.182') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Kiro (User)' AND publisher = 'Amazon Web Services' AND version_compare(version, '1.0.198') < 0);"
       },
-      "installer_url": "https://prod.download.desktop.kiro.dev/releases/stable/win32-x64/signed/1.0.182/kiro-ide-1.0.182-stable-win32-x64.exe",
+      "installer_url": "https://prod.download.desktop.kiro.dev/releases/stable/win32-x64/signed/1.0.198/kiro-ide-1.0.198-stable-win32-x64.exe",
       "install_script_ref": "c5bc3c21",
       "uninstall_script_ref": "afe8f2fa",
-      "sha256": "8e82d97f492961fbeef41db2bb0636a7e173b1ea05402eb744068d994f1c687d",
+      "sha256": "b7614f5c9b11df95c8628d70c54b038ec02415555699dcb081ba86199b2c7f77",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/microsoft-excel/darwin.json
+++ b/ee/maintained-apps/outputs/microsoft-excel/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "16.111",
+      "version": "16.111.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.Excel';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.Excel' AND version_compare(bundle_short_version, '16.111') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.Excel' AND version_compare(bundle_short_version, '16.111.1') < 0);"
       },
       "installer_url": "https://res.public.onecdn.static.microsoft/mro1cdnstorage/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_Excel_16.111.26071913_Installer.pkg",
       "install_script_ref": "a058ee4b",

--- a/ee/maintained-apps/outputs/microsoft-onenote/darwin.json
+++ b/ee/maintained-apps/outputs/microsoft-onenote/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "16.111",
+      "version": "16.111.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.onenote.mac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.onenote.mac' AND version_compare(bundle_short_version, '16.111') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.onenote.mac' AND version_compare(bundle_short_version, '16.111.1') < 0);"
       },
       "installer_url": "https://res.public.onecdn.static.microsoft/mro1cdnstorage/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_OneNote_16.111.26071913_Updater.pkg",
       "install_script_ref": "fe16d50a",

--- a/ee/maintained-apps/outputs/microsoft-powerpoint/darwin.json
+++ b/ee/maintained-apps/outputs/microsoft-powerpoint/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "16.111",
+      "version": "16.111.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.Powerpoint';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.Powerpoint' AND version_compare(bundle_short_version, '16.111') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.Powerpoint' AND version_compare(bundle_short_version, '16.111.1') < 0);"
       },
       "installer_url": "https://res.public.onecdn.static.microsoft/mro1cdnstorage/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_PowerPoint_16.111.26071913_Installer.pkg",
       "install_script_ref": "daf855a0",

--- a/ee/maintained-apps/outputs/microsoft-word/darwin.json
+++ b/ee/maintained-apps/outputs/microsoft-word/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "16.111",
+      "version": "16.111.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.Word';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.Word' AND version_compare(bundle_short_version, '16.111') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.Word' AND version_compare(bundle_short_version, '16.111.1') < 0);"
       },
       "installer_url": "https://res.public.onecdn.static.microsoft/mro1cdnstorage/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_Word_16.111.26071913_Installer.pkg",
       "install_script_ref": "e06030dd",

--- a/ee/maintained-apps/outputs/miro/darwin.json
+++ b/ee/maintained-apps/outputs/miro/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "0.11.160",
+      "version": "0.11.162",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.realtimeboard';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.realtimeboard' AND version_compare(bundle_short_version, '0.11.160') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.realtimeboard' AND version_compare(bundle_short_version, '0.11.162') < 0);"
       },
       "installer_url": "https://desktop.miro.com/platforms/darwin-arm64/Install-Miro.dmg",
       "install_script_ref": "ea60f0ac",

--- a/ee/maintained-apps/outputs/power-bi/windows.json
+++ b/ee/maintained-apps/outputs/power-bi/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.155.756.0",
+      "version": "2.156.951.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Microsoft Power BI Desktop (x64)' AND publisher = 'Microsoft Corporation';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Microsoft Power BI Desktop (x64)' AND publisher = 'Microsoft Corporation' AND version_compare(version, '2.155.756.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Microsoft Power BI Desktop (x64)' AND publisher = 'Microsoft Corporation' AND version_compare(version, '2.156.951.0') < 0);"
       },
-      "installer_url": "https://download.microsoft.com/download/8/8/0/880BCA75-79DD-466A-927D-1ABF1F5454B0/PBIDesktopSetup-2026-06_x64.exe",
+      "installer_url": "https://download.microsoft.com/download/8/8/0/880BCA75-79DD-466A-927D-1ABF1F5454B0/PBIDesktopSetup-2026-07_x64.exe",
       "install_script_ref": "cc478c11",
       "uninstall_script_ref": "abc3b459",
-      "sha256": "d73aaadbb3e22095057be5eae8d3b8ac96b33be17d18d41e58c4c39493e3d185",
+      "sha256": "ff265b2dd4a52e77475452de014ed5babb4c73b83284fc17adda7d774a62c5c4",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/qlab/darwin.json
+++ b/ee/maintained-apps/outputs/qlab/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "5.6.2",
+      "version": "5.6.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.figure53.QLab.5';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.figure53.QLab.5' AND version_compare(bundle_short_version, '5.6.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.figure53.QLab.5' AND version_compare(bundle_short_version, '5.6.3') < 0);"
       },
-      "installer_url": "https://qlab.app/downloads/archive/QLab-5.6.2.zip",
+      "installer_url": "https://qlab.app/downloads/archive/QLab-5.6.3.zip",
       "install_script_ref": "00ad3e5d",
       "uninstall_script_ref": "a60a2320",
-      "sha256": "923df9c0ef8c0b659439fdfb0111b022dd841692e4b0672a34a56b7e439436fa",
+      "sha256": "fa655221b20f5add503faedfacd1d8d3b37a24f0ac7b05736c3e61e905300dea",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/remote-desktop-manager/windows.json
+++ b/ee/maintained-apps/outputs/remote-desktop-manager/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.2.14.0",
+      "version": "2026.2.16.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Remote Desktop Manager' AND publisher = 'Devolutions inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Remote Desktop Manager' AND publisher = 'Devolutions inc.' AND version_compare(version, '2026.2.14.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Remote Desktop Manager' AND publisher = 'Devolutions inc.' AND version_compare(version, '2026.2.16.0') < 0);"
       },
-      "installer_url": "https://cdn.devolutions.net/download/Setup.RemoteDesktopManager.win-x64.2026.2.14.0.msi",
+      "installer_url": "https://cdn.devolutions.net/download/Setup.RemoteDesktopManager.win-x64.2026.2.16.0.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "df5e7f6c",
-      "sha256": "96c855f8941eefeba9893f33b1d71c3191e67f76db901e8fd69fa943996542b2",
+      "sha256": "8caa52f37bda1a03f984f89b80af54154b6cb501f27951ff9f669ebd27090f5e",
       "default_categories": [
         "Productivity"
       ],

--- a/ee/maintained-apps/outputs/rive/darwin.json
+++ b/ee/maintained-apps/outputs/rive/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.8.5165",
+      "version": "0.8.5252",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'app.rive.editor';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.rive.editor' AND version_compare(bundle_short_version, '0.8.5165') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.rive.editor' AND version_compare(bundle_short_version, '0.8.5252') < 0);"
       },
-      "installer_url": "https://releases.rive.app/macos/0.8.5165/Rive.dmg",
+      "installer_url": "https://releases.rive.app/macos/0.8.5252/Rive.dmg",
       "install_script_ref": "2bbfee4e",
       "uninstall_script_ref": "8f862785",
-      "sha256": "c5d4ee7488cc2eaccc7a3d545b5fb98b4899b22885475e65bd1acd1585612cf0",
+      "sha256": "6029962923dd8ff06f37f17df2ec86e50dd517a82ba8b4f83f23b9e793ee8f53",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/telegram/windows.json
+++ b/ee/maintained-apps/outputs/telegram/windows.json
@@ -6,7 +6,7 @@
         "exists": "SELECT 1 FROM programs WHERE name = 'Telegram Desktop' AND publisher = 'Telegram FZ-LLC';",
         "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Telegram Desktop' AND publisher = 'Telegram FZ-LLC' AND version_compare(version, '7.0.4') < 0);"
       },
-      "installer_url": "https://td.telegram.org/tx64/tsetup-x64.7.0.4.exe",
+      "installer_url": "https://github.com/telegramdesktop/tdesktop/releases/download/v7.0.4/tsetup-x64.7.0.4.exe",
       "install_script_ref": "0b88a95e",
       "uninstall_script_ref": "42311f1b",
       "sha256": "f70bdb9ca2bf45cc4c33c83bc898b2e43a919ee013f71307976b66210b3171f7",

--- a/ee/maintained-apps/outputs/thunderbird/darwin.json
+++ b/ee/maintained-apps/outputs/thunderbird/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "152.0.1",
+      "version": "153.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.thunderbird';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.thunderbird' AND version_compare(bundle_short_version, '152.0.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.thunderbird' AND version_compare(bundle_short_version, '153.0') < 0);"
       },
-      "installer_url": "https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/152.0.1/mac/en-US/Thunderbird%20152.0.1.dmg",
+      "installer_url": "https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/153.0/mac/en-US/Thunderbird%20153.0.dmg",
       "install_script_ref": "7cfa15ee",
       "uninstall_script_ref": "88749f85",
-      "sha256": "2ddb04427a7153e2c25f2f118ba42d5904f73b8e8b7599a0761a30c774fc00c6",
+      "sha256": "b6941531638a0fe09e5ad30bf2aeba14fb5a73bb5e40511b505d0c8063463f6c",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/typora/windows.json
+++ b/ee/maintained-apps/outputs/typora/windows.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "1.14.1",
+      "version": "1.14.7",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Typora' AND publisher = 'typora.io';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Typora' AND publisher = 'typora.io' AND version_compare(version, '1.14.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Typora' AND publisher = 'typora.io' AND version_compare(version, '1.14.7') < 0);"
       },
       "installer_url": "https://downloads.typora.io/windows/typora-setup-x64-1.14.7.exe",
       "install_script_ref": "cf428c2f",

--- a/ee/maintained-apps/outputs/wispr-flow/darwin.json
+++ b/ee/maintained-apps/outputs/wispr-flow/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.6.168",
+      "version": "1.6.182",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.wispr-flow';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.wispr-flow' AND version_compare(bundle_short_version, '1.6.168') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.wispr-flow' AND version_compare(bundle_short_version, '1.6.182') < 0);"
       },
-      "installer_url": "https://dl.wisprflow.com/wispr-flow/darwin/arm64/dmgs/Flow-v1.6.168.dmg",
+      "installer_url": "https://dl.wisprflow.com/wispr-flow/darwin/arm64/dmgs/Flow-v1.6.182.dmg",
       "install_script_ref": "3a49fcfd",
       "uninstall_script_ref": "e0cf2e96",
-      "sha256": "a70a7438125b9119608c4b9ee7bdb29d181a54a6ac3cb18e9a140e48d13b880a",
+      "sha256": "397e3ffcdf349fdce7fd45a321522a6a21a646aaeec55e3e734ff793bc3acc8d",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Refreshed Windows installers for Amazon Corretto, AWS CLI, Azul Zulu JDK, Claude, Devolutions Launcher, Figma, Google Chrome, Kiro, Power BI, Remote Desktop Manager, Telegram, and Typora.
  * Updated macOS releases for Claude, Draw.io, Gitify, Kiro, Microsoft Office apps, Miro, QLab, Rive, Thunderbird, and Wispr Flow.
  * Updated Firefox Nightly’s macOS download metadata.
  * Installer links, version detection, and integrity checks now reflect the latest available releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->