### PR TITLE
Fix resend button not showing on keyboard navigation in OS settings modal

### DIFF
--- a/changes/missing-keyboard-accessibility-os-settings
+++ b/changes/missing-keyboard-accessibility-os-settings
@@ -1,0 +1,1 @@
+- Fixed an accessibility issue, where the resend button would not show up when focused inside the OS settings modal

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/ConfigProfileStatusTable/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/ConfigProfileStatusTable/_styles.scss
@@ -5,7 +5,10 @@
     opacity: 0;
   }
 
-  tr:hover {
+  // Reveal on row hover or when the button receives keyboard focus, so
+  // keyboard users can see the button they've tabbed to.
+  tr:hover,
+  tr:focus-within {
     .config-profile-host-count-cell__resend-button {
       opacity: 1;
     }

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/_styles.scss
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/_styles.scss
@@ -37,7 +37,10 @@
     transition: opacity 250ms;
   }
 
-  tr:hover {
+  // Reveal on row hover or when the button receives keyboard focus, so
+  // keyboard users can see the button they've tabbed to.
+  tr:hover,
+  tr:focus-within {
     .resend-link:not(.os-settings-resend-cell__resending) {
       opacity: 1;
     }
@@ -49,7 +52,8 @@
     transition: opacity 250ms;
   }
 
-  tr:hover {
+  tr:hover,
+  tr:focus-within {
     .rotate-link:not(.os-settings-resend-cell__rotating) {
       opacity: 1;
     }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves none

After:

https://github.com/user-attachments/assets/cc9b73be-a015-49dd-adc3-5b516c02ea4c


Before:

https://github.com/user-attachments/assets/e870bc22-5984-4076-bb21-35699eda45bf

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard accessibility in OS settings tables.
  * Resend and rotate actions now appear when their table row receives keyboard focus, in addition to mouse hover.
* **Documentation**
  * Added a change note describing the accessibility improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->