### PR TITLE
Fix script/query editor selecting text when scrolling after a single click (#48490)

### DIFF
--- a/changes/48490-script-editor-scroll-selection
+++ b/changes/48490-script-editor-scroll-selection
@@ -1,0 +1,1 @@
+- Fixed the script and query editors so that scrolling after a single click no longer selects text instead of scrolling.

--- a/frontend/components/Editor/Editor.tsx
+++ b/frontend/components/Editor/Editor.tsx
@@ -10,6 +10,7 @@ import { Ace } from "ace-builds";
 
 import TooltipWrapper from "components/TooltipWrapper";
 import CopyButton from "components/buttons/CopyButton";
+import { releaseStuckSelectionOnScroll } from "utilities/ace_editor";
 
 const baseClass = "editor";
 
@@ -107,6 +108,10 @@ const Editor = ({
       },
       readOnly: true,
     });
+
+    // Prevent scrolling from selecting text after a stationary click (#48490).
+    releaseStuckSelectionOnScroll(editor);
+
     onLoadProp?.(editor);
   };
 

--- a/frontend/components/SQLEditor/SQLEditor.tsx
+++ b/frontend/components/SQLEditor/SQLEditor.tsx
@@ -17,6 +17,7 @@ import {
   sqlDataTypes,
   sqlKeyWords,
 } from "utilities/sql_tools";
+import { releaseStuckSelectionOnScroll } from "utilities/ace_editor";
 
 import CopyButton from "components/buttons/CopyButton";
 import Icon from "components/Icon";
@@ -229,6 +230,9 @@ const SQLEditor = ({
       },
       readOnly: true,
     });
+
+    // Prevent scrolling from selecting text after a stationary click (#48490).
+    releaseStuckSelectionOnScroll(editor);
 
     if (isReadonlyCopy) {
       // keep Ace read-only and remove any selection

--- a/frontend/utilities/ace_editor.tests.ts
+++ b/frontend/utilities/ace_editor.tests.ts
@@ -1,0 +1,72 @@
+import { Ace } from "ace-builds";
+
+import { releaseStuckSelectionOnScroll } from "./ace_editor";
+
+interface IMockMouseHandler {
+  isMousePressed: boolean;
+  releaseMouse?: jest.Mock;
+}
+
+const buildEditor = (mouseHandler: IMockMouseHandler | undefined) => {
+  const container = document.createElement("div");
+  return {
+    editor: ({
+      container,
+      $mouseHandler: mouseHandler,
+    } as unknown) as Ace.Editor,
+    container,
+  };
+};
+
+const scroll = (container: HTMLElement, buttons: number) => {
+  container.dispatchEvent(new WheelEvent("wheel", { buttons }));
+};
+
+describe("releaseStuckSelectionOnScroll", () => {
+  it("releases a stuck selection capture when scrolling with no button pressed", () => {
+    const releaseMouse = jest.fn();
+    const { editor, container } = buildEditor({
+      isMousePressed: true,
+      releaseMouse,
+    });
+
+    releaseStuckSelectionOnScroll(editor);
+    scroll(container, 0);
+
+    expect(releaseMouse).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not release while a mouse button is held (a real drag-select)", () => {
+    const releaseMouse = jest.fn();
+    const { editor, container } = buildEditor({
+      isMousePressed: true,
+      releaseMouse,
+    });
+
+    releaseStuckSelectionOnScroll(editor);
+    scroll(container, 1);
+
+    expect(releaseMouse).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the mouse handler is not in a pressed state", () => {
+    const releaseMouse = jest.fn();
+    const { editor, container } = buildEditor({
+      isMousePressed: false,
+      releaseMouse,
+    });
+
+    releaseStuckSelectionOnScroll(editor);
+    scroll(container, 0);
+
+    expect(releaseMouse).not.toHaveBeenCalled();
+  });
+
+  it("does not throw when the mouse handler is unavailable", () => {
+    const { editor, container } = buildEditor(undefined);
+
+    releaseStuckSelectionOnScroll(editor);
+
+    expect(() => scroll(container, 0)).not.toThrow();
+  });
+});

--- a/frontend/utilities/ace_editor.ts
+++ b/frontend/utilities/ace_editor.ts
@@ -1,0 +1,35 @@
+import { Ace } from "ace-builds";
+
+/**
+ * Works around an Ace editor bug where scrolling after a stationary single
+ * click selects text instead of scrolling (fleetdm/fleet#48490).
+ *
+ * Ace's mouse handler keeps an internal "select" capture alive after a
+ * mousedown and only tears it down on the next mousemove/mouseup. On a click
+ * with no pointer movement (common with trackpads and trackball mice), that
+ * capture can stay active. Because Ace's self-healing guard only runs on
+ * mousemove, scrolling the editor afterwards keeps re-running its selection
+ * logic against the now stationary pointer and extends the selection instead of
+ * just scrolling.
+ *
+ * This releases the stuck capture on wheel events when no mouse button is
+ * actually pressed, mirroring Ace's own mousemove guard. The listener uses the
+ * capture phase so it runs before Ace processes the scroll, and it lives on
+ * editor.container, which is removed when the editor unmounts.
+ */
+export const releaseStuckSelectionOnScroll = (editor: Ace.Editor): void => {
+  // $mouseHandler is not part of Ace's public typings.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const mouseHandler = (editor as any).$mouseHandler;
+  editor.container.addEventListener(
+    "wheel",
+    (e: WheelEvent) => {
+      if (mouseHandler?.isMousePressed && !e.buttons) {
+        mouseHandler.releaseMouse?.();
+      }
+    },
+    // Capture phase so this runs before Ace processes the scroll; passive since
+    // we never call preventDefault (avoids a non-passive wheel-listener warning).
+    { capture: true, passive: true }
+  );
+};

--- a/frontend/utilities/ace_editor.ts
+++ b/frontend/utilities/ace_editor.ts
@@ -17,6 +17,7 @@ import { Ace } from "ace-builds";
  * capture phase so it runs before Ace processes the scroll, and it lives on
  * editor.container, which is removed when the editor unmounts.
  */
+// eslint-disable-next-line import/prefer-default-export
 export const releaseStuckSelectionOnScroll = (editor: Ace.Editor): void => {
   // $mouseHandler is not part of Ace's public typings.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #48490

## Summary

When editing a script in the Fleet UI editor, a single click followed by a scroll (with a trackpad or trackball mouse, without moving the pointer in between) selected text instead of scrolling.

**Root cause:** The editors use `react-ace` / `ace-builds`. Ace's `MouseHandler` keeps an internal "select" capture alive after `mousedown` and only tears it down on the next `mousemove`/`mouseup`. On a click with no pointer movement that capture can stay active, and Ace's self-healing guard only runs on `mousemove` — which is why moving the pointer avoids the bug. Wheel/scroll events never fire `mousemove`, so each scroll tick re-runs Ace's selection logic against the now-stationary pointer and extends the selection.

**Fix:** New `releaseStuckSelectionOnScroll(editor)` utility adds a capture-phase, passive `wheel` listener that releases the stuck capture when the handler is still "pressed" but no mouse button is actually down (`e.buttons === 0`). This mirrors Ace's own `mousemove` guard on the event type it missed, and leaves genuine click-drag-select (button held) untouched. Wired into both Ace consumers: the script editor (`Editor`) and the SQL/query editor (`SQLEditor`).

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented, JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests (`frontend/utilities/ace_editor.tests.ts`)
- [ ] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed script and SQL editor behavior so a single click no longer causes scroll to select text.
  * Scrolling now properly moves the view without leaving selection “stuck,” while preserving selection during active drag interactions.

* **Tests**
  * Added Jest coverage for the scroll/selection release behavior, including wheel scrolling with no button pressed and drag/pressed-state scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->