### PR TITLE
Allow bypassing network blocking in production via config

### DIFF
--- a/changes/allow-network-blocking-bypass-in-prod
+++ b/changes/allow-network-blocking-bypass-in-prod
@@ -1,0 +1,1 @@
+* Added a `server_bypass_network_blocking` server config option to allow disabling all outbound network blocking protections for integration HTTP requests in production, for environments where egress is already constrained by external infrastructure.

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -149,6 +149,21 @@ the way that the Fleet server works.
 	return serveCmd
 }
 
+// networkBlockingModeFor decides the outbound network-blocking mode for
+// integration HTTP requests. BypassNetworkBlocking is an infra-level escape
+// hatch, only settable via server startup config, never a runtime admin
+// operation.
+func networkBlockingModeFor(devModeEnabled bool, serverConfig configpkg.ServerConfig) fleethttp.NetworkBlockingMode {
+	switch {
+	case devModeEnabled, serverConfig.BypassNetworkBlocking:
+		return fleethttp.BlockingBypassAll
+	case serverConfig.AllowPrivateNetworkIntegrations:
+		return fleethttp.BlockingPrivateAllowed
+	default:
+		return fleethttp.BlockingFull
+	}
+}
+
 // runServeCmd is a named function so that NilAway can analyze it for nil-safety.
 func runServeCmd(cmd *cobra.Command, configManager configpkg.Manager, debug, devLicense, devExpiredLicense bool) {
 	config := configManager.LoadConfig()
@@ -158,14 +173,7 @@ func runServeCmd(cmd *cobra.Command, configManager configpkg.Manager, debug, dev
 	}
 
 	// Set network blocking mode for outbound integration requests.
-	switch {
-	case dev_mode.IsEnabled:
-		fleethttp.SetNetworkBlockingMode(fleethttp.BlockingBypassAll)
-	case config.Server.AllowPrivateNetworkIntegrations:
-		fleethttp.SetNetworkBlockingMode(fleethttp.BlockingPrivateAllowed)
-	default:
-		fleethttp.SetNetworkBlockingMode(fleethttp.BlockingFull)
-	}
+	fleethttp.SetNetworkBlockingMode(networkBlockingModeFor(dev_mode.IsEnabled, config.Server))
 
 	license, err := initLicense(&config, devLicense, devExpiredLicense)
 	if err != nil {

--- a/cmd/fleet/serve_test.go
+++ b/cmd/fleet/serve_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fleetdm/fleet/v4/pkg/fleethttp"
 	"github.com/fleetdm/fleet/v4/pkg/nettest"
 	"github.com/fleetdm/fleet/v4/server/config"
 	"github.com/fleetdm/fleet/v4/server/contexts/license"
@@ -1472,6 +1473,49 @@ func TestGetTLSConfigInvalidProfile(t *testing.T) {
 	require.Contains(t, capturedErr.Error(), "not-a-real-profile")
 	require.Contains(t, capturedErr.Error(), "is invalid")
 	require.Equal(t, "set TLS profile", capturedMsg)
+}
+
+func TestNetworkBlockingModeFor(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name           string
+		devModeEnabled bool
+		serverConfig   config.ServerConfig
+		expectedMode   fleethttp.NetworkBlockingMode
+	}{
+		{
+			name:         "production default blocks everything",
+			serverConfig: config.ServerConfig{},
+			expectedMode: fleethttp.BlockingFull,
+		},
+		{
+			name:         "allow_private_network_integrations allows private networks only",
+			serverConfig: config.ServerConfig{AllowPrivateNetworkIntegrations: true},
+			expectedMode: fleethttp.BlockingPrivateAllowed,
+		},
+		{
+			name:         "bypass_network_blocking bypasses all filtering",
+			serverConfig: config.ServerConfig{BypassNetworkBlocking: true},
+			expectedMode: fleethttp.BlockingBypassAll,
+		},
+		{
+			name:         "bypass_network_blocking takes precedence over allow_private_network_integrations",
+			serverConfig: config.ServerConfig{BypassNetworkBlocking: true, AllowPrivateNetworkIntegrations: true},
+			expectedMode: fleethttp.BlockingBypassAll,
+		},
+		{
+			name:           "dev mode bypasses all filtering regardless of config",
+			devModeEnabled: true,
+			serverConfig:   config.ServerConfig{},
+			expectedMode:   fleethttp.BlockingBypassAll,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.expectedMode, networkBlockingModeFor(c.devModeEnabled, c.serverConfig))
+		})
+	}
 }
 
 func TestInitLicense(t *testing.T) {

--- a/pkg/fleethttp/fleethttp.go
+++ b/pkg/fleethttp/fleethttp.go
@@ -33,8 +33,13 @@ const (
 	// (e.g. EJBCA, Jira, SCEP servers). Set via
 	// --server_allow_private_network_integrations.
 	BlockingPrivateAllowed
-	// BlockingBypassAll performs no filtering at all. Used in dev mode
-	// where integrations are tested against localhost.
+	// BlockingBypassAll performs no filtering at all. Used in dev mode, and
+	// can also be set in production via --server_bypass_network_blocking as
+	// an infra-level escape hatch for environments where egress is already
+	// constrained by external infrastructure (e.g. a proxy or firewall) that
+	// Fleet's own checks would otherwise conflict with. Disables SSRF
+	// protection for every outbound integration request, not just the one
+	// causing the conflict.
 	BlockingBypassAll
 )
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -142,6 +142,7 @@ type ServerConfig struct {
 	GzipResponses                    bool          `yaml:"gzip_responses"`
 	DefaultMaxRequestBodySize        int64         `yaml:"default_max_request_body_size"`
 	AllowPrivateNetworkIntegrations  bool          `yaml:"allow_private_network_integrations"`
+	BypassNetworkBlocking            bool          `yaml:"bypass_network_blocking"`
 }
 
 func (s *ServerConfig) DefaultHTTPServer(ctx context.Context, handler http.Handler) *http.Server {
@@ -1411,6 +1412,7 @@ func (man Manager) addConfigs() {
 		"Trusted proxy configuration for client IP extraction: 'none' (RemoteAddr only), a header name (e.g., 'True-Client-IP'), a hop count (e.g., '2'), or comma-separated IP/CIDR ranges")
 	man.addConfigBool("server.gzip_responses", false, "Enable gzip-compressed responses for supported clients")
 	man.addConfigBool("server.allow_private_network_integrations", false, "Allow integration HTTP requests to private network addresses (RFC 1918). Loopback and cloud metadata addresses are always blocked regardless of this setting.")
+	man.addConfigBool("server.bypass_network_blocking", false, "Disable all outbound network blocking protections for integration HTTP requests (loopback, cloud metadata, and private network addresses). Only intended for environments where egress is already constrained by external infrastructure (e.g. an egress proxy or firewall) that Fleet's own checks would otherwise conflict with. This is an infrastructure-level setting and cannot be changed at runtime.")
 	man.addConfigByteSize("server.default_max_request_body_size", installersize.Human(platform_http.MaxRequestBodySize), "Default maximum size in bytes for request bodies, certain endpoints will have higher limits (e.g. 10MiB, 500KB, 1G)")
 
 	// Hide the sandbox flag as we don't want it to be discoverable for users for now
@@ -1925,6 +1927,7 @@ func (man Manager) LoadConfig() FleetConfig {
 			GzipResponses:                    man.getConfigBool("server.gzip_responses"),
 			DefaultMaxRequestBodySize:        man.getConfigByteSize("server.default_max_request_body_size"),
 			AllowPrivateNetworkIntegrations:  man.getConfigBool("server.allow_private_network_integrations"),
+			BypassNetworkBlocking:            man.getConfigBool("server.bypass_network_blocking"),
 		},
 		Auth: AuthConfig{
 			BcryptCost:                  man.getConfigInt("auth.bcrypt_cost"),


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #49751

A customer's egress proxy (an Envoy sidecar bound to loopback) was getting blocked by Fleet's SSRF network-blocking check, since the check applies to whatever address the HTTP transport dials, including the proxy hop itself, not just the ultimate destination. There was no supported way to disable this in production (the existing full-bypass mode was dev-only), leaving no path forward for environments where egress is already constrained by external infrastructure.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.


## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a production server setting to bypass outbound network blocking for integration requests when external egress controls are already in place.
  * The setting is disabled by default and can be configured through the server configuration.

* **Documentation**
  * Clarified that bypassing network blocking disables SSRF protections for all outbound integration requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->