### PR TITLE
Update FleetDM manifest and MSI URLs to stable version

### DIFF
--- a/articles/sysadmin-diaries-restoring-fleetd.md
+++ b/articles/sysadmin-diaries-restoring-fleetd.md
@@ -46,7 +46,7 @@ Here is the XML command for macOS:
     <key>Command</key>
     <dict>
       <key>ManifestURL</key>
-      <string>https://download.fleetdm.com/fleetd-base-manifest.plist</string>
+      <string>https://download.fleetdm.com/stable/fleetd-base-manifest.plist</string>
       <key>RequestType</key>
       <string>InstallEnterpriseApplication</string>
     </dict>
@@ -89,7 +89,7 @@ Then, execute the command using `fleetctl`:
 			<Product Version="1.0.0.0">
 				<Download>
 					<ContentURLList>
-						<ContentURL>https://download.fleetdm.com/fleetd-base.msi</ContentURL>
+						<ContentURL>https://download.fleetdm.com/stable/fleetd-base.msi</ContentURL>
 					</ContentURLList>
 				</Download>
 				<Validation>


### PR DESCRIPTION
Updated guide to reference proper URL. 

re: https://fleetdm.slack.com/archives/C062D0THVV1/p1784730512266759
