### PR TITLE
log command UUIDs for fleetd and bootstrap in DEP release flow

### DIFF
--- a/server/worker/apple_mdm.go
+++ b/server/worker/apple_mdm.go
@@ -568,7 +568,7 @@ func (a *AppleMDM) installFleetd(ctx context.Context, hostUUID string) (string, 
 	if err := a.Commander.InstallEnterpriseApplication(ctx, []string{hostUUID}, cmdUUID, manifestURL); err != nil {
 		return "", err
 	}
-	a.Log.InfoContext(ctx, "sent command to install fleetd", "host_uuid", hostUUID)
+	a.Log.InfoContext(ctx, "sent command to install fleetd", "host_uuid", hostUUID, "command_uuid", cmdUUID)
 	return cmdUUID, nil
 }
 
@@ -725,7 +725,7 @@ func (a *AppleMDM) installBootstrapPackage(ctx context.Context, hostUUID string,
 	if err != nil {
 		return "", err
 	}
-	a.Log.InfoContext(ctx, "sent command to install bootstrap package", "host_uuid", hostUUID)
+	a.Log.InfoContext(ctx, "sent command to install bootstrap package", "host_uuid", hostUUID, "command_uuid", cmdUUID)
 	return cmdUUID, nil
 }
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

Super small change to make it easier to correlate bootstrap and fleetd `InstallEnterpriseApplication` command UUID with log statements

# Checklist for submitter

If some of the following don't apply, delete the relevant line.



## Testing


- [ ] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging for Apple MDM command delivery by including the associated command identifier when application and bootstrap package installation commands are sent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->