### PR TITLE
Website: Update logging in register-one-fleet-instance-using-vpp action

### DIFF
--- a/website/api/controllers/vpp-proxy/register-one-fleet-instance-using-vpp.js
+++ b/website/api/controllers/vpp-proxy/register-one-fleet-instance-using-vpp.js
@@ -48,6 +48,9 @@ module.exports = {
         { algorithm: 'ES256' }
       );
     } catch(unusedErr) {
+      // If a license could not be verified, log the error name
+      sails.log.info('VPP auth rejected:', unusedErr.name);
+
       // If there is an error parsing the provided fleetLicenseKey, return a couldNotVerifyLicense response.
       throw 'couldNotVerifyLicense';
     }


### PR DESCRIPTION
Changes:
- Updated register-one-fleet-instance-using-vpp action to log the name of the error when a Fleet license key cannot be verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic logging when VPP license verification fails, including the verification error type.
  * License validation behavior remains unchanged for invalid or unverifiable licenses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->