### PR TITLE
Website: Update license verification logging in register-one-fleet-instance-using-vpp action

### DIFF
--- a/website/api/controllers/vpp-proxy/register-one-fleet-instance-using-vpp.js
+++ b/website/api/controllers/vpp-proxy/register-one-fleet-instance-using-vpp.js
@@ -47,9 +47,9 @@ module.exports = {
         sails.config.custom.licenseKeyGeneratorPublicKey,
         { algorithm: 'ES256' }
       );
-    } catch(unusedErr) {
-      // If a license could not be verified, log the error name
-      sails.log.info('VPP auth rejected:', unusedErr.name);
+    } catch(err) {
+      // If a license could not be verified, log the error name and message
+      sails.log.info('VPP proxy could not verify Fleet license:', err.name, err.message);
 
       // If there is an error parsing the provided fleetLicenseKey, return a couldNotVerifyLicense response.
       throw 'couldNotVerifyLicense';


### PR DESCRIPTION
Changes:
- Updated the error logged in `register-one-fleet-instance-using-vpp` action when a Fleet license key cannot be verified to include the error's message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting when Fleet license verification fails, providing more specific details to support troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->