### PR TITLE
Add Podman Desktop Fleet-maintained app for Windows

### DIFF
--- a/ee/maintained-apps/inputs/winget/podman-desktop.json
+++ b/ee/maintained-apps/inputs/winget/podman-desktop.json
@@ -1,0 +1,14 @@
+{
+  "name": "Podman Desktop",
+  "slug": "podman-desktop/windows",
+  "package_identifier": "RedHat.Podman-Desktop",
+  "unique_identifier": "Podman Desktop",
+  "fuzzy_match_name": true,
+  "program_publisher": "Podman Desktop",
+  "installer_arch": "x64",
+  "installer_type": "exe",
+  "installer_scope": "machine",
+  "default_categories": ["Developer tools"],
+  "install_script_path": "ee/maintained-apps/inputs/winget/scripts/podman-desktop_install.ps1",
+  "uninstall_script_path": "ee/maintained-apps/inputs/winget/scripts/podman-desktop_uninstall.ps1"
+}

--- a/ee/maintained-apps/inputs/winget/scripts/podman-desktop_install.ps1
+++ b/ee/maintained-apps/inputs/winget/scripts/podman-desktop_install.ps1
@@ -1,0 +1,28 @@
+# Learn more about .exe install scripts:
+# http://fleetdm.com/learn-more-about/exe-install-scripts
+#
+# Podman Desktop ships as an electron-builder NSIS ("nullsoft") installer.
+# "/S" runs it silently; "/ALLUSERS" forces the per-machine install so the ARP
+# entry lands under HKLM (Fleet installs run as SYSTEM).
+
+$exeFilePath = "${env:INSTALLER_PATH}"
+
+try {
+
+$processOptions = @{
+  FilePath = "$exeFilePath"
+  ArgumentList = "/S", "/ALLUSERS"
+  PassThru = $true
+  Wait = $true
+}
+
+$process = Start-Process @processOptions
+$exitCode = $process.ExitCode
+
+Write-Host "Install exit code: $exitCode"
+Exit $exitCode
+
+} catch {
+  Write-Host "Error: $_"
+  Exit 1
+}

--- a/ee/maintained-apps/inputs/winget/scripts/podman-desktop_uninstall.ps1
+++ b/ee/maintained-apps/inputs/winget/scripts/podman-desktop_uninstall.ps1
@@ -1,0 +1,82 @@
+# Uninstalls Podman Desktop.
+#
+# Podman Desktop is an electron-builder NSIS app. Its ARP DisplayName carries
+# the version ("Podman Desktop 1.28.3"), so match on the "Podman Desktop *"
+# prefix. Run the uninstaller with "/S /ALLUSERS" to mirror the machine-scope
+# install and remove the HKLM entry (Fleet runs uninstalls as SYSTEM).
+
+$displayNameLike = "Podman Desktop*"
+$publisher = "Podman Desktop"
+
+$paths = @(
+  'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall',
+  'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall',
+  'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall',
+  'HKCU:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall'
+)
+
+$uninstall = $null
+foreach ($p in $paths) {
+  $items = Get-ItemProperty "$p\*" -ErrorAction SilentlyContinue | Where-Object {
+    $_.DisplayName -like $displayNameLike -and $_.Publisher -like "$publisher*"
+  }
+  if ($items) { $uninstall = $items | Select-Object -First 1; break }
+}
+
+if (-not $uninstall -or (-not $uninstall.UninstallString -and -not $uninstall.QuietUninstallString)) {
+  Write-Host "Uninstall entry not found"
+  Exit 0
+}
+
+Stop-Process -Name "Podman Desktop" -Force -ErrorAction SilentlyContinue
+
+$uninstallCommand = if ($uninstall.QuietUninstallString) {
+    $uninstall.QuietUninstallString
+} else {
+    $uninstall.UninstallString
+}
+
+$exePath = ""
+$existingArgs = ""
+if ($uninstallCommand -match '^\s*"([^"]+)"\s*(.*)$') {
+    $exePath = $matches[1]
+    $existingArgs = $matches[2].Trim()
+} elseif ($uninstallCommand -match '(?i)^\s*(.+?\.exe)\s*(.*)$') {
+    $exePath = $matches[1]
+    $existingArgs = $matches[2].Trim()
+} elseif ($uninstallCommand -match '^\s*(\S+)\s*(.*)$') {
+    $exePath = $matches[1]
+    $existingArgs = $matches[2].Trim()
+} else {
+    Throw "Could not parse uninstall string: $uninstallCommand"
+}
+
+if ($existingArgs -notmatch '\b/S\b') {
+    $existingArgs = ("$existingArgs /S").Trim()
+}
+# Mirror the install: ensure all-users uninstall so the machine-scope ARP
+# entry under HKLM is removed (not just the calling user's HKCU view).
+if ($existingArgs -notmatch '(?i)/ALLUSERS') {
+    $existingArgs = ("$existingArgs /ALLUSERS").Trim()
+}
+
+Write-Host "Uninstall command: $exePath"
+Write-Host "Uninstall args: $existingArgs"
+
+try {
+    $processOptions = @{
+        FilePath = $exePath
+        ArgumentList = $existingArgs
+        NoNewWindow = $true
+        PassThru = $true
+        Wait = $true
+    }
+
+    $process = Start-Process @processOptions
+    $exitCode = $process.ExitCode
+    Write-Host "Uninstall exit code: $exitCode"
+    Exit $exitCode
+} catch {
+    Write-Host "Error running uninstaller: $_"
+    Exit 1
+}

--- a/ee/maintained-apps/outputs/apps.json
+++ b/ee/maintained-apps/outputs/apps.json
@@ -6467,7 +6467,14 @@
       "slug": "podman-desktop/darwin",
       "platform": "darwin",
       "unique_identifier": "io.podmandesktop.PodmanDesktop",
-      "description": "Open source tool for developers to work with containers and Kubernetes."
+      "description": "Podman Desktop is an open source tool for developers to work with containers and Kubernetes."
+    },
+    {
+      "name": "Podman Desktop",
+      "slug": "podman-desktop/windows",
+      "platform": "windows",
+      "unique_identifier": "Podman Desktop",
+      "description": "Podman Desktop is an open source tool for developers to work with containers and Kubernetes."
     },
     {
       "name": "PopChar X",

--- a/ee/maintained-apps/outputs/podman-desktop/windows.json
+++ b/ee/maintained-apps/outputs/podman-desktop/windows.json
@@ -1,0 +1,22 @@
+{
+  "versions": [
+    {
+      "version": "1.28.3",
+      "queries": {
+        "exists": "SELECT 1 FROM programs WHERE name LIKE 'Podman Desktop %' AND publisher = 'Podman Desktop';",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Podman Desktop %' AND publisher = 'Podman Desktop' AND version_compare(version, '1.28.3') < 0);"
+      },
+      "installer_url": "https://github.com/containers/podman-desktop/releases/download/v1.28.3/podman-desktop-1.28.3-setup-x64.exe",
+      "install_script_ref": "a1a2e133",
+      "uninstall_script_ref": "934e0da5",
+      "sha256": "1b405749ae21b3c84d639fd01d6f667076d439a13e5498d2c084cb158bb6bb05",
+      "default_categories": [
+        "Developer tools"
+      ]
+    }
+  ],
+  "refs": {
+    "934e0da5": "# Uninstalls Podman Desktop.\n#\n# Podman Desktop is an electron-builder NSIS app. Its ARP DisplayName carries\n# the version (\"Podman Desktop 1.28.3\"), so match on the \"Podman Desktop *\"\n# prefix. Run the uninstaller with \"/S /ALLUSERS\" to mirror the machine-scope\n# install and remove the HKLM entry (Fleet runs uninstalls as SYSTEM).\n\n$displayNameLike = \"Podman Desktop*\"\n$publisher = \"Podman Desktop\"\n\n$paths = @(\n  'HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall',\n  'HKLM:\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall',\n  'HKCU:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall',\n  'HKCU:\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall'\n)\n\n$uninstall = $null\nforeach ($p in $paths) {\n  $items = Get-ItemProperty \"$p\\*\" -ErrorAction SilentlyContinue | Where-Object {\n    $_.DisplayName -like $displayNameLike -and $_.Publisher -like \"$publisher*\"\n  }\n  if ($items) { $uninstall = $items | Select-Object -First 1; break }\n}\n\nif (-not $uninstall -or (-not $uninstall.UninstallString -and -not $uninstall.QuietUninstallString)) {\n  Write-Host \"Uninstall entry not found\"\n  Exit 0\n}\n\nStop-Process -Name \"Podman Desktop\" -Force -ErrorAction SilentlyContinue\n\n$uninstallCommand = if ($uninstall.QuietUninstallString) {\n    $uninstall.QuietUninstallString\n} else {\n    $uninstall.UninstallString\n}\n\n$exePath = \"\"\n$existingArgs = \"\"\nif ($uninstallCommand -match '^\\s*\"([^\"]+)\"\\s*(.*)$') {\n    $exePath = $matches[1]\n    $existingArgs = $matches[2].Trim()\n} elseif ($uninstallCommand -match '(?i)^\\s*(.+?\\.exe)\\s*(.*)$') {\n    $exePath = $matches[1]\n    $existingArgs = $matches[2].Trim()\n} elseif ($uninstallCommand -match '^\\s*(\\S+)\\s*(.*)$') {\n    $exePath = $matches[1]\n    $existingArgs = $matches[2].Trim()\n} else {\n    Throw \"Could not parse uninstall string: $uninstallCommand\"\n}\n\nif ($existingArgs -notmatch '\\b/S\\b') {\n    $existingArgs = (\"$existingArgs /S\").Trim()\n}\n# Mirror the install: ensure all-users uninstall so the machine-scope ARP\n# entry under HKLM is removed (not just the calling user's HKCU view).\nif ($existingArgs -notmatch '(?i)/ALLUSERS') {\n    $existingArgs = (\"$existingArgs /ALLUSERS\").Trim()\n}\n\nWrite-Host \"Uninstall command: $exePath\"\nWrite-Host \"Uninstall args: $existingArgs\"\n\ntry {\n    $processOptions = @{\n        FilePath = $exePath\n        ArgumentList = $existingArgs\n        NoNewWindow = $true\n        PassThru = $true\n        Wait = $true\n    }\n\n    $process = Start-Process @processOptions\n    $exitCode = $process.ExitCode\n    Write-Host \"Uninstall exit code: $exitCode\"\n    Exit $exitCode\n} catch {\n    Write-Host \"Error running uninstaller: $_\"\n    Exit 1\n}\n",
+    "a1a2e133": "# Learn more about .exe install scripts:\n# http://fleetdm.com/learn-more-about/exe-install-scripts\n#\n# Podman Desktop ships as an electron-builder NSIS (\"nullsoft\") installer.\n# \"/S\" runs it silently; \"/ALLUSERS\" forces the per-machine install so the ARP\n# entry lands under HKLM (Fleet installs run as SYSTEM).\n\n$exeFilePath = \"${env:INSTALLER_PATH}\"\n\ntry {\n\n$processOptions = @{\n  FilePath = \"$exeFilePath\"\n  ArgumentList = \"/S\", \"/ALLUSERS\"\n  PassThru = $true\n  Wait = $true\n}\n\n$process = Start-Process @processOptions\n$exitCode = $process.ExitCode\n\nWrite-Host \"Install exit code: $exitCode\"\nExit $exitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n"
+  }
+}


### PR DESCRIPTION
**Related issue:** Resolves #49737

Adds **Podman Desktop** (`RedHat.Podman-Desktop`, v1.28.3) as a Windows Fleet-maintained app. It pairs with the existing `podman-desktop/darwin` FMA under the same catalog name, so the two group together in the FMA library and share the existing icon.

## What changed

- `ee/maintained-apps/inputs/winget/podman-desktop.json` — input manifest (x64, machine scope, `exe`/NSIS)
- `ee/maintained-apps/inputs/winget/scripts/podman-desktop_install.ps1` / `_uninstall.ps1` — custom install/uninstall scripts
- `ee/maintained-apps/outputs/podman-desktop/windows.json` — generated output
- `ee/maintained-apps/outputs/apps.json` — new Windows catalog entry; also reworded the existing macOS description to the standard "`<App>` is a(n)…" format for consistency

## Identity verification (verified, not guessed)

Podman Desktop ships as an **electron-builder NSIS** installer, and the winget metadata does **not** match what osquery sees on a host. I decompressed the NSIS header and traced electron-builder's source to confirm the registry identity:

- **DisplayName** = `Podman Desktop 1.28.3` → `unique_identifier: "Podman Desktop"` with `fuzzy_match_name` (matches the version-suffixed name).
- **Publisher** = `Podman Desktop` — derived from the package's `author.name` (`COMPANY_NAME` → registry `Publisher`), **not** the winget locale's `RedHat`. Using "RedHat" would have made the exists query silently never match on real hosts.
- **SHA256** matches the winget manifest exactly; version `1.28.3` equals the registry `DisplayVersion`, so the patch policy reconciles cleanly.

Silent install uses `/S /ALLUSERS`; uninstall does a registry lookup with the defensive three-shape UninstallString parser and mirrors `/S /ALLUSERS`, following the proven `another-redis-desktop-manager` electron-builder machine-scope pattern.

## Reviewer notes

- **x64 only.** The winget manifest also has an arm64 installer, but the repo has no arm64 FMA inputs yet (x64 is the established convention). A separate arm64 slug can be added later.
- Installer URL is a **pinned GitHub release** asset (not a "latest" redirect), so the SHA is stable until the FMA auto-updater bumps the version.
- No shared Go code changed — only FMA input/output data.

## Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Generated the output via `go run cmd/maintained-apps/main.go --slug="podman-desktop/windows" --debug`; verified exists/patched queries, pinned SHA matches the winget manifest, and `apps.json` is valid JSON.
- [ ] QA'd install/uninstall on a Windows host (will be exercised by the FMA validator).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Podman Desktop to the maintained app catalog for Windows and macOS.
  * Added support for downloading and silently installing Podman Desktop on Windows.
  * Added reliable silent uninstallation, including stopping running app processes.
  * Added version metadata, categories, integrity verification, and app descriptions for Podman Desktop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->