### PR TITLE
test case and doc to ensure bootstrap package comes before profiles

### DIFF
--- a/articles/setup-experience.md
+++ b/articles/setup-experience.md
@@ -133,7 +133,9 @@ A manual rotation cancels any active auto-rotation timer for that host.
 
 ## Bootstrap package
 
-Fleet supports installing a bootstrap package on macOS hosts that automatically enroll to Fleet. Apple requires that your package is a [distribution package](https://fleetdm.com/learn-more-about/macos-distribution-packages). You can install software during out-of-the-box Windows and Linux setup. Learn more in [this separate guide](https://fleetdm.com/guides/windows-linux-setup-experience). 
+Fleet supports installing a bootstrap package on macOS hosts that automatically enroll to Fleet. Apple requires that your package is a [distribution package](https://fleetdm.com/learn-more-about/macos-distribution-packages). You can install software during out-of-the-box Windows and Linux setup. Learn more in [this separate guide](https://fleetdm.com/guides/windows-linux-setup-experience).
+
+> Fleet will always deliver the command to install a bootstrap package before delivering commands for installing profiles. 
 
 This enables installing tools like [Puppet](https://www.puppet.com/), [Munki](https://www.munki.org/munki/), or [Chef](https://www.chef.io/products/chef-infra) for configuration management and/or running custom scripts and installing tools like [DEP notify](https://gitlab.com/Mactroll/DEPNotify) to customize the setup experience for your end users.
 

--- a/server/worker/apple_mdm_test.go
+++ b/server/worker/apple_mdm_test.go
@@ -413,7 +413,7 @@ func TestAppleMDM(t *testing.T) {
 		}
 		var commands []enqueuedCommand
 		mysqltest.ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
-			return sqlx.SelectContext(ctx, q, &commands, "SELECT request_type, command FROM nano_commands ORDER BY created_at")
+			return sqlx.SelectContext(ctx, q, &commands, "SELECT request_type, command FROM nano_enrollment_queue neq INNER JOIN nano_commands nc ON neq.command_uuid = nc.command_uuid WHERE neq.id = ? ORDER BY neq.created_at", h.UUID)
 		})
 
 		fleetdIdx, bootstrapIdx := -1, -1

--- a/server/worker/apple_mdm_test.go
+++ b/server/worker/apple_mdm_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -360,6 +361,86 @@ func TestAppleMDM(t *testing.T) {
 		ms, err := ds.GetHostMDMMacOSSetup(ctx, h.ID)
 		require.NoError(t, err)
 		require.Equal(t, "custom-bootstrap", ms.BootstrapPackageName)
+	})
+
+	t.Run("bootstrap package comes before profiles", func(t *testing.T) {
+		mysqltest.SetTestABMAssets(t, ds, testOrgName)
+		defer mysqltest.TruncateTables(t, ds)
+
+		// create some config profiles that should be installed during enrollment
+		for i := 1; i <= 3; i++ {
+			_, err := ds.NewMDMAppleConfigProfile(ctx, fleet.MDMAppleConfigProfile{
+				Mobileconfig: fmt.Appendf(nil, "profile%d", i),
+				Identifier:   fmt.Sprintf("profile%d", i),
+				Name:         fmt.Sprintf("Profile %d", i),
+			}, nil)
+			require.NoError(t, err)
+		}
+
+		h := createEnrolledHost(t, 1, nil, true, "darwin")
+		err := ds.InsertMDMAppleBootstrapPackage(ctx, &fleet.MDMAppleBootstrapPackage{
+			Name:   "custom-bootstrap",
+			TeamID: 0, // no-team
+			Bytes:  []byte("test"),
+			Sha256: []byte("test"),
+			Token:  "token",
+		}, nil)
+		require.NoError(t, err)
+
+		mdmWorker := &AppleMDM{
+			Datastore: ds,
+			Log:       slogLog,
+			Commander: apple_mdm.NewMDMAppleCommander(mdmStorage, mockPusher{}),
+		}
+		w := NewWorker(ds, slogLog)
+		w.Register(mdmWorker)
+
+		err = QueueAppleMDMJob(ctx, ds, slogLog, AppleMDMPostDEPEnrollmentTask, h.UUID, "darwin", nil, "", false, false)
+		require.NoError(t, err)
+
+		// run the worker, should succeed
+		err = w.ProcessJobs(ctx)
+		require.NoError(t, err)
+
+		// fetch the enqueued commands in the order they were created. Both the
+		// fleetd install and the bootstrap package install use the
+		// "InstallEnterpriseApplication" request type, so we disambiguate them by
+		// their command body: fleetd is sent with a ManifestURL, while the
+		// bootstrap package embeds the manifest inline (Manifest key).
+		type enqueuedCommand struct {
+			RequestType string `db:"request_type"`
+			Command     string `db:"command"`
+		}
+		var commands []enqueuedCommand
+		mysqltest.ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			return sqlx.SelectContext(ctx, q, &commands, "SELECT request_type, command FROM nano_commands ORDER BY created_at")
+		})
+
+		fleetdIdx, bootstrapIdx := -1, -1
+		var profileIdxs []int
+		for i, c := range commands {
+			switch {
+			case c.RequestType == "InstallEnterpriseApplication" && strings.Contains(c.Command, "ManifestURL"):
+				fleetdIdx = i
+			case c.RequestType == "InstallEnterpriseApplication":
+				bootstrapIdx = i
+			case c.RequestType == "InstallProfile" || c.RequestType == "DeclarativeManagement":
+				profileIdxs = append(profileIdxs, i)
+			}
+		}
+
+		// all three kinds of commands should have been enqueued
+		require.NotEqual(t, -1, fleetdIdx, "fleetd install command not found")
+		require.NotEqual(t, -1, bootstrapIdx, "bootstrap package install command not found")
+		require.NotEmpty(t, profileIdxs, "no profile commands found")
+
+		// fleetd install always comes before the bootstrap package
+		require.Less(t, fleetdIdx, bootstrapIdx, "fleetd install must come before the bootstrap package")
+
+		// the bootstrap package always comes before any profile command
+		for _, idx := range profileIdxs {
+			require.Less(t, bootstrapIdx, idx, "bootstrap package must come before all profile commands")
+		}
 	})
 
 	t.Run("installs custom bootstrap manifest of a team", func(t *testing.T) {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #49750 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information. (Already a part of something else, this is just further solidifying the current behaviour)

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify the command sequence during Apple device enrollment.
  * Ensures the fleet management agent installation happens first, followed by the bootstrap package, and then configuration profile and management commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->