### PR TITLE
Fix test failures by avoiding mutating shared state

### DIFF
--- a/ee/server/service/setup_experience_test.go
+++ b/ee/server/service/setup_experience_test.go
@@ -347,7 +347,7 @@ func TestSetupExperienceScriptCustomHostVitalInfraErrorPropagates(t *testing.T) 
 	ds.ValidateReferencedCustomHostVitalsFunc = func(ctx context.Context, documents []string) error {
 		return ctxerr.Wrap(ctx, errors.New("connection refused"), "validating custom host vitals")
 	}
-	ds.SetSetupExperienceScriptFunc = func(ctx context.Context, script *fleet.Script) error { return nil }
+	ds.SetSetupExperienceScriptFunc = func(ctx context.Context, script *fleet.Script) (bool, error) { return false, nil }
 
 	err := svc.SetSetupExperienceScript(ctx, nil, "potato.sh", bytes.NewReader([]byte("echo $FLEET_HOST_VITAL_99")))
 	require.Error(t, err)

--- a/server/service/secret_variables_test.go
+++ b/server/service/secret_variables_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	activity_api "github.com/fleetdm/fleet/v4/server/activity/api"
+	"github.com/fleetdm/fleet/v4/server/config"
 	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mock"
@@ -90,15 +91,14 @@ func TestCreateSecretVariables(t *testing.T) {
 	})
 
 	t.Run("failure test", func(t *testing.T) {
-		ctx = viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{GlobalRole: ptr.String(fleet.RoleGitOps)}})
-		testSetEmptyPrivateKey = true
-		t.Cleanup(func() {
-			testSetEmptyPrivateKey = false
-		})
-		err := svc.CreateSecretVariables(ctx, []fleet.SecretVariable{{Name: "foo", Value: "bar"}}, true)
+		cfg := config.TestConfig()
+		cfg.Server.PrivateKey = ""
+		svcNoKey, ctxNoKey := newTestServiceWithConfig(t, ds, cfg, nil, nil)
+		ctxNoKey = viewer.NewContext(ctxNoKey, viewer.Viewer{User: &fleet.User{GlobalRole: ptr.String(fleet.RoleGitOps)}})
+		err := svcNoKey.CreateSecretVariables(ctxNoKey, []fleet.SecretVariable{{Name: "foo", Value: "bar"}}, true)
 		require.ErrorContains(t, err, "Couldn't save secret variables. Missing required private key")
-		testSetEmptyPrivateKey = false
 
+		ctx = viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{GlobalRole: ptr.String(fleet.RoleGitOps)}})
 		ds.UpsertSecretVariablesFunc = func(ctx context.Context, secrets []fleet.SecretVariable) (created []string, updated []string, err error) {
 			return nil, nil, errors.New("test error")
 		}

--- a/server/service/secret_variables_test.go
+++ b/server/service/secret_variables_test.go
@@ -94,11 +94,11 @@ func TestCreateSecretVariables(t *testing.T) {
 		cfg := config.TestConfig()
 		cfg.Server.PrivateKey = ""
 		svcNoKey, ctxNoKey := newTestServiceWithConfig(t, ds, cfg, nil, nil)
-		ctxNoKey = viewer.NewContext(ctxNoKey, viewer.Viewer{User: &fleet.User{GlobalRole: ptr.String(fleet.RoleGitOps)}})
+		ctxNoKey = viewer.NewContext(ctxNoKey, viewer.Viewer{User: &fleet.User{GlobalRole: new(fleet.RoleGitOps)}})
 		err := svcNoKey.CreateSecretVariables(ctxNoKey, []fleet.SecretVariable{{Name: "foo", Value: "bar"}}, true)
 		require.ErrorContains(t, err, "Couldn't save secret variables. Missing required private key")
 
-		ctx = viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{GlobalRole: ptr.String(fleet.RoleGitOps)}})
+		ctx = viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{GlobalRole: new(fleet.RoleGitOps)}})
 		ds.UpsertSecretVariablesFunc = func(ctx context.Context, secrets []fleet.SecretVariable) (created []string, updated []string, err error) {
 			return nil, nil, errors.New("test error")
 		}


### PR DESCRIPTION
Fix test failures by avoiding mutating shared state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated coverage for secret variable creation when the server’s private key is missing.
  * Improved test isolation by using a dedicated configuration for the failure scenario.
  * Adjusted setup-experience failure test to reflect an updated store interface return value, while preserving existing error-behavior assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->