### PR TITLE
Fix compile error in setup experience script test

### DIFF
--- a/ee/server/service/setup_experience_test.go
+++ b/ee/server/service/setup_experience_test.go
@@ -347,7 +347,7 @@ func TestSetupExperienceScriptCustomHostVitalInfraErrorPropagates(t *testing.T) 
 	ds.ValidateReferencedCustomHostVitalsFunc = func(ctx context.Context, documents []string) error {
 		return ctxerr.Wrap(ctx, errors.New("connection refused"), "validating custom host vitals")
 	}
-	ds.SetSetupExperienceScriptFunc = func(ctx context.Context, script *fleet.Script) error { return nil }
+	ds.SetSetupExperienceScriptFunc = func(ctx context.Context, script *fleet.Script) (bool, error) { return false, nil }
 
 	err := svc.SetSetupExperienceScript(ctx, nil, "potato.sh", bytes.NewReader([]byte("echo $FLEET_HOST_VITAL_99")))
 	require.Error(t, err)


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** N/A — fixes a compile break on `main`.

## Description

`main` currently fails to compile the `ee/server/service` test package, which turns the `lint`, `lint-incremental`, and `test-go (main)` jobs red on all open PRs.

The `SetSetupExperienceScript` datastore method was changed to return `(changed bool, err error)` (commit fbccb8cc59). The interface, the generated mock, and two of the three mock assignments in `setup_experience_test.go` were updated, but the assignment on line 350 was missed:

```
ee/server/service/setup_experience_test.go:350:36: cannot use func(ctx context.Context, script *fleet.Script) error {…}
as mock.SetSetupExperienceScriptFunc value in assignment (typecheck)
```

This updates that remaining assignment to the new signature, matching lines 252 and 329.

## Testing

- `go vet ./ee/server/service/` passes.
- Confirmed no other `SetSetupExperienceScriptFunc` assignments use the old signature.

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated setup experience error-handling coverage to reflect the latest validation behavior.
  * Confirmed infrastructure connection errors continue to propagate correctly instead of being classified as invalid-argument errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->