### PR TITLE
Add apps installed through Windows app store to software inventory

### DIFF
--- a/changes/14717-windows-app-store-software-inventory
+++ b/changes/14717-windows-app-store-software-inventory
@@ -1,0 +1,1 @@
+- Renamed the "Program (Windows)" software type to "Application (Windows)", which includes apps installed through the Windows app store.

--- a/frontend/interfaces/software.tests.ts
+++ b/frontend/interfaces/software.tests.ts
@@ -20,7 +20,7 @@ describe("formatSoftwareType", () => {
       },
       {
         source: "programs" as const,
-        expected: "Program (Windows)",
+        expected: "Application (Windows)",
         description: "Windows programs",
       },
       {

--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -306,7 +306,7 @@ export const SOURCE_TYPE_CONVERSION = {
   firefox_addons: "Browser plugin", // we rely on `extension_for` when computing which browser to show in firefox_addons display names.
   safari_extensions: "Browser plugin (Safari)",
   homebrew_packages: "Package (Homebrew)",
-  programs: "Program (Windows)",
+  programs: "Application (Windows)",
   ie_extensions: "Browser plugin (IE)",
   chocolatey_packages: "Package (Chocolatey)",
   pkg_packages: "Package (pkg)",


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #14717 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Renamed the Windows software inventory label from **“Program (Windows)”** to **“Application (Windows)”**.
  * The updated label includes applications installed through the Windows App Store.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->