### PR TITLE
Fleet UI: Fix TS errors from removed button variants

### DIFF
--- a/frontend/components/FleetsDropdown/FleetsDropdown.tsx
+++ b/frontend/components/FleetsDropdown/FleetsDropdown.tsx
@@ -212,7 +212,6 @@ const CustomMenu = (props: MenuProps<INumberDropdownOption, false>) => {
           <Button
             variant="subdued"
             onClick={onClickAddFleet}
-            iconStroke
             size="small"
           >
             <>

--- a/frontend/components/FleetsDropdown/FleetsDropdown.tsx
+++ b/frontend/components/FleetsDropdown/FleetsDropdown.tsx
@@ -216,7 +216,7 @@ const CustomMenu = (props: MenuProps<INumberDropdownOption, false>) => {
           >
             <>
               Add fleet
-              <Icon name="plus" color="ui-fleet-black-75" />
+              <Icon name="plus" />
             </>
           </Button>
         </div>

--- a/frontend/components/FleetsDropdown/FleetsDropdown.tsx
+++ b/frontend/components/FleetsDropdown/FleetsDropdown.tsx
@@ -209,11 +209,7 @@ const CustomMenu = (props: MenuProps<INumberDropdownOption, false>) => {
           onMouseDown={addFleetMouseDown}
           onKeyDown={addFleetKeyDown}
         >
-          <Button
-            variant="subdued"
-            onClick={onClickAddFleet}
-            size="small"
-          >
+          <Button variant="subdued" onClick={onClickAddFleet} size="small">
             <>
               Add fleet
               <Icon name="plus" />

--- a/frontend/components/FleetsDropdown/FleetsDropdown.tsx
+++ b/frontend/components/FleetsDropdown/FleetsDropdown.tsx
@@ -216,7 +216,7 @@ const CustomMenu = (props: MenuProps<INumberDropdownOption, false>) => {
           >
             <>
               Add fleet
-              <Icon name="plus" color="core-fleet-green" />
+              <Icon name="plus" color="ui-fleet-black-75" />
             </>
           </Button>
         </div>

--- a/frontend/components/FleetsDropdown/FleetsDropdown.tsx
+++ b/frontend/components/FleetsDropdown/FleetsDropdown.tsx
@@ -210,7 +210,7 @@ const CustomMenu = (props: MenuProps<INumberDropdownOption, false>) => {
           onKeyDown={addFleetKeyDown}
         >
           <Button
-            variant="brand-inverse-icon"
+            variant="subdued"
             onClick={onClickAddFleet}
             iconStroke
             size="small"

--- a/frontend/pages/hosts/details/HostDetailsPage/components/ReleaseFromABModal/ReleaseFromABModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/components/ReleaseFromABModal/ReleaseFromABModal.tsx
@@ -113,7 +113,7 @@ const ReleaseFromABModal = ({
       <ModalFooter
         primaryButtons={
           <>
-            <Button variant="inverse-alert" onClick={onModalExit}>
+            <Button variant="secondary" onClick={onModalExit}>
               Cancel
             </Button>
             <Button


### PR DESCRIPTION
## Issue
Post-merge cleanup — no linked issue. #49292 removed the `brand-inverse-icon` and `inverse-alert` `ButtonVariant`s from `Button.tsx`, but two callers still referenced them, breaking the frontend build.

## Description
- Bug fix (root cause): #49292 dropped the old button variants, but `FleetsDropdown` (from #49690) and `ReleaseFromABModal` were still passing them. Webpack failed with `TS2769: No overload matches this call` on both.
- `FleetsDropdown` add-fleet button: `brand-inverse-icon` → `subdued` (low-emphasis borderless text + icon, the closest post-#49292 fit).
- `ReleaseFromABModal` cancel button: `inverse-alert` → `secondary` (standard bordered secondary, pairs with the `alert` primary).

## Screenrecording
- Frontend builds cleanly; the two affected surfaces (FleetsDropdown footer, Release-from-ABM modal) render with the new variants.


<img width="897" height="643" alt="Screenshot 2026-07-23 at 7 57 51 AM" src="https://github.com/user-attachments/assets/f2f2e099-9b6f-42d3-a0cc-f2b70bad4479" />


## Testing

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the “Add fleet” footer button to use a subdued button variant and simplified the plus icon rendering for a cleaner presentation.
  * Adjusted the “Cancel” button in the release-from-AB modal to use the secondary button styling for a more consistent look.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->