### PR TITLE
Add managed_local_account_settings config surface for Apple and Windows (#48720)

### DIFF
--- a/cmd/fleetctl/fleetctl/apply_deprecated_test.go
+++ b/cmd/fleetctl/fleetctl/apply_deprecated_test.go
@@ -330,7 +330,12 @@ spec:
 			GracePeriodDays: optjson.SetInt(0),
 		},
 		MacOSSettings: fleet.MacOSSettings{
-			CustomSettings: []fleet.MDMProfileSpec{{Path: mobileConfigPath}},
+			CustomSettings:              []fleet.MDMProfileSpec{{Path: mobileConfigPath}},
+			ManagedLocalAccountSettings: fleet.ManagedLocalAccountSettings{Enabled: optjson.SetBool(false)},
+			EndUserLocalAccountType:     optjson.SetString("admin"),
+		},
+		WindowsSettings: fleet.WindowsSettings{
+			ManagedLocalAccountSettings: fleet.ManagedLocalAccountSettings{Enabled: optjson.SetBool(false)},
 		},
 		WindowsEnabledAndConfigured: true,
 	}, currentAppConfig.MDM)
@@ -376,7 +381,12 @@ spec:
 			GracePeriodDays: optjson.SetInt(0),
 		},
 		MacOSSettings: fleet.MacOSSettings{
-			CustomSettings: []fleet.MDMProfileSpec{{Path: mobileConfigPath}},
+			CustomSettings:              []fleet.MDMProfileSpec{{Path: mobileConfigPath}},
+			ManagedLocalAccountSettings: fleet.ManagedLocalAccountSettings{Enabled: optjson.SetBool(false)},
+			EndUserLocalAccountType:     optjson.SetString("admin"),
+		},
+		WindowsSettings: fleet.WindowsSettings{
+			ManagedLocalAccountSettings: fleet.ManagedLocalAccountSettings{Enabled: optjson.SetBool(false)},
 		},
 		WindowsEnabledAndConfigured: true,
 	}, currentAppConfig.MDM)

--- a/cmd/fleetctl/fleetctl/apply_test.go
+++ b/cmd/fleetctl/fleetctl/apply_test.go
@@ -823,8 +823,20 @@ spec:
       grace_period_days: 1
 `)
 
+	// the managed local account alias fields are force-synced from the canonical
+	// macos_setup values on save (see SyncManagedLocalAccountAliases)
+	aliasSyncedMacOSSettings := fleet.MacOSSettings{
+		ManagedLocalAccountSettings: fleet.ManagedLocalAccountSettings{Enabled: optjson.SetBool(false)},
+		EndUserLocalAccountType:     optjson.SetString("admin"),
+	}
+	aliasSyncedWindowsSettings := fleet.WindowsSettings{
+		ManagedLocalAccountSettings: fleet.ManagedLocalAccountSettings{Enabled: optjson.SetBool(false)},
+	}
+
 	newMDMSettings := fleet.MDM{
 		DeprecatedAppleBMDefaultTeam: "team1",
+		MacOSSettings:                aliasSyncedMacOSSettings,
+		WindowsSettings:              aliasSyncedWindowsSettings,
 		AppleBMTermsExpired:          false,
 		MacOSUpdates: fleet.AppleOSUpdateSettings{
 			MinimumVersion: optjson.SetString("14.6.1"),
@@ -910,6 +922,8 @@ spec:
 
 	newMDMSettings = fleet.MDM{
 		DeprecatedAppleBMDefaultTeam: "team1",
+		MacOSSettings:                aliasSyncedMacOSSettings,
+		WindowsSettings:              aliasSyncedWindowsSettings,
 		AppleBMTermsExpired:          false,
 		MacOSUpdates: fleet.AppleOSUpdateSettings{
 			MinimumVersion: optjson.SetString("14.6.1"),
@@ -1642,7 +1656,12 @@ spec:
 			GracePeriodDays: optjson.SetInt(0),
 		},
 		MacOSSettings: fleet.MacOSSettings{
-			CustomSettings: []fleet.MDMProfileSpec{{Path: mobileConfigPath}},
+			CustomSettings:              []fleet.MDMProfileSpec{{Path: mobileConfigPath}},
+			ManagedLocalAccountSettings: fleet.ManagedLocalAccountSettings{Enabled: optjson.SetBool(false)},
+			EndUserLocalAccountType:     optjson.SetString("admin"),
+		},
+		WindowsSettings: fleet.WindowsSettings{
+			ManagedLocalAccountSettings: fleet.ManagedLocalAccountSettings{Enabled: optjson.SetBool(false)},
 		},
 		WindowsEnabledAndConfigured: true,
 	}, currentAppConfig.MDM)
@@ -1688,7 +1707,12 @@ spec:
 			GracePeriodDays: optjson.SetInt(0),
 		},
 		MacOSSettings: fleet.MacOSSettings{
-			CustomSettings: []fleet.MDMProfileSpec{{Path: mobileConfigPath}},
+			CustomSettings:              []fleet.MDMProfileSpec{{Path: mobileConfigPath}},
+			ManagedLocalAccountSettings: fleet.ManagedLocalAccountSettings{Enabled: optjson.SetBool(false)},
+			EndUserLocalAccountType:     optjson.SetString("admin"),
+		},
+		WindowsSettings: fleet.WindowsSettings{
+			ManagedLocalAccountSettings: fleet.ManagedLocalAccountSettings{Enabled: optjson.SetBool(false)},
 		},
 		WindowsEnabledAndConfigured: true,
 	}, currentAppConfig.MDM)

--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -500,6 +500,7 @@ func (cmd *GenerateGitopsCommand) Run() error {
 			IPadOSUpdates:              cmd.AppConfig.MDM.IPadOSUpdates,
 			WindowsUpdates:             cmd.AppConfig.MDM.WindowsUpdates,
 			MacOSSetup:                 cmd.AppConfig.MDM.MacOSSetup,
+			WindowsSettings:            cmd.AppConfig.MDM.WindowsSettings,
 		}
 
 		// Collect failing policy IDs from webhook settings so we can output
@@ -1348,6 +1349,7 @@ func (cmd *GenerateGitopsCommand) generateControls(teamId *uint, teamName string
 		macosSettingsT := reflect.TypeFor[fleet.MacOSSettings]()
 		windowsSettingsT := reflect.TypeFor[fleet.WindowsSettings]()
 		androidSettingsT := reflect.TypeFor[fleet.AndroidSettings]()
+		managedLocalAccountT := reflect.TypeFor[fleet.ManagedLocalAccountSettings]()
 
 		if cmd.AppConfig.MDM.EnabledAndConfigured {
 			macosSettings := map[string]any{}
@@ -1364,15 +1366,38 @@ func (cmd *GenerateGitopsCommand) generateControls(teamId *uint, teamName string
 			if len(assets) > 0 {
 				macosSettings[jsonFieldName(macosSettingsT, "Assets")] = assets
 			}
+			// The managed local account fields under apple_settings alias the deprecated
+			// setup_experience fields; emit them here (only when set to non-default values) so the
+			// generated YAML uses the new spelling. The account type is emitted independently of
+			// the enabled flag so a stored non-admin type is never silently dropped.
+			if cmd.AppConfig.License.IsPremium() && teamMdm != nil {
+				if teamMdm.MacOSSetup.EnableManagedLocalAccount.Value {
+					macosSettings[jsonFieldName(macosSettingsT, "ManagedLocalAccountSettings")] = map[string]any{
+						jsonFieldName(managedLocalAccountT, "Enabled"): true,
+					}
+				}
+				if accountType := teamMdm.MacOSSetup.EndUserLocalAccountType.Value; accountType != "" && accountType != "admin" {
+					macosSettings[jsonFieldName(macosSettingsT, "EndUserLocalAccountType")] = accountType
+				}
+			}
 			if len(macosSettings) > 0 {
 				result[jsonFieldName(t, "MacOSSettings")] = macosSettings
 			}
 		}
-		if cmd.AppConfig.MDM.WindowsEnabledAndConfigured && profiles != nil {
-			if len(profiles["windows_profiles"].([]map[string]interface{})) > 0 {
-				result[jsonFieldName(t, "WindowsSettings")] = map[string]interface{}{
-					jsonFieldName(windowsSettingsT, "CustomSettings"): profiles["windows_profiles"],
+		if cmd.AppConfig.MDM.WindowsEnabledAndConfigured {
+			windowsSettings := map[string]any{}
+			if profiles != nil {
+				if windowsProfiles, _ := profiles["windows_profiles"].([]map[string]any); len(windowsProfiles) > 0 {
+					windowsSettings[jsonFieldName(windowsSettingsT, "CustomSettings")] = windowsProfiles
 				}
+			}
+			if cmd.AppConfig.License.IsPremium() && teamMdm != nil && teamMdm.WindowsSettings.ManagedLocalAccountSettings.Enabled.Value {
+				windowsSettings[jsonFieldName(windowsSettingsT, "ManagedLocalAccountSettings")] = map[string]any{
+					jsonFieldName(managedLocalAccountT, "Enabled"): true,
+				}
+			}
+			if len(windowsSettings) > 0 {
+				result[jsonFieldName(t, "WindowsSettings")] = windowsSettings
 			}
 		}
 		if cmd.AppConfig.MDM.AndroidEnabledAndConfigured && profiles != nil {
@@ -1505,10 +1530,10 @@ func (cmd *GenerateGitopsCommand) generateControls(teamId *uint, teamName string
 			hasEnrollmentProfile := enrollmentProfile != nil
 
 			// If the team has any of these configured, we need to generate the macos_setup section.
+			// The managed local account fields are not part of this placeholder: they are emitted
+			// under apple_settings.managed_local_account_settings above.
 			if hasBootstrapPackage || hasSetupScript || hasEnrollmentProfile ||
-				(teamMdm != nil && (teamMdm.MacOSSetup.EnableEndUserAuthentication ||
-					teamMdm.MacOSSetup.EnableManagedLocalAccount.Value ||
-					(teamMdm.MacOSSetup.EndUserLocalAccountType.Valid && teamMdm.MacOSSetup.EndUserLocalAccountType.Value != "admin"))) {
+				(teamMdm != nil && teamMdm.MacOSSetup.EnableEndUserAuthentication) {
 				result[jsonFieldName(mdmT, "MacOSSetup")] = "TODO: update with your setup_experience configuration"
 				cmd.Messages.Notes = append(cmd.Messages.Notes, Note{
 					Filename: teamName,

--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -2991,8 +2991,9 @@ func TestGenerateControlsManagedLocalAccount(t *testing.T) {
 	require.NoError(t, err)
 
 	// no TODO placeholder: the managed local account settings alone must not trigger it
-	_, ok := controlsRaw["macos_setup"]
-	require.False(t, ok, "expected no macos_setup TODO placeholder")
+	// (generateControls emits the placeholder under the renamed setup_experience key)
+	_, ok := controlsRaw["setup_experience"]
+	require.False(t, ok, "expected no setup_experience TODO placeholder")
 
 	macosSettings, ok := controlsRaw["apple_settings"].(map[string]any)
 	require.True(t, ok, "expected a macos_settings section")

--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -2959,3 +2959,85 @@ func TestGeneratePoliciesPatchPolicyOrphanedFromFleetMaintainedApp(t *testing.T)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "Team patch policy")
 }
+
+// TestGenerateControlsManagedLocalAccount verifies that the managed local account settings are
+// emitted under the per-platform settings sections (new apple_settings spelling) instead of the
+// shared setup_experience TODO placeholder (#48720).
+func TestGenerateControlsManagedLocalAccount(t *testing.T) {
+	fleetClient := &MockClient{}
+	appConfig, err := fleetClient.GetAppConfig()
+	require.NoError(t, err)
+
+	cmd := &GenerateGitopsCommand{
+		Client:       fleetClient,
+		CLI:          cli.NewContext(cli.NewApp(), nil, nil),
+		Messages:     Messages{},
+		FilesToWrite: make(map[string]any),
+		AppConfig:    appConfig,
+		ScriptList:   make(map[uint]string),
+	}
+
+	mdmConfig := fleet.TeamMDM{
+		MacOSSetup: fleet.MacOSSetup{
+			EnableManagedLocalAccount: optjson.SetBool(true),
+			EndUserLocalAccountType:   optjson.SetString("standard"),
+		},
+		WindowsSettings: fleet.WindowsSettings{
+			ManagedLocalAccountSettings: fleet.ManagedLocalAccountSettings{Enabled: optjson.SetBool(true)},
+		},
+	}
+
+	controlsRaw, err := cmd.generateControls(new(uint), "no_team", &mdmConfig)
+	require.NoError(t, err)
+
+	// no TODO placeholder: the managed local account settings alone must not trigger it
+	_, ok := controlsRaw["macos_setup"]
+	require.False(t, ok, "expected no macos_setup TODO placeholder")
+
+	macosSettings, ok := controlsRaw["apple_settings"].(map[string]any)
+	require.True(t, ok, "expected a macos_settings section")
+	require.Equal(t, map[string]any{"enabled": true}, macosSettings["managed_local_account_settings"])
+	require.Equal(t, "standard", macosSettings["end_user_local_account_type"])
+
+	windowsSettings, ok := controlsRaw["windows_settings"].(map[string]any)
+	require.True(t, ok, "expected a windows_settings section")
+	require.Equal(t, map[string]any{"enabled": true}, windowsSettings["managed_local_account_settings"])
+
+	// default account type is omitted, and disabled platforms emit nothing
+	mdmConfig = fleet.TeamMDM{
+		MacOSSetup: fleet.MacOSSetup{
+			EnableManagedLocalAccount: optjson.SetBool(true),
+			EndUserLocalAccountType:   optjson.SetString("admin"),
+		},
+	}
+	controlsRaw, err = cmd.generateControls(new(uint), "no_team", &mdmConfig)
+	require.NoError(t, err)
+	macosSettings, ok = controlsRaw["apple_settings"].(map[string]any)
+	require.True(t, ok, "expected a macos_settings section")
+	require.Equal(t, map[string]any{"enabled": true}, macosSettings["managed_local_account_settings"])
+	require.NotContains(t, macosSettings, "end_user_local_account_type")
+	if windowsSection, ok := controlsRaw["windows_settings"].(map[string]any); ok {
+		require.NotContains(t, windowsSection, "managed_local_account_settings")
+	}
+
+	// feature fully disabled: no managed local account keys at all
+	controlsRaw, err = cmd.generateControls(new(uint), "no_team", &fleet.TeamMDM{})
+	require.NoError(t, err)
+	if macosSection, ok := controlsRaw["apple_settings"].(map[string]any); ok {
+		require.NotContains(t, macosSection, "managed_local_account_settings")
+	}
+
+	// a stored non-admin account type is emitted even when the feature is disabled, so it is
+	// never silently dropped from generated output
+	mdmConfig = fleet.TeamMDM{
+		MacOSSetup: fleet.MacOSSetup{
+			EndUserLocalAccountType: optjson.SetString("standard"),
+		},
+	}
+	controlsRaw, err = cmd.generateControls(new(uint), "no_team", &mdmConfig)
+	require.NoError(t, err)
+	macosSettings, ok = controlsRaw["apple_settings"].(map[string]any)
+	require.True(t, ok, "expected an apple_settings section")
+	require.Equal(t, "standard", macosSettings["end_user_local_account_type"])
+	require.NotContains(t, macosSettings, "managed_local_account_settings")
+}

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -8792,3 +8792,78 @@ func TestGetLabelUsagePolicyScopes(t *testing.T) {
 		})
 	}
 }
+
+// TestGitOpsManagedLocalAccount covers the new managed_local_account_settings keys end to end
+// through the real gitops client and server (#48720): the apple_settings surface converges onto
+// the deprecated setup_experience storage, the Windows toggle persists, repeated applies are
+// stable, and removing the keys from the YAML declaratively disables the feature.
+func TestGitOpsManagedLocalAccount(t *testing.T) {
+	// Cannot run t.Parallel() because it sets environment variables.
+	ds, savedAppConfigPtr, _ := testing_utils.SetupFullGitOpsPremiumServer(t)
+
+	const fleetServerURL = "https://fleet.example.com"
+	t.Setenv("FLEET_SERVER_URL", fleetServerURL)
+
+	writeConfig := func(controls string) string {
+		f, err := os.CreateTemp(t.TempDir(), "*.yml")
+		require.NoError(t, err)
+		_, err = f.WriteString(fmt.Sprintf(`
+controls:
+%s
+queries:
+policies:
+agent_options:
+org_settings:
+  server_settings:
+    server_url: %s
+  org_info:
+    contact_url: https://example.com/contact
+    org_logo_url: ""
+    org_logo_url_light_background: ""
+    org_name: GitOps Managed Local Account Test
+  secrets:
+    - secret: globalSecret
+software:
+`, controls, fleetServerURL))
+		require.NoError(t, err)
+		return f.Name()
+	}
+
+	// enable via the new nested keys on both platforms
+	enabledFile := writeConfig(`  windows_enabled_and_configured: true
+  apple_settings:
+    managed_local_account_settings:
+      enabled: true
+    end_user_local_account_type: standard
+  windows_settings:
+    managed_local_account_settings:
+      enabled: true`)
+	_ = runAppForTest(t, []string{"gitops", "-f", enabledFile})
+	require.True(t, ds.SaveAppConfigFuncInvoked)
+	require.True(t, (*savedAppConfigPtr).MDM.MacOSSetup.EnableManagedLocalAccount.Value,
+		"apple_settings.managed_local_account_settings.enabled must converge onto the deprecated storage")
+	require.Equal(t, "standard", (*savedAppConfigPtr).MDM.MacOSSetup.EndUserLocalAccountType.Value)
+	require.True(t, (*savedAppConfigPtr).MDM.WindowsSettings.ManagedLocalAccountSettings.Enabled.Value)
+
+	// a second apply of the same file must be stable (no oscillation against the stored values)
+	_ = runAppForTest(t, []string{"gitops", "-f", enabledFile})
+	require.True(t, (*savedAppConfigPtr).MDM.MacOSSetup.EnableManagedLocalAccount.Value)
+	require.Equal(t, "standard", (*savedAppConfigPtr).MDM.MacOSSetup.EndUserLocalAccountType.Value)
+	require.True(t, (*savedAppConfigPtr).MDM.WindowsSettings.ManagedLocalAccountSettings.Enabled.Value)
+
+	// removing the keys from the YAML declaratively disables the feature on both platforms
+	disabledFile := writeConfig(`  windows_enabled_and_configured: true`)
+	_ = runAppForTest(t, []string{"gitops", "-f", disabledFile})
+	require.False(t, (*savedAppConfigPtr).MDM.MacOSSetup.EnableManagedLocalAccount.Value)
+	require.Equal(t, "admin", (*savedAppConfigPtr).MDM.MacOSSetup.EndUserLocalAccountType.Value)
+	require.False(t, (*savedAppConfigPtr).MDM.WindowsSettings.ManagedLocalAccountSettings.Enabled.Value)
+
+	// the deprecated setup_experience spelling still applies, to the Apple value only
+	deprecatedFile := writeConfig(`  windows_enabled_and_configured: true
+  setup_experience:
+    enable_create_local_admin_account: true`)
+	_ = runAppForTest(t, []string{"gitops", "-f", deprecatedFile})
+	require.True(t, (*savedAppConfigPtr).MDM.MacOSSetup.EnableManagedLocalAccount.Value)
+	require.False(t, (*savedAppConfigPtr).MDM.WindowsSettings.ManagedLocalAccountSettings.Enabled.Value,
+		"the deprecated field must not control the Windows setting")
+}

--- a/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedAppConfigEmpty.yml
+++ b/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedAppConfigEmpty.yml
@@ -60,11 +60,19 @@ spec:
       webhook_url: ""
     macos_settings:
       custom_settings: null
+      managed_local_account_settings:
+        enabled: false
+      end_user_local_account_type: admin
     apple_settings:
       configuration_profiles: null
+      managed_local_account_settings:
+        enabled: false
+      end_user_local_account_type: admin
     windows_settings:
       custom_settings: null
       configuration_profiles: null
+      managed_local_account_settings:
+        enabled: false
     android_settings:
       custom_settings: null
       configuration_profiles: null

--- a/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedAppConfigSet.yml
+++ b/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedAppConfigSet.yml
@@ -60,11 +60,19 @@ spec:
       webhook_url: ""
     macos_settings:
       custom_settings: null
+      managed_local_account_settings:
+        enabled: false
+      end_user_local_account_type: admin
     apple_settings:
       configuration_profiles: null
+      managed_local_account_settings:
+        enabled: false
+      end_user_local_account_type: admin
     windows_settings:
       custom_settings: null
       configuration_profiles: null
+      managed_local_account_settings:
+        enabled: false
     android_settings:
       custom_settings: null
       configuration_profiles: null

--- a/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedTeam1And2Empty.yml
+++ b/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedTeam1And2Empty.yml
@@ -22,8 +22,13 @@ spec:
       windows_require_bitlocker_pin: null
       apple_settings:
         configuration_profiles: null
+        managed_local_account_settings:
+          enabled: false
+        end_user_local_account_type: admin
       windows_settings:
         configuration_profiles: null
+        managed_local_account_settings:
+          enabled: false
       android_settings:
         configuration_profiles: null
         certificates: null
@@ -81,8 +86,13 @@ spec:
       windows_require_bitlocker_pin: null
       macos_settings:
         custom_settings: null
+        managed_local_account_settings:
+          enabled: false
+        end_user_local_account_type: admin
       windows_settings:
         custom_settings: null
+        managed_local_account_settings:
+          enabled: false
       android_settings:
         custom_settings: null
         certificates: null
@@ -144,8 +154,13 @@ spec:
       windows_require_bitlocker_pin: null
       apple_settings:
         configuration_profiles: null
+        managed_local_account_settings:
+          enabled: false
+        end_user_local_account_type: admin
       windows_settings:
         configuration_profiles: null
+        managed_local_account_settings:
+          enabled: false
       android_settings:
         configuration_profiles: null
         certificates: null
@@ -196,8 +211,13 @@ spec:
       windows_require_bitlocker_pin: null
       macos_settings:
         custom_settings: null
+        managed_local_account_settings:
+          enabled: false
+        end_user_local_account_type: admin
       windows_settings:
         custom_settings: null
+        managed_local_account_settings:
+          enabled: false
       android_settings:
         custom_settings: null
         certificates: null

--- a/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedTeam1And2Set.yml
+++ b/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedTeam1And2Set.yml
@@ -22,8 +22,13 @@ spec:
       windows_require_bitlocker_pin: null
       apple_settings:
         configuration_profiles: null
+        managed_local_account_settings:
+          enabled: false
+        end_user_local_account_type: admin
       windows_settings:
         configuration_profiles: null
+        managed_local_account_settings:
+          enabled: false
       android_settings:
         configuration_profiles: null
         certificates: null
@@ -81,8 +86,13 @@ spec:
       windows_require_bitlocker_pin: null
       macos_settings:
         custom_settings: null
+        managed_local_account_settings:
+          enabled: false
+        end_user_local_account_type: admin
       windows_settings:
         custom_settings: null
+        managed_local_account_settings:
+          enabled: false
       android_settings:
         custom_settings: null
         certificates: null
@@ -144,8 +154,13 @@ spec:
       windows_require_bitlocker_pin: null
       apple_settings:
         configuration_profiles: null
+        managed_local_account_settings:
+          enabled: false
+        end_user_local_account_type: admin
       windows_settings:
         configuration_profiles: null
+        managed_local_account_settings:
+          enabled: false
       android_settings:
         configuration_profiles: null
         certificates: null
@@ -197,8 +212,13 @@ spec:
       windows_require_bitlocker_pin: null
       macos_settings:
         custom_settings: null
+        managed_local_account_settings:
+          enabled: false
+        end_user_local_account_type: admin
       windows_settings:
         custom_settings: null
+        managed_local_account_settings:
+          enabled: false
       android_settings:
         custom_settings: null
         certificates: null

--- a/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedTeam1Empty.yml
+++ b/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedTeam1Empty.yml
@@ -22,6 +22,9 @@ spec:
       windows_require_bitlocker_pin: null
       apple_settings:
         configuration_profiles: null
+        managed_local_account_settings:
+          enabled: false
+        end_user_local_account_type: admin
       android_settings:
         configuration_profiles: null
         certificates: null
@@ -55,6 +58,8 @@ spec:
         grace_period_days: null
       windows_settings:
         configuration_profiles: null
+        managed_local_account_settings:
+          enabled: false
     scripts: null
     secrets: null
     webhook_settings:
@@ -81,6 +86,9 @@ spec:
       windows_require_bitlocker_pin: null
       macos_settings:
         custom_settings: null
+        managed_local_account_settings:
+          enabled: false
+        end_user_local_account_type: admin
       android_settings:
         custom_settings: null
         certificates: null
@@ -114,6 +122,8 @@ spec:
         grace_period_days: null
       windows_settings:
         custom_settings: null
+        managed_local_account_settings:
+          enabled: false
     scripts: null
     secrets: null
     webhook_settings:

--- a/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedTeam1Set.yml
+++ b/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedTeam1Set.yml
@@ -21,8 +21,13 @@ spec:
       windows_require_bitlocker_pin: null
       apple_settings:
         configuration_profiles: null
+        managed_local_account_settings:
+          enabled: false
+        end_user_local_account_type: admin
       windows_settings:
         configuration_profiles: null
+        managed_local_account_settings:
+          enabled: false
       android_settings:
         configuration_profiles: null
         certificates: null
@@ -80,8 +85,13 @@ spec:
       windows_require_bitlocker_pin: null
       macos_settings:
         custom_settings: null
+        managed_local_account_settings:
+          enabled: false
+        end_user_local_account_type: admin
       windows_settings:
         custom_settings: null
+        managed_local_account_settings:
+          enabled: false
       android_settings:
         custom_settings: null
         certificates: null

--- a/ee/server/service/mdm.go
+++ b/ee/server/service/mdm.go
@@ -301,7 +301,7 @@ func (svc *Service) updateAppConfigMDMAppleSetup(ctx context.Context, payload fl
 			}
 		}
 		if didUpdateManagedLocalAccount {
-			if err := svc.updateMacOSSetupEnableManagedLocalAccount(ctx, ac.MDM.MacOSSetup.EnableManagedLocalAccount.Value, nil, nil); err != nil {
+			if err := svc.logEnableManagedLocalAccountActivity(ctx, ac.MDM.MacOSSetup.EnableManagedLocalAccount.Value, nil, nil); err != nil {
 				return err
 			}
 		}
@@ -326,7 +326,9 @@ func (svc *Service) updateMacOSSetupEnableEndUserAuth(ctx context.Context, enabl
 	return nil
 }
 
-func (svc *Service) updateMacOSSetupEnableManagedLocalAccount(ctx context.Context, enable bool, teamID *uint, teamName *string) error {
+// logEnableManagedLocalAccountActivity logs the enabled/disabled managed local account activity
+// for either platform's toggle (the activity types are platform-agnostic).
+func (svc *Service) logEnableManagedLocalAccountActivity(ctx context.Context, enable bool, teamID *uint, teamName *string) error {
 	var act fleet.ActivityDetails
 	if enable {
 		act = fleet.ActivityTypeEnabledManagedLocalAccount{TeamID: teamID, TeamName: teamName}
@@ -334,7 +336,7 @@ func (svc *Service) updateMacOSSetupEnableManagedLocalAccount(ctx context.Contex
 		act = fleet.ActivityTypeDisabledManagedLocalAccount{TeamID: teamID, TeamName: teamName}
 	}
 	if err := svc.NewActivity(ctx, authz.UserFromContext(ctx), act); err != nil {
-		return ctxerr.Wrap(ctx, err, "create activity for macos enable managed local account change")
+		return ctxerr.Wrap(ctx, err, "create activity for enable managed local account change")
 	}
 	return nil
 }

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -718,7 +718,7 @@ func (svc *Service) ModifyTeam(ctx context.Context, teamID uint, payload fleet.T
 		}
 	}
 	if macOSManagedLocalAccountUpdated {
-		if err := svc.updateMacOSSetupEnableManagedLocalAccount(ctx, team.Config.MDM.MacOSSetup.EnableManagedLocalAccount.Value, &team.ID, &team.Name); err != nil {
+		if err := svc.logEnableManagedLocalAccountActivity(ctx, team.Config.MDM.MacOSSetup.EnableManagedLocalAccount.Value, &team.ID, &team.Name); err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "update macos setup enable managed local account")
 		}
 	}
@@ -727,7 +727,7 @@ func (svc *Service) ModifyTeam(ctx context.Context, teamID uint, payload fleet.T
 	if windowsManagedLocalAccountUpdated &&
 		!(macOSManagedLocalAccountUpdated &&
 			team.Config.MDM.MacOSSetup.EnableManagedLocalAccount.Value == team.Config.MDM.WindowsSettings.ManagedLocalAccountSettings.Enabled.Value) {
-		if err := svc.updateMacOSSetupEnableManagedLocalAccount(ctx, team.Config.MDM.WindowsSettings.ManagedLocalAccountSettings.Enabled.Value, &team.ID, &team.Name); err != nil {
+		if err := svc.logEnableManagedLocalAccountActivity(ctx, team.Config.MDM.WindowsSettings.ManagedLocalAccountSettings.Enabled.Value, &team.ID, &team.Name); err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "update windows enable managed local account")
 		}
 	}
@@ -2278,7 +2278,7 @@ func (svc *Service) editTeamFromSpec(
 	}
 
 	if didUpdateEnableManagedLocalAccount {
-		if err := svc.updateMacOSSetupEnableManagedLocalAccount(
+		if err := svc.logEnableManagedLocalAccountActivity(
 			ctx, team.Config.MDM.MacOSSetup.EnableManagedLocalAccount.Value, &team.ID, &team.Name,
 		); err != nil {
 			return err
@@ -2290,7 +2290,7 @@ func (svc *Service) editTeamFromSpec(
 	if didUpdateWindowsManagedLocalAccount &&
 		!(didUpdateEnableManagedLocalAccount &&
 			team.Config.MDM.MacOSSetup.EnableManagedLocalAccount.Value == team.Config.MDM.WindowsSettings.ManagedLocalAccountSettings.Enabled.Value) {
-		if err := svc.updateMacOSSetupEnableManagedLocalAccount(
+		if err := svc.logEnableManagedLocalAccountActivity(
 			ctx, team.Config.MDM.WindowsSettings.ManagedLocalAccountSettings.Enabled.Value, &team.ID, &team.Name,
 		); err != nil {
 			return err
@@ -2668,7 +2668,7 @@ func (svc *Service) updateTeamMDMAppleSetup(ctx context.Context, tm *fleet.Team,
 			}
 		}
 		if didUpdateManagedLocalAccount {
-			if err := svc.updateMacOSSetupEnableManagedLocalAccount(ctx, tm.Config.MDM.MacOSSetup.EnableManagedLocalAccount.Value, &tm.ID, &tm.Name); err != nil {
+			if err := svc.logEnableManagedLocalAccountActivity(ctx, tm.Config.MDM.MacOSSetup.EnableManagedLocalAccount.Value, &tm.ID, &tm.Name); err != nil {
 				return err
 			}
 		}

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -217,19 +217,69 @@ func (svc *Service) ModifyTeam(ctx context.Context, teamID uint, payload fleet.T
 	}
 
 	var (
-		macOSMinVersionUpdated          bool
-		updateNewHostsChanged           bool
-		iOSMinVersionUpdated            bool
-		iPadOSMinVersionUpdated         bool
-		windowsUpdatesUpdated           bool
-		macOSDiskEncryptionUpdated      bool
-		recoveryLockPasswordUpdated     bool
-		macOSEnableEndUserAuthUpdated   bool
-		macOSManagedLocalAccountUpdated bool
-		conditionalAccessUpdated        bool
-		nameTemplateUpdated             bool
+		macOSMinVersionUpdated            bool
+		updateNewHostsChanged             bool
+		iOSMinVersionUpdated              bool
+		iPadOSMinVersionUpdated           bool
+		windowsUpdatesUpdated             bool
+		macOSDiskEncryptionUpdated        bool
+		recoveryLockPasswordUpdated       bool
+		macOSEnableEndUserAuthUpdated     bool
+		macOSManagedLocalAccountUpdated   bool
+		windowsManagedLocalAccountUpdated bool
+		conditionalAccessUpdated          bool
+		nameTemplateUpdated               bool
 	)
 	if payload.MDM != nil {
+		// apple_settings.managed_local_account_settings aliases the deprecated setup_experience
+		// fields. Resolve the two surfaces against the stored team values (the surface that
+		// changed wins on a GET-modify-PATCH echo; genuine conflicts are rejected).
+		if payload.MDM.MacOSSettings != nil {
+			var deprecatedEnabled optjson.Bool
+			var deprecatedAccountType optjson.String
+			if payload.MDM.MacOSSetup != nil {
+				deprecatedEnabled = payload.MDM.MacOSSetup.EnableManagedLocalAccount
+				deprecatedAccountType = payload.MDM.MacOSSetup.EndUserLocalAccountType
+			}
+			resolvedEnabled := fleet.ResolveManagedLocalAccountAliasBool(deprecatedEnabled,
+				payload.MDM.MacOSSettings.ManagedLocalAccountSettings.Enabled,
+				team.Config.MDM.MacOSSetup.EnableManagedLocalAccount)
+			resolvedAccountType, err := fleet.ResolveManagedLocalAccountAliasAccountType(deprecatedAccountType,
+				payload.MDM.MacOSSettings.EndUserLocalAccountType,
+				team.Config.MDM.MacOSSetup.EndUserLocalAccountType)
+			if err != nil {
+				return nil, err
+			}
+			switch {
+			case payload.MDM.MacOSSetup != nil:
+				// let the existing MacOSSetup block below apply the resolved values
+				payload.MDM.MacOSSetup.EnableManagedLocalAccount = resolvedEnabled
+				payload.MDM.MacOSSetup.EndUserLocalAccountType = resolvedAccountType
+			case resolvedEnabled.Valid || resolvedAccountType.Valid:
+				// alias-only write: apply directly rather than synthesizing a MacOSSetup payload,
+				// which would run the end-user-authentication validations on a request that never
+				// touched setup experience
+				aliasSetup := fleet.MacOSSetup{
+					EnableManagedLocalAccount: resolvedEnabled,
+					EndUserLocalAccountType:   resolvedAccountType,
+				}
+				if err := aliasSetup.ValidateAgainst(team.Config.MDM.MacOSSetup); err != nil {
+					return nil, err
+				}
+				macOSManagedLocalAccountUpdated = resolvedEnabled.Valid &&
+					team.Config.MDM.MacOSSetup.EnableManagedLocalAccount.Value != resolvedEnabled.Value
+				if macOSManagedLocalAccountUpdated && resolvedEnabled.Value && !appCfg.MDM.EnabledAndConfigured {
+					return nil, fleet.NewInvalidArgumentError("setup_experience.enable_managed_local_account",
+						`Couldn't update setup_experience.enable_managed_local_account because MDM features aren't turned on in Fleet.`)
+				}
+				if resolvedEnabled.Valid {
+					team.Config.MDM.MacOSSetup.EnableManagedLocalAccount = resolvedEnabled
+				}
+				if resolvedAccountType.Valid {
+					team.Config.MDM.MacOSSetup.EndUserLocalAccountType = resolvedAccountType
+				}
+			}
+		}
 		if payload.MDM.MacOSUpdates != nil {
 			if err := payload.MDM.MacOSUpdates.Validate(); err != nil {
 				return nil, fleet.NewInvalidArgumentError("macos_updates", err.Error())
@@ -405,6 +455,16 @@ func (svc *Service) ModifyTeam(ctx context.Context, teamID uint, payload fleet.T
 			if payload.MDM.MacOSSetup.EndUserLocalAccountType.Set {
 				team.Config.MDM.MacOSSetup.EndUserLocalAccountType = payload.MDM.MacOSSetup.EndUserLocalAccountType
 			}
+		}
+
+		if payload.MDM.WindowsSettings != nil && payload.MDM.WindowsSettings.ManagedLocalAccountSettings.Enabled.Valid {
+			newEnabled := payload.MDM.WindowsSettings.ManagedLocalAccountSettings.Enabled
+			windowsManagedLocalAccountUpdated = team.Config.MDM.WindowsSettings.ManagedLocalAccountSettings.Enabled.Value != newEnabled.Value
+			if windowsManagedLocalAccountUpdated && newEnabled.Value && !appCfg.MDM.WindowsEnabledAndConfigured {
+				return nil, fleet.NewInvalidArgumentError("mdm.windows_settings.managed_local_account_settings.enabled",
+					"Couldn't update windows_settings.managed_local_account_settings because Windows MDM isn't turned on in Fleet.")
+			}
+			team.Config.MDM.WindowsSettings.ManagedLocalAccountSettings.Enabled = newEnabled
 		}
 	}
 
@@ -660,6 +720,15 @@ func (svc *Service) ModifyTeam(ctx context.Context, teamID uint, payload fleet.T
 	if macOSManagedLocalAccountUpdated {
 		if err := svc.updateMacOSSetupEnableManagedLocalAccount(ctx, team.Config.MDM.MacOSSetup.EnableManagedLocalAccount.Value, &team.ID, &team.Name); err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "update macos setup enable managed local account")
+		}
+	}
+	// The Windows toggle logs the same platform-agnostic activity types; skip it when the macOS
+	// toggle changed in the same direction in this request to avoid two identical entries.
+	if windowsManagedLocalAccountUpdated &&
+		!(macOSManagedLocalAccountUpdated &&
+			team.Config.MDM.MacOSSetup.EnableManagedLocalAccount.Value == team.Config.MDM.WindowsSettings.ManagedLocalAccountSettings.Enabled.Value) {
+		if err := svc.updateMacOSSetupEnableManagedLocalAccount(ctx, team.Config.MDM.WindowsSettings.ManagedLocalAccountSettings.Enabled.Value, &team.ID, &team.Name); err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "update windows enable managed local account")
 		}
 	}
 	// Create activity if conditional access was enabled or disabled for the team.
@@ -1441,7 +1510,7 @@ func (svc *Service) ApplyTeamSpecs(ctx context.Context, specs []*fleet.TeamSpec,
 				})
 			}
 
-			team, err := svc.createTeamFromSpec(ctx, spec, appConfig, secrets, applyOpts.DryRun)
+			team, err := svc.createTeamFromSpec(ctx, spec, appConfig, secrets, applyOpts)
 			if err != nil {
 				return nil, ctxerr.Wrap(ctx, err, "creating team from spec")
 			}
@@ -1505,8 +1574,9 @@ func (svc *Service) createTeamFromSpec(
 	spec *fleet.TeamSpec,
 	appCfg *fleet.AppConfig,
 	secrets []*fleet.EnrollSecret,
-	dryRun bool,
+	opts fleet.ApplyTeamSpecOptions,
 ) (*fleet.Team, error) {
+	dryRun := opts.DryRun
 	agentOptions := &spec.AgentOptions
 	if len(spec.AgentOptions) == 0 {
 		agentOptions = appCfg.AgentOptions
@@ -1530,6 +1600,18 @@ func (svc *Service) createTeamFromSpec(
 	if err := svc.applyTeamMacOSSettings(ctx, spec, &macOSSettings); err != nil {
 		return nil, err
 	}
+	// a new team has no stored values, so pass a zero MacOSSetup
+	if err := reconcileManagedLocalAccountSpecAliases(spec, fleet.MacOSSetup{}); err != nil {
+		return nil, ctxerr.Wrap(ctx, err)
+	}
+	windowsEnabledAndConfigured := appCfg.MDM.WindowsEnabledAndConfigured
+	if opts.DryRunAssumptions != nil && opts.DryRunAssumptions.WindowsEnabledAndConfigured.Valid {
+		windowsEnabledAndConfigured = opts.DryRunAssumptions.WindowsEnabledAndConfigured.Value
+	}
+	if spec.MDM.WindowsSettings.ManagedLocalAccountSettings.Enabled.Value && !windowsEnabledAndConfigured {
+		return nil, ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("windows_settings.managed_local_account_settings.enabled",
+			"Couldn't enable windows_settings.managed_local_account_settings. "+fleet.ErrWindowsMDMNotConfigured.Error()))
+	}
 	macOSSetup := spec.MDM.MacOSSetup
 	if !macOSSetup.EnableReleaseDeviceManually.Valid {
 		macOSSetup.EnableReleaseDeviceManually = optjson.SetBool(false)
@@ -1542,7 +1624,8 @@ func (svc *Service) createTeamFromSpec(
 	}
 
 	if macOSSetup.MacOSSetupAssistant.Value != "" || macOSSetup.BootstrapPackage.Value != "" ||
-		macOSSetup.EnableReleaseDeviceManually.Value || macOSSetup.ManualAgentInstall.Value {
+		macOSSetup.EnableReleaseDeviceManually.Value || macOSSetup.ManualAgentInstall.Value ||
+		macOSSetup.EnableManagedLocalAccount.Value {
 		if !appCfg.MDM.EnabledAndConfigured {
 			return nil, ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("setup_experience",
 				`Couldn't update setup_experience because MDM features aren't turned on in Fleet. Use fleetctl generate mdm-apple and then fleet serve with mdm configuration to turn on MDM features.`))
@@ -1826,6 +1909,9 @@ func (svc *Service) editTeamFromSpec(
 	if err := svc.applyTeamMacOSSettings(ctx, spec, &team.Config.MDM.MacOSSettings); err != nil {
 		return err
 	}
+	if err := reconcileManagedLocalAccountSpecAliases(spec, team.Config.MDM.MacOSSetup); err != nil {
+		return ctxerr.Wrap(ctx, err)
+	}
 
 	// 1. if the spec has the new setting, use that
 	// 2. else if the spec has the deprecated setting, use that
@@ -1980,6 +2066,16 @@ func (svc *Service) editTeamFromSpec(
 	// edits when the cached AppConfig lags behind a recent enable.
 	if spec.MDM.WindowsSettings.CustomSettings.Set {
 		team.Config.MDM.WindowsSettings.CustomSettings = spec.MDM.WindowsSettings.CustomSettings
+	}
+	var didUpdateWindowsManagedLocalAccount bool
+	if spec.MDM.WindowsSettings.ManagedLocalAccountSettings.Enabled.Valid {
+		newWindowsManagedLocalAccount := spec.MDM.WindowsSettings.ManagedLocalAccountSettings.Enabled
+		didUpdateWindowsManagedLocalAccount = team.Config.MDM.WindowsSettings.ManagedLocalAccountSettings.Enabled.Value != newWindowsManagedLocalAccount.Value
+		if didUpdateWindowsManagedLocalAccount && newWindowsManagedLocalAccount.Value && !windowsEnabledAndConfigured {
+			return ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("windows_settings.managed_local_account_settings.enabled",
+				"Couldn't enable windows_settings.managed_local_account_settings. "+fleet.ErrWindowsMDMNotConfigured.Error()))
+		}
+		team.Config.MDM.WindowsSettings.ManagedLocalAccountSettings.Enabled = newWindowsManagedLocalAccount
 	}
 	if spec.MDM.AndroidSettings.CustomSettings.Set {
 		team.Config.MDM.AndroidSettings.CustomSettings = spec.MDM.AndroidSettings.CustomSettings
@@ -2189,6 +2285,18 @@ func (svc *Service) editTeamFromSpec(
 		}
 	}
 
+	// The Windows toggle logs the same platform-agnostic activity types; skip it when the macOS
+	// toggle changed in the same direction in this apply to avoid two identical entries.
+	if didUpdateWindowsManagedLocalAccount &&
+		!(didUpdateEnableManagedLocalAccount &&
+			team.Config.MDM.MacOSSetup.EnableManagedLocalAccount.Value == team.Config.MDM.WindowsSettings.ManagedLocalAccountSettings.Enabled.Value) {
+		if err := svc.updateMacOSSetupEnableManagedLocalAccount(
+			ctx, team.Config.MDM.WindowsSettings.ManagedLocalAccountSettings.Enabled.Value, &team.ID, &team.Name,
+		); err != nil {
+			return err
+		}
+	}
+
 	// Update OS update settings if they were updated.
 	if mdmMacOSUpdatesEdited {
 		if err := svc.mdmAppleEditedAppleOSUpdates(ctx, &team.ID, fleet.MacOS, team.Config.MDM.MacOSUpdates); err != nil {
@@ -2268,6 +2376,37 @@ func (svc *Service) validateTeamCalendarIntegrations(
 	} else if u.Scheme != "https" && u.Scheme != "http" {
 		invalid.Append("integrations.google_calendar.webhook_url", "webhook_url must be https or http")
 	}
+	return nil
+}
+
+// reconcileManagedLocalAccountSpecAliases converges the apple_settings managed local account
+// alias fields from a team spec's macos_settings map onto the canonical spec.MDM.MacOSSetup
+// fields, so the existing setup-experience apply logic handles them. When both surfaces are
+// written with different values, the one that changed relative to the stored team values wins
+// (an exported spec echoes both surfaces); genuine conflicts are rejected. For team creation,
+// pass a zero MacOSSetup as the stored values.
+func reconcileManagedLocalAccountSpecAliases(spec *fleet.TeamSpec, storedMacOSSetup fleet.MacOSSetup) error {
+	var aliasSettings fleet.MacOSSettings
+	if _, err := aliasSettings.FromMap(spec.MDM.MacOSSettings); err != nil {
+		// applyTeamMacOSSettings surfaces map parsing errors with full context; here we only care
+		// about well-formed input
+		return fleet.NewUserMessageError(err, http.StatusBadRequest)
+	}
+
+	spec.MDM.MacOSSetup.EnableManagedLocalAccount = fleet.ResolveManagedLocalAccountAliasBool(
+		spec.MDM.MacOSSetup.EnableManagedLocalAccount,
+		aliasSettings.ManagedLocalAccountSettings.Enabled,
+		storedMacOSSetup.EnableManagedLocalAccount,
+	)
+	resolvedAccountType, err := fleet.ResolveManagedLocalAccountAliasAccountType(
+		spec.MDM.MacOSSetup.EndUserLocalAccountType,
+		aliasSettings.EndUserLocalAccountType,
+		storedMacOSSetup.EndUserLocalAccountType,
+	)
+	if err != nil {
+		return err
+	}
+	spec.MDM.MacOSSetup.EndUserLocalAccountType = resolvedAccountType
 	return nil
 }
 

--- a/ee/server/service/teams_test.go
+++ b/ee/server/service/teams_test.go
@@ -1412,3 +1412,299 @@ func TestModifyTeamMDMManagedLocalAccountRequiresMDM(t *testing.T) {
 	require.Contains(t, err.Error(), "setup_experience.enable_managed_local_account")
 	require.False(t, ds.SaveTeamFuncInvoked, "team should not have been saved")
 }
+
+// TestModifyTeamManagedLocalAccountAliases covers the new managed_local_account_settings surface
+// on the team PATCH endpoint (#48720): the Apple fields converge onto the deprecated MacOSSetup
+// fields, and the Windows field is stored on WindowsSettings.
+func TestModifyTeamManagedLocalAccountAliases(t *testing.T) {
+	setup := func(t *testing.T, windowsMDMConfigured bool) (*Service, *mock.Store, *[]string, context.Context) {
+		authorizer, err := authz.NewAuthorizer()
+		require.NoError(t, err)
+		ctx := test.UserContext(context.Background(),
+			&fleet.User{ID: 1, GlobalRole: new(fleet.RoleAdmin)})
+
+		ds := new(mock.Store)
+		ds.AppConfigFunc = func(context.Context) (*fleet.AppConfig, error) {
+			return &fleet.AppConfig{MDM: fleet.MDM{
+				EnabledAndConfigured:        true,
+				WindowsEnabledAndConfigured: windowsMDMConfigured,
+			}}, nil
+		}
+		ds.TeamWithExtrasFunc = func(_ context.Context, tid uint) (*fleet.Team, error) {
+			return &fleet.Team{ID: tid, Name: "team-1"}, nil
+		}
+		ds.SaveTeamFunc = func(_ context.Context, team *fleet.Team) (*fleet.Team, error) {
+			return team, nil
+		}
+
+		activities := &[]string{}
+		mockSvc := &svcmock.Service{}
+		mockSvc.HasCustomSetupAssistantConfigurationWebURLFunc = func(context.Context, *uint) (bool, error) {
+			return false, nil
+		}
+		mockSvc.NewActivityFunc = func(_ context.Context, _ *fleet.User, act fleet.ActivityDetails) error {
+			switch act.(type) {
+			case fleet.ActivityTypeEnabledManagedLocalAccount, fleet.ActivityTypeDisabledManagedLocalAccount:
+				*activities = append(*activities, act.ActivityName())
+			}
+			return nil
+		}
+
+		svc := &Service{
+			Service: mockSvc,
+			ds:      ds,
+			config:  config.FleetConfig{Server: config.ServerConfig{PrivateKey: "something"}},
+			authz:   authorizer,
+			logger:  slog.New(slog.DiscardHandler),
+		}
+		return svc, ds, activities, ctx
+	}
+
+	t.Run("apple new surface converges onto macos_setup", func(t *testing.T) {
+		svc, ds, activities, ctx := setup(t, true)
+		team, err := svc.ModifyTeam(ctx, 1, fleet.TeamPayload{MDM: &fleet.TeamPayloadMDM{
+			MacOSSettings: &fleet.TeamPayloadMacOSSettings{
+				ManagedLocalAccountSettings: fleet.ManagedLocalAccountSettings{Enabled: optjson.SetBool(true)},
+			},
+		}})
+		require.NoError(t, err)
+		require.True(t, ds.SaveTeamFuncInvoked)
+		require.True(t, team.Config.MDM.MacOSSetup.EnableManagedLocalAccount.Value)
+		require.Equal(t, []string{fleet.ActivityTypeEnabledManagedLocalAccount{}.ActivityName()}, *activities)
+	})
+
+	t.Run("changed surface wins over a stored echo across surfaces", func(t *testing.T) {
+		// stored is false, so the deprecated false is an unchanged echo (a GET-modify-PATCH
+		// round trip) and the new-surface true wins
+		svc, ds, _, ctx := setup(t, true)
+		team, err := svc.ModifyTeam(ctx, 1, fleet.TeamPayload{MDM: &fleet.TeamPayloadMDM{
+			MacOSSetup: &fleet.MacOSSetup{EnableManagedLocalAccount: optjson.SetBool(false)},
+			MacOSSettings: &fleet.TeamPayloadMacOSSettings{
+				ManagedLocalAccountSettings: fleet.ManagedLocalAccountSettings{Enabled: optjson.SetBool(true)},
+			},
+		}})
+		require.NoError(t, err)
+		require.True(t, ds.SaveTeamFuncInvoked)
+		require.True(t, team.Config.MDM.MacOSSetup.EnableManagedLocalAccount.Value)
+	})
+
+	t.Run("genuinely conflicting account types rejected", func(t *testing.T) {
+		// stored type is "admin"; both surfaces change it, to different values
+		svc, ds, _, ctx := setup(t, true)
+		_, err := svc.ModifyTeam(ctx, 1, fleet.TeamPayload{MDM: &fleet.TeamPayloadMDM{
+			MacOSSetup: &fleet.MacOSSetup{
+				EnableManagedLocalAccount: optjson.SetBool(true),
+				EndUserLocalAccountType:   optjson.SetString("standard"),
+			},
+			MacOSSettings: &fleet.TeamPayloadMacOSSettings{
+				EndUserLocalAccountType: optjson.SetString("none"),
+			},
+		}})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Conflicting values")
+		require.False(t, ds.SaveTeamFuncInvoked)
+	})
+
+	t.Run("windows toggle persists and fires activity", func(t *testing.T) {
+		svc, ds, activities, ctx := setup(t, true)
+		team, err := svc.ModifyTeam(ctx, 1, fleet.TeamPayload{MDM: &fleet.TeamPayloadMDM{
+			WindowsSettings: &fleet.TeamPayloadWindowsSettings{
+				ManagedLocalAccountSettings: fleet.ManagedLocalAccountSettings{Enabled: optjson.SetBool(true)},
+			},
+		}})
+		require.NoError(t, err)
+		require.True(t, ds.SaveTeamFuncInvoked)
+		require.True(t, team.Config.MDM.WindowsSettings.ManagedLocalAccountSettings.Enabled.Value)
+		require.False(t, team.Config.MDM.MacOSSetup.EnableManagedLocalAccount.Value)
+		require.Equal(t, []string{fleet.ActivityTypeEnabledManagedLocalAccount{}.ActivityName()}, *activities)
+	})
+
+	t.Run("alias-only patch skips end user authentication validation", func(t *testing.T) {
+		// a custom DEP setup assistant with configuration_web_url must not block a PATCH that
+		// only touches the managed local account fields (regression: synthesizing a MacOSSetup
+		// payload used to trigger validateEndUserAuthenticationAndSetupAssistant)
+		svc, ds, _, ctx := setup(t, true)
+		mockSvc := svc.Service.(*svcmock.Service)
+		mockSvc.HasCustomSetupAssistantConfigurationWebURLFunc = func(context.Context, *uint) (bool, error) {
+			return true, nil
+		}
+		team, err := svc.ModifyTeam(ctx, 1, fleet.TeamPayload{MDM: &fleet.TeamPayloadMDM{
+			MacOSSettings: &fleet.TeamPayloadMacOSSettings{
+				ManagedLocalAccountSettings: fleet.ManagedLocalAccountSettings{Enabled: optjson.SetBool(true)},
+			},
+		}})
+		require.NoError(t, err)
+		require.True(t, ds.SaveTeamFuncInvoked)
+		require.True(t, team.Config.MDM.MacOSSetup.EnableManagedLocalAccount.Value)
+		require.False(t, mockSvc.HasCustomSetupAssistantConfigurationWebURLFuncInvoked)
+	})
+
+	t.Run("windows enable requires windows MDM", func(t *testing.T) {
+		svc, ds, _, ctx := setup(t, false)
+		_, err := svc.ModifyTeam(ctx, 1, fleet.TeamPayload{MDM: &fleet.TeamPayloadMDM{
+			WindowsSettings: &fleet.TeamPayloadWindowsSettings{
+				ManagedLocalAccountSettings: fleet.ManagedLocalAccountSettings{Enabled: optjson.SetBool(true)},
+			},
+		}})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "windows_settings.managed_local_account_settings")
+		require.False(t, ds.SaveTeamFuncInvoked)
+	})
+}
+
+// TestApplyTeamSpecsManagedLocalAccount covers the GitOps team apply path for the new
+// managed_local_account_settings keys, including the regression where editTeamFromSpec copies
+// WindowsSettings selectively and would otherwise drop the Windows toggle.
+func TestApplyTeamSpecsManagedLocalAccount(t *testing.T) {
+	setup := func(t *testing.T, existing *fleet.Team) (*Service, *mock.Store, **fleet.Team, context.Context) {
+		authorizer, err := authz.NewAuthorizer()
+		require.NoError(t, err)
+		ctx := test.UserContext(context.Background(),
+			&fleet.User{ID: 1, GlobalRole: new(fleet.RoleAdmin)})
+
+		ds := new(mock.Store)
+		ds.AppConfigFunc = func(context.Context) (*fleet.AppConfig, error) {
+			return &fleet.AppConfig{MDM: fleet.MDM{
+				EnabledAndConfigured:        true,
+				WindowsEnabledAndConfigured: true,
+			}}, nil
+		}
+		ds.TeamByFilenameFunc = func(context.Context, string) (*fleet.Team, error) {
+			return nil, &notFoundError{}
+		}
+		ds.TeamByNameFunc = func(_ context.Context, name string) (*fleet.Team, error) {
+			if existing == nil {
+				return nil, &notFoundError{}
+			}
+			return existing, nil
+		}
+		ds.TeamConflictsWithNameFunc = func(context.Context, string, uint) (*fleet.Team, error) {
+			return nil, nil
+		}
+		saved := new(*fleet.Team)
+		ds.SaveTeamFunc = func(_ context.Context, team *fleet.Team) (*fleet.Team, error) {
+			*saved = team
+			return team, nil
+		}
+		ds.NewTeamFunc = func(_ context.Context, team *fleet.Team) (*fleet.Team, error) {
+			team.ID = 42
+			*saved = team
+			return team, nil
+		}
+		ds.TeamWithExtrasFunc = func(_ context.Context, tid uint) (*fleet.Team, error) {
+			return &fleet.Team{ID: tid, Name: "TestTeam"}, nil
+		}
+
+		mockSvc := &svcmock.Service{}
+		mockSvc.NewActivityFunc = func(context.Context, *fleet.User, fleet.ActivityDetails) error {
+			return nil
+		}
+
+		svc := &Service{
+			Service: mockSvc,
+			ds:      ds,
+			config:  config.FleetConfig{Server: config.ServerConfig{PrivateKey: "something"}},
+			authz:   authorizer,
+			logger:  slog.New(slog.DiscardHandler),
+		}
+		return svc, ds, saved, ctx
+	}
+
+	existingTeam := func() *fleet.Team {
+		return &fleet.Team{ID: 42, Name: "TestTeam"}
+	}
+
+	t.Run("edit persists the windows toggle", func(t *testing.T) {
+		svc, _, saved, ctx := setup(t, existingTeam())
+		spec := &fleet.TeamSpec{
+			Name: "TestTeam",
+			MDM: fleet.TeamSpecMDM{
+				WindowsSettings: fleet.WindowsSettings{
+					ManagedLocalAccountSettings: fleet.ManagedLocalAccountSettings{Enabled: optjson.SetBool(true)},
+				},
+			},
+		}
+		_, err := svc.ApplyTeamSpecs(ctx, []*fleet.TeamSpec{spec}, fleet.ApplyTeamSpecOptions{})
+		require.NoError(t, err)
+		require.NotNil(t, *saved)
+		require.True(t, (*saved).Config.MDM.WindowsSettings.ManagedLocalAccountSettings.Enabled.Value)
+	})
+
+	t.Run("edit converges the apple alias onto macos_setup", func(t *testing.T) {
+		svc, _, saved, ctx := setup(t, existingTeam())
+		spec := &fleet.TeamSpec{
+			Name: "TestTeam",
+			MDM: fleet.TeamSpecMDM{
+				MacOSSettings: map[string]any{
+					"managed_local_account_settings": map[string]any{"enabled": true},
+					"end_user_local_account_type":    "standard",
+				},
+			},
+		}
+		_, err := svc.ApplyTeamSpecs(ctx, []*fleet.TeamSpec{spec}, fleet.ApplyTeamSpecOptions{})
+		require.NoError(t, err)
+		require.NotNil(t, *saved)
+		require.True(t, (*saved).Config.MDM.MacOSSetup.EnableManagedLocalAccount.Value)
+		require.Equal(t, "standard", (*saved).Config.MDM.MacOSSetup.EndUserLocalAccountType.Value)
+	})
+
+	t.Run("edit resolves a stored echo in favor of the changed surface", func(t *testing.T) {
+		// stored is false, so the deprecated false (e.g. the gitops client's injected default)
+		// is an unchanged echo and the new-surface true wins
+		svc, _, saved, ctx := setup(t, existingTeam())
+		spec := &fleet.TeamSpec{
+			Name: "TestTeam",
+			MDM: fleet.TeamSpecMDM{
+				MacOSSettings: map[string]any{
+					"managed_local_account_settings": map[string]any{"enabled": true},
+				},
+				MacOSSetup: fleet.MacOSSetup{EnableManagedLocalAccount: optjson.SetBool(false)},
+			},
+		}
+		_, err := svc.ApplyTeamSpecs(ctx, []*fleet.TeamSpec{spec}, fleet.ApplyTeamSpecOptions{})
+		require.NoError(t, err)
+		require.NotNil(t, *saved)
+		require.True(t, (*saved).Config.MDM.MacOSSetup.EnableManagedLocalAccount.Value)
+	})
+
+	t.Run("edit rejects genuinely conflicting account types across surfaces", func(t *testing.T) {
+		// stored type is "admin"; both surfaces change it, to different values
+		svc, ds, _, ctx := setup(t, existingTeam())
+		spec := &fleet.TeamSpec{
+			Name: "TestTeam",
+			MDM: fleet.TeamSpecMDM{
+				MacOSSettings: map[string]any{
+					"end_user_local_account_type": "none",
+				},
+				MacOSSetup: fleet.MacOSSetup{
+					EnableManagedLocalAccount: optjson.SetBool(true),
+					EndUserLocalAccountType:   optjson.SetString("standard"),
+				},
+			},
+		}
+		_, err := svc.ApplyTeamSpecs(ctx, []*fleet.TeamSpec{spec}, fleet.ApplyTeamSpecOptions{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Conflicting values")
+		require.False(t, ds.SaveTeamFuncInvoked)
+	})
+
+	t.Run("create persists both platforms", func(t *testing.T) {
+		svc, _, saved, ctx := setup(t, nil)
+		spec := &fleet.TeamSpec{
+			Name: "TestTeam",
+			MDM: fleet.TeamSpecMDM{
+				MacOSSettings: map[string]any{
+					"managed_local_account_settings": map[string]any{"enabled": true},
+				},
+				WindowsSettings: fleet.WindowsSettings{
+					ManagedLocalAccountSettings: fleet.ManagedLocalAccountSettings{Enabled: optjson.SetBool(true)},
+				},
+			},
+		}
+		_, err := svc.ApplyTeamSpecs(ctx, []*fleet.TeamSpec{spec}, fleet.ApplyTeamSpecOptions{})
+		require.NoError(t, err)
+		require.NotNil(t, *saved)
+		require.True(t, (*saved).Config.MDM.MacOSSetup.EnableManagedLocalAccount.Value)
+		require.True(t, (*saved).Config.MDM.WindowsSettings.ManagedLocalAccountSettings.Enabled.Value)
+	})
+}

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -490,6 +490,12 @@ func (w WindowsUpdates) Validate() error {
 	return nil
 }
 
+// ManagedLocalAccountSettings configures the hidden managed local admin account for one platform.
+// Future fields (username, password policy) land here.
+type ManagedLocalAccountSettings struct {
+	Enabled optjson.Bool `json:"enabled"`
+}
+
 // MacOSSettings contains settings specific to macOS.
 type MacOSSettings struct {
 	// CustomSettings is a slice of configuration profile file paths.
@@ -506,6 +512,14 @@ type MacOSSettings struct {
 	// omitted from ToMap/FromMap.
 	Assets []MDMProfileSpec `json:"assets,omitempty"`
 
+	// ManagedLocalAccountSettings and EndUserLocalAccountType are aliases of the deprecated
+	// MacOSSetup.EnableManagedLocalAccount and MacOSSetup.EndUserLocalAccountType fields, which
+	// remain the stored source of truth. Writes on either surface converge onto MacOSSetup, and
+	// these fields are (re)populated from MacOSSetup when marshaling, so both surfaces always
+	// return consistent values (see SyncManagedLocalAccountAliases).
+	ManagedLocalAccountSettings ManagedLocalAccountSettings `json:"managed_local_account_settings"`
+	EndUserLocalAccountType     optjson.String              `json:"end_user_local_account_type"`
+
 	// NOTE: make sure to update the ToMap/FromMap methods when adding/updating fields.
 }
 
@@ -515,8 +529,10 @@ func (s MacOSSettings) GetMDMProfileSpecs() []MDMProfileSpec {
 
 func (s MacOSSettings) ToMap() map[string]interface{} {
 	return map[string]interface{}{
-		"custom_settings":        s.CustomSettings,
-		"enable_disk_encryption": s.DeprecatedEnableDiskEncryption,
+		"custom_settings":                s.CustomSettings,
+		"enable_disk_encryption":         s.DeprecatedEnableDiskEncryption,
+		"managed_local_account_settings": s.ManagedLocalAccountSettings,
+		"end_user_local_account_type":    s.EndUserLocalAccountType,
 	}
 }
 
@@ -593,6 +609,46 @@ func (s *MacOSSettings) FromMap(m map[string]interface{}) (map[string]bool, erro
 			}
 		}
 		s.DeprecatedEnableDiskEncryption = ptr.Bool(b)
+	}
+
+	if v, ok := m["managed_local_account_settings"]; ok {
+		set["managed_local_account_settings"] = true
+		if v != nil {
+			mlas, ok := v.(map[string]any)
+			if !ok {
+				return nil, &json.UnmarshalTypeError{
+					Value: fmt.Sprintf("%T", v),
+					Type:  reflect.TypeFor[ManagedLocalAccountSettings](),
+					Field: "macos_settings.managed_local_account_settings",
+				}
+			}
+			if ev, ok := mlas["enabled"]; ok && ev != nil {
+				b, ok := ev.(bool)
+				if !ok {
+					return nil, &json.UnmarshalTypeError{
+						Value: fmt.Sprintf("%T", ev),
+						Type:  reflect.TypeFor[bool](),
+						Field: "macos_settings.managed_local_account_settings.enabled",
+					}
+				}
+				s.ManagedLocalAccountSettings.Enabled = optjson.SetBool(b)
+			}
+		}
+	}
+
+	if v, ok := m["end_user_local_account_type"]; ok {
+		set["end_user_local_account_type"] = true
+		if v != nil {
+			str, ok := v.(string)
+			if !ok {
+				return nil, &json.UnmarshalTypeError{
+					Value: fmt.Sprintf("%T", v),
+					Type:  reflect.TypeFor[string](),
+					Field: "macos_settings.end_user_local_account_type",
+				}
+			}
+			s.EndUserLocalAccountType = optjson.SetString(str)
+		}
 	}
 
 	return set, nil
@@ -1279,9 +1335,85 @@ func (c AppConfig) MarshalJSON() ([]byte, error) {
 	if !c.MDM.MacOSSetup.EndUserLocalAccountType.Valid {
 		c.MDM.MacOSSetup.EndUserLocalAccountType = optjson.SetString("admin")
 	}
+	SyncManagedLocalAccountAliases(&c.MDM.MacOSSettings, c.MDM.MacOSSetup, &c.MDM.WindowsSettings)
 	type aliasConfig AppConfig
 	aa := aliasConfig(c)
 	return json.Marshal(aa)
+}
+
+// ResolveManagedLocalAccountAliasBool resolves a managed local account boolean written through
+// its deprecated surface (setup_experience) and/or its new alias surface (apple_settings) in one
+// payload. When both are provided with different values, the surface that changed relative to
+// the stored value wins: a GET-modify-PATCH round trip echoes the unchanged surface back with
+// the stored value, and rejecting that echo would break editing either field in an exported
+// config. The returned value is unset when neither surface provided one.
+func ResolveManagedLocalAccountAliasBool(deprecated, alias, stored optjson.Bool) optjson.Bool {
+	switch {
+	case !alias.Valid:
+		return deprecated
+	case !deprecated.Valid:
+		return alias
+	case deprecated.Value == alias.Value:
+		return deprecated
+	case deprecated.Value == stored.Value:
+		// the deprecated surface is an unchanged echo of the stored value
+		return alias
+	default:
+		// the alias surface echoes the stored value (with two boolean values, one side always
+		// matches the stored value when the two surfaces differ)
+		return deprecated
+	}
+}
+
+// ResolveManagedLocalAccountAliasAccountType is the string equivalent of
+// ResolveManagedLocalAccountAliasBool for end_user_local_account_type. Unlike the boolean, both
+// surfaces can differ from the stored value at once, which is a genuine conflict and returns an
+// error. An empty stored value means the "admin" default.
+func ResolveManagedLocalAccountAliasAccountType(deprecated, alias, stored optjson.String) (optjson.String, error) {
+	storedValue := stored.Value
+	if storedValue == "" {
+		storedValue = "admin"
+	}
+	switch {
+	case !alias.Valid:
+		return deprecated, nil
+	case !deprecated.Valid:
+		return alias, nil
+	case deprecated.Value == alias.Value:
+		return deprecated, nil
+	case deprecated.Value == storedValue:
+		// the deprecated surface is an unchanged echo of the stored value
+		return alias, nil
+	case alias.Value == storedValue:
+		// the alias surface is an unchanged echo of the stored value
+		return deprecated, nil
+	default:
+		return optjson.String{}, NewInvalidArgumentError("apple_settings.end_user_local_account_type",
+			"Conflicting values: `setup_experience.end_user_local_account_type` (deprecated) and `apple_settings.end_user_local_account_type` cannot be set to different values in the same request.")
+	}
+}
+
+// SyncManagedLocalAccountAliases populates the managed_local_account_settings alias fields under
+// macos_settings (a.k.a. apple_settings) from the canonical MacOSSetup values, and defaults the
+// Windows enabled flag, so marshaled output (API responses and stored JSON) always returns
+// consistent values on both surfaces. Called from AppConfig.MarshalJSON, Team.MarshalJSON, and
+// TeamConfig.Value.
+func SyncManagedLocalAccountAliases(macOSSettings *MacOSSettings, macOSSetup MacOSSetup, windowsSettings *WindowsSettings) {
+	enabled := macOSSetup.EnableManagedLocalAccount
+	if !enabled.Valid {
+		enabled = optjson.SetBool(false)
+	}
+	macOSSettings.ManagedLocalAccountSettings.Enabled = enabled
+
+	accountType := macOSSetup.EndUserLocalAccountType
+	if !accountType.Valid {
+		accountType = optjson.SetString("admin")
+	}
+	macOSSettings.EndUserLocalAccountType = accountType
+
+	if !windowsSettings.ManagedLocalAccountSettings.Enabled.Valid {
+		windowsSettings.ManagedLocalAccountSettings.Enabled = optjson.SetBool(false)
+	}
 }
 
 func (c *AppConfig) assignDeprecatedFields() {
@@ -2118,6 +2250,11 @@ type WindowsSettings struct {
 	// NOTE: These are only present here for informational purposes.
 	// (The source of truth for profiles is in MySQL.)
 	CustomSettings optjson.Slice[MDMProfileSpec] `json:"custom_settings" renameto:"configuration_profiles"`
+
+	// ManagedLocalAccountSettings configures the hidden managed local admin account created by
+	// fleetd on Windows hosts during Autopilot/OOBE enrollment. Unlike the macOS equivalent under
+	// MacOSSettings, this is the stored source of truth (there is no deprecated alias).
+	ManagedLocalAccountSettings ManagedLocalAccountSettings `json:"managed_local_account_settings"`
 }
 
 func (ws WindowsSettings) GetMDMProfileSpecs() []MDMProfileSpec {

--- a/server/fleet/app_test.go
+++ b/server/fleet/app_test.go
@@ -912,3 +912,181 @@ func TestMacOSSetupValidate(t *testing.T) {
 		}
 	})
 }
+
+func TestSyncManagedLocalAccountAliases(t *testing.T) {
+	t.Run("app config marshal populates aliases from macos_setup", func(t *testing.T) {
+		var ac AppConfig
+		ac.MDM.MacOSSetup.EnableManagedLocalAccount = optjson.SetBool(true)
+		ac.MDM.MacOSSetup.EndUserLocalAccountType = optjson.SetString("standard")
+
+		b, err := json.Marshal(ac)
+		require.NoError(t, err)
+
+		var out map[string]any
+		require.NoError(t, json.Unmarshal(b, &out))
+		mdm := out["mdm"].(map[string]any)
+		macOSSettings := mdm["macos_settings"].(map[string]any)
+		require.Equal(t, map[string]any{"enabled": true}, macOSSettings["managed_local_account_settings"])
+		require.Equal(t, "standard", macOSSettings["end_user_local_account_type"])
+		windowsSettings := mdm["windows_settings"].(map[string]any)
+		require.Equal(t, map[string]any{"enabled": false}, windowsSettings["managed_local_account_settings"])
+	})
+
+	t.Run("app config marshal defaults when macos_setup is unset", func(t *testing.T) {
+		var ac AppConfig
+
+		b, err := json.Marshal(ac)
+		require.NoError(t, err)
+
+		var out map[string]any
+		require.NoError(t, json.Unmarshal(b, &out))
+		mdm := out["mdm"].(map[string]any)
+		macOSSettings := mdm["macos_settings"].(map[string]any)
+		require.Equal(t, map[string]any{"enabled": false}, macOSSettings["managed_local_account_settings"])
+		require.Equal(t, "admin", macOSSettings["end_user_local_account_type"])
+	})
+
+	t.Run("marshal overrides stale alias values with the canonical ones", func(t *testing.T) {
+		var ac AppConfig
+		ac.MDM.MacOSSetup.EnableManagedLocalAccount = optjson.SetBool(false)
+		ac.MDM.MacOSSettings.ManagedLocalAccountSettings.Enabled = optjson.SetBool(true) // stale
+
+		b, err := json.Marshal(ac)
+		require.NoError(t, err)
+
+		var out map[string]any
+		require.NoError(t, json.Unmarshal(b, &out))
+		mdm := out["mdm"].(map[string]any)
+		macOSSettings := mdm["macos_settings"].(map[string]any)
+		require.Equal(t, map[string]any{"enabled": false}, macOSSettings["managed_local_account_settings"])
+	})
+
+	t.Run("windows enabled value is preserved", func(t *testing.T) {
+		var ac AppConfig
+		ac.MDM.WindowsSettings.ManagedLocalAccountSettings.Enabled = optjson.SetBool(true)
+
+		b, err := json.Marshal(ac)
+		require.NoError(t, err)
+
+		var out map[string]any
+		require.NoError(t, json.Unmarshal(b, &out))
+		mdm := out["mdm"].(map[string]any)
+		windowsSettings := mdm["windows_settings"].(map[string]any)
+		require.Equal(t, map[string]any{"enabled": true}, windowsSettings["managed_local_account_settings"])
+	})
+}
+
+func TestMacOSSettingsFromMapManagedLocalAccount(t *testing.T) {
+	t.Run("parses managed local account fields", func(t *testing.T) {
+		var s MacOSSettings
+		set, err := s.FromMap(map[string]any{
+			"managed_local_account_settings": map[string]any{"enabled": true},
+			"end_user_local_account_type":    "standard",
+		})
+		require.NoError(t, err)
+		require.True(t, set["managed_local_account_settings"])
+		require.True(t, set["end_user_local_account_type"])
+		require.True(t, s.ManagedLocalAccountSettings.Enabled.Valid)
+		require.True(t, s.ManagedLocalAccountSettings.Enabled.Value)
+		require.Equal(t, "standard", s.EndUserLocalAccountType.Value)
+	})
+
+	t.Run("absent keys leave fields unset", func(t *testing.T) {
+		var s MacOSSettings
+		set, err := s.FromMap(map[string]any{})
+		require.NoError(t, err)
+		require.False(t, set["managed_local_account_settings"])
+		require.False(t, s.ManagedLocalAccountSettings.Enabled.Valid)
+		require.False(t, s.EndUserLocalAccountType.Valid)
+	})
+
+	t.Run("non-object managed_local_account_settings errors", func(t *testing.T) {
+		var s MacOSSettings
+		_, err := s.FromMap(map[string]any{"managed_local_account_settings": "yes"})
+		require.Error(t, err)
+	})
+
+	t.Run("non-bool enabled errors", func(t *testing.T) {
+		var s MacOSSettings
+		_, err := s.FromMap(map[string]any{"managed_local_account_settings": map[string]any{"enabled": "yes"}})
+		require.Error(t, err)
+	})
+
+	t.Run("non-string end_user_local_account_type errors", func(t *testing.T) {
+		var s MacOSSettings
+		_, err := s.FromMap(map[string]any{"end_user_local_account_type": true})
+		require.Error(t, err)
+	})
+}
+
+func TestResolveManagedLocalAccountAliases(t *testing.T) {
+	t.Run("bool", func(t *testing.T) {
+		unset := optjson.Bool{}
+		cases := []struct {
+			name                      string
+			deprecated, alias, stored optjson.Bool
+			want                      optjson.Bool
+		}{
+			{"neither set", unset, unset, optjson.SetBool(false), unset},
+			{"only deprecated", optjson.SetBool(true), unset, optjson.SetBool(false), optjson.SetBool(true)},
+			{"only alias", unset, optjson.SetBool(true), optjson.SetBool(false), optjson.SetBool(true)},
+			{"both equal", optjson.SetBool(true), optjson.SetBool(true), optjson.SetBool(false), optjson.SetBool(true)},
+			{"deprecated echoes stored, alias wins", optjson.SetBool(false), optjson.SetBool(true), optjson.SetBool(false), optjson.SetBool(true)},
+			{"alias echoes stored, deprecated wins", optjson.SetBool(false), optjson.SetBool(true), optjson.SetBool(true), optjson.SetBool(false)},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				require.Equal(t, tc.want, ResolveManagedLocalAccountAliasBool(tc.deprecated, tc.alias, tc.stored))
+			})
+		}
+	})
+
+	t.Run("account type", func(t *testing.T) {
+		unset := optjson.String{}
+		cases := []struct {
+			name                      string
+			deprecated, alias, stored optjson.String
+			want                      optjson.String
+			wantErr                   bool
+		}{
+			{"neither set", unset, unset, optjson.SetString("admin"), unset, false},
+			{"only deprecated", optjson.SetString("standard"), unset, unset, optjson.SetString("standard"), false},
+			{"only alias", unset, optjson.SetString("standard"), unset, optjson.SetString("standard"), false},
+			{"both equal", optjson.SetString("none"), optjson.SetString("none"), unset, optjson.SetString("none"), false},
+			{"deprecated echoes stored, alias wins", optjson.SetString("admin"), optjson.SetString("standard"), optjson.SetString("admin"), optjson.SetString("standard"), false},
+			{"deprecated echoes empty stored as admin, alias wins", optjson.SetString("admin"), optjson.SetString("standard"), unset, optjson.SetString("standard"), false},
+			{"alias echoes stored, deprecated wins", optjson.SetString("standard"), optjson.SetString("admin"), optjson.SetString("admin"), optjson.SetString("standard"), false},
+			{"both changed to different values conflicts", optjson.SetString("standard"), optjson.SetString("none"), optjson.SetString("admin"), unset, true},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				got, err := ResolveManagedLocalAccountAliasAccountType(tc.deprecated, tc.alias, tc.stored)
+				if tc.wantErr {
+					require.ErrorContains(t, err, "Conflicting values")
+					return
+				}
+				require.NoError(t, err)
+				require.Equal(t, tc.want, got)
+			})
+		}
+	})
+}
+
+func TestAppConfigCloneManagedLocalAccountSettings(t *testing.T) {
+	var ac AppConfig
+	ac.MDM.MacOSSettings.ManagedLocalAccountSettings.Enabled = optjson.SetBool(true)
+	ac.MDM.MacOSSettings.EndUserLocalAccountType = optjson.SetString("standard")
+	ac.MDM.WindowsSettings.ManagedLocalAccountSettings.Enabled = optjson.SetBool(true)
+
+	cloned, err := ac.Clone()
+	require.NoError(t, err)
+	clonedAC := cloned.(*AppConfig)
+	require.Equal(t, ac.MDM.MacOSSettings, clonedAC.MDM.MacOSSettings)
+	require.Equal(t, ac.MDM.WindowsSettings, clonedAC.MDM.WindowsSettings)
+
+	// mutating the clone must not affect the original (plain value fields)
+	clonedAC.MDM.WindowsSettings.ManagedLocalAccountSettings.Enabled = optjson.SetBool(false)
+	clonedAC.MDM.MacOSSettings.EndUserLocalAccountType = optjson.SetString("admin")
+	require.True(t, ac.MDM.WindowsSettings.ManagedLocalAccountSettings.Enabled.Value)
+	require.Equal(t, "standard", ac.MDM.MacOSSettings.EndUserLocalAccountType.Value)
+}

--- a/server/fleet/teams.go
+++ b/server/fleet/teams.go
@@ -98,6 +98,25 @@ type TeamPayloadMDM struct {
 
 	MacOSSetup       *MacOSSetup    `json:"macos_setup"`
 	HostNameTemplate optjson.String `json:"name_template"`
+
+	// MacOSSettings and WindowsSettings expose only the managed local account surface on the team
+	// PATCH endpoint; configuration profiles are managed through their own endpoints. The macOS
+	// fields alias the deprecated MacOSSetup fields (see SyncManagedLocalAccountAliases).
+	MacOSSettings   *TeamPayloadMacOSSettings   `json:"macos_settings" renameto:"apple_settings"`
+	WindowsSettings *TeamPayloadWindowsSettings `json:"windows_settings"`
+}
+
+// TeamPayloadMacOSSettings is the subset of macos_settings (apple_settings) fields settable via
+// the team PATCH endpoint.
+type TeamPayloadMacOSSettings struct {
+	ManagedLocalAccountSettings ManagedLocalAccountSettings `json:"managed_local_account_settings"`
+	EndUserLocalAccountType     optjson.String              `json:"end_user_local_account_type"`
+}
+
+// TeamPayloadWindowsSettings is the subset of windows_settings fields settable via the team PATCH
+// endpoint.
+type TeamPayloadWindowsSettings struct {
+	ManagedLocalAccountSettings ManagedLocalAccountSettings `json:"managed_local_account_settings"`
 }
 
 // Team is the data representation for the "Team" concept (group of hosts and
@@ -160,6 +179,9 @@ func (t Team) MarshalJSON() ([]byte, error) {
 	// We do not want it be promoted to the parent struct, because it causes issues when using sqlx for scanning.
 	// Also need to implement json.Marshaler/Unmarshaler on each type that embeds Team so because it will be promoted
 	// to the parent struct.
+	// force-populate the managed local account alias fields so both API surfaces agree
+	SyncManagedLocalAccountAliases(&t.Config.MDM.MacOSSettings, t.Config.MDM.MacOSSetup, &t.Config.MDM.WindowsSettings)
+
 	x := struct {
 		ID          uint            `json:"id"`
 		CreatedAt   time.Time       `json:"created_at"`
@@ -460,6 +482,8 @@ func (t TeamConfig) Value() (driver.Value, error) {
 	if !t.MDM.MacOSSetup.EndUserLocalAccountType.Valid {
 		t.MDM.MacOSSetup.EndUserLocalAccountType = optjson.SetString("admin")
 	}
+	// keep the stored managed local account alias fields consistent with the canonical values
+	SyncManagedLocalAccountAliases(&t.MDM.MacOSSettings, t.MDM.MacOSSetup, &t.MDM.WindowsSettings)
 	return json.Marshal(t)
 }
 
@@ -750,6 +774,9 @@ func TeamSpecFromTeam(t *Team) (*TeamSpec, error) {
 	var mdmSpec TeamSpecMDM
 	mdmSpec.MacOSUpdates = t.Config.MDM.MacOSUpdates
 	mdmSpec.WindowsUpdates = t.Config.MDM.WindowsUpdates
+	// make sure the managed local account alias fields reflect the canonical values (teams stored
+	// before the alias fields existed have them unset in the config JSON)
+	SyncManagedLocalAccountAliases(&t.Config.MDM.MacOSSettings, t.Config.MDM.MacOSSetup, &t.Config.MDM.WindowsSettings)
 	mdmSpec.MacOSSettings = t.Config.MDM.MacOSSettings.ToMap()
 	delete(mdmSpec.MacOSSettings, "enable_disk_encryption")
 	mdmSpec.MacOSSetup = t.Config.MDM.MacOSSetup

--- a/server/fleet/teams_test.go
+++ b/server/fleet/teams_test.go
@@ -1,6 +1,7 @@
 package fleet
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 
@@ -394,4 +395,65 @@ func TestTeamConfigCopy(t *testing.T) {
 		require.True(t, clone.Features.EnableHostUsers)
 		require.Equal(t, "value1", *clone.Features.DetailQueryOverrides["key1"])
 	})
+}
+
+func TestTeamMDMCopyManagedLocalAccountSettings(t *testing.T) {
+	tm := &TeamMDM{
+		MacOSSettings: MacOSSettings{
+			ManagedLocalAccountSettings: ManagedLocalAccountSettings{Enabled: optjson.SetBool(true)},
+			EndUserLocalAccountType:     optjson.SetString("standard"),
+		},
+		MacOSSetup: MacOSSetup{
+			EnableManagedLocalAccount: optjson.SetBool(true),
+			EndUserLocalAccountType:   optjson.SetString("standard"),
+		},
+		WindowsSettings: WindowsSettings{
+			ManagedLocalAccountSettings: ManagedLocalAccountSettings{Enabled: optjson.SetBool(true)},
+		},
+	}
+	clone := tm.Copy()
+	require.NotSame(t, tm, clone)
+	require.Equal(t, tm, clone)
+
+	// mutating the copy must not affect the original (plain value fields)
+	clone.WindowsSettings.ManagedLocalAccountSettings.Enabled = optjson.SetBool(false)
+	require.True(t, tm.WindowsSettings.ManagedLocalAccountSettings.Enabled.Value)
+}
+
+func TestTeamMarshalSyncsManagedLocalAccountAliases(t *testing.T) {
+	team := Team{
+		ID:   1,
+		Name: "t1",
+		Config: TeamConfig{
+			MDM: TeamMDM{
+				MacOSSetup: MacOSSetup{
+					EnableManagedLocalAccount: optjson.SetBool(true),
+					EndUserLocalAccountType:   optjson.SetString("standard"),
+				},
+				WindowsSettings: WindowsSettings{
+					ManagedLocalAccountSettings: ManagedLocalAccountSettings{Enabled: optjson.SetBool(true)},
+				},
+			},
+		},
+	}
+
+	b, err := json.Marshal(team)
+	require.NoError(t, err)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(b, &out))
+	mdm := out["mdm"].(map[string]any)
+	macOSSettings := mdm["macos_settings"].(map[string]any)
+	require.Equal(t, map[string]any{"enabled": true}, macOSSettings["managed_local_account_settings"])
+	require.Equal(t, "standard", macOSSettings["end_user_local_account_type"])
+	windowsSettings := mdm["windows_settings"].(map[string]any)
+	require.Equal(t, map[string]any{"enabled": true}, windowsSettings["managed_local_account_settings"])
+
+	// the DB save path (TeamConfig.Value) must produce the same consistent view
+	v, err := team.Config.Value()
+	require.NoError(t, err)
+	var stored map[string]any
+	require.NoError(t, json.Unmarshal(v.([]byte), &stored))
+	storedMDM := stored["mdm"].(map[string]any)
+	storedMacOSSettings := storedMDM["macos_settings"].(map[string]any)
+	require.Equal(t, map[string]any{"enabled": true}, storedMacOSSettings["managed_local_account_settings"])
 }

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -859,6 +859,27 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 		appConfig.MDM.MacOSSetup.LockEndUserInfo = optjson.SetBool(appConfig.MDM.MacOSSetup.EnableEndUserAuthentication)
 	}
 
+	// macos_settings.managed_local_account_settings.enabled and
+	// macos_settings.end_user_local_account_type alias the deprecated macos_setup
+	// (setup_experience) fields; converge new-surface writes onto newAppConfig.MDM.MacOSSetup so
+	// the merge blocks below (and validateMDM) see a single canonical value. When both surfaces
+	// are written, the one that changed relative to the stored value wins (a GET-modify-PATCH
+	// round trip echoes the unchanged surface); genuinely conflicting writes are rejected.
+	newAppConfig.MDM.MacOSSetup.EnableManagedLocalAccount = fleet.ResolveManagedLocalAccountAliasBool(
+		newAppConfig.MDM.MacOSSetup.EnableManagedLocalAccount,
+		newAppConfig.MDM.MacOSSettings.ManagedLocalAccountSettings.Enabled,
+		oldAppConfig.MDM.MacOSSetup.EnableManagedLocalAccount,
+	)
+	resolvedAccountType, err := fleet.ResolveManagedLocalAccountAliasAccountType(
+		newAppConfig.MDM.MacOSSetup.EndUserLocalAccountType,
+		newAppConfig.MDM.MacOSSettings.EndUserLocalAccountType,
+		oldAppConfig.MDM.MacOSSetup.EndUserLocalAccountType,
+	)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err)
+	}
+	newAppConfig.MDM.MacOSSetup.EndUserLocalAccountType = resolvedAccountType
+
 	if !oldAppConfig.MDM.MacOSSetup.EnableManagedLocalAccount.Valid {
 		oldAppConfig.MDM.MacOSSetup.EnableManagedLocalAccount = optjson.SetBool(false)
 	}
@@ -875,6 +896,15 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 		appConfig.MDM.MacOSSetup.EndUserLocalAccountType = newAppConfig.MDM.MacOSSetup.EndUserLocalAccountType
 	} else {
 		appConfig.MDM.MacOSSetup.EndUserLocalAccountType = oldAppConfig.MDM.MacOSSetup.EndUserLocalAccountType
+	}
+
+	// windows_settings.managed_local_account_settings.enabled is stored as-is (no deprecated
+	// alias). Like EnableDiskEncryption above, an explicit JSON null means "not provided": keep
+	// the old value rather than persisting an invalid optjson state.
+	if newAppConfig.MDM.WindowsSettings.ManagedLocalAccountSettings.Enabled.Valid {
+		appConfig.MDM.WindowsSettings.ManagedLocalAccountSettings.Enabled = newAppConfig.MDM.WindowsSettings.ManagedLocalAccountSettings.Enabled
+	} else {
+		appConfig.MDM.WindowsSettings.ManagedLocalAccountSettings.Enabled = oldAppConfig.MDM.WindowsSettings.ManagedLocalAccountSettings.Enabled
 	}
 
 	if appConfig.MDM.MacOSSetup.ManualAgentInstall.Valid && appConfig.MDM.MacOSSetup.ManualAgentInstall.Value {
@@ -1165,6 +1195,11 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 			return nil, ctxerr.Wrap(ctx, err, "bootstrap psso assets")
 		}
 	}
+
+	// normalize the managed local account alias fields from the canonical values so the saved
+	// config doesn't carry whatever optjson state the payload happened to have (e.g. explicit
+	// nulls); marshaling does the same, this keeps the in-memory struct consistent too
+	fleet.SyncManagedLocalAccountAliases(&appConfig.MDM.MacOSSettings, appConfig.MDM.MacOSSetup, &appConfig.MDM.WindowsSettings)
 
 	if err := svc.ds.SaveAppConfig(ctx, appConfig); err != nil {
 		return nil, err
@@ -1537,7 +1572,8 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 		}
 	}
 
-	if oldAppConfig.MDM.MacOSSetup.EnableManagedLocalAccount.Value != appConfig.MDM.MacOSSetup.EnableManagedLocalAccount.Value {
+	macOSManagedLocalAccountChanged := oldAppConfig.MDM.MacOSSetup.EnableManagedLocalAccount.Value != appConfig.MDM.MacOSSetup.EnableManagedLocalAccount.Value
+	if macOSManagedLocalAccountChanged {
 		var act fleet.ActivityDetails
 		if appConfig.MDM.MacOSSetup.EnableManagedLocalAccount.Value {
 			act = fleet.ActivityTypeEnabledManagedLocalAccount{}
@@ -1546,6 +1582,22 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 		}
 		if err := svc.NewActivity(ctx, authz.UserFromContext(ctx), act); err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "create activity for macos enable managed local account change")
+		}
+	}
+
+	// The Windows toggle logs the same platform-agnostic activity types; skip it when the macOS
+	// toggle changed in the same direction in this request to avoid two identical entries.
+	if oldAppConfig.MDM.WindowsSettings.ManagedLocalAccountSettings.Enabled.Value != appConfig.MDM.WindowsSettings.ManagedLocalAccountSettings.Enabled.Value &&
+		!(macOSManagedLocalAccountChanged &&
+			appConfig.MDM.MacOSSetup.EnableManagedLocalAccount.Value == appConfig.MDM.WindowsSettings.ManagedLocalAccountSettings.Enabled.Value) {
+		var act fleet.ActivityDetails
+		if appConfig.MDM.WindowsSettings.ManagedLocalAccountSettings.Enabled.Value {
+			act = fleet.ActivityTypeEnabledManagedLocalAccount{}
+		} else {
+			act = fleet.ActivityTypeDisabledManagedLocalAccount{}
+		}
+		if err := svc.NewActivity(ctx, authz.UserFromContext(ctx), act); err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "create activity for windows enable managed local account change")
 		}
 	}
 
@@ -1881,6 +1933,26 @@ func (svc *Service) validateMDM(
 	if mdm.MacOSSetup.ManualAgentInstall.Valid && oldMdm.MacOSSetup.ManualAgentInstall.Value != mdm.MacOSSetup.ManualAgentInstall.Value && !lic.IsPremium() {
 		invalid.Append("setup_experience.macos_manual_agent_install", ErrMissingLicense.Error())
 	}
+	// managed local account settings (both platforms) and the Apple end user account type are
+	// premium-only. Compare resolved values so a free-tier payload echoing the defaults back
+	// (enabled false, type "admin") is not rejected.
+	if mdm.MacOSSetup.EnableManagedLocalAccount.Value != oldMdm.MacOSSetup.EnableManagedLocalAccount.Value && !lic.IsPremium() {
+		invalid.Append("apple_settings.managed_local_account_settings.enabled", ErrMissingLicense.Error())
+	}
+	oldAccountType := oldMdm.MacOSSetup.EndUserLocalAccountType.Value
+	if oldAccountType == "" {
+		oldAccountType = "admin"
+	}
+	newAccountType := mdm.MacOSSetup.EndUserLocalAccountType.Value
+	if newAccountType == "" {
+		newAccountType = "admin"
+	}
+	if newAccountType != oldAccountType && !lic.IsPremium() {
+		invalid.Append("apple_settings.end_user_local_account_type", ErrMissingLicense.Error())
+	}
+	if mdm.WindowsSettings.ManagedLocalAccountSettings.Enabled.Value != oldMdm.WindowsSettings.ManagedLocalAccountSettings.Enabled.Value && !lic.IsPremium() {
+		invalid.Append("windows_settings.managed_local_account_settings.enabled", ErrMissingLicense.Error())
+	}
 	if mdm.WindowsMigrationEnabled && !lic.IsPremium() {
 		invalid.Append("windows_migration_enabled", ErrMissingLicense.Error())
 	}
@@ -1950,6 +2022,12 @@ func (svc *Service) validateMDM(
 			!fleet.MDMProfileSpecsMatch(mdm.WindowsSettings.CustomSettings.Value, oldMdm.WindowsSettings.CustomSettings.Value) {
 			invalid.Append("windows_settings.configuration_profiles",
 				`Couldn’t edit windows_settings.configuration_profiles. Windows MDM isn’t turned on. This can be enabled by setting "controls.windows_enabled_and_configured: true" in the default configuration. Visit https://fleetdm.com/guides/windows-mdm-setup and https://fleetdm.com/docs/configuration/yaml-files#controls to learn more about enabling MDM.`)
+		}
+
+		if mdm.WindowsSettings.ManagedLocalAccountSettings.Enabled.Value &&
+			!oldMdm.WindowsSettings.ManagedLocalAccountSettings.Enabled.Value {
+			invalid.Append("windows_settings.managed_local_account_settings.enabled",
+				`Couldn’t enable windows_settings.managed_local_account_settings. Windows MDM isn’t turned on. This can be enabled by setting "controls.windows_enabled_and_configured: true" in the default configuration. Visit https://fleetdm.com/guides/windows-mdm-setup and https://fleetdm.com/docs/configuration/yaml-files#controls to learn more about enabling MDM.`)
 		}
 	}
 	fleet.ValidateMDMProfileSpecs(invalid, "windows", mdm.WindowsSettings.CustomSettings.Value)

--- a/server/service/appconfig_test.go
+++ b/server/service/appconfig_test.go
@@ -1224,8 +1224,13 @@ func TestMDMConfig(t *testing.T) {
 			IPadOSUpdates:           fleet.AppleOSUpdateSettings{MinimumVersion: optjson.String{Set: true}, Deadline: optjson.String{Set: true}},
 			VolumePurchasingProgram: optjson.Slice[fleet.MDMAppleVolumePurchasingProgramInfo]{Set: true, Value: []fleet.MDMAppleVolumePurchasingProgramInfo{}},
 			WindowsUpdates:          fleet.WindowsUpdates{DeadlineDays: optjson.Int{Set: true}, GracePeriodDays: optjson.Int{Set: true}},
+			MacOSSettings: fleet.MacOSSettings{
+				ManagedLocalAccountSettings: fleet.ManagedLocalAccountSettings{Enabled: optjson.SetBool(false)},
+				EndUserLocalAccountType:     optjson.SetString("admin"),
+			},
 			WindowsSettings: fleet.WindowsSettings{
-				CustomSettings: optjson.Slice[fleet.MDMProfileSpec]{Set: true, Value: []fleet.MDMProfileSpec{}},
+				CustomSettings:              optjson.Slice[fleet.MDMProfileSpec]{Set: true, Value: []fleet.MDMProfileSpec{}},
+				ManagedLocalAccountSettings: fleet.ManagedLocalAccountSettings{Enabled: optjson.SetBool(false)},
 			},
 			AndroidSettings: fleet.AndroidSettings{
 				CustomSettings: optjson.Slice[fleet.MDMProfileSpec]{Set: true, Value: []fleet.MDMProfileSpec{}},
@@ -3127,6 +3132,193 @@ func TestModifyAppConfigManagedLocalAccount(t *testing.T) {
 				wantActivities = []string{tt.wantActivity}
 			}
 			require.Equal(t, wantActivities, gotActivities)
+		})
+	}
+}
+
+// TestModifyAppConfigManagedLocalAccountAliases covers the new
+// apple_settings/windows_settings.managed_local_account_settings surface added for #48720: the
+// Apple fields alias the deprecated macos_setup (setup_experience) fields, and the Windows field
+// is stored as-is.
+func TestModifyAppConfigManagedLocalAccountAliases(t *testing.T) {
+	admin := &fleet.User{GlobalRole: new(fleet.RoleAdmin)}
+
+	type wantState struct {
+		macOSEnabled   bool
+		accountType    string
+		windowsEnabled bool
+	}
+
+	testCases := []struct {
+		name           string
+		freeTier       bool
+		startMacOS     bool
+		startWindows   bool
+		patch          string
+		wantErr        string
+		wantActivities []string
+		want           *wantState
+	}{
+		{
+			name:           "enable via new apple surface persists to macos_setup",
+			patch:          `{"mdm": {"macos_settings": {"managed_local_account_settings": {"enabled": true}}}}`,
+			wantActivities: []string{fleet.ActivityTypeEnabledManagedLocalAccount{}.ActivityName()},
+			want:           &wantState{macOSEnabled: true, accountType: "admin"},
+		},
+		{
+			name:           "enable via apple_settings alias key persists to macos_setup",
+			patch:          `{"mdm": {"apple_settings": {"managed_local_account_settings": {"enabled": true}}}}`,
+			wantActivities: []string{fleet.ActivityTypeEnabledManagedLocalAccount{}.ActivityName()},
+			want:           &wantState{macOSEnabled: true, accountType: "admin"},
+		},
+		{
+			name:           "account type via new surface persists to macos_setup",
+			patch:          `{"mdm": {"macos_settings": {"managed_local_account_settings": {"enabled": true}, "end_user_local_account_type": "standard"}}}`,
+			wantActivities: []string{fleet.ActivityTypeEnabledManagedLocalAccount{}.ActivityName()},
+			want:           &wantState{macOSEnabled: true, accountType: "standard"},
+		},
+		{
+			name: "both surfaces with different values: the changed surface wins over the stored echo",
+			// stored is false, so the deprecated false is an unchanged echo (a GET-modify-PATCH
+			// round trip) and the new-surface true wins
+			patch:          `{"mdm": {"macos_setup": {"enable_managed_local_account": false}, "macos_settings": {"managed_local_account_settings": {"enabled": true}}}}`,
+			wantActivities: []string{fleet.ActivityTypeEnabledManagedLocalAccount{}.ActivityName()},
+			want:           &wantState{macOSEnabled: true, accountType: "admin"},
+		},
+		{
+			name:       "deprecated surface wins when the new surface echoes the stored value",
+			startMacOS: true,
+			// stored is true, so alias true is the echo and the deprecated false is the change
+			patch:          `{"mdm": {"macos_setup": {"enable_managed_local_account": false}, "macos_settings": {"managed_local_account_settings": {"enabled": true}}}}`,
+			wantActivities: []string{fleet.ActivityTypeDisabledManagedLocalAccount{}.ActivityName()},
+			want:           &wantState{accountType: "admin"},
+		},
+		{
+			name: "genuinely conflicting account types rejected",
+			// stored type is "admin"; both surfaces change it, to different values
+			patch:   `{"mdm": {"macos_setup": {"enable_managed_local_account": true, "end_user_local_account_type": "standard"}, "macos_settings": {"end_user_local_account_type": "none"}}}`,
+			wantErr: "Conflicting values",
+		},
+		{
+			name:           "matching deprecated and new apple values accepted",
+			patch:          `{"mdm": {"macos_setup": {"enable_managed_local_account": true}, "macos_settings": {"managed_local_account_settings": {"enabled": true}}}}`,
+			wantActivities: []string{fleet.ActivityTypeEnabledManagedLocalAccount{}.ActivityName()},
+			want:           &wantState{macOSEnabled: true, accountType: "admin"},
+		},
+		{
+			name:           "windows enable persists and fires activity",
+			patch:          `{"mdm": {"windows_settings": {"managed_local_account_settings": {"enabled": true}}}}`,
+			wantActivities: []string{fleet.ActivityTypeEnabledManagedLocalAccount{}.ActivityName()},
+			want:           &wantState{accountType: "admin", windowsEnabled: true},
+		},
+		{
+			name:           "windows disable persists and fires activity",
+			startWindows:   true,
+			patch:          `{"mdm": {"windows_settings": {"managed_local_account_settings": {"enabled": false}}}}`,
+			wantActivities: []string{fleet.ActivityTypeDisabledManagedLocalAccount{}.ActivityName()},
+			want:           &wantState{accountType: "admin"},
+		},
+		{
+			name:         "windows null enabled means not provided",
+			startWindows: true,
+			patch:        `{"mdm": {"windows_settings": {"managed_local_account_settings": {"enabled": null}}}}`,
+			want:         &wantState{accountType: "admin", windowsEnabled: true},
+		},
+		{
+			name:           "enabling both platforms in one payload fires one activity",
+			patch:          `{"mdm": {"macos_settings": {"managed_local_account_settings": {"enabled": true}}, "windows_settings": {"managed_local_account_settings": {"enabled": true}}}}`,
+			wantActivities: []string{fleet.ActivityTypeEnabledManagedLocalAccount{}.ActivityName()},
+			want:           &wantState{macOSEnabled: true, accountType: "admin", windowsEnabled: true},
+		},
+		{
+			name:     "windows enable requires premium",
+			freeTier: true,
+			patch:    `{"mdm": {"windows_settings": {"managed_local_account_settings": {"enabled": true}}}}`,
+			wantErr:  "missing or invalid license",
+		},
+		{
+			name:     "apple enable via new surface requires premium",
+			freeTier: true,
+			patch:    `{"mdm": {"macos_settings": {"managed_local_account_settings": {"enabled": true}}}}`,
+			wantErr:  "missing or invalid license",
+		},
+		{
+			name:    "account type under windows_settings rejected",
+			patch:   `{"mdm": {"windows_settings": {"managed_local_account_settings": {"enabled": true}, "end_user_local_account_type": "admin"}}}`,
+			wantErr: "end_user_local_account_type",
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			ds := new(mock.Store)
+			tier := fleet.TierPremium
+			if tt.freeTier {
+				tier = fleet.TierFree
+			}
+			opts := &TestServerOpts{License: &fleet.LicenseInfo{Tier: tier}}
+			// keeping Windows MDM enabled across the PATCH requires a configured WSTEP cert/key pair
+			cfg := config.TestConfig()
+			cfg.MDM.WindowsWSTEPIdentityCert = "testdata/server.pem"
+			cfg.MDM.WindowsWSTEPIdentityKey = "testdata/server.key"
+			svc, ctx := newTestServiceWithConfig(t, ds, cfg, nil, nil, opts)
+			ctx = viewer.NewContext(ctx, viewer.Viewer{User: admin})
+
+			dsAppConfig := &fleet.AppConfig{
+				OrgInfo:        fleet.OrgInfo{OrgName: "Test"},
+				ServerSettings: fleet.ServerSettings{ServerURL: "https://example.org"},
+			}
+			dsAppConfig.MDM.EnabledAndConfigured = true
+			dsAppConfig.MDM.WindowsEnabledAndConfigured = true
+			dsAppConfig.MDM.MacOSSetup.EnableManagedLocalAccount = optjson.SetBool(tt.startMacOS)
+			dsAppConfig.MDM.WindowsSettings.ManagedLocalAccountSettings.Enabled = optjson.SetBool(tt.startWindows)
+
+			ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) { return dsAppConfig, nil }
+			ds.SaveAppConfigFunc = func(ctx context.Context, conf *fleet.AppConfig) error {
+				*dsAppConfig = *conf
+				return nil
+			}
+			ds.SaveABMTokenFunc = func(ctx context.Context, tok *fleet.ABMToken) error { return nil }
+			ds.ListVPPTokensFunc = func(ctx context.Context) ([]*fleet.VPPTokenDB, error) { return []*fleet.VPPTokenDB{}, nil }
+			ds.ListABMTokensFunc = func(ctx context.Context) ([]*fleet.ABMToken, error) { return []*fleet.ABMToken{}, nil }
+
+			var gotActivities []string
+			opts.ActivityMock.NewActivityFunc = func(_ context.Context, _ *activity_api.User, act activity_api.ActivityDetails) error {
+				switch act.(type) {
+				case fleet.ActivityTypeEnabledManagedLocalAccount, fleet.ActivityTypeDisabledManagedLocalAccount:
+					gotActivities = append(gotActivities, act.ActivityName())
+				}
+				return nil
+			}
+
+			_, err := svc.ModifyAppConfig(ctx, []byte(tt.patch), fleet.ApplySpecOptions{})
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantErr)
+				require.Empty(t, gotActivities)
+				require.False(t, ds.SaveAppConfigFuncInvoked, "config should not have been saved")
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantActivities, gotActivities)
+
+			require.Equal(t, tt.want.macOSEnabled, dsAppConfig.MDM.MacOSSetup.EnableManagedLocalAccount.Value)
+			require.Equal(t, tt.want.windowsEnabled, dsAppConfig.MDM.WindowsSettings.ManagedLocalAccountSettings.Enabled.Value)
+
+			// both API surfaces must agree in the marshaled config
+			b, err := json.Marshal(dsAppConfig)
+			require.NoError(t, err)
+			var out map[string]any
+			require.NoError(t, json.Unmarshal(b, &out))
+			mdm := out["mdm"].(map[string]any)
+			macOSSettings := mdm["macos_settings"].(map[string]any)
+			require.Equal(t, map[string]any{"enabled": tt.want.macOSEnabled}, macOSSettings["managed_local_account_settings"])
+			require.Equal(t, tt.want.accountType, macOSSettings["end_user_local_account_type"])
+			macOSSetup := mdm["macos_setup"].(map[string]any)
+			require.Equal(t, tt.want.macOSEnabled, macOSSetup["enable_managed_local_account"])
+			windowsSettings := mdm["windows_settings"].(map[string]any)
+			require.Equal(t, map[string]any{"enabled": tt.want.windowsEnabled}, windowsSettings["managed_local_account_settings"])
 		})
 	}
 }

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -2667,6 +2667,33 @@ func (c *Client) DoGitOps(
 		// update_new_hosts is only used for macOS so ignore any values posted for iPadOS
 		iPadOSUpdates["update_new_hosts"] = nil
 
+		// The apple_settings managed local account fields alias the deprecated setup_experience
+		// fields. Converge them onto macos_setup before the defaults below inject
+		// enable_managed_local_account: false, which would fight the new-surface value on the
+		// server. The gitops parser normalizes controls.macos_settings/windows_settings to their
+		// fleet struct types (see pkg/spec/gitops.go), so that is the shape asserted here.
+		if aliasSettings, ok := mdmAppConfig["macos_settings"].(fleet.MacOSSettings); ok {
+			if aliasSettings.ManagedLocalAccountSettings.Enabled.Valid || aliasSettings.EndUserLocalAccountType.Valid {
+				if incoming.Controls.MacOSSetup == nil {
+					incoming.Controls.MacOSSetup = &fleet.MacOSSetup{}
+				}
+				if enabled := aliasSettings.ManagedLocalAccountSettings.Enabled; enabled.Valid {
+					if incoming.Controls.MacOSSetup.EnableManagedLocalAccount.Valid &&
+						incoming.Controls.MacOSSetup.EnableManagedLocalAccount.Value != enabled.Value {
+						return nil, errors.New("Conflicting values: `controls.setup_experience.enable_create_local_admin_account` (deprecated) and `controls.apple_settings.managed_local_account_settings.enabled` cannot be set to different values in the same request.")
+					}
+					incoming.Controls.MacOSSetup.EnableManagedLocalAccount = enabled
+				}
+				if accountType := aliasSettings.EndUserLocalAccountType; accountType.Valid {
+					if incoming.Controls.MacOSSetup.EndUserLocalAccountType.Valid &&
+						incoming.Controls.MacOSSetup.EndUserLocalAccountType.Value != accountType.Value {
+						return nil, errors.New("Conflicting values: `controls.setup_experience.end_user_local_account_type` (deprecated) and `controls.apple_settings.end_user_local_account_type` cannot be set to different values in the same request.")
+					}
+					incoming.Controls.MacOSSetup.EndUserLocalAccountType = accountType
+				}
+			}
+		}
+
 		// Put in default values for macos_setup
 		if incoming.Controls.MacOSSetup != nil {
 			incoming.Controls.MacOSSetup.SetDefaultsIfNeeded()
@@ -2674,12 +2701,19 @@ func (c *Client) DoGitOps(
 		} else {
 			mdmAppConfig["macos_setup"] = fleet.NewMacOSSetupWithDefaults()
 		}
-		// Put in default values for windows_settings
+		// Put in default values for windows_settings. gitops is declarative: default the Windows
+		// managed local account toggle to disabled when the key is absent, so removing it from
+		// the YAML turns the feature off (mirrors the macos_setup defaults above).
 		if incoming.Controls.WindowsSettings != nil {
+			if ws, ok := incoming.Controls.WindowsSettings.(fleet.WindowsSettings); ok && !ws.ManagedLocalAccountSettings.Enabled.Valid {
+				ws.ManagedLocalAccountSettings.Enabled = optjson.SetBool(false)
+				incoming.Controls.WindowsSettings = ws
+			}
 			mdmAppConfig["windows_settings"] = incoming.Controls.WindowsSettings
 		} else {
 			mdmAppConfig["windows_settings"] = fleet.WindowsSettings{
-				CustomSettings: optjson.Slice[fleet.MDMProfileSpec]{Value: []fleet.MDMProfileSpec{}},
+				CustomSettings:              optjson.Slice[fleet.MDMProfileSpec]{Value: []fleet.MDMProfileSpec{}},
+				ManagedLocalAccountSettings: fleet.ManagedLocalAccountSettings{Enabled: optjson.SetBool(false)},
 			}
 		}
 		// Put in default values for android_settings

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -337,11 +337,18 @@ func (s *integrationEnterpriseTestSuite) TestTeamSpecs() {
 			EnableManagedLocalAccount:   optjson.SetBool(false),
 			EndUserLocalAccountType:     optjson.SetString("admin"),
 		},
+		// the managed local account alias fields are force-synced from the canonical
+		// macos_setup values when the team config is saved (see SyncManagedLocalAccountAliases)
+		MacOSSettings: fleet.MacOSSettings{
+			ManagedLocalAccountSettings: fleet.ManagedLocalAccountSettings{Enabled: optjson.SetBool(false)},
+			EndUserLocalAccountType:     optjson.SetString("admin"),
+		},
 		// because the WindowsSettings was marshalled to JSON to be saved in the DB,
 		// it did get marshalled, and then when unmarshalled it was set (but
 		// empty).
 		WindowsSettings: fleet.WindowsSettings{
-			CustomSettings: optjson.Slice[fleet.MDMProfileSpec]{Set: true, Value: []fleet.MDMProfileSpec{}},
+			CustomSettings:              optjson.Slice[fleet.MDMProfileSpec]{Set: true, Value: []fleet.MDMProfileSpec{}},
+			ManagedLocalAccountSettings: fleet.ManagedLocalAccountSettings{Enabled: optjson.SetBool(false)},
 		},
 		AndroidSettings: fleet.AndroidSettings{
 			CustomSettings: optjson.Slice[fleet.MDMProfileSpec]{Set: true, Value: []fleet.MDMProfileSpec{}},
@@ -469,8 +476,15 @@ func (s *integrationEnterpriseTestSuite) TestTeamSpecs() {
 			EnableManagedLocalAccount:   optjson.SetBool(false),
 			EndUserLocalAccountType:     optjson.SetString("admin"),
 		},
+		// the managed local account alias fields are force-synced from the canonical
+		// macos_setup values when the team config is saved (see SyncManagedLocalAccountAliases)
+		MacOSSettings: fleet.MacOSSettings{
+			ManagedLocalAccountSettings: fleet.ManagedLocalAccountSettings{Enabled: optjson.SetBool(false)},
+			EndUserLocalAccountType:     optjson.SetString("admin"),
+		},
 		WindowsSettings: fleet.WindowsSettings{
-			CustomSettings: optjson.Slice[fleet.MDMProfileSpec]{Set: true, Value: []fleet.MDMProfileSpec{}},
+			CustomSettings:              optjson.Slice[fleet.MDMProfileSpec]{Set: true, Value: []fleet.MDMProfileSpec{}},
+			ManagedLocalAccountSettings: fleet.ManagedLocalAccountSettings{Enabled: optjson.SetBool(false)},
 		},
 		AndroidSettings: fleet.AndroidSettings{
 			CustomSettings: optjson.Slice[fleet.MDMProfileSpec]{Set: true, Value: []fleet.MDMProfileSpec{}},
@@ -512,8 +526,15 @@ func (s *integrationEnterpriseTestSuite) TestTeamSpecs() {
 			EnableManagedLocalAccount:   optjson.SetBool(false),
 			EndUserLocalAccountType:     optjson.SetString("admin"),
 		},
+		// the managed local account alias fields are force-synced from the canonical
+		// macos_setup values when the team config is saved (see SyncManagedLocalAccountAliases)
+		MacOSSettings: fleet.MacOSSettings{
+			ManagedLocalAccountSettings: fleet.ManagedLocalAccountSettings{Enabled: optjson.SetBool(false)},
+			EndUserLocalAccountType:     optjson.SetString("admin"),
+		},
 		WindowsSettings: fleet.WindowsSettings{
-			CustomSettings: optjson.Slice[fleet.MDMProfileSpec]{Set: true, Value: []fleet.MDMProfileSpec{}},
+			CustomSettings:              optjson.Slice[fleet.MDMProfileSpec]{Set: true, Value: []fleet.MDMProfileSpec{}},
+			ManagedLocalAccountSettings: fleet.ManagedLocalAccountSettings{Enabled: optjson.SetBool(false)},
 		},
 		AndroidSettings: fleet.AndroidSettings{
 			CustomSettings: optjson.Slice[fleet.MDMProfileSpec]{Set: true, Value: []fleet.MDMProfileSpec{}},
@@ -557,8 +578,15 @@ func (s *integrationEnterpriseTestSuite) TestTeamSpecs() {
 			EnableManagedLocalAccount:   optjson.SetBool(false),
 			EndUserLocalAccountType:     optjson.SetString("admin"),
 		},
+		// the managed local account alias fields are force-synced from the canonical
+		// macos_setup values when the team config is saved (see SyncManagedLocalAccountAliases)
+		MacOSSettings: fleet.MacOSSettings{
+			ManagedLocalAccountSettings: fleet.ManagedLocalAccountSettings{Enabled: optjson.SetBool(false)},
+			EndUserLocalAccountType:     optjson.SetString("admin"),
+		},
 		WindowsSettings: fleet.WindowsSettings{
-			CustomSettings: optjson.Slice[fleet.MDMProfileSpec]{Set: true, Value: []fleet.MDMProfileSpec{}},
+			CustomSettings:              optjson.Slice[fleet.MDMProfileSpec]{Set: true, Value: []fleet.MDMProfileSpec{}},
+			ManagedLocalAccountSettings: fleet.ManagedLocalAccountSettings{Enabled: optjson.SetBool(false)},
 		},
 		AndroidSettings: fleet.AndroidSettings{
 			CustomSettings: optjson.Slice[fleet.MDMProfileSpec]{Set: true, Value: []fleet.MDMProfileSpec{}},
@@ -3460,8 +3488,15 @@ func (s *integrationEnterpriseTestSuite) TestWindowsUpdatesTeamConfig() {
 			EnableManagedLocalAccount:   optjson.SetBool(false),
 			EndUserLocalAccountType:     optjson.SetString("admin"),
 		},
+		// the managed local account alias fields are force-synced from the canonical
+		// macos_setup values when the team config is saved (see SyncManagedLocalAccountAliases)
+		MacOSSettings: fleet.MacOSSettings{
+			ManagedLocalAccountSettings: fleet.ManagedLocalAccountSettings{Enabled: optjson.SetBool(false)},
+			EndUserLocalAccountType:     optjson.SetString("admin"),
+		},
 		WindowsSettings: fleet.WindowsSettings{
-			CustomSettings: optjson.Slice[fleet.MDMProfileSpec]{Set: true, Value: []fleet.MDMProfileSpec{}},
+			CustomSettings:              optjson.Slice[fleet.MDMProfileSpec]{Set: true, Value: []fleet.MDMProfileSpec{}},
+			ManagedLocalAccountSettings: fleet.ManagedLocalAccountSettings{Enabled: optjson.SetBool(false)},
 		},
 		AndroidSettings: fleet.AndroidSettings{
 			CustomSettings: optjson.Slice[fleet.MDMProfileSpec]{Set: true, Value: []fleet.MDMProfileSpec{}},


### PR DESCRIPTION
Adds the new managed_local_account_settings object under apple_settings (macos_settings) and windows_settings for both global config and fleets, per the API contract in docs PRs #47915 and #48110 (story #43488).

- The Apple fields alias the deprecated setup_experience fields (enable_create_local_admin_account, end_user_local_account_type), which remain the stored source of truth. Marshaled output (API responses and stored JSON) force-syncs the alias fields so both surfaces always agree across every write path (config PATCH, team PATCH, setup-experience PATCH, GitOps apply).
- Writes on either surface converge through shared resolvers: when both surfaces are written with different values, the one that changed relative to the stored value wins (a GET-modify-PATCH round trip echoes the unchanged surface); genuinely conflicting account-type writes return 422.
- Windows has no deprecated alias: WindowsSettings stores the toggle directly. editTeamFromSpec now copies it (it previously copied only CustomSettings, which would silently drop the setting on team GitOps applies), and enabling it requires Windows MDM and a premium license.
- The enable/disable managed local account activities fire for the Windows toggle from the config PATCH and team apply paths, deduplicated when both platforms change in the same direction in one request.
- GitOps: the client converges the apple_settings alias onto macos_setup before injecting setup-experience defaults, and defaults the Windows toggle to disabled when the key is absent so removing it from YAML turns the feature off. fleetctl generate-gitops emits the new nested fields (and end_user_local_account_type when not "admin") instead of the shared setup_experience TODO placeholder.

Claude-Session: https://claude.ai/code/session_01L8PivHPDz7puhMUKMp3WA8

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added managed local account settings for macOS and Windows configuration.
  * Added GitOps support for enabling, disabling, and preserving managed local account settings.
  * Added Apple account-type configuration with compatibility for existing setup settings.
* **Bug Fixes**
  * Improved validation, conflict handling, default values, and activity reporting across configuration surfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->