### PR TITLE
fleetctl generate-gitops: export setup_experience section

### DIFF
--- a/changes/49833-generate-gitops-setup-experience
+++ b/changes/49833-generate-gitops-setup-experience
@@ -1,0 +1,1 @@
+- `fleetctl generate-gitops` now exports the `controls.setup_experience` section (Setup Assistant enrollment profile, setup script, and macOS setup toggles) instead of emitting a TODO placeholder. The bootstrap package is emitted as a TODO because Fleet downloads it from a URL that a UI-uploaded package doesn't have.

--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -1437,21 +1437,94 @@ func (cmd *GenerateGitopsCommand) generateControls(teamId *uint, teamName string
 			}
 			hasEnrollmentProfile := enrollmentProfile != nil
 
-			// If the team has any of these configured, we need to generate the macos_setup section.
+			// If the team has any of these configured, generate the setup_experience section.
 			if hasBootstrapPackage || hasSetupScript || hasEnrollmentProfile ||
 				(teamMdm != nil && (teamMdm.MacOSSetup.EnableEndUserAuthentication ||
 					teamMdm.MacOSSetup.EnableManagedLocalAccount.Value ||
 					(teamMdm.MacOSSetup.EndUserLocalAccountType.Valid && teamMdm.MacOSSetup.EndUserLocalAccountType.Value != "admin"))) {
-				result[jsonFieldName(mdmT, "MacOSSetup")] = "TODO: update with your setup_experience configuration"
-				cmd.Messages.Notes = append(cmd.Messages.Notes, Note{
-					Filename: teamName,
-					Note:     "The setup_experience configuration is not supported by this tool yet.  To configure it, please follow the Fleet documentation at https://fleetdm.com/docs/configuration/yaml-files#setup-experience",
-				})
+				setupExperience, err := cmd.generateSetupExperience(teamName, teamMdm, bootstrapPackage, setupScript, enrollmentProfile)
+				if err != nil {
+					fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error generating setup experience for %s: %s\n", teamName, err)
+					return nil, err
+				}
+				result[jsonFieldName(mdmT, "MacOSSetup")] = setupExperience
 			}
 		}
 	}
 
 	return result, nil
+}
+
+// generateSetupExperience builds the controls.setup_experience (macOS setup) section.
+// It writes the Setup Assistant (automatic enrollment) profile and the setup script to
+// files and references them by path. The bootstrap package can't be fully generated:
+// Fleet downloads it from a URL at apply time, and a package uploaded through the UI has
+// no external URL, so we emit a TODO placeholder plus a note.
+func (cmd *GenerateGitopsCommand) generateSetupExperience(
+	teamName string,
+	teamMdm *fleet.TeamMDM,
+	bootstrapPackage *fleet.MDMAppleBootstrapPackage,
+	setupScript *fleet.Script,
+	enrollmentProfile *fleet.MDMAppleSetupAssistant,
+) (map[string]interface{}, error) {
+	msT := reflect.TypeOf(fleet.MacOSSetup{})
+	setupExperience := map[string]interface{}{}
+
+	// macOS setup toggles.
+	if teamMdm != nil {
+		ms := teamMdm.MacOSSetup
+		setupExperience[jsonFieldName(msT, "EnableEndUserAuthentication")] = ms.EnableEndUserAuthentication
+		if ms.EnableReleaseDeviceManually.Valid {
+			setupExperience[jsonFieldName(msT, "EnableReleaseDeviceManually")] = ms.EnableReleaseDeviceManually.Value
+		}
+		if ms.ManualAgentInstall.Valid {
+			setupExperience[jsonFieldName(msT, "ManualAgentInstall")] = ms.ManualAgentInstall.Value
+		}
+		if ms.EnableManagedLocalAccount.Valid {
+			setupExperience[jsonFieldName(msT, "EnableManagedLocalAccount")] = ms.EnableManagedLocalAccount.Value
+		}
+		if ms.EndUserLocalAccountType.Valid && ms.EndUserLocalAccountType.Value != "" {
+			setupExperience[jsonFieldName(msT, "EndUserLocalAccountType")] = ms.EndUserLocalAccountType.Value
+		}
+	}
+
+	// Setup Assistant (automatic enrollment) profile: write the JSON to a file and reference it.
+	if enrollmentProfile != nil {
+		fileName := fmt.Sprintf("lib/%s/setup-experience/setup-assistant.json", teamName)
+		var pretty bytes.Buffer
+		if err := json.Indent(&pretty, enrollmentProfile.Profile, "", "  "); err == nil {
+			cmd.FilesToWrite[fileName] = pretty.String()
+		} else {
+			cmd.FilesToWrite[fileName] = string(enrollmentProfile.Profile)
+		}
+		setupExperience[jsonFieldName(msT, "MacOSSetupAssistant")] = fmt.Sprintf("../%s", fileName)
+	}
+
+	// Setup script: write the contents to a file and reference it.
+	if setupScript != nil {
+		contents, err := cmd.Client.GetScriptContents(setupScript.ID)
+		if err != nil {
+			return nil, fmt.Errorf("getting setup experience script contents: %w", err)
+		}
+		fileName := fmt.Sprintf("lib/%s/setup-experience/setup-script.sh", teamName)
+		cmd.FilesToWrite[fileName] = string(contents)
+		setupExperience[jsonFieldName(msT, "Script")] = fmt.Sprintf("../%s", fileName)
+	}
+
+	// Bootstrap package: Fleet downloads this from a URL at apply time. A package uploaded through
+	// the UI has no external URL to export, so leave a TODO and a note pointing to the docs.
+	if bootstrapPackage != nil {
+		setupExperience[jsonFieldName(msT, "BootstrapPackage")] = fmt.Sprintf(
+			"TODO: host %q at a URL Fleet can download, then set macos_bootstrap_package to that URL", bootstrapPackage.Name)
+		cmd.Messages.Notes = append(cmd.Messages.Notes, Note{
+			Filename: teamName,
+			Note: fmt.Sprintf(
+				"The bootstrap package %q was uploaded through the UI and has no URL to export. Host it where Fleet can download it and set setup_experience.macos_bootstrap_package to that URL. See https://fleetdm.com/docs/configuration/yaml-files#macos-setup",
+				bootstrapPackage.Name),
+		})
+	}
+
+	return setupExperience, nil
 }
 
 func (cmd *GenerateGitopsCommand) generateProfiles(teamId *uint, teamName string) (map[string]interface{}, error) {

--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -818,6 +818,7 @@ func (MockClient) GetBootstrapPackageMetadata(teamID uint, forUpdate bool) (*fle
 func (MockClient) GetSetupExperienceScript(teamID uint) (*fleet.Script, error) {
 	if teamID == 4 {
 		return &fleet.Script{
+			ID:   2,
 			Name: "Setup Experience Script for Team 1",
 		}, nil
 	}
@@ -830,7 +831,8 @@ func (MockClient) GetSetupExperienceScript(teamID uint) (*fleet.Script, error) {
 func (MockClient) GetAppleMDMEnrollmentProfile(teamID uint) (*fleet.MDMAppleSetupAssistant, error) {
 	if teamID == 5 {
 		return &fleet.MDMAppleSetupAssistant{
-			Name: "Apple MDM Enrollment Profile for Team 1",
+			Name:    "Apple MDM Enrollment Profile for Team 1",
+			Profile: json.RawMessage(`{"profile_name":"Fleet Setup Assistant"}`),
 		}, nil
 	}
 	if teamID == 0 || teamID == 1 || teamID == 2 || teamID == 3 || teamID == 4 {
@@ -1624,16 +1626,27 @@ func TestGenerateControls(t *testing.T) {
 	controlsRaw, err = cmd.generateControls(ptr.Uint(3), "some_team", nil)
 	require.NoError(t, err)
 	verifyControlsHasMacosSetup(t, controlsRaw)
+	// The bootstrap package has no URL to export, so we emit a TODO for the URL.
+	setupExperience := controlsRaw["setup_experience"].(map[string]interface{})
+	require.Contains(t, setupExperience["macos_bootstrap_package"], "TODO")
 
 	// Generate controls for a team with a setup experience script.
 	controlsRaw, err = cmd.generateControls(ptr.Uint(4), "some_team", nil)
 	require.NoError(t, err)
 	verifyControlsHasMacosSetup(t, controlsRaw)
+	// The script contents are written to a file and referenced by path.
+	setupExperience = controlsRaw["setup_experience"].(map[string]interface{})
+	require.Equal(t, "../lib/some_team/setup-experience/setup-script.sh", setupExperience["macos_script"])
+	require.Equal(t, "pop goes the weasel!", cmd.FilesToWrite["lib/some_team/setup-experience/setup-script.sh"])
 
 	// Generate controls for a team with a setup experience profile.
 	controlsRaw, err = cmd.generateControls(ptr.Uint(5), "some_team", nil)
 	require.NoError(t, err)
 	verifyControlsHasMacosSetup(t, controlsRaw)
+	// The enrollment profile JSON is written to a file and referenced by path.
+	setupExperience = controlsRaw["setup_experience"].(map[string]interface{})
+	require.Equal(t, "../lib/some_team/setup-experience/setup-assistant.json", setupExperience["apple_setup_assistant"])
+	require.Contains(t, cmd.FilesToWrite["lib/some_team/setup-experience/setup-assistant.json"], "Fleet Setup Assistant")
 }
 
 func TestGenerateSoftware(t *testing.T) {
@@ -2115,9 +2128,9 @@ func TestGenerateLabels(t *testing.T) {
 }
 
 func verifyControlsHasMacosSetup(t *testing.T, controlsRaw map[string]interface{}) {
-	macosSetup, ok := controlsRaw["setup_experience"].(string)
-	require.True(t, ok, "Expected setup_experience section to be a string")
-	require.Equal(t, macosSetup, "TODO: update with your setup_experience configuration")
+	setupExperience, ok := controlsRaw["setup_experience"].(map[string]interface{})
+	require.True(t, ok, "Expected setup_experience section to be a map")
+	require.NotEmpty(t, setupExperience, "Expected setup_experience section to be non-empty")
 }
 
 func TestGenerateControlsAndMDMWithoutMDMEnabledAndConfigured(t *testing.T) {


### PR DESCRIPTION
**Related issue:** #49833

> Draft — partial by design, and not yet manually QA'd against a live Fleet instance (see the unchecked box below). Opening for discussion on how to handle the bootstrap package.

# What this does

`fleetctl generate-gitops` currently emits `setup_experience: "TODO: update with your setup_experience configuration"` instead of the real config. This replaces that with actual generation of `controls.setup_experience`:

- **Setup Assistant (ADE) profile** — writes the enrollment profile JSON to `lib/<team>/setup-experience/setup-assistant.json` and references it via `apple_setup_assistant`.
- **Setup script** — writes the script contents to `lib/<team>/setup-experience/setup-script.sh` and references it via `macos_script`.
- **macOS setup toggles** — `enable_end_user_authentication`, `apple_enable_release_device_manually`, `macos_manual_agent_install`, `enable_create_local_admin_account`, `end_user_local_account_type`.
- **Bootstrap package** — emitted as a `TODO` with a note, because Fleet downloads it from a URL at apply time and a UI-uploaded package has no external URL to export. **This is the open design question for the issue.**

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented, JS inline code is prevented, and untrusted data interpolated into shell scripts/commands is validated.
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops (N/A)
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes (N/A)

## Testing

- [x] Added/updated automated tests (`TestGenerateControls` covers bootstrap TODO, setup script file+path, and enrollment profile file+path)
- [ ] QA'd all new/changed functionality manually — **pending**: not yet run end-to-end via `fleetctl generate-gitops` against a live instance with these settings configured.

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps
- [x] Verified that the setting is exported via `fleetctl generate-gitops` (that's the point of this PR; bootstrap package is a documented TODO)
- [ ] Verified the setting is documented in a separate PR to the GitOps documentation (already documented under `#macos-setup`)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled (N/A)