### PR TITLE
Add patch_when_closed to GitOps and generate-gitops

### DIFF
--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -1728,6 +1728,7 @@ func (cmd *GenerateGitopsCommand) generatePolicies(teamId *uint, filePath string
 				return nil, err
 			}
 			policySpec["fleet_maintained_app_slug"] = fma.Slug
+			policySpec[jsonFieldName(t, "PatchWhenClosed")] = policy.PatchWhenClosed
 		}
 		if policy.Type != "" {
 			policySpec["type"] = policy.Type

--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -440,6 +440,7 @@ func (MockClient) GetPolicies(teamID *uint) ([]*fleet.Policy, error) {
 				Platform:                 "linux,windows",
 				ConditionalAccessEnabled: true,
 				Type:                     fleet.PolicyTypePatch,
+				PatchWhenClosed:          true,
 			},
 			PatchSoftware: &fleet.PolicySoftwareTitle{
 				SoftwareTitleID: 8,

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamPolicies.yaml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamPolicies.yaml
@@ -17,6 +17,7 @@
   critical: false
   description: This is a team patch policy
   name: Team patch policy
+  patch_when_closed: true
   platform: linux,windows
   query: SELECT * FROM team_policy WHERE id = 1
   resolution: Do a team thing

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/fleets/team-a-thumbsup.yml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/fleets/team-a-thumbsup.yml
@@ -70,6 +70,7 @@ policies:
   description: This is a team patch policy
   fleet_maintained_app_slug: foo/darwin
   name: Team patch policy
+  patch_when_closed: true
   platform: linux,windows
   resolution: Do a team thing
   type: patch

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/fleets/unassigned.yml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/fleets/unassigned.yml
@@ -55,6 +55,7 @@ policies:
   description: This is a team patch policy
   fleet_maintained_app_slug: foo/darwin
   name: Team patch policy
+  patch_when_closed: true
   platform: linux,windows
   resolution: Do a team thing
   type: patch

--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
@@ -3870,6 +3870,112 @@ func (s *enterpriseIntegrationGitopsTestSuite) setupDarwinFMA(t *testing.T) (slu
 	return slug, installerServer.URL
 }
 
+func (s *enterpriseIntegrationGitopsTestSuite) TestGitOpsPatchWhenClosed() {
+	t := s.T()
+	ctx := context.Background()
+
+	user := s.createGitOpsUser(t)
+	fleetctlConfig := s.createFleetctlConfig(t, user)
+	t.Setenv("FLEET_URL", s.Server.URL)
+
+	slug, installer := s.setupDarwinFMA(t)
+	teamName := uuid.NewString()
+
+	manifestServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/"+slug+".json" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(ma.FMAManifestFile{
+			Versions: []*ma.FMAManifestApp{{
+				Version:            "1.0",
+				Queries:            ma.FMAQueries{Exists: "SELECT 1 FROM osquery_info;"},
+				InstallerURL:       installer + "/foo.pkg",
+				InstallScriptRef:   "fooscript",
+				UninstallScriptRef: "fooscript",
+				SHA256:             "no_check", // See ma.noCheckHash
+			}},
+			Refs: map[string]string{"fooscript": "echo hello"},
+		})
+	}))
+	t.Cleanup(manifestServer.Close)
+	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_BASE_URL", manifestServer.URL, t)
+
+	const globalConfig = `
+agent_options:
+controls:
+org_settings:
+  server_settings:
+    server_url: $FLEET_URL
+  org_info:
+    org_name: Fleet
+  secrets:
+policies:
+reports:
+`
+	globalFile := filepath.Join(t.TempDir(), "global.yml")
+	require.NoError(t, os.WriteFile(globalFile, []byte(globalConfig), 0o644))
+	teamFile := filepath.Join(t.TempDir(), "team.yml")
+
+	teamCfg := func(policyBody string) string {
+		return fmt.Sprintf(`
+controls:
+software:
+  fleet_maintained_apps:
+    - slug: %s
+policies:
+%s
+agent_options:
+name: %s
+settings:
+  secrets: [{"secret":"enroll_secret"}]
+reports:
+`, slug, policyBody, teamName)
+	}
+	apply := func(policyBody string) {
+		require.NoError(t, os.WriteFile(teamFile, []byte(teamCfg(policyBody)), 0o644))
+		s.assertRealRunOutput(t, fleetctltest.RunAppForTest(t, []string{
+			"gitops", "--config", fleetctlConfig.Name(), "-f", globalFile, "-f", teamFile,
+		}))
+	}
+
+	// patch_when_closed with continuous_automations omitted: applies and auto-sets it on.
+	pwcOmittedCA := fmt.Sprintf(`  - name: patch-policy
+    type: patch
+    fleet_maintained_app_slug: %s
+    patch_when_closed: true`, slug)
+	apply(pwcOmittedCA)
+
+	team, err := s.DS.TeamByName(ctx, teamName)
+	require.NoError(t, err)
+	pols, err := s.DS.ListMergedTeamPolicies(ctx, team.ID, fleet.ListOptions{}, "", "")
+	require.NoError(t, err)
+	require.Len(t, pols, 1)
+	require.Equal(t, "patch-policy", pols[0].Name)
+	require.True(t, pols[0].PatchWhenClosed, "patch_when_closed should persist")
+	require.True(t, pols[0].ContinuousAutomationsEnabled, "continuous automations should be auto-set on")
+	firstID := pols[0].ID
+
+	// Re-applying the same config is a no-op: the policy keeps its ID and flags.
+	apply(pwcOmittedCA)
+	pols, err = s.DS.ListMergedTeamPolicies(ctx, team.ID, fleet.ListOptions{}, "", "")
+	require.NoError(t, err)
+	require.Len(t, pols, 1)
+	require.Equal(t, firstID, pols[0].ID, "re-apply should be a no-op")
+	require.True(t, pols[0].PatchWhenClosed)
+	require.True(t, pols[0].ContinuousAutomationsEnabled)
+
+	// An explicit continuous_automations_enabled: false is rejected end-to-end.
+	require.NoError(t, os.WriteFile(teamFile, []byte(teamCfg(fmt.Sprintf(`  - name: patch-policy
+    type: patch
+    fleet_maintained_app_slug: %s
+    continuous_automations_enabled: false
+    patch_when_closed: true`, slug))), 0o644))
+	fleetctltest.RunAppCheckErr(t, []string{
+		"gitops", "--config", fleetctlConfig.Name(), "-f", globalFile, "-f", teamFile,
+	}, `"continuous_automations_enabled" must be true when "patch_when_closed" is true`)
+}
+
 func (s *enterpriseIntegrationGitopsTestSuite) TestGitOpsRemovedFMAEmitsPolicyDeletedActivities() {
 	t := s.T()
 	ctx := context.Background()

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -968,9 +968,15 @@ func (svc *Service) reconcilePatchPolicy(ctx context.Context, payload *fleet.Upd
 	if payload.PatchWhenClosed != nil && *payload.PatchWhenClosed && !patchEnabled {
 		return &fleet.BadRequestError{Message: `"patch_when_closed" requires "patch" to be enabled.`}
 	}
-	patchWhenClosed := patchEnabled && existing != nil && existing.PatchWhenClosed
-	if payload.PatchWhenClosed != nil {
-		patchWhenClosed = patchEnabled && *payload.PatchWhenClosed
+	// Default patch_when_closed on for a new patch policy, otherwise keep the existing value.
+	patchWhenClosed := existing != nil && existing.PatchWhenClosed
+	switch {
+	case !patchEnabled:
+		patchWhenClosed = false
+	case payload.PatchWhenClosed != nil:
+		patchWhenClosed = *payload.PatchWhenClosed
+	case existing == nil:
+		patchWhenClosed = true
 	}
 
 	// While Fleet's managed query owns the pre-install condition, the user query can't be edited.

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -488,7 +488,7 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 
 	// The patch controls only apply to Fleet-maintained apps.
 	if (payload.Patch != nil || payload.PatchWhenClosed != nil) && existingInstaller.FleetMaintainedAppID == nil {
-		return nil, &fleet.BadRequestError{Message: `"patch" and "patch_when_closed" are only supported for Fleet-maintained apps.`}
+		return nil, &fleet.BadRequestError{Message: `"patch" and "patch_when_closed" are only available for Fleet-maintained apps.`}
 	}
 
 	if payload.DisplayName != nil && *payload.DisplayName != software.DisplayName {
@@ -979,9 +979,9 @@ func (svc *Service) reconcilePatchPolicy(ctx context.Context, payload *fleet.Upd
 		patchWhenClosed = true
 	}
 
-	// While Fleet's managed query owns the pre-install condition, the user query can't be edited.
-	if patchWhenClosed && payload.PreInstallQuery != nil && *payload.PreInstallQuery != installer.PreInstallQuery {
-		return &fleet.BadRequestError{Message: `Couldn't edit. The pre-install query is managed by Fleet while "patch_when_closed" is enabled and can't be edited.`}
+	// The pre-install query is read-only while patch_when_closed is enabled.
+	if patchWhenClosed && payload.PreInstallQuery != nil {
+		return &fleet.BadRequestError{Message: `Couldn't edit. "pre_install_query" is managed by Fleet and can't be set directly while "patch_when_closed" is enabled.`}
 	}
 
 	teamID := ptr.ValOrZero(payload.TeamID)

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -486,6 +486,14 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 
 	payload.InstallerID = existingInstaller.InstallerID
 
+	// Resolve the resulting patch-policy state up front so we can reject a user pre-install
+	// query edit while the managed query owns it. The policy itself is reconciled after the
+	// installer row is saved.
+	patchPlan, err := svc.planPatchPolicy(ctx, payload, existingInstaller)
+	if err != nil {
+		return nil, err
+	}
+
 	if payload.DisplayName != nil && *payload.DisplayName != software.DisplayName {
 		trimmed := strings.TrimSpace(*payload.DisplayName)
 		if trimmed == "" && *payload.DisplayName != "" {
@@ -638,6 +646,11 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 	// default pre-install query is blank, so blanking out the query doesn't have a semantic meaning we have to take care of
 	if payload.PreInstallQuery != nil {
 		if *payload.PreInstallQuery != existingInstaller.PreInstallQuery {
+			if patchPlan.managed() {
+				return nil, &fleet.BadRequestError{
+					Message: `Couldn't edit. The pre-install query is managed by Fleet while "patch_when_closed" is enabled and can't be edited.`,
+				}
+			}
 			dirty["PreInstallQuery"] = true
 		}
 	}
@@ -918,6 +931,10 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 		}
 	}
 
+	if err := svc.applyPatchPolicyPlan(ctx, payload, patchPlan); err != nil {
+		return nil, err
+	}
+
 	// re-pull the edited installer to reflect side effects; return that specific
 	// package, not the title's first-added one. May be able to optimize this out later.
 	updatedInstaller, err := svc.ds.GetSoftwareInstallerMetadataByTeamTitleAndInstallerID(ctxdb.RequirePrimary(ctx, true), payload.TeamID, payload.TitleID, payload.InstallerID, true)
@@ -932,6 +949,111 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 	updatedInstaller.Status = statuses
 
 	return updatedInstaller, nil
+}
+
+// patchPolicyPlan is the patch-policy state a title should end up in after an update-package
+// request, resolved before the installer row is saved.
+type patchPolicyPlan struct {
+	existing        *fleet.PatchPolicyData
+	patchEnabled    bool
+	patchWhenClosed bool
+}
+
+func (p patchPolicyPlan) managed() bool {
+	return p.patchEnabled && p.patchWhenClosed
+}
+
+func (svc *Service) planPatchPolicy(ctx context.Context, payload *fleet.UpdateSoftwareInstallerPayload, existingInstaller *fleet.SoftwareInstaller) (patchPolicyPlan, error) {
+	var plan patchPolicyPlan
+
+	// Neither the patch policy nor the managed pre-install query can change unless one of these
+	// fields is present, so skip the lookup entirely otherwise.
+	if payload.Patch == nil && payload.PatchWhenClosed == nil && payload.PreInstallQuery == nil {
+		return plan, nil
+	}
+
+	// Only the Fleet-maintained package backs a patch policy: the patch controls are FMA-only,
+	// and a pre-install-query edit on any other package is never managed, so it stays editable.
+	if existingInstaller.FleetMaintainedAppID == nil {
+		if payload.Patch != nil || payload.PatchWhenClosed != nil {
+			return plan, &fleet.BadRequestError{Message: `"patch" and "patch_when_closed" are only supported for Fleet-maintained apps.`}
+		}
+		return plan, nil
+	}
+
+	existing, err := svc.ds.GetPatchPolicy(ctx, payload.TeamID, payload.TitleID)
+	if err != nil && !fleet.IsNotFound(err) {
+		return plan, ctxerr.Wrap(ctx, err, "getting patch policy")
+	}
+	plan.existing = existing
+
+	plan.patchEnabled = existing != nil
+	if payload.Patch != nil {
+		plan.patchEnabled = *payload.Patch
+	}
+
+	plan.patchWhenClosed = existing != nil && existing.PatchWhenClosed
+	if payload.PatchWhenClosed != nil {
+		plan.patchWhenClosed = *payload.PatchWhenClosed
+	}
+
+	// A disabled patch policy can't skip installs while the app is open. Reject an explicit
+	// request for both in the same call, otherwise just drop patch_when_closed.
+	if !plan.patchEnabled {
+		if payload.PatchWhenClosed != nil && *payload.PatchWhenClosed {
+			return plan, &fleet.BadRequestError{Message: `"patch_when_closed" requires "patch" to be enabled.`}
+		}
+		plan.patchWhenClosed = false
+	}
+
+	return plan, nil
+}
+
+func (svc *Service) applyPatchPolicyPlan(ctx context.Context, payload *fleet.UpdateSoftwareInstallerPayload, plan patchPolicyPlan) error {
+	if payload.Patch == nil && payload.PatchWhenClosed == nil {
+		return nil
+	}
+	teamID := ptr.ValOrZero(payload.TeamID)
+
+	if !plan.patchEnabled {
+		if plan.existing != nil {
+			if _, err := svc.DeleteTeamPolicies(ctx, teamID, []uint{plan.existing.ID}); err != nil {
+				return ctxerr.Wrap(ctx, err, "deleting patch policy")
+			}
+		}
+		return nil
+	}
+
+	if plan.existing == nil {
+		patchType := fleet.PolicyTypePatch
+		_, err := svc.NewTeamPolicy(ctx, teamID, fleet.NewTeamPolicyPayload{
+			Type:                 &patchType,
+			PatchSoftwareTitleID: &payload.TitleID,
+			PatchWhenClosed:      plan.patchWhenClosed,
+		})
+		var conflict *fleet.ConflictError
+		switch {
+		case err == nil:
+			return nil
+		case !errors.As(err, &conflict):
+			return ctxerr.Wrap(ctx, err, "creating patch policy")
+		}
+		// A concurrent request already created the patch policy. Converge its patch_when_closed
+		// below instead of failing on the unique constraint.
+		if plan.existing, err = svc.ds.GetPatchPolicy(ctx, payload.TeamID, payload.TitleID); err != nil {
+			return ctxerr.Wrap(ctx, err, "getting patch policy after conflict")
+		}
+	}
+
+	if plan.patchWhenClosed != plan.existing.PatchWhenClosed {
+		patchWhenClosed := plan.patchWhenClosed
+		if _, err := svc.ModifyTeamPolicy(ctx, teamID, plan.existing.ID, fleet.ModifyPolicyPayload{
+			PatchWhenClosed: &patchWhenClosed,
+		}); err != nil {
+			return ctxerr.Wrap(ctx, err, "updating patch policy")
+		}
+	}
+	return nil
 }
 
 func (svc *Service) validateEmbeddedSecretsOnScript(ctx context.Context, scriptName string, script *string,

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -486,12 +486,9 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 
 	payload.InstallerID = existingInstaller.InstallerID
 
-	// Resolve the resulting patch-policy state up front so we can reject a user pre-install
-	// query edit while the managed query owns it. The policy itself is reconciled after the
-	// installer row is saved.
-	patchPlan, err := svc.planPatchPolicy(ctx, payload, existingInstaller)
-	if err != nil {
-		return nil, err
+	// The patch controls only apply to Fleet-maintained apps.
+	if (payload.Patch != nil || payload.PatchWhenClosed != nil) && existingInstaller.FleetMaintainedAppID == nil {
+		return nil, &fleet.BadRequestError{Message: `"patch" and "patch_when_closed" are only supported for Fleet-maintained apps.`}
 	}
 
 	if payload.DisplayName != nil && *payload.DisplayName != software.DisplayName {
@@ -646,11 +643,6 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 	// default pre-install query is blank, so blanking out the query doesn't have a semantic meaning we have to take care of
 	if payload.PreInstallQuery != nil {
 		if *payload.PreInstallQuery != existingInstaller.PreInstallQuery {
-			if patchPlan.managed() {
-				return nil, &fleet.BadRequestError{
-					Message: `Couldn't edit. The pre-install query is managed by Fleet while "patch_when_closed" is enabled and can't be edited.`,
-				}
-			}
 			dirty["PreInstallQuery"] = true
 		}
 	}
@@ -816,6 +808,11 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 		"Labels":            {},
 	}
 	var shouldDoSideEffects bool
+
+	if err := svc.reconcilePatchPolicy(ctx, payload, existingInstaller); err != nil {
+		return nil, err
+	}
+
 	// persist changes starting here, now that we've done all the validation/diffing we can
 	if len(dirty) > 0 {
 		switch {
@@ -931,10 +928,6 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 		}
 	}
 
-	if err := svc.applyPatchPolicyPlan(ctx, payload, patchPlan); err != nil {
-		return nil, err
-	}
-
 	// re-pull the edited installer to reflect side effects; return that specific
 	// package, not the title's first-added one. May be able to optimize this out later.
 	updatedInstaller, err := svc.ds.GetSoftwareInstallerMetadataByTeamTitleAndInstallerID(ctxdb.RequirePrimary(ctx, true), payload.TeamID, payload.TitleID, payload.InstallerID, true)
@@ -951,109 +944,60 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 	return updatedInstaller, nil
 }
 
-// patchPolicyPlan is the patch-policy state a title should end up in after an update-package
-// request, resolved before the installer row is saved.
-type patchPolicyPlan struct {
-	existing        *fleet.PatchPolicyData
-	patchEnabled    bool
-	patchWhenClosed bool
-}
-
-func (p patchPolicyPlan) managed() bool {
-	return p.patchEnabled && p.patchWhenClosed
-}
-
-func (svc *Service) planPatchPolicy(ctx context.Context, payload *fleet.UpdateSoftwareInstallerPayload, existingInstaller *fleet.SoftwareInstaller) (patchPolicyPlan, error) {
-	var plan patchPolicyPlan
-
-	// Neither the patch policy nor the managed pre-install query can change unless one of these
-	// fields is present, so skip the lookup entirely otherwise.
-	if payload.Patch == nil && payload.PatchWhenClosed == nil && payload.PreInstallQuery == nil {
-		return plan, nil
+func (svc *Service) reconcilePatchPolicy(ctx context.Context, payload *fleet.UpdateSoftwareInstallerPayload, installer *fleet.SoftwareInstaller) error {
+	// Only the Fleet-maintained package has a managed pre-install query, so nothing here applies
+	// to any other package. Patch controls on a non-FMA package are rejected by the caller.
+	if installer.FleetMaintainedAppID == nil {
+		return nil
 	}
-
-	// Only the Fleet-maintained package backs a patch policy: the patch controls are FMA-only,
-	// and a pre-install-query edit on any other package is never managed, so it stays editable.
-	if existingInstaller.FleetMaintainedAppID == nil {
-		if payload.Patch != nil || payload.PatchWhenClosed != nil {
-			return plan, &fleet.BadRequestError{Message: `"patch" and "patch_when_closed" are only supported for Fleet-maintained apps.`}
-		}
-		return plan, nil
+	if payload.Patch == nil && payload.PatchWhenClosed == nil && payload.PreInstallQuery == nil {
+		return nil
 	}
 
 	existing, err := svc.ds.GetPatchPolicy(ctx, payload.TeamID, payload.TitleID)
 	if err != nil && !fleet.IsNotFound(err) {
-		return plan, ctxerr.Wrap(ctx, err, "getting patch policy")
+		return ctxerr.Wrap(ctx, err, "getting patch policy")
 	}
-	plan.existing = existing
 
-	plan.patchEnabled = existing != nil
+	patchEnabled := existing != nil
 	if payload.Patch != nil {
-		plan.patchEnabled = *payload.Patch
+		patchEnabled = *payload.Patch
 	}
-
-	plan.patchWhenClosed = existing != nil && existing.PatchWhenClosed
+	// patch_when_closed needs a patch policy: reject when patch is disabled, or when it's omitted
+	// and the title has no policy to enable it on.
+	if payload.PatchWhenClosed != nil && *payload.PatchWhenClosed && !patchEnabled {
+		return &fleet.BadRequestError{Message: `"patch_when_closed" requires "patch" to be enabled.`}
+	}
+	patchWhenClosed := patchEnabled && existing != nil && existing.PatchWhenClosed
 	if payload.PatchWhenClosed != nil {
-		plan.patchWhenClosed = *payload.PatchWhenClosed
+		patchWhenClosed = patchEnabled && *payload.PatchWhenClosed
 	}
 
-	// A disabled patch policy can't skip installs while the app is open. Reject an explicit
-	// request for both in the same call, otherwise just drop patch_when_closed.
-	if !plan.patchEnabled {
-		if payload.PatchWhenClosed != nil && *payload.PatchWhenClosed {
-			return plan, &fleet.BadRequestError{Message: `"patch_when_closed" requires "patch" to be enabled.`}
-		}
-		plan.patchWhenClosed = false
+	// While Fleet's managed query owns the pre-install condition, the user query can't be edited.
+	if patchWhenClosed && payload.PreInstallQuery != nil && *payload.PreInstallQuery != installer.PreInstallQuery {
+		return &fleet.BadRequestError{Message: `Couldn't edit. The pre-install query is managed by Fleet while "patch_when_closed" is enabled and can't be edited.`}
 	}
 
-	return plan, nil
-}
-
-func (svc *Service) applyPatchPolicyPlan(ctx context.Context, payload *fleet.UpdateSoftwareInstallerPayload, plan patchPolicyPlan) error {
-	if payload.Patch == nil && payload.PatchWhenClosed == nil {
-		return nil
-	}
 	teamID := ptr.ValOrZero(payload.TeamID)
-
-	if !plan.patchEnabled {
-		if plan.existing != nil {
-			if _, err := svc.DeleteTeamPolicies(ctx, teamID, []uint{plan.existing.ID}); err != nil {
-				return ctxerr.Wrap(ctx, err, "deleting patch policy")
-			}
+	switch {
+	case !patchEnabled:
+		if existing == nil {
+			return nil
 		}
-		return nil
-	}
-
-	if plan.existing == nil {
+		_, err = svc.DeleteTeamPolicies(ctx, teamID, []uint{existing.ID})
+	case existing == nil:
 		patchType := fleet.PolicyTypePatch
-		_, err := svc.NewTeamPolicy(ctx, teamID, fleet.NewTeamPolicyPayload{
+		_, err = svc.NewTeamPolicy(ctx, teamID, fleet.NewTeamPolicyPayload{
 			Type:                 &patchType,
 			PatchSoftwareTitleID: &payload.TitleID,
-			PatchWhenClosed:      plan.patchWhenClosed,
+			PatchWhenClosed:      patchWhenClosed,
 		})
-		var conflict *fleet.ConflictError
-		switch {
-		case err == nil:
-			return nil
-		case !errors.As(err, &conflict):
-			return ctxerr.Wrap(ctx, err, "creating patch policy")
-		}
-		// A concurrent request already created the patch policy. Converge its patch_when_closed
-		// below instead of failing on the unique constraint.
-		if plan.existing, err = svc.ds.GetPatchPolicy(ctx, payload.TeamID, payload.TitleID); err != nil {
-			return ctxerr.Wrap(ctx, err, "getting patch policy after conflict")
-		}
+	case patchWhenClosed != existing.PatchWhenClosed:
+		_, err = svc.ModifyTeamPolicy(ctx, teamID, existing.ID, fleet.ModifyPolicyPayload{PatchWhenClosed: &patchWhenClosed})
+	default:
+		return nil
 	}
-
-	if plan.patchWhenClosed != plan.existing.PatchWhenClosed {
-		patchWhenClosed := plan.patchWhenClosed
-		if _, err := svc.ModifyTeamPolicy(ctx, teamID, plan.existing.ID, fleet.ModifyPolicyPayload{
-			PatchWhenClosed: &patchWhenClosed,
-		}); err != nil {
-			return ctxerr.Wrap(ctx, err, "updating patch policy")
-		}
-	}
-	return nil
+	return ctxerr.Wrap(ctx, err, "reconciling patch policy")
 }
 
 func (svc *Service) validateEmbeddedSecretsOnScript(ctx context.Context, scriptName string, script *string,

--- a/ee/server/service/software_installers_test.go
+++ b/ee/server/service/software_installers_test.go
@@ -2713,6 +2713,18 @@ func TestReconcilePatchPolicy(t *testing.T) {
 		assert.True(t, base.NewTeamPolicyFuncInvoked)
 	})
 
+	// patch:true with patch_when_closed omitted defaults a new policy to "only when closed".
+	t.Run("new policy defaults to patch_when_closed", func(t *testing.T) {
+		svc, base := setup(t, nil)
+		var got bool
+		base.NewTeamPolicyFunc = func(ctx context.Context, tID uint, p fleet.NewTeamPolicyPayload) (*fleet.Policy, error) {
+			got = p.PatchWhenClosed
+			return &fleet.Policy{}, nil
+		}
+		require.NoError(t, svc.reconcilePatchPolicy(ctx, payload(new(true), nil), fmaInstaller))
+		assert.True(t, got)
+	})
+
 	// patch:false deletes the existing patch policy.
 	t.Run("deletes when patch disabled", func(t *testing.T) {
 		svc, base := setup(t, &fleet.PatchPolicyData{ID: 9})

--- a/ee/server/service/software_installers_test.go
+++ b/ee/server/service/software_installers_test.go
@@ -2641,3 +2641,166 @@ func TestNormalizeSetupExperiencePlatforms(t *testing.T) {
 		})
 	}
 }
+
+func TestPlanPatchPolicy(t *testing.T) {
+	ctx := context.Background()
+	titleID := uint(42)
+	teamID := uint(0)
+	fmaInstaller := &fleet.SoftwareInstaller{TitleID: &titleID, FleetMaintainedAppID: new(uint(7))}
+	nonFMAInstaller := &fleet.SoftwareInstaller{TitleID: &titleID}
+
+	newSvc := func(t *testing.T, existing *fleet.PatchPolicyData) *Service {
+		ds := new(mock.Store)
+		ds.GetPatchPolicyFunc = func(ctx context.Context, gotTeamID *uint, gotTitleID uint) (*fleet.PatchPolicyData, error) {
+			if existing == nil {
+				return nil, &notFoundError{}
+			}
+			return existing, nil
+		}
+		svc, _ := newTestServiceWithMock(t, ds)
+		return svc
+	}
+
+	payload := func(patch *bool, patchWhenClosed *bool) *fleet.UpdateSoftwareInstallerPayload {
+		return &fleet.UpdateSoftwareInstallerPayload{TitleID: titleID, TeamID: &teamID, Patch: patch, PatchWhenClosed: patchWhenClosed}
+	}
+
+	// The patch controls only apply to Fleet-maintained apps.
+	t.Run("rejects patch fields on non-FMA installer", func(t *testing.T) {
+		_, err := newSvc(t, nil).planPatchPolicy(ctx, payload(new(true), nil), nonFMAInstaller)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "Fleet-maintained apps")
+	})
+
+	// patch_when_closed can't be enabled unless patch is enabled too.
+	t.Run("rejects patch_when_closed without patch", func(t *testing.T) {
+		_, err := newSvc(t, nil).planPatchPolicy(ctx, payload(nil, new(true)), fmaInstaller)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "requires")
+	})
+
+	// Enabling both on a title with no patch policy yet marks it managed (create path).
+	t.Run("enabling patch and patch_when_closed is managed", func(t *testing.T) {
+		plan, err := newSvc(t, nil).planPatchPolicy(ctx, payload(new(true), new(true)), fmaInstaller)
+		require.NoError(t, err)
+		assert.Nil(t, plan.existing)
+		assert.True(t, plan.patchEnabled)
+		assert.True(t, plan.managed())
+	})
+
+	// A pre-install query edit on a title whose existing patch policy already has
+	// patch_when_closed set resolves as managed, so the edit is rejected.
+	t.Run("existing patch_when_closed policy is managed on pre-install edit", func(t *testing.T) {
+		p := payload(nil, nil)
+		p.PreInstallQuery = new("SELECT 1;")
+		plan, err := newSvc(t, &fleet.PatchPolicyData{ID: 5, PatchWhenClosed: true}).planPatchPolicy(ctx, p, fmaInstaller)
+		require.NoError(t, err)
+		require.NotNil(t, plan.existing)
+		assert.True(t, plan.managed())
+	})
+
+	// When nothing patch-related and no pre-install query is in the request, the lookup is
+	// skipped entirely and the title is treated as unmanaged.
+	t.Run("no patch or pre-install fields skips lookup", func(t *testing.T) {
+		plan, err := newSvc(t, &fleet.PatchPolicyData{ID: 5, PatchWhenClosed: true}).planPatchPolicy(ctx, payload(nil, nil), fmaInstaller)
+		require.NoError(t, err)
+		assert.Nil(t, plan.existing)
+		assert.False(t, plan.managed())
+	})
+
+	// Disabling patch drops management, re-exposing the user pre-install query.
+	t.Run("disabling patch is not managed", func(t *testing.T) {
+		plan, err := newSvc(t, &fleet.PatchPolicyData{ID: 5, PatchWhenClosed: true}).planPatchPolicy(ctx, payload(new(false), nil), fmaInstaller)
+		require.NoError(t, err)
+		assert.False(t, plan.patchEnabled)
+		assert.False(t, plan.managed())
+	})
+
+	// A pre-install edit on a non-FMA package is never managed, even when the title has an
+	// FMA-backed patch-when-closed policy on a sibling package.
+	t.Run("non-FMA package pre-install edit is not managed", func(t *testing.T) {
+		p := payload(nil, nil)
+		p.PreInstallQuery = new("SELECT 1;")
+		plan, err := newSvc(t, &fleet.PatchPolicyData{ID: 5, PatchWhenClosed: true}).planPatchPolicy(ctx, p, nonFMAInstaller)
+		require.NoError(t, err)
+		assert.Nil(t, plan.existing)
+		assert.False(t, plan.managed())
+	})
+}
+
+func TestApplyPatchPolicyPlan(t *testing.T) {
+	ctx := context.Background()
+	titleID := uint(42)
+	teamID := uint(0)
+	patchOn := &fleet.UpdateSoftwareInstallerPayload{TitleID: titleID, TeamID: &teamID, Patch: new(true)}
+
+	// patch:true with no existing policy creates the patch policy.
+	t.Run("creates when no policy exists", func(t *testing.T) {
+		ds := new(mock.Store)
+		svc, base := newTestServiceWithMock(t, ds)
+		base.NewTeamPolicyFunc = func(ctx context.Context, tID uint, p fleet.NewTeamPolicyPayload) (*fleet.Policy, error) {
+			require.NotNil(t, p.Type)
+			assert.Equal(t, fleet.PolicyTypePatch, *p.Type)
+			assert.True(t, p.PatchWhenClosed)
+			return &fleet.Policy{}, nil
+		}
+		err := svc.applyPatchPolicyPlan(ctx, patchOn, patchPolicyPlan{patchEnabled: true, patchWhenClosed: true})
+		require.NoError(t, err)
+		assert.True(t, base.NewTeamPolicyFuncInvoked)
+	})
+
+	// patch:false deletes the existing patch policy.
+	t.Run("deletes when patch disabled", func(t *testing.T) {
+		ds := new(mock.Store)
+		svc, base := newTestServiceWithMock(t, ds)
+		var deleted []uint
+		base.DeleteTeamPoliciesFunc = func(ctx context.Context, tID uint, ids []uint) ([]uint, error) {
+			deleted = ids
+			return ids, nil
+		}
+		payload := &fleet.UpdateSoftwareInstallerPayload{TitleID: titleID, TeamID: &teamID, Patch: new(false)}
+		err := svc.applyPatchPolicyPlan(ctx, payload, patchPolicyPlan{existing: &fleet.PatchPolicyData{ID: 9}})
+		require.NoError(t, err)
+		assert.Equal(t, []uint{9}, deleted)
+	})
+
+	// Toggling patch_when_closed on an existing policy updates it rather than recreating it.
+	t.Run("updates patch_when_closed on existing policy", func(t *testing.T) {
+		ds := new(mock.Store)
+		svc, base := newTestServiceWithMock(t, ds)
+		var modified *bool
+		base.ModifyTeamPolicyFunc = func(ctx context.Context, tID uint, id uint, p fleet.ModifyPolicyPayload) (*fleet.Policy, error) {
+			assert.Equal(t, uint(9), id)
+			modified = p.PatchWhenClosed
+			return &fleet.Policy{}, nil
+		}
+		payload := &fleet.UpdateSoftwareInstallerPayload{TitleID: titleID, TeamID: &teamID, PatchWhenClosed: new(true)}
+		err := svc.applyPatchPolicyPlan(ctx, payload, patchPolicyPlan{existing: &fleet.PatchPolicyData{ID: 9}, patchEnabled: true, patchWhenClosed: true})
+		require.NoError(t, err)
+		assert.False(t, base.NewTeamPolicyFuncInvoked)
+		require.NotNil(t, modified)
+		assert.True(t, *modified)
+	})
+
+	// A concurrent create that loses the unique-constraint race converges instead of failing.
+	t.Run("converges on create conflict", func(t *testing.T) {
+		ds := new(mock.Store)
+		svc, base := newTestServiceWithMock(t, ds)
+		base.NewTeamPolicyFunc = func(ctx context.Context, tID uint, p fleet.NewTeamPolicyPayload) (*fleet.Policy, error) {
+			return nil, &fleet.ConflictError{Message: "already has a patch policy"}
+		}
+		ds.GetPatchPolicyFunc = func(ctx context.Context, tID *uint, id uint) (*fleet.PatchPolicyData, error) {
+			return &fleet.PatchPolicyData{ID: 9, PatchWhenClosed: false}, nil
+		}
+		var modified *bool
+		base.ModifyTeamPolicyFunc = func(ctx context.Context, tID uint, id uint, p fleet.ModifyPolicyPayload) (*fleet.Policy, error) {
+			modified = p.PatchWhenClosed
+			return &fleet.Policy{}, nil
+		}
+		err := svc.applyPatchPolicyPlan(ctx, patchOn, patchPolicyPlan{patchEnabled: true, patchWhenClosed: true})
+		require.NoError(t, err)
+		assert.True(t, ds.GetPatchPolicyFuncInvoked)
+		require.NotNil(t, modified)
+		assert.True(t, *modified)
+	})
+}

--- a/ee/server/service/software_installers_test.go
+++ b/ee/server/service/software_installers_test.go
@@ -913,6 +913,16 @@ func TestUpdateSoftwareInstallerMatchesSoftwareIdentity(t *testing.T) {
 		require.True(t, state.ds.SaveInstallerUpdatesFuncInvoked)
 	})
 
+	t.Run("rejects patch controls on a non-FMA installer", func(t *testing.T) {
+		state := setup(t, "Dummy App", "dummy_installer.pkg", "pkg", "darwin", "dummy-storage", []string{"com.example.dummy"}, false)
+		_, err := state.svc.UpdateSoftwareInstaller(state.ctx, &fleet.UpdateSoftwareInstallerPayload{
+			TitleID: titleID,
+			TeamID:  &state.teamID,
+			Patch:   new(true),
+		})
+		require.ErrorContains(t, err, "Fleet-maintained apps")
+	})
+
 	t.Run("upgrade code allows a different title name", func(t *testing.T) {
 		contents, storageID := readInstaller(t, "../../../server/service/testdata/software-installers/fleet-osquery.msi")
 		state := setup(t, "Fleet agent", "fleet-osquery.msi", "msi", "windows", storageID, []string{"{70A53353-01E5-424B-8819-ED882B3805D9}"}, false)
@@ -2642,14 +2652,15 @@ func TestNormalizeSetupExperiencePlatforms(t *testing.T) {
 	}
 }
 
-func TestPlanPatchPolicy(t *testing.T) {
+func TestReconcilePatchPolicy(t *testing.T) {
 	ctx := context.Background()
 	titleID := uint(42)
 	teamID := uint(0)
-	fmaInstaller := &fleet.SoftwareInstaller{TitleID: &titleID, FleetMaintainedAppID: new(uint(7))}
+	fmaInstaller := &fleet.SoftwareInstaller{TitleID: &titleID, FleetMaintainedAppID: new(uint(7)), PreInstallQuery: "SELECT old;"}
 	nonFMAInstaller := &fleet.SoftwareInstaller{TitleID: &titleID}
 
-	newSvc := func(t *testing.T, existing *fleet.PatchPolicyData) *Service {
+	// setup resolves GetPatchPolicy to existing (nil means the title has no patch policy).
+	setup := func(t *testing.T, existing *fleet.PatchPolicyData) (*Service, *svcmock.Service) {
 		ds := new(mock.Store)
 		ds.GetPatchPolicyFunc = func(ctx context.Context, gotTeamID *uint, gotTitleID uint) (*fleet.PatchPolicyData, error) {
 			if existing == nil {
@@ -2657,150 +2668,86 @@ func TestPlanPatchPolicy(t *testing.T) {
 			}
 			return existing, nil
 		}
-		svc, _ := newTestServiceWithMock(t, ds)
-		return svc
+		return newTestServiceWithMock(t, ds)
 	}
 
 	payload := func(patch *bool, patchWhenClosed *bool) *fleet.UpdateSoftwareInstallerPayload {
 		return &fleet.UpdateSoftwareInstallerPayload{TitleID: titleID, TeamID: &teamID, Patch: patch, PatchWhenClosed: patchWhenClosed}
 	}
 
-	// The patch controls only apply to Fleet-maintained apps.
-	t.Run("rejects patch fields on non-FMA installer", func(t *testing.T) {
-		_, err := newSvc(t, nil).planPatchPolicy(ctx, payload(new(true), nil), nonFMAInstaller)
-		require.Error(t, err)
-		require.ErrorContains(t, err, "Fleet-maintained apps")
-	})
-
-	// patch_when_closed can't be enabled unless patch is enabled too.
+	// patch_when_closed can't be enabled unless patch is enabled too, whether patch is omitted
+	// (with no existing policy) or explicitly disabled.
 	t.Run("rejects patch_when_closed without patch", func(t *testing.T) {
-		_, err := newSvc(t, nil).planPatchPolicy(ctx, payload(nil, new(true)), fmaInstaller)
-		require.Error(t, err)
-		require.ErrorContains(t, err, "requires")
+		svc, _ := setup(t, nil)
+		require.ErrorContains(t, svc.reconcilePatchPolicy(ctx, payload(nil, new(true)), fmaInstaller), "requires")
+		require.ErrorContains(t, svc.reconcilePatchPolicy(ctx, payload(new(false), new(true)), fmaInstaller), "requires")
 	})
 
-	// Enabling both on a title with no patch policy yet marks it managed (create path).
-	t.Run("enabling patch and patch_when_closed is managed", func(t *testing.T) {
-		plan, err := newSvc(t, nil).planPatchPolicy(ctx, payload(new(true), new(true)), fmaInstaller)
-		require.NoError(t, err)
-		assert.Nil(t, plan.existing)
-		assert.True(t, plan.patchEnabled)
-		assert.True(t, plan.managed())
-	})
-
-	// A pre-install query edit on a title whose existing patch policy already has
-	// patch_when_closed set resolves as managed, so the edit is rejected.
-	t.Run("existing patch_when_closed policy is managed on pre-install edit", func(t *testing.T) {
+	// While patch_when_closed is on, the user pre-install query is managed and can't be edited.
+	t.Run("rejects pre-install edit while managed", func(t *testing.T) {
+		svc, _ := setup(t, &fleet.PatchPolicyData{ID: 9, PatchWhenClosed: true})
 		p := payload(nil, nil)
-		p.PreInstallQuery = new("SELECT 1;")
-		plan, err := newSvc(t, &fleet.PatchPolicyData{ID: 5, PatchWhenClosed: true}).planPatchPolicy(ctx, p, fmaInstaller)
-		require.NoError(t, err)
-		require.NotNil(t, plan.existing)
-		assert.True(t, plan.managed())
+		p.PreInstallQuery = new("SELECT changed;")
+		err := svc.reconcilePatchPolicy(ctx, p, fmaInstaller)
+		require.ErrorContains(t, err, "managed by Fleet")
 	})
 
-	// When nothing patch-related and no pre-install query is in the request, the lookup is
-	// skipped entirely and the title is treated as unmanaged.
-	t.Run("no patch or pre-install fields skips lookup", func(t *testing.T) {
-		plan, err := newSvc(t, &fleet.PatchPolicyData{ID: 5, PatchWhenClosed: true}).planPatchPolicy(ctx, payload(nil, nil), fmaInstaller)
-		require.NoError(t, err)
-		assert.Nil(t, plan.existing)
-		assert.False(t, plan.managed())
-	})
-
-	// Disabling patch drops management, re-exposing the user pre-install query.
-	t.Run("disabling patch is not managed", func(t *testing.T) {
-		plan, err := newSvc(t, &fleet.PatchPolicyData{ID: 5, PatchWhenClosed: true}).planPatchPolicy(ctx, payload(new(false), nil), fmaInstaller)
-		require.NoError(t, err)
-		assert.False(t, plan.patchEnabled)
-		assert.False(t, plan.managed())
-	})
-
-	// A pre-install edit on a non-FMA package is never managed, even when the title has an
-	// FMA-backed patch-when-closed policy on a sibling package.
-	t.Run("non-FMA package pre-install edit is not managed", func(t *testing.T) {
+	// A pre-install edit on a non-FMA package is never managed.
+	t.Run("allows pre-install edit on non-FMA package", func(t *testing.T) {
+		svc, _ := setup(t, &fleet.PatchPolicyData{ID: 9, PatchWhenClosed: true})
 		p := payload(nil, nil)
-		p.PreInstallQuery = new("SELECT 1;")
-		plan, err := newSvc(t, &fleet.PatchPolicyData{ID: 5, PatchWhenClosed: true}).planPatchPolicy(ctx, p, nonFMAInstaller)
-		require.NoError(t, err)
-		assert.Nil(t, plan.existing)
-		assert.False(t, plan.managed())
+		p.PreInstallQuery = new("SELECT changed;")
+		require.NoError(t, svc.reconcilePatchPolicy(ctx, p, nonFMAInstaller))
 	})
-}
 
-func TestApplyPatchPolicyPlan(t *testing.T) {
-	ctx := context.Background()
-	titleID := uint(42)
-	teamID := uint(0)
-	patchOn := &fleet.UpdateSoftwareInstallerPayload{TitleID: titleID, TeamID: &teamID, Patch: new(true)}
-
-	// patch:true with no existing policy creates the patch policy.
+	// patch:true with no existing policy creates one with the requested patch_when_closed.
 	t.Run("creates when no policy exists", func(t *testing.T) {
-		ds := new(mock.Store)
-		svc, base := newTestServiceWithMock(t, ds)
+		svc, base := setup(t, nil)
 		base.NewTeamPolicyFunc = func(ctx context.Context, tID uint, p fleet.NewTeamPolicyPayload) (*fleet.Policy, error) {
 			require.NotNil(t, p.Type)
 			assert.Equal(t, fleet.PolicyTypePatch, *p.Type)
 			assert.True(t, p.PatchWhenClosed)
 			return &fleet.Policy{}, nil
 		}
-		err := svc.applyPatchPolicyPlan(ctx, patchOn, patchPolicyPlan{patchEnabled: true, patchWhenClosed: true})
-		require.NoError(t, err)
+		require.NoError(t, svc.reconcilePatchPolicy(ctx, payload(new(true), new(true)), fmaInstaller))
 		assert.True(t, base.NewTeamPolicyFuncInvoked)
 	})
 
 	// patch:false deletes the existing patch policy.
 	t.Run("deletes when patch disabled", func(t *testing.T) {
-		ds := new(mock.Store)
-		svc, base := newTestServiceWithMock(t, ds)
+		svc, base := setup(t, &fleet.PatchPolicyData{ID: 9})
 		var deleted []uint
 		base.DeleteTeamPoliciesFunc = func(ctx context.Context, tID uint, ids []uint) ([]uint, error) {
 			deleted = ids
 			return ids, nil
 		}
-		payload := &fleet.UpdateSoftwareInstallerPayload{TitleID: titleID, TeamID: &teamID, Patch: new(false)}
-		err := svc.applyPatchPolicyPlan(ctx, payload, patchPolicyPlan{existing: &fleet.PatchPolicyData{ID: 9}})
-		require.NoError(t, err)
+		require.NoError(t, svc.reconcilePatchPolicy(ctx, payload(new(false), nil), fmaInstaller))
 		assert.Equal(t, []uint{9}, deleted)
 	})
 
 	// Toggling patch_when_closed on an existing policy updates it rather than recreating it.
 	t.Run("updates patch_when_closed on existing policy", func(t *testing.T) {
-		ds := new(mock.Store)
-		svc, base := newTestServiceWithMock(t, ds)
+		svc, base := setup(t, &fleet.PatchPolicyData{ID: 9, PatchWhenClosed: false})
 		var modified *bool
 		base.ModifyTeamPolicyFunc = func(ctx context.Context, tID uint, id uint, p fleet.ModifyPolicyPayload) (*fleet.Policy, error) {
 			assert.Equal(t, uint(9), id)
 			modified = p.PatchWhenClosed
 			return &fleet.Policy{}, nil
 		}
-		payload := &fleet.UpdateSoftwareInstallerPayload{TitleID: titleID, TeamID: &teamID, PatchWhenClosed: new(true)}
-		err := svc.applyPatchPolicyPlan(ctx, payload, patchPolicyPlan{existing: &fleet.PatchPolicyData{ID: 9}, patchEnabled: true, patchWhenClosed: true})
-		require.NoError(t, err)
+		require.NoError(t, svc.reconcilePatchPolicy(ctx, payload(nil, new(true)), fmaInstaller))
 		assert.False(t, base.NewTeamPolicyFuncInvoked)
 		require.NotNil(t, modified)
 		assert.True(t, *modified)
 	})
 
-	// A concurrent create that loses the unique-constraint race converges instead of failing.
-	t.Run("converges on create conflict", func(t *testing.T) {
-		ds := new(mock.Store)
-		svc, base := newTestServiceWithMock(t, ds)
-		base.NewTeamPolicyFunc = func(ctx context.Context, tID uint, p fleet.NewTeamPolicyPayload) (*fleet.Policy, error) {
-			return nil, &fleet.ConflictError{Message: "already has a patch policy"}
-		}
-		ds.GetPatchPolicyFunc = func(ctx context.Context, tID *uint, id uint) (*fleet.PatchPolicyData, error) {
-			return &fleet.PatchPolicyData{ID: 9, PatchWhenClosed: false}, nil
-		}
-		var modified *bool
-		base.ModifyTeamPolicyFunc = func(ctx context.Context, tID uint, id uint, p fleet.ModifyPolicyPayload) (*fleet.Policy, error) {
-			modified = p.PatchWhenClosed
-			return &fleet.Policy{}, nil
-		}
-		err := svc.applyPatchPolicyPlan(ctx, patchOn, patchPolicyPlan{patchEnabled: true, patchWhenClosed: true})
-		require.NoError(t, err)
-		assert.True(t, ds.GetPatchPolicyFuncInvoked)
-		require.NotNil(t, modified)
-		assert.True(t, *modified)
+	// An unmanaged FMA title with no patch changes touches no policy.
+	t.Run("unmanaged with no patch change is a noop", func(t *testing.T) {
+		svc, base := setup(t, &fleet.PatchPolicyData{ID: 9, PatchWhenClosed: false})
+		p := payload(nil, nil)
+		p.PreInstallQuery = new("SELECT changed;")
+		require.NoError(t, svc.reconcilePatchPolicy(ctx, p, fmaInstaller))
+		assert.False(t, base.NewTeamPolicyFuncInvoked)
+		assert.False(t, base.ModifyTeamPolicyFuncInvoked)
+		assert.False(t, base.DeleteTeamPoliciesFuncInvoked)
 	})
 }

--- a/ee/server/service/software_installers_test.go
+++ b/ee/server/service/software_installers_test.go
@@ -2752,8 +2752,9 @@ func TestReconcilePatchPolicy(t *testing.T) {
 		assert.True(t, *modified)
 	})
 
-	// An unmanaged FMA title with no patch changes touches no policy.
-	t.Run("unmanaged with no patch change is a noop", func(t *testing.T) {
+	// A pre-install edit is allowed and touches no policy when the title's patch policy has
+	// patch_when_closed off.
+	t.Run("pre-install edit allowed when patch_when_closed is off", func(t *testing.T) {
 		svc, base := setup(t, &fleet.PatchPolicyData{ID: 9, PatchWhenClosed: false})
 		p := payload(nil, nil)
 		p.PreInstallQuery = new("SELECT changed;")

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -222,8 +222,11 @@ type Policy struct {
 
 type GitOpsPolicySpec struct {
 	fleet.PolicySpec
-	RunScript       *PolicyRunScript                       `json:"run_script"`
-	InstallSoftware optjson.BoolOr[*PolicyInstallSoftware] `json:"install_software"`
+	// Shadows PolicySpec.ContinuousAutomationsEnabled to tell whether the key was set
+	// explicitly vs. omitted, which patch_when_closed validation needs.
+	ContinuousAutomations optjson.Bool                           `json:"continuous_automations_enabled"`
+	RunScript             *PolicyRunScript                       `json:"run_script"`
+	InstallSoftware       optjson.BoolOr[*PolicyInstallSoftware] `json:"install_software"`
 	// InstallSoftwareURL is populated after parsing the software installer yaml
 	// referenced by InstallSoftware.PackagePath.
 	InstallSoftwareURL string `json:"-"`
@@ -1879,9 +1882,9 @@ func parsePolicies(top map[string]json.RawMessage, result *GitOps, baseDir strin
 	}
 
 	// make an index of all FMAs by slug
-	fmasBySlug := make(map[string]struct{}, len(result.Software.FleetMaintainedApps))
+	fmasBySlug := make(map[string]*fleet.MaintainedAppSpec, len(result.Software.FleetMaintainedApps))
 	for _, s := range result.Software.FleetMaintainedApps {
-		fmasBySlug[s.Slug] = struct{}{}
+		fmasBySlug[s.Slug] = s
 	}
 	var errs []error
 	if policies, errs = expandBaseItems(policies, baseDir, "policy", GlobExpandOptions{
@@ -1953,6 +1956,10 @@ func parsePolicies(top map[string]json.RawMessage, result *GitOps, baseDir strin
 		} else {
 			item.Name = norm.NFC.String(item.Name)
 		}
+		// Reconcile the shadow value into the embedded field the apply path reads.
+		if item.ContinuousAutomations.Valid {
+			item.ContinuousAutomationsEnabled = item.ContinuousAutomations.Value
+		}
 		if item.Type == "" {
 			item.Type = fleet.PolicyTypeDynamic
 		}
@@ -1972,6 +1979,22 @@ func parsePolicies(top map[string]json.RawMessage, result *GitOps, baseDir strin
 			}
 			if item.FleetMaintainedAppSlug != "" {
 				patchSlugs = append(patchSlugs, item.FleetMaintainedAppSlug)
+			}
+			if item.PatchWhenClosed {
+				// Declarative: reject an explicit false instead of letting the datastore silently
+				// force it on; auto-set when omitted.
+				if item.ContinuousAutomations.Valid && !item.ContinuousAutomations.Value {
+					multiError = multierror.Append(multiError, fmt.Errorf(
+						`Couldn't apply policy %q: "continuous_automations_enabled" must be true when "patch_when_closed" is true.`, item.Name))
+				} else {
+					item.ContinuousAutomationsEnabled = true
+				}
+				// Fleet manages the app-open query, so a user pre_install_query on the FMA is rejected.
+				if fma, ok := fmasBySlug[item.FleetMaintainedAppSlug]; ok && fma.PreInstallQuery.Path != "" {
+					multiError = multierror.Append(multiError, fmt.Errorf(
+						`Couldn't apply policy %q: "pre_install_query" can't be set on Fleet-maintained app %q when "patch_when_closed" is true; Fleet manages this query.`,
+						item.Name, item.FleetMaintainedAppSlug))
+				}
 			}
 		} else if item.FleetMaintainedAppSlug != "" {
 			multiError = multierror.Append(multiError, errors.New("fleet_maintained_app_slug is only supported for patch policies"))
@@ -2038,7 +2061,7 @@ func parsePolicyRunScript(baseDir string, parentFilePath string, teamName *strin
 	return nil
 }
 
-func parsePolicyInstallSoftware(baseDir string, teamName *string, policy *Policy, packages []*fleet.SoftwarePackageSpec, appStoreApps []*fleet.TeamSpecAppStoreApp, fmasBySlug map[string]struct{}) []error {
+func parsePolicyInstallSoftware(baseDir string, teamName *string, policy *Policy, packages []*fleet.SoftwarePackageSpec, appStoreApps []*fleet.TeamSpecAppStoreApp, fmasBySlug map[string]*fleet.MaintainedAppSpec) []error {
 	installSoftwareObj := policy.InstallSoftware.Other
 	if installSoftwareObj == nil {
 		policy.SoftwareTitleID = ptr.Uint(0) // unset the installer

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -4995,7 +4995,7 @@ func TestParsePolicyInstallSoftware(t *testing.T) {
 				InstallSoftware: installSoftware,
 			},
 		}
-		fmasBySlug := map[string]struct{}{"zoom/darwin": {}}
+		fmasBySlug := map[string]*fleet.MaintainedAppSpec{"zoom/darwin": {Slug: "zoom/darwin"}}
 		errs := parsePolicyInstallSoftware(".", &teamName, policy, nil, nil, fmasBySlug)
 		require.Nil(t, errs)
 		assert.Equal(t, "zoom/darwin", policy.InstallSoftware.Other.FleetMaintainedAppSlug)
@@ -5013,7 +5013,7 @@ func TestParsePolicyInstallSoftware(t *testing.T) {
 				InstallSoftware: installSoftware,
 			},
 		}
-		fmasBySlug := map[string]struct{}{"zoom/darwin": {}}
+		fmasBySlug := map[string]*fleet.MaintainedAppSpec{"zoom/darwin": {Slug: "zoom/darwin"}}
 		errs := parsePolicyInstallSoftware(".", &teamName, policy, nil, nil, fmasBySlug)
 		require.Len(t, errs, 1)
 		assert.Contains(t, errs[0].Error(), `fleet_maintained_app_slug "notreal/darwin" not found`)
@@ -5072,7 +5072,7 @@ func TestParsePolicyInstallSoftware(t *testing.T) {
 				InstallSoftware: installSoftware,
 			},
 		}
-		fmasBySlug := map[string]struct{}{"zoom/darwin": {}}
+		fmasBySlug := map[string]*fleet.MaintainedAppSpec{"zoom/darwin": {Slug: "zoom/darwin"}}
 		errs := parsePolicyInstallSoftware(".", &teamName, policy, nil, nil, fmasBySlug)
 		require.Nil(t, errs)
 		assert.Equal(t, "zoom/darwin", policy.FleetMaintainedAppSlug)
@@ -5095,7 +5095,7 @@ func TestParsePolicyInstallSoftware(t *testing.T) {
 				InstallSoftware: installSoftware,
 			},
 		}
-		fmasBySlug := map[string]struct{}{"zoom/darwin": {}, "1password/darwin": {}}
+		fmasBySlug := map[string]*fleet.MaintainedAppSpec{"zoom/darwin": {Slug: "zoom/darwin"}, "1password/darwin": {Slug: "1password/darwin"}}
 		errs := parsePolicyInstallSoftware(".", &teamName, policy, nil, nil, fmasBySlug)
 		require.Nil(t, errs)
 		assert.Equal(t, "1password/darwin", policy.FleetMaintainedAppSlug)
@@ -5495,6 +5495,123 @@ policies:
 			require.Error(t, err)
 			for _, want := range tc.wantErrs {
 				assert.ErrorContains(t, err, want)
+			}
+		})
+	}
+}
+
+func TestGitOpsPatchWhenClosed(t *testing.T) {
+	t.Parallel()
+
+	const fmaSoftware = `
+software:
+  fleet_maintained_apps:
+    - slug: google-chrome/darwin
+`
+	// An FMA that carries a user-authored pre_install_query, which patch-when-closed rejects.
+	const fmaSoftwareWithPreInstall = `
+software:
+  fleet_maintained_apps:
+    - slug: google-chrome/darwin
+      pre_install_query:
+        path: ./preinstall.yml
+`
+
+	tests := []struct {
+		name     string
+		software string
+		policies string
+		// wantErrs empty means the config must apply cleanly.
+		wantErrs []string
+		// wantCA, when set, asserts the resulting ContinuousAutomationsEnabled on the single policy.
+		wantCA *bool
+	}{
+		{
+			name:     "patch_when_closed with continuous_automations omitted auto-sets it true",
+			software: fmaSoftware,
+			policies: `
+policies:
+  - name: Chrome up to date
+    type: patch
+    platform: darwin
+    fleet_maintained_app_slug: google-chrome/darwin
+    patch_when_closed: true
+`,
+			wantCA: new(true),
+		},
+		{
+			name:     "patch_when_closed with continuous_automations explicitly true applies",
+			software: fmaSoftware,
+			policies: `
+policies:
+  - name: Chrome up to date
+    type: patch
+    platform: darwin
+    fleet_maintained_app_slug: google-chrome/darwin
+    continuous_automations_enabled: true
+    patch_when_closed: true
+`,
+			wantCA: new(true),
+		},
+		{
+			name:     "patch_when_closed with explicit continuous_automations false is rejected",
+			software: fmaSoftware,
+			policies: `
+policies:
+  - name: Chrome up to date
+    type: patch
+    platform: darwin
+    fleet_maintained_app_slug: google-chrome/darwin
+    continuous_automations_enabled: false
+    patch_when_closed: true
+`,
+			wantErrs: []string{`"continuous_automations_enabled" must be true when "patch_when_closed" is true`},
+		},
+		{
+			name:     "patch_when_closed rejects a pre_install_query on the referenced FMA",
+			software: fmaSoftwareWithPreInstall,
+			policies: `
+policies:
+  - name: Chrome up to date
+    type: patch
+    platform: darwin
+    fleet_maintained_app_slug: google-chrome/darwin
+    patch_when_closed: true
+`,
+			wantErrs: []string{`"pre_install_query" can't be set on Fleet-maintained app "google-chrome/darwin"`},
+		},
+		{
+			// Backward compat: without the key, continuous automations stay off.
+			name:     "patch policy without patch_when_closed leaves continuous_automations off",
+			software: fmaSoftware,
+			policies: `
+policies:
+  - name: Chrome up to date
+    type: patch
+    platform: darwin
+    fleet_maintained_app_slug: google-chrome/darwin
+`,
+			wantCA: new(false),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			config := getTeamConfig([]string{"policies"}) + tc.software + tc.policies
+			path, basePath := createTempFile(t, "", config)
+			g, err := GitOpsFromFile(path, basePath, premiumAppConfig(), nopLogf)
+			if len(tc.wantErrs) > 0 {
+				require.Error(t, err)
+				for _, want := range tc.wantErrs {
+					assert.ErrorContains(t, err, want)
+				}
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, g.Policies, 1)
+			if tc.wantCA != nil {
+				assert.Equal(t, *tc.wantCA, g.Policies[0].ContinuousAutomationsEnabled)
 			}
 		})
 	}

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -5602,9 +5602,8 @@ policies:
 			path, basePath := createTempFile(t, "", config)
 			g, err := GitOpsFromFile(path, basePath, premiumAppConfig(), nopLogf)
 			if len(tc.wantErrs) > 0 {
-				require.Error(t, err)
 				for _, want := range tc.wantErrs {
-					assert.ErrorContains(t, err, want)
+					require.ErrorContains(t, err, want)
 				}
 				return
 			}

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -40,7 +40,7 @@ const policyCols = `
 	p.author_id, p.platforms, p.created_at, p.updated_at, p.critical,
 	p.calendar_events_enabled, p.software_installer_id, p.script_id,
 	p.vpp_apps_teams_id, p.conditional_access_enabled, p.type,
-	p.patch_software_title_id, p.continuous_automations_enabled
+	p.patch_software_title_id, p.continuous_automations_enabled, p.patch_when_closed
 `
 
 const (
@@ -418,12 +418,12 @@ func savePolicy(ctx context.Context, db sqlx.ExtContext, logger *slog.Logger, p 
 			SET name = ?, query = ?, description = ?, resolution = ?,
 			platforms = ?, critical = ?, calendar_events_enabled = ?,
 			software_installer_id = ?, script_id = ?, vpp_apps_teams_id = ?,
-			conditional_access_enabled = ?, continuous_automations_enabled = ?,
+			conditional_access_enabled = ?, continuous_automations_enabled = ?, patch_when_closed = ?,
 			checksum = ` + policiesChecksumComputedColumn() + `
 			WHERE id = ?
 	`
 	result, err := db.ExecContext(
-		ctx, updateStmt, p.Name, p.Query, p.Description, p.Resolution, p.Platform, p.Critical, p.CalendarEventsEnabled, p.SoftwareInstallerID, p.ScriptID, p.VPPAppsTeamsID, p.ConditionalAccessEnabled, p.ContinuousAutomationsEnabled, p.ID,
+		ctx, updateStmt, p.Name, p.Query, p.Description, p.Resolution, p.Platform, p.Critical, p.CalendarEventsEnabled, p.SoftwareInstallerID, p.ScriptID, p.VPPAppsTeamsID, p.ConditionalAccessEnabled, p.ContinuousAutomationsEnabled, p.PatchWhenClosed, p.ID,
 	)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "updating policy")
@@ -1410,13 +1410,13 @@ func newTeamPolicy(ctx context.Context, db sqlx.ExtContext, teamID uint, authorI
 				name, query, description, team_id, resolution, author_id,
 				platforms, critical, calendar_events_enabled, software_installer_id,
 				script_id, vpp_apps_teams_id, conditional_access_enabled, checksum,
-				type, patch_software_title_id, continuous_automations_enabled
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, %s, ?, ?, ?)`,
+				type, patch_software_title_id, continuous_automations_enabled, patch_when_closed
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, %s, ?, ?, ?, ?)`,
 			policiesChecksumComputedColumn(),
 		),
 		nameUnicode, args.Query, args.Description, teamID, args.Resolution, authorID, args.Platform, args.Critical,
 		args.CalendarEventsEnabled, args.SoftwareInstallerID, args.ScriptID, args.VPPAppsTeamsID,
-		args.ConditionalAccessEnabled, args.Type, args.PatchSoftwareTitleID, args.ContinuousAutomationsEnabled,
+		args.ConditionalAccessEnabled, args.Type, args.PatchSoftwareTitleID, args.ContinuousAutomationsEnabled, args.PatchWhenClosed,
 	)
 	switch {
 	case err == nil:
@@ -1727,8 +1727,9 @@ func (ds *Datastore) ApplyPolicySpecs(ctx context.Context, authorID uint, specs 
 			checksum,
 			type,
 			patch_software_title_id,
-			continuous_automations_enabled
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, %s, ?, ?, ?)
+			continuous_automations_enabled,
+			patch_when_closed
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, %s, ?, ?, ?, ?)
 		ON DUPLICATE KEY UPDATE
 			query = VALUES(query),
 			description = VALUES(description),
@@ -1743,7 +1744,8 @@ func (ds *Datastore) ApplyPolicySpecs(ctx context.Context, authorID uint, specs 
 			conditional_access_enabled = VALUES(conditional_access_enabled),
 			type = VALUES(type),
 			patch_software_title_id = VALUES(patch_software_title_id),
-			continuous_automations_enabled = VALUES(continuous_automations_enabled)
+			continuous_automations_enabled = VALUES(continuous_automations_enabled),
+			patch_when_closed = VALUES(patch_when_closed)
 		`, policiesChecksumComputedColumn(),
 		)
 		for teamID, teamPolicySpecs := range teamIDToPolicies {
@@ -1804,12 +1806,18 @@ func (ds *Datastore) ApplyPolicySpecs(ctx context.Context, authorID uint, specs 
 					patchSoftwareTitleIDArg = fmaTitleID
 				}
 
+				// A patch-when-closed policy only runs its managed pre-install query on
+				// continuous automation runs, so continuous automations are required.
+				if spec.PatchWhenClosed {
+					spec.ContinuousAutomationsEnabled = true
+				}
+
 				res, err := tx.ExecContext(
 					ctx,
 					query,
 					spec.Name, spec.Query, spec.Description, authorID, spec.Resolution, teamID, spec.Platform, spec.Critical,
 					spec.CalendarEventsEnabled, softwareInstallerID, vppAppsTeamsID, scriptID, spec.ConditionalAccessEnabled,
-					spec.Type, patchSoftwareTitleIDArg, spec.ContinuousAutomationsEnabled,
+					spec.Type, patchSoftwareTitleIDArg, spec.ContinuousAutomationsEnabled, spec.PatchWhenClosed,
 				)
 				if err != nil {
 					return ctxerr.Wrap(ctx, err, "exec ApplyPolicySpecs insert")
@@ -2979,7 +2987,7 @@ func (ds *Datastore) getPatchPolicyInstaller(ctx context.Context, teamID uint, t
 }
 
 func (ds *Datastore) GetPatchPolicy(ctx context.Context, teamID *uint, titleID uint) (*fleet.PatchPolicyData, error) {
-	query := `SELECT id, name FROM policies WHERE team_id = ? AND patch_software_title_id = ?`
+	query := `SELECT id, name, patch_when_closed FROM policies WHERE team_id = ? AND patch_software_title_id = ?`
 	var policy fleet.PatchPolicyData
 
 	err := sqlx.GetContext(ctx, ds.reader(ctx), &policy, query, ptr.ValOrZero(teamID), titleID)

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -1806,8 +1806,8 @@ func (ds *Datastore) ApplyPolicySpecs(ctx context.Context, authorID uint, specs 
 					patchSoftwareTitleIDArg = fmaTitleID
 				}
 
-				// A patch-when-closed policy only runs its managed pre-install query on
-				// continuous automation runs, so continuous automations are required.
+				// Continuous automations must be enabled so the patch policy keeps retrying the
+				// install until the app is closed.
 				if spec.PatchWhenClosed {
 					spec.ContinuousAutomationsEnabled = true
 				}

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -67,7 +67,7 @@ func (ds *Datastore) GetSoftwareInstallDetails(ctx context.Context, executionId 
     hsi.execution_id AS execution_id,
     hsi.software_installer_id AS installer_id,
     hsi.self_service AS self_service,
-    COALESCE(si.pre_install_query, '') AS pre_install_condition,
+    COALESCE(CASE WHEN p.patch_when_closed = 1 THEN si.app_open_query ELSE si.pre_install_query END, '') AS pre_install_condition,
     inst.contents AS install_script,
     uninst.contents AS uninstall_script,
     COALESCE(pisnt.contents, '') AS post_install_script
@@ -76,6 +76,9 @@ func (ds *Datastore) GetSoftwareInstallDetails(ctx context.Context, executionId 
   INNER JOIN
     software_installers si
     ON hsi.software_installer_id = si.id
+  LEFT OUTER JOIN
+    policies p
+    ON p.id = hsi.policy_id
   LEFT OUTER JOIN
     script_contents inst
     ON inst.id = si.install_script_content_id
@@ -96,7 +99,7 @@ func (ds *Datastore) GetSoftwareInstallDetails(ctx context.Context, executionId 
     ua.execution_id AS execution_id,
     siua.software_installer_id AS installer_id,
 		ua.payload->'$.self_service' AS self_service,
-    COALESCE(si.pre_install_query, '') AS pre_install_condition,
+    COALESCE(CASE WHEN p.patch_when_closed = 1 THEN si.app_open_query ELSE si.pre_install_query END, '') AS pre_install_condition,
     inst.contents AS install_script,
     uninst.contents AS uninstall_script,
     COALESCE(pisnt.contents, '') AS post_install_script
@@ -108,6 +111,9 @@ func (ds *Datastore) GetSoftwareInstallDetails(ctx context.Context, executionId 
   INNER JOIN
     software_installers si
     ON siua.software_installer_id = si.id
+  LEFT OUTER JOIN
+    policies p
+    ON p.id = siua.policy_id
   LEFT OUTER JOIN
     script_contents inst
     ON inst.id = si.install_script_content_id

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -140,8 +140,7 @@ func (ds *Datastore) GetSoftwareInstallDetails(ctx context.Context, executionId 
 		return nil, ctxerr.Wrap(ctx, err, "get software install details")
 	}
 
-	// A patch-when-closed policy install uses the Fleet-managed app-open query as its pre-install
-	// condition in place of the user's query.
+	// A patch-when-closed policy install uses the installer's app open query as its pre-install condition.
 	if result.PatchWhenClosed {
 		result.PreInstallCondition = result.AppOpenQuery
 	}

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -67,7 +67,9 @@ func (ds *Datastore) GetSoftwareInstallDetails(ctx context.Context, executionId 
     hsi.execution_id AS execution_id,
     hsi.software_installer_id AS installer_id,
     hsi.self_service AS self_service,
-    COALESCE(CASE WHEN p.patch_when_closed = 1 THEN si.app_open_query ELSE si.pre_install_query END, '') AS pre_install_condition,
+    COALESCE(si.pre_install_query, '') AS pre_install_condition,
+    si.app_open_query AS app_open_query,
+    COALESCE(p.patch_when_closed, 0) AS patch_when_closed,
     inst.contents AS install_script,
     uninst.contents AS uninstall_script,
     COALESCE(pisnt.contents, '') AS post_install_script
@@ -99,7 +101,9 @@ func (ds *Datastore) GetSoftwareInstallDetails(ctx context.Context, executionId 
     ua.execution_id AS execution_id,
     siua.software_installer_id AS installer_id,
 		ua.payload->'$.self_service' AS self_service,
-    COALESCE(CASE WHEN p.patch_when_closed = 1 THEN si.app_open_query ELSE si.pre_install_query END, '') AS pre_install_condition,
+    COALESCE(si.pre_install_query, '') AS pre_install_condition,
+    si.app_open_query AS app_open_query,
+    COALESCE(p.patch_when_closed, 0) AS patch_when_closed,
     inst.contents AS install_script,
     uninst.contents AS uninstall_script,
     COALESCE(pisnt.contents, '') AS post_install_script
@@ -134,6 +138,12 @@ func (ds *Datastore) GetSoftwareInstallDetails(ctx context.Context, executionId 
 			return nil, ctxerr.Wrap(ctx, notFound("SoftwareInstallerDetails").WithName(executionId), "get software installer details")
 		}
 		return nil, ctxerr.Wrap(ctx, err, "get software install details")
+	}
+
+	// A patch-when-closed policy install uses the Fleet-managed app-open query as its pre-install
+	// condition in place of the user's query.
+	if result.PatchWhenClosed {
+		result.PreInstallCondition = result.AppOpenQuery
 	}
 
 	// Install scripts run per-host, so custom host vitals resolve against the target host.

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -51,6 +51,7 @@ func TestSoftwareInstallers(t *testing.T) {
 		{"BatchSetSoftwareInstallersScopedViaLabels", testBatchSetSoftwareInstallersScopedViaLabels},
 		{"MatchOrCreateSoftwareInstallerWithAutomaticPolicies", testMatchOrCreateSoftwareInstallerWithAutomaticPolicies},
 		{"SoftwareInstallerAppOpenQueryRoundTrip", testSoftwareInstallerAppOpenQueryRoundTrip},
+		{"GetSoftwareInstallDetailsPatchWhenClosed", testGetSoftwareInstallDetailsPatchWhenClosed},
 		{"GetDetailsForUninstallFromExecutionID", testGetDetailsForUninstallFromExecutionID},
 		{"GetTeamsWithInstallerByHash", testGetTeamsWithInstallerByHash},
 		{"MatchOrCreateSoftwareInstallerDuplicateHash", testMatchOrCreateSoftwareInstallerDuplicateHash},
@@ -7171,6 +7172,95 @@ func testDeleteSoftwareInstallerRepointsPolicies(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	require.NotNil(t, got.SoftwareInstallerID)
 	require.Equal(t, installerB, *got.SoftwareInstallerID)
+}
+
+func testGetSoftwareInstallDetailsPatchWhenClosed(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+	user := test.NewUser(t, ds, "Author", "author-pwc@example.com", true)
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "pwc-team"})
+	require.NoError(t, err)
+	host := test.NewHost(t, ds, "pwc-host", "pwc-1", "pwc-key", "pwc-uuid", time.Now())
+	require.NoError(t, ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&team.ID, []uint{host.ID})))
+
+	const userQuery = "SELECT 1 FROM user_configured_query;"
+	const managedQuery = "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path LIKE concat(a.path, '/%') WHERE a.bundle_identifier = 'com.example.pwc');"
+
+	// A Fleet-maintained-app-backed installer carries both the user pre-install query and the
+	// Fleet-managed app_open_query.
+	newInstaller := func(t *testing.T, slug string) (uint, uint) {
+		app, err := ds.UpsertMaintainedApp(ctx, &fleet.MaintainedApp{
+			Name:             slug,
+			Slug:             slug,
+			Platform:         "darwin",
+			UniqueIdentifier: "com.example." + slug,
+		})
+		require.NoError(t, err)
+		tfr, err := fleet.NewTempFileReader(strings.NewReader("hello"), t.TempDir)
+		require.NoError(t, err)
+		installerID, titleID, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+			InstallScript:        "echo install",
+			UninstallScript:      "echo uninstall",
+			PreInstallQuery:      userQuery,
+			AppOpenQuery:         managedQuery,
+			InstallerFile:        tfr,
+			StorageID:            slug,
+			Filename:             slug,
+			Title:                slug,
+			Version:              "1.0",
+			Source:               "apps",
+			Platform:             "darwin",
+			TeamID:               &team.ID,
+			UserID:               user.ID,
+			ValidatedLabels:      &fleet.LabelIdentsWithScope{},
+			FleetMaintainedAppID: new(app.ID),
+		})
+		require.NoError(t, err)
+		return installerID, titleID
+	}
+
+	patchPolicy := func(t *testing.T, titleID uint, patchWhenClosed bool) *fleet.Policy {
+		p, err := ds.NewTeamPolicy(ctx, team.ID, &user.ID, fleet.PolicyPayload{
+			Type:                 fleet.PolicyTypePatch,
+			PatchSoftwareTitleID: &titleID,
+			PatchWhenClosed:      patchWhenClosed,
+		})
+		require.NoError(t, err)
+		require.Equal(t, patchWhenClosed, p.PatchWhenClosed)
+		return p
+	}
+
+	// Patch policy with patch_when_closed: the policy-triggered install gets the managed query.
+	closedInstaller, closedTitle := newInstaller(t, "pwc-closed")
+	closedPol := patchPolicy(t, closedTitle, true)
+	closedExec, err := ds.InsertSoftwareInstallRequest(ctx, host.ID, closedInstaller, fleet.HostSoftwareInstallOptions{PolicyID: &closedPol.ID})
+	require.NoError(t, err)
+	closedDetails, err := ds.GetSoftwareInstallDetails(ctx, closedExec)
+	require.NoError(t, err)
+	require.Equal(t, managedQuery, closedDetails.PreInstallCondition)
+
+	// Activating the install moves it into host_software_installs, exercising the other UNION
+	// branch of the query, which must resolve the managed query the same way.
+	_, err = ds.activateNextUpcomingActivity(ctx, ds.writer(ctx), host.ID, "")
+	require.NoError(t, err)
+	activatedDetails, err := ds.GetSoftwareInstallDetails(ctx, closedExec)
+	require.NoError(t, err)
+	require.Equal(t, managedQuery, activatedDetails.PreInstallCondition)
+
+	// Same installer, but a manual (non-policy) install falls back to the user query.
+	manualExec, err := ds.InsertSoftwareInstallRequest(ctx, host.ID, closedInstaller, fleet.HostSoftwareInstallOptions{})
+	require.NoError(t, err)
+	manualDetails, err := ds.GetSoftwareInstallDetails(ctx, manualExec)
+	require.NoError(t, err)
+	require.Equal(t, userQuery, manualDetails.PreInstallCondition)
+
+	// A patch policy without patch_when_closed keeps the user query on the policy path.
+	forceInstaller, forceTitle := newInstaller(t, "pwc-force")
+	forcePol := patchPolicy(t, forceTitle, false)
+	forceExec, err := ds.InsertSoftwareInstallRequest(ctx, host.ID, forceInstaller, fleet.HostSoftwareInstallOptions{PolicyID: &forcePol.ID})
+	require.NoError(t, err)
+	forceDetails, err := ds.GetSoftwareInstallDetails(ctx, forceExec)
+	require.NoError(t, err)
+	require.Equal(t, userQuery, forceDetails.PreInstallCondition)
 }
 
 func testSoftwareInstallerAppOpenQueryRoundTrip(t *testing.T, ds *Datastore) {

--- a/server/fleet/api_policies.go
+++ b/server/fleet/api_policies.go
@@ -187,6 +187,7 @@ type TeamPolicyRequest struct {
 	LabelsExcludeAll             []string `json:"labels_exclude_all" premium:"true"`
 	ConditionalAccessEnabled     bool     `json:"conditional_access_enabled"`
 	ContinuousAutomationsEnabled bool     `json:"continuous_automations_enabled" premium:"true"`
+	PatchWhenClosed              bool     `json:"patch_when_closed" premium:"true"`
 	Type                         *string  `json:"type"`
 	PatchSoftwareTitleID         *uint    `json:"patch_software_title_id"`
 }

--- a/server/fleet/policies.go
+++ b/server/fleet/policies.go
@@ -150,6 +150,7 @@ var (
 	errPolicyPlatformUpdated                         = errors.New("\"platform\" can't be updated")
 	errPolicyConditionalAccessEnabledInvalidPlatform = errors.New("\"conditional_access_enabled\" is only valid on \"darwin\" and \"windows\" policies")
 	errPolicyFMASlugRequiresPatch                    = errors.New("\"fleet_maintained_app_slug\" is only supported for patch policies")
+	errPolicyPatchWhenClosedRequiresPatch            = errors.New("\"patch_when_closed\" is only supported for patch policies")
 )
 
 // PolicyNoTeamID is the team ID of "No team" policies.
@@ -160,6 +161,9 @@ const MaxPolicyAutomationRetries = 3
 
 // Verify verifies the policy payload is valid.
 func (p PolicyPayload) Verify() error {
+	if p.PatchWhenClosed && p.Type != PolicyTypePatch {
+		return errPolicyPatchWhenClosedRequiresPatch
+	}
 	if p.Type == PolicyTypePatch {
 		if p.QueryID != nil {
 			return errPolicyPatchAndQuerySet
@@ -360,6 +364,9 @@ type ModifyPolicyPayload struct {
 
 // Verify verifies the policy payload is valid.
 func (p ModifyPolicyPayload) Verify() error {
+	if p.PatchWhenClosed != nil && *p.PatchWhenClosed && p.Type != PolicyTypePatch {
+		return errPolicyPatchWhenClosedRequiresPatch
+	}
 	if p.Type == PolicyTypePatch {
 		if p.Name != nil {
 			if err := verifyPolicyName(*p.Name); err != nil {
@@ -607,6 +614,8 @@ type PolicySpec struct {
 	//
 	// Only applies to team policies.
 	ContinuousAutomationsEnabled bool `json:"continuous_automations_enabled"`
+	// PatchWhenClosed skips the install while the app is open, via the managed pre-install query.
+	PatchWhenClosed bool `json:"patch_when_closed"`
 
 	Type                   string `json:"type"`
 	FleetMaintainedAppSlug string `json:"fleet_maintained_app_slug"`
@@ -662,6 +671,9 @@ func (p PolicySpec) Verify() error {
 	}
 	if p.Type != PolicyTypePatch && p.FleetMaintainedAppSlug != "" {
 		return errPolicyFMASlugRequiresPatch
+	}
+	if p.PatchWhenClosed && p.Type != PolicyTypePatch {
+		return errPolicyPatchWhenClosedRequiresPatch
 	}
 	return p.VerifyLabelScopes()
 }

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -721,11 +721,9 @@ type UpdateSoftwareInstallerPayload struct {
 	PinnedVersion *string
 	// Configuration is the in-house app's managed app configuration as raw XML bytes (iOS / iPadOS only). nil means leave unchanged; explicit empty means clear.
 	Configuration []byte
-	// Patch controls the patch policy for a Fleet-maintained app: true creates or keeps it,
-	// false deletes it. nil leaves the patch policy unchanged. FMA-only.
+	// Patch enables or disables the title's patch policy. FMA-only.
 	Patch *bool
-	// PatchWhenClosed sets patch_when_closed on the title's patch policy so the install is
-	// skipped while the app is open. nil leaves it unchanged. FMA-only.
+	// PatchWhenClosed skips the install while the app is open. FMA-only.
 	PatchWhenClosed *bool
 }
 

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -718,6 +718,12 @@ type UpdateSoftwareInstallerPayload struct {
 	PinnedVersion *string
 	// Configuration is the in-house app's managed app configuration as raw XML bytes (iOS / iPadOS only). nil means leave unchanged; explicit empty means clear.
 	Configuration []byte
+	// Patch controls the patch policy for a Fleet-maintained app: true creates or keeps it,
+	// false deletes it. nil leaves the patch policy unchanged. FMA-only.
+	Patch *bool
+	// PatchWhenClosed sets patch_when_closed on the title's patch policy so the install is
+	// skipped while the app is open. nil leaves it unchanged. FMA-only.
+	PatchWhenClosed *bool
 }
 
 func (u *UpdateSoftwareInstallerPayload) IsNoopPayload(existing *SoftwareTitle) bool {
@@ -725,7 +731,7 @@ func (u *UpdateSoftwareInstallerPayload) IsNoopPayload(existing *SoftwareTitle) 
 		u.InstallScript == nil && u.PostInstallScript == nil && u.UninstallScript == nil &&
 		u.LabelsIncludeAny == nil && u.LabelsExcludeAny == nil && u.LabelsIncludeAll == nil &&
 		u.DisplayName == nil && u.CategoryIDs == nil && u.Configuration == nil &&
-		u.PinnedVersion == nil
+		u.PinnedVersion == nil && u.Patch == nil && u.PatchWhenClosed == nil
 }
 
 // DownloadSoftwareInstallerPayload is the payload for downloading a software installer.
@@ -873,8 +879,9 @@ type AutomaticInstallPolicy struct {
 }
 
 type PatchPolicyData struct {
-	ID   uint   `json:"id" db:"id"`
-	Name string `json:"name" db:"name"`
+	ID              uint   `json:"id" db:"id"`
+	Name            string `json:"name" db:"name"`
+	PatchWhenClosed bool   `json:"patch_when_closed" db:"patch_when_closed"`
 }
 
 // SoftwarePackageOrApp provides information about a software installer

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -53,6 +53,9 @@ type SoftwareInstallDetails struct {
 	SoftwareInstallerURL *SoftwareInstallerURL `json:"installer_url,omitempty"`
 	// MaxRetries is the number of additional attempts allowed after the initial attempt (0 = no retries).
 	MaxRetries uint `json:"max_retries,omitempty"`
+
+	AppOpenQuery    string `json:"-" db:"app_open_query"`
+	PatchWhenClosed bool   `json:"-" db:"patch_when_closed"`
 }
 
 type SoftwareInstallerURL struct {

--- a/server/service/global_policies.go
+++ b/server/service/global_policies.go
@@ -254,8 +254,9 @@ func (svc Service) removeGlobalPoliciesFromWebhookConfig(ctx context.Context, id
 /////////////////////////////////////////////////////////////////////////////////
 
 const (
-	errPolicyAllFleetsForConditionalAccess     = "\"All fleets\" policy cannot have conditional_access_enabled set"
-	errPolicyAllFleetsForContinuousAutomations = "\"All fleets\" policy cannot have continuous_automations_enabled set"
+	errPolicyAllFleetsForConditionalAccess          = "\"All fleets\" policy cannot have conditional_access_enabled set"
+	errPolicyAllFleetsForContinuousAutomations      = "\"All fleets\" policy cannot have continuous_automations_enabled set"
+	errPatchWhenClosedRequiresContinuousAutomations = "\"continuous_automations_enabled\" cannot be disabled while \"patch_when_closed\" is enabled"
 )
 
 func modifyGlobalPolicyEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (fleet.Errorer, error) {

--- a/server/service/software_installers.go
+++ b/server/service/software_installers.go
@@ -62,6 +62,10 @@ type updateSoftwareInstallerRequest struct {
 	Version *string
 	// Configuration is the in-house app's managed app configuration as raw XML bytes (iOS / iPadOS only). nil means leave unchanged.
 	Configuration []byte
+	// Patch creates or keeps the title's patch policy when true and deletes it when false. Omitted leaves it unchanged. FMA-only.
+	Patch *bool
+	// PatchWhenClosed skips the install while the app is open. Omitted leaves it unchanged. FMA-only.
+	PatchWhenClosed *bool
 }
 
 type uploadSoftwareInstallerResponse struct {
@@ -160,6 +164,22 @@ func (updateSoftwareInstallerRequest) DecodeRequest(ctx context.Context, r *http
 	// Only set Version when the field is present, so an omitted field stays nil and an empty value means "Latest".
 	if versionMultipart, ok := r.MultipartForm.Value["version"]; ok && len(versionMultipart) > 0 {
 		decoded.Version = &versionMultipart[0]
+	}
+
+	if patchVal, ok := r.MultipartForm.Value["patch"]; ok && len(patchVal) > 0 && patchVal[0] != "" {
+		parsed, err := strconv.ParseBool(patchVal[0])
+		if err != nil {
+			return nil, &fleet.BadRequestError{Message: fmt.Sprintf("failed to decode patch bool in multipart form: %s", err.Error())}
+		}
+		decoded.Patch = &parsed
+	}
+
+	if patchWhenClosedVal, ok := r.MultipartForm.Value["patch_when_closed"]; ok && len(patchWhenClosedVal) > 0 && patchWhenClosedVal[0] != "" {
+		parsed, err := strconv.ParseBool(patchWhenClosedVal[0])
+		if err != nil {
+			return nil, &fleet.BadRequestError{Message: fmt.Sprintf("failed to decode patch_when_closed bool in multipart form: %s", err.Error())}
+		}
+		decoded.PatchWhenClosed = &parsed
 	}
 
 	val, ok = r.MultipartForm.Value["self_service"]
@@ -279,6 +299,8 @@ func updateSoftwareInstallerEndpoint(ctx context.Context, request interface{}, s
 		DisplayName:       req.DisplayName,
 		Configuration:     req.Configuration,
 		PinnedVersion:     req.Version,
+		Patch:             req.Patch,
+		PatchWhenClosed:   req.PatchWhenClosed,
 	}
 	if req.File != nil {
 		ff, err := req.File.Open()

--- a/server/service/team_policies.go
+++ b/server/service/team_policies.go
@@ -42,6 +42,7 @@ func teamPolicyEndpoint(ctx context.Context, request interface{}, svc fleet.Serv
 		LabelsExcludeAll:             req.LabelsExcludeAll,
 		ConditionalAccessEnabled:     req.ConditionalAccessEnabled,
 		ContinuousAutomationsEnabled: req.ContinuousAutomationsEnabled,
+		PatchWhenClosed:              req.PatchWhenClosed,
 		Type:                         req.Type,
 		PatchSoftwareTitleID:         req.PatchSoftwareTitleID,
 	})
@@ -301,6 +302,12 @@ func (svc *Service) newTeamPolicyPayloadToPolicyPayload(ctx context.Context, tea
 	if err != nil {
 		return fleet.PolicyPayload{}, err
 	}
+
+	// patch_when_closed requires continuous automations, so force them on. On create the field
+	// is a plain bool, so an explicit false is indistinguishable from an omitted one and gets
+	// forced silently. The modify path uses a bool pointer and rejects an explicit false.
+	continuousAutomationsEnabled := p.ContinuousAutomationsEnabled || p.PatchWhenClosed
+
 	return fleet.PolicyPayload{
 		QueryID:                      p.QueryID,
 		Name:                         p.Name,
@@ -318,7 +325,8 @@ func (svc *Service) newTeamPolicyPayloadToPolicyPayload(ctx context.Context, tea
 		LabelsExcludeAny:             p.LabelsExcludeAny,
 		LabelsExcludeAll:             p.LabelsExcludeAll,
 		ConditionalAccessEnabled:     p.ConditionalAccessEnabled,
-		ContinuousAutomationsEnabled: p.ContinuousAutomationsEnabled,
+		ContinuousAutomationsEnabled: continuousAutomationsEnabled,
+		PatchWhenClosed:              p.PatchWhenClosed,
 		Type:                         policyType,
 		PatchSoftwareTitleID:         p.PatchSoftwareTitleID,
 	}, nil
@@ -700,6 +708,19 @@ func (svc *Service) modifyPolicy(ctx context.Context, teamID *uint, id uint, p f
 	if p.ContinuousAutomationsEnabled != nil {
 		policy.ContinuousAutomationsEnabled = *p.ContinuousAutomationsEnabled
 	}
+	patchWhenClosed := policy.PatchWhenClosed
+	if p.PatchWhenClosed != nil {
+		patchWhenClosed = *p.PatchWhenClosed
+	}
+	if patchWhenClosed && p.ContinuousAutomationsEnabled != nil && !*p.ContinuousAutomationsEnabled {
+		return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
+			Message: fmt.Sprintf("policy payload verification: %s", errPatchWhenClosedRequiresContinuousAutomations),
+		})
+	}
+	if patchWhenClosed {
+		policy.ContinuousAutomationsEnabled = true
+	}
+	policy.PatchWhenClosed = patchWhenClosed
 	if removeStats {
 		policy.FailingHostCount = 0
 		policy.PassingHostCount = 0

--- a/server/service/team_policies.go
+++ b/server/service/team_policies.go
@@ -303,10 +303,11 @@ func (svc *Service) newTeamPolicyPayloadToPolicyPayload(ctx context.Context, tea
 		return fleet.PolicyPayload{}, err
 	}
 
-	// patch_when_closed requires continuous automations, so force them on. On create the field
-	// is a plain bool, so an explicit false is indistinguishable from an omitted one and gets
-	// forced silently. The modify path uses a bool pointer and rejects an explicit false.
-	continuousAutomationsEnabled := p.ContinuousAutomationsEnabled || p.PatchWhenClosed
+	// Continuous automations must be enabled so the patch policy keeps retrying until the app is closed.
+	continuousAutomationsEnabled := p.ContinuousAutomationsEnabled
+	if p.PatchWhenClosed {
+		continuousAutomationsEnabled = true
+	}
 
 	return fleet.PolicyPayload{
 		QueryID:                      p.QueryID,

--- a/server/service/team_policies_test.go
+++ b/server/service/team_policies_test.go
@@ -204,6 +204,117 @@ func TestTeamPolicyVPPAutomationRejectsNonMacOS(t *testing.T) {
 	require.ErrorContains(t, err, "is associated to an iOS or iPadOS VPP app")
 }
 
+func TestTeamPolicyPatchWhenClosed(t *testing.T) {
+	const (
+		teamID               = uint(1)
+		policyID             = uint(42)
+		patchSoftwareTitleID = uint(401)
+	)
+	patchType := fleet.PolicyTypePatch
+
+	freshPatchPolicy := func() *fleet.Policy {
+		tID := teamID
+		return &fleet.Policy{
+			PolicyData: fleet.PolicyData{
+				ID:                   policyID,
+				TeamID:               &tID,
+				Name:                 "macOS - App up to date",
+				Type:                 fleet.PolicyTypePatch,
+				PatchSoftwareTitleID: new(patchSoftwareTitleID),
+			},
+		}
+	}
+
+	adminCtx := func(ctx context.Context) context.Context {
+		return viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{ID: 1, GlobalRole: new(fleet.RoleAdmin)}})
+	}
+
+	setupDS := func() *mock.Store {
+		ds := new(mock.Store)
+		ds.PolicyFunc = func(ctx context.Context, id uint) (*fleet.Policy, error) {
+			return freshPatchPolicy(), nil
+		}
+		ds.GetSoftwareInstallerMetadataByTeamAndTitleIDFunc = func(ctx context.Context, tID *uint, titleID uint, withScriptContents bool) (*fleet.SoftwareInstaller, error) {
+			return &fleet.SoftwareInstaller{TitleID: new(patchSoftwareTitleID), SoftwareTitle: "App", DisplayName: "App"}, nil
+		}
+		return ds
+	}
+
+	// Creating a patch-when-closed policy forces continuous automations on, even when the
+	// request left the field at its default false.
+	t.Run("create auto-sets continuous automations", func(t *testing.T) {
+		ds := setupDS()
+		var captured fleet.PolicyPayload
+		ds.NewTeamPolicyFunc = func(ctx context.Context, tID uint, authorID *uint, args fleet.PolicyPayload) (*fleet.Policy, error) {
+			captured = args
+			return freshPatchPolicy(), nil
+		}
+		opts := &TestServerOpts{}
+		svc, baseCtx := newTestService(t, ds, nil, nil, opts)
+		opts.ActivityMock.NewActivityFunc = func(_ context.Context, _ *activity_api.User, _ activity_api.ActivityDetails) error {
+			return nil
+		}
+
+		_, err := svc.NewTeamPolicy(adminCtx(baseCtx), teamID, fleet.NewTeamPolicyPayload{
+			Type:                 &patchType,
+			PatchSoftwareTitleID: new(patchSoftwareTitleID),
+			PatchWhenClosed:      true,
+		})
+		require.NoError(t, err)
+		assert.True(t, captured.PatchWhenClosed)
+		assert.True(t, captured.ContinuousAutomationsEnabled, "patch_when_closed should force continuous automations on")
+	})
+
+	// patch_when_closed only applies to patch policies.
+	t.Run("create rejects patch_when_closed on non-patch policy", func(t *testing.T) {
+		ds := setupDS()
+		svc, baseCtx := newTestService(t, ds, nil, nil)
+		_, err := svc.NewTeamPolicy(adminCtx(baseCtx), teamID, fleet.NewTeamPolicyPayload{
+			Name:            "dynamic policy",
+			Query:           "SELECT 1;",
+			PatchWhenClosed: true,
+		})
+		require.Error(t, err)
+		require.ErrorContains(t, err, "patch_when_closed")
+	})
+
+	// Continuous automations can't be turned off in the same request that keeps
+	// patch_when_closed on.
+	t.Run("modify rejects disabling continuous automations", func(t *testing.T) {
+		ds := setupDS()
+		svc, baseCtx := newTestService(t, ds, nil, nil)
+		_, err := svc.ModifyTeamPolicy(adminCtx(baseCtx), teamID, policyID, fleet.ModifyPolicyPayload{
+			PatchWhenClosed:              new(true),
+			ContinuousAutomationsEnabled: new(false),
+		})
+		require.Error(t, err)
+		require.ErrorContains(t, err, "continuous_automations_enabled")
+	})
+
+	// Enabling patch_when_closed on modify forces continuous automations on.
+	t.Run("modify auto-sets continuous automations", func(t *testing.T) {
+		ds := setupDS()
+		var saved *fleet.Policy
+		ds.SavePolicyFunc = func(ctx context.Context, p *fleet.Policy, _ bool, _ bool) error {
+			saved = p
+			return nil
+		}
+		opts := &TestServerOpts{}
+		svc, baseCtx := newTestService(t, ds, nil, nil, opts)
+		opts.ActivityMock.NewActivityFunc = func(_ context.Context, _ *activity_api.User, _ activity_api.ActivityDetails) error {
+			return nil
+		}
+
+		_, err := svc.ModifyTeamPolicy(adminCtx(baseCtx), teamID, policyID, fleet.ModifyPolicyPayload{
+			PatchWhenClosed: new(true),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, saved)
+		assert.True(t, saved.PatchWhenClosed)
+		assert.True(t, saved.ContinuousAutomationsEnabled)
+	})
+}
+
 // TestTeamPolicyAutomationsPopulated verifies that every endpoint that
 // returns a team policy populates the install_software, run_script, and
 // patch_software automation fields by exercising the


### PR DESCRIPTION
**Related issue:** Resolves #49418

Adds `patch_when_closed` support to GitOps for patch policies and round-trips it through `fleetctl generate-gitops`.

- Validate `patch_when_closed` in the patch-policy YAML: reject an explicit `continuous_automations_enabled: false` alongside it (GitOps is declarative — the datastore would otherwise silently force it on), auto-set it when omitted, and reject a `pre_install_query` on the referenced Fleet-maintained app (Fleet manages that query).
- Emit `patch_when_closed` from `fleetctl generate-gitops`.

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

## New Fleet configuration settings

Follow this checklist for GitOps-enabled settings:

- [x] Verified that the setting is exported via `fleetctl generate-gitops`
- [x] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md) (#49022)
- [x] Verified that the setting is cleared on the server if it is not supplied in a YAML file
