### PR TITLE
Cherry pick: Fixed unreleased Windows cert ingestion perf issue (#49787)

### DIFF
--- a/server/datastore/mysql/host_certificates.go
+++ b/server/datastore/mysql/host_certificates.go
@@ -113,10 +113,11 @@ func (ds *Datastore) UpdateHostCertificates(ctx context.Context, hostID uint, ho
 		//   h.Write(data)
 		//   sha1Sum := h.Sum(nil)
 		normalizedSHA1 := strings.ToUpper(hex.EncodeToString(cert.SHA1Sum))
-		incomingSourcesBySHA1[normalizedSHA1] = append(incomingSourcesBySHA1[normalizedSHA1], certSourceToSet{
-			Source:   cert.Source,
-			Username: cert.Username,
-		})
+		// Dedupe (source, username) tuples per certificate: osquery can report the same certificate scope more than once.
+		srcToSet := certSourceToSet{Source: cert.Source, Username: cert.Username}
+		if !slices.Contains(incomingSourcesBySHA1[normalizedSHA1], srcToSet) {
+			incomingSourcesBySHA1[normalizedSHA1] = append(incomingSourcesBySHA1[normalizedSHA1], srcToSet)
+		}
 		incomingBySHA1[normalizedSHA1] = cert
 	}
 
@@ -127,15 +128,38 @@ func (ds *Datastore) UpdateHostCertificates(ctx context.Context, hostID uint, ho
 		return ctxerr.Wrap(ctx, err, "list host certificates for update")
 	}
 
+	// listHostCertsDB returns one row per (certificate row x source row). host_certificates has no unique index on (host_id,
+	// sha1_sum), so treat the newest row as canonical: diff sources against it alone, and soft-delete the duplicates in the
+	// transaction below. Newest wins.
 	existingBySHA1 := make(map[string]*fleet.HostCertificateRecord, len(existingCerts))
-	existingSourcesBySHA1 := make(map[string][]certSourceToSet, len(existingCerts))
 	for _, ec := range existingCerts {
 		normalizedSHA1 := strings.ToUpper(hex.EncodeToString(ec.SHA1Sum))
-		existingBySHA1[normalizedSHA1] = ec
-		existingSourcesBySHA1[normalizedSHA1] = append(existingSourcesBySHA1[normalizedSHA1], certSourceToSet{
-			Source:   ec.Source,
-			Username: ec.Username,
-		})
+		if cur, ok := existingBySHA1[normalizedSHA1]; !ok || ec.ID > cur.ID {
+			existingBySHA1[normalizedSHA1] = ec
+		}
+	}
+	existingSourcesBySHA1 := make(map[string][]certSourceToSet, len(existingBySHA1))
+	existingSourceRowIDsBySHA1 := make(map[string]map[certSourceToSet]uint, len(existingBySHA1))
+	var certIDsToRetire []uint      // duplicate host_certificates rows, soft-deleted in the tx (self-heal)
+	var sourceRowIDsToRetire []uint // their host_certificate_sources rows, deleted
+	seenRetiredCertIDs := make(map[uint]struct{})
+	for _, ec := range existingCerts {
+		normalizedSHA1 := strings.ToUpper(hex.EncodeToString(ec.SHA1Sum))
+		winner := existingBySHA1[normalizedSHA1]
+		if ec.ID != winner.ID {
+			if _, ok := seenRetiredCertIDs[ec.ID]; !ok {
+				seenRetiredCertIDs[ec.ID] = struct{}{}
+				certIDsToRetire = append(certIDsToRetire, ec.ID)
+			}
+			sourceRowIDsToRetire = append(sourceRowIDsToRetire, ec.SourceID)
+			continue
+		}
+		srcToSet := certSourceToSet{Source: ec.Source, Username: ec.Username}
+		existingSourcesBySHA1[normalizedSHA1] = append(existingSourcesBySHA1[normalizedSHA1], srcToSet)
+		if existingSourceRowIDsBySHA1[normalizedSHA1] == nil {
+			existingSourceRowIDsBySHA1[normalizedSHA1] = make(map[certSourceToSet]uint)
+		}
+		existingSourceRowIDsBySHA1[normalizedSHA1][srcToSet] = ec.SourceID
 	}
 
 	toInsert := make([]*fleet.HostCertificateRecord, 0, len(incomingBySHA1))
@@ -379,26 +403,55 @@ func (ds *Datastore) UpdateHostCertificates(ctx context.Context, hostID uint, ho
 			return ctxerr.Wrap(ctx, err, "insert host certs")
 		}
 
+		// Self-heal: retire duplicate cert rows (and their source rows) before resolving canonical ids,
+		// so a host that accumulated duplicate rows returns to one active row per certificate.
+		if err := softDeleteHostCertsDB(ctx, tx, hostID, certIDsToRetire); err != nil {
+			return ctxerr.Wrap(ctx, err, "soft delete duplicate host certs")
+		}
+
+		// Compute the precise source-row changes: delete only rows that are stale (by primary key) and insert only tuples that are missing.
+		staleSourceRowIDs := append([]uint(nil), sourceRowIDsToRetire...)
+		var sourceRowsToInsert []hostCertSourceRow
 		if len(toSetSourcesBySHA1) > 0 {
-			// must reload the DB IDs to insert the host_certificates_sources rows
+			// must reload the DB IDs to insert the host_certificate_sources rows
 			certIDsBySHA1, err := loadHostCertIDsForSHA1DB(ctx, tx, hostID, slices.Collect(maps.Keys(toSetSourcesBySHA1)))
 			if err != nil {
 				return ctxerr.Wrap(ctx, err, "load host certs ids")
 			}
 
-			toReplaceSources := make([]*fleet.HostCertificateRecord, 0, len(toSetSourcesBySHA1))
-			for sha1, sources := range toSetSourcesBySHA1 {
-				for _, source := range sources {
-					toReplaceSources = append(toReplaceSources, &fleet.HostCertificateRecord{
-						ID:       certIDsBySHA1[sha1],
-						Source:   source.Source,
-						Username: source.Username,
+			for sha1, desired := range toSetSourcesBySHA1 {
+				certID, ok := certIDsBySHA1[sha1]
+				if !ok {
+					// cert row not found on the writer (e.g. deleted concurrently); nothing to attach sources to
+					continue
+				}
+				existingRowIDs := existingSourceRowIDsBySHA1[sha1]
+				desiredSet := make(map[certSourceToSet]struct{}, len(desired))
+				for _, s := range desired {
+					desiredSet[s] = struct{}{}
+				}
+				for s, rowID := range existingRowIDs {
+					if _, ok := desiredSet[s]; !ok {
+						staleSourceRowIDs = append(staleSourceRowIDs, rowID)
+					}
+				}
+				for _, s := range desired {
+					if _, ok := existingRowIDs[s]; ok {
+						continue
+					}
+					sourceRowsToInsert = append(sourceRowsToInsert, hostCertSourceRow{
+						HostCertificateID: certID,
+						Source:            s.Source,
+						Username:          s.Username,
 					})
 				}
 			}
-			if err := replaceHostCertsSourcesDB(ctx, tx, toReplaceSources); err != nil {
-				return ctxerr.Wrap(ctx, err, "replace host certs sources")
-			}
+		}
+		if err := deleteHostCertSourceRowsDB(ctx, tx, staleSourceRowIDs); err != nil {
+			return ctxerr.Wrap(ctx, err, "delete stale host cert sources")
+		}
+		if err := insertHostCertSourceRowsDB(ctx, tx, sourceRowsToInsert); err != nil {
+			return ctxerr.Wrap(ctx, err, "insert host cert sources")
 		}
 
 		if err := softDeleteHostCertsDB(ctx, tx, hostID, toDelete); err != nil {
@@ -621,7 +674,11 @@ func loadHostCertIDsForSHA1DB(ctx context.Context, tx sqlx.QueryerContext, hostI
 	certIDsBySHA1 := make(map[string]uint, len(certs))
 	for _, cert := range certs {
 		normalizedSHA1 := strings.ToUpper(hex.EncodeToString(cert.SHA1Sum))
-		certIDsBySHA1[normalizedSHA1] = cert.ID
+		// Keep the newest row when duplicates exist (matching the canonical-row selection in UpdateHostCertificates)
+		// so sources attach to the row that survives duplicate healing instead of an arbitrary duplicate.
+		if curID, ok := certIDsBySHA1[normalizedSHA1]; !ok || cert.ID > curID {
+			certIDsBySHA1[normalizedSHA1] = cert.ID
+		}
 	}
 	return certIDsBySHA1, nil
 }
@@ -661,6 +718,7 @@ SELECT
 	hc.issuer_org_unit,
 	hc.issuer_common_name,
 	hc.origin,
+	hcs.id AS source_id,
 	hcs.source,
 	hcs.username
 	%s`, fromWhereClause)
@@ -695,89 +753,66 @@ SELECT
 	return certs, metaData, nil
 }
 
-func replaceHostCertsSourcesDB(ctx context.Context, tx sqlx.ExtContext, toReplaceSources []*fleet.HostCertificateRecord) error {
-	if len(toReplaceSources) == 0 {
+// deleteHostCertSourceRowsDB deletes host_certificate_sources rows by primary key.
+func deleteHostCertSourceRowsDB(ctx context.Context, tx sqlx.ExtContext, ids []uint) error {
+	if len(ids) == 0 {
 		return nil
 	}
+	// Sort for deterministic lock ordering across concurrent transactions.
+	slices.Sort(ids)
+	stmt, args, err := sqlx.In(`DELETE FROM host_certificate_sources WHERE id IN (?)`, ids)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "building delete host cert sources query")
+	}
+	if _, err := tx.ExecContext(ctx, stmt, args...); err != nil {
+		return ctxerr.Wrap(ctx, err, "deleting host cert sources")
+	}
+	return nil
+}
 
-	// FIXME: It is entirely possible for the caller to pass duplicates in the toReplaceSources slice
-	// (e.g. multiple elements with the same source and username for the same certificate ID).
-	// Although this function checks against duplicates in the database, it does not deduplicate the
-	// slice itself. This can lead to unique constraint violations when ths function inserts new sources.
-	//
-	// For Apple, it was implicitly assumed that there would be no incoming duplicates (likely based
-	// on Apple KeyChain behavior). But for Windows, duplicates are commonly reported by osquery. We
-	// should consider the best pattern for ensuring deduplication happens here or up the call
-	// stack. For now, we are deduping Windows certs in the upstream osqquery directIngest function,
-	// but that may not be the best approach if we want to guard against other potential issues.
+// hostCertSourceRow is one (host_certificate_id, source, username) tuple to insert into host_certificate_sources.
+type hostCertSourceRow struct {
+	HostCertificateID uint
+	Source            fleet.HostCertificateSource
+	Username          string
+}
 
-	// Sort by host_certificate_id to ensure consistent lock ordering and prevent deadlocks
-	slices.SortFunc(toReplaceSources, func(a, b *fleet.HostCertificateRecord) int {
-		if a.ID != b.ID {
-			if a.ID < b.ID {
+// insertHostCertSourceRowsDB inserts the given (host_certificate_id, source, username) tuples. The caller passes only
+// tuples it believes are missing; ON DUPLICATE KEY UPDATE is a no-op guard.
+func insertHostCertSourceRowsDB(ctx context.Context, tx sqlx.ExtContext, rows []hostCertSourceRow) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	// Sort by (host_certificate_id, source, username) for deterministic lock ordering across concurrent transactions.
+	slices.SortFunc(rows, func(a, b hostCertSourceRow) int {
+		if a.HostCertificateID != b.HostCertificateID {
+			if a.HostCertificateID < b.HostCertificateID {
 				return -1
 			}
 			return 1
 		}
-		// Secondary sort by source/username for determinism
 		if a.Source != b.Source {
 			return strings.Compare(string(a.Source), string(b.Source))
 		}
 		return strings.Compare(a.Username, b.Username)
 	})
 
-	// Build unique certificate IDs for deletion (already sorted from above)
-	certIDs := make([]uint, 0, len(toReplaceSources))
-	var lastID uint
-	for i, source := range toReplaceSources {
-		// Deduplicate: only add if this ID is different from the last one
-		if i == 0 || source.ID != lastID {
-			certIDs = append(certIDs, source.ID)
-			lastID = source.ID
-		}
+	const singleRowPlaceholderCount = 3
+	placeholders := make([]string, 0, len(rows))
+	args := make([]any, 0, len(rows)*singleRowPlaceholderCount)
+	for _, row := range rows {
+		placeholders = append(placeholders, "("+strings.Repeat("?,", singleRowPlaceholderCount-1)+"?)")
+		args = append(args, row.HostCertificateID, row.Source, row.Username)
 	}
-
-	// Check if any sources exist before deleting to avoid unnecessary gap locks
-	stmtCheck := `SELECT EXISTS(SELECT 1 FROM host_certificate_sources WHERE host_certificate_id IN (?))`
-	stmtCheck, args, err := sqlx.In(stmtCheck, certIDs)
-	if err != nil {
-		return ctxerr.Wrap(ctx, err, "building check host cert sources query")
-	}
-	var exists bool
-	if err := sqlx.GetContext(ctx, tx, &exists, stmtCheck, args...); err != nil {
-		return ctxerr.Wrap(ctx, err, "checking if host cert sources exist")
-	}
-
-	// Only delete if sources exist
-	if exists {
-		stmtDelete := `DELETE FROM host_certificate_sources WHERE host_certificate_id IN (?)`
-		stmtDelete, args, err := sqlx.In(stmtDelete, certIDs)
-		if err != nil {
-			return ctxerr.Wrap(ctx, err, "building delete host cert sources query")
-		}
-		if _, err := tx.ExecContext(ctx, stmtDelete, args...); err != nil {
-			return ctxerr.Wrap(ctx, err, "deleting host cert sources")
-		}
-	}
-
-	// Insert new sources
-	stmtInsert := `
+	stmt := fmt.Sprintf(`
 	INSERT INTO host_certificate_sources (
 		host_certificate_id,
 		source,
 		username
-	) VALUES %s`
-
-	const singleRowPlaceholderCount = 3
-	placeholders := make([]string, 0, len(toReplaceSources))
-	args = make([]any, 0, len(toReplaceSources)*singleRowPlaceholderCount)
-	for _, source := range toReplaceSources {
-		placeholders = append(placeholders, "("+strings.Repeat("?,", singleRowPlaceholderCount-1)+"?)")
-		args = append(args, source.ID, source.Source, source.Username)
-	}
-
-	stmtInsert = fmt.Sprintf(stmtInsert, strings.Join(placeholders, ","))
-	if _, err := tx.ExecContext(ctx, stmtInsert, args...); err != nil {
+	) VALUES %s
+	ON DUPLICATE KEY UPDATE host_certificate_id = host_certificate_sources.host_certificate_id`,
+		strings.Join(placeholders, ","))
+	if _, err := tx.ExecContext(ctx, stmt, args...); err != nil {
 		return ctxerr.Wrap(ctx, err, "inserting host cert sources")
 	}
 	return nil

--- a/server/datastore/mysql/host_certificates_test.go
+++ b/server/datastore/mysql/host_certificates_test.go
@@ -37,6 +37,8 @@ func TestHostCertificates(t *testing.T) {
 		{"Update certificate sources isolation", testUpdateHostCertificatesSourcesIsolation},
 		{"Windows scope-aware reconciliation", testUpdateHostCertificatesWindowsScopeReconciliation},
 		{"Re-ingest after soft delete attaches sources to live row", testUpdateHostCertificatesReingestAfterSoftDelete},
+		{"Self-heals duplicate cert rows and converges", testUpdateHostCertificatesSelfHealsDuplicates},
+		{"Precise source writes preserve unchanged rows", testUpdateHostCertificatesPreciseSourceWrites},
 		{"Origin-scoped delete", testUpdateHostCertificatesOriginScopedDelete},
 		{"Origin downgrade on osquery rediscovery", testUpdateHostCertificatesOriginDowngrade},
 		{"Create certificates with long country code", testHostCertificateWithInvalidCountryCode},
@@ -1254,6 +1256,176 @@ func testUpdateHostCertificatesReingestAfterSoftDelete(t *testing.T, ds *Datasto
 	got, err = loadHostCertIDsForSHA1DB(ctx, ds.reader(ctx), hostID, []string{sha1Hex})
 	require.NoError(t, err)
 	require.Empty(t, got)
+}
+
+// testUpdateHostCertificatesSelfHealsDuplicates reproduces the bad host state behind issue: host_certificates has no unique index
+// on (host_id, sha1_sum), so concurrent re-ingestion of the same report (osquery resends results after a timed-out write, or a
+// stale replica read) can leave duplicate active rows per certificate. The fix must soft-delete the duplicates on the next report
+// (self-heal) and produce zero source-row writes on subsequent identical reports (convergence).
+func testUpdateHostCertificatesSelfHealsDuplicates(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+	const (
+		hostID   = uint(88)
+		hostUUID = "dup-rows-host-uuid"
+	)
+
+	certSys := mkTestCertRecord(t, hostID, "dup-sys.example.com", fleet.SystemHostCertificate, "")
+	certPairSys := mkTestCertRecord(t, hostID, "dup-pair.example.com", fleet.SystemHostCertificate, "")
+	// The same certificate observed in a user scope too (two source rows, one cert row).
+	pairUserCopy := *certPairSys
+	pairUserCopy.Source = fleet.UserHostCertificate
+	pairUserCopy.Username = "alice"
+	certPairUser := &pairUserCopy
+
+	ingest := func() {
+		sysCopy := *certSys
+		pairSysCopy := *certPairSys
+		pairUserCopyLocal := *certPairUser
+		require.NoError(t, ds.UpdateHostCertificates(ctx, hostID, hostUUID,
+			[]*fleet.HostCertificateRecord{&sysCopy, &pairSysCopy, &pairUserCopyLocal},
+			fleet.HostCertificateOriginOsquery, nil))
+	}
+
+	ingest()
+
+	// Simulate the concurrent double-ingest: duplicate every active cert row and its source rows under new ids.
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		_, err := q.ExecContext(ctx, `
+			INSERT INTO host_certificates
+				(host_id, sha1_sum, not_valid_after, not_valid_before, certificate_authority, common_name,
+				key_algorithm, key_strength, key_usage, serial, signing_algorithm, subject_country, subject_org,
+				subject_org_unit, subject_common_name, issuer_country, issuer_org, issuer_org_unit,
+				issuer_common_name, origin)
+			SELECT host_id, sha1_sum, not_valid_after, not_valid_before, certificate_authority, common_name,
+				key_algorithm, key_strength, key_usage, serial, signing_algorithm, subject_country, subject_org,
+				subject_org_unit, subject_common_name, issuer_country, issuer_org, issuer_org_unit,
+				issuer_common_name, origin
+			FROM host_certificates WHERE host_id = ? AND deleted_at IS NULL`, hostID)
+		return err
+	})
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		_, err := q.ExecContext(ctx, `
+			INSERT INTO host_certificate_sources (host_certificate_id, source, username)
+			SELECT hcDup.id, hcs.source, hcs.username
+			FROM host_certificate_sources hcs
+			JOIN host_certificates hcOrig ON hcOrig.id = hcs.host_certificate_id
+			JOIN host_certificates hcDup
+				ON hcDup.host_id = hcOrig.host_id AND hcDup.sha1_sum = hcOrig.sha1_sum AND hcDup.id > hcOrig.id
+			WHERE hcOrig.host_id = ?`, hostID)
+		return err
+	})
+
+	countActiveCerts := func() int {
+		var n int
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			return sqlx.GetContext(ctx, q, &n,
+				`SELECT COUNT(*) FROM host_certificates WHERE host_id = ? AND deleted_at IS NULL`, hostID)
+		})
+		return n
+	}
+	sourceRowIDs := func() []uint {
+		var ids []uint
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			return sqlx.SelectContext(ctx, q, &ids, `
+				SELECT hcs.id FROM host_certificate_sources hcs
+				JOIN host_certificates hc ON hc.id = hcs.host_certificate_id
+				WHERE hc.host_id = ? ORDER BY hcs.id`, hostID)
+		})
+		return ids
+	}
+
+	require.Equal(t, 4, countActiveCerts(), "setup: expected duplicated active cert rows")
+	require.Len(t, sourceRowIDs(), 6, "setup: expected duplicated source rows")
+
+	// One identical report self-heals: duplicates soft-deleted, their source rows removed.
+	ingest()
+	require.Equal(t, 2, countActiveCerts(), "expected duplicates to be soft-deleted")
+	healedSourceIDs := sourceRowIDs()
+	require.Len(t, healedSourceIDs, 3, "expected duplicate source rows to be removed")
+
+	// Convergence: further identical reports must not rewrite any source rows.
+	for range 2 {
+		ingest()
+		require.Equal(t, healedSourceIDs, sourceRowIDs(), "identical report must not rewrite host_certificate_sources rows")
+		require.Equal(t, 2, countActiveCerts())
+	}
+
+	// The API view is deduplicated again: exactly one row per (cert, source), with the right scopes surviving.
+	listed, _, err := ds.ListHostCertificates(ctx, hostID, fleet.ListOptions{OrderKey: "common_name", TestSecondaryOrderKey: "username"})
+	require.NoError(t, err)
+	type listedRow struct {
+		commonName string
+		source     fleet.HostCertificateSource
+		username   string
+	}
+	got := make([]listedRow, 0, len(listed))
+	for _, l := range listed {
+		got = append(got, listedRow{l.CommonName, l.Source, l.Username})
+	}
+	require.Equal(t, []listedRow{
+		{"dup-pair.example.com", fleet.SystemHostCertificate, ""},
+		{"dup-pair.example.com", fleet.UserHostCertificate, "alice"},
+		{"dup-sys.example.com", fleet.SystemHostCertificate, ""},
+	}, got)
+}
+
+// testUpdateHostCertificatesPreciseSourceWrites verifies that a source-set change touches only the rows that actually
+// changed: unchanged source rows must keep their primary key (no delete-and-reinsert).
+func testUpdateHostCertificatesPreciseSourceWrites(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+	const (
+		hostID   = uint(89)
+		hostUUID = "precise-writes-host-uuid"
+	)
+
+	base := mkTestCertRecord(t, hostID, "precise.example.com", fleet.SystemHostCertificate, "")
+	ingest := func(sources ...fleet.HostCertificateScope) {
+		records := make([]*fleet.HostCertificateRecord, 0, len(sources))
+		for _, s := range sources {
+			rec := *base
+			rec.Source = s.Source
+			rec.Username = s.Username
+			records = append(records, &rec)
+		}
+		require.NoError(t, ds.UpdateHostCertificates(ctx, hostID, hostUUID, records, fleet.HostCertificateOriginOsquery, nil))
+	}
+
+	type sourceRow struct {
+		ID       uint   `db:"id"`
+		Source   string `db:"source"`
+		Username string `db:"username"`
+	}
+	sourceRows := func() []sourceRow {
+		var rows []sourceRow
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			return sqlx.SelectContext(ctx, q, &rows, `
+				SELECT hcs.id, hcs.source, hcs.username FROM host_certificate_sources hcs
+				JOIN host_certificates hc ON hc.id = hcs.host_certificate_id
+				WHERE hc.host_id = ? ORDER BY hcs.source, hcs.username`, hostID)
+		})
+		return rows
+	}
+
+	ingest(
+		fleet.HostCertificateScope{Source: fleet.SystemHostCertificate},
+		fleet.HostCertificateScope{Source: fleet.UserHostCertificate, Username: "alice"},
+	)
+	before := sourceRows()
+	require.Len(t, before, 2)
+	systemRowID := before[0].ID
+	require.Equal(t, "system", before[0].Source)
+	require.Equal(t, "alice", before[1].Username)
+
+	// alice's scope is replaced by bob's; the system row must be untouched.
+	ingest(
+		fleet.HostCertificateScope{Source: fleet.SystemHostCertificate},
+		fleet.HostCertificateScope{Source: fleet.UserHostCertificate, Username: "bob"},
+	)
+	after := sourceRows()
+	require.Len(t, after, 2)
+	require.Equal(t, systemRowID, after[0].ID, "unchanged system source row must keep its primary key")
+	require.Equal(t, "system", after[0].Source)
+	require.Equal(t, "bob", after[1].Username, "alice's source row should be replaced by bob's")
 }
 
 // mkTestCertRecord builds a HostCertificateRecord for hostID with a random serial, valid from an hour ago to 24 hours

--- a/server/fleet/host_certificates.go
+++ b/server/fleet/host_certificates.go
@@ -91,6 +91,9 @@ type HostCertificateRecord struct {
 
 	Source   HostCertificateSource `json:"-" db:"source"`
 	Username string                `json:"-" db:"username"` // username that owns the certificate, only if source == 'user'
+	// SourceID is the id of the host_certificate_sources row this record's Source/Username pair came from. Internal:
+	// populated by the datastore list query so stale source rows can be deleted precisely by primary key.
+	SourceID uint `json:"-" db:"source_id"`
 
 	// Origin identifies the ingestion source (osquery vs mdm). Used internally to
 	// scope deletion semantics; not exposed in the public API.


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #49705

Verified fix with 100k host Windows load test.

# Checklist for submitter

## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host
isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Alerted the release DRI if additional load testing is needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
* Improved host certificate deduplication and automated self-healing when duplicate certificate records are ingested.
* Updated source reconciliation to only change what’s stale, preventing unnecessary rewrites of unchanged source entries.
* Ensured certificate sources consistently associate to the newest canonical certificate record for each certificate hash.
* Improved certificate listing accuracy by returning a deduplicated set of certificate/source pairs with correct usernames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

(cherry picked from commit f72de68f43117b52682c3a2cf5d6a127eccaf1eb)

