### PR TITLE
Fleet UI: Hide empty host summary card on Free-tier Android hosts

### DIFF
--- a/changes/fix-49441-android-free-empty-summary-card
+++ b/changes/fix-49441-android-free-empty-summary-card
@@ -1,1 +1,0 @@
-* Fixed an empty summary card rendering above the Vitals section on the host details page for Android hosts on Fleet Free.

--- a/changes/fix-49441-android-free-empty-summary-card
+++ b/changes/fix-49441-android-free-empty-summary-card
@@ -1,0 +1,1 @@
+* Fixed an empty summary card rendering above the Vitals section on the host details page for Android hosts on Fleet Free.

--- a/changes/fix-49441-free-tier-empty-summary-card
+++ b/changes/fix-49441-free-tier-empty-summary-card
@@ -1,0 +1,1 @@
+* Fixed an empty summary card rendering above the Vitals section on the host details page for Fleet Free hosts with no summary content (Android, and iOS/iPadOS with no OS settings).

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tests.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tests.tsx
@@ -6,6 +6,7 @@ import createMockUser from "__mocks__/userMock";
 import { createMockHostSummary } from "__mocks__/hostMock";
 
 import { BootstrapPackageStatus } from "interfaces/mdm";
+import { HostPlatform } from "interfaces/platform";
 import HostSummary from "./HostSummary";
 
 describe("Host Summary section", () => {
@@ -201,7 +202,7 @@ describe("Host Summary section", () => {
   });
 
   describe("Empty card", () => {
-    it.each([
+    it.each<[string, HostPlatform, string]>([
       ["Android", "android", "Android 14"],
       ["iOS", "ios", "iOS 17.4"],
       ["iPadOS", "ipados", "iPadOS 17.4"],
@@ -218,7 +219,7 @@ describe("Host Summary section", () => {
           },
         });
         const summaryData = createMockHostSummary({
-          platform: platform as "android" | "ios" | "ipados",
+          platform,
           os_version,
         });
 

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tests.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tests.tsx
@@ -201,31 +201,38 @@ describe("Host Summary section", () => {
   });
 
   describe("Empty card", () => {
-    it("does not render the summary card for a Free-tier Android host with no OS settings", () => {
-      const render = createCustomRenderer({
-        context: {
-          app: {
-            isPremiumTier: false,
-            isGlobalAdmin: true,
-            currentUser: createMockUser(),
+    it.each([
+      ["Android", "android", "Android 14"],
+      ["iOS", "ios", "iOS 17.4"],
+      ["iPadOS", "ipados", "iPadOS 17.4"],
+    ])(
+      "does not render the summary card for a Free-tier %s host with no OS settings",
+      (_label, platform, os_version) => {
+        const render = createCustomRenderer({
+          context: {
+            app: {
+              isPremiumTier: false,
+              isGlobalAdmin: true,
+              currentUser: createMockUser(),
+            },
           },
-        },
-      });
-      const summaryData = createMockHostSummary({
-        platform: "android",
-        os_version: "Android 14",
-      });
+        });
+        const summaryData = createMockHostSummary({
+          platform: platform as "android" | "ios" | "ipados",
+          os_version,
+        });
 
-      const { container } = render(
-        <HostSummary
-          summaryData={summaryData}
-          isPremiumTier={false}
-          hostSettings={[]}
-        />
-      );
+        const { container } = render(
+          <HostSummary
+            summaryData={summaryData}
+            isPremiumTier={false}
+            hostSettings={[]}
+          />
+        );
 
-      expect(container).toBeEmptyDOMElement();
-    });
+        expect(container).toBeEmptyDOMElement();
+      }
+    );
   });
 
   describe("Bootstrap package data", () => {

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tests.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tests.tsx
@@ -200,6 +200,34 @@ describe("Host Summary section", () => {
     });
   });
 
+  describe("Empty card", () => {
+    it("does not render the summary card for a Free-tier Android host with no OS settings", () => {
+      const render = createCustomRenderer({
+        context: {
+          app: {
+            isPremiumTier: false,
+            isGlobalAdmin: true,
+            currentUser: createMockUser(),
+          },
+        },
+      });
+      const summaryData = createMockHostSummary({
+        platform: "android",
+        os_version: "Android 14",
+      });
+
+      const { container } = render(
+        <HostSummary
+          summaryData={summaryData}
+          isPremiumTier={false}
+          hostSettings={[]}
+        />
+      );
+
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+
   describe("Bootstrap package data", () => {
     it("renders Bootstrap package indicator when status is present", () => {
       const toggleBootstrapPackageModal = jest.fn();

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
@@ -202,13 +202,45 @@ const HostSummary = ({
       : [hostNameSetting];
   }
 
+  const showStatus = !isIosOrIpadosHost && !isAndroidHost;
+  const showTeam = !!isPremiumTier;
+  const showOsSettings =
+    isOsSettingsDisplayPlatform(platform, os_version) &&
+    !!derivedHostSettings &&
+    derivedHostSettings.length > 0;
+  const showIssues =
+    summaryData.issues?.total_issues_count > 0 &&
+    !isIosOrIpadosHost &&
+    !isAndroidHost;
+  const showBootstrapPackage =
+    !!bootstrapPackageData?.status && !isIosOrIpadosHost && !isAndroidHost;
+  const showMaintenanceWindow =
+    !!isPremiumTier &&
+    // TODO - refactor normalizeEmptyValues pattern
+    !!summaryData.maintenance_window &&
+    summaryData.maintenance_window !== "---";
+
+  // Hide the card entirely when nothing inside it would render (e.g. Free tier
+  // Android host with no OS settings) — otherwise an empty card sits above the
+  // Vitals section (#49441).
+  if (
+    !showStatus &&
+    !showTeam &&
+    !showOsSettings &&
+    !showIssues &&
+    !showBootstrapPackage &&
+    !showMaintenanceWindow
+  ) {
+    return <></>;
+  }
+
   return (
     <Card
       borderRadiusSize="xxlarge"
       paddingSize="xlarge"
       className={classNames}
     >
-      {!isIosOrIpadosHost && !isAndroidHost && (
+      {showStatus && (
         <DataSet
           title="Status"
           value={
@@ -224,26 +256,21 @@ const HostSummary = ({
           }
         />
       )}
-      {isPremiumTier && renderHostTeam()}
-      {isOsSettingsDisplayPlatform(platform, os_version) &&
-        derivedHostSettings &&
-        derivedHostSettings.length > 0 && (
-          <DataSet
-            className={`${baseClass}__os-settings`}
-            title="OS settings"
-            value={
-              <OSSettingsIndicator
-                profiles={derivedHostSettings}
-                onClick={toggleOSSettingsModal}
-              />
-            }
-          />
-        )}
-      {summaryData.issues?.total_issues_count > 0 &&
-        !isIosOrIpadosHost &&
-        !isAndroidHost &&
-        renderIssues()}
-      {bootstrapPackageData?.status && !isIosOrIpadosHost && !isAndroidHost && (
+      {showTeam && renderHostTeam()}
+      {showOsSettings && derivedHostSettings && (
+        <DataSet
+          className={`${baseClass}__os-settings`}
+          title="OS settings"
+          value={
+            <OSSettingsIndicator
+              profiles={derivedHostSettings}
+              onClick={toggleOSSettingsModal}
+            />
+          }
+        />
+      )}
+      {showIssues && renderIssues()}
+      {showBootstrapPackage && bootstrapPackageData?.status && (
         <DataSet
           title="Bootstrap package"
           value={
@@ -254,10 +281,7 @@ const HostSummary = ({
           }
         />
       )}
-      {isPremiumTier &&
-        // TODO - refactor normalizeEmptyValues pattern
-        !!summaryData.maintenance_window &&
-        summaryData.maintenance_window !== "---" &&
+      {showMaintenanceWindow &&
         renderMaintenanceWindow(summaryData.maintenance_window)}
     </Card>
   );

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
@@ -66,7 +66,7 @@ const HostSummary = ({
   hostSettings,
   osSettings,
   className,
-}: IHostSummaryProps): JSX.Element => {
+}: IHostSummaryProps): JSX.Element | null => {
   const classNames = classnames(baseClass, className);
 
   const { status, platform, os_version, mdm } = summaryData;
@@ -234,7 +234,7 @@ const HostSummary = ({
     !showBootstrapPackage &&
     !showMaintenanceWindow
   ) {
-    return <></>;
+    return null;
   }
 
   return (

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
@@ -24,7 +24,10 @@ import DataSet from "components/DataSet";
 import StatusIndicator from "components/StatusIndicator";
 import IssuesIndicator from "pages/hosts/components/IssuesIndicator";
 
-import { DATE_FNS_FORMAT_STRINGS } from "utilities/constants";
+import {
+  DATE_FNS_FORMAT_STRINGS,
+  DEFAULT_EMPTY_CELL_VALUE,
+} from "utilities/constants";
 
 import OSSettingsIndicator from "./OSSettingsIndicator";
 import BootstrapPackageIndicator from "./BootstrapPackageIndicator/BootstrapPackageIndicator";
@@ -95,7 +98,7 @@ const HostSummary = ({
     <DataSet
       title="Fleet"
       value={
-        summaryData.team_name !== "---" ? (
+        summaryData.team_name !== DEFAULT_EMPTY_CELL_VALUE ? (
           `${summaryData.team_name}`
         ) : (
           <span className="no-team">Unassigned</span>
@@ -218,11 +221,11 @@ const HostSummary = ({
     !!isPremiumTier &&
     // TODO - refactor normalizeEmptyValues pattern
     !!summaryData.maintenance_window &&
-    summaryData.maintenance_window !== "---";
+    summaryData.maintenance_window !== DEFAULT_EMPTY_CELL_VALUE;
 
   // Hide the card entirely when nothing inside it would render (e.g. Free tier
   // Android host with no OS settings) — otherwise an empty card sits above the
-  // Vitals section (#49441).
+  // Vitals section.
   if (
     !showStatus &&
     !showTeam &&


### PR DESCRIPTION
## Issue

Resolves #49441

## Description

On Fleet Free, the host details page renders an empty card above the Vitals section for hosts where every summary section is gated off. The reporter flagged this for Android, but the same shape hits iOS and iPadOS too:

- **Status / Issues / Bootstrap package** — hidden for Android *and* for iOS/iPadOS (`!isAndroidHost`, `!isIosOrIpadosHost`)
- **Fleet (team) / Scheduled maintenance** — hidden on Free (`!isPremiumTier`)
- **OS settings** — only shows when the host actually has settings

When none apply, the wrapper still renders empty. Hoisted each section's visibility into named `show*` booleans and short-circuit to `<></>` when none are true, so the card is skipped instead of rendering an empty shell. The rendering conditions themselves are unchanged.

## Screenshot mock returning null instead of the card

<img width="1421" height="337" alt="Screenshot 2026-07-23 at 12 28 07 PM" src="https://github.com/user-attachments/assets/25b6ac1d-5a4d-4bc0-b90e-a73e6b9fb065" />

## Testing

- [x] Added parametrized `HostSummary` tests asserting the card renders nothing for Free-tier Android, iOS, and iPadOS hosts with no OS settings
- [x] `yarn test --testPathPattern=HostSummary` — 12/12 pass
- [x] `make lint-js` — 0 errors in touched files
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an empty summary card appearing above the Vitals section on Fleet Free host details pages.
  * Summary cards now remain hidden when no relevant content is available for Android, iOS, and iPadOS hosts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->