### PR TITLE
Patch when closed: install skip, no-retry, and activity

### DIFF
--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -2184,11 +2184,13 @@ SELECT
 	hsi.created_at as created_at,
 	hsi.updated_at as updated_at,
 	st.source,
-	hsi.attempt_number
+	hsi.attempt_number,
+	COALESCE(p.patch_when_closed, 0) AS patch_when_closed
 FROM
 	host_software_installs hsi
 	LEFT JOIN software_titles st ON hsi.software_title_id = st.id
 	LEFT JOIN software_installers si ON hsi.software_installer_id = si.id
+	LEFT JOIN policies p ON hsi.policy_id = p.id
 WHERE
 	hsi.execution_id = :execution_id AND
 	hsi.uninstall = 0 AND
@@ -2217,7 +2219,8 @@ SELECT
 	ua.created_at as created_at,
 	ua.updated_at as updated_at,
 	st.source,
-	NULL AS attempt_number
+	NULL AS attempt_number,
+	COALESCE(p.patch_when_closed, 0) AS patch_when_closed
 FROM
 	upcoming_activities ua
 	INNER JOIN software_install_upcoming_activities siua
@@ -2226,6 +2229,8 @@ FROM
 		ON siua.software_title_id = st.id
 	LEFT JOIN software_installers si
 		ON siua.software_installer_id = si.id
+	LEFT JOIN policies p
+		ON siua.policy_id = p.id
 WHERE
 	ua.execution_id = :execution_id AND
 	ua.activity_type = 'software_install' AND

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -1186,6 +1186,8 @@ type ActivityTypeInstalledSoftware struct {
 	FromSetupExperience bool    `json:"from_setup_experience"`
 	CommandUUID         string  `json:"command_uuid,omitempty"`
 	FailureReason       string  `json:"failure_reason,omitempty"`
+	// InstallSkippedWhenAppOpen is set only on a patch-when-closed skip; Status is then "failed_install".
+	InstallSkippedWhenAppOpen bool `json:"install_skipped_when_app_open,omitempty"`
 }
 
 func (a ActivityTypeInstalledSoftware) ActivityName() string {

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -490,10 +490,14 @@ type HostSoftwareInstallerResult struct {
 	// nil = not triggered by a policy
 	// 1,2,3 attempt, 3 being max retries
 	AttemptNumber *int `json:"attempt_number,omitempty" db:"attempt_number"`
+	// PatchWhenClosed is set from the triggering policy; it distinguishes an empty pre-install result
+	// caused by the app being open from an ordinary pre-install-query failure.
+	PatchWhenClosed bool `json:"-" db:"patch_when_closed"`
 }
 
 const (
 	SoftwareInstallerQueryFailCopy          = "Query didn't return result or failed\nInstall stopped"
+	SoftwareInstallerAppOpenCopy            = "The app was open\nInstall stopped"
 	SoftwareInstallerQuerySuccessCopy       = "Query returned result\nProceeding to install..."
 	SoftwareInstallerScriptsDisabledCopy    = "Installing software...\nError: Scripts are disabled for this host. To run scripts, deploy the fleetd agent with --enable-scripts."
 	SoftwareInstallerInstallFailCopy        = "Installing software...\nFailed\n%s"
@@ -516,7 +520,12 @@ func (h *HostSoftwareInstallerResult) EnhanceOutputDetails() {
 
 	if h.PreInstallQueryOutput != nil {
 		if *h.PreInstallQueryOutput == "" {
-			*h.PreInstallQueryOutput = SoftwareInstallerQueryFailCopy
+			// For patch-when-closed, an empty result means the app was open, not a query failure.
+			if h.PatchWhenClosed {
+				*h.PreInstallQueryOutput = SoftwareInstallerAppOpenCopy
+			} else {
+				*h.PreInstallQueryOutput = SoftwareInstallerQueryFailCopy
+			}
 			return
 		}
 		*h.PreInstallQueryOutput = SoftwareInstallerQuerySuccessCopy

--- a/server/fleet/software_test.go
+++ b/server/fleet/software_test.go
@@ -129,6 +129,28 @@ func TestEnhanceOutputDetails(t *testing.T) {
 			expectedPostInstallScriptOutput: nil,
 		},
 		{
+			name: "patch-when-closed empty pre-install output shows app-was-open copy",
+			initial: HostSoftwareInstallerResult{
+				Status:                SoftwareInstallFailed,
+				PreInstallQueryOutput: new(""),
+				PatchWhenClosed:       true,
+			},
+			expectedPreInstallQueryOutput:   new(SoftwareInstallerAppOpenCopy),
+			expectedOutput:                  nil,
+			expectedPostInstallScriptOutput: nil,
+		},
+		{
+			name: "non-managed empty pre-install output shows generic query-fail copy",
+			initial: HostSoftwareInstallerResult{
+				Status:                SoftwareInstallFailed,
+				PreInstallQueryOutput: new(""),
+				PatchWhenClosed:       false,
+			},
+			expectedPreInstallQueryOutput:   new(SoftwareInstallerQueryFailCopy),
+			expectedOutput:                  nil,
+			expectedPostInstallScriptOutput: nil,
+		},
+		{
 			name: "non-pending status with non-empty PreInstallQueryOutput",
 			initial: HostSoftwareInstallerResult{
 				Status:                SoftwareInstalled,

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -1634,6 +1634,17 @@ func (svc *Service) SaveHostSoftwareInstallResult(ctx context.Context, result *f
 		return err
 	}
 
+	// A patch-when-closed policy install whose managed app-open query returned no result means the
+	// app was open: a skip, not a failure. Key on the policy flag, not empty output, so an ordinary
+	// empty pre_install_query on a non-managed policy still fails and counts toward the retry cap.
+	isAppOpenSkip := false
+	if result.Status() == fleet.SoftwareInstallFailed &&
+		result.PreInstallConditionOutput != nil && *result.PreInstallConditionOutput == "" {
+		if cur, curErr := svc.ds.GetSoftwareInstallResults(ctx, result.InstallUUID); curErr == nil && cur != nil {
+			isAppOpenSkip = cur.PolicyID != nil && cur.PatchWhenClosed
+		}
+	}
+
 	// Check if a non-policy install failure will be retried so we can skip
 	// updating setup experience status during intermediate retries.
 	willRetryNonPolicyOnFailure := false
@@ -1673,7 +1684,13 @@ func (svc *Service) SaveHostSoftwareInstallResult(ctx context.Context, result *f
 		}
 	}
 
-	installWasCanceled, err := svc.ds.SetHostSoftwareInstallResult(ctx, result, attemptNumber)
+	// attempt_number=0 keeps the skip out of the retry-sequence count, so it never consumes an attempt.
+	attemptToStore := attemptNumber
+	if isAppOpenSkip {
+		attemptToStore = new(0)
+	}
+
+	installWasCanceled, err := svc.ds.SetHostSoftwareInstallResult(ctx, result, attemptToStore)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "save host software installation result")
 	}
@@ -1703,7 +1720,8 @@ func (svc *Service) SaveHostSoftwareInstallResult(ctx context.Context, result *f
 				policyName = &policy.Name // fall back to blank policy name if we can't retrieve the policy
 			}
 
-			if status == fleet.SoftwareInstallFailed {
+			// Skip the immediate-retry ladder for app-open skips; the next continuous run re-fires.
+			if status == fleet.SoftwareInstallFailed && !isAppOpenSkip {
 				shouldRetry, err := svc.shouldRetryPolicyAutomationSoftwareInstall(ctx, host, hsi)
 				if err != nil {
 					svc.logger.ErrorContext(ctx,
@@ -1756,18 +1774,19 @@ func (svc *Service) SaveHostSoftwareInstallResult(ctx context.Context, result *f
 			ctx,
 			user,
 			fleet.ActivityTypeInstalledSoftware{
-				HostID:              host.ID,
-				HostDisplayName:     host.DisplayName(),
-				SoftwareTitle:       hsi.SoftwareTitle,
-				SoftwarePackage:     hsi.SoftwarePackage,
-				HashSHA256:          hsi.HashSHA256,
-				InstallUUID:         result.InstallUUID,
-				Status:              string(status),
-				Source:              hsi.Source,
-				SelfService:         hsi.SelfService,
-				PolicyID:            hsi.PolicyID,
-				PolicyName:          policyName,
-				FromSetupExperience: fromSetupExperience,
+				HostID:                    host.ID,
+				HostDisplayName:           host.DisplayName(),
+				SoftwareTitle:             hsi.SoftwareTitle,
+				SoftwarePackage:           hsi.SoftwarePackage,
+				HashSHA256:                hsi.HashSHA256,
+				InstallUUID:               result.InstallUUID,
+				Status:                    string(status),
+				Source:                    hsi.Source,
+				SelfService:               hsi.SelfService,
+				PolicyID:                  hsi.PolicyID,
+				PolicyName:                policyName,
+				FromSetupExperience:       fromSetupExperience,
+				InstallSkippedWhenAppOpen: isAppOpenSkip,
 			},
 		); err != nil {
 			return ctxerr.Wrap(ctx, err, "create activity for software installation")

--- a/server/service/orbit_test.go
+++ b/server/service/orbit_test.go
@@ -1230,6 +1230,182 @@ func TestSoftwareInstallReplicaLag(t *testing.T) {
 	require.Equal(t, 1, retryCount, "should have scheduled a retry in upcoming_activities")
 }
 
+// TestSaveHostSoftwareInstallResultAppOpenSkip verifies that an app-open result on a patch-when-closed
+// policy install is a skip (attempt_number=0, no retry, activity flagged), while an ordinary empty
+// pre_install_query on a non-managed policy still fails, counts, and retries.
+func TestSaveHostSoftwareInstallResultAppOpenSkip(t *testing.T) {
+	ds := mysqltest.CreateMySQLDS(t)
+	defer ds.Close()
+
+	opts := &TestServerOpts{License: &fleet.LicenseInfo{Tier: fleet.TierPremium}, SkipCreateTestUsers: true}
+	svc, ctx := newTestService(t, ds, nil, nil, opts)
+
+	// The test service mocks the activity service, so capture emitted activities by install UUID.
+	installedActivities := make(map[string]fleet.ActivityTypeInstalledSoftware)
+	opts.ActivityMock.NewActivityFunc = func(_ context.Context, _ *activity_api.User, activity activity_api.ActivityDetails) error {
+		if a, ok := activity.(fleet.ActivityTypeInstalledSoftware); ok {
+			installedActivities[a.InstallUUID] = a
+		}
+		return nil
+	}
+
+	user, err := ds.NewUser(ctx, &fleet.User{
+		Name:       "Admin",
+		Password:   []byte("p4ssw0rd.123"),
+		Email:      "admin@example.com",
+		GlobalRole: new(fleet.RoleAdmin),
+	})
+	require.NoError(t, err)
+	ctx = viewer.NewContext(ctx, viewer.Viewer{User: user})
+
+	installerPayload := &fleet.UploadSoftwareInstallerPayload{
+		InstallScript:   "echo 'installing'",
+		Filename:        "test_installer.pkg",
+		StorageID:       uuid.New().String(),
+		Title:           "Test Software",
+		Version:         "1.0.0",
+		Source:          "apps",
+		Platform:        "darwin",
+		UserID:          user.ID,
+		TeamID:          nil,
+		ValidatedLabels: &fleet.LabelIdentsWithScope{},
+	}
+	installerID, _, err := ds.MatchOrCreateSoftwareInstaller(ctx, installerPayload)
+	require.NoError(t, err)
+
+	var titleID uint
+	mysqltest.ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, q, &titleID,
+			`SELECT title_id FROM software_installers WHERE id = ?`, installerID)
+	})
+
+	// createFailingPolicy makes a global policy (optionally patch-when-closed) and marks it failing
+	// for the host so a retry would be eligible.
+	createFailingPolicy := func(t *testing.T, host *fleet.Host, patchWhenClosed bool) uint {
+		policy, err := ds.NewGlobalPolicy(ctx, &user.ID, fleet.PolicyPayload{
+			Name:  "policy-" + uuid.NewString(),
+			Query: "SELECT 1;",
+		})
+		require.NoError(t, err)
+		if patchWhenClosed {
+			mysqltest.ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+				_, err := q.ExecContext(ctx, `UPDATE policies SET patch_when_closed = 1 WHERE id = ?`, policy.ID)
+				return err
+			})
+		}
+		_, err = ds.RecordPolicyQueryExecutions(ctx, host, map[uint]*bool{policy.ID: new(false)}, time.Now(), false, nil)
+		require.NoError(t, err)
+		return policy.ID
+	}
+
+	// insertPendingInstall queues a pending policy-automation install, returning its execution id.
+	insertPendingInstall := func(t *testing.T, host *fleet.Host, policyID uint) string {
+		installUUID := uuid.New().String()
+		mysqltest.ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			_, err := q.ExecContext(ctx, `
+				INSERT INTO host_software_installs (
+					execution_id, host_id, software_installer_id, policy_id,
+					installer_filename, version, software_title_id, software_title_name
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+			`, installUUID, host.ID, installerID, policyID,
+				installerPayload.Filename, installerPayload.Version, titleID, installerPayload.Title)
+			return err
+		})
+		return installUUID
+	}
+
+	getAttemptNumber := func(t *testing.T, installUUID string) *int {
+		var attempt *int
+		mysqltest.ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			return sqlx.GetContext(ctx, q, &attempt,
+				`SELECT attempt_number FROM host_software_installs WHERE execution_id = ?`, installUUID)
+		})
+		return attempt
+	}
+
+	countPendingRetries := func(t *testing.T, hostID uint) int {
+		var n int
+		mysqltest.ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			return sqlx.GetContext(ctx, q, &n,
+				`SELECT COUNT(*) FROM upcoming_activities WHERE activity_type = 'software_install' AND host_id = ?`, hostID)
+		})
+		return n
+	}
+
+	t.Run("app open -> skip, no attempt consumed, no retry, activity flagged", func(t *testing.T) {
+		host := test.NewHost(t, ds, "skip-host", "10.0.0.1", uuid.NewString(), uuid.NewString(), time.Now())
+		installUUID := insertPendingInstall(t, host, createFailingPolicy(t, host, true))
+
+		result := &fleet.HostSoftwareInstallResultPayload{
+			HostID:                    host.ID,
+			InstallUUID:               installUUID,
+			PreInstallConditionOutput: new(""), // app open
+		}
+		hctx := hostctx.NewContext(ctx, host)
+		require.NoError(t, svc.SaveHostSoftwareInstallResult(hctx, result))
+
+		attempt := getAttemptNumber(t, installUUID)
+		require.NotNil(t, attempt)
+		require.Equal(t, 0, *attempt, "skip must not consume a retry attempt")
+
+		require.Equal(t, 0, countPendingRetries(t, host.ID), "skip must not queue an immediate retry")
+
+		act, ok := installedActivities[installUUID]
+		require.True(t, ok, "an installed_software activity should have been emitted")
+		require.Equal(t, string(fleet.SoftwareInstallFailed), act.Status)
+		require.True(t, act.InstallSkippedWhenAppOpen, "activity should be flagged as an app-open skip")
+	})
+
+	t.Run("regression: ordinary empty pre_install_query fails, counts, and retries", func(t *testing.T) {
+		host := test.NewHost(t, ds, "regress-host", "10.0.0.2", uuid.NewString(), uuid.NewString(), time.Now())
+		installUUID := insertPendingInstall(t, host, createFailingPolicy(t, host, false))
+
+		result := &fleet.HostSoftwareInstallResultPayload{
+			HostID:                    host.ID,
+			InstallUUID:               installUUID,
+			PreInstallConditionOutput: new(""),
+		}
+		hctx := hostctx.NewContext(ctx, host)
+		require.NoError(t, svc.SaveHostSoftwareInstallResult(hctx, result))
+
+		attempt := getAttemptNumber(t, installUUID)
+		require.NotNil(t, attempt)
+		require.Equal(t, 1, *attempt, "ordinary pre-install failure must count toward the retry limit")
+
+		require.Equal(t, 1, countPendingRetries(t, host.ID), "ordinary failure should queue a retry")
+
+		act, ok := installedActivities[installUUID]
+		require.True(t, ok, "an installed_software activity should have been emitted")
+		require.Equal(t, string(fleet.SoftwareInstallFailed), act.Status)
+		require.False(t, act.InstallSkippedWhenAppOpen, "non-managed failure must not be flagged as a skip")
+	})
+
+	t.Run("many consecutive app-open runs never hit the retry cap", func(t *testing.T) {
+		host := test.NewHost(t, ds, "many-runs-host", "10.0.0.3", uuid.NewString(), uuid.NewString(), time.Now())
+		policyID := createFailingPolicy(t, host, true)
+
+		// More consecutive runs than the retry cap; each is a fresh install the app-open query skips.
+		for range fleet.MaxPolicyAutomationRetries + 2 {
+			installUUID := insertPendingInstall(t, host, policyID)
+			hctx := hostctx.NewContext(ctx, host)
+			require.NoError(t, svc.SaveHostSoftwareInstallResult(hctx, &fleet.HostSoftwareInstallResultPayload{
+				HostID:                    host.ID,
+				InstallUUID:               installUUID,
+				PreInstallConditionOutput: new(""),
+			}))
+			attempt := getAttemptNumber(t, installUUID)
+			require.NotNil(t, attempt)
+			require.Equal(t, 0, *attempt, "every consecutive skip must store attempt_number=0")
+		}
+
+		// The count stays 0, so the cap is never reached and no retries queue.
+		count, err := ds.CountHostSoftwareInstallAttempts(ctx, host.ID, installerID, policyID)
+		require.NoError(t, err)
+		require.Equal(t, 0, count, "skips never accumulate toward the retry cap")
+		require.Equal(t, 0, countPendingRetries(t, host.ID), "skips never queue retries")
+	})
+}
+
 // TestGetOrbitConfigWindowsSetupExperience verifies that GetOrbitConfig sets
 // notifs.RunSetupExperience=true for Windows hosts whose MDM enrollment is
 // in awaiting_configuration Pending or Active, and false otherwise (None,

--- a/server/service/orbit_test.go
+++ b/server/service/orbit_test.go
@@ -1258,6 +1258,11 @@ func TestSaveHostSoftwareInstallResultAppOpenSkip(t *testing.T) {
 	require.NoError(t, err)
 	ctx = viewer.NewContext(ctx, viewer.Viewer{User: user})
 
+	// patch_when_closed is only valid on a team policy, never global: it forces continuous
+	// automations and a title-bound patch policy, both rejected on "All fleets".
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "patch-when-closed-team"})
+	require.NoError(t, err)
+
 	installerPayload := &fleet.UploadSoftwareInstallerPayload{
 		InstallScript:   "echo 'installing'",
 		Filename:        "test_installer.pkg",
@@ -1267,7 +1272,7 @@ func TestSaveHostSoftwareInstallResultAppOpenSkip(t *testing.T) {
 		Source:          "apps",
 		Platform:        "darwin",
 		UserID:          user.ID,
-		TeamID:          nil,
+		TeamID:          &team.ID,
 		ValidatedLabels: &fleet.LabelIdentsWithScope{},
 	}
 	installerID, _, err := ds.MatchOrCreateSoftwareInstaller(ctx, installerPayload)
@@ -1279,10 +1284,10 @@ func TestSaveHostSoftwareInstallResultAppOpenSkip(t *testing.T) {
 			`SELECT title_id FROM software_installers WHERE id = ?`, installerID)
 	})
 
-	// createFailingPolicy makes a global policy (optionally patch-when-closed) and marks it failing
-	// for the host so a retry would be eligible.
+	// createFailingPolicy makes a failing team policy for the host (optionally patch-when-closed) so a
+	// retry would be eligible. patch_when_closed isn't settable via the create path yet, so set it directly.
 	createFailingPolicy := func(t *testing.T, host *fleet.Host, patchWhenClosed bool) uint {
-		policy, err := ds.NewGlobalPolicy(ctx, &user.ID, fleet.PolicyPayload{
+		policy, err := ds.NewTeamPolicy(ctx, team.ID, &user.ID, fleet.PolicyPayload{
 			Name:  "policy-" + uuid.NewString(),
 			Query: "SELECT 1;",
 		})
@@ -1334,6 +1339,7 @@ func TestSaveHostSoftwareInstallResultAppOpenSkip(t *testing.T) {
 
 	t.Run("app open -> skip, no attempt consumed, no retry, activity flagged", func(t *testing.T) {
 		host := test.NewHost(t, ds, "skip-host", "10.0.0.1", uuid.NewString(), uuid.NewString(), time.Now())
+		require.NoError(t, ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&team.ID, []uint{host.ID})))
 		installUUID := insertPendingInstall(t, host, createFailingPolicy(t, host, true))
 
 		result := &fleet.HostSoftwareInstallResultPayload{
@@ -1358,6 +1364,7 @@ func TestSaveHostSoftwareInstallResultAppOpenSkip(t *testing.T) {
 
 	t.Run("regression: ordinary empty pre_install_query fails, counts, and retries", func(t *testing.T) {
 		host := test.NewHost(t, ds, "regress-host", "10.0.0.2", uuid.NewString(), uuid.NewString(), time.Now())
+		require.NoError(t, ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&team.ID, []uint{host.ID})))
 		installUUID := insertPendingInstall(t, host, createFailingPolicy(t, host, false))
 
 		result := &fleet.HostSoftwareInstallResultPayload{
@@ -1382,6 +1389,7 @@ func TestSaveHostSoftwareInstallResultAppOpenSkip(t *testing.T) {
 
 	t.Run("many consecutive app-open runs never hit the retry cap", func(t *testing.T) {
 		host := test.NewHost(t, ds, "many-runs-host", "10.0.0.3", uuid.NewString(), uuid.NewString(), time.Now())
+		require.NoError(t, ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&team.ID, []uint{host.ID})))
 		policyID := createFailingPolicy(t, host, true)
 
 		// More consecutive runs than the retry cap; each is a fresh install the app-open query skips.


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #49417

Makes an "app was open" result on a patch-when-closed policy install a **skip** rather than a failure:

- Detects the skip in `SaveHostSoftwareInstallResult` — policy `patch_when_closed` + empty pre-install output — and labels the `installed_software` activity with `install_skipped_when_app_open`.
- Doesn't let the skip consume a retry attempt: stores `attempt_number = 0` (excluded from the retry-sequence count) and doesn't queue an immediate retry — the next continuous-automation run re-fires.
- Shows "The app was open" copy in install details, distinct from the generic pre-install-query-failed copy.
- Keys on the managed policy flag, not on empty output, so an ordinary empty `pre_install_query` on a non-managed policy still fails and still counts toward the retry limit.

The `changes/` entry for this feature lives on the base feature branch per the stacked-PR convention.

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements).
- [x] Timeouts are implemented and retries are limited to avoid infinite loops.

## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one host's records do not affect another)
- [x] QA'd all new/changed functionality manually
  - Drove the orbit `software_install/result` endpoint end-to-end against a running server: app-open result → `failed_install`, activity `install_skipped_when_app_open: true`, `attempt_number = 0`, no retry queued, and install details showing "The app was open".
  - Regression: an ordinary empty `pre_install_query` on a non-managed policy still fails, counts (`attempt_number = 1`), and queues a retry.
