### PR TITLE
Fleet UI: Drop I-beam cursor on non-underlined tooltips

### DIFF
--- a/changes/fix-49438-issues-count-text-cursor
+++ b/changes/fix-49438-issues-count-text-cursor
@@ -1,0 +1,1 @@
+- Fixed tooltips wrapping icons or numeric values (like the Issues count on the host details page) showing a text (I-beam) cursor on hover, which made them look editable; those tooltips now use the default arrow cursor. Underlined-text tooltips are unchanged.

--- a/frontend/components/TooltipWrapper/_styles.scss
+++ b/frontend/components/TooltipWrapper/_styles.scss
@@ -8,6 +8,8 @@
   &__element {
     white-space: nowrap;
     line-height: inherit; // Same line height as parent
+    cursor: default;
+    user-select: none;
   }
 
   // text-decoration dashed cannot be used as it's not firefox compatible so must use border-bottom
@@ -16,6 +18,9 @@
     width: fit-content;
     border-bottom: 1px dashed $ui-fleet-black-50;
     margin-bottom: -1px;
+    // Underline variant wraps prose-style anchors — restore browser defaults so users can select text.
+    cursor: auto;
+    user-select: auto;
   }
 
   &__tip-text {

--- a/frontend/components/TooltipWrapper/_styles.scss
+++ b/frontend/components/TooltipWrapper/_styles.scss
@@ -9,7 +9,6 @@
     white-space: nowrap;
     line-height: inherit; // Same line height as parent
     cursor: default;
-    user-select: none;
   }
 
   // text-decoration dashed cannot be used as it's not firefox compatible so must use border-bottom


### PR DESCRIPTION
## Issue
Closes #49438

## Description
- Bug fix (root cause): `TooltipWrapper` never set a cursor on its anchor `<div>`, so the browser fell back to `cursor: auto` — which resolves to an I-beam over text content. Reporter noticed this on the Issues count on host details, where the value looks editable.
- Applied at the shared `TooltipWrapper` level, not just IssuesIndicator — the same behavior existed on every non-underlined tooltip anchor in the app.
- Split by variant: non-underlined tooltips (icons, numeric values, badges) now use `cursor: default` + `user-select: none`. Underlined tooltips (prose-style anchors like the SSO login tooltip) keep browser defaults so users can still select the text.

## Screenrecording
- Hover the Issues count on host details vs. an underlined tooltip anchor 



https://github.com/user-attachments/assets/893ac39b-36d2-4c72-955e-be9644af47dd


https://github.com/user-attachments/assets/fae512fa-2843-4790-8e04-dbd7ab4c2aea



## Testing

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated tooltip cursor behavior to prevent an I-beam cursor over icons and numeric values, such as issue counts.
  * Preserved standard text interaction and selection for underlined tooltips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->