### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/remote-desktop-manager/darwin.json
+++ b/ee/maintained-apps/outputs/remote-desktop-manager/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.2.3.2",
+      "version": "2026.2.4.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.devolutions.remotedesktopmanager';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.devolutions.remotedesktopmanager' AND version_compare(bundle_short_version, '2026.2.3.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.devolutions.remotedesktopmanager' AND version_compare(bundle_short_version, '2026.2.4.1') < 0);"
       },
-      "installer_url": "https://cdn.devolutions.net/download/Mac/Devolutions.RemoteDesktopManager.Mac.2026.2.3.2.dmg",
+      "installer_url": "https://cdn.devolutions.net/download/Mac/Devolutions.RemoteDesktopManager.Mac.2026.2.4.1.dmg",
       "install_script_ref": "4607770f",
       "uninstall_script_ref": "4fd2b3fa",
-      "sha256": "d56c53b091fb588b6b8fc06ae85596324d2ccf929ba469898c2a08ca43991fa0",
+      "sha256": "d138f14c8b2528e618ba6eb96acefff1e15bb4ae1c2cdd47b48ae4febc662e3a",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/superhuman/darwin.json
+++ b/ee/maintained-apps/outputs/superhuman/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1041.0.18",
+      "version": "1041.0.24",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.superhuman.mail';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.superhuman.mail' AND version_compare(bundle_short_version, '1041.0.18') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.superhuman.mail' AND version_compare(bundle_short_version, '1041.0.24') < 0);"
       },
-      "installer_url": "https://storage.googleapis.com/download.superhuman.com/supertron-update/Superhuman-1041.0.18-arm64-latest-mac.zip",
+      "installer_url": "https://storage.googleapis.com/download.superhuman.com/supertron-update/Superhuman-1041.0.24-arm64-latest-mac.zip",
       "install_script_ref": "b7ebe5bf",
       "uninstall_script_ref": "1809183d",
-      "sha256": "bc1e8f7413bb98f1b03ca0c12b970d5992845df83625f93f40bffbbfeaf38e5c",
+      "sha256": "489584dfcb913be56e0f2c81fedb440fd94f52f8e634cc3b83e65e5d619ed327",
       "default_categories": [
         "Communication"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the macOS Remote Desktop Manager package to version 2026.2.4.1.
  * Updated the macOS Superhuman package to version 1041.0.24.
  * Refreshed installer download links and verification checksums for both applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->