### PR TITLE
Patch when closed: policy and package api

### DIFF
--- a/ee/maintained-apps/ingesters/homebrew/ingester_test.go
+++ b/ee/maintained-apps/ingesters/homebrew/ingester_test.go
@@ -216,7 +216,7 @@ func TestIngestValidations(t *testing.T) {
 
 			// The managed "is app open" query matches a running process inside the app bundle.
 			require.Equal(t,
-				fmt.Sprintf("SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON LEFT(p.path, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = '%s');", out.UniqueIdentifier),
+				fmt.Sprintf("SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = '%s');", out.UniqueIdentifier),
 				out.Queries.Open,
 			)
 		})

--- a/ee/maintained-apps/ingesters/homebrew/ingester_test.go
+++ b/ee/maintained-apps/ingesters/homebrew/ingester_test.go
@@ -216,7 +216,7 @@ func TestIngestValidations(t *testing.T) {
 
 			// The managed "is app open" query matches a running process inside the app bundle.
 			require.Equal(t,
-				fmt.Sprintf("SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path LIKE concat(a.path, '/%%') WHERE a.bundle_identifier = '%s');", out.UniqueIdentifier),
+				fmt.Sprintf("SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON LEFT(p.path, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = '%s');", out.UniqueIdentifier),
 				out.Queries.Open,
 			)
 		})

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -809,17 +809,22 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 	}
 	var shouldDoSideEffects bool
 
-	existingPolicy, err := svc.ds.GetPatchPolicy(ctx, payload.TeamID, payload.TitleID)
-	if err != nil && !fleet.IsNotFound(err) {
-		return nil, ctxerr.Wrap(ctx, err, "getting patch policy")
-	}
-	patchFlag, patchWhenClosedFlag, err := planPatchPolicy(payload, existingInstaller, existingPolicy)
-	if err != nil {
-		return nil, err
-	}
-	if patchFlag && patchWhenClosedFlag && existingInstaller.PreInstallQuery != "" {
-		payload.PreInstallQuery = new("")
-		dirty["PreInstallQuery"] = true
+	var existingPolicy *fleet.PatchPolicyData
+	var patchFlag, patchWhenClosedFlag bool
+
+	if existingInstaller.FleetMaintainedAppID != nil {
+		existingPolicy, err = svc.ds.GetPatchPolicy(ctx, payload.TeamID, payload.TitleID)
+		if err != nil && !fleet.IsNotFound(err) {
+			return nil, ctxerr.Wrap(ctx, err, "getting patch policy")
+		}
+		patchFlag, patchWhenClosedFlag, err = planPatchPolicy(payload, existingInstaller, existingPolicy)
+		if err != nil {
+			return nil, err
+		}
+		if patchFlag && patchWhenClosedFlag && existingInstaller.PreInstallQuery != "" {
+			payload.PreInstallQuery = new("")
+			dirty["PreInstallQuery"] = true
+		}
 	}
 
 	// persist changes starting here, now that we've done all the validation/diffing we can

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -968,9 +968,15 @@ func (svc *Service) reconcilePatchPolicy(ctx context.Context, payload *fleet.Upd
 	if payload.PatchWhenClosed != nil && *payload.PatchWhenClosed && !patchEnabled {
 		return &fleet.BadRequestError{Message: `"patch_when_closed" requires "patch" to be enabled.`}
 	}
-	patchWhenClosed := patchEnabled && existing != nil && existing.PatchWhenClosed
-	if payload.PatchWhenClosed != nil {
-		patchWhenClosed = patchEnabled && *payload.PatchWhenClosed
+	// Default patch_when_closed on for a new patch policy, otherwise keep the existing value.
+	patchWhenClosed := existing != nil && existing.PatchWhenClosed
+	switch {
+	case !patchEnabled:
+		patchWhenClosed = false
+	case payload.PatchWhenClosed != nil:
+		patchWhenClosed = *payload.PatchWhenClosed
+	case existing == nil:
+		patchWhenClosed = true
 	}
 
 	// While Fleet's managed query owns the pre-install condition, the user query can't be edited.

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -950,6 +950,8 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 			Type:                 &patchType,
 			PatchSoftwareTitleID: &payload.TitleID,
 			PatchWhenClosed:      patchWhenClosedFlag,
+			// patch_when_closed requires continuous automations on; the create rejects it otherwise.
+			ContinuousAutomationsEnabled: patchWhenClosedFlag,
 		}); err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "creating patch policy")
 		}
@@ -991,8 +993,7 @@ func planPatchPolicy(payload *fleet.UpdateSoftwareInstallerPayload, installer *f
 	} else {
 		patchFlag = *payload.Patch
 	}
-	// An omitted patch_when_closed keeps the current value, or defaults on for a new policy. A value
-	// set without patch is ignored, not rejected: the caller just won't create a policy to carry it.
+	// An omitted patch_when_closed keeps the current value, or defaults on for a new policy.
 	if payload.PatchWhenClosed == nil {
 		if existingPolicy != nil {
 			patchWhenClosedFlag = existingPolicy.PatchWhenClosed
@@ -1001,6 +1002,11 @@ func planPatchPolicy(payload *fleet.UpdateSoftwareInstallerPayload, installer *f
 		}
 	} else {
 		patchWhenClosedFlag = *payload.PatchWhenClosed
+	}
+
+	// patch_when_closed is only meaningful with patch enabled (in this request or already on the title).
+	if payload.PatchWhenClosed != nil && !patchFlag {
+		return false, false, &fleet.BadRequestError{Message: `If "patch_when_closed" is set, "patch" must be true.`}
 	}
 
 	// The pre-install query is read-only only while patch_when_closed will actually be in effect.

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -488,7 +488,7 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 
 	// The patch controls only apply to Fleet-maintained apps.
 	if (payload.Patch != nil || payload.PatchWhenClosed != nil) && existingInstaller.FleetMaintainedAppID == nil {
-		return nil, &fleet.BadRequestError{Message: `"patch" and "patch_when_closed" are only supported for Fleet-maintained apps.`}
+		return nil, &fleet.BadRequestError{Message: `"patch" and "patch_when_closed" are only available for Fleet-maintained apps.`}
 	}
 
 	if payload.DisplayName != nil && *payload.DisplayName != software.DisplayName {
@@ -979,9 +979,9 @@ func (svc *Service) reconcilePatchPolicy(ctx context.Context, payload *fleet.Upd
 		patchWhenClosed = true
 	}
 
-	// While Fleet's managed query owns the pre-install condition, the user query can't be edited.
-	if patchWhenClosed && payload.PreInstallQuery != nil && *payload.PreInstallQuery != installer.PreInstallQuery {
-		return &fleet.BadRequestError{Message: `Couldn't edit. The pre-install query is managed by Fleet while "patch_when_closed" is enabled and can't be edited.`}
+	// The pre-install query is read-only while patch_when_closed is enabled.
+	if patchWhenClosed && payload.PreInstallQuery != nil {
+		return &fleet.BadRequestError{Message: `Couldn't edit. "pre_install_query" is managed by Fleet and can't be set directly while "patch_when_closed" is enabled.`}
 	}
 
 	teamID := ptr.ValOrZero(payload.TeamID)

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -809,8 +809,15 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 	}
 	var shouldDoSideEffects bool
 
-	if err := svc.reconcilePatchPolicy(ctx, payload, existingInstaller); err != nil {
+	shouldHavePatchPolicy, patchWhenClosed, currentPatchPolicy, err := svc.planPatchPolicy(ctx, payload, existingInstaller)
+	if err != nil {
 		return nil, err
+	}
+	if patchWhenClosed && existingInstaller.PreInstallQuery != "" {
+		// Enabling patch_when_closed deletes the pre-install query, so the save cancels the title's
+		// pending installs. Blank it in the payload so the save persists the change rather than restoring it.
+		payload.PreInstallQuery = new("")
+		dirty["PreInstallQuery"] = true
 	}
 
 	// persist changes starting here, now that we've done all the validation/diffing we can
@@ -928,6 +935,29 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 		}
 	}
 
+	// Create, update, or delete the patch policy after the installer save, so the pre-install query
+	// is already cleared and the policy's own clear is a no-op.
+	patchTeamID := ptr.ValOrZero(payload.TeamID)
+	switch {
+	case !shouldHavePatchPolicy && currentPatchPolicy != nil:
+		if _, err := svc.DeleteTeamPolicies(ctx, patchTeamID, []uint{currentPatchPolicy.ID}); err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "deleting patch policy")
+		}
+	case shouldHavePatchPolicy && currentPatchPolicy == nil:
+		patchType := fleet.PolicyTypePatch
+		if _, err := svc.NewTeamPolicy(ctx, patchTeamID, fleet.NewTeamPolicyPayload{
+			Type:                 &patchType,
+			PatchSoftwareTitleID: &payload.TitleID,
+			PatchWhenClosed:      patchWhenClosed,
+		}); err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "creating patch policy")
+		}
+	case shouldHavePatchPolicy && currentPatchPolicy != nil && patchWhenClosed != currentPatchPolicy.PatchWhenClosed:
+		if _, err := svc.ModifyTeamPolicy(ctx, patchTeamID, currentPatchPolicy.ID, fleet.ModifyPolicyPayload{PatchWhenClosed: &patchWhenClosed}); err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "modifying patch policy")
+		}
+	}
+
 	// re-pull the edited installer to reflect side effects; return that specific
 	// package, not the title's first-added one. May be able to optimize this out later.
 	updatedInstaller, err := svc.ds.GetSoftwareInstallerMetadataByTeamTitleAndInstallerID(ctxdb.RequirePrimary(ctx, true), payload.TeamID, payload.TitleID, payload.InstallerID, true)
@@ -944,66 +974,52 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 	return updatedInstaller, nil
 }
 
-func (svc *Service) reconcilePatchPolicy(ctx context.Context, payload *fleet.UpdateSoftwareInstallerPayload, installer *fleet.SoftwareInstaller) error {
-	// Only the Fleet-maintained package has a managed pre-install query, so nothing here applies
-	// to any other package. Patch controls on a non-FMA package are rejected by the caller.
+func (svc *Service) planPatchPolicy(ctx context.Context, payload *fleet.UpdateSoftwareInstallerPayload, installer *fleet.SoftwareInstaller) (shouldHavePatchPolicy bool, patchWhenClosed bool, currentPatchPolicy *fleet.PatchPolicyData, err error) {
+	// Only the Fleet-maintained package has a managed pre-install query; patch controls on any other
+	// package are rejected by the caller.
 	if installer.FleetMaintainedAppID == nil {
-		return nil
+		return false, false, nil, nil
 	}
 	if payload.Patch == nil && payload.PatchWhenClosed == nil && payload.PreInstallQuery == nil {
-		return nil
+		return false, false, nil, nil
 	}
 
-	existing, err := svc.ds.GetPatchPolicy(ctx, payload.TeamID, payload.TitleID)
+	currentPatchPolicy, err = svc.ds.GetPatchPolicy(ctx, payload.TeamID, payload.TitleID)
 	if err != nil && !fleet.IsNotFound(err) {
-		return ctxerr.Wrap(ctx, err, "getting patch policy")
+		return false, false, nil, ctxerr.Wrap(ctx, err, "getting patch policy")
 	}
 
-	patchEnabled := existing != nil
+	// Resolve both optional flags into plain bools so the logic below never touches the pointers.
+	// patch keeps the current state when omitted.
 	if payload.Patch != nil {
-		patchEnabled = *payload.Patch
+		shouldHavePatchPolicy = *payload.Patch
+	} else if currentPatchPolicy != nil {
+		shouldHavePatchPolicy = true
 	}
-	// patch_when_closed needs a patch policy: reject when patch is disabled, or when it's omitted
-	// and the title has no policy to enable it on.
-	if payload.PatchWhenClosed != nil && *payload.PatchWhenClosed && !patchEnabled {
-		return &fleet.BadRequestError{Message: `"patch_when_closed" requires "patch" to be enabled.`}
-	}
-	// Default patch_when_closed on for a new patch policy, otherwise keep the existing value.
-	patchWhenClosed := existing != nil && existing.PatchWhenClosed
-	switch {
-	case !patchEnabled:
-		patchWhenClosed = false
-	case payload.PatchWhenClosed != nil:
+	// patch_when_closed: an explicit value wins; otherwise it only applies when a policy will exist,
+	// keeping the current value or defaulting on for a new policy. It stays false when patch is off
+	// unless explicitly requested, so the reject below is just "if patchWhenClosed".
+	if payload.PatchWhenClosed != nil {
 		patchWhenClosed = *payload.PatchWhenClosed
-	case existing == nil:
-		patchWhenClosed = true
+	} else if shouldHavePatchPolicy {
+		if currentPatchPolicy != nil {
+			patchWhenClosed = currentPatchPolicy.PatchWhenClosed
+		} else {
+			patchWhenClosed = true
+		}
 	}
 
+	if !shouldHavePatchPolicy {
+		if patchWhenClosed {
+			return false, false, nil, &fleet.BadRequestError{Message: `"patch_when_closed" requires "patch" to be enabled.`}
+		}
+		return false, false, currentPatchPolicy, nil
+	}
 	// The pre-install query is read-only while patch_when_closed is enabled.
 	if patchWhenClosed && payload.PreInstallQuery != nil {
-		return &fleet.BadRequestError{Message: `Couldn't edit. "pre_install_query" is managed by Fleet and can't be set directly while "patch_when_closed" is enabled.`}
+		return false, false, nil, &fleet.BadRequestError{Message: `Couldn't edit. "pre_install_query" is managed by Fleet and can't be set directly while "patch_when_closed" is enabled.`}
 	}
-
-	teamID := ptr.ValOrZero(payload.TeamID)
-	switch {
-	case !patchEnabled:
-		if existing == nil {
-			return nil
-		}
-		_, err = svc.DeleteTeamPolicies(ctx, teamID, []uint{existing.ID})
-	case existing == nil:
-		patchType := fleet.PolicyTypePatch
-		_, err = svc.NewTeamPolicy(ctx, teamID, fleet.NewTeamPolicyPayload{
-			Type:                 &patchType,
-			PatchSoftwareTitleID: &payload.TitleID,
-			PatchWhenClosed:      patchWhenClosed,
-		})
-	case patchWhenClosed != existing.PatchWhenClosed:
-		_, err = svc.ModifyTeamPolicy(ctx, teamID, existing.ID, fleet.ModifyPolicyPayload{PatchWhenClosed: &patchWhenClosed})
-	default:
-		return nil
-	}
-	return ctxerr.Wrap(ctx, err, "reconciling patch policy")
+	return true, patchWhenClosed, currentPatchPolicy, nil
 }
 
 func (svc *Service) validateEmbeddedSecretsOnScript(ctx context.Context, scriptName string, script *string,

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -809,13 +809,15 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 	}
 	var shouldDoSideEffects bool
 
-	shouldHavePatchPolicy, patchWhenClosed, currentPatchPolicy, err := svc.planPatchPolicy(ctx, payload, existingInstaller)
+	existingPolicy, err := svc.ds.GetPatchPolicy(ctx, payload.TeamID, payload.TitleID)
+	if err != nil && !fleet.IsNotFound(err) {
+		return nil, ctxerr.Wrap(ctx, err, "getting patch policy")
+	}
+	patchFlag, patchWhenClosedFlag, err := planPatchPolicy(payload, existingInstaller, existingPolicy)
 	if err != nil {
 		return nil, err
 	}
-	if patchWhenClosed && existingInstaller.PreInstallQuery != "" {
-		// Enabling patch_when_closed deletes the pre-install query, so the save cancels the title's
-		// pending installs. Blank it in the payload so the save persists the change rather than restoring it.
+	if patchFlag && patchWhenClosedFlag && existingInstaller.PreInstallQuery != "" {
 		payload.PreInstallQuery = new("")
 		dirty["PreInstallQuery"] = true
 	}
@@ -935,25 +937,24 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 		}
 	}
 
-	// Create, update, or delete the patch policy after the installer save, so the pre-install query
-	// is already cleared and the policy's own clear is a no-op.
+	// Create, update, or delete the patch policy after the installer save
 	patchTeamID := ptr.ValOrZero(payload.TeamID)
 	switch {
-	case !shouldHavePatchPolicy && currentPatchPolicy != nil:
-		if _, err := svc.DeleteTeamPolicies(ctx, patchTeamID, []uint{currentPatchPolicy.ID}); err != nil {
+	case !patchFlag && existingPolicy != nil:
+		if _, err := svc.DeleteTeamPolicies(ctx, patchTeamID, []uint{existingPolicy.ID}); err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "deleting patch policy")
 		}
-	case shouldHavePatchPolicy && currentPatchPolicy == nil:
+	case patchFlag && existingPolicy == nil:
 		patchType := fleet.PolicyTypePatch
 		if _, err := svc.NewTeamPolicy(ctx, patchTeamID, fleet.NewTeamPolicyPayload{
 			Type:                 &patchType,
 			PatchSoftwareTitleID: &payload.TitleID,
-			PatchWhenClosed:      patchWhenClosed,
+			PatchWhenClosed:      patchWhenClosedFlag,
 		}); err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "creating patch policy")
 		}
-	case shouldHavePatchPolicy && currentPatchPolicy != nil && patchWhenClosed != currentPatchPolicy.PatchWhenClosed:
-		if _, err := svc.ModifyTeamPolicy(ctx, patchTeamID, currentPatchPolicy.ID, fleet.ModifyPolicyPayload{PatchWhenClosed: &patchWhenClosed}); err != nil {
+	case patchFlag && existingPolicy != nil && patchWhenClosedFlag != existingPolicy.PatchWhenClosed:
+		if _, err := svc.ModifyTeamPolicy(ctx, patchTeamID, existingPolicy.ID, fleet.ModifyPolicyPayload{PatchWhenClosed: &patchWhenClosedFlag}); err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "modifying patch policy")
 		}
 	}
@@ -974,52 +975,39 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 	return updatedInstaller, nil
 }
 
-func (svc *Service) planPatchPolicy(ctx context.Context, payload *fleet.UpdateSoftwareInstallerPayload, installer *fleet.SoftwareInstaller) (shouldHavePatchPolicy bool, patchWhenClosed bool, currentPatchPolicy *fleet.PatchPolicyData, err error) {
+func planPatchPolicy(payload *fleet.UpdateSoftwareInstallerPayload, installer *fleet.SoftwareInstaller, existingPolicy *fleet.PatchPolicyData) (patchFlag bool, patchWhenClosedFlag bool, err error) {
 	// Only the Fleet-maintained package has a managed pre-install query; patch controls on any other
 	// package are rejected by the caller.
 	if installer.FleetMaintainedAppID == nil {
-		return false, false, nil, nil
-	}
-	if payload.Patch == nil && payload.PatchWhenClosed == nil && payload.PreInstallQuery == nil {
-		return false, false, nil, nil
-	}
-
-	currentPatchPolicy, err = svc.ds.GetPatchPolicy(ctx, payload.TeamID, payload.TitleID)
-	if err != nil && !fleet.IsNotFound(err) {
-		return false, false, nil, ctxerr.Wrap(ctx, err, "getting patch policy")
+		return false, false, nil
 	}
 
 	// Resolve both optional flags into plain bools so the logic below never touches the pointers.
-	// patch keeps the current state when omitted.
-	if payload.Patch != nil {
-		shouldHavePatchPolicy = *payload.Patch
-	} else if currentPatchPolicy != nil {
-		shouldHavePatchPolicy = true
-	}
-	// patch_when_closed: an explicit value wins; otherwise it only applies when a policy will exist,
-	// keeping the current value or defaulting on for a new policy. It stays false when patch is off
-	// unless explicitly requested, so the reject below is just "if patchWhenClosed".
-	if payload.PatchWhenClosed != nil {
-		patchWhenClosed = *payload.PatchWhenClosed
-	} else if shouldHavePatchPolicy {
-		if currentPatchPolicy != nil {
-			patchWhenClosed = currentPatchPolicy.PatchWhenClosed
-		} else {
-			patchWhenClosed = true
+	// An omitted patch keeps the current state.
+	if payload.Patch == nil {
+		if existingPolicy != nil {
+			patchFlag = true
 		}
+	} else {
+		patchFlag = *payload.Patch
+	}
+	// An omitted patch_when_closed keeps the current value, or defaults on for a new policy. A value
+	// set without patch is ignored, not rejected: the caller just won't create a policy to carry it.
+	if payload.PatchWhenClosed == nil {
+		if existingPolicy != nil {
+			patchWhenClosedFlag = existingPolicy.PatchWhenClosed
+		} else {
+			patchWhenClosedFlag = true
+		}
+	} else {
+		patchWhenClosedFlag = *payload.PatchWhenClosed
 	}
 
-	if !shouldHavePatchPolicy {
-		if patchWhenClosed {
-			return false, false, nil, &fleet.BadRequestError{Message: `"patch_when_closed" requires "patch" to be enabled.`}
-		}
-		return false, false, currentPatchPolicy, nil
+	// The pre-install query is read-only only while patch_when_closed will actually be in effect.
+	if patchFlag && patchWhenClosedFlag && payload.PreInstallQuery != nil {
+		return false, false, &fleet.BadRequestError{Message: `Couldn't edit. "pre_install_query" is managed by Fleet and can't be set directly while "patch_when_closed" is enabled.`}
 	}
-	// The pre-install query is read-only while patch_when_closed is enabled.
-	if patchWhenClosed && payload.PreInstallQuery != nil {
-		return false, false, nil, &fleet.BadRequestError{Message: `Couldn't edit. "pre_install_query" is managed by Fleet and can't be set directly while "patch_when_closed" is enabled.`}
-	}
-	return true, patchWhenClosed, currentPatchPolicy, nil
+	return patchFlag, patchWhenClosedFlag, nil
 }
 
 func (svc *Service) validateEmbeddedSecretsOnScript(ctx context.Context, scriptName string, script *string,

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -821,10 +821,6 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 		if err != nil {
 			return nil, err
 		}
-		if patchFlag && patchWhenClosedFlag && existingInstaller.PreInstallQuery != "" {
-			payload.PreInstallQuery = new("")
-			dirty["PreInstallQuery"] = true
-		}
 	}
 
 	// persist changes starting here, now that we've done all the validation/diffing we can

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -486,12 +486,9 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 
 	payload.InstallerID = existingInstaller.InstallerID
 
-	// Resolve the resulting patch-policy state up front so we can reject a user pre-install
-	// query edit while the managed query owns it. The policy itself is reconciled after the
-	// installer row is saved.
-	patchPlan, err := svc.planPatchPolicy(ctx, payload, existingInstaller)
-	if err != nil {
-		return nil, err
+	// The patch controls only apply to Fleet-maintained apps.
+	if (payload.Patch != nil || payload.PatchWhenClosed != nil) && existingInstaller.FleetMaintainedAppID == nil {
+		return nil, &fleet.BadRequestError{Message: `"patch" and "patch_when_closed" are only supported for Fleet-maintained apps.`}
 	}
 
 	if payload.DisplayName != nil && *payload.DisplayName != software.DisplayName {
@@ -646,11 +643,6 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 	// default pre-install query is blank, so blanking out the query doesn't have a semantic meaning we have to take care of
 	if payload.PreInstallQuery != nil {
 		if *payload.PreInstallQuery != existingInstaller.PreInstallQuery {
-			if patchPlan.managed() {
-				return nil, &fleet.BadRequestError{
-					Message: `Couldn't edit. The pre-install query is managed by Fleet while "patch_when_closed" is enabled and can't be edited.`,
-				}
-			}
 			dirty["PreInstallQuery"] = true
 		}
 	}
@@ -936,10 +928,6 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 		}
 	}
 
-	if err := svc.applyPatchPolicyPlan(ctx, payload, patchPlan); err != nil {
-		return nil, err
-	}
-
 	// re-pull the edited installer to reflect side effects; return that specific
 	// package, not the title's first-added one. May be able to optimize this out later.
 	updatedInstaller, err := svc.ds.GetSoftwareInstallerMetadataByTeamTitleAndInstallerID(ctxdb.RequirePrimary(ctx, true), payload.TeamID, payload.TitleID, payload.InstallerID, true)
@@ -956,109 +944,60 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 	return updatedInstaller, nil
 }
 
-// patchPolicyPlan is the patch-policy state a title should end up in after an update-package
-// request, resolved before the installer row is saved.
-type patchPolicyPlan struct {
-	existing        *fleet.PatchPolicyData
-	patchEnabled    bool
-	patchWhenClosed bool
-}
-
-func (p patchPolicyPlan) managed() bool {
-	return p.patchEnabled && p.patchWhenClosed
-}
-
-func (svc *Service) planPatchPolicy(ctx context.Context, payload *fleet.UpdateSoftwareInstallerPayload, existingInstaller *fleet.SoftwareInstaller) (patchPolicyPlan, error) {
-	var plan patchPolicyPlan
-
-	// Neither the patch policy nor the managed pre-install query can change unless one of these
-	// fields is present, so skip the lookup entirely otherwise.
-	if payload.Patch == nil && payload.PatchWhenClosed == nil && payload.PreInstallQuery == nil {
-		return plan, nil
+func (svc *Service) reconcilePatchPolicy(ctx context.Context, payload *fleet.UpdateSoftwareInstallerPayload, installer *fleet.SoftwareInstaller) error {
+	// Only the Fleet-maintained package has a managed pre-install query, so nothing here applies
+	// to any other package. Patch controls on a non-FMA package are rejected by the caller.
+	if installer.FleetMaintainedAppID == nil {
+		return nil
 	}
-
-	// Only the Fleet-maintained package backs a patch policy: the patch controls are FMA-only,
-	// and a pre-install-query edit on any other package is never managed, so it stays editable.
-	if existingInstaller.FleetMaintainedAppID == nil {
-		if payload.Patch != nil || payload.PatchWhenClosed != nil {
-			return plan, &fleet.BadRequestError{Message: `"patch" and "patch_when_closed" are only supported for Fleet-maintained apps.`}
-		}
-		return plan, nil
+	if payload.Patch == nil && payload.PatchWhenClosed == nil && payload.PreInstallQuery == nil {
+		return nil
 	}
 
 	existing, err := svc.ds.GetPatchPolicy(ctx, payload.TeamID, payload.TitleID)
 	if err != nil && !fleet.IsNotFound(err) {
-		return plan, ctxerr.Wrap(ctx, err, "getting patch policy")
+		return ctxerr.Wrap(ctx, err, "getting patch policy")
 	}
-	plan.existing = existing
 
-	plan.patchEnabled = existing != nil
+	patchEnabled := existing != nil
 	if payload.Patch != nil {
-		plan.patchEnabled = *payload.Patch
+		patchEnabled = *payload.Patch
 	}
-
-	plan.patchWhenClosed = existing != nil && existing.PatchWhenClosed
+	// patch_when_closed needs a patch policy: reject when patch is disabled, or when it's omitted
+	// and the title has no policy to enable it on.
+	if payload.PatchWhenClosed != nil && *payload.PatchWhenClosed && !patchEnabled {
+		return &fleet.BadRequestError{Message: `"patch_when_closed" requires "patch" to be enabled.`}
+	}
+	patchWhenClosed := patchEnabled && existing != nil && existing.PatchWhenClosed
 	if payload.PatchWhenClosed != nil {
-		plan.patchWhenClosed = *payload.PatchWhenClosed
+		patchWhenClosed = patchEnabled && *payload.PatchWhenClosed
 	}
 
-	// A disabled patch policy can't skip installs while the app is open. Reject an explicit
-	// request for both in the same call, otherwise just drop patch_when_closed.
-	if !plan.patchEnabled {
-		if payload.PatchWhenClosed != nil && *payload.PatchWhenClosed {
-			return plan, &fleet.BadRequestError{Message: `"patch_when_closed" requires "patch" to be enabled.`}
-		}
-		plan.patchWhenClosed = false
+	// While Fleet's managed query owns the pre-install condition, the user query can't be edited.
+	if patchWhenClosed && payload.PreInstallQuery != nil && *payload.PreInstallQuery != installer.PreInstallQuery {
+		return &fleet.BadRequestError{Message: `Couldn't edit. The pre-install query is managed by Fleet while "patch_when_closed" is enabled and can't be edited.`}
 	}
 
-	return plan, nil
-}
-
-func (svc *Service) applyPatchPolicyPlan(ctx context.Context, payload *fleet.UpdateSoftwareInstallerPayload, plan patchPolicyPlan) error {
-	if payload.Patch == nil && payload.PatchWhenClosed == nil {
-		return nil
-	}
 	teamID := ptr.ValOrZero(payload.TeamID)
-
-	if !plan.patchEnabled {
-		if plan.existing != nil {
-			if _, err := svc.DeleteTeamPolicies(ctx, teamID, []uint{plan.existing.ID}); err != nil {
-				return ctxerr.Wrap(ctx, err, "deleting patch policy")
-			}
+	switch {
+	case !patchEnabled:
+		if existing == nil {
+			return nil
 		}
-		return nil
-	}
-
-	if plan.existing == nil {
+		_, err = svc.DeleteTeamPolicies(ctx, teamID, []uint{existing.ID})
+	case existing == nil:
 		patchType := fleet.PolicyTypePatch
-		_, err := svc.NewTeamPolicy(ctx, teamID, fleet.NewTeamPolicyPayload{
+		_, err = svc.NewTeamPolicy(ctx, teamID, fleet.NewTeamPolicyPayload{
 			Type:                 &patchType,
 			PatchSoftwareTitleID: &payload.TitleID,
-			PatchWhenClosed:      plan.patchWhenClosed,
+			PatchWhenClosed:      patchWhenClosed,
 		})
-		var conflict *fleet.ConflictError
-		switch {
-		case err == nil:
-			return nil
-		case !errors.As(err, &conflict):
-			return ctxerr.Wrap(ctx, err, "creating patch policy")
-		}
-		// A concurrent request already created the patch policy. Converge its patch_when_closed
-		// below instead of failing on the unique constraint.
-		if plan.existing, err = svc.ds.GetPatchPolicy(ctx, payload.TeamID, payload.TitleID); err != nil {
-			return ctxerr.Wrap(ctx, err, "getting patch policy after conflict")
-		}
+	case patchWhenClosed != existing.PatchWhenClosed:
+		_, err = svc.ModifyTeamPolicy(ctx, teamID, existing.ID, fleet.ModifyPolicyPayload{PatchWhenClosed: &patchWhenClosed})
+	default:
+		return nil
 	}
-
-	if plan.patchWhenClosed != plan.existing.PatchWhenClosed {
-		patchWhenClosed := plan.patchWhenClosed
-		if _, err := svc.ModifyTeamPolicy(ctx, teamID, plan.existing.ID, fleet.ModifyPolicyPayload{
-			PatchWhenClosed: &patchWhenClosed,
-		}); err != nil {
-			return ctxerr.Wrap(ctx, err, "updating patch policy")
-		}
-	}
-	return nil
+	return ctxerr.Wrap(ctx, err, "reconciling patch policy")
 }
 
 func (svc *Service) validateEmbeddedSecretsOnScript(ctx context.Context, scriptName string, script *string,

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -486,9 +486,12 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 
 	payload.InstallerID = existingInstaller.InstallerID
 
-	// The patch controls only apply to Fleet-maintained apps.
-	if (payload.Patch != nil || payload.PatchWhenClosed != nil) && existingInstaller.FleetMaintainedAppID == nil {
-		return nil, &fleet.BadRequestError{Message: `"patch" and "patch_when_closed" are only available for Fleet-maintained apps.`}
+	// Resolve the resulting patch-policy state up front so we can reject a user pre-install
+	// query edit while the managed query owns it. The policy itself is reconciled after the
+	// installer row is saved.
+	patchPlan, err := svc.planPatchPolicy(ctx, payload, existingInstaller)
+	if err != nil {
+		return nil, err
 	}
 
 	if payload.DisplayName != nil && *payload.DisplayName != software.DisplayName {
@@ -643,6 +646,11 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 	// default pre-install query is blank, so blanking out the query doesn't have a semantic meaning we have to take care of
 	if payload.PreInstallQuery != nil {
 		if *payload.PreInstallQuery != existingInstaller.PreInstallQuery {
+			if patchPlan.managed() {
+				return nil, &fleet.BadRequestError{
+					Message: `Couldn't edit. The pre-install query is managed by Fleet while "patch_when_closed" is enabled and can't be edited.`,
+				}
+			}
 			dirty["PreInstallQuery"] = true
 		}
 	}
@@ -928,6 +936,10 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 		}
 	}
 
+	if err := svc.applyPatchPolicyPlan(ctx, payload, patchPlan); err != nil {
+		return nil, err
+	}
+
 	// re-pull the edited installer to reflect side effects; return that specific
 	// package, not the title's first-added one. May be able to optimize this out later.
 	updatedInstaller, err := svc.ds.GetSoftwareInstallerMetadataByTeamTitleAndInstallerID(ctxdb.RequirePrimary(ctx, true), payload.TeamID, payload.TitleID, payload.InstallerID, true)
@@ -944,66 +956,109 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 	return updatedInstaller, nil
 }
 
-func (svc *Service) reconcilePatchPolicy(ctx context.Context, payload *fleet.UpdateSoftwareInstallerPayload, installer *fleet.SoftwareInstaller) error {
-	// Only the Fleet-maintained package has a managed pre-install query, so nothing here applies
-	// to any other package. Patch controls on a non-FMA package are rejected by the caller.
-	if installer.FleetMaintainedAppID == nil {
-		return nil
-	}
+// patchPolicyPlan is the patch-policy state a title should end up in after an update-package
+// request, resolved before the installer row is saved.
+type patchPolicyPlan struct {
+	existing        *fleet.PatchPolicyData
+	patchEnabled    bool
+	patchWhenClosed bool
+}
+
+func (p patchPolicyPlan) managed() bool {
+	return p.patchEnabled && p.patchWhenClosed
+}
+
+func (svc *Service) planPatchPolicy(ctx context.Context, payload *fleet.UpdateSoftwareInstallerPayload, existingInstaller *fleet.SoftwareInstaller) (patchPolicyPlan, error) {
+	var plan patchPolicyPlan
+
+	// Neither the patch policy nor the managed pre-install query can change unless one of these
+	// fields is present, so skip the lookup entirely otherwise.
 	if payload.Patch == nil && payload.PatchWhenClosed == nil && payload.PreInstallQuery == nil {
-		return nil
+		return plan, nil
+	}
+
+	// Only the Fleet-maintained package backs a patch policy: the patch controls are FMA-only,
+	// and a pre-install-query edit on any other package is never managed, so it stays editable.
+	if existingInstaller.FleetMaintainedAppID == nil {
+		if payload.Patch != nil || payload.PatchWhenClosed != nil {
+			return plan, &fleet.BadRequestError{Message: `"patch" and "patch_when_closed" are only supported for Fleet-maintained apps.`}
+		}
+		return plan, nil
 	}
 
 	existing, err := svc.ds.GetPatchPolicy(ctx, payload.TeamID, payload.TitleID)
 	if err != nil && !fleet.IsNotFound(err) {
-		return ctxerr.Wrap(ctx, err, "getting patch policy")
+		return plan, ctxerr.Wrap(ctx, err, "getting patch policy")
 	}
+	plan.existing = existing
 
-	patchEnabled := existing != nil
+	plan.patchEnabled = existing != nil
 	if payload.Patch != nil {
-		patchEnabled = *payload.Patch
-	}
-	// patch_when_closed needs a patch policy: reject when patch is disabled, or when it's omitted
-	// and the title has no policy to enable it on.
-	if payload.PatchWhenClosed != nil && *payload.PatchWhenClosed && !patchEnabled {
-		return &fleet.BadRequestError{Message: `"patch_when_closed" requires "patch" to be enabled.`}
-	}
-	// Default patch_when_closed on for a new patch policy, otherwise keep the existing value.
-	patchWhenClosed := existing != nil && existing.PatchWhenClosed
-	switch {
-	case !patchEnabled:
-		patchWhenClosed = false
-	case payload.PatchWhenClosed != nil:
-		patchWhenClosed = *payload.PatchWhenClosed
-	case existing == nil:
-		patchWhenClosed = true
+		plan.patchEnabled = *payload.Patch
 	}
 
-	// The pre-install query is read-only while patch_when_closed is enabled.
-	if patchWhenClosed && payload.PreInstallQuery != nil {
-		return &fleet.BadRequestError{Message: `Couldn't edit. "pre_install_query" is managed by Fleet and can't be set directly while "patch_when_closed" is enabled.`}
+	plan.patchWhenClosed = existing != nil && existing.PatchWhenClosed
+	if payload.PatchWhenClosed != nil {
+		plan.patchWhenClosed = *payload.PatchWhenClosed
 	}
 
-	teamID := ptr.ValOrZero(payload.TeamID)
-	switch {
-	case !patchEnabled:
-		if existing == nil {
-			return nil
+	// A disabled patch policy can't skip installs while the app is open. Reject an explicit
+	// request for both in the same call, otherwise just drop patch_when_closed.
+	if !plan.patchEnabled {
+		if payload.PatchWhenClosed != nil && *payload.PatchWhenClosed {
+			return plan, &fleet.BadRequestError{Message: `"patch_when_closed" requires "patch" to be enabled.`}
 		}
-		_, err = svc.DeleteTeamPolicies(ctx, teamID, []uint{existing.ID})
-	case existing == nil:
-		patchType := fleet.PolicyTypePatch
-		_, err = svc.NewTeamPolicy(ctx, teamID, fleet.NewTeamPolicyPayload{
-			Type:                 &patchType,
-			PatchSoftwareTitleID: &payload.TitleID,
-			PatchWhenClosed:      patchWhenClosed,
-		})
-	case patchWhenClosed != existing.PatchWhenClosed:
-		_, err = svc.ModifyTeamPolicy(ctx, teamID, existing.ID, fleet.ModifyPolicyPayload{PatchWhenClosed: &patchWhenClosed})
-	default:
+		plan.patchWhenClosed = false
+	}
+
+	return plan, nil
+}
+
+func (svc *Service) applyPatchPolicyPlan(ctx context.Context, payload *fleet.UpdateSoftwareInstallerPayload, plan patchPolicyPlan) error {
+	if payload.Patch == nil && payload.PatchWhenClosed == nil {
 		return nil
 	}
-	return ctxerr.Wrap(ctx, err, "reconciling patch policy")
+	teamID := ptr.ValOrZero(payload.TeamID)
+
+	if !plan.patchEnabled {
+		if plan.existing != nil {
+			if _, err := svc.DeleteTeamPolicies(ctx, teamID, []uint{plan.existing.ID}); err != nil {
+				return ctxerr.Wrap(ctx, err, "deleting patch policy")
+			}
+		}
+		return nil
+	}
+
+	if plan.existing == nil {
+		patchType := fleet.PolicyTypePatch
+		_, err := svc.NewTeamPolicy(ctx, teamID, fleet.NewTeamPolicyPayload{
+			Type:                 &patchType,
+			PatchSoftwareTitleID: &payload.TitleID,
+			PatchWhenClosed:      plan.patchWhenClosed,
+		})
+		var conflict *fleet.ConflictError
+		switch {
+		case err == nil:
+			return nil
+		case !errors.As(err, &conflict):
+			return ctxerr.Wrap(ctx, err, "creating patch policy")
+		}
+		// A concurrent request already created the patch policy. Converge its patch_when_closed
+		// below instead of failing on the unique constraint.
+		if plan.existing, err = svc.ds.GetPatchPolicy(ctx, payload.TeamID, payload.TitleID); err != nil {
+			return ctxerr.Wrap(ctx, err, "getting patch policy after conflict")
+		}
+	}
+
+	if plan.patchWhenClosed != plan.existing.PatchWhenClosed {
+		patchWhenClosed := plan.patchWhenClosed
+		if _, err := svc.ModifyTeamPolicy(ctx, teamID, plan.existing.ID, fleet.ModifyPolicyPayload{
+			PatchWhenClosed: &patchWhenClosed,
+		}); err != nil {
+			return ctxerr.Wrap(ctx, err, "updating patch policy")
+		}
+	}
+	return nil
 }
 
 func (svc *Service) validateEmbeddedSecretsOnScript(ctx context.Context, scriptName string, script *string,

--- a/ee/server/service/software_installers_test.go
+++ b/ee/server/service/software_installers_test.go
@@ -2713,6 +2713,18 @@ func TestReconcilePatchPolicy(t *testing.T) {
 		assert.True(t, base.NewTeamPolicyFuncInvoked)
 	})
 
+	// patch:true with patch_when_closed omitted defaults a new policy to "only when closed".
+	t.Run("new policy defaults to patch_when_closed", func(t *testing.T) {
+		svc, base := setup(t, nil)
+		var got bool
+		base.NewTeamPolicyFunc = func(ctx context.Context, tID uint, p fleet.NewTeamPolicyPayload) (*fleet.Policy, error) {
+			got = p.PatchWhenClosed
+			return &fleet.Policy{}, nil
+		}
+		require.NoError(t, svc.reconcilePatchPolicy(ctx, payload(new(true), nil), fmaInstaller))
+		assert.True(t, got)
+	})
+
 	// patch:false deletes the existing patch policy.
 	t.Run("deletes when patch disabled", func(t *testing.T) {
 		svc, base := setup(t, &fleet.PatchPolicyData{ID: 9})

--- a/ee/server/service/software_installers_test.go
+++ b/ee/server/service/software_installers_test.go
@@ -2662,15 +2662,13 @@ func TestPlanPatchPolicy(t *testing.T) {
 		return &fleet.UpdateSoftwareInstallerPayload{TitleID: titleID, TeamID: &teamID, Patch: patch, PatchWhenClosed: patchWhenClosed}
 	}
 
-	// patch_when_closed with no patch is silently ignored (no policy, no error), whether patch is
-	// omitted with no existing policy or explicitly disabled.
-	t.Run("ignores patch_when_closed without patch", func(t *testing.T) {
-		patchFlag, _, err := planPatchPolicy(payload(nil, new(true)), fmaInstaller, nil)
-		require.NoError(t, err)
-		assert.False(t, patchFlag)
-		patchFlag, _, err = planPatchPolicy(payload(new(false), new(true)), fmaInstaller, nil)
-		require.NoError(t, err)
-		assert.False(t, patchFlag)
+	// patch_when_closed set without patch enabled is rejected, whether patch is omitted with no
+	// existing policy or explicitly disabled.
+	t.Run("rejects patch_when_closed without patch", func(t *testing.T) {
+		_, _, err := planPatchPolicy(payload(nil, new(true)), fmaInstaller, nil)
+		require.ErrorContains(t, err, `"patch" must be true`)
+		_, _, err = planPatchPolicy(payload(new(false), new(true)), fmaInstaller, nil)
+		require.ErrorContains(t, err, `"patch" must be true`)
 	})
 
 	// While patch_when_closed is on, the user pre-install query is managed and can't be edited.

--- a/ee/server/service/software_installers_test.go
+++ b/ee/server/service/software_installers_test.go
@@ -2652,7 +2652,7 @@ func TestNormalizeSetupExperiencePlatforms(t *testing.T) {
 	}
 }
 
-func TestReconcilePatchPolicy(t *testing.T) {
+func TestPlanPatchPolicy(t *testing.T) {
 	ctx := context.Background()
 	titleID := uint(42)
 	teamID := uint(0)
@@ -2660,7 +2660,7 @@ func TestReconcilePatchPolicy(t *testing.T) {
 	nonFMAInstaller := &fleet.SoftwareInstaller{TitleID: &titleID}
 
 	// setup resolves GetPatchPolicy to existing (nil means the title has no patch policy).
-	setup := func(t *testing.T, existing *fleet.PatchPolicyData) (*Service, *svcmock.Service) {
+	setup := func(t *testing.T, existing *fleet.PatchPolicyData) *Service {
 		ds := new(mock.Store)
 		ds.GetPatchPolicyFunc = func(ctx context.Context, gotTeamID *uint, gotTitleID uint) (*fleet.PatchPolicyData, error) {
 			if existing == nil {
@@ -2668,7 +2668,8 @@ func TestReconcilePatchPolicy(t *testing.T) {
 			}
 			return existing, nil
 		}
-		return newTestServiceWithMock(t, ds)
+		svc, _ := newTestServiceWithMock(t, ds)
+		return svc
 	}
 
 	payload := func(patch *bool, patchWhenClosed *bool) *fleet.UpdateSoftwareInstallerPayload {
@@ -2678,89 +2679,77 @@ func TestReconcilePatchPolicy(t *testing.T) {
 	// patch_when_closed can't be enabled unless patch is enabled too, whether patch is omitted
 	// (with no existing policy) or explicitly disabled.
 	t.Run("rejects patch_when_closed without patch", func(t *testing.T) {
-		svc, _ := setup(t, nil)
-		require.ErrorContains(t, svc.reconcilePatchPolicy(ctx, payload(nil, new(true)), fmaInstaller), "requires")
-		require.ErrorContains(t, svc.reconcilePatchPolicy(ctx, payload(new(false), new(true)), fmaInstaller), "requires")
+		svc := setup(t, nil)
+		_, _, _, err := svc.planPatchPolicy(ctx, payload(nil, new(true)), fmaInstaller)
+		require.ErrorContains(t, err, "requires")
+		_, _, _, err = svc.planPatchPolicy(ctx, payload(new(false), new(true)), fmaInstaller)
+		require.ErrorContains(t, err, "requires")
 	})
 
 	// While patch_when_closed is on, the user pre-install query is managed and can't be edited.
 	t.Run("rejects pre-install edit while managed", func(t *testing.T) {
-		svc, _ := setup(t, &fleet.PatchPolicyData{ID: 9, PatchWhenClosed: true})
+		svc := setup(t, &fleet.PatchPolicyData{ID: 9, PatchWhenClosed: true})
 		p := payload(nil, nil)
 		p.PreInstallQuery = new("SELECT changed;")
-		err := svc.reconcilePatchPolicy(ctx, p, fmaInstaller)
+		_, _, _, err := svc.planPatchPolicy(ctx, p, fmaInstaller)
 		require.ErrorContains(t, err, "managed by Fleet")
 	})
 
-	// A pre-install edit on a non-FMA package is never managed.
+	// A pre-install edit on a non-FMA package is never managed; nothing to plan.
 	t.Run("allows pre-install edit on non-FMA package", func(t *testing.T) {
-		svc, _ := setup(t, &fleet.PatchPolicyData{ID: 9, PatchWhenClosed: true})
+		svc := setup(t, &fleet.PatchPolicyData{ID: 9, PatchWhenClosed: true})
 		p := payload(nil, nil)
 		p.PreInstallQuery = new("SELECT changed;")
-		require.NoError(t, svc.reconcilePatchPolicy(ctx, p, nonFMAInstaller))
+		shouldHavePatchPolicy, _, _, err := svc.planPatchPolicy(ctx, p, nonFMAInstaller)
+		require.NoError(t, err)
+		assert.False(t, shouldHavePatchPolicy)
 	})
 
-	// patch:true with no existing policy creates one with the requested patch_when_closed.
+	// patch:true with no existing policy plans a create with patch_when_closed on.
 	t.Run("creates when no policy exists", func(t *testing.T) {
-		svc, base := setup(t, nil)
-		base.NewTeamPolicyFunc = func(ctx context.Context, tID uint, p fleet.NewTeamPolicyPayload) (*fleet.Policy, error) {
-			require.NotNil(t, p.Type)
-			assert.Equal(t, fleet.PolicyTypePatch, *p.Type)
-			assert.True(t, p.PatchWhenClosed)
-			return &fleet.Policy{}, nil
-		}
-		require.NoError(t, svc.reconcilePatchPolicy(ctx, payload(new(true), new(true)), fmaInstaller))
-		assert.True(t, base.NewTeamPolicyFuncInvoked)
+		svc := setup(t, nil)
+		shouldHavePatchPolicy, patchWhenClosed, current, err := svc.planPatchPolicy(ctx, payload(new(true), new(true)), fmaInstaller)
+		require.NoError(t, err)
+		assert.True(t, shouldHavePatchPolicy)
+		assert.True(t, patchWhenClosed)
+		assert.Nil(t, current)
 	})
 
 	// patch:true with patch_when_closed omitted defaults a new policy to "only when closed".
 	t.Run("new policy defaults to patch_when_closed", func(t *testing.T) {
-		svc, base := setup(t, nil)
-		var got bool
-		base.NewTeamPolicyFunc = func(ctx context.Context, tID uint, p fleet.NewTeamPolicyPayload) (*fleet.Policy, error) {
-			got = p.PatchWhenClosed
-			return &fleet.Policy{}, nil
-		}
-		require.NoError(t, svc.reconcilePatchPolicy(ctx, payload(new(true), nil), fmaInstaller))
-		assert.True(t, got)
+		svc := setup(t, nil)
+		_, patchWhenClosed, _, err := svc.planPatchPolicy(ctx, payload(new(true), nil), fmaInstaller)
+		require.NoError(t, err)
+		assert.True(t, patchWhenClosed)
 	})
 
-	// patch:false deletes the existing patch policy.
+	// patch:false plans a delete of the existing patch policy.
 	t.Run("deletes when patch disabled", func(t *testing.T) {
-		svc, base := setup(t, &fleet.PatchPolicyData{ID: 9})
-		var deleted []uint
-		base.DeleteTeamPoliciesFunc = func(ctx context.Context, tID uint, ids []uint) ([]uint, error) {
-			deleted = ids
-			return ids, nil
-		}
-		require.NoError(t, svc.reconcilePatchPolicy(ctx, payload(new(false), nil), fmaInstaller))
-		assert.Equal(t, []uint{9}, deleted)
+		svc := setup(t, &fleet.PatchPolicyData{ID: 9})
+		shouldHavePatchPolicy, _, current, err := svc.planPatchPolicy(ctx, payload(new(false), nil), fmaInstaller)
+		require.NoError(t, err)
+		assert.False(t, shouldHavePatchPolicy)
+		require.NotNil(t, current)
+		assert.Equal(t, uint(9), current.ID)
 	})
 
-	// Toggling patch_when_closed on an existing policy updates it rather than recreating it.
+	// Toggling patch_when_closed on an existing policy plans an update from its prior value.
 	t.Run("updates patch_when_closed on existing policy", func(t *testing.T) {
-		svc, base := setup(t, &fleet.PatchPolicyData{ID: 9, PatchWhenClosed: false})
-		var modified *bool
-		base.ModifyTeamPolicyFunc = func(ctx context.Context, tID uint, id uint, p fleet.ModifyPolicyPayload) (*fleet.Policy, error) {
-			assert.Equal(t, uint(9), id)
-			modified = p.PatchWhenClosed
-			return &fleet.Policy{}, nil
-		}
-		require.NoError(t, svc.reconcilePatchPolicy(ctx, payload(nil, new(true)), fmaInstaller))
-		assert.False(t, base.NewTeamPolicyFuncInvoked)
-		require.NotNil(t, modified)
-		assert.True(t, *modified)
+		svc := setup(t, &fleet.PatchPolicyData{ID: 9, PatchWhenClosed: false})
+		_, patchWhenClosed, current, err := svc.planPatchPolicy(ctx, payload(nil, new(true)), fmaInstaller)
+		require.NoError(t, err)
+		require.NotNil(t, current)
+		assert.False(t, current.PatchWhenClosed)
+		assert.True(t, patchWhenClosed)
 	})
 
-	// A pre-install edit is allowed and touches no policy when the title's patch policy has
-	// patch_when_closed off.
+	// A pre-install edit is allowed when the title's patch policy has patch_when_closed off.
 	t.Run("pre-install edit allowed when patch_when_closed is off", func(t *testing.T) {
-		svc, base := setup(t, &fleet.PatchPolicyData{ID: 9, PatchWhenClosed: false})
+		svc := setup(t, &fleet.PatchPolicyData{ID: 9, PatchWhenClosed: false})
 		p := payload(nil, nil)
 		p.PreInstallQuery = new("SELECT changed;")
-		require.NoError(t, svc.reconcilePatchPolicy(ctx, p, fmaInstaller))
-		assert.False(t, base.NewTeamPolicyFuncInvoked)
-		assert.False(t, base.ModifyTeamPolicyFuncInvoked)
-		assert.False(t, base.DeleteTeamPoliciesFuncInvoked)
+		_, patchWhenClosed, _, err := svc.planPatchPolicy(ctx, p, fmaInstaller)
+		require.NoError(t, err)
+		assert.False(t, patchWhenClosed)
 	})
 }

--- a/ee/server/service/software_installers_test.go
+++ b/ee/server/service/software_installers_test.go
@@ -2653,103 +2653,79 @@ func TestNormalizeSetupExperiencePlatforms(t *testing.T) {
 }
 
 func TestPlanPatchPolicy(t *testing.T) {
-	ctx := context.Background()
 	titleID := uint(42)
 	teamID := uint(0)
 	fmaInstaller := &fleet.SoftwareInstaller{TitleID: &titleID, FleetMaintainedAppID: new(uint(7)), PreInstallQuery: "SELECT old;"}
 	nonFMAInstaller := &fleet.SoftwareInstaller{TitleID: &titleID}
 
-	// setup resolves GetPatchPolicy to existing (nil means the title has no patch policy).
-	setup := func(t *testing.T, existing *fleet.PatchPolicyData) *Service {
-		ds := new(mock.Store)
-		ds.GetPatchPolicyFunc = func(ctx context.Context, gotTeamID *uint, gotTitleID uint) (*fleet.PatchPolicyData, error) {
-			if existing == nil {
-				return nil, &notFoundError{}
-			}
-			return existing, nil
-		}
-		svc, _ := newTestServiceWithMock(t, ds)
-		return svc
-	}
-
 	payload := func(patch *bool, patchWhenClosed *bool) *fleet.UpdateSoftwareInstallerPayload {
 		return &fleet.UpdateSoftwareInstallerPayload{TitleID: titleID, TeamID: &teamID, Patch: patch, PatchWhenClosed: patchWhenClosed}
 	}
 
-	// patch_when_closed can't be enabled unless patch is enabled too, whether patch is omitted
-	// (with no existing policy) or explicitly disabled.
-	t.Run("rejects patch_when_closed without patch", func(t *testing.T) {
-		svc := setup(t, nil)
-		_, _, _, err := svc.planPatchPolicy(ctx, payload(nil, new(true)), fmaInstaller)
-		require.ErrorContains(t, err, "requires")
-		_, _, _, err = svc.planPatchPolicy(ctx, payload(new(false), new(true)), fmaInstaller)
-		require.ErrorContains(t, err, "requires")
+	// patch_when_closed with no patch is silently ignored (no policy, no error), whether patch is
+	// omitted with no existing policy or explicitly disabled.
+	t.Run("ignores patch_when_closed without patch", func(t *testing.T) {
+		patchFlag, _, err := planPatchPolicy(payload(nil, new(true)), fmaInstaller, nil)
+		require.NoError(t, err)
+		assert.False(t, patchFlag)
+		patchFlag, _, err = planPatchPolicy(payload(new(false), new(true)), fmaInstaller, nil)
+		require.NoError(t, err)
+		assert.False(t, patchFlag)
 	})
 
 	// While patch_when_closed is on, the user pre-install query is managed and can't be edited.
 	t.Run("rejects pre-install edit while managed", func(t *testing.T) {
-		svc := setup(t, &fleet.PatchPolicyData{ID: 9, PatchWhenClosed: true})
 		p := payload(nil, nil)
 		p.PreInstallQuery = new("SELECT changed;")
-		_, _, _, err := svc.planPatchPolicy(ctx, p, fmaInstaller)
+		_, _, err := planPatchPolicy(p, fmaInstaller, &fleet.PatchPolicyData{ID: 9, PatchWhenClosed: true})
 		require.ErrorContains(t, err, "managed by Fleet")
 	})
 
 	// A pre-install edit on a non-FMA package is never managed; nothing to plan.
 	t.Run("allows pre-install edit on non-FMA package", func(t *testing.T) {
-		svc := setup(t, &fleet.PatchPolicyData{ID: 9, PatchWhenClosed: true})
 		p := payload(nil, nil)
 		p.PreInstallQuery = new("SELECT changed;")
-		shouldHavePatchPolicy, _, _, err := svc.planPatchPolicy(ctx, p, nonFMAInstaller)
+		patchFlag, _, err := planPatchPolicy(p, nonFMAInstaller, &fleet.PatchPolicyData{ID: 9, PatchWhenClosed: true})
 		require.NoError(t, err)
-		assert.False(t, shouldHavePatchPolicy)
+		assert.False(t, patchFlag)
 	})
 
 	// patch:true with no existing policy plans a create with patch_when_closed on.
 	t.Run("creates when no policy exists", func(t *testing.T) {
-		svc := setup(t, nil)
-		shouldHavePatchPolicy, patchWhenClosed, current, err := svc.planPatchPolicy(ctx, payload(new(true), new(true)), fmaInstaller)
+		patchFlag, patchWhenClosedFlag, err := planPatchPolicy(payload(new(true), new(true)), fmaInstaller, nil)
 		require.NoError(t, err)
-		assert.True(t, shouldHavePatchPolicy)
-		assert.True(t, patchWhenClosed)
-		assert.Nil(t, current)
+		assert.True(t, patchFlag)
+		assert.True(t, patchWhenClosedFlag)
 	})
 
 	// patch:true with patch_when_closed omitted defaults a new policy to "only when closed".
 	t.Run("new policy defaults to patch_when_closed", func(t *testing.T) {
-		svc := setup(t, nil)
-		_, patchWhenClosed, _, err := svc.planPatchPolicy(ctx, payload(new(true), nil), fmaInstaller)
+		_, patchWhenClosedFlag, err := planPatchPolicy(payload(new(true), nil), fmaInstaller, nil)
 		require.NoError(t, err)
-		assert.True(t, patchWhenClosed)
+		assert.True(t, patchWhenClosedFlag)
 	})
 
-	// patch:false plans a delete of the existing patch policy.
-	t.Run("deletes when patch disabled", func(t *testing.T) {
-		svc := setup(t, &fleet.PatchPolicyData{ID: 9})
-		shouldHavePatchPolicy, _, current, err := svc.planPatchPolicy(ctx, payload(new(false), nil), fmaInstaller)
+	// patch:false disables the existing patch policy.
+	t.Run("disables when patch off", func(t *testing.T) {
+		patchFlag, _, err := planPatchPolicy(payload(new(false), nil), fmaInstaller, &fleet.PatchPolicyData{ID: 9})
 		require.NoError(t, err)
-		assert.False(t, shouldHavePatchPolicy)
-		require.NotNil(t, current)
-		assert.Equal(t, uint(9), current.ID)
+		assert.False(t, patchFlag)
 	})
 
-	// Toggling patch_when_closed on an existing policy plans an update from its prior value.
+	// Toggling patch_when_closed on an existing policy keeps patch on and flips the value.
 	t.Run("updates patch_when_closed on existing policy", func(t *testing.T) {
-		svc := setup(t, &fleet.PatchPolicyData{ID: 9, PatchWhenClosed: false})
-		_, patchWhenClosed, current, err := svc.planPatchPolicy(ctx, payload(nil, new(true)), fmaInstaller)
+		patchFlag, patchWhenClosedFlag, err := planPatchPolicy(payload(nil, new(true)), fmaInstaller, &fleet.PatchPolicyData{ID: 9, PatchWhenClosed: false})
 		require.NoError(t, err)
-		require.NotNil(t, current)
-		assert.False(t, current.PatchWhenClosed)
-		assert.True(t, patchWhenClosed)
+		assert.True(t, patchFlag)
+		assert.True(t, patchWhenClosedFlag)
 	})
 
 	// A pre-install edit is allowed when the title's patch policy has patch_when_closed off.
 	t.Run("pre-install edit allowed when patch_when_closed is off", func(t *testing.T) {
-		svc := setup(t, &fleet.PatchPolicyData{ID: 9, PatchWhenClosed: false})
 		p := payload(nil, nil)
 		p.PreInstallQuery = new("SELECT changed;")
-		_, patchWhenClosed, _, err := svc.planPatchPolicy(ctx, p, fmaInstaller)
+		_, patchWhenClosedFlag, err := planPatchPolicy(p, fmaInstaller, &fleet.PatchPolicyData{ID: 9, PatchWhenClosed: false})
 		require.NoError(t, err)
-		assert.False(t, patchWhenClosed)
+		assert.False(t, patchWhenClosedFlag)
 	})
 }

--- a/ee/server/service/software_installers_test.go
+++ b/ee/server/service/software_installers_test.go
@@ -2752,8 +2752,9 @@ func TestReconcilePatchPolicy(t *testing.T) {
 		assert.True(t, *modified)
 	})
 
-	// An unmanaged FMA title with no patch changes touches no policy.
-	t.Run("unmanaged with no patch change is a noop", func(t *testing.T) {
+	// A pre-install edit is allowed and touches no policy when the title's patch policy has
+	// patch_when_closed off.
+	t.Run("pre-install edit allowed when patch_when_closed is off", func(t *testing.T) {
 		svc, base := setup(t, &fleet.PatchPolicyData{ID: 9, PatchWhenClosed: false})
 		p := payload(nil, nil)
 		p.PreInstallQuery = new("SELECT changed;")

--- a/ee/server/service/software_installers_test.go
+++ b/ee/server/service/software_installers_test.go
@@ -2652,15 +2652,14 @@ func TestNormalizeSetupExperiencePlatforms(t *testing.T) {
 	}
 }
 
-func TestReconcilePatchPolicy(t *testing.T) {
+func TestPlanPatchPolicy(t *testing.T) {
 	ctx := context.Background()
 	titleID := uint(42)
 	teamID := uint(0)
-	fmaInstaller := &fleet.SoftwareInstaller{TitleID: &titleID, FleetMaintainedAppID: new(uint(7)), PreInstallQuery: "SELECT old;"}
+	fmaInstaller := &fleet.SoftwareInstaller{TitleID: &titleID, FleetMaintainedAppID: new(uint(7))}
 	nonFMAInstaller := &fleet.SoftwareInstaller{TitleID: &titleID}
 
-	// setup resolves GetPatchPolicy to existing (nil means the title has no patch policy).
-	setup := func(t *testing.T, existing *fleet.PatchPolicyData) (*Service, *svcmock.Service) {
+	newSvc := func(t *testing.T, existing *fleet.PatchPolicyData) *Service {
 		ds := new(mock.Store)
 		ds.GetPatchPolicyFunc = func(ctx context.Context, gotTeamID *uint, gotTitleID uint) (*fleet.PatchPolicyData, error) {
 			if existing == nil {
@@ -2668,99 +2667,150 @@ func TestReconcilePatchPolicy(t *testing.T) {
 			}
 			return existing, nil
 		}
-		return newTestServiceWithMock(t, ds)
+		svc, _ := newTestServiceWithMock(t, ds)
+		return svc
 	}
 
 	payload := func(patch *bool, patchWhenClosed *bool) *fleet.UpdateSoftwareInstallerPayload {
 		return &fleet.UpdateSoftwareInstallerPayload{TitleID: titleID, TeamID: &teamID, Patch: patch, PatchWhenClosed: patchWhenClosed}
 	}
 
-	// patch_when_closed can't be enabled unless patch is enabled too, whether patch is omitted
-	// (with no existing policy) or explicitly disabled.
+	// The patch controls only apply to Fleet-maintained apps.
+	t.Run("rejects patch fields on non-FMA installer", func(t *testing.T) {
+		_, err := newSvc(t, nil).planPatchPolicy(ctx, payload(new(true), nil), nonFMAInstaller)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "Fleet-maintained apps")
+	})
+
+	// patch_when_closed can't be enabled unless patch is enabled too.
 	t.Run("rejects patch_when_closed without patch", func(t *testing.T) {
-		svc, _ := setup(t, nil)
-		require.ErrorContains(t, svc.reconcilePatchPolicy(ctx, payload(nil, new(true)), fmaInstaller), "requires")
-		require.ErrorContains(t, svc.reconcilePatchPolicy(ctx, payload(new(false), new(true)), fmaInstaller), "requires")
+		_, err := newSvc(t, nil).planPatchPolicy(ctx, payload(nil, new(true)), fmaInstaller)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "requires")
 	})
 
-	// While patch_when_closed is on, the user pre-install query is managed and can't be edited.
-	t.Run("rejects pre-install edit while managed", func(t *testing.T) {
-		svc, _ := setup(t, &fleet.PatchPolicyData{ID: 9, PatchWhenClosed: true})
+	// Enabling both on a title with no patch policy yet marks it managed (create path).
+	t.Run("enabling patch and patch_when_closed is managed", func(t *testing.T) {
+		plan, err := newSvc(t, nil).planPatchPolicy(ctx, payload(new(true), new(true)), fmaInstaller)
+		require.NoError(t, err)
+		assert.Nil(t, plan.existing)
+		assert.True(t, plan.patchEnabled)
+		assert.True(t, plan.managed())
+	})
+
+	// A pre-install query edit on a title whose existing patch policy already has
+	// patch_when_closed set resolves as managed, so the edit is rejected.
+	t.Run("existing patch_when_closed policy is managed on pre-install edit", func(t *testing.T) {
 		p := payload(nil, nil)
-		p.PreInstallQuery = new("SELECT changed;")
-		err := svc.reconcilePatchPolicy(ctx, p, fmaInstaller)
-		require.ErrorContains(t, err, "managed by Fleet")
+		p.PreInstallQuery = new("SELECT 1;")
+		plan, err := newSvc(t, &fleet.PatchPolicyData{ID: 5, PatchWhenClosed: true}).planPatchPolicy(ctx, p, fmaInstaller)
+		require.NoError(t, err)
+		require.NotNil(t, plan.existing)
+		assert.True(t, plan.managed())
 	})
 
-	// A pre-install edit on a non-FMA package is never managed.
-	t.Run("allows pre-install edit on non-FMA package", func(t *testing.T) {
-		svc, _ := setup(t, &fleet.PatchPolicyData{ID: 9, PatchWhenClosed: true})
+	// When nothing patch-related and no pre-install query is in the request, the lookup is
+	// skipped entirely and the title is treated as unmanaged.
+	t.Run("no patch or pre-install fields skips lookup", func(t *testing.T) {
+		plan, err := newSvc(t, &fleet.PatchPolicyData{ID: 5, PatchWhenClosed: true}).planPatchPolicy(ctx, payload(nil, nil), fmaInstaller)
+		require.NoError(t, err)
+		assert.Nil(t, plan.existing)
+		assert.False(t, plan.managed())
+	})
+
+	// Disabling patch drops management, re-exposing the user pre-install query.
+	t.Run("disabling patch is not managed", func(t *testing.T) {
+		plan, err := newSvc(t, &fleet.PatchPolicyData{ID: 5, PatchWhenClosed: true}).planPatchPolicy(ctx, payload(new(false), nil), fmaInstaller)
+		require.NoError(t, err)
+		assert.False(t, plan.patchEnabled)
+		assert.False(t, plan.managed())
+	})
+
+	// A pre-install edit on a non-FMA package is never managed, even when the title has an
+	// FMA-backed patch-when-closed policy on a sibling package.
+	t.Run("non-FMA package pre-install edit is not managed", func(t *testing.T) {
 		p := payload(nil, nil)
-		p.PreInstallQuery = new("SELECT changed;")
-		require.NoError(t, svc.reconcilePatchPolicy(ctx, p, nonFMAInstaller))
+		p.PreInstallQuery = new("SELECT 1;")
+		plan, err := newSvc(t, &fleet.PatchPolicyData{ID: 5, PatchWhenClosed: true}).planPatchPolicy(ctx, p, nonFMAInstaller)
+		require.NoError(t, err)
+		assert.Nil(t, plan.existing)
+		assert.False(t, plan.managed())
 	})
+}
 
-	// patch:true with no existing policy creates one with the requested patch_when_closed.
+func TestApplyPatchPolicyPlan(t *testing.T) {
+	ctx := context.Background()
+	titleID := uint(42)
+	teamID := uint(0)
+	patchOn := &fleet.UpdateSoftwareInstallerPayload{TitleID: titleID, TeamID: &teamID, Patch: new(true)}
+
+	// patch:true with no existing policy creates the patch policy.
 	t.Run("creates when no policy exists", func(t *testing.T) {
-		svc, base := setup(t, nil)
+		ds := new(mock.Store)
+		svc, base := newTestServiceWithMock(t, ds)
 		base.NewTeamPolicyFunc = func(ctx context.Context, tID uint, p fleet.NewTeamPolicyPayload) (*fleet.Policy, error) {
 			require.NotNil(t, p.Type)
 			assert.Equal(t, fleet.PolicyTypePatch, *p.Type)
 			assert.True(t, p.PatchWhenClosed)
 			return &fleet.Policy{}, nil
 		}
-		require.NoError(t, svc.reconcilePatchPolicy(ctx, payload(new(true), new(true)), fmaInstaller))
+		err := svc.applyPatchPolicyPlan(ctx, patchOn, patchPolicyPlan{patchEnabled: true, patchWhenClosed: true})
+		require.NoError(t, err)
 		assert.True(t, base.NewTeamPolicyFuncInvoked)
-	})
-
-	// patch:true with patch_when_closed omitted defaults a new policy to "only when closed".
-	t.Run("new policy defaults to patch_when_closed", func(t *testing.T) {
-		svc, base := setup(t, nil)
-		var got bool
-		base.NewTeamPolicyFunc = func(ctx context.Context, tID uint, p fleet.NewTeamPolicyPayload) (*fleet.Policy, error) {
-			got = p.PatchWhenClosed
-			return &fleet.Policy{}, nil
-		}
-		require.NoError(t, svc.reconcilePatchPolicy(ctx, payload(new(true), nil), fmaInstaller))
-		assert.True(t, got)
 	})
 
 	// patch:false deletes the existing patch policy.
 	t.Run("deletes when patch disabled", func(t *testing.T) {
-		svc, base := setup(t, &fleet.PatchPolicyData{ID: 9})
+		ds := new(mock.Store)
+		svc, base := newTestServiceWithMock(t, ds)
 		var deleted []uint
 		base.DeleteTeamPoliciesFunc = func(ctx context.Context, tID uint, ids []uint) ([]uint, error) {
 			deleted = ids
 			return ids, nil
 		}
-		require.NoError(t, svc.reconcilePatchPolicy(ctx, payload(new(false), nil), fmaInstaller))
+		payload := &fleet.UpdateSoftwareInstallerPayload{TitleID: titleID, TeamID: &teamID, Patch: new(false)}
+		err := svc.applyPatchPolicyPlan(ctx, payload, patchPolicyPlan{existing: &fleet.PatchPolicyData{ID: 9}})
+		require.NoError(t, err)
 		assert.Equal(t, []uint{9}, deleted)
 	})
 
 	// Toggling patch_when_closed on an existing policy updates it rather than recreating it.
 	t.Run("updates patch_when_closed on existing policy", func(t *testing.T) {
-		svc, base := setup(t, &fleet.PatchPolicyData{ID: 9, PatchWhenClosed: false})
+		ds := new(mock.Store)
+		svc, base := newTestServiceWithMock(t, ds)
 		var modified *bool
 		base.ModifyTeamPolicyFunc = func(ctx context.Context, tID uint, id uint, p fleet.ModifyPolicyPayload) (*fleet.Policy, error) {
 			assert.Equal(t, uint(9), id)
 			modified = p.PatchWhenClosed
 			return &fleet.Policy{}, nil
 		}
-		require.NoError(t, svc.reconcilePatchPolicy(ctx, payload(nil, new(true)), fmaInstaller))
+		payload := &fleet.UpdateSoftwareInstallerPayload{TitleID: titleID, TeamID: &teamID, PatchWhenClosed: new(true)}
+		err := svc.applyPatchPolicyPlan(ctx, payload, patchPolicyPlan{existing: &fleet.PatchPolicyData{ID: 9}, patchEnabled: true, patchWhenClosed: true})
+		require.NoError(t, err)
 		assert.False(t, base.NewTeamPolicyFuncInvoked)
 		require.NotNil(t, modified)
 		assert.True(t, *modified)
 	})
 
-	// A pre-install edit is allowed and touches no policy when the title's patch policy has
-	// patch_when_closed off.
-	t.Run("pre-install edit allowed when patch_when_closed is off", func(t *testing.T) {
-		svc, base := setup(t, &fleet.PatchPolicyData{ID: 9, PatchWhenClosed: false})
-		p := payload(nil, nil)
-		p.PreInstallQuery = new("SELECT changed;")
-		require.NoError(t, svc.reconcilePatchPolicy(ctx, p, fmaInstaller))
-		assert.False(t, base.NewTeamPolicyFuncInvoked)
-		assert.False(t, base.ModifyTeamPolicyFuncInvoked)
-		assert.False(t, base.DeleteTeamPoliciesFuncInvoked)
+	// A concurrent create that loses the unique-constraint race converges instead of failing.
+	t.Run("converges on create conflict", func(t *testing.T) {
+		ds := new(mock.Store)
+		svc, base := newTestServiceWithMock(t, ds)
+		base.NewTeamPolicyFunc = func(ctx context.Context, tID uint, p fleet.NewTeamPolicyPayload) (*fleet.Policy, error) {
+			return nil, &fleet.ConflictError{Message: "already has a patch policy"}
+		}
+		ds.GetPatchPolicyFunc = func(ctx context.Context, tID *uint, id uint) (*fleet.PatchPolicyData, error) {
+			return &fleet.PatchPolicyData{ID: 9, PatchWhenClosed: false}, nil
+		}
+		var modified *bool
+		base.ModifyTeamPolicyFunc = func(ctx context.Context, tID uint, id uint, p fleet.ModifyPolicyPayload) (*fleet.Policy, error) {
+			modified = p.PatchWhenClosed
+			return &fleet.Policy{}, nil
+		}
+		err := svc.applyPatchPolicyPlan(ctx, patchOn, patchPolicyPlan{patchEnabled: true, patchWhenClosed: true})
+		require.NoError(t, err)
+		assert.True(t, ds.GetPatchPolicyFuncInvoked)
+		require.NotNil(t, modified)
+		assert.True(t, *modified)
 	})
 }

--- a/ee/server/service/software_installers_test.go
+++ b/ee/server/service/software_installers_test.go
@@ -2652,14 +2652,15 @@ func TestNormalizeSetupExperiencePlatforms(t *testing.T) {
 	}
 }
 
-func TestPlanPatchPolicy(t *testing.T) {
+func TestReconcilePatchPolicy(t *testing.T) {
 	ctx := context.Background()
 	titleID := uint(42)
 	teamID := uint(0)
-	fmaInstaller := &fleet.SoftwareInstaller{TitleID: &titleID, FleetMaintainedAppID: new(uint(7))}
+	fmaInstaller := &fleet.SoftwareInstaller{TitleID: &titleID, FleetMaintainedAppID: new(uint(7)), PreInstallQuery: "SELECT old;"}
 	nonFMAInstaller := &fleet.SoftwareInstaller{TitleID: &titleID}
 
-	newSvc := func(t *testing.T, existing *fleet.PatchPolicyData) *Service {
+	// setup resolves GetPatchPolicy to existing (nil means the title has no patch policy).
+	setup := func(t *testing.T, existing *fleet.PatchPolicyData) (*Service, *svcmock.Service) {
 		ds := new(mock.Store)
 		ds.GetPatchPolicyFunc = func(ctx context.Context, gotTeamID *uint, gotTitleID uint) (*fleet.PatchPolicyData, error) {
 			if existing == nil {
@@ -2667,150 +2668,86 @@ func TestPlanPatchPolicy(t *testing.T) {
 			}
 			return existing, nil
 		}
-		svc, _ := newTestServiceWithMock(t, ds)
-		return svc
+		return newTestServiceWithMock(t, ds)
 	}
 
 	payload := func(patch *bool, patchWhenClosed *bool) *fleet.UpdateSoftwareInstallerPayload {
 		return &fleet.UpdateSoftwareInstallerPayload{TitleID: titleID, TeamID: &teamID, Patch: patch, PatchWhenClosed: patchWhenClosed}
 	}
 
-	// The patch controls only apply to Fleet-maintained apps.
-	t.Run("rejects patch fields on non-FMA installer", func(t *testing.T) {
-		_, err := newSvc(t, nil).planPatchPolicy(ctx, payload(new(true), nil), nonFMAInstaller)
-		require.Error(t, err)
-		require.ErrorContains(t, err, "Fleet-maintained apps")
-	})
-
-	// patch_when_closed can't be enabled unless patch is enabled too.
+	// patch_when_closed can't be enabled unless patch is enabled too, whether patch is omitted
+	// (with no existing policy) or explicitly disabled.
 	t.Run("rejects patch_when_closed without patch", func(t *testing.T) {
-		_, err := newSvc(t, nil).planPatchPolicy(ctx, payload(nil, new(true)), fmaInstaller)
-		require.Error(t, err)
-		require.ErrorContains(t, err, "requires")
+		svc, _ := setup(t, nil)
+		require.ErrorContains(t, svc.reconcilePatchPolicy(ctx, payload(nil, new(true)), fmaInstaller), "requires")
+		require.ErrorContains(t, svc.reconcilePatchPolicy(ctx, payload(new(false), new(true)), fmaInstaller), "requires")
 	})
 
-	// Enabling both on a title with no patch policy yet marks it managed (create path).
-	t.Run("enabling patch and patch_when_closed is managed", func(t *testing.T) {
-		plan, err := newSvc(t, nil).planPatchPolicy(ctx, payload(new(true), new(true)), fmaInstaller)
-		require.NoError(t, err)
-		assert.Nil(t, plan.existing)
-		assert.True(t, plan.patchEnabled)
-		assert.True(t, plan.managed())
-	})
-
-	// A pre-install query edit on a title whose existing patch policy already has
-	// patch_when_closed set resolves as managed, so the edit is rejected.
-	t.Run("existing patch_when_closed policy is managed on pre-install edit", func(t *testing.T) {
+	// While patch_when_closed is on, the user pre-install query is managed and can't be edited.
+	t.Run("rejects pre-install edit while managed", func(t *testing.T) {
+		svc, _ := setup(t, &fleet.PatchPolicyData{ID: 9, PatchWhenClosed: true})
 		p := payload(nil, nil)
-		p.PreInstallQuery = new("SELECT 1;")
-		plan, err := newSvc(t, &fleet.PatchPolicyData{ID: 5, PatchWhenClosed: true}).planPatchPolicy(ctx, p, fmaInstaller)
-		require.NoError(t, err)
-		require.NotNil(t, plan.existing)
-		assert.True(t, plan.managed())
+		p.PreInstallQuery = new("SELECT changed;")
+		err := svc.reconcilePatchPolicy(ctx, p, fmaInstaller)
+		require.ErrorContains(t, err, "managed by Fleet")
 	})
 
-	// When nothing patch-related and no pre-install query is in the request, the lookup is
-	// skipped entirely and the title is treated as unmanaged.
-	t.Run("no patch or pre-install fields skips lookup", func(t *testing.T) {
-		plan, err := newSvc(t, &fleet.PatchPolicyData{ID: 5, PatchWhenClosed: true}).planPatchPolicy(ctx, payload(nil, nil), fmaInstaller)
-		require.NoError(t, err)
-		assert.Nil(t, plan.existing)
-		assert.False(t, plan.managed())
-	})
-
-	// Disabling patch drops management, re-exposing the user pre-install query.
-	t.Run("disabling patch is not managed", func(t *testing.T) {
-		plan, err := newSvc(t, &fleet.PatchPolicyData{ID: 5, PatchWhenClosed: true}).planPatchPolicy(ctx, payload(new(false), nil), fmaInstaller)
-		require.NoError(t, err)
-		assert.False(t, plan.patchEnabled)
-		assert.False(t, plan.managed())
-	})
-
-	// A pre-install edit on a non-FMA package is never managed, even when the title has an
-	// FMA-backed patch-when-closed policy on a sibling package.
-	t.Run("non-FMA package pre-install edit is not managed", func(t *testing.T) {
+	// A pre-install edit on a non-FMA package is never managed.
+	t.Run("allows pre-install edit on non-FMA package", func(t *testing.T) {
+		svc, _ := setup(t, &fleet.PatchPolicyData{ID: 9, PatchWhenClosed: true})
 		p := payload(nil, nil)
-		p.PreInstallQuery = new("SELECT 1;")
-		plan, err := newSvc(t, &fleet.PatchPolicyData{ID: 5, PatchWhenClosed: true}).planPatchPolicy(ctx, p, nonFMAInstaller)
-		require.NoError(t, err)
-		assert.Nil(t, plan.existing)
-		assert.False(t, plan.managed())
+		p.PreInstallQuery = new("SELECT changed;")
+		require.NoError(t, svc.reconcilePatchPolicy(ctx, p, nonFMAInstaller))
 	})
-}
 
-func TestApplyPatchPolicyPlan(t *testing.T) {
-	ctx := context.Background()
-	titleID := uint(42)
-	teamID := uint(0)
-	patchOn := &fleet.UpdateSoftwareInstallerPayload{TitleID: titleID, TeamID: &teamID, Patch: new(true)}
-
-	// patch:true with no existing policy creates the patch policy.
+	// patch:true with no existing policy creates one with the requested patch_when_closed.
 	t.Run("creates when no policy exists", func(t *testing.T) {
-		ds := new(mock.Store)
-		svc, base := newTestServiceWithMock(t, ds)
+		svc, base := setup(t, nil)
 		base.NewTeamPolicyFunc = func(ctx context.Context, tID uint, p fleet.NewTeamPolicyPayload) (*fleet.Policy, error) {
 			require.NotNil(t, p.Type)
 			assert.Equal(t, fleet.PolicyTypePatch, *p.Type)
 			assert.True(t, p.PatchWhenClosed)
 			return &fleet.Policy{}, nil
 		}
-		err := svc.applyPatchPolicyPlan(ctx, patchOn, patchPolicyPlan{patchEnabled: true, patchWhenClosed: true})
-		require.NoError(t, err)
+		require.NoError(t, svc.reconcilePatchPolicy(ctx, payload(new(true), new(true)), fmaInstaller))
 		assert.True(t, base.NewTeamPolicyFuncInvoked)
 	})
 
 	// patch:false deletes the existing patch policy.
 	t.Run("deletes when patch disabled", func(t *testing.T) {
-		ds := new(mock.Store)
-		svc, base := newTestServiceWithMock(t, ds)
+		svc, base := setup(t, &fleet.PatchPolicyData{ID: 9})
 		var deleted []uint
 		base.DeleteTeamPoliciesFunc = func(ctx context.Context, tID uint, ids []uint) ([]uint, error) {
 			deleted = ids
 			return ids, nil
 		}
-		payload := &fleet.UpdateSoftwareInstallerPayload{TitleID: titleID, TeamID: &teamID, Patch: new(false)}
-		err := svc.applyPatchPolicyPlan(ctx, payload, patchPolicyPlan{existing: &fleet.PatchPolicyData{ID: 9}})
-		require.NoError(t, err)
+		require.NoError(t, svc.reconcilePatchPolicy(ctx, payload(new(false), nil), fmaInstaller))
 		assert.Equal(t, []uint{9}, deleted)
 	})
 
 	// Toggling patch_when_closed on an existing policy updates it rather than recreating it.
 	t.Run("updates patch_when_closed on existing policy", func(t *testing.T) {
-		ds := new(mock.Store)
-		svc, base := newTestServiceWithMock(t, ds)
+		svc, base := setup(t, &fleet.PatchPolicyData{ID: 9, PatchWhenClosed: false})
 		var modified *bool
 		base.ModifyTeamPolicyFunc = func(ctx context.Context, tID uint, id uint, p fleet.ModifyPolicyPayload) (*fleet.Policy, error) {
 			assert.Equal(t, uint(9), id)
 			modified = p.PatchWhenClosed
 			return &fleet.Policy{}, nil
 		}
-		payload := &fleet.UpdateSoftwareInstallerPayload{TitleID: titleID, TeamID: &teamID, PatchWhenClosed: new(true)}
-		err := svc.applyPatchPolicyPlan(ctx, payload, patchPolicyPlan{existing: &fleet.PatchPolicyData{ID: 9}, patchEnabled: true, patchWhenClosed: true})
-		require.NoError(t, err)
+		require.NoError(t, svc.reconcilePatchPolicy(ctx, payload(nil, new(true)), fmaInstaller))
 		assert.False(t, base.NewTeamPolicyFuncInvoked)
 		require.NotNil(t, modified)
 		assert.True(t, *modified)
 	})
 
-	// A concurrent create that loses the unique-constraint race converges instead of failing.
-	t.Run("converges on create conflict", func(t *testing.T) {
-		ds := new(mock.Store)
-		svc, base := newTestServiceWithMock(t, ds)
-		base.NewTeamPolicyFunc = func(ctx context.Context, tID uint, p fleet.NewTeamPolicyPayload) (*fleet.Policy, error) {
-			return nil, &fleet.ConflictError{Message: "already has a patch policy"}
-		}
-		ds.GetPatchPolicyFunc = func(ctx context.Context, tID *uint, id uint) (*fleet.PatchPolicyData, error) {
-			return &fleet.PatchPolicyData{ID: 9, PatchWhenClosed: false}, nil
-		}
-		var modified *bool
-		base.ModifyTeamPolicyFunc = func(ctx context.Context, tID uint, id uint, p fleet.ModifyPolicyPayload) (*fleet.Policy, error) {
-			modified = p.PatchWhenClosed
-			return &fleet.Policy{}, nil
-		}
-		err := svc.applyPatchPolicyPlan(ctx, patchOn, patchPolicyPlan{patchEnabled: true, patchWhenClosed: true})
-		require.NoError(t, err)
-		assert.True(t, ds.GetPatchPolicyFuncInvoked)
-		require.NotNil(t, modified)
-		assert.True(t, *modified)
+	// An unmanaged FMA title with no patch changes touches no policy.
+	t.Run("unmanaged with no patch change is a noop", func(t *testing.T) {
+		svc, base := setup(t, &fleet.PatchPolicyData{ID: 9, PatchWhenClosed: false})
+		p := payload(nil, nil)
+		p.PreInstallQuery = new("SELECT changed;")
+		require.NoError(t, svc.reconcilePatchPolicy(ctx, p, fmaInstaller))
+		assert.False(t, base.NewTeamPolicyFuncInvoked)
+		assert.False(t, base.ModifyTeamPolicyFuncInvoked)
+		assert.False(t, base.DeleteTeamPoliciesFuncInvoked)
 	})
 }

--- a/pkg/patch_policy/patch_policy.go
+++ b/pkg/patch_policy/patch_policy.go
@@ -235,7 +235,7 @@ var windowsOpenQueryOverrides = map[string]string{ //nolint:gosec // G101 false 
 	"PyCharm Community Edition":    "IN ('pycharm.exe','pycharm64.exe')",
 	"PyCharm Professional":         "IN ('pycharm.exe','pycharm64.exe')",
 	"Rider":                        "IN ('rider.exe','rider64.exe')",
-	"RStudio":                      "IN ('rgui.exe','rsession.exe' 'rstudio.exe')",
+	"RStudio":                      "IN ('rgui.exe','rsession.exe','rstudio.exe')",
 	"RubyMine":                     "IN ('rubymine.exe','rubymine64.exe')",
 	"RustRover":                    "IN ('rustrover.exe','rustrover64.exe')",
 	"Spotify":                      "IN ('spotify.exe','spotifywebhelper.exe')",

--- a/pkg/patch_policy/patch_policy.go
+++ b/pkg/patch_policy/patch_policy.go
@@ -169,7 +169,7 @@ func defaultMacOSOpenQuery(bundleIdentifier string) string {
 	// - get processes by name - requires a lot of manual overrides
 	// - use the running_apps table - not reliable when run through orbit
 	// - use the "app" artifact in the homebrew cask - requires extra code to extract
-	openTemplate := "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path LIKE concat(a.path, '/%%') WHERE a.bundle_identifier = '%s');"
+	openTemplate := "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON LEFT(p.path, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = '%s');"
 	return fmt.Sprintf(openTemplate, escapeSQLLiteral(bundleIdentifier))
 }
 

--- a/pkg/patch_policy/patch_policy.go
+++ b/pkg/patch_policy/patch_policy.go
@@ -169,7 +169,7 @@ func defaultMacOSOpenQuery(bundleIdentifier string) string {
 	// - get processes by name - requires a lot of manual overrides
 	// - use the running_apps table - not reliable when run through orbit
 	// - use the "app" artifact in the homebrew cask - requires extra code to extract
-	openTemplate := "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON LEFT(p.path, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = '%s');"
+	openTemplate := "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = '%s');"
 	return fmt.Sprintf(openTemplate, escapeSQLLiteral(bundleIdentifier))
 }
 

--- a/pkg/patch_policy/patch_policy_test.go
+++ b/pkg/patch_policy/patch_policy_test.go
@@ -74,11 +74,11 @@ func TestGenerateOpenQuery(t *testing.T) {
 	// macOS resolves the app's install path from its bundle identifier and matches a process
 	// running from inside it.
 	got := patch_policy.GenerateOpenQuery("darwin", "org.mozilla.firefox", "")
-	require.Equal(t, "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path LIKE concat(a.path, '/%') WHERE a.bundle_identifier = 'org.mozilla.firefox');", got)
+	require.Equal(t, "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON LEFT(p.path, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'org.mozilla.firefox');", got)
 
 	// Apostrophes in the bundle identifier are escaped so they can't break the literal.
 	got = patch_policy.GenerateOpenQuery("darwin", "com.oreilly.o'reilly", "")
-	require.Equal(t, "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path LIKE concat(a.path, '/%') WHERE a.bundle_identifier = 'com.oreilly.o''reilly');", got)
+	require.Equal(t, "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON LEFT(p.path, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.oreilly.o''reilly');", got)
 
 	// Windows matches a process named "<title>.exe".
 	got = patch_policy.GenerateOpenQuery("windows", "", "Slack")

--- a/pkg/patch_policy/patch_policy_test.go
+++ b/pkg/patch_policy/patch_policy_test.go
@@ -74,11 +74,11 @@ func TestGenerateOpenQuery(t *testing.T) {
 	// macOS resolves the app's install path from its bundle identifier and matches a process
 	// running from inside it.
 	got := patch_policy.GenerateOpenQuery("darwin", "org.mozilla.firefox", "")
-	require.Equal(t, "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON LEFT(p.path, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'org.mozilla.firefox');", got)
+	require.Equal(t, "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'org.mozilla.firefox');", got)
 
 	// Apostrophes in the bundle identifier are escaped so they can't break the literal.
 	got = patch_policy.GenerateOpenQuery("darwin", "com.oreilly.o'reilly", "")
-	require.Equal(t, "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON LEFT(p.path, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.oreilly.o''reilly');", got)
+	require.Equal(t, "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.oreilly.o''reilly');", got)
 
 	// Windows matches a process named "<title>.exe".
 	got = patch_policy.GenerateOpenQuery("windows", "", "Slack")

--- a/server/datastore/mysql/migrations/tables/20260721173820_PatchWhenClosed_test.go
+++ b/server/datastore/mysql/migrations/tables/20260721173820_PatchWhenClosed_test.go
@@ -49,7 +49,7 @@ func TestUp_20260721173820(t *testing.T) {
 		`SELECT patch_when_closed FROM policies WHERE id = ?`, policy2))
 	assert.True(t, patchWhenClosed)
 
-	const managedQuery = "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path LIKE concat(a.path, '/%') WHERE a.bundle_identifier = 'com.example.app');"
+	const managedQuery = "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON LEFT(p.path, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.example.app');"
 	title2 := execNoErrLastID(t, db,
 		`INSERT INTO software_titles (name, source, extension_for) VALUES ('App2', 'apps', '')`)
 	installer2 := execNoErrLastID(t, db, `

--- a/server/datastore/mysql/migrations/tables/20260721173820_PatchWhenClosed_test.go
+++ b/server/datastore/mysql/migrations/tables/20260721173820_PatchWhenClosed_test.go
@@ -49,7 +49,7 @@ func TestUp_20260721173820(t *testing.T) {
 		`SELECT patch_when_closed FROM policies WHERE id = ?`, policy2))
 	assert.True(t, patchWhenClosed)
 
-	const managedQuery = "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON LEFT(p.path, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.example.app');"
+	const managedQuery = "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.example.app');"
 	title2 := execNoErrLastID(t, db,
 		`INSERT INTO software_titles (name, source, extension_for) VALUES ('App2', 'apps', '')`)
 	installer2 := execNoErrLastID(t, db, `

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -1806,8 +1806,8 @@ func (ds *Datastore) ApplyPolicySpecs(ctx context.Context, authorID uint, specs 
 					patchSoftwareTitleIDArg = fmaTitleID
 				}
 
-				// A patch-when-closed policy only runs its managed pre-install query on
-				// continuous automation runs, so continuous automations are required.
+				// Continuous automations must be enabled so the patch policy keeps retrying the
+				// install until the app is closed.
 				if spec.PatchWhenClosed {
 					spec.ContinuousAutomationsEnabled = true
 				}

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -1782,6 +1782,13 @@ func (ds *Datastore) ApplyPolicySpecs(ctx context.Context, authorID uint, specs 
 					if err != nil {
 						return ctxerr.Wrap(ctx, err, "getting patch policy installer")
 					}
+
+					// Defensive: this can only happen if this endpoint is being called not via gitops
+					// and batch software didn't get called before.
+					if spec.PatchWhenClosed && installer.PreInstallQuery != "" {
+						return ctxerr.Errorf(ctx, "policy %q: pre_install_query can't be set on Fleet-maintained app %q when patch_when_closed is true", spec.Name, spec.FleetMaintainedAppSlug)
+					}
+
 					generated, err := patch_policy.GenerateFromInstaller(patch_policy.PolicyData{
 						Name:        spec.Name,
 						Description: spec.Description,

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -1806,8 +1806,8 @@ func (ds *Datastore) ApplyPolicySpecs(ctx context.Context, authorID uint, specs 
 					patchSoftwareTitleIDArg = fmaTitleID
 				}
 
-				// Continuous automations must be enabled so the patch policy keeps retrying the
-				// install until the app is closed.
+				// A patch-when-closed policy only runs its managed pre-install query on
+				// continuous automation runs, so continuous automations are required.
 				if spec.PatchWhenClosed {
 					spec.ContinuousAutomationsEnabled = true
 				}

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -93,6 +93,7 @@ func TestPolicies(t *testing.T) {
 		{"PolicyModificationResetsAttemptNumber", testPolicyModificationResetsAttemptNumber},
 		{"TeamPatchPolicy", testTeamPatchPolicy},
 		{"ApplyPolicySpecsDynamicAndPatchSameFMA", testApplyPolicySpecsDynamicAndPatchSameFMA},
+		{"ApplyPolicySpecsPatchWhenClosedRejectsPreInstallQuery", testApplyPolicySpecsPatchWhenClosedRejectsPreInstallQuery},
 		{"ApplyPolicySpecsRenamePatchPolicyRegression43687", testApplyPolicySpecsRenamePatchPolicyRegression43687},
 		{"TeamPolicyAutomationFilter", testTeamPolicyAutomationFilter},
 		{"BatchedPolicyMembershipCleanup", testBatchedPolicyMembershipCleanup},
@@ -8331,6 +8332,64 @@ func testApplyPolicySpecsDynamicAndPatchSameFMA(t *testing.T, ds *Datastore) {
 	require.Equal(t, "patch-fma", patch.Name)
 	require.NotNil(t, patch.PatchSoftwareTitleID, "patch policy must set patch_software_title_id")
 	require.Equal(t, fmaTitleID, *patch.PatchSoftwareTitleID)
+}
+
+func testApplyPolicySpecsPatchWhenClosedRejectsPreInstallQuery(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+	user1 := test.NewUser(t, ds, "Alice", "alice@example.com", true)
+	team1, err := ds.NewTeam(ctx, &fleet.Team{Name: "team-pwc-pre-install"})
+	require.NoError(t, err)
+
+	maintainedApp, err := ds.UpsertMaintainedApp(ctx, &fleet.MaintainedApp{
+		Name:             "Maintained2",
+		Slug:             "maintained2",
+		Platform:         "darwin",
+		UniqueIdentifier: "fleet.maintained2",
+	})
+	require.NoError(t, err)
+
+	// The package carries a user-set pre-install query.
+	_, _, err = ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+		InstallScript:        "hello",
+		PreInstallQuery:      "SELECT 1",
+		StorageID:            "storage-pwc-pre-install",
+		Filename:             "maintained2",
+		Title:                "Maintained2",
+		Version:              "1.0",
+		Source:               "apps",
+		Platform:             "darwin",
+		BundleIdentifier:     "fleet.maintained2",
+		UserID:               user1.ID,
+		TeamID:               &team1.ID,
+		ValidatedLabels:      &fleet.LabelIdentsWithScope{},
+		FleetMaintainedAppID: &maintainedApp.ID,
+	})
+	require.NoError(t, err)
+
+	spec := func(patchWhenClosed bool) []*fleet.PolicySpec {
+		return []*fleet.PolicySpec{{
+			Name:                   "patch-fma-when-closed",
+			Query:                  "SELECT 1;",
+			Team:                   team1.Name,
+			Type:                   fleet.PolicyTypePatch,
+			FleetMaintainedAppSlug: "maintained2",
+			PatchWhenClosed:        patchWhenClosed,
+		}}
+	}
+
+	// patch_when_closed is rejected while the package has its own pre-install query.
+	err = ds.ApplyPolicySpecs(ctx, user1.ID, spec(true))
+	require.ErrorContains(t, err, "pre_install_query can't be set on Fleet-maintained app")
+
+	// The rejected batch wrote nothing.
+	var count int
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, q, &count, `SELECT COUNT(*) FROM policies WHERE name = ?`, "patch-fma-when-closed")
+	})
+	require.Zero(t, count)
+
+	// The same spec applies without patch_when_closed.
+	require.NoError(t, ds.ApplyPolicySpecs(ctx, user1.ID, spec(false)))
 }
 
 // testApplyPolicySpecsRenamePatchPolicyRegression43687 reproduces the customer

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -140,8 +140,7 @@ func (ds *Datastore) GetSoftwareInstallDetails(ctx context.Context, executionId 
 		return nil, ctxerr.Wrap(ctx, err, "get software install details")
 	}
 
-	// A patch-when-closed policy install uses the Fleet-managed app-open query as its pre-install
-	// condition in place of the user's query.
+	// A patch-when-closed policy install uses the installer's app open query as its pre-install condition.
 	if result.PatchWhenClosed {
 		result.PreInstallCondition = result.AppOpenQuery
 	}

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -1990,6 +1990,33 @@ func (ds *Datastore) ProcessInstallerUpdateSideEffects(ctx context.Context, inst
 	return ds.activateNextUpcomingActivityForBatchOfHosts(ctx, activateAffectedHostIDs)
 }
 
+func (ds *Datastore) ClearPreInstallQueryForTitle(ctx context.Context, teamID uint, titleID uint) error {
+	// An FMA title has one is_active=1 row, so team and title identify the managed installer.
+	var installer fleet.SoftwareInstaller
+	err := sqlx.GetContext(ctx, ds.writer(ctx), &installer, `
+		SELECT id, COALESCE(pre_install_query, '') AS pre_install_query
+		FROM software_installers
+		WHERE global_or_team_id = ?
+			AND title_id = ?
+			AND fleet_maintained_app_id IS NOT NULL
+			AND is_active = 1
+		LIMIT 1`, teamID, titleID)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return nil
+	case err != nil:
+		return ctxerr.Wrap(ctx, err, "get title installer")
+	case installer.PreInstallQuery == "":
+		return nil
+	}
+
+	if _, err := ds.writer(ctx).ExecContext(ctx,
+		`UPDATE software_installers SET pre_install_query = '' WHERE id = ?`, installer.InstallerID); err != nil {
+		return ctxerr.Wrap(ctx, err, "clear pre-install query for title")
+	}
+	return ds.ProcessInstallerUpdateSideEffects(ctx, installer.InstallerID, true, false)
+}
+
 func (ds *Datastore) runInstallerUpdateSideEffectsInTransaction(ctx context.Context, tx sqlx.ExtContext, installerID uint, wasMetadataUpdated bool, wasPackageUpdated bool, isEdit bool) (affectedHostIDs []uint, err error) {
 	if wasMetadataUpdated || wasPackageUpdated { // cancel pending installs/uninstalls
 		// TODO make this less naive; this assumes that installs/uninstalls execute and report back immediately

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -67,7 +67,9 @@ func (ds *Datastore) GetSoftwareInstallDetails(ctx context.Context, executionId 
     hsi.execution_id AS execution_id,
     hsi.software_installer_id AS installer_id,
     hsi.self_service AS self_service,
-    COALESCE(CASE WHEN p.patch_when_closed = 1 THEN si.app_open_query ELSE si.pre_install_query END, '') AS pre_install_condition,
+    COALESCE(si.pre_install_query, '') AS pre_install_condition,
+    si.app_open_query AS app_open_query,
+    COALESCE(p.patch_when_closed, 0) AS patch_when_closed,
     inst.contents AS install_script,
     uninst.contents AS uninstall_script,
     COALESCE(pisnt.contents, '') AS post_install_script
@@ -99,7 +101,9 @@ func (ds *Datastore) GetSoftwareInstallDetails(ctx context.Context, executionId 
     ua.execution_id AS execution_id,
     siua.software_installer_id AS installer_id,
 		ua.payload->'$.self_service' AS self_service,
-    COALESCE(CASE WHEN p.patch_when_closed = 1 THEN si.app_open_query ELSE si.pre_install_query END, '') AS pre_install_condition,
+    COALESCE(si.pre_install_query, '') AS pre_install_condition,
+    si.app_open_query AS app_open_query,
+    COALESCE(p.patch_when_closed, 0) AS patch_when_closed,
     inst.contents AS install_script,
     uninst.contents AS uninstall_script,
     COALESCE(pisnt.contents, '') AS post_install_script
@@ -136,7 +140,8 @@ func (ds *Datastore) GetSoftwareInstallDetails(ctx context.Context, executionId 
 		return nil, ctxerr.Wrap(ctx, err, "get software install details")
 	}
 
-	// A patch-when-closed policy install uses the installer's app open query as its pre-install condition.
+	// A patch-when-closed policy install uses the Fleet-managed app-open query as its pre-install
+	// condition in place of the user's query.
 	if result.PatchWhenClosed {
 		result.PreInstallCondition = result.AppOpenQuery
 	}

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -67,9 +67,7 @@ func (ds *Datastore) GetSoftwareInstallDetails(ctx context.Context, executionId 
     hsi.execution_id AS execution_id,
     hsi.software_installer_id AS installer_id,
     hsi.self_service AS self_service,
-    COALESCE(si.pre_install_query, '') AS pre_install_condition,
-    si.app_open_query AS app_open_query,
-    COALESCE(p.patch_when_closed, 0) AS patch_when_closed,
+    COALESCE(CASE WHEN p.patch_when_closed = 1 THEN si.app_open_query ELSE si.pre_install_query END, '') AS pre_install_condition,
     inst.contents AS install_script,
     uninst.contents AS uninstall_script,
     COALESCE(pisnt.contents, '') AS post_install_script
@@ -101,9 +99,7 @@ func (ds *Datastore) GetSoftwareInstallDetails(ctx context.Context, executionId 
     ua.execution_id AS execution_id,
     siua.software_installer_id AS installer_id,
 		ua.payload->'$.self_service' AS self_service,
-    COALESCE(si.pre_install_query, '') AS pre_install_condition,
-    si.app_open_query AS app_open_query,
-    COALESCE(p.patch_when_closed, 0) AS patch_when_closed,
+    COALESCE(CASE WHEN p.patch_when_closed = 1 THEN si.app_open_query ELSE si.pre_install_query END, '') AS pre_install_condition,
     inst.contents AS install_script,
     uninst.contents AS uninstall_script,
     COALESCE(pisnt.contents, '') AS post_install_script

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -7226,6 +7226,10 @@ func testGetSoftwareInstallDetailsPatchWhenClosed(t *testing.T, ds *Datastore) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, patchWhenClosed, p.PatchWhenClosed)
+		if patchWhenClosed {
+			// The service does this after writing the policy; call it here to exercise the same effect.
+			require.NoError(t, ds.ClearPreInstallQueryForTitle(ctx, team.ID, titleID))
+		}
 		return p
 	}
 
@@ -7246,12 +7250,13 @@ func testGetSoftwareInstallDetailsPatchWhenClosed(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	require.Equal(t, managedQuery, activatedDetails.PreInstallCondition)
 
-	// Same installer, but a manual (non-policy) install falls back to the user query.
+	// Same installer via a manual (non-policy) install: no pre-install condition, because enabling
+	// patch_when_closed cleared the installer's user query.
 	manualExec, err := ds.InsertSoftwareInstallRequest(ctx, host.ID, closedInstaller, fleet.HostSoftwareInstallOptions{})
 	require.NoError(t, err)
 	manualDetails, err := ds.GetSoftwareInstallDetails(ctx, manualExec)
 	require.NoError(t, err)
-	require.Equal(t, userQuery, manualDetails.PreInstallCondition)
+	require.Empty(t, manualDetails.PreInstallCondition)
 
 	// A patch policy without patch_when_closed keeps the user query on the policy path.
 	forceInstaller, forceTitle := newInstaller(t, "pwc-force")

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -7183,7 +7183,7 @@ func testGetSoftwareInstallDetailsPatchWhenClosed(t *testing.T, ds *Datastore) {
 	require.NoError(t, ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&team.ID, []uint{host.ID})))
 
 	const userQuery = "SELECT 1 FROM user_configured_query;"
-	const managedQuery = "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON LEFT(p.path, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.example.pwc');"
+	const managedQuery = "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.example.pwc');"
 
 	// A Fleet-maintained-app-backed installer carries both the user pre-install query and the
 	// Fleet-managed app_open_query.
@@ -7304,7 +7304,7 @@ func testSoftwareInstallerAppOpenQueryRoundTrip(t *testing.T, ds *Datastore) {
 	}
 
 	// The managed "is app open" query round-trips through create -> metadata read.
-	const managed = "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON LEFT(p.path, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.example.app');"
+	const managed = "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.example.app');"
 	titleID := newInstaller(t, "app-open-1", managed)
 	meta, err := ds.GetSoftwareInstallerMetadataByTeamAndTitleID(ctx, nil, titleID, false)
 	require.NoError(t, err)

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -7183,7 +7183,7 @@ func testGetSoftwareInstallDetailsPatchWhenClosed(t *testing.T, ds *Datastore) {
 	require.NoError(t, ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&team.ID, []uint{host.ID})))
 
 	const userQuery = "SELECT 1 FROM user_configured_query;"
-	const managedQuery = "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path LIKE concat(a.path, '/%') WHERE a.bundle_identifier = 'com.example.pwc');"
+	const managedQuery = "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON LEFT(p.path, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.example.pwc');"
 
 	// A Fleet-maintained-app-backed installer carries both the user pre-install query and the
 	// Fleet-managed app_open_query.
@@ -7304,7 +7304,7 @@ func testSoftwareInstallerAppOpenQueryRoundTrip(t *testing.T, ds *Datastore) {
 	}
 
 	// The managed "is app open" query round-trips through create -> metadata read.
-	const managed = "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON p.path LIKE concat(a.path, '/%') WHERE a.bundle_identifier = 'com.example.app');"
+	const managed = "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON LEFT(p.path, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.example.app');"
 	titleID := newInstaller(t, "app-open-1", managed)
 	meta, err := ds.GetSoftwareInstallerMetadataByTeamAndTitleID(ctx, nil, titleID, false)
 	require.NoError(t, err)

--- a/server/fleet/api_policies.go
+++ b/server/fleet/api_policies.go
@@ -187,9 +187,9 @@ type TeamPolicyRequest struct {
 	LabelsExcludeAll             []string `json:"labels_exclude_all" premium:"true"`
 	ConditionalAccessEnabled     bool     `json:"conditional_access_enabled"`
 	ContinuousAutomationsEnabled bool     `json:"continuous_automations_enabled" premium:"true"`
-	PatchWhenClosed              bool     `json:"patch_when_closed" premium:"true"`
 	Type                         *string  `json:"type"`
 	PatchSoftwareTitleID         *uint    `json:"patch_software_title_id"`
+	PatchWhenClosed              bool     `json:"patch_when_closed" premium:"true"`
 }
 
 type TeamPolicyResponse struct {

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2931,6 +2931,11 @@ type Datastore interface {
 	// to how the virtual column works).
 	ProcessInstallerUpdateSideEffects(ctx context.Context, installerID uint, wasMetadataUpdated bool, wasPackageUpdated bool) error
 
+	// ClearPreInstallQueryForTitle blanks the pre-install query on a title's active Fleet-maintained
+	// installer and cancels its pending installs. It's a no-op when the query is already empty, so
+	// callers can invoke it freely.
+	ClearPreInstallQueryForTitle(ctx context.Context, teamID uint, titleID uint) error
+
 	// SaveInstallerUpdates persists new values to an existing installer. See comments in the payload struct
 	// for which fields must be set.
 	SaveInstallerUpdates(ctx context.Context, payload *UpdateSoftwareInstallerPayload) error

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2932,8 +2932,7 @@ type Datastore interface {
 	ProcessInstallerUpdateSideEffects(ctx context.Context, installerID uint, wasMetadataUpdated bool, wasPackageUpdated bool) error
 
 	// ClearPreInstallQueryForTitle blanks the pre-install query on a title's active Fleet-maintained
-	// installer and cancels its pending installs. It's a no-op when the query is already empty, so
-	// callers can invoke it freely.
+	// installer and cancels its pending installs. No-op when the query is already empty.
 	ClearPreInstallQueryForTitle(ctx context.Context, teamID uint, titleID uint) error
 
 	// SaveInstallerUpdates persists new values to an existing installer. See comments in the payload struct

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -721,11 +721,9 @@ type UpdateSoftwareInstallerPayload struct {
 	PinnedVersion *string
 	// Configuration is the in-house app's managed app configuration as raw XML bytes (iOS / iPadOS only). nil means leave unchanged; explicit empty means clear.
 	Configuration []byte
-	// Patch controls the patch policy for a Fleet-maintained app: true creates or keeps it,
-	// false deletes it. nil leaves the patch policy unchanged. FMA-only.
+	// Patch enables or disables the title's patch policy. FMA-only.
 	Patch *bool
-	// PatchWhenClosed sets patch_when_closed on the title's patch policy so the install is
-	// skipped while the app is open. nil leaves it unchanged. FMA-only.
+	// PatchWhenClosed skips the install while the app is open. FMA-only.
 	PatchWhenClosed *bool
 }
 

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -721,9 +721,11 @@ type UpdateSoftwareInstallerPayload struct {
 	PinnedVersion *string
 	// Configuration is the in-house app's managed app configuration as raw XML bytes (iOS / iPadOS only). nil means leave unchanged; explicit empty means clear.
 	Configuration []byte
-	// Patch enables or disables the title's patch policy. FMA-only.
+	// Patch controls the patch policy for a Fleet-maintained app: true creates or keeps it,
+	// false deletes it. nil leaves the patch policy unchanged. FMA-only.
 	Patch *bool
-	// PatchWhenClosed skips the install while the app is open. FMA-only.
+	// PatchWhenClosed sets patch_when_closed on the title's patch policy so the install is
+	// skipped while the app is open. nil leaves it unchanged. FMA-only.
 	PatchWhenClosed *bool
 }
 

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1656,6 +1656,8 @@ type UpdateInstallerUpgradeCodeFunc func(ctx context.Context, id uint, upgradeCo
 
 type ProcessInstallerUpdateSideEffectsFunc func(ctx context.Context, installerID uint, wasMetadataUpdated bool, wasPackageUpdated bool) error
 
+type ClearPreInstallQueryForTitleFunc func(ctx context.Context, teamID uint, titleID uint) error
+
 type SaveInstallerUpdatesFunc func(ctx context.Context, payload *fleet.UpdateSoftwareInstallerPayload) error
 
 type UpdateInstallerSelfServiceFlagFunc func(ctx context.Context, selfService bool, id uint) error
@@ -4686,6 +4688,9 @@ type DataStore struct {
 
 	ProcessInstallerUpdateSideEffectsFunc        ProcessInstallerUpdateSideEffectsFunc
 	ProcessInstallerUpdateSideEffectsFuncInvoked bool
+
+	ClearPreInstallQueryForTitleFunc        ClearPreInstallQueryForTitleFunc
+	ClearPreInstallQueryForTitleFuncInvoked bool
 
 	SaveInstallerUpdatesFunc        SaveInstallerUpdatesFunc
 	SaveInstallerUpdatesFuncInvoked bool
@@ -11273,6 +11278,13 @@ func (s *DataStore) ProcessInstallerUpdateSideEffects(ctx context.Context, insta
 	s.ProcessInstallerUpdateSideEffectsFuncInvoked = true
 	s.mu.Unlock()
 	return s.ProcessInstallerUpdateSideEffectsFunc(ctx, installerID, wasMetadataUpdated, wasPackageUpdated)
+}
+
+func (s *DataStore) ClearPreInstallQueryForTitle(ctx context.Context, teamID uint, titleID uint) error {
+	s.mu.Lock()
+	s.ClearPreInstallQueryForTitleFuncInvoked = true
+	s.mu.Unlock()
+	return s.ClearPreInstallQueryForTitleFunc(ctx, teamID, titleID)
 }
 
 func (s *DataStore) SaveInstallerUpdates(ctx context.Context, payload *fleet.UpdateSoftwareInstallerPayload) error {

--- a/server/service/global_policies.go
+++ b/server/service/global_policies.go
@@ -256,7 +256,7 @@ func (svc Service) removeGlobalPoliciesFromWebhookConfig(ctx context.Context, id
 const (
 	errPolicyAllFleetsForConditionalAccess          = "\"All fleets\" policy cannot have conditional_access_enabled set"
 	errPolicyAllFleetsForContinuousAutomations      = "\"All fleets\" policy cannot have continuous_automations_enabled set"
-	errPatchWhenClosedRequiresContinuousAutomations = "\"continuous_automations_enabled\" cannot be disabled while \"patch_when_closed\" is enabled"
+	errPatchWhenClosedRequiresContinuousAutomations = "If \"patch_when_closed\" is true, \"continuous_automations_enabled\" can't be set to false."
 )
 
 func modifyGlobalPolicyEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (fleet.Errorer, error) {

--- a/server/service/global_policies.go
+++ b/server/service/global_policies.go
@@ -500,6 +500,11 @@ func (svc *Service) ApplyPolicySpecs(ctx context.Context, policies []*fleet.Poli
 			return fleet.ErrMissingLicense
 		}
 
+		// PatchWhenClosed is premium-only.
+		if policy.PatchWhenClosed && !license.IsPremium(ctx) {
+			return fleet.ErrMissingLicense
+		}
+
 		// Make sure any applied labels exist.
 		labels := slices.Concat(policy.LabelsIncludeAny, policy.LabelsIncludeAll, policy.LabelsExcludeAny, policy.LabelsExcludeAll)
 		if len(labels) > 0 {

--- a/server/service/global_policies_test.go
+++ b/server/service/global_policies_test.go
@@ -555,6 +555,54 @@ func TestApplyPolicySpecsLabelScopeRequiresPremium(t *testing.T) {
 	require.False(t, ds.ApplyPolicySpecsFuncInvoked)
 }
 
+func TestApplyPolicySpecsPatchWhenClosedRequiresPremium(t *testing.T) {
+	newDS := func() *mock.Store {
+		ds := new(mock.Store)
+		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+			return &fleet.AppConfig{}, nil
+		}
+		ds.TeamByNameFunc = func(ctx context.Context, name string) (*fleet.Team, error) {
+			return &fleet.Team{ID: 1, Name: name}, nil
+		}
+		ds.ApplyPolicySpecsFunc = func(ctx context.Context, authorID uint, specs []*fleet.PolicySpec) error {
+			return nil
+		}
+		return ds
+	}
+
+	// patch_when_closed requires a patch-type team policy.
+	patchSpec := func() *fleet.PolicySpec {
+		return &fleet.PolicySpec{
+			Name:            "patch policy",
+			Team:            "team1",
+			Type:            fleet.PolicyTypePatch,
+			PatchWhenClosed: true,
+		}
+	}
+
+	testAdmin := fleet.User{ID: 1, GlobalRole: new(fleet.RoleAdmin)}
+
+	// A free-tier caller can't apply patch_when_closed, and we never reach the datastore.
+	t.Run("free tier rejected", func(t *testing.T) {
+		ds := newDS()
+		svc, ctx := newTestService(t, ds, nil, nil)
+		viewerCtx := viewer.NewContext(ctx, viewer.Viewer{User: &testAdmin})
+		err := svc.ApplyPolicySpecs(viewerCtx, []*fleet.PolicySpec{patchSpec()})
+		require.ErrorIs(t, err, fleet.ErrMissingLicense)
+		require.False(t, ds.ApplyPolicySpecsFuncInvoked)
+	})
+
+	// A premium caller applies it successfully.
+	t.Run("premium accepted", func(t *testing.T) {
+		ds := newDS()
+		svc, ctx := newTestService(t, ds, nil, nil, &TestServerOpts{License: &fleet.LicenseInfo{Tier: fleet.TierPremium}})
+		viewerCtx := viewer.NewContext(ctx, viewer.Viewer{User: &testAdmin})
+		err := svc.ApplyPolicySpecs(viewerCtx, []*fleet.PolicySpec{patchSpec()})
+		require.NoError(t, err)
+		require.True(t, ds.ApplyPolicySpecsFuncInvoked)
+	})
+}
+
 func TestApplyPolicySpecsDefaultType(t *testing.T) {
 	ds := new(mock.Store)
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {

--- a/server/service/software_titles.go
+++ b/server/service/software_titles.go
@@ -261,6 +261,12 @@ func (svc *Service) SoftwareTitleByID(ctx context.Context, id uint, teamID *uint
 							return nil, ctxerr.Wrap(ctx, err, "get patch policy")
 						}
 						pkg.PatchPolicy = patchPolicy
+
+						// While patch_when_closed is on, the pre-install query is Fleet's managed
+						// app open query, shown read-only.
+						if patchPolicy != nil && patchPolicy.PatchWhenClosed {
+							pkg.PreInstallQuery = pkg.AppOpenQuery
+						}
 					}
 				}
 

--- a/server/service/team_policies.go
+++ b/server/service/team_policies.go
@@ -104,6 +104,12 @@ func (svc Service) NewTeamPolicy(ctx context.Context, teamID uint, tp fleet.NewT
 		return nil, ctxerr.Wrap(ctx, err, "populate automations")
 	}
 
+	if policy.Type == fleet.PolicyTypePatch && policy.PatchWhenClosed && policy.PatchSoftwareTitleID != nil {
+		if err := svc.ds.ClearPreInstallQueryForTitle(ctx, teamID, *policy.PatchSoftwareTitleID); err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "clear pre-install query for title")
+		}
+	}
+
 	if teamID == 0 {
 		noTeamID := int64(0)
 		if err := svc.NewActivity(
@@ -795,6 +801,12 @@ func (svc *Service) modifyPolicy(ctx context.Context, teamID *uint, id uint, p f
 
 	if err := svc.populateAutomationsForTeamPolicy(ctx, policy); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "populate automations")
+	}
+
+	if policy.Type == fleet.PolicyTypePatch && policy.PatchWhenClosed && policy.PatchSoftwareTitleID != nil {
+		if err := svc.ds.ClearPreInstallQueryForTitle(ctx, ptr.ValOrZero(teamID), *policy.PatchSoftwareTitleID); err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "clear pre-install query for title")
+		}
 	}
 
 	if teamID == nil {

--- a/server/service/team_policies.go
+++ b/server/service/team_policies.go
@@ -42,9 +42,9 @@ func teamPolicyEndpoint(ctx context.Context, request interface{}, svc fleet.Serv
 		LabelsExcludeAll:             req.LabelsExcludeAll,
 		ConditionalAccessEnabled:     req.ConditionalAccessEnabled,
 		ContinuousAutomationsEnabled: req.ContinuousAutomationsEnabled,
-		PatchWhenClosed:              req.PatchWhenClosed,
 		Type:                         req.Type,
 		PatchSoftwareTitleID:         req.PatchSoftwareTitleID,
+		PatchWhenClosed:              req.PatchWhenClosed,
 	})
 	if err != nil {
 		return fleet.TeamPolicyResponse{Err: err}, nil
@@ -310,9 +310,8 @@ func (svc *Service) newTeamPolicyPayloadToPolicyPayload(ctx context.Context, tea
 	}
 
 	// Continuous automations must be enabled so the patch policy keeps retrying until the app is closed.
-	continuousAutomationsEnabled := p.ContinuousAutomationsEnabled
-	if p.PatchWhenClosed {
-		continuousAutomationsEnabled = true
+	if p.PatchWhenClosed && !p.ContinuousAutomationsEnabled {
+		return fleet.PolicyPayload{}, &fleet.BadRequestError{Message: errPatchWhenClosedRequiresContinuousAutomations}
 	}
 
 	return fleet.PolicyPayload{
@@ -332,7 +331,7 @@ func (svc *Service) newTeamPolicyPayloadToPolicyPayload(ctx context.Context, tea
 		LabelsExcludeAny:             p.LabelsExcludeAny,
 		LabelsExcludeAll:             p.LabelsExcludeAll,
 		ConditionalAccessEnabled:     p.ConditionalAccessEnabled,
-		ContinuousAutomationsEnabled: continuousAutomationsEnabled,
+		ContinuousAutomationsEnabled: p.ContinuousAutomationsEnabled,
 		PatchWhenClosed:              p.PatchWhenClosed,
 		Type:                         policyType,
 		PatchSoftwareTitleID:         p.PatchSoftwareTitleID,
@@ -719,10 +718,9 @@ func (svc *Service) modifyPolicy(ctx context.Context, teamID *uint, id uint, p f
 	if p.PatchWhenClosed != nil {
 		patchWhenClosed = *p.PatchWhenClosed
 	}
+	// patch_when_closed needs continuous automations: reject an explicit false, otherwise force it on.
 	if patchWhenClosed && p.ContinuousAutomationsEnabled != nil && !*p.ContinuousAutomationsEnabled {
-		return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
-			Message: fmt.Sprintf("policy payload verification: %s", errPatchWhenClosedRequiresContinuousAutomations),
-		})
+		return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{Message: errPatchWhenClosedRequiresContinuousAutomations})
 	}
 	if patchWhenClosed {
 		policy.ContinuousAutomationsEnabled = true

--- a/server/service/team_policies.go
+++ b/server/service/team_policies.go
@@ -303,10 +303,11 @@ func (svc *Service) newTeamPolicyPayloadToPolicyPayload(ctx context.Context, tea
 		return fleet.PolicyPayload{}, err
 	}
 
-	// patch_when_closed requires continuous automations, so force them on. On create the field
-	// is a plain bool, so an explicit false is indistinguishable from an omitted one and gets
-	// forced silently. The modify path uses a bool pointer and rejects an explicit false.
-	continuousAutomationsEnabled := p.ContinuousAutomationsEnabled || p.PatchWhenClosed
+	// Continuous automations must be enabled so the patch policy keeps retrying until the app is closed.
+	continuousAutomationsEnabled := p.ContinuousAutomationsEnabled
+	if p.PatchWhenClosed {
+		continuousAutomationsEnabled = true
+	}
 
 	return fleet.PolicyPayload{
 		QueryID:                      p.QueryID,

--- a/server/service/team_policies.go
+++ b/server/service/team_policies.go
@@ -303,11 +303,10 @@ func (svc *Service) newTeamPolicyPayloadToPolicyPayload(ctx context.Context, tea
 		return fleet.PolicyPayload{}, err
 	}
 
-	// Continuous automations must be enabled so the patch policy keeps retrying until the app is closed.
-	continuousAutomationsEnabled := p.ContinuousAutomationsEnabled
-	if p.PatchWhenClosed {
-		continuousAutomationsEnabled = true
-	}
+	// patch_when_closed requires continuous automations, so force them on. On create the field
+	// is a plain bool, so an explicit false is indistinguishable from an omitted one and gets
+	// forced silently. The modify path uses a bool pointer and rejects an explicit false.
+	continuousAutomationsEnabled := p.ContinuousAutomationsEnabled || p.PatchWhenClosed
 
 	return fleet.PolicyPayload{
 		QueryID:                      p.QueryID,

--- a/server/service/team_policies_test.go
+++ b/server/service/team_policies_test.go
@@ -243,9 +243,9 @@ func TestTeamPolicyPatchWhenClosed(t *testing.T) {
 		return ds
 	}
 
-	// Creating a patch-when-closed policy forces continuous automations on, even when the
-	// request left the field at its default false.
-	t.Run("create auto-sets continuous automations", func(t *testing.T) {
+	// Creating a patch-when-closed policy with continuous automations on succeeds and clears the
+	// title's managed pre-install query.
+	t.Run("create patch-when-closed policy", func(t *testing.T) {
 		ds := setupDS()
 		var captured fleet.PolicyPayload
 		ds.NewTeamPolicyFunc = func(ctx context.Context, tID uint, authorID *uint, args fleet.PolicyPayload) (*fleet.Policy, error) {
@@ -261,15 +261,30 @@ func TestTeamPolicyPatchWhenClosed(t *testing.T) {
 		}
 
 		_, err := svc.NewTeamPolicy(adminCtx(baseCtx), teamID, fleet.NewTeamPolicyPayload{
-			Type:                 &patchType,
-			PatchSoftwareTitleID: new(patchSoftwareTitleID),
-			PatchWhenClosed:      true,
+			Type:                         &patchType,
+			PatchSoftwareTitleID:         new(patchSoftwareTitleID),
+			PatchWhenClosed:              true,
+			ContinuousAutomationsEnabled: true,
 		})
 		require.NoError(t, err)
 		assert.True(t, captured.PatchWhenClosed)
-		assert.True(t, captured.ContinuousAutomationsEnabled, "patch_when_closed should force continuous automations on")
+		assert.True(t, captured.ContinuousAutomationsEnabled)
 		// enabling patch_when_closed cancels the title's pending installs so they re-evaluate
 		assert.True(t, ds.ClearPreInstallQueryForTitleFuncInvoked)
+	})
+
+	// continuous_automations_enabled=false with patch_when_closed=true is rejected on create too.
+	t.Run("create rejects disabling continuous automations", func(t *testing.T) {
+		ds := setupDS()
+		svc, baseCtx := newTestService(t, ds, nil, nil)
+		_, err := svc.NewTeamPolicy(adminCtx(baseCtx), teamID, fleet.NewTeamPolicyPayload{
+			Type:                         &patchType,
+			PatchSoftwareTitleID:         new(patchSoftwareTitleID),
+			PatchWhenClosed:              true,
+			ContinuousAutomationsEnabled: false,
+		})
+		require.Error(t, err)
+		require.ErrorContains(t, err, "continuous_automations_enabled")
 	})
 
 	// patch_when_closed only applies to patch policies.
@@ -285,8 +300,8 @@ func TestTeamPolicyPatchWhenClosed(t *testing.T) {
 		require.ErrorContains(t, err, "patch_when_closed")
 	})
 
-	// Continuous automations can't be turned off in the same request that keeps
-	// patch_when_closed on.
+	// An explicit continuous_automations_enabled=false alongside patch_when_closed=true is rejected;
+	// omitting it (see next case) still auto-sets it to true.
 	t.Run("modify rejects disabling continuous automations", func(t *testing.T) {
 		ds := setupDS()
 		svc, baseCtx := newTestService(t, ds, nil, nil)

--- a/server/service/team_policies_test.go
+++ b/server/service/team_policies_test.go
@@ -237,6 +237,9 @@ func TestTeamPolicyPatchWhenClosed(t *testing.T) {
 		ds.GetSoftwareInstallerMetadataByTeamAndTitleIDFunc = func(ctx context.Context, tID *uint, titleID uint, withScriptContents bool) (*fleet.SoftwareInstaller, error) {
 			return &fleet.SoftwareInstaller{TitleID: new(patchSoftwareTitleID), SoftwareTitle: "App", DisplayName: "App"}, nil
 		}
+		ds.ClearPreInstallQueryForTitleFunc = func(ctx context.Context, teamID uint, titleID uint) error {
+			return nil
+		}
 		return ds
 	}
 
@@ -247,7 +250,9 @@ func TestTeamPolicyPatchWhenClosed(t *testing.T) {
 		var captured fleet.PolicyPayload
 		ds.NewTeamPolicyFunc = func(ctx context.Context, tID uint, authorID *uint, args fleet.PolicyPayload) (*fleet.Policy, error) {
 			captured = args
-			return freshPatchPolicy(), nil
+			created := freshPatchPolicy()
+			created.PatchWhenClosed = true
+			return created, nil
 		}
 		opts := &TestServerOpts{}
 		svc, baseCtx := newTestService(t, ds, nil, nil, opts)
@@ -263,6 +268,8 @@ func TestTeamPolicyPatchWhenClosed(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, captured.PatchWhenClosed)
 		assert.True(t, captured.ContinuousAutomationsEnabled, "patch_when_closed should force continuous automations on")
+		// enabling patch_when_closed cancels the title's pending installs so they re-evaluate
+		assert.True(t, ds.ClearPreInstallQueryForTitleFuncInvoked)
 	})
 
 	// patch_when_closed only applies to patch policies.
@@ -312,6 +319,8 @@ func TestTeamPolicyPatchWhenClosed(t *testing.T) {
 		require.NotNil(t, saved)
 		assert.True(t, saved.PatchWhenClosed)
 		assert.True(t, saved.ContinuousAutomationsEnabled)
+		// enabling patch_when_closed cancels the title's pending installs so they re-evaluate
+		assert.True(t, ds.ClearPreInstallQueryForTitleFuncInvoked)
 	})
 }
 

--- a/server/service/team_policies_test.go
+++ b/server/service/team_policies_test.go
@@ -292,12 +292,14 @@ func TestTeamPolicyPatchWhenClosed(t *testing.T) {
 		ds := setupDS()
 		svc, baseCtx := newTestService(t, ds, nil, nil)
 		_, err := svc.NewTeamPolicy(adminCtx(baseCtx), teamID, fleet.NewTeamPolicyPayload{
-			Name:            "dynamic policy",
-			Query:           "SELECT 1;",
-			PatchWhenClosed: true,
+			Name:  "dynamic policy",
+			Query: "SELECT 1;",
+			// Continuous automations must be on, otherwise that check rejects the payload first.
+			PatchWhenClosed:              true,
+			ContinuousAutomationsEnabled: true,
 		})
 		require.Error(t, err)
-		require.ErrorContains(t, err, "patch_when_closed")
+		require.ErrorContains(t, err, "only supported for patch policies")
 	})
 
 	// An explicit continuous_automations_enabled=false alongside patch_when_closed=true is rejected;


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #49416

- Adds patch_when_closed to the new policy, update policy, and update package endpoints
- Sets pre_install_query in the software title endpoint to  software_installers.app_open_query if the policy is a patch when closed policy (discussed in standup)
- Deletes the existing pre_install_query if setting patch_when_closed (discussed in standup)
- Fixes a small error in the patch_policy package
- Fixes the default macOS query in patch_policy package to use to escape symbols in a.path


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “patch when closed” option for patch policies and Fleet-maintained apps.
  * Added installer controls for enabling patching and configuring whether apps must be closed before installation.
  * Automatically manages pre-install behavior and continuous automation requirements for these policies.

* **Bug Fixes**
  * Improved app detection based on application path prefixes on macOS.
  * Corrected RStudio process detection on Windows.
  * Added validation to prevent incompatible patch policy settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->