### PR TITLE
Show ABM organization name in edit-fleets success toast

### DIFF
--- a/changes/48914-ab-toast-org-name.md
+++ b/changes/48914-ab-toast-org-name.md
@@ -1,1 +1,1 @@
-- Improved the Apple Business Manager success toast shown after editing fleet assignments to name the organization (for example, "Successfully updated fleets for Acme Inc.") instead of the less clear "Successfully updated fleets for AB token."
+- Improved the Apple Business success toast shown after editing fleet assignments to name the organization.

--- a/changes/48914-ab-toast-org-name.md
+++ b/changes/48914-ab-toast-org-name.md
@@ -1,0 +1,1 @@
+- Improved the Apple Business Manager success toast shown after editing fleet assignments to name the organization (for example, "Successfully updated fleets for Acme Inc.") instead of the less clear "Successfully updated fleets for AB token."

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleBusinessManagerPage/components/EditTeamsAbmModal/EditTeamsAbmModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleBusinessManagerPage/components/EditTeamsAbmModal/EditTeamsAbmModal.tsx
@@ -111,14 +111,21 @@ const EditTeamsAbmModal = ({
           tokenId: token.id,
           teams: getSelectedTeamIds(selectedTeamNames, availableTeams),
         });
-        notify.success("Successfully updated fleets for AB token.");
+        notify.success(`Successfully updated fleets for ${token.org_name}`);
         onSuccess();
       } catch (e) {
         notify.error("Couldn’t edit. Please try again.", { response: e });
         onCancel();
       }
     },
-    [token.id, selectedTeamNames, availableTeams, onSuccess, onCancel]
+    [
+      token.id,
+      token.org_name,
+      selectedTeamNames,
+      availableTeams,
+      onSuccess,
+      onCancel,
+    ]
   );
 
   return (


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #48914

## Description

The success toast shown after editing fleet assignments for an Apple Business Manager (ABM) organization read:

> Successfully updated fleets for AB token.

The trailing "AB token" made the message unclear. It now names the organization instead, matching the modal's title:

> Successfully updated fleets for `<org name>`.

The organization name (`token.org_name`) was already available in the component (it's used as the modal title), so this is a copy-only change with no new data plumbing.

Note: the issue's expected behavior left the exact wording to Product ("TODO — Product to decide"). This implements Product's written suggestion (`Successfully updated fleets for {org name}`) so the awkward wording isn't blocking; the string is trivial to adjust if Product/design prefer different phrasing in review.

## Testing

- Manually QA'd in the UI: with a configured ABM organization, edited a fleet assignment and confirmed the toast now shows the org name.
- Existing unit tests for the modal's helpers (`getOptions`, `getSelectedTeamIds`) still pass; no test asserts the toast string.
- `eslint` and `prettier` pass on the changed file (added `token.org_name` to the `useCallback` dependency array to satisfy `react-hooks/exhaustive-deps`).

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the success notification shown after fleet teams are saved to include the associated organization name.
  * Ensured the notification always reflects the currently selected organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->