### PR TITLE
don't stop propagation for react-select

### DIFF
--- a/frontend/components/FleetsDropdown/FleetsDropdown.tests.tsx
+++ b/frontend/components/FleetsDropdown/FleetsDropdown.tests.tsx
@@ -74,6 +74,37 @@ describe("FleetsDropdown - component", () => {
     expect(getTrigger(/Fleet 1/)).toBeInTheDocument();
   });
 
+  it("clicking a fleet option updates the selected fleet", async () => {
+    const user = userEvent.setup();
+
+    const TestHarness = () => {
+      const [selectedFleetId, setSelectedFleetId] = React.useState(1);
+
+      return (
+        <FleetsDropdown
+          currentUserFleets={USER_FLEETS}
+          selectedFleetId={selectedFleetId}
+          onChange={setSelectedFleetId}
+        />
+      );
+    };
+
+    render(<TestHarness />);
+
+    // Starts on Fleet 1
+    expect(getTrigger(/Fleet 1/)).toBeInTheDocument();
+
+    // Open menu and click Fleet 2
+    await user.click(getTrigger(/Fleet 1/));
+    await user.click(screen.getByText("Fleet 2"));
+
+    // Selection propagated through onChange -> selectedFleetId
+    expect(getTrigger(/Fleet 2/)).toBeInTheDocument();
+
+    // Menu should close after selection
+    expect(screen.queryByText("Fleet 1")).not.toBeInTheDocument();
+  });
+
   describe("in-menu search", () => {
     // Search only appears once the list has 10+ rows.
     const MANY_FLEETS = [

--- a/frontend/components/FleetsDropdown/FleetsDropdown.tsx
+++ b/frontend/components/FleetsDropdown/FleetsDropdown.tsx
@@ -270,7 +270,6 @@ const CustomMenuList = (props: MenuListProps<INumberDropdownOption, false>) => {
         },
         onMouseDown: (event: React.MouseEvent<HTMLDivElement>) => {
           originalOnMouseDown?.(event);
-          event.stopPropagation();
         },
         // Chrome (and other browsers with `keyboard-focusable-scrollers`
         // enabled) auto-focuses scrollable containers to allow keyboard


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves unreleased bug with Fleet dropdown not working


https://github.com/user-attachments/assets/6460efe2-2181-48bc-9ca0-67f64241a3e9



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information. Unreleased

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fleet selection behavior so dropdown interactions work reliably without overriding built-in menu handling.
  * Selecting a fleet now correctly updates the displayed fleet and closes the dropdown menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->