### PR TITLE
Allow scripts to run on Fleet Free regardless of stale fleet assignments

### DIFF
--- a/changes/49291-free-tier-script-execution.md
+++ b/changes/49291-free-tier-script-execution.md
@@ -1,0 +1,1 @@
+- Fixed running scripts on Fleet Free for hosts previously assigned to a fleet on Fleet Premium.

--- a/server/service/scripts.go
+++ b/server/service/scripts.go
@@ -190,15 +190,23 @@ func (svc *Service) RunHostScript(ctx context.Context, request *fleet.HostScript
 			}
 			return nil, err
 		}
-		var scriptTmID, hostTmID uint
-		if script.TeamID != nil {
-			scriptTmID = *script.TeamID
-		}
-		if host.TeamID != nil {
-			hostTmID = *host.TeamID
-		}
-		if scriptTmID != hostTmID {
-			return nil, fleet.NewInvalidArgumentError("script_id", `The script does not belong to the same fleet (or "Unassigned") as the host.`)
+		// The script/host fleet (team) match is only meaningful on Premium, where
+		// fleets are a feature. On Free, a host may retain a stale team_id from a
+		// prior Premium license — a license change is a feature gate, not a data
+		// migration — so enforcing this here would wrongly block scripts on those
+		// hosts. See https://github.com/fleetdm/fleet/issues/49291.
+		lic, _ := license.FromContext(ctx)
+		if lic.IsPremium() {
+			var scriptTmID, hostTmID uint
+			if script.TeamID != nil {
+				scriptTmID = *script.TeamID
+			}
+			if host.TeamID != nil {
+				hostTmID = *host.TeamID
+			}
+			if scriptTmID != hostTmID {
+				return nil, fleet.NewInvalidArgumentError("script_id", `The script does not belong to the same fleet (or "Unassigned") as the host.`)
+			}
 		}
 
 		isQueued, err := svc.ds.IsExecutionPendingForHost(ctx, request.HostID, *request.ScriptID)
@@ -1164,9 +1172,16 @@ func (svc *Service) BatchScriptExecute(ctx context.Context, scriptID uint, hostI
 		return "", fleet.NewInvalidArgumentError("filters", "too_many_hosts")
 	}
 
+	// The script/host fleet (team) match is only enforced on Premium; on Free,
+	// hosts may carry a stale team_id from a prior Premium license, which must
+	// not block execution. Same rationale as RunHostScript. See #49291.
+	lic, _ := license.FromContext(ctx)
 	hostIDsToExecute := make([]uint, 0, len(hosts))
 	for _, host := range hosts {
 		hostIDsToExecute = append(hostIDsToExecute, host.ID)
+		if !lic.IsPremium() {
+			continue
+		}
 		if host.TeamID == nil && script.TeamID == nil {
 			continue
 		}

--- a/server/service/scripts_test.go
+++ b/server/service/scripts_test.go
@@ -1077,6 +1077,104 @@ func TestBatchScriptExecute(t *testing.T) {
 	})
 }
 
+// fleetMatchCase is the shared matrix for the script/host fleet-match behavior
+// by tier. On Free the match is skipped entirely (any script runs on any host,
+// since team_ids are stale leftovers from a prior Premium license); on Premium
+// the original strict match is preserved. Regression coverage for
+// https://github.com/fleetdm/fleet/issues/49291.
+type fleetMatchCase struct {
+	name       string
+	tier       string
+	scriptTeam *uint
+	hostTeam   *uint
+	wantErr    bool
+}
+
+var fleetMatchCases = []fleetMatchCase{
+	// Free: everything runs, regardless of stale team_ids.
+	{"free/no-team script on team host (reported bug)", fleet.TierFree, nil, new(uint(1)), false},
+	{"free/team script on unassigned host", fleet.TierFree, new(uint(2)), nil, false},
+	{"free/team script on different-team host", fleet.TierFree, new(uint(2)), new(uint(1)), false},
+	{"free/no-team script on no-team host", fleet.TierFree, nil, nil, false},
+	// Premium: strict match preserved.
+	{"premium/no-team script on team host", fleet.TierPremium, nil, new(uint(1)), true},
+	{"premium/team script on different-team host", fleet.TierPremium, new(uint(2)), new(uint(1)), true},
+	{"premium/team script on unassigned host", fleet.TierPremium, new(uint(2)), nil, true},
+	{"premium/matching team", fleet.TierPremium, new(uint(1)), new(uint(1)), false},
+	{"premium/no-team script on no-team host", fleet.TierPremium, nil, nil, false},
+}
+
+func TestRunHostScriptFleetMatchByTier(t *testing.T) {
+	run := func(t *testing.T, tc fleetMatchCase) error {
+		ds := new(mock.Store)
+		license := &fleet.LicenseInfo{Tier: tc.tier, Expiration: time.Now().Add(24 * time.Hour)}
+		svc, ctx := newTestService(t, ds, nil, nil, &TestServerOpts{License: license, SkipCreateTestUsers: true})
+
+		host := &fleet.Host{ID: 1, Hostname: "h", TeamID: tc.hostTeam, SeenTime: time.Now(), OrbitNodeKey: new("abc")}
+		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) { return &fleet.AppConfig{}, nil }
+		ds.HostFunc = func(ctx context.Context, hostID uint) (*fleet.Host, error) { return host, nil }
+		ds.ScriptFunc = func(ctx context.Context, id uint) (*fleet.Script, error) { return &fleet.Script{ID: id, TeamID: tc.scriptTeam}, nil }
+		ds.GetScriptContentsFunc = func(ctx context.Context, id uint) ([]byte, error) { return []byte("echo"), nil }
+		ds.IsExecutionPendingForHostFunc = func(ctx context.Context, hostID, scriptID uint) (bool, error) { return false, nil }
+		ds.ListPendingHostScriptExecutionsFunc = func(ctx context.Context, hostID uint, onlyShowInternal bool) ([]*fleet.HostScriptResult, error) {
+			return nil, nil
+		}
+		ds.ValidateEmbeddedSecretsFunc = func(ctx context.Context, documents []string) error { return nil }
+		ds.NewHostScriptExecutionRequestFunc = func(ctx context.Context, request *fleet.HostScriptRequestPayload) (*fleet.HostScriptResult, error) {
+			return &fleet.HostScriptResult{HostID: request.HostID, ExecutionID: "abc"}, nil
+		}
+		ctx = viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{GlobalRole: new(fleet.RoleAdmin)}})
+		_, err := svc.RunHostScript(ctx, &fleet.HostScriptRequestPayload{HostID: 1, ScriptID: new(uint(1))}, 0)
+		return err
+	}
+
+	for _, tc := range fleetMatchCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := run(t, tc)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.ErrorContains(t, err, "does not belong to the same fleet")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestBatchScriptExecuteFleetMatchByTier(t *testing.T) {
+	run := func(t *testing.T, tc fleetMatchCase) ([]uint, error) {
+		ds := new(mock.Store)
+		license := &fleet.LicenseInfo{Tier: tc.tier, Expiration: time.Now().Add(24 * time.Hour)}
+		svc, ctx := newTestService(t, ds, nil, nil, &TestServerOpts{License: license, SkipCreateTestUsers: true})
+		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) { return &fleet.AppConfig{}, nil }
+		ds.ScriptFunc = func(ctx context.Context, id uint) (*fleet.Script, error) { return &fleet.Script{ID: id, TeamID: tc.scriptTeam}, nil }
+		ds.ListHostsLiteByIDsFunc = func(ctx context.Context, ids []uint) ([]*fleet.Host, error) {
+			return []*fleet.Host{{ID: 1, TeamID: tc.hostTeam}}, nil
+		}
+		var executed []uint
+		ds.BatchExecuteScriptFunc = func(ctx context.Context, userID *uint, scriptID uint, hostIDs []uint) (string, error) {
+			executed = hostIDs
+			return "batch-abc", nil
+		}
+		ctx = viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{GlobalRole: new(fleet.RoleAdmin)}})
+		_, err := svc.BatchScriptExecute(ctx, 1, []uint{1}, nil, nil)
+		return executed, err
+	}
+
+	for _, tc := range fleetMatchCases {
+		t.Run(tc.name, func(t *testing.T) {
+			executed, err := run(t, tc)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.ErrorContains(t, err, "all hosts must be on the same fleet as the script")
+			} else {
+				require.NoError(t, err)
+				require.ElementsMatch(t, []uint{1}, executed)
+			}
+		})
+	}
+}
+
 func TestWipeHostRequestDecodeBody(t *testing.T) {
 	ctx := context.Background()
 

--- a/server/service/scripts_test.go
+++ b/server/service/scripts_test.go
@@ -1113,7 +1113,9 @@ func TestRunHostScriptFleetMatchByTier(t *testing.T) {
 		host := &fleet.Host{ID: 1, Hostname: "h", TeamID: tc.hostTeam, SeenTime: time.Now(), OrbitNodeKey: new("abc")}
 		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) { return &fleet.AppConfig{}, nil }
 		ds.HostFunc = func(ctx context.Context, hostID uint) (*fleet.Host, error) { return host, nil }
-		ds.ScriptFunc = func(ctx context.Context, id uint) (*fleet.Script, error) { return &fleet.Script{ID: id, TeamID: tc.scriptTeam}, nil }
+		ds.ScriptFunc = func(ctx context.Context, id uint) (*fleet.Script, error) {
+			return &fleet.Script{ID: id, TeamID: tc.scriptTeam}, nil
+		}
 		ds.GetScriptContentsFunc = func(ctx context.Context, id uint) ([]byte, error) { return []byte("echo"), nil }
 		ds.IsExecutionPendingForHostFunc = func(ctx context.Context, hostID, scriptID uint) (bool, error) { return false, nil }
 		ds.ListPendingHostScriptExecutionsFunc = func(ctx context.Context, hostID uint, onlyShowInternal bool) ([]*fleet.HostScriptResult, error) {
@@ -1147,7 +1149,9 @@ func TestBatchScriptExecuteFleetMatchByTier(t *testing.T) {
 		license := &fleet.LicenseInfo{Tier: tc.tier, Expiration: time.Now().Add(24 * time.Hour)}
 		svc, ctx := newTestService(t, ds, nil, nil, &TestServerOpts{License: license, SkipCreateTestUsers: true})
 		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) { return &fleet.AppConfig{}, nil }
-		ds.ScriptFunc = func(ctx context.Context, id uint) (*fleet.Script, error) { return &fleet.Script{ID: id, TeamID: tc.scriptTeam}, nil }
+		ds.ScriptFunc = func(ctx context.Context, id uint) (*fleet.Script, error) {
+			return &fleet.Script{ID: id, TeamID: tc.scriptTeam}, nil
+		}
 		ds.ListHostsLiteByIDsFunc = func(ctx context.Context, ids []uint) ([]*fleet.Host, error) {
 			return []*fleet.Host{{ID: 1, TeamID: tc.hostTeam}}, nil
 		}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #49291

## Description

On **Fleet Free**, running a script failed for hosts that had been assigned to a fleet while on **Fleet Premium**, with:

> The script does not belong to the same fleet (or "Unassigned") as the host.

**Root cause:** `RunHostScript` (single) and `BatchScriptExecute` (batch) enforce a script/host fleet (team) match. A license downgrade is a **feature gate, not a data migration**, so hosts (and scripts) keep the `team_id`s they had on Premium. On Free — where fleets aren't a feature — newly created scripts are unassigned (`team_id = NULL`), so the match failed against every still-assigned host and blocked script execution entirely.

**Fix:** the fleet match is now enforced **only on Premium**. On Free it is skipped, so any script runs on any host (consistent with fleets not being a feature there). Premium fleet isolation is unchanged.

## Behavior after the fix

| Script fleet | Host fleet | Free | Premium |
|---|---|---|---|
| Unassigned | Assigned (stale) — *the reported bug* | ✅ runs | ❌ blocked |
| Assigned | Unassigned | ✅ runs | ❌ blocked |
| Assigned | Different fleet | ✅ runs | ❌ blocked |
| Unassigned | Unassigned | ✅ runs | ✅ runs |
| Assigned | Same fleet | ✅ runs | ✅ runs |

Both entry points are fixed: single-host (`POST /scripts/run`) and batch (`POST /scripts/run/batch`).

## Testing

- Added table-driven unit tests over the full matrix above for **both** `RunHostScript` and `BatchScriptExecute` (`TestRunHostScriptFleetMatchByTier`, `TestBatchScriptExecuteFleetMatchByTier`) — 18 subtests. Confirmed the reported-bug cases **fail without the fix**.
- Manually QA'd end-to-end on a local server with a simulated host: Free runs (returns an `execution_id`) and Premium blocks (`422`), through both the UI and the API, single and batch.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Free-tier script execution no longer fails due to outdated/stale fleet assignments on hosts.
  * Bulk script execution on Free-tier licenses now skips per-host fleet-matching checks, avoiding unnecessary mismatch errors.
  * Premium-tier executions continue to enforce fleet matching to prevent invalid script/host pairings.

* **Tests**
  * Added regression coverage for fleet-matching behavior across license tiers for both single-host and bulk script execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->