### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/browserstacklocal/windows.json
+++ b/ee/maintained-apps/outputs/browserstacklocal/windows.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "3.7.7",
+      "version": "3.7.8",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'BrowserStackLocal' AND publisher = 'BrowserStack';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'BrowserStackLocal' AND publisher = 'BrowserStack' AND version_compare(version, '3.7.7') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'BrowserStackLocal' AND publisher = 'BrowserStack' AND version_compare(version, '3.7.8') < 0);"
       },
       "installer_url": "https://www.browserstack.com/local-testing/downloads/native-app/BrowserStackLocal.msi",
       "install_script_ref": "8959087b",

--- a/ee/maintained-apps/outputs/bruno/windows.json
+++ b/ee/maintained-apps/outputs/bruno/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.5.3",
+      "version": "4.0.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Bruno' AND publisher = 'Anoop M D';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Bruno' AND publisher = 'Anoop M D' AND version_compare(version, '3.5.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Bruno' AND publisher = 'Anoop M D' AND version_compare(version, '4.0.0') < 0);"
       },
-      "installer_url": "https://github.com/usebruno/bruno/releases/download/v3.5.3/bruno_3.5.3_x64_win.msi",
+      "installer_url": "https://github.com/usebruno/bruno/releases/download/v4.0.0/bruno_4.0.0_x64_win.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "bfadc5e4",
-      "sha256": "c113924652339215ba6dc419bdb0daca9bec45895e9c02f8763a855dde339fa8",
+      "sha256": "7b5d661b12f25d976725dab382bc682a609de93e4c979655bb0d8a5a48d74848",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/canva/darwin.json
+++ b/ee/maintained-apps/outputs/canva/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.122.0",
+      "version": "1.123.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.canva.CanvaDesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.canva.CanvaDesktop' AND version_compare(bundle_short_version, '1.122.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.canva.CanvaDesktop' AND version_compare(bundle_short_version, '1.123.0') < 0);"
       },
-      "installer_url": "https://desktop-release.canva.com/Canva-1.122.0-universal.dmg",
+      "installer_url": "https://desktop-release.canva.com/Canva-1.123.0-universal.dmg",
       "install_script_ref": "09fd302e",
       "uninstall_script_ref": "8588c4f7",
-      "sha256": "8580657c74bca6d88b5d2acd51538b7c35b630b39950ff24d20d0b2404701f86",
+      "sha256": "a457864d1f34b7d0ff4591063602f50c47ab908be52dc97321e015fc8b6ba6e8",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/canva/windows.json
+++ b/ee/maintained-apps/outputs/canva/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.122.0",
+      "version": "1.123.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Canva' AND publisher = 'Canva Pty Ltd';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Canva' AND publisher = 'Canva Pty Ltd' AND version_compare(version, '1.122.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Canva' AND publisher = 'Canva Pty Ltd' AND version_compare(version, '1.123.0') < 0);"
       },
-      "installer_url": "https://desktop-release.canva.com/Canva%20Setup%201.122.0.exe",
+      "installer_url": "https://desktop-release.canva.com/Canva%20Setup%201.123.0.exe",
       "install_script_ref": "af334744",
       "uninstall_script_ref": "f683286d",
-      "sha256": "fa0dec6c910cfa9944062f649671bb8b8293d79acc4d888578f4bd23e9446c92",
+      "sha256": "0ef96d5ec6d08f2adea6fb547c87bb38625ca93e9115dbd3ba965cf43d5f9ab5",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/chatgpt/darwin.json
+++ b/ee/maintained-apps/outputs/chatgpt/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.721.30844",
+      "version": "26.721.31836",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.chat';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.chat' AND version_compare(bundle_short_version, '26.721.30844') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.chat' AND version_compare(bundle_short_version, '26.721.31836') < 0);"
       },
-      "installer_url": "https://persistent.oaistatic.com/codex-app-prod/ChatGPT-darwin-arm64-26.721.30844.zip",
+      "installer_url": "https://persistent.oaistatic.com/codex-app-prod/ChatGPT-darwin-arm64-26.721.31836.zip",
       "install_script_ref": "6872008e",
       "uninstall_script_ref": "678e6cf0",
-      "sha256": "295db7bfd46fce3f78c4fbd5dc9ded61ef3648fc2df86baaa13015bb21277b9b",
+      "sha256": "6c3b9593e1afa1ed574ca609ce228f95f49cdd4ef1cc4e6e87915a3f9e8ef659",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/claude/windows.json
+++ b/ee/maintained-apps/outputs/claude/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.24012.0",
+      "version": "1.24012.1",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Claude' AND publisher = 'Anthropic, PBC';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Claude' AND publisher = 'Anthropic, PBC' AND version_compare(version, '1.24012.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Claude' AND publisher = 'Anthropic, PBC' AND version_compare(version, '1.24012.1') < 0);"
       },
-      "installer_url": "https://downloads.claude.ai/releases/win32/x64/1.24012.0/Claude-44be967d07ffab39b371cc3297a6a71a5ef92fa9.msix",
+      "installer_url": "https://downloads.claude.ai/releases/win32/x64/1.24012.1/Claude-0adcaed55041a881be363f2c4a4729f67a8b27d7.msix",
       "install_script_ref": "16c020cc",
       "uninstall_script_ref": "03f72055",
-      "sha256": "7600470f2e94fecf67030ae4595b116613941291dbebcebcaaf4ce0047946284",
+      "sha256": "9a583530c3f25a48fb0296d68a91ca8f677fdaa4878a40c1ced19593e82fb565",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/clion/windows.json
+++ b/ee/maintained-apps/outputs/clion/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.2",
+      "version": "2026.2.0.1",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'CLion %' AND publisher = 'JetBrains s.r.o.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'CLion %' AND publisher = 'JetBrains s.r.o.' AND version_compare(version, '262.8665.262') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'CLion %' AND publisher = 'JetBrains s.r.o.' AND version_compare(version, '262.8665.321') < 0);"
       },
-      "installer_url": "https://download.jetbrains.com/cpp/CLion-2026.2.exe",
+      "installer_url": "https://download.jetbrains.com/cpp/CLion-2026.2.0.1.exe",
       "install_script_ref": "f1faeca2",
       "uninstall_script_ref": "7da7c7ff",
-      "sha256": "44e86485fcd0b23804d165a02bd9a002ace860198f4a62ca2168b638e30b7637",
+      "sha256": "1eb5d666a1f3985cd66a8136e4eb3c3b685ea49e5977977a4ec7c226f240d8ba",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/cursor/darwin.json
+++ b/ee/maintained-apps/outputs/cursor/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.12.30",
+      "version": "3.13.10",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92' AND version_compare(bundle_short_version, '3.12.30') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92' AND version_compare(bundle_short_version, '3.13.10') < 0);"
       },
-      "installer_url": "https://downloads.cursor.com/production/63a2996a10d9e476b6c28e951dd7691d9c0cf480/darwin/arm64/Cursor-darwin-arm64.zip",
+      "installer_url": "https://downloads.cursor.com/production/4f02290ccd9304f0e6bf8ee85f6e9106f02ac1f7/darwin/arm64/Cursor-darwin-arm64.zip",
       "install_script_ref": "5147ff0b",
       "uninstall_script_ref": "9d80ae1c",
-      "sha256": "5d8f4374d2153a35b2a72249e34f473fe290ab73d9d5edef0ef80909f503596c",
+      "sha256": "3513de46326ef1e0dcf5af1197f9c69da33365bac0ea3ccbbe171eed7462409a",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/downie/darwin.json
+++ b/ee/maintained-apps/outputs/downie/darwin.json
@@ -6,10 +6,10 @@
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.charliemonroe.Downie-4';",
         "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.charliemonroe.Downie-4' AND version_compare(bundle_short_version, '4.12.11') < 0);"
       },
-      "installer_url": "https://software.charliemonroe.net/trial/downie/v4/Downie_4_5218.dmg",
+      "installer_url": "https://software.charliemonroe.net/trial/downie/v4/Downie_4_5221.dmg",
       "install_script_ref": "1468a553",
       "uninstall_script_ref": "24e71e3c",
-      "sha256": "96deef993f818949f038d12b34b12ef29e17ea15cff268927611eacad4d6749c",
+      "sha256": "2a16482eba21dae91d59a4f932f87cc7f56e01f118b1974aa5de87eaac8f5b80",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/drawio/darwin.json
+++ b/ee/maintained-apps/outputs/drawio/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "30.4.1",
+      "version": "31.0.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jgraph.drawio.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jgraph.drawio.desktop' AND version_compare(bundle_short_version, '30.4.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jgraph.drawio.desktop' AND version_compare(bundle_short_version, '31.0.2') < 0);"
       },
-      "installer_url": "https://github.com/jgraph/drawio-desktop/releases/download/v30.4.1/draw.io-arm64-30.4.1.dmg",
+      "installer_url": "https://github.com/jgraph/drawio-desktop/releases/download/v31.0.2/draw.io-arm64-31.0.2.dmg",
       "install_script_ref": "1f3003b7",
       "uninstall_script_ref": "19c87f7a",
-      "sha256": "445ef3db8ce81e3e0c337cac404baefeb4715efd47ca0b048c5deb48ad842fb9",
+      "sha256": "e35e838417c208e29da9b3f5c2106923af825c565353eb9acf1a3ed9a829766d",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/dropbox/windows.json
+++ b/ee/maintained-apps/outputs/dropbox/windows.json
@@ -1,22 +1,22 @@
 {
   "versions": [
     {
-      "version": "262.3.3075",
+      "version": "262.4.3183",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Dropbox' AND publisher = 'Dropbox, Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Dropbox' AND publisher = 'Dropbox, Inc.' AND version_compare(version, '262.3.3075') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Dropbox' AND publisher = 'Dropbox, Inc.' AND version_compare(version, '262.4.3183') < 0);"
       },
-      "installer_url": "https://edge.dropboxstatic.com/dbx-releng/client/Dropbox%20262.3.3075%20Enterprise%20Installer.x64.msi",
+      "installer_url": "https://edge.dropboxstatic.com/dbx-releng/client/Dropbox%20262.4.3183%20Enterprise%20Installer.x64.msi",
       "install_script_ref": "8959087b",
-      "uninstall_script_ref": "b8df2b6f",
-      "sha256": "2fa2ded4039893dae1879ff487c2df112a8a5958167193dcee3c9b9a2ac85226",
+      "uninstall_script_ref": "53f61d33",
+      "sha256": "2c60de2aacb6bcc232b50f47a5f1c899227988cf49ddafb57553848c1e317483",
       "default_categories": [
         "Productivity"
       ]
     }
   ],
   "refs": {
-    "8959087b": "$logFile = \"${env:TEMP}/fleet-install-software.log\"\n\ntry {\n\n$installProcess = Start-Process msiexec.exe `\n  -ArgumentList \"/quiet /norestart /lv ${logFile} /i `\"${env:INSTALLER_PATH}`\"\" `\n  -PassThru -Verb RunAs -Wait\n\nGet-Content $logFile -Tail 500\n\nExit $installProcess.ExitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n",
-    "b8df2b6f": "$product_code = '{3DCEFA4A-E4B4-5D5A-BB8F-9F5974FD4C61}'\n$timeoutSeconds = 300  # 5 minute timeout\n\n# Fleet uninstalls app using product code that's extracted on upload\n$process = Start-Process msiexec -ArgumentList @(\"/quiet\", \"/x\", $product_code, \"/norestart\") -PassThru\n\n# Wait for process with timeout\n$completed = $process.WaitForExit($timeoutSeconds * 1000)\n\nif (-not $completed) {\n    Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue\n    Exit 1603  # ERROR_UNINSTALL_FAILURE\n}\n\n# MSI exit codes that indicate success. 3010 = ERROR_SUCCESS_REBOOT_REQUIRED,\n# 1641 = ERROR_SUCCESS_REBOOT_INITIATED. Treat these as success rather than failure.\n$successCodes = @(0, 3010, 1641)\n\n# Check exit code and output result\nif ($successCodes -contains $process.ExitCode) {\n    Write-Output \"Exit 0\"\n    Exit 0\n} else {\n    Write-Output \"Exit $($process.ExitCode)\"\n    Exit $process.ExitCode\n}\n"
+    "53f61d33": "$product_code = '{19E6620D-ECB8-55CC-9287-18856FCC08E8}'\n$timeoutSeconds = 300  # 5 minute timeout\n\n# Fleet uninstalls app using product code that's extracted on upload\n$process = Start-Process msiexec -ArgumentList @(\"/quiet\", \"/x\", $product_code, \"/norestart\") -PassThru\n\n# Wait for process with timeout\n$completed = $process.WaitForExit($timeoutSeconds * 1000)\n\nif (-not $completed) {\n    Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue\n    Exit 1603  # ERROR_UNINSTALL_FAILURE\n}\n\n# MSI exit codes that indicate success. 3010 = ERROR_SUCCESS_REBOOT_REQUIRED,\n# 1641 = ERROR_SUCCESS_REBOOT_INITIATED. Treat these as success rather than failure.\n$successCodes = @(0, 3010, 1641)\n\n# Check exit code and output result\nif ($successCodes -contains $process.ExitCode) {\n    Write-Output \"Exit 0\"\n    Exit 0\n} else {\n    Write-Output \"Exit $($process.ExitCode)\"\n    Exit $process.ExitCode\n}\n",
+    "8959087b": "$logFile = \"${env:TEMP}/fleet-install-software.log\"\n\ntry {\n\n$installProcess = Start-Process msiexec.exe `\n  -ArgumentList \"/quiet /norestart /lv ${logFile} /i `\"${env:INSTALLER_PATH}`\"\" `\n  -PassThru -Verb RunAs -Wait\n\nGet-Content $logFile -Tail 500\n\nExit $installProcess.ExitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n"
   }
 }

--- a/ee/maintained-apps/outputs/gog-galaxy/windows.json
+++ b/ee/maintained-apps/outputs/gog-galaxy/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.1.6.29",
+      "version": "2.1.7.22",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'GOG GALAXY' AND publisher = 'GOG.com';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'GOG GALAXY' AND publisher = 'GOG.com' AND version_compare(version, '2.1.6.29') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'GOG GALAXY' AND publisher = 'GOG.com' AND version_compare(version, '2.1.7.22') < 0);"
       },
-      "installer_url": "https://content-system.gog.com/open_link/download?path=/open/galaxy/client/setup_galaxy_2.1.6.29.exe",
+      "installer_url": "https://content-system.gog.com/open_link/download?path=/open/galaxy/client/setup_galaxy_2.1.7.22.exe",
       "install_script_ref": "e1c78c6b",
       "uninstall_script_ref": "824492ce",
-      "sha256": "c2888e0a1425823e47ed04c26e2d3c81cb14564a8e92d9c9628c3ed77a9d87bc",
+      "sha256": "d7598ec128db51d74e9e961b8348fd443e4b7060e45b5a2ad311e39dcadaea70",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/goland/darwin.json
+++ b/ee/maintained-apps/outputs/goland/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.2",
+      "version": "2026.2.0.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.goland';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.goland' AND version_compare(bundle_short_version, '2026.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.goland' AND version_compare(bundle_short_version, '2026.2.0.1') < 0);"
       },
-      "installer_url": "https://download.jetbrains.com/go/goland-2026.2-aarch64.dmg",
+      "installer_url": "https://download.jetbrains.com/go/goland-2026.2.0.1-aarch64.dmg",
       "install_script_ref": "1d48cff5",
       "uninstall_script_ref": "20571185",
-      "sha256": "5d80575a6eb1784184e722a0cd51efcdc80f05c2e925ff944cf65299c2263982",
+      "sha256": "ceb400b0e391e0e8405e779bc27464ddd6b88781a2d2df1ff9221a1008b03344",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/google-chrome/darwin.json
+++ b/ee/maintained-apps/outputs/google-chrome/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "150.0.7871.182",
+      "version": "150.0.7871.187",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.Chrome';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.Chrome' AND version_compare(bundle_short_version, '150.0.7871.182') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.Chrome' AND version_compare(bundle_short_version, '150.0.7871.187') < 0);"
       },
       "installer_url": "https://dl.google.com/dl/chrome/mac/universal/stable/gcem/GoogleChrome.pkg",
       "install_script_ref": "bf744c88",

--- a/ee/maintained-apps/outputs/kitty/darwin.json
+++ b/ee/maintained-apps/outputs/kitty/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.48.0",
+      "version": "0.48.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'net.kovidgoyal.kitty';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.kovidgoyal.kitty' AND version_compare(bundle_short_version, '0.48.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.kovidgoyal.kitty' AND version_compare(bundle_short_version, '0.48.1') < 0);"
       },
-      "installer_url": "https://github.com/kovidgoyal/kitty/releases/download/v0.48.0/kitty-0.48.0.dmg",
+      "installer_url": "https://github.com/kovidgoyal/kitty/releases/download/v0.48.1/kitty-0.48.1.dmg",
       "install_script_ref": "113bbbcb",
       "uninstall_script_ref": "610c592a",
-      "sha256": "ed8f4297a84c967e14040865ead2e24e768d67dd4f6fd0bb384a1073ca1e74b7",
+      "sha256": "6d4e683945815e9d5ca42eac9480a3692258cf6145c823b92623f54b5dfa4b36",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/splice/darwin.json
+++ b/ee/maintained-apps/outputs/splice/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "5.4.11",
+      "version": "5.4.12",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.splice.Splice';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.splice.Splice' AND version_compare(bundle_short_version, '5.4.11') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.splice.Splice' AND version_compare(bundle_short_version, '5.4.12') < 0);"
       },
-      "installer_url": "https://desktop.splice.com/conveyor/stable/splice-5.4.11-mac-aarch64.zip",
+      "installer_url": "https://desktop.splice.com/conveyor/stable/splice-5.4.12-mac-aarch64.zip",
       "install_script_ref": "b0b98c91",
       "uninstall_script_ref": "d58773e7",
-      "sha256": "374aca8d80517e21993b013448f28f40cc6824547c004d6fa0610fc699068391",
+      "sha256": "913e4f4b7d65bb3ee1393d9751b1f339750ca575e6c368b170a959902ceace86",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Refreshed maintained application releases across Windows and macOS, including BrowserStackLocal, Bruno, Canva, ChatGPT, Claude, CLion, Cursor, Draw.io, Dropbox, GOG GALAXY, GoLand, Google Chrome, Kitty, Downie, and Splice.
  - Updated installer download links and integrity checksums where applicable.
  - Improved release detection so systems recognize the latest versions and apply updates correctly.
  - Updated Dropbox’s uninstall handling for its new installer release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->