### PR TITLE
[Update-Activity] Add 'platform' field to audit log examples

### DIFF
--- a/docs/Contributing/reference/audit-logs.md
+++ b/docs/Contributing/reference/audit-logs.md
@@ -2875,7 +2875,7 @@ This activity contains the following fields:
 {
   "fleet_id": 123,
   "fleet_name": "Workstations",
-  "platform": "Windows"
+  "platform": "windows"
 }
 ```
 
@@ -2894,7 +2894,7 @@ This activity contains the following fields:
 {
   "fleet_id": 123,
   "fleet_name": "Workstations",
-  "platform": "Windows"
+  "platform": "windows"
 }
 ```
 

--- a/docs/Contributing/reference/audit-logs.md
+++ b/docs/Contributing/reference/audit-logs.md
@@ -2867,13 +2867,15 @@ Generated when a user turns on create managed local account for a fleet (or unas
 This activity contains the following fields:
 - "fleet_id": The ID of the fleet that create managed local account applies to, `null` if it applies to devices that are not in a fleet ("Unassigned").
 - "fleet_name": The name of the fleet that create managed local account applies to, `null` if it applies to devices that are not in a fleet ("Unassigned").
+- "platform": The platform of the fleet that create managed local account applies to.
 
 #### Example
 
 ```json
 {
   "fleet_id": 123,
-  "fleet_name": "Workstations"
+  "fleet_name": "Workstations",
+  "platform": "Windows"
 }
 ```
 
@@ -2884,13 +2886,15 @@ Generated when a user turns off create managed local account for a fleet (or una
 This activity contains the following fields:
 - "fleet_id": The ID of the fleet that create managed local account applies to, `null` if it applies to devices that are not in a fleet ("Unassigned").
 - "fleet_name": The name of the fleet that create managed local account applies to, `null` if it applies to devices that are not in a fleet ("Unassigned").
+- "platform": The platform of the fleet that create managed local account applies to.
 
 #### Example
 
 ```json
 {
   "fleet_id": 123,
-  "fleet_name": "Workstations"
+  "fleet_name": "Workstations",
+  "platform": "Windows"
 }
 ```
 


### PR DESCRIPTION
Added 'platform' field to audit log examples for managed local accounts.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #43488