### PR TITLE
Update fleet desktop FMA to v1.4.0

### DIFF
--- a/ee/maintained-apps/inputs/homebrew/custom-tap/Casks/fleet-desktop.rb
+++ b/ee/maintained-apps/inputs/homebrew/custom-tap/Casks/fleet-desktop.rb
@@ -8,8 +8,7 @@ cask "fleet-desktop" do
   homepage "https://github.com/fleetdm/fleet/tree/main/apps/fleet-desktop-macos"
 
   livecheck do
-    url :url
-    strategy :github_latest
+    skip "Manually versioned upon release"
   end
 
   depends_on macos: ">= :ventura"

--- a/ee/maintained-apps/inputs/homebrew/custom-tap/Casks/fleet-desktop.rb
+++ b/ee/maintained-apps/inputs/homebrew/custom-tap/Casks/fleet-desktop.rb
@@ -1,11 +1,11 @@
 cask "fleet-desktop" do
-  version "1.3.4"
-  sha256 "b05a04b9df26d0d4a6333a73bfa16c0389baff1931482d0011eee1fa400b232f"
+  version "1.4.0"
+  sha256 "c920b983524df5296c10e4b15c5789df2dacacddd5b1423562b57bb1cc6d9d71"
 
-  url "https://github.com/allenhouchins/fleet-desktop/releases/download/v#{version}/fleet_desktop-v#{version}.pkg"
+  url "https://download.fleetdm.com/fleet-desktop-macos/v#{version}/fleet_desktop-v#{version}.pkg"
   name "Fleet Desktop"
   desc "End-user client for Fleet device management"
-  homepage "https://github.com/allenhouchins/fleet-desktop"
+  homepage "https://github.com/fleetdm/fleet/tree/main/apps/fleet-desktop-macos"
 
   livecheck do
     url :url


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #45524

Release alongside v4.90.0 release. Don't release prior

FMA update of Fleet Desktop macOS to 1.4.0 https://github.com/fleetdm/fleet/actions/runs/30112916197

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the Fleet Desktop Homebrew cask to version 1.4.0.
  * Downloads now use the official Fleet Desktop distribution URL.
  * Updated the project homepage reference.
* **Maintenance**
  * Adjusted automatic update detection to use manual, release-based versioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->