### PR TITLE
[Update] YAML configuration documentation for deprecations

### DIFF
--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -533,6 +533,9 @@ The `setup_experience` section lets you control the out-of-the-box [setup experi
 - `apple_setup_assistant` is a path to a custom [automatic enrollment (ADE) profile](https://support.apple.com/guide/deployment/automated-device-enrollment-management-dep73069dd57/web) (.json). Applies to macOS and iOS/iPadOS hosts.
 - `macos_script` is the path to a custom setup script to run after the host is first set up. Applies to macOS only.
 
+`enable_managed_local_account` and `end_user_local_account_type` at this level are deprecated. 
+Please use the platform-specific `apple_settings.managed_local_account_settings`, `apple_settings.end_user_local_account_type`, or `windows_settings.managed_local_account_settings` instead.
+
 #### Example
 
 `fleets/fleet-name.yml`, or `fleets/unassigned.yml`


### PR DESCRIPTION
Deprecated 'enable_managed_local_account' and 'end_user_local_account_type' settings. Updated documentation to recommend platform-specific settings.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #43488 