### PR TITLE
Website: (Android proxy) Add deviceNotFound exit to four android proxy endpoints

### DIFF
--- a/website/api/controllers/android-proxy/delete-android-device.js
+++ b/website/api/controllers/android-proxy/delete-android-device.js
@@ -27,6 +27,7 @@ module.exports = {
     enterpriseNotAccessible: { description: 'Fleet is not authorized to manage this Android enterprise.', responseType: 'notFound' },
     deviceNoLongerManaged: { description: 'The specified device is no longer managed by the Android enterprise.', responseType: 'notFound' },
     managementApiError: { statusCode: 503, description: 'The Android management API returned a transient 5xx error.' },
+    deviceNotFound: {description: 'The specified device does not exist in this Android enterprise', responseType: 'notFound'},
   },
 
 
@@ -76,6 +77,9 @@ module.exports = {
     }).intercept({status: 403}, ()=>{
       // If the Android management API returns a 403 response, return a enterpriseNotAccessible (notFound) response to the Fleet server.
       return {'enterpriseNotAccessible': 'Fleet is not authorized to manage this Android enterprise.'};
+    }).intercept({status: 404}, ()=>{
+      // If the Android management API returns a 404 response, return a deviceNotFound (notFound) response to the Fleet server.
+      return 'deviceNotFound';
     }).intercept((err)=>{
       let errorString = err.toString();
       if (errorString.includes('Device is no longer being managed')) {

--- a/website/api/controllers/android-proxy/get-android-device.js
+++ b/website/api/controllers/android-proxy/get-android-device.js
@@ -26,6 +26,7 @@ module.exports = {
     notFound: { description: 'No Android enterprise found for this Fleet server.', responseType: 'notFound' },
     enterpriseNotAccessible: { description: 'Fleet is not authorized to manage this Android enterprise.', responseType: 'notFound' },
     deviceNoLongerManaged: { description: 'The device is no longer managed by the Android enterprise.', responseType: 'notFound' },
+    deviceNotFound: {description: 'The specified device does not exist in this Android enterprise', responseType: 'notFound'}
   },
 
 
@@ -77,6 +78,9 @@ module.exports = {
     }).intercept({status: 403}, ()=>{
       // If the Android management API returns a 403 response, return a enterpriseNotAccessible (notFound) response to the Fleet server.
       return {'enterpriseNotAccessible': 'Fleet is not authorized to manage this Android enterprise.'};
+    }).intercept({status: 404}, ()=>{
+      // If the Android management API returns a 404 response, return a deviceNotFound (notFound) response to the Fleet server.
+      return 'deviceNotFound';
     }).intercept((err)=>{
       let errorString = err.toString();
       if (errorString.includes('Device is no longer being managed')) {

--- a/website/api/controllers/android-proxy/issue-command-on-android-device.js
+++ b/website/api/controllers/android-proxy/issue-command-on-android-device.js
@@ -84,6 +84,7 @@ module.exports = {
     notFound: { description: 'No Android enterprise found for this Fleet server.', responseType: 'notFound' },
     enterpriseNotAccessible: { description: 'Fleet is not authorized to manage this Android enterprise.', responseType: 'notFound' },
     deviceNoLongerManaged: { description: 'The specified device is no longer managed by the Android enterprise.', responseType: 'notFound' },
+    deviceNotFound: {description: 'The specified device does not exist in this Android enterprise', responseType: 'notFound'}
     managementApiError: { statusCode: 503, description: 'The Android management API returned a transient 5xx error.' },
   },
 
@@ -175,6 +176,9 @@ module.exports = {
     }).intercept({status: 403}, ()=>{
       // If the Android management API returns a 403 response, return a enterpriseNotAccessible (notFound) response to the Fleet server.
       return {'enterpriseNotAccessible': 'Fleet is not authorized to manage this Android enterprise.'};
+    }).intercept({status: 404}, ()=>{
+      // If the Android management API returns a 404 response, return a deviceNotFound (notFound) response to the Fleet server.
+      return 'deviceNotFound';
     }).intercept((err)=>{
       let errorString = err.toString();
       if (errorString.includes('Device is no longer being managed')) {

--- a/website/api/controllers/android-proxy/issue-command-on-android-device.js
+++ b/website/api/controllers/android-proxy/issue-command-on-android-device.js
@@ -84,7 +84,7 @@ module.exports = {
     notFound: { description: 'No Android enterprise found for this Fleet server.', responseType: 'notFound' },
     enterpriseNotAccessible: { description: 'Fleet is not authorized to manage this Android enterprise.', responseType: 'notFound' },
     deviceNoLongerManaged: { description: 'The specified device is no longer managed by the Android enterprise.', responseType: 'notFound' },
-    deviceNotFound: {description: 'The specified device does not exist in this Android enterprise', responseType: 'notFound'}
+    deviceNotFound: {description: 'The specified device does not exist in this Android enterprise', responseType: 'notFound'},
     managementApiError: { statusCode: 503, description: 'The Android management API returned a transient 5xx error.' },
   },
 

--- a/website/api/controllers/android-proxy/modify-android-device.js
+++ b/website/api/controllers/android-proxy/modify-android-device.js
@@ -28,6 +28,7 @@ module.exports = {
     deviceNoLongerManaged: { description: 'The device is no longer managed by the Android enterprise.', responseType: 'notFound' },
     invalidPolicyName: {description: 'The specified policy_name is invalid', responseType: 'badRequest' },
     managementApiError: { statusCode: 503, description: 'The Android management API returned a transient 5xx error.' },
+    deviceNotFound: {description: 'The specified device does not exist in this Android enterprise', responseType: 'notFound'}
   },
 
 
@@ -82,6 +83,9 @@ module.exports = {
     }).intercept({status: 403}, ()=>{
       // If the Android management API returns a 403 response, return a enterpriseNotAccessible (notFound) response to the Fleet server.
       return {'enterpriseNotAccessible': 'Fleet is not authorized to manage this Android enterprise.'};
+    }).intercept({status: 404}, ()=>{
+      // If the Android management API returns a 404 response, return a deviceNotFound (notFound) response to the Fleet server.
+      return 'deviceNotFound';
     }).intercept((err)=>{
       let errorString = err.toString();
       if (errorString.includes('Device is no longer being managed')) {


### PR DESCRIPTION
Changes:
- Updated the delete-android-device, get-android-device, issue-command-on-android-device, and modify-android-device actions to return a `deviceNotFound` response to Fleet servers when the Android management API returns a 404 response.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Android device management error handling.
  - Device deletion, retrieval, command issuance, and modification now clearly report when the requested device cannot be found.
  - Prevents missing devices from being reported as generic errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->