### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/brave-browser/darwin.json
+++ b/ee/maintained-apps/outputs/brave-browser/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "150.1.92.143",
+      "version": "150.1.92.144",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.brave.Browser';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.brave.Browser' AND version_compare(bundle_short_version, '150.1.92.143') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.brave.Browser' AND version_compare(bundle_short_version, '150.1.92.144') < 0);"
       },
-      "installer_url": "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/stable-arm64/192.143/Brave-Browser-arm64.dmg",
+      "installer_url": "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/stable-arm64/192.144/Brave-Browser-arm64.dmg",
       "install_script_ref": "013e53e8",
       "uninstall_script_ref": "9a376609",
-      "sha256": "817bac1ba37b7ef6d37695b597d5c936ad416905ba201a16aa40a7de62c70674",
+      "sha256": "bf6dc0d6eba200257c300359aa3e0bff0162d8f55cfbaa5fb4e6ef4fbfe0d3fd",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/chatwise/darwin.json
+++ b/ee/maintained-apps/outputs/chatwise/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.7.3",
+      "version": "26.7.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'app.chatwise';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.chatwise' AND version_compare(bundle_short_version, '26.7.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.chatwise' AND version_compare(bundle_short_version, '26.7.4') < 0);"
       },
-      "installer_url": "https://releases.chatwise.app/26.7.3/ChatWise-26.7.3-arm64.dmg",
+      "installer_url": "https://releases.chatwise.app/26.7.4/ChatWise-26.7.4-arm64.dmg",
       "install_script_ref": "b3b382a0",
       "uninstall_script_ref": "da509fe4",
-      "sha256": "285ecdf7225ad044a2d3801c70016d2521e1046134bc576c7c0befd896c8cd86",
+      "sha256": "5023f1dc53a1bfff788ba317aed2893b8208d5e9e419864f41674693672b2817",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/claude/darwin.json
+++ b/ee/maintained-apps/outputs/claude/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.24012.1",
+      "version": "1.24012.9",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.24012.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.24012.9') < 0);"
       },
-      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.24012.1/Claude-0adcaed55041a881be363f2c4a4729f67a8b27d7.zip",
+      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.24012.9/Claude-03c61d06f8e01a4db2273b9514e225f21d2ba62e.zip",
       "install_script_ref": "8b957973",
       "uninstall_script_ref": "421baa98",
-      "sha256": "de2833b60daabdbf0e9237d9f8f3b8102ef19418e354117b19b321d0a3a12e6f",
+      "sha256": "39ad2d181e2b1b017c5506f66c08399c23575c802d8b63927f40128e77103a9b",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/dialpad/darwin.json
+++ b/ee/maintained-apps/outputs/dialpad/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "2606.1.2",
+      "version": "2607.1.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.dialpad';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.dialpad' AND version_compare(bundle_short_version, '2606.1.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.dialpad' AND version_compare(bundle_short_version, '2607.1.1') < 0);"
       },
       "installer_url": "https://download.dialpad.com/osx/arm64/dialpad.pkg",
       "install_script_ref": "49548b01",

--- a/ee/maintained-apps/outputs/firefox@developer-edition/darwin.json
+++ b/ee/maintained-apps/outputs/firefox@developer-edition/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "154.0b1",
+      "version": "154.0b2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefoxdeveloperedition';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefoxdeveloperedition' AND version_compare(bundle_version, '15426.7.22') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefoxdeveloperedition' AND version_compare(bundle_version, '15426.7.24') < 0);"
       },
-      "installer_url": "https://download-installer.cdn.mozilla.net/pub/devedition/releases/154.0b1/mac/en-US/Firefox%20154.0b1.dmg",
+      "installer_url": "https://download-installer.cdn.mozilla.net/pub/devedition/releases/154.0b2/mac/en-US/Firefox%20154.0b2.dmg",
       "install_script_ref": "a313f903",
       "uninstall_script_ref": "b108b0ff",
-      "sha256": "28ab899ade74fb436e450eee2db6a491a8f288e38d4def4ea828a2755f6f6cd5",
+      "sha256": "38c58ba59dc8cbebb0c4a3aaace8c34bd34bdfce2d2bf251d83e15f324fd3be0",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/netron/darwin.json
+++ b/ee/maintained-apps/outputs/netron/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "9.1.8",
+      "version": "9.1.9",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.lutzroeder.netron';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.lutzroeder.netron' AND version_compare(bundle_short_version, '9.1.8') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.lutzroeder.netron' AND version_compare(bundle_short_version, '9.1.9') < 0);"
       },
-      "installer_url": "https://github.com/lutzroeder/netron/releases/download/v9.1.8/Netron-9.1.8-mac.zip",
+      "installer_url": "https://github.com/lutzroeder/netron/releases/download/v9.1.9/Netron-9.1.9-mac.zip",
       "install_script_ref": "4929401f",
       "uninstall_script_ref": "acbbb0d7",
-      "sha256": "3a1473b25e98343c0a4065608d387efa921f2952e901ce39801f8f1786491451",
+      "sha256": "a011cb524d557edb7bb2bc5cd349fa0098fa624265f8081bc0c65ba2661976da",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/notepadexe/darwin.json
+++ b/ee/maintained-apps/outputs/notepadexe/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.5.6",
+      "version": "1.5.7",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'best.swift.Notepad';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'best.swift.Notepad' AND version_compare(bundle_short_version, '1.5.6') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'best.swift.Notepad' AND version_compare(bundle_short_version, '1.5.7') < 0);"
       },
-      "installer_url": "https://github.com/notepadhq/notepadexe-public/releases/download/1.5.6/Notepad.zip",
+      "installer_url": "https://github.com/notepadhq/notepadexe-public/releases/download/1.5.7/Notepad.zip",
       "install_script_ref": "17716d6a",
       "uninstall_script_ref": "abe56690",
-      "sha256": "8dacd2f3a2ea2126aaec0a2cc59e65ede493a49a881dd8834ddf6cceb03f8d51",
+      "sha256": "1cb30ccb240668564814ae8a2f8f4f8ef6b736589ac3576d9afb0a627a59ca55",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/onedrive/darwin.json
+++ b/ee/maintained-apps/outputs/onedrive/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.113.0614.0004",
+      "version": "26.119.0622.0003",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.OneDrive';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.OneDrive' AND version_compare(bundle_short_version, '26.113.0614.0004') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.OneDrive' AND version_compare(bundle_short_version, '26.119.0622.0003') < 0);"
       },
-      "installer_url": "https://oneclient.sfx.ms/Mac/Installers/26.113.0614.0004/universal/OneDrive.pkg",
+      "installer_url": "https://oneclient.sfx.ms/Mac/Installers/26.119.0622.0003/universal/OneDrive.pkg",
       "install_script_ref": "1e78de1c",
       "uninstall_script_ref": "b1c16fe2",
-      "sha256": "f2fceb86f97304d57ae1b5cb2e02b3a1addedc6c68e0bc95e8b67e362b95992f",
+      "sha256": "ed8037715552d25538207786b36503ead1be5d5c8cd457c4cabba67df7a11e35",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/prisma-browser/darwin.json
+++ b/ee/maintained-apps/outputs/prisma-browser/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "150.49.7.182",
+      "version": "150.49.8.187",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.talon-sec.Work';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.talon-sec.Work' AND version_compare(bundle_short_version, '150.49.7.182') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.talon-sec.Work' AND version_compare(bundle_short_version, '150.49.8.187') < 0);"
       },
-      "installer_url": "https://updates.talon-sec.com/releases/Prisma%20Access%20Browser/mac/packaged/universal/Prisma%20Access%20Browser-150.49.7.182-c674b580.pkg",
+      "installer_url": "https://updates.talon-sec.com/releases/Prisma%20Access%20Browser/mac/packaged/universal/Prisma%20Access%20Browser-150.49.8.187-2f81552d.pkg",
       "install_script_ref": "7381dac4",
       "uninstall_script_ref": "ff947f47",
-      "sha256": "1a4c888b95cd435877ee58a6e030fa4af71de45c0a16b0012e6b32e18b88f0fe",
+      "sha256": "0dfa384f361a80cda0864613ac84b4a5e1be806a7b0d9407c0a1a4652f2fa39d",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/reqable/darwin.json
+++ b/ee/maintained-apps/outputs/reqable/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.2.13",
+      "version": "3.2.14",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.reqable.macosx';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.reqable.macosx' AND version_compare(bundle_short_version, '3.2.13') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.reqable.macosx' AND version_compare(bundle_short_version, '3.2.14') < 0);"
       },
-      "installer_url": "https://github.com/reqable/reqable-app/releases/download/3.2.13/reqable-app-macos-arm64.dmg",
+      "installer_url": "https://github.com/reqable/reqable-app/releases/download/3.2.14/reqable-app-macos-arm64.dmg",
       "install_script_ref": "5d84816f",
       "uninstall_script_ref": "3319d75e",
-      "sha256": "69d8e38a283e2efc15175d16773640a20351e193abfcaa2588bbd946367e76ec",
+      "sha256": "0b24ae1b7306fb81c1678acd69c8fdcac110f5d6000dccc5cbcf4c011835f32b",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/sequel-ace/darwin.json
+++ b/ee/maintained-apps/outputs/sequel-ace/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "5.3.0",
+      "version": "5.3.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.sequelace.SequelAce';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.sequelace.SequelAce' AND version_compare(bundle_short_version, '5.3.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.sequelace.SequelAce' AND version_compare(bundle_short_version, '5.3.1') < 0);"
       },
-      "installer_url": "https://github.com/Sequel-Ace/Sequel-Ace/releases/download/production/5.3.0-20102/Sequel-Ace-5.3.0.zip",
+      "installer_url": "https://github.com/Sequel-Ace/Sequel-Ace/releases/download/production/5.3.1-20104/Sequel-Ace-5.3.1.zip",
       "install_script_ref": "fd823f80",
       "uninstall_script_ref": "3049be7c",
-      "sha256": "63564b424fc6b35382989c7dd0916ba03219d6dcb14704046aee7b88d9240511",
+      "sha256": "b66755ec66716e977e295ceb3daca46e081149067adc7e2b087b3dbdf9239f90",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/spokenly/darwin.json
+++ b/ee/maintained-apps/outputs/spokenly/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.25.4",
+      "version": "2.26.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'app.spokenly';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.spokenly' AND version_compare(bundle_short_version, '2.25.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.spokenly' AND version_compare(bundle_short_version, '2.26.0') < 0);"
       },
-      "installer_url": "https://cdn.spokenly.app/releases/macos/Spokenly-2.25.4.dmg",
+      "installer_url": "https://cdn.spokenly.app/releases/macos/Spokenly-2.26.0.dmg",
       "install_script_ref": "5f8295ce",
       "uninstall_script_ref": "a5d6883d",
-      "sha256": "5e4987dfde3abdd0844329c2afc9e6d08ec7177090596a78dff56c566a3431ee",
+      "sha256": "5bcae0335646281d85683a637ebbbb689e6dd7664dbf2e78971ada20ee9cd8b6",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/versions/darwin.json
+++ b/ee/maintained-apps/outputs/versions/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.4.4",
+      "version": "2.4.5",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.versionsapp.v2';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.versionsapp.v2' AND version_compare(bundle_short_version, '2.4.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.versionsapp.v2' AND version_compare(bundle_short_version, '2.4.5') < 0);"
       },
-      "installer_url": "https://updates.versionsapp.com/v2/prod/Versions-2.4.4-2040.zip",
+      "installer_url": "https://updates.versionsapp.com/v2/prod/Versions-2.4.5-2042.zip",
       "install_script_ref": "4baad7da",
       "uninstall_script_ref": "503c2dfc",
-      "sha256": "e2b91a4d8921fce230d5713ec60cad7dfd95c560af691533e125d99c7ffd013b",
+      "sha256": "38cd533eff8669046f9d4a886c5ebabfdb93e8c51f9bb94e43fa5f3d31af9ae4",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/vivaldi/darwin.json
+++ b/ee/maintained-apps/outputs/vivaldi/darwin.json
@@ -1,12 +1,12 @@
 {
   "versions": [
     {
-      "version": "8.1.4087.56",
+      "version": "8.1.4087.58",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.vivaldi.Vivaldi';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.vivaldi.Vivaldi' AND version_compare(bundle_short_version, '8.1.4087.56') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.vivaldi.Vivaldi' AND version_compare(bundle_short_version, '8.1.4087.58') < 0);"
       },
-      "installer_url": "https://downloads.vivaldi.com/stable/Vivaldi.8.1.4087.56.universal.dmg",
+      "installer_url": "https://downloads.vivaldi.com/stable/Vivaldi.8.1.4087.58.universal.dmg",
       "install_script_ref": "6a60dca7",
       "uninstall_script_ref": "7c1876ca",
       "sha256": "no_check",

--- a/ee/maintained-apps/outputs/warp/darwin.json
+++ b/ee/maintained-apps/outputs/warp/darwin.json
@@ -1,12 +1,12 @@
 {
   "versions": [
     {
-      "version": "0.2026.07.15.08.55.01",
+      "version": "0.2026.07.22.09.01.01",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable' AND version_compare(bundle_short_version, '0.2026.07.15.08.55.01') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable' AND version_compare(bundle_short_version, '0.2026.07.22.09.01.01') < 0);"
       },
-      "installer_url": "https://releases.warp.dev/stable/v0.2026.07.15.08.55.stable_01/Warp.dmg",
+      "installer_url": "https://releases.warp.dev/stable/v0.2026.07.22.09.01.stable_01/Warp.dmg",
       "install_script_ref": "007bc795",
       "uninstall_script_ref": "932356de",
       "sha256": "no_check",

--- a/ee/maintained-apps/outputs/webcatalog/darwin.json
+++ b/ee/maintained-apps/outputs/webcatalog/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "77.6.0",
+      "version": "77.7.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.webcatalog.jordan';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.webcatalog.jordan' AND version_compare(bundle_short_version, '77.6.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.webcatalog.jordan' AND version_compare(bundle_short_version, '77.7.0') < 0);"
       },
-      "installer_url": "https://cdn-2.webcatalog.io/webcatalog/WebCatalog-77.6.0-universal.dmg",
+      "installer_url": "https://cdn-2.webcatalog.io/webcatalog/WebCatalog-77.7.0-universal.dmg",
       "install_script_ref": "f04928dc",
       "uninstall_script_ref": "d196a4c8",
-      "sha256": "30dee39c633aec3d775bb409083d393f71d3f67df6a3cf5fb634f45b66a2f8b8",
+      "sha256": "e6cddb9246d62adfe7f03d38a58750c05dd671d190ea554e4cb6ac238459180c",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/wechat/darwin.json
+++ b/ee/maintained-apps/outputs/wechat/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.1.12.25",
+      "version": "4.1.12.27",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.tencent.xinWeChat';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.tencent.xinWeChat' AND version_compare(bundle_short_version, '4.1.12.25') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.tencent.xinWeChat' AND version_compare(bundle_short_version, '4.1.12.27') < 0);"
       },
-      "installer_url": "https://dldir1.qq.com/weixin/Universal/Mac/xWeChatMac_universal_4.1.12.25_269337.dmg",
+      "installer_url": "https://dldir1.qq.com/weixin/Universal/Mac/xWeChatMac_universal_4.1.12.27_269339.dmg",
       "install_script_ref": "57f30b74",
       "uninstall_script_ref": "18d6be1e",
-      "sha256": "1048b2374c9507ce557c831f0df425cd04af5116bde99a522827741f6cf4fa8f",
+      "sha256": "8db40a7a80337e88baa50741372ccf75134bf3146db44de889b28b62884c45f2",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/whatsapp/darwin.json
+++ b/ee/maintained-apps/outputs/whatsapp/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "26.29.20",
+      "version": "26.29.22",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp' AND version_compare(bundle_short_version, '26.29.20') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp' AND version_compare(bundle_short_version, '26.29.22') < 0);"
       },
       "installer_url": "https://web.whatsapp.com/desktop/mac_native/release/?configuration=Release&src=whatsapp_downloads_page",
       "install_script_ref": "157dabb3",

--- a/ee/maintained-apps/outputs/workflowy/darwin.json
+++ b/ee/maintained-apps/outputs/workflowy/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.3.2607221820",
+      "version": "4.3.2607240847",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.workflowy.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.workflowy.desktop' AND version_compare(bundle_short_version, '4.3.2607221820') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.workflowy.desktop' AND version_compare(bundle_short_version, '4.3.2607240847') < 0);"
       },
-      "installer_url": "https://github.com/workflowy/desktop/releases/download/v4.3.2607221820/WorkFlowy.zip",
+      "installer_url": "https://github.com/workflowy/desktop/releases/download/v4.3.2607240847/WorkFlowy.zip",
       "install_script_ref": "467dafec",
       "uninstall_script_ref": "effe5345",
-      "sha256": "85945c5a4a0e480186c70422b51a734a73bad975148fb5a1cea507f6bdbf0131",
+      "sha256": "cd93f9e19e425b176083a48134e30bf0c37f35bda31471389168c77463f53911",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the latest macOS installer metadata for 20 maintained applications, including Brave Browser, ChatWise, Claude, Firefox Developer Edition, OneDrive, WhatsApp, and Workflowy.
  * Updated download links, version detection, and package verification data to support the latest releases.

* **Bug Fixes**
  * Ensured application updates are correctly recognized and downloaded using current release information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->