### PR TITLE
Add Windows 11 hardware readiness report to dogfood GitOps

### DIFF
--- a/it-and-security/default.yml
+++ b/it-and-security/default.yml
@@ -89,6 +89,7 @@ reports:
   - path: ./lib/all/reports/collect-known-vulnerable-chrome-extensions.yml
   - path: ./lib/macos/reports/detect-apns-certificate.yml
   - path: ./lib/macos/reports/collect-xprotect-reports.yml
+  - path: ./lib/windows/reports/collect-windows-11-hardware-readiness.yml
 controls:
   apple_require_hardware_attestation: true
   enable_disk_encryption: true

--- a/it-and-security/default.yml
+++ b/it-and-security/default.yml
@@ -89,7 +89,6 @@ reports:
   - path: ./lib/all/reports/collect-known-vulnerable-chrome-extensions.yml
   - path: ./lib/macos/reports/detect-apns-certificate.yml
   - path: ./lib/macos/reports/collect-xprotect-reports.yml
-  - path: ./lib/windows/reports/collect-windows-11-hardware-readiness.yml
 controls:
   apple_require_hardware_attestation: true
   enable_disk_encryption: true

--- a/it-and-security/fleets/testing-and-qa.yml
+++ b/it-and-security/fleets/testing-and-qa.yml
@@ -92,6 +92,7 @@ policies:
   - path: ../lib/linux/policies/check-fleet-desktop-extension-enabled.yml
 reports:
   - path: ../lib/all/reports/dex-queries.yml
+  - path: ../lib/windows/reports/collect-windows-11-hardware-readiness.yml
 software:
   packages:
     # Linux apps

--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -214,6 +214,7 @@ reports:
   - path: ../lib/all/reports/collect-chromium-browser-extensions.yml
   - path: ../lib/all/reports/collect-firefox-browser-extensions.yml
   - path: ../lib/all/reports/collect-listening-ports.yml
+  - path: ../lib/windows/reports/collect-windows-11-hardware-readiness.yml
 software:
   packages:
     # macOS apps

--- a/it-and-security/lib/windows/reports/collect-windows-11-hardware-readiness.yml
+++ b/it-and-security/lib/windows/reports/collect-windows-11-hardware-readiness.yml
@@ -1,0 +1,45 @@
+- name: Collect Windows 11 hardware readiness
+  description: "Collects hardware details and evaluates each device against Microsoft's minimum Windows 11 hardware requirements (64-bit CPU, 2+ cores, 1GHz+ clock speed, 4GB+ RAM, 64GB+ storage, TPM 2.0 enabled, Secure Boot enabled)."
+  query: |
+    SELECT
+      device_name, manufacturer, model, serial_number,
+      os_name, os_version, os_build,
+      cpu_model, cpu_ghz, cpu_cores, cpu_bits,
+      ram_gb, system_disk_gb, tpm_version, tpm_enabled, secure_boot,
+      CASE WHEN cpu_bits = 64                               THEN 'pass' ELSE 'fail' END AS check_64bit,
+      CASE WHEN cpu_cores >= 2                              THEN 'pass' ELSE 'fail' END AS check_cores,
+      CASE WHEN cpu_ghz >= 1.0                              THEN 'pass' ELSE 'fail' END AS check_cpu_speed,
+      CASE WHEN ram_gb >= 4                                 THEN 'pass' ELSE 'fail' END AS check_ram,
+      CASE WHEN system_disk_gb >= 64                        THEN 'pass' ELSE 'fail' END AS check_storage,
+      CASE WHEN tpm_version LIKE '2.0%' AND tpm_enabled = 1 THEN 'pass' ELSE 'fail' END AS check_tpm,
+      CASE WHEN secure_boot = 1                             THEN 'pass' ELSE 'fail' END AS check_secure_boot,
+      CASE WHEN cpu_bits = 64 AND cpu_cores >= 2 AND cpu_ghz >= 1.0
+            AND ram_gb >= 4 AND system_disk_gb >= 64
+            AND tpm_version LIKE '2.0%' AND tpm_enabled = 1
+            AND secure_boot = 1
+           THEN 'ready' ELSE 'not ready' END AS win11_hardware_baseline
+    FROM (
+      SELECT
+        (SELECT computer_name   FROM system_info)                                 AS device_name,
+        (SELECT hardware_vendor FROM system_info)                                 AS manufacturer,
+        (SELECT hardware_model  FROM system_info)                                 AS model,
+        (SELECT hardware_serial FROM system_info)                                 AS serial_number,
+        (SELECT name    FROM os_version)                                          AS os_name,
+        (SELECT version FROM os_version)                                          AS os_version,
+        (SELECT build   FROM os_version)                                          AS os_build,
+        (SELECT model           FROM cpu_info LIMIT 1)                            AS cpu_model,
+        (SELECT ROUND(max_clock_speed / 1000.0, 2) FROM cpu_info LIMIT 1)         AS cpu_ghz,
+        (SELECT number_of_cores FROM cpu_info LIMIT 1)                            AS cpu_cores,
+        (SELECT address_width   FROM cpu_info LIMIT 1)                            AS cpu_bits,
+        ROUND((SELECT physical_memory FROM system_info) / 1073741824.0, 1)        AS ram_gb,
+        ROUND((SELECT size FROM logical_drives WHERE boot_partition = 1 LIMIT 1)
+              / 1000000000.0, 1)                                                  AS system_disk_gb,
+        (SELECT spec_version FROM tpm_info LIMIT 1)                               AS tpm_version,
+        (SELECT enabled      FROM tpm_info LIMIT 1)                               AS tpm_enabled,
+        (SELECT secure_boot  FROM secureboot LIMIT 1)                             AS secure_boot
+    );
+  interval: 86400 # Every 1 day
+  observer_can_run: true
+  automations_enabled: false
+  logging: differential
+  platform: windows


### PR DESCRIPTION
**Related issue:** N/A

## Summary

Adds a new osquery report to Fleet's own dogfood GitOps config (`it-and-security/`) that recreates the Microsoft Endpoint Analytics Windows 11 hardware readiness check directly via osquery, instead of relying on Intune's Graph summary.

- New file: `it-and-security/lib/windows/reports/collect-windows-11-hardware-readiness.yml`
- Registered under the global `reports:` list in `it-and-security/default.yml`, so it applies across all fleets (not scoped to a single team)
- Scoped to `platform: windows` only, since `tpm_info`, `secureboot`, and `logical_drives` are Windows-only osquery tables

The report evaluates per-host pass/fail against Microsoft's minimum requirements: 64-bit CPU, 2+ cores, 1GHz+ clock speed, 4GB+ RAM, 64GB+ storage, TPM 2.0 enabled, and Secure Boot enabled, plus an overall `win11_hardware_baseline` ready/not-ready column.

## Known gaps (carried over from the source query)

- No osquery equivalent for Microsoft's approved-CPU-family allowlist check — `cpu_model` is surfaced for manual cross-reference instead.
- `secure_boot` / `tpm_enabled` reflect current firmware state, not hardware capability — a host with TPM disabled in firmware or running legacy BIOS will fail even though it may be fixable without new hardware.
- If `boot_partition` doesn't populate reliably on some hosts, the disk subquery may need a fallback to `WHERE device_id = 'C:'`.

# Checklist for submitter

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] QA'd all new/changed functionality manually (validated YAML parses correctly and the query text round-trips unchanged; will be exercised for real by the dogfood-gitops workflow on merge)

## New Fleet configuration settings

- [x] Setting(s) is/are explicitly excluded from GitOps (N/A — this is a GitOps config change itself, not a new server setting)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Windows 11 hardware readiness report for supported devices.
  * Reports evaluate processor, memory, storage, TPM, Secure Boot, and operating system requirements.
  * Devices receive an overall readiness status of “ready” or “not ready.”
  * The report is now available in testing and workstation fleets and updates daily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->