### PR TITLE
Website: Update contact form for users who visit the page from "Get a demo" buttons

### DIFF
--- a/website/api/controllers/view-contact.js
+++ b/website/api/controllers/view-contact.js
@@ -12,6 +12,12 @@ module.exports = {
       description: 'A boolean that determines whether or not to display the talk to us form when the contact page loads.',
       defaultsTo: false,
     },
+
+    talkToUs: {
+      type: 'boolean',
+      description: 'A boolean that determines whether or not to *only* display the talk to us form when the contact page loads.',
+      defaultsTo: false,
+    },
   },
 
   exits: {
@@ -27,7 +33,7 @@ module.exports = {
   },
 
 
-  fn: async function ({sendMessage}) {
+  fn: async function ({sendMessage, talkToUs}) {
 
     if (!_.isObject(sails.config.builtStaticContent) || !_.isArray(sails.config.builtStaticContent.openPositions)) {
       throw {badConfig: 'builtStaticContent.openPositions'};
@@ -45,6 +51,11 @@ module.exports = {
       }
     }
 
+    let onlyShowTalkToUsForm = false;
+    if(talkToUs){
+      onlyShowTalkToUsForm = true;
+    }
+
     if(sendMessage) {
       formToShow = 'contact';
     }
@@ -57,7 +68,8 @@ module.exports = {
       formToShow,
       userIsLoggedIn,
       userHasPremiumSubscription,
-      currentOpenPositionsForApplicationDropdown
+      currentOpenPositionsForApplicationDropdown,
+      onlyShowTalkToUsForm,
     };
 
   }

--- a/website/assets/js/components/call-to-action.component.js
+++ b/website/assets/js/components/call-to-action.component.js
@@ -63,7 +63,7 @@ parasails.registerComponent('callToAction', {
       </div>
     </div>
     <div purpose="default-cta" v-else>
-      <a purpose="cta-button" href="/contact">Get a demo</a>
+      <a purpose="cta-button" href="/contact?talkToUs">Get a demo</a>
       <!-- <animated-arrow-button  href="/register">Try it yourself</animated-arrow-button> -->
     </div>
   </div>

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -458,7 +458,7 @@
                     <%}%>
                   </div>
                   <div purpose="mobile-nav-cta" class="d-flex flex-row align-items-center">
-                    <a purpose="glass-header-btn" class="align-items-center d-flex" href="/contact" no-underline>Get a demo</a>
+                    <a purpose="glass-header-btn" class="align-items-center d-flex" href="/contact?talkToUs" no-underline>Get a demo</a>
 <!--                       <a purpose="layout-animated-arrow-button" class="start-cta-continue-button" href="/try" no-underline>
                         Try it yourself
                         <svg purpose="animated-arrow" xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12">
@@ -731,7 +731,7 @@
                     <path purpose="chevron" d="M1.35712 1L5.64283 6L1.35712 11" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                   </svg>
                 </a> -->
-                <a purpose="glass-header-btn" class="align-items-center d-flex" href="/contact" no-underline>Get a demo</a>
+                <a purpose="glass-header-btn" class="align-items-center d-flex" href="/contact?talkToUs" no-underline>Get a demo</a>
                 <% if(_.has(me, 'id')) {%>
                   <a purpose="log-out-button" href="/logout" class="justify-content-end text-decoration-none">Log out</a>
                 <% } %>

--- a/website/views/pages/ai-in-it.ejs
+++ b/website/views/pages/ai-in-it.ejs
@@ -79,7 +79,7 @@
           </div>
           <p>Talk to us about your fleet, or get hands-on at a free in-person workshop.</p>
           <div purpose="button-row">
-            <a purpose="cta-button" href="/contact">Get a demo</a>
+            <a purpose="cta-button" href="/contact?talkToUs">Get a demo</a>
             <animated-arrow-button href="/workshops">Get certified</animated-arrow-button>
           </div>
         </div>

--- a/website/views/pages/articles/basic-article.ejs
+++ b/website/views/pages/articles/basic-article.ejs
@@ -69,7 +69,7 @@
             <a purpose="sidebar-link" href="/docs"><img alt="Docs" src="/images/icon-docs-16x16@2x.png"> Docs</a>
             <a purpose="sidebar-link" href="/docs/rest-api"><img alt="REST API" src="/images/icon-api-16x16@2x.png"> REST API</a>
             <a purpose="sidebar-link" href="/guides"><img alt="Guides" src="/images/icon-guides-16x16@2x.png"> Guides</a>
-            <a purpose="sidebar-link" href="/contact"><img alt="Get a demo" src="/images/icon-contact-16x16@2x.png">Get a demo</a>
+            <a purpose="sidebar-link" href="/contact?talkToUs"><img alt="Get a demo" src="/images/icon-contact-16x16@2x.png">Get a demo</a>
             <div purpose="edit-link">
               <a purpose="sidebar-link" :href="'https://github.com/fleetdm/fleet/edit/main/articles/'+thisPage.sectionRelativeRepoPath"> <img src="/images/icon-edit-16x16@2x.png" alt="Suggest an edit">Suggest an edit</a>
             </div>

--- a/website/views/pages/articles/basic-comparison.ejs
+++ b/website/views/pages/articles/basic-comparison.ejs
@@ -8,7 +8,7 @@
         </div>
         <p><%= thisPage.meta.introductionTextBlockOne%></p>
         <%if(thisPage.meta.introductionTextBlockTwo){%><p class="mb-0"><%= thisPage.meta.introductionTextBlockTwo%></p><% } %>
-        <div><a purpose="demo-button" class="btn btn-primary" href="/contact">Get a demo</a></div>
+        <div><a purpose="demo-button" class="btn btn-primary" href="/contact?talkToUs">Get a demo</a></div>
       </div>
       <div purpose="hero-image">
         <img alt="Hero image" src="/images/comparison-page-hero-504x349@2x.png">
@@ -34,7 +34,7 @@
           <hr>
           <h2>See Fleet in action</h2>
           <p>Compare your current setup and plan your move to Fleet</p>
-          <div><a purpose="demo-button" class="btn btn-primary" href="/contact">Get a demo</a></div>
+          <div><a purpose="demo-button" class="btn btn-primary" href="/contact?talkToUs">Get a demo</a></div>
         </div>
       </div>
     </div>

--- a/website/views/pages/articles/case-study.ejs
+++ b/website/views/pages/articles/case-study.ejs
@@ -112,7 +112,7 @@
 
         <p>Fleet is the open-source endpoint management platform that gives you total control, unlike the proprietary 'black boxes' of legacy vendors. Our open device management provides full visibility into our code and roadmap, plus a true choice of deployment—on-prem or cloud—with 100% feature parity. Our API-first approach empowers technical teams to automate with GitOps, scale confidently, and get the real-time data needed to secure their entire macOS, iOS, Windows, and Linux fleets.</p>
         <div purpose="button-row">
-          <a purpose="cta-button" href="/contact">Get a demo</a>
+          <a purpose="cta-button" href="/contact?talkToUs">Get a demo</a>
           <!-- <animated-arrow-button href="/try">Try it yourself</animated-arrow-button> -->
         </div>
       </div>

--- a/website/views/pages/contact.ejs
+++ b/website/views/pages/contact.ejs
@@ -16,10 +16,12 @@
         <h2 class="mb-3">Request a workshop</h2>
         <p style="margin-bottom: 32px;">Fill out the form below to request a workshop in your area.</p>
       </div>
-      <div purpose="contact-form-switch" class="d-flex flex-sm-row flex-column justify-content-center mx-auto" v-if="!userHasPremiumSubscription && !['apply', 'gitops-workshop-request'].includes(formToDisplay)">
+      <div purpose="contact-form-switch" class="d-flex flex-sm-row flex-column justify-content-center mx-auto" v-if="(!userHasPremiumSubscription && !['apply', 'gitops-workshop-request'].includes(formToDisplay)) && !onlyShowTalkToUsForm">
         <div purpose="switch-option" :class="[formToDisplay === 'talk-to-us' ? 'selected' : '']" @click="clickSwitchForms('talk-to-us')">Get a demo</div>
         <div purpose="switch-option" :class="[formToDisplay === 'contact' ? 'selected' : '']" @click="clickSwitchForms('contact')">Send a message</div>
         <div purpose="switch" :class="formToDisplay+'-selected'"></div>
+      </div>
+      <div purpose="contact-form-switch" style="border: none;" v-else>
       </div>
       <div v-if="formToDisplay === 'contact'">
 

--- a/website/views/pages/customers.ejs
+++ b/website/views/pages/customers.ejs
@@ -210,7 +210,7 @@
         <h2 class="mx-auto">Manage all your devices like it's 2026</h2>
         </div>
         <div purpose="button-row" class="d-flex flex-sm-row flex-column justify-content-center align-items-center mx-auto">
-          <a purpose="cta-button" class="mr-0" href="/contact">Get a demo</a>
+          <a purpose="cta-button" class="mr-0" href="/contact?talkToUs">Get a demo</a>
           <!-- <animated-arrow-button href="/gitops-workshop">Join a workshop</animated-arrow-button> -->
         </div>
       </div>

--- a/website/views/pages/customers/new-license.ejs
+++ b/website/views/pages/customers/new-license.ejs
@@ -71,7 +71,7 @@
         </div>
         <div :class="[showBillingForm ? 'pt-2' : '' ]" v-if="!showBillingForm">
           <ajax-button purpose="submit-button" spinner="true" type="submit" :syncing="syncing" class="btn btn-block btn-lg btn-primary" v-if="!numberOfHostsQuoted">Continue</ajax-button>
-          <a spinner="true" purpose="submit-button" href="/contact" :syncing="syncing" class="btn btn-block btn-lg btn-primary" v-if="showQuotedPrice && numberOfHostsQuoted > 699"><span>Talk to us</span></a>
+          <a spinner="true" purpose="submit-button" href="/contact?talkToUs" :syncing="syncing" class="btn btn-block btn-lg btn-primary" v-if="showQuotedPrice && numberOfHostsQuoted > 699"><span>Talk to us</span></a>
           <ajax-button spinner="true" purpose="submit-button" :syncing="syncing" class="btn btn-block btn-lg btn-primary" v-if="showQuotedPrice && numberOfHostsQuoted < 700">Continue</ajax-button>
         </div>
       </ajax-form>

--- a/website/views/pages/deployment.ejs
+++ b/website/views/pages/deployment.ejs
@@ -11,7 +11,7 @@
             <p>Run Fleet the way that fits your team. Every deployment option includes the same features. The difference is who manages the infrastructure and where it runs.</p>
           </div>
           <div purpose="button-row" class="justify-content-center">
-            <a href="/contact" purpose="cta-button">Talk to us</a>
+            <a href="/contact?talkToUs" purpose="cta-button">Talk to us</a>
           </div>
         </div>
       </div><%/* page-hero */%>
@@ -106,7 +106,7 @@
                 <p>Fastest way to get started</p>
                 <p>Lowest operational overhead</p>
               </div>
-              <a purpose="cta-button" class="btn btn-primary" href="/contact" no-underline>Get started</a>
+              <a purpose="cta-button" class="btn btn-primary" href="/contact?talkToUs" no-underline>Get started</a>
             </div>
             <div purpose="details-card">
               <div >

--- a/website/views/pages/device-management.ejs
+++ b/website/views/pages/device-management.ejs
@@ -11,7 +11,7 @@
             <p>Configure, update, and secure macOS, Windows, <a href="/linux-management">Linux</a>, iOS, iPadOS, Android, and ChromeOS devices with one tool. Replace fragmented point solutions with a single platform your whole team can use.</p>
           </div>
           <div purpose="button-row" class="d-flex justify-content-start align-items-center">
-            <a purpose="cta-button" href="/contact">Get a demo</a>
+            <a purpose="cta-button" href="/contact?talkToUs">Get a demo</a>
             <animated-arrow-button href="/pricing">Compare features</animated-arrow-button>
           </div>
         </div>
@@ -274,7 +274,7 @@
               <p>Support regional privacy rules with configurable management controls.</p>
               <p>Set clear expectations about how to configure company devices.</p>
             </div>
-            <a purpose="section-button" href="/contact">Get a demo</a>
+            <a purpose="section-button" href="/contact?talkToUs">Get a demo</a>
           </div>
         </div>
       </div>
@@ -315,7 +315,7 @@
         <h4>Open device management</h4>
         <h1>Manage all your devices like it's 2026</h1>
         <div purpose="button-row" class="d-flex justify-content-center align-items-center mx-auto">
-          <a purpose="cta-button" href="/contact">Get a demo</a>
+          <a purpose="cta-button" href="/contact?talkToUs">Get a demo</a>
           <animated-arrow-button href="/pricing">View pricing</animated-arrow-button>
         </div>
       </div>

--- a/website/views/pages/docs/basic-documentation.ejs
+++ b/website/views/pages/docs/basic-documentation.ejs
@@ -35,7 +35,7 @@
           <a purpose="subpage-link" href="/docs/contributing" target="_blank" no-icon>Contribute</a>
           <a purpose="subpage-link" href="/releases" no-icon>Release notes</a>
           <a purpose="subpage-link" href="/support" no-icon>Support</a>
-          <a purpose="subpage-link" href="/contact">Get a demo</a>
+          <a purpose="subpage-link" href="/contact?talkToUs">Get a demo</a>
           <a purpose="subpage-link" href="/better">“Why is Fleet on my computer?”</a>
         </div>
         <div class="d-none d-lg-block left-cta" purpose="swag-cta" v-if="showSwagForm && ['REST API', 'Fleet server configuration'].includes(thisPage.title)">
@@ -144,7 +144,7 @@
       <a purpose="modal-nav-link" href="/docs/contributing" target="_blank" no-icon>Contribute</a>
       <a purpose="modal-nav-link" href="/releases" no-icon>Release notes</a>
       <a purpose="modal-nav-link" href="/support" no-icon>Support</a>
-      <a purpose="modal-nav-link" href="/contact">Get a demo</a>
+      <a purpose="modal-nav-link" href="/contact?talkToUs">Get a demo</a>
       <a purpose="modal-nav-link" href="/better">“Why is Fleet on my computer?”</a>
     </div>
   </modal>

--- a/website/views/pages/docs/command-details.ejs
+++ b/website/views/pages/docs/command-details.ejs
@@ -35,7 +35,7 @@
         <div purpose="right-sidebar" class="d-flex flex-column">
           <div purpose="docs-links" class="order-3">
             <a purpose="sidebar-link" target="_blank" :href="'https://github.com/fleetdm/fleet/edit/main/docs/mdm-commands.yml'+'#L'+thisCommand.lineNumberInYaml" no-icon> <img src="/images/icon-edit-16x16@2x.png" alt="Suggest an edit">Suggest an edit</a>
-            <a purpose="sidebar-link" href="/contact"><img alt="Talk to an engineer" src="/images/icon-contact-16x16@2x.png">Get a demo</a>
+            <a purpose="sidebar-link" href="/contact?talkToUs"><img alt="Talk to an engineer" src="/images/icon-contact-16x16@2x.png">Get a demo</a>
           </div>
         </div>
       </div>

--- a/website/views/pages/docs/report-details.ejs
+++ b/website/views/pages/docs/report-details.ejs
@@ -61,7 +61,7 @@
             </div>
             <div purpose="docs-links" class="order-3">
               <a purpose="sidebar-link" :href="'https://github.com/fleetdm/fleet/edit/main/'+reportLibraryYmlRepoPath+'#L'+report.lineNumberInYaml"> <img src="/images/icon-edit-16x16@2x.png" alt="Suggest an edit">Edit</a>
-              <a purpose="sidebar-link" href="/contact"><img alt="Talk to an engineer" src="/images/icon-contact-16x16@2x.png">Get a demo</a>
+              <a purpose="sidebar-link" href="/contact?talkToUs"><img alt="Talk to an engineer" src="/images/icon-contact-16x16@2x.png">Get a demo</a>
             </div>
           </div>
         </div>

--- a/website/views/pages/docs/script-details.ejs
+++ b/website/views/pages/docs/script-details.ejs
@@ -33,7 +33,7 @@
         <div purpose="right-sidebar" class="d-flex flex-column">
           <div purpose="docs-links" class="order-3">
             <a purpose="sidebar-link" target="_blank" href="https://github.com/fleetdm/fleet/tree/main/docs/scripts.yml" no-icon> <img src="/images/icon-edit-16x16@2x.png" alt="Suggest an edit">Edit</a>
-            <a purpose="sidebar-link" href="/contact"><img alt="Talk to an engineer" src="/images/icon-contact-16x16@2x.png">Get a demo</a>
+            <a purpose="sidebar-link" href="/contact?talkToUs"><img alt="Talk to an engineer" src="/images/icon-contact-16x16@2x.png">Get a demo</a>
           </div>
         </div>
       </div>

--- a/website/views/pages/fleet-premium-trial.ejs
+++ b/website/views/pages/fleet-premium-trial.ejs
@@ -410,7 +410,7 @@
           </p>
         </div>
         <div purpose="modal-alt-button-links">
-          <a purpose="modal-button" href="/contact" no-underline>
+          <a purpose="modal-button" href="/contact?talkToUs" no-underline>
             <img alt="Premium support" src="/images/icon-premium-support-64x64@2x.png">
             <h4>Have Fleet host it</h4>
             <p>Fleet Premium, fully managed.</p>

--- a/website/views/pages/homepage.ejs
+++ b/website/views/pages/homepage.ejs
@@ -16,7 +16,7 @@
             </h1>
             <p purpose="hero-subtitle">Open MDM, patching, and vuln management for every OS.</p>
             <div purpose="button-row" class="d-flex justify-content-start align-items-center">
-              <a purpose="cta-button" href="/contact">Get a demo</a>
+              <a purpose="cta-button" href="/contact?talkToUs">Get a demo</a>
               <animated-arrow-button href="#compare-features">Compare features</animated-arrow-button>
             </div>
           </div>
@@ -598,7 +598,7 @@
           </div>
         </h1>
         <div purpose="button-row" style="margin-top: 40px;" class="d-flex flex-sm-row flex-column justify-content-center align-items-center mx-auto">
-          <a purpose="cta-button" class="mr-0" href="/contact">Get a demo</a>
+          <a purpose="cta-button" class="mr-0" href="/contact?talkToUs">Get a demo</a>
           <!-- <animated-arrow-button href="/gitops-workshop">Free workshop</animated-arrow-button>-->
           <!-- <animated-arrow-button href="/pricing">View pricing</animated-arrow-button> -->
           <!-- <animated-arrow-button href="/try">Try it yourself</animated-arrow-button> -->

--- a/website/views/pages/infrastructure-as-code.ejs
+++ b/website/views/pages/infrastructure-as-code.ejs
@@ -8,7 +8,7 @@
         </div>
         <p>See every change, undo any error, repeat every success. Define your fleet in version-controlled YAML. Review changes in pull requests. Let Fleet enforce the desired state.</p>
         <div purpose="button-row">
-          <a purpose="cta-button" href="/contact">Get a demo</a>
+          <a purpose="cta-button" href="/contact?talkToUs">Get a demo</a>
           <animated-arrow-button href="/gitops-workshop">Free in-person workshop</animated-arrow-button>
         </div>
       </div>
@@ -529,7 +529,7 @@
           <h2>Infrastructure as code for device management</h2>
         </div>
         <div purpose="button-row">
-          <a purpose="cta-button" href="/contact">Get a demo</a>
+          <a purpose="cta-button" href="/contact?talkToUs">Get a demo</a>
           <animated-arrow-button href="/gitops-workshop">Free in-person workshop</animated-arrow-button>
         </div>
       </div>

--- a/website/views/pages/landing-pages/android-mdm.ejs
+++ b/website/views/pages/landing-pages/android-mdm.ejs
@@ -12,7 +12,7 @@
               <p>Enroll, configure, and secure Android phones and tablets at enterprise scale. Manage Android alongside macOS, iOS, iPadOS, Windows, Linux, and ChromeOS in one place.</p>
             </div>
             <div purpose="button-row">
-              <a purpose="cta-button" class="btn btn-primary" href="/contact">Get a demo</a>
+              <a purpose="cta-button" class="btn btn-primary" href="/contact?talkToUs">Get a demo</a>
               <animated-arrow-button href="/gitops-workshop">Join a workshop</animated-arrow-button>
             </div>
           </div>
@@ -195,7 +195,7 @@
         <h4>Android Device Management</h4>
         <h2>Modern, open source MDM for every Android device</h2>
         <div purpose="button-row" style="margin-top: 32px;" class="d-flex justify-content-center align-items-center mx-auto">
-          <a purpose="cta-button" class="btn btn-primary" href="/contact">Get a demo</a>
+          <a purpose="cta-button" class="btn btn-primary" href="/contact?talkToUs">Get a demo</a>
           <animated-arrow-button href="/gitops-workshop">Join a workshop</animated-arrow-button>
         </div>
       </div>

--- a/website/views/pages/landing-pages/apple-mdm.ejs
+++ b/website/views/pages/landing-pages/apple-mdm.ejs
@@ -12,7 +12,7 @@
               <p>Enroll, configure, and secure Mac, iPhone, and iPad at enterprise scale. Manage Apple alongside Windows, Linux, Android, and ChromeOS in one place.</p>
             </div>
             <div purpose="button-row">
-              <a purpose="cta-button" class="btn btn-primary" href="/contact">Get a demo</a>
+              <a purpose="cta-button" class="btn btn-primary" href="/contact?talkToUs">Get a demo</a>
               <animated-arrow-button href="/gitops-workshop">Join a workshop</animated-arrow-button>
             </div>
           </div>
@@ -205,7 +205,7 @@
         <h4>Apple Device Management</h4>
         <h2>Modern, open source MDM for every Mac</h2>
         <div purpose="button-row" style="margin-top: 32px;" class="d-flex justify-content-center align-items-center mx-auto">
-          <a purpose="cta-button" class="btn btn-primary" href="/contact">Get a demo</a>
+          <a purpose="cta-button" class="btn btn-primary" href="/contact?talkToUs">Get a demo</a>
           <animated-arrow-button href="/gitops-workshop">Join a workshop</animated-arrow-button>
         </div>
       </div>

--- a/website/views/pages/landing-pages/open-source.ejs
+++ b/website/views/pages/landing-pages/open-source.ejs
@@ -429,7 +429,7 @@
         <p>The free version of Fleet will always be free. Spin it up in your homelab or deploy it across your organization.</p>
         <div purpose="button-row" style="margin-top: 32px;" class="d-flex justify-content-center align-items-center mx-auto">
           <a purpose="cta-button" class="btn btn-primary" href="/pricing">Get started</a>
-          <animated-arrow-button href="/contact">Get a demo</animated-arrow-button>
+          <animated-arrow-button href="/contact?talkToUs">Get a demo</animated-arrow-button>
         </div>
       </div>
     </div>

--- a/website/views/pages/landing-pages/replace-jamf.ejs
+++ b/website/views/pages/landing-pages/replace-jamf.ejs
@@ -11,7 +11,7 @@
         </div>
         <%// gap %>
         <div purpose="button-row">
-            <a purpose="cta-button" href="/contact">Get a demo</a>
+            <a purpose="cta-button" href="/contact?talkToUs">Get a demo</a>
             <animated-arrow-button href="/gitops-workshop">Join a workshop</animated-arrow-button>
         </div>
         <%// gap %>

--- a/website/views/pages/landing-pages/windows-mdm.ejs
+++ b/website/views/pages/landing-pages/windows-mdm.ejs
@@ -12,7 +12,7 @@
               <p>Enroll, configure, and secure Windows 10 and 11 at enterprise scale. Manage Windows alongside macOS, Linux, iOS, iPadOS, Android, and ChromeOS in one place.</p>
             </div>
             <div purpose="button-row">
-              <a purpose="cta-button" class="btn btn-primary" href="/contact">Get a demo</a>
+              <a purpose="cta-button" class="btn btn-primary" href="/contact?talkToUs">Get a demo</a>
               <animated-arrow-button href="/gitops-workshop">Join a workshop</animated-arrow-button>
             </div>
           </div>
@@ -404,7 +404,7 @@
         <h4>Windows Device Management</h4>
         <h2>Modern, open source MDM for every Windows device</h2>
         <div purpose="button-row" style="margin-top: 32px;" class="d-flex justify-content-center align-items-center mx-auto">
-          <a purpose="cta-button" class="btn btn-primary" href="/contact">Get a demo</a>
+          <a purpose="cta-button" class="btn btn-primary" href="/contact?talkToUs">Get a demo</a>
           <animated-arrow-button href="/gitops-workshop">Join a workshop</animated-arrow-button>
         </div>
       </div>

--- a/website/views/pages/linux-management.ejs
+++ b/website/views/pages/linux-management.ejs
@@ -167,7 +167,7 @@
           <h2>Visibility and control</h2>
           <p>Manage Linux with the depth you'd expect from your macOS and Windows tools, from software and compliance to remote lock and wipe.</p>
           <div purpose="button-row">
-          <a purpose="cta-button" class="btn btn-primary" href="/contact">Talk to an engineer</a>
+          <a purpose="cta-button" class="btn btn-primary" href="/contact?talkToUs">Talk to an engineer</a>
           </div>
         </div>
         <div purpose="feature-with-image-row">

--- a/website/views/pages/linux-management.ejs
+++ b/website/views/pages/linux-management.ejs
@@ -378,7 +378,7 @@
           <h1>No more Linux blindspots for IT teams</h1>
         </div>
         <div purpose="button-row" class="d-flex justify-content-center align-items-center mx-auto">
-          <a purpose="cta-button" class="btn btn-primary" href="/contact">Get a demo</a>
+          <a purpose="cta-button" class="btn btn-primary" href="/contact?talkToUs">Get a demo</a>
           <animated-arrow-button href="/docs">Read the docs</animated-arrow-button>
         </div>
       </div>

--- a/website/views/pages/pricing.ejs
+++ b/website/views/pages/pricing.ejs
@@ -69,7 +69,7 @@
                 </div>
               </div>
               <div>
-                <a purpose="card-button" class="btn btn-block btn-lg btn-primary mx-auto mb-0" href="/contact">Talk to sales</a>
+                <a purpose="card-button" class="btn btn-block btn-lg btn-primary mx-auto mb-0" href="/contact?talkToUs">Talk to sales</a>
               </div>
             </div>
           </div>

--- a/website/views/pages/reports/state-of-device-management.ejs
+++ b/website/views/pages/reports/state-of-device-management.ejs
@@ -331,7 +331,7 @@
           <p>Get up and running with a test environment of Fleet within minutes</p>
         </div>
         <div purpose="cta-btns" class="mx-auto d-flex flex-sm-row flex-column justify-content-center">
-          <a purpose="get-started-btn" class="d-sm-flex align-items-center justify-content-center btn btn-primary mx-auto mr-sm-4 ml-sm-0" href="/contact">Get a demo</a>
+          <a purpose="get-started-btn" class="d-sm-flex align-items-center justify-content-center btn btn-primary mx-auto mr-sm-4 ml-sm-0" href="/contact?talkToUs">Get a demo</a>
           <a purpose="animated-arrow-btn-red" style="max-width: 220px;" class="btn btn-lg btn-white mr-2 pl-0 mx-auto mx-sm-0 mt-2 mt-sm-0" href="/register">Try it out
           </a>
         </div>
@@ -543,7 +543,7 @@
               <p>Fortune 1,000 companies use Fleet to keep their<br class="d-none d-sm-block"> MacOS, Windows, and Linux devices secure and compliant.</p>
             </div>
             <div purpose="cta-btns" class="mx-auto d-flex flex-sm-row flex-column justify-content-center">
-              <a purpose="get-started-btn" class="d-sm-flex align-items-center justify-content-center btn btn-primary mx-auto mr-sm-4 ml-sm-0" href="/contact">Get a demo</a>
+              <a purpose="get-started-btn" class="d-sm-flex align-items-center justify-content-center btn btn-primary mx-auto mr-sm-4 ml-sm-0" href="/contact?talkToUs">Get a demo</a>
               <a purpose="animated-arrow-btn-red" style="max-width: 220px;" class="btn btn-lg mr-2 pl-0 mx-auto mx-sm-0 mt-2 mt-sm-0" href="/register">Try it out
               </a>
             </div>

--- a/website/views/pages/security-and-control.ejs
+++ b/website/views/pages/security-and-control.ejs
@@ -10,7 +10,7 @@
           <p>Get instant visibility into every plugin, extension, plugin, app, and package across your devices. Set policies for what's allowed, and let Fleet enforce them automatically, from detection to remediation.</p>
         </div>
         <div purpose="button-row">
-          <a purpose="cta-button" href="/contact">Get a demo</a>
+          <a purpose="cta-button" href="/contact?talkToUs">Get a demo</a>
           <animated-arrow-button href="/pricing">Compare features</animated-arrow-button>
         </div>
       </div>
@@ -410,7 +410,7 @@
             <h1>Control what belongs on every device</h1>
           </div>
           <div purpose="button-row">
-            <a purpose="cta-button" href="/contact">Get a demo</a>
+            <a purpose="cta-button" href="/contact?talkToUs">Get a demo</a>
             <animated-arrow-button href="/pricing">View pricing</animated-arrow-button>
           </div>
         </div>

--- a/website/views/pages/security-and-control.ejs
+++ b/website/views/pages/security-and-control.ejs
@@ -331,7 +331,7 @@
           <div purpose="feature-text">
             <h2>Vulnerability response, built in</h2>
             <p>Fleet's vulnerability response is part of the same platform you use to manage devices. No separate tool, no separate workflow.</p>
-            <animated-arrow-button href="/contact">Talk to an engineer</animated-arrow-button>
+            <animated-arrow-button href="/contact?talkToUs">Talk to an engineer</animated-arrow-button>
           </div>
         </div>
         <div purpose="three-column-features">

--- a/website/views/pages/software-management.ejs
+++ b/website/views/pages/software-management.ejs
@@ -10,7 +10,7 @@
           Deploy software from a built-in catalog or upload your own packages. Fleet checks every device continuously and installs updates automatically.
         </p>
         <div purpose="button-row" class="d-flex justify-content-start">
-          <a purpose="cta-button" href="/contact">Get a demo</a>
+          <a purpose="cta-button" href="/contact?talkToUs">Get a demo</a>
           <animated-arrow-button href="/pricing">Compare features</animated-arrow-button>
         </div>
       </div>
@@ -270,7 +270,7 @@
               Get new macOS, Windows, and Linux devices ready without manual intervention and let end users help themselves.
             </p>
             <div purpose="button-row">
-              <a purpose="cta-button" href="/contact">Get a demo</a>
+              <a purpose="cta-button" href="/contact?talkToUs">Get a demo</a>
               <animated-arrow-button href="/guides/setup-experience">Preview setup experience</animated-arrow-button>
             </div>
           </div>
@@ -370,7 +370,7 @@
             <h1>Patch faster on any OS</h1>
           </div>
           <div purpose="button-row">
-            <a purpose="cta-button" href="/contact">Get a demo</a>
+            <a purpose="cta-button" href="/contact?talkToUs">Get a demo</a>
             <animated-arrow-button href="/try">Try it yourself</animated-arrow-button>
           </div>
         </div>

--- a/website/views/pages/visibility-and-reporting.ejs
+++ b/website/views/pages/visibility-and-reporting.ejs
@@ -275,7 +275,7 @@
             <h1>See every device in seconds</h1>
           </div>
           <div purpose="button-row">
-            <a purpose="cta-button" href="/contact">Talk to an engineer</a>
+            <a purpose="cta-button" href="/contact?talkToUs">Talk to an engineer</a>
             <animated-arrow-button href="/pricing">View pricing</animated-arrow-button>
           </div>
         </div>

--- a/website/views/pages/visibility-and-reporting.ejs
+++ b/website/views/pages/visibility-and-reporting.ejs
@@ -10,7 +10,7 @@
           <p>Fleet maintains a live connection to every device, from laptops to servers. Get answers in real time, diagnose issues without relying on end users, and prove compliance on demand.</p>
         </div>
         <div purpose="button-row">
-          <a purpose="cta-button" href="/contact">Get a demo</a>
+          <a purpose="cta-button" href="/contact?talkToUs">Get a demo</a>
           <animated-arrow-button href="/try">Try it yourself</animated-arrow-button>
         </div>
       </div>


### PR DESCRIPTION
Closes:  https://github.com/fleetdm/fleet/issues/47653

Changes:
- Updated the contact page to only display the "Talk to us" form if a user visits it with a `?talkToUs` query string.
- Updated all "Get a demo" buttons to go to `/contact?talkToUs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated “Talk to us” contact experience.
  * Updated “Get a demo,” “Talk to sales,” and “Talk to an engineer” links across the site to open the appropriate contact form directly.
* **Bug Fixes**
  * Improved contact form selection so the requested form displays consistently across supported pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->