### PR TITLE
Website: replace purple link icon

### DIFF
--- a/website/assets/styles/pages/articles/basic-article.less
+++ b/website/assets/styles/pages/articles/basic-article.less
@@ -14,7 +14,7 @@
       height: 16px;
       vertical-align: middle;
       margin-left: 8px;
-      content: url('/images/icon-link-16x16@2x.png');
+      content: url('/images/icon-link-green-16x16@2x.png');
     }
   }
 

--- a/website/assets/styles/pages/articles/basic-whitepaper.less
+++ b/website/assets/styles/pages/articles/basic-whitepaper.less
@@ -13,7 +13,7 @@
       height: 16px;
       vertical-align: middle;
       margin-left: 8px;
-      content: url('/images/icon-link-16x16@2x.png');
+      content: url('/images/icon-link-green-16x16@2x.png');
     }
   }
 

--- a/website/assets/styles/pages/legal/privacy.less
+++ b/website/assets/styles/pages/legal/privacy.less
@@ -13,7 +13,7 @@
       height: 16px;
       vertical-align: middle;
       margin-left: 8px;
-      content: url('/images/icon-link-16x16@2x.png');
+      content: url('/images/icon-link-green-16x16@2x.png');
     }
   }
 

--- a/website/assets/styles/pages/legal/terms.less
+++ b/website/assets/styles/pages/legal/terms.less
@@ -13,7 +13,7 @@
       height: 16px;
       vertical-align: middle;
       margin-left: 8px;
-      content: url('/images/icon-link-16x16@2x.png');
+      content: url('/images/icon-link-green-16x16@2x.png');
     }
   }
 


### PR DESCRIPTION
Closes: https://github.com/fleetdm/fleet/issues/49885

Changes:
- Replaced the icon shown when hovering over headings on pages built from Markdown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated heading link hover icons across article and legal pages to use the green link icon for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->