### PR TITLE
Consistent URL/email on-blur validation across forms (#40410 follow-up)

### DIFF
--- a/changes/40410-consistent-form-validation-onblur.md
+++ b/changes/40410-consistent-form-validation-onblur.md
@@ -1,0 +1,1 @@
+- Made form validation consistent across more forms (#40410 follow-up): validation errors now appear when leaving a field (on blur) and no longer appear before any input. This covers the policy automations "Other workflows" Destination URL, the add/edit user Email field, and the host status webhook Destination URL (both global settings and fleet settings).

--- a/frontend/pages/admin/IntegrationsPage/cards/GlobalHostStatusWebhook/GlobalHostStatusWebhook.tests.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/GlobalHostStatusWebhook/GlobalHostStatusWebhook.tests.tsx
@@ -1,0 +1,113 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import { renderWithSetup, createMockRouter } from "test/test-utils";
+
+import createMockConfig from "__mocks__/configMock";
+
+import GlobalHostStatusWebhook from "./GlobalHostStatusWebhook";
+
+const REQUIRED_URL_ERROR = "Destination URL must be present";
+const INVALID_URL_ERROR = "Destination URL is not a valid URL";
+const URL_PLACEHOLDER = "https://server.com/example";
+const ENABLE_LABEL = "Enable host status webhook";
+
+const baseConfig = createMockConfig();
+
+// The webhook starts disabled with an empty URL so we can exercise enabling it.
+const disabledWebhookConfig = {
+  ...baseConfig,
+  webhook_settings: {
+    ...baseConfig.webhook_settings,
+    host_status_webhook: {
+      enable_host_status_webhook: false,
+      destination_url: "",
+      host_percentage: 1,
+      days_count: 1,
+    },
+  },
+};
+
+const renderCard = (handleSubmit = jest.fn()) => {
+  const utils = renderWithSetup(
+    <GlobalHostStatusWebhook
+      appConfig={disabledWebhookConfig}
+      handleSubmit={handleSubmit}
+      isUpdatingSettings={false}
+      router={createMockRouter()}
+    />
+  );
+  return { ...utils, handleSubmit };
+};
+
+describe("GlobalHostStatusWebhook - Destination URL validation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("does not show an error when the webhook is first enabled (#40410)", async () => {
+    const { user } = renderCard();
+
+    await user.click(screen.getByText(ENABLE_LABEL));
+
+    expect(screen.getByPlaceholderText(URL_PLACEHOLDER)).toBeInTheDocument();
+    expect(screen.queryByText(REQUIRED_URL_ERROR)).not.toBeInTheDocument();
+    expect(screen.queryByText(INVALID_URL_ERROR)).not.toBeInTheDocument();
+  });
+
+  it("shows an error when the URL field is blurred while empty", async () => {
+    const { user } = renderCard();
+
+    await user.click(screen.getByText(ENABLE_LABEL));
+    await user.click(screen.getByPlaceholderText(URL_PLACEHOLDER));
+    await user.tab();
+
+    expect(await screen.findByText(REQUIRED_URL_ERROR)).toBeInTheDocument();
+  });
+
+  it("shows an error when the URL field is blurred with an invalid URL", async () => {
+    const { user } = renderCard();
+
+    await user.click(screen.getByText(ENABLE_LABEL));
+    await user.type(screen.getByPlaceholderText(URL_PLACEHOLDER), "not-a-url");
+    await user.tab();
+
+    expect(await screen.findByText(INVALID_URL_ERROR)).toBeInTheDocument();
+  });
+
+  it("clears the error once a URL is entered", async () => {
+    const { user } = renderCard();
+
+    await user.click(screen.getByText(ENABLE_LABEL));
+    const urlInput = screen.getByPlaceholderText(URL_PLACEHOLDER);
+    await user.click(urlInput);
+    await user.tab();
+    expect(await screen.findByText(REQUIRED_URL_ERROR)).toBeInTheDocument();
+
+    await user.type(urlInput, "https://example.com");
+
+    expect(screen.queryByText(REQUIRED_URL_ERROR)).not.toBeInTheDocument();
+  });
+
+  it("blocks submit and shows an error when the URL is empty", async () => {
+    const { user, handleSubmit } = renderCard();
+
+    await user.click(screen.getByText(ENABLE_LABEL));
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(await screen.findByText(REQUIRED_URL_ERROR)).toBeInTheDocument();
+    expect(handleSubmit).not.toHaveBeenCalled();
+  });
+
+  it("submits when the URL is valid", async () => {
+    const { user, handleSubmit } = renderCard();
+
+    await user.click(screen.getByText(ENABLE_LABEL));
+    await user.type(
+      screen.getByPlaceholderText(URL_PLACEHOLDER),
+      "https://example.com"
+    );
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(handleSubmit).toHaveBeenCalled();
+  });
+});

--- a/frontend/pages/admin/IntegrationsPage/cards/GlobalHostStatusWebhook/GlobalHostStatusWebhook.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/GlobalHostStatusWebhook/GlobalHostStatusWebhook.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from "react";
+import React, { useState, useMemo } from "react";
 
 import { IInputFieldParseTarget } from "interfaces/form_field";
 import {
@@ -73,7 +73,7 @@ const GlobalHostStatusWebhook = ({
     setFormErrors({});
   };
 
-  const validateForm = () => {
+  const getFormErrors = (): IGlobalHostStatusWebhookFormErrors => {
     const errors: IGlobalHostStatusWebhookFormErrors = {};
 
     if (enableHostStatusWebhook) {
@@ -84,12 +84,14 @@ const GlobalHostStatusWebhook = ({
       }
     }
 
-    setFormErrors(errors);
+    return errors;
   };
 
-  useEffect(() => {
-    validateForm();
-  }, [enableHostStatusWebhook]);
+  // Runs on blur only — enabling the webhook must not surface an error before
+  // the user has had a chance to enter a URL (#40410).
+  const validateForm = () => {
+    setFormErrors(getFormErrors());
+  };
 
   const toggleHostStatusWebhookPreviewModal = () => {
     setShowHostStatusWebhookPreviewModal(!showHostStatusWebhookPreviewModal);
@@ -98,6 +100,12 @@ const GlobalHostStatusWebhook = ({
 
   const onFormSubmit = (evt: React.MouseEvent<HTMLFormElement>) => {
     evt.preventDefault();
+
+    const errors = getFormErrors();
+    setFormErrors(errors);
+    if (Object.keys(errors).length > 0) {
+      return;
+    }
 
     // Formatting of API not UI
     const formDataToSubmit = {

--- a/frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/TeamSettings/TeamSettings.tests.tsx
+++ b/frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/TeamSettings/TeamSettings.tests.tsx
@@ -1,0 +1,149 @@
+import React from "react";
+import { screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+
+import mockServer from "test/mock-server";
+import {
+  baseUrl,
+  createCustomRenderer,
+  createMockRouter,
+  createMockLocation,
+} from "test/test-utils";
+import { createGetConfigHandler } from "test/handlers/config-handlers";
+import createMockUser from "__mocks__/userMock";
+import { createMockTeamSummary } from "__mocks__/teamMock";
+import teamsAPI from "services/entities/teams";
+
+import TeamSettings from "./TeamSettings";
+
+const URL_ERROR = /valid webhook destination URL/i;
+const REQUIRED_URL_ERROR = /Please enter a valid webhook destination URL/i;
+const HOST_EXPIRY_ERROR = /Host expiry window must be a positive number/i;
+const ENABLE_WEBHOOK = "Enable host status webhook";
+const ENABLE_HOST_EXPIRY = "Enable host expiry";
+const URL_PLACEHOLDER = "https://server.com/example";
+
+const disabledWebhook = {
+  enable_host_status_webhook: false,
+  destination_url: "",
+  host_percentage: 1,
+  days_count: 1,
+};
+
+const renderTeamSettings = (hostStatusWebhook = disabledWebhook) => {
+  mockServer.use(
+    createGetConfigHandler(),
+    // teamsAPI.load(1) -> GET /api/latest/fleet/fleets/1; component does select: (d) => d.team
+    http.get(baseUrl("/fleets/:id"), () =>
+      HttpResponse.json({
+        team: {
+          id: 1,
+          name: "Team 1",
+          host_expiry_settings: {
+            host_expiry_enabled: false,
+            host_expiry_window: 0,
+          },
+          webhook_settings: { host_status_webhook: hostStatusWebhook },
+          features: {
+            historical_data: { uptime: true, vulnerabilities: true },
+          },
+        },
+      })
+    )
+  );
+
+  const render = createCustomRenderer({
+    withBackendMock: true,
+    context: {
+      app: {
+        isPremiumTier: true,
+        isGlobalAdmin: true,
+        isOnGlobalTeam: true,
+        currentUser: createMockUser({ global_role: "admin" }),
+        availableTeams: [createMockTeamSummary({ id: 1, name: "Team 1" })],
+        setCurrentTeam: jest.fn(),
+      },
+    },
+  });
+
+  return render(
+    <TeamSettings
+      location={createMockLocation({
+        pathname: "/settings/teams/settings",
+        search: "?fleet_id=1",
+        query: { fleet_id: "1" },
+      })}
+      router={createMockRouter()}
+    />
+  );
+};
+
+describe("TeamSettings - host status webhook validation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("does not show a URL error when the webhook is enabled (#40410)", async () => {
+    const { user } = renderTeamSettings();
+    await screen.findByText("Webhook settings");
+
+    await user.click(screen.getByText(ENABLE_WEBHOOK));
+
+    expect(screen.getByPlaceholderText(URL_PLACEHOLDER)).toBeInTheDocument();
+    expect(screen.queryByText(URL_ERROR)).not.toBeInTheDocument();
+  });
+
+  it("shows a URL error when the field is blurred while empty", async () => {
+    const { user } = renderTeamSettings();
+    await screen.findByText("Webhook settings");
+
+    await user.click(screen.getByText(ENABLE_WEBHOOK));
+    await user.click(screen.getByPlaceholderText(URL_PLACEHOLDER));
+    await user.tab();
+
+    expect(await screen.findByText(REQUIRED_URL_ERROR)).toBeInTheDocument();
+  });
+
+  it("blocks submit and shows an error when the URL is empty", async () => {
+    const updateSpy = jest
+      .spyOn(teamsAPI, "update")
+      .mockResolvedValue({} as never);
+    const { user } = renderTeamSettings();
+    await screen.findByText("Webhook settings");
+
+    await user.click(screen.getByText(ENABLE_WEBHOOK));
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(await screen.findByText(REQUIRED_URL_ERROR)).toBeInTheDocument();
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it("clears the error and submits once a valid URL is entered", async () => {
+    const updateSpy = jest
+      .spyOn(teamsAPI, "update")
+      .mockResolvedValue({} as never);
+    const { user } = renderTeamSettings();
+    await screen.findByText("Webhook settings");
+
+    await user.click(screen.getByText(ENABLE_WEBHOOK));
+    await user.type(
+      screen.getByPlaceholderText(URL_PLACEHOLDER),
+      "https://example.com/hook"
+    );
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(updateSpy).toHaveBeenCalled());
+    expect(screen.queryByText(URL_ERROR)).not.toBeInTheDocument();
+  });
+
+  // Regression: suppressing the webhook URL error on change must not disable
+  // host-expiry on-change validation.
+  it("still validates the host expiry window on change", async () => {
+    const { user } = renderTeamSettings();
+    await screen.findByText("Webhook settings");
+
+    await user.click(screen.getByText(ENABLE_HOST_EXPIRY));
+
+    expect(await screen.findByText(HOST_EXPIRY_ERROR)).toBeInTheDocument();
+  });
+});

--- a/frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/TeamSettings/TeamSettings.tsx
+++ b/frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/TeamSettings/TeamSettings.tsx
@@ -242,12 +242,28 @@ const TeamSettings = ({ location, router }: ITeamSubnavProps) => {
       const { name, value } = newVal;
       const newFormData = { ...formData, [name]: value };
       setFormData(newFormData);
-      setFormErrors(
-        validateTeamSettingsFormData(globalHostExpiryEnabled, newFormData)
-      );
+      setFormErrors((prev) => {
+        const next = validateTeamSettingsFormData(
+          globalHostExpiryEnabled,
+          newFormData
+        );
+        // The webhook URL error should appear on blur/submit, not while the
+        // user is enabling the webhook or typing (#40410). Carry it forward
+        // only if it was already shown.
+        if (!prev.host_status_webhook_destination_url) {
+          delete next.host_status_webhook_destination_url;
+        }
+        return next;
+      });
     },
     [formData, globalHostExpiryEnabled]
   );
+
+  const onHostStatusWebhookUrlBlur = () => {
+    setFormErrors(
+      validateTeamSettingsFormData(globalHostExpiryEnabled, formData)
+    );
+  };
 
   const datasetsBeingDisabled = useMemo<HistoricalDataConfigKey[]>(() => {
     const list: HistoricalDataConfigKey[] = [];
@@ -331,13 +347,23 @@ const TeamSettings = ({ location, router }: ITeamSubnavProps) => {
   const updateTeamSettings = useCallback(
     (evt: React.MouseEvent<HTMLFormElement>) => {
       evt.preventDefault();
+      // Validate on submit since the webhook URL error is suppressed on change
+      // until the field is blurred (#40410) — don't let an invalid/empty URL save.
+      const errors = validateTeamSettingsFormData(
+        globalHostExpiryEnabled,
+        formData
+      );
+      setFormErrors(errors);
+      if (Object.keys(errors).length > 0) {
+        return;
+      }
       if (datasetsBeingDisabled.length > 0) {
         setConfirmModalOpen(true);
         return;
       }
       performSave();
     },
-    [datasetsBeingDisabled, performSave]
+    [datasetsBeingDisabled, performSave, globalHostExpiryEnabled, formData]
   );
 
   const renderForm = () => {
@@ -379,6 +405,7 @@ const TeamSettings = ({ location, router }: ITeamSubnavProps) => {
               name="teamHostStatusWebhookDestinationUrl"
               value={formData.teamHostStatusWebhookDestinationUrl}
               parseTarget
+              onBlur={onHostStatusWebhookUrlBlur}
               error={formErrors.host_status_webhook_destination_url}
               disabled={gitopsModeEnabled}
               tooltip={

--- a/frontend/pages/admin/ManageUsersPage/components/UserForm/UserForm.tests.tsx
+++ b/frontend/pages/admin/ManageUsersPage/components/UserForm/UserForm.tests.tsx
@@ -95,6 +95,51 @@ describe("UserForm - component", () => {
     ).not.toBeInTheDocument();
   });
 
+  // #40410: blurring one field must not surface errors on fields the user has
+  // not yet touched (previously, blurring the autofocused Name field flagged the
+  // empty Email and Password fields).
+  it("does not surface an Email error when only the Name field is blurred", async () => {
+    const { user } = renderWithSetup(<UserForm {...defaultProps} />);
+
+    await user.click(screen.getByLabelText("Full name"));
+    await user.tab();
+
+    expect(
+      screen.queryByText("Email field must be completed")
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Password field must be completed")
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the Email error after the Email field is blurred", async () => {
+    const { user } = renderWithSetup(<UserForm {...defaultProps} />);
+
+    await user.click(screen.getByLabelText("Email"));
+    await user.tab();
+
+    expect(
+      screen.getByText("Email field must be completed")
+    ).toBeInTheDocument();
+  });
+
+  it("clears the Email error once a valid email is entered", async () => {
+    const { user } = renderWithSetup(<UserForm {...defaultProps} />);
+
+    const emailField = screen.getByLabelText("Email");
+    await user.click(emailField);
+    await user.tab();
+    expect(
+      screen.getByText("Email field must be completed")
+    ).toBeInTheDocument();
+
+    await user.type(emailField, "user@example.com");
+
+    expect(
+      screen.queryByText("Email field must be completed")
+    ).not.toBeInTheDocument();
+  });
+
   it("displays disabled SSO option when SSO is globally disabled but was previously enabled for the user", async () => {
     const props = {
       ...defaultProps,

--- a/frontend/pages/admin/ManageUsersPage/components/UserForm/UserForm.tsx
+++ b/frontend/pages/admin/ManageUsersPage/components/UserForm/UserForm.tsx
@@ -216,16 +216,34 @@ const UserForm = ({
     setFormErrors(errsToSet);
   };
 
-  const onInputBlur = () => {
-    setFormErrors(
-      validate(
-        formData,
-        canUseSso,
-        isNewUser,
-        !!isSsoEnabled,
-        initiallyPasswordAuth
-      )
+  const onInputBlur = (evt: React.FocusEvent<HTMLElement>) => {
+    // Validate only the field being blurred, not the whole form — otherwise
+    // blurring the autofocused Name field would surface errors on Email and
+    // Password before the user has touched them (#40410). Controls without a
+    // named target (e.g. the MFA checkbox wrapper) have nothing to validate.
+    const name = (evt.target as HTMLInputElement).name;
+    if (!name) {
+      return;
+    }
+    const newErrs = validate(
+      formData,
+      canUseSso,
+      isNewUser,
+      !!isSsoEnabled,
+      initiallyPasswordAuth
     );
+    setFormErrors((curErrs) => {
+      const next = { ...curErrs };
+      // @ts-ignore — dynamic field key (matches onInputChange above)
+      if (newErrs[name]) {
+        // @ts-ignore
+        next[name] = newErrs[name];
+      } else {
+        // @ts-ignore
+        delete next[name];
+      }
+      return next;
+    });
   };
 
   const onRadioChange = (formField: string): ((evt: string) => void) => {
@@ -318,12 +336,8 @@ const UserForm = ({
   const onFormSubmit = (evt: FormEvent): void => {
     evt.preventDefault();
 
-    // separate from `validate` function as it renders a toast notification, incompatible with
-    // pure `validate` function
-    if (!formData.global_role && !formData.teams.length) {
-      notify.error(`Please select at least one fleet for this user.`);
-      return;
-    }
+    // Validate all fields on submit so every field error is surfaced at once.
+    // (Field errors otherwise only appear on that field's blur — #40410.)
     const errs = validate(
       formData,
       canUseSso,
@@ -333,6 +347,12 @@ const UserForm = ({
     );
     if (Object.keys(errs).length > 0) {
       setFormErrors(errs);
+      return;
+    }
+    // separate from `validate` function as it renders a toast notification, incompatible with
+    // pure `validate` function
+    if (!formData.global_role && !formData.teams.length) {
+      notify.error(`Please select at least one fleet for this user.`);
       return;
     }
     onSubmit(addSubmitData());
@@ -747,7 +767,6 @@ const UserForm = ({
             className={`${isNewUser ? "add" : "save"}-loading
           `}
             isLoading={isUpdatingUsers}
-            disabled={Object.keys(formErrors).length > 0}
           >
             {isNewUser ? "Add" : "Save"}
           </Button>

--- a/frontend/pages/policies/ManagePoliciesPage/components/AutomationsModal/components/OtherWorkflowsModal/OtherWorkflowsModal.tests.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/AutomationsModal/components/OtherWorkflowsModal/OtherWorkflowsModal.tests.tsx
@@ -1,0 +1,100 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import { renderWithSetup, createMockRouter } from "test/test-utils";
+
+import { IAutomationsConfig } from "interfaces/config";
+import { IGlobalIntegrations } from "interfaces/integration";
+import createMockConfig from "__mocks__/configMock";
+
+import OtherWorkflowsModal from "./OtherWorkflowsModal";
+
+const INVALID_URL_ERROR = "Destination URL is not a valid URL";
+const REQUIRED_URL_ERROR = "Please add a destination URL";
+const URL_PLACEHOLDER = "https://server.com/example";
+
+const baseConfig = createMockConfig();
+
+// Webhook automations enabled + empty URL so the Destination URL field renders
+// and is editable.
+const automationsConfig = ({
+  webhook_settings: {
+    ...baseConfig.webhook_settings,
+    failing_policies_webhook: {
+      ...baseConfig.webhook_settings.failing_policies_webhook,
+      enable_failing_policies_webhook: true,
+      destination_url: "",
+    },
+  },
+  integrations: { jira: [], zendesk: [], google_calendar: null },
+} as unknown) as IAutomationsConfig;
+
+const availableIntegrations = ({
+  jira: [],
+  zendesk: [],
+} as unknown) as IGlobalIntegrations;
+
+const renderModal = () =>
+  renderWithSetup(
+    <OtherWorkflowsModal
+      router={createMockRouter()}
+      automationsConfig={automationsConfig}
+      availableIntegrations={availableIntegrations}
+    />
+  );
+
+describe("OtherWorkflowsModal - Destination URL validation", () => {
+  it("does not show a validation error on open", () => {
+    renderModal();
+
+    expect(screen.getByPlaceholderText(URL_PLACEHOLDER)).toBeInTheDocument();
+    expect(screen.queryByText(INVALID_URL_ERROR)).not.toBeInTheDocument();
+    expect(screen.queryByText(REQUIRED_URL_ERROR)).not.toBeInTheDocument();
+  });
+
+  it("shows an error when blurred with an invalid URL", async () => {
+    const { user } = renderModal();
+
+    await user.type(
+      screen.getByPlaceholderText(URL_PLACEHOLDER),
+      "not-a-valid-url"
+    );
+    await user.tab();
+
+    expect(await screen.findByText(INVALID_URL_ERROR)).toBeInTheDocument();
+  });
+
+  it("shows a required error when blurred while empty", async () => {
+    const { user } = renderModal();
+
+    await user.click(screen.getByPlaceholderText(URL_PLACEHOLDER));
+    await user.tab();
+
+    expect(await screen.findByText(REQUIRED_URL_ERROR)).toBeInTheDocument();
+  });
+
+  it("clears the error once the user edits the field", async () => {
+    const { user } = renderModal();
+
+    const urlInput = screen.getByPlaceholderText(URL_PLACEHOLDER);
+    await user.type(urlInput, "not-a-valid-url");
+    await user.tab();
+    expect(await screen.findByText(INVALID_URL_ERROR)).toBeInTheDocument();
+
+    await user.type(urlInput, "a");
+
+    expect(screen.queryByText(INVALID_URL_ERROR)).not.toBeInTheDocument();
+  });
+
+  it("shows no error when blurred with a valid URL", async () => {
+    const { user } = renderModal();
+
+    await user.type(
+      screen.getByPlaceholderText(URL_PLACEHOLDER),
+      "https://example.com/webhook"
+    );
+    await user.tab();
+
+    expect(screen.queryByText(INVALID_URL_ERROR)).not.toBeInTheDocument();
+    expect(screen.queryByText(REQUIRED_URL_ERROR)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/pages/policies/ManagePoliciesPage/components/AutomationsModal/components/OtherWorkflowsModal/OtherWorkflowsModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/AutomationsModal/components/OtherWorkflowsModal/OtherWorkflowsModal.tsx
@@ -52,6 +52,16 @@ const getIntegrationType = (integration?: IIntegration) =>
   (!!integration?.project_key && "jira") ||
   undefined;
 
+const getDestinationUrlError = (url: string): string | undefined => {
+  if (!url) {
+    return "Please add a destination URL";
+  }
+  if (!validUrl({ url })) {
+    return "Destination URL is not a valid URL";
+  }
+  return undefined;
+};
+
 const OtherWorkflowsModal = forwardRef<
   IAutomationFormHandle<IOtherWorkflowsModalSubmit>,
   IOtherWorkflowsModalProps
@@ -157,10 +167,9 @@ const OtherWorkflowsModal = forwardRef<
             : "Add an integration to create tickets for policy automations.";
         }
         if (isWebhookEnabled) {
-          if (!destinationUrl) {
-            newErrors.url = "Please add a destination URL";
-          } else if (!validUrl({ url: destinationUrl })) {
-            newErrors.url = "Destination URL is not a valid URL";
+          const urlError = getDestinationUrlError(destinationUrl);
+          if (urlError) {
+            newErrors.url = urlError;
           }
         }
       }
@@ -199,6 +208,20 @@ const OtherWorkflowsModal = forwardRef<
       setErrors((errs) => omit(errs, "url"));
     };
 
+    const onBlurUrl = () => {
+      // Skip validation when the field is disabled (automations off or GitOps
+      // mode) so we don't surface an error on a control the user can't edit.
+      // This must mirror the InputField's `disabled` condition below.
+      if (!isPolicyAutomationsEnabled || gitOpsModeEnabled) {
+        return;
+      }
+      const urlError = getDestinationUrlError(destinationUrl);
+      setErrors((errs) => {
+        const next = omit(errs, "url");
+        return urlError ? { ...next, url: urlError } : next;
+      });
+    };
+
     const onChangeRadio = (val: string) => {
       switch (val) {
         case "webhook":
@@ -235,6 +258,7 @@ const OtherWorkflowsModal = forwardRef<
           type="text"
           value={destinationUrl}
           onChange={onChangeUrl}
+          onBlur={onBlurUrl}
           error={errors.url}
           helpText="For configured policies, Fleet will send a JSON payload to this URL with a list of hosts whose statuses changed from pass to fail."
           placeholder="https://server.com/example"


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #40410

Follow-up to #48854, which added on-blur validation to the software vulnerability automations webhook. QA found three more forms with inconsistent validation, in two flavors:

- **Validated only on save** (no on-blur feedback): Policies > Manage automations > Other workflows > Destination URL.
- **Errored before any input** (validation fired on mount/enable): Settings > Users > Add/edit user > Email, and the host status webhook Destination URL (both global and fleet settings).

This makes them consistent with the rest of the app: no error on open/enable → validate on blur → clear the field's error as the user edits → validate on submit.

- `OtherWorkflowsModal` — added an on-blur handler for the Destination URL (guarded by the field's disabled condition).
- `UserForm` — on-blur now validates only the blurred field (so blurring the autofocused Name no longer flags the empty Email/Password); submit validates all fields.
- `GlobalHostStatusWebhook` — removed the `useEffect` that validated the moment the webhook was enabled; validation now runs on blur and submit.
- `TeamSettings` (fleet host status webhook) — the Destination URL error is no longer surfaced on change/enable; it validates on blur and submit.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] Input data is properly validated (URL and email fields validate on blur and on submit; no errors are shown before the user interacts).

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook destination URL validation across integrations, team settings, and workflow automation forms.
  * Validation messages now appear after leaving the URL field, rather than prematurely while enabling or editing.
  * Prevented saving or submitting forms with missing or invalid destination URLs.
  * Correctly clears validation errors once a valid URL is entered.
  * Improved user form validation so field-specific errors appear only for the field being reviewed, while submit continues to validate the full form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->