### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/antigravity/darwin.json
+++ b/ee/maintained-apps/outputs/antigravity/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.3.1",
+      "version": "2.4.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.antigravity';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.antigravity' AND version_compare(bundle_short_version, '2.3.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.antigravity' AND version_compare(bundle_short_version, '2.4.2') < 0);"
       },
-      "installer_url": "https://storage.googleapis.com/antigravity-public/antigravity-hub/2.3.1-5358163105546240/darwin-arm/Antigravity.dmg",
+      "installer_url": "https://storage.googleapis.com/antigravity-public/antigravity-hub/2.4.2-6711062033203200/darwin-arm/Antigravity.dmg",
       "install_script_ref": "ec27c305",
       "uninstall_script_ref": "8838465b",
-      "sha256": "841714173d20026d1865ea3efbe04406dfeccdda44b3eb1f2c465216bc0786b8",
+      "sha256": "3a4d1ebf441797605a242a227bb977d7a82ab058195873b45ae0d98fa9da500c",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/arc/darwin.json
+++ b/ee/maintained-apps/outputs/arc/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.157.0",
+      "version": "1.157.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'company.thebrowser.Browser';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'company.thebrowser.Browser' AND version_compare(bundle_short_version, '1.157.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'company.thebrowser.Browser' AND version_compare(bundle_short_version, '1.157.1') < 0);"
       },
-      "installer_url": "https://releases.arc.net/release/Arc-1.157.0-83934.zip",
+      "installer_url": "https://releases.arc.net/release/Arc-1.157.1-84133.zip",
       "install_script_ref": "bb0dd542",
       "uninstall_script_ref": "a19b04fa",
-      "sha256": "7a463bbae6326536c29397ce2356ef7cdc697fb1e150538af3ba9f73e33692e3",
+      "sha256": "5ded8afd261da0dc2422a0a6b92245a16afeba2cac3409d8ab70c1a9d527b237",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/dot/darwin.json
+++ b/ee/maintained-apps/outputs/dot/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.3.2",
+      "version": "2.3.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.dot.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.dot.app' AND version_compare(bundle_short_version, '2.3.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.dot.app' AND version_compare(bundle_short_version, '2.3.3') < 0);"
       },
-      "installer_url": "https://github.com/prateekkeshari/dot-releases/releases/download/v2.3.2/Dot-2.3.2.dmg",
+      "installer_url": "https://github.com/prateekkeshari/dot-releases/releases/download/v2.3.3/Dot-2.3.3.dmg",
       "install_script_ref": "2fd2fbc1",
       "uninstall_script_ref": "3e5c7f37",
-      "sha256": "c20cb6377d2fc2897f05a2ed8af2f72f26808bb1a934fb65c119ddb631f2d267",
+      "sha256": "4ce5fd781b447c33982548aac2a936f40de405b495204f49e605e335211ed475",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/obs/darwin.json
+++ b/ee/maintained-apps/outputs/obs/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "32.2.0",
+      "version": "32.2.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.obsproject.obs-studio';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.obsproject.obs-studio' AND version_compare(bundle_short_version, '32.2.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.obsproject.obs-studio' AND version_compare(bundle_short_version, '32.2.1') < 0);"
       },
-      "installer_url": "https://cdn-fastly.obsproject.com/downloads/obs-studio-32.2.0-macos-apple.dmg",
+      "installer_url": "https://cdn-fastly.obsproject.com/downloads/obs-studio-32.2.1-macos-apple.dmg",
       "install_script_ref": "b96854c1",
       "uninstall_script_ref": "54899728",
-      "sha256": "e4bed7f871efa8f2bb5b31d1bbdbde1d0b1016062050f5eab03fd16d44f7a04d",
+      "sha256": "6120c995614be17ecd0ee0877514a88b121249e6261cde46d1440b87d7ffd70c",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/ocenaudio/darwin.json
+++ b/ee/maintained-apps/outputs/ocenaudio/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "3.20.0",
+      "version": "3.20.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.ocenaudio';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.ocenaudio' AND version_compare(bundle_short_version, '3.20.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.ocenaudio' AND version_compare(bundle_short_version, '3.20.1') < 0);"
       },
       "installer_url": "https://www.ocenaudio.com/downloads/index.php/ocenaudio_universal.dmg",
       "install_script_ref": "0c2240cf",


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated the macOS versions of several maintained applications:
    - Antigravity to 2.4.2
    - Arc to 1.157.1
    - Dot to 2.3.3
    - OBS Studio to 32.2.1
    - Ocenaudio to 3.20.1
  - Updated download information and verification data to match the latest releases, enabling accurate installation and upgrade detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->