### PR TITLE
Use snapshot logging for Windows 11 hardware readiness report

### DIFF
--- a/it-and-security/lib/windows/reports/collect-windows-11-hardware-readiness.yml
+++ b/it-and-security/lib/windows/reports/collect-windows-11-hardware-readiness.yml
@@ -41,5 +41,5 @@
   interval: 86400 # Every 1 day
   observer_can_run: true
   automations_enabled: false
-  logging: differential
+  logging: snapshot
   platform: windows


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** NA

Switches the dogfood "Collect Windows 11 hardware readiness" report from `logging: differential` to `logging: snapshot`, so each run reports the full current state of every host rather than only rows that changed since the last run.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

## Testing

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Windows 11 hardware readiness reports to use snapshot logging, ensuring each report captures a complete current-state view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->