### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/anydesk/darwin.json
+++ b/ee/maintained-apps/outputs/anydesk/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "9.7.1",
+      "version": "9.7.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.philandro.anydesk';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.philandro.anydesk' AND version_compare(bundle_short_version, '9.7.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.philandro.anydesk' AND version_compare(bundle_short_version, '9.7.3') < 0);"
       },
       "installer_url": "https://download.anydesk.com/anydesk.dmg",
       "install_script_ref": "f32ce46c",

--- a/ee/maintained-apps/outputs/elgato-control-center/darwin.json
+++ b/ee/maintained-apps/outputs/elgato-control-center/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.8.2",
+      "version": "1.9",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.corsair.ControlCenter';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.corsair.ControlCenter' AND version_compare(bundle_short_version, '1.8.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.corsair.ControlCenter' AND version_compare(bundle_short_version, '1.9') < 0);"
       },
-      "installer_url": "https://edge.elgato.com/egc/macos/eccm/1.8.2/ElgatoControlCenter-1.8.2.20643.zip",
+      "installer_url": "https://edge.elgato.com/egc/macos/eccm/1.9/ElgatoControlCenter-1.9.20829.app.zip",
       "install_script_ref": "b4374aef",
       "uninstall_script_ref": "01138a65",
-      "sha256": "c84270f56f4adacd1c47058cc5a3824b0911886f3519c21b4f54c4ebf9dce869",
+      "sha256": "0bb521ee9413ca48aa0fa85db07fd98f1301490bab9001d003a06960681fc0a1",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/firefox@nightly/darwin.json
+++ b/ee/maintained-apps/outputs/firefox@nightly/darwin.json
@@ -4,12 +4,12 @@
       "version": "155.0a1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15526.7.25') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15526.7.26') < 0);"
       },
-      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/07/2026-07-25-20-50-14-mozilla-central/firefox-155.0a1.en-US.mac.dmg",
+      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/07/2026-07-26-09-24-01-mozilla-central/firefox-155.0a1.en-US.mac.dmg",
       "install_script_ref": "418c9331",
       "uninstall_script_ref": "d7c711ad",
-      "sha256": "993726505c475c8ee07b4dd85d021ee5646c1b134851fb3544631a88ac5bc30b",
+      "sha256": "7ccb18441a0894597474cf1fb718168bfd1315f32c63aba9284968261c24b15a",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/marked-app/darwin.json
+++ b/ee/maintained-apps/outputs/marked-app/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.1.12",
+      "version": "3.1.15",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.brettterpstra.marked';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.brettterpstra.marked' AND version_compare(bundle_short_version, '3.1.12') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.brettterpstra.marked' AND version_compare(bundle_short_version, '3.1.15') < 0);"
       },
-      "installer_url": "https://updates.markedapp.com/updates/Marked%203.1.12.zip",
+      "installer_url": "https://updates.markedapp.com/updates/Marked%203.1.15-1197.zip",
       "install_script_ref": "c6782863",
       "uninstall_script_ref": "9e4b9fca",
-      "sha256": "140ae4b6b2c62c2eb8849b6b0862b9bfae48d7a3982e9da9fe289e7ba795b40f",
+      "sha256": "d1f44eb6b61ca9c3a809b95f2b8494092b46fe8d9f01a7ef04c6dd3376e9483a",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/notepadexe/darwin.json
+++ b/ee/maintained-apps/outputs/notepadexe/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.5.8",
+      "version": "1.5.9",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'best.swift.Notepad';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'best.swift.Notepad' AND version_compare(bundle_short_version, '1.5.8') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'best.swift.Notepad' AND version_compare(bundle_short_version, '1.5.9') < 0);"
       },
-      "installer_url": "https://github.com/notepadhq/notepadexe-public/releases/download/1.5.8/Notepad.zip",
+      "installer_url": "https://github.com/notepadhq/notepadexe-public/releases/download/1.5.9/Notepad.zip",
       "install_script_ref": "17716d6a",
       "uninstall_script_ref": "abe56690",
-      "sha256": "b889cffd98ba5877af701a56ddc9459fff87cd43e56d8fed9892c44efcdab7f4",
+      "sha256": "bbc5c6a70ca1be21f8769b4e72ad3e16dd3ae4a40d79c705a4fd161a9b3239fa",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/purevpn/darwin.json
+++ b/ee/maintained-apps/outputs/purevpn/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "9.44.0",
+      "version": "9.45.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.purevpn.app.mac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.purevpn.app.mac' AND version_compare(bundle_short_version, '9.44.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.purevpn.app.mac' AND version_compare(bundle_short_version, '9.45.0') < 0);"
       },
       "installer_url": "https://dzglif4kkvz04.cloudfront.net/mac-2.0/packages/Production/PureVPN.pkg",
       "install_script_ref": "0c187c4e",

--- a/ee/maintained-apps/outputs/rize/darwin.json
+++ b/ee/maintained-apps/outputs/rize/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.0.15",
+      "version": "3.0.26",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'io.rize';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.rize' AND version_compare(bundle_short_version, '3.0.15') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.rize' AND version_compare(bundle_short_version, '3.0.26') < 0);"
       },
-      "installer_url": "https://github.com/rize-io/lua/releases/download/v3.0.15/Rize-3.0.15-arm64.dmg",
+      "installer_url": "https://github.com/rize-io/lua/releases/download/v3.0.26/Rize-3.0.26-arm64.dmg",
       "install_script_ref": "a335f511",
       "uninstall_script_ref": "8f8ad201",
-      "sha256": "77d01df1e49310f5dfb6958a9ed7e9e7f82ddcc96731c056eeb7231ad574d056",
+      "sha256": "87b0a137f0c7cf4f680f09c9e5da3a8e8cdd32d05904f46fe0f81bbce4548788",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/zettlr/darwin.json
+++ b/ee/maintained-apps/outputs/zettlr/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.6.0",
+      "version": "4.7.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.zettlr.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.zettlr.app' AND version_compare(bundle_short_version, '4.6.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.zettlr.app' AND version_compare(bundle_short_version, '4.7.0') < 0);"
       },
-      "installer_url": "https://github.com/Zettlr/Zettlr/releases/download/v4.6.0/Zettlr-4.6.0-arm64.dmg",
+      "installer_url": "https://github.com/Zettlr/Zettlr/releases/download/v4.7.0/Zettlr-4.7.0-arm64.dmg",
       "install_script_ref": "fc21f2d9",
       "uninstall_script_ref": "a3051277",
-      "sha256": "c0ff76d9e869eee312d7c131764fe73322344f85127ed2e5fada1076cb88cf32",
+      "sha256": "e03e3701557707f6fa50520f4c03f8345cd65206d2810bf5ae433ef40a7ed8f8",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/zettlr/windows.json
+++ b/ee/maintained-apps/outputs/zettlr/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.6.0",
+      "version": "4.7.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Zettlr' AND publisher = 'Hendrik Erz';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Zettlr' AND publisher = 'Hendrik Erz' AND version_compare(version, '4.6.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Zettlr' AND publisher = 'Hendrik Erz' AND version_compare(version, '4.7.0') < 0);"
       },
-      "installer_url": "https://github.com/Zettlr/Zettlr/releases/download/v4.6.0/Zettlr-4.6.0-x64.exe",
+      "installer_url": "https://github.com/Zettlr/Zettlr/releases/download/v4.7.0/Zettlr-4.7.0-x64.exe",
       "install_script_ref": "64dd4e97",
       "uninstall_script_ref": "5d3c0b64",
-      "sha256": "79670357c5badcc7bab7ff73ebc7f57d50647bd141ad655b94913010bd707874",
+      "sha256": "70354eaeeaea7d0592eed91e030a35461cbb3ec73165d96bfde8a9423b43330c",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the latest macOS releases of AnyDesk (9.7.3), Elgato Control Center (1.9), Marked (3.1.15), NotepadEXE (1.5.9), PureVPN (9.45.0), Rize (3.0.26), and Zettlr (4.7.0).
  * Updated Firefox Nightly detection and installer verification for the latest macOS build.
  * Updated Zettlr for Windows to version 4.7.0.
  * Refreshed installer links, version checks, and package verification data where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->