### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/mellel/darwin.json
+++ b/ee/maintained-apps/outputs/mellel/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "6.7.0",
+      "version": "6.7.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.redlex.mellel6';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.redlex.mellel6' AND version_compare(bundle_short_version, '6.7.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.redlex.mellel6' AND version_compare(bundle_short_version, '6.7.1') < 0);"
       },
-      "installer_url": "https://d1riogbqt3a9uw.cloudfront.net/mellel_67002.dmg",
+      "installer_url": "https://d1riogbqt3a9uw.cloudfront.net/mellel_67102.dmg",
       "install_script_ref": "46b16a97",
       "uninstall_script_ref": "7a83c8df",
-      "sha256": "f8833dc531d5d028fe0fed2aef033a61f4330dd75b0a931825b0f3ce9a6e727f",
+      "sha256": "c29a8f555a43b504fa4ecbfa186cfa526ac29a1f1a67a6b25d48014f4af7400d",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/only-switch/darwin.json
+++ b/ee/maintained-apps/outputs/only-switch/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.7.1",
+      "version": "2.7.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'jacklandrin.OnlySwitch';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'jacklandrin.OnlySwitch' AND version_compare(bundle_short_version, '2.7.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'jacklandrin.OnlySwitch' AND version_compare(bundle_short_version, '2.7.2') < 0);"
       },
-      "installer_url": "https://github.com/jacklandrin/OnlySwitch/releases/download/release_2.7.1/OnlySwitch.dmg",
+      "installer_url": "https://github.com/jacklandrin/OnlySwitch/releases/download/release_2.7.2/OnlySwitch.dmg",
       "install_script_ref": "42848bd5",
       "uninstall_script_ref": "d68f8240",
-      "sha256": "64ea5052e2cec7726161ac80a9344fe18e1469c9390650a5953ba7b073a80308",
+      "sha256": "6ec78cdf0deb14a5bec7569a8795db87f2cae828c4edd750e01e4cdf75323508",
       "default_categories": [
         "Utilities"
       ]

--- a/ee/maintained-apps/outputs/reqable/darwin.json
+++ b/ee/maintained-apps/outputs/reqable/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.2.14",
+      "version": "3.2.15",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.reqable.macosx';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.reqable.macosx' AND version_compare(bundle_short_version, '3.2.14') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.reqable.macosx' AND version_compare(bundle_short_version, '3.2.15') < 0);"
       },
-      "installer_url": "https://github.com/reqable/reqable-app/releases/download/3.2.14/reqable-app-macos-arm64.dmg",
+      "installer_url": "https://github.com/reqable/reqable-app/releases/download/3.2.15/reqable-app-macos-arm64.dmg",
       "install_script_ref": "5d84816f",
       "uninstall_script_ref": "3319d75e",
-      "sha256": "0b24ae1b7306fb81c1678acd69c8fdcac110f5d6000dccc5cbcf4c011835f32b",
+      "sha256": "195c1e691de0a8aa16fdbe0a153d43283ff68371c353be6b8059ba0a40a71dea",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/reqable/windows.json
+++ b/ee/maintained-apps/outputs/reqable/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.2.14",
+      "version": "3.2.15",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Reqable' AND publisher = 'Reqqable Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Reqable' AND publisher = 'Reqqable Inc.' AND version_compare(version, '3.2.14') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Reqable' AND publisher = 'Reqqable Inc.' AND version_compare(version, '3.2.15') < 0);"
       },
-      "installer_url": "https://github.com/reqable/reqable-app/releases/download/3.2.14/reqable-app-windows-x86_64.exe",
+      "installer_url": "https://github.com/reqable/reqable-app/releases/download/3.2.15/reqable-app-windows-x86_64.exe",
       "install_script_ref": "d2ffec58",
       "uninstall_script_ref": "b33fc442",
-      "sha256": "85d7624436e9e0edeee7965644d005068d2b6b4b6a682a87355c12682d7a8d2c",
+      "sha256": "0067f0d9534deb778214b65611ae0ea84813073025b7866d0d755285403719a1",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/visual-studio-code/windows.json
+++ b/ee/maintained-apps/outputs/visual-studio-code/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.129.0",
+      "version": "1.130.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Microsoft Visual Studio Code' AND publisher = 'Microsoft Corporation';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Microsoft Visual Studio Code' AND publisher = 'Microsoft Corporation' AND version_compare(version, '1.129.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Microsoft Visual Studio Code' AND publisher = 'Microsoft Corporation' AND version_compare(version, '1.130.0') < 0);"
       },
-      "installer_url": "https://vscode.download.prss.microsoft.com/dbazure/download/stable/125df4672b8a6a34975303c6b0baa124e560a4f7/VSCodeSetup-x64-1.129.0.exe",
+      "installer_url": "https://vscode.download.prss.microsoft.com/dbazure/download/stable/1b6a188127eeaf9194f945eb6eb89a657e93c54c/VSCodeSetup-x64-1.130.0.exe",
       "install_script_ref": "49122823",
       "uninstall_script_ref": "e09509e2",
-      "sha256": "92928c03031740352816c0c7feeeafa0b065a59d70ba07a7793b5e9c28beffcf",
+      "sha256": "7310ee584734b4ef7e450804dfac567d5cff5a7b3c472cb14ad7bf5281c2ba06",
       "default_categories": [
         "Developer tools"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated Mellel for macOS to version 6.7.1.
  * Updated OnlySwitch for macOS to version 2.7.2.
  * Updated Reqable to version 3.2.15 on macOS and Windows.
  * Updated Visual Studio Code for Windows to version 1.130.0.
  * Refreshed installer links and verification data for each release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->