### PR TITLE
Add host_id and host_serial to Apple mdm_enrolled activity

### DIFF
--- a/changes/49777-mdm-enrolled-host-id-apple.md
+++ b/changes/49777-mdm-enrolled-host-id-apple.md
@@ -1,0 +1,1 @@
+- Added `host_id` and `host_serial` to the `mdm_enrolled` activity for Apple (macOS, iOS, iPadOS) enrollments, and the activity now appears on the host's activity timeline.

--- a/frontend/interfaces/activity.ts
+++ b/frontend/interfaces/activity.ts
@@ -215,6 +215,7 @@ export type IHostPastActivityType =
   | ActivityType.WipedHost
   | ActivityType.FailedWipe
   | ActivityType.MdmUnenrolled
+  | ActivityType.MdmEnrolled
   | ActivityType.ReadHostDiskEncryptionKey
   | ActivityType.RetrievedHostMyDeviceURL
   | ActivityType.ViewedHostRecoveryLockPassword

--- a/frontend/pages/hosts/details/cards/Activity/ActivityConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityConfig.tsx
@@ -35,6 +35,7 @@ import RotatedManagedLocalAccountPasswordActivityItem from "./ActivityItems/Rota
 import FailedToRotateManagedLocalAccountPasswordActivityItem from "./ActivityItems/FailedToRotateManagedLocalAccountPassword";
 import FailedEnrollmentProfileRenewalActivityItem from "./ActivityItems/FailedEnrollmentProfileRenewalActivityItem";
 import MdmUnenrolledActivityItem from "./ActivityItems/MdmUnenrolledActivityItem";
+import MdmEnrolledActivityItem from "./ActivityItems/MdmEnrolledActivityItem";
 import RanCustomMdmCommandActivityItem from "./ActivityItems/RanCustomMdmCommandActivityItem";
 import EditedCustomHostVitalValueActivityItem from "./ActivityItems/EditedCustomHostVitalValueActivityItem";
 import PolicyAutomationActivityItem from "./ActivityItems/PolicyAutomationActivityItem";
@@ -94,6 +95,7 @@ export const pastActivityComponentMap: Record<
   [ActivityType.FailedToRotateManagedLocalAccountPassword]: FailedToRotateManagedLocalAccountPasswordActivityItem,
   [ActivityType.FailedEnrollmentProfileRenewal]: FailedEnrollmentProfileRenewalActivityItem,
   [ActivityType.MdmUnenrolled]: MdmUnenrolledActivityItem,
+  [ActivityType.MdmEnrolled]: MdmEnrolledActivityItem,
   [ActivityType.RanCustomMdmCommand]: RanCustomMdmCommandActivityItem,
   [ActivityType.EditedCustomHostVitalValue]: EditedCustomHostVitalValueActivityItem,
   [ActivityType.RanAutomationWebhook]: PolicyAutomationActivityItem,

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/MdmEnrolledActivityItem/MdmEnrolledActivityItem.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/MdmEnrolledActivityItem/MdmEnrolledActivityItem.tests.tsx
@@ -24,7 +24,7 @@ describe("MdmEnrolledActivityItem", () => {
   const cases: Array<[Platform, string, RegExp]> = [
     ["ios", "Admin User", /told Fleet to enroll this host/i],
     ["android", "Admin User", /told Fleet to enroll this host/i],
-    ["android", "", /This host is enrolled in Fleet/i],
+    ["android", "", /This host enrolled to Fleet/i],
     [
       "darwin",
       "Admin User",

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/MdmEnrolledActivityItem/MdmEnrolledActivityItem.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/MdmEnrolledActivityItem/MdmEnrolledActivityItem.tests.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { createMockHostPastActivity } from "__mocks__/activityMock";
+
+import { ActivityType } from "interfaces/activity";
+import { Platform } from "interfaces/platform";
+
+import MdmEnrolledActivityItem from "./MdmEnrolledActivityItem";
+
+const renderItem = (platform: Platform, actor: string) =>
+  render(
+    <MdmEnrolledActivityItem
+      activity={createMockHostPastActivity({
+        type: ActivityType.MdmEnrolled,
+        actor_full_name: actor,
+        actor_id: actor ? 1 : 0,
+        details: { platform },
+      })}
+      tab="past"
+    />
+  );
+
+describe("MdmEnrolledActivityItem", () => {
+  const cases: Array<[Platform, string, RegExp]> = [
+    ["ios", "Admin User", /told Fleet to enroll this host/i],
+    ["android", "Admin User", /told Fleet to enroll this host/i],
+    ["android", "", /This host is enrolled in Fleet/i],
+    [
+      "darwin",
+      "Admin User",
+      /told Fleet to turn on mobile device management \(MDM\) for this host/i,
+    ],
+    [
+      "darwin",
+      "",
+      /Mobile device management \(MDM\) was turned on for this host/i,
+    ],
+  ];
+
+  it.each(cases)("renders %s copy (actor=%j)", (platform, actor, expected) => {
+    renderItem(platform, actor);
+    if (actor) expect(screen.getByText(actor)).toBeVisible();
+    expect(screen.getByText(expected)).toBeVisible();
+  });
+
+  it("does not render the cancel or show-details icons", () => {
+    renderItem("darwin", "Admin User");
+    expect(screen.queryByTestId("close-icon")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("info-outline-icon")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/MdmEnrolledActivityItem/MdmEnrolledActivityItem.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/MdmEnrolledActivityItem/MdmEnrolledActivityItem.tsx
@@ -21,7 +21,7 @@ const MdmEnrolledActivityItem = ({
         <b>{actor_full_name}</b> told Fleet to enroll this host.
       </>
     ) : (
-      <>This host is enrolled in Fleet.</>
+      <>This host enrolled to Fleet.</>
     );
   } else {
     content = actor_full_name ? (

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/MdmEnrolledActivityItem/MdmEnrolledActivityItem.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/MdmEnrolledActivityItem/MdmEnrolledActivityItem.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+
+import { isAndroid, isIPadOrIPhone } from "interfaces/platform";
+
+import ActivityItem from "components/ActivityItem";
+
+import { IHostActivityItemComponentProps } from "../../ActivityConfig";
+
+const baseClass = "mdm-enrolled-activity-item";
+
+const MdmEnrolledActivityItem = ({
+  activity,
+}: IHostActivityItemComponentProps) => {
+  const { actor_full_name } = activity;
+  const platform = activity.details?.platform ?? "";
+
+  let content: React.ReactNode;
+  if (isAndroid(platform) || isIPadOrIPhone(platform)) {
+    content = actor_full_name ? (
+      <>
+        <b>{actor_full_name}</b> told Fleet to enroll this host.
+      </>
+    ) : (
+      <>This host is enrolled in Fleet.</>
+    );
+  } else {
+    content = actor_full_name ? (
+      <>
+        <b>{actor_full_name}</b> told Fleet to turn on mobile device management
+        (MDM) for this host.
+      </>
+    ) : (
+      <>Mobile device management (MDM) was turned on for this host.</>
+    );
+  }
+
+  return (
+    <ActivityItem
+      className={baseClass}
+      activity={activity}
+      hideCancel
+      hideShowDetails
+    >
+      {content}
+    </ActivityItem>
+  );
+};
+
+export default MdmEnrolledActivityItem;

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/MdmEnrolledActivityItem/index.ts
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/MdmEnrolledActivityItem/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MdmEnrolledActivityItem";

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -421,6 +421,7 @@ func (a ActivityTypeFleetEnrolled) ActivityName() string {
 }
 
 type ActivityTypeMDMEnrolled struct {
+	HostID           uint    `json:"host_id"`
 	HostSerial       *string `json:"host_serial"`
 	HostDisplayName  string  `json:"host_display_name"`
 	InstalledFromDEP bool    `json:"installed_from_dep"`
@@ -432,6 +433,16 @@ type ActivityTypeMDMEnrolled struct {
 
 func (a ActivityTypeMDMEnrolled) ActivityName() string {
 	return "mdm_enrolled"
+}
+
+// HostIDs links this activity to the host on the host details timeline. Returns nil when the host
+// is unknown (eg the enrollment is being processed before the host record exists) so the global
+// activity is still recorded but no activity_host_past row is inserted.
+func (a ActivityTypeMDMEnrolled) HostIDs() []uint {
+	if a.HostID == 0 {
+		return nil
+	}
+	return []uint{a.HostID}
 }
 
 // TODO(BMAA): Should we add enrollment_id for BYOD unenrollments?

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -421,7 +421,10 @@ func (a ActivityTypeFleetEnrolled) ActivityName() string {
 }
 
 type ActivityTypeMDMEnrolled struct {
-	HostID           uint    `json:"host_id"`
+	// HostID is omitted when zero so Windows enrollments (which don't set it;
+	// see #47874) keep their existing activity payload. It is always set for
+	// Apple enrollments.
+	HostID           uint    `json:"host_id,omitempty"`
 	HostSerial       *string `json:"host_serial"`
 	HostDisplayName  string  `json:"host_display_name"`
 	InstalledFromDEP bool    `json:"installed_from_dep"`

--- a/server/mdm/lifecycle/lifecycle.go
+++ b/server/mdm/lifecycle/lifecycle.go
@@ -249,13 +249,18 @@ func (t *HostLifecycle) turnOnApple(ctx context.Context, opts HostOptions) error
 	// create MDM enrolled activity if not in the middle of a SCEP renewal
 	if !info.SCEPRenewalInProgress {
 		mdmEnrolledActivity := &fleet.ActivityTypeMDMEnrolled{
+			HostID:           info.HostID,
 			HostDisplayName:  info.DisplayName,
 			InstalledFromDEP: info.DEPAssignedToFleet,
 			MDMPlatform:      fleet.MDMPlatformApple,
 			Platform:         info.Platform,
 		}
 		if nanoEnroll.Type == userEnrollmentDeviceType {
-			mdmEnrolledActivity.EnrollmentID = ptr.String(opts.UserEnrollmentID)
+			// Account-driven user (BYOD) enrollments have no hardware serial, so
+			// report the enrollment ID as the serial too, keeping host_serial
+			// populated for automations regardless of enrollment type.
+			mdmEnrolledActivity.EnrollmentID = new(opts.UserEnrollmentID)
+			mdmEnrolledActivity.HostSerial = new(opts.UserEnrollmentID)
 		} else {
 			mdmEnrolledActivity.HostSerial = ptr.String(info.HardwareSerial)
 		}

--- a/server/mdm/lifecycle/lifecycle_test.go
+++ b/server/mdm/lifecycle/lifecycle_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/fleetdm/fleet/v4/server/contexts/license"
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/mdm"
 	"github.com/fleetdm/fleet/v4/server/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -173,6 +174,65 @@ func TestReconcileHostNameEnforcementOnEnrollment(t *testing.T) {
 // duplicate DEP hosts (same serial) does not recreate a pending "ghost" host
 // when another DEP-assigned host with that serial still exists, while a host
 // with no duplicate is still restored as before.
+// TestMDMEnrolledActivityHostIDAndSerial verifies the Apple mdm_enrolled activity
+// carries host_id (so it lands on the host's activity timeline via HostIDs) and a
+// populated host_serial for both device and account-driven user (BYOD)
+// enrollments. Regression coverage for #49777.
+func TestMDMEnrolledActivityHostIDAndSerial(t *testing.T) {
+	ctx := license.NewContext(context.Background(), &fleet.LicenseInfo{Tier: fleet.TierPremium})
+	const hostID = uint(99)
+
+	// runTurnOn drives an Apple turn-on enrollment of the given nano enrollment
+	// type and returns the mdm_enrolled activity that was recorded.
+	runTurnOn := func(t *testing.T, enrollType, hardwareSerial string, opts HostOptions) *fleet.ActivityTypeMDMEnrolled {
+		ds := new(mock.Store)
+		ds.GetNanoMDMEnrollmentFunc = func(ctx context.Context, uuid string) (*fleet.NanoEnrollment, error) {
+			return &fleet.NanoEnrollment{Enabled: true, Type: enrollType, TokenUpdateTally: 1}, nil
+		}
+		ds.GetHostMDMCheckinInfoFunc = func(ctx context.Context, uuid string) (*fleet.HostMDMCheckinInfo, error) {
+			return &fleet.HostMDMCheckinInfo{HostID: hostID, Platform: opts.Platform, HardwareSerial: hardwareSerial}, nil
+		}
+		ds.NewJobFunc = func(ctx context.Context, job *fleet.Job) (*fleet.Job, error) { return job, nil }
+		ds.ReconcileHostDeviceNamesForHostsFunc = func(ctx context.Context, hostIDs []uint) error { return nil }
+
+		var captured *fleet.ActivityTypeMDMEnrolled
+		newAct := func(ctx context.Context, user *fleet.User, details fleet.ActivityDetails) error {
+			if a, ok := details.(*fleet.ActivityTypeMDMEnrolled); ok {
+				captured = a
+			}
+			return nil
+		}
+
+		lc := New(ds, slog.New(slog.DiscardHandler), newAct)
+		require.NoError(t, lc.Do(ctx, opts))
+		require.NotNil(t, captured, "an mdm_enrolled activity should have been recorded")
+		return captured
+	}
+
+	t.Run("device enrollment: host_id set, host_serial is the hardware serial", func(t *testing.T) {
+		a := runTurnOn(t, mdm.EnrollType(mdm.Device).String(), "C08VQ2AXHT96",
+			HostOptions{Action: HostActionTurnOn, Platform: "darwin", UUID: "host-uuid"})
+
+		require.Equal(t, hostID, a.HostID)
+		require.Equal(t, []uint{hostID}, a.HostIDs())
+		require.NotNil(t, a.HostSerial)
+		require.Equal(t, "C08VQ2AXHT96", *a.HostSerial)
+		require.Nil(t, a.EnrollmentID)
+	})
+
+	t.Run("account-driven user enrollment: host_id set, host_serial is the enrollment id", func(t *testing.T) {
+		a := runTurnOn(t, mdm.EnrollType(mdm.UserEnrollmentDevice).String(), "",
+			HostOptions{Action: HostActionTurnOn, Platform: "ios", UUID: "ADUE-ENROLL-ID", UserEnrollmentID: "ADUE-ENROLL-ID"})
+
+		require.Equal(t, hostID, a.HostID)
+		require.Equal(t, []uint{hostID}, a.HostIDs())
+		require.NotNil(t, a.EnrollmentID)
+		require.Equal(t, "ADUE-ENROLL-ID", *a.EnrollmentID)
+		require.NotNil(t, a.HostSerial)
+		require.Equal(t, "ADUE-ENROLL-ID", *a.HostSerial)
+	})
+}
+
 func TestDeleteAppleDuplicateDEPHost(t *testing.T) {
 	ctx := license.NewContext(context.Background(), &fleet.LicenseInfo{Tier: fleet.TierPremium})
 

--- a/server/service/integration_mdm_dep_test.go
+++ b/server/service/integration_mdm_dep_test.go
@@ -1175,11 +1175,13 @@ func (s *integrationMDMTestSuite) TestDEPProfileAssignment() {
 			found = true
 			require.Nil(t, activity.ActorID)
 			require.Nil(t, activity.ActorFullName)
+			depHost, err := s.ds.HostByIdentifier(context.Background(), devices[0].SerialNumber)
+			require.NoError(t, err)
 			require.JSONEq(
 				t,
 				fmt.Sprintf(
-					`{"host_serial": "%s", "enrollment_id": null, "host_display_name": "%s (%s)", "installed_from_dep": true, "mdm_platform": "apple", "platform": "darwin"}`,
-					devices[0].SerialNumber, devices[0].Model, devices[0].SerialNumber,
+					`{"host_id": %d, "host_serial": "%s", "enrollment_id": null, "host_display_name": "%s (%s)", "installed_from_dep": true, "mdm_platform": "apple", "platform": "darwin"}`,
+					depHost.ID, devices[0].SerialNumber, devices[0].Model, devices[0].SerialNumber,
 				),
 				string(*activity.Details),
 			)
@@ -1408,11 +1410,13 @@ func (s *integrationMDMTestSuite) TestDEPProfileAssignment() {
 	s.awaitRunAppleMDMWorkerSchedule()
 
 	// The last activity should have `installed_from_dep=true`.
+	depReenrollHost, err := s.ds.HostByIdentifier(context.Background(), mdmDevice.SerialNumber)
+	require.NoError(t, err)
 	s.lastActivityMatches(
 		"mdm_enrolled",
 		fmt.Sprintf(
-			`{"host_serial": "%s", "enrollment_id": null, "host_display_name": "%s (%s)", "installed_from_dep": true, "mdm_platform": "apple", "platform": "darwin"}`,
-			mdmDevice.SerialNumber, mdmDevice.Model, mdmDevice.SerialNumber,
+			`{"host_id": %d, "host_serial": "%s", "enrollment_id": null, "host_display_name": "%s (%s)", "installed_from_dep": true, "mdm_platform": "apple", "platform": "darwin"}`,
+			depReenrollHost.ID, mdmDevice.SerialNumber, mdmDevice.Model, mdmDevice.SerialNumber,
 		),
 		0,
 	)

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -1855,13 +1855,17 @@ func (s *integrationMDMTestSuite) TestAppleMDMDeviceEnrollment() {
 	mdmDeviceA := mdmtest.NewTestMDMClientAppleDirect(mdmEnrollInfo, "MacBookPro16,1")
 	err := mdmDeviceA.Enroll()
 	require.NoError(t, err)
+	hostA, err := s.ds.HostByIdentifier(context.Background(), mdmDeviceA.SerialNumber)
+	require.NoError(t, err)
 	s.lastActivityOfTypeMatches(fleet.ActivityTypeMDMEnrolled{}.ActivityName(),
-		fmt.Sprintf(`{"host_serial": "%s", "enrollment_id": null, "host_display_name": "%s (%s)", "installed_from_dep": false, "mdm_platform": "apple", "platform": "darwin"}`, mdmDeviceA.SerialNumber, mdmDeviceA.Model, mdmDeviceA.SerialNumber), 0)
+		fmt.Sprintf(`{"host_id": %d, "host_serial": "%s", "enrollment_id": null, "host_display_name": "%s (%s)", "installed_from_dep": false, "mdm_platform": "apple", "platform": "darwin"}`, hostA.ID, mdmDeviceA.SerialNumber, mdmDeviceA.Model, mdmDeviceA.SerialNumber), 0)
 	mdmDeviceB := mdmtest.NewTestMDMClientAppleDirect(mdmEnrollInfo, "MacBookPro16,1")
 	err = mdmDeviceB.Enroll()
 	require.NoError(t, err)
+	hostB, err := s.ds.HostByIdentifier(context.Background(), mdmDeviceB.SerialNumber)
+	require.NoError(t, err)
 	s.lastActivityOfTypeMatches(fleet.ActivityTypeMDMEnrolled{}.ActivityName(),
-		fmt.Sprintf(`{"host_serial": "%s", "enrollment_id": null, "host_display_name": "%s (%s)", "installed_from_dep": false, "mdm_platform": "apple", "platform": "darwin"}`, mdmDeviceB.SerialNumber, mdmDeviceB.Model, mdmDeviceB.SerialNumber), 0)
+		fmt.Sprintf(`{"host_id": %d, "host_serial": "%s", "enrollment_id": null, "host_display_name": "%s (%s)", "installed_from_dep": false, "mdm_platform": "apple", "platform": "darwin"}`, hostB.ID, mdmDeviceB.SerialNumber, mdmDeviceB.Model, mdmDeviceB.SerialNumber), 0)
 	// Find the ID of Fleet's MDM solution
 	var mdmID uint
 	mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
@@ -16235,8 +16239,10 @@ func (s *integrationMDMTestSuite) TestAppleMDMAccountDrivenUserEnrollment() {
 	require.NoError(t, iPhoneMdmDevice.Enroll())
 	assert.Equal(t, "sso_user@example.com", iPhoneMdmDevice.EnrollInfo.AssignedManagedAppleID)
 
+	iPhoneHost, err := s.ds.HostByIdentifier(context.Background(), iPhoneMdmDevice.EnrollmentID())
+	require.NoError(t, err)
 	s.lastActivityOfTypeMatches(fleet.ActivityTypeMDMEnrolled{}.ActivityName(),
-		fmt.Sprintf(`{"host_serial": null, "enrollment_id": "%s", "host_display_name": "%s (%s)", "installed_from_dep": false, "mdm_platform": "apple", "platform": "ios"}`, iPhoneMdmDevice.EnrollmentID(), iPhoneMdmDevice.Model, iPhoneMdmDevice.EnrollmentID()), 0)
+		fmt.Sprintf(`{"host_id": %d, "host_serial": "%s", "enrollment_id": "%s", "host_display_name": "%s (%s)", "installed_from_dep": false, "mdm_platform": "apple", "platform": "ios"}`, iPhoneHost.ID, iPhoneMdmDevice.EnrollmentID(), iPhoneMdmDevice.EnrollmentID(), iPhoneMdmDevice.Model, iPhoneMdmDevice.EnrollmentID()), 0)
 	linkedIDPAccount, err := s.ds.GetMDMIdPAccountByHostUUID(context.Background(), iPhoneMdmDevice.EnrollmentID())
 	require.NoError(t, err)
 	require.NotNil(t, linkedIDPAccount)
@@ -16270,8 +16276,10 @@ func (s *integrationMDMTestSuite) TestAppleMDMAccountDrivenUserEnrollment() {
 	require.NoError(t, iPadMdmDevice.Enroll())
 	assert.Equal(t, "sso_user2@example.com", iPadMdmDevice.EnrollInfo.AssignedManagedAppleID)
 
+	iPadHost, err := s.ds.HostByIdentifier(context.Background(), iPadMdmDevice.EnrollmentID())
+	require.NoError(t, err)
 	s.lastActivityOfTypeMatches(fleet.ActivityTypeMDMEnrolled{}.ActivityName(),
-		fmt.Sprintf(`{"host_serial": null, "enrollment_id": "%s", "host_display_name": "%s (%s)", "installed_from_dep": false, "mdm_platform": "apple", "platform": "ipados"}`, iPadMdmDevice.EnrollmentID(), iPadMdmDevice.Model, iPadMdmDevice.EnrollmentID()), 0)
+		fmt.Sprintf(`{"host_id": %d, "host_serial": "%s", "enrollment_id": "%s", "host_display_name": "%s (%s)", "installed_from_dep": false, "mdm_platform": "apple", "platform": "ipados"}`, iPadHost.ID, iPadMdmDevice.EnrollmentID(), iPadMdmDevice.EnrollmentID(), iPadMdmDevice.Model, iPadMdmDevice.EnrollmentID()), 0)
 	linkedIDPAccount, err = s.ds.GetMDMIdPAccountByHostUUID(context.Background(), iPadMdmDevice.EnrollmentID())
 	require.NoError(t, err)
 	require.NotNil(t, linkedIDPAccount)
@@ -16285,8 +16293,10 @@ func (s *integrationMDMTestSuite) TestAppleMDMAccountDrivenUserEnrollment() {
 	require.NoError(t, oldUrlIphoneMdmDevice.Enroll())
 	assert.Equal(t, "sso_user2@example.com", oldUrlIphoneMdmDevice.EnrollInfo.AssignedManagedAppleID)
 
+	oldUrlIphoneHost, err := s.ds.HostByIdentifier(context.Background(), oldUrlIphoneMdmDevice.EnrollmentID())
+	require.NoError(t, err)
 	s.lastActivityOfTypeMatches(fleet.ActivityTypeMDMEnrolled{}.ActivityName(),
-		fmt.Sprintf(`{"host_serial": null, "enrollment_id": "%s", "host_display_name": "%s (%s)", "installed_from_dep": false, "mdm_platform": "apple", "platform": "ios"}`, oldUrlIphoneMdmDevice.EnrollmentID(), oldUrlIphoneMdmDevice.Model, oldUrlIphoneMdmDevice.EnrollmentID()), 0)
+		fmt.Sprintf(`{"host_id": %d, "host_serial": "%s", "enrollment_id": "%s", "host_display_name": "%s (%s)", "installed_from_dep": false, "mdm_platform": "apple", "platform": "ios"}`, oldUrlIphoneHost.ID, oldUrlIphoneMdmDevice.EnrollmentID(), oldUrlIphoneMdmDevice.EnrollmentID(), oldUrlIphoneMdmDevice.Model, oldUrlIphoneMdmDevice.EnrollmentID()), 0)
 	linkedIDPAccount, err = s.ds.GetMDMIdPAccountByHostUUID(context.Background(), oldUrlIphoneMdmDevice.EnrollmentID())
 	require.NoError(t, err)
 	require.NotNil(t, linkedIDPAccount)

--- a/server/service/integration_vpp_install_test.go
+++ b/server/service/integration_vpp_install_test.go
@@ -1395,14 +1395,21 @@ func (s *integrationMDMTestSuite) TestVPPAppActivitiesOnCancelInstall() {
 	listPastResp = listActivitiesResponse{}
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d/activities", mdmHost2.ID), nil, http.StatusOK, &listPastResp)
 	require.GreaterOrEqual(t, len(listPastResp.Activities), 2)
+	// mdm_unenrolled is emitted last in the unenroll flow, so it heads the (descending) feed.
 	require.Equal(t, fleet.ActivityTypeMDMUnenrolled{}.ActivityName(), listPastResp.Activities[0].Type)
-	require.Equal(t, fleet.ActivityInstalledAppStoreApp{}.ActivityName(), listPastResp.Activities[1].Type)
-	require.Contains(t, string(*listPastResp.Activities[1].Details), fmt.Sprintf(`"app_store_id": %q`, app1.AdamID))
-	require.Contains(t, string(*listPastResp.Activities[1].Details), `"status": "failed_install"`)
-	if len(listPastResp.Activities) > 2 {
-		// the third activity should not be the cancellation of the second app
-		require.Equal(t, fleet.ActivityInstalledAppStoreApp{}.ActivityName(), listPastResp.Activities[2].Type)
+	// Only the first VPP app was activated, so exactly one installed_app_store_app cancellation
+	// should appear (the second app was never activated). Filter by type, since the feed also
+	// includes the host's mdm_enrolled activity.
+	appStoreType := fleet.ActivityInstalledAppStoreApp{}.ActivityName()
+	var appStoreActs []*fleet.Activity
+	for _, act := range listPastResp.Activities {
+		if act.Type == appStoreType {
+			appStoreActs = append(appStoreActs, act)
+		}
 	}
+	require.Len(t, appStoreActs, 1)
+	require.Contains(t, string(*appStoreActs[0].Details), fmt.Sprintf(`"app_store_id": %q`, app1.AdamID))
+	require.Contains(t, string(*appStoreActs[0].Details), `"status": "failed_install"`)
 
 	// listing the host's software available for install shows the cancelled app as failed
 	getHostSw = getHostSoftwareResponse{}
@@ -1890,10 +1897,18 @@ func (s *integrationMDMTestSuite) TestInHouseAppSelfInstall() {
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d/activities/upcoming", iosHost.ID), nil, http.StatusOK, &listUpcomingAct)
 	require.Len(t, listUpcomingAct.Activities, 0)
 
-	// host has the past activity for the installed app
+	// host has the past activity for the installed app (the feed also includes the host's
+	// mdm_enrolled activity, so filter by type).
 	var listPastResp listActivitiesResponse
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d/activities", iosHost.ID), nil, http.StatusOK, &listPastResp)
-	require.Len(t, listPastResp.Activities, 1)
+	installedSoftwareType := fleet.ActivityTypeInstalledSoftware{}.ActivityName()
+	installedCount := 0
+	for _, act := range listPastResp.Activities {
+		if act.Type == installedSoftwareType {
+			installedCount++
+		}
+	}
+	require.Equal(t, 1, installedCount)
 
 	// update the app to have a label condition
 	clr := fleet.CreateLabelResponse{}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #49777

## Description

Adds `host_id` and `host_serial` to the Apple `mdm_enrolled` activity so IT admins can build automations on top of it, and surfaces the activity on the individual host's activity timeline.

- **`server/fleet/activities.go`** — added `HostID` to `ActivityTypeMDMEnrolled` and a `HostIDs()` method (mirrors the existing `ActivityTypeMDMUnenrolled` pattern), so the activity is linked to the host and appears on its timeline.
- **`server/mdm/lifecycle/lifecycle.go`** — populate `host_id` for macOS/iOS/iPadOS enrollments. Account-driven user (BYOD) enrollments have no hardware serial, so they report the enrollment ID as `host_serial` too, keeping `host_serial` populated for automations regardless of enrollment type.
- **Frontend** — new `MdmEnrolledActivityItem` component, registered in the host past-activity component map (and the `IHostPastActivityType` union), renders the now-host-linked `mdm_enrolled` activity on the host details **Activity** card. There's no Figma, so the copy mirrors the sibling `mdm_unenrolled` item (e.g. "Mobile device management (MDM) was turned on for this host").

`host_id` uses `omitempty`, so Windows (`microsoft_mdm.go`) enrollments keep their existing activity payload unchanged — Windows is intentionally out of scope, handled in #47874, which also owns the audit-log documentation update for the shared field.

> **For reviewer:** the ADUE `host_serial = enrollment_id` behavior comes from the issue's test plan. It means `host_serial` and `enrollment_id` carry the same value for BYOD. Flagging in case Product would rather leave `host_serial` empty for ADUE and have automations read `enrollment_id`.

## Testing

- **Automated:** `TestMDMEnrolledActivityHostIDAndSerial` (`server/mdm/lifecycle`) covers device enrollment (`host_serial` = hardware serial) and ADUE (`host_serial` = enrollment ID), both asserting `host_id`/`HostIDs()`. Also verified `server/datastore/mysql` `TestMDMEnrollment`, `server/activity/internal/mysql` `TestListActivities`, and `server/service` `TestMDMTokenUpdate*` pass.
- **Live (simulated) manual macOS enrollment** via `osquery-perf`: the `mdm_enrolled` activity recorded `host_id` + `host_serial`, and an `activity_host_past` row linked it to the host (confirmed it shows on the host timeline).
- **Frontend:** `MdmEnrolledActivityItem.tests.tsx` covers the rendered copy for macOS/iOS/Android and the actor/no-actor variants; also visually confirmed the activity renders on a host's Activity card in the running app. `yarn jest`, `eslint`, and `tsc` pass.
- Updated the MDM integration tests (`integration_mdm_test.go`, `integration_mdm_dep_test.go`, `integration_vpp_install_test.go`) whose activity-detail and host-feed assertions changed now that `mdm_enrolled` carries `host_id` and appears on the host timeline (feed assertions now filter by activity type).
- **Pending on-device QA (next week):** DEP/ADE macOS and account-driven user enrollment (iOS/iPadOS) on real hardware, per the issue's test plan.
- Regression: Windows `mdm_enrolled` payload is unchanged (`host_id` is omitted when zero); both platforms' `mdm_unenrolled` are unaffected.

# Screenshot for the frontend change

<img width="706" height="382" alt="Screenshot 2026-07-28 at 11 16 57 AM" src="https://github.com/user-attachments/assets/8f57d129-f819-4399-8754-18b397a49db8" />

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually <!-- manual macOS verified via simulator; DEP + real-device ADUE pending next week -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for rendering “MDM enrolled” in the host activity feed with platform- and actor-aware messaging.

* **Bug Fixes**
  * Updated Apple “MDM enrolled” activity details to include the correct host identifier and serial/enrollment identifiers.
  * Ensured host-scoped activity behavior applies only when the host is known (host id present).

* **Tests**
  * Expanded regression and integration coverage for “MDM enrolled” activity details and feed contents, including VPP-related assertion stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
