### PR TITLE
[Route] Add route for IDP account sync information

### DIFF
--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -1366,6 +1366,7 @@ module.exports.routes = {
   'GET /learn-more-about/configuration-profile-assets': '/articles/custom-os-settings#apple-declarations-ddm',
   'GET /learn-more-about/mdm-enrollment': '/guides/windows-mdm-setup#manual-enrollment',
   'GET /learn-more-about/device-and-user-scope': '/guides/custom-os-settings#device-and-user-scope',
+  'GET /learn-more-about/idp-account-sync': '/guides/deploying-apple-account-provisioning-with-fleet',
 
   // Sitemap
   // =============================================================================================================


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #45524 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a redirect from the IDP account sync information page to the Apple account provisioning deployment guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->