### PR TITLE
Align helper text with checkbox/radio labels

### DIFF
--- a/changes/49734-checkbox-radio-help-text-alignment
+++ b/changes/49734-checkbox-radio-help-text-alignment
@@ -1,0 +1,1 @@
+- Fixed helper text under checkboxes and radio buttons so it aligns with the label instead of the control.

--- a/frontend/components/forms/fields/Checkbox/Checkbox.stories.tsx
+++ b/frontend/components/forms/fields/Checkbox/Checkbox.stories.tsx
@@ -33,3 +33,10 @@ export const WithLabel: Story = {
     children: <b>Label</b>,
   },
 };
+
+export const WithHelpText: Story = {
+  args: {
+    children: <b>Label</b>,
+    helpText: "This is some helper text that should align with the label.",
+  },
+};

--- a/frontend/components/forms/fields/Radio/Radio.stories.tsx
+++ b/frontend/components/forms/fields/Radio/Radio.stories.tsx
@@ -25,3 +25,9 @@ export default meta;
 type Story = StoryObj<typeof Radio>;
 
 export const Default: Story = {};
+
+export const WithHelpText: Story = {
+  args: {
+    helpText: "This is some helper text that should align with the label.",
+  },
+};

--- a/frontend/components/forms/fields/Radio/_styles.scss
+++ b/frontend/components/forms/fields/Radio/_styles.scss
@@ -73,6 +73,8 @@
   &__help-text {
     @include help-text;
     margin-top: $pad-xxsmall;
+    // aligns helper text with the radio label instead of the radio control
+    padding-left: $pad-large;
   }
 
   &__disabled {

--- a/frontend/components/forms/fields/Radio/_styles.scss
+++ b/frontend/components/forms/fields/Radio/_styles.scss
@@ -5,7 +5,7 @@
   font-size: $x-small;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: $pad-xsmall;
 
   // this includes the control button and the radio label text
   &__radio-control {

--- a/frontend/components/forms/fields/Radio/_styles.scss
+++ b/frontend/components/forms/fields/Radio/_styles.scss
@@ -3,6 +3,9 @@
 
 .radio {
   font-size: $x-small;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 
   // this includes the control button and the radio label text
   &__radio-control {
@@ -72,9 +75,8 @@
 
   &__help-text {
     @include help-text;
-    margin-top: $pad-xxsmall;
     // aligns helper text with the radio label instead of the radio control
-    padding-left: $pad-large;
+    padding-left: px-to-rem(28);
   }
 
   &__disabled {

--- a/frontend/styles/global/_global.scss
+++ b/frontend/styles/global/_global.scss
@@ -218,7 +218,7 @@ form,
     // flex properties only have an effect when checkbox help text is present
     display: flex;
     flex-direction: column;
-    gap: $pad-small;
+    gap: $pad-xsmall;
 
     .form-field__help-text {
       // aligns helper text with the checkbox label instead of the checkbox icon

--- a/frontend/styles/global/_global.scss
+++ b/frontend/styles/global/_global.scss
@@ -219,6 +219,11 @@ form,
     display: flex;
     flex-direction: column;
     gap: $pad-small;
+
+    .form-field__help-text {
+      // aligns helper text with the checkbox label instead of the checkbox icon
+      padding-left: $pad-large;
+    }
   }
 
   &--slider {


### PR DESCRIPTION
Moves changes from #49920 to `main`.

Originally targeting `docs-v4.91.0` — retargeted to this branch.

**Related:** #49920

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checkbox and radio button helper-text alignment so it lines up with the associated label.
  * Adjusted spacing between controls, labels, and helper text for a cleaner form layout.

* **Documentation**
  * Added component examples demonstrating checkbox and radio buttons with helper text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->