### PR TITLE
Add macOS apps to fleet maintained apps for testing & QA

### DIFF
--- a/it-and-security/fleets/testing-and-qa.yml
+++ b/it-and-security/fleets/testing-and-qa.yml
@@ -98,4 +98,12 @@ software:
     # Linux apps
   fleet_maintained_apps:
     # macOS apps
+    - slug: slack/darwin # Slack for macOS
+      self_service: true
+    - slug: zoom/darwin # Zoom for macOS
+      self_service: true
+    - slug: google-chrome/darwin # Google Chrome for macOS
+      self_service: true
+    - slug: claude/darwin # Claude for macOS
+      self_service: true  
     # Windows apps


### PR DESCRIPTION
- To verify best practice workflow for rollbacks: https://fleetdm.com/guides/fleet-maintained-apps#rollback-to-a-previous-version


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Slack, Zoom, Google Chrome, and Claude to the macOS self-service software catalog for the Testing & QA fleet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->