### PR TITLE
pass validation for fleets gitops files for DDM assets

### DIFF
--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -6,11 +6,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -3462,6 +3464,86 @@ software:
 		require.Len(t, enrolledTeamSecrets, 1)
 		assert.Equal(t, secret, enrolledTeamSecrets[0].Secret)
 	})
+}
+
+// TestGitOpsDDMAssetsNotAppliedOnFreeTier verifies that applying a GitOps
+// config that manages Apple DDM assets never calls the premium-only assets
+// batch endpoint on Fleet Free.
+func TestGitOpsDDMAssetsNotAppliedOnFreeTier(t *testing.T) {
+	// Cannot run t.Parallel() because runServerWithMockedDS sets environment variables.
+
+	server, ds := testing_utils.RunServerWithMockedDS(
+		t, &service.TestServerOpts{
+			License:       &fleet.LicenseInfo{Tier: fleet.TierFree},
+			KeyValueStore: testing_utils.NewMemKeyValueStore(),
+		},
+	)
+	setupEmptyGitOpsMocks(ds)
+
+	// "No team" apply reads/writes the default team config and looks up team 0.
+	defaultTeamConfig := &fleet.TeamConfig{}
+	ds.DefaultTeamConfigFunc = func(ctx context.Context) (*fleet.TeamConfig, error) {
+		return defaultTeamConfig, nil
+	}
+	ds.SaveDefaultTeamConfigFunc = func(ctx context.Context, config *fleet.TeamConfig) error {
+		defaultTeamConfig = config
+		return nil
+	}
+	ds.TeamLiteFunc = func(ctx context.Context, tid uint) (*fleet.TeamLite, error) {
+		return &fleet.TeamLite{ID: 0, Name: fleet.ReservedNameNoTeam, Config: defaultTeamConfig.ToLite()}, nil
+	}
+	ds.NewJobFunc = func(ctx context.Context, job *fleet.Job) (*fleet.Job, error) {
+		job.ID = 1
+		return job, nil
+	}
+
+	// Count requests reaching the premium-only DDM assets batch endpoint.
+	var assetsBatchCalls atomic.Int32
+	base := server.Config.Handler
+	server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/fleet/assets/batch") {
+			assetsBatchCalls.Add(1)
+		}
+		base.ServeHTTP(w, r)
+	})
+
+	const (
+		fleetServerURL = "https://fleet.example.com"
+		orgName        = "GitOps Test"
+	)
+
+	// A global config that manages macos_settings and declares a DDM asset. A
+	// non-empty asset set forces the client down the (premium-gated) apply path.
+	dir := t.TempDir()
+	assetPath := filepath.Join(dir, "asset.json")
+	require.NoError(t, os.WriteFile(assetPath, []byte(`{
+  "Type": "com.apple.asset.credential.userpassword",
+  "Identifier": "com.fleetdm.asset.example",
+  "Payload": {"UserName": "admin"}
+}`), 0o600))
+
+	globalFilePath := filepath.Join(dir, "global.yml")
+	require.NoError(t, os.WriteFile(globalFilePath, fmt.Appendf(nil, `
+controls:
+  macos_settings:
+    assets:
+      - path: ./asset.json
+queries:
+policies:
+agent_options:
+org_settings:
+  server_settings:
+    server_url: %s
+  org_info:
+    contact_url: https://example.com/contact
+    org_name: %s
+  secrets:
+software:
+`, fleetServerURL, orgName), 0o600))
+
+	_, err := runAppNoChecks([]string{"gitops", "-f", globalFilePath})
+	require.NoError(t, err, "free-tier GitOps with DDM assets must succeed; a non-zero call count means the premium-only batch endpoint was hit")
+	assert.Zero(t, assetsBatchCalls.Load(), "DDM assets batch endpoint must never be called on Fleet Free")
 }
 
 func createTeamFileBasic(t *testing.T, secret string) *os.File {

--- a/cmd/fleetctl/fleetctl/testing_utils/testing_utils.go
+++ b/cmd/fleetctl/fleetctl/testing_utils/testing_utils.go
@@ -58,6 +58,12 @@ func RunServerWithMockedDS(t *testing.T, opts ...*service.TestServerOpts) (*http
 	ds.UpsertCustomHostVitalsFunc = func(ctx context.Context, vitals []fleet.CustomHostVital) ([]fleet.CustomHostVital, []fleet.CustomHostVital, error) {
 		return nil, nil, nil
 	}
+	ds.BatchSetAppleDDMAssetsFunc = func(ctx context.Context, teamID *uint, assets []*fleet.MDMAppleDDMAssetToSet) (*fleet.MDMAppleDDMAssetsBatchChanges, error) {
+		return &fleet.MDMAppleDDMAssetsBatchChanges{}, nil
+	}
+	ds.ListAppleDDMAssetsFunc = func(ctx context.Context, teamID *uint) ([]*fleet.DDMAsset, error) {
+		return nil, nil
+	}
 	var users []*fleet.User
 	var admin *fleet.User
 	ds.NewUserFunc = func(ctx context.Context, user *fleet.User) (*fleet.User, error) {

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -503,7 +503,8 @@ type MacOSSettings struct {
 	// paths. Unlike CustomSettings, assets are not stored on the AppConfig/team
 	// spec: this field is only populated while parsing a GitOps file so the
 	// assets can be applied via their own batch endpoint. It is intentionally
-	// omitted from ToMap/FromMap.
+	// omitted from FromMap; ToMap includes it only so the key passes the team
+	// spec's strict key validation (see applyTeamSpecsRequest.DecodeBody).
 	Assets []MDMProfileSpec `json:"assets,omitempty"`
 
 	// NOTE: make sure to update the ToMap/FromMap methods when adding/updating fields.
@@ -517,6 +518,7 @@ func (s MacOSSettings) ToMap() map[string]interface{} {
 	return map[string]interface{}{
 		"custom_settings":        s.CustomSettings,
 		"enable_disk_encryption": s.DeprecatedEnableDiskEncryption,
+		"assets":                 s.Assets,
 	}
 }
 

--- a/server/fleet/teams.go
+++ b/server/fleet/teams.go
@@ -757,6 +757,9 @@ func TeamSpecFromTeam(t *Team) (*TeamSpec, error) {
 	mdmSpec.WindowsUpdates = t.Config.MDM.WindowsUpdates
 	mdmSpec.MacOSSettings = t.Config.MDM.MacOSSettings.ToMap()
 	delete(mdmSpec.MacOSSettings, "enable_disk_encryption")
+	// assets are only present in ToMap for GitOps request validation; they are
+	// not stored on the team config, so keep them out of the generated spec.
+	delete(mdmSpec.MacOSSettings, "assets")
 	mdmSpec.MacOSSetup = t.Config.MDM.MacOSSetup
 	mdmSpec.EnableDiskEncryption = optjson.SetBool(t.Config.MDM.EnableDiskEncryption)
 	mdmSpec.EnableRecoveryLockPassword = optjson.SetBool(t.Config.MDM.EnableRecoveryLockPassword)

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -751,8 +751,13 @@ func (c *Client) ApplyGroup(
 		// custom settings but windows is present and empty (but mac is absent),
 		// shouldn't that clear the windows ones?
 		// Apply DDM assets before profiles/declarations so a declaration in the
-		// same GitOps run can reference an asset uploaded alongside it.
-		if macosAssets := extractAppCfgMacOSAssets(specs.AppConfig); len(macosAssets) > 0 {
+		// same GitOps run can reference an asset uploaded alongside it. Assets
+		// require premium and turned-on MDM (the batch endpoint rejects the call
+		// otherwise), so skip it when either is missing. A non-nil spec means
+		// macos_settings is managed, so reconcile even when the asset set is empty
+		// (that clears any existing assets).
+		if macosAssets := extractAppCfgMacOSAssets(specs.AppConfig); macosAssets != nil &&
+			appconfig != nil && appconfig.License.IsPremium() && appconfig.MDM.EnabledAndConfigured {
 			assetContents, err := getAssetsContents(baseDir, macosAssets, opts.ExpandEnvConfigProfiles)
 			if err != nil {
 				return nil, nil, nil, nil, err
@@ -1057,8 +1062,10 @@ func (c *Client) ApplyGroup(
 		}
 
 		// Apply DDM assets before profiles/declarations so a declaration in the
-		// same GitOps run can reference an asset uploaded alongside it.
-		if len(tmAssetContents) > 0 {
+		// same GitOps run can reference an asset uploaded alongside it. Assets
+		// require premium and turned-on MDM (the batch endpoint rejects the call
+		// otherwise), so skip it when either is missing.
+		if len(tmAssetContents) > 0 && appconfig != nil && appconfig.License.IsPremium() && appconfig.MDM.EnabledAndConfigured {
 			for tmName, assets := range tmAssetContents {
 				currentTeamName := getTeamName(tmName)
 				teamID, ok := teamIDsByName[currentTeamName]
@@ -1686,8 +1693,20 @@ func extractAppCfgAndroidCustomSettings(appCfg interface{}) []fleet.MDMProfileSp
 func extractMacOSAssetSpecs(macOSSettings any) []fleet.MDMProfileSpec {
 	switch v := macOSSettings.(type) {
 	case fleet.MacOSSettings:
+		// macos_settings is present (GitOps decodes it into the struct), so assets
+		// are reconciled even when none are listed. Normalize nil to a non-nil
+		// empty slice so the caller treats it as "reconcile to empty".
+		if v.Assets == nil {
+			return []fleet.MDMProfileSpec{}
+		}
 		return v.Assets
 	case *fleet.MacOSSettings:
+		if v == nil {
+			return nil
+		}
+		if v.Assets == nil {
+			return []fleet.MDMProfileSpec{}
+		}
 		return v.Assets
 	case map[string]any:
 		raw, ok := v["assets"].([]any)
@@ -1720,13 +1739,20 @@ func extractAppCfgMacOSAssets(appCfg any) []fleet.MDMProfileSpec {
 }
 
 // extractTmSpecsMDMAssets returns the Apple DDM asset specs keyed by team name.
+//
+// Assets are reconciled whenever a team manages macos_settings (the key is
+// present), mirroring how custom_settings behaves: a present-but-empty asset
+// set is a request to clear all of the team's assets. macos_settings is decoded
+// through a pointer so its absence (leave assets untouched) is distinguishable
+// from an empty macos_settings (reconcile assets to the provided, possibly
+// empty, set).
 func extractTmSpecsMDMAssets(tmSpecs []json.RawMessage) map[string][]fleet.MDMProfileSpec {
 	var m map[string][]fleet.MDMProfileSpec
 	for _, tm := range tmSpecs {
 		var spec struct {
 			Name string `json:"name"`
 			MDM  struct {
-				MacOSSettings struct {
+				MacOSSettings *struct {
 					Assets []fleet.MDMProfileSpec `json:"assets"`
 				} `json:"macos_settings"`
 			} `json:"mdm"`
@@ -1736,13 +1762,20 @@ func extractTmSpecsMDMAssets(tmSpecs []json.RawMessage) map[string][]fleet.MDMPr
 			continue
 		}
 		spec.Name = norm.NFC.String(spec.Name)
-		if spec.Name == "" || len(spec.MDM.MacOSSettings.Assets) == 0 {
+		if spec.Name == "" || spec.MDM.MacOSSettings == nil {
+			// macos_settings not managed for this team; leave its assets untouched.
 			continue
 		}
 		if m == nil {
 			m = make(map[string][]fleet.MDMProfileSpec)
 		}
-		m[spec.Name] = spec.MDM.MacOSSettings.Assets
+		// A present but empty (or absent) assets key clears the team's assets, so
+		// normalize nil to a non-nil empty slice to signal "reconcile to empty".
+		assets := spec.MDM.MacOSSettings.Assets
+		if assets == nil {
+			assets = []fleet.MDMProfileSpec{}
+		}
+		m[spec.Name] = assets
 	}
 	return m
 }

--- a/server/service/client_test.go
+++ b/server/service/client_test.go
@@ -156,6 +156,85 @@ spec:
 	}
 }
 
+func TestExtractMacOSAssetSpecs(t *testing.T) {
+	// GitOps decodes macos_settings into a fleet.MacOSSettings struct. Whenever
+	// the struct is present, assets must be reconciled (a nil/empty asset set
+	// clears existing assets), so the extractor returns a non-nil slice.
+	t.Run("gitops struct, no assets => non-nil empty (reconcile to empty)", func(t *testing.T) {
+		got := extractMacOSAssetSpecs(fleet.MacOSSettings{CustomSettings: []fleet.MDMProfileSpec{{Path: "a"}}})
+		require.NotNil(t, got)
+		assert.Empty(t, got)
+	})
+	t.Run("gitops struct with assets", func(t *testing.T) {
+		got := extractMacOSAssetSpecs(fleet.MacOSSettings{Assets: []fleet.MDMProfileSpec{{Path: "x"}}})
+		assert.Equal(t, []fleet.MDMProfileSpec{{Path: "x"}}, got)
+	})
+	t.Run("gitops struct pointer with assets", func(t *testing.T) {
+		got := extractMacOSAssetSpecs(&fleet.MacOSSettings{Assets: []fleet.MDMProfileSpec{{Path: "x"}}})
+		assert.Equal(t, []fleet.MDMProfileSpec{{Path: "x"}}, got)
+	})
+	// Legacy fleetctl apply passes a raw map; there the assets key drives
+	// behavior: absent means "leave untouched" (nil), present means reconcile.
+	t.Run("legacy map, no assets key => nil (leave untouched)", func(t *testing.T) {
+		got := extractMacOSAssetSpecs(map[string]any{"custom_settings": []any{}})
+		assert.Nil(t, got)
+	})
+	t.Run("legacy map, empty assets => non-nil empty", func(t *testing.T) {
+		got := extractMacOSAssetSpecs(map[string]any{"assets": []any{}})
+		require.NotNil(t, got)
+		assert.Empty(t, got)
+	})
+	t.Run("legacy map with assets", func(t *testing.T) {
+		got := extractMacOSAssetSpecs(map[string]any{"assets": []any{map[string]any{"path": "x"}}})
+		assert.Equal(t, []fleet.MDMProfileSpec{{Path: "x"}}, got)
+	})
+	t.Run("unrelated type => nil", func(t *testing.T) {
+		assert.Nil(t, extractMacOSAssetSpecs("nope"))
+	})
+}
+
+func TestExtractTmSpecsMDMAssets(t *testing.T) {
+	cases := []struct {
+		desc string
+		spec string
+		// want is the expected value keyed by team name; nil means the team must
+		// be absent from the result map (assets left untouched).
+		want map[string][]fleet.MDMProfileSpec
+	}{
+		{
+			"macos_settings absent => untouched",
+			`{"name":"T1","mdm":{}}`,
+			nil,
+		},
+		{
+			"macos_settings present, no assets => reconcile to empty (clear)",
+			`{"name":"T1","mdm":{"macos_settings":{"custom_settings":[]}}}`,
+			map[string][]fleet.MDMProfileSpec{"T1": {}},
+		},
+		{
+			"macos_settings present, empty assets => reconcile to empty (clear)",
+			`{"name":"T1","mdm":{"macos_settings":{"assets":[]}}}`,
+			map[string][]fleet.MDMProfileSpec{"T1": {}},
+		},
+		{
+			"macos_settings present with assets",
+			`{"name":"T1","mdm":{"macos_settings":{"assets":[{"path":"x"}]}}}`,
+			map[string][]fleet.MDMProfileSpec{"T1": {{Path: "x"}}},
+		},
+		{
+			"empty team name => skipped",
+			`{"name":"","mdm":{"macos_settings":{"assets":[]}}}`,
+			nil,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			got := extractTmSpecsMDMAssets([]json.RawMessage{json.RawMessage(c.spec)})
+			assert.Equal(t, c.want, got)
+		})
+	}
+}
+
 func TestExtractAppConfigWindowsCustomSettings(t *testing.T) {
 	cases := []struct {
 		desc string


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #49979 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information. (Unreleased bug)

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented Fleet Free from attempting to apply premium-only Apple DDM assets.
  * Improved macOS DDM asset reconciliation so explicitly empty settings can clear previously configured assets.
  * Ensured GitOps and team configurations consistently recognize and validate macOS asset settings.
  * Restricted DDM asset processing to Premium deployments with configured and enabled MDM.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->