### PR TITLE
Add VEX exclusions for fleetctl docker image

### DIFF
--- a/security/status.md
+++ b/security/status.md
@@ -284,6 +284,22 @@ Following is the vulnerability report of Fleet and its dependencies.
 
 ## `fleetdm/fleetctl` docker image
 
+### [GHSA-r7wm-3cxj-wff9](https://nvd.nist.gov/vuln/detail/GHSA-r7wm-3cxj-wff9)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** Incomplete fix for GHSA-72hv-8253-57qq; like the parent advisory, it only affects Java/JVM services that feed attacker-controlled chunked input to Jackson's asynchronous (non-blocking) JSON parser. jackson-core is bundled by Apple Transporter (itms), a local CLI upload tool included for macOS package notarization (fleetctl notarizes with rcodesign), which never parses untrusted streamed JSON.
+- **Products:** `fleetctl`,`pkg:maven/com.fasterxml.jackson.core/jackson-core`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-07-27 14:10:31
+
+### [GHSA-hrxh-6v49-42gf](https://nvd.nist.gov/vuln/detail/GHSA-hrxh-6v49-42gf)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** The vulnerabilities affect the xDS RBAC authorization engine and the HTTP/2 server transport of gRPC-Go; fleetctl does not run a gRPC server nor use xDS (grpc is a transitive dependency used by the Fleet server).
+- **Products:** `fleetctl`,`pkg:golang/google.golang.org/grpc`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-07-27 14:10:31
+
 ### [GHSA-72hv-8253-57qq](https://nvd.nist.gov/vuln/detail/GHSA-72hv-8253-57qq)
 - **Author:** @lucasmrod
 - **Status:** `not_affected`
@@ -347,6 +363,22 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Products:** `fleetctl`,`pkg:maven/com.fasterxml.jackson.core/jackson-databind`
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2026-07-01 13:33:33
+
+### [CVE-2026-46604](https://nvd.nist.gov/vuln/detail/CVE-2026-46604)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl links golang.org/x/image only for its WebP decoder (used to validate org logo images); the vulnerable TIFF decoder (golang.org/x/image/tiff) is only imported by a macOS-only orbit extension and is not compiled into fleetctl.
+- **Products:** `fleetctl`,`pkg:golang/golang.org/x/image`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-07-27 14:10:31
+
+### [CVE-2026-46602](https://nvd.nist.gov/vuln/detail/CVE-2026-46602)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl links golang.org/x/image only for its WebP decoder (used to validate org logo images); the vulnerable TIFF decoder (golang.org/x/image/tiff) is only imported by a macOS-only orbit extension and is not compiled into fleetctl.
+- **Products:** `fleetctl`,`pkg:golang/golang.org/x/image`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-07-27 14:10:31
 
 ### [CVE-2026-42504](https://nvd.nist.gov/vuln/detail/CVE-2026-42504)
 - **Author:** @lucasmrod

--- a/security/vex/fleetctl/CVE-2026-46602.vex.json
+++ b/security/vex/fleetctl/CVE-2026-46602.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-2a748d30a876a0d062f3dfd71c523bd4b37ac0c4d19d51510b16efc1ffeeeec9",
+  "author": "@lucasmrod",
+  "timestamp": "2026-07-27T14:10:31-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-46602"
+      },
+      "timestamp": "2026-07-27T14:10:31-03:00",
+      "products": [
+        {
+          "@id": "fleetctl"
+        },
+        {
+          "@id": "pkg:golang/golang.org/x/image"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl links golang.org/x/image only for its WebP decoder (used to validate org logo images); the vulnerable TIFF decoder (golang.org/x/image/tiff) is only imported by a macOS-only orbit extension and is not compiled into fleetctl.",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/security/vex/fleetctl/CVE-2026-46604.vex.json
+++ b/security/vex/fleetctl/CVE-2026-46604.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-38dd219831f2de0dd1966087f83b528c485a66c1ecbc0aff136b060e7a1c5b35",
+  "author": "@lucasmrod",
+  "timestamp": "2026-07-27T14:10:31-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-46604"
+      },
+      "timestamp": "2026-07-27T14:10:31-03:00",
+      "products": [
+        {
+          "@id": "fleetctl"
+        },
+        {
+          "@id": "pkg:golang/golang.org/x/image"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl links golang.org/x/image only for its WebP decoder (used to validate org logo images); the vulnerable TIFF decoder (golang.org/x/image/tiff) is only imported by a macOS-only orbit extension and is not compiled into fleetctl.",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/security/vex/fleetctl/GHSA-hrxh-6v49-42gf.vex.json
+++ b/security/vex/fleetctl/GHSA-hrxh-6v49-42gf.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-8a1235b55d3b4853fa1f50bd3e7dbe33274eb48b92c813b6d5727ff0eb6f691a",
+  "author": "@lucasmrod",
+  "timestamp": "2026-07-27T14:10:31-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "GHSA-hrxh-6v49-42gf"
+      },
+      "timestamp": "2026-07-27T14:10:31-03:00",
+      "products": [
+        {
+          "@id": "fleetctl"
+        },
+        {
+          "@id": "pkg:golang/google.golang.org/grpc"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "The vulnerabilities affect the xDS RBAC authorization engine and the HTTP/2 server transport of gRPC-Go; fleetctl does not run a gRPC server nor use xDS (grpc is a transitive dependency used by the Fleet server).",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/security/vex/fleetctl/GHSA-r7wm-3cxj-wff9.vex.json
+++ b/security/vex/fleetctl/GHSA-r7wm-3cxj-wff9.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-066f14886591a434e2a46cb63375e0811651ea79d10f23114768655df40a35b5",
+  "author": "@lucasmrod",
+  "timestamp": "2026-07-27T14:10:31-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "GHSA-r7wm-3cxj-wff9"
+      },
+      "timestamp": "2026-07-27T14:10:31-03:00",
+      "products": [
+        {
+          "@id": "fleetctl"
+        },
+        {
+          "@id": "pkg:maven/com.fasterxml.jackson.core/jackson-core"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "Incomplete fix for GHSA-72hv-8253-57qq; like the parent advisory, it only affects Java/JVM services that feed attacker-controlled chunked input to Jackson's asynchronous (non-blocking) JSON parser. jackson-core is bundled by Apple Transporter (itms), a local CLI upload tool included for macOS package notarization (fleetctl notarizes with rcodesign), which never parses untrusted streamed JSON.",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}


### PR DESCRIPTION
Run: https://github.com/fleetdm/fleet/actions/runs/30288436739.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added vulnerability status records for four advisories affecting fleetctl and related components.
  * Documented fleetctl as **not affected** because the vulnerable code paths are not used or included.
  * Added rationale covering WebP-only image decoding, unavailable macOS-only TIFF functionality, absence of gRPC server and xDS RBAC usage, and inapplicable Jackson parser conditions.
  * Included standardized advisory metadata and version information for improved security transparency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->