### PR TITLE
Guide: Clarify which policy automations are premium & fleet-level

### DIFF
--- a/articles/automations.md
+++ b/articles/automations.md
@@ -20,6 +20,8 @@ Automations are fired for scheduled policy runs. Running a live policy doesn't t
 
 ### Calendar
 
+_Available in Fleet Premium_, fleet-level policies only.
+
 You can configure Fleet to automatically reserve time in your end users' calendars (maintenance
 windows), trigger or send report results to webhooks, or create tickets.
 
@@ -27,11 +29,13 @@ To learn how to use Fleet's maintenance windows, head to this [article](https://
 
 ### Software and scripts
 
-By default, software and script automations are only triggered when a policy is newly failing on a host. A policy is "newly failing" if a host updated its response from no response to "fail" or from "pass" to "fail." A policy that remains failing ("fail" → "fail") does not retrigger the automation.
+_Available in Fleet Premium_, fleet-level policies only.
+
+By default, software and script automations are only triggered when a policy is newly failing on a host. A policy is "newly failing" if a host updated its response from no response to "fail" or from "pass" to "fail." A policy that remains failing ("fail" → "fail") does not re-trigger the automation.
+
+To install software and script automations on every subsequent failing result, instead of only on newly failing hosts, set `continuous_automations_enabled` to `true` on the policy. When enabled, Fleet triggers the software install or script each time it receives a failing response, including consecutive failures ("fail" → "fail"). Because this can retry an automation that doesn't resolve the policy, it may cause a retry loop. Continuous automations don't affect webhooks, tickets, calendar events, or conditional access, which always trigger only on newly failing hosts.
 
 Automations for [software](https://fleetdm.com/guides/automatic-software-install-in-fleet) and [scripts](https://fleetdm.com/guides/policy-automation-run-script) are attempted up to 3 total times. Each time the policy runs and fails, Fleet triggers the software install or script again, up to a total of 3 attempts. If the host passes the policy, the retry count resets.
-
-To run software and script automations on _every_ failing policy result, instead of only on newly failing hosts, set `continuous_automations_enabled` to `true` on the policy (_Available in Fleet Premium_, fleet policies only). When enabled, Fleet triggers the software install or script each time it receives a failing response, including consecutive failures ("fail" → "fail"). Because this can retry an automation that doesn't resolve the policy, it may cause a retry loop. Continuous automations don't affect webhooks, tickets, calendar events, or conditional access, which always trigger only on newly failing hosts.
 
 ### Webhooks and tickets
 


### PR DESCRIPTION
Also clarified language about continuous retries, and moved section about retrying on policy automation failure to a spot that made more sense.

Re: [discussion](https://macadmins.slack.com/archives/C0214NELAE7/p1784951700300179) in Mac Admins Slack > #fleet