### PR TITLE
Add exclusions for released fleetctl docker image

### DIFF
--- a/security/status.md
+++ b/security/status.md
@@ -332,6 +332,14 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2026-07-06 08:51:11
 
+### [CVE-2026-57433](https://nvd.nist.gov/vuln/detail/CVE-2026-57433)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** perl is not used during fleetd package generation.
+- **Products:** `fleetctl`,`pkg:deb/debian/perl-base`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-07-27 17:15:39
+
 ### [CVE-2026-54513](https://nvd.nist.gov/vuln/detail/CVE-2026-54513)
 - **Author:** @lucasmrod
 - **Status:** `not_affected`

--- a/security/vex/fleetctl/CVE-2026-57433.vex.json
+++ b/security/vex/fleetctl/CVE-2026-57433.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-b141cb2cfe309854b18482ce258698e94e1fa4b647be29161fc6504026317d24",
+  "author": "@lucasmrod",
+  "timestamp": "2026-07-27T17:15:39Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-57433"
+      },
+      "timestamp": "2026-07-27T17:15:39Z",
+      "products": [
+        {
+          "@id": "fleetctl"
+        },
+        {
+          "@id": "pkg:deb/debian/perl-base"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "perl is not used during fleetd package generation",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}


### PR DESCRIPTION
Run: https://github.com/fleetdm/fleet/actions/runs/30288702449

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added a vulnerability assessment for CVE-2026-57433.
  * Documented that the affected products are not impacted because the vulnerable code is not used in the relevant execution path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->