### PR TITLE
Add exclusions for wix docker image

### DIFF
--- a/security/status.md
+++ b/security/status.md
@@ -979,6 +979,14 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2026-05-19 10:16:53
 
+### [CVE-2026-12912](https://nvd.nist.gov/vuln/detail/CVE-2026-12912)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not do TIFF processing when using fleetdm/wix.
+- **Products:** `wix`,`pkg:deb/debian/libtiff6`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-07-27 17:21:36
+
 ### [CVE-2026-0861](https://nvd.nist.gov/vuln/detail/CVE-2026-0861)
 - **Author:** @lucasmrod
 - **Status:** `not_affected`

--- a/security/vex/wix/CVE-2026-12912.vex.json
+++ b/security/vex/wix/CVE-2026-12912.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-1f22e4e657b703f67b706c1acd0deb9bfaf3a1f345f31b1c28e1596af3dcd502",
+  "author": "@lucasmrod",
+  "timestamp": "2026-07-27T17:21:36.772722Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-12912"
+      },
+      "timestamp": "2026-07-27T17:21:36.772722Z",
+      "products": [
+        {
+          "@id": "wix"
+        },
+        {
+          "@id": "pkg:deb/debian/libtiff6"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not do TIFF processing when using fleetdm/wix",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}


### PR DESCRIPTION
Run: https://github.com/fleetdm/fleet/actions/runs/30289212899.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added vulnerability assessment metadata for CVE-2026-12912.
  * Clarified that the affected code is not executed by fleetctl when using the wix ecosystem.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->