### PR TITLE
Fleet UI: Fix empty button boxes in batch run script modal

### DIFF
--- a/.claude/rules/fleet-frontend.md
+++ b/.claude/rules/fleet-frontend.md
@@ -103,6 +103,7 @@ Render software title names via `getDisplayedSoftwareName(name, display_name)` f
 - Use `classnames()` for conditional classes
 - Style files use underscore prefix: `_styles.scss`
 - Prefer `gap` over `margin` for spacing between sibling elements when the parent is `display: flex`/`grid`. Use the layout mixins from `frontend/styles/var/mixins.scss`: `vertical-card-layout`, `vertical-form-layout`, `vertical-modal-layout`, `vertical-page-layout`, `vertical-page-tab-panel-layout`, `vertical-data-set-layout`
+- **Row hover-reveal actions** (a button/dropdown that only appears when the containing row is hovered): add `className="row-hover-button"` to the element. The fade + `:focus-visible` reveal is defined for `tr` in `frontend/components/TableContainer/_styles.scss` and for `.paginated-list__row` in `frontend/components/PaginatedList/_styles.scss` — don't hand-roll a local `opacity: 0` / `:hover { opacity: 1 }` per-consumer. Never fade only `.children-wrapper` — bordered/filled `Button` variants (e.g. `secondary`) leave an empty button frame behind.
 
 ## Forms
 Cap free-text inputs' `maxLength` to the backend column length (check `server/datastore/mysql/schema.sql`, don't guess) via `inputOptions={{ maxLength: NAME_MAX_LENGTH }}` on `InputField`, using a local constant.

--- a/frontend/components/PaginatedList/_styles.scss
+++ b/frontend/components/PaginatedList/_styles.scss
@@ -76,12 +76,17 @@
     // so bordered/filled variants like `secondary` don't leave an empty box behind.
     .row-hover-button {
       opacity: 0;
+      // Suppress pointer events while hidden so the invisible button can't
+      // intercept clicks meant for the row. Tab navigation still works —
+      // pointer-events only gates mouse/touch, not keyboard focus.
+      pointer-events: none;
       transition: opacity 250ms;
 
       // Reveal on the button's own keyboard focus, not just row hover —
       // otherwise tabbing to a hidden row-hover button never shows it.
       &:focus-visible {
         opacity: 1;
+        pointer-events: auto;
       }
     }
 
@@ -99,6 +104,7 @@
 
       .row-hover-button {
         opacity: 1;
+        pointer-events: auto;
       }
     }
 

--- a/frontend/components/PaginatedList/_styles.scss
+++ b/frontend/components/PaginatedList/_styles.scss
@@ -71,6 +71,20 @@
       min-width: 0;
       /* This is crucial for proper shrinking */
     }
+
+    // Fade the entire button (border + fill + children), not just its children,
+    // so bordered/filled variants like `secondary` don't leave an empty box behind.
+    .row-hover-button {
+      opacity: 0;
+      transition: opacity 250ms;
+
+      // Reveal on the button's own keyboard focus, not just row hover —
+      // otherwise tabbing to a hidden row-hover button never shows it.
+      &:focus-visible {
+        opacity: 1;
+      }
+    }
+
     &:not(.paginated-list__row--disabled):hover {
       background: $ui-off-white;
       cursor: pointer;
@@ -81,6 +95,10 @@
 
       .policy-row__preview-button {
         visibility: visible;
+      }
+
+      .row-hover-button {
+        opacity: 1;
       }
     }
 

--- a/frontend/components/TableContainer/_styles.scss
+++ b/frontend/components/TableContainer/_styles.scss
@@ -258,6 +258,10 @@
   tr {
     .row-hover-button {
       opacity: 0;
+      // Suppress pointer events while hidden so the invisible button can't
+      // intercept clicks meant for the row. Tab navigation still works —
+      // pointer-events only gates mouse/touch, not keyboard focus.
+      pointer-events: none;
       transition: 250ms;
       text-overflow: none;
 
@@ -265,12 +269,16 @@
       // otherwise tabbing directly to a hidden row-hover button never shows it.
       &:focus-visible {
         opacity: 1;
+        pointer-events: auto;
       }
 
       // React-select's dropdown opacity must be controlled at input level for keyboard nav
       // So must be controlled at input level here as well
       &.actions-dropdown {
         opacity: 1;
+        // React-select handles its own keyboard nav; keep it hit-testable
+        // so focus/blur bookkeeping continues to work even before row hover.
+        pointer-events: auto;
         .actions-dropdown-select__control {
           opacity: 0;
 
@@ -285,6 +293,7 @@
     &:focus-visible {
       .row-hover-button {
         opacity: 1;
+        pointer-events: auto;
       }
       .row-hover-button.actions-dropdown {
         .actions-dropdown-select__control {

--- a/frontend/components/buttons/Button/_styles.scss
+++ b/frontend/components/buttons/Button/_styles.scss
@@ -127,6 +127,11 @@ $base-class: "button";
     opacity: 0;
   }
 
+  // Wraps children so the loading spinner can swap in without a layout shift.
+  // Do NOT hide-then-reveal buttons by fading `.children-wrapper` alone —
+  // bordered/filled variants (`secondary` etc.) will leave an empty button
+  // box behind. Fade the whole button, or use `.row-hover-button`
+  // (see PaginatedList / TableContainer styles).
   .children-wrapper {
     display: flex;
     flex-direction: row;

--- a/frontend/pages/hosts/ManageHostsPage/components/RunScriptBatchPaginatedList/RunScriptBatchPaginatedList.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/RunScriptBatchPaginatedList/RunScriptBatchPaginatedList.tsx
@@ -79,6 +79,7 @@ const RunScriptBatchPaginatedList = ({
     <>
       <a>{script.name}</a>
       <Button
+        className="row-hover-button"
         variant="secondary"
         onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
           e.stopPropagation();

--- a/frontend/pages/hosts/ManageHostsPage/components/RunScriptBatchPaginatedList/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/RunScriptBatchPaginatedList/_styles.scss
@@ -3,15 +3,6 @@
     display: flex;
     justify-content: space-between;
     padding: $pad-small $pad-large;
-    .button > .children-wrapper {
-      opacity: 0;
-      transition: opacity 250ms;
-    }
-    &:hover {
-      .button > .children-wrapper {
-        opacity: 1;
-      }
-    }
   }
   .loading-spinner.centered {
     margin: auto;


### PR DESCRIPTION
## Issue

Resolves #49879

## Description

- Bug fix (root cause): #49292 swapped the row's Run script button from `variant="inverse"` (transparent) to `variant="secondary"` (bordered + off-white fill), but the local hover-reveal CSS only faded `.children-wrapper`. The new border/fill stayed fully visible → empty button box on every row.
- Reworked to use a shared `.row-hover-button` class scoped under `.paginated-list__row` in `PaginatedList/_styles.scss` — mirrors the `tr .row-hover-button` pattern already used in `TableContainer/_styles.scss`. Fades the whole button (border + fill + children) and reveals on row hover + button `:focus-visible`.
- Deleted the local hover CSS in `RunScriptBatchPaginatedList/_styles.scss`.
- Prevention: added a comment on `Button`'s `.children-wrapper` warning against the anti-pattern, and documented `.row-hover-button` as the canonical hover-reveal in `.claude/rules/fleet-frontend.md`.

## Screenrecording


https://github.com/user-attachments/assets/e68fb7a6-fc20-45ea-ac4f-e0272dd1b8e1



## Testing

- [x] `yarn lint` — 0 errors in touched files
- [x] `npx prettier --check` — clean
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Row-level actions now appear when a row is hovered or when the action receives keyboard focus.
  * Improved keyboard accessibility by ensuring focused actions are visible and interactive.

* **Bug Fixes**
  * Hidden row actions no longer intercept mouse or touch interactions.
  * Preserved reliable interaction behavior for action menus and loading states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->