### PR TITLE
Fix check-doc-gen failing on main: use npm ci and drop extraneous lockfile entries

### DIFF
--- a/.github/workflows/check-automated-doc.yml
+++ b/.github/workflows/check-automated-doc.yml
@@ -63,11 +63,14 @@ jobs:
       - name: Verify osquery table JSON schema is up-to-date
         run: |
           cd website
-          npm install
+          # npm ci (not npm install) so npm never rewrites package-lock.json:
+          # newer npm records packages shipped inside dependency tarballs (e.g.
+          # sails-hook-grunt) as "extraneous" lockfile entries, causing spurious drift.
+          npm ci
           ./node_modules/sails/bin/sails.js run generate-merged-schema
           if [[ $(git diff) ]]; then
             echo "❌ fail: uncommitted changes"
-            echo "please run 'cd website && npm install && ./node_modules/sails/bin/sails.js run generate-merged-schema' and commit the changes"
+            echo "please run 'cd website && npm ci && ./node_modules/sails/bin/sails.js run generate-merged-schema' and commit the changes"
             git --no-pager diff
             exit 1
           fi


### PR DESCRIPTION
**Related issue:** N/A — fixes the `check-doc-gen` job failing on `main`

The "Check automated documentation is up-to-date" workflow has been failing on every push to `main` (and every PR that triggers it) since ~18:30 UTC 2026-07-27. The failing step, "Verify osquery table JSON schema is up-to-date," runs `cd website && npm install && sails run generate-merged-schema` and fails if `git diff` is non-empty afterward.

The diff it fails on is `website/package-lock.json` itself: `sails-hook-grunt`'s published tarball ships a `node_modules` folder with packages that aren't part of its dependency graph (dev leftovers like `mocha@3.0.2` and `growl@1.9.2`). Newer npm on the CI runners records those on-disk packages in the lockfile as `"extraneous": true` entries, so any committed lockfile that omits them (e.g. after #49852 regenerated it) no longer matches what `npm install` produces — and any committed lockfile that *includes* them gets flagged by `dependency-review` for the critical `growl@1.9.2` advisory (GHSA-qh2h-chj9-jffq), even though growl is never actually installable from the dependency graph.

This PR fixes the root cause instead of chasing npm's output:

- **`check-doc-gen` now uses `npm ci` instead of `npm install`** — `npm ci` never rewrites `package-lock.json`, so the step's `git diff` check only catches what it's meant to catch (schema drift), and future runner npm upgrades can't reintroduce lockfile churn.
- **`website/package-lock.json` regenerated with `npm install --package-lock-only`** — drops the 107 `extraneous` entries (including `growl@1.9.2`) that were committed to pacify the old `npm install`-based check. No dependency versions change; `npm ci --dry-run` validates the lockfile is in sync.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

## Testing

- [x] QA'd all new/changed functionality manually — verified locally that `npm ci --dry-run` accepts the updated lockfile and that `growl`/`extraneous` entries are gone. Since this PR now modifies the workflow file itself, the `pull_request` path filter triggers `check-doc-gen` on this PR, verifying the `npm ci` path end-to-end in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automated schema validation by using deterministic dependency installation to reduce unnecessary lockfile churn.
  * Refreshed the generated-schema failure message with the correct regeneration steps to follow when updates are detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->