### PR TITLE
Add tooltip explaining missing Refetch button for Android hosts

### DIFF
--- a/changes/50001-android-refetch-tooltip
+++ b/changes/50001-android-refetch-tooltip
@@ -1,0 +1,1 @@
+- Added a tooltip to "Last fetched" on the Host details page for Android hosts, explaining why there's no Refetch button (Android hosts sync data automatically when they change).

--- a/frontend/pages/hosts/details/cards/HostHeader/HostHeader.tests.tsx
+++ b/frontend/pages/hosts/details/cards/HostHeader/HostHeader.tests.tsx
@@ -56,6 +56,24 @@ describe("HostHeader", () => {
     expect(screen.queryByText("Refetch")).not.toBeInTheDocument();
   });
 
+  it("shows a tooltip explaining the missing refetch button for Android hosts", async () => {
+    const { user } = renderWithSetup(
+      <HostHeader
+        summaryData={{ ...defaultSummaryData, platform: "android" }}
+        showRefetchSpinner={false}
+        onRefetchHost={jest.fn()}
+        renderActionsDropdown={renderActionDropdown}
+        hostMdmEnrollmentStatus={null}
+      />
+    );
+
+    await user.hover(screen.getByText(/Last fetched/i));
+
+    expect(
+      await screen.findByText(/there's no Refetch button/i)
+    ).toBeInTheDocument();
+  });
+
   it("disables refetch button when host is offline", () => {
     render(
       <HostHeader

--- a/frontend/pages/hosts/details/cards/HostHeader/HostHeader.tsx
+++ b/frontend/pages/hosts/details/cards/HostHeader/HostHeader.tsx
@@ -12,7 +12,11 @@ import TooltipWrapper from "components/TooltipWrapper";
 import { MdmEnrollmentStatus } from "interfaces/mdm";
 
 import { HostMdmDeviceStatusUIState } from "../../helpers";
-import { DEVICE_STATUS_TAGS, REFETCH_TOOLTIP_MESSAGES } from "./helpers";
+import {
+  ANDROID_NO_REFETCH_TOOLTIP_MESSAGE,
+  DEVICE_STATUS_TAGS,
+  REFETCH_TOOLTIP_MESSAGES,
+} from "./helpers";
 
 const baseClass = "host-header";
 
@@ -209,8 +213,16 @@ const HostHeader = ({
           {renderDeviceStatusTag()}
 
           <div className={`${baseClass}__last-fetched`}>
-            {"Last fetched"} {lastFetched}
-            &nbsp;
+            <TooltipWrapper
+              disableTooltip={!isAndroid(platform)}
+              tipContent={ANDROID_NO_REFETCH_TOOLTIP_MESSAGE}
+              underline={isAndroid(platform)}
+              position="bottom"
+              showArrow
+            >
+              {"Last fetched"} {lastFetched}
+              &nbsp;
+            </TooltipWrapper>
           </div>
         </div>
       </div>

--- a/frontend/pages/hosts/details/cards/HostHeader/helpers.tsx
+++ b/frontend/pages/hosts/details/cards/HostHeader/helpers.tsx
@@ -167,3 +167,10 @@ export const REFETCH_TOOLTIP_MESSAGES: Record<
     </>
   ),
 } as const;
+
+export const ANDROID_NO_REFETCH_TOOLTIP_MESSAGE = (
+  <>
+    For Android hosts, there&apos;s no Refetch button on the Host details page
+    in Fleet because Android hosts sync data automatically when they change.
+  </>
+);


### PR DESCRIPTION
<img width="632" height="196" alt="Screenshot 2026-07-27 at 3 09 16 PM" src="https://github.com/user-attachments/assets/7bfc1440-48a4-4baf-8747-cc5e848a3a53" />

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #50001

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an explanatory tooltip to the “Last fetched” field for Android hosts.
  * The tooltip clarifies that Android hosts sync automatically and therefore do not have a “Refetch” button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->