### PR TITLE
Website: rename "Reporting" pricing feature for clarity

### DIFF
--- a/handbook/company/pricing-features-table.yml
+++ b/handbook/company/pricing-features-table.yml
@@ -971,8 +971,8 @@
 #  ╦═╗╔═╗╔═╗╔═╗╦═╗╔╦╗╦╔╗╔╔═╗  
 #  ╠╦╝║╣ ╠═╝║ ║╠╦╝ ║ ║║║║║ ╦   
 #  ╩╚═╚═╝╩  ╚═╝╩╚═ ╩ ╩╝╚╝╚═╝                                                                                                                                                                                                               
-- industryName: Reporting
-  description: Generate reports based on searchable device attributes
+- industryName: Report on groups of devices
+  description: Create a report scoped to a specific fleet, instead of your whole deployment.
   documentationUrl: https://fleetdm.com/docs/rest-api/rest-api#get-query-report
   productCategories: [Endpoint operations,Device management,Vulnerability management]
   pricingTableCategories: [Device management]


### PR DESCRIPTION
## Summary
Renames "Reporting" on /pricing to "Report on groups of devices" and updates the description for accuracy — it was easily confused with the "Reports" feature listed just above it.

## Related
- fleetdm/confidential#16974

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for generating reports scoped to specific fleets of devices instead of the entire deployment.
  * Updated the pricing features table to reflect fleet-level reporting capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->