### PR TITLE
Add scripts and configuration profiles steps to downgrade guide

### DIFF
--- a/articles/downgrade-fleet.md
+++ b/articles/downgrade-fleet.md
@@ -39,7 +39,7 @@ Configuration profiles and assets are configured per fleet and won't be applied 
 1. Head to the **Controls > OS settings > Configuration profiles** page in the Fleet UI. Select either **Profiles** or **Assets** in the menu, and select a fleet from the dropdown at the top of the page.
 2. For each configuration profile or assset that belongs to a fleet, select the download icon to save a copy.
 3. Select **Unassigned** in the top dropdown, then upload each configuration profile you saved.
-4. **Optional:** Delete each configuration profile that belongs to a fleet because they will no longer be applied following the downgrade process.
+4. **Optional:** Delete each configuration profile and asset that belongs to a fleet because they will no longer be applied following the downgrade process.
 
 ## Back up your fleets
 

--- a/articles/downgrade-fleet.md
+++ b/articles/downgrade-fleet.md
@@ -37,7 +37,7 @@ Scripts are configured per fleet and won't be accessible after your fleets are d
 Configuration profiles and assets are configured per fleet and won't be applied after your fleets are deleted. Move them to "Unassigned" so they continue to apply to your hosts following the downgrade.
 
 1. Head to the **Controls > OS settings > Configuration profiles** page in the Fleet UI. Select either **Profiles** or **Assets** in the menu, and select a fleet from the dropdown at the top of the page.
-2. For each configuration profile that belongs to a fleet, select the download icon to save a copy.
+2. For each configuration profile or assset that belongs to a fleet, select the download icon to save a copy.
 3. Select **Unassigned** in the top dropdown, then upload each configuration profile you saved.
 4. **Optional:** Delete each configuration profile that belongs to a fleet because they will no longer be applied following the downgrade process.
 

--- a/articles/downgrade-fleet.md
+++ b/articles/downgrade-fleet.md
@@ -38,7 +38,7 @@ Configuration profiles and assets are configured per fleet and won't be applied 
 
 1. Head to the **Controls > OS settings > Configuration profiles** page in the Fleet UI. Select either **Profiles** or **Assets** in the menu, and select a fleet from the dropdown at the top of the page.
 2. For each configuration profile or assset that belongs to a fleet, select the download icon to save a copy.
-3. Select **Unassigned** in the top dropdown, then upload each configuration profile you saved.
+3. Select **Unassigned** in the top dropdown, then upload each configuration profile and/or asset you saved.
 4. **Optional:** Delete each configuration profile and asset that belongs to a fleet because they will no longer be applied following the downgrade process.
 
 ## Back up your fleets

--- a/articles/downgrade-fleet.md
+++ b/articles/downgrade-fleet.md
@@ -32,15 +32,6 @@ Scripts are configured per fleet and won't be accessible after your fleets are d
 3. Select **Unassigned** in the top dropdown, then select **Add script** and upload each script you saved.
 4. **Optional:** Delete each script that belongs to a fleet because they will no longer be accessible in the Fleet UI following the downgrade process.
 
-## Move all fleet-level configuration profiles to "Unassigned"
-
-Configuration profiles are configured per fleet and won't be applied after your fleets are deleted. Move them to "Unassigned" so they continue to apply to your hosts following the downgrade.
-
-1. Head to the **Controls > OS settings > Configuration profiles** page in the Fleet UI and select a fleet from the dropdown at the top of the page.
-2. For each configuration profile that belongs to a fleet, select the download icon to save a copy.
-3. Select **Unassigned** in the top dropdown, then upload each configuration profile you saved.
-4. **Optional:** Delete each configuration profile that belongs to a fleet because they will no longer be applied following the downgrade process.
-
 ## Back up your fleets
 
 1. Run the `fleetctl get fleets > fleets.yml` command. Save the `fleets.yml` file so you can restore your fleets if you upgrade again later.

--- a/articles/downgrade-fleet.md
+++ b/articles/downgrade-fleet.md
@@ -36,7 +36,7 @@ Scripts are configured per fleet and won't be accessible after your fleets are d
 
 Configuration profiles and assets are configured per fleet and won't be applied after your fleets are deleted. Move them to "Unassigned" so they continue to apply to your hosts following the downgrade.
 
-1. Head to the **Controls > OS settings > Configuration profiles** page in the Fleet UI and select a fleet from the dropdown at the top of the page.
+1. Head to the **Controls > OS settings > Configuration profiles** page in the Fleet UI. Select either **Profiles** or **Assets** in the menu, and select a fleet from the dropdown at the top of the page.
 2. For each configuration profile that belongs to a fleet, select the download icon to save a copy.
 3. Select **Unassigned** in the top dropdown, then upload each configuration profile you saved.
 4. **Optional:** Delete each configuration profile that belongs to a fleet because they will no longer be applied following the downgrade process.

--- a/articles/downgrade-fleet.md
+++ b/articles/downgrade-fleet.md
@@ -32,7 +32,7 @@ Scripts are configured per fleet and won't be accessible after your fleets are d
 3. Select **Unassigned** in the top dropdown, then select **Add script** and upload each script you saved.
 4. **Optional:** Delete each script that belongs to a fleet because they will no longer be accessible in the Fleet UI following the downgrade process.
 
-## Move all fleet-level configuration profiles to "Unassigned"
+## Move all fleet-level configuration profiles and assets to "Unassigned"
 
 Configuration profiles are configured per fleet and won't be applied after your fleets are deleted. Move them to "Unassigned" so they continue to apply to your hosts following the downgrade.
 

--- a/articles/downgrade-fleet.md
+++ b/articles/downgrade-fleet.md
@@ -23,22 +23,22 @@ Follow these steps to downgrade your Fleet instance from Fleet Premium.
 2. For each policy that belongs to a fleet, copy the **Name**, **Description**, **Resolve**, and **Query**. Then, select **All fleets** in the top dropdown, select **Add a policy**, select **Create your own policy**, paste each item in the appropriate field, and select **Save**.
 3. Delete each policy that belongs to a fleet because they will no longer run on any hosts following the downgrade process.
 
-## Move all fleet-level scripts to "No team"
+## Move all fleet-level scripts to "Unassigned"
 
-Scripts are configured per fleet and won't be accessible after your fleets are deleted. Move them to "No team" so they remain available following the downgrade.
+Scripts are configured per fleet and won't be accessible after your fleets are deleted. Move them to "Unassigned" so they remain available following the downgrade.
 
 1. Head to the **Controls > Scripts** page in the Fleet UI and select a fleet from the dropdown at the top of the page.
 2. For each script that belongs to a fleet, select the download icon to save a copy.
-3. Select **No team** in the top dropdown, then select **Add script** and upload each script you saved.
+3. Select **Unassigned** in the top dropdown, then select **Add script** and upload each script you saved.
 4. **Optional:** Delete each script that belongs to a fleet because they will no longer be accessible in the Fleet UI following the downgrade process.
 
-## Move all fleet-level configuration profiles to "No team"
+## Move all fleet-level configuration profiles to "Unassigned"
 
-Configuration profiles are configured per fleet and won't be applied after your fleets are deleted. Move them to "No team" so they continue to apply to your hosts following the downgrade.
+Configuration profiles are configured per fleet and won't be applied after your fleets are deleted. Move them to "Unassigned" so they continue to apply to your hosts following the downgrade.
 
 1. Head to the **Controls > OS settings > Configuration profiles** page in the Fleet UI and select a fleet from the dropdown at the top of the page.
 2. For each configuration profile that belongs to a fleet, select the download icon to save a copy.
-3. Select **No team** in the top dropdown, then upload each configuration profile you saved.
+3. Select **Unassigned** in the top dropdown, then upload each configuration profile you saved.
 4. **Optional:** Delete each configuration profile that belongs to a fleet because they will no longer be applied following the downgrade process.
 
 ## Back up your fleets

--- a/articles/downgrade-fleet.md
+++ b/articles/downgrade-fleet.md
@@ -23,6 +23,24 @@ Follow these steps to downgrade your Fleet instance from Fleet Premium.
 2. For each policy that belongs to a fleet, copy the **Name**, **Description**, **Resolve**, and **Query**. Then, select **All fleets** in the top dropdown, select **Add a policy**, select **Create your own policy**, paste each item in the appropriate field, and select **Save**.
 3. Delete each policy that belongs to a fleet because they will no longer run on any hosts following the downgrade process.
 
+## Move all fleet-level scripts to "No team"
+
+Scripts are configured per fleet and won't be accessible after your fleets are deleted. Move them to "No team" so they remain available following the downgrade.
+
+1. Head to the **Controls > Scripts** page in the Fleet UI and select a fleet from the dropdown at the top of the page.
+2. For each script that belongs to a fleet, select the download icon to save a copy.
+3. Select **No team** in the top dropdown, then select **Add script** and upload each script you saved.
+4. **Optional:** Delete each script that belongs to a fleet because they will no longer be accessible in the Fleet UI following the downgrade process.
+
+## Move all fleet-level configuration profiles to "No team"
+
+Configuration profiles are configured per fleet and won't be applied after your fleets are deleted. Move them to "No team" so they continue to apply to your hosts following the downgrade.
+
+1. Head to the **Controls > OS settings > Configuration profiles** page in the Fleet UI and select a fleet from the dropdown at the top of the page.
+2. For each configuration profile that belongs to a fleet, select the download icon to save a copy.
+3. Select **No team** in the top dropdown, then upload each configuration profile you saved.
+4. **Optional:** Delete each configuration profile that belongs to a fleet because they will no longer be applied following the downgrade process.
+
 ## Back up your fleets
 
 1. Run the `fleetctl get fleets > fleets.yml` command. Save the `fleets.yml` file so you can restore your fleets if you upgrade again later.

--- a/articles/downgrade-fleet.md
+++ b/articles/downgrade-fleet.md
@@ -34,7 +34,7 @@ Scripts are configured per fleet and won't be accessible after your fleets are d
 
 ## Move all fleet-level configuration profiles and assets to "Unassigned"
 
-Configuration profiles are configured per fleet and won't be applied after your fleets are deleted. Move them to "Unassigned" so they continue to apply to your hosts following the downgrade.
+Configuration profiles and assets are configured per fleet and won't be applied after your fleets are deleted. Move them to "Unassigned" so they continue to apply to your hosts following the downgrade.
 
 1. Head to the **Controls > OS settings > Configuration profiles** page in the Fleet UI and select a fleet from the dropdown at the top of the page.
 2. For each configuration profile that belongs to a fleet, select the download icon to save a copy.

--- a/articles/downgrade-fleet.md
+++ b/articles/downgrade-fleet.md
@@ -32,6 +32,15 @@ Scripts are configured per fleet and won't be accessible after your fleets are d
 3. Select **Unassigned** in the top dropdown, then select **Add script** and upload each script you saved.
 4. **Optional:** Delete each script that belongs to a fleet because they will no longer be accessible in the Fleet UI following the downgrade process.
 
+## Move all fleet-level configuration profiles to "Unassigned"
+
+Configuration profiles are configured per fleet and won't be applied after your fleets are deleted. Move them to "Unassigned" so they continue to apply to your hosts following the downgrade.
+
+1. Head to the **Controls > OS settings > Configuration profiles** page in the Fleet UI and select a fleet from the dropdown at the top of the page.
+2. For each configuration profile that belongs to a fleet, select the download icon to save a copy.
+3. Select **Unassigned** in the top dropdown, then upload each configuration profile you saved.
+4. **Optional:** Delete each configuration profile that belongs to a fleet because they will no longer be applied following the downgrade process.
+
 ## Back up your fleets
 
 1. Run the `fleetctl get fleets > fleets.yml` command. Save the `fleets.yml` file so you can restore your fleets if you upgrade again later.


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** NA

## Description

Improves the [downgrade guide](https://fleetdm.com/guides/downgrade-fleet) instead of changing product behavior, per product design's direction.

The guide told users to move fleet-level **reports** and **policies** to the global level before downgrading, but omitted **scripts** and **configuration profiles**. Both are scoped per fleet and become inaccessible once fleets are deleted during the downgrade, so users lose them with no warning.

Adds two sections — "Move all fleet-level scripts to Unassigned" and "Move all fleet-level configuration profiles to Unassigned" — placed before the fleet-deletion step so users move them while the fleets still exist. Unlike reports/policies (which move to the global level), scripts and configuration profiles have no global bucket — they live under a fleet or **Unassigned** — so the steps direct users to re-add them under **Unassigned**, which remains available on Fleet Free.

> **Draft — pending wording pass.** The steps use "Unassigned" to match the label in the Controls dropdown. Flagging for @Mel for a wording review before this goes out.

## Testing

- [ ] N/A — documentation only.

# Checklist for submitter

- [x] Documentation change only; no code, tests, or migrations.
