### PR TITLE
Require Fleet MDM enrollment before escrowing macOS disk encryption key

### DIFF
--- a/changes/48965-escrow-requires-fleet-mdm.md
+++ b/changes/48965-escrow-requires-fleet-mdm.md
@@ -1,0 +1,1 @@
+- Fixed Fleet storing an unusable disk encryption key and logging an escrow activity for macOS hosts that aren't enrolled in Fleet's MDM.

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -2785,8 +2785,10 @@ func (s *integrationMDMTestSuite) TestMDMAppleHostDiskEncryptionWithDisabledEncr
 	t := s.T()
 	ctx := context.Background()
 
-	// Create a macOS host enrolled via orbit
-	host := createOrbitEnrolledHost(t, "darwin", "h1", s.ds)
+	// Create a macOS host enrolled in Fleet's MDM. Fleet MDM enrollment is required
+	// to escrow a disk encryption key (see the IsHostConnectedToFleetMDM check in
+	// the darwin key ingestion).
+	host, _ := createHostThenEnrollMDM(s.ds, s.server.URL, t)
 
 	// Turn on disk encryption for the global team
 	acResp := appConfigResponse{}

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -2931,6 +2931,15 @@ func directIngestDiskEncryptionKeyFileDarwin(
 		decryptable = ptr.Bool(false)
 	}
 
+	// Only archive the key if disk encryption is enabled for this host (team / globally)
+	if !IsDiskEncryptionEnabledForHost(ctx, logger, ds, host) {
+		logger.DebugContext(ctx, "skipping key archival, disk encryption not enabled for host (team/globally)",
+			"component", "service",
+			"method", "directIngestDiskEncryptionKeyFileDarwin",
+			"host", host.Hostname)
+		return nil
+	}
+
 	// Only archive the key if the host is connected to Fleet's MDM. Without Fleet
 	// MDM, Fleet never installed the FileVault escrow profile, so a key found on
 	// disk (e.g. left over from a previous MDM) can't be decrypted or used.
@@ -2941,15 +2950,6 @@ func directIngestDiskEncryptionKeyFileDarwin(
 	}
 	if !connected {
 		logger.DebugContext(ctx, "skipping key archival, host not connected to Fleet MDM",
-			"component", "service",
-			"method", "directIngestDiskEncryptionKeyFileDarwin",
-			"host", host.Hostname)
-		return nil
-	}
-
-	// Only archive the key if disk encryption is enabled for this host (team / globally)
-	if !IsDiskEncryptionEnabledForHost(ctx, logger, ds, host) {
-		logger.DebugContext(ctx, "skipping key archival, disk encryption not enabled for host (team/globally)",
 			"component", "service",
 			"method", "directIngestDiskEncryptionKeyFileDarwin",
 			"host", host.Hostname)
@@ -3016,6 +3016,15 @@ func directIngestDiskEncryptionKeyFileLinesDarwin(
 		decryptable = ptr.Bool(false)
 	}
 
+	// Only archive the key if disk encryption is enabled for this host (team/globally)
+	if !IsDiskEncryptionEnabledForHost(ctx, logger, ds, host) {
+		logger.DebugContext(ctx, "skipping key archival, disk encryption not enabled for host team/globally",
+			"component", "service",
+			"method", "directIngestDiskEncryptionKeyFileLinesDarwin",
+			"host", host.Hostname)
+		return nil
+	}
+
 	// Only archive the key if the host is connected to Fleet's MDM. Without Fleet
 	// MDM, Fleet never installed the FileVault escrow profile, so a key found on
 	// disk (e.g. left over from a previous MDM) can't be decrypted or used.
@@ -3026,15 +3035,6 @@ func directIngestDiskEncryptionKeyFileLinesDarwin(
 	}
 	if !connected {
 		logger.DebugContext(ctx, "skipping key archival, host not connected to Fleet MDM",
-			"component", "service",
-			"method", "directIngestDiskEncryptionKeyFileLinesDarwin",
-			"host", host.Hostname)
-		return nil
-	}
-
-	// Only archive the key if disk encryption is enabled for this host (team/globally)
-	if !IsDiskEncryptionEnabledForHost(ctx, logger, ds, host) {
-		logger.DebugContext(ctx, "skipping key archival, disk encryption not enabled for host team/globally",
 			"component", "service",
 			"method", "directIngestDiskEncryptionKeyFileLinesDarwin",
 			"host", host.Hostname)

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -2931,6 +2931,22 @@ func directIngestDiskEncryptionKeyFileDarwin(
 		decryptable = ptr.Bool(false)
 	}
 
+	// Only archive the key if the host is connected to Fleet's MDM. Without Fleet
+	// MDM, Fleet never installed the FileVault escrow profile, so a key found on
+	// disk (e.g. left over from a previous MDM) can't be decrypted or used.
+	// Escrowing it would record a misleading activity and store an unusable key.
+	connected, err := ds.IsHostConnectedToFleetMDM(ctx, host)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "checking Fleet MDM connection before disk encryption key archival")
+	}
+	if !connected {
+		logger.DebugContext(ctx, "skipping key archival, host not connected to Fleet MDM",
+			"component", "service",
+			"method", "directIngestDiskEncryptionKeyFileDarwin",
+			"host", host.Hostname)
+		return nil
+	}
+
 	// Only archive the key if disk encryption is enabled for this host (team / globally)
 	if !IsDiskEncryptionEnabledForHost(ctx, logger, ds, host) {
 		logger.DebugContext(ctx, "skipping key archival, disk encryption not enabled for host (team/globally)",
@@ -2998,6 +3014,22 @@ func directIngestDiskEncryptionKeyFileLinesDarwin(
 	base64Key := base64.StdEncoding.EncodeToString(b)
 	if base64Key == "" {
 		decryptable = ptr.Bool(false)
+	}
+
+	// Only archive the key if the host is connected to Fleet's MDM. Without Fleet
+	// MDM, Fleet never installed the FileVault escrow profile, so a key found on
+	// disk (e.g. left over from a previous MDM) can't be decrypted or used.
+	// Escrowing it would record a misleading activity and store an unusable key.
+	connected, err := ds.IsHostConnectedToFleetMDM(ctx, host)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "checking Fleet MDM connection before disk encryption key archival")
+	}
+	if !connected {
+		logger.DebugContext(ctx, "skipping key archival, host not connected to Fleet MDM",
+			"component", "service",
+			"method", "directIngestDiskEncryptionKeyFileLinesDarwin",
+			"host", host.Hostname)
+		return nil
 	}
 
 	// Only archive the key if disk encryption is enabled for this host (team/globally)

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -2416,6 +2416,11 @@ func TestDirectIngestDiskEncryptionKeyDarwin(t *testing.T) {
 		}, nil
 	}
 
+	// Default to connected to Fleet MDM; the dedicated subtest below overrides this.
+	ds.IsHostConnectedToFleetMDMFunc = func(ctx context.Context, h *fleet.Host) (bool, error) {
+		return true, nil
+	}
+
 	var wantKey string
 
 	mockFileLines := func(wantKey string, wantEncrypted string) []map[string]string {
@@ -2453,6 +2458,28 @@ func TestDirectIngestDiskEncryptionKeyDarwin(t *testing.T) {
 		}
 		return false, nil
 	}
+
+	t.Run("host not connected to Fleet MDM", func(t *testing.T) {
+		ds.IsHostConnectedToFleetMDMFunc = func(ctx context.Context, h *fleet.Host) (bool, error) {
+			return false, nil
+		}
+		defer func() {
+			ds.IsHostConnectedToFleetMDMFunc = func(ctx context.Context, h *fleet.Host) (bool, error) {
+				return true, nil
+			}
+		}()
+
+		// A host that isn't enrolled in Fleet's MDM must not have its key escrowed,
+		// even with an encrypted disk and a key present (e.g. left over from a prior MDM).
+		err := directIngestDiskEncryptionKeyFileLinesDarwin(ctx, logger, host, ds,
+			[]map[string]string{{"encrypted": "1", "hex_line": hex.EncodeToString([]byte("prk"))}})
+		require.NoError(t, err)
+		require.False(t, ds.SetOrUpdateHostDiskEncryptionKeyFuncInvoked)
+
+		err = directIngestDiskEncryptionKeyFileDarwin(ctx, logger, host, ds, mockFilevaultPRK("prk", "1"))
+		require.NoError(t, err)
+		require.False(t, ds.SetOrUpdateHostDiskEncryptionKeyFuncInvoked)
+	})
 
 	t.Run("empty key", func(t *testing.T) {
 		err := directIngestDiskEncryptionKeyFileLinesDarwin(ctx, logger, host, ds, []map[string]string{})


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #48965

## Description

Fleet was escrowing a macOS disk encryption key — and logging an "escrowed a disk encryption key" activity — for hosts that aren't enrolled in Fleet's MDM (e.g. still managed by Jamf, or with a leftover `/var/db/FileVaultPRK.dat`). Because Fleet never installed its FileVault escrow profile on such a host, the stored key is unusable: the cron marks it `decryptable = 0` and `GET /hosts/:id/encryption_key` returns 422, so "Show disk encryption key" never appears. The result is a misleading activity and a dead key row.

Root cause: the macOS key ingestion (`directIngestDiskEncryptionKeyFileDarwin` and its `file_lines` fallback) gated only on the disk being encrypted and disk encryption being enabled for the host's team — it never checked Fleet MDM enrollment. The Windows/orbit key path (`SetOrUpdateDiskEncryptionKey`) already performs this check.

- **`server/service/osquery_utils/queries.go`** — added an `IsHostConnectedToFleetMDM` guard to both macOS ingestion functions, skipping archival (no key stored, no activity) when the host isn't connected to Fleet MDM. Mirrors the existing Windows path.

Prevention only — this stops new bad escrows; it does not delete keys previously escrowed for non-enrolled hosts.

## Testing

- **Unit** (`queries_test.go`): added a "host not connected to Fleet MDM" case asserting neither ingestion function escrows when the host isn't Fleet-MDM-connected, and initialized the `IsHostConnectedToFleetMDM` mock so existing cases still pass.
- **Integration** (`integration_mdm_test.go`): `TestMDMAppleHostDiskEncryptionWithDisabledEncryptionSetting` was creating an orbit-only host (no Fleet MDM) and expecting escrow to succeed — i.e. relied on the bug. Switched it to a Fleet-MDM-enrolled host (`createHostThenEnrollMDM`), which is now required for escrow. Passes.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements).

## Testing

- [x] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually <!-- covered by automated integration test; live no-device repro is impractical, flagged for reviewer -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - FileVault recovery keys are now archived/escrowed only for macOS hosts that are connected to Fleet MDM.
  - Hosts without an active Fleet MDM connection no longer attempt to archive encryption keys.
  - Disk-encryption key archival now cleanly reports MDM connectivity errors when checks fail.
- **Tests**
  - Added/updated coverage to verify both connected and disconnected host scenarios, including ensuring no archival occurs when MDM is not connected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->