### PR TITLE
Update `tools/telemetry`

### DIFF
--- a/tools/telemetry/docker-compose.yml
+++ b/tools/telemetry/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "2"
 services:
 
   # Jaeger
@@ -14,7 +13,7 @@ services:
 
   # Collector
   otel-collector:
-    image: otel/opentelemetry-collector-contrib-dev:latest
+    image: otel/opentelemetry-collector-contrib:latest
     command: ["--config=/etc/otel-collector-config.yaml"]
     volumes:
       - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml

--- a/tools/telemetry/otel-collector-config.yaml
+++ b/tools/telemetry/otel-collector-config.yaml
@@ -2,29 +2,29 @@ receivers:
   otlp:
     protocols:
       grpc:
-
-  # Dummy receiver that's never used, because a pipeline is
-  # required to have one.
-  otlp/spanmetrics:
-    protocols:
-      grpc:
-        endpoint: "localhost:65535"
+        endpoint: "0.0.0.0:4317"
 
 exporters:
   prometheus:
     endpoint: "0.0.0.0:8889"
 
-  logging:
+  debug:
 
-  jaeger:
-    endpoint: jaeger-all-in-one:14250
+  # Jaeger ingests OTLP natively (COLLECTOR_OTLP_ENABLED=true in
+  # docker-compose.yml); the dedicated jaeger exporter was removed
+  # from the collector.
+  otlp/jaeger:
+    endpoint: jaeger-all-in-one:4317
     tls:
       insecure: true
 
 processors:
   batch:
+
+connectors:
+  # Replaces the removed spanmetrics processor: consumes traces,
+  # emits metrics into the metrics pipeline.
   spanmetrics:
-    metrics_exporter: prometheus
 
 extensions:
   health_check:
@@ -38,16 +38,9 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [spanmetrics, batch]
-      exporters: [logging, jaeger]
-    metrics:
-      receivers: [otlp]
       processors: [batch]
-      exporters: [logging, prometheus]
-    # The exporter name in this pipeline must match the
-    # spanmetrics.metrics_exporter name.  The receiver is just a
-    # dummy and never used; added to pass validation requiring at
-    # least one receiver in a pipeline.
-    metrics/spanmetrics:
-      receivers: [otlp/spanmetrics]
-      exporters: [prometheus]
+      exporters: [debug, otlp/jaeger, spanmetrics]
+    metrics:
+      receivers: [otlp, spanmetrics]
+      processors: [batch]
+      exporters: [debug, prometheus]


### PR DESCRIPTION
Had to use `tools/telemetry` to smoke test https://github.com/fleetdm/fleet/pull/49957.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Updated telemetry collection to use the standard OpenTelemetry Collector image.
  * Improved trace forwarding to Jaeger and added clearer diagnostic output.
  * Reworked span-to-metrics processing for more reliable telemetry metrics.
  * Updated telemetry endpoints and pipeline routing for improved connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->