### PR TITLE
iOS/iPadOS device vitals: ack parsing + wiring (2/2)

### DIFF
--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -6237,6 +6237,16 @@ func (svc *MDMAppleCheckinAndCommandService) handleRefetchDeviceResults(ctx cont
 		return nil, ctxerr.Wrap(ctx, err, "failed to update host")
 	}
 
+	// A failure here is logged rather than returned: the refetch results are
+	// already persisted above, this is a non-critical write the next refetch
+	// will redo, and aborting would skip the MDM-enrollment-status and
+	// lost-mode reconciliation below. Mirrors UpdateHostDeviceNameStatusFromReport
+	// just below.
+	vitals := parseMDMAppleDeviceVitals(queryResponses)
+	if err := svc.ds.SetOrUpdateHostMDMAppleDeviceVitals(ctx, host.UUID, vitals); err != nil {
+		svc.logger.ErrorContext(ctx, "update host mdm apple device vitals from refetch", "host_uuid", host.UUID, "err", err)
+	}
+
 	if deviceNameOK && deviceName != "" && fleet.IsAppleMobilePlatform(host.Platform) {
 		// Reconcile the host-name enforcement row (if any) against the name the
 		// device reported: confirms a rename (verifying → verified) or records

--- a/server/service/apple_mdm_device_vitals.go
+++ b/server/service/apple_mdm_device_vitals.go
@@ -1,0 +1,228 @@
+package service
+
+import (
+	"time"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+)
+
+// plistOpt returns a pointer to queryResponses[key] cast to T, or nil if the
+// key is absent or holds a value of a different type. Mirrors the existing
+// "only assign when present" pattern in handleRefetchDeviceResults, extended
+// to the generic case via Go generics since T varies per Apple query key
+// (string, bool, float64, int64, time.Time).
+func plistOpt[T any](queryResponses map[string]any, key string) *T {
+	v, ok := queryResponses[key]
+	if !ok {
+		return nil
+	}
+	t, ok := v.(T)
+	if !ok {
+		return nil
+	}
+	return &t
+}
+
+// plistOptInt64 returns queryResponses[key] as an int64, or nil if absent/wrong
+// type. The plist library (github.com/micromdm/plist) decodes a plist
+// <integer> into either int64 or uint64 depending on whether the value is
+// negative (see its signedInt type) — non-negative values, the common case
+// for Apple's DeviceInformation integer fields (CellularTechnology, the
+// AccessibilitySettings TextSize), decode as uint64 even in XML plists, and
+// binary plists decode ALL integers as uint64 regardless of sign. Asserting
+// only int64 would silently drop every such value.
+func plistOptInt64(queryResponses map[string]any, key string) *int64 {
+	v, ok := queryResponses[key]
+	if !ok {
+		return nil
+	}
+	switch n := v.(type) {
+	case int64:
+		return &n
+	case uint64:
+		i := int64(n) //nolint:gosec // Apple's documented integer fields fit comfortably in int64.
+		return &i
+	default:
+		return nil
+	}
+}
+
+// plistOptBytes returns queryResponses[key] cast to []byte (the Go type the
+// plist library produces for a plist <data> element), or nil if absent/wrong
+// type.
+func plistOptBytes(queryResponses map[string]any, key string) []byte {
+	v, ok := queryResponses[key]
+	if !ok {
+		return nil
+	}
+	b, ok := v.([]byte)
+	if !ok {
+		return nil
+	}
+	return b
+}
+
+// plistOptDataArray returns queryResponses[key] cast to [][]byte (an array of
+// plist <data> elements), or nil if absent/wrong type. Used for
+// DevicePropertiesAttestation, whose value is a DER certificate chain.
+func plistOptDataArray(queryResponses map[string]any, key string) [][]byte {
+	v, ok := queryResponses[key]
+	if !ok {
+		return nil
+	}
+	arr, ok := v.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([][]byte, 0, len(arr))
+	for _, elem := range arr {
+		if b, ok := elem.([]byte); ok {
+			out = append(out, b)
+		}
+	}
+	return out
+}
+
+// plistOptDictArray returns queryResponses[key] cast to a slice of nested
+// dictionaries, or nil if absent/wrong type. Used for ServiceSubscriptions.
+func plistOptDictArray(queryResponses map[string]any, key string) []map[string]any {
+	v, ok := queryResponses[key]
+	if !ok {
+		return nil
+	}
+	arr, ok := v.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]map[string]any, 0, len(arr))
+	for _, elem := range arr {
+		if m, ok := elem.(map[string]any); ok {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+func parseMDMAppleAccessibilitySettings(queryResponses map[string]any) *fleet.MDMAppleAccessibilitySettings {
+	m, ok := queryResponses["AccessibilitySettings"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	return &fleet.MDMAppleAccessibilitySettings{
+		BoldTextEnabled:            plistOpt[bool](m, "BoldTextEnabled"),
+		GrayscaleEnabled:           plistOpt[bool](m, "GrayscaleEnabled"),
+		IncreaseContrastEnabled:    plistOpt[bool](m, "IncreaseContrastEnabled"),
+		ReduceMotionEnabled:        plistOpt[bool](m, "ReduceMotionEnabled"),
+		ReduceTransparencyEnabled:  plistOpt[bool](m, "ReduceTransparencyEnabled"),
+		TextSize:                   plistOptInt64(m, "TextSize"),
+		TouchAccommodationsEnabled: plistOpt[bool](m, "TouchAccommodationsEnabled"),
+		VoiceOverEnabled:           plistOpt[bool](m, "VoiceOverEnabled"),
+		ZoomEnabled:                plistOpt[bool](m, "ZoomEnabled"),
+	}
+}
+
+func parseMDMAppleOrganizationInfo(queryResponses map[string]any) *fleet.MDMAppleOrganizationInfo {
+	m, ok := queryResponses["OrganizationInfo"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	return &fleet.MDMAppleOrganizationInfo{
+		OrganizationName:    plistOpt[string](m, "OrganizationName"),
+		OrganizationAddress: plistOpt[string](m, "OrganizationAddress"),
+		OrganizationPhone:   plistOpt[string](m, "OrganizationPhone"),
+		OrganizationEmail:   plistOpt[string](m, "OrganizationEmail"),
+		OrganizationMagic:   plistOpt[string](m, "OrganizationMagic"),
+	}
+}
+
+func parseMDMAppleDeviceVitalsMDMOptions(queryResponses map[string]any) *fleet.MDMAppleDeviceVitalsMDMOptions {
+	m, ok := queryResponses["MDMOptions"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	return &fleet.MDMAppleDeviceVitalsMDMOptions{
+		ActivationLockAllowedWhileSupervised:             plistOpt[bool](m, "ActivationLockAllowedWhileSupervised"),
+		BootstrapTokenAllowed:                            plistOpt[bool](m, "BootstrapTokenAllowed"),
+		PromptUserToAllowBootstrapTokenForAuthentication: plistOpt[bool](m, "PromptUserToAllowBootstrapTokenForAuthentication"),
+	}
+}
+
+func parseMDMAppleServiceSubscriptions(queryResponses map[string]any) []fleet.MDMAppleServiceSubscription {
+	dicts := plistOptDictArray(queryResponses, "ServiceSubscriptions")
+	if dicts == nil {
+		return nil
+	}
+	subscriptions := make([]fleet.MDMAppleServiceSubscription, 0, len(dicts))
+	for _, m := range dicts {
+		slot := plistOpt[string](m, "Slot")
+		if slot == nil {
+			// Slot is the child table's key; a subscription entry without one can't
+			// be persisted.
+			continue
+		}
+		subscriptions = append(subscriptions, fleet.MDMAppleServiceSubscription{
+			Slot:                     *slot,
+			CarrierSettingsVersion:   plistOpt[string](m, "CarrierSettingsVersion"),
+			CurrentCarrierNetwork:    plistOpt[string](m, "CurrentCarrierNetwork"),
+			CurrentMCC:               plistOpt[string](m, "CurrentMCC"),
+			CurrentMNC:               plistOpt[string](m, "CurrentMNC"),
+			EID:                      plistOpt[string](m, "EID"),
+			ICCID:                    plistOpt[string](m, "ICCID"),
+			IMEI:                     plistOpt[string](m, "IMEI"),
+			IsDataPreferred:          plistOpt[bool](m, "IsDataPreferred"),
+			IsRoaming:                plistOpt[bool](m, "IsRoaming"),
+			IsVoicePreferred:         plistOpt[bool](m, "IsVoicePreferred"),
+			Label:                    plistOpt[string](m, "Label"),
+			LabelID:                  plistOpt[string](m, "LabelID"),
+			MEID:                     plistOpt[string](m, "MEID"),
+			PhoneNumber:              plistOpt[string](m, "PhoneNumber"),
+			SubscriberCarrierNetwork: plistOpt[string](m, "SubscriberCarrierNetwork"),
+		})
+	}
+	return subscriptions
+}
+
+// parseMDMAppleDeviceVitals builds the fields to persist to
+// host_mdm_apple_device_vitals / host_mdm_apple_service_subscriptions from a
+// DeviceInformation command ack's QueryResponses dictionary. Fields absent
+// from queryResponses (an enrollment method that doesn't support them, or an
+// older OS) are left nil, which SetOrUpdateHostMDMAppleDeviceVitals persists
+// as SQL NULL.
+func parseMDMAppleDeviceVitals(queryResponses map[string]any) fleet.MDMAppleDeviceVitals {
+	return fleet.MDMAppleDeviceVitals{
+		UDID:                       plistOpt[string](queryResponses, "UDID"),
+		ModelNumber:                plistOpt[string](queryResponses, "ModelNumber"),
+		ModemFirmwareVersion:       plistOpt[string](queryResponses, "ModemFirmwareVersion"),
+		SupplementalBuildVersion:   plistOpt[string](queryResponses, "SupplementalBuildVersion"),
+		SupplementalOSVersionExtra: plistOpt[string](queryResponses, "SupplementalOSVersionExtra"),
+		BluetoothMAC:               plistOpt[string](queryResponses, "BluetoothMAC"),
+		WiFiMAC:                    plistOpt[string](queryResponses, "WiFiMAC"),
+		EASDeviceIdentifier:        plistOpt[string](queryResponses, "EASDeviceIdentifier"),
+		ITunesStoreAccountHash:     plistOpt[string](queryResponses, "iTunesStoreAccountHash"),
+		PushToken:                  plistOptBytes(queryResponses, "PushToken"),
+
+		BatteryLevel:       plistOpt[float64](queryResponses, "BatteryLevel"),
+		CellularTechnology: plistOptInt64(queryResponses, "CellularTechnology"),
+
+		AppAnalyticsEnabled:           plistOpt[bool](queryResponses, "AppAnalyticsEnabled"),
+		AwaitingConfiguration:         plistOpt[bool](queryResponses, "AwaitingConfiguration"),
+		DataRoamingEnabled:            plistOpt[bool](queryResponses, "DataRoamingEnabled"),
+		DiagnosticSubmissionEnabled:   plistOpt[bool](queryResponses, "DiagnosticSubmissionEnabled"),
+		IsCloudBackupEnabled:          plistOpt[bool](queryResponses, "IsCloudBackupEnabled"),
+		IsDeviceLocatorServiceEnabled: plistOpt[bool](queryResponses, "IsDeviceLocatorServiceEnabled"),
+		IsDoNotDisturbInEffect:        plistOpt[bool](queryResponses, "IsDoNotDisturbInEffect"),
+		IsMDMLostModeEnabled:          plistOpt[bool](queryResponses, "IsMDMLostModeEnabled"),
+		IsNetworkTethered:             plistOpt[bool](queryResponses, "IsNetworkTethered"),
+		ITunesStoreAccountIsActive:    plistOpt[bool](queryResponses, "iTunesStoreAccountIsActive"),
+		PersonalHotspotEnabled:        plistOpt[bool](queryResponses, "PersonalHotspotEnabled"),
+
+		LastCloudBackupDate: plistOpt[time.Time](queryResponses, "LastCloudBackupDate"),
+
+		AccessibilitySettings:       parseMDMAppleAccessibilitySettings(queryResponses),
+		OrganizationInfo:            parseMDMAppleOrganizationInfo(queryResponses),
+		MDMOptions:                  parseMDMAppleDeviceVitalsMDMOptions(queryResponses),
+		DevicePropertiesAttestation: plistOptDataArray(queryResponses, "DevicePropertiesAttestation"),
+
+		ServiceSubscriptions: parseMDMAppleServiceSubscriptions(queryResponses),
+	}
+}

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -6443,6 +6443,20 @@ func TestMDMCommandAndReportResultsIOSIPadOSRefetch(t *testing.T) {
 		require.Equal(t, "Work iPad", reportedName)
 		return nil
 	}
+	var vitalsCalls int
+	ds.SetOrUpdateHostMDMAppleDeviceVitalsFunc = func(ctx context.Context, incomingHostUUID string, vitals fleet.MDMAppleDeviceVitals) error {
+		require.Equal(t, hostUUID, incomingHostUUID)
+		require.NotNil(t, vitals.WiFiMAC)
+		require.Equal(t, "ff:ff:ff:ff:ff:ff", *vitals.WiFiMAC)
+		vitalsCalls++
+		if vitalsCalls == 1 {
+			require.NotNil(t, vitals.IsMDMLostModeEnabled)
+			require.True(t, *vitals.IsMDMLostModeEnabled)
+		} else {
+			require.Nil(t, vitals.IsMDMLostModeEnabled)
+		}
+		return nil
+	}
 
 	_, err := svc.CommandAndReportResults(
 		&mdm.Request{Context: ctx},
@@ -6490,6 +6504,7 @@ func TestMDMCommandAndReportResultsIOSIPadOSRefetch(t *testing.T) {
 	require.True(t, ds.UpdateMDMDataFuncInvoked)
 	require.True(t, ds.GetLatestAppleMDMCommandOfTypeFuncInvoked)
 	require.True(t, ds.SetLockCommandForLostModeCheckinFuncInvoked)
+	require.True(t, ds.SetOrUpdateHostMDMAppleDeviceVitalsFuncInvoked)
 
 	_, err = svc.CommandAndReportResults(
 		&mdm.Request{Context: ctx},
@@ -6568,6 +6583,12 @@ func TestMDMCommandAndReportResultsIOSRefetchSupplementalOSVersion(t *testing.T)
 	ds.UpdateHostDeviceNameStatusFromReportFunc = func(ctx context.Context, incomingHostUUID, reportedName string) error {
 		return nil
 	}
+	ds.SetOrUpdateHostMDMAppleDeviceVitalsFunc = func(ctx context.Context, incomingHostUUID string, vitals fleet.MDMAppleDeviceVitals) error {
+		require.Equal(t, hostUUID, incomingHostUUID)
+		require.NotNil(t, vitals.SupplementalOSVersionExtra)
+		require.Equal(t, "(a)", *vitals.SupplementalOSVersionExtra)
+		return nil
+	}
 
 	_, err := svc.CommandAndReportResults(
 		&mdm.Request{Context: ctx},
@@ -6609,6 +6630,7 @@ func TestMDMCommandAndReportResultsIOSRefetchSupplementalOSVersion(t *testing.T)
 
 	require.True(t, ds.UpdateHostFuncInvoked)
 	require.True(t, ds.UpdateHostOperatingSystemFuncInvoked)
+	require.True(t, ds.SetOrUpdateHostMDMAppleDeviceVitalsFuncInvoked)
 }
 
 // TestMDMCommandAndReportResultsIOSIPadOSRefetchDefensive covers handling of
@@ -6831,6 +6853,9 @@ func TestMDMCommandAndReportResultsIOSIPadOSRefetchDefensive(t *testing.T) {
 			ds.UpdateHostDeviceNameStatusFromReportFunc = func(ctx context.Context, incomingHostUUID, reportedName string) error {
 				return nil
 			}
+			ds.SetOrUpdateHostMDMAppleDeviceVitalsFunc = func(ctx context.Context, incomingHostUUID string, vitals fleet.MDMAppleDeviceVitals) error {
+				return nil
+			}
 
 			ds.UpdateHostFunc = func(ctx context.Context, host *fleet.Host) error {
 				assert.Equal(t, tc.expect.expectComputerName, host.ComputerName, "ComputerName")
@@ -6931,6 +6956,9 @@ func TestMDMCommandAndReportResultsIOSRefetchMissingProductNameIPhone(t *testing
 	var updatedOS fleet.OperatingSystem
 	ds.UpdateHostOperatingSystemFunc = func(ctx context.Context, incomingHostID uint, hostOS fleet.OperatingSystem) error {
 		updatedOS = hostOS
+		return nil
+	}
+	ds.SetOrUpdateHostMDMAppleDeviceVitalsFunc = func(ctx context.Context, incomingHostUUID string, vitals fleet.MDMAppleDeviceVitals) error {
 		return nil
 	}
 
@@ -7138,6 +7166,9 @@ func TestMDMCommandAndReportResultsIOSRefetchSupplementalOSVersionNonString(t *t
 	ds.UpdateHostDeviceNameStatusFromReportFunc = func(ctx context.Context, incomingHostUUID, reportedName string) error {
 		return nil
 	}
+	ds.SetOrUpdateHostMDMAppleDeviceVitalsFunc = func(ctx context.Context, incomingHostUUID string, vitals fleet.MDMAppleDeviceVitals) error {
+		return nil
+	}
 
 	_, err := svc.CommandAndReportResults(
 		&mdm.Request{Context: ctx},
@@ -7218,6 +7249,9 @@ func TestMDMCommandAndReportResultsIOSRefetchSupplementalOSVersionFallbackTrunca
 	ds.UpdateHostDeviceNameStatusFromReportFunc = func(ctx context.Context, incomingHostUUID, reportedName string) error {
 		return nil
 	}
+	ds.SetOrUpdateHostMDMAppleDeviceVitalsFunc = func(ctx context.Context, incomingHostUUID string, vitals fleet.MDMAppleDeviceVitals) error {
+		return nil
+	}
 
 	_, err := svc.CommandAndReportResults(
 		&mdm.Request{Context: ctx},
@@ -7259,6 +7293,364 @@ func TestMDMCommandAndReportResultsIOSRefetchSupplementalOSVersionFallbackTrunca
 
 	require.True(t, ds.UpdateHostFuncInvoked)
 	require.True(t, ds.UpdateHostOperatingSystemFuncInvoked)
+}
+
+// TestMDMCommandAndReportResultsIOSIPadOSRefetchDeviceVitals covers the 29
+// fields added for #49984: all present -> all persisted; a field absent (an
+// enrollment method that doesn't support it) -> left nil, no error.
+func TestMDMCommandAndReportResultsIOSIPadOSRefetchDeviceVitals(t *testing.T) {
+	ctx := t.Context()
+	hostID := uint(7)
+	hostUUID := "VITALS-HOST-UUID"
+	commandUUID := fleet.RefetchDeviceCommandUUIDPrefix + "VITALS-UUID"
+
+	ds := new(mock.Store)
+	svc := MDMAppleCheckinAndCommandService{ds: ds, logger: slog.New(slog.DiscardHandler)}
+
+	ds.HostByIdentifierFunc = func(ctx context.Context, identifier string) (*fleet.Host, error) {
+		return &fleet.Host{ID: hostID, UUID: hostUUID, Platform: "ipados"}, nil
+	}
+	ds.UpdateHostFunc = func(ctx context.Context, host *fleet.Host) error { return nil }
+	ds.SetOrUpdateHostDisksSpaceFunc = func(ctx context.Context, incomingHostID uint, gigsAvailable, percentAvailable, gigsTotal float64, gigsAll *float64) error {
+		return nil
+	}
+	ds.UpdateHostOperatingSystemFunc = func(ctx context.Context, incomingHostID uint, hostOS fleet.OperatingSystem) error {
+		return nil
+	}
+	ds.RemoveHostMDMCommandFunc = func(ctx context.Context, command fleet.HostMDMCommand) error { return nil }
+	ds.CleanupStaleNanoRefetchCommandsFunc = func(ctx context.Context, enrollmentID, commandUUIDPrefix, currentCommandUUID string) error {
+		return nil
+	}
+	ds.UpdateHostDeviceNameStatusFromReportFunc = func(ctx context.Context, incomingHostUUID, reportedName string) error {
+		return nil
+	}
+
+	allFieldsRaw := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CommandUUID</key>
+	<string>` + commandUUID + `</string>
+	<key>QueryResponses</key>
+	<dict>
+		<key>DeviceName</key>
+		<string>Work iPad</string>
+		<key>DeviceCapacity</key>
+		<real>64</real>
+		<key>AvailableDeviceCapacity</key>
+		<real>51.26</real>
+		<key>OSVersion</key>
+		<string>17.5.1</string>
+		<key>ProductName</key>
+		<string>iPad13,18</string>
+		<key>UDID</key>
+		<string>00008030-ABCDEF012345</string>
+		<key>ModelNumber</key>
+		<string>MK1A3LL/A</string>
+		<key>ModemFirmwareVersion</key>
+		<string>1.0.0</string>
+		<key>SupplementalBuildVersion</key>
+		<string>21F79</string>
+		<key>SupplementalOSVersionExtra</key>
+		<string>(a)</string>
+		<key>BluetoothMAC</key>
+		<string>11:22:33:44:55:66</string>
+		<key>WiFiMAC</key>
+		<string>ff:ff:ff:ff:ff:ff</string>
+		<key>EASDeviceIdentifier</key>
+		<string>eas-device-id</string>
+		<key>iTunesStoreAccountHash</key>
+		<string>hash-123</string>
+		<key>PushToken</key>
+		<data>cHVzaC10b2tlbg==</data>
+		<key>BatteryLevel</key>
+		<real>0.85</real>
+		<key>CellularTechnology</key>
+		<integer>1</integer>
+		<key>AppAnalyticsEnabled</key>
+		<true/>
+		<key>AwaitingConfiguration</key>
+		<false/>
+		<key>DataRoamingEnabled</key>
+		<true/>
+		<key>DiagnosticSubmissionEnabled</key>
+		<false/>
+		<key>IsCloudBackupEnabled</key>
+		<true/>
+		<key>IsDeviceLocatorServiceEnabled</key>
+		<true/>
+		<key>IsDoNotDisturbInEffect</key>
+		<false/>
+		<key>IsMDMLostModeEnabled</key>
+		<false/>
+		<key>IsNetworkTethered</key>
+		<false/>
+		<key>iTunesStoreAccountIsActive</key>
+		<true/>
+		<key>PersonalHotspotEnabled</key>
+		<false/>
+		<key>LastCloudBackupDate</key>
+		<date>2026-07-01T00:00:00Z</date>
+		<key>AccessibilitySettings</key>
+		<dict>
+			<key>VoiceOverEnabled</key>
+			<true/>
+			<key>ZoomEnabled</key>
+			<false/>
+			<key>TextSize</key>
+			<integer>5</integer>
+		</dict>
+		<key>OrganizationInfo</key>
+		<dict>
+			<key>OrganizationName</key>
+			<string>Acme Inc.</string>
+			<key>OrganizationEmail</key>
+			<string>[email protected]</string>
+		</dict>
+		<key>MDMOptions</key>
+		<dict>
+			<key>BootstrapTokenAllowed</key>
+			<true/>
+		</dict>
+		<key>DevicePropertiesAttestation</key>
+		<array>
+			<data>bGVhZi1jZXJ0</data>
+			<data>aW50ZXJtZWRpYXRlLWNlcnQ=</data>
+		</array>
+		<key>ServiceSubscriptions</key>
+		<array>
+			<dict>
+				<key>Slot</key>
+				<string>CTSubscriptionSlotOne</string>
+				<key>ICCID</key>
+				<string>8901410321111111111</string>
+				<key>IsDataPreferred</key>
+				<true/>
+				<key>CurrentCarrierNetwork</key>
+				<string>Fleet Wireless</string>
+				<key>PhoneNumber</key>
+				<string>+15555550100</string>
+			</dict>
+			<dict>
+				<key>Slot</key>
+				<string>CTSubscriptionSlotTwo</string>
+				<key>EID</key>
+				<string>89049032000000000000000000000000</string>
+				<key>IMEI</key>
+				<string>35 000000 000000 0</string>
+			</dict>
+		</array>
+	</dict>
+	<key>Status</key>
+	<string>Acknowledged</string>
+	<key>UDID</key>
+	<string>` + hostUUID + `</string>
+</dict>
+</plist>`)
+
+	var gotVitals fleet.MDMAppleDeviceVitals
+	ds.SetOrUpdateHostMDMAppleDeviceVitalsFunc = func(ctx context.Context, incomingHostUUID string, vitals fleet.MDMAppleDeviceVitals) error {
+		require.Equal(t, hostUUID, incomingHostUUID)
+		gotVitals = vitals
+		return nil
+	}
+
+	_, err := svc.CommandAndReportResults(
+		&mdm.Request{Context: ctx},
+		&mdm.CommandResults{Enrollment: mdm.Enrollment{UDID: hostUUID}, CommandUUID: commandUUID, Raw: allFieldsRaw},
+	)
+	require.NoError(t, err)
+	require.True(t, ds.SetOrUpdateHostMDMAppleDeviceVitalsFuncInvoked)
+
+	require.Equal(t, "00008030-ABCDEF012345", ptr.ValOrZero(gotVitals.UDID))
+	require.Equal(t, "MK1A3LL/A", ptr.ValOrZero(gotVitals.ModelNumber))
+	require.Equal(t, "1.0.0", ptr.ValOrZero(gotVitals.ModemFirmwareVersion))
+	require.Equal(t, "21F79", ptr.ValOrZero(gotVitals.SupplementalBuildVersion))
+	require.Equal(t, "(a)", ptr.ValOrZero(gotVitals.SupplementalOSVersionExtra))
+	require.Equal(t, "11:22:33:44:55:66", ptr.ValOrZero(gotVitals.BluetoothMAC))
+	require.Equal(t, "ff:ff:ff:ff:ff:ff", ptr.ValOrZero(gotVitals.WiFiMAC))
+	require.Equal(t, "eas-device-id", ptr.ValOrZero(gotVitals.EASDeviceIdentifier))
+	require.Equal(t, "hash-123", ptr.ValOrZero(gotVitals.ITunesStoreAccountHash))
+	require.Equal(t, []byte("push-token"), gotVitals.PushToken)
+	require.InDelta(t, 0.85, ptr.ValOrZero(gotVitals.BatteryLevel), 0.001)
+	require.EqualValues(t, 1, ptr.ValOrZero(gotVitals.CellularTechnology))
+	require.True(t, ptr.ValOrZero(gotVitals.AppAnalyticsEnabled))
+	require.False(t, ptr.ValOrZero(gotVitals.AwaitingConfiguration))
+	require.True(t, ptr.ValOrZero(gotVitals.DataRoamingEnabled))
+	require.False(t, ptr.ValOrZero(gotVitals.DiagnosticSubmissionEnabled))
+	require.True(t, ptr.ValOrZero(gotVitals.IsCloudBackupEnabled))
+	require.True(t, ptr.ValOrZero(gotVitals.IsDeviceLocatorServiceEnabled))
+	require.False(t, ptr.ValOrZero(gotVitals.IsDoNotDisturbInEffect))
+	require.False(t, ptr.ValOrZero(gotVitals.IsMDMLostModeEnabled))
+	require.False(t, ptr.ValOrZero(gotVitals.IsNetworkTethered))
+	require.True(t, ptr.ValOrZero(gotVitals.ITunesStoreAccountIsActive))
+	require.False(t, ptr.ValOrZero(gotVitals.PersonalHotspotEnabled))
+	require.NotNil(t, gotVitals.LastCloudBackupDate)
+	require.Equal(t, 2026, gotVitals.LastCloudBackupDate.Year())
+
+	require.NotNil(t, gotVitals.AccessibilitySettings)
+	require.True(t, ptr.ValOrZero(gotVitals.AccessibilitySettings.VoiceOverEnabled))
+	require.False(t, ptr.ValOrZero(gotVitals.AccessibilitySettings.ZoomEnabled))
+	require.EqualValues(t, 5, ptr.ValOrZero(gotVitals.AccessibilitySettings.TextSize))
+
+	require.NotNil(t, gotVitals.OrganizationInfo)
+	require.Equal(t, "Acme Inc.", ptr.ValOrZero(gotVitals.OrganizationInfo.OrganizationName))
+	require.Equal(t, "[email protected]", ptr.ValOrZero(gotVitals.OrganizationInfo.OrganizationEmail))
+
+	require.NotNil(t, gotVitals.MDMOptions)
+	require.True(t, ptr.ValOrZero(gotVitals.MDMOptions.BootstrapTokenAllowed))
+
+	// Real devices report DevicePropertiesAttestation as a 2-certificate chain
+	// (leaf + the "Apple Enterprise Attestation Sub CA" intermediate), per
+	// manual testing against a physical iPhone.
+	require.Equal(t, [][]byte{[]byte("leaf-cert"), []byte("intermediate-cert")}, gotVitals.DevicePropertiesAttestation)
+
+	// A physical+eSIM dual-SIM device, per manual testing, reports one fully
+	// populated subscription for its active line and a second, mostly-null
+	// subscription for an inactive/unprovisioned eSIM slot (only EID/IMEI
+	// set) — both must be persisted as separate rows.
+	require.Len(t, gotVitals.ServiceSubscriptions, 2)
+	require.Equal(t, "CTSubscriptionSlotOne", gotVitals.ServiceSubscriptions[0].Slot)
+	require.Equal(t, "8901410321111111111", ptr.ValOrZero(gotVitals.ServiceSubscriptions[0].ICCID))
+	require.True(t, ptr.ValOrZero(gotVitals.ServiceSubscriptions[0].IsDataPreferred))
+	require.Equal(t, "Fleet Wireless", ptr.ValOrZero(gotVitals.ServiceSubscriptions[0].CurrentCarrierNetwork))
+
+	require.Equal(t, "CTSubscriptionSlotTwo", gotVitals.ServiceSubscriptions[1].Slot)
+	require.Equal(t, "89049032000000000000000000000000", ptr.ValOrZero(gotVitals.ServiceSubscriptions[1].EID))
+	require.Nil(t, gotVitals.ServiceSubscriptions[1].ICCID)
+	require.Nil(t, gotVitals.ServiceSubscriptions[1].IsDataPreferred)
+
+	// A second ack with none of the new fields present must persist a
+	// zero-value vitals struct (all nils) rather than error.
+	sparseRaw := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CommandUUID</key>
+	<string>` + commandUUID + `</string>
+	<key>QueryResponses</key>
+	<dict>
+		<key>DeviceName</key>
+		<string>Work iPad</string>
+		<key>DeviceCapacity</key>
+		<real>64</real>
+		<key>AvailableDeviceCapacity</key>
+		<real>51.26</real>
+		<key>OSVersion</key>
+		<string>17.5.1</string>
+		<key>ProductName</key>
+		<string>iPad13,18</string>
+	</dict>
+	<key>Status</key>
+	<string>Acknowledged</string>
+	<key>UDID</key>
+	<string>` + hostUUID + `</string>
+</dict>
+</plist>`)
+
+	gotVitals = fleet.MDMAppleDeviceVitals{}
+	ds.SetOrUpdateHostMDMAppleDeviceVitalsFuncInvoked = false
+	_, err = svc.CommandAndReportResults(
+		&mdm.Request{Context: ctx},
+		&mdm.CommandResults{Enrollment: mdm.Enrollment{UDID: hostUUID}, CommandUUID: commandUUID, Raw: sparseRaw},
+	)
+	require.NoError(t, err)
+	require.True(t, ds.SetOrUpdateHostMDMAppleDeviceVitalsFuncInvoked)
+	require.Nil(t, gotVitals.UDID)
+	require.Nil(t, gotVitals.BatteryLevel)
+	require.Nil(t, gotVitals.AccessibilitySettings)
+	require.Nil(t, gotVitals.DevicePropertiesAttestation)
+	require.Empty(t, gotVitals.ServiceSubscriptions)
+}
+
+// TestMDMCommandAndReportResultsIOSIPadOSRefetchDeviceVitalsWriteFailure
+// covers that a failure persisting the new vitals doesn't abort the rest of
+// handleRefetchDeviceResults — in particular, the lost-mode lock/wipe
+// reconciliation that runs later in the same function must still happen.
+func TestMDMCommandAndReportResultsIOSIPadOSRefetchDeviceVitalsWriteFailure(t *testing.T) {
+	ctx := t.Context()
+	hostID := uint(8)
+	hostUUID := "VITALS-FAIL-HOST-UUID"
+	commandUUID := fleet.RefetchDeviceCommandUUIDPrefix + "VITALS-FAIL-UUID"
+	lostModeCommandUUID := uuid.NewString()
+
+	ds := new(mock.Store)
+	svc := MDMAppleCheckinAndCommandService{ds: ds, logger: slog.New(slog.DiscardHandler)}
+
+	ds.HostByIdentifierFunc = func(ctx context.Context, identifier string) (*fleet.Host, error) {
+		return &fleet.Host{
+			ID:   hostID,
+			UUID: hostUUID,
+			MDM:  fleet.MDMHostData{EnrollmentStatus: new("Pending")},
+		}, nil
+	}
+	ds.UpdateHostFunc = func(ctx context.Context, host *fleet.Host) error { return nil }
+	ds.SetOrUpdateHostDisksSpaceFunc = func(ctx context.Context, incomingHostID uint, gigsAvailable, percentAvailable, gigsTotal float64, gigsAll *float64) error {
+		return nil
+	}
+	ds.UpdateHostOperatingSystemFunc = func(ctx context.Context, incomingHostID uint, hostOS fleet.OperatingSystem) error {
+		return nil
+	}
+	ds.RemoveHostMDMCommandFunc = func(ctx context.Context, command fleet.HostMDMCommand) error { return nil }
+	ds.CleanupStaleNanoRefetchCommandsFunc = func(ctx context.Context, enrollmentID, commandUUIDPrefix, currentCommandUUID string) error {
+		return nil
+	}
+	ds.UpdateHostDeviceNameStatusFromReportFunc = func(ctx context.Context, incomingHostUUID, reportedName string) error {
+		return nil
+	}
+	ds.SetOrUpdateHostMDMAppleDeviceVitalsFunc = func(ctx context.Context, incomingHostUUID string, vitals fleet.MDMAppleDeviceVitals) error {
+		return errors.New("boom: vitals write failed")
+	}
+	ds.UpdateMDMDataFunc = func(ctx context.Context, incomingHostID uint, enrolled bool) error { return nil }
+	ds.GetLatestAppleMDMCommandOfTypeFunc = func(ctx context.Context, incomingHostUUID, commandType string) (*fleet.MDMCommand, error) {
+		return &fleet.MDMCommand{CommandUUID: lostModeCommandUUID}, nil
+	}
+	ds.SetLockCommandForLostModeCheckinFunc = func(ctx context.Context, incomingHostUUID uint, commandUUID string) error {
+		return nil
+	}
+
+	_, err := svc.CommandAndReportResults(
+		&mdm.Request{Context: ctx},
+		&mdm.CommandResults{
+			Enrollment:  mdm.Enrollment{UDID: hostUUID},
+			CommandUUID: commandUUID,
+			Raw: []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>CommandUUID</key>
+        <string>` + commandUUID + `</string>
+        <key>QueryResponses</key>
+        <dict>
+                <key>DeviceName</key>
+                <string>Work iPad</string>
+                <key>DeviceCapacity</key>
+                <real>64</real>
+                <key>AvailableDeviceCapacity</key>
+                <real>51.26</real>
+                <key>OSVersion</key>
+                <string>17.5.1</string>
+                <key>ProductName</key>
+                <string>iPad13,18</string>
+                <key>WiFiMAC</key>
+                <string>ff:ff:ff:ff:ff:ff</string>
+                <key>IsMDMLostModeEnabled</key>
+                <true/>
+        </dict>
+        <key>Status</key>
+        <string>Acknowledged</string>
+        <key>UDID</key>
+        <string>` + hostUUID + `</string>
+</dict>
+</plist>`),
+		},
+	)
+
+	require.NoError(t, err, "a vitals persistence failure must not abort the check-in")
+	require.True(t, ds.SetOrUpdateHostMDMAppleDeviceVitalsFuncInvoked)
+	require.True(t, ds.UpdateHostFuncInvoked)
+	require.True(t, ds.UpdateMDMDataFuncInvoked)
+	require.True(t, ds.SetLockCommandForLostModeCheckinFuncInvoked, "lost-mode reconciliation must still run despite the vitals write failure")
 }
 
 func TestUnmarshalAppList(t *testing.T) {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Relates to #49984

This is PR 2 of 2 for #49984, stacked on top of PR 1 (#50046) — diff here is scoped to just the ack-parsing/wiring work on top of that PR's storage and command changes. This PR parses the additional `DeviceInformation` ack fields requested by PR 1's command expansion and persists them via `SetOrUpdateHostMDMAppleDeviceVitals`. A persistence failure is logged rather than aborting the MDM check-in, since it's a non-critical write the next refetch will redo.

# Checklist for submitter

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

It will be included in the feature branch.

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually

Enrolled my iPhone to Fleet (dual-SIM, physical + eSIM):

<img width="1458" height="830" alt="Screenshot 2026-07-28 at 10 57 00 AM" src="https://github.com/user-attachments/assets/1735b5e6-ac2d-4dc1-a66b-c8d8063b7c76" />

`host_mdm_apple_device_vitals` — populated as expected:
- `battery_level: 0.87`, `cellular_technology: 1`, all `is_*` booleans, `last_cloud_backup_date` — parsed correctly
- `device_properties_attestation`: JSON array of **2** base64 DER certs (leaf + "Apple Enterprise Attestation Sub CA" intermediate) — confirms it's a cert chain, not a boolean, per the deviation noted in the parent issue
- `mdm_options: {}` — key present, no sub-options applicable → empty object, not `NULL` (expected `omitempty` behavior)
- `push_token: NULL` — expected; Apple only returns this for user-channel enrollments, not device-channel
- `organization_info` / `accessibility_settings: NULL` — expected, nothing configured/toggled
- `model_number`, `modem_firmware_version`, `supplemental_build_version`, `bluetooth_mac`, `wifi_mac`, `eas_device_identifier`, `itunes_store_account_hash` — all populated

`host_mdm_apple_service_subscriptions` — **2 rows** for one dual-SIM device, confirming the multi-slot replace logic works on real hardware:
- `CTSubscriptionSlotOne` — fully populated (carrier, MCC/MNC, ICCID, phone number, etc.)
- `CTSubscriptionSlotTwo` — only `eid`/`imei` populated, everything else `NULL` — an inactive/unprovisioned eSIM slot reporting a sparse row, exactly the shape the tests were built to mirror



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Apple device management now captures and stores additional iPhone and iPad device vitals during device information refreshes.
  * Supports details such as Wi‑Fi MAC address, lost mode status, operating system information, accessibility settings, organization details, and service subscriptions.

* **Bug Fixes**
  * Missing or unexpected device information no longer interrupts refresh processing.
  * Failures saving supplementary device vitals no longer prevent other device management actions from completing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->