### PR TITLE
Website: update primary cta on homepage

### DIFF
--- a/website/views/pages/homepage.ejs
+++ b/website/views/pages/homepage.ejs
@@ -16,7 +16,7 @@
             </h1>
             <p purpose="hero-subtitle">Open MDM, patching, and vuln management for every OS.</p>
             <div purpose="button-row" class="d-flex justify-content-start align-items-center">
-              <a purpose="cta-button" href="/contact?talkToUs">Get a demo</a>
+              <a purpose="cta-button" href="/register">Try it yourself</a>
               <animated-arrow-button href="#compare-features">Compare features</animated-arrow-button>
             </div>
           </div>
@@ -598,10 +598,10 @@
           </div>
         </h1>
         <div purpose="button-row" style="margin-top: 40px;" class="d-flex flex-sm-row flex-column justify-content-center align-items-center mx-auto">
-          <a purpose="cta-button" class="mr-0" href="/contact?talkToUs">Get a demo</a>
+          <a purpose="cta-button" href="/register">Try it yourself</a>
           <!-- <animated-arrow-button href="/gitops-workshop">Free workshop</animated-arrow-button>-->
           <!-- <animated-arrow-button href="/pricing">View pricing</animated-arrow-button> -->
-          <!-- <animated-arrow-button href="/try">Try it yourself</animated-arrow-button> -->
+          <animated-arrow-button href="/contact?talkToUs">Get a demo</animated-arrow-button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Changes:
- Updated the primary cta on the homepage to "Try it yourself"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated homepage calls to action to encourage visitors to try the product directly.
  * Added a “Try it yourself” option to the bottom CTA section.
  * Retained the “Get a demo” option as the final CTA button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->