### PR TITLE
iOS/iPadOS device vitals: expose in GET host API response

### DIFF
--- a/server/datastore/mysql/apple_mdm_device_vitals.go
+++ b/server/datastore/mysql/apple_mdm_device_vitals.go
@@ -311,7 +311,9 @@ func (ds *Datastore) LoadHostMDMAppleDeviceVitals(ctx context.Context, host *fle
 		host.ITunesStoreAccountHash = row.ITunesStoreAccountHash
 		host.PushToken = row.PushToken
 		host.BatteryLevel = row.BatteryLevel
-		host.CellularTechnology = row.CellularTechnology
+		if row.CellularTechnology != nil {
+			host.CellularTechnology = new(fleet.MDMAppleCellularTechnology(*row.CellularTechnology))
+		}
 		host.AppAnalyticsEnabled = row.AppAnalyticsEnabled
 		host.AwaitingConfiguration = row.AwaitingConfiguration
 		host.DataRoamingEnabled = row.DataRoamingEnabled

--- a/server/datastore/mysql/apple_mdm_device_vitals.go
+++ b/server/datastore/mysql/apple_mdm_device_vitals.go
@@ -2,6 +2,7 @@ package mysql
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"reflect"
 	"time"
@@ -269,5 +270,98 @@ func replaceHostMDMAppleServiceSubscriptions(ctx context.Context, tx sqlx.ExtCon
 			}
 		}
 	}
+	return nil
+}
+
+const deviceVitalsSelectStmt = `
+	SELECT
+		host_uuid, udid, model_number, modem_firmware_version, supplemental_build_version,
+		supplemental_os_version_extra, bluetooth_mac, wifi_mac, eas_device_identifier,
+		itunes_store_account_hash, push_token, battery_level, cellular_technology,
+		app_analytics_enabled, awaiting_configuration, data_roaming_enabled,
+		diagnostic_submission_enabled, is_cloud_backup_enabled, is_device_locator_service_enabled,
+		is_do_not_disturb_in_effect, is_mdm_lost_mode_enabled, is_network_tethered,
+		itunes_store_account_is_active, personal_hotspot_enabled, last_cloud_backup_date,
+		accessibility_settings, organization_info, mdm_options, device_properties_attestation
+	FROM host_mdm_apple_device_vitals
+	WHERE host_uuid = ?`
+
+const serviceSubscriptionsSelectStmt = `
+	SELECT
+		host_uuid, slot, carrier_settings_version, current_carrier_network, current_mcc, current_mnc,
+		eid, iccid, imei, is_data_preferred, is_roaming, is_voice_preferred, label, label_id, meid,
+		phone_number, subscriber_carrier_network
+	FROM host_mdm_apple_service_subscriptions
+	WHERE host_uuid = ?
+	ORDER BY slot`
+
+func (ds *Datastore) LoadHostMDMAppleDeviceVitals(ctx context.Context, host *fleet.Host) error {
+	var row deviceVitalsRow
+	err := sqlx.GetContext(ctx, ds.reader(ctx), &row, deviceVitalsSelectStmt, host.UUID)
+	switch err {
+	case nil:
+		host.UDID = row.UDID
+		host.ModelNumber = row.ModelNumber
+		host.ModemFirmwareVersion = row.ModemFirmwareVersion
+		host.SupplementalBuildVersion = row.SupplementalBuildVersion
+		host.SupplementalOSVersionExtra = row.SupplementalOSVersionExtra
+		host.BluetoothMAC = row.BluetoothMAC
+		host.WiFiMAC = row.WiFiMAC
+		host.EASDeviceIdentifier = row.EASDeviceIdentifier
+		host.ITunesStoreAccountHash = row.ITunesStoreAccountHash
+		host.PushToken = row.PushToken
+		host.BatteryLevel = row.BatteryLevel
+		host.CellularTechnology = row.CellularTechnology
+		host.AppAnalyticsEnabled = row.AppAnalyticsEnabled
+		host.AwaitingConfiguration = row.AwaitingConfiguration
+		host.DataRoamingEnabled = row.DataRoamingEnabled
+		host.DiagnosticSubmissionEnabled = row.DiagnosticSubmissionEnabled
+		host.IsCloudBackupEnabled = row.IsCloudBackupEnabled
+		host.IsDeviceLocatorServiceEnabled = row.IsDeviceLocatorServiceEnabled
+		host.IsDoNotDisturbInEffect = row.IsDoNotDisturbInEffect
+		host.IsMDMLostModeEnabled = row.IsMDMLostModeEnabled
+		host.IsNetworkTethered = row.IsNetworkTethered
+		host.ITunesStoreAccountIsActive = row.ITunesStoreAccountIsActive
+		host.PersonalHotspotEnabled = row.PersonalHotspotEnabled
+		host.LastCloudBackupDate = row.LastCloudBackupDate
+
+		if row.AccessibilitySettings != nil {
+			var v fleet.MDMAppleAccessibilitySettings
+			if err := json.Unmarshal(row.AccessibilitySettings, &v); err != nil {
+				return ctxerr.Wrap(ctx, err, "unmarshal host accessibility settings")
+			}
+			host.AccessibilitySettings = &v
+		}
+		if row.OrganizationInfo != nil {
+			var v fleet.MDMAppleOrganizationInfo
+			if err := json.Unmarshal(row.OrganizationInfo, &v); err != nil {
+				return ctxerr.Wrap(ctx, err, "unmarshal host organization info")
+			}
+			host.OrganizationInfo = &v
+		}
+		if row.MDMOptions != nil {
+			var v fleet.MDMAppleDeviceVitalsMDMOptions
+			if err := json.Unmarshal(row.MDMOptions, &v); err != nil {
+				return ctxerr.Wrap(ctx, err, "unmarshal host mdm options")
+			}
+			host.MDMOptions = &v
+		}
+		if row.DevicePropertiesAttestation != nil {
+			if err := json.Unmarshal(row.DevicePropertiesAttestation, &host.DevicePropertiesAttestation); err != nil {
+				return ctxerr.Wrap(ctx, err, "unmarshal host device properties attestation")
+			}
+		}
+	case sql.ErrNoRows:
+		// no vitals collected yet for this host; leave fields nil.
+	default:
+		return ctxerr.Wrap(ctx, err, "get host mdm apple device vitals")
+	}
+
+	var subs []fleet.MDMAppleServiceSubscription
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &subs, serviceSubscriptionsSelectStmt, host.UUID); err != nil {
+		return ctxerr.Wrap(ctx, err, "get host mdm apple service subscriptions")
+	}
+	host.ServiceSubscriptions = subs
+
 	return nil
 }

--- a/server/datastore/mysql/apple_mdm_device_vitals_test.go
+++ b/server/datastore/mysql/apple_mdm_device_vitals_test.go
@@ -21,6 +21,9 @@ func TestHostMDMAppleDeviceVitals(t *testing.T) {
 		{"NullHandling", testHostMDMAppleDeviceVitalsNullHandling},
 		{"ServiceSubscriptionsReplace", testHostMDMAppleDeviceVitalsServiceSubscriptionsReplace},
 		{"ResubmitIdenticalPayload", testHostMDMAppleDeviceVitalsResubmitIdenticalPayload},
+		{"Load", testLoadHostMDMAppleDeviceVitalsDB},
+		{"LoadPartial", testLoadHostMDMAppleDeviceVitalsDBPartial},
+		{"LoadNoRow", testLoadHostMDMAppleDeviceVitalsDBNoRow},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -163,4 +166,136 @@ func testHostMDMAppleDeviceVitalsResubmitIdenticalPayload(t *testing.T, ds *Data
 	require.Equal(t, 1, count)
 	require.NoError(t, ds.writer(ctx).Get(&count, `SELECT COUNT(*) FROM host_mdm_apple_service_subscriptions WHERE host_uuid = ?`, host.UUID))
 	require.Equal(t, 1, count)
+}
+
+func testLoadHostMDMAppleDeviceVitalsDB(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+	host := test.NewHost(t, ds, "vitals-load-host", "1.1.1.4", "vitals-load-host-key", "vitals-load-host-uuid", time.Now(), test.WithPlatform("ios"))
+
+	lastBackup := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	vitals := fleet.MDMAppleDeviceVitals{
+		UDID:                          new("00008030-AAA"),
+		ModelNumber:                   new("MNEP3LL/A"),
+		ModemFirmwareVersion:          new("2.01.00"),
+		SupplementalBuildVersion:      new("21E236"),
+		SupplementalOSVersionExtra:    new("a"),
+		BluetoothMAC:                  new("a4:83:e7:12:34:57"),
+		WiFiMAC:                       new("a4:83:e7:12:34:58"),
+		EASDeviceIdentifier:           new("3E2A1F9C"),
+		ITunesStoreAccountHash:        new("a1b2c3"),
+		PushToken:                     []byte("push-token-bytes"),
+		BatteryLevel:                  new(0.87),
+		CellularTechnology:            new(int64(1)),
+		AppAnalyticsEnabled:           new(true),
+		AwaitingConfiguration:         new(false),
+		DataRoamingEnabled:            new(false),
+		DiagnosticSubmissionEnabled:   new(true),
+		IsCloudBackupEnabled:          new(true),
+		IsDeviceLocatorServiceEnabled: new(true),
+		IsDoNotDisturbInEffect:        new(false),
+		IsMDMLostModeEnabled:          new(false),
+		IsNetworkTethered:             new(false),
+		ITunesStoreAccountIsActive:    new(true),
+		PersonalHotspotEnabled:        new(false),
+		LastCloudBackupDate:           &lastBackup,
+		AccessibilitySettings: &fleet.MDMAppleAccessibilitySettings{
+			VoiceOverEnabled: new(true),
+			GrayscaleEnabled: new(false),
+		},
+		OrganizationInfo: &fleet.MDMAppleOrganizationInfo{
+			OrganizationName: new("Acme Corp"),
+		},
+		MDMOptions: &fleet.MDMAppleDeviceVitalsMDMOptions{
+			BootstrapTokenAllowed: new(true),
+		},
+		DevicePropertiesAttestation: [][]byte{[]byte("leaf-cert"), []byte("intermediate-cert")},
+		ServiceSubscriptions: []fleet.MDMAppleServiceSubscription{
+			{Slot: "CTSubscriptionSlotOne", ICCID: new("iccid-1")},
+			{Slot: "CTSubscriptionSlotTwo", EID: new("eid-2")},
+		},
+	}
+	require.NoError(t, ds.SetOrUpdateHostMDMAppleDeviceVitals(ctx, host.UUID, vitals))
+
+	loaded := fleet.Host{UUID: host.UUID}
+	require.NoError(t, ds.LoadHostMDMAppleDeviceVitals(ctx, &loaded))
+
+	require.Equal(t, "00008030-AAA", *loaded.UDID)
+	require.Equal(t, "MNEP3LL/A", *loaded.ModelNumber)
+	require.Equal(t, "2.01.00", *loaded.ModemFirmwareVersion)
+	require.Equal(t, "21E236", *loaded.SupplementalBuildVersion)
+	require.Equal(t, "a", *loaded.SupplementalOSVersionExtra)
+	require.Equal(t, "a4:83:e7:12:34:57", *loaded.BluetoothMAC)
+	require.Equal(t, "a4:83:e7:12:34:58", *loaded.WiFiMAC)
+	require.Equal(t, "3E2A1F9C", *loaded.EASDeviceIdentifier)
+	require.Equal(t, "a1b2c3", *loaded.ITunesStoreAccountHash)
+	require.Equal(t, []byte("push-token-bytes"), loaded.PushToken)
+	require.InDelta(t, 0.87, *loaded.BatteryLevel, 0.001)
+	require.EqualValues(t, 1, *loaded.CellularTechnology)
+	require.True(t, *loaded.AppAnalyticsEnabled)
+	require.False(t, *loaded.AwaitingConfiguration)
+	require.False(t, *loaded.DataRoamingEnabled)
+	require.True(t, *loaded.DiagnosticSubmissionEnabled)
+	require.True(t, *loaded.IsCloudBackupEnabled)
+	require.True(t, *loaded.IsDeviceLocatorServiceEnabled)
+	require.False(t, *loaded.IsDoNotDisturbInEffect)
+	require.False(t, *loaded.IsMDMLostModeEnabled)
+	require.False(t, *loaded.IsNetworkTethered)
+	require.True(t, *loaded.ITunesStoreAccountIsActive)
+	require.False(t, *loaded.PersonalHotspotEnabled)
+	require.WithinDuration(t, lastBackup, *loaded.LastCloudBackupDate, time.Second)
+
+	require.NotNil(t, loaded.AccessibilitySettings)
+	require.True(t, *loaded.AccessibilitySettings.VoiceOverEnabled)
+	require.False(t, *loaded.AccessibilitySettings.GrayscaleEnabled)
+	require.NotNil(t, loaded.OrganizationInfo)
+	require.Equal(t, "Acme Corp", *loaded.OrganizationInfo.OrganizationName)
+	require.NotNil(t, loaded.MDMOptions)
+	require.True(t, *loaded.MDMOptions.BootstrapTokenAllowed)
+	require.Equal(t, [][]byte{[]byte("leaf-cert"), []byte("intermediate-cert")}, loaded.DevicePropertiesAttestation)
+
+	require.Len(t, loaded.ServiceSubscriptions, 2)
+	require.Equal(t, "CTSubscriptionSlotOne", loaded.ServiceSubscriptions[0].Slot)
+	require.Equal(t, "iccid-1", *loaded.ServiceSubscriptions[0].ICCID)
+	require.Equal(t, "CTSubscriptionSlotTwo", loaded.ServiceSubscriptions[1].Slot)
+	require.Equal(t, "eid-2", *loaded.ServiceSubscriptions[1].EID)
+}
+
+func testLoadHostMDMAppleDeviceVitalsDBPartial(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+	host := test.NewHost(t, ds, "vitals-partial-host", "1.1.1.5", "vitals-partial-host-key", "vitals-partial-host-uuid", time.Now(), test.WithPlatform("ipados"))
+
+	// Simulates an enrollment method that doesn't support every key: only a
+	// subset of fields present in the ack, the rest absent from the table row.
+	vitals := fleet.MDMAppleDeviceVitals{
+		UDID:         new("00008030-CCC"),
+		BatteryLevel: new(0.5),
+	}
+	require.NoError(t, ds.SetOrUpdateHostMDMAppleDeviceVitals(ctx, host.UUID, vitals))
+
+	loaded := fleet.Host{UUID: host.UUID}
+	require.NoError(t, ds.LoadHostMDMAppleDeviceVitals(ctx, &loaded))
+
+	require.Equal(t, "00008030-CCC", *loaded.UDID)
+	require.InDelta(t, 0.5, *loaded.BatteryLevel, 0.001)
+	require.Nil(t, loaded.ModelNumber)
+	require.Nil(t, loaded.AccessibilitySettings)
+	require.Nil(t, loaded.OrganizationInfo)
+	require.Nil(t, loaded.MDMOptions)
+	require.Nil(t, loaded.DevicePropertiesAttestation)
+	require.Empty(t, loaded.ServiceSubscriptions)
+}
+
+func testLoadHostMDMAppleDeviceVitalsDBNoRow(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+	host := test.NewHost(t, ds, "vitals-no-row-host", "1.1.1.6", "vitals-no-row-host-key", "vitals-no-row-host-uuid", time.Now(), test.WithPlatform("ios"))
+
+	// No refetch has happened yet since this shipped: no row at all in
+	// host_mdm_apple_device_vitals for this host.
+	loaded := fleet.Host{UUID: host.UUID}
+	require.NoError(t, ds.LoadHostMDMAppleDeviceVitals(ctx, &loaded))
+
+	require.Nil(t, loaded.UDID)
+	require.Nil(t, loaded.BatteryLevel)
+	require.Nil(t, loaded.AccessibilitySettings)
+	require.Empty(t, loaded.ServiceSubscriptions)
 }

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1269,6 +1269,11 @@ type Datastore interface {
 	// from a DeviceInformation command ack into host_mdm_apple_device_vitals
 	// and host_mdm_apple_service_subscriptions.
 	SetOrUpdateHostMDMAppleDeviceVitals(ctx context.Context, hostUUID string, vitals MDMAppleDeviceVitals) error
+	// LoadHostMDMAppleDeviceVitals populates host's HostMDMAppleDeviceVitals
+	// fields from host_mdm_apple_device_vitals and
+	// host_mdm_apple_service_subscriptions. Callers are responsible for only
+	// calling this for iOS/iPadOS hosts.
+	LoadHostMDMAppleDeviceVitals(ctx context.Context, host *Host) error
 
 	GetConfigEnableDiskEncryption(ctx context.Context, teamID *uint) (DiskEncryptionConfig, error)
 	SetOrUpdateHostDiskTpmPIN(ctx context.Context, hostID uint, pinSet bool) error

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -472,6 +472,17 @@ type Host struct {
 	// true -> at least one non-revoked cert exists
 	// false -> we know there is no cert
 	HasHostIdentityCert *bool `json:"-" db:"has_host_identity_cert" csv:"-"`
+
+	// HostMDMAppleDeviceVitals holds additional iOS/iPadOS vitals collected
+	// via the DeviceInformation MDM command and persisted to
+	// host_mdm_apple_device_vitals / host_mdm_apple_service_subscriptions
+	// (see HostMDMAppleDeviceVitals and MDMAppleDeviceVitals, same package).
+	// Embedded anonymously so its fields flatten into the top-level host
+	// JSON response. Only populated for iOS/iPadOS hosts, via a separate
+	// query (loadHostMDMAppleDeviceVitalsDB) — every field is omitted (not
+	// null) for every other platform, or when a given field wasn't returned
+	// by a particular enrollment.
+	HostMDMAppleDeviceVitals
 }
 
 type HostForeignVitalGroup struct {

--- a/server/fleet/mdm_apple_device_vitals.go
+++ b/server/fleet/mdm_apple_device_vitals.go
@@ -1,6 +1,79 @@
 package fleet
 
-import "time"
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// MDMAppleCellularTechnology is the cellular radio technology a device
+// supports, as reported by the CellularTechnology key of a DeviceInformation
+// command ack. Apple reports it as an integer, which is what Fleet persists;
+// it's mapped to a display string only when serializing an API response, so
+// the stored value stays exactly what Apple sent.
+//
+// Reference: https://developer.apple.com/documentation/devicemanagement/deviceinformationresponse/queryresponses-data.dictionary
+type MDMAppleCellularTechnology int64
+
+const (
+	MDMAppleCellularTechnologyNone       MDMAppleCellularTechnology = 0
+	MDMAppleCellularTechnologyGSM        MDMAppleCellularTechnology = 1
+	MDMAppleCellularTechnologyCDMA       MDMAppleCellularTechnology = 2
+	MDMAppleCellularTechnologyGSMAndCDMA MDMAppleCellularTechnology = 3
+	// MDMAppleCellularTechnologyUnknown is not a value Apple reports. It's
+	// what a value outside Apple's documented set maps to, so that Apple
+	// extending the enum can't fail serialization of a whole host response
+	// (nor deserialization of one, e.g. by fleetctl). The integer Apple
+	// actually sent is preserved in host_mdm_apple_device_vitals either way.
+	MDMAppleCellularTechnologyUnknown MDMAppleCellularTechnology = -1
+)
+
+func (c MDMAppleCellularTechnology) String() string {
+	switch c {
+	case MDMAppleCellularTechnologyNone:
+		return "None"
+	case MDMAppleCellularTechnologyGSM:
+		return "GSM"
+	case MDMAppleCellularTechnologyCDMA:
+		return "CDMA"
+	case MDMAppleCellularTechnologyGSMAndCDMA:
+		return "GSM and CDMA"
+	default:
+		return "unknown"
+	}
+}
+
+func (c MDMAppleCellularTechnology) MarshalJSON() ([]byte, error) {
+	return json.Marshal(c.String())
+}
+
+func (c *MDMAppleCellularTechnology) UnmarshalJSON(b []byte) error {
+	// Accept the raw integer too, so a value straight out of Apple's ack (or
+	// the database) round-trips through this type.
+	var i int64
+	if err := json.Unmarshal(b, &i); err == nil {
+		*c = MDMAppleCellularTechnology(i)
+		return nil
+	}
+
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return fmt.Errorf("invalid MDMAppleCellularTechnology: %s", string(b))
+	}
+	switch s {
+	case "None":
+		*c = MDMAppleCellularTechnologyNone
+	case "GSM":
+		*c = MDMAppleCellularTechnologyGSM
+	case "CDMA":
+		*c = MDMAppleCellularTechnologyCDMA
+	case "GSM and CDMA":
+		*c = MDMAppleCellularTechnologyGSMAndCDMA
+	default:
+		*c = MDMAppleCellularTechnologyUnknown
+	}
+	return nil
+}
 
 // MDMAppleAccessibilitySettings is the accessibility settings currently set
 // on an iOS/iPadOS device, as reported by the AccessibilitySettings key of a
@@ -152,8 +225,11 @@ type HostMDMAppleDeviceVitals struct {
 	ITunesStoreAccountHash     *string `json:"itunes_store_account_hash,omitempty" db:"-" csv:"-"`
 	PushToken                  []byte  `json:"push_token,omitempty" db:"-" csv:"-"`
 
-	BatteryLevel       *float64 `json:"battery_level,omitempty" db:"-" csv:"-"`
-	CellularTechnology *int64   `json:"cellular_technology,omitempty" db:"-" csv:"-"`
+	BatteryLevel *float64 `json:"battery_level,omitempty" db:"-" csv:"-"`
+	// CellularTechnology serializes as Apple's display label ("GSM", "CDMA",
+	// ...), not the raw integer stored in the DB. See
+	// MDMAppleCellularTechnology.
+	CellularTechnology *MDMAppleCellularTechnology `json:"cellular_technology,omitempty" db:"-" csv:"-"`
 
 	AppAnalyticsEnabled           *bool `json:"app_analytics_enabled,omitempty" db:"-" csv:"-"`
 	AwaitingConfiguration         *bool `json:"awaiting_configuration,omitempty" db:"-" csv:"-"`

--- a/server/fleet/mdm_apple_device_vitals.go
+++ b/server/fleet/mdm_apple_device_vitals.go
@@ -5,36 +5,42 @@ import "time"
 // MDMAppleAccessibilitySettings is the accessibility settings currently set
 // on an iOS/iPadOS device, as reported by the AccessibilitySettings key of a
 // DeviceInformation command ack.
+// csv:"-" on every field below because gocsv flattens nested struct fields
+// into the List Hosts CSV report regardless of the csv tag on the outer
+// fleet.Host field that holds the pointer to this struct; the outer tag
+// alone doesn't stop it from being flattened in CSV (only List Hosts, not
+// GET a single host, exports CSV, and this data isn't loaded for that
+// endpoint anyway).
 type MDMAppleAccessibilitySettings struct {
-	BoldTextEnabled            *bool  `json:"bold_text_enabled,omitempty"`
-	GrayscaleEnabled           *bool  `json:"grayscale_enabled,omitempty"`
-	IncreaseContrastEnabled    *bool  `json:"increase_contrast_enabled,omitempty"`
-	ReduceMotionEnabled        *bool  `json:"reduce_motion_enabled,omitempty"`
-	ReduceTransparencyEnabled  *bool  `json:"reduce_transparency_enabled,omitempty"`
-	TextSize                   *int64 `json:"text_size,omitempty"`
-	TouchAccommodationsEnabled *bool  `json:"touch_accommodations_enabled,omitempty"`
-	VoiceOverEnabled           *bool  `json:"voice_over_enabled,omitempty"`
-	ZoomEnabled                *bool  `json:"zoom_enabled,omitempty"`
+	BoldTextEnabled            *bool  `json:"bold_text_enabled,omitempty" csv:"-"`
+	GrayscaleEnabled           *bool  `json:"grayscale_enabled,omitempty" csv:"-"`
+	IncreaseContrastEnabled    *bool  `json:"increase_contrast_enabled,omitempty" csv:"-"`
+	ReduceMotionEnabled        *bool  `json:"reduce_motion_enabled,omitempty" csv:"-"`
+	ReduceTransparencyEnabled  *bool  `json:"reduce_transparency_enabled,omitempty" csv:"-"`
+	TextSize                   *int64 `json:"text_size,omitempty" csv:"-"`
+	TouchAccommodationsEnabled *bool  `json:"touch_accommodations_enabled,omitempty" csv:"-"`
+	VoiceOverEnabled           *bool  `json:"voice_over_enabled,omitempty" csv:"-"`
+	ZoomEnabled                *bool  `json:"zoom_enabled,omitempty" csv:"-"`
 }
 
 // MDMAppleOrganizationInfo is the MDM server's organization info as reported
 // back by the device via the OrganizationInfo key of a DeviceInformation
 // command ack.
 type MDMAppleOrganizationInfo struct {
-	OrganizationName    *string `json:"organization_name,omitempty"`
-	OrganizationAddress *string `json:"organization_address,omitempty"`
-	OrganizationPhone   *string `json:"organization_phone,omitempty"`
-	OrganizationEmail   *string `json:"organization_email,omitempty"`
-	OrganizationMagic   *string `json:"organization_magic,omitempty"`
+	OrganizationName    *string `json:"organization_name,omitempty" csv:"-"`
+	OrganizationAddress *string `json:"organization_address,omitempty" csv:"-"`
+	OrganizationPhone   *string `json:"organization_phone,omitempty" csv:"-"`
+	OrganizationEmail   *string `json:"organization_email,omitempty" csv:"-"`
+	OrganizationMagic   *string `json:"organization_magic,omitempty" csv:"-"`
 }
 
 // MDMAppleDeviceVitalsMDMOptions is the device's view of MDM options
 // currently in effect, as reported by the MDMOptions key of a
 // DeviceInformation command ack.
 type MDMAppleDeviceVitalsMDMOptions struct {
-	ActivationLockAllowedWhileSupervised             *bool `json:"activation_lock_allowed_while_supervised,omitempty"`
-	BootstrapTokenAllowed                            *bool `json:"bootstrap_token_allowed,omitempty"`
-	PromptUserToAllowBootstrapTokenForAuthentication *bool `json:"prompt_user_to_allow_bootstrap_token_for_authentication,omitempty"`
+	ActivationLockAllowedWhileSupervised             *bool `json:"activation_lock_allowed_while_supervised,omitempty" csv:"-"`
+	BootstrapTokenAllowed                            *bool `json:"bootstrap_token_allowed,omitempty" csv:"-"`
+	PromptUserToAllowBootstrapTokenForAuthentication *bool `json:"prompt_user_to_allow_bootstrap_token_for_authentication,omitempty" csv:"-"`
 }
 
 // MDMAppleServiceSubscription is a single cellular service subscription
@@ -120,4 +126,56 @@ type MDMAppleDeviceVitals struct {
 	DevicePropertiesAttestation [][]byte `db:"-"`
 
 	ServiceSubscriptions []MDMAppleServiceSubscription `db:"-"`
+}
+
+// HostMDMAppleDeviceVitals is MDMAppleDeviceVitals reshaped for the GET host
+// API response: json-tagged instead of db-tagged, and without HostUUID
+// (redundant with Host.UUID). fleet.Host embeds this anonymously so its
+// fields flatten into the top-level host JSON response.
+//
+// Every field is tagged db:"-" because these are loaded via a separate query
+// for iOS/iPadOS hosts only (see loadHostMDMAppleDeviceVitalsDB), not the
+// main hosts SELECT, and csv:"-" because gocsv flattens embedded struct
+// fields into the List Hosts CSV export regardless of any tag on the
+// embedding field itself — only a tag on each individual field here stops
+// that (that endpoint doesn't load this data anyway, only GET a single host
+// does).
+type HostMDMAppleDeviceVitals struct {
+	UDID                       *string `json:"udid,omitempty" db:"-" csv:"-"`
+	ModelNumber                *string `json:"model_number,omitempty" db:"-" csv:"-"`
+	ModemFirmwareVersion       *string `json:"modem_firmware_version,omitempty" db:"-" csv:"-"`
+	SupplementalBuildVersion   *string `json:"supplemental_build_version,omitempty" db:"-" csv:"-"`
+	SupplementalOSVersionExtra *string `json:"supplemental_os_version_extra,omitempty" db:"-" csv:"-"`
+	BluetoothMAC               *string `json:"bluetooth_mac,omitempty" db:"-" csv:"-"`
+	WiFiMAC                    *string `json:"wifi_mac,omitempty" db:"-" csv:"-"`
+	EASDeviceIdentifier        *string `json:"eas_device_identifier,omitempty" db:"-" csv:"-"`
+	ITunesStoreAccountHash     *string `json:"itunes_store_account_hash,omitempty" db:"-" csv:"-"`
+	PushToken                  []byte  `json:"push_token,omitempty" db:"-" csv:"-"`
+
+	BatteryLevel       *float64 `json:"battery_level,omitempty" db:"-" csv:"-"`
+	CellularTechnology *int64   `json:"cellular_technology,omitempty" db:"-" csv:"-"`
+
+	AppAnalyticsEnabled           *bool `json:"app_analytics_enabled,omitempty" db:"-" csv:"-"`
+	AwaitingConfiguration         *bool `json:"awaiting_configuration,omitempty" db:"-" csv:"-"`
+	DataRoamingEnabled            *bool `json:"data_roaming_enabled,omitempty" db:"-" csv:"-"`
+	DiagnosticSubmissionEnabled   *bool `json:"diagnostic_submission_enabled,omitempty" db:"-" csv:"-"`
+	IsCloudBackupEnabled          *bool `json:"is_cloud_backup_enabled,omitempty" db:"-" csv:"-"`
+	IsDeviceLocatorServiceEnabled *bool `json:"is_device_locator_service_enabled,omitempty" db:"-" csv:"-"`
+	IsDoNotDisturbInEffect        *bool `json:"is_do_not_disturb_in_effect,omitempty" db:"-" csv:"-"`
+	IsMDMLostModeEnabled          *bool `json:"is_mdm_lost_mode_enabled,omitempty" db:"-" csv:"-"`
+	IsNetworkTethered             *bool `json:"is_network_tethered,omitempty" db:"-" csv:"-"`
+	ITunesStoreAccountIsActive    *bool `json:"itunes_store_account_is_active,omitempty" db:"-" csv:"-"`
+	PersonalHotspotEnabled        *bool `json:"personal_hotspot_enabled,omitempty" db:"-" csv:"-"`
+
+	LastCloudBackupDate *time.Time `json:"last_cloud_backup_date,omitempty" db:"-" csv:"-"`
+
+	AccessibilitySettings *MDMAppleAccessibilitySettings  `json:"accessibility_settings,omitempty" db:"-" csv:"-"`
+	OrganizationInfo      *MDMAppleOrganizationInfo       `json:"organization_info,omitempty" db:"-" csv:"-"`
+	MDMOptions            *MDMAppleDeviceVitalsMDMOptions `json:"mdm_options,omitempty" db:"-" csv:"-"`
+	// DevicePropertiesAttestation is the raw DER certificate chain Apple
+	// returns (base64-encoded once marshaled to JSON), not a boolean/status
+	// object. See MDMAppleDeviceVitals.DevicePropertiesAttestation.
+	DevicePropertiesAttestation [][]byte `json:"device_properties_attestation,omitempty" db:"-" csv:"-"`
+
+	ServiceSubscriptions []MDMAppleServiceSubscription `json:"service_subscriptions,omitempty" db:"-" csv:"-"`
 }

--- a/server/fleet/mdm_apple_device_vitals_test.go
+++ b/server/fleet/mdm_apple_device_vitals_test.go
@@ -1,0 +1,55 @@
+package fleet
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMDMAppleCellularTechnologyJSON(t *testing.T) {
+	// Apple reports CellularTechnology as an integer; the API returns its
+	// display label. The integer stays the persisted representation.
+	cases := []struct {
+		raw  int64
+		want string
+	}{
+		{0, `"None"`},
+		{1, `"GSM"`},
+		{2, `"CDMA"`},
+		{3, `"GSM and CDMA"`},
+		// A value outside Apple's documented set must not fail serialization
+		// of the whole host response.
+		{4, `"unknown"`},
+	}
+	for _, c := range cases {
+		got, err := json.Marshal(MDMAppleCellularTechnology(c.raw))
+		require.NoError(t, err)
+		require.JSONEq(t, c.want, string(got))
+	}
+
+	// Round-trips from the display label, so a client (or Fleet's own test
+	// suite) can unmarshal a host response it just received.
+	for _, c := range cases[:4] {
+		var ct MDMAppleCellularTechnology
+		require.NoError(t, json.Unmarshal([]byte(c.want), &ct))
+		require.EqualValues(t, c.raw, ct)
+	}
+
+	// The raw integer is also accepted, so a value straight from the ack or
+	// the database decodes.
+	var ct MDMAppleCellularTechnology
+	require.NoError(t, json.Unmarshal([]byte("2"), &ct))
+	require.Equal(t, MDMAppleCellularTechnologyCDMA, ct)
+
+	// An unrecognized label decodes to the sentinel rather than erroring.
+	require.NoError(t, json.Unmarshal([]byte(`"LTE"`), &ct))
+	require.Equal(t, MDMAppleCellularTechnologyUnknown, ct)
+
+	// Absent (nil pointer) is omitted entirely, not rendered as a label.
+	b, err := json.Marshal(struct {
+		CellularTechnology *MDMAppleCellularTechnology `json:"cellular_technology,omitempty"`
+	}{})
+	require.NoError(t, err)
+	require.JSONEq(t, `{}`, string(b))
+}

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -874,6 +874,8 @@ type SetOrUpdateHostDisksSpaceFunc func(ctx context.Context, hostID uint, gigsAv
 
 type SetOrUpdateHostMDMAppleDeviceVitalsFunc func(ctx context.Context, hostUUID string, vitals fleet.MDMAppleDeviceVitals) error
 
+type LoadHostMDMAppleDeviceVitalsFunc func(ctx context.Context, host *fleet.Host) error
+
 type GetConfigEnableDiskEncryptionFunc func(ctx context.Context, teamID *uint) (fleet.DiskEncryptionConfig, error)
 
 type SetOrUpdateHostDiskTpmPINFunc func(ctx context.Context, hostID uint, pinSet bool) error
@@ -3525,6 +3527,9 @@ type DataStore struct {
 
 	SetOrUpdateHostMDMAppleDeviceVitalsFunc        SetOrUpdateHostMDMAppleDeviceVitalsFunc
 	SetOrUpdateHostMDMAppleDeviceVitalsFuncInvoked bool
+
+	LoadHostMDMAppleDeviceVitalsFunc        LoadHostMDMAppleDeviceVitalsFunc
+	LoadHostMDMAppleDeviceVitalsFuncInvoked bool
 
 	GetConfigEnableDiskEncryptionFunc        GetConfigEnableDiskEncryptionFunc
 	GetConfigEnableDiskEncryptionFuncInvoked bool
@@ -8566,6 +8571,13 @@ func (s *DataStore) SetOrUpdateHostMDMAppleDeviceVitals(ctx context.Context, hos
 	s.SetOrUpdateHostMDMAppleDeviceVitalsFuncInvoked = true
 	s.mu.Unlock()
 	return s.SetOrUpdateHostMDMAppleDeviceVitalsFunc(ctx, hostUUID, vitals)
+}
+
+func (s *DataStore) LoadHostMDMAppleDeviceVitals(ctx context.Context, host *fleet.Host) error {
+	s.mu.Lock()
+	s.LoadHostMDMAppleDeviceVitalsFuncInvoked = true
+	s.mu.Unlock()
+	return s.LoadHostMDMAppleDeviceVitalsFunc(ctx, host)
 }
 
 func (s *DataStore) GetConfigEnableDiskEncryption(ctx context.Context, teamID *uint) (fleet.DiskEncryptionConfig, error) {

--- a/server/service/devices_endpoint_test.go
+++ b/server/service/devices_endpoint_test.go
@@ -57,6 +57,9 @@ func TestGetDeviceHostEndpointScrubbing(t *testing.T) {
 	ds.LoadHostSoftwareFunc = func(ctx context.Context, host *fleet.Host, includeVulnerabilities bool) error {
 		return nil
 	}
+	ds.LoadHostMDMAppleDeviceVitalsFunc = func(ctx context.Context, host *fleet.Host) error {
+		return nil
+	}
 	ds.ListPoliciesForHostFunc = func(ctx context.Context, host *fleet.Host) ([]*fleet.HostPolicy, error) {
 		return nil, nil
 	}
@@ -189,6 +192,9 @@ func TestGetDeviceHostEndpointNoScrubbingForMacOS(t *testing.T) {
 	}
 
 	ds.LoadHostSoftwareFunc = func(ctx context.Context, host *fleet.Host, includeVulnerabilities bool) error {
+		return nil
+	}
+	ds.LoadHostMDMAppleDeviceVitalsFunc = func(ctx context.Context, host *fleet.Host) error {
 		return nil
 	}
 	ds.ListPoliciesForHostFunc = func(ctx context.Context, host *fleet.Host) ([]*fleet.HostPolicy, error) {

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -1686,6 +1686,12 @@ func (svc *Service) getHostDetails(ctx context.Context, host *fleet.Host, opts f
 		host.HostSoftware.Software = []fleet.HostSoftwareEntry{}
 	}
 
+	if fleet.IsAppleMobilePlatform(host.Platform) {
+		if err := svc.ds.LoadHostMDMAppleDeviceVitals(ctx, host); err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "load host mdm apple device vitals")
+		}
+	}
+
 	labels, err := svc.ds.ListLabelsForHost(ctx, host.ID)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "get labels for host")

--- a/server/service/hosts_test.go
+++ b/server/service/hosts_test.go
@@ -437,6 +437,9 @@ func TestHostDetailsMDMTimestamps(t *testing.T) {
 	ds.LoadHostSoftwareFunc = func(ctx context.Context, host *fleet.Host, includeCVEScores bool) error {
 		return nil
 	}
+	ds.LoadHostMDMAppleDeviceVitalsFunc = func(ctx context.Context, host *fleet.Host) error {
+		return nil
+	}
 	ds.ListPoliciesForHostFunc = func(ctx context.Context, host *fleet.Host) ([]*fleet.HostPolicy, error) {
 		return nil, nil
 	}
@@ -907,6 +910,7 @@ func TestHostDetailsHostNameStatus(t *testing.T) {
 	ds.ListLabelsForHostFunc = func(ctx context.Context, hid uint) ([]*fleet.Label, error) { return nil, nil }
 	ds.ListPacksForHostFunc = func(ctx context.Context, hid uint) ([]*fleet.Pack, error) { return nil, nil }
 	ds.LoadHostSoftwareFunc = func(ctx context.Context, host *fleet.Host, includeCVEScores bool) error { return nil }
+	ds.LoadHostMDMAppleDeviceVitalsFunc = func(ctx context.Context, host *fleet.Host) error { return nil }
 	ds.ListPoliciesForHostFunc = func(ctx context.Context, host *fleet.Host) ([]*fleet.HostPolicy, error) { return nil, nil }
 	ds.ListHostBatteriesFunc = func(ctx context.Context, hostID uint) ([]*fleet.HostBattery, error) { return nil, nil }
 	ds.ListUpcomingHostMaintenanceWindowsFunc = func(ctx context.Context, hid uint) ([]*fleet.HostMaintenanceWindow, error) {

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -11471,6 +11471,9 @@ func (s *integrationTestSuite) TestGetHostIOSVitals() {
 	for _, key := range hostIOSVitalsJSONKeys {
 		assert.Contains(t, hostJSON, key, "expected key %q in response for fully populated iOS host", key)
 	}
+	// cellular_technology is stored as Apple's raw integer but returned as its
+	// display label.
+	assert.Equal(t, "GSM", hostJSON["cellular_technology"])
 
 	// GET /hosts/identifier/:identifier funnels through the same datastore
 	// loading path and must behave identically.

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -11363,6 +11363,158 @@ func (s *integrationTestSuite) TestGetHostDiskEncryption() {
 	require.Contains(t, errMsg, fleet.ErrWindowsMDMNotConfigured.Error())
 }
 
+// hostIOSVitalsJSONKeys are the JSON keys of the 29 iOS/iPadOS vitals fields
+// added to fleet.Host: they must be fully omitted (not present, not null)
+// from the host response for non-iOS/iPadOS hosts, or for a field that's
+// absent from the host's host_mdm_apple_device_vitals row.
+var hostIOSVitalsJSONKeys = []string{
+	"udid", "model_number", "modem_firmware_version", "supplemental_build_version",
+	"supplemental_os_version_extra", "bluetooth_mac", "wifi_mac", "eas_device_identifier",
+	"itunes_store_account_hash", "push_token", "battery_level", "cellular_technology",
+	"app_analytics_enabled", "awaiting_configuration", "data_roaming_enabled",
+	"diagnostic_submission_enabled", "is_cloud_backup_enabled", "is_device_locator_service_enabled",
+	"is_do_not_disturb_in_effect", "is_mdm_lost_mode_enabled", "is_network_tethered",
+	"itunes_store_account_is_active", "personal_hotspot_enabled", "last_cloud_backup_date",
+	"accessibility_settings", "organization_info", "mdm_options", "device_properties_attestation",
+	"service_subscriptions",
+}
+
+func (s *integrationTestSuite) getHostJSON(path string) map[string]any {
+	t := s.T()
+	res := s.DoRaw("GET", path, nil, http.StatusOK)
+	defer res.Body.Close()
+
+	var raw struct {
+		Host map[string]any `json:"host"`
+	}
+	require.NoError(t, json.NewDecoder(res.Body).Decode(&raw))
+	return raw.Host
+}
+
+func (s *integrationTestSuite) TestGetHostIOSVitals() {
+	t := s.T()
+	ctx := t.Context()
+
+	newHost := func(platform, uuidSuffix string) *fleet.Host {
+		name := strings.ReplaceAll(t.Name(), "/", "_") + uuidSuffix
+		h, err := s.ds.NewHost(ctx, &fleet.Host{
+			DetailUpdatedAt: time.Now(),
+			LabelUpdatedAt:  time.Now(),
+			PolicyUpdatedAt: time.Now(),
+			SeenTime:        time.Now(),
+			NodeKey:         new(name),
+			OsqueryHostID:   new(name),
+			UUID:            name,
+			Hostname:        name + ".local",
+			PrimaryIP:       "192.168.1.1",
+			PrimaryMac:      "30-65-EC-6F-C4-58",
+			Platform:        platform,
+		})
+		require.NoError(t, err)
+		return h
+	}
+
+	lastBackup := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	fullVitals := fleet.MDMAppleDeviceVitals{
+		UDID:                          new("00008030-AAA"),
+		ModelNumber:                   new("MNEP3LL/A"),
+		ModemFirmwareVersion:          new("2.01.00"),
+		SupplementalBuildVersion:      new("21E236"),
+		SupplementalOSVersionExtra:    new("a"),
+		BluetoothMAC:                  new("a4:83:e7:12:34:57"),
+		WiFiMAC:                       new("a4:83:e7:12:34:58"),
+		EASDeviceIdentifier:           new("3E2A1F9C"),
+		ITunesStoreAccountHash:        new("a1b2c3"),
+		PushToken:                     []byte("push-token-bytes"),
+		BatteryLevel:                  new(0.87),
+		CellularTechnology:            new(int64(1)),
+		AppAnalyticsEnabled:           new(true),
+		AwaitingConfiguration:         new(false),
+		DataRoamingEnabled:            new(false),
+		DiagnosticSubmissionEnabled:   new(true),
+		IsCloudBackupEnabled:          new(true),
+		IsDeviceLocatorServiceEnabled: new(true),
+		IsDoNotDisturbInEffect:        new(false),
+		IsMDMLostModeEnabled:          new(false),
+		IsNetworkTethered:             new(false),
+		ITunesStoreAccountIsActive:    new(true),
+		PersonalHotspotEnabled:        new(false),
+		LastCloudBackupDate:           &lastBackup,
+		AccessibilitySettings: &fleet.MDMAppleAccessibilitySettings{
+			VoiceOverEnabled: new(true),
+			GrayscaleEnabled: new(false),
+		},
+		OrganizationInfo: &fleet.MDMAppleOrganizationInfo{
+			OrganizationName: new("Acme Corp"),
+		},
+		MDMOptions: &fleet.MDMAppleDeviceVitalsMDMOptions{
+			BootstrapTokenAllowed: new(true),
+		},
+		DevicePropertiesAttestation: [][]byte{[]byte("leaf-cert"), []byte("intermediate-cert")},
+		ServiceSubscriptions: []fleet.MDMAppleServiceSubscription{
+			{Slot: "CTSubscriptionSlotOne", ICCID: new("iccid-1")},
+		},
+	}
+
+	// A fully populated iOS host returns all 29 fields, on both GET endpoints.
+	fullHost := newHost("ios", "-full")
+	require.NoError(t, s.ds.SetOrUpdateHostMDMAppleDeviceVitals(ctx, fullHost.UUID, fullVitals))
+
+	var getHostResp getHostResponse
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d", fullHost.ID), nil, http.StatusOK, &getHostResp)
+	require.Equal(t, "00008030-AAA", *getHostResp.Host.UDID)
+	require.InDelta(t, 0.87, *getHostResp.Host.BatteryLevel, 0.001)
+	require.True(t, *getHostResp.Host.AccessibilitySettings.VoiceOverEnabled)
+	require.Len(t, getHostResp.Host.ServiceSubscriptions, 1)
+
+	hostJSON := s.getHostJSON(fmt.Sprintf("/api/latest/fleet/hosts/%d", fullHost.ID))
+	for _, key := range hostIOSVitalsJSONKeys {
+		assert.Contains(t, hostJSON, key, "expected key %q in response for fully populated iOS host", key)
+	}
+
+	// GET /hosts/identifier/:identifier funnels through the same datastore
+	// loading path and must behave identically.
+	var getByIdentifierResp getHostResponse
+	s.DoJSON("GET", "/api/latest/fleet/hosts/identifier/"+fullHost.UUID, nil, http.StatusOK, &getByIdentifierResp)
+	require.Equal(t, "00008030-AAA", *getByIdentifierResp.Host.UDID)
+
+	identifierJSON := s.getHostJSON("/api/latest/fleet/hosts/identifier/" + fullHost.UUID)
+	for _, key := range hostIOSVitalsJSONKeys {
+		assert.Contains(t, identifierJSON, key, "expected key %q in identifier response for fully populated iOS host", key)
+	}
+
+	// A non-Apple-mobile host omits all 29 keys.
+	macHost := newHost("darwin", "-macos")
+	hostJSON = s.getHostJSON(fmt.Sprintf("/api/latest/fleet/hosts/%d", macHost.ID))
+	for _, key := range hostIOSVitalsJSONKeys {
+		assert.NotContains(t, hostJSON, key, "did not expect key %q for a non-Apple-mobile host", key)
+	}
+
+	// A field absent from the side table row is omitted; other populated
+	// fields are still present.
+	partialHost := newHost("ipados", "-partial")
+	partialVitals := fleet.MDMAppleDeviceVitals{
+		UDID:         new("00008030-CCC"),
+		BatteryLevel: new(0.5),
+	}
+	require.NoError(t, s.ds.SetOrUpdateHostMDMAppleDeviceVitals(ctx, partialHost.UUID, partialVitals))
+
+	hostJSON = s.getHostJSON(fmt.Sprintf("/api/latest/fleet/hosts/%d", partialHost.ID))
+	assert.Contains(t, hostJSON, "udid")
+	assert.Contains(t, hostJSON, "battery_level")
+	assert.NotContains(t, hostJSON, "model_number")
+	assert.NotContains(t, hostJSON, "accessibility_settings")
+	assert.NotContains(t, hostJSON, "service_subscriptions")
+
+	// An iOS host with no vitals row yet (hasn't refetched since this
+	// shipped) omits all 29 keys, with no error.
+	noRowHost := newHost("ios", "-no-row")
+	hostJSON = s.getHostJSON(fmt.Sprintf("/api/latest/fleet/hosts/%d", noRowHost.ID))
+	for _, key := range hostIOSVitalsJSONKeys {
+		assert.NotContains(t, hostJSON, key, "did not expect key %q for an iOS host with no vitals row yet", key)
+	}
+}
+
 func (s *integrationTestSuite) TestListVulnerabilities() {
 	t := s.T()
 	var resp listVulnerabilitiesResponse


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #49985

Exposes the the 29 iOS/iPadOS device vitals fields in `GET /hosts/:id` and `GET /hosts/identifier/:identifier` for iOS/iPadOS hosts.

# Checklist for submitter

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

Will be added in feature branch.

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Host details for iOS and iPadOS devices now include available Apple MDM device vitals and service subscription information.
  * Vitals are shown only when present, while unsupported platforms and missing data remain omitted.
  * Added support for nested accessibility, organization, MDM options, and attestation details in host responses.

* **Bug Fixes**
  * Improved handling of hosts without stored Apple MDM vitals, avoiding errors and incomplete responses.

* **Tests**
  * Added coverage for complete, partial, and missing vitals data across host detail endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->