### PR TITLE
Bound Google Workspace directory sync pagination

### DIFF
--- a/changes/49365-google-workspace-sync-limits.md
+++ b/changes/49365-google-workspace-sync-limits.md
@@ -1,0 +1,1 @@
+- Bounded how much of a Google Workspace directory one IdP sync pass pulls, so a very large directory or a misbehaving response can no longer paginate indefinitely or grow server memory without limit. A sync that exceeds a limit fails with an error naming the limit (visible as the last IdP sync status) instead of ingesting a partial directory.

--- a/cmd/fleet/cron_registration.go
+++ b/cmd/fleet/cron_registration.go
@@ -347,7 +347,13 @@ func registerPremiumCrons(ctx context.Context, deps cronSchedulesDeps) {
 	})
 
 	deps.register("failed to register google workspace sync schedule", func() (fleet.CronSchedule, error) {
-		return cron.NewGoogleWorkspaceSchedule(ctx, deps.instanceID, deps.ds, googleworkspace.NewDirectory, deps.logger)
+		factory := googleworkspace.NewDirectoryFactory(googleworkspace.Limits{
+			MaxUsers:            deps.config.GoogleWorkspace.MaxUsers,
+			MaxGroups:           deps.config.GoogleWorkspace.MaxGroups,
+			MaxGroupMembers:     deps.config.GoogleWorkspace.MaxGroupMembers,
+			MaxGroupMemberships: deps.config.GoogleWorkspace.MaxGroupMemberships,
+		})
+		return cron.NewGoogleWorkspaceSchedule(ctx, deps.instanceID, deps.ds, factory, deps.logger)
 	})
 }
 

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -462,6 +462,7 @@ func runServeCmd(cmd *cobra.Command, configManager configpkg.Manager, debug, dev
 	var svc fleet.Service
 	config.MDM.AndroidAgent.Validate(initFatal)
 	config.MDM.ValidateAndroidBatchSize(initFatal)
+	config.GoogleWorkspace.Validate(initFatal)
 	androidSvc, err := android_service.NewService(
 		ctx,
 		logger,

--- a/ee/server/googleworkspace/google_workspace.go
+++ b/ee/server/googleworkspace/google_workspace.go
@@ -27,6 +27,21 @@ const (
 	membersPageSize = 200
 )
 
+// Field projections limiting each listing to what Fleet reads, so the API doesn't
+// serialize and Fleet doesn't parse the rest of the resource (a user carries
+// thumbnails, custom schemas, phones, addresses, aliases, SSH keys and more).
+//
+// nextPageToken must be present or Pages() cannot advance. name, organizations, and
+// emails are requested whole rather than sub-selected: the Admin SDK types the latter
+// two as `any`, and a sub-selection that doesn't match the response shape would
+// silently yield empty departments or emails instead of failing. Keep in sync with
+// mapUser, groupDisplayName, and the member filter in Directory.ListGroups.
+const (
+	usersFields   = "nextPageToken,users(id,primaryEmail,suspended,archived,name,organizations,emails)"
+	groupsFields  = "nextPageToken,groups(id,name,email)"
+	membersFields = "nextPageToken,members(id,type)"
+)
+
 // tokenURIKey is the key holding the OAuth2 token endpoint in a service-account
 // JSON. Real Google service-account JSON always includes it; we honor it so a
 // QA/load-test fake can route the token exchange to a stub endpoint.
@@ -46,20 +61,19 @@ var directoryScopes = []string{
 	directory.AdminDirectoryGroupMemberReadonlyScope,
 }
 
-// maxPagesPerListing bounds page iteration for every listing, regardless of the
-// configured Limits. It catches what a record limit cannot: a malformed response or
-// a proxy that keeps returning a next-page token with empty (or barely filled)
-// pages never grows the result set, so only a page count stops it. It is
-// deliberately far above what a real listing needs — the default user limit is
-// reached in 1,000 pages — so it never fails a sync that would otherwise complete.
-// It is a var only so tests can lower it and exercise the guard cheaply.
-var maxPagesPerListing = 10_000
+// defaultMaxPagesPerListing bounds page iteration for every listing, regardless of
+// the configured Limits. It catches what a record limit cannot: a malformed response
+// or a proxy that keeps returning a next-page token with empty (or barely filled)
+// pages never grows the result set, so only a page count stops it. It is deliberately
+// far above what a real listing needs — the default user limit is reached in 1,000
+// pages — so it never fails a sync that would otherwise complete.
+const defaultMaxPagesPerListing = 10_000
 
 // Limits bound how much of a directory a single sync pass pulls, guarding against
-// holding an unbounded directory in memory. They are safety rails, not tuning
-// knobs: no real Google Workspace tenant is expected to reach them. Defaults and
-// their rationale live with the configuration in server/config. A zero or negative
-// value disables the limit; maxPagesPerListing still applies.
+// holding an unbounded directory in memory. They are safety rails, not tuning knobs:
+// no real Google Workspace tenant is expected to reach them. Defaults and their
+// rationale live with the configuration in server/config. A limit of 0 is disabled
+// (server config validation rejects negatives); the page cap always applies.
 //
 // Exceeding a limit fails the sync rather than truncating the pull: reconciliation
 // treats the pull as authoritative and deletes any scim user/group missing from it,
@@ -74,6 +88,18 @@ type Limits struct {
 	// MaxGroupMemberships bounds the total memberships kept across all groups in
 	// one pass, which is the dominant memory term for a large directory.
 	MaxGroupMemberships int
+	// maxPages replaces defaultMaxPagesPerListing when set. Unexported: it is not an
+	// operator setting, only a way for tests to reach the page cap cheaply without
+	// mutating package state.
+	maxPages int
+}
+
+// pageCap is the page-iteration cap in force for a listing.
+func (l Limits) pageCap() int {
+	if l.maxPages > 0 {
+		return l.maxPages
+	}
+	return defaultMaxPagesPerListing
 }
 
 // Config keys the limits come from, named in the errors so an operator hitting a
@@ -404,33 +430,39 @@ func newGoogleAPI(ctx context.Context, intg *fleet.GoogleWorkspaceIntegration, l
 	return &googleAPI{service: service, limits: limits}, nil
 }
 
-// checkListLimits aborts pagination once a list call has collected more than
-// recordLimit records, or has iterated past maxPagesPerListing however it is
-// configured. Returning an error from a Pages callback stops iteration and surfaces
-// the error to the caller, which fails the sync — the alternative, a truncated pull,
-// would make reconciliation delete every record past the limit.
+// checkListLimits aborts pagination once a listing has reached more than recordLimit
+// records, or has served its last allowed page with more still to come. Returning an
+// error from a Pages callback stops iteration and surfaces the error to the caller,
+// which fails the sync — the alternative, a truncated pull, would make reconciliation
+// delete every record past the limit.
+//
+// records counts the page just received, before it is retained, so a breach doesn't
+// hold a page past the limit. hasMore reports whether the response carried a
+// next-page token, so a listing that ends exactly on the last allowed page succeeds
+// and no request is spent past the cap.
+//
 // The messages stay terse because they end up in the 255-character sync status
 // column, and the setting name is the part an operator needs; the caller's error
 // wrapping already says this is Google Workspace.
-func checkListLimits(ctx context.Context, records, pages, recordLimit int, resource, setting string) error {
+func (a *googleAPI) checkListLimits(ctx context.Context, records, pages int, hasMore bool, recordLimit int, resource, setting string) error {
 	if recordLimit > 0 && records > recordLimit {
 		return ctxerr.Errorf(ctx, "exceeded the limit of %d %s; raise %s to sync this domain",
 			recordLimit, resource, setting)
 	}
-	if pages > maxPagesPerListing {
-		return ctxerr.Errorf(ctx, "%s listing stopped after %d pages without completing; the API kept returning next-page tokens",
-			resource, maxPagesPerListing)
+	if pageLimit := a.limits.pageCap(); hasMore && pages >= pageLimit {
+		return ctxerr.Errorf(ctx, "%s listing exceeded the limit of %d pages; the API kept returning next-page tokens",
+			resource, pageLimit)
 	}
 	return nil
 }
 
 func (a *googleAPI) ListUsers(ctx context.Context, domain string, forEachPage func(users []*directory.User) error) error {
 	pages, records := 0, 0
-	err := a.service.Users.List().Domain(domain).MaxResults(usersPageSize).Pages(ctx, func(page *directory.Users) error {
+	err := a.service.Users.List().Domain(domain).MaxResults(usersPageSize).Fields(usersFields).Pages(ctx, func(page *directory.Users) error {
 		pages++
 		records += len(page.Users)
 		// Check before handing the page over, so an over-limit page isn't mapped.
-		if err := checkListLimits(ctx, records, pages, a.limits.MaxUsers, "users", maxUsersSetting); err != nil {
+		if err := a.checkListLimits(ctx, records, pages, page.NextPageToken != "", a.limits.MaxUsers, "users", maxUsersSetting); err != nil {
 			return err
 		}
 		return forEachPage(page.Users)
@@ -444,10 +476,14 @@ func (a *googleAPI) ListUsers(ctx context.Context, domain string, forEachPage fu
 func (a *googleAPI) ListGroups(ctx context.Context, domain string) ([]*directory.Group, error) {
 	var groups []*directory.Group
 	pages := 0
-	err := a.service.Groups.List().Domain(domain).MaxResults(groupsPageSize).Pages(ctx, func(page *directory.Groups) error {
-		groups = append(groups, page.Groups...)
+	err := a.service.Groups.List().Domain(domain).MaxResults(groupsPageSize).Fields(groupsFields).Pages(ctx, func(page *directory.Groups) error {
 		pages++
-		return checkListLimits(ctx, len(groups), pages, a.limits.MaxGroups, "groups", maxGroupsSetting)
+		// Check before retaining the page, so a breach doesn't hold groups past the limit.
+		if err := a.checkListLimits(ctx, len(groups)+len(page.Groups), pages, page.NextPageToken != "", a.limits.MaxGroups, "groups", maxGroupsSetting); err != nil {
+			return err
+		}
+		groups = append(groups, page.Groups...)
+		return nil
 	})
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "google workspace groups.list")
@@ -460,10 +496,13 @@ func (a *googleAPI) ListGroupMembers(ctx context.Context, groupKey string) ([]*d
 	pages := 0
 	// The group is named by the caller's error wrapping, and the sync status column
 	// this error lands in is only 255 characters, so don't repeat it here.
-	err := a.service.Members.List(groupKey).MaxResults(membersPageSize).Pages(ctx, func(page *directory.Members) error {
-		members = append(members, page.Members...)
+	err := a.service.Members.List(groupKey).MaxResults(membersPageSize).Fields(membersFields).Pages(ctx, func(page *directory.Members) error {
 		pages++
-		return checkListLimits(ctx, len(members), pages, a.limits.MaxGroupMembers, "group members", maxGroupMembersSetting)
+		if err := a.checkListLimits(ctx, len(members)+len(page.Members), pages, page.NextPageToken != "", a.limits.MaxGroupMembers, "group members", maxGroupMembersSetting); err != nil {
+			return err
+		}
+		members = append(members, page.Members...)
+		return nil
 	})
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "google workspace members.list")

--- a/ee/server/googleworkspace/google_workspace.go
+++ b/ee/server/googleworkspace/google_workspace.go
@@ -87,8 +87,16 @@ const (
 
 // lowLevelAPI is the minimal Admin SDK Directory API surface the Directory needs.
 // It exists so tests can supply a fake implementation without hitting Google.
+//
+// ListUsers hands over one page at a time so the caller can map each page and let it
+// go: a raw *directory.User costs around 2 KB, mostly map[string]any overhead for the
+// fields the Admin SDK types as `any`, which is four times what Fleet's mapped
+// ScimUser costs. Accumulating them all was the largest term in a sync's memory use.
+// Groups and members are returned whole — their raw objects are a tenth the size, and
+// streaming groups would mean issuing a members.list for every group in the middle of
+// an in-flight groups.list pagination.
 type lowLevelAPI interface {
-	ListUsers(ctx context.Context, domain string) ([]*directory.User, error)
+	ListUsers(ctx context.Context, domain string, forEachPage func(users []*directory.User) error) error
 	ListGroups(ctx context.Context, domain string) ([]*directory.Group, error)
 	ListGroupMembers(ctx context.Context, groupKey string) ([]*directory.Member, error)
 }
@@ -126,33 +134,38 @@ func (d *Directory) log() *slog.Logger {
 	return d.logger
 }
 
-// ListUsers returns every user in the configured domain mapped to a ScimUser.
+// ListUsers returns every user in the configured domain mapped to a ScimUser. Each
+// page is mapped as it arrives so the raw Directory objects can be collected.
 func (d *Directory) ListUsers(ctx context.Context) ([]*fleet.ScimUser, error) {
-	users, err := d.api.ListUsers(ctx, d.domain)
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "list google workspace users")
-	}
 	logger := d.log()
-	out := make([]*fleet.ScimUser, 0, len(users))
-	for _, u := range users {
-		// A user with no ID or primary email cannot be linked to a host, so skip it.
-		if u.Id == "" || u.PrimaryEmail == "" {
-			logger.DebugContext(ctx, "skipping google workspace user with missing id or primary email",
-				"id", u.Id, "primary_email", u.PrimaryEmail)
-			continue
+	var out []*fleet.ScimUser
+	err := d.api.ListUsers(ctx, d.domain, func(users []*directory.User) error {
+		for _, u := range users {
+			// A user with no ID or primary email cannot be linked to a host, so skip it.
+			if u.Id == "" || u.PrimaryEmail == "" {
+				logger.DebugContext(ctx, "skipping google workspace user with missing id or primary email",
+					"id", u.Id, "primary_email", u.PrimaryEmail)
+				continue
+			}
+			su := mapUser(u)
+			logger.DebugContext(ctx, "ingested google workspace user",
+				"external_id", u.Id,
+				"user_name", su.UserName,
+				"active", derefBool(su.Active),
+				"department", derefString(su.Department),
+				"num_emails", len(su.Emails),
+				// Raw organizations as returned by the Directory API, to diagnose
+				// missing department values (empty/absent means the API returned none).
+				"raw_organizations", rawJSON(u.Organizations),
+			)
+			out = append(out, su)
 		}
-		su := mapUser(u)
-		logger.DebugContext(ctx, "ingested google workspace user",
-			"external_id", u.Id,
-			"user_name", su.UserName,
-			"active", derefBool(su.Active),
-			"department", derefString(su.Department),
-			"num_emails", len(su.Emails),
-			// Raw organizations as returned by the Directory API, to diagnose
-			// missing department values (empty/absent means the API returned none).
-			"raw_organizations", rawJSON(u.Organizations),
-		)
-		out = append(out, su)
+		return nil
+	})
+	if err != nil {
+		// Never return what was mapped before the failure: the sync deletes every
+		// scim user missing from the pull.
+		return nil, ctxerr.Wrap(ctx, err, "list google workspace users")
 	}
 	return out, nil
 }
@@ -411,18 +424,21 @@ func checkListLimits(ctx context.Context, records, pages, recordLimit int, resou
 	return nil
 }
 
-func (a *googleAPI) ListUsers(ctx context.Context, domain string) ([]*directory.User, error) {
-	var users []*directory.User
-	pages := 0
+func (a *googleAPI) ListUsers(ctx context.Context, domain string, forEachPage func(users []*directory.User) error) error {
+	pages, records := 0, 0
 	err := a.service.Users.List().Domain(domain).MaxResults(usersPageSize).Pages(ctx, func(page *directory.Users) error {
-		users = append(users, page.Users...)
 		pages++
-		return checkListLimits(ctx, len(users), pages, a.limits.MaxUsers, "users", maxUsersSetting)
+		records += len(page.Users)
+		// Check before handing the page over, so an over-limit page isn't mapped.
+		if err := checkListLimits(ctx, records, pages, a.limits.MaxUsers, "users", maxUsersSetting); err != nil {
+			return err
+		}
+		return forEachPage(page.Users)
 	})
 	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "google workspace users.list")
+		return ctxerr.Wrap(ctx, err, "google workspace users.list")
 	}
-	return users, nil
+	return nil
 }
 
 func (a *googleAPI) ListGroups(ctx context.Context, domain string) ([]*directory.Group, error) {

--- a/ee/server/googleworkspace/google_workspace.go
+++ b/ee/server/googleworkspace/google_workspace.go
@@ -7,6 +7,7 @@ package googleworkspace
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"os"
 	"strings"
@@ -46,6 +47,36 @@ var directoryScopes = []string{
 	directory.AdminDirectoryGroupMemberReadonlyScope,
 }
 
+// Limits bound how much of a directory a single sync pass pulls. They are safety
+// rails, not tuning knobs: no real Google Workspace tenant is expected to reach
+// them. They guard against runaway pagination (a malformed response or a proxy can
+// keep handing out page tokens indefinitely) and against holding an unbounded
+// directory in memory. A zero or negative value means unlimited.
+//
+// Exceeding a limit fails the sync rather than truncating the pull: reconciliation
+// treats the pull as authoritative and deletes any scim user/group missing from it,
+// so a truncated directory would destroy IdP data.
+type Limits struct {
+	// MaxUsers bounds users returned by one users.list pass.
+	MaxUsers int
+	// MaxGroups bounds groups returned by one groups.list pass.
+	MaxGroups int
+	// MaxGroupMembers bounds members returned for a single group.
+	MaxGroupMembers int
+	// MaxGroupMemberships bounds the total memberships kept across all groups in
+	// one pass, which is the dominant memory term for a large directory.
+	MaxGroupMemberships int
+}
+
+// Config keys the limits come from, named in the errors so an operator hitting a
+// limit knows what to raise.
+const (
+	maxUsersSetting            = "google_workspace.max_users"
+	maxGroupsSetting           = "google_workspace.max_groups"
+	maxGroupMembersSetting     = "google_workspace.max_group_members"
+	maxGroupMembershipsSetting = "google_workspace.max_group_memberships"
+)
+
 // lowLevelAPI is the minimal Admin SDK Directory API surface the Directory needs.
 // It exists so tests can supply a fake implementation without hitting Google.
 type lowLevelAPI interface {
@@ -59,16 +90,25 @@ type Directory struct {
 	api    lowLevelAPI
 	domain string
 	logger *slog.Logger
+	limits Limits
 }
 
 // NewDirectory builds a Directory that talks to the real Admin SDK Directory API
 // using the integration's service account and impersonated admin user.
-func NewDirectory(ctx context.Context, intg *fleet.GoogleWorkspaceIntegration, logger *slog.Logger) (fleet.GoogleWorkspaceDirectory, error) {
-	api, err := newGoogleAPI(ctx, intg, logger)
+func NewDirectory(ctx context.Context, intg *fleet.GoogleWorkspaceIntegration, logger *slog.Logger, limits Limits) (fleet.GoogleWorkspaceDirectory, error) {
+	api, err := newGoogleAPI(ctx, intg, logger, limits)
 	if err != nil {
 		return nil, err
 	}
-	return &Directory{api: api, domain: intg.Domain, logger: logger}, nil
+	return &Directory{api: api, domain: intg.Domain, logger: logger, limits: limits}, nil
+}
+
+// NewDirectoryFactory returns a NewDirectory bound to limits, for injecting into
+// the sync cron (it matches cron.GoogleWorkspaceDirectoryFactory).
+func NewDirectoryFactory(limits Limits) func(context.Context, *fleet.GoogleWorkspaceIntegration, *slog.Logger) (fleet.GoogleWorkspaceDirectory, error) {
+	return func(ctx context.Context, intg *fleet.GoogleWorkspaceIntegration, logger *slog.Logger) (fleet.GoogleWorkspaceDirectory, error) {
+		return NewDirectory(ctx, intg, logger, limits)
+	}
 }
 
 func (d *Directory) log() *slog.Logger {
@@ -117,6 +157,7 @@ func (d *Directory) ListGroups(ctx context.Context) ([]*fleet.GoogleWorkspaceGro
 		return nil, ctxerr.Wrap(ctx, err, "list google workspace groups")
 	}
 	out := make([]*fleet.GoogleWorkspaceGroup, 0, len(groups))
+	memberships := 0
 	for _, g := range groups {
 		if g.Id == "" {
 			continue
@@ -135,6 +176,13 @@ func (d *Directory) ListGroups(ctx context.Context) ([]*fleet.GoogleWorkspaceGro
 				continue
 			}
 			memberIDs = append(memberIDs, m.Id)
+		}
+		// Every group's members are held until the whole pull is reconciled, so cap
+		// the running total, not just each group.
+		memberships += len(memberIDs)
+		if d.limits.MaxGroupMemberships > 0 && memberships > d.limits.MaxGroupMemberships {
+			return nil, ctxerr.Errorf(ctx, "google workspace directory exceeded the limit of %d total group memberships; raise %s to sync this domain",
+				d.limits.MaxGroupMemberships, maxGroupMembershipsSetting)
 		}
 		d.log().DebugContext(ctx, "ingested google workspace group",
 			"external_id", g.Id,
@@ -299,9 +347,10 @@ func jsonRoundTrip(raw any, dst any) {
 // googleAPI is the production lowLevelAPI backed by the Admin SDK Directory API.
 type googleAPI struct {
 	service *directory.Service
+	limits  Limits
 }
 
-func newGoogleAPI(ctx context.Context, intg *fleet.GoogleWorkspaceIntegration, logger *slog.Logger) (*googleAPI, error) {
+func newGoogleAPI(ctx context.Context, intg *fleet.GoogleWorkspaceIntegration, logger *slog.Logger, limits Limits) (*googleAPI, error) {
 	// Honor token_uri from the service-account JSON (real GSA JSON always carries
 	// it). Falls back to Google's endpoint when absent.
 	tokenURL := google.JWTTokenURL
@@ -331,14 +380,45 @@ func newGoogleAPI(ctx context.Context, intg *fleet.GoogleWorkspaceIntegration, l
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "create google workspace directory service")
 	}
-	return &googleAPI{service: service}, nil
+	return &googleAPI{service: service, limits: limits}, nil
+}
+
+// maxPages bounds page iteration independently of the record limit. A malformed
+// response or a misbehaving proxy can return empty pages with a next-page token
+// forever, which a record limit alone never catches because the result set never
+// grows. Allowing twice the pages a completely full result set needs leaves room
+// for the partially filled pages the Directory API may return.
+func maxPages(recordLimit, pageSize int) int {
+	return (recordLimit/pageSize + 1) * 2
+}
+
+// checkPageLimits aborts pagination once a list call has collected more than
+// recordLimit records or iterated past the page limit derived from it. Returning an
+// error from a Pages callback stops iteration and surfaces the error to the caller,
+// which fails the sync — the alternative, a truncated pull, would make
+// reconciliation delete every record past the limit.
+func checkPageLimits(ctx context.Context, records, pages, recordLimit, pageSize int, resource, setting string) error {
+	if recordLimit <= 0 {
+		return nil
+	}
+	if records > recordLimit {
+		return ctxerr.Errorf(ctx, "google workspace directory exceeded the limit of %d %s; raise %s to sync this domain",
+			recordLimit, resource, setting)
+	}
+	if limit := maxPages(recordLimit, pageSize); pages > limit {
+		return ctxerr.Errorf(ctx, "google workspace %s listing did not complete within %d pages; raise %s if the domain is that large",
+			resource, limit, setting)
+	}
+	return nil
 }
 
 func (a *googleAPI) ListUsers(ctx context.Context, domain string) ([]*directory.User, error) {
 	var users []*directory.User
+	pages := 0
 	err := a.service.Users.List().Domain(domain).MaxResults(usersPageSize).Pages(ctx, func(page *directory.Users) error {
 		users = append(users, page.Users...)
-		return nil
+		pages++
+		return checkPageLimits(ctx, len(users), pages, a.limits.MaxUsers, usersPageSize, "users", maxUsersSetting)
 	})
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "google workspace users.list")
@@ -348,9 +428,11 @@ func (a *googleAPI) ListUsers(ctx context.Context, domain string) ([]*directory.
 
 func (a *googleAPI) ListGroups(ctx context.Context, domain string) ([]*directory.Group, error) {
 	var groups []*directory.Group
+	pages := 0
 	err := a.service.Groups.List().Domain(domain).MaxResults(groupsPageSize).Pages(ctx, func(page *directory.Groups) error {
 		groups = append(groups, page.Groups...)
-		return nil
+		pages++
+		return checkPageLimits(ctx, len(groups), pages, a.limits.MaxGroups, groupsPageSize, "groups", maxGroupsSetting)
 	})
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "google workspace groups.list")
@@ -360,9 +442,12 @@ func (a *googleAPI) ListGroups(ctx context.Context, domain string) ([]*directory
 
 func (a *googleAPI) ListGroupMembers(ctx context.Context, groupKey string) ([]*directory.Member, error) {
 	var members []*directory.Member
+	pages := 0
+	resource := fmt.Sprintf("members of group %s", groupKey)
 	err := a.service.Members.List(groupKey).MaxResults(membersPageSize).Pages(ctx, func(page *directory.Members) error {
 		members = append(members, page.Members...)
-		return nil
+		pages++
+		return checkPageLimits(ctx, len(members), pages, a.limits.MaxGroupMembers, membersPageSize, resource, maxGroupMembersSetting)
 	})
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "google workspace members.list")

--- a/ee/server/googleworkspace/google_workspace.go
+++ b/ee/server/googleworkspace/google_workspace.go
@@ -7,7 +7,6 @@ package googleworkspace
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"log/slog"
 	"os"
 	"strings"
@@ -47,11 +46,20 @@ var directoryScopes = []string{
 	directory.AdminDirectoryGroupMemberReadonlyScope,
 }
 
-// Limits bound how much of a directory a single sync pass pulls. They are safety
-// rails, not tuning knobs: no real Google Workspace tenant is expected to reach
-// them. They guard against runaway pagination (a malformed response or a proxy can
-// keep handing out page tokens indefinitely) and against holding an unbounded
-// directory in memory. A zero or negative value means unlimited.
+// maxPagesPerListing bounds page iteration for every listing, regardless of the
+// configured Limits. It catches what a record limit cannot: a malformed response or
+// a proxy that keeps returning a next-page token with empty (or barely filled)
+// pages never grows the result set, so only a page count stops it. It is
+// deliberately far above what a real listing needs — the default user limit is
+// reached in 1,000 pages — so it never fails a sync that would otherwise complete.
+// It is a var only so tests can lower it and exercise the guard cheaply.
+var maxPagesPerListing = 10_000
+
+// Limits bound how much of a directory a single sync pass pulls, guarding against
+// holding an unbounded directory in memory. They are safety rails, not tuning
+// knobs: no real Google Workspace tenant is expected to reach them. Defaults and
+// their rationale live with the configuration in server/config. A zero or negative
+// value disables the limit; maxPagesPerListing still applies.
 //
 // Exceeding a limit fails the sync rather than truncating the pull: reconciliation
 // treats the pull as authoritative and deletes any scim user/group missing from it,
@@ -181,7 +189,7 @@ func (d *Directory) ListGroups(ctx context.Context) ([]*fleet.GoogleWorkspaceGro
 		// the running total, not just each group.
 		memberships += len(memberIDs)
 		if d.limits.MaxGroupMemberships > 0 && memberships > d.limits.MaxGroupMemberships {
-			return nil, ctxerr.Errorf(ctx, "google workspace directory exceeded the limit of %d total group memberships; raise %s to sync this domain",
+			return nil, ctxerr.Errorf(ctx, "exceeded the limit of %d total group memberships; raise %s to sync this domain",
 				d.limits.MaxGroupMemberships, maxGroupMembershipsSetting)
 		}
 		d.log().DebugContext(ctx, "ingested google workspace group",
@@ -383,31 +391,22 @@ func newGoogleAPI(ctx context.Context, intg *fleet.GoogleWorkspaceIntegration, l
 	return &googleAPI{service: service, limits: limits}, nil
 }
 
-// maxPages bounds page iteration independently of the record limit. A malformed
-// response or a misbehaving proxy can return empty pages with a next-page token
-// forever, which a record limit alone never catches because the result set never
-// grows. Allowing twice the pages a completely full result set needs leaves room
-// for the partially filled pages the Directory API may return.
-func maxPages(recordLimit, pageSize int) int {
-	return (recordLimit/pageSize + 1) * 2
-}
-
-// checkPageLimits aborts pagination once a list call has collected more than
-// recordLimit records or iterated past the page limit derived from it. Returning an
-// error from a Pages callback stops iteration and surfaces the error to the caller,
-// which fails the sync — the alternative, a truncated pull, would make
-// reconciliation delete every record past the limit.
-func checkPageLimits(ctx context.Context, records, pages, recordLimit, pageSize int, resource, setting string) error {
-	if recordLimit <= 0 {
-		return nil
-	}
-	if records > recordLimit {
-		return ctxerr.Errorf(ctx, "google workspace directory exceeded the limit of %d %s; raise %s to sync this domain",
+// checkListLimits aborts pagination once a list call has collected more than
+// recordLimit records, or has iterated past maxPagesPerListing however it is
+// configured. Returning an error from a Pages callback stops iteration and surfaces
+// the error to the caller, which fails the sync — the alternative, a truncated pull,
+// would make reconciliation delete every record past the limit.
+// The messages stay terse because they end up in the 255-character sync status
+// column, and the setting name is the part an operator needs; the caller's error
+// wrapping already says this is Google Workspace.
+func checkListLimits(ctx context.Context, records, pages, recordLimit int, resource, setting string) error {
+	if recordLimit > 0 && records > recordLimit {
+		return ctxerr.Errorf(ctx, "exceeded the limit of %d %s; raise %s to sync this domain",
 			recordLimit, resource, setting)
 	}
-	if limit := maxPages(recordLimit, pageSize); pages > limit {
-		return ctxerr.Errorf(ctx, "google workspace %s listing did not complete within %d pages; raise %s if the domain is that large",
-			resource, limit, setting)
+	if pages > maxPagesPerListing {
+		return ctxerr.Errorf(ctx, "%s listing stopped after %d pages without completing; the API kept returning next-page tokens",
+			resource, maxPagesPerListing)
 	}
 	return nil
 }
@@ -418,7 +417,7 @@ func (a *googleAPI) ListUsers(ctx context.Context, domain string) ([]*directory.
 	err := a.service.Users.List().Domain(domain).MaxResults(usersPageSize).Pages(ctx, func(page *directory.Users) error {
 		users = append(users, page.Users...)
 		pages++
-		return checkPageLimits(ctx, len(users), pages, a.limits.MaxUsers, usersPageSize, "users", maxUsersSetting)
+		return checkListLimits(ctx, len(users), pages, a.limits.MaxUsers, "users", maxUsersSetting)
 	})
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "google workspace users.list")
@@ -432,7 +431,7 @@ func (a *googleAPI) ListGroups(ctx context.Context, domain string) ([]*directory
 	err := a.service.Groups.List().Domain(domain).MaxResults(groupsPageSize).Pages(ctx, func(page *directory.Groups) error {
 		groups = append(groups, page.Groups...)
 		pages++
-		return checkPageLimits(ctx, len(groups), pages, a.limits.MaxGroups, groupsPageSize, "groups", maxGroupsSetting)
+		return checkListLimits(ctx, len(groups), pages, a.limits.MaxGroups, "groups", maxGroupsSetting)
 	})
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "google workspace groups.list")
@@ -443,11 +442,12 @@ func (a *googleAPI) ListGroups(ctx context.Context, domain string) ([]*directory
 func (a *googleAPI) ListGroupMembers(ctx context.Context, groupKey string) ([]*directory.Member, error) {
 	var members []*directory.Member
 	pages := 0
-	resource := fmt.Sprintf("members of group %s", groupKey)
+	// The group is named by the caller's error wrapping, and the sync status column
+	// this error lands in is only 255 characters, so don't repeat it here.
 	err := a.service.Members.List(groupKey).MaxResults(membersPageSize).Pages(ctx, func(page *directory.Members) error {
 		members = append(members, page.Members...)
 		pages++
-		return checkPageLimits(ctx, len(members), pages, a.limits.MaxGroupMembers, membersPageSize, resource, maxGroupMembersSetting)
+		return checkListLimits(ctx, len(members), pages, a.limits.MaxGroupMembers, "group members", maxGroupMembersSetting)
 	})
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "google workspace members.list")

--- a/ee/server/googleworkspace/google_workspace_test.go
+++ b/ee/server/googleworkspace/google_workspace_test.go
@@ -19,8 +19,20 @@ type fakeAPI struct {
 	memberErr error
 }
 
-func (f *fakeAPI) ListUsers(_ context.Context, _ string) ([]*directory.User, error) {
-	return f.users, f.usersErr
+// ListUsers delivers the fake's users in two pages when there is more than one, so
+// callers are exercised across page boundaries.
+func (f *fakeAPI) ListUsers(_ context.Context, _ string, forEachPage func([]*directory.User) error) error {
+	if f.usersErr != nil {
+		return f.usersErr
+	}
+	if len(f.users) < 2 {
+		return forEachPage(f.users)
+	}
+	split := len(f.users) / 2
+	if err := forEachPage(f.users[:split]); err != nil {
+		return err
+	}
+	return forEachPage(f.users[split:])
 }
 
 func (f *fakeAPI) ListGroups(_ context.Context, _ string) ([]*directory.Group, error) {

--- a/ee/server/googleworkspace/limits_test.go
+++ b/ee/server/googleworkspace/limits_test.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"sync/atomic"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/stretchr/testify/require"
@@ -21,8 +22,8 @@ import (
 // pagingFake is a fake Directory API whose listings keep handing out next-page
 // tokens, so pagination stops only when a limit trips or when the listing's page
 // count is reached. A perPage of 0 makes a listing return empty pages, which is the
-// malformed-response case the page limit exists for: the record limit alone never
-// catches it, because the result set never grows.
+// malformed-response case the page limit exists for: a record limit never catches
+// it, because the result set never grows.
 type pagingFake struct {
 	usersPerPage int
 	// userPages is how many pages the users listing has; 0 means it never ends.
@@ -34,19 +35,25 @@ type pagingFake struct {
 }
 
 // server starts the fake and returns it along with the number of Directory API
-// requests it has served, so a test can show pagination actually stopped.
-func (f pagingFake) server(t *testing.T) (*httptest.Server, *atomic.Int64) {
+// requests it has served, so a test can show pagination actually stopped. Requests
+// past ceiling fail: a regression that stops honoring a limit would otherwise
+// paginate until the test binary times out instead of failing an assertion.
+func (f pagingFake) server(t *testing.T, ceiling int64) (*httptest.Server, *atomic.Int64) {
 	requests := new(atomic.Int64)
 
-	// servePage returns the requested page index and the token for the next page,
-	// empty when this is the last of pages pages.
-	servePage := func(r *http.Request, pages int) (int, string) {
-		requests.Add(1)
+	// servePage returns the requested page index and the token for the next page
+	// (empty when this is the last of pages pages), or false when the fake has
+	// already served every request it was allowed.
+	servePage := func(w http.ResponseWriter, r *http.Request, pages int) (int, string, bool) {
+		if requests.Add(1) > ceiling {
+			http.Error(w, "fake request ceiling exceeded", http.StatusBadRequest)
+			return 0, "", false
+		}
 		page, _ := strconv.Atoi(r.URL.Query().Get("pageToken"))
 		if pages > 0 && page+1 >= pages {
-			return page, ""
+			return page, "", true
 		}
-		return page, strconv.Itoa(page + 1)
+		return page, strconv.Itoa(page + 1), true
 	}
 
 	mux := http.NewServeMux()
@@ -54,7 +61,10 @@ func (f pagingFake) server(t *testing.T) (*httptest.Server, *atomic.Int64) {
 		_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "x", "token_type": "Bearer", "expires_in": 3600})
 	})
 	mux.HandleFunc("GET /admin/directory/v1/users", func(w http.ResponseWriter, r *http.Request) {
-		page, next := servePage(r, f.userPages)
+		page, next, ok := servePage(w, r, f.userPages)
+		if !ok {
+			return
+		}
 		users := make([]map[string]any, 0, f.usersPerPage)
 		for i := range f.usersPerPage {
 			id := fmt.Sprintf("u%d-%d", page, i)
@@ -63,7 +73,10 @@ func (f pagingFake) server(t *testing.T) (*httptest.Server, *atomic.Int64) {
 		_ = json.NewEncoder(w).Encode(map[string]any{"users": users, "nextPageToken": next})
 	})
 	mux.HandleFunc("GET /admin/directory/v1/groups", func(w http.ResponseWriter, r *http.Request) {
-		page, next := servePage(r, f.groupPages)
+		page, next, ok := servePage(w, r, f.groupPages)
+		if !ok {
+			return
+		}
 		groups := make([]map[string]any, 0, f.groupsPerPage)
 		for i := range f.groupsPerPage {
 			id := fmt.Sprintf("g%d-%d", page, i)
@@ -72,7 +85,10 @@ func (f pagingFake) server(t *testing.T) (*httptest.Server, *atomic.Int64) {
 		_ = json.NewEncoder(w).Encode(map[string]any{"groups": groups, "nextPageToken": next})
 	})
 	mux.HandleFunc("GET /admin/directory/v1/groups/{k}/members", func(w http.ResponseWriter, r *http.Request) {
-		page, next := servePage(r, f.memberPages)
+		page, next, ok := servePage(w, r, f.memberPages)
+		if !ok {
+			return
+		}
 		members := make([]map[string]any, 0, f.membersPerPage)
 		for i := range f.membersPerPage {
 			members = append(members, map[string]any{"id": fmt.Sprintf("%s-m%d-%d", r.PathValue("k"), page, i), "type": "USER"})
@@ -110,6 +126,12 @@ func testServiceAccountKey(t *testing.T) []byte {
 	return pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
 }
 
+// errBudget is how long a limit error may be. cronGoogleWorkspaceSync truncates the
+// sync status to fleet.SCIMMaxFieldLength runes after adding its own wrapping, and a
+// real Google group ID is 21 characters where the fake's is 4, so a longer message
+// loses the setting name that tells the operator what to raise.
+const errBudget = fleet.SCIMMaxFieldLength - 55
+
 func TestDirectoryPaginationLimits(t *testing.T) {
 	pemKey := testServiceAccountKey(t)
 
@@ -119,116 +141,152 @@ func TestDirectoryPaginationLimits(t *testing.T) {
 		// listGroups lists groups (and their members) instead of users.
 		listGroups bool
 		limits     Limits
+		// maxPages lowers maxPagesPerListing so the page guard can be exercised
+		// without serving its production number of pages.
+		maxPages int
 		// wantErrContains is empty when the listing is expected to succeed.
 		wantErrContains string
-		// wantMaxRequests bounds the API calls the listing may make, so a
-		// regression that keeps paginating fails instead of hanging.
-		wantMaxRequests int64
+		// wantRecords is the number of users or groups a successful listing returns.
+		wantRecords int
+		// wantRequests is the exact number of API calls the listing should make; the
+		// fake fails anything past it, so a lost limit check fails fast.
+		wantRequests int64
 	}{
 		{
 			name:            "users over record limit",
 			fake:            pagingFake{usersPerPage: usersPageSize},
 			limits:          Limits{MaxUsers: 1000},
-			wantErrContains: "exceeded the limit of 1000 users",
-			wantMaxRequests: 3,
+			wantErrContains: "exceeded the limit of 1000 users; raise google_workspace.max_users",
+			wantRequests:    3,
 		},
 		{
 			// The record limit can never trip here, only the page limit can.
 			name:            "users empty pages forever",
 			fake:            pagingFake{usersPerPage: 0},
 			limits:          Limits{MaxUsers: 1000},
-			wantErrContains: "users listing did not complete within 6 pages",
-			wantMaxRequests: 7,
+			maxPages:        5,
+			wantErrContains: "users listing stopped after 5 pages without completing",
+			wantRequests:    6,
 		},
 		{
-			name:            "users under limit",
-			fake:            pagingFake{usersPerPage: 2, userPages: 2},
-			limits:          Limits{MaxUsers: 1000},
-			wantMaxRequests: 2,
-		},
-		{
-			name:            "users unlimited",
-			fake:            pagingFake{usersPerPage: 2, userPages: 3},
+			// The page limit must hold with the record limit disabled too, or the
+			// documented escape hatch would restore the unbounded loop.
+			name:            "users empty pages forever with no record limit",
+			fake:            pagingFake{usersPerPage: 0},
 			limits:          Limits{MaxUsers: 0},
-			wantMaxRequests: 3,
+			maxPages:        5,
+			wantErrContains: "users listing stopped after 5 pages without completing",
+			wantRequests:    6,
+		},
+		{
+			name:         "users under limit",
+			fake:         pagingFake{usersPerPage: 2, userPages: 2},
+			limits:       Limits{MaxUsers: 1000},
+			wantRecords:  4,
+			wantRequests: 2,
+		},
+		{
+			// More users than the record limit in the cases above would allow.
+			name:         "users unlimited",
+			fake:         pagingFake{usersPerPage: usersPageSize, userPages: 4},
+			limits:       Limits{MaxUsers: 0},
+			wantRecords:  4 * usersPageSize,
+			wantRequests: 4,
 		},
 		{
 			name:            "groups over record limit",
 			fake:            pagingFake{groupsPerPage: groupsPageSize, membersPerPage: 1, memberPages: 1},
 			listGroups:      true,
 			limits:          Limits{MaxGroups: 400},
-			wantErrContains: "exceeded the limit of 400 groups",
-			wantMaxRequests: 3,
+			wantErrContains: "exceeded the limit of 400 groups; raise google_workspace.max_groups",
+			wantRequests:    3,
 		},
 		{
-			name:            "groups empty pages forever",
+			name:            "groups empty pages forever with no record limit",
 			fake:            pagingFake{groupsPerPage: 0},
 			listGroups:      true,
-			limits:          Limits{MaxGroups: 400},
-			wantErrContains: "groups listing did not complete within 6 pages",
-			wantMaxRequests: 7,
+			limits:          Limits{MaxGroups: 0},
+			maxPages:        5,
+			wantErrContains: "groups listing stopped after 5 pages without completing",
+			wantRequests:    6,
 		},
 		{
-			name:            "members of one group over record limit",
+			name:            "group members over record limit",
 			fake:            pagingFake{groupsPerPage: 1, groupPages: 1, membersPerPage: membersPageSize},
 			listGroups:      true,
 			limits:          Limits{MaxGroupMembers: 400},
-			wantErrContains: "exceeded the limit of 400 members of group g0-0",
+			wantErrContains: "exceeded the limit of 400 group members; raise google_workspace.max_group_members",
 			// One groups page plus the member pages for the first group.
-			wantMaxRequests: 4,
+			wantRequests: 4,
 		},
 		{
-			name:            "members of one group empty pages forever",
+			name:            "group members empty pages forever with no record limit",
 			fake:            pagingFake{groupsPerPage: 1, groupPages: 1, membersPerPage: 0},
 			listGroups:      true,
-			limits:          Limits{MaxGroupMembers: 400},
-			wantErrContains: "members of group g0-0 listing did not complete within 6 pages",
-			wantMaxRequests: 8,
+			limits:          Limits{MaxGroupMembers: 0},
+			maxPages:        5,
+			wantErrContains: "group members listing stopped after 5 pages without completing",
+			wantRequests:    7,
 		},
 		{
 			name:            "total memberships over limit",
 			fake:            pagingFake{groupsPerPage: 3, groupPages: 1, membersPerPage: 4, memberPages: 1},
 			listGroups:      true,
 			limits:          Limits{MaxGroupMemberships: 10},
-			wantErrContains: "exceeded the limit of 10 total group memberships",
+			wantErrContains: "exceeded the limit of 10 total group memberships; raise google_workspace.max_group_memberships",
 			// Groups page plus member listings for the first three groups.
-			wantMaxRequests: 4,
+			wantRequests: 4,
 		},
 		{
-			name:            "groups and memberships under limits",
-			fake:            pagingFake{groupsPerPage: 3, groupPages: 1, membersPerPage: 4, memberPages: 1},
-			listGroups:      true,
-			limits:          Limits{MaxGroups: 400, MaxGroupMembers: 400, MaxGroupMemberships: 12},
-			wantMaxRequests: 4,
+			name:         "groups and memberships under limits",
+			fake:         pagingFake{groupsPerPage: 3, groupPages: 1, membersPerPage: 4, memberPages: 1},
+			listGroups:   true,
+			limits:       Limits{MaxGroups: 400, MaxGroupMembers: 400, MaxGroupMemberships: 12},
+			wantRecords:  3,
+			wantRequests: 4,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			srv, requests := tc.fake.server(t)
+			if tc.maxPages > 0 {
+				original := maxPagesPerListing
+				maxPagesPerListing = tc.maxPages
+				t.Cleanup(func() { maxPagesPerListing = original })
+			}
+
+			srv, requests := tc.fake.server(t, tc.wantRequests+1)
 			dir := newTestDirectory(t, srv, pemKey, tc.limits)
 
-			var err error
+			var (
+				records int
+				err     error
+			)
 			if tc.listGroups {
-				_, err = dir.ListGroups(t.Context())
+				var groups []*fleet.GoogleWorkspaceGroup
+				groups, err = dir.ListGroups(t.Context())
+				records = len(groups)
+				if tc.wantErrContains != "" {
+					// A limit must abort the pull, never return part of it: the sync
+					// deletes every scim record missing from what it gets back.
+					require.Nil(t, groups)
+				}
 			} else {
-				_, err = dir.ListUsers(t.Context())
+				var users []*fleet.ScimUser
+				users, err = dir.ListUsers(t.Context())
+				records = len(users)
+				if tc.wantErrContains != "" {
+					require.Nil(t, users)
+				}
 			}
 
 			if tc.wantErrContains == "" {
 				require.NoError(t, err)
+				require.Equal(t, tc.wantRecords, records)
 			} else {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.wantErrContains)
+				require.LessOrEqual(t, utf8.RuneCountInString(err.Error()), errBudget)
 			}
-			require.LessOrEqual(t, requests.Load(), tc.wantMaxRequests)
+			require.Equal(t, tc.wantRequests, requests.Load())
 		})
 	}
-}
-
-func TestMaxPages(t *testing.T) {
-	// Twice the pages a full result set needs, so partially filled pages don't trip
-	// the guard before the record limit does.
-	require.Equal(t, 4, maxPages(500, 500))
-	require.Equal(t, 6, maxPages(1000, 500))
-	require.Equal(t, 2, maxPages(1, 500))
-	require.Equal(t, 2002, maxPages(500_000, 500))
 }

--- a/ee/server/googleworkspace/limits_test.go
+++ b/ee/server/googleworkspace/limits_test.go
@@ -1,0 +1,234 @@
+package googleworkspace
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync/atomic"
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/stretchr/testify/require"
+)
+
+// pagingFake is a fake Directory API whose listings keep handing out next-page
+// tokens, so pagination stops only when a limit trips or when the listing's page
+// count is reached. A perPage of 0 makes a listing return empty pages, which is the
+// malformed-response case the page limit exists for: the record limit alone never
+// catches it, because the result set never grows.
+type pagingFake struct {
+	usersPerPage int
+	// userPages is how many pages the users listing has; 0 means it never ends.
+	userPages      int
+	groupsPerPage  int
+	groupPages     int
+	membersPerPage int
+	memberPages    int
+}
+
+// server starts the fake and returns it along with the number of Directory API
+// requests it has served, so a test can show pagination actually stopped.
+func (f pagingFake) server(t *testing.T) (*httptest.Server, *atomic.Int64) {
+	requests := new(atomic.Int64)
+
+	// servePage returns the requested page index and the token for the next page,
+	// empty when this is the last of pages pages.
+	servePage := func(r *http.Request, pages int) (int, string) {
+		requests.Add(1)
+		page, _ := strconv.Atoi(r.URL.Query().Get("pageToken"))
+		if pages > 0 && page+1 >= pages {
+			return page, ""
+		}
+		return page, strconv.Itoa(page + 1)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /token", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "x", "token_type": "Bearer", "expires_in": 3600})
+	})
+	mux.HandleFunc("GET /admin/directory/v1/users", func(w http.ResponseWriter, r *http.Request) {
+		page, next := servePage(r, f.userPages)
+		users := make([]map[string]any, 0, f.usersPerPage)
+		for i := range f.usersPerPage {
+			id := fmt.Sprintf("u%d-%d", page, i)
+			users = append(users, map[string]any{"id": id, "primaryEmail": id + "@b.com"})
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"users": users, "nextPageToken": next})
+	})
+	mux.HandleFunc("GET /admin/directory/v1/groups", func(w http.ResponseWriter, r *http.Request) {
+		page, next := servePage(r, f.groupPages)
+		groups := make([]map[string]any, 0, f.groupsPerPage)
+		for i := range f.groupsPerPage {
+			id := fmt.Sprintf("g%d-%d", page, i)
+			groups = append(groups, map[string]any{"id": id, "name": id})
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"groups": groups, "nextPageToken": next})
+	})
+	mux.HandleFunc("GET /admin/directory/v1/groups/{k}/members", func(w http.ResponseWriter, r *http.Request) {
+		page, next := servePage(r, f.memberPages)
+		members := make([]map[string]any, 0, f.membersPerPage)
+		for i := range f.membersPerPage {
+			members = append(members, map[string]any{"id": fmt.Sprintf("%s-m%d-%d", r.PathValue("k"), page, i), "type": "USER"})
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"members": members, "nextPageToken": next})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, requests
+}
+
+// newTestDirectory points a real Directory client at the fake server through the
+// endpoint override seam, so the limits are exercised in the production code path.
+func newTestDirectory(t *testing.T, srv *httptest.Server, pemKey []byte, limits Limits) fleet.GoogleWorkspaceDirectory {
+	t.Setenv(endpointOverrideEnv, srv.URL)
+	intg := &fleet.GoogleWorkspaceIntegration{
+		Domain:                "b.com",
+		ImpersonatedUserEmail: "admin@b.com",
+		ApiKey: fleet.GoogleCalendarApiKey{Values: map[string]string{
+			fleet.GoogleCalendarEmail:      "sa@b.com",
+			fleet.GoogleCalendarPrivateKey: string(pemKey),
+			tokenURIKey:                    srv.URL + "/token",
+		}},
+	}
+	dir, err := NewDirectory(t.Context(), intg, slog.New(slog.DiscardHandler), limits)
+	require.NoError(t, err)
+	return dir
+}
+
+func testServiceAccountKey(t *testing.T) []byte {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+	return pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+}
+
+func TestDirectoryPaginationLimits(t *testing.T) {
+	pemKey := testServiceAccountKey(t)
+
+	for _, tc := range []struct {
+		name string
+		fake pagingFake
+		// listGroups lists groups (and their members) instead of users.
+		listGroups bool
+		limits     Limits
+		// wantErrContains is empty when the listing is expected to succeed.
+		wantErrContains string
+		// wantMaxRequests bounds the API calls the listing may make, so a
+		// regression that keeps paginating fails instead of hanging.
+		wantMaxRequests int64
+	}{
+		{
+			name:            "users over record limit",
+			fake:            pagingFake{usersPerPage: usersPageSize},
+			limits:          Limits{MaxUsers: 1000},
+			wantErrContains: "exceeded the limit of 1000 users",
+			wantMaxRequests: 3,
+		},
+		{
+			// The record limit can never trip here, only the page limit can.
+			name:            "users empty pages forever",
+			fake:            pagingFake{usersPerPage: 0},
+			limits:          Limits{MaxUsers: 1000},
+			wantErrContains: "users listing did not complete within 6 pages",
+			wantMaxRequests: 7,
+		},
+		{
+			name:            "users under limit",
+			fake:            pagingFake{usersPerPage: 2, userPages: 2},
+			limits:          Limits{MaxUsers: 1000},
+			wantMaxRequests: 2,
+		},
+		{
+			name:            "users unlimited",
+			fake:            pagingFake{usersPerPage: 2, userPages: 3},
+			limits:          Limits{MaxUsers: 0},
+			wantMaxRequests: 3,
+		},
+		{
+			name:            "groups over record limit",
+			fake:            pagingFake{groupsPerPage: groupsPageSize, membersPerPage: 1, memberPages: 1},
+			listGroups:      true,
+			limits:          Limits{MaxGroups: 400},
+			wantErrContains: "exceeded the limit of 400 groups",
+			wantMaxRequests: 3,
+		},
+		{
+			name:            "groups empty pages forever",
+			fake:            pagingFake{groupsPerPage: 0},
+			listGroups:      true,
+			limits:          Limits{MaxGroups: 400},
+			wantErrContains: "groups listing did not complete within 6 pages",
+			wantMaxRequests: 7,
+		},
+		{
+			name:            "members of one group over record limit",
+			fake:            pagingFake{groupsPerPage: 1, groupPages: 1, membersPerPage: membersPageSize},
+			listGroups:      true,
+			limits:          Limits{MaxGroupMembers: 400},
+			wantErrContains: "exceeded the limit of 400 members of group g0-0",
+			// One groups page plus the member pages for the first group.
+			wantMaxRequests: 4,
+		},
+		{
+			name:            "members of one group empty pages forever",
+			fake:            pagingFake{groupsPerPage: 1, groupPages: 1, membersPerPage: 0},
+			listGroups:      true,
+			limits:          Limits{MaxGroupMembers: 400},
+			wantErrContains: "members of group g0-0 listing did not complete within 6 pages",
+			wantMaxRequests: 8,
+		},
+		{
+			name:            "total memberships over limit",
+			fake:            pagingFake{groupsPerPage: 3, groupPages: 1, membersPerPage: 4, memberPages: 1},
+			listGroups:      true,
+			limits:          Limits{MaxGroupMemberships: 10},
+			wantErrContains: "exceeded the limit of 10 total group memberships",
+			// Groups page plus member listings for the first three groups.
+			wantMaxRequests: 4,
+		},
+		{
+			name:            "groups and memberships under limits",
+			fake:            pagingFake{groupsPerPage: 3, groupPages: 1, membersPerPage: 4, memberPages: 1},
+			listGroups:      true,
+			limits:          Limits{MaxGroups: 400, MaxGroupMembers: 400, MaxGroupMemberships: 12},
+			wantMaxRequests: 4,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, requests := tc.fake.server(t)
+			dir := newTestDirectory(t, srv, pemKey, tc.limits)
+
+			var err error
+			if tc.listGroups {
+				_, err = dir.ListGroups(t.Context())
+			} else {
+				_, err = dir.ListUsers(t.Context())
+			}
+
+			if tc.wantErrContains == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.wantErrContains)
+			}
+			require.LessOrEqual(t, requests.Load(), tc.wantMaxRequests)
+		})
+	}
+}
+
+func TestMaxPages(t *testing.T) {
+	// Twice the pages a full result set needs, so partially filled pages don't trip
+	// the guard before the record limit does.
+	require.Equal(t, 4, maxPages(500, 500))
+	require.Equal(t, 6, maxPages(1000, 500))
+	require.Equal(t, 2, maxPages(1, 500))
+	require.Equal(t, 2002, maxPages(500_000, 500))
+}

--- a/ee/server/googleworkspace/limits_test.go
+++ b/ee/server/googleworkspace/limits_test.go
@@ -141,9 +141,6 @@ func TestDirectoryPaginationLimits(t *testing.T) {
 		// listGroups lists groups (and their members) instead of users.
 		listGroups bool
 		limits     Limits
-		// maxPages lowers maxPagesPerListing so the page guard can be exercised
-		// without serving its production number of pages.
-		maxPages int
 		// wantErrContains is empty when the listing is expected to succeed.
 		wantErrContains string
 		// wantRecords is the number of users or groups a successful listing returns.
@@ -163,20 +160,18 @@ func TestDirectoryPaginationLimits(t *testing.T) {
 			// The record limit can never trip here, only the page limit can.
 			name:            "users empty pages forever",
 			fake:            pagingFake{usersPerPage: 0},
-			limits:          Limits{MaxUsers: 1000},
-			maxPages:        5,
-			wantErrContains: "users listing stopped after 5 pages without completing",
-			wantRequests:    6,
+			limits:          Limits{MaxUsers: 1000, maxPages: 5},
+			wantErrContains: "users listing exceeded the limit of 5 pages",
+			wantRequests:    5,
 		},
 		{
 			// The page limit must hold with the record limit disabled too, or the
 			// documented escape hatch would restore the unbounded loop.
 			name:            "users empty pages forever with no record limit",
 			fake:            pagingFake{usersPerPage: 0},
-			limits:          Limits{MaxUsers: 0},
-			maxPages:        5,
-			wantErrContains: "users listing stopped after 5 pages without completing",
-			wantRequests:    6,
+			limits:          Limits{MaxUsers: 0, maxPages: 5},
+			wantErrContains: "users listing exceeded the limit of 5 pages",
+			wantRequests:    5,
 		},
 		{
 			name:         "users under limit",
@@ -184,6 +179,15 @@ func TestDirectoryPaginationLimits(t *testing.T) {
 			limits:       Limits{MaxUsers: 1000},
 			wantRecords:  4,
 			wantRequests: 2,
+		},
+		{
+			// A listing whose last page is the last allowed page has nothing more to
+			// fetch, so it must succeed rather than trip the page limit.
+			name:         "users ending on the last allowed page",
+			fake:         pagingFake{usersPerPage: 2, userPages: 5},
+			limits:       Limits{MaxUsers: 1000, maxPages: 5},
+			wantRecords:  10,
+			wantRequests: 5,
 		},
 		{
 			// More users than the record limit in the cases above would allow.
@@ -205,10 +209,9 @@ func TestDirectoryPaginationLimits(t *testing.T) {
 			name:            "groups empty pages forever with no record limit",
 			fake:            pagingFake{groupsPerPage: 0},
 			listGroups:      true,
-			limits:          Limits{MaxGroups: 0},
-			maxPages:        5,
-			wantErrContains: "groups listing stopped after 5 pages without completing",
-			wantRequests:    6,
+			limits:          Limits{MaxGroups: 0, maxPages: 5},
+			wantErrContains: "groups listing exceeded the limit of 5 pages",
+			wantRequests:    5,
 		},
 		{
 			name:            "group members over record limit",
@@ -223,10 +226,9 @@ func TestDirectoryPaginationLimits(t *testing.T) {
 			name:            "group members empty pages forever with no record limit",
 			fake:            pagingFake{groupsPerPage: 1, groupPages: 1, membersPerPage: 0},
 			listGroups:      true,
-			limits:          Limits{MaxGroupMembers: 0},
-			maxPages:        5,
-			wantErrContains: "group members listing stopped after 5 pages without completing",
-			wantRequests:    7,
+			limits:          Limits{MaxGroupMembers: 0, maxPages: 5},
+			wantErrContains: "group members listing exceeded the limit of 5 pages",
+			wantRequests:    6,
 		},
 		{
 			name:            "total memberships over limit",
@@ -247,12 +249,6 @@ func TestDirectoryPaginationLimits(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.maxPages > 0 {
-				original := maxPagesPerListing
-				maxPagesPerListing = tc.maxPages
-				t.Cleanup(func() { maxPagesPerListing = original })
-			}
-
 			srv, requests := tc.fake.server(t, tc.wantRequests+1)
 			dir := newTestDirectory(t, srv, pemKey, tc.limits)
 

--- a/ee/server/googleworkspace/seam_test.go
+++ b/ee/server/googleworkspace/seam_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -22,23 +23,31 @@ import (
 // API calls against a local fake server (over plain HTTP).
 func TestDirectoryEndpointOverride(t *testing.T) {
 	// Field projections as each endpoint received them, so the test can show the
-	// listings ask only for what Fleet maps.
+	// listings ask only for what Fleet maps. Written from the server's handler
+	// goroutines, so guard it rather than relying on the request/response round trip
+	// to order the writes before the assertions below.
+	var fieldsMu sync.Mutex
 	requestedFields := map[string]string{}
+	recordFields := func(endpoint string, r *http.Request) {
+		fieldsMu.Lock()
+		defer fieldsMu.Unlock()
+		requestedFields[endpoint] = r.URL.Query().Get("fields")
+	}
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /token", func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "x", "token_type": "Bearer", "expires_in": 3600})
 	})
 	mux.HandleFunc("GET /admin/directory/v1/users", func(w http.ResponseWriter, r *http.Request) {
-		requestedFields["users"] = r.URL.Query().Get("fields")
+		recordFields("users", r)
 		_ = json.NewEncoder(w).Encode(map[string]any{"users": []map[string]any{{"id": "1", "primaryEmail": "a@b.com"}}})
 	})
 	mux.HandleFunc("GET /admin/directory/v1/groups", func(w http.ResponseWriter, r *http.Request) {
-		requestedFields["groups"] = r.URL.Query().Get("fields")
+		recordFields("groups", r)
 		_ = json.NewEncoder(w).Encode(map[string]any{"groups": []map[string]any{{"id": "g1", "name": "G"}}})
 	})
 	mux.HandleFunc("GET /admin/directory/v1/groups/{k}/members", func(w http.ResponseWriter, r *http.Request) {
-		requestedFields["members"] = r.URL.Query().Get("fields")
+		recordFields("members", r)
 		_ = json.NewEncoder(w).Encode(map[string]any{"members": []map[string]any{{"id": "1", "type": "USER"}}})
 	})
 	srv := httptest.NewServer(mux)
@@ -75,6 +84,8 @@ func TestDirectoryEndpointOverride(t *testing.T) {
 
 	// Every listing must project its fields, and every projection must carry
 	// nextPageToken or pagination cannot advance past the first page.
+	fieldsMu.Lock()
+	defer fieldsMu.Unlock()
 	require.Equal(t, map[string]string{
 		"users":   usersFields,
 		"groups":  groupsFields,

--- a/ee/server/googleworkspace/seam_test.go
+++ b/ee/server/googleworkspace/seam_test.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -20,17 +21,24 @@ import (
 // JSON, the real Directory client performs its JWT token exchange and Directory
 // API calls against a local fake server (over plain HTTP).
 func TestDirectoryEndpointOverride(t *testing.T) {
+	// Field projections as each endpoint received them, so the test can show the
+	// listings ask only for what Fleet maps.
+	requestedFields := map[string]string{}
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /token", func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "x", "token_type": "Bearer", "expires_in": 3600})
 	})
-	mux.HandleFunc("GET /admin/directory/v1/users", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("GET /admin/directory/v1/users", func(w http.ResponseWriter, r *http.Request) {
+		requestedFields["users"] = r.URL.Query().Get("fields")
 		_ = json.NewEncoder(w).Encode(map[string]any{"users": []map[string]any{{"id": "1", "primaryEmail": "a@b.com"}}})
 	})
-	mux.HandleFunc("GET /admin/directory/v1/groups", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("GET /admin/directory/v1/groups", func(w http.ResponseWriter, r *http.Request) {
+		requestedFields["groups"] = r.URL.Query().Get("fields")
 		_ = json.NewEncoder(w).Encode(map[string]any{"groups": []map[string]any{{"id": "g1", "name": "G"}}})
 	})
-	mux.HandleFunc("GET /admin/directory/v1/groups/{k}/members", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("GET /admin/directory/v1/groups/{k}/members", func(w http.ResponseWriter, r *http.Request) {
+		requestedFields["members"] = r.URL.Query().Get("fields")
 		_ = json.NewEncoder(w).Encode(map[string]any{"members": []map[string]any{{"id": "1", "type": "USER"}}})
 	})
 	srv := httptest.NewServer(mux)
@@ -64,4 +72,48 @@ func TestDirectoryEndpointOverride(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, groups, 1)
 	require.Len(t, groups[0].MemberExternalIDs, 1)
+
+	// Every listing must project its fields, and every projection must carry
+	// nextPageToken or pagination cannot advance past the first page.
+	require.Equal(t, map[string]string{
+		"users":   usersFields,
+		"groups":  groupsFields,
+		"members": membersFields,
+	}, requestedFields)
+	for name, fields := range requestedFields {
+		require.Contains(t, fields, "nextPageToken", "%s projection must request nextPageToken", name)
+	}
+}
+
+// TestFieldProjectionsCoverMappedFields pins each projection against the fields the
+// mapping code reads. A projection that drops one of these does not fail — the API
+// simply omits it — so the directory would silently sync with empty values.
+func TestFieldProjectionsCoverMappedFields(t *testing.T) {
+	for _, tc := range []struct {
+		fields string
+		// needed are the response fields the mapping code depends on.
+		needed []string
+	}{
+		{
+			// mapUser reads id, primaryEmail, suspended, archived, name, organizations
+			// (department, primary) and emails (address, type, primary).
+			fields: usersFields,
+			needed: []string{"id", "primaryEmail", "suspended", "archived", "name", "organizations", "emails"},
+		},
+		{
+			// groupDisplayName falls back from name to email.
+			fields: groupsFields,
+			needed: []string{"id", "name", "email"},
+		},
+		{
+			// Directory.ListGroups keeps members by id and filters on type.
+			fields: membersFields,
+			needed: []string{"id", "type"},
+		},
+	} {
+		t.Run(tc.fields, func(t *testing.T) {
+			inner := tc.fields[strings.Index(tc.fields, "(")+1 : len(tc.fields)-1]
+			require.ElementsMatch(t, tc.needed, strings.Split(inner, ","))
+		})
+	}
 }

--- a/ee/server/googleworkspace/seam_test.go
+++ b/ee/server/googleworkspace/seam_test.go
@@ -53,7 +53,7 @@ func TestDirectoryEndpointOverride(t *testing.T) {
 		}},
 	}
 
-	dir, err := NewDirectory(t.Context(), intg, slog.New(slog.DiscardHandler))
+	dir, err := NewDirectory(t.Context(), intg, slog.New(slog.DiscardHandler), Limits{})
 	require.NoError(t, err)
 
 	users, err := dir.ListUsers(t.Context())

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -1010,8 +1010,9 @@ func (c *CalendarConfig) SetAlwaysReloadEvent(value bool) {
 //
 //   - Users: Google publishes no per-account cap; 500,000 (1,000 pages of 500) is
 //     far above the largest directory Fleet expects to sync.
-//   - Groups: also uncapped by Google. 100,000 doubles as the fan-out guard, since
-//     members are fetched one group at a time.
+//   - Groups: also uncapped by Google. 100,000 also bounds the per-group member
+//     fan-out, since members are fetched one group at a time (it does not bound how
+//     long a pass takes: 100,000 sequential member listings is already a long sync).
 //   - Members per group: Google itself enforces a hard limit of 50,000 direct
 //     members per group, so 60,000 sits just above a ceiling Google won't exceed.
 //   - Total memberships: every group's members are held until the pull is
@@ -1032,6 +1033,22 @@ type GoogleWorkspaceConfig struct {
 	MaxGroups           int `yaml:"max_groups"`
 	MaxGroupMembers     int `yaml:"max_group_members"`
 	MaxGroupMemberships int `yaml:"max_group_memberships"`
+}
+
+// Validate checks that the sync limits are non-negative, so a typo can't silently
+// disable a safety rail.
+func (g GoogleWorkspaceConfig) Validate(initFatal func(err error, msg string)) {
+	for setting, value := range map[string]int{
+		"google_workspace.max_users":             g.MaxUsers,
+		"google_workspace.max_groups":            g.MaxGroups,
+		"google_workspace.max_group_members":     g.MaxGroupMembers,
+		"google_workspace.max_group_memberships": g.MaxGroupMemberships,
+	} {
+		if value < 0 {
+			initFatal(fmt.Errorf("%s must be non-negative (0 = no limit)", setting),
+				"Google Workspace configuration")
+		}
+	}
 }
 
 type x509KeyPairConfig struct {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -819,6 +819,7 @@ type FleetConfig struct {
 	Prometheus                 PrometheusConfig
 	MDM                        MDMConfig
 	Calendar                   CalendarConfig
+	GoogleWorkspace            GoogleWorkspaceConfig `yaml:"google_workspace"`
 	Partnerships               PartnershipsConfig
 	MicrosoftCompliancePartner MicrosoftCompliancePartnerConfig `yaml:"microsoft_compliance_partner"`
 	ConditionalAccess          ConditionalAccessConfig          `yaml:"conditional_access"`
@@ -1001,6 +1002,36 @@ func (c *CalendarConfig) AlwaysReloadEvent() bool {
 
 func (c *CalendarConfig) SetAlwaysReloadEvent(value bool) {
 	c.alwaysReloadEvent = value
+}
+
+// Defaults for the Google Workspace directory sync limits. They are safety rails
+// against runaway pagination and unbounded memory growth, sized above what any real
+// tenant is expected to have, not tuning knobs:
+//
+//   - Users: Google publishes no per-account cap; 500,000 (1,000 pages of 500) is
+//     far above the largest directory Fleet expects to sync.
+//   - Groups: also uncapped by Google. 100,000 doubles as the fan-out guard, since
+//     members are fetched one group at a time.
+//   - Members per group: Google itself enforces a hard limit of 50,000 direct
+//     members per group, so 60,000 sits just above a ceiling Google won't exceed.
+//   - Total memberships: every group's members are held until the pull is
+//     reconciled, so the sum is the dominant memory term.
+const (
+	DefaultGoogleWorkspaceMaxUsers            = 500_000
+	DefaultGoogleWorkspaceMaxGroups           = 100_000
+	DefaultGoogleWorkspaceMaxGroupMembers     = 60_000
+	DefaultGoogleWorkspaceMaxGroupMemberships = 5_000_000
+)
+
+// GoogleWorkspaceConfig holds the limits applied to one directory sync pass. These
+// are hidden settings: they exist so an operator with a directory larger than the
+// defaults can be unblocked without waiting for a Fleet release. A value of 0
+// disables the corresponding limit.
+type GoogleWorkspaceConfig struct {
+	MaxUsers            int `yaml:"max_users"`
+	MaxGroups           int `yaml:"max_groups"`
+	MaxGroupMembers     int `yaml:"max_group_members"`
+	MaxGroupMemberships int `yaml:"max_group_memberships"`
 }
 
 type x509KeyPairConfig struct {
@@ -1819,6 +1850,20 @@ func (man Manager) addConfigs() {
 		"How much time to wait between processing calendar integration.",
 	)
 
+	// Google Workspace directory sync limits (hidden; safety rails, not tuning knobs)
+	man.addConfigInt("google_workspace.max_users", DefaultGoogleWorkspaceMaxUsers,
+		"Maximum users pulled from a Google Workspace directory in one sync (0 = no limit)")
+	man.addConfigInt("google_workspace.max_groups", DefaultGoogleWorkspaceMaxGroups,
+		"Maximum groups pulled from a Google Workspace directory in one sync (0 = no limit)")
+	man.addConfigInt("google_workspace.max_group_members", DefaultGoogleWorkspaceMaxGroupMembers,
+		"Maximum members pulled for a single Google Workspace group (0 = no limit)")
+	man.addConfigInt("google_workspace.max_group_memberships", DefaultGoogleWorkspaceMaxGroupMemberships,
+		"Maximum total group memberships pulled from a Google Workspace directory in one sync (0 = no limit)")
+	man.hideConfig("google_workspace.max_users")
+	man.hideConfig("google_workspace.max_groups")
+	man.hideConfig("google_workspace.max_group_members")
+	man.hideConfig("google_workspace.max_group_memberships")
+
 	// Partnerships
 	man.addConfigBool("partnerships.enable_secureframe", false, "Point transparency URL at Secureframe landing page")
 
@@ -2160,6 +2205,12 @@ func (man Manager) LoadConfig() FleetConfig {
 		},
 		Calendar: CalendarConfig{
 			Periodicity: man.getConfigDuration("calendar.periodicity"),
+		},
+		GoogleWorkspace: GoogleWorkspaceConfig{
+			MaxUsers:            man.getConfigInt("google_workspace.max_users"),
+			MaxGroups:           man.getConfigInt("google_workspace.max_groups"),
+			MaxGroupMembers:     man.getConfigInt("google_workspace.max_group_members"),
+			MaxGroupMemberships: man.getConfigInt("google_workspace.max_group_memberships"),
 		},
 		Partnerships: PartnershipsConfig{
 			EnableSecureframe: man.getConfigBool("partnerships.enable_secureframe"),

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -1045,7 +1045,7 @@ func (g GoogleWorkspaceConfig) Validate(initFatal func(err error, msg string)) {
 		"google_workspace.max_group_memberships": g.MaxGroupMemberships,
 	} {
 		if value < 0 {
-			initFatal(fmt.Errorf("%s must be non-negative (0 = no limit)", setting),
+			initFatal(fmt.Errorf("%s must be non-negative (0 = no limit), got %d", setting, value),
 				"Google Workspace configuration")
 		}
 	}

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -893,6 +893,33 @@ google_workspace:
 	}
 }
 
+func TestGoogleWorkspaceConfigValidate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid when zero or positive", func(t *testing.T) {
+		cfg := GoogleWorkspaceConfig{MaxUsers: 0, MaxGroups: 1, MaxGroupMembers: 2, MaxGroupMemberships: 3}
+		cfg.Validate(func(err error, msg string) { t.Fatalf("unexpected error: %v", err) })
+	})
+
+	// A negative value would silently disable the limit, so it must be rejected at
+	// startup rather than removing a safety rail.
+	for _, tc := range []struct {
+		name string
+		cfg  GoogleWorkspaceConfig
+	}{
+		{"negative max users", GoogleWorkspaceConfig{MaxUsers: -1}},
+		{"negative max groups", GoogleWorkspaceConfig{MaxGroups: -1}},
+		{"negative max group members", GoogleWorkspaceConfig{MaxGroupMembers: -1}},
+		{"negative max group memberships", GoogleWorkspaceConfig{MaxGroupMemberships: -1}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			called := false
+			tc.cfg.Validate(func(err error, msg string) { called = true })
+			require.True(t, called)
+		})
+	}
+}
+
 func TestServerConfigWithH2C(t *testing.T) {
 	ctx := context.Background()
 

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -824,6 +824,75 @@ func TestAndroidBatchSizeValidate(t *testing.T) {
 	})
 }
 
+func TestGoogleWorkspaceConfig(t *testing.T) {
+	cases := []struct {
+		desc    string
+		yaml    string
+		envVars []string
+		want    GoogleWorkspaceConfig
+	}{
+		{
+			desc: "defaults",
+			want: GoogleWorkspaceConfig{
+				MaxUsers:            DefaultGoogleWorkspaceMaxUsers,
+				MaxGroups:           DefaultGoogleWorkspaceMaxGroups,
+				MaxGroupMembers:     DefaultGoogleWorkspaceMaxGroupMembers,
+				MaxGroupMemberships: DefaultGoogleWorkspaceMaxGroupMemberships,
+			},
+		},
+		{
+			desc: "yaml overrides",
+			yaml: `
+google_workspace:
+  max_users: 10
+  max_groups: 20
+  max_group_members: 30
+  max_group_memberships: 40`,
+			want: GoogleWorkspaceConfig{MaxUsers: 10, MaxGroups: 20, MaxGroupMembers: 30, MaxGroupMemberships: 40},
+		},
+		{
+			desc: "env overrides",
+			envVars: []string{
+				"FLEET_GOOGLE_WORKSPACE_MAX_USERS=1",
+				"FLEET_GOOGLE_WORKSPACE_MAX_GROUPS=2",
+				"FLEET_GOOGLE_WORKSPACE_MAX_GROUP_MEMBERS=3",
+				"FLEET_GOOGLE_WORKSPACE_MAX_GROUP_MEMBERSHIPS=4",
+			},
+			want: GoogleWorkspaceConfig{MaxUsers: 1, MaxGroups: 2, MaxGroupMembers: 3, MaxGroupMemberships: 4},
+		},
+		{
+			desc:    "zero disables a limit",
+			envVars: []string{"FLEET_GOOGLE_WORKSPACE_MAX_USERS=0"},
+			want: GoogleWorkspaceConfig{
+				MaxUsers:            0,
+				MaxGroups:           DefaultGoogleWorkspaceMaxGroups,
+				MaxGroupMembers:     DefaultGoogleWorkspaceMaxGroupMembers,
+				MaxGroupMemberships: DefaultGoogleWorkspaceMaxGroupMemberships,
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			var cmd cobra.Command
+			cmd.PersistentFlags().StringP("config", "c", "", "Path to a configuration file")
+			man := NewManager(&cmd)
+
+			man.viper.SetConfigType("yaml")
+			require.NoError(t, man.viper.ReadConfig(strings.NewReader(c.yaml)))
+
+			testutils.SaveEnv(t)
+			os.Clearenv()
+			for _, env := range c.envVars {
+				kv := strings.SplitN(env, "=", 2)
+				t.Setenv(kv[0], kv[1])
+			}
+
+			require.Equal(t, c.want, man.LoadConfig().GoogleWorkspace)
+		})
+	}
+}
+
 func TestServerConfigWithH2C(t *testing.T) {
 	ctx := context.Background()
 

--- a/server/cron/google_workspace_cron_test.go
+++ b/server/cron/google_workspace_cron_test.go
@@ -219,6 +219,45 @@ func TestGoogleWorkspaceSyncEmptyPullDoesNotDelete(t *testing.T) {
 	assert.Empty(t, r.deletedGroups, "empty pull must not wipe groups")
 }
 
+// TestGoogleWorkspaceSyncLimitErrorDoesNotDelete pins the invariant the directory
+// sync limits rely on: a pull that hits a limit must abort, leaving existing IdP
+// data alone. Reconciliation treats the pull as authoritative, so a limit that
+// truncated instead of erroring would delete every record past it.
+func TestGoogleWorkspaceSyncLimitErrorDoesNotDelete(t *testing.T) {
+	existingUser := scimUser("g1", "alice@example.com", "Engineering", true)
+	existingUser.ID = 1
+	existingGroup := fleet.ScimGroup{ID: 5, ExternalID: new("grp1"), DisplayName: "Engineering"}
+
+	for _, tc := range []struct {
+		name string
+		dir  *fakeDirectory
+	}{
+		{
+			name: "users limit",
+			dir:  &fakeDirectory{usersErr: errors.New("exceeded the limit of 500000 users; raise google_workspace.max_users to sync this domain")},
+		},
+		{
+			name: "groups limit",
+			dir: &fakeDirectory{
+				users:     []*fleet.ScimUser{gwUser("g1", "alice@example.com", "Engineering", true)},
+				groupsErr: errors.New("exceeded the limit of 100000 groups; raise google_workspace.max_groups to sync this domain"),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := newSyncRecorder(gwAppConfig(), []fleet.ScimUser{existingUser}, []fleet.ScimGroup{existingGroup})
+
+			err := runSync(t, r, tc.dir)
+			require.Error(t, err)
+			assert.Empty(t, r.deletedUsers, "a limit error must not delete users")
+			assert.Empty(t, r.deletedGroups, "a limit error must not delete groups")
+			require.NotNil(t, r.lastRequest)
+			assert.Equal(t, "error", r.lastRequest.Status)
+			assert.Contains(t, r.lastRequest.Details, "raise google_workspace.max_")
+		})
+	}
+}
+
 func TestGoogleWorkspaceSyncDirectoryErrorRecordsStatus(t *testing.T) {
 	r := newSyncRecorder(gwAppConfig(), nil, nil)
 	dir := &fakeDirectory{usersErr: errors.New("delegation not authorized")}


### PR DESCRIPTION
**Related issue:** Resolves #49365

## What changed

The Admin SDK `.Pages()` iterators in `ListUsers`, `ListGroups`, and `ListGroupMembers` had no page or record bound, so a very large Google Workspace directory grew server memory without limit, and a malformed response or proxy handing out next-page tokens forever could paginate indefinitely (the cron runs every 5 minutes on a context with no deadline).

Two guards now apply to every listing:

- **`maxPagesPerListing` (10,000, constant, always enforced)** — catches what a record limit cannot: empty or barely-filled pages with a perpetual next-page token never grow the result set, so only a page count stops that loop. It holds regardless of how the limits below are configured, and sits far above what a real listing needs (the default user limit is reached in 1,000 pages), so it never fails a sync that would otherwise complete.
- **Record limits** — bound what is held in memory. `Directory.ListGroups` additionally caps the *total* memberships across the pull, which is the dominant memory term (every group's member IDs are retained until reconciliation).

**Exceeding a limit fails the sync; it never truncates the pull.** Reconciliation treats the pull as authoritative and deletes any scim user/group absent from it, so a truncated directory would delete real IdP data (cascading to `host_scim_user`). Errors name the setting to raise and are short enough to survive truncation into the 255-character sync status column, which is where an admin sees them.

### Defaults

| Setting | Default | Basis |
|---|---|---|
| `google_workspace.max_group_members` | 60,000 | Google itself hard-caps a group at [50,000 direct members](https://support.google.com/a/answer/6099642?hl=en), so this sits just above a ceiling Google won't exceed |
| `google_workspace.max_users` | 500,000 | Google publishes no per-account user cap; 1,000 pages is ~0.4 min of the [2,400 queries/min](https://developers.google.com/workspace/admin/directory/v1/limits) quota, and this is far above any directory Fleet expects to sync |
| `google_workspace.max_groups` | 100,000 | Also bounds the per-group member fan-out, since members are fetched one group at a time |
| `google_workspace.max_group_memberships` | 5,000,000 | Sum across one pass — the dominant memory term |

### Measured memory

What the limits actually bound, measured by allocating the structures one sync pass holds — raw `*directory.User` with `Organizations`/`Emails` decoded as `map[string]any` the way the JSON decoder produces them, the mapped `ScimUser`s, the rows `listAllScimUsers` loads, the three lookup maps, and the group/membership slices — at 1/5 of the defaults and scaled:

| Phase | Peak at default limits |
|---|---|
| Users, accumulating every raw page (previous behavior) | 1,243 MB live / 1,321 MB process |
| Users, mapping each page and dropping it (this PR) | **241 MB** |
| Users reconcile: mapped pull + DB rows + lookup maps | 538 MB |
| Groups phase, everything above still live — **overall peak** | **823 MB** |

A raw `*directory.User` costs ~2.0 KB, almost all `map[string]any` overhead, against ~0.5 KB for Fleet's mapped `ScimUser` — so `googleAPI.ListUsers` now hands each page to a callback and retains only what it mapped, taking the users phase from 1.24 GB to 241 MB and the whole-sync peak from ~1.3 GB to ~823 MB. Groups and members are still returned whole: their raw objects are a tenth the size, and streaming groups would issue a `members.list` for every group in the middle of an in-flight `groups.list` pagination.

At realistic directory sizes this is not close to binding: ~25 MB at 10K users, ~125 MB at 50K, ~250 MB at 100K. The remaining 823 MB ceiling is ~241 MB of mapped users, ~300 MB of `scim_users` rows plus lookup maps, and ~285 MB of memberships (57 bytes each). Two notes for reviewers: the DB-side load is bounded by what is already in `scim_users`, not by anything here; and shrinking the last two terms would mean reconciling per page instead of per pass, which is a larger change than this story.

All four are **hidden** settings (`hideConfig`, same treatment as `mdm.android_batch_size`): they are safety rails, not tuning knobs, so they don't take on a documented config surface — but an operator whose legitimately-large tenant trips one can be unblocked via `FLEET_GOOGLE_WORKSPACE_MAX_*` without waiting for a release. `0` disables a record limit (`maxPagesPerListing` still applies); negative values are rejected at startup so a typo can't silently remove a rail.

Not addressed here: `max_groups` bounds the number of member-list calls but not how long a pass takes, and the sync job still has no deadline — a separate concern from this issue's pagination bound.

## Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops

## Testing

- [x] Added/updated automated tests

`ee/server/googleworkspace/limits_test.go` drives the real Directory client against an `httptest` fake through the existing `FLEET_TEST_GOOGLE_WORKSPACE_ENDPOINT` seam: per resource, over-record-limit, paginating-forever *with the record limit disabled*, under-limit, unlimited, and total memberships. Each case asserts the exact request count and that an error returns no partial result; the fake rejects requests past that count, so a lost limit check fails an assertion instead of hanging. `server/cron/google_workspace_cron_test.go` adds a test that a limit error deletes no scim users or groups. `server/config/config_test.go` covers defaults, YAML, env, `0`, and rejection of negatives.

```
go test ./ee/server/googleworkspace/ ./server/config/
go test -run GoogleWorkspace ./server/cron/
make lint-go-incremental
```

- [ ] QA'd all new/changed functionality manually — not done; steps below for the reviewer/QA.

Using the existing fake directory tool:

```sh
go run ./tools/gw-directory-fake generate -users 30 -groups 4 -members-per-group 5 \
    -domain qa.example.com -out /tmp/fixture.json
go run ./tools/gw-directory-fake serve -fixture /tmp/fixture.json -addr :8091
# run Fleet with FLEET_TEST_GOOGLE_WORKSPACE_ENDPOINT=http://localhost:8091
```

1. Default limits: sync succeeds; IdP settings shows the last sync as successful.
2. `FLEET_GOOGLE_WORKSPACE_MAX_USERS=10`: sync fails; status detail reads `exceeded the limit of 10 users; raise google_workspace.max_users to sync this domain`; **`scim_users` is unchanged** — nothing deleted.
3. `FLEET_GOOGLE_WORKSPACE_MAX_GROUP_MEMBERSHIPS=5`: fails naming total group memberships.
4. `FLEET_GOOGLE_WORKSPACE_MAX_USERS=-1`: server refuses to start.
5. Restore defaults: the next tick succeeds and reconciles normally.

## New Fleet configuration settings

- [x] Setting(s) is/are explicitly excluded from GitOps

These are server configuration (`fleet.yml` / `FLEET_*` env), hidden from generated config docs, and not part of GitOps YAML.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable safety limits for Google Workspace directory sync (max users, groups, group members, and total memberships).
  * Introduced enforced pagination and per-sync page-iteration caps for directory listings.
  * Added server startup validation for Google Workspace sync configuration.
* **Bug Fixes**
  * Prevented partial sync data from being applied when directory listing exceeds limits or pagination caps.
  * Ensured existing SCIM users/groups are not deleted when Workspace limit errors occur.
* **Tests**
  * Added/extended unit and integration tests covering limit enforcement, pagination stopping behavior, projection field coverage, and non-deletion on limit errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->