### PR TITLE
Add sortable 'Added to Fleet' column to hosts table

### DIFF
--- a/changes/50083-added-to-fleet-column
+++ b/changes/50083-added-to-fleet-column
@@ -1,0 +1,1 @@
+* Added a sortable "Added to Fleet" column to the hosts table, showing when each host last enrolled with Fleet.

--- a/changes/50083-added-to-fleet-column
+++ b/changes/50083-added-to-fleet-column
@@ -1,1 +1,2 @@
 * Added a sortable "Added to Fleet" column to the hosts table, showing when each host last enrolled with Fleet.
+* Fixed sort direction on the "Last seen" and "Last fetched" columns of the hosts table so that sort descending puts the oldest date (biggest "days ago" number) first, matching the visible duration rather than the underlying timestamp.

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -732,6 +732,37 @@ const allHostTableHeaders = (teamId?: number): IHostTableColumnConfig[] => [
       );
     },
   },
+  // Added to Fleet
+  {
+    title: "Added to Fleet",
+    Header: (cellProps: IHostTableHeaderProps) => {
+      const titleWithToolTip = (
+        <TooltipWrapper
+          tipContent={
+            <>
+              The last time the <br /> host enrolled with Fleet.
+            </>
+          }
+        >
+          Added to Fleet
+        </TooltipWrapper>
+      );
+      return (
+        <HeaderCell
+          value={titleWithToolTip}
+          isSortedDesc={cellProps.column.isSortedDesc}
+        />
+      );
+    },
+    accessor: "last_enrolled_at",
+    id: "last_enrolled_at",
+    Cell: (cellProps: IHostTableStringCellProps) => (
+      <TextCell
+        value={{ timeString: cellProps.cell.value }}
+        formatter={HumanTimeDiffWithFleetLaunchCutoff}
+      />
+    ),
+  },
 ];
 
 const defaultHiddenColumns = [
@@ -752,6 +783,7 @@ const defaultHiddenColumns = [
   "seen_time",
   "hardware_model",
   "hardware_serial",
+  "last_enrolled_at",
 ];
 
 /**

--- a/frontend/pages/hosts/ManageHostsPage/HostsPageConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostsPageConfig.tsx
@@ -68,6 +68,16 @@ export const DEFAULT_SORT_DIRECTION = "asc";
 export const DEFAULT_PAGE_SIZE = 50;
 export const DEFAULT_PAGE_INDEX = 0;
 
+// Columns rendered as "N days ago" durations. Sort direction is inverted so
+// arrow-down = biggest days-ago (oldest date) first, matching the visible
+// number rather than the underlying timestamp.
+export const TIME_AGO_SORT_HEADERS = new Set([
+  "seen_time",
+  "detail_updated_at",
+  "last_restarted_at",
+  "last_enrolled_at",
+]);
+
 export const hostSelectStatuses = (isPremiumTier: boolean) => {
   const baseStatuses = [
     {

--- a/frontend/pages/hosts/ManageHostsPage/HostsPageConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostsPageConfig.tsx
@@ -1,4 +1,4 @@
-import { HOSTS_QUERY_PARAMS } from "services/entities/hosts";
+import { HOSTS_QUERY_PARAMS, ISortOption } from "services/entities/hosts";
 
 export const MANAGE_HOSTS_PAGE_FILTER_KEYS = [
   "query",
@@ -68,15 +68,24 @@ export const DEFAULT_SORT_DIRECTION = "asc";
 export const DEFAULT_PAGE_SIZE = 50;
 export const DEFAULT_PAGE_INDEX = 0;
 
-// Columns rendered as "N days ago" durations. Sort direction is inverted so
-// arrow-down = biggest days-ago (oldest date) first, matching the visible
-// number rather than the underlying timestamp.
+// Columns rendered as "N days ago" durations. Sort direction is inverted at
+// the API boundary so arrow-down = biggest days-ago (oldest date) first —
+// matching the visible number rather than the underlying timestamp.
 export const TIME_AGO_SORT_HEADERS = new Set([
   "seen_time",
   "detail_updated_at",
   "last_restarted_at",
   "last_enrolled_at",
 ]);
+
+export const toApiSortBy = (sortBy: ISortOption[]): ISortOption[] =>
+  sortBy.map((s) => {
+    if (!TIME_AGO_SORT_HEADERS.has(s.key)) return s;
+    return {
+      key: s.key,
+      direction: s.direction === "asc" ? "desc" : "asc",
+    };
+  });
 
 export const hostSelectStatuses = (isPremiumTier: boolean) => {
   const baseStatuses = [

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1065,21 +1065,10 @@ const ManageHostsPage = ({
 
       let sort = sortBy;
       if (sortHeader) {
-        let direction = sortDirection;
-        if (
-          sortHeader === "last_restarted_at" ||
-          sortHeader === "last_enrolled_at"
-        ) {
-          if (sortDirection === "asc") {
-            direction = "desc";
-          } else {
-            direction = "asc";
-          }
-        }
         sort = [
           {
             key: sortHeader,
-            direction: direction || DEFAULT_SORT_DIRECTION,
+            direction: sortDirection || DEFAULT_SORT_DIRECTION,
           },
         ];
       } else if (!sortBy.length) {

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -111,7 +111,7 @@ import {
   DEFAULT_SORT_DIRECTION,
   DEFAULT_PAGE_SIZE,
   DEFAULT_PAGE_INDEX,
-  TIME_AGO_SORT_HEADERS,
+  toApiSortBy,
   hostSelectStatuses,
   MANAGE_HOSTS_PAGE_FILTER_KEYS,
   MANAGE_HOSTS_PAGE_LABEL_INCOMPATIBLE_QUERY_PARAMS,
@@ -295,6 +295,7 @@ const ManageHostsPage = ({
   );
   const [searchQuery, setSearchQuery] = useState(initialQuery);
   const [sortBy, setSortBy] = useState<ISortOption[]>(initialSortBy);
+  const apiSortBy = useMemo(() => toApiSortBy(sortBy), [sortBy]);
   const [tableQueryData, setTableQueryData] = useState<ITableQueryData>();
   const [isUpdating, setIsUpdating] = useState<boolean>(false);
 
@@ -599,7 +600,7 @@ const ManageHostsPage = ({
         scope: "hosts",
         selectedLabels,
         globalFilter: searchQuery,
-        sortBy,
+        sortBy: apiSortBy,
         teamId: teamIdForApi,
         policyId,
         policyResponse,
@@ -1066,18 +1067,10 @@ const ManageHostsPage = ({
 
       let sort = sortBy;
       if (sortHeader) {
-        let direction = sortDirection;
-        if (TIME_AGO_SORT_HEADERS.has(sortHeader)) {
-          if (sortDirection === "asc") {
-            direction = "desc";
-          } else {
-            direction = "asc";
-          }
-        }
         sort = [
           {
             key: sortHeader,
-            direction: direction || DEFAULT_SORT_DIRECTION,
+            direction: sortDirection || DEFAULT_SORT_DIRECTION,
           },
         ];
       } else if (!sortBy.length) {
@@ -1658,7 +1651,7 @@ const ManageHostsPage = ({
       let options = {
         selectedLabels,
         globalFilter: searchQuery,
-        sortBy,
+        sortBy: apiSortBy,
         teamId: teamIdForApi,
         policyId,
         policyResponse,
@@ -1725,7 +1718,7 @@ const ManageHostsPage = ({
       teamIdForApi,
       selectedLabels,
       searchQuery,
-      sortBy,
+      apiSortBy,
       policyId,
       policyResponse,
       macSettingsStatus,

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1066,7 +1066,10 @@ const ManageHostsPage = ({
       let sort = sortBy;
       if (sortHeader) {
         let direction = sortDirection;
-        if (sortHeader === "last_restarted_at") {
+        if (
+          sortHeader === "last_restarted_at" ||
+          sortHeader === "last_enrolled_at"
+        ) {
           if (sortDirection === "asc") {
             direction = "desc";
           } else {

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -111,6 +111,7 @@ import {
   DEFAULT_SORT_DIRECTION,
   DEFAULT_PAGE_SIZE,
   DEFAULT_PAGE_INDEX,
+  TIME_AGO_SORT_HEADERS,
   hostSelectStatuses,
   MANAGE_HOSTS_PAGE_FILTER_KEYS,
   MANAGE_HOSTS_PAGE_LABEL_INCOMPATIBLE_QUERY_PARAMS,
@@ -1065,10 +1066,18 @@ const ManageHostsPage = ({
 
       let sort = sortBy;
       if (sortHeader) {
+        let direction = sortDirection;
+        if (TIME_AGO_SORT_HEADERS.has(sortHeader)) {
+          if (sortDirection === "asc") {
+            direction = "desc";
+          } else {
+            direction = "asc";
+          }
+        }
         sort = [
           {
             key: sortHeader,
-            direction: sortDirection || DEFAULT_SORT_DIRECTION,
+            direction: direction || DEFAULT_SORT_DIRECTION,
           },
         ];
       } else if (!sortBy.length) {


### PR DESCRIPTION
**Related issue:** Resolves #50083

# Screenshot demonstrating the fix

- Hosts page:
<img width="1473" height="335" alt="image" src="https://github.com/user-attachments/assets/2f88ad6e-a514-4304-ac80-f56678e6be47" />

- Edit columns modal:
<img width="798" height="707" alt="image" src="https://github.com/user-attachments/assets/0a79e8f3-1b21-4f84-bd04-726f44b9a0fa" />

## Note on sort direction

The new "Added to Fleet" column renders as a "days ago" duration (same formatter as Last seen / Last fetched / Last restarted). To keep behavior consistent across all four time-ago columns on the hosts table, this PR applies the sort-direction inversion originally introduced for `last_restarted_at` in #14878 (fix for #13160) to all of them:

- `seen_time` (Last seen)
- `detail_updated_at` (Last fetched)
- `last_restarted_at` (Last restarted) — unchanged behavior
- `last_enrolled_at` (Added to Fleet) — new

Arrow-down on any of these columns now sorts by the visible duration (biggest "days ago" first / oldest date first), rather than by the raw underlying timestamp. This is a user-facing behavior change on Last seen and Last fetched — please re-QA sort order on those two columns alongside the new one.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually

<!-- Attach: Edit columns modal showing the new "Added to Fleet" column option, and the Hosts page with the column enabled -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **Added to Fleet** column to the hosts table.
  * Displays when each host last enrolled with Fleet, with an explanatory tooltip.
  * The column is hidden by default and can be enabled through table settings.
  * Supports ascending and descending sorting.

* **Bug Fixes**
  * Corrected descending sorting for **Last seen** and **Last fetched** to reflect the displayed host age.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->