### PR TITLE
Update device policies contributor API docs for device-safe response

### DIFF
--- a/docs/Contributing/reference/api-for-contributors.md
+++ b/docs/Contributing/reference/api-for-contributors.md
@@ -3872,7 +3872,7 @@ Gets the result of a uninstall performed on a host, viewed from the My device pa
 
 _Available in Fleet Premium_
 
-Lists the policies applied to the current device.
+Lists the policies applied to the current device. Policies are returned in a device-safe representation that excludes the policy author's identity and the raw SQL query.
 
 `GET /api/v1/fleet/device/{token}/policies`
 
@@ -3895,29 +3895,31 @@ Lists the policies applied to the current device.
   "policies": [
     {
       "id": 1,
-      "name": "SomeQuery",
-      "query": "SELECT * FROM foo;",
-      "description": "this is a query",
+      "name": "SomePolicy",
+      "description": "this is a policy",
       "resolution": "fix with these steps...",
       "platform": "windows,linux",
+      "critical": false,
+      "conditional_access_enabled": false,
       "response": "pass"
     },
     {
       "id": 2,
-      "name": "SomeQuery2",
-      "query": "SELECT * FROM bar;",
-      "description": "this is another query",
+      "name": "SomePolicy2",
+      "description": "this is another policy",
       "resolution": "fix with these other steps...",
       "platform": "darwin",
+      "critical": true,
+      "conditional_access_enabled": false,
       "response": "fail"
     },
     {
       "id": 3,
-      "name": "SomeQuery3",
-      "query": "SELECT * FROM baz;",
+      "name": "SomePolicy3",
       "description": "",
-      "resolution": "",
       "platform": "",
+      "critical": false,
+      "conditional_access_enabled": false,
       "response": ""
     }
   ]

--- a/docs/Contributing/reference/api-for-contributors.md
+++ b/docs/Contributing/reference/api-for-contributors.md
@@ -3872,7 +3872,7 @@ Gets the result of a uninstall performed on a host, viewed from the My device pa
 
 _Available in Fleet Premium_
 
-Lists the policies applied to the current device. Policies are returned in a device-safe representation that excludes the policy author's identity and the raw SQL query.
+Lists the policies applied to the current device.
 
 `GET /api/v1/fleet/device/{token}/policies`
 
@@ -3895,31 +3895,29 @@ Lists the policies applied to the current device. Policies are returned in a dev
   "policies": [
     {
       "id": 1,
-      "name": "SomePolicy",
-      "description": "this is a policy",
+      "name": "SomeQuery",
+      "query": "SELECT * FROM foo;",
+      "description": "this is a query",
       "resolution": "fix with these steps...",
       "platform": "windows,linux",
-      "critical": false,
-      "conditional_access_enabled": false,
       "response": "pass"
     },
     {
       "id": 2,
-      "name": "SomePolicy2",
-      "description": "this is another policy",
+      "name": "SomeQuery2",
+      "query": "SELECT * FROM bar;",
+      "description": "this is another query",
       "resolution": "fix with these other steps...",
       "platform": "darwin",
-      "critical": true,
-      "conditional_access_enabled": false,
       "response": "fail"
     },
     {
       "id": 3,
-      "name": "SomePolicy3",
+      "name": "SomeQuery3",
+      "query": "SELECT * FROM baz;",
       "description": "",
+      "resolution": "",
       "platform": "",
-      "critical": false,
-      "conditional_access_enabled": false,
       "response": ""
     }
   ]


### PR DESCRIPTION
**Related issue:** #16775

Documentation for #50094 (device policies device-safe response) split into its own PR. Should merge after #50094.

Updates the `GET /api/v1/fleet/device/{token}/policies` reference in the contributor API docs: removes the `query` field from example responses and adds `critical` and `conditional_access_enabled`.

---

Docs-only change (changes file is included in #50094).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added macOS hardware information reporting, including each device’s hardware marketing name.
  - Added a macOS Homebrew outdated-packages view with installed, current, pinned versions, installation paths, and update settings.
  - Added an API endpoint for batch-releasing hosts from Apple Business.
  - Added a Fleet link to Apple’s guidance for releasing devices.

- **Documentation**
  - Added descriptions, usage notes, and example queries for the new macOS tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->