### PR TITLE
Website: update territory routing for talk to us submissions

### DIFF
--- a/website/api/controllers/deliver-talk-to-us-form-submission.js
+++ b/website/api/controllers/deliver-talk-to-us-form-submission.js
@@ -122,11 +122,13 @@ Only include a key when you are confident of its value. Omit any key you are uns
     // If we got a employer.numberOfEmployees value from the getEnriched helper, or the user entered more than 700 hosts, get the SF user who owns the territory that this user's company is in, and send them to a "Talk to us" calendly event.
     if(numberOfHosts >= 700 || (employeeCountFromEnrichmentHelper && employeeCountFromEnrichmentHelper >= 700)) {
       contactInformation.contactSource = 'Website - Contact forms - Demo - ICP';
-
+      let numberOfEmployeesToUseForTerritoryLookup;
       if(employeeCountFromEnrichmentHelper && employeeCountFromEnrichmentHelper >= 700) {
         contactInformation.description = `Submitted the "Talk to us" form and was taken to the Calendly page for the "Talk to us" event because of the number of employees (${employeeCountFromEnrichmentHelper}) returned by Coresignal. Provided organization name: ${organization}, Number of employees: ${numberOfHosts}`;
+        numberOfEmployeesToUseForTerritoryLookup = employeeCountFromEnrichmentHelper;
       } else {
         contactInformation.description = `Submitted the "Talk to us" form and was taken to the Calendly page for the "Talk to us" event. Provided organization name: ${organization}, Number of employees: ${numberOfHosts}`;
+        numberOfEmployeesToUseForTerritoryLookup = numberOfHosts;
       }
 
       sails.helpers.salesforce.updateOrCreateContactAndAccount.with(contactInformation).exec((err)=>{
@@ -142,18 +144,21 @@ Only include a key when you are confident of its value. Omit any key you are uns
       let territoryUserId = await sails.helpers.salesforce.getTerritoryUserId.with({
         state: locationForTerritoryLookup.state,
         country: locationForTerritoryLookup.country,
-        city: locationForTerritoryLookup.city
+        city: locationForTerritoryLookup.city,
+        website: emailDomain,
+        numberOfEmployees: numberOfEmployeesToUseForTerritoryLookup,
       }).tolerate((err)=>{
         sails.log.warn(`When a user submitted the "Talk to us" form, Salesforce territory information could not be found using the provided information. This user will be sent to the calendly link for the washingtonDc region. Full error: ${require('util').inspect(err)}`);
         return '0054x0000086sOlAAI';
       });
 
       let bookingUrlByUserId = {
-        '005UG000006YYDVYA4': 'https://calendly.com/d/d3fs-28g-vdk/talk-to-us', //newYorkCity
-        '0054x0000086sOlAAI': 'https://calendly.com/d/dzyz-tt7-yt8/talk-to-us', //washingtonDc
-        '005UG000008y0wbYAA': 'https://calendly.com/d/ds9c-9vt-mz6/talk-to-us', //losAngeles
-        '0054x0000086wsGAAQ': 'https://calendly.com/d/dz4c-mjx-6xv/talk-to-us', //sanFrancisco
-        '005UG000009NnSfYAK': 'https://calendly.com/d/ds88-n2m-ddt/talk-to-us', //stockholm
+        '0054x000005mpQmAAI': 'https://calendly.com/d/d3hw-r73-gt7/talk-to-us',// New York City - Enterprise
+        '005UG000008y0wbYAA': 'https://calendly.com/d/ds9c-9vt-mz6/talk-to-us',// Los Angeles - Enterprise
+        '0054x0000086wsGAAQ': 'https://calendly.com/d/dz4c-mjx-6xv/talk-to-us',// San Francisco - Enterprise
+        '005UG000006YYDVYA4': 'https://calendly.com/d/d3fs-28g-vdk/talk-to-us',// San Francisco - Mid-market
+        '0054x0000086sOlAAI': 'https://calendly.com/d/dzyz-tt7-yt8/talk-to-us',// New York City - Mid-market
+        '005UG000009NnSfYAK': 'https://calendly.com/d/ds88-n2m-ddt/talk-to-us',// Stockholm
       };
 
       let eventUrlForThisUsersTerritory = bookingUrlByUserId[territoryUserId];

--- a/website/api/helpers/salesforce/get-territory-user-id.js
+++ b/website/api/helpers/salesforce/get-territory-user-id.js
@@ -11,6 +11,8 @@ module.exports = {
     state: { type: 'string' },
     city: { type: 'string' },
     country: { type: 'string'},
+    numberOfEmployees: {type: 'number'},
+    website: {type: 'string'},
   },
 
 
@@ -23,7 +25,7 @@ module.exports = {
   },
 
 
-  fn: async function ({state, city, country}) {
+  fn: async function ({state, city, country, numberOfEmployees, website}) {
 
     if(!country) {
       // IF a country is not provided, throw an error and log the provided inputs to help us debug the issue.
@@ -46,6 +48,8 @@ module.exports = {
     if(state) { apexInputs.append('state', state); }
     if(country) { apexInputs.append('country', country); }
     if(city) { apexInputs.append('city', city); }
+    if(website) { apexInputs.append('website', website); }
+    if(numberOfEmployees) { apexInputs.append('numberOfEmployees', numberOfEmployees); }
 
     let territoryInformation = await sails.helpers.flow.build(async ()=>{
       return await salesforceConnection.apex.get(`/territory-lookup?${apexInputs.toString()}`);


### PR DESCRIPTION
https://github.com/fleetdm/confidential/issues/16947

Changes:
- Updated the get-territory-user-id helper to accept `website` and `numberOfEmployees` inputs
- Updated the deliver-talk-to-us-form-submission action to send website and number of employees to the get-territory-user-id helper, and updated the `bookingUrlByUserId` dictionary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved territory routing for “Talk to us” submissions by using employee count, city, and website details.
  * Updated routing logic to direct submissions to the appropriate Calendly booking link.
  * Preserved existing validation and error handling for incomplete or unexpected territory lookup results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->