### PR TITLE
Clarify maintained app download timeout errors

### DIFF
--- a/changes/48416-maintained-app-timeout-error-message
+++ b/changes/48416-maintained-app-timeout-error-message
@@ -1,0 +1,1 @@
+* Improved the error message shown when adding a Fleet-maintained app times out or is canceled by a proxy or load balancer while downloading a large installer.

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/helpers.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/helpers.tests.tsx
@@ -1,3 +1,4 @@
+import { REQUEST_TIMEOUT_ERROR_MESSAGE } from "../../helpers";
 import { getErrorMessage } from "./helpers";
 
 jest.mock("axios", () => {
@@ -8,9 +9,16 @@ jest.mock("axios", () => {
   };
 });
 
-const errWithReason = (reason: string) => ({
-  response: { status: 409, data: { errors: [{ name: "Error", reason }] } },
+const errWithStatus = (status: number, reason: string) => ({
+  response: { status, data: { errors: [{ name: "base", reason }] } },
 });
+
+const responseWithStatus = (status: number, reason: string) => ({
+  status,
+  data: { errors: [{ name: "base", reason }] },
+});
+
+const errWithReason = (reason: string) => errWithStatus(409, reason);
 
 describe("getErrorMessage", () => {
   it("passes through the Firefox/ESR conflict message without doubling the prefix", () => {
@@ -27,5 +35,34 @@ describe("getErrorMessage", () => {
     const err = errWithReason("Something went wrong");
 
     expect(getErrorMessage(err)).toBe("Couldn't add. Something went wrong.");
+  });
+
+  it("shows the friendly timeout message on 504", () => {
+    expect(getErrorMessage(errWithStatus(504, "anything"))).toBe(
+      REQUEST_TIMEOUT_ERROR_MESSAGE
+    );
+  });
+
+  it("shows the friendly timeout message when the service rejects with a 504 response", () => {
+    expect(getErrorMessage(responseWithStatus(504, "anything"))).toBe(
+      REQUEST_TIMEOUT_ERROR_MESSAGE
+    );
+  });
+
+  it("shows the friendly timeout message on 499 (upstream cancel) and never leaks 'context canceled'", () => {
+    const msg = getErrorMessage(
+      errWithStatus(
+        499,
+        'downloading app installer: reading installer "x" contents: context canceled'
+      )
+    );
+    expect(msg).toBe(REQUEST_TIMEOUT_ERROR_MESSAGE);
+    expect(msg).not.toMatch(/context canceled/i);
+  });
+
+  it("still shows the friendly timeout message on 408", () => {
+    expect(getErrorMessage(errWithStatus(408, "x"))).toBe(
+      REQUEST_TIMEOUT_ERROR_MESSAGE
+    );
   });
 });

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/helpers.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/helpers.tsx
@@ -1,5 +1,5 @@
 import { isAxiosError } from "axios";
-import { getErrorReason } from "interfaces/errors";
+import { getErrorReason, hasStatusKey } from "interfaces/errors";
 
 import { generateSecretErrMsg } from "pages/SoftwarePage/helpers";
 
@@ -54,9 +54,11 @@ export const getFleetAppPolicyQuery = (name: string) => {
 };
 
 export const getErrorMessage = (err: unknown) => {
+  const responseStatus =
+    (isAxiosError(err) ? err.response?.status : undefined) ??
+    (hasStatusKey(err) ? err.status : undefined);
   const isTimeout =
-    isAxiosError(err) &&
-    (err.response?.status === 504 || err.response?.status === 408);
+    responseStatus === 504 || responseStatus === 408 || responseStatus === 499; // upstream proxy/LB canceled the request
   const reason = getErrorReason(err);
 
   if (

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/helpers.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/helpers.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 export const ADD_SOFTWARE_ERROR_PREFIX = "Couldn't add.";
 export const DEFAULT_ADD_SOFTWARE_ERROR_MESSAGE = `${ADD_SOFTWARE_ERROR_PREFIX} Please try again.`;
-export const REQUEST_TIMEOUT_ERROR_MESSAGE = `${ADD_SOFTWARE_ERROR_PREFIX} Request timeout. Please make sure your server and load balancer timeout is long enough.`;
+export const REQUEST_TIMEOUT_ERROR_MESSAGE = `${ADD_SOFTWARE_ERROR_PREFIX} The request timed out. Make sure your server, and any proxy or load balancer in front of Fleet, allows enough time to transfer large installers.`;
 
 export const DIFFERENT_FILE_TYPE_MESSAGE =
   "The selected package is for a different file type.";

--- a/server/fleet/errors.go
+++ b/server/fleet/errors.go
@@ -38,7 +38,13 @@ var (
 	CantResendAppleDeclarationProfilesMessage    = "Can't resend declaration (DDM) profiles. Unlike configuration profiles (.mobileconfig), the host automatically checks in to get the latest DDM profiles."
 	CantAddSoftwareConflictMessage               = "Couldn't add software. %s already has an installer available for the %s fleet."
 	// Args: the two conflicting app names (order not significant).
-	CantAddConflictingFMAMessage                 = "Couldn't add software. Only one of %s or %s can be added to the same fleet."
+	CantAddConflictingFMAMessage = "Couldn't add software. Only one of %s or %s can be added to the same fleet."
+	// AddMaintainedAppTimeoutErrMsg is returned when Fleet's own 15-minute installer
+	// download timeout is exceeded (context.DeadlineExceeded).
+	AddMaintainedAppTimeoutErrMsg = "Couldn't add. Downloading the installer took longer than Fleet's 15-minute limit. This can happen with very large installers or a slow connection to the vendor's content delivery network (CDN). Try again, and make sure any proxy, gateway, or load balancer in front of Fleet allows the request to run at least that long."
+	// AddMaintainedAppCanceledErrMsg is returned when an upstream proxy, gateway, or
+	// load balancer cancels the request before the download finishes (context.Canceled).
+	AddMaintainedAppCanceledErrMsg               = "Couldn't add. The request was canceled before the installer finished downloading. This usually means a proxy, gateway, or load balancer in front of Fleet (for example, Envoy, or an AWS/GCP load balancer) closed the connection first. Increase its request and idle timeout above the time it takes to download large installers."
 	SoftwarePackageHashConflictMessage           = "%s package is already added (same SHA-256 hash)."
 	SoftwarePackageTitleMismatchMessage          = "Couldn't add. %s doesn't match the software title. To add it, go to Software and add it as new software."
 	SoftwareAlreadyHasVPPAppMessage              = "%s already has an Apple App Store (VPP) on the %s fleet."

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -22058,7 +22058,7 @@ func (s *integrationEnterpriseTestSuite) TestMaintainedApps() {
 	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_INSTALLER_TIMEOUT", "1s")
 	r = s.Do("POST", "/api/latest/fleet/software/fleet_maintained_apps", &addFleetMaintainedAppRequest{AppID: 3}, http.StatusGatewayTimeout)
 	dev_mode.ClearOverride("FLEET_DEV_MAINTAINED_APPS_INSTALLER_TIMEOUT")
-	require.Contains(t, extractServerErrorText(r.Body), "Couldn't add. Request timeout. Please make sure your server and load balancer timeout is long enough.")
+	require.Contains(t, extractServerErrorText(r.Body), fleet.AddMaintainedAppTimeoutErrMsg)
 
 	// Add a maintained app to no team
 

--- a/server/service/maintained_apps.go
+++ b/server/service/maintained_apps.go
@@ -109,10 +109,12 @@ func addFleetMaintainedAppEndpoint(ctx context.Context, request interface{}, svc
 		req.LabelsIncludeAll,
 	)
 	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) {
-			err = fleet.NewGatewayTimeoutError("Couldn't add. Request timeout. Please make sure your server and load balancer timeout is long enough.", err)
+		switch {
+		case errors.Is(err, context.DeadlineExceeded):
+			err = fleet.NewGatewayTimeoutError(fleet.AddMaintainedAppTimeoutErrMsg, err)
+		case errors.Is(err, context.Canceled):
+			err = fleet.NewGatewayTimeoutError(fleet.AddMaintainedAppCanceledErrMsg, err)
 		}
-
 		return &addFleetMaintainedAppResponse{Err: err}, nil
 	}
 	return &addFleetMaintainedAppResponse{SoftwareTitleID: titleId}, nil

--- a/server/service/maintained_apps_test.go
+++ b/server/service/maintained_apps_test.go
@@ -3,14 +3,67 @@ package service
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"testing"
 
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type fakeAddFMASvc struct {
+	fleet.Service
+	err error
+}
+
+func (s fakeAddFMASvc) AddFleetMaintainedApp(ctx context.Context, _ *uint, _ uint, _, _, _, _ string, _ bool, _ bool, _, _, _ []string) (uint, error) {
+	return 0, s.err
+}
+
+func TestAddFleetMaintainedAppEndpointErrorTranslation(t *testing.T) {
+	ctx := t.Context()
+	// inner error mirrors the real wrap chain from DownloadInstaller
+	wrap := func(sentinel error) error {
+		return ctxerr.Wrap(ctx, ctxerr.Wrapf(ctx, sentinel, "reading installer %q contents", "https://cdn/app.pkg"), "downloading app installer")
+	}
+
+	cases := []struct {
+		name    string
+		in      error
+		wantMsg string // expected GatewayError.Message
+		want504 bool
+	}{
+		{"canceled", wrap(context.Canceled), fleet.AddMaintainedAppCanceledErrMsg, true},
+		{"deadline", wrap(context.DeadlineExceeded), fleet.AddMaintainedAppTimeoutErrMsg, true},
+		{"other", wrap(errors.New("boom")), "", false}, // passthrough, untouched
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := addFleetMaintainedAppEndpoint(ctx, &addFleetMaintainedAppRequest{}, fakeAddFMASvc{err: tc.in})
+			require.NoError(t, err)
+			gotErr := resp.(*addFleetMaintainedAppResponse).Err
+			require.Error(t, gotErr)
+
+			if tc.want504 {
+				var ge *fleet.GatewayError
+				require.ErrorAs(t, gotErr, &ge)
+				require.Equal(t, http.StatusGatewayTimeout, ge.StatusCode())
+				require.Equal(t, tc.wantMsg, ge.Message)
+				// GatewayError has no Unwrap, so errors.Is can't reach the sentinel
+				// and EncodeError's 499 branch won't fire.
+				require.NotErrorIs(t, gotErr, context.Canceled)
+				require.NotErrorIs(t, gotErr, context.DeadlineExceeded)
+			} else {
+				var ge *fleet.GatewayError
+				require.NotErrorAs(t, gotErr, &ge) // untouched passthrough
+			}
+		})
+	}
+}
 
 func TestAddFleetMaintainedAppDecodeRequest(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
**Related issue:** Resolves #48416

When adding a Fleet-maintained app, a large-installer download that's canceled or times out now returns a clear message pointing at the likely proxy/load-balancer timeout, instead of a raw `context canceled`.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when adding Fleet-maintained apps times out or is canceled during large installer downloads.
  * Added clearer guidance for configuring server, proxy, and load balancer timeouts.
  * Properly handles additional timeout and upstream cancellation responses, including HTTP 408, 499, and 504.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->