### PR TITLE
Fix macOS-only copy on two Windows FMA catalog entries

### DIFF
--- a/ee/maintained-apps/outputs/apps.json
+++ b/ee/maintained-apps/outputs/apps.json
@@ -6915,7 +6915,7 @@
       "slug": "proxyman/windows",
       "platform": "windows",
       "unique_identifier": "Proxyman",
-      "description": "Proxyman is a high-performance macOS app that enables developers to view HTTP/HTTPS requests and responses."
+      "description": "Proxyman is a high-performance app that enables developers to view HTTP/HTTPS requests and responses."
     },
     {
       "name": "Pulsar",
@@ -9165,11 +9165,11 @@
       "description": "WeChat for Mac is a free messaging and calling application."
     },
     {
-      "name": "WeChat for Mac",
+      "name": "WeChat",
       "slug": "wechat/windows",
       "platform": "windows",
       "unique_identifier": "WeChat",
-      "description": "WeChat for Mac is a free messaging and calling application."
+      "description": "WeChat is a free messaging and calling application."
     },
     {
       "name": "WeekToDo",

--- a/frontend/pages/SoftwarePage/components/icons/index.ts
+++ b/frontend/pages/SoftwarePage/components/icons/index.ts
@@ -2228,6 +2228,7 @@ export const SOFTWARE_NAME_TO_ICON_MAP = {
   webcatalog: Webcatalog,
   webex: Webex,
   webstorm: WebStorm,
+  wechat: Wechat,
   "wechat for mac": Wechat,
   weektodo: Weektodo,
   whatroute: Whatroute,


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** N/A — found while removing the macOS Yubikey Manager FMA (#50109)

Two Windows Fleet-maintained apps describe themselves as macOS software in `ee/maintained-apps/outputs/apps.json`, because the entries were copy-pasted from their macOS counterparts. This copy is customer-facing: it shows in the Fleet UI's software catalog and on `fleetdm.com/software-catalog/<slug>`.

- `proxyman/windows` — "Proxyman is a high-performance **macOS** app that enables developers to view HTTP/HTTPS requests and responses." → drops "macOS". (The `proxyman/darwin` description keeps it; it's accurate there.)
- `wechat/windows` — name "**WeChat for Mac**" and "**WeChat for Mac** is a free messaging and calling application." → "WeChat". The winget input (`inputs/winget/wechat.json`) already declares `"name": "WeChat"`, so this also makes `apps.json` agree with its own input. The `wechat/darwin` entry keeps "WeChat for Mac", which is the actual macOS product name.

Renaming the Windows entry needs a matching icon key. `getMatchedSoftwareIcon` matches on the lowercased app name and requires an exact match or a whole-word prefix (`matchLoosePrefixToKey`: `s === key || s.startsWith(key + " ")`), so the existing `"wechat for mac"` key would **not** match a name of "WeChat" and the app would fall back to the generic package icon. Added a `wechat: Wechat` key alongside it (both point at the same component; the `"wechat for mac"` key stays for macOS and for hosts reporting that name in inventory).

No server-side impact: `UpsertMaintainedApp` keys on `slug` and updates `name` in place, and `ReconcileMaintainedAppSoftwareNames` only renames `darwin` titles, so the Windows rename doesn't touch existing software titles. Website icons resolve from the slug (`build-static-content.js` builds `app-icon-<slug>-60x60@2x.png`), not the name, so `app-icon-wechat-60x60@2x.png` is unaffected.

Descriptions here mirror upstream cask/winget copy, so these are minimal factual corrections rather than a voice rewrite.

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] QA'd all new/changed functionality manually:
  - `apps.json` still parses; 1378 apps; verified the four `proxyman`/`wechat` entries read as intended and the `darwin` ones are untouched.
  - Traced the icon lookup by hand: name "wechat" now hits the new exact-match key; "wechat for mac" still hits the original.
  - Swept every non-darwin entry in `apps.json` for macOS-only phrasing (`Rosetta`, `macOS`, `Mac`, `Apple`) — these two were the only genuine mismatches. `duo-desktop/windows` (lists macOS, Windows, and Linux) and `imazing-profile-editor/windows` (edits Apple configuration profiles) are correct as written.

Note: `node_modules` isn't installed in my working copy, so ESLint/Prettier weren't run locally — the added line is a one-line map entry matching the surrounding style. CI will confirm.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the Windows app listings for Proxyman and WeChat with clearer, platform-appropriate names and descriptions.
  - Updated WeChat icon mapping so the correct icon appears for the normalized app name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->