### PR TITLE
Create ubuntu and windows healthcheck scripts

### DIFF
--- a/docs/solutions/linux/scripts/linux_ubuntu_fleetd_healthcheck.sh
+++ b/docs/solutions/linux/scripts/linux_ubuntu_fleetd_healthcheck.sh
@@ -1,0 +1,322 @@
+#!/usr/bin/env bash
+# fleetd_healthcheck_ubuntu.sh
+#
+# Checks the health of all fleetd components on Ubuntu and collects logs into
+# a timestamped archive for support/troubleshooting.
+#
+# Components checked:
+#   - orbit.service      (systemd service)
+#   - orbit              (process: /opt/orbit/bin/orbit/orbit)
+#   - osqueryd           (process: spawned and managed by orbit)
+#   - fleet-desktop      (process: optional, only present if packaged with --fleet-desktop)
+#
+# Sources:
+#   - Service name/unit:  orbit/pkg/packaging/linux_shared.go (writeSystemdUnit)
+#   - Binary path:        /opt/orbit/bin/orbit/orbit (symlinked to /usr/local/bin/orbit)
+#   - Process name:       constant.DesktopAppExecName = "fleet-desktop"
+#   - Log paths:          /var/log/orbit/, /var/log/osquery/ (created at install time)
+#   - Env file:           /etc/default/orbit (written by writeEnvFile)
+#
+# Also collects a lookback window (default 72h, override with LOOKBACK_HOURS env
+# var) of system events — reboots, package changes, systemd failures, journal
+# errors — to help correlate a reported problem with what changed beforehand.
+#
+# Must be run as root.
+
+set -euo pipefail
+
+# ── Colour helpers ─────────────────────────────────────────────────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+ok()   { echo -e "  ${GREEN}[OK]${NC}    $*"; }
+warn() { echo -e "  ${YELLOW}[WARN]${NC}  $*"; }
+fail() { echo -e "  ${RED}[FAIL]${NC}  $*"; }
+info() { echo -e "  [INFO]  $*"; }
+
+if [[ $EUID -ne 0 ]]; then
+  echo "This script must be run as root." >&2
+  exit 1
+fi
+
+LOOKBACK_HOURS="${LOOKBACK_HOURS:-72}"
+
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+HOSTNAME_SAFE=$(hostname | tr '.' '_')
+ARCHIVE_NAME="fleetd_healthcheck_${HOSTNAME_SAFE}_${TIMESTAMP}"
+WORK_DIR=$(mktemp -d "/tmp/${ARCHIVE_NAME}.XXXXXX")
+SUMMARY="${WORK_DIR}/summary.txt"
+OVERALL_EXIT=0
+
+log() { echo "$*" | tee -a "${SUMMARY}"; }
+
+# ── Header ─────────────────────────────────────────────────────────────────────
+log "============================================================"
+log " Fleet fleetd Health Check"
+log " Host:      $(hostname)"
+log " Date:      $(date)"
+log " Kernel:    $(uname -r)"
+log " OS:        $(. /etc/os-release 2>/dev/null && echo "$PRETTY_NAME" || echo "unknown")"
+log "============================================================"
+log ""
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 1. SYSTEMD SERVICE
+# ══════════════════════════════════════════════════════════════════════════════
+log "── 1. systemd service (orbit.service) ──────────────────────"
+
+SERVICE="orbit.service"
+if systemctl is-active --quiet "${SERVICE}" 2>/dev/null; then
+  ok "${SERVICE} is active (running)"
+else
+  fail "${SERVICE} is NOT active"
+  OVERALL_EXIT=1
+fi
+
+if systemctl is-enabled --quiet "${SERVICE}" 2>/dev/null; then
+  ok "${SERVICE} is enabled"
+else
+  warn "${SERVICE} is not enabled — will not start on boot"
+fi
+
+SYSTEMD_STATUS=$(systemctl status "${SERVICE}" --no-pager 2>&1 || true)
+echo "${SYSTEMD_STATUS}" >> "${SUMMARY}"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 2. PROCESS CHECKS
+# ══════════════════════════════════════════════════════════════════════════════
+log ""
+log "── 2. Processes ────────────────────────────────────────────"
+
+check_process() {
+  local label="$1"
+  local pattern="$2"
+  local result
+  result=$(pgrep -af "${pattern}" 2>/dev/null || true)
+  if [[ -n "${result}" ]]; then
+    ok "${label} is running"
+    echo "    ${result}" | tee -a "${SUMMARY}"
+  else
+    fail "${label} is NOT running (pattern: ${pattern})"
+    OVERALL_EXIT=1
+  fi
+}
+
+# orbit binary path is /opt/orbit/bin/orbit/orbit
+# Source: linux_shared.go ExecStart=/opt/orbit/bin/orbit/orbit
+check_process "orbit"        "/opt/orbit/bin/orbit/orbit"
+
+# osqueryd is spawned by orbit; match the binary name
+check_process "osqueryd"     "osqueryd"
+
+# fleet-desktop: only present if package was built with --fleet-desktop
+# Source: constant.DesktopAppExecName = "fleet-desktop"
+if pgrep -af "fleet-desktop" >/dev/null 2>&1; then
+  ok "fleet-desktop is running"
+  pgrep -af "fleet-desktop" | tee -a "${SUMMARY}" | sed 's/^/    /'
+else
+  warn "fleet-desktop is NOT running (expected if not packaged with --fleet-desktop)"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 3. KEY FILES
+# ══════════════════════════════════════════════════════════════════════════════
+log ""
+log "── 3. Key files and directories ────────────────────────────"
+
+check_file() {
+  local label="$1"
+  local path="$2"
+  if [[ -e "${path}" ]]; then
+    ok "${label}: ${path}"
+  else
+    fail "${label} not found: ${path}"
+    OVERALL_EXIT=1
+  fi
+}
+
+check_file "orbit binary"        "/opt/orbit/bin/orbit/orbit"
+check_file "orbit symlink"       "/usr/local/bin/orbit"
+check_file "osquery pidfile"     "/opt/orbit/osquery.pid"
+check_file "env file"            "/etc/default/orbit"
+check_file "orbit node key"      "/opt/orbit/secret-orbit-node-key.txt"
+check_file "enroll secret"       "/opt/orbit/secret.txt"
+
+# Report orbit node key presence without printing value
+if [[ -s "/opt/orbit/secret-orbit-node-key.txt" ]]; then
+  ok "orbit node key is non-empty (enrolled)"
+else
+  fail "orbit node key is missing or empty (not enrolled)"
+  OVERALL_EXIT=1
+fi
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 4. ENV FILE SUMMARY
+# ══════════════════════════════════════════════════════════════════════════════
+log ""
+log "── 4. Orbit environment (/etc/default/orbit) ───────────────"
+if [[ -f /etc/default/orbit ]]; then
+  # Print contents but redact any secrets
+  grep -v -i "secret\|password\|token\|key" /etc/default/orbit \
+    | tee -a "${SUMMARY}" \
+    | sed 's/^/    /'
+else
+  fail "/etc/default/orbit not found"
+  OVERALL_EXIT=1
+fi
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 5. ORBIT VERSION
+# ══════════════════════════════════════════════════════════════════════════════
+log ""
+log "── 5. Orbit version ────────────────────────────────────────"
+if command -v orbit >/dev/null 2>&1; then
+  ORBIT_VERSION=$(orbit version 2>/dev/null || echo "unknown")
+  info "${ORBIT_VERSION}"
+  echo "${ORBIT_VERSION}" >> "${SUMMARY}"
+else
+  warn "orbit not found on PATH (/usr/local/bin/orbit missing or not in PATH)"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 6. LOG COLLECTION
+# ══════════════════════════════════════════════════════════════════════════════
+log ""
+log "── 6. Log collection ───────────────────────────────────────"
+
+collect_log() {
+  local label="$1"
+  local src="$2"
+  local dest_dir="$3"
+  if [[ -f "${src}" ]]; then
+    mkdir -p "${dest_dir}"
+    cp "${src}" "${dest_dir}/"
+    ok "Collected ${label}: ${src}"
+  elif [[ -d "${src}" ]]; then
+    mkdir -p "${dest_dir}"
+    cp -r "${src}/." "${dest_dir}/"
+    ok "Collected ${label} directory: ${src}"
+  else
+    warn "${label} not found at ${src} (skipping)"
+  fi
+}
+
+# orbit logs — /var/log/orbit/ created at install time by linux_shared.go
+# (usually empty; orbit's stdout/stderr goes to syslog/journal by default — see below)
+collect_log "orbit logs"   "/var/log/orbit"   "${WORK_DIR}/logs/orbit"
+
+# osquery logs — /var/log/osquery/ created at install time by linux_shared.go
+# (usually empty; osqueryd's stdout/stderr goes to syslog/journal by default — see below)
+collect_log "osquery logs" "/var/log/osquery" "${WORK_DIR}/logs/osquery"
+
+# osquery filesystem logger output — only populated when logger_path/logger_plugin
+# is set to "filesystem" in agent options. This is where result/status logs
+# (osqueryd.INFO*, osqueryd.results.log, osqueryd.snapshots.log, etc.) actually live.
+collect_log "osquery filesystem logger" "/opt/orbit/osquery_log" "${WORK_DIR}/logs/osquery_log"
+
+# systemd journal for orbit.service (last 500 lines)
+if command -v journalctl >/dev/null 2>&1; then
+  journalctl -u orbit.service --no-pager -n 500 \
+    > "${WORK_DIR}/logs/orbit_journal.log" 2>&1 && \
+    ok "Collected systemd journal (last 500 lines)" || \
+    warn "journalctl failed for orbit.service"
+fi
+
+# syslog fallback — orbit/osqueryd stderr goes to syslog on Debian/Ubuntu
+for syslog_path in /var/log/syslog /var/log/messages; do
+  if [[ -f "${syslog_path}" ]]; then
+    grep -i "orbit\|osquery\|fleet" "${syslog_path}" \
+      > "${WORK_DIR}/logs/syslog_orbit_grep.log" 2>/dev/null || true
+    ok "Grepped syslog for orbit/osquery/fleet: ${syslog_path}"
+    break
+  fi
+done
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 7. SYSTEM EVENTS (lookback window)
+# ══════════════════════════════════════════════════════════════════════════════
+# Captures what changed on the box before the user noticed a problem — reboots,
+# package installs/upgrades/removals, systemd failures, and journal errors.
+# Users rarely remember every change; having this saves a round trip of
+# clarifying questions when triaging a report.
+log ""
+log "── 7. System events, last ${LOOKBACK_HOURS}h ───────────────"
+
+mkdir -p "${WORK_DIR}/logs/system_events"
+SINCE_TS=$(date -d "-${LOOKBACK_HOURS} hours" '+%Y-%m-%d %H:%M:%S')
+
+# Reboots/shutdowns
+if command -v last >/dev/null 2>&1; then
+  last -x reboot shutdown -F 2>/dev/null | head -20 \
+    > "${WORK_DIR}/logs/system_events/reboots.log" || true
+  ok "Collected reboot/shutdown history"
+fi
+
+# Package installs/upgrades/removals (dpkg.log lines are ISO-timestamped,
+# so a lexicographic compare against SINCE_TS also orders them chronologically)
+if [[ -f /var/log/dpkg.log ]]; then
+  awk -v since="${SINCE_TS}" '$0 >= since' /var/log/dpkg.log \
+    > "${WORK_DIR}/logs/system_events/dpkg_recent.log" || true
+  RECENT_PKG_COUNT=$(grep -cE ' (install|upgrade|remove|purge) ' \
+    "${WORK_DIR}/logs/system_events/dpkg_recent.log" 2>/dev/null || echo 0)
+  if [[ "${RECENT_PKG_COUNT}" -gt 0 ]]; then
+    warn "${RECENT_PKG_COUNT} package install/upgrade/remove event(s) in last ${LOOKBACK_HOURS}h"
+  else
+    ok "No package install/upgrade/remove events in last ${LOOKBACK_HOURS}h"
+  fi
+fi
+
+# Currently-failed systemd units (unrelated failures often explain "it stopped working")
+FAILED_UNITS=$(systemctl --failed --no-legend 2>/dev/null || true)
+echo "${FAILED_UNITS}" > "${WORK_DIR}/logs/system_events/systemd_failed_units.log"
+if [[ -n "${FAILED_UNITS}" ]]; then
+  warn "systemd reports failed units:"
+  echo "${FAILED_UNITS}" | tee -a "${SUMMARY}" | sed 's/^/    /'
+else
+  ok "No failed systemd units"
+fi
+
+# Journal errors (priority err and above) in the window
+if command -v journalctl >/dev/null 2>&1; then
+  journalctl -p 3 --since "${LOOKBACK_HOURS} hours ago" --no-pager \
+    > "${WORK_DIR}/logs/system_events/journal_errors.log" 2>&1 || true
+  JOURNAL_ERR_COUNT=$(wc -l < "${WORK_DIR}/logs/system_events/journal_errors.log" 2>/dev/null || echo 0)
+  if [[ "${JOURNAL_ERR_COUNT}" -gt 0 ]]; then
+    warn "${JOURNAL_ERR_COUNT} journal error-level line(s) in last ${LOOKBACK_HOURS}h (see journal_errors.log)"
+  else
+    ok "No journal errors in last ${LOOKBACK_HOURS}h"
+  fi
+
+  # OOM killer events — a frequent, easily-missed cause of "it just stopped"
+  OOM_HITS=$(journalctl --since "${LOOKBACK_HOURS} hours ago" --no-pager 2>/dev/null \
+    | grep -i "out of memory\|oom-killer" || true)
+  if [[ -n "${OOM_HITS}" ]]; then
+    warn "OOM killer activity detected in last ${LOOKBACK_HOURS}h"
+    echo "${OOM_HITS}" > "${WORK_DIR}/logs/system_events/oom_events.log"
+  fi
+fi
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 8. PACKAGE THE ARCHIVE
+# ══════════════════════════════════════════════════════════════════════════════
+log ""
+log "── 8. Packaging archive ────────────────────────────────────"
+
+ARCHIVE_PATH="/tmp/${ARCHIVE_NAME}.tar.gz"
+tar -czf "${ARCHIVE_PATH}" -C "$(dirname "${WORK_DIR}")" "$(basename "${WORK_DIR}")"
+rm -rf "${WORK_DIR}"
+
+info "Archive created: ${ARCHIVE_PATH}"
+log ""
+
+# ══════════════════════════════════════════════════════════════════════════════
+# FINAL RESULT
+# ══════════════════════════════════════════════════════════════════════════════
+log "============================================================"
+if [[ ${OVERALL_EXIT} -eq 0 ]]; then
+  log " Result: ALL CHECKS PASSED"
+else
+  log " Result: ONE OR MORE CHECKS FAILED — review summary above"
+fi
+log " Archive: ${ARCHIVE_PATH}"
+log "============================================================"
+
+exit ${OVERALL_EXIT}

--- a/docs/solutions/linux/scripts/linux_ubuntu_fleetd_healthcheck.sh
+++ b/docs/solutions/linux/scripts/linux_ubuntu_fleetd_healthcheck.sh
@@ -155,7 +155,7 @@ log ""
 log "── 4. Orbit environment (/etc/default/orbit) ───────────────"
 if [[ -f /etc/default/orbit ]]; then
   # Print contents but redact any secrets
-  grep -v -i "secret\|password\|token\|key" /etc/default/orbit \
+  awk 'BEGIN { IGNORECASE=1 } !/secret|password|token|key/' /etc/default/orbit \
     | tee -a "${SUMMARY}" \
     | sed 's/^/    /'
 else

--- a/docs/solutions/linux/scripts/linux_ubuntu_fleetd_healthcheck.sh
+++ b/docs/solutions/linux/scripts/linux_ubuntu_fleetd_healthcheck.sh
@@ -213,6 +213,7 @@ collect_log "osquery logs" "/var/log/osquery" "${WORK_DIR}/logs/osquery"
 collect_log "osquery filesystem logger" "/opt/orbit/osquery_log" "${WORK_DIR}/logs/osquery_log"
 
 # systemd journal for orbit.service (last 500 lines)
+mkdir -p "${WORK_DIR}/logs"
 if command -v journalctl >/dev/null 2>&1; then
   journalctl -u orbit.service --no-pager -n 500 \
     > "${WORK_DIR}/logs/orbit_journal.log" 2>&1 && \

--- a/docs/solutions/windows/scripts/fleetd-healthcheck.ps1
+++ b/docs/solutions/windows/scripts/fleetd-healthcheck.ps1
@@ -266,11 +266,11 @@ if (-not $DesktopLogsFound) {
 $EventLogDir = Join-Path $WorkDir 'logs\event_log'
 New-Item -ItemType Directory -Path $EventLogDir -Force | Out-Null
 try {
-  Get-WinEvent -FilterHashtable @{ LogName = 'System', 'Application'; StartTime = $Since } -ErrorAction Stop |
-    Where-Object { $_.Message -match 'orbit|osquery|fleet' } |
-    Select-Object TimeCreated, LogName, ProviderName, Id, LevelDisplayName, Message |
+  $Matches = Get-WinEvent -FilterHashtable @{ LogName = 'System', 'Application'; StartTime = $Since } -ErrorAction SilentlyContinue |
+    Where-Object { $_.Message -match 'orbit|osquery|fleet' }
+  $Matches | Select-Object TimeCreated, LogName, ProviderName, Id, LevelDisplayName, Message |
     Export-Csv -Path (Join-Path $EventLogDir 'orbit_osquery_fleet_events.csv') -NoTypeInformation
-  Ok "Collected System/Application event log entries mentioning orbit/osquery/fleet"
+  Ok "Collected $(($Matches | Measure-Object).Count) System/Application event(s) mentioning orbit/osquery/fleet"
 } catch {
   Warn "Failed to query Windows Event Log: $_"
 }

--- a/docs/solutions/windows/scripts/fleetd-healthcheck.ps1
+++ b/docs/solutions/windows/scripts/fleetd-healthcheck.ps1
@@ -371,8 +371,14 @@ if ($OverallExit -eq 0) {
 Log " Archive: $ArchivePath"
 Log "============================================================"
 
-Compress-Archive -Path (Join-Path $WorkDir '*') -DestinationPath $ArchivePath -Force
-Remove-Item -Path $WorkDir -Recurse -Force
-Write-Host "  [INFO]  Archive created: $ArchivePath"
+try {
+  Compress-Archive -Path (Join-Path $WorkDir '*') -DestinationPath $ArchivePath -Force -ErrorAction Stop
+  Remove-Item -Path $WorkDir -Recurse -Force
+  Write-Host "  [INFO]  Archive created: $ArchivePath"
+} catch {
+  Write-Error "Failed to create archive: $_"
+  Write-Host "  [WARN]  Archive creation failed; diagnostic data retained at: $WorkDir"
+  $OverallExit = 1
+}
 
 exit $OverallExit

--- a/docs/solutions/windows/scripts/fleetd-healthcheck.ps1
+++ b/docs/solutions/windows/scripts/fleetd-healthcheck.ps1
@@ -346,7 +346,9 @@ try {
     $ResourceEvents | Select-Object TimeCreated, Id, Message | Export-Csv -Path (Join-Path $SystemEventsDir 'resource_exhaustion_events.csv') -NoTypeInformation
   }
 } catch {
-  # Provider may not be present on all SKUs - not a failure condition
+  if ($_.Exception.Message -notmatch 'no provider|not found') {
+    Warn "Failed to query resource-exhaustion events: $_"
+  }
 }
 
 # ==============================================================================

--- a/docs/solutions/windows/scripts/fleetd-healthcheck.ps1
+++ b/docs/solutions/windows/scripts/fleetd-healthcheck.ps1
@@ -191,7 +191,7 @@ Log ""
 Log "-- 4. Service configuration (redacted) ------------------------"
 if ($SvcCim -and $SvcCim.PathName) {
   # Redact anything that looks like a secret/token/key/password in the service args
-  $Redacted = $SvcCim.PathName -replace '(?i)(--[\w-]*(secret|password|token|key)[\w-]*[= ]")[^"]*(")', '$1<redacted>$3'
+  $Redacted = $SvcCim.PathName -replace '(?i)(--[\w-]*(?:secret|password|token|key)[\w-]*[= ])(?:"[^"]*"|\S+)', '$1<redacted>'
   Log "    $Redacted"
 } else {
   Fail "Could not read service ImagePath/arguments"

--- a/docs/solutions/windows/scripts/fleetd-healthcheck.ps1
+++ b/docs/solutions/windows/scripts/fleetd-healthcheck.ps1
@@ -1,0 +1,378 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+  fleetd_healthcheck_windows.ps1
+
+  Checks the health of all fleetd components on Windows and collects logs into
+  a timestamped archive for support/troubleshooting. Windows counterpart to
+  fleetd_healthcheck_ubuntu.sh.
+
+  Components checked:
+    - "Fleet osquery" service (Windows service, runs orbit.exe)
+    - orbit               (process: orbit.exe)
+    - osqueryd            (process: spawned and managed by orbit)
+    - fleet-desktop       (process: optional, only present if packaged with --fleet-desktop)
+
+  Sources:
+    - Service name:        orbit/pkg/constant/constant.go (SystemServiceName = "Fleet osquery")
+    - Install root:        orbit/pkg/packaging/windows_templates.go (ORBITROOT = C:\Program Files\Orbit)
+    - File names:          orbit/pkg/constant/constant.go (OrbitNodeKeyFileName, OsqueryEnrollSecretFileName, OsqueryPidfile)
+    - Registry key:        HKLM:\SOFTWARE\FleetDM\Orbit (Path)
+    - Log paths:           https://fleetdm.com/guides/fleet-troubleshooting-for-it-admins
+                              - orbit/osquery: C:\Windows\system32\config\systemprofile\AppData\Local\FleetDM\Orbit\Logs\orbit-osquery.log
+                              - fleet-desktop: %LocalAppData%\Fleet\fleet-desktop.log (per user)
+                              - osquery filesystem logger: C:\Program Files\Orbit\osquery_log
+
+  Also collects a lookback window (default 72h, override with -LookbackHours or
+  $env:LOOKBACK_HOURS) of system events - reboots, install/uninstall activity,
+  failed services, System/Application errors - to help correlate a reported
+  problem with what changed beforehand.
+
+  Must be run from an elevated (Administrator) PowerShell session.
+#>
+
+[CmdletBinding()]
+param(
+  [int]$LookbackHours = $(if ($env:LOOKBACK_HOURS) { [int]$env:LOOKBACK_HOURS } else { 72 })
+)
+
+$ErrorActionPreference = 'Continue'
+
+# -- Colour helpers -------------------------------------------------------------
+function Ok   { param([string]$Msg) Write-Host "  [OK]    $Msg" -ForegroundColor Green;  Add-Content -Path $Summary -Value "  [OK]    $Msg" }
+function Warn { param([string]$Msg) Write-Host "  [WARN]  $Msg" -ForegroundColor Yellow; Add-Content -Path $Summary -Value "  [WARN]  $Msg" }
+function Fail { param([string]$Msg) Write-Host "  [FAIL]  $Msg" -ForegroundColor Red;    Add-Content -Path $Summary -Value "  [FAIL]  $Msg" }
+function Info { param([string]$Msg) Write-Host "  [INFO]  $Msg";                          Add-Content -Path $Summary -Value "  [INFO]  $Msg" }
+function Log  { param([string]$Msg) Write-Host $Msg;                                      Add-Content -Path $Summary -Value $Msg }
+
+$IsAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltinRole]::Administrator)
+if (-not $IsAdmin) {
+  Write-Error "This script must be run from an elevated (Administrator) PowerShell session."
+  exit 1
+}
+
+$Timestamp    = Get-Date -Format 'yyyyMMdd_HHmmss'
+$HostnameSafe = $env:COMPUTERNAME -replace '\.', '_'
+$ArchiveName  = "fleetd_healthcheck_${HostnameSafe}_${Timestamp}"
+$WorkDir      = Join-Path $env:TEMP $ArchiveName
+New-Item -ItemType Directory -Path $WorkDir -Force | Out-Null
+$Summary      = Join-Path $WorkDir 'summary.txt'
+New-Item -ItemType File -Path $Summary -Force | Out-Null
+$OverallExit  = 0
+
+$OrbitRoot = Join-Path $env:ProgramFiles 'Orbit'
+$ServiceName = 'Fleet osquery'
+$Since = (Get-Date).AddHours(-$LookbackHours)
+
+# -- Header ---------------------------------------------------------------------
+$OsInfo = (Get-CimInstance Win32_OperatingSystem).Caption
+Log "============================================================"
+Log " Fleet fleetd Health Check"
+Log " Host:      $env:COMPUTERNAME"
+Log " Date:      $(Get-Date)"
+Log " OS:        $OsInfo"
+Log "============================================================"
+Log ""
+
+# ==============================================================================
+# 1. WINDOWS SERVICE
+# ==============================================================================
+Log "-- 1. Windows service (`"$ServiceName`") --------------------"
+
+$Svc = Get-Service -Name $ServiceName -ErrorAction SilentlyContinue
+if ($Svc -and $Svc.Status -eq 'Running') {
+  Ok "$ServiceName is running"
+} else {
+  Fail "$ServiceName is NOT running$(if ($Svc) { " (status: $($Svc.Status))" } else { " (service not found)" })"
+  $OverallExit = 1
+}
+
+$SvcCim = Get-CimInstance Win32_Service -Filter "Name='$ServiceName'" -ErrorAction SilentlyContinue
+if ($SvcCim) {
+  if ($SvcCim.StartMode -eq 'Auto') {
+    Ok "$ServiceName start mode is Automatic"
+  } else {
+    Warn "$ServiceName start mode is '$($SvcCim.StartMode)' - will not start on boot"
+  }
+  Add-Content -Path $Summary -Value ($SvcCim | Format-List Name, DisplayName, State, Status, StartMode, PathName | Out-String)
+} else {
+  Warn "Could not read service details via WMI/CIM"
+}
+
+# ==============================================================================
+# 2. PROCESS CHECKS
+# ==============================================================================
+Log ""
+Log "-- 2. Processes ---------------------------------------------"
+
+function Check-Process {
+  param([string]$Label, [string]$Name)
+  $Procs = Get-Process -Name $Name -ErrorAction SilentlyContinue
+  if ($Procs) {
+    Ok "$Label is running"
+    foreach ($p in $Procs) {
+      $cmd = (Get-CimInstance Win32_Process -Filter "ProcessId=$($p.Id)" -ErrorAction SilentlyContinue).CommandLine
+      Add-Content -Path $Summary -Value "    PID $($p.Id): $cmd"
+    }
+  } else {
+    Fail "$Label is NOT running (process name: $Name)"
+    $script:OverallExit = 1
+  }
+}
+
+Check-Process "orbit" "orbit"
+Check-Process "osqueryd" "osqueryd"
+
+$Desktop = Get-Process -Name "fleet-desktop" -ErrorAction SilentlyContinue
+if ($Desktop) {
+  Ok "fleet-desktop is running"
+  foreach ($p in $Desktop) { Add-Content -Path $Summary -Value "    PID $($p.Id)" }
+} else {
+  Warn "fleet-desktop is NOT running (expected if not packaged with --fleet-desktop)"
+}
+
+# ==============================================================================
+# 3. KEY FILES / REGISTRY
+# ==============================================================================
+Log ""
+Log "-- 3. Key files, directories, and registry -------------------"
+
+function Check-Path {
+  param([string]$Label, [string]$Path)
+  if (Test-Path -LiteralPath $Path) {
+    Ok "${Label}: $Path"
+  } else {
+    Fail "$Label not found: $Path"
+    $script:OverallExit = 1
+  }
+}
+
+Check-Path "Orbit root directory"  $OrbitRoot
+Check-Path "osquery pidfile"       (Join-Path $OrbitRoot 'osquery.pid')
+Check-Path "orbit node key"        (Join-Path $OrbitRoot 'secret-orbit-node-key.txt')
+Check-Path "enroll secret"         (Join-Path $OrbitRoot 'secret.txt')
+
+$OrbitExe = Get-ChildItem -Path (Join-Path $OrbitRoot 'bin\orbit') -Filter 'orbit.exe' -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
+if ($OrbitExe) {
+  Ok "orbit binary: $($OrbitExe.FullName)"
+} else {
+  Fail "orbit.exe not found under $OrbitRoot\bin\orbit"
+  $OverallExit = 1
+}
+
+$OsquerydExe = Get-ChildItem -Path (Join-Path $OrbitRoot 'bin\osqueryd') -Filter 'osqueryd.exe' -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
+if ($OsquerydExe) {
+  Ok "osqueryd binary: $($OsquerydExe.FullName)"
+} else {
+  Warn "osqueryd.exe not found under $OrbitRoot\bin\osqueryd"
+}
+
+$NodeKeyPath = Join-Path $OrbitRoot 'secret-orbit-node-key.txt'
+if ((Test-Path -LiteralPath $NodeKeyPath) -and (Get-Item -LiteralPath $NodeKeyPath).Length -gt 0) {
+  Ok "orbit node key is non-empty (enrolled)"
+} else {
+  Fail "orbit node key is missing or empty (not enrolled)"
+  $OverallExit = 1
+}
+
+$RegPath = 'HKLM:\SOFTWARE\FleetDM\Orbit'
+if (Test-Path -LiteralPath $RegPath) {
+  $RegProps = Get-ItemProperty -Path $RegPath -ErrorAction SilentlyContinue
+  Ok "Registry key found: $RegPath"
+  Add-Content -Path $Summary -Value ($RegProps | Select-Object * -ExcludeProperty PS* | Out-String)
+} else {
+  Warn "Registry key not found: $RegPath"
+}
+
+# ==============================================================================
+# 4. SERVICE CONFIGURATION SUMMARY
+# ==============================================================================
+Log ""
+Log "-- 4. Service configuration (redacted) ------------------------"
+if ($SvcCim -and $SvcCim.PathName) {
+  # Redact anything that looks like a secret/token/key/password in the service args
+  $Redacted = $SvcCim.PathName -replace '(?i)(--[\w-]*(secret|password|token|key)[\w-]*[= ]")[^"]*(")', '$1<redacted>$3'
+  Log "    $Redacted"
+} else {
+  Fail "Could not read service ImagePath/arguments"
+  $OverallExit = 1
+}
+
+# ==============================================================================
+# 5. ORBIT VERSION
+# ==============================================================================
+Log ""
+Log "-- 5. Orbit version --------------------------------------------"
+if ($OrbitExe) {
+  try {
+    $OrbitVersion = & $OrbitExe.FullName version 2>&1 | Out-String
+    Info $OrbitVersion.Trim()
+    Add-Content -Path $Summary -Value $OrbitVersion
+  } catch {
+    Warn "Failed to run 'orbit.exe version': $_"
+  }
+} else {
+  Warn "orbit.exe not found - skipping version check"
+}
+
+# ==============================================================================
+# 6. LOG COLLECTION
+# ==============================================================================
+Log ""
+Log "-- 6. Log collection ---------------------------------------------"
+
+function Collect-Log {
+  param([string]$Label, [string]$Src, [string]$DestDir)
+  if (Test-Path -LiteralPath $Src -PathType Leaf) {
+    New-Item -ItemType Directory -Path $DestDir -Force | Out-Null
+    Copy-Item -LiteralPath $Src -Destination $DestDir -Force
+    Ok "Collected ${Label}: $Src"
+  } elseif (Test-Path -LiteralPath $Src -PathType Container) {
+    New-Item -ItemType Directory -Path $DestDir -Force | Out-Null
+    Copy-Item -Path (Join-Path $Src '*') -Destination $DestDir -Recurse -Force -ErrorAction SilentlyContinue
+    Ok "Collected $Label directory: $Src"
+  } else {
+    Warn "$Label not found at $Src (skipping)"
+  }
+}
+
+# orbit/osquery combined log - runs as LocalSystem, so it lives under the
+# SYSTEM profile rather than a normal user's AppData.
+Collect-Log "orbit/osquery log" `
+  "$env:SystemRoot\system32\config\systemprofile\AppData\Local\FleetDM\Orbit\Logs\orbit-osquery.log" `
+  (Join-Path $WorkDir 'logs\orbit')
+
+# osquery filesystem logger output - only populated when logger_path/logger_plugin
+# is set to "filesystem" in agent options.
+Collect-Log "osquery filesystem logger" (Join-Path $OrbitRoot 'osquery_log') (Join-Path $WorkDir 'logs\osquery_log')
+
+# fleet-desktop runs per-user; sweep all user profiles for its log file
+$DesktopLogsFound = $false
+Get-ChildItem 'C:\Users' -Directory -ErrorAction SilentlyContinue | ForEach-Object {
+  $DesktopLog = Join-Path $_.FullName 'AppData\Local\Fleet\fleet-desktop.log'
+  if (Test-Path -LiteralPath $DesktopLog) {
+    $DestDir = Join-Path $WorkDir "logs\fleet-desktop\$($_.Name)"
+    New-Item -ItemType Directory -Path $DestDir -Force | Out-Null
+    Copy-Item -LiteralPath $DesktopLog -Destination $DestDir -Force
+    Ok "Collected fleet-desktop log for user $($_.Name): $DesktopLog"
+    $DesktopLogsFound = $true
+  }
+}
+if (-not $DesktopLogsFound) {
+  Warn "No fleet-desktop.log found under any user profile (expected if fleet-desktop is not installed)"
+}
+
+# Windows Event Log entries mentioning orbit/osquery/fleet (System + Application)
+$EventLogDir = Join-Path $WorkDir 'logs\event_log'
+New-Item -ItemType Directory -Path $EventLogDir -Force | Out-Null
+try {
+  Get-WinEvent -FilterHashtable @{ LogName = 'System', 'Application'; StartTime = $Since } -ErrorAction Stop |
+    Where-Object { $_.Message -match 'orbit|osquery|fleet' } |
+    Select-Object TimeCreated, LogName, ProviderName, Id, LevelDisplayName, Message |
+    Export-Csv -Path (Join-Path $EventLogDir 'orbit_osquery_fleet_events.csv') -NoTypeInformation
+  Ok "Collected System/Application event log entries mentioning orbit/osquery/fleet"
+} catch {
+  Warn "Failed to query Windows Event Log: $_"
+}
+
+# ==============================================================================
+# 7. SYSTEM EVENTS (lookback window)
+# ==============================================================================
+# Captures what changed on the box before the user noticed a problem - reboots,
+# software installs/removals, service failures, and system errors. Users rarely
+# remember every change; having this saves a round trip of clarifying questions.
+Log ""
+Log "-- 7. System events, last ${LookbackHours}h -----------------------"
+
+$SystemEventsDir = Join-Path $WorkDir 'logs\system_events'
+New-Item -ItemType Directory -Path $SystemEventsDir -Force | Out-Null
+
+# Reboots/shutdowns - EventIDs: 6005/6006 (start/stop), 1074 (user-initiated), 41 (unexpected/dirty)
+try {
+  $Reboots = Get-WinEvent -FilterHashtable @{ LogName = 'System'; Id = 6005, 6006, 1074, 41; StartTime = $Since } -ErrorAction SilentlyContinue
+  $Reboots | Select-Object TimeCreated, Id, Message | Export-Csv -Path (Join-Path $SystemEventsDir 'reboots.csv') -NoTypeInformation
+  Ok "Collected reboot/shutdown history"
+} catch {
+  Warn "Failed to query reboot/shutdown events: $_"
+}
+
+# Software install/uninstall activity (MsiInstaller provider in Application log)
+try {
+  $MsiEvents = Get-WinEvent -FilterHashtable @{ LogName = 'Application'; ProviderName = 'MsiInstaller'; StartTime = $Since } -ErrorAction SilentlyContinue
+  $MsiEvents | Select-Object TimeCreated, Id, Message | Export-Csv -Path (Join-Path $SystemEventsDir 'msi_install_events.csv') -NoTypeInformation
+  $RecentPkgCount = ($MsiEvents | Measure-Object).Count
+  if ($RecentPkgCount -gt 0) {
+    Warn "$RecentPkgCount install/uninstall event(s) in last ${LookbackHours}h"
+  } else {
+    Ok "No install/uninstall events in last ${LookbackHours}h"
+  }
+} catch {
+  Warn "Failed to query MsiInstaller events: $_"
+}
+
+# Services set to Automatic start but not currently running
+try {
+  $FailedServices = Get-CimInstance Win32_Service | Where-Object { $_.StartMode -eq 'Auto' -and $_.State -ne 'Running' }
+  $FailedServices | Select-Object Name, DisplayName, State, StartMode | Export-Csv -Path (Join-Path $SystemEventsDir 'stopped_auto_services.csv') -NoTypeInformation
+  if ($FailedServices) {
+    Warn "$($FailedServices.Count) Automatic-start service(s) not running:"
+    $FailedServices | ForEach-Object { Add-Content -Path $Summary -Value "    $($_.Name) ($($_.DisplayName)): $($_.State)" }
+  } else {
+    Ok "No Automatic-start services are stopped"
+  }
+} catch {
+  Warn "Failed to enumerate services: $_"
+}
+
+# System/Application error-level events in the window
+try {
+  $ErrorEvents = Get-WinEvent -FilterHashtable @{ LogName = 'System', 'Application'; Level = 2; StartTime = $Since } -ErrorAction SilentlyContinue
+  $ErrorEvents | Select-Object TimeCreated, LogName, ProviderName, Id, Message | Export-Csv -Path (Join-Path $SystemEventsDir 'error_events.csv') -NoTypeInformation
+  $ErrCount = ($ErrorEvents | Measure-Object).Count
+  if ($ErrCount -gt 0) {
+    Warn "$ErrCount error-level event(s) in last ${LookbackHours}h (see error_events.csv)"
+  } else {
+    Ok "No System/Application errors in last ${LookbackHours}h"
+  }
+} catch {
+  Warn "Failed to query error-level events: $_"
+}
+
+# Resource exhaustion (low memory) - Windows' rough equivalent of the Linux OOM killer
+try {
+  $ResourceEvents = Get-WinEvent -FilterHashtable @{ LogName = 'System'; ProviderName = 'Microsoft-Windows-Resource-Exhaustion-Detector'; StartTime = $Since } -ErrorAction SilentlyContinue
+  if ($ResourceEvents) {
+    Warn "Low-memory/resource-exhaustion activity detected in last ${LookbackHours}h"
+    $ResourceEvents | Select-Object TimeCreated, Id, Message | Export-Csv -Path (Join-Path $SystemEventsDir 'resource_exhaustion_events.csv') -NoTypeInformation
+  }
+} catch {
+  # Provider may not be present on all SKUs - not a failure condition
+}
+
+# ==============================================================================
+# 8. PACKAGE THE ARCHIVE
+# ==============================================================================
+# All logging finishes before the work dir is zipped and removed below, so
+# summary.txt (and the final result) end up inside the archive too.
+Log ""
+Log "-- 8. Packaging archive ----------------------------------------"
+
+$ArchivePath = Join-Path $env:TEMP "$ArchiveName.zip"
+
+# ==============================================================================
+# FINAL RESULT
+# ==============================================================================
+Log "============================================================"
+if ($OverallExit -eq 0) {
+  Log " Result: ALL CHECKS PASSED"
+} else {
+  Log " Result: ONE OR MORE CHECKS FAILED -- review summary above"
+}
+Log " Archive: $ArchivePath"
+Log "============================================================"
+
+Compress-Archive -Path (Join-Path $WorkDir '*') -DestinationPath $ArchivePath -Force
+Remove-Item -Path $WorkDir -Recurse -Force
+Write-Host "  [INFO]  Archive created: $ArchivePath"
+
+exit $OverallExit


### PR DESCRIPTION
Adds scripts for Windows and Ubuntu that checks the health of all fleetd components and collects logs and recent events into a timestamped archive for support and troubleshooting.

These have been used by multiple customers now, and has simplified the collection of logs from multiple locations while including events that can assist with troubleshooting. Adding to solutions for wider use.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Linux and Windows healthcheck scripts for Fleet deployments.
  * Healthchecks verify services, processes, required files, configuration, versions, and enrollment status.
  * Collects relevant logs and recent system events into timestamped archives.
  * Redacts sensitive configuration values from collected diagnostics.
  * Reports check results and returns a failure status when required checks do not pass.
  * Supports configurable event lookback periods, defaulting to 72 hours.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->