### PR TITLE
AULD: Enrollment insert and backfill osquery query

### DIFF
--- a/docs/Contributing/product-groups/orchestration/understanding-host-vitals.md
+++ b/docs/Contributing/product-groups/orchestration/understanding-host-vitals.md
@@ -357,6 +357,20 @@ WITH
 	SELECT encrypted, hex(line) as hex_line FROM de LEFT JOIN fl;
 ```
 
+## mdm_macos_software_update_id
+
+- Platforms: darwin
+
+- Discovery query:
+```sql
+SELECT 1 FROM osquery_registry WHERE active = true AND registry = 'table' AND name = 'ioreg'
+```
+
+- Query:
+```sql
+SELECT key, value FROM ioreg WHERE c = 'IOPlatformExpertDevice' AND key IN ('compatible', 'bridge-model', 'board-id');
+```
+
 ## mdm_windows
 
 - Platforms: windows

--- a/pkg/mdm/mdmtest/apple.go
+++ b/pkg/mdm/mdmtest/apple.go
@@ -587,6 +587,8 @@ func (c *TestAppleMDMClient) fetchOTAProfile(url string) error {
 	<string>%s</string>
 	<key>VERSION</key>
 	<string>22A5316k</string>
+	<key>SOFTWARE_UPDATE_DEVICE_ID</key>
+	<string>bogus-OTA-update-id</string>
 </dict>
 </plist>`, c.Model, c.SerialNumber, c.UUID))
 

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -8523,7 +8523,7 @@ func (ds *Datastore) InsertAppleSoftwareUpdateDeviceID(ctx context.Context, host
 	`
 
 	if _, err := ds.writer(ctx).ExecContext(ctx, stmt, hostUUID, updateDeviceID); err != nil {
-		return ctxerr.Wrap(ctx, err, "inserting macOS software update device ID")
+		return ctxerr.Wrap(ctx, err, "inserting Apple software update device ID")
 	}
 
 	return nil

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -8508,7 +8508,7 @@ func (ds *Datastore) GetHostDEPAssignmentsByHostIDs(ctx context.Context, hostIDs
 	return res, nil
 }
 
-func (ds *Datastore) InsertMacOSSoftwareUpdateDeviceID(ctx context.Context, hostUUID string, updateDeviceID string) error {
+func (ds *Datastore) InsertAppleSoftwareUpdateDeviceID(ctx context.Context, hostUUID string, updateDeviceID string) error {
 	if hostUUID == "" {
 		return ctxerr.New(ctx, "host UUID is required")
 	}

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -8507,3 +8507,24 @@ func (ds *Datastore) GetHostDEPAssignmentsByHostIDs(ctx context.Context, hostIDs
 	}
 	return res, nil
 }
+
+func (ds *Datastore) InsertMacOSSoftwareUpdateDeviceID(ctx context.Context, hostUUID string, updateDeviceID string) error {
+	if hostUUID == "" {
+		return ctxerr.New(ctx, "host UUID is required")
+	}
+
+	if updateDeviceID == "" {
+		return ctxerr.New(ctx, "update device ID is required")
+	}
+
+	const stmt = `
+		INSERT INTO host_mdm_apple_os_updates (host_uuid, software_update_device_id) VALUES (?, ?)
+			ON DUPLICATE KEY UPDATE software_update_device_id = VALUES(software_update_device_id)
+	`
+
+	if _, err := ds.writer(ctx).ExecContext(ctx, stmt, hostUUID, updateDeviceID); err != nil {
+		return ctxerr.Wrap(ctx, err, "inserting macOS software update device ID")
+	}
+
+	return nil
+}

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -667,6 +667,7 @@ var additionalHostRefsByUUID = map[string]string{
 	"host_certificate_templates":            "host_uuid",
 	"host_mdm_apple_enrollment_permissions": "host_uuid",
 	"host_mdm_apple_device_names":           "host_uuid",
+	"host_mdm_apple_os_updates":             "host_uuid",
 }
 
 // additionalHostRefsSoftDelete are tables that reference a host but for which

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -9752,6 +9752,9 @@ func testHostsDeleteHosts(t *testing.T, ds *Datastore) {
 	)
 	require.NoError(t, err)
 
+	err = ds.InsertMacOSSoftwareUpdateDeviceID(ctx, host.UUID, "bogus-update-id")
+	require.NoError(t, err)
+
 	// Check there's an entry for the host in all the associated tables.
 	for _, hostRef := range hostRefs {
 		var ok bool

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -9752,7 +9752,7 @@ func testHostsDeleteHosts(t *testing.T, ds *Datastore) {
 	)
 	require.NoError(t, err)
 
-	err = ds.InsertMacOSSoftwareUpdateDeviceID(ctx, host.UUID, "bogus-update-id")
+	err = ds.InsertAppleSoftwareUpdateDeviceID(ctx, host.UUID, "bogus-update-id")
 	require.NoError(t, err)
 
 	// Check there's an entry for the host in all the associated tables.

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -1363,25 +1363,49 @@ var appleSiliconMajorThreshold = map[string]int{
 	"iMac": 21,
 }
 
-// IsMacAppleSilicon determines whether the device is an Apple Silicon Mac. If the model identifier
-// starts with iPhone, iPod, or iPad, it returns false with no error; however, other non-Mac Apple
-// devices like AppleTV will return an error.
-func IsMacAppleSilicon(modelIdentifier string) (bool, error) {
+func IsMacIdentifier(modelIdentifier string) (bool, string, int, error) {
 	if strings.HasPrefix(modelIdentifier, "iPhone") ||
 		strings.HasPrefix(modelIdentifier, "iPod") ||
 		strings.HasPrefix(modelIdentifier, "iPad") {
 		// If the model identifier starts with iPhone, iPod, or iPad, we'll return false with no
 		// error; however, other non-Mac Apple devices like AppleTV will return an error
-		return false, nil
+		return false, "", 0, nil
 	}
 
 	matches := macProductRe.FindStringSubmatch(modelIdentifier)
 	if matches == nil {
-		return false, fmt.Errorf("unrecognized product identifier format: %q", modelIdentifier)
+		return false, "", 0, fmt.Errorf("unrecognized product identifier format: %q", modelIdentifier)
 	}
 
 	family := matches[1]
 	major, _ := strconv.Atoi(matches[2])
+
+	if family == "Mac" ||
+		family == "VirtualMac" ||
+		family == "MacBook" ||
+		family == "MacBookAir" ||
+		family == "MacBookPro" ||
+		family == "Macmini" ||
+		family == "iMac" ||
+		family == "iMacPro" ||
+		family == "MacPro" {
+		return true, family, major, nil
+	}
+
+	return false, "", 0, fmt.Errorf("failed to detect if model identifier (%q) was mac", modelIdentifier)
+}
+
+// IsMacAppleSilicon determines whether the device is an Apple Silicon Mac. If the model identifier
+// starts with iPhone, iPod, or iPad, it returns false with no error; however, other non-Mac Apple
+// devices like AppleTV will return an error.
+func IsMacAppleSilicon(modelIdentifier string) (bool, error) {
+	isMac, family, major, err := IsMacIdentifier(modelIdentifier)
+	if err != nil {
+		return false, err
+	}
+	if !isMac {
+		return false, nil
+	}
 
 	// Model identifiers starting with "Mac" immediately followed by a digit (e.g. "Mac13,1")
 	// represent the unified naming scheme Apple adopted for Apple Silicon products such as the

--- a/server/fleet/apple_mdm_test.go
+++ b/server/fleet/apple_mdm_test.go
@@ -985,6 +985,86 @@ func TestValidateNoSecretsInProfileName(t *testing.T) {
 	}
 }
 
+func TestIsMacIdentifier(t *testing.T) {
+	cases := []struct {
+		product string
+		want    bool
+		wantErr bool
+	}{
+		// --- MacBookPro ---
+		{product: "MacBookPro16,1", want: true},
+		{product: "MacBookPro16,4", want: true},
+		{product: "MacBookPro17,1", want: true},
+		{product: "MacBookPro18,3", want: true},
+		{product: "MacBookPro18,4", want: true},
+
+		// --- MacBookAir ---
+		{product: "MacBookAir9,1", want: true},
+		{product: "MacBookAir10,1", want: true},
+		{product: "MacBookAir14,2", want: true},
+
+		// --- Macmini ---
+		{product: "Macmini8,1", want: true},
+		{product: "Macmini9,1", want: true},
+		{product: "Macmini9,2", want: true},
+
+		// --- iMac ---
+		{product: "iMac20,1", want: true},
+		{product: "iMac20,2", want: true},
+		{product: "iMac21,1", want: true},
+		{product: "iMac21,2", want: true},
+
+		// --- MacBook (no suffix) — all x86, line discontinued before Apple Silicon ---
+		{product: "MacBook10,1", want: true},
+		{product: "MacBook9,1", want: true},
+
+		// --- iMacPro — all x86, discontinued before Apple Silicon ---
+		{product: "iMacPro1,1", want: true},
+
+		// --- MacPro — old numbering, all x86 ---
+		{product: "MacPro7,1", want: true},
+		{product: "MacPro6,1", want: true},
+
+		// --- Mac (bare prefix) — unified Apple Silicon naming ---
+		{product: "Mac13,1", want: true},
+		{product: "Mac13,2", want: true},
+		{product: "Mac14,8", want: true},
+		{product: "Mac16,10", want: true},
+
+		// --- Non-Mac Apple devices — return false without error ---
+		{product: "iPhone15,2", want: false},
+		{product: "iPhone14,3", want: false},
+		{product: "iPad13,18", want: false},
+		{product: "iPodTouch9,1", want: false},
+
+		// --- Virtual Mac machines ---
+		{product: "VirtualMac2,1", want: true},
+
+		// --- Error cases ---
+		// Empty string
+		{product: "", wantErr: true},
+		// No comma separator
+		{product: "MacBookPro18", wantErr: true},
+		// Garbage input
+		{product: "not-a-model", wantErr: true},
+		// Non-Mac Apple devices that don't start with iPhone/iPod/iPad return an error
+		{product: "AppleTV6,2", wantErr: true},
+		{product: "AppleTV14,1", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.product, func(t *testing.T) {
+			got, _, _, err := IsMacIdentifier(tc.product)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.want, got)
+			}
+		})
+	}
+}
+
 func TestIsMacAppleSilicon(t *testing.T) {
 	cases := []struct {
 		product string
@@ -1059,6 +1139,7 @@ func TestIsMacAppleSilicon(t *testing.T) {
 		// Non-Mac Apple devices that don't start with iPhone/iPod/iPad return an error
 		{product: "AppleTV6,2", wantErr: true},
 		{product: "AppleTV14,1", wantErr: true},
+		{product: "VirtualMac2,1", wantErr: true},
 	}
 
 	for _, tc := range cases {

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -3847,8 +3847,8 @@ type Datastore interface {
 	// deleted so the caller can log the corresponding activities.
 	BatchSetAppleDDMAssets(ctx context.Context, teamID *uint, assets []*MDMAppleDDMAssetToSet) (*MDMAppleDDMAssetsBatchChanges, error)
 
-	// InsertMacOSSoftwareUpdateDeviceID inserts a new macOS software update device ID for the given host UUID for per-host os update tracking.
-	InsertMacOSSoftwareUpdateDeviceID(ctx context.Context, hostUUID string, updateDeviceID string) error
+	// InsertAppleSoftwareUpdateDeviceID inserts a new Apple software update device ID for the given host UUID for per-host os update tracking.
+	InsertAppleSoftwareUpdateDeviceID(ctx context.Context, hostUUID string, updateDeviceID string) error
 }
 
 type AndroidDatastore interface {

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -3846,6 +3846,9 @@ type Datastore interface {
 	// declaration. It returns the names of the assets it created, edited, and
 	// deleted so the caller can log the corresponding activities.
 	BatchSetAppleDDMAssets(ctx context.Context, teamID *uint, assets []*MDMAppleDDMAssetToSet) (*MDMAppleDDMAssetsBatchChanges, error)
+
+	// InsertMacOSSoftwareUpdateDeviceID inserts a new macOS software update device ID for the given host UUID for per-host os update tracking.
+	InsertMacOSSoftwareUpdateDeviceID(ctx context.Context, hostUUID string, updateDeviceID string) error
 }
 
 type AndroidDatastore interface {

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -13497,7 +13497,7 @@ func (s *DataStore) BatchSetAppleDDMAssets(ctx context.Context, teamID *uint, as
 	return s.BatchSetAppleDDMAssetsFunc(ctx, teamID, assets)
 }
 
-func (s *DataStore) InsertMacOSSoftwareUpdateDeviceID(ctx context.Context, hostUUID string, updateDeviceID string) error {
+func (s *DataStore) InsertAppleSoftwareUpdateDeviceID(ctx context.Context, hostUUID string, updateDeviceID string) error {
 	s.mu.Lock()
 	s.InsertMacOSSoftwareUpdateDeviceIDFuncInvoked = true
 	s.mu.Unlock()

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -2268,6 +2268,8 @@ type GetAppleDDMAssetsReferencedByDeclarationsFunc func(ctx context.Context, dec
 
 type BatchSetAppleDDMAssetsFunc func(ctx context.Context, teamID *uint, assets []*fleet.MDMAppleDDMAssetToSet) (*fleet.MDMAppleDDMAssetsBatchChanges, error)
 
+type InsertMacOSSoftwareUpdateDeviceIDFunc func(ctx context.Context, hostUUID string, updateDeviceID string) error
+
 type DataStore struct {
 	AppConfigFunc        AppConfigFunc
 	AppConfigFuncInvoked bool
@@ -5634,6 +5636,9 @@ type DataStore struct {
 
 	BatchSetAppleDDMAssetsFunc        BatchSetAppleDDMAssetsFunc
 	BatchSetAppleDDMAssetsFuncInvoked bool
+
+	InsertMacOSSoftwareUpdateDeviceIDFunc        InsertMacOSSoftwareUpdateDeviceIDFunc
+	InsertMacOSSoftwareUpdateDeviceIDFuncInvoked bool
 
 	mu sync.Mutex
 }
@@ -13490,4 +13495,11 @@ func (s *DataStore) BatchSetAppleDDMAssets(ctx context.Context, teamID *uint, as
 	s.BatchSetAppleDDMAssetsFuncInvoked = true
 	s.mu.Unlock()
 	return s.BatchSetAppleDDMAssetsFunc(ctx, teamID, assets)
+}
+
+func (s *DataStore) InsertMacOSSoftwareUpdateDeviceID(ctx context.Context, hostUUID string, updateDeviceID string) error {
+	s.mu.Lock()
+	s.InsertMacOSSoftwareUpdateDeviceIDFuncInvoked = true
+	s.mu.Unlock()
+	return s.InsertMacOSSoftwareUpdateDeviceIDFunc(ctx, hostUUID, updateDeviceID)
 }

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -2268,7 +2268,7 @@ type GetAppleDDMAssetsReferencedByDeclarationsFunc func(ctx context.Context, dec
 
 type BatchSetAppleDDMAssetsFunc func(ctx context.Context, teamID *uint, assets []*fleet.MDMAppleDDMAssetToSet) (*fleet.MDMAppleDDMAssetsBatchChanges, error)
 
-type InsertMacOSSoftwareUpdateDeviceIDFunc func(ctx context.Context, hostUUID string, updateDeviceID string) error
+type InsertAppleSoftwareUpdateDeviceIDFunc func(ctx context.Context, hostUUID string, updateDeviceID string) error
 
 type DataStore struct {
 	AppConfigFunc        AppConfigFunc
@@ -5637,8 +5637,8 @@ type DataStore struct {
 	BatchSetAppleDDMAssetsFunc        BatchSetAppleDDMAssetsFunc
 	BatchSetAppleDDMAssetsFuncInvoked bool
 
-	InsertMacOSSoftwareUpdateDeviceIDFunc        InsertMacOSSoftwareUpdateDeviceIDFunc
-	InsertMacOSSoftwareUpdateDeviceIDFuncInvoked bool
+	InsertAppleSoftwareUpdateDeviceIDFunc        InsertAppleSoftwareUpdateDeviceIDFunc
+	InsertAppleSoftwareUpdateDeviceIDFuncInvoked bool
 
 	mu sync.Mutex
 }
@@ -13499,7 +13499,7 @@ func (s *DataStore) BatchSetAppleDDMAssets(ctx context.Context, teamID *uint, as
 
 func (s *DataStore) InsertAppleSoftwareUpdateDeviceID(ctx context.Context, hostUUID string, updateDeviceID string) error {
 	s.mu.Lock()
-	s.InsertMacOSSoftwareUpdateDeviceIDFuncInvoked = true
+	s.InsertAppleSoftwareUpdateDeviceIDFuncInvoked = true
 	s.mu.Unlock()
-	return s.InsertMacOSSoftwareUpdateDeviceIDFunc(ctx, hostUUID, updateDeviceID)
+	return s.InsertAppleSoftwareUpdateDeviceIDFunc(ctx, hostUUID, updateDeviceID)
 }

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -2743,11 +2743,14 @@ func (svc *Service) GetMDMAppleEnrollmentProfileByToken(ctx context.Context, tok
 		return nil, ctxerr.Wrap(ctx, err, "signing profile")
 	}
 
-	// Best-effort: don't block enrollment profile delivery if this write fails.
+	softwareUpdateDeviceID := machineInfo.Product
 	if isMac, _, _, err := fleet.IsMacIdentifier(machineInfo.Product); isMac && err == nil && machineInfo.SoftwareUpdateDeviceID != "" {
-		if err := svc.ds.InsertMacOSSoftwareUpdateDeviceID(ctx, machineInfo.UDID, machineInfo.SoftwareUpdateDeviceID); err != nil {
-			svc.logger.ErrorContext(ctx, "inserting macOS software update device id", "host_uuid", machineInfo.UDID, "err", err)
-		}
+		softwareUpdateDeviceID = machineInfo.SoftwareUpdateDeviceID
+	}
+
+	// Best-effort: don't block enrollment profile delivery if this write fails.
+	if err := svc.ds.InsertAppleSoftwareUpdateDeviceID(ctx, machineInfo.UDID, softwareUpdateDeviceID); err != nil {
+		svc.logger.ErrorContext(ctx, "inserting Apple software update device id", "host_uuid", machineInfo.UDID, "err", err)
 	}
 
 	return signed, nil
@@ -8013,11 +8016,14 @@ func (svc *Service) MDMAppleProcessOTAEnrollment(
 		return nil, ctxerr.Wrap(ctx, err, "signing profile")
 	}
 
-	// Best-effort: don't block enrollment profile delivery if this write fails.
+	softwareUpdateDeviceID := deviceInfo.Product
 	if isMac, _, _, err := fleet.IsMacIdentifier(deviceInfo.Product); isMac && err == nil && deviceInfo.SoftwareUpdateDeviceID != "" {
-		if err := svc.ds.InsertMacOSSoftwareUpdateDeviceID(ctx, deviceInfo.UDID, deviceInfo.SoftwareUpdateDeviceID); err != nil {
-			svc.logger.ErrorContext(ctx, "inserting macOS software update device id", "host_uuid", deviceInfo.UDID, "err", err)
-		}
+		softwareUpdateDeviceID = deviceInfo.SoftwareUpdateDeviceID
+	}
+
+	// Best-effort: don't block enrollment profile delivery if this write fails.
+	if err := svc.ds.InsertAppleSoftwareUpdateDeviceID(ctx, deviceInfo.UDID, softwareUpdateDeviceID); err != nil {
+		svc.logger.ErrorContext(ctx, "inserting Apple software update device id", "host_uuid", deviceInfo.UDID, "err", err)
 	}
 
 	return signed, nil

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -2744,9 +2744,8 @@ func (svc *Service) GetMDMAppleEnrollmentProfileByToken(ctx context.Context, tok
 	}
 
 	// Once we return the enrollment profile, we capture and store the software device id for macOS hosts.
-	if isMac, _, _, err := fleet.IsMacIdentifier(machineInfo.Product); isMac && err == nil {
+	if isMac, _, _, err := fleet.IsMacIdentifier(machineInfo.Product); isMac && err == nil && machineInfo.SoftwareUpdateDeviceID != "" {
 		if err := svc.ds.InsertMacOSSoftwareUpdateDeviceID(ctx, machineInfo.UDID, machineInfo.SoftwareUpdateDeviceID); err != nil {
-			// TODO: Do we want to fail gracefully cathing it with the osquery query?
 			return nil, ctxerr.Wrap(ctx, err, "inserting macOS software update device id")
 		}
 	}
@@ -8015,9 +8014,8 @@ func (svc *Service) MDMAppleProcessOTAEnrollment(
 	}
 
 	// Once we return the enrollment profile, we capture and store the software device id for macOS hosts.
-	if isMac, _, _, err := fleet.IsMacIdentifier(deviceInfo.Product); isMac && err == nil {
+	if isMac, _, _, err := fleet.IsMacIdentifier(deviceInfo.Product); isMac && err == nil && deviceInfo.SoftwareUpdateDeviceID != "" {
 		if err := svc.ds.InsertMacOSSoftwareUpdateDeviceID(ctx, deviceInfo.UDID, deviceInfo.SoftwareUpdateDeviceID); err != nil {
-			// TODO: Do we want to fail gracefully cathing it with the osquery query?
 			return nil, ctxerr.Wrap(ctx, err, "inserting macOS software update device id")
 		}
 	}

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -2743,6 +2743,14 @@ func (svc *Service) GetMDMAppleEnrollmentProfileByToken(ctx context.Context, tok
 		return nil, ctxerr.Wrap(ctx, err, "signing profile")
 	}
 
+	// Once we return the enrollment profile, we capture and store the software device id for macOS hosts.
+	if isMac, _, _, err := fleet.IsMacIdentifier(machineInfo.Product); isMac && err == nil {
+		if err := svc.ds.InsertMacOSSoftwareUpdateDeviceID(ctx, machineInfo.UDID, machineInfo.SoftwareUpdateDeviceID); err != nil {
+			// TODO: Do we want to fail gracefully cathing it with the osquery query?
+			return nil, ctxerr.Wrap(ctx, err, "inserting macOS software update device id")
+		}
+	}
+
 	return signed, nil
 }
 
@@ -8004,6 +8012,14 @@ func (svc *Service) MDMAppleProcessOTAEnrollment(
 	signed, err := mdmcrypto.Sign(ctx, enrollmentProf, svc.ds)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "signing profile")
+	}
+
+	// Once we return the enrollment profile, we capture and store the software device id for macOS hosts.
+	if isMac, _, _, err := fleet.IsMacIdentifier(deviceInfo.Product); isMac && err == nil {
+		if err := svc.ds.InsertMacOSSoftwareUpdateDeviceID(ctx, deviceInfo.UDID, deviceInfo.SoftwareUpdateDeviceID); err != nil {
+			// TODO: Do we want to fail gracefully cathing it with the osquery query?
+			return nil, ctxerr.Wrap(ctx, err, "inserting macOS software update device id")
+		}
 	}
 
 	return signed, nil

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -2743,10 +2743,10 @@ func (svc *Service) GetMDMAppleEnrollmentProfileByToken(ctx context.Context, tok
 		return nil, ctxerr.Wrap(ctx, err, "signing profile")
 	}
 
-	// Once we return the enrollment profile, we capture and store the software device id for macOS hosts.
+	// Best-effort: don't block enrollment profile delivery if this write fails.
 	if isMac, _, _, err := fleet.IsMacIdentifier(machineInfo.Product); isMac && err == nil && machineInfo.SoftwareUpdateDeviceID != "" {
 		if err := svc.ds.InsertMacOSSoftwareUpdateDeviceID(ctx, machineInfo.UDID, machineInfo.SoftwareUpdateDeviceID); err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "inserting macOS software update device id")
+			svc.logger.ErrorContext(ctx, "inserting macOS software update device id", "host_uuid", machineInfo.UDID, "err", err)
 		}
 	}
 
@@ -8013,10 +8013,10 @@ func (svc *Service) MDMAppleProcessOTAEnrollment(
 		return nil, ctxerr.Wrap(ctx, err, "signing profile")
 	}
 
-	// Once we return the enrollment profile, we capture and store the software device id for macOS hosts.
+	// Best-effort: don't block enrollment profile delivery if this write fails.
 	if isMac, _, _, err := fleet.IsMacIdentifier(deviceInfo.Product); isMac && err == nil && deviceInfo.SoftwareUpdateDeviceID != "" {
 		if err := svc.ds.InsertMacOSSoftwareUpdateDeviceID(ctx, deviceInfo.UDID, deviceInfo.SoftwareUpdateDeviceID); err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "inserting macOS software update device id")
+			svc.logger.ErrorContext(ctx, "inserting macOS software update device id", "host_uuid", deviceInfo.UDID, "err", err)
 		}
 	}
 

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -256,6 +256,9 @@ func setupAppleMDMService(t *testing.T, license *fleet.LicenseInfo) (fleet.Servi
 	ds.ListABMTokensFunc = func(ctx context.Context) ([]*fleet.ABMToken, error) {
 		return []*fleet.ABMToken{{ID: 1}}, nil
 	}
+	ds.InsertAppleSoftwareUpdateDeviceIDFunc = func(ctx context.Context, hostUUID, updateDeviceID string) error {
+		return nil
+	}
 
 	return svc, ctx, ds, opts
 }

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -15908,7 +15908,7 @@ func (s *integrationMDMTestSuite) TestEnrollmentProfilesWithSpecialChars() {
 
 	// manual enrollment from My Device
 	token := "token_test_manual_enroll"
-	createHostAndDeviceToken(t, s.ds, token)
+	host := createHostAndDeviceToken(t, s.ds, token)
 	var r getDeviceMDMManualEnrollProfileResponse
 	s.DoJSON("GET", "/api/latest/fleet/device/"+token+"/mdm/apple/manual_enrollment_profile", nil, http.StatusOK, &r)
 	u, err := url.Parse(r.EnrollURL)
@@ -15928,8 +15928,10 @@ func (s *integrationMDMTestSuite) TestEnrollmentProfilesWithSpecialChars() {
 	require.NoError(t, err)
 
 	di, err := mdmtest.EncodeDeviceInfo(fleet.MDMAppleMachineInfo{
-		Serial: uuid.New().String(),
-		UDID:   uuid.New().String(),
+		Serial:                 uuid.New().String(),
+		UDID:                   host.UUID,
+		Product:                "Mac13,1",
+		SoftwareUpdateDeviceID: "bogus-update-id",
 	})
 	require.NoError(t, err)
 	s.downloadAndVerifyEnrollmentProfile(t, optsDownloadEnrollProf{
@@ -15940,6 +15942,15 @@ func (s *integrationMDMTestSuite) TestEnrollmentProfilesWithSpecialChars() {
 
 	// unsigned manual enrollment profile for IT admins
 	s.downloadAndVerifyEnrollmentProfileManual(t)
+
+	// Verify that macOS enrollment inserts entry into os updates tracking
+	mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		var count int
+		err := sqlx.GetContext(ctx, q, &count, `SELECT COUNT(*) FROM host_mdm_apple_os_updates WHERE host_uuid = ?`, host.UUID)
+		require.NoError(t, err)
+		require.Equal(t, 1, count)
+		return nil
+	})
 
 	// ensure the fleetd profile sends a good enroll secret too
 	s.awaitTriggerProfileSchedule(t)
@@ -16120,6 +16131,15 @@ func (s *integrationMDMTestSuite) TestOTAEnrollment() {
 
 			hostByIdentifierResp := verifySuccessfulOTAEnrollment(mdmDevice, hwModel, "darwin", enrollTime)
 			require.Nil(t, hostByIdentifierResp.Host.TeamID)
+
+			// Verify that OTA enrollment upserts the macOS entry for software_device_id.
+			mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+				var count int
+				err := sqlx.GetContext(t.Context(), q, &count, `SELECT COUNT(*) FROM host_mdm_apple_os_updates WHERE host_uuid = ?`, mdmDevice.UUID)
+				require.NoError(t, err)
+				require.Equal(t, 1, count)
+				return nil
+			})
 		})
 
 		t.Run("ota enrolling an ipad", func(t *testing.T) {

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -3307,9 +3307,7 @@ func directIngestMDMMacOSSoftwareUpdateID(ctx context.Context, logger *slog.Logg
 		return nil
 	}
 
-	// inspired by https://github.com/brunerd/macAdminTools/blob/main/Scripts/getSupportedMacOSVersions_ASLS.sh
-	// bridge-model is never used, and it only rely's on board-id and compatible by checking device architecture
-	// however we can just rely on returned values.
+	// Use bridge-model (T2), board-id (Intel), or compatible (Apple Silicon) depending on what's present.
 	var boardID, bridgeModel, compatible string
 	for _, row := range rows {
 		if val, ok := row["key"]; ok && val == "board-id" {
@@ -3321,7 +3319,8 @@ func directIngestMDMMacOSSoftwareUpdateID(ctx context.Context, logger *slog.Logg
 		} else if val, ok := row["key"]; ok && val == "compatible" {
 			// If compatible presents itself, then always take that as that represent an Apple Silicon based mac.
 			// It might be present as well on Intel macs, but then board-id will override the value.
-			compatible = row["value"]
+			v := row["value"]
+			compatible = strings.Split(v, "\x00")[0] // take the first element of the null-separated list. While queries checked does not return multiple, the HEX value does (indicating truncation happens indirectly elsewhere upstream.)
 		}
 	}
 

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -953,7 +953,7 @@ var mdmQueries = map[string]DetailQuery{
 		DirectIngestFunc: directIngestMDMDeviceIDWindows,
 	},
 	"mdm_macos_software_update_id": {
-		Query:            `SELECT key, value FROM ioreg WHERE c = 'IOPlatformExpertDevice' AND key IN ('compatible','bridge-model','board-id');`,
+		Query:            `SELECT key, value FROM ioreg WHERE c = 'IOPlatformExpertDevice' AND key IN ('compatible', 'board-id');`,
 		Platforms:        []string{"darwin"},
 		DirectIngestFunc: directIngestMDMMacOSSoftwareUpdateID,
 		Discovery:        discoveryTable("ioreg"),
@@ -3307,18 +3307,27 @@ func directIngestMDMMacOSSoftwareUpdateID(ctx context.Context, logger *slog.Logg
 		return nil
 	}
 
-	if len(rows) > 1 {
-		// TODO: Can a device ever report more than 1 row? I haven't seen it.
-		return ctxerr.Errorf(ctx, "directIngestMDMMacOSSoftwareUpdateID invalid number of rows: %d", len(rows))
+	// inspired by https://github.com/brunerd/macAdminTools/blob/main/Scripts/getSupportedMacOSVersions_ASLS.sh
+	// bridge-model is never used, and it only rely's on board-id and compatible by checking device architecture
+	// however we can just rely on returned values.
+	var deviceID string
+	for _, row := range rows {
+		if val, ok := row["key"]; ok && val == "board-id" {
+			// If board-id presents itself, then always take that as that represent an Intel based mac.
+			deviceID = row["value"]
+			break
+		} else if val, ok := row["key"]; ok && val == "compatible" {
+			// If compatible presents itself, then always take that as that represent an Apple Silicon based mac.
+			// It might be present as well on Intel macs, but then board-id will override the value.
+			deviceID = row["value"]
+		}
 	}
 
-	softwareUpdateDeviceID := rows[0]["value"]
-
-	if softwareUpdateDeviceID == "" {
+	if deviceID == "" {
 		return ctxerr.Errorf(ctx, "directIngestMDMMacOSSoftwareUpdateID empty software update device ID")
 	}
 
-	return ds.InsertMacOSSoftwareUpdateDeviceID(ctx, host.UUID, softwareUpdateDeviceID)
+	return ds.InsertMacOSSoftwareUpdateDeviceID(ctx, host.UUID, deviceID)
 }
 
 var luksVerifyQuery = DetailQuery{

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -3343,7 +3343,7 @@ func directIngestMDMMacOSSoftwareUpdateID(ctx context.Context, logger *slog.Logg
 		return ctxerr.Errorf(ctx, "directIngestMDMMacOSSoftwareUpdateID empty software update device ID")
 	}
 
-	return ds.InsertMacOSSoftwareUpdateDeviceID(ctx, host.UUID, deviceID)
+	return ds.InsertAppleSoftwareUpdateDeviceID(ctx, host.UUID, deviceID)
 }
 
 var luksVerifyQuery = DetailQuery{

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -3311,14 +3311,14 @@ func directIngestMDMMacOSSoftwareUpdateID(ctx context.Context, logger *slog.Logg
 	var boardID, bridgeModel, compatible string
 	for _, row := range rows {
 		if val, ok := row["key"]; ok && val == "board-id" {
-			// If board-id presents itself, then always take that as that represent an Intel based mac.
+			// board-id identifies Intel-based Macs.
 			boardID = row["value"]
 		} else if val, ok := row["key"]; ok && val == "bridge-model" {
-			// If bridge-model presents itself, then always take that as that represent an Intel based mac. It takes priority over board-id.
+			// bridge-model identifies Intel Macs with a T2 chip; takes priority over board-id.
 			bridgeModel = row["value"]
 		} else if val, ok := row["key"]; ok && val == "compatible" {
-			// If compatible presents itself, then always take that as that represent an Apple Silicon based mac.
-			// It might be present as well on Intel macs, but then board-id will override the value.
+			// compatible identifies Apple Silicon Macs. On Intel Macs it may also
+			// be present, but board-id or bridge-model will take precedence below.
 			v := row["value"]
 			compatible = strings.Split(v, "\x00")[0] // take the first element of the null-separated list. While queries checked does not return multiple, the HEX value does (indicating truncation happens indirectly elsewhere upstream.)
 		}

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -952,6 +952,12 @@ var mdmQueries = map[string]DetailQuery{
 		Platforms:        []string{"windows"},
 		DirectIngestFunc: directIngestMDMDeviceIDWindows,
 	},
+	"mdm_macos_software_update_id": {
+		Query:            `SELECT key, value FROM ioreg WHERE c = 'IOPlatformExpertDevice' AND key IN ('compatible','bridge-model','board-id');`,
+		Platforms:        []string{"darwin"},
+		DirectIngestFunc: directIngestMDMMacOSSoftwareUpdateID,
+		Discovery:        discoveryTable("ioreg"),
+	},
 }
 
 // discoveryTable returns a query to determine whether a table exists or not.
@@ -3294,6 +3300,25 @@ func maybeAssignWindowsEnrollmentDefaultFleet(ctx context.Context, logger *slog.
 	logger.InfoContext(ctx, "assigned windows enrollment default fleet",
 		"host_id", hostID, "team_id", *teamID, "team_name", teamName, "mdm_device_id", device.MDMDeviceID)
 	return nil
+}
+
+func directIngestMDMMacOSSoftwareUpdateID(ctx context.Context, logger *slog.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
+	if len(rows) == 0 {
+		return nil
+	}
+
+	if len(rows) > 1 {
+		// TODO: Can a device ever report more than 1 row? I haven't seen it.
+		return ctxerr.Errorf(ctx, "directIngestMDMMacOSSoftwareUpdateID invalid number of rows: %d", len(rows))
+	}
+
+	softwareUpdateDeviceID := rows[0]["value"]
+
+	if softwareUpdateDeviceID == "" {
+		return ctxerr.Errorf(ctx, "directIngestMDMMacOSSoftwareUpdateID empty software update device ID")
+	}
+
+	return ds.InsertMacOSSoftwareUpdateDeviceID(ctx, host.UUID, softwareUpdateDeviceID)
 }
 
 var luksVerifyQuery = DetailQuery{

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -953,7 +953,7 @@ var mdmQueries = map[string]DetailQuery{
 		DirectIngestFunc: directIngestMDMDeviceIDWindows,
 	},
 	"mdm_macos_software_update_id": {
-		Query:            `SELECT key, value FROM ioreg WHERE c = 'IOPlatformExpertDevice' AND key IN ('compatible', 'board-id');`,
+		Query:            `SELECT key, value FROM ioreg WHERE c = 'IOPlatformExpertDevice' AND key IN ('compatible', 'bridge-model', 'board-id');`,
 		Platforms:        []string{"darwin"},
 		DirectIngestFunc: directIngestMDMMacOSSoftwareUpdateID,
 		Discovery:        discoveryTable("ioreg"),
@@ -3310,17 +3310,34 @@ func directIngestMDMMacOSSoftwareUpdateID(ctx context.Context, logger *slog.Logg
 	// inspired by https://github.com/brunerd/macAdminTools/blob/main/Scripts/getSupportedMacOSVersions_ASLS.sh
 	// bridge-model is never used, and it only rely's on board-id and compatible by checking device architecture
 	// however we can just rely on returned values.
-	var deviceID string
+	var boardID, bridgeModel, compatible string
 	for _, row := range rows {
 		if val, ok := row["key"]; ok && val == "board-id" {
 			// If board-id presents itself, then always take that as that represent an Intel based mac.
-			deviceID = row["value"]
-			break
+			boardID = row["value"]
+		} else if val, ok := row["key"]; ok && val == "bridge-model" {
+			// If bridge-model presents itself, then always take that as that represent an Intel based mac. It takes priority over board-id.
+			bridgeModel = row["value"]
 		} else if val, ok := row["key"]; ok && val == "compatible" {
 			// If compatible presents itself, then always take that as that represent an Apple Silicon based mac.
 			// It might be present as well on Intel macs, but then board-id will override the value.
-			deviceID = row["value"]
+			compatible = row["value"]
 		}
+	}
+
+	var deviceID string
+	if compatible != "" {
+		deviceID = compatible
+	}
+
+	// Always take boardID over compatible.
+	if boardID != "" {
+		deviceID = boardID
+	}
+
+	// Always take bridge-model over boardID
+	if bridgeModel != "" {
+		deviceID = bridgeModel
 	}
 
 	if deviceID == "" {

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -4723,7 +4723,7 @@ func TestDirectIngestMDMMacOSSoftwareUpdateID(t *testing.T) {
 
 	t.Run("apple silicon mac takes compatible", func(t *testing.T) {
 		err := directIngestMDMMacOSSoftwareUpdateID(t.Context(), logger, &host, ds, []map[string]string{
-			{"key": "compatible", "value": "Apple Silicon"},
+			{"key": "compatible", "value": "Apple Silicon\x00Mac16,7"},
 		})
 		require.NoError(t, err)
 		require.True(t, ds.InsertMacOSSoftwareUpdateDeviceIDFuncInvoked)

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -4678,14 +4678,14 @@ func TestDirectIngestMDMMacOSSoftwareUpdateID(t *testing.T) {
 	hostUUID := "test-uuid"
 	host := fleet.Host{ID: 1, UUID: hostUUID}
 	var insertedDeviceID string
-	ds.InsertMacOSSoftwareUpdateDeviceIDFunc = func(ctx context.Context, hostUUID, updateDeviceID string) error {
+	ds.InsertAppleSoftwareUpdateDeviceIDFunc = func(ctx context.Context, hostUUID, updateDeviceID string) error {
 		insertedDeviceID = updateDeviceID
 		return nil
 	}
 
 	t.Run("no rows returns with no error", func(t *testing.T) {
 		require.NoError(t, directIngestMDMMacOSSoftwareUpdateID(t.Context(), logger, &host, ds, []map[string]string{}))
-		require.False(t, ds.InsertMacOSSoftwareUpdateDeviceIDFuncInvoked)
+		require.False(t, ds.InsertAppleSoftwareUpdateDeviceIDFuncInvoked)
 	})
 
 	t.Run("empty value return error", func(t *testing.T) {
@@ -4694,7 +4694,7 @@ func TestDirectIngestMDMMacOSSoftwareUpdateID(t *testing.T) {
 		})
 		require.Error(t, err)
 		require.ErrorContains(t, err, "empty software update device ID")
-		require.False(t, ds.InsertMacOSSoftwareUpdateDeviceIDFuncInvoked)
+		require.False(t, ds.InsertAppleSoftwareUpdateDeviceIDFuncInvoked)
 	})
 
 	t.Run("intel mac takes board-id", func(t *testing.T) {
@@ -4703,10 +4703,10 @@ func TestDirectIngestMDMMacOSSoftwareUpdateID(t *testing.T) {
 			{"key": "board-id", "value": "valid-id"},
 		})
 		require.NoError(t, err)
-		require.True(t, ds.InsertMacOSSoftwareUpdateDeviceIDFuncInvoked)
+		require.True(t, ds.InsertAppleSoftwareUpdateDeviceIDFuncInvoked)
 		require.Equal(t, "valid-id", insertedDeviceID)
 
-		ds.InsertMacOSSoftwareUpdateDeviceIDFuncInvoked = false
+		ds.InsertAppleSoftwareUpdateDeviceIDFuncInvoked = false
 		insertedDeviceID = ""
 	})
 
@@ -4717,7 +4717,7 @@ func TestDirectIngestMDMMacOSSoftwareUpdateID(t *testing.T) {
 			{"key": "board-id", "value": "valid-id"},
 		})
 		require.NoError(t, err)
-		require.True(t, ds.InsertMacOSSoftwareUpdateDeviceIDFuncInvoked)
+		require.True(t, ds.InsertAppleSoftwareUpdateDeviceIDFuncInvoked)
 		require.Equal(t, "valid-bridge-model", insertedDeviceID)
 	})
 
@@ -4726,10 +4726,10 @@ func TestDirectIngestMDMMacOSSoftwareUpdateID(t *testing.T) {
 			{"key": "compatible", "value": "Apple Silicon\x00Mac16,7"},
 		})
 		require.NoError(t, err)
-		require.True(t, ds.InsertMacOSSoftwareUpdateDeviceIDFuncInvoked)
+		require.True(t, ds.InsertAppleSoftwareUpdateDeviceIDFuncInvoked)
 		require.Equal(t, "Apple Silicon", insertedDeviceID)
 
-		ds.InsertMacOSSoftwareUpdateDeviceIDFuncInvoked = false
+		ds.InsertAppleSoftwareUpdateDeviceIDFuncInvoked = false
 		insertedDeviceID = ""
 	})
 }

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -4671,3 +4671,45 @@ func TestMaybeAssignWindowsEnrollmentDefaultFleet(t *testing.T) {
 		})
 	}
 }
+
+func TestDirectIngestMDMMacOSSoftwareUpdateID(t *testing.T) {
+	ds := new(mock.Store)
+	logger := slog.New(slog.DiscardHandler)
+	hostUUID := "test-uuid"
+	host := fleet.Host{ID: 1, UUID: hostUUID}
+	ds.InsertMacOSSoftwareUpdateDeviceIDFunc = func(ctx context.Context, hostUUID, updateDeviceID string) error {
+		return nil
+	}
+
+	t.Run("no rows returns with no error", func(t *testing.T) {
+		require.NoError(t, directIngestMDMMacOSSoftwareUpdateID(t.Context(), logger, &host, ds, []map[string]string{}))
+		require.False(t, ds.InsertMacOSSoftwareUpdateDeviceIDFuncInvoked)
+	})
+
+	t.Run("more than 1 row returns error", func(t *testing.T) {
+		err := directIngestMDMMacOSSoftwareUpdateID(t.Context(), logger, &host, ds, []map[string]string{
+			{"software_update_id": "1"},
+			{"software_update_id": "2"},
+		})
+		require.Error(t, err)
+		require.ErrorContains(t, err, "invalid number of rows")
+		require.False(t, ds.InsertMacOSSoftwareUpdateDeviceIDFuncInvoked)
+	})
+
+	t.Run("empty value return error", func(t *testing.T) {
+		err := directIngestMDMMacOSSoftwareUpdateID(t.Context(), logger, &host, ds, []map[string]string{
+			{"value": ""},
+		})
+		require.Error(t, err)
+		require.ErrorContains(t, err, "empty software update device ID")
+		require.False(t, ds.InsertMacOSSoftwareUpdateDeviceIDFuncInvoked)
+	})
+
+	t.Run("valid value inserts entry", func(t *testing.T) {
+		err := directIngestMDMMacOSSoftwareUpdateID(t.Context(), logger, &host, ds, []map[string]string{
+			{"value": "valid-id"},
+		})
+		require.NoError(t, err)
+		require.True(t, ds.InsertMacOSSoftwareUpdateDeviceIDFuncInvoked)
+	})
+}

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -4677,22 +4677,14 @@ func TestDirectIngestMDMMacOSSoftwareUpdateID(t *testing.T) {
 	logger := slog.New(slog.DiscardHandler)
 	hostUUID := "test-uuid"
 	host := fleet.Host{ID: 1, UUID: hostUUID}
+	var insertedDeviceID string
 	ds.InsertMacOSSoftwareUpdateDeviceIDFunc = func(ctx context.Context, hostUUID, updateDeviceID string) error {
+		insertedDeviceID = updateDeviceID
 		return nil
 	}
 
 	t.Run("no rows returns with no error", func(t *testing.T) {
 		require.NoError(t, directIngestMDMMacOSSoftwareUpdateID(t.Context(), logger, &host, ds, []map[string]string{}))
-		require.False(t, ds.InsertMacOSSoftwareUpdateDeviceIDFuncInvoked)
-	})
-
-	t.Run("more than 1 row returns error", func(t *testing.T) {
-		err := directIngestMDMMacOSSoftwareUpdateID(t.Context(), logger, &host, ds, []map[string]string{
-			{"software_update_id": "1"},
-			{"software_update_id": "2"},
-		})
-		require.Error(t, err)
-		require.ErrorContains(t, err, "invalid number of rows")
 		require.False(t, ds.InsertMacOSSoftwareUpdateDeviceIDFuncInvoked)
 	})
 
@@ -4705,11 +4697,29 @@ func TestDirectIngestMDMMacOSSoftwareUpdateID(t *testing.T) {
 		require.False(t, ds.InsertMacOSSoftwareUpdateDeviceIDFuncInvoked)
 	})
 
-	t.Run("valid value inserts entry", func(t *testing.T) {
+	t.Run("intel mac takes board-id", func(t *testing.T) {
 		err := directIngestMDMMacOSSoftwareUpdateID(t.Context(), logger, &host, ds, []map[string]string{
-			{"value": "valid-id"},
+			{"key": "compatible", "value": "Intel"},
+			{"key": "board-id", "value": "valid-id"},
 		})
 		require.NoError(t, err)
 		require.True(t, ds.InsertMacOSSoftwareUpdateDeviceIDFuncInvoked)
+		require.Equal(t, "valid-id", insertedDeviceID)
+
+		ds.InsertMacOSSoftwareUpdateDeviceIDFuncInvoked = false
+		insertedDeviceID = ""
+	})
+
+	t.Run("apple silicon mac takes compatible", func(t *testing.T) {
+		err := directIngestMDMMacOSSoftwareUpdateID(t.Context(), logger, &host, ds, []map[string]string{
+			{"key": "compatible", "value": "Apple Silicon"},
+			{"key": "bridge-model", "value": "some-value"},
+		})
+		require.NoError(t, err)
+		require.True(t, ds.InsertMacOSSoftwareUpdateDeviceIDFuncInvoked)
+		require.Equal(t, "Apple Silicon", insertedDeviceID)
+
+		ds.InsertMacOSSoftwareUpdateDeviceIDFuncInvoked = false
+		insertedDeviceID = ""
 	})
 }

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -4710,10 +4710,20 @@ func TestDirectIngestMDMMacOSSoftwareUpdateID(t *testing.T) {
 		insertedDeviceID = ""
 	})
 
+	t.Run("intel T2 mac takes bridge-model", func(t *testing.T) {
+		err := directIngestMDMMacOSSoftwareUpdateID(t.Context(), logger, &host, ds, []map[string]string{
+			{"key": "bridge-model", "value": "valid-bridge-model"},
+			{"key": "compatible", "value": "Intel"},
+			{"key": "board-id", "value": "valid-id"},
+		})
+		require.NoError(t, err)
+		require.True(t, ds.InsertMacOSSoftwareUpdateDeviceIDFuncInvoked)
+		require.Equal(t, "valid-bridge-model", insertedDeviceID)
+	})
+
 	t.Run("apple silicon mac takes compatible", func(t *testing.T) {
 		err := directIngestMDMMacOSSoftwareUpdateID(t.Context(), logger, &host, ds, []map[string]string{
 			{"key": "compatible", "value": "Apple Silicon"},
-			{"key": "bridge-model", "value": "some-value"},
 		})
 		require.NoError(t, err)
 		require.True(t, ds.InsertMacOSSoftwareUpdateDeviceIDFuncInvoked)


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #47714 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information. (Will be part of another PR)

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collect and persist macOS software update device identifiers for hosts during both manual and OTA enrollment flows.
  * Added an osquery detail/query to derive the identifier from hardware properties and upsert it into datastore.
* **Bug Fixes**
  * Host deletion now also removes related Apple macOS OS update records.
* **Improved Device Recognition**
  * Enhanced Mac model identifier parsing and refined Apple Silicon detection with expanded test coverage.
* **Reliability**
  * Enrollment profile delivery remains unaffected if saving the identifier fails (errors are logged).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->