### PR TITLE
Fleet UI: Prevent transient Self-service empty state

### DIFF
--- a/changes/50120-fix-self-service-empty-state-flash
+++ b/changes/50120-fix-self-service-empty-state-flash
@@ -1,0 +1,1 @@
+- Fixed the transient empty state shown when changing Self-service search and category filters.

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceCard/SelfServiceCard.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceCard/SelfServiceCard.tests.tsx
@@ -474,7 +474,6 @@ describe("SelfServiceCard", () => {
 
   it("renders empty search state when the search query yields no rows", () => {
     const props = createTestProps({
-      enhancedSoftware: [],
       queryParams: { ...DEFAULT_QUERY_PARAMS, query: "nonexistent" },
     });
     const render = createCustomRenderer({ withBackendMock: true });
@@ -494,6 +493,45 @@ describe("SelfServiceCard", () => {
       name: /Reach out to IT/i,
     });
     expect(contactLink[0]).toHaveAttribute("href", props.contactUrl);
+  });
+
+  it("removes the empty search state immediately when search is cleared", async () => {
+    mockServer.use(
+      listDeviceSelfServiceCategoriesHandler([{ id: 1, name: "🌎 Browsers" }])
+    );
+    const browserPackage = createMockHostSoftwarePackage({
+      categories: (["🌎 Browsers"] as string[]) as SoftwareCategory[],
+    });
+    const props = createTestProps({
+      queryParams: { ...DEFAULT_QUERY_PARAMS, query: "nonexistent" },
+      enhancedSoftware: [
+        {
+          ...createMockDeviceSoftware({ name: "browser" }),
+          ui_status: "installed",
+          software_package: browserPackage,
+        },
+      ],
+    });
+    const render = createCustomRenderer({ withBackendMock: true });
+    const { rerender } = render(<SelfServiceCard {...props} />);
+
+    expect(
+      await screen.findByText("No items match your search")
+    ).toBeInTheDocument();
+    // Ensure the categories request has settled before exercising the update.
+    await screen.findByRole("button", { expanded: false });
+
+    rerender(
+      <SelfServiceCard
+        {...props}
+        queryParams={{ ...DEFAULT_QUERY_PARAMS, query: "" }}
+      />
+    );
+
+    expect(
+      screen.queryByText("No items match your search")
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("browser")).toBeInTheDocument();
   });
 
   it("renders empty-category state when the category filter yields no rows", async () => {

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceCard/SelfServiceCard.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceCard/SelfServiceCard.tests.tsx
@@ -637,7 +637,8 @@ describe("SelfServiceCard", () => {
       await screen.findByText("No items match your search")
     ).toBeInTheDocument();
     // Ensure the categories request has settled before exercising the update.
-    await screen.findByRole("button", { expanded: false });
+    // Trigger renders the current selection label ("All" when none is picked).
+    await screen.findByRole("button", { name: /^All$/i });
 
     rerender(
       <SelfServiceCard

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceCard/SelfServiceCard.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceCard/SelfServiceCard.tests.tsx
@@ -592,7 +592,6 @@ describe("SelfServiceCard", () => {
 
   it("renders empty search state when the search query yields no rows", () => {
     const props = createTestProps({
-      enhancedSoftware: [],
       queryParams: { ...DEFAULT_QUERY_PARAMS, query: "nonexistent" },
     });
     const render = createCustomRenderer({ withBackendMock: true });
@@ -612,6 +611,45 @@ describe("SelfServiceCard", () => {
       name: /Reach out to IT/i,
     });
     expect(contactLink[0]).toHaveAttribute("href", props.contactUrl);
+  });
+
+  it("removes the empty search state immediately when search is cleared", async () => {
+    mockServer.use(
+      listDeviceSelfServiceCategoriesHandler([{ id: 1, name: "🌎 Browsers" }])
+    );
+    const browserPackage = createMockHostSoftwarePackage({
+      categories: (["🌎 Browsers"] as string[]) as SoftwareCategory[],
+    });
+    const props = createTestProps({
+      queryParams: { ...DEFAULT_QUERY_PARAMS, query: "nonexistent" },
+      enhancedSoftware: [
+        {
+          ...createMockDeviceSoftware({ name: "browser" }),
+          ui_status: "installed",
+          software_package: browserPackage,
+        },
+      ],
+    });
+    const render = createCustomRenderer({ withBackendMock: true });
+    const { rerender } = render(<SelfServiceCard {...props} />);
+
+    expect(
+      await screen.findByText("No items match your search")
+    ).toBeInTheDocument();
+    // Ensure the categories request has settled before exercising the update.
+    await screen.findByRole("button", { expanded: false });
+
+    rerender(
+      <SelfServiceCard
+        {...props}
+        queryParams={{ ...DEFAULT_QUERY_PARAMS, query: "" }}
+      />
+    );
+
+    expect(
+      screen.queryByText("No items match your search")
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("browser")).toBeInTheDocument();
   });
 
   it("renders empty-category state when the category filter yields no rows", async () => {

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceCard/SelfServiceCard.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceCard/SelfServiceCard.tsx
@@ -241,14 +241,14 @@ const SelfServiceCard = ({
     );
   }
 
-  // Search query filter required for mobile view only ( desktop view has filter built into TableContainer)
-  const filteredSoftware = isMobileView
-    ? softwareInSelectedCategory.filter((software) => {
-        const query = queryParams.query?.toLowerCase().trim() ?? "";
-        if (!query) return true;
-        return software.name.toLowerCase().includes(query);
-      })
-    : softwareInSelectedCategory;
+  // Filter before rendering either view. TableContainer's client-side filter is
+  // debounced separately from the search field, which can briefly report the
+  // previous result count after the URL query changes.
+  const filteredSoftware = softwareInSelectedCategory.filter((software) => {
+    const query = queryParams.query?.toLowerCase().trim() ?? "";
+    if (!query) return true;
+    return software.name.toLowerCase().includes(query);
+  });
 
   // The button is shown on desktop ONLY when a specific category is selected
   // (`category_id` is defined). On the unfiltered "All" view we suppress it so a

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceCard/SelfServiceCard.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceCard/SelfServiceCard.tsx
@@ -265,7 +265,7 @@ const SelfServiceCard = ({
   // in sync with the current search query. The desktop table used to rely on
   // TableContainer's client-side filter, but that path is debounced separately
   // from the search field and briefly reported the previous zero-result count
-  // when the URL query changed — see #50120.
+  // when the URL query changed.
   const filteredSoftware = softwareInSelectedCategoryMatchingQuery;
 
   // The button is shown on desktop ONLY when a specific category is selected

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceCard/SelfServiceCard.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceCard/SelfServiceCard.tsx
@@ -261,10 +261,12 @@ const SelfServiceCard = ({
     );
   }
 
-  // Search query filter required for mobile view only ( desktop view has filter built into TableContainer)
-  const filteredSoftware = isMobileView
-    ? softwareInSelectedCategoryMatchingQuery
-    : softwareInSelectedCategory;
+  // Filter at this layer for both desktop and mobile so the empty state stays
+  // in sync with the current search query. The desktop table used to rely on
+  // TableContainer's client-side filter, but that path is debounced separately
+  // from the search field and briefly reported the previous zero-result count
+  // when the URL query changed — see #50120.
+  const filteredSoftware = softwareInSelectedCategoryMatchingQuery;
 
   // The button is shown on desktop ONLY when a specific category is selected
   // (`category_id` is defined). On the unfiltered "All" view we suppress it so a

--- a/frontend/pages/hosts/details/cards/Software/SelfService/components/SelfServiceTable/SelfServiceTable.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/components/SelfServiceTable/SelfServiceTable.tsx
@@ -92,9 +92,6 @@ const SelfServiceTable = ({
           initialSortPage === 0
         }
         pageSize={9999}
-        searchQuery={queryParams.query}
-        searchQueryColumn="name"
-        isClientSideFilter
         isClientSidePagination
         disableAutoResetPage
         onClientSidePaginationChange={onClientSidePaginationChange}

--- a/frontend/pages/hosts/details/cards/Software/SelfService/helpers.ts
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/helpers.ts
@@ -100,12 +100,11 @@ export const filterSoftwareByCustomCategory = (
   });
 };
 
-// Client-side name-match filter used by the desktop "Install all" count and
-// the mobile tile list. Kept in sync with `SelfServiceTable`'s
-// `searchQueryColumn="name"` (raw name, case-insensitive contains) and the
-// backend `MatchQuery` on `software_titles.name`. Also drives the `query`
-// param sent to install_all so the button installs exactly what the user
-// sees on screen.
+// Client-side name-match filter used by the desktop table, the mobile tile
+// list, and the "Install all" count. Case-insensitive `includes` on the raw
+// `name`, mirroring the backend `MatchQuery` on `software_titles.name`. Also
+// drives the `query` param sent to install_all so the button installs
+// exactly what the user sees on screen.
 export const filterSoftwareByQuery = (
   software: IDeviceSoftwareWithUiStatus[],
   query: string | undefined


### PR DESCRIPTION
**Related issue:** Resolves #50120

## What changed

- Apply the Self-service name filter before rendering both desktop and mobile views.
- Remove the desktop table's second, debounced copy of the same filter.
- Add a regression test for clearing a search that previously returned no results.

## Why

The search field updates the URL after its debounce, but `TableContainer` then waited another 300 ms before updating its client-side filter. During that gap, its previous zero-result count rendered the empty state even though matching software was available.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually
- [x] Focused SelfServiceCard suite (24 tests)
- [x] TypeScript (`tsc --noEmit`)
- [x] Prettier
- [x] ESLint (zero errors; two pre-existing `any` warnings)


https://github.com/user-attachments/assets/4e4ff404-acf0-4f78-a656-83c7edb0d440



## Checklist for submitter

- [x] Changes file added for this user-visible fix.
- [x] No input, endpoint, database, configuration, or fleetd changes.

This contribution was prepared with AI assistance. The changes and tests were validated locally before submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a brief empty-state flash when changing Self-service search or category filters.
  * Search results now update consistently across desktop and mobile views.
  * Clearing a non-matching search immediately restores the relevant software results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->