### PR TITLE
Document the build-enforced 150-char meta description limit in content skills

### DIFF
--- a/.claude/skills/content-style/references/content-types.md
+++ b/.claude/skills/content-style/references/content-types.md
@@ -50,6 +50,8 @@ Each content type has its own shape. Identify the type first, then apply the mat
 
 Articles, guides, and announcements end with this YAML block. Match `articleTitle` to the H1 exactly. Don't fabricate the author, username, or date — ask if you don't have them.
 
+The 150-character cap on `description` is **enforced by the website build**, not a style preference: `website/scripts/build-static-content.js` throws `An article page has an invalid description meta tag` and fails the whole production build for any page over the limit, whatever its category. Count the characters rather than eyeballing it.
+
 ```
 <meta name="articleTitle" value="[Must match the H1 exactly]">
 <meta name="authorFullName" value="[author name]">

--- a/.claude/skills/fleet-article-formatting/SKILL.md
+++ b/.claude/skills/fleet-article-formatting/SKILL.md
@@ -108,6 +108,15 @@ Fleet pieces typically carry two calls to action, and they play different roles:
 - **The post-takeaways button** (above) — one button, high on the page, for the reader who's already convinced.
 - **The closing CTA** — at the foot of the article, a fuller menu of next steps. This can be a short "See it live" block (a guide link plus one or two bullets such as **Get a demo** → `/contact` and **Join a GitOps training session** → `/gitops-workshop`) and/or an italic CTA line with links. Keep it to the actions that genuinely fit the piece; real links only.
 
+### Endmatter
+
+Every article ends with the `<meta>` block from [`content-style/references/content-types.md`](../content-style/references/content-types.md). Emit it as part of the draft; `assets/article-template.md` already carries it. Two fields need care:
+
+- `articleTitle` matches the H1 exactly, character for character.
+- **`description` must be 150 characters or fewer.** This is enforced by the website build, not a style preference: `website/scripts/build-static-content.js` throws `An article page has an invalid description meta tag` and fails the whole production build for any article over the limit. It applies to every content type that uses this endmatter, articles and comparisons included. Count the characters rather than eyeballing it, since a description that reads like one or two sentences lands near 150 more often than you'd expect. Trim words, don't drop the substance.
+
+Never fabricate `authorFullName`, `authorGitHubUsername`, or `publishedOn`. If you don't have them, leave the placeholders and tell the author which fields to fill in.
+
 ## Voice and terminology
 
 Fleet's voice is confident, specific, and honest. It respects the reader's intelligence and never oversells.
@@ -175,6 +184,7 @@ Use this to bring older Fleet content up to the current format. Work through it 
 - Every capability claim is true and grounded; partial truths are hedged; unverified claims are flagged.
 - No idea is repeated across sections without a reason; formatting is restrained outside the takeaways.
 - Closing lands the through-line without re-listing the takeaways; the top button and closing CTA aren't identical, and all links are real.
+- Endmatter is present, `articleTitle` matches the H1 exactly, and `description` is 150 characters or fewer (counted, not estimated). Author and date are real or flagged, never invented.
 - The `content-style` skill has been run over the prose, and its voice, grammar, and terminology guidance is satisfied.
 
 ## Reference

--- a/.claude/skills/fleet-article-formatting/assets/article-template.md
+++ b/.claude/skills/fleet-article-formatting/assets/article-template.md
@@ -4,7 +4,7 @@
 <meta name="authorFullName" value="">
 <meta name="authorGitHubUsername" value="">
 <meta name="publishedOn" value="YYYY-MM-DD">
-<meta name="description" value="">
+<meta name="description" value="[1-2 sentences. 150 chars max, enforced by the website build. Factual, benefit-driven, no filler.]">
 
 # Title (sentence case, outcome-led)
 

--- a/.claude/skills/fleet-guide-formatting/SKILL.md
+++ b/.claude/skills/fleet-guide-formatting/SKILL.md
@@ -71,7 +71,7 @@ Fill it in like this:
 
 - `articleTitle`: matches the H1 exactly, character for character.
 - `category`: always `guides` for this skill. If it should be anything else, this skill doesn't apply (see Scope).
-- `description`: 1-2 sentences, 150 characters max, factual and benefit-driven. Write this one. It's the only field you can derive from the guide itself.
+- `description`: 1-2 sentences, factual and benefit-driven. Write this one. It's the only field you can derive from the guide itself. **150 characters max, enforced by the website build**, not a style preference: `website/scripts/build-static-content.js` throws `An article page has an invalid description meta tag` and fails the whole production build if you go over. Count the characters rather than eyeballing it, since a description that reads like one or two sentences lands near 150 more often than you'd expect.
 - `authorFullName`, `authorGitHubUsername`, and `publishedOn`: **never fabricate these.** If you don't know the author or the intended publish date, leave the placeholder in place and tell the author which fields they need to fill in.
 
 ## Write a new guide
@@ -97,7 +97,7 @@ Read the file, run the `content-style` skill over it, then check each item. Repo
 - [ ] Has a Verify section if success or failure isn't obvious from the last step.
 - [ ] Troubleshooting entries, if present, lead with a bold symptom, not a generic "Issue:" label.
 - [ ] Ends after the last practical section. No summary or conclusion coda.
-- [ ] Endmatter present and complete: all six `<meta>` tags, `category` is `guides`, `articleTitle` matches the H1 exactly, and `description` is under 150 characters. Author and date are real, or flagged as needing the author's input. Never invented.
+- [ ] Endmatter present and complete: all six `<meta>` tags, `category` is `guides`, `articleTitle` matches the H1 exactly, and `description` is 150 characters or fewer (counted, not estimated, since the website build fails over the limit). Author and date are real, or flagged as needing the author's input. Never invented.
 - [ ] `content-style` was run over the prose in this session, and its findings are reported alongside the structural ones.
 - [ ] **If it has no prerequisites and no concrete steps**, it's not a guide. Recommend recategorizing to `articles` or restructuring around a real procedure. Don't just reshuffle headings on a piece that has no steps to number.
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** N/A

# Checklist for submitter

This PR only edits Claude Code skill files under `.claude/` — no product code, so most of the template below doesn't apply.

## What changed

Documents the **build-enforced 150-character limit on `<meta name="description">`** in the content skills that generate that tag.

`website/scripts/build-static-content.js:687` throws `An article page has an invalid description meta tag` and fails the entire production build for any page whose description exceeds 150 characters, regardless of category. Before this PR:

- `fleet-article-formatting` never mentioned the limit at all. It had **no endmatter section whatsoever**, and `assets/article-template.md` shipped `<meta name="description" value="">` with no guidance in the placeholder.
- `fleet-guide-formatting` and `content-style/references/content-types.md` stated "150 chars max" as what reads like a style preference, with no indication that going over breaks the deploy.

So a draft could satisfy every skill self-check and still fail the build.

Changes:

- **`fleet-article-formatting/SKILL.md`** — new `### Endmatter` section covering the 150-char limit (naming the enforcing script and the error message), `articleTitle` matching the H1 exactly, and the no-fabrication rule for `authorFullName`/`authorGitHubUsername`/`publishedOn`. Added a matching self-check bullet.
- **`fleet-article-formatting/assets/article-template.md`** — filled in the empty `description` placeholder with the constraint.
- **`fleet-guide-formatting/SKILL.md`** — the two existing 150-char mentions now say build-enforced and name the failure mode.
- **`content-style/references/content-types.md`** — same note on the shared endmatter block both skills point at, so it's stated once at the source.

Each spot also says to **count** the characters rather than estimate, which is the actual failure mode: a description that reads like one or two natural sentences lands just over 150 more often than you'd expect.

## Why

Found the hard way. A case study drafted in [#50152](https://github.com/fleetdm/fleet/pull/50152) had a 153-character description that read as perfectly reasonable length and broke `npm run build-for-prod`:

```
Error: Failed compiling markdown content: An article page has an invalid description meta tag
(<meta name="description" value="Hawx automated seasonal iOS onboarding and offboarding with Fleet,
Tines, and Okta, eliminating start-of-season helpdesk floods in a one-month migration.">)
at ".../articles/hawx.md". To resolve, make sure the value of the meta description is less
than 150 characters long.
```

The limit is cheap to respect while drafting and annoying to discover at deploy time, so it belongs in the skills that write the tag.

## Note for reviewers

The proposed `fleet-case-study-formatting` skill in [#49917](https://github.com/fleetdm/fleet/pull/49917) is **not touched here**, deliberately, to avoid a conflict with that open PR. Its `assets/case-study-template.md` already says "150 chars max" in the description placeholder, though its `SKILL.md` doesn't mention the limit. Worth adding the build-enforcement note there before that PR merges, in that PR rather than this one.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`. — N/A, Claude Code config only, not a product change

## Testing

- [ ] Added/updated automated tests — N/A, markdown/config only
- [x] QA'd manually:
  - Traced the constraint to its source at `website/scripts/build-static-content.js:687` and confirmed the quoted error text and the `> 150` comparison, so the skills describe real behavior rather than a remembered rule.
  - Confirmed the check applies to all categories (it runs before the `category === 'case study'` branch), which is why the note went in the shared `content-types.md` block too.
  - Scanned every `<meta name="description">` across `articles/`, `docs/`, and `handbook/`: **0 pages currently exceed 150 characters**, so this is preventive documentation only and no existing content needs fixing.
  - Read the edited skill files back end-to-end for correct rendering and no contradictions with surrounding guidance.
