### PR TITLE
Add risk scoring rubric and mitigation/approval requirements to risk management policy

### DIFF
--- a/handbook/it/security.md
+++ b/handbook/it/security.md
@@ -1679,11 +1679,69 @@ Fleet policy requires:
 - The risk register is monitored quarterly to assess compliance with the above policy, and document newly discovered or created risks.
 
 
+### Risk scoring rubric
+
+Every risk in the risk register is rated on two scales, and the two ratings are multiplied together (`likelihood × impact`) to produce the risk score. The score determines the risk level, the corrective action timeline, and whether approval is required to accept the risk instead of mitigating it.
+
+Likelihood — how likely the risk is to occur:
+
+| Rating | Likelihood      |
+| ------ | --------------- |
+| 1      | Very unlikely   |
+| 2      | Unlikely        |
+| 3      | Somewhat likely |
+| 4      | Likely          |
+| 5      | Very likely     |
+
+Impact — the consequences to Fleet if the risk occurs:
+
+| Rating | Impact           |
+| ------ | ---------------- |
+| 1      | Very low impact  |
+| 2      | Low impact       |
+| 3      | Medium impact    |
+| 4      | High impact      |
+| 5      | Very high impact |
+
+Risk level by score:
+
+| Score   | Risk level |
+| ------- | ---------- |
+| 1–6     | Low        |
+| 7–19    | Medium     |
+| 20–25   | High       |
+
+Scores for every combination of likelihood and impact:
+
+| Impact ↓ / Likelihood → | 1 Very unlikely | 2 Unlikely   | 3 Somewhat likely | 4 Likely     | 5 Very likely |
+| ----------------------- | --------------- | ------------ | ----------------- | ------------ | ------------- |
+| **5 Very high**         | 5 (Low)         | 10 (Medium)  | 15 (Medium)       | 20 (High)    | 25 (High)     |
+| **4 High**              | 4 (Low)         | 8 (Medium)   | 12 (Medium)       | 16 (Medium)  | 20 (High)     |
+| **3 Medium**            | 3 (Low)         | 6 (Low)      | 9 (Medium)        | 12 (Medium)  | 15 (Medium)   |
+| **2 Low**               | 2 (Low)         | 4 (Low)      | 6 (Low)           | 8 (Medium)   | 10 (Medium)   |
+| **1 Very low**          | 1 (Low)         | 2 (Low)      | 3 (Low)           | 4 (Low)      | 5 (Low)       |
+
+
 ### Acceptable Risk Levels
 
 Risks that are either low impact or low probability are generally considered acceptable.
 
 All other risks must be individually reviewed and managed.
+
+
+### Risk mitigation and approval
+
+Whether a risk requires mitigation, and who must approve accepting it, is determined by its risk level:
+
+| Risk level    | Mitigation                                                       | Approval to accept the risk instead of mitigating it                      |
+| ------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| Low (1–6)     | Not required. Mitigate on a best-effort basis.                    | None. Acceptance is recorded in the risk register by the risk owner.       |
+| Medium (7–19) | Required. A documented treatment plan with an owner and due date. | Fleet's Head of Security.                                                 |
+| High (20–25)  | Required. A documented treatment plan with an owner and due date. | Fleet's Head of Security and CIO.                                         |
+
+- Accepting a medium or high risk requires a documented business justification, the compensating controls in place, and an expiration date no longer than one year from the date of approval. Accepted risks must be reviewed and re-evaluated on or before the expiration date.
+- Mitigation work that will not complete within the corrective action timeline below must be treated as an accepted risk for the remaining period and approved accordingly.
+- Rescoring a risk to a lower level requires the same approval as accepting it at its original level.
 
 
 ### Risk corrective action timelines

--- a/handbook/it/security.md
+++ b/handbook/it/security.md
@@ -1733,13 +1733,12 @@ All other risks must be individually reviewed and managed.
 
 Whether a risk requires mitigation, and who must approve accepting it, is determined by its risk level:
 
-| Risk level    | Mitigation                                                       | Approval to accept the risk instead of mitigating it                      |
-| ------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| Low (1–6)     | Not required. Mitigate on a best-effort basis.                    | None. Acceptance is recorded in the risk register by the risk owner.       |
-| Medium (7–19) | Required. A documented treatment plan with an owner and due date. | Fleet's Head of Security.                                                 |
-| High (20–25)  | Required. A documented treatment plan with an owner and due date. | Fleet's Head of Security and CIO.                                         |
+| Risk level               | Mitigation                                                        | Approval to accept the risk instead of mitigating it                 |
+| ------------------------ | ----------------------------------------------------------------- | -------------------------------------------------------------------- |
+| Low (1–6), Medium (7–19) | Not required. Mitigate within the corrective action timeline below on a best-effort basis. | None. Acceptance is recorded in the risk register by the risk owner. |
+| High (20–25)             | Required. A documented treatment plan with an owner and due date.  | Fleet's Head of Security and CIO.                                    |
 
-- Accepting a medium or high risk requires a documented business justification, the compensating controls in place, and an expiration date no longer than one year from the date of approval. Accepted risks must be reviewed and re-evaluated on or before the expiration date.
+- Accepting a high risk requires a documented business justification, the compensating controls in place, and an expiration date no longer than one year from the date of approval. Accepted risks must be reviewed and re-evaluated on or before the expiration date.
 - Mitigation work that will not complete within the corrective action timeline below must be treated as an accepted risk for the remaining period and approved accordingly.
 - Rescoring a risk to a lower level requires the same approval as accepting it at its original level.
 


### PR DESCRIPTION
Adds the risk scoring rubric and mitigation/approval requirements to Fleet's risk management policy in the handbook.

## What changed

Two new sections in `handbook/it/security.md`, between the risk management policy and the existing risk corrective action timelines:

**Risk scoring rubric** — documents how risks in the risk register are scored:
- Likelihood scale (1 Very unlikely → 5 Very likely)
- Impact scale (1 Very low impact → 5 Very high impact)
- Risk score = `likelihood × impact`, with level bands Low (1–6), Medium (7–19), High (20–25)
- The full 5×5 matrix of every likelihood/impact combination

The matrix is built as a native markdown table rather than an embedded screenshot, and each cell states its risk level in text ("20 (High)") instead of relying on color alone, so it renders on fleetdm.com, stays diffable, and is readable without color.

**Risk mitigation and approval** — documents when a risk requires mitigation and who must approve accepting it instead:
- Low and Medium: mitigation not required (best effort, within the corrective action timeline), no approval needed to accept
- High: mitigation required via a documented treatment plan, and accepting it instead requires Head of Security and CIO approval
- Accepting a high risk needs a business justification, compensating controls, and an expiration date no longer than one year, reviewed on or before expiry
- Missing the corrective action timeline is treated as an accepted risk and needs the same approval
- Rescoring a risk down requires the same approval as accepting it at its original level

## Why

The rubric was previously only documented in our risk register tool, and the policy didn't say what triggers mitigation or whose approval is needed to accept a risk. Both are now in the handbook alongside the corrective action timelines they interact with.

## Notes for reviewers

- The level bands are derived from the existing rubric's color boundaries: Low tops out at 6, Medium covers 8–16, High starts at 20. The band ranges are written as 1–6 / 7–19 / 20–25 to cover the gaps that `likelihood × impact` can't produce.
- Only high risks gate on approval. Medium risks are treated the same as low ones: mitigate on a best-effort basis within the existing 120-day corrective action timeline, no approval required to accept. Approval authorities follow the pattern already used elsewhere in this handbook page (policy exceptions require Head of Security and CEO approval), with the CIO as the second approver for high risks.
- The pre-existing "Acceptable Risk Levels" section is left as-is. It says risks that are either low impact or low probability are generally acceptable, which the rubric mostly agrees with, with the exception of very high impact × unlikely (score 10, Medium). Happy to fold that section into the rubric in a follow-up if reviewers prefer one source of truth.

# Checklist for submitter

- [x] Handbook-only change. No code, tests, migrations, configuration settings, or fleetd changes.
