### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/krita/windows.json
+++ b/ee/maintained-apps/outputs/krita/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "5.3.2.1",
+      "version": "5.3.3.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Krita_x64' AND publisher = 'Krita Foundation';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Krita_x64' AND publisher = 'Krita Foundation' AND version_compare(version, '5.3.2.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Krita_x64' AND publisher = 'Krita Foundation' AND version_compare(version, '5.3.3.0') < 0);"
       },
-      "installer_url": "https://download.kde.org/stable/krita/5.3.2.1/krita-x64-5.3.2.1-setup.exe",
+      "installer_url": "https://download.kde.org/stable/krita/5.3.3/krita-x64-5.3.3-setup.exe",
       "install_script_ref": "4899cb9d",
       "uninstall_script_ref": "1259500a",
-      "sha256": "b68c3c1000a0660c79ccb82f7a85e9ede0b9dde055561ceacd0ff2a147040fb8",
+      "sha256": "cf6dc324c1f3bdb5d3069a7f7d7456fcbb6176fab1f09683a52b836fa0d97a05",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/loom/darwin.json
+++ b/ee/maintained-apps/outputs/loom/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.364.1",
+      "version": "0.365.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.loom.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.loom.desktop' AND version_compare(bundle_short_version, '0.364.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.loom.desktop' AND version_compare(bundle_short_version, '0.365.0') < 0);"
       },
-      "installer_url": "https://packages.loom.com/desktop-packages/Loom-0.364.1-arm64.dmg",
+      "installer_url": "https://packages.loom.com/desktop-packages/Loom-0.365.0-arm64.dmg",
       "install_script_ref": "bd0f7905",
       "uninstall_script_ref": "1a901a1f",
-      "sha256": "a8e3d14a90715ddb7ccfd1a941c321a93940637a054944684dea88e4a05e4cf7",
+      "sha256": "a6cba46f99f7cd39d305e6579115bc85b69713c9668a9426dc9e39010ac8e1e9",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/loom/windows.json
+++ b/ee/maintained-apps/outputs/loom/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.364.1",
+      "version": "0.365.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Loom' AND publisher = 'Loom, Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Loom' AND publisher = 'Loom, Inc.' AND version_compare(version, '0.364.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Loom' AND publisher = 'Loom, Inc.' AND version_compare(version, '0.365.0') < 0);"
       },
-      "installer_url": "https://cdn.loom.com/desktop-packages/Loom%20Setup%200.364.1.exe",
+      "installer_url": "https://cdn.loom.com/desktop-packages/Loom%20Setup%200.365.0.exe",
       "install_script_ref": "77327cbf",
       "uninstall_script_ref": "b012f1e7",
-      "sha256": "7672347b4b335d186f467436d90a9a7fd8d83017eb18ca5bab4dc2cc28c62d77",
+      "sha256": "9bf4d6b485b8721b07cd318d2321d0e3578b85e43adbadee7ceba4067f5278b4",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/vivaldi/windows.json
+++ b/ee/maintained-apps/outputs/vivaldi/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "8.1.4087.58",
+      "version": "8.1.4087.61",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Vivaldi' AND publisher = 'Vivaldi Technologies AS.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Vivaldi' AND publisher = 'Vivaldi Technologies AS.' AND version_compare(version, '8.1.4087.58') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Vivaldi' AND publisher = 'Vivaldi Technologies AS.' AND version_compare(version, '8.1.4087.61') < 0);"
       },
-      "installer_url": "https://downloads.vivaldi.com/stable/Vivaldi.8.1.4087.58.x64.exe",
+      "installer_url": "https://downloads.vivaldi.com/stable/Vivaldi.8.1.4087.61.x64.exe",
       "install_script_ref": "d5d49757",
       "uninstall_script_ref": "4e1acf1b",
-      "sha256": "66faca87b1c726deced21779417b594c1fbe55660af97f24b2b0bb263090298b",
+      "sha256": "5f897427cb9caee96751b8b4a08eefb83898008fb5d9ad7e5d1323a1b4b55179",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/zed/darwin.json
+++ b/ee/maintained-apps/outputs/zed/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.12.1",
+      "version": "1.13.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed' AND version_compare(bundle_short_version, '1.12.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed' AND version_compare(bundle_short_version, '1.13.1') < 0);"
       },
-      "installer_url": "https://zed.dev/api/releases/stable/1.12.1/Zed-aarch64.dmg",
+      "installer_url": "https://zed.dev/api/releases/stable/1.13.1/Zed-aarch64.dmg",
       "install_script_ref": "ad597b79",
       "uninstall_script_ref": "0436e2d8",
-      "sha256": "842dbbffc4befb44de0a899ea14263854c2f0336e6f68159f637b98ca96b9fb4",
+      "sha256": "e0f608371ed05b18e08931ba03a120e35d5c5f9359c9edbc58f473b4f7b03651",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/zed/windows.json
+++ b/ee/maintained-apps/outputs/zed/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.12.1",
+      "version": "1.13.1",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Zed' AND publisher = 'Zed Industries';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Zed' AND publisher = 'Zed Industries' AND version_compare(version, '1.12.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Zed' AND publisher = 'Zed Industries' AND version_compare(version, '1.13.1') < 0);"
       },
-      "installer_url": "https://github.com/zed-industries/zed/releases/download/v1.12.1/Zed-x86_64.exe",
+      "installer_url": "https://github.com/zed-industries/zed/releases/download/v1.13.1/Zed-x86_64.exe",
       "install_script_ref": "e5193bc1",
       "uninstall_script_ref": "3b164442",
-      "sha256": "443a94d86011c4b5f39f701543e25998c6478bd18b8357486cea9282faf27597",
+      "sha256": "5699c1651fff0e3bfe7dac1480e45bc8e405f40ea288b19071f0186209809f53",
       "default_categories": [
         "Developer tools"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated installer metadata for Krita on Windows to version 5.3.3.0.
  * Updated Loom for macOS and Windows to version 0.365.0.
  * Updated Vivaldi for Windows to version 8.1.4087.61.
  * Updated Zed for macOS and Windows to version 1.13.1.
  * Refreshed download links, version detection, and installer verification checksums for each release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->