### PR TITLE
Fleet UI: Button icon padding correction

### DIFF
--- a/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
+++ b/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
@@ -7,7 +7,6 @@ import { IConfig } from "interfaces/config";
 import { LEARN_MORE_ABOUT_BASE_LINK } from "utilities/constants";
 
 import Button from "components/buttons/Button";
-import Icon from "components/Icon/Icon";
 import RevealButton from "components/buttons/RevealButton";
 import InputField from "components/forms/fields/InputField";
 import TooltipWrapper from "components/TooltipWrapper";
@@ -201,9 +200,9 @@ const PlatformWrapper = ({
                 variant="secondary"
                 className={`${baseClass}__fleet-certificate-download`}
                 onClick={onDownloadCertificate}
+                rightIcon="download"
               >
                 Download
-                <Icon name="download" size="small" />
               </Button>
             </p>
           ) : (
@@ -393,9 +392,12 @@ const PlatformWrapper = ({
                   Osquery uses an enroll secret to authenticate with the Fleet
                   server.
                   <br />
-                  <Button variant="secondary" onClick={onDownloadEnrollSecret}>
+                  <Button
+                    variant="secondary"
+                    onClick={onDownloadEnrollSecret}
+                    rightIcon="download"
+                  >
                     Download
-                    <Icon name="download" size="small" />
                   </Button>
                 </p>
               </div>
@@ -414,9 +416,12 @@ const PlatformWrapper = ({
                       {fetchCertificateError}
                     </span>
                   ) : (
-                    <Button variant="secondary" onClick={onDownloadFlagfile}>
+                    <Button
+                      variant="secondary"
+                      onClick={onDownloadFlagfile}
+                      rightIcon="download"
+                    >
                       Download
-                      <Icon name="download" size="small" />
                     </Button>
                   )}
                 </p>

--- a/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
+++ b/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
@@ -200,7 +200,8 @@ const PlatformWrapper = ({
                 variant="secondary"
                 className={`${baseClass}__fleet-certificate-download`}
                 onClick={onDownloadCertificate}
-                rightIcon="download"
+                icon="download"
+                iconPosition="right"
               >
                 Download
               </Button>
@@ -395,7 +396,8 @@ const PlatformWrapper = ({
                   <Button
                     variant="secondary"
                     onClick={onDownloadEnrollSecret}
-                    rightIcon="download"
+                    icon="download"
+                    iconPosition="right"
                   >
                     Download
                   </Button>
@@ -419,7 +421,8 @@ const PlatformWrapper = ({
                     <Button
                       variant="secondary"
                       onClick={onDownloadFlagfile}
-                      rightIcon="download"
+                      icon="download"
+                      iconPosition="right"
                     >
                       Download
                     </Button>

--- a/frontend/components/BackButton/BackButton.tsx
+++ b/frontend/components/BackButton/BackButton.tsx
@@ -31,7 +31,7 @@ const BackButton = ({
       variant="subdued"
       onClick={onClick}
       className={classes}
-      leftIcon="chevron-left"
+      icon="chevron-left"
     >
       <span>{text}</span>
     </Button>

--- a/frontend/components/BackButton/BackButton.tsx
+++ b/frontend/components/BackButton/BackButton.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { browserHistory } from "react-router";
 
-import Icon from "components/Icon";
 import classnames from "classnames";
 import Button from "components/buttons/Button";
 
@@ -28,8 +27,12 @@ const BackButton = ({
   };
 
   return (
-    <Button variant="subdued" onClick={onClick} className={classes}>
-      <Icon name="chevron-left" />
+    <Button
+      variant="subdued"
+      onClick={onClick}
+      className={classes}
+      leftIcon="chevron-left"
+    >
       <span>{text}</span>
     </Button>
   );

--- a/frontend/components/EnrollSecrets/EnrollSecretModal/EnrollSecretModal.tsx
+++ b/frontend/components/EnrollSecrets/EnrollSecretModal/EnrollSecretModal.tsx
@@ -7,7 +7,6 @@ import EmptyState from "components/EmptyState";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
 import Modal from "components/Modal";
 import Button from "components/buttons/Button";
-import Icon from "components/Icon/Icon";
 import EnrollSecretTable from "../EnrollSecretTable";
 
 interface IEnrollSecretModal {
@@ -101,8 +100,8 @@ const EnrollSecretModal = ({
                   onClick={addNewSecretClick}
                   className={`${baseClass}__add-secret-btn`}
                   variant="secondary"
+                  leftIcon="plus"
                 >
-                  <Icon name="plus" />
                   Add secret
                 </Button>
               )}
@@ -123,8 +122,8 @@ const EnrollSecretModal = ({
                 onClick={addNewSecretClick}
                 className={`${baseClass}__add-secret-btn`}
                 variant="secondary"
+                leftIcon="plus"
               >
-                <Icon name="plus" />
                 Add secret
               </Button>
             )}

--- a/frontend/components/EnrollSecrets/EnrollSecretModal/EnrollSecretModal.tsx
+++ b/frontend/components/EnrollSecrets/EnrollSecretModal/EnrollSecretModal.tsx
@@ -100,7 +100,7 @@ const EnrollSecretModal = ({
                   onClick={addNewSecretClick}
                   className={`${baseClass}__add-secret-btn`}
                   variant="secondary"
-                  leftIcon="plus"
+                  icon="plus"
                 >
                   Add secret
                 </Button>
@@ -122,7 +122,7 @@ const EnrollSecretModal = ({
                 onClick={addNewSecretClick}
                 className={`${baseClass}__add-secret-btn`}
                 variant="secondary"
-                leftIcon="plus"
+                icon="plus"
               >
                 Add secret
               </Button>

--- a/frontend/components/EnrollSecrets/EnrollSecretTable/EnrollSecretRow/EnrollSecretRow.tsx
+++ b/frontend/components/EnrollSecrets/EnrollSecretTable/EnrollSecretRow/EnrollSecretRow.tsx
@@ -51,6 +51,7 @@ const EnrollSecretRow = ({
             className={`${baseClass}__edit-secret-icon`}
             variant="secondary"
             icon="pencil"
+            ariaLabel="Edit enroll secret"
           />
           <Button
             onClick={onDeleteSecretClick}
@@ -58,6 +59,7 @@ const EnrollSecretRow = ({
             className={`${baseClass}__delete-secret-icon`}
             variant="secondary"
             icon="trash"
+            ariaLabel="Delete enroll secret"
           />
         </div>
       )}

--- a/frontend/components/EnrollSecrets/EnrollSecretTable/EnrollSecretRow/EnrollSecretRow.tsx
+++ b/frontend/components/EnrollSecrets/EnrollSecretTable/EnrollSecretRow/EnrollSecretRow.tsx
@@ -5,7 +5,6 @@ import { IEnrollSecret } from "interfaces/enroll_secret";
 
 import Button from "components/buttons/Button";
 import InputFieldHiddenContent from "components/forms/fields/InputFieldHiddenContent";
-import Icon from "components/Icon";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
 
 const baseClass = "enroll-secrets";
@@ -51,17 +50,15 @@ const EnrollSecretRow = ({
             onClick={onEditSecretClick}
             className={`${baseClass}__edit-secret-icon`}
             variant="secondary"
-          >
-            <Icon name="pencil" />
-          </Button>
+            icon="pencil"
+          />
           <Button
             onClick={onDeleteSecretClick}
             disabled={disableChildren}
             className={`${baseClass}__delete-secret-icon`}
             variant="secondary"
-          >
-            <Icon name="trash" />
-          </Button>
+            icon="trash"
+          />
         </div>
       )}
     />

--- a/frontend/components/FeedListItem/FeedListItem.tsx
+++ b/frontend/components/FeedListItem/FeedListItem.tsx
@@ -88,9 +88,8 @@ const FeedListItem = ({
               variant="subdued"
               onClick={onClickFeedItem}
               ariaLabel="show info"
-            >
-              <Icon name="info-outline" />
-            </Button>
+              icon="info-outline"
+            />
           )}
           {allowCancel && (
             <Button

--- a/frontend/components/FleetsDropdown/FleetsDropdown.tsx
+++ b/frontend/components/FleetsDropdown/FleetsDropdown.tsx
@@ -213,7 +213,8 @@ const CustomMenu = (props: MenuProps<INumberDropdownOption, false>) => {
             variant="subdued"
             onClick={onClickAddFleet}
             size="small"
-            rightIcon="plus"
+            icon="plus"
+            iconPosition="right"
           >
             Add fleet
           </Button>

--- a/frontend/components/FleetsDropdown/FleetsDropdown.tsx
+++ b/frontend/components/FleetsDropdown/FleetsDropdown.tsx
@@ -209,11 +209,13 @@ const CustomMenu = (props: MenuProps<INumberDropdownOption, false>) => {
           onMouseDown={addFleetMouseDown}
           onKeyDown={addFleetKeyDown}
         >
-          <Button variant="subdued" onClick={onClickAddFleet} size="small">
-            <>
-              Add fleet
-              <Icon name="plus" />
-            </>
+          <Button
+            variant="subdued"
+            onClick={onClickAddFleet}
+            size="small"
+            rightIcon="plus"
+          >
+            Add fleet
           </Button>
         </div>
       )}

--- a/frontend/components/Pagination/Pagination.tsx
+++ b/frontend/components/Pagination/Pagination.tsx
@@ -39,8 +39,9 @@ const Pagination = ({
         disabled={disablePrev}
         onClick={onPrevPage}
         className={`${baseClass}__pagination-button`}
+        leftIcon="chevron-left"
       >
-        <Icon name="chevron-left" /> Previous
+        Previous
       </Button>
       <Button
         variant="subdued"

--- a/frontend/components/Pagination/Pagination.tsx
+++ b/frontend/components/Pagination/Pagination.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import classnames from "classnames";
 
 import Button from "components/buttons/Button";
-import Icon from "components/Icon";
 
 const baseClass = "pagination";
 
@@ -39,7 +38,7 @@ const Pagination = ({
         disabled={disablePrev}
         onClick={onPrevPage}
         className={`${baseClass}__pagination-button`}
-        leftIcon="chevron-left"
+        icon="chevron-left"
       >
         Previous
       </Button>
@@ -48,8 +47,10 @@ const Pagination = ({
         disabled={disableNext}
         onClick={onNextPage}
         className={`${baseClass}__pagination-button`}
+        icon="chevron-right"
+        iconPosition="right"
       >
-        Next <Icon name="chevron-right" color="ui-fleet-black-75" />
+        Next
       </Button>
     </div>
   );

--- a/frontend/components/Pagination/_styles.scss
+++ b/frontend/components/Pagination/_styles.scss
@@ -4,5 +4,5 @@
   margin-top: $pad-small;
   margin-left: auto;
   text-align: right;
-  gap: $pad-large;
+  gap: $pad-small;
 }

--- a/frontend/components/TargetsInput/TargetsInputHostsTableConfig.tsx
+++ b/frontend/components/TargetsInput/TargetsInputHostsTableConfig.tsx
@@ -10,7 +10,6 @@ import TextCell from "components/TableContainer/DataTable/TextCell";
 import LiveQueryIssueCell from "components/TableContainer/DataTable/LiveQueryIssueCell/LiveQueryIssueCell";
 import StatusIndicator from "components/StatusIndicator";
 import Button from "components/buttons/Button";
-import Icon from "components/Icon/Icon";
 
 export type ITargestInputHostTableConfig = Column<IHost>;
 type ITableStringCellProps = IStringCellProps<IHost>;
@@ -29,9 +28,8 @@ export const generateTableHeaders = (
             <Button
               onClick={() => handleRowRemove(cellProps.row)}
               variant="subdued"
-            >
-              <Icon name="close-filled" />
-            </Button>
+              icon="close-filled"
+            />
           ),
           disableHidden: true,
         },

--- a/frontend/components/TargetsInput/TargetsInputHostsTableConfig.tsx
+++ b/frontend/components/TargetsInput/TargetsInputHostsTableConfig.tsx
@@ -29,6 +29,7 @@ export const generateTableHeaders = (
               onClick={() => handleRowRemove(cellProps.row)}
               variant="subdued"
               icon="close-filled"
+              ariaLabel="Remove"
             />
           ),
           disableHidden: true,

--- a/frontend/components/buttons/Button/Button.stories.tsx
+++ b/frontend/components/buttons/Button/Button.stories.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { Meta, StoryObj } from "@storybook/react";
-import Icon from "components/Icon";
 import { ButtonVariant, IButtonProps } from "./Button";
 import Button from ".";
 
@@ -34,13 +33,13 @@ type Story = StoryObj<typeof Button>;
 // Base template for NON-loading variants (explicitly hides isLoading)
 const Template = (
   variant: ButtonVariant,
-  children?: JSX.Element,
+  children?: React.ReactNode,
   extraArgs?: Partial<IButtonProps> // e.g. { size: "small" } or { disabled: true }
 ): Story => ({
   args: {
     ...DEFAULT_ARGS,
     variant,
-    children: children || DEFAULT_ARGS.children, // Fall back to default text
+    children: children ?? DEFAULT_ARGS.children, // Fall back to default text
     ...extraArgs,
   },
   argTypes: {
@@ -70,23 +69,25 @@ const createLoadingVariant = (variant: ButtonVariant): Story => ({
 export const DefaultVariant = createLoadingVariant("default");
 // Used for Action dropdown triggers in the product.
 export const DefaultIconAfterVariant = Template("default", undefined, {
-  rightIcon: "chevron-right",
+  icon: "chevron-right",
+  iconPosition: "right",
 });
 
 export const AlertVariant = createLoadingVariant("alert");
 
 // Bordered secondary button — see #35329
 export const SecondaryVariant = Template("secondary");
-export const SecondaryIconAfterVariant = Template("secondary", undefined, {
-  rightIcon: "plus",
-});
 export const SecondaryIconBeforeVariant = Template("secondary", undefined, {
-  leftIcon: "plus",
+  icon: "plus",
 });
-export const SecondaryIconOnlyVariant = Template(
-  "secondary",
-  <Icon name="trash" />
-);
+export const SecondaryIconAfterVariant = Template("secondary", undefined, {
+  icon: "plus",
+  iconPosition: "right",
+});
+export const SecondaryIconOnlyVariant = Template("secondary", null, {
+  icon: "trash",
+  ariaLabel: "Delete",
+});
 export const SecondarySmallVariant = Template("secondary", undefined, {
   size: "small",
 });
@@ -95,7 +96,7 @@ export const SecondarySmallIconBeforeVariant = Template(
   undefined,
   {
     size: "small",
-    leftIcon: "plus",
+    icon: "plus",
   }
 );
 export const SecondaryDisabledVariant = Template("secondary", undefined, {
@@ -103,22 +104,25 @@ export const SecondaryDisabledVariant = Template("secondary", undefined, {
 });
 
 // Borderless subdued button (low-emphasis text + icon)
-export const SubduedIconAfterVariant = Template("subdued", undefined, {
-  rightIcon: "chevron-right",
-});
 export const SubduedIconBeforeVariant = Template("subdued", undefined, {
-  leftIcon: "chevron-left",
+  icon: "chevron-left",
 });
-export const SubduedIconOnlyVariant = Template(
-  "subdued",
-  <Icon name="chevron-right" />
-);
+export const SubduedIconAfterVariant = Template("subdued", undefined, {
+  icon: "chevron-right",
+  iconPosition: "right",
+});
+export const SubduedIconOnlyVariant = Template("subdued", null, {
+  icon: "chevron-right",
+  ariaLabel: "Next",
+});
 export const SubduedSmallVariant = Template("subdued", undefined, {
   size: "small",
-  rightIcon: "chevron-right",
+  icon: "chevron-right",
+  iconPosition: "right",
 });
 export const SubduedDisabledVariant = Template("subdued", undefined, {
-  rightIcon: "chevron-right",
+  icon: "chevron-right",
+  iconPosition: "right",
   disabled: true,
 });
 

--- a/frontend/components/buttons/Button/Button.stories.tsx
+++ b/frontend/components/buttons/Button/Button.stories.tsx
@@ -39,7 +39,7 @@ const Template = (
   args: {
     ...DEFAULT_ARGS,
     variant,
-    children: children ?? DEFAULT_ARGS.children, // Fall back to default text
+    children: children === undefined ? DEFAULT_ARGS.children : children, // Fall back to default text; pass `null` for icon-only stories
     ...extraArgs,
   },
   argTypes: {

--- a/frontend/components/buttons/Button/Button.stories.tsx
+++ b/frontend/components/buttons/Button/Button.stories.tsx
@@ -68,23 +68,30 @@ const createLoadingVariant = (variant: ButtonVariant): Story => ({
 
 // Variants with loading state
 export const DefaultVariant = createLoadingVariant("default");
+export const DefaultIconBeforeVariant = Template("default", undefined, {
+  leftIcon: "plus",
+});
+export const DefaultIconAfterVariant = Template("default", undefined, {
+  rightIcon: "chevron-right",
+});
+export const DefaultSmallIconBeforeVariant = Template("default", undefined, {
+  size: "small",
+  leftIcon: "plus",
+});
+
 export const AlertVariant = createLoadingVariant("alert");
+export const AlertIconBeforeVariant = Template("alert", undefined, {
+  leftIcon: "trash",
+});
 
 // Bordered secondary button — see #35329
 export const SecondaryVariant = Template("secondary");
-export const SecondaryIconAfterVariant = Template(
-  "secondary",
-  <>
-    Button text <Icon name="plus" size="small" />
-  </>
-);
-export const SecondaryIconBeforeVariant = Template(
-  "secondary",
-  <>
-    <Icon name="plus" size="small" />
-    Button text
-  </>
-);
+export const SecondaryIconAfterVariant = Template("secondary", undefined, {
+  rightIcon: "plus",
+});
+export const SecondaryIconBeforeVariant = Template("secondary", undefined, {
+  leftIcon: "plus",
+});
 export const SecondaryIconOnlyVariant = Template(
   "secondary",
   <Icon name="trash" />
@@ -92,42 +99,37 @@ export const SecondaryIconOnlyVariant = Template(
 export const SecondarySmallVariant = Template("secondary", undefined, {
   size: "small",
 });
+export const SecondarySmallIconBeforeVariant = Template(
+  "secondary",
+  undefined,
+  {
+    size: "small",
+    leftIcon: "plus",
+  }
+);
 export const SecondaryDisabledVariant = Template("secondary", undefined, {
   disabled: true,
 });
 
 // Borderless subdued button (low-emphasis text + icon)
-export const SubduedIconAfterVariant = Template(
-  "subdued",
-  <>
-    Button text <Icon name="chevron-right" size="small" />
-  </>
-);
-export const SubduedIconBeforeVariant = Template(
-  "subdued",
-  <>
-    <Icon name="chevron-left" size="small" />
-    Button text
-  </>
-);
+export const SubduedIconAfterVariant = Template("subdued", undefined, {
+  rightIcon: "chevron-right",
+});
+export const SubduedIconBeforeVariant = Template("subdued", undefined, {
+  leftIcon: "chevron-left",
+});
 export const SubduedIconOnlyVariant = Template(
   "subdued",
   <Icon name="chevron-right" />
 );
-export const SubduedSmallVariant = Template(
-  "subdued",
-  <>
-    Button text <Icon name="chevron-right" size="small" />
-  </>,
-  { size: "small" }
-);
-export const SubduedDisabledVariant = Template(
-  "subdued",
-  <>
-    Button text <Icon name="chevron-right" size="small" />
-  </>,
-  { disabled: true }
-);
+export const SubduedSmallVariant = Template("subdued", undefined, {
+  size: "small",
+  rightIcon: "chevron-right",
+});
+export const SubduedDisabledVariant = Template("subdued", undefined, {
+  rightIcon: "chevron-right",
+  disabled: true,
+});
 
 export const PillVariant = Template("pill");
 export const LinkVariant = Template("link");

--- a/frontend/components/buttons/Button/Button.stories.tsx
+++ b/frontend/components/buttons/Button/Button.stories.tsx
@@ -68,21 +68,12 @@ const createLoadingVariant = (variant: ButtonVariant): Story => ({
 
 // Variants with loading state
 export const DefaultVariant = createLoadingVariant("default");
-export const DefaultIconBeforeVariant = Template("default", undefined, {
-  leftIcon: "plus",
-});
+// Used for Action dropdown triggers in the product.
 export const DefaultIconAfterVariant = Template("default", undefined, {
   rightIcon: "chevron-right",
 });
-export const DefaultSmallIconBeforeVariant = Template("default", undefined, {
-  size: "small",
-  leftIcon: "plus",
-});
 
 export const AlertVariant = createLoadingVariant("alert");
-export const AlertIconBeforeVariant = Template("alert", undefined, {
-  leftIcon: "trash",
-});
 
 // Bordered secondary button — see #35329
 export const SecondaryVariant = Template("secondary");

--- a/frontend/components/buttons/Button/Button.tests.tsx
+++ b/frontend/components/buttons/Button/Button.tests.tsx
@@ -85,4 +85,30 @@ describe("Button component", () => {
     );
     expect(container.firstChild).not.toHaveClass("button--icon-only");
   });
+  it("renders a leftIcon and applies the with-left-icon class", () => {
+    const { container } = render(
+      <Button variant="secondary" leftIcon="plus">
+        Add
+      </Button>
+    );
+    expect(container.firstChild).toHaveClass("button--with-left-icon");
+    expect(screen.getByTestId("plus-icon")).toBeInTheDocument();
+  });
+  it("renders a rightIcon and applies the with-right-icon class", () => {
+    const { container } = render(
+      <Button variant="subdued" rightIcon="chevron-right">
+        Next
+      </Button>
+    );
+    expect(container.firstChild).toHaveClass("button--with-right-icon");
+    expect(screen.getByTestId("chevron-right-icon")).toBeInTheDocument();
+  });
+  it("does not add the icon-only class when leftIcon is set with a single icon child", () => {
+    const { container } = render(
+      <Button variant="secondary" leftIcon="plus">
+        <Icon name="trash" />
+      </Button>
+    );
+    expect(container.firstChild).not.toHaveClass("button--icon-only");
+  });
 });

--- a/frontend/components/buttons/Button/Button.tests.tsx
+++ b/frontend/components/buttons/Button/Button.tests.tsx
@@ -112,7 +112,7 @@ describe("Button component", () => {
       screen.getByTestId("chevron-right-icon")
     );
   });
-  it("does not apply icon classes on variants outside the icon-enabled set", () => {
+  it("does not render the icon or apply icon classes on variants outside the icon-enabled set", () => {
     const { container } = render(
       <Button variant="pill" icon="plus">
         Add
@@ -120,6 +120,33 @@ describe("Button component", () => {
     );
     expect(container.firstChild).not.toHaveClass("button--with-icon");
     expect(container.firstChild).not.toHaveClass("button--icon-only");
+    expect(screen.queryByTestId("plus-icon")).not.toBeInTheDocument();
+  });
+  it("auto-colors the icon white on white-text variants (default)", () => {
+    render(
+      <Button variant="default" icon="plus">
+        Add
+      </Button>
+    );
+    expect(
+      screen
+        .getByTestId("plus-icon")
+        .querySelector("path")
+        ?.getAttribute("stroke")
+    ).toContain("core-fleet-white");
+  });
+  it("matches the icon color to the text on secondary/subdued", () => {
+    render(
+      <Button variant="secondary" icon="plus">
+        Add
+      </Button>
+    );
+    expect(
+      screen
+        .getByTestId("plus-icon")
+        .querySelector("path")
+        ?.getAttribute("stroke")
+    ).toContain("ui-fleet-black-75");
   });
   it("adds the icon-only class for a legacy <Icon> child pattern on secondary/subdued", () => {
     // Some call sites keep the child <Icon> pattern to pass color/className.

--- a/frontend/components/buttons/Button/Button.tests.tsx
+++ b/frontend/components/buttons/Button/Button.tests.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { render, fireEvent, screen } from "@testing-library/react";
-import Icon from "components/Icon";
 import Button from "./Button";
 
 describe("Button component", () => {
@@ -69,46 +68,56 @@ describe("Button component", () => {
     );
     expect(container.firstChild).toHaveClass("button--secondary__small");
   });
-  it("adds the icon-only class when a secondary button has only an icon", () => {
+  it("adds the icon-only class on a secondary button with icon and no label", () => {
     const { container } = render(
-      <Button variant="secondary">
-        <Icon name="trash" />
-      </Button>
+      <Button variant="secondary" icon="trash" ariaLabel="Delete" />
     );
     expect(container.firstChild).toHaveClass("button--icon-only");
   });
-  it("does not add the icon-only class when a secondary button has a text label", () => {
-    const { container } = render(
-      <Button variant="secondary">
-        Delete <Icon name="trash" />
-      </Button>
+  it("sizes the icon to small on a small icon-only button", () => {
+    render(
+      <Button
+        variant="secondary"
+        size="small"
+        icon="trash"
+        ariaLabel="Delete"
+      />
     );
-    expect(container.firstChild).not.toHaveClass("button--icon-only");
+    // Small icon = 12px per ICON_SIZES.
+    expect(
+      screen.getByTestId("trash-icon").querySelector("svg")
+    ).toHaveAttribute("width", "12");
   });
-  it("renders a leftIcon and applies the with-left-icon class", () => {
+  it("renders icon left of the label by default and applies the with-icon class", () => {
     const { container } = render(
-      <Button variant="secondary" leftIcon="plus">
+      <Button variant="secondary" icon="plus">
         Add
       </Button>
     );
-    expect(container.firstChild).toHaveClass("button--with-left-icon");
+    expect(container.firstChild).toHaveClass("button--with-icon");
+    expect(container.firstChild).not.toHaveClass("button--icon-only");
     expect(screen.getByTestId("plus-icon")).toBeInTheDocument();
   });
-  it("renders a rightIcon and applies the with-right-icon class", () => {
+  it("renders icon right of the label when iconPosition is right", () => {
     const { container } = render(
-      <Button variant="subdued" rightIcon="chevron-right">
+      <Button variant="subdued" icon="chevron-right" iconPosition="right">
         Next
       </Button>
     );
-    expect(container.firstChild).toHaveClass("button--with-right-icon");
-    expect(screen.getByTestId("chevron-right-icon")).toBeInTheDocument();
+    expect(container.firstChild).toHaveClass("button--with-icon");
+    expect(container.firstChild).not.toHaveClass("button--icon-only");
+    const wrapper = container.querySelector(".children-wrapper");
+    expect(wrapper?.lastElementChild).toBe(
+      screen.getByTestId("chevron-right-icon")
+    );
   });
-  it("does not add the icon-only class when leftIcon is set with a single icon child", () => {
+  it("does not apply icon classes on variants outside the icon-enabled set", () => {
     const { container } = render(
-      <Button variant="secondary" leftIcon="plus">
-        <Icon name="trash" />
+      <Button variant="pill" icon="plus">
+        Add
       </Button>
     );
+    expect(container.firstChild).not.toHaveClass("button--with-icon");
     expect(container.firstChild).not.toHaveClass("button--icon-only");
   });
 });

--- a/frontend/components/buttons/Button/Button.tests.tsx
+++ b/frontend/components/buttons/Button/Button.tests.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { render, fireEvent, screen } from "@testing-library/react";
+import Icon from "components/Icon";
 import Button from "./Button";
 
 describe("Button component", () => {
@@ -119,5 +120,15 @@ describe("Button component", () => {
     );
     expect(container.firstChild).not.toHaveClass("button--with-icon");
     expect(container.firstChild).not.toHaveClass("button--icon-only");
+  });
+  it("adds the icon-only class for a legacy <Icon> child pattern on secondary/subdued", () => {
+    // Some call sites keep the child <Icon> pattern to pass color/className.
+    // We still want the square icon-only styling for those.
+    const { container } = render(
+      <Button variant="secondary" ariaLabel="Close">
+        <Icon name="close" color="core-fleet-black" />
+      </Button>
+    );
+    expect(container.firstChild).toHaveClass("button--icon-only");
   });
 });

--- a/frontend/components/buttons/Button/Button.tests.tsx
+++ b/frontend/components/buttons/Button/Button.tests.tsx
@@ -148,6 +148,16 @@ describe("Button component", () => {
         ?.getAttribute("stroke")
     ).toContain("ui-fleet-black-75");
   });
+  it("treats a false child as no label and applies icon-only styling", () => {
+    // Callers commonly do `{cond && "Label"}` — a false-y cond means no label.
+    const { container } = render(
+      <Button variant="secondary" icon="trash" ariaLabel="Delete">
+        {false && "Delete"}
+      </Button>
+    );
+    expect(container.firstChild).toHaveClass("button--icon-only");
+    expect(container.firstChild).not.toHaveClass("button--with-icon");
+  });
   it("adds the icon-only class for a legacy <Icon> child pattern on secondary/subdued", () => {
     // Some call sites keep the child <Icon> pattern to pass color/className.
     // We still want the square icon-only styling for those.

--- a/frontend/components/buttons/Button/Button.tests.tsx
+++ b/frontend/components/buttons/Button/Button.tests.tsx
@@ -135,6 +135,27 @@ describe("Button component", () => {
         ?.getAttribute("stroke")
     ).toContain("core-fleet-white");
   });
+  it("auto-colors the icon white on the alert variant", () => {
+    render(
+      <Button variant="alert" icon="plus">
+        Delete
+      </Button>
+    );
+    expect(
+      screen
+        .getByTestId("plus-icon")
+        .querySelector("path")
+        ?.getAttribute("stroke")
+    ).toContain("core-fleet-white");
+  });
+  it("does not render the icon on the oversized variant (icons not enabled)", () => {
+    render(
+      <Button variant="oversized" icon="plus">
+        Continue
+      </Button>
+    );
+    expect(screen.queryByTestId("plus-icon")).not.toBeInTheDocument();
+  });
   it("matches the icon color to the text on secondary/subdued", () => {
     render(
       <Button variant="secondary" icon="plus">
@@ -157,6 +178,24 @@ describe("Button component", () => {
     );
     expect(container.firstChild).toHaveClass("button--icon-only");
     expect(container.firstChild).not.toHaveClass("button--with-icon");
+  });
+  it("warns in dev when an icon-only button has neither ariaLabel nor title", () => {
+    const warn = jest
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    render(<Button variant="secondary" icon="trash" />);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("no ariaLabel or title")
+    );
+    warn.mockRestore();
+  });
+  it("does not warn when an icon-only button has a title but no ariaLabel", () => {
+    const warn = jest
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    render(<Button variant="secondary" icon="trash" title="Delete" />);
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
   });
   it("adds the icon-only class for a legacy <Icon> child pattern on secondary/subdued", () => {
     // Some call sites keep the child <Icon> pattern to pass color/className.

--- a/frontend/components/buttons/Button/Button.tsx
+++ b/frontend/components/buttons/Button/Button.tsx
@@ -167,8 +167,11 @@ class Button extends React.Component<IButtonProps, IButtonState> {
       variant === "grey-pill";
     // Icons: 16px on default-size buttons, 12px on small-size buttons.
     const iconSize = size === "small" ? "small" : "medium";
-    // Default (green) buttons have white text — icons should match.
-    const iconColor = variant === "default" ? "core-fleet-white" : undefined;
+    // Default (green) and alert (red) buttons have white text — icons should match.
+    const iconColor =
+      variant === "default" || variant === "alert"
+        ? "core-fleet-white"
+        : undefined;
 
     return (
       <button

--- a/frontend/components/buttons/Button/Button.tsx
+++ b/frontend/components/buttons/Button/Button.tsx
@@ -154,11 +154,14 @@ class Button extends React.Component<IButtonProps, IButtonState> {
       icon,
       iconPosition,
     } = this.props;
-    const hasLabel = React.Children.count(children) > 0;
     // Square, centered layout for a bare icon on secondary/subdued — see #35329.
     // Detects both the modern `icon` prop and the legacy `<Icon>` child pattern
     // used by call sites that need a color/className override on the icon.
+    // `toArray` (not `Children.count`) so `{cond && "text"}` with a false `cond`
+    // reads as "no label" — otherwise the false child still counts as a label
+    // and the visually-lone icon skips its square styling.
     const childArray = React.Children.toArray(children);
+    const hasLabel = childArray.length > 0;
     const hasLoneIconChild =
       !icon &&
       childArray.length === 1 &&
@@ -221,9 +224,9 @@ class Button extends React.Component<IButtonProps, IButtonState> {
             "transparent-text": isLoading,
           })}
         >
-          {iconElement && iconPosition === "left" && iconElement}
+          {iconPosition === "left" && iconElement}
           {children}
-          {iconElement && iconPosition === "right" && iconElement}
+          {iconPosition === "right" && iconElement}
         </div>
         {isLoading && <Spinner small button white={hasWhiteText} delay={0} />}
       </button>

--- a/frontend/components/buttons/Button/Button.tsx
+++ b/frontend/components/buttons/Button/Button.tsx
@@ -186,8 +186,18 @@ class Button extends React.Component<IButtonProps, IButtonState> {
     const hasWhiteText = WHITE_TEXT_VARIANTS.includes(variant!);
     // Icons: 16px on default-size buttons, 12px on small-size buttons.
     const iconSize = size === "small" ? "small" : "medium";
-    const iconColor = hasWhiteText ? "core-fleet-white" : undefined;
-    const iconElement = icon && (
+    // Match the icon to the button text: white on dark-fill variants,
+    // ui-fleet-black-75 on the light secondary/subdued variants.
+    let iconColor: "core-fleet-white" | "ui-fleet-black-75" | undefined;
+    if (hasWhiteText) {
+      iconColor = "core-fleet-white";
+    } else if (variant === "secondary" || variant === "subdued") {
+      iconColor = "ui-fleet-black-75";
+    }
+    // Skip the icon on variants that don't support it — otherwise the SVG
+    // renders unspaced against the label, since the `--with-icon` gap rule is
+    // scoped to ICON_ENABLED_VARIANTS in _styles.scss.
+    const iconElement = icon && ICON_ENABLED_VARIANTS.includes(variant!) && (
       <Icon name={icon} size={iconSize} color={iconColor} />
     );
 

--- a/frontend/components/buttons/Button/Button.tsx
+++ b/frontend/components/buttons/Button/Button.tsx
@@ -18,9 +18,24 @@ export type ButtonVariant =
   | "unstyled-modal-query"
   | "oversized";
 
+// Variants whose text color is white — icons default to white on these.
+const WHITE_TEXT_VARIANTS: readonly ButtonVariant[] = [
+  "default",
+  "alert",
+  "oversized",
+];
+
+// Only these variants participate in icon / iconPosition / icon-only styling.
+const ICON_ENABLED_VARIANTS: readonly ButtonVariant[] = [
+  "default",
+  "alert",
+  "secondary",
+  "subdued",
+];
+
 export interface IButtonProps {
   autofocus?: boolean;
-  children: React.ReactNode;
+  children?: React.ReactNode;
   className?: string;
   disabled?: boolean;
   tabIndex?: number;
@@ -52,10 +67,14 @@ export interface IButtonProps {
   ariaPressed?: boolean;
   /** Small: 1/2 the padding, Wide: 200px */
   size?: "small" | "wide" | "default";
-  /** Renders an icon before the label with icon-side padding trimmed to match design. */
-  leftIcon?: IconNames;
-  /** Renders an icon after the label with icon-side padding trimmed to match design. */
-  rightIcon?: IconNames;
+  /**
+   * Icon rendered inside the button. Sized automatically (16px on default,
+   * 12px on `size="small"`) and colored to match the variant's text.
+   * With no `children`, renders an icon-only square (secondary/subdued only).
+   */
+  icon?: IconNames;
+  /** Where to render `icon` relative to the label. Ignored when icon-only. */
+  iconPosition?: "left" | "right";
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -69,6 +88,7 @@ class Button extends React.Component<IButtonProps, IButtonState> {
   static defaultProps = {
     type: "button",
     variant: "default",
+    iconPosition: "left",
   };
 
   componentDidMount(): void {
@@ -131,21 +151,15 @@ class Button extends React.Component<IButtonProps, IButtonState> {
       ariaLabel,
       ariaPressed,
       size,
-      leftIcon,
-      rightIcon,
+      icon,
+      iconPosition,
     } = this.props;
-    // The bordered "secondary" and borderless "subdued" variants render as a
-    // square when their only content is an icon (no text label) — see #35329.
-    // toArray strips false/null and flattens fragments, so we reliably detect a
-    // lone <Icon> child while ignoring conditional or wrapped text content.
-    const childArray = React.Children.toArray(children);
+    const hasLabel = React.Children.count(children) > 0;
+    // Square, centered layout for a bare icon on secondary/subdued — see #35329.
     const isIconOnly =
-      (variant === "secondary" || variant === "subdued") &&
-      !leftIcon &&
-      !rightIcon &&
-      childArray.length === 1 &&
-      React.isValidElement(childArray[0]) &&
-      childArray[0].type === Icon;
+      !!icon && !hasLabel && (variant === "secondary" || variant === "subdued");
+    const hasIconWithLabel =
+      !!icon && hasLabel && ICON_ENABLED_VARIANTS.includes(variant!);
     const fullClassName = classnames(
       baseClass,
       `${baseClass}--${variant}`,
@@ -155,23 +169,18 @@ class Button extends React.Component<IButtonProps, IButtonState> {
         [`${baseClass}__wide`]: size === "wide",
         [`${baseClass}--disabled`]: disabled,
         [`${baseClass}--icon-only`]: isIconOnly,
-        [`${baseClass}--with-left-icon`]: !!leftIcon,
-        [`${baseClass}--with-right-icon`]: !!rightIcon,
+        [`${baseClass}--with-icon`]: hasIconWithLabel,
       }
     );
-    const onWhite =
-      variant === "link" ||
-      variant === "secondary" ||
-      variant === "subdued" ||
-      variant === "pill" ||
-      variant === "grey-pill";
+    // Variants with white text (dark backgrounds) — icons and the loading
+    // spinner both render white so they're visible.
+    const hasWhiteText = WHITE_TEXT_VARIANTS.includes(variant!);
     // Icons: 16px on default-size buttons, 12px on small-size buttons.
     const iconSize = size === "small" ? "small" : "medium";
-    // Default (green) and alert (red) buttons have white text — icons should match.
-    const iconColor =
-      variant === "default" || variant === "alert"
-        ? "core-fleet-white"
-        : undefined;
+    const iconColor = hasWhiteText ? "core-fleet-white" : undefined;
+    const iconElement = icon && (
+      <Icon name={icon} size={iconSize} color={iconColor} />
+    );
 
     return (
       <button
@@ -188,16 +197,16 @@ class Button extends React.Component<IButtonProps, IButtonState> {
         aria-label={ariaLabel}
         aria-pressed={ariaPressed}
       >
-        <div className={isLoading ? "transparent-text" : "children-wrapper"}>
-          {leftIcon && (
-            <Icon name={leftIcon} size={iconSize} color={iconColor} />
-          )}
+        <div
+          className={classnames("children-wrapper", {
+            "transparent-text": isLoading,
+          })}
+        >
+          {iconElement && iconPosition === "left" && iconElement}
           {children}
-          {rightIcon && (
-            <Icon name={rightIcon} size={iconSize} color={iconColor} />
-          )}
+          {iconElement && iconPosition === "right" && iconElement}
         </div>
-        {isLoading && <Spinner small button white={!onWhite} delay={0} />}
+        {isLoading && <Spinner small button white={hasWhiteText} delay={0} />}
       </button>
     );
   }

--- a/frontend/components/buttons/Button/Button.tsx
+++ b/frontend/components/buttons/Button/Button.tsx
@@ -18,7 +18,9 @@ export type ButtonVariant =
   | "unstyled-modal-query"
   | "oversized";
 
-// Variants whose text color is white — icons default to white on these.
+// Variants whose text color is white — icons and the loading spinner default
+// to white on these. `oversized` is in the list for the spinner; it doesn't
+// render icons (not in ICON_ENABLED_VARIANTS).
 const WHITE_TEXT_VARIANTS: readonly ButtonVariant[] = [
   "default",
   "alert",
@@ -203,6 +205,23 @@ class Button extends React.Component<IButtonProps, IButtonState> {
     const iconElement = icon && ICON_ENABLED_VARIANTS.includes(variant!) && (
       <Icon name={icon} size={iconSize} color={iconColor} />
     );
+    // Icon-only buttons need an explicit accessible name. Browsers fall back
+    // to `title` when `aria-label` is missing, so either satisfies a screen
+    // reader; warn (in dev) when neither is set.
+    if (
+      process.env.NODE_ENV !== "production" &&
+      isIconOnly &&
+      !ariaLabel &&
+      !title
+    ) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `Icon-only Button (icon="${
+          icon ?? "unknown"
+        }") has no ariaLabel or title — ` +
+          `screen readers will announce it as an unlabeled button.`
+      );
+    }
 
     return (
       <button

--- a/frontend/components/buttons/Button/Button.tsx
+++ b/frontend/components/buttons/Button/Button.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import classnames from "classnames";
 import Spinner from "components/Spinner";
 import Icon from "components/Icon";
+import { IconNames } from "components/icons";
 
 const baseClass = "button";
 
@@ -51,6 +52,10 @@ export interface IButtonProps {
   ariaPressed?: boolean;
   /** Small: 1/2 the padding, Wide: 200px */
   size?: "small" | "wide" | "default";
+  /** Renders an icon before the label with icon-side padding trimmed to match design. */
+  leftIcon?: IconNames;
+  /** Renders an icon after the label with icon-side padding trimmed to match design. */
+  rightIcon?: IconNames;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -126,6 +131,8 @@ class Button extends React.Component<IButtonProps, IButtonState> {
       ariaLabel,
       ariaPressed,
       size,
+      leftIcon,
+      rightIcon,
     } = this.props;
     // The bordered "secondary" and borderless "subdued" variants render as a
     // square when their only content is an icon (no text label) — see #35329.
@@ -134,6 +141,8 @@ class Button extends React.Component<IButtonProps, IButtonState> {
     const childArray = React.Children.toArray(children);
     const isIconOnly =
       (variant === "secondary" || variant === "subdued") &&
+      !leftIcon &&
+      !rightIcon &&
       childArray.length === 1 &&
       React.isValidElement(childArray[0]) &&
       childArray[0].type === Icon;
@@ -146,6 +155,8 @@ class Button extends React.Component<IButtonProps, IButtonState> {
         [`${baseClass}__wide`]: size === "wide",
         [`${baseClass}--disabled`]: disabled,
         [`${baseClass}--icon-only`]: isIconOnly,
+        [`${baseClass}--with-left-icon`]: !!leftIcon,
+        [`${baseClass}--with-right-icon`]: !!rightIcon,
       }
     );
     const onWhite =
@@ -154,6 +165,10 @@ class Button extends React.Component<IButtonProps, IButtonState> {
       variant === "subdued" ||
       variant === "pill" ||
       variant === "grey-pill";
+    // Icons: 16px on default-size buttons, 12px on small-size buttons.
+    const iconSize = size === "small" ? "small" : "medium";
+    // Default (green) buttons have white text — icons should match.
+    const iconColor = variant === "default" ? "core-fleet-white" : undefined;
 
     return (
       <button
@@ -171,7 +186,13 @@ class Button extends React.Component<IButtonProps, IButtonState> {
         aria-pressed={ariaPressed}
       >
         <div className={isLoading ? "transparent-text" : "children-wrapper"}>
+          {leftIcon && (
+            <Icon name={leftIcon} size={iconSize} color={iconColor} />
+          )}
           {children}
+          {rightIcon && (
+            <Icon name={rightIcon} size={iconSize} color={iconColor} />
+          )}
         </div>
         {isLoading && <Spinner small button white={!onWhite} delay={0} />}
       </button>

--- a/frontend/components/buttons/Button/Button.tsx
+++ b/frontend/components/buttons/Button/Button.tsx
@@ -156,8 +156,17 @@ class Button extends React.Component<IButtonProps, IButtonState> {
     } = this.props;
     const hasLabel = React.Children.count(children) > 0;
     // Square, centered layout for a bare icon on secondary/subdued — see #35329.
+    // Detects both the modern `icon` prop and the legacy `<Icon>` child pattern
+    // used by call sites that need a color/className override on the icon.
+    const childArray = React.Children.toArray(children);
+    const hasLoneIconChild =
+      !icon &&
+      childArray.length === 1 &&
+      React.isValidElement(childArray[0]) &&
+      childArray[0].type === Icon;
     const isIconOnly =
-      !!icon && !hasLabel && (variant === "secondary" || variant === "subdued");
+      (variant === "secondary" || variant === "subdued") &&
+      ((!!icon && !hasLabel) || hasLoneIconChild);
     const hasIconWithLabel =
       !!icon && hasLabel && ICON_ENABLED_VARIANTS.includes(variant!);
     const fullClassName = classnames(

--- a/frontend/components/buttons/Button/_styles.scss
+++ b/frontend/components/buttons/Button/_styles.scss
@@ -145,6 +145,10 @@ $base-class: "button";
       $core-fleet-green-down
     );
     display: flex;
+
+    &__small {
+      @include button-pad-4px-8px;
+    }
   }
 
   &--success {
@@ -159,6 +163,10 @@ $base-class: "button";
       $core-vibrant-red-down
     );
     display: flex;
+
+    &__small {
+      @include button-pad-4px-8px;
+    }
 
     .loading-spinner {
       &__ring {
@@ -316,6 +324,36 @@ $base-class: "button";
   &--secondary__small.button--icon-only,
   &--subdued__small.button--icon-only {
     width: 28px;
+  }
+
+  // Buttons with leftIcon / rightIcon use uniform 16px horizontal padding and
+  // an 8px gap between icon and label at default size. Small buttons drop to
+  // 8px horizontal padding and a 4px gap. Applies to all variants that carry
+  // an icon (default, alert, secondary, subdued).
+  &--with-left-icon,
+  &--with-right-icon {
+    padding-left: $pad-medium;
+    padding-right: $pad-medium;
+
+    .children-wrapper {
+      gap: $pad-small;
+    }
+  }
+
+  &--default__small.button--with-left-icon,
+  &--default__small.button--with-right-icon,
+  &--alert__small.button--with-left-icon,
+  &--alert__small.button--with-right-icon,
+  &--secondary__small.button--with-left-icon,
+  &--secondary__small.button--with-right-icon,
+  &--subdued__small.button--with-left-icon,
+  &--subdued__small.button--with-right-icon {
+    padding-left: $pad-small;
+    padding-right: $pad-small;
+
+    .children-wrapper {
+      gap: $pad-xsmall;
+    }
   }
 
   &--disabled {

--- a/frontend/components/buttons/Button/_styles.scss
+++ b/frontend/components/buttons/Button/_styles.scss
@@ -326,24 +326,23 @@ $base-class: "button";
     width: 28px;
   }
 
-  // Buttons with leftIcon / rightIcon add an 8px gap between icon and label
-  // (4px on small). Horizontal padding is left to the base variant/size —
-  // it does not change based on icon presence or icon side.
-  &--with-left-icon,
-  &--with-right-icon {
+  // Buttons with an icon + label get an 8px gap between them (4px on small).
+  // Only default, alert, secondary, and subdued carry icons — scoped so the
+  // `icon` prop is a no-op on link, pill, unstyled, etc. Horizontal padding
+  // is left to the base variant/size.
+  &--default.button--with-icon,
+  &--alert.button--with-icon,
+  &--secondary.button--with-icon,
+  &--subdued.button--with-icon {
     .children-wrapper {
       gap: $pad-small;
     }
   }
 
-  &--default__small.button--with-left-icon,
-  &--default__small.button--with-right-icon,
-  &--alert__small.button--with-left-icon,
-  &--alert__small.button--with-right-icon,
-  &--secondary__small.button--with-left-icon,
-  &--secondary__small.button--with-right-icon,
-  &--subdued__small.button--with-left-icon,
-  &--subdued__small.button--with-right-icon {
+  &--default__small.button--with-icon,
+  &--alert__small.button--with-icon,
+  &--secondary__small.button--with-icon,
+  &--subdued__small.button--with-icon {
     .children-wrapper {
       gap: $pad-xsmall;
     }

--- a/frontend/components/buttons/Button/_styles.scss
+++ b/frontend/components/buttons/Button/_styles.scss
@@ -151,11 +151,6 @@ $base-class: "button";
     }
   }
 
-  &--success {
-    @include button-variant($ui-success, $ui-success-over, $ui-success-down);
-    display: flex;
-  }
-
   &--alert {
     @include button-variant(
       $core-vibrant-red,
@@ -429,18 +424,6 @@ $base-class: "button";
     padding: $pad-large $pad-small;
     font-size: $medium;
     width: 100%;
-  }
-
-  // Designed to offset padding for text to justify left of parent component
-  &.button--justify-left {
-    left: -$pad-small;
-    margin-right: -$pad-small;
-  }
-
-  // Designed to offset padding for text to justify right of parent component
-  &.button--justify-right {
-    right: -$pad-small;
-    margin-left: -$pad-small;
   }
 
   // Used in registration/auth pages

--- a/frontend/components/buttons/Button/_styles.scss
+++ b/frontend/components/buttons/Button/_styles.scss
@@ -326,15 +326,11 @@ $base-class: "button";
     width: 28px;
   }
 
-  // Buttons with leftIcon / rightIcon use uniform 16px horizontal padding and
-  // an 8px gap between icon and label at default size. Small buttons drop to
-  // 8px horizontal padding and a 4px gap. Applies to all variants that carry
-  // an icon (default, alert, secondary, subdued).
+  // Buttons with leftIcon / rightIcon add an 8px gap between icon and label
+  // (4px on small). Horizontal padding is left to the base variant/size —
+  // it does not change based on icon presence or icon side.
   &--with-left-icon,
   &--with-right-icon {
-    padding-left: $pad-medium;
-    padding-right: $pad-medium;
-
     .children-wrapper {
       gap: $pad-small;
     }
@@ -348,9 +344,6 @@ $base-class: "button";
   &--secondary__small.button--with-right-icon,
   &--subdued__small.button--with-left-icon,
   &--subdued__small.button--with-right-icon {
-    padding-left: $pad-small;
-    padding-right: $pad-small;
-
     .children-wrapper {
       gap: $pad-xsmall;
     }

--- a/frontend/components/forms/LoginForm/LoginForm.tsx
+++ b/frontend/components/forms/LoginForm/LoginForm.tsx
@@ -135,7 +135,7 @@ const LoginForm = ({
             onClick={() => setShowPendingEmail(false)}
             variant="subdued"
             className="back-link"
-            leftIcon="chevron-left"
+            icon="chevron-left"
           >
             Back to login
           </Button>

--- a/frontend/components/forms/LoginForm/LoginForm.tsx
+++ b/frontend/components/forms/LoginForm/LoginForm.tsx
@@ -4,7 +4,6 @@ import classnames from "classnames";
 import { ILoginUserData } from "interfaces/user";
 
 import CustomLink from "components/CustomLink";
-import Icon from "components/Icon";
 import Button from "components/buttons/Button";
 import TooltipWrapper from "components/TooltipWrapper";
 // @ts-ignore
@@ -136,8 +135,8 @@ const LoginForm = ({
             onClick={() => setShowPendingEmail(false)}
             variant="subdued"
             className="back-link"
+            leftIcon="chevron-left"
           >
-            <Icon name="chevron-left" />
             Back to login
           </Button>
           <h1>Check your email</h1>

--- a/frontend/components/forms/fields/InputField/InputField.tsx
+++ b/frontend/components/forms/fields/InputField/InputField.tsx
@@ -6,7 +6,6 @@ import { PlacesType } from "react-tooltip-5";
 import FormField from "components/forms/FormField";
 import Button from "components/buttons/Button";
 import CopyButton from "components/buttons/CopyButton";
-import Icon from "components/Icon";
 
 const baseClass = "input-field";
 
@@ -153,9 +152,8 @@ const InputField = ({
             onClick={onToggleSecret}
             ariaLabel={showSecret ? "Hide secret" : "Show secret"}
             ariaPressed={showSecret}
-          >
-            <Icon name="eye" />
-          </Button>
+            icon="eye"
+          />
         )}
       </div>
     );

--- a/frontend/components/queries/PackQueriesTable/PackQueriesTable.tsx
+++ b/frontend/components/queries/PackQueriesTable/PackQueriesTable.tsx
@@ -7,7 +7,6 @@ import TableContainer from "components/TableContainer";
 import { ITableQueryData } from "components/TableContainer/TableContainer";
 import Button from "components/buttons/Button";
 import EmptyState from "components/EmptyState";
-import Icon from "components/Icon/Icon";
 import {
   generateTableHeaders,
   generateDataSet,
@@ -113,11 +112,12 @@ const PackQueriesTable = ({
         <EmptyState
           header="Your pack has no reports"
           primaryButton={
-            <Button onClick={onAddPackQuery} variant="secondary">
-              <>
-                Add report
-                <Icon name="plus" />
-              </>
+            <Button
+              onClick={onAddPackQuery}
+              variant="secondary"
+              rightIcon="plus"
+            >
+              Add report
             </Button>
           }
         />

--- a/frontend/components/queries/PackQueriesTable/PackQueriesTable.tsx
+++ b/frontend/components/queries/PackQueriesTable/PackQueriesTable.tsx
@@ -115,7 +115,8 @@ const PackQueriesTable = ({
             <Button
               onClick={onAddPackQuery}
               variant="secondary"
-              rightIcon="plus"
+              icon="plus"
+              iconPosition="right"
             >
               Add report
             </Button>

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/Certificates.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/Certificates.tsx
@@ -15,7 +15,6 @@ import UploadList from "components/UploadList";
 import ActionsDropdown from "components/ActionsDropdown";
 import Button from "components/buttons/Button";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
-import Icon from "components/Icon";
 import ListItem from "components/ListItem";
 import Pagination from "components/Pagination";
 import CustomLink from "components/CustomLink";
@@ -276,9 +275,9 @@ const Certificates = ({
                 size="small"
                 onClick={() => setShowAddCertModal(true)}
                 disabled={disableChildren}
+                icon="plus"
               >
-                <Icon name="plus" size="small" />
-                <span>Add certificate</span>
+                Add certificate
               </Button>
             )}
           />

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/ConfigurationProfiles.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/ConfigurationProfiles.tsx
@@ -21,7 +21,6 @@ import DataError from "components/DataError";
 import EmptyState from "components/EmptyState";
 import Button from "components/buttons/Button";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
-import Icon from "components/Icon";
 import TabNav from "components/TabNav";
 import TabText from "components/TabText";
 
@@ -300,9 +299,9 @@ const ConfigurationProfiles = ({
                         size="small"
                         onClick={() => setShowAddProfileModal(true)}
                         disabled={disableChildren}
+                        icon="plus"
                       >
-                        <Icon name="plus" size="small" />
-                        <span>Add profile</span>
+                        Add profile
                       </Button>
                     )}
                   />

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/AssetListItem/AssetListItem.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/AssetListItem/AssetListItem.tsx
@@ -9,7 +9,6 @@ import { notify } from "components/ToastNotification";
 
 import Button from "components/buttons/Button";
 import CopyButton from "components/buttons/CopyButton";
-import Icon from "components/Icon";
 import ListItem from "components/ListItem";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
 import TooltipTruncatedText from "components/TooltipTruncatedText";
@@ -68,9 +67,8 @@ const AssetListItem = ({
         variant="secondary"
         onClick={onClickDownload}
         ariaLabel={`Download ${asset.name}`}
-      >
-        <Icon name="download" />
-      </Button>
+        icon="download"
+      />
       {!isTechnician && (
         <GitOpsModeTooltipWrapper
           renderChildren={(disableChildren) => (
@@ -80,9 +78,8 @@ const AssetListItem = ({
               variant="secondary"
               onClick={() => onClickDelete(asset)}
               ariaLabel={`Delete ${asset.name}`}
-            >
-              <Icon name="trash" />
-            </Button>
+              icon="trash"
+            />
           )}
         />
       )}

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/AssetsTab/AssetsTab.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/AssetsTab/AssetsTab.tsx
@@ -15,7 +15,6 @@ import Card from "components/Card/Card";
 import DataError from "components/DataError";
 import EmptyState from "components/EmptyState";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
-import Icon from "components/Icon";
 import PageDescription from "components/PageDescription";
 import PremiumFeatureMessage from "components/PremiumFeatureMessage";
 import Spinner from "components/Spinner";
@@ -189,9 +188,9 @@ const AssetsTab = ({ currentTeamId, router }: IAssetsTabProps) => {
                 size="small"
                 onClick={() => setShowAddAssetModal(true)}
                 disabled={disableChildren}
+                icon="plus"
               >
-                <Icon name="plus" size="small" />
-                <span>Add asset</span>
+                Add asset
               </Button>
             )}
           />

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/ProfileListItem/ProfileListItem.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/ProfileListItem/ProfileListItem.tsx
@@ -211,6 +211,7 @@ const ProfileListItem = ({
             variant="secondary"
             onClick={onClickDownload}
             icon="download"
+            ariaLabel={`Download ${profile.name}`}
           />
           {!isTechnician && (
             <GitOpsModeTooltipWrapper

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/ProfileListItem/ProfileListItem.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/ProfileListItem/ProfileListItem.tsx
@@ -193,9 +193,8 @@ const ProfileListItem = ({
             className={`${subClass}__action-button`}
             variant="secondary"
             onClick={() => onClickInfo(profile)}
-          >
-            <Icon name="info" size="medium" />
-          </Button>
+            icon="info"
+          />
           {!isTechnician && (
             // stays enabled in GitOps mode -- the modal is the only place to
             // see a profile's label targeting; it blocks saving instead
@@ -204,17 +203,15 @@ const ProfileListItem = ({
               variant="secondary"
               onClick={() => onClickEdit(profile)}
               ariaLabel={`Edit ${profile.name}`}
-            >
-              <Icon name="pencil" />
-            </Button>
+              icon="pencil"
+            />
           )}
           <Button
             className={`${subClass}__action-button`}
             variant="secondary"
             onClick={onClickDownload}
-          >
-            <Icon name="download" />
-          </Button>
+            icon="download"
+          />
           {!isTechnician && (
             <GitOpsModeTooltipWrapper
               renderChildren={(disableChildren) => (
@@ -223,9 +220,8 @@ const ProfileListItem = ({
                   className={`${subClass}__action-button`}
                   variant="secondary"
                   onClick={() => onClickDelete(profile)}
-                >
-                  <Icon name="trash" />
-                </Button>
+                  icon="trash"
+                />
               )}
             />
           )}

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/ProfileListItem/ProfileListItem.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/ProfileListItem/ProfileListItem.tsx
@@ -194,6 +194,7 @@ const ProfileListItem = ({
             variant="secondary"
             onClick={() => onClickInfo(profile)}
             icon="info"
+            ariaLabel={`View ${profile.name} details`}
           />
           {!isTechnician && (
             // stays enabled in GitOps mode -- the modal is the only place to
@@ -222,6 +223,7 @@ const ProfileListItem = ({
                   variant="secondary"
                   onClick={() => onClickDelete(profile)}
                   icon="trash"
+                  ariaLabel={`Delete ${profile.name}`}
                 />
               )}
             />

--- a/frontend/pages/ManageControlsPage/Scripts/cards/ScriptLibrary/ScriptLibrary.tsx
+++ b/frontend/pages/ManageControlsPage/Scripts/cards/ScriptLibrary/ScriptLibrary.tsx
@@ -28,7 +28,6 @@ import PageDescription from "components/PageDescription";
 import EmptyState from "components/EmptyState";
 import Button from "components/buttons/Button";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
-import Icon from "components/Icon";
 
 import UploadList from "../../../../../components/UploadList";
 import DeleteScriptModal from "../../components/DeleteScriptModal";
@@ -215,9 +214,9 @@ const ScriptLibrary = ({ router, teamId, location }: IScriptLibraryProps) => {
                 size="small"
                 onClick={() => setShowAddScriptModal(true)}
                 disabled={disableChildren}
+                icon="plus"
               >
-                <Icon name="plus" size="small" />
-                <span>Add script</span>
+                Add script
               </Button>
             )}
           />

--- a/frontend/pages/ManageControlsPage/Scripts/components/ScriptListItem/ScriptListItem.tsx
+++ b/frontend/pages/ManageControlsPage/Scripts/components/ScriptListItem/ScriptListItem.tsx
@@ -7,7 +7,6 @@ import { IScript } from "interfaces/script";
 import scriptAPI from "services/entities/scripts";
 
 import Button from "components/buttons/Button";
-import Icon from "components/Icon";
 import ListItem from "components/ListItem";
 import { ISupportedGraphicNames } from "components/ListItem/ListItem";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
@@ -111,9 +110,8 @@ const ScriptListItem = ({
             className={`${baseClass}__action-button`}
             variant="secondary"
             ariaLabel={`Edit ${script.name}`}
-          >
-            <Icon name="pencil" />
-          </Button>
+            icon="pencil"
+          />
         )}
       />
       <Button
@@ -121,9 +119,8 @@ const ScriptListItem = ({
         variant="secondary"
         onClick={onClickDownload}
         ariaLabel={`Download ${script.name}`}
-      >
-        <Icon name="download" />
-      </Button>
+        icon="download"
+      />
       <GitOpsModeTooltipWrapper
         renderChildren={(disableChildren) => (
           <Button
@@ -132,9 +129,8 @@ const ScriptListItem = ({
             className={`${baseClass}__action-button`}
             variant="secondary"
             ariaLabel={`Delete ${script.name}`}
-          >
-            <Icon name="trash" />
-          </Button>
+            icon="trash"
+          />
         )}
       />
     </div>

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/components/BootstrapPackageListItem/BootstrapPackageListItem.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/components/BootstrapPackageListItem/BootstrapPackageListItem.tsx
@@ -5,7 +5,6 @@ import URL_PREFIX from "router/url_prefix";
 import { IBootstrapPackageMetadata } from "interfaces/mdm";
 import endpoints from "utilities/endpoints";
 
-import Icon from "components/Icon";
 import Button from "components/buttons/Button";
 import Graphic from "components/Graphic";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
@@ -44,9 +43,8 @@ const DownloadPackageButton = ({ url, token, className }: ITestFormProps) => {
         variant="subdued"
         type="submit"
         className={`${baseClass}__list-item-button`}
-      >
-        <Icon name="download" />
-      </Button>
+        icon="download"
+      />
     </form>
   );
 };
@@ -90,9 +88,8 @@ const BootstrapPackageListItem = ({
               variant="subdued"
               disabled={disabled}
               onClick={() => onDelete(bootstrapPackage)}
-            >
-              <Icon name="trash" />
-            </Button>
+              icon="trash"
+            />
           )}
         />
       </div>

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/components/BootstrapPackageListItem/BootstrapPackageListItem.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/components/BootstrapPackageListItem/BootstrapPackageListItem.tsx
@@ -44,6 +44,7 @@ const DownloadPackageButton = ({ url, token, className }: ITestFormProps) => {
         type="submit"
         className={`${baseClass}__list-item-button`}
         icon="download"
+        ariaLabel="Download bootstrap package"
       />
     </form>
   );
@@ -89,6 +90,7 @@ const BootstrapPackageListItem = ({
               disabled={disabled}
               onClick={() => onDelete(bootstrapPackage)}
               icon="trash"
+              ariaLabel="Delete bootstrap package"
             />
           )}
         />

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/RunScript/components/SetupExperienceScriptCard/SetupExperienceScriptCard.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/RunScript/components/SetupExperienceScriptCard/SetupExperienceScriptCard.tsx
@@ -10,7 +10,6 @@ import { uploadedFromNow } from "utilities/date_format";
 import Button from "components/buttons/Button";
 import Card from "components/Card";
 import Graphic from "components/Graphic";
-import Icon from "components/Icon";
 import { notify } from "components/ToastNotification";
 import { API_NO_TEAM_ID } from "interfaces/team";
 
@@ -57,16 +56,15 @@ const SetupExperienceScriptCard = ({
           className={`${baseClass}__download-button`}
           variant="secondary"
           onClick={onDownload}
-        >
-          <Icon name="download" />
-        </Button>
+          icon="download"
+        />
         <Button
           className={`${baseClass}__delete-button`}
           variant="secondary"
           onClick={onDelete}
-        >
-          <Icon name="trash" color="ui-fleet-black-75" />
-        </Button>
+          icon="trash"
+          ariaLabel="Delete script"
+        />
       </div>
     </Card>
   );

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/RunScript/components/SetupExperienceScriptCard/SetupExperienceScriptCard.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/RunScript/components/SetupExperienceScriptCard/SetupExperienceScriptCard.tsx
@@ -57,6 +57,7 @@ const SetupExperienceScriptCard = ({
           variant="secondary"
           onClick={onDownload}
           icon="download"
+          ariaLabel="Download script"
         />
         <Button
           className={`${baseClass}__delete-button`}

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/SetupAssistant/components/SetupAssistantProfileCard/SetupAssistantProfileCard.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/SetupAssistant/components/SetupAssistantProfileCard/SetupAssistantProfileCard.tsx
@@ -4,7 +4,6 @@ import classnames from "classnames";
 
 import { uploadedFromNow } from "utilities/date_format";
 
-import Icon from "components/Icon";
 import Card from "components/Card";
 import Graphic from "components/Graphic";
 import Button from "components/buttons/Button";
@@ -83,17 +82,15 @@ const SetupAssistantProfileCard = (props: ISetupAssistantProfileCardProps) => {
           className={`${baseClass}__download-button`}
           variant="secondary"
           onClick={onDownload}
-        >
-          <Icon name="download" />
-        </Button>
+          icon="download"
+        />
         {!props.defaultProfile && (
           <Button
             className={`${baseClass}__delete-button`}
             variant="secondary"
             onClick={props.onDelete}
-          >
-            <Icon name="trash" />
-          </Button>
+            icon="trash"
+          />
         )}
       </div>
     </Card>

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/SetupAssistant/components/SetupAssistantProfileCard/SetupAssistantProfileCard.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/SetupAssistant/components/SetupAssistantProfileCard/SetupAssistantProfileCard.tsx
@@ -83,6 +83,7 @@ const SetupAssistantProfileCard = (props: ISetupAssistantProfileCardProps) => {
           variant="secondary"
           onClick={onDownload}
           icon="download"
+          ariaLabel="Download setup assistant profile"
         />
         {!props.defaultProfile && (
           <Button
@@ -90,6 +91,7 @@ const SetupAssistantProfileCard = (props: ISetupAssistantProfileCardProps) => {
             variant="secondary"
             onClick={props.onDelete}
             icon="trash"
+            ariaLabel="Delete setup assistant profile"
           />
         )}
       </div>

--- a/frontend/pages/ManageControlsPage/Variables/cards/CustomHostVitalsTab/CustomHostVitalsTab.tsx
+++ b/frontend/pages/ManageControlsPage/Variables/cards/CustomHostVitalsTab/CustomHostVitalsTab.tsx
@@ -11,7 +11,6 @@ import customHostVitalsAPI, {
 } from "services/entities/custom_host_vitals";
 
 import Button from "components/buttons/Button";
-import Icon from "components/Icon";
 import Spinner from "components/Spinner";
 import EmptyState from "components/EmptyState";
 import PageDescription from "components/PageDescription";
@@ -165,9 +164,9 @@ const CustomHostVitalsTab: React.FC<IVariablesCardProps> = ({
             size={variant === "secondary" ? "small" : undefined}
             onClick={onClickAdd}
             disabled={disableChildren}
+            icon={variant === "secondary" ? "plus" : undefined}
           >
-            {variant === "secondary" && <Icon name="plus" size="small" />}
-            <span>Add vital</span>
+            Add vital
           </Button>
         )}
       />

--- a/frontend/pages/ManageControlsPage/Variables/cards/GlobalVariables/GlobalVariables.tsx
+++ b/frontend/pages/ManageControlsPage/Variables/cards/GlobalVariables/GlobalVariables.tsx
@@ -22,7 +22,6 @@ import Button from "components/buttons/Button";
 import Spinner from "components/Spinner";
 import EmptyState from "components/EmptyState";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
-import Icon from "components/Icon";
 import PageDescription from "components/PageDescription";
 import TableContainer from "components/TableContainer";
 import { ITableQueryData } from "components/TableContainer/TableContainer";
@@ -189,8 +188,8 @@ const GlobalVariables = ({ router, location }: IGlobalVariablesProps) => {
                 size="small"
                 onClick={onClickAddVariable}
                 disabled={disableChildren}
+                leftIcon="plus"
               >
-                <Icon name="plus" size="small" />
                 <span>Add variable</span>
               </Button>
             )}

--- a/frontend/pages/ManageControlsPage/Variables/cards/GlobalVariables/GlobalVariables.tsx
+++ b/frontend/pages/ManageControlsPage/Variables/cards/GlobalVariables/GlobalVariables.tsx
@@ -190,7 +190,7 @@ const GlobalVariables = ({ router, location }: IGlobalVariablesProps) => {
                 disabled={disableChildren}
                 icon="plus"
               >
-                <span>Add variable</span>
+                Add variable
               </Button>
             )}
           />

--- a/frontend/pages/ManageControlsPage/Variables/cards/GlobalVariables/GlobalVariables.tsx
+++ b/frontend/pages/ManageControlsPage/Variables/cards/GlobalVariables/GlobalVariables.tsx
@@ -188,7 +188,7 @@ const GlobalVariables = ({ router, location }: IGlobalVariablesProps) => {
                 size="small"
                 onClick={onClickAddVariable}
                 disabled={disableChildren}
-                leftIcon="plus"
+                icon="plus"
               >
                 <span>Add variable</span>
               </Button>

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
@@ -22,7 +22,6 @@ import PremiumFeatureMessage from "components/PremiumFeatureMessage";
 import Card from "components/Card";
 import SoftwareIcon from "pages/SoftwarePage/components/icons/SoftwareIcon";
 import Button from "components/buttons/Button";
-import Icon from "components/Icon";
 import PageDescription from "components/PageDescription";
 
 import FleetAppDetailsForm from "./FleetAppDetailsForm";
@@ -92,8 +91,12 @@ const FleetAppSummary = ({
         </div>
       </div>
       <div className={`${baseClass}__fleet-app-summary--show-details`}>
-        <Button variant="subdued" onClick={onClickShowAppDetails}>
-          <Icon name="info" /> Show details
+        <Button
+          variant="subdued"
+          onClick={onClickShowAppDetails}
+          leftIcon="info"
+        >
+          Show details
         </Button>
       </div>
     </Card>

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
@@ -91,11 +91,7 @@ const FleetAppSummary = ({
         </div>
       </div>
       <div className={`${baseClass}__fleet-app-summary--show-details`}>
-        <Button
-          variant="subdued"
-          onClick={onClickShowAppDetails}
-          leftIcon="info"
-        >
+        <Button variant="subdued" onClick={onClickShowAppDetails} icon="info">
           Show details
         </Button>
       </div>

--- a/frontend/pages/SoftwarePage/SoftwareInventory/SoftwareInventoryTable/SoftwareInventoryTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareInventory/SoftwareInventoryTable/SoftwareInventoryTable.tsx
@@ -255,7 +255,7 @@ const SoftwareTable = ({
             variant="secondary"
             onClick={onAddFiltersClick}
             disabled={controlsDisabled}
-            leftIcon="filter"
+            icon="filter"
           >
             <span>{vulnFilterDetails.buttonText}</span>
           </Button>

--- a/frontend/pages/SoftwarePage/SoftwareInventory/SoftwareInventoryTable/SoftwareInventoryTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareInventory/SoftwareInventoryTable/SoftwareInventoryTable.tsx
@@ -24,7 +24,6 @@ import LastUpdatedText from "components/LastUpdatedText";
 import { ITableQueryData } from "components/TableContainer/TableContainer";
 import TableCount from "components/TableContainer/TableCount";
 import Button from "components/buttons/Button";
-import Icon from "components/Icon";
 import TooltipWrapper from "components/TooltipWrapper";
 
 import EmptySoftwareTable from "pages/SoftwarePage/components/tables/EmptySoftwareTable";
@@ -256,8 +255,8 @@ const SoftwareTable = ({
             variant="secondary"
             onClick={onAddFiltersClick}
             disabled={controlsDisabled}
+            leftIcon="filter"
           >
-            <Icon name="filter" />
             <span>{vulnFilterDetails.buttonText}</span>
           </Button>
         </TooltipWrapper>

--- a/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/SelfServiceCategoriesPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/SelfServiceCategoriesPage.tsx
@@ -224,7 +224,7 @@ const SelfServiceCategoriesPage = ({
               <Button
                 variant="secondary"
                 onClick={() => setShowAddModal(true)}
-                leftIcon="plus"
+                icon="plus"
               >
                 Add category
               </Button>

--- a/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/SelfServiceCategoriesPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/SelfServiceCategoriesPage.tsx
@@ -221,8 +221,11 @@ const SelfServiceCategoriesPage = ({
               Self-service categories
             </span>
             {canManage && (
-              <Button variant="secondary" onClick={() => setShowAddModal(true)}>
-                <Icon name="plus" />
+              <Button
+                variant="secondary"
+                onClick={() => setShowAddModal(true)}
+                leftIcon="plus"
+              >
                 Add category
               </Button>
             )}

--- a/frontend/pages/SoftwarePage/SoftwareLibrary/SoftwareLibraryTable/SoftwareLibraryTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareLibrary/SoftwareLibraryTable/SoftwareLibraryTable.tsx
@@ -205,11 +205,7 @@ const SoftwareLibraryTable = ({
   const renderCustomControls = () => {
     return (
       <div className={`${baseClass}__controls`}>
-        <Button
-          variant="secondary"
-          onClick={onClickCategories}
-          leftIcon="settings"
-        >
+        <Button variant="secondary" onClick={onClickCategories} icon="settings">
           Categories
         </Button>
         <Slider

--- a/frontend/pages/SoftwarePage/SoftwareLibrary/SoftwareLibraryTable/SoftwareLibraryTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareLibrary/SoftwareLibraryTable/SoftwareLibraryTable.tsx
@@ -22,7 +22,6 @@ import LastUpdatedText from "components/LastUpdatedText";
 import Slider from "components/forms/fields/Slider";
 import { ITableQueryData } from "components/TableContainer/TableContainer";
 import TableCount from "components/TableContainer/TableCount";
-import Icon from "components/Icon";
 
 import EmptySoftwareTable from "pages/SoftwarePage/components/tables/EmptySoftwareTable";
 
@@ -206,8 +205,12 @@ const SoftwareLibraryTable = ({
   const renderCustomControls = () => {
     return (
       <div className={`${baseClass}__controls`}>
-        <Button variant="secondary" onClick={onClickCategories}>
-          <Icon name="settings" /> Categories
+        <Button
+          variant="secondary"
+          onClick={onClickCategories}
+          leftIcon="settings"
+        >
+          Categories
         </Button>
         <Slider
           value={selfServiceOnly}

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/LibraryItemAccordion/LibraryItemAccordion.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/LibraryItemAccordion/LibraryItemAccordion.tsx
@@ -232,7 +232,7 @@ const LibraryItemAccordion = ({
           size="small"
           onClick={handleBadgeClick(onBadgeClick)}
           className={`${baseClass}__badge-button`}
-          leftIcon={iconName}
+          icon={iconName}
         >
           <span>{label}</span>
         </Button>
@@ -280,9 +280,8 @@ const LibraryItemAccordion = ({
           onClick={handleBadgeClick(onClick)}
           className={`${baseClass}__icon-button`}
           ariaLabel={ariaLabel}
-        >
-          <Icon name={iconName} />
-        </Button>
+          icon={iconName}
+        />
       ) : (
         <Icon name={iconName} />
       )}
@@ -354,7 +353,7 @@ const LibraryItemAccordion = ({
                 size="small"
                 onClick={handleBadgeClick(onLabelCountClick)}
                 className={`${baseClass}__badge-button`}
-                leftIcon="tag"
+                icon="tag"
               >
                 <span>{labelCount}</span>
               </Button>
@@ -375,7 +374,7 @@ const LibraryItemAccordion = ({
               size="small"
               onClick={handleBadgeClick(onLabelCountClick)}
               className={`${baseClass}__badge-button`}
-              leftIcon="tag"
+              icon="tag"
             >
               <span>{ALL_HOSTS_LABEL}</span>
             </Button>
@@ -579,9 +578,8 @@ const LibraryItemAccordion = ({
       onClick={onTrashClick}
       ariaLabel="Delete this version"
       className={`${baseClass}__trash-button`}
-    >
-      <Icon name="trash" />
-    </Button>
+      icon="trash"
+    />
   );
 
   // GitOps-lock the trash button for installer types whose mutations should
@@ -733,9 +731,8 @@ const LibraryItemAccordion = ({
                 onClick={onDownloadClick}
                 ariaLabel="Download installer"
                 className={`${baseClass}__download-button`}
-              >
-                <Icon name="download" />
-              </Button>
+                icon="download"
+              />
             )}
             {canEditSoftware && renderTrashButton()}
           </div>

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/LibraryItemAccordion/LibraryItemAccordion.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/LibraryItemAccordion/LibraryItemAccordion.tsx
@@ -232,8 +232,8 @@ const LibraryItemAccordion = ({
           size="small"
           onClick={handleBadgeClick(onBadgeClick)}
           className={`${baseClass}__badge-button`}
+          leftIcon={iconName}
         >
-          <Icon name={iconName} />
           <span>{label}</span>
         </Button>
       );
@@ -354,8 +354,8 @@ const LibraryItemAccordion = ({
                 size="small"
                 onClick={handleBadgeClick(onLabelCountClick)}
                 className={`${baseClass}__badge-button`}
+                leftIcon="tag"
               >
-                <Icon name="tag" />
                 <span>{labelCount}</span>
               </Button>
             ) : (
@@ -375,8 +375,8 @@ const LibraryItemAccordion = ({
               size="small"
               onClick={handleBadgeClick(onLabelCountClick)}
               className={`${baseClass}__badge-button`}
+              leftIcon="tag"
             >
-              <Icon name="tag" />
               <span>{ALL_HOSTS_LABEL}</span>
             </Button>
           ) : (

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
@@ -41,7 +41,6 @@ import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
 
 import { notify } from "components/ToastNotification";
 import Button from "components/buttons/Button";
-import Icon from "components/Icon";
 import TooltipWrapper from "components/TooltipWrapper";
 import Spinner from "components/Spinner";
 import MainContent from "components/MainContent";
@@ -438,8 +437,8 @@ const SoftwareTitleDetailsPage = ({
         variant="secondary"
         onClick={() => setShowAddPackageModal(true)}
         disabled={atPackageLimit}
+        leftIcon="plus"
       >
-        <Icon name="plus" />
         Add package
       </Button>
     );

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
@@ -437,7 +437,7 @@ const SoftwareTitleDetailsPage = ({
         variant="secondary"
         onClick={() => setShowAddPackageModal(true)}
         disabled={atPackageLimit}
-        leftIcon="plus"
+        icon="plus"
       >
         Add package
       </Button>

--- a/frontend/pages/SoftwarePage/components/cards/SoftwareDetailsSummary/SoftwareDetailsSummary.tsx
+++ b/frontend/pages/SoftwarePage/components/cards/SoftwareDetailsSummary/SoftwareDetailsSummary.tsx
@@ -346,7 +346,7 @@ const SoftwareDetailsSummary = ({
                       variant="subdued"
                       onClick={onClickEditAppearance}
                       disabled={disableChildren || !onClickEditAppearance}
-                      leftIcon="pencil"
+                      icon="pencil"
                     >
                       Edit
                     </Button>

--- a/frontend/pages/SoftwarePage/components/cards/SoftwareDetailsSummary/SoftwareDetailsSummary.tsx
+++ b/frontend/pages/SoftwarePage/components/cards/SoftwareDetailsSummary/SoftwareDetailsSummary.tsx
@@ -26,7 +26,6 @@ import LastUpdatedHostCount from "components/LastUpdatedHostCount";
 import Button from "components/buttons/Button";
 import ActionsDropdown from "components/ActionsDropdown";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
-import Icon from "components/Icon";
 import TooltipWrapper from "components/TooltipWrapper";
 import TooltipTruncatedText from "components/TooltipTruncatedText";
 import CustomLink from "components/CustomLink";
@@ -347,8 +346,8 @@ const SoftwareDetailsSummary = ({
                       variant="subdued"
                       onClick={onClickEditAppearance}
                       disabled={disableChildren || !onClickEditAppearance}
+                      leftIcon="pencil"
                     >
-                      <Icon name="pencil" />
                       Edit
                     </Button>
                   )}

--- a/frontend/pages/SoftwarePage/components/forms/AdvancedOptionsFields/AdvancedOptionsFields.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/AdvancedOptionsFields/AdvancedOptionsFields.tsx
@@ -63,7 +63,12 @@ const AdvancedOptionsFields = ({
     }
 
     return (
-      <Button variant="subdued" onClick={onClickShowSchema} rightIcon="info">
+      <Button
+        variant="subdued"
+        onClick={onClickShowSchema}
+        icon="info"
+        iconPosition="right"
+      >
         Schema
       </Button>
     );

--- a/frontend/pages/SoftwarePage/components/forms/AdvancedOptionsFields/AdvancedOptionsFields.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/AdvancedOptionsFields/AdvancedOptionsFields.tsx
@@ -4,7 +4,6 @@ import classnames from "classnames";
 import Editor from "components/Editor";
 import SQLEditor from "components/SQLEditor";
 import Button from "components/buttons/Button";
-import Icon from "components/Icon";
 
 const baseClass = "advanced-options-fields";
 
@@ -64,9 +63,8 @@ const AdvancedOptionsFields = ({
     }
 
     return (
-      <Button variant="subdued" onClick={onClickShowSchema}>
+      <Button variant="subdued" onClick={onClickShowSchema} rightIcon="info">
         Schema
-        <Icon name="info" size="small" />
       </Button>
     );
   };

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CertAuthorityListHeader/CertAuthorityListHeader.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CertAuthorityListHeader/CertAuthorityListHeader.tsx
@@ -1,6 +1,5 @@
 import Button from "components/buttons/Button";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
-import Icon from "components/Icon";
 import React from "react";
 
 const baseClass = "cert-authority-list-header";
@@ -24,11 +23,9 @@ const CertAuthorityListHeader = ({
               variant="secondary"
               className={`${baseClass}__add-button`}
               onClick={onClickAddCertAuthority}
+              leftIcon="plus"
             >
-              <>
-                <Icon name="plus" />
-                Add CA
-              </>
+              Add CA
             </Button>
           )}
         />

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CertAuthorityListHeader/CertAuthorityListHeader.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CertAuthorityListHeader/CertAuthorityListHeader.tsx
@@ -23,7 +23,7 @@ const CertAuthorityListHeader = ({
               variant="secondary"
               className={`${baseClass}__add-button`}
               onClick={onClickAddCertAuthority}
-              leftIcon="plus"
+              icon="plus"
             >
               Add CA
             </Button>

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CertAuthorityListItem/CertAuthorityListItem.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CertAuthorityListItem/CertAuthorityListItem.tsx
@@ -3,7 +3,6 @@ import React from "react";
 import ListItem from "components/ListItem";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
 import Button from "components/buttons/Button";
-import Icon from "components/Icon";
 import { ICertAuthorityListData } from "../CertificateAuthorityList/CertificateAuthorityList";
 
 const baseClass = "cert-authority-list-item";
@@ -24,9 +23,8 @@ const Actions = ({ onEdit, onDelete }: IActionsProps) => {
             onClick={onEdit}
             className={`${baseClass}__action-button`}
             variant="subdued"
-          >
-            <Icon name="pencil" />
-          </Button>
+            icon="pencil"
+          />
         )}
       />
       <GitOpsModeTooltipWrapper
@@ -37,9 +35,8 @@ const Actions = ({ onEdit, onDelete }: IActionsProps) => {
             onClick={onDelete}
             className={`${baseClass}__action-button`}
             variant="subdued"
-          >
-            <Icon name="trash" />
-          </Button>
+            icon="trash"
+          />
         )}
       />
     </>

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CertAuthorityListItem/CertAuthorityListItem.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CertAuthorityListItem/CertAuthorityListItem.tsx
@@ -24,6 +24,7 @@ const Actions = ({ onEdit, onDelete }: IActionsProps) => {
             className={`${baseClass}__action-button`}
             variant="subdued"
             icon="pencil"
+            ariaLabel="Edit certificate authority"
           />
         )}
       />
@@ -36,6 +37,7 @@ const Actions = ({ onEdit, onDelete }: IActionsProps) => {
             className={`${baseClass}__action-button`}
             variant="subdued"
             icon="trash"
+            ariaLabel="Delete certificate authority"
           />
         )}
       />

--- a/frontend/pages/admin/IntegrationsPage/cards/ConditionalAccess/ConditionalAccess.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/ConditionalAccess/ConditionalAccess.tsx
@@ -9,7 +9,6 @@ import configAPI from "services/entities/config";
 
 import CustomLink from "components/CustomLink";
 import SectionHeader from "components/SectionHeader";
-import Icon from "components/Icon";
 import { IconNames } from "components/icons";
 import { notify } from "components/ToastNotification";
 
@@ -369,9 +368,13 @@ const ConditionalAccess = () => {
         iconName={oktaConfigured ? "success" : undefined}
         cta={
           oktaConfigured ? (
-            <Button variant="subdued" onClick={handleOktaDelete}>
+            <Button
+              variant="subdued"
+              onClick={handleOktaDelete}
+              icon="trash"
+              iconPosition="right"
+            >
               Delete
-              <Icon name="trash" color="ui-fleet-black-75" />
             </Button>
           ) : (
             <Button onClick={toggleOktaModal}>Connect</Button>
@@ -436,9 +439,13 @@ const ConditionalAccess = () => {
     let entraCta: React.JSX.Element | undefined;
     if (entraIsConfigured) {
       entraCta = (
-        <Button variant="subdued" onClick={handleEntraDelete}>
+        <Button
+          variant="subdued"
+          onClick={handleEntraDelete}
+          icon="trash"
+          iconPosition="right"
+        >
           Delete
-          <Icon name="trash" color="ui-fleet-black-75" />
         </Button>
       );
     } else if (!entraIsAwaitingOAuth) {

--- a/frontend/pages/admin/IntegrationsPage/cards/ConditionalAccess/components/OktaConditionalAccessModal/OktaConditionalAccessModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/ConditionalAccess/components/OktaConditionalAccessModal/OktaConditionalAccessModal.tsx
@@ -306,7 +306,8 @@ const OktaConditionalAccessModal = ({
             onClick={onDownloadSigningCert}
             isLoading={isDownloadingCert}
             disabled={isDownloadingCert}
-            rightIcon="download"
+            icon="download"
+            iconPosition="right"
           >
             <span>Download certificate</span>
           </Button>

--- a/frontend/pages/admin/IntegrationsPage/cards/ConditionalAccess/components/OktaConditionalAccessModal/OktaConditionalAccessModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/ConditionalAccess/components/OktaConditionalAccessModal/OktaConditionalAccessModal.tsx
@@ -11,7 +11,6 @@ import InputField from "components/forms/fields/InputField";
 import CustomLink from "components/CustomLink";
 import Modal from "components/Modal";
 import Button from "components/buttons/Button";
-import Icon from "components/Icon";
 import TooltipWrapper from "components/TooltipWrapper";
 import { IInputFieldParseTarget } from "interfaces/form_field";
 import { getErrorReason } from "interfaces/errors";
@@ -307,9 +306,9 @@ const OktaConditionalAccessModal = ({
             onClick={onDownloadSigningCert}
             isLoading={isDownloadingCert}
             disabled={isDownloadingCert}
+            rightIcon="download"
           >
             <span>Download certificate</span>
-            <Icon name="download" />
           </Button>
         </div>
 

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/WindowsAutomaticEnrollmentPage/EntraClientIDsListHeader/EntraClientIDsListHeader.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/WindowsAutomaticEnrollmentPage/EntraClientIDsListHeader/EntraClientIDsListHeader.tsx
@@ -2,7 +2,6 @@ import React from "react";
 
 import Button from "components/buttons/Button";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
-import Icon from "components/Icon";
 
 const baseClass = "entra-client-ids-list-header";
 
@@ -25,11 +24,9 @@ const EntraClientIDsListHeader = ({
               variant="secondary"
               className={`${baseClass}__add-button`}
               onClick={onClickAddClientId}
+              leftIcon="plus"
             >
-              <>
-                <Icon name="plus" />
-                Add
-              </>
+              Add
             </Button>
           )}
         />

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/WindowsAutomaticEnrollmentPage/EntraClientIDsListHeader/EntraClientIDsListHeader.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/WindowsAutomaticEnrollmentPage/EntraClientIDsListHeader/EntraClientIDsListHeader.tsx
@@ -24,7 +24,7 @@ const EntraClientIDsListHeader = ({
               variant="secondary"
               className={`${baseClass}__add-button`}
               onClick={onClickAddClientId}
-              leftIcon="plus"
+              icon="plus"
             >
               Add
             </Button>

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/WindowsAutomaticEnrollmentPage/EntraClientIDsListItem/EntraClientIDsListItem.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/WindowsAutomaticEnrollmentPage/EntraClientIDsListItem/EntraClientIDsListItem.tsx
@@ -3,7 +3,6 @@ import React from "react";
 import ListItem from "components/ListItem";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
 import Button from "components/buttons/Button";
-import Icon from "components/Icon";
 
 const baseClass = "entra-client-ids-list-item";
 
@@ -30,9 +29,8 @@ const EntraClientIDsListItem = ({
               className={`${baseClass}__action-button`}
               variant="subdued"
               ariaLabel={`Delete Microsoft Entra client ID ${clientId}`}
-            >
-              <Icon name="trash" />
-            </Button>
+              icon="trash"
+            />
           )}
         />
       }

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/WindowsAutomaticEnrollmentPage/EntraTenantsListHeader/EntraTenantsListHeader.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/WindowsAutomaticEnrollmentPage/EntraTenantsListHeader/EntraTenantsListHeader.tsx
@@ -2,7 +2,6 @@ import React from "react";
 
 import Button from "components/buttons/Button";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
-import Icon from "components/Icon";
 
 const baseClass = "entra-tenants-list-header";
 
@@ -25,11 +24,9 @@ const EntraTenantsListHeader = ({
               variant="secondary"
               className={`${baseClass}__add-button`}
               onClick={onClickAddTenant}
+              leftIcon="plus"
             >
-              <>
-                <Icon name="plus" />
-                Add
-              </>
+              Add
             </Button>
           )}
         />

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/WindowsAutomaticEnrollmentPage/EntraTenantsListHeader/EntraTenantsListHeader.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/WindowsAutomaticEnrollmentPage/EntraTenantsListHeader/EntraTenantsListHeader.tsx
@@ -24,7 +24,7 @@ const EntraTenantsListHeader = ({
               variant="secondary"
               className={`${baseClass}__add-button`}
               onClick={onClickAddTenant}
-              leftIcon="plus"
+              icon="plus"
             >
               Add
             </Button>

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/WindowsAutomaticEnrollmentPage/EntraTenantsListItem/EntraTenantsListItem.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/WindowsAutomaticEnrollmentPage/EntraTenantsListItem/EntraTenantsListItem.tsx
@@ -3,7 +3,6 @@ import React from "react";
 import ListItem from "components/ListItem";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
 import Button from "components/buttons/Button";
-import Icon from "components/Icon";
 
 const baseClass = "entra-tenants-list-item";
 
@@ -30,9 +29,8 @@ const EntraTenantsListItem = ({
               className={`${baseClass}__action-button`}
               variant="subdued"
               ariaLabel={`Delete Microsoft Entra tenant ${tenantId}`}
-            >
-              <Icon name="trash" />
-            </Button>
+              icon="trash"
+            />
           )}
         />
       }

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/AppleBusinessManagerSection/AppleAutomaticEnrollmentCard/AppleAutomaticEnrollmentCard.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/AppleBusinessManagerSection/AppleAutomaticEnrollmentCard/AppleAutomaticEnrollmentCard.tsx
@@ -26,7 +26,7 @@ const AppleAutomaticEnrollmentCard = ({
     <SectionCard
       iconName="success"
       cta={
-        <Button onClick={viewDetails} variant="subdued" leftIcon="pencil">
+        <Button onClick={viewDetails} variant="subdued" icon="pencil">
           Edit
         </Button>
       }

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/AppleBusinessManagerSection/AppleAutomaticEnrollmentCard/AppleAutomaticEnrollmentCard.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/AppleBusinessManagerSection/AppleAutomaticEnrollmentCard/AppleAutomaticEnrollmentCard.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 
 import Button from "components/buttons/Button";
-import Icon from "components/Icon/Icon";
 
 import SectionCard from "../../SectionCard";
 
@@ -27,8 +26,7 @@ const AppleAutomaticEnrollmentCard = ({
     <SectionCard
       iconName="success"
       cta={
-        <Button onClick={viewDetails} variant="subdued">
-          <Icon name="pencil" />
+        <Button onClick={viewDetails} variant="subdued" leftIcon="pencil">
           Edit
         </Button>
       }

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/AppleBusinessManagerSection/VppCard/VppCard.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/AppleBusinessManagerSection/VppCard/VppCard.tsx
@@ -24,7 +24,7 @@ const VppCard = ({ isAppleMdmOn, isVppOn, viewDetails }: IVppCardProps) => {
     <SectionCard
       iconName="success"
       cta={
-        <Button onClick={viewDetails} variant="subdued" leftIcon="pencil">
+        <Button onClick={viewDetails} variant="subdued" icon="pencil">
           Edit
         </Button>
       }

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/AppleBusinessManagerSection/VppCard/VppCard.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/AppleBusinessManagerSection/VppCard/VppCard.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 
 import Button from "components/buttons/Button";
-import Icon from "components/Icon";
 
 import SectionCard from "../../SectionCard";
 
@@ -25,8 +24,7 @@ const VppCard = ({ isAppleMdmOn, isVppOn, viewDetails }: IVppCardProps) => {
     <SectionCard
       iconName="success"
       cta={
-        <Button onClick={viewDetails} variant="subdued">
-          <Icon name="pencil" />
+        <Button onClick={viewDetails} variant="subdued" leftIcon="pencil">
           Edit
         </Button>
       }

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/MdmSettingsSection/AndroidMdmCard/AndroidMdmCard.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/MdmSettingsSection/AndroidMdmCard/AndroidMdmCard.tsx
@@ -3,7 +3,6 @@ import React, { useContext } from "react";
 import { AppContext } from "context/app";
 
 import Button from "components/buttons/Button";
-import Icon from "components/Icon";
 
 import SectionCard from "../../SectionCard";
 
@@ -39,8 +38,7 @@ const TurnOffAndroidMdmCard = ({
       className={baseClass}
       iconName="success"
       cta={
-        <Button onClick={onClickEdit} variant="subdued">
-          <Icon name="pencil" />
+        <Button onClick={onClickEdit} variant="subdued" leftIcon="pencil">
           Edit
         </Button>
       }

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/MdmSettingsSection/AndroidMdmCard/AndroidMdmCard.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/MdmSettingsSection/AndroidMdmCard/AndroidMdmCard.tsx
@@ -38,7 +38,7 @@ const TurnOffAndroidMdmCard = ({
       className={baseClass}
       iconName="success"
       cta={
-        <Button onClick={onClickEdit} variant="subdued" leftIcon="pencil">
+        <Button onClick={onClickEdit} variant="subdued" icon="pencil">
           Edit
         </Button>
       }

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/MdmSettingsSection/AppleMdmCard/AppleMdmCard.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/MdmSettingsSection/AppleMdmCard/AppleMdmCard.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 
 import Button from "components/buttons/Button";
-import Icon from "components/Icon";
 import DataError from "components/DataError";
 import { AxiosError } from "axios";
 import { IMdmApple } from "interfaces/mdm";
@@ -36,8 +35,7 @@ const SeeDetailsAppleMdmCard = ({
     <SectionCard
       iconName="success"
       cta={
-        <Button onClick={onClickDetails} variant="subdued">
-          <Icon name="pencil" />
+        <Button onClick={onClickDetails} variant="subdued" leftIcon="pencil">
           Edit
         </Button>
       }

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/MdmSettingsSection/AppleMdmCard/AppleMdmCard.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/MdmSettingsSection/AppleMdmCard/AppleMdmCard.tsx
@@ -35,7 +35,7 @@ const SeeDetailsAppleMdmCard = ({
     <SectionCard
       iconName="success"
       cta={
-        <Button onClick={onClickDetails} variant="subdued" leftIcon="pencil">
+        <Button onClick={onClickDetails} variant="subdued" icon="pencil">
           Edit
         </Button>
       }

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/MdmSettingsSection/WindowsMdmCard/WindowsMdmCard.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/MdmSettingsSection/WindowsMdmCard/WindowsMdmCard.tsx
@@ -3,7 +3,6 @@ import React, { useContext } from "react";
 import { AppContext } from "context/app";
 
 import Button from "components/buttons/Button";
-import Icon from "components/Icon";
 import SectionCard from "../../SectionCard";
 
 const baseClass = "windows-mdm-card";
@@ -37,8 +36,7 @@ const TurnOffWindowsMdmCard = ({
     <SectionCard
       iconName="success"
       cta={
-        <Button onClick={onClickEdit} variant="subdued">
-          <Icon name="pencil" />
+        <Button onClick={onClickEdit} variant="subdued" leftIcon="pencil">
           Edit
         </Button>
       }

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/MdmSettingsSection/WindowsMdmCard/WindowsMdmCard.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/MdmSettingsSection/WindowsMdmCard/WindowsMdmCard.tsx
@@ -36,7 +36,7 @@ const TurnOffWindowsMdmCard = ({
     <SectionCard
       iconName="success"
       cta={
-        <Button onClick={onClickEdit} variant="subdued" leftIcon="pencil">
+        <Button onClick={onClickEdit} variant="subdued" icon="pencil">
           Edit
         </Button>
       }

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/MicrosoftEntraSection/WindowsAutomaticEnrollmentCard/WindowsEnrollmentCard.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/MicrosoftEntraSection/WindowsAutomaticEnrollmentCard/WindowsEnrollmentCard.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 
 import Button from "components/buttons/Button";
-import Icon from "components/Icon/Icon";
 import SectionCard from "../../SectionCard";
 
 interface IWindowsAutomaticEnrollmentCardProps {
@@ -27,8 +26,7 @@ const WindowsTenantAddedCard = ({
   <SectionCard
     iconName="success"
     cta={
-      <Button onClick={editTenants} variant="subdued">
-        <Icon name="pencil" />
+      <Button onClick={editTenants} variant="subdued" leftIcon="pencil">
         Edit
       </Button>
     }

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/MicrosoftEntraSection/WindowsAutomaticEnrollmentCard/WindowsEnrollmentCard.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/MicrosoftEntraSection/WindowsAutomaticEnrollmentCard/WindowsEnrollmentCard.tsx
@@ -26,7 +26,7 @@ const WindowsTenantAddedCard = ({
   <SectionCard
     iconName="success"
     cta={
-      <Button onClick={editTenants} variant="subdued" leftIcon="pencil">
+      <Button onClick={editTenants} variant="subdued" icon="pencil">
         Edit
       </Button>
     }

--- a/frontend/pages/admin/ManageUsersPage/components/ApiEndpointSelectorTable/ApiEndpointSelectorTable.tsx
+++ b/frontend/pages/admin/ManageUsersPage/components/ApiEndpointSelectorTable/ApiEndpointSelectorTable.tsx
@@ -125,6 +125,7 @@ const generateSelectedTableHeaders = (
         onClick={() => handleRemove(cellProps.row)}
         variant="subdued"
         icon="close-filled"
+        ariaLabel="Remove"
       />
     ),
     disableHidden: true,

--- a/frontend/pages/admin/ManageUsersPage/components/ApiEndpointSelectorTable/ApiEndpointSelectorTable.tsx
+++ b/frontend/pages/admin/ManageUsersPage/components/ApiEndpointSelectorTable/ApiEndpointSelectorTable.tsx
@@ -13,7 +13,6 @@ import TableContainer from "components/TableContainer";
 import TextCell from "components/TableContainer/DataTable/TextCell/TextCell";
 import PillBadge from "components/PillBadge";
 import Button from "components/buttons/Button";
-import Icon from "components/Icon/Icon";
 import InputFieldWithIcon from "components/forms/fields/InputFieldWithIcon/InputFieldWithIcon";
 import DataError from "components/DataError";
 import CustomLink from "components/CustomLink";
@@ -122,9 +121,11 @@ const generateSelectedTableHeaders = (
     id: "delete",
     Header: "",
     Cell: (cellProps: { row: Row<IApiEndpointRow> }) => (
-      <Button onClick={() => handleRemove(cellProps.row)} variant="subdued">
-        <Icon name="close-filled" />
-      </Button>
+      <Button
+        onClick={() => handleRemove(cellProps.row)}
+        variant="subdued"
+        icon="close-filled"
+      />
     ),
     disableHidden: true,
   },

--- a/frontend/pages/admin/OrgSettingsPage/cards/Info/Info.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Info/Info.tsx
@@ -8,7 +8,6 @@ import SettingsSection from "pages/admin/components/SettingsSection";
 import PageDescription from "components/PageDescription";
 import Button from "components/buttons/Button";
 import CustomLink from "components/CustomLink";
-import Icon from "components/Icon";
 import InputField from "components/forms/fields/InputField";
 // @ts-ignore
 import OrgLogoIcon from "components/icons/OrgLogoIcon";
@@ -90,9 +89,8 @@ const LogoCard = ({
                 onClick={onEdit}
                 disabled={disableChildren}
                 title="Replace logo"
-              >
-                <Icon name="pencil" />
-              </Button>
+                icon="pencil"
+              />
             )}
           />
           <GitOpsModeTooltipWrapper
@@ -104,9 +102,8 @@ const LogoCard = ({
                 onClick={onDelete}
                 disabled={disableChildren || !hasCustomLogo}
                 title="Remove logo"
-              >
-                <Icon name="trash" />
-              </Button>
+                icon="trash"
+              />
             )}
           />
         </div>

--- a/frontend/pages/admin/OrgSettingsPage/cards/Info/Info.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Info/Info.tsx
@@ -90,6 +90,7 @@ const LogoCard = ({
                 disabled={disableChildren}
                 title="Replace logo"
                 icon="pencil"
+                ariaLabel="Replace logo"
               />
             )}
           />
@@ -103,6 +104,7 @@ const LogoCard = ({
                 disabled={disableChildren || !hasCustomLogo}
                 title="Remove logo"
                 icon="trash"
+                ariaLabel="Remove logo"
               />
             )}
           />

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -86,7 +86,6 @@ import { strToBool } from "utilities/strings/stringUtils";
 
 import { notify } from "components/ToastNotification";
 import Button from "components/buttons/Button";
-import Icon from "components/Icon/Icon";
 import { SingleValue } from "react-select-5";
 import DropdownWrapper from "components/forms/fields/DropdownWrapper";
 import { CustomOptionType } from "components/forms/fields/DropdownWrapper/DropdownWrapper";
@@ -1791,7 +1790,7 @@ const ManageHostsPage = ({
               onClick={onExportHostsResults}
               variant="secondary"
               disabled={isTrulyEmpty}
-              leftIcon="download"
+              icon="download"
             >
               Export hosts
             </Button>
@@ -1801,11 +1800,9 @@ const ManageHostsPage = ({
             onClick={toggleEditColumnsModal}
             variant="secondary"
             disabled={isTrulyEmpty}
+            icon="columns"
           >
-            <>
-              <Icon name="columns" color="ui-fleet-black-75" />
-              Edit columns
-            </>
+            Edit columns
           </Button>
         </div>
         <div className={`${baseClass}__filter-dropdowns`}>
@@ -2084,7 +2081,7 @@ const ManageHostsPage = ({
                 }
                 className={`${baseClass}__custom-host-vitals`}
                 variant="secondary"
-                leftIcon="pencil"
+                icon="pencil"
               >
                 <span>Custom host vitals</span>
               </Button>
@@ -2094,7 +2091,7 @@ const ManageHostsPage = ({
                 onClick={() => setShowEnrollSecretModal(true)}
                 className={`${baseClass}__enroll-hosts button`}
                 variant="secondary"
-                leftIcon="settings"
+                icon="settings"
               >
                 <span>Enroll secrets</span>
               </Button>

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1791,11 +1791,9 @@ const ManageHostsPage = ({
               onClick={onExportHostsResults}
               variant="secondary"
               disabled={isTrulyEmpty}
+              leftIcon="download"
             >
-              <>
-                <Icon name="download" size="small" />
-                Export hosts
-              </>
+              Export hosts
             </Button>
           )}
           <Button
@@ -2086,8 +2084,8 @@ const ManageHostsPage = ({
                 }
                 className={`${baseClass}__custom-host-vitals`}
                 variant="secondary"
+                leftIcon="pencil"
               >
-                <Icon name="pencil" />
                 <span>Custom host vitals</span>
               </Button>
             )}
@@ -2096,8 +2094,8 @@ const ManageHostsPage = ({
                 onClick={() => setShowEnrollSecretModal(true)}
                 className={`${baseClass}__enroll-hosts button`}
                 variant="secondary"
+                leftIcon="settings"
               >
-                <Icon name="settings" />
                 <span>Enroll secrets</span>
               </Button>
             )}

--- a/frontend/pages/hosts/ManageHostsPage/components/CustomLabelGroupHeading/CustomLabelGroupHeading.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/CustomLabelGroupHeading/CustomLabelGroupHeading.tsx
@@ -69,6 +69,7 @@ const CustomLabelGroupHeading = (
             variant="secondary"
             onClick={onAddLabel}
             icon="plus"
+            ariaLabel="Add label"
           />
         )}
       </div>

--- a/frontend/pages/hosts/ManageHostsPage/components/CustomLabelGroupHeading/CustomLabelGroupHeading.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/CustomLabelGroupHeading/CustomLabelGroupHeading.tsx
@@ -68,9 +68,8 @@ const CustomLabelGroupHeading = (
             className={`${baseClass}__add-label-button`}
             variant="secondary"
             onClick={onAddLabel}
-          >
-            <Icon name="plus" />
-          </Button>
+            icon="plus"
+          />
         )}
       </div>
     </components.GroupHeading>

--- a/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
@@ -42,7 +42,6 @@ import {
 import Dropdown from "components/forms/fields/Dropdown";
 import Button from "components/buttons/Button";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
-import Icon from "components/Icon/Icon";
 import { abmIssueTooltip } from "pages/DashboardPage/cards/ABMIssueHosts/ABMIssueHosts";
 
 import FilterPill from "../FilterPill";
@@ -233,9 +232,8 @@ const HostsFilterBlock = ({
                           variant="secondary"
                           size="small"
                           disabled={disableChildren}
-                        >
-                          <Icon name="pencil" size="small" />
-                        </Button>
+                          icon="pencil"
+                        />
                       )
                     }
                     <Button
@@ -244,9 +242,8 @@ const HostsFilterBlock = ({
                       variant="secondary"
                       size="small"
                       disabled={disableChildren}
-                    >
-                      <Icon name="trash" size="small" />
-                    </Button>
+                      icon="trash"
+                    />
                   </>
                 )}
               />

--- a/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
@@ -233,6 +233,7 @@ const HostsFilterBlock = ({
                           size="small"
                           disabled={disableChildren}
                           icon="pencil"
+                          ariaLabel="Edit label"
                         />
                       )
                     }
@@ -243,6 +244,7 @@ const HostsFilterBlock = ({
                       size="small"
                       disabled={disableChildren}
                       icon="trash"
+                      ariaLabel="Delete label"
                     />
                   </>
                 )}

--- a/frontend/pages/hosts/components/ScriptDetailsModal/ScriptDetailsModal.tsx
+++ b/frontend/pages/hosts/components/ScriptDetailsModal/ScriptDetailsModal.tsx
@@ -200,6 +200,7 @@ const ScriptDetailsModal = ({
                 variant="subdued"
                 onClick={() => onClickDownload()}
                 icon="download"
+                ariaLabel="Download script"
               />
               <GitOpsModeTooltipWrapper
                 position="bottom"

--- a/frontend/pages/hosts/components/ScriptDetailsModal/ScriptDetailsModal.tsx
+++ b/frontend/pages/hosts/components/ScriptDetailsModal/ScriptDetailsModal.tsx
@@ -18,7 +18,6 @@ import Modal from "components/Modal";
 import ModalFooter from "components/ModalFooter";
 import Button from "components/buttons/Button";
 import Spinner from "components/Spinner";
-import Icon from "components/Icon";
 import Textarea from "components/Textarea";
 import DataError from "components/DataError";
 import ActionsDropdown from "components/ActionsDropdown";
@@ -200,9 +199,8 @@ const ScriptDetailsModal = ({
                 className={`${baseClass}__action-button`}
                 variant="subdued"
                 onClick={() => onClickDownload()}
-              >
-                <Icon name="download" />
-              </Button>
+                icon="download"
+              />
               <GitOpsModeTooltipWrapper
                 position="bottom"
                 renderChildren={(disableChildren) => (
@@ -211,9 +209,9 @@ const ScriptDetailsModal = ({
                     className={`${baseClass}__action-button`}
                     variant="subdued"
                     onClick={onDelete}
-                  >
-                    <Icon name="trash" color="ui-fleet-black-75" />
-                  </Button>
+                    icon="trash"
+                    ariaLabel="Delete script"
+                  />
                 )}
               />
             </>

--- a/frontend/pages/hosts/details/DeviceUserPage/components/InfoButton/InfoButton.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/components/InfoButton/InfoButton.tsx
@@ -13,7 +13,8 @@ const InfoButton = ({ onClick }: IInfoButton) => {
       className={baseClass}
       onClick={onClick}
       variant="subdued"
-      rightIcon="info"
+      icon="info"
+      iconPosition="right"
     >
       Info
     </Button>

--- a/frontend/pages/hosts/details/DeviceUserPage/components/InfoButton/InfoButton.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/components/InfoButton/InfoButton.tsx
@@ -1,5 +1,4 @@
 import Button from "components/buttons/Button";
-import Icon from "components/Icon";
 import React from "react";
 
 const baseClass = "info-button";
@@ -10,10 +9,13 @@ interface IInfoButton {
 
 const InfoButton = ({ onClick }: IInfoButton) => {
   return (
-    <Button className={baseClass} onClick={onClick} variant="subdued">
-      <>
-        Info <Icon name="info" size="small" />
-      </>
+    <Button
+      className={baseClass}
+      onClick={onClick}
+      variant="subdued"
+      rightIcon="info"
+    >
+      Info
     </Button>
   );
 };

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/ManagedAccountModal/ManagedAccountModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/ManagedAccountModal/ManagedAccountModal.tsx
@@ -118,7 +118,7 @@ const ManagedAccountModal = ({
                   onClick={onRotatePassword}
                   disabled={isRotating}
                   className={`${baseClass}__rotate-button`}
-                  leftIcon="refresh"
+                  icon="refresh"
                 >
                   {isRotating ? "Rotating..." : "Rotate password"}
                 </Button>

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/ManagedAccountModal/ManagedAccountModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/ManagedAccountModal/ManagedAccountModal.tsx
@@ -10,7 +10,6 @@ import Button from "components/buttons/Button";
 import InputFieldHiddenContent from "components/forms/fields/InputFieldHiddenContent";
 import DataError from "components/DataError";
 import Spinner from "components/Spinner";
-import Icon from "components/Icon";
 import InfoBanner from "components/InfoBanner";
 import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
 import { monthDayTimeFormat } from "utilities/date_format";
@@ -119,8 +118,8 @@ const ManagedAccountModal = ({
                   onClick={onRotatePassword}
                   disabled={isRotating}
                   className={`${baseClass}__rotate-button`}
+                  leftIcon="refresh"
                 >
-                  <Icon name="refresh" />
                   {isRotating ? "Rotating..." : "Rotate password"}
                 </Button>
               )}

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/RecoveryLockPasswordModal/RecoveryLockPasswordModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/RecoveryLockPasswordModal/RecoveryLockPasswordModal.tsx
@@ -12,7 +12,6 @@ import InputFieldHiddenContent from "components/forms/fields/InputFieldHiddenCon
 import DataError from "components/DataError";
 import Spinner from "components/Spinner";
 import CustomLink from "components/CustomLink";
-import Icon from "components/Icon";
 import InfoBanner from "components/InfoBanner";
 import {
   DEFAULT_USE_QUERY_OPTIONS,
@@ -83,8 +82,8 @@ const RecoveryLockPasswordModal = ({
         onClick={onRotatePassword}
         disabled={isRotating}
         className={`${baseClass}__rotate-button`}
+        leftIcon="refresh"
       >
-        <Icon name="refresh" />
         {isRotating ? "Rotating..." : "Rotate password"}
       </Button>
     );

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/RecoveryLockPasswordModal/RecoveryLockPasswordModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/RecoveryLockPasswordModal/RecoveryLockPasswordModal.tsx
@@ -82,7 +82,7 @@ const RecoveryLockPasswordModal = ({
         onClick={onRotatePassword}
         disabled={isRotating}
         className={`${baseClass}__rotate-button`}
-        leftIcon="refresh"
+        icon="refresh"
       >
         {isRotating ? "Rotating..." : "Rotate password"}
       </Button>

--- a/frontend/pages/hosts/details/HostQueryReport/HQRTable/HQRTable.tsx
+++ b/frontend/pages/hosts/details/HostQueryReport/HQRTable/HQRTable.tsx
@@ -1,6 +1,5 @@
 import Button from "components/buttons/Button";
 import EmptyState from "components/EmptyState";
-import Icon from "components/Icon";
 import TableContainer from "components/TableContainer";
 import TableCount from "components/TableContainer/TableCount";
 import React, { useCallback, useState } from "react";
@@ -111,21 +110,18 @@ const HQRTable = ({
           onClick={onShowQuery}
           variant="secondary"
           size="small"
+          rightIcon="eye"
         >
-          <>
-            Show query <Icon name="eye" size="small" />
-          </>
+          Show query
         </Button>
         <Button
           className={`${baseClass}__export-btn`}
           onClick={onExportQueryResults}
           variant="secondary"
           size="small"
+          rightIcon="download"
         >
-          <>
-            Export results
-            <Icon name="download" size="small" />
-          </>
+          Export results
         </Button>
       </div>
     );

--- a/frontend/pages/hosts/details/HostQueryReport/HQRTable/HQRTable.tsx
+++ b/frontend/pages/hosts/details/HostQueryReport/HQRTable/HQRTable.tsx
@@ -110,7 +110,8 @@ const HQRTable = ({
           onClick={onShowQuery}
           variant="secondary"
           size="small"
-          rightIcon="eye"
+          icon="eye"
+          iconPosition="right"
         >
           Show query
         </Button>
@@ -119,7 +120,8 @@ const HQRTable = ({
           onClick={onExportQueryResults}
           variant="secondary"
           size="small"
-          rightIcon="download"
+          icon="download"
+          iconPosition="right"
         >
           Export results
         </Button>

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsResendCell/OSSettingsResendCell.tsx
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsResendCell/OSSettingsResendCell.tsx
@@ -12,7 +12,6 @@ import { getErrorReason } from "interfaces/errors";
 
 import { notify } from "components/ToastNotification";
 import Button from "components/buttons/Button";
-import Icon from "components/Icon";
 
 import { IHostMdmProfileWithAddedStatus } from "../OSSettingsTableConfig";
 
@@ -37,8 +36,8 @@ const ResendButton = ({ isResending, onClick }: IResendButtonProps) => {
       variant="secondary"
       className={classNames}
       size="small"
+      leftIcon="refresh"
     >
-      <Icon name="refresh" size="small" />
       {buttonText}
     </Button>
   );
@@ -63,8 +62,8 @@ const RotateButton = ({ isRotating, onClick }: IRotateButtonProps) => {
       variant="secondary"
       className={classNames}
       size="small"
+      leftIcon="refresh"
     >
-      <Icon name="refresh" size="small" />
       {buttonText}
     </Button>
   );

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsResendCell/OSSettingsResendCell.tsx
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsResendCell/OSSettingsResendCell.tsx
@@ -36,7 +36,7 @@ const ResendButton = ({ isResending, onClick }: IResendButtonProps) => {
       variant="secondary"
       className={classNames}
       size="small"
-      leftIcon="refresh"
+      icon="refresh"
     >
       {buttonText}
     </Button>
@@ -62,7 +62,7 @@ const RotateButton = ({ isRotating, onClick }: IRotateButtonProps) => {
       variant="secondary"
       className={classNames}
       size="small"
-      leftIcon="refresh"
+      icon="refresh"
     >
       {buttonText}
     </Button>

--- a/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostSoftwareLibraryTable/HostSoftwareLibraryTable.tsx
+++ b/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostSoftwareLibraryTable/HostSoftwareLibraryTable.tsx
@@ -215,7 +215,7 @@ const HostSoftwareLibraryTable = ({
             className={`${baseClass}__add-software-button`}
             variant="secondary"
             onClick={onAddSoftware}
-            leftIcon="plus"
+            icon="plus"
           >
             <span>Add software</span>
           </Button>

--- a/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostSoftwareLibraryTable/HostSoftwareLibraryTable.tsx
+++ b/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostSoftwareLibraryTable/HostSoftwareLibraryTable.tsx
@@ -18,7 +18,6 @@ import { ITableQueryData } from "components/TableContainer/TableContainer";
 import { CustomOptionType } from "components/forms/fields/DropdownWrapper/DropdownWrapper";
 
 import Button from "components/buttons/Button";
-import Icon from "components/Icon";
 import EmptySoftwareTable from "pages/SoftwarePage/components/tables/EmptySoftwareTable";
 import TableCount from "components/TableContainer/TableCount";
 import EmptyState from "components/EmptyState";
@@ -216,8 +215,8 @@ const HostSoftwareLibraryTable = ({
             className={`${baseClass}__add-software-button`}
             variant="secondary"
             onClick={onAddSoftware}
+            leftIcon="plus"
           >
-            <Icon name="plus" />
             <span>Add software</span>
           </Button>
         )}

--- a/frontend/pages/hosts/details/cards/Queries/HostQueries.tsx
+++ b/frontend/pages/hosts/details/cards/Queries/HostQueries.tsx
@@ -9,7 +9,6 @@ import Button from "components/buttons/Button";
 import CustomLink from "components/CustomLink";
 import EmptyState from "components/EmptyState";
 import CardHeader from "components/CardHeader";
-import Icon from "components/Icon";
 import PATHS from "router/paths";
 import { InjectedRouter } from "react-router";
 import { Row } from "react-table";
@@ -143,8 +142,12 @@ const HostQueries = ({
       <div className={`${baseClass}__header`}>
         <CardHeader header="Reports" />
         {canAddQuery && (
-          <Button variant="secondary" onClick={onClickAddQuery} size="small">
-            <Icon name="plus" />
+          <Button
+            variant="secondary"
+            onClick={onClickAddQuery}
+            size="small"
+            leftIcon="plus"
+          >
             Add report
           </Button>
         )}

--- a/frontend/pages/hosts/details/cards/Queries/HostQueries.tsx
+++ b/frontend/pages/hosts/details/cards/Queries/HostQueries.tsx
@@ -146,7 +146,7 @@ const HostQueries = ({
             variant="secondary"
             onClick={onClickAddQuery}
             size="small"
-            leftIcon="plus"
+            icon="plus"
           >
             Add report
           </Button>

--- a/frontend/pages/hosts/details/cards/Software/HostSoftwareTable/HostSoftwareTable.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftwareTable/HostSoftwareTable.tsx
@@ -206,7 +206,7 @@ const HostSoftwareTable = ({
           variant="secondary"
           onClick={onAddFiltersClick}
           disabled={isTrulyEmpty}
-          leftIcon="filter"
+          icon="filter"
         >
           <span>{vulnFilterDetails.buttonText}</span>
         </Button>

--- a/frontend/pages/hosts/details/cards/Software/HostSoftwareTable/HostSoftwareTable.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftwareTable/HostSoftwareTable.tsx
@@ -24,7 +24,6 @@ import TableContainer from "components/TableContainer";
 import { ITableQueryData } from "components/TableContainer/TableContainer";
 import TooltipWrapper from "components/TooltipWrapper";
 import Button from "components/buttons/Button";
-import Icon from "components/Icon";
 import DropdownWrapper, {
   CustomOptionType,
 } from "components/forms/fields/DropdownWrapper/DropdownWrapper";
@@ -207,8 +206,8 @@ const HostSoftwareTable = ({
           variant="secondary"
           onClick={onAddFiltersClick}
           disabled={isTrulyEmpty}
+          leftIcon="filter"
         >
-          <Icon name="filter" />
           <span>{vulnFilterDetails.buttonText}</span>
         </Button>
       </TooltipWrapper>

--- a/frontend/pages/hosts/details/cards/Software/SelfService/components/UpdatesCard/UpdateSoftwareItem/UpdateSoftwareItem.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/components/UpdatesCard/UpdateSoftwareItem/UpdateSoftwareItem.tsx
@@ -129,7 +129,7 @@ const InstallerStatus = ({
                   onShowInstallerDetails();
                 }}
                 size="small"
-                leftIcon={displayConfig.iconName || "install"}
+                icon={displayConfig.iconName || "install"}
               >
                 {displayConfig.displayText}
               </Button>

--- a/frontend/pages/hosts/details/cards/Software/SelfService/components/UpdatesCard/UpdateSoftwareItem/UpdateSoftwareItem.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/components/UpdatesCard/UpdateSoftwareItem/UpdateSoftwareItem.tsx
@@ -129,8 +129,8 @@ const InstallerStatus = ({
                   onShowInstallerDetails();
                 }}
                 size="small"
+                leftIcon={displayConfig.iconName || "install"}
               >
-                <Icon name={displayConfig.iconName || "install"} />
                 {displayConfig.displayText}
               </Button>
             </span>

--- a/frontend/pages/hosts/details/cards/User/User.tsx
+++ b/frontend/pages/hosts/details/cards/User/User.tsx
@@ -8,7 +8,6 @@ import CardHeader from "components/CardHeader";
 import DataSet from "components/DataSet";
 import TooltipWrapper from "components/TooltipWrapper";
 import Button from "components/buttons/Button";
-import Icon from "components/Icon";
 
 import UserValue from "./components/UserValue";
 import {
@@ -76,9 +75,13 @@ const User = ({
         <CardHeader header="User" />
         <div className={`${baseClass}__header-actions`}>
           {canViewMyDeviceLink && (
-            <Button variant="secondary" onClick={onClickMyDevice} size="small">
+            <Button
+              variant="secondary"
+              onClick={onClickMyDevice}
+              size="small"
+              rightIcon="external-link"
+            >
               My device
-              <Icon name="external-link" />
             </Button>
           )}
           {canWriteEndUser && (
@@ -87,8 +90,8 @@ const User = ({
               variant="secondary"
               onClick={onClickUpdateUser}
               size="small"
+              leftIcon={writeButtonIcon}
             >
-              <Icon name={writeButtonIcon} size="small" />
               {writeButtonText}
             </Button>
           )}

--- a/frontend/pages/hosts/details/cards/User/User.tsx
+++ b/frontend/pages/hosts/details/cards/User/User.tsx
@@ -79,7 +79,8 @@ const User = ({
               variant="secondary"
               onClick={onClickMyDevice}
               size="small"
-              rightIcon="external-link"
+              icon="external-link"
+              iconPosition="right"
             >
               My device
             </Button>
@@ -90,7 +91,7 @@ const User = ({
               variant="secondary"
               onClick={onClickUpdateUser}
               size="small"
-              leftIcon={writeButtonIcon}
+              icon={writeButtonIcon}
             >
               {writeButtonText}
             </Button>

--- a/frontend/pages/labels/NewLabelPage/NewLabelPage.tsx
+++ b/frontend/pages/labels/NewLabelPage/NewLabelPage.tsx
@@ -516,7 +516,8 @@ const NewLabelPage = ({
                   <Button
                     variant="subdued"
                     onClick={onOpenSidebar}
-                    rightIcon="info"
+                    icon="info"
+                    iconPosition="right"
                   >
                     Schema
                   </Button>

--- a/frontend/pages/labels/NewLabelPage/NewLabelPage.tsx
+++ b/frontend/pages/labels/NewLabelPage/NewLabelPage.tsx
@@ -51,7 +51,6 @@ import InputField from "components/forms/fields/InputField";
 import Dropdown from "components/forms/fields/Dropdown";
 import Button from "components/buttons/Button";
 import SQLEditor from "components/SQLEditor";
-import Icon from "components/Icon";
 import TargetsInput from "components/TargetsInput";
 import Radio from "components/forms/fields/Radio";
 import PlatformField from "../components/PlatformField";
@@ -514,9 +513,12 @@ const NewLabelPage = ({
               label="Query"
               labelActionComponent={
                 showOpenSidebarButton ? (
-                  <Button variant="subdued" onClick={onOpenSidebar}>
+                  <Button
+                    variant="subdued"
+                    onClick={onOpenSidebar}
+                    rightIcon="info"
+                  >
                     Schema
-                    <Icon name="info" size="small" />
                   </Button>
                 ) : null
               }

--- a/frontend/pages/labels/components/DynamicLabelForm/DynamicLabelForm.tsx
+++ b/frontend/pages/labels/components/DynamicLabelForm/DynamicLabelForm.tsx
@@ -5,7 +5,6 @@ import { Ace } from "ace-builds";
 import { validateQuery } from "components/forms/validators/validate_query";
 import SQLEditor from "components/SQLEditor";
 import Button from "components/buttons/Button";
-import Icon from "components/Icon";
 
 import { LabelPlatform } from "interfaces/label";
 
@@ -86,9 +85,8 @@ const DynamicLabelForm = ({
     }
 
     return (
-      <Button variant="subdued" onClick={onOpenSidebar}>
+      <Button variant="subdued" onClick={onOpenSidebar} rightIcon="info">
         Schema
-        <Icon name="info" size="small" />
       </Button>
     );
   };

--- a/frontend/pages/labels/components/DynamicLabelForm/DynamicLabelForm.tsx
+++ b/frontend/pages/labels/components/DynamicLabelForm/DynamicLabelForm.tsx
@@ -85,7 +85,12 @@ const DynamicLabelForm = ({
     }
 
     return (
-      <Button variant="subdued" onClick={onOpenSidebar} rightIcon="info">
+      <Button
+        variant="subdued"
+        onClick={onOpenSidebar}
+        icon="info"
+        iconPosition="right"
+      >
         Schema
       </Button>
     );

--- a/frontend/pages/labels/components/ManualLabelForm/LabelHostTargetTableConfig.tsx
+++ b/frontend/pages/labels/components/ManualLabelForm/LabelHostTargetTableConfig.tsx
@@ -27,6 +27,7 @@ export const generateTableHeaders = (
               onClick={() => handleRowRemove(cellProps.row)}
               variant="subdued"
               icon="close-filled"
+              ariaLabel="Remove"
             />
           ),
           disableHidden: true,

--- a/frontend/pages/labels/components/ManualLabelForm/LabelHostTargetTableConfig.tsx
+++ b/frontend/pages/labels/components/ManualLabelForm/LabelHostTargetTableConfig.tsx
@@ -7,7 +7,6 @@ import { IStringCellProps } from "interfaces/datatable_config";
 import { IHost } from "interfaces/host";
 
 import TextCell from "components/TableContainer/DataTable/TextCell";
-import Icon from "components/Icon/Icon";
 import Button from "components/buttons/Button";
 
 export type ITargestInputHostTableConfig = Column<IHost>;
@@ -27,9 +26,8 @@ export const generateTableHeaders = (
             <Button
               onClick={() => handleRowRemove(cellProps.row)}
               variant="subdued"
-            >
-              <Icon name="close-filled" />
-            </Button>
+              icon="close-filled"
+            />
           ),
           disableHidden: true,
         },

--- a/frontend/pages/policies/details/PolicyDetailsPage/PolicyDetailsPage.tsx
+++ b/frontend/pages/policies/details/PolicyDetailsPage/PolicyDetailsPage.tsx
@@ -430,7 +430,8 @@ const PolicyDetailsPage = ({
                         );
                     }}
                     disabled={!!disabledLiveQuery}
-                    rightIcon="run"
+                    icon="run"
+                    iconPosition="right"
                   >
                     Run policy
                   </Button>

--- a/frontend/pages/policies/details/PolicyDetailsPage/PolicyDetailsPage.tsx
+++ b/frontend/pages/policies/details/PolicyDetailsPage/PolicyDetailsPage.tsx
@@ -430,8 +430,9 @@ const PolicyDetailsPage = ({
                         );
                     }}
                     disabled={!!disabledLiveQuery}
+                    rightIcon="run"
                   >
-                    Run policy <Icon name="run" />
+                    Run policy
                   </Button>
                 )}
                 {canEditPolicy && (

--- a/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/PolicyAutomationActivityDetailsModal.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/PolicyAutomationActivityDetailsModal.tsx
@@ -111,7 +111,7 @@ const PolicyAutomationActivityDetailsModal = ({
               variant="secondary"
               onClick={onResetPolicy}
               className={`${baseClass}__reset`}
-              leftIcon="refresh"
+              icon="refresh"
             >
               Reset policy
             </Button>

--- a/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/PolicyAutomationActivityDetailsModal.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/PolicyAutomationActivityDetailsModal.tsx
@@ -111,8 +111,8 @@ const PolicyAutomationActivityDetailsModal = ({
               variant="secondary"
               onClick={onResetPolicy}
               className={`${baseClass}__reset`}
+              leftIcon="refresh"
             >
-              <Icon name="refresh" />
               Reset policy
             </Button>
           )}

--- a/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/PolicyAutomationsActivitiesTable.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/PolicyAutomationsActivitiesTable.tsx
@@ -227,7 +227,8 @@ const PolicyAutomationsActivitiesTable = ({
               <Button
                 variant="subdued"
                 onClick={onClickResetPolicy}
-                rightIcon="refresh"
+                icon="refresh"
+                iconPosition="right"
               >
                 Reset policy
               </Button>

--- a/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/PolicyAutomationsActivitiesTable.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/PolicyAutomationsActivitiesTable.tsx
@@ -25,7 +25,6 @@ import { ITableQueryData } from "components/TableContainer/TableContainer";
 import EmptyState from "components/EmptyState";
 import DataError from "components/DataError";
 import Button from "components/buttons/Button";
-import Icon from "components/Icon";
 import SearchField from "components/forms/fields/SearchField";
 import DropdownWrapper from "components/forms/fields/DropdownWrapper";
 import { CustomOptionType } from "components/forms/fields/DropdownWrapper/DropdownWrapper";
@@ -225,9 +224,12 @@ const PolicyAutomationsActivitiesTable = ({
           )}
           <div className={`${baseClass}__controls`}>
             {canResetPolicy && (
-              <Button variant="subdued" onClick={onClickResetPolicy}>
+              <Button
+                variant="subdued"
+                onClick={onClickResetPolicy}
+                rightIcon="refresh"
+              >
                 Reset policy
-                <Icon name="refresh" />
               </Button>
             )}
             {showControls && (

--- a/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tsx
@@ -494,7 +494,8 @@ const PolicyForm = ({
           <Button
             variant="subdued"
             onClick={onOpenSchemaSidebar}
-            rightIcon="info"
+            icon="info"
+            iconPosition="right"
           >
             Schema
           </Button>
@@ -801,7 +802,8 @@ const PolicyForm = ({
                     disabledLiveQuery
                   }
                   variant="secondary"
-                  rightIcon="run"
+                  icon="run"
+                  iconPosition="right"
                 >
                   Run policy
                 </Button>

--- a/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tsx
@@ -491,11 +491,12 @@ const PolicyForm = ({
     return (
       <div className={`${baseClass}__sql-editor-label-actions`}>
         {showOpenSchemaActionText && (
-          <Button variant="subdued" onClick={onOpenSchemaSidebar}>
-            <>
-              Schema
-              <Icon name="info" />
-            </>
+          <Button
+            variant="subdued"
+            onClick={onOpenSchemaSidebar}
+            rightIcon="info"
+          >
+            Schema
           </Button>
         )}
         {!policyIdForEdit && (
@@ -800,8 +801,9 @@ const PolicyForm = ({
                     disabledLiveQuery
                   }
                   variant="secondary"
+                  rightIcon="run"
                 >
-                  Run policy <Icon name="run" />
+                  Run policy
                 </Button>
               </span>
             </TooltipWrapper>

--- a/frontend/pages/policies/edit/components/PolicyResults/PolicyResults.tsx
+++ b/frontend/pages/policies/edit/components/PolicyResults/PolicyResults.tsx
@@ -14,7 +14,6 @@ import { ITarget } from "interfaces/target";
 
 import Button from "components/buttons/Button";
 import EmptyState from "components/EmptyState";
-import Icon from "components/Icon/Icon";
 import TabNav from "components/TabNav";
 import TabText from "components/TabText";
 import InfoBanner from "components/InfoBanner";
@@ -125,11 +124,10 @@ const PolicyResults = ({
             tableType === "errors" ? onExportErrorsResults : onExportResults
           }
           variant="secondary"
+          icon="download"
+          iconPosition="right"
         >
-          <>
-            Export {tableType}
-            <Icon name="download" color="ui-fleet-black-75" />
-          </>
+          Export {tableType}
         </Button>
       </div>
     );

--- a/frontend/pages/policies/edit/components/PolicyResults/PolicyResults.tsx
+++ b/frontend/pages/policies/edit/components/PolicyResults/PolicyResults.tsx
@@ -114,7 +114,8 @@ const PolicyResults = ({
           className={`${baseClass}__show-query-btn`}
           onClick={onShowQueryModal}
           variant="secondary"
-          rightIcon="eye"
+          icon="eye"
+          iconPosition="right"
         >
           Show query
         </Button>

--- a/frontend/pages/policies/edit/components/PolicyResults/PolicyResults.tsx
+++ b/frontend/pages/policies/edit/components/PolicyResults/PolicyResults.tsx
@@ -114,10 +114,9 @@ const PolicyResults = ({
           className={`${baseClass}__show-query-btn`}
           onClick={onShowQueryModal}
           variant="secondary"
+          rightIcon="eye"
         >
-          <>
-            Show query <Icon name="eye" />
-          </>
+          Show query
         </Button>
         <Button
           className={`${baseClass}__export-btn`}

--- a/frontend/pages/policies/edit/components/SaveNewPolicyModal/SaveNewPolicyModal.tsx
+++ b/frontend/pages/policies/edit/components/SaveNewPolicyModal/SaveNewPolicyModal.tsx
@@ -394,7 +394,7 @@ const SaveNewPolicyModal = ({
               variant="secondary"
               type="button"
               onClick={() => setShowAutomations(true)}
-              leftIcon="plus"
+              icon="plus"
             >
               Add automations
             </Button>

--- a/frontend/pages/policies/edit/components/SaveNewPolicyModal/SaveNewPolicyModal.tsx
+++ b/frontend/pages/policies/edit/components/SaveNewPolicyModal/SaveNewPolicyModal.tsx
@@ -394,8 +394,9 @@ const SaveNewPolicyModal = ({
               variant="secondary"
               type="button"
               onClick={() => setShowAutomations(true)}
+              leftIcon="plus"
             >
-              <Icon name="plus" /> Add automations
+              Add automations
             </Button>
           </div>
         )}

--- a/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
+++ b/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
@@ -22,7 +22,6 @@ import { DOCUMENT_TITLE_SUFFIX, SUPPORT_LINK } from "utilities/constants";
 import { getPathWithQueryParams } from "utilities/url";
 import useTeamIdParam from "hooks/useTeamIdParam";
 
-import Icon from "components/Icon";
 import Spinner from "components/Spinner/Spinner";
 import Button from "components/buttons/Button";
 import BackButton from "components/BackButton";
@@ -297,8 +296,9 @@ const QueryDetailsPage = ({
                               );
                           }}
                           disabled={isLiveQueryDisabled}
+                          rightIcon="run"
                         >
-                          Live report <Icon name="run" />
+                          Live report
                         </Button>
                       </div>
                     </TooltipWrapper>

--- a/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
+++ b/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
@@ -296,7 +296,8 @@ const QueryDetailsPage = ({
                               );
                           }}
                           disabled={isLiveQueryDisabled}
-                          rightIcon="run"
+                          icon="run"
+                          iconPosition="right"
                         >
                           Live report
                         </Button>

--- a/frontend/pages/queries/details/components/QueryReport/QueryReport.tsx
+++ b/frontend/pages/queries/details/components/QueryReport/QueryReport.tsx
@@ -11,7 +11,6 @@ import { IQueryReport, IQueryReportResultRow } from "interfaces/query_report";
 import PATHS from "router/paths";
 
 import Button from "components/buttons/Button";
-import Icon from "components/Icon/Icon";
 import TableContainer from "components/TableContainer";
 import TableCount from "components/TableContainer/TableCount";
 import { generateResultsCountText } from "components/TableContainer/utilities/TableContainerUtils";
@@ -85,11 +84,9 @@ const QueryReport = ({
           onClick={onExportQueryResults}
           variant="secondary"
           size="small"
+          rightIcon="download"
         >
-          <>
-            Export results
-            <Icon name="download" size="small" />
-          </>
+          Export results
         </Button>
       </div>
     );

--- a/frontend/pages/queries/details/components/QueryReport/QueryReport.tsx
+++ b/frontend/pages/queries/details/components/QueryReport/QueryReport.tsx
@@ -84,7 +84,8 @@ const QueryReport = ({
           onClick={onExportQueryResults}
           variant="secondary"
           size="small"
-          rightIcon="download"
+          icon="download"
+          iconPosition="right"
         >
           Export results
         </Button>

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -434,11 +434,8 @@ const EditQueryForm = ({
     }
 
     return (
-      <Button variant="subdued" onClick={onOpenSchemaSidebar}>
-        <>
-          Schema
-          <Icon name="info" size="small" />
-        </>
+      <Button variant="subdued" onClick={onOpenSchemaSidebar} rightIcon="info">
+        Schema
       </Button>
     );
   };
@@ -579,8 +576,9 @@ const EditQueryForm = ({
                 );
               }}
               disabled={disabledLiveQuery}
+              rightIcon="run"
             >
-              Live report <Icon name="run" />
+              Live report
             </Button>
           </TooltipWrapper>
         </div>
@@ -882,8 +880,9 @@ const EditQueryForm = ({
                   );
                 }}
                 disabled={disabledLiveQuery}
+                rightIcon="run"
               >
-                Live report <Icon name="run" />
+                Live report
               </Button>
             </TooltipWrapper>
           </div>

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -434,7 +434,12 @@ const EditQueryForm = ({
     }
 
     return (
-      <Button variant="subdued" onClick={onOpenSchemaSidebar} rightIcon="info">
+      <Button
+        variant="subdued"
+        onClick={onOpenSchemaSidebar}
+        icon="info"
+        iconPosition="right"
+      >
         Schema
       </Button>
     );
@@ -576,7 +581,8 @@ const EditQueryForm = ({
                 );
               }}
               disabled={disabledLiveQuery}
-              rightIcon="run"
+              icon="run"
+              iconPosition="right"
             >
               Live report
             </Button>
@@ -880,7 +886,8 @@ const EditQueryForm = ({
                   );
                 }}
                 disabled={disabledLiveQuery}
-                rightIcon="run"
+                icon="run"
+                iconPosition="right"
               >
                 Live report
               </Button>

--- a/frontend/pages/queries/edit/components/QueryResults/QueryResults.tsx
+++ b/frontend/pages/queries/edit/components/QueryResults/QueryResults.tsx
@@ -193,7 +193,8 @@ const QueryResults = ({
           className={`${baseClass}__show-query-btn`}
           onClick={onShowQueryModal}
           variant="secondary"
-          rightIcon="eye"
+          icon="eye"
+          iconPosition="right"
         >
           Show query
         </Button>
@@ -205,7 +206,8 @@ const QueryResults = ({
               : onExportQueryResults
           }
           variant="secondary"
-          rightIcon="download"
+          icon="download"
+          iconPosition="right"
         >
           Export {tableType}
         </Button>

--- a/frontend/pages/queries/edit/components/QueryResults/QueryResults.tsx
+++ b/frontend/pages/queries/edit/components/QueryResults/QueryResults.tsx
@@ -15,7 +15,6 @@ import { ICampaign, ICampaignError } from "interfaces/campaign";
 import { ITarget } from "interfaces/target";
 
 import Button from "components/buttons/Button";
-import Icon from "components/Icon/Icon";
 import TableContainer from "components/TableContainer";
 import TableCount from "components/TableContainer/TableCount";
 import TabNav from "components/TabNav";
@@ -194,10 +193,9 @@ const QueryResults = ({
           className={`${baseClass}__show-query-btn`}
           onClick={onShowQueryModal}
           variant="secondary"
+          rightIcon="eye"
         >
-          <>
-            Show query <Icon name="eye" />
-          </>
+          Show query
         </Button>
         <Button
           className={`${baseClass}__export-btn`}
@@ -207,11 +205,9 @@ const QueryResults = ({
               : onExportQueryResults
           }
           variant="secondary"
+          rightIcon="download"
         >
-          <>
-            Export {tableType}
-            <Icon name="download" />
-          </>
+          Export {tableType}
         </Button>
       </div>
     );

--- a/frontend/styles/global/_global.scss
+++ b/frontend/styles/global/_global.scss
@@ -149,7 +149,7 @@ form,
   }
 
   // Override button width to auto unless icon-only or wide buttons which has fixed widths
-  .button:not(.button--icon):not(.button--icon__small):not(.button__wide):not(.button--icon-only) {
+  .button:not(.button__wide):not(.button--icon-only) {
     width: auto;
   }
 
@@ -327,21 +327,13 @@ body.dark-mode .site-nav-item:not(.dup-org-logo):hover {
   background-color: $dark-mode-nav-hover;
 }
 
-body.dark-mode .card .button--inverse:hover,
-body.dark-mode .card .button--inverse-alert:hover,
-body.dark-mode .card .button--text-icon:hover,
-body.dark-mode .card .button--icon:hover,
 body.dark-mode .card .button--secondary:hover,
 body.dark-mode .card .button--subdued:hover {
   background-color: $core-fleet-white;
 }
 
 // A modal inside a card inherits the .card hover above, which matches the
-// modal surface and hides it. Restore the normal inverse hover.
-body.dark-mode .modal__modal_container .button--inverse:hover,
-body.dark-mode .modal__modal_container .button--inverse-alert:hover,
-body.dark-mode .modal__modal_container .button--text-icon:hover,
-body.dark-mode .modal__modal_container .button--icon:hover,
+// modal surface and hides it. Restore the normal secondary/subdued hover.
 body.dark-mode .modal__modal_container .button--secondary:hover,
 body.dark-mode .modal__modal_container .button--subdued:hover {
   background-color: $ui-fleet-black-5;


### PR DESCRIPTION
## Issue
Closes #34377

## Description
- New `Button` icon API: single `icon?: IconNames` prop with optional `iconPosition: "left" | "right"` (default `"left"`). Icon-only buttons are derived from `icon && no children` — no more `leftIcon` / `rightIcon` / `isIconOnly` heuristic and no `React.cloneElement` acrobatics on icon children.
- Icon rendering is centralized in `Button`: size derives from button `size` (16px default, 12px small), color derives from variant (`core-fleet-white` on `default` / `alert` / `oversized`; Icon default elsewhere). Callers stop passing `size` and `color` on icons.
- Spacing (per Mike T design review 2026-07-29): default-size buttons keep their base 16px horizontal padding with an 8px gap between icon and label; small-size buttons use 8px horizontal padding with a 4px gap. Horizontal padding does NOT change based on icon presence or icon side. Applies uniformly across `default`, `alert`, `secondary`, `subdued`.
- SCSS: single `--with-icon` class replaces `--with-left-icon` / `--with-right-icon`. Gap rules are scoped to the four icon-enabled variants, so the `icon` prop is a no-op on `link`, `pill`, `unstyled`, etc.
- Two constants at the top of `Button.tsx` are the single source of truth for future variant tweaks: `WHITE_TEXT_VARIANTS` and `ICON_ENABLED_VARIANTS`.
- Migrated ~74 call sites off the old `leftIcon` / `rightIcon` props and off the ad-hoc `<Button><Icon .../></Button>` child pattern. Sites that need a non-default icon color (e.g. TargetOption's green plus) or a `className` on the Icon (e.g. FeedListItem's close) intentionally stay on the child pattern.
- Fills in previously-missing `variant="default" size="small"` and `variant="alert" size="small"` SCSS (no existing callers used those combos).

## Screenrecording
- Storybook comparison against Figma for each variant × size × icon-side combo


<!-- recording pending -->


## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Buttons now support built-in icons positioned before or after labels, as well as icon-only actions.
  * Added clearer accessible labels for icon-only controls across common workflows.
* **Style**
  * Improved spacing, sizing, colors, and disabled states for buttons with icons.
  * Reduced spacing between pagination controls and refined dark-mode hover behavior.
* **Bug Fixes**
  * Standardized button rendering to preserve consistent icon alignment and appearance across the application.
* **Tests**
  * Expanded coverage for icon placement, variants, accessibility, sizing, loading, and legacy button content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->