### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/aws-cli/windows.json
+++ b/ee/maintained-apps/outputs/aws-cli/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.36.10",
+      "version": "2.36.11",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'AWS Command Line Interface v2 %' AND publisher = 'Amazon Web Services';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'AWS Command Line Interface v2 %' AND publisher = 'Amazon Web Services' AND version_compare(version, '2.36.10') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'AWS Command Line Interface v2 %' AND publisher = 'Amazon Web Services' AND version_compare(version, '2.36.11') < 0);"
       },
-      "installer_url": "https://awscli.amazonaws.com/AWSCLIV2-2.36.10.msi",
+      "installer_url": "https://awscli.amazonaws.com/AWSCLIV2-2.36.11.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "58bcd016",
-      "sha256": "73517ce321046fdaadc957a300bafdccdfe0b511ba529a316eb27bb3a43ac4d3",
+      "sha256": "c6e04d7564ad6a0ce9e03a135e2d9ce854f74192051c0c6d65ec516e0531c100",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/devin-desktop/darwin.json
+++ b/ee/maintained-apps/outputs/devin-desktop/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.5.17",
+      "version": "3.6.22",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.exafunction.windsurf';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.exafunction.windsurf' AND version_compare(bundle_short_version, '3.5.17') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.exafunction.windsurf' AND version_compare(bundle_short_version, '3.6.22') < 0);"
       },
-      "installer_url": "https://windsurf-stable.codeiumdata.com/darwin-arm64-dmg/stable/2c489dfc762456657db8662309c0d5e76e886397/Devin-darwin-arm64-3.5.17.dmg",
+      "installer_url": "https://windsurf-stable.codeiumdata.com/darwin-arm64-dmg/stable/d5152ff5891d78b46644988943b78f408d06b861/Devin-darwin-arm64-3.6.22.dmg",
       "install_script_ref": "917a2397",
       "uninstall_script_ref": "4fdaa2d1",
-      "sha256": "09a4c5f196367db5a669a435f2a08edd1b67a6418eefbf25a0b1befdbfef271c",
+      "sha256": "debc7af84cbfc1104cc57630edb9c58afdb96968835367bc066a1117a9810622",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/gitify/darwin.json
+++ b/ee/maintained-apps/outputs/gitify/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.1.1",
+      "version": "7.2.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.gitify';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.gitify' AND version_compare(bundle_short_version, '7.1.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.gitify' AND version_compare(bundle_short_version, '7.2.0') < 0);"
       },
-      "installer_url": "https://github.com/gitify-app/gitify/releases/download/v7.1.1/Gitify-7.1.1-universal-mac.zip",
+      "installer_url": "https://github.com/gitify-app/gitify/releases/download/v7.2.0/Gitify-7.2.0-universal-mac.zip",
       "install_script_ref": "4dfde5cf",
       "uninstall_script_ref": "33618979",
-      "sha256": "f0356be4f569a3796cede45ffc9f52ff15ac52459a1a926fa384b17fc0b47f29",
+      "sha256": "068435faeb84adaede0d749e798b967f7ac0ad0534043d489ad2d037cb658047",
       "default_categories": [
         "Utilities"
       ]

--- a/ee/maintained-apps/outputs/goland/windows.json
+++ b/ee/maintained-apps/outputs/goland/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.2.0.1",
+      "version": "2026.2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'GoLand %' AND publisher = 'JetBrains s.r.o.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'GoLand %' AND publisher = 'JetBrains s.r.o.' AND version_compare(version, '262.8665.336') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'GoLand %' AND publisher = 'JetBrains s.r.o.' AND version_compare(version, '262.8665.270') < 0);"
       },
-      "installer_url": "https://download.jetbrains.com/go/goland-2026.2.0.1.exe",
+      "installer_url": "https://download.jetbrains.com/go/goland-2026.2.exe",
       "install_script_ref": "6d754683",
       "uninstall_script_ref": "f2b296c7",
-      "sha256": "cbb1baa41c12bba7d973d2c614dfabea29ef03b2ca9ce84bb24b3f8c84dbf13e",
+      "sha256": "22ab9a1594c26894c0e470d0ac6f21177c7174b486cbd81130260e907895ee96",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/linear/darwin.json
+++ b/ee/maintained-apps/outputs/linear/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.31.1",
+      "version": "1.32.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.linear';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.linear' AND version_compare(bundle_short_version, '1.31.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.linear' AND version_compare(bundle_short_version, '1.32.0') < 0);"
       },
-      "installer_url": "https://releases.linear.app/Linear-1.31.1-universal.dmg",
+      "installer_url": "https://releases.linear.app/Linear-1.32.0-universal.dmg",
       "install_script_ref": "c1909feb",
       "uninstall_script_ref": "934dc9bd",
-      "sha256": "85a673f5175b7108856c2a9dcbf4b6e5a0ac16848a9f774502460bf0d8284d8c",
+      "sha256": "78fc057b2f9a8ee2425fd791e803bbea20704ceec12d4600ba608460027a36b5",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/rancher/darwin.json
+++ b/ee/maintained-apps/outputs/rancher/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.23.1",
+      "version": "1.24.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'io.rancherdesktop.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.rancherdesktop.app' AND version_compare(bundle_short_version, '1.23.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.rancherdesktop.app' AND version_compare(bundle_short_version, '1.24.0') < 0);"
       },
-      "installer_url": "https://github.com/rancher-sandbox/rancher-desktop/releases/download/v1.23.1/Rancher.Desktop-1.23.1.aarch64.dmg",
+      "installer_url": "https://github.com/rancher-sandbox/rancher-desktop/releases/download/v1.24.0/Rancher.Desktop-1.24.0.aarch64.dmg",
       "install_script_ref": "dbccbe89",
       "uninstall_script_ref": "fe73e13f",
-      "sha256": "4b4a3a06923d14b703da99d519268b8972d00104db4b8564d49faec64dcaee50",
+      "sha256": "0c4eb779d376f51e34b339124ad4f24b771a8f2c69718e839f89958209e78b34",
       "default_categories": [
         "Developer tools"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated AWS CLI for Windows to version 2.36.11.
  * Updated Windsurf for macOS to version 3.6.22.
  * Updated Gitify for macOS to version 7.2.0.
  * Updated GoLand for Windows to the 2026.2 release.
  * Updated Linear for macOS to version 1.32.0.
  * Updated Rancher Desktop for macOS to version 1.24.0.
  * Refreshed installer links and verification data for each release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->