### PR TITLE
Stop leaking live query campaign existence via the websocket results stream

### DIFF
--- a/changes/fix-stream-campaign-results-existence-leak
+++ b/changes/fix-stream-campaign-results-existence-leak
@@ -1,0 +1,1 @@
+* Fixed the live query results websocket stream returning a different error for a nonexistent campaign versus one owned by another user.

--- a/server/service/service_campaign_test.go
+++ b/server/service/service_campaign_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"crypto/tls"
+	"database/sql"
 	"log/slog"
 	"math/rand"
 	"net/http"
@@ -167,6 +168,81 @@ func TestStreamCampaignResultsClosesReditOnWSClose(t *testing.T) {
 		newActiveConn = s.ActiveCount
 	}
 	require.Equal(t, prevActiveConn-1, newActiveConn)
+}
+
+// TestStreamCampaignResultsDoesNotLeakCampaignExistence ensures that
+// selecting a nonexistent campaign and selecting a campaign owned by another
+// user produce the exact same websocket error message. Distinct messages
+// here would let an authenticated user enumerate other users' live query
+// campaigns by observing which response they get.
+func TestStreamCampaignResultsDoesNotLeakCampaignExistence(t *testing.T) {
+	ds := new(mock.Store)
+	svc, _ := newTestService(t, ds, nil, nil)
+
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return &fleet.AppConfig{}, nil
+	}
+	ds.SessionByKeyFunc = func(ctx context.Context, key string) (*fleet.Session, error) {
+		return &fleet.Session{
+			CreateTimestamp: fleet.CreateTimestamp{CreatedAt: time.Now()},
+			ID:              1,
+			AccessedAt:      time.Now(),
+			UserID:          1,
+			Key:             "observer-token",
+		}, nil
+	}
+	ds.UserByIDFunc = func(ctx context.Context, id uint) (*fleet.User, error) {
+		return &fleet.User{ID: 1, GlobalRole: new(fleet.RoleObserver)}, nil
+	}
+	ds.MarkSessionAccessedFunc = func(context.Context, *fleet.Session) error {
+		return nil
+	}
+
+	othersCampaignID := uint(99)
+	ds.DistributedQueryCampaignFunc = func(ctx context.Context, id uint) (*fleet.DistributedQueryCampaign, error) {
+		if id == othersCampaignID {
+			// Owned by a different user than the one authenticating below.
+			return &fleet.DistributedQueryCampaign{ID: othersCampaignID, UserID: 2}, nil
+		}
+		return nil, sql.ErrNoRows
+	}
+
+	pathHandler := makeStreamDistributedQueryCampaignResultsHandler(config.TestConfig().Server, svc, slog.New(slog.DiscardHandler))
+	s := httptest.NewServer(pathHandler("/api/{fleetversion:(?:v1|2022-04)}/fleet/results/"))
+	defer s.Close()
+	u := "ws" + strings.TrimPrefix(s.URL, "http") + "/api/2022-04/fleet/results/websocket"
+
+	dialer := &websocket.Dialer{
+		Proxy:            http.ProxyFromEnvironment,
+		HandshakeTimeout: 45 * time.Second,
+		TLSClientConfig:  &tls.Config{InsecureSkipVerify: true},
+	}
+
+	selectCampaign := func(t *testing.T, campaignID uint) string {
+		conn, _, err := dialer.Dial(u, nil)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		require.NoError(t, conn.WriteJSON(ws.JSONMessage{
+			Type: "auth",
+			Data: map[string]any{"token": "observer-token"},
+		}))
+		require.NoError(t, conn.WriteJSON(ws.JSONMessage{
+			Type: "select_campaign",
+			Data: map[string]any{"campaign_id": campaignID},
+		}))
+
+		_, msg, err := conn.ReadMessage()
+		require.NoError(t, err)
+		return string(msg)
+	}
+
+	nonExistentMsg := selectCampaign(t, 999999) // waits out the replica-lag retry/timeout
+	otherUsersMsg := selectCampaign(t, othersCampaignID)
+
+	assert.Equal(t, nonExistentMsg, otherUsersMsg,
+		"a nonexistent campaign and one owned by another user must be indistinguishable")
+	assert.Contains(t, nonExistentMsg, "forbidden")
 }
 
 func testUpdateStats(t *testing.T, ds *mysql.Datastore, usingReplica bool) {

--- a/server/service/service_campaigns.go
+++ b/server/service/service_campaigns.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"fmt"
 	"log/slog"
 	"time"
 
@@ -101,12 +100,14 @@ func (svc Service) StreamCampaignResults(ctx context.Context, conn *websocket.Co
 	select {
 	case err := <-done:
 		if err != nil {
-			_ = conn.WriteJSONError(fmt.Sprintf("cannot find campaign for ID %d", campaignID)) //nolint:errcheck
+			logger.InfoContext(ctx, "stream results campaign lookup failed", "err", err)
+			conn.WriteJSONError(authz.ForbiddenErrorMessage) //nolint:errcheck
 			return
 		}
 	case <-time.After(5 * time.Second):
 		stop <- struct{}{}
-		_ = conn.WriteJSONError(fmt.Sprintf("timeout: cannot find campaign for ID %d", campaignID)) //nolint:errcheck
+		logger.InfoContext(ctx, "stream results campaign lookup timed out")
+		conn.WriteJSONError(authz.ForbiddenErrorMessage) //nolint:errcheck
 		return
 	}
 


### PR DESCRIPTION
# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized websocket error responses when requested campaigns are unavailable.
  * Prevented campaign existence from being inferred through differing error messages.
  * Improved consistency for both nonexistent campaigns and campaigns inaccessible to the current user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->