### PR TITLE
Fix help text for Apple OS target form

### DIFF
--- a/frontend/pages/ManageControlsPage/OSUpdates/components/AppleOSTargetForm/AppleOSTargetForm.tsx
+++ b/frontend/pages/ManageControlsPage/OSUpdates/components/AppleOSTargetForm/AppleOSTargetForm.tsx
@@ -201,7 +201,7 @@ const AppleOSTargetForm = ({
           <>
             Use only versions{" "}
             <CustomLink
-              text="available from Apple."
+              text="available from Apple"
               newTab
               url="https://fleetdm.com/learn-more-about/apple-available-os-updates"
             />


### PR DESCRIPTION
- Remove period because the "Learn more" link comes right after:
<img width="645" height="111" alt="Screenshot 2026-07-30 at 8 42 32 AM" src="https://github.com/user-attachments/assets/1b5b45e6-0276-43bd-ba8b-99c1c293b71b" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Apple OS updates “Minimum version” help text by removing the trailing period from the Apple availability link label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->