### PR TITLE
Fix 5XXs on software install endpoints from software row locking

### DIFF
--- a/changes/50165-software-install-row-locking.md
+++ b/changes/50165-software-install-row-locking.md
@@ -1,0 +1,4 @@
+- Fixed 502 errors and timeouts on the software install endpoints caused by the hourly Fleet-maintained apps sync taking exclusive row locks on the entire `software` and `software_titles` tables while normalizing software names.
+- Fixed a macOS Fleet-maintained app's name being applied to the iOS and iPadOS apps that share its bundle identifier.
+- Fixed macOS Fleet-maintained app software names not being corrected when the catalog refresh failed, by moving the correction to its own schedule instead of running it as a step of that refresh.
+

--- a/changes/50165-software-install-row-locking.md
+++ b/changes/50165-software-install-row-locking.md
@@ -1,4 +1,4 @@
 - Fixed 502 errors and timeouts on the software install endpoints caused by the hourly Fleet-maintained apps sync taking exclusive row locks on the entire `software` and `software_titles` tables while normalizing software names.
 - Fixed a macOS Fleet-maintained app's name being applied to the iOS and iPadOS apps that share its bundle identifier.
-- Fixed macOS Fleet-maintained app software names not being corrected when the catalog refresh failed, by moving the correction to its own schedule instead of running it as a step of that refresh.
+- Fixed macOS Fleet-maintained app software names not being corrected when the catalog refresh failed.
 

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -2389,15 +2389,6 @@ func newWindowsMaintainedAppTitlesSchedule(
 	return s, nil
 }
 
-// Deliberately not a job on the Fleet-maintained apps schedule, for the same reasons as
-// newWindowsMaintainedAppTitlesSchedule: it reads only local software and software title
-// state, so it must keep running when the catalog fetch fails. Previously this ran inside
-// the catalog sync, which meant a failed or partial fetch also skipped the rename pass and
-// left names the previous fetch had already recorded uncorrected until a later sync
-// succeeded.
-//
-// Back-dating the first run also gives the pass a run shortly after startup, which is what
-// heals names that are already mismatched when a server upgrades.
 func newMacOSMaintainedAppNamesSchedule(
 	ctx context.Context,
 	instanceID string,

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -2331,7 +2331,21 @@ func newMaintainedAppSchedule(
 		// ensures it runs a few seconds after Fleet is started
 		schedule.WithDefaultPrevRunCreatedAt(time.Now().Add(priorJobDiff)),
 		schedule.WithJob("refresh_maintained_apps", func(ctx context.Context) error {
-			return maintained_apps.SyncAppsList(ctx, ds)
+			if err := maintained_apps.SyncAppsList(ctx, ds); err != nil {
+				return err
+			}
+
+			// A name the catalog just changed applies now rather than whenever
+			// CronMacOSMaintainedAppNames next runs. That schedule stays the authority, so
+			// this is best effort: the apps are stored at this point, and failing the sync
+			// over a rename the other schedule will redo would be the wrong trade. Running
+			// it only after a successful sync is the point -- a failed or partial fetch must
+			// not decide whether the rename pass happens, which is why it is a schedule of
+			// its own and no longer a step in here.
+			if err := ds.ReconcileMaintainedAppSoftwareNames(ctx); err != nil {
+				logger.WarnContext(ctx, "reconciling macOS maintained app software names after a catalog refresh", "err", err)
+			}
+			return nil
 		}),
 	)
 
@@ -2369,6 +2383,41 @@ func newWindowsMaintainedAppTitlesSchedule(
 		schedule.WithDefaultPrevRunCreatedAt(time.Now().Add(priorJobDiff)),
 		schedule.WithJob("reconcile_windows_maintained_app_titles", func(ctx context.Context) error {
 			return ds.ReconcileWindowsMaintainedAppSoftwareTitles(ctx)
+		}),
+	)
+
+	return s, nil
+}
+
+// Deliberately not a job on the Fleet-maintained apps schedule, for the same reasons as
+// newWindowsMaintainedAppTitlesSchedule: it reads only local software and software title
+// state, so it must keep running when the catalog fetch fails. Previously this ran inside
+// the catalog sync, which meant a failed or partial fetch also skipped the rename pass and
+// left names the previous fetch had already recorded uncorrected until a later sync
+// succeeded.
+//
+// Back-dating the first run also gives the pass a run shortly after startup, which is what
+// heals names that are already mismatched when a server upgrades.
+func newMacOSMaintainedAppNamesSchedule(
+	ctx context.Context,
+	instanceID string,
+	ds fleet.Datastore,
+	logger *slog.Logger,
+) (*schedule.Schedule, error) {
+	const (
+		name            = string(fleet.CronMacOSMaintainedAppNames)
+		defaultInterval = 1 * time.Hour
+		priorJobDiff    = -(defaultInterval - 30*time.Second)
+	)
+
+	logger = logger.With("cron", name)
+	s := schedule.New(
+		ctx, name, instanceID, defaultInterval, ds, ds,
+		schedule.WithLogger(logger),
+		// ensures it runs a few seconds after Fleet is started
+		schedule.WithDefaultPrevRunCreatedAt(time.Now().Add(priorJobDiff)),
+		schedule.WithJob("reconcile_macos_maintained_app_names", func(ctx context.Context) error {
+			return ds.ReconcileMaintainedAppSoftwareNames(ctx)
 		}),
 	)
 

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -2361,7 +2361,21 @@ func newMaintainedAppSchedule(
 		// ensures it runs a few seconds after Fleet is started
 		schedule.WithDefaultPrevRunCreatedAt(time.Now().Add(priorJobDiff)),
 		schedule.WithJob("refresh_maintained_apps", func(ctx context.Context) error {
-			return maintained_apps.SyncAppsList(ctx, ds)
+			if err := maintained_apps.SyncAppsList(ctx, ds); err != nil {
+				return err
+			}
+
+			// A name the catalog just changed applies now rather than whenever
+			// CronMacOSMaintainedAppNames next runs. That schedule stays the authority, so
+			// this is best effort: the apps are stored at this point, and failing the sync
+			// over a rename the other schedule will redo would be the wrong trade. Running
+			// it only after a successful sync is the point -- a failed or partial fetch must
+			// not decide whether the rename pass happens, which is why it is a schedule of
+			// its own and no longer a step in here.
+			if err := ds.ReconcileMaintainedAppSoftwareNames(ctx); err != nil {
+				logger.WarnContext(ctx, "reconciling macOS maintained app software names after a catalog refresh", "err", err)
+			}
+			return nil
 		}),
 	)
 
@@ -2399,6 +2413,41 @@ func newWindowsMaintainedAppTitlesSchedule(
 		schedule.WithDefaultPrevRunCreatedAt(time.Now().Add(priorJobDiff)),
 		schedule.WithJob("reconcile_windows_maintained_app_titles", func(ctx context.Context) error {
 			return ds.ReconcileWindowsMaintainedAppSoftwareTitles(ctx)
+		}),
+	)
+
+	return s, nil
+}
+
+// Deliberately not a job on the Fleet-maintained apps schedule, for the same reasons as
+// newWindowsMaintainedAppTitlesSchedule: it reads only local software and software title
+// state, so it must keep running when the catalog fetch fails. Previously this ran inside
+// the catalog sync, which meant a failed or partial fetch also skipped the rename pass and
+// left names the previous fetch had already recorded uncorrected until a later sync
+// succeeded.
+//
+// Back-dating the first run also gives the pass a run shortly after startup, which is what
+// heals names that are already mismatched when a server upgrades.
+func newMacOSMaintainedAppNamesSchedule(
+	ctx context.Context,
+	instanceID string,
+	ds fleet.Datastore,
+	logger *slog.Logger,
+) (*schedule.Schedule, error) {
+	const (
+		name            = string(fleet.CronMacOSMaintainedAppNames)
+		defaultInterval = 1 * time.Hour
+		priorJobDiff    = -(defaultInterval - 30*time.Second)
+	)
+
+	logger = logger.With("cron", name)
+	s := schedule.New(
+		ctx, name, instanceID, defaultInterval, ds, ds,
+		schedule.WithLogger(logger),
+		// ensures it runs a few seconds after Fleet is started
+		schedule.WithDefaultPrevRunCreatedAt(time.Now().Add(priorJobDiff)),
+		schedule.WithJob("reconcile_macos_maintained_app_names", func(ctx context.Context) error {
+			return ds.ReconcileMaintainedAppSoftwareNames(ctx)
 		}),
 	)
 

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -2419,15 +2419,6 @@ func newWindowsMaintainedAppTitlesSchedule(
 	return s, nil
 }
 
-// Deliberately not a job on the Fleet-maintained apps schedule, for the same reasons as
-// newWindowsMaintainedAppTitlesSchedule: it reads only local software and software title
-// state, so it must keep running when the catalog fetch fails. Previously this ran inside
-// the catalog sync, which meant a failed or partial fetch also skipped the rename pass and
-// left names the previous fetch had already recorded uncorrected until a later sync
-// succeeded.
-//
-// Back-dating the first run also gives the pass a run shortly after startup, which is what
-// heals names that are already mismatched when a server upgrades.
 func newMacOSMaintainedAppNamesSchedule(
 	ctx context.Context,
 	instanceID string,

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -2365,13 +2365,10 @@ func newMaintainedAppSchedule(
 				return err
 			}
 
-			// A name the catalog just changed applies now rather than whenever
-			// CronMacOSMaintainedAppNames next runs. That schedule stays the authority, so
-			// this is best effort: the apps are stored at this point, and failing the sync
-			// over a rename the other schedule will redo would be the wrong trade. Running
-			// it only after a successful sync is the point -- a failed or partial fetch must
-			// not decide whether the rename pass happens, which is why it is a schedule of
-			// its own and no longer a step in here.
+			// Best effort so a name the catalog just changed applies now instead of on
+			// CronMacOSMaintainedAppNames' next tick. That schedule owns the pass and
+			// surfaces its errors, so a failure here warns instead of failing a refresh
+			// that already succeeded.
 			if err := ds.ReconcileMaintainedAppSoftwareNames(ctx); err != nil {
 				logger.WarnContext(ctx, "reconciling macOS maintained app software names after a catalog refresh", "err", err)
 			}

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -2361,18 +2361,10 @@ func newMaintainedAppSchedule(
 		// ensures it runs a few seconds after Fleet is started
 		schedule.WithDefaultPrevRunCreatedAt(time.Now().Add(priorJobDiff)),
 		schedule.WithJob("refresh_maintained_apps", func(ctx context.Context) error {
-			if err := maintained_apps.SyncAppsList(ctx, ds); err != nil {
-				return err
-			}
-
-			// Best effort so a name the catalog just changed applies now instead of on
-			// CronMacOSMaintainedAppNames' next tick. That schedule owns the pass and
-			// surfaces its errors, so a failure here warns instead of failing a refresh
-			// that already succeeded.
-			if err := ds.ReconcileMaintainedAppSoftwareNames(ctx); err != nil {
-				logger.WarnContext(ctx, "reconciling macOS maintained app software names after a catalog refresh", "err", err)
-			}
-			return nil
+			return maintained_apps.SyncAppsList(ctx, ds)
+		}),
+		schedule.WithJob("reconcile_macos_maintained_app_names", func(ctx context.Context) error {
+			return ds.ReconcileMaintainedAppSoftwareNames(ctx)
 		}),
 	)
 
@@ -2410,32 +2402,6 @@ func newWindowsMaintainedAppTitlesSchedule(
 		schedule.WithDefaultPrevRunCreatedAt(time.Now().Add(priorJobDiff)),
 		schedule.WithJob("reconcile_windows_maintained_app_titles", func(ctx context.Context) error {
 			return ds.ReconcileWindowsMaintainedAppSoftwareTitles(ctx)
-		}),
-	)
-
-	return s, nil
-}
-
-func newMacOSMaintainedAppNamesSchedule(
-	ctx context.Context,
-	instanceID string,
-	ds fleet.Datastore,
-	logger *slog.Logger,
-) (*schedule.Schedule, error) {
-	const (
-		name            = string(fleet.CronMacOSMaintainedAppNames)
-		defaultInterval = 1 * time.Hour
-		priorJobDiff    = -(defaultInterval - 30*time.Second)
-	)
-
-	logger = logger.With("cron", name)
-	s := schedule.New(
-		ctx, name, instanceID, defaultInterval, ds, ds,
-		schedule.WithLogger(logger),
-		// ensures it runs a few seconds after Fleet is started
-		schedule.WithDefaultPrevRunCreatedAt(time.Now().Add(priorJobDiff)),
-		schedule.WithJob("reconcile_macos_maintained_app_names", func(ctx context.Context) error {
-			return ds.ReconcileMaintainedAppSoftwareNames(ctx)
 		}),
 	)
 

--- a/cmd/fleet/cron_registration.go
+++ b/cmd/fleet/cron_registration.go
@@ -310,6 +310,10 @@ func registerPremiumCrons(ctx context.Context, deps cronSchedulesDeps) {
 		return newWindowsMaintainedAppTitlesSchedule(ctx, deps.instanceID, deps.ds, deps.logger)
 	})
 
+	deps.register("failed to register macos maintained app names schedule", func() (fleet.CronSchedule, error) {
+		return newMacOSMaintainedAppNamesSchedule(ctx, deps.instanceID, deps.ds, deps.logger)
+	})
+
 	deps.register("failed to register maintained apps auto-update schedule", func() (fleet.CronSchedule, error) {
 		return newMaintainedAppsAutoUpdateSchedule(ctx, deps.instanceID, deps.ds, deps.softwareInstallStore, deps.logger)
 	})

--- a/cmd/fleet/cron_registration.go
+++ b/cmd/fleet/cron_registration.go
@@ -330,10 +330,6 @@ func registerPremiumCrons(ctx context.Context, deps cronSchedulesDeps) {
 		return newWindowsMaintainedAppTitlesSchedule(ctx, deps.instanceID, deps.ds, deps.logger)
 	})
 
-	deps.register("failed to register macos maintained app names schedule", func() (fleet.CronSchedule, error) {
-		return newMacOSMaintainedAppNamesSchedule(ctx, deps.instanceID, deps.ds, deps.logger)
-	})
-
 	deps.register("failed to register maintained apps auto-update schedule", func() (fleet.CronSchedule, error) {
 		return newMaintainedAppsAutoUpdateSchedule(ctx, deps.instanceID, deps.ds, deps.softwareInstallStore, deps.logger)
 	})

--- a/cmd/fleet/cron_registration.go
+++ b/cmd/fleet/cron_registration.go
@@ -330,6 +330,10 @@ func registerPremiumCrons(ctx context.Context, deps cronSchedulesDeps) {
 		return newWindowsMaintainedAppTitlesSchedule(ctx, deps.instanceID, deps.ds, deps.logger)
 	})
 
+	deps.register("failed to register macos maintained app names schedule", func() (fleet.CronSchedule, error) {
+		return newMacOSMaintainedAppNamesSchedule(ctx, deps.instanceID, deps.ds, deps.logger)
+	})
+
 	deps.register("failed to register maintained apps auto-update schedule", func() (fleet.CronSchedule, error) {
 		return newMaintainedAppsAutoUpdateSchedule(ctx, deps.instanceID, deps.ds, deps.softwareInstallStore, deps.logger)
 	})

--- a/server/datastore/mysql/maintained_apps.go
+++ b/server/datastore/mysql/maintained_apps.go
@@ -53,75 +53,204 @@ ON DUPLICATE KEY UPDATE
 	return app, nil
 }
 
+// maintainedAppNameReconcileBatchSize caps how many rows a single reconcile UPDATE
+// touches. Each batch is its own autocommit statement, so this bounds how long
+// InnoDB holds row locks on software / software_titles. A var so tests can lower it.
+var maintainedAppNameReconcileBatchSize = 500
+
 // ReconcileMaintainedAppSoftwareNames renames macOS software_titles and software rows
 // to the canonical Fleet-maintained app name (e.g. "Code" -> "Microsoft Visual Studio
 // Code"). Inventory and the installer already share a title via bundle_identifier, so
-// only the name needs correcting. Called once per catalog sync, which is the right
-// trigger because the canonical names come from that catalog; set-based and idempotent.
+// only the name needs correcting. Batched and idempotent.
+//
+// Runs on its own schedule (CronMacOSMaintainedAppNames) rather than as a step in the
+// catalog sync. Tying it to the sync meant a failed fetch, or one that errored part way
+// through its upserts, skipped the pass and left names the previous fetch had already
+// recorded uncorrected. The refresh still calls it on success, so a name the catalog just
+// changed applies immediately rather than on the next tick; the schedule is what covers a
+// refresh that failed.
 //
 // A bundle identifier is not unique across apps (Firefox and Firefox ESR both use
 // org.mozilla.firefox), so renaming by identifier alone is ambiguous: it renames first
 // by the precise installer link, then by bundle identifier but only where it maps to a
 // single app name.
 //
+// The writes deliberately avoid `UPDATE ... JOIN (<derived table>)`. The catalog subqueries
+// need GROUP BY, so MySQL materializes them, and at scale the optimizer flips to scanning the
+// target table once per materialized row. An UPDATE locks every row it reads -- the WHERE
+// filter is applied after the row is locked -- so that plan takes exclusive next-key locks on
+// all of software and software_titles, which blocks any insert needing a shared lock on a
+// software_titles row. That took down the software install endpoints, which reach
+// software_titles through their foreign keys.
+//
+// Discovery is a different matter and does join. That hazard is specific to UPDATE: a SELECT
+// here is a non-locking consistent read. So each pass finds its mismatched rows in one query
+// and then renames them by primary key in bounded batches, each batch its own statement, so
+// locks stay on a handful of rows and never span batches. Every UPDATE re-checks `name <> ?`,
+// which keeps the pass idempotent.
+//
 // Windows needs a merge rather than a rename and does not depend on the catalog, so it
 // runs separately. See ReconcileWindowsMaintainedAppSoftwareTitles.
 func (ds *Datastore) ReconcileMaintainedAppSoftwareNames(ctx context.Context) error {
-	// title_id -> name, for titles linked to a single FMA via their installer.
-	// GROUP BY also collapses a title's per-team installer rows to avoid fan-out.
-	const titleNameByFMA = `
+	// Reads go to the primary: the catalog refresh calls this straight after upserting those
+	// rows, so a replica may not have them yet and a freshly published name would be missed
+	// until the schedule's next tick. These are index lookups, not scans, and take no locks.
+	primaryCtx := ctxdb.RequirePrimary(ctx, true)
+
+	var renamedTitles, renamedSoftware int64
+
+	// Pass 1 renames via the precise installer link, pass 2 by bundle identifier where it maps
+	// to a single app. They run in order, each discovering only after the previous has applied,
+	// so where the two disagree the identifier wins and pass 2 never re-attempts what pass 1
+	// already fixed.
+	//
+	// Within a pass the title is renamed before its software rows and each write commits on its
+	// own, so a failure part-way can leave a title carrying the canonical name while its
+	// software rows still carry the reported one. That window is preferred over the
+	// alternative: one transaction spanning every write is what caused the lock contention this
+	// pass was rewritten to avoid. The next run repairs it.
+	steps := []struct {
+		label      string
+		selectStmt string
+		updateStmt string
+		renamed    *int64
+	}{
+		{"software_titles by installer link", mismatchedTitlesByInstallerLink, updateSoftwareTitleNames, &renamedTitles},
+		{"software by installer link", mismatchedSoftwareByInstallerLink, updateSoftwareNames, &renamedSoftware},
+		{"software_titles by bundle identifier", mismatchedTitlesByIdentifier, updateSoftwareTitleNames, &renamedTitles},
+		{"software by bundle identifier", mismatchedSoftwareByIdentifier, updateSoftwareNames, &renamedSoftware},
+	}
+
+	for _, step := range steps {
+		var rows []struct {
+			ID   uint   `db:"id"`
+			Name string `db:"name"`
+		}
+		if err := sqlx.SelectContext(ctx, ds.reader(primaryCtx), &rows, step.selectStmt); err != nil {
+			return ctxerr.Wrapf(ctx, err, "reconcile maintained app names: find %s", step.label)
+		}
+		if len(rows) == 0 {
+			continue
+		}
+
+		// One UPDATE carries one name, so group the ids by the name they should get. Grouping is
+		// an exact map lookup, never a comparison, so it cannot disagree with the
+		// collation-sensitive `name <> ?` that the UPDATE itself applies.
+		idsByName := make(map[string][]uint, len(rows))
+		for _, r := range rows {
+			idsByName[r.Name] = append(idsByName[r.Name], r.ID)
+		}
+
+		for name, ids := range idsByName {
+			if err := common_mysql.BatchProcessSimple(ids, maintainedAppNameReconcileBatchSize, func(batch []uint) error {
+				stmt, args, err := sqlx.In(step.updateStmt, name, batch, name)
+				if err != nil {
+					return ctxerr.Wrap(ctx, err, "build rename statement")
+				}
+				n, err := ds.renameWithRetry(ctx, stmt, args...)
+				if err != nil {
+					return err
+				}
+				*step.renamed += n
+				return nil
+			}); err != nil {
+				return ctxerr.Wrapf(ctx, err, "reconcile maintained app names: rename %s", step.label)
+			}
+		}
+	}
+
+	if (renamedTitles > 0 || renamedSoftware > 0) && ds.logger != nil {
+		ds.logger.InfoContext(ctx, "reconciled Fleet-maintained app software names",
+			"software_titles_renamed", renamedTitles, "software_renamed", renamedSoftware)
+	}
+
+	return nil
+}
+
+// Statements for ReconcileMaintainedAppSoftwareNames.
+//
+// The join order is pinned with STRAIGHT_JOIN so the materialized catalog is always the outer
+// table and each software row is reached by index: ~960 index lookups inside one query rather
+// than one query per catalog entry. Left to itself the optimizer can pick the
+// scan-per-catalog-row plan instead, which is what made the original UPDATE examine ~106M
+// rows. The name comparison stays in SQL so it uses the columns' utf8mb4_unicode_ci
+// collation; comparing in Go would be byte-exact, disagree with the UPDATE's own predicate,
+// and re-select case-only differences on every run.
+//
+// additional_identifier is 1 for ios_apps and 2 for ipados_apps, so requiring 0 keeps a macOS
+// app's canonical name off its iOS and iPadOS sibling titles, which are distinct products
+// that happen to share a bundle identifier. `software` has no such column, so it excludes
+// those sources directly.
+const (
+	// title_id -> name, for titles linked to a single app via their installer. GROUP BY also
+	// collapses a title's per-team installer rows to avoid fan-out.
+	catalogNamesByTitle = `
 		SELECT si.title_id, MIN(fma.name) AS name
 		FROM software_installers si
 		JOIN fleet_maintained_apps fma
 			ON fma.id = si.fleet_maintained_app_id AND fma.platform = 'darwin'
+		WHERE si.title_id IS NOT NULL
 		GROUP BY si.title_id
 		HAVING COUNT(DISTINCT fma.name) = 1`
 
-	// darwin bundle identifiers mapping to exactly one FMA name; shared ones are excluded.
-	const unambiguousByIdentifier = `
+	// darwin bundle identifiers mapping to exactly one app name; shared ones are excluded.
+	catalogNamesByIdentifier = `
 		SELECT unique_identifier, MIN(name) AS name
 		FROM fleet_maintained_apps
 		WHERE platform = 'darwin'
 		GROUP BY unique_identifier
 		HAVING COUNT(DISTINCT name) = 1`
 
-	updates := []struct {
-		label string
-		stmt  string
-	}{
-		// Pass 1: precise, via installer link.
-		{"software_titles by installer link", `
-			UPDATE software_titles st
-				JOIN (` + titleNameByFMA + `) fma ON fma.title_id = st.id
-			SET st.name = fma.name
-			WHERE st.name <> fma.name`},
-		{"software by installer link", `
-			UPDATE software s
-				JOIN (` + titleNameByFMA + `) fma ON fma.title_id = s.title_id
-			SET s.name = fma.name
-			WHERE s.name <> fma.name`},
+	mismatchedTitlesByInstallerLink = `
+		SELECT st.id, fma.name
+		FROM (` + catalogNamesByTitle + `) fma
+		STRAIGHT_JOIN software_titles st ON st.id = fma.title_id
+		WHERE st.name <> fma.name`
 
-		// Pass 2: by bundle identifier, unambiguous only.
-		{"software_titles by bundle identifier", `
-			UPDATE software_titles st
-				JOIN (` + unambiguousByIdentifier + `) fma ON fma.unique_identifier = st.bundle_identifier
-			SET st.name = fma.name
-			WHERE st.name <> fma.name`},
-		{"software by bundle identifier", `
-			UPDATE software s
-				JOIN (` + unambiguousByIdentifier + `) fma ON fma.unique_identifier = s.bundle_identifier
-			SET s.name = fma.name
-			WHERE s.name <> fma.name`},
-	}
+	mismatchedSoftwareByInstallerLink = `
+		SELECT s.id, fma.name
+		FROM (` + catalogNamesByTitle + `) fma
+		STRAIGHT_JOIN software s ON s.title_id = fma.title_id
+		WHERE s.name <> fma.name`
 
-	return ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
-		for _, u := range updates {
-			if _, err := tx.ExecContext(ctx, u.stmt); err != nil {
-				return ctxerr.Wrapf(ctx, err, "reconcile maintained app names: %s", u.label)
-			}
+	mismatchedTitlesByIdentifier = `
+		SELECT st.id, fma.name
+		FROM (` + catalogNamesByIdentifier + `) fma
+		STRAIGHT_JOIN software_titles st
+			ON st.bundle_identifier = fma.unique_identifier AND st.additional_identifier = 0
+		WHERE st.name <> fma.name`
+
+	mismatchedSoftwareByIdentifier = `
+		SELECT s.id, fma.name
+		FROM (` + catalogNamesByIdentifier + `) fma
+		STRAIGHT_JOIN software s
+			ON s.bundle_identifier = fma.unique_identifier
+			AND s.source NOT IN ('ios_apps', 'ipados_apps')
+		WHERE s.name <> fma.name`
+
+	updateSoftwareTitleNames = `UPDATE software_titles SET name = ? WHERE id IN (?) AND name <> ?`
+
+	updateSoftwareNames = `UPDATE software SET name = ? WHERE id IN (?) AND name <> ?`
+)
+
+// renameWithRetry runs one rename statement, retrying the transient lock errors that
+// concurrent software ingestion can produce. The batches are small and each runs in its own
+// transaction, so the retry never widens the lock scope.
+func (ds *Datastore) renameWithRetry(ctx context.Context, stmt string, args ...any) (int64, error) {
+	var renamed int64
+	err := ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
+		res, err := tx.ExecContext(ctx, stmt, args...)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "rename rows")
 		}
+		n, err := res.RowsAffected()
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "count renamed rows")
+		}
+		renamed = n
 		return nil
 	})
+	return renamed, err
 }
 
 // ReconcileWindowsMaintainedAppSoftwareTitles collapses versioned Windows program

--- a/server/datastore/mysql/maintained_apps.go
+++ b/server/datastore/mysql/maintained_apps.go
@@ -54,15 +54,14 @@ ON DUPLICATE KEY UPDATE
 }
 
 // maintainedAppNameReconcileBatchSize caps how many rows a single reconcile UPDATE
-// touches. Each batch is its own autocommit statement, so this bounds how long
-// InnoDB holds row locks on software / software_titles. A var so tests can lower it.
+// touches. Each batch commits its own transaction, so this bounds how long InnoDB
+// holds row locks on software / software_titles. A var so tests can lower it.
 var maintainedAppNameReconcileBatchSize = 500
 
 // maintainedAppNameReconcileDiscoveryLimit caps how many mismatched rows one discovery
-// SELECT returns, bounding the pass's memory no matter how large the catalog or the
-// software inventory grows. Renaming a window removes its rows from the next SELECT's
-// result, so the pass re-runs the same query until a window comes back short rather
-// than paginating with an offset. A var so tests can lower it.
+// SELECT returns, bounding the pass's memory no matter how many rows need renaming;
+// the windowed loop in ReconcileMaintainedAppSoftwareNames drains rows past it. A var
+// so tests can lower it.
 var maintainedAppNameReconcileDiscoveryLimit = 10_000
 
 // ReconcileMaintainedAppSoftwareNames renames macOS software_titles and software rows
@@ -70,39 +69,18 @@ var maintainedAppNameReconcileDiscoveryLimit = 10_000
 // Code"). Inventory and the installer already share a title via bundle_identifier, so
 // only the name needs correcting. Batched and idempotent.
 //
-// Runs on its own schedule (CronMacOSMaintainedAppNames) rather than as a step in the
-// catalog sync. Tying it to the sync meant a failed fetch, or one that errored part way
-// through its upserts, skipped the pass and left names the previous fetch had already
-// recorded uncorrected. The refresh still calls it on success, so a name the catalog just
-// changed applies immediately rather than on the next tick; the schedule is what covers a
-// refresh that failed.
-//
 // A bundle identifier is not unique across apps (Firefox and Firefox ESR both use
 // org.mozilla.firefox), so renaming by identifier alone is ambiguous: it renames first
 // by the precise installer link, then by bundle identifier but only where it maps to a
 // single app name.
 //
-// The writes deliberately avoid `UPDATE ... JOIN (<derived table>)`. The catalog subqueries
-// need GROUP BY, so MySQL materializes them, and at scale the optimizer flips to scanning the
-// target table once per materialized row. An UPDATE locks every row it reads -- the WHERE
-// filter is applied after the row is locked -- so that plan takes exclusive next-key locks on
-// all of software and software_titles, which blocks any insert needing a shared lock on a
-// software_titles row. That took down the software install endpoints, which reach
-// software_titles through their foreign keys.
-//
 // Discovery is a different matter and does join. That hazard is specific to UPDATE: a SELECT
 // here is a non-locking consistent read. So each pass finds its mismatched rows in
-// LIMIT-bounded windows and renames them by primary key in bounded batches, each batch its
-// own statement, so locks stay on a handful of rows and never span batches, and memory is
+// LIMIT-bounded windows and renames them by primary key in small batches, each batch its own
+// transaction: locks stay on a handful of rows and never span batches, and memory stays
 // bounded no matter how many rows are mismatched. Every UPDATE re-checks `name <> ?`, which
 // keeps the pass idempotent.
-//
-// Windows needs a merge rather than a rename and does not depend on the catalog, so it
-// runs separately. See ReconcileWindowsMaintainedAppSoftwareTitles.
 func (ds *Datastore) ReconcileMaintainedAppSoftwareNames(ctx context.Context) error {
-	// Reads go to the primary: the catalog refresh calls this straight after upserting those
-	// rows, so a replica may not have them yet and a freshly published name would be missed
-	// until the schedule's next tick. These are index lookups, not scans, and take no locks.
 	primaryCtx := ctxdb.RequirePrimary(ctx, true)
 
 	var renamedTitles, renamedSoftware int64
@@ -134,7 +112,7 @@ func (ds *Datastore) ReconcileMaintainedAppSoftwareNames(ctx context.Context) er
 		// memory. Renaming a window removes its rows from the next SELECT's result -- every
 		// UPDATE re-checks `name <> ?` -- so re-running the same query walks the remainder
 		// without an offset, and a window that comes back short means nothing is left. A
-		// selected row the rename cannot fix would error out rather than loop.
+		// rename that fails returns its error, so the loop cannot spin on rows it cannot fix.
 		for {
 			var rows []struct {
 				ID   uint   `db:"id"`
@@ -147,9 +125,7 @@ func (ds *Datastore) ReconcileMaintainedAppSoftwareNames(ctx context.Context) er
 				break
 			}
 
-			// One UPDATE carries one name, so group the ids by the name they should get. Grouping is
-			// an exact map lookup, never a comparison, so it cannot disagree with the
-			// collation-sensitive `name <> ?` that the UPDATE itself applies.
+			// One UPDATE carries one name, so group the ids by the name they should get.
 			idsByName := make(map[string][]uint, len(rows))
 			for _, r := range rows {
 				idsByName[r.Name] = append(idsByName[r.Name], r.ID)
@@ -189,12 +165,11 @@ func (ds *Datastore) ReconcileMaintainedAppSoftwareNames(ctx context.Context) er
 // Statements for ReconcileMaintainedAppSoftwareNames.
 //
 // The join order is pinned with STRAIGHT_JOIN so the materialized catalog is always the outer
-// table and each software row is reached by index: ~960 index lookups inside one query rather
-// than one query per catalog entry. Left to itself the optimizer can pick the
-// scan-per-catalog-row plan instead, which is what made the original UPDATE examine ~106M
-// rows. The name comparison stays in SQL so it uses the columns' utf8mb4_unicode_ci
-// collation; comparing in Go would be byte-exact, disagree with the UPDATE's own predicate,
-// and re-select case-only differences on every run.
+// table and every software row is reached by index. Left to itself the optimizer can flip
+// that around and scan the target table once per catalog row -- the plan behind the incident
+// described on the function. The name comparison stays in SQL so it uses the columns'
+// utf8mb4_unicode_ci collation; comparing in Go would be byte-exact, disagree with the
+// UPDATE's own predicate, and re-select case-only differences on every run.
 //
 // additional_identifier is 1 for ios_apps and 2 for ipados_apps, so requiring 0 keeps a macOS
 // app's canonical name off its iOS and iPadOS sibling titles, which are distinct products

--- a/server/datastore/mysql/maintained_apps.go
+++ b/server/datastore/mysql/maintained_apps.go
@@ -140,7 +140,7 @@ func (ds *Datastore) ReconcileMaintainedAppSoftwareNames(ctx context.Context) er
 				ID   uint   `db:"id"`
 				Name string `db:"name"`
 			}
-			if err := sqlx.SelectContext(ctx, ds.reader(primaryCtx), &rows, step.selectStmt, maintainedAppNameReconcileDiscoveryLimit); err != nil {
+			if err := sqlx.SelectContext(primaryCtx, ds.reader(primaryCtx), &rows, step.selectStmt, maintainedAppNameReconcileDiscoveryLimit); err != nil {
 				return ctxerr.Wrapf(ctx, err, "reconcile maintained app names: find %s", step.label)
 			}
 			if len(rows) == 0 {

--- a/server/datastore/mysql/maintained_apps.go
+++ b/server/datastore/mysql/maintained_apps.go
@@ -58,6 +58,13 @@ ON DUPLICATE KEY UPDATE
 // InnoDB holds row locks on software / software_titles. A var so tests can lower it.
 var maintainedAppNameReconcileBatchSize = 500
 
+// maintainedAppNameReconcileDiscoveryLimit caps how many mismatched rows one discovery
+// SELECT returns, bounding the pass's memory no matter how large the catalog or the
+// software inventory grows. Renaming a window removes its rows from the next SELECT's
+// result, so the pass re-runs the same query until a window comes back short rather
+// than paginating with an offset. A var so tests can lower it.
+var maintainedAppNameReconcileDiscoveryLimit = 10_000
+
 // ReconcileMaintainedAppSoftwareNames renames macOS software_titles and software rows
 // to the canonical Fleet-maintained app name (e.g. "Code" -> "Microsoft Visual Studio
 // Code"). Inventory and the installer already share a title via bundle_identifier, so
@@ -84,10 +91,11 @@ var maintainedAppNameReconcileBatchSize = 500
 // software_titles through their foreign keys.
 //
 // Discovery is a different matter and does join. That hazard is specific to UPDATE: a SELECT
-// here is a non-locking consistent read. So each pass finds its mismatched rows in one query
-// and then renames them by primary key in bounded batches, each batch its own statement, so
-// locks stay on a handful of rows and never span batches. Every UPDATE re-checks `name <> ?`,
-// which keeps the pass idempotent.
+// here is a non-locking consistent read. So each pass finds its mismatched rows in
+// LIMIT-bounded windows and renames them by primary key in bounded batches, each batch its
+// own statement, so locks stay on a handful of rows and never span batches, and memory is
+// bounded no matter how many rows are mismatched. Every UPDATE re-checks `name <> ?`, which
+// keeps the pass idempotent.
 //
 // Windows needs a merge rather than a rename and does not depend on the catalog, so it
 // runs separately. See ReconcileWindowsMaintainedAppSoftwareTitles.
@@ -122,39 +130,50 @@ func (ds *Datastore) ReconcileMaintainedAppSoftwareNames(ctx context.Context) er
 	}
 
 	for _, step := range steps {
-		var rows []struct {
-			ID   uint   `db:"id"`
-			Name string `db:"name"`
-		}
-		if err := sqlx.SelectContext(ctx, ds.reader(primaryCtx), &rows, step.selectStmt); err != nil {
-			return ctxerr.Wrapf(ctx, err, "reconcile maintained app names: find %s", step.label)
-		}
-		if len(rows) == 0 {
-			continue
-		}
+		// Discovery is windowed by LIMIT so the pass never holds every mismatched row in
+		// memory. Renaming a window removes its rows from the next SELECT's result -- every
+		// UPDATE re-checks `name <> ?` -- so re-running the same query walks the remainder
+		// without an offset, and a window that comes back short means nothing is left. A
+		// selected row the rename cannot fix would error out rather than loop.
+		for {
+			var rows []struct {
+				ID   uint   `db:"id"`
+				Name string `db:"name"`
+			}
+			if err := sqlx.SelectContext(ctx, ds.reader(primaryCtx), &rows, step.selectStmt, maintainedAppNameReconcileDiscoveryLimit); err != nil {
+				return ctxerr.Wrapf(ctx, err, "reconcile maintained app names: find %s", step.label)
+			}
+			if len(rows) == 0 {
+				break
+			}
 
-		// One UPDATE carries one name, so group the ids by the name they should get. Grouping is
-		// an exact map lookup, never a comparison, so it cannot disagree with the
-		// collation-sensitive `name <> ?` that the UPDATE itself applies.
-		idsByName := make(map[string][]uint, len(rows))
-		for _, r := range rows {
-			idsByName[r.Name] = append(idsByName[r.Name], r.ID)
-		}
+			// One UPDATE carries one name, so group the ids by the name they should get. Grouping is
+			// an exact map lookup, never a comparison, so it cannot disagree with the
+			// collation-sensitive `name <> ?` that the UPDATE itself applies.
+			idsByName := make(map[string][]uint, len(rows))
+			for _, r := range rows {
+				idsByName[r.Name] = append(idsByName[r.Name], r.ID)
+			}
 
-		for name, ids := range idsByName {
-			if err := common_mysql.BatchProcessSimple(ids, maintainedAppNameReconcileBatchSize, func(batch []uint) error {
-				stmt, args, err := sqlx.In(step.updateStmt, name, batch, name)
-				if err != nil {
-					return ctxerr.Wrap(ctx, err, "build rename statement")
+			for name, ids := range idsByName {
+				if err := common_mysql.BatchProcessSimple(ids, maintainedAppNameReconcileBatchSize, func(batch []uint) error {
+					stmt, args, err := sqlx.In(step.updateStmt, name, batch, name)
+					if err != nil {
+						return ctxerr.Wrap(ctx, err, "build rename statement")
+					}
+					n, err := ds.renameWithRetry(ctx, stmt, args...)
+					if err != nil {
+						return err
+					}
+					*step.renamed += n
+					return nil
+				}); err != nil {
+					return ctxerr.Wrapf(ctx, err, "reconcile maintained app names: rename %s", step.label)
 				}
-				n, err := ds.renameWithRetry(ctx, stmt, args...)
-				if err != nil {
-					return err
-				}
-				*step.renamed += n
-				return nil
-			}); err != nil {
-				return ctxerr.Wrapf(ctx, err, "reconcile maintained app names: rename %s", step.label)
+			}
+
+			if len(rows) < maintainedAppNameReconcileDiscoveryLimit {
+				break
 			}
 		}
 	}
@@ -205,20 +224,23 @@ const (
 		SELECT st.id, fma.name
 		FROM (` + catalogNamesByTitle + `) fma
 		STRAIGHT_JOIN software_titles st ON st.id = fma.title_id
-		WHERE st.name <> fma.name`
+		WHERE st.name <> fma.name
+		LIMIT ?`
 
 	mismatchedSoftwareByInstallerLink = `
 		SELECT s.id, fma.name
 		FROM (` + catalogNamesByTitle + `) fma
 		STRAIGHT_JOIN software s ON s.title_id = fma.title_id
-		WHERE s.name <> fma.name`
+		WHERE s.name <> fma.name
+		LIMIT ?`
 
 	mismatchedTitlesByIdentifier = `
 		SELECT st.id, fma.name
 		FROM (` + catalogNamesByIdentifier + `) fma
 		STRAIGHT_JOIN software_titles st
 			ON st.bundle_identifier = fma.unique_identifier AND st.additional_identifier = 0
-		WHERE st.name <> fma.name`
+		WHERE st.name <> fma.name
+		LIMIT ?`
 
 	mismatchedSoftwareByIdentifier = `
 		SELECT s.id, fma.name
@@ -226,7 +248,8 @@ const (
 		STRAIGHT_JOIN software s
 			ON s.bundle_identifier = fma.unique_identifier
 			AND s.source NOT IN ('ios_apps', 'ipados_apps')
-		WHERE s.name <> fma.name`
+		WHERE s.name <> fma.name
+		LIMIT ?`
 
 	updateSoftwareTitleNames = `UPDATE software_titles SET name = ? WHERE id IN (?) AND name <> ?`
 

--- a/server/datastore/mysql/maintained_apps.go
+++ b/server/datastore/mysql/maintained_apps.go
@@ -166,10 +166,10 @@ func (ds *Datastore) ReconcileMaintainedAppSoftwareNames(ctx context.Context) er
 //
 // The join order is pinned with STRAIGHT_JOIN so the materialized catalog is always the outer
 // table and every software row is reached by index. Left to itself the optimizer can flip
-// that around and scan the target table once per catalog row -- the plan behind the incident
-// described on the function. The name comparison stays in SQL so it uses the columns'
-// utf8mb4_unicode_ci collation; comparing in Go would be byte-exact, disagree with the
-// UPDATE's own predicate, and re-select case-only differences on every run.
+// that around and scan the target table once per catalog row. The name comparison stays in
+// SQL so it uses the columns' utf8mb4_unicode_ci collation; comparing in Go would be
+// byte-exact, disagree with the UPDATE's own predicate, and re-select case-only differences
+// on every run.
 //
 // additional_identifier is 1 for ios_apps and 2 for ipados_apps, so requiring 0 keeps a macOS
 // app's canonical name off its iOS and iPadOS sibling titles, which are distinct products

--- a/server/datastore/mysql/maintained_apps_test.go
+++ b/server/datastore/mysql/maintained_apps_test.go
@@ -57,6 +57,11 @@ func TestMaintainedApps(t *testing.T) {
 		{"WindowsFMAReconcileIndependentOfCatalogSync", testWindowsFMAReconcileIndependentOfCatalogSync},
 		{"ReconcileSoftwareNames", testReconcileSoftwareNames},
 		{"ReconcileSoftwareNamesSharedIdentifier", testReconcileSoftwareNamesSharedIdentifier},
+		{"ReconcileSoftwareNamesBatched", testReconcileSoftwareNamesBatched},
+		{"ReconcileSoftwareNamesOrphanedInstaller", testReconcileSoftwareNamesOrphanedInstaller},
+		{"ReconcileSoftwareNamesIdentifierWinsOverInstallerLink", testReconcileSoftwareNamesIdentifierWinsOverInstallerLink},
+		{"ReconcileSoftwareNamesMultiTeamInstallers", testReconcileSoftwareNamesMultiTeamInstallers},
+		{"ReconcileSoftwareNamesLeavesMobileSiblings", testReconcileSoftwareNamesLeavesMobileSiblings},
 		{"ListAvailableAppsSharedIdentifier", testListAvailableAppsSharedIdentifier},
 	}
 
@@ -1201,6 +1206,373 @@ func testReconcileSoftwareNamesSharedIdentifier(t *testing.T, ds *Datastore) {
 			`SELECT name FROM software WHERE title_id = ? AND bundle_identifier = 'org.mozilla.firefox'`, titleID)
 	})
 	require.Equal(t, "Mozilla Firefox", softwareName)
+}
+
+// testReconcileSoftwareNamesBatched: reconcile renames in bounded batches to keep
+// InnoDB row locks short-lived, so it must keep walking until every matching row is
+// renamed, and it must not touch rows outside the match set.
+func testReconcileSoftwareNamesBatched(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	// Force several batches over a handful of rows.
+	oldBatchSize := maintainedAppNameReconcileBatchSize
+	maintainedAppNameReconcileBatchSize = 2
+	t.Cleanup(func() { maintainedAppNameReconcileBatchSize = oldBatchSize })
+
+	user := test.NewUser(t, ds, "Zaphod Beeblebrox", "zaphod@example.com", true)
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "Team Batched"})
+	require.NoError(t, err)
+
+	host, err := ds.NewHost(ctx, &fleet.Host{
+		Hostname:        "batched-host",
+		Platform:        "darwin",
+		OsqueryHostID:   new("batched-osquery-id"),
+		NodeKey:         new("batched-node-key"),
+		DetailUpdatedAt: ds.clock.Now(),
+		LabelUpdatedAt:  ds.clock.Now(),
+		PolicyUpdatedAt: ds.clock.Now(),
+		SeenTime:        ds.clock.Now(),
+	})
+	require.NoError(t, err)
+
+	// Seven versions of one app, so the rename spans four batches of two. Plus an
+	// unrelated app with no FMA, which must never be renamed.
+	var software []fleet.Software
+	for _, version := range []string{"1.0", "2.0", "3.0", "4.0", "5.0", "6.0", "7.0"} {
+		software = append(software, fleet.Software{
+			Name: "Code", Version: version, Source: "apps", BundleIdentifier: "com.microsoft.VSCode",
+		})
+	}
+	software = append(software, fleet.Software{
+		Name: "Unrelated", Version: "1.0", Source: "apps", BundleIdentifier: "com.example.unrelated",
+	})
+	_, err = ds.UpdateHostSoftware(ctx, host.ID, software)
+	require.NoError(t, err)
+
+	softwareNames := func(bundleID string) []string {
+		var names []string
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			return sqlx.SelectContext(ctx, q, &names,
+				`SELECT name FROM software WHERE bundle_identifier = ? ORDER BY id`, bundleID)
+		})
+		return names
+	}
+	titleName := func(bundleID string) string {
+		var name string
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			return sqlx.GetContext(ctx, q, &name,
+				`SELECT name FROM software_titles WHERE bundle_identifier = ?`, bundleID)
+		})
+		return name
+	}
+
+	require.Equal(t, []string{"Code", "Code", "Code", "Code", "Code", "Code", "Code"}, softwareNames("com.microsoft.VSCode"))
+
+	vscode, err := ds.UpsertMaintainedApp(ctx, &fleet.MaintainedApp{
+		Name:             "Microsoft Visual Studio Code",
+		Slug:             "visual-studio-code/darwin",
+		Platform:         "darwin",
+		UniqueIdentifier: "com.microsoft.VSCode",
+	})
+	require.NoError(t, err)
+
+	// Pass 2 (by unambiguous bundle identifier) must rename all seven rows, not just
+	// the first batch.
+	require.NoError(t, ds.ReconcileMaintainedAppSoftwareNames(ctx))
+	require.Equal(t, []string{
+		"Microsoft Visual Studio Code", "Microsoft Visual Studio Code", "Microsoft Visual Studio Code",
+		"Microsoft Visual Studio Code", "Microsoft Visual Studio Code", "Microsoft Visual Studio Code",
+		"Microsoft Visual Studio Code",
+	}, softwareNames("com.microsoft.VSCode"))
+	require.Equal(t, "Microsoft Visual Studio Code", titleName("com.microsoft.VSCode"))
+
+	// The app with no FMA is outside the match set and must be untouched.
+	require.Equal(t, []string{"Unrelated"}, softwareNames("com.example.unrelated"))
+	require.Equal(t, "Unrelated", titleName("com.example.unrelated"))
+
+	// Link the title to the FMA via an installer and change the canonical name, so
+	// pass 1 (by installer link) has to walk all seven rows too.
+	_, _, err = ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+		Title:                "Microsoft Visual Studio Code",
+		TeamID:               &team.ID,
+		Source:               "apps",
+		InstallScript:        "nothing",
+		Filename:             "VSCode.dmg",
+		UserID:               user.ID,
+		Platform:             string(fleet.MacOSPlatform),
+		BundleIdentifier:     "com.microsoft.VSCode",
+		FleetMaintainedAppID: &vscode.ID,
+		ValidatedLabels:      &fleet.LabelIdentsWithScope{},
+	})
+	require.NoError(t, err)
+
+	_, err = ds.UpsertMaintainedApp(ctx, &fleet.MaintainedApp{
+		Name:             "Visual Studio Code",
+		Slug:             "visual-studio-code/darwin",
+		Platform:         "darwin",
+		UniqueIdentifier: "com.microsoft.VSCode",
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, ds.ReconcileMaintainedAppSoftwareNames(ctx))
+	require.Equal(t, []string{
+		"Visual Studio Code", "Visual Studio Code", "Visual Studio Code", "Visual Studio Code",
+		"Visual Studio Code", "Visual Studio Code", "Visual Studio Code",
+	}, softwareNames("com.microsoft.VSCode"))
+	require.Equal(t, "Visual Studio Code", titleName("com.microsoft.VSCode"))
+
+	// Idempotent: a second run with everything already canonical is a no-op.
+	require.NoError(t, ds.ReconcileMaintainedAppSoftwareNames(ctx))
+	require.Equal(t, "Visual Studio Code", titleName("com.microsoft.VSCode"))
+	require.Equal(t, []string{"Unrelated"}, softwareNames("com.example.unrelated"))
+}
+
+// upsertDarwinFMA upserts a darwin maintained app. Call it once per app: the upsert's
+// ON DUPLICATE KEY UPDATE reports no insert id, so a repeat call returns ID 0.
+func upsertDarwinFMA(t *testing.T, ds *Datastore, appName, bundleID, slug string) *fleet.MaintainedApp {
+	app, err := ds.UpsertMaintainedApp(t.Context(), &fleet.MaintainedApp{
+		Name:             appName,
+		Slug:             slug,
+		Platform:         "darwin",
+		UniqueIdentifier: bundleID,
+	})
+	require.NoError(t, err)
+	require.NotZero(t, app.ID)
+	return app
+}
+
+// addDarwinFMAInstaller adds app to a team as an installer, linked to the software title
+// carrying titleBundleID. It returns that title's ID.
+func addDarwinFMAInstaller(t *testing.T, ds *Datastore, userID uint, teamID *uint, app *fleet.MaintainedApp, titleBundleID string) uint {
+	_, titleID, err := ds.MatchOrCreateSoftwareInstaller(t.Context(), &fleet.UploadSoftwareInstallerPayload{
+		Title:                app.Name,
+		TeamID:               teamID,
+		Source:               "apps",
+		InstallScript:        "nothing",
+		Filename:             app.Name + ".dmg",
+		UserID:               userID,
+		Platform:             string(fleet.MacOSPlatform),
+		BundleIdentifier:     titleBundleID,
+		FleetMaintainedAppID: &app.ID,
+		ValidatedLabels:      &fleet.LabelIdentsWithScope{},
+	})
+	require.NoError(t, err)
+	return titleID
+}
+
+// testReconcileSoftwareNamesOrphanedInstaller: an installer whose title was deleted has a
+// NULL title_id. The installer-link lookup must skip it rather than fail the whole pass --
+// title_id is scanned into a non-nullable uint, so a NULL group would error out.
+func testReconcileSoftwareNamesOrphanedInstaller(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	user := test.NewUser(t, ds, "Trillian", "trillian@example.com", true)
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "Team Orphan"})
+	require.NoError(t, err)
+
+	host, err := ds.NewHost(ctx, &fleet.Host{
+		Hostname:        "orphan-host",
+		Platform:        "darwin",
+		OsqueryHostID:   new("orphan-osquery-id"),
+		NodeKey:         new("orphan-node-key"),
+		DetailUpdatedAt: ds.clock.Now(),
+		LabelUpdatedAt:  ds.clock.Now(),
+		PolicyUpdatedAt: ds.clock.Now(),
+		SeenTime:        ds.clock.Now(),
+	})
+	require.NoError(t, err)
+
+	_, err = ds.UpdateHostSoftware(ctx, host.ID, []fleet.Software{
+		{Name: "Code", Version: "1.0", Source: "apps", BundleIdentifier: "com.microsoft.VSCode"},
+	})
+	require.NoError(t, err)
+
+	vscode := upsertDarwinFMA(t, ds, "Microsoft Visual Studio Code", "com.microsoft.VSCode", "visual-studio-code/darwin")
+	addDarwinFMAInstaller(t, ds, user.ID, &team.ID, vscode, "com.microsoft.VSCode")
+
+	// Orphan the installer the way CleanupSoftwareTitles does, via the FK's ON DELETE SET NULL.
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		_, err := q.ExecContext(ctx, `UPDATE software_installers SET title_id = NULL`)
+		return err
+	})
+
+	// Must not error. The bundle-identifier pass still applies the canonical name.
+	require.NoError(t, ds.ReconcileMaintainedAppSoftwareNames(ctx))
+
+	var name string
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, q, &name,
+			`SELECT name FROM software_titles WHERE bundle_identifier = 'com.microsoft.VSCode' AND additional_identifier = 0`)
+	})
+	require.Equal(t, "Microsoft Visual Studio Code", name)
+}
+
+// testReconcileSoftwareNamesIdentifierWinsOverInstallerLink pins the precedence between
+// the two passes. The installer link runs first, then the unambiguous bundle identifier,
+// so when they disagree the identifier is what lands.
+func testReconcileSoftwareNamesIdentifierWinsOverInstallerLink(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	user := test.NewUser(t, ds, "Slartibartfast", "slarti@example.com", true)
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "Team Precedence"})
+	require.NoError(t, err)
+
+	// An app whose identifier is com.example.identifier, so that identifier maps
+	// unambiguously to "Identifier Name".
+	_, err = ds.UpsertMaintainedApp(ctx, &fleet.MaintainedApp{
+		Name:             "Identifier Name",
+		Slug:             "identifier-name/darwin",
+		Platform:         "darwin",
+		UniqueIdentifier: "com.example.identifier",
+	})
+	require.NoError(t, err)
+
+	// A different app, linked by installer to a title that carries the identifier above.
+	other := upsertDarwinFMA(t, ds, "Installer Link Name", "com.example.other", "installer-link/darwin")
+	titleID := addDarwinFMAInstaller(t, ds, user.ID, &team.ID, other, "com.example.identifier")
+
+	require.NoError(t, ds.ReconcileMaintainedAppSoftwareNames(ctx))
+
+	var name string
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, q, &name, `SELECT name FROM software_titles WHERE id = ?`, titleID)
+	})
+	require.Equal(t, "Identifier Name", name, "the bundle-identifier pass runs last and wins")
+}
+
+// testReconcileSoftwareNamesMultiTeamInstallers: one app added to several teams has an
+// installer row per team, all pointing at the same title. The GROUP BY must collapse them
+// so the title is not treated as ambiguous.
+func testReconcileSoftwareNamesMultiTeamInstallers(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	user := test.NewUser(t, ds, "Marvin", "marvin@example.com", true)
+	teamA, err := ds.NewTeam(ctx, &fleet.Team{Name: "Team A"})
+	require.NoError(t, err)
+	teamB, err := ds.NewTeam(ctx, &fleet.Team{Name: "Team B"})
+	require.NoError(t, err)
+
+	host, err := ds.NewHost(ctx, &fleet.Host{
+		Hostname:        "multi-team-host",
+		Platform:        "darwin",
+		OsqueryHostID:   new("multi-osquery-id"),
+		NodeKey:         new("multi-node-key"),
+		DetailUpdatedAt: ds.clock.Now(),
+		LabelUpdatedAt:  ds.clock.Now(),
+		PolicyUpdatedAt: ds.clock.Now(),
+		SeenTime:        ds.clock.Now(),
+	})
+	require.NoError(t, err)
+
+	_, err = ds.UpdateHostSoftware(ctx, host.ID, []fleet.Software{
+		{Name: "Code", Version: "1.0", Source: "apps", BundleIdentifier: "com.microsoft.VSCode"},
+	})
+	require.NoError(t, err)
+
+	vscode := upsertDarwinFMA(t, ds, "Microsoft Visual Studio Code", "com.microsoft.VSCode", "visual-studio-code/darwin")
+	titleA := addDarwinFMAInstaller(t, ds, user.ID, &teamA.ID, vscode, "com.microsoft.VSCode")
+	titleB := addDarwinFMAInstaller(t, ds, user.ID, &teamB.ID, vscode, "com.microsoft.VSCode")
+	require.Equal(t, titleA, titleB, "per-team installers must share one title")
+
+	var installerCount int
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, q, &installerCount,
+			`SELECT COUNT(*) FROM software_installers WHERE title_id = ?`, titleA)
+	})
+	require.Equal(t, 2, installerCount)
+
+	require.NoError(t, ds.ReconcileMaintainedAppSoftwareNames(ctx))
+
+	var names []string
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		return sqlx.SelectContext(ctx, q, &names,
+			`SELECT name FROM software WHERE bundle_identifier = 'com.microsoft.VSCode'`)
+	})
+	require.Equal(t, []string{"Microsoft Visual Studio Code"}, names)
+}
+
+// testReconcileSoftwareNamesLeavesMobileSiblings: iOS and iPadOS titles can share a bundle
+// identifier with a macOS app but are separate products, so a macOS app's canonical name
+// must not be pushed onto them.
+func testReconcileSoftwareNamesLeavesMobileSiblings(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	host, err := ds.NewHost(ctx, &fleet.Host{
+		Hostname:        "sibling-host",
+		Platform:        "darwin",
+		OsqueryHostID:   new("sibling-osquery-id"),
+		NodeKey:         new("sibling-node-key"),
+		DetailUpdatedAt: ds.clock.Now(),
+		LabelUpdatedAt:  ds.clock.Now(),
+		PolicyUpdatedAt: ds.clock.Now(),
+		SeenTime:        ds.clock.Now(),
+	})
+	require.NoError(t, err)
+
+	_, err = ds.UpdateHostSoftware(ctx, host.ID, []fleet.Software{
+		{Name: "Code", Version: "1.0", Source: "apps", BundleIdentifier: "com.microsoft.VSCode"},
+	})
+	require.NoError(t, err)
+
+	// iOS and iPadOS titles sharing the identifier, as VPP or in-house apps produce.
+	// additional_identifier is generated from source, so these coexist with the macOS row.
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		for _, source := range []string{"ios_apps", "ipados_apps"} {
+			res, err := q.ExecContext(ctx,
+				`INSERT INTO software_titles (name, source, bundle_identifier) VALUES (?, ?, 'com.microsoft.VSCode')`,
+				"Code Mobile", source)
+			if err != nil {
+				return err
+			}
+			titleID, err := res.LastInsertId()
+			if err != nil {
+				return err
+			}
+			if _, err := q.ExecContext(ctx,
+				`INSERT INTO software (name, version, source, bundle_identifier, title_id, checksum)
+				 VALUES (?, '1.0', ?, 'com.microsoft.VSCode', ?, UNHEX(MD5(?)))`,
+				"Code Mobile", source, titleID, source); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+
+	_, err = ds.UpsertMaintainedApp(ctx, &fleet.MaintainedApp{
+		Name:             "Microsoft Visual Studio Code",
+		Slug:             "visual-studio-code/darwin",
+		Platform:         "darwin",
+		UniqueIdentifier: "com.microsoft.VSCode",
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, ds.ReconcileMaintainedAppSoftwareNames(ctx))
+
+	namesBySource := func(table string) map[string]string {
+		out := map[string]string{}
+		var rows []struct {
+			Source string `db:"source"`
+			Name   string `db:"name"`
+		}
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			return sqlx.SelectContext(ctx, q, &rows,
+				`SELECT source, name FROM `+table+` WHERE bundle_identifier = 'com.microsoft.VSCode'`)
+		})
+		for _, r := range rows {
+			out[r.Source] = r.Name
+		}
+		return out
+	}
+
+	titles := namesBySource("software_titles")
+	require.Equal(t, "Microsoft Visual Studio Code", titles["apps"])
+	require.Equal(t, "Code Mobile", titles["ios_apps"])
+	require.Equal(t, "Code Mobile", titles["ipados_apps"])
+
+	software := namesBySource("software")
+	require.Equal(t, "Microsoft Visual Studio Code", software["apps"])
+	require.Equal(t, "Code Mobile", software["ios_apps"])
+	require.Equal(t, "Code Mobile", software["ipados_apps"])
 }
 
 // testListAvailableAppsSharedIdentifier: adding Firefox must not mark its

--- a/server/datastore/mysql/maintained_apps_test.go
+++ b/server/datastore/mysql/maintained_apps_test.go
@@ -58,6 +58,7 @@ func TestMaintainedApps(t *testing.T) {
 		{"ReconcileSoftwareNames", testReconcileSoftwareNames},
 		{"ReconcileSoftwareNamesSharedIdentifier", testReconcileSoftwareNamesSharedIdentifier},
 		{"ReconcileSoftwareNamesBatched", testReconcileSoftwareNamesBatched},
+		{"ReconcileSoftwareNamesDiscoveryWindowed", testReconcileSoftwareNamesDiscoveryWindowed},
 		{"ReconcileSoftwareNamesOrphanedInstaller", testReconcileSoftwareNamesOrphanedInstaller},
 		{"ReconcileSoftwareNamesIdentifierWinsOverInstallerLink", testReconcileSoftwareNamesIdentifierWinsOverInstallerLink},
 		{"ReconcileSoftwareNamesMultiTeamInstallers", testReconcileSoftwareNamesMultiTeamInstallers},
@@ -1325,6 +1326,64 @@ func testReconcileSoftwareNamesBatched(t *testing.T, ds *Datastore) {
 	require.NoError(t, ds.ReconcileMaintainedAppSoftwareNames(ctx))
 	require.Equal(t, "Visual Studio Code", titleName("com.microsoft.VSCode"))
 	require.Equal(t, []string{"Unrelated"}, softwareNames("com.example.unrelated"))
+}
+
+// testReconcileSoftwareNamesDiscoveryWindowed: each discovery SELECT is capped by
+// maintainedAppNameReconcileDiscoveryLimit so the pass never holds every mismatched row
+// in memory at once. Renamed rows drop out of the next SELECT, so the pass must keep
+// re-discovering until a window comes back short, not stop after the first one.
+func testReconcileSoftwareNamesDiscoveryWindowed(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	// Seven mismatched software rows against a window of three and batches of two, so
+	// the pass needs several windows and the window and batch edges never line up.
+	oldBatchSize := maintainedAppNameReconcileBatchSize
+	oldDiscoveryLimit := maintainedAppNameReconcileDiscoveryLimit
+	maintainedAppNameReconcileBatchSize = 2
+	maintainedAppNameReconcileDiscoveryLimit = 3
+	t.Cleanup(func() {
+		maintainedAppNameReconcileBatchSize = oldBatchSize
+		maintainedAppNameReconcileDiscoveryLimit = oldDiscoveryLimit
+	})
+
+	host, err := ds.NewHost(ctx, &fleet.Host{
+		Hostname:        "windowed-host",
+		Platform:        "darwin",
+		OsqueryHostID:   new("windowed-osquery-id"),
+		NodeKey:         new("windowed-node-key"),
+		DetailUpdatedAt: ds.clock.Now(),
+		LabelUpdatedAt:  ds.clock.Now(),
+		PolicyUpdatedAt: ds.clock.Now(),
+		SeenTime:        ds.clock.Now(),
+	})
+	require.NoError(t, err)
+
+	var software []fleet.Software
+	for _, version := range []string{"1.0", "2.0", "3.0", "4.0", "5.0", "6.0", "7.0"} {
+		software = append(software, fleet.Software{
+			Name: "Code", Version: version, Source: "apps", BundleIdentifier: "com.microsoft.VSCode",
+		})
+	}
+	_, err = ds.UpdateHostSoftware(ctx, host.ID, software)
+	require.NoError(t, err)
+
+	upsertDarwinFMA(t, ds, "Microsoft Visual Studio Code", "com.microsoft.VSCode", "visual-studio-code/darwin")
+
+	require.NoError(t, ds.ReconcileMaintainedAppSoftwareNames(ctx))
+
+	var names []string
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		return sqlx.SelectContext(ctx, q, &names,
+			`SELECT DISTINCT name FROM software WHERE bundle_identifier = 'com.microsoft.VSCode'`)
+	})
+	require.Equal(t, []string{"Microsoft Visual Studio Code"}, names)
+
+	var titleName string
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, q, &titleName,
+			`SELECT name FROM software_titles WHERE bundle_identifier = 'com.microsoft.VSCode'`)
+	})
+	require.Equal(t, "Microsoft Visual Studio Code", titleName)
 }
 
 // upsertDarwinFMA upserts a darwin maintained app. Call it once per app: the upsert's

--- a/server/datastore/mysql/maintained_apps_test.go
+++ b/server/datastore/mysql/maintained_apps_test.go
@@ -3,6 +3,7 @@ package mysql
 import (
 	"context"
 	"fmt"
+	"slices"
 	"testing"
 	"time"
 
@@ -1000,21 +1001,8 @@ func testReconcileSoftwareNames(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 
 	// Verify the software and software_titles were created with the osquery name "Code"
-	var softwareNames []string
-	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
-		return sqlx.SelectContext(ctx, q, &softwareNames,
-			`SELECT name FROM software WHERE bundle_identifier = 'com.microsoft.VSCode' ORDER BY version`)
-	})
-	require.Len(t, softwareNames, 2)
-	require.Equal(t, "Code", softwareNames[0])
-	require.Equal(t, "Code", softwareNames[1])
-
-	var titleName string
-	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
-		return sqlx.GetContext(ctx, q, &titleName,
-			`SELECT name FROM software_titles WHERE bundle_identifier = 'com.microsoft.VSCode'`)
-	})
-	require.Equal(t, "Code", titleName)
+	require.Equal(t, []string{"Code", "Code"}, softwareNames(t, ds, "com.microsoft.VSCode"))
+	require.Equal(t, "Code", softwareTitleName(t, ds, "com.microsoft.VSCode"))
 
 	// Now upsert an FMA with the canonical name
 	_, err = ds.UpsertMaintainedApp(ctx, &fleet.MaintainedApp{
@@ -1027,37 +1015,16 @@ func testReconcileSoftwareNames(t *testing.T, ds *Datastore) {
 
 	// The upsert itself must not rename; confirm the pre-reconcile state still has
 	// the osquery name in both the software and software_titles tables.
-	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
-		return sqlx.SelectContext(ctx, q, &softwareNames,
-			`SELECT name FROM software WHERE bundle_identifier = 'com.microsoft.VSCode' ORDER BY version`)
-	})
-	require.Len(t, softwareNames, 2)
-	require.Equal(t, "Code", softwareNames[0])
-	require.Equal(t, "Code", softwareNames[1])
-	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
-		return sqlx.GetContext(ctx, q, &titleName,
-			`SELECT name FROM software_titles WHERE bundle_identifier = 'com.microsoft.VSCode'`)
-	})
-	require.Equal(t, "Code", titleName)
+	require.Equal(t, []string{"Code", "Code"}, softwareNames(t, ds, "com.microsoft.VSCode"))
+	require.Equal(t, "Code", softwareTitleName(t, ds, "com.microsoft.VSCode"))
 
 	// The upsert doesn't rename; the reconcile pass does (unambiguous identifier).
 	require.NoError(t, ds.ReconcileMaintainedAppSoftwareNames(ctx))
 
-	// Verify software entries were updated to use the FMA canonical name
-	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
-		return sqlx.SelectContext(ctx, q, &softwareNames,
-			`SELECT name FROM software WHERE bundle_identifier = 'com.microsoft.VSCode' ORDER BY version`)
-	})
-	require.Len(t, softwareNames, 2)
-	require.Equal(t, "Microsoft Visual Studio Code", softwareNames[0])
-	require.Equal(t, "Microsoft Visual Studio Code", softwareNames[1])
-
-	// Verify software_titles was also updated
-	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
-		return sqlx.GetContext(ctx, q, &titleName,
-			`SELECT name FROM software_titles WHERE bundle_identifier = 'com.microsoft.VSCode'`)
-	})
-	require.Equal(t, "Microsoft Visual Studio Code", titleName)
+	// Verify software entries and the title were updated to the FMA canonical name
+	require.Equal(t, []string{"Microsoft Visual Studio Code", "Microsoft Visual Studio Code"},
+		softwareNames(t, ds, "com.microsoft.VSCode"))
+	require.Equal(t, "Microsoft Visual Studio Code", softwareTitleName(t, ds, "com.microsoft.VSCode"))
 
 	// Verify upserting the same FMA again and reconciling doesn't cause issues (idempotent)
 	_, err = ds.UpsertMaintainedApp(ctx, &fleet.MaintainedApp{
@@ -1070,13 +1037,8 @@ func testReconcileSoftwareNames(t *testing.T, ds *Datastore) {
 	require.NoError(t, ds.ReconcileMaintainedAppSoftwareNames(ctx))
 
 	// Names should still be the FMA canonical name
-	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
-		return sqlx.SelectContext(ctx, q, &softwareNames,
-			`SELECT name FROM software WHERE bundle_identifier = 'com.microsoft.VSCode' ORDER BY version`)
-	})
-	require.Len(t, softwareNames, 2)
-	require.Equal(t, "Microsoft Visual Studio Code", softwareNames[0])
-	require.Equal(t, "Microsoft Visual Studio Code", softwareNames[1])
+	require.Equal(t, []string{"Microsoft Visual Studio Code", "Microsoft Visual Studio Code"},
+		softwareNames(t, ds, "com.microsoft.VSCode"))
 
 	// Verify Windows FMA does NOT update darwin software entries
 	// First create darwin software with a different bundle_id
@@ -1102,12 +1064,7 @@ func testReconcileSoftwareNames(t *testing.T, ds *Datastore) {
 	require.NoError(t, ds.ReconcileMaintainedAppSoftwareNames(ctx))
 
 	// A Windows FMA must not rename darwin software.
-	var someAppName string
-	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
-		return sqlx.GetContext(ctx, q, &someAppName,
-			`SELECT name FROM software WHERE bundle_identifier = 'com.example.someapp'`)
-	})
-	require.Equal(t, "Some App", someAppName)
+	require.Equal(t, []string{"Some App"}, softwareNames(t, ds, "com.example.someapp"))
 }
 
 // testReconcileSoftwareNamesSharedIdentifier: two FMAs sharing a bundle identifier
@@ -1144,30 +1101,16 @@ func testReconcileSoftwareNamesSharedIdentifier(t *testing.T, ds *Datastore) {
 	})
 	require.NoError(t, err)
 
-	titleName := func() string {
-		var name string
-		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
-			return sqlx.GetContext(ctx, q, &name,
-				`SELECT name FROM software_titles WHERE bundle_identifier = 'org.mozilla.firefox'`)
-		})
-		return name
-	}
-
 	// Ingestion must not guess a name for the shared identifier.
-	require.Equal(t, "Firefox.app", titleName())
+	require.Equal(t, "Firefox.app", softwareTitleName(t, ds, "org.mozilla.firefox"))
 
 	// No FMA link and an ambiguous identifier: reconcile must leave it alone.
 	// (Regression: the title used to flip to "Mozilla Firefox ESR" by sync order.)
 	require.NoError(t, ds.ReconcileMaintainedAppSoftwareNames(ctx))
-	require.Equal(t, "Firefox.app", titleName())
+	require.Equal(t, "Firefox.app", softwareTitleName(t, ds, "org.mozilla.firefox"))
 	// Reconcile updates the software table with a separate statement, so assert it
 	// too: with an ambiguous identifier and no FMA link, that row is left alone.
-	var ambiguousSoftwareName string
-	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
-		return sqlx.GetContext(ctx, q, &ambiguousSoftwareName,
-			`SELECT name FROM software WHERE bundle_identifier = 'org.mozilla.firefox'`)
-	})
-	require.Equal(t, "Firefox.app", ambiguousSoftwareName)
+	require.Equal(t, []string{"Firefox.app"}, softwareNames(t, ds, "org.mozilla.firefox"))
 
 	// Add the Firefox (non-ESR) FMA, linking the existing title to a specific FMA.
 	_, titleID, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
@@ -1185,11 +1128,11 @@ func testReconcileSoftwareNamesSharedIdentifier(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 
 	// The install reuses the existing title, so the name is unchanged until reconcile.
-	require.Equal(t, "Firefox.app", titleName())
+	require.Equal(t, "Firefox.app", softwareTitleName(t, ds, "org.mozilla.firefox"))
 
 	// Reconcile resolves the ambiguity via the installer link.
 	require.NoError(t, ds.ReconcileMaintainedAppSoftwareNames(ctx))
-	require.Equal(t, "Mozilla Firefox", titleName())
+	require.Equal(t, "Mozilla Firefox", softwareTitleName(t, ds, "org.mozilla.firefox"))
 
 	var softwareName string
 	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
@@ -1230,24 +1173,7 @@ func testReconcileSoftwareNamesBatched(t *testing.T, ds *Datastore) {
 	_, err = ds.UpdateHostSoftware(ctx, host.ID, software)
 	require.NoError(t, err)
 
-	softwareNames := func(bundleID string) []string {
-		var names []string
-		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
-			return sqlx.SelectContext(ctx, q, &names,
-				`SELECT name FROM software WHERE bundle_identifier = ? ORDER BY id`, bundleID)
-		})
-		return names
-	}
-	titleName := func(bundleID string) string {
-		var name string
-		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
-			return sqlx.GetContext(ctx, q, &name,
-				`SELECT name FROM software_titles WHERE bundle_identifier = ?`, bundleID)
-		})
-		return name
-	}
-
-	require.Equal(t, []string{"Code", "Code", "Code", "Code", "Code", "Code", "Code"}, softwareNames("com.microsoft.VSCode"))
+	require.Equal(t, slices.Repeat([]string{"Code"}, 7), softwareNames(t, ds, "com.microsoft.VSCode"))
 
 	vscode, err := ds.UpsertMaintainedApp(ctx, &fleet.MaintainedApp{
 		Name:             "Microsoft Visual Studio Code",
@@ -1260,16 +1186,13 @@ func testReconcileSoftwareNamesBatched(t *testing.T, ds *Datastore) {
 	// Pass 2 (by unambiguous bundle identifier) must rename all seven rows, not just
 	// the first batch.
 	require.NoError(t, ds.ReconcileMaintainedAppSoftwareNames(ctx))
-	require.Equal(t, []string{
-		"Microsoft Visual Studio Code", "Microsoft Visual Studio Code", "Microsoft Visual Studio Code",
-		"Microsoft Visual Studio Code", "Microsoft Visual Studio Code", "Microsoft Visual Studio Code",
-		"Microsoft Visual Studio Code",
-	}, softwareNames("com.microsoft.VSCode"))
-	require.Equal(t, "Microsoft Visual Studio Code", titleName("com.microsoft.VSCode"))
+	require.Equal(t, slices.Repeat([]string{"Microsoft Visual Studio Code"}, 7),
+		softwareNames(t, ds, "com.microsoft.VSCode"))
+	require.Equal(t, "Microsoft Visual Studio Code", softwareTitleName(t, ds, "com.microsoft.VSCode"))
 
 	// The app with no FMA is outside the match set and must be untouched.
-	require.Equal(t, []string{"Unrelated"}, softwareNames("com.example.unrelated"))
-	require.Equal(t, "Unrelated", titleName("com.example.unrelated"))
+	require.Equal(t, []string{"Unrelated"}, softwareNames(t, ds, "com.example.unrelated"))
+	require.Equal(t, "Unrelated", softwareTitleName(t, ds, "com.example.unrelated"))
 
 	// Link the title to the FMA via an installer and change the canonical name, so
 	// pass 1 (by installer link) has to walk all seven rows too.
@@ -1296,16 +1219,14 @@ func testReconcileSoftwareNamesBatched(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 
 	require.NoError(t, ds.ReconcileMaintainedAppSoftwareNames(ctx))
-	require.Equal(t, []string{
-		"Visual Studio Code", "Visual Studio Code", "Visual Studio Code", "Visual Studio Code",
-		"Visual Studio Code", "Visual Studio Code", "Visual Studio Code",
-	}, softwareNames("com.microsoft.VSCode"))
-	require.Equal(t, "Visual Studio Code", titleName("com.microsoft.VSCode"))
+	require.Equal(t, slices.Repeat([]string{"Visual Studio Code"}, 7),
+		softwareNames(t, ds, "com.microsoft.VSCode"))
+	require.Equal(t, "Visual Studio Code", softwareTitleName(t, ds, "com.microsoft.VSCode"))
 
 	// Idempotent: a second run with everything already canonical is a no-op.
 	require.NoError(t, ds.ReconcileMaintainedAppSoftwareNames(ctx))
-	require.Equal(t, "Visual Studio Code", titleName("com.microsoft.VSCode"))
-	require.Equal(t, []string{"Unrelated"}, softwareNames("com.example.unrelated"))
+	require.Equal(t, "Visual Studio Code", softwareTitleName(t, ds, "com.microsoft.VSCode"))
+	require.Equal(t, []string{"Unrelated"}, softwareNames(t, ds, "com.example.unrelated"))
 }
 
 // testReconcileSoftwareNamesDiscoveryWindowed: each discovery SELECT is capped by
@@ -1341,19 +1262,32 @@ func testReconcileSoftwareNamesDiscoveryWindowed(t *testing.T, ds *Datastore) {
 
 	require.NoError(t, ds.ReconcileMaintainedAppSoftwareNames(ctx))
 
+	// Every row, not just the distinct set, so a window that stopped early is caught.
+	require.Equal(t, slices.Repeat([]string{"Microsoft Visual Studio Code"}, 7),
+		softwareNames(t, ds, "com.microsoft.VSCode"))
+	require.Equal(t, "Microsoft Visual Studio Code", softwareTitleName(t, ds, "com.microsoft.VSCode"))
+}
+
+// softwareTitleName returns the name of the macOS software title carrying bundleID.
+// additional_identifier is 0 for macOS titles, which keeps this to a single row even when iOS
+// or iPadOS siblings share the identifier.
+func softwareTitleName(t *testing.T, ds *Datastore, bundleID string) string {
+	var name string
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(t.Context(), q, &name,
+			`SELECT name FROM software_titles WHERE bundle_identifier = ? AND additional_identifier = 0`, bundleID)
+	})
+	return name
+}
+
+// softwareNames returns the names of every software row carrying bundleID, oldest first.
+func softwareNames(t *testing.T, ds *Datastore, bundleID string) []string {
 	var names []string
 	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
-		return sqlx.SelectContext(ctx, q, &names,
-			`SELECT DISTINCT name FROM software WHERE bundle_identifier = 'com.microsoft.VSCode'`)
+		return sqlx.SelectContext(t.Context(), q, &names,
+			`SELECT name FROM software WHERE bundle_identifier = ? ORDER BY id`, bundleID)
 	})
-	require.Equal(t, []string{"Microsoft Visual Studio Code"}, names)
-
-	var titleName string
-	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
-		return sqlx.GetContext(ctx, q, &titleName,
-			`SELECT name FROM software_titles WHERE bundle_identifier = 'com.microsoft.VSCode'`)
-	})
-	require.Equal(t, "Microsoft Visual Studio Code", titleName)
+	return names
 }
 
 // upsertDarwinFMA upserts a darwin maintained app. Call it once per app: the upsert's
@@ -1419,12 +1353,7 @@ func testReconcileSoftwareNamesOrphanedInstaller(t *testing.T, ds *Datastore) {
 	// Must not error. The bundle-identifier pass still applies the canonical name.
 	require.NoError(t, ds.ReconcileMaintainedAppSoftwareNames(ctx))
 
-	var name string
-	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
-		return sqlx.GetContext(ctx, q, &name,
-			`SELECT name FROM software_titles WHERE bundle_identifier = 'com.microsoft.VSCode' AND additional_identifier = 0`)
-	})
-	require.Equal(t, "Microsoft Visual Studio Code", name)
+	require.Equal(t, "Microsoft Visual Studio Code", softwareTitleName(t, ds, "com.microsoft.VSCode"))
 }
 
 // testReconcileSoftwareNamesIdentifierWinsOverInstallerLink pins the precedence between
@@ -1493,12 +1422,7 @@ func testReconcileSoftwareNamesMultiTeamInstallers(t *testing.T, ds *Datastore) 
 
 	require.NoError(t, ds.ReconcileMaintainedAppSoftwareNames(ctx))
 
-	var names []string
-	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
-		return sqlx.SelectContext(ctx, q, &names,
-			`SELECT name FROM software WHERE bundle_identifier = 'com.microsoft.VSCode'`)
-	})
-	require.Equal(t, []string{"Microsoft Visual Studio Code"}, names)
+	require.Equal(t, []string{"Microsoft Visual Studio Code"}, softwareNames(t, ds, "com.microsoft.VSCode"))
 }
 
 // testReconcileSoftwareNamesLeavesMobileSiblings: iOS and iPadOS titles can share a bundle

--- a/server/datastore/mysql/maintained_apps_test.go
+++ b/server/datastore/mysql/maintained_apps_test.go
@@ -1120,17 +1120,7 @@ func testReconcileSoftwareNamesSharedIdentifier(t *testing.T, ds *Datastore) {
 	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "Team Firefox"})
 	require.NoError(t, err)
 
-	host, err := ds.NewHost(ctx, &fleet.Host{
-		Hostname:        "firefox-host",
-		Platform:        "darwin",
-		OsqueryHostID:   new("ff-osquery-id"),
-		NodeKey:         new("ff-node-key"),
-		DetailUpdatedAt: ds.clock.Now(),
-		LabelUpdatedAt:  ds.clock.Now(),
-		PolicyUpdatedAt: ds.clock.Now(),
-		SeenTime:        ds.clock.Now(),
-	})
-	require.NoError(t, err)
+	host := newTestHostWithPlatform(t, ds, "firefox-host", "darwin", nil)
 
 	// Two FMAs that share the same macOS bundle identifier.
 	firefox, err := ds.UpsertMaintainedApp(ctx, &fleet.MaintainedApp{
@@ -1224,17 +1214,7 @@ func testReconcileSoftwareNamesBatched(t *testing.T, ds *Datastore) {
 	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "Team Batched"})
 	require.NoError(t, err)
 
-	host, err := ds.NewHost(ctx, &fleet.Host{
-		Hostname:        "batched-host",
-		Platform:        "darwin",
-		OsqueryHostID:   new("batched-osquery-id"),
-		NodeKey:         new("batched-node-key"),
-		DetailUpdatedAt: ds.clock.Now(),
-		LabelUpdatedAt:  ds.clock.Now(),
-		PolicyUpdatedAt: ds.clock.Now(),
-		SeenTime:        ds.clock.Now(),
-	})
-	require.NoError(t, err)
+	host := newTestHostWithPlatform(t, ds, "batched-host", "darwin", nil)
 
 	// Seven versions of one app, so the rename spans four batches of two. Plus an
 	// unrelated app with no FMA, which must never be renamed.
@@ -1346,17 +1326,7 @@ func testReconcileSoftwareNamesDiscoveryWindowed(t *testing.T, ds *Datastore) {
 		maintainedAppNameReconcileDiscoveryLimit = oldDiscoveryLimit
 	})
 
-	host, err := ds.NewHost(ctx, &fleet.Host{
-		Hostname:        "windowed-host",
-		Platform:        "darwin",
-		OsqueryHostID:   new("windowed-osquery-id"),
-		NodeKey:         new("windowed-node-key"),
-		DetailUpdatedAt: ds.clock.Now(),
-		LabelUpdatedAt:  ds.clock.Now(),
-		PolicyUpdatedAt: ds.clock.Now(),
-		SeenTime:        ds.clock.Now(),
-	})
-	require.NoError(t, err)
+	host := newTestHostWithPlatform(t, ds, "windowed-host", "darwin", nil)
 
 	var software []fleet.Software
 	for _, version := range []string{"1.0", "2.0", "3.0", "4.0", "5.0", "6.0", "7.0"} {
@@ -1364,7 +1334,7 @@ func testReconcileSoftwareNamesDiscoveryWindowed(t *testing.T, ds *Datastore) {
 			Name: "Code", Version: version, Source: "apps", BundleIdentifier: "com.microsoft.VSCode",
 		})
 	}
-	_, err = ds.UpdateHostSoftware(ctx, host.ID, software)
+	_, err := ds.UpdateHostSoftware(ctx, host.ID, software)
 	require.NoError(t, err)
 
 	upsertDarwinFMA(t, ds, "Microsoft Visual Studio Code", "com.microsoft.VSCode", "visual-studio-code/darwin")
@@ -1430,17 +1400,7 @@ func testReconcileSoftwareNamesOrphanedInstaller(t *testing.T, ds *Datastore) {
 	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "Team Orphan"})
 	require.NoError(t, err)
 
-	host, err := ds.NewHost(ctx, &fleet.Host{
-		Hostname:        "orphan-host",
-		Platform:        "darwin",
-		OsqueryHostID:   new("orphan-osquery-id"),
-		NodeKey:         new("orphan-node-key"),
-		DetailUpdatedAt: ds.clock.Now(),
-		LabelUpdatedAt:  ds.clock.Now(),
-		PolicyUpdatedAt: ds.clock.Now(),
-		SeenTime:        ds.clock.Now(),
-	})
-	require.NoError(t, err)
+	host := newTestHostWithPlatform(t, ds, "orphan-host", "darwin", nil)
 
 	_, err = ds.UpdateHostSoftware(ctx, host.ID, []fleet.Software{
 		{Name: "Code", Version: "1.0", Source: "apps", BundleIdentifier: "com.microsoft.VSCode"},
@@ -1512,17 +1472,7 @@ func testReconcileSoftwareNamesMultiTeamInstallers(t *testing.T, ds *Datastore) 
 	teamB, err := ds.NewTeam(ctx, &fleet.Team{Name: "Team B"})
 	require.NoError(t, err)
 
-	host, err := ds.NewHost(ctx, &fleet.Host{
-		Hostname:        "multi-team-host",
-		Platform:        "darwin",
-		OsqueryHostID:   new("multi-osquery-id"),
-		NodeKey:         new("multi-node-key"),
-		DetailUpdatedAt: ds.clock.Now(),
-		LabelUpdatedAt:  ds.clock.Now(),
-		PolicyUpdatedAt: ds.clock.Now(),
-		SeenTime:        ds.clock.Now(),
-	})
-	require.NoError(t, err)
+	host := newTestHostWithPlatform(t, ds, "multi-team-host", "darwin", nil)
 
 	_, err = ds.UpdateHostSoftware(ctx, host.ID, []fleet.Software{
 		{Name: "Code", Version: "1.0", Source: "apps", BundleIdentifier: "com.microsoft.VSCode"},
@@ -1557,19 +1507,9 @@ func testReconcileSoftwareNamesMultiTeamInstallers(t *testing.T, ds *Datastore) 
 func testReconcileSoftwareNamesLeavesMobileSiblings(t *testing.T, ds *Datastore) {
 	ctx := t.Context()
 
-	host, err := ds.NewHost(ctx, &fleet.Host{
-		Hostname:        "sibling-host",
-		Platform:        "darwin",
-		OsqueryHostID:   new("sibling-osquery-id"),
-		NodeKey:         new("sibling-node-key"),
-		DetailUpdatedAt: ds.clock.Now(),
-		LabelUpdatedAt:  ds.clock.Now(),
-		PolicyUpdatedAt: ds.clock.Now(),
-		SeenTime:        ds.clock.Now(),
-	})
-	require.NoError(t, err)
+	host := newTestHostWithPlatform(t, ds, "sibling-host", "darwin", nil)
 
-	_, err = ds.UpdateHostSoftware(ctx, host.ID, []fleet.Software{
+	_, err := ds.UpdateHostSoftware(ctx, host.ID, []fleet.Software{
 		{Name: "Code", Version: "1.0", Source: "apps", BundleIdentifier: "com.microsoft.VSCode"},
 	})
 	require.NoError(t, err)

--- a/server/datastore/mysql/maintained_apps_test.go
+++ b/server/datastore/mysql/maintained_apps_test.go
@@ -1420,8 +1420,9 @@ func addDarwinFMAInstaller(t *testing.T, ds *Datastore, userID uint, teamID *uin
 }
 
 // testReconcileSoftwareNamesOrphanedInstaller: an installer whose title was deleted has a
-// NULL title_id. The installer-link lookup must skip it rather than fail the whole pass --
-// title_id is scanned into a non-nullable uint, so a NULL group would error out.
+// NULL title_id. The installer-link pass must skip it -- its catalog subquery filters out
+// the NULL group rather than carrying a group no title can join -- while the
+// bundle-identifier pass still applies the canonical name.
 func testReconcileSoftwareNamesOrphanedInstaller(t *testing.T, ds *Datastore) {
 	ctx := t.Context()
 

--- a/server/fleet/cron_schedules.go
+++ b/server/fleet/cron_schedules.go
@@ -35,16 +35,10 @@ const (
 	CronMaintainedApps               CronScheduleName = "maintained_apps"
 	// CronWindowsMaintainedAppTitles merges Windows software titles whose reported
 	// name embeds the version onto the title owned by the Fleet-maintained app's
-	// installer. Separate from CronMaintainedApps because it reads only local
-	// installer and title state, so it must not be gated on the catalog fetch, and
-	// separate from CronCleanupsThenAggregation so it can run shortly after startup
-	// without changing the startup behaviour of that schedule's other jobs.
+	// installer.
 	CronWindowsMaintainedAppTitles CronScheduleName = "windows_maintained_app_titles"
 	// CronMacOSMaintainedAppNames renames macOS software and software titles to the
-	// canonical Fleet-maintained app name. Separate from CronMaintainedApps for the same
-	// reasons as CronWindowsMaintainedAppTitles: it reads only local software and title
-	// state, so a failed catalog fetch must not stop it from repairing names the previous
-	// fetch already recorded.
+	// canonical Fleet-maintained app name.
 	CronMacOSMaintainedAppNames CronScheduleName = "macos_maintained_app_names"
 	// CronMaintainedAppsAutoUpdate advances each Fleet-maintained app's active
 	// installer to the newest cached version its pin state allows. Premium only;

--- a/server/fleet/cron_schedules.go
+++ b/server/fleet/cron_schedules.go
@@ -40,6 +40,12 @@ const (
 	// separate from CronCleanupsThenAggregation so it can run shortly after startup
 	// without changing the startup behaviour of that schedule's other jobs.
 	CronWindowsMaintainedAppTitles CronScheduleName = "windows_maintained_app_titles"
+	// CronMacOSMaintainedAppNames renames macOS software and software titles to the
+	// canonical Fleet-maintained app name. Separate from CronMaintainedApps for the same
+	// reasons as CronWindowsMaintainedAppTitles: it reads only local software and title
+	// state, so a failed catalog fetch must not stop it from repairing names the previous
+	// fetch already recorded.
+	CronMacOSMaintainedAppNames CronScheduleName = "macos_maintained_app_names"
 	// CronMaintainedAppsAutoUpdate advances each Fleet-maintained app's active
 	// installer to the newest cached version its pin state allows. Premium only;
 	// runs every 1h.

--- a/server/fleet/cron_schedules.go
+++ b/server/fleet/cron_schedules.go
@@ -38,9 +38,6 @@ const (
 	// name embeds the version onto the title owned by the Fleet-maintained app's
 	// installer.
 	CronWindowsMaintainedAppTitles CronScheduleName = "windows_maintained_app_titles"
-	// CronMacOSMaintainedAppNames renames macOS software and software titles to the
-	// canonical Fleet-maintained app name.
-	CronMacOSMaintainedAppNames CronScheduleName = "macos_maintained_app_names"
 	// CronMaintainedAppsAutoUpdate advances each Fleet-maintained app's active
 	// installer to the newest cached version its pin state allows. Premium only;
 	// runs every 1h.

--- a/server/fleet/cron_schedules.go
+++ b/server/fleet/cron_schedules.go
@@ -41,6 +41,12 @@ const (
 	// separate from CronCleanupsThenAggregation so it can run shortly after startup
 	// without changing the startup behaviour of that schedule's other jobs.
 	CronWindowsMaintainedAppTitles CronScheduleName = "windows_maintained_app_titles"
+	// CronMacOSMaintainedAppNames renames macOS software and software titles to the
+	// canonical Fleet-maintained app name. Separate from CronMaintainedApps for the same
+	// reasons as CronWindowsMaintainedAppTitles: it reads only local software and title
+	// state, so a failed catalog fetch must not stop it from repairing names the previous
+	// fetch already recorded.
+	CronMacOSMaintainedAppNames CronScheduleName = "macos_maintained_app_names"
 	// CronMaintainedAppsAutoUpdate advances each Fleet-maintained app's active
 	// installer to the newest cached version its pin state allows. Premium only;
 	// runs every 1h.

--- a/server/fleet/cron_schedules.go
+++ b/server/fleet/cron_schedules.go
@@ -36,16 +36,10 @@ const (
 	CronMaintainedApps               CronScheduleName = "maintained_apps"
 	// CronWindowsMaintainedAppTitles merges Windows software titles whose reported
 	// name embeds the version onto the title owned by the Fleet-maintained app's
-	// installer. Separate from CronMaintainedApps because it reads only local
-	// installer and title state, so it must not be gated on the catalog fetch, and
-	// separate from CronCleanupsThenAggregation so it can run shortly after startup
-	// without changing the startup behaviour of that schedule's other jobs.
+	// installer.
 	CronWindowsMaintainedAppTitles CronScheduleName = "windows_maintained_app_titles"
 	// CronMacOSMaintainedAppNames renames macOS software and software titles to the
-	// canonical Fleet-maintained app name. Separate from CronMaintainedApps for the same
-	// reasons as CronWindowsMaintainedAppTitles: it reads only local software and title
-	// state, so a failed catalog fetch must not stop it from repairing names the previous
-	// fetch already recorded.
+	// canonical Fleet-maintained app name.
 	CronMacOSMaintainedAppNames CronScheduleName = "macos_maintained_app_names"
 	// CronMaintainedAppsAutoUpdate advances each Fleet-maintained app's active
 	// installer to the newest cached version its pin state allows. Premium only;

--- a/server/mdm/maintainedapps/sync.go
+++ b/server/mdm/maintainedapps/sync.go
@@ -153,14 +153,6 @@ func upsertMaintainedApps(ctx context.Context, appsList *AppsList, ds fleet.Data
 		return ctxerr.Wrap(ctx, err, "clear removed maintained apps during refresh")
 	}
 
-	// Normalizing existing software names to the canonical catalog names is deliberately
-	// not done here. It runs on its own schedule (CronMacOSMaintainedAppNames), because
-	// doing it here tied it to a successful fetch: a fetch that failed, or that errored
-	// part way through the upserts above, skipped the rename pass entirely and left the
-	// names the previous fetch had already recorded uncorrected. Ingestion applies the
-	// canonical name to newly reported software on its own, so nothing here depends on the
-	// pass having run.
-
 	return nil
 }
 

--- a/server/mdm/maintainedapps/sync.go
+++ b/server/mdm/maintainedapps/sync.go
@@ -153,11 +153,13 @@ func upsertMaintainedApps(ctx context.Context, appsList *AppsList, ds fleet.Data
 		return ctxerr.Wrap(ctx, err, "clear removed maintained apps during refresh")
 	}
 
-	// Normalize software names to canonical FMA names. Runs after the loop so it
-	// sees every app at once, which matters for FMAs sharing a bundle identifier.
-	if err := ds.ReconcileMaintainedAppSoftwareNames(ctx); err != nil {
-		return ctxerr.Wrap(ctx, err, "reconcile maintained app software names during refresh")
-	}
+	// Normalizing existing software names to the canonical catalog names is deliberately
+	// not done here. It runs on its own schedule (CronMacOSMaintainedAppNames), because
+	// doing it here tied it to a successful fetch: a fetch that failed, or that errored
+	// part way through the upserts above, skipped the rename pass entirely and left the
+	// names the previous fetch had already recorded uncorrected. Ingestion applies the
+	// canonical name to newly reported software on its own, so nothing here depends on the
+	// pass having run.
 
 	return nil
 }


### PR DESCRIPTION
Resolves #50165

The hourly Fleet-maintained apps refresh normalized software names with four multi-table `UPDATE ... JOIN (<derived table>)` statements in one transaction. The derived tables need GROUP BY, so MySQL materializes them, and at scale the optimizer flips to scanning the target table once per materialized row. An UPDATE locks every row it reads -- the WHERE filter is applied after the row is locked -- so that plan held exclusive next-key locks on all of `software` and `software_titles` for the whole run. Inserts needing a shared lock on a `software_titles` row then blocked on the foreign key check, timing out the software install endpoints. Forcing the plan locally takes 657 next-key locks on a 651-row table while matching zero rows.

The hazard is specific to UPDATE, so discovery still joins and only the writes changed:

- Find mismatched rows with one SELECT per pass and table, join order pinned by STRAIGHT_JOIN so the catalog is the outer table and every software row is reached by index. A SELECT here is a non-locking consistent read.
- Rename by primary key in batches of 500, each its own retried single-statement transaction, so locks are at most 500 record locks and release per statement. Every UPDATE re-checks `name <> ?`, keeping the pass idempotent. The comparison stays in SQL to preserve the column's utf8mb4_unicode_ci collation.
- Move the pass to its own schedule (CronMacOSMaintainedAppNames) so a failed catalog fetch no longer skips it, with a back-dated first run so existing mismatches heal on upgrade. The refresh still triggers it on success, best effort, so a name change applies immediately.
- Stop applying a macOS app's name to the iOS and iPadOS titles sharing its bundle identifier.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [X] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an independent hourly schedule to reconcile macOS maintained app names.
  * Catalog refresh now reconciles names only after a successful sync.
* **Bug Fixes**
  * Reconciliation now processes names in bounded batches and retries transient database conflicts.
  * Reconciliation warnings no longer fail scheduled jobs, while sync failures still do.
  * Improved handling for orphaned installers, naming precedence, and macOS versus iOS/iPadOS software.
* **Tests**
  * Added coverage for batch processing and reconciliation edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->