### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/evernote/windows.json
+++ b/ee/maintained-apps/outputs/evernote/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "11.26.4",
+      "version": "11.27.5",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Evernote%' AND publisher = 'Evernote Corporation';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Evernote%' AND publisher = 'Evernote Corporation' AND version_compare(version, '11.26.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Evernote%' AND publisher = 'Evernote Corporation' AND version_compare(version, '11.27.5') < 0);"
       },
-      "installer_url": "https://win.desktop.evernote.com/builds/Evernote-11.26.4-win-ddl-stage-20260717191948-2b1586022236ddbe2ab56acb08e507d128e39dad-setup.exe",
+      "installer_url": "https://win.desktop.evernote.com/builds/Evernote-11.27.5-win-ddl-stage-20260724150529-95d616891db3da8a048d6d178f0bc45153a8d267-setup.exe",
       "install_script_ref": "5820d576",
       "uninstall_script_ref": "d4142835",
-      "sha256": "9146ee01395f636a9fd025a3d3d9a2ebe78de63817e2e120a37ca608a781c9e3",
+      "sha256": "f0431e7b6aebac787c5fd35e6cf54cfc2765f6e08caa646b61d92fd23eadac96",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/granola/windows.json
+++ b/ee/maintained-apps/outputs/granola/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.447.2",
+      "version": "7.452.1",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Granola %' AND publisher = 'Granola';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Granola %' AND publisher = 'Granola' AND version_compare(version, '7.447.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Granola %' AND publisher = 'Granola' AND version_compare(version, '7.452.1') < 0);"
       },
-      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.447.2/Granola-7.447.2-win-x64.exe",
+      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.452.1/Granola-7.452.1-win-x64.exe",
       "install_script_ref": "3f66ac53",
       "uninstall_script_ref": "a4fab3f5",
-      "sha256": "d700fbed24f27fbe996e0bf25682128b9b89b0b219f2db091a6baf3e1f9e0a5e",
+      "sha256": "7ac8fca4d79953eae1509d9ad71340c71ab6bae4790c842d1a81ebf3f88922be",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/postman/windows.json
+++ b/ee/maintained-apps/outputs/postman/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.21.6",
+      "version": "12.21.7",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.21.6') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.21.7') < 0);"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.21.6/windows_64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.21.7/windows_64",
       "install_script_ref": "8594f0bc",
       "uninstall_script_ref": "fd59d029",
-      "sha256": "066705a484f6bd4eb514c2b2339ca0afd0fae17a19916784780c820368f29069",
+      "sha256": "dfb73305f085a56686b04adf91726c34f12b195c816c650a491bbea3c8e2559f",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/trezor-suite/darwin.json
+++ b/ee/maintained-apps/outputs/trezor-suite/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.7.2",
+      "version": "26.7.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'io.trezor.TrezorSuite';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.trezor.TrezorSuite' AND version_compare(bundle_short_version, '26.7.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.trezor.TrezorSuite' AND version_compare(bundle_short_version, '26.7.3') < 0);"
       },
-      "installer_url": "https://data.trezor.io/suite/releases/desktop/latest/Trezor-Suite-26.7.2-mac-arm64.dmg",
+      "installer_url": "https://data.trezor.io/suite/releases/desktop/latest/Trezor-Suite-26.7.3-mac-arm64.dmg",
       "install_script_ref": "a95207a7",
       "uninstall_script_ref": "9026a399",
-      "sha256": "9a455b0da5c310f2a55ba953c4d22450fa618ca181f4ac40b405ea58d6268e20",
+      "sha256": "bc77bde31935f9dc1148ae43e365da981ed55d25c4c3b1e4ebc14b7e76dac1b3",
       "default_categories": [
         "Security"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated Evernote for Windows to version 11.27.5.
  * Updated Granola for Windows to version 7.452.1.
  * Updated Postman for Windows to version 12.21.7.
  * Updated Trezor Suite for macOS to version 26.7.3.
  * Refreshed installer links and verification checksums for each release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->