### PR TITLE
Restore host_mdm.server_url on Apple MDM re-enrollment

### DIFF
--- a/changes/50187-ios-ipados-mdm-server-url-reenrollment
+++ b/changes/50187-ios-ipados-mdm-server-url-reenrollment
@@ -1,0 +1,1 @@
+- Fixed a bug where iOS and iPadOS hosts that unenrolled and re-enrolled in Fleet MDM could continue reporting an empty MDM server URL in the host API.

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -2073,7 +2073,7 @@ func upsertMDMAppleHostMDMInfoDB(ctx context.Context, tx sqlx.ExtContext, appCfg
 
 	_, err = tx.ExecContext(ctx, fmt.Sprintf(`
 		INSERT INTO host_mdm (enrolled, server_url, installed_from_dep, mdm_id, is_server, host_id, is_personal_enrollment) VALUES %s
-		ON DUPLICATE KEY UPDATE enrolled = VALUES(enrolled), is_personal_enrollment = VALUES(is_personal_enrollment)`, strings.Join(parts, ",")), args...)
+		ON DUPLICATE KEY UPDATE enrolled = VALUES(enrolled), server_url = VALUES(server_url), is_personal_enrollment = VALUES(is_personal_enrollment)`, strings.Join(parts, ",")), args...)
 
 	return ctxerr.Wrap(ctx, err, "upsert host mdm info")
 }

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -8162,9 +8162,9 @@ func testMDMAppleUpsertHostPersonalEnrollment(t *testing.T, ds *Datastore) {
 }
 
 // testMDMAppleUpsertHostRestoresServerURLOnReenroll guards host_mdm.server_url
-// through unenroll → re-enroll. MDMTurnOff clears server_url; MDMAppleUpsertHost
-// must rewrite it on conflict. Without that, iOS/iPadOS hosts keep
-// server_url='' forever (no osquery to refresh MDM details).
+// through unenroll -> re-enroll. MDMTurnOff clears server_url; MDMAppleUpsertHost
+// must rewrite it on conflict. Without that, iOS/iPadOS hosts keep an empty
+// server_url forever (no osquery to refresh MDM details).
 // Regression for https://github.com/fleetdm/fleet/issues/50187
 func testMDMAppleUpsertHostRestoresServerURLOnReenroll(t *testing.T, ds *Datastore) {
 	ctx := t.Context()
@@ -8212,7 +8212,7 @@ func testMDMAppleUpsertHostRestoresServerURLOnReenroll(t *testing.T, ds *Datasto
 		require.False(t, afterTurnOff.Enrolled)
 		require.Empty(t, afterTurnOff.ServerURL)
 
-		// Re-enroll hits updateMDMAppleHostDB → upsertMDMAppleHostMDMInfoDB with
+		// Re-enroll hits updateMDMAppleHostDB -> upsertMDMAppleHostMDMInfoDB with
 		// an existing host_mdm row (ON DUPLICATE KEY UPDATE path).
 		err = ds.MDMAppleUpsertHost(ctx, &fleet.Host{
 			UUID:           uuid,

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -104,6 +104,7 @@ func TestMDMApple(t *testing.T) {
 		{"ListIOSAndIPadOSToRefetch", testListIOSAndIPadOSToRefetch},
 		{"MDMAppleUpsertHostIOSiPadOS", testMDMAppleUpsertHostIOSIPadOS},
 		{"MDMAppleUpsertHostPersonalEnrollment", testMDMAppleUpsertHostPersonalEnrollment},
+		{"MDMAppleUpsertHostRestoresServerURLOnReenroll", testMDMAppleUpsertHostRestoresServerURLOnReenroll},
 		{"IngestMDMAppleDevicesFromDEPSyncIOSIPadOS", testIngestMDMAppleDevicesFromDEPSyncIOSIPadOS},
 		{"MDMAppleProfilesOnIOSIPadOS", testMDMAppleProfilesOnIOSIPadOS},
 		{"ReconcileAppleProfilesDuplicateHostUUID", testReconcileAppleProfilesDuplicateHostUUID},
@@ -8158,6 +8159,73 @@ func testMDMAppleUpsertHostPersonalEnrollment(t *testing.T, ds *Datastore) {
 	// A brand-new host inserted directly as BYOD (insertMDMAppleHostDB path).
 	byodID := upsert("byod-first", true)
 	require.True(t, readPersonalEnrollment(byodID), "fresh BYOD enrollment should be personal")
+}
+
+// testMDMAppleUpsertHostRestoresServerURLOnReenroll guards host_mdm.server_url
+// through unenroll → re-enroll. MDMTurnOff clears server_url; MDMAppleUpsertHost
+// must rewrite it on conflict. Without that, iOS/iPadOS hosts keep
+// server_url='' forever (no osquery to refresh MDM details).
+// Regression for https://github.com/fleetdm/fleet/issues/50187
+func testMDMAppleUpsertHostRestoresServerURLOnReenroll(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+	createBuiltinLabels(t, ds)
+
+	appCfg, err := ds.AppConfig(ctx)
+	require.NoError(t, err)
+	expectedServerURL, err := apple_mdm.ResolveAppleMDMURL(appCfg.MDMUrl())
+	require.NoError(t, err)
+
+	type hostMDMRow struct {
+		Enrolled  bool   `db:"enrolled"`
+		ServerURL string `db:"server_url"`
+	}
+	readHostMDM := func(hostID uint) hostMDMRow {
+		var row hostMDMRow
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			return sqlx.GetContext(ctx, q, &row,
+				`SELECT enrolled, server_url FROM host_mdm WHERE host_id = ?`, hostID)
+		})
+		return row
+	}
+
+	for _, platform := range []string{"ios", "ipados"} {
+		uuid := fmt.Sprintf("reenroll-server-url-%s", platform)
+		err := ds.MDMAppleUpsertHost(ctx, &fleet.Host{
+			UUID:           uuid,
+			HardwareSerial: "serial-" + uuid,
+			HardwareModel:  "test-model",
+			Platform:       platform,
+		}, false)
+		require.NoError(t, err)
+
+		h, err := ds.HostByIdentifier(ctx, uuid)
+		require.NoError(t, err)
+
+		initial := readHostMDM(h.ID)
+		require.True(t, initial.Enrolled)
+		require.Equal(t, expectedServerURL, initial.ServerURL)
+
+		_, _, err = ds.MDMTurnOff(ctx, uuid)
+		require.NoError(t, err)
+
+		afterTurnOff := readHostMDM(h.ID)
+		require.False(t, afterTurnOff.Enrolled)
+		require.Empty(t, afterTurnOff.ServerURL)
+
+		// Re-enroll hits updateMDMAppleHostDB → upsertMDMAppleHostMDMInfoDB with
+		// an existing host_mdm row (ON DUPLICATE KEY UPDATE path).
+		err = ds.MDMAppleUpsertHost(ctx, &fleet.Host{
+			UUID:           uuid,
+			HardwareSerial: "serial-" + uuid,
+			HardwareModel:  "test-model",
+			Platform:       platform,
+		}, false)
+		require.NoError(t, err)
+
+		afterReenroll := readHostMDM(h.ID)
+		require.True(t, afterReenroll.Enrolled, "platform %s", platform)
+		require.Equal(t, expectedServerURL, afterReenroll.ServerURL, "platform %s", platform)
+	}
 }
 
 func testIngestMDMAppleDevicesFromDEPSyncIOSIPadOS(t *testing.T, ds *Datastore) {


### PR DESCRIPTION
**Related issue:** Fixes #50187

## Problem

`MDMTurnOff` clears `host_mdm.server_url`. On re-enroll, `upsertMDMAppleHostMDMInfoDB` only updated `enrolled` and `is_personal_enrollment` on conflict, so the cleared URL stayed empty.

macOS often self-heals via osquery. **iOS/iPadOS do not**, so they keep `mdm.server_url: ""` forever while still showing `connected_to_fleet: true`.

## Fix

Also set `server_url` on `ON DUPLICATE KEY UPDATE`.

Minimal variant of #50188 (server_url only).

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

🤖 Generated with xai/grok-4.5 via pi

