### PR TITLE
[Activity] Document escrow disk encryption key activities

### DIFF
--- a/docs/Contributing/reference/audit-logs.md
+++ b/docs/Contributing/reference/audit-logs.md
@@ -501,7 +501,7 @@ This activity contains the following fields:
 ```json
 {
 	"host_id": 42,
-	"host_display_name": "USER-",
+	"host_display_name": "USER-WINDOWS",
 	"host_serial": "ABC123",
 	"triggered_by": "expiration",
 	"host_expiry_window": 30

--- a/docs/Contributing/reference/audit-logs.md
+++ b/docs/Contributing/reference/audit-logs.md
@@ -501,7 +501,7 @@ This activity contains the following fields:
 ```json
 {
 	"host_id": 42,
-	"host_display_name": "USER-WINDOWS",
+	"host_display_name": "USER-",
 	"host_serial": "ABC123",
 	"triggered_by": "expiration",
 	"host_expiry_window": 30
@@ -3126,13 +3126,13 @@ This activity contains the following fields:
 }
 ```
 
-## enabled_escrow_disk_encryption_key_only
+## edited_disk_encryption_settings_apple
 
-Generated when a user turns on escrow only for a fleet (or unassigned hosts).
+Generated when a user edits disk encryption settings for Apple hosts on a fleet (or unassigned hosts).
 
 This activity contains the following fields:
-- "fleet_id": The ID of the fleet that escrow only applies to, `null` if it applies to hosts that are not in a fleet ("Unassigned").
-- "fleet_name": The name of the fleet that escrow applies to, `null` if it applies to devices that are not in a fleet ("Unassigned").
+- "fleet_id": The ID of the fleet, `null` if it applies to hosts that are not in a fleet ("Unassigned").
+- "fleet_name": The name of the fleet, `null` if it applies to devices that are not in a fleet ("Unassigned").
 
 #### Example
 
@@ -3143,13 +3143,30 @@ This activity contains the following fields:
 }
 ```
 
-## disabled_escrow_disk_encryption_key_only
+## edited_disk_encryption_settings_windows
 
-Generated when a user turns off escrow only for a fleet (or unassigned hosts).
+Generated when a user edits disk encryption settings for Windows hosts on a fleet (or unassigned hosts).
 
 This activity contains the following fields:
-- "fleet_id": The ID of the fleet that escrow only applies to, `null` if it applies to hosts that are not in a fleet ("Unassigned").
-- "fleet_name": The name of the fleet that escrow applies to, `null` if it applies to devices that are not in a fleet ("Unassigned").
+- "fleet_id": The ID of the fleet, `null` if it applies to hosts that are not in a fleet ("Unassigned").
+- "fleet_name": The name of the fleet, `null` if it applies to devices that are not in a fleet ("Unassigned").
+
+#### Example
+
+```json
+{
+  "fleet_id": 123,
+  "fleet_name": "Workstations"
+}
+```
+
+## edited_disk_encryption_settings_linux
+
+Generated when a user edits disk encryption settings for Linux hosts on a fleet (or unassigned hosts).
+
+This activity contains the following fields:
+- "fleet_id": The ID of the fleet, `null` if it applies to hosts that are not in a fleet ("Unassigned").
+- "fleet_name": The name of the fleet, `null` if it applies to devices that are not in a fleet ("Unassigned").
 
 #### Example
 

--- a/docs/Contributing/reference/audit-logs.md
+++ b/docs/Contributing/reference/audit-logs.md
@@ -3126,6 +3126,40 @@ This activity contains the following fields:
 }
 ```
 
+## enabled_escrow_disk_encryption_key_only
+
+Generated when a user turns on escrow only for a fleet (or unassigned hosts).
+
+This activity contains the following fields:
+- "fleet_id": The ID of the fleet that escrow only applies to, `null` if it applies to hosts that are not in a fleet ("Unassigned").
+- "fleet_name": The name of the fleet that escrow applies to, `null` if it applies to devices that are not in a fleet ("Unassigned").
+
+#### Example
+
+```json
+{
+  "fleet_id": 123,
+  "fleet_name": "Workstations"
+}
+```
+
+## disabled_escrow_disk_encryption_key_only
+
+Generated when a user turns off escrow only for a fleet (or unassigned hosts).
+
+This activity contains the following fields:
+- "fleet_id": The ID of the fleet that escrow only applies to, `null` if it applies to hosts that are not in a fleet ("Unassigned").
+- "fleet_name": The name of the fleet that escrow applies to, `null` if it applies to devices that are not in a fleet ("Unassigned").
+
+#### Example
+
+```json
+{
+  "fleet_id": 123,
+  "fleet_name": "Workstations"
+}
+```
+
 
 <meta name="title" value="Audit logs">
 <meta name="pageOrderInSection" value="1400">

--- a/docs/Contributing/reference/audit-logs.md
+++ b/docs/Contributing/reference/audit-logs.md
@@ -945,6 +945,7 @@ This activity contains the following fields:
 ```
 
 ## enabled_macos_disk_encryption
+> **Deprecated:** Use platform based `edited_disk_encryption_settings_*` instead.
 
 Generated when a user turns on disk encryption for a fleet (or no fleet).
 
@@ -964,6 +965,7 @@ This activity contains the following fields:
 ```
 
 ## disabled_macos_disk_encryption
+> **Deprecated:** Use platform based `edited_disk_encryption_settings_*` instead.
 
 Generated when a user turns off disk encryption for a fleet (or no fleet).
 

--- a/docs/Contributing/reference/audit-logs.md
+++ b/docs/Contributing/reference/audit-logs.md
@@ -3135,7 +3135,7 @@ Generated when a user edits disk encryption settings for hosts on a fleet (or un
 This activity contains the following fields:
 - "fleet_id": The ID of the fleet, `null` if it applies to hosts that are not in a fleet ("Unassigned").
 - "fleet_name": The name of the fleet, `null` if it applies to devices that are not in a fleet ("Unassigned").
-- "platform": The platform of the fleet. Options are "macos", "windows", or "linux".
+- "platform": The platform that disk encryption settings were updated for. Options are "macos", "windows", or "linux".
 
 #### Example
 

--- a/docs/Contributing/reference/audit-logs.md
+++ b/docs/Contributing/reference/audit-logs.md
@@ -945,7 +945,7 @@ This activity contains the following fields:
 ```
 
 ## enabled_macos_disk_encryption
-> **Deprecated:** Use platform based `edited_disk_encryption_settings_*` instead.
+> **Deprecated:** Use platform based `edited_disk_encryption_settings` instead.
 
 Generated when a user turns on disk encryption for a fleet (or no fleet).
 
@@ -965,7 +965,7 @@ This activity contains the following fields:
 ```
 
 ## disabled_macos_disk_encryption
-> **Deprecated:** Use platform based `edited_disk_encryption_settings_*` instead.
+> **Deprecated:** Use platform based `edited_disk_encryption_settings` instead.
 
 Generated when a user turns off disk encryption for a fleet (or no fleet).
 
@@ -3128,57 +3128,24 @@ This activity contains the following fields:
 }
 ```
 
-## edited_disk_encryption_settings_apple
+## edited_disk_encryption_settings
 
-Generated when a user edits disk encryption settings for Apple hosts on a fleet (or unassigned hosts).
+Generated when a user edits disk encryption settings for hosts on a fleet (or unassigned hosts).
 
 This activity contains the following fields:
 - "fleet_id": The ID of the fleet, `null` if it applies to hosts that are not in a fleet ("Unassigned").
 - "fleet_name": The name of the fleet, `null` if it applies to devices that are not in a fleet ("Unassigned").
+- "platform": The platform of the fleet. Options are "macos", "windows", or "linux".
 
 #### Example
 
 ```json
 {
   "fleet_id": 123,
-  "fleet_name": "Workstations"
+  "fleet_name": "Workstations",
+  "platform": "windows"
 }
 ```
-
-## edited_disk_encryption_settings_windows
-
-Generated when a user edits disk encryption settings for Windows hosts on a fleet (or unassigned hosts).
-
-This activity contains the following fields:
-- "fleet_id": The ID of the fleet, `null` if it applies to hosts that are not in a fleet ("Unassigned").
-- "fleet_name": The name of the fleet, `null` if it applies to devices that are not in a fleet ("Unassigned").
-
-#### Example
-
-```json
-{
-  "fleet_id": 123,
-  "fleet_name": "Workstations"
-}
-```
-
-## edited_disk_encryption_settings_linux
-
-Generated when a user edits disk encryption settings for Linux hosts on a fleet (or unassigned hosts).
-
-This activity contains the following fields:
-- "fleet_id": The ID of the fleet, `null` if it applies to hosts that are not in a fleet ("Unassigned").
-- "fleet_name": The name of the fleet, `null` if it applies to devices that are not in a fleet ("Unassigned").
-
-#### Example
-
-```json
-{
-  "fleet_id": 123,
-  "fleet_name": "Workstations"
-}
-```
-
 
 <meta name="title" value="Audit logs">
 <meta name="pageOrderInSection" value="1400">

--- a/docs/Contributing/reference/audit-logs.md
+++ b/docs/Contributing/reference/audit-logs.md
@@ -945,7 +945,7 @@ This activity contains the following fields:
 ```
 
 ## enabled_macos_disk_encryption
-> **Deprecated:** Use platform based `edited_disk_encryption_settings` instead.
+> **Deprecated:** Use `edited_disk_encryption_settings` instead.
 
 Generated when a user turns on disk encryption for a fleet (or no fleet).
 
@@ -965,7 +965,7 @@ This activity contains the following fields:
 ```
 
 ## disabled_macos_disk_encryption
-> **Deprecated:** Use platform based `edited_disk_encryption_settings` instead.
+> **Deprecated:** Use `edited_disk_encryption_settings` instead.
 
 Generated when a user turns off disk encryption for a fleet (or no fleet).
 


### PR DESCRIPTION
Moves reference doc changes from #49135 to `docs-v4.92.0`.

Originally documented for `docs-v4.91.0` — feature pushed to this release.

**Related:** #49135