### PR TITLE
Match query reports from hosts in /api/v1/osquery/log endpoint

### DIFF
--- a/changes/16776-forged-query-report-rows
+++ b/changes/16776-forged-query-report-rows
@@ -1,0 +1,1 @@
+- Fixed the osquery result log endpoint so that an enrolled host can no longer inject rows into the report of a saved query it was never scheduled to run. Results are now only stored when the reported query belongs to the host's fleet and is actually on a schedule, instead of being trusted based on the reported query name alone.

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -14293,6 +14293,115 @@ func (s *integrationTestSuite) TestQueryReports() {
 	// TODO: Set global discard flag and verify that all data is gone.
 }
 
+// TestQueryReportsRejectResultsNotScheduledForHost checks that an enrolled host
+// cannot forge rows in the report of a saved query it was never scheduled to
+// run, by submitting result logs that reference the query by name.
+func (s *integrationTestSuite) TestQueryReportsRejectResultsNotScheduledForHost() {
+	t := s.T()
+	ctx := context.Background()
+
+	counts := make(map[uint]int)
+	s.lq.GetQueryResultsCountsOverride = func(queryIDs []uint) (map[uint]int, error) {
+		return counts, nil
+	}
+	s.lq.IncrQueryResultsCountsOverride = func(queryIDsToAmounts map[uint]int) error {
+		for queryID, amount := range queryIDsToAmounts {
+			counts[queryID] += amount
+		}
+		return nil
+	}
+	defer func() {
+		s.lq.GetQueryResultsCountsOverride = nil
+		s.lq.IncrQueryResultsCountsOverride = nil
+	}()
+
+	host, err := s.ds.NewHost(ctx, &fleet.Host{
+		DetailUpdatedAt: time.Now(),
+		LabelUpdatedAt:  time.Now(),
+		PolicyUpdatedAt: time.Now(),
+		SeenTime:        time.Now(),
+		NodeKey:         new("forge-1"),
+		UUID:            "forge-1",
+		Hostname:        "forge.local",
+		OsqueryHostID:   new("forge-1"),
+		Platform:        "darwin",
+	})
+	require.NoError(t, err)
+
+	// A global report with no schedule and automations disabled: Fleet never sends
+	// it to any host, so no host can legitimately report results for it.
+	unscheduled, err := s.ds.NewQuery(ctx, &fleet.Query{
+		Name:               "Unscheduled report",
+		Query:              "SELECT 1;",
+		Saved:              true,
+		Interval:           0,
+		AutomationsEnabled: false,
+		DiscardData:        false,
+		Logging:            fleet.LoggingSnapshot,
+	})
+	require.NoError(t, err)
+
+	// A scheduled report belonging to a team the host is not a member of.
+	team, err := s.ds.NewTeam(ctx, &fleet.Team{Name: t.Name() + "-team"})
+	require.NoError(t, err)
+	otherTeam, err := s.ds.NewQuery(ctx, &fleet.Query{
+		Name:               "Other team report",
+		Query:              "SELECT 1;",
+		Saved:              true,
+		Interval:           60,
+		AutomationsEnabled: false,
+		DiscardData:        false,
+		Logging:            fleet.LoggingSnapshot,
+		TeamID:             &team.ID,
+	})
+	require.NoError(t, err)
+
+	forgeResults := func(packName, queryName string) {
+		slreq := submitLogsRequest{
+			NodeKey: *host.NodeKey,
+			LogType: "result",
+			Data: []json.RawMessage{json.RawMessage(`{
+  "snapshot": [{"forged": "true", "value": "tampered-row"}],
+  "action": "snapshot",
+  "name": "pack/` + packName + `/` + queryName + `",
+  "hostIdentifier": "` + *host.OsqueryHostID + `",
+  "calendarTime": "Fri Oct  6 17:32:08 2023 UTC",
+  "unixTime": 1696613528
+}`)},
+		}
+		slres := submitLogsResponse{}
+		s.DoJSON("POST", "/api/osquery/log", slreq, http.StatusOK, &slres)
+		require.NoError(t, slres.Err)
+	}
+
+	reportRows := func(queryID uint) int {
+		var gqrr fleet.GetQueryReportResponse
+		s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/queries/%d/report", queryID), fleet.GetQueryReportRequest{}, http.StatusOK, &gqrr)
+		require.NoError(t, gqrr.Err)
+		return len(gqrr.Results)
+	}
+
+	// Neither forged submission is persisted, and the report row counters are
+	// left untouched.
+	forgeResults("Global", unscheduled.Name)
+	forgeResults("team-"+otherTeam.TeamIDStr(), otherTeam.Name)
+	require.Zero(t, reportRows(unscheduled.ID))
+	require.Zero(t, reportRows(otherTeam.ID))
+	require.Empty(t, counts)
+
+	// Put the global report on a schedule: the same submission is now accepted,
+	// which confirms the schedule correlation is what rejected it above. The other
+	// team's report stays rejected, as the host is still not a member of that team.
+	unscheduled.Interval = 60
+	require.NoError(t, s.ds.SaveQuery(ctx, unscheduled, false, false))
+
+	forgeResults("Global", unscheduled.Name)
+	forgeResults("team-"+otherTeam.TeamIDStr(), otherTeam.Name)
+	require.Equal(t, 1, reportRows(unscheduled.ID))
+	require.Zero(t, reportRows(otherTeam.ID))
+	require.Equal(t, map[uint]int{unscheduled.ID: 1}, counts)
+}
+
 // Creates a set of results for use in tests for Query Results.
 func results(num int, hostID string) string {
 	b := strings.Builder{}

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -3232,6 +3232,69 @@ func (svc *Service) SubmitResultLogs(ctx context.Context, logs []json.RawMessage
 // Query Reports
 ////////////////////////////////////////////////////////////////////////////////
 
+// queriesScheduledForHost returns the subset of the reported query names in
+// queriesDBData that the host is actually scheduled to run.
+//
+// osquery identifies scheduled query results by name only, so without this
+// correlation any enrolled host could submit results for any saved query in the
+// deployment — including queries of other teams and queries that are not
+// scheduled at all — and have them persisted in admin-visible query reports.
+//
+// This runs on every result log submission, so it must stay cheap: it needs no
+// DB access of its own, as the query rows in queriesDBData come from
+// Datastore.QueryByName, which is already cached in cached_mysql.
+//
+// The conditions below mirror Datastore.ListScheduledQueriesForAgents, which is
+// what builds the host's schedule, assuming query reports are enabled (the only
+// case where this is called). The label scope, platform and min osquery version
+// of a query are deliberately not enforced here: a host that is in the query's
+// fleet can already legitimately report results for it, so narrowing it further
+// costs a lookup per submission without preventing a cross-fleet forgery.
+func (svc *Service) queriesScheduledForHost(
+	ctx context.Context,
+	host *fleet.Host,
+	queriesDBData map[string]*fleet.Query,
+) map[string]struct{} {
+	var hostTeamID uint
+	if host.TeamID != nil {
+		hostTeamID = *host.TeamID
+	}
+
+	scheduled := make(map[string]struct{}, len(queriesDBData))
+	var notScheduledNames []string
+
+	for reportedName, dbQuery := range queriesDBData {
+		switch {
+		case !dbQuery.Saved:
+			// Only saved queries are part of a host's schedule.
+		case dbQuery.Interval == 0:
+			// The query is not scheduled to run on any host, thus no host can
+			// legitimately report results for it.
+		case dbQuery.TeamID != nil && *dbQuery.TeamID != hostTeamID:
+			// The query belongs to a team the host is not a member of. Either the host
+			// was transferred to another team, or it reported another team's pack name.
+		case !dbQuery.AutomationsEnabled && (dbQuery.DiscardData || dbQuery.Logging != fleet.LoggingSnapshot):
+			// Fleet does not send this query to hosts, as it would do nothing with its
+			// results: they are neither forwarded to the log destination (automations
+			// are off) nor stored in a query report (data discarded or not a snapshot).
+		default:
+			scheduled[reportedName] = struct{}{}
+			continue
+		}
+		notScheduledNames = append(notScheduledNames, reportedName)
+	}
+
+	if len(notScheduledNames) > 0 {
+		// Logged in one line per submission to help detect hosts forging results, as
+		// well as to troubleshoot legitimate results dropped because the host's
+		// schedule changed since it last refreshed its config.
+		svc.logger.DebugContext(ctx, "discarding results for queries not scheduled for host",
+			"host_id", host.ID, "queries", strings.Join(notScheduledNames, ", "))
+	}
+
+	return scheduled
+}
+
 func (svc *Service) saveResultLogsToQueryReports(
 	ctx context.Context,
 	unmarshaledResults []*fleet.ScheduledQueryResult,
@@ -3254,6 +3317,10 @@ func (svc *Service) saveResultLogsToQueryReports(
 
 	// Filter results to only the most recent for each query.
 	unmarshaledResultsFiltered = getMostRecentResults(unmarshaledResultsFiltered)
+
+	// Reported query names the host is actually scheduled to run. Anything else is
+	// forged or stale and must not make it into a query report.
+	scheduledForHost := svc.queriesScheduledForHost(ctx, host, queriesDBData)
 
 	// Batch fetch query result counts from Redis for all queries
 	var queryResultCounts map[uint]int
@@ -3280,18 +3347,15 @@ func (svc *Service) saveResultLogsToQueryReports(
 			continue
 		}
 
-		if dbQuery.DiscardData || dbQuery.Logging != fleet.LoggingSnapshot {
-			// Ignore result if query is marked as discard data or if logging is not snapshot
+		if _, ok := scheduledForHost[result.QueryName]; !ok {
+			// Ignore results for queries that are not part of this host's schedule
+			// (e.g. queries of another team, out of the host's label scope, or not
+			// scheduled at all), otherwise a host could forge rows in any report.
 			continue
 		}
 
-		hostTeamID := uint(0)
-		if host.TeamID != nil {
-			hostTeamID = *host.TeamID
-		}
-		if dbQuery.TeamID != nil && *dbQuery.TeamID != hostTeamID {
-			// The host was transferred to another team/global so we ignore the incoming results
-			// of this query that belong to a different team.
+		if dbQuery.DiscardData || dbQuery.Logging != fleet.LoggingSnapshot {
+			// Ignore result if query is marked as discard data or if logging is not snapshot
 			continue
 		}
 

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -657,6 +657,8 @@ func TestSubmitResultLogsToLogDestination(t *testing.T) {
 			return &fleet.Query{
 				ID:                 4242,
 				Name:               name,
+				Saved:              true,
+				Interval:           3600,
 				AutomationsEnabled: true,
 				TeamID:             ptr.Uint(1),
 				Logging:            fleet.LoggingSnapshot,
@@ -665,6 +667,8 @@ func TestSubmitResultLogsToLogDestination(t *testing.T) {
 			return &fleet.Query{
 				ID:                 4343,
 				Name:               name,
+				Saved:              true,
+				Interval:           3600,
 				AutomationsEnabled: true,
 				TeamID:             ptr.Uint(2),
 				Logging:            fleet.LoggingSnapshot,
@@ -673,23 +677,31 @@ func TestSubmitResultLogsToLogDestination(t *testing.T) {
 			return &fleet.Query{
 				ID:                 uint(name[0]),
 				Name:               name,
+				Saved:              true,
+				Interval:           3600,
 				AutomationsEnabled: true,
 			}, nil
 		case teamID != nil && *teamID == 1 && name == "hosts":
 			return &fleet.Query{
 				Name:               name,
+				Saved:              true,
+				Interval:           3600,
 				AutomationsEnabled: true,
 				TeamID:             teamID,
 			}, nil
 		case teamID == nil && name == "query_not_automated":
 			return &fleet.Query{
 				Name:               name,
+				Saved:              true,
+				Interval:           3600,
 				AutomationsEnabled: false,
 			}, nil
 		case teamID == nil && name == "query_should_be_saved_and_submitted":
 			return &fleet.Query{
 				ID:                 123,
 				Name:               name,
+				Saved:              true,
+				Interval:           3600,
 				AutomationsEnabled: true,
 				Logging:            fleet.LoggingSnapshot,
 			}, nil
@@ -697,6 +709,8 @@ func TestSubmitResultLogsToLogDestination(t *testing.T) {
 			return &fleet.Query{
 				ID:                 777,
 				Name:               name,
+				Saved:              true,
+				Interval:           3600,
 				AutomationsEnabled: true,
 				Logging:            fleet.LoggingSnapshot,
 			}, nil
@@ -704,6 +718,8 @@ func TestSubmitResultLogsToLogDestination(t *testing.T) {
 			return &fleet.Query{
 				ID:                 1234,
 				Name:               name,
+				Saved:              true,
+				Interval:           3600,
 				AutomationsEnabled: true,
 				Logging:            fleet.LoggingSnapshot,
 			}, nil
@@ -711,6 +727,8 @@ func TestSubmitResultLogsToLogDestination(t *testing.T) {
 			return &fleet.Query{
 				ID:                 444,
 				Name:               name,
+				Saved:              true,
+				Interval:           3600,
 				AutomationsEnabled: false,
 				Logging:            fleet.LoggingSnapshot,
 			}, nil
@@ -718,6 +736,8 @@ func TestSubmitResultLogsToLogDestination(t *testing.T) {
 			return &fleet.Query{
 				ID:                 555,
 				Name:               name,
+				Saved:              true,
+				Interval:           3600,
 				AutomationsEnabled: true,
 				Logging:            fleet.LoggingSnapshot,
 			}, nil
@@ -902,6 +922,8 @@ func TestSaveResultLogsToQueryReports(t *testing.T) {
 	discardDataTrue := map[string]*fleet.Query{
 		"pack/Global/Uptime": {
 			ID:          1,
+			Saved:       true,
+			Interval:    3600,
 			DiscardData: true,
 			Logging:     fleet.LoggingSnapshot,
 		},
@@ -913,6 +935,8 @@ func TestSaveResultLogsToQueryReports(t *testing.T) {
 	discardDataFalse := map[string]*fleet.Query{
 		"pack/Global/Uptime": {
 			ID:          1,
+			Saved:       true,
+			Interval:    3600,
 			DiscardData: false,
 			Logging:     fleet.LoggingSnapshot,
 		},
@@ -951,6 +975,8 @@ func TestSaveResultLogsToQueryReportsWithTableOverLimit(t *testing.T) {
 	discardDataFalse := map[string]*fleet.Query{
 		"pack/Global/Uptime": {
 			ID:          1,
+			Saved:       true,
+			Interval:    3600,
 			DiscardData: false,
 			Logging:     fleet.LoggingSnapshot,
 		},
@@ -994,6 +1020,8 @@ func TestSubmitResultLogsToQueryResultsWithEmptySnapShot(t *testing.T) {
 	ds.QueryByNameFunc = func(ctx context.Context, teamID *uint, name string) (*fleet.Query, error) {
 		return &fleet.Query{
 			ID:          1,
+			Saved:       true,
+			Interval:    3600,
 			DiscardData: false,
 			Logging:     fleet.LoggingSnapshot,
 		}, nil
@@ -1045,6 +1073,8 @@ func TestSubmitResultLogsToQueryResultsDoesNotCountNullDataRows(t *testing.T) {
 	ds.QueryByNameFunc = func(ctx context.Context, teamID *uint, name string) (*fleet.Query, error) {
 		return &fleet.Query{
 			ID:          1,
+			Saved:       true,
+			Interval:    3600,
 			DiscardData: false,
 			Logging:     fleet.LoggingSnapshot,
 		}, nil
@@ -1065,6 +1095,81 @@ func TestSubmitResultLogsToQueryResultsDoesNotCountNullDataRows(t *testing.T) {
 	err = svc.SubmitResultLogs(ctx, results)
 	require.NoError(t, err)
 	assert.True(t, ds.OverwriteQueryResultRowsFuncInvoked)
+}
+
+// TestSubmitResultLogsOnlyStoresQueriesScheduledForHost checks that a host
+// cannot forge rows in the report of a saved query it was never scheduled to
+// run. osquery identifies scheduled query results by name only, so the reported
+// name must be correlated with the host's schedule before storing the results.
+func TestSubmitResultLogsOnlyStoresQueriesScheduledForHost(t *testing.T) {
+	const hostID = 999
+
+	// The reported queries, keyed by the query name the host claims to be
+	// reporting results for.
+	queries := map[string]*fleet.Query{
+		"scheduled": {
+			ID: 1, Name: "scheduled", Saved: true, Interval: 3600,
+			Logging: fleet.LoggingSnapshot,
+		},
+		"not_scheduled": {
+			// No schedule interval: Fleet never sends this query to any host, so no
+			// host can legitimately report results for it.
+			ID: 2, Name: "not_scheduled", Saved: true, Interval: 0,
+			Logging: fleet.LoggingSnapshot,
+		},
+		"not_saved": {
+			ID: 3, Name: "not_saved", Saved: false, Interval: 3600,
+			Logging: fleet.LoggingSnapshot,
+		},
+		"other_team": {
+			ID: 4, Name: "other_team", Saved: true, Interval: 3600,
+			TeamID: new(uint(42)), Logging: fleet.LoggingSnapshot,
+		},
+		"not_delivered_to_hosts": {
+			// Neither automations nor query reports: not part of any host's schedule.
+			ID: 5, Name: "not_delivered_to_hosts", Saved: true, Interval: 3600,
+			AutomationsEnabled: false, DiscardData: true, Logging: fleet.LoggingSnapshot,
+		},
+	}
+
+	for _, tc := range []struct {
+		queryName string
+		stored    bool
+	}{
+		{queryName: "scheduled", stored: true},
+		{queryName: "not_scheduled", stored: false},
+		{queryName: "not_saved", stored: false},
+		{queryName: "other_team", stored: false},
+		{queryName: "not_delivered_to_hosts", stored: false},
+	} {
+		t.Run(tc.queryName, func(t *testing.T) {
+			ds := new(mock.Store)
+			svc, ctx := newTestService(t, ds, nil, nil)
+			ctx = hostctx.NewContext(ctx, &fleet.Host{ID: hostID, TeamID: nil})
+
+			ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+				return &fleet.AppConfig{}, nil
+			}
+			ds.QueryByNameFunc = func(ctx context.Context, teamID *uint, name string) (*fleet.Query, error) {
+				query, ok := queries[name]
+				if !ok || teamID != nil {
+					return nil, newNotFoundError()
+				}
+				return query, nil
+			}
+			ds.OverwriteQueryResultRowsFunc = func(ctx context.Context, rows []*fleet.ScheduledQueryResultRow, maxQueryReportRows int) (int, error) {
+				return len(rows), nil
+			}
+
+			log := fmt.Sprintf(
+				`{"action":"snapshot","name":"pack/Global/%s","hostIdentifier":"1379f59d98f4","calendarTime":"Tue Jan 10 20:08:51 2017 UTC","unixTime":1484078931,"snapshot":[{"forged":"true"}]}`,
+				tc.queryName,
+			)
+			require.NoError(t, svc.SubmitResultLogs(ctx, []json.RawMessage{json.RawMessage(log)}))
+
+			assert.Equal(t, tc.stored, ds.OverwriteQueryResultRowsFuncInvoked)
+		})
+	}
 }
 
 type failingLogger struct{}
@@ -1103,6 +1208,8 @@ func TestSubmitResultLogsFail(t *testing.T) {
 	ds.QueryByNameFunc = func(ctx context.Context, teamID *uint, name string) (*fleet.Query, error) {
 		return &fleet.Query{
 			ID:                 1,
+			Saved:              true,
+			Interval:           3600,
 			DiscardData:        false,
 			AutomationsEnabled: true,
 			Name:               name,


### PR DESCRIPTION
- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [X] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually