### PR TITLE
Cherry-pick #50106: allow .py packages to set setup_experience_platform

### DIFF
--- a/ee/server/service/software_installers_test.go
+++ b/ee/server/service/software_installers_test.go
@@ -2620,6 +2620,10 @@ func TestNormalizeSetupExperiencePlatforms(t *testing.T) {
 		{name: "pkg any rejected", input: []string{"darwin"}, extension: "pkg", wantErr: `platform "darwin" is not a valid "setup_experience_platform" value for a .pkg package`},
 		{name: "msi any rejected", input: []string{"darwin"}, extension: "msi", wantErr: `platform "darwin" is not a valid "setup_experience_platform" value for a .msi package`},
 		{name: "sh unsupported windows", input: []string{"windows"}, extension: "sh", wantErr: `platform "windows" is not a valid "setup_experience_platform" value for a .sh package`},
+		{name: "py darwin", input: []string{"darwin"}, extension: "py", want: []string{"darwin"}},
+		{name: "py linux", input: []string{"linux"}, extension: "py", want: []string{"linux"}},
+		{name: "py both platforms", input: []string{"darwin", "linux"}, extension: "py", want: []string{"darwin", "linux"}},
+		{name: "py unsupported windows", input: []string{"windows"}, extension: "py", wantErr: `platform "windows" is not a valid "setup_experience_platform" value for a .py package`},
 		{name: "empty string skipped", input: []string{""}, extension: "sh", want: []string{}},
 	}
 

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -801,7 +801,7 @@ func CanonicalPlatform(p string) string {
 func AllowedSetupExperiencePlatformsForExtension(ext string) []string {
 	ext = strings.TrimPrefix(strings.ToLower(ext), ".")
 	switch ext {
-	case "sh":
+	case "sh", "py":
 		return []string{"darwin", "linux"}
 	default:
 		return nil

--- a/server/fleet/software_installer_test.go
+++ b/server/fleet/software_installer_test.go
@@ -184,6 +184,30 @@ func TestSoftwareInstallerPlatformFromExtension(t *testing.T) {
 	}
 }
 
+func TestAllowedSetupExperiencePlatformsForExtension(t *testing.T) {
+	testCases := []struct {
+		ext      string
+		expected []string
+	}{
+		{".py", []string{"darwin", "linux"}},
+		{"py", []string{"darwin", "linux"}},
+		{".sh", []string{"darwin", "linux"}},
+		{"sh", []string{"darwin", "linux"}},
+		{".ps1", nil},
+		{"ps1", nil},
+		{".exe", nil},
+		{"exe", nil},
+		{"", nil},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.ext, func(t *testing.T) {
+			result := AllowedSetupExperiencePlatformsForExtension(tc.ext)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
 func TestSofwareInstallerSourceFromExtensionAndName(t *testing.T) {
 	testCases := []struct {
 		ext      string


### PR DESCRIPTION
**Related issue:** Resolves #50106

Cherry-picks only the #50106 slice from #50143 (merged to `main`) into the 4.90 RC. `.py` script-only packages now accept `setup_experience_platform` (`darwin`/`linux`), matching `.sh` — previously `AllowedSetupExperiencePlatformsForExtension` returned `nil` for `.py`, so every value was rejected with an empty allowlist (`allowed: `). This is an `~unreleased` bug (first ships in 4.90.0); the other five fixes from #50143 remain on `main`.

# Checklist for submitter

## Testing

- [x] Added/updated automated tests

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results
