### PR TITLE
Add "Let's get you set up" call ownership to GTM operations handbook

### DIFF
--- a/handbook/company/go-to-market-operations.md
+++ b/handbook/company/go-to-market-operations.md
@@ -311,6 +311,10 @@ Monitor hourly, sorted by Created Date (newest first). No lead untouched > 60 mi
 - Salesforce updated before moving to next lead
 
 
+## "Let's get you set up" calls
+
+"Let's get you set up" calls happen every Friday at 10 AM and 2 PM US Central time. [Dave Siederer](https://www.linkedin.com/in/siederer/) _([@ds0x](https://github.com/ds0x))_ on the Solutions Consulting team owns these calls. Scheduling is tied to Dave's calendar, and he coordinates coverage when he is unable to attend. Every call includes a Solutions Consultant and a Solutions Specialist.
+
 
 ## Proof of value (POV)
 

--- a/handbook/company/go-to-market-operations.md
+++ b/handbook/company/go-to-market-operations.md
@@ -313,7 +313,7 @@ Monitor hourly, sorted by Created Date (newest first). No lead untouched > 60 mi
 
 ## "Let's get you set up" calls
 
-"Let's get you set up" calls happen every Friday at 10 AM and 2 PM US Central time. [Dave Siederer](https://www.linkedin.com/in/siederer/) _([@ds0x](https://github.com/ds0x))_ on the Solutions Consulting team owns these calls. Scheduling is tied to Dave's calendar, and he coordinates coverage when he is unable to attend. Every call includes a Solutions Consultant and a Solutions Specialist.
+"Let's get you set up" calls happen every Friday at 10 AM and 2 PM US Central time. [Dave Siederer](https://www.linkedin.com/in/siederer/) _([@ds0x](https://github.com/ds0x))_ on the Solutions Consulting team is point person for these calls. He will be on these calls as his schedule allows and coordinates coverage when he is unable to attend. Every call includes a Solutions Consultant and a Solutions Specialist.
 
 
 ## Proof of value (POV)


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Manually QA'd the change (handbook-only: previewed the Markdown rendering)

## Details

Adds a "Let's get you set up" calls section to the 🚂 Go-To-Market operations handbook page, documenting:

- Ownership: Dave Siederer (@ds0x) on the Solutions Consulting team owns these calls. Scheduling is tied to his calendar, and he coordinates coverage when he is unable to attend.
- Staffing: every call includes a Solutions Consultant and a Solutions Specialist.
- Schedule: every Friday at 10 AM and 2 PM US Central time.

The section is placed after the "Solution Specialist inbound lead follow-up" process and before "Proof of value (POV)", matching the meeting-booking stage of the funnel. No product code changes, so no changes file is needed.
