### PR TITLE
Update community contributions process for AI-driven workflow

### DIFF
--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -130,13 +130,17 @@ Make sure to create a Github issue and link it to the PR so that we can track th
 
 1. **On-call triage**: All community PRs are first reviewed by the on-call engineer. The on-call engineer routes the PR to the appropriate product group.
 
-2. **EM assessment**: The Engineering Manager (EM) of the owning product group evaluates the size, complexity, and review effort required.
+2. **Classification** (EM): The Engineering Manager (EM) of the owning product group determines what type of change this is: bug fix, reliability improvement, product change, or something else.
 
-3. **Quick wins** (estimated review time of 30 minutes or less): The team reviews and merges promptly. Follow the existing merge process below.
+3. **Decision gate**: Based on the type, the right person decides whether this is something we want to pursue:
+   - Product changes (UI, user-facing behavior, API responses or endpoints, configuration options, CLI commands, or documentation): the Product Designer (PD) decides.
+   - Bug fixes and reliability issues: the Engineering Manager decides.
 
-4. **Larger contributions** (estimated review time over 30 minutes, or complex/risky changes): The EM adds the PR to the team's ready column. The team reviews it when capacity allows, fitting it into their planned work. A comment should be posted on the PR thanking the contributor and letting them know the timeline.
+   If the PR is not something we want to pursue, thank the contributor, explain the reasoning, and close the PR.
 
-5. **Product changes**: If the PR changes the product (UI, user-facing behavior, API responses or endpoints, configuration options, CLI commands, or documentation), the EM assigns it to the relevant Product Designer (PD) for review before merging.
+4. **Size and complexity** (EM): If accepted, the EM evaluates the review effort required:
+   - **Quick wins** (estimated review time of 30 minutes or less): The team reviews and merges promptly. Follow the existing merge process below.
+   - **Larger contributions** (estimated review time over 30 minutes, or complex/risky changes): The EM adds the PR to the team's ready column. The team reviews it when capacity allows, fitting it into their planned work. A comment should be posted on the PR thanking the contributor and letting them know the timeline.
 
 
 #### Merge a community pull request

--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -114,26 +114,27 @@ All conversation about an unfixed vulnerability stays in the confidential repo â
 
 ### Community contributions
 
+Fleet values every community contribution. We want to be upfront about how our engineering workflow has evolved so contributors know what to expect.
+
+Fleet uses AI tools extensively to accelerate code development. This means that writing code is no longer the team's bottleneck. Instead, the primary engineering work has shifted to deep code review: understanding the design, evaluating architecture decisions, assessing security implications, and ensuring the team fully owns every line that ships. Fleet is committed to understanding every line of code that goes into the product, regardless of who wrote it.
+
+Because of this shift, contributed code, while genuinely appreciated, does not save the team as much development time as it once did. The review effort is the same whether code was written by a contributor or by the team itself. This is not a reflection of the quality of contributions. It is a reflection of the depth of review Fleet requires before merging any change. Larger or more complex PRs may take longer to review as the team fits them into their planned work.
+
 #### Review a community pull request
 
-If you're assigned a community pull request (PR) for review, it is important to keep things moving for the contributor. The goal is to not go more than one business day without following up with the contributor. This applies to PRs from Fleeties, open source contributors, member of the Customer Success team, etc.
-
-If the PR is a quick fix (i.e. typo) or obvious technical improvement that doesn't change the product, it can be merged.
+The goal is to not go more than one business day without following up with the contributor. This applies to PRs from Fleeties, open source contributors, members of the Customer Success team, etc.
 
 If the PR is a bug fix that the author has not validated manually, close the PR. Notify the author that the PR will be re-opened and reviewed after they validate the fix.
 
 Make sure to create a Github issue and link it to the PR so that we can track the changes in our release process. Make sure to assign the correct milestone to the issue (by having an issue, QA will make sure the fix is not causing regressions).
 
-**For PRs that change the product:**
+1. **On-call triage**: All community PRs are first reviewed by the on-call engineer. The on-call engineer routes the PR to the appropriate product group.
 
-- Assign the PR to the appropriate Product Designer (PD).
-- @ mention the relevant PD in a comment on the PR.
+2. **EM assessment**: The Engineering Manager (EM) of the owning product group evaluates the size, complexity, and review effort required.
 
-The PD will be the contact point for the contributor and will ensure the PR is reviewed by the appropriate team member when ready. The PD should:
+3. **Quick wins** (estimated review time of 30 minutes or less): The team reviews and merges promptly. Follow the existing merge process below.
 
-- Set the PR to draft.
-- Immediately decide whether to prioritize a [user story or quick win](https://fleetdm.com/handbook/company/product-groups#work-items) and bring it through drafting or put the change to the side (not prioritize).
-- Thank the contributor for their hard work, notify them on whether their change was prioritized or put to the side. If the change was put to the side, ask the contributor to file a [feature request](https://github.com/fleetdm/fleet/issues/new?assignees=&labels=%3Aproduct&projects=&template=feature-request.md&title=) that describes the change, let them know that it only means the change has been rejected _at that time_, and close the PR.
+4. **Larger contributions** (estimated review time over 30 minutes, or complex/risky changes): The EM adds the PR to the team's ready column. The team reviews it when capacity allows, fitting it into their planned work. A comment should be posted on the PR thanking the contributor and letting them know the timeline.
 
 
 #### Merge a community pull request

--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -118,7 +118,7 @@ Fleet values every community contribution. We want to be upfront about how our e
 
 Fleet uses AI tools extensively to accelerate code development. This means that writing code is no longer the team's bottleneck. Instead, the primary engineering work has shifted to deep code review: understanding the design, evaluating architecture decisions, assessing security implications, and ensuring the team fully owns every line that ships. Fleet is committed to understanding every line of code that goes into the product, regardless of who wrote it.
 
-Because of this shift, contributed code, while genuinely appreciated, does not save the team as much development time as it once did. The review effort is the same whether code was written by a contributor or by the team itself. This is not a reflection of the quality of contributions. It is a reflection of the depth of review Fleet requires before merging any change. Larger or more complex PRs may take longer to review as the team fits them into their planned work. Bug reports with clear reproduction steps, feature requests, and design feedback remain especially valuable.
+Because of this shift, the review effort for any change is the same regardless of who wrote the code. Every contribution receives the same depth of review that Fleet applies to its own work. Larger or more complex PRs may take longer to review as the team fits them into their planned work. Bug reports with clear reproduction steps, feature requests, and design feedback remain especially valuable.
 
 #### Review a community pull request
 

--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -140,7 +140,7 @@ Make sure to create a Github issue and link it to the PR so that we can track th
 
 4. **Size and complexity** (EM): If accepted, the EM evaluates the review effort required:
    - **Quick wins** (estimated review time of 30 minutes or less): The team reviews and merges promptly. Follow the existing merge process below.
-   - **Larger contributions** (estimated review time over 30 minutes, or complex/risky changes): The EM adds the PR to the team's ready column. The team reviews it when capacity allows, fitting it into their planned work. A comment should be posted on the PR thanking the contributor and letting them know the timeline.
+   - **Larger contributions** (estimated review time over 30 minutes, or complex/risky changes): The EM adds the PR to the team's ready column. The team reviews it when capacity allows, fitting it into their planned work. A comment should be posted on the PR thanking the contributor and letting them know the timeline. The EM should consider converting the PR to a draft to signal that it is not yet under active review.
 
 
 #### Merge a community pull request

--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -136,6 +136,8 @@ Make sure to create a Github issue and link it to the PR so that we can track th
 
 4. **Larger contributions** (estimated review time over 30 minutes, or complex/risky changes): The EM adds the PR to the team's ready column. The team reviews it when capacity allows, fitting it into their planned work. A comment should be posted on the PR thanking the contributor and letting them know the timeline.
 
+5. **Product changes**: If the PR changes the product (UI, user-facing behavior, or workflows), the EM assigns it to the relevant Product Designer (PD) for review before merging.
+
 
 #### Merge a community pull request
 

--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -138,9 +138,7 @@ Make sure to create a Github issue and link it to the PR so that we can track th
 
    If the PR is not something we want to pursue, thank the contributor, explain the reasoning, optionally invite them to file a [feature request](https://github.com/fleetdm/fleet/issues/new?assignees=&labels=%3Aproduct&projects=&template=feature-request.md&title=), and close the PR.
 
-4. **Size and complexity** (EM): If accepted, the EM evaluates the review effort required:
-   - **Quick wins** (estimated review time of 30 minutes or less): The team reviews and merges promptly. Follow the existing merge process below.
-   - **Larger contributions** (estimated review time over 30 minutes, or complex/risky changes): The EM adds the PR to the team's ready column. The team reviews it when capacity allows, fitting it into their planned work. A comment should be posted on the PR thanking the contributor and letting them know the timeline. The EM should consider converting the PR to a draft to signal that it is not yet under active review.
+4. **Track the work**: Create an issue using the relevant [work item](https://fleetdm.com/handbook/company/product-groups#work-items) issue template. The issue then moves across the relevant product group's board following the [standard process](https://fleetdm.com/handbook/company/product-groups#how-issues-move).
 
 
 #### Merge a community pull request

--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -118,25 +118,25 @@ Fleet values every community contribution. We want to be upfront about how our e
 
 Fleet uses AI tools extensively to accelerate code development. This means that writing code is no longer the team's bottleneck. Instead, the primary engineering work has shifted to deep code review: understanding the design, evaluating architecture decisions, assessing security implications, and ensuring the team fully owns every line that ships. Fleet is committed to understanding every line of code that goes into the product, regardless of who wrote it.
 
-Because of this shift, contributed code, while genuinely appreciated, does not save the team as much development time as it once did. The review effort is the same whether code was written by a contributor or by the team itself. This is not a reflection of the quality of contributions. It is a reflection of the depth of review Fleet requires before merging any change. Larger or more complex PRs may take longer to review as the team fits them into their planned work.
+Because of this shift, contributed code, while genuinely appreciated, does not save the team as much development time as it once did. The review effort is the same whether code was written by a contributor or by the team itself. This is not a reflection of the quality of contributions. It is a reflection of the depth of review Fleet requires before merging any change. Larger or more complex PRs may take longer to review as the team fits them into their planned work. Bug reports with clear reproduction steps, feature requests, and design feedback remain especially valuable.
 
 #### Review a community pull request
 
-The goal is to not go more than one business day without following up with the contributor. This applies to PRs from Fleeties, open source contributors, members of the Customer Success team, etc.
+The goal is to not go more than one business day without responding to the contributor and routing the PR to the right team. This applies to PRs from Fleeties, open source contributors, members of the Customer Success team, etc.
 
 If the PR is a bug fix that the author has not validated manually, close the PR. Notify the author that the PR will be re-opened and reviewed after they validate the fix.
 
 Make sure to create a Github issue and link it to the PR so that we can track the changes in our release process. Make sure to assign the correct milestone to the issue (by having an issue, QA will make sure the fix is not causing regressions).
 
-1. **On-call triage**: All community PRs are first reviewed by the on-call engineer. The on-call engineer routes the PR to the appropriate product group.
+1. **On-call triage**: All community PRs are first reviewed by the on-call engineer, who routes the PR to the appropriate product group's EM. Internal Fleeties who already know the owning team can go directly to the EM.
 
 2. **Classification** (EM): The Engineering Manager (EM) of the owning product group determines what type of change this is: bug fix, reliability improvement, product change, or something else.
 
 3. **Decision gate**: Based on the type, the right person decides whether this is something we want to pursue:
-   - Product changes (UI, user-facing behavior, API responses or endpoints, configuration options, CLI commands, or documentation): the Product Designer (PD) decides.
-   - Bug fixes and reliability issues: the Engineering Manager decides.
+   - Product changes (UI, user-facing behavior, API responses or endpoints, configuration options, CLI commands, or significant documentation changes that alter the product definition or meaning): the Product Designer (PD) decides.
+   - Bug fixes, typo fixes, minor documentation improvements, and reliability issues: the Engineering Manager decides.
 
-   If the PR is not something we want to pursue, thank the contributor, explain the reasoning, and close the PR.
+   If the PR is not something we want to pursue, thank the contributor, explain the reasoning, optionally invite them to file a [feature request](https://github.com/fleetdm/fleet/issues/new?assignees=&labels=%3Aproduct&projects=&template=feature-request.md&title=), and close the PR.
 
 4. **Size and complexity** (EM): If accepted, the EM evaluates the review effort required:
    - **Quick wins** (estimated review time of 30 minutes or less): The team reviews and merges promptly. Follow the existing merge process below.

--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -136,7 +136,7 @@ Make sure to create a Github issue and link it to the PR so that we can track th
 
 4. **Larger contributions** (estimated review time over 30 minutes, or complex/risky changes): The EM adds the PR to the team's ready column. The team reviews it when capacity allows, fitting it into their planned work. A comment should be posted on the PR thanking the contributor and letting them know the timeline.
 
-5. **Product changes**: If the PR changes the product (UI, user-facing behavior, or workflows), the EM assigns it to the relevant Product Designer (PD) for review before merging.
+5. **Product changes**: If the PR changes the product (UI, user-facing behavior, API responses or endpoints, configuration options, CLI commands, or documentation), the EM assigns it to the relevant Product Designer (PD) for review before merging.
 
 
 #### Merge a community pull request

--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -124,9 +124,6 @@ Because of this shift, the review effort for any change is the same regardless o
 
 The goal is to not go more than one business day without responding to the contributor and routing the PR to the right team. This applies to PRs from Fleeties, open source contributors, members of the Customer Success team, etc.
 
-If the PR is a bug fix that the author has not validated manually, close the PR. Notify the author that the PR will be re-opened and reviewed after they validate the fix.
-
-Make sure to create a Github issue and link it to the PR so that we can track the changes in our release process. Make sure to assign the correct milestone to the issue (by having an issue, QA will make sure the fix is not causing regressions).
 
 1. **On-call triage**: All community PRs are first reviewed by the on-call engineer, who routes the PR to the appropriate product group's EM. Internal Fleeties who already know the owning team can go directly to the EM.
 


### PR DESCRIPTION
**Related issue:** N/A

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

N/A - handbook-only change, no changelog needed.

## Summary

Updates the community contributions section of the engineering handbook to reflect how Fleet's AI-driven workflow has changed how the team handles external PRs.

**What changed:**
- Added a community-facing explanation of why review (not coding) is now the team's primary engineering work, and what that means for contribution timelines
- Replaced the old PD-centric routing flow with an EM-driven triage process:
  1. On-call engineer triages and routes to the right product group
  2. EM assesses size, complexity, and review effort
  3. Quick wins (30 min or less): reviewed and merged promptly
  4. Larger contributions: added to the team's ready column with a comment and timeline
- Preserved: one-business-day follow-up goal, bug fix validation rule, GitHub issue linking, merge/stale PR handling

## Test plan

- [ ] Read through the updated handbook section for clarity and tone
- [ ] Confirm the process aligns with current team structure and on-call responsibilities