### PR TITLE
Fix YAML docs link 404 in custom package GitOps callout (slug reversed)

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareCustomPackage/SoftwareCustomPackage.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareCustomPackage/SoftwareCustomPackage.tests.tsx
@@ -16,12 +16,12 @@ describe("GitOpsCustomPackageBanner", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders the YAML docs link pointing at learn-more-about/software-yaml", () => {
+  it("renders the YAML docs link pointing at learn-more-about/yaml-software", () => {
     render(<GitOpsCustomPackageBanner />);
     const link = screen.getByRole("link", { name: /YAML docs/i });
     expect(link).toHaveAttribute(
       "href",
-      expect.stringMatching(/learn-more-about\/software-yaml$/)
+      expect.stringMatching(/learn-more-about\/yaml-software$/)
     );
     expect(link).toHaveAttribute("target", "_blank");
   });

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareCustomPackage/SoftwareCustomPackage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareCustomPackage/SoftwareCustomPackage.tsx
@@ -45,7 +45,7 @@ export const GitOpsCustomPackageBanner = () => (
     adding, copy its SHA-256 hash into your YAML so the next GitOps workflow
     doesn&apos;t delete it.{" "}
     <CustomLink
-      url={`${LEARN_MORE_ABOUT_BASE_LINK}/software-yaml`}
+      url={`${LEARN_MORE_ABOUT_BASE_LINK}/yaml-software`}
       text="YAML docs"
       newTab
     />

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/AddPackageModal/AddPackageModal.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/AddPackageModal/AddPackageModal.tests.tsx
@@ -119,7 +119,7 @@ describe("AddPackageModal", () => {
       const link = screen.getByRole("link", { name: /YAML docs/i });
       expect(link).toHaveAttribute(
         "href",
-        expect.stringMatching(/learn-more-about\/software-yaml$/)
+        expect.stringMatching(/learn-more-about\/yaml-software$/)
       );
     });
 


### PR DESCRIPTION
**Related issue:** Resolves #50070

The "YAML docs" link in the GitOps callout on the custom-package flows pointed at the unregistered slug `learn-more-about/software-yaml`, returning a 404. Corrected to the registered `learn-more-about/yaml-software` (302 → `docs/configuration/yaml-files#software`). The link lives in the shared `GitOpsCustomPackageBanner`, so this fixes it in both places it renders: the **Add software → Custom package** page and the **Add package** modal on the software title details page. Also updated the two unit tests that asserted the old slug.

# Checklist for submitter

## Testing

- [x] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the GitOps custom package “YAML docs” link to direct users to the new YAML software documentation page.
* **Bug Fixes**
  * Corrected YAML documentation links in the custom package banner and package addition modal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->