### PR TITLE
Cherry-pick #50267: Fix YAML docs link 404 in custom package GitOps callout (slug reversed)

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareCustomPackage/SoftwareCustomPackage.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareCustomPackage/SoftwareCustomPackage.tests.tsx
@@ -16,12 +16,12 @@ describe("GitOpsCustomPackageBanner", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders the YAML docs link pointing at learn-more-about/software-yaml", () => {
+  it("renders the YAML docs link pointing at learn-more-about/yaml-software", () => {
     render(<GitOpsCustomPackageBanner />);
     const link = screen.getByRole("link", { name: /YAML docs/i });
     expect(link).toHaveAttribute(
       "href",
-      expect.stringMatching(/learn-more-about\/software-yaml$/)
+      expect.stringMatching(/learn-more-about\/yaml-software$/)
     );
     expect(link).toHaveAttribute("target", "_blank");
   });

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareCustomPackage/SoftwareCustomPackage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareCustomPackage/SoftwareCustomPackage.tsx
@@ -45,7 +45,7 @@ export const GitOpsCustomPackageBanner = () => (
     adding, copy its SHA-256 hash into your YAML so the next GitOps workflow
     doesn&apos;t delete it.{" "}
     <CustomLink
-      url={`${LEARN_MORE_ABOUT_BASE_LINK}/software-yaml`}
+      url={`${LEARN_MORE_ABOUT_BASE_LINK}/yaml-software`}
       text="YAML docs"
       newTab
     />

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/AddPackageModal/AddPackageModal.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/AddPackageModal/AddPackageModal.tests.tsx
@@ -119,7 +119,7 @@ describe("AddPackageModal", () => {
       const link = screen.getByRole("link", { name: /YAML docs/i });
       expect(link).toHaveAttribute(
         "href",
-        expect.stringMatching(/learn-more-about\/software-yaml$/)
+        expect.stringMatching(/learn-more-about\/yaml-software$/)
       );
     });
 


### PR DESCRIPTION
Cherry-pick of #50267 into the 4.90 RC branch. Resolves #50070.

The "YAML docs" link in the GitOps callout on the custom-package flows pointed at the unregistered slug `learn-more-about/software-yaml` (404). Corrected to the registered `learn-more-about/yaml-software`. Fixes both render sites (Add software page + Add package modal) via the shared `GitOpsCustomPackageBanner`; unit tests updated.