### PR TITLE
Add 'linux' as platform for labels

### DIFF
--- a/changes/44088-linux-label-platform
+++ b/changes/44088-linux-label-platform
@@ -1,0 +1,1 @@
+- Added `linux` as a label platform option, which targets hosts on any Linux distribution.

--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -735,6 +735,12 @@ func (MockClient) GetLabels(teamID uint) ([]*fleet.LabelSpec, error) {
 		Description:         "Label C description",
 		LabelMembershipType: fleet.LabelMembershipTypeHostVitals,
 		HostVitalsCriteria:  ptr.RawMessage(json.RawMessage(`{"vital": "end_user_idp_group", "value": "some-group"}`)),
+	}, {
+		Name:                "Label D",
+		Description:         "Label D description",
+		Platform:            "linux",
+		LabelMembershipType: fleet.LabelMembershipTypeDynamic,
+		Query:               "SELECT 1",
 	}}, nil
 }
 

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -386,7 +386,7 @@ policies:
 agent_options:
 queries:
 labels:
-  - name: Test - Linux invalid platform
+  - name: Test - bados invalid platform
     query: SELECT 1;
     platform: bados
 org_settings:

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -388,7 +388,7 @@ queries:
 labels:
   - name: Test - Linux invalid platform
     query: SELECT 1;
-    platform: linux
+    platform: bados
 org_settings:
   server_settings:
     server_url: https://fleet.example.com
@@ -401,7 +401,7 @@ org_settings:
 
 	_, err = runAppNoChecks([]string{"gitops", "-f", tmpFile.Name(), "--dry-run"})
 	require.ErrorContains(t, err, "invalid platform")
-	require.ErrorContains(t, err, "linux")
+	require.ErrorContains(t, err, "bados")
 }
 
 func TestGitOpsBasicGlobalPremium(t *testing.T) {

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedLabels.yaml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedLabels.yaml
@@ -15,3 +15,8 @@
   criteria:
     vital: end_user_idp_group
     value: some-group
+- name: Label D
+  description: Label D description
+  label_membership_type: dynamic
+  query: SELECT 1
+  platform: linux

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_free/default.yml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_free/default.yml
@@ -51,6 +51,11 @@ labels:
   description: Label C description
   label_membership_type: host_vitals
   name: Label C
+- description: Label D description
+  label_membership_type: dynamic
+  name: Label D
+  platform: linux
+  query: SELECT 1
 org_settings:
   activity_expiry_settings:
     activity_expiry_enabled: false

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/default.yml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/default.yml
@@ -33,6 +33,11 @@ labels:
   description: Label C description
   label_membership_type: host_vitals
   name: Label C
+- description: Label D description
+  label_membership_type: dynamic
+  name: Label D
+  platform: linux
+  query: SELECT 1
 org_settings:
   activity_expiry_settings:
     activity_expiry_enabled: false

--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
@@ -941,6 +941,7 @@ agent_options:
 labels:
   - name: Label1
     query: select 1
+    platform: linux
 controls:
   apple_settings:
     configuration_profiles:

--- a/frontend/interfaces/label.ts
+++ b/frontend/interfaces/label.ts
@@ -15,6 +15,19 @@ export default PropTypes.shape({
 });
 
 export type LabelType = "regular" | "builtin";
+
+// Valid platform values for a dynamic label, mirroring the server's
+// ValidLabelPlatformVariants (server/fleet/labels.go). "" targets all
+// platforms.
+export const LABEL_PLATFORMS = [
+  "",
+  "darwin",
+  "windows",
+  "linux",
+  "ubuntu",
+  "centos",
+] as const;
+export type LabelPlatform = typeof LABEL_PLATFORMS[number];
 export type LabelMembershipType = "dynamic" | "manual" | "host_vitals";
 export const LabelMembershipTypeToDisplayCopy: Record<
   LabelMembershipType,
@@ -112,7 +125,7 @@ export interface ILabel extends ILabelSummary {
 
   // dynamic-specific
   query: string; // does return '""' for other types
-  platform: string; // does return '""' for other types
+  platform: LabelPlatform; // "" for non-dynamic label types, and for dynamic labels targeting all platforms
 
   // host_vitals-specific
   criteria: LabelHostVitalsCriteria | null;
@@ -128,7 +141,7 @@ export interface ILabelSpecResponse {
     name: string;
     description: string;
     query: string;
-    platform?: string; // improve to only allow possible platforms from API
+    platform?: LabelPlatform;
     label_type?: LabelType;
     label_membership_type: LabelMembershipType;
     hosts?: string[];

--- a/frontend/pages/labels/NewLabelPage/NewLabelPage.tsx
+++ b/frontend/pages/labels/NewLabelPage/NewLabelPage.tsx
@@ -36,6 +36,7 @@ import {
   CUSTOM_HOST_VITAL_CRITERION,
   LabelHostVitalsCriterion,
   LabelMembershipType,
+  LabelPlatform,
 } from "interfaces/label";
 import { IHost } from "interfaces/host";
 import { IInputFieldParseTarget } from "interfaces/form_field";
@@ -95,7 +96,7 @@ export interface INewLabelFormData {
   type: LabelMembershipType;
   // dynamic
   labelQuery: string;
-  platform: string;
+  platform: LabelPlatform;
 
   // host vitals
   vital: LabelHostVitalsCriterion; // TODO - make use of recursive `LabelHostVitalsCriteria` type in future iterations to support logical combinations of different criteria

--- a/frontend/pages/labels/components/DynamicLabelForm/DynamicLabelForm.tsx
+++ b/frontend/pages/labels/components/DynamicLabelForm/DynamicLabelForm.tsx
@@ -7,6 +7,8 @@ import SQLEditor from "components/SQLEditor";
 import Button from "components/buttons/Button";
 import Icon from "components/Icon";
 
+import { LabelPlatform } from "interfaces/label";
+
 import LabelForm from "../LabelForm";
 import { ILabelFormData } from "../LabelForm/LabelForm";
 import PlatformField from "../PlatformField";
@@ -17,14 +19,14 @@ export interface IDynamicLabelFormData {
   name: string;
   description: string;
   query: string;
-  platform: string;
+  platform: LabelPlatform;
 }
 
 interface IDynamicLabelFormProps {
   defaultName?: string;
   defaultDescription?: string;
   defaultQuery?: string;
-  defaultPlatform?: string;
+  defaultPlatform?: LabelPlatform;
   showOpenSidebarButton?: boolean;
   isEditing?: boolean;
   onOpenSidebar?: () => void;
@@ -109,7 +111,7 @@ const DynamicLabelForm = ({
     });
   };
 
-  const onChangePlatform = (value: string) => {
+  const onChangePlatform = (value: LabelPlatform) => {
     setPlatform(value);
   };
 

--- a/frontend/pages/labels/components/PlatformField/PlatformField.tests.tsx
+++ b/frontend/pages/labels/components/PlatformField/PlatformField.tests.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import PlatformField from "./PlatformField";
+
+describe("PlatformField component", () => {
+  it("renders all platform options, including generic Linux", async () => {
+    const onChange = jest.fn();
+    render(<PlatformField platform="" onChange={onChange} />);
+
+    // Open the dropdown.
+    await userEvent.click(screen.getByText(/all platforms/i));
+
+    expect(screen.getByText("macOS")).toBeInTheDocument();
+    expect(screen.getByText("Windows")).toBeInTheDocument();
+    expect(screen.getByText("Linux")).toBeInTheDocument();
+    expect(screen.getByText("Ubuntu (Linux)")).toBeInTheDocument();
+    expect(screen.getByText("CentOS (Linux)")).toBeInTheDocument();
+  });
+
+  it("calls onChange with the platform value when Linux is selected", async () => {
+    const onChange = jest.fn();
+    render(<PlatformField platform="" onChange={onChange} />);
+
+    await userEvent.click(screen.getByText(/all platforms/i));
+    await userEvent.click(screen.getByText("Linux"));
+
+    expect(onChange).toHaveBeenCalledWith("linux");
+  });
+
+  it("renders read-only display text when editing", () => {
+    render(<PlatformField platform="linux" isEditing />);
+
+    expect(screen.getByText("Linux")).toBeInTheDocument();
+  });
+
+  it("renders updated display text for ubuntu and centos when editing", () => {
+    const { rerender } = render(<PlatformField platform="ubuntu" isEditing />);
+    expect(screen.getByText("Ubuntu (Linux)")).toBeInTheDocument();
+
+    rerender(<PlatformField platform="centos" isEditing />);
+    expect(screen.getByText("CentOS (Linux)")).toBeInTheDocument();
+  });
+});

--- a/frontend/pages/labels/components/PlatformField/PlatformField.tsx
+++ b/frontend/pages/labels/components/PlatformField/PlatformField.tsx
@@ -6,9 +6,11 @@ import DropdownWrapper, {
 } from "components/forms/fields/DropdownWrapper/DropdownWrapper";
 import FormField from "components/forms/FormField";
 
+import { LabelPlatform } from "interfaces/label";
+
 // Used to display the platform of an existing label on the edit label page
 // (platform is not editable after creation).
-const PLATFORM_STRINGS: { [key: string]: string } = {
+const PLATFORM_STRINGS: Record<Exclude<LabelPlatform, "">, string> = {
   darwin: "macOS",
   windows: "Windows",
   linux: "Linux",
@@ -16,7 +18,11 @@ const PLATFORM_STRINGS: { [key: string]: string } = {
   centos: "CentOS (Linux)",
 };
 
-const platformOptions: CustomOptionType[] = [
+interface IPlatformOption extends CustomOptionType {
+  value: LabelPlatform;
+}
+
+const platformOptions: IPlatformOption[] = [
   { label: "All platforms", value: "" },
   { label: "macOS", value: "darwin" },
   { label: "Windows", value: "windows" },
@@ -28,9 +34,9 @@ const platformOptions: CustomOptionType[] = [
 const baseClass = "platform-field";
 
 interface IPlatformFieldProps {
-  platform: string;
+  platform: LabelPlatform;
   isEditing?: boolean;
-  onChange?: (platform: string) => void;
+  onChange?: (platform: LabelPlatform) => void;
 }
 
 const PlatformField = ({
@@ -39,8 +45,10 @@ const PlatformField = ({
   onChange = noop,
 }: IPlatformFieldProps) => {
   const handleDropdownChange = (newValue: CustomOptionType | null) => {
-    // DropdownWrapper passes a SingleValue<CustomOptionType> | null
-    onChange(newValue?.value ?? "");
+    // DropdownWrapper passes a SingleValue<CustomOptionType> | null, which
+    // widens value to string; the options above only carry LabelPlatform
+    // values, so the assertion is safe.
+    onChange((newValue?.value ?? "") as LabelPlatform);
   };
 
   return (

--- a/frontend/pages/labels/components/PlatformField/PlatformField.tsx
+++ b/frontend/pages/labels/components/PlatformField/PlatformField.tsx
@@ -6,20 +6,23 @@ import DropdownWrapper, {
 } from "components/forms/fields/DropdownWrapper/DropdownWrapper";
 import FormField from "components/forms/FormField";
 
+// Used to display the platform of an existing label on the edit label page
+// (platform is not editable after creation).
 const PLATFORM_STRINGS: { [key: string]: string } = {
   darwin: "macOS",
-  windows: "MS Windows",
-  ubuntu: "Ubuntu Linux",
-  zorin: "Zorin OS",
-  centos: "CentOS Linux",
+  windows: "Windows",
+  linux: "Linux",
+  ubuntu: "Ubuntu (Linux)",
+  centos: "CentOS (Linux)",
 };
 
 const platformOptions: CustomOptionType[] = [
   { label: "All platforms", value: "" },
   { label: "macOS", value: "darwin" },
   { label: "Windows", value: "windows" },
-  { label: "Ubuntu", value: "ubuntu" },
-  { label: "Centos", value: "centos" },
+  { label: "Linux", value: "linux" },
+  { label: "Ubuntu (Linux)", value: "ubuntu" },
+  { label: "CentOS (Linux)", value: "centos" },
 ];
 
 const baseClass = "platform-field";

--- a/server/datastore/mysql/labels.go
+++ b/server/datastore/mysql/labels.go
@@ -958,7 +958,7 @@ func (ds *Datastore) LabelQueriesForHost(ctx context.Context, host *fleet.Host) 
 		(team_id IS NULL OR team_id = ?)`
 	query, args, err := sqlx.In(query, platforms, fleet.LabelMembershipTypeDynamic, host.TeamID)
 	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "building label queries for host query")
+		return nil, ctxerr.Wrap(ctx, err, "building label queries for host")
 	}
 	rows, err := ds.reader(ctx).QueryContext(ctx, query, args...)
 	if err != nil && err != sql.ErrNoRows {

--- a/server/datastore/mysql/labels.go
+++ b/server/datastore/mysql/labels.go
@@ -935,25 +935,32 @@ func applyLabelTeamFilter(query string, filter fleet.TeamFilter, initialParams .
 	return maybeIn(query)
 }
 
-func platformForHost(host *fleet.Host) string {
-	if host.Platform != "rhel" {
-		return host.Platform
+// platformsForHost returns the label platform values that match the given
+// host. A host matches labels with its specific platform (with rhel hosts
+// running CentOS matching "centos"), and Linux hosts additionally match the
+// generic "linux" platform regardless of distribution.
+func platformsForHost(host *fleet.Host) []string {
+	specific := host.Platform
+	if host.Platform == "rhel" && strings.Contains(strings.ToLower(host.OSVersion), "centos") {
+		specific = "centos"
 	}
-	if strings.Contains(strings.ToLower(host.OSVersion), "centos") {
-		return "centos"
+	if fleet.IsLinux(specific) && specific != "linux" {
+		return []string{specific, "linux"}
 	}
-	return host.Platform
+	return []string{specific}
 }
 
 func (ds *Datastore) LabelQueriesForHost(ctx context.Context, host *fleet.Host) (map[string]string, error) {
-	var rows *sql.Rows
-	var err error
-	platform := platformForHost(host)
+	platforms := platformsForHost(host)
 	query := `SELECT id, query FROM labels WHERE
-		(platform = ? OR platform = '') AND
+		(platform IN (?) OR platform = '') AND
 		label_membership_type = ? AND
 		(team_id IS NULL OR team_id = ?)`
-	rows, err = ds.reader(ctx).QueryContext(ctx, query, platform, fleet.LabelMembershipTypeDynamic, host.TeamID)
+	query, args, err := sqlx.In(query, platforms, fleet.LabelMembershipTypeDynamic, host.TeamID)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "building label queries for host query")
+	}
+	rows, err := ds.reader(ctx).QueryContext(ctx, query, args...)
 	if err != nil && err != sql.ErrNoRows {
 		return nil, ctxerr.Wrap(ctx, err, "selecting label queries for host")
 	}

--- a/server/datastore/mysql/labels_test.go
+++ b/server/datastore/mysql/labels_test.go
@@ -90,6 +90,7 @@ func TestLabels(t *testing.T) {
 		{"SingleByName", testLabelByName},
 		{"Save", testLabelsSave},
 		{"QueriesForCentOSHost", testLabelsQueriesForCentOSHost},
+		{"QueriesForLinuxPlatformLabel", testLabelsQueriesForLinuxPlatformLabel},
 		{"RecordNonExistentQueryLabelExecution", testLabelsRecordNonexistentQueryLabelExecution},
 		{"RecordLabelQueryExecutionsQueryErrorKeepsMembership", testRecordLabelQueryExecutionsQueryErrorKeepsMembership},
 		{"DeleteLabel", testDeleteLabel},
@@ -1238,6 +1239,89 @@ func testLabelsQueriesForCentOSHost(t *testing.T, db *Datastore) {
 	require.NoError(t, err)
 	require.Len(t, queries, 1)
 	assert.Equal(t, "select 1;", queries[fmt.Sprint(label.ID)])
+}
+
+func testLabelsQueriesForLinuxPlatformLabel(t *testing.T, db *Datastore) {
+	ctx := t.Context()
+
+	// A label with the generic "linux" platform matches hosts on any Linux
+	// distribution.
+	linuxLabel, err := db.NewLabel(ctx, &fleet.Label{
+		UpdateCreateTimestamps: fleet.UpdateCreateTimestamps{
+			CreateTimestamp: fleet.CreateTimestamp{CreatedAt: time.Now()},
+			UpdateTimestamp: fleet.UpdateTimestamp{UpdatedAt: time.Now()},
+		},
+		Name:                "linux label",
+		Query:               "select 1;",
+		Platform:            "linux",
+		LabelType:           fleet.LabelTypeRegular,
+		LabelMembershipType: fleet.LabelMembershipTypeDynamic,
+	})
+	require.NoError(t, err)
+
+	// A distro-specific label keeps matching only that distro.
+	ubuntuLabel, err := db.NewLabel(ctx, &fleet.Label{
+		UpdateCreateTimestamps: fleet.UpdateCreateTimestamps{
+			CreateTimestamp: fleet.CreateTimestamp{CreatedAt: time.Now()},
+			UpdateTimestamp: fleet.UpdateTimestamp{UpdatedAt: time.Now()},
+		},
+		Name:                "ubuntu label",
+		Query:               "select 2;",
+		Platform:            "ubuntu",
+		LabelType:           fleet.LabelTypeRegular,
+		LabelMembershipType: fleet.LabelMembershipTypeDynamic,
+	})
+	require.NoError(t, err)
+
+	cases := []struct {
+		name       string
+		platform   string
+		osVersion  string
+		wantLinux  bool
+		wantUbuntu bool
+	}{
+		{"ubuntu host matches linux and ubuntu labels", "ubuntu", "Ubuntu 22.04", true, true},
+		{"debian host matches linux label only", "debian", "Debian GNU/Linux 12", true, false},
+		{"rhel host matches linux label only", "rhel", "Red Hat Enterprise Linux 9", true, false},
+		// CentOS reports platform "rhel"; matching centos-specific labels is
+		// covered by testLabelsQueriesForCentOSHost.
+		{"centos host matches linux label", "rhel", "CentOS 7", true, false},
+		{"generic linux host matches linux label", "linux", "Linux 6.1", true, false},
+		{"darwin host matches neither", "darwin", "macOS 14.0", false, false},
+		{"windows host matches neither", "windows", "Windows 11", false, false},
+	}
+
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			host, err := db.EnrollOsquery(ctx,
+				fleet.WithEnrollOsqueryHostID(fmt.Sprint(i)),
+				fleet.WithEnrollOsqueryNodeKey(fmt.Sprint(i)),
+			)
+			require.NoError(t, err, "enrollment should succeed")
+
+			host.Platform = tc.platform
+			host.OSVersion = tc.osVersion
+			err = db.UpdateHost(ctx, host)
+			require.NoError(t, err)
+
+			queries, err := db.LabelQueriesForHost(ctx, host)
+			require.NoError(t, err)
+
+			linuxKey := fmt.Sprint(linuxLabel.ID)
+			ubuntuKey := fmt.Sprint(ubuntuLabel.ID)
+
+			if tc.wantLinux {
+				assert.Contains(t, queries, linuxKey, "expected linux label for %s host", tc.platform)
+			} else {
+				assert.NotContains(t, queries, linuxKey, "did not expect linux label for %s host", tc.platform)
+			}
+			if tc.wantUbuntu {
+				assert.Contains(t, queries, ubuntuKey, "expected ubuntu label for %s host", tc.platform)
+			} else {
+				assert.NotContains(t, queries, ubuntuKey, "did not expect ubuntu label for %s host", tc.platform)
+			}
+		})
+	}
 }
 
 func testLabelsRecordNonexistentQueryLabelExecution(t *testing.T, db *Datastore) {

--- a/server/fleet/labels.go
+++ b/server/fleet/labels.go
@@ -146,6 +146,7 @@ var ValidLabelPlatformVariants = map[string]struct{}{
 	"":        {}, // empty platform is valid value
 	"darwin":  {},
 	"windows": {},
+	"linux":   {}, // matches hosts on any Linux distribution
 	"ubuntu":  {},
 	"centos":  {},
 }

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -5321,11 +5321,27 @@ func (s *integrationTestSuite) TestLabels() {
 			&fleet.LabelPayload{
 				Name:     "amazing label",
 				Query:    "select 1",
-				Platform: "linux",
+				Platform: "bados",
 			},
 			http.StatusUnprocessableEntity,
 			&createResp,
 		)
+
+		// create a label with the generic "linux" platform (matches all Linux distros)
+		s.DoJSON(
+			"POST",
+			"/api/latest/fleet/labels",
+			&fleet.LabelPayload{
+				Name:     "linux label",
+				Query:    "select 1",
+				Platform: "linux",
+			},
+			http.StatusOK,
+			&createResp,
+		)
+		assert.NotZero(t, createResp.Label.ID)
+		assert.Equal(t, "linux", createResp.Label.Platform)
+		linuxLbl := createResp.Label.Label
 
 		// create a valid dynamic label
 		s.DoJSON("POST", "/api/latest/fleet/labels", &fleet.LabelPayload{Name: t.Name(), Query: "select 1"}, http.StatusOK, &createResp)
@@ -5479,7 +5495,7 @@ func (s *integrationTestSuite) TestLabels() {
 		assert.EqualValues(t, 0, modResp.Label.HostCount)
 
 		// list labels
-		dynamicLabels := []fleet.Label{lbl1}
+		dynamicLabels := []fleet.Label{lbl1, linuxLbl}
 		manualLabels := []fleet.Label{manualLbl1, manualLbl2}
 		s.DoJSON("GET", "/api/latest/fleet/labels", nil, http.StatusOK, &listResp, "per_page", strconv.Itoa(100))
 		assert.Len(t, listResp.Labels, builtInsCount+len(dynamicLabels)+len(manualLabels))
@@ -5501,7 +5517,7 @@ func (s *integrationTestSuite) TestLabels() {
 		assert.NotZero(t, createResp.Label.ID)
 		lbl2 := createResp.Label.Label
 		dynamicLabels = append(dynamicLabels, lbl2)
-		require.Len(t, dynamicLabels, 2) // to make linter happy (dynamicLabels is not used past this point)
+		require.Len(t, dynamicLabels, 3) // to make linter happy (dynamicLabels is not used past this point)
 
 		// add lbl2 hosts to that label
 		for _, h := range lbl2Hosts {
@@ -5673,6 +5689,7 @@ func (s *integrationTestSuite) TestLabels() {
 
 		// delete a label by id
 		var delIDResp fleet.DeleteLabelByIDResponse
+		s.DoJSON("DELETE", fmt.Sprintf("/api/latest/fleet/labels/id/%d", linuxLbl.ID), nil, http.StatusOK, &delIDResp)
 		s.DoJSON("DELETE", fmt.Sprintf("/api/latest/fleet/labels/id/%d", lbl1.ID), nil, http.StatusOK, &delIDResp)
 
 		// delete a non-existing label by id
@@ -6396,12 +6413,30 @@ func (s *integrationTestSuite) TestLabelSpecs() {
 				{
 					Name:                name,
 					Query:               "select 1",
-					Platform:            "linux",
+					Platform:            "bados",
 					LabelMembershipType: fleet.LabelMembershipTypeDynamic,
 				},
 			},
 		},
 		http.StatusUnprocessableEntity,
+		&applyResp,
+	)
+
+	// apply a valid label spec - generic "linux" platform
+	s.DoJSON(
+		"POST",
+		"/api/latest/fleet/spec/labels",
+		fleet.ApplyLabelSpecsRequest{
+			Specs: []*fleet.LabelSpec{
+				{
+					Name:                name + "_linux",
+					Query:               "select 1",
+					Platform:            "linux",
+					LabelMembershipType: fleet.LabelMembershipTypeDynamic,
+				},
+			},
+		},
+		http.StatusOK,
 		&applyResp,
 	)
 
@@ -6455,15 +6490,19 @@ func (s *integrationTestSuite) TestLabelSpecs() {
 		},
 	}, http.StatusOK, &applyResp)
 
-	// list label specs, has the newly created one
+	// list label specs, has the newly created ones
 	s.DoJSON("GET", "/api/latest/fleet/spec/labels", nil, http.StatusOK, &listResp)
-	assert.Len(t, listResp.Specs, builtInsCount+1)
+	assert.Len(t, listResp.Specs, builtInsCount+2)
 
 	// get a specific label spec
 	var getResp fleet.GetLabelSpecResponse
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/spec/labels/%s", url.PathEscape(name)), nil, http.StatusOK, &getResp)
 	assert.Equal(t, name, getResp.Spec.Name)
 	assert.NotEqual(t, 0, getResp.Spec.ID)
+
+	// the generic "linux" platform round-trips through the spec endpoints
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/spec/labels/%s", url.PathEscape(name+"_linux")), nil, http.StatusOK, &getResp)
+	assert.Equal(t, "linux", getResp.Spec.Platform)
 
 	// get a non-existing label spec
 	s.DoJSON("GET", "/api/latest/fleet/spec/labels/zzz", nil, http.StatusNotFound, &getResp)


### PR DESCRIPTION
Resolves #44088.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

- [X] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Linux as a label platform option.
  * Linux labels now apply across supported distributions, including Ubuntu, Debian, RHEL, CentOS, and generic Linux hosts.
  * Updated platform names for improved clarity and consistency.

* **Bug Fixes**
  * Improved platform matching so Linux labels apply consistently to compatible hosts.
  * Removed the obsolete Zorin platform option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->