### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/1password/windows.json
+++ b/ee/maintained-apps/outputs/1password/windows.json
@@ -1,22 +1,22 @@
 {
   "versions": [
     {
-      "version": "8.12.28",
+      "version": "8.12.30",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = '1Password' AND publisher = 'Agilebits Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = '1Password' AND publisher = 'Agilebits Inc.' AND version_compare(version, '8.12.28') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = '1Password' AND publisher = 'Agilebits Inc.' AND version_compare(version, '8.12.30') < 0);"
       },
-      "installer_url": "https://c.1password.com/dist/1P/win8/1PasswordSetup-8.12.28.msi",
+      "installer_url": "https://c.1password.com/dist/1P/win8/1PasswordSetup-8.12.30.msi",
       "install_script_ref": "8959087b",
-      "uninstall_script_ref": "3ea05247",
-      "sha256": "c7fd4808fba19af902584551b0aac92b9cf16542ede546fbe42d65e286abde90",
+      "uninstall_script_ref": "c70e0a85",
+      "sha256": "65bbda1a2efea756625be2b1698b6f3b73e14830f20ec142dc98d33c73ffcbfa",
       "default_categories": [
         "Productivity"
       ]
     }
   ],
   "refs": {
-    "3ea05247": "# 1Password Uninstall Script\n# Closes running processes before uninstalling to prevent hangs\n\n$product_code = '{C1935B55-A897-4171-B3EE-07E47C886A94}'\n$timeoutSeconds = 300  # 5 minute timeout\n\n# Close any running 1Password processes\nGet-Process -Name \"1Password*\" -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue\nStart-Sleep -Seconds 2\n\n# Fleet uninstalls app using product code that's extracted on upload\n$process = Start-Process msiexec -ArgumentList @(\"/quiet\", \"/x\", $product_code, \"/norestart\") -PassThru\n\n# Wait for process with timeout\n$completed = $process.WaitForExit($timeoutSeconds * 1000)\n\nif (-not $completed) {\n    Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue\n    Exit 1603  # ERROR_INSTALL_FAILURE\n}\n\n# Check exit code and output result\nif ($process.ExitCode -eq 0) {\n    Write-Output \"Exit 0\"\n    Exit 0\n} else {\n    Write-Output \"Exit $($process.ExitCode)\"\n    Exit $process.ExitCode\n}\n\n",
-    "8959087b": "$logFile = \"${env:TEMP}/fleet-install-software.log\"\n\ntry {\n\n$installProcess = Start-Process msiexec.exe `\n  -ArgumentList \"/quiet /norestart /lv ${logFile} /i `\"${env:INSTALLER_PATH}`\"\" `\n  -PassThru -Verb RunAs -Wait\n\nGet-Content $logFile -Tail 500\n\nExit $installProcess.ExitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n"
+    "8959087b": "$logFile = \"${env:TEMP}/fleet-install-software.log\"\n\ntry {\n\n$installProcess = Start-Process msiexec.exe `\n  -ArgumentList \"/quiet /norestart /lv ${logFile} /i `\"${env:INSTALLER_PATH}`\"\" `\n  -PassThru -Verb RunAs -Wait\n\nGet-Content $logFile -Tail 500\n\nExit $installProcess.ExitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n",
+    "c70e0a85": "# 1Password Uninstall Script\n# Closes running processes before uninstalling to prevent hangs\n\n$product_code = '{598797D5-61EB-46AF-8F8B-0C2070B648A2}'\n$timeoutSeconds = 300  # 5 minute timeout\n\n# Close any running 1Password processes\nGet-Process -Name \"1Password*\" -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue\nStart-Sleep -Seconds 2\n\n# Fleet uninstalls app using product code that's extracted on upload\n$process = Start-Process msiexec -ArgumentList @(\"/quiet\", \"/x\", $product_code, \"/norestart\") -PassThru\n\n# Wait for process with timeout\n$completed = $process.WaitForExit($timeoutSeconds * 1000)\n\nif (-not $completed) {\n    Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue\n    Exit 1603  # ERROR_INSTALL_FAILURE\n}\n\n# Check exit code and output result\nif ($process.ExitCode -eq 0) {\n    Write-Output \"Exit 0\"\n    Exit 0\n} else {\n    Write-Output \"Exit $($process.ExitCode)\"\n    Exit $process.ExitCode\n}\n\n"
   }
 }

--- a/ee/maintained-apps/outputs/arc/darwin.json
+++ b/ee/maintained-apps/outputs/arc/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.157.1",
+      "version": "1.158.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'company.thebrowser.Browser';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'company.thebrowser.Browser' AND version_compare(bundle_short_version, '1.157.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'company.thebrowser.Browser' AND version_compare(bundle_short_version, '1.158.1') < 0);"
       },
-      "installer_url": "https://releases.arc.net/release/Arc-1.157.1-84133.zip",
+      "installer_url": "https://releases.arc.net/release/Arc-1.158.1-84367.zip",
       "install_script_ref": "cbf109ae",
       "uninstall_script_ref": "a19b04fa",
-      "sha256": "5ded8afd261da0dc2422a0a6b92245a16afeba2cac3409d8ab70c1a9d527b237",
+      "sha256": "be7330c46a541676f82326cfb896534a40c37f5384c1bc33bf0cb90ddd205ab5",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/beeper/darwin.json
+++ b/ee/maintained-apps/outputs/beeper/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.2.1004",
+      "version": "4.3.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.automattic.beeper.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.automattic.beeper.desktop' AND version_compare(bundle_short_version, '4.2.1004') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.automattic.beeper.desktop' AND version_compare(bundle_short_version, '4.3.0') < 0);"
       },
-      "installer_url": "https://beeper-desktop.download.beeper.com/builds/Beeper-4.2.1004-arm64-mac.zip",
+      "installer_url": "https://beeper-desktop.download.beeper.com/builds/Beeper-4.3.0-arm64-mac.zip",
       "install_script_ref": "403ed251",
       "uninstall_script_ref": "978d30f8",
-      "sha256": "bbecfa9a46ee70de944131f0751b4c4d22c2887408fea6c5f8509df55a6e7ea4",
+      "sha256": "2f580987c833d7df7dc3b75800a987d3c15653779f932dea8c571834f9f9bda3",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/bricklink-studio/darwin.json
+++ b/ee/maintained-apps/outputs/bricklink-studio/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.26.6_1",
+      "version": "2.26.7_1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.BrickLink.Studio';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.BrickLink.Studio' AND version_compare(bundle_short_version, '2.26.6_1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.BrickLink.Studio' AND version_compare(bundle_short_version, '2.26.7_1') < 0);"
       },
-      "installer_url": "https://studio.download.bricklink.info/Studio2.0/Archive/2.26.6_1/Studio+2.0.pkg",
+      "installer_url": "https://studio.download.bricklink.info/Studio2.0/Archive/2.26.7_1/Studio+2.0.pkg",
       "install_script_ref": "59096fcd",
       "uninstall_script_ref": "1c500b78",
-      "sha256": "e270f66d0f09948ca8d3c2fb48d1b28ba71ef2d089d4195924a52c7eb88c0b78",
+      "sha256": "526d727e85ab9104429a41c63bc1d3ace63f76353843d98a2fab9d6f7c5ff95d",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/chatgpt/darwin.json
+++ b/ee/maintained-apps/outputs/chatgpt/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.721.81911",
+      "version": "26.727.40816",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.chat';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.chat' AND version_compare(bundle_short_version, '26.721.81911') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.chat' AND version_compare(bundle_short_version, '26.727.40816') < 0);"
       },
-      "installer_url": "https://persistent.oaistatic.com/codex-app-prod/ChatGPT-darwin-arm64-26.721.81911.zip",
+      "installer_url": "https://persistent.oaistatic.com/codex-app-prod/ChatGPT-darwin-arm64-26.727.40816.zip",
       "install_script_ref": "cbce2d7d",
       "uninstall_script_ref": "678e6cf0",
-      "sha256": "a373727d40d9efe8cc762df444a07b5233071ff1cd6307465a73f025b1d69344",
+      "sha256": "fdbede9b8a28b5bf3bbf1213fa04291724faa6ed2d1d61bb04853bbdfebce219",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/claude/windows.json
+++ b/ee/maintained-apps/outputs/claude/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.24012.1",
+      "version": "1.24012.9",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Claude' AND publisher = 'Anthropic, PBC';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Claude' AND publisher = 'Anthropic, PBC' AND version_compare(version, '1.24012.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Claude' AND publisher = 'Anthropic, PBC' AND version_compare(version, '1.24012.9') < 0);"
       },
-      "installer_url": "https://downloads.claude.ai/releases/win32/x64/1.24012.1/Claude-0adcaed55041a881be363f2c4a4729f67a8b27d7.msix",
+      "installer_url": "https://downloads.claude.ai/releases/win32/x64/1.24012.9/Claude-03c61d06f8e01a4db2273b9514e225f21d2ba62e.msix",
       "install_script_ref": "16c020cc",
       "uninstall_script_ref": "03f72055",
-      "sha256": "9a583530c3f25a48fb0296d68a91ca8f677fdaa4878a40c1ced19593e82fb565",
+      "sha256": "c7d61479f06a3490bd2598405aa95a428abb9fe31ed97f9e0a1fba7cd2745fe2",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/cursor/windows.json
+++ b/ee/maintained-apps/outputs/cursor/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.13.21",
+      "version": "3.13.25",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Cursor' AND publisher = 'Anysphere';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Cursor' AND publisher = 'Anysphere' AND version_compare(version, '3.13.21') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Cursor' AND publisher = 'Anysphere' AND version_compare(version, '3.13.25') < 0);"
       },
-      "installer_url": "https://downloads.cursor.com/production/55434bd8062ece6fee083b82beed2aee42d253f3/win32/x64/system-setup/CursorSetup-x64-3.13.21.exe",
+      "installer_url": "https://downloads.cursor.com/production/31e8d61c448c7472e371505838a0fe34083dad55/win32/x64/system-setup/CursorSetup-x64-3.13.25.exe",
       "install_script_ref": "03589b5e",
       "uninstall_script_ref": "6c8096c5",
-      "sha256": "65516ea8bf833e899847fc84c7d95a212f182df651956604eeecfe230bee8f2f",
+      "sha256": "643acd8962282726a6e379d10d04e6d7def06fe7a2b1efdbdec526b10ff4b11d",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/firefox@nightly/darwin.json
+++ b/ee/maintained-apps/outputs/firefox@nightly/darwin.json
@@ -6,10 +6,10 @@
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly';",
         "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15526.7.30') < 0);"
       },
-      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/07/2026-07-30-13-27-38-mozilla-central/firefox-155.0a1.en-US.mac.dmg",
+      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/07/2026-07-30-21-43-47-mozilla-central/firefox-155.0a1.en-US.mac.dmg",
       "install_script_ref": "d9c4cf87",
       "uninstall_script_ref": "0661f848",
-      "sha256": "1b9c3ed590041bb06514a514c46881b93614885f1277109a8395865022184af2",
+      "sha256": "8dc3ba7bdeb144f4b255e80ad6f1a91d362d87f1dbc43c9394414c4e1f4e7fb8",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/gitkraken/windows.json
+++ b/ee/maintained-apps/outputs/gitkraken/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.3.0",
+      "version": "12.3.1",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'GitKraken' AND publisher = 'GitKraken';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'GitKraken' AND publisher = 'GitKraken' AND version_compare(version, '12.3.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'GitKraken' AND publisher = 'GitKraken' AND version_compare(version, '12.3.1') < 0);"
       },
-      "installer_url": "https://api.gitkraken.dev/releases/production/windows/x64/12.3.0/GitKrakenSetup.exe",
+      "installer_url": "https://api.gitkraken.dev/releases/production/windows/x64/12.3.1/GitKrakenSetup.exe",
       "install_script_ref": "c85d5da1",
       "uninstall_script_ref": "36370543",
-      "sha256": "c29a8211761b872169c3c6842524c5c6f7a5c8d52cfda236708daf1967982332",
+      "sha256": "9ccf04778fcd960f83d79d541b23b9b58cd4581ce0b74b6bccb0ad86d9e6d134",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/ibm-semeru-jdk-11/windows.json
+++ b/ee/maintained-apps/outputs/ibm-semeru-jdk-11/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "11.0.31.11",
+      "version": "11.0.32.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'IBM Semeru Runtime Open Edition (JDK)%' AND publisher = 'Semeru' AND version LIKE '11.%';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'IBM Semeru Runtime Open Edition (JDK)%' AND publisher = 'Semeru' AND version LIKE '11.%' AND version_compare(version, '11.0.31.11') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'IBM Semeru Runtime Open Edition (JDK)%' AND publisher = 'Semeru' AND version LIKE '11.%' AND version_compare(version, '11.0.32.0') < 0);"
       },
-      "installer_url": "https://github.com/ibmruntimes/semeru11-binaries/releases/download/jdk-11.0.31.0/ibm-semeru-open-jdk_x64_windows_11.0.31.0.msi",
+      "installer_url": "https://github.com/ibmruntimes/semeru11-binaries/releases/download/jdk-11.0.32.0/ibm-semeru-open-jdk_x64_windows_11.0.32.0.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "6def04f2",
-      "sha256": "81caf40097f6ba901a911604001caba4e9e3d872bc99fa3ee28e22ba15f2e29c",
+      "sha256": "30ec941c751b46b9bed0a8340d7f3220980dea04818f3c83defbf5aaea43dbf9",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/ibm-semeru-jdk-17/windows.json
+++ b/ee/maintained-apps/outputs/ibm-semeru-jdk-17/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "17.0.19.10",
+      "version": "17.0.20.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'IBM Semeru Runtime Open Edition (JDK)%' AND publisher = 'Semeru' AND version LIKE '17.%';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'IBM Semeru Runtime Open Edition (JDK)%' AND publisher = 'Semeru' AND version LIKE '17.%' AND version_compare(version, '17.0.19.10') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'IBM Semeru Runtime Open Edition (JDK)%' AND publisher = 'Semeru' AND version LIKE '17.%' AND version_compare(version, '17.0.20.0') < 0);"
       },
-      "installer_url": "https://github.com/ibmruntimes/semeru17-binaries/releases/download/jdk-17.0.19.0/ibm-semeru-open-jdk_x64_windows_17.0.19.0.msi",
+      "installer_url": "https://github.com/ibmruntimes/semeru17-binaries/releases/download/jdk-17.0.20.0/ibm-semeru-open-jdk_x64_windows_17.0.20.0.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "03940015",
-      "sha256": "afcb245006aeb77f48000643f479803113a17cf30b770fce2ab4f79666b11dac",
+      "sha256": "d9bef02cc3d51715d731c67468018f6b42d463398d59e725410d1692a1387f55",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/ibm-semeru-jdk-21/windows.json
+++ b/ee/maintained-apps/outputs/ibm-semeru-jdk-21/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "21.0.11.10",
+      "version": "21.0.12.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'IBM Semeru Runtime Open Edition (JDK)%' AND publisher = 'Semeru' AND version LIKE '21.%';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'IBM Semeru Runtime Open Edition (JDK)%' AND publisher = 'Semeru' AND version LIKE '21.%' AND version_compare(version, '21.0.11.10') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'IBM Semeru Runtime Open Edition (JDK)%' AND publisher = 'Semeru' AND version LIKE '21.%' AND version_compare(version, '21.0.12.0') < 0);"
       },
-      "installer_url": "https://github.com/ibmruntimes/semeru21-binaries/releases/download/jdk-21.0.11.0/ibm-semeru-open-jdk_x64_windows_21.0.11.0.msi",
+      "installer_url": "https://github.com/ibmruntimes/semeru21-binaries/releases/download/jdk-21.0.12.0/ibm-semeru-open-jdk_x64_windows_21.0.12.0.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "54418552",
-      "sha256": "e47653183dc6a2d9013524df08210fac6c5b7abd71f74f639f6d5314750eedfc",
+      "sha256": "77d7c8d78b1c9c9628b2c5c44d2597fc667fee6225f6709a1fa2ea24ca8d43e6",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/ibm-semeru-jdk-8/windows.json
+++ b/ee/maintained-apps/outputs/ibm-semeru-jdk-8/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "8.0.492.9",
+      "version": "8.0.502.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'IBM Semeru Runtime Open Edition (JDK)%' AND publisher = 'Semeru' AND version LIKE '8.%';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'IBM Semeru Runtime Open Edition (JDK)%' AND publisher = 'Semeru' AND version LIKE '8.%' AND version_compare(version, '8.0.492.9') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'IBM Semeru Runtime Open Edition (JDK)%' AND publisher = 'Semeru' AND version LIKE '8.%' AND version_compare(version, '8.0.502.0') < 0);"
       },
-      "installer_url": "https://github.com/ibmruntimes/semeru8-binaries/releases/download/jdk-8.0.492.0/ibm-semeru-open-jdk_x64_windows_8.0.492.0.msi",
+      "installer_url": "https://github.com/ibmruntimes/semeru8-binaries/releases/download/jdk-8.0.502.0/ibm-semeru-open-jdk_x64_windows_8.0.502.0.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "11b3094c",
-      "sha256": "4f53c0d00a0c68a4e3a224b618bb2eba23f85e1308948da5cefc503f309cffb3",
+      "sha256": "50eafa193115e31d2d450420e8605f91f28f0ca03c77ec36f0d1beee6a675fad",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/ibm-semeru-jre-17/windows.json
+++ b/ee/maintained-apps/outputs/ibm-semeru-jre-17/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "17.0.19.10",
+      "version": "17.0.20.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'IBM Semeru Runtime Open Edition (JRE)%' AND publisher = 'Semeru' AND version LIKE '17.%';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'IBM Semeru Runtime Open Edition (JRE)%' AND publisher = 'Semeru' AND version LIKE '17.%' AND version_compare(version, '17.0.19.10') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'IBM Semeru Runtime Open Edition (JRE)%' AND publisher = 'Semeru' AND version LIKE '17.%' AND version_compare(version, '17.0.20.0') < 0);"
       },
-      "installer_url": "https://github.com/ibmruntimes/semeru17-binaries/releases/download/jdk-17.0.19.0/ibm-semeru-open-jre_x64_windows_17.0.19.0.msi",
+      "installer_url": "https://github.com/ibmruntimes/semeru17-binaries/releases/download/jdk-17.0.20.0/ibm-semeru-open-jre_x64_windows_17.0.20.0.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "d244631d",
-      "sha256": "4698a739709ca0671e5eb5cf227d1f2a3647ab4cfff85f28035f3df2e1b47aa4",
+      "sha256": "ce9fe428ffb7e157cd23625b84c78a86941e759cc183f048cce9c53be0cb7fe0",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/ibm-semeru-jre-21/windows.json
+++ b/ee/maintained-apps/outputs/ibm-semeru-jre-21/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "21.0.11.10",
+      "version": "21.0.12.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'IBM Semeru Runtime Open Edition (JRE)%' AND publisher = 'Semeru' AND version LIKE '21.%';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'IBM Semeru Runtime Open Edition (JRE)%' AND publisher = 'Semeru' AND version LIKE '21.%' AND version_compare(version, '21.0.11.10') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'IBM Semeru Runtime Open Edition (JRE)%' AND publisher = 'Semeru' AND version LIKE '21.%' AND version_compare(version, '21.0.12.0') < 0);"
       },
-      "installer_url": "https://github.com/ibmruntimes/semeru21-binaries/releases/download/jdk-21.0.11.0/ibm-semeru-open-jre_x64_windows_21.0.11.0.msi",
+      "installer_url": "https://github.com/ibmruntimes/semeru21-binaries/releases/download/jdk-21.0.12.0/ibm-semeru-open-jre_x64_windows_21.0.12.0.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "622f7475",
-      "sha256": "8cdeb707578e660d967ad128407ecf0e095c0591e1c342783fda6a0a93eea79b",
+      "sha256": "a9fdd97de3e8c59b6d08471f6b254157f4fc58be534f63cd4d8a1bc6455b3899",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/kiro-cli/darwin.json
+++ b/ee/maintained-apps/outputs/kiro-cli/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.15.2",
+      "version": "2.16.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kiro.cli';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kiro.cli' AND version_compare(bundle_short_version, '2.15.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kiro.cli' AND version_compare(bundle_short_version, '2.16.0') < 0);"
       },
-      "installer_url": "https://desktop-release.q.us-east-1.amazonaws.com/2.15.2/Kiro%20CLI.dmg",
+      "installer_url": "https://desktop-release.q.us-east-1.amazonaws.com/2.16.0/Kiro%20CLI.dmg",
       "install_script_ref": "21bed962",
       "uninstall_script_ref": "ed98f0de",
-      "sha256": "17fab46662f2758e0b5d2093e30b7dd2a879e6550915aaf5da4a43c956249449",
+      "sha256": "6131f8061f341c51bb546f7b9eea44c22bfe1d79d336bd904b7e2a31a9a0f3c7",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/melodics/darwin.json
+++ b/ee/maintained-apps/outputs/melodics/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "5.0.881",
+      "version": "5.0.925",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.melodics.Melodics';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.melodics.Melodics' AND version_compare(bundle_short_version, '5.0.881') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.melodics.Melodics' AND version_compare(bundle_short_version, '5.0.925') < 0);"
       },
-      "installer_url": "https://web-cdn.melodics.com/download/3EF110EC-12DE-4F6D-88B0-82FF89F431CB.zip",
+      "installer_url": "https://web-cdn.melodics.com/download/A499629C-EB7E-4B64-902A-0D7A0795F4BF.zip",
       "install_script_ref": "fa7d6756",
       "uninstall_script_ref": "4abaa93b",
-      "sha256": "d85115c1ac1d90d43117b3774183b6575b5278c7848153d50723febeaeb5bed2",
+      "sha256": "8d97e51bf2b00ecf2f9280566dcb58c508791fd6a347382a62130a14de29a4f0",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/microsoft-azure-storage-explorer/darwin.json
+++ b/ee/maintained-apps/outputs/microsoft-azure-storage-explorer/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.44.0",
+      "version": "1.45.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.StorageExplorer';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.StorageExplorer' AND version_compare(bundle_short_version, '1.44.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.StorageExplorer' AND version_compare(bundle_short_version, '1.45.0') < 0);"
       },
-      "installer_url": "https://github.com/microsoft/AzureStorageExplorer/releases/download/v1.44.0/StorageExplorer-darwin-arm64.zip",
+      "installer_url": "https://github.com/microsoft/AzureStorageExplorer/releases/download/v1.45.0/StorageExplorer-darwin-arm64.zip",
       "install_script_ref": "e616ea6f",
       "uninstall_script_ref": "343d0773",
-      "sha256": "6e8bfd353116e7e8d34bd4d98e971da1335ca8190c7fe43b1e7cb7e70ca53888",
+      "sha256": "5750a3d17014c3185c433dc1f8fbddbd4d486758ea2ecc144c66e50b58199b22",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/nextcloud-talk/darwin.json
+++ b/ee/maintained-apps/outputs/nextcloud-talk/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.2.2",
+      "version": "2.2.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.nextcloud.talk.mac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.nextcloud.talk.mac' AND version_compare(bundle_short_version, '2.2.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.nextcloud.talk.mac' AND version_compare(bundle_short_version, '2.2.3') < 0);"
       },
-      "installer_url": "https://github.com/nextcloud-releases/talk-desktop/releases/download/v2.2.2/Nextcloud.Talk-macos-universal.dmg",
+      "installer_url": "https://github.com/nextcloud-releases/talk-desktop/releases/download/v2.2.3/Nextcloud.Talk-macos-universal.dmg",
       "install_script_ref": "7677109a",
       "uninstall_script_ref": "baa87dcf",
-      "sha256": "41f67d964ce14c3894cbb769821755dad6fdd4b351d24b1d9a7acf86a15cc637",
+      "sha256": "069c95257c82602d6a1f879c0e86c70552cb4de543c7f30f581b275e0ae72a11",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/nodejs/windows.json
+++ b/ee/maintained-apps/outputs/nodejs/windows.json
@@ -1,22 +1,22 @@
 {
   "versions": [
     {
-      "version": "26.4.0",
+      "version": "26.5.1",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Node.js' AND publisher = 'Node.js Foundation';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Node.js' AND publisher = 'Node.js Foundation' AND version_compare(version, '26.4.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Node.js' AND publisher = 'Node.js Foundation' AND version_compare(version, '26.5.1') < 0);"
       },
-      "installer_url": "https://nodejs.org/dist/v26.4.0/node-v26.4.0-x64.msi",
+      "installer_url": "https://nodejs.org/dist/v26.5.1/node-v26.5.1-x64.msi",
       "install_script_ref": "8959087b",
-      "uninstall_script_ref": "4b733ca4",
-      "sha256": "c9df873c4cf0463c63b79774d96b2e126ca6ba9d9f86529846864d41775101d6",
+      "uninstall_script_ref": "fe1dc93a",
+      "sha256": "826a4551bb9d3c00c61c17a2521a1e901ac7304e3090a3c2d07c1e0fe2b4d60d",
       "default_categories": [
         "Developer tools"
       ]
     }
   ],
   "refs": {
-    "4b733ca4": "$product_code = '{16ACB226-F825-4982-A438-4E2A4D52BC44}'\n$timeoutSeconds = 300  # 5 minute timeout\n\n# Fleet uninstalls app using product code that's extracted on upload\n$process = Start-Process msiexec -ArgumentList @(\"/quiet\", \"/x\", $product_code, \"/norestart\") -PassThru\n\n# Wait for process with timeout\n$completed = $process.WaitForExit($timeoutSeconds * 1000)\n\nif (-not $completed) {\n    Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue\n    Exit 1603  # ERROR_UNINSTALL_FAILURE\n}\n\n# MSI exit codes that indicate success. 3010 = ERROR_SUCCESS_REBOOT_REQUIRED,\n# 1641 = ERROR_SUCCESS_REBOOT_INITIATED. Treat these as success rather than failure.\n$successCodes = @(0, 3010, 1641)\n\n# Check exit code and output result\nif ($successCodes -contains $process.ExitCode) {\n    Write-Output \"Exit 0\"\n    Exit 0\n} else {\n    Write-Output \"Exit $($process.ExitCode)\"\n    Exit $process.ExitCode\n}\n",
-    "8959087b": "$logFile = \"${env:TEMP}/fleet-install-software.log\"\n\ntry {\n\n$installProcess = Start-Process msiexec.exe `\n  -ArgumentList \"/quiet /norestart /lv ${logFile} /i `\"${env:INSTALLER_PATH}`\"\" `\n  -PassThru -Verb RunAs -Wait\n\nGet-Content $logFile -Tail 500\n\nExit $installProcess.ExitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n"
+    "8959087b": "$logFile = \"${env:TEMP}/fleet-install-software.log\"\n\ntry {\n\n$installProcess = Start-Process msiexec.exe `\n  -ArgumentList \"/quiet /norestart /lv ${logFile} /i `\"${env:INSTALLER_PATH}`\"\" `\n  -PassThru -Verb RunAs -Wait\n\nGet-Content $logFile -Tail 500\n\nExit $installProcess.ExitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n",
+    "fe1dc93a": "$product_code = '{09051536-C2FF-4E63-B5ED-F98A6D700260}'\n$timeoutSeconds = 300  # 5 minute timeout\n\n# Fleet uninstalls app using product code that's extracted on upload\n$process = Start-Process msiexec -ArgumentList @(\"/quiet\", \"/x\", $product_code, \"/norestart\") -PassThru\n\n# Wait for process with timeout\n$completed = $process.WaitForExit($timeoutSeconds * 1000)\n\nif (-not $completed) {\n    Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue\n    Exit 1603  # ERROR_UNINSTALL_FAILURE\n}\n\n# MSI exit codes that indicate success. 3010 = ERROR_SUCCESS_REBOOT_REQUIRED,\n# 1641 = ERROR_SUCCESS_REBOOT_INITIATED. Treat these as success rather than failure.\n$successCodes = @(0, 3010, 1641)\n\n# Check exit code and output result\nif ($successCodes -contains $process.ExitCode) {\n    Write-Output \"Exit 0\"\n    Exit 0\n} else {\n    Write-Output \"Exit $($process.ExitCode)\"\n    Exit $process.ExitCode\n}\n"
   }
 }

--- a/ee/maintained-apps/outputs/obs/windows.json
+++ b/ee/maintained-apps/outputs/obs/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "32.1.2",
+      "version": "32.2.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'OBS Studio' AND publisher = 'OBS Project';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'OBS Studio' AND publisher = 'OBS Project' AND version_compare(version, '32.1.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'OBS Studio' AND publisher = 'OBS Project' AND version_compare(version, '32.2.0') < 0);"
       },
-      "installer_url": "https://github.com/obsproject/obs-studio/releases/download/32.1.2/OBS-Studio-32.1.2-Windows-x64-Installer.exe",
+      "installer_url": "https://github.com/obsproject/obs-studio/releases/download/32.2.0/OBS-Studio-32.2.0-Windows-x64-Installer.exe",
       "install_script_ref": "8a919fae",
       "uninstall_script_ref": "145a6b76",
-      "sha256": "94d180c1fc481ccc307b95513f795d088d63ac4f61ad3253c2ac0d94d0844110",
+      "sha256": "e85f7cc39129c4c1999d84765fde8dade4c9a9800972f78d752ad218e7c50302",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/spokenly/darwin.json
+++ b/ee/maintained-apps/outputs/spokenly/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.27.3",
+      "version": "2.27.5",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'app.spokenly';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.spokenly' AND version_compare(bundle_short_version, '2.27.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.spokenly' AND version_compare(bundle_short_version, '2.27.5') < 0);"
       },
-      "installer_url": "https://cdn.spokenly.app/releases/macos/Spokenly-2.27.3.dmg",
+      "installer_url": "https://cdn.spokenly.app/releases/macos/Spokenly-2.27.5.dmg",
       "install_script_ref": "11a51e11",
       "uninstall_script_ref": "99a71452",
-      "sha256": "3092076383a65c16a08f3253e292a2c80789e1299f783bd331f302791487415d",
+      "sha256": "229f6ac9af202f957ecab78b5f97f7ea343a854cc2652155b3a8a8e8828b6597",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/virtualbox/windows.json
+++ b/ee/maintained-apps/outputs/virtualbox/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.2.12",
+      "version": "7.2.14",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Oracle VirtualBox %' AND publisher = 'Oracle and/or its affiliates';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Oracle VirtualBox %' AND publisher = 'Oracle and/or its affiliates' AND version_compare(version, '7.2.12') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Oracle VirtualBox %' AND publisher = 'Oracle and/or its affiliates' AND version_compare(version, '7.2.14') < 0);"
       },
-      "installer_url": "https://download.virtualbox.org/virtualbox/7.2.12/VirtualBox-7.2.12-174389-Win.exe",
+      "installer_url": "https://download.virtualbox.org/virtualbox/7.2.14/VirtualBox-7.2.14-174565-Win.exe",
       "install_script_ref": "556130e3",
       "uninstall_script_ref": "fb3c3d4d",
-      "sha256": "5094f3d573fe2a511bfc7ae8982c2f6544ae9b5051048dc7a0e9985c74dcac4c",
+      "sha256": "5fb111f32a15763d519bf9ef23e0111153521f641cde7460e5b8e895ca27a1d2",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/warp/darwin.json
+++ b/ee/maintained-apps/outputs/warp/darwin.json
@@ -1,12 +1,12 @@
 {
   "versions": [
     {
-      "version": "0.2026.07.22.09.01.01",
+      "version": "0.2026.07.29.09.05.02",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable' AND version_compare(bundle_short_version, '0.2026.07.22.09.01.01') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable' AND version_compare(bundle_short_version, '0.2026.07.29.09.05.02') < 0);"
       },
-      "installer_url": "https://releases.warp.dev/stable/v0.2026.07.22.09.01.stable_01/Warp.dmg",
+      "installer_url": "https://releases.warp.dev/stable/v0.2026.07.29.09.05.stable_02/Warp.dmg",
       "install_script_ref": "662fa5d8",
       "uninstall_script_ref": "932356de",
       "sha256": "no_check",


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Refreshed Windows packages for 1Password, Claude, Cursor, GitKraken, Node.js, OBS Studio, VirtualBox, and IBM Semeru JDK/JRE releases.
  - Refreshed macOS packages for Arc, Beeper, BrickLink Studio, ChatGPT, Firefox Nightly, Kiro CLI, Melodics, Azure Storage Explorer, Nextcloud Talk, Spokenly, and Warp.
  - Updated installer metadata, version detection, download sources, and integrity checks to support the latest releases.
  - Updated uninstall handling where required for 1Password and Node.js.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->