### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/brave-browser/darwin.json
+++ b/ee/maintained-apps/outputs/brave-browser/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "150.1.92.144",
+      "version": "151.1.93.129",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.brave.Browser';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.brave.Browser' AND version_compare(bundle_short_version, '150.1.92.144') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.brave.Browser' AND version_compare(bundle_short_version, '151.1.93.129') < 0);"
       },
-      "installer_url": "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/stable-arm64/192.144/Brave-Browser-arm64.dmg",
+      "installer_url": "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/stable-arm64/193.129/Brave-Browser-arm64.dmg",
       "install_script_ref": "32bb30f2",
       "uninstall_script_ref": "9a376609",
-      "sha256": "bf6dc0d6eba200257c300359aa3e0bff0162d8f55cfbaa5fb4e6ef4fbfe0d3fd",
+      "sha256": "b4652d0d7bed441a450d275872b0b2b668a4d970fe1a8da67cd44b271ea061d6",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/ibm-semeru-jre-8/windows.json
+++ b/ee/maintained-apps/outputs/ibm-semeru-jre-8/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "8.0.492.9",
+      "version": "8.0.502.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'IBM Semeru Runtime Open Edition (JRE)%' AND publisher = 'Semeru' AND version LIKE '8.%';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'IBM Semeru Runtime Open Edition (JRE)%' AND publisher = 'Semeru' AND version LIKE '8.%' AND version_compare(version, '8.0.492.9') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'IBM Semeru Runtime Open Edition (JRE)%' AND publisher = 'Semeru' AND version LIKE '8.%' AND version_compare(version, '8.0.502.0') < 0);"
       },
-      "installer_url": "https://github.com/ibmruntimes/semeru8-binaries/releases/download/jdk-8.0.492.0/ibm-semeru-open-jre_x64_windows_8.0.492.0.msi",
+      "installer_url": "https://github.com/ibmruntimes/semeru8-binaries/releases/download/jdk-8.0.502.0/ibm-semeru-open-jre_x64_windows_8.0.502.0.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "ec929ddf",
-      "sha256": "b21693e6902cd56f0dee3fb35f2913c0cb0c9f5ee3adb1dbbc9f90cd9921779c",
+      "sha256": "2c2320363c6a4b3d39fe2133e9af575e5148f45c861497285dca5cc03c81ffe1",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/nordpass/darwin.json
+++ b/ee/maintained-apps/outputs/nordpass/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "7.9.2",
+      "version": "7.9.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.nordsec.nordpass';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.nordsec.nordpass' AND version_compare(bundle_short_version, '7.9.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.nordsec.nordpass' AND version_compare(bundle_short_version, '7.9.3') < 0);"
       },
       "installer_url": "https://downloads.npass.app/mac/arm/NordPass.dmg",
       "install_script_ref": "001e7928",


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated Brave Browser for macOS to version 151.1.93.129.
  * Updated IBM Semeru JRE 8 for Windows to version 8.0.502.0.
  * Updated NordPass for macOS to version 7.9.3.
  * Refreshed installer information, checksums, and version detection for the updated releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->