### PR TITLE
Support custom activations and management declarations for DDM profiles

### DIFF
--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -5386,6 +5386,20 @@ ON DUPLICATE KEY UPDATE
 		return ctxerr.Wrap(ctx, err, "inserting declaration activation")
 	}
 
+	// Read the UUID back rather than reusing the generated one: on an edit the
+	// upsert keeps the existing row, so the generated UUID was never used.
+	var activationUUID string
+	const reloadStmt = `SELECT activation_uuid FROM mdm_apple_ddm_activations WHERE declaration_uuid = ?`
+	if err := sqlx.GetContext(ctx, tx, &activationUUID, reloadStmt, declUUID); err != nil {
+		return ctxerr.Wrap(ctx, err, "reload declaration activation")
+	}
+
+	if _, err := setVariableAssociationsForColumnDB(ctx, tx, []fleet.MDMProfileUUIDFleetVariables{
+		{ProfileUUID: activationUUID, FleetVariables: act.FleetVariables},
+	}, "apple_ddm_activation_uuid"); err != nil {
+		return ctxerr.Wrap(ctx, err, "inserting activation variable associations")
+	}
+
 	return nil
 }
 

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -5344,6 +5344,31 @@ func setMDMAppleDDMActivationDB(ctx context.Context, tx sqlx.ExtContext, declUUI
 		return nil
 	}
 
+	act := declaration.Activation
+
+	// The upsert below fires on any of this table's unique keys, so an
+	// identifier already held by a *different* declaration's activation would
+	// silently overwrite that row while leaving its declaration_uuid pointing
+	// elsewhere. Reject it up front instead. The (team_id,
+	// configuration_identifier) key needs no such guard: a configuration
+	// identifier is unique per team, so a conflict there is always the same
+	// declaration.
+	const conflictStmt = `
+SELECT 1 FROM mdm_apple_ddm_activations
+WHERE team_id = ? AND identifier = ? AND declaration_uuid != ?`
+
+	var conflict bool
+	switch err := sqlx.GetContext(ctx, tx, &conflict, conflictStmt, tmID, act.Identifier, declUUID); {
+	case err == nil:
+		return ctxerr.Wrap(ctx, &existsError{
+			ResourceType: "MDMAppleCustomActivation.Identifier",
+			Identifier:   act.Identifier,
+			TeamID:       &tmID,
+		}, "conflicting activation identifier")
+	case !errors.Is(err, sql.ErrNoRows):
+		return ctxerr.Wrap(ctx, err, "checking for conflicting activation identifier")
+	}
+
 	const upsertStmt = `
 INSERT INTO mdm_apple_ddm_activations (
 	activation_uuid,
@@ -5366,7 +5391,6 @@ ON DUPLICATE KEY UPDATE
 	secrets_updated_at = VALUES(secrets_updated_at)
 `
 
-	act := declaration.Activation
 	if _, err := tx.ExecContext(ctx, upsertStmt,
 		fleet.MDMAppleDDMActivationUUIDPrefix+uuid.NewString(),
 		tmID,
@@ -5376,13 +5400,6 @@ ON DUPLICATE KEY UPDATE
 		declaration.Identifier,
 		act.SecretsUpdatedAt,
 	); err != nil {
-		if IsDuplicate(err) {
-			return ctxerr.Wrap(ctx, &existsError{
-				ResourceType: "MDMAppleCustomActivation.Identifier",
-				Identifier:   act.Identifier,
-				TeamID:       &tmID,
-			}, "inserting declaration activation")
-		}
 		return ctxerr.Wrap(ctx, err, "inserting declaration activation")
 	}
 

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -5260,6 +5260,10 @@ func (ds *Datastore) insertOrUpsertMDMAppleDeclaration(ctx context.Context, insO
 			return ctxerr.Wrap(ctx, err, "inserting declaration variable associations")
 		}
 
+		if err := setMDMAppleDDMActivationDB(ctx, tx, declUUID, tmID, declaration); err != nil {
+			return err
+		}
+
 		if isSoftwareUpdate {
 			if err := trackAppleUpdateConfigProfileDB(ctx, tx, tmID, declUUID); err != nil {
 				return err
@@ -5279,6 +5283,70 @@ func (ds *Datastore) insertOrUpsertMDMAppleDeclaration(ctx context.Context, insO
 
 	declaration.DeclarationUUID = declUUID
 	return declaration, nil
+}
+
+// setMDMAppleDDMActivationDB writes the custom activation attached to a
+// declaration, or removes the stored one when the declaration no longer has an
+// activation, so re-uploading a profile without one clears it.
+//
+// The row is keyed on declaration_uuid rather than inserted fresh each time, so
+// an edit keeps the same activation_uuid and its Fleet variable associations
+// survive. uploaded_at only moves when the content actually changes, matching
+// how declarations themselves are upserted.
+func setMDMAppleDDMActivationDB(ctx context.Context, tx sqlx.ExtContext, declUUID string, tmID uint,
+	declaration *fleet.MDMAppleDeclaration,
+) error {
+	if declaration.Activation == nil {
+		const deleteStmt = `DELETE FROM mdm_apple_ddm_activations WHERE declaration_uuid = ?`
+		if _, err := tx.ExecContext(ctx, deleteStmt, declUUID); err != nil {
+			return ctxerr.Wrap(ctx, err, "deleting declaration activation")
+		}
+		return nil
+	}
+
+	const upsertStmt = `
+INSERT INTO mdm_apple_ddm_activations (
+	activation_uuid,
+	team_id,
+	identifier,
+	raw_json,
+	declaration_uuid,
+	configuration_identifier,
+	secrets_updated_at,
+	uploaded_at
+)
+VALUES (?,?,?,?,?,?,?,NOW(6))
+ON DUPLICATE KEY UPDATE
+	uploaded_at = IF(raw_json = VALUES(raw_json)
+		AND identifier = VALUES(identifier)
+		AND IFNULL(secrets_updated_at = VALUES(secrets_updated_at), TRUE), uploaded_at, NOW(6)),
+	identifier = VALUES(identifier),
+	raw_json = VALUES(raw_json),
+	configuration_identifier = VALUES(configuration_identifier),
+	secrets_updated_at = VALUES(secrets_updated_at)
+`
+
+	act := declaration.Activation
+	if _, err := tx.ExecContext(ctx, upsertStmt,
+		fleet.MDMAppleDDMActivationUUIDPrefix+uuid.NewString(),
+		tmID,
+		act.Identifier,
+		act.RawJSON,
+		declUUID,
+		declaration.Identifier,
+		act.SecretsUpdatedAt,
+	); err != nil {
+		if IsDuplicate(err) {
+			return ctxerr.Wrap(ctx, &existsError{
+				ResourceType: "MDMAppleCustomActivation.Identifier",
+				Identifier:   act.Identifier,
+				TeamID:       &tmID,
+			}, "inserting declaration activation")
+		}
+		return ctxerr.Wrap(ctx, err, "inserting declaration activation")
+	}
+
+	return nil
 }
 
 func batchSetDeclarationLabelAssociationsDB(ctx context.Context, tx sqlx.ExtContext,

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -627,10 +627,8 @@ WHERE
 		}
 	}
 
-	// Load the custom activation, if any, so callers that write the declaration
-	// back can carry it forward. setMDMAppleDDMActivationDB deletes the stored
-	// activation when the declaration it writes has none, so an edit that
-	// dropped this would silently clear it.
+	// Callers that write the declaration back must carry this forward; one
+	// written without an activation has its stored activation deleted.
 	activation, err := ds.getCustomActivationForDeclaration(ctx, res.DeclarationUUID)
 	if err != nil {
 		return nil, err
@@ -640,9 +638,7 @@ WHERE
 	return &res, nil
 }
 
-// getCustomActivationForDeclaration returns the custom activation attached to a
-// declaration, or nil when it has none. Having no activation is a normal state,
-// not a not-found error.
+// Returns nil when the declaration has none, which is a normal state.
 func (ds *Datastore) getCustomActivationForDeclaration(ctx context.Context, declUUID string) (*fleet.MDMAppleCustomActivation, error) {
 	const stmt = `
 SELECT
@@ -5325,14 +5321,8 @@ func (ds *Datastore) insertOrUpsertMDMAppleDeclaration(ctx context.Context, insO
 	return declaration, nil
 }
 
-// setMDMAppleDDMActivationDB writes the custom activation attached to a
-// declaration, or removes the stored one when the declaration no longer has an
-// activation, so re-uploading a profile without one clears it.
-//
-// The row is keyed on declaration_uuid rather than inserted fresh each time, so
-// an edit keeps the same activation_uuid and its Fleet variable associations
-// survive. uploaded_at only moves when the content actually changes, matching
-// how declarations themselves are upserted.
+// Keyed on declaration_uuid rather than inserted fresh, so an edit keeps the
+// same activation_uuid and its variable associations survive.
 func setMDMAppleDDMActivationDB(ctx context.Context, tx sqlx.ExtContext, declUUID string, tmID uint,
 	declaration *fleet.MDMAppleDeclaration,
 ) error {
@@ -5346,13 +5336,9 @@ func setMDMAppleDDMActivationDB(ctx context.Context, tx sqlx.ExtContext, declUUI
 
 	act := declaration.Activation
 
-	// The upsert below fires on any of this table's unique keys, so an
-	// identifier already held by a *different* declaration's activation would
-	// silently overwrite that row while leaving its declaration_uuid pointing
-	// elsewhere. Reject it up front instead. The (team_id,
-	// configuration_identifier) key needs no such guard: a configuration
-	// identifier is unique per team, so a conflict there is always the same
-	// declaration.
+	// The upsert fires on any unique key, so an identifier held by a different
+	// declaration's activation would overwrite that row. (team_id,
+	// configuration_identifier) needs no guard: it's always the same declaration.
 	const conflictStmt = `
 SELECT 1 FROM mdm_apple_ddm_activations
 WHERE team_id = ? AND identifier = ? AND declaration_uuid != ?`
@@ -5392,7 +5378,7 @@ ON DUPLICATE KEY UPDATE
 `
 
 	if _, err := tx.ExecContext(ctx, upsertStmt,
-		fleet.MDMAppleDDMActivationUUIDPrefix+uuid.NewString(),
+		uuid.NewString(),
 		tmID,
 		act.Identifier,
 		act.RawJSON,
@@ -5403,8 +5389,7 @@ ON DUPLICATE KEY UPDATE
 		return ctxerr.Wrap(ctx, err, "inserting declaration activation")
 	}
 
-	// Read the UUID back rather than reusing the generated one: on an edit the
-	// upsert keeps the existing row, so the generated UUID was never used.
+	// On an edit the upsert keeps the existing row, so the generated UUID is unused.
 	var activationUUID string
 	const reloadStmt = `SELECT activation_uuid FROM mdm_apple_ddm_activations WHERE declaration_uuid = ?`
 	if err := sqlx.GetContext(ctx, tx, &activationUUID, reloadStmt, declUUID); err != nil {

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -627,7 +627,47 @@ WHERE
 		}
 	}
 
+	// Load the custom activation, if any, so callers that write the declaration
+	// back can carry it forward. setMDMAppleDDMActivationDB deletes the stored
+	// activation when the declaration it writes has none, so an edit that
+	// dropped this would silently clear it.
+	activation, err := ds.getCustomActivationForDeclaration(ctx, res.DeclarationUUID)
+	if err != nil {
+		return nil, err
+	}
+	res.Activation = activation
+
 	return &res, nil
+}
+
+// getCustomActivationForDeclaration returns the custom activation attached to a
+// declaration, or nil when it has none. Having no activation is a normal state,
+// not a not-found error.
+func (ds *Datastore) getCustomActivationForDeclaration(ctx context.Context, declUUID string) (*fleet.MDMAppleCustomActivation, error) {
+	const stmt = `
+SELECT
+	activation_uuid,
+	team_id,
+	identifier,
+	raw_json,
+	declaration_uuid,
+	configuration_identifier,
+	secrets_updated_at,
+	created_at,
+	uploaded_at
+FROM
+	mdm_apple_ddm_activations
+WHERE
+	declaration_uuid = ?`
+
+	var act fleet.MDMAppleCustomActivation
+	if err := sqlx.GetContext(ctx, ds.reader(ctx), &act, stmt, declUUID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, ctxerr.Wrap(ctx, err, "get declaration custom activation")
+	}
+	return &act, nil
 }
 
 func (ds *Datastore) DeleteMDMAppleConfigProfileByDeprecatedID(ctx context.Context, profileID uint) error {

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -5346,10 +5346,10 @@ WHERE team_id = ? AND identifier = ? AND declaration_uuid != ?`
 	var conflict bool
 	switch err := sqlx.GetContext(ctx, tx, &conflict, conflictStmt, tmID, act.Identifier, declUUID); {
 	case err == nil:
-		return ctxerr.Wrap(ctx, &existsError{
-			ResourceType: "MDMAppleCustomActivation.Identifier",
-			Identifier:   act.Identifier,
-			TeamID:       &tmID,
+		// Not an existsError: the callers turn those into a message about the
+		// configuration profile's identifier, which isn't the one that clashed.
+		return ctxerr.Wrap(ctx, &fleet.ConflictError{
+			Message: "An activation with this identifier already exists.",
 		}, "conflicting activation identifier")
 	case !errors.Is(err, sql.ErrNoRows):
 		return ctxerr.Wrap(ctx, err, "checking for conflicting activation identifier")

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -13929,7 +13929,7 @@ func testMDMAppleCustomActivations(t *testing.T, ds *Datastore) {
 	require.JSONEq(t, string(actRaw), string(stored.RawJSON))
 	require.Equal(t, decl.DeclarationUUID, stored.DeclarationUUID)
 	require.Equal(t, "com.fleet.act-test", stored.ConfigurationIdentifier)
-	require.True(t, strings.HasPrefix(stored.ActivationUUID, fleet.MDMAppleDDMActivationUUIDPrefix))
+	require.NotEmpty(t, stored.ActivationUUID)
 
 	// It comes back on the list endpoint, base64 is applied at the JSON layer.
 	profs, _, err := ds.ListMDMConfigProfiles(ctx, nil, fleet.ListOptions{})

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -13991,7 +13991,7 @@ func testMDMAppleCustomActivations(t *testing.T, ds *Datastore) {
 
 	// An identifier already used by another declaration's activation is
 	// rejected rather than silently overwriting that declaration's row.
-	otherDecl, err := ds.NewMDMAppleDeclaration(ctx, &fleet.MDMAppleDeclaration{
+	_, err = ds.NewMDMAppleDeclaration(ctx, &fleet.MDMAppleDeclaration{
 		Identifier: "com.fleet.act-test.other",
 		Name:       "act-test-other",
 		RawJSON:    []byte(`{"Type":"com.apple.configuration.passcode.settings","Identifier":"com.fleet.act-test.other","Payload":{"Echo":"bar"}}`),
@@ -14020,7 +14020,26 @@ func testMDMAppleCustomActivations(t *testing.T, ds *Datastore) {
 		`SELECT declaration_uuid FROM mdm_apple_ddm_activations WHERE identifier = 'com.fleet.act-test.custom'`))
 	require.Equal(t, decl.DeclarationUUID, stillOwned)
 
-	require.NoError(t, ds.DeleteMDMAppleDeclaration(ctx, otherDecl.DeclarationUUID))
+	// Deleting a declaration through the datastore removes its activation.
+	// The migration test proves the FK cascade with raw SQL; this proves the
+	// path the delete endpoint actually takes.
+	otherActDecl, err := ds.SetOrUpdateMDMAppleDeclaration(ctx, &fleet.MDMAppleDeclaration{
+		Identifier: "com.fleet.act-test.other",
+		Name:       "act-test-other",
+		RawJSON:    []byte(`{"Type":"com.apple.configuration.passcode.settings","Identifier":"com.fleet.act-test.other","Payload":{"Echo":"bar"}}`),
+		Activation: &fleet.MDMAppleCustomActivation{
+			Identifier:              "com.fleet.act-test.other.custom",
+			RawJSON:                 []byte(`{"Type":"com.apple.activation.simple","Identifier":"com.fleet.act-test.other.custom","Payload":{"StandardConfigurations":["com.fleet.act-test.other"]}}`),
+			ConfigurationIdentifier: "com.fleet.act-test.other",
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, ds.DeleteMDMAppleDeclaration(ctx, otherActDecl.DeclarationUUID))
+
+	require.NoError(t, sqlx.GetContext(ctx, ds.reader(ctx), &count,
+		`SELECT COUNT(*) FROM mdm_apple_ddm_activations WHERE declaration_uuid = ?`, otherActDecl.DeclarationUUID))
+	require.Zero(t, count, "deleting a declaration must remove its activation")
 
 	// A write that carries the activation forward without restating its
 	// variables must not drop the associations. This is the shape a

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -94,6 +94,7 @@ func TestMDMApple(t *testing.T) {
 		{"LockUnlockWipeMacOS", testLockUnlockWipeMacOS},
 		{"ScreenDEPAssignProfileSerialsForCooldown", testScreenDEPAssignProfileSerialsForCooldown},
 		{"MDMAppleDDMDeclarationsToken", testMDMAppleDDMDeclarationsToken},
+		{"MDMAppleCustomActivations", testMDMAppleCustomActivations},
 		{"NewMDMAppleDeclarationSoftwareUpdateTracking", testNewMDMAppleDeclarationSoftwareUpdateTracking},
 		{"SetOrUpdateMDMAppleDeclarationSoftwareUpdateTracking", testSetOrUpdateMDMAppleDeclarationSoftwareUpdateTracking},
 		{"MDMAppleSetPendingDeclarationsAs", testMDMAppleSetPendingDeclarationsAs},
@@ -13889,4 +13890,83 @@ func testGetABMOrganizationNamesAssociatedByDefaultTeams(t *testing.T, ds *Datas
 
 	_, err := ds.GetABMTokenOrgNamesAssociatedByDefaultTeams(ctx, nil)
 	require.Error(t, err)
+}
+
+func testMDMAppleCustomActivations(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	declRaw := []byte(`{"Type":"com.apple.configuration.passcode.settings","Identifier":"com.fleet.act-test","Payload":{"Echo":"foo"}}`)
+	actRaw := []byte(`{"Type":"com.apple.activation.simple","Identifier":"com.fleet.act-test.custom","Payload":{"StandardConfigurations":["com.fleet.act-test"],"Predicate":"@status(os.version.major) >= 15"}}`)
+
+	newDecl := func(activation *fleet.MDMAppleCustomActivation) *fleet.MDMAppleDeclaration {
+		return &fleet.MDMAppleDeclaration{
+			Identifier: "com.fleet.act-test",
+			Name:       "act-test",
+			RawJSON:    declRaw,
+			Activation: activation,
+		}
+	}
+
+	// A declaration uploaded with an activation stores it, linked by UUID.
+	decl, err := ds.NewMDMAppleDeclaration(ctx, newDecl(&fleet.MDMAppleCustomActivation{
+		Identifier:              "com.fleet.act-test.custom",
+		RawJSON:                 actRaw,
+		ConfigurationIdentifier: "com.fleet.act-test",
+	}), nil)
+	require.NoError(t, err)
+
+	var stored struct {
+		ActivationUUID          string `db:"activation_uuid"`
+		Identifier              string `db:"identifier"`
+		RawJSON                 []byte `db:"raw_json"`
+		DeclarationUUID         string `db:"declaration_uuid"`
+		ConfigurationIdentifier string `db:"configuration_identifier"`
+	}
+	require.NoError(t, sqlx.GetContext(ctx, ds.reader(ctx), &stored,
+		`SELECT activation_uuid, identifier, raw_json, declaration_uuid, configuration_identifier
+		 FROM mdm_apple_ddm_activations WHERE declaration_uuid = ?`, decl.DeclarationUUID))
+	require.Equal(t, "com.fleet.act-test.custom", stored.Identifier)
+	require.JSONEq(t, string(actRaw), string(stored.RawJSON))
+	require.Equal(t, decl.DeclarationUUID, stored.DeclarationUUID)
+	require.Equal(t, "com.fleet.act-test", stored.ConfigurationIdentifier)
+	require.True(t, strings.HasPrefix(stored.ActivationUUID, fleet.MDMAppleDDMActivationUUIDPrefix))
+
+	// It comes back on the list endpoint, base64 is applied at the JSON layer.
+	profs, _, err := ds.ListMDMConfigProfiles(ctx, nil, fleet.ListOptions{})
+	require.NoError(t, err)
+	var found bool
+	for _, p := range profs {
+		if p.ProfileUUID == decl.DeclarationUUID {
+			found = true
+			require.JSONEq(t, string(actRaw), string(p.Activation))
+		}
+	}
+	require.True(t, found, "declaration missing from list")
+
+	// Editing the activation keeps the same row rather than creating a second.
+	editedAct := []byte(`{"Type":"com.apple.activation.simple","Identifier":"com.fleet.act-test.custom","Payload":{"StandardConfigurations":["com.fleet.act-test"],"Predicate":"@status(os.version.major) >= 26"}}`)
+	_, err = ds.SetOrUpdateMDMAppleDeclaration(ctx, newDecl(&fleet.MDMAppleCustomActivation{
+		Identifier:              "com.fleet.act-test.custom",
+		RawJSON:                 editedAct,
+		ConfigurationIdentifier: "com.fleet.act-test",
+	}), nil)
+	require.NoError(t, err)
+
+	var count int
+	require.NoError(t, sqlx.GetContext(ctx, ds.reader(ctx), &count,
+		`SELECT COUNT(*) FROM mdm_apple_ddm_activations WHERE declaration_uuid = ?`, decl.DeclarationUUID))
+	require.Equal(t, 1, count)
+
+	var rawAfterEdit []byte
+	require.NoError(t, sqlx.GetContext(ctx, ds.reader(ctx), &rawAfterEdit,
+		`SELECT raw_json FROM mdm_apple_ddm_activations WHERE declaration_uuid = ?`, decl.DeclarationUUID))
+	require.JSONEq(t, string(editedAct), string(rawAfterEdit))
+
+	// Re-uploading the declaration without an activation removes it.
+	_, err = ds.SetOrUpdateMDMAppleDeclaration(ctx, newDecl(nil), nil)
+	require.NoError(t, err)
+
+	require.NoError(t, sqlx.GetContext(ctx, ds.reader(ctx), &count,
+		`SELECT COUNT(*) FROM mdm_apple_ddm_activations WHERE declaration_uuid = ?`, decl.DeclarationUUID))
+	require.Zero(t, count)
 }

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -13962,11 +13962,43 @@ func testMDMAppleCustomActivations(t *testing.T, ds *Datastore) {
 		`SELECT raw_json FROM mdm_apple_ddm_activations WHERE declaration_uuid = ?`, decl.DeclarationUUID))
 	require.JSONEq(t, string(editedAct), string(rawAfterEdit))
 
-	// Re-uploading the declaration without an activation removes it.
+	// The single-profile read returns it too.
+	fetched, err := ds.GetMDMAppleDeclaration(ctx, decl.DeclarationUUID)
+	require.NoError(t, err)
+	require.NotNil(t, fetched.Activation)
+	require.JSONEq(t, string(editedAct), string(fetched.Activation.RawJSON))
+	require.Equal(t, "com.fleet.act-test.custom", fetched.Activation.Identifier)
+
+	// Fleet variables in the activation are associated with it, not with the
+	// declaration, and satisfy the exactly-one-owner check constraint.
+	varAct := []byte(`{"Type":"com.apple.activation.simple","Identifier":"com.fleet.act-test.custom","Payload":{"StandardConfigurations":["com.fleet.act-test"],"Predicate":"$FLEET_VAR_HOST_UUID"}}`)
+	_, err = ds.SetOrUpdateMDMAppleDeclaration(ctx, newDecl(&fleet.MDMAppleCustomActivation{
+		Identifier:              "com.fleet.act-test.custom",
+		RawJSON:                 varAct,
+		ConfigurationIdentifier: "com.fleet.act-test",
+		FleetVariables:          []fleet.FleetVarName{fleet.FleetVarHostUUID},
+	}), nil)
+	require.NoError(t, err)
+
+	var activationUUID string
+	require.NoError(t, sqlx.GetContext(ctx, ds.reader(ctx), &activationUUID,
+		`SELECT activation_uuid FROM mdm_apple_ddm_activations WHERE declaration_uuid = ?`, decl.DeclarationUUID))
+
+	var varCount int
+	require.NoError(t, sqlx.GetContext(ctx, ds.reader(ctx), &varCount,
+		`SELECT COUNT(*) FROM mdm_configuration_profile_variables WHERE apple_ddm_activation_uuid = ?`, activationUUID))
+	require.Equal(t, 1, varCount)
+
+	// Re-uploading the declaration without an activation removes it, and the
+	// FK cascade takes the variable association with it.
 	_, err = ds.SetOrUpdateMDMAppleDeclaration(ctx, newDecl(nil), nil)
 	require.NoError(t, err)
 
 	require.NoError(t, sqlx.GetContext(ctx, ds.reader(ctx), &count,
 		`SELECT COUNT(*) FROM mdm_apple_ddm_activations WHERE declaration_uuid = ?`, decl.DeclarationUUID))
 	require.Zero(t, count)
+
+	require.NoError(t, sqlx.GetContext(ctx, ds.reader(ctx), &varCount,
+		`SELECT COUNT(*) FROM mdm_configuration_profile_variables WHERE apple_ddm_activation_uuid = ?`, activationUUID))
+	require.Zero(t, varCount)
 }

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -13989,6 +13989,57 @@ func testMDMAppleCustomActivations(t *testing.T, ds *Datastore) {
 		`SELECT COUNT(*) FROM mdm_configuration_profile_variables WHERE apple_ddm_activation_uuid = ?`, activationUUID))
 	require.Equal(t, 1, varCount)
 
+	// An identifier already used by another declaration's activation is
+	// rejected rather than silently overwriting that declaration's row.
+	otherDecl, err := ds.NewMDMAppleDeclaration(ctx, &fleet.MDMAppleDeclaration{
+		Identifier: "com.fleet.act-test.other",
+		Name:       "act-test-other",
+		RawJSON:    []byte(`{"Type":"com.apple.configuration.passcode.settings","Identifier":"com.fleet.act-test.other","Payload":{"Echo":"bar"}}`),
+	}, nil)
+	require.NoError(t, err)
+
+	_, err = ds.SetOrUpdateMDMAppleDeclaration(ctx, &fleet.MDMAppleDeclaration{
+		Identifier: "com.fleet.act-test.other",
+		Name:       "act-test-other",
+		RawJSON:    []byte(`{"Type":"com.apple.configuration.passcode.settings","Identifier":"com.fleet.act-test.other","Payload":{"Echo":"bar"}}`),
+		Activation: &fleet.MDMAppleCustomActivation{
+			// same identifier as the first declaration's activation
+			Identifier:              "com.fleet.act-test.custom",
+			RawJSON:                 actRaw,
+			ConfigurationIdentifier: "com.fleet.act-test.other",
+		},
+	}, nil)
+	require.Error(t, err)
+	var existsErr interface{ IsExists() bool }
+	require.ErrorAs(t, err, &existsErr, "expected an already-exists error, got %v", err)
+	require.True(t, existsErr.IsExists())
+
+	// the first declaration's activation is untouched
+	var stillOwned string
+	require.NoError(t, sqlx.GetContext(ctx, ds.reader(ctx), &stillOwned,
+		`SELECT declaration_uuid FROM mdm_apple_ddm_activations WHERE identifier = 'com.fleet.act-test.custom'`))
+	require.Equal(t, decl.DeclarationUUID, stillOwned)
+
+	require.NoError(t, ds.DeleteMDMAppleDeclaration(ctx, otherDecl.DeclarationUUID))
+
+	// A write that carries the activation forward without restating its
+	// variables must not drop the associations. This is the shape a
+	// labels-only edit produces, since the service reuses the activation
+	// returned by GetMDMAppleDeclaration, which doesn't load them.
+	carried, err := ds.GetMDMAppleDeclaration(ctx, decl.DeclarationUUID)
+	require.NoError(t, err)
+	require.NotNil(t, carried.Activation)
+	require.Empty(t, carried.Activation.FleetVariables, "loaded activation carries no variables")
+
+	carriedAct := *carried.Activation
+	carriedAct.FleetVariables = []fleet.FleetVarName{fleet.FleetVarHostUUID}
+	_, err = ds.SetOrUpdateMDMAppleDeclaration(ctx, newDecl(&carriedAct), nil)
+	require.NoError(t, err)
+
+	require.NoError(t, sqlx.GetContext(ctx, ds.reader(ctx), &varCount,
+		`SELECT COUNT(*) FROM mdm_configuration_profile_variables WHERE apple_ddm_activation_uuid = ?`, activationUUID))
+	require.Equal(t, 1, varCount)
+
 	// Re-uploading the declaration without an activation removes it, and the
 	// FK cascade takes the variable association with it.
 	_, err = ds.SetOrUpdateMDMAppleDeclaration(ctx, newDecl(nil), nil)

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -14010,9 +14010,11 @@ func testMDMAppleCustomActivations(t *testing.T, ds *Datastore) {
 		},
 	}, nil)
 	require.Error(t, err)
-	var existsErr interface{ IsExists() bool }
-	require.ErrorAs(t, err, &existsErr, "expected an already-exists error, got %v", err)
-	require.True(t, existsErr.IsExists())
+	// A conflict rather than an exists error, so callers don't report it as a
+	// clash on the configuration profile's identifier.
+	var conflictErr *fleet.ConflictError
+	require.ErrorAs(t, err, &conflictErr, "expected a conflict error, got %v", err)
+	require.Contains(t, conflictErr.Error(), "An activation with this identifier already exists.")
 
 	// the first declaration's activation is untouched
 	var stillOwned string

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -14014,7 +14014,7 @@ func testMDMAppleCustomActivations(t *testing.T, ds *Datastore) {
 	// clash on the configuration profile's identifier.
 	var conflictErr *fleet.ConflictError
 	require.ErrorAs(t, err, &conflictErr, "expected a conflict error, got %v", err)
-	require.Contains(t, conflictErr.Error(), "An activation with this identifier already exists.")
+	require.ErrorContains(t, err, "An activation with this identifier already exists.")
 
 	// the first declaration's activation is untouched
 	var stillOwned string

--- a/server/datastore/mysql/mdm.go
+++ b/server/datastore/mysql/mdm.go
@@ -2347,6 +2347,19 @@ func batchSetProfileVariableAssociationsDB(
 		return false, fmt.Errorf("unsupported platform %s", platform)
 	}
 
+	return setVariableAssociationsForColumnDB(ctx, tx, profileVariablesByUUID, columnName)
+}
+
+// setVariableAssociationsForColumnDB rewrites the Fleet variable associations
+// for a set of owners in mdm_configuration_profile_variables. The owner column
+// varies -- profiles, declarations and custom DDM activations all key into the
+// same table -- so it is passed in rather than derived here.
+func setVariableAssociationsForColumnDB(
+	ctx context.Context,
+	tx sqlx.ExtContext,
+	profileVariablesByUUID []fleet.MDMProfileUUIDFleetVariables,
+	columnName string,
+) (didUpdate bool, err error) {
 	// collect the profile uuids to clear
 	profileUUIDsToDelete := make([]string, 0, len(profileVariablesByUUID))
 	// small optimization - if there are no variables to insert, we can stop here

--- a/server/datastore/mysql/mdm.go
+++ b/server/datastore/mysql/mdm.go
@@ -848,7 +848,51 @@ FROM (
 		}
 	}
 
+	// load the custom activations for the declarations in this page. Only
+	// declarations can have one, and most won't, so this is skipped entirely
+	// when the page has no declarations.
+	activations, err := ds.getCustomActivationsForDeclarations(ctx, macDeclUUIDs)
+	if err != nil {
+		return nil, nil, err
+	}
+	for declUUID, rawJSON := range activations {
+		if prof, ok := profMap[declUUID]; ok {
+			prof.Activation = rawJSON
+		}
+	}
+
 	return profs, metaData, nil
+}
+
+// getCustomActivationsForDeclarations returns the raw activation JSON for the
+// given declarations, keyed by declaration UUID. Declarations without a custom
+// activation are absent from the map rather than present with a nil value, so
+// callers leave MDMConfigProfilePayload.Activation unset and it is omitted from
+// the API response.
+func (ds *Datastore) getCustomActivationsForDeclarations(ctx context.Context, declUUIDs []string) (map[string][]byte, error) {
+	if len(declUUIDs) == 0 {
+		return nil, nil
+	}
+
+	const selectStmt = `SELECT declaration_uuid, raw_json FROM mdm_apple_ddm_activations WHERE declaration_uuid IN (?)`
+	stmt, args, err := sqlx.In(selectStmt, declUUIDs)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "sqlx.In get declaration activations")
+	}
+
+	var rows []struct {
+		DeclarationUUID string `db:"declaration_uuid"`
+		RawJSON         []byte `db:"raw_json"`
+	}
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &rows, stmt, args...); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "select declaration activations")
+	}
+
+	activations := make(map[string][]byte, len(rows))
+	for _, r := range rows {
+		activations[r.DeclarationUUID] = r.RawJSON
+	}
+	return activations, nil
 }
 
 func (ds *Datastore) listProfileLabelsForProfiles(ctx context.Context, winProfUUIDs, macProfUUIDs, androidProfUUIDs, macDeclUUIDs []string) ([]fleet.ConfigurationProfileLabel, error) {

--- a/server/datastore/mysql/mdm.go
+++ b/server/datastore/mysql/mdm.go
@@ -2360,6 +2360,16 @@ func setVariableAssociationsForColumnDB(
 	profileVariablesByUUID []fleet.MDMProfileUUIDFleetVariables,
 	columnName string,
 ) (didUpdate bool, err error) {
+	// columnName is interpolated into the statements below. Every caller passes
+	// a literal today, but the helper is shared across profiles, declarations
+	// and activations, so keep the invariant explicit rather than implied.
+	switch columnName {
+	case "apple_profile_uuid", "windows_profile_uuid", "apple_declaration_uuid",
+		"android_profile_uuid", "apple_ddm_activation_uuid":
+	default:
+		return false, ctxerr.Errorf(ctx, "unsupported variable association column %q", columnName)
+	}
+
 	// collect the profile uuids to clear
 	profileUUIDsToDelete := make([]string, 0, len(profileVariablesByUUID))
 	// small optimization - if there are no variables to insert, we can stop here

--- a/server/datastore/mysql/mdm.go
+++ b/server/datastore/mysql/mdm.go
@@ -848,9 +848,6 @@ FROM (
 		}
 	}
 
-	// load the custom activations for the declarations in this page. Only
-	// declarations can have one, and most won't, so this is skipped entirely
-	// when the page has no declarations.
 	activations, err := ds.getCustomActivationsForDeclarations(ctx, macDeclUUIDs)
 	if err != nil {
 		return nil, nil, err
@@ -864,11 +861,8 @@ FROM (
 	return profs, metaData, nil
 }
 
-// getCustomActivationsForDeclarations returns the raw activation JSON for the
-// given declarations, keyed by declaration UUID. Declarations without a custom
-// activation are absent from the map rather than present with a nil value, so
-// callers leave MDMConfigProfilePayload.Activation unset and it is omitted from
-// the API response.
+// Declarations without one are absent from the map, so callers leave
+// MDMConfigProfilePayload.Activation unset and it's omitted from the response.
 func (ds *Datastore) getCustomActivationsForDeclarations(ctx context.Context, declUUIDs []string) (map[string][]byte, error) {
 	if len(declUUIDs) == 0 {
 		return nil, nil
@@ -2350,19 +2344,15 @@ func batchSetProfileVariableAssociationsDB(
 	return setVariableAssociationsForColumnDB(ctx, tx, profileVariablesByUUID, columnName)
 }
 
-// setVariableAssociationsForColumnDB rewrites the Fleet variable associations
-// for a set of owners in mdm_configuration_profile_variables. The owner column
-// varies -- profiles, declarations and custom DDM activations all key into the
-// same table -- so it is passed in rather than derived here.
+// Profiles, declarations and activations all key into the same table, so the
+// owner column is passed in rather than derived here.
 func setVariableAssociationsForColumnDB(
 	ctx context.Context,
 	tx sqlx.ExtContext,
 	profileVariablesByUUID []fleet.MDMProfileUUIDFleetVariables,
 	columnName string,
 ) (didUpdate bool, err error) {
-	// columnName is interpolated into the statements below. Every caller passes
-	// a literal today, but the helper is shared across profiles, declarations
-	// and activations, so keep the invariant explicit rather than implied.
+	// columnName is interpolated below; keep the invariant explicit.
 	switch columnName {
 	case "apple_profile_uuid", "windows_profile_uuid", "apple_declaration_uuid",
 		"android_profile_uuid", "apple_ddm_activation_uuid":

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -913,10 +913,8 @@ type MDMAppleDeclaration struct {
 	// Fleet requires that Identifier must be unique in combination with the Name and TeamID.
 	Identifier string `db:"identifier" json:"identifier"`
 
-	// Type is the "Type" key of the associated declaration. It isn't persisted
-	// (it can always be read back out of RawJSON) but is carried here so
-	// callers can tell a configuration from a management declaration without
-	// re-parsing the JSON.
+	// Not persisted; carried so callers can tell a configuration from a
+	// management declaration without re-parsing RawJSON.
 	Type string `db:"-" json:"-"`
 
 	// Name corresponds to the file name of the associated JSON declaration payload.
@@ -945,10 +943,7 @@ type MDMAppleDeclaration struct {
 	// populate mdm_apple_declaration_asset_references in the batch-set path.
 	AssetReferenceUUIDs []string `db:"-" json:"-"`
 
-	// Activation is the custom activation to store alongside this declaration.
-	// A nil Activation means the declaration has none, and any activation
-	// previously stored for it is removed on write, so re-uploading a profile
-	// without one clears it.
+	// Nil removes any stored activation on write, which is how one is cleared.
 	Activation *MDMAppleCustomActivation `db:"-" json:"-"`
 
 	CreatedAt          time.Time  `db:"created_at" json:"created_at"`
@@ -1016,25 +1011,13 @@ func (r *MDMAppleRawDeclaration) ValidateScope() error {
 var ForbiddenDeclTypes = map[string]struct{}{
 	"com.apple.configuration.watch.enrollment": {},
 	"com.apple.configuration.account.google":   {},
+	"com.apple.management.server-capabilities": {},
 }
 
 const (
-	// MDMAppleConfigurationTypePrefix is the prefix of every Apple
-	// configuration declaration type.
 	MDMAppleConfigurationTypePrefix = "com.apple.configuration."
-	// MDMAppleManagementTypePrefix is the prefix of every Apple management
-	// declaration type (organization info, server info, properties). These are
-	// stored and uploaded like configurations, but they are never activated:
-	// they're served under the manifest's Management section rather than
-	// Configurations.
-	MDMAppleManagementTypePrefix = "com.apple.management."
+	MDMAppleManagementTypePrefix    = "com.apple.management."
 )
-
-// IsManagementDeclaration reports whether a declaration type is an Apple
-// management declaration rather than a configuration.
-func IsManagementDeclaration(declType string) bool {
-	return strings.HasPrefix(declType, MDMAppleManagementTypePrefix)
-}
 
 func (r *MDMAppleRawDeclaration) ValidateUserProvided() error {
 	var err error
@@ -1051,7 +1034,7 @@ func (r *MDMAppleRawDeclaration) ValidateUserProvided() error {
 		return NewInvalidArgumentError(r.Type, "Declaration profile can't include software management types. To manage software, please use the Software tab.")
 	}
 
-	if !strings.HasPrefix(r.Type, MDMAppleConfigurationTypePrefix) && !IsManagementDeclaration(r.Type) {
+	if !strings.HasPrefix(r.Type, MDMAppleConfigurationTypePrefix) && !strings.HasPrefix(r.Type, MDMAppleManagementTypePrefix) {
 		return NewInvalidArgumentError(r.Type, "Only configuration declarations (com.apple.configuration.) and management declarations (com.apple.management.) are supported.")
 	}
 
@@ -1067,62 +1050,38 @@ func GetRawDeclarationValues(raw []byte) (*MDMAppleRawDeclaration, error) {
 	return &rawDecl, nil
 }
 
-// MDMAppleActivationTypePrefix is the prefix every Apple activation
-// declaration type carries. Fleet accepts any type under it rather than only
-// com.apple.activation.simple, so new activation types Apple introduces work
-// without a Fleet change.
+// Any type under this prefix is accepted, not just com.apple.activation.simple,
+// so new Apple activation types don't need a Fleet change.
 const MDMAppleActivationTypePrefix = "com.apple.activation."
 
-// MDMAppleCustomActivation is a custom activation declaration supplied by an
-// admin, stored 1:1 against the configuration declaration it activates.
-// Distinct from MDMAppleDDMActivation, which is Apple's wire format for an
-// activation served to a device.
-//
-// Fleet stores the document verbatim and never interprets its Payload, most
-// importantly the Predicate, which the device evaluates.
+// A custom activation stored against the configuration declaration it
+// activates. Not to be confused with MDMAppleDDMActivation, Apple's wire format.
 type MDMAppleCustomActivation struct {
-	ActivationUUID string `db:"activation_uuid"`
-	TeamID         uint   `db:"team_id"`
-	// Identifier is the activation's own Identifier, distinct from the
-	// identifier of the configuration it activates.
-	Identifier string          `db:"identifier"`
-	RawJSON    json.RawMessage `db:"raw_json"`
-	// DeclarationUUID is the authoritative link to the configuration this
-	// activation gates; it cascades on delete.
-	DeclarationUUID string `db:"declaration_uuid"`
-	// ConfigurationIdentifier is the Identifier of that same declaration, kept
-	// alongside the UUID because the activation JSON references its
-	// configuration by Identifier rather than by UUID.
-	ConfigurationIdentifier string     `db:"configuration_identifier"`
-	SecretsUpdatedAt        *time.Time `db:"secrets_updated_at"`
-	CreatedAt               time.Time  `db:"created_at"`
-	UploadedAt              time.Time  `db:"uploaded_at"`
+	ActivationUUID          string          `db:"activation_uuid"`
+	TeamID                  uint            `db:"team_id"`
+	Identifier              string          `db:"identifier"`
+	RawJSON                 json.RawMessage `db:"raw_json"`
+	DeclarationUUID         string          `db:"declaration_uuid"`
+	ConfigurationIdentifier string          `db:"configuration_identifier"`
+	SecretsUpdatedAt        *time.Time      `db:"secrets_updated_at"`
+	CreatedAt               time.Time       `db:"created_at"`
+	UploadedAt              time.Time       `db:"uploaded_at"`
 
-	// FleetVariables are the Fleet variables referenced by RawJSON, recorded
-	// against the activation in mdm_configuration_profile_variables so the
-	// activation is re-delivered when their values change.
 	FleetVariables []FleetVarName `db:"-"`
 }
 
-// MDMAppleRawActivation holds the fields Fleet reads out of a user-provided
-// activation declaration. Everything else in the document — most importantly
-// Payload.Predicate — is stored and served verbatim; Fleet never interprets
-// it and leaves the device to evaluate or reject it.
+// The fields of an activation declaration used for validation. Everything
+// else, Payload.Predicate included, is stored and served verbatim.
 type MDMAppleRawActivation struct {
-	// Type is the "Type" field on the raw activation JSON.
-	Type string `json:"Type"`
-	// Identifier is the activation's own identifier, distinct from the
-	// identifier of the configuration it activates.
+	Type       string `json:"Type"`
 	Identifier string `json:"Identifier"`
 	Payload    struct {
-		// StandardConfigurations lists the configuration declarations this
-		// activation turns on. Apple allows several; Fleet allows exactly one,
-		// the configuration the activation is uploaded alongside.
+		// Apple allows several; Fleet allows exactly the configuration the
+		// activation is uploaded with.
 		StandardConfigurations []string `json:"StandardConfigurations"`
 	} `json:"Payload"`
 }
 
-// GetRawActivationValues parses a user-provided activation declaration.
 func GetRawActivationValues(raw []byte) (*MDMAppleRawActivation, error) {
 	var rawAct MDMAppleRawActivation
 	if err := json.Unmarshal(raw, &rawAct); err != nil {
@@ -1132,14 +1091,8 @@ func GetRawActivationValues(raw []byte) (*MDMAppleRawActivation, error) {
 	return &rawAct, nil
 }
 
-// ValidateUserProvided checks a user-provided activation against the
-// configuration declaration it is being attached to. It deliberately does not
-// reuse MDMAppleRawDeclaration.ValidateUserProvided, which only admits
-// com.apple.configuration.* types and would reject every activation.
-//
-// configurationIdentifier is the Identifier of the declaration the activation
-// is uploaded alongside; Fleet's model is one activation per configuration, so
-// StandardConfigurations must name exactly that identifier and nothing else.
+// Deliberately not reusing MDMAppleRawDeclaration.ValidateUserProvided, which
+// only admits com.apple.configuration.* and would reject every activation.
 func (r *MDMAppleRawActivation) ValidateUserProvided(configurationIdentifier string) error {
 	invalid := &InvalidArgumentError{}
 

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -1097,6 +1097,11 @@ type MDMAppleCustomActivation struct {
 	SecretsUpdatedAt        *time.Time `db:"secrets_updated_at"`
 	CreatedAt               time.Time  `db:"created_at"`
 	UploadedAt              time.Time  `db:"uploaded_at"`
+
+	// FleetVariables are the Fleet variables referenced by RawJSON, recorded
+	// against the activation in mdm_configuration_profile_variables so the
+	// activation is re-delivered when their values change.
+	FleetVariables []FleetVarName `db:"-"`
 }
 
 // MDMAppleRawActivation holds the fields Fleet reads out of a user-provided

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -913,6 +913,12 @@ type MDMAppleDeclaration struct {
 	// Fleet requires that Identifier must be unique in combination with the Name and TeamID.
 	Identifier string `db:"identifier" json:"identifier"`
 
+	// Type is the "Type" key of the associated declaration. It isn't persisted
+	// (it can always be read back out of RawJSON) but is carried here so
+	// callers can tell a configuration from a management declaration without
+	// re-parsing the JSON.
+	Type string `db:"-" json:"-"`
+
 	// Name corresponds to the file name of the associated JSON declaration payload.
 	// Fleet requires that Name must be unique in combination with the Identifier and TeamID.
 	Name string `db:"name" json:"name"`
@@ -1006,6 +1012,24 @@ var ForbiddenDeclTypes = map[string]struct{}{
 	"com.apple.configuration.account.google":   {},
 }
 
+const (
+	// MDMAppleConfigurationTypePrefix is the prefix of every Apple
+	// configuration declaration type.
+	MDMAppleConfigurationTypePrefix = "com.apple.configuration."
+	// MDMAppleManagementTypePrefix is the prefix of every Apple management
+	// declaration type (organization info, server info, properties). These are
+	// stored and uploaded like configurations, but they are never activated:
+	// they're served under the manifest's Management section rather than
+	// Configurations.
+	MDMAppleManagementTypePrefix = "com.apple.management."
+)
+
+// IsManagementDeclaration reports whether a declaration type is an Apple
+// management declaration rather than a configuration.
+func IsManagementDeclaration(declType string) bool {
+	return strings.HasPrefix(declType, MDMAppleManagementTypePrefix)
+}
+
 func (r *MDMAppleRawDeclaration) ValidateUserProvided() error {
 	var err error
 
@@ -1021,8 +1045,8 @@ func (r *MDMAppleRawDeclaration) ValidateUserProvided() error {
 		return NewInvalidArgumentError(r.Type, "Declaration profile can't include software management types. To manage software, please use the Software tab.")
 	}
 
-	if !strings.HasPrefix(r.Type, "com.apple.configuration.") {
-		return NewInvalidArgumentError(r.Type, "Only configuration declarations (com.apple.configuration.) are supported.")
+	if !strings.HasPrefix(r.Type, MDMAppleConfigurationTypePrefix) && !IsManagementDeclaration(r.Type) {
+		return NewInvalidArgumentError(r.Type, "Only configuration declarations (com.apple.configuration.) and management declarations (com.apple.management.) are supported.")
 	}
 
 	return err
@@ -1183,6 +1207,7 @@ func NewMDMAppleDeclaration(raw []byte, teamID *uint, name string, declType, ide
 
 	decl.Identifier = ident
 	decl.Name = name
+	decl.Type = declType
 	decl.RawJSON = raw
 	decl.TeamID = teamID
 

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -945,6 +945,12 @@ type MDMAppleDeclaration struct {
 	// populate mdm_apple_declaration_asset_references in the batch-set path.
 	AssetReferenceUUIDs []string `db:"-" json:"-"`
 
+	// Activation is the custom activation to store alongside this declaration.
+	// A nil Activation means the declaration has none, and any activation
+	// previously stored for it is removed on write, so re-uploading a profile
+	// without one clears it.
+	Activation *MDMAppleCustomActivation `db:"-" json:"-"`
+
 	CreatedAt          time.Time  `db:"created_at" json:"created_at"`
 	UploadedAt         time.Time  `db:"uploaded_at" json:"uploaded_at"`
 	SecretsUpdatedAt   *time.Time `db:"secrets_updated_at" json:"-"`
@@ -1066,6 +1072,32 @@ func GetRawDeclarationValues(raw []byte) (*MDMAppleRawDeclaration, error) {
 // com.apple.activation.simple, so new activation types Apple introduces work
 // without a Fleet change.
 const MDMAppleActivationTypePrefix = "com.apple.activation."
+
+// MDMAppleCustomActivation is a custom activation declaration supplied by an
+// admin, stored 1:1 against the configuration declaration it activates.
+// Distinct from MDMAppleDDMActivation, which is Apple's wire format for an
+// activation served to a device.
+//
+// Fleet stores the document verbatim and never interprets its Payload, most
+// importantly the Predicate, which the device evaluates.
+type MDMAppleCustomActivation struct {
+	ActivationUUID string `db:"activation_uuid"`
+	TeamID         uint   `db:"team_id"`
+	// Identifier is the activation's own Identifier, distinct from the
+	// identifier of the configuration it activates.
+	Identifier string          `db:"identifier"`
+	RawJSON    json.RawMessage `db:"raw_json"`
+	// DeclarationUUID is the authoritative link to the configuration this
+	// activation gates; it cascades on delete.
+	DeclarationUUID string `db:"declaration_uuid"`
+	// ConfigurationIdentifier is the Identifier of that same declaration, kept
+	// alongside the UUID because the activation JSON references its
+	// configuration by Identifier rather than by UUID.
+	ConfigurationIdentifier string     `db:"configuration_identifier"`
+	SecretsUpdatedAt        *time.Time `db:"secrets_updated_at"`
+	CreatedAt               time.Time  `db:"created_at"`
+	UploadedAt              time.Time  `db:"uploaded_at"`
+}
 
 // MDMAppleRawActivation holds the fields Fleet reads out of a user-provided
 // activation declaration. Everything else in the document — most importantly

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -1037,6 +1037,79 @@ func GetRawDeclarationValues(raw []byte) (*MDMAppleRawDeclaration, error) {
 	return &rawDecl, nil
 }
 
+// MDMAppleActivationTypePrefix is the prefix every Apple activation
+// declaration type carries. Fleet accepts any type under it rather than only
+// com.apple.activation.simple, so new activation types Apple introduces work
+// without a Fleet change.
+const MDMAppleActivationTypePrefix = "com.apple.activation."
+
+// MDMAppleRawActivation holds the fields Fleet reads out of a user-provided
+// activation declaration. Everything else in the document — most importantly
+// Payload.Predicate — is stored and served verbatim; Fleet never interprets
+// it and leaves the device to evaluate or reject it.
+type MDMAppleRawActivation struct {
+	// Type is the "Type" field on the raw activation JSON.
+	Type string `json:"Type"`
+	// Identifier is the activation's own identifier, distinct from the
+	// identifier of the configuration it activates.
+	Identifier string `json:"Identifier"`
+	Payload    struct {
+		// StandardConfigurations lists the configuration declarations this
+		// activation turns on. Apple allows several; Fleet allows exactly one,
+		// the configuration the activation is uploaded alongside.
+		StandardConfigurations []string `json:"StandardConfigurations"`
+	} `json:"Payload"`
+}
+
+// GetRawActivationValues parses a user-provided activation declaration.
+func GetRawActivationValues(raw []byte) (*MDMAppleRawActivation, error) {
+	var rawAct MDMAppleRawActivation
+	if err := json.Unmarshal(raw, &rawAct); err != nil {
+		return nil, NewInvalidArgumentError("activation", fmt.Sprintf("Couldn't add. The activation should include valid JSON: %s", err)).WithStatus(http.StatusBadRequest)
+	}
+
+	return &rawAct, nil
+}
+
+// ValidateUserProvided checks a user-provided activation against the
+// configuration declaration it is being attached to. It deliberately does not
+// reuse MDMAppleRawDeclaration.ValidateUserProvided, which only admits
+// com.apple.configuration.* types and would reject every activation.
+//
+// configurationIdentifier is the Identifier of the declaration the activation
+// is uploaded alongside; Fleet's model is one activation per configuration, so
+// StandardConfigurations must name exactly that identifier and nothing else.
+func (r *MDMAppleRawActivation) ValidateUserProvided(configurationIdentifier string) error {
+	invalid := &InvalidArgumentError{}
+
+	if r.Type == "" {
+		invalid.Append("Type", "Activation must include a Type.")
+	} else if !strings.HasPrefix(r.Type, MDMAppleActivationTypePrefix) {
+		invalid.Append("Type", fmt.Sprintf("Only activation declarations (%s) are supported.", MDMAppleActivationTypePrefix))
+	}
+
+	if strings.TrimSpace(r.Identifier) == "" {
+		invalid.Append("Identifier", "Activation must include an Identifier.")
+	}
+
+	switch configs := r.Payload.StandardConfigurations; {
+	case len(configs) == 0:
+		invalid.Append("StandardConfigurations", "Activation must reference the configuration profile it's uploaded with.")
+	case len(configs) > 1:
+		invalid.Append("StandardConfigurations", "Activation can only reference one configuration profile.")
+	case configs[0] != configurationIdentifier:
+		invalid.Append("StandardConfigurations", fmt.Sprintf(
+			"Activation must reference the configuration profile it's uploaded with. Expected %q, got %q.",
+			configurationIdentifier, configs[0]))
+	}
+
+	if invalid.HasErrors() {
+		return invalid
+	}
+
+	return nil
+}
+
 // MDMAppleHostDeclaration represents the state of a declaration on a host
 type MDMAppleHostDeclaration struct {
 	// HostUUID is the uuid of the host affected by this declaration

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -1017,6 +1017,11 @@ var ForbiddenDeclTypes = map[string]struct{}{
 const (
 	MDMAppleConfigurationTypePrefix = "com.apple.configuration."
 	MDMAppleManagementTypePrefix    = "com.apple.management."
+
+	// Apple's DeclarationBase caps Identifier at 64 octets. A longer one is
+	// stored fine but rejected by the device at delivery.
+	// https://developer.apple.com/documentation/devicemanagement/declarationbase
+	MDMAppleDeclarationIdentifierMaxLen = 64
 )
 
 func (r *MDMAppleRawDeclaration) ValidateUserProvided() error {
@@ -1036,6 +1041,11 @@ func (r *MDMAppleRawDeclaration) ValidateUserProvided() error {
 
 	if !strings.HasPrefix(r.Type, MDMAppleConfigurationTypePrefix) && !strings.HasPrefix(r.Type, MDMAppleManagementTypePrefix) {
 		return NewInvalidArgumentError(r.Type, "Only configuration declarations (com.apple.configuration.) and management declarations (com.apple.management.) are supported.")
+	}
+
+	if len(r.Identifier) > MDMAppleDeclarationIdentifierMaxLen {
+		return NewInvalidArgumentError("Identifier", fmt.Sprintf(
+			"Identifier must be %d bytes or fewer.", MDMAppleDeclarationIdentifierMaxLen))
 	}
 
 	return err
@@ -1102,8 +1112,12 @@ func (r *MDMAppleRawActivation) ValidateUserProvided(configurationIdentifier str
 		invalid.Append("Type", fmt.Sprintf("Only activation declarations (%s) are supported.", MDMAppleActivationTypePrefix))
 	}
 
-	if strings.TrimSpace(r.Identifier) == "" {
+	switch {
+	case strings.TrimSpace(r.Identifier) == "":
 		invalid.Append("Identifier", "Activation must include an Identifier.")
+	case len(r.Identifier) > MDMAppleDeclarationIdentifierMaxLen:
+		invalid.Append("Identifier", fmt.Sprintf(
+			"Identifier must be %d bytes or fewer.", MDMAppleDeclarationIdentifierMaxLen))
 	}
 
 	switch configs := r.Payload.StandardConfigurations; {

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -1101,12 +1101,10 @@ func GetRawActivationValues(raw []byte) (*MDMAppleRawActivation, error) {
 	return &rawAct, nil
 }
 
-// Deliberately not reusing MDMAppleRawDeclaration.ValidateUserProvided, which
-// only admits com.apple.configuration.* and would reject every activation.
 func (r *MDMAppleRawActivation) ValidateUserProvided(configurationIdentifier string) error {
 	invalid := &InvalidArgumentError{}
 
-	if r.Type == "" {
+	if strings.TrimSpace(r.Type) == "" {
 		invalid.Append("Type", "Activation must include a Type.")
 	} else if !strings.HasPrefix(r.Type, MDMAppleActivationTypePrefix) {
 		invalid.Append("Type", fmt.Sprintf("Only activation declarations (%s) are supported.", MDMAppleActivationTypePrefix))

--- a/server/fleet/apple_mdm_test.go
+++ b/server/fleet/apple_mdm_test.go
@@ -1073,3 +1073,119 @@ func TestIsMacAppleSilicon(t *testing.T) {
 		})
 	}
 }
+
+func TestGetRawActivationValues(t *testing.T) {
+	t.Run("valid activation", func(t *testing.T) {
+		raw, err := GetRawActivationValues([]byte(`{
+			"Type": "com.apple.activation.simple",
+			"Identifier": "com.fleet.act.passcode",
+			"Payload": {
+				"StandardConfigurations": ["com.fleet.cfg.passcode"],
+				"Predicate": "@status(os.version.major) >= 15"
+			}
+		}`))
+		require.NoError(t, err)
+		require.Equal(t, "com.apple.activation.simple", raw.Type)
+		require.Equal(t, "com.fleet.act.passcode", raw.Identifier)
+		require.Equal(t, []string{"com.fleet.cfg.passcode"}, raw.Payload.StandardConfigurations)
+	})
+
+	t.Run("malformed JSON", func(t *testing.T) {
+		_, err := GetRawActivationValues([]byte(`{"Type":`))
+		require.Error(t, err)
+		require.ErrorContains(t, err, "should include valid JSON")
+	})
+}
+
+func TestMDMAppleRawActivationValidateUserProvided(t *testing.T) {
+	const configIdentifier = "com.fleet.cfg.passcode"
+
+	cases := []struct {
+		name        string
+		activation  MDMAppleRawActivation
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "valid activation",
+			activation: rawActivation("com.apple.activation.simple", "com.fleet.act.passcode",
+				configIdentifier),
+		},
+		{
+			// Fleet accepts the whole com.apple.activation.* namespace so a new
+			// Apple activation type doesn't need a Fleet change.
+			name: "unknown activation type under the activation prefix is allowed",
+			activation: rawActivation("com.apple.activation.something-new", "com.fleet.act.passcode",
+				configIdentifier),
+		},
+		{
+			name:        "missing type",
+			activation:  rawActivation("", "com.fleet.act.passcode", configIdentifier),
+			wantErr:     true,
+			errContains: "Activation must include a Type.",
+		},
+		{
+			name: "configuration type is not an activation",
+			activation: rawActivation("com.apple.configuration.passcode.settings", "com.fleet.act.passcode",
+				configIdentifier),
+			wantErr:     true,
+			errContains: "Only activation declarations (com.apple.activation.) are supported.",
+		},
+		{
+			name:        "missing identifier",
+			activation:  rawActivation("com.apple.activation.simple", "   ", configIdentifier),
+			wantErr:     true,
+			errContains: "Activation must include an Identifier.",
+		},
+		{
+			name:        "no configurations referenced",
+			activation:  rawActivation("com.apple.activation.simple", "com.fleet.act.passcode"),
+			wantErr:     true,
+			errContains: "Activation must reference the configuration profile it's uploaded with.",
+		},
+		{
+			name: "more than one configuration referenced",
+			activation: rawActivation("com.apple.activation.simple", "com.fleet.act.passcode",
+				configIdentifier, "com.fleet.cfg.firewall"),
+			wantErr:     true,
+			errContains: "Activation can only reference one configuration profile.",
+		},
+		{
+			name: "references a different configuration",
+			activation: rawActivation("com.apple.activation.simple", "com.fleet.act.passcode",
+				"com.fleet.cfg.firewall"),
+			wantErr:     true,
+			errContains: `Expected "com.fleet.cfg.passcode", got "com.fleet.cfg.firewall".`,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.activation.ValidateUserProvided(configIdentifier)
+			if c.wantErr {
+				require.Error(t, err)
+				require.ErrorContains(t, err, c.errContains)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+
+	t.Run("all problems are reported at once", func(t *testing.T) {
+		act := rawActivation("com.apple.configuration.passcode.settings", "")
+		err := act.ValidateUserProvided(configIdentifier)
+		require.Error(t, err)
+
+		var invalid *InvalidArgumentError
+		require.ErrorAs(t, err, &invalid)
+		require.Len(t, invalid.Errors, 3)
+	})
+}
+
+func rawActivation(declType, identifier string, standardConfigurations ...string) MDMAppleRawActivation {
+	var act MDMAppleRawActivation
+	act.Type = declType
+	act.Identifier = identifier
+	act.Payload.StandardConfigurations = standardConfigurations
+	return act
+}

--- a/server/fleet/apple_mdm_test.go
+++ b/server/fleet/apple_mdm_test.go
@@ -278,7 +278,23 @@ func TestMDMAppleRawDeclarationValidateUserProvided(t *testing.T) {
 			name:        "non-configuration declaration not allowed",
 			declType:    "com.apple.activation.simple",
 			wantErr:     true,
-			errContains: "Only configuration declarations (com.apple.configuration.) are supported.",
+			errContains: "Only configuration declarations (com.apple.configuration.) and management declarations (com.apple.management.) are supported.",
+		},
+		{
+			name:     "management declaration allowed",
+			declType: "com.apple.management.organization-info",
+			wantErr:  false,
+		},
+		{
+			name:     "management properties declaration allowed",
+			declType: "com.apple.management.properties",
+			wantErr:  false,
+		},
+		{
+			name:        "activation declaration still not allowed",
+			declType:    "com.apple.activation.simple",
+			wantErr:     true,
+			errContains: "and management declarations",
 		},
 	}
 
@@ -1188,4 +1204,27 @@ func rawActivation(declType, identifier string, standardConfigurations ...string
 	act.Identifier = identifier
 	act.Payload.StandardConfigurations = standardConfigurations
 	return act
+}
+
+func TestIsManagementDeclaration(t *testing.T) {
+	cases := []struct {
+		declType string
+		want     bool
+	}{
+		{"com.apple.management.organization-info", true},
+		{"com.apple.management.server-info", true},
+		{"com.apple.management.properties", true},
+		{"com.apple.configuration.passcode.settings", false},
+		// Not a management declaration: this is a configuration whose type
+		// merely contains "management".
+		{"com.apple.configuration.management.status-subscriptions", false},
+		{"com.apple.activation.simple", false},
+		{"", false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.declType, func(t *testing.T) {
+			require.Equal(t, c.want, IsManagementDeclaration(c.declType))
+		})
+	}
 }

--- a/server/fleet/apple_mdm_test.go
+++ b/server/fleet/apple_mdm_test.go
@@ -1199,26 +1199,3 @@ func rawActivation(declType, identifier string, standardConfigurations ...string
 	act.Payload.StandardConfigurations = standardConfigurations
 	return act
 }
-
-func TestIsManagementDeclaration(t *testing.T) {
-	cases := []struct {
-		declType string
-		want     bool
-	}{
-		{"com.apple.management.organization-info", true},
-		{"com.apple.management.server-info", true},
-		{"com.apple.management.properties", true},
-		{"com.apple.configuration.passcode.settings", false},
-		// Not a management declaration: this is a configuration whose type
-		// merely contains "management".
-		{"com.apple.configuration.management.status-subscriptions", false},
-		{"com.apple.activation.simple", false},
-		{"", false},
-	}
-
-	for _, c := range cases {
-		t.Run(c.declType, func(t *testing.T) {
-			require.Equal(t, c.want, IsManagementDeclaration(c.declType))
-		})
-	}
-}

--- a/server/fleet/apple_mdm_test.go
+++ b/server/fleet/apple_mdm_test.go
@@ -290,12 +290,6 @@ func TestMDMAppleRawDeclarationValidateUserProvided(t *testing.T) {
 			declType: "com.apple.management.properties",
 			wantErr:  false,
 		},
-		{
-			name:        "activation declaration still not allowed",
-			declType:    "com.apple.activation.simple",
-			wantErr:     true,
-			errContains: "and management declarations",
-		},
 	}
 
 	for _, c := range cases {

--- a/server/fleet/apple_mdm_test.go
+++ b/server/fleet/apple_mdm_test.go
@@ -235,6 +235,7 @@ func TestMDMAppleRawDeclarationValidateUserProvided(t *testing.T) {
 	cases := []struct {
 		name        string
 		declType    string
+		identifier  string
 		wantErr     bool
 		errContains string
 	}{
@@ -290,13 +291,32 @@ func TestMDMAppleRawDeclarationValidateUserProvided(t *testing.T) {
 			declType: "com.apple.management.properties",
 			wantErr:  false,
 		},
+		{
+			name:        "identifier over Apple's 64 octet limit",
+			declType:    "com.apple.configuration.passcode.settings",
+			identifier:  strings.Repeat("a", 65),
+			wantErr:     true,
+			errContains: "Identifier must be 64 bytes or fewer.",
+		},
+		{
+			// octets, not characters: 22 three-byte runes exceed 64
+			name:        "multibyte identifier counted in octets",
+			declType:    "com.apple.configuration.passcode.settings",
+			identifier:  strings.Repeat("日", 22),
+			wantErr:     true,
+			errContains: "Identifier must be 64 bytes or fewer.",
+		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
+			identifier := c.identifier
+			if identifier == "" {
+				identifier = "test-identifier"
+			}
 			decl := &MDMAppleRawDeclaration{
 				Type:       c.declType,
-				Identifier: "test-identifier",
+				Identifier: identifier,
 			}
 
 			err := decl.ValidateUserProvided()
@@ -1146,6 +1166,12 @@ func TestMDMAppleRawActivationValidateUserProvided(t *testing.T) {
 			activation:  rawActivation("com.apple.activation.simple", "   ", configIdentifier),
 			wantErr:     true,
 			errContains: "Activation must include an Identifier.",
+		},
+		{
+			name:        "identifier over Apple's 64 octet limit",
+			activation:  rawActivation("com.apple.activation.simple", strings.Repeat("a", 65), configIdentifier),
+			wantErr:     true,
+			errContains: "Identifier must be 64 bytes or fewer.",
 		},
 		{
 			name:        "no configurations referenced",

--- a/server/fleet/apple_mdm_test.go
+++ b/server/fleet/apple_mdm_test.go
@@ -1155,6 +1155,12 @@ func TestMDMAppleRawActivationValidateUserProvided(t *testing.T) {
 			errContains: "Activation must include a Type.",
 		},
 		{
+			name:        "whitespace type",
+			activation:  rawActivation("      ", "com.fleet.act.passcode", configIdentifier),
+			wantErr:     true,
+			errContains: "Activation must include a Type.",
+		},
+		{
 			name: "configuration type is not an activation",
 			activation: rawActivation("com.apple.configuration.passcode.settings", "com.fleet.act.passcode",
 				configIdentifier),

--- a/server/fleet/errors.go
+++ b/server/fleet/errors.go
@@ -56,6 +56,7 @@ var (
 	SoftwareLabelsPackageLevelOnlyMessage        = "Couldn't add software (%q). Labels can be specified only in the package-level file when adding multiple packages of the same software."
 	SoftwareLabelsConflictMessage                = "Couldn't add software (%q). Labels can be specified either in the fleet-level file or in the package YAML file."
 	ConfigProfileLabelScopingPremiumCauseMsg     = "Scoping configuration profiles with labels"
+	DDMCustomActivationPremiumCauseMsg           = "Custom activations for declaration (DDM) profiles"
 )
 
 // ErrWithStatusCode is an interface for errors that should set a specific HTTP

--- a/server/fleet/mdm.go
+++ b/server/fleet/mdm.go
@@ -25,6 +25,10 @@ const (
 	MDMAppleProfileUUIDPrefix     = "a"
 	MDMWindowsProfileUUIDPrefix   = "w"
 	MDMAndroidProfileUUIDPrefix   = "g"
+	// MDMAppleDDMActivationUUIDPrefix is "v" rather than "a", which Apple
+	// profiles already use. Activations are never addressed by UUID through the
+	// API; the prefix exists for consistency and readability in the database.
+	MDMAppleDDMActivationUUIDPrefix = "v"
 
 	// RefetchMDMUnenrollCriticalQueryDuration is the duration to set the
 	// RefetchCriticalQueriesUntil field when migrating a device from a
@@ -654,6 +658,10 @@ type MDMConfigProfilePayload struct {
 	LabelsIncludeAll []ConfigurationProfileLabel `json:"labels_include_all,omitempty" db:"-"`
 	LabelsIncludeAny []ConfigurationProfileLabel `json:"labels_include_any,omitempty" db:"-"`
 	LabelsExcludeAny []ConfigurationProfileLabel `json:"labels_exclude_any,omitempty" db:"-"`
+	// Activation is the custom activation attached to a declaration (DDM)
+	// profile. It is a []byte so encoding/json emits it base64-encoded, and it
+	// is omitted entirely for profiles that don't have one.
+	Activation []byte `json:"activation,omitempty" db:"-"`
 }
 
 // BatchModifyMDMConfigProfilePayload represents the payload for a config profile when

--- a/server/fleet/mdm.go
+++ b/server/fleet/mdm.go
@@ -659,9 +659,9 @@ type MDMConfigProfilePayload struct {
 	LabelsIncludeAny []ConfigurationProfileLabel `json:"labels_include_any,omitempty" db:"-"`
 	LabelsExcludeAny []ConfigurationProfileLabel `json:"labels_exclude_any,omitempty" db:"-"`
 	// Activation is the custom activation attached to a declaration (DDM)
-	// profile. It is a []byte so encoding/json emits it base64-encoded, and it
-	// is omitted entirely for profiles that don't have one.
-	Activation []byte `json:"activation,omitempty" db:"-"`
+	// profile, emitted as raw JSON rather than an encoded string, and omitted
+	// entirely for profiles that don't have one.
+	Activation json.RawMessage `json:"activation,omitempty" db:"-"`
 }
 
 // BatchModifyMDMConfigProfilePayload represents the payload for a config profile when

--- a/server/fleet/mdm.go
+++ b/server/fleet/mdm.go
@@ -25,10 +25,6 @@ const (
 	MDMAppleProfileUUIDPrefix     = "a"
 	MDMWindowsProfileUUIDPrefix   = "w"
 	MDMAndroidProfileUUIDPrefix   = "g"
-	// MDMAppleDDMActivationUUIDPrefix is "v" rather than "a", which Apple
-	// profiles already use. Activations are never addressed by UUID through the
-	// API; the prefix exists for consistency and readability in the database.
-	MDMAppleDDMActivationUUIDPrefix = "v"
 
 	// RefetchMDMUnenrollCriticalQueryDuration is the duration to set the
 	// RefetchCriticalQueriesUntil field when migrating a device from a
@@ -658,10 +654,8 @@ type MDMConfigProfilePayload struct {
 	LabelsIncludeAll []ConfigurationProfileLabel `json:"labels_include_all,omitempty" db:"-"`
 	LabelsIncludeAny []ConfigurationProfileLabel `json:"labels_include_any,omitempty" db:"-"`
 	LabelsExcludeAny []ConfigurationProfileLabel `json:"labels_exclude_any,omitempty" db:"-"`
-	// Activation is the custom activation attached to a declaration (DDM)
-	// profile, emitted as raw JSON rather than an encoded string, and omitted
-	// entirely for profiles that don't have one.
-	Activation json.RawMessage `json:"activation,omitempty" db:"-"`
+	// Base64-encoded activation for declaration (DDM) profiles.
+	Activation []byte `json:"activation,omitempty" db:"-"`
 }
 
 // BatchModifyMDMConfigProfilePayload represents the payload for a config profile when

--- a/server/fleet/mdm.go
+++ b/server/fleet/mdm.go
@@ -733,7 +733,7 @@ func NewMDMConfigProfilePayloadFromAppleDDM(decl *MDMAppleDeclaration) *MDMConfi
 	if decl.TeamID != nil && *decl.TeamID > 0 {
 		tid = decl.TeamID
 	}
-	return &MDMConfigProfilePayload{
+	payload := &MDMConfigProfilePayload{
 		ProfileUUID:      decl.DeclarationUUID,
 		TeamID:           tid,
 		Name:             decl.Name,
@@ -746,6 +746,10 @@ func NewMDMConfigProfilePayloadFromAppleDDM(decl *MDMAppleDeclaration) *MDMConfi
 		LabelsIncludeAny: decl.LabelsIncludeAny,
 		LabelsExcludeAny: decl.LabelsExcludeAny,
 	}
+	if decl.Activation != nil {
+		payload.Activation = decl.Activation.RawJSON
+	}
+	return payload
 }
 
 func NewMDMConfigProfilePayloadFromAndroid(cp *MDMAndroidConfigProfile) *MDMConfigProfilePayload {

--- a/server/fleet/mdm.go
+++ b/server/fleet/mdm.go
@@ -654,8 +654,9 @@ type MDMConfigProfilePayload struct {
 	LabelsIncludeAll []ConfigurationProfileLabel `json:"labels_include_all,omitempty" db:"-"`
 	LabelsIncludeAny []ConfigurationProfileLabel `json:"labels_include_any,omitempty" db:"-"`
 	LabelsExcludeAny []ConfigurationProfileLabel `json:"labels_exclude_any,omitempty" db:"-"`
-	// Base64-encoded activation for declaration (DDM) profiles.
-	Activation []byte `json:"activation,omitempty" db:"-"`
+	// Base64-encoded activation for declaration (DDM) profiles, null for any
+	// other profile type and for declarations without a custom activation.
+	Activation []byte `json:"activation" db:"-"`
 }
 
 // BatchModifyMDMConfigProfilePayload represents the payload for a config profile when

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -1240,6 +1240,12 @@ type Service interface {
 	// unsupported extension is uploaded.
 	NewMDMUnsupportedConfigProfile(ctx context.Context, teamID uint, filename string) error
 
+	// NewMDMActivationUnsupportedProfile is called when an activation is
+	// uploaded alongside a profile that isn't an Apple declaration. Like the
+	// two below, it exists so the error goes through an authorization check --
+	// the endpoint can't reach svc.authz through this interface.
+	NewMDMActivationUnsupportedProfile(ctx context.Context, teamID uint) error
+
 	// NewMDMInvalidJSONConfigProfile is called when a JSON profile is uploaded with contents that
 	// cannot be resolved to either Apple DDM or Android format
 	NewMDMInvalidJSONConfigProfile(ctx context.Context, teamID uint, err error) error

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -1248,7 +1248,7 @@ type Service interface {
 	// contents and/or label targeting in place. Supported for Apple
 	// .mobileconfig profiles, Apple DDM declarations, Windows profiles, and
 	// Android profiles.
-	UpdateMDMConfigProfile(ctx context.Context, profileUUID string, profile []byte, labelsInclude []string, labelsMembershipMode MDMLabelsMode, labelsExcludeAny []string) error
+	UpdateMDMConfigProfile(ctx context.Context, profileUUID string, profile []byte, labelsInclude []string, labelsMembershipMode MDMLabelsMode, labelsExcludeAny []string, activation []byte) error
 
 	// ListMDMConfigProfiles returns a list of paginated configuration profiles.
 	ListMDMConfigProfiles(ctx context.Context, teamID *uint, opt ListOptions) ([]*MDMConfigProfilePayload, *PaginationMetadata, error)

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -1241,9 +1241,10 @@ type Service interface {
 	NewMDMUnsupportedConfigProfile(ctx context.Context, teamID uint, filename string) error
 
 	// NewMDMActivationUnsupportedProfile is called when an activation is
-	// uploaded alongside a profile that isn't an Apple declaration. Like the
-	// two below, it exists so the error goes through an authorization check --
-	// the endpoint can't reach svc.authz through this interface.
+	// uploaded alongside a profile that isn't an Apple declaration. Like
+	// NewMDMUnsupportedConfigProfile and NewMDMInvalidJSONConfigProfile, it
+	// exists so the error goes through an authorization check -- the endpoint
+	// can't reach svc.authz through this interface.
 	NewMDMActivationUnsupportedProfile(ctx context.Context, teamID uint) error
 
 	// NewMDMInvalidJSONConfigProfile is called when a JSON profile is uploaded with contents that

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -932,7 +932,9 @@ type Service interface {
 	// NewMDMAppleConfigProfile creates a new configuration profile for the specified team.
 	NewMDMAppleConfigProfile(ctx context.Context, teamID uint, data []byte, labelsInclude []string, labelsMembershipMode MDMLabelsMode, labelsExcludeAny []string) (*MDMAppleConfigProfile, error)
 	// NewMDMAppleConfigProfileWithPayload creates a new declaration for the specified team.
-	NewMDMAppleDeclaration(ctx context.Context, teamID uint, data []byte, labelsInclude []string, name string, labelsMembershipMode MDMLabelsMode, labelsExcludeAny []string) (*MDMAppleDeclaration, error)
+	// activation is an optional custom activation declaration to attach to the
+	// declaration; nil or empty means Fleet generates the activation as before.
+	NewMDMAppleDeclaration(ctx context.Context, teamID uint, data []byte, labelsInclude []string, name string, labelsMembershipMode MDMLabelsMode, labelsExcludeAny []string, activation []byte) (*MDMAppleDeclaration, error)
 
 	// GetMDMAppleConfigProfileByDeprecatedID retrieves the specified Apple
 	// configuration profile via its numeric ID. This method is deprecated and

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -1240,11 +1240,9 @@ type Service interface {
 	// unsupported extension is uploaded.
 	NewMDMUnsupportedConfigProfile(ctx context.Context, teamID uint, filename string) error
 
-	// NewMDMActivationUnsupportedProfile is called when an activation is
-	// uploaded alongside a profile that isn't an Apple declaration. Like
-	// NewMDMUnsupportedConfigProfile and NewMDMInvalidJSONConfigProfile, it
-	// exists so the error goes through an authorization check -- the endpoint
-	// can't reach svc.authz through this interface.
+	// Called when an activation is uploaded alongside a profile that isn't an
+	// Apple declaration. Exists, like the two below, so the error goes through
+	// an authorization check.
 	NewMDMActivationUnsupportedProfile(ctx context.Context, teamID uint) error
 
 	// NewMDMInvalidJSONConfigProfile is called when a JSON profile is uploaded with contents that

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -933,7 +933,7 @@ type Service interface {
 	NewMDMAppleConfigProfile(ctx context.Context, teamID uint, data []byte, labelsInclude []string, labelsMembershipMode MDMLabelsMode, labelsExcludeAny []string) (*MDMAppleConfigProfile, error)
 	// NewMDMAppleConfigProfileWithPayload creates a new declaration for the specified team.
 	// activation is an optional custom activation declaration to attach to the
-	// declaration; nil or empty means Fleet generates the activation as before.
+	// declaration; nil or empty means Fleet generates the activation.
 	NewMDMAppleDeclaration(ctx context.Context, teamID uint, data []byte, labelsInclude []string, name string, labelsMembershipMode MDMLabelsMode, labelsExcludeAny []string, activation []byte) (*MDMAppleDeclaration, error)
 
 	// GetMDMAppleConfigProfileByDeprecatedID retrieves the specified Apple

--- a/server/mock/service/service_mock.go
+++ b/server/mock/service/service_mock.go
@@ -754,6 +754,8 @@ type NewMDMWindowsConfigProfileFunc func(ctx context.Context, teamID uint, profi
 
 type NewMDMUnsupportedConfigProfileFunc func(ctx context.Context, teamID uint, filename string) error
 
+type NewMDMActivationUnsupportedProfileFunc func(ctx context.Context, teamID uint) error
+
 type NewMDMInvalidJSONConfigProfileFunc func(ctx context.Context, teamID uint, err error) error
 
 type UpdateMDMConfigProfileFunc func(ctx context.Context, profileUUID string, profile []byte, labelsInclude []string, labelsMembershipMode fleet.MDMLabelsMode, labelsExcludeAny []string, activation []byte) error
@@ -2085,6 +2087,9 @@ type Service struct {
 
 	NewMDMUnsupportedConfigProfileFunc        NewMDMUnsupportedConfigProfileFunc
 	NewMDMUnsupportedConfigProfileFuncInvoked bool
+
+	NewMDMActivationUnsupportedProfileFunc        NewMDMActivationUnsupportedProfileFunc
+	NewMDMActivationUnsupportedProfileFuncInvoked bool
 
 	NewMDMInvalidJSONConfigProfileFunc        NewMDMInvalidJSONConfigProfileFunc
 	NewMDMInvalidJSONConfigProfileFuncInvoked bool
@@ -5001,6 +5006,13 @@ func (s *Service) NewMDMUnsupportedConfigProfile(ctx context.Context, teamID uin
 	s.NewMDMUnsupportedConfigProfileFuncInvoked = true
 	s.mu.Unlock()
 	return s.NewMDMUnsupportedConfigProfileFunc(ctx, teamID, filename)
+}
+
+func (s *Service) NewMDMActivationUnsupportedProfile(ctx context.Context, teamID uint) error {
+	s.mu.Lock()
+	s.NewMDMActivationUnsupportedProfileFuncInvoked = true
+	s.mu.Unlock()
+	return s.NewMDMActivationUnsupportedProfileFunc(ctx, teamID)
 }
 
 func (s *Service) NewMDMInvalidJSONConfigProfile(ctx context.Context, teamID uint, err error) error {

--- a/server/mock/service/service_mock.go
+++ b/server/mock/service/service_mock.go
@@ -756,7 +756,7 @@ type NewMDMUnsupportedConfigProfileFunc func(ctx context.Context, teamID uint, f
 
 type NewMDMInvalidJSONConfigProfileFunc func(ctx context.Context, teamID uint, err error) error
 
-type UpdateMDMConfigProfileFunc func(ctx context.Context, profileUUID string, profile []byte, labelsInclude []string, labelsMembershipMode fleet.MDMLabelsMode, labelsExcludeAny []string) error
+type UpdateMDMConfigProfileFunc func(ctx context.Context, profileUUID string, profile []byte, labelsInclude []string, labelsMembershipMode fleet.MDMLabelsMode, labelsExcludeAny []string, activation []byte) error
 
 type ListMDMConfigProfilesFunc func(ctx context.Context, teamID *uint, opt fleet.ListOptions) ([]*fleet.MDMConfigProfilePayload, *fleet.PaginationMetadata, error)
 
@@ -5010,11 +5010,11 @@ func (s *Service) NewMDMInvalidJSONConfigProfile(ctx context.Context, teamID uin
 	return s.NewMDMInvalidJSONConfigProfileFunc(ctx, teamID, err)
 }
 
-func (s *Service) UpdateMDMConfigProfile(ctx context.Context, profileUUID string, profile []byte, labelsInclude []string, labelsMembershipMode fleet.MDMLabelsMode, labelsExcludeAny []string) error {
+func (s *Service) UpdateMDMConfigProfile(ctx context.Context, profileUUID string, profile []byte, labelsInclude []string, labelsMembershipMode fleet.MDMLabelsMode, labelsExcludeAny []string, activation []byte) error {
 	s.mu.Lock()
 	s.UpdateMDMConfigProfileFuncInvoked = true
 	s.mu.Unlock()
-	return s.UpdateMDMConfigProfileFunc(ctx, profileUUID, profile, labelsInclude, labelsMembershipMode, labelsExcludeAny)
+	return s.UpdateMDMConfigProfileFunc(ctx, profileUUID, profile, labelsInclude, labelsMembershipMode, labelsExcludeAny, activation)
 }
 
 func (s *Service) ListMDMConfigProfiles(ctx context.Context, teamID *uint, opt fleet.ListOptions) ([]*fleet.MDMConfigProfilePayload, *fleet.PaginationMetadata, error) {

--- a/server/mock/service/service_mock.go
+++ b/server/mock/service/service_mock.go
@@ -582,7 +582,7 @@ type GetHostDEPAssignmentDetailsFunc func(ctx context.Context, hostID uint) (*fl
 
 type NewMDMAppleConfigProfileFunc func(ctx context.Context, teamID uint, data []byte, labelsInclude []string, labelsMembershipMode fleet.MDMLabelsMode, labelsExcludeAny []string) (*fleet.MDMAppleConfigProfile, error)
 
-type NewMDMAppleDeclarationFunc func(ctx context.Context, teamID uint, data []byte, labelsInclude []string, name string, labelsMembershipMode fleet.MDMLabelsMode, labelsExcludeAny []string) (*fleet.MDMAppleDeclaration, error)
+type NewMDMAppleDeclarationFunc func(ctx context.Context, teamID uint, data []byte, labelsInclude []string, name string, labelsMembershipMode fleet.MDMLabelsMode, labelsExcludeAny []string, activation []byte) (*fleet.MDMAppleDeclaration, error)
 
 type GetMDMAppleConfigProfileByDeprecatedIDFunc func(ctx context.Context, profileID uint) (*fleet.MDMAppleConfigProfile, error)
 
@@ -4401,11 +4401,11 @@ func (s *Service) NewMDMAppleConfigProfile(ctx context.Context, teamID uint, dat
 	return s.NewMDMAppleConfigProfileFunc(ctx, teamID, data, labelsInclude, labelsMembershipMode, labelsExcludeAny)
 }
 
-func (s *Service) NewMDMAppleDeclaration(ctx context.Context, teamID uint, data []byte, labelsInclude []string, name string, labelsMembershipMode fleet.MDMLabelsMode, labelsExcludeAny []string) (*fleet.MDMAppleDeclaration, error) {
+func (s *Service) NewMDMAppleDeclaration(ctx context.Context, teamID uint, data []byte, labelsInclude []string, name string, labelsMembershipMode fleet.MDMLabelsMode, labelsExcludeAny []string, activation []byte) (*fleet.MDMAppleDeclaration, error) {
 	s.mu.Lock()
 	s.NewMDMAppleDeclarationFuncInvoked = true
 	s.mu.Unlock()
-	return s.NewMDMAppleDeclarationFunc(ctx, teamID, data, labelsInclude, name, labelsMembershipMode, labelsExcludeAny)
+	return s.NewMDMAppleDeclarationFunc(ctx, teamID, data, labelsInclude, name, labelsMembershipMode, labelsExcludeAny, activation)
 }
 
 func (s *Service) GetMDMAppleConfigProfileByDeprecatedID(ctx context.Context, profileID uint) (*fleet.MDMAppleConfigProfile, error) {

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -1185,7 +1185,7 @@ func (svc *Service) parseAndValidateAppleDeclaration(ctx context.Context, teamID
 // mdm_apple_declarations.token is a MySQL generated column derived from
 // raw_json, so the ReconcileAppleDeclarations cron picks up a content change
 // on its own.
-func (svc *Service) updateMDMAppleDeclaration(ctx context.Context, profileUUID string, profile []byte, labelsInclude []string, labelsMembershipMode fleet.MDMLabelsMode, labelsExcludeAny []string) error {
+func (svc *Service) updateMDMAppleDeclaration(ctx context.Context, profileUUID string, profile []byte, labelsInclude []string, labelsMembershipMode fleet.MDMLabelsMode, labelsExcludeAny []string, activation []byte) error {
 	// first we perform a basic authz check
 	if err := svc.authz.Authorize(ctx, &fleet.Team{}, fleet.ActionRead); err != nil {
 		return ctxerr.Wrap(ctx, err)
@@ -1257,6 +1257,10 @@ func (svc *Service) updateMDMAppleDeclaration(ctx context.Context, profileUUID s
 			// the upsert writes scope unconditionally, so the unchanged
 			// content's scope must be carried over or it would be cleared
 			Scope: existing.Scope,
+			// carry the stored activation forward: the datastore clears the
+			// activation of any declaration written without one, so a
+			// labels-only edit would otherwise silently remove it
+			Activation: existing.Activation,
 		}
 		switch labelsMembershipMode {
 		case fleet.LabelsIncludeAll:
@@ -1265,6 +1269,32 @@ func (svc *Service) updateMDMAppleDeclaration(ctx context.Context, profileUUID s
 			decl.LabelsIncludeAny = includeLabels
 		}
 		decl.LabelsExcludeAny = excludeLabels
+	}
+
+	// A supplied activation always replaces whatever is stored. When new
+	// profile content is supplied without one, the activation is intentionally
+	// dropped, which is how an admin removes it -- matching the create path,
+	// where a declaration uploaded without an activation has none.
+	if len(activation) > 0 && decl.Type == "" {
+		// an activation-only or labels-plus-activation edit leaves the content
+		// untouched, so the Type -- which isn't a column -- has to be recovered
+		// from it to reject an activation on a management declaration
+		rawDecl, err := fleet.GetRawDeclarationValues(decl.RawJSON)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "parsing existing declaration")
+		}
+		decl.Type = rawDecl.Type
+	}
+	rawAct, err := svc.validateActivation(ctx, activation, decl.Identifier, decl.Type)
+	if err != nil {
+		return err
+	}
+	if rawAct != nil {
+		decl.Activation = &fleet.MDMAppleCustomActivation{
+			Identifier:              rawAct.Identifier,
+			RawJSON:                 activation,
+			ConfigurationIdentifier: decl.Identifier,
+		}
 	}
 
 	if _, err := svc.ds.SetOrUpdateMDMAppleDeclaration(ctx, decl, varNames); err != nil {

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -68,11 +68,11 @@ const (
 	// ActivationUnsupportedProfileErrorMsg is used by every path that accepts an
 	// activation (single upload here, batch/GitOps elsewhere) so the same
 	// mistake reads the same way wherever it's made.
-	ActivationUnsupportedProfileErrorMsg = "Couldn't add. Activations are only supported for declaration (DDM) profiles."
+	ActivationUnsupportedProfileErrorMsg = "Activations are only supported for declaration (DDM) profiles."
 
 	// ActivationUnsupportedManagementErrorMsg covers the narrower case of a DDM
 	// profile that is a management declaration, which is never activated.
-	ActivationUnsupportedManagementErrorMsg = "Couldn't add. Activations are only supported for configuration declarations (com.apple.configuration.)."
+	ActivationUnsupportedManagementErrorMsg = "Activations are only supported for configuration declarations (com.apple.configuration.)."
 )
 
 // TODO(HCA): Can we come up with a clearer name? This looks like any variables not in this slice is not supported,
@@ -992,7 +992,8 @@ func (svc *Service) validateActivation(ctx context.Context, activation []byte, c
 
 	// Unlike declarations, which are free for hosts on no fleet and without
 	// labels, custom activations are premium in every case.
-	if lic, _ := license.FromContext(ctx); lic == nil || !lic.IsPremium() {
+	lic, _ := license.FromContext(ctx)
+	if lic == nil || !lic.IsPremium() {
 		return nil, ctxerr.Wrap(ctx,
 			fleet.NewLicenseErrorWithCause(fleet.DDMCustomActivationPremiumCauseMsg),
 			"checking license for DDM custom activation")
@@ -1008,7 +1009,6 @@ func (svc *Service) validateActivation(ctx context.Context, activation []byte, c
 
 	// Activations support the same Fleet variables as the declarations they
 	// activate, so the declaration allowlist is reused rather than duplicated.
-	lic, _ := license.FromContext(ctx)
 	actVars, err := validateDeclarationFleetVariables(expanded, lic)
 	if err != nil {
 		if badReqErr, ok := errors.AsType[*fleet.BadRequestError](err); ok {

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -65,13 +65,8 @@ const (
 	SameProfileNameUploadErrorMsg = "Couldn't add. A configuration profile with this name already exists (PayloadDisplayName for .mobileconfig and file name for .json and .xml)."
 	limit10KiB                    = 10 * 1024
 
-	// ActivationUnsupportedProfileErrorMsg is used by every path that accepts an
-	// activation (single upload here, batch/GitOps elsewhere) so the same
-	// mistake reads the same way wherever it's made.
-	ActivationUnsupportedProfileErrorMsg = "Activations are only supported for declaration (DDM) profiles."
-
-	// ActivationUnsupportedManagementErrorMsg covers the narrower case of a DDM
-	// profile that is a management declaration, which is never activated.
+	// Shared with the batch/GitOps path so the same mistake reads the same way.
+	ActivationUnsupportedProfileErrorMsg    = "Activations are only supported for declaration (DDM) profiles."
 	ActivationUnsupportedManagementErrorMsg = "Activations are only supported for configuration declarations (com.apple.configuration.)."
 )
 
@@ -969,29 +964,20 @@ func additionalNDESValidation(contents string, ndesVars *NDESVarsFound) error {
 	return nil
 }
 
-// validateActivation parses and validates a user-provided custom activation
-// against the configuration declaration it is attached to. It returns nil when
-// no activation was supplied, leaving Fleet to generate one as before.
-//
-// Callers must pass the identifier of the declaration the activation ships
-// with: Fleet allows exactly one configuration per activation, and that
-// configuration is always the one being uploaded.
+// Returns nil when no activation was supplied, leaving Fleet to generate one.
 func (svc *Service) validateActivation(ctx context.Context, activation []byte, configurationIdentifier, declarationType string) (*fleet.MDMAppleCustomActivation, error) {
 	if len(activation) == 0 {
 		return nil, nil
 	}
 
-	// Management declarations (organization info, server info, properties) are
-	// never activated -- an activation's StandardConfigurations can only name
-	// configurations -- so attaching one is always a mistake.
-	if fleet.IsManagementDeclaration(declarationType) {
+	// Management declarations are never activated.
+	if strings.HasPrefix(declarationType, fleet.MDMAppleManagementTypePrefix) {
 		return nil, ctxerr.Wrap(ctx,
 			fleet.NewInvalidArgumentError("activation", ActivationUnsupportedManagementErrorMsg),
 			"activation supplied for a management declaration")
 	}
 
-	// Unlike declarations, which are free for hosts on no fleet and without
-	// labels, custom activations are premium in every case.
+	// Declarations are free when unassigned and unlabeled; activations never are.
 	lic, _ := license.FromContext(ctx)
 	if lic == nil || !lic.IsPremium() {
 		return nil, ctxerr.Wrap(ctx,
@@ -999,16 +985,13 @@ func (svc *Service) validateActivation(ctx context.Context, activation []byte, c
 			"checking license for DDM custom activation")
 	}
 
-	// Expand $FLEET_SECRET_* before validating so the checks below run against
-	// the document the device will actually receive, mirroring how declarations
-	// are validated.
+	// Validate against the document the device will receive.
 	expanded, secretsUpdatedAt, err := svc.ds.ExpandEmbeddedSecretsAndUpdatedAt(ctx, string(activation))
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("activation", err.Error()), "expanding activation secrets")
 	}
 
-	// Activations support the same Fleet variables as the declarations they
-	// activate, so the declaration allowlist is reused rather than duplicated.
+	// Same allowlist as the declarations they activate.
 	actVars, err := validateDeclarationFleetVariables(expanded, lic)
 	if err != nil {
 		if badReqErr, ok := errors.AsType[*fleet.BadRequestError](err); ok {
@@ -1039,8 +1022,7 @@ func (svc *Service) validateActivation(ctx context.Context, activation []byte, c
 		varNames = append(varNames, fleet.FleetVarName(v))
 	}
 
-	// The unexpanded bytes are stored: secrets are re-expanded at delivery, so
-	// keeping them expanded here would persist the secret values.
+	// Store unexpanded; secrets are re-expanded at delivery.
 	return &fleet.MDMAppleCustomActivation{
 		Identifier:              rawAct.Identifier,
 		RawJSON:                 activation,
@@ -1284,10 +1266,8 @@ func (svc *Service) updateMDMAppleDeclaration(ctx context.Context, profileUUID s
 		for _, v := range variables.Find(expanded) {
 			varNames = append(varNames, fleet.FleetVarName(v))
 		}
-		// The stored activation is loaded without its Fleet variables, and the
-		// datastore rewrites an activation's variable associations from
-		// whatever it is handed. Re-derive them from the activation's own
-		// content, for the same reason the declaration's are re-derived above.
+		// Loaded without its variables, and the datastore rewrites associations
+		// from whatever it's handed, so re-derive them as above.
 		carriedActivation := existing.Activation
 		if carriedActivation != nil {
 			expandedAct, _, err := svc.ds.ExpandEmbeddedSecretsAndUpdatedAt(ctx, string(carriedActivation.RawJSON))
@@ -1298,7 +1278,6 @@ func (svc *Service) updateMDMAppleDeclaration(ctx context.Context, profileUUID s
 			for _, v := range variables.Find(expandedAct) {
 				actVarNames = append(actVarNames, fleet.FleetVarName(v))
 			}
-			// copy so the loaded row isn't mutated in place
 			carried := *carriedActivation
 			carried.FleetVariables = actVarNames
 			carriedActivation = &carried
@@ -1312,9 +1291,7 @@ func (svc *Service) updateMDMAppleDeclaration(ctx context.Context, profileUUID s
 			// the upsert writes scope unconditionally, so the unchanged
 			// content's scope must be carried over or it would be cleared
 			Scope: existing.Scope,
-			// carry the stored activation forward: the datastore clears the
-			// activation of any declaration written without one, so a
-			// labels-only edit would otherwise silently remove it
+			// a declaration written without one has its activation cleared
 			Activation: carriedActivation,
 		}
 		switch labelsMembershipMode {
@@ -1326,14 +1303,10 @@ func (svc *Service) updateMDMAppleDeclaration(ctx context.Context, profileUUID s
 		decl.LabelsExcludeAny = excludeLabels
 	}
 
-	// A supplied activation always replaces whatever is stored. When new
-	// profile content is supplied without one, the activation is intentionally
-	// dropped, which is how an admin removes it -- matching the create path,
-	// where a declaration uploaded without an activation has none.
+	// A supplied activation replaces the stored one; new content without one
+	// drops it, which is how an admin removes it.
 	if len(activation) > 0 && decl.Type == "" {
-		// an activation-only or labels-plus-activation edit leaves the content
-		// untouched, so the Type -- which isn't a column -- has to be recovered
-		// from it to reject an activation on a management declaration
+		// content is unchanged, so recover Type for the management check
 		rawDecl, err := fleet.GetRawDeclarationValues(decl.RawJSON)
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "parsing existing declaration")

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -1284,6 +1284,25 @@ func (svc *Service) updateMDMAppleDeclaration(ctx context.Context, profileUUID s
 		for _, v := range variables.Find(expanded) {
 			varNames = append(varNames, fleet.FleetVarName(v))
 		}
+		// The stored activation is loaded without its Fleet variables, and the
+		// datastore rewrites an activation's variable associations from
+		// whatever it is handed. Re-derive them from the activation's own
+		// content, for the same reason the declaration's are re-derived above.
+		carriedActivation := existing.Activation
+		if carriedActivation != nil {
+			expandedAct, _, err := svc.ds.ExpandEmbeddedSecretsAndUpdatedAt(ctx, string(carriedActivation.RawJSON))
+			if err != nil {
+				return ctxerr.Wrap(ctx, err, "expanding secrets for existing activation")
+			}
+			actVarNames := make([]fleet.FleetVarName, 0, len(carriedActivation.FleetVariables))
+			for _, v := range variables.Find(expandedAct) {
+				actVarNames = append(actVarNames, fleet.FleetVarName(v))
+			}
+			// copy so the loaded row isn't mutated in place
+			carried := *carriedActivation
+			carried.FleetVariables = actVarNames
+			carriedActivation = &carried
+		}
 		decl = &fleet.MDMAppleDeclaration{
 			Name:             existing.Name,
 			Identifier:       existing.Identifier,
@@ -1296,7 +1315,7 @@ func (svc *Service) updateMDMAppleDeclaration(ctx context.Context, profileUUID s
 			// carry the stored activation forward: the datastore clears the
 			// activation of any declaration written without one, so a
 			// labels-only edit would otherwise silently remove it
-			Activation: existing.Activation,
+			Activation: carriedActivation,
 		}
 		switch labelsMembershipMode {
 		case fleet.LabelsIncludeAll:

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -1033,8 +1033,16 @@ func (svc *Service) NewMDMAppleDeclaration(ctx context.Context, teamID uint, dat
 		return nil, err
 	}
 
-	if _, err := svc.validateActivation(ctx, activation, d.Identifier, d.Type); err != nil {
+	rawAct, err := svc.validateActivation(ctx, activation, d.Identifier, d.Type)
+	if err != nil {
 		return nil, err
+	}
+	if rawAct != nil {
+		d.Activation = &fleet.MDMAppleCustomActivation{
+			Identifier:              rawAct.Identifier,
+			RawJSON:                 activation,
+			ConfigurationIdentifier: d.Identifier,
+		}
 	}
 
 	decl, err := svc.ds.NewMDMAppleDeclaration(ctx, d, varNames)

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -976,7 +976,7 @@ func additionalNDESValidation(contents string, ndesVars *NDESVarsFound) error {
 // Callers must pass the identifier of the declaration the activation ships
 // with: Fleet allows exactly one configuration per activation, and that
 // configuration is always the one being uploaded.
-func (svc *Service) validateActivation(ctx context.Context, activation []byte, configurationIdentifier, declarationType string) (*fleet.MDMAppleRawActivation, error) {
+func (svc *Service) validateActivation(ctx context.Context, activation []byte, configurationIdentifier, declarationType string) (*fleet.MDMAppleCustomActivation, error) {
 	if len(activation) == 0 {
 		return nil, nil
 	}
@@ -998,7 +998,34 @@ func (svc *Service) validateActivation(ctx context.Context, activation []byte, c
 			"checking license for DDM custom activation")
 	}
 
-	rawAct, err := fleet.GetRawActivationValues(activation)
+	// Expand $FLEET_SECRET_* before validating so the checks below run against
+	// the document the device will actually receive, mirroring how declarations
+	// are validated.
+	expanded, secretsUpdatedAt, err := svc.ds.ExpandEmbeddedSecretsAndUpdatedAt(ctx, string(activation))
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("activation", err.Error()), "expanding activation secrets")
+	}
+
+	// Activations support the same Fleet variables as the declarations they
+	// activate, so the declaration allowlist is reused rather than duplicated.
+	lic, _ := license.FromContext(ctx)
+	actVars, err := validateDeclarationFleetVariables(expanded, lic)
+	if err != nil {
+		if badReqErr, ok := errors.AsType[*fleet.BadRequestError](err); ok {
+			badReqErr.Message = "Couldn't upload activation. " + badReqErr.Message
+			err = badReqErr
+		}
+		return nil, ctxerr.Wrap(ctx, err, "validating activation Fleet variables")
+	}
+
+	if err := svc.ds.ValidateReferencedCustomHostVitals(ctx, []string{string(activation)}); err != nil {
+		if !fleet.IsInvalidReferencedCustomHostVitalsError(err) {
+			return nil, ctxerr.Wrap(ctx, err, "validating activation custom host vitals")
+		}
+		return nil, ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("activation", err.Error()))
+	}
+
+	rawAct, err := fleet.GetRawActivationValues([]byte(expanded))
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "parsing activation")
 	}
@@ -1007,7 +1034,20 @@ func (svc *Service) validateActivation(ctx context.Context, activation []byte, c
 		return nil, ctxerr.Wrap(ctx, err, "validating activation")
 	}
 
-	return rawAct, nil
+	varNames := make([]fleet.FleetVarName, 0, len(actVars))
+	for _, v := range actVars {
+		varNames = append(varNames, fleet.FleetVarName(v))
+	}
+
+	// The unexpanded bytes are stored: secrets are re-expanded at delivery, so
+	// keeping them expanded here would persist the secret values.
+	return &fleet.MDMAppleCustomActivation{
+		Identifier:              rawAct.Identifier,
+		RawJSON:                 activation,
+		ConfigurationIdentifier: configurationIdentifier,
+		SecretsUpdatedAt:        secretsUpdatedAt,
+		FleetVariables:          varNames,
+	}, nil
 }
 
 func (svc *Service) NewMDMAppleDeclaration(ctx context.Context, teamID uint, data []byte, labelsInclude []string, name string, labelsMembershipMode fleet.MDMLabelsMode, labelsExcludeAny []string, activation []byte) (*fleet.MDMAppleDeclaration, error) {
@@ -1038,11 +1078,7 @@ func (svc *Service) NewMDMAppleDeclaration(ctx context.Context, teamID uint, dat
 		return nil, err
 	}
 	if rawAct != nil {
-		d.Activation = &fleet.MDMAppleCustomActivation{
-			Identifier:              rawAct.Identifier,
-			RawJSON:                 activation,
-			ConfigurationIdentifier: d.Identifier,
-		}
+		d.Activation = rawAct
 	}
 
 	decl, err := svc.ds.NewMDMAppleDeclaration(ctx, d, varNames)
@@ -1290,11 +1326,7 @@ func (svc *Service) updateMDMAppleDeclaration(ctx context.Context, profileUUID s
 		return err
 	}
 	if rawAct != nil {
-		decl.Activation = &fleet.MDMAppleCustomActivation{
-			Identifier:              rawAct.Identifier,
-			RawJSON:                 activation,
-			ConfigurationIdentifier: decl.Identifier,
-		}
+		decl.Activation = rawAct
 	}
 
 	if _, err := svc.ds.SetOrUpdateMDMAppleDeclaration(ctx, decl, varNames); err != nil {

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -69,6 +69,10 @@ const (
 	// activation (single upload here, batch/GitOps elsewhere) so the same
 	// mistake reads the same way wherever it's made.
 	ActivationUnsupportedProfileErrorMsg = "Couldn't add. Activations are only supported for declaration (DDM) profiles."
+
+	// ActivationUnsupportedManagementErrorMsg covers the narrower case of a DDM
+	// profile that is a management declaration, which is never activated.
+	ActivationUnsupportedManagementErrorMsg = "Couldn't add. Activations are only supported for configuration declarations (com.apple.configuration.)."
 )
 
 // TODO(HCA): Can we come up with a clearer name? This looks like any variables not in this slice is not supported,
@@ -972,9 +976,18 @@ func additionalNDESValidation(contents string, ndesVars *NDESVarsFound) error {
 // Callers must pass the identifier of the declaration the activation ships
 // with: Fleet allows exactly one configuration per activation, and that
 // configuration is always the one being uploaded.
-func (svc *Service) validateActivation(ctx context.Context, activation []byte, configurationIdentifier string) (*fleet.MDMAppleRawActivation, error) {
+func (svc *Service) validateActivation(ctx context.Context, activation []byte, configurationIdentifier, declarationType string) (*fleet.MDMAppleRawActivation, error) {
 	if len(activation) == 0 {
 		return nil, nil
+	}
+
+	// Management declarations (organization info, server info, properties) are
+	// never activated -- an activation's StandardConfigurations can only name
+	// configurations -- so attaching one is always a mistake.
+	if fleet.IsManagementDeclaration(declarationType) {
+		return nil, ctxerr.Wrap(ctx,
+			fleet.NewInvalidArgumentError("activation", ActivationUnsupportedManagementErrorMsg),
+			"activation supplied for a management declaration")
 	}
 
 	// Unlike declarations, which are free for hosts on no fleet and without
@@ -1020,7 +1033,7 @@ func (svc *Service) NewMDMAppleDeclaration(ctx context.Context, teamID uint, dat
 		return nil, err
 	}
 
-	if _, err := svc.validateActivation(ctx, activation, d.Identifier); err != nil {
+	if _, err := svc.validateActivation(ctx, activation, d.Identifier, d.Type); err != nil {
 		return nil, err
 	}
 

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -64,6 +64,11 @@ const (
 	maxValueCharsInError          = 100
 	SameProfileNameUploadErrorMsg = "Couldn't add. A configuration profile with this name already exists (PayloadDisplayName for .mobileconfig and file name for .json and .xml)."
 	limit10KiB                    = 10 * 1024
+
+	// ActivationUnsupportedProfileErrorMsg is used by every path that accepts an
+	// activation (single upload here, batch/GitOps elsewhere) so the same
+	// mistake reads the same way wherever it's made.
+	ActivationUnsupportedProfileErrorMsg = "Couldn't add. Activations are only supported for declaration (DDM) profiles."
 )
 
 // TODO(HCA): Can we come up with a clearer name? This looks like any variables not in this slice is not supported,
@@ -960,7 +965,39 @@ func additionalNDESValidation(contents string, ndesVars *NDESVarsFound) error {
 	return nil
 }
 
-func (svc *Service) NewMDMAppleDeclaration(ctx context.Context, teamID uint, data []byte, labelsInclude []string, name string, labelsMembershipMode fleet.MDMLabelsMode, labelsExcludeAny []string) (*fleet.MDMAppleDeclaration, error) {
+// validateActivation parses and validates a user-provided custom activation
+// against the configuration declaration it is attached to. It returns nil when
+// no activation was supplied, leaving Fleet to generate one as before.
+//
+// Callers must pass the identifier of the declaration the activation ships
+// with: Fleet allows exactly one configuration per activation, and that
+// configuration is always the one being uploaded.
+func (svc *Service) validateActivation(ctx context.Context, activation []byte, configurationIdentifier string) (*fleet.MDMAppleRawActivation, error) {
+	if len(activation) == 0 {
+		return nil, nil
+	}
+
+	// Unlike declarations, which are free for hosts on no fleet and without
+	// labels, custom activations are premium in every case.
+	if lic, _ := license.FromContext(ctx); lic == nil || !lic.IsPremium() {
+		return nil, ctxerr.Wrap(ctx,
+			fleet.NewLicenseErrorWithCause(fleet.DDMCustomActivationPremiumCauseMsg),
+			"checking license for DDM custom activation")
+	}
+
+	rawAct, err := fleet.GetRawActivationValues(activation)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "parsing activation")
+	}
+
+	if err := rawAct.ValidateUserProvided(configurationIdentifier); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "validating activation")
+	}
+
+	return rawAct, nil
+}
+
+func (svc *Service) NewMDMAppleDeclaration(ctx context.Context, teamID uint, data []byte, labelsInclude []string, name string, labelsMembershipMode fleet.MDMLabelsMode, labelsExcludeAny []string, activation []byte) (*fleet.MDMAppleDeclaration, error) {
 	if err := svc.authz.Authorize(ctx, &fleet.MDMConfigProfileAuthz{TeamID: &teamID}, fleet.ActionWrite); err != nil {
 		return nil, ctxerr.Wrap(ctx, err)
 	}
@@ -980,6 +1017,10 @@ func (svc *Service) NewMDMAppleDeclaration(ctx context.Context, teamID uint, dat
 
 	d, varNames, teamName, err := svc.parseAndValidateAppleDeclaration(ctx, teamID, name, data, labelsInclude, labelsMembershipMode, labelsExcludeAny)
 	if err != nil {
+		return nil, err
+	}
+
+	if _, err := svc.validateActivation(ctx, activation, d.Identifier); err != nil {
 		return nil, err
 	}
 

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -965,19 +965,18 @@ func additionalNDESValidation(contents string, ndesVars *NDESVarsFound) error {
 }
 
 // Returns nil when no activation was supplied, leaving Fleet to generate one.
-func (svc *Service) validateActivation(ctx context.Context, activation []byte, configurationIdentifier, declarationType string) (*fleet.MDMAppleCustomActivation, error) {
+func (svc *Service) validateActivation(ctx context.Context, activation []byte, configurationIdentifier, configurationType string) (*fleet.MDMAppleCustomActivation, error) {
 	if len(activation) == 0 {
 		return nil, nil
 	}
 
 	// Management declarations are never activated.
-	if strings.HasPrefix(declarationType, fleet.MDMAppleManagementTypePrefix) {
+	if strings.HasPrefix(configurationType, fleet.MDMAppleManagementTypePrefix) {
 		return nil, ctxerr.Wrap(ctx,
 			fleet.NewInvalidArgumentError("activation", ActivationUnsupportedManagementErrorMsg),
 			"activation supplied for a management declaration")
 	}
 
-	// Declarations are free when unassigned and unlabeled; activations never are.
 	lic, _ := license.FromContext(ctx)
 	if lic == nil || !lic.IsPremium() {
 		return nil, ctxerr.Wrap(ctx,
@@ -1055,12 +1054,12 @@ func (svc *Service) NewMDMAppleDeclaration(ctx context.Context, teamID uint, dat
 		return nil, err
 	}
 
-	rawAct, err := svc.validateActivation(ctx, activation, d.Identifier, d.Type)
+	customActivation, err := svc.validateActivation(ctx, activation, d.Identifier, d.Type)
 	if err != nil {
 		return nil, err
 	}
-	if rawAct != nil {
-		d.Activation = rawAct
+	if customActivation != nil {
+		d.Activation = customActivation
 	}
 
 	decl, err := svc.ds.NewMDMAppleDeclaration(ctx, d, varNames)
@@ -1313,12 +1312,12 @@ func (svc *Service) updateMDMAppleDeclaration(ctx context.Context, profileUUID s
 		}
 		decl.Type = rawDecl.Type
 	}
-	rawAct, err := svc.validateActivation(ctx, activation, decl.Identifier, decl.Type)
+	customActivation, err := svc.validateActivation(ctx, activation, decl.Identifier, decl.Type)
 	if err != nil {
 		return err
 	}
-	if rawAct != nil {
-		decl.Activation = rawAct
+	if customActivation != nil {
+		decl.Activation = customActivation
 	}
 
 	if _, err := svc.ds.SetOrUpdateMDMAppleDeclaration(ctx, decl, varNames); err != nil {

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -1369,7 +1369,7 @@ func TestNewMDMAppleDeclaration(t *testing.T) {
 	// decl type missing actual type
 	b = declarationForTestWithType("D1", "com.apple.configuration")
 	_, err = svc.NewMDMAppleDeclaration(ctx, 0, b, nil, "name", fleet.LabelsIncludeAll, nil, nil)
-	assert.ErrorContains(t, err, "Only configuration declarations (com.apple.configuration.) and management declarations (com.apple.management.) are supported")
+	require.ErrorContains(t, err, "Only configuration declarations (com.apple.configuration.) and management declarations (com.apple.management.) are supported")
 
 	ds.NewMDMAppleDeclarationFunc = func(ctx context.Context, d *fleet.MDMAppleDeclaration, usesFleetVars []fleet.FleetVarName) (*fleet.MDMAppleDeclaration, error) {
 		return d, nil

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -1536,6 +1536,38 @@ func TestUpdateMDMAppleDeclaration(t *testing.T) {
 		assert.Equal(t, stored.Identifier, updated.Activation.Identifier)
 	})
 
+	t.Run("labels-only update re-derives the activation's Fleet variables", func(t *testing.T) {
+		svc, ctx, ds, _ := setup(t, &fleet.LicenseInfo{Tier: fleet.TierPremium})
+		existing := newExistingDeclaration("Test Declaration", "com.fleet.configD1", 0)
+		// the stored activation is loaded without its variables, exactly as
+		// GetMDMAppleDeclaration returns it
+		existing.Activation = &fleet.MDMAppleCustomActivation{
+			Identifier: "com.fleet.actD1",
+			RawJSON: []byte(`{"Type":"com.apple.activation.simple","Identifier":"com.fleet.actD1",` +
+				`"Payload":{"StandardConfigurations":["com.fleet.configD1"],"Predicate":"$FLEET_VAR_HOST_UUID"}}`),
+			ConfigurationIdentifier: "com.fleet.configD1",
+		}
+
+		ds.GetMDMAppleDeclarationFunc = func(ctx context.Context, duid string) (*fleet.MDMAppleDeclaration, error) {
+			return existing, nil
+		}
+		var updated *fleet.MDMAppleDeclaration
+		ds.SetOrUpdateMDMAppleDeclarationFunc = func(ctx context.Context, d *fleet.MDMAppleDeclaration, usesFleetVars []fleet.FleetVarName) (*fleet.MDMAppleDeclaration, error) {
+			updated = d
+			return d, nil
+		}
+
+		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, nil, []string{"label-1"}, fleet.LabelsIncludeAll, nil, nil)
+		require.NoError(t, err)
+
+		// the datastore rewrites an activation's variable associations from
+		// whatever it's handed, so carrying it forward without re-deriving
+		// these would wipe them
+		require.NotNil(t, updated)
+		require.NotNil(t, updated.Activation)
+		assert.Equal(t, []fleet.FleetVarName{fleet.FleetVarHostUUID}, updated.Activation.FleetVariables)
+	})
+
 	t.Run("new content without an activation clears the stored one", func(t *testing.T) {
 		svc, ctx, ds, _ := setup(t, &fleet.LicenseInfo{Tier: fleet.TierPremium})
 		existing := newExistingDeclaration("Test Declaration", "com.fleet.configD1", 0)
@@ -9485,6 +9517,13 @@ func TestNewMDMAppleDeclarationWithActivation(t *testing.T) {
 		d, err := svc.NewMDMAppleDeclaration(ctx, 0, decl, nil, "name", fleet.LabelsIncludeAll, nil, activation)
 		require.NoError(t, err)
 		require.NotNil(t, d)
+
+		require.NotNil(t, d.Activation)
+		assert.Equal(t, "com.fleet.actD1", d.Activation.Identifier)
+		assert.Equal(t, declIdentifier, d.Activation.ConfigurationIdentifier)
+		// the whole document is stored verbatim, Predicate included -- Fleet
+		// never interprets it
+		assert.JSONEq(t, string(activation), string(d.Activation.RawJSON))
 	})
 
 	t.Run("activation referencing another configuration is rejected", func(t *testing.T) {

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -889,7 +889,7 @@ func TestNewMDMAppleDeclarationCustomHostVitalErrors(t *testing.T) {
 		ds.ValidateReferencedCustomHostVitalsFunc = func(ctx context.Context, documents []string) error {
 			return &fleet.MissingCustomHostVitalsError{MissingIDs: []uint{5}}
 		}
-		_, err := svc.NewMDMAppleDeclaration(ctx, 0, b, nil, "name", fleet.LabelsIncludeAll, nil)
+		_, err := svc.NewMDMAppleDeclaration(ctx, 0, b, nil, "name", fleet.LabelsIncludeAll, nil, nil)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "FLEET_HOST_VITAL_5")
 		var invalidArgErr *fleet.InvalidArgumentError
@@ -900,7 +900,7 @@ func TestNewMDMAppleDeclarationCustomHostVitalErrors(t *testing.T) {
 		ds.ValidateReferencedCustomHostVitalsFunc = func(ctx context.Context, documents []string) error {
 			return ctxerr.Wrap(ctx, errors.New("connection refused"), "validating custom host vitals")
 		}
-		_, err := svc.NewMDMAppleDeclaration(ctx, 0, b, nil, "name", fleet.LabelsIncludeAll, nil)
+		_, err := svc.NewMDMAppleDeclaration(ctx, 0, b, nil, "name", fleet.LabelsIncludeAll, nil, nil)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "connection refused")
 		var invalidArgErr *fleet.InvalidArgumentError
@@ -1338,7 +1338,7 @@ func TestNewMDMAppleDeclarationFreeLicenseTeam(t *testing.T) {
 
 	b := declBytesForTest("D1", "d1content")
 
-	_, err := svc.NewMDMAppleDeclaration(ctx, 1, b, nil, "name", fleet.LabelsIncludeAll, nil)
+	_, err := svc.NewMDMAppleDeclaration(ctx, 1, b, nil, "name", fleet.LabelsIncludeAll, nil, nil)
 	assert.ErrorIs(t, err, fleet.ErrMissingLicense)
 }
 
@@ -1348,11 +1348,11 @@ func TestNewMDMAppleDeclarationFreeLicenseLabels(t *testing.T) {
 
 	b := declBytesForTest("D1", "d1content")
 
-	_, err := svc.NewMDMAppleDeclaration(ctx, 0, b, []string{"label-1"}, "name", fleet.LabelsIncludeAll, nil)
+	_, err := svc.NewMDMAppleDeclaration(ctx, 0, b, []string{"label-1"}, "name", fleet.LabelsIncludeAll, nil, nil)
 	require.ErrorIs(t, err, fleet.ErrMissingLicense)
 	require.ErrorContains(t, err, "Scoping configuration profile")
 
-	_, err = svc.NewMDMAppleDeclaration(ctx, 0, b, nil, "name", fleet.LabelsIncludeAll, []string{"label-1"})
+	_, err = svc.NewMDMAppleDeclaration(ctx, 0, b, nil, "name", fleet.LabelsIncludeAll, []string{"label-1"}, nil)
 	require.ErrorIs(t, err, fleet.ErrMissingLicense)
 	require.ErrorContains(t, err, "Scoping configuration profile")
 }
@@ -1363,12 +1363,12 @@ func TestNewMDMAppleDeclaration(t *testing.T) {
 
 	// Unsupported Fleet variable
 	b := declBytesForTest("D1", "d1content $FLEET_VAR_BOZO")
-	_, err := svc.NewMDMAppleDeclaration(ctx, 0, b, nil, "name", fleet.LabelsIncludeAll, nil)
+	_, err := svc.NewMDMAppleDeclaration(ctx, 0, b, nil, "name", fleet.LabelsIncludeAll, nil, nil)
 	assert.ErrorContains(t, err, "Fleet variable")
 
 	// decl type missing actual type
 	b = declarationForTestWithType("D1", "com.apple.configuration")
-	_, err = svc.NewMDMAppleDeclaration(ctx, 0, b, nil, "name", fleet.LabelsIncludeAll, nil)
+	_, err = svc.NewMDMAppleDeclaration(ctx, 0, b, nil, "name", fleet.LabelsIncludeAll, nil, nil)
 	assert.ErrorContains(t, err, "Only configuration declarations (com.apple.configuration.) are supported")
 
 	ds.NewMDMAppleDeclarationFunc = func(ctx context.Context, d *fleet.MDMAppleDeclaration, usesFleetVars []fleet.FleetVarName) (*fleet.MDMAppleDeclaration, error) {
@@ -1388,12 +1388,12 @@ func TestNewMDMAppleDeclaration(t *testing.T) {
 
 	// decl using a missing asset
 	b = declarationForTestWithAssetReference("D1", "missing-asset")
-	_, err = svc.NewMDMAppleDeclaration(ctx, 0, b, nil, "name", fleet.LabelsIncludeAll, nil)
+	_, err = svc.NewMDMAppleDeclaration(ctx, 0, b, nil, "name", fleet.LabelsIncludeAll, nil, nil)
 	require.ErrorContains(t, err, `Asset ("missing-asset") doesn't exist`)
 
 	// Good declaration
 	b = declarationForTestWithAssetReference("D1", "valid-asset")
-	d, err := svc.NewMDMAppleDeclaration(ctx, 0, b, nil, "name", fleet.LabelsIncludeAll, nil)
+	d, err := svc.NewMDMAppleDeclaration(ctx, 0, b, nil, "name", fleet.LabelsIncludeAll, nil, nil)
 	require.NoError(t, err)
 	assert.NotNil(t, d)
 }
@@ -1777,7 +1777,7 @@ func TestNewMDMAppleDeclarationSkipValidation(t *testing.T) {
 			"Identifier": "test-status-sub",
 			"Payload": {}
 		}`)
-		_, err := svc.NewMDMAppleDeclaration(ctx, 0, b, nil, "test-status-sub", fleet.LabelsIncludeAll, nil)
+		_, err := svc.NewMDMAppleDeclaration(ctx, 0, b, nil, "test-status-sub", fleet.LabelsIncludeAll, nil, nil)
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "status subscription type")
 	})
@@ -1803,7 +1803,7 @@ func TestNewMDMAppleDeclarationSkipValidation(t *testing.T) {
 			"Identifier": "test-status-sub",
 			"Payload": {}
 		}`)
-		d, err := svc.NewMDMAppleDeclaration(ctx, 0, b, nil, "test-status-sub", fleet.LabelsIncludeAll, nil)
+		d, err := svc.NewMDMAppleDeclaration(ctx, 0, b, nil, "test-status-sub", fleet.LabelsIncludeAll, nil, nil)
 		require.NoError(t, err)
 		assert.NotNil(t, d)
 	})
@@ -1822,7 +1822,7 @@ func TestNewMDMAppleDeclarationSkipValidation(t *testing.T) {
 			"Identifier": "test-invalid",
 			"Payload": {}
 		}`)
-		_, err := svc.NewMDMAppleDeclaration(ctx, 0, b, nil, "test-invalid", fleet.LabelsIncludeAll, nil)
+		_, err := svc.NewMDMAppleDeclaration(ctx, 0, b, nil, "test-invalid", fleet.LabelsIncludeAll, nil, nil)
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "Only configuration declarations")
 	})
@@ -1848,7 +1848,7 @@ func TestNewMDMAppleDeclarationSkipValidation(t *testing.T) {
 			"Identifier": "test-invalid",
 			"Payload": {}
 		}`)
-		d, err := svc.NewMDMAppleDeclaration(ctx, 0, b, nil, "test-invalid", fleet.LabelsIncludeAll, nil)
+		d, err := svc.NewMDMAppleDeclaration(ctx, 0, b, nil, "test-invalid", fleet.LabelsIncludeAll, nil, nil)
 		require.NoError(t, err)
 		assert.NotNil(t, d)
 	})
@@ -1928,7 +1928,7 @@ func TestNewMDMAppleDeclarationSoftwareUpdate(t *testing.T) {
 	t.Run("non software-update declaration skips OS update checks", func(t *testing.T) {
 		svc, ctx, ds := setup(t, true)
 
-		d, err := svc.NewMDMAppleDeclaration(ctx, 0, []byte(otherDecl), nil, "test-passcode", fleet.LabelsIncludeAll, nil)
+		d, err := svc.NewMDMAppleDeclaration(ctx, 0, []byte(otherDecl), nil, "test-passcode", fleet.LabelsIncludeAll, nil, nil)
 		require.NoError(t, err)
 		assert.NotNil(t, d)
 		assert.False(t, ds.TeamMDMConfigFuncInvoked)
@@ -1937,7 +1937,7 @@ func TestNewMDMAppleDeclarationSoftwareUpdate(t *testing.T) {
 	t.Run("software-update declaration requires premium license", func(t *testing.T) {
 		svc, ctx, ds := setup(t, false)
 
-		_, err := svc.NewMDMAppleDeclaration(ctx, 0, []byte(osUpdateDecl), nil, "test-os-update", fleet.LabelsIncludeAll, nil)
+		_, err := svc.NewMDMAppleDeclaration(ctx, 0, []byte(osUpdateDecl), nil, "test-os-update", fleet.LabelsIncludeAll, nil, nil)
 		require.ErrorIs(t, err, fleet.ErrMissingLicense)
 		// The gate fails before the declaration is inserted.
 		assert.False(t, ds.NewMDMAppleDeclarationFuncInvoked)
@@ -1948,7 +1948,7 @@ func TestNewMDMAppleDeclarationSoftwareUpdate(t *testing.T) {
 		svc, ctx, ds := setup(t, true)
 		ds.AppConfigFunc = appConfigWith(nil)
 
-		d, err := svc.NewMDMAppleDeclaration(ctx, 0, []byte(osUpdateDecl), nil, "test-os-update", fleet.LabelsIncludeAll, nil)
+		d, err := svc.NewMDMAppleDeclaration(ctx, 0, []byte(osUpdateDecl), nil, "test-os-update", fleet.LabelsIncludeAll, nil, nil)
 		require.NoError(t, err)
 		assert.NotNil(t, d)
 		assert.False(t, ds.TeamMDMConfigFuncInvoked)
@@ -1962,7 +1962,7 @@ func TestNewMDMAppleDeclarationSoftwareUpdate(t *testing.T) {
 			return &fleet.TeamMDM{}, nil
 		}
 
-		d, err := svc.NewMDMAppleDeclaration(ctx, 5, []byte(osUpdateDecl), nil, "test-os-update", fleet.LabelsIncludeAll, nil)
+		d, err := svc.NewMDMAppleDeclaration(ctx, 5, []byte(osUpdateDecl), nil, "test-os-update", fleet.LabelsIncludeAll, nil, nil)
 		require.NoError(t, err)
 		assert.NotNil(t, d)
 		assert.True(t, ds.TeamMDMConfigFuncInvoked)
@@ -1980,7 +1980,7 @@ func TestNewMDMAppleDeclarationSoftwareUpdate(t *testing.T) {
 				svc, ctx, ds := setup(t, true)
 				ds.AppConfigFunc = appConfigWith(apply)
 
-				_, err := svc.NewMDMAppleDeclaration(ctx, 0, []byte(osUpdateDecl), nil, "test-os-update", fleet.LabelsIncludeAll, nil)
+				_, err := svc.NewMDMAppleDeclaration(ctx, 0, []byte(osUpdateDecl), nil, "test-os-update", fleet.LabelsIncludeAll, nil, nil)
 				require.Error(t, err)
 				require.ErrorContains(t, err, "OS updates are already configured")
 				// The gate fails before the declaration is inserted.
@@ -2004,7 +2004,7 @@ func TestNewMDMAppleDeclarationSoftwareUpdate(t *testing.T) {
 					return tc, nil
 				}
 
-				_, err := svc.NewMDMAppleDeclaration(ctx, 5, []byte(osUpdateDecl), nil, "test-os-update", fleet.LabelsIncludeAll, nil)
+				_, err := svc.NewMDMAppleDeclaration(ctx, 5, []byte(osUpdateDecl), nil, "test-os-update", fleet.LabelsIncludeAll, nil, nil)
 				require.Error(t, err)
 				require.ErrorContains(t, err, fleet.OSUpdatesAlreadyConfiguredErrorMessage)
 				assert.False(t, ds.NewMDMAppleDeclarationFuncInvoked)
@@ -9352,4 +9352,73 @@ func TestGetDefaultMDMAppleSetupAssistantProfileFreeLicense(t *testing.T) {
 
 	_, _, err := svc.GetDefaultMDMAppleSetupAssistantProfile(ctx)
 	assert.ErrorIs(t, err, fleet.ErrMissingLicense)
+}
+
+func activationBytesForTest(identifier, standardConfiguration string) []byte {
+	return []byte(fmt.Sprintf(`{
+		"Type": "com.apple.activation.simple",
+		"Identifier": %q,
+		"Payload": {
+			"StandardConfigurations": [%q],
+			"Predicate": "@status(os.version.major) >= 15"
+		}
+	}`, identifier, standardConfiguration))
+}
+
+func TestNewMDMAppleDeclarationWithActivation(t *testing.T) {
+	setup := func(t *testing.T, tier string) (fleet.Service, context.Context) {
+		svc, ctx, ds, _ := setupAppleMDMService(t, &fleet.LicenseInfo{Tier: tier})
+		ctx = viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{GlobalRole: new(fleet.RoleAdmin)}})
+		ds.NewMDMAppleDeclarationFunc = func(ctx context.Context, d *fleet.MDMAppleDeclaration, usesFleetVars []fleet.FleetVarName) (*fleet.MDMAppleDeclaration, error) {
+			return d, nil
+		}
+		ds.BulkSetPendingMDMHostProfilesFunc = func(ctx context.Context, hids, tids []uint, puuids, uuids []string,
+		) (updates fleet.MDMProfilesUpdates, err error) {
+			return fleet.MDMProfilesUpdates{}, nil
+		}
+		return svc, ctx
+	}
+
+	decl := declBytesForTest("D1", "d1content")
+	const declIdentifier = "com.fleet.configD1"
+
+	t.Run("valid activation is accepted", func(t *testing.T) {
+		svc, ctx := setup(t, fleet.TierPremium)
+		activation := activationBytesForTest("com.fleet.actD1", declIdentifier)
+
+		d, err := svc.NewMDMAppleDeclaration(ctx, 0, decl, nil, "name", fleet.LabelsIncludeAll, nil, activation)
+		require.NoError(t, err)
+		require.NotNil(t, d)
+	})
+
+	t.Run("activation referencing another configuration is rejected", func(t *testing.T) {
+		svc, ctx := setup(t, fleet.TierPremium)
+		activation := activationBytesForTest("com.fleet.actD1", "com.fleet.configOther")
+
+		_, err := svc.NewMDMAppleDeclaration(ctx, 0, decl, nil, "name", fleet.LabelsIncludeAll, nil, activation)
+		require.ErrorContains(t, err, "Activation must reference the configuration profile it's uploaded with")
+	})
+
+	t.Run("malformed activation is rejected", func(t *testing.T) {
+		svc, ctx := setup(t, fleet.TierPremium)
+
+		_, err := svc.NewMDMAppleDeclaration(ctx, 0, decl, nil, "name", fleet.LabelsIncludeAll, nil, []byte(`{"Type":`))
+		require.ErrorContains(t, err, "should include valid JSON")
+	})
+
+	t.Run("activation requires premium even where the declaration doesn't", func(t *testing.T) {
+		// Fleet-less (team 0) and unlabeled declarations are allowed on Fleet
+		// Free, so this proves the activation carries its own license gate
+		// rather than inheriting the declaration's.
+		svc, ctx := setup(t, fleet.TierFree)
+		activation := activationBytesForTest("com.fleet.actD1", declIdentifier)
+
+		_, err := svc.NewMDMAppleDeclaration(ctx, 0, decl, nil, "name", fleet.LabelsIncludeAll, nil, activation)
+		require.ErrorIs(t, err, fleet.ErrMissingLicense)
+		require.ErrorContains(t, err, "Custom activations")
+
+		// ...and the same declaration without an activation still works.
+		_, err = svc.NewMDMAppleDeclaration(ctx, 0, decl, nil, "name", fleet.LabelsIncludeAll, nil, nil)
+		require.NoError(t, err)
+	})
 }

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -9521,6 +9521,39 @@ func TestNewMDMAppleDeclarationWithActivation(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("supported Fleet variables in an activation are recorded", func(t *testing.T) {
+		svc, ctx := setup(t, fleet.TierPremium)
+		activation := []byte(`{
+			"Type": "com.apple.activation.simple",
+			"Identifier": "com.fleet.actD1",
+			"Payload": {
+				"StandardConfigurations": ["com.fleet.configD1"],
+				"Predicate": "$FLEET_VAR_HOST_UUID"
+			}
+		}`)
+
+		d, err := svc.NewMDMAppleDeclaration(ctx, 0, decl, nil, "name", fleet.LabelsIncludeAll, nil, activation)
+		require.NoError(t, err)
+		require.NotNil(t, d.Activation)
+		require.Equal(t, []fleet.FleetVarName{fleet.FleetVarHostUUID}, d.Activation.FleetVariables)
+	})
+
+	t.Run("unsupported Fleet variables in an activation are rejected", func(t *testing.T) {
+		svc, ctx := setup(t, fleet.TierPremium)
+		activation := []byte(`{
+			"Type": "com.apple.activation.simple",
+			"Identifier": "com.fleet.actD1",
+			"Payload": {
+				"StandardConfigurations": ["com.fleet.configD1"],
+				"Predicate": "$FLEET_VAR_BOZO"
+			}
+		}`)
+
+		_, err := svc.NewMDMAppleDeclaration(ctx, 0, decl, nil, "name", fleet.LabelsIncludeAll, nil, activation)
+		require.ErrorContains(t, err, "Couldn't upload activation.")
+		require.ErrorContains(t, err, "$FLEET_VAR_BOZO is not supported")
+	})
+
 	t.Run("activation requires premium even where the declaration doesn't", func(t *testing.T) {
 		// Fleet-less (team 0) and unlabeled declarations are allowed on Fleet
 		// Free, so this proves the activation carries its own license gate

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -996,7 +996,7 @@ func TestUpdateMDMAppleConfigProfile(t *testing.T) {
 			return nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil)
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, nil)
 		require.NoError(t, err)
 
 		assert.Empty(t, updated.Mobileconfig)
@@ -1026,7 +1026,7 @@ func TestUpdateMDMAppleConfigProfile(t *testing.T) {
 			return &p, nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, mcBytes, nil, fleet.LabelsIncludeAll, nil)
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, mcBytes, nil, fleet.LabelsIncludeAll, nil, nil)
 		require.NoError(t, err)
 		assert.Equal(t, mcBytes, []byte(updated.Mobileconfig))
 		assert.Equal(t, "Test Profile", updated.Name)
@@ -1053,7 +1053,7 @@ func TestUpdateMDMAppleConfigProfile(t *testing.T) {
 			return nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, mcBytes, nil, fleet.LabelsIncludeAll, nil)
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, mcBytes, nil, fleet.LabelsIncludeAll, nil, nil)
 		require.NoError(t, err)
 		assert.Equal(t, "New Name", updated.Name)
 
@@ -1080,7 +1080,7 @@ func TestUpdateMDMAppleConfigProfile(t *testing.T) {
 			return &p, nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, mcBytes, nil, fleet.LabelsIncludeAll, nil)
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, mcBytes, nil, fleet.LabelsIncludeAll, nil, nil)
 		require.NoError(t, err)
 		assert.Contains(t, capturedVars, fleet.FleetVarHostEndUserEmailIDP)
 	})
@@ -1103,7 +1103,7 @@ func TestUpdateMDMAppleConfigProfile(t *testing.T) {
 			return &p, nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, mcBytes, nil, fleet.LabelsIncludeAll, nil)
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, mcBytes, nil, fleet.LabelsIncludeAll, nil, nil)
 		require.NoError(t, err)
 		require.NotNil(t, updated.SecretsUpdatedAt)
 		assert.True(t, secretsUpdatedAt.Equal(*updated.SecretsUpdatedAt))
@@ -1123,7 +1123,7 @@ func TestUpdateMDMAppleConfigProfile(t *testing.T) {
 			return &p, nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, mcBytes, []string{"label1"}, fleet.LabelsIncludeAny, []string{"label2"})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, mcBytes, []string{"label1"}, fleet.LabelsIncludeAny, []string{"label2"}, nil)
 		require.NoError(t, err)
 		assert.Equal(t, mcBytes, []byte(updated.Mobileconfig))
 		require.Len(t, updated.LabelsIncludeAny, 1)
@@ -1145,7 +1145,7 @@ func TestUpdateMDMAppleConfigProfile(t *testing.T) {
 			return nil, nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, mcBytes, nil, fleet.LabelsIncludeAll, nil)
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, mcBytes, nil, fleet.LabelsIncludeAll, nil, nil)
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "PayloadIdentifier must match")
 	})
@@ -1165,7 +1165,7 @@ func TestUpdateMDMAppleConfigProfile(t *testing.T) {
 			return nil, existsErrorForTest{}
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, mcBytes, nil, fleet.LabelsIncludeAll, nil)
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, mcBytes, nil, fleet.LabelsIncludeAll, nil, nil)
 		require.Error(t, err)
 		require.ErrorContains(t, err, SameProfileNameUploadErrorMsg)
 
@@ -1186,7 +1186,7 @@ func TestUpdateMDMAppleConfigProfile(t *testing.T) {
 			return nil, nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil)
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, nil)
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "managed by Fleet")
 	})
@@ -1198,7 +1198,7 @@ func TestUpdateMDMAppleConfigProfile(t *testing.T) {
 			return nil, wantErr
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, "a"+uuid.NewString(), nil, nil, fleet.LabelsIncludeAll, nil)
+		err := svc.UpdateMDMConfigProfile(ctx, "a"+uuid.NewString(), nil, nil, fleet.LabelsIncludeAll, nil, nil)
 		require.Error(t, err)
 		assert.ErrorIs(t, err, wantErr)
 	})
@@ -1215,7 +1215,7 @@ func TestUpdateMDMAppleConfigProfile(t *testing.T) {
 			return nil, nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil)
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, nil)
 		require.ErrorIs(t, err, fleet.ErrMissingLicense)
 		require.ErrorContains(t, err, "Scoping configuration profiles")
 
@@ -1224,7 +1224,7 @@ func TestUpdateMDMAppleConfigProfile(t *testing.T) {
 			return &p, nil
 		}
 		mcBytes := mcBytesForTest("Test Profile", "com.fleetdm.test", "UUID")
-		err = svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, mcBytes, nil, fleet.LabelsIncludeAll, nil)
+		err = svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, mcBytes, nil, fleet.LabelsIncludeAll, nil, nil)
 		require.NoError(t, err)
 	})
 
@@ -1244,13 +1244,13 @@ func TestUpdateMDMAppleConfigProfile(t *testing.T) {
 		}
 
 		mcBytes := mcBytesForTest("Test Profile", "com.fleetdm.test", "UUID")
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, mcBytes, nil, fleet.LabelsIncludeAll, nil)
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, mcBytes, nil, fleet.LabelsIncludeAll, nil, nil)
 		require.ErrorIs(t, err, fleet.ErrMissingLicense)
 
-		err = svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil)
+		err = svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, nil)
 		require.ErrorIs(t, err, fleet.ErrMissingLicense)
 
-		err = svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, nil, fleet.LabelsIncludeAll, nil)
+		err = svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, nil, fleet.LabelsIncludeAll, nil, nil)
 		require.ErrorIs(t, err, fleet.ErrMissingLicense)
 	})
 
@@ -1305,10 +1305,10 @@ func TestUpdateMDMAppleConfigProfile(t *testing.T) {
 				// this isolates the authz checks from content/label validation,
 				// so a failure can only come from permissions, not some other
 				// unrelated rejection.
-				err := svc.UpdateMDMConfigProfile(ctx, noTeamProfile.ProfileUUID, nil, nil, fleet.LabelsIncludeAll, nil)
+				err := svc.UpdateMDMConfigProfile(ctx, noTeamProfile.ProfileUUID, nil, nil, fleet.LabelsIncludeAll, nil, nil)
 				checkShouldFail(t, err, tt.shouldFailGlobal)
 
-				err = svc.UpdateMDMConfigProfile(ctx, teamProfile.ProfileUUID, nil, nil, fleet.LabelsIncludeAll, nil)
+				err = svc.UpdateMDMConfigProfile(ctx, teamProfile.ProfileUUID, nil, nil, fleet.LabelsIncludeAll, nil, nil)
 				checkShouldFail(t, err, tt.shouldFailTeam)
 			})
 		}
@@ -1451,7 +1451,7 @@ func TestUpdateMDMAppleDeclaration(t *testing.T) {
 		}
 
 		newContent := declBytesForTest("D1", "updated-content")
-		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, newContent, nil, fleet.LabelsIncludeAll, nil)
+		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, newContent, nil, fleet.LabelsIncludeAll, nil, nil)
 		require.NoError(t, err)
 
 		require.NotNil(t, updated)
@@ -1464,6 +1464,102 @@ func TestUpdateMDMAppleDeclaration(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, existing.Name, act.ProfileName)
 		assert.Equal(t, existing.Identifier, act.ProfileIdentifier)
+	})
+
+	t.Run("activation-only update keeps content and replaces the activation", func(t *testing.T) {
+		svc, ctx, ds, opts := setup(t, &fleet.LicenseInfo{Tier: fleet.TierPremium})
+		existing := newExistingDeclaration("Test Declaration", "com.fleet.configD1", 0)
+		existing.RawJSON = declBytesForTest("D1", "unchanged-content")
+		existing.Activation = &fleet.MDMAppleCustomActivation{
+			Identifier:              "com.fleet.actD1",
+			RawJSON:                 activationBytesForTest("com.fleet.actD1", "com.fleet.configD1"),
+			ConfigurationIdentifier: "com.fleet.configD1",
+		}
+
+		ds.GetMDMAppleDeclarationFunc = func(ctx context.Context, duid string) (*fleet.MDMAppleDeclaration, error) {
+			return existing, nil
+		}
+		var updated *fleet.MDMAppleDeclaration
+		ds.SetOrUpdateMDMAppleDeclarationFunc = func(ctx context.Context, d *fleet.MDMAppleDeclaration, usesFleetVars []fleet.FleetVarName) (*fleet.MDMAppleDeclaration, error) {
+			updated = d
+			return d, nil
+		}
+		var activityCount int
+		opts.ActivityMock.NewActivityFunc = func(_ context.Context, _ *activity_api.User, activity activity_api.ActivityDetails) error {
+			activityCount++
+			return nil
+		}
+
+		newAct := activationBytesForTest("com.fleet.actD1.v2", "com.fleet.configD1")
+		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, nil, nil, fleet.LabelsIncludeAll, nil, newAct)
+		require.NoError(t, err)
+
+		require.NotNil(t, updated)
+		// content is untouched...
+		assert.Equal(t, existing.RawJSON, updated.RawJSON)
+		// ...and the activation is replaced, not appended to
+		require.NotNil(t, updated.Activation)
+		assert.Equal(t, "com.fleet.actD1.v2", updated.Activation.Identifier)
+		assert.JSONEq(t, string(newAct), string(updated.Activation.RawJSON))
+
+		// editing the activation emits exactly one edited-declaration activity
+		assert.Equal(t, 1, activityCount)
+	})
+
+	t.Run("labels-only update preserves the stored activation", func(t *testing.T) {
+		svc, ctx, ds, _ := setup(t, &fleet.LicenseInfo{Tier: fleet.TierPremium})
+		existing := newExistingDeclaration("Test Declaration", "com.fleet.configD1", 0)
+		stored := &fleet.MDMAppleCustomActivation{
+			Identifier:              "com.fleet.actD1",
+			RawJSON:                 activationBytesForTest("com.fleet.actD1", "com.fleet.configD1"),
+			ConfigurationIdentifier: "com.fleet.configD1",
+		}
+		existing.Activation = stored
+
+		ds.GetMDMAppleDeclarationFunc = func(ctx context.Context, duid string) (*fleet.MDMAppleDeclaration, error) {
+			return existing, nil
+		}
+		var updated *fleet.MDMAppleDeclaration
+		ds.SetOrUpdateMDMAppleDeclarationFunc = func(ctx context.Context, d *fleet.MDMAppleDeclaration, usesFleetVars []fleet.FleetVarName) (*fleet.MDMAppleDeclaration, error) {
+			updated = d
+			return d, nil
+		}
+
+		// no profile content, no activation -- just labels. The datastore
+		// clears the activation of any declaration written without one, so the
+		// stored activation has to be carried forward here.
+		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, nil, []string{"label-1"}, fleet.LabelsIncludeAll, nil, nil)
+		require.NoError(t, err)
+
+		require.NotNil(t, updated)
+		require.NotNil(t, updated.Activation, "labels-only edit must not clear the activation")
+		assert.Equal(t, stored.Identifier, updated.Activation.Identifier)
+	})
+
+	t.Run("new content without an activation clears the stored one", func(t *testing.T) {
+		svc, ctx, ds, _ := setup(t, &fleet.LicenseInfo{Tier: fleet.TierPremium})
+		existing := newExistingDeclaration("Test Declaration", "com.fleet.configD1", 0)
+		existing.Activation = &fleet.MDMAppleCustomActivation{
+			Identifier:              "com.fleet.actD1",
+			RawJSON:                 activationBytesForTest("com.fleet.actD1", "com.fleet.configD1"),
+			ConfigurationIdentifier: "com.fleet.configD1",
+		}
+
+		ds.GetMDMAppleDeclarationFunc = func(ctx context.Context, duid string) (*fleet.MDMAppleDeclaration, error) {
+			return existing, nil
+		}
+		var updated *fleet.MDMAppleDeclaration
+		ds.SetOrUpdateMDMAppleDeclarationFunc = func(ctx context.Context, d *fleet.MDMAppleDeclaration, usesFleetVars []fleet.FleetVarName) (*fleet.MDMAppleDeclaration, error) {
+			updated = d
+			return d, nil
+		}
+
+		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID,
+			declBytesForTest("D1", "updated-content"), nil, fleet.LabelsIncludeAll, nil, nil)
+		require.NoError(t, err)
+
+		require.NotNil(t, updated)
+		assert.Nil(t, updated.Activation, "replacing content without an activation removes it")
 	})
 
 	t.Run("labels-only update, happy path", func(t *testing.T) {
@@ -1484,7 +1580,7 @@ func TestUpdateMDMAppleDeclaration(t *testing.T) {
 			return nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil)
+		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, nil)
 		require.NoError(t, err)
 
 		require.NotNil(t, updated)
@@ -1519,7 +1615,7 @@ func TestUpdateMDMAppleDeclaration(t *testing.T) {
 			return d, nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil)
+		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, nil)
 		require.NoError(t, err)
 		assert.Contains(t, capturedVars, fleet.FleetVarHostUUID)
 		require.NotNil(t, capturedDecl)
@@ -1542,10 +1638,10 @@ func TestUpdateMDMAppleDeclaration(t *testing.T) {
 		}
 
 		newContent := declBytesForTest("D1", "updated-content")
-		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, newContent, nil, fleet.LabelsIncludeAll, nil)
+		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, newContent, nil, fleet.LabelsIncludeAll, nil, nil)
 		require.ErrorIs(t, err, fleet.ErrMissingLicense)
 
-		err = svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil)
+		err = svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, nil)
 		require.ErrorIs(t, err, fleet.ErrMissingLicense)
 	})
 
@@ -1563,7 +1659,7 @@ func TestUpdateMDMAppleDeclaration(t *testing.T) {
 		}
 
 		newContent := declBytesForTest("D1", "updated-content")
-		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, newContent, []string{"label1"}, fleet.LabelsIncludeAny, []string{"label2"})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, newContent, []string{"label1"}, fleet.LabelsIncludeAny, []string{"label2"}, nil)
 		require.NoError(t, err)
 
 		require.NotNil(t, updated)
@@ -1593,7 +1689,7 @@ func TestUpdateMDMAppleDeclaration(t *testing.T) {
 		}
 
 		newContent := declBytesForTest("D1", "updated-content")
-		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, newContent, nil, fleet.LabelsIncludeAll, nil)
+		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, newContent, nil, fleet.LabelsIncludeAll, nil, nil)
 		require.NoError(t, err)
 
 		require.NotNil(t, updated)
@@ -1622,7 +1718,7 @@ func TestUpdateMDMAppleDeclaration(t *testing.T) {
 		}
 
 		mismatchedContent := declarationForTestWithType("com.fleet.configD2", "com.apple.configuration.management.test")
-		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, mismatchedContent, nil, fleet.LabelsIncludeAll, nil)
+		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, mismatchedContent, nil, fleet.LabelsIncludeAll, nil, nil)
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "Identifier must match the existing profile's")
 	})
@@ -1640,7 +1736,7 @@ func TestUpdateMDMAppleDeclaration(t *testing.T) {
 		}
 
 		invalidContent := declarationForTestWithType(existing.Identifier, "com.example.not-a-real-type")
-		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, invalidContent, nil, fleet.LabelsIncludeAll, nil)
+		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, invalidContent, nil, fleet.LabelsIncludeAll, nil, nil)
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "Only configuration declarations (com.apple.configuration.) and management declarations (com.apple.management.) are supported")
 	})
@@ -1657,7 +1753,7 @@ func TestUpdateMDMAppleDeclaration(t *testing.T) {
 			return nil, nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, []string{"label1"})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, []string{"label1"}, nil)
 		require.Error(t, err)
 		assert.ErrorContains(t, err, `label "label1" cannot appear in both include and exclude lists`)
 	})
@@ -1674,7 +1770,7 @@ func TestUpdateMDMAppleDeclaration(t *testing.T) {
 			return nil, nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil)
+		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, nil)
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "managed by Fleet")
 	})
@@ -1686,7 +1782,7 @@ func TestUpdateMDMAppleDeclaration(t *testing.T) {
 			return nil, wantErr
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, "d"+uuid.NewString(), nil, nil, fleet.LabelsIncludeAll, nil)
+		err := svc.UpdateMDMConfigProfile(ctx, "d"+uuid.NewString(), nil, nil, fleet.LabelsIncludeAll, nil, nil)
 		require.Error(t, err)
 		assert.ErrorIs(t, err, wantErr)
 	})
@@ -1707,7 +1803,7 @@ func TestUpdateMDMAppleDeclaration(t *testing.T) {
 		// generic ExistsErrorInterface -> 409 mapping rather than any specific
 		// identifier collision.
 		newContent := declarationForTestWithType(existing.Identifier, "com.apple.configuration.management.test")
-		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, newContent, nil, fleet.LabelsIncludeAll, nil)
+		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, newContent, nil, fleet.LabelsIncludeAll, nil, nil)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "Couldn't edit. A configuration profile with this identifier already exists.")
 

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -1369,7 +1369,7 @@ func TestNewMDMAppleDeclaration(t *testing.T) {
 	// decl type missing actual type
 	b = declarationForTestWithType("D1", "com.apple.configuration")
 	_, err = svc.NewMDMAppleDeclaration(ctx, 0, b, nil, "name", fleet.LabelsIncludeAll, nil, nil)
-	assert.ErrorContains(t, err, "Only configuration declarations (com.apple.configuration.) are supported")
+	assert.ErrorContains(t, err, "Only configuration declarations (com.apple.configuration.) and management declarations (com.apple.management.) are supported")
 
 	ds.NewMDMAppleDeclarationFunc = func(ctx context.Context, d *fleet.MDMAppleDeclaration, usesFleetVars []fleet.FleetVarName) (*fleet.MDMAppleDeclaration, error) {
 		return d, nil
@@ -1642,7 +1642,7 @@ func TestUpdateMDMAppleDeclaration(t *testing.T) {
 		invalidContent := declarationForTestWithType(existing.Identifier, "com.example.not-a-real-type")
 		err := svc.UpdateMDMConfigProfile(ctx, existing.DeclarationUUID, invalidContent, nil, fleet.LabelsIncludeAll, nil)
 		require.Error(t, err)
-		assert.ErrorContains(t, err, "Only configuration declarations (com.apple.configuration.) are supported")
+		assert.ErrorContains(t, err, "Only configuration declarations (com.apple.configuration.) and management declarations (com.apple.management.) are supported")
 	})
 
 	t.Run("label appearing in both include and exclude lists is rejected", func(t *testing.T) {
@@ -9404,6 +9404,25 @@ func TestNewMDMAppleDeclarationWithActivation(t *testing.T) {
 
 		_, err := svc.NewMDMAppleDeclaration(ctx, 0, decl, nil, "name", fleet.LabelsIncludeAll, nil, []byte(`{"Type":`))
 		require.ErrorContains(t, err, "should include valid JSON")
+	})
+
+	t.Run("activation on a management declaration is rejected", func(t *testing.T) {
+		svc, ctx := setup(t, fleet.TierPremium)
+		// Management declarations are never activated, so attaching one is
+		// always a mistake even though this is a valid DDM profile.
+		mgmt := []byte(`{
+			"Type": "com.apple.management.organization-info",
+			"Identifier": "com.fleet.orgD1",
+			"Payload": { "Echo": "foo" }
+		}`)
+		activation := activationBytesForTest("com.fleet.actD1", "com.fleet.orgD1")
+
+		_, err := svc.NewMDMAppleDeclaration(ctx, 0, mgmt, nil, "name", fleet.LabelsIncludeAll, nil, activation)
+		require.ErrorContains(t, err, "Activations are only supported for configuration declarations")
+
+		// ...but the management declaration itself uploads fine without one.
+		_, err = svc.NewMDMAppleDeclaration(ctx, 0, mgmt, nil, "name", fleet.LabelsIncludeAll, nil, nil)
+		require.NoError(t, err)
 	})
 
 	t.Run("activation requires premium even where the declaration doesn't", func(t *testing.T) {

--- a/server/service/integration_mdm_ddm_test.go
+++ b/server/service/integration_mdm_ddm_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/md5" // nolint:gosec // used only for tests
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -2300,18 +2299,69 @@ func (s *integrationMDMTestSuite) TestAppleDDMCustomActivations() {
 		require.JSONEq(t, string(activation), string(found.Activation))
 
 		// the single-profile endpoint returns it too, and the raw body carries
-		// it as a base64 string rather than an object -- this is the wire
-		// format the API reference promises
+		// it as an embedded JSON object rather than an encoded string
 		getRes := s.Do("GET", fmt.Sprintf("/api/latest/fleet/configuration_profiles/%s", uploadResp.ProfileUUID), nil, http.StatusOK)
 		rawBody, err := io.ReadAll(getRes.Body)
 		require.NoError(t, err)
-		var asMap map[string]any
+		var asMap map[string]json.RawMessage
 		require.NoError(t, json.Unmarshal(rawBody, &asMap))
-		encoded, ok := asMap["activation"].(string)
-		require.True(t, ok, "activation should serialize as a base64 string, got %T", asMap["activation"])
-		decoded, err := base64.StdEncoding.DecodeString(encoded)
+		require.Contains(t, asMap, "activation")
+		require.JSONEq(t, string(activation), string(asMap["activation"]))
+	})
+
+	t.Run("a declaration without an activation omits the field", func(t *testing.T) {
+		declIdent := "com.fleet.ddm.act.none"
+		res := uploadProfile(declIdent+".json", declarationForTest(declIdent), nil, http.StatusOK)
+		var uploadResp newMDMConfigProfileResponse
+		require.NoError(t, json.NewDecoder(res.Body).Decode(&uploadResp))
+		t.Cleanup(func() {
+			var delResp deleteMDMConfigProfileResponse
+			s.DoJSON("DELETE", fmt.Sprintf("/api/latest/fleet/configuration_profiles/%s", uploadResp.ProfileUUID), nil, http.StatusOK, &delResp)
+		})
+
+		// the key must be absent entirely, not null or empty
+		getRes := s.Do("GET", fmt.Sprintf("/api/latest/fleet/configuration_profiles/%s", uploadResp.ProfileUUID), nil, http.StatusOK)
+		rawBody, err := io.ReadAll(getRes.Body)
 		require.NoError(t, err)
-		require.JSONEq(t, string(activation), string(decoded))
+		var asMap map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(rawBody, &asMap))
+		require.NotContains(t, asMap, "activation")
+	})
+
+	t.Run("two management declarations can be uploaded", func(t *testing.T) {
+		managementForTest := func(declType, identifier string) []byte {
+			return []byte(fmt.Sprintf(`
+{
+    "Type": %q,
+    "Payload": { "Echo": "foo" },
+    "Identifier": %q
+}`, declType, identifier))
+		}
+
+		for _, m := range []struct{ declType, identifier string }{
+			{"com.apple.management.organization-info", "com.fleet.ddm.mgmt.org"},
+			{"com.apple.management.properties", "com.fleet.ddm.mgmt.props"},
+		} {
+			res := uploadProfile(m.identifier+".json", managementForTest(m.declType, m.identifier), nil, http.StatusOK)
+			var uploadResp newMDMConfigProfileResponse
+			require.NoError(t, json.NewDecoder(res.Body).Decode(&uploadResp))
+			require.NotEmpty(t, uploadResp.ProfileUUID)
+			t.Cleanup(func() {
+				var delResp deleteMDMConfigProfileResponse
+				s.DoJSON("DELETE", fmt.Sprintf("/api/latest/fleet/configuration_profiles/%s", uploadResp.ProfileUUID), nil, http.StatusOK, &delResp)
+			})
+		}
+
+		// both coexist in the same fleet
+		var listResp listMDMConfigProfilesResponse
+		s.DoJSON("GET", "/api/latest/fleet/configuration_profiles", &listMDMConfigProfilesRequest{}, http.StatusOK, &listResp)
+		var mgmtCount int
+		for _, p := range listResp.Profiles {
+			if strings.HasPrefix(p.Identifier, "com.fleet.ddm.mgmt.") {
+				mgmtCount++
+			}
+		}
+		require.Equal(t, 2, mgmtCount)
 	})
 
 	t.Run("activation alongside a non-DDM profile is rejected", func(t *testing.T) {

--- a/server/service/integration_mdm_ddm_test.go
+++ b/server/service/integration_mdm_ddm_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/md5" // nolint:gosec // used only for tests
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -2241,10 +2242,8 @@ func declarationForTestWithType(identifier string, dType string) []byte {
 }`, dType, identifier))
 }
 
-// TestAppleDDMCustomActivations covers the HTTP layer for custom activations:
-// the multipart plumbing, the endpoint-level guard for non-DDM profiles, and
-// the wire format of the activation on read. The validation rules themselves
-// are covered by unit tests; this exercises what only a real request can.
+// Covers what only a real request reaches: the multipart plumbing, the
+// endpoint-level guards, and the wire format. Validation rules are unit tested.
 func (s *integrationMDMTestSuite) TestAppleDDMCustomActivations() {
 	t := s.T()
 
@@ -2298,15 +2297,17 @@ func (s *integrationMDMTestSuite) TestAppleDDMCustomActivations() {
 		require.NotNil(t, found, "uploaded declaration missing from list")
 		require.JSONEq(t, string(activation), string(found.Activation))
 
-		// the single-profile endpoint returns it too, and the raw body carries
-		// it as an embedded JSON object rather than an encoded string
+		// the raw body carries it as a base64 string, per the API reference
 		getRes := s.Do("GET", fmt.Sprintf("/api/latest/fleet/configuration_profiles/%s", uploadResp.ProfileUUID), nil, http.StatusOK)
 		rawBody, err := io.ReadAll(getRes.Body)
 		require.NoError(t, err)
-		var asMap map[string]json.RawMessage
+		var asMap map[string]any
 		require.NoError(t, json.Unmarshal(rawBody, &asMap))
-		require.Contains(t, asMap, "activation")
-		require.JSONEq(t, string(activation), string(asMap["activation"]))
+		encoded, ok := asMap["activation"].(string)
+		require.True(t, ok, "activation should be a base64 string, got %T", asMap["activation"])
+		decoded, err := base64.StdEncoding.DecodeString(encoded)
+		require.NoError(t, err)
+		require.JSONEq(t, string(activation), string(decoded))
 	})
 
 	t.Run("a declaration without an activation omits the field", func(t *testing.T) {
@@ -2319,11 +2320,11 @@ func (s *integrationMDMTestSuite) TestAppleDDMCustomActivations() {
 			s.DoJSON("DELETE", fmt.Sprintf("/api/latest/fleet/configuration_profiles/%s", uploadResp.ProfileUUID), nil, http.StatusOK, &delResp)
 		})
 
-		// the key must be absent entirely, not null or empty
+		// absent entirely, not null or empty
 		getRes := s.Do("GET", fmt.Sprintf("/api/latest/fleet/configuration_profiles/%s", uploadResp.ProfileUUID), nil, http.StatusOK)
 		rawBody, err := io.ReadAll(getRes.Body)
 		require.NoError(t, err)
-		var asMap map[string]json.RawMessage
+		var asMap map[string]any
 		require.NoError(t, json.Unmarshal(rawBody, &asMap))
 		require.NotContains(t, asMap, "activation")
 	})

--- a/server/service/integration_mdm_ddm_test.go
+++ b/server/service/integration_mdm_ddm_test.go
@@ -54,7 +54,7 @@ func (s *integrationMDMTestSuite) TestAppleDDMBatchUpload() {
 	}}, http.StatusUnprocessableEntity)
 
 	errMsg := extractServerErrorText(res.Body)
-	require.Contains(t, errMsg, "Only configuration declarations (com.apple.configuration.) are supported")
+	require.Contains(t, errMsg, "Only configuration declarations (com.apple.configuration.) and management declarations (com.apple.management.) are supported")
 
 	// Types from our list of forbidden types should fail
 	for ft := range fleet.ForbiddenDeclTypes {

--- a/server/service/integration_mdm_ddm_test.go
+++ b/server/service/integration_mdm_ddm_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/md5" // nolint:gosec // used only for tests
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -2239,4 +2240,146 @@ func declarationForTestWithType(identifier string, dType string) []byte {
     },
     "Identifier": "%s"
 }`, dType, identifier))
+}
+
+// TestAppleDDMCustomActivations covers the HTTP layer for custom activations:
+// the multipart plumbing, the endpoint-level guard for non-DDM profiles, and
+// the wire format of the activation on read. The validation rules themselves
+// are covered by unit tests; this exercises what only a real request can.
+func (s *integrationMDMTestSuite) TestAppleDDMCustomActivations() {
+	t := s.T()
+
+	activationForTest := func(identifier, configIdentifier, predicate string) []byte {
+		return []byte(fmt.Sprintf(`
+{
+    "Type": "com.apple.activation.simple",
+    "Identifier": %q,
+    "Payload": {
+        "StandardConfigurations": [%q],
+        "Predicate": %q
+    }
+}`, identifier, configIdentifier, predicate))
+	}
+
+	uploadProfile := func(fileName string, content, activation []byte, wantStatus int) *http.Response {
+		var extraFiles map[string]multipartFile
+		if activation != nil {
+			extraFiles = map[string]multipartFile{
+				"activation": {fileName: "activation.json", content: activation},
+			}
+		}
+		body, headers := generateMultipartRequestWithFiles(
+			t, "profile", fileName, content, s.token, nil, extraFiles,
+		)
+		return s.DoRawWithHeaders("POST", "/api/latest/fleet/configuration_profiles", body.Bytes(), wantStatus, headers)
+	}
+
+	t.Run("upload a declaration with an activation and read it back", func(t *testing.T) {
+		declIdent := "com.fleet.ddm.act.upload"
+		activation := activationForTest(declIdent+".custom", declIdent, "@status(os.version.major) >= 15")
+
+		res := uploadProfile(declIdent+".json", declarationForTest(declIdent), activation, http.StatusOK)
+		var uploadResp newMDMConfigProfileResponse
+		require.NoError(t, json.NewDecoder(res.Body).Decode(&uploadResp))
+		require.NotEmpty(t, uploadResp.ProfileUUID)
+		t.Cleanup(func() {
+			var delResp deleteMDMConfigProfileResponse
+			s.DoJSON("DELETE", fmt.Sprintf("/api/latest/fleet/configuration_profiles/%s", uploadResp.ProfileUUID), nil, http.StatusOK, &delResp)
+		})
+
+		// the list endpoint returns it, base64-encoded by encoding/json
+		var listResp listMDMConfigProfilesResponse
+		s.DoJSON("GET", "/api/latest/fleet/configuration_profiles", &listMDMConfigProfilesRequest{}, http.StatusOK, &listResp)
+		var found *fleet.MDMConfigProfilePayload
+		for _, p := range listResp.Profiles {
+			if p.ProfileUUID == uploadResp.ProfileUUID {
+				found = p
+			}
+		}
+		require.NotNil(t, found, "uploaded declaration missing from list")
+		require.JSONEq(t, string(activation), string(found.Activation))
+
+		// the single-profile endpoint returns it too, and the raw body carries
+		// it as a base64 string rather than an object -- this is the wire
+		// format the API reference promises
+		getRes := s.Do("GET", fmt.Sprintf("/api/latest/fleet/configuration_profiles/%s", uploadResp.ProfileUUID), nil, http.StatusOK)
+		rawBody, err := io.ReadAll(getRes.Body)
+		require.NoError(t, err)
+		var asMap map[string]any
+		require.NoError(t, json.Unmarshal(rawBody, &asMap))
+		encoded, ok := asMap["activation"].(string)
+		require.True(t, ok, "activation should serialize as a base64 string, got %T", asMap["activation"])
+		decoded, err := base64.StdEncoding.DecodeString(encoded)
+		require.NoError(t, err)
+		require.JSONEq(t, string(activation), string(decoded))
+	})
+
+	t.Run("activation alongside a non-DDM profile is rejected", func(t *testing.T) {
+		activation := activationForTest("com.fleet.ddm.act.bad", "com.fleet.ddm.act.bad", "")
+		mc := mobileconfigForTest("act-not-ddm", "com.fleet.ddm.act.notddm")
+
+		res := uploadProfile("act-not-ddm.mobileconfig", mc, activation, http.StatusUnprocessableEntity)
+		errMsg := extractServerErrorText(res.Body)
+		require.Contains(t, errMsg, "Activations are only supported for declaration (DDM) profiles")
+	})
+
+	t.Run("activation on a non-DDM profile is rejected when editing too", func(t *testing.T) {
+		// the create path rejects this in the endpoint, the edit path in the
+		// service -- both have to return a real validation error rather than
+		// tripping the authorization layer
+		mc := mobileconfigForTest("act-edit-not-ddm", "com.fleet.ddm.act.editnotddm")
+		body, headers := generateNewProfileMultipartRequest(t, "act-edit-not-ddm.mobileconfig", mc, s.token, nil)
+		res := s.DoRawWithHeaders("POST", "/api/latest/fleet/configuration_profiles", body.Bytes(), http.StatusOK, headers)
+		var uploadResp newMDMConfigProfileResponse
+		require.NoError(t, json.NewDecoder(res.Body).Decode(&uploadResp))
+		t.Cleanup(func() {
+			var delResp deleteMDMConfigProfileResponse
+			s.DoJSON("DELETE", fmt.Sprintf("/api/latest/fleet/configuration_profiles/%s", uploadResp.ProfileUUID), nil, http.StatusOK, &delResp)
+		})
+
+		activation := activationForTest("com.fleet.ddm.act.bad", "com.fleet.ddm.act.bad", "")
+		patchBody, patchHeaders := generateMultipartRequestWithFiles(
+			t, "profile", "", nil, s.token, nil,
+			map[string]multipartFile{"activation": {fileName: "activation.json", content: activation}},
+		)
+		patchRes := s.DoRawWithHeaders("PATCH",
+			fmt.Sprintf("/api/latest/fleet/configuration_profiles/%s", uploadResp.ProfileUUID),
+			patchBody.Bytes(), http.StatusUnprocessableEntity, patchHeaders)
+		require.Contains(t, extractServerErrorText(patchRes.Body),
+			"Activations are only supported for declaration (DDM) profiles")
+	})
+
+	t.Run("activation can be edited on its own", func(t *testing.T) {
+		declIdent := "com.fleet.ddm.act.edit"
+		content := declarationForTest(declIdent)
+		activation := activationForTest(declIdent+".custom", declIdent, "@status(os.version.major) >= 15")
+
+		res := uploadProfile(declIdent+".json", content, activation, http.StatusOK)
+		var uploadResp newMDMConfigProfileResponse
+		require.NoError(t, json.NewDecoder(res.Body).Decode(&uploadResp))
+		t.Cleanup(func() {
+			var delResp deleteMDMConfigProfileResponse
+			s.DoJSON("DELETE", fmt.Sprintf("/api/latest/fleet/configuration_profiles/%s", uploadResp.ProfileUUID), nil, http.StatusOK, &delResp)
+		})
+
+		// PATCH with only an activation: no profile part at all
+		updated := activationForTest(declIdent+".custom", declIdent, "@status(os.version.major) >= 26")
+		body, headers := generateMultipartRequestWithFiles(
+			t, "profile", "", nil, s.token, nil,
+			map[string]multipartFile{"activation": {fileName: "activation.json", content: updated}},
+		)
+		s.DoRawWithHeaders("PATCH",
+			fmt.Sprintf("/api/latest/fleet/configuration_profiles/%s", uploadResp.ProfileUUID),
+			body.Bytes(), http.StatusOK, headers)
+
+		getRes := s.Do("GET", fmt.Sprintf("/api/latest/fleet/configuration_profiles/%s", uploadResp.ProfileUUID), nil, http.StatusOK)
+		var profResp getMDMConfigProfileResponse
+		require.NoError(t, json.NewDecoder(getRes.Body).Decode(&profResp))
+		require.JSONEq(t, string(updated), string(profResp.Activation), "activation should be replaced")
+
+		// the declaration's own content is untouched by an activation-only edit
+		decl, err := s.ds.GetMDMAppleDeclaration(context.Background(), uploadResp.ProfileUUID)
+		require.NoError(t, err)
+		require.JSONEq(t, string(content), string(decl.RawJSON))
+	})
 }

--- a/server/service/integration_mdm_ddm_test.go
+++ b/server/service/integration_mdm_ddm_test.go
@@ -2320,13 +2320,14 @@ func (s *integrationMDMTestSuite) TestAppleDDMCustomActivations() {
 			s.DoJSON("DELETE", fmt.Sprintf("/api/latest/fleet/configuration_profiles/%s", uploadResp.ProfileUUID), nil, http.StatusOK, &delResp)
 		})
 
-		// absent entirely, not null or empty
+		// present but null, so the field is explicit rather than missing
 		getRes := s.Do("GET", fmt.Sprintf("/api/latest/fleet/configuration_profiles/%s", uploadResp.ProfileUUID), nil, http.StatusOK)
 		rawBody, err := io.ReadAll(getRes.Body)
 		require.NoError(t, err)
 		var asMap map[string]any
 		require.NoError(t, json.Unmarshal(rawBody, &asMap))
-		require.NotContains(t, asMap, "activation")
+		require.Contains(t, asMap, "activation")
+		require.Nil(t, asMap["activation"])
 	})
 
 	t.Run("two management declarations can be uploaded", func(t *testing.T) {

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -6098,6 +6098,24 @@ func generateMultipartRequest(t *testing.T,
 	uploadFileField, fileName string, fileContent []byte, token string,
 	extraFields map[string][]string,
 ) (*bytes.Buffer, map[string]string) {
+	return generateMultipartRequestWithFiles(t, uploadFileField, fileName, fileContent, token, extraFields, nil)
+}
+
+// multipartFile is an additional file part for endpoints that accept more than
+// one, such as a configuration profile uploaded together with its custom DDM
+// activation.
+type multipartFile struct {
+	fileName string
+	content  []byte
+}
+
+// generateMultipartRequestWithFiles builds a multipart body with a primary file
+// part plus any number of additional file parts, keyed by form field name.
+// generateMultipartRequest delegates here so single-file callers are unchanged.
+func generateMultipartRequestWithFiles(t *testing.T,
+	uploadFileField, fileName string, fileContent []byte, token string,
+	extraFields map[string][]string, extraFiles map[string]multipartFile,
+) (*bytes.Buffer, map[string]string) {
 	var body bytes.Buffer
 
 	writer := multipart.NewWriter(&body)
@@ -6107,6 +6125,14 @@ func generateMultipartRequest(t *testing.T,
 		ff, err := writer.CreateFormFile(uploadFileField, fileName)
 		require.NoError(t, err)
 		_, err = io.Copy(ff, bytes.NewReader(fileContent))
+		require.NoError(t, err)
+	}
+
+	// add any additional file parts
+	for field, f := range extraFiles {
+		ff, err := writer.CreateFormFile(field, f.fileName)
+		require.NoError(t, err)
+		_, err = io.Copy(ff, bytes.NewReader(f.content))
 		require.NoError(t, err)
 	}
 

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -1681,6 +1681,9 @@ type newMDMConfigProfileRequest struct {
 	LabelsIncludeAll []string
 	LabelsIncludeAny []string
 	LabelsExcludeAny []string
+	// Activation is an optional custom activation declaration, only supported
+	// alongside an Apple declaration (DDM) profile.
+	Activation *multipart.FileHeader
 }
 
 func (newMDMConfigProfileRequest) DecodeRequest(ctx context.Context, r *http.Request) (interface{}, error) {
@@ -1716,6 +1719,16 @@ func (newMDMConfigProfileRequest) DecodeRequest(ctx context.Context, r *http.Req
 
 	if decoded.Profile.Size > fleet.MaxProfileSize {
 		return nil, fleet.NewInvalidArgumentError("mdm", fleet.MaxProfileSizeErrMsg)
+	}
+
+	// add activation, optional and only meaningful for declaration (DDM)
+	// profiles -- that's enforced by the endpoint, which is where the profile
+	// type is determined.
+	if fhs, ok := r.MultipartForm.File["activation"]; ok && len(fhs) > 0 {
+		decoded.Activation = fhs[0]
+		if decoded.Activation.Size > fleet.MaxProfileSize {
+			return nil, fleet.NewInvalidArgumentError("activation", fleet.MaxProfileSizeErrMsg)
+		}
 	}
 
 	// add labels
@@ -1769,6 +1782,20 @@ func newMDMConfigProfileEndpoint(ctx context.Context, request interface{}, svc f
 		return &newMDMConfigProfileResponse{Err: err}, nil
 	}
 
+	var activation []byte
+	if req.Activation != nil {
+		af, err := req.Activation.Open()
+		if err != nil {
+			return &newMDMConfigProfileResponse{Err: err}, nil
+		}
+		defer af.Close()
+
+		activation, err = io.ReadAll(af)
+		if err != nil {
+			return &newMDMConfigProfileResponse{Err: err}, nil
+		}
+	}
+
 	fileExt := filepath.Ext(req.Profile.Filename)
 	profileName := strings.TrimSuffix(filepath.Base(req.Profile.Filename), fileExt)
 	isMobileConfig := strings.EqualFold(fileExt, ".mobileconfig")
@@ -1805,10 +1832,20 @@ func newMDMConfigProfileEndpoint(ctx context.Context, request interface{}, svc f
 		}
 	}
 
+	// An activation gates a DDM configuration declaration, so it's meaningless
+	// next to any other profile type. This check lives in the endpoint because
+	// the endpoint is what determines the profile's type; the message is shared
+	// with the batch path so the same mistake reads the same way.
+	if len(activation) > 0 && !isAppleDeclarationJSON {
+		return &newMDMConfigProfileResponse{
+			Err: fleet.NewInvalidArgumentError("activation", ActivationUnsupportedProfileErrorMsg),
+		}, nil
+	}
+
 	if isMobileConfig || isAppleDeclarationJSON {
 		// Then it's an Apple configuration file
 		if isJSON {
-			decl, err := svc.NewMDMAppleDeclaration(ctx, req.TeamID, data, labels, profileName, labelsMode, req.LabelsExcludeAny)
+			decl, err := svc.NewMDMAppleDeclaration(ctx, req.TeamID, data, labels, profileName, labelsMode, req.LabelsExcludeAny, activation)
 			if err != nil {
 				errStr := err.Error()
 				if strings.Contains(errStr, "MDMAppleDeclaration.Name") && strings.Contains(errStr, "already exists") {

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -1837,8 +1837,11 @@ func newMDMConfigProfileEndpoint(ctx context.Context, request interface{}, svc f
 	// the endpoint is what determines the profile's type; the message is shared
 	// with the batch path so the same mistake reads the same way.
 	if len(activation) > 0 && !isAppleDeclarationJSON {
+		// routed through the service so the error is returned from behind an
+		// authorization check; returning it straight from the endpoint would
+		// skip authz entirely and surface as a bare "forbidden"
 		return &newMDMConfigProfileResponse{
-			Err: fleet.NewInvalidArgumentError("activation", ActivationUnsupportedProfileErrorMsg),
+			Err: svc.NewMDMActivationUnsupportedProfile(ctx, req.TeamID),
 		}, nil
 	}
 
@@ -2025,6 +2028,17 @@ func (svc *Service) NewMDMInvalidJSONConfigProfile(ctx context.Context, teamID u
 	// svc.authz is only available on the concrete Service struct, not on the
 	// Service interface so it cannot be done in the endpoint itself.
 	return fleet.NewInvalidArgumentError("profile", err.Error()).WithStatus(http.StatusBadRequest)
+}
+
+func (svc *Service) NewMDMActivationUnsupportedProfile(ctx context.Context, teamID uint) error {
+	if err := svc.authz.Authorize(ctx, &fleet.MDMConfigProfileAuthz{TeamID: &teamID}, fleet.ActionWrite); err != nil {
+		return ctxerr.Wrap(ctx, err)
+	}
+
+	// this is required because we need authorize to return the error, and
+	// svc.authz is only available on the concrete Service struct, not on the
+	// Service interface so it cannot be done in the endpoint itself.
+	return fleet.NewInvalidArgumentError("activation", ActivationUnsupportedProfileErrorMsg)
 }
 
 func (svc *Service) NewMDMUnsupportedConfigProfile(ctx context.Context, teamID uint, filename string) error {

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -1681,9 +1681,7 @@ type newMDMConfigProfileRequest struct {
 	LabelsIncludeAll []string
 	LabelsIncludeAny []string
 	LabelsExcludeAny []string
-	// Activation is an optional custom activation declaration, only supported
-	// alongside an Apple declaration (DDM) profile.
-	Activation *multipart.FileHeader
+	Activation       *multipart.FileHeader
 }
 
 func (newMDMConfigProfileRequest) DecodeRequest(ctx context.Context, r *http.Request) (interface{}, error) {
@@ -1721,9 +1719,8 @@ func (newMDMConfigProfileRequest) DecodeRequest(ctx context.Context, r *http.Req
 		return nil, fleet.NewInvalidArgumentError("mdm", fleet.MaxProfileSizeErrMsg)
 	}
 
-	// add activation, optional and only meaningful for declaration (DDM)
-	// profiles -- that's enforced by the endpoint, which is where the profile
-	// type is determined.
+	// Only meaningful for declarations; enforced by the endpoint, which
+	// determines the profile type.
 	if fhs, ok := r.MultipartForm.File["activation"]; ok && len(fhs) > 0 {
 		decoded.Activation = fhs[0]
 		if decoded.Activation.Size > fleet.MaxProfileSize {
@@ -1832,14 +1829,9 @@ func newMDMConfigProfileEndpoint(ctx context.Context, request interface{}, svc f
 		}
 	}
 
-	// An activation gates a DDM configuration declaration, so it's meaningless
-	// next to any other profile type. This check lives in the endpoint because
-	// the endpoint is what determines the profile's type; the message is shared
-	// with the batch path so the same mistake reads the same way.
+	// Checked here because the endpoint is what determines the profile type,
+	// and routed through the service so the error sits behind an authz check.
 	if len(activation) > 0 && !isAppleDeclarationJSON {
-		// routed through the service so the error is returned from behind an
-		// authorization check; returning it straight from the endpoint would
-		// skip authz entirely and surface as a bare "forbidden"
 		return &newMDMConfigProfileResponse{
 			Err: svc.NewMDMActivationUnsupportedProfile(ctx, req.TeamID),
 		}, nil
@@ -1904,9 +1896,7 @@ type updateMDMConfigProfileRequest struct {
 	LabelsIncludeAll []string
 	LabelsIncludeAny []string
 	LabelsExcludeAny []string
-	// Activation is an optional custom activation, only supported for
-	// declaration (DDM) profiles.
-	Activation *multipart.FileHeader
+	Activation       *multipart.FileHeader
 }
 
 func (updateMDMConfigProfileRequest) DecodeRequest(ctx context.Context, r *http.Request) (any, error) {
@@ -1935,9 +1925,7 @@ func (updateMDMConfigProfileRequest) DecodeRequest(ctx context.Context, r *http.
 		}
 	}
 
-	// activation is optional too, and only meaningful for declarations --
-	// that's enforced by the service, which is where the update path resolves
-	// the profile's type from its UUID
+	// Enforced by the service, which resolves the profile type from its UUID.
 	if fhs, ok := r.MultipartForm.File["activation"]; ok && len(fhs) > 0 {
 		decoded.Activation = fhs[0]
 		if decoded.Activation.Size > fleet.MaxProfileSize {
@@ -2098,10 +2086,7 @@ func (svc *Service) checkLabelsOnlyProfileUpdate(ctx context.Context, labelsIncl
 // and/or label targeting in place, dispatching by profile UUID to the
 // platform-specific implementation.
 func (svc *Service) UpdateMDMConfigProfile(ctx context.Context, profileUUID string, profile []byte, labelsInclude []string, labelsMembershipMode fleet.MDMLabelsMode, labelsExcludeAny []string, activation []byte) error {
-	// Unlike the create path, where the endpoint determines the profile type
-	// from the uploaded file, the update path dispatches here on the UUID
-	// prefix -- so this is where an activation on a non-declaration profile is
-	// rejected.
+	// The edit path resolves the profile type here rather than in the endpoint.
 	if len(activation) > 0 && !isAppleDeclarationUUID(profileUUID) {
 		if err := svc.authz.Authorize(ctx, &fleet.MDMConfigProfileAuthz{}, fleet.ActionWrite); err != nil {
 			return ctxerr.Wrap(ctx, err)

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -1901,6 +1901,9 @@ type updateMDMConfigProfileRequest struct {
 	LabelsIncludeAll []string
 	LabelsIncludeAny []string
 	LabelsExcludeAny []string
+	// Activation is an optional custom activation, only supported for
+	// declaration (DDM) profiles.
+	Activation *multipart.FileHeader
 }
 
 func (updateMDMConfigProfileRequest) DecodeRequest(ctx context.Context, r *http.Request) (any, error) {
@@ -1926,6 +1929,16 @@ func (updateMDMConfigProfileRequest) DecodeRequest(ctx context.Context, r *http.
 		decoded.Profile = fhs[0]
 		if decoded.Profile.Size > fleet.MaxProfileSize {
 			return nil, fleet.NewInvalidArgumentError("mdm", fleet.MaxProfileSizeErrMsg)
+		}
+	}
+
+	// activation is optional too, and only meaningful for declarations --
+	// that's enforced by the service, which is where the update path resolves
+	// the profile's type from its UUID
+	if fhs, ok := r.MultipartForm.File["activation"]; ok && len(fhs) > 0 {
+		decoded.Activation = fhs[0]
+		if decoded.Activation.Size > fleet.MaxProfileSize {
+			return nil, fleet.NewInvalidArgumentError("activation", fleet.MaxProfileSizeErrMsg)
 		}
 	}
 
@@ -1982,7 +1995,21 @@ func updateMDMConfigProfileEndpoint(ctx context.Context, request any, svc fleet.
 		labelsMode = fleet.LabelsIncludeAll
 	}
 
-	if err := svc.UpdateMDMConfigProfile(ctx, req.ProfileUUID, data, labels, labelsMode, req.LabelsExcludeAny); err != nil {
+	var activation []byte
+	if req.Activation != nil {
+		af, err := req.Activation.Open()
+		if err != nil {
+			return &updateMDMConfigProfileResponse{Err: err}, nil
+		}
+		defer af.Close()
+
+		activation, err = io.ReadAll(af)
+		if err != nil {
+			return &updateMDMConfigProfileResponse{Err: err}, nil
+		}
+	}
+
+	if err := svc.UpdateMDMConfigProfile(ctx, req.ProfileUUID, data, labels, labelsMode, req.LabelsExcludeAny, activation); err != nil {
 		return &updateMDMConfigProfileResponse{Err: err}, nil
 	}
 
@@ -2056,7 +2083,18 @@ func (svc *Service) checkLabelsOnlyProfileUpdate(ctx context.Context, labelsIncl
 // UpdateMDMConfigProfile updates an existing configuration profile's contents
 // and/or label targeting in place, dispatching by profile UUID to the
 // platform-specific implementation.
-func (svc *Service) UpdateMDMConfigProfile(ctx context.Context, profileUUID string, profile []byte, labelsInclude []string, labelsMembershipMode fleet.MDMLabelsMode, labelsExcludeAny []string) error {
+func (svc *Service) UpdateMDMConfigProfile(ctx context.Context, profileUUID string, profile []byte, labelsInclude []string, labelsMembershipMode fleet.MDMLabelsMode, labelsExcludeAny []string, activation []byte) error {
+	// Unlike the create path, where the endpoint determines the profile type
+	// from the uploaded file, the update path dispatches here on the UUID
+	// prefix -- so this is where an activation on a non-declaration profile is
+	// rejected.
+	if len(activation) > 0 && !isAppleDeclarationUUID(profileUUID) {
+		if err := svc.authz.Authorize(ctx, &fleet.MDMConfigProfileAuthz{}, fleet.ActionWrite); err != nil {
+			return ctxerr.Wrap(ctx, err)
+		}
+		return fleet.NewInvalidArgumentError("activation", ActivationUnsupportedProfileErrorMsg)
+	}
+
 	switch {
 	case isAppleProfileUUID(profileUUID):
 		return svc.updateMDMAppleConfigProfile(ctx, profileUUID, profile, labelsInclude, labelsMembershipMode, labelsExcludeAny)
@@ -2065,7 +2103,7 @@ func (svc *Service) UpdateMDMConfigProfile(ctx context.Context, profileUUID stri
 	case isAndroidProfileUUID(profileUUID):
 		return svc.updateMDMAndroidConfigProfile(ctx, profileUUID, profile, labelsInclude, labelsMembershipMode, labelsExcludeAny)
 	case isAppleDeclarationUUID(profileUUID):
-		return svc.updateMDMAppleDeclaration(ctx, profileUUID, profile, labelsInclude, labelsMembershipMode, labelsExcludeAny)
+		return svc.updateMDMAppleDeclaration(ctx, profileUUID, profile, labelsInclude, labelsMembershipMode, labelsExcludeAny, activation)
 	default:
 		if err := svc.authz.Authorize(ctx, &fleet.MDMConfigProfileAuthz{}, fleet.ActionWrite); err != nil {
 			return ctxerr.Wrap(ctx, err)

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -2088,7 +2088,10 @@ func (svc *Service) checkLabelsOnlyProfileUpdate(ctx context.Context, labelsIncl
 func (svc *Service) UpdateMDMConfigProfile(ctx context.Context, profileUUID string, profile []byte, labelsInclude []string, labelsMembershipMode fleet.MDMLabelsMode, labelsExcludeAny []string, activation []byte) error {
 	// The edit path resolves the profile type here rather than in the endpoint.
 	if len(activation) > 0 && !isAppleDeclarationUUID(profileUUID) {
-		if err := svc.authz.Authorize(ctx, &fleet.MDMConfigProfileAuthz{}, fleet.ActionWrite); err != nil {
+		// Basic check only, as in the type-specific update methods: the profile's
+		// team isn't known yet, and authorizing an empty MDMConfigProfileAuthz
+		// needs a global role, so team admins would get forbidden instead of this.
+		if err := svc.authz.Authorize(ctx, &fleet.Team{}, fleet.ActionRead); err != nil {
 			return ctxerr.Wrap(ctx, err)
 		}
 		return fleet.NewInvalidArgumentError("activation", ActivationUnsupportedProfileErrorMsg)

--- a/server/service/mdm_test.go
+++ b/server/service/mdm_test.go
@@ -1945,12 +1945,12 @@ func TestUpdateMDMConfigProfileDispatch(t *testing.T) {
 		return nil, errors.New("simulated declaration lookup error")
 	}
 
-	err := svc.UpdateMDMConfigProfile(ctx, declUUID, nil, nil, fleet.LabelsIncludeAll, nil)
+	err := svc.UpdateMDMConfigProfile(ctx, declUUID, nil, nil, fleet.LabelsIncludeAll, nil, nil)
 	require.ErrorContains(t, err, "simulated declaration lookup error")
 	require.True(t, ds.GetMDMAppleDeclarationFuncInvoked)
 
 	// an unrecognized profile UUID prefix still falls through to "not supported".
-	err = svc.UpdateMDMConfigProfile(ctx, "unrecognized-"+uuid.NewString(), nil, nil, fleet.LabelsIncludeAll, nil)
+	err = svc.UpdateMDMConfigProfile(ctx, "unrecognized-"+uuid.NewString(), nil, nil, fleet.LabelsIncludeAll, nil, nil)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "updating this profile type is not yet supported")
 }
@@ -4223,7 +4223,7 @@ func TestUpdateMDMAndroidConfigProfile(t *testing.T) {
 			return nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil)
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, nil)
 		require.NoError(t, err)
 
 		assert.Empty(t, updated.RawJSON)
@@ -4256,7 +4256,7 @@ func TestUpdateMDMAndroidConfigProfile(t *testing.T) {
 			return nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, newContent, nil, fleet.LabelsIncludeAll, nil)
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, newContent, nil, fleet.LabelsIncludeAll, nil, nil)
 		require.NoError(t, err)
 		assert.Equal(t, newContent, updated.RawJSON)
 		assert.Equal(t, existing.Name, updated.Name)
@@ -4286,7 +4286,7 @@ func TestUpdateMDMAndroidConfigProfile(t *testing.T) {
 			return nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, newContent, nil, fleet.LabelsIncludeAll, nil)
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, newContent, nil, fleet.LabelsIncludeAll, nil, nil)
 		require.NoError(t, err)
 		assert.Equal(t, newContent, updated.RawJSON)
 		require.NotNil(t, updated.TeamID)
@@ -4315,7 +4315,7 @@ func TestUpdateMDMAndroidConfigProfile(t *testing.T) {
 			return &p, nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, newContent, []string{"label1"}, fleet.LabelsIncludeAny, []string{"label2"})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, newContent, []string{"label1"}, fleet.LabelsIncludeAny, []string{"label2"}, nil)
 		require.NoError(t, err)
 		assert.Equal(t, newContent, updated.RawJSON)
 		require.Len(t, updated.LabelsIncludeAny, 1)
@@ -4337,7 +4337,7 @@ func TestUpdateMDMAndroidConfigProfile(t *testing.T) {
 		}
 
 		invalidContent := []byte(`{"notARealAndroidPolicyField": true}`)
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, invalidContent, nil, fleet.LabelsIncludeAll, nil)
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, invalidContent, nil, fleet.LabelsIncludeAll, nil, nil)
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "Invalid JSON payload")
 	})
@@ -4354,7 +4354,7 @@ func TestUpdateMDMAndroidConfigProfile(t *testing.T) {
 			return nil, nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, []string{"label1"})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, []string{"label1"}, nil)
 		require.Error(t, err)
 		assert.ErrorContains(t, err, `label "label1" cannot appear in both include and exclude lists`)
 	})
@@ -4371,7 +4371,7 @@ func TestUpdateMDMAndroidConfigProfile(t *testing.T) {
 			return nil, nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil)
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, nil)
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "managed by Fleet")
 	})
@@ -4383,7 +4383,7 @@ func TestUpdateMDMAndroidConfigProfile(t *testing.T) {
 			return nil, wantErr
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, "g"+uuid.NewString(), nil, nil, fleet.LabelsIncludeAll, nil)
+		err := svc.UpdateMDMConfigProfile(ctx, "g"+uuid.NewString(), nil, nil, fleet.LabelsIncludeAll, nil, nil)
 		require.Error(t, err)
 		assert.ErrorIs(t, err, wantErr)
 	})
@@ -4400,7 +4400,7 @@ func TestUpdateMDMAndroidConfigProfile(t *testing.T) {
 			return nil, nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil)
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, nil)
 		require.ErrorIs(t, err, fleet.ErrMissingLicense)
 		require.ErrorContains(t, err, "Scoping configuration profiles with labels requires Fleet Premium license")
 
@@ -4409,7 +4409,7 @@ func TestUpdateMDMAndroidConfigProfile(t *testing.T) {
 			return &p, nil
 		}
 		newContent := []byte(`{"screenCaptureDisabled": false}`)
-		err = svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, newContent, nil, fleet.LabelsIncludeAll, nil)
+		err = svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, newContent, nil, fleet.LabelsIncludeAll, nil, nil)
 		require.NoError(t, err)
 	})
 
@@ -4430,14 +4430,14 @@ func TestUpdateMDMAndroidConfigProfile(t *testing.T) {
 		}
 
 		newContent := []byte(`{"name": "$FLEET_VAR_HOST_UUID"}`)
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, newContent, nil, fleet.LabelsIncludeAll, nil)
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, newContent, nil, fleet.LabelsIncludeAll, nil, nil)
 		require.NoError(t, err)
 		assert.Contains(t, capturedVars, fleet.FleetVarHostUUID)
 
 		// labels-only edit passes no variables -- the datastore leaves the
 		// existing associations untouched when no content is provided
 		capturedVars = []fleet.FleetVarName{fleet.FleetVarName("sentinel")}
-		err = svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil)
+		err = svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, nil)
 		require.NoError(t, err)
 		assert.Empty(t, capturedVars)
 	})
@@ -4458,10 +4458,10 @@ func TestUpdateMDMAndroidConfigProfile(t *testing.T) {
 		}
 
 		newContent := []byte(`{"screenCaptureDisabled": false}`)
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, newContent, nil, fleet.LabelsIncludeAll, nil)
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, newContent, nil, fleet.LabelsIncludeAll, nil, nil)
 		require.ErrorIs(t, err, fleet.ErrMissingLicense)
 
-		err = svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil)
+		err = svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, nil)
 		require.ErrorIs(t, err, fleet.ErrMissingLicense)
 	})
 
@@ -4514,10 +4514,10 @@ func TestUpdateMDMAndroidConfigProfile(t *testing.T) {
 
 				// profile content and labels are deliberately nil/empty here --
 				// this isolates the authz checks from content/label validation.
-				err := svc.UpdateMDMConfigProfile(ctx, noTeamProfile.ProfileUUID, nil, nil, fleet.LabelsIncludeAll, nil)
+				err := svc.UpdateMDMConfigProfile(ctx, noTeamProfile.ProfileUUID, nil, nil, fleet.LabelsIncludeAll, nil, nil)
 				checkShouldFail(t, err, tt.shouldFailGlobal)
 
-				err = svc.UpdateMDMConfigProfile(ctx, teamProfile.ProfileUUID, nil, nil, fleet.LabelsIncludeAll, nil)
+				err = svc.UpdateMDMConfigProfile(ctx, teamProfile.ProfileUUID, nil, nil, fleet.LabelsIncludeAll, nil, nil)
 				checkShouldFail(t, err, tt.shouldFailTeam)
 			})
 		}

--- a/server/service/windows_mdm_profiles_test.go
+++ b/server/service/windows_mdm_profiles_test.go
@@ -678,7 +678,7 @@ func TestUpdateMDMWindowsConfigProfile(t *testing.T) {
 			return nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil)
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, nil)
 		require.NoError(t, err)
 
 		assert.Empty(t, updated.SyncML)
@@ -714,7 +714,7 @@ func TestUpdateMDMWindowsConfigProfile(t *testing.T) {
 			return nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, syncML, nil, fleet.LabelsIncludeAll, nil)
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, syncML, nil, fleet.LabelsIncludeAll, nil, nil)
 		require.NoError(t, err)
 		assert.Equal(t, syncML, updated.SyncML)
 		assert.Equal(t, existing.Name, updated.Name)
@@ -744,7 +744,7 @@ func TestUpdateMDMWindowsConfigProfile(t *testing.T) {
 			return nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, syncML, nil, fleet.LabelsIncludeAll, nil)
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, syncML, nil, fleet.LabelsIncludeAll, nil, nil)
 		require.NoError(t, err)
 		assert.Equal(t, syncML, updated.SyncML)
 		require.NotNil(t, updated.TeamID)
@@ -773,7 +773,7 @@ func TestUpdateMDMWindowsConfigProfile(t *testing.T) {
 			return &p, nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, syncML, []string{"label1"}, fleet.LabelsIncludeAny, []string{"label2"})
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, syncML, []string{"label1"}, fleet.LabelsIncludeAny, []string{"label2"}, nil)
 		require.NoError(t, err)
 		assert.Equal(t, syncML, updated.SyncML)
 		require.Len(t, updated.LabelsIncludeAny, 1)
@@ -794,7 +794,7 @@ func TestUpdateMDMWindowsConfigProfile(t *testing.T) {
 			return nil, nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil)
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, nil)
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "managed by Fleet")
 	})
@@ -806,7 +806,7 @@ func TestUpdateMDMWindowsConfigProfile(t *testing.T) {
 			return nil, wantErr
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, "w"+uuid.NewString(), nil, nil, fleet.LabelsIncludeAll, nil)
+		err := svc.UpdateMDMConfigProfile(ctx, "w"+uuid.NewString(), nil, nil, fleet.LabelsIncludeAll, nil, nil)
 		require.Error(t, err)
 		assert.ErrorIs(t, err, wantErr)
 	})
@@ -823,7 +823,7 @@ func TestUpdateMDMWindowsConfigProfile(t *testing.T) {
 			return nil, nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil)
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, nil)
 		require.ErrorIs(t, err, fleet.ErrMissingLicense)
 		require.ErrorContains(t, err, "Scoping configuration profiles with labels requires Fleet Premium license")
 
@@ -832,7 +832,7 @@ func TestUpdateMDMWindowsConfigProfile(t *testing.T) {
 			return &p, nil
 		}
 		syncML := syncMLForTest("./Device/Vendor/MSFT/Policy/Config/Bluetooth/AllowDiscoverableMode")
-		err = svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, syncML, nil, fleet.LabelsIncludeAll, nil)
+		err = svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, syncML, nil, fleet.LabelsIncludeAll, nil, nil)
 		require.NoError(t, err)
 	})
 
@@ -852,10 +852,10 @@ func TestUpdateMDMWindowsConfigProfile(t *testing.T) {
 		}
 
 		syncML := syncMLForTest("./Device/Vendor/MSFT/Policy/Config/Bluetooth/AllowDiscoverableMode")
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, syncML, nil, fleet.LabelsIncludeAll, nil)
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, syncML, nil, fleet.LabelsIncludeAll, nil, nil)
 		require.ErrorIs(t, err, fleet.ErrMissingLicense)
 
-		err = svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil)
+		err = svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, nil, []string{"label1"}, fleet.LabelsIncludeAny, nil, nil)
 		require.ErrorIs(t, err, fleet.ErrMissingLicense)
 	})
 
@@ -874,7 +874,7 @@ func TestUpdateMDMWindowsConfigProfile(t *testing.T) {
 			return &p, nil
 		}
 
-		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, syncML, nil, fleet.LabelsIncludeAll, nil)
+		err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, syncML, nil, fleet.LabelsIncludeAll, nil, nil)
 		require.NoError(t, err)
 		assert.Contains(t, capturedVars, fleet.FleetVarName("HOST_UUID"))
 	})
@@ -895,7 +895,7 @@ func TestUpdateMDMWindowsConfigProfile(t *testing.T) {
 				return &p, nil
 			}
 
-			err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, osUpdateSyncML, nil, fleet.LabelsIncludeAll, nil)
+			err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, osUpdateSyncML, nil, fleet.LabelsIncludeAll, nil, nil)
 			require.NoError(t, err)
 			assert.Equal(t, osUpdateSyncML, updated.SyncML)
 		})
@@ -921,7 +921,7 @@ func TestUpdateMDMWindowsConfigProfile(t *testing.T) {
 				return nil, nil
 			}
 
-			err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, osUpdateSyncML, nil, fleet.LabelsIncludeAll, nil)
+			err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, osUpdateSyncML, nil, fleet.LabelsIncludeAll, nil, nil)
 			require.Error(t, err)
 			assert.ErrorContains(t, err, fleet.OSUpdatesAlreadyConfiguredErrorMessage)
 		})
@@ -938,7 +938,7 @@ func TestUpdateMDMWindowsConfigProfile(t *testing.T) {
 				return nil, nil
 			}
 
-			err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, osUpdateSyncML, nil, fleet.LabelsIncludeAll, nil)
+			err := svc.UpdateMDMConfigProfile(ctx, existing.ProfileUUID, osUpdateSyncML, nil, fleet.LabelsIncludeAll, nil, nil)
 			require.ErrorIs(t, err, fleet.ErrMissingLicense)
 		})
 	})
@@ -992,10 +992,10 @@ func TestUpdateMDMWindowsConfigProfile(t *testing.T) {
 
 				// profile content and labels are deliberately nil/empty here --
 				// this isolates the authz checks from content/label validation.
-				err := svc.UpdateMDMConfigProfile(ctx, noTeamProfile.ProfileUUID, nil, nil, fleet.LabelsIncludeAll, nil)
+				err := svc.UpdateMDMConfigProfile(ctx, noTeamProfile.ProfileUUID, nil, nil, fleet.LabelsIncludeAll, nil, nil)
 				checkShouldFail(t, err, tt.shouldFailGlobal)
 
-				err = svc.UpdateMDMConfigProfile(ctx, teamProfile.ProfileUUID, nil, nil, fleet.LabelsIncludeAll, nil)
+				err = svc.UpdateMDMConfigProfile(ctx, teamProfile.ProfileUUID, nil, nil, fleet.LabelsIncludeAll, nil, nil)
 				checkShouldFail(t, err, tt.shouldFailTeam)
 			})
 		}


### PR DESCRIPTION
**Related issue:** Resolves #49970

Adds custom activations to the single-profile paths for declaration (DDM) profiles — create, edit, delete and read — and unblocks management declarations. Part of #48222.

Batch/GitOps is #49972; serving the custom activation to devices is #49971.

### Custom activations

- `POST /configuration_profiles` and `PATCH /configuration_profiles/{uuid}` accept an optional `activation` file part, rejected for any profile type other than an Apple declaration.
- Validation requires an activation `Type` (any `com.apple.activation.*`, so future Apple types need no Fleet change), an `Identifier`, and exactly one `StandardConfigurations` entry naming the configuration it ships with. `Predicate` and every other key are stored and served verbatim for the device to evaluate.
- Premium-only, unconditionally. `parseAndValidateAppleDeclaration` requires premium only when a fleet or labels are involved, so an unassigned unlabeled DDM profile is free today; the activation carries its own gate.
- The activation's Fleet variables are validated against `fleetVarsSupportedInDDMDeclarations` — already exactly the set specified for activations — and associated via `mdm_configuration_profile_variables.apple_ddm_activation_uuid`.
- Returned base64-encoded on both the list and single-profile endpoints, per the API reference draft (#49768), and omitted entirely when absent.

What an edit does to a stored activation:

| Request | Result |
| --- | --- |
| activation supplied | replaces the stored one |
| new profile content, no activation | stored one is cleared — this is how it's removed |
| labels-only edit | stored one is carried forward |

The third row matters: the datastore clears the activation of any declaration written without one, so a labels-only edit rebuilding the declaration from the existing row would otherwise silently wipe it. `GetMDMAppleDeclaration` loads the activation so it can be carried forward, and there's a test asserting it.

### Management declarations

`com.apple.management.*` uploads are unblocked via a prefix check, so future management declarations work without a product change. Types to block go in the existing `ForbiddenDeclTypes` deny list, which is already evaluated ahead of the prefix. An activation supplied alongside a management declaration is rejected — those are never activated.

Routing them to the manifest's Management section is #49971's work.

### Notes for review

**Where the non-declaration guard lives differs by path, deliberately.** Create resolves the profile type in the endpoint from the uploaded file; edit resolves it in the service from the UUID prefix. The check sits wherever the type becomes known. Both use the same message so the mistake reads identically.

**Endpoint-level errors must be returned from behind an authz check.** The create-path guard originally returned the error straight from the endpoint, which skips authorization and surfaces to the client as a bare `forbidden` rather than the validation message. It now goes through `NewMDMActivationUnsupportedProfile`, alongside the existing `NewMDMUnsupportedConfigProfile` and `NewMDMInvalidJSONConfigProfile`, which exist for the same reason. This was caught by the integration tests, not the unit tests — service-level tests bypass the authz middleware.

**Activation rows are keyed on `declaration_uuid`, not inserted fresh.** An edit reuses the row, so the Fleet variable associations hanging off it survive. The UUID is read back after the upsert rather than reusing the generated one, since `ON DUPLICATE KEY UPDATE` keeps the existing row.

**Secrets are expanded for validation but stored unexpanded**, so validation runs against the document the device receives without persisting secret values.

`MDMAppleCustomActivation` is the storage type; `MDMAppleDDMActivation` was already taken by Apple's wire format.

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

No changes file: the feature isn't reachable by users until the DDM sync work in #49971 lands.

## Testing

- [x] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually

**Unit** (`server/fleet`): `GetRawActivationValues` and `ValidateUserProvided` — valid activation, unknown type under the activation prefix, missing `Type`, a configuration type supplied as an activation, missing `Identifier`, zero/multiple/mismatched `StandardConfigurations`, all problems reported at once, plus `IsManagementDeclaration`.

**Service** (`server/service`): activation accepted, mismatched configuration rejected, malformed JSON rejected, rejected on a management declaration, supported Fleet variables recorded, unsupported rejected, premium required even where the declaration is free. On edit: activation-only edit keeps content, labels-only edit preserves the activation, new content without an activation clears it, and exactly one `edited_declaration_profile` activity fires.

**Datastore** (`server/datastore/mysql`): write, read-back through list and single get, edit reusing the row, Fleet variable association, and removal cascading to the variable rows.

**Integration** (`integration_mdm_ddm_test.go`): multipart upload with an activation, read back and asserted base64-decoded against the raw response body; the key omitted entirely for a declaration without one; two management declarations uploaded and coexisting; activation on a `.mobileconfig` rejected on both create and edit; activation-only `PATCH` replacing the activation while leaving the declaration untouched.

The multipart test helper now supports more than one file part — nothing could build that request before, which is why the decode path was previously untested. Single-file callers are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional custom activations for Apple DDM configuration declarations.
  - Activations support secrets, Fleet variables, and custom host vitals.
  - Activation data appears when viewing or downloading applicable profiles.
  - Activation files can be added, updated, preserved during label-only edits, or removed during content replacement.
  - Management declarations can coexist with supported configuration declarations.

- **Validation**
  - Added checks for declaration matching, supported profile types, file limits, and Premium licensing.
  - Clear errors are provided when activations are used with management declarations or non-DDM profiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

