### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/android-studio/windows.json
+++ b/ee/maintained-apps/outputs/android-studio/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.1.2.10",
+      "version": "2026.1.3.7",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Android Studio' AND publisher = 'Google LLC';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Android Studio' AND publisher = 'Google LLC' AND version_compare(version, '2026.1.2.10') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Android Studio' AND publisher = 'Google LLC' AND version_compare(version, '2026.1.3.7') < 0);"
       },
-      "installer_url": "https://edgedl.me.gvt1.com/android/studio/install/2026.1.2.10/android-studio-quail2-windows.exe",
+      "installer_url": "https://edgedl.me.gvt1.com/android/studio/install/2026.1.3.7/android-studio-quail3-windows.exe",
       "install_script_ref": "36676cba",
       "uninstall_script_ref": "c48a6948",
-      "sha256": "938fd37c6029c2bdff8b62bed4fb8c87a260bebe2dc7da12d3f79b3af432829e",
+      "sha256": "33c0da36175dbab84b16257e9709fce0ca9bdc533af92ed08d6634116f78bcdd",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/aws-cli/windows.json
+++ b/ee/maintained-apps/outputs/aws-cli/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.36.11",
+      "version": "2.36.13",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'AWS Command Line Interface v2 %' AND publisher = 'Amazon Web Services';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'AWS Command Line Interface v2 %' AND publisher = 'Amazon Web Services' AND version_compare(version, '2.36.11') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'AWS Command Line Interface v2 %' AND publisher = 'Amazon Web Services' AND version_compare(version, '2.36.13') < 0);"
       },
-      "installer_url": "https://awscli.amazonaws.com/AWSCLIV2-2.36.11.msi",
+      "installer_url": "https://awscli.amazonaws.com/AWSCLIV2-2.36.13.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "58bcd016",
-      "sha256": "c6e04d7564ad6a0ce9e03a135e2d9ce854f74192051c0c6d65ec516e0531c100",
+      "sha256": "8842aec8f8d9b7d7458f2ddc4107d0ec10b731f7657bd930d1780bdf77b22374",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/busycontacts/darwin.json
+++ b/ee/maintained-apps/outputs/busycontacts/darwin.json
@@ -1,12 +1,12 @@
 {
   "versions": [
     {
-      "version": "2026.2.2",
+      "version": "2026.3.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.busymac.busycontacts';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.busymac.busycontacts' AND version_compare(bundle_short_version, '2026.2.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.busymac.busycontacts' AND version_compare(bundle_short_version, '2026.3.1') < 0);"
       },
-      "installer_url": "https://www.busymac.com/download/bct-2026.2.2.zip",
+      "installer_url": "https://www.busymac.com/download/bct-2026.3.1.zip",
       "install_script_ref": "b1c9951e",
       "uninstall_script_ref": "9a7ce57b",
       "sha256": "no_check",

--- a/ee/maintained-apps/outputs/calibre/darwin.json
+++ b/ee/maintained-apps/outputs/calibre/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "9.11.0",
+      "version": "9.12.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'net.kovidgoyal.calibre';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.kovidgoyal.calibre' AND version_compare(bundle_short_version, '9.11.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.kovidgoyal.calibre' AND version_compare(bundle_short_version, '9.12.0') < 0);"
       },
-      "installer_url": "https://download.calibre-ebook.com/9.11.0/calibre-9.11.0.dmg",
+      "installer_url": "https://download.calibre-ebook.com/9.12.0/calibre-9.12.0.dmg",
       "install_script_ref": "099b9491",
       "uninstall_script_ref": "1945fe9a",
-      "sha256": "300c1acf1f8b941e265d0f8c39fc608c3cfea865a31702e084643d536b78c951",
+      "sha256": "9bf73b38ecf46e064b068c89047e6d55c827458a1db20d7c90dc435db4b1783a",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/calibre/windows.json
+++ b/ee/maintained-apps/outputs/calibre/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "9.11.0",
+      "version": "9.12.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'calibre %' AND publisher = 'Kovid Goyal';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'calibre %' AND publisher = 'Kovid Goyal' AND version_compare(version, '9.11.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'calibre %' AND publisher = 'Kovid Goyal' AND version_compare(version, '9.12.0') < 0);"
       },
-      "installer_url": "https://download.calibre-ebook.com/9.11.0/calibre-64bit-9.11.0.msi",
+      "installer_url": "https://download.calibre-ebook.com/9.12.0/calibre-64bit-9.12.0.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "3ae8dcd8",
-      "sha256": "59bd2a7fb7978665e16b7f94218479d64ddedc80ec7fccb47a6768ae348ceb3d",
+      "sha256": "f6456073bfcf37adf6302fb4149fa8b4d798d411bc0dafd99cb629a5006dcfa6",
       "default_categories": [
         "Productivity"
       ],

--- a/ee/maintained-apps/outputs/obs/windows.json
+++ b/ee/maintained-apps/outputs/obs/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "32.2.0",
+      "version": "32.2.1",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'OBS Studio' AND publisher = 'OBS Project';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'OBS Studio' AND publisher = 'OBS Project' AND version_compare(version, '32.2.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'OBS Studio' AND publisher = 'OBS Project' AND version_compare(version, '32.2.1') < 0);"
       },
-      "installer_url": "https://github.com/obsproject/obs-studio/releases/download/32.2.0/OBS-Studio-32.2.0-Windows-x64-Installer.exe",
+      "installer_url": "https://github.com/obsproject/obs-studio/releases/download/32.2.1/OBS-Studio-32.2.1-Windows-x64-Installer.exe",
       "install_script_ref": "8a919fae",
       "uninstall_script_ref": "145a6b76",
-      "sha256": "e85f7cc39129c4c1999d84765fde8dade4c9a9800972f78d752ad218e7c50302",
+      "sha256": "bbb95e52b96ad9b7ccd5abd13121379d29774d6cc5fdbef82ffa249e8a24a289",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/onedrive/windows.json
+++ b/ee/maintained-apps/outputs/onedrive/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.113.0614.0004",
+      "version": "26.123.0628.0001",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Microsoft OneDrive' AND publisher = 'Microsoft Corporation';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Microsoft OneDrive' AND publisher = 'Microsoft Corporation' AND version_compare(version, '26.113.0614.0004') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Microsoft OneDrive' AND publisher = 'Microsoft Corporation' AND version_compare(version, '26.123.0628.0001') < 0);"
       },
-      "installer_url": "https://oneclient.sfx.ms/Win/Installers/26.113.0614.0004/amd64/OneDriveSetup.exe",
+      "installer_url": "https://oneclient.sfx.ms/Win/Installers/26.123.0628.0001/amd64/OneDriveSetup.exe",
       "install_script_ref": "ab0b56ab",
       "uninstall_script_ref": "374be511",
-      "sha256": "b1c63da9ee9a34ccdb35d8c8c26cfca970048091f1f138a48ab3318dacdae990",
+      "sha256": "43b9414209461265a61fd576daddf94cdffabc1f62a7ac3675aa754d655b337c",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/postman/darwin.json
+++ b/ee/maintained-apps/outputs/postman/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.21.7",
+      "version": "12.21.8",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac' AND version_compare(bundle_short_version, '12.21.7') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac' AND version_compare(bundle_short_version, '12.21.8') < 0);"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.21.7/osx_arm64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.21.8/osx_arm64",
       "install_script_ref": "0e85ef74",
       "uninstall_script_ref": "20883323",
-      "sha256": "45885252ddfa1568e448f3c463ae6d6d62e25c94796f8a09da8cb598d4dd2e44",
+      "sha256": "67cbbcce5bd33f0821a065b7f3aa8b57839766da1ad129c1877fd2dce81dd6d3",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/postman/windows.json
+++ b/ee/maintained-apps/outputs/postman/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.21.7",
+      "version": "12.21.8",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.21.7') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.21.8') < 0);"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.21.7/windows_64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.21.8/windows_64",
       "install_script_ref": "8594f0bc",
       "uninstall_script_ref": "fd59d029",
-      "sha256": "dfb73305f085a56686b04adf91726c34f12b195c816c650a491bbea3c8e2559f",
+      "sha256": "f1bdc5a65f59d5dd972c611b2eb2b217ca97ea8f2199fc59aed4d31e346a12dd",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/typora/darwin.json
+++ b/ee/maintained-apps/outputs/typora/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.14.6",
+      "version": "1.14.8",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'abnerworks.Typora';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'abnerworks.Typora' AND version_compare(bundle_short_version, '1.14.6') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'abnerworks.Typora' AND version_compare(bundle_short_version, '1.14.8') < 0);"
       },
-      "installer_url": "https://downloads.typora.io/mac/Typora-1.14.6.dmg",
+      "installer_url": "https://downloads.typora.io/mac/Typora-1.14.8.dmg",
       "install_script_ref": "163abff2",
       "uninstall_script_ref": "a8ba94c9",
-      "sha256": "ff1e93e87fcd5b4211796f4bf6d3d56affa26b9d12342b9f5e2c1b297dcc4dd7",
+      "sha256": "048b3b10100938ffc29f89a517197066c3625e0d338a27e767aee6efc84c0527",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/unity-hub/darwin.json
+++ b/ee/maintained-apps/outputs/unity-hub/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.19.5",
+      "version": "3.20.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.unity3d.unityhub';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.unity3d.unityhub' AND version_compare(bundle_short_version, '3.19.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.unity3d.unityhub' AND version_compare(bundle_short_version, '3.20.0') < 0);"
       },
-      "installer_url": "https://public-cdn.cloud.unity3d.com/hub/prod/3.19.5/UnityHubSetup-3.19.5-arm64.dmg",
+      "installer_url": "https://public-cdn.cloud.unity3d.com/hub/prod/3.20.0/UnityHubSetup-3.20.0-arm64.dmg",
       "install_script_ref": "f7867145",
       "uninstall_script_ref": "5b95ff58",
-      "sha256": "da6773add1f638d8bd00615a47661408d1de4a3c94e7efb5a37f1e7131e63272",
+      "sha256": "49bb701e48ac7aa02f352348fb6e0aae20f808730ee8f4c371b3c3494c6232d9",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/wispr-flow/darwin.json
+++ b/ee/maintained-apps/outputs/wispr-flow/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.6.288",
+      "version": "1.6.326",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.wispr-flow';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.wispr-flow' AND version_compare(bundle_short_version, '1.6.288') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.wispr-flow' AND version_compare(bundle_short_version, '1.6.326') < 0);"
       },
-      "installer_url": "https://dl.wisprflow.com/wispr-flow/darwin/arm64/dmgs/Flow-v1.6.288.dmg",
+      "installer_url": "https://dl.wisprflow.com/wispr-flow/darwin/arm64/dmgs/Flow-v1.6.326.dmg",
       "install_script_ref": "a95fa7bb",
       "uninstall_script_ref": "e0cf2e96",
-      "sha256": "7f8783d7b9f87f320fd6346d96067bed86d88013b97b7fa2939166f7dca17ccc",
+      "sha256": "e86e4fed4be5b321e87eec8ff21cd42a161183f18ac48df9a8182ce1f07f5d90",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated Android Studio for Windows to 2026.1.3.7 and AWS CLI for Windows to 2.36.13.
  * Updated Calibre for macOS and Windows to 9.12.0.
  * Updated OBS Studio for Windows to 32.2.1 and OneDrive for Windows to 26.123.0628.0001.
  * Updated Postman for macOS and Windows to 12.21.8.
  * Updated BusyContacts to 2026.3.1, Typora to 1.14.8, Unity Hub to 3.20.0, and Wispr Flow to 1.6.326.
  * Refreshed download metadata and integrity checks for all updated applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->