### PR TITLE
[YAML] [Guide] [Docs] Add linux platform option for labels (#44088)

### DIFF
--- a/articles/managing-labels-in-fleet.md
+++ b/articles/managing-labels-in-fleet.md
@@ -6,7 +6,7 @@ In Fleet, labels organize hosts into groups you can target with [software](https
 
 ## Label types
 
-- **Dynamic:** Query-based; auto-applied to any host returning a result for the label's SQL query. Optionally restrict to a platform (`darwin`, `windows`, `ubuntu`, `centos`).
+- **Dynamic:** Query-based; auto-applied to any host returning a result for the label's SQL query. Optionally restrict to a platform (`darwin`, `windows`, `linux`, `ubuntu`, `centos`). The `linux` option matches hosts on any Linux distribution.
 - **Manual:** Applied to an explicit list of hosts, specified by `hardware_serial`, `uuid`, or Fleet host ID. Useful for one-off groupings (e.g., a pilot group).
 - **Host vitals:** Auto-applied to hosts matching a host vital from your IdP. Supported criteria: `end_user_idp_group` and `end_user_idp_department`. Requires a connected IdP (Okta, Microsoft Entra ID, Google Workspace, authentik, or any SCIM provider; see [Foreign host vitals](https://fleetdm.com/guides/foreign-vitals-map-idp-users-to-hosts)).
 

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -38,8 +38,8 @@ The `hostname` host identifier is deprecated. Please use a host's `id`, `hardwar
 ```yaml
 labels:
   - name: Arm64
-    platform: darwin,windows
-    description: Hosts on the Arm64 architecture
+    platform: darwin
+    description: macOS hosts on the Arm64 architecture
     query: "SELECT 1 FROM system_info WHERE cpu_type LIKE 'arm64%' OR cpu_type LIKE 'aarch64%'"
     label_membership_type: dynamic
   - name: C-Suite

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -15,7 +15,7 @@ Labels support `path:` (single file) and `paths:` (glob pattern) references. See
 - `name` specifies the label's name. Must be unique across all global and fleet labels.
     + Changing a label's `name` in GitOps will delete and re-create the label, temporarily clearing its membership. To avoid this, update the label name in the UI before making the change in YAML. 
 - `description` specifies the label's description.
-- `platform` specifies platforms for the label to target. Provides an additional filter. Choices for platform are `darwin`, `windows`, `ubuntu`, and `centos`. All platforms are included by default and this option is represented by an empty string. Only supported if `label_membership_type` is `dynamic`.
+- `platform` specifies platforms for the label to target. Provides an additional filter. Choices for platform are `darwin`, `windows`, `linux`, `ubuntu`, and `centos`. The `linux` option targets hosts on any Linux distribution. All platforms are included by default and this option is represented by an empty string. Only supported if `label_membership_type` is `dynamic`.
 - `label_membership_type` specifies label type which determines how hosts are added to the label. Choices for type are `dynamic` , `manual`, and `host_vitals` (default: `dynamic`).
 - `query` is the query in SQL syntax used to filter the hosts. Only supported if `label_membership_type` is `dynamic`.
 - `hosts` is a list of host identifiers (`id`, `hardware_serial`, or `uuid`). The label will apply to any host with a matching identifier. Only supported if `label_membership_type` is `manual`. If omitted, existing host membership is preserved (no changes). If provided but empty, all hosts are removed from the label.

--- a/docs/solutions/labels/rollout-rings.labels.yml
+++ b/docs/solutions/labels/rollout-rings.labels.yml
@@ -13,9 +13,8 @@
 # would collide across platforms. Only running one OS? Delete the other two
 # platforms' blocks below; nothing else in this file depends on them.
 #
-# `platform` choices are `darwin`, `windows`, `ubuntu`, `centos`. There is
-# no bare "linux" value, so Linux rings list `ubuntu,centos` to cover both
-# distro families in one label.
+# `platform` choices are `darwin`, `windows`, `linux`, `ubuntu`, `centos`.
+# Linux rings use `linux`, which matches hosts on any Linux distribution.
  
 # ---- macOS --------------------------------------------------------------
  
@@ -126,7 +125,7 @@
 - name: Linux - Ring 1 - Canary (1%)
   description: "Cumulative ~1% shard. Linux only. First to receive new versions."
   label_membership_type: dynamic
-  platform: ubuntu,centos
+  platform: linux
   query: |
     SELECT 1 FROM system_info
     WHERE (
@@ -137,7 +136,7 @@
 - name: Linux - Ring 2 - Early (5%)
   description: "Cumulative. Linux only. Includes all hosts in Linux Ring 1."
   label_membership_type: dynamic
-  platform: ubuntu,centos
+  platform: linux
   query: |
     SELECT 1 FROM system_info
     WHERE (
@@ -148,7 +147,7 @@
 - name: Linux - Ring 3 - Pilot (25%)
   description: "Cumulative. Linux only. Includes all hosts in Linux Rings 1-2."
   label_membership_type: dynamic
-  platform: ubuntu,centos
+  platform: linux
   query: |
     SELECT 1 FROM system_info
     WHERE (
@@ -159,7 +158,7 @@
 - name: Linux - Ring 4 - Broad (75%)
   description: "Cumulative. Linux only. Includes all hosts in Linux Rings 1-3."
   label_membership_type: dynamic
-  platform: ubuntu,centos
+  platform: linux
   query: |
     SELECT 1 FROM system_info
     WHERE (
@@ -170,5 +169,5 @@
 - name: Linux - Ring 5 - All (100%)
   description: "All Linux hosts. Kept for promotion-target symmetry."
   label_membership_type: dynamic
-  platform: ubuntu,centos
+  platform: linux
   query: SELECT 1 FROM system_info;


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #50255 (sub-task of #44088)

Story #44088 adds `linux` as a valid `platform` option for dynamic labels, matching hosts on any Linux distribution. The REST API reference was already updated in #48508 (merged to `docs-v4.91.0`). This PR updates the three remaining documentation surfaces:

- **GitOps YAML reference** (`docs/Configuration/yaml-files.md`): the label `platform` bullet now lists `linux` among the choices and notes it targets hosts on any Linux distribution.
- **Labels guide** (`articles/managing-labels-in-fleet.md`): the "Dynamic" bullet now lists `linux` and notes it matches any Linux distribution.
- **Rollout rings solutions example** (`docs/solutions/labels/rollout-rings.labels.yml`): header comment lists `linux` among the choices, and the five Linux ring labels use `platform: linux` instead of `ubuntu,centos` (comma-separated values were never accepted by label platform validation, so those labels never matched any host).

Also fixes the inline example in `docs/Configuration/yaml-files.md`, which used `platform: darwin,windows` — invalid for the same reason (validation is an exact match against the allowed set in `server/fleet/labels.go`).

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

## Testing

- [x] QA'd all new/changed functionality manually (documentation-only change; verified no label-platform choice list in `docs/` or `articles/` is missing `linux`, and no comma-separated `platform` values remain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)