### PR TITLE
Remove stale Prometheus example config link from reference architectures doc

### DIFF
--- a/docs/Deploy/Reference-Architectures.md
+++ b/docs/Deploy/Reference-Architectures.md
@@ -562,7 +562,7 @@ Individual checks can be run by providing the `check` URL parameter (e.x., `/hea
 
 ### Metrics
 
-Fleet exposes server metrics in a format compatible with [Prometheus](https://prometheus.io/). A simple example Prometheus configuration is available in [tools/app/prometheus.yml](https://github.com/fleetdm/fleet/blob/194ad5963b0d55bdf976aa93f3de6cabd590c97a/tools/app/prometheus.yml).
+Fleet exposes server metrics in a format compatible with [Prometheus](https://prometheus.io/).
 
 Prometheus can be configured to use a wide range of service discovery mechanisms within AWS, GCP, Azure, Kubernetes, and more. See the Prometheus [configuration documentation](https://prometheus.io/docs/prometheus/latest/configuration/configuration/) for more information.
 


### PR DESCRIPTION
Removes the link to the example Prometheus config (`tools/app/prometheus.yml`) from the reference architectures doc, since that file is being removed in #50053.

Split out of #50053 so the docs change can be reviewed separately.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Documentation-only change; no changes file, tests, or QA needed.
