### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/dataflare/darwin.json
+++ b/ee/maintained-apps/outputs/dataflare/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.1.6",
+      "version": "3.1.7",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'app.dataflare.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.dataflare.desktop' AND version_compare(bundle_short_version, '3.1.6') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.dataflare.desktop' AND version_compare(bundle_short_version, '3.1.7') < 0);"
       },
-      "installer_url": "https://assets.dataflare.app/release/darwin/aarch64/Dataflare-3.1.6.dmg",
+      "installer_url": "https://assets.dataflare.app/release/darwin/aarch64/Dataflare-3.1.7.dmg",
       "install_script_ref": "d96ff327",
       "uninstall_script_ref": "bf5b4266",
-      "sha256": "31de1e61c720b56c096ef4c106e1adbb785a078d1f55de003120bff47cbb7641",
+      "sha256": "786baeadb508c179e987d117e1a05d25a86e2f83481b4cb746b3e02fd3f045ec",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/dataflare/windows.json
+++ b/ee/maintained-apps/outputs/dataflare/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.1.6",
+      "version": "3.1.7",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Dataflare' AND publisher = 'Dataflare';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Dataflare' AND publisher = 'Dataflare' AND version_compare(version, '3.1.6') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Dataflare' AND publisher = 'Dataflare' AND version_compare(version, '3.1.7') < 0);"
       },
-      "installer_url": "https://assets.dataflare.app/release/windows/x86_64/Dataflare-Setup-3.1.6.exe",
+      "installer_url": "https://assets.dataflare.app/release/windows/x86_64/Dataflare-Setup-3.1.7.exe",
       "install_script_ref": "a5276316",
       "uninstall_script_ref": "4710d9ad",
-      "sha256": "a57017433f3e277cd9ef8f9a9765b8612a510088aab0fa58e32e1de6d6d7e10d",
+      "sha256": "946c910cd41805b5cfe3ca8d978483eb2b7f8cb5d694f5e8327c6c5c02fd0a74",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/eclipse-temurin-jdk-8/windows.json
+++ b/ee/maintained-apps/outputs/eclipse-temurin-jdk-8/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "8.0.492.9",
+      "version": "8.0.502.7",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Eclipse Temurin JDK%' AND publisher = 'Eclipse Adoptium' AND version LIKE '8.%';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Eclipse Temurin JDK%' AND publisher = 'Eclipse Adoptium' AND version LIKE '8.%' AND version_compare(version, '8.0.492.9') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Eclipse Temurin JDK%' AND publisher = 'Eclipse Adoptium' AND version LIKE '8.%' AND version_compare(version, '8.0.502.7') < 0);"
       },
-      "installer_url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u492-b09/OpenJDK8U-jdk_x64_windows_hotspot_8u492b09.msi",
+      "installer_url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u502-b07/OpenJDK8U-jdk_x64_windows_hotspot_8u502b07.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "fb42ab0d",
-      "sha256": "e931546f0557e0735472e99c5f0a62d34854ab8a2fee9709bfcbc7ea6dcc5172",
+      "sha256": "3888c5a2c851587c06262fb225f4c8098c6096f30aff1808b171c1c8f184e358",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/eclipse-temurin-jre-8/windows.json
+++ b/ee/maintained-apps/outputs/eclipse-temurin-jre-8/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "8.0.492.9",
+      "version": "8.0.502.7",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Eclipse Temurin JRE%' AND publisher = 'Eclipse Adoptium' AND version LIKE '8.%';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Eclipse Temurin JRE%' AND publisher = 'Eclipse Adoptium' AND version LIKE '8.%' AND version_compare(version, '8.0.492.9') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Eclipse Temurin JRE%' AND publisher = 'Eclipse Adoptium' AND version LIKE '8.%' AND version_compare(version, '8.0.502.7') < 0);"
       },
-      "installer_url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u492-b09/OpenJDK8U-jre_x64_windows_hotspot_8u492b09.msi",
+      "installer_url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u502-b07/OpenJDK8U-jre_x64_windows_hotspot_8u502b07.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "24e08f0a",
-      "sha256": "b606dcaef8d8896be34e18dbd536437b03761411c7b0a992bcdd6c0962a53edc",
+      "sha256": "d10ea23f35e10be60775bdff2ea858f4d56fd59e2d7b2c75b61412465fea1fe6",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/firefox@nightly/darwin.json
+++ b/ee/maintained-apps/outputs/firefox@nightly/darwin.json
@@ -4,12 +4,12 @@
       "version": "155.0a1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15526.7.30') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15526.7.31') < 0);"
       },
-      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/07/2026-07-30-21-43-47-mozilla-central/firefox-155.0a1.en-US.mac.dmg",
+      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/07/2026-07-31-08-57-38-mozilla-central/firefox-155.0a1.en-US.mac.dmg",
       "install_script_ref": "d9c4cf87",
       "uninstall_script_ref": "0661f848",
-      "sha256": "8dc3ba7bdeb144f4b255e80ad6f1a91d362d87f1dbc43c9394414c4e1f4e7fb8",
+      "sha256": "926bafc758a9d912c00dae9f6cddedfcb8fb7f0c7d996021823343802e318641",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/mockoon/darwin.json
+++ b/ee/maintained-apps/outputs/mockoon/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "9.7.0",
+      "version": "9.8.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.mockoon.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.mockoon.app' AND version_compare(bundle_short_version, '9.7.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.mockoon.app' AND version_compare(bundle_short_version, '9.8.0') < 0);"
       },
-      "installer_url": "https://github.com/mockoon/mockoon/releases/download/v9.7.0/mockoon.setup.9.7.0.arm64.dmg",
+      "installer_url": "https://github.com/mockoon/mockoon/releases/download/v9.8.0/mockoon.setup.9.8.0.arm64.dmg",
       "install_script_ref": "ced539a3",
       "uninstall_script_ref": "69ac3b20",
-      "sha256": "ebb05ad602b1a4df68e0b633027d4011fb335f9539b0a2ed1c1a28d9523934ac",
+      "sha256": "99c0a347b5e8c39b6f2c3059b7d4fd2b2a012af90f36ee08fbfbd65417c64d2b",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/pgadmin4/darwin.json
+++ b/ee/maintained-apps/outputs/pgadmin4/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "9.16",
+      "version": "9.17",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.pgadmin.pgadmin4';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.pgadmin.pgadmin4' AND version_compare(bundle_short_version, '9.16') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.pgadmin.pgadmin4' AND version_compare(bundle_short_version, '9.17') < 0);"
       },
-      "installer_url": "https://ftp.postgresql.org/pub/pgadmin/pgadmin4/v9.16/macos/pgadmin4-9.16-arm64.dmg",
+      "installer_url": "https://ftp.postgresql.org/pub/pgadmin/pgadmin4/v9.17/macos/pgadmin4-9.17-arm64.dmg",
       "install_script_ref": "d04370f3",
       "uninstall_script_ref": "212c6861",
-      "sha256": "ba8da45576cae9ed91b23d67094c97de1daf3b793b42a4fe65c1ff1a120ea174",
+      "sha256": "c49fe899451596ffcf18dbf4c452c89bcec3082dbc31838d46b7dbda792d84df",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/pgadmin4/windows.json
+++ b/ee/maintained-apps/outputs/pgadmin4/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "9.16",
+      "version": "9.17",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'pgAdmin 4 %' AND publisher = 'The pgAdmin Development Team';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'pgAdmin 4 %' AND publisher = 'The pgAdmin Development Team' AND version_compare(version, '9.16') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'pgAdmin 4 %' AND publisher = 'The pgAdmin Development Team' AND version_compare(version, '9.17') < 0);"
       },
-      "installer_url": "https://ftp.postgresql.org/pub/pgadmin/pgadmin4/v9.16/windows/pgadmin4-9.16-x64.exe",
+      "installer_url": "https://ftp.postgresql.org/pub/pgadmin/pgadmin4/v9.17/windows/pgadmin4-9.17-x64.exe",
       "install_script_ref": "632aa4d1",
       "uninstall_script_ref": "912990ef",
-      "sha256": "06a0e2f2586099e038d7dc34da20f94f86465696c0238e9c86032bc933d00067",
+      "sha256": "f152ab1666d4b4182f5e550d05840c7a05123c77fb992591086ab5e73758300f",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/postman/darwin.json
+++ b/ee/maintained-apps/outputs/postman/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.21.8",
+      "version": "12.21.9",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac' AND version_compare(bundle_short_version, '12.21.8') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac' AND version_compare(bundle_short_version, '12.21.9') < 0);"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.21.8/osx_arm64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.21.9/osx_arm64",
       "install_script_ref": "0e85ef74",
       "uninstall_script_ref": "20883323",
-      "sha256": "67cbbcce5bd33f0821a065b7f3aa8b57839766da1ad129c1877fd2dce81dd6d3",
+      "sha256": "d19e586c2c92b4accd433e9a001499ed194004ff587f66acbc44c5b4b23eb298",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/raycast/darwin.json
+++ b/ee/maintained-apps/outputs/raycast/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.104.23",
+      "version": "1.104.24",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.raycast.macos';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.raycast.macos' AND version_compare(bundle_short_version, '1.104.23') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.raycast.macos' AND version_compare(bundle_short_version, '1.104.24') < 0);"
       },
-      "installer_url": "https://releases.raycast.com/releases/1.104.23/download?build=arm",
+      "installer_url": "https://releases.raycast.com/releases/1.104.24/download?build=arm",
       "install_script_ref": "f52a81be",
       "uninstall_script_ref": "cb893329",
-      "sha256": "fdaa2d6f2719998f0548e2f351299130c7f3c2c37fdafd3ca0d7b88ad798da81",
+      "sha256": "927f5b65849e0122a3db73588965fbe8e2115c24e89c06d40804f26213dd1a0a",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/setapp/darwin.json
+++ b/ee/maintained-apps/outputs/setapp/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.54.0",
+      "version": "3.54.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.setapp.DesktopClient.SetappAgent';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.setapp.DesktopClient.SetappAgent' AND version_compare(bundle_short_version, '3.54.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.setapp.DesktopClient.SetappAgent' AND version_compare(bundle_short_version, '3.54.1') < 0);"
       },
-      "installer_url": "https://dl.devmate.com/com.setapp.DesktopClient/153/1784621405/Setapp-153.zip",
+      "installer_url": "https://dl.devmate.com/com.setapp.DesktopClient/154/1785484295/Setapp-154.zip",
       "install_script_ref": "eb0dc2d0",
       "uninstall_script_ref": "9ef05eb6",
-      "sha256": "3b8579b2ccc7f0a3bab102fca3417dfca9f243d1ac5dbc08fb60e85b3796f124",
+      "sha256": "356afe716fd432db41809dfaa9fb52b5d81666d1aeeb9fa061953860d952504c",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/typora/darwin.json
+++ b/ee/maintained-apps/outputs/typora/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.14.6",
+      "version": "1.14.8",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'abnerworks.Typora';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'abnerworks.Typora' AND version_compare(bundle_short_version, '1.14.6') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'abnerworks.Typora' AND version_compare(bundle_short_version, '1.14.8') < 0);"
       },
-      "installer_url": "https://downloads.typora.io/mac/Typora-1.14.6.dmg",
+      "installer_url": "https://downloads.typora.io/mac/Typora-1.14.8.dmg",
       "install_script_ref": "163abff2",
       "uninstall_script_ref": "a8ba94c9",
-      "sha256": "ff1e93e87fcd5b4211796f4bf6d3d56affa26b9d12342b9f5e2c1b297dcc4dd7",
+      "sha256": "048b3b10100938ffc29f89a517197066c3625e0d338a27e767aee6efc84c0527",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated Dataflare on macOS and Windows to version 3.1.7.
  * Updated Eclipse Temurin JDK and JRE 8 for Windows to version 8.0.502.7.
  * Updated Firefox Nightly for macOS to the 2026-07-31 build.
  * Updated Mockoon, pgAdmin 4, Postman, Raycast, Setapp, and Typora for macOS.
  * Updated pgAdmin 4 for Windows to version 9.17.
  * Refreshed installer details and integrity checks for all updated applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->