### PR TITLE
Add column applicability table to ai_tools schema notes

### DIFF
--- a/schema/tables/ai_tools.yml
+++ b/schema/tables/ai_tools.yml
@@ -42,7 +42,28 @@ examples: |-
   ```
   SELECT name, identifier, source, risk_flags FROM ai_tools WHERE type = 'browser_extension';
   ```
-notes: The extension enumerates all home directories on the host (`/Users/*`, `/home/*`, `/root`, `C:\Users\*`), not just the daemon account's. Running as root provides full visibility across all users.
+notes: |-
+  The extension enumerates all home directories on the host (`/Users/*`, `/home/*`, `/root`, `C:\Users\*`), not just the daemon account's. Running as root provides full visibility across all users.
+
+  #### Which columns apply to which type
+
+  Common columns are shared field slots, but only some are populated per `type` — the rest are empty for that row. Type-specific data lives in `detail` instead.
+
+  | Column | `mcp_server` | `ide_plugins` | `agents` | `apps` | `agent_instruction` | `browser_extension` | `sockets` |
+  |---|---|---|---|---|---|---|---|
+  | `name` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+  | `identifier` | server name | plugin id | binary | bundle id | tool | extension id | service |
+  | `category` | `mcp-server` | AI category | agent category | — | `agent-instruction` | ✓ | ✓ |
+  | `location` | local/remote | `local` | `local` | `local` | `local` | `local` | local/remote |
+  | `source` | client | editor | install method | platform source | tool | browser | direction |
+  | `version` | — | ✓ | ✓ | ✓ | — | ✓ | — |
+  | `path` | config path | install path | ✓ | ✓ | ✓ | ✓ | process path |
+  | `endpoint` | remote URL | — | — | — | — | — | remote `addr:port` |
+  | `running`, `pid` | ✓ | — | ✓ | ✓ | — | — | ✓ |
+  | `port` | listening port | — | — | API port | — | — | local port |
+  | `risk_flags` | ✓ | — | ✓ | — | ✓ | ✓ | — |
+  | `sha256` | ✓ | — | ✓ | ✓ | ✓ | ✓ | — |
+  | `uid`, `username` | ✓ | ✓ | ✓ | — | ✓ | ✓ | username only |
 columns:
   - name: type
     description: "Options are `mcp_server`, `ide_plugins`, `agents`, `apps`, `sockets`, `agent_instruction`, or `browser_extension`."

--- a/schema/tables/ai_tools.yml
+++ b/schema/tables/ai_tools.yml
@@ -45,25 +45,7 @@ examples: |-
 notes: |-
   The extension enumerates all home directories on the host (`/Users/*`, `/home/*`, `/root`, `C:\Users\*`), not just the daemon account's. Running as root provides full visibility across all users.
 
-  #### Which columns apply to which type
-
-  Common columns are shared field slots, but only some are populated per `type` — the rest are empty for that row. Type-specific data lives in `detail` instead.
-
-  | Column | `mcp_server` | `ide_plugins` | `agents` | `apps` | `agent_instruction` | `browser_extension` | `sockets` |
-  |---|---|---|---|---|---|---|---|
-  | `name` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-  | `identifier` | server name | plugin id | binary | bundle id | tool | extension id | service |
-  | `category` | `mcp-server` | AI category | agent category | — | `agent-instruction` | ✓ | ✓ |
-  | `location` | local/remote | `local` | `local` | `local` | `local` | `local` | local/remote |
-  | `source` | client | editor | install method | platform source | tool | browser | direction |
-  | `version` | — | ✓ | ✓ | ✓ | — | ✓ | — |
-  | `path` | config path | install path | ✓ | ✓ | ✓ | ✓ | process path |
-  | `endpoint` | remote URL | — | — | — | — | — | remote `addr:port` |
-  | `running`, `pid` | ✓ | — | ✓ | ✓ | — | — | ✓ |
-  | `port` | listening port | — | — | API port | — | — | local port |
-  | `risk_flags` | ✓ | — | ✓ | — | ✓ | ✓ | — |
-  | `sha256` | ✓ | — | ✓ | ✓ | ✓ | ✓ | — |
-  | `uid`, `username` | ✓ | ✓ | ✓ | — | ✓ | ✓ | username only |
+  Common columns are shared field slots, but only some are populated per `type` — the rest are empty for that row. Type-specific data lives in `detail` instead. See the [column applicability table](https://karmine05.github.io/dirtyfrag-blog/posts/agentic-detector/) for a full breakdown of which columns apply to which type.
 columns:
   - name: type
     description: "Options are `mcp_server`, `ide_plugins`, `agents`, `apps`, `sockets`, `agent_instruction`, or `browser_extension`."


### PR DESCRIPTION
Updated notes section with detailed explanations and added a table for column applicability by type.Documents which common columns are populated per `type` in ai_tools, based on the schema's actual columns (removed confidence/evidence and other columns not present in the yml).

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved documentation for AI tool configuration fields.
  * Clarified which columns are shared across tools and how type-specific details are represented.
  * Added a reference table explaining field applicability by tool type and how values are interpreted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->