### PR TITLE
fleet-mcp: align Render blueprint with the deployed service

### DIFF
--- a/cmd/fleet-mcp/render.yaml
+++ b/cmd/fleet-mcp/render.yaml
@@ -17,6 +17,9 @@ services:
       - key: LOG_LEVEL
         value: info
       # Upper bound run_live_query waits for hosts to report (Go duration).
-      # Keep >= the Fleet server's FLEET_LIVE_QUERY_REST_PERIOD. Default 25s.
+      # Keep >= the Fleet server's FLEET_LIVE_QUERY_REST_PERIOD. The code default
+      # when unset stays 25s; a hosted deployment targets whole fleets, where
+      # enough hosts are asleep or offline that 25s returns a misleading
+      # near-empty result before they check in.
       - key: FLEET_LIVE_QUERY_REST_PERIOD
-        value: 25s
+        value: 900s

--- a/cmd/fleet-mcp/render.yaml
+++ b/cmd/fleet-mcp/render.yaml
@@ -2,7 +2,7 @@ services:
   - type: web
     name: fleet-mcp
     runtime: go
-    plan: starter
+    plan: standard
     rootDir: cmd/fleet-mcp
     buildCommand: go build -o fleet-mcp .
     startCommand: ./fleet-mcp


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #43544

This blueprint has drifted from the deployed `fleet-mcp` service in two ways. `FLEET_LIVE_QUERY_REST_PERIOD=25s` is too short for a hosted service aimed at a whole fleet: enough targeted hosts are asleep or offline that `run_live_query` returns a near-empty result before they check in, reading as "no data" rather than "still waiting." And `plan: starter` disagrees with the Standard instance the service actually runs on, so a blueprint sync risked silently downgrading it. Both fields carry literal values, making them blueprint-managed, so a dashboard override would be reverted on the next sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated the hosted Fleet deployment to use the standard plan.
  * Increased the live-query interval to 15 minutes.
  * Clarified configuration guidance for Fleet server alignment and hosted Fleet behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->