### PR TITLE
POC: Zero-touch enrollment for company-owned Android (research doc)

### DIFF
--- a/docs/Contributing/research/mdm/android-zero-touch-enrollment.md
+++ b/docs/Contributing/research/mdm/android-zero-touch-enrollment.md
@@ -167,9 +167,8 @@ consequences shape the design:
   the same. Assignment is therefore a staging operation; nothing happens until the next wipe.
   **Verify before building on this.** Google is silent on what happens to an already-provisioned device
   that is later assigned a configuration, so "waits for the next reset" is the documented behaviour rather
-  than a guarantee about every state. An earlier draft of this document claimed assignment wipes an
-  in-service device; that was a misreading of the sentence quoted in the next bullet, whose subject is a
-  device still in the setup wizard.
+  than a guarantee about every state. Note the adjacent sentence quoted in the next bullet is easy to
+  misread as applying here — its subject is a device still in the setup wizard, not one in service.
 - **A device that skips zero-touch for lack of network resets itself later.** If a device has a
   configuration but no connectivity during setup, zero-touch is skipped and the device boots unmanaged —
   then "resets itself after the first connection to Google servers," warning the user one hour ahead. This

--- a/docs/Contributing/research/mdm/android-zero-touch-enrollment.md
+++ b/docs/Contributing/research/mdm/android-zero-touch-enrollment.md
@@ -1,0 +1,1013 @@
+# Zero-touch enrollment for company-owned Android devices
+
+Status: research / design proposal. Not yet scheduled.
+
+## Abstract
+
+Fleet can already manage company-owned Android devices, but it cannot provision them without a human
+touching each one. Today an admin must generate a short-lived enrollment token in Fleet and then scan a
+QR code (or type `afw#setup`) on every device. Fleet has an equivalent zero-touch story on Apple —
+Automated Device Enrollment via Apple Business — but nothing on Android. This document specifies what it
+would take to close that gap using Google's Android zero-touch enrollment program, so that a device
+purchased from a zero-touch reseller ships directly to an employee, and on first boot provisions itself
+into the correct Fleet team as a fully managed device with no admin involvement.
+
+The core technical insight is that zero-touch enrollment does not introduce a new enrollment protocol.
+Google's zero-touch service simply pre-stages the same Android Management API (AMAPI) enrollment token
+Fleet already creates, delivering it to the device through Google's provisioning servers instead of a QR
+code. The device then follows the exact AMAPI provisioning path Fleet already supports, and Fleet learns
+about it through the Pub/Sub `ENROLLMENT` notification it already handles. That makes this a
+configuration-management and lifecycle feature, not a new MDM protocol implementation — the entire
+existing profile delivery, software install, command, and host-vitals pipeline is reused unchanged.
+
+The work therefore breaks into four parts. First, a new Google API integration: the **Android Device
+Provisioning Partner API** (`androiddeviceprovisioning.googleapis.com`), customer surface, which is
+already present in Fleet's vendored `google.golang.org/api` module and needs no new dependency. Second, a
+credential model for that API, which is the single largest open question — Google offers a service-account
+path (simple, automation-friendly, but requires a manual Google-approved linking request) and an
+interactive OAuth path (self-service, but a per-admin refresh token and probable scope verification). Third,
+Fleet-side changes: long-lived reusable enrollment tokens, a new table and config assets, a
+configuration-per-team model, a reconciliation cron, pending-host records so admins can see devices before
+first boot, activities, GitOps keys, REST endpoints, and UI. Fourth, a change to how Fleet identifies the
+target team at enrollment time — the current design embeds a mutable enroll secret in the token's
+`additionalData`, which silently breaks long-lived zero-touch tokens whenever an admin rotates a team's
+enroll secret. That last item is a correctness prerequisite, not a nice-to-have.
+
+The document also proposes a phased delivery in which Phase 1 ships real, usable zero-touch support with
+**no** new Google API integration at all — Fleet generates the DPC extras JSON and the admin pastes it into
+Google's zero-touch portal once per team. Phase 1 is small, unblocks customers immediately, and de-risks the
+credential decision in Phase 2 by proving the token and team-mapping model in production first.
+
+## Table of contents
+
+- [Scope](#scope)
+- [How Android zero-touch enrollment actually works](#how-android-zero-touch-enrollment-actually-works)
+- [Where Fleet is today](#where-fleet-is-today)
+- [Gap analysis](#gap-analysis)
+- [Google APIs required](#google-apis-required)
+- [Credential and authorization options](#credential-and-authorization-options)
+- [Design](#design)
+- [Fleet modifications](#fleet-modifications)
+- [Phased delivery](#phased-delivery)
+- [Edge cases and failure modes](#edge-cases-and-failure-modes)
+- [Testing plan](#testing-plan)
+- [Security considerations](#security-considerations)
+- [Open questions](#open-questions)
+- [Effort estimate](#effort-estimate)
+- [References](#references)
+
+## Scope
+
+"Zero-touch enrollment for company-owned devices" means different things per platform. This document is
+about the Android gap, because that is the only company-owned platform where Fleet has no zero-touch path
+at all.
+
+| Platform | Zero-touch mechanism | Fleet status |
+| --- | --- | --- |
+| macOS / iOS / iPadOS | Apple Automated Device Enrollment (ADE) via Apple Business | Supported. See `docs/Contributing/architecture/mdm/automated-device-enrollment.md` |
+| Android (company-owned) | Google Android zero-touch enrollment | **Not supported — this document** |
+| Windows | Windows Autopilot (Entra ID + Windows Autopilot service) | Not supported. Separate effort, unrelated APIs |
+| ChromeOS | Chrome zero-touch enrollment (same provisioning API, `deviceType` CHROME_OS) | Out of scope; Fleet has no ChromeOS MDM |
+
+Within Android, zero-touch applies to three company-owned management modes. All three are reachable
+through the same mechanism, differing only in the `allowPersonalUsage` value on the enrollment token:
+
+- **Fully managed (COBO)** — company-owned, business only. `PERSONAL_USAGE_DISALLOWED`.
+- **Company-owned with a work profile (COPE)** — company-owned, personally enabled.
+  `PERSONAL_USAGE_ALLOWED`.
+- **Dedicated / kiosk (COSU)** — no user identity. `PERSONAL_USAGE_DISALLOWED_USERLESS`. Google made this
+  value mandatory for dedicated-device enrollment as of January 2025.
+
+Personally-owned (BYOD) work profile enrollment is explicitly **out of scope**: zero-touch requires the
+device to be purchased through a zero-touch reseller and claimed to the organization, which by definition
+makes it company-owned.
+
+## How Android zero-touch enrollment actually works
+
+Understanding the actor model matters, because it determines what Fleet can and cannot do.
+
+### Actors
+
+1. **Reseller** — an authorized zero-touch reseller partner. When an organization buys devices, the
+   reseller registers each device's hardware identifiers (IMEI/MEID or serial number, plus manufacturer)
+   into Google's zero-touch system and *claims* the device to that organization's customer account. **Only
+   resellers can create device records.** IT admins cannot, and neither can an EMM. This is a hard
+   constraint: Fleet can never add a device to zero-touch.
+2. **Customer account** — the organization's zero-touch account, created by the reseller on first
+   purchase. Admins manage it at `https://enterprise.google.com/android/zero-touch/customers`. Each
+   customer account has an ID and an API resource name of the form `customers/{CUSTOMER_ID}`.
+3. **DPC (Device Policy Controller)** — the agent that provisions and manages the device. For AMAPI-based
+   EMMs like Fleet, the DPC is Google's own **Android Device Policy**
+   (`com.google.android.apps.work.clouddpc`). Fleet does not ship a DPC.
+4. **EMM (Fleet)** — provides a console where admins manage zero-touch configurations, using the
+   customer API on the admin's behalf.
+
+### Configurations
+
+The unit of zero-touch policy is a **Configuration**, owned by the customer account. A configuration
+bundles the DPC to install, the provisioning extras to hand that DPC, support contact info, and a custom
+message shown during setup. Fields (all from `customers.configurations`):
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| `configurationName` | Yes | Shown to admins in the portal. Fleet would use the team name. |
+| `dpcResourcePath` | Yes | `customers/{CUST_ID}/dpcs/{DPC_ID}`. Must be discovered via `customers.dpcs.list` and matched to Android Device Policy — do not hardcode. |
+| `dpcExtras` | No | JSON string of provisioning extras. **This is where Fleet's enrollment token goes.** |
+| `companyName` | Yes | Shown on device during provisioning. Fleet would default to org name from app config. |
+| `contactEmail` | Yes | Validated by Google. Shown to the user before provisioning. |
+| `contactPhone` | Yes | Shown to the user before provisioning. Digits, spaces, `+`, `-`, `()`. |
+| `customMessage` | No | One or two sentences shown before provisioning. |
+| `isDefault` | Yes | Applies to all newly purchased devices. **Only one default per customer account.** Setting a new default silently clears the old one. |
+| `forcedResetTime` | No | Timeout before forcing a factory reset when setup cannot complete (typically no network). 0–6 hours, default 2 hours. |
+| `name`, `configurationId` | Output only | Server-assigned. |
+
+### Device records and configuration assignment
+
+Devices under a customer account expose `deviceIdentifier` (serial number, manufacturer, model,
+IMEI/MEID, plus `imei2`/`meid2` for dual-SIM), `deviceMetadata` (reseller-set key/value pairs),
+`claims[]` (the zero-touch claim, `SECTION_TYPE_ZERO_TOUCH`), and `configuration` (the applied
+configuration path, or empty).
+
+A device gets a configuration one of two ways:
+
+- Implicitly, by the customer account's **default configuration**, which applies to newly claimed devices.
+- Explicitly, via `customers.devices:applyConfiguration`, which overrides the default for that device.
+
+`customers.devices:removeConfiguration` unassigns; `customers.devices:unclaim` removes the device from
+zero-touch entirely (destructive — the organization loses the claim and must go back to the reseller).
+
+### First-boot flow
+
+1. Device is factory reset or unboxed and connects to a network during setup.
+2. It checks in with Google's provisioning servers, identifying itself by hardware ID.
+3. If a configuration is assigned, Google returns it and the device enters the fully managed device setup
+   wizard, showing `companyName`, `customMessage`, `contactEmail`, and `contactPhone`.
+4. The device downloads Android Device Policy from Google Play.
+5. Android Device Policy receives `ACTION_PROVISION_MANAGED_DEVICE` with the extras from `dpcExtras`,
+   reads the AMAPI enrollment token, and enrolls into the AMAPI enterprise.
+6. AMAPI publishes an `ENROLLMENT` notification to the enterprise's Pub/Sub topic. **This is where Fleet
+   re-enters the picture, on the code path it already has.**
+
+### When provisioning triggers — and the destructive edge
+
+Zero-touch is evaluated **only during the out-of-box setup wizard**: on first boot, or on the next factory
+reset. It is not a push mechanism and cannot provision a device that is already set up and running.
+Three consequences matter for Fleet's design:
+
+- **It re-triggers on every factory reset, indefinitely.** A device claimed to a customer account and
+  assigned a configuration re-provisions every time it is reset, for as long as the claim exists. The end
+  user cannot bypass or defer it. This stickiness is the security property that makes zero-touch valuable
+  for company-owned hardware — and the reason a broken configuration is a fleet-wide outage rather than a
+  per-device annoyance.
+- **Assigning a configuration to a device that is already in use causes a factory reset.** Per Google's
+  admin documentation, a device that lacks connectivity during setup skips the zero-touch flow and boots
+  unmanaged, but then "resets itself after the first connection to Google servers," giving the user one
+  hour of warning. The same applies to a device already in service when a configuration is applied to it.
+  **`customers.devices:applyConfiguration` is therefore potentially destructive of end-user data**, which
+  is not obvious from the API surface — the method name suggests a metadata write. Fleet must treat it as
+  a destructive action in the UI, with explicit warning and confirmation, and the same warning belongs on
+  the "set default configuration" path, since the default applies to every newly claimed device.
+- **Two distinct reset mechanisms exist**, and they are easy to conflate: `forcedResetTime` (0–6 hours,
+  default 2) is the in-setup timeout when the wizard cannot reach Google, while the self-reset above fires
+  after setup has completed unmanaged. Both end in a factory reset; only the first is configurable.
+
+### DPC extras for AMAPI
+
+The exact `dpcExtras` payload for an AMAPI-managed device:
+
+```json
+{
+  "android.app.extra.PROVISIONING_DEVICE_ADMIN_COMPONENT_NAME":
+    "com.google.android.apps.work.clouddpc/.receivers.CloudDeviceAdminReceiver",
+  "android.app.extra.PROVISIONING_DEVICE_ADMIN_SIGNATURE_CHECKSUM":
+    "I5YvS0O5hXY46mb01BlRjq4oJJGs2kuUcHvVkAPEXlg",
+  "android.app.extra.PROVISIONING_ADMIN_EXTRAS_BUNDLE": {
+    "com.google.android.apps.work.clouddpc.EXTRA_ENROLLMENT_TOKEN": "<AMAPI enrollment token value>"
+  }
+}
+```
+
+Google's EMM guidance on extras, which Fleet should follow:
+
+- Put everything Fleet-specific inside `PROVISIONING_ADMIN_EXTRAS_BUNDLE`, not as top-level extras.
+- Do **not** put account credentials or secrets in the configuration. The AMAPI enrollment token is the
+  one unavoidable exception, and it is scoped to enrollment only.
+- Optionally supported and reasonable for Fleet to expose later:
+  `EXTRA_PROVISIONING_LOCALE`, `EXTRA_PROVISIONING_TIME_ZONE`, `EXTRA_PROVISIONING_LOCAL_TIME`,
+  `EXTRA_PROVISIONING_LEAVE_ALL_SYSTEM_APPS_ENABLED`, `EXTRA_PROVISIONING_MAIN_COLOR`,
+  `EXTRA_PROVISIONING_DISCLAIMERS`.
+- Google explicitly advises against `PROVISIONING_DEVICE_ADMIN_PACKAGE_DOWNLOAD_LOCATION`,
+  `..._PACKAGE_CHECKSUM`, and cookie-header extras — those belong to other enrollment methods.
+
+### Device eligibility
+
+- Android 8.0+ (or Pixel on 7.1+) per the zero-touch EMM guide. Google's Workspace-facing documentation
+  states 9.0+ (Pixel 7.0+) for work-profile devices, so the floor varies by source and management mode —
+  verify against the Android Enterprise device list rather than either number.
+- Google Mobile Services present.
+- Registered by a participating zero-touch reseller and claimed to the organization's customer account.
+
+### Devices the organization already owns
+
+This is the most consequential limitation for adoption, and it should be stated plainly in Fleet's UI and
+docs rather than discovered.
+
+An organization's **existing** Android fleet generally cannot be moved to zero-touch. Registration is
+performed by the reseller that sold the device, and there is no self-service path — Google's newer
+"automatic zero-touch enrollment" framing in the Workspace documentation still requires reseller
+registration. A device bought at retail or through a non-participating channel has no route in at all.
+Devices purchased from a participating reseller can often be registered retroactively on request, since
+the reseller has both the tooling (`partners.devices.claim`) and the sales record, but that is the
+reseller's call and outside Fleet's control. Deregistering a device likewise requires going back to the
+reseller to reverse.
+
+The practical consequence: zero-touch is a **forward-looking** capability tied to procurement, not a
+migration path for an installed base. For devices already owned, Fleet's existing QR-code and
+`afw#setup` flows already achieve the same *management* end state — a fully managed device in the correct
+team — at the cost of one human touch per device at factory-reset time.
+
+What that does **not** replicate is zero-touch's stickiness. A QR-enrolled device that is factory reset
+boots unmanaged; a zero-touch device re-provisions itself. Where the requirement is tamper resistance
+rather than provisioning convenience, only reseller registration satisfies it. Fleet's messaging should
+distinguish these two value propositions instead of presenting zero-touch purely as a convenience
+feature, because they lead to different purchasing decisions.
+
+Platform-specific alternative, noted for completeness and **not** proposed here: Samsung Knox Mobile
+Enrollment supports admin self-registration of already-owned devices via the Knox Deployment App or a KME
+QR profile, without reseller involvement, and can target AMAPI. It is a separate program from Google
+zero-touch and would be a distinct integration effort.
+
+## Where Fleet is today
+
+Fleet's Android MDM lives in `server/mdm/android/` as a deliberately decoupled bounded context (see
+`server/mdm/android/README.md`).
+
+### Enrollment token creation
+
+`Service.CreateEnrollmentToken` in `server/mdm/android/service/service.go:549` is the entire current
+enrollment surface. It:
+
+1. Verifies Android MDM is configured.
+2. Verifies the supplied enroll secret (`svc.ds.VerifyEnrollSecret`), which is what determines the target
+   team.
+3. Optionally requires and validates an IdP account UUID for end-user authentication.
+4. Marshals `{enroll_secret, idp_uuid}` into the token's `additionalData`.
+5. Sets `allowPersonalUsage` from a `fully_managed` query parameter — `PERSONAL_USAGE_DISALLOWED` when
+   true, `PERSONAL_USAGE_ALLOWED` otherwise.
+6. Sets `oneTimeOnly: true` and leaves `duration` unset, so **the token expires in one hour and works
+   exactly once**.
+7. Returns the token value, a `https://enterprise.google.com/android/enroll?et=<token>` URL, and a QR code.
+
+The frontend surface is `frontend/components/AddHostsModal/PlatformWrapper/AndroidPanel/AndroidPanel.tsx`,
+which offers a "work profile" / "fully managed" radio and renders the QR code.
+
+### Enrollment completion
+
+`Service.enrollHost` (`server/mdm/android/service/pubsub.go:599`) handles the Pub/Sub `ENROLLMENT`
+notification. It unmarshals `device.EnrollmentTokenData` back into `{enroll_secret, idp_uuid}`, verifies
+the enroll secret again, resolves the team, and creates or updates the host. `addNewHost`
+(`pubsub.go:893`) is the new-device path; it maps AMAPI `hardwareInfo.serialNumber` into
+`host.HardwareSerial` (`pubsub.go:947`), which matters for correlating zero-touch device records later.
+
+### AMAPI client
+
+`androidmgmt.Client` (`server/mdm/android/service/androidmgmt/client.go`) is an interface with two
+implementations:
+
+- `ProxyClient` — the default. Routes AMAPI calls through `https://fleetdm.com/api/android/`, using a
+  per-enterprise `FleetServerSecret` as a bearer token. Fleet's hosted proxy owns the Google Cloud
+  project, the service credentials, and the Pub/Sub topic.
+- `GoogleClient` — development only, gated behind `FLEET_DEV_ANDROID_GOOGLE_CLIENT=1` and
+  `FLEET_DEV_ANDROID_GOOGLE_SERVICE_CREDENTIALS`. Talks to Google directly with a service account.
+
+This proxy architecture is the most important existing constraint on the design, and is discussed in
+detail below.
+
+### Storage
+
+`android_enterprises` holds one row: `enterprise_id`, `signup_name`, `signup_token`, `pubsub_topic_id`,
+`user_id`. Secrets live in `mdm_config_assets` under names defined in `server/fleet/mdm.go` —
+`android_pubsub_token`, `android_fleet_server_secret`. There is no per-team Android enrollment state
+anywhere.
+
+## Gap analysis
+
+| Capability | Needed for zero-touch | Fleet today |
+| --- | --- | --- |
+| Long-lived, reusable enrollment token | Yes — the token sits in a configuration for months and is used by many devices | 1 hour, `oneTimeOnly: true` |
+| Stable team identification in the token | Yes — the token outlives enroll secret rotations | Embeds the mutable enroll secret |
+| Zero-touch customer API client | Yes | Does not exist |
+| Credential storage for that API | Yes | Does not exist |
+| Configuration-per-team model | Yes | Does not exist |
+| Reconciliation of Google-side state | Yes — configs drift, admins edit in the portal | Does not exist |
+| Pending/awaiting-enrollment host visibility | Desirable, matches ADE | Does not exist for Android |
+| Per-device configuration override | Yes — how a device lands in a non-default team | Does not exist |
+| Activities / audit trail | Yes | Does not exist |
+| GitOps | Yes, for parity | Does not exist |
+| `PERSONAL_USAGE_DISALLOWED_USERLESS` (dedicated devices) | For COSU | Not exposed |
+| End-user IdP auth during zero-touch provisioning | Depends on requirements | BYOD-cookie-based only; not reachable from zero-touch |
+
+## Google APIs required
+
+### 1. Android Device Provisioning Partner API — customer surface (new)
+
+- **Service**: `androiddeviceprovisioning.googleapis.com`
+- **Go package**: `google.golang.org/api/androiddeviceprovisioning/v1` — **already present in Fleet's
+  module graph** at `google.golang.org/api v0.269.0` (`go.mod:181`). No new dependency. The generated
+  package exposes `CustomersService`, `CustomersConfigurationsService`, `CustomersDevicesService`, and
+  `CustomersDpcsService`.
+- **OAuth scope**: `https://www.googleapis.com/auth/androidworkzerotouchemm`. Note this is *different*
+  from the reseller scope `https://www.googleapis.com/auth/androidworkprovisioning`. The generated Go
+  package declares no default scopes, so it must be passed explicitly via `option.WithScopes(...)`.
+- **Enablement**: the API must be enabled on the Google Cloud project whose credential is used.
+- **Recommended header**: `X-GOOG-API-FORMAT-VERSION: 2`, which Google requires to get structured error
+  details — specifically `TosError`, needed to detect the terms-of-service case below.
+
+Methods Fleet needs:
+
+| Method | Use in Fleet |
+| --- | --- |
+| `customers.list` | Discover the customer account(s) the credential can act on. Returns `customers/{id}`. |
+| `customers.dpcs.list` | Find the Android Device Policy resource path for `dpcResourcePath`. Match on the last path component; never hardcode. |
+| `customers.configurations.list` | Reconcile Fleet's known configurations against Google's, detect out-of-band edits and deletions. |
+| `customers.configurations.create` | Create a configuration per Fleet team. |
+| `customers.configurations.patch` | Update `dpcExtras` on token rotation, and metadata on team rename. |
+| `customers.configurations.delete` | Remove a configuration when a team is deleted or zero-touch is disabled for it. |
+| `customers.devices.list` | Enumerate claimed devices to build pending-host records. Paginated via `nextPageToken`. |
+| `customers.devices.get` | Refresh a single device. |
+| `customers.devices:applyConfiguration` | Assign a specific device to a specific team's configuration. |
+| `customers.devices:removeConfiguration` | Unassign, falling back to the default configuration. |
+| `customers.devices:unclaim` | Destructive; expose only behind an explicit confirmation, if at all. |
+
+Not needed: the entire `partners.*` reseller surface. Fleet is not a reseller and should not attempt to
+become one — device claiming is a supply-chain function.
+
+**Terms of service handling**: calls return `403 Forbidden` with a `TosError` body until the acting user
+has accepted the current zero-touch terms. Fleet must detect this specific case and surface an actionable
+message linking to `https://enterprise.google.com/android/zero-touch/customers`, rather than a generic
+403. Google can update the terms at any time, so this is not a one-time setup error — it can appear
+mid-life on a working integration and must be handled in the cron, not only during setup.
+
+### 2. Android Management API (existing, extended)
+
+No new API, but new usage of it:
+
+- `enterprises.enrollmentTokens.create` with:
+  - `duration` set explicitly. The field accepts 1 minute up to roughly 10,000 years; default is 1 hour.
+    If the requested duration would overflow the maximum timestamp, Google coerces it.
+  - `oneTimeOnly: false`, so many devices can enroll with the same token.
+  - `allowPersonalUsage` set per management mode (`PERSONAL_USAGE_DISALLOWED`, `PERSONAL_USAGE_ALLOWED`,
+    or `PERSONAL_USAGE_DISALLOWED_USERLESS`).
+  - `additionalData` — max 1024 characters, surfaced on the device as `enrollmentTokenData`. This is
+    Fleet's only channel for carrying team intent through provisioning, and the 1024-character ceiling is
+    a real design constraint.
+  - `policyName` — Fleet already points this at `{enterprise}/policies/1`.
+- `enterprises.enrollmentTokens.delete` — needed to revoke a leaked or superseded zero-touch token.
+- `enterprises.enrollmentTokens.list` — lists active, unexpired tokens; useful for drift detection and
+  cleanup.
+- `EnrollmentToken.user` is deprecated and ignored; do not use it.
+
+### 3. Google Cloud Pub/Sub (existing)
+
+Unchanged. Zero-touch devices produce the same `ENROLLMENT` notification as QR-code devices. This is
+precisely why the feature is tractable.
+
+### 4. Optionally: AMAPI `signinDetail` (only if end-user IdP auth is required on zero-touch)
+
+Zero-touch hands the device a plain enrollment token with no user interaction, so a Fleet-mediated IdP
+login cannot happen the way it does for BYOD (which relies on a browser cookie set before the enrollment
+token is requested — `mdm.BYODIdpCookieName`, `service.go:508`).
+
+If end-user authentication during zero-touch provisioning is a requirement, the mechanism is AMAPI's
+sign-in URL enrollment. An enterprise can have any number of `SigninDetail` entries, uniquely keyed by
+(`signinUrl`, `allowPersonalUsage`, `tokenTag`). Each yields a server-generated, read-only
+`signinEnrollmentToken`. Placing that token in `dpcExtras` instead of a normal enrollment token causes
+the device to open `signinUrl` during provisioning; Fleet's page runs the IdP flow and must finish by
+redirecting to `https://enterprise.google.com/android/enroll?et=<token>` on success or
+`https://enterprise.google.com/android/enroll/invalid` on failure.
+
+This is a substantial sub-project — it means Fleet serves an unauthenticated, device-facing web flow that
+mints enrollment tokens. **Recommendation: exclude it from the initial scope.** Company-owned zero-touch
+devices are typically assigned to a person out-of-band, and the AMAPI `provisioningInfo` /
+`authenticatedUserEmail` mechanism plus Fleet's existing per-team assignment covers most needs. Revisit
+only if customers ask for user-attributed zero-touch specifically.
+
+## Credential and authorization options
+
+This is the decision that gates everything else, and it deserves an explicit decision before
+implementation starts.
+
+### Option A — Service account key uploaded by the admin (recommended)
+
+The admin creates a Google Cloud project, enables the Android Device Provisioning Partner API, creates a
+service account, downloads its JSON key, and uploads that key to Fleet. Fleet uses two-legged OAuth with
+scope `androidworkzerotouchemm`.
+
+- **Pros**: no refresh-token lifecycle, no consent UI, no dependency on an individual admin's Google
+  account, and Google explicitly recommends service accounts for "continuously-running automated
+  services" — which is exactly what Fleet's reconciliation cron is. It also mirrors Fleet's existing ABM
+  token UX almost exactly: do work in the vendor portal, download a credential, upload it to Fleet.
+- **Cons**: the service account must be linked to the zero-touch customer account, and per Google's
+  current documentation that linking is **a Google Form submission followed by an email confirmation**,
+  not a self-service portal action. That is human latency of unknown duration on the customer's critical
+  path, and it is opaque to Fleet.
+- **Verify before committing**: whether a self-service linking path now exists in the customer portal
+  (the reseller portal does have a "Service accounts → Link service account" screen; the customer portal
+  may have gained parity), and whether there is a per-organization limit on linked service accounts.
+
+### Option B — Interactive OAuth (three-legged) by the admin
+
+Fleet registers an OAuth client, the admin consents with the Google account their reseller established in
+the zero-touch account, and Fleet stores the refresh token. This is what Google's EMM integration guide
+describes as the standard EMM console pattern.
+
+- **Pros**: fully self-service, no Google Form, works the moment the admin clicks through consent.
+  Architecturally consistent with Fleet's existing AMAPI signup, which already round-trips through
+  `fleetdm.com` with a callback URL.
+- **Cons**: the grant is bound to one human's Google account, so it breaks when that person's access is
+  removed — a recurring support burden. `androidworkzerotouchemm` is likely to be treated as a sensitive
+  scope requiring Google app verification, which is a schedule risk. Refresh tokens can be revoked
+  server-side without notice, so Fleet needs re-consent detection and prompting. Self-hosted Fleet needs
+  either its own OAuth client (admin burden) or a proxy-mediated redirect URI.
+
+### Option C — No API at all: Fleet emits the DPC extras, admin pastes them
+
+Fleet generates a long-lived reusable enrollment token per team and displays the complete `dpcExtras`
+JSON with a copy button plus step-by-step portal instructions. The admin creates the configuration by
+hand in Google's portal.
+
+- **Pros**: zero Google API integration, zero credential storage, zero authorization risk. Works today
+  for every customer including self-hosted and air-gapped-adjacent deployments. Small enough to ship in
+  one release.
+- **Cons**: not "zero-touch admin" — the admin does per-team manual portal work. No pending-host
+  visibility, no per-device team override, no drift detection.
+
+### Recommendation
+
+Ship **Option C as Phase 1**, then **Option A as Phase 2** with **Option B as an alternate path** for
+customers blocked on service-account linking. Option C is not a throwaway: it forces Fleet to get the
+long-lived token model, the team-mapping fix, and the extras generation right, all of which Phase 2
+reuses verbatim. It also means the credential decision does not block customer value.
+
+### The Fleet Cloud proxy question
+
+Fleet's AMAPI traffic defaults through `https://fleetdm.com/api/android/`, with Fleet's hosted project
+owning the Google credentials. The zero-touch customer API **cannot** follow that model in the same way,
+and this needs to be explicit:
+
+- The zero-touch customer account belongs to the customer, established by *their* reseller. Fleet's
+  hosted service account has no relationship to it and cannot be granted one without the customer
+  linking it.
+- If Fleet linked one shared service account to many customer accounts, `customers.list` would return
+  every linked customer to every caller. Fleet would then be responsible for enforcing tenant isolation
+  in the proxy, on a credential with no per-tenant scoping. **This is a multi-tenancy hazard and should
+  be rejected.**
+
+Therefore: zero-touch credentials are **per-Fleet-instance and customer-supplied**, and zero-touch API
+calls go **direct to Google**, not through the proxy — regardless of how AMAPI traffic is routed. This is
+a deliberate architectural divergence from the rest of Android MDM and should be documented as such,
+because it will surprise people reading the code.
+
+## Design
+
+### Configuration per team
+
+Fleet teams are the natural unit. Each Fleet team that opts into zero-touch gets:
+
+- One long-lived AMAPI enrollment token, carrying that team's identity in `additionalData` and the
+  team's chosen management mode in `allowPersonalUsage`.
+- One zero-touch Configuration whose `dpcExtras` embeds that token and whose `configurationName` is
+  derived from the team name.
+
+Because Google permits exactly one default configuration per customer account, Fleet exposes a single
+**"default team for zero-touch"** setting. That team's configuration carries `isDefault: true`; all newly
+purchased devices land in it. Any other team's devices are placed via
+`customers.devices:applyConfiguration`. Changing the default team means patching two configurations, and
+Fleet must handle Google's implicit clearing of the previous default rather than assuming its own view is
+authoritative.
+
+A distinct configuration is needed per (team, management mode) pair, since `allowPersonalUsage` is fixed
+at token creation. Keeping mode as a per-team setting rather than a per-configuration one keeps the model
+comprehensible; teams that need both fully managed and dedicated devices should be separate teams.
+
+### Fixing team identification: the critical prerequisite
+
+Today `additionalData` carries `{"enroll_secret": "...", "idp_uuid": "..."}` and `addNewHost`
+(`pubsub.go:908`) hard-fails when `VerifyEnrollSecret` does not match:
+
+```go
+enrollSecret, err := svc.ds.VerifyEnrollSecret(ctx, enrollmentTokenRequest.EnrollSecret)
+if err != nil {
+    return ctxerr.Wrap(ctx, err, "verifying enroll secret")
+}
+```
+
+For a one-hour token this is fine. For a token embedded in a zero-touch configuration for a year, it is a
+latent outage: **the moment an admin rotates that team's enroll secret, every subsequent zero-touch
+device enrolls successfully into AMAPI and then fails to become a Fleet host.** The device is managed by
+Google, invisible in Fleet, and the failure surfaces only as a repeating Pub/Sub error. This is
+exactly the kind of silent, delayed breakage that is worst to debug in the field.
+
+Two viable fixes:
+
+1. **Carry a stable team reference.** Extend the `additionalData` payload with a version tag and a
+   durable identifier, for example
+   `{"v":2,"zt":true,"team_id":3,"enroll_secret":"..."}`, and in `enrollHost`/`addNewHost` prefer
+   `team_id` when `zt` is set, treating an enroll-secret mismatch as non-fatal in that case. A team UUID
+   would be preferable to a numeric ID for stability across restores, if one is available. Note the 1024
+   character `additionalData` limit — it is generous here but must be validated, not assumed.
+2. **Re-issue on rotation.** Hook enroll-secret changes and patch every affected zero-touch
+   configuration with a freshly minted token.
+
+**Do both.** Fix 1 makes the system correct under drift; fix 2 keeps the stored token consistent with
+Fleet's state. Fix 1 alone leaves a stale secret in Google's configuration; fix 2 alone leaves a window
+where in-flight provisioning breaks, and fails entirely if the patch call errors.
+
+Whichever payload shape is chosen, it must be versioned, because tokens already in the wild will carry
+the v1 shape and must keep working. `getAndroidHostKey` / `GetAndroidDeviceLastTeamID` already override
+the token's team for previously-known devices (`pubsub.go:916`), and that precedence must be preserved:
+last-known team still wins over the zero-touch token's team, so a factory-reset device returns to where
+the admin put it.
+
+### Token lifetime and rotation
+
+Fleet should create zero-touch tokens with an explicit long duration and rotate on demand rather than on
+a short clock. Rationale: a mid-provisioning token swap is the highest-risk moment in the whole flow, and
+frequent rotation multiplies exposure to that risk for little security benefit — the token's only power
+is to enroll a device into the enterprise, and it lives in a store readable only by zero-touch portal
+admins.
+
+Concretely:
+
+- Create with `duration` of roughly one year and `oneTimeOnly: false`.
+- Store `expires_at` and have the reconciliation cron rotate when within, say, 30 days of expiry.
+- On rotation: mint the new token, patch `dpcExtras`, confirm the patch succeeded, and only then delete
+  the old token — never the reverse. Keep a grace period before deletion so devices that already
+  fetched the old configuration can still complete.
+- Expose an explicit admin "rotate zero-touch token" action for the leak case, which deletes the old
+  token immediately and accepts the in-flight breakage.
+
+### Pending hosts
+
+`customers.devices.list` returns hardware identifiers before any device has ever booted, and AMAPI
+reports `hardwareInfo.serialNumber` at enrollment, which Fleet already stores as `HardwareSerial`
+(`pubsub.go:947`). That makes correlation possible and enables an Android analogue of Apple's
+`host_dep_assignments` "awaiting enrollment" experience: admins see the devices they bought, in the team
+they will land in, before anyone opens a box.
+
+Caveats to design around:
+
+- Serial number is the practical join key, but some devices report IMEI/MEID only, and dual-SIM devices
+  have `imei2`/`meid2`. The correlation must try serial first, then IMEI/MEID, and tolerate no match.
+- AMAPI's `hardwareInfo.serialNumber` is documented as unavailable for personally-owned devices; for
+  company-owned zero-touch devices it should be present, but the code must not assume it.
+- Formatting differences (case, leading zeros, whitespace) are a realistic source of missed matches;
+  normalize on both sides. `fleet.Preprocess` exists for this class of problem.
+- Getting this wrong creates duplicate host records, which is worse than having no pending hosts at all.
+  If correlation confidence is low, ship Phase 2 without pending hosts and add them once real device data
+  is available.
+
+### Ownership, portability, and offboarding
+
+Two separate registrations exist, owned by different parties, and conflating them leads to wrong
+conclusions about lock-in.
+
+**The zero-touch device claim belongs to the customer.** It lives in *their* zero-touch customer account
+(`customers/{CUSTOMER_ID}`), created by *their* reseller against *their* organization. Fleet is not a
+party to the claim and does not appear in it. Fleet's service account or OAuth grant is merely a
+delegated caller that the customer can revoke at any time without affecting the claim.
+
+**The AMAPI enterprise is bound to Fleet.** `EnterprisesCreate` passes `ProjectId(g.androidProjectID)`
+(`androidmgmt/google_client.go:92`), so the enterprise is created under a Google Cloud project — and in
+the default proxy deployment, that project is Fleet's, not the customer's. This produces an *EMM-managed*
+enterprise, which cannot be transferred to another EMM's project. Note the asymmetry: a deployment using
+`GoogleClient` with the customer's own credentials would create the enterprise under the customer's
+project instead. That path is currently development-only, but it is the lever if enterprise ownership ever
+becomes a customer requirement.
+
+**The only coupling between the two systems is the enrollment token string inside `dpcExtras`.** That is a
+mutable field in a record the customer owns. This loose coupling is the important architectural property,
+and it is worth preserving deliberately rather than by accident.
+
+Consequences for migrating away from Fleet:
+
+- **The zero-touch side migrates cleanly.** The customer's portal admins replace the token in `dpcExtras`
+  with the incoming EMM's, or point the device at a new configuration. Devices stay claimed, no reseller
+  involvement, no re-registration. Critically, they can do this **without Fleet's cooperation** — even if
+  the Fleet instance is decommissioned or the contract has lapsed. Fleet holds no hostage here, and that
+  should be stated plainly in customer-facing material rather than left ambiguous.
+- **The AMAPI side requires a factory reset per device.** Device Owner cannot be transferred over the air
+  between EMM enterprises. AMAPI's DPC migration facility is custom-DPC-to-Android-Device-Policy *within
+  one enterprise*, not cross-EMM. This is a universal Android Enterprise constraint, not a Fleet
+  limitation, and applies identically in the inbound direction for customers migrating *to* Fleet.
+- **Zero-touch makes migration easier, not harder.** The standard playbook is: repoint the configuration
+  at the new EMM, then factory reset in batches; each device self-provisions into the new EMM with no
+  hands-on step. Zero-touch is the migration mechanism.
+
+**Offboarding hazard — ordering matters, and the current turn-off flow is unsafe.** `enterprises.delete`
+performs "a cascaded deletion of all AM API devices associated with the deleted enterprise," and
+`Service.DeleteEnterprise` (`service.go:424`, calling `EnterpriseDelete` at `service.go:442`) is what runs
+when an admin turns off Android MDM. If zero-touch configurations exist, deleting the enterprise
+invalidates the enrollment token still embedded in them. Every subsequent factory reset then hits a
+configuration whose token is dead, and the device cannot complete provisioning — ending in the forced
+reset behavior described earlier. In other words, **turning off Android MDM in Fleet silently breaks
+provisioning for every zero-touch-claimed device, with the damage surfacing only on each device's next
+reset.**
+
+Required mitigations:
+
+- Turning off Android MDM must detect existing zero-touch configurations and block or hard-warn, listing
+  the affected teams and device count. This should be treated as a release blocker for Phase 2, not a
+  polish item.
+- Offer a "prepare for migration" action that deletes Fleet's configurations from the customer account
+  (leaving claims intact) before enterprise deletion, so devices boot unmanaged rather than looping.
+- Document the correct offboarding order: repoint or delete zero-touch configurations → reset devices →
+  then delete the enterprise in Fleet.
+- Verify the on-device end state after a cascaded enterprise deletion — whether devices become unmanaged,
+  remain orphaned but provisioned, or require a reset. This is not documented clearly by Google and needs
+  hands-on testing before the offboarding guidance can be considered correct.
+
+### Reconciliation cron
+
+A new cron, following `newAndroidMDMDeviceReconcilerSchedule` (`cmd/fleet/cron.go:2513`) as the pattern
+and registered in `cmd/fleet/cron_registration.go`:
+
+1. Verify the credential still works; mark the integration invalid and stop if not.
+2. `customers.list` — confirm the expected customer account is still reachable.
+3. `customers.dpcs.list` — refresh the Android Device Policy resource path.
+4. `customers.configurations.list` — diff against Fleet's rows. Recreate configurations deleted out of
+   band; re-patch drifted `dpcExtras`; reconcile which configuration Google considers default.
+5. Rotate tokens approaching expiry.
+6. `customers.devices.list` (paginated) — upsert pending device records, reconcile per-device
+   configuration assignments against team intent.
+7. Detect and surface `TosError`.
+
+Reasonable interval: 30 minutes, tunable. It must be bounded and paginated — the existing Android device
+reconciler had to have its pagination loop bounded (commit `8a65ecf20bf`), and the same failure mode
+applies here. Google's per-project quotas for the provisioning API are undocumented in the pages
+reviewed and should be confirmed before choosing an interval for large fleets.
+
+## Fleet modifications
+
+### New package
+
+`server/mdm/android/zerotouch/` (or `server/mdm/android/service/androidprov/`, mirroring `androidmgmt/`)
+containing an interface-first client so it can be mocked, exactly as `androidmgmt.Client` is:
+
+```go
+// Client is used to interact with the zero-touch enrollment customer API.
+// See: https://developers.google.com/zero-touch/reference/customer/rest
+type Client interface {
+	CustomersList(ctx context.Context) ([]*androiddeviceprovisioning.Company, error)
+	DPCsList(ctx context.Context, customerName string) ([]*androiddeviceprovisioning.Dpc, error)
+
+	ConfigurationsList(ctx context.Context, customerName string) ([]*androiddeviceprovisioning.Configuration, error)
+	ConfigurationCreate(ctx context.Context, customerName string, cfg *androiddeviceprovisioning.Configuration) (*androiddeviceprovisioning.Configuration, error)
+	ConfigurationPatch(ctx context.Context, configName string, cfg *androiddeviceprovisioning.Configuration, updateMask string) (*androiddeviceprovisioning.Configuration, error)
+	ConfigurationDelete(ctx context.Context, configName string) error
+
+	DevicesList(ctx context.Context, customerName, pageToken string) (*androiddeviceprovisioning.CustomerListDevicesResponse, error)
+	DeviceApplyConfiguration(ctx context.Context, customerName, deviceName, configName string) error
+	DeviceRemoveConfiguration(ctx context.Context, customerName, deviceName string) error
+}
+```
+
+Plus a `mock/` package generated in the same style as `server/mdm/android/mock/client.go`, and an
+`IsTermsOfServiceError(err error) bool` helper alongside the existing `IsNotModifiedError` /
+`IsBadRequestError` in `androidmgmt/client.go`.
+
+The `arch_test.go` in `server/mdm/android/` enforces the bounded-context import rules; new code must
+satisfy it.
+
+### Database
+
+One new table plus a couple of columns. Timestamps at `TIMESTAMP(6)` precision and binary UUIDs per
+Fleet's MySQL conventions.
+
+```sql
+CREATE TABLE `android_zero_touch_configurations` (
+  `id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `team_id` INT UNSIGNED DEFAULT NULL,
+  `global_or_team_id` INT NOT NULL DEFAULT '0',
+  -- Google-side identity
+  `customer_id` VARCHAR(64) NOT NULL,
+  `configuration_id` VARCHAR(64) NOT NULL DEFAULT '',
+  `configuration_name` VARCHAR(255) NOT NULL DEFAULT '',
+  `is_default` TINYINT(1) NOT NULL DEFAULT '0',
+  -- Fleet-side intent
+  `management_mode` VARCHAR(40) NOT NULL,  -- allowPersonalUsage value
+  `company_name` VARCHAR(255) NOT NULL DEFAULT '',
+  `contact_email` VARCHAR(255) NOT NULL DEFAULT '',
+  `contact_phone` VARCHAR(64) NOT NULL DEFAULT '',
+  `custom_message` TEXT,
+  -- Token state (token value itself lives in mdm_config_assets, not here)
+  `enrollment_token_name` VARCHAR(255) NOT NULL DEFAULT '',
+  `enrollment_token_expires_at` TIMESTAMP(6) NULL DEFAULT NULL,
+  `last_synced_at` TIMESTAMP(6) NULL DEFAULT NULL,
+  `sync_error` TEXT,
+  `created_at` TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_android_zt_global_or_team_id` (`global_or_team_id`),
+  KEY `fk_android_zt_team_id` (`team_id`),
+  CONSTRAINT `fk_android_zt_team_id` FOREIGN KEY (`team_id`) REFERENCES `teams` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+```
+
+The `global_or_team_id` / `team_id` pair with a `UNIQUE KEY` on the former follows
+`android_app_configurations` and gives correct "No team" handling — worth stating explicitly, since "No
+team" is a routine source of bugs in team-scoped features.
+
+For pending hosts, either a second table or reuse of the host pattern:
+
+```sql
+CREATE TABLE `android_zero_touch_devices` (
+  `id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `google_device_id` VARCHAR(64) NOT NULL,
+  `serial_number` VARCHAR(255) NOT NULL DEFAULT '',
+  `imei` VARCHAR(32) NOT NULL DEFAULT '',
+  `meid` VARCHAR(32) NOT NULL DEFAULT '',
+  `manufacturer` VARCHAR(255) NOT NULL DEFAULT '',
+  `model` VARCHAR(255) NOT NULL DEFAULT '',
+  `configuration_id` INT UNSIGNED DEFAULT NULL,
+  `host_id` INT UNSIGNED DEFAULT NULL,  -- set once correlated post-enrollment
+  `deleted_at` TIMESTAMP(6) NULL DEFAULT NULL,
+  `created_at` TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_android_zt_devices_google_device_id` (`google_device_id`),
+  KEY `idx_android_zt_devices_serial` (`serial_number`),
+  KEY `idx_android_zt_devices_host_id` (`host_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+```
+
+Use `make migration name=AddAndroidZeroTouchConfigurations`. If this lands alongside other work, the
+migration timestamp will likely need bumping before merge.
+
+### Secrets
+
+New `MDMAssetName` values in `server/fleet/mdm.go`, stored encrypted in `mdm_config_assets`:
+
+- `android_zero_touch_service_account` — the uploaded service-account JSON key (Option A).
+- `android_zero_touch_oauth_refresh_token` — refresh token (Option B).
+- `android_zero_touch_enrollment_token` — the current long-lived token value per configuration. Storing
+  it as an asset rather than a table column keeps it out of ordinary query paths and gets encryption for
+  free. Since assets are keyed by name, this needs either a name-per-team scheme or an asset table
+  variant that supports scoping — worth checking `mdm_config_assets` for existing per-entity precedent
+  (the VPP and ABM token tables solved this differently) before choosing.
+
+### Service layer and API
+
+New endpoints, registered in `server/mdm/android/service/handler.go` following the existing pattern, with
+request/response structs and `Err error` fields per Fleet's API conventions:
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/api/_version_/fleet/android_enterprise/zero_touch` | Integration status: linked customer, credential validity, ToS state, last sync, errors |
+| `POST` | `/api/_version_/fleet/android_enterprise/zero_touch/credentials` | Upload service-account key (or begin OAuth) |
+| `DELETE` | `/api/_version_/fleet/android_enterprise/zero_touch/credentials` | Disconnect |
+| `GET` | `/api/_version_/fleet/android_enterprise/zero_touch/configurations` | List Fleet's configurations |
+| `PUT` | `/api/_version_/fleet/android_enterprise/zero_touch/configurations/:team_id` | Create or update a team's configuration |
+| `DELETE` | `/api/_version_/fleet/android_enterprise/zero_touch/configurations/:team_id` | Remove |
+| `POST` | `/api/_version_/fleet/android_enterprise/zero_touch/configurations/:team_id/rotate_token` | Force rotation |
+| `GET` | `/api/_version_/fleet/android_enterprise/zero_touch/dpc_extras/:team_id` | Phase 1: return the copy-paste JSON |
+| `GET` | `/api/_version_/fleet/android_enterprise/zero_touch/devices` | Paginated device list with team and enrollment status |
+| `POST` | `/api/_version_/fleet/android_enterprise/zero_touch/devices/:id/team` | Move a device to a team |
+
+Conventions to hold to: authorize first in the service method, validate inputs in the service method (not
+the endpoint) and accumulate errors into a single `InvalidArgumentError`, wrap all errors with
+`ctxerr.Wrap`, and return client errors as 4xx without logging them as server errors. Google-side
+validation failures — a rejected `contactEmail`, a malformed phone number — are client errors and must
+not surface as 500s. Since `contactEmail` and `contactPhone` are validated by Google, Fleet should
+validate them locally too so the admin gets a field-level error instead of a round-trip failure.
+
+Zero-touch is a company-owned-fleet management feature and should be **Premium-gated**, consistent with
+ABM/ADE, with the enterprise logic in `ee/server/service/`. Note the precedent that Android COBO wipe was
+moved to Free (commit `fa7d9282359`), so this is a product decision to confirm rather than an obvious
+one.
+
+### Enrollment path changes
+
+- `CreateEnrollmentToken` gains an internal variant for zero-touch: explicit long `duration`,
+  `oneTimeOnly: false`, mode-specific `allowPersonalUsage`, and the v2 `additionalData` payload. Keep the
+  existing signature intact for the QR path; a shared private helper taking an options struct is cleaner
+  than adding another positional `bool` (the current `fullyManaged bool` parameter is already at the
+  limit of readability, and Fleet's style guide favors descriptive naming over stacked booleans).
+- `enrollHost` and `addNewHost` in `pubsub.go` learn the v2 payload, prefer `team_id` for zero-touch
+  tokens, and stop treating an enroll-secret mismatch as fatal in that case — while preserving the
+  existing `GetAndroidDeviceLastTeamID` precedence.
+- Enroll-secret mutation paths trigger re-issue of affected zero-touch tokens.
+
+### Activities
+
+New activity types, documented in `docs/Contributing/reference/audit-logs.md`:
+`enabled_android_zero_touch`, `disabled_android_zero_touch`,
+`created_android_zero_touch_configuration`, `edited_android_zero_touch_configuration`,
+`deleted_android_zero_touch_configuration`, `rotated_android_zero_touch_enrollment_token`,
+`changed_android_zero_touch_device_team`.
+
+### GitOps
+
+Zero-touch configuration is exactly the kind of state that should be declarative. Add to
+`mdm.android_zero_touch` in `default.yml` and per-team files:
+
+```yaml
+mdm:
+  android_zero_touch:
+    management_mode: fully_managed   # fully_managed | work_profile | dedicated
+    company_name: "Acme Corp"
+    contact_email: "it@acme.example.com"
+    contact_phone: "+1 555 0100"
+    custom_message: "Contact IT if setup does not complete."
+    default: true                    # at most one team may set this
+    forced_reset_time: 2h
+```
+
+Per `CLAUDE.md`'s GitOps notes, two things need explicit tests: **removal** — deleting the key must delete
+the Google-side configuration, which is the classic `apply`-inherited bug — and **all three placements**
+(`default.yml`, `teams/*.yml`, `teams/no-team.yml`). Also validate that no more than one team claims
+`default: true`, within the incoming payload rather than against the DB, since GitOps is declarative.
+
+### Frontend
+
+- **Settings → Integrations → MDM → Android**: extend `AndroidMdmPage.tsx` with a zero-touch section —
+  connect/disconnect credentials, linked customer account, ToS acceptance prompt, last sync, per-team
+  configuration editor, and the Phase 1 copy-paste extras view. `AndroidMdmCard.tsx` should reflect
+  zero-touch status in the summary.
+- **Add hosts modal**: `AndroidPanel.tsx` gains a zero-touch tab explaining that eligible devices need no
+  QR code, with a link to the settings page. This is also the right place to state the
+  bought-from-a-reserved-reseller prerequisite, since that is where the confusion happens.
+- **Hosts list**: surface pending zero-touch devices, matching how ADE "awaiting enrollment" hosts appear.
+- Free/Primo gating per the `tier-modes` conventions if Premium-gated.
+- Command palette entries for the new settings page per the `command-palette` conventions.
+
+### fleetctl
+
+`fleetctl get android-zero-touch` / equivalent for parity with existing MDM inspection commands, plus
+whatever `fleetctl gitops` needs to round-trip the new keys.
+
+### Documentation
+
+- New guide in `articles/` — likely `android-zero-touch-enrollment.md`, following the guide format
+  (prerequisites, numbered steps, gotchas inline). The reseller prerequisite and the service-account
+  linking wait are the two things to lead with.
+- Extend `articles/android-mdm-setup.md`.
+- REST API reference for the new endpoints.
+- An architecture doc under `docs/Contributing/architecture/mdm/`, parallel to
+  `automated-device-enrollment.md`.
+- Update `docs/Contributing/product-groups/mdm/android-mdm.md`.
+
+## Phased delivery
+
+**Phase 1 — manual configuration (no new Google API).** Long-lived reusable enrollment tokens; the v2
+`additionalData` team-identification fix; re-issue on enroll-secret rotation; DPC extras generation and
+display; docs. Delivers working zero-touch for every customer, and proves the token model in production
+before any API integration exists.
+
+**Phase 2 — customer API integration.** Credential upload and validation; the client package and mock;
+the configuration table; create/patch/delete driven from Fleet; reconciliation cron; activities; ToS
+error handling; UI. This is where "manage zero-touch from Fleet" becomes true.
+
+**Phase 3 — device-level management.** Device list sync, pending hosts, per-device configuration
+override, host-record correlation, hosts-list integration.
+
+**Phase 4 — polish and parity.** GitOps, fleetctl, dedicated-device (`PERSONAL_USAGE_DISALLOWED_USERLESS`)
+support, optional provisioning extras (locale, timezone, system apps), and — only if demanded —
+`signinDetail`-based end-user authentication.
+
+Phase 1 is independently shippable and worth doing even if Phases 2–4 are never scheduled.
+
+## Edge cases and failure modes
+
+| Scenario | Consequence | Handling |
+| --- | --- | --- |
+| Enroll secret rotated while a zero-touch token is live | Devices enroll into AMAPI but never become Fleet hosts — silent, delayed | The v2 `team_id` fix plus re-issue on rotation. **Highest-severity item in this document.** |
+| Admin edits or deletes the configuration in Google's portal | Fleet's view is wrong; devices provision with stale extras or not at all | Reconciliation cron detects drift, restores, and records `sync_error` |
+| Team deleted in Fleet | Orphaned Google configuration; devices provision into nothing | `ON DELETE CASCADE` on the row plus a cron cleanup pass for the Google-side object |
+| Team was the zero-touch default | New purchases have no default | Refuse deletion, or reassign the default and warn |
+| Token expires | All zero-touch provisioning fails at once, fleet-wide | Rotate 30 days early; alert on approaching expiry; treat expiry as a first-class monitored condition |
+| Google ToS updated | Every API call 403s mid-life | Detect `TosError` with `X-GOOG-API-FORMAT-VERSION: 2`; surface an actionable banner |
+| Credential revoked or key deleted | Cron fails silently | Mark integration invalid, surface in UI, stop retrying hot |
+| Android MDM turned off in Fleet while zero-touch configurations exist | `enterprises.delete` cascades, invalidating the token in every configuration; each device breaks on its *next* reset, long after the action | Block or hard-warn on turn-off; offer a pre-offboarding configuration cleanup. **Release blocker for Phase 2** |
+| Customer migrates to another EMM | Devices need a factory reset regardless of EMM; zero-touch claims are unaffected | Document the repoint-then-reset order; do not delete the Fleet enterprise first |
+| Two Fleet instances share a customer account | Configurations fight over `isDefault` | Detect unknown configurations; do not blindly delete configurations Fleet did not create |
+| Device factory reset | Re-provisions via zero-touch | Existing `GetAndroidDeviceLastTeamID` restores the last-known team; keep that precedence over the token's team |
+| Device unclaimed at the reseller | Zero-touch stops applying; re-registration requires contacting the reseller | Reconcile removals; mark pending device gone rather than deleting history; warn that unclaim is not self-service to undo |
+| Device never boots | Pending host lingers forever | Show claim age; allow dismissal |
+| Configuration applied to a device already in service | **Device factory resets, destroying end-user data**, after a one-hour warning on next contact with Google | Treat `applyConfiguration` and default-configuration changes as destructive in the UI: explicit warning plus confirmation |
+| No network during setup | Zero-touch is skipped and the device boots unmanaged, then self-resets on first connection to Google | Expose `forcedResetTime`; document both reset mechanisms and the failure signature |
+| Serial number missing or mismatched | Pending device never correlates, or a duplicate host appears | Multi-key correlation with normalization; prefer no correlation over a wrong one |
+| `additionalData` exceeds 1024 chars | Token creation fails | Validate length before the API call; keep the payload minimal |
+| Non-GMS or pre-8.0 device | Zero-touch simply does not apply | Document; nothing Fleet can do |
+
+## Testing plan
+
+- **Unit** — table-driven tests with `t.Run` subtests over the client interface via the new mock, per
+  Fleet's Go test conventions. Cover configuration diffing, default-configuration transitions, token
+  rotation ordering (patch before delete), `additionalData` v1/v2 parsing, and serial normalization.
+- **Enroll-secret rotation regression** — the specific case above, asserted end to end: create a
+  zero-touch token, rotate the team's enroll secret, deliver a synthetic `ENROLLMENT` notification,
+  assert the host lands in the right team. This test is the reason to do the work.
+- **Integration** — extend `server/mdm/android/tests/` and the AMAPI mock at `cmd/android-amapi-mock/`
+  with a provisioning-API surface, so the cron and endpoints can be exercised without Google.
+- **Multi-team** — per `CLAUDE.md`, cover "No team", multiple teams, and the default-team transition.
+- **Multi-host** — at least two physically distinct zero-touch devices from different manufacturers in
+  manual QA, per Fleet's multi-host testing requirement. Serial/IMEI reporting differences between OEMs
+  are the likeliest source of correlation bugs, and one device will not reveal them.
+- **GitOps** — add, edit, and *remove* the `android_zero_touch` key in all three file placements.
+- **Manual QA prerequisites** — a real zero-touch customer test account, obtainable from Google with a
+  corporate email, and at least one reseller-claimed device. Note Google's constraint that the DPC must
+  be published on Play, which is satisfied automatically since Fleet uses Android Device Policy.
+- **Frontend** — Jest coverage for the new settings section and Add-hosts tab.
+
+## Security considerations
+
+- The enrollment token in `dpcExtras` is a bearer credential for joining the AMAPI enterprise. Its blast
+  radius is bounded — it enrolls a device into management, it does not read or write Fleet data — but a
+  leaked reusable token lets an attacker enroll arbitrary devices into a team, which pollutes inventory
+  and could be used to pull team-scoped configuration profiles and their embedded secrets. That last
+  point deserves a threat-model review, since Android profiles support variables and certificate
+  templates.
+- Never place the Fleet enroll secret, IdP credentials, or any Fleet API token in `dpcExtras`. Google's
+  own guidance says not to put secrets in configurations; the enrollment token is the single justified
+  exception.
+- Service-account keys and OAuth refresh tokens must go in `mdm_config_assets` (encrypted at rest), never
+  in `app_config_json`, and must be redacted from all logs and API responses. The existing
+  `ProxyClient` logger already demonstrates the redaction pattern for `Authorization` headers.
+- Reject the shared-service-account multi-tenant proxy model, as described above.
+- Authorization on all new endpoints must be team-scoped where the resource is team-scoped, using the
+  double-authorize pattern (generic check, load entity, entity-scoped check).
+- `customers.devices:unclaim` is irreversible and requires going back to the reseller to undo. Either do
+  not expose it or gate it behind explicit typed confirmation.
+- Worth a `fleet-security-auditor` pass before merge, given this touches enrollment and MDM credentials.
+
+## Open questions
+
+1. **Credential model** — Option A or B? This blocks Phase 2 and needs confirmation from Google's Android
+   Enterprise partner team on whether customer-account service-account linking is still form-based, and
+   on the verification status of the `androidworkzerotouchemm` scope.
+2. **Proxy divergence** — is the "zero-touch always goes direct to Google" decision acceptable to the
+   Fleet Cloud architecture, given every other Android call is proxied?
+3. **Premium gating** — Premium-only, or Free like Android COBO wipe?
+4. **End-user authentication** — is user-attributed zero-touch a requirement? If yes, `signinDetail` is a
+   separate design effort and should be specified before Phase 1 locks the token model.
+5. **Pending hosts** — is serial/IMEI correlation reliable enough across OEMs to ship? Needs real device
+   data.
+6. **API quotas** — what are Google's rate limits on the provisioning API? Determines cron interval and
+   pagination strategy for large fleets.
+7. **Multiple customer accounts** — can one organization have several zero-touch customer accounts (for
+   example, one per reseller or region)? `customers.list` returns a list, and Google's own quickstarts
+   just take the first element. Fleet should not do that silently.
+8. **Dedicated devices** — is COSU in scope for the first release, or deferred? It affects whether
+   management mode needs to be per-configuration rather than per-team.
+
+## Effort estimate
+
+Rough, assuming a backend engineer plus frontend support, and *excluding* the time to resolve the
+credential question and obtain a Google test account — both of which are on the critical path and have
+external latency.
+
+| Phase | Backend | Frontend | Notes |
+| --- | --- | --- | --- |
+| 1 — manual configuration | 1–2 weeks | 2–3 days | The `additionalData` fix is most of the risk |
+| 2 — customer API integration | 3–4 weeks | 1–1.5 weeks | Client, mock, migration, cron, endpoints |
+| 3 — device-level management | 2–3 weeks | 1 week | Correlation is the uncertain part |
+| 4 — polish and parity | 1–2 weeks | 2–3 days | Excludes `signinDetail` |
+
+`signinDetail`-based end-user authentication, if required, is an additional 3–4 weeks and should be
+scoped separately.
+
+## References
+
+### Google — zero-touch enrollment
+
+- [Overview](https://developers.google.com/zero-touch/guides/overview)
+- [How it works (customers)](https://developers.google.com/zero-touch/guides/customer/how-it-works)
+- [EMM integration guide](https://developers.google.com/zero-touch/guides/customer/emm)
+- [Customer API reference](https://developers.google.com/zero-touch/reference/customer/rest)
+- [`customers.configurations`](https://developers.google.com/zero-touch/reference/customer/rest/v1/customers.configurations)
+- [`customers.devices`](https://developers.google.com/zero-touch/reference/customer/rest/v1/customers.devices)
+- [Authorization](https://developers.google.com/zero-touch/guides/auth)
+- [Service accounts for customers](https://developers.google.com/zero-touch/guides/customer/service-accounts)
+- [Python quickstart with a service account](https://developers.google.com/zero-touch/guides/customer/quickstart/python-service-account)
+- [Zero-touch enrollment for IT admins](https://support.google.com/work/android/answer/7514005)
+- [Zero-touch customer portal](https://enterprise.google.com/android/zero-touch/customers)
+- [Sample Colab notebooks](https://github.com/googlesamples/zero-touch-enrollment-colabs)
+
+### Google — Android Management API
+
+- [Enroll and provision a device](https://developers.google.com/android/management/provision-device)
+- [`enterprises.enrollmentTokens`](https://developers.google.com/android/management/reference/rest/v1/enterprises.enrollmentTokens)
+- [`AllowPersonalUsage`](https://developers.google.com/android/management/reference/rest/v1/AllowPersonalUsage)
+- [Notifications (Pub/Sub)](https://developers.google.com/android/management/notifications)
+
+### Fleet
+
+- `server/mdm/android/README.md` — bounded-context rationale
+- `server/mdm/android/service/service.go:549` — `CreateEnrollmentToken`
+- `server/mdm/android/service/pubsub.go:599` — `enrollHost`
+- `server/mdm/android/service/pubsub.go:893` — `addNewHost`
+- `server/mdm/android/service/androidmgmt/client.go` — AMAPI client interface
+- `cmd/fleet/cron.go:2513` — Android device reconciler cron pattern
+- `docs/Contributing/architecture/mdm/automated-device-enrollment.md` — the Apple analogue
+- `docs/Contributing/product-groups/mdm/android-mdm.md`

--- a/docs/Contributing/research/mdm/android-zero-touch-enrollment.md
+++ b/docs/Contributing/research/mdm/android-zero-touch-enrollment.md
@@ -4,44 +4,38 @@ Status: research / design proposal. Not yet scheduled.
 
 ## Abstract
 
-Fleet can already manage company-owned Android devices, but it cannot provision them without a human
-touching each one. Today an admin must generate a short-lived enrollment token in Fleet and then scan a
-QR code (or type `afw#setup`) on every device. Fleet has an equivalent zero-touch story on Apple —
-Automated Device Enrollment via Apple Business — but nothing on Android. This document specifies what it
-would take to close that gap using Google's Android zero-touch enrollment program, so that a device
-purchased from a zero-touch reseller ships directly to an employee, and on first boot provisions itself
-into the correct Fleet team as a fully managed device with no admin involvement.
+Fleet manages company-owned Android devices but cannot provision them without a human touching each one:
+an admin generates a one-hour enrollment token and someone scans a QR code on every device. Fleet has a
+zero-touch path on Apple (Automated Device Enrollment via Apple Business) and none on Android. This
+document specifies what it would take to close that gap using Google's Android zero-touch enrollment, so
+that a device purchased from a zero-touch reseller ships straight to an employee and provisions itself
+into the correct Fleet team on first boot.
 
-The core technical insight is that zero-touch enrollment does not introduce a new enrollment protocol.
-Google's zero-touch service simply pre-stages the same Android Management API (AMAPI) enrollment token
-Fleet already creates, delivering it to the device through Google's provisioning servers instead of a QR
-code. The device then follows the exact AMAPI provisioning path Fleet already supports, and Fleet learns
-about it through the Pub/Sub `ENROLLMENT` notification it already handles. That makes this a
-configuration-management and lifecycle feature, not a new MDM protocol implementation — the entire
-existing profile delivery, software install, command, and host-vitals pipeline is reused unchanged.
+Zero-touch introduces no new enrollment protocol. Google's provisioning service pre-stages the same
+Android Management API (AMAPI) enrollment token Fleet already creates and delivers it to the device
+instead of a QR code. The device then follows the AMAPI path Fleet already supports, and Fleet is notified
+by the Pub/Sub `ENROLLMENT` message it already handles. Profile delivery, software installs, commands, and
+host vitals are reused unchanged.
 
-The work therefore breaks into four parts. First, a new Google API integration: the **Android Device
-Provisioning Partner API** (`androiddeviceprovisioning.googleapis.com`), customer surface, which is
-already present in Fleet's vendored `google.golang.org/api` module and needs no new dependency. Second, a
-credential model for that API, which is the single largest open question — Google offers a service-account
-path (simple, automation-friendly, but requires a manual Google-approved linking request) and an
-interactive OAuth path (self-service, but a per-admin refresh token and probable scope verification). Third,
-Fleet-side changes: long-lived reusable enrollment tokens, a new table and config assets, a
-configuration-per-team model, a reconciliation cron, pending-host records so admins can see devices before
-first boot, activities, GitOps keys, REST endpoints, and UI. Fourth, a change to how Fleet identifies the
-target team at enrollment time — the current design embeds a mutable enroll secret in the token's
-`additionalData`, which silently breaks long-lived zero-touch tokens whenever an admin rotates a team's
-enroll secret. That last item is a correctness prerequisite, not a nice-to-have.
+Four workstreams follow. **One:** integrate the Android Device Provisioning Partner API
+(`androiddeviceprovisioning.googleapis.com`), customer surface — already in Fleet's module graph, so no
+new dependency. **Two:** choose a credential model for it, the largest open question. Google offers a
+service-account path (fits an automated cron, but linking it to a customer account currently requires a
+Google Form and email confirmation) and an interactive OAuth path (self-service, but bound to one admin's
+Google account with probable scope verification). **Three:** build the Fleet side — long-lived reusable
+tokens, a configuration per team, a reconciliation cron, pending-host records, activities, GitOps keys,
+REST endpoints, UI. **Four:** change how Fleet identifies the target team at enrollment. Fleet embeds a
+mutable enroll secret in the token's `additionalData`; rotating a team's enroll secret then silently
+breaks every long-lived zero-touch token. That is a correctness prerequisite, not an enhancement.
 
-The document also proposes a phased delivery in which Phase 1 ships real, usable zero-touch support with
-**no** new Google API integration at all — Fleet generates the DPC extras JSON and the admin pastes it into
-Google's zero-touch portal once per team. Phase 1 is small, unblocks customers immediately, and de-risks the
-credential decision in Phase 2 by proving the token and team-mapping model in production first.
+Phase 1 ships usable zero-touch with **no** Google API integration: Fleet emits the DPC extras JSON and
+the admin pastes it into Google's portal once per team. It is small, unblocks customers immediately, and
+proves the token and team-mapping model before the credential decision is made.
 
 ## Table of contents
 
 - [Scope](#scope)
-- [How Android zero-touch enrollment actually works](#how-android-zero-touch-enrollment-actually-works)
+- [How Android zero-touch enrollment works](#how-android-zero-touch-enrollment-works)
 - [Where Fleet is today](#where-fleet-is-today)
 - [Gap analysis](#gap-analysis)
 - [Google APIs required](#google-apis-required)
@@ -52,128 +46,115 @@ credential decision in Phase 2 by proving the token and team-mapping model in pr
 - [Edge cases and failure modes](#edge-cases-and-failure-modes)
 - [Testing plan](#testing-plan)
 - [Security considerations](#security-considerations)
+- [Unverified claims](#unverified-claims)
 - [Open questions](#open-questions)
 - [Effort estimate](#effort-estimate)
 - [References](#references)
 
 ## Scope
 
-"Zero-touch enrollment for company-owned devices" means different things per platform. This document is
-about the Android gap, because that is the only company-owned platform where Fleet has no zero-touch path
-at all.
+Android is the only company-owned platform where Fleet has no zero-touch path.
 
 | Platform | Zero-touch mechanism | Fleet status |
 | --- | --- | --- |
 | macOS / iOS / iPadOS | Apple Automated Device Enrollment (ADE) via Apple Business | Supported. See `docs/Contributing/architecture/mdm/automated-device-enrollment.md` |
 | Android (company-owned) | Google Android zero-touch enrollment | **Not supported — this document** |
-| Windows | Windows Autopilot (Entra ID + Windows Autopilot service) | Not supported. Separate effort, unrelated APIs |
-| ChromeOS | Chrome zero-touch enrollment (same provisioning API, `deviceType` CHROME_OS) | Out of scope; Fleet has no ChromeOS MDM |
+| Windows | Windows Autopilot | Not supported. Separate effort, unrelated APIs |
+| ChromeOS | Chrome zero-touch enrollment (same provisioning API, `deviceType` `CHROME_OS`) | Out of scope; Fleet has no ChromeOS MDM |
 
-Within Android, zero-touch applies to three company-owned management modes. All three are reachable
-through the same mechanism, differing only in the `allowPersonalUsage` value on the enrollment token:
+Zero-touch supports three management modes, differing only in the `allowPersonalUsage` value on the
+enrollment token:
 
-- **Fully managed (COBO)** — company-owned, business only. `PERSONAL_USAGE_DISALLOWED`.
-- **Company-owned with a work profile (COPE)** — company-owned, personally enabled.
-  `PERSONAL_USAGE_ALLOWED`.
-- **Dedicated / kiosk (COSU)** — no user identity. `PERSONAL_USAGE_DISALLOWED_USERLESS`. Google made this
-  value mandatory for dedicated-device enrollment as of January 2025.
+- **Fully managed (COBO)** — `PERSONAL_USAGE_DISALLOWED`.
+- **Company-owned with a work profile (COPE)** — `PERSONAL_USAGE_ALLOWED`. Android 8+, though Android 11
+  reworked COPE to treat the personal side closer to BYOD.
+- **Dedicated / kiosk (COSU)** — `PERSONAL_USAGE_DISALLOWED_USERLESS`, which Google made mandatory for
+  dedicated-device enrollment as of January 2025.
 
-Personally-owned (BYOD) work profile enrollment is explicitly **out of scope**: zero-touch requires the
-device to be purchased through a zero-touch reseller and claimed to the organization, which by definition
-makes it company-owned.
+Zero-touch does **not** support work profiles on personally-owned devices. Google's provisioning-method
+matrix lists zero-touch as supporting COPE, fully managed, and dedicated only. BYOD is therefore out of
+scope by mechanism, not just by policy.
 
-## How Android zero-touch enrollment actually works
-
-Understanding the actor model matters, because it determines what Fleet can and cannot do.
+## How Android zero-touch enrollment works
 
 ### Actors
 
-1. **Reseller** — an authorized zero-touch reseller partner. When an organization buys devices, the
-   reseller registers each device's hardware identifiers (IMEI/MEID or serial number, plus manufacturer)
-   into Google's zero-touch system and *claims* the device to that organization's customer account. **Only
-   resellers can create device records.** IT admins cannot, and neither can an EMM. This is a hard
-   constraint: Fleet can never add a device to zero-touch.
+1. **Reseller** — an authorized zero-touch reseller. On purchase, the reseller registers each device's
+   hardware identifiers (IMEI/MEID or serial number, plus manufacturer) and *claims* the device to the
+   organization's customer account. **Only resellers can create device records** — not IT admins, not an
+   EMM. Fleet can never add a device to zero-touch.
 2. **Customer account** — the organization's zero-touch account, created by the reseller on first
-   purchase. Admins manage it at `https://enterprise.google.com/android/zero-touch/customers`. Each
-   customer account has an ID and an API resource name of the form `customers/{CUSTOMER_ID}`.
+   purchase, managed at `https://enterprise.google.com/android/zero-touch/customers`, addressed as
+   `customers/{CUSTOMER_ID}`.
 3. **DPC (Device Policy Controller)** — the agent that provisions and manages the device. For AMAPI-based
-   EMMs like Fleet, the DPC is Google's own **Android Device Policy**
-   (`com.google.android.apps.work.clouddpc`). Fleet does not ship a DPC.
-4. **EMM (Fleet)** — provides a console where admins manage zero-touch configurations, using the
-   customer API on the admin's behalf.
+   EMMs, that is Google's **Android Device Policy** (`com.google.android.apps.work.clouddpc`). Fleet ships
+   no DPC.
+4. **EMM (Fleet)** — provides the console where admins manage configurations, calling the customer API on
+   the admin's behalf.
 
 ### Configurations
 
-The unit of zero-touch policy is a **Configuration**, owned by the customer account. A configuration
-bundles the DPC to install, the provisioning extras to hand that DPC, support contact info, and a custom
-message shown during setup. Fields (all from `customers.configurations`):
+A **Configuration** is owned by the customer account and bundles the DPC to install, the provisioning
+extras handed to that DPC, support contact details, and a message shown during setup.
 
 | Field | Required | Notes |
 | --- | --- | --- |
 | `configurationName` | Yes | Shown to admins in the portal. Fleet would use the team name. |
-| `dpcResourcePath` | Yes | `customers/{CUST_ID}/dpcs/{DPC_ID}`. Must be discovered via `customers.dpcs.list` and matched to Android Device Policy — do not hardcode. |
-| `dpcExtras` | No | JSON string of provisioning extras. **This is where Fleet's enrollment token goes.** |
-| `companyName` | Yes | Shown on device during provisioning. Fleet would default to org name from app config. |
-| `contactEmail` | Yes | Validated by Google. Shown to the user before provisioning. |
-| `contactPhone` | Yes | Shown to the user before provisioning. Digits, spaces, `+`, `-`, `()`. |
+| `dpcResourcePath` | Yes | `customers/{CUST_ID}/dpcs/*`. Discover via `customers.dpcs.list`; do not hardcode. |
+| `dpcExtras` | No | JSON string of provisioning extras. **Fleet's enrollment token goes here.** |
+| `companyName` | Yes | Shown on device during provisioning. Fleet would default to the org name in app config. |
+| `contactEmail` | Yes | Validated by Google. Shown before provisioning. |
+| `contactPhone` | Yes | Shown before provisioning. Digits, spaces, `+`, `-`, `()`. |
 | `customMessage` | No | One or two sentences shown before provisioning. |
-| `isDefault` | Yes | Applies to all newly purchased devices. **Only one default per customer account.** Setting a new default silently clears the old one. |
-| `forcedResetTime` | No | Timeout before forcing a factory reset when setup cannot complete (typically no network). 0–6 hours, default 2 hours. |
+| `isDefault` | Yes | Applies to devices the organization purchases in future. Setting it to `true` sets the previous default's `isDefault` to `false`. |
+| `forcedResetTime` | No | Timeout before forcing a factory reset when setup cannot complete, typically for lack of network. 0–6 hours, default 2. |
 | `name`, `configurationId` | Output only | Server-assigned. |
 
 ### Device records and configuration assignment
 
-Devices under a customer account expose `deviceIdentifier` (serial number, manufacturer, model,
-IMEI/MEID, plus `imei2`/`meid2` for dual-SIM), `deviceMetadata` (reseller-set key/value pairs),
-`claims[]` (the zero-touch claim, `SECTION_TYPE_ZERO_TOUCH`), and `configuration` (the applied
-configuration path, or empty).
+Devices expose `deviceIdentifier` (serial number, manufacturer, model, IMEI/MEID, plus `imei2`/`meid2` for
+dual-SIM), `deviceMetadata` (reseller-set key/value pairs), `claims[]` (the zero-touch claim,
+`SECTION_TYPE_ZERO_TOUCH`), and `configuration` (the applied configuration path, or empty).
 
-A device gets a configuration one of two ways:
+A device gets a configuration either implicitly from the account's **default configuration**, which
+applies to newly purchased devices, or explicitly via `customers.devices:applyConfiguration`.
 
-- Implicitly, by the customer account's **default configuration**, which applies to newly claimed devices.
-- Explicitly, via `customers.devices:applyConfiguration`, which overrides the default for that device.
-
-`customers.devices:removeConfiguration` unassigns; `customers.devices:unclaim` removes the device from
-zero-touch entirely (destructive — the organization loses the claim and must go back to the reseller).
+`customers.devices:removeConfiguration` removes a configuration from a device.
+`customers.devices:unclaim` removes the device from zero-touch entirely; re-registering requires going
+back to the reseller.
 
 ### First-boot flow
 
-1. Device is factory reset or unboxed and connects to a network during setup.
+1. Device is unboxed or factory reset and connects to a network during setup.
 2. It checks in with Google's provisioning servers, identifying itself by hardware ID.
-3. If a configuration is assigned, Google returns it and the device enters the fully managed device setup
-   wizard, showing `companyName`, `customMessage`, `contactEmail`, and `contactPhone`.
-4. The device downloads Android Device Policy from Google Play.
+3. If a configuration is assigned, the device enters the fully managed setup wizard, showing
+   `companyName`, `customMessage`, `contactEmail`, and `contactPhone`.
+4. The device installs Android Device Policy from Google Play.
 5. Android Device Policy receives `ACTION_PROVISION_MANAGED_DEVICE` with the extras from `dpcExtras`,
-   reads the AMAPI enrollment token, and enrolls into the AMAPI enterprise.
-6. AMAPI publishes an `ENROLLMENT` notification to the enterprise's Pub/Sub topic. **This is where Fleet
-   re-enters the picture, on the code path it already has.**
+   reads the enrollment token, and enrolls into the AMAPI enterprise.
+6. AMAPI publishes an `ENROLLMENT` notification to the enterprise's Pub/Sub topic. **Fleet re-enters here,
+   on the code path it already has.**
 
-### When provisioning triggers — and the destructive edge
+### When provisioning triggers
 
-Zero-touch is evaluated **only during the out-of-box setup wizard**: on first boot, or on the next factory
-reset. It is not a push mechanism and cannot provision a device that is already set up and running.
-Three consequences matter for Fleet's design:
+Zero-touch is evaluated **only during the out-of-box setup wizard** — on first boot or after a factory
+reset. It is not a push mechanism and cannot provision a device that is already set up and running. Three
+consequences shape the design:
 
-- **It re-triggers on every factory reset, indefinitely.** A device claimed to a customer account and
-  assigned a configuration re-provisions every time it is reset, for as long as the claim exists. The end
-  user cannot bypass or defer it. This stickiness is the security property that makes zero-touch valuable
-  for company-owned hardware — and the reason a broken configuration is a fleet-wide outage rather than a
-  per-device annoyance.
-- **Assigning a configuration to a device that is already in use causes a factory reset.** Per Google's
-  admin documentation, a device that lacks connectivity during setup skips the zero-touch flow and boots
-  unmanaged, but then "resets itself after the first connection to Google servers," giving the user one
-  hour of warning. The same applies to a device already in service when a configuration is applied to it.
-  **`customers.devices:applyConfiguration` is therefore potentially destructive of end-user data**, which
-  is not obvious from the API surface — the method name suggests a metadata write. Fleet must treat it as
-  a destructive action in the UI, with explicit warning and confirmation, and the same warning belongs on
-  the "set default configuration" path, since the default applies to every newly claimed device.
-- **Two distinct reset mechanisms exist**, and they are easy to conflate: `forcedResetTime` (0–6 hours,
-  default 2) is the in-setup timeout when the wizard cannot reach Google, while the self-reset above fires
-  after setup has completed unmanaged. Both end in a factory reset; only the first is configurable.
+- **It re-triggers on every factory reset, for as long as the claim exists.** The end user cannot bypass
+  or defer it. This is the security property that makes zero-touch valuable for company-owned hardware,
+  and the reason a broken configuration is a fleet-wide outage rather than a per-device annoyance.
+- **Applying a configuration to a device already in service triggers a factory reset.** Google's admin
+  documentation states that a device lacking connectivity during setup skips zero-touch and boots
+  unmanaged, then "resets itself after the first connection to Google servers," warning the user one hour
+  ahead. So `customers.devices:applyConfiguration` can destroy end-user data — which the method name does
+  not suggest. Fleet must treat it, and changes to the default configuration, as destructive actions
+  requiring explicit confirmation.
+- **Two reset mechanisms exist and are easily conflated.** `forcedResetTime` (0–6 hours, default 2) is the
+  in-setup timeout when the wizard cannot reach Google. The self-reset above fires after setup completed
+  unmanaged. Only the first is configurable.
 
 ### DPC extras for AMAPI
-
-The exact `dpcExtras` payload for an AMAPI-managed device:
 
 ```json
 {
@@ -187,124 +168,125 @@ The exact `dpcExtras` payload for an AMAPI-managed device:
 }
 ```
 
-Google's EMM guidance on extras, which Fleet should follow:
+**Google's two documentation sets contradict each other here.** The AMAPI provisioning guide gives exactly
+the payload above, including the component name and signature checksum. The zero-touch EMM integration
+guide advises against including device-admin component name and checksum extras, calling them
+inappropriate for this enrollment method. Follow the AMAPI guide, since it is specific to Android Device
+Policy, and verify on real hardware before shipping — a wrong payload here fails at provisioning time on
+the device, where it is expensive to debug.
 
-- Put everything Fleet-specific inside `PROVISIONING_ADMIN_EXTRAS_BUNDLE`, not as top-level extras.
-- Do **not** put account credentials or secrets in the configuration. The AMAPI enrollment token is the
-  one unavoidable exception, and it is scoped to enrollment only.
-- Optionally supported and reasonable for Fleet to expose later:
-  `EXTRA_PROVISIONING_LOCALE`, `EXTRA_PROVISIONING_TIME_ZONE`, `EXTRA_PROVISIONING_LOCAL_TIME`,
-  `EXTRA_PROVISIONING_LEAVE_ALL_SYSTEM_APPS_ENABLED`, `EXTRA_PROVISIONING_MAIN_COLOR`,
-  `EXTRA_PROVISIONING_DISCLAIMERS`.
-- Google explicitly advises against `PROVISIONING_DEVICE_ADMIN_PACKAGE_DOWNLOAD_LOCATION`,
-  `..._PACKAGE_CHECKSUM`, and cookie-header extras — those belong to other enrollment methods.
+Other guidance from the EMM guide that does apply:
+
+- Put Fleet-specific values inside `PROVISIONING_ADMIN_EXTRAS_BUNDLE`, not as top-level extras.
+- Do not put credentials or secrets in a configuration. The enrollment token is the one unavoidable
+  exception and is scoped to enrollment.
+- Supported and reasonable to expose later: `EXTRA_PROVISIONING_LOCALE`, `EXTRA_PROVISIONING_TIME_ZONE`,
+  `EXTRA_PROVISIONING_LOCAL_TIME`, `EXTRA_PROVISIONING_LEAVE_ALL_SYSTEM_APPS_ENABLED`,
+  `EXTRA_PROVISIONING_MAIN_COLOR`, `EXTRA_PROVISIONING_DISCLAIMERS`.
+- Avoid package download location and cookie-header extras; they belong to other enrollment methods.
 
 ### Device eligibility
 
-- Android 8.0+ (or Pixel on 7.1+) per the zero-touch EMM guide. Google's Workspace-facing documentation
-  states 9.0+ (Pixel 7.0+) for work-profile devices, so the floor varies by source and management mode —
-  verify against the Android Enterprise device list rather than either number.
+- Android 8.0+ (Pixel 7.1+) per the zero-touch EMM guide. Google's Workspace-facing documentation says
+  9.0+ (Pixel 7.0+) for work-profile devices, so the floor varies by source and mode. Verify against the
+  Android Enterprise device list rather than either number.
 - Google Mobile Services present.
-- Registered by a participating zero-touch reseller and claimed to the organization's customer account.
+- Registered by a participating reseller and claimed to the organization's customer account.
 
 ### Devices the organization already owns
 
-This is the most consequential limitation for adoption, and it should be stated plainly in Fleet's UI and
-docs rather than discovered.
+An organization's existing Android fleet generally cannot be moved onto zero-touch, and this is the most
+consequential limitation for adoption. Registration is performed by the reseller that sold the device;
+there is no self-service path, and Google's newer "automatic zero-touch enrollment" framing in the
+Workspace documentation still requires reseller registration. A device bought at retail or through a
+non-participating channel has no route in.
 
-An organization's **existing** Android fleet generally cannot be moved to zero-touch. Registration is
-performed by the reseller that sold the device, and there is no self-service path — Google's newer
-"automatic zero-touch enrollment" framing in the Workspace documentation still requires reseller
-registration. A device bought at retail or through a non-participating channel has no route in at all.
-Devices purchased from a participating reseller can often be registered retroactively on request, since
-the reseller has both the tooling (`partners.devices.claim`) and the sales record, but that is the
-reseller's call and outside Fleet's control. Deregistering a device likewise requires going back to the
-reseller to reverse.
+Devices bought from a participating reseller can often be registered retroactively on request — the
+reseller has the tooling (`partners.devices.claim`) and the sales record — but that is the reseller's call
+and outside Fleet's control. Deregistering also requires the reseller to reverse.
 
-The practical consequence: zero-touch is a **forward-looking** capability tied to procurement, not a
-migration path for an installed base. For devices already owned, Fleet's existing QR-code and
-`afw#setup` flows already achieve the same *management* end state — a fully managed device in the correct
-team — at the cost of one human touch per device at factory-reset time.
+So zero-touch is a forward-looking capability tied to procurement, not a migration path for an installed
+base. For devices already owned, Fleet's existing enrollment link and QR code reach the same *management*
+end state — a fully managed device in the correct team — at one human touch per device at factory-reset
+time.
 
-What that does **not** replicate is zero-touch's stickiness. A QR-enrolled device that is factory reset
-boots unmanaged; a zero-touch device re-provisions itself. Where the requirement is tamper resistance
-rather than provisioning convenience, only reseller registration satisfies it. Fleet's messaging should
-distinguish these two value propositions instead of presenting zero-touch purely as a convenience
-feature, because they lead to different purchasing decisions.
+What that does not replicate is stickiness. A QR-enrolled device that is factory reset boots unmanaged; a
+zero-touch device re-provisions itself. Where the requirement is tamper resistance rather than
+provisioning convenience, only reseller registration satisfies it. These are two different value
+propositions leading to different purchasing decisions and should not be conflated in messaging.
 
-Platform-specific alternative, noted for completeness and **not** proposed here: Samsung Knox Mobile
-Enrollment supports admin self-registration of already-owned devices via the Knox Deployment App or a KME
-QR profile, without reseller involvement, and can target AMAPI. It is a separate program from Google
-zero-touch and would be a distinct integration effort.
+Noted for completeness and **not proposed here**: Samsung Knox Mobile Enrollment supports admin
+self-registration of already-owned devices via the Knox Deployment App or a KME QR profile, without
+reseller involvement, and can target AMAPI. It is a separate program and a distinct integration effort.
 
 ## Where Fleet is today
 
-Fleet's Android MDM lives in `server/mdm/android/` as a deliberately decoupled bounded context (see
+Fleet's Android MDM lives in `server/mdm/android/` as a decoupled bounded context (see
 `server/mdm/android/README.md`).
 
 ### Enrollment token creation
 
-`Service.CreateEnrollmentToken` in `server/mdm/android/service/service.go:549` is the entire current
+`Service.CreateEnrollmentToken` (`server/mdm/android/service/service.go:549`) is the whole current
 enrollment surface. It:
 
 1. Verifies Android MDM is configured.
-2. Verifies the supplied enroll secret (`svc.ds.VerifyEnrollSecret`), which is what determines the target
-   team.
+2. Verifies the enroll secret (`svc.ds.VerifyEnrollSecret`), which determines the target team.
 3. Optionally requires and validates an IdP account UUID for end-user authentication.
 4. Marshals `{enroll_secret, idp_uuid}` into the token's `additionalData`.
 5. Sets `allowPersonalUsage` from a `fully_managed` query parameter — `PERSONAL_USAGE_DISALLOWED` when
-   true, `PERSONAL_USAGE_ALLOWED` otherwise.
+   true, `PERSONAL_USAGE_ALLOWED` otherwise (`service.go:608`).
 6. Sets `oneTimeOnly: true` and leaves `duration` unset, so **the token expires in one hour and works
-   exactly once**.
-7. Returns the token value, a `https://enterprise.google.com/android/enroll?et=<token>` URL, and a QR code.
+   once**.
+7. Returns the token value, an `https://enterprise.google.com/android/enroll?et=<token>` URL, and a QR
+   code.
 
 The frontend surface is `frontend/components/AddHostsModal/PlatformWrapper/AndroidPanel/AndroidPanel.tsx`,
-which offers a "work profile" / "fully managed" radio and renders the QR code.
+which offers a work-profile / fully-managed radio and builds a Fleet enrollment URL.
 
 ### Enrollment completion
 
-`Service.enrollHost` (`server/mdm/android/service/pubsub.go:599`) handles the Pub/Sub `ENROLLMENT`
-notification. It unmarshals `device.EnrollmentTokenData` back into `{enroll_secret, idp_uuid}`, verifies
-the enroll secret again, resolves the team, and creates or updates the host. `addNewHost`
-(`pubsub.go:893`) is the new-device path; it maps AMAPI `hardwareInfo.serialNumber` into
-`host.HardwareSerial` (`pubsub.go:947`), which matters for correlating zero-touch device records later.
+`Service.enrollHost` (`server/mdm/android/service/pubsub.go:599`) handles the `ENROLLMENT` notification.
+It unmarshals `device.EnrollmentTokenData` back into `{enroll_secret, idp_uuid}`, re-verifies the enroll
+secret, resolves the team, and creates or updates the host. `addNewHost` (`pubsub.go:893`) is the
+new-device path and maps AMAPI `hardwareInfo.serialNumber` into `host.HardwareSerial` (`pubsub.go:947`),
+which matters for correlating zero-touch device records later. `ENROLLMENT` is among the notification
+types Fleet enables at enterprise creation (`service.go:299`).
 
 ### AMAPI client
 
-`androidmgmt.Client` (`server/mdm/android/service/androidmgmt/client.go`) is an interface with two
-implementations:
+`androidmgmt.Client` (`server/mdm/android/service/androidmgmt/client.go`) has two implementations:
 
-- `ProxyClient` — the default. Routes AMAPI calls through `https://fleetdm.com/api/android/`, using a
-  per-enterprise `FleetServerSecret` as a bearer token. Fleet's hosted proxy owns the Google Cloud
-  project, the service credentials, and the Pub/Sub topic.
-- `GoogleClient` — development only, gated behind `FLEET_DEV_ANDROID_GOOGLE_CLIENT=1` and
-  `FLEET_DEV_ANDROID_GOOGLE_SERVICE_CREDENTIALS`. Talks to Google directly with a service account.
+- `ProxyClient` — the default. Routes AMAPI calls through `https://fleetdm.com/api/android/` using a
+  per-enterprise `FleetServerSecret` bearer token. Fleet's hosted proxy owns the Google Cloud project, the
+  service credentials, and the Pub/Sub topic.
+- `GoogleClient` — development only, selected when `FLEET_DEV_ANDROID_GOOGLE_CLIENT` is `1`/`ON`
+  (`service.go:115`) with credentials in `FLEET_DEV_ANDROID_GOOGLE_SERVICE_CREDENTIALS`. Talks to Google
+  directly with a service account.
 
-This proxy architecture is the most important existing constraint on the design, and is discussed in
-detail below.
+This proxy architecture is the most important existing constraint on the design.
 
 ### Storage
 
 `android_enterprises` holds one row: `enterprise_id`, `signup_name`, `signup_token`, `pubsub_topic_id`,
-`user_id`. Secrets live in `mdm_config_assets` under names defined in `server/fleet/mdm.go` —
-`android_pubsub_token`, `android_fleet_server_secret`. There is no per-team Android enrollment state
-anywhere.
+`user_id`. Secrets live in `mdm_config_assets`, encrypted at rest with the server private key
+(`server/datastore/mysql/apple_mdm.go:6007`), under names in `server/fleet/mdm.go` —
+`android_pubsub_token`, `android_fleet_server_secret`. There is no per-team Android enrollment state.
 
 ## Gap analysis
 
 | Capability | Needed for zero-touch | Fleet today |
 | --- | --- | --- |
-| Long-lived, reusable enrollment token | Yes — the token sits in a configuration for months and is used by many devices | 1 hour, `oneTimeOnly: true` |
+| Long-lived, reusable enrollment token | Yes — one token serves many devices over months | 1 hour, `oneTimeOnly: true` |
 | Stable team identification in the token | Yes — the token outlives enroll secret rotations | Embeds the mutable enroll secret |
 | Zero-touch customer API client | Yes | Does not exist |
 | Credential storage for that API | Yes | Does not exist |
 | Configuration-per-team model | Yes | Does not exist |
-| Reconciliation of Google-side state | Yes — configs drift, admins edit in the portal | Does not exist |
+| Reconciliation of Google-side state | Yes — admins can edit configurations in the portal | Does not exist |
 | Pending/awaiting-enrollment host visibility | Desirable, matches ADE | Does not exist for Android |
 | Per-device configuration override | Yes — how a device lands in a non-default team | Does not exist |
 | Activities / audit trail | Yes | Does not exist |
 | GitOps | Yes, for parity | Does not exist |
-| `PERSONAL_USAGE_DISALLOWED_USERLESS` (dedicated devices) | For COSU | Not exposed |
+| `PERSONAL_USAGE_DISALLOWED_USERLESS` (dedicated) | For COSU | Not exposed |
 | End-user IdP auth during zero-touch provisioning | Depends on requirements | BYOD-cookie-based only; not reachable from zero-touch |
 
 ## Google APIs required
@@ -312,188 +294,164 @@ anywhere.
 ### 1. Android Device Provisioning Partner API — customer surface (new)
 
 - **Service**: `androiddeviceprovisioning.googleapis.com`
-- **Go package**: `google.golang.org/api/androiddeviceprovisioning/v1` — **already present in Fleet's
-  module graph** at `google.golang.org/api v0.269.0` (`go.mod:181`). No new dependency. The generated
-  package exposes `CustomersService`, `CustomersConfigurationsService`, `CustomersDevicesService`, and
-  `CustomersDpcsService`.
-- **OAuth scope**: `https://www.googleapis.com/auth/androidworkzerotouchemm`. Note this is *different*
-  from the reseller scope `https://www.googleapis.com/auth/androidworkprovisioning`. The generated Go
-  package declares no default scopes, so it must be passed explicitly via `option.WithScopes(...)`.
-- **Enablement**: the API must be enabled on the Google Cloud project whose credential is used.
-- **Recommended header**: `X-GOOG-API-FORMAT-VERSION: 2`, which Google requires to get structured error
-  details — specifically `TosError`, needed to detect the terms-of-service case below.
-
-Methods Fleet needs:
+- **Go package**: `google.golang.org/api/androiddeviceprovisioning/v1` — already in Fleet's module graph
+  via `google.golang.org/api v0.269.0` (`go.mod:181`). No new dependency. It exposes `CustomersService`,
+  `CustomersConfigurationsService`, `CustomersDevicesService`, and `CustomersDpcsService`.
+- **OAuth scope**: `https://www.googleapis.com/auth/androidworkzerotouchemm`. This differs from the
+  reseller scope `https://www.googleapis.com/auth/androidworkprovisioning`. The generated package declares
+  no default scopes, so it must be passed explicitly via `option.WithScopes(...)`.
+- **Enablement**: the API must be enabled on the Google Cloud project owning the credential.
+- **Required header for error handling**: `X-GOOG-API-FORMAT-VERSION: 2`, without which Google does not
+  return the structured `TosError` detail described below.
 
 | Method | Use in Fleet |
 | --- | --- |
-| `customers.list` | Discover the customer account(s) the credential can act on. Returns `customers/{id}`. |
+| `customers.list` | Discover the customer accounts the credential can act on. Returns `Company` objects — "the customer accounts the calling user is a member of" — and is paginated. |
 | `customers.dpcs.list` | Find the Android Device Policy resource path for `dpcResourcePath`. Match on the last path component; never hardcode. |
-| `customers.configurations.list` | Reconcile Fleet's known configurations against Google's, detect out-of-band edits and deletions. |
+| `customers.configurations.list` | Diff Fleet's rows against Google's; detect out-of-band edits and deletions. |
 | `customers.configurations.create` | Create a configuration per Fleet team. |
-| `customers.configurations.patch` | Update `dpcExtras` on token rotation, and metadata on team rename. |
-| `customers.configurations.delete` | Remove a configuration when a team is deleted or zero-touch is disabled for it. |
-| `customers.devices.list` | Enumerate claimed devices to build pending-host records. Paginated via `nextPageToken`. |
+| `customers.configurations.patch` | Update `dpcExtras` on token rotation, metadata on team rename. |
+| `customers.configurations.delete` | Remove a configuration when a team is deleted or opts out. |
+| `customers.devices.list` | Enumerate claimed devices for pending-host records. Paginated via `nextPageToken`. |
 | `customers.devices.get` | Refresh a single device. |
-| `customers.devices:applyConfiguration` | Assign a specific device to a specific team's configuration. |
-| `customers.devices:removeConfiguration` | Unassign, falling back to the default configuration. |
-| `customers.devices:unclaim` | Destructive; expose only behind an explicit confirmation, if at all. |
+| `customers.devices:applyConfiguration` | Assign a device to a specific team's configuration. Destructive — see above. |
+| `customers.devices:removeConfiguration` | Remove a device's configuration. |
+| `customers.devices:unclaim` | Destructive and reseller-only to reverse; expose behind explicit confirmation, if at all. |
 
-Not needed: the entire `partners.*` reseller surface. Fleet is not a reseller and should not attempt to
-become one — device claiming is a supply-chain function.
+Not needed: the `partners.*` reseller surface. Device claiming is a supply-chain function and Fleet should
+not attempt to become a reseller.
 
-**Terms of service handling**: calls return `403 Forbidden` with a `TosError` body until the acting user
-has accepted the current zero-touch terms. Fleet must detect this specific case and surface an actionable
-message linking to `https://enterprise.google.com/android/zero-touch/customers`, rather than a generic
-403. Google can update the terms at any time, so this is not a one-time setup error — it can appear
-mid-life on a working integration and must be handled in the cron, not only during setup.
+**Terms of service**: calls return `403 Forbidden` with a `TosError` body until the acting user has
+accepted the current zero-touch terms. Fleet must detect this case specifically and link to
+`https://enterprise.google.com/android/zero-touch/customers`. Google can update terms at any time, so this
+is not a setup-only error — it can appear on a working integration and must be handled in the cron.
 
 ### 2. Android Management API (existing, extended)
 
-No new API, but new usage of it:
+New usage of an API Fleet already calls:
 
 - `enterprises.enrollmentTokens.create` with:
-  - `duration` set explicitly. The field accepts 1 minute up to roughly 10,000 years; default is 1 hour.
-    If the requested duration would overflow the maximum timestamp, Google coerces it.
-  - `oneTimeOnly: false`, so many devices can enroll with the same token.
-  - `allowPersonalUsage` set per management mode (`PERSONAL_USAGE_DISALLOWED`, `PERSONAL_USAGE_ALLOWED`,
-    or `PERSONAL_USAGE_DISALLOWED_USERLESS`).
-  - `additionalData` — max 1024 characters, surfaced on the device as `enrollmentTokenData`. This is
-    Fleet's only channel for carrying team intent through provisioning, and the 1024-character ceiling is
-    a real design constraint.
-  - `policyName` — Fleet already points this at `{enterprise}/policies/1`.
-- `enterprises.enrollmentTokens.delete` — needed to revoke a leaked or superseded zero-touch token.
-- `enterprises.enrollmentTokens.list` — lists active, unexpired tokens; useful for drift detection and
-  cleanup.
-- `EnrollmentToken.user` is deprecated and ignored; do not use it.
+  - `duration` set explicitly. Accepts 1 minute to roughly 10,000 years; default 1 hour. A duration that
+    would overflow the maximum timestamp is coerced.
+  - `oneTimeOnly: false`, so many devices can use one token.
+  - `allowPersonalUsage` per management mode.
+  - `additionalData` — max 1024 characters, surfaced on the device as `enrollmentTokenData`. Fleet's only
+    channel for carrying team intent through provisioning; the ceiling is a real constraint.
+  - `policyName` — Fleet already points this at `{enterprise}/policies/1`
+    (`android.DefaultAndroidPolicyID`).
+- `enterprises.enrollmentTokens.delete` — revoke a leaked or superseded token.
+- `enterprises.enrollmentTokens.list` — lists active, unexpired tokens; useful for drift detection.
+- `EnrollmentToken.user` is deprecated and ignored. Do not use it.
 
 ### 3. Google Cloud Pub/Sub (existing)
 
-Unchanged. Zero-touch devices produce the same `ENROLLMENT` notification as QR-code devices. This is
-precisely why the feature is tractable.
+Unchanged. Zero-touch devices produce the same `ENROLLMENT` notification as QR-code devices.
 
-### 4. Optionally: AMAPI `signinDetail` (only if end-user IdP auth is required on zero-touch)
+### 4. Optional: AMAPI `signinDetail`, only if end-user IdP auth is required
 
-Zero-touch hands the device a plain enrollment token with no user interaction, so a Fleet-mediated IdP
-login cannot happen the way it does for BYOD (which relies on a browser cookie set before the enrollment
-token is requested — `mdm.BYODIdpCookieName`, `service.go:508`).
+Zero-touch hands the device a plain enrollment token with no user interaction, so Fleet's BYOD IdP flow
+cannot apply — it depends on a browser cookie set before the token is requested (`mdm.BYODIdpCookieName`,
+`service.go:508`).
 
-If end-user authentication during zero-touch provisioning is a requirement, the mechanism is AMAPI's
-sign-in URL enrollment. An enterprise can have any number of `SigninDetail` entries, uniquely keyed by
-(`signinUrl`, `allowPersonalUsage`, `tokenTag`). Each yields a server-generated, read-only
-`signinEnrollmentToken`. Placing that token in `dpcExtras` instead of a normal enrollment token causes
-the device to open `signinUrl` during provisioning; Fleet's page runs the IdP flow and must finish by
-redirecting to `https://enterprise.google.com/android/enroll?et=<token>` on success or
+AMAPI's sign-in URL enrollment is the mechanism for authenticating a user during provisioning. An
+enterprise can hold any number of `SigninDetail` entries, keyed by (`signinUrl`, `allowPersonalUsage`,
+`tokenTag`), each yielding a server-generated read-only `signinEnrollmentToken`. The sign-in endpoint must
+finish by redirecting to `https://enterprise.google.com/android/enroll?et=<token>` on success or
 `https://enterprise.google.com/android/enroll/invalid` on failure.
 
-This is a substantial sub-project — it means Fleet serves an unauthenticated, device-facing web flow that
-mints enrollment tokens. **Recommendation: exclude it from the initial scope.** Company-owned zero-touch
-devices are typically assigned to a person out-of-band, and the AMAPI `provisioningInfo` /
-`authenticatedUserEmail` mechanism plus Fleet's existing per-team assignment covers most needs. Revisit
-only if customers ask for user-attributed zero-touch specifically.
+**Whether a `signinEnrollmentToken` can be placed in `dpcExtras` to drive this from zero-touch is not
+documented and must be tested.** Google's provisioning-method matrix treats zero-touch and sign-in URL as
+separate methods and does not describe combining them.
+
+Either way this is a substantial sub-project: Fleet would serve an unauthenticated, device-facing web flow
+that mints enrollment tokens. **Recommendation: exclude from initial scope.** Company-owned devices are
+typically assigned to a person out of band. Revisit only if customers ask for user-attributed zero-touch.
 
 ## Credential and authorization options
 
-This is the decision that gates everything else, and it deserves an explicit decision before
-implementation starts.
+This decision gates Phase 2 and should be settled before implementation starts.
 
 ### Option A — Service account key uploaded by the admin (recommended)
 
-The admin creates a Google Cloud project, enables the Android Device Provisioning Partner API, creates a
-service account, downloads its JSON key, and uploads that key to Fleet. Fleet uses two-legged OAuth with
-scope `androidworkzerotouchemm`.
+The admin creates a Google Cloud project, enables the API, creates a service account, downloads its JSON
+key, and uploads it to Fleet. Fleet uses two-legged OAuth with the `androidworkzerotouchemm` scope.
 
-- **Pros**: no refresh-token lifecycle, no consent UI, no dependency on an individual admin's Google
-  account, and Google explicitly recommends service accounts for "continuously-running automated
-  services" — which is exactly what Fleet's reconciliation cron is. It also mirrors Fleet's existing ABM
-  token UX almost exactly: do work in the vendor portal, download a credential, upload it to Fleet.
-- **Cons**: the service account must be linked to the zero-touch customer account, and per Google's
-  current documentation that linking is **a Google Form submission followed by an email confirmation**,
-  not a self-service portal action. That is human latency of unknown duration on the customer's critical
-  path, and it is opaque to Fleet.
-- **Verify before committing**: whether a self-service linking path now exists in the customer portal
-  (the reseller portal does have a "Service accounts → Link service account" screen; the customer portal
-  may have gained parity), and whether there is a per-organization limit on linked service accounts.
+- **Pros**: no refresh-token lifecycle, no consent UI, no dependency on one person's Google account.
+  Google recommends service accounts for continuously-running automated services, which is what the
+  reconciliation cron is. Mirrors Fleet's ABM token UX: do work in the vendor portal, download a
+  credential, upload it.
+- **Cons**: the service account must be linked to the customer account, and per Google's current
+  documentation that linking is a **Google Form submission followed by email confirmation**, not a portal
+  action. That is human latency of unknown duration on the customer's critical path, opaque to Fleet.
+- **Verify first**: whether the customer portal has since gained a self-service linking screen (the
+  reseller portal has one), and whether there is a limit on linked service accounts per organization.
 
-### Option B — Interactive OAuth (three-legged) by the admin
+### Option B — Interactive OAuth (three-legged)
 
-Fleet registers an OAuth client, the admin consents with the Google account their reseller established in
-the zero-touch account, and Fleet stores the refresh token. This is what Google's EMM integration guide
-describes as the standard EMM console pattern.
+Fleet registers an OAuth client; the admin consents with the Google account their reseller established in
+the zero-touch account; Fleet stores the refresh token. This is the pattern Google's EMM integration guide
+describes.
 
-- **Pros**: fully self-service, no Google Form, works the moment the admin clicks through consent.
-  Architecturally consistent with Fleet's existing AMAPI signup, which already round-trips through
-  `fleetdm.com` with a callback URL.
-- **Cons**: the grant is bound to one human's Google account, so it breaks when that person's access is
-  removed — a recurring support burden. `androidworkzerotouchemm` is likely to be treated as a sensitive
-  scope requiring Google app verification, which is a schedule risk. Refresh tokens can be revoked
-  server-side without notice, so Fleet needs re-consent detection and prompting. Self-hosted Fleet needs
-  either its own OAuth client (admin burden) or a proxy-mediated redirect URI.
+- **Pros**: self-service, no Google Form, works immediately after consent. Consistent with Fleet's AMAPI
+  signup, which already round-trips through `fleetdm.com` with a callback URL.
+- **Cons**: the grant is bound to one person's Google account and breaks when their access is removed — a
+  recurring support burden. `androidworkzerotouchemm` is likely a sensitive scope requiring Google app
+  verification, a schedule risk. Refresh tokens can be revoked without notice, so Fleet needs re-consent
+  detection. Self-hosted Fleet needs its own OAuth client or a proxy-mediated redirect URI.
 
-### Option C — No API at all: Fleet emits the DPC extras, admin pastes them
+### Option C — No API: Fleet emits the DPC extras, admin pastes them
 
-Fleet generates a long-lived reusable enrollment token per team and displays the complete `dpcExtras`
-JSON with a copy button plus step-by-step portal instructions. The admin creates the configuration by
-hand in Google's portal.
+Fleet generates a long-lived reusable token per team and displays the complete `dpcExtras` JSON with a
+copy button and portal instructions. The admin creates the configuration by hand.
 
-- **Pros**: zero Google API integration, zero credential storage, zero authorization risk. Works today
-  for every customer including self-hosted and air-gapped-adjacent deployments. Small enough to ship in
-  one release.
-- **Cons**: not "zero-touch admin" — the admin does per-team manual portal work. No pending-host
-  visibility, no per-device team override, no drift detection.
+- **Pros**: no API integration, no credential storage, no authorization risk. Works for every customer
+  including self-hosted. Ships in one release.
+- **Cons**: per-team manual portal work. No pending-host visibility, no per-device team override, no drift
+  detection.
 
 ### Recommendation
 
-Ship **Option C as Phase 1**, then **Option A as Phase 2** with **Option B as an alternate path** for
-customers blocked on service-account linking. Option C is not a throwaway: it forces Fleet to get the
-long-lived token model, the team-mapping fix, and the extras generation right, all of which Phase 2
-reuses verbatim. It also means the credential decision does not block customer value.
+Ship **C as Phase 1**, then **A as Phase 2**, keeping **B** as an alternate for customers blocked on
+service-account linking. C is not throwaway — it forces the long-lived token model, the team-mapping fix,
+and extras generation, all reused verbatim by Phase 2, and it decouples customer value from the credential
+decision.
 
 ### The Fleet Cloud proxy question
 
 Fleet's AMAPI traffic defaults through `https://fleetdm.com/api/android/`, with Fleet's hosted project
-owning the Google credentials. The zero-touch customer API **cannot** follow that model in the same way,
-and this needs to be explicit:
+owning the credentials. Zero-touch cannot follow that model:
 
-- The zero-touch customer account belongs to the customer, established by *their* reseller. Fleet's
-  hosted service account has no relationship to it and cannot be granted one without the customer
-  linking it.
-- If Fleet linked one shared service account to many customer accounts, `customers.list` would return
-  every linked customer to every caller. Fleet would then be responsible for enforcing tenant isolation
-  in the proxy, on a credential with no per-tenant scoping. **This is a multi-tenancy hazard and should
-  be rejected.**
+- The customer's zero-touch account was established by *their* reseller. Fleet's hosted service account
+  has no relationship to it and cannot gain one without the customer linking it.
+- A single shared service account linked to many customer accounts would make `customers.list` return
+  every linked customer to every caller, putting Fleet's proxy in charge of tenant isolation on a
+  credential with no per-tenant scoping. **Reject this.**
 
-Therefore: zero-touch credentials are **per-Fleet-instance and customer-supplied**, and zero-touch API
-calls go **direct to Google**, not through the proxy — regardless of how AMAPI traffic is routed. This is
-a deliberate architectural divergence from the rest of Android MDM and should be documented as such,
-because it will surprise people reading the code.
+Therefore zero-touch credentials are **per-Fleet-instance and customer-supplied**, and zero-touch calls go
+**direct to Google**, regardless of how AMAPI traffic is routed. This diverges deliberately from the rest
+of Android MDM and should be documented in the code, because it will surprise readers.
 
 ## Design
 
 ### Configuration per team
 
-Fleet teams are the natural unit. Each Fleet team that opts into zero-touch gets:
+Each Fleet team that opts into zero-touch gets one long-lived enrollment token carrying that team's
+identity in `additionalData` and its management mode in `allowPersonalUsage`, plus one Configuration whose
+`dpcExtras` embeds that token and whose `configurationName` derives from the team name.
 
-- One long-lived AMAPI enrollment token, carrying that team's identity in `additionalData` and the
-  team's chosen management mode in `allowPersonalUsage`.
-- One zero-touch Configuration whose `dpcExtras` embeds that token and whose `configurationName` is
-  derived from the team name.
+Google permits one default configuration per customer account, so Fleet exposes a single **default team
+for zero-touch**. That team's configuration carries `isDefault: true` and receives all newly purchased
+devices; other teams' devices are placed with `customers.devices:applyConfiguration`. Changing the default
+patches two configurations, and Fleet must read back Google's state rather than assume its own view is
+authoritative, because setting a new default silently flips the old one to `false`.
 
-Because Google permits exactly one default configuration per customer account, Fleet exposes a single
-**"default team for zero-touch"** setting. That team's configuration carries `isDefault: true`; all newly
-purchased devices land in it. Any other team's devices are placed via
-`customers.devices:applyConfiguration`. Changing the default team means patching two configurations, and
-Fleet must handle Google's implicit clearing of the previous default rather than assuming its own view is
-authoritative.
-
-A distinct configuration is needed per (team, management mode) pair, since `allowPersonalUsage` is fixed
-at token creation. Keeping mode as a per-team setting rather than a per-configuration one keeps the model
-comprehensible; teams that need both fully managed and dedicated devices should be separate teams.
+`allowPersonalUsage` is fixed at token creation, so a configuration is per (team, management mode). Keep
+mode a per-team setting; teams needing both fully managed and dedicated devices should be separate teams.
 
 ### Fixing team identification: the critical prerequisite
 
-Today `additionalData` carries `{"enroll_secret": "...", "idp_uuid": "..."}` and `addNewHost`
-(`pubsub.go:908`) hard-fails when `VerifyEnrollSecret` does not match:
+`additionalData` carries `{"enroll_secret": "...", "idp_uuid": "..."}`, and `addNewHost` (`pubsub.go:908`)
+hard-fails when the secret does not verify:
 
 ```go
 enrollSecret, err := svc.ds.VerifyEnrollSecret(ctx, enrollmentTokenRequest.EnrollSecret)
@@ -502,157 +460,136 @@ if err != nil {
 }
 ```
 
-For a one-hour token this is fine. For a token embedded in a zero-touch configuration for a year, it is a
-latent outage: **the moment an admin rotates that team's enroll secret, every subsequent zero-touch
-device enrolls successfully into AMAPI and then fails to become a Fleet host.** The device is managed by
-Google, invisible in Fleet, and the failure surfaces only as a repeating Pub/Sub error. This is
-exactly the kind of silent, delayed breakage that is worst to debug in the field.
+Fine for a one-hour token. For a token embedded in a configuration for a year it is a latent outage: **once
+an admin rotates that team's enroll secret, every subsequent zero-touch device enrolls into AMAPI and then
+fails to become a Fleet host** — managed by Google, invisible in Fleet, visible only as a repeating
+Pub/Sub error.
 
-Two viable fixes:
+Two fixes, both needed:
 
-1. **Carry a stable team reference.** Extend the `additionalData` payload with a version tag and a
-   durable identifier, for example
-   `{"v":2,"zt":true,"team_id":3,"enroll_secret":"..."}`, and in `enrollHost`/`addNewHost` prefer
-   `team_id` when `zt` is set, treating an enroll-secret mismatch as non-fatal in that case. A team UUID
-   would be preferable to a numeric ID for stability across restores, if one is available. Note the 1024
-   character `additionalData` limit — it is generous here but must be validated, not assumed.
-2. **Re-issue on rotation.** Hook enroll-secret changes and patch every affected zero-touch
-   configuration with a freshly minted token.
+1. **Carry a stable team reference.** Version the `additionalData` payload and add a durable identifier,
+   for example `{"v":2,"zt":true,"team_id":3,"enroll_secret":"..."}`. In `enrollHost`/`addNewHost`, prefer
+   `team_id` when `zt` is set and treat a secret mismatch as non-fatal in that case. A team UUID would be
+   more stable than a numeric ID across restores, if one exists. Validate the payload against the
+   1024-character limit rather than assuming headroom.
+2. **Re-issue on rotation.** Hook enroll-secret changes and patch every affected configuration with a
+   fresh token.
 
-**Do both.** Fix 1 makes the system correct under drift; fix 2 keeps the stored token consistent with
-Fleet's state. Fix 1 alone leaves a stale secret in Google's configuration; fix 2 alone leaves a window
-where in-flight provisioning breaks, and fails entirely if the patch call errors.
+Fix 1 alone leaves a stale secret in Google's configuration. Fix 2 alone leaves a window where in-flight
+provisioning breaks, and fails outright if the patch call errors.
 
-Whichever payload shape is chosen, it must be versioned, because tokens already in the wild will carry
-the v1 shape and must keep working. `getAndroidHostKey` / `GetAndroidDeviceLastTeamID` already override
-the token's team for previously-known devices (`pubsub.go:916`), and that precedence must be preserved:
-last-known team still wins over the zero-touch token's team, so a factory-reset device returns to where
-the admin put it.
+The payload must be versioned because v1 tokens already exist in the wild. Preserve the existing
+precedence in `pubsub.go:916`, where `GetAndroidDeviceLastTeamID` overrides the token's team for
+previously-known devices, so a factory-reset device returns to the team an admin moved it to.
 
 ### Token lifetime and rotation
 
-Fleet should create zero-touch tokens with an explicit long duration and rotate on demand rather than on
-a short clock. Rationale: a mid-provisioning token swap is the highest-risk moment in the whole flow, and
-frequent rotation multiplies exposure to that risk for little security benefit — the token's only power
-is to enroll a device into the enterprise, and it lives in a store readable only by zero-touch portal
-admins.
+Create tokens with a long explicit duration and rotate on demand rather than on a short clock. A
+mid-provisioning token swap is the riskiest moment in the flow, and frequent rotation multiplies that risk
+for little gain: the token's only power is enrolling a device into the enterprise, and it sits in a store
+readable only by zero-touch portal admins.
 
-Concretely:
-
-- Create with `duration` of roughly one year and `oneTimeOnly: false`.
-- Store `expires_at` and have the reconciliation cron rotate when within, say, 30 days of expiry.
-- On rotation: mint the new token, patch `dpcExtras`, confirm the patch succeeded, and only then delete
-  the old token — never the reverse. Keep a grace period before deletion so devices that already
-  fetched the old configuration can still complete.
-- Expose an explicit admin "rotate zero-touch token" action for the leak case, which deletes the old
-  token immediately and accepts the in-flight breakage.
+- Create with `duration` around one year and `oneTimeOnly: false`.
+- Store `expires_at`; have the cron rotate within roughly 30 days of expiry.
+- On rotation, mint the new token, patch `dpcExtras`, confirm the patch succeeded, and only then delete the
+  old token — never the reverse. Keep a grace period so devices that already fetched the old configuration
+  can finish.
+- Provide an explicit "rotate now" action for the leak case, which deletes the old token immediately and
+  accepts in-flight breakage.
 
 ### Pending hosts
 
-`customers.devices.list` returns hardware identifiers before any device has ever booted, and AMAPI
-reports `hardwareInfo.serialNumber` at enrollment, which Fleet already stores as `HardwareSerial`
-(`pubsub.go:947`). That makes correlation possible and enables an Android analogue of Apple's
-`host_dep_assignments` "awaiting enrollment" experience: admins see the devices they bought, in the team
-they will land in, before anyone opens a box.
+`customers.devices.list` returns hardware identifiers before a device has ever booted, and AMAPI reports
+`hardwareInfo.serialNumber` at enrollment, which Fleet stores as `HardwareSerial` (`pubsub.go:947`). That
+enables an Android analogue of Apple's `host_dep_assignments` "awaiting enrollment" view.
 
-Caveats to design around:
+Caveats:
 
 - Serial number is the practical join key, but some devices report IMEI/MEID only, and dual-SIM devices
-  have `imei2`/`meid2`. The correlation must try serial first, then IMEI/MEID, and tolerate no match.
-- AMAPI's `hardwareInfo.serialNumber` is documented as unavailable for personally-owned devices; for
-  company-owned zero-touch devices it should be present, but the code must not assume it.
-- Formatting differences (case, leading zeros, whitespace) are a realistic source of missed matches;
-  normalize on both sides. `fleet.Preprocess` exists for this class of problem.
-- Getting this wrong creates duplicate host records, which is worse than having no pending hosts at all.
-  If correlation confidence is low, ship Phase 2 without pending hosts and add them once real device data
-  is available.
+  have `imei2`/`meid2`. Try serial, then IMEI/MEID, and tolerate no match.
+- AMAPI documents that on personally-owned devices running Android 12+, `serialNumber` is the same value as
+  `enterpriseSpecificId` rather than a real serial. Company-owned zero-touch devices should report a true
+  serial, but the code must not assume the field is meaningful.
+- Normalize case, leading zeros, and whitespace on both sides; `fleet.Preprocess`
+  (`server/fleet/utils.go:65`) exists for this.
+- A wrong match creates duplicate host records, which is worse than no pending hosts. If confidence is
+  low, ship without pending hosts and add them once real device data exists.
 
 ### Ownership, portability, and offboarding
 
-Two separate registrations exist, owned by different parties, and conflating them leads to wrong
-conclusions about lock-in.
+Two registrations exist, owned by different parties. Conflating them produces wrong conclusions about
+lock-in.
 
-**The zero-touch device claim belongs to the customer.** It lives in *their* zero-touch customer account
-(`customers/{CUSTOMER_ID}`), created by *their* reseller against *their* organization. Fleet is not a
-party to the claim and does not appear in it. Fleet's service account or OAuth grant is merely a
-delegated caller that the customer can revoke at any time without affecting the claim.
+**The zero-touch claim belongs to the customer.** It lives in their customer account, created by their
+reseller against their organization. Fleet is not a party to it. Fleet's credential is a delegated caller
+the customer can revoke at any time without affecting the claim.
 
 **The AMAPI enterprise is bound to Fleet.** `EnterprisesCreate` passes `ProjectId(g.androidProjectID)`
-(`androidmgmt/google_client.go:92`), so the enterprise is created under a Google Cloud project — and in
-the default proxy deployment, that project is Fleet's, not the customer's. This produces an *EMM-managed*
-enterprise, which cannot be transferred to another EMM's project. Note the asymmetry: a deployment using
-`GoogleClient` with the customer's own credentials would create the enterprise under the customer's
-project instead. That path is currently development-only, but it is the lever if enterprise ownership ever
-becomes a customer requirement.
+(`androidmgmt/google_client.go:92`), so the enterprise belongs to a Google Cloud project — Fleet's, in the
+default proxy deployment. That makes it an *EMM-managed* enterprise, which cannot be transferred to
+another EMM's project. A deployment using `GoogleClient` with the customer's own credentials would create
+it under the customer's project instead; that path is development-only today, but it is the lever if
+enterprise ownership becomes a customer requirement.
 
-**The only coupling between the two systems is the enrollment token string inside `dpcExtras`.** That is a
-mutable field in a record the customer owns. This loose coupling is the important architectural property,
-and it is worth preserving deliberately rather than by accident.
+**The only coupling between the two systems is the enrollment token string in `dpcExtras`** — a mutable
+field in a record the customer owns.
 
-Consequences for migrating away from Fleet:
+Migrating away from Fleet:
 
-- **The zero-touch side migrates cleanly.** The customer's portal admins replace the token in `dpcExtras`
-  with the incoming EMM's, or point the device at a new configuration. Devices stay claimed, no reseller
-  involvement, no re-registration. Critically, they can do this **without Fleet's cooperation** — even if
-  the Fleet instance is decommissioned or the contract has lapsed. Fleet holds no hostage here, and that
-  should be stated plainly in customer-facing material rather than left ambiguous.
+- **The zero-touch side migrates cleanly.** Portal admins replace the token in `dpcExtras` with the
+  incoming EMM's, or point devices at a new configuration. Devices stay claimed; no reseller involvement.
+  They can do this **without Fleet's cooperation**, even if the instance is gone. Worth stating plainly in
+  customer-facing material.
 - **The AMAPI side requires a factory reset per device.** Device Owner cannot be transferred over the air
-  between EMM enterprises. AMAPI's DPC migration facility is custom-DPC-to-Android-Device-Policy *within
-  one enterprise*, not cross-EMM. This is a universal Android Enterprise constraint, not a Fleet
-  limitation, and applies identically in the inbound direction for customers migrating *to* Fleet.
-- **Zero-touch makes migration easier, not harder.** The standard playbook is: repoint the configuration
-  at the new EMM, then factory reset in batches; each device self-provisions into the new EMM with no
-  hands-on step. Zero-touch is the migration mechanism.
+  between EMM enterprises. AMAPI's DPC migration facility covers custom-DPC-to-Android-Device-Policy
+  *within one enterprise*, not cross-EMM. This is a universal Android Enterprise constraint and applies
+  identically to customers migrating *to* Fleet.
+- **Zero-touch makes migration easier.** Repoint the configuration, then factory reset in batches; each
+  device self-provisions into the new EMM with no hands-on step.
 
-**Offboarding hazard — ordering matters, and the current turn-off flow is unsafe.** `enterprises.delete`
-performs "a cascaded deletion of all AM API devices associated with the deleted enterprise," and
-`Service.DeleteEnterprise` (`service.go:424`, calling `EnterpriseDelete` at `service.go:442`) is what runs
-when an admin turns off Android MDM. If zero-touch configurations exist, deleting the enterprise
-invalidates the enrollment token still embedded in them. Every subsequent factory reset then hits a
-configuration whose token is dead, and the device cannot complete provisioning — ending in the forced
-reset behavior described earlier. In other words, **turning off Android MDM in Fleet silently breaks
-provisioning for every zero-touch-claimed device, with the damage surfacing only on each device's next
-reset.**
+**Offboarding hazard: the current turn-off flow is unsafe.** `enterprises.delete` performs "a cascaded
+deletion of all AM API devices associated with the deleted enterprise" and is only available for
+EMM-managed enterprises. `Service.DeleteEnterprise` (`service.go:424`, calling `EnterpriseDelete` at
+`service.go:442`) runs when an admin turns off Android MDM. If zero-touch configurations exist, deleting
+the enterprise invalidates the token still embedded in them, so every subsequent factory reset hits a dead
+token and cannot complete provisioning. **Turning off Android MDM therefore breaks provisioning for every
+zero-touch-claimed device, with damage surfacing only at each device's next reset.**
 
-Required mitigations:
+Mitigations:
 
-- Turning off Android MDM must detect existing zero-touch configurations and block or hard-warn, listing
-  the affected teams and device count. This should be treated as a release blocker for Phase 2, not a
-  polish item.
-- Offer a "prepare for migration" action that deletes Fleet's configurations from the customer account
-  (leaving claims intact) before enterprise deletion, so devices boot unmanaged rather than looping.
-- Document the correct offboarding order: repoint or delete zero-touch configurations → reset devices →
-  then delete the enterprise in Fleet.
-- Verify the on-device end state after a cascaded enterprise deletion — whether devices become unmanaged,
-  remain orphaned but provisioned, or require a reset. This is not documented clearly by Google and needs
-  hands-on testing before the offboarding guidance can be considered correct.
+- Turn-off must detect existing zero-touch configurations and block or hard-warn, listing affected teams
+  and device counts. Treat as a Phase 2 release blocker.
+- Provide a "prepare for migration" action that deletes Fleet's configurations (leaving claims intact)
+  before enterprise deletion, so devices boot unmanaged instead of looping.
+- Document the order: repoint or delete configurations → reset devices → delete the enterprise.
+- Verify on hardware what state devices land in after a cascaded enterprise deletion. Google does not
+  document this clearly, and the offboarding guidance is not trustworthy until someone checks.
 
 ### Reconciliation cron
 
-A new cron, following `newAndroidMDMDeviceReconcilerSchedule` (`cmd/fleet/cron.go:2513`) as the pattern
-and registered in `cmd/fleet/cron_registration.go`:
+Following `newAndroidMDMDeviceReconcilerSchedule` (`cmd/fleet/cron.go:2515`) and registered in
+`cmd/fleet/cron_registration.go`:
 
-1. Verify the credential still works; mark the integration invalid and stop if not.
+1. Verify the credential; mark the integration invalid and stop if it fails.
 2. `customers.list` — confirm the expected customer account is still reachable.
 3. `customers.dpcs.list` — refresh the Android Device Policy resource path.
 4. `customers.configurations.list` — diff against Fleet's rows. Recreate configurations deleted out of
-   band; re-patch drifted `dpcExtras`; reconcile which configuration Google considers default.
+   band, re-patch drifted `dpcExtras`, reconcile which configuration Google considers default.
 5. Rotate tokens approaching expiry.
-6. `customers.devices.list` (paginated) — upsert pending device records, reconcile per-device
-   configuration assignments against team intent.
+6. `customers.devices.list` (paginated) — upsert pending device records, reconcile per-device assignments
+   against team intent.
 7. Detect and surface `TosError`.
 
-Reasonable interval: 30 minutes, tunable. It must be bounded and paginated — the existing Android device
-reconciler had to have its pagination loop bounded (commit `8a65ecf20bf`), and the same failure mode
-applies here. Google's per-project quotas for the provisioning API are undocumented in the pages
-reviewed and should be confirmed before choosing an interval for large fleets.
+Suggested interval 30 minutes, tunable. It must be bounded and paginated: the existing Android device
+reconciler needed its pagination loop bounded (commit `8a65ecf20bf`) and the same failure mode applies.
+Google's per-project quotas for this API are not stated in the documentation reviewed and should be
+confirmed before choosing an interval for large fleets.
 
 ## Fleet modifications
 
 ### New package
 
-`server/mdm/android/zerotouch/` (or `server/mdm/android/service/androidprov/`, mirroring `androidmgmt/`)
-containing an interface-first client so it can be mocked, exactly as `androidmgmt.Client` is:
+`server/mdm/android/zerotouch/`, interface-first so it can be mocked, as `androidmgmt.Client` is:
 
 ```go
 // Client is used to interact with the zero-touch enrollment customer API.
@@ -672,17 +609,15 @@ type Client interface {
 }
 ```
 
-Plus a `mock/` package generated in the same style as `server/mdm/android/mock/client.go`, and an
-`IsTermsOfServiceError(err error) bool` helper alongside the existing `IsNotModifiedError` /
-`IsBadRequestError` in `androidmgmt/client.go`.
+Plus a `mock/` package in the style of `server/mdm/android/mock/client.go`, and an
+`IsTermsOfServiceError(err error) bool` helper in this new package, mirroring how `IsNotModifiedError` and
+`IsBadRequestError` sit beside the client interface in `androidmgmt/client.go`.
 
-The `arch_test.go` in `server/mdm/android/` enforces the bounded-context import rules; new code must
-satisfy it.
+`server/mdm/android/arch_test.go` enforces the bounded-context import rules; new code must satisfy it.
 
 ### Database
 
-One new table plus a couple of columns. Timestamps at `TIMESTAMP(6)` precision and binary UUIDs per
-Fleet's MySQL conventions.
+Two new tables. Timestamps at `TIMESTAMP(6)` precision per Fleet's MySQL conventions.
 
 ```sql
 CREATE TABLE `android_zero_touch_configurations` (
@@ -700,7 +635,7 @@ CREATE TABLE `android_zero_touch_configurations` (
   `contact_email` VARCHAR(255) NOT NULL DEFAULT '',
   `contact_phone` VARCHAR(64) NOT NULL DEFAULT '',
   `custom_message` TEXT,
-  -- Token state (token value itself lives in mdm_config_assets, not here)
+  -- Token state (the token value itself lives in mdm_config_assets)
   `enrollment_token_name` VARCHAR(255) NOT NULL DEFAULT '',
   `enrollment_token_expires_at` TIMESTAMP(6) NULL DEFAULT NULL,
   `last_synced_at` TIMESTAMP(6) NULL DEFAULT NULL,
@@ -714,11 +649,11 @@ CREATE TABLE `android_zero_touch_configurations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 ```
 
-The `global_or_team_id` / `team_id` pair with a `UNIQUE KEY` on the former follows
-`android_app_configurations` and gives correct "No team" handling — worth stating explicitly, since "No
-team" is a routine source of bugs in team-scoped features.
-
-For pending hosts, either a second table or reuse of the host pattern:
+The nullable `team_id` plus non-null `global_or_team_id` pattern is borrowed from
+`android_app_configurations`, which uses it to give "No team" a real value (`0`) in a unique key. Note the
+difference: that table's unique key is composite, `(global_or_team_id, application_id)`, because a team has
+many app configurations. Here a team has exactly one zero-touch configuration, so the unique key is on
+`global_or_team_id` alone.
 
 ```sql
 CREATE TABLE `android_zero_touch_devices` (
@@ -741,75 +676,69 @@ CREATE TABLE `android_zero_touch_devices` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 ```
 
-Use `make migration name=AddAndroidZeroTouchConfigurations`. If this lands alongside other work, the
-migration timestamp will likely need bumping before merge.
+Create with `make migration name=AddAndroidZeroTouchConfigurations`. If this lands alongside other work
+the migration timestamp will likely need bumping before merge.
 
 ### Secrets
 
-New `MDMAssetName` values in `server/fleet/mdm.go`, stored encrypted in `mdm_config_assets`:
+New `MDMAssetName` values in `server/fleet/mdm.go`, encrypted in `mdm_config_assets`:
 
-- `android_zero_touch_service_account` — the uploaded service-account JSON key (Option A).
+- `android_zero_touch_service_account` — uploaded service-account JSON key (Option A).
 - `android_zero_touch_oauth_refresh_token` — refresh token (Option B).
-- `android_zero_touch_enrollment_token` — the current long-lived token value per configuration. Storing
-  it as an asset rather than a table column keeps it out of ordinary query paths and gets encryption for
-  free. Since assets are keyed by name, this needs either a name-per-team scheme or an asset table
-  variant that supports scoping — worth checking `mdm_config_assets` for existing per-entity precedent
-  (the VPP and ABM token tables solved this differently) before choosing.
+- `android_zero_touch_enrollment_token` — the current long-lived token per configuration. Storing it as an
+  asset keeps it out of ordinary query paths and gets encryption for free, but assets are keyed by name
+  alone, so a per-team scheme is needed. Check how the ABM and VPP token tables solved per-entity secret
+  storage before choosing.
 
 ### Service layer and API
 
-New endpoints, registered in `server/mdm/android/service/handler.go` following the existing pattern, with
-request/response structs and `Err error` fields per Fleet's API conventions:
+New endpoints in `server/mdm/android/service/handler.go`, with request/response structs carrying
+`Err error` per Fleet's API conventions:
 
 | Method | Path | Purpose |
 | --- | --- | --- |
-| `GET` | `/api/_version_/fleet/android_enterprise/zero_touch` | Integration status: linked customer, credential validity, ToS state, last sync, errors |
-| `POST` | `/api/_version_/fleet/android_enterprise/zero_touch/credentials` | Upload service-account key (or begin OAuth) |
+| `GET` | `/api/_version_/fleet/android_enterprise/zero_touch` | Status: linked customer, credential validity, ToS state, last sync, errors |
+| `POST` | `/api/_version_/fleet/android_enterprise/zero_touch/credentials` | Upload service-account key, or begin OAuth |
 | `DELETE` | `/api/_version_/fleet/android_enterprise/zero_touch/credentials` | Disconnect |
 | `GET` | `/api/_version_/fleet/android_enterprise/zero_touch/configurations` | List Fleet's configurations |
 | `PUT` | `/api/_version_/fleet/android_enterprise/zero_touch/configurations/:team_id` | Create or update a team's configuration |
 | `DELETE` | `/api/_version_/fleet/android_enterprise/zero_touch/configurations/:team_id` | Remove |
 | `POST` | `/api/_version_/fleet/android_enterprise/zero_touch/configurations/:team_id/rotate_token` | Force rotation |
-| `GET` | `/api/_version_/fleet/android_enterprise/zero_touch/dpc_extras/:team_id` | Phase 1: return the copy-paste JSON |
+| `GET` | `/api/_version_/fleet/android_enterprise/zero_touch/dpc_extras/:team_id` | Phase 1: the copy-paste JSON |
 | `GET` | `/api/_version_/fleet/android_enterprise/zero_touch/devices` | Paginated device list with team and enrollment status |
 | `POST` | `/api/_version_/fleet/android_enterprise/zero_touch/devices/:id/team` | Move a device to a team |
 
-Conventions to hold to: authorize first in the service method, validate inputs in the service method (not
-the endpoint) and accumulate errors into a single `InvalidArgumentError`, wrap all errors with
-`ctxerr.Wrap`, and return client errors as 4xx without logging them as server errors. Google-side
-validation failures — a rejected `contactEmail`, a malformed phone number — are client errors and must
-not surface as 500s. Since `contactEmail` and `contactPhone` are validated by Google, Fleet should
-validate them locally too so the admin gets a field-level error instead of a round-trip failure.
+Authorize first in the service method; validate inputs there too, accumulating into one
+`InvalidArgumentError`; wrap errors with `ctxerr.Wrap`; return client errors as 4xx without logging them
+as server errors. Google-side validation failures — a rejected `contactEmail`, a malformed phone number —
+are client errors, not 500s. Validate both fields locally as well, so the admin gets a field-level error
+instead of a round-trip failure.
 
-Zero-touch is a company-owned-fleet management feature and should be **Premium-gated**, consistent with
-ABM/ADE, with the enterprise logic in `ee/server/service/`. Note the precedent that Android COBO wipe was
-moved to Free (commit `fa7d9282359`), so this is a product decision to confirm rather than an obvious
-one.
+**Tier gating needs a decision and a mechanism.** Zero-touch is a company-owned-fleet feature, which
+argues for Premium, consistent with ABM/ADE. But `server/mdm/android/` contains no license or tier checks
+today, and the bounded context has no Android code in `ee/server/service/`, so there is no established
+pattern to follow — unlike most Fleet features. Note also that Android COBO wipe was moved to Free
+(commit `fa7d9282359`). Both the product decision and the gating mechanism are open.
 
 ### Enrollment path changes
 
-- `CreateEnrollmentToken` gains an internal variant for zero-touch: explicit long `duration`,
-  `oneTimeOnly: false`, mode-specific `allowPersonalUsage`, and the v2 `additionalData` payload. Keep the
-  existing signature intact for the QR path; a shared private helper taking an options struct is cleaner
-  than adding another positional `bool` (the current `fullyManaged bool` parameter is already at the
-  limit of readability, and Fleet's style guide favors descriptive naming over stacked booleans).
-- `enrollHost` and `addNewHost` in `pubsub.go` learn the v2 payload, prefer `team_id` for zero-touch
-  tokens, and stop treating an enroll-secret mismatch as fatal in that case — while preserving the
-  existing `GetAndroidDeviceLastTeamID` precedence.
-- Enroll-secret mutation paths trigger re-issue of affected zero-touch tokens.
+- `CreateEnrollmentToken` gains a zero-touch variant: explicit long `duration`, `oneTimeOnly: false`,
+  mode-specific `allowPersonalUsage`, v2 `additionalData`. Keep the existing signature for the QR path and
+  factor a private helper taking an options struct rather than adding a second positional bool — the
+  current `fullyManaged bool` is already at the limit of readability.
+- `enrollHost` and `addNewHost` learn the v2 payload, prefer `team_id` for zero-touch tokens, and stop
+  treating a secret mismatch as fatal in that case, while preserving `GetAndroidDeviceLastTeamID`
+  precedence.
+- Enroll-secret mutation paths re-issue affected zero-touch tokens.
 
 ### Activities
 
-New activity types, documented in `docs/Contributing/reference/audit-logs.md`:
-`enabled_android_zero_touch`, `disabled_android_zero_touch`,
-`created_android_zero_touch_configuration`, `edited_android_zero_touch_configuration`,
-`deleted_android_zero_touch_configuration`, `rotated_android_zero_touch_enrollment_token`,
-`changed_android_zero_touch_device_team`.
+New types, documented in `docs/Contributing/reference/audit-logs.md`: `enabled_android_zero_touch`,
+`disabled_android_zero_touch`, `created_android_zero_touch_configuration`,
+`edited_android_zero_touch_configuration`, `deleted_android_zero_touch_configuration`,
+`rotated_android_zero_touch_enrollment_token`, `changed_android_zero_touch_device_team`.
 
 ### GitOps
-
-Zero-touch configuration is exactly the kind of state that should be declarative. Add to
-`mdm.android_zero_touch` in `default.yml` and per-team files:
 
 ```yaml
 mdm:
@@ -823,159 +752,164 @@ mdm:
     forced_reset_time: 2h
 ```
 
-Per `CLAUDE.md`'s GitOps notes, two things need explicit tests: **removal** — deleting the key must delete
-the Google-side configuration, which is the classic `apply`-inherited bug — and **all three placements**
-(`default.yml`, `teams/*.yml`, `teams/no-team.yml`). Also validate that no more than one team claims
-`default: true`, within the incoming payload rather than against the DB, since GitOps is declarative.
+Per `CLAUDE.md`'s GitOps notes, two cases need explicit tests: **removal** — deleting the key must delete
+the Google-side configuration, the classic `apply`-inherited bug — and **all three placements**
+(`default.yml`, `teams/*.yml`, `teams/no-team.yml`). Validate that at most one team claims
+`default: true`, within the incoming payload rather than against the DB.
 
 ### Frontend
 
 - **Settings → Integrations → MDM → Android**: extend `AndroidMdmPage.tsx` with a zero-touch section —
-  connect/disconnect credentials, linked customer account, ToS acceptance prompt, last sync, per-team
-  configuration editor, and the Phase 1 copy-paste extras view. `AndroidMdmCard.tsx` should reflect
-  zero-touch status in the summary.
-- **Add hosts modal**: `AndroidPanel.tsx` gains a zero-touch tab explaining that eligible devices need no
-  QR code, with a link to the settings page. This is also the right place to state the
-  bought-from-a-reserved-reseller prerequisite, since that is where the confusion happens.
-- **Hosts list**: surface pending zero-touch devices, matching how ADE "awaiting enrollment" hosts appear.
-- Free/Primo gating per the `tier-modes` conventions if Premium-gated.
-- Command palette entries for the new settings page per the `command-palette` conventions.
+  connect/disconnect credentials, linked customer account, ToS prompt, last sync, per-team configuration
+  editor, and the Phase 1 copy-paste extras view. Reflect status in `AndroidMdmCard.tsx`.
+- **Add hosts modal**: `AndroidPanel.tsx` gains a zero-touch tab noting that eligible devices need no QR
+  code, and stating the reseller-registration prerequisite — this is where that confusion surfaces.
+- **Hosts list**: show pending zero-touch devices, matching ADE "awaiting enrollment" hosts.
+- Free/Primo gating per the `tier-modes` conventions, if gated.
+- Command palette entries per the `command-palette` conventions.
 
 ### fleetctl
 
-`fleetctl get android-zero-touch` / equivalent for parity with existing MDM inspection commands, plus
-whatever `fleetctl gitops` needs to round-trip the new keys.
+`fleetctl get android-zero-touch` or equivalent, plus whatever `fleetctl gitops` needs to round-trip the
+new keys.
 
 ### Documentation
 
-- New guide in `articles/` — likely `android-zero-touch-enrollment.md`, following the guide format
-  (prerequisites, numbered steps, gotchas inline). The reseller prerequisite and the service-account
-  linking wait are the two things to lead with.
+- New guide in `articles/`, following the guide format. Lead with the reseller prerequisite and the
+  service-account linking wait.
 - Extend `articles/android-mdm-setup.md`.
 - REST API reference for the new endpoints.
-- An architecture doc under `docs/Contributing/architecture/mdm/`, parallel to
+- Architecture doc under `docs/Contributing/architecture/mdm/`, parallel to
   `automated-device-enrollment.md`.
 - Update `docs/Contributing/product-groups/mdm/android-mdm.md`.
 
 ## Phased delivery
 
-**Phase 1 — manual configuration (no new Google API).** Long-lived reusable enrollment tokens; the v2
-`additionalData` team-identification fix; re-issue on enroll-secret rotation; DPC extras generation and
-display; docs. Delivers working zero-touch for every customer, and proves the token model in production
-before any API integration exists.
+**Phase 1 — manual configuration, no new Google API.** Long-lived reusable tokens; the v2 team-identity
+fix; re-issue on enroll-secret rotation; DPC extras generation and display; docs.
 
-**Phase 2 — customer API integration.** Credential upload and validation; the client package and mock;
-the configuration table; create/patch/delete driven from Fleet; reconciliation cron; activities; ToS
-error handling; UI. This is where "manage zero-touch from Fleet" becomes true.
+**Phase 2 — customer API integration.** Credential upload and validation; client package and mock;
+configuration table; create/patch/delete from Fleet; reconciliation cron; activities; ToS handling; UI;
+the turn-off guard.
 
-**Phase 3 — device-level management.** Device list sync, pending hosts, per-device configuration
-override, host-record correlation, hosts-list integration.
+**Phase 3 — device-level management.** Device list sync, pending hosts, per-device override, host
+correlation, hosts-list integration.
 
-**Phase 4 — polish and parity.** GitOps, fleetctl, dedicated-device (`PERSONAL_USAGE_DISALLOWED_USERLESS`)
-support, optional provisioning extras (locale, timezone, system apps), and — only if demanded —
-`signinDetail`-based end-user authentication.
+**Phase 4 — parity.** GitOps, fleetctl, dedicated-device support, optional provisioning extras, and — only
+if demanded — `signinDetail` authentication.
 
-Phase 1 is independently shippable and worth doing even if Phases 2–4 are never scheduled.
+Phase 1 is independently shippable and worth doing even if Phases 2–4 never are.
 
 ## Edge cases and failure modes
 
 | Scenario | Consequence | Handling |
 | --- | --- | --- |
-| Enroll secret rotated while a zero-touch token is live | Devices enroll into AMAPI but never become Fleet hosts — silent, delayed | The v2 `team_id` fix plus re-issue on rotation. **Highest-severity item in this document.** |
-| Admin edits or deletes the configuration in Google's portal | Fleet's view is wrong; devices provision with stale extras or not at all | Reconciliation cron detects drift, restores, and records `sync_error` |
-| Team deleted in Fleet | Orphaned Google configuration; devices provision into nothing | `ON DELETE CASCADE` on the row plus a cron cleanup pass for the Google-side object |
+| Enroll secret rotated while a zero-touch token is live | Devices enroll into AMAPI but never become Fleet hosts — silent, delayed | v2 `team_id` fix plus re-issue on rotation. **Highest-severity item here** |
+| Admin edits or deletes the configuration in Google's portal | Fleet's view is wrong; devices provision with stale extras or not at all | Cron detects drift, restores, records `sync_error` |
+| Team deleted in Fleet | Orphaned Google configuration | `ON DELETE CASCADE` plus a cron pass to delete the Google-side object |
 | Team was the zero-touch default | New purchases have no default | Refuse deletion, or reassign the default and warn |
-| Token expires | All zero-touch provisioning fails at once, fleet-wide | Rotate 30 days early; alert on approaching expiry; treat expiry as a first-class monitored condition |
+| Token expires | All zero-touch provisioning fails at once, fleet-wide | Rotate 30 days early; treat approaching expiry as a monitored condition |
 | Google ToS updated | Every API call 403s mid-life | Detect `TosError` with `X-GOOG-API-FORMAT-VERSION: 2`; surface an actionable banner |
 | Credential revoked or key deleted | Cron fails silently | Mark integration invalid, surface in UI, stop retrying hot |
-| Android MDM turned off in Fleet while zero-touch configurations exist | `enterprises.delete` cascades, invalidating the token in every configuration; each device breaks on its *next* reset, long after the action | Block or hard-warn on turn-off; offer a pre-offboarding configuration cleanup. **Release blocker for Phase 2** |
-| Customer migrates to another EMM | Devices need a factory reset regardless of EMM; zero-touch claims are unaffected | Document the repoint-then-reset order; do not delete the Fleet enterprise first |
-| Two Fleet instances share a customer account | Configurations fight over `isDefault` | Detect unknown configurations; do not blindly delete configurations Fleet did not create |
-| Device factory reset | Re-provisions via zero-touch | Existing `GetAndroidDeviceLastTeamID` restores the last-known team; keep that precedence over the token's team |
-| Device unclaimed at the reseller | Zero-touch stops applying; re-registration requires contacting the reseller | Reconcile removals; mark pending device gone rather than deleting history; warn that unclaim is not self-service to undo |
-| Device never boots | Pending host lingers forever | Show claim age; allow dismissal |
-| Configuration applied to a device already in service | **Device factory resets, destroying end-user data**, after a one-hour warning on next contact with Google | Treat `applyConfiguration` and default-configuration changes as destructive in the UI: explicit warning plus confirmation |
-| No network during setup | Zero-touch is skipped and the device boots unmanaged, then self-resets on first connection to Google | Expose `forcedResetTime`; document both reset mechanisms and the failure signature |
-| Serial number missing or mismatched | Pending device never correlates, or a duplicate host appears | Multi-key correlation with normalization; prefer no correlation over a wrong one |
-| `additionalData` exceeds 1024 chars | Token creation fails | Validate length before the API call; keep the payload minimal |
-| Non-GMS or pre-8.0 device | Zero-touch simply does not apply | Document; nothing Fleet can do |
+| Android MDM turned off while zero-touch configurations exist | `enterprises.delete` cascades and invalidates the embedded token; each device breaks at its *next* reset, long after the action | Block or hard-warn on turn-off; offer pre-offboarding cleanup. **Phase 2 release blocker** |
+| Customer migrates to another EMM | Factory reset needed per device regardless of EMM; claims unaffected | Document repoint-then-reset order; do not delete the Fleet enterprise first |
+| Two Fleet instances share a customer account | Configurations fight over `isDefault` | Detect unknown configurations; never delete ones Fleet did not create |
+| Device factory reset | Re-provisions via zero-touch | `GetAndroidDeviceLastTeamID` restores the last-known team; keep that precedence |
+| Device unclaimed at the reseller | Zero-touch stops applying; re-registration needs the reseller | Reconcile removals; mark the pending device gone rather than deleting history |
+| Device never boots | Pending host lingers | Show claim age; allow dismissal |
+| Configuration applied to a device already in service | **Factory reset, destroying end-user data**, after a one-hour warning on next contact with Google | Treat `applyConfiguration` and default changes as destructive: warning plus confirmation |
+| No network during setup | Zero-touch skipped, device boots unmanaged, then self-resets on first connection to Google | Expose `forcedResetTime`; document both reset mechanisms |
+| Serial number missing, substituted, or mismatched | Pending device never correlates, or a duplicate host appears | Multi-key correlation with normalization; prefer no match over a wrong one |
+| `additionalData` exceeds 1024 chars | Token creation fails | Validate length before the API call |
+| Non-GMS or pre-8.0 device | Zero-touch does not apply | Document; nothing Fleet can do |
 
 ## Testing plan
 
-- **Unit** — table-driven tests with `t.Run` subtests over the client interface via the new mock, per
-  Fleet's Go test conventions. Cover configuration diffing, default-configuration transitions, token
-  rotation ordering (patch before delete), `additionalData` v1/v2 parsing, and serial normalization.
-- **Enroll-secret rotation regression** — the specific case above, asserted end to end: create a
-  zero-touch token, rotate the team's enroll secret, deliver a synthetic `ENROLLMENT` notification,
-  assert the host lands in the right team. This test is the reason to do the work.
-- **Integration** — extend `server/mdm/android/tests/` and the AMAPI mock at `cmd/android-amapi-mock/`
-  with a provisioning-API surface, so the cron and endpoints can be exercised without Google.
-- **Multi-team** — per `CLAUDE.md`, cover "No team", multiple teams, and the default-team transition.
-- **Multi-host** — at least two physically distinct zero-touch devices from different manufacturers in
-  manual QA, per Fleet's multi-host testing requirement. Serial/IMEI reporting differences between OEMs
-  are the likeliest source of correlation bugs, and one device will not reveal them.
-- **GitOps** — add, edit, and *remove* the `android_zero_touch` key in all three file placements.
-- **Manual QA prerequisites** — a real zero-touch customer test account, obtainable from Google with a
-  corporate email, and at least one reseller-claimed device. Note Google's constraint that the DPC must
-  be published on Play, which is satisfied automatically since Fleet uses Android Device Policy.
+- **Unit** — table-driven `t.Run` subtests over the client interface via the new mock. Cover configuration
+  diffing, default-configuration transitions, rotation ordering (patch before delete), `additionalData`
+  v1/v2 parsing, and serial normalization.
+- **Enroll-secret rotation regression** — create a zero-touch token, rotate the team's enroll secret,
+  deliver a synthetic `ENROLLMENT` notification, assert the host lands in the right team. This test is the
+  reason to do the work.
+- **Integration** — extend `server/mdm/android/tests/` and the mock at `cmd/android-amapi-mock/` with a
+  provisioning-API surface, so the cron and endpoints run without Google.
+- **Multi-team** — per `CLAUDE.md`: "No team", multiple teams, and the default-team transition.
+- **Multi-host** — at least two zero-touch devices from different manufacturers in manual QA, per Fleet's
+  multi-host requirement. OEM differences in serial/IMEI reporting are the likeliest correlation bugs and
+  one device will not reveal them.
+- **GitOps** — add, edit, and *remove* the key in all three placements.
+- **Manual QA prerequisites** — a zero-touch customer test account (obtainable from Google with a
+  corporate email) and at least one reseller-claimed device. Google's rule that the DPC must be published
+  on Play is satisfied automatically, since Fleet uses Android Device Policy.
 - **Frontend** — Jest coverage for the new settings section and Add-hosts tab.
 
 ## Security considerations
 
 - The enrollment token in `dpcExtras` is a bearer credential for joining the AMAPI enterprise. Its blast
-  radius is bounded — it enrolls a device into management, it does not read or write Fleet data — but a
-  leaked reusable token lets an attacker enroll arbitrary devices into a team, which pollutes inventory
-  and could be used to pull team-scoped configuration profiles and their embedded secrets. That last
-  point deserves a threat-model review, since Android profiles support variables and certificate
-  templates.
-- Never place the Fleet enroll secret, IdP credentials, or any Fleet API token in `dpcExtras`. Google's
-  own guidance says not to put secrets in configurations; the enrollment token is the single justified
-  exception.
-- Service-account keys and OAuth refresh tokens must go in `mdm_config_assets` (encrypted at rest), never
-  in `app_config_json`, and must be redacted from all logs and API responses. The existing
-  `ProxyClient` logger already demonstrates the redaction pattern for `Authorization` headers.
-- Reject the shared-service-account multi-tenant proxy model, as described above.
-- Authorization on all new endpoints must be team-scoped where the resource is team-scoped, using the
-  double-authorize pattern (generic check, load entity, entity-scoped check).
-- `customers.devices:unclaim` is irreversible and requires going back to the reseller to undo. Either do
-  not expose it or gate it behind explicit typed confirmation.
-- Worth a `fleet-security-auditor` pass before merge, given this touches enrollment and MDM credentials.
+  radius is bounded — it enrolls devices, it cannot read or write Fleet data — but a leaked reusable token
+  lets an attacker enroll arbitrary devices into a team, polluting inventory and potentially pulling
+  team-scoped configuration profiles. Since Android profiles support variables and certificate templates,
+  that warrants a threat-model review.
+- Never place the Fleet enroll secret, IdP credentials, or any Fleet API token in `dpcExtras`.
+- Service-account keys and refresh tokens go in `mdm_config_assets`, never `app_config_json`, and must be
+  redacted from logs and API responses. `ProxyClient`'s logger already shows the redaction pattern for
+  `Authorization` headers (`proxy_client.go:46`).
+- Reject the shared-service-account multi-tenant proxy model.
+- Team-scope authorization on all new endpoints using the double-authorize pattern.
+- `customers.devices:unclaim` is reseller-only to reverse. Either do not expose it or require typed
+  confirmation.
+- Run a `fleet-security-auditor` pass before merge.
+
+## Unverified claims
+
+Everything else in this document is drawn from Google's published reference documentation or from Fleet's
+source. These specific points are inference or contested and must be confirmed before they are relied on:
+
+1. **Whether `signinEnrollmentToken` works in `dpcExtras`** to drive sign-in-URL authentication from
+   zero-touch. Google documents the two methods separately and does not describe combining them.
+2. **The correct `dpcExtras` payload**, given that the AMAPI provisioning guide and the zero-touch EMM
+   guide contradict each other on whether to include the device-admin component name and signature
+   checksum. Test on hardware.
+3. **Whether customer-account service-account linking is still a Google Form.** The documentation says so;
+   the reseller portal has a self-service screen and the customer portal may have gained parity.
+4. **Whether `androidworkzerotouchemm` is a sensitive scope** requiring Google app verification for
+   Option B.
+5. **What state devices land in after a cascaded `enterprises.delete`** — unmanaged, orphaned, or
+   requiring a reset.
+6. **Whether serial/IMEI correlation is reliable across OEMs** well enough to build pending hosts on.
+7. **Google's rate limits for the provisioning API**, which determine the cron interval.
+8. **Whether `removeConfiguration` falls back to the default configuration** or leaves the device with
+   none. Google documents only "Removes a configuration from device."
 
 ## Open questions
 
-1. **Credential model** — Option A or B? This blocks Phase 2 and needs confirmation from Google's Android
-   Enterprise partner team on whether customer-account service-account linking is still form-based, and
-   on the verification status of the `androidworkzerotouchemm` scope.
-2. **Proxy divergence** — is the "zero-touch always goes direct to Google" decision acceptable to the
-   Fleet Cloud architecture, given every other Android call is proxied?
-3. **Premium gating** — Premium-only, or Free like Android COBO wipe?
-4. **End-user authentication** — is user-attributed zero-touch a requirement? If yes, `signinDetail` is a
-   separate design effort and should be specified before Phase 1 locks the token model.
-5. **Pending hosts** — is serial/IMEI correlation reliable enough across OEMs to ship? Needs real device
-   data.
-6. **API quotas** — what are Google's rate limits on the provisioning API? Determines cron interval and
-   pagination strategy for large fleets.
-7. **Multiple customer accounts** — can one organization have several zero-touch customer accounts (for
-   example, one per reseller or region)? `customers.list` returns a list, and Google's own quickstarts
-   just take the first element. Fleet should not do that silently.
-8. **Dedicated devices** — is COSU in scope for the first release, or deferred? It affects whether
-   management mode needs to be per-configuration rather than per-team.
+1. **Credential model** — Option A or B? Blocks Phase 2. Needs Google's Android Enterprise partner team on
+   items 3 and 4 above.
+2. **Proxy divergence** — is "zero-touch goes direct to Google" acceptable to Fleet Cloud, given every
+   other Android call is proxied?
+3. **Tier gating** — Premium or Free, and by what mechanism, given the Android bounded context has none?
+4. **End-user authentication** — is user-attributed zero-touch a requirement? If so, specify
+   `signinDetail` before Phase 1 locks the token model.
+5. **Pending hosts** — ship in Phase 3 or defer until real device data exists?
+6. **Multiple customer accounts** — can one organization hold several (per reseller, per region)?
+   `customers.list` is paginated and returns every account the caller belongs to; Google's own quickstarts
+   take the first element. Fleet must not do that silently.
+7. **Dedicated devices** — COSU in the first release or deferred? Affects whether management mode must be
+   per-configuration rather than per-team.
 
 ## Effort estimate
 
-Rough, assuming a backend engineer plus frontend support, and *excluding* the time to resolve the
-credential question and obtain a Google test account — both of which are on the critical path and have
-external latency.
+Rough, assuming one backend engineer plus frontend support, and excluding the credential decision and
+obtaining a Google test account — both on the critical path with external latency.
 
 | Phase | Backend | Frontend | Notes |
 | --- | --- | --- | --- |
 | 1 — manual configuration | 1–2 weeks | 2–3 days | The `additionalData` fix is most of the risk |
-| 2 — customer API integration | 3–4 weeks | 1–1.5 weeks | Client, mock, migration, cron, endpoints |
+| 2 — customer API integration | 3–4 weeks | 1–1.5 weeks | Client, mock, migration, cron, endpoints, turn-off guard |
 | 3 — device-level management | 2–3 weeks | 1 week | Correlation is the uncertain part |
-| 4 — polish and parity | 1–2 weeks | 2–3 days | Excludes `signinDetail` |
+| 4 — parity | 1–2 weeks | 2–3 days | Excludes `signinDetail` |
 
-`signinDetail`-based end-user authentication, if required, is an additional 3–4 weeks and should be
-scoped separately.
+`signinDetail` authentication, if required, adds 3–4 weeks and should be scoped separately.
 
 ## References
 
@@ -999,15 +933,18 @@ scoped separately.
 - [Enroll and provision a device](https://developers.google.com/android/management/provision-device)
 - [`enterprises.enrollmentTokens`](https://developers.google.com/android/management/reference/rest/v1/enterprises.enrollmentTokens)
 - [`AllowPersonalUsage`](https://developers.google.com/android/management/reference/rest/v1/AllowPersonalUsage)
+- [`enterprises.delete`](https://developers.google.com/android/management/reference/rest/v1/enterprises/delete)
+- [Migrate existing devices to AMAPI](https://developers.google.com/android/management/dpc-migration)
 - [Notifications (Pub/Sub)](https://developers.google.com/android/management/notifications)
 
 ### Fleet
 
 - `server/mdm/android/README.md` — bounded-context rationale
 - `server/mdm/android/service/service.go:549` — `CreateEnrollmentToken`
+- `server/mdm/android/service/service.go:424` — `DeleteEnterprise`
 - `server/mdm/android/service/pubsub.go:599` — `enrollHost`
 - `server/mdm/android/service/pubsub.go:893` — `addNewHost`
 - `server/mdm/android/service/androidmgmt/client.go` — AMAPI client interface
-- `cmd/fleet/cron.go:2513` — Android device reconciler cron pattern
+- `cmd/fleet/cron.go:2515` — Android device reconciler cron pattern
 - `docs/Contributing/architecture/mdm/automated-device-enrollment.md` — the Apple analogue
 - `docs/Contributing/product-groups/mdm/android-mdm.md`

--- a/docs/Contributing/research/mdm/android-zero-touch-enrollment.md
+++ b/docs/Contributing/research/mdm/android-zero-touch-enrollment.md
@@ -17,20 +17,26 @@ instead of a QR code. The device then follows the AMAPI path Fleet already suppo
 by the Pub/Sub `ENROLLMENT` message it already handles. Profile delivery, software installs, commands, and
 host vitals are reused unchanged.
 
-Four workstreams follow. **One:** integrate the Android Device Provisioning Partner API
-(`androiddeviceprovisioning.googleapis.com`), customer surface — already in Fleet's module graph, so no
-new dependency. **Two:** choose a credential model for it, the largest open question. Google offers a
-service-account path (fits an automated cron, but linking it to a customer account currently requires a
-Google Form and email confirmation) and an interactive OAuth path (self-service, but bound to one admin's
-Google account with probable scope verification). **Three:** build the Fleet side — long-lived reusable
-tokens, a configuration per team, a reconciliation cron, pending-host records, activities, GitOps keys,
-REST endpoints, UI. **Four:** change how Fleet identifies the target team at enrollment. Fleet embeds a
-mutable enroll secret in the token's `additionalData`; rotating a team's enroll secret then silently
-breaks every long-lived zero-touch token. That is a correctness prerequisite, not an enhancement.
+Four workstreams follow. **One:** decide how Fleet reaches the customer's zero-touch account. There are
+four options, and the choice drives everything else: Google's **zero-touch iframe**, which is an AMAPI call
+and so needs no new credential and routes through Fleet's existing proxy, but generates a configuration the
+admin cannot modify; a **service-account key** for the Android Device Provisioning Partner API, which fits an
+automated cron but currently requires a Google Form and email confirmation to link; **interactive OAuth**,
+self-service but bound to one admin's Google account; or **no integration at all**, with Fleet emitting the
+provisioning extras for the admin to paste into Google's portal. **Two:** integrate whichever API that
+implies — the provisioning API is already in Fleet's module graph, so no new dependency either way.
+**Three:** build the Fleet side — long-lived reusable tokens, a configuration per team, a reconciliation
+cron, pending-host records, activities, GitOps keys, REST endpoints, UI. **Four:** change how Fleet
+identifies the target team at enrollment. Fleet embeds a mutable enroll secret in the token's
+`additionalData`, so rotating a team's enroll secret silently breaks enrollment for every device that Fleet
+has not seen before — which is every new zero-touch device. That is a correctness prerequisite, not an
+enhancement.
 
-Phase 1 ships usable zero-touch with **no** Google API integration: Fleet emits the DPC extras JSON and
-the admin pastes it into Google's portal once per team. It is small, unblocks customers immediately, and
-proves the token and team-mapping model before the credential decision is made.
+Phase 1 ships usable zero-touch with **no** Google API integration: Fleet emits the DPC extras JSON and the
+admin pastes it into Google's portal once per team. It is small, unblocks customers immediately, and proves
+the token and team-identity model before the access decision is made. One question should be answered before
+anything is built, because it is cheap and it reshapes the plan: whether the zero-touch iframe can carry
+per-team provisioning extras. If it can, it removes the credential problem entirely.
 
 ## Table of contents
 
@@ -58,21 +64,25 @@ Android is the only company-owned platform where Fleet has no zero-touch path.
 | --- | --- | --- |
 | macOS / iOS / iPadOS | Apple Automated Device Enrollment (ADE) via Apple Business | Supported. See `docs/Contributing/architecture/mdm/automated-device-enrollment.md` |
 | Android (company-owned) | Google Android zero-touch enrollment | **Not supported — this document** |
-| Windows | Windows Autopilot | Not supported. Separate effort, unrelated APIs |
-| ChromeOS | Chrome zero-touch enrollment (same provisioning API, `deviceType` `CHROME_OS`) | Out of scope; Fleet has no ChromeOS MDM |
+| Windows | Windows Autopilot (via Entra ID) | Supported. See `docs/Contributing/product-groups/mdm/windows-autopilot.md` and `articles/windows-mdm-setup.md` |
+| ChromeOS | Chrome zero-touch enrollment (same provisioning API, `deviceType` `DEVICE_TYPE_CHROME_OS`) | Out of scope; Fleet has no ChromeOS MDM |
 
 Zero-touch supports three management modes, differing only in the `allowPersonalUsage` value on the
 enrollment token:
 
 - **Fully managed (COBO)** — `PERSONAL_USAGE_DISALLOWED`.
-- **Company-owned with a work profile (COPE)** — `PERSONAL_USAGE_ALLOWED`. Android 8+, though Android 11
+- **Company-owned with a work profile (COPE)** — `PERSONAL_USAGE_ALLOWED`. **Android 10+ for zero-touch
+  specifically**: the zero-touch EMM guide requires Android 8.0+ for fully managed but says "Company-owned
+  Android 10+ devices can be provisioned as fully managed or with a work profile." Android 11 further
   reworked COPE to treat the personal side closer to BYOD.
 - **Dedicated / kiosk (COSU)** — `PERSONAL_USAGE_DISALLOWED_USERLESS`, which Google made mandatory for
   dedicated-device enrollment as of January 2025.
 
-Zero-touch does **not** support work profiles on personally-owned devices. Google's provisioning-method
-matrix lists zero-touch as supporting COPE, fully managed, and dedicated only. BYOD is therefore out of
-scope by mechanism, not just by policy.
+Zero-touch does **not** support work profiles on personally-owned devices. Google's provisioning guide
+lists the methods per ownership type as prose rather than a table; zero-touch appears under both
+company-owned sections and is absent from the personally-owned list, which offers only Settings, the
+Android Device Policy app, an enrollment-token link, and sign-in URL. BYOD is therefore out of scope by
+mechanism, not just by policy.
 
 ## How Android zero-touch enrollment works
 
@@ -80,8 +90,13 @@ scope by mechanism, not just by policy.
 
 1. **Reseller** — an authorized zero-touch reseller. On purchase, the reseller registers each device's
    hardware identifiers (IMEI/MEID or serial number, plus manufacturer) and *claims* the device to the
-   organization's customer account. **Only resellers can create device records** — not IT admins, not an
-   EMM. Fleet can never add a device to zero-touch.
+   organization's customer account. **Only resellers can create device records.** Google states this
+   directly — "Resellers create devices when a customer purchases them for zero-touch enrollment—IT admins
+   can't create devices" — and there is no device-create method on the customer API, only
+   `partners.devices.claim` on the reseller API. Note that the *same* Google page also says "An
+   organization can also create configurations and devices using the zero-touch enrollment portal," which
+   contradicts it. Treat the reseller-only rule as correct, since it is the one corroborated by the API
+   surface and by the support docs, but the contradiction is unresolved.
 2. **Customer account** — the organization's zero-touch account, created by the reseller on first
    purchase, managed at `https://enterprise.google.com/android/zero-touch/customers`, addressed as
    `customers/{CUSTOMER_ID}`.
@@ -129,8 +144,11 @@ back to the reseller.
 3. If a configuration is assigned, the device enters the fully managed setup wizard, showing
    `companyName`, `customMessage`, `contactEmail`, and `contactPhone`.
 4. The device installs Android Device Policy from Google Play.
-5. Android Device Policy receives `ACTION_PROVISION_MANAGED_DEVICE` with the extras from `dpcExtras`,
-   reads the enrollment token, and enrolls into the AMAPI enterprise.
+5. Android Device Policy is launched with the extras from `dpcExtras`, reads the enrollment token, and
+   enrolls into the AMAPI enterprise. (Google's zero-touch guide still names the
+   `ACTION_PROVISION_MANAGED_DEVICE` intent here, but that action was deprecated in API level 31 and now
+   fails on Android 12+; the current flow uses `ACTION_PROVISION_MANAGED_DEVICE_FROM_TRUSTED_SOURCE` with
+   `ACTION_GET_PROVISIONING_MODE`. This is informational for Fleet, which does not implement a DPC.)
 6. AMAPI publishes an `ENROLLMENT` notification to the enterprise's Pub/Sub topic. **Fleet re-enters here,
    on the code path it already has.**
 
@@ -143,15 +161,22 @@ consequences shape the design:
 - **It re-triggers on every factory reset, for as long as the claim exists.** The end user cannot bypass
   or defer it. This is the security property that makes zero-touch valuable for company-owned hardware,
   and the reason a broken configuration is a fleet-wide outage rather than a per-device annoyance.
-- **Applying a configuration to a device already in service triggers a factory reset.** Google's admin
-  documentation states that a device lacking connectivity during setup skips zero-touch and boots
-  unmanaged, then "resets itself after the first connection to Google servers," warning the user one hour
-  ahead. So `customers.devices:applyConfiguration` can destroy end-user data — which the method name does
-  not suggest. Fleet must treat it, and changes to the default configuration, as destructive actions
-  requiring explicit confirmation.
-- **Two reset mechanisms exist and are easily conflated.** `forcedResetTime` (0–6 hours, default 2) is the
-  in-setup timeout when the wizard cannot reach Google. The self-reset above fires after setup completed
-  unmanaged. Only the first is configurable.
+- **Assigning a configuration does not reset a device that is already in service.**
+  `customers.devices:applyConfiguration` is documented as: "After applying a configuration to a device, the
+  device automatically provisions itself on first boot, or next factory reset." Google's IT-admin help says
+  the same. Assignment is therefore a staging operation; nothing happens until the next wipe.
+  **Verify before building on this.** Google is silent on what happens to an already-provisioned device
+  that is later assigned a configuration, so "waits for the next reset" is the documented behaviour rather
+  than a guarantee about every state. An earlier draft of this document claimed assignment wipes an
+  in-service device; that was a misreading of the sentence quoted in the next bullet, whose subject is a
+  device still in the setup wizard.
+- **A device that skips zero-touch for lack of network resets itself later.** If a device has a
+  configuration but no connectivity during setup, zero-touch is skipped and the device boots unmanaged —
+  then "resets itself after the first connection to Google servers," warning the user one hour ahead. This
+  is distinct from `forcedResetTime` (0–6 hours, default 2), which is the in-setup timeout when the wizard
+  cannot reach Google. Only the latter is configurable. Google documents a third trigger in the same
+  family: registered dual-SIM devices shipped with Google Play Services older than 24.07.12 factory-reset
+  if zero-touch does not provision them during initial setup.
 
 ### DPC extras for AMAPI
 
@@ -229,9 +254,15 @@ Fleet's Android MDM lives in `server/mdm/android/` as a decoupled bounded contex
 enrollment surface. It:
 
 1. Verifies Android MDM is configured.
-2. Verifies the enroll secret (`svc.ds.VerifyEnrollSecret`), which determines the target team.
+2. Verifies the enroll secret (`svc.ds.VerifyEnrollSecret`, `service.go:558`). Note the result is
+   discarded here — the team is not resolved at token-creation time, only at enrollment.
 3. Optionally requires and validates an IdP account UUID for end-user authentication.
-4. Marshals `{enroll_secret, idp_uuid}` into the token's `additionalData`.
+4. Marshals an `enrollmentTokenRequest` into the token's `additionalData`. **The struct carries only
+   `query:` tags, no `json:` tags** (`service.go:480-484`), so the wire format uses Go field names and
+   includes a third field:
+   `{"EnrollSecret":"...","FullyManaged":false,"IdpUUID":"..."}`. `FullyManaged` is always `false`
+   because `CreateEnrollmentToken` never sets it when marshalling. Fleet's own integration tests encode
+   this shape (`server/mdm/android/tests/integration_os_version_test.go:82`).
 5. Sets `allowPersonalUsage` from a `fully_managed` query parameter — `PERSONAL_USAGE_DISALLOWED` when
    true, `PERSONAL_USAGE_ALLOWED` otherwise (`service.go:608`).
 6. Sets `oneTimeOnly: true` and leaves `duration` unset, so **the token expires in one hour and works
@@ -244,9 +275,10 @@ which offers a work-profile / fully-managed radio and builds a Fleet enrollment 
 
 ### Enrollment completion
 
-`Service.enrollHost` (`server/mdm/android/service/pubsub.go:599`) handles the `ENROLLMENT` notification.
-It unmarshals `device.EnrollmentTokenData` back into `{enroll_secret, idp_uuid}`, re-verifies the enroll
-secret, resolves the team, and creates or updates the host. `addNewHost` (`pubsub.go:893`) is the
+`ENROLLMENT` notifications are dispatched by `ProcessPubSubPush` (`pubsub.go:66`) to
+`handlePubSubEnrollment` (`pubsub.go:512`), which calls `Service.enrollHost` (`pubsub.go:599`).
+It unmarshals `device.EnrollmentTokenData` back into the same struct, re-verifies the enroll secret,
+resolves the team, and creates or updates the host. `addNewHost` (`pubsub.go:893`) is the
 new-device path and maps AMAPI `hardwareInfo.serialNumber` into `host.HardwareSerial` (`pubsub.go:947`),
 which matters for correlating zero-touch device records later. `ENROLLMENT` is among the notification
 types Fleet enables at enterprise creation (`service.go:299`).
@@ -313,7 +345,7 @@ This proxy architecture is the most important existing constraint on the design.
 | `customers.configurations.delete` | Remove a configuration when a team is deleted or opts out. |
 | `customers.devices.list` | Enumerate claimed devices for pending-host records. Paginated via `nextPageToken`. |
 | `customers.devices.get` | Refresh a single device. |
-| `customers.devices:applyConfiguration` | Assign a device to a specific team's configuration. Destructive — see above. |
+| `customers.devices:applyConfiguration` | Assign a device to a specific team's configuration. Takes effect at the device's next factory reset, not immediately. |
 | `customers.devices:removeConfiguration` | Remove a device's configuration. |
 | `customers.devices:unclaim` | Destructive and reseller-only to reverse; expose behind explicit confirmation, if at all. |
 
@@ -339,7 +371,10 @@ New usage of an API Fleet already calls:
   - `policyName` — Fleet already points this at `{enterprise}/policies/1`
     (`android.DefaultAndroidPolicyID`).
 - `enterprises.enrollmentTokens.delete` — revoke a leaked or superseded token.
-- `enterprises.enrollmentTokens.list` — lists active, unexpired tokens; useful for drift detection.
+- `enterprises.enrollmentTokens.list` — lists active, unexpired tokens, but **returns only a partial
+  view**: `name`, `expirationTimestamp`, `allowPersonalUsage`, `value`, `qrCode`. `additionalData` and
+  `policyName` are absent, so it cannot detect drift in the fields this design cares about. Useful for
+  lifecycle cleanup only.
 - `EnrollmentToken.user` is deprecated and ignored. Do not use it.
 
 ### 3. Google Cloud Pub/Sub (existing)
@@ -348,9 +383,12 @@ Unchanged. Zero-touch devices produce the same `ENROLLMENT` notification as QR-c
 
 ### 4. Optional: AMAPI `signinDetail`, only if end-user IdP auth is required
 
-Zero-touch hands the device a plain enrollment token with no user interaction, so Fleet's BYOD IdP flow
-cannot apply — it depends on a browser cookie set before the token is requested (`mdm.BYODIdpCookieName`,
-`service.go:508`).
+Zero-touch hands the device a token with no browser involved, so Fleet's existing IdP flow cannot apply.
+That flow takes the IdP account either from an explicit `idp_uuid` query parameter, which is checked first
+(`service.go:500`), or from a cookie (`mdm.BYODIdpCookieName`, `service.go:508`) — both of which require a
+browser. Note the requirement itself is not BYOD-specific: `RequiresEnrollOTAAuthentication`
+(`pkg/mdm/ota_enroll.go`) keys off the team's setup-experience IdP setting and applies regardless of
+`fullyManaged`.
 
 AMAPI's sign-in URL enrollment is the mechanism for authenticating a user during provisioning. An
 enterprise can hold any number of `SigninDetail` entries, keyed by (`signinUrl`, `allowPersonalUsage`,
@@ -358,19 +396,28 @@ enterprise can hold any number of `SigninDetail` entries, keyed by (`signinUrl`,
 finish by redirecting to `https://enterprise.google.com/android/enroll?et=<token>` on success or
 `https://enterprise.google.com/android/enroll/invalid` on failure.
 
-**Whether a `signinEnrollmentToken` can be placed in `dpcExtras` to drive this from zero-touch is not
-documented and must be tested.** Google's provisioning-method matrix treats zero-touch and sign-in URL as
-separate methods and does not describe combining them.
+Google documents this combination explicitly: "Add the resulting `signinEnrollmentToken` as provisioning
+extra to a QR code, NFC payload, or **Zero-touch configuration**." Google's canonical `dpcExtras` example is
+in fact the *sign-in* variant — its placeholder inside `PROVISIONING_ADMIN_EXTRAS_BUNDLE` is
+`"{Sign In URL token}"`, not a plain enrollment token.
 
-Either way this is a substantial sub-project: Fleet would serve an unauthenticated, device-facing web flow
-that mints enrollment tokens. **Recommendation: exclude from initial scope.** Company-owned devices are
-typically assigned to a person out of band. Revisit only if customers ask for user-attributed zero-touch.
+**A cheaper mechanism probably covers Fleet's need.** `googleAuthenticationOptions` on the enrollment token
+takes `authenticationRequirement` (`OPTIONAL` / `REQUIRED`) and `requiredAccountEmail`, overrides the
+enterprise-wide `googleAuthenticationSettings` policy, and hides the Skip button on the Google sign-in
+screen. It applies to a plain enrollment token and therefore to zero-touch, giving account-attributed
+enrollment with no device-facing web flow. Caveat: it is **not** present in the pinned
+`google.golang.org/api v0.269.0` generated code, so it needs a library bump. Google also notes that
+`PERSONAL_USAGE_DISALLOWED` already "requires users to sign in with a work email to access the device."
+
+`signinDetail` remains a substantial sub-project — Fleet would serve an unauthenticated, device-facing web
+flow that mints enrollment tokens. **Recommendation: exclude `signinDetail` from initial scope and evaluate
+`googleAuthenticationOptions` first**, since it is a field on a call Fleet already makes.
 
 ## Credential and authorization options
 
 This decision gates Phase 2 and should be settled before implementation starts.
 
-### Option A — Service account key uploaded by the admin (recommended)
+### Option A — Service account key uploaded by the admin
 
 The admin creates a Google Cloud project, enables the API, creates a service account, downloads its JSON
 key, and uploads it to Fleet. Fleet uses two-legged OAuth with the `androidworkzerotouchemm` scope.
@@ -408,17 +455,53 @@ copy button and portal instructions. The admin creates the configuration by hand
 - **Cons**: per-team manual portal work. No pending-host visibility, no per-device team override, no drift
   detection.
 
+### Option D — The AMAPI zero-touch iframe
+
+Google ships a path purpose-built for AMAPI EMMs that avoids the provisioning API entirely. Fleet calls
+`enterprises.webTokens.create` with `iframeFeature: 'ZERO_TOUCH'`, then embeds
+`https://enterprise.google.com/android/zero-touch/embedded/companyhome` with `token`, `dpcId`
+(`com.google.android.apps.work.clouddpc`), and an optional `dpcExtras` URL parameter carrying URL-encoded
+provisioning extras. The admin links their own zero-touch account from inside the iframe.
+
+- **Pros**: `webTokens.create` is an **AMAPI** call, so it routes through Fleet's existing proxy with the
+  existing credential. No customer-supplied credential, no Google Form, no OAuth client, no new API
+  integration, and no new secret to store. Google's IT-admin help actively points customers at it: "Many
+  EMMs also implement the zero-touch iframe to simplify the process of setting up zero-touch devices after
+  you purchase them from a reseller."
+- **Cons**, and they are structural: "The zero-touch iframe automatically generates a zero-touch
+  configuration. This configuration is not modifiable by the IT admin." Fleet sets the extras once via the
+  `dpcExtras` URL parameter and otherwise does not control the configuration. That appears to rule out the
+  configuration-per-team model this document is built on, and with it per-device team assignment,
+  pending-host records, and drift detection — everything that needs `customers.*`. Google also describes
+  the generated profile applying to devices in the account that have no profile, which is default-like
+  behaviour rather than per-team targeting.
+- **Verify before choosing**: whether more than one configuration can be generated per enterprise, and
+  whether `dpcExtras` can be varied per team through separate iframe renderings. If it can, Option D may
+  dominate A and B outright. If it cannot, Option D is a low-effort single-team path and the
+  provisioning-API options remain necessary for team granularity.
+
 ### Recommendation
 
-Ship **C as Phase 1**, then **A as Phase 2**, keeping **B** as an alternate for customers blocked on
-service-account linking. C is not throwaway — it forces the long-lived token model, the team-mapping fix,
-and extras generation, all reused verbatim by Phase 2, and it decouples customer value from the credential
-decision.
+The right sequence depends on the Option D question above, which should be resolved first because it is
+cheap to answer and changes the plan materially.
+
+- If Option D supports only one effective configuration per enterprise: ship **C as Phase 1** (it proves
+  the token and team-mapping model with no integration), then **A as Phase 2** for team granularity, with
+  **B** as an alternate for customers blocked on service-account linking. Consider also offering **D** as a
+  one-click path for single-team deployments, since it is nearly free once `webTokens` is wired up.
+- If Option D supports per-team extras: make **D** the primary path and drop A and B to a later phase or
+  out of scope. It removes the entire credential problem, which is otherwise this project's largest risk.
+
+Either way C remains worth shipping first: it is small, unblocks customers immediately, and everything it
+forces Fleet to get right — long-lived tokens, the team-identity fix, extras generation — is reused by every
+other option.
 
 ### The Fleet Cloud proxy question
 
+This applies to Options A and B only; Option D routes through the existing proxy by construction.
+
 Fleet's AMAPI traffic defaults through `https://fleetdm.com/api/android/`, with Fleet's hosted project
-owning the credentials. Zero-touch cannot follow that model:
+owning the credentials. The **provisioning API** cannot follow that model:
 
 - The customer's zero-touch account was established by *their* reseller. Fleet's hosted service account
   has no relationship to it and cannot gain one without the customer linking it.
@@ -426,9 +509,10 @@ owning the credentials. Zero-touch cannot follow that model:
   every linked customer to every caller, putting Fleet's proxy in charge of tenant isolation on a
   credential with no per-tenant scoping. **Reject this.**
 
-Therefore zero-touch credentials are **per-Fleet-instance and customer-supplied**, and zero-touch calls go
-**direct to Google**, regardless of how AMAPI traffic is routed. This diverges deliberately from the rest
-of Android MDM and should be documented in the code, because it will surprise readers.
+So under A or B, zero-touch credentials are **per-Fleet-instance and customer-supplied** and provisioning
+API calls go **direct to Google**, regardless of how AMAPI traffic is routed. That is a deliberate
+divergence from the rest of Android MDM and should be commented in the code. Under D the question does not
+arise, which is a further argument for resolving D first.
 
 ## Design
 
@@ -449,8 +533,9 @@ mode a per-team setting; teams needing both fully managed and dedicated devices 
 
 ### Fixing team identification: the critical prerequisite
 
-`additionalData` carries `{"enroll_secret": "...", "idp_uuid": "..."}`, and `addNewHost` (`pubsub.go:908`)
-hard-fails when the secret does not verify:
+`additionalData` carries `{"EnrollSecret":"...","FullyManaged":false,"IdpUUID":"..."}` — Go field names,
+because the struct has no `json:` tags — and `addNewHost` hard-fails at `pubsub.go:908` when the secret
+does not verify:
 
 ```go
 enrollSecret, err := svc.ds.VerifyEnrollSecret(ctx, enrollmentTokenRequest.EnrollSecret)
@@ -459,10 +544,17 @@ if err != nil {
 }
 ```
 
-Fine for a one-hour token. For a token embedded in a configuration for a year it is a latent outage: **once
-an admin rotates that team's enroll secret, every subsequent zero-touch device enrolls into AMAPI and then
-fails to become a Fleet host** — managed by Google, invisible in Fleet, visible only as a repeating
-Pub/Sub error.
+Fine for a one-hour token. For a token embedded in a configuration for a year it is a latent outage:
+**once an admin rotates that team's enroll secret, every zero-touch device Fleet has never seen before
+enrolls into AMAPI and then fails to become a Fleet host** — managed by Google, invisible in Fleet, visible
+only as a repeating Pub/Sub error.
+
+The scope matters. `enrollHost` branches on `getExistingHost`, and only the new-device path is fatal. For a
+device Fleet already knows, a secret that fails to verify is explicitly tolerated (`pubsub.go:628-631`,
+`if err != nil && !fleet.IsNotFound(err)`) and the host keeps its existing team. Since `getAndroidHostKey`
+is stable across unenroll/re-enroll for the same device and enterprise, a *factory-reset* zero-touch device
+takes the tolerant path and survives. The breakage lands on new hardware out of the box — the primary
+zero-touch scenario, so the finding stands, but it is not every device.
 
 Two fixes, both needed:
 
@@ -485,8 +577,17 @@ previously-known devices, so a factory-reset device returns to the team an admin
 
 Create tokens with a long explicit duration and rotate on demand rather than on a short clock. A
 mid-provisioning token swap is the riskiest moment in the flow, and frequent rotation multiplies that risk
-for little gain: the token's only power is enrolling a device into the enterprise, and it sits in a store
-readable only by zero-touch portal admins.
+for little gain: the token's only power is enrolling a device into the enterprise.
+
+**This deviates from Google's stated guidance**, which is worth naming rather than glossing: "For security
+reasons, it's recommended to delete active enrollment tokens as soon as they're not intended to be used
+anymore," and on create, "It's up to the caller's responsibility to manage the lifecycle of newly created
+tokens and deleting them when they're not intended to be used anymore." That guidance is written for
+short-lived QR enrollment, where a token really is finished after one device. Zero-touch structurally needs
+a token that stays valid as long as a configuration references it, so both cannot hold. Mitigation: keep
+exactly one live token per configuration, delete superseded ones promptly, and treat the stored value as a
+credential — rather than shortening its life until expiry becomes the likelier outage. Record this as a
+deliberate deviation.
 
 - Create with `duration` around one year and `oneTimeOnly: false`.
 - Store `expires_at`; have the cron rotate within roughly 30 days of expiry.
@@ -509,8 +610,11 @@ Caveats:
 - AMAPI documents that on personally-owned devices running Android 12+, `serialNumber` is the same value as
   `enterpriseSpecificId` rather than a real serial. Company-owned zero-touch devices should report a true
   serial, but the code must not assume the field is meaningful.
-- Normalize case, leading zeros, and whitespace on both sides; `fleet.Preprocess`
-  (`server/fleet/utils.go:65`) exists for this.
+- Normalize on both sides before comparing. `fleet.Preprocess` (`server/fleet/utils.go:65`) covers only
+  whitespace trimming and Unicode NFC — it does **not** case-fold or strip leading zeros, so those need
+  handling separately. Google also warns that `serialNumber` "might not be unique across different device
+  models," so serial alone is not a safe key. For dual-SIM devices Google advises resellers to register the
+  numerically lowest IMEI, which is worth confirming with the customer's reseller.
 - A wrong match creates duplicate host records, which is worse than no pending hosts. If confidence is
   low, ship without pending hosts and add them once real device data exists.
 
@@ -549,7 +653,10 @@ Migrating away from Fleet:
 **Offboarding hazard: the current turn-off flow is unsafe.** `enterprises.delete` performs "a cascaded
 deletion of all AM API devices associated with the deleted enterprise" and is only available for
 EMM-managed enterprises. `Service.DeleteEnterprise` (`service.go:424`, calling `EnterpriseDelete` at
-`service.go:442`) runs when an admin turns off Android MDM. If zero-touch configurations exist, deleting
+`service.go:442`) runs when an admin turns off Android MDM. **It is not the only caller**: a second path
+reaches `EnterpriseDelete` at `service.go:820` from `VerifyExistingEnterpriseIfAny` (`service.go:801`), which
+the `cleanup_android_enterprise` cron job invokes (`cmd/fleet/cron.go:1600`). The cascade can therefore fire
+with no admin action at all. If zero-touch configurations exist, deleting
 the enterprise invalidates the token still embedded in them, so every subsequent factory reset hits a dead
 token and cannot complete provisioning. **Turning off Android MDM therefore breaks provisioning for every
 zero-touch-claimed device, with damage surfacing only at each device's next reset.**
@@ -558,6 +665,8 @@ Mitigations:
 
 - Turn-off must detect existing zero-touch configurations and block or hard-warn, listing affected teams
   and device counts. Treat as a Phase 2 release blocker.
+- The `cleanup_android_enterprise` cron path needs the same guard. A UI-only check leaves the cascade
+  reachable from a background job, which is the worse case because no one is watching when it fires.
 - Provide a "prepare for migration" action that deletes Fleet's configurations (leaving claims intact)
   before enterprise deletion, so devices boot unmanaged instead of looping.
 - Document the order: repoint or delete configurations → reset devices → delete the enterprise.
@@ -577,7 +686,9 @@ Following `newAndroidMDMDeviceReconcilerSchedule` (`cmd/fleet/cron.go:2515`) and
 5. Rotate tokens approaching expiry.
 6. `customers.devices.list` (paginated) — upsert pending device records, reconcile per-device assignments
    against team intent.
-7. Detect and surface `TosError`.
+7. Detect and surface `TosError`. Cheaper pre-check: `Company.termsStatus` is an output-only field on the
+   objects `customers.list` already returns (`TERMS_STATUS_ACCEPTED` / `_NOT_ACCEPTED` / `_STALE`), so the
+   cron can flag a ToS problem without waiting for a 403.
 
 Suggested interval 30 minutes, tunable. It must be bounded and paginated: the existing Android device
 reconciler needed its pagination loop bounded (commit `8a65ecf20bf`) and the same failure mode applies.
@@ -629,7 +740,8 @@ CREATE TABLE `android_zero_touch_configurations` (
   `configuration_name` VARCHAR(255) NOT NULL DEFAULT '',
   `is_default` TINYINT(1) NOT NULL DEFAULT '0',
   -- Fleet-side intent
-  `management_mode` VARCHAR(40) NOT NULL,  -- allowPersonalUsage value
+  `management_mode` VARCHAR(40) NOT NULL,  -- store the AMAPI allowPersonalUsage value verbatim,
+                                           -- not the GitOps alias; map at the YAML boundary
   `company_name` VARCHAR(255) NOT NULL DEFAULT '',
   `contact_email` VARCHAR(255) NOT NULL DEFAULT '',
   `contact_phone` VARCHAR(64) NOT NULL DEFAULT '',
@@ -644,7 +756,9 @@ CREATE TABLE `android_zero_touch_configurations` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_android_zt_global_or_team_id` (`global_or_team_id`),
   KEY `fk_android_zt_team_id` (`team_id`),
-  CONSTRAINT `fk_android_zt_team_id` FOREIGN KEY (`team_id`) REFERENCES `teams` (`id`) ON DELETE CASCADE
+  -- SET NULL, not CASCADE: the row must survive team deletion so the cron knows Fleet created the
+  -- Google-side configuration and may therefore delete it. See the failure-mode table.
+  CONSTRAINT `fk_android_zt_team_id` FOREIGN KEY (`team_id`) REFERENCES `teams` (`id`) ON DELETE SET NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 ```
 
@@ -663,7 +777,8 @@ CREATE TABLE `android_zero_touch_devices` (
   `meid` VARCHAR(32) NOT NULL DEFAULT '',
   `manufacturer` VARCHAR(255) NOT NULL DEFAULT '',
   `model` VARCHAR(255) NOT NULL DEFAULT '',
-  `configuration_id` INT UNSIGNED DEFAULT NULL,
+  `zt_configuration_id` INT UNSIGNED DEFAULT NULL,  -- FK to android_zero_touch_configurations.id;
+                                                   -- deliberately NOT the Google configuration_id above
   `host_id` INT UNSIGNED DEFAULT NULL,  -- set once correlated post-enrollment
   `deleted_at` TIMESTAMP(6) NULL DEFAULT NULL,
   `created_at` TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
@@ -685,14 +800,16 @@ New `MDMAssetName` values in `server/fleet/mdm.go`, encrypted in `mdm_config_ass
 - `android_zero_touch_service_account` — uploaded service-account JSON key (Option A).
 - `android_zero_touch_oauth_refresh_token` — refresh token (Option B).
 - `android_zero_touch_enrollment_token` — the current long-lived token per configuration. Storing it as an
-  asset keeps it out of ordinary query paths and gets encryption for free, but assets are keyed by name
-  alone, so a per-team scheme is needed. Check how the ABM and VPP token tables solved per-entity secret
-  storage before choosing.
+  asset keeps it out of ordinary query paths and gets encryption for free, but the unique key is
+  `(name, deletion_uuid)` — effectively name-scoped for live rows — so a per-team naming scheme is needed.
+  Check how the ABM and VPP token tables solved per-entity secret storage before choosing.
 
 ### Service layer and API
 
 New endpoints in `server/mdm/android/service/handler.go`, with request/response structs carrying
-`Err error` per Fleet's API conventions:
+`Err error` per Fleet's API conventions. Paths below use `:name` for readability; Fleet registers with
+gorilla-mux brace syntax — `{token}` at `handler.go:35`, `{id:[0-9]+}` elsewhere — so the real
+registrations would use `{team_id:[0-9]+}` and `{id:[0-9]+}`.
 
 | Method | Path | Purpose |
 | --- | --- | --- |
@@ -713,11 +830,15 @@ as server errors. Google-side validation failures — a rejected `contactEmail`,
 are client errors, not 500s. Validate both fields locally as well, so the admin gets a field-level error
 instead of a round-trip failure.
 
-**Tier gating needs a decision and a mechanism.** Zero-touch is a company-owned-fleet feature, which
-argues for Premium, consistent with ABM/ADE. But `server/mdm/android/` contains no license or tier checks
-today, and the bounded context has no Android code in `ee/server/service/`, so there is no established
-pattern to follow — unlike most Fleet features. Note also that Android COBO wipe was moved to Free
-(commit `fa7d9282359`). Both the product decision and the gating mechanism are open.
+**Tier gating needs a product decision.** Zero-touch is a company-owned-fleet feature, which argues for
+Premium, consistent with ABM/ADE. The mechanism is less open than it first appears: `server/mdm/android/`
+itself contains no license checks, but Android tier gating already exists outside the bounded context —
+`fleet.AndroidPremiumOnlyJSONKeys` (`server/fleet/android.go:59`, enforced at `:87`) gates `systemUpdate`
+in Android profiles, and `ee/server/service/` does hold Android code (`service.go:47` carries
+`androidModule android.Service`; `hosts.go` dispatches Android lock/wipe; `mdm.go` has
+`clearPasscodeAndroid`). Gating outside the bounded context, with the module injected into the EE service,
+*is* the pattern. Note the counter-precedent that Android COBO wipe was deliberately moved to Free
+(commit `fa7d9282359`), so the product call is genuinely open even though the mechanism is not.
 
 ### Enrollment path changes
 
@@ -739,22 +860,42 @@ New types, documented in `docs/Contributing/reference/audit-logs.md`: `enabled_a
 
 ### GitOps
 
+**There is no top-level `mdm:` key in Fleet GitOps.** Valid top-level keys are enumerated at
+`pkg/spec/gitops.go:522`: `name`, `settings`, `org_settings`, `agent_options`, `controls`, `policies`,
+`reports`, `software`, `labels`, `custom_host_vitals`. Existing Android settings live under
+`controls.android_settings`, and MDM connector configuration under `org_settings.mdm`, which is
+`default.yml`-only — `pkg/spec/gitops.go:536` rejects `org_settings` in a file that has `name`.
+
+That forces a choice, and it should be made deliberately rather than by picking whichever shape looks
+tidiest:
+
+- **Connector-shaped** — put it under `org_settings.mdm`, following `apple_business`, which is documented as
+  configurable only for "All fleets." Global credential plus per-team configuration then cannot both live in
+  YAML, so per-team settings would need another home.
+- **Controls-shaped** — put per-team settings under `controls.android_settings.zero_touch`, which works in
+  `default.yml`, `teams/*.yml`, and `teams/no-team.yml`, with the credential handled separately under
+  `org_settings.mdm`.
+
+Controls-shaped is the better fit, because the per-team configuration is the part that benefits from being
+declarative. Sketch:
+
 ```yaml
-mdm:
-  android_zero_touch:
-    management_mode: fully_managed   # fully_managed | work_profile | dedicated
-    company_name: "Acme Corp"
-    contact_email: "it@acme.example.com"
-    contact_phone: "+1 555 0100"
-    custom_message: "Contact IT if setup does not complete."
-    default: true                    # at most one team may set this
-    forced_reset_time: 2h
+controls:
+  android_settings:
+    zero_touch:
+      management_mode: fully_managed   # maps to allowPersonalUsage
+      company_name: "Acme Corp"
+      contact_email: "it@acme.example.com"
+      contact_phone: "+1 555 0100"
+      custom_message: "Contact IT if setup does not complete."
+      default: true                    # at most one team may set this
+      forced_reset_time: 2h
 ```
 
 Per `CLAUDE.md`'s GitOps notes, two cases need explicit tests: **removal** — deleting the key must delete
-the Google-side configuration, the classic `apply`-inherited bug — and **all three placements**
-(`default.yml`, `teams/*.yml`, `teams/no-team.yml`). Validate that at most one team claims
-`default: true`, within the incoming payload rather than against the DB.
+the Google-side configuration, the classic `apply`-inherited bug — and each placement the chosen shape
+actually supports. Validate that at most one team claims `default: true`, within the incoming payload rather
+than against the DB.
 
 ### Frontend
 
@@ -787,15 +928,19 @@ new keys.
 **Phase 1 — manual configuration, no new Google API.** Long-lived reusable tokens; the v2 team-identity
 fix; re-issue on enroll-secret rotation; DPC extras generation and display; docs.
 
-**Phase 2 — customer API integration.** Credential upload and validation; client package and mock;
-configuration table; create/patch/delete from Fleet; reconciliation cron; activities; ToS handling; UI;
-the turn-off guard.
+**Phase 1a — answer the iframe question.** Days, not weeks. Determine whether the zero-touch iframe can
+carry per-team provisioning extras. A yes reshapes Phase 2 into "wire up `enterprises.webTokens.create` and
+render an iframe" and deletes the credential workstream; a no confirms the provisioning-API path below.
+
+**Phase 2 — customer API integration** (only if the iframe cannot do per-team). Credential upload and
+validation; client package and mock; configuration table; create/patch/delete from Fleet; reconciliation
+cron; activities; ToS handling; UI; the turn-off guard **and the `cleanup_android_enterprise` cron guard**.
 
 **Phase 3 — device-level management.** Device list sync, pending hosts, per-device override, host
 correlation, hosts-list integration.
 
 **Phase 4 — parity.** GitOps, fleetctl, dedicated-device support, optional provisioning extras, and — only
-if demanded — `signinDetail` authentication.
+if `googleAuthenticationOptions` proves insufficient — `signinDetail` authentication.
 
 Phase 1 is independently shippable and worth doing even if Phases 2–4 never are.
 
@@ -805,7 +950,7 @@ Phase 1 is independently shippable and worth doing even if Phases 2–4 never ar
 | --- | --- | --- |
 | Enroll secret rotated while a zero-touch token is live | Devices enroll into AMAPI but never become Fleet hosts — silent, delayed | v2 `team_id` fix plus re-issue on rotation. **Highest-severity item here** |
 | Admin edits or deletes the configuration in Google's portal | Fleet's view is wrong; devices provision with stale extras or not at all | Cron detects drift, restores, records `sync_error` |
-| Team deleted in Fleet | Orphaned Google configuration | `ON DELETE CASCADE` plus a cron pass to delete the Google-side object |
+| Team deleted in Fleet | Orphaned Google configuration | Needs a tombstone, or `ON DELETE SET NULL` rather than `CASCADE`. **`CASCADE` is wrong**: once the row is gone Fleet cannot tell it created the Google-side configuration, colliding with the "never delete what Fleet did not create" rule below |
 | Team was the zero-touch default | New purchases have no default | Refuse deletion, or reassign the default and warn |
 | Token expires | All zero-touch provisioning fails at once, fleet-wide | Rotate 30 days early; treat approaching expiry as a monitored condition |
 | Google ToS updated | Every API call 403s mid-life | Detect `TosError` with `X-GOOG-API-FORMAT-VERSION: 2`; surface an actionable banner |
@@ -816,8 +961,8 @@ Phase 1 is independently shippable and worth doing even if Phases 2–4 never ar
 | Device factory reset | Re-provisions via zero-touch | `GetAndroidDeviceLastTeamID` restores the last-known team; keep that precedence |
 | Device unclaimed at the reseller | Zero-touch stops applying; re-registration needs the reseller | Reconcile removals; mark the pending device gone rather than deleting history |
 | Device never boots | Pending host lingers | Show claim age; allow dismissal |
-| Configuration applied to a device already in service | **Factory reset, destroying end-user data**, after a one-hour warning on next contact with Google | Treat `applyConfiguration` and default changes as destructive: warning plus confirmation |
-| No network during setup | Zero-touch skipped, device boots unmanaged, then self-resets on first connection to Google | Expose `forcedResetTime`; document both reset mechanisms |
+| Configuration applied to a device already in service | Nothing until the device's next factory reset — so an admin may expect an immediate change and see none | State in the UI that assignment takes effect at next reset. Google is silent on edge states here; verify |
+| No network during setup | Zero-touch skipped, device boots unmanaged, then self-resets on first connection to Google after a one-hour warning | Expose `forcedResetTime`; document all three reset triggers |
 | Serial number missing, substituted, or mismatched | Pending device never correlates, or a duplicate host appears | Multi-key correlation with normalization; prefer no match over a wrong one |
 | `additionalData` exceeds 1024 chars | Token creation fails | Validate length before the API call |
 | Non-GMS or pre-8.0 device | Zero-touch does not apply | Document; nothing Fleet can do |
@@ -853,7 +998,10 @@ Phase 1 is independently shippable and worth doing even if Phases 2–4 never ar
   lets an attacker enroll arbitrary devices into a team, polluting inventory and potentially pulling
   team-scoped configuration profiles. Since Android profiles support variables and certificate templates,
   that warrants a threat-model review.
-- Never place the Fleet enroll secret, IdP credentials, or any Fleet API token in `dpcExtras`.
+- Never place the Fleet enroll secret, IdP credentials, or any Fleet API token in `dpcExtras`. Google gives
+  the reason, which is stronger than a general secrets-hygiene argument: "A masquerading device may be able
+  to use a false IMEI or serial number to read the configuration." Configuration contents are effectively
+  readable by anyone who can guess a claimed device's hardware ID.
 - Service-account keys and refresh tokens go in `mdm_config_assets`, never `app_config_json`, and must be
   redacted from logs and API responses. `ProxyClient`'s logger already shows the redaction pattern for
   `Authorization` headers (`proxy_client.go:46`).
@@ -871,19 +1019,26 @@ needs hardware to settle, it is flagged in place in the section it affects — s
 `dpcExtras` payload, `signinDetail` with zero-touch, service-account linking, and post-offboarding device
 state. The questions below are the ones that block decisions.
 
-1. **Credential model** — Option A or B? Blocks Phase 2. Needs Google's Android Enterprise partner team on
-   two points: whether customer-account service-account linking is still a Google Form, and whether
-   `androidworkzerotouchemm` is a sensitive scope requiring app verification.
-2. **Proxy divergence** — is "zero-touch goes direct to Google" acceptable to Fleet Cloud, given every
-   other Android call is proxied?
-3. **Tier gating** — Premium or Free, and by what mechanism, given the Android bounded context has none?
-4. **End-user authentication** — is user-attributed zero-touch a requirement? If so, specify
-   `signinDetail` before Phase 1 locks the token model.
-5. **Pending hosts** — ship in Phase 3 or defer until real device data exists?
-6. **Multiple customer accounts** — can one organization hold several (per reseller, per region)?
+1. **Can the zero-touch iframe carry per-team provisioning extras?** Answer this first — it is cheap, and a
+   yes removes the whole credential problem along with open question 2. Specifically: can more than one
+   configuration exist per enterprise via the iframe, and can `dpcExtras` differ per team across renderings?
+2. **Credential model, if the iframe cannot do per-team** — Option A or B? Needs Google's Android Enterprise
+   partner team on two points: whether customer-account service-account linking is still a Google Form, and
+   whether `androidworkzerotouchemm` is a sensitive scope requiring app verification.
+3. **Proxy divergence** — under Options A and B, is "provisioning API goes direct to Google" acceptable to
+   Fleet Cloud, given every other Android call is proxied? Moot under the iframe.
+4. **Does `googleAuthenticationOptions` satisfy the end-user-authentication requirement?** If yes,
+   `signinDetail` drops out of scope entirely and a library bump replaces a multi-week sub-project.
+5. **Tier gating** — Premium or Free? The mechanism already exists (see the service-layer section); this is
+   purely a product call, weighed against the deliberate decision to make Android COBO wipe Free.
+6. **End-user authentication** — is user-attributed zero-touch a requirement at all? If it is, question 4
+   determines whether it costs a library bump or a multi-week sub-project. Settle this before Phase 1 locks
+   the token model.
+7. **Pending hosts** — ship in Phase 3 or defer until real device data exists?
+8. **Multiple customer accounts** — can one organization hold several (per reseller, per region)?
    `customers.list` is paginated and returns every account the caller belongs to; Google's own quickstarts
    take the first element. Fleet must not do that silently.
-7. **Dedicated devices** — COSU in the first release or deferred? Affects whether management mode must be
+9. **Dedicated devices** — COSU in the first release or deferred? Affects whether management mode must be
    per-configuration rather than per-team.
 
 ## Effort estimate
@@ -894,11 +1049,13 @@ obtaining a Google test account — both on the critical path with external late
 | Phase | Backend | Frontend | Notes |
 | --- | --- | --- | --- |
 | 1 — manual configuration | 1–2 weeks | 2–3 days | The `additionalData` fix is most of the risk |
-| 2 — customer API integration | 3–4 weeks | 1–1.5 weeks | Client, mock, migration, cron, endpoints, turn-off guard |
+| 1a — iframe question | 2–3 days | — | Gates the shape of Phase 2 |
+| 2 — customer API integration | 3–4 weeks | 1–1.5 weeks | Client, mock, migration, cron, endpoints, turn-off and cron guards. Substantially smaller, possibly near-zero, if the iframe suffices |
 | 3 — device-level management | 2–3 weeks | 1 week | Correlation is the uncertain part |
 | 4 — parity | 1–2 weeks | 2–3 days | Excludes `signinDetail` |
 
-`signinDetail` authentication, if required, adds 3–4 weeks and should be scoped separately.
+`signinDetail` authentication, if genuinely required, adds 3–4 weeks and should be scoped separately — but
+check `googleAuthenticationOptions` first, which is a library bump plus a field.
 
 ## References
 
@@ -910,7 +1067,9 @@ obtaining a Google test account — both on the critical path with external late
 - [Customer API reference](https://developers.google.com/zero-touch/reference/customer/rest)
 - [`customers.configurations`](https://developers.google.com/zero-touch/reference/customer/rest/v1/customers.configurations)
 - [`customers.devices`](https://developers.google.com/zero-touch/reference/customer/rest/v1/customers.devices)
-- [Authorization](https://developers.google.com/zero-touch/guides/auth)
+- [Authorization — reseller API](https://developers.google.com/zero-touch/guides/auth) (documents the
+  `androidworkprovisioning` scope; the customer-API guides live under `/zero-touch/guides/customer/`)
+- [Zero-touch iframe for AMAPI](https://developers.google.com/android/management/zero-touch-iframe)
 - [Service accounts for customers](https://developers.google.com/zero-touch/guides/customer/service-accounts)
 - [Python quickstart with a service account](https://developers.google.com/zero-touch/guides/customer/quickstart/python-service-account)
 - [Zero-touch enrollment for IT admins](https://support.google.com/work/android/answer/7514005)

--- a/docs/Contributing/research/mdm/android-zero-touch-enrollment.md
+++ b/docs/Contributing/research/mdm/android-zero-touch-enrollment.md
@@ -46,7 +46,6 @@ proves the token and team-mapping model before the credential decision is made.
 - [Edge cases and failure modes](#edge-cases-and-failure-modes)
 - [Testing plan](#testing-plan)
 - [Security considerations](#security-considerations)
-- [Unverified claims](#unverified-claims)
 - [Open questions](#open-questions)
 - [Effort estimate](#effort-estimate)
 - [References](#references)
@@ -828,6 +827,10 @@ Phase 1 is independently shippable and worth doing even if Phases 2–4 never ar
 - **Unit** — table-driven `t.Run` subtests over the client interface via the new mock. Cover configuration
   diffing, default-configuration transitions, rotation ordering (patch before delete), `additionalData`
   v1/v2 parsing, and serial normalization.
+- **Behaviour to pin down against the real API before relying on it** — whether
+  `customers.devices:removeConfiguration` leaves the device with no configuration or falls back to the
+  account default. Google documents only "Removes a configuration from device," and the answer determines
+  whether removing a team's configuration silently re-homes its devices into the default team.
 - **Enroll-secret rotation regression** — create a zero-touch token, rotate the team's enroll secret,
   deliver a synthetic `ENROLLMENT` notification, assert the host lands in the right team. This test is the
   reason to do the work.
@@ -860,31 +863,17 @@ Phase 1 is independently shippable and worth doing even if Phases 2–4 never ar
   confirmation.
 - Run a `fleet-security-auditor` pass before merge.
 
-## Unverified claims
-
-Everything else in this document is drawn from Google's published reference documentation or from Fleet's
-source. These specific points are inference or contested and must be confirmed before they are relied on:
-
-1. **Whether `signinEnrollmentToken` works in `dpcExtras`** to drive sign-in-URL authentication from
-   zero-touch. Google documents the two methods separately and does not describe combining them.
-2. **The correct `dpcExtras` payload**, given that the AMAPI provisioning guide and the zero-touch EMM
-   guide contradict each other on whether to include the device-admin component name and signature
-   checksum. Test on hardware.
-3. **Whether customer-account service-account linking is still a Google Form.** The documentation says so;
-   the reseller portal has a self-service screen and the customer portal may have gained parity.
-4. **Whether `androidworkzerotouchemm` is a sensitive scope** requiring Google app verification for
-   Option B.
-5. **What state devices land in after a cascaded `enterprises.delete`** — unmanaged, orphaned, or
-   requiring a reset.
-6. **Whether serial/IMEI correlation is reliable across OEMs** well enough to build pending hosts on.
-7. **Google's rate limits for the provisioning API**, which determine the cron interval.
-8. **Whether `removeConfiguration` falls back to the default configuration** or leaves the device with
-   none. Google documents only "Removes a configuration from device."
-
 ## Open questions
 
+Claims in this document come from Google's published reference documentation or from Fleet's source, except
+where the text says otherwise. Where something is inference, contested between Google's own documents, or
+needs hardware to settle, it is flagged in place in the section it affects — see in particular the
+`dpcExtras` payload, `signinDetail` with zero-touch, service-account linking, and post-offboarding device
+state. The questions below are the ones that block decisions.
+
 1. **Credential model** — Option A or B? Blocks Phase 2. Needs Google's Android Enterprise partner team on
-   items 3 and 4 above.
+   two points: whether customer-account service-account linking is still a Google Form, and whether
+   `androidworkzerotouchemm` is a sensitive scope requiring app verification.
 2. **Proxy divergence** — is "zero-touch goes direct to Google" acceptable to Fleet Cloud, given every
    other Android call is proxied?
 3. **Tier gating** — Premium or Free, and by what mechanism, given the Android bounded context has none?


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #49995

Research/design doc for the POC: what it would take for Fleet to support Google Android zero-touch enrollment, so a device bought from a zero-touch reseller provisions itself into the correct Fleet team on first boot with no admin involvement.

Docs-only — no product code, schema, config, or API changes. The SQL, endpoint list, and Go interfaces are proposals, not implementations. Draft, because one cheap question (below) should be answered before any of this is built, and it changes the shape of the work.

Feeds the TODOs in the parent story #49165.

## The short version

Zero-touch is not a new MDM protocol. Google's provisioning service pre-stages the same AMAPI enrollment token Fleet already mints and delivers it to the device instead of a QR code. The device then follows the AMAPI path Fleet already supports, and Fleet is notified by the Pub/Sub `ENROLLMENT` message it already handles. Profiles, software, commands, and host vitals are reused unchanged.

## Answer this before building anything: the zero-touch iframe

Google ships a path purpose-built for AMAPI EMMs that may remove the largest risk in this project.

Fleet calls `enterprises.webTokens.create` with `iframeFeature: 'ZERO_TOUCH'` and embeds `enterprise.google.com/android/zero-touch/embedded/companyhome` with `dpcId` and a `dpcExtras` URL parameter. The admin links their own zero-touch account from inside the iframe.

`webTokens.create` is an **AMAPI** call. So it routes through Fleet's existing proxy with the existing credential: no customer-supplied credential, no Google Form, no OAuth client, no new API integration, no new secret to store. That cuts straight through what the doc otherwise has to treat as its biggest open question.

The catch is real: *"The zero-touch iframe automatically generates a zero-touch configuration. This configuration is not modifiable by the IT admin."* Fleet sets the extras once via the URL parameter and otherwise doesn't control the configuration — which may rule out the configuration-per-team model the rest of the design is built on, and with it per-device team assignment, pending hosts, and drift detection.

**So the question is:** can the iframe carry per-team provisioning extras — more than one configuration per enterprise, with `dpcExtras` varying per team across renderings? It's days of work to answer. A yes makes the iframe the primary path and deletes the entire credential workstream. A no confirms the provisioning-API design and the credential decision stands. The doc adds this as **Phase 1a** and open question 1 rather than guessing.

I kept the per-team design as the primary proposal rather than rewriting around the iframe, because trading a verified design for an unverified one would be the wrong call before that question is answered. If it comes back yes, the Design section needs a real rewrite, not a patch.

## Two findings that change scope

**1. Long-lived tokens break under enroll secret rotation.** `addNewHost` hard-fails when `VerifyEnrollSecret` doesn't match (`pubsub.go:908`), and the enroll secret is embedded in `additionalData`. Fine for a 1-hour QR token. For a token sitting in a zero-touch configuration for a year, rotating that team's enroll secret means **every device Fleet has never seen before** enrolls into AMAPI and then silently fails to become a Fleet host — managed by Google, invisible in Fleet, visible only as a repeating Pub/Sub error.

Scope matters here: `enrollHost` tolerates the failure for hosts Fleet already knows (`pubsub.go:628`), so a factory-reset device survives on its last-known team. The breakage lands on new hardware out of the box, which is the primary zero-touch case. Correctness prerequisite, not an enhancement.

**2. Deleting the AMAPI enterprise breaks zero-touch fleet-wide, and it isn't only reachable from the UI.** `enterprises.delete` cascades to all devices, invalidating the enrollment token still embedded in the customer's zero-touch configurations. Each device then fails at its *next* factory reset, possibly months later, with no obvious link to the cause.

`Service.DeleteEnterprise` (`service.go:424`) runs on admin turn-off, but there's a second caller at `service.go:820` via `VerifyExistingEnterpriseIfAny`, driven by the `cleanup_android_enterprise` cron (`cron.go:1600`). A UI-only guard leaves the cascade reachable from a background job — the worse case, because no one is watching. Both paths need guarding; marked a Phase 2 release blocker.

## Decisions needed

1. **Can the iframe do per-team extras?** Above. Answer first.
2. **Credential model, only if it can't** — service-account key (fits the cron, but linking it to a *customer* account is currently a Google Form plus email confirmation) or interactive OAuth (self-service, but bound to one human's Google account and probably needs scope verification). Needs Google's Android Enterprise partner team.
3. **Proxy divergence, only under those two options** — the customer's zero-touch account is theirs, and a shared Fleet service account linked to many customers would make `customers.list` return every tenant to every caller. The doc rejects that and goes direct to Google. Moot under the iframe.
4. **Tier gating** — Premium or Free? The mechanism already exists (`AndroidPremiumOnlyJSONKeys`, plus Android code in `ee/server/service/`), so this is purely a product call, weighed against the deliberate decision to make Android COBO wipe Free.

## Worth knowing regardless of whether we build this

- **Zero-touch is procurement-linked, not a migration path.** Only resellers can register devices, so an existing Android fleet generally can't be moved onto it. Google's newer "automatic zero-touch enrollment" framing still requires reseller registration. (Google's own how-it-works page contradicts itself on this — it also says organizations can create devices in the portal. The doc flags the contradiction.)
- **QR enrollment is not a substitute for the security property.** A QR-enrolled device that's factory reset boots unmanaged; a zero-touch device re-provisions itself. Same management end state, different tamper resistance — these lead to different purchasing decisions and shouldn't be conflated in messaging.
- **Assigning a configuration takes effect at the next factory reset, not immediately.** Worth stating in the UI, since an admin may expect an immediate change and see none. Google is silent on what happens to an already-provisioned device that is later assigned one, so this is documented behaviour rather than a guarantee about every state.
- **Migrating away from Fleet is clean on the zero-touch side.** The customer owns the claim and can repoint `dpcExtras` at another EMM without Fleet's cooperation. The per-device factory reset migration requires is a universal Android Enterprise constraint, not ours.
- **Google's own docs contradict each other on the `dpcExtras` payload.** The AMAPI provisioning guide's example includes the device-admin component name and signature checksum; the zero-touch EMM guide advises against exactly those extras. Follow the AMAPI guide and verify on hardware — a wrong payload fails on-device, where it's expensive to debug.
- **End-user authentication may be much cheaper than assumed.** `googleAuthenticationOptions` on the enrollment token gives account-attributed enrollment with no device-facing web flow — a library bump plus a field, versus a multi-week `signinDetail` sub-project. Evaluate it first.

## Phasing

**Phase 1** ships usable zero-touch with no Google API integration: long-lived reusable tokens, the `additionalData` team-identity fix, and Fleet emitting the `dpcExtras` JSON for the admin to paste into Google's portal once per team. ~1–2 weeks, independently shippable, and everything it forces us to get right is reused by every other option.

**Phase 1a** (2–3 days) answers the iframe question and determines the shape of Phase 2. Phases 2–4 then add the customer API (or the iframe), pending hosts, and GitOps/fleetctl parity.

## Provenance

Every code citation has been verified against the tree and every API claim against Google's reference docs and the generated client library. One detail worth flagging because it is easy to get wrong and the design depends on it: `additionalData` is `{"EnrollSecret","FullyManaged","IdpUUID"}` on the wire, because the struct carries `query:` tags and no `json:` tags — so any versioning scheme has to be built against that shape, not the snake_case one the field names suggest.

Claims are sourced from Google's reference docs or Fleet's source unless the text says otherwise. Where something is inference, contested between Google's own documents, or needs hardware to settle, it's flagged in place, and **Open questions** collects the ones that block decisions. Three need hands-on verification rather than more reading: whether the iframe supports per-team extras, whether serial/IMEI correlation is reliable enough across OEMs to build pending hosts on, and what state devices land in after a cascaded enterprise deletion.

# Checklist for submitter

- [x] Documentation only — no changes file needed (no user-visible product change)
- [x] No code, schema, API, config, or GitOps changes in this PR
- [x] All 35 code citations and both cited commits verified against the tree; all referenced file paths exist
