### PR TITLE
[YAML] Add 'self_service' option to configuration profiles

### DIFF
--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -390,14 +390,17 @@ controls:
   apple_settings:
     configuration_profiles:
       - paths: ../lib/macos/profiles/*.mobileconfig
+        self_service: true
   windows_settings:
     configuration_profiles:
       - paths: ../lib/windows/profiles/*.xml
+        self_service: true
         labels_include_any:
           - Engineering
   android_settings:
     configuration_profiles:
       - path: ../lib/android-profile.json
+        self_service: true
     certificates:
       - name: wifi-certificate
         certificate_authority_name: EST_WIFI
@@ -451,6 +454,8 @@ Each entry can use either `path:` or `paths:`:
 - **`paths:`** accepts a [glob pattern](#path-vs-paths-glob-patterns) to match multiple files (e.g. `../lib/windows/profiles/*.xml`). Labels and other options specified on a `paths:` entry apply to all matched files.
 
 Use `labels_include_all` to target hosts that have all labels, `labels_include_any` to target hosts that have any label, or `labels_exclude_any` to target hosts that don't have any of the labels. Only one of `labels_include_all`, `labels_include_any`, or `labels_exclude_any` can be specified. If none are specified, all hosts are targeted.
+
+Use `self_service` to specify whether end users can manually install from **Fleet Desktop > Controls**. When set to true, profile will not be deployed automatically and is opt-in.
 
 ### android_settings
 
@@ -538,7 +543,7 @@ Currently, you can specify `install_software` in the [`policies` YAML](#policies
 
 Currently, Fleet only allows one package, Apple App Store app, or Fleet-maintained app for a specific software. This means, if you specify a Google Chrome for macOS twice in `packages` or once in `packages` and once in `fleet_maintained_apps`, only one of them will be added to Fleet.
 
-Currently, when a `.ipa` file is added in `packages`, Fleet adds software for both iOS and iPadOS, along with all specified settings (e.g. `self_service`). If software for one platform is deleted in the UI, it will come back when GitOps is re-run.
+Currently, when a `.ipa` file is added in `packages`, Fleet adds software for both iOS and iPadOS, along with all specified settings (e.g. ``). If software for one platform is deleted in the UI, it will come back when GitOps is re-run.
 
 #### Example
 

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -543,7 +543,7 @@ Currently, you can specify `install_software` in the [`policies` YAML](#policies
 
 Currently, Fleet only allows one package, Apple App Store app, or Fleet-maintained app for a specific software. This means, if you specify a Google Chrome for macOS twice in `packages` or once in `packages` and once in `fleet_maintained_apps`, only one of them will be added to Fleet.
 
-Currently, when a `.ipa` file is added in `packages`, Fleet adds software for both iOS and iPadOS, along with all specified settings (e.g. ``). If software for one platform is deleted in the UI, it will come back when GitOps is re-run.
+Currently, when a `.ipa` file is added in `packages`, Fleet adds software for both iOS and iPadOS, along with all specified settings (e.g. `self_service`). If software for one platform is deleted in the UI, it will come back when GitOps is re-run.
 
 #### Example
 

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -450,9 +450,9 @@ controls:
     configuration_profiles:
       - paths: ../lib/macos/profiles/*.mobileconfig
         self_service: true
-        hidden: true
       - paths: ../lib/macos/profiles/*.mobileconfig2
         self_service: false
+        hidden: true
       - path: ../lib/macos/profiles/my-declaration.json
       - paths: ../lib/macos/profiles/ddm.json
         labels_include_any:

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -623,7 +623,7 @@ Currently, you can specify `install_software` in the [`policies` YAML](#policies
 
 Currently, Fleet only allows one package, Apple App Store app, or Fleet-maintained app for a specific software. This means, if you specify a Google Chrome for macOS twice in `packages` or once in `packages` and once in `fleet_maintained_apps`, only one of them will be added to Fleet.
 
-Currently, when a `.ipa` file is added in `packages`, Fleet adds software for both iOS and iPadOS, along with all specified settings (e.g. ``). If software for one platform is deleted in the UI, it will come back when GitOps is re-run.
+Currently, when a `.ipa` file is added in `packages`, Fleet adds software for both iOS and iPadOS, along with all specified settings (e.g. `self_service`). If software for one platform is deleted in the UI, it will come back when GitOps is re-run.
 
 Script-only packages (.sh, .ps1, .py) also support $FLEET_SECRET_* variables. Fleet replaces them with their values when the install script is sent to the host.
 

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -450,6 +450,9 @@ controls:
     configuration_profiles:
       - paths: ../lib/macos/profiles/*.mobileconfig
         self_service: true
+      - paths: ../lib/macos/profiles/*.mobileconfig2
+        self_service: false
+        hidden: true
       - path: ../lib/macos/profiles/my-declaration.json
       - paths: ../lib/macos/profiles/ddm.json
         labels_include_any:
@@ -461,14 +464,12 @@ controls:
   windows_settings:
     configuration_profiles:
       - paths: ../lib/windows/profiles/*.xml
-        self_service: true
         labels_include_any:
           - Engineering
     enable_managed_local_account: true   
   android_settings:
     configuration_profiles:
       - path: ../lib/android-profile.json
-        self_service: true
     certificates:
       - name: wifi-certificate
         certificate_authority_name: EST_WIFI
@@ -535,6 +536,8 @@ In addition to configuration profiles, you can upload **assets** which are `.jso
 > PayloadScope set to "User" in a DDM declaration's top-level JSON is required for user-scoped payloads, see [Custom OS settings](https://fleetdm.com/guides/custom-os-settings#macos) for details.`
 
 Use `self_service` to specify whether end users can manually install from **Fleet Desktop > Controls**. When set to true, profile will not be deployed automatically and is opt-in.
+
+Use `hidden` to specify whether to hide the profile from the end user by default on **Fleet Desktop > Controls**. End users can toggle "Show hidden profiles" in the UI to view all profiles on the host, but these profiles do not require the end user to take any action. `self_service` must be set to `false` (force install of profile) to use this option.
 
 ### android_settings
 

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -450,9 +450,9 @@ controls:
     configuration_profiles:
       - paths: ../lib/macos/profiles/*.mobileconfig
         self_service: true
+        hidden: true
       - paths: ../lib/macos/profiles/*.mobileconfig2
         self_service: false
-        hidden: true
       - path: ../lib/macos/profiles/my-declaration.json
       - paths: ../lib/macos/profiles/ddm.json
         labels_include_any:

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -448,6 +448,9 @@ controls:
     grace_period_days: 2
   apple_settings:
     configuration_profiles:
+      - paths: ../lib/macos/profiles/*.mobileconfig
+        self_service: true
+      - path: ../lib/macos/profiles/my-declaration.json
       - paths: ../lib/macos/profiles/ddm.json
         labels_include_any:
           - Engineering
@@ -458,12 +461,14 @@ controls:
   windows_settings:
     configuration_profiles:
       - paths: ../lib/windows/profiles/*.xml
+        self_service: true
         labels_include_any:
           - Engineering
     enable_managed_local_account: true   
   android_settings:
     configuration_profiles:
       - path: ../lib/android-profile.json
+        self_service: true
     certificates:
       - name: wifi-certificate
         certificate_authority_name: EST_WIFI
@@ -529,6 +534,7 @@ In addition to configuration profiles, you can upload **assets** which are `.jso
 
 > PayloadScope set to "User" in a DDM declaration's top-level JSON is required for user-scoped payloads, see [Custom OS settings](https://fleetdm.com/guides/custom-os-settings#macos) for details.`
 
+Use `self_service` to specify whether end users can manually install from **Fleet Desktop > Controls**. When set to true, profile will not be deployed automatically and is opt-in.
 
 ### android_settings
 
@@ -617,7 +623,7 @@ Currently, you can specify `install_software` in the [`policies` YAML](#policies
 
 Currently, Fleet only allows one package, Apple App Store app, or Fleet-maintained app for a specific software. This means, if you specify a Google Chrome for macOS twice in `packages` or once in `packages` and once in `fleet_maintained_apps`, only one of them will be added to Fleet.
 
-Currently, when a `.ipa` file is added in `packages`, Fleet adds software for both iOS and iPadOS, along with all specified settings (e.g. `self_service`). If software for one platform is deleted in the UI, it will come back when GitOps is re-run.
+Currently, when a `.ipa` file is added in `packages`, Fleet adds software for both iOS and iPadOS, along with all specified settings (e.g. ``). If software for one platform is deleted in the UI, it will come back when GitOps is re-run.
 
 Script-only packages (.sh, .ps1, .py) also support $FLEET_SECRET_* variables. Fleet replaces them with their values when the install script is sent to the host.
 


### PR DESCRIPTION
Added 'self_service' option to configuration profiles for macOS, Windows, and Android settings, allowing end users to manually install profiles. Updated documentation to clarify the behavior of the 'self_service' setting.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #46834