### PR TITLE
Website: Update software-management.ejs so that we mention the 1000+ apps in the catalog

### DIFF
--- a/website/views/pages/software-management.ejs
+++ b/website/views/pages/software-management.ejs
@@ -7,7 +7,7 @@
           <h1>Patch faster on any OS</h1>
         </div>
         <p purpose="hero-text">
-          Deploy software from a built-in catalog or upload your own packages. Fleet checks every device continuously and installs updates automatically.
+          Deploy software from a built-in catalog of <a href="https://fleetdm.com/software-catalog">1,000+ apps</a> or upload your own packages. Fleet checks every device continuously and installs updates automatically on macOS, Windows, and more.
         </p>
         <div purpose="button-row" class="d-flex justify-content-start">
           <a purpose="cta-button" href="/contact?talkToUs">Get a demo</a>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the software management page to link to Fleet’s software catalog.
  * Clarified that the catalog includes 1,000+ apps.
  * Noted automatic updates across macOS, Windows, and additional platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->