### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/adobe-acrobat-reader/windows.json
+++ b/ee/maintained-apps/outputs/adobe-acrobat-reader/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.001.21745",
+      "version": "26.001.21771",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Adobe Acrobat (64-bit)' AND publisher = 'Adobe';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Adobe Acrobat (64-bit)' AND publisher = 'Adobe' AND version_compare(version, '26.001.21745') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Adobe Acrobat (64-bit)' AND publisher = 'Adobe' AND version_compare(version, '26.001.21771') < 0);"
       },
-      "installer_url": "https://ardownload2.adobe.com/pub/adobe/acrobat/win/AcrobatDC/2600121745/AcroRdrDCx642600121745_MUI.exe",
+      "installer_url": "https://ardownload2.adobe.com/pub/adobe/acrobat/win/AcrobatDC/2600121771/AcroRdrDCx642600121771_MUI.exe",
       "install_script_ref": "7dc0b065",
       "uninstall_script_ref": "3bb10c80",
-      "sha256": "4752935149f5128b84ff15d8d18b51da23d52a2f16cebe6d40be22e1c4ae4a41",
+      "sha256": "290696326395fdd08cc11b467372ff68aa5e60e1d577a3910e1103a5690ceb4a",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/beekeeper-studio/darwin.json
+++ b/ee/maintained-apps/outputs/beekeeper-studio/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "5.9.2",
+      "version": "5.9.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'io.beekeeperstudio.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.beekeeperstudio.desktop' AND version_compare(bundle_short_version, '5.9.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.beekeeperstudio.desktop' AND version_compare(bundle_short_version, '5.9.3') < 0);"
       },
-      "installer_url": "https://github.com/beekeeper-studio/beekeeper-studio/releases/download/v5.9.2/Beekeeper-Studio-5.9.2-arm64.dmg",
+      "installer_url": "https://github.com/beekeeper-studio/beekeeper-studio/releases/download/v5.9.3/Beekeeper-Studio-5.9.3-arm64.dmg",
       "install_script_ref": "5d46a1c1",
       "uninstall_script_ref": "eaf45799",
-      "sha256": "b737b2f7782847e5cf073cc148edbe18356316ecf10c82f49d2145f8c4046cc8",
+      "sha256": "0950fd4fc24d93db4956df4371b1726ba90ac4e776e4d6847df22104027eb276",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/boltai/darwin.json
+++ b/ee/maintained-apps/outputs/boltai/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.14.1",
+      "version": "2.14.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'co.podzim.boltai-mobile';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'co.podzim.boltai-mobile' AND version_compare(bundle_short_version, '2.14.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'co.podzim.boltai-mobile' AND version_compare(bundle_short_version, '2.14.2') < 0);"
       },
-      "installer_url": "https://updates.boltai.com/dmg/BoltAI-2.14.1.dmg",
+      "installer_url": "https://updates.boltai.com/dmg/BoltAI-2.14.2.dmg",
       "install_script_ref": "4b6c58a2",
       "uninstall_script_ref": "8c3f3ae8",
-      "sha256": "cc26b01d2d857e092b49fc9268e1702b20fa37757ec713fe6cc8e7d4d01d3f40",
+      "sha256": "21b8e1653a938ad6c178ab58f68e50c139b91a22beb1ec99f563663e68533806",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/chatwise/darwin.json
+++ b/ee/maintained-apps/outputs/chatwise/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.7.6",
+      "version": "26.7.8",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'app.chatwise';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.chatwise' AND version_compare(bundle_short_version, '26.7.6') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.chatwise' AND version_compare(bundle_short_version, '26.7.8') < 0);"
       },
-      "installer_url": "https://releases.chatwise.app/26.7.6/ChatWise-26.7.6-arm64.dmg",
+      "installer_url": "https://releases.chatwise.app/26.7.8/ChatWise-26.7.8-arm64.dmg",
       "install_script_ref": "292ab15f",
       "uninstall_script_ref": "da509fe4",
-      "sha256": "7c6da6f58cde391de3b2708de34225cb1d6a7890ee01b1deaea46b74b1bb3139",
+      "sha256": "ef3e8c0e8685c690bd692bd1d0449f40aa10bb1051af534f00a381271a447d64",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/cmake-app/darwin.json
+++ b/ee/maintained-apps/outputs/cmake-app/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.4.1",
+      "version": "4.4.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.cmake.cmake';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.cmake.cmake' AND version_compare(bundle_short_version, '4.4.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.cmake.cmake' AND version_compare(bundle_short_version, '4.4.2') < 0);"
       },
-      "installer_url": "https://cmake.org/files/v4.4/cmake-4.4.1-macos-universal.dmg",
+      "installer_url": "https://cmake.org/files/v4.4/cmake-4.4.2-macos-universal.dmg",
       "install_script_ref": "bf131a87",
       "uninstall_script_ref": "ff358276",
-      "sha256": "8d14969564edd694b38cfa897a71b5e27236b918b64a4caf617a5b02cdf96425",
+      "sha256": "33d16c2683aee4fe9a8c26c9f2d3003e04391ac4c4f48273ab1cf70e9b0bf679",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/cursor/darwin.json
+++ b/ee/maintained-apps/outputs/cursor/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.13.25",
+      "version": "3.14.7",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92' AND version_compare(bundle_short_version, '3.13.25') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92' AND version_compare(bundle_short_version, '3.14.7') < 0);"
       },
-      "installer_url": "https://downloads.cursor.com/production/31e8d61c448c7472e371505838a0fe34083dad55/darwin/arm64/Cursor-darwin-arm64.zip",
+      "installer_url": "https://downloads.cursor.com/production/a758f2241ca99fecf380180b6cbdbbce0f1f42cf/darwin/arm64/Cursor-darwin-arm64.zip",
       "install_script_ref": "1ae48b55",
       "uninstall_script_ref": "03b9aece",
-      "sha256": "33246714f675efedec0985b13cbc0104873ebfb6501821d5177fbe2fd3f74db8",
+      "sha256": "393dc55f28c13992989ad62f73bb57e46b3600eb33886c15801f5864231ae958",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/cursor/windows.json
+++ b/ee/maintained-apps/outputs/cursor/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.13.25",
+      "version": "3.14.7",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Cursor' AND publisher = 'Anysphere';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Cursor' AND publisher = 'Anysphere' AND version_compare(version, '3.13.25') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Cursor' AND publisher = 'Anysphere' AND version_compare(version, '3.14.7') < 0);"
       },
-      "installer_url": "https://downloads.cursor.com/production/31e8d61c448c7472e371505838a0fe34083dad55/win32/x64/system-setup/CursorSetup-x64-3.13.25.exe",
+      "installer_url": "https://downloads.cursor.com/production/a758f2241ca99fecf380180b6cbdbbce0f1f42cf/win32/x64/system-setup/CursorSetup-x64-3.14.7.exe",
       "install_script_ref": "03589b5e",
       "uninstall_script_ref": "6c8096c5",
-      "sha256": "643acd8962282726a6e379d10d04e6d7def06fe7a2b1efdbdec526b10ff4b11d",
+      "sha256": "9db251bc79311a31c543cd2e3122f85621fff9755ef690e4b2fa47b3106410f5",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/dataflare/darwin.json
+++ b/ee/maintained-apps/outputs/dataflare/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.1.6",
+      "version": "3.1.7",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'app.dataflare.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.dataflare.desktop' AND version_compare(bundle_short_version, '3.1.6') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.dataflare.desktop' AND version_compare(bundle_short_version, '3.1.7') < 0);"
       },
-      "installer_url": "https://assets.dataflare.app/release/darwin/aarch64/Dataflare-3.1.6.dmg",
+      "installer_url": "https://assets.dataflare.app/release/darwin/aarch64/Dataflare-3.1.7.dmg",
       "install_script_ref": "d96ff327",
       "uninstall_script_ref": "bf5b4266",
-      "sha256": "31de1e61c720b56c096ef4c106e1adbb785a078d1f55de003120bff47cbb7641",
+      "sha256": "786baeadb508c179e987d117e1a05d25a86e2f83481b4cb746b3e02fd3f045ec",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/dataflare/windows.json
+++ b/ee/maintained-apps/outputs/dataflare/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.1.6",
+      "version": "3.1.7",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Dataflare' AND publisher = 'Dataflare';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Dataflare' AND publisher = 'Dataflare' AND version_compare(version, '3.1.6') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Dataflare' AND publisher = 'Dataflare' AND version_compare(version, '3.1.7') < 0);"
       },
-      "installer_url": "https://assets.dataflare.app/release/windows/x86_64/Dataflare-Setup-3.1.6.exe",
+      "installer_url": "https://assets.dataflare.app/release/windows/x86_64/Dataflare-Setup-3.1.7.exe",
       "install_script_ref": "a5276316",
       "uninstall_script_ref": "4710d9ad",
-      "sha256": "a57017433f3e277cd9ef8f9a9765b8612a510088aab0fa58e32e1de6d6d7e10d",
+      "sha256": "946c910cd41805b5cfe3ca8d978483eb2b7f8cb5d694f5e8327c6c5c02fd0a74",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/eclipse-temurin-jdk-8/windows.json
+++ b/ee/maintained-apps/outputs/eclipse-temurin-jdk-8/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "8.0.492.9",
+      "version": "8.0.502.7",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Eclipse Temurin JDK%' AND publisher = 'Eclipse Adoptium' AND version LIKE '8.%';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Eclipse Temurin JDK%' AND publisher = 'Eclipse Adoptium' AND version LIKE '8.%' AND version_compare(version, '8.0.492.9') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Eclipse Temurin JDK%' AND publisher = 'Eclipse Adoptium' AND version LIKE '8.%' AND version_compare(version, '8.0.502.7') < 0);"
       },
-      "installer_url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u492-b09/OpenJDK8U-jdk_x64_windows_hotspot_8u492b09.msi",
+      "installer_url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u502-b07/OpenJDK8U-jdk_x64_windows_hotspot_8u502b07.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "fb42ab0d",
-      "sha256": "e931546f0557e0735472e99c5f0a62d34854ab8a2fee9709bfcbc7ea6dcc5172",
+      "sha256": "3888c5a2c851587c06262fb225f4c8098c6096f30aff1808b171c1c8f184e358",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/eclipse-temurin-jre-8/windows.json
+++ b/ee/maintained-apps/outputs/eclipse-temurin-jre-8/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "8.0.492.9",
+      "version": "8.0.502.7",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Eclipse Temurin JRE%' AND publisher = 'Eclipse Adoptium' AND version LIKE '8.%';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Eclipse Temurin JRE%' AND publisher = 'Eclipse Adoptium' AND version LIKE '8.%' AND version_compare(version, '8.0.492.9') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Eclipse Temurin JRE%' AND publisher = 'Eclipse Adoptium' AND version LIKE '8.%' AND version_compare(version, '8.0.502.7') < 0);"
       },
-      "installer_url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u492-b09/OpenJDK8U-jre_x64_windows_hotspot_8u492b09.msi",
+      "installer_url": "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u502-b07/OpenJDK8U-jre_x64_windows_hotspot_8u502b07.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "24e08f0a",
-      "sha256": "b606dcaef8d8896be34e18dbd536437b03761411c7b0a992bcdd6c0962a53edc",
+      "sha256": "d10ea23f35e10be60775bdff2ea858f4d56fd59e2d7b2c75b61412465fea1fe6",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/firefox@developer-edition/darwin.json
+++ b/ee/maintained-apps/outputs/firefox@developer-edition/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "154.0b4",
+      "version": "154.0b5",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefoxdeveloperedition';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefoxdeveloperedition' AND version_compare(bundle_version, '15426.7.29') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefoxdeveloperedition' AND version_compare(bundle_version, '15426.7.31') < 0);"
       },
-      "installer_url": "https://download-installer.cdn.mozilla.net/pub/devedition/releases/154.0b4/mac/en-US/Firefox%20154.0b4.dmg",
+      "installer_url": "https://download-installer.cdn.mozilla.net/pub/devedition/releases/154.0b5/mac/en-US/Firefox%20154.0b5.dmg",
       "install_script_ref": "b679ecd7",
       "uninstall_script_ref": "292c5733",
-      "sha256": "725eedb303b8908575fe66eba6a9ec404c896011052dfab3794ffa88964d5359",
+      "sha256": "7fdaf6e951982776d6a1bc129334ea5990ce1d2580f24702b3d23807c4d365fa",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/firefox@nightly/darwin.json
+++ b/ee/maintained-apps/outputs/firefox@nightly/darwin.json
@@ -4,12 +4,12 @@
       "version": "155.0a1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15526.7.30') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15526.7.31') < 0);"
       },
-      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/07/2026-07-30-21-43-47-mozilla-central/firefox-155.0a1.en-US.mac.dmg",
+      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/07/2026-07-31-08-57-38-mozilla-central/firefox-155.0a1.en-US.mac.dmg",
       "install_script_ref": "d9c4cf87",
       "uninstall_script_ref": "0661f848",
-      "sha256": "8dc3ba7bdeb144f4b255e80ad6f1a91d362d87f1dbc43c9394414c4e1f4e7fb8",
+      "sha256": "926bafc758a9d912c00dae9f6cddedfcb8fb7f0c7d996021823343802e318641",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/imazing/windows.json
+++ b/ee/maintained-apps/outputs/imazing/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.5.5.0",
+      "version": "3.3.1.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'iMazing' AND publisher = 'DigiDNA';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'iMazing' AND publisher = 'DigiDNA' AND version_compare(version, '3.5.5.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'iMazing' AND publisher = 'DigiDNA' AND version_compare(version, '3.3.1.0') < 0);"
       },
-      "installer_url": "https://downloads.imazing.com/windows/iMazing/iMazing3forWindows.exe",
+      "installer_url": "https://downloads.imazing.com/windows/iMazing/3.3.1/iMazing_3.3.1.exe",
       "install_script_ref": "145b29b1",
       "uninstall_script_ref": "a8fdf759",
-      "sha256": "f0d4b2869f0beff57b0879713d041f09e2c26651f21719c612ce58220d535986",
+      "sha256": "9913a5b076b13bed7036120b1135316ceb6785bff6398eda7457194e0d2821a6",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/krita/darwin.json
+++ b/ee/maintained-apps/outputs/krita/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "5.3.2.1",
+      "version": "5.3.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.kde.krita';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.kde.krita' AND version_compare(bundle_short_version, '5.3.2.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.kde.krita' AND version_compare(bundle_short_version, '5.3.3') < 0);"
       },
-      "installer_url": "https://download.kde.org/stable/krita/5.3.2.1/krita-5.3.2.1-signed.dmg",
+      "installer_url": "https://download.kde.org/stable/krita/5.3.3/krita-5.3.3-signed.dmg",
       "install_script_ref": "cdb966e7",
       "uninstall_script_ref": "7b9f27dc",
-      "sha256": "94cb787aba6a18601646c040fe28ce327f83b60a72cd44bb56c98fbdec67c700",
+      "sha256": "625e37c01cfb74094ae58353dd9d343cd389a00c33cb65d6ddf1f2f1e2bc3a19",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/mockoon/darwin.json
+++ b/ee/maintained-apps/outputs/mockoon/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "9.7.0",
+      "version": "9.8.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.mockoon.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.mockoon.app' AND version_compare(bundle_short_version, '9.7.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.mockoon.app' AND version_compare(bundle_short_version, '9.8.0') < 0);"
       },
-      "installer_url": "https://github.com/mockoon/mockoon/releases/download/v9.7.0/mockoon.setup.9.7.0.arm64.dmg",
+      "installer_url": "https://github.com/mockoon/mockoon/releases/download/v9.8.0/mockoon.setup.9.8.0.arm64.dmg",
       "install_script_ref": "ced539a3",
       "uninstall_script_ref": "69ac3b20",
-      "sha256": "ebb05ad602b1a4df68e0b633027d4011fb335f9539b0a2ed1c1a28d9523934ac",
+      "sha256": "99c0a347b5e8c39b6f2c3059b7d4fd2b2a012af90f36ee08fbfbd65417c64d2b",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/netron/darwin.json
+++ b/ee/maintained-apps/outputs/netron/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "9.1.9",
+      "version": "9.2.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.lutzroeder.netron';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.lutzroeder.netron' AND version_compare(bundle_short_version, '9.1.9') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.lutzroeder.netron' AND version_compare(bundle_short_version, '9.2.0') < 0);"
       },
-      "installer_url": "https://github.com/lutzroeder/netron/releases/download/v9.1.9/Netron-9.1.9-mac.zip",
+      "installer_url": "https://github.com/lutzroeder/netron/releases/download/v9.2.0/Netron-9.2.0-mac.zip",
       "install_script_ref": "ee434397",
       "uninstall_script_ref": "acbbb0d7",
-      "sha256": "a011cb524d557edb7bb2bc5cd349fa0098fa624265f8081bc0c65ba2661976da",
+      "sha256": "be72b8a2d942cc41469eee08818bfd5ea4ff9bb168eba3e2390d6cf32b27785b",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/notesnook/darwin.json
+++ b/ee/maintained-apps/outputs/notesnook/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.4.3",
+      "version": "3.4.5",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.streetwriters.notesnook';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.streetwriters.notesnook' AND version_compare(bundle_short_version, '3.4.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.streetwriters.notesnook' AND version_compare(bundle_short_version, '3.4.5') < 0);"
       },
-      "installer_url": "https://github.com/streetwriters/notesnook/releases/download/v3.4.3/notesnook_mac_arm64.dmg",
+      "installer_url": "https://github.com/streetwriters/notesnook/releases/download/v3.4.5/notesnook_mac_arm64.dmg",
       "install_script_ref": "61e13773",
       "uninstall_script_ref": "181a288a",
-      "sha256": "b20a57f06475fc6e7e1aeff24add994991729521aaad10259d47ca8b99cda077",
+      "sha256": "c70f28486a93a2f0a2a11bba15529922b16b684ef63f03efa999ace7e2b74bf3",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/pgadmin4/darwin.json
+++ b/ee/maintained-apps/outputs/pgadmin4/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "9.16",
+      "version": "9.17",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.pgadmin.pgadmin4';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.pgadmin.pgadmin4' AND version_compare(bundle_short_version, '9.16') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.pgadmin.pgadmin4' AND version_compare(bundle_short_version, '9.17') < 0);"
       },
-      "installer_url": "https://ftp.postgresql.org/pub/pgadmin/pgadmin4/v9.16/macos/pgadmin4-9.16-arm64.dmg",
+      "installer_url": "https://ftp.postgresql.org/pub/pgadmin/pgadmin4/v9.17/macos/pgadmin4-9.17-arm64.dmg",
       "install_script_ref": "d04370f3",
       "uninstall_script_ref": "212c6861",
-      "sha256": "ba8da45576cae9ed91b23d67094c97de1daf3b793b42a4fe65c1ff1a120ea174",
+      "sha256": "c49fe899451596ffcf18dbf4c452c89bcec3082dbc31838d46b7dbda792d84df",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/pgadmin4/windows.json
+++ b/ee/maintained-apps/outputs/pgadmin4/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "9.16",
+      "version": "9.17",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'pgAdmin 4 %' AND publisher = 'The pgAdmin Development Team';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'pgAdmin 4 %' AND publisher = 'The pgAdmin Development Team' AND version_compare(version, '9.16') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'pgAdmin 4 %' AND publisher = 'The pgAdmin Development Team' AND version_compare(version, '9.17') < 0);"
       },
-      "installer_url": "https://ftp.postgresql.org/pub/pgadmin/pgadmin4/v9.16/windows/pgadmin4-9.16-x64.exe",
+      "installer_url": "https://ftp.postgresql.org/pub/pgadmin/pgadmin4/v9.17/windows/pgadmin4-9.17-x64.exe",
       "install_script_ref": "632aa4d1",
       "uninstall_script_ref": "912990ef",
-      "sha256": "06a0e2f2586099e038d7dc34da20f94f86465696c0238e9c86032bc933d00067",
+      "sha256": "f152ab1666d4b4182f5e550d05840c7a05123c77fb992591086ab5e73758300f",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/podman-desktop/darwin.json
+++ b/ee/maintained-apps/outputs/podman-desktop/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.29.0",
+      "version": "1.29.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'io.podmandesktop.PodmanDesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.podmandesktop.PodmanDesktop' AND version_compare(bundle_short_version, '1.29.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.podmandesktop.PodmanDesktop' AND version_compare(bundle_short_version, '1.29.1') < 0);"
       },
-      "installer_url": "https://github.com/containers/podman-desktop/releases/download/v1.29.0/podman-desktop-1.29.0-arm64.dmg",
+      "installer_url": "https://github.com/containers/podman-desktop/releases/download/v1.29.1/podman-desktop-1.29.1-arm64.dmg",
       "install_script_ref": "e5a669f0",
       "uninstall_script_ref": "d4656e95",
-      "sha256": "e3df690297c24ae7a8555eedbf7e84cbc89fa1466366ec56b6b479b43bfa2d01",
+      "sha256": "8521dbfe1b22e5f9d9c46f613f0b576263494c7e8a8ab60cd8347e46aae3930b",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/podman-desktop/windows.json
+++ b/ee/maintained-apps/outputs/podman-desktop/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.29.0",
+      "version": "1.29.1",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Podman Desktop %' AND publisher = 'Podman Desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Podman Desktop %' AND publisher = 'Podman Desktop' AND version_compare(version, '1.29.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Podman Desktop %' AND publisher = 'Podman Desktop' AND version_compare(version, '1.29.1') < 0);"
       },
-      "installer_url": "https://github.com/containers/podman-desktop/releases/download/v1.29.0/podman-desktop-1.29.0-setup-x64.exe",
+      "installer_url": "https://github.com/containers/podman-desktop/releases/download/v1.29.1/podman-desktop-1.29.1-setup-x64.exe",
       "install_script_ref": "a1a2e133",
       "uninstall_script_ref": "934e0da5",
-      "sha256": "d5b42835d5a7caddd3a926401735cae9d981ecfcf494929b1e736f7b57fb2942",
+      "sha256": "43143381361e1343cf6c037dad0b5e52e95d6e352a8ac5725026eb67b882b89b",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/postman/darwin.json
+++ b/ee/maintained-apps/outputs/postman/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.21.8",
+      "version": "12.21.9",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac' AND version_compare(bundle_short_version, '12.21.8') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac' AND version_compare(bundle_short_version, '12.21.9') < 0);"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.21.8/osx_arm64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.21.9/osx_arm64",
       "install_script_ref": "0e85ef74",
       "uninstall_script_ref": "20883323",
-      "sha256": "67cbbcce5bd33f0821a065b7f3aa8b57839766da1ad129c1877fd2dce81dd6d3",
+      "sha256": "d19e586c2c92b4accd433e9a001499ed194004ff587f66acbc44c5b4b23eb298",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/raycast/darwin.json
+++ b/ee/maintained-apps/outputs/raycast/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.104.23",
+      "version": "1.104.24",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.raycast.macos';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.raycast.macos' AND version_compare(bundle_short_version, '1.104.23') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.raycast.macos' AND version_compare(bundle_short_version, '1.104.24') < 0);"
       },
-      "installer_url": "https://releases.raycast.com/releases/1.104.23/download?build=arm",
+      "installer_url": "https://releases.raycast.com/releases/1.104.24/download?build=arm",
       "install_script_ref": "f52a81be",
       "uninstall_script_ref": "cb893329",
-      "sha256": "fdaa2d6f2719998f0548e2f351299130c7f3c2c37fdafd3ca0d7b88ad798da81",
+      "sha256": "927f5b65849e0122a3db73588965fbe8e2115c24e89c06d40804f26213dd1a0a",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/setapp/darwin.json
+++ b/ee/maintained-apps/outputs/setapp/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.54.0",
+      "version": "3.54.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.setapp.DesktopClient.SetappAgent';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.setapp.DesktopClient.SetappAgent' AND version_compare(bundle_short_version, '3.54.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.setapp.DesktopClient.SetappAgent' AND version_compare(bundle_short_version, '3.54.1') < 0);"
       },
-      "installer_url": "https://dl.devmate.com/com.setapp.DesktopClient/153/1784621405/Setapp-153.zip",
+      "installer_url": "https://dl.devmate.com/com.setapp.DesktopClient/154/1785484295/Setapp-154.zip",
       "install_script_ref": "eb0dc2d0",
       "uninstall_script_ref": "9ef05eb6",
-      "sha256": "3b8579b2ccc7f0a3bab102fca3417dfca9f243d1ac5dbc08fb60e85b3796f124",
+      "sha256": "356afe716fd432db41809dfaa9fb52b5d81666d1aeeb9fa061953860d952504c",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/shotcut/darwin.json
+++ b/ee/maintained-apps/outputs/shotcut/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.6.25",
+      "version": "26.7.30",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.meltytech.Shotcut';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.meltytech.Shotcut' AND version_compare(bundle_short_version, '26.6.25') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.meltytech.Shotcut' AND version_compare(bundle_short_version, '26.7.30') < 0);"
       },
-      "installer_url": "https://github.com/mltframework/shotcut/releases/download/v26.6.25/shotcut-macos-26.6.25.dmg",
+      "installer_url": "https://github.com/mltframework/shotcut/releases/download/v26.7.30/shotcut-macos-26.7.30.dmg",
       "install_script_ref": "569ddb04",
       "uninstall_script_ref": "7a77ca77",
-      "sha256": "630dcb251915f0ceaf9344b5fd4213cfda162ccef2ae00215bdf4de79d3e5c69",
+      "sha256": "991ddd6ec617f07792ca398b14c8db61b3e4694dd537aa1face66617a06cedf0",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/spokenly/darwin.json
+++ b/ee/maintained-apps/outputs/spokenly/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.27.5",
+      "version": "2.27.6",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'app.spokenly';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.spokenly' AND version_compare(bundle_short_version, '2.27.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.spokenly' AND version_compare(bundle_short_version, '2.27.6') < 0);"
       },
-      "installer_url": "https://cdn.spokenly.app/releases/macos/Spokenly-2.27.5.dmg",
+      "installer_url": "https://cdn.spokenly.app/releases/macos/Spokenly-2.27.6.dmg",
       "install_script_ref": "11a51e11",
       "uninstall_script_ref": "99a71452",
-      "sha256": "229f6ac9af202f957ecab78b5f97f7ea343a854cc2652155b3a8a8e8828b6597",
+      "sha256": "8fee17d521cad472297592251cd720e2e6313e859e4a923ebc8d513553891e12",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/superhuman/darwin.json
+++ b/ee/maintained-apps/outputs/superhuman/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1041.0.25",
+      "version": "1041.0.26",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.superhuman.mail';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.superhuman.mail' AND version_compare(bundle_short_version, '1041.0.25') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.superhuman.mail' AND version_compare(bundle_short_version, '1041.0.26') < 0);"
       },
-      "installer_url": "https://storage.googleapis.com/download.superhuman.com/supertron-update/Superhuman-1041.0.25-arm64-latest-mac.zip",
+      "installer_url": "https://storage.googleapis.com/download.superhuman.com/supertron-update/Superhuman-1041.0.26-arm64-latest-mac.zip",
       "install_script_ref": "7e74bd96",
       "uninstall_script_ref": "1809183d",
-      "sha256": "00433042ca7404638255339e3732a407f2b7240c745f5a9d8ecf2b9c46ff86ac",
+      "sha256": "225c865519e6bd7b427e3a46efe44780786cbe43112d83a8e173ad247870f96e",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/typora/darwin.json
+++ b/ee/maintained-apps/outputs/typora/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.14.6",
+      "version": "1.14.8",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'abnerworks.Typora';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'abnerworks.Typora' AND version_compare(bundle_short_version, '1.14.6') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'abnerworks.Typora' AND version_compare(bundle_short_version, '1.14.8') < 0);"
       },
-      "installer_url": "https://downloads.typora.io/mac/Typora-1.14.6.dmg",
+      "installer_url": "https://downloads.typora.io/mac/Typora-1.14.8.dmg",
       "install_script_ref": "163abff2",
       "uninstall_script_ref": "a8ba94c9",
-      "sha256": "ff1e93e87fcd5b4211796f4bf6d3d56affa26b9d12342b9f5e2c1b297dcc4dd7",
+      "sha256": "048b3b10100938ffc29f89a517197066c3625e0d338a27e767aee6efc84c0527",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/typora/darwin.json
+++ b/ee/maintained-apps/outputs/typora/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.14.8",
+      "version": "1.14.6",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'abnerworks.Typora';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'abnerworks.Typora' AND version_compare(bundle_short_version, '1.14.8') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'abnerworks.Typora' AND version_compare(bundle_short_version, '1.14.6') < 0);"
       },
-      "installer_url": "https://downloads.typora.io/mac/Typora-1.14.8.dmg",
+      "installer_url": "https://downloads.typora.io/mac/Typora-1.14.6.dmg",
       "install_script_ref": "163abff2",
       "uninstall_script_ref": "a8ba94c9",
-      "sha256": "048b3b10100938ffc29f89a517197066c3625e0d338a27e767aee6efc84c0527",
+      "sha256": "ff1e93e87fcd5b4211796f4bf6d3d56affa26b9d12342b9f5e2c1b297dcc4dd7",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Refreshed available versions and verified download information for 30 maintained applications across macOS and Windows.
  - Updated Adobe Acrobat Reader, Beekeeper Studio, BoltAI, ChatWise, CMake, Cursor, Dataflare, Eclipse Temurin JDK/JRE, Firefox Developer Edition/Nightly, iMazing, Krita, Mockoon, Netron, Notesnook, pgAdmin 4, Podman Desktop, Postman, Raycast, Setapp, Shotcut, Spokenly, Superhuman, and Typora.
  - Installation and uninstallation behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->