### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/aws-cli/windows.json
+++ b/ee/maintained-apps/outputs/aws-cli/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.36.13",
+      "version": "2.36.14",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'AWS Command Line Interface v2 %' AND publisher = 'Amazon Web Services';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'AWS Command Line Interface v2 %' AND publisher = 'Amazon Web Services' AND version_compare(version, '2.36.13') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'AWS Command Line Interface v2 %' AND publisher = 'Amazon Web Services' AND version_compare(version, '2.36.14') < 0);"
       },
-      "installer_url": "https://awscli.amazonaws.com/AWSCLIV2-2.36.13.msi",
+      "installer_url": "https://awscli.amazonaws.com/AWSCLIV2-2.36.14.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "58bcd016",
-      "sha256": "8842aec8f8d9b7d7458f2ddc4107d0ec10b731f7657bd930d1780bdf77b22374",
+      "sha256": "5b672727d1d696f205239a8d0893474df374a2106f5f2acae01c219088294d1b",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/aws-sam-cli/windows.json
+++ b/ee/maintained-apps/outputs/aws-sam-cli/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.164.0",
+      "version": "1.165.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'AWS SAM Command Line Interface' AND publisher = 'AWS Serverless Applications';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'AWS SAM Command Line Interface' AND publisher = 'AWS Serverless Applications' AND version_compare(version, '1.164.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'AWS SAM Command Line Interface' AND publisher = 'AWS Serverless Applications' AND version_compare(version, '1.165.0') < 0);"
       },
-      "installer_url": "https://github.com/aws/aws-sam-cli/releases/download/v1.164.0/AWS_SAM_CLI_64_PY3.msi",
+      "installer_url": "https://github.com/aws/aws-sam-cli/releases/download/v1.165.0/AWS_SAM_CLI_64_PY3.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "a3074b39",
-      "sha256": "18838f304905c49095777152d00ceb93b3a73785e0c0b039c729037c69299217",
+      "sha256": "7e3618c694dee849d4cc6193ae0cdfc4179b1c3a8143ccc37372f0bcec07d6c1",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/datagrip/windows.json
+++ b/ee/maintained-apps/outputs/datagrip/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.2.1",
+      "version": "2026.2.2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'DataGrip %' AND publisher = 'JetBrains s.r.o.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'DataGrip %' AND publisher = 'JetBrains s.r.o.' AND version_compare(version, '262.8665.339') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'DataGrip %' AND publisher = 'JetBrains s.r.o.' AND version_compare(version, '262.9437.70') < 0);"
       },
-      "installer_url": "https://download.jetbrains.com/datagrip/datagrip-2026.2.1.exe",
+      "installer_url": "https://download.jetbrains.com/datagrip/datagrip-2026.2.2.exe",
       "install_script_ref": "0897461e",
       "uninstall_script_ref": "020465dd",
-      "sha256": "ebb350d6c2920fd39032de69b2407b0b6283ef78c7dc344358f875b6f956daa7",
+      "sha256": "5b091158369589c1819f8e341f7b96c81a5a904848a6f9fac39cde425ecfadc8",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/fellow/darwin.json
+++ b/ee/maintained-apps/outputs/fellow/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "5.7.0",
+      "version": "5.7.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.fellow';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.fellow' AND version_compare(bundle_short_version, '5.7.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.fellow' AND version_compare(bundle_short_version, '5.7.2') < 0);"
       },
-      "installer_url": "https://cdn.fellow.app/desktop/5.7.0/darwin/stable/universal/Fellow-5.7.0-universal.dmg",
+      "installer_url": "https://cdn.fellow.app/desktop/5.7.2/darwin/stable/universal/Fellow-5.7.2-universal.dmg",
       "install_script_ref": "fec4efb2",
       "uninstall_script_ref": "8110dadb",
-      "sha256": "7f308fb56ef22648a640b64d1ef341ac601ab3b75a87aa55bee1727da2466b56",
+      "sha256": "04536265c4ef322a2b9c4f32b682f4d3dbf837b43223b50426e51e5671421513",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/microsoft-edge/darwin.json
+++ b/ee/maintained-apps/outputs/microsoft-edge/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "150.0.4078.105",
+      "version": "151.0.4129.59",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.edgemac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.edgemac' AND version_compare(bundle_short_version, '150.0.4078.105') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.edgemac' AND version_compare(bundle_short_version, '151.0.4129.59') < 0);"
       },
-      "installer_url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/91f7c352-7e04-44c0-bafe-101ee6d44bba/MicrosoftEdge-150.0.4078.105.dmg",
+      "installer_url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/01a6b458-9d0d-4c98-88f7-1d3e21d14464/MicrosoftEdge-151.0.4129.59.dmg",
       "install_script_ref": "4c051c40",
       "uninstall_script_ref": "afe8f338",
-      "sha256": "ad068a173f76c3f0b9183418fdda344fde7e61fe369416fdb307c502b01bf5d1",
+      "sha256": "8bdfc85dea06afdfdcde206d12993b1a4537c00f9adb8885f0cc225e6912ec78",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/postman/darwin.json
+++ b/ee/maintained-apps/outputs/postman/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.21.9",
+      "version": "12.21.10",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac' AND version_compare(bundle_short_version, '12.21.9') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac' AND version_compare(bundle_short_version, '12.21.10') < 0);"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.21.9/osx_arm64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.21.10/osx_arm64",
       "install_script_ref": "0e85ef74",
       "uninstall_script_ref": "20883323",
-      "sha256": "d19e586c2c92b4accd433e9a001499ed194004ff587f66acbc44c5b4b23eb298",
+      "sha256": "32898552c96ad46f925bbd83bb6104fd40c2234dda5bf03ac2a62cf82e46c139",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/postman/windows.json
+++ b/ee/maintained-apps/outputs/postman/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.21.9",
+      "version": "12.21.10",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.21.9') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.21.10') < 0);"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.21.9/windows_64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.21.10/windows_64",
       "install_script_ref": "8594f0bc",
       "uninstall_script_ref": "fd59d029",
-      "sha256": "14348111dd748c5c1981d0a3965c6ed1d375d51791d89e83c1f7e1121342f023",
+      "sha256": "8d2524d4cf073addef35583103357907a29ed45b8bba0afd3a4927a61d8bc4a9",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/typora/darwin.json
+++ b/ee/maintained-apps/outputs/typora/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.14.6",
+      "version": "1.14.8",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'abnerworks.Typora';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'abnerworks.Typora' AND version_compare(bundle_short_version, '1.14.6') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'abnerworks.Typora' AND version_compare(bundle_short_version, '1.14.8') < 0);"
       },
-      "installer_url": "https://downloads.typora.io/mac/Typora-1.14.6.dmg",
+      "installer_url": "https://downloads.typora.io/mac/Typora-1.14.8.dmg",
       "install_script_ref": "163abff2",
       "uninstall_script_ref": "a8ba94c9",
-      "sha256": "ff1e93e87fcd5b4211796f4bf6d3d56affa26b9d12342b9f5e2c1b297dcc4dd7",
+      "sha256": "048b3b10100938ffc29f89a517197066c3625e0d338a27e767aee6efc84c0527",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated AWS CLI for Windows to 2.36.14.
  * Updated AWS SAM CLI for Windows to 1.165.0.
  * Updated DataGrip for Windows to 2026.2.2.
  * Updated Fellow for macOS to 5.7.2.
  * Updated Microsoft Edge for macOS to 151.0.4129.59.
  * Updated Postman for macOS and Windows to 12.21.10.
  * Updated Typora for macOS to 1.14.8.
  * Refreshed download details and integrity checks for each release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->