### PR TITLE
Unfreeze Keeper Password Manager (macOS)

### DIFF
--- a/ee/maintained-apps/inputs/homebrew/keeper-password-manager.json
+++ b/ee/maintained-apps/inputs/homebrew/keeper-password-manager.json
@@ -6,6 +6,5 @@
   "slug": "keeper-password-manager/darwin",
   "default_categories": [
     "Productivity"
-  ],
-  "frozen": true
+  ]
 }

--- a/ee/maintained-apps/outputs/keeper-password-manager/darwin.json
+++ b/ee/maintained-apps/outputs/keeper-password-manager/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "18.2.1",
+      "version": "18.5.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.keepersecurity.passwordmanager';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.keepersecurity.passwordmanager' AND version_compare(bundle_short_version, '18.2.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.keepersecurity.passwordmanager' AND version_compare(bundle_short_version, '18.5.0') < 0);"
       },
       "installer_url": "https://keepersecurity.com/desktop_electron/Darwin/KeeperSetup.dmg",
       "install_script_ref": "bd9c8589",


### PR DESCRIPTION
Automated unfreeze probe. Removes `"frozen": true` and regenerates the output manifest so
`test-fma-darwin-pr-only` can validate `keeper-password-manager/darwin` at its current upstream version.

Frozen since: 2026-02-10 (#39623, automated FMA update run)
Version: 18.2.1 -> 18.5.0

Draft until validation reports. Merge only if the FMA checks are green and the validate shard
actually ran for this slug.

**Related issue:** NA

# Checklist for submitter

- [x] QA'd all new/changed functionality manually — pending CI validation, see above.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBxhs5D65LRUwCEJejBLJH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the Keeper Password Manager macOS app to version 18.5.0.
  * Improved app version detection for the latest release.
  * Removed an outdated configuration restriction from the Homebrew app definition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->