### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/chatgpt/darwin.json
+++ b/ee/maintained-apps/outputs/chatgpt/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.727.40816",
+      "version": "26.727.51351",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.chat';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.chat' AND version_compare(bundle_short_version, '26.727.40816') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.chat' AND version_compare(bundle_short_version, '26.727.51351') < 0);"
       },
-      "installer_url": "https://persistent.oaistatic.com/codex-app-prod/ChatGPT-darwin-arm64-26.727.40816.zip",
+      "installer_url": "https://persistent.oaistatic.com/codex-app-prod/ChatGPT-darwin-arm64-26.727.51351.zip",
       "install_script_ref": "cbce2d7d",
       "uninstall_script_ref": "678e6cf0",
-      "sha256": "fdbede9b8a28b5bf3bbf1213fa04291724faa6ed2d1d61bb04853bbdfebce219",
+      "sha256": "8f3fc87e634332fddc711e5221eb2af554f5f6ecb04e6a69b3d10e01f4f196c8",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/dockdoor/darwin.json
+++ b/ee/maintained-apps/outputs/dockdoor/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.39.4",
+      "version": "1.39.5",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.ethanbills.DockDoor';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.ethanbills.DockDoor' AND version_compare(bundle_short_version, '1.39.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.ethanbills.DockDoor' AND version_compare(bundle_short_version, '1.39.5') < 0);"
       },
-      "installer_url": "https://github.com/ejbills/DockDoor/releases/download/1.39.4/DockDoor.dmg",
+      "installer_url": "https://github.com/ejbills/DockDoor/releases/download/1.39.5/DockDoor.dmg",
       "install_script_ref": "8a8c0b06",
       "uninstall_script_ref": "0e456379",
-      "sha256": "3ec497dff5b77976f00a1f607e9e79bf2ec4c97d8d6fcb5358d8c0130e96ab16",
+      "sha256": "2c3c06027f2a2e74375d1c4c95d2133b6bf7e88843cc7026c4c40d5e84c56d40",
       "default_categories": [
         "Utilities"
       ]

--- a/ee/maintained-apps/outputs/microsoft-edge/windows.json
+++ b/ee/maintained-apps/outputs/microsoft-edge/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "150.0.4078.105",
+      "version": "151.0.4129.59",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Microsoft Edge' AND publisher = 'Microsoft Corporation';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Microsoft Edge' AND publisher = 'Microsoft Corporation' AND version_compare(version, '150.0.4078.105') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Microsoft Edge' AND publisher = 'Microsoft Corporation' AND version_compare(version, '151.0.4129.59') < 0);"
       },
-      "installer_url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/1641ca3d-63ab-4dc5-85a8-1d931217907c/MicrosoftEdgeEnterpriseX64.msi",
+      "installer_url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/6d262b14-57af-4d34-aa54-b13dd27d2547/MicrosoftEdgeEnterpriseX64.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "e12e9902",
-      "sha256": "e8f3eebed93fe98fd60f36749b0cb2d26e31fb8f704ea4700b7c68634fafc753",
+      "sha256": "ad2fb7b3bd49564d0967c4eb0b0307d5420a9636e8e2f479e7ffc4e8b7b86ae6",
       "default_categories": [
         "Browsers"
       ],

--- a/ee/maintained-apps/outputs/shotcut/windows.json
+++ b/ee/maintained-apps/outputs/shotcut/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.6.25",
+      "version": "26.7.30",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Shotcut' AND publisher = 'Meltytech';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Shotcut' AND publisher = 'Meltytech' AND version_compare(version, '26.6.25') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Shotcut' AND publisher = 'Meltytech' AND version_compare(version, '26.7.30') < 0);"
       },
-      "installer_url": "https://github.com/mltframework/shotcut/releases/download/v26.6.25/shotcut-win64-26.6.25.exe",
+      "installer_url": "https://github.com/mltframework/shotcut/releases/download/v26.7.30/shotcut-win64-26.7.30.exe",
       "install_script_ref": "fbf50bbc",
       "uninstall_script_ref": "664e5a3e",
-      "sha256": "94daad5ffca5d54cdb62b320c19e8fec05e5e5f7572ed287340135c6416843f3",
+      "sha256": "b72baa8253cc6112117badcacd9c2bc032b7dc4ce9b0ae58db9e9590efe47e99",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/typora/darwin.json
+++ b/ee/maintained-apps/outputs/typora/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.14.6",
+      "version": "1.14.8",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'abnerworks.Typora';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'abnerworks.Typora' AND version_compare(bundle_short_version, '1.14.6') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'abnerworks.Typora' AND version_compare(bundle_short_version, '1.14.8') < 0);"
       },
-      "installer_url": "https://downloads.typora.io/mac/Typora-1.14.6.dmg",
+      "installer_url": "https://downloads.typora.io/mac/Typora-1.14.8.dmg",
       "install_script_ref": "163abff2",
       "uninstall_script_ref": "a8ba94c9",
-      "sha256": "ff1e93e87fcd5b4211796f4bf6d3d56affa26b9d12342b9f5e2c1b297dcc4dd7",
+      "sha256": "048b3b10100938ffc29f89a517197066c3625e0d338a27e767aee6efc84c0527",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated ChatGPT for macOS to version 26.727.51351.
  - Updated DockDoor for macOS to version 1.39.5.
  - Updated Microsoft Edge for Windows to version 151.0.4129.59.
  - Updated Shotcut for Windows to version 26.7.30.
  - Updated Typora for macOS to version 1.14.8.
  - Refreshed download information and integrity checks for each application to support reliable installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->