### PR TITLE
Update Evernote macOS version to 11.27.5

### DIFF
--- a/ee/maintained-apps/outputs/evernote/darwin.json
+++ b/ee/maintained-apps/outputs/evernote/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "11.20.2",
+      "version": "11.27.5",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.evernote.Evernote';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.evernote.Evernote' AND version_compare(bundle_short_version, '11.20.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.evernote.Evernote' AND version_compare(bundle_short_version, '11.27.5') < 0);"
       },
       "installer_url": "https://mac.desktop.evernote.com/builds/Evernote-10.105.4-mac-ddl-stage-20240910164757-a2e60a8d876a07eded5d212fa56ba45214114ad0.dmg",
       "install_script_ref": "4cd3103c",


### PR DESCRIPTION
**Related issue:** Resolves #

# Checklist for submitter

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [ ] QA'd all new/changed functionality manually

---

## Summary

Updates the Evernote macOS application version from 11.20.2 to 11.27.5 in the maintained apps configuration. This change updates both the version identifier and the corresponding SQL query that checks for patched versions.

## Changes

- Updated `ee/maintained-apps/outputs/evernote/darwin.json`:
  - Version bumped from `11.20.2` to `11.27.5`
  - Updated the `patched` query to check against the new version `11.27.5` instead of `11.20.2`

This ensures that Fleet's vulnerability detection and patching workflows correctly identify whether Evernote on macOS is up-to-date with the latest version.

https://claude.ai/code/session_01F85XismGHNQj3ZEn7zPNpD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the listed Evernote macOS app version to 11.27.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->