### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/boltai/darwin.json
+++ b/ee/maintained-apps/outputs/boltai/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.14.3",
+      "version": "2.14.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'co.podzim.boltai-mobile';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'co.podzim.boltai-mobile' AND version_compare(bundle_short_version, '2.14.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'co.podzim.boltai-mobile' AND version_compare(bundle_short_version, '2.14.4') < 0);"
       },
-      "installer_url": "https://updates.boltai.com/dmg/BoltAI-2.14.3.dmg",
+      "installer_url": "https://updates.boltai.com/dmg/BoltAI-2.14.4.dmg",
       "install_script_ref": "4b6c58a2",
       "uninstall_script_ref": "8c3f3ae8",
-      "sha256": "031d7a8354ef981fdfcbedc9841ac59d61020b748e6c119c05c5f73042908534",
+      "sha256": "40a6b45f77edba582b69da891b56e44ffa2e53d83f42c844d5919882bebba1dc",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/bome-network/darwin.json
+++ b/ee/maintained-apps/outputs/bome-network/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.6.0",
+      "version": "1.7.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.bome.network';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.bome.network' AND version_compare(bundle_short_version, '1.6.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.bome.network' AND version_compare(bundle_short_version, '1.7.0') < 0);"
       },
-      "installer_url": "https://download.bome.com/BomeNet1.6.0_macOS.dmg",
+      "installer_url": "https://download.bome.com/BomeNet1.7.0_macOS.dmg",
       "install_script_ref": "f614c9b5",
       "uninstall_script_ref": "647d1ff7",
-      "sha256": "24f99bdf3356bf1218c65b315ca63085d8d41cd21f73a67c374cd73acf02d959",
+      "sha256": "0c2f6d336c227f1dfcc9c6db88e8daa2de7503f3931fae0868f06630d3215ce3",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/dockside/darwin.json
+++ b/ee/maintained-apps/outputs/dockside/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.9.25",
+      "version": "2.9.26",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.hachipoo.Dockside';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hachipoo.Dockside' AND version_compare(bundle_short_version, '2.9.25') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hachipoo.Dockside' AND version_compare(bundle_short_version, '2.9.26') < 0);"
       },
-      "installer_url": "https://github.com/PrajwalSD/Dockside/releases/download/v2.9.25/Dockside.dmg",
+      "installer_url": "https://github.com/PrajwalSD/Dockside/releases/download/v2.9.26/Dockside.dmg",
       "install_script_ref": "bb2b7871",
       "uninstall_script_ref": "262fd2cc",
-      "sha256": "f59355a70301dfffa913e4bd847c3edb782d88c640109c84ecdf9fa61172f0df",
+      "sha256": "f74c281b18ac859b93837df8e60508b529374d508dc7ac2f8f5af35f9f51bafc",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/firefox@nightly/darwin.json
+++ b/ee/maintained-apps/outputs/firefox@nightly/darwin.json
@@ -6,10 +6,10 @@
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly';",
         "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15526.8.1') < 0);"
       },
-      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/08/2026-08-01-09-49-16-mozilla-central/firefox-155.0a1.en-US.mac.dmg",
+      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/08/2026-08-01-21-12-58-mozilla-central/firefox-155.0a1.en-US.mac.dmg",
       "install_script_ref": "d9c4cf87",
       "uninstall_script_ref": "0661f848",
-      "sha256": "6b0c58599eaa50bee0801085be6f8337d4021ae30ef0619426d7093008c9b4b2",
+      "sha256": "7993f6ab0f2dc5eb4ebb98d5bc772143882fbd265e61d5efdf131001fc8997fc",
       "default_categories": [
         "Browsers"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS installation metadata for BoltAI to version 2.14.4.
  * Updated Bome Network to version 1.7.0.
  * Updated Dockside to version 2.9.26.
  * Updated the Firefox Nightly macOS build to the 2026-08-01 release.
  * Refreshed download links and integrity checks for each updated application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->