### PR TITLE
Unfreeze Adobe Acrobat Pro (macOS)

### DIFF
--- a/ee/maintained-apps/inputs/homebrew/adobe-acrobat-pro.json
+++ b/ee/maintained-apps/inputs/homebrew/adobe-acrobat-pro.json
@@ -4,6 +4,5 @@
   "token": "adobe-acrobat-pro",
   "installer_format": "dmg",
   "slug": "adobe-acrobat-pro/darwin",
-  "default_categories": ["Productivity"],
-  "frozen": true
+  "default_categories": ["Productivity"]
 }

--- a/ee/maintained-apps/outputs/adobe-acrobat-pro/darwin.json
+++ b/ee/maintained-apps/outputs/adobe-acrobat-pro/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "26.001.21691",
+      "version": "26.001.21771",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.adobe.Acrobat.Pro';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.adobe.Acrobat.Pro' AND version_compare(bundle_short_version, '26.001.21691') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.adobe.Acrobat.Pro' AND version_compare(bundle_short_version, '26.001.21771') < 0);"
       },
       "installer_url": "https://trials.adobe.com/AdobeProducts/APRO/Acrobat_HelpX/osx10/Acrobat_DC_Web_WWMUI.dmg",
       "install_script_ref": "afddc3a7",


### PR DESCRIPTION
Automated unfreeze probe. Removes `"frozen": true` and regenerates the output manifest so
`test-fma-darwin-pr-only` can validate `adobe-acrobat-pro/darwin` at its current upstream version.

Frozen since: 2026-06-23 (#48089, automated FMA update run)
Version: 26.001.21691 -> 26.001.21771

Upstream Homebrew reports 26.001.21771, newer than the pinned 26.001.21691 that #50370 set from the
delivered installer, so this is a genuine forward bump rather than a regression. The cask uses a
stable "latest" download URL with `sha256: no_check`, so the regenerated diff is version and
`patched` query only.

Draft until validation reports. Merge only if the FMA checks are green and the validate shard
actually ran for this slug.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** NA

# Checklist for submitter

- [x] QA'd all new/changed functionality manually — pending CI validation, see above.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LvsXk65MD2s93jeGJuHAk5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated Adobe Acrobat Pro to version 26.001.21771.
* **Bug Fixes**
  * Improved configuration handling for Adobe Acrobat Pro by removing an outdated restriction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->