### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/actual/darwin.json
+++ b/ee/maintained-apps/outputs/actual/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.7.0",
+      "version": "26.8.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.actualbudget.actual';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.actualbudget.actual' AND version_compare(bundle_short_version, '26.7.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.actualbudget.actual' AND version_compare(bundle_short_version, '26.8.0') < 0);"
       },
-      "installer_url": "https://github.com/actualbudget/actual/releases/download/v26.7.0/Actual-mac-arm64.dmg",
+      "installer_url": "https://github.com/actualbudget/actual/releases/download/v26.8.0/Actual-mac-arm64.dmg",
       "install_script_ref": "a6f737ee",
       "uninstall_script_ref": "27bb5492",
-      "sha256": "7e9b5be9d3d1a78de6a7a625717dd0e31ccfb2f79f9718f761726925dac44ece",
+      "sha256": "13c469e2f919e5aa1ed04de11ead29e8ec77401606ddd76c0dd7ed779b9abe73",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/boltai/darwin.json
+++ b/ee/maintained-apps/outputs/boltai/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.14.3",
+      "version": "2.14.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'co.podzim.boltai-mobile';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'co.podzim.boltai-mobile' AND version_compare(bundle_short_version, '2.14.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'co.podzim.boltai-mobile' AND version_compare(bundle_short_version, '2.14.4') < 0);"
       },
-      "installer_url": "https://updates.boltai.com/dmg/BoltAI-2.14.3.dmg",
+      "installer_url": "https://updates.boltai.com/dmg/BoltAI-2.14.4.dmg",
       "install_script_ref": "4b6c58a2",
       "uninstall_script_ref": "8c3f3ae8",
-      "sha256": "031d7a8354ef981fdfcbedc9841ac59d61020b748e6c119c05c5f73042908534",
+      "sha256": "40a6b45f77edba582b69da891b56e44ffa2e53d83f42c844d5919882bebba1dc",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/bome-network/darwin.json
+++ b/ee/maintained-apps/outputs/bome-network/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.6.0",
+      "version": "1.7.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.bome.network';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.bome.network' AND version_compare(bundle_short_version, '1.6.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.bome.network' AND version_compare(bundle_short_version, '1.7.0') < 0);"
       },
-      "installer_url": "https://download.bome.com/BomeNet1.6.0_macOS.dmg",
+      "installer_url": "https://download.bome.com/BomeNet1.7.0_macOS.dmg",
       "install_script_ref": "f614c9b5",
       "uninstall_script_ref": "647d1ff7",
-      "sha256": "24f99bdf3356bf1218c65b315ca63085d8d41cd21f73a67c374cd73acf02d959",
+      "sha256": "0c2f6d336c227f1dfcc9c6db88e8daa2de7503f3931fae0868f06630d3215ce3",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/dbeaver-community/darwin.json
+++ b/ee/maintained-apps/outputs/dbeaver-community/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.1.3",
+      "version": "26.1.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.jkiss.dbeaver.core.product';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.jkiss.dbeaver.core.product' AND version_compare(bundle_short_version, '26.1.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.jkiss.dbeaver.core.product' AND version_compare(bundle_short_version, '26.1.4') < 0);"
       },
-      "installer_url": "https://dbeaver.io/files/26.1.3/dbeaver-ce-26.1.3-macos-aarch64.dmg",
+      "installer_url": "https://dbeaver.io/files/26.1.4/dbeaver-ce-26.1.4-macos-aarch64.dmg",
       "install_script_ref": "277d4c1a",
       "uninstall_script_ref": "f1704b2e",
-      "sha256": "3585fae75814a440e1d8eef6d192a5edf51360b14aa53273c82fd89cde159f2b",
+      "sha256": "28f66f7131314e128cefe4abd08f161be07bfa14c914ca88a80107f910ddef4b",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/dbeaver-community/windows.json
+++ b/ee/maintained-apps/outputs/dbeaver-community/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.1.3",
+      "version": "26.1.4",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'DBeaver %' AND publisher = 'DBeaver Corp';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'DBeaver %' AND publisher = 'DBeaver Corp' AND version_compare(version, '26.1.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'DBeaver %' AND publisher = 'DBeaver Corp' AND version_compare(version, '26.1.4') < 0);"
       },
-      "installer_url": "https://github.com/dbeaver/dbeaver/releases/download/26.1.3/dbeaver-ce-26.1.3-windows-x86_64.exe",
+      "installer_url": "https://github.com/dbeaver/dbeaver/releases/download/26.1.4/dbeaver-ce-26.1.4-windows-x86_64.exe",
       "install_script_ref": "44838cfb",
       "uninstall_script_ref": "7c58ef20",
-      "sha256": "df3e522e3dbd4e6a7f91dcd8e422a0be13220d2e895a681b5b6732adb518297d",
+      "sha256": "3ee1f622c29e0097ef89157e2abe08798f38f5c506b089e7a92cff2deeb2e498",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/dockside/darwin.json
+++ b/ee/maintained-apps/outputs/dockside/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.9.25",
+      "version": "2.9.26",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.hachipoo.Dockside';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hachipoo.Dockside' AND version_compare(bundle_short_version, '2.9.25') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hachipoo.Dockside' AND version_compare(bundle_short_version, '2.9.26') < 0);"
       },
-      "installer_url": "https://github.com/PrajwalSD/Dockside/releases/download/v2.9.25/Dockside.dmg",
+      "installer_url": "https://github.com/PrajwalSD/Dockside/releases/download/v2.9.26/Dockside.dmg",
       "install_script_ref": "bb2b7871",
       "uninstall_script_ref": "262fd2cc",
-      "sha256": "f59355a70301dfffa913e4bd847c3edb782d88c640109c84ecdf9fa61172f0df",
+      "sha256": "f74c281b18ac859b93837df8e60508b529374d508dc7ac2f8f5af35f9f51bafc",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/exifcleaner/darwin.json
+++ b/ee/maintained-apps/outputs/exifcleaner/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.0.0",
+      "version": "4.0.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.exifcleaner';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.exifcleaner' AND version_compare(bundle_short_version, '4.0.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.exifcleaner' AND version_compare(bundle_short_version, '4.0.1') < 0);"
       },
-      "installer_url": "https://github.com/szTheory/exifcleaner/releases/download/v4.0.0/ExifCleaner-4.0.0-arm64.dmg",
+      "installer_url": "https://github.com/szTheory/exifcleaner/releases/download/v4.0.1/ExifCleaner-4.0.1-arm64.dmg",
       "install_script_ref": "d01e9e3e",
       "uninstall_script_ref": "b28572f0",
-      "sha256": "f8837c155fe3cd826ef9f82b87d3936780bbafbcfc2b1902cc2a594a26037c1d",
+      "sha256": "3bf251e84cc879df264ad012a2a0c7682bdc16312d49441ecb0316917d0616ad",
       "default_categories": [
         "Utilities"
       ]

--- a/ee/maintained-apps/outputs/firefox@nightly/darwin.json
+++ b/ee/maintained-apps/outputs/firefox@nightly/darwin.json
@@ -4,12 +4,12 @@
       "version": "155.0a1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15526.8.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15526.8.2') < 0);"
       },
-      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/08/2026-08-01-09-49-16-mozilla-central/firefox-155.0a1.en-US.mac.dmg",
+      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/08/2026-08-02-09-20-52-mozilla-central/firefox-155.0a1.en-US.mac.dmg",
       "install_script_ref": "d9c4cf87",
       "uninstall_script_ref": "0661f848",
-      "sha256": "6b0c58599eaa50bee0801085be6f8337d4021ae30ef0619426d7093008c9b4b2",
+      "sha256": "113c7abedd856dbb25257d1edd0e36d53dd169e32b21137f128b33db8c24f018",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/linearmouse/darwin.json
+++ b/ee/maintained-apps/outputs/linearmouse/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.11.3",
+      "version": "0.11.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.lujjjh.LinearMouse';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.lujjjh.LinearMouse' AND version_compare(bundle_short_version, '0.11.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.lujjjh.LinearMouse' AND version_compare(bundle_short_version, '0.11.4') < 0);"
       },
-      "installer_url": "https://dl.linearmouse.org/v0.11.3/LinearMouse.dmg",
+      "installer_url": "https://dl.linearmouse.org/v0.11.4/LinearMouse.dmg",
       "install_script_ref": "d00f4222",
       "uninstall_script_ref": "dcd89a8c",
-      "sha256": "8db843f475ceb2d0ac786c21bae308b19ae8baab35e5ce7feafe98493df2c0da",
+      "sha256": "755127ba3cb053c50615dc1240ed7ad7fd7a337ab3f3bbb890a06644cd62d85f",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/ocenaudio/darwin.json
+++ b/ee/maintained-apps/outputs/ocenaudio/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "3.20.1",
+      "version": "3.20.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.ocenaudio';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.ocenaudio' AND version_compare(bundle_short_version, '3.20.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.ocenaudio' AND version_compare(bundle_short_version, '3.20.2') < 0);"
       },
       "installer_url": "https://www.ocenaudio.com/downloads/index.php/ocenaudio_universal.dmg",
       "install_script_ref": "4cced93a",

--- a/ee/maintained-apps/outputs/openrct2/darwin.json
+++ b/ee/maintained-apps/outputs/openrct2/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.5.3",
+      "version": "0.5.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'io.openrct2.OpenRCT2';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.openrct2.OpenRCT2' AND version_compare(bundle_short_version, '0.5.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.openrct2.OpenRCT2' AND version_compare(bundle_short_version, '0.5.4') < 0);"
       },
-      "installer_url": "https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.5.3/OpenRCT2-v0.5.3-macos-universal.zip",
+      "installer_url": "https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.5.4/OpenRCT2-v0.5.4-macos-universal.zip",
       "install_script_ref": "8ded53e4",
       "uninstall_script_ref": "9fdb5f82",
-      "sha256": "dc597f5cc6115a7e5eff61c09a77a5edeb4686a69f72230dda4257c5c4f6f395",
+      "sha256": "f52fec44e34d3d0094b94f1ff1d5d90f220f9a8ce32c99b2723fb513d2fe1e14",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/spokenly/darwin.json
+++ b/ee/maintained-apps/outputs/spokenly/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.27.8",
+      "version": "2.27.9",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'app.spokenly';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.spokenly' AND version_compare(bundle_short_version, '2.27.8') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.spokenly' AND version_compare(bundle_short_version, '2.27.9') < 0);"
       },
-      "installer_url": "https://cdn.spokenly.app/releases/macos/Spokenly-2.27.8.dmg",
+      "installer_url": "https://cdn.spokenly.app/releases/macos/Spokenly-2.27.9.dmg",
       "install_script_ref": "11a51e11",
       "uninstall_script_ref": "99a71452",
-      "sha256": "01e5362bda39e5c05cc1d9047b233738a02c94575427ef303a2beeb5e8b1b227",
+      "sha256": "002269f56a297ff8972dae91e01b8269af3983394c93db88187c2e4438215c7d",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/stats/darwin.json
+++ b/ee/maintained-apps/outputs/stats/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.0.9",
+      "version": "3.0.10",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'eu.exelban.Stats';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'eu.exelban.Stats' AND version_compare(bundle_short_version, '3.0.9') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'eu.exelban.Stats' AND version_compare(bundle_short_version, '3.0.10') < 0);"
       },
-      "installer_url": "https://github.com/exelban/stats/releases/download/v3.0.9/Stats.dmg",
+      "installer_url": "https://github.com/exelban/stats/releases/download/v3.0.10/Stats.dmg",
       "install_script_ref": "f0bd0f4d",
       "uninstall_script_ref": "48380d78",
-      "sha256": "cdbb45ab9dae5911a4ee2a7687ebcbc1431d771612ca0f54db933974ab75a66b",
+      "sha256": "efe1061573655f17fddc23b96699cc9383299de2cba91589d71403ac1467f442",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/windirstat/windows.json
+++ b/ee/maintained-apps/outputs/windirstat/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.7.0",
+      "version": "2.8.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'WinDirStat %' AND publisher = 'WinDirStat Team';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'WinDirStat %' AND publisher = 'WinDirStat Team' AND version_compare(version, '2.7.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'WinDirStat %' AND publisher = 'WinDirStat Team' AND version_compare(version, '2.8.0') < 0);"
       },
-      "installer_url": "https://github.com/windirstat/windirstat/releases/download/release/v2.7.0/WinDirStat-x64.msi",
+      "installer_url": "https://github.com/windirstat/windirstat/releases/download/release/v2.8.0/WinDirStat-x64.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "dbd2c315",
-      "sha256": "66643671d6b4e09eaffbe28e0d89cc9bca06d94495225a20020822b40536ccc4",
+      "sha256": "c40a6ec73497b18eb4ce2cbe071983b4f637cd04644bfca73c176d624794f79a",
       "default_categories": [
         "Utilities"
       ],

--- a/ee/maintained-apps/outputs/zed/darwin.json
+++ b/ee/maintained-apps/outputs/zed/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.13.1",
+      "version": "1.13.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed' AND version_compare(bundle_short_version, '1.13.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed' AND version_compare(bundle_short_version, '1.13.2') < 0);"
       },
-      "installer_url": "https://zed.dev/api/releases/stable/1.13.1/Zed-aarch64.dmg",
+      "installer_url": "https://zed.dev/api/releases/stable/1.13.2/Zed-aarch64.dmg",
       "install_script_ref": "bdea8414",
       "uninstall_script_ref": "0436e2d8",
-      "sha256": "e0f608371ed05b18e08931ba03a120e35d5c5f9359c9edbc58f473b4f7b03651",
+      "sha256": "141971b98a99f788bbb29cbf9ee62240ae662221b79e508805862488de9cd91c",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/zed/windows.json
+++ b/ee/maintained-apps/outputs/zed/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.13.1",
+      "version": "1.13.2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Zed' AND publisher = 'Zed Industries';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Zed' AND publisher = 'Zed Industries' AND version_compare(version, '1.13.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Zed' AND publisher = 'Zed Industries' AND version_compare(version, '1.13.2') < 0);"
       },
-      "installer_url": "https://github.com/zed-industries/zed/releases/download/v1.13.1/Zed-x86_64.exe",
+      "installer_url": "https://github.com/zed-industries/zed/releases/download/v1.13.2/Zed-x86_64.exe",
       "install_script_ref": "e5193bc1",
       "uninstall_script_ref": "3b164442",
-      "sha256": "5699c1651fff0e3bfe7dac1480e45bc8e405f40ea288b19071f0186209809f53",
+      "sha256": "f9e73b28ed1d202832dc2ff1e5df1be46297d16ac7aa1762f230f7c9995fd5b3",
       "default_categories": [
         "Developer tools"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated app catalogs with the latest releases for Actual, BoltAI, Bome Network, DBeaver Community, Dockside, ExifCleaner, Firefox Nightly, LinearMouse, Ocenaudio, OpenRCT2, Spokenly, Stats, WinDirStat, and Zed.
  - Added refreshed installer links, version detection, and integrity checks for the updated packages.
  - Updates cover macOS and Windows, including DBeaver Community and Zed on both platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->