### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/antigravity/darwin.json
+++ b/ee/maintained-apps/outputs/antigravity/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.4.3",
+      "version": "2.5.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.antigravity';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.antigravity' AND version_compare(bundle_short_version, '2.4.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.antigravity' AND version_compare(bundle_short_version, '2.5.0') < 0);"
       },
-      "installer_url": "https://storage.googleapis.com/antigravity-public/antigravity-hub/2.4.3-4510119262814208/darwin-arm/Antigravity.dmg",
+      "installer_url": "https://storage.googleapis.com/antigravity-public/antigravity-hub/2.5.0-5471848641724416/darwin-arm/Antigravity.dmg",
       "install_script_ref": "b60a046d",
       "uninstall_script_ref": "5e1a08b9",
-      "sha256": "ba5ea61b6915acccc5e6e2165e18949f05f2e725fab89e780aa6b36e37132ded",
+      "sha256": "18b6e837d1fef34456d22296b2def3ee90a0a14a539a0c1d83c3eaaf5029811f",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/badgeify/darwin.json
+++ b/ee/maintained-apps/outputs/badgeify/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.14.2",
+      "version": "1.14.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'studio.techflow.badgeify';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'studio.techflow.badgeify' AND version_compare(bundle_short_version, '1.14.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'studio.techflow.badgeify' AND version_compare(bundle_short_version, '1.14.3') < 0);"
       },
-      "installer_url": "https://api.badgeify.app/release/download/darwin/universal/1.14.2",
+      "installer_url": "https://api.badgeify.app/release/download/darwin/universal/1.14.3",
       "install_script_ref": "cdee59cc",
       "uninstall_script_ref": "9d0f29ae",
-      "sha256": "a982cb301f56bad8406cec455439a882abdf3ca3e1a90629b0de765a73dd763c",
+      "sha256": "cdec814a6e868a6dfbe294f762eee2d443669574aeaf9ee7e260af98cc104fbb",
       "default_categories": [
         "Utilities"
       ]

--- a/ee/maintained-apps/outputs/creative-force-kelvin/windows.json
+++ b/ee/maintained-apps/outputs/creative-force-kelvin/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "6.6.0",
+      "version": "6.7.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Kelvin' AND publisher = 'Creative Force';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Kelvin' AND publisher = 'Creative Force' AND version_compare(version, '6.6.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Kelvin' AND publisher = 'Creative Force' AND version_compare(version, '6.7.0') < 0);"
       },
-      "installer_url": "https://download.creativeforce.io/released-files.042024/prod/kelvin/win/Kelvin-6.6.0-win.msi",
+      "installer_url": "https://download.creativeforce.io/released-files.042024/prod/kelvin/win/Kelvin-6.7.0-win.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "afce06ed",
-      "sha256": "a65473fc49c433f8445e9545c4299b67b48d7c916a03d7ec52b97cb748db29ea",
+      "sha256": "0e21052588d81e64a0197cc238974be191d75cc0e6661825f2615ed12f14dfcc",
       "default_categories": [
         "Productivity"
       ],

--- a/ee/maintained-apps/outputs/galaxy-modeler/windows.json
+++ b/ee/maintained-apps/outputs/galaxy-modeler/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.6.2",
+      "version": "13.0.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Galaxy Modeler' AND publisher = 'Ideamerit';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Galaxy Modeler' AND publisher = 'Ideamerit' AND version_compare(version, '12.6.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Galaxy Modeler' AND publisher = 'Ideamerit' AND version_compare(version, '13.0.0') < 0);"
       },
-      "installer_url": "https://www.datensen.com/downloads/Galaxy%20Modeler-12.6.2-x64.exe",
+      "installer_url": "https://www.datensen.com/downloads/Galaxy%20Modeler-13.0.0-x64.exe",
       "install_script_ref": "44443700",
       "uninstall_script_ref": "5719b9f7",
-      "sha256": "c82fc58b557d629c46206f898f23aa103aac5cb08831d8aa17e4a3728bb917a6",
+      "sha256": "4dba982a6a422d18e6bc26b664d4faed335def49c467377aeb96e940bbca219c",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/ocenaudio/windows.json
+++ b/ee/maintained-apps/outputs/ocenaudio/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.20.1",
+      "version": "3.20.2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'ocenaudio' AND publisher = 'Ocenaudio Team';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'ocenaudio' AND publisher = 'Ocenaudio Team' AND version_compare(version, '3.20.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'ocenaudio' AND publisher = 'Ocenaudio Team' AND version_compare(version, '3.20.2') < 0);"
       },
       "installer_url": "https://www.ocenaudio.com/downloads/index.php/ocenaudio_windows64.exe",
       "install_script_ref": "ebf8794b",
       "uninstall_script_ref": "7264fb50",
-      "sha256": "c9a31c8fd00c8d5e2b0417c1aea105b72bb095a87a4433574805c16bfc98d8be",
+      "sha256": "c4322adbce034f9e90a576b353d48ed46056552eaaa76b2703d08da5c4e0e037",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/orbstack/darwin.json
+++ b/ee/maintained-apps/outputs/orbstack/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.2.1",
+      "version": "2.2.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kdrag0n.MacVirt';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kdrag0n.MacVirt' AND version_compare(bundle_short_version, '2.2.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kdrag0n.MacVirt' AND version_compare(bundle_short_version, '2.2.2') < 0);"
       },
-      "installer_url": "https://cdn-updates.orbstack.dev/arm64/OrbStack_v2.2.1_20628_arm64.dmg",
+      "installer_url": "https://cdn-updates.orbstack.dev/arm64/OrbStack_v2.2.2_20903_arm64.dmg",
       "install_script_ref": "01247e9f",
       "uninstall_script_ref": "a77f3f59",
-      "sha256": "5bc1719c3c987c4c60c65be9fdd65b4730990e1697ec1cb1c33e6bba31bf92b5",
+      "sha256": "3e2e9d746f9141fc6b999f0b36c1e9b3e9828729c677c57f5fe05ee4d8b64e91",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/postman/darwin.json
+++ b/ee/maintained-apps/outputs/postman/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.21.10",
+      "version": "12.22.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac' AND version_compare(bundle_short_version, '12.21.10') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac' AND version_compare(bundle_short_version, '12.22.0') < 0);"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.21.10/osx_arm64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.22.0/osx_arm64",
       "install_script_ref": "0e85ef74",
       "uninstall_script_ref": "20883323",
-      "sha256": "32898552c96ad46f925bbd83bb6104fd40c2234dda5bf03ac2a62cf82e46c139",
+      "sha256": "ace58ec4046da09180dc6510efc6da7846c4e15cd881604471f936d1e4718085",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/postman/windows.json
+++ b/ee/maintained-apps/outputs/postman/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.21.10",
+      "version": "12.22.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.21.10') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.22.0') < 0);"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.21.10/windows_64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.22.0/windows_64",
       "install_script_ref": "8594f0bc",
       "uninstall_script_ref": "fd59d029",
-      "sha256": "8d2524d4cf073addef35583103357907a29ed45b8bba0afd3a4927a61d8bc4a9",
+      "sha256": "e22893f590746ae50280c6ba8f39aaa0e611079083791c93ceea636cc60ba073",
       "default_categories": [
         "Developer tools"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated Antigravity for macOS to version 2.5.0.
  * Updated Badgeify for macOS to version 1.14.3.
  * Updated Creative Force Kelvin for Windows to version 6.7.0.
  * Updated Galaxy Modeler for Windows to version 13.0.0.
  * Updated ocenaudio for Windows to version 3.20.2.
  * Updated OrbStack for macOS to version 2.2.2.
  * Updated Postman for macOS and Windows to version 12.22.0.
  * Refreshed package download and verification details for all updated applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->