### PR TITLE
Add VEX exclusions for fleetdm/wix

### DIFF
--- a/security/status.md
+++ b/security/status.md
@@ -779,6 +779,30 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2026-07-13 12:01:46
 
+### [CVE-2026-59850](https://nvd.nist.gov/vuln/detail/CVE-2026-59850)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not establish SSH connections when using fleetdm/wix to generate MSI packages.
+- **Products:** `wix`,`pkg:deb/debian/libssh-4`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-08-03 09:32:48
+
+### [CVE-2026-59849](https://nvd.nist.gov/vuln/detail/CVE-2026-59849)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not establish SSH connections when using fleetdm/wix to generate MSI packages.
+- **Products:** `wix`,`pkg:deb/debian/libssh-4`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-08-03 09:32:48
+
+### [CVE-2026-59847](https://nvd.nist.gov/vuln/detail/CVE-2026-59847)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not establish SSH connections when using fleetdm/wix to generate MSI packages.
+- **Products:** `wix`,`pkg:deb/debian/libssh-4`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-08-03 09:32:48
+
 ### [CVE-2026-5773](https://nvd.nist.gov/vuln/detail/CVE-2026-5773)
 - **Author:** @lucasmrod
 - **Status:** `not_affected`
@@ -939,6 +963,14 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2026-05-20 10:30:00
 
+### [CVE-2026-3731](https://nvd.nist.gov/vuln/detail/CVE-2026-3731)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not establish SSH connections when using fleetdm/wix to generate MSI packages.
+- **Products:** `wix`,`pkg:deb/debian/libssh-4`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-08-03 09:32:48
+
 ### [CVE-2026-33846](https://nvd.nist.gov/vuln/detail/CVE-2026-33846)
 - **Author:** @lucasmrod
 - **Status:** `not_affected`
@@ -1059,6 +1091,14 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2026-05-19 10:16:53
 
+### [CVE-2026-15370](https://nvd.nist.gov/vuln/detail/CVE-2026-15370)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not establish SSH connections when using fleetdm/wix to generate MSI packages.
+- **Products:** `wix`,`pkg:deb/debian/libssh-4`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-08-03 09:32:48
+
 ### [CVE-2026-12912](https://nvd.nist.gov/vuln/detail/CVE-2026-12912)
 - **Author:** @lucasmrod
 - **Status:** `not_affected`
@@ -1066,6 +1106,14 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Products:** `wix`,`pkg:deb/debian/libtiff6`
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2026-07-27 17:21:36
+
+### [CVE-2026-0966](https://nvd.nist.gov/vuln/detail/CVE-2026-0966)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not establish SSH connections when using fleetdm/wix to generate MSI packages.
+- **Products:** `wix`,`pkg:deb/debian/libssh-4`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-08-03 09:32:48
 
 ### [CVE-2026-0861](https://nvd.nist.gov/vuln/detail/CVE-2026-0861)
 - **Author:** @lucasmrod

--- a/security/vex/wix/CVE-2026-0966.vex.json
+++ b/security/vex/wix/CVE-2026-0966.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-4e677a702d2f3941fddf82d3076853b106c3ca43c5ef663bb48007bed8a83d8d",
+  "author": "@lucasmrod",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-0966"
+      },
+      "products": [
+        {
+          "@id": "wix"
+        },
+        {
+          "@id": "pkg:deb/debian/libssh-4"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not establish SSH connections when using fleetdm/wix to generate MSI packages",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "timestamp": "2026-08-03T09:32:48.479247Z"
+    }
+  ],
+  "timestamp": "2026-08-03T09:32:48Z"
+}

--- a/security/vex/wix/CVE-2026-15370.vex.json
+++ b/security/vex/wix/CVE-2026-15370.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-69d65577a008d8dba2f845169c302fb93fd1a379b4e8b1b71a0e7ba65a68048d",
+  "author": "@lucasmrod",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-15370"
+      },
+      "products": [
+        {
+          "@id": "wix"
+        },
+        {
+          "@id": "pkg:deb/debian/libssh-4"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not establish SSH connections when using fleetdm/wix to generate MSI packages",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "timestamp": "2026-08-03T09:32:48.498571Z"
+    }
+  ],
+  "timestamp": "2026-08-03T09:32:48Z"
+}

--- a/security/vex/wix/CVE-2026-3731.vex.json
+++ b/security/vex/wix/CVE-2026-3731.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-8e004d49e901d1da42bf0120b6612835994d52a910a91728f0014b234ef17a4f",
+  "author": "@lucasmrod",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-3731"
+      },
+      "products": [
+        {
+          "@id": "wix"
+        },
+        {
+          "@id": "pkg:deb/debian/libssh-4"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not establish SSH connections when using fleetdm/wix to generate MSI packages",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "timestamp": "2026-08-03T09:32:48.516791Z"
+    }
+  ],
+  "timestamp": "2026-08-03T09:32:48Z"
+}

--- a/security/vex/wix/CVE-2026-59847.vex.json
+++ b/security/vex/wix/CVE-2026-59847.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-6a3a4650d3951852324d28872cc4fcdf5a73f1bd23eccf31e8662790000eadf6",
+  "author": "@lucasmrod",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-59847"
+      },
+      "products": [
+        {
+          "@id": "wix"
+        },
+        {
+          "@id": "pkg:deb/debian/libssh-4"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not establish SSH connections when using fleetdm/wix to generate MSI packages",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "timestamp": "2026-08-03T09:32:48.53337Z"
+    }
+  ],
+  "timestamp": "2026-08-03T09:32:48Z"
+}

--- a/security/vex/wix/CVE-2026-59849.vex.json
+++ b/security/vex/wix/CVE-2026-59849.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-e22e90c01c2e2178200da47450176c98f513c93b13ae6af36edf1bf630d456e1",
+  "author": "@lucasmrod",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-59849"
+      },
+      "products": [
+        {
+          "@id": "wix"
+        },
+        {
+          "@id": "pkg:deb/debian/libssh-4"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not establish SSH connections when using fleetdm/wix to generate MSI packages",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "timestamp": "2026-08-03T09:32:48.548741Z"
+    }
+  ],
+  "timestamp": "2026-08-03T09:32:48Z"
+}

--- a/security/vex/wix/CVE-2026-59850.vex.json
+++ b/security/vex/wix/CVE-2026-59850.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-2beec2767cb4251beffb50c40652e2ffebfaa450c7b81aba40ccdcf40b513118",
+  "author": "@lucasmrod",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-59850"
+      },
+      "products": [
+        {
+          "@id": "wix"
+        },
+        {
+          "@id": "pkg:deb/debian/libssh-4"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not establish SSH connections when using fleetdm/wix to generate MSI packages",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "timestamp": "2026-08-03T09:32:48.562951Z"
+    }
+  ],
+  "timestamp": "2026-08-03T09:32:48Z"
+}


### PR DESCRIPTION
Fixes: https://github.com/fleetdm/fleet/actions/runs/30791953163

New run: https://github.com/fleetdm/fleet/actions/runs/30802123748

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added vulnerability assessments for six CVEs.
  * Documented that the affected products are not impacted because MSI package generation does not establish SSH connections.
  * Included supporting vulnerability metadata and assessment details for improved security transparency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->