### PR TITLE
Fix Windows Git FMA patch policy never detecting outdated installs

### DIFF
--- a/changes/50283-git-fma-windows-patch-policy
+++ b/changes/50283-git-fma-windows-patch-policy
@@ -1,0 +1,1 @@
+- Fixed a bug where the patch policy for the Windows Git Fleet-maintained app always returned "Pass", even on hosts running an outdated version, so update automations never triggered. The generated query matched `programs.name LIKE 'Git %'`, but Git for Windows registers itself in the registry as exactly `Git`.

--- a/ee/maintained-apps/inputs/winget/git.json
+++ b/ee/maintained-apps/inputs/winget/git.json
@@ -3,7 +3,7 @@
   "slug": "git/windows",
   "package_identifier": "Git.Git",
   "unique_identifier": "Git",
-  "fuzzy_match_name": true,
+  "fuzzy_match_name": "Git%",
   "installer_arch": "x64",
   "installer_type": "exe",
   "installer_scope": "machine",

--- a/ee/maintained-apps/outputs/git/windows.json
+++ b/ee/maintained-apps/outputs/git/windows.json
@@ -3,8 +3,8 @@
     {
       "version": "2.55.0.3",
       "queries": {
-        "exists": "SELECT 1 FROM programs WHERE name LIKE 'Git %' AND publisher = 'The Git Development Community';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Git %' AND publisher = 'The Git Development Community' AND version_compare(version, '2.55.0.3') < 0);"
+        "exists": "SELECT 1 FROM programs WHERE name LIKE 'Git%' AND publisher = 'The Git Development Community';",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Git%' AND publisher = 'The Git Development Community' AND version_compare(version, '2.55.0.3') < 0);"
       },
       "installer_url": "https://github.com/git-for-windows/git/releases/download/v2.55.0.windows.3/Git-2.55.0.3-64-bit.exe",
       "install_script_ref": "64df8252",


### PR DESCRIPTION
**Related issue:** Resolves #50283

Git for Windows registers itself in the Windows uninstall registry as exactly `Git` — its Inno Setup script has set `UninstallDisplayName={#APP_NAME}` since [build-extra#365](https://github.com/git-for-windows/build-extra/pull/365) (2021). The generated queries matched `programs.name LIKE 'Git %'`, which cannot match that name, so the patch policy's `NOT EXISTS (...)` was always true and every host reported `Pass` regardless of installed version — update automations never fired. The same mismatch meant an existing Git install couldn't be matched to the maintained app.

The input now uses the custom fuzzy pattern `Git%`, which also covers the pre-2021 `Git <version>` DisplayName form (the oldest installs, which are exactly what a patch policy needs to flag), and relies on the existing `publisher = 'The Git Development Community'` guard to exclude GitHub Desktop, Git LFS, GitKraken and Git Extensions. This is the same match the app's own uninstall script and the FMA Windows CI workflow already use.

Instances that already created this policy pick up the corrected query when the next Git version becomes active, since the patch policy query is regenerated from the active installer.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`.

## Testing

Verified the `LIKE` semantics in SQLite against real-world `programs` rows (old pattern misses `Git`, new pattern matches both DisplayName forms, publisher guard still excludes GitHub Desktop / Git LFS / GitKraken / Git Extensions), and confirmed winget's `PackageVersion` matches the registry `DisplayVersion` for Git so up-to-date hosts still pass. `outputs/git/windows.json` was regenerated with the ingester rather than hand-edited. Not manually QA'd on a Windows host — relying on `test-fma-windows` validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git for Windows detection across supported environments.
  * Outdated installations can now be correctly identified and included in update automation, including registrations named “Git.”
  * Existing publisher and version checks remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->