### PR TITLE
Bump Zoom Rooms FMA (custom-tap) to 7.1.5.13403

### DIFF
--- a/ee/maintained-apps/inputs/homebrew/custom-tap/Casks/zoom-rooms.rb
+++ b/ee/maintained-apps/inputs/homebrew/custom-tap/Casks/zoom-rooms.rb
@@ -1,6 +1,6 @@
 cask "zoom-rooms" do
-  version "7.1.0.13088"
-  sha256 "856750027dba77cf3b1f265c54694db2daf4196e140d1e529948bb097fb23c57"
+  version "7.1.5.13403"
+  sha256 "3b303bc150a3a5d639f09439abf84f2117784a2124ba660f7c73917ba5ef9ab6"
 
   url "https://cdn.zoom.us/prod/#{version}/ZoomRooms.pkg"
   name "Zoom Rooms"

--- a/ee/maintained-apps/inputs/homebrew/custom-tap/api/zoom-rooms.json
+++ b/ee/maintained-apps/inputs/homebrew/custom-tap/api/zoom-rooms.json
@@ -6,9 +6,9 @@
   ],
   "desc": "Conference room software for Zoom meetings",
   "homepage": "https://www.zoom.com/en/products/zoom-rooms/",
-  "url": "https://cdn.zoom.us/prod/7.1.0.13088/ZoomRooms.pkg",
+  "url": "https://cdn.zoom.us/prod/7.1.5.13403/ZoomRooms.pkg",
   "url_specs": {},
-  "version": "7.1.0.13088",
+  "version": "7.1.5.13403",
   "autobump": true,
   "no_autobump_message": null,
   "skip_livecheck": true,
@@ -16,7 +16,7 @@
   "bundle_short_version": null,
   "pinned": false,
   "pinned_version": null,
-  "sha256": "856750027dba77cf3b1f265c54694db2daf4196e140d1e529948bb097fb23c57",
+  "sha256": "3b303bc150a3a5d639f09439abf84f2117784a2124ba660f7c73917ba5ef9ab6",
   "artifacts": [
     {
       "uninstall": [
@@ -87,6 +87,6 @@
   "languages": [],
   "ruby_source_path": "Casks/zoom-rooms.rb",
   "ruby_source_checksum": {
-    "sha256": "e71152c4bae02186b8510a19434853a8048dbd7ce7f21a0c46b6a7cf6576ab0c"
+    "sha256": "68a54a05536d96778206ce47a5ea03de6136a760b797ed8d08addef89c31e405"
   }
 }

--- a/ee/maintained-apps/outputs/zoom-rooms/darwin.json
+++ b/ee/maintained-apps/outputs/zoom-rooms/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.1.0.13088",
+      "version": "7.1.5.13403",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'us.zoom.ZoomPresence';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'us.zoom.ZoomPresence' AND version_compare(bundle_short_version, '7.1.0.13088') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'us.zoom.ZoomPresence' AND version_compare(bundle_short_version, '7.1.5.13403') < 0);"
       },
-      "installer_url": "https://cdn.zoom.us/prod/7.1.0.13088/ZoomRooms.pkg",
+      "installer_url": "https://cdn.zoom.us/prod/7.1.5.13403/ZoomRooms.pkg",
       "install_script_ref": "6fe6c33d",
       "uninstall_script_ref": "24ba341d",
-      "sha256": "856750027dba77cf3b1f265c54694db2daf4196e140d1e529948bb097fb23c57",
+      "sha256": "3b303bc150a3a5d639f09439abf84f2117784a2124ba660f7c73917ba5ef9ab6",
       "default_categories": [
         "Communication"
       ]


### PR DESCRIPTION
**Related issue:** NA — routine custom-tap cask maintenance

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops

## Testing

- [x] `go test ./ee/maintained-apps/...` passes
- [ ] QA'd all new/changed functionality manually (installer metadata, URL, and checksum verified as below; not yet deployed through a Fleet server)

No `changes/` file, consistent with prior custom-tap cask-bump PRs (#49563, #48028, #45912).

## Version bump details

| | Old | New |
|---|---|---|
| Version | 7.1.0.13088 | 7.1.5.13403 |

- **Upstream source:** `https://zoom.us/client/latest/ZoomRooms.pkg` redirects to `https://cdn.zoom.us/prod/7.1.5.13403/ZoomRooms.pkg` (Zoom does not expose a parseable Zoom Rooms version feed, per the cask's `livecheck` block, so this is the standard manual-bump discovery method).
- **New download URL:** `https://cdn.zoom.us/prod/7.1.5.13403/ZoomRooms.pkg`
- **sha256:** `3b303bc150a3a5d639f09439abf84f2117784a2124ba660f7c73917ba5ef9ab6`
- Downloaded installer verified: 587 MB, `xar archive` (matches expected `.pkg` format).

**Reviewer note:** `api/zoom-rooms.json` was updated mechanically because `regenerate.sh` requires macOS. Before merging, run `ee/maintained-apps/inputs/homebrew/custom-tap/regenerate.sh` locally and confirm `git diff` is clean for `api/zoom-rooms.json`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8YEGYFy9Uc88wvyg96ySE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated Zoom Rooms for macOS to version 7.1.5.13403.
  * Refreshed download links and package verification checksums.
  * Installation and uninstallation behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->