### PR TITLE
Fleet UI: Fix New user form dropdown layout shift

### DIFF
--- a/changes/48792-new-user-dropdown-layout-shift
+++ b/changes/48792-new-user-dropdown-layout-shift
@@ -1,0 +1,1 @@
+* Fixed the page content shifting left when opening a role dropdown near the bottom of the New user form (`/settings/users/new/human`). Dropdowns now flip upward when there's no room below the trigger.

--- a/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
+++ b/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
@@ -15,6 +15,7 @@ import Select, {
   components,
   DropdownIndicatorProps,
   GroupBase,
+  MenuPlacement,
   OptionProps,
   PropsValue,
   SingleValue,
@@ -130,6 +131,10 @@ export interface IDropdownWrapper {
    * not infer any of these on its own; without a value here screen readers
    * announce a bare "combobox". */
   ariaLabel?: string;
+  /** Defaults to "auto" so a menu near the viewport bottom flips upward
+   * instead of stretching the page and triggering a scrollbar-driven
+   * layout shift. */
+  menuPlacement?: MenuPlacement;
 }
 
 const getOptionBackgroundColor = (
@@ -376,6 +381,7 @@ const DropdownWrapper = ({
   nowrapMenu,
   customNoOptionsMessage,
   ariaLabel,
+  menuPlacement = "auto",
 }: IDropdownWrapper) => {
   const wrapperClassNames = classnames(baseClass, className, {
     [`${baseClass}__table-filter`]: variant === "table-filter",
@@ -474,6 +480,7 @@ const DropdownWrapper = ({
         tabIndex={isDisabled ? -1 : 0} // Ensures disabled dropdown has no keyboard accessibility
         placeholder={placeholder}
         onMenuOpen={onMenuOpen}
+        menuPlacement={menuPlacement}
         // Resolve accessible name: explicit prop wins, otherwise fall back
         // to the placeholder (usually "Select X"), otherwise the required
         // `name` (often a kebab-case identifier — least readable but


### PR DESCRIPTION
## Issue

Closes #48792 

Follow-up to #49430 / #48792 — reviewer flagged the same layout shift on `/settings/users/new/human`.

## Description

`DropdownWrapper` inherited react-select-5's default `menuPlacement="bottom"`, so the Role dropdown and per-fleet role dropdowns on the New user form opened downward, stretched the page taller, triggered a vertical scrollbar, and shifted content left ~15px — same mechanism as #48792.

- `DropdownWrapper` now accepts an optional `menuPlacement` prop, defaulting to `"auto"`, and forwards it to `<Select>`. The four callers that already pass `menuPlacement` explicitly (`UserMenu`, `ScriptDetailsModal`, `Certificates`, `ModalFooter.stories`) keep their overrides.

## Screenshot

<img width="1032" height="800" alt="Screenshot 2026-08-03 at 9 08 25 AM" src="https://github.com/user-attachments/assets/81beccf2-caf2-4955-9117-8b7ef364fc3d" />


## Testing

- [x] `/settings/users/new/human`: scroll form so a role dropdown sits near the viewport bottom → menu flips upward, no scrollbar appears, no 15px shift.
- [x] Same page, dropdown near the top: menu still opens downward.
- [x] Other DropdownWrappers across the app (filters, edit-user modal, etc.) still open downward when there's room.

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the New User form’s role dropdown positioning.
  * The menu now opens upward when space below is limited, preventing page content from shifting horizontally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->