### PR TITLE
Docs - Add max_software_package_size to app config

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -1794,7 +1794,7 @@ None.
   "activity_expiry_settings": {
     "activity_expiry_enabled": false,
     "activity_expiry_window": 0,
-    "preserve_host_activity_on_reenrollment": false,
+    "preserve_host_activity_on_reenrollment": false
   },
   "features": {
     "enable_host_users": true,
@@ -2050,7 +2050,8 @@ None.
     "disable_data_sync": false,
     "periodicity": 3600000000000,
     "recent_vulnerability_max_age": 2592000000000000
-  }
+  },
+  "max_software_package_size": 10737418240
 }
 ```
 
@@ -2160,7 +2161,7 @@ Modifies the Fleet's configuration with the supplied information.
   "activity_expiry_settings": {
     "activity_expiry_enabled": false,
     "activity_expiry_window": 0,
-    "preserve_host_activity_on_reenrollment": false,
+    "preserve_host_activity_on_reenrollment": false
   },
   "features": {
     "enable_host_users": true,


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

Updates documentation to add a new `max_software_package_size` field to the `GET /api/v1/fleet/config` endpoint for #42735 
(Also fixes bad json formatting around that)

@rachaelshaw do you have any suggestion for a better place to put this field? It comes from an environment variable and not  the saved config in the database, so there isn't an obvious existing place to put it in currently. 