### PR TITLE
Website: add support for new usage statistics

### DIFF
--- a/website/api/controllers/webhooks/receive-usage-analytics.js
+++ b/website/api/controllers/webhooks/receive-usage-analytics.js
@@ -53,6 +53,8 @@ module.exports = {
     conditionalAccessEnabled: {type: 'boolean', defaultsTo: false},
     gitOpsModeEnabled: {type: 'boolean', defaultsTo: false},
     gitOpsModeExceptions: {type: ['string'], defaultsTo: [] },
+    numHostsFleetMDMEnrolledMacOS: {type: 'number', defaultsTo: 0 },
+    numHostsFleetMDMEnrolledWindows: {type: 'number', defaultsTo: 0 },
   },
 
 

--- a/website/api/models/HistoricalUsageSnapshot.js
+++ b/website/api/models/HistoricalUsageSnapshot.js
@@ -57,7 +57,8 @@ module.exports = {
     entraConditionalAccessConfigured: {required: true, type: 'boolean'},
     gitOpsModeEnabled: {required: true, type: 'boolean'},
     gitOpsModeExceptions: {required: true, type: 'json'},
-
+    numHostsFleetMDMEnrolledMacOS: {required: true, type: 'number'},
+    numHostsFleetMDMEnrolledWindows: {required: true, type: 'number'},
     //  ╔═╗╔╦╗╔╗ ╔═╗╔╦╗╔═╗
     //  ║╣ ║║║╠╩╗║╣  ║║╚═╗
     //  ╚═╝╩ ╩╚═╝╚═╝═╩╝╚═╝


### PR DESCRIPTION
Changes:
- Updated the website to support two new usage statistics sent by Fleet servers: `numHostsFleetMDMEnrolledWindows` and `numHostsFleetMDMEnrolledMacOS`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Usage analytics now track Fleet MDM-enrolled host counts separately for macOS and Windows.
  * Historical usage records include these platform-specific enrollment totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->