### PR TITLE
Add software installer file size check before upload

### DIFF
--- a/changes/42735-fix-inconsistent-error-message
+++ b/changes/42735-fix-inconsistent-error-message
@@ -1,0 +1,1 @@
+- Added a software package maximum size error message in the UI to fix inconsistent errors across different browsers.

--- a/changes/42735-frontend-installer-size-check
+++ b/changes/42735-frontend-installer-size-check
@@ -1,0 +1,2 @@
+- Added `max_software_package_size` and `max_software_package_size_human` to the `GET /api/v1/fleet/config` response.
+- Fleet now rejects an oversized software package in the browser when it's selected, instead of after the upload finishes, so the maximum file size is reported the same way in Safari, Chrome, and Firefox.

--- a/changes/42735-frontend-installer-size-check
+++ b/changes/42735-frontend-installer-size-check
@@ -1,2 +1,0 @@
-- Added `max_software_package_size` and `max_software_package_size_human` to the `GET /api/v1/fleet/config` response.
-- Fleet now rejects an oversized software package in the browser when it's selected, instead of after the upload finishes, so the maximum file size is reported the same way in Safari, Chrome, and Firefox.

--- a/cmd/fleetctl/fleetctl/testdata/expectedGetConfigIncludeServerConfigJson.json
+++ b/cmd/fleetctl/fleetctl/testdata/expectedGetConfigIncludeServerConfigJson.json
@@ -280,6 +280,7 @@
         }
       }
     },
+    "max_software_package_size": 537919488,
     "gitops": {
       "gitops_mode_enabled": false,
       "repository_url": "",

--- a/cmd/fleetctl/fleetctl/testdata/expectedGetConfigIncludeServerConfigYaml.yml
+++ b/cmd/fleetctl/fleetctl/testdata/expectedGetConfigIncludeServerConfigYaml.yml
@@ -158,6 +158,7 @@ spec:
         max_backups: 0
         max_size: 500
       plugin: filesystem
+  max_software_package_size: 537919488
   org_info:
     org_logo_url: ""
     org_logo_url_light_background: ""

--- a/frontend/__mocks__/configMock.ts
+++ b/frontend/__mocks__/configMock.ts
@@ -235,7 +235,6 @@ const DEFAULT_CONFIG_MOCK: IConfig = {
     },
   },
   max_software_package_size: 10 * 1024 * 1024 * 1024,
-  max_software_package_size_human: "10GiB",
 };
 
 export const createMockConfig = (overrides?: Partial<IConfig>): IConfig => {

--- a/frontend/__mocks__/configMock.ts
+++ b/frontend/__mocks__/configMock.ts
@@ -234,6 +234,8 @@ const DEFAULT_CONFIG_MOCK: IConfig = {
       secrets: true,
     },
   },
+  max_software_package_size: 10 * 1024 * 1024 * 1024,
+  max_software_package_size_human: "10GiB",
 };
 
 export const createMockConfig = (overrides?: Partial<IConfig>): IConfig => {

--- a/frontend/interfaces/config.ts
+++ b/frontend/interfaces/config.ts
@@ -243,8 +243,6 @@ export interface IConfig {
   mdm: IMdmConfig;
   gitops: IGitOpsModeConfig;
   partnerships?: IFleetPartnerships;
-  /** Largest software installer the server will accept, in bytes. Set by the
-   * server's config file or environment, so it can't be changed from the UI. */
   max_software_package_size: number;
 }
 

--- a/frontend/interfaces/config.ts
+++ b/frontend/interfaces/config.ts
@@ -243,6 +243,13 @@ export interface IConfig {
   mdm: IMdmConfig;
   gitops: IGitOpsModeConfig;
   partnerships?: IFleetPartnerships;
+  /** Largest software installer the server will accept, in bytes. Set by the
+   * server's config file or environment, so it can't be changed from the UI. */
+  max_software_package_size: number;
+  /** The same limit as the server renders it, e.g. "1GiB". Use this in copy
+   * rather than formatting the byte count, so the wording matches the error
+   * the server returns to clients that upload anyway. */
+  max_software_package_size_human: string;
 }
 
 interface IFleetPartnerships {

--- a/frontend/interfaces/config.ts
+++ b/frontend/interfaces/config.ts
@@ -246,10 +246,6 @@ export interface IConfig {
   /** Largest software installer the server will accept, in bytes. Set by the
    * server's config file or environment, so it can't be changed from the UI. */
   max_software_package_size: number;
-  /** The same limit as the server renders it, e.g. "1GiB". Use this in copy
-   * rather than formatting the byte count, so the wording matches the error
-   * the server returns to clients that upload anyway. */
-  max_software_package_size_human: string;
 }
 
 interface IFleetPartnerships {

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditSoftwareModal/helpers.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditSoftwareModal/helpers.tsx
@@ -10,7 +10,7 @@ import {
 } from "pages/SoftwarePage/helpers";
 import { ensurePeriod } from "pages/SoftwarePage/SoftwareAddPage/helpers";
 
-const EDIT_SOFTWARE_ERROR_PREFIX = "Couldn't edit software.";
+export const EDIT_SOFTWARE_ERROR_PREFIX = "Couldn't edit software.";
 const DEFAULT_ERROR_MESSAGE = `${EDIT_SOFTWARE_ERROR_PREFIX} Please try again.`;
 
 // eslint-disable-next-line import/prefer-default-export

--- a/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tests.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tests.tsx
@@ -102,6 +102,19 @@ describe("PackageForm", () => {
       expect(screen.queryByLabelText("All hosts")).not.toBeInTheDocument();
     });
 
+    it("rejects any package when the limit is zero", async () => {
+      // A zero limit is a real setting, not a missing one, and the server
+      // refuses every upload under it.
+      const errorSpy = jest.spyOn(notify, "error");
+      const { container } = renderForm({}, { max_software_package_size: 0 });
+
+      await selectFileOfSize(container, 1);
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        "Couldn't add. The maximum file size is 0B."
+      );
+    });
+
     it("accepts a package at the configured maximum", async () => {
       const errorSpy = jest.spyOn(notify, "error");
       const { container } = renderForm(

--- a/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tests.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tests.tsx
@@ -1,8 +1,11 @@
 import React from "react";
 import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import { createCustomRenderer } from "test/test-utils";
 import { createMockSoftwarePackage } from "__mocks__/softwareMock";
+import { notify } from "components/ToastNotification";
+import { IConfig } from "interfaces/config";
 
 import PackageForm from "./PackageForm";
 
@@ -14,7 +17,8 @@ const BASE_PROPS = {
 };
 
 const renderForm = (
-  overrides: Partial<React.ComponentProps<typeof PackageForm>> = {}
+  overrides: Partial<React.ComponentProps<typeof PackageForm>> = {},
+  config?: Partial<IConfig>
 ) => {
   const render = createCustomRenderer({
     withBackendMock: true,
@@ -22,10 +26,22 @@ const renderForm = (
       app: {
         isPremiumTier: true,
         isGlobalAdmin: true,
+        config,
       },
     },
   });
   return render(<PackageForm {...BASE_PROPS} {...overrides} />);
+};
+
+const ONE_GIB = 1024 * 1024 * 1024;
+
+// The form reads File.size, so fake the size rather than allocating a real
+// multi-gigabyte buffer.
+const selectFileOfSize = async (container: HTMLElement, size: number) => {
+  const file = new File(["installer"], "test.pkg");
+  Object.defineProperty(file, "size", { value: size });
+  const input = container.querySelector("#upload-file") as HTMLInputElement;
+  await userEvent.upload(input, file);
 };
 
 const TARGET_BANNER_COPY = /If multiple packages of the same software target the same host, Fleet will install the one that was added first\./i;
@@ -61,6 +77,42 @@ describe("PackageForm", () => {
       expect(screen.queryByText(TARGET_BANNER_COPY)).not.toBeInTheDocument();
       expect(screen.getByLabelText("All hosts")).toBeInTheDocument();
       expect(screen.getByLabelText("Custom")).toBeInTheDocument();
+    });
+  });
+
+  describe("Maximum package size", () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it("rejects a package over the configured maximum before uploading", async () => {
+      const errorSpy = jest.spyOn(notify, "error");
+      const { container } = renderForm(
+        {},
+        { max_software_package_size: ONE_GIB }
+      );
+
+      await selectFileOfSize(container, ONE_GIB + 1);
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        "Couldn't add. The maximum file size is 1GiB."
+      );
+      // The rejected file never reaches form state, so the Target section
+      // stays hidden.
+      expect(screen.queryByLabelText("All hosts")).not.toBeInTheDocument();
+    });
+
+    it("accepts a package at the configured maximum", async () => {
+      const errorSpy = jest.spyOn(notify, "error");
+      const { container } = renderForm(
+        {},
+        { max_software_package_size: ONE_GIB }
+      );
+
+      await selectFileOfSize(container, ONE_GIB);
+
+      expect(errorSpy).not.toHaveBeenCalled();
+      expect(screen.getByLabelText("All hosts")).toBeInTheDocument();
     });
   });
 });

--- a/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
@@ -1,7 +1,8 @@
 // Used in AddPackageModal.tsx and EditSoftwareModal.tsx
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useContext } from "react";
 import classnames from "classnames";
 
+import { AppContext } from "context/app";
 import useGitOpsMode from "hooks/useGitOpsMode";
 import { LEARN_MORE_ABOUT_BASE_LINK } from "utilities/constants";
 import {
@@ -33,6 +34,8 @@ import {
 import { DropdownTargetLabelSelector } from "components/TargetLabelSelector";
 import SoftwareOptionsSelector from "pages/SoftwarePage/components/forms/SoftwareOptionsSelector";
 import { GitOpsCustomPackageBanner } from "pages/SoftwarePage/SoftwareAddPage/SoftwareCustomPackage/SoftwareCustomPackage";
+import { ADD_SOFTWARE_ERROR_PREFIX } from "pages/SoftwarePage/SoftwareAddPage/helpers";
+import { EDIT_SOFTWARE_ERROR_PREFIX } from "pages/SoftwarePage/SoftwareTitleDetailsPage/EditSoftwareModal/helpers";
 import InfoBanner from "components/InfoBanner";
 import CustomLink from "components/CustomLink";
 
@@ -181,6 +184,9 @@ const PackageForm = ({
   initialTargetType,
 }: IPackageFormProps) => {
   const { gitOpsModeEnabled, repoURL } = useGitOpsMode("software");
+  const { config } = useContext(AppContext);
+  const maxSoftwarePackageSize = config?.max_software_package_size;
+  const maxSoftwarePackageSizeHuman = config?.max_software_package_size_human;
 
   const initialFormData: IPackageFormData = {
     // `formData.software` is typed as `File | null` (its shape once a user
@@ -212,6 +218,20 @@ const PackageForm = ({
   const onFileSelect = (files: FileList | null) => {
     if (files && files.length > 0) {
       const file = files[0];
+
+      // Reject an oversized package here rather than letting the upload run to
+      // completion and fail server side. Safari reports the server's early
+      // close as a generic network error, so without this the admin loses the
+      // real reason along with the upload time.
+      if (maxSoftwarePackageSize && file.size > maxSoftwarePackageSize) {
+        const errorPrefix = isEditingSoftware
+          ? EDIT_SOFTWARE_ERROR_PREFIX
+          : ADD_SOFTWARE_ERROR_PREFIX;
+        notify.error(
+          `${errorPrefix} The maximum file size is ${maxSoftwarePackageSizeHuman}.`
+        );
+        return;
+      }
 
       // Only populate default install/uninstall scripts when adding (but not editing) software
       if (isEditingSoftware) {

--- a/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
@@ -41,7 +41,11 @@ import InfoBanner from "components/InfoBanner";
 import CustomLink from "components/CustomLink";
 
 import PackageAdvancedOptions from "../PackageAdvancedOptions";
-import { createTooltipContent, generateFormValidation } from "./helpers";
+import {
+  createTooltipContent,
+  estimateUploadSize,
+  generateFormValidation,
+} from "./helpers";
 import SoftwareDeploySlider from "../SoftwareDeploySelector";
 
 export const baseClass = "package-form";
@@ -215,20 +219,27 @@ const PackageForm = ({
     software: { isValid: false },
   });
 
+  const notifyTooLarge = () => {
+    const errorPrefix = isEditingSoftware
+      ? EDIT_SOFTWARE_ERROR_PREFIX
+      : ADD_SOFTWARE_ERROR_PREFIX;
+    notify.error(
+      `${errorPrefix} The maximum file size is ${formatFileSize(
+        maxSoftwarePackageSize || 0
+      )}.`
+    );
+  };
+
   const onFileSelect = (files: FileList | null) => {
     if (files && files.length > 0) {
       const file = files[0];
 
       // Reject before uploading if file size is too big
-      if (maxSoftwarePackageSize && file.size > maxSoftwarePackageSize) {
-        const errorPrefix = isEditingSoftware
-          ? EDIT_SOFTWARE_ERROR_PREFIX
-          : ADD_SOFTWARE_ERROR_PREFIX;
-        notify.error(
-          `${errorPrefix} The maximum file size is ${formatFileSize(
-            maxSoftwarePackageSize
-          )}.`
-        );
+      if (
+        maxSoftwarePackageSize !== undefined &&
+        file.size > maxSoftwarePackageSize
+      ) {
+        notifyTooLarge();
         return;
       }
 
@@ -269,6 +280,16 @@ const PackageForm = ({
 
   const onFormSubmit = (evt: React.FormEvent<HTMLFormElement>) => {
     evt.preventDefault();
+
+    // The server caps the whole request body, and not just the file.
+    if (
+      maxSoftwarePackageSize !== undefined &&
+      estimateUploadSize(formData) > maxSoftwarePackageSize
+    ) {
+      notifyTooLarge();
+      return;
+    }
+
     onSubmit(formData);
   };
 

--- a/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
@@ -6,6 +6,7 @@ import { AppContext } from "context/app";
 import useGitOpsMode from "hooks/useGitOpsMode";
 import { LEARN_MORE_ABOUT_BASE_LINK } from "utilities/constants";
 import {
+  formatFileSize,
   getExtensionFromFileName,
   getFileDetails,
 } from "utilities/file/fileUtils";
@@ -186,7 +187,6 @@ const PackageForm = ({
   const { gitOpsModeEnabled, repoURL } = useGitOpsMode("software");
   const { config } = useContext(AppContext);
   const maxSoftwarePackageSize = config?.max_software_package_size;
-  const maxSoftwarePackageSizeHuman = config?.max_software_package_size_human;
 
   const initialFormData: IPackageFormData = {
     // `formData.software` is typed as `File | null` (its shape once a user
@@ -219,16 +219,15 @@ const PackageForm = ({
     if (files && files.length > 0) {
       const file = files[0];
 
-      // Reject an oversized package here rather than letting the upload run to
-      // completion and fail server side. Safari reports the server's early
-      // close as a generic network error, so without this the admin loses the
-      // real reason along with the upload time.
+      // Reject before uploading if file size is too big
       if (maxSoftwarePackageSize && file.size > maxSoftwarePackageSize) {
         const errorPrefix = isEditingSoftware
           ? EDIT_SOFTWARE_ERROR_PREFIX
           : ADD_SOFTWARE_ERROR_PREFIX;
         notify.error(
-          `${errorPrefix} The maximum file size is ${maxSoftwarePackageSizeHuman}.`
+          `${errorPrefix} The maximum file size is ${formatFileSize(
+            maxSoftwarePackageSize
+          )}.`
         );
         return;
       }

--- a/frontend/pages/SoftwarePage/components/forms/PackageForm/helpers.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageForm/helpers.tsx
@@ -263,14 +263,18 @@ export const estimateUploadSize = (formData: IPackageFormData) => {
     String(formData.selfService).length +
     String(formData.automaticInstall).length;
 
+  // Names are user written, so count bytes. Anything outside ASCII takes more
+  // than one.
+  const encoder = new TextEncoder();
+
   formData.categories.forEach((category) => {
-    fieldsSize += category.length;
+    fieldsSize += encoder.encode(category).length;
   });
 
   // Labels are only sent when the target is Custom, and only the selected ones.
   if (formData.targetType === "Custom") {
     listNamesFromSelectedLabels(formData.labelTargets).forEach((label) => {
-      fieldsSize += label.length;
+      fieldsSize += encoder.encode(label).length;
     });
   }
 

--- a/frontend/pages/SoftwarePage/components/forms/PackageForm/helpers.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageForm/helpers.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 
 import { validateQuery } from "components/forms/validators/validate_query";
+import { listNamesFromSelectedLabels } from "services/entities/labels";
 import { getExtensionFromFileName } from "utilities/file/fileUtils";
+import { encodeScriptBase64 } from "utilities/scripts_encoding";
 import { getGitOpsModeTipContent } from "utilities/helpers";
 import { IPackageFormData, IPackageFormValidation } from "./PackageForm";
 
@@ -234,6 +236,45 @@ export const createTooltipContent = (
       ))}
     </>
   );
+};
+
+/** Calculates the size of the payload, because the server limits the whole
+ * request and not just the installer file. Not all fields are accounted for
+ * in this calculation so if the final payload sent is over the size limit,
+ * the server will reject it.
+ */
+export const estimateUploadSize = (formData: IPackageFormData) => {
+  const scripts = [
+    formData.installScript,
+    formData.uninstallScript,
+    formData.preInstallQuery,
+    formData.postInstallScript,
+  ];
+
+  // The scripts are base64 encoded on the way out, so encode them to get the
+  // length that actually goes over the wire.
+  let scriptsSize = 0;
+  scripts.forEach((script) => {
+    scriptsSize += encodeScriptBase64(script)?.length || 0;
+  });
+
+  // The two flags are sent as "true" or "false".
+  let fieldsSize =
+    String(formData.selfService).length +
+    String(formData.automaticInstall).length;
+
+  formData.categories.forEach((category) => {
+    fieldsSize += category.length;
+  });
+
+  // Labels are only sent when the target is Custom, and only the selected ones.
+  if (formData.targetType === "Custom") {
+    listNamesFromSelectedLabels(formData.labelTargets).forEach((label) => {
+      fieldsSize += label.length;
+    });
+  }
+
+  return (formData.software?.size || 0) + scriptsSize + fieldsSize;
 };
 
 export default generateFormValidation;

--- a/frontend/utilities/file/fileUtils.tests.tsx
+++ b/frontend/utilities/file/fileUtils.tests.tsx
@@ -1,4 +1,5 @@
 import {
+  formatFileSize,
   getExtensionFromFileName,
   getFileDetails,
   getPlatformDisplayName,
@@ -118,6 +119,30 @@ describe("fileUtils", () => {
     expect(getFileDetails(file)).toEqual({
       name: "my.file.name.pkg",
       description: "macOS",
+    });
+  });
+
+  describe("fileUtils - formatFileSize", () => {
+    // Expectations verified against the server's installersize.Human, which is
+    // what writes the same limit into its own too-large error
+    const testCases = [
+      { bytes: 0, expectedSize: "0B" },
+      { bytes: 999, expectedSize: "999B" },
+      { bytes: 1000, expectedSize: "1kB" },
+      { bytes: 1024, expectedSize: "1KiB" },
+      { bytes: 1000000, expectedSize: "1MB" },
+      { bytes: 1048576, expectedSize: "1MiB" },
+      { bytes: 536870912, expectedSize: "512MiB" },
+      { bytes: 1073741824, expectedSize: "1GiB" },
+      { bytes: 1500000000, expectedSize: "1.5GB" },
+      { bytes: 10737418240, expectedSize: "10GiB" },
+      { bytes: 5497558138880, expectedSize: "5TiB" },
+    ];
+
+    testCases.forEach(({ bytes, expectedSize }) => {
+      it(`should return "${expectedSize}" for ${bytes} bytes`, () => {
+        expect(formatFileSize(bytes)).toEqual(expectedSize);
+      });
     });
   });
 });

--- a/frontend/utilities/file/fileUtils.tests.tsx
+++ b/frontend/utilities/file/fileUtils.tests.tsx
@@ -137,6 +137,8 @@ describe("fileUtils", () => {
       { bytes: 1500000000, expectedSize: "1.5GB" },
       { bytes: 10737418240, expectedSize: "10GiB" },
       { bytes: 5497558138880, expectedSize: "5TiB" },
+      { bytes: 1000000000000000, expectedSize: "1PB" },
+      { bytes: 1125899906842624, expectedSize: "1PiB" },
     ];
 
     testCases.forEach(({ bytes, expectedSize }) => {

--- a/frontend/utilities/file/fileUtils.tsx
+++ b/frontend/utilities/file/fileUtils.tsx
@@ -103,8 +103,30 @@ export interface IFileDetails {
   description?: React.ReactNode;
 }
 
-const DECIMAL_ABBREVIATIONS = ["B", "kB", "MB", "GB", "TB"];
-const BINARY_ABBREVIATIONS = ["B", "KiB", "MiB", "GiB", "TiB"];
+// Both tables match the ones go-units gives the server, so the two agree at
+// every magnitude rather than only up to terabytes.
+const DECIMAL_ABBREVIATIONS = [
+  "B",
+  "kB",
+  "MB",
+  "GB",
+  "TB",
+  "PB",
+  "EB",
+  "ZB",
+  "YB",
+];
+const BINARY_ABBREVIATIONS = [
+  "B",
+  "KiB",
+  "MiB",
+  "GiB",
+  "TiB",
+  "PiB",
+  "EiB",
+  "ZiB",
+  "YiB",
+];
 
 const formatWithBase = (
   bytes: number,

--- a/frontend/utilities/file/fileUtils.tsx
+++ b/frontend/utilities/file/fileUtils.tsx
@@ -102,3 +102,29 @@ export interface IFileDetails {
   name: string;
   description?: React.ReactNode;
 }
+
+const DECIMAL_ABBREVIATIONS = ["B", "kB", "MB", "GB", "TB"];
+const BINARY_ABBREVIATIONS = ["B", "KiB", "MiB", "GiB", "TiB"];
+
+const formatWithBase = (
+  bytes: number,
+  base: number,
+  abbreviations: string[]
+) => {
+  let size = bytes;
+  let abbreviationIndex = 0;
+  while (size >= base && abbreviationIndex < abbreviations.length - 1) {
+    size /= base;
+    abbreviationIndex += 1;
+  }
+  // 4 significant digits with trailing zeros dropped, matching Go's "%.4g"
+  return `${Number(size.toPrecision(4))}${abbreviations[abbreviationIndex]}`;
+};
+
+// Returns a human readable size, like the server's installersize.Human function
+export const formatFileSize = (bytes: number) => {
+  const decimal = formatWithBase(bytes, 1000, DECIMAL_ABBREVIATIONS);
+  const binary = formatWithBase(bytes, 1024, BINARY_ABBREVIATIONS);
+
+  return binary.length < decimal.length ? binary : decimal;
+};

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -1054,11 +1054,12 @@ type EnrichedAppConfig struct {
 
 // enrichedAppConfigFields are grouped separately to aid with JSON unmarshaling
 type enrichedAppConfigFields struct {
-	UpdateInterval  *UpdateIntervalConfig  `json:"update_interval,omitempty"`
-	Vulnerabilities *VulnerabilitiesConfig `json:"vulnerabilities,omitempty"`
-	License         *LicenseInfo           `json:"license,omitempty"`
-	Logging         *Logging               `json:"logging,omitempty"`
-	Email           *EmailConfig           `json:"email,omitempty"`
+	UpdateInterval         *UpdateIntervalConfig  `json:"update_interval,omitempty"`
+	Vulnerabilities        *VulnerabilitiesConfig `json:"vulnerabilities,omitempty"`
+	License                *LicenseInfo           `json:"license,omitempty"`
+	Logging                *Logging               `json:"logging,omitempty"`
+	Email                  *EmailConfig           `json:"email,omitempty"`
+	MaxSoftwarePackageSize int64                  `json:"max_software_package_size,omitempty"`
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface to make sure we serialize

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -1059,7 +1059,7 @@ type enrichedAppConfigFields struct {
 	License                *LicenseInfo           `json:"license,omitempty"`
 	Logging                *Logging               `json:"logging,omitempty"`
 	Email                  *EmailConfig           `json:"email,omitempty"`
-	MaxSoftwarePackageSize int64                  `json:"max_software_package_size,omitempty"`
+	MaxSoftwarePackageSize int64                  `json:"max_software_package_size"`
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface to make sure we serialize

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -547,7 +547,7 @@ type Service interface {
 	AppConfigObfuscated(ctx context.Context) (info *AppConfig, err error)
 	ModifyAppConfig(ctx context.Context, p []byte, applyOpts ApplySpecOptions) (info *AppConfig, err error)
 	SandboxEnabled() bool
-	// MaxInstallerSizeBytes returns the configured upper bound for software installer uploads.
+	// MaxInstallerSizeBytes returns the configured maximum size for software installer uploads.
 	MaxInstallerSizeBytes() int64
 	AppConfigUrls(ctx context.Context) (urls *AppConfigUrls, err error)
 

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -547,6 +547,8 @@ type Service interface {
 	AppConfigObfuscated(ctx context.Context) (info *AppConfig, err error)
 	ModifyAppConfig(ctx context.Context, p []byte, applyOpts ApplySpecOptions) (info *AppConfig, err error)
 	SandboxEnabled() bool
+	// MaxInstallerSizeBytes returns the configured upper bound for software installer uploads.
+	MaxInstallerSizeBytes() int64
 	AppConfigUrls(ctx context.Context) (urls *AppConfigUrls, err error)
 
 	// ApplyEnrollSecretSpec adds and updates the enroll secrets specified in the spec.

--- a/server/mock/service/service_mock.go
+++ b/server/mock/service/service_mock.go
@@ -316,6 +316,8 @@ type ModifyAppConfigFunc func(ctx context.Context, p []byte, applyOpts fleet.App
 
 type SandboxEnabledFunc func() bool
 
+type MaxInstallerSizeBytesFunc func() int64
+
 type AppConfigUrlsFunc func(ctx context.Context) (urls *fleet.AppConfigUrls, err error)
 
 type ApplyEnrollSecretSpecFunc func(ctx context.Context, spec *fleet.EnrollSecretSpec, applyOpts fleet.ApplySpecOptions) error
@@ -1430,6 +1432,9 @@ type Service struct {
 
 	SandboxEnabledFunc        SandboxEnabledFunc
 	SandboxEnabledFuncInvoked bool
+
+	MaxInstallerSizeBytesFunc        MaxInstallerSizeBytesFunc
+	MaxInstallerSizeBytesFuncInvoked bool
 
 	AppConfigUrlsFunc        AppConfigUrlsFunc
 	AppConfigUrlsFuncInvoked bool
@@ -3473,6 +3478,13 @@ func (s *Service) SandboxEnabled() bool {
 	s.SandboxEnabledFuncInvoked = true
 	s.mu.Unlock()
 	return s.SandboxEnabledFunc()
+}
+
+func (s *Service) MaxInstallerSizeBytes() int64 {
+	s.mu.Lock()
+	s.MaxInstallerSizeBytesFuncInvoked = true
+	s.mu.Unlock()
+	return s.MaxInstallerSizeBytesFunc()
 }
 
 func (s *Service) AppConfigUrls(ctx context.Context) (urls *fleet.AppConfigUrls, err error) {

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -24,6 +24,7 @@ import (
 	authz_ctx "github.com/fleetdm/fleet/v4/server/contexts/authz"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxdb"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/contexts/installersize"
 	"github.com/fleetdm/fleet/v4/server/contexts/license"
 	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -58,6 +59,12 @@ type appConfigResponseFields struct {
 	SandboxEnabled bool                `json:"sandbox_enabled,omitempty"`
 	Err            error               `json:"error,omitempty"`
 	Partnerships   *fleet.Partnerships `json:"partnerships,omitempty"`
+	// MaxSoftwarePackageSize is the value of server.max_installer_size, which is
+	// set from the config file or the environment rather than the database. It
+	// is sent alongside the same string the server puts in its own too-large
+	// error so clients can reject a package without restating the limit.
+	MaxSoftwarePackageSize      int64  `json:"max_software_package_size"`
+	MaxSoftwarePackageSizeHuman string `json:"max_software_package_size_human"`
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface to make sure we serialize
@@ -206,6 +213,7 @@ func getAppConfigEndpoint(ctx context.Context, request interface{}, svc fleet.Se
 	}
 
 	features := appConfig.Features
+	maxSoftwarePackageSize := svc.MaxInstallerSizeBytes()
 	response := appConfigResponse{
 		AppConfig: fleet.AppConfig{
 			OrgInfo:                appConfig.OrgInfo,
@@ -236,6 +244,9 @@ func getAppConfigEndpoint(ctx context.Context, request interface{}, svc fleet.Se
 			Email:           emailConfig,
 			SandboxEnabled:  svc.SandboxEnabled(),
 			Partnerships:    partnerships,
+
+			MaxSoftwarePackageSize:      maxSoftwarePackageSize,
+			MaxSoftwarePackageSizeHuman: installersize.Human(maxSoftwarePackageSize),
 		},
 	}
 	return response, nil
@@ -2853,4 +2864,8 @@ func isValidHostname(h string) bool {
 	}
 
 	return true
+}
+
+func (svc *Service) MaxInstallerSizeBytes() int64 {
+	return svc.config.Server.MaxInstallerSizeBytes
 }

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -24,7 +24,6 @@ import (
 	authz_ctx "github.com/fleetdm/fleet/v4/server/contexts/authz"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxdb"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
-	"github.com/fleetdm/fleet/v4/server/contexts/installersize"
 	"github.com/fleetdm/fleet/v4/server/contexts/license"
 	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -59,12 +58,8 @@ type appConfigResponseFields struct {
 	SandboxEnabled bool                `json:"sandbox_enabled,omitempty"`
 	Err            error               `json:"error,omitempty"`
 	Partnerships   *fleet.Partnerships `json:"partnerships,omitempty"`
-	// MaxSoftwarePackageSize is the value of server.max_installer_size, which is
-	// set from the config file or the environment rather than the database. It
-	// is sent alongside the same string the server puts in its own too-large
-	// error so clients can reject a package without restating the limit.
-	MaxSoftwarePackageSize      int64  `json:"max_software_package_size"`
-	MaxSoftwarePackageSizeHuman string `json:"max_software_package_size_human"`
+	// Maximum software package size is loaded from the service.
+	MaxSoftwarePackageSize int64 `json:"max_software_package_size,omitempty"`
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface to make sure we serialize
@@ -213,7 +208,6 @@ func getAppConfigEndpoint(ctx context.Context, request interface{}, svc fleet.Se
 	}
 
 	features := appConfig.Features
-	maxSoftwarePackageSize := svc.MaxInstallerSizeBytes()
 	response := appConfigResponse{
 		AppConfig: fleet.AppConfig{
 			OrgInfo:                appConfig.OrgInfo,
@@ -237,16 +231,14 @@ func getAppConfigEndpoint(ctx context.Context, request interface{}, svc fleet.Se
 			ConditionalAccess: appConfig.ConditionalAccess,
 		},
 		appConfigResponseFields: appConfigResponseFields{
-			UpdateInterval:  updateIntervalConfig,
-			Vulnerabilities: vulnConfig,
-			License:         lic,
-			Logging:         loggingConfig,
-			Email:           emailConfig,
-			SandboxEnabled:  svc.SandboxEnabled(),
-			Partnerships:    partnerships,
-
-			MaxSoftwarePackageSize:      maxSoftwarePackageSize,
-			MaxSoftwarePackageSizeHuman: installersize.Human(maxSoftwarePackageSize),
+			UpdateInterval:         updateIntervalConfig,
+			Vulnerabilities:        vulnConfig,
+			License:                lic,
+			Logging:                loggingConfig,
+			Email:                  emailConfig,
+			SandboxEnabled:         svc.SandboxEnabled(),
+			Partnerships:           partnerships,
+			MaxSoftwarePackageSize: svc.MaxInstallerSizeBytes(),
 		},
 	}
 	return response, nil

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -59,7 +59,7 @@ type appConfigResponseFields struct {
 	Err            error               `json:"error,omitempty"`
 	Partnerships   *fleet.Partnerships `json:"partnerships,omitempty"`
 	// Maximum software package size is loaded from the service.
-	MaxSoftwarePackageSize int64 `json:"max_software_package_size,omitempty"`
+	MaxSoftwarePackageSize int64 `json:"max_software_package_size"`
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface to make sure we serialize
@@ -334,8 +334,9 @@ func modifyAppConfigEndpoint(ctx context.Context, request interface{}, svc fleet
 	response := appConfigResponse{
 		AppConfig: *appConfig,
 		appConfigResponseFields: appConfigResponseFields{
-			License: lic,
-			Logging: loggingConfig,
+			License:                lic,
+			Logging:                loggingConfig,
+			MaxSoftwarePackageSize: svc.MaxInstallerSizeBytes(),
 		},
 	}
 

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -8869,6 +8869,8 @@ func (s *integrationTestSuite) TestAppConfig() {
 	assert.False(t, acResp.ServerSettings.AIFeaturesDisabled)
 	assert.False(t, acResp.GitOpsConfig.GitopsModeEnabled)
 	assert.Zero(t, acResp.GitOpsConfig.RepositoryURL)
+	expectedMaxPackageSize := config.TestConfig().Server.MaxInstallerSizeBytes
+	assert.Equal(t, expectedMaxPackageSize, acResp.MaxSoftwarePackageSize)
 
 	// set the apple BM terms expired flag, and the enabled and configured flags,
 	// we'll check again at the end of this test to make sure they weren't


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #42735 
- Exposes max_software_package_size in the `GET /api/v1/fleet/config` endpoint
- Add frontend logic to use it to deny files that are too big before they get uploaded

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually
  - Tested on Chrome, Safari, and Firefox on macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable maximum software package size to application settings.
  * Software uploads exceeding the limit are rejected with a clear, size-specific error message.
  * Packages at or below the configured limit are accepted.
  * Added user-friendly file-size formatting across common units.
  * Upload validation accounts for the complete request size, including scripts and settings.

* **Tests**
  * Added coverage for upload validation, boundary conditions, size formatting, and configuration responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->