### PR TITLE
Link custom host vitals from the host name template description

### DIFF
--- a/frontend/pages/ManageControlsPage/OSSettings/cards/HostNameTemplate/HostNameTemplate.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/HostNameTemplate/HostNameTemplate.tsx
@@ -206,10 +206,9 @@ const HostNameTemplate = ({
     <>
       Set a naming convention for all macOS, iOS, or iPadOS hosts{scopeSuffix}{" "}
       Use <CustomLink text="built-in" url={builtInVariablesUrl} newTab />{" "}
-      variables,{" "}
-      <CustomLink text="custom" url={customVariablesUrl} /> variables, or{" "}
-      <CustomLink text="host vitals" url={customHostVitalsUrl} /> to
-      differentiate between hosts.
+      variables, <CustomLink text="custom" url={customVariablesUrl} />{" "}
+      variables, or <CustomLink text="host vitals" url={customHostVitalsUrl} />{" "}
+      to differentiate between hosts.
     </>
   );
 

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/HostNameTemplate/HostNameTemplate.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/HostNameTemplate/HostNameTemplate.tsx
@@ -197,12 +197,18 @@ const HostNameTemplate = ({
   const customVariablesUrl = getPathWithQueryParams(PATHS.CONTROLS_VARIABLES, {
     fleet_id: currentTeamId,
   });
+  const customHostVitalsUrl = getPathWithQueryParams(
+    PATHS.CONTROLS_VARIABLES_CUSTOM_HOST_VITALS,
+    { fleet_id: currentTeamId }
+  );
 
   const description = (
     <>
       Set a naming convention for all macOS, iOS, or iPadOS hosts{scopeSuffix}{" "}
-      Use <CustomLink text="built-in" url={builtInVariablesUrl} newTab /> or{" "}
-      <CustomLink text="custom" url={customVariablesUrl} /> variables to
+      Use <CustomLink text="built-in" url={builtInVariablesUrl} newTab />{" "}
+      variables,{" "}
+      <CustomLink text="custom" url={customVariablesUrl} /> variables, or{" "}
+      <CustomLink text="host vitals" url={customHostVitalsUrl} /> to
       differentiate between hosts.
     </>
   );

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/HostNameTemplate/HostNameTemplate.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/HostNameTemplate/HostNameTemplate.tsx
@@ -206,8 +206,8 @@ const HostNameTemplate = ({
     <>
       Set a naming convention for all macOS, iOS, or iPadOS hosts{scopeSuffix}{" "}
       Use <CustomLink text="built-in" url={builtInVariablesUrl} newTab />{" "}
-      variables,{" "}
-      <CustomLink text="custom" url={customVariablesUrl} /> variables, or{" "}
+      variables, <CustomLink text="custom" url={customVariablesUrl} />{" "}
+      variables, or{" "}
       <CustomLink text="custom host vitals" url={customHostVitalsUrl} />{" "}
       variables to differentiate between hosts.
     </>

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/HostNameTemplate/HostNameTemplate.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/HostNameTemplate/HostNameTemplate.tsx
@@ -208,8 +208,8 @@ const HostNameTemplate = ({
       Use <CustomLink text="built-in" url={builtInVariablesUrl} newTab />{" "}
       variables,{" "}
       <CustomLink text="custom" url={customVariablesUrl} /> variables, or{" "}
-      <CustomLink text="host vitals" url={customHostVitalsUrl} /> to
-      differentiate between hosts.
+      <CustomLink text="custom host vitals" url={customHostVitalsUrl} />{" "}
+      variables to differentiate between hosts.
     </>
   );
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #49489

The host name template card's description only linked to built-in and custom variables, even though `$FLEET_HOST_VITAL_<id>` references are also supported there as of #49489. This was missed when that story shipped, leaving admins without a pointer to the custom host vitals tab from the one place they'd set up a template.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

Already included in main as part of the feature branch merge.

<img width="767" height="117" alt="Screenshot 2026-08-04 at 11 22 07 AM" src="https://github.com/user-attachments/assets/6358ed90-88e1-4f97-8f26-ab56d00bde0b" />


## Testing

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OS Settings documentation with separate links for built-in and custom host vitals variables to improve accessibility and user reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->