### PR TITLE
Fix Gpg4win FMA ingest panic after winget relabeled 5.1.0 as x64

### DIFF
--- a/ee/maintained-apps/inputs/winget/gpg4win.json
+++ b/ee/maintained-apps/inputs/winget/gpg4win.json
@@ -7,7 +7,7 @@
   "program_publisher": "The Gpg4win Project",
   "install_script_path": "ee/maintained-apps/inputs/winget/scripts/gpg4win_install.ps1",
   "uninstall_script_path": "ee/maintained-apps/inputs/winget/scripts/gpg4win_uninstall.ps1",
-  "installer_arch": "x86",
+  "installer_arch": "x64",
   "installer_type": "exe",
   "installer_scope": "machine",
   "default_categories": ["Security"]

--- a/ee/maintained-apps/outputs/gpg4win/windows.json
+++ b/ee/maintained-apps/outputs/gpg4win/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "5.0.2",
+      "version": "5.1.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Gpg4win %' AND publisher = 'The Gpg4win Project';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Gpg4win %' AND publisher = 'The Gpg4win Project' AND version_compare(version, '5.0.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Gpg4win %' AND publisher = 'The Gpg4win Project' AND version_compare(version, '5.1.0') < 0);"
       },
-      "installer_url": "https://files.gpg4win.org/gpg4win-5.0.2.exe",
+      "installer_url": "https://files.gpg4win.org/gpg4win-5.1.0.exe",
       "install_script_ref": "33dd6930",
       "uninstall_script_ref": "5b342b42",
-      "sha256": "11864cdc6dedd58c5448ab1c0868886e56bdad96972bc06dcd44b80f9e527051",
+      "sha256": "9682f2825c70dc3e7efd8a3fcb9e676ccb9674bebbf6be1a30d5837f5b420a2e",
       "default_categories": [
         "Security"
       ]


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** NA — caught from a failing `Update Fleet-maintained apps` ingest run.

# What this does

Changes `installer_arch` from `x86` to `x64` for the Gpg4win Windows FMA, and regenerates its output (5.0.2 → 5.1.0).

## Why the ingest was failing

```
{"level":"INFO","msg":"ingesting winget app","name":"Gpg4win"}
panic: ingesting winget app: failed to find installer for app
```

This is **not** a removed winget package — Gpg4win is still published as `GnuPG.Gpg4win`. The manifest was fetched and parsed fine; the failure is the `selectedInstaller == nil` check in `ee/maintained-apps/ingesters/winget/ingester.go`, which means no installer entry matched all four selector fields from our input.

Upstream flipped the architecture label between versions:

| | 5.0.2 (last ingested) | 5.1.0 (new) |
|---|---|---|
| `Architecture` | **x86** | **x64** |
| Manifest generator | `wingetcreate 1.10.3.0` | `YamlCreate.ps1 Dumplings Mod` |

Our input pinned `x86` to match 5.0.2, so nothing matched once 5.1.0 landed in `winget-pkgs` (2026-08-03 18:11 UTC, microsoft/winget-pkgs#409397). The ingester only walks to an older version directory on a genuine 404 of the installer manifest — never because the newest version's installer failed to match — so it panics instead of falling back.

## The new x64 label is the correct one

Verified against the real installer rather than trusting either manifest:

- The NSIS stub's PE header is i386, which is very likely what `wingetcreate` guessed `x86` from. Installer stubs are almost always 32-bit, so stub arch says nothing about the payload.
- The payload ships 64-bit binaries in `bin/` (PE machine `0x8664`) alongside a 32-bit `bin_32/` compatibility set.

So 5.0.2's `x86` was the inaccurate manifest and the bot corrected it. Regenerated `sha256` also matches a fresh download of `gpg4win-5.1.0.exe` bit-for-bit (`9682f282…20a2e`).

## Blast radius

Worth flagging: this one field blocked **the entire FMA ingest**, not just Gpg4win. `failed to find installer for app` isn't matched by `isTransientGitHubError`, so it returns up to `panic(err)` in `cmd/maintained-apps/main.go`, which aborts the process before `processOutput` writes *any* app's manifest. Because the `ingesters` map is iterated in random order, this could take out the homebrew side too. Any future upstream flip of `installer_arch` / `installer_scope` / `installer_type` / `installer_locale` on any single app will do the same thing — worth a follow-up to make non-transient per-app ingest errors skip-and-report instead of fatal.

## Why no changes file

The net user-visible effect is a routine FMA version bump (Gpg4win 5.1.0), which the scheduled ingest PR delivers without changelog entries. Happy to add one if you'd rather it be called out.

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] QA'd all new/changed functionality manually

Verification performed:

- `go run ./cmd/maintained-apps -slug gpg4win/windows` completes with no panic (previously fatal).
- Diff is scoped to the two expected files; `outputs/apps.json` is untouched, since name/description didn't change.
- Regenerated `sha256` matches a fresh download of the upstream installer.
- Install/uninstall scripts need no changes — both already enumerate the native *and* `Wow6432Node` registry views across `HKLM`/`HKCU`, so detection survives the 32→64-bit flip.
- `installer_arch` is only a manifest selector plus CI runner routing in `.github/scripts/partition-fma-apps.sh`, where x64/x86/neutral all land on the same x64 runner. No routing change, and the field is never written into `outputs/`, so no user-visible arch claim changes.

Still needs the FMA validator's install/uninstall run on a Windows runner to confirm 5.1.0 installs and is detected — that's what the draft is for.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Gpg4win updated to version 5.1.0 with 64-bit installer support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->