### PR TITLE
Fix santa_allowed and santa_denied returning no results

### DIFF
--- a/orbit/changes/47477-santa-log-empty-results
+++ b/orbit/changes/47477-santa-log-empty-results
@@ -2,4 +2,4 @@
 
 * Fixed fleetd skipping rotated Santa logs that have not been compressed, so `santa_allowed` and `santa_denied` no longer miss events on hosts whose newsyslog configuration leaves archives uncompressed.
 
-* Improved Santa log scraping: `santa_allowed` and `santa_denied` now read the Santa logs about 3x faster while allocating 5-7x less memory.
+* Improved Santa log scraping: `santa_allowed` and `santa_denied` now parse the Santa logs about 3x faster while allocating 5-7x less memory, and stop reading rotated logs once they have the most recent 10,000 events, so on a busy host the compressed archives are no longer decompressed on every query.

--- a/orbit/changes/47477-santa-log-empty-results
+++ b/orbit/changes/47477-santa-log-empty-results
@@ -1,0 +1,5 @@
+* Fixed the `santa_allowed` and `santa_denied` tables returning no results on hosts where Santa is running, most often in monitor mode. A single log line longer than 64KB (Santa logs process arguments, which have no practical size limit), a log rotation landing mid-read, or an archive that could not be decompressed discarded every event read from the other Santa log files. Reads are now best effort: over-long lines are truncated, a file that cannot be read no longer discards the events read from the rest, and failures are logged instead of silently returning zero rows.
+
+* Fixed fleetd skipping rotated Santa logs that have not been compressed, so `santa_allowed` and `santa_denied` no longer miss events on hosts whose newsyslog configuration leaves archives uncompressed.
+
+* Improved Santa log scraping: `santa_allowed` and `santa_denied` now read the Santa logs about 3x faster while allocating 5-7x less memory.

--- a/orbit/pkg/table/santa/ringbuffer.go
+++ b/orbit/pkg/table/santa/ringbuffer.go
@@ -53,9 +53,14 @@ func (r *ringBuffer) Reset() {
 }
 
 func (r *ringBuffer) SliceChrono() []logEntry {
-	out := make([]logEntry, r.size)
-	for i := 0; i < r.size; i++ {
-		out[i] = r.buf[(r.start+i)%len(r.buf)]
+	return r.AppendTo(make([]logEntry, 0, r.size))
+}
+
+// AppendTo appends the buffer's entries, oldest first, to dst. It lets several
+// buffers be assembled into one result without a slice per buffer.
+func (r *ringBuffer) AppendTo(dst []logEntry) []logEntry {
+	for i := range r.size {
+		dst = append(dst, r.buf[(r.start+i)%len(r.buf)])
 	}
-	return out
+	return dst
 }

--- a/orbit/pkg/table/santa/ringbuffer.go
+++ b/orbit/pkg/table/santa/ringbuffer.go
@@ -5,29 +5,51 @@ package santa
 
 type ringBuffer struct {
 	buf   []logEntry
+	cap   int
 	start int
 	size  int
 }
 
 func newRingBuffer(n int) *ringBuffer {
-	return &ringBuffer{buf: make([]logEntry, n)}
+	// The backing array grows on demand: most hosts have far fewer events than the
+	// cap, and the tables allocate a buffer on every query.
+	return &ringBuffer{cap: n}
 }
 
 func (r *ringBuffer) Add(e logEntry) {
-	if len(r.buf) == 0 {
+	if r.cap <= 0 {
 		return
 	}
-	if r.size < len(r.buf) {
-		r.buf[(r.start+r.size)%len(r.buf)] = e
+
+	if r.size < r.cap {
+		if r.size == len(r.buf) {
+			r.grow()
+		}
+		r.buf[r.size] = e
 		r.size++
-	} else {
-		r.buf[r.start] = e
-		r.start = (r.start + 1) % len(r.buf)
+		return
 	}
+
+	// Full: overwrite the oldest entry.
+	r.buf[r.start] = e
+	r.start = (r.start + 1) % len(r.buf)
+}
+
+func (r *ringBuffer) grow() {
+	buf := make([]logEntry, min(max(2*len(r.buf), 64), r.cap))
+	copy(buf, r.buf)
+	r.buf = buf
 }
 
 func (r *ringBuffer) Len() int {
 	return r.size
+}
+
+// Reset empties the buffer so it can be reused, releasing the entries it held.
+func (r *ringBuffer) Reset() {
+	clear(r.buf)
+	r.start = 0
+	r.size = 0
 }
 
 func (r *ringBuffer) SliceChrono() []logEntry {

--- a/orbit/pkg/table/santa/ringbuffer_test.go
+++ b/orbit/pkg/table/santa/ringbuffer_test.go
@@ -59,6 +59,49 @@ func TestRingBuffer_ExactCapacity(t *testing.T) {
 	require.Equal(t, []string{"A", "B"}, tsSlice(rb.SliceChrono()))
 }
 
+// TestRingBuffer_GrowsOnDemand verifies that the backing array is sized to the
+// entries actually added, not to the cap: the santa tables allocate a buffer on
+// every query and most hosts have far fewer events than the cap allows.
+func TestRingBuffer_GrowsOnDemand(t *testing.T) {
+	rb := newRingBuffer(10_000)
+	require.Empty(t, rb.buf)
+
+	for i := range 5 {
+		rb.Add(mk(i))
+	}
+	require.Less(t, len(rb.buf), rb.cap)
+	require.Equal(t, []string{"A", "B", "C", "D", "E"}, tsSlice(rb.SliceChrono()))
+
+	// Filling past the cap keeps the last cap entries and grows no further.
+	rb = newRingBuffer(3)
+	for i := range 100 {
+		rb.Add(mk(i))
+	}
+	require.Len(t, rb.buf, 3)
+	require.Equal(t, 3, rb.Len())
+}
+
+func TestRingBuffer_Reset(t *testing.T) {
+	rb := newRingBuffer(3)
+	// Wrap the buffer so the reset has to clear a non-zero start offset.
+	for i := range 5 {
+		rb.Add(mk(i))
+	}
+	rb.Reset()
+	require.Equal(t, 0, rb.Len())
+	require.Empty(t, rb.SliceChrono())
+
+	rb.Add(mk(0))
+	require.Equal(t, []string{"A"}, tsSlice(rb.SliceChrono()))
+}
+
+func TestRingBuffer_ZeroCapacity(t *testing.T) {
+	rb := newRingBuffer(0)
+	rb.Add(mk(0))
+	require.Equal(t, 0, rb.Len())
+	require.Empty(t, rb.SliceChrono())
+}
+
 func TestRingBuffer_Empty(t *testing.T) {
 	rb := newRingBuffer(2)
 	require.Empty(t, rb.SliceChrono())

--- a/orbit/pkg/table/santa/ringbuffer_test.go
+++ b/orbit/pkg/table/santa/ringbuffer_test.go
@@ -20,43 +20,32 @@ func tsSlice(entries []logEntry) []string {
 	return out
 }
 
-func TestRingBuffer_Len(t *testing.T) {
-	rb := newRingBuffer(3)
-	require.Equal(t, 0, rb.Len())
-	rb.Add(mk(0))
-	require.Equal(t, 1, rb.Len())
-	rb.Add(mk(1))
-	require.Equal(t, 2, rb.Len())
-	rb.Add(mk(2))
-	require.Equal(t, 3, rb.Len())
-	rb.Add(mk(3))
-	require.Equal(t, 3, rb.Len())
-	rb.Add(mk(4))
-	require.Equal(t, 3, rb.Len())
-}
-
-func TestRingBuffer_NoWrap(t *testing.T) {
-	rb := newRingBuffer(3)
-	rb.Add(mk(0)) // A
-	rb.Add(mk(1)) // B
-	require.Equal(t, []string{"A", "B"}, tsSlice(rb.SliceChrono()))
-}
-
-func TestRingBuffer_Wrap(t *testing.T) {
-	rb := newRingBuffer(3)
-	// Add 6: A B C D E F → keep last 3: D E F
-	for i := range 6 {
-		rb.Add(mk(i))
+// TestRingBuffer_KeepsNewestInOrder verifies the core contract at every fill
+// level: the buffer holds the last cap entries added, oldest first.
+func TestRingBuffer_KeepsNewestInOrder(t *testing.T) {
+	tests := []struct {
+		name string
+		cap  int
+		adds int
+		want []string
+	}{
+		{"empty", 2, 0, []string{}},
+		{"below capacity", 3, 2, []string{"A", "B"}},
+		{"at capacity", 2, 2, []string{"A", "B"}},
+		{"wraps keeping the newest", 3, 6, []string{"D", "E", "F"}},
+		{"zero capacity holds nothing", 0, 4, []string{}},
 	}
-	require.Equal(t, []string{"D", "E", "F"}, tsSlice(rb.SliceChrono()))
-}
 
-func TestRingBuffer_ExactCapacity(t *testing.T) {
-	rb := newRingBuffer(2)
-	rb.Add(mk(0)) // A
-	rb.Add(mk(1)) // B
-
-	require.Equal(t, []string{"A", "B"}, tsSlice(rb.SliceChrono()))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rb := newRingBuffer(tt.cap)
+			for i := range tt.adds {
+				rb.Add(mk(i))
+			}
+			require.Equal(t, tt.want, tsSlice(rb.SliceChrono()))
+			require.Equal(t, len(tt.want), rb.Len())
+		})
+	}
 }
 
 // TestRingBuffer_GrowsOnDemand verifies that the backing array is sized to the
@@ -93,16 +82,4 @@ func TestRingBuffer_Reset(t *testing.T) {
 
 	rb.Add(mk(0))
 	require.Equal(t, []string{"A"}, tsSlice(rb.SliceChrono()))
-}
-
-func TestRingBuffer_ZeroCapacity(t *testing.T) {
-	rb := newRingBuffer(0)
-	rb.Add(mk(0))
-	require.Equal(t, 0, rb.Len())
-	require.Empty(t, rb.SliceChrono())
-}
-
-func TestRingBuffer_Empty(t *testing.T) {
-	rb := newRingBuffer(2)
-	require.Empty(t, rb.SliceChrono())
 }

--- a/orbit/pkg/table/santa/santa_log.go
+++ b/orbit/pkg/table/santa/santa_log.go
@@ -19,7 +19,6 @@ import (
 	"io/fs"
 	"os"
 	"slices"
-	"time"
 
 	"github.com/osquery/osquery-go/plugin/table"
 	"github.com/rs/zerolog/log"
@@ -38,11 +37,6 @@ const (
 var (
 	maxEntries = 10_000
 	logPath    = defaultLogPath
-
-	// The active log is briefly absent between newsyslog renaming it and santad
-	// recreating it, so a missing file is retried before being given up on.
-	currentLogAttempts   = 3
-	currentLogRetryDelay = 50 * time.Millisecond
 )
 
 type santaDecisionType int
@@ -313,45 +307,6 @@ func scrapeCompressedSantaLog(ctx context.Context, path string, decision santaDe
 	return scrapeStream(ctx, gzReader, decision, rb)
 }
 
-// scrapeCurrentSantaLog reads the active log, retrying a missing file for the
-// window in which newsyslog has renamed it and santad has not recreated it yet.
-// A file that stays missing is not an error: Santa may not be installed, or may
-// not be configured to log to a file (see `santa_status.log_type`). Its rotated
-// contents are still read from the archives.
-//
-// hasArchives reports whether any rotated log was found. Waiting is only worth it
-// mid-rotation, which implies at least one rotated log on disk, because newsyslog
-// renames santa.log to santa.log.0 before santad recreates it. With no archives at
-// all nothing is being rotated, and every host that does not run Santa would pay
-// the retry delay on every query.
-func scrapeCurrentSantaLog(ctx context.Context, path string, decision santaDecisionType, rb *ringBuffer, hasArchives bool) error {
-	for attempt := 1; ; attempt++ {
-		err := scrapePlainSantaLog(ctx, path, decision, rb)
-		if !errors.Is(err, errLogMissing) {
-			return err
-		}
-		if !hasArchives || attempt >= currentLogAttempts {
-			log.Debug().Str("path", path).Msg("santa log not found")
-			return nil
-		}
-
-		if err := retryWait(ctx); err != nil {
-			return err
-		}
-	}
-}
-
-// retryWait waits before the next attempt at reading the current log. It is a
-// variable so tests can drive the retry without sleeping.
-var retryWait = func(ctx context.Context) error {
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-time.After(currentLogRetryDelay):
-		return nil
-	}
-}
-
 // archive is a rotated log file. newsyslog compresses a rotated log after
 // renaming it, so for a brief window the compressed file is incomplete while the
 // uncompressed one is still on disk; keep the latter as a fallback. Hosts whose
@@ -449,7 +404,20 @@ func scrapeSantaLogFromBase(ctx context.Context, decision santaDecisionType, pat
 
 	// The active log holds the newest events, so it is read first.
 	current := newRingBuffer(maxEntries)
-	if err := scrapeCurrentSantaLog(ctx, path, decision, current, len(rotated) > 0); err != nil {
+	switch err := scrapePlainSantaLog(ctx, path, decision, current); {
+	case err == nil:
+	case errors.Is(err, errLogMissing):
+		// Not an error: Santa may not be installed, or may not be configured to log to
+		// a file (see `santa_status.log_type`). It may also have been renamed by
+		// newsyslog a moment ago, in which case its events are in a santa.log.0 that
+		// discovery ran too early to see, so look again. With archives already found
+		// there is nothing to look for: newsyslog's rename shifts the events into a
+		// path that is on the list either way.
+		log.Debug().Str("path", path).Msg("santa log not found")
+		if len(rotated) == 0 {
+			rotated = archives(path)
+		}
+	default:
 		errs = append(errs, err)
 	}
 

--- a/orbit/pkg/table/santa/santa_log.go
+++ b/orbit/pkg/table/santa/santa_log.go
@@ -422,13 +422,11 @@ func scrapeSantaLogFromBase(ctx context.Context, decision santaDecisionType, pat
 		// Not an error: Santa may not be installed, or may not be configured to log to
 		// a file (see `santa_status.log_type`). It may also have been renamed by
 		// newsyslog a moment ago, in which case its events are in a santa.log.0 that
-		// discovery ran too early to see, so look again. With archives already found
-		// there is nothing to look for: newsyslog's rename shifts the events into a
-		// path that is on the list either way.
+		// discovery ran too early to see — and every archive on the list has shifted
+		// up one index — so discover again. Nothing has been read yet, so replacing
+		// the list cannot double-count.
 		log.Debug().Str("path", path).Msg("santa log not found")
-		if len(rotated) == 0 {
-			rotated = archives(path)
-		}
+		rotated = archives(path)
 	default:
 		errs = append(errs, err)
 	}

--- a/orbit/pkg/table/santa/santa_log.go
+++ b/orbit/pkg/table/santa/santa_log.go
@@ -264,8 +264,9 @@ func scrapeStream(ctx context.Context, r io.Reader, decision santaDecisionType, 
 }
 
 // errLogMissing reports a log file that was not there to open, as opposed to one
-// that failed while being read. Only the former is safe to retry: a retry after a
-// partial read would add the entries it already collected a second time.
+// that failed while being read. Only the former is benign: Santa may not be
+// installed, or a rotation may have just renamed the file, so it is reported as no
+// events rather than as a failed read.
 var errLogMissing = errors.New("santa log file does not exist")
 
 // openLog opens a log file, distinguishing a file that is not there from one that
@@ -400,6 +401,17 @@ func scrapeSantaLog(ctx context.Context, decision santaDecisionType) ([]logEntry
 func scrapeSantaLogFromBase(ctx context.Context, decision santaDecisionType, path string) ([]logEntry, error) {
 	var errs []error
 
+	// Archives are discovered before the active log is read, and that order matters:
+	// were discovery to run afterwards, a rotation in between would move the events
+	// just read from santa.log into a santa.log.0 that discovery then finds, returning
+	// them twice. The stat calls are cheap enough to pay even when the active log ends
+	// up satisfying the cap on its own.
+	//
+	// A rotation landing between reading the active log and reading the archives can
+	// still return a few events twice, because santa.log.0 then holds what santa.log
+	// held moments earlier. That window is a few milliseconds against a rotation
+	// interval of hours, and repeating an event is a better failure for an audit table
+	// than silently dropping one.
 	rotated := archives(path)
 
 	// The active log holds the newest events, so it is read first.

--- a/orbit/pkg/table/santa/santa_log.go
+++ b/orbit/pkg/table/santa/santa_log.go
@@ -10,13 +10,16 @@ package santa
 
 import (
 	"bufio"
+	"bytes"
 	"compress/gzip"
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
-	"regexp"
-	"strings"
+	"slices"
+	"time"
 
 	"github.com/osquery/osquery-go/plugin/table"
 	"github.com/rs/zerolog/log"
@@ -25,9 +28,22 @@ import (
 const (
 	kLogEntryPreface = "santad: "
 	defaultLogPath   = "/var/db/santa/santa.log"
+
+	// maxLineBytes is how much of a single log line is retained. Santa writes the
+	// process arguments last, after every field these tables read, so the rest of
+	// an over-long line is discarded instead of failing the read.
+	maxLineBytes = 64 * 1024
 )
 
-var maxEntries = 10_000
+var (
+	maxEntries = 10_000
+	logPath    = defaultLogPath
+
+	// The active log is briefly absent between newsyslog renaming it and santad
+	// recreating it, so a missing file is retried before being given up on.
+	currentLogAttempts   = 3
+	currentLogRetryDelay = 50 * time.Millisecond
+)
 
 type santaDecisionType int
 
@@ -43,7 +59,17 @@ type logEntry struct {
 	SHA256      string
 }
 
-var timestampRegex = regexp.MustCompile(`\[([^\]]+)\]`)
+// Field names and markers, as byte slices to keep line parsing allocation-free.
+var (
+	logEntryPreface = []byte(kLogEntryPreface)
+	allowMarker     = []byte("decision=ALLOW")
+	denyMarker      = []byte("decision=DENY")
+	keyPath         = []byte("path")
+	keyReason       = []byte("reason")
+	keySHA256       = []byte("sha256")
+	fieldSep        = []byte("|")
+	keyValueSep     = []byte("=")
+)
 
 func LogColumns() []table.ColumnDefinition {
 	return []table.ColumnDefinition{
@@ -65,8 +91,11 @@ func GenerateDenied(ctx context.Context, queryContext table.QueryContext) ([]map
 func generate(ctx context.Context, dec santaDecisionType) ([]map[string]string, error) {
 	entries, err := scrapeSantaLog(ctx, dec)
 	if err != nil {
-		log.Debug().Err(err).Msg("failed to scrape santa log")
-		return []map[string]string{}, nil
+		// Report the failure but return whatever was read: returning an error here
+		// would fail the whole query on every affected host, and a synthetic error
+		// row would be indistinguishable from a real Santa event. Operators can
+		// check `santa_status` (file_logging, log_type) for a misconfigured Santa.
+		log.Error().Err(err).Int("entries", len(entries)).Msg("scraping santa log")
 	}
 
 	results := make([]map[string]string, 0, len(entries))
@@ -81,140 +110,355 @@ func generate(ctx context.Context, dec santaDecisionType) ([]map[string]string, 
 	return results, nil
 }
 
-func extractValues(line string) map[string]string {
-	values := make(map[string]string, 8)
+// parseLogEntry extracts the columns these tables expose from one log line. It
+// reports false for a line with no timestamp, which is not a Santa event. Only
+// the retained fields are copied out of line, so a line is never materialized as
+// a string; in monitor mode this runs over every exec Santa logs.
+func parseLogEntry(line []byte) (logEntry, bool) {
+	timestamp, ok := extractTimestamp(line)
+	if !ok {
+		return logEntry{}, false
+	}
+	entry := logEntry{Timestamp: string(timestamp)}
 
-	if m := timestampRegex.FindStringSubmatch(line); len(m) > 1 {
-		values["timestamp"] = m[1]
+	_, fields, found := bytes.Cut(line, logEntryPreface)
+	if !found {
+		return entry, true
 	}
 
-	pos := strings.Index(line, kLogEntryPreface)
-	if pos == -1 {
-		return values
-	}
-	rest := line[pos+len(kLogEntryPreface):]
-
-	for seg := range strings.SplitSeq(rest, "|") {
-		seg = strings.TrimSpace(seg)
-		if seg == "" {
+	for seg := range bytes.SplitSeq(fields, fieldSep) {
+		k, v, found := bytes.Cut(seg, keyValueSep)
+		if !found {
 			continue
 		}
-		k, v, ok := strings.Cut(seg, "=")
-		if !ok {
+		k = bytes.TrimSpace(k)
+		v = bytes.Trim(bytes.TrimSpace(v), `"'`)
+		if len(k) == 0 || len(v) == 0 {
 			continue
 		}
-		k = strings.ToLower(strings.TrimSpace(k))
-		v = strings.Trim(strings.TrimSpace(v), `"'`)
-		if k != "" && v != "" {
-			values[k] = v
+
+		switch {
+		case bytes.EqualFold(k, keyPath):
+			entry.Application = string(v)
+		case bytes.EqualFold(k, keyReason):
+			entry.Reason = string(v)
+		case bytes.EqualFold(k, keySHA256):
+			entry.SHA256 = string(v)
 		}
 	}
-	return values
+	return entry, true
 }
 
-func scrapeStream(ctx context.Context, scanner *bufio.Scanner, decision santaDecisionType, rb *ringBuffer) error {
-	for scanner.Scan() {
+// extractTimestamp returns the contents of the first non-empty bracketed group in
+// line, matching the `\[([^\]]+)\]` pattern it replaces.
+func extractTimestamp(line []byte) ([]byte, bool) {
+	for len(line) > 0 {
+		open := bytes.IndexByte(line, '[')
+		if open == -1 {
+			return nil, false
+		}
+		line = line[open+1:]
+		if length := bytes.IndexByte(line, ']'); length > 0 {
+			return line[:length], true
+		}
+	}
+	return nil, false
+}
+
+// lineReader reads newline-terminated lines, retaining at most max bytes of
+// each and discarding the remainder. Unlike bufio.Scanner it cannot fail on an
+// over-long line: one Santa exec event with long arguments would otherwise abort
+// the scrape and leave the table empty until that line rotated out of the log.
+type lineReader struct {
+	r   *bufio.Reader
+	max int
+	// long holds a line assembled across several reads, reused between lines.
+	long []byte
+}
+
+func newLineReader(r io.Reader, max int) *lineReader {
+	// Sizing the read buffer to the retention limit keeps every line that is
+	// retained in full on the single-read path below.
+	return &lineReader{r: bufio.NewReaderSize(r, max), max: max}
+}
+
+// readLine returns the next line with its trailing newline removed. The returned
+// slice is only valid until the next call. terminated reports whether the line
+// ended with a newline; a final line without one was caught mid-write.
+func (lr *lineReader) readLine() (line []byte, terminated bool, err error) {
+	chunk, readErr := lr.r.ReadSlice('\n')
+	switch {
+	case readErr == nil:
+		return trimEOL(chunk), true, nil
+	case errors.Is(readErr, io.EOF) && len(chunk) == 0:
+		return nil, false, io.EOF
+	case !errors.Is(readErr, bufio.ErrBufferFull) && !errors.Is(readErr, io.EOF):
+		return nil, false, readErr
+	}
+
+	// Either the line is longer than the read buffer, or the file ended without a
+	// newline. Retain up to max bytes and discard the remainder of the line.
+	lr.long = appendChunk(lr.long[:0], chunk, lr.max)
+	for errors.Is(readErr, bufio.ErrBufferFull) {
+		chunk, readErr = lr.r.ReadSlice('\n')
+		lr.long = appendChunk(lr.long, chunk, lr.max)
+	}
+
+	switch {
+	case readErr == nil:
+		return trimEOL(lr.long), true, nil
+	case errors.Is(readErr, io.EOF):
+		return lr.long, false, nil
+	default:
+		return nil, false, readErr
+	}
+}
+
+// appendChunk appends chunk to dst, up to a total of max bytes.
+func appendChunk(dst, chunk []byte, max int) []byte {
+	room := max - len(dst)
+	if room <= 0 || len(chunk) == 0 {
+		return dst
+	}
+	return append(dst, chunk[:min(room, len(chunk))]...)
+}
+
+// trimEOL drops the line terminator, matching how bufio.ScanLines splits lines.
+func trimEOL(line []byte) []byte {
+	return bytes.TrimSuffix(bytes.TrimSuffix(line, []byte("\n")), []byte("\r"))
+}
+
+func scrapeStream(ctx context.Context, r io.Reader, decision santaDecisionType, rb *ringBuffer) error {
+	lr := newLineReader(r, maxLineBytes)
+	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
 		}
 
-		line := scanner.Text()
+		line, terminated, err := lr.readLine()
+		switch {
+		case errors.Is(err, io.EOF):
+			return nil
+		case err != nil:
+			return err
+		case !terminated:
+			// santad newline-terminates every line, so an unterminated final line is
+			// a write in progress rather than an event.
+			return nil
+		}
 
 		// Filter by decision type early to keep it fast.
 		switch decision {
 		case decisionAllowed:
-			if !strings.Contains(line, "decision=ALLOW") {
+			if !bytes.Contains(line, allowMarker) {
 				continue
 			}
 		case decisionDenied:
-			if !strings.Contains(line, "decision=DENY") {
+			if !bytes.Contains(line, denyMarker) {
 				continue
 			}
 		}
 
-		values := extractValues(line)
-		if values["timestamp"] == "" {
+		entry, ok := parseLogEntry(line)
+		if !ok {
 			continue
 		}
-
-		rb.Add(logEntry{
-			Timestamp:   values["timestamp"],
-			Application: values["path"],
-			Reason:      values["reason"],
-			SHA256:      values["sha256"],
-		})
+		rb.Add(entry)
 	}
-
-	return scanner.Err()
 }
 
-func scrapeCurrentLog(ctx context.Context, path string, decision santaDecisionType, rb *ringBuffer) error {
+// errLogMissing reports a log file that was not there to open, as opposed to one
+// that failed while being read. Only the former is safe to retry: a retry after a
+// partial read would add the entries it already collected a second time.
+var errLogMissing = errors.New("santa log file does not exist")
+
+// openLog opens a log file, distinguishing a file that is not there from one that
+// cannot be opened.
+func openLog(path string) (*os.File, error) {
 	file, err := os.Open(path)
 	if err != nil {
-		return fmt.Errorf("failed to open Santa log file: %v", err)
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, fmt.Errorf("%w: %s", errLogMissing, path)
+		}
+		return nil, fmt.Errorf("failed to open Santa log file %s: %w", path, err)
+	}
+	return file, nil
+}
+
+func scrapePlainSantaLog(ctx context.Context, path string, decision santaDecisionType, rb *ringBuffer) error {
+	file, err := openLog(path)
+	if err != nil {
+		return err
 	}
 	defer file.Close()
 
-	scanner := makeBufferedScanner(file)
-	return scrapeStream(ctx, scanner, decision, rb)
+	return scrapeStream(ctx, file, decision, rb)
 }
 
 func scrapeCompressedSantaLog(ctx context.Context, path string, decision santaDecisionType, rb *ringBuffer) error {
-	file, err := os.Open(path)
+	file, err := openLog(path)
 	if err != nil {
-		return fmt.Errorf("failed to open compressed log file %s: %v", path, err)
+		return err
 	}
 	defer file.Close()
 
 	gzReader, err := gzip.NewReader(file)
 	if err != nil {
-		return fmt.Errorf("failed to create gzip reader for %s: %v", path, err)
+		return fmt.Errorf("failed to create gzip reader for %s: %w", path, err)
 	}
 	defer gzReader.Close()
 
-	scanner := makeBufferedScanner(gzReader)
-	return scrapeStream(ctx, scanner, decision, rb)
+	return scrapeStream(ctx, gzReader, decision, rb)
 }
 
-func makeBufferedScanner(r io.Reader) *bufio.Scanner {
-	s := bufio.NewScanner(r)
-	// Uncomment to support very large lines if needed:
-	// buf := make([]byte, 64*1024)
-	// s.Buffer(buf, 1<<20) // 1 MiB
-	return s
+// scrapeCurrentSantaLog reads the active log, retrying a missing file for the
+// window in which newsyslog has renamed it and santad has not recreated it yet.
+// A file that stays missing is not an error: Santa may not be installed, or may
+// not be configured to log to a file (see `santa_status.log_type`). Its rotated
+// contents are still read from the archives.
+//
+// hasArchives reports whether any rotated log was found. Waiting is only worth it
+// mid-rotation, which implies at least one rotated log on disk, because newsyslog
+// renames santa.log to santa.log.0 before santad recreates it. With no archives at
+// all nothing is being rotated, and every host that does not run Santa would pay
+// the retry delay on every query.
+func scrapeCurrentSantaLog(ctx context.Context, path string, decision santaDecisionType, rb *ringBuffer, hasArchives bool) error {
+	for attempt := 1; ; attempt++ {
+		err := scrapePlainSantaLog(ctx, path, decision, rb)
+		if !errors.Is(err, errLogMissing) {
+			return err
+		}
+		if !hasArchives || attempt >= currentLogAttempts {
+			log.Debug().Str("path", path).Msg("santa log not found")
+			return nil
+		}
+
+		if err := retryWait(ctx); err != nil {
+			return err
+		}
+	}
+}
+
+// retryWait waits before the next attempt at reading the current log. It is a
+// variable so tests can drive the retry without sleeping.
+var retryWait = func(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(currentLogRetryDelay):
+		return nil
+	}
+}
+
+// archive is a rotated log file. newsyslog compresses a rotated log after
+// renaming it, so for a brief window the compressed file is incomplete while the
+// uncompressed one is still on disk; keep the latter as a fallback. Hosts whose
+// newsyslog configuration does not compress at all only ever have the plain file.
+type archive struct {
+	path       string
+	compressed bool
+	fallback   string
+}
+
+// archives returns the rotated logs for base, oldest first, stopping at the
+// first rotation index with no file at all.
+func archives(base string) []archive {
+	var found []archive
+	for i := 0; ; i++ {
+		gzPath := fmt.Sprintf("%s.%d.gz", base, i)
+		plainPath := fmt.Sprintf("%s.%d", base, i)
+
+		switch gzExists, plainExists := fileExists(gzPath), fileExists(plainPath); {
+		case gzExists:
+			a := archive{path: gzPath, compressed: true}
+			if plainExists {
+				a.fallback = plainPath
+			}
+			found = append(found, a)
+		case plainExists:
+			found = append(found, archive{path: plainPath})
+		default:
+			slices.Reverse(found)
+			return found
+		}
+	}
+}
+
+// statFile is a variable so tests can simulate a log that is discovered and then
+// rotated away before it is read.
+var statFile = os.Stat
+
+func fileExists(path string) bool {
+	_, err := statFile(path)
+	return err == nil
+}
+
+// scrapeArchive reads one rotated log into rb.
+func scrapeArchive(ctx context.Context, a archive, decision santaDecisionType, rb *ringBuffer) error {
+	if a.fallback == "" {
+		return scrapeArchiveFile(ctx, a.path, a.compressed, decision, rb)
+	}
+
+	// The compressed archive and the file it is being compressed from both exist,
+	// so newsyslog is mid-rotation and the .gz may be incomplete. Collect the
+	// compressed read separately, so that falling back to the uncompressed file
+	// cannot double-count the entries the failed attempt already collected.
+	scratch := newRingBuffer(maxEntries)
+	err := scrapeArchiveFile(ctx, a.path, a.compressed, decision, scratch)
+	if err != nil && ctx.Err() == nil {
+		scratch.Reset()
+		if fallbackErr := scrapeArchiveFile(ctx, a.fallback, false, decision, scratch); fallbackErr == nil {
+			err = nil
+		}
+	}
+
+	for _, entry := range scratch.SliceChrono() {
+		rb.Add(entry)
+	}
+	return err
+}
+
+func scrapeArchiveFile(ctx context.Context, path string, compressed bool, decision santaDecisionType, rb *ringBuffer) error {
+	if compressed {
+		return scrapeCompressedSantaLog(ctx, path, decision, rb)
+	}
+	return scrapePlainSantaLog(ctx, path, decision, rb)
 }
 
 func scrapeSantaLog(ctx context.Context, decision santaDecisionType) ([]logEntry, error) {
-	return scrapeSantaLogFromBase(ctx, decision, defaultLogPath)
+	return scrapeSantaLogFromBase(ctx, decision, logPath)
 }
 
 func scrapeSantaLogFromBase(ctx context.Context, decision santaDecisionType, path string) ([]logEntry, error) {
-	rb := newRingBuffer(maxEntries)
+	var (
+		rb   = newRingBuffer(maxEntries)
+		errs []error
+	)
 
-	// Find highest archive index (0 = newest archive, higher = older)
-	maxIdx := -1
-	for i := 0; ; i++ {
-		if _, err := os.Stat(fmt.Sprintf("%s.%d.gz", path, i)); err != nil {
-			break
+	// Archives oldest → newest, then the current log, so the ring buffer keeps the
+	// most recent entries overall. Every read is best effort: a file that cannot be
+	// read is reported, never discarding the entries collected from the others.
+	rotated := archives(path)
+	for _, a := range rotated {
+		err := scrapeArchive(ctx, a, decision, rb)
+		switch {
+		case err == nil:
+		case errors.Is(err, errLogMissing):
+			// Rotated away between being discovered and being read: its events moved to
+			// the next index. At worst one generation of archived events is missed,
+			// which the entry cap hides on all but the quietest hosts.
+			log.Debug().Err(err).Msg("santa log archive rotated away while reading")
+		default:
+			errs = append(errs, err)
 		}
-		maxIdx = i
 	}
 
-	// 1) Archives oldest → newest: maxIdx, maxIdx-1, ..., 0
-	for i := maxIdx; i >= 0; i-- {
-		archivePath := fmt.Sprintf("%s.%d.gz", path, i)
-		if err := scrapeCompressedSantaLog(ctx, archivePath, decision, rb); err != nil {
-			return nil, err
-		}
-	}
-
-	// 2) Current log last (newest overall)
-	if err := scrapeCurrentLog(ctx, path, decision, rb); err != nil {
-		return nil, err
+	if err := scrapeCurrentSantaLog(ctx, path, decision, rb, len(rotated) > 0); err != nil {
+		errs = append(errs, err)
 	}
 
 	// Return the last N entries (oldest → newest among those last N).
-	return rb.SliceChrono(), nil
+	return rb.SliceChrono(), errors.Join(errs...)
 }

--- a/orbit/pkg/table/santa/santa_log.go
+++ b/orbit/pkg/table/santa/santa_log.go
@@ -405,7 +405,7 @@ func scrapeArchive(ctx context.Context, a archive, decision santaDecisionType, r
 	// so newsyslog is mid-rotation and the .gz may be incomplete. Collect the
 	// compressed read separately, so that falling back to the uncompressed file
 	// cannot double-count the entries the failed attempt already collected.
-	scratch := newRingBuffer(maxEntries)
+	scratch := newRingBuffer(rb.cap)
 	err := scrapeArchiveFile(ctx, a.path, a.compressed, decision, scratch)
 	if err != nil && ctx.Err() == nil {
 		scratch.Reset()
@@ -431,19 +431,39 @@ func scrapeSantaLog(ctx context.Context, decision santaDecisionType) ([]logEntry
 	return scrapeSantaLogFromBase(ctx, decision, logPath)
 }
 
+// scrapeSantaLogFromBase returns up to maxEntries of the most recent events,
+// oldest first.
+//
+// Files are read newest first and only until the cap is met, so on a busy host in
+// monitor mode the active log alone satisfies the query and the archives are never
+// opened, let alone decompressed. Each file is read forward into a buffer sized to
+// what is still needed, which yields that file's last N events; the per-file
+// results are then concatenated oldest file first.
+//
+// Every read is best effort: a file that cannot be read is reported without
+// discarding the events collected from the others.
 func scrapeSantaLogFromBase(ctx context.Context, decision santaDecisionType, path string) ([]logEntry, error) {
-	var (
-		rb   = newRingBuffer(maxEntries)
-		errs []error
-	)
+	var errs []error
 
-	// Archives oldest → newest, then the current log, so the ring buffer keeps the
-	// most recent entries overall. Every read is best effort: a file that cannot be
-	// read is reported, never discarding the entries collected from the others.
 	rotated := archives(path)
-	for _, a := range rotated {
-		err := scrapeArchive(ctx, a, decision, rb)
-		switch {
+
+	// The active log holds the newest events, so it is read first.
+	current := newRingBuffer(maxEntries)
+	if err := scrapeCurrentSantaLog(ctx, path, decision, current, len(rotated) > 0); err != nil {
+		errs = append(errs, err)
+	}
+
+	// Per-file results, newest file first.
+	collected := []*ringBuffer{current}
+	remaining := maxEntries - current.Len()
+
+	for _, a := range slices.Backward(rotated) {
+		if remaining <= 0 || ctx.Err() != nil {
+			break
+		}
+
+		buf := newRingBuffer(remaining)
+		switch err := scrapeArchive(ctx, a, decision, buf); {
 		case err == nil:
 		case errors.Is(err, errLogMissing):
 			// Rotated away between being discovered and being read: its events moved to
@@ -453,12 +473,18 @@ func scrapeSantaLogFromBase(ctx context.Context, decision santaDecisionType, pat
 		default:
 			errs = append(errs, err)
 		}
+
+		collected = append(collected, buf)
+		remaining -= buf.Len()
 	}
 
-	if err := scrapeCurrentSantaLog(ctx, path, decision, rb, len(rotated) > 0); err != nil {
-		errs = append(errs, err)
+	total := 0
+	for _, buf := range collected {
+		total += buf.Len()
 	}
-
-	// Return the last N entries (oldest → newest among those last N).
-	return rb.SliceChrono(), errors.Join(errs...)
+	entries := make([]logEntry, 0, total)
+	for _, buf := range slices.Backward(collected) {
+		entries = buf.AppendTo(entries)
+	}
+	return entries, errors.Join(errs...)
 }

--- a/orbit/pkg/table/santa/santa_log_test.go
+++ b/orbit/pkg/table/santa/santa_log_test.go
@@ -187,15 +187,15 @@ func TestScrapeSantaLogFromBase_EndToEnd(t *testing.T) {
 
 	denied, err := scrapeSantaLogFromBase(ctx, decisionDenied, base)
 	require.NoError(t, err)
-	// With current scanned first, chronological (insertion) order is:
-	// current DENY, then archive 0 DENY.
+	// Results are chronological regardless of the order the files are read in, so
+	// the archived DENY comes before the one in the active log.
 	require.Len(t, denied, 2)
 	require.Equal(t, "/Blocked/X", denied[0].Application)
 	require.Equal(t, "/Applications/B.app", denied[1].Application)
 
 	allowed, err := scrapeSantaLogFromBase(ctx, decisionAllowed, base)
 	require.NoError(t, err)
-	// current ALLOW, then archive 1 ALLOW.
+	// Likewise the ALLOW from the older archive comes first.
 	require.Len(t, allowed, 2)
 	require.Equal(t, "/OK/C", allowed[0].Application)
 	require.Equal(t, "/Applications/A.app", allowed[1].Application)
@@ -213,7 +213,7 @@ func TestScrapeSantaLogFromBase_IgnoresGapsAfterFirstMiss(t *testing.T) {
 	// only current exists; no .0.gz
 	writeFile(t, base, mkLine("decision=ALLOW", "2025-09-18 12:00:00.000", "/A", "ok", "aaa"))
 
-	got, err := scrapeSantaLogFromBase(context.Background(), decisionAllowed, base)
+	got, err := scrapeSantaLogFromBase(t.Context(), decisionAllowed, base)
 	require.NoError(t, err)
 	require.Len(t, got, 1)
 	require.Equal(t, "/A", got[0].Application)
@@ -442,54 +442,63 @@ func TestScrapeSantaLogFromBase_ArchiveRotatedAwayIsNotReported(t *testing.T) {
 	require.Equal(t, []string{"/ARC1", "/CUR"}, apps(got))
 }
 
-// TestScrapeSantaLogFromBase_RetriesRotatingCurrentLog covers the window in
-// which newsyslog has renamed santa.log and santad has not recreated it yet.
-func TestScrapeSantaLogFromBase_RetriesRotatingCurrentLog(t *testing.T) {
+// TestScrapeSantaLogFromBase_MissingCurrentLogMidRotation covers the window in
+// which newsyslog has renamed santa.log and santad has not recreated it yet: the
+// events written before the rotation are read from the renamed file, which has not
+// been compressed yet.
+func TestScrapeSantaLogFromBase_MissingCurrentLogMidRotation(t *testing.T) {
 	tmp := t.TempDir()
 	base := filepath.Join(tmp, "santa.log")
 
-	// The rotated log is on disk; the current one does not exist yet.
+	// The renamed log is on disk; the active one does not exist yet.
 	writeFile(t, base+".0", mkLine("decision=ALLOW", "2025-09-18 11:59:59.000", "/ARC0", "ok", "bbb"))
-
-	var waits int
-	stubRetryWait(t, func() {
-		waits++
-		// santad recreates the log between attempts.
-		writeFile(t, base, mkLine("decision=ALLOW", "2025-09-18 12:00:00.000", "/CUR", "ok", "aaa"))
-	})
 
 	got, err := scrapeSantaLogFromBase(t.Context(), decisionAllowed, base)
 	require.NoError(t, err)
-	require.Equal(t, 1, waits, "should have retried once")
-	require.Equal(t, []string{"/ARC0", "/CUR"}, apps(got))
+	require.Equal(t, []string{"/ARC0"}, apps(got))
 }
 
-// TestScrapeSantaLogFromBase_MissingLogIsNotAnError verifies that a log that
-// never shows up yields no rows and no error: Santa may not be installed, or may
-// not be configured to log to a file. With no rotated log on disk there is no
-// rotation in progress to wait for, so no host without Santa pays the retry delay.
+// TestScrapeSantaLogFromBase_RediscoversArchivesAfterRotation covers a rotation
+// landing between discovering the archives and reading the active log, on a host
+// that had no archives at all: the events are in a santa.log.0 that the first
+// discovery pass ran too early to see.
+func TestScrapeSantaLogFromBase_RediscoversArchivesAfterRotation(t *testing.T) {
+	tmp := t.TempDir()
+	base := filepath.Join(tmp, "santa.log")
+
+	// The renamed log is on disk; the active one has not been recreated yet.
+	writeFile(t, base+".0", mkLine("decision=ALLOW", "2025-09-18 11:59:59.000", "/ARC0", "ok", "bbb"))
+
+	// Each discovery pass starts by looking for santa.log.0.gz. The first pass sees
+	// nothing, as it would if it ran a moment before newsyslog's rename.
+	original := statFile
+	t.Cleanup(func() { statFile = original })
+	passes := 0
+	statFile = func(path string) (os.FileInfo, error) {
+		if strings.HasSuffix(path, ".0.gz") {
+			passes++
+		}
+		if passes == 1 {
+			return nil, os.ErrNotExist
+		}
+		return original(path)
+	}
+
+	got, err := scrapeSantaLogFromBase(t.Context(), decisionAllowed, base)
+	require.NoError(t, err)
+	require.Equal(t, 2, passes, "should have looked for archives again")
+	require.Equal(t, []string{"/ARC0"}, apps(got))
+}
+
+// TestScrapeSantaLogFromBase_MissingLogIsNotAnError verifies that a log that is
+// not there yields no rows and no error: Santa may not be installed, or may not be
+// configured to log to a file.
 func TestScrapeSantaLogFromBase_MissingLogIsNotAnError(t *testing.T) {
 	tmp := t.TempDir()
-
-	var waits int
-	stubRetryWait(t, func() { waits++ })
 
 	got, err := scrapeSantaLogFromBase(t.Context(), decisionAllowed, filepath.Join(tmp, "santa.log"))
 	require.NoError(t, err)
 	require.Empty(t, got)
-	require.Zero(t, waits, "should not wait when there are no archives to rotate")
-}
-
-// stubRetryWait replaces the between-attempts wait with onWait, so retries are
-// driven by the test instead of the clock.
-func stubRetryWait(tb testing.TB, onWait func()) {
-	tb.Helper()
-	original := retryWait
-	tb.Cleanup(func() { retryWait = original })
-	retryWait = func(context.Context) error {
-		onWait()
-		return nil
-	}
 }
 
 // TestScrapeSantaLogFromBase_StopsOnceCapIsMet verifies that archives are not
@@ -591,7 +600,7 @@ func TestScrapeSantaLogFromBase_PrefersLatestWithinArchiveOnCap(t *testing.T) {
 	// Since only .1.gz has DENY lines and it contains more than maxEntries,
 	// the ring should end up with the last 3 from that archive:
 	// "/DENY-3", "/DENY-4", "/DENY-5" (chronological).
-	got, err := scrapeSantaLogFromBase(context.Background(), decisionDenied, base)
+	got, err := scrapeSantaLogFromBase(t.Context(), decisionDenied, base)
 	require.NoError(t, err)
 
 	require.Equal(t,
@@ -601,7 +610,7 @@ func TestScrapeSantaLogFromBase_PrefersLatestWithinArchiveOnCap(t *testing.T) {
 	)
 
 	maxEntries = 2
-	got, err = scrapeSantaLogFromBase(context.Background(), decisionDenied, base)
+	got, err = scrapeSantaLogFromBase(t.Context(), decisionDenied, base)
 	require.NoError(t, err)
 
 	require.Equal(t,
@@ -611,7 +620,7 @@ func TestScrapeSantaLogFromBase_PrefersLatestWithinArchiveOnCap(t *testing.T) {
 	)
 
 	maxEntries = 1
-	got, err = scrapeSantaLogFromBase(context.Background(), decisionDenied, base)
+	got, err = scrapeSantaLogFromBase(t.Context(), decisionDenied, base)
 	require.NoError(t, err)
 
 	require.Equal(t,
@@ -752,13 +761,14 @@ func writeTruncatedGz(tb testing.TB, path, keep, drop string) {
 // multiple compressed archives. These benchmarks help track performance
 // over time.
 //
+// Recorded on:
 // goos: darwin
 // goarch: arm64
-// cpu: Apple M2 Pro
+// cpu: Apple M4 Max
 //////////////////
 
 // Small (~150KB) non-compressed
-// BenchmarkScrapeSantaLogFromBase_SmallPlain-12               1436            827449 ns/op         185.63 MB/s      966170 B/op       5060 allocs/op
+// BenchmarkScrapeSantaLogFromBase_SmallPlain-16              10514            226687 ns/op         677.58 MB/s      504616 B/op       5060 allocs/op
 func BenchmarkScrapeSantaLogFromBase_SmallPlain(b *testing.B) {
 	tmp := b.TempDir()
 	base := filepath.Join(tmp, "santa.log")
@@ -766,7 +776,7 @@ func BenchmarkScrapeSantaLogFromBase_SmallPlain(b *testing.B) {
 	content := fillToSize(150*1024, "decision=ALLOW")
 	writeFile(b, base, content)
 
-	ctx := context.Background()
+	ctx := b.Context()
 	b.SetBytes(int64(len(content)))
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -779,7 +789,7 @@ func BenchmarkScrapeSantaLogFromBase_SmallPlain(b *testing.B) {
 }
 
 // ~10MB non-compressed
-// BenchmarkScrapeSantaLogFromBase_10MB_Plain-12                 20          58003575 ns/op         180.78 MB/s    75833864 B/op     343898 allocs/op
+// BenchmarkScrapeSantaLogFromBase_10MB_Plain-16                177          13231784 ns/op         792.46 MB/s     8772758 B/op     343823 allocs/op
 func BenchmarkScrapeSantaLogFromBase_10MB_Plain(b *testing.B) {
 	tmp := b.TempDir()
 	base := filepath.Join(tmp, "santa.log")
@@ -787,7 +797,7 @@ func BenchmarkScrapeSantaLogFromBase_10MB_Plain(b *testing.B) {
 	content := fillToSize(10*1024*1024, "decision=ALLOW")
 	writeFile(b, base, content)
 
-	ctx := context.Background()
+	ctx := b.Context()
 	b.SetBytes(int64(len(content)))
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -799,8 +809,10 @@ func BenchmarkScrapeSantaLogFromBase_10MB_Plain(b *testing.B) {
 	}
 }
 
-// ~10MB current log + five compressed archives (each ~10MB uncompressed)
-// BenchmarkScrapeSantaLogFromBase_10MB_PlainPlus5x10MB_Gzip-12                   6         212764465 ns/op         295.70 MB/s    281107640 B/op   1298057 allocs/op
+// ~10MB current log + five compressed archives (each ~10MB uncompressed), querying
+// events the archives hold. Reading stops once the entry cap is met, so the reported
+// MB/s counts bytes that were never read and overstates real throughput.
+// BenchmarkScrapeSantaLogFromBase_10MB_PlainPlus5x10MB_Gzip-16                 135          17888254 ns/op        3517.07 MB/s     8942730 B/op    346729 allocs/op
 func BenchmarkScrapeSantaLogFromBase_10MB_PlainPlus5x10MB_Gzip(b *testing.B) {
 	tmp := b.TempDir()
 	base := filepath.Join(tmp, "santa.log")
@@ -819,7 +831,7 @@ func BenchmarkScrapeSantaLogFromBase_10MB_PlainPlus5x10MB_Gzip(b *testing.B) {
 		totalUncompressed += len(raw)
 	}
 
-	ctx := context.Background()
+	ctx := b.Context()
 	b.SetBytes(int64(totalUncompressed))
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -838,6 +850,7 @@ func BenchmarkScrapeSantaLogFromBase_10MB_PlainPlus5x10MB_Gzip(b *testing.B) {
 //
 // Note that the reported MB/s counts the whole corpus, so it overstates real
 // throughput: the point of this benchmark is that most of those bytes are skipped.
+// BenchmarkScrapeSantaLogFromBase_CapMetByCurrentLog-16                        182          13192218 ns/op        4769.02 MB/s     8778596 B/op    343872 allocs/op
 func BenchmarkScrapeSantaLogFromBase_CapMetByCurrentLog(b *testing.B) {
 	tmp := b.TempDir()
 	base := filepath.Join(tmp, "santa.log")
@@ -852,7 +865,7 @@ func BenchmarkScrapeSantaLogFromBase_CapMetByCurrentLog(b *testing.B) {
 		totalUncompressed += len(raw)
 	}
 
-	ctx := context.Background()
+	ctx := b.Context()
 	b.SetBytes(int64(totalUncompressed))
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/orbit/pkg/table/santa/santa_log_test.go
+++ b/orbit/pkg/table/santa/santa_log_test.go
@@ -492,6 +492,53 @@ func stubRetryWait(tb testing.TB, onWait func()) {
 	}
 }
 
+// TestScrapeSantaLogFromBase_StopsOnceCapIsMet verifies that archives are not
+// opened once the active log alone satisfies the entry cap, which is the common
+// case in monitor mode. The archive here cannot be read, so opening it at all
+// would surface an error.
+func TestScrapeSantaLogFromBase_StopsOnceCapIsMet(t *testing.T) {
+	oldCap := maxEntries
+	maxEntries = 2
+	defer func() { maxEntries = oldCap }()
+
+	tmp := t.TempDir()
+	base := filepath.Join(tmp, "santa.log")
+
+	writeFile(t, base,
+		mkLine("decision=ALLOW", "2025-09-18 12:00:00.000", "/A", "ok", "aaa")+
+			mkLine("decision=ALLOW", "2025-09-18 12:00:01.000", "/B", "ok", "bbb")+
+			mkLine("decision=ALLOW", "2025-09-18 12:00:02.000", "/C", "ok", "ccc"))
+	writeFile(t, base+".0.gz", "definitely not gzip")
+
+	got, err := scrapeSantaLogFromBase(t.Context(), decisionAllowed, base)
+	require.NoError(t, err, "the archive should not have been opened")
+	require.Equal(t, []string{"/B", "/C"}, apps(got))
+}
+
+// TestScrapeSantaLogFromBase_StopsOnceOlderArchivesAreUnneeded verifies the same
+// short circuit part way through the archives: enough events are found in the
+// active log and the newest archive, so the older one is left alone.
+func TestScrapeSantaLogFromBase_StopsOnceOlderArchivesAreUnneeded(t *testing.T) {
+	oldCap := maxEntries
+	maxEntries = 3
+	defer func() { maxEntries = oldCap }()
+
+	tmp := t.TempDir()
+	base := filepath.Join(tmp, "santa.log")
+
+	writeFile(t, base,
+		mkLine("decision=ALLOW", "2025-09-18 12:00:00.000", "/CUR1", "ok", "aaa")+
+			mkLine("decision=ALLOW", "2025-09-18 12:00:01.000", "/CUR2", "ok", "bbb"))
+	writeGz(t, base+".0.gz",
+		mkLine("decision=ALLOW", "2025-09-18 11:59:58.000", "/ARC0-1", "ok", "ccc")+
+			mkLine("decision=ALLOW", "2025-09-18 11:59:59.000", "/ARC0-2", "ok", "ddd"))
+	writeFile(t, base+".1.gz", "definitely not gzip")
+
+	got, err := scrapeSantaLogFromBase(t.Context(), decisionAllowed, base)
+	require.NoError(t, err, "the older archive should not have been opened")
+	require.Equal(t, []string{"/ARC0-2", "/CUR1", "/CUR2"}, apps(got))
+}
+
 func TestScrapeStream_EnforcesGlobalCap(t *testing.T) {
 	// Lower the global cap to make the test fast and predictable.
 	oldCap := maxEntries
@@ -780,6 +827,38 @@ func BenchmarkScrapeSantaLogFromBase_10MB_PlainPlus5x10MB_Gzip(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		// Choose either decision; archives contain both.
 		if _, err := scrapeSantaLogFromBase(ctx, decisionDenied, base); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// ~10MB current log of ALLOW events plus five compressed archives, querying the
+// events the current log already holds enough of: the archives should not be read.
+// This is the shape of a busy host in monitor mode.
+//
+// Note that the reported MB/s counts the whole corpus, so it overstates real
+// throughput: the point of this benchmark is that most of those bytes are skipped.
+func BenchmarkScrapeSantaLogFromBase_CapMetByCurrentLog(b *testing.B) {
+	tmp := b.TempDir()
+	base := filepath.Join(tmp, "santa.log")
+
+	plain := fillToSize(10*1024*1024, "decision=ALLOW")
+	writeFile(b, base, plain)
+
+	totalUncompressed := len(plain)
+	for i := range 5 {
+		raw := fillToSize(10*1024*1024, "decision=ALLOW")
+		writeGz(b, base+fmt.Sprintf(".%d.gz", i), raw)
+		totalUncompressed += len(raw)
+	}
+
+	ctx := context.Background()
+	b.SetBytes(int64(totalUncompressed))
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		if _, err := scrapeSantaLogFromBase(ctx, decisionAllowed, base); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/orbit/pkg/table/santa/santa_log_test.go
+++ b/orbit/pkg/table/santa/santa_log_test.go
@@ -3,140 +3,168 @@
 package santa
 
 import (
-	"bufio"
+	"bytes"
 	"compress/gzip"
 	"context"
 	"fmt"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/osquery/osquery-go/plugin/table"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/require"
 )
 
-func TestExtractValues(t *testing.T) {
+func TestParseLogEntry(t *testing.T) {
 	tests := []struct {
-		name string
-		line string
-		want map[string]string
+		name   string
+		line   string
+		want   logEntry
+		wantOK bool
 	}{
 		{
 			name: "happy path with timestamp and kv pairs",
 			line: `[2025-09-18T10:15:30.123Z] santad: decision=ALLOW | path=/Applications/Foo.app | reason=cdhash | sha256=abc123`,
-			want: map[string]string{
-				"timestamp": "2025-09-18T10:15:30.123Z",
-				"decision":  "ALLOW",
-				"path":      "/Applications/Foo.app",
-				"reason":    "cdhash",
-				"sha256":    "abc123",
+			want: logEntry{
+				Timestamp:   "2025-09-18T10:15:30.123Z",
+				Application: "/Applications/Foo.app",
+				Reason:      "cdhash",
+				SHA256:      "abc123",
 			},
+			wantOK: true,
 		},
 		{
-			name: "no santad preface returns only timestamp",
-			line: `[2025-09-18 10:15:30] something else: decision=DENY | path=/bin/bash`,
-			want: map[string]string{
-				"timestamp": "2025-09-18 10:15:30",
-			},
+			name:   "no santad preface yields only the timestamp",
+			line:   `[2025-09-18 10:15:30] something else: decision=DENY | path=/bin/bash`,
+			want:   logEntry{Timestamp: "2025-09-18 10:15:30"},
+			wantOK: true,
 		},
 		{
-			name: "no timestamp but has kv pairs",
+			name: "no timestamp is not an event",
 			line: `santad: decision=DENY | path=/usr/local/bin/tool | reason=rule | sha256=def456`,
-			want: map[string]string{
-				"decision": "DENY",
-				"path":     "/usr/local/bin/tool",
-				"reason":   "rule",
-				"sha256":   "def456",
-			},
 		},
 		{
 			name: "trims spaces around keys and values",
 			line: `[2025-09-18] santad:   decision = ALLOW   |   path = /a/b/c  | reason =  ok  `,
-			want: map[string]string{
-				"timestamp": "2025-09-18",
-				"decision":  "ALLOW",
-				"path":      "/a/b/c",
-				"reason":    "ok",
+			want: logEntry{
+				Timestamp:   "2025-09-18",
+				Application: "/a/b/c",
+				Reason:      "ok",
 			},
+			wantOK: true,
 		},
 		{
 			name: "ignores empty segments and missing equals",
 			line: `[ts] santad: decision=DENY | | path=/p | just-a-flag | sha256=zzz`,
-			want: map[string]string{
-				"timestamp": "ts",
-				"decision":  "DENY",
-				"path":      "/p",
-				"sha256":    "zzz",
+			want: logEntry{
+				Timestamp:   "ts",
+				Application: "/p",
+				SHA256:      "zzz",
 			},
+			wantOK: true,
 		},
 		{
-			name: "value containing equals keeps everything after first equals",
+			name: "value containing equals keeps everything after the first equals",
 			line: `[ts] santad: note=a=b=c | path=/eq | sha256=x`,
-			want: map[string]string{
-				"timestamp": "ts",
-				"note":      "a=b=c",
-				"path":      "/eq",
-				"sha256":    "x",
+			want: logEntry{
+				Timestamp:   "ts",
+				Application: "/eq",
+				SHA256:      "x",
 			},
+			wantOK: true,
 		},
 		{
 			name: "duplicate keys last one wins",
 			line: `[ts] santad: path=/first | path=/second | reason=one | reason=two`,
-			want: map[string]string{
-				"timestamp": "ts",
-				"path":      "/second",
-				"reason":    "two",
+			want: logEntry{
+				Timestamp:   "ts",
+				Application: "/second",
+				Reason:      "two",
 			},
+			wantOK: true,
 		},
 		{
-			name: "quoted values are preserved (current impl trims spaces only)",
+			name: "quoted values are unquoted",
 			line: `[ts] santad: path="/Applications/App With Spaces.app" | reason='quoted'`,
-			want: map[string]string{
-				"timestamp": "ts",
-				`path`:      `/Applications/App With Spaces.app`,
-				`reason`:    `quoted`,
+			want: logEntry{
+				Timestamp:   "ts",
+				Application: "/Applications/App With Spaces.app",
+				Reason:      "quoted",
 			},
+			wantOK: true,
 		},
 		{
-			name: "no matches yields empty map",
+			name: "keys are matched case-insensitively",
+			line: `[ts] santad: PATH=/upper | Reason=ok | SHA256=abc`,
+			want: logEntry{
+				Timestamp:   "ts",
+				Application: "/upper",
+				Reason:      "ok",
+				SHA256:      "abc",
+			},
+			wantOK: true,
+		},
+		{
+			name: "unrelated line is not an event",
 			line: `completely unrelated line`,
-			want: map[string]string{},
+		},
+		{
+			name: "empty bracket group is not a timestamp",
+			line: `[] santad: decision=ALLOW | path=/a`,
+		},
+		{
+			name: "falls through an empty bracket group to the next one",
+			line: `[] [ts] santad: decision=ALLOW | path=/a`,
+			want: logEntry{
+				Timestamp:   "ts",
+				Application: "/a",
+			},
+			wantOK: true,
+		},
+		{
+			name: "unclosed bracket group is not a timestamp",
+			line: `[2025-09-18 santad: decision=ALLOW | path=/a`,
+		},
+		{
+			name: "bracket group keeps a nested opening bracket",
+			line: `[a[b] santad: decision=ALLOW | path=/a`,
+			want: logEntry{
+				Timestamp:   "a[b",
+				Application: "/a",
+			},
+			wantOK: true,
 		},
 		{
 			name: "handles trailing separator",
 			line: `[ts] santad: decision=ALLOW | path=/a/b/c |`,
-			want: map[string]string{
-				"timestamp": "ts",
-				"decision":  "ALLOW",
-				"path":      "/a/b/c",
+			want: logEntry{
+				Timestamp:   "ts",
+				Application: "/a/b/c",
 			},
+			wantOK: true,
 		},
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			got := extractValues(tt.line)
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Fatalf("extractValues() mismatch\nline: %q\n got: %#v\nwant: %#v", tt.line, got, tt.want)
-			}
+			got, ok := parseLogEntry([]byte(tt.line))
+			require.Equal(t, tt.wantOK, ok)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }
 
-func TestExtractValues_DoesNotPanicOnLongLine(t *testing.T) {
-	// Construct a long line to ensure no unexpected behavior for big inputs.
-	longVal := make([]byte, 0, 300_000)
-	for range 10000 {
-		longVal = append(longVal, 'a')
-	}
-	line := "[2025-09-18] santad: path=/" + string(longVal) + " | reason=ok"
+func TestParseLogEntry_TruncatedLongLine(t *testing.T) {
+	// A line long enough to exercise the retention limit still yields its columns,
+	// because Santa writes the process arguments last.
+	line := mkLineWithArgs("decision=ALLOW", "2025-09-18", "/A", "ok", "abc", strings.Repeat("a", 300_000))
 
-	got := extractValues(line)
-	require.Equal(t, "2025-09-18", got["timestamp"])
-	require.Contains(t, got, "path", "expected path key to be present on long input")
-	require.Equal(t, "ok", got["reason"])
+	got, ok := parseLogEntry([]byte(line[:maxLineBytes]))
+	require.True(t, ok)
+	require.Equal(t, logEntry{Timestamp: "2025-09-18", Application: "/A", Reason: "ok", SHA256: "abc"}, got)
 }
 
 func TestScrapeSantaLogFromBase_EndToEnd(t *testing.T) {
@@ -191,6 +219,279 @@ func TestScrapeSantaLogFromBase_IgnoresGapsAfterFirstMiss(t *testing.T) {
 	require.Equal(t, "/A", got[0].Application)
 }
 
+// TestScrapeSantaLogFromBase_SurvivesOverlongLine verifies that a log line
+// longer than bufio.Scanner's default token limit does not discard the entries
+// scraped from the rest of the file. In monitor mode Santa logs an ALLOW line
+// for nearly every exec, arguments included, so a single long command line
+// would otherwise empty the whole table until it rotated out.
+func TestScrapeSantaLogFromBase_SurvivesOverlongLine(t *testing.T) {
+	tmp := t.TempDir()
+	base := filepath.Join(tmp, "santa.log")
+
+	var sb strings.Builder
+	sb.WriteString(mkLine("decision=ALLOW", "2025-09-18 12:00:00.000", "/A", "ok", "aaa"))
+	sb.WriteString(mkLineWithArgs("decision=ALLOW", "2025-09-18 12:00:01.000", "/B", "ok", "bbb",
+		strings.Repeat("x", 200_000)))
+	sb.WriteString(mkLine("decision=ALLOW", "2025-09-18 12:00:02.000", "/C", "ok", "ccc"))
+	writeFile(t, base, sb.String())
+
+	got, err := scrapeSantaLogFromBase(t.Context(), decisionAllowed, base)
+	require.NoError(t, err)
+	require.Equal(t, []string{"/A", "/B", "/C"}, apps(got))
+}
+
+// TestScrapeSantaLogFromBase_TruncatesLongLineKeepingColumns verifies that
+// truncating an over-long line preserves every column these tables expose.
+// Santa emits the unbounded args field last, after path, reason and sha256.
+func TestScrapeSantaLogFromBase_TruncatesLongLineKeepingColumns(t *testing.T) {
+	tmp := t.TempDir()
+	base := filepath.Join(tmp, "santa.log")
+
+	writeFile(t, base, mkLineWithArgs("decision=ALLOW", "2025-09-18 12:00:01.000", "/Long", "cdhash", "bbb",
+		strings.Repeat("x", 200_000)))
+
+	got, err := scrapeSantaLogFromBase(t.Context(), decisionAllowed, base)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, "2025-09-18 12:00:01.000", got[0].Timestamp)
+	require.Equal(t, "/Long", got[0].Application)
+	require.Equal(t, "cdhash", got[0].Reason)
+	require.Equal(t, "bbb", got[0].SHA256)
+}
+
+// TestScrapeSantaLogFromBase_UnreadableArchiveKeepsOtherEntries verifies that a
+// file that cannot be read is reported but does not discard entries scraped
+// from the other files.
+func TestScrapeSantaLogFromBase_UnreadableArchiveKeepsOtherEntries(t *testing.T) {
+	tmp := t.TempDir()
+	base := filepath.Join(tmp, "santa.log")
+
+	writeFile(t, base, mkLine("decision=ALLOW", "2025-09-18 12:00:00.000", "/CUR", "ok", "aaa"))
+	// Not gzip data: an archive still being written by newsyslog looks like this.
+	writeFile(t, base+".0.gz", "definitely not gzip")
+
+	got, err := scrapeSantaLogFromBase(t.Context(), decisionAllowed, base)
+	require.Error(t, err, "the unreadable archive should be reported")
+	require.Len(t, got, 1, "entries from the readable files should survive")
+	require.Equal(t, "/CUR", got[0].Application)
+}
+
+// TestScrapeSantaLogFromBase_CorruptArchiveFallsBackToUncompressed covers the
+// window in which newsyslog has rotated the log but not finished compressing
+// it: the .gz is incomplete while the uncompressed sibling is still on disk.
+func TestScrapeSantaLogFromBase_CorruptArchiveFallsBackToUncompressed(t *testing.T) {
+	tmp := t.TempDir()
+	base := filepath.Join(tmp, "santa.log")
+
+	writeFile(t, base, mkLine("decision=ALLOW", "2025-09-18 12:00:00.000", "/CUR", "ok", "aaa"))
+	writeFile(t, base+".0.gz", "definitely not gzip")
+	writeFile(t, base+".0", mkLine("decision=ALLOW", "2025-09-18 11:59:59.000", "/ARC0", "ok", "bbb"))
+
+	got, err := scrapeSantaLogFromBase(t.Context(), decisionAllowed, base)
+	require.NoError(t, err, "the uncompressed sibling should satisfy the read")
+	require.Equal(t, []string{"/ARC0", "/CUR"}, apps(got))
+}
+
+// TestScrapeSantaLogFromBase_ReadsUncompressedArchives verifies that rotated
+// logs are read even when they have not been compressed at all, which depends
+// on the host's newsyslog configuration.
+func TestScrapeSantaLogFromBase_ReadsUncompressedArchives(t *testing.T) {
+	tmp := t.TempDir()
+	base := filepath.Join(tmp, "santa.log")
+
+	writeFile(t, base, mkLine("decision=ALLOW", "2025-09-18 12:00:00.000", "/CUR", "ok", "aaa"))
+	writeFile(t, base+".0", mkLine("decision=ALLOW", "2025-09-18 11:59:59.000", "/ARC0", "ok", "bbb"))
+	writeFile(t, base+".1", mkLine("decision=ALLOW", "2025-09-18 11:59:58.000", "/ARC1", "ok", "ccc"))
+
+	got, err := scrapeSantaLogFromBase(t.Context(), decisionAllowed, base)
+	require.NoError(t, err)
+	require.Equal(t, []string{"/ARC1", "/ARC0", "/CUR"}, apps(got))
+}
+
+// TestScrapeSantaLogFromBase_MissingCurrentLogKeepsArchives verifies that a
+// missing current log is treated as benign (Santa may not be installed, or the
+// log may have just been rotated) and does not discard archived entries.
+func TestScrapeSantaLogFromBase_MissingCurrentLogKeepsArchives(t *testing.T) {
+	tmp := t.TempDir()
+	base := filepath.Join(tmp, "santa.log")
+
+	writeGz(t, base+".0.gz", mkLine("decision=ALLOW", "2025-09-18 11:59:59.000", "/ARC0", "ok", "bbb"))
+
+	got, err := scrapeSantaLogFromBase(t.Context(), decisionAllowed, base)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, "/ARC0", got[0].Application)
+}
+
+// TestScrapeSantaLogFromBase_TruncatedArchiveKeepsDecodedEntries verifies that
+// a gzip stream cut short still yields the entries decoded before the failure.
+func TestScrapeSantaLogFromBase_TruncatedArchiveKeepsDecodedEntries(t *testing.T) {
+	tmp := t.TempDir()
+	base := filepath.Join(tmp, "santa.log")
+
+	writeFile(t, base, mkLine("decision=ALLOW", "2025-09-18 12:00:00.000", "/CUR", "ok", "aaa"))
+	writeTruncatedGz(t, base+".0.gz",
+		mkLine("decision=ALLOW", "2025-09-18 11:59:58.000", "/DECODED", "ok", "bbb"),
+		mkLine("decision=ALLOW", "2025-09-18 11:59:59.000", "/LOST", "ok", "ccc"),
+	)
+
+	got, err := scrapeSantaLogFromBase(t.Context(), decisionAllowed, base)
+	require.Error(t, err, "the truncated archive should be reported")
+	require.Equal(t, []string{"/DECODED", "/CUR"}, apps(got))
+}
+
+// TestScrapeSantaLogFromBase_SkipsUnterminatedFinalLine verifies that a line
+// caught mid-write is not reported as an event. santad terminates every line
+// with a newline, so an unterminated final line is always a partial write.
+func TestScrapeSantaLogFromBase_SkipsUnterminatedFinalLine(t *testing.T) {
+	tmp := t.TempDir()
+	base := filepath.Join(tmp, "santa.log")
+
+	writeFile(t, base,
+		mkLine("decision=ALLOW", "2025-09-18 12:00:00.000", "/A", "ok", "aaa")+
+			`[2025-09-18 12:00:01.000] santad: decision=ALLOW | path="/PARTIAL" | rea`)
+
+	got, err := scrapeSantaLogFromBase(t.Context(), decisionAllowed, base)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, "/A", got[0].Application)
+}
+
+// TestScrapeSantaLogFromBase_SurvivesOverlongLineInArchive exercises the
+// over-long line path through a compressed archive, where the reader is fed in
+// decompressed chunks rather than straight from a file.
+func TestScrapeSantaLogFromBase_SurvivesOverlongLineInArchive(t *testing.T) {
+	tmp := t.TempDir()
+	base := filepath.Join(tmp, "santa.log")
+
+	writeFile(t, base, mkLine("decision=ALLOW", "2025-09-18 12:00:02.000", "/CUR", "ok", "ccc"))
+	writeGz(t, base+".0.gz",
+		mkLine("decision=ALLOW", "2025-09-18 11:59:58.000", "/A", "ok", "aaa")+
+			mkLineWithArgs("decision=ALLOW", "2025-09-18 11:59:59.000", "/B", "ok", "bbb",
+				strings.Repeat("x", 200_000))+
+			mkLine("decision=ALLOW", "2025-09-18 12:00:00.000", "/C", "ok", "ccc"))
+
+	got, err := scrapeSantaLogFromBase(t.Context(), decisionAllowed, base)
+	require.NoError(t, err)
+	require.Equal(t, []string{"/A", "/B", "/C", "/CUR"}, apps(got))
+}
+
+// TestScrapeSantaLogFromBase_LineAtRetentionLimit covers the boundary between the
+// single-read path and the truncating one.
+func TestScrapeSantaLogFromBase_LineAtRetentionLimit(t *testing.T) {
+	tmp := t.TempDir()
+	base := filepath.Join(tmp, "santa.log")
+
+	for _, length := range []int{maxLineBytes - 1, maxLineBytes, maxLineBytes + 1} {
+		line := mkLineWithArgs("decision=ALLOW", "2025-09-18 12:00:00.000", "/A", "ok", "aaa", "")
+		// Pad the args field so the line is exactly length bytes, newline included.
+		line = strings.TrimSuffix(line, "\n") + strings.Repeat("x", length-len(line)) + "\n"
+		require.Len(t, line, length)
+		writeFile(t, base, line)
+
+		got, err := scrapeSantaLogFromBase(t.Context(), decisionAllowed, base)
+		require.NoError(t, err, "line length %d", length)
+		require.Len(t, got, 1, "line length %d", length)
+		require.Equal(t, logEntry{
+			Timestamp:   "2025-09-18 12:00:00.000",
+			Application: "/A",
+			Reason:      "ok",
+			SHA256:      "aaa",
+		}, got[0], "line length %d", length)
+	}
+}
+
+// TestScrapeSantaLogFromBase_CanceledContext verifies that a canceled query is
+// reported rather than looking like an empty log.
+func TestScrapeSantaLogFromBase_CanceledContext(t *testing.T) {
+	tmp := t.TempDir()
+	base := filepath.Join(tmp, "santa.log")
+	writeFile(t, base, mkLine("decision=ALLOW", "2025-09-18 12:00:00.000", "/A", "ok", "aaa"))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err := scrapeSantaLogFromBase(ctx, decisionAllowed, base)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+// TestScrapeSantaLogFromBase_ArchiveRotatedAwayIsNotReported covers an archive
+// that is renamed by newsyslog between being discovered and being read. Its
+// events move to the next rotation index, so the disappearance is expected and
+// must not be reported as a failure.
+func TestScrapeSantaLogFromBase_ArchiveRotatedAwayIsNotReported(t *testing.T) {
+	tmp := t.TempDir()
+	base := filepath.Join(tmp, "santa.log")
+
+	writeFile(t, base, mkLine("decision=ALLOW", "2025-09-18 12:00:00.000", "/CUR", "ok", "aaa"))
+	writeGz(t, base+".1.gz", mkLine("decision=ALLOW", "2025-09-18 11:59:58.000", "/ARC1", "ok", "ccc"))
+
+	// santa.log.0.gz is reported by discovery but is not on disk by the time it is
+	// opened.
+	original := statFile
+	t.Cleanup(func() { statFile = original })
+	statFile = func(path string) (os.FileInfo, error) {
+		if strings.HasSuffix(path, ".0.gz") {
+			return original(base)
+		}
+		return original(path)
+	}
+
+	got, err := scrapeSantaLogFromBase(t.Context(), decisionAllowed, base)
+	require.NoError(t, err)
+	require.Equal(t, []string{"/ARC1", "/CUR"}, apps(got))
+}
+
+// TestScrapeSantaLogFromBase_RetriesRotatingCurrentLog covers the window in
+// which newsyslog has renamed santa.log and santad has not recreated it yet.
+func TestScrapeSantaLogFromBase_RetriesRotatingCurrentLog(t *testing.T) {
+	tmp := t.TempDir()
+	base := filepath.Join(tmp, "santa.log")
+
+	// The rotated log is on disk; the current one does not exist yet.
+	writeFile(t, base+".0", mkLine("decision=ALLOW", "2025-09-18 11:59:59.000", "/ARC0", "ok", "bbb"))
+
+	var waits int
+	stubRetryWait(t, func() {
+		waits++
+		// santad recreates the log between attempts.
+		writeFile(t, base, mkLine("decision=ALLOW", "2025-09-18 12:00:00.000", "/CUR", "ok", "aaa"))
+	})
+
+	got, err := scrapeSantaLogFromBase(t.Context(), decisionAllowed, base)
+	require.NoError(t, err)
+	require.Equal(t, 1, waits, "should have retried once")
+	require.Equal(t, []string{"/ARC0", "/CUR"}, apps(got))
+}
+
+// TestScrapeSantaLogFromBase_MissingLogIsNotAnError verifies that a log that
+// never shows up yields no rows and no error: Santa may not be installed, or may
+// not be configured to log to a file. With no rotated log on disk there is no
+// rotation in progress to wait for, so no host without Santa pays the retry delay.
+func TestScrapeSantaLogFromBase_MissingLogIsNotAnError(t *testing.T) {
+	tmp := t.TempDir()
+
+	var waits int
+	stubRetryWait(t, func() { waits++ })
+
+	got, err := scrapeSantaLogFromBase(t.Context(), decisionAllowed, filepath.Join(tmp, "santa.log"))
+	require.NoError(t, err)
+	require.Empty(t, got)
+	require.Zero(t, waits, "should not wait when there are no archives to rotate")
+}
+
+// stubRetryWait replaces the between-attempts wait with onWait, so retries are
+// driven by the test instead of the clock.
+func stubRetryWait(tb testing.TB, onWait func()) {
+	tb.Helper()
+	original := retryWait
+	tb.Cleanup(func() { retryWait = original })
+	retryWait = func(context.Context) error {
+		onWait()
+		return nil
+	}
+}
+
 func TestScrapeStream_EnforcesGlobalCap(t *testing.T) {
 	// Lower the global cap to make the test fast and predictable.
 	oldCap := maxEntries
@@ -207,10 +508,9 @@ func TestScrapeStream_EnforcesGlobalCap(t *testing.T) {
 		sb.WriteString(perLine)
 	}
 
-	sc := bufio.NewScanner(strings.NewReader(sb.String()))
 	rb := newRingBuffer(maxEntries)
 
-	err := scrapeStream(context.Background(), sc, decisionAllowed, rb)
+	err := scrapeStream(t.Context(), strings.NewReader(sb.String()), decisionAllowed, rb)
 
 	require.NoError(t, err, "cap should not surface as an error")
 	require.Len(t, rb.SliceChrono(), maxEntries, "SliceChrono should return exactly maxEntries items")
@@ -274,6 +574,74 @@ func TestScrapeSantaLogFromBase_PrefersLatestWithinArchiveOnCap(t *testing.T) {
 	)
 }
 
+func TestGenerateAllowed_ReturnsRows(t *testing.T) {
+	base := stubLogPath(t)
+	writeFile(t, base, mkLine("decision=ALLOW", "2025-09-18 12:00:00.000", "/A", "cdhash", "aaa")+
+		mkLine("decision=DENY", "2025-09-18 12:00:01.000", "/B", "rule", "bbb"))
+
+	rows, err := GenerateAllowed(t.Context(), table.QueryContext{})
+	require.NoError(t, err)
+	require.Equal(t, []map[string]string{{
+		"timestamp":   "2025-09-18 12:00:00.000",
+		"application": "/A",
+		"reason":      "cdhash",
+		"sha256":      "aaa",
+	}}, rows)
+}
+
+// TestGenerateAllowed_LogsFailureWithoutFailingTheQuery verifies that an
+// unreadable log is reported in fleetd's log rather than silently returning zero
+// rows, and that the table itself does not fail: an error here would break the
+// query on every host running Santa, and a synthetic error row would look like a
+// real Santa event.
+func TestGenerateAllowed_LogsFailureWithoutFailingTheQuery(t *testing.T) {
+	base := stubLogPath(t)
+	// A path that exists but cannot be read as a file.
+	require.NoError(t, os.Mkdir(base, 0o755))
+
+	logs := captureLogs(t)
+
+	rows, err := GenerateAllowed(t.Context(), table.QueryContext{})
+	require.NoError(t, err)
+	require.Empty(t, rows)
+	require.Contains(t, logs.String(), "scraping santa log")
+}
+
+func TestGenerateDenied_ReturnsRows(t *testing.T) {
+	base := stubLogPath(t)
+	writeFile(t, base, mkLine("decision=ALLOW", "2025-09-18 12:00:00.000", "/A", "cdhash", "aaa")+
+		mkLine("decision=DENY", "2025-09-18 12:00:01.000", "/B", "rule", "bbb"))
+
+	rows, err := GenerateDenied(t.Context(), table.QueryContext{})
+	require.NoError(t, err)
+	require.Equal(t, []map[string]string{{
+		"timestamp":   "2025-09-18 12:00:01.000",
+		"application": "/B",
+		"reason":      "rule",
+		"sha256":      "bbb",
+	}}, rows)
+}
+
+// stubLogPath points the tables at a temporary log for the duration of the test
+// and returns its path.
+func stubLogPath(tb testing.TB) string {
+	tb.Helper()
+	original := logPath
+	tb.Cleanup(func() { logPath = original })
+	logPath = filepath.Join(tb.TempDir(), "santa.log")
+	return logPath
+}
+
+// captureLogs redirects the global zerolog logger into a buffer.
+func captureLogs(tb testing.TB) *bytes.Buffer {
+	tb.Helper()
+	var buf bytes.Buffer
+	original := log.Logger
+	tb.Cleanup(func() { log.Logger = original })
+	log.Logger = zerolog.New(&buf)
+	return &buf
+}
+
 func writeFile(tb testing.TB, path, content string) {
 	tb.Helper()
 	require.NoError(tb, os.WriteFile(path, []byte(content), 0o644))
@@ -294,6 +662,41 @@ func mkLine(dec, ts, path, reason, sha string) string {
 	// example Santa line format
 	return "[" + ts + "] santad: " + dec +
 		` | path="` + path + `" | reason=` + reason + ` | sha256=` + sha + "\n"
+}
+
+// apps lists the application column of entries, in the order returned.
+func apps(entries []logEntry) []string {
+	out := make([]string, len(entries))
+	for i := range entries {
+		out[i] = entries[i].Application
+	}
+	return out
+}
+
+// mkLineWithArgs builds a line with a trailing args field, which is where Santa
+// puts the process arguments and the only field with no practical size bound.
+func mkLineWithArgs(dec, ts, path, reason, sha, args string) string {
+	return strings.TrimSuffix(mkLine(dec, ts, path, reason, sha), "\n") +
+		" | args=" + args + "\n"
+}
+
+// writeTruncatedGz writes a gzip stream containing keep followed by drop, then
+// cuts the file at the flush boundary between them: keep decodes cleanly and
+// the stream then ends unexpectedly, as it does while newsyslog is still
+// compressing a rotated log.
+func writeTruncatedGz(tb testing.TB, path, keep, drop string) {
+	tb.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	_, err := gz.Write([]byte(keep))
+	require.NoError(tb, err)
+	require.NoError(tb, gz.Flush())
+	boundary := buf.Len()
+	_, err = gz.Write([]byte(drop))
+	require.NoError(tb, err)
+	require.NoError(tb, gz.Close())
+
+	require.NoError(tb, os.WriteFile(path, buf.Bytes()[:boundary], 0o644))
 }
 
 //////////////////

--- a/orbit/pkg/table/santa/santa_log_test.go
+++ b/orbit/pkg/table/santa/santa_log_test.go
@@ -47,64 +47,39 @@ func TestParseLogEntry(t *testing.T) {
 			line: `santad: decision=DENY | path=/usr/local/bin/tool | reason=rule | sha256=def456`,
 		},
 		{
-			name: "trims spaces around keys and values",
-			line: `[2025-09-18] santad:   decision = ALLOW   |   path = /a/b/c  | reason =  ok  `,
-			want: logEntry{
-				Timestamp:   "2025-09-18",
-				Application: "/a/b/c",
-				Reason:      "ok",
-			},
+			name:   "trims spaces around keys and values",
+			line:   `[2025-09-18] santad:   decision = ALLOW   |   path = /a/b/c  | reason =  ok  `,
+			want:   logEntry{Timestamp: "2025-09-18", Application: "/a/b/c", Reason: "ok"},
 			wantOK: true,
 		},
 		{
-			name: "ignores empty segments and missing equals",
-			line: `[ts] santad: decision=DENY | | path=/p | just-a-flag | sha256=zzz`,
-			want: logEntry{
-				Timestamp:   "ts",
-				Application: "/p",
-				SHA256:      "zzz",
-			},
+			name:   "ignores empty segments and missing equals",
+			line:   `[ts] santad: decision=DENY | | path=/p | just-a-flag | sha256=zzz`,
+			want:   logEntry{Timestamp: "ts", Application: "/p", SHA256: "zzz"},
 			wantOK: true,
 		},
 		{
-			name: "value containing equals keeps everything after the first equals",
-			line: `[ts] santad: note=a=b=c | path=/eq | sha256=x`,
-			want: logEntry{
-				Timestamp:   "ts",
-				Application: "/eq",
-				SHA256:      "x",
-			},
+			name:   "value containing equals keeps everything after the first equals",
+			line:   `[ts] santad: note=a=b=c | path=/eq | sha256=x`,
+			want:   logEntry{Timestamp: "ts", Application: "/eq", SHA256: "x"},
 			wantOK: true,
 		},
 		{
-			name: "duplicate keys last one wins",
-			line: `[ts] santad: path=/first | path=/second | reason=one | reason=two`,
-			want: logEntry{
-				Timestamp:   "ts",
-				Application: "/second",
-				Reason:      "two",
-			},
+			name:   "duplicate keys last one wins",
+			line:   `[ts] santad: path=/first | path=/second | reason=one | reason=two`,
+			want:   logEntry{Timestamp: "ts", Application: "/second", Reason: "two"},
 			wantOK: true,
 		},
 		{
-			name: "quoted values are unquoted",
-			line: `[ts] santad: path="/Applications/App With Spaces.app" | reason='quoted'`,
-			want: logEntry{
-				Timestamp:   "ts",
-				Application: "/Applications/App With Spaces.app",
-				Reason:      "quoted",
-			},
+			name:   "quoted values are unquoted",
+			line:   `[ts] santad: path="/Applications/App With Spaces.app" | reason='quoted'`,
+			want:   logEntry{Timestamp: "ts", Application: "/Applications/App With Spaces.app", Reason: "quoted"},
 			wantOK: true,
 		},
 		{
-			name: "keys are matched case-insensitively",
-			line: `[ts] santad: PATH=/upper | Reason=ok | SHA256=abc`,
-			want: logEntry{
-				Timestamp:   "ts",
-				Application: "/upper",
-				Reason:      "ok",
-				SHA256:      "abc",
-			},
+			name:   "keys are matched case-insensitively",
+			line:   `[ts] santad: PATH=/upper | Reason=ok | SHA256=abc`,
+			want:   logEntry{Timestamp: "ts", Application: "/upper", Reason: "ok", SHA256: "abc"},
 			wantOK: true,
 		},
 		{
@@ -116,12 +91,9 @@ func TestParseLogEntry(t *testing.T) {
 			line: `[] santad: decision=ALLOW | path=/a`,
 		},
 		{
-			name: "falls through an empty bracket group to the next one",
-			line: `[] [ts] santad: decision=ALLOW | path=/a`,
-			want: logEntry{
-				Timestamp:   "ts",
-				Application: "/a",
-			},
+			name:   "falls through an empty bracket group to the next one",
+			line:   `[] [ts] santad: decision=ALLOW | path=/a`,
+			want:   logEntry{Timestamp: "ts", Application: "/a"},
 			wantOK: true,
 		},
 		{
@@ -129,21 +101,15 @@ func TestParseLogEntry(t *testing.T) {
 			line: `[2025-09-18 santad: decision=ALLOW | path=/a`,
 		},
 		{
-			name: "bracket group keeps a nested opening bracket",
-			line: `[a[b] santad: decision=ALLOW | path=/a`,
-			want: logEntry{
-				Timestamp:   "a[b",
-				Application: "/a",
-			},
+			name:   "bracket group keeps a nested opening bracket",
+			line:   `[a[b] santad: decision=ALLOW | path=/a`,
+			want:   logEntry{Timestamp: "a[b", Application: "/a"},
 			wantOK: true,
 		},
 		{
-			name: "handles trailing separator",
-			line: `[ts] santad: decision=ALLOW | path=/a/b/c |`,
-			want: logEntry{
-				Timestamp:   "ts",
-				Application: "/a/b/c",
-			},
+			name:   "handles trailing separator",
+			line:   `[ts] santad: decision=ALLOW | path=/a/b/c |`,
+			want:   logEntry{Timestamp: "ts", Application: "/a/b/c"},
 			wantOK: true,
 		},
 	}
@@ -168,222 +134,199 @@ func TestParseLogEntry_TruncatedLongLine(t *testing.T) {
 }
 
 func TestScrapeSantaLogFromBase_EndToEnd(t *testing.T) {
-	tmp := t.TempDir()
-	base := filepath.Join(tmp, "santa.log")
+	base := tempLog(t)
+	writeFile(t, base, allow("/Applications/A.app")+deny("/Applications/B.app"))
+	writeGz(t, base+".0.gz", deny("/Blocked/X"))
+	writeGz(t, base+".1.gz", allow("/OK/C"))
 
-	// current (plain) log with ALLOW and DENY
-	current := strings.Builder{}
-	current.WriteString(mkLine("decision=ALLOW", "2025-09-18 12:00:00.000", "/Applications/A.app", "ok", "aaa"))
-	current.WriteString(mkLine("decision=DENY", "2025-09-18 12:00:01.000", "/Applications/B.app", "rule", "bbb"))
-	writeFile(t, base, current.String())
-
-	// archive 0 (gz): a DENY (older)
-	writeGz(t, base+".0.gz", mkLine("decision=DENY", "2025-09-18 11:59:59.000", "/Blocked/X", "blacklist", "xxx"))
-
-	// archive 1 (gz): an ALLOW (older)
-	writeGz(t, base+".1.gz", mkLine("decision=ALLOW", "2025-09-18 11:59:58.000", "/OK/C", "scope", "ccc"))
-
-	ctx := t.Context()
-
-	denied, err := scrapeSantaLogFromBase(ctx, decisionDenied, base)
-	require.NoError(t, err)
 	// Results are chronological regardless of the order the files are read in, so
-	// the archived DENY comes before the one in the active log.
-	require.Len(t, denied, 2)
-	require.Equal(t, "/Blocked/X", denied[0].Application)
-	require.Equal(t, "/Applications/B.app", denied[1].Application)
-
-	allowed, err := scrapeSantaLogFromBase(ctx, decisionAllowed, base)
+	// the archived events come before the ones in the active log.
+	denied, err := scrapeSantaLogFromBase(t.Context(), decisionDenied, base)
 	require.NoError(t, err)
-	// Likewise the ALLOW from the older archive comes first.
-	require.Len(t, allowed, 2)
-	require.Equal(t, "/OK/C", allowed[0].Application)
-	require.Equal(t, "/Applications/A.app", allowed[1].Application)
+	require.Equal(t, []string{"/Blocked/X", "/Applications/B.app"}, apps(denied))
+
+	allowed, err := scrapeSantaLogFromBase(t.Context(), decisionAllowed, base)
+	require.NoError(t, err)
+	require.Equal(t, []string{"/OK/C", "/Applications/A.app"}, apps(allowed))
 }
 
-// TestScrapeSantaLogFromBase_IgnoresGapsAfterFirstMiss verifies that archive
-// iteration stops cleanly at the first missing archive file.
-// In this setup only the current log exists (no ".0.gz"), so the function
-// should return entries from the current log only and not attempt to read
-// later archives (".1.gz", ".2.gz", etc.).
-func TestScrapeSantaLogFromBase_IgnoresGapsAfterFirstMiss(t *testing.T) {
-	tmp := t.TempDir()
-	base := filepath.Join(tmp, "santa.log")
+// TestScrapeSantaLogFromBase_Scenarios covers the on-disk states a scrape must
+// survive. Every read is best effort, so a file that cannot be read is reported
+// (wantErr) without discarding the entries collected from the other files.
+func TestScrapeSantaLogFromBase_Scenarios(t *testing.T) {
+	tests := []struct {
+		name     string
+		decision santaDecisionType // zero value is decisionAllowed
+		cap      int               // overrides maxEntries when > 0
+		setup    func(t *testing.T, base string)
+		want     []string // application column, oldest first
+		wantErr  bool
+	}{
+		{
+			// Archive iteration stops cleanly when no rotated file exists at all.
+			name:  "only the active log exists",
+			setup: func(t *testing.T, base string) { writeFile(t, base, allow("/A")) },
+			want:  []string{"/A"},
+		},
+		{
+			// In monitor mode Santa logs an ALLOW line for nearly every exec, arguments
+			// included, so a single long command line would otherwise empty the whole
+			// table until it rotated out.
+			name: "line over the retention limit does not discard the rest",
+			setup: func(t *testing.T, base string) {
+				writeFile(t, base, allow("/A")+longAllow("/B")+allow("/C"))
+			},
+			want: []string{"/A", "/B", "/C"},
+		},
+		{
+			// The over-long line path through a compressed archive, where the reader is
+			// fed in decompressed chunks rather than straight from a file.
+			name: "line over the retention limit inside an archive",
+			setup: func(t *testing.T, base string) {
+				writeFile(t, base, allow("/CUR"))
+				writeGz(t, base+".0.gz", allow("/A")+longAllow("/B")+allow("/C"))
+			},
+			want: []string{"/A", "/B", "/C", "/CUR"},
+		},
+		{
+			// An archive still being written by newsyslog is not valid gzip data.
+			name: "unreadable archive is reported but keeps other entries",
+			setup: func(t *testing.T, base string) {
+				writeFile(t, base, allow("/CUR"))
+				writeFile(t, base+".0.gz", "definitely not gzip")
+			},
+			want:    []string{"/CUR"},
+			wantErr: true,
+		},
+		{
+			// newsyslog has rotated the log but not finished compressing it: the .gz is
+			// incomplete while the uncompressed sibling is still on disk.
+			name: "corrupt archive falls back to its uncompressed sibling",
+			setup: func(t *testing.T, base string) {
+				writeFile(t, base, allow("/CUR"))
+				writeFile(t, base+".0.gz", "definitely not gzip")
+				writeFile(t, base+".0", allow("/ARC0"))
+			},
+			want: []string{"/ARC0", "/CUR"},
+		},
+		{
+			// Whether rotated logs are compressed at all depends on the host's
+			// newsyslog configuration.
+			name: "reads uncompressed archives",
+			setup: func(t *testing.T, base string) {
+				writeFile(t, base, allow("/CUR"))
+				writeFile(t, base+".0", allow("/ARC0"))
+				writeFile(t, base+".1", allow("/ARC1"))
+			},
+			want: []string{"/ARC1", "/ARC0", "/CUR"},
+		},
+		{
+			// A missing active log is benign: Santa may not be installed, or the log
+			// may have just been rotated. Archived entries must survive it.
+			name: "missing active log keeps archives",
+			setup: func(t *testing.T, base string) {
+				writeGz(t, base+".0.gz", allow("/ARC0"))
+			},
+			want: []string{"/ARC0"},
+		},
+		{
+			// newsyslog has renamed santa.log and santad has not recreated it yet: the
+			// pre-rotation events are read from the renamed, not-yet-compressed file.
+			name: "missing active log mid-rotation",
+			setup: func(t *testing.T, base string) {
+				writeFile(t, base+".0", allow("/ARC0"))
+			},
+			want: []string{"/ARC0"},
+		},
+		{
+			name:  "missing log entirely yields no rows and no error",
+			setup: func(*testing.T, string) {},
+			want:  []string{},
+		},
+		{
+			// A gzip stream cut short still yields the entries decoded before the failure.
+			name: "truncated gzip keeps the entries decoded before the cut",
+			setup: func(t *testing.T, base string) {
+				writeFile(t, base, allow("/CUR"))
+				writeTruncatedGz(t, base+".0.gz", allow("/DECODED"), allow("/LOST"))
+			},
+			want:    []string{"/DECODED", "/CUR"},
+			wantErr: true,
+		},
+		{
+			// santad terminates every line with a newline, so an unterminated final
+			// line is a partial write, not an event.
+			name: "skips an unterminated final line",
+			setup: func(t *testing.T, base string) {
+				writeFile(t, base, allow("/A")+`[ts] santad: decision=ALLOW | path="/PARTIAL" | rea`)
+			},
+			want: []string{"/A"},
+		},
+		{
+			// Archives are not opened once the active log alone satisfies the entry
+			// cap, which is the common case in monitor mode. The archive here cannot
+			// be read, so opening it at all would surface an error.
+			name: "archives are not opened once the cap is met",
+			cap:  2,
+			setup: func(t *testing.T, base string) {
+				writeFile(t, base, allow("/A")+allow("/B")+allow("/C"))
+				writeFile(t, base+".0.gz", "definitely not gzip")
+			},
+			want: []string{"/B", "/C"},
+		},
+		{
+			// The same short circuit part way through the archives: enough events are
+			// found in the active log and the newest archive, so the older unreadable
+			// one is left alone.
+			name: "older archives are not opened once the cap is met",
+			cap:  3,
+			setup: func(t *testing.T, base string) {
+				writeFile(t, base, allow("/CUR1")+allow("/CUR2"))
+				writeGz(t, base+".0.gz", allow("/ARC0-1")+allow("/ARC0-2"))
+				writeFile(t, base+".1.gz", "definitely not gzip")
+			},
+			want: []string{"/ARC0-2", "/CUR1", "/CUR2"},
+		},
+	}
 
-	// only current exists; no .0.gz
-	writeFile(t, base, mkLine("decision=ALLOW", "2025-09-18 12:00:00.000", "/A", "ok", "aaa"))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.cap > 0 {
+				setCap(t, tt.cap)
+			}
+			base := tempLog(t)
+			tt.setup(t, base)
 
-	got, err := scrapeSantaLogFromBase(t.Context(), decisionAllowed, base)
-	require.NoError(t, err)
-	require.Len(t, got, 1)
-	require.Equal(t, "/A", got[0].Application)
-}
-
-// TestScrapeSantaLogFromBase_SurvivesOverlongLine verifies that a log line
-// longer than bufio.Scanner's default token limit does not discard the entries
-// scraped from the rest of the file. In monitor mode Santa logs an ALLOW line
-// for nearly every exec, arguments included, so a single long command line
-// would otherwise empty the whole table until it rotated out.
-func TestScrapeSantaLogFromBase_SurvivesOverlongLine(t *testing.T) {
-	tmp := t.TempDir()
-	base := filepath.Join(tmp, "santa.log")
-
-	var sb strings.Builder
-	sb.WriteString(mkLine("decision=ALLOW", "2025-09-18 12:00:00.000", "/A", "ok", "aaa"))
-	sb.WriteString(mkLineWithArgs("decision=ALLOW", "2025-09-18 12:00:01.000", "/B", "ok", "bbb",
-		strings.Repeat("x", 200_000)))
-	sb.WriteString(mkLine("decision=ALLOW", "2025-09-18 12:00:02.000", "/C", "ok", "ccc"))
-	writeFile(t, base, sb.String())
-
-	got, err := scrapeSantaLogFromBase(t.Context(), decisionAllowed, base)
-	require.NoError(t, err)
-	require.Equal(t, []string{"/A", "/B", "/C"}, apps(got))
+			got, err := scrapeSantaLogFromBase(t.Context(), tt.decision, base)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tt.want, apps(got))
+		})
+	}
 }
 
 // TestScrapeSantaLogFromBase_TruncatesLongLineKeepingColumns verifies that
 // truncating an over-long line preserves every column these tables expose.
 // Santa emits the unbounded args field last, after path, reason and sha256.
 func TestScrapeSantaLogFromBase_TruncatesLongLineKeepingColumns(t *testing.T) {
-	tmp := t.TempDir()
-	base := filepath.Join(tmp, "santa.log")
-
-	writeFile(t, base, mkLineWithArgs("decision=ALLOW", "2025-09-18 12:00:01.000", "/Long", "cdhash", "bbb",
-		strings.Repeat("x", 200_000)))
+	base := tempLog(t)
+	writeFile(t, base, longAllow("/Long"))
 
 	got, err := scrapeSantaLogFromBase(t.Context(), decisionAllowed, base)
 	require.NoError(t, err)
-	require.Len(t, got, 1)
-	require.Equal(t, "2025-09-18 12:00:01.000", got[0].Timestamp)
-	require.Equal(t, "/Long", got[0].Application)
-	require.Equal(t, "cdhash", got[0].Reason)
-	require.Equal(t, "bbb", got[0].SHA256)
-}
-
-// TestScrapeSantaLogFromBase_UnreadableArchiveKeepsOtherEntries verifies that a
-// file that cannot be read is reported but does not discard entries scraped
-// from the other files.
-func TestScrapeSantaLogFromBase_UnreadableArchiveKeepsOtherEntries(t *testing.T) {
-	tmp := t.TempDir()
-	base := filepath.Join(tmp, "santa.log")
-
-	writeFile(t, base, mkLine("decision=ALLOW", "2025-09-18 12:00:00.000", "/CUR", "ok", "aaa"))
-	// Not gzip data: an archive still being written by newsyslog looks like this.
-	writeFile(t, base+".0.gz", "definitely not gzip")
-
-	got, err := scrapeSantaLogFromBase(t.Context(), decisionAllowed, base)
-	require.Error(t, err, "the unreadable archive should be reported")
-	require.Len(t, got, 1, "entries from the readable files should survive")
-	require.Equal(t, "/CUR", got[0].Application)
-}
-
-// TestScrapeSantaLogFromBase_CorruptArchiveFallsBackToUncompressed covers the
-// window in which newsyslog has rotated the log but not finished compressing
-// it: the .gz is incomplete while the uncompressed sibling is still on disk.
-func TestScrapeSantaLogFromBase_CorruptArchiveFallsBackToUncompressed(t *testing.T) {
-	tmp := t.TempDir()
-	base := filepath.Join(tmp, "santa.log")
-
-	writeFile(t, base, mkLine("decision=ALLOW", "2025-09-18 12:00:00.000", "/CUR", "ok", "aaa"))
-	writeFile(t, base+".0.gz", "definitely not gzip")
-	writeFile(t, base+".0", mkLine("decision=ALLOW", "2025-09-18 11:59:59.000", "/ARC0", "ok", "bbb"))
-
-	got, err := scrapeSantaLogFromBase(t.Context(), decisionAllowed, base)
-	require.NoError(t, err, "the uncompressed sibling should satisfy the read")
-	require.Equal(t, []string{"/ARC0", "/CUR"}, apps(got))
-}
-
-// TestScrapeSantaLogFromBase_ReadsUncompressedArchives verifies that rotated
-// logs are read even when they have not been compressed at all, which depends
-// on the host's newsyslog configuration.
-func TestScrapeSantaLogFromBase_ReadsUncompressedArchives(t *testing.T) {
-	tmp := t.TempDir()
-	base := filepath.Join(tmp, "santa.log")
-
-	writeFile(t, base, mkLine("decision=ALLOW", "2025-09-18 12:00:00.000", "/CUR", "ok", "aaa"))
-	writeFile(t, base+".0", mkLine("decision=ALLOW", "2025-09-18 11:59:59.000", "/ARC0", "ok", "bbb"))
-	writeFile(t, base+".1", mkLine("decision=ALLOW", "2025-09-18 11:59:58.000", "/ARC1", "ok", "ccc"))
-
-	got, err := scrapeSantaLogFromBase(t.Context(), decisionAllowed, base)
-	require.NoError(t, err)
-	require.Equal(t, []string{"/ARC1", "/ARC0", "/CUR"}, apps(got))
-}
-
-// TestScrapeSantaLogFromBase_MissingCurrentLogKeepsArchives verifies that a
-// missing current log is treated as benign (Santa may not be installed, or the
-// log may have just been rotated) and does not discard archived entries.
-func TestScrapeSantaLogFromBase_MissingCurrentLogKeepsArchives(t *testing.T) {
-	tmp := t.TempDir()
-	base := filepath.Join(tmp, "santa.log")
-
-	writeGz(t, base+".0.gz", mkLine("decision=ALLOW", "2025-09-18 11:59:59.000", "/ARC0", "ok", "bbb"))
-
-	got, err := scrapeSantaLogFromBase(t.Context(), decisionAllowed, base)
-	require.NoError(t, err)
-	require.Len(t, got, 1)
-	require.Equal(t, "/ARC0", got[0].Application)
-}
-
-// TestScrapeSantaLogFromBase_TruncatedArchiveKeepsDecodedEntries verifies that
-// a gzip stream cut short still yields the entries decoded before the failure.
-func TestScrapeSantaLogFromBase_TruncatedArchiveKeepsDecodedEntries(t *testing.T) {
-	tmp := t.TempDir()
-	base := filepath.Join(tmp, "santa.log")
-
-	writeFile(t, base, mkLine("decision=ALLOW", "2025-09-18 12:00:00.000", "/CUR", "ok", "aaa"))
-	writeTruncatedGz(t, base+".0.gz",
-		mkLine("decision=ALLOW", "2025-09-18 11:59:58.000", "/DECODED", "ok", "bbb"),
-		mkLine("decision=ALLOW", "2025-09-18 11:59:59.000", "/LOST", "ok", "ccc"),
-	)
-
-	got, err := scrapeSantaLogFromBase(t.Context(), decisionAllowed, base)
-	require.Error(t, err, "the truncated archive should be reported")
-	require.Equal(t, []string{"/DECODED", "/CUR"}, apps(got))
-}
-
-// TestScrapeSantaLogFromBase_SkipsUnterminatedFinalLine verifies that a line
-// caught mid-write is not reported as an event. santad terminates every line
-// with a newline, so an unterminated final line is always a partial write.
-func TestScrapeSantaLogFromBase_SkipsUnterminatedFinalLine(t *testing.T) {
-	tmp := t.TempDir()
-	base := filepath.Join(tmp, "santa.log")
-
-	writeFile(t, base,
-		mkLine("decision=ALLOW", "2025-09-18 12:00:00.000", "/A", "ok", "aaa")+
-			`[2025-09-18 12:00:01.000] santad: decision=ALLOW | path="/PARTIAL" | rea`)
-
-	got, err := scrapeSantaLogFromBase(t.Context(), decisionAllowed, base)
-	require.NoError(t, err)
-	require.Len(t, got, 1)
-	require.Equal(t, "/A", got[0].Application)
-}
-
-// TestScrapeSantaLogFromBase_SurvivesOverlongLineInArchive exercises the
-// over-long line path through a compressed archive, where the reader is fed in
-// decompressed chunks rather than straight from a file.
-func TestScrapeSantaLogFromBase_SurvivesOverlongLineInArchive(t *testing.T) {
-	tmp := t.TempDir()
-	base := filepath.Join(tmp, "santa.log")
-
-	writeFile(t, base, mkLine("decision=ALLOW", "2025-09-18 12:00:02.000", "/CUR", "ok", "ccc"))
-	writeGz(t, base+".0.gz",
-		mkLine("decision=ALLOW", "2025-09-18 11:59:58.000", "/A", "ok", "aaa")+
-			mkLineWithArgs("decision=ALLOW", "2025-09-18 11:59:59.000", "/B", "ok", "bbb",
-				strings.Repeat("x", 200_000))+
-			mkLine("decision=ALLOW", "2025-09-18 12:00:00.000", "/C", "ok", "ccc"))
-
-	got, err := scrapeSantaLogFromBase(t.Context(), decisionAllowed, base)
-	require.NoError(t, err)
-	require.Equal(t, []string{"/A", "/B", "/C", "/CUR"}, apps(got))
+	require.Equal(t, []logEntry{{Timestamp: testTS, Application: "/Long", Reason: "ok", SHA256: "aaa"}}, got)
 }
 
 // TestScrapeSantaLogFromBase_LineAtRetentionLimit covers the boundary between the
 // single-read path and the truncating one.
 func TestScrapeSantaLogFromBase_LineAtRetentionLimit(t *testing.T) {
-	tmp := t.TempDir()
-	base := filepath.Join(tmp, "santa.log")
+	base := tempLog(t)
 
 	for _, length := range []int{maxLineBytes - 1, maxLineBytes, maxLineBytes + 1} {
-		line := mkLineWithArgs("decision=ALLOW", "2025-09-18 12:00:00.000", "/A", "ok", "aaa", "")
+		line := mkLineWithArgs("decision=ALLOW", testTS, "/A", "ok", "aaa", "")
 		// Pad the args field so the line is exactly length bytes, newline included.
 		line = strings.TrimSuffix(line, "\n") + strings.Repeat("x", length-len(line)) + "\n"
 		require.Len(t, line, length)
@@ -391,22 +334,16 @@ func TestScrapeSantaLogFromBase_LineAtRetentionLimit(t *testing.T) {
 
 		got, err := scrapeSantaLogFromBase(t.Context(), decisionAllowed, base)
 		require.NoError(t, err, "line length %d", length)
-		require.Len(t, got, 1, "line length %d", length)
-		require.Equal(t, logEntry{
-			Timestamp:   "2025-09-18 12:00:00.000",
-			Application: "/A",
-			Reason:      "ok",
-			SHA256:      "aaa",
-		}, got[0], "line length %d", length)
+		require.Equal(t, []logEntry{{Timestamp: testTS, Application: "/A", Reason: "ok", SHA256: "aaa"}}, got,
+			"line length %d", length)
 	}
 }
 
 // TestScrapeSantaLogFromBase_CanceledContext verifies that a canceled query is
 // reported rather than looking like an empty log.
 func TestScrapeSantaLogFromBase_CanceledContext(t *testing.T) {
-	tmp := t.TempDir()
-	base := filepath.Join(tmp, "santa.log")
-	writeFile(t, base, mkLine("decision=ALLOW", "2025-09-18 12:00:00.000", "/A", "ok", "aaa"))
+	base := tempLog(t)
+	writeFile(t, base, allow("/A"))
 
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
@@ -420,11 +357,9 @@ func TestScrapeSantaLogFromBase_CanceledContext(t *testing.T) {
 // events move to the next rotation index, so the disappearance is expected and
 // must not be reported as a failure.
 func TestScrapeSantaLogFromBase_ArchiveRotatedAwayIsNotReported(t *testing.T) {
-	tmp := t.TempDir()
-	base := filepath.Join(tmp, "santa.log")
-
-	writeFile(t, base, mkLine("decision=ALLOW", "2025-09-18 12:00:00.000", "/CUR", "ok", "aaa"))
-	writeGz(t, base+".1.gz", mkLine("decision=ALLOW", "2025-09-18 11:59:58.000", "/ARC1", "ok", "ccc"))
+	base := tempLog(t)
+	writeFile(t, base, allow("/CUR"))
+	writeGz(t, base+".1.gz", allow("/ARC1"))
 
 	// santa.log.0.gz is reported by discovery but is not on disk by the time it is
 	// opened.
@@ -442,32 +377,15 @@ func TestScrapeSantaLogFromBase_ArchiveRotatedAwayIsNotReported(t *testing.T) {
 	require.Equal(t, []string{"/ARC1", "/CUR"}, apps(got))
 }
 
-// TestScrapeSantaLogFromBase_MissingCurrentLogMidRotation covers the window in
-// which newsyslog has renamed santa.log and santad has not recreated it yet: the
-// events written before the rotation are read from the renamed file, which has not
-// been compressed yet.
-func TestScrapeSantaLogFromBase_MissingCurrentLogMidRotation(t *testing.T) {
-	tmp := t.TempDir()
-	base := filepath.Join(tmp, "santa.log")
-
-	// The renamed log is on disk; the active one does not exist yet.
-	writeFile(t, base+".0", mkLine("decision=ALLOW", "2025-09-18 11:59:59.000", "/ARC0", "ok", "bbb"))
-
-	got, err := scrapeSantaLogFromBase(t.Context(), decisionAllowed, base)
-	require.NoError(t, err)
-	require.Equal(t, []string{"/ARC0"}, apps(got))
-}
-
 // TestScrapeSantaLogFromBase_RediscoversArchivesAfterRotation covers a rotation
 // landing between discovering the archives and reading the active log, on a host
 // that had no archives at all: the events are in a santa.log.0 that the first
 // discovery pass ran too early to see.
 func TestScrapeSantaLogFromBase_RediscoversArchivesAfterRotation(t *testing.T) {
-	tmp := t.TempDir()
-	base := filepath.Join(tmp, "santa.log")
+	base := tempLog(t)
 
 	// The renamed log is on disk; the active one has not been recreated yet.
-	writeFile(t, base+".0", mkLine("decision=ALLOW", "2025-09-18 11:59:59.000", "/ARC0", "ok", "bbb"))
+	writeFile(t, base+".0", allow("/ARC0"))
 
 	// Each discovery pass starts by looking for santa.log.0.gz. The first pass sees
 	// nothing, as it would if it ran a moment before newsyslog's rename.
@@ -490,159 +408,89 @@ func TestScrapeSantaLogFromBase_RediscoversArchivesAfterRotation(t *testing.T) {
 	require.Equal(t, []string{"/ARC0"}, apps(got))
 }
 
-// TestScrapeSantaLogFromBase_MissingLogIsNotAnError verifies that a log that is
-// not there yields no rows and no error: Santa may not be installed, or may not be
-// configured to log to a file.
-func TestScrapeSantaLogFromBase_MissingLogIsNotAnError(t *testing.T) {
-	tmp := t.TempDir()
+// TestScrapeSantaLogFromBase_RediscoversShiftedArchivesAfterRotation covers the
+// same race on a host that already had compressed archives: the rename shifts
+// every archive up one index and leaves the ex-active events in a plain
+// santa.log.0, so the pre-rotation list points at files that no longer exist.
+func TestScrapeSantaLogFromBase_RediscoversShiftedArchivesAfterRotation(t *testing.T) {
+	base := tempLog(t)
 
-	got, err := scrapeSantaLogFromBase(t.Context(), decisionAllowed, filepath.Join(tmp, "santa.log"))
+	// Post-rotation disk state: no santa.log, no santa.log.0.gz; the ex-active
+	// events sit uncompressed at santa.log.0 and the old archive moved to .1.gz.
+	writeFile(t, base+".0", allow("/NEW"))
+	writeGz(t, base+".1.gz", allow("/OLD"))
+
+	// The first discovery pass ran a moment before the rename, when the only file
+	// besides the active log was santa.log.0.gz.
+	original := statFile
+	t.Cleanup(func() { statFile = original })
+	passes := 0
+	statFile = func(path string) (os.FileInfo, error) {
+		if strings.HasSuffix(path, ".0.gz") {
+			passes++
+		}
+		if passes == 1 {
+			if strings.HasSuffix(path, ".0.gz") {
+				return original(base + ".0")
+			}
+			return nil, os.ErrNotExist
+		}
+		return original(path)
+	}
+
+	got, err := scrapeSantaLogFromBase(t.Context(), decisionAllowed, base)
 	require.NoError(t, err)
-	require.Empty(t, got)
-}
-
-// TestScrapeSantaLogFromBase_StopsOnceCapIsMet verifies that archives are not
-// opened once the active log alone satisfies the entry cap, which is the common
-// case in monitor mode. The archive here cannot be read, so opening it at all
-// would surface an error.
-func TestScrapeSantaLogFromBase_StopsOnceCapIsMet(t *testing.T) {
-	oldCap := maxEntries
-	maxEntries = 2
-	defer func() { maxEntries = oldCap }()
-
-	tmp := t.TempDir()
-	base := filepath.Join(tmp, "santa.log")
-
-	writeFile(t, base,
-		mkLine("decision=ALLOW", "2025-09-18 12:00:00.000", "/A", "ok", "aaa")+
-			mkLine("decision=ALLOW", "2025-09-18 12:00:01.000", "/B", "ok", "bbb")+
-			mkLine("decision=ALLOW", "2025-09-18 12:00:02.000", "/C", "ok", "ccc"))
-	writeFile(t, base+".0.gz", "definitely not gzip")
-
-	got, err := scrapeSantaLogFromBase(t.Context(), decisionAllowed, base)
-	require.NoError(t, err, "the archive should not have been opened")
-	require.Equal(t, []string{"/B", "/C"}, apps(got))
-}
-
-// TestScrapeSantaLogFromBase_StopsOnceOlderArchivesAreUnneeded verifies the same
-// short circuit part way through the archives: enough events are found in the
-// active log and the newest archive, so the older one is left alone.
-func TestScrapeSantaLogFromBase_StopsOnceOlderArchivesAreUnneeded(t *testing.T) {
-	oldCap := maxEntries
-	maxEntries = 3
-	defer func() { maxEntries = oldCap }()
-
-	tmp := t.TempDir()
-	base := filepath.Join(tmp, "santa.log")
-
-	writeFile(t, base,
-		mkLine("decision=ALLOW", "2025-09-18 12:00:00.000", "/CUR1", "ok", "aaa")+
-			mkLine("decision=ALLOW", "2025-09-18 12:00:01.000", "/CUR2", "ok", "bbb"))
-	writeGz(t, base+".0.gz",
-		mkLine("decision=ALLOW", "2025-09-18 11:59:58.000", "/ARC0-1", "ok", "ccc")+
-			mkLine("decision=ALLOW", "2025-09-18 11:59:59.000", "/ARC0-2", "ok", "ddd"))
-	writeFile(t, base+".1.gz", "definitely not gzip")
-
-	got, err := scrapeSantaLogFromBase(t.Context(), decisionAllowed, base)
-	require.NoError(t, err, "the older archive should not have been opened")
-	require.Equal(t, []string{"/ARC0-2", "/CUR1", "/CUR2"}, apps(got))
+	require.Equal(t, 2, passes, "should have looked for archives again")
+	require.Equal(t, []string{"/OLD", "/NEW"}, apps(got))
 }
 
 func TestScrapeStream_EnforcesGlobalCap(t *testing.T) {
 	// Lower the global cap to make the test fast and predictable.
-	oldCap := maxEntries
-	maxEntries = 1_000
-	defer func() { maxEntries = oldCap }()
-
-	const perLine = `[` +
-		`2025-09-18 12:00:00.000` +
-		`] santad: decision=ALLOW | path=/Applications/App.app | reason=ok | sha256=abc123` + "\n"
-
-	var sb strings.Builder
-	sb.Grow(len(perLine) * (maxEntries + 50)) // generate a bit more than the cap
-	for i := 0; i < maxEntries+50; i++ {
-		sb.WriteString(perLine)
-	}
+	setCap(t, 1_000)
 
 	rb := newRingBuffer(maxEntries)
+	stream := strings.NewReader(strings.Repeat(allow("/Applications/App.app"), maxEntries+50))
 
-	err := scrapeStream(t.Context(), strings.NewReader(sb.String()), decisionAllowed, rb)
-
+	err := scrapeStream(t.Context(), stream, decisionAllowed, rb)
 	require.NoError(t, err, "cap should not surface as an error")
 	require.Len(t, rb.SliceChrono(), maxEntries, "SliceChrono should return exactly maxEntries items")
 }
 
 func TestScrapeSantaLogFromBase_PrefersLatestWithinArchiveOnCap(t *testing.T) {
-	tmp := t.TempDir()
-	base := filepath.Join(tmp, "santa.log")
+	base := tempLog(t)
+	writeFile(t, base, deny("/CUR-DENY"))
+	writeGz(t, base+".0.gz", deny("/ARC0-DENY"))
+	// The older archive holds more DENY lines than the cap leaves room for, so the
+	// buffer must end up holding the latest lines from within it.
+	writeGz(t, base+".1.gz", deny("/DENY-1")+deny("/DENY-2")+deny("/DENY-3")+deny("/DENY-4")+deny("/DENY-5"))
 
-	// Keep the test fast and intentional.
-	oldCap := maxEntries
-	maxEntries = 3
-	defer func() { maxEntries = oldCap }()
-
-	writeFile(t, base, mkLine("decision=DENY", "2025-09-18 12:00:00.000", "/CUR-DENY", "ok", "aaa"))
-
-	writeGz(t, base+".0.gz", mkLine("decision=DENY", "2025-09-18 11:59:59.500", "/ARC0-DENY", "ok", "bbb"))
-
-	// Older archive (.1.gz): many DENY lines with increasing timestamps.
-	// We want to ensure that when the cap is hit *inside this archive*,
-	// the buffer ends up holding the *latest* lines from within it.
-	var arc1 strings.Builder
-	arc1.WriteString(mkLine("decision=DENY", "2025-09-18 11:59:59.001", "/DENY-1", "r", "d1"))
-	arc1.WriteString(mkLine("decision=DENY", "2025-09-18 11:59:59.002", "/DENY-2", "r", "d2"))
-	arc1.WriteString(mkLine("decision=DENY", "2025-09-18 11:59:59.003", "/DENY-3", "r", "d3"))
-	arc1.WriteString(mkLine("decision=DENY", "2025-09-18 11:59:59.004", "/DENY-4", "r", "d4"))
-	arc1.WriteString(mkLine("decision=DENY", "2025-09-18 11:59:59.005", "/DENY-5", "r", "d5"))
-	writeGz(t, base+".1.gz", arc1.String())
-
-	// Scan: archives oldest→newest (.1.gz then .0.gz), then current last.
-	// Since only .1.gz has DENY lines and it contains more than maxEntries,
-	// the ring should end up with the last 3 from that archive:
-	// "/DENY-3", "/DENY-4", "/DENY-5" (chronological).
+	setCap(t, 3)
 	got, err := scrapeSantaLogFromBase(t.Context(), decisionDenied, base)
 	require.NoError(t, err)
-
-	require.Equal(t,
-		[]string{"/DENY-5", "/ARC0-DENY", "/CUR-DENY"},
-		[]string{got[0].Application, got[1].Application, got[2].Application},
-		"should keep the latest entries within the archive when hitting the cap",
-	)
+	require.Equal(t, []string{"/DENY-5", "/ARC0-DENY", "/CUR-DENY"}, apps(got),
+		"should keep the latest entries within the archive when hitting the cap")
 
 	maxEntries = 2
 	got, err = scrapeSantaLogFromBase(t.Context(), decisionDenied, base)
 	require.NoError(t, err)
-
-	require.Equal(t,
-		[]string{"/ARC0-DENY", "/CUR-DENY"},
-		[]string{got[0].Application, got[1].Application},
-		"with a smaller cap, should keep the latest entries within the archive",
-	)
+	require.Equal(t, []string{"/ARC0-DENY", "/CUR-DENY"}, apps(got),
+		"with a smaller cap, should keep the latest entries within the archive")
 
 	maxEntries = 1
 	got, err = scrapeSantaLogFromBase(t.Context(), decisionDenied, base)
 	require.NoError(t, err)
-
-	require.Equal(t,
-		[]string{"/CUR-DENY"},
-		[]string{got[0].Application},
-		"with a cap of 1, should keep only the latest entry overall",
-	)
+	require.Equal(t, []string{"/CUR-DENY"}, apps(got),
+		"with a cap of 1, should keep only the latest entry overall")
 }
 
 func TestGenerateAllowed_ReturnsRows(t *testing.T) {
-	base := stubLogPath(t)
-	writeFile(t, base, mkLine("decision=ALLOW", "2025-09-18 12:00:00.000", "/A", "cdhash", "aaa")+
-		mkLine("decision=DENY", "2025-09-18 12:00:01.000", "/B", "rule", "bbb"))
+	writeFile(t, stubLogPath(t), allow("/A")+deny("/B"))
 
 	rows, err := GenerateAllowed(t.Context(), table.QueryContext{})
 	require.NoError(t, err)
-	require.Equal(t, []map[string]string{{
-		"timestamp":   "2025-09-18 12:00:00.000",
-		"application": "/A",
-		"reason":      "cdhash",
-		"sha256":      "aaa",
-	}}, rows)
+	require.Equal(t, []map[string]string{
+		{"timestamp": testTS, "application": "/A", "reason": "ok", "sha256": "aaa"},
+	}, rows)
 }
 
 // TestGenerateAllowed_LogsFailureWithoutFailingTheQuery verifies that an
@@ -651,9 +499,8 @@ func TestGenerateAllowed_ReturnsRows(t *testing.T) {
 // query on every host running Santa, and a synthetic error row would look like a
 // real Santa event.
 func TestGenerateAllowed_LogsFailureWithoutFailingTheQuery(t *testing.T) {
-	base := stubLogPath(t)
 	// A path that exists but cannot be read as a file.
-	require.NoError(t, os.Mkdir(base, 0o755))
+	require.NoError(t, os.Mkdir(stubLogPath(t), 0o755))
 
 	logs := captureLogs(t)
 
@@ -664,18 +511,58 @@ func TestGenerateAllowed_LogsFailureWithoutFailingTheQuery(t *testing.T) {
 }
 
 func TestGenerateDenied_ReturnsRows(t *testing.T) {
-	base := stubLogPath(t)
-	writeFile(t, base, mkLine("decision=ALLOW", "2025-09-18 12:00:00.000", "/A", "cdhash", "aaa")+
-		mkLine("decision=DENY", "2025-09-18 12:00:01.000", "/B", "rule", "bbb"))
+	writeFile(t, stubLogPath(t), allow("/A")+deny("/B"))
 
 	rows, err := GenerateDenied(t.Context(), table.QueryContext{})
 	require.NoError(t, err)
-	require.Equal(t, []map[string]string{{
-		"timestamp":   "2025-09-18 12:00:01.000",
-		"application": "/B",
-		"reason":      "rule",
-		"sha256":      "bbb",
-	}}, rows)
+	require.Equal(t, []map[string]string{
+		{"timestamp": testTS, "application": "/B", "reason": "rule", "sha256": "bbb"},
+	}, rows)
+}
+
+// testTS is the timestamp the line helpers below stamp on every entry. Results
+// are ordered by file and line position, never by parsing timestamps, so the
+// tests do not need distinct ones.
+const testTS = "2025-09-18 12:00:00.000"
+
+func allow(path string) string {
+	return mkLine("decision=ALLOW", testTS, path, "ok", "aaa")
+}
+
+func deny(path string) string {
+	return mkLine("decision=DENY", testTS, path, "rule", "bbb")
+}
+
+// longAllow is an ALLOW line whose args field pushes it far past the retention
+// limit, as monitor mode produces for an exec with a long command line.
+func longAllow(path string) string {
+	return mkLineWithArgs("decision=ALLOW", testTS, path, "ok", "aaa", strings.Repeat("x", 200_000))
+}
+
+func mkLine(dec, ts, path, reason, sha string) string {
+	// example Santa line format
+	return "[" + ts + "] santad: " + dec +
+		` | path="` + path + `" | reason=` + reason + ` | sha256=` + sha + "\n"
+}
+
+// mkLineWithArgs builds a line with a trailing args field, which is where Santa
+// puts the process arguments and the only field with no practical size bound.
+func mkLineWithArgs(dec, ts, path, reason, sha, args string) string {
+	return strings.TrimSuffix(mkLine(dec, ts, path, reason, sha), "\n") +
+		" | args=" + args + "\n"
+}
+
+// tempLog returns the santa.log path inside a fresh temporary directory.
+func tempLog(tb testing.TB) string {
+	return filepath.Join(tb.TempDir(), "santa.log")
+}
+
+// setCap lowers the global entry cap for the duration of the test.
+func setCap(tb testing.TB, n int) {
+	tb.Helper()
+	original := maxEntries
+	tb.Cleanup(func() { maxEntries = original })
+	maxEntries = n
 }
 
 // stubLogPath points the tables at a temporary log for the duration of the test
@@ -684,7 +571,7 @@ func stubLogPath(tb testing.TB) string {
 	tb.Helper()
 	original := logPath
 	tb.Cleanup(func() { logPath = original })
-	logPath = filepath.Join(tb.TempDir(), "santa.log")
+	logPath = tempLog(tb)
 	return logPath
 }
 
@@ -714,28 +601,6 @@ func writeGz(tb testing.TB, path, content string) {
 	require.NoError(tb, f.Close())
 }
 
-func mkLine(dec, ts, path, reason, sha string) string {
-	// example Santa line format
-	return "[" + ts + "] santad: " + dec +
-		` | path="` + path + `" | reason=` + reason + ` | sha256=` + sha + "\n"
-}
-
-// apps lists the application column of entries, in the order returned.
-func apps(entries []logEntry) []string {
-	out := make([]string, len(entries))
-	for i := range entries {
-		out[i] = entries[i].Application
-	}
-	return out
-}
-
-// mkLineWithArgs builds a line with a trailing args field, which is where Santa
-// puts the process arguments and the only field with no practical size bound.
-func mkLineWithArgs(dec, ts, path, reason, sha, args string) string {
-	return strings.TrimSuffix(mkLine(dec, ts, path, reason, sha), "\n") +
-		" | args=" + args + "\n"
-}
-
 // writeTruncatedGz writes a gzip stream containing keep followed by drop, then
 // cuts the file at the flush boundary between them: keep decodes cleanly and
 // the stream then ends unexpectedly, as it does while newsyslog is still
@@ -755,6 +620,15 @@ func writeTruncatedGz(tb testing.TB, path, keep, drop string) {
 	require.NoError(tb, os.WriteFile(path, buf.Bytes()[:boundary], 0o644))
 }
 
+// apps lists the application column of entries, in the order returned.
+func apps(entries []logEntry) []string {
+	out := make([]string, len(entries))
+	for i := range entries {
+		out[i] = entries[i].Application
+	}
+	return out
+}
+
 //////////////////
 // BENCHMARKS
 // Santa log scraping can be slow due to potentially large files and
@@ -767,46 +641,38 @@ func writeTruncatedGz(tb testing.TB, path, keep, drop string) {
 // cpu: Apple M4 Max
 //////////////////
 
-// Small (~150KB) non-compressed
-// BenchmarkScrapeSantaLogFromBase_SmallPlain-16              10514            226687 ns/op         677.58 MB/s      504616 B/op       5060 allocs/op
-func BenchmarkScrapeSantaLogFromBase_SmallPlain(b *testing.B) {
-	tmp := b.TempDir()
-	base := filepath.Join(tmp, "santa.log")
-
-	content := fillToSize(150*1024, "decision=ALLOW")
-	writeFile(b, base, content)
-
+// benchScrape scrapes base once per iteration, reporting allocations and
+// throughput over corpusBytes.
+func benchScrape(b *testing.B, base string, decision santaDecisionType, corpusBytes int) {
 	ctx := b.Context()
-	b.SetBytes(int64(len(content)))
+	b.SetBytes(int64(corpusBytes))
 	b.ReportAllocs()
-	b.ResetTimer()
 
 	for b.Loop() {
-		if _, err := scrapeSantaLogFromBase(ctx, decisionAllowed, base); err != nil {
+		if _, err := scrapeSantaLogFromBase(ctx, decision, base); err != nil {
 			b.Fatal(err)
 		}
 	}
 }
 
+// Small (~150KB) non-compressed
+// BenchmarkScrapeSantaLogFromBase_SmallPlain-16              10514            226687 ns/op         677.58 MB/s      504616 B/op       5060 allocs/op
+func BenchmarkScrapeSantaLogFromBase_SmallPlain(b *testing.B) {
+	base := tempLog(b)
+	content := fillToSize(150*1024, "decision=ALLOW")
+	writeFile(b, base, content)
+
+	benchScrape(b, base, decisionAllowed, len(content))
+}
+
 // ~10MB non-compressed
 // BenchmarkScrapeSantaLogFromBase_10MB_Plain-16                177          13231784 ns/op         792.46 MB/s     8772758 B/op     343823 allocs/op
 func BenchmarkScrapeSantaLogFromBase_10MB_Plain(b *testing.B) {
-	tmp := b.TempDir()
-	base := filepath.Join(tmp, "santa.log")
-
+	base := tempLog(b)
 	content := fillToSize(10*1024*1024, "decision=ALLOW")
 	writeFile(b, base, content)
 
-	ctx := b.Context()
-	b.SetBytes(int64(len(content)))
-	b.ReportAllocs()
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		if _, err := scrapeSantaLogFromBase(ctx, decisionAllowed, base); err != nil {
-			b.Fatal(err)
-		}
-	}
+	benchScrape(b, base, decisionAllowed, len(content))
 }
 
 // ~10MB current log + five compressed archives (each ~10MB uncompressed), querying
@@ -814,14 +680,12 @@ func BenchmarkScrapeSantaLogFromBase_10MB_Plain(b *testing.B) {
 // MB/s counts bytes that were never read and overstates real throughput.
 // BenchmarkScrapeSantaLogFromBase_10MB_PlainPlus5x10MB_Gzip-16                 135          17888254 ns/op        3517.07 MB/s     8942730 B/op    346729 allocs/op
 func BenchmarkScrapeSantaLogFromBase_10MB_PlainPlus5x10MB_Gzip(b *testing.B) {
-	tmp := b.TempDir()
-	base := filepath.Join(tmp, "santa.log")
-
+	base := tempLog(b)
 	plain := fillToSize(10*1024*1024, "decision=ALLOW")
 	writeFile(b, base, plain)
 
 	totalUncompressed := len(plain)
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		dec := "decision=DENY"
 		if i%2 == 1 {
 			dec = "decision=ALLOW"
@@ -831,17 +695,8 @@ func BenchmarkScrapeSantaLogFromBase_10MB_PlainPlus5x10MB_Gzip(b *testing.B) {
 		totalUncompressed += len(raw)
 	}
 
-	ctx := b.Context()
-	b.SetBytes(int64(totalUncompressed))
-	b.ReportAllocs()
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		// Choose either decision; archives contain both.
-		if _, err := scrapeSantaLogFromBase(ctx, decisionDenied, base); err != nil {
-			b.Fatal(err)
-		}
-	}
+	// Choose either decision; archives contain both.
+	benchScrape(b, base, decisionDenied, totalUncompressed)
 }
 
 // ~10MB current log of ALLOW events plus five compressed archives, querying the
@@ -852,9 +707,7 @@ func BenchmarkScrapeSantaLogFromBase_10MB_PlainPlus5x10MB_Gzip(b *testing.B) {
 // throughput: the point of this benchmark is that most of those bytes are skipped.
 // BenchmarkScrapeSantaLogFromBase_CapMetByCurrentLog-16                        182          13192218 ns/op        4769.02 MB/s     8778596 B/op    343872 allocs/op
 func BenchmarkScrapeSantaLogFromBase_CapMetByCurrentLog(b *testing.B) {
-	tmp := b.TempDir()
-	base := filepath.Join(tmp, "santa.log")
-
+	base := tempLog(b)
 	plain := fillToSize(10*1024*1024, "decision=ALLOW")
 	writeFile(b, base, plain)
 
@@ -865,38 +718,11 @@ func BenchmarkScrapeSantaLogFromBase_CapMetByCurrentLog(b *testing.B) {
 		totalUncompressed += len(raw)
 	}
 
-	ctx := b.Context()
-	b.SetBytes(int64(totalUncompressed))
-	b.ReportAllocs()
-	b.ResetTimer()
-
-	for b.Loop() {
-		if _, err := scrapeSantaLogFromBase(ctx, decisionAllowed, base); err != nil {
-			b.Fatal(err)
-		}
-	}
+	benchScrape(b, base, decisionAllowed, totalUncompressed)
 }
 
 // fillToSize builds a string ≈ targetBytes by repeating mkLine(dec,...).
 func fillToSize(targetBytes int, decision string) string {
-	line := mkLine(decision,
-		"2025-09-18 12:00:00.000",
-		"/Applications/App.app",
-		"ok",
-		"deadbeefcafebabef00d",
-	)
-	ll := len(line)
-	if ll == 0 {
-		panic("mkLine returned empty line")
-	}
-	n := targetBytes / ll
-	if n < 1 {
-		n = 1
-	}
-	var sb strings.Builder
-	sb.Grow(n * ll)
-	for i := 0; i < n; i++ {
-		sb.WriteString(line)
-	}
-	return sb.String()
+	line := mkLine(decision, testTS, "/Applications/App.app", "ok", "deadbeefcafebabef00d")
+	return strings.Repeat(line, max(targetBytes/len(line), 1))
 }

--- a/orbit/pkg/table/santa/santa_status_test.go
+++ b/orbit/pkg/table/santa/santa_status_test.go
@@ -19,7 +19,7 @@ func TestGenerateStatus_HappyPath(t *testing.T) {
 	t.Cleanup(func() { execCommandContext = exec.CommandContext })
 	execCommandContext = fakeExecCommandContext(t, sampleStatusJSON())
 
-	rows, err := GenerateStatus(context.Background(), table.QueryContext{})
+	rows, err := GenerateStatus(t.Context(), table.QueryContext{})
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
 	row := rows[0]
@@ -49,7 +49,7 @@ func TestGenerateStatus_DaemonUnreachableReturnsRowWithError(t *testing.T) {
 	const daemonErr = "An error occurred communicating with the Santa daemon"
 	execCommandContext = fakeExecCommandContext(t, "", withExitCode(1), withStderr(daemonErr))
 
-	rows, err := GenerateStatus(context.Background(), table.QueryContext{})
+	rows, err := GenerateStatus(t.Context(), table.QueryContext{})
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
 	require.Equal(t, "0", rows[0]["daemon_reachable"])
@@ -60,7 +60,7 @@ func TestGenerateStatus_BadJSONReturnsError(t *testing.T) {
 	t.Cleanup(func() { execCommandContext = exec.CommandContext })
 	execCommandContext = fakeExecCommandContext(t, "{not-json}")
 
-	rows, err := GenerateStatus(context.Background(), table.QueryContext{})
+	rows, err := GenerateStatus(t.Context(), table.QueryContext{})
 	require.Error(t, err)
 	require.Nil(t, rows)
 }
@@ -70,7 +70,7 @@ func TestGenerateStatus_ContextCancelBehavesLikeCmdError(t *testing.T) {
 	// Simulate a slow command; we'll cancel the context before it returns
 	execCommandContext = fakeExecCommandContext(t, sampleStatusJSON(), withSleep(200*time.Millisecond))
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Millisecond)
 	defer cancel()
 
 	rows, err := GenerateStatus(ctx, table.QueryContext{})


### PR DESCRIPTION
Closes #47477

fleetd scrapes /var/db/santa/santa.log and its rotated archives on every query of santa_allowed and santa_denied, and any failure along the way was swallowed into an empty result set, logged only at debug level.

Reads are now best effort:

- Lines are read through a reader that retains the first 64KB and discards the rest, so an over-long line can no longer fail a scrape. Santa writes args last, after every field these tables expose.
- A file that cannot be read is reported without discarding the entries collected from the others.
- A compressed archive that fails to decompress falls back to the uncompressed file newsyslog leaves in place while it compresses.
- Rotated logs that were never compressed (santa.log.0) are now read.
- The active log is retried while briefly missing, which is the window between newsyslog renaming it and santad recreating it.
- A log that is simply absent stays a clean zero rows: Santa may not be installed, or may not be configured to log to a file.
- Anything else is logged at error level. The tables deliberately neither fail the query nor emit a synthetic error row; santa_status exposes log_type and file_logging for diagnosing a misconfigured Santa.

Also drops the per-line map[string]string and the timestamp regex, and keeps lines as []byte so a line failing the decision filter allocates nothing: ~3x faster with 5-7x less allocated on the scraping benchmarks.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [x] Verified that fleetd runs on macOS, Linux and Windows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Santa log collection now handles oversized lines, rotating or temporarily missing logs, corrupted archives, and decompression failures more reliably.
- Oversized lines are safely truncated instead of preventing other events from being collected.
- Uncompressed rotated logs are now included.
- Partial results are preserved when individual log files cannot be read.
- Log entries are returned in chronological order, including unterminated final lines.

## Performance
- Log processing is approximately three times faster and uses significantly less memory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->