### PR TITLE
iOS/iPadOS device vitals: restrict new fields to non-BYOD enrollments

### DIFF
--- a/frontend/pages/hosts/details/cards/Vitals/Vitals.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Vitals/Vitals.tests.tsx
@@ -4,6 +4,7 @@ import { createCustomRenderer } from "test/test-utils";
 
 import createMockHost, { createMockHostGeolocation } from "__mocks__/hostMock";
 import { createMockHostMdmData } from "__mocks__/mdmMock";
+import { MdmEnrollmentStatus } from "interfaces/mdm";
 import { HostPlatform } from "interfaces/platform";
 import { IHostCustomVital } from "interfaces/custom_host_vitals";
 import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
@@ -411,11 +412,20 @@ describe("View all vitals button", () => {
   const renderVitalsCard = ({
     platform = "ios",
     withToggle = false,
+    enrollmentStatus,
   }: {
     platform?: HostPlatform;
     withToggle?: boolean;
+    enrollmentStatus?: MdmEnrollmentStatus;
   } = {}) => {
-    const mockHost = createMockHost({ platform });
+    const mockHost = createMockHost({
+      platform,
+      ...(enrollmentStatus
+        ? {
+            mdm: createMockHostMdmData({ enrollment_status: enrollmentStatus }),
+          }
+        : {}),
+    });
     const toggleVitalsModal = withToggle ? jest.fn() : undefined;
 
     const utils = render(
@@ -471,6 +481,18 @@ describe("View all vitals button", () => {
       screen.queryByRole("button", { name: "View all" })
     ).not.toBeInTheDocument();
   });
+
+  it("does not render the button for a personal (BYOD) iOS host even when toggleVitalsModal is provided", () => {
+    renderVitalsCard({
+      platform: "ios",
+      withToggle: true,
+      enrollmentStatus: "On (manual - personal)",
+    });
+
+    expect(
+      screen.queryByRole("button", { name: "View all" })
+    ).not.toBeInTheDocument();
+  });
 });
 
 describe("Card vitals cap", () => {
@@ -499,7 +521,12 @@ describe("Card vitals cap", () => {
     {
       customHostVitals,
       withModal = true,
-    }: { customHostVitals?: IHostCustomVital[]; withModal?: boolean } = {}
+      enrollmentStatus = "On (manual)",
+    }: {
+      customHostVitals?: IHostCustomVital[];
+      withModal?: boolean;
+      enrollmentStatus?: MdmEnrollmentStatus;
+    } = {}
   ) => {
     const mockHost = createMockHost({
       platform,
@@ -509,7 +536,7 @@ describe("Card vitals cap", () => {
       cpu_type: "arm64",
       primary_ip: "192.168.1.1",
       public_ip: "203.0.113.1",
-      mdm: createMockHostMdmData({ enrollment_status: "On (manual)" }),
+      mdm: createMockHostMdmData({ enrollment_status: enrollmentStatus }),
     });
 
     return render(
@@ -584,6 +611,18 @@ describe("Card vitals cap", () => {
     const { container } = renderCard("ios", {
       customHostVitals: makeCustomVitals(10),
       withModal: false,
+    });
+
+    expect(getRenderedVitals(container).length).toBeGreaterThan(CAP);
+    expect(
+      screen.queryByRole("button", { name: "View all" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not cap a personal (BYOD) iOS host, since there's nothing extra behind 'View all'", () => {
+    const { container } = renderCard("ios", {
+      customHostVitals: makeCustomVitals(10),
+      enrollmentStatus: "On (manual - personal)",
     });
 
     expect(getRenderedVitals(container).length).toBeGreaterThan(CAP);

--- a/frontend/pages/hosts/details/cards/Vitals/Vitals.tsx
+++ b/frontend/pages/hosts/details/cards/Vitals/Vitals.tsx
@@ -739,7 +739,7 @@ const Vitals = ({
   const isIosOrIpadosHost = isIPadOrIPhone(vitalsData.platform);
   const showExpandedVitals =
     isIosOrIpadosHost &&
-    !isBYODAccountDrivenUserEnrollment(mdm?.enrollment_status);
+    !isBYODAccountDrivenUserEnrollment(mdm?.enrollment_status ?? null);
 
   const gridRef = useRef<HTMLDivElement>(null);
   const [columnCount, setColumnCount] = useState(FALLBACK_COLUMN_COUNT);

--- a/frontend/pages/hosts/details/cards/Vitals/Vitals.tsx
+++ b/frontend/pages/hosts/details/cards/Vitals/Vitals.tsx
@@ -737,6 +737,9 @@ const Vitals = ({
   onEditCustomHostVital,
 }: IVitalsProps) => {
   const isIosOrIpadosHost = isIPadOrIPhone(vitalsData.platform);
+  const showExpandedVitals =
+    isIosOrIpadosHost &&
+    !isBYODAccountDrivenUserEnrollment(mdm?.enrollment_status);
 
   const gridRef = useRef<HTMLDivElement>(null);
   const [columnCount, setColumnCount] = useState(FALLBACK_COLUMN_COUNT);
@@ -768,7 +771,7 @@ const Vitals = ({
   // Only cap where "View all" can reach what's hidden. Capping without it
   // would drop vitals with no way to see them.
   const cardVitals =
-    isIosOrIpadosHost && toggleVitalsModal
+    showExpandedVitals && toggleVitalsModal
       ? sortedVitals.slice(0, columnCount * IOS_CARD_VITAL_ROWS)
       : sortedVitals;
 
@@ -782,7 +785,7 @@ const Vitals = ({
     >
       <div className={`${baseClass}__header`}>
         <CardHeader header="Vitals" />
-        {isIosOrIpadosHost && toggleVitalsModal && (
+        {showExpandedVitals && toggleVitalsModal && (
           <Button variant="subdued" size="small" onClick={toggleVitalsModal}>
             View all
           </Button>

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -6062,6 +6062,7 @@ SELECT
 	h.id as host_id,
 	h.uuid as uuid,
 	hmdm.installed_from_dep,
+	hmdm.is_personal_enrollment,
 	JSON_ARRAYAGG(hmc.command_type) as commands_already_sent
 FROM hosts h
 	INNER JOIN host_mdm hmdm ON hmdm.host_id = h.id

--- a/server/fleet/mdm.go
+++ b/server/fleet/mdm.go
@@ -1311,10 +1311,11 @@ func (p InstallableDevicePlatform) IsApplePlatform() bool {
 }
 
 type AppleDevicesToRefetch struct {
-	HostID              uint                   `db:"host_id"`
-	UUID                string                 `db:"uuid"`
-	InstalledFromDEP    bool                   `db:"installed_from_dep"`
-	CommandsAlreadySent MDMCommandsAlreadySent `db:"commands_already_sent"`
+	HostID               uint                   `db:"host_id"`
+	UUID                 string                 `db:"uuid"`
+	InstalledFromDEP     bool                   `db:"installed_from_dep"`
+	IsPersonalEnrollment bool                   `db:"is_personal_enrollment"`
+	CommandsAlreadySent  MDMCommandsAlreadySent `db:"commands_already_sent"`
 }
 
 type MDMCommandsAlreadySent []string

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -1755,19 +1755,31 @@ func IOSiPadOSRefetch(ctx context.Context, ds fleet.Datastore, commander *MDMApp
 	}
 
 	// DeviceInformation is last because the refetch response clears the refetch_requested flag
-	deviceInfoUUIDs := make([]string, 0, len(devices))
+	deviceInfoUUIDs := struct {
+		Personal []string
+		Other    []string
+	}{}
 	for _, device := range devices {
 		if !slices.Contains(device.CommandsAlreadySent, fleet.RefetchDeviceCommandUUIDPrefix) {
-			deviceInfoUUIDs = append(deviceInfoUUIDs, device.UUID)
+			if device.IsPersonalEnrollment {
+				deviceInfoUUIDs.Personal = append(deviceInfoUUIDs.Personal, device.UUID)
+			} else {
+				deviceInfoUUIDs.Other = append(deviceInfoUUIDs.Other, device.UUID)
+			}
 			hostMDMCommands = append(hostMDMCommands, fleet.HostMDMCommand{
 				HostID:      device.HostID,
 				CommandType: fleet.RefetchDeviceCommandUUIDPrefix,
 			})
 		}
 	}
-	if len(deviceInfoUUIDs) > 0 {
+	for i, uuids := range [][]string{deviceInfoUUIDs.Personal, deviceInfoUUIDs.Other} {
+		isPersonalEnrollment := i == 0
+		if len(uuids) == 0 {
+			continue
+		}
+
 		commandUUID := uuid.NewString()
-		err := commander.DeviceInformation(ctx, deviceInfoUUIDs, fleet.RefetchDeviceCommandUUIDPrefix+commandUUID)
+		err := commander.DeviceInformation(ctx, uuids, fleet.RefetchDeviceCommandUUIDPrefix+commandUUID, isPersonalEnrollment)
 		turnedOff, turnedOffError := turnOffMDMIfAPNSFailed(ctx, ds, err, logger, newActivityFn)
 		if turnedOffError != nil {
 			return turnedOffError

--- a/server/mdm/apple/commander.go
+++ b/server/mdm/apple/commander.go
@@ -460,8 +460,21 @@ func (svc *MDMAppleCommander) DeviceConfigured(ctx context.Context, hostUUID, cm
 	return svc.EnqueueCommand(ctx, []string{hostUUID}, raw)
 }
 
+var byodDeviceInformationQueryKeys = []string{
+	"DeviceName",
+	"DeviceCapacity",
+	"AvailableDeviceCapacity",
+	"OSVersion",
+	"SupplementalOSVersionExtra",
+	"WiFiMAC",
+	"ProductName",
+	"IsMDMLostModeEnabled",
+	"TimeZone",
+}
+
 // deviceInformationQueryKeys are the Apple query keys requested in a
-// DeviceInformation command's <Queries> array, in request order.
+// DeviceInformation command's <Queries> array for non-personal
+// (company-owned) hosts, in request order.
 var deviceInformationQueryKeys = []string{
 	"DeviceName",
 	"DeviceCapacity",
@@ -500,9 +513,14 @@ var deviceInformationQueryKeys = []string{
 	"UDID",
 }
 
-func (svc *MDMAppleCommander) DeviceInformation(ctx context.Context, hostUUIDs []string, cmdUUID string) error {
+func (svc *MDMAppleCommander) DeviceInformation(ctx context.Context, hostUUIDs []string, cmdUUID string, isPersonalEnrollment bool) error {
+	keys := deviceInformationQueryKeys
+	if isPersonalEnrollment {
+		keys = byodDeviceInformationQueryKeys
+	}
+
 	var queries strings.Builder
-	for _, key := range deviceInformationQueryKeys {
+	for _, key := range keys {
 		queries.WriteString("            <string>")
 		queries.WriteString(key)
 		queries.WriteString("</string>\n")

--- a/server/mdm/apple/commander_test.go
+++ b/server/mdm/apple/commander_test.go
@@ -1158,61 +1158,95 @@ func TestMDMAppleCommanderDeviceInformation(t *testing.T) {
 		return false, nil
 	}
 
-	var gotCommand struct {
+	type gotCommandType struct {
 		Command struct {
 			Queries     []string `plist:"Queries"`
 			RequestType string   `plist:"RequestType"`
 		} `plist:"Command"`
 	}
-	mdmStorage.EnqueueCommandFunc = func(ctx context.Context, id []string, cmd *mdm.CommandWithSubtype) (map[string]error, error) {
-		require.NoError(t, plist.Unmarshal(cmd.Raw, &gotCommand))
-		return nil, nil
-	}
 
-	cmdUUID := uuid.New().String()
-	err := cmdr.DeviceInformation(ctx, hostUUIDs, cmdUUID)
-	require.NoError(t, err)
-	require.True(t, mdmStorage.EnqueueCommandFuncInvoked)
+	t.Run("non-personal enrollment requests all fields", func(t *testing.T) {
+		var gotCommand gotCommandType
+		mdmStorage.EnqueueCommandFunc = func(ctx context.Context, id []string, cmd *mdm.CommandWithSubtype) (map[string]error, error) {
+			require.NoError(t, plist.Unmarshal(cmd.Raw, &gotCommand))
+			return nil, nil
+		}
 
-	require.Equal(t, "DeviceInformation", gotCommand.Command.RequestType)
-	// Compared against an explicit, independent list (not the package's own
-	// deviceInformationQueryKeys var) so an accidental edit to that var would
-	// actually be caught here.
-	require.Equal(t, []string{
-		"DeviceName",
-		"DeviceCapacity",
-		"AvailableDeviceCapacity",
-		"OSVersion",
-		"SupplementalOSVersionExtra",
-		"WiFiMAC",
-		"ProductName",
-		"IsMDMLostModeEnabled",
-		"TimeZone",
-		"AccessibilitySettings",
-		"AppAnalyticsEnabled",
-		"AwaitingConfiguration",
-		"BatteryLevel",
-		"BluetoothMAC",
-		"CellularTechnology",
-		"DataRoamingEnabled",
-		"DevicePropertiesAttestation",
-		"DiagnosticSubmissionEnabled",
-		"EASDeviceIdentifier",
-		"IsCloudBackupEnabled",
-		"IsDeviceLocatorServiceEnabled",
-		"IsDoNotDisturbInEffect",
-		"IsNetworkTethered",
-		"iTunesStoreAccountHash",
-		"iTunesStoreAccountIsActive",
-		"LastCloudBackupDate",
-		"MDMOptions",
-		"ModelNumber",
-		"ModemFirmwareVersion",
-		"OrganizationInfo",
-		"PersonalHotspotEnabled",
-		"PushToken",
-		"ServiceSubscriptions",
-		"SupplementalBuildVersion",
-		"UDID",
-	}, gotCommand.Command.Queries)
+		cmdUUID := uuid.New().String()
+		err := cmdr.DeviceInformation(ctx, hostUUIDs, cmdUUID, false)
+		require.NoError(t, err)
+		require.True(t, mdmStorage.EnqueueCommandFuncInvoked)
+
+		require.Equal(t, "DeviceInformation", gotCommand.Command.RequestType)
+		// Compared against an explicit, independent list (not the package's own
+		// deviceInformationQueryKeys var) so an accidental edit to that var would
+		// actually be caught here.
+		require.Equal(t, []string{
+			"DeviceName",
+			"DeviceCapacity",
+			"AvailableDeviceCapacity",
+			"OSVersion",
+			"SupplementalOSVersionExtra",
+			"WiFiMAC",
+			"ProductName",
+			"IsMDMLostModeEnabled",
+			"TimeZone",
+			"AccessibilitySettings",
+			"AppAnalyticsEnabled",
+			"AwaitingConfiguration",
+			"BatteryLevel",
+			"BluetoothMAC",
+			"CellularTechnology",
+			"DataRoamingEnabled",
+			"DevicePropertiesAttestation",
+			"DiagnosticSubmissionEnabled",
+			"EASDeviceIdentifier",
+			"IsCloudBackupEnabled",
+			"IsDeviceLocatorServiceEnabled",
+			"IsDoNotDisturbInEffect",
+			"IsNetworkTethered",
+			"iTunesStoreAccountHash",
+			"iTunesStoreAccountIsActive",
+			"LastCloudBackupDate",
+			"MDMOptions",
+			"ModelNumber",
+			"ModemFirmwareVersion",
+			"OrganizationInfo",
+			"PersonalHotspotEnabled",
+			"PushToken",
+			"ServiceSubscriptions",
+			"SupplementalBuildVersion",
+			"UDID",
+		}, gotCommand.Command.Queries)
+	})
+
+	t.Run("personal (BYOD) enrollment only requests pre-#49984 fields", func(t *testing.T) {
+		var gotCommand gotCommandType
+		mdmStorage.EnqueueCommandFunc = func(ctx context.Context, id []string, cmd *mdm.CommandWithSubtype) (map[string]error, error) {
+			require.NoError(t, plist.Unmarshal(cmd.Raw, &gotCommand))
+			return nil, nil
+		}
+		mdmStorage.EnqueueCommandFuncInvoked = false
+
+		cmdUUID := uuid.New().String()
+		err := cmdr.DeviceInformation(ctx, hostUUIDs, cmdUUID, true)
+		require.NoError(t, err)
+		require.True(t, mdmStorage.EnqueueCommandFuncInvoked)
+
+		require.Equal(t, "DeviceInformation", gotCommand.Command.RequestType)
+		// None of the PII-bearing fields added by #49984 (battery level,
+		// service subscriptions/phone numbers, accessibility settings, etc.)
+		// must appear here.
+		require.Equal(t, []string{
+			"DeviceName",
+			"DeviceCapacity",
+			"AvailableDeviceCapacity",
+			"OSVersion",
+			"SupplementalOSVersionExtra",
+			"WiFiMAC",
+			"ProductName",
+			"IsMDMLostModeEnabled",
+			"TimeZone",
+		}, gotCommand.Command.Queries)
+	})
 }

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -1599,13 +1599,14 @@ func (svc *Service) RefetchHost(ctx context.Context, id uint) error {
 			return err
 		}
 
+		hostMDM, err := svc.ds.GetHostMDM(ctx, host.ID)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "get host MDM info")
+		}
+
 		hostMDMCommands := make([]fleet.HostMDMCommand, 0, 3)
 		cmdUUID := uuid.NewString()
 		if doAppRefetch {
-			hostMDM, err := svc.ds.GetHostMDM(ctx, host.ID)
-			if err != nil {
-				return ctxerr.Wrap(ctx, err, "get host MDM info")
-			}
 			isBYOD := !hostMDM.InstalledFromDep
 			err = svc.mdmAppleCommander.InstalledApplicationList(ctx, []string{host.UUID}, fleet.RefetchAppsCommandUUIDPrefix+cmdUUID, isBYOD)
 			if err != nil {
@@ -1629,7 +1630,7 @@ func (svc *Service) RefetchHost(ctx context.Context, id uint) error {
 
 		if doDeviceInfoRefetch {
 			// DeviceInformation is last because the refetch response clears the refetch_requested flag
-			err = svc.mdmAppleCommander.DeviceInformation(ctx, []string{host.UUID}, fleet.RefetchDeviceCommandUUIDPrefix+cmdUUID)
+			err = svc.mdmAppleCommander.DeviceInformation(ctx, []string{host.UUID}, fleet.RefetchDeviceCommandUUIDPrefix+cmdUUID, hostMDM.IsPersonalEnrollment)
 			if err != nil {
 				return ctxerr.Wrap(ctx, err, "refetch host with MDM")
 			}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Relates to #49984

Restricts device vitals fields added by #49984 (battery level, service subscriptions/phone numbers, accessibility settings, etc.) to non-BYOD iOS/iPadOS enrollments only. Personal (BYOD) hosts continue to get the 9 fields Fleet requested before #49984 (device name, capacity, OS version, product name, lost-mode status, etc.), but not the newer ones, since those can carry PII a personal device's owner may not want their employer to see.

Note: Raised during review of #50046, see [this comment](https://github.com/fleetdm/fleet/pull/50046#pullrequestreview-4798153603).

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for personally enrolled iOS and iPadOS devices.
  * Personally enrolled devices now receive a streamlined device-information request.
  * Vitals for personally enrolled devices display the full list without a “View all” limit or button.
* **Bug Fixes**
  * Corrected Vitals card behavior for BYOD devices while preserving existing behavior for other hosts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->