### PR TITLE
iOS/iPadOS device vitals: osquery-perf synthetic vitals

### DIFF
--- a/cmd/osquery-perf/README.md
+++ b/cmd/osquery-perf/README.md
@@ -120,6 +120,8 @@ go run agent.go --os_templates ipad_13.18,iphone_14.6 --host_count 10 --mdm_scep
 
 `mdm_user_prob` determines the probability of MDM user enrollment for each host. The default is 0 (0%). You can set it to 1.0 to ensure all hosts enroll in MDM user enrollment. This probability stacks with `mdm_prob`. So this probability is based on the hosts who end up MDM enrolling.
 
+`mdm_ios_byod_prob` determines the probability that a simulated iOS/iPadOS device (`iphone_14.6`, `ipad_13.18`, `iphone_17` templates) reports as a personal (BYOD) enrollment, which omits the newer device vitals fields from its `DeviceInformation` ack, matching what Fleet's server asks a real BYOD device for. The default is 0 (all simulated iOS/iPadOS devices report the full vitals set).
+
 ### Apple Platform SSO (PSSO)
 
 A subset of macOS MDM agents can additionally exercise Apple Platform SSO: device

--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -358,6 +358,7 @@ type mdmAgent struct {
 	mdmProfileFailureProb      float64
 	osVersion                  string
 	supplementalOSVersionExtra string
+	isPersonalEnrollment       bool
 }
 
 // stats, model, *serverURL, *mdmSCEPChallenge, *mdmCheckInInterval
@@ -3761,8 +3762,16 @@ func (a *mdmAgent) runAppleIDeviceMDMLoop(mdmSCEPChallenge string) {
 			a.stats.IncrementMDMCommandsReceived()
 			switch mdmCommandPayload.Command.RequestType {
 			case "DeviceInformation":
-				mdmCommandPayload, err = mdmClient.AcknowledgeDeviceInformationWithVitals(udid, mdmCommandPayload.CommandUUID, deviceName,
-					productName, "America/Los_Angeles", a.osVersion, a.supplementalOSVersionExtra)
+				if a.isPersonalEnrollment {
+					// A personal (BYOD) enrollment doesn't get asked for the
+					// newer device vitals fields (see byodDeviceInformationQueryKeys
+					// in server/mdm/apple/commander.go), so it shouldn't report them.
+					mdmCommandPayload, err = mdmClient.AcknowledgeDeviceInformationWithExtra(udid, mdmCommandPayload.CommandUUID, deviceName,
+						productName, "America/Los_Angeles", a.osVersion, a.supplementalOSVersionExtra)
+				} else {
+					mdmCommandPayload, err = mdmClient.AcknowledgeDeviceInformationWithVitals(udid, mdmCommandPayload.CommandUUID, deviceName,
+						productName, "America/Los_Angeles", a.osVersion, a.supplementalOSVersionExtra)
+				}
 			case "InstalledApplicationList":
 				software := a.softwareIOSandIPadOS(softwareSource)
 				mdmCommandPayload, err = mdmClient.AcknowledgeInstalledApplicationList(udid, mdmCommandPayload.CommandUUID, software)
@@ -3942,6 +3951,7 @@ func main() {
 		mdmUserProb           = flag.Float64("mdm_user_prob", 0.0, "Probability of a host having an MDM user enrollment (compounds on mdm_prob) [0, 1]")
 		mdmSCEPChallenge      = flag.String("mdm_scep_challenge", "", "SCEP challenge to use when running macOS MDM enroll")
 		mdmProfileFailureProb = flag.Float64("mdm_profile_failure_prob", 0.0, "Probability of an MDM profile to fail install [0, 1]")
+		mdmIOSBYODProb        = flag.Float64("mdm_ios_byod_prob", 0.0, "Probability of a simulated iOS/iPadOS device (os_templates iphone_14.6/ipad_13.18/iphone_17) reporting as a personal (BYOD) enrollment, which omits the newer device vitals fields from its DeviceInformation ack [0, 1]")
 
 		mdmPSSOProb      = flag.Float64("mdm_psso_prob", 0.0, "Probability of an MDM-enrolled macOS host also simulating Apple Platform SSO [0, 1]. Requires the Fleet server to have account provisioning configured and the PSSO profile assigned to the host")
 		mdmPSSOClientID  = flag.String("mdm_psso_client_id", "", "Apple Platform SSO IdP/extension client ID. Must match the Fleet server's account provisioning config; PSSO is skipped when empty")
@@ -4111,6 +4121,7 @@ func main() {
 				serverAddress:              *serverURL,
 				osVersion:                  osVersion,
 				supplementalOSVersionExtra: supplementalOSVersionExtra,
+				isPersonalEnrollment:       rand.Float64() < *mdmIOSBYODProb, // nolint:gosec,G404 // load testing, not security-sensitive
 				softwareCount: softwareEntityCount{
 					entityCount: entityCount{
 						common: *commonSoftwareCount,

--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -3761,7 +3761,7 @@ func (a *mdmAgent) runAppleIDeviceMDMLoop(mdmSCEPChallenge string) {
 			a.stats.IncrementMDMCommandsReceived()
 			switch mdmCommandPayload.Command.RequestType {
 			case "DeviceInformation":
-				mdmCommandPayload, err = mdmClient.AcknowledgeDeviceInformationWithExtra(udid, mdmCommandPayload.CommandUUID, deviceName,
+				mdmCommandPayload, err = mdmClient.AcknowledgeDeviceInformationWithVitals(udid, mdmCommandPayload.CommandUUID, deviceName,
 					productName, "America/Los_Angeles", a.osVersion, a.supplementalOSVersionExtra)
 			case "InstalledApplicationList":
 				software := a.softwareIOSandIPadOS(softwareSource)

--- a/pkg/mdm/mdmtest/apple.go
+++ b/pkg/mdm/mdmtest/apple.go
@@ -1242,7 +1242,7 @@ func deviceVitalsQueryResponses(udid string) map[string]any {
 	// Spread the derived values across independent bits of the hash so they don't
 	// all flip together between two adjacent udids.
 	bit := func(n uint) bool { return seed>>(n%64)&1 == 1 }
-	octet := func(n uint) byte { return byte(seed >> n) }
+	octet := func(n uint) byte { return byte(seed >> n) } //nolint:gosec // dismiss G115
 
 	return map[string]any{
 		"AccessibilitySettings": map[string]any{
@@ -1251,7 +1251,7 @@ func deviceVitalsQueryResponses(udid string) map[string]any {
 			"IncreaseContrastEnabled":    bit(2),
 			"ReduceMotionEnabled":        bit(3),
 			"ReduceTransparencyEnabled":  bit(4),
-			"TextSize":                   uint64(seed % 12),
+			"TextSize":                   seed % 12,
 			"TouchAccommodationsEnabled": bit(5),
 			"VoiceOverEnabled":           bit(6),
 			"ZoomEnabled":                bit(7),
@@ -1261,7 +1261,7 @@ func deviceVitalsQueryResponses(udid string) map[string]any {
 		"BatteryLevel":          float64(seed%101) / 100,
 		"BluetoothMAC": fmt.Sprintf("%02x:%02x:%02x:%02x:%02x:%02x",
 			octet(0), octet(8), octet(16), octet(24), octet(32), octet(40)),
-		"CellularTechnology":            uint64(seed % 4),
+		"CellularTechnology":            seed % 4,
 		"DataRoamingEnabled":            bit(9),
 		"DevicePropertiesAttestation":   syntheticAttestationChain(seed),
 		"DiagnosticSubmissionEnabled":   bit(10),
@@ -1309,10 +1309,10 @@ func syntheticAttestationChain(seed uint64) [][]byte {
 	for i := range chain {
 		// mathrand2 (not this file's crypto/rand) since the bytes only need to be
 		// deterministic per seed, not random in any meaningful sense.
-		rng := mathrand2.New(mathrand2.NewPCG(seed, uint64(i)))
+		rng := mathrand2.New(mathrand2.NewPCG(seed, uint64(i))) // nolint:gosec,G404 // load testing, not security-sensitive
 		der := make([]byte, 1024)
 		for j := range der {
-			der[j] = byte(rng.Uint64())
+			der[j] = byte(rng.Uint64()) //nolint:gosec // dismiss G115
 		}
 		chain[i] = der
 	}

--- a/pkg/mdm/mdmtest/apple.go
+++ b/pkg/mdm/mdmtest/apple.go
@@ -14,13 +14,17 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"io"
 	"log/slog"
+	"maps"
 	mrand "math/rand"
+	mathrand2 "math/rand/v2"
 	"net/http"
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/fleetdm/fleet/v4/pkg/fleethttp"
 	shared_mdm "github.com/fleetdm/fleet/v4/pkg/mdm"
@@ -1178,6 +1182,37 @@ func (c *TestAppleMDMClient) AcknowledgeDeviceInformation(udid, cmdUUID, deviceN
 // If supplementalOSVersionExtra is non-empty it is included as SupplementalOSVersionExtra
 // in the response, representing a Rapid Security Response suffix such as "(a)".
 func (c *TestAppleMDMClient) AcknowledgeDeviceInformationWithExtra(udid, cmdUUID, deviceName, productName, timeZone, osVersion, supplementalOSVersionExtra string) (*mdm.Command, error) {
+	payload := map[string]any{
+		"Status":         "Acknowledged",
+		"UDID":           udid,
+		"CommandUUID":    cmdUUID,
+		"QueryResponses": deviceInformationQueryResponses(deviceName, productName, timeZone, osVersion, supplementalOSVersionExtra),
+	}
+	return c.sendAndDecodeCommandResponse(payload)
+}
+
+// AcknowledgeDeviceInformationWithVitals is AcknowledgeDeviceInformationWithExtra
+// plus the iOS/iPadOS device vitals Fleet requests (see deviceInformationQueryKeys
+// in server/mdm/apple/commander.go). It exists separately so that existing callers
+// keep reporting the smaller response they assert against today.
+//
+// Values are derived from udid so synthetic hosts don't all report byte-identical
+// vitals, and the attestation chain is sized like a real one so load tests see
+// representative write volume — it dominates the row (see the sizing note on
+// DevicePropertiesAttestation below).
+func (c *TestAppleMDMClient) AcknowledgeDeviceInformationWithVitals(udid, cmdUUID, deviceName, productName, timeZone, osVersion, supplementalOSVersionExtra string) (*mdm.Command, error) {
+	queryResponses := deviceInformationQueryResponses(deviceName, productName, timeZone, osVersion, supplementalOSVersionExtra)
+	maps.Copy(queryResponses, deviceVitalsQueryResponses(udid))
+	payload := map[string]any{
+		"Status":         "Acknowledged",
+		"UDID":           udid,
+		"CommandUUID":    cmdUUID,
+		"QueryResponses": queryResponses,
+	}
+	return c.sendAndDecodeCommandResponse(payload)
+}
+
+func deviceInformationQueryResponses(deviceName, productName, timeZone, osVersion, supplementalOSVersionExtra string) map[string]any {
 	if osVersion == "" {
 		osVersion = "17.5.1"
 	}
@@ -1194,13 +1229,132 @@ func (c *TestAppleMDMClient) AcknowledgeDeviceInformationWithExtra(udid, cmdUUID
 	if supplementalOSVersionExtra != "" {
 		queryResponses["SupplementalOSVersionExtra"] = supplementalOSVersionExtra
 	}
-	payload := map[string]any{
-		"Status":         "Acknowledged",
-		"UDID":           udid,
-		"CommandUUID":    cmdUUID,
-		"QueryResponses": queryResponses,
+	return queryResponses
+}
+
+// deviceVitalsQueryResponses builds the device-vitals half of a DeviceInformation
+// response, varied per udid so that a fleet of synthetic hosts produces distinct
+// rows rather than one value repeated N times.
+func deviceVitalsQueryResponses(udid string) map[string]any {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(udid))
+	seed := h.Sum64()
+	// Spread the derived values across independent bits of the hash so they don't
+	// all flip together between two adjacent udids.
+	bit := func(n uint) bool { return seed>>(n%64)&1 == 1 }
+	octet := func(n uint) byte { return byte(seed >> n) }
+
+	return map[string]any{
+		"AccessibilitySettings": map[string]any{
+			"BoldTextEnabled":            bit(0),
+			"GrayscaleEnabled":           bit(1),
+			"IncreaseContrastEnabled":    bit(2),
+			"ReduceMotionEnabled":        bit(3),
+			"ReduceTransparencyEnabled":  bit(4),
+			"TextSize":                   uint64(seed % 12),
+			"TouchAccommodationsEnabled": bit(5),
+			"VoiceOverEnabled":           bit(6),
+			"ZoomEnabled":                bit(7),
+		},
+		"AppAnalyticsEnabled":   bit(8),
+		"AwaitingConfiguration": bit(20),
+		"BatteryLevel":          float64(seed%101) / 100,
+		"BluetoothMAC": fmt.Sprintf("%02x:%02x:%02x:%02x:%02x:%02x",
+			octet(0), octet(8), octet(16), octet(24), octet(32), octet(40)),
+		"CellularTechnology":            uint64(seed % 4),
+		"DataRoamingEnabled":            bit(9),
+		"DevicePropertiesAttestation":   syntheticAttestationChain(seed),
+		"DiagnosticSubmissionEnabled":   bit(10),
+		"EASDeviceIdentifier":           fmt.Sprintf("%016x", seed),
+		"IsCloudBackupEnabled":          bit(11),
+		"IsDeviceLocatorServiceEnabled": bit(12),
+		"IsDoNotDisturbInEffect":        bit(13),
+		"IsNetworkTethered":             bit(14),
+		"iTunesStoreAccountHash":        fmt.Sprintf("%016x%016x", seed, seed*2654435761),
+		"iTunesStoreAccountIsActive":    bit(15),
+		"LastCloudBackupDate":           time.Now().UTC().Add(-time.Duration(seed%720) * time.Hour),
+		"MDMOptions": map[string]any{
+			"ActivationLockAllowedWhileSupervised":             bit(16),
+			"BootstrapTokenAllowed":                            bit(17),
+			"PromptUserToAllowBootstrapTokenForAuthentication": bit(18),
+		},
+		"ModelNumber":          fmt.Sprintf("MT%03dLL/A", seed%1000),
+		"ModemFirmwareVersion": fmt.Sprintf("%d.%02d.00", seed%10, seed%100),
+		"OrganizationInfo": map[string]any{
+			"OrganizationName":    "Fleet Device Management",
+			"OrganizationAddress": "123 Example St",
+			"OrganizationPhone":   "+15555550100",
+			"OrganizationEmail":   "it@example.com",
+			"OrganizationMagic":   fmt.Sprintf("%016x", seed),
+		},
+		"PersonalHotspotEnabled":   bit(19),
+		"PushToken":                []byte(fmt.Sprintf("%016x%016x", seed, seed*31)),
+		"ServiceSubscriptions":     syntheticServiceSubscriptions(seed),
+		"SupplementalBuildVersion": "21F90",
+		"UDID":                     udid,
 	}
-	return c.sendAndDecodeCommandResponse(payload)
+}
+
+// syntheticAttestationChain returns a leaf + intermediate pair sized like the
+// real Apple Enterprise Attestation chain. Real X.509 certificates in a DER
+// chain run roughly 1 KB each, and since Fleet stores this as a JSON array of
+// base64 strings it is by far the largest column in host_mdm_apple_device_vitals
+// (~3 KB of the ~4 KB row) — the whole point of sending it from osquery-perf is
+// that a load test writes representative bytes rather than a stub.
+//
+// The contents are not parseable certificates: Fleet stores the chain verbatim
+// without decoding it, so only the size and shape matter here.
+func syntheticAttestationChain(seed uint64) [][]byte {
+	chain := make([][]byte, 2)
+	for i := range chain {
+		// mathrand2 (not this file's crypto/rand) since the bytes only need to be
+		// deterministic per seed, not random in any meaningful sense.
+		rng := mathrand2.New(mathrand2.NewPCG(seed, uint64(i)))
+		der := make([]byte, 1024)
+		for j := range der {
+			der[j] = byte(rng.Uint64())
+		}
+		chain[i] = der
+	}
+	return chain
+}
+
+// syntheticServiceSubscriptions returns one or two subscriptions, mirroring the
+// single-SIM and dual-SIM (physical + eSIM) shapes a real device reports. The
+// second (eSIM) slot only carries Slot/EID/IMEI, matching what an
+// inactive/unprovisioned eSIM reports on a real dual-SIM iPhone (see
+// MDMAppleServiceSubscription's doc comment in
+// server/fleet/mdm_apple_device_vitals.go).
+func syntheticServiceSubscriptions(seed uint64) []map[string]any {
+	subs := []map[string]any{
+		{
+			"CarrierSettingsVersion":   fmt.Sprintf("%d.0", seed%60),
+			"CurrentCarrierNetwork":    "Example Mobile",
+			"CurrentMCC":               fmt.Sprintf("%03d", seed%1000),
+			"CurrentMNC":               fmt.Sprintf("%03d", (seed/1000)%1000),
+			"EID":                      fmt.Sprintf("%032d", seed%1e16),
+			"ICCID":                    fmt.Sprintf("%020d", seed%1e18),
+			"IMEI":                     fmt.Sprintf("%015d", seed%1e15),
+			"IsDataPreferred":          true,
+			"IsRoaming":                seed%7 == 0,
+			"IsVoicePreferred":         true,
+			"Label":                    "Primary",
+			"LabelID":                  fmt.Sprintf("%016X", seed),
+			"MEID":                     fmt.Sprintf("%014X", seed%1e14),
+			"PhoneNumber":              fmt.Sprintf("+1555%07d", seed%1e7),
+			"SubscriberCarrierNetwork": "Example Mobile",
+			"Slot":                     "CTSubscriptionSlotOne",
+		},
+	}
+	if seed%2 == 0 {
+		n := seed * 31
+		subs = append(subs, map[string]any{
+			"Slot": "CTSubscriptionSlotTwo",
+			"EID":  fmt.Sprintf("%032d", n%1e16),
+			"IMEI": fmt.Sprintf("%015d", n%1e15),
+		})
+	}
+	return subs
 }
 
 func (c *TestAppleMDMClient) AcknowledgeDeviceLocation(udid, cmdUUID string, lat, long float64) (*mdm.Command, error) {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #50521

`AcknowledgeDeviceInformationWithVitals` now returns the new query keys (accessibility settings, battery level, service subscriptions, attestation chain, etc.) so `host_mdm_apple_device_vitals`/`host_mdm_apple_service_subscriptions` get representative synthetic data instead of staying empty.

# Checklist for submitter

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

It will be included in the feature branch.


## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved Apple device management acknowledgments by including device vitals in device-information responses.
* Apple device records now provide more complete status details, including battery, network connectivity, accessibility, security, and subscription information.
* Enhanced consistency of device information across management workflows, helping ensure administrators receive more reliable and comprehensive device status data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->