### PR TITLE
Hide Self-service preview tabs in Edit appearance for Android apps

### DIFF
--- a/changes/44791-android-edit-appearance-self-service-preview
+++ b/changes/44791-android-edit-appearance-self-service-preview
@@ -1,1 +1,1 @@
-- Removed the misleading Self-service preview tab from the "Edit appearance" modal for Android apps, since Android apps are installed from the Play Store rather than the Fleet self-service web view.
+- Removed the misleading Self-service preview tab from the "Edit appearance" modal for Android apps. Android apps are installed from the Play Store rather than the Fleet self-service web view and updating its appearance will not change anything in Play Store.

--- a/changes/44791-android-edit-appearance-self-service-preview
+++ b/changes/44791-android-edit-appearance-self-service-preview
@@ -1,0 +1,1 @@
+- Removed the misleading Self-service preview tab from the "Edit appearance" modal for Android apps, since Android apps are installed from the Play Store rather than the Fleet self-service web view.

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditIconModal/EditIconModal.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditIconModal/EditIconModal.tests.tsx
@@ -45,6 +45,23 @@ describe("EditIconModal", () => {
     expect(save).toBeInTheDocument();
   });
 
+  it("hides the preview tabs and Self-service view for Android apps", () => {
+    const render = createCustomRenderer({ withBackendMock: true });
+    const ANDROID_PROPS = {
+      ...MOCK_PROPS,
+      previewInfo: {
+        ...MOCK_PROPS.previewInfo,
+        source: "android_apps",
+      },
+    };
+    render(<EditIconModal {...ANDROID_PROPS} />);
+
+    expect(screen.getByText("Preview")).toBeInTheDocument();
+    expect(screen.queryByText("Fleet")).not.toBeInTheDocument();
+    expect(screen.queryByText("Self-service")).not.toBeInTheDocument();
+    expect(screen.getByText("Version")).toBeInTheDocument();
+  });
+
   it("shows the correct software name and preview info in Fleet card", () => {
     const render = createCustomRenderer({ withBackendMock: true });
     render(<EditIconModal {...MOCK_PROPS} />);

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditIconModal/EditIconModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditIconModal/EditIconModal.tsx
@@ -4,6 +4,7 @@ import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
 
 import {
   IAppStoreApp,
+  isAndroidSoftwareSource,
   isIpadOrIphoneSoftwareSource,
   ISoftwarePackage,
   InstallerType,
@@ -162,6 +163,7 @@ const EditIconModal = ({
   const isIosOrIpadosApp = isIpadOrIphoneSoftwareSource(
     previewInfo?.source || ""
   );
+  const isAndroidApp = isAndroidSoftwareSource(previewInfo?.source || "");
 
   // Fetch current custom icon from API if applicable
   const shouldFetchCustomIcon =
@@ -613,20 +615,24 @@ const EditIconModal = ({
         gitopsCompatible={false}
       />
       <h2>Preview</h2>
-      <TabNav>
-        <Tabs selectedIndex={previewTabIndex} onSelect={onTabChange}>
-          <TabList>
-            <Tab>
-              <TabText>Fleet</TabText>
-            </Tab>
-            <Tab>
-              <TabText>Self-service</TabText>
-            </Tab>
-          </TabList>
-          <TabPanel>{renderPreviewFleetCard()}</TabPanel>
-          <TabPanel>{renderPreviewSelfServiceCard()}</TabPanel>
-        </Tabs>
-      </TabNav>
+      {isAndroidApp ? (
+        renderPreviewFleetCard()
+      ) : (
+        <TabNav>
+          <Tabs selectedIndex={previewTabIndex} onSelect={onTabChange}>
+            <TabList>
+              <Tab>
+                <TabText>Fleet</TabText>
+              </Tab>
+              <Tab>
+                <TabText>Self-service</TabText>
+              </Tab>
+            </TabList>
+            <TabPanel>{renderPreviewFleetCard()}</TabPanel>
+            <TabPanel>{renderPreviewSelfServiceCard()}</TabPanel>
+          </Tabs>
+        </TabNav>
+      )}
     </>
   );
 


### PR DESCRIPTION
<img width="890" height="562" alt="Screenshot 2026-08-04 at 12 57 28 PM" src="https://github.com/user-attachments/assets/cb3a0817-13a8-483e-a5ad-d6c430c81f32" />

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #44791

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

## Summary

Android apps are always self-service and installed from the Play Store in the end user's work profile — there's no Fleet self-service web view for them. The "Edit appearance" modal's Preview section still showed a "Fleet" / "Self-service" tab pair with a browser-style self-service preview for Android titles, which doesn't reflect what end users actually see (#44791).

This PR removes the tab nav for Android software titles in `EditIconModal` — the Preview section now renders just the Fleet card, with no tabs and no Self-service preview.

## Test plan

- [x] `yarn test` for `EditIconModal.tests.tsx` (added a test asserting no tabs/Self-service text render for an `android_apps` source, existing test confirms tabs still render for non-Android)
- [x] Manually verified in a local dev instance: seeded an Android software title, opened Actions > Edit appearance, confirmed Preview renders the Fleet card directly with no tabs

(Recreated from #50530, which accidentally included unrelated commits from a stale branch base.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the misleading Android Self-service preview from the Edit appearance modal.
  * Android app previews now show only the Fleet preview and Version view.
  * Other software continues to display both Fleet and Self-service preview options.
* **Tests**
  * Added coverage to verify the correct preview tabs and version display for Android apps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->