### PR TITLE
Fleet UI: Flush Self-service search right without Install all button

### DIFF
--- a/changes/50532-self-service-header-gap
+++ b/changes/50532-self-service-header-gap
@@ -1,0 +1,1 @@
+* Fixed the My device > Self-service search bar not sitting flush right when the "Install all" button isn't rendered.

--- a/frontend/pages/hosts/details/cards/Software/SelfService/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/_styles.scss
@@ -28,11 +28,12 @@
     gap: $pad-medium;
     align-items: center;
 
-    // Pushes the install-all button (and any following siblings) to the right
-    // edge whether or not CategoryFilter renders on the left. Works at all
-    // widths — on the narrow layout below it keeps Install all flush right on
-    // row 2.
-    &__install-all {
+    // Groups Install all + Search on the right of CategoryFilter with a
+    // tighter internal gap than the parent's $pad-medium.
+    &__actions {
+      display: flex;
+      align-items: center;
+      gap: $pad-small;
       margin-left: auto;
     }
 
@@ -47,9 +48,17 @@
   // remaining Install all + Search comfortably fit on one row at any width.
   &__header-filters--with-categories {
     @media (max-width: ($break-sm - 1)) {
+      // Unwrap __actions so Search and Install all reorder as direct
+      // siblings of __header-filters for the split-row layout.
+      .software-self-service__header-filters__actions {
+        display: contents;
+      }
       .software-self-service__header-filters__search {
         order: -1;
         flex-basis: 100%;
+      }
+      .software-self-service__header-filters__install-all {
+        margin-left: auto;
       }
     }
   }

--- a/frontend/pages/hosts/details/cards/Software/SelfService/components/SelfServiceFilters/SelfServiceFilters.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/components/SelfServiceFilters/SelfServiceFilters.tsx
@@ -43,15 +43,17 @@ const SelfServiceFilters = ({
           onChange={onCategoryChange}
         />
       )}
-      {installAllSlot && (
-        <div className={`${baseClass}__install-all`}>{installAllSlot}</div>
-      )}
-      <div className={`${baseClass}__search`}>
-        <SearchField
-          placeholder="Search by name"
-          onChange={onSearchQueryChange}
-          defaultValue={query}
-        />
+      <div className={`${baseClass}__actions`}>
+        {installAllSlot && (
+          <div className={`${baseClass}__install-all`}>{installAllSlot}</div>
+        )}
+        <div className={`${baseClass}__search`}>
+          <SearchField
+            placeholder="Search by name"
+            onChange={onSearchQueryChange}
+            defaultValue={query}
+          />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Issue
Closes #50532

## Description
- Bug fix (root cause): `.software-self-service__header-filters` put `margin-left: auto` only on `__install-all`, so when Install all wasn't rendered (no category selected, or every category item already installed/in-progress) the search bar collapsed next to CategoryFilter instead of staying flush right.
- Wrapped Install all + Search in a shared `__actions` container. The wrapper owns `margin-left: auto` (right-aligns as a group whether or not Install all renders) and its internal `gap` tightens the Install all → Search spacing from `$pad-medium` to `$pad-small`.
- Narrow-viewport layout (`--with-categories` under `$break-sm`) preserved via `display: contents` on `__actions` so Search still reorders to a full-width top row.

## Screenrecording
- Header layout with and without Install all rendered; narrow-viewport layout unchanged.


Uploading Screen Recording 2026-08-04 at 1.17.14 PM.mov…


## Testing

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Self-service search bar alignment when the “Install all” button is unavailable.
  * Improved header spacing and alignment across narrow and wide layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->