### PR TITLE
Rename 'Certificate enrollment' to 'Certificate authorities'

### DIFF
--- a/ee/server/service/scep/scep_proxy.go
+++ b/ee/server/service/scep/scep_proxy.go
@@ -783,7 +783,7 @@ func NDESChallengeErrorToDetail(err error) string {
 	switch {
 	case errors.As(err, &NDESInvalidError{}):
 		return fmt.Sprintf("Invalid NDES admin credentials. Fleet couldn't populate %s. "+
-			"Please update credentials in Settings > Integrations > Certificate enrollment.", varName)
+			"Please update credentials in Settings > Integrations > Certificate authorities.", varName)
 	case errors.As(err, &NDESPasswordCacheFullError{}):
 		return fmt.Sprintf("The NDES password cache is full. Fleet couldn't populate %s. "+
 			"Please increase the number of cached passwords in NDES and try again.", varName)

--- a/ee/server/service/scep/scep_proxy_test.go
+++ b/ee/server/service/scep/scep_proxy_test.go
@@ -1261,11 +1261,11 @@ func TestNDESChallengeErrorToDetail(t *testing.T) {
 		wantNotContains []string
 	}{
 		{
-			name:         "invalid credentials points to Certificate enrollment",
+			name:         "invalid credentials points to Certificate authorities",
 			err:          NewNDESInvalidError("invalid admin URL or credentials"),
-			wantContains: []string{"Invalid NDES admin credentials", varName, "Settings > Integrations > Certificate enrollment."},
-			// Regression guard: must not point to the renamed/removed UI location (#46380).
-			wantNotContains: []string{"Mobile Device Management", "Simple Certificate Enrollment Protocol", "Certificate authorities"},
+			wantContains: []string{"Invalid NDES admin credentials", varName, "Settings > Integrations > Certificate authorities."},
+			// Regression guard: must not point to the renamed/removed UI location.
+			wantNotContains: []string{"Mobile Device Management", "Simple Certificate Enrollment Protocol", "Certificate enrollment"},
 		},
 		{
 			name:         "password cache full",

--- a/frontend/components/CommandPalette/groups/settings.ts
+++ b/frontend/components/CommandPalette/groups/settings.ts
@@ -166,7 +166,7 @@ const buildSettingsItems = (ctx: ICommandPaletteContext): ICommandItem[] => {
           ? [
               {
                 id: "settings-int-certificate-authorities",
-                label: "Certificate enrollment",
+                label: "Certificate authorities",
                 path: paths.ADMIN_INTEGRATIONS_CERTIFICATE_AUTHORITIES,
                 keywords: [
                   "scep",

--- a/frontend/pages/admin/IntegrationsPage/IntegrationNavItems.tsx
+++ b/frontend/pages/admin/IntegrationsPage/IntegrationNavItems.tsx
@@ -57,7 +57,7 @@ const getIntegrationSettingsNavItems = (): ISideNavItem<any>[] => {
       Card: IdentityProviders,
     },
     {
-      title: "Certificate enrollment",
+      title: "Certificate authorities",
       urlSection: "certificate-authorities",
       path: PATHS.ADMIN_INTEGRATIONS_CERTIFICATE_AUTHORITIES,
       Card: CertificateAuthorities,

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/CertificateAuthorities.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/CertificateAuthorities.tsx
@@ -155,7 +155,7 @@ const CertificateAuthorities = () => {
   };
 
   return (
-    <SettingsSection title="Certificate enrollment">
+    <SettingsSection title="Certificate authorities">
       {renderContent()}
       {showAddCertAuthorityModal && certAuthorities && (
         <AddCertAuthorityModal


### PR DESCRIPTION
Not sure when this got changed but we want "Certificate authorities"

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated integration navigation, settings, command palette, and error guidance labels from “Certificate enrollment” to “Certificate authorities.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
