### PR TITLE
Rest api docs update

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -13705,7 +13705,8 @@ Returns information about the specified Fleet-maintained app.
     "url": "https://downloads.1password.com/mac/1Password-8.10.50-aarch64.zip",
     "install_script": "#!/bin/sh\ninstaller -pkg \"$INSTALLER_PATH\" -target /",
     "uninstall_script": "#!/bin/sh\npkg_ids=$PACKAGE_ID\nfor pkg_id in '${pkg_ids[@]}'...",
-    "software_title_id": 3
+    "software_title_id": 3,
+    "automatic_install_query": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.1password.1password';",
     "categories": ["Productivity"]
   }
 }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #49420

Adds documentation for the new automatic_install_query that the `GET /api/v1/fleet/software/fleet_maintained_apps/1` endpoint requires for the feature. https://github.com/fleetdm/fleet/pull/50437#discussion_r3707992649

`software_title.packages[].patch_policy.continuous_automations_enabled` was also added. I left it out of this PR because nothing documents the `patch_policy` object currently, it is null in all examples.