### PR TITLE
Backfill historical load test metrics (4.63–4.85) from the results spreadsheet

### DIFF
--- a/tools/loadtest/metrics/README.md
+++ b/tools/loadtest/metrics/README.md
@@ -69,6 +69,7 @@ Historical runs live under `runs/`, grouped by what the load test exercised:
 | **Baseline** — per-release branch load test | `runs/baseline/`  | `<version>loadtest`            | `486loadtest` |
 | **Migration** — n-1 → n schema migration    | `runs/migration/` | `<n-1>to<n>mig`                | `485to486mig` |
 | **MDM** — platform-specific MDM load test   | `runs/mdm/`       | `<version><platform>` / `<platform>-release` | `483applemdm`, `486-windows` |
+| **Historical** — backfilled from the manual results spreadsheet (4.63–4.85) | `runs/historical/` | as recorded in the sheet | `4630loadtestbl` — see [runs/historical/README.md](runs/historical/README.md) |
 
 The category subfolder is purely for human organization; the scripts don't depend on it.
 Keeping workspace names to these conventions is what makes `--filter` a reliable category

--- a/tools/loadtest/metrics/runs/historical/4460loadtesto2/4460loadtesto2-2025-04-04-1h.json
+++ b/tools/loadtest/metrics/runs/historical/4460loadtesto2/4460loadtesto2-2025-04-04-1h.json
@@ -1,0 +1,99 @@
+{
+  "metadata": {
+    "workspace": "4460loadtesto2",
+    "collected_at": "2025-04-04T00:00:00Z",
+    "interval": "1h",
+    "release": "4.66.0",
+    "category": "baseline",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 16
+  },
+  "fleet_server": {
+    "cpu_utilization": null,
+    "memory_utilization": null,
+    "task_counts": {
+      "runningCount": 30
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 45.0
+    },
+    "memory_utilization": {
+      "Average": 7.5
+    },
+    "task_counts": {
+      "runningCount": 200
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 15.0
+    },
+    "write_iops": {
+      "Average": 2700.0
+    },
+    "deadlocks": null
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 2.5,
+      "maximum": 3.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 45.0
+      },
+      "read_iops": {
+        "Average": 1.0
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 3.5,
+        "maximum": 4.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": null,
+      "memory_utilization": null
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": null
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Release/baseline",
+    "one_click": null,
+    "notes": "This was the second 4.66.0 loadtest env spun up to confirm o\u2026",
+    "raw": {
+      "full_day": "yes",
+      "fleet_containers": "30",
+      "loadtest_containers": "200",
+      "writer_top_sql": "INSERT INTO `host_seen_ti\u2026",
+      "writer_cpu": "~15%",
+      "writer_sessions": "2-3",
+      "writer_iops": "~2,700",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "~45% average",
+      "reader_sessions": "3-4",
+      "reader_iops": "~1",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "45%",
+      "osquery_mem": "7.50%",
+      "deadlocks": "~0-3, peak at 20"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/4630loadtestbl/4630loadtestbl-2025-02-12-1h.json
+++ b/tools/loadtest/metrics/runs/historical/4630loadtestbl/4630loadtestbl-2025-02-12-1h.json
@@ -1,0 +1,117 @@
+{
+  "metadata": {
+    "workspace": "4630loadtestbl",
+    "collected_at": "2025-02-12T00:00:00Z",
+    "interval": "1h",
+    "release": "4.63.0",
+    "category": "baseline",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 6
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 75.0
+    },
+    "memory_utilization": {
+      "Average": 5.0
+    },
+    "task_counts": {
+      "runningCount": 30
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 50.0
+    },
+    "memory_utilization": {
+      "Average": 6.0
+    },
+    "task_counts": {
+      "runningCount": 200
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 23.0,
+      "Maximum": 27.0
+    },
+    "write_iops": {
+      "Average": 2635.0
+    },
+    "deadlocks": null
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 9.0,
+      "maximum": 17.0
+    },
+    "iops_utilization": {
+      "utilization_pct": 13.0
+    }
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 61.5,
+        "Maximum": 73.0
+      },
+      "read_iops": {
+        "Average": 3.0
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 5.0,
+        "maximum": 14.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 1.75,
+        "Maximum": 2.0
+      },
+      "memory_utilization": {
+        "Average": 0.46,
+        "Maximum": 0.5
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": null
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Release/baseline",
+    "one_click": null,
+    "notes": "100K hosts, no mdm",
+    "raw": {
+      "full_day": "yes",
+      "fleet_containers": "30",
+      "loadtest_containers": "200",
+      "fleet_cpu": "~75%",
+      "fleet_mem": "~5%",
+      "errors": "host reported software with empty name, <tok>, ingesting que\u2026",
+      "writer_top_sql": "INSERT INTO `host_seen_ti\u2026",
+      "writer_cpu": "19-27%",
+      "writer_sessions": "5-17 avg ~9",
+      "writer_iops": "2635 (~13%)",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "50-73%, peak was 73%",
+      "reader_sessions": "2-14 avg ~5",
+      "reader_iops": "3",
+      "redis_cpu": "1.5-2%",
+      "redis_mem": "0.42-0.5%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "50%",
+      "osquery_mem": "6%"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/4640loadtest-gabe/4640loadtest-gabe-2025-02-11-1h.json
+++ b/tools/loadtest/metrics/runs/historical/4640loadtest-gabe/4640loadtest-gabe-2025-02-11-1h.json
@@ -1,0 +1,105 @@
+{
+  "metadata": {
+    "workspace": "4640loadtest-gabe",
+    "collected_at": "2025-02-11T00:00:00Z",
+    "interval": "1h",
+    "release": "4.64.0",
+    "category": "baseline",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 7
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 60.0
+    },
+    "memory_utilization": {
+      "Average": 30.0
+    },
+    "task_counts": {
+      "runningCount": null
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 55.0
+    },
+    "memory_utilization": {
+      "Average": 30.0
+    },
+    "task_counts": {
+      "runningCount": null
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 10.0
+    },
+    "write_iops": {
+      "Average": 1300.0
+    },
+    "deadlocks": null
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 4.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 20.0,
+        "Maximum": 37.0
+      },
+      "read_iops": {
+        "Average": 25.0
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 13.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 3.0
+      },
+      "memory_utilization": {
+        "Average": 0.25
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": null
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Ticket #25875",
+    "one_click": null,
+    "notes": "20K hosts w/ mdm enabled",
+    "raw": {
+      "fleet_cpu": "~60%",
+      "fleet_mem": "~30%",
+      "api_latency": "<url>",
+      "writer_cpu": "~10%",
+      "writer_sessions": "avg ~4",
+      "writer_iops": "1.3K",
+      "reader_cpu": "~37% was peak, avg was ~20%",
+      "reader_sessions": "avg ~13",
+      "reader_iops": "25",
+      "redis_cpu": "~3%",
+      "redis_mem": "0.25%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "55%",
+      "osquery_mem": "30%"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/4640loadtestbl/4640loadtestbl-2025-02-17-1h.json
+++ b/tools/loadtest/metrics/runs/historical/4640loadtestbl/4640loadtestbl-2025-02-17-1h.json
@@ -1,0 +1,118 @@
+{
+  "metadata": {
+    "workspace": "4640loadtestbl",
+    "collected_at": "2025-02-17T00:00:00Z",
+    "interval": "1h",
+    "release": "4.64.0",
+    "category": "baseline",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 8
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 75.0
+    },
+    "memory_utilization": {
+      "Average": 3.0
+    },
+    "task_counts": {
+      "runningCount": 30
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 45.0
+    },
+    "memory_utilization": {
+      "Average": 6.0
+    },
+    "task_counts": {
+      "runningCount": 200
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 16.5,
+      "Maximum": 20.0
+    },
+    "write_iops": {
+      "Average": 2787.0
+    },
+    "deadlocks": null
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 6.0,
+      "maximum": 8.0
+    },
+    "iops_utilization": {
+      "utilization_pct": 14.0
+    }
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 51.5,
+        "Maximum": 58.0
+      },
+      "read_iops": {
+        "Average": 2.0
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 7.0,
+        "maximum": 14.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 1.75,
+        "Maximum": 2.0
+      },
+      "memory_utilization": {
+        "Average": 0.26,
+        "Maximum": 0.27
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": null
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Release/baseline",
+    "one_click": null,
+    "notes": "100K hosts, no mdm",
+    "raw": {
+      "full_day": "yes",
+      "fleet_containers": "30",
+      "loadtest_containers": "200",
+      "fleet_cpu": "~75%",
+      "fleet_mem": "~3%",
+      "errors": "Using filter in \"Load test key metrics and checks\" there are\u2026",
+      "writer_top_sql": "INSERT INTO `host_seen_ti\u2026",
+      "writer_cpu": "13-20%",
+      "writer_sessions": "4-8 avg ~6",
+      "writer_iops": "2787 (~14%)",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "45-58%",
+      "reader_sessions": "4-14 avg ~7",
+      "reader_iops": "2",
+      "redis_cpu": "1.5-2%",
+      "redis_mem": "0.25-0.27%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "45%",
+      "osquery_mem": "6%",
+      "deadlocks": "Between 0 and 8.4 per minute"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/4640loadtesto/4640loadtesto-2025-02-18-1h.json
+++ b/tools/loadtest/metrics/runs/historical/4640loadtesto/4640loadtesto-2025-02-18-1h.json
@@ -1,0 +1,115 @@
+{
+  "metadata": {
+    "workspace": "4640loadtesto",
+    "collected_at": "2025-02-18T00:00:00Z",
+    "interval": "1h",
+    "release": "4.64.0",
+    "category": "baseline",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 9
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 75.0
+    },
+    "memory_utilization": {
+      "Average": 3.0
+    },
+    "task_counts": {
+      "runningCount": 20
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 46.0
+    },
+    "memory_utilization": {
+      "Average": 17.5
+    },
+    "task_counts": {
+      "runningCount": 120
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 21.5
+    },
+    "write_iops": {
+      "Average": 2380.0
+    },
+    "deadlocks": null
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 6.0,
+      "maximum": 9.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 32.0,
+        "Maximum": 56.0
+      },
+      "read_iops": {
+        "Average": 0.33
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 6.0,
+        "maximum": 13.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 1.9,
+        "Maximum": 2.3
+      },
+      "memory_utilization": {
+        "Average": 0.23,
+        "Maximum": 0.25
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": 0
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Ticket #25160 #25235",
+    "one_click": null,
+    "notes": "60K hosts with mdm",
+    "raw": {
+      "full_day": "no",
+      "fleet_containers": "20",
+      "loadtest_containers": "120",
+      "fleet_cpu": "~75%",
+      "fleet_mem": "~3%",
+      "errors": "No new errors",
+      "writer_top_sql": "COMMIT",
+      "writer_cpu": "~21.5%",
+      "writer_sessions": "3-9 avg ~6",
+      "writer_iops": "2380",
+      "reader_top_sql": "INSERT INTO `host_seen_ti\u2026",
+      "reader_cpu": "~32%, peak at 56%",
+      "reader_sessions": "2-13 avg ~6",
+      "reader_iops": "0.33",
+      "redis_cpu": "1.5-2.3%",
+      "redis_mem": "0.2-0.25%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "46%",
+      "osquery_mem": "17.50%",
+      "deadlocks": "Between 0 and 4 per minute"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/4640ltvulnbl/4640ltvulnbl-2025-02-21-1h.json
+++ b/tools/loadtest/metrics/runs/historical/4640ltvulnbl/4640ltvulnbl-2025-02-21-1h.json
@@ -1,0 +1,118 @@
+{
+  "metadata": {
+    "workspace": "4640ltvulnbl",
+    "collected_at": "2025-02-21T00:00:00Z",
+    "interval": "1h",
+    "release": "4.64.0",
+    "category": "baseline",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 10
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 72.0
+    },
+    "memory_utilization": {
+      "Average": 3.0
+    },
+    "task_counts": {
+      "runningCount": 30
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 46.0
+    },
+    "memory_utilization": {
+      "Average": 7.0
+    },
+    "task_counts": {
+      "runningCount": 200
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 18.5,
+      "Maximum": 25.0
+    },
+    "write_iops": {
+      "Average": 3311.0
+    },
+    "deadlocks": null
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 8.0,
+      "maximum": 14.0
+    },
+    "iops_utilization": {
+      "utilization_pct": 16.0
+    }
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 44.0,
+        "Maximum": 74.0
+      },
+      "read_iops": {
+        "Average": 0.17
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 6.0,
+        "maximum": 12.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 1.93,
+        "Maximum": 2.45
+      },
+      "memory_utilization": {
+        "Average": 0.26,
+        "Maximum": 0.27
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": 0
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "New baseline after adding additional vuln titles t\u2026",
+    "one_click": null,
+    "notes": "100k hosts, no mdm, increased vuln software",
+    "raw": {
+      "full_day": "no",
+      "fleet_containers": "30",
+      "loadtest_containers": "200",
+      "fleet_cpu": "~72%",
+      "fleet_mem": "~3%",
+      "errors": "No new errors",
+      "writer_top_sql": "INSERT INTO `host_seen_ti\u2026",
+      "writer_cpu": "12-25%",
+      "writer_sessions": "4-14 avg ~8",
+      "writer_iops": "3311 (~16%)",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "74% at peak, avg ~44%",
+      "reader_sessions": "1-12 avg ~6",
+      "reader_iops": "0.175",
+      "redis_cpu": "1.4-2.45%",
+      "redis_mem": "0.25-0.27%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "46%",
+      "osquery_mem": "7%",
+      "deadlocks": "Between 0 and 8 per min with a peak at 60"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/4650loadtestj1/4650loadtestj1-2025-02-27-1h.json
+++ b/tools/loadtest/metrics/runs/historical/4650loadtestj1/4650loadtestj1-2025-02-27-1h.json
@@ -1,0 +1,75 @@
+{
+  "metadata": {
+    "workspace": "4650loadtestj1",
+    "collected_at": "2025-02-27T00:00:00Z",
+    "interval": "1h",
+    "release": "4.65.0",
+    "category": "baseline",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 11
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 75.0
+    },
+    "memory_utilization": {
+      "Average": 3.0
+    },
+    "task_counts": {
+      "runningCount": 30
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": null,
+    "memory_utilization": null,
+    "task_counts": {
+      "runningCount": 200
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": null,
+    "write_iops": null,
+    "deadlocks": null
+  },
+  "rds_writer_extended": {
+    "threads_running": null,
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": null,
+      "read_iops": null
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": null
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": null,
+      "memory_utilization": null
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": null
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Ticket #26178",
+    "one_click": null,
+    "notes": null,
+    "raw": {
+      "fleet_containers": "30",
+      "loadtest_containers": "200",
+      "fleet_cpu": "~75%",
+      "fleet_mem": "~3%",
+      "errors": "Error from #26675"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/4650lt0311/4650lt0311-2025-03-12-1h.json
+++ b/tools/loadtest/metrics/runs/historical/4650lt0311/4650lt0311-2025-03-12-1h.json
@@ -1,0 +1,116 @@
+{
+  "metadata": {
+    "workspace": "4650lt0311",
+    "collected_at": "2025-03-12T00:00:00Z",
+    "interval": "1h",
+    "release": "4.65.0",
+    "category": "baseline",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 13
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 73.0
+    },
+    "memory_utilization": {
+      "Average": 3.0
+    },
+    "task_counts": {
+      "runningCount": 30
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 47.0
+    },
+    "memory_utilization": {
+      "Average": 7.0
+    },
+    "task_counts": {
+      "runningCount": 200
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 50.0
+    },
+    "write_iops": {
+      "Average": 2630.0
+    },
+    "deadlocks": null
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 8.0,
+      "maximum": 17.0
+    },
+    "iops_utilization": {
+      "utilization_pct": 13.15
+    }
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 10.0,
+        "Maximum": 16.0
+      },
+      "read_iops": {
+        "Maximum": 1.37
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 3.0,
+        "maximum": 5.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 1.85,
+        "Maximum": 2.2
+      },
+      "memory_utilization": {
+        "Average": 0.26
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": null
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Release/baseline",
+    "one_click": null,
+    "notes": "100K hosts, no mdm",
+    "raw": {
+      "full_day": "yes",
+      "fleet_containers": "30",
+      "loadtest_containers": "200",
+      "fleet_cpu": "~73%",
+      "fleet_mem": "~3%",
+      "errors": "Error from #27041",
+      "writer_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "writer_cpu": "50%",
+      "writer_sessions": "2-17 avg ~8",
+      "writer_iops": "2630 (~13.15%)",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "16% at peak, avg ~10%",
+      "reader_sessions": "1-5 avg ~3",
+      "reader_iops": "max 1.37",
+      "redis_cpu": "1.5-2.2%",
+      "redis_mem": "0.26%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "47%",
+      "osquery_mem": "7%",
+      "deadlocks": "between 0 and 6 per min, max 16"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/4650wincptest/4650wincptest-2025-03-10-1h.json
+++ b/tools/loadtest/metrics/runs/historical/4650wincptest/4650wincptest-2025-03-10-1h.json
@@ -1,0 +1,116 @@
+{
+  "metadata": {
+    "workspace": "4650wincptest",
+    "collected_at": "2025-03-10T00:00:00Z",
+    "interval": "1h",
+    "release": "4.65.0",
+    "category": "mdm",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 12
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 31.0
+    },
+    "memory_utilization": {
+      "Average": 2.0
+    },
+    "task_counts": {
+      "runningCount": 30
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 60.0
+    },
+    "memory_utilization": {
+      "Average": 45.0
+    },
+    "task_counts": {
+      "runningCount": 40
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 2.5
+    },
+    "write_iops": {
+      "Average": 1740.0
+    },
+    "deadlocks": null
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 4.0,
+      "maximum": 9.0
+    },
+    "iops_utilization": {
+      "utilization_pct": 8.7
+    }
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 25.0
+      },
+      "read_iops": {
+        "Average": 2.0,
+        "Maximum": 5.4
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 5.0,
+        "maximum": 9.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 2.38,
+        "Maximum": 3.15
+      },
+      "memory_utilization": {
+        "Average": 0.26
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": 0
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Ticket #26918",
+    "one_click": null,
+    "notes": "20k hosts, all Windows with MDM",
+    "raw": {
+      "full_day": "no",
+      "fleet_containers": "30",
+      "loadtest_containers": "40",
+      "fleet_cpu": "~31%",
+      "fleet_mem": "~2%",
+      "errors": "No new errors",
+      "writer_top_sql": "UPDATE `software` `s` JOI\u2026",
+      "writer_cpu": "~2.5%",
+      "writer_sessions": "2-9 avg ~4",
+      "writer_iops": "1740 (~8.7%)",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "25.00%",
+      "reader_sessions": "2-9 avg ~5",
+      "reader_iops": "max 5.4 otherwise about 2",
+      "redis_cpu": "1.6-3.15%",
+      "redis_mem": "0.26%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "60%",
+      "osquery_mem": "45%",
+      "deadlocks": "Between 0 and 1 per min"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/4660loadtesto/4660loadtesto-2025-04-02-1h.json
+++ b/tools/loadtest/metrics/runs/historical/4660loadtesto/4660loadtesto-2025-04-02-1h.json
@@ -1,0 +1,95 @@
+{
+  "metadata": {
+    "workspace": "4660loadtesto",
+    "collected_at": "2025-04-02T00:00:00Z",
+    "interval": "1h",
+    "release": "4.66.0",
+    "category": "baseline",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 15
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 100.0
+    },
+    "memory_utilization": null,
+    "task_counts": {
+      "runningCount": 30
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": null,
+    "memory_utilization": null,
+    "task_counts": {
+      "runningCount": 200
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 16.0
+    },
+    "write_iops": {
+      "Average": 1000.0
+    },
+    "deadlocks": null
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 400.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 30.0,
+        "Maximum": 40.0
+      },
+      "read_iops": {
+        "Average": 4.0
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "maximum": 136.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": null,
+      "memory_utilization": null
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": null
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Release/baseline",
+    "one_click": null,
+    "notes": "Fleet containers were constantly crashing. Investigation of \u2026",
+    "raw": {
+      "fleet_containers": "30",
+      "loadtest_containers": "200",
+      "fleet_cpu": "~100% (on one server)",
+      "fleet_mem": "Did not record",
+      "errors": "Large DB Write actions, ~100x what we would expect",
+      "writer_top_sql": "UPDATE `software` `s` JOI\u2026",
+      "writer_cpu": "~16%",
+      "writer_sessions": "avg ~400",
+      "writer_iops": "~1000",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "~30%, peak at 40%",
+      "reader_sessions": "Peak 136",
+      "reader_iops": "~4",
+      "osquery_uptime": "100%"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/4670loadtestj/4670loadtestj-2025-04-24-1h.json
+++ b/tools/loadtest/metrics/runs/historical/4670loadtestj/4670loadtestj-2025-04-24-1h.json
@@ -1,0 +1,116 @@
+{
+  "metadata": {
+    "workspace": "4670loadtestj",
+    "collected_at": "2025-04-24T00:00:00Z",
+    "interval": "1h",
+    "release": "4.67.0",
+    "category": "baseline",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 17
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 73.0
+    },
+    "memory_utilization": {
+      "Average": 4.0
+    },
+    "task_counts": {
+      "runningCount": 30
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 45.0
+    },
+    "memory_utilization": {
+      "Average": 8.35
+    },
+    "task_counts": {
+      "runningCount": 200
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 19.0,
+      "Maximum": 25.0
+    },
+    "write_iops": {
+      "Average": 2700.0
+    },
+    "deadlocks": null
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 12.0,
+      "maximum": 19.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 43.5,
+        "Maximum": 52.0
+      },
+      "read_iops": {
+        "Average": 2.0,
+        "Maximum": 3.4
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 8.0,
+        "maximum": 14.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 2.2,
+        "Maximum": 3.0
+      },
+      "memory_utilization": {
+        "Average": 0.26
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": 0
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Release/baseline",
+    "one_click": null,
+    "notes": "Was run prior to the ListHostSoftware refactor being reverte\u2026",
+    "raw": {
+      "full_day": "yes",
+      "fleet_containers": "30",
+      "loadtest_containers": "200",
+      "fleet_cpu": "~73%",
+      "fleet_mem": "~4%",
+      "errors": "No new errors",
+      "writer_top_sql": "INSERT INTO `host_seen_ti\u2026",
+      "writer_cpu": "13-25%",
+      "writer_sessions": "5-19",
+      "writer_iops": "~2,700",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "35-52%",
+      "reader_sessions": "2-14",
+      "reader_iops": "max 3.4 otherwise about 2",
+      "redis_cpu": "1.4-3%",
+      "redis_mem": "0.26",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "45%",
+      "osquery_mem": "8.35%",
+      "deadlocks": "~0-5, peak at 23"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/4673to468mig/4673to468mig-2025-05-21-1h.json
+++ b/tools/loadtest/metrics/runs/historical/4673to468mig/4673to468mig-2025-05-21-1h.json
@@ -1,0 +1,114 @@
+{
+  "metadata": {
+    "workspace": "4673to468mig",
+    "collected_at": "2025-05-21T00:00:00Z",
+    "interval": "1h",
+    "release": "4.68.0",
+    "category": "migration",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 19
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 72.0
+    },
+    "memory_utilization": {
+      "Average": 5.5
+    },
+    "task_counts": {
+      "runningCount": 30
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 46.0
+    },
+    "memory_utilization": {
+      "Average": 9.3
+    },
+    "task_counts": {
+      "runningCount": 200
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 20.0
+    },
+    "write_iops": {
+      "Average": 2700.0
+    },
+    "deadlocks": null
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 9.0,
+      "maximum": 18.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 50.0
+      },
+      "read_iops": {
+        "Average": 1.0,
+        "Maximum": 3.6
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 5.0,
+        "maximum": 11.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 1.9,
+        "Maximum": 2.29
+      },
+      "memory_utilization": {
+        "Average": 0.28
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": 0
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Migration Test",
+    "one_click": null,
+    "notes": "No abnormal spikes in performance after upgrade",
+    "raw": {
+      "full_day": "no",
+      "fleet_containers": "30",
+      "loadtest_containers": "200",
+      "fleet_cpu": "~72%",
+      "fleet_mem": "~5.5%",
+      "errors": "No new errors",
+      "writer_top_sql": "INSERT INTO `host_seen_ti\u2026",
+      "writer_cpu": "~20%",
+      "writer_sessions": "4-18 avg 9",
+      "writer_iops": "~2,700",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "~50%",
+      "reader_sessions": "1-11 avg ~5",
+      "reader_iops": "max 3.6 otherwise about 1",
+      "redis_cpu": "1.5-2.29%",
+      "redis_mem": "0.28%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "46%",
+      "osquery_mem": "9.30%",
+      "deadlocks": "~0-5 peak at 23"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/4680loadtest02/4680loadtest02-2025-05-21-1h.json
+++ b/tools/loadtest/metrics/runs/historical/4680loadtest02/4680loadtest02-2025-05-21-1h.json
@@ -1,0 +1,114 @@
+{
+  "metadata": {
+    "workspace": "4680loadtest02",
+    "collected_at": "2025-05-21T00:00:00Z",
+    "interval": "1h",
+    "release": "4.68.0",
+    "category": "baseline",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 20
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 73.0
+    },
+    "memory_utilization": {
+      "Average": 4.0
+    },
+    "task_counts": {
+      "runningCount": 30
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 46.0
+    },
+    "memory_utilization": {
+      "Average": 8.05
+    },
+    "task_counts": {
+      "runningCount": 200
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 20.0
+    },
+    "write_iops": {
+      "Average": 2700.0
+    },
+    "deadlocks": null
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 7.0,
+      "maximum": 10.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 48.0
+      },
+      "read_iops": {
+        "Average": 1.0,
+        "Maximum": 1.55
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 9.0,
+        "maximum": 14.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 1.98,
+        "Maximum": 2.57
+      },
+      "memory_utilization": {
+        "Average": 0.25
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": 0
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Release/baseline",
+    "one_click": null,
+    "notes": "100K hosts, no mdm",
+    "raw": {
+      "full_day": "yes",
+      "fleet_containers": "30",
+      "loadtest_containers": "200",
+      "fleet_cpu": "~73%",
+      "fleet_mem": "~4%",
+      "errors": "No new errors",
+      "writer_top_sql": "INSERT INTO `host_seen_ti\u2026",
+      "writer_cpu": "~20%",
+      "writer_sessions": "3-10 avg 7",
+      "writer_iops": "~2,700",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "~48%",
+      "reader_sessions": "1-14 avg ~9",
+      "reader_iops": "max 1.55 otherwise <1",
+      "redis_cpu": "1.4-2.57%",
+      "redis_mem": "0.25%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "46%",
+      "osquery_mem": "8.05%",
+      "deadlocks": "~0-3 peak at 20"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/468to469mig/468to469mig-2025-06-12-1h.json
+++ b/tools/loadtest/metrics/runs/historical/468to469mig/468to469mig-2025-06-12-1h.json
@@ -1,0 +1,114 @@
+{
+  "metadata": {
+    "workspace": "468to469mig",
+    "collected_at": "2025-06-12T00:00:00Z",
+    "interval": "1h",
+    "release": "4.69.0",
+    "category": "migration",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 23
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 72.0
+    },
+    "memory_utilization": {
+      "Average": 9.0
+    },
+    "task_counts": {
+      "runningCount": 30
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 46.0
+    },
+    "memory_utilization": {
+      "Average": 9.19
+    },
+    "task_counts": {
+      "runningCount": 200
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 17.0
+    },
+    "write_iops": {
+      "Average": 2500.0
+    },
+    "deadlocks": null
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 7.0,
+      "maximum": 12.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 50.0
+      },
+      "read_iops": {
+        "Average": 1.0,
+        "Maximum": 3.3
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 8.0,
+        "maximum": 14.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 1.9,
+        "Maximum": 2.4
+      },
+      "memory_utilization": {
+        "Average": 0.26
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": 0
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Migration Test (SEE \"Additional metrics or notes\" \u2026",
+    "one_click": null,
+    "notes": "#29958 CPU issue , all metrics are after the fix was applied",
+    "raw": {
+      "full_day": "yes",
+      "fleet_containers": "30",
+      "loadtest_containers": "200",
+      "fleet_cpu": "~72%",
+      "fleet_mem": "~9%",
+      "errors": "No new errors",
+      "writer_top_sql": "INSERT INTO `host_seen_ti\u2026",
+      "writer_cpu": "~17%",
+      "writer_sessions": "3-12 avg 7",
+      "writer_iops": "~2500",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "~50%",
+      "reader_sessions": "2-14 avg ~8",
+      "reader_iops": "max 3.3 otherwise about 1",
+      "redis_cpu": "1.4-2.4%",
+      "redis_mem": "0.26%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "46%",
+      "osquery_mem": "9.19%",
+      "deadlocks": "~0-4 peak at 54"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/4690loadtesto/4690loadtesto-2025-06-12-1h.json
+++ b/tools/loadtest/metrics/runs/historical/4690loadtesto/4690loadtesto-2025-06-12-1h.json
@@ -1,0 +1,114 @@
+{
+  "metadata": {
+    "workspace": "4690loadtesto",
+    "collected_at": "2025-06-12T00:00:00Z",
+    "interval": "1h",
+    "release": "4.69.0",
+    "category": "baseline",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 24
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 73.0
+    },
+    "memory_utilization": {
+      "Average": 9.0
+    },
+    "task_counts": {
+      "runningCount": 30
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 47.0
+    },
+    "memory_utilization": {
+      "Average": 8.59
+    },
+    "task_counts": {
+      "runningCount": 200
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 16.0
+    },
+    "write_iops": {
+      "Average": 2700.0
+    },
+    "deadlocks": null
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 7.0,
+      "maximum": 17.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 50.0
+      },
+      "read_iops": {
+        "Average": 1.0,
+        "Maximum": 6.5
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 6.0,
+        "maximum": 12.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 1.8,
+        "Maximum": 2.2
+      },
+      "memory_utilization": {
+        "Average": 0.26
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": 0
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Release/baseline (SEE \"Additional metrics or notes\u2026",
+    "one_click": null,
+    "notes": "#29958 CPU issue , all metrics are after the fix was applied",
+    "raw": {
+      "full_day": "yes",
+      "fleet_containers": "30",
+      "loadtest_containers": "200",
+      "fleet_cpu": "~73%",
+      "fleet_mem": "~9%",
+      "errors": "No new errors",
+      "writer_top_sql": "INSERT INTO `host_seen_ti\u2026",
+      "writer_cpu": "~16%",
+      "writer_sessions": "3-17 avg 7",
+      "writer_iops": "~2700",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "~50%",
+      "reader_sessions": "2-12 avg ~6",
+      "reader_iops": "max 6.5 otherwise about 1",
+      "redis_cpu": "1.4-2.2%",
+      "redis_mem": "0.26%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "47%",
+      "osquery_mem": "8.59%",
+      "deadlocks": "~0-3"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/469to470mig/469to470mig-2025-06-24-1h.json
+++ b/tools/loadtest/metrics/runs/historical/469to470mig/469to470mig-2025-06-24-1h.json
@@ -1,0 +1,114 @@
+{
+  "metadata": {
+    "workspace": "469to470mig",
+    "collected_at": "2025-06-24T00:00:00Z",
+    "interval": "1h",
+    "release": "4.70.0",
+    "category": "migration",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 25
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 73.0
+    },
+    "memory_utilization": {
+      "Average": 4.0
+    },
+    "task_counts": {
+      "runningCount": 30
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 46.42
+    },
+    "memory_utilization": {
+      "Average": 8.8
+    },
+    "task_counts": {
+      "runningCount": 200
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 19.0
+    },
+    "write_iops": {
+      "Average": 2700.0
+    },
+    "deadlocks": null
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 4.0,
+      "maximum": 7.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 50.0
+      },
+      "read_iops": {
+        "Average": 1.0,
+        "Maximum": 24.98
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 6.0,
+        "maximum": 12.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 1.83,
+        "Maximum": 2.29
+      },
+      "memory_utilization": {
+        "Average": 0.26
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": null
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Migration Test",
+    "one_click": null,
+    "notes": "Error message happens when adding osquery-perf hosts. There \u2026",
+    "raw": {
+      "full_day": "yes",
+      "fleet_containers": "30",
+      "loadtest_containers": "200",
+      "fleet_cpu": "~73%",
+      "fleet_mem": "~4%",
+      "errors": "{\"component\":\"service\",\"err\":\"invalid source \",\"level\":\"erro\u2026",
+      "writer_top_sql": "INSERT INTO `host_seen_ti\u2026",
+      "writer_cpu": "~19%",
+      "writer_sessions": "2-7 avg 4",
+      "writer_iops": "~2700",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "~50%",
+      "reader_sessions": "2-12 avg ~6",
+      "reader_iops": "max 24.98 otherwise about 1",
+      "redis_cpu": "1.37-2.29%",
+      "redis_mem": "0.26%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "46.42%",
+      "osquery_mem": "8.80%",
+      "deadlocks": "~0-1"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/470loadtest/470loadtest-2025-06-26-1h.json
+++ b/tools/loadtest/metrics/runs/historical/470loadtest/470loadtest-2025-06-26-1h.json
@@ -1,0 +1,114 @@
+{
+  "metadata": {
+    "workspace": "470loadtest",
+    "collected_at": "2025-06-26T00:00:00Z",
+    "interval": "1h",
+    "release": "4.70.0",
+    "category": "baseline",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 26
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 70.0
+    },
+    "memory_utilization": {
+      "Average": 4.0
+    },
+    "task_counts": {
+      "runningCount": 30
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 46.0
+    },
+    "memory_utilization": {
+      "Average": 8.0
+    },
+    "task_counts": {
+      "runningCount": 200
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 14.0
+    },
+    "write_iops": {
+      "Average": 2750.0
+    },
+    "deadlocks": null
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 4.5,
+      "maximum": 9.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 40.0
+      },
+      "read_iops": {
+        "Average": 1.0,
+        "Maximum": 5.2
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 6.0,
+        "maximum": 12.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 1.81,
+        "Maximum": 2.18
+      },
+      "memory_utilization": {
+        "Average": 0.26
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": null
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Release/baseline",
+    "one_click": null,
+    "notes": "Error message happens when adding osquery-perf hosts. There \u2026",
+    "raw": {
+      "full_day": "yes",
+      "fleet_containers": "30",
+      "loadtest_containers": "200",
+      "fleet_cpu": "~70%",
+      "fleet_mem": "~4%",
+      "errors": "{\"component\":\"service\",\"err\":\"invalid source \",\"level\":\"erro\u2026",
+      "writer_top_sql": "INSERT INTO `host_seen_ti\u2026",
+      "writer_cpu": "~14%",
+      "writer_sessions": "2-9 avg 4.5",
+      "writer_iops": "~2750",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "~40%",
+      "reader_sessions": "2-12 avg ~6",
+      "reader_iops": "max 5.2 otherwise about 1",
+      "redis_cpu": "1.45-2.18%",
+      "redis_mem": "0.26%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "46%",
+      "osquery_mem": "8%",
+      "deadlocks": "~0-3 peak at 14"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/470to471mig-w/470to471mig-w-2025-07-16-1h.json
+++ b/tools/loadtest/metrics/runs/historical/470to471mig-w/470to471mig-w-2025-07-16-1h.json
@@ -1,0 +1,114 @@
+{
+  "metadata": {
+    "workspace": "470to471mig-w",
+    "collected_at": "2025-07-16T00:00:00Z",
+    "interval": "1h",
+    "release": "4.71.0",
+    "category": "migration",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 27
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 72.0
+    },
+    "memory_utilization": {
+      "Average": 4.9
+    },
+    "task_counts": {
+      "runningCount": 30
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 45.0
+    },
+    "memory_utilization": {
+      "Average": 8.4
+    },
+    "task_counts": {
+      "runningCount": 200
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 14.0
+    },
+    "write_iops": {
+      "Average": 3000.0
+    },
+    "deadlocks": null
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 6.0,
+      "maximum": 14.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 40.0
+      },
+      "read_iops": {
+        "Average": 1.0,
+        "Maximum": 25.0
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 8.0,
+        "maximum": 15.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 1.8,
+        "Maximum": 2.2
+      },
+      "memory_utilization": {
+        "Average": 0.26
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": null
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Migration Test",
+    "one_click": null,
+    "notes": "Error message happens when adding osquery-perf hosts. There \u2026",
+    "raw": {
+      "full_day": "no",
+      "fleet_containers": "30",
+      "loadtest_containers": "200",
+      "fleet_cpu": "~72%",
+      "fleet_mem": "~4.9%",
+      "errors": "{\"component\":\"service\",\"err\":\"invalid source \",\"level\":\"erro\u2026",
+      "writer_top_sql": "INSERT INTO `host_seen_ti\u2026",
+      "writer_cpu": "~14%",
+      "writer_sessions": "2-14 avg 6",
+      "writer_iops": "~3000",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "~40%",
+      "reader_sessions": "3-15 avg ~8",
+      "reader_iops": "max 25 otherwise about 1",
+      "redis_cpu": "1.4-2.2%",
+      "redis_mem": "0.26%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "45%",
+      "osquery_mem": "8.40%",
+      "deadlocks": "~0-4 peak at 186"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/4711to472mig-w/4711to472mig-w-2025-08-08-1h.json
+++ b/tools/loadtest/metrics/runs/historical/4711to472mig-w/4711to472mig-w-2025-08-08-1h.json
@@ -1,0 +1,114 @@
+{
+  "metadata": {
+    "workspace": "4711to472mig-w",
+    "collected_at": "2025-08-08T00:00:00Z",
+    "interval": "1h",
+    "release": "4.72.0",
+    "category": "migration",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 32
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 74.0
+    },
+    "memory_utilization": {
+      "Average": 4.5
+    },
+    "task_counts": {
+      "runningCount": 20
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 63.0
+    },
+    "memory_utilization": {
+      "Average": 8.5
+    },
+    "task_counts": {
+      "runningCount": 200
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 12.5
+    },
+    "write_iops": {
+      "Average": 2650.0
+    },
+    "deadlocks": null
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 7.0,
+      "maximum": 19.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 42.0
+      },
+      "read_iops": {
+        "Average": 1.0,
+        "Maximum": 4.0
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 7.0,
+        "maximum": 14.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 2.05,
+        "Maximum": 2.4
+      },
+      "memory_utilization": {
+        "Average": 0.26
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": null
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Migration Test",
+    "one_click": null,
+    "notes": "Error message happens when adding osquery-perf hosts. There \u2026",
+    "raw": {
+      "full_day": "yes",
+      "fleet_containers": "20",
+      "loadtest_containers": "200",
+      "fleet_cpu": "~74%",
+      "fleet_mem": "~4.5%",
+      "errors": "{\"component\":\"service\",\"err\":\"invalid source \",\"level\":\"erro\u2026",
+      "writer_top_sql": "INSERT INTO `host_seen_ti\u2026",
+      "writer_cpu": "~12.5%",
+      "writer_sessions": "4-19 avg 7",
+      "writer_iops": "~2650",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "~42%",
+      "reader_sessions": "2-14 avg ~7",
+      "reader_iops": "max 4 otherwise about 1",
+      "redis_cpu": "1.7-2.4%",
+      "redis_mem": "0.26%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "63%",
+      "osquery_mem": "8.50%",
+      "deadlocks": "~0-2 peak at 40"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/471loadtest/471loadtest-2025-07-17-1h.json
+++ b/tools/loadtest/metrics/runs/historical/471loadtest/471loadtest-2025-07-17-1h.json
@@ -1,0 +1,114 @@
+{
+  "metadata": {
+    "workspace": "471loadtest",
+    "collected_at": "2025-07-17T00:00:00Z",
+    "interval": "1h",
+    "release": "4.71.0",
+    "category": "baseline",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 28
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 74.0
+    },
+    "memory_utilization": {
+      "Average": 3.6
+    },
+    "task_counts": {
+      "runningCount": 30
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 47.0
+    },
+    "memory_utilization": {
+      "Average": 7.4
+    },
+    "task_counts": {
+      "runningCount": 200
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 12.0
+    },
+    "write_iops": {
+      "Average": 2800.0
+    },
+    "deadlocks": null
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 6.0,
+      "maximum": 12.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 37.0
+      },
+      "read_iops": {
+        "Average": 1.0,
+        "Maximum": 12.0
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 7.0,
+        "maximum": 13.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 1.95,
+        "Maximum": 2.2
+      },
+      "memory_utilization": {
+        "Average": 0.26
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": null
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Release/baseline",
+    "one_click": null,
+    "notes": "Error message happens when adding osquery-perf hosts. There \u2026",
+    "raw": {
+      "full_day": "yes",
+      "fleet_containers": "30",
+      "loadtest_containers": "200",
+      "fleet_cpu": "~74%",
+      "fleet_mem": "~3.6%",
+      "errors": "{\"component\":\"service\",\"err\":\"invalid source \",\"level\":\"erro\u2026",
+      "writer_top_sql": "INSERT INTO `host_seen_ti\u2026",
+      "writer_cpu": "~12%",
+      "writer_sessions": "4-12 avg 6",
+      "writer_iops": "~2800",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "~37%",
+      "reader_sessions": "1-13 avg ~7",
+      "reader_iops": "max 12 otherwise about 1",
+      "redis_cpu": "1.7-2.2%",
+      "redis_mem": "0.26%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "47%",
+      "osquery_mem": "7.40%",
+      "deadlocks": "~0-4 peak at 42"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/4720mdm/4720mdm-2025-08-01-1h.json
+++ b/tools/loadtest/metrics/runs/historical/4720mdm/4720mdm-2025-08-01-1h.json
@@ -1,0 +1,114 @@
+{
+  "metadata": {
+    "workspace": "4720mdm",
+    "collected_at": "2025-08-01T00:00:00Z",
+    "interval": "1h",
+    "release": "4.72.0",
+    "category": "mdm",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 29
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 18.0
+    },
+    "memory_utilization": {
+      "Average": 25.0
+    },
+    "task_counts": {
+      "runningCount": 20
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 44.0
+    },
+    "memory_utilization": {
+      "Average": 22.0
+    },
+    "task_counts": {
+      "runningCount": 10
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 1.0
+    },
+    "write_iops": {
+      "Average": 300.0,
+      "Maximum": 400.0
+    },
+    "deadlocks": null
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 2.5,
+      "maximum": 3.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 1.0
+      },
+      "read_iops": {
+        "Average": 2.0
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 2.5,
+        "maximum": 4.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 1.95,
+        "Maximum": 2.2
+      },
+      "memory_utilization": {
+        "Average": 2.3
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": null
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Ticket #27390",
+    "one_click": null,
+    "notes": "Error message happens when adding osquery-perf hosts. There \u2026",
+    "raw": {
+      "full_day": "yes",
+      "fleet_containers": "20",
+      "loadtest_containers": "10",
+      "fleet_cpu": "~18%",
+      "fleet_mem": "~25%",
+      "errors": "{\"component\":\"service\",\"err\":\"invalid source \",\"level\":\"erro\u2026",
+      "writer_top_sql": "INSERT INTO `host_seen_ti\u2026",
+      "writer_cpu": "~1%",
+      "writer_sessions": "2-3",
+      "writer_iops": "200-400",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "~1%",
+      "reader_sessions": "1-4",
+      "reader_iops": "~2",
+      "redis_cpu": "1.7-2.2%",
+      "redis_mem": "2.30%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "44%",
+      "osquery_mem": "22%",
+      "deadlocks": ".04 - .08"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/472loadtest/472loadtest-2025-08-09-1h.json
+++ b/tools/loadtest/metrics/runs/historical/472loadtest/472loadtest-2025-08-09-1h.json
@@ -1,0 +1,115 @@
+{
+  "metadata": {
+    "workspace": "472loadtest",
+    "collected_at": "2025-08-09T00:00:00Z",
+    "interval": "1h",
+    "release": "4.72.0",
+    "category": "baseline",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 33
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 76.2,
+      "Maximum": 79.0
+    },
+    "memory_utilization": {
+      "Average": 7.8
+    },
+    "task_counts": {
+      "runningCount": 30
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 70.0
+    },
+    "memory_utilization": {
+      "Average": 8.3
+    },
+    "task_counts": {
+      "runningCount": 200
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 30.0
+    },
+    "write_iops": {
+      "Average": 2700.0
+    },
+    "deadlocks": null
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 8.0,
+      "maximum": 17.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 30.0
+      },
+      "read_iops": {
+        "Average": 1.0,
+        "Maximum": 11.0
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 6.0,
+        "maximum": 11.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 2.1,
+        "Maximum": 2.6
+      },
+      "memory_utilization": {
+        "Average": 0.29
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": null
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Release/baseline",
+    "one_click": null,
+    "notes": "Higher CPU usage on the server during the first 6 hours afte\u2026",
+    "raw": {
+      "full_day": "yes",
+      "fleet_containers": "30",
+      "loadtest_containers": "200",
+      "fleet_cpu": "~76.2% with a 78-79% first 6 hours",
+      "fleet_mem": "~7.8%",
+      "errors": "{\"component\":\"service\",\"err\":\"invalid source \",\"level\":\"erro\u2026",
+      "writer_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "writer_cpu": "~30%",
+      "writer_sessions": "3-17 avg 8",
+      "writer_iops": "~2700",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "~30%",
+      "reader_sessions": "2-11 avg ~6",
+      "reader_iops": "max 11 otherwise 1",
+      "redis_cpu": "1.6-2.6%",
+      "redis_mem": "0.29%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "70%",
+      "osquery_mem": "8.30%",
+      "deadlocks": "~1 peak at 30"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/4735orch3/4735orch3-2025-10-10-1h.json
+++ b/tools/loadtest/metrics/runs/historical/4735orch3/4735orch3-2025-10-10-1h.json
@@ -1,0 +1,114 @@
+{
+  "metadata": {
+    "workspace": "4735orch3",
+    "collected_at": "2025-10-10T00:00:00Z",
+    "interval": "1h",
+    "release": "4.73.5",
+    "category": "baseline",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 40
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 80.0,
+      "Maximum": 100.0
+    },
+    "memory_utilization": {
+      "Average": 10.0
+    },
+    "task_counts": {
+      "runningCount": 20
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 27.0
+    },
+    "memory_utilization": {
+      "Average": 4.0
+    },
+    "task_counts": {
+      "runningCount": 104
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 11.0
+    },
+    "write_iops": {
+      "Average": 2000.0
+    },
+    "deadlocks": null
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 103.5,
+      "maximum": 200.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 22.0
+      },
+      "read_iops": {
+        "Average": 32.0,
+        "Maximum": 64.0
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 7.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 2.0,
+        "Maximum": 2.5
+      },
+      "memory_utilization": {
+        "Average": 0.35
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": null
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Ticket #33668",
+    "one_click": null,
+    "notes": "Full update and context can be found here: <url>",
+    "raw": {
+      "full_day": "yes",
+      "fleet_containers": "20",
+      "loadtest_containers": "104",
+      "fleet_cpu": "~80% with occasional spikes to 100%",
+      "fleet_mem": "~10%",
+      "errors": "Various errors, mainly related to all the locks that happen \u2026",
+      "writer_top_sql": "INSERT IGNORE INTO `softw\u2026",
+      "writer_cpu": "~11%",
+      "writer_sessions": "7-200",
+      "writer_iops": "~2000",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "~22%",
+      "reader_sessions": "~7",
+      "reader_iops": "0-64",
+      "redis_cpu": "1.5- 2.5%",
+      "redis_mem": "0.35%",
+      "osquery_uptime": "N/A",
+      "osquery_cpu": "27%",
+      "osquery_mem": "4%",
+      "deadlocks": "~0-22"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/473loadtest-w3/473loadtest-w3-2025-09-04-1h.json
+++ b/tools/loadtest/metrics/runs/historical/473loadtest-w3/473loadtest-w3-2025-09-04-1h.json
@@ -1,0 +1,114 @@
+{
+  "metadata": {
+    "workspace": "473loadtest-w3",
+    "collected_at": "2025-09-04T00:00:00Z",
+    "interval": "1h",
+    "release": "4.73.0",
+    "category": "baseline",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 35
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 71.0
+    },
+    "memory_utilization": {
+      "Average": 3.6
+    },
+    "task_counts": {
+      "runningCount": 30
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 47.5
+    },
+    "memory_utilization": {
+      "Average": 7.6
+    },
+    "task_counts": {
+      "runningCount": 200
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 12.8
+    },
+    "write_iops": {
+      "Average": 2600.0
+    },
+    "deadlocks": null
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 4.0,
+      "maximum": 13.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 50.0
+      },
+      "read_iops": {
+        "Average": 1.0,
+        "Maximum": 4.0
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 7.0,
+        "maximum": 14.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 2.05,
+        "Maximum": 2.4
+      },
+      "memory_utilization": {
+        "Average": 0.27
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": 0
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Release/baseline",
+    "one_click": null,
+    "notes": null,
+    "raw": {
+      "full_day": "yes",
+      "fleet_containers": "30",
+      "loadtest_containers": "200",
+      "fleet_cpu": "~71%",
+      "fleet_mem": "~3.6%",
+      "errors": "No new errors",
+      "writer_top_sql": "INSERT INTO `host_seen_ti\u2026",
+      "writer_cpu": "~12.8%",
+      "writer_sessions": "2-13 avg 4",
+      "writer_iops": "~2600",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "~50%",
+      "reader_sessions": "3-14 avg 7",
+      "reader_iops": "max 4 otherwise about 1",
+      "redis_cpu": "1.7-2.4%",
+      "redis_mem": "0.27%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "47.50%",
+      "osquery_mem": "7.60%",
+      "deadlocks": "~2 peak at 25"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/473mdm/473mdm-2025-09-02-1h.json
+++ b/tools/loadtest/metrics/runs/historical/473mdm/473mdm-2025-09-02-1h.json
@@ -1,0 +1,114 @@
+{
+  "metadata": {
+    "workspace": "473mdm",
+    "collected_at": "2025-09-02T00:00:00Z",
+    "interval": "1h",
+    "release": "4.73.0",
+    "category": "mdm",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 34
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 14.0
+    },
+    "memory_utilization": {
+      "Average": 1.6
+    },
+    "task_counts": {
+      "runningCount": 20
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 60.0
+    },
+    "memory_utilization": {
+      "Average": 39.0
+    },
+    "task_counts": {
+      "runningCount": 10
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 1.0
+    },
+    "write_iops": {
+      "Average": 375.0,
+      "Maximum": 500.0
+    },
+    "deadlocks": null
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 2.0,
+      "maximum": 3.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 4.0
+      },
+      "read_iops": {
+        "Average": 2.0
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 3.0,
+        "maximum": 5.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 2.2,
+        "Maximum": 2.9
+      },
+      "memory_utilization": {
+        "Average": 0.23
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": 0
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Ticket #28133",
+    "one_click": null,
+    "notes": null,
+    "raw": {
+      "full_day": "no",
+      "fleet_containers": "20",
+      "loadtest_containers": "10",
+      "fleet_cpu": "~14%",
+      "fleet_mem": "~1.6%",
+      "errors": "No new errors",
+      "writer_top_sql": "COMMIT",
+      "writer_cpu": "~1%",
+      "writer_sessions": "2-3 avg 2",
+      "writer_iops": "250-500",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "~4%",
+      "reader_sessions": "2-5 avg ~3",
+      "reader_iops": "~2",
+      "redis_cpu": "1.5-2.9%",
+      "redis_mem": "0.23%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "60%",
+      "osquery_mem": "39%",
+      "deadlocks": "~1 peak at 1"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/473to474mig-w1/473to474mig-w1-2025-10-01-1h.json
+++ b/tools/loadtest/metrics/runs/historical/473to474mig-w1/473to474mig-w1-2025-10-01-1h.json
@@ -1,0 +1,113 @@
+{
+  "metadata": {
+    "workspace": "473to474mig-w1",
+    "collected_at": "2025-10-01T00:00:00Z",
+    "interval": "1h",
+    "release": "4.74.0",
+    "category": "migration",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 38
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 65.0
+    },
+    "memory_utilization": {
+      "Average": 10.0
+    },
+    "task_counts": {
+      "runningCount": 30
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 50.0
+    },
+    "memory_utilization": {
+      "Average": 9.5
+    },
+    "task_counts": {
+      "runningCount": 200
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 15.0
+    },
+    "write_iops": {
+      "Average": 2600.0
+    },
+    "deadlocks": null
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 4.0,
+      "maximum": 6.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 50.0
+      },
+      "read_iops": {
+        "Average": 2.5,
+        "Maximum": 4.4
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 14.0,
+        "maximum": 17.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 2.0,
+        "Maximum": 2.5
+      },
+      "memory_utilization": {
+        "Average": 0.4
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": null
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Migration Test",
+    "one_click": null,
+    "notes": "Ran into an issue where loadtest containers have restarted a\u2026",
+    "raw": {
+      "full_day": "yes",
+      "fleet_containers": "30",
+      "loadtest_containers": "200",
+      "fleet_cpu": "~65%",
+      "fleet_mem": "~10%",
+      "writer_top_sql": "INSERT INTO `host_seen_ti\u2026",
+      "writer_cpu": "~15%",
+      "writer_sessions": "2-6 avg 4",
+      "writer_iops": "~2600",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "~50%",
+      "reader_sessions": "11-17 avg 14",
+      "reader_iops": "1-4 max 4.4",
+      "redis_cpu": "1.5- 2.5%",
+      "redis_mem": "0.40%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "50%",
+      "osquery_mem": "9.50%",
+      "deadlocks": "~0 peak at 3500"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/4740mdm/4740mdm-2025-09-29-1h.json
+++ b/tools/loadtest/metrics/runs/historical/4740mdm/4740mdm-2025-09-29-1h.json
@@ -1,0 +1,113 @@
+{
+  "metadata": {
+    "workspace": "4740mdm",
+    "collected_at": "2025-09-29T00:00:00Z",
+    "interval": "1h",
+    "release": "4.74.0",
+    "category": "mdm",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 36
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 25.0
+    },
+    "memory_utilization": {
+      "Average": 1.74
+    },
+    "task_counts": {
+      "runningCount": 20
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 50.0
+    },
+    "memory_utilization": {
+      "Average": 30.0
+    },
+    "task_counts": {
+      "runningCount": 10
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 4.0
+    },
+    "write_iops": {
+      "Average": 400.0
+    },
+    "deadlocks": null
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 3.0,
+      "maximum": 4.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 1.0
+      },
+      "read_iops": {
+        "Average": 3.0,
+        "Maximum": 4.0
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 3.0,
+        "maximum": 4.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 2.1,
+        "Maximum": 2.7
+      },
+      "memory_utilization": {
+        "Average": 0.24
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": 0
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Ticket #28974",
+    "one_click": null,
+    "notes": "Baseline test after adding 4 Certificate Authorities. Before\u2026",
+    "raw": {
+      "fleet_containers": "20",
+      "loadtest_containers": "10",
+      "fleet_cpu": "~25%",
+      "fleet_mem": "~1.74%",
+      "errors": "No new errors. I did see this initially then it went away",
+      "writer_top_sql": "INSERT IGNORE INTO `softw\u2026",
+      "writer_cpu": "~4%",
+      "writer_sessions": "2-4 avg",
+      "writer_iops": "~400",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "~1%",
+      "reader_sessions": "2-4 avg",
+      "reader_iops": "2 -4",
+      "redis_cpu": "1.5 - 2.7%",
+      "redis_mem": "0.24%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "50%",
+      "osquery_mem": "30%",
+      "deadlocks": "~1-2"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/4740orch/4740orch-2025-10-02-1h.json
+++ b/tools/loadtest/metrics/runs/historical/4740orch/4740orch-2025-10-02-1h.json
@@ -1,0 +1,113 @@
+{
+  "metadata": {
+    "workspace": "4740orch",
+    "collected_at": "2025-10-02T00:00:00Z",
+    "interval": "1h",
+    "release": "4.74.0",
+    "category": "baseline",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 39
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 80.0
+    },
+    "memory_utilization": {
+      "Average": 3.9
+    },
+    "task_counts": {
+      "runningCount": 30
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 48.0
+    },
+    "memory_utilization": {
+      "Average": 8.0
+    },
+    "task_counts": {
+      "runningCount": 200
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 12.0
+    },
+    "write_iops": {
+      "Average": 2500.0
+    },
+    "deadlocks": null
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 3.0,
+      "maximum": 4.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 43.6
+      },
+      "read_iops": {
+        "Average": 1.0,
+        "Maximum": 2.0
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 7.0,
+        "maximum": 8.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 2.0,
+        "Maximum": 2.5
+      },
+      "memory_utilization": {
+        "Average": 0.38
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": null
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Baseline Test",
+    "one_click": null,
+    "notes": null,
+    "raw": {
+      "full_day": "yes",
+      "fleet_containers": "30",
+      "loadtest_containers": "200",
+      "fleet_cpu": "~80%",
+      "fleet_mem": "~3.9%",
+      "writer_top_sql": "INSERT INTO `host_seen_ti\u2026",
+      "writer_cpu": "~12%",
+      "writer_sessions": "2-4 avg",
+      "writer_iops": "~2500",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "~43.6",
+      "reader_sessions": "6-8 avg",
+      "reader_iops": "0-2",
+      "redis_cpu": "1.5- 2.5%",
+      "redis_mem": "0.38%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "48%",
+      "osquery_mem": "8%",
+      "deadlocks": "~0-17"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/474to475mig-w/474to475mig-w-2025-10-16-1h.json
+++ b/tools/loadtest/metrics/runs/historical/474to475mig-w/474to475mig-w-2025-10-16-1h.json
@@ -1,0 +1,113 @@
+{
+  "metadata": {
+    "workspace": "474to475mig-w",
+    "collected_at": "2025-10-16T00:00:00Z",
+    "interval": "1h",
+    "release": "4.75.0",
+    "category": "migration",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 41
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 78.0
+    },
+    "memory_utilization": {
+      "Average": 5.5
+    },
+    "task_counts": {
+      "runningCount": 30
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 27.0
+    },
+    "memory_utilization": {
+      "Average": 0.3
+    },
+    "task_counts": {
+      "runningCount": 200
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 13.0
+    },
+    "write_iops": {
+      "Average": 2800.0
+    },
+    "deadlocks": null
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 8.0,
+      "maximum": 11.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 46.0
+      },
+      "read_iops": {
+        "Average": 7.5,
+        "Maximum": 15.0
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 10.5,
+        "maximum": 15.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 2.15,
+        "Maximum": 2.7
+      },
+      "memory_utilization": {
+        "Average": 0.32
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": null
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Migration Test",
+    "one_click": null,
+    "notes": null,
+    "raw": {
+      "full_day": "no",
+      "fleet_containers": "30",
+      "loadtest_containers": "200",
+      "fleet_cpu": "~78% but with http signature on (extra ~4%)",
+      "fleet_mem": "~5.5%",
+      "writer_top_sql": "INSERT INTO `host_seen_ti\u2026",
+      "writer_cpu": "~13%",
+      "writer_sessions": "5-11 avg 8",
+      "writer_iops": "~2800",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "~46%",
+      "reader_sessions": "~6-15",
+      "reader_iops": "0-15",
+      "redis_cpu": "1.6-2.7%",
+      "redis_mem": "0.32%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "27%",
+      "osquery_mem": "0.30%",
+      "deadlocks": "~0-2 peak 30"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/4750orchl/4750orchl-2025-10-17-1h-2.json
+++ b/tools/loadtest/metrics/runs/historical/4750orchl/4750orchl-2025-10-17-1h-2.json
@@ -1,0 +1,114 @@
+{
+  "metadata": {
+    "workspace": "4750orchl",
+    "collected_at": "2025-10-17T01:00:00Z",
+    "interval": "1h",
+    "release": "4.75.0",
+    "category": "baseline",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 43
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 26.0
+    },
+    "memory_utilization": {
+      "Average": 2.0
+    },
+    "task_counts": {
+      "runningCount": 20
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 24.0
+    },
+    "memory_utilization": {
+      "Average": 4.0
+    },
+    "task_counts": {
+      "runningCount": 30
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 4.0
+    },
+    "write_iops": {
+      "Average": 1110.0
+    },
+    "deadlocks": {
+      "Sum": 0
+    }
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 2.0,
+      "maximum": 2.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 7.4
+      },
+      "read_iops": {
+        "Average": 0.1
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 2.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 1.85,
+        "Maximum": 2.0
+      },
+      "memory_utilization": {
+        "Average": 0.21
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": 0
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Ticket #34055",
+    "one_click": null,
+    "notes": "This loadtest was spun up using distributed hosts flags in o\u2026",
+    "raw": {
+      "full_day": "no",
+      "fleet_containers": "20",
+      "loadtest_containers": "30",
+      "fleet_cpu": "~26%",
+      "fleet_mem": "~2%",
+      "errors": "No new errors",
+      "writer_top_sql": "INSERT INTO `host_seen_ti\u2026",
+      "writer_cpu": "~4%",
+      "writer_sessions": "0-2 avg 2",
+      "writer_iops": "~1110",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "~7.4%",
+      "reader_sessions": "2 avg",
+      "reader_iops": "avg 0.1",
+      "redis_cpu": "1.7-2%",
+      "redis_mem": "0.21%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "~24%",
+      "osquery_mem": "4%",
+      "deadlocks": "~0"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/4750orchl/4750orchl-2025-10-17-1h.json
+++ b/tools/loadtest/metrics/runs/historical/4750orchl/4750orchl-2025-10-17-1h.json
@@ -1,0 +1,112 @@
+{
+  "metadata": {
+    "workspace": "4750orchl",
+    "collected_at": "2025-10-17T00:00:00Z",
+    "interval": "1h",
+    "release": "4.75.0",
+    "category": "baseline",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 42
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 85.0
+    },
+    "memory_utilization": {
+      "Average": 4.5
+    },
+    "task_counts": {
+      "runningCount": 30
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 57.0
+    },
+    "memory_utilization": {
+      "Average": 30.0
+    },
+    "task_counts": {
+      "runningCount": 200
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 13.8
+    },
+    "write_iops": {
+      "Average": 2900.0
+    },
+    "deadlocks": null
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 2.5,
+      "maximum": 8.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 54.0
+      },
+      "read_iops": {
+        "Average": 0.9
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 12.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 1.75,
+        "Maximum": 2.0
+      },
+      "memory_utilization": {
+        "Average": 0.2
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": 0
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Baseline Test",
+    "one_click": null,
+    "notes": null,
+    "raw": {
+      "full_day": "no",
+      "fleet_containers": "30",
+      "loadtest_containers": "200",
+      "fleet_cpu": "~85%",
+      "fleet_mem": "~4.5%",
+      "errors": "No new errors",
+      "writer_top_sql": "INSERT INTO `host_seen_ti\u2026",
+      "writer_cpu": "~13.8%",
+      "writer_sessions": "2-8 avg 2.5",
+      "writer_iops": "~2900",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "~54%",
+      "reader_sessions": "12 avg",
+      "reader_iops": "avg 0.9",
+      "redis_cpu": "1.5-2%",
+      "redis_mem": "0.20%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "57%",
+      "osquery_mem": "30%",
+      "deadlocks": "~0-2 avg 0.5"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/475to476mig/475to476mig-2025-11-04-1h.json
+++ b/tools/loadtest/metrics/runs/historical/475to476mig/475to476mig-2025-11-04-1h.json
@@ -1,0 +1,115 @@
+{
+  "metadata": {
+    "workspace": "475to476mig",
+    "collected_at": "2025-11-04T00:00:00Z",
+    "interval": "1h",
+    "release": "4.76.0",
+    "category": "migration",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 44
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 79.0
+    },
+    "memory_utilization": {
+      "Average": 6.5
+    },
+    "task_counts": {
+      "runningCount": 30
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 30.0
+    },
+    "memory_utilization": {
+      "Average": 4.0
+    },
+    "task_counts": {
+      "runningCount": 200
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 20.0
+    },
+    "write_iops": {
+      "Average": 3000.0
+    },
+    "deadlocks": {
+      "Sum": 0
+    }
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 6.0,
+      "maximum": 12.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 55.0
+      },
+      "read_iops": {
+        "Average": 2.0,
+        "Maximum": 6.0
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 7.5
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 2.0,
+        "Maximum": 2.5
+      },
+      "memory_utilization": {
+        "Average": 0.27
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": 0
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Migration Test",
+    "one_click": null,
+    "notes": "Notice very long vulnerability processing time. We have an e\u2026",
+    "raw": {
+      "full_day": "yes",
+      "fleet_containers": "30",
+      "loadtest_containers": "200",
+      "fleet_cpu": "~79%",
+      "fleet_mem": "~6.5%",
+      "errors": "No errors",
+      "writer_top_sql": "INSERT INTO `host_seen_ti\u2026",
+      "writer_cpu": "~20%",
+      "writer_sessions": "0-12 avg 6",
+      "writer_iops": "~3000",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "~55%",
+      "reader_sessions": "7.5 avg",
+      "reader_iops": "1-6 avg 2",
+      "redis_cpu": "1.5-2.5%",
+      "redis_mem": "0.27%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "30%",
+      "osquery_mem": "4%",
+      "deadlocks": "~0"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/476loadtest/476loadtest-2025-11-06-1h.json
+++ b/tools/loadtest/metrics/runs/historical/476loadtest/476loadtest-2025-11-06-1h.json
@@ -1,0 +1,116 @@
+{
+  "metadata": {
+    "workspace": "476loadtest",
+    "collected_at": "2025-11-06T00:00:00Z",
+    "interval": "1h",
+    "release": "4.76.0",
+    "category": "baseline",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 45
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 75.0
+    },
+    "memory_utilization": {
+      "Average": 4.5
+    },
+    "task_counts": {
+      "runningCount": 30
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 25.0
+    },
+    "memory_utilization": {
+      "Average": 3.75
+    },
+    "task_counts": {
+      "runningCount": 200
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 20.0
+    },
+    "write_iops": {
+      "Average": 2700.0
+    },
+    "deadlocks": {
+      "Sum": 0
+    }
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 6.0,
+      "maximum": 12.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 50.0
+      },
+      "read_iops": {
+        "Average": 1.0,
+        "Maximum": 63.0
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 8.5,
+        "maximum": 13.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 2.2,
+        "Maximum": 2.75
+      },
+      "memory_utilization": {
+        "Average": 0.26
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": null
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Baseline Test",
+    "one_click": null,
+    "notes": "Opened this bug for the errors and high DB load: <url>",
+    "raw": {
+      "full_day": "yes",
+      "fleet_containers": "30",
+      "loadtest_containers": "200",
+      "fleet_cpu": "~75%",
+      "fleet_mem": "~4.5%",
+      "errors": "{\"component\":\"http\",\"err\":\"error in query ingestion\",\"host_i\u2026",
+      "writer_top_sql": "DELETE FROM host_software\u2026",
+      "writer_cpu": "~20%",
+      "writer_sessions": "3-12 avg 6",
+      "writer_iops": "~2700",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "~50%",
+      "reader_sessions": "~4-13",
+      "reader_iops": "0-63 avg 1",
+      "redis_cpu": "1.65-2.75%",
+      "redis_mem": "0.26%",
+      "osquery_uptime": "not 100%",
+      "osquery_cpu": "25%",
+      "osquery_mem": "3.75%",
+      "deadlocks": "~0"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/476to477mig/476to477mig-2025-11-20-1h.json
+++ b/tools/loadtest/metrics/runs/historical/476to477mig/476to477mig-2025-11-20-1h.json
@@ -1,0 +1,116 @@
+{
+  "metadata": {
+    "workspace": "476to477mig",
+    "collected_at": "2025-11-20T00:00:00Z",
+    "interval": "1h",
+    "release": "4.77.0",
+    "category": "migration",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 46
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 77.0
+    },
+    "memory_utilization": {
+      "Average": 4.6
+    },
+    "task_counts": {
+      "runningCount": 30
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 25.0
+    },
+    "memory_utilization": {
+      "Average": 4.3
+    },
+    "task_counts": {
+      "runningCount": 200
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 20.0
+    },
+    "write_iops": {
+      "Average": 2800.0
+    },
+    "deadlocks": {
+      "Sum": 0
+    }
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 6.0,
+      "maximum": 12.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 55.0
+      },
+      "read_iops": {
+        "Average": 1.0,
+        "Maximum": 55.0
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 9.0,
+        "maximum": 14.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 2.1,
+        "Maximum": 2.65
+      },
+      "memory_utilization": {
+        "Average": 0.22
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": null
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Migration Test",
+    "one_click": null,
+    "notes": "Same issue as the above causing some perf spikes. Nothing ne\u2026",
+    "raw": {
+      "full_day": "yes",
+      "fleet_containers": "30",
+      "loadtest_containers": "200",
+      "fleet_cpu": "~77%",
+      "fleet_mem": "~4.6%",
+      "errors": "Errors related to spikes here: <url>",
+      "writer_top_sql": "DELETE FROM host_software\u2026",
+      "writer_cpu": "~20%",
+      "writer_sessions": "3-12 avg 6",
+      "writer_iops": "~2800",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "~55%",
+      "reader_sessions": "~4-14",
+      "reader_iops": "0-55 avg 1",
+      "redis_cpu": "1.55-2.65%",
+      "redis_mem": "0.22%",
+      "osquery_uptime": "not 100% due to writer spikes",
+      "osquery_cpu": "25%",
+      "osquery_mem": "4.30%",
+      "deadlocks": "~0"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/4770loadtest/4770loadtest-2025-11-21-1h.json
+++ b/tools/loadtest/metrics/runs/historical/4770loadtest/4770loadtest-2025-11-21-1h.json
@@ -1,0 +1,97 @@
+{
+  "metadata": {
+    "workspace": "4770loadtest",
+    "collected_at": "2025-11-21T00:00:00Z",
+    "interval": "1h",
+    "release": "4.77.0",
+    "category": "baseline",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 47
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 48.0
+    },
+    "memory_utilization": {
+      "Average": 3.8
+    },
+    "task_counts": {
+      "runningCount": 30
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": null,
+    "memory_utilization": null,
+    "task_counts": {
+      "runningCount": 200
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 11.0
+    },
+    "write_iops": {
+      "Average": 2300.0
+    },
+    "deadlocks": null
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 5.0,
+      "maximum": 8.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 37.0
+      },
+      "read_iops": {
+        "Average": 0.0
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 6.0,
+        "maximum": 10.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": null,
+      "memory_utilization": null
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": null
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Baseline Test",
+    "one_click": "yes",
+    "notes": "This is one of the first one-click setups we have used and a\u2026",
+    "raw": {
+      "full_day": "yes",
+      "fleet_containers": "30",
+      "loadtest_containers": "200",
+      "fleet_cpu": "~48%",
+      "fleet_mem": "~3.8%",
+      "writer_top_sql": "INSERT INTO `host_seen_ti\u2026",
+      "writer_cpu": "~11%",
+      "writer_sessions": "4-8 avg 5",
+      "writer_iops": "~2300",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "~37%",
+      "reader_sessions": "~2-10",
+      "reader_iops": "avg 0"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/477loadtest/477loadtest-2025-11-25-1h.json
+++ b/tools/loadtest/metrics/runs/historical/477loadtest/477loadtest-2025-11-25-1h.json
@@ -1,0 +1,115 @@
+{
+  "metadata": {
+    "workspace": "477loadtest",
+    "collected_at": "2025-11-25T00:00:00Z",
+    "interval": "1h",
+    "release": "4.77.0",
+    "category": "baseline",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 49
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 77.0
+    },
+    "memory_utilization": {
+      "Average": 9.5
+    },
+    "task_counts": {
+      "runningCount": 30
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 26.0
+    },
+    "memory_utilization": {
+      "Average": 9.0
+    },
+    "task_counts": {
+      "runningCount": 200
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 26.0
+    },
+    "write_iops": {
+      "Average": 3000.0
+    },
+    "deadlocks": {
+      "Sum": 0
+    }
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 7.0,
+      "maximum": 15.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 48.0
+      },
+      "read_iops": {
+        "Average": 1.0
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 9.5,
+        "maximum": 16.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 2.0,
+        "Maximum": 2.6
+      },
+      "memory_utilization": {
+        "Average": 0.23
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": null
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Baseline Test",
+    "one_click": "no",
+    "notes": "Writer load related to <url>",
+    "raw": {
+      "full_day": "yes",
+      "fleet_containers": "30",
+      "loadtest_containers": "200",
+      "fleet_cpu": "~77%",
+      "fleet_mem": "~9.5%",
+      "errors": "{\"count\":\"count\"-1,\"examples\":\"examples\"-2 Token-3 python_pa\u2026",
+      "writer_top_sql": "DELETE FROM `host_softwar\u2026",
+      "writer_cpu": "~26%",
+      "writer_sessions": "4-15 avg 7",
+      "writer_iops": "~3000",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "~48%",
+      "reader_sessions": "~3-16",
+      "reader_iops": "avg 1",
+      "redis_cpu": "1.4-2.6%",
+      "redis_mem": "0.23%",
+      "osquery_uptime": "not 100% due to writer spikes",
+      "osquery_cpu": "26%",
+      "osquery_mem": "9%",
+      "deadlocks": "~0"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/477to478mig/477to478mig-2025-12-18-1h.json
+++ b/tools/loadtest/metrics/runs/historical/477to478mig/477to478mig-2025-12-18-1h.json
@@ -1,0 +1,116 @@
+{
+  "metadata": {
+    "workspace": "477to478mig",
+    "collected_at": "2025-12-18T00:00:00Z",
+    "interval": "1h",
+    "release": "4.78.0",
+    "category": "migration",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 50
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 49.0
+    },
+    "memory_utilization": {
+      "Average": 4.0
+    },
+    "task_counts": {
+      "runningCount": 30
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 17.0
+    },
+    "memory_utilization": {
+      "Average": 9.0
+    },
+    "task_counts": {
+      "runningCount": 200
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 20.0
+    },
+    "write_iops": {
+      "Average": 2700.0
+    },
+    "deadlocks": {
+      "Sum": 0
+    }
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 5.0,
+      "maximum": 10.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 37.0
+      },
+      "read_iops": {
+        "Average": 1.0,
+        "Maximum": 55.0
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 9.5,
+        "maximum": 15.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 2.05,
+        "Maximum": 2.7
+      },
+      "memory_utilization": {
+        "Average": 0.33
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": null
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Migration Test",
+    "one_click": "yes",
+    "notes": "Known errors related to new software inventory",
+    "raw": {
+      "full_day": "yes",
+      "fleet_containers": "30",
+      "loadtest_containers": "200",
+      "fleet_cpu": "~49%",
+      "fleet_mem": "~4%",
+      "errors": "<url> & <url>",
+      "writer_top_sql": "DELETE FROM `host_softwar\u2026",
+      "writer_cpu": "~20%",
+      "writer_sessions": "3-10 avg 5",
+      "writer_iops": "~2700",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "~37%",
+      "reader_sessions": "~4-15",
+      "reader_iops": "avg 1 spikes to 55",
+      "redis_cpu": "1.4-2.7%",
+      "redis_mem": "0.33%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "17%",
+      "osquery_mem": "9%",
+      "deadlocks": "~0"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/478loadtest/478loadtest-2025-12-19-1h.json
+++ b/tools/loadtest/metrics/runs/historical/478loadtest/478loadtest-2025-12-19-1h.json
@@ -1,0 +1,116 @@
+{
+  "metadata": {
+    "workspace": "478loadtest",
+    "collected_at": "2025-12-19T00:00:00Z",
+    "interval": "1h",
+    "release": "4.78.0",
+    "category": "baseline",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 51
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 46.0
+    },
+    "memory_utilization": {
+      "Average": 3.7
+    },
+    "task_counts": {
+      "runningCount": 30
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 18.0
+    },
+    "memory_utilization": {
+      "Average": 9.5
+    },
+    "task_counts": {
+      "runningCount": 200
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 21.0
+    },
+    "write_iops": {
+      "Average": 2800.0
+    },
+    "deadlocks": {
+      "Sum": 0
+    }
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 5.0,
+      "maximum": 9.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 41.0
+      },
+      "read_iops": {
+        "Average": 1.0,
+        "Maximum": 56.0
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 8.5,
+        "maximum": 12.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 2.25,
+        "Maximum": 3.0
+      },
+      "memory_utilization": {
+        "Average": 0.31
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": null
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Baseline Test",
+    "one_click": "yes",
+    "notes": "Known errors related to new software inventory",
+    "raw": {
+      "full_day": "yes",
+      "fleet_containers": "30",
+      "loadtest_containers": "200",
+      "fleet_cpu": "~46%",
+      "fleet_mem": "~3.7%",
+      "errors": "<url> & <url>",
+      "writer_top_sql": "DELETE FROM `host_softwar\u2026",
+      "writer_cpu": "~21%",
+      "writer_sessions": "2-9 avg 5",
+      "writer_iops": "~2800",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "~41%",
+      "reader_sessions": "~5-12",
+      "reader_iops": "avg 1 spikes to 56 & 22",
+      "redis_cpu": "1.5-3%",
+      "redis_mem": "0.31%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "18%",
+      "osquery_mem": "9.50%",
+      "deadlocks": "~0"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/478to479mig/478to479mig-2026-01-10-1h.json
+++ b/tools/loadtest/metrics/runs/historical/478to479mig/478to479mig-2026-01-10-1h.json
@@ -1,0 +1,115 @@
+{
+  "metadata": {
+    "workspace": "478to479mig",
+    "collected_at": "2026-01-10T00:00:00Z",
+    "interval": "1h",
+    "release": "4.79.0",
+    "category": "migration",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 52
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 50.0
+    },
+    "memory_utilization": {
+      "Average": 4.0
+    },
+    "task_counts": {
+      "runningCount": 30
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 24.0
+    },
+    "memory_utilization": {
+      "Average": 10.0
+    },
+    "task_counts": {
+      "runningCount": 200
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 20.0
+    },
+    "write_iops": {
+      "Average": 2900.0
+    },
+    "deadlocks": {
+      "Sum": 0
+    }
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 5.0,
+      "maximum": 10.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 39.0
+      },
+      "read_iops": {
+        "Average": 1.0,
+        "Maximum": 44.0
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 9.5,
+        "maximum": 16.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 2.05,
+        "Maximum": 2.7
+      },
+      "memory_utilization": {
+        "Average": 0.3
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": null
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Migration Test",
+    "one_click": "yes",
+    "notes": "Several new errors during the migration window",
+    "raw": {
+      "full_day": "yes",
+      "fleet_containers": "30",
+      "loadtest_containers": "200",
+      "fleet_cpu": "~50%",
+      "fleet_mem": "~4%",
+      "writer_top_sql": "COMMIT",
+      "writer_cpu": "~20%",
+      "writer_sessions": "2-10 avg 5",
+      "writer_iops": "~2900",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "~39%",
+      "reader_sessions": "~3-16",
+      "reader_iops": "avg 1 spikes 40 44",
+      "redis_cpu": "1.4-2.7%",
+      "redis_mem": "0.30%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "24%",
+      "osquery_mem": "10%",
+      "deadlocks": "~0"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/479loadtest/479loadtest-2026-01-13-1h.json
+++ b/tools/loadtest/metrics/runs/historical/479loadtest/479loadtest-2026-01-13-1h.json
@@ -1,0 +1,115 @@
+{
+  "metadata": {
+    "workspace": "479loadtest",
+    "collected_at": "2026-01-13T00:00:00Z",
+    "interval": "1h",
+    "release": "4.79.0",
+    "category": "baseline",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 53
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 49.0
+    },
+    "memory_utilization": {
+      "Average": 3.7
+    },
+    "task_counts": {
+      "runningCount": 30
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 18.0
+    },
+    "memory_utilization": {
+      "Average": 9.5
+    },
+    "task_counts": {
+      "runningCount": 200
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 35.0
+    },
+    "write_iops": {
+      "Average": 2900.0
+    },
+    "deadlocks": {
+      "Sum": 0
+    }
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 8.0,
+      "maximum": 17.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 35.0
+      },
+      "read_iops": {
+        "Average": 1.0,
+        "Maximum": 180.0
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 5.5,
+        "maximum": 10.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 2.05,
+        "Maximum": 2.7
+      },
+      "memory_utilization": {
+        "Average": 0.3
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": null
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Baseline Test",
+    "one_click": "yes",
+    "notes": "DB load swap between the writer and reader about 16 hours in\u2026",
+    "raw": {
+      "full_day": "yes",
+      "fleet_containers": "30",
+      "loadtest_containers": "200",
+      "fleet_cpu": "~49%",
+      "fleet_mem": "~3.7%",
+      "writer_top_sql": "INSERT INTO `host_seen_ti\u2026",
+      "writer_cpu": "~50% > ~20%",
+      "writer_sessions": "4-17 avg 8",
+      "writer_iops": "~2900",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "~35%",
+      "reader_sessions": "~1-10",
+      "reader_iops": "avg 1 spikes to 180",
+      "redis_cpu": "1.4-2.7%",
+      "redis_mem": "0.30%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "18%",
+      "osquery_mem": "9.50%",
+      "deadlocks": "~0"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/479to480mig/479to480mig-2026-01-28-1h.json
+++ b/tools/loadtest/metrics/runs/historical/479to480mig/479to480mig-2026-01-28-1h.json
@@ -1,0 +1,117 @@
+{
+  "metadata": {
+    "workspace": "479to480mig",
+    "collected_at": "2026-01-28T00:00:00Z",
+    "interval": "1h",
+    "release": "4.80.0",
+    "category": "migration",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 54
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 50.0
+    },
+    "memory_utilization": {
+      "Average": 4.0
+    },
+    "task_counts": {
+      "runningCount": 30
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 20.0
+    },
+    "memory_utilization": {
+      "Average": 9.8
+    },
+    "task_counts": {
+      "runningCount": 200
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 22.0
+    },
+    "write_iops": {
+      "Average": 2500.0,
+      "Maximum": 4000.0
+    },
+    "deadlocks": {
+      "Sum": 0
+    }
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 6.0,
+      "maximum": 20.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 40.0
+      },
+      "read_iops": {
+        "Average": 1.0,
+        "Maximum": 75.0
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 8.5,
+        "maximum": 16.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 2.1,
+        "Maximum": 2.8
+      },
+      "memory_utilization": {
+        "Average": 0.3
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": 0
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Migration Test",
+    "one_click": "yes",
+    "notes": null,
+    "raw": {
+      "full_day": "no",
+      "fleet_containers": "30",
+      "loadtest_containers": "200",
+      "fleet_cpu": "~50%",
+      "fleet_mem": "~4%",
+      "errors": "No new errors",
+      "writer_top_sql": "COMMIT",
+      "writer_cpu": "~22%",
+      "writer_sessions": "3-20 avg 6",
+      "writer_iops": "~1000-4000",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "~40%",
+      "reader_sessions": "~1-16",
+      "reader_iops": "avg 1 spikes to 75",
+      "redis_cpu": "1.4-2.8%",
+      "redis_mem": "0.30%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "20%",
+      "osquery_mem": "9.80%",
+      "deadlocks": "~0"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/480loadtest/480loadtest-2026-01-29-1h.json
+++ b/tools/loadtest/metrics/runs/historical/480loadtest/480loadtest-2026-01-29-1h.json
@@ -1,0 +1,115 @@
+{
+  "metadata": {
+    "workspace": "480loadtest",
+    "collected_at": "2026-01-29T00:00:00Z",
+    "interval": "1h",
+    "release": "4.80.0",
+    "category": "baseline",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 55
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 50.0
+    },
+    "memory_utilization": {
+      "Average": 3.5
+    },
+    "task_counts": {
+      "runningCount": 30
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 17.5
+    },
+    "memory_utilization": {
+      "Average": 9.5
+    },
+    "task_counts": {
+      "runningCount": 200
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 39.5
+    },
+    "write_iops": {
+      "Average": 2900.0
+    },
+    "deadlocks": {
+      "Sum": 0
+    }
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 7.0,
+      "maximum": 14.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 19.5
+      },
+      "read_iops": {
+        "Maximum": 20.0
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 3.5,
+        "maximum": 6.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 2.05,
+        "Maximum": 2.5
+      },
+      "memory_utilization": {
+        "Average": 0.3
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": null
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Baseline Test",
+    "one_click": "yes",
+    "notes": "<url> - DB load changes ~16 hours into the test",
+    "raw": {
+      "full_day": "yes",
+      "fleet_containers": "30",
+      "loadtest_containers": "200",
+      "fleet_cpu": "~50%",
+      "fleet_mem": "~3.5%",
+      "errors": "{\"component\":\"http\",\"err\":\"error in query ingestion || error\u2026",
+      "writer_top_sql": "DELETE FROM `host_softwar\u2026",
+      "writer_cpu": "~56% > ~23%",
+      "writer_sessions": "3-14 avg 7",
+      "writer_iops": "~2900",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "~5% > ~34%",
+      "reader_sessions": "~1-6",
+      "reader_iops": "avg spikes to 20",
+      "redis_cpu": "1.6-2.5%",
+      "redis_mem": "0.30%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "17.50%",
+      "osquery_mem": "9.50%",
+      "deadlocks": "~0"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/480to481mig/480to481mig-2026-02-18-1h.json
+++ b/tools/loadtest/metrics/runs/historical/480to481mig/480to481mig-2026-02-18-1h.json
@@ -1,0 +1,115 @@
+{
+  "metadata": {
+    "workspace": "480to481mig",
+    "collected_at": "2026-02-18T00:00:00Z",
+    "interval": "1h",
+    "release": "4.81.0",
+    "category": "migration",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 56
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 52.0
+    },
+    "memory_utilization": {
+      "Average": 4.0
+    },
+    "task_counts": {
+      "runningCount": 30
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 17.0
+    },
+    "memory_utilization": {
+      "Average": 9.5
+    },
+    "task_counts": {
+      "runningCount": 200
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 38.0
+    },
+    "write_iops": {
+      "Average": 2900.0
+    },
+    "deadlocks": {
+      "Sum": 0
+    }
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 4.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 24.0
+      },
+      "read_iops": {
+        "Average": 1.0,
+        "Maximum": 240.0
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 3.5,
+        "maximum": 6.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 2.05,
+        "Maximum": 2.5
+      },
+      "memory_utilization": {
+        "Average": 0.37
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": 0
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Migration test",
+    "one_click": "yes",
+    "notes": null,
+    "raw": {
+      "full_day": "yes",
+      "fleet_containers": "30",
+      "loadtest_containers": "200",
+      "fleet_cpu": "~52%",
+      "fleet_mem": "~4%",
+      "errors": "No new errores: logged a follow-up bug for existing one here\u2026",
+      "writer_top_sql": "DELETE FROM `host_softwar\u2026",
+      "writer_cpu": "~56% > ~20%",
+      "writer_sessions": "avg 4",
+      "writer_iops": "~2900",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "~10% > ~38%",
+      "reader_sessions": "~1-6",
+      "reader_iops": "avg 1 spikes to 240",
+      "redis_cpu": "1.6-2.5%",
+      "redis_mem": "0.37%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "17%",
+      "osquery_mem": "9.50%",
+      "deadlocks": "~0"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/481loadtest/481loadtest-2026-02-18-1h.json
+++ b/tools/loadtest/metrics/runs/historical/481loadtest/481loadtest-2026-02-18-1h.json
@@ -1,0 +1,115 @@
+{
+  "metadata": {
+    "workspace": "481loadtest",
+    "collected_at": "2026-02-18T00:00:00Z",
+    "interval": "1h",
+    "release": "4.81.0",
+    "category": "baseline",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 57
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 50.7
+    },
+    "memory_utilization": {
+      "Average": 3.7
+    },
+    "task_counts": {
+      "runningCount": 30
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 23.0
+    },
+    "memory_utilization": {
+      "Average": 9.5
+    },
+    "task_counts": {
+      "runningCount": 200
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 22.0
+    },
+    "write_iops": {
+      "Average": 3100.0
+    },
+    "deadlocks": {
+      "Sum": 0
+    }
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 6.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 40.0
+      },
+      "read_iops": {
+        "Average": 1.0,
+        "Maximum": 56.0
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 3.5,
+        "maximum": 6.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 2.05,
+        "Maximum": 2.5
+      },
+      "memory_utilization": {
+        "Average": 0.37
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": 0
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Baseline test",
+    "one_click": "yes",
+    "notes": null,
+    "raw": {
+      "full_day": "yes",
+      "fleet_containers": "30",
+      "loadtest_containers": "200",
+      "fleet_cpu": "~50.7%",
+      "fleet_mem": "~3.7%",
+      "errors": "No new errores: logged a follow-up bug for existing one here\u2026",
+      "writer_top_sql": "COMMIT",
+      "writer_cpu": "~22%",
+      "writer_sessions": "avg 6",
+      "writer_iops": "~3100",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "~40%",
+      "reader_sessions": "~1-6",
+      "reader_iops": "avg 1 spikes to 56",
+      "redis_cpu": "1.6-2.5%",
+      "redis_mem": "0.37%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "23%",
+      "osquery_mem": "9.50%",
+      "deadlocks": "~0"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/481to482mig/481to482mig-2026-03-05-1h.json
+++ b/tools/loadtest/metrics/runs/historical/481to482mig/481to482mig-2026-03-05-1h.json
@@ -1,0 +1,114 @@
+{
+  "metadata": {
+    "workspace": "481to482mig",
+    "collected_at": "2026-03-05T00:00:00Z",
+    "interval": "1h",
+    "release": "4.82.0",
+    "category": "migration",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 59
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 50.3
+    },
+    "memory_utilization": {
+      "Average": 4.0
+    },
+    "task_counts": {
+      "runningCount": 30
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 17.0
+    },
+    "memory_utilization": {
+      "Average": 9.5
+    },
+    "task_counts": {
+      "runningCount": 200
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 18.0
+    },
+    "write_iops": {
+      "Average": 3000.0
+    },
+    "deadlocks": {
+      "Sum": 0
+    }
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 9.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 40.0
+      },
+      "read_iops": {
+        "Average": 1.0,
+        "Maximum": 154.0
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 9.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 2.05,
+        "Maximum": 2.5
+      },
+      "memory_utilization": {
+        "Average": 0.33
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": null
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Migration test",
+    "one_click": "yes",
+    "notes": "Error discussed here, should be resolved on 4.82: <url>",
+    "raw": {
+      "full_day": "yes",
+      "fleet_containers": "30",
+      "loadtest_containers": "200",
+      "fleet_cpu": "~50.3%",
+      "fleet_mem": "~4.0%",
+      "errors": "{\"err\":\"failed to upload metrics: exporter export timeout: r\u2026",
+      "writer_top_sql": "COMMIT",
+      "writer_cpu": "~18%",
+      "writer_sessions": "avg 9",
+      "writer_iops": "~3000",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "~40%",
+      "reader_sessions": "avg 9",
+      "reader_iops": "avg 1 spikes to 154",
+      "redis_cpu": "1.6-2.5%",
+      "redis_mem": "0.33%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "17%",
+      "osquery_mem": "9.50%",
+      "deadlocks": "~0"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/482loadtest-30/482loadtest-30-2026-03-10-1h.json
+++ b/tools/loadtest/metrics/runs/historical/482loadtest-30/482loadtest-30-2026-03-10-1h.json
@@ -1,0 +1,114 @@
+{
+  "metadata": {
+    "workspace": "482loadtest-30",
+    "collected_at": "2026-03-10T00:00:00Z",
+    "interval": "1h",
+    "release": "4.82.0",
+    "category": "baseline",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 60
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 48.8
+    },
+    "memory_utilization": {
+      "Average": 4.0
+    },
+    "task_counts": {
+      "runningCount": 30
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 17.0
+    },
+    "memory_utilization": {
+      "Average": 9.59
+    },
+    "task_counts": {
+      "runningCount": 200
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 18.0
+    },
+    "write_iops": {
+      "Average": 2700.0
+    },
+    "deadlocks": {
+      "Sum": 0
+    }
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 5.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 40.0
+      },
+      "read_iops": {
+        "Average": 1.0,
+        "Maximum": 53.0
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 8.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 2.1,
+        "Maximum": 2.5
+      },
+      "memory_utilization": {
+        "Average": 0.38
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": 0
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Baseline test with 30 fleet containers",
+    "one_click": "yes",
+    "notes": "This instance was used to establish a baseline values for 30\u2026",
+    "raw": {
+      "full_day": "yes",
+      "fleet_containers": "30",
+      "loadtest_containers": "200",
+      "fleet_cpu": "~48.80%",
+      "fleet_mem": "~4.0%",
+      "errors": "No errors",
+      "writer_top_sql": "COMMIT",
+      "writer_cpu": "~18%",
+      "writer_sessions": "avg 5",
+      "writer_iops": "~2700",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "~40%",
+      "reader_sessions": "avg 8",
+      "reader_iops": "avg 1 spikes to 53",
+      "redis_cpu": "1.7-2.5%",
+      "redis_mem": "0.38%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "17%",
+      "osquery_mem": "9.59%",
+      "deadlocks": "~0"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/482loadtest/482loadtest-2026-03-10-1h.json
+++ b/tools/loadtest/metrics/runs/historical/482loadtest/482loadtest-2026-03-10-1h.json
@@ -1,0 +1,115 @@
+{
+  "metadata": {
+    "workspace": "482loadtest",
+    "collected_at": "2026-03-10T00:00:00Z",
+    "interval": "1h",
+    "release": "4.82.0",
+    "category": "baseline",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 61
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 58.0
+    },
+    "memory_utilization": {
+      "Average": 4.0
+    },
+    "task_counts": {
+      "runningCount": 25
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 17.0
+    },
+    "memory_utilization": {
+      "Average": 9.59
+    },
+    "task_counts": {
+      "runningCount": 200
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 24.0
+    },
+    "write_iops": {
+      "Average": 2750.0
+    },
+    "deadlocks": {
+      "Sum": 0
+    }
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 7.0,
+      "maximum": 250.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 44.0
+      },
+      "read_iops": {
+        "Average": 2.0,
+        "Maximum": 48.0
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 9.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 2.1,
+        "Maximum": 2.5
+      },
+      "memory_utilization": {
+        "Average": 0.38
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": null
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Baseline test with 25 fleet containers",
+    "one_click": "yes",
+    "notes": "We tried using 25 containers which led to higher DB load, we\u2026",
+    "raw": {
+      "full_day": "yes",
+      "fleet_containers": "25",
+      "loadtest_containers": "200",
+      "fleet_cpu": "~58%",
+      "fleet_mem": "~4.0%",
+      "errors": "Numerous errors related to server crashes due to high DB loa\u2026",
+      "writer_top_sql": "DELETE FROM `host_softwar\u2026",
+      "writer_cpu": "~24%",
+      "writer_sessions": "avg 7 spikes to 250",
+      "writer_iops": "~2750",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "~44%",
+      "reader_sessions": "avg 9",
+      "reader_iops": "avg 2 spikes to 48",
+      "redis_cpu": "1.7-2.5%",
+      "redis_mem": "0.38%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "17%",
+      "osquery_mem": "9.59%",
+      "deadlocks": "~0"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/482plusvc/482plusvc-2026-03-18-1h.json
+++ b/tools/loadtest/metrics/runs/historical/482plusvc/482plusvc-2026-03-18-1h.json
@@ -1,0 +1,114 @@
+{
+  "metadata": {
+    "workspace": "482plusvc",
+    "collected_at": "2026-03-18T00:00:00Z",
+    "interval": "1h",
+    "release": "4.82.1",
+    "category": "other",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 62
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 33.0
+    },
+    "memory_utilization": {
+      "Average": 8.0
+    },
+    "task_counts": {
+      "runningCount": 25
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 17.0
+    },
+    "memory_utilization": {
+      "Average": 9.61
+    },
+    "task_counts": {
+      "runningCount": 200
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 20.0
+    },
+    "write_iops": {
+      "Average": 2700.0
+    },
+    "deadlocks": {
+      "Sum": 0
+    }
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 3.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 35.0
+      },
+      "read_iops": {
+        "Average": 2.0,
+        "Maximum": 38.0
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 4.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 1.7,
+        "Maximum": 2.2
+      },
+      "memory_utilization": {
+        "Average": 0.2
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": 0
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Confirming db spike fix for 4.82.1",
+    "one_click": "yes",
+    "notes": null,
+    "raw": {
+      "full_day": "no",
+      "fleet_containers": "25",
+      "loadtest_containers": "200",
+      "fleet_cpu": "~33",
+      "fleet_mem": "~8%",
+      "errors": "No errors",
+      "writer_top_sql": "COMMIT",
+      "writer_cpu": "~20%",
+      "writer_sessions": "avg 3",
+      "writer_iops": "~2700",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "~35%",
+      "reader_sessions": "avg 4",
+      "reader_iops": "avg 2 spikes to 38",
+      "redis_cpu": "1.2-2.2%",
+      "redis_mem": "0.20%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "17%",
+      "osquery_mem": "9.61%",
+      "deadlocks": "~0"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/482to483mig/482to483mig-2026-03-27-1h.json
+++ b/tools/loadtest/metrics/runs/historical/482to483mig/482to483mig-2026-03-27-1h.json
@@ -1,0 +1,114 @@
+{
+  "metadata": {
+    "workspace": "482to483mig",
+    "collected_at": "2026-03-27T00:00:00Z",
+    "interval": "1h",
+    "release": "4.83.0",
+    "category": "migration",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 65
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 60.2
+    },
+    "memory_utilization": {
+      "Average": 5.85
+    },
+    "task_counts": {
+      "runningCount": 24
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 17.2
+    },
+    "memory_utilization": {
+      "Average": 10.3
+    },
+    "task_counts": {
+      "runningCount": 195
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 16.5
+    },
+    "write_iops": {
+      "Average": 2600.0
+    },
+    "deadlocks": {
+      "Sum": 0
+    }
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 5.0,
+      "maximum": 214.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 36.0
+      },
+      "read_iops": {
+        "Average": 3.0,
+        "Maximum": 834.0
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 8.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 1.6
+      },
+      "memory_utilization": {
+        "Average": 0.3
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": 0
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Migration loadtest",
+    "one_click": "yes",
+    "notes": null,
+    "raw": {
+      "full_day": "no",
+      "fleet_containers": "24",
+      "loadtest_containers": "195",
+      "fleet_cpu": "~60.2%",
+      "fleet_mem": "~5.85%",
+      "errors": "no errors aside from cancelled crons during the migration",
+      "writer_top_sql": "COMMIT",
+      "writer_cpu": "~16.5%",
+      "writer_sessions": "avg 5 spikes to 214",
+      "writer_iops": "~2600",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "~36%",
+      "reader_sessions": "avg 8",
+      "reader_iops": "avg 3 spikes to 834",
+      "redis_cpu": "1.60%",
+      "redis_mem": "0.30%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "17.20%",
+      "osquery_mem": "10.30%",
+      "deadlocks": "~0"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/483to484mig/483to484mig-2026-04-21-1h.json
+++ b/tools/loadtest/metrics/runs/historical/483to484mig/483to484mig-2026-04-21-1h.json
@@ -1,0 +1,113 @@
+{
+  "metadata": {
+    "workspace": "483to484mig",
+    "collected_at": "2026-04-21T00:00:00Z",
+    "interval": "1h",
+    "release": "4.84.0",
+    "category": "migration",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 67
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 60.0
+    },
+    "memory_utilization": {
+      "Average": 4.45
+    },
+    "task_counts": {
+      "runningCount": 25
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 2.9
+    },
+    "memory_utilization": {
+      "Average": 2.5
+    },
+    "task_counts": {
+      "runningCount": 50
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 36.5
+    },
+    "write_iops": {
+      "Average": 2750.0
+    },
+    "deadlocks": {
+      "Sum": 0
+    }
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 5.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 23.5
+      },
+      "read_iops": {
+        "Average": 2.0,
+        "Maximum": 400.0
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 7.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 1.9
+      },
+      "memory_utilization": {
+        "Average": 0.37
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": 0
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Migration loadtest",
+    "one_click": "yes",
+    "notes": null,
+    "raw": {
+      "full_day": "yes",
+      "fleet_containers": "25",
+      "loadtest_containers": "50",
+      "fleet_cpu": "~60%",
+      "fleet_mem": "~4.45%",
+      "errors": "no errors aside from cancelled crons during the migration",
+      "writer_top_sql": "COMMIT",
+      "writer_cpu": "50% > 23%",
+      "writer_sessions": "avg 5",
+      "writer_iops": "~2750",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "6% > 41%",
+      "reader_sessions": "avg 7",
+      "reader_iops": "avg 2 spikes to 400",
+      "redis_cpu": "1.90%",
+      "redis_mem": "0.37%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "2.90%",
+      "osquery_mem": "2.50%",
+      "deadlocks": "~0"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/484to485mig/484to485mig-2026-05-07-1h.json
+++ b/tools/loadtest/metrics/runs/historical/484to485mig/484to485mig-2026-05-07-1h.json
@@ -1,0 +1,113 @@
+{
+  "metadata": {
+    "workspace": "484to485mig",
+    "collected_at": "2026-05-07T00:00:00Z",
+    "interval": "1h",
+    "release": "4.85.0",
+    "category": "migration",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 69
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 60.0
+    },
+    "memory_utilization": {
+      "Average": 8.5
+    },
+    "task_counts": {
+      "runningCount": 25
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 3.0
+    },
+    "memory_utilization": {
+      "Average": 3.0
+    },
+    "task_counts": {
+      "runningCount": 50
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 20.0
+    },
+    "write_iops": {
+      "Average": 2700.0
+    },
+    "deadlocks": {
+      "Sum": 0
+    }
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 8.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 27.0
+      },
+      "read_iops": {
+        "Average": 2.0,
+        "Maximum": 3.5
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 5.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 1.8
+      },
+      "memory_utilization": {
+        "Average": 0.4
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": null
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Migration loadtest",
+    "one_click": "yes",
+    "notes": null,
+    "raw": {
+      "full_day": "no",
+      "fleet_containers": "25",
+      "loadtest_containers": "50",
+      "fleet_cpu": "~60.0",
+      "fleet_mem": "~8.5%",
+      "errors": "{Token-1,\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\u2026",
+      "writer_top_sql": "COMMIT",
+      "writer_cpu": "~20%",
+      "writer_sessions": "avg 8",
+      "writer_iops": "~2700",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "~27%",
+      "reader_sessions": "avg 5",
+      "reader_iops": "avg 2 spikes 3.5",
+      "redis_cpu": "1.80%",
+      "redis_mem": "0.40%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "3%",
+      "osquery_mem": "3%",
+      "deadlocks": "~0"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/README.md
+++ b/tools/loadtest/metrics/runs/historical/README.md
@@ -1,0 +1,62 @@
+# Historical runs (spreadsheet backfill)
+
+These runs were backfilled from the manual-logging era of the
+"Fleet release load testing results" Google Sheet (releases 4.63.0 → 4.85.0,
+Feb 2025 – May 2026), one JSON per sheet row, so the whole history is usable by
+the tooling in this directory (`compare-metrics.sh` and the metrics dashboard).
+From 4.83 onward, runs collected with
+`collect-metrics.sh` live in `../baseline`, `../migration`, and `../mdm`; sheet
+rows duplicating those runs were not backfilled.
+
+## Reading these files
+
+- The sheet recorded human-observed 1-hour averages, so `metadata.interval` is
+  `"1h"` and per-hour rate normalization is a no-op.
+- `metadata.source` is `"spreadsheet-backfill"`, `metadata.category` records the
+  run type (used by the dashboard's run selector), and `metadata.sheet_row`
+  points back to the source row.
+- **JSON `null` means the sheet tracked the metric but the cell was blank or
+  unparseable for that row.** Fields the sheet never tracked (ALB metrics,
+  percentiles, coverage, Performance Insights) are omitted entirely.
+- `backfill.raw` preserves the original cell text for every parsed or dropped
+  value — nothing from the sheet was discarded, even where parsing was lossy.
+
+## Parsing rules
+
+Sheet cells were free text; they were converted with these rules:
+
+| Cell style | Example | Result |
+|---|---|---|
+| Approximate | `~75%`, `~2,700`, `1.3K` | `75`, `2700`, `1300` |
+| Leading range | `19-27%` | Average = midpoint (23), Maximum = 27 |
+| Average keyword | `5-17 avg ~9` | Average = 9, Maximum = 17 |
+| Peak/spike/max | `avg 1 spikes to 55`, `16% at peak, avg ~10%` | Average = 1/10, Maximum = 55/16 |
+| Shift during run | `50% > 23%` | Average = mean of observations |
+| IOPS with utilization | `2635 (~13%)` | `write_iops.Average` = 2635, `iops_utilization` = 13 |
+| Utilization only | `11.57%` in the IOPS column | `iops_utilization` only — never converted to ops/s |
+| Errors prose | `No new errors` | `0`; any other prose → `null` |
+| Deadlocks prose | `~0` → `0` | rate descriptions (`0-8.4 per minute`) → `null` (unit differs from the collector's `Sum`) |
+
+## Rows not backfilled
+
+Sheet rows with no parseable performance metrics (pure ticket pointers):
+
+| Sheet row | Environment | Reason |
+|---|---|---|
+| 14 | 4660-mdm | Profile-timing UX test; results in ticket #21338 |
+| 21 | 469-mdmloadtest | DDM profile test; results in ticket #27979 |
+| 22 | 469-mdmbatchtest | Batch profile resend test; results in ticket #25549 |
+| 31 | 4720mdm (second row) | Results in ticket #30409 |
+| 37 | 4740mdm (continuation row) | Host-count change note only |
+| 48 | 4770vbt | High-software-count experiment, no recorded metrics |
+
+## Caveats
+
+- Averages derived from ranges are midpoints of human-observed ranges — treat
+  them as indicative, not precise. The exact original text is in `backfill.raw`.
+- Some `baseline`-categorized runs used nonstandard configurations (e.g.
+  `4640loadtest-gabe` at 20K hosts, the `orch` variants); their absolute values
+  aren't comparable to standard 100K-host baselines. Deselect them in the
+  dashboard's run list when they distort a trend, and check `backfill.notes`.
+- Two `4750orchl` runs happened the same day; the second file carries a `-2`
+  suffix and a +1h `collected_at` so the runs keep distinct identities.

--- a/tools/loadtest/metrics/runs/historical/README.md
+++ b/tools/loadtest/metrics/runs/historical/README.md
@@ -20,6 +20,9 @@ rows duplicating those runs were not backfilled.
   percentiles, coverage, Performance Insights) are omitted entirely.
 - `backfill.raw` preserves the original cell text for every parsed or dropped
   value — nothing from the sheet was discarded, even where parsing was lossy.
+- `<url>`, `<tok>`, and `Token-N` placeholders mark where links and token-like
+  strings were redacted at extraction time (these files live in a public repo).
+  The unredacted text remains in the source sheet row (`metadata.sheet_row`).
 
 ## Parsing rules
 

--- a/tools/loadtest/metrics/runs/historical/andrey-481/andrey-481-2026-02-23-1h.json
+++ b/tools/loadtest/metrics/runs/historical/andrey-481/andrey-481-2026-02-23-1h.json
@@ -1,0 +1,113 @@
+{
+  "metadata": {
+    "workspace": "andrey-481",
+    "collected_at": "2026-02-23T00:00:00Z",
+    "interval": "1h",
+    "release": "4.81.0",
+    "category": "other",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 58
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 50.46
+    },
+    "memory_utilization": {
+      "Average": 3.8
+    },
+    "task_counts": {
+      "runningCount": 30
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 17.0
+    },
+    "memory_utilization": {
+      "Average": 9.0
+    },
+    "task_counts": {
+      "runningCount": 200
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 20.0
+    },
+    "write_iops": {
+      "Average": 3300.0
+    },
+    "deadlocks": {
+      "Sum": 0
+    }
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 8.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 38.0
+      },
+      "read_iops": {
+        "Average": 20.0
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 7.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 2.05,
+        "Maximum": 2.5
+      },
+      "memory_utilization": {
+        "Average": 0.37
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": 0
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "QA - <url>",
+    "one_click": "yes",
+    "notes": null,
+    "raw": {
+      "full_day": "no",
+      "fleet_containers": "30",
+      "loadtest_containers": "200",
+      "fleet_cpu": "~50.46%",
+      "fleet_mem": "~3.8%",
+      "errors": "No new errores: logged a follow-up bug for existing one here\u2026",
+      "writer_top_sql": "COMMIT",
+      "writer_cpu": "~20%",
+      "writer_sessions": "avg 8",
+      "writer_iops": "~3300",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "~38%",
+      "reader_sessions": "avg 7",
+      "reader_iops": "avg 20",
+      "redis_cpu": "1.6-2.5%",
+      "redis_mem": "0.37%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "17%",
+      "osquery_mem": "9.00%",
+      "deadlocks": "~0"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/mig66to68/mig66to68-2025-05-06-1h.json
+++ b/tools/loadtest/metrics/runs/historical/mig66to68/mig66to68-2025-05-06-1h.json
@@ -1,0 +1,115 @@
+{
+  "metadata": {
+    "workspace": "mig66to68",
+    "collected_at": "2025-05-06T00:00:00Z",
+    "interval": "1h",
+    "release": "4.68.0",
+    "category": "migration",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 18
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 58.0
+    },
+    "memory_utilization": {
+      "Average": 4.0
+    },
+    "task_counts": {
+      "runningCount": 30
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 38.0
+    },
+    "memory_utilization": {
+      "Average": 8.97
+    },
+    "task_counts": {
+      "runningCount": 200
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 16.0,
+      "Maximum": 21.0
+    },
+    "write_iops": {
+      "Average": 2700.0
+    },
+    "deadlocks": null
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 5.0,
+      "maximum": 11.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 50.0
+      },
+      "read_iops": {
+        "Average": 1.0,
+        "Maximum": 3.2
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 4.0,
+        "maximum": 9.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 2.1,
+        "Maximum": 2.7
+      },
+      "memory_utilization": {
+        "Average": 0.4
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": 0
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "Migration Test",
+    "one_click": null,
+    "notes": "Was run after code cut but there were many cherry picks afte\u2026",
+    "raw": {
+      "full_day": "yes",
+      "fleet_containers": "30",
+      "loadtest_containers": "200",
+      "fleet_cpu": "~58%",
+      "fleet_mem": "~4%",
+      "errors": "No new errors",
+      "writer_top_sql": "INSERT INTO `host_seen_ti\u2026",
+      "writer_cpu": "11-21%",
+      "writer_sessions": "2-11 avg 5",
+      "writer_iops": "~2700",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "~50%",
+      "reader_sessions": "1-9 avg ~4",
+      "reader_iops": "max 3.2 otherwise about 1",
+      "redis_cpu": "1.5-2.7%",
+      "redis_mem": "0.40%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "38%",
+      "osquery_mem": "8.97%",
+      "deadlocks": "~0-6"
+    }
+  }
+}

--- a/tools/loadtest/metrics/runs/historical/qa-42544/qa-42544-2026-03-30-1h.json
+++ b/tools/loadtest/metrics/runs/historical/qa-42544/qa-42544-2026-03-30-1h.json
@@ -1,0 +1,113 @@
+{
+  "metadata": {
+    "workspace": "qa-42544",
+    "collected_at": "2026-03-30T00:00:00Z",
+    "interval": "1h",
+    "release": "4.83.0",
+    "category": "mdm",
+    "source": "spreadsheet-backfill",
+    "sheet_row": 63
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 65.0
+    },
+    "memory_utilization": {
+      "Average": 3.0
+    },
+    "task_counts": {
+      "runningCount": 25
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 42.0
+    },
+    "memory_utilization": {
+      "Average": 25.0
+    },
+    "task_counts": {
+      "runningCount": 80
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Average": 50.0
+    },
+    "write_iops": {
+      "Average": 3600.0
+    },
+    "deadlocks": {
+      "Sum": 0
+    }
+  },
+  "rds_writer_extended": {
+    "threads_running": {
+      "average": 14.0
+    },
+    "iops_utilization": null
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Average": 11.0
+      },
+      "read_iops": {
+        "Average": 2.0,
+        "Maximum": 80.0
+      }
+    }
+  ],
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "threads_running": {
+        "average": 3.0
+      }
+    }
+  ],
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Average": 5.5
+      },
+      "memory_utilization": {
+        "Average": 6.6
+      }
+    }
+  ],
+  "fleet_server_errors": {
+    "error_count": 0
+  },
+  "backfill": {
+    "source": "Fleet release load testing results (Google Sheet), manual-logging era",
+    "purpose": "MDM loadtest for 42544",
+    "one_click": "yes",
+    "notes": null,
+    "raw": {
+      "full_day": "no",
+      "fleet_containers": "25",
+      "loadtest_containers": "80",
+      "fleet_cpu": "~65%",
+      "fleet_mem": "~3%",
+      "errors": "No errors",
+      "writer_top_sql": "COMMIT",
+      "writer_cpu": "~50%",
+      "writer_sessions": "avg 14",
+      "writer_iops": "~3600",
+      "reader_top_sql": "SELECT `h` . `id` , `h` .\u2026",
+      "reader_cpu": "~11%",
+      "reader_sessions": "avg 3",
+      "reader_iops": "avg 2 spikes to 80",
+      "redis_cpu": "~5.5%",
+      "redis_mem": "6.60%",
+      "osquery_uptime": "100%",
+      "osquery_cpu": "42%",
+      "osquery_mem": "25%",
+      "deadlocks": "~0"
+    }
+  }
+}


### PR DESCRIPTION
**Related issue:** N/A — backfills historical load test results so the manual results spreadsheet can be retired.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] QA'd all new/changed functionality manually

All 54 files were verified in three layers: (1) every consumed sheet cell diffed byte-for-byte against the live sheet; (2) dates, workspaces, releases, and container counts mechanically cross-checked; (3) all 475 distinct raw→parsed translations reviewed individually (one parsing defect found and corrected before this PR). Loaded alongside the script-collected runs in the metrics tooling and compared with `compare-metrics.sh` without issues. Scanned for credentials/PII: no AWS keys, ARNs, account IDs, URLs, IPs, emails, or token-like strings (link/token content was scrubbed to `<url>`/`<tok>` placeholders at extraction time).

# Details

Converts the manual-logging era of the "Fleet release load testing results" spreadsheet (releases 4.63.0 → 4.85.0, Feb 2025 – May 2026) into per-run JSON artifacts under `runs/historical/`, one file per sheet row, in the same schema `collect-metrics.sh` emits — so 18 months of release-over-release history is usable by `compare-metrics.sh` (and the upcoming metrics dashboard) with no special handling.

- 54 runs backfilled; sheet rows duplicating script-collected runs (4.83+) and 6 rows with no parseable metrics (pure ticket pointers) were skipped — both listed in `runs/historical/README.md`.
- Free-text cells were parsed with documented rules (ranges → midpoint + max, `avg`/`peak`/`spike` keywords, IOPS-vs-utilization unit routing, prose errors → 0/null). JSON `null` = the sheet tracked the metric but the cell was blank/unparseable; fields the sheet never tracked are omitted.
- Every parsed or dropped cell's original text is preserved under `backfill.raw`, so no information is lost even where parsing was lossy.
- `runs/historical/README.md` documents provenance, parsing rules, skipped rows, and caveats (midpoint averages are indicative; a few baseline-tagged runs used nonstandard configs).

Per the metrics README's submission guidance, this PR is run artifacts only — no script changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added historical one-hour load-test records spanning releases 4.63.0 through 4.85.0.
  - Included baseline, migration, MDM, and QA performance snapshots.
  - Records now provide Fleet Server, container, database, Redis, resource utilization, task, I/O, session, deadlock, and error metrics.
  - Added collection metadata, source notes, and backfilled spreadsheet values, with unavailable measurements clearly identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->