### PR TITLE
Docs: correct GitOps mode label editing behavior and document exceptions

### DIFF
--- a/articles/gitops-mode.md
+++ b/articles/gitops-mode.md
@@ -14,13 +14,23 @@ To turn GitOps mode on or off, navigate to **Settings** > **Integrations** > **C
 
 ![](../website/assets/images/articles/enabling-gitops-mode-960x594@2x.gif)
 
+## Exceptions
+
+Exceptions let you opt a resource out of GitOps mode, so you can manage that resource in the Fleet UI while everything else stays in git. Under **Settings** > **Integrations** > **Change management**, you can add an exception for labels, software, or enroll secrets.
+
+When a resource has an exception, two things happen:
+- The Fleet UI stays editable for that resource, even with GitOps mode on.
+- `fleetctl gitops` fails if your YAML includes that resource's key. The error tells you to remove the key or disable the exception. This keeps the UI and git from overwriting each other.
+
+Fleet enables the enroll secrets exception by default. Fleet instances upgraded to Fleet 4.84.0 also have the labels exception enabled, so the first GitOps run after the upgrade doesn't delete labels that aren't in git.
+
 ## Still available
 
 GitOps mode prevents the UI user from editing [GitOps-configurable features](https://fleetdm.com/docs/configuration/yaml-files). They will still be able to, for example:
 - Read any data presented in the UI
 - Add and edit users
-- Add and edit labels
 - Run live queries
+- Add and edit labels, software, or enroll secrets, if that resource has an [exception](#exceptions)
 
 ## More
 <!-- TODO - update to link to Allen's article, uncomment -->

--- a/articles/gitops-mode.md
+++ b/articles/gitops-mode.md
@@ -25,7 +25,7 @@ When a resource has an exception, three things happen:
 
 Exceptions apply to `fleetctl gitops` whether or not GitOps mode is turned on.
 
-Fleet enables the enroll secrets exception by default. Fleet instances upgraded to Fleet 4.84.0 also have the labels exception enabled, so the first GitOps run after the upgrade doesn't delete labels that aren't in git.
+Fleet enables the enroll secrets exception by default.
 
 ## Still available
 

--- a/articles/gitops-mode.md
+++ b/articles/gitops-mode.md
@@ -18,9 +18,12 @@ To turn GitOps mode on or off, navigate to **Settings** > **Integrations** > **C
 
 Exceptions let you opt a resource out of GitOps mode, so you can manage that resource in the Fleet UI while everything else stays in git. Under **Settings** > **Integrations** > **Change management**, you can add an exception for labels, software, or enroll secrets.
 
-When a resource has an exception, two things happen:
+When a resource has an exception, three things happen:
 - The Fleet UI stays editable for that resource, even with GitOps mode on.
+- `fleetctl gitops` leaves your existing labels, software, or enroll secrets intact. Without the exception, omitting the key deletes them.
 - `fleetctl gitops` fails if your YAML includes that resource's key. The error tells you to remove the key or disable the exception. This keeps the UI and git from overwriting each other.
+
+Exceptions apply to `fleetctl gitops` whether or not GitOps mode is turned on.
 
 Fleet enables the enroll secrets exception by default. Fleet instances upgraded to Fleet 4.84.0 also have the labels exception enabled, so the first GitOps run after the upgrade doesn't delete labels that aren't in git.
 

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -25,9 +25,11 @@ Only one of `query`, `hosts`, or `criteria` can be specified. If none are specif
 
 The `hostname` host identifier is deprecated. Please use a host's `id`, `hardware_serial`, or `uuid` instead.
 
-> `labels` is an optional key: if included in `default.yml`, existing global labels not listed will be deleted. If included in `fleets/fleet-name.yml`, the fleet's existing labels not listed will be deleted. If the `label` key is omitted, existing labels will stay intact.
+> `labels` is an optional key. Its behavior depends on the labels exception in **Settings** > **Integrations** > **Change management**.
 >
-> When [GitOps mode](https://fleetdm.com/learn-more-about/ui-gitops-mode) is enabled, the Fleet UI prevents creating and editing labels. To manage labels in the UI instead of git, enable the labels exception in **Settings** > **Integrations** > **Change management**. Learn more in the [GitOps mode guide](https://fleetdm.com/guides/gitops-mode).
+> When the labels exception is disabled, labels are managed in git. If `labels` is included in `default.yml`, existing global labels not listed will be deleted. If included in `fleets/fleet-name.yml`, the fleet's existing labels not listed will be deleted. Omitting the `labels` key also deletes that file's existing labels. The Fleet UI prevents creating and editing labels while [GitOps mode](https://fleetdm.com/learn-more-about/ui-gitops-mode) is enabled.
+>
+> When the labels exception is enabled, labels are managed outside of git. `fleetctl gitops` leaves existing labels intact, and fails if a YAML file includes a `labels` key. The Fleet UI allows creating and editing labels, even while GitOps mode is enabled. Fleet instances upgraded to Fleet 4.84.0 have the labels exception enabled. Learn more in the [GitOps mode guide](https://fleetdm.com/guides/gitops-mode).
 >
 > Any labels referenced in other sections (like [policies](https://fleetdm.com/docs/configuration/yaml-files#policies), [reports](https://fleetdm.com/docs/configuration/yaml-files#reports) or [software](https://fleetdm.com/docs/configuration/yaml-files#software)) _must_ be specified in the `labels` section.
 

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -29,7 +29,7 @@ The `hostname` host identifier is deprecated. Please use a host's `id`, `hardwar
 >
 > When the labels exception is disabled, labels are managed in git. If `labels` is included in `default.yml`, existing global labels not listed will be deleted. If included in `fleets/fleet-name.yml`, the fleet's existing labels not listed will be deleted. Omitting the `labels` key also deletes that file's existing labels. The Fleet UI prevents creating and editing labels while [GitOps mode](https://fleetdm.com/learn-more-about/ui-gitops-mode) is enabled.
 >
-> When the labels exception is enabled, labels are managed outside of git. `fleetctl gitops` leaves existing labels intact, and fails if a YAML file includes a `labels` key. The Fleet UI allows creating and editing labels, even while GitOps mode is enabled. Fleet instances upgraded to Fleet 4.84.0 have the labels exception enabled. Learn more in the [GitOps mode guide](https://fleetdm.com/guides/gitops-mode).
+> When the labels exception is enabled, labels are managed outside of git. `fleetctl gitops` leaves existing labels intact, and fails if a YAML file includes a `labels` key. The Fleet UI allows creating and editing labels, even while GitOps mode is enabled. Learn more in the [GitOps mode guide](https://fleetdm.com/guides/gitops-mode).
 >
 > Any labels referenced in other sections (like [policies](https://fleetdm.com/docs/configuration/yaml-files#policies), [reports](https://fleetdm.com/docs/configuration/yaml-files#reports) or [software](https://fleetdm.com/docs/configuration/yaml-files#software)) _must_ be specified in the `labels` section.
 

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -25,7 +25,9 @@ Only one of `query`, `hosts`, or `criteria` can be specified. If none are specif
 
 The `hostname` host identifier is deprecated. Please use a host's `id`, `hardware_serial`, or `uuid` instead.
 
-> `labels` is an optional key: if included in `default.yml`, existing global labels not listed will be deleted. If included in `fleets/fleet-name.yml`, the fleet's existing labels not listed will be deleted. If the `label` key is omitted, existing labels will stay intact. For this reason, enabling [GitOps mode](https://fleetdm.com/learn-more-about/ui-gitops-mode) _does not_ restrict creating/editing labels via the UI.
+> `labels` is an optional key: if included in `default.yml`, existing global labels not listed will be deleted. If included in `fleets/fleet-name.yml`, the fleet's existing labels not listed will be deleted. If the `label` key is omitted, existing labels will stay intact.
+>
+> When [GitOps mode](https://fleetdm.com/learn-more-about/ui-gitops-mode) is enabled, the Fleet UI prevents creating and editing labels. To manage labels in the UI instead of git, enable the labels exception in **Settings** > **Integrations** > **Change management**. Learn more in the [GitOps mode guide](https://fleetdm.com/guides/gitops-mode).
 >
 > Any labels referenced in other sections (like [policies](https://fleetdm.com/docs/configuration/yaml-files#policies), [reports](https://fleetdm.com/docs/configuration/yaml-files#reports) or [software](https://fleetdm.com/docs/configuration/yaml-files#software)) _must_ be specified in the `labels` section.
 
@@ -790,6 +792,8 @@ The `gitops` section allows configuring [GitOps mode](https://fleetdm.com/learn-
 - `repository_url` (default: `""`) — the URL of the GitOps repository that manages this Fleet. Must be a valid `http://` or `https://` URL. Required when `gitops_mode_enabled: true`.
 
 Can only be configured for "All fleets" (`org_settings`).
+
+> GitOps mode exceptions for labels, software, and enroll secrets can't be set in YAML. Configure them in the Fleet UI under **Settings** > **Integrations** > **Change management**. Learn more in the [GitOps mode guide](https://fleetdm.com/guides/gitops-mode).
 
 > If `gitops:` is not provided in your YAML file, any existing GitOps mode settings will be preserved.
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #50551

Two published pages still describe pre-4.84 behavior, telling users that GitOps mode doesn't restrict label editing in the UI. Since 4.84 that's only true when the labels exception is enabled. This PR corrects both pages and documents the exceptions framework.

**`docs/Configuration/yaml-files.md`**
- `labels` section: rewrote the note around the two exception states. Beyond the sentence the issue flagged, the premise it rested on was also stale: the note said omitting the `labels` key leaves existing labels intact. Since #42191, `computeLabelChanges` (`cmd/fleetctl/fleetctl/gitops.go:947`) branches on `len(specifiedLabels) == 0`, so omitting the key deletes every custom label in that scope unless the labels exception is enabled. Its own tests name this behavior ("labels omitted removes all regular labels when not excepted"). The note now spells out both states and fixes a `label` / `labels` typo.
- `gitops` section: added a note that exceptions can't be set in YAML. `Client.DoGitOps` strips the `exceptions` key defensively (`server/service/client.go:726`), so this was worth stating explicitly.

**`articles/gitops-mode.md`**
- Added an "Exceptions" section covering the three exception types, what an exception does to both the UI and `fleetctl gitops`, and the enroll secrets default. Upgrade behavior is left to the release notes. It notes that exceptions affect `fleetctl gitops` whether or not GitOps mode is on, since neither the apply-path check nor `computeLabelChanges` reads `gitops_mode_enabled`.
- "Still available" no longer lists "Add and edit labels" unconditionally. It now points at the exceptions section for labels, software, and enroll secrets.

Behavior the docs now match:
- UI gating is `GitOpsModeTooltipWrapper` with `entityType="labels"` (`frontend/pages/labels/components/LabelForm/LabelForm.tsx:172`, `NewLabelPage.tsx:676`, `HostsFilterBlock.tsx:223`). `useGitOpsMode` treats an enabled exception as GitOps mode being off for that entity.
- Apply-path enforcement is in `server/service/client.go:2219-2242` (premium only).
- Defaults: `server/fleet/app.go:1216` for new installs, migration `20260323144117_AddGitOpsExceptionsToAppConfig.go` for upgrades.

The backend is unchanged and was already correct. `ModifyLabel` applies no GitOps check, and the per-host label endpoints stay available regardless of GitOps mode or exception state, so this PR is docs-only.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  Not applicable: documentation-only change, no product behavior change.

## Testing

- [x] QA'd all new/changed functionality manually
  Verified the described behavior against the UI gating, the `fleetctl gitops` apply path, and the exception defaults in code (references above).
