### PR TITLE
Support custom DDM activations in GitOps

### DIFF
--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -75,6 +75,7 @@ type generateGitopsClient interface {
 	ListDDMAssets(teamID *uint) ([]*fleet.DDMAsset, error)
 	GetScriptContents(scriptID uint) ([]byte, error)
 	GetProfileContents(profileID string) ([]byte, error)
+	GetProfileActivation(profileID string) ([]byte, error)
 	DownloadDDMAsset(assetUUID string) ([]byte, error)
 	GetEULAMetadata() (*fleet.MDMEULA, error)
 	GetEULAContent(token string) ([]byte, error)
@@ -1603,6 +1604,33 @@ func (cmd *GenerateGitopsCommand) generateProfiles(teamId *uint, teamName string
 		}
 
 		profileSpec["path"] = path
+
+		// Only declarations can carry one, and the list endpoint doesn't return
+		// activations, so it takes a second call.
+		var activation []byte
+		if profile.Platform == "darwin" && strings.HasSuffix(generatedFilename, ".json") {
+			activation, err = cmd.Client.GetProfileActivation(profile.ProfileUUID)
+			if err != nil {
+				fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error getting profile activation: %s\n", err)
+				return nil, err
+			}
+		}
+
+		// Written as a sibling file so the generated YAML round-trips through gitops.
+		if len(activation) > 0 {
+			activationFileName := fmt.Sprintf("activations/%s", generatedFilename)
+			if teamId == nil {
+				activationFileName = fmt.Sprintf("lib/%s", activationFileName)
+			} else {
+				activationFileName = fmt.Sprintf("lib/%s/%s", teamName, activationFileName)
+			}
+			cmd.FilesToWrite[activationFileName] = string(activation)
+			if teamId == nil {
+				profileSpec["activation"] = fmt.Sprintf("./%s", activationFileName)
+			} else {
+				profileSpec["activation"] = fmt.Sprintf("../%s", activationFileName)
+			}
+		}
 
 		switch profile.Platform {
 		case "darwin":

--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -35,6 +35,14 @@ type MockClient struct {
 	WithoutMDM       bool
 	WithoutVPP       bool
 	WithAssets       bool
+	WithActivations  bool
+}
+
+func (c MockClient) GetProfileActivation(profileID string) ([]byte, error) {
+	if !c.WithActivations || profileID != "team-declaration-profile-uuid" {
+		return nil, nil
+	}
+	return []byte(`{"Type":"com.apple.activation.simple","Identifier":"com.example.team-declaration.activation","Payload":{"StandardConfigurations":["com.example.team-declaration"]}}`), nil
 }
 
 func (c *MockClient) GetAppConfig() (*fleet.EnrichedAppConfig, error) {
@@ -168,14 +176,23 @@ func (c MockClient) ListConfigurationProfiles(teamID *uint) ([]*fleet.MDMConfigP
 		}, nil
 	}
 	if *teamID == 1 {
-		return []*fleet.MDMConfigProfilePayload{
+		profiles := []*fleet.MDMConfigProfilePayload{
 			{
 				ProfileUUID: "test-mobileconfig-profile-uuid",
 				Name:        "Team MacOS MobileConfig Profile",
 				Platform:    "darwin",
 				Identifier:  "com.example.team-macos-mobileconfig-profile",
 			},
-		}, nil
+		}
+		if c.WithActivations {
+			profiles = append(profiles, &fleet.MDMConfigProfilePayload{
+				ProfileUUID: "team-declaration-profile-uuid",
+				Name:        "Team Declaration",
+				Platform:    "darwin",
+				Identifier:  "com.example.team-declaration",
+			})
+		}
+		return profiles, nil
 	}
 	if *teamID == 0 || *teamID == 2 || *teamID == 3 || *teamID == 4 || *teamID == 5 || *teamID == 6 {
 		return nil, nil
@@ -228,6 +245,8 @@ func (MockClient) GetProfileContents(profileID string) ([]byte, error) {
 		return []byte(`{"name": "Global Android Profile", "cameraDisabled": true}`), nil
 	case "test-mobileconfig-profile-uuid":
 		return []byte("<xml>test mobileconfig profile</xml>"), nil
+	case "team-declaration-profile-uuid":
+		return []byte(`{"Type":"com.apple.configuration.passcode.settings","Identifier":"com.example.team-declaration","Payload":{}}`), nil
 	}
 	return nil, errors.New("profile not found")
 }
@@ -1111,6 +1130,56 @@ func TestGenerateGitopsWithAssets(t *testing.T) {
 	}))
 	require.True(t, sawAssetsSection, "expected an assets: section referencing an assets/ path")
 	require.True(t, sawAssetFile, "expected a DDM asset json file to be written")
+}
+
+func TestGenerateGitopsWithActivations(t *testing.T) {
+	configureFMAManifestServer(t)
+	// Plain team name: the emoji one slugs the directory but not the YAML
+	// reference, which would break the resolve check below for unrelated reasons.
+	fleetClient := &MockClient{WithActivations: true, TeamNameOverride: "team-a"}
+	action := createGenerateGitopsAction(fleetClient)
+	buf := new(bytes.Buffer)
+	tempDir := os.TempDir() + "/" + uuid.New().String()
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	flagSet.String("dir", tempDir, "")
+
+	cliContext := cli.NewContext(&cli.App{
+		Name:      "test",
+		Usage:     "test",
+		Writer:    buf,
+		ErrWriter: buf,
+	}, flagSet, nil)
+	require.NoError(t, action(cliContext), buf.String())
+	t.Cleanup(func() { _ = os.RemoveAll(tempDir) })
+
+	// The emitted path is relative to the YAML holding it, so resolving it from
+	// there is what proves gitops can read back what generate-gitops wrote.
+	var refs int
+	require.NoError(t, filepath.Walk(tempDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() || filepath.Ext(path) != ".yml" {
+			return err
+		}
+		b, err := os.ReadFile(path) //nolint:gosec // reading files under a temp dir created by this test
+		if err != nil {
+			return err
+		}
+		for line := range strings.SplitSeq(string(b), "\n") {
+			_, ref, found := strings.Cut(strings.TrimSpace(line), "activation:")
+			if !found {
+				continue
+			}
+			ref = strings.TrimSpace(ref)
+			require.Contains(t, ref, "/activations/", "activation should live in its own directory")
+
+			resolved := filepath.Join(filepath.Dir(path), ref)
+			contents, err := os.ReadFile(resolved) //nolint:gosec // path derived from the temp dir above
+			require.NoError(t, err, "activation %q referenced by %s does not resolve", ref, path)
+			require.Contains(t, string(contents), "com.apple.activation.simple")
+			refs++
+		}
+		return nil
+	}))
+	require.Equal(t, 1, refs, "expected the declaration's activation to be referenced exactly once")
 }
 
 func TestGenerateGitopsWithoutMDM(t *testing.T) {

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -1339,6 +1339,15 @@ func parseControls(top map[string]json.RawMessage, result *GitOps, logFn Logf, y
 			return multierror.Append(multiError, MaybeParseTypeError(controlsFilePath, []string{"controls", "macos_settings"}, err))
 		}
 
+		// An activation names exactly one declaration in its
+		// StandardConfigurations, so it can't be attached to a glob.
+		for _, cs := range macOSSettings.CustomSettings {
+			if cs.Activation != "" && cs.Paths != "" {
+				multiError = multierror.Append(multiError,
+					fmt.Errorf(`profile %q cannot use "activation" with "paths"; use "path" for a single profile`, cs.Paths))
+			}
+		}
+
 		// Expand globs in profile paths.
 		var errs []error
 		macOSSettings.CustomSettings, errs = expandBaseItems(macOSSettings.CustomSettings, controlsDir, "profile", GlobExpandOptions{
@@ -1350,6 +1359,12 @@ func parseControls(top map[string]json.RawMessage, result *GitOps, logFn Logf, y
 		for i := range macOSSettings.CustomSettings {
 
 			err := resolveAndUpdateProfilePath(&macOSSettings.CustomSettings[i], result)
+			if err != nil {
+				return multierror.Append(multiError, err)
+			}
+			// expandBaseItems only knows about path/paths, so the activation path
+			// is still relative to the controls file here.
+			err = resolveAndUpdateActivationPath(&macOSSettings.CustomSettings[i], controlsDir, result)
 			if err != nil {
 				return multierror.Append(multiError, err)
 			}
@@ -1591,6 +1606,22 @@ func processControlsPathIfNeeded(controlsTop GitOpsControls, result *GitOps, con
 	pathControls.Defined = true
 	result.Controls = pathControls
 	return errs
+}
+
+func resolveAndUpdateActivationPath(profile *fleet.MDMProfileSpec, baseDir string, result *GitOps) error {
+	if profile.Activation == "" {
+		return nil
+	}
+	resolved, err := filepath.Abs(resolveApplyRelativePath(baseDir, profile.Activation))
+	if err != nil {
+		return fmt.Errorf("failed to resolve activation path %s: %v", profile.Activation, err)
+	}
+	profile.Activation = resolved
+	fileBytes, err := os.ReadFile(resolved)
+	if err != nil {
+		return fmt.Errorf("failed to read activation file %s: %v", resolved, err)
+	}
+	return LookupEnvSecrets(string(fileBytes), result.FleetSecrets)
 }
 
 func resolveAndUpdateProfilePath(profile *fleet.MDMProfileSpec, result *GitOps) error {

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -5523,3 +5523,65 @@ policies:
 		})
 	}
 }
+
+func TestGitOpsProfileActivation(t *testing.T) {
+	writeConfig := func(t *testing.T, profileEntry string) (string, string) {
+		dir := t.TempDir()
+		libDir := filepath.Join(dir, "lib")
+		require.NoError(t, os.Mkdir(libDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(libDir, "ddm.json"),
+			[]byte(`{"Type":"com.apple.configuration.passcode.settings","Identifier":"com.fleet.cfg","Payload":{"Echo":"x"}}`), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(libDir, "ddm2.json"),
+			[]byte(`{"Type":"com.apple.configuration.passcode.settings","Identifier":"com.fleet.cfg2","Payload":{"Echo":"x"}}`), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(libDir, "activation.json"),
+			[]byte(`{"Type":"com.apple.activation.simple","Identifier":"com.fleet.act","Payload":{"StandardConfigurations":["com.fleet.cfg"]}}`), 0o644))
+
+		config := `
+reports:
+policies:
+agent_options:
+org_settings:
+  server_settings:
+  org_info:
+  secrets:
+controls:
+  apple_settings:
+    configuration_profiles:
+` + profileEntry
+		yamlPath := filepath.Join(dir, "gitops.yml")
+		require.NoError(t, os.WriteFile(yamlPath, []byte(config), 0o644))
+		return dir, yamlPath
+	}
+
+	t.Run("activation path is resolved to an absolute path", func(t *testing.T) {
+		dir, yamlPath := writeConfig(t, "      - path: ./lib/ddm.json\n        activation: ./lib/activation.json\n")
+
+		gitops, err := GitOpsFromFile(yamlPath, dir, nil, nopLogf)
+		require.NoError(t, err)
+
+		macOSSettings, ok := gitops.Controls.MacOSSettings.(fleet.MacOSSettings)
+		require.True(t, ok, "unexpected type %T", gitops.Controls.MacOSSettings)
+		require.Len(t, macOSSettings.CustomSettings, 1)
+
+		// The resolved path must be absolute so gitops works from any directory.
+		got := macOSSettings.CustomSettings[0].Activation
+		require.True(t, filepath.IsAbs(got), "activation path should be absolute, got %q", got)
+		require.Equal(t, filepath.Join(dir, "lib", "activation.json"), got)
+	})
+
+	t.Run("activation with a glob is rejected", func(t *testing.T) {
+		dir, yamlPath := writeConfig(t, "      - paths: ./lib/*.json\n        activation: ./lib/activation.json\n")
+
+		_, err := GitOpsFromFile(yamlPath, dir, nil, nopLogf)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `cannot use "activation" with "paths"`)
+	})
+
+	t.Run("missing activation file errors", func(t *testing.T) {
+		dir, yamlPath := writeConfig(t, "      - path: ./lib/ddm.json\n        activation: ./lib/nope.json\n")
+
+		_, err := GitOpsFromFile(yamlPath, dir, nil, nopLogf)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to read activation file")
+	})
+}

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -5600,8 +5600,10 @@ SELECT
 	hmad.assets_updated_at,
 	hmad.activation_updated_at,
 	act.identifier AS activation_identifier,
+	HEX(act.token) AS activation_token,
 	JSON_UNQUOTE(JSON_EXTRACT(mad.raw_json, '$.Type')) AS declaration_type,
-	IF(hmad.variables_updated_at IS NOT NULL AND operation_type = ?, mad.raw_json, NULL) as raw_json
+	IF(hmad.variables_updated_at IS NOT NULL AND operation_type = ?, mad.raw_json, NULL) as raw_json,
+	IF(hmad.variables_updated_at IS NOT NULL AND operation_type = ?, act.raw_json, NULL) as activation_raw_json
 FROM
 	host_mdm_apple_declarations hmad
 	JOIN mdm_apple_declarations mad ON mad.declaration_uuid = hmad.declaration_uuid
@@ -5610,7 +5612,8 @@ WHERE
 	hmad.host_uuid = ? AND hmad.scope = ?`
 
 	var res []fleet.MDMAppleDDMDeclarationItem
-	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &res, stmt, fleet.MDMOperationTypeInstall, hostUUID, scope); err != nil {
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &res, stmt,
+		fleet.MDMOperationTypeInstall, fleet.MDMOperationTypeInstall, hostUUID, scope); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "get DDM declaration items")
 	}
 
@@ -5631,6 +5634,7 @@ SELECT
 	act.raw_json,
 	mad.identifier AS configuration_identifier,
 	HEX(mad.token) AS token,
+	HEX(act.token) AS activation_token,
 	hmad.variables_updated_at,
 	hmad.assets_updated_at,
 	hmad.activation_updated_at,
@@ -5823,7 +5827,7 @@ func (ds *Datastore) MDMAppleStoreDDMStatusReport(ctx context.Context, hostUUID 
 
 	updateHostDeclarationsStmt := `
 INSERT INTO host_mdm_apple_declarations
-    (host_uuid, declaration_uuid, status, operation_type, detail, declaration_name, declaration_identifier, token, secrets_updated_at)
+    (host_uuid, declaration_uuid, status, operation_type, detail, declaration_name, declaration_identifier, token, secrets_updated_at, scope)
 VALUES
   %s
 ON DUPLICATE KEY UPDATE
@@ -5853,9 +5857,9 @@ ON DUPLICATE KEY UPDATE
 		// Skip updates for 'remove' operations because it is possible that IT admin removed a profile and then re-added it.
 		// Pending removes are cleaned up after we update status of installs.
 		if u, ok := updatesByToken[fleet.EffectiveDDMToken(c.Token, c.VariablesUpdatedAt, c.AssetsUpdatedAt, c.ActivationUpdatedAt)]; ok && c.OperationType != fleet.MDMOperationTypeRemove {
-			insertVals.WriteString("(?, ?, ?, ?, ?, ?, ?, UNHEX(?), ?),")
-			args = append(args, hostUUID, c.DeclarationUUID, u.Status, u.OperationType, u.Detail, c.Identifier, c.Name, c.Token,
-				c.SecretsUpdatedAt)
+			insertVals.WriteString("(?, ?, ?, ?, ?, ?, ?, UNHEX(?), ?, ?),")
+			args = append(args, hostUUID, c.DeclarationUUID, u.Status, u.OperationType, u.Detail, c.Name, c.Identifier, c.Token,
+				c.SecretsUpdatedAt, scope)
 		}
 	}
 

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -4801,7 +4801,13 @@ func (ds *Datastore) batchSetMDMAppleDeclarations(ctx context.Context, tx sqlx.E
 		return false, ctxerr.Wrap(ctx, err, "update declaration asset associations")
 	}
 
-	return deletedDeclarations || insertedOrUpdatedDeclarations || updatedLabels || updatedVars || updatedAssets, nil
+	updatedActivations, err := batchSetDeclarationActivationsDB(ctx, tx, incomingDeclarations, teamIDOrZero)
+	if err != nil {
+		return false, ctxerr.Wrap(ctx, err, "update declaration activations")
+	}
+
+	return deletedDeclarations || insertedOrUpdatedDeclarations || updatedLabels || updatedVars || updatedAssets ||
+		updatedActivations, nil
 }
 
 // updateDeclarationsAssetAssociations reconciles mdm_apple_declaration_asset_references
@@ -5263,7 +5269,7 @@ func (ds *Datastore) insertOrUpsertMDMAppleDeclaration(ctx context.Context, insO
 			return ctxerr.Wrap(ctx, err, "inserting declaration variable associations")
 		}
 
-		if err := setMDMAppleDDMActivationDB(ctx, tx, declUUID, tmID, declaration); err != nil {
+		if _, err := setMDMAppleDDMActivationDB(ctx, tx, declUUID, tmID, declaration); err != nil {
 			return err
 		}
 
@@ -5328,17 +5334,67 @@ func setMDMAppleDeclarationAssetReferencesDB(ctx context.Context, tx sqlx.ExtCon
 	return updatedDB, nil
 }
 
+// batchSetDeclarationActivationsDB matches declarations by name because the
+// batch upsert keys on it, so an incoming declaration's UUID isn't necessarily
+// the stored one. A declaration with no activation has any stored one removed,
+// which is how dropping the activation key from GitOps YAML clears it.
+func batchSetDeclarationActivationsDB(ctx context.Context, tx sqlx.ExtContext,
+	incomingDeclarations []*fleet.MDMAppleDeclaration, teamID uint,
+) (updatedDB bool, err error) {
+	if len(incomingDeclarations) == 0 {
+		return false, nil
+	}
+
+	names := make([]string, 0, len(incomingDeclarations))
+	for _, d := range incomingDeclarations {
+		names = append(names, d.Name)
+	}
+
+	const uuidsStmt = `SELECT name, declaration_uuid FROM mdm_apple_declarations WHERE team_id = ? AND name IN (?)`
+	stmt, args, err := sqlx.In(uuidsStmt, teamID, names)
+	if err != nil {
+		return false, ctxerr.Wrap(ctx, err, "sqlx.In resolve declaration uuids")
+	}
+	var rows []struct {
+		Name            string `db:"name"`
+		DeclarationUUID string `db:"declaration_uuid"`
+	}
+	if err := sqlx.SelectContext(ctx, tx, &rows, stmt, args...); err != nil {
+		return false, ctxerr.Wrap(ctx, err, "resolve declaration uuids")
+	}
+	uuidByName := make(map[string]string, len(rows))
+	for _, r := range rows {
+		uuidByName[r.Name] = r.DeclarationUUID
+	}
+
+	for _, d := range incomingDeclarations {
+		declUUID, ok := uuidByName[d.Name]
+		if !ok {
+			return false, ctxerr.Errorf(ctx, "declaration %q not found after upsert", d.Name)
+		}
+		updated, err := setMDMAppleDDMActivationDB(ctx, tx, declUUID, teamID, d)
+		if err != nil {
+			return false, err
+		}
+		updatedDB = updatedDB || updated
+	}
+
+	return updatedDB, nil
+}
+
 // Keyed on declaration_uuid rather than inserted fresh, so an edit keeps the
 // same activation_uuid and its variable associations survive.
 func setMDMAppleDDMActivationDB(ctx context.Context, tx sqlx.ExtContext, declUUID string, tmID uint,
 	declaration *fleet.MDMAppleDeclaration,
-) error {
+) (updatedDB bool, err error) {
 	if declaration.Activation == nil {
 		const deleteStmt = `DELETE FROM mdm_apple_ddm_activations WHERE declaration_uuid = ?`
-		if _, err := tx.ExecContext(ctx, deleteStmt, declUUID); err != nil {
-			return ctxerr.Wrap(ctx, err, "deleting declaration activation")
+		res, err := tx.ExecContext(ctx, deleteStmt, declUUID)
+		if err != nil {
+			return false, ctxerr.Wrap(ctx, err, "deleting declaration activation")
 		}
-		return nil
+		deleted, _ := res.RowsAffected()
+		return deleted > 0, nil
 	}
 
 	act := declaration.Activation
@@ -5355,11 +5411,11 @@ WHERE team_id = ? AND identifier = ? AND declaration_uuid != ?`
 	case err == nil:
 		// Not an existsError: the callers turn those into a message about the
 		// configuration profile's identifier, which isn't the one that clashed.
-		return ctxerr.Wrap(ctx, &fleet.ConflictError{
+		return false, ctxerr.Wrap(ctx, &fleet.ConflictError{
 			Message: "An activation with this identifier already exists.",
 		}, "conflicting activation identifier")
 	case !errors.Is(err, sql.ErrNoRows):
-		return ctxerr.Wrap(ctx, err, "checking for conflicting activation identifier")
+		return false, ctxerr.Wrap(ctx, err, "checking for conflicting activation identifier")
 	}
 
 	const upsertStmt = `
@@ -5384,6 +5440,15 @@ ON DUPLICATE KEY UPDATE
 	secrets_updated_at = VALUES(secrets_updated_at)
 `
 
+	// insertOnDuplicateDidInsertOrUpdate needs a LAST_INSERT_ID this table has no
+	// AUTO_INCREMENT to supply, and CLIENT_FOUND_ROWS makes RowsAffected report 1
+	// for unchanged rows. uploaded_at only advances when the content changes.
+	var prevUploadedAt sql.NullTime
+	const prevStmt = `SELECT uploaded_at FROM mdm_apple_ddm_activations WHERE declaration_uuid = ?`
+	if err := sqlx.GetContext(ctx, tx, &prevUploadedAt, prevStmt, declUUID); err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return false, ctxerr.Wrap(ctx, err, "reading current activation")
+	}
+
 	if _, err := tx.ExecContext(ctx, upsertStmt,
 		uuid.NewString(),
 		tmID,
@@ -5393,23 +5458,29 @@ ON DUPLICATE KEY UPDATE
 		declaration.Identifier,
 		act.SecretsUpdatedAt,
 	); err != nil {
-		return ctxerr.Wrap(ctx, err, "inserting declaration activation")
+		return false, ctxerr.Wrap(ctx, err, "inserting declaration activation")
 	}
 
 	// On an edit the upsert keeps the existing row, so the generated UUID is unused.
-	var activationUUID string
-	const reloadStmt = `SELECT activation_uuid FROM mdm_apple_ddm_activations WHERE declaration_uuid = ?`
-	if err := sqlx.GetContext(ctx, tx, &activationUUID, reloadStmt, declUUID); err != nil {
-		return ctxerr.Wrap(ctx, err, "reload declaration activation")
+	var reloaded struct {
+		ActivationUUID string    `db:"activation_uuid"`
+		UploadedAt     time.Time `db:"uploaded_at"`
 	}
+	const reloadStmt = `SELECT activation_uuid, uploaded_at FROM mdm_apple_ddm_activations WHERE declaration_uuid = ?`
+	if err := sqlx.GetContext(ctx, tx, &reloaded, reloadStmt, declUUID); err != nil {
+		return false, ctxerr.Wrap(ctx, err, "reload declaration activation")
+	}
+	activationUUID := reloaded.ActivationUUID
+	updatedDB = !prevUploadedAt.Valid || !prevUploadedAt.Time.Equal(reloaded.UploadedAt)
 
-	if _, err := setVariableAssociationsForColumnDB(ctx, tx, []fleet.MDMProfileUUIDFleetVariables{
+	updatedVars, err := setVariableAssociationsForColumnDB(ctx, tx, []fleet.MDMProfileUUIDFleetVariables{
 		{ProfileUUID: activationUUID, FleetVariables: act.FleetVariables},
-	}, "apple_ddm_activation_uuid"); err != nil {
-		return ctxerr.Wrap(ctx, err, "inserting activation variable associations")
+	}, "apple_ddm_activation_uuid")
+	if err != nil {
+		return false, ctxerr.Wrap(ctx, err, "inserting activation variable associations")
 	}
 
-	return nil
+	return updatedDB || updatedVars, nil
 }
 
 func batchSetDeclarationLabelAssociationsDB(ctx context.Context, tx sqlx.ExtContext,

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -5560,7 +5560,7 @@ func batchSetDeclarationLabelAssociationsDB(ctx context.Context, tx sqlx.ExtCont
 func (ds *Datastore) MDMAppleDDMDeclarationsToken(ctx context.Context, hostUUID string, scope fleet.PayloadScope) (*fleet.MDMAppleDDMDeclarationsToken, error) {
 	const stmt = `
 SELECT
-	COALESCE(MD5(CONCAT(COUNT(0), GROUP_CONCAT(CONCAT(CONCAT(HEX(mad.token), IFNULL(hmad.variables_updated_at, '')), IFNULL(hmad.assets_updated_at, ''))
+	COALESCE(MD5(CONCAT(COUNT(0), GROUP_CONCAT(CONCAT(CONCAT(CONCAT(HEX(mad.token), IFNULL(hmad.variables_updated_at, '')), IFNULL(hmad.assets_updated_at, '')), IFNULL(hmad.activation_updated_at, ''))
 		ORDER BY
 			mad.uploaded_at DESC, mad.declaration_uuid ASC separator ''))), '') AS token,
 	COALESCE(MAX(mad.created_at), NOW()) AS latest_created_timestamp
@@ -5598,10 +5598,14 @@ SELECT
 	mad.identifier, mad.declaration_uuid, status, operation_type, mad.uploaded_at,
 	hmad.variables_updated_at,
 	hmad.assets_updated_at,
+	hmad.activation_updated_at,
+	act.identifier AS activation_identifier,
+	JSON_UNQUOTE(JSON_EXTRACT(mad.raw_json, '$.Type')) AS declaration_type,
 	IF(hmad.variables_updated_at IS NOT NULL AND operation_type = ?, mad.raw_json, NULL) as raw_json
 FROM
 	host_mdm_apple_declarations hmad
 	JOIN mdm_apple_declarations mad ON mad.declaration_uuid = hmad.declaration_uuid
+	LEFT JOIN mdm_apple_ddm_activations act ON act.declaration_uuid = mad.declaration_uuid
 WHERE
 	hmad.host_uuid = ? AND hmad.scope = ?`
 
@@ -5613,6 +5617,48 @@ WHERE
 	return res, nil
 }
 
+// MDMAppleDDMActivationResponse resolves an activation request to either the
+// stored custom activation or the declaration Fleet synthesizes one for,
+// restricted to declarations the host is scoped to. RawJSON is nil for the
+// synthesized case.
+//
+// Generated activations are named after the declaration's UUID rather than its
+// identifier so an admin-chosen activation identifier can never collide with
+// one Fleet invents.
+func (ds *Datastore) MDMAppleDDMActivationResponse(ctx context.Context, identifier string, hostUUID string, scope fleet.PayloadScope) (*fleet.MDMAppleDDMActivationForDelivery, error) {
+	const stmt = `
+SELECT
+	act.raw_json,
+	mad.identifier AS configuration_identifier,
+	HEX(mad.token) AS token,
+	hmad.variables_updated_at,
+	hmad.assets_updated_at,
+	hmad.activation_updated_at,
+	mad.declaration_uuid
+FROM
+	host_mdm_apple_declarations hmad
+	JOIN mdm_apple_declarations mad ON mad.declaration_uuid = hmad.declaration_uuid
+	LEFT JOIN mdm_apple_ddm_activations act ON act.declaration_uuid = mad.declaration_uuid
+WHERE
+	hmad.host_uuid = ? AND hmad.scope = ? AND hmad.operation_type = ?
+	AND (
+		act.identifier = ?
+		OR (act.activation_uuid IS NULL AND CONCAT(mad.declaration_uuid, ?) = ?)
+	)`
+
+	var res fleet.MDMAppleDDMActivationForDelivery
+	if err := sqlx.GetContext(ctx, ds.reader(ctx), &res, stmt,
+		hostUUID, scope, fleet.MDMOperationTypeInstall,
+		identifier, fleet.MDMAppleGeneratedActivationSuffix, identifier,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, notFound("MDMAppleActivation").WithName(identifier)
+		}
+		return nil, ctxerr.Wrap(ctx, err, "get ddm activation response")
+	}
+	return &res, nil
+}
+
 func (ds *Datastore) MDMAppleDDMDeclarationsResponse(ctx context.Context, identifier string, hostUUID string, scope fleet.PayloadScope) (*fleet.MDMAppleDeclaration, error) {
 	// TODO: When hosts table is indexed by uuid, consider joining on hosts to ensure that the
 	// declaration for the host's current team is returned. In the case where the specified
@@ -5620,7 +5666,8 @@ func (ds *Datastore) MDMAppleDDMDeclarationsResponse(ctx context.Context, identi
 	// declarations are removed, but the join would provide an extra layer of safety.
 	const stmt = `
 SELECT
-	mad.declaration_uuid, mad.raw_json, HEX(mad.token) as token, hmad.variables_updated_at, hmad.assets_updated_at
+	mad.declaration_uuid, mad.raw_json, HEX(mad.token) as token,
+	hmad.variables_updated_at, hmad.assets_updated_at, hmad.activation_updated_at
 FROM
 	host_mdm_apple_declarations hmad
 	JOIN mdm_apple_declarations mad ON hmad.declaration_uuid = mad.declaration_uuid
@@ -5805,7 +5852,7 @@ ON DUPLICATE KEY UPDATE
 	for _, c := range current {
 		// Skip updates for 'remove' operations because it is possible that IT admin removed a profile and then re-added it.
 		// Pending removes are cleaned up after we update status of installs.
-		if u, ok := updatesByToken[fleet.EffectiveDDMToken(c.Token, c.VariablesUpdatedAt, c.AssetsUpdatedAt)]; ok && c.OperationType != fleet.MDMOperationTypeRemove {
+		if u, ok := updatesByToken[fleet.EffectiveDDMToken(c.Token, c.VariablesUpdatedAt, c.AssetsUpdatedAt, c.ActivationUpdatedAt)]; ok && c.OperationType != fleet.MDMOperationTypeRemove {
 			insertVals.WriteString("(?, ?, ?, ?, ?, ?, ?, UNHEX(?), ?),")
 			args = append(args, hostUUID, c.DeclarationUUID, u.Status, u.OperationType, u.Detail, c.Identifier, c.Name, c.Token,
 				c.SecretsUpdatedAt)

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -5816,7 +5816,7 @@ func cleanUpDuplicateRemoveInstall(ctx context.Context, tx sqlx.ExtContext, prof
 // scoped to that channel or the other channel's rows would look "removed".
 func (ds *Datastore) MDMAppleStoreDDMStatusReport(ctx context.Context, hostUUID string, scope fleet.PayloadScope, updates []*fleet.MDMAppleHostDeclaration) error {
 	getHostDeclarationsStmt := `
-    SELECT host_uuid, status, operation_type, HEX(token) as token, secrets_updated_at, variables_updated_at, assets_updated_at, declaration_uuid, declaration_identifier, declaration_name
+    SELECT host_uuid, status, operation_type, HEX(token) as token, secrets_updated_at, variables_updated_at, assets_updated_at, activation_updated_at, declaration_uuid, declaration_identifier, declaration_name
     FROM host_mdm_apple_declarations
     WHERE host_uuid = ? AND scope = ?
   `

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -5599,22 +5599,56 @@ SELECT
 	hmad.variables_updated_at,
 	hmad.assets_updated_at,
 	hmad.activation_updated_at,
-	act.identifier AS activation_identifier,
-	HEX(act.token) AS activation_token,
 	JSON_UNQUOTE(JSON_EXTRACT(mad.raw_json, '$.Type')) AS declaration_type,
-	IF(hmad.variables_updated_at IS NOT NULL AND operation_type = ?, mad.raw_json, NULL) as raw_json,
-	IF(hmad.variables_updated_at IS NOT NULL AND operation_type = ?, act.raw_json, NULL) as activation_raw_json
+	IF(hmad.variables_updated_at IS NOT NULL AND operation_type = ?, mad.raw_json, NULL) as raw_json
 FROM
 	host_mdm_apple_declarations hmad
 	JOIN mdm_apple_declarations mad ON mad.declaration_uuid = hmad.declaration_uuid
-	LEFT JOIN mdm_apple_ddm_activations act ON act.declaration_uuid = mad.declaration_uuid
 WHERE
 	hmad.host_uuid = ? AND hmad.scope = ?`
 
 	var res []fleet.MDMAppleDDMDeclarationItem
 	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &res, stmt,
-		fleet.MDMOperationTypeInstall, fleet.MDMOperationTypeInstall, hostUUID, scope); err != nil {
+		fleet.MDMOperationTypeInstall, hostUUID, scope); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "get DDM declaration items")
+	}
+
+	return res, nil
+}
+
+// ListCustomActivationsForDeclarations returns the custom activations attached
+// to the given declarations. Declarations without one are simply absent, and
+// the caller synthesizes Fleet's activation for those.
+func (ds *Datastore) ListCustomActivationsForDeclarations(ctx context.Context, declUUIDs []string) ([]*fleet.MDMAppleDDMActivationItem, error) {
+	if len(declUUIDs) == 0 {
+		return nil, nil
+	}
+
+	// Custom host vitals aren't recorded in mdm_configuration_profile_variables,
+	// so they only show up by scanning the body -- same approach as the reconciler.
+	const stmt = `
+SELECT
+	act.declaration_uuid,
+	act.identifier,
+	HEX(act.token) AS token,
+	act.raw_json,
+	(
+		EXISTS(SELECT 1 FROM mdm_configuration_profile_variables v WHERE v.apple_ddm_activation_uuid = act.activation_uuid)
+		OR INSTR(act.raw_json, ?) > 0
+	) AS has_fleet_variables
+FROM
+	mdm_apple_ddm_activations act
+WHERE
+	act.declaration_uuid IN (?)`
+
+	q, args, err := sqlx.In(stmt, fleet.CustomHostVitalPrefix, declUUIDs)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "build custom activations query")
+	}
+
+	var res []*fleet.MDMAppleDDMActivationItem
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &res, q, args...); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "list custom activations for declarations")
 	}
 
 	return res, nil

--- a/server/datastore/mysql/apple_mdm_batched.go
+++ b/server/datastore/mysql/apple_mdm_batched.go
@@ -646,8 +646,20 @@ func (ds *Datastore) listAppleDeclarationsForReconcileTransaction(ctx context.Co
 		declUUIDs = append(declUUIDs, u)
 	}
 	if len(declUUIDs) > 0 {
-		const varsStmt = `SELECT DISTINCT apple_declaration_uuid FROM mdm_configuration_profile_variables WHERE apple_declaration_uuid IN (?)`
-		q, args, err := sqlx.In(varsStmt, declUUIDs)
+		// A variable may live only in the custom activation, which is recorded
+		// against apple_ddm_activation_uuid. Missing those leaves the owning
+		// declaration unstamped, so the host never re-fetches when the value
+		// changes.
+		const varsStmt = `
+SELECT DISTINCT apple_declaration_uuid AS declaration_uuid
+FROM mdm_configuration_profile_variables
+WHERE apple_declaration_uuid IN (?)
+UNION
+SELECT DISTINCT act.declaration_uuid
+FROM mdm_configuration_profile_variables v
+	JOIN mdm_apple_ddm_activations act ON act.activation_uuid = v.apple_ddm_activation_uuid
+WHERE act.declaration_uuid IN (?)`
+		q, args, err := sqlx.In(varsStmt, declUUIDs, declUUIDs)
 		if err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "build apple declaration variables query")
 		}

--- a/server/datastore/mysql/apple_mdm_batched.go
+++ b/server/datastore/mysql/apple_mdm_batched.go
@@ -714,6 +714,56 @@ func (ds *Datastore) listAppleDeclarationsForReconcileTransaction(ctx context.Co
 				d.AssetsUpdatedAt = &t
 			}
 		}
+
+		// Same idea for a custom activation: editing it bumps its uploaded_at,
+		// which re-syncs the declaration it activates.
+		// GREATEST so a secret re-stamp counts as a change even when the
+		// activation itself wasn't re-uploaded. COALESCE because GREATEST
+		// returns NULL if any argument is NULL.
+		const activationsStmt = `
+			SELECT declaration_uuid,
+				GREATEST(uploaded_at, COALESCE(secrets_updated_at, uploaded_at)) AS activation_updated_at
+			FROM mdm_apple_ddm_activations
+			WHERE declaration_uuid IN (?)`
+		cq, cargs, err := sqlx.In(activationsStmt, declUUIDs)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "build apple declaration activations query")
+		}
+		type activationRow struct {
+			DeclarationUUID     string       `db:"declaration_uuid"`
+			ActivationUpdatedAt sql.NullTime `db:"activation_updated_at"`
+		}
+		var activationRows []activationRow
+		if err := sqlx.SelectContext(ctx, tx, &activationRows, cq, cargs...); err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "select apple declarations with custom activations")
+		}
+		for _, cr := range activationRows {
+			if d, ok := byUUID[cr.DeclarationUUID]; ok && cr.ActivationUpdatedAt.Valid {
+				t := cr.ActivationUpdatedAt.Time
+				d.ActivationUpdatedAt = &t
+			}
+		}
+
+		// A declaration whose activation uses Fleet variables needs the same
+		// per-host token busting as one that uses them itself.
+		const actVarsStmt = `
+			SELECT DISTINCT a.declaration_uuid
+			FROM mdm_apple_ddm_activations a
+			JOIN mdm_configuration_profile_variables v ON v.apple_ddm_activation_uuid = a.activation_uuid
+			WHERE a.declaration_uuid IN (?)`
+		avq, avargs, err := sqlx.In(actVarsStmt, declUUIDs)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "build apple activation variables query")
+		}
+		var withActVars []string
+		if err := sqlx.SelectContext(ctx, tx, &withActVars, avq, avargs...); err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "select apple activations with fleet variables")
+		}
+		for _, u := range withActVars {
+			if d, ok := byUUID[u]; ok {
+				d.HasFleetVariables = true
+			}
+		}
 	}
 
 	return out, nil
@@ -752,6 +802,7 @@ func (ds *Datastore) bulkGetHostMDMAppleDeclarationsByUUIDsTransaction(
 			secrets_updated_at,
 			variables_updated_at,
 			assets_updated_at,
+			activation_updated_at,
 			scope
 		FROM host_mdm_apple_declarations
 		WHERE host_uuid IN (?)
@@ -915,7 +966,8 @@ func (ds *Datastore) BulkUpsertMDMAppleHostDeclarations(
 	const baseStmt = `
 		INSERT INTO host_mdm_apple_declarations
 		  (host_uuid, declaration_uuid, declaration_identifier, declaration_name,
-		   status, operation_type, token, secrets_updated_at, variables_updated_at, assets_updated_at, scope)
+		   status, operation_type, token, secrets_updated_at, variables_updated_at, assets_updated_at,
+		   activation_updated_at, scope)
 		VALUES %s
 		ON DUPLICATE KEY UPDATE
 		  status = VALUES(status),
@@ -926,6 +978,7 @@ func (ds *Datastore) BulkUpsertMDMAppleHostDeclarations(
 		  secrets_updated_at = VALUES(secrets_updated_at),
 		  variables_updated_at = VALUES(variables_updated_at),
 		  assets_updated_at = VALUES(assets_updated_at),
+		  activation_updated_at = VALUES(activation_updated_at),
 		  scope = VALUES(scope)
 	`
 
@@ -935,7 +988,7 @@ func (ds *Datastore) BulkUpsertMDMAppleHostDeclarations(
 		batch := rows[i:end]
 
 		valueParts := make([]string, 0, len(batch))
-		args := make([]any, 0, len(batch)*10)
+		args := make([]any, 0, len(batch)*12)
 		batchByKey := make(map[string]*fleet.MDMAppleHostDeclaration, len(batch))
 		for _, r := range batch {
 			// Scope defaults to System
@@ -943,10 +996,11 @@ func (ds *Datastore) BulkUpsertMDMAppleHostDeclarations(
 			if scope == "" {
 				scope = fleet.PayloadScopeSystem
 			}
-			valueParts = append(valueParts, "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
+			valueParts = append(valueParts, "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
 			args = append(args,
 				r.HostUUID, r.DeclarationUUID, r.Identifier, r.Name,
-				r.Status, r.OperationType, r.Token, r.SecretsUpdatedAt, r.VariablesUpdatedAt, r.AssetsUpdatedAt, scope,
+				r.Status, r.OperationType, r.Token, r.SecretsUpdatedAt, r.VariablesUpdatedAt, r.AssetsUpdatedAt,
+				r.ActivationUpdatedAt, scope,
 			)
 			batchByKey[fmt.Sprintf("%s\n%s", r.HostUUID, r.DeclarationUUID)] = r
 		}

--- a/server/datastore/mysql/apple_mdm_batched.go
+++ b/server/datastore/mysql/apple_mdm_batched.go
@@ -684,6 +684,24 @@ func (ds *Datastore) listAppleDeclarationsForReconcileTransaction(ctx context.Co
 			}
 		}
 
+		// Same scan against custom activations: they're expanded at delivery like
+		// the declaration body, so a vital referenced only from the activation
+		// still has to stamp variables_updated_at on the owning declaration.
+		const actVitalsStmt = `SELECT declaration_uuid FROM mdm_apple_ddm_activations WHERE declaration_uuid IN (?) AND INSTR(raw_json, ?) > 0`
+		q, args, err = sqlx.In(actVitalsStmt, declUUIDs, fleet.CustomHostVitalPrefix)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "build activation custom host vitals query")
+		}
+		var actWithVitals []string
+		if err := sqlx.SelectContext(ctx, tx, &actWithVitals, q, args...); err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "select activations with custom host vitals")
+		}
+		for _, u := range actWithVitals {
+			if d, ok := byUUID[u]; ok {
+				d.HasFleetVariables = true
+			}
+		}
+
 		// For declarations that reference DDM assets, load the most recent
 		// uploaded_at across their referenced assets. The reconciler stamps this
 		// onto host_mdm_apple_declarations.assets_updated_at so that editing an
@@ -988,6 +1006,8 @@ func (ds *Datastore) BulkUpsertMDMAppleHostDeclarations(
 		batch := rows[i:end]
 
 		valueParts := make([]string, 0, len(batch))
+		// Keep the per-row placeholder count under 60: MySQL caps a prepared
+		// statement at 65535 placeholders, and each batch binds batchSize rows.
 		args := make([]any, 0, len(batch)*12)
 		batchByKey := make(map[string]*fleet.MDMAppleHostDeclaration, len(batch))
 		for _, r := range batch {

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -95,6 +95,7 @@ func TestMDMApple(t *testing.T) {
 		{"ScreenDEPAssignProfileSerialsForCooldown", testScreenDEPAssignProfileSerialsForCooldown},
 		{"MDMAppleDDMDeclarationsToken", testMDMAppleDDMDeclarationsToken},
 		{"MDMAppleCustomActivations", testMDMAppleCustomActivations},
+		{"MDMAppleBatchCustomActivations", testMDMAppleBatchCustomActivations},
 		{"NewMDMAppleDeclarationSoftwareUpdateTracking", testNewMDMAppleDeclarationSoftwareUpdateTracking},
 		{"SetOrUpdateMDMAppleDeclarationSoftwareUpdateTracking", testSetOrUpdateMDMAppleDeclarationSoftwareUpdateTracking},
 		{"MDMAppleSetPendingDeclarationsAs", testMDMAppleSetPendingDeclarationsAs},
@@ -14325,4 +14326,81 @@ func testAppleOSUpdateAssets(t *testing.T, ds *Datastore) {
 		require.EqualValues(t, 0, deleted)
 		require.Len(t, listed()["ios"], 1)
 	})
+}
+
+func testMDMAppleBatchCustomActivations(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	declRaw := []byte(`{"Type":"com.apple.configuration.passcode.settings","Identifier":"com.fleet.batch.cfg","Payload":{"Echo":"foo"}}`)
+	actRaw := []byte(`{"Type":"com.apple.activation.simple","Identifier":"com.fleet.batch.act","Payload":{"StandardConfigurations":["com.fleet.batch.cfg"],"Predicate":"TRUEPREDICATE"}}`)
+
+	decl := func(activation *fleet.MDMAppleCustomActivation) *fleet.MDMAppleDeclaration {
+		return &fleet.MDMAppleDeclaration{
+			Identifier: "com.fleet.batch.cfg",
+			Name:       "batch-cfg",
+			RawJSON:    declRaw,
+			Activation: activation,
+		}
+	}
+	withActivation := func(raw []byte) *fleet.MDMAppleCustomActivation {
+		return &fleet.MDMAppleCustomActivation{
+			Identifier:              "com.fleet.batch.act",
+			RawJSON:                 raw,
+			ConfigurationIdentifier: "com.fleet.batch.cfg",
+		}
+	}
+
+	countActivations := func() int {
+		var n int
+		require.NoError(t, sqlx.GetContext(ctx, ds.reader(ctx), &n, `SELECT COUNT(*) FROM mdm_apple_ddm_activations`))
+		return n
+	}
+
+	updates, err := ds.BatchSetMDMProfiles(ctx, nil, nil, nil,
+		[]*fleet.MDMAppleDeclaration{decl(withActivation(actRaw))}, nil, nil)
+	require.NoError(t, err)
+	require.True(t, updates.AppleDeclaration)
+	require.Equal(t, 1, countActivations())
+
+	var stored []byte
+	require.NoError(t, sqlx.GetContext(ctx, ds.reader(ctx), &stored,
+		`SELECT raw_json FROM mdm_apple_ddm_activations WHERE identifier = 'com.fleet.batch.act'`))
+	require.JSONEq(t, string(actRaw), string(stored))
+
+	// Changing only the activation must report an update, or the batch path
+	// won't emit an edited-declaration activity.
+	editedAct := []byte(`{"Type":"com.apple.activation.simple","Identifier":"com.fleet.batch.act","Payload":{"StandardConfigurations":["com.fleet.batch.cfg"],"Predicate":"FALSEPREDICATE"}}`)
+	updates, err = ds.BatchSetMDMProfiles(ctx, nil, nil, nil,
+		[]*fleet.MDMAppleDeclaration{decl(withActivation(editedAct))}, nil, nil)
+	require.NoError(t, err)
+	require.True(t, updates.AppleDeclaration, "an activation-only change must count as an update")
+
+	require.NoError(t, sqlx.GetContext(ctx, ds.reader(ctx), &stored,
+		`SELECT raw_json FROM mdm_apple_ddm_activations WHERE identifier = 'com.fleet.batch.act'`))
+	require.JSONEq(t, string(editedAct), string(stored))
+	require.Equal(t, 1, countActivations(), "editing must reuse the row, not add one")
+
+	// Re-applying identical content must report no change, or every gitops run
+	// would emit an edited-declaration activity.
+	updates, err = ds.BatchSetMDMProfiles(ctx, nil, nil, nil,
+		[]*fleet.MDMAppleDeclaration{decl(withActivation(editedAct))}, nil, nil)
+	require.NoError(t, err)
+	require.False(t, updates.AppleDeclaration, "an unchanged re-apply must not count as an update")
+
+	// Dropping the activation key from GitOps YAML removes the stored one.
+	updates, err = ds.BatchSetMDMProfiles(ctx, nil, nil, nil,
+		[]*fleet.MDMAppleDeclaration{decl(nil)}, nil, nil)
+	require.NoError(t, err)
+	require.True(t, updates.AppleDeclaration)
+	require.Zero(t, countActivations())
+
+	// And removing the declaration entirely cascades.
+	_, err = ds.BatchSetMDMProfiles(ctx, nil, nil, nil,
+		[]*fleet.MDMAppleDeclaration{decl(withActivation(actRaw))}, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, countActivations())
+
+	_, err = ds.BatchSetMDMProfiles(ctx, nil, nil, nil, []*fleet.MDMAppleDeclaration{}, nil, nil)
+	require.NoError(t, err)
+	require.Zero(t, countActivations())
 }

--- a/server/datastore/mysql/custom_host_vitals.go
+++ b/server/datastore/mysql/custom_host_vitals.go
@@ -382,10 +382,15 @@ func resendMDMProfilesForCustomHostVital(ctx context.Context, tx sqlx.ExtContext
 			JOIN mdm_windows_configuration_profiles mwcp ON mwcp.profile_uuid = hmwp.profile_uuid
 			WHERE hmwp.host_uuid = ? AND hmwp.operation_type = ? AND hmwp.status IS NOT NULL AND INSTR(mwcp.syncml, ?) > 0`
 
-		customHostVitalResendAppleDeclarationsSelectStmt = `SELECT hmad.declaration_uuid AS uuid, mad.raw_json AS contents
+		// A custom activation is expanded at delivery like the declaration, so a
+		// vital referenced only there has to resend the owning declaration too.
+		customHostVitalResendAppleDeclarationsSelectStmt = `SELECT hmad.declaration_uuid AS uuid,
+				CONCAT(mad.raw_json, ' ', COALESCE(act.raw_json, '')) AS contents
 			FROM host_mdm_apple_declarations hmad
 			JOIN mdm_apple_declarations mad ON mad.declaration_uuid = hmad.declaration_uuid
-			WHERE hmad.host_uuid = ? AND hmad.operation_type = ? AND hmad.status IS NOT NULL AND INSTR(mad.raw_json, ?) > 0`
+			LEFT JOIN mdm_apple_ddm_activations act ON act.declaration_uuid = mad.declaration_uuid
+			WHERE hmad.host_uuid = ? AND hmad.operation_type = ? AND hmad.status IS NOT NULL
+				AND INSTR(CONCAT(mad.raw_json, ' ', COALESCE(act.raw_json, '')), ?) > 0`
 
 		customHostVitalResendAndroidProfilesSelectStmt = `SELECT hmap.profile_uuid AS uuid, macp.raw_json AS contents
 			FROM host_mdm_android_profiles hmap

--- a/server/datastore/mysql/scim.go
+++ b/server/datastore/mysql/scim.go
@@ -1446,8 +1446,11 @@ func triggerResendProfilesUsingVariables(ctx context.Context, tx sqlx.ExtContext
 		JOIN mdm_apple_declarations mad
 			ON (mad.team_id = h.team_id OR (COALESCE(mad.team_id, 0) = 0 AND h.team_id IS NULL)) AND
 				 mad.declaration_uuid = hmad.declaration_uuid
+		LEFT JOIN mdm_apple_ddm_activations act
+			ON act.declaration_uuid = mad.declaration_uuid
 		JOIN mdm_configuration_profile_variables mcpv
 			ON mcpv.apple_declaration_uuid = mad.declaration_uuid
+				OR mcpv.apple_ddm_activation_uuid = act.activation_uuid
 		JOIN fleet_variables fv
 			ON mcpv.fleet_variable_id = fv.id
 	SET

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -561,6 +561,9 @@ type AppleDeclarationForReconcile struct {
 	// effective token and re-syncs the host, even when the declaration's own
 	// content/token is unchanged. Mirrors HasFleetVariables/VariablesUpdatedAt.
 	AssetsUpdatedAt *time.Time
+
+	// uploaded_at of the custom activation attached to this declaration, if any.
+	ActivationUpdatedAt *time.Time
 }
 
 // AppleLabeledEntity implementation.
@@ -952,24 +955,22 @@ type MDMAppleDeclaration struct {
 	// Nil removes any stored activation on write, which is how one is cleared.
 	Activation *MDMAppleCustomActivation `db:"-" json:"-"`
 
-	CreatedAt          time.Time  `db:"created_at" json:"created_at"`
-	UploadedAt         time.Time  `db:"uploaded_at" json:"uploaded_at"`
-	SecretsUpdatedAt   *time.Time `db:"secrets_updated_at" json:"-"`
-	VariablesUpdatedAt *time.Time `db:"variables_updated_at" json:"-"`
-	AssetsUpdatedAt    *time.Time `db:"assets_updated_at" json:"-"`
+	CreatedAt           time.Time  `db:"created_at" json:"created_at"`
+	UploadedAt          time.Time  `db:"uploaded_at" json:"uploaded_at"`
+	SecretsUpdatedAt    *time.Time `db:"secrets_updated_at" json:"-"`
+	VariablesUpdatedAt  *time.Time `db:"variables_updated_at" json:"-"`
+	AssetsUpdatedAt     *time.Time `db:"assets_updated_at" json:"-"`
+	ActivationUpdatedAt *time.Time `db:"activation_updated_at" json:"-"`
 }
 
-// EffectiveDDMToken computes the per-declaration token that incorporates the
-// static content hash together with the host-specific variables_updated_at
-// and/or assets_updated_at timestamps. When both are nil (the declaration
-// references no Fleet variables or DDM assets), the effective token equals
-// the static token unchanged.
-func EffectiveDDMToken(staticToken string, variablesUpdatedAt *time.Time, assetsUpdatedAt *time.Time) string {
-	if variablesUpdatedAt == nil && assetsUpdatedAt == nil {
+// Folds host-specific timestamps into the static content hash so a change to
+// anything the declaration depends on moves the token.
+func EffectiveDDMToken(staticToken string, variablesUpdatedAt, assetsUpdatedAt, activationUpdatedAt *time.Time) string {
+	if variablesUpdatedAt == nil && assetsUpdatedAt == nil && activationUpdatedAt == nil {
 		return staticToken
 	}
-	// Must match MySQL's DATETIME(6) string representation used in
-	// MDMAppleDDMDeclarationsToken's IFNULL(hmad.variables_updated_at, '') and IFNULL(hmad.assets_updated_at, '').
+	// Order and format must match MDMAppleDDMDeclarationsToken's CONCAT exactly,
+	// or every host re-syncs on every check-in.
 	hasher := md5.New() // nolint:gosec // used for declarative management token
 	hasher.Write([]byte(staticToken))
 	if variablesUpdatedAt != nil {
@@ -977,6 +978,9 @@ func EffectiveDDMToken(staticToken string, variablesUpdatedAt *time.Time, assets
 	}
 	if assetsUpdatedAt != nil {
 		hasher.Write([]byte(assetsUpdatedAt.Format("2006-01-02 15:04:05.000000")))
+	}
+	if activationUpdatedAt != nil {
+		hasher.Write([]byte(activationUpdatedAt.Format("2006-01-02 15:04:05.000000")))
 	}
 	return hex.EncodeToString(hasher.Sum(nil))
 }
@@ -1184,6 +1188,10 @@ type MDMAppleHostDeclaration struct {
 	// were last computed. Non-null only for declarations that use Fleet assets.
 	AssetsUpdatedAt *time.Time `db:"assets_updated_at" json:"-"`
 
+	// ActivationUpdatedAt tracks the uploaded_at of this declaration's custom
+	// activation. Non-null only for declarations that have one.
+	ActivationUpdatedAt *time.Time `db:"activation_updated_at" json:"-"`
+
 	// Scope is the channel this declaration is delivered on for the host,
 	// mirrored from the declaration's scope so the DDM serving queries can
 	// filter per channel. "System" (default) is the device channel, "User" the
@@ -1196,6 +1204,7 @@ func (p MDMAppleHostDeclaration) Equal(other MDMAppleHostDeclaration) bool {
 	secretsEqual := p.SecretsUpdatedAt == nil && other.SecretsUpdatedAt == nil || p.SecretsUpdatedAt != nil && other.SecretsUpdatedAt != nil && p.SecretsUpdatedAt.Equal(*other.SecretsUpdatedAt)
 	varsEqual := p.VariablesUpdatedAt == nil && other.VariablesUpdatedAt == nil || p.VariablesUpdatedAt != nil && other.VariablesUpdatedAt != nil && p.VariablesUpdatedAt.Equal(*other.VariablesUpdatedAt)
 	assetsEqual := p.AssetsUpdatedAt == nil && other.AssetsUpdatedAt == nil || p.AssetsUpdatedAt != nil && other.AssetsUpdatedAt != nil && p.AssetsUpdatedAt.Equal(*other.AssetsUpdatedAt)
+	activationEqual := p.ActivationUpdatedAt == nil && other.ActivationUpdatedAt == nil || p.ActivationUpdatedAt != nil && other.ActivationUpdatedAt != nil && p.ActivationUpdatedAt.Equal(*other.ActivationUpdatedAt)
 	return statusEqual &&
 		p.HostUUID == other.HostUUID &&
 		p.DeclarationUUID == other.DeclarationUUID &&
@@ -1207,7 +1216,8 @@ func (p MDMAppleHostDeclaration) Equal(other MDMAppleHostDeclaration) bool {
 		p.Scope == other.Scope &&
 		secretsEqual &&
 		varsEqual &&
-		assetsEqual
+		assetsEqual &&
+		activationEqual
 }
 
 func NewMDMAppleDeclaration(raw []byte, teamID *uint, name string, declType, ident string) *MDMAppleDeclaration {
@@ -1221,6 +1231,23 @@ func NewMDMAppleDeclaration(raw []byte, teamID *uint, name string, declType, ide
 
 	return &decl
 }
+
+// MDMAppleDDMActivationForDelivery is a stored custom activation together with
+// the per-host timestamps needed to compute its ServerToken.
+type MDMAppleDDMActivationForDelivery struct {
+	// Nil when the host asked for an activation Fleet synthesizes; the LEFT
+	// JOIN yields NULL there, which json.RawMessage can't scan.
+	RawJSON                 []byte     `db:"raw_json"`
+	ConfigurationIdentifier string     `db:"configuration_identifier"`
+	Token                   string     `db:"token"`
+	VariablesUpdatedAt      *time.Time `db:"variables_updated_at"`
+	AssetsUpdatedAt         *time.Time `db:"assets_updated_at"`
+	ActivationUpdatedAt     *time.Time `db:"activation_updated_at"`
+	DeclarationUUID         string     `db:"declaration_uuid"`
+}
+
+// Suffix Fleet appends to a declaration's UUID when synthesizing an activation.
+const MDMAppleGeneratedActivationSuffix = ".activation"
 
 // MDMAppleDDMTokensResponse is the response from the DDM tokens endpoint.
 //
@@ -1283,7 +1310,12 @@ type MDMAppleDDMDeclarationItem struct {
 	// AssetsUpdatedAt is not part of the DDM profile, but part of the host-ddm tuple, as the assets'
 	// values depend on the host. It is used to compute the token for the DDM for a specific host, as the
 	// ServerToken field is just for the static token of the DDM.
-	AssetsUpdatedAt *time.Time `db:"assets_updated_at"`
+	AssetsUpdatedAt     *time.Time `db:"assets_updated_at"`
+	ActivationUpdatedAt *time.Time `db:"activation_updated_at"`
+	// Identifier of the custom activation attached to this declaration; nil
+	// means Fleet synthesizes one.
+	ActivationIdentifier *string `db:"activation_identifier"`
+	DeclarationType      *string `db:"declaration_type"`
 	// RawJSON is conditionally loaded only for declarations that use Fleet
 	// variables (variables_updated_at IS NOT NULL and operation_type = 'install')
 	// so that handleDeclarationItems can check variable resolution without an
@@ -1383,6 +1415,12 @@ type MDMAppleDDMErrors struct {
 // A status report that contains details about an error.
 //
 // https://developer.apple.com/documentation/devicemanagement/statusreason
+// Reason codes Apple returns for activation predicates.
+const (
+	MDMAppleDDMReasonPredicate        = "Info.Predicate"
+	MDMAppleDDMReasonActivationFailed = "Error.ActivationFailed"
+)
+
 type MDMAppleDDMStatusErrorReason struct {
 	// Code is the error code for this error.
 	Code string `json:"Code"`

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -1315,7 +1315,7 @@ type MDMAppleDDMDeclarationItem struct {
 	// ServerToken field is just for the static token of the DDM.
 	AssetsUpdatedAt     *time.Time `db:"assets_updated_at"`
 	ActivationUpdatedAt *time.Time `db:"activation_updated_at"`
-	DeclarationType *string `db:"declaration_type"`
+	DeclarationType     *string    `db:"declaration_type"`
 	// RawJSON is conditionally loaded only for declarations that use Fleet
 	// variables (variables_updated_at IS NOT NULL and operation_type = 'install')
 	// so that handleDeclarationItems can check variable resolution without an

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -1315,23 +1315,28 @@ type MDMAppleDDMDeclarationItem struct {
 	// ServerToken field is just for the static token of the DDM.
 	AssetsUpdatedAt     *time.Time `db:"assets_updated_at"`
 	ActivationUpdatedAt *time.Time `db:"activation_updated_at"`
-	// Identifier of the custom activation attached to this declaration; nil
-	// means Fleet synthesizes one.
-	ActivationIdentifier *string `db:"activation_identifier"`
-	// ActivationToken is the custom activation's own token, so editing the
-	// declaration or one of its assets doesn't re-sync the activation. Nil
-	// alongside ActivationIdentifier when Fleet synthesizes the activation.
-	ActivationToken *string `db:"activation_token"`
 	DeclarationType *string `db:"declaration_type"`
 	// RawJSON is conditionally loaded only for declarations that use Fleet
 	// variables (variables_updated_at IS NOT NULL and operation_type = 'install')
 	// so that handleDeclarationItems can check variable resolution without an
 	// extra query.
 	RawJSON *json.RawMessage `db:"raw_json"`
-	// ActivationRawJSON is the custom activation's body, loaded under the same
-	// condition as RawJSON. Fleet variables in an activation are expanded at
-	// delivery too, so they have to be preflighted alongside the declaration.
-	ActivationRawJSON *json.RawMessage `db:"activation_raw_json"`
+}
+
+// MDMAppleDDMActivationItem is a custom activation as the manifest needs it:
+// its own identifier and token, plus enough to know whether its Fleet variables
+// resolve for a host. Kept apart from MDMAppleDDMDeclarationItem so the
+// activation section of the manifest is built from activation data rather than
+// columns carried along on each declaration row.
+type MDMAppleDDMActivationItem struct {
+	DeclarationUUID string `db:"declaration_uuid"`
+	Identifier      string `db:"identifier"`
+	// Token is the activation's own token, hex-encoded.
+	Token   string `db:"token"`
+	RawJSON []byte `db:"raw_json"`
+	// HasFleetVariables covers both recorded Fleet variables and custom host
+	// vitals, which are only detectable by scanning the body.
+	HasFleetVariables bool `db:"has_fleet_variables"`
 }
 
 // MDMAppleDDMDeclarationResponse represents a declaration in the datastore. It is used for the DDM

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -1237,13 +1237,16 @@ func NewMDMAppleDeclaration(raw []byte, teamID *uint, name string, declType, ide
 type MDMAppleDDMActivationForDelivery struct {
 	// Nil when the host asked for an activation Fleet synthesizes; the LEFT
 	// JOIN yields NULL there, which json.RawMessage can't scan.
-	RawJSON                 []byte     `db:"raw_json"`
-	ConfigurationIdentifier string     `db:"configuration_identifier"`
-	Token                   string     `db:"token"`
-	VariablesUpdatedAt      *time.Time `db:"variables_updated_at"`
-	AssetsUpdatedAt         *time.Time `db:"assets_updated_at"`
-	ActivationUpdatedAt     *time.Time `db:"activation_updated_at"`
-	DeclarationUUID         string     `db:"declaration_uuid"`
+	RawJSON                 []byte `db:"raw_json"`
+	ConfigurationIdentifier string `db:"configuration_identifier"`
+	Token                   string `db:"token"`
+	// ActivationToken is the custom activation's own token, empty when Fleet
+	// synthesizes the activation. Must match what the manifest advertised.
+	ActivationToken     *string    `db:"activation_token"`
+	VariablesUpdatedAt  *time.Time `db:"variables_updated_at"`
+	AssetsUpdatedAt     *time.Time `db:"assets_updated_at"`
+	ActivationUpdatedAt *time.Time `db:"activation_updated_at"`
+	DeclarationUUID     string     `db:"declaration_uuid"`
 }
 
 // Suffix Fleet appends to a declaration's UUID when synthesizing an activation.
@@ -1315,12 +1318,20 @@ type MDMAppleDDMDeclarationItem struct {
 	// Identifier of the custom activation attached to this declaration; nil
 	// means Fleet synthesizes one.
 	ActivationIdentifier *string `db:"activation_identifier"`
-	DeclarationType      *string `db:"declaration_type"`
+	// ActivationToken is the custom activation's own token, so editing the
+	// declaration or one of its assets doesn't re-sync the activation. Nil
+	// alongside ActivationIdentifier when Fleet synthesizes the activation.
+	ActivationToken *string `db:"activation_token"`
+	DeclarationType *string `db:"declaration_type"`
 	// RawJSON is conditionally loaded only for declarations that use Fleet
 	// variables (variables_updated_at IS NOT NULL and operation_type = 'install')
 	// so that handleDeclarationItems can check variable resolution without an
 	// extra query.
 	RawJSON *json.RawMessage `db:"raw_json"`
+	// ActivationRawJSON is the custom activation's body, loaded under the same
+	// condition as RawJSON. Fleet variables in an activation are expanded at
+	// delivery too, so they have to be preflighted alongside the declaration.
+	ActivationRawJSON *json.RawMessage `db:"activation_raw_json"`
 }
 
 // MDMAppleDDMDeclarationResponse represents a declaration in the datastore. It is used for the DDM
@@ -1412,15 +1423,15 @@ type MDMAppleDDMErrors struct {
 	Reasons []MDMAppleDDMStatusErrorReason `json:"Reasons"`
 }
 
-// A status report that contains details about an error.
-//
-// https://developer.apple.com/documentation/devicemanagement/statusreason
 // Reason codes Apple returns for activation predicates.
 const (
 	MDMAppleDDMReasonPredicate        = "Info.Predicate"
 	MDMAppleDDMReasonActivationFailed = "Error.ActivationFailed"
 )
 
+// A status report that contains details about an error.
+//
+// https://developer.apple.com/documentation/devicemanagement/statusreason
 type MDMAppleDDMStatusErrorReason struct {
 	// Code is the error code for this error.
 	Code string `json:"Code"`

--- a/server/fleet/apple_mdm_test.go
+++ b/server/fleet/apple_mdm_test.go
@@ -694,6 +694,8 @@ func TestMDMAppleHostDeclarationEqual(t *testing.T) {
 	fieldsInEqualMethod++
 	items[1].AssetsUpdatedAt = items[0].AssetsUpdatedAt
 	fieldsInEqualMethod++
+	items[1].ActivationUpdatedAt = items[0].ActivationUpdatedAt
+	fieldsInEqualMethod++
 	items[1].Scope = items[0].Scope
 	fieldsInEqualMethod++
 	assert.Equal(t, fieldsInEqualMethod, numberOfFields, "MDMAppleHostDeclaration.Equal needs to be updated for new/updated field(s)")
@@ -725,27 +727,27 @@ func TestEffectiveDDMToken(t *testing.T) {
 	const layout = "2006-01-02 15:04:05.000000"
 
 	t.Run("no vars, no assets returns static token unchanged", func(t *testing.T) {
-		require.Equal(t, staticToken, EffectiveDDMToken(staticToken, nil, nil))
+		require.Equal(t, staticToken, EffectiveDDMToken(staticToken, nil, nil, nil))
 	})
 
 	t.Run("only variables", func(t *testing.T) {
-		require.Equal(t, md5Hex(staticToken, vars.Format(layout)), EffectiveDDMToken(staticToken, &vars, nil))
+		require.Equal(t, md5Hex(staticToken, vars.Format(layout)), EffectiveDDMToken(staticToken, &vars, nil, nil))
 	})
 
 	t.Run("only assets", func(t *testing.T) {
-		got := EffectiveDDMToken(staticToken, nil, &assets)
+		got := EffectiveDDMToken(staticToken, nil, &assets, nil)
 		require.Equal(t, md5Hex(staticToken, assets.Format(layout)), got)
 		// An asset update must change the effective token away from the static one.
 		require.NotEqual(t, staticToken, got)
 	})
 
 	t.Run("both variables and assets, order is static+vars+assets", func(t *testing.T) {
-		require.Equal(t, md5Hex(staticToken, vars.Format(layout), assets.Format(layout)), EffectiveDDMToken(staticToken, &vars, &assets))
+		require.Equal(t, md5Hex(staticToken, vars.Format(layout), assets.Format(layout)), EffectiveDDMToken(staticToken, &vars, &assets, nil))
 	})
 
 	t.Run("different asset timestamps yield different tokens", func(t *testing.T) {
 		later := assets.Add(time.Second)
-		require.NotEqual(t, EffectiveDDMToken(staticToken, nil, &assets), EffectiveDDMToken(staticToken, nil, &later))
+		require.NotEqual(t, EffectiveDDMToken(staticToken, nil, &assets, nil), EffectiveDDMToken(staticToken, nil, &later, nil))
 	})
 }
 

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2127,6 +2127,7 @@ type Datastore interface {
 	MDMAppleDDMDeclarationItems(ctx context.Context, hostUUID string, scope PayloadScope) ([]MDMAppleDDMDeclarationItem, error)
 	// MDMAppleDDMDeclarationPayload returns the declaration payload for the specified identifier and team.
 	MDMAppleDDMDeclarationsResponse(ctx context.Context, identifier string, hostUUID string, scope PayloadScope) (*MDMAppleDeclaration, error)
+	MDMAppleDDMActivationResponse(ctx context.Context, identifier string, hostUUID string, scope PayloadScope) (*MDMAppleDDMActivationForDelivery, error)
 
 	// MDMAppleHostDeclarationsGetAndClearResync finds any hosts that requested a resync,
 	// partitioned by channel (device vs user) so the reconciler only pokes the

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2125,6 +2125,11 @@ type Datastore interface {
 	// MDMAppleDDMDeclarationItems returns the declaration items for the specified host UUID
 	// on the given channel (scope).
 	MDMAppleDDMDeclarationItems(ctx context.Context, hostUUID string, scope PayloadScope) ([]MDMAppleDDMDeclarationItem, error)
+
+	// ListCustomActivationsForDeclarations returns the custom activations
+	// attached to the given declarations. Declarations without one are absent
+	// from the result.
+	ListCustomActivationsForDeclarations(ctx context.Context, declUUIDs []string) ([]*MDMAppleDDMActivationItem, error)
 	// MDMAppleDDMDeclarationPayload returns the declaration payload for the specified identifier and team.
 	MDMAppleDDMDeclarationsResponse(ctx context.Context, identifier string, hostUUID string, scope PayloadScope) (*MDMAppleDeclaration, error)
 	MDMAppleDDMActivationResponse(ctx context.Context, identifier string, hostUUID string, scope PayloadScope) (*MDMAppleDDMActivationForDelivery, error)

--- a/server/fleet/mdm.go
+++ b/server/fleet/mdm.go
@@ -691,6 +691,9 @@ type MDMProfileBatchPayload struct {
 	LabelsIncludeAny []string   `json:"labels_include_any,omitempty"`
 	LabelsExcludeAny []string   `json:"labels_exclude_any,omitempty"`
 	SecretsUpdatedAt *time.Time `json:"-"`
+
+	// Base64-encoded custom activation, only valid for Apple declarations.
+	Activation []byte `json:"activation,omitempty"`
 }
 
 func NewMDMConfigProfilePayloadFromWindows(cp *MDMWindowsConfigProfile) *MDMConfigProfilePayload {
@@ -779,6 +782,10 @@ func NewMDMConfigProfilePayloadFromAndroid(cp *MDMAndroidConfigProfile) *MDMConf
 type MDMProfileSpec struct {
 	Path  string `json:"path,omitempty"`
 	Paths string `json:"paths,omitempty"`
+
+	// Activation is a path to a custom activation JSON file, only valid
+	// alongside an Apple declaration.
+	Activation string `json:"activation,omitempty"`
 
 	// Deprecated: the Labels field is now deprecated, it is superseded by
 	// LabelsIncludeAll, so any value set via this field will be transferred to

--- a/server/mdm/apple/reconcile.go
+++ b/server/mdm/apple/reconcile.go
@@ -260,6 +260,10 @@ func ComputeDeclarationDeltas(
 				// so the per-host effective token changes and the host re-fetches,
 				// even though the declaration's own content/token is unchanged.
 				needsInstall = true
+			case d.ActivationUpdatedAt != nil && (c.ActivationUpdatedAt == nil || c.ActivationUpdatedAt.Before(*d.ActivationUpdatedAt)):
+				// Same, for an edited custom activation. Editing only its predicate
+				// leaves the declaration's own content untouched.
+				needsInstall = true
 			case c.OperationType == "" || c.OperationType == fleet.MDMOperationTypeRemove:
 				needsInstall = true
 			case c.OperationType == fleet.MDMOperationTypeInstall && c.Status == nil:
@@ -291,6 +295,9 @@ func ComputeDeclarationDeltas(
 			// and no needless re-delivery is triggered.
 			if d.AssetsUpdatedAt != nil {
 				row.AssetsUpdatedAt = d.AssetsUpdatedAt
+			}
+			if d.ActivationUpdatedAt != nil {
+				row.ActivationUpdatedAt = d.ActivationUpdatedAt
 			}
 			declRowsToWrite = append(declRowsToWrite, row)
 			markChanged(host.UUID, desiredScope)

--- a/server/mdm/apple/reconcile.go
+++ b/server/mdm/apple/reconcile.go
@@ -264,6 +264,12 @@ func ComputeDeclarationDeltas(
 				// Same, for an edited custom activation. Editing only its predicate
 				// leaves the declaration's own content untouched.
 				needsInstall = true
+			case d.ActivationUpdatedAt == nil && c.ActivationUpdatedAt != nil:
+				// The custom activation was removed. Unlike an asset reference, it
+				// lives in its own table, so the declaration's token is unchanged and
+				// nothing else here would notice; without this the host keeps the old
+				// activation and its predicate forever.
+				needsInstall = true
 			case c.OperationType == "" || c.OperationType == fleet.MDMOperationTypeRemove:
 				needsInstall = true
 			case c.OperationType == fleet.MDMOperationTypeInstall && c.Status == nil:

--- a/server/mdm/apple/reconcile_test.go
+++ b/server/mdm/apple/reconcile_test.go
@@ -811,6 +811,76 @@ func TestComputeDeclarationDeltasAssets(t *testing.T) {
 	})
 }
 
+func TestComputeDeclarationDeltasActivations(t *testing.T) {
+	host := &fleet.AppleHostReconcileInfo{
+		HostID: 1, UUID: "uuid-A", TeamID: nil, Platform: "darwin",
+		LabelUpdatedAt: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+	}
+	declsWithBrokenLabel := map[string]struct{}{}
+
+	activationUpdatedAt := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+
+	// The declaration's own token stays "tokA" throughout: a custom activation
+	// lives in its own table, so adding, editing or removing one never changes
+	// the declaration's content.
+	declWithActivation := &fleet.AppleDeclarationForReconcile{
+		DeclarationUUID: "aDeclAct", DeclarationIdentifier: "com.example.act", DeclarationName: "ActDecl",
+		TeamID: 0, Token: []byte("tokA"), IncludeMode: fleet.AppleProfileIncludeNone,
+		ActivationUpdatedAt: &activationUpdatedAt,
+	}
+	declNoActivation := *declWithActivation
+	declNoActivation.ActivationUpdatedAt = nil
+
+	hostHasActivation := func() map[string][]*fleet.MDMAppleHostDeclaration {
+		return map[string][]*fleet.MDMAppleHostDeclaration{
+			"uuid-A": {{
+				HostUUID:            "uuid-A",
+				DeclarationUUID:     "aDeclAct",
+				Token:               "tokA",
+				OperationType:       fleet.MDMOperationTypeInstall,
+				Status:              new(fleet.MDMDeliveryVerified),
+				ActivationUpdatedAt: &activationUpdatedAt,
+			}},
+		}
+	}
+
+	t.Run("activation unchanged since last delivery -> no diff", func(t *testing.T) {
+		changedDevice, changedUser, rows := ComputeDeclarationDeltas(
+			[]*fleet.AppleHostReconcileInfo{host}, nil, hostHasActivation(),
+			map[uint][]*fleet.AppleDeclarationForReconcile{0: {declWithActivation}}, declsWithBrokenLabel,
+		)
+		require.Empty(t, changedDevice)
+		require.Empty(t, changedUser)
+		require.Empty(t, rows)
+	})
+
+	t.Run("activation removed pokes and clears the stamp", func(t *testing.T) {
+		// Without this the host keeps serving the deleted custom activation,
+		// predicate included, because nothing else in the delta changes.
+		changedDevice, _, rows := ComputeDeclarationDeltas(
+			[]*fleet.AppleHostReconcileInfo{host}, nil, hostHasActivation(),
+			map[uint][]*fleet.AppleDeclarationForReconcile{0: {&declNoActivation}}, declsWithBrokenLabel,
+		)
+		require.ElementsMatch(t, []string{"uuid-A"}, changedDevice)
+		require.Len(t, rows, 1)
+		require.Equal(t, fleet.MDMOperationTypeInstall, rows[0].OperationType)
+		require.Equal(t, "tokA", rows[0].Token)
+		require.Nil(t, rows[0].ActivationUpdatedAt, "the stamp must clear so the effective token changes")
+	})
+
+	t.Run("no activation on either side -> no diff", func(t *testing.T) {
+		current := hostHasActivation()
+		current["uuid-A"][0].ActivationUpdatedAt = nil
+		changedDevice, changedUser, rows := ComputeDeclarationDeltas(
+			[]*fleet.AppleHostReconcileInfo{host}, nil, current,
+			map[uint][]*fleet.AppleDeclarationForReconcile{0: {&declNoActivation}}, declsWithBrokenLabel,
+		)
+		require.Empty(t, changedDevice)
+		require.Empty(t, changedUser)
+		require.Empty(t, rows)
+	})
+}
+
 func TestMDMAppleExecuteReconcileBatch(t *testing.T) {
 	ctx := context.Background()
 	mdmStorage := &mdmmock.MDMAppleStore{}

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1284,6 +1284,8 @@ type MDMAppleDDMDeclarationsTokenFunc func(ctx context.Context, hostUUID string,
 
 type MDMAppleDDMDeclarationItemsFunc func(ctx context.Context, hostUUID string, scope fleet.PayloadScope) ([]fleet.MDMAppleDDMDeclarationItem, error)
 
+type ListCustomActivationsForDeclarationsFunc func(ctx context.Context, declUUIDs []string) ([]*fleet.MDMAppleDDMActivationItem, error)
+
 type MDMAppleDDMDeclarationsResponseFunc func(ctx context.Context, identifier string, hostUUID string, scope fleet.PayloadScope) (*fleet.MDMAppleDeclaration, error)
 
 type MDMAppleDDMActivationResponseFunc func(ctx context.Context, identifier string, hostUUID string, scope fleet.PayloadScope) (*fleet.MDMAppleDDMActivationForDelivery, error)
@@ -4176,6 +4178,9 @@ type DataStore struct {
 
 	MDMAppleDDMDeclarationItemsFunc        MDMAppleDDMDeclarationItemsFunc
 	MDMAppleDDMDeclarationItemsFuncInvoked bool
+
+	ListCustomActivationsForDeclarationsFunc        ListCustomActivationsForDeclarationsFunc
+	ListCustomActivationsForDeclarationsFuncInvoked bool
 
 	MDMAppleDDMDeclarationsResponseFunc        MDMAppleDDMDeclarationsResponseFunc
 	MDMAppleDDMDeclarationsResponseFuncInvoked bool
@@ -10091,6 +10096,13 @@ func (s *DataStore) MDMAppleDDMDeclarationItems(ctx context.Context, hostUUID st
 	s.MDMAppleDDMDeclarationItemsFuncInvoked = true
 	s.mu.Unlock()
 	return s.MDMAppleDDMDeclarationItemsFunc(ctx, hostUUID, scope)
+}
+
+func (s *DataStore) ListCustomActivationsForDeclarations(ctx context.Context, declUUIDs []string) ([]*fleet.MDMAppleDDMActivationItem, error) {
+	s.mu.Lock()
+	s.ListCustomActivationsForDeclarationsFuncInvoked = true
+	s.mu.Unlock()
+	return s.ListCustomActivationsForDeclarationsFunc(ctx, declUUIDs)
 }
 
 func (s *DataStore) MDMAppleDDMDeclarationsResponse(ctx context.Context, identifier string, hostUUID string, scope fleet.PayloadScope) (*fleet.MDMAppleDeclaration, error) {

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1286,6 +1286,8 @@ type MDMAppleDDMDeclarationItemsFunc func(ctx context.Context, hostUUID string, 
 
 type MDMAppleDDMDeclarationsResponseFunc func(ctx context.Context, identifier string, hostUUID string, scope fleet.PayloadScope) (*fleet.MDMAppleDeclaration, error)
 
+type MDMAppleDDMActivationResponseFunc func(ctx context.Context, identifier string, hostUUID string, scope fleet.PayloadScope) (*fleet.MDMAppleDDMActivationForDelivery, error)
+
 type MDMAppleHostDeclarationsGetAndClearResyncFunc func(ctx context.Context) (deviceHostUUIDs []string, userHostUUIDs []string, err error)
 
 type MDMAppleStoreDDMStatusReportFunc func(ctx context.Context, hostUUID string, scope fleet.PayloadScope, updates []*fleet.MDMAppleHostDeclaration) error
@@ -4177,6 +4179,9 @@ type DataStore struct {
 
 	MDMAppleDDMDeclarationsResponseFunc        MDMAppleDDMDeclarationsResponseFunc
 	MDMAppleDDMDeclarationsResponseFuncInvoked bool
+
+	MDMAppleDDMActivationResponseFunc        MDMAppleDDMActivationResponseFunc
+	MDMAppleDDMActivationResponseFuncInvoked bool
 
 	MDMAppleHostDeclarationsGetAndClearResyncFunc        MDMAppleHostDeclarationsGetAndClearResyncFunc
 	MDMAppleHostDeclarationsGetAndClearResyncFuncInvoked bool
@@ -10093,6 +10098,13 @@ func (s *DataStore) MDMAppleDDMDeclarationsResponse(ctx context.Context, identif
 	s.MDMAppleDDMDeclarationsResponseFuncInvoked = true
 	s.mu.Unlock()
 	return s.MDMAppleDDMDeclarationsResponseFunc(ctx, identifier, hostUUID, scope)
+}
+
+func (s *DataStore) MDMAppleDDMActivationResponse(ctx context.Context, identifier string, hostUUID string, scope fleet.PayloadScope) (*fleet.MDMAppleDDMActivationForDelivery, error) {
+	s.mu.Lock()
+	s.MDMAppleDDMActivationResponseFuncInvoked = true
+	s.mu.Unlock()
+	return s.MDMAppleDDMActivationResponseFunc(ctx, identifier, hostUUID, scope)
 }
 
 func (s *DataStore) MDMAppleHostDeclarationsGetAndClearResync(ctx context.Context) (deviceHostUUIDs []string, userHostUUIDs []string, err error) {

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -7200,7 +7200,7 @@ func (svc *MDMAppleDDMService) handleDeclarationItems(ctx context.Context, hostU
 	activations := []fleet.MDMAppleDDMManifest{}
 	configurations := []fleet.MDMAppleDDMManifest{}
 	management := []fleet.MDMAppleDDMManifest{}
-	configurationUUIDs := []string{}
+	declarationUUIDs := []string{}
 	var removeDeclarationUUIDsToUpdateToPending []string
 	for _, d := range di {
 		if d.OperationType == nil {
@@ -7219,25 +7219,39 @@ func (svc *MDMAppleDDMService) handleDeclarationItems(ctx context.Context, hostU
 		// fetch or apply it. NOTE: the declaration is still included in the token
 		// computation below so that the token matches the SQL-computed
 		// token from handleTokens.
+		// The activation is expanded at delivery too, so an unresolvable variable
+		// there has to drop the declaration here as well -- otherwise the manifest
+		// advertises an activation the host can never fetch.
 		if d.VariablesUpdatedAt != nil {
-			if d.RawJSON != nil {
-				if _, err := svc.replaceDeclarationFleetVariables(ctx, string(*d.RawJSON), hostUUID); err != nil {
-					if nryErr, ok := errors.AsType[notReadyYetError](err); ok {
-						if err := svc.markDeclarationPending(ctx, hostUUID, d.DeclarationUUID, nryErr.Message); err != nil {
-							return nil, ctxerr.Wrap(ctx, err, "mark declaration as pending")
-						}
-						continue
-					}
-
-					if err := svc.markDeclarationFailed(ctx, hostUUID, d.DeclarationUUID, err.Error()); err != nil {
-						return nil, ctxerr.Wrap(ctx, err, "mark declaration as failed")
+			var unresolvable error
+			for _, raw := range []*json.RawMessage{d.RawJSON, d.ActivationRawJSON} {
+				if raw == nil {
+					continue
+				}
+				if _, err := svc.replaceDeclarationFleetVariables(ctx, string(*raw), hostUUID); err != nil {
+					unresolvable = err
+					break
+				}
+			}
+			if unresolvable != nil {
+				if nryErr, ok := errors.AsType[notReadyYetError](unresolvable); ok {
+					if err := svc.markDeclarationPending(ctx, hostUUID, d.DeclarationUUID, nryErr.Message); err != nil {
+						return nil, ctxerr.Wrap(ctx, err, "mark declaration as pending")
 					}
 					continue
 				}
+				if err := svc.markDeclarationFailed(ctx, hostUUID, d.DeclarationUUID, unresolvable.Error()); err != nil {
+					return nil, ctxerr.Wrap(ctx, err, "mark declaration as failed")
+				}
+				continue
 			}
 		}
 
 		effectiveToken := fleet.EffectiveDDMToken(d.ServerToken, d.VariablesUpdatedAt, d.AssetsUpdatedAt, d.ActivationUpdatedAt)
+
+		// Management declarations can reference assets too (organization-info
+		// carries one), so they belong in the asset lookup as well.
+		declarationUUIDs = append(declarationUUIDs, d.DeclarationUUID)
 
 		if d.DeclarationType != nil && strings.HasPrefix(*d.DeclarationType, fleet.MDMAppleManagementTypePrefix) {
 			management = append(management, fleet.MDMAppleDDMManifest{
@@ -7251,19 +7265,26 @@ func (svc *MDMAppleDDMService) handleDeclarationItems(ctx context.Context, hostU
 			Identifier:  d.Identifier,
 			ServerToken: effectiveToken,
 		})
-		configurationUUIDs = append(configurationUUIDs, d.DeclarationUUID)
 
+		// A synthesized activation has no content of its own, so it rides on the
+		// declaration's effective token. A custom one is independent content and
+		// carries its own, so editing the declaration or an asset it references
+		// no longer forces the host to re-fetch the activation.
 		activationIdentifier := d.DeclarationUUID + fleet.MDMAppleGeneratedActivationSuffix
+		activationToken := effectiveToken
 		if d.ActivationIdentifier != nil {
 			activationIdentifier = *d.ActivationIdentifier
+			if d.ActivationToken != nil {
+				activationToken = *d.ActivationToken
+			}
 		}
 		activations = append(activations, fleet.MDMAppleDDMManifest{
 			Identifier:  activationIdentifier,
-			ServerToken: effectiveToken,
+			ServerToken: activationToken,
 		})
 	}
 
-	referencedAssets, err := svc.ds.GetAppleDDMAssetsReferencedByDeclarations(ctx, configurationUUIDs)
+	referencedAssets, err := svc.ds.GetAppleDDMAssetsReferencedByDeclarations(ctx, declarationUUIDs)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "getting referenced assets")
 	}
@@ -7444,6 +7465,9 @@ func (svc *MDMAppleDDMService) handleActivationDeclaration(ctx context.Context, 
 	return []byte(response), nil
 }
 
+// serveCustomActivation returns the stored activation stamped with its own
+// token, which is what handleDeclarationItems advertised for it. effectiveToken
+// is only the fallback for a row that somehow has no activation token.
 func (svc *MDMAppleDDMService) serveCustomActivation(ctx context.Context, act *fleet.MDMAppleDDMActivationForDelivery, hostUUID, effectiveToken string) ([]byte, error) {
 	expanded, err := svc.ds.ExpandEmbeddedSecrets(ctx, string(act.RawJSON))
 	if err != nil {
@@ -7462,7 +7486,11 @@ func (svc *MDMAppleDDMService) serveCustomActivation(ctx context.Context, act *f
 	if err := json.Unmarshal([]byte(expanded), &tempd); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "unmarshaling stored activation")
 	}
-	tempd["ServerToken"] = effectiveToken
+	serverToken := effectiveToken
+	if act.ActivationToken != nil {
+		serverToken = *act.ActivationToken
+	}
+	tempd["ServerToken"] = serverToken
 
 	b, err := json.Marshal(tempd)
 	if err != nil {
@@ -7535,20 +7563,6 @@ func (svc *MDMAppleDDMService) handleDeclarationStatus(ctx context.Context, dm *
 		return ctxerr.Wrap(ctx, err, "unmarshalling response")
 	}
 
-	// Management declarations report under their own section but are tracked in
-	// the same host_mdm_apple_declarations rows as configurations. Which section
-	// a report came from has to survive the merge, because the two are graded
-	// differently -- see the isManagement case below.
-	configurationReports := make([]reportedDeclaration, 0,
-		len(statusReport.StatusItems.Management.Declarations.Configurations)+
-			len(statusReport.StatusItems.Management.Declarations.Management))
-	for _, c := range statusReport.StatusItems.Management.Declarations.Configurations {
-		configurationReports = append(configurationReports, reportedDeclaration{MDMAppleDDMStatusDeclaration: c})
-	}
-	for _, m := range statusReport.StatusItems.Management.Declarations.Management {
-		configurationReports = append(configurationReports,
-			reportedDeclaration{MDMAppleDDMStatusDeclaration: m, isManagement: true})
-	}
 	// A configuration whose activation didn't activate reports
 	// Error.ActivationFailed, which looks like a failure but isn't one when the
 	// cause is a predicate that simply evaluated false. Apple reports that as
@@ -7560,63 +7574,27 @@ func (svc *MDMAppleDDMService) handleDeclarationStatus(ctx context.Context, dm *
 		}
 	}
 
-	updates := make([]*fleet.MDMAppleHostDeclaration, len(configurationReports))
-	for i, r := range configurationReports {
-		var status fleet.MDMDeliveryStatus
-		var detail string
-		switch activationFailed := declarationReasonCode(r.MDMAppleDDMStatusDeclaration, fleet.MDMAppleDDMReasonActivationFailed); {
-		case r.isManagement:
-			// Apple: "A management declaration has an active state which is always
-			// false and not part of the activation process." Grading it on Active
-			// like a configuration would leave every one of them stuck verifying.
-			switch r.Valid {
-			case fleet.MDMAppleDeclarationValid:
-				status = fleet.MDMDeliveryVerified
-			case fleet.MDMAppleDeclarationInvalid:
-				status = fleet.MDMDeliveryFailed
-				detail = apple_mdm.FmtDDMError(r.Reasons)
-			default:
-				// Unknown: the device hasn't checked it yet.
-				status = fleet.MDMDeliveryVerifying
-			}
-		case activationFailed != nil && predicateNotApplied(activationFailed, predicateByActivation) != nil:
-			// Not applied because the predicate excluded this host. Fleet
-			// delivered it correctly, so this is verified, not failed.
-			status = fleet.MDMDeliveryVerified
-			detail = fmtDDMPredicateNotApplied(predicateNotApplied(activationFailed, predicateByActivation))
-		case activationFailed != nil:
-			// The activation genuinely failed -- bad predicate syntax, or some
-			// other client-side error.
-			status = fleet.MDMDeliveryFailed
-			detail = apple_mdm.FmtDDMError(r.Reasons)
-		case r.Active && r.Valid == fleet.MDMAppleDeclarationValid:
-			status = fleet.MDMDeliveryVerified
-		case r.Valid == fleet.MDMAppleDeclarationInvalid || isUnknownDeclarationType(r.MDMAppleDDMStatusDeclaration):
-			status = fleet.MDMDeliveryFailed
-			detail = apple_mdm.FmtDDMError(r.Reasons)
-		case r.Valid == fleet.MDMAppleDeclarationValid:
-			// The debug messages here can be used to figure out why a DDM profile is stuck in a certain state on a device.
-			svc.logger.DebugContext(ctx, "valid but inactive declaration status",
-				"status", r.Valid, "active", r.Active, "host", dm.Identifier(), "declaration", r.Identifier)
-			status = fleet.MDMDeliveryVerifying
-		case r.Valid == fleet.MDMAppleDeclarationUnknown: // should be rare
-			svc.logger.DebugContext(ctx, "unknown declaration status",
-				"status", r.Valid, "active", r.Active, "host", dm.Identifier(), "declaration", r.Identifier)
-			status = fleet.MDMDeliveryVerifying
-		default:
-			// This should never happen. If we see this happening, we should handle it.
-			svc.logger.ErrorContext(ctx, "undefined declaration status",
-				"status", r.Valid, "active", r.Active, "host", dm.Identifier(), "declaration", r.Identifier)
-			status = fleet.MDMDeliveryFailed
-			detail = fmt.Sprintf("undefined declaration status: %s; %s", r.Valid, apple_mdm.FmtDDMError(r.Reasons))
-		}
-
-		updates[i] = &fleet.MDMAppleHostDeclaration{
+	// Configurations and management declarations are graded differently, so
+	// each gets its own pass rather than one switch juggling both.
+	decls := statusReport.StatusItems.Management.Declarations
+	updates := make([]*fleet.MDMAppleHostDeclaration, 0, len(decls.Configurations)+len(decls.Management))
+	for _, r := range decls.Configurations {
+		status, detail := svc.configurationDeclarationStatus(ctx, dm, r, predicateByActivation)
+		updates = append(updates, &fleet.MDMAppleHostDeclaration{
 			Status:        &status,
 			OperationType: fleet.MDMOperationTypeInstall,
 			Detail:        detail,
 			Token:         r.ServerToken,
-		}
+		})
+	}
+	for _, r := range decls.Management {
+		status, detail := managementDeclarationStatus(r)
+		updates = append(updates, &fleet.MDMAppleHostDeclaration{
+			Status:        &status,
+			OperationType: fleet.MDMOperationTypeInstall,
+			Detail:        detail,
+			Token:         r.ServerToken,
+		})
 	}
 
 	// MDMAppleStoreDDMStatusReport takes care of cleaning ("pending", "remove")
@@ -7651,11 +7629,59 @@ func predicateNotApplied(activationFailed *fleet.MDMAppleDDMStatusErrorReason, b
 	return byActivation[id]
 }
 
-// reportedDeclaration keeps track of which section of the status report a
-// declaration came from, which decides how its status is graded.
-type reportedDeclaration struct {
-	fleet.MDMAppleDDMStatusDeclaration
-	isManagement bool
+// managementDeclarationStatus grades a com.apple.management.* declaration.
+// Apple: "A management declaration has an active state which is always false
+// and not part of the activation process", so validity alone decides.
+func managementDeclarationStatus(r fleet.MDMAppleDDMStatusDeclaration) (fleet.MDMDeliveryStatus, string) {
+	switch {
+	case r.Valid == fleet.MDMAppleDeclarationValid:
+		return fleet.MDMDeliveryVerified, ""
+	case r.Valid == fleet.MDMAppleDeclarationInvalid:
+		return fleet.MDMDeliveryFailed, apple_mdm.FmtDDMError(r.Reasons)
+	case len(r.Reasons) > 0:
+		// Still unknown, but the device reported reasons: something already went
+		// wrong, so surface it instead of waiting forever for a verdict.
+		return fleet.MDMDeliveryFailed, apple_mdm.FmtDDMError(r.Reasons)
+	default:
+		// Unknown with nothing to report: the device hasn't checked it yet.
+		return fleet.MDMDeliveryVerifying, ""
+	}
+}
+
+// configurationDeclarationStatus grades a com.apple.configuration.* declaration,
+// correlating against the activations that gate it.
+func (svc *MDMAppleDDMService) configurationDeclarationStatus(ctx context.Context, dm *mdm.DeclarativeManagement,
+	r fleet.MDMAppleDDMStatusDeclaration, predicateByActivation map[string]*fleet.MDMAppleDDMStatusErrorReason,
+) (fleet.MDMDeliveryStatus, string) {
+	switch activationFailed := declarationReasonCode(r, fleet.MDMAppleDDMReasonActivationFailed); {
+	case activationFailed != nil && predicateNotApplied(activationFailed, predicateByActivation) != nil:
+		// Not applied because the predicate excluded this host. Fleet delivered
+		// it correctly, so this is verified, not failed.
+		return fleet.MDMDeliveryVerified, fmtDDMPredicateNotApplied(predicateNotApplied(activationFailed, predicateByActivation))
+	case activationFailed != nil:
+		// The activation genuinely failed -- bad predicate syntax, or some other
+		// client-side error.
+		return fleet.MDMDeliveryFailed, apple_mdm.FmtDDMError(r.Reasons)
+	case r.Active && r.Valid == fleet.MDMAppleDeclarationValid:
+		return fleet.MDMDeliveryVerified, ""
+	case r.Valid == fleet.MDMAppleDeclarationInvalid || isUnknownDeclarationType(r):
+		return fleet.MDMDeliveryFailed, apple_mdm.FmtDDMError(r.Reasons)
+	case r.Valid == fleet.MDMAppleDeclarationValid:
+		// The debug messages here can be used to figure out why a DDM profile is stuck in a certain state on a device.
+		svc.logger.DebugContext(ctx, "valid but inactive declaration status",
+			"status", r.Valid, "active", r.Active, "host", dm.Identifier(), "declaration", r.Identifier)
+		return fleet.MDMDeliveryVerifying, ""
+	case r.Valid == fleet.MDMAppleDeclarationUnknown: // should be rare
+		svc.logger.DebugContext(ctx, "unknown declaration status",
+			"status", r.Valid, "active", r.Active, "host", dm.Identifier(), "declaration", r.Identifier)
+		return fleet.MDMDeliveryVerifying, ""
+	default:
+		// This should never happen. If we see this happening, we should handle it.
+		svc.logger.ErrorContext(ctx, "undefined declaration status",
+			"status", r.Valid, "active", r.Active, "host", dm.Identifier(), "declaration", r.Identifier)
+		return fleet.MDMDeliveryFailed,
+			fmt.Sprintf("undefined declaration status: %s; %s", r.Valid, apple_mdm.FmtDDMError(r.Reasons))
+	}
 }
 
 func declarationReasonCode(r fleet.MDMAppleDDMStatusDeclaration, code string) *fleet.MDMAppleDDMStatusErrorReason {

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -7536,11 +7536,19 @@ func (svc *MDMAppleDDMService) handleDeclarationStatus(ctx context.Context, dm *
 	}
 
 	// Management declarations report under their own section but are tracked in
-	// the same host_mdm_apple_declarations rows as configurations.
-	configurationReports := append(
-		append([]fleet.MDMAppleDDMStatusDeclaration{}, statusReport.StatusItems.Management.Declarations.Configurations...),
-		statusReport.StatusItems.Management.Declarations.Management...,
-	)
+	// the same host_mdm_apple_declarations rows as configurations. Which section
+	// a report came from has to survive the merge, because the two are graded
+	// differently -- see the isManagement case below.
+	configurationReports := make([]reportedDeclaration, 0,
+		len(statusReport.StatusItems.Management.Declarations.Configurations)+
+			len(statusReport.StatusItems.Management.Declarations.Management))
+	for _, c := range statusReport.StatusItems.Management.Declarations.Configurations {
+		configurationReports = append(configurationReports, reportedDeclaration{MDMAppleDDMStatusDeclaration: c})
+	}
+	for _, m := range statusReport.StatusItems.Management.Declarations.Management {
+		configurationReports = append(configurationReports,
+			reportedDeclaration{MDMAppleDDMStatusDeclaration: m, isManagement: true})
+	}
 	// A configuration whose activation didn't activate reports
 	// Error.ActivationFailed, which looks like a failure but isn't one when the
 	// cause is a predicate that simply evaluated false. Apple reports that as
@@ -7556,7 +7564,21 @@ func (svc *MDMAppleDDMService) handleDeclarationStatus(ctx context.Context, dm *
 	for i, r := range configurationReports {
 		var status fleet.MDMDeliveryStatus
 		var detail string
-		switch activationFailed := declarationReasonCode(r, fleet.MDMAppleDDMReasonActivationFailed); {
+		switch activationFailed := declarationReasonCode(r.MDMAppleDDMStatusDeclaration, fleet.MDMAppleDDMReasonActivationFailed); {
+		case r.isManagement:
+			// Apple: "A management declaration has an active state which is always
+			// false and not part of the activation process." Grading it on Active
+			// like a configuration would leave every one of them stuck verifying.
+			switch r.Valid {
+			case fleet.MDMAppleDeclarationValid:
+				status = fleet.MDMDeliveryVerified
+			case fleet.MDMAppleDeclarationInvalid:
+				status = fleet.MDMDeliveryFailed
+				detail = apple_mdm.FmtDDMError(r.Reasons)
+			default:
+				// Unknown: the device hasn't checked it yet.
+				status = fleet.MDMDeliveryVerifying
+			}
 		case activationFailed != nil && predicateNotApplied(activationFailed, predicateByActivation) != nil:
 			// Not applied because the predicate excluded this host. Fleet
 			// delivered it correctly, so this is verified, not failed.
@@ -7569,7 +7591,7 @@ func (svc *MDMAppleDDMService) handleDeclarationStatus(ctx context.Context, dm *
 			detail = apple_mdm.FmtDDMError(r.Reasons)
 		case r.Active && r.Valid == fleet.MDMAppleDeclarationValid:
 			status = fleet.MDMDeliveryVerified
-		case r.Valid == fleet.MDMAppleDeclarationInvalid || isUnknownDeclarationType(r):
+		case r.Valid == fleet.MDMAppleDeclarationInvalid || isUnknownDeclarationType(r.MDMAppleDDMStatusDeclaration):
 			status = fleet.MDMDeliveryFailed
 			detail = apple_mdm.FmtDDMError(r.Reasons)
 		case r.Valid == fleet.MDMAppleDeclarationValid:
@@ -7627,6 +7649,13 @@ func predicateNotApplied(activationFailed *fleet.MDMAppleDDMStatusErrorReason, b
 		return nil
 	}
 	return byActivation[id]
+}
+
+// reportedDeclaration keeps track of which section of the status report a
+// declaration came from, which decides how its status is graded.
+type reportedDeclaration struct {
+	fleet.MDMAppleDDMStatusDeclaration
+	isManagement bool
 }
 
 func declarationReasonCode(r fleet.MDMAppleDDMStatusDeclaration, code string) *fleet.MDMAppleDDMStatusErrorReason {

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -7541,22 +7541,32 @@ func (svc *MDMAppleDDMService) handleDeclarationStatus(ctx context.Context, dm *
 		append([]fleet.MDMAppleDDMStatusDeclaration{}, statusReport.StatusItems.Management.Declarations.Configurations...),
 		statusReport.StatusItems.Management.Declarations.Management...,
 	)
+	// A configuration whose activation didn't activate reports
+	// Error.ActivationFailed, which looks like a failure but isn't one when the
+	// cause is a predicate that simply evaluated false. Apple reports that as
+	// Info.Predicate on the *activation*, so the two have to be correlated.
+	predicateByActivation := make(map[string]*fleet.MDMAppleDDMStatusErrorReason)
+	for _, a := range statusReport.StatusItems.Management.Declarations.Activations {
+		if reason := declarationReasonCode(a, fleet.MDMAppleDDMReasonPredicate); reason != nil {
+			predicateByActivation[a.Identifier] = reason
+		}
+	}
+
 	updates := make([]*fleet.MDMAppleHostDeclaration, len(configurationReports))
 	for i, r := range configurationReports {
 		var status fleet.MDMDeliveryStatus
 		var detail string
-		switch {
-		case declarationReasonCode(r, fleet.MDMAppleDDMReasonActivationFailed) != nil:
-			// The activation itself failed, predicate included. Treated like any
-			// other client-side failure.
+		switch activationFailed := declarationReasonCode(r, fleet.MDMAppleDDMReasonActivationFailed); {
+		case activationFailed != nil && predicateNotApplied(activationFailed, predicateByActivation) != nil:
+			// Not applied because the predicate excluded this host. Fleet
+			// delivered it correctly, so this is verified, not failed.
+			status = fleet.MDMDeliveryVerified
+			detail = fmtDDMPredicateNotApplied(predicateNotApplied(activationFailed, predicateByActivation))
+		case activationFailed != nil:
+			// The activation genuinely failed -- bad predicate syntax, or some
+			// other client-side error.
 			status = fleet.MDMDeliveryFailed
 			detail = apple_mdm.FmtDDMError(r.Reasons)
-		case declarationReasonCode(r, fleet.MDMAppleDDMReasonPredicate) != nil:
-			// The predicate evaluated false, so the device deliberately didn't
-			// apply the configuration. Fleet delivered it correctly, so this is
-			// verified rather than failed, with the reason surfaced in detail.
-			status = fleet.MDMDeliveryVerified
-			detail = fmtDDMPredicateNotApplied(declarationReasonCode(r, fleet.MDMAppleDDMReasonPredicate))
 		case r.Active && r.Valid == fleet.MDMAppleDeclarationValid:
 			status = fleet.MDMDeliveryVerified
 		case r.Valid == fleet.MDMAppleDeclarationInvalid || isUnknownDeclarationType(r):
@@ -7608,6 +7618,17 @@ func (svc *MDMAppleDDMService) handleDeclarationStatus(ctx context.Context, dm *
 }
 
 // Checks the active, valid and first reason to verify if it is an unknown declaration type error
+// predicateNotApplied returns the activation's Info.Predicate reason when the
+// configuration's Error.ActivationFailed was caused by a predicate evaluating
+// false. Apple puts the activation's identifier in the failure's details.
+func predicateNotApplied(activationFailed *fleet.MDMAppleDDMStatusErrorReason, byActivation map[string]*fleet.MDMAppleDDMStatusErrorReason) *fleet.MDMAppleDDMStatusErrorReason {
+	id, _ := activationFailed.Details["Identifier"].(string)
+	if id == "" {
+		return nil
+	}
+	return byActivation[id]
+}
+
 func declarationReasonCode(r fleet.MDMAppleDDMStatusDeclaration, code string) *fleet.MDMAppleDDMStatusErrorReason {
 	for i := range r.Reasons {
 		if r.Reasons[i].Code == code {

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -7199,6 +7199,7 @@ func (svc *MDMAppleDDMService) handleDeclarationItems(ctx context.Context, hostU
 
 	activations := []fleet.MDMAppleDDMManifest{}
 	configurations := []fleet.MDMAppleDDMManifest{}
+	management := []fleet.MDMAppleDDMManifest{}
 	configurationUUIDs := []string{}
 	var removeDeclarationUUIDsToUpdateToPending []string
 	for _, d := range di {
@@ -7236,14 +7237,28 @@ func (svc *MDMAppleDDMService) handleDeclarationItems(ctx context.Context, hostU
 			}
 		}
 
-		effectiveToken := fleet.EffectiveDDMToken(d.ServerToken, d.VariablesUpdatedAt, d.AssetsUpdatedAt)
+		effectiveToken := fleet.EffectiveDDMToken(d.ServerToken, d.VariablesUpdatedAt, d.AssetsUpdatedAt, d.ActivationUpdatedAt)
+
+		if d.DeclarationType != nil && strings.HasPrefix(*d.DeclarationType, fleet.MDMAppleManagementTypePrefix) {
+			management = append(management, fleet.MDMAppleDDMManifest{
+				Identifier:  d.Identifier,
+				ServerToken: effectiveToken,
+			})
+			continue
+		}
+
 		configurations = append(configurations, fleet.MDMAppleDDMManifest{
 			Identifier:  d.Identifier,
 			ServerToken: effectiveToken,
 		})
 		configurationUUIDs = append(configurationUUIDs, d.DeclarationUUID)
+
+		activationIdentifier := d.DeclarationUUID + fleet.MDMAppleGeneratedActivationSuffix
+		if d.ActivationIdentifier != nil {
+			activationIdentifier = *d.ActivationIdentifier
+		}
 		activations = append(activations, fleet.MDMAppleDDMManifest{
-			Identifier:  fmt.Sprintf("%s.activation", d.Identifier),
+			Identifier:  activationIdentifier,
 			ServerToken: effectiveToken,
 		})
 	}
@@ -7267,22 +7282,24 @@ func (svc *MDMAppleDDMService) handleDeclarationItems(ctx context.Context, hostU
 	// Calculate token based on count and concatenated tokens for install items
 	var count int
 	type tokenSorting struct {
-		token              string
-		variablesUpdatedAt *time.Time
-		assetsUpdatedAt    *time.Time
-		uploadedAt         time.Time
-		declarationUUID    string
+		token               string
+		variablesUpdatedAt  *time.Time
+		assetsUpdatedAt     *time.Time
+		activationUpdatedAt *time.Time
+		uploadedAt          time.Time
+		declarationUUID     string
 	}
 	var tokens []tokenSorting
 	for _, d := range di {
 		if d.OperationType != nil && *d.OperationType == string(fleet.MDMOperationTypeInstall) {
 			// Extract d.ServerToken and order by d.UploadedAt descending and then by d.DeclarationUUID ascending
 			sorting := tokenSorting{
-				token:              d.ServerToken,
-				variablesUpdatedAt: d.VariablesUpdatedAt,
-				assetsUpdatedAt:    d.AssetsUpdatedAt,
-				uploadedAt:         d.UploadedAt,
-				declarationUUID:    d.DeclarationUUID,
+				token:               d.ServerToken,
+				variablesUpdatedAt:  d.VariablesUpdatedAt,
+				assetsUpdatedAt:     d.AssetsUpdatedAt,
+				activationUpdatedAt: d.ActivationUpdatedAt,
+				uploadedAt:          d.UploadedAt,
+				declarationUUID:     d.DeclarationUUID,
 			}
 			tokens = append(tokens, sorting)
 			count++
@@ -7298,14 +7315,16 @@ func (svc *MDMAppleDDMService) handleDeclarationItems(ctx context.Context, hostU
 	var tokenBuilder strings.Builder
 	for _, t := range tokens {
 		// Must match MySQL's CONCAT order and DATETIME(6) string representation
-		// used in MDMAppleDDMDeclarationsToken:
-		//   HEX(mad.token) + IFNULL(variables_updated_at, '') + IFNULL(assets_updated_at, '')
+		// used in MDMAppleDDMDeclarationsToken.
 		tokenBuilder.WriteString(t.token)
 		if t.variablesUpdatedAt != nil {
 			tokenBuilder.WriteString(t.variablesUpdatedAt.Format("2006-01-02 15:04:05.000000"))
 		}
 		if t.assetsUpdatedAt != nil {
 			tokenBuilder.WriteString(t.assetsUpdatedAt.Format("2006-01-02 15:04:05.000000"))
+		}
+		if t.activationUpdatedAt != nil {
+			tokenBuilder.WriteString(t.activationUpdatedAt.Format("2006-01-02 15:04:05.000000"))
 		}
 	}
 
@@ -7322,7 +7341,7 @@ func (svc *MDMAppleDDMService) handleDeclarationItems(ctx context.Context, hostU
 			Activations:    activations,
 			Configurations: configurations,
 			Assets:         ddmAssets,
-			Management:     []fleet.MDMAppleDDMManifest{},
+			Management:     management,
 		},
 		DeclarationsToken: token,
 	})
@@ -7354,7 +7373,9 @@ func (svc *MDMAppleDDMService) handleDeclarationsResponse(ctx context.Context, e
 	case "activation":
 		return svc.handleActivationDeclaration(ctx, parts, hostUUID, scope)
 	case "configuration":
-		return svc.handleConfigurationDeclaration(ctx, parts, hostUUID, scope)
+		return svc.handleConfigurationDeclaration(ctx, parts, hostUUID, scope, false)
+	case "management":
+		return svc.handleConfigurationDeclaration(ctx, parts, hostUUID, scope, true)
 	case "asset":
 		return svc.handleDeclarationAsset(ctx, parts, hostUUID)
 	default:
@@ -7396,15 +7417,18 @@ func (svc *MDMAppleDDMService) handleDeclarationAsset(ctx context.Context, parts
 }
 
 func (svc *MDMAppleDDMService) handleActivationDeclaration(ctx context.Context, parts []string, hostUUID string, scope fleet.PayloadScope) ([]byte, error) {
-	references := strings.TrimSuffix(parts[2], ".activation")
-
-	// ensure the declaration for the requested activation still exists
-	d, err := svc.ds.MDMAppleDDMDeclarationsResponse(ctx, references, hostUUID, scope)
+	act, err := svc.ds.MDMAppleDDMActivationResponse(ctx, parts[2], hostUUID, scope)
 	if err != nil {
 		if fleet.IsNotFound(err) {
 			return nil, nano_service.NewHTTPStatusError(http.StatusNotFound, err)
 		}
-		return nil, ctxerr.Wrap(ctx, err, "getting linked configuration for activation declaration")
+		return nil, ctxerr.Wrap(ctx, err, "getting activation declaration")
+	}
+
+	effectiveToken := fleet.EffectiveDDMToken(act.Token, act.VariablesUpdatedAt, act.AssetsUpdatedAt, act.ActivationUpdatedAt)
+
+	if len(act.RawJSON) > 0 {
+		return svc.serveCustomActivation(ctx, act, hostUUID, effectiveToken)
 	}
 
 	response := fmt.Sprintf(`
@@ -7415,18 +7439,55 @@ func (svc *MDMAppleDDMService) handleActivationDeclaration(ctx context.Context, 
   },
   "ServerToken": "%s",
   "Type": "com.apple.activation.simple"
-}`, parts[2], references, fleet.EffectiveDDMToken(d.Token, d.VariablesUpdatedAt, d.AssetsUpdatedAt))
+}`, parts[2], act.ConfigurationIdentifier, effectiveToken)
 
 	return []byte(response), nil
 }
 
-func (svc *MDMAppleDDMService) handleConfigurationDeclaration(ctx context.Context, parts []string, hostUUID string, scope fleet.PayloadScope) ([]byte, error) {
+func (svc *MDMAppleDDMService) serveCustomActivation(ctx context.Context, act *fleet.MDMAppleDDMActivationForDelivery, hostUUID, effectiveToken string) ([]byte, error) {
+	expanded, err := svc.ds.ExpandEmbeddedSecrets(ctx, string(act.RawJSON))
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "expanding embedded secrets for activation")
+	}
+
+	expanded, err = svc.replaceDeclarationFleetVariables(ctx, expanded, hostUUID)
+	if err != nil {
+		if err := svc.markDeclarationFailed(ctx, hostUUID, act.DeclarationUUID, err.Error()); err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "mark declaration as failed")
+		}
+		return nil, nil
+	}
+
+	var tempd map[string]any
+	if err := json.Unmarshal([]byte(expanded), &tempd); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "unmarshaling stored activation")
+	}
+	tempd["ServerToken"] = effectiveToken
+
+	b, err := json.Marshal(tempd)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "marshaling activation")
+	}
+	return b, nil
+}
+
+func (svc *MDMAppleDDMService) handleConfigurationDeclaration(ctx context.Context, parts []string, hostUUID string, scope fleet.PayloadScope, wantManagement bool) ([]byte, error) {
 	d, err := svc.ds.MDMAppleDDMDeclarationsResponse(ctx, parts[2], hostUUID, scope)
 	if err != nil {
 		if fleet.IsNotFound(err) {
 			return nil, nano_service.NewHTTPStatusError(http.StatusNotFound, err)
 		}
 		return nil, ctxerr.Wrap(ctx, err, "getting declaration response")
+	}
+
+	// The two endpoints share a lookup but must not serve each other's rows.
+	rawDecl, err := fleet.GetRawDeclarationValues(d.RawJSON)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "parsing stored declaration")
+	}
+	if isManagement := strings.HasPrefix(rawDecl.Type, fleet.MDMAppleManagementTypePrefix); isManagement != wantManagement {
+		return nil, nano_service.NewHTTPStatusError(http.StatusNotFound,
+			ctxerr.Errorf(ctx, "declaration %s is not served by this endpoint", parts[2]))
 	}
 
 	expanded, err := svc.ds.ExpandEmbeddedSecrets(ctx, string(d.RawJSON))
@@ -7459,7 +7520,7 @@ func (svc *MDMAppleDDMService) handleConfigurationDeclaration(ctx context.Contex
 	// normally stripped at delivery time since it is not a part of the Apple
 	// schema and unused by the device.
 	delete(tempd, "PayloadScope")
-	tempd["ServerToken"] = fleet.EffectiveDDMToken(d.Token, d.VariablesUpdatedAt, d.AssetsUpdatedAt) //nolint:nilaway // tempd is non-nil after successful json.Unmarshal
+	tempd["ServerToken"] = fleet.EffectiveDDMToken(d.Token, d.VariablesUpdatedAt, d.AssetsUpdatedAt, d.ActivationUpdatedAt) //nolint:nilaway // tempd is non-nil after successful json.Unmarshal
 
 	b, err := json.Marshal(tempd)
 	if err != nil {
@@ -7474,18 +7535,34 @@ func (svc *MDMAppleDDMService) handleDeclarationStatus(ctx context.Context, dm *
 		return ctxerr.Wrap(ctx, err, "unmarshalling response")
 	}
 
-	configurationReports := statusReport.StatusItems.Management.Declarations.Configurations
+	// Management declarations report under their own section but are tracked in
+	// the same host_mdm_apple_declarations rows as configurations.
+	configurationReports := append(
+		append([]fleet.MDMAppleDDMStatusDeclaration{}, statusReport.StatusItems.Management.Declarations.Configurations...),
+		statusReport.StatusItems.Management.Declarations.Management...,
+	)
 	updates := make([]*fleet.MDMAppleHostDeclaration, len(configurationReports))
 	for i, r := range configurationReports {
 		var status fleet.MDMDeliveryStatus
 		var detail string
 		switch {
+		case declarationReasonCode(r, fleet.MDMAppleDDMReasonActivationFailed) != nil:
+			// The activation itself failed, predicate included. Treated like any
+			// other client-side failure.
+			status = fleet.MDMDeliveryFailed
+			detail = apple_mdm.FmtDDMError(r.Reasons)
+		case declarationReasonCode(r, fleet.MDMAppleDDMReasonPredicate) != nil:
+			// The predicate evaluated false, so the device deliberately didn't
+			// apply the configuration. Fleet delivered it correctly, so this is
+			// verified rather than failed, with the reason surfaced in detail.
+			status = fleet.MDMDeliveryVerified
+			detail = fmtDDMPredicateNotApplied(declarationReasonCode(r, fleet.MDMAppleDDMReasonPredicate))
 		case r.Active && r.Valid == fleet.MDMAppleDeclarationValid:
 			status = fleet.MDMDeliveryVerified
 		case r.Valid == fleet.MDMAppleDeclarationInvalid || isUnknownDeclarationType(r):
 			status = fleet.MDMDeliveryFailed
 			detail = apple_mdm.FmtDDMError(r.Reasons)
-		case r.Valid == fleet.MDMAppleDeclarationValid: // should be rare/never
+		case r.Valid == fleet.MDMAppleDeclarationValid:
 			// The debug messages here can be used to figure out why a DDM profile is stuck in a certain state on a device.
 			svc.logger.DebugContext(ctx, "valid but inactive declaration status",
 				"status", r.Valid, "active", r.Active, "host", dm.Identifier(), "declaration", r.Identifier)
@@ -7531,6 +7608,29 @@ func (svc *MDMAppleDDMService) handleDeclarationStatus(ctx context.Context, dm *
 }
 
 // Checks the active, valid and first reason to verify if it is an unknown declaration type error
+func declarationReasonCode(r fleet.MDMAppleDDMStatusDeclaration, code string) *fleet.MDMAppleDDMStatusErrorReason {
+	for i := range r.Reasons {
+		if r.Reasons[i].Code == code {
+			return &r.Reasons[i]
+		}
+	}
+	return nil
+}
+
+// fmtDDMPredicateNotApplied explains a configuration the device validated but
+// deliberately didn't apply, quoting the predicate when Apple supplies it.
+func fmtDDMPredicateNotApplied(reason *fleet.MDMAppleDDMStatusErrorReason) string {
+	if reason == nil {
+		return ""
+	}
+	for _, k := range []string{"Predicate", "predicate"} {
+		if v, ok := reason.Details[k]; ok {
+			return fmt.Sprintf("Fleet verified, but predicate (%v) evaluated to false and settings were not applied to this host.", v)
+		}
+	}
+	return "Fleet verified, but the activation predicate evaluated to false and settings were not applied to this host."
+}
+
 func isUnknownDeclarationType(declarationResponse fleet.MDMAppleDDMStatusDeclaration) bool {
 	return !declarationResponse.Active &&
 		declarationResponse.Valid == fleet.MDMAppleDeclarationUnknown &&

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -7197,10 +7197,29 @@ func (svc *MDMAppleDDMService) handleDeclarationItems(ctx context.Context, hostU
 		return nil, ctxerr.Wrap(ctx, err, "getting synchronization tokens")
 	}
 
-	activations := []fleet.MDMAppleDDMManifest{}
-	configurations := []fleet.MDMAppleDDMManifest{}
-	management := []fleet.MDMAppleDDMManifest{}
-	declarationUUIDs := []string{}
+	// Custom activations are fetched separately so the activation section is
+	// built from activation data, with its own token and its own variable check,
+	// rather than columns carried along on each declaration row.
+	allDeclUUIDs := make([]string, 0, len(di))
+	for _, d := range di {
+		allDeclUUIDs = append(allDeclUUIDs, d.DeclarationUUID)
+	}
+	customActivations, err := svc.ds.ListCustomActivationsForDeclarations(ctx, allDeclUUIDs)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "listing custom activations")
+	}
+	activationByDecl := make(map[string]*fleet.MDMAppleDDMActivationItem, len(customActivations))
+	for _, a := range customActivations {
+		activationByDecl[a.DeclarationUUID] = a
+	}
+
+	// Pass 1: keep the declarations this host should install, and record the
+	// removes that still need marking pending.
+	type installable struct {
+		item           fleet.MDMAppleDDMDeclarationItem
+		effectiveToken string
+	}
+	var toInstall []installable
 	var removeDeclarationUUIDsToUpdateToPending []string
 	for _, d := range di {
 		if d.OperationType == nil {
@@ -7219,69 +7238,93 @@ func (svc *MDMAppleDDMService) handleDeclarationItems(ctx context.Context, hostU
 		// fetch or apply it. NOTE: the declaration is still included in the token
 		// computation below so that the token matches the SQL-computed
 		// token from handleTokens.
-		// The activation is expanded at delivery too, so an unresolvable variable
-		// there has to drop the declaration here as well -- otherwise the manifest
-		// advertises an activation the host can never fetch.
-		if d.VariablesUpdatedAt != nil {
-			var unresolvable error
-			for _, raw := range []*json.RawMessage{d.RawJSON, d.ActivationRawJSON} {
-				if raw == nil {
-					continue
-				}
-				if _, err := svc.replaceDeclarationFleetVariables(ctx, string(*raw), hostUUID); err != nil {
-					unresolvable = err
-					break
-				}
-			}
-			if unresolvable != nil {
-				if nryErr, ok := errors.AsType[notReadyYetError](unresolvable); ok {
+		if d.VariablesUpdatedAt != nil && d.RawJSON != nil {
+			if _, err := svc.replaceDeclarationFleetVariables(ctx, string(*d.RawJSON), hostUUID); err != nil {
+				if nryErr, ok := errors.AsType[notReadyYetError](err); ok {
 					if err := svc.markDeclarationPending(ctx, hostUUID, d.DeclarationUUID, nryErr.Message); err != nil {
 						return nil, ctxerr.Wrap(ctx, err, "mark declaration as pending")
 					}
 					continue
 				}
-				if err := svc.markDeclarationFailed(ctx, hostUUID, d.DeclarationUUID, unresolvable.Error()); err != nil {
+				if err := svc.markDeclarationFailed(ctx, hostUUID, d.DeclarationUUID, err.Error()); err != nil {
 					return nil, ctxerr.Wrap(ctx, err, "mark declaration as failed")
 				}
 				continue
 			}
 		}
 
-		effectiveToken := fleet.EffectiveDDMToken(d.ServerToken, d.VariablesUpdatedAt, d.AssetsUpdatedAt, d.ActivationUpdatedAt)
+		toInstall = append(toInstall, installable{
+			item:           d,
+			effectiveToken: fleet.EffectiveDDMToken(d.ServerToken, d.VariablesUpdatedAt, d.AssetsUpdatedAt, d.ActivationUpdatedAt),
+		})
+	}
+
+	// Pass 2: build the activations. A custom activation is expanded at delivery
+	// like a declaration, so its variables are checked here -- against the
+	// activation itself, which may carry variables the declaration doesn't.
+	activations := []fleet.MDMAppleDDMManifest{}
+	failedByActivation := make(map[string]struct{})
+	for _, in := range toInstall {
+		d := in.item
+		if d.DeclarationType != nil && strings.HasPrefix(*d.DeclarationType, fleet.MDMAppleManagementTypePrefix) {
+			// Activations only take StandardConfigurations, never management.
+			continue
+		}
+
+		act := activationByDecl[d.DeclarationUUID]
+		if act == nil {
+			activations = append(activations, fleet.MDMAppleDDMManifest{
+				Identifier:  d.DeclarationUUID + fleet.MDMAppleGeneratedActivationSuffix,
+				ServerToken: in.effectiveToken,
+			})
+			continue
+		}
+
+		if act.HasFleetVariables {
+			if _, err := svc.replaceDeclarationFleetVariables(ctx, string(act.RawJSON), hostUUID); err != nil {
+				// Same not-ready-yet distinction the declaration gets: a value that
+				// hasn't arrived yet is pending, not a failure.
+				if nryErr, ok := errors.AsType[notReadyYetError](err); ok {
+					if err := svc.markDeclarationPending(ctx, hostUUID, d.DeclarationUUID, nryErr.Message); err != nil {
+						return nil, ctxerr.Wrap(ctx, err, "mark declaration as pending")
+					}
+					failedByActivation[d.DeclarationUUID] = struct{}{}
+					continue
+				}
+				if err := svc.markDeclarationFailed(ctx, hostUUID, d.DeclarationUUID, err.Error()); err != nil {
+					return nil, ctxerr.Wrap(ctx, err, "mark declaration as failed")
+				}
+				failedByActivation[d.DeclarationUUID] = struct{}{}
+				continue
+			}
+		}
+
+		activations = append(activations, fleet.MDMAppleDDMManifest{
+			Identifier:  act.Identifier,
+			ServerToken: act.Token,
+		})
+	}
+
+	// Pass 3: the core profile flow.
+	configurations := []fleet.MDMAppleDDMManifest{}
+	management := []fleet.MDMAppleDDMManifest{}
+	declarationUUIDs := []string{}
+	for _, in := range toInstall {
+		d := in.item
+		if _, failed := failedByActivation[d.DeclarationUUID]; failed {
+			continue
+		}
 
 		// Management declarations can reference assets too (organization-info
 		// carries one), so they belong in the asset lookup as well.
 		declarationUUIDs = append(declarationUUIDs, d.DeclarationUUID)
 
+		entry := fleet.MDMAppleDDMManifest{Identifier: d.Identifier, ServerToken: in.effectiveToken}
 		if d.DeclarationType != nil && strings.HasPrefix(*d.DeclarationType, fleet.MDMAppleManagementTypePrefix) {
-			management = append(management, fleet.MDMAppleDDMManifest{
-				Identifier:  d.Identifier,
-				ServerToken: effectiveToken,
-			})
+			management = append(management, entry)
 			continue
 		}
-
-		configurations = append(configurations, fleet.MDMAppleDDMManifest{
-			Identifier:  d.Identifier,
-			ServerToken: effectiveToken,
-		})
-
-		// A synthesized activation has no content of its own, so it rides on the
-		// declaration's effective token. A custom one is independent content and
-		// carries its own, so editing the declaration or an asset it references
-		// no longer forces the host to re-fetch the activation.
-		activationIdentifier := d.DeclarationUUID + fleet.MDMAppleGeneratedActivationSuffix
-		activationToken := effectiveToken
-		if d.ActivationIdentifier != nil {
-			activationIdentifier = *d.ActivationIdentifier
-			if d.ActivationToken != nil {
-				activationToken = *d.ActivationToken
-			}
-		}
-		activations = append(activations, fleet.MDMAppleDDMManifest{
-			Identifier:  activationIdentifier,
-			ServerToken: activationToken,
-		})
+		configurations = append(configurations, entry)
 	}
 
 	referencedAssets, err := svc.ds.GetAppleDDMAssetsReferencedByDeclarations(ctx, declarationUUIDs)
@@ -7575,7 +7618,7 @@ func (svc *MDMAppleDDMService) handleDeclarationStatus(ctx context.Context, dm *
 	}
 
 	// Configurations and management declarations are graded differently, so
-	// each gets its own pass rather than one switch juggling both.
+	// each gets its own pass.
 	decls := statusReport.StatusItems.Management.Declarations
 	updates := make([]*fleet.MDMAppleHostDeclaration, 0, len(decls.Configurations)+len(decls.Management))
 	for _, r := range decls.Configurations {

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -7458,7 +7458,7 @@ func (svc *MDMAppleDDMService) serveCustomActivation(ctx context.Context, act *f
 		return nil, nil
 	}
 
-	var tempd map[string]any
+	tempd := make(map[string]any)
 	if err := json.Unmarshal([]byte(expanded), &tempd); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "unmarshaling stored activation")
 	}

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -7301,7 +7301,7 @@ func (svc *MDMAppleDDMService) handleDeclarationItems(ctx context.Context, hostU
 
 		activations = append(activations, fleet.MDMAppleDDMManifest{
 			Identifier:  act.Identifier,
-			ServerToken: act.Token,
+			ServerToken: fleet.EffectiveDDMToken(act.Token, in.item.VariablesUpdatedAt, nil, nil),
 		})
 	}
 
@@ -7529,9 +7529,10 @@ func (svc *MDMAppleDDMService) serveCustomActivation(ctx context.Context, act *f
 	if err := json.Unmarshal([]byte(expanded), &tempd); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "unmarshaling stored activation")
 	}
+	// Must match what handleDeclarationItems advertised for this activation.
 	serverToken := effectiveToken
 	if act.ActivationToken != nil {
-		serverToken = *act.ActivationToken
+		serverToken = fleet.EffectiveDDMToken(*act.ActivationToken, act.VariablesUpdatedAt, nil, nil)
 	}
 	tempd["ServerToken"] = serverToken
 

--- a/server/service/apple_mdm_ddm_test.go
+++ b/server/service/apple_mdm_ddm_test.go
@@ -596,31 +596,86 @@ func TestDeclarativeManagement_DeclarationItems(t *testing.T) {
 	})
 
 	t.Run("PredicateStatusMapping", func(t *testing.T) {
+		// Payloads below are the real reports a macOS 26 host sent to a Fleet
+		// server, not hand-written. Apple splits a predicate outcome across two
+		// arrays: the activation carries Info.Predicate, while the configuration
+		// it gates reports Error.ActivationFailed. Reading only the
+		// configuration makes a host the predicate simply excluded look failed.
+		predicateFalse := func(configIdent, activationIdent, token string) fleet.MDMAppleDDMStatusReport {
+			var r fleet.MDMAppleDDMStatusReport
+			r.StatusItems.Management.Declarations.Activations = []fleet.MDMAppleDDMStatusDeclaration{{
+				Identifier:  activationIdent,
+				Active:      false,
+				Valid:       fleet.MDMAppleDeclarationValid,
+				ServerToken: token,
+				Reasons: []fleet.MDMAppleDDMStatusErrorReason{{
+					Code:        fleet.MDMAppleDDMReasonPredicate,
+					Description: "Activations (" + activationIdent + ") predicate (FALSEPREDICATE) evaluated to false.",
+					Details: map[string]any{
+						"Identifier":  activationIdent,
+						"ServerToken": token,
+						"Predicate":   "FALSEPREDICATE",
+					},
+				}},
+			}}
+			r.StatusItems.Management.Declarations.Configurations = []fleet.MDMAppleDDMStatusDeclaration{{
+				Identifier:  configIdent,
+				Active:      false,
+				Valid:       fleet.MDMAppleDeclarationUnknown,
+				ServerToken: token,
+				Reasons: []fleet.MDMAppleDDMStatusErrorReason{{
+					Code:        fleet.MDMAppleDDMReasonActivationFailed,
+					Description: "Activation " + activationIdent + " has errors.",
+					Details: map[string]any{
+						"Identifier":  activationIdent,
+						"ServerToken": token,
+					},
+				}},
+			}}
+			return r
+		}
+
+		// Same shape, but the activation reports no Info.Predicate -- the
+		// activation genuinely failed rather than being scoped out.
+		activationBroken := func(configIdent, activationIdent, token string) fleet.MDMAppleDDMStatusReport {
+			r := predicateFalse(configIdent, activationIdent, token)
+			r.StatusItems.Management.Declarations.Activations[0].Reasons = nil
+			return r
+		}
+
+		applied := func(configIdent, token string) fleet.MDMAppleDDMStatusReport {
+			var r fleet.MDMAppleDDMStatusReport
+			r.StatusItems.Management.Declarations.Configurations = []fleet.MDMAppleDDMStatusDeclaration{{
+				Identifier:  configIdent,
+				Active:      true,
+				Valid:       fleet.MDMAppleDeclarationValid,
+				ServerToken: token,
+			}}
+			return r
+		}
+
 		cases := []struct {
 			name       string
-			reasons    []fleet.MDMAppleDDMStatusErrorReason
-			active     bool
-			valid      fleet.MDMAppleDeclarationValidity
+			report     func(configIdent, activationIdent, token string) fleet.MDMAppleDDMStatusReport
 			wantStatus fleet.MDMDeliveryStatus
 			wantDetail string
 		}{
 			{
-				name:       "predicate false is verified, not failed",
-				reasons:    []fleet.MDMAppleDDMStatusErrorReason{{Code: fleet.MDMAppleDDMReasonPredicate, Details: map[string]any{"Predicate": `status.device.model.family == "MacbookPro18"`}}},
-				valid:      fleet.MDMAppleDeclarationValid,
+				name:       "predicate excluded the host is verified, not failed",
+				report:     predicateFalse,
 				wantStatus: fleet.MDMDeliveryVerified,
-				wantDetail: `Fleet verified, but predicate (status.device.model.family == "MacbookPro18") evaluated to false and settings were not applied to this host.`,
+				wantDetail: "Fleet verified, but predicate (FALSEPREDICATE) evaluated to false and settings were not applied to this host.",
 			},
 			{
-				name:       "predicate failure is failed",
-				reasons:    []fleet.MDMAppleDDMStatusErrorReason{{Code: fleet.MDMAppleDDMReasonActivationFailed, Description: "bad predicate"}},
-				valid:      fleet.MDMAppleDeclarationInvalid,
+				name:       "activation failure without a predicate reason is failed",
+				report:     activationBroken,
 				wantStatus: fleet.MDMDeliveryFailed,
 			},
 			{
-				name:       "no predicate reason keeps existing mapping",
-				active:     true,
-				valid:      fleet.MDMAppleDeclarationValid,
+				name: "applied configuration is verified",
+				report: func(configIdent, _ string, token string) fleet.MDMAppleDDMStatusReport {
+					return applied(configIdent, token)
+				},
 				wantStatus: fleet.MDMDeliveryVerified,
 			},
 		}
@@ -633,24 +688,18 @@ func TestDeclarativeManagement_DeclarationItems(t *testing.T) {
 				createHost(t, hostUUID, hardwareSerial)
 				setupDeviceAndEnrollment(t, hostUUID, hardwareSerial)
 
+				configIdent := "com.example.pred." + suffix
+				activationIdent := configIdent + ".custom"
 				decl, err := ds.NewMDMAppleDeclaration(ctx, &fleet.MDMAppleDeclaration{
 					Name:       "PredDecl-" + suffix,
-					Identifier: "com.example.pred." + suffix,
-					RawJSON:    []byte(`{"Type":"com.apple.configuration.test","Identifier":"com.example.pred","Payload":{"Enabled":true}}`),
+					Identifier: configIdent,
+					RawJSON:    []byte(`{"Type":"com.apple.configuration.test","Identifier":"` + configIdent + `","Payload":{"Enabled":true}}`),
 					Scope:      fleet.PayloadScopeSystem,
 				}, nil)
 				require.NoError(t, err)
 				token := insertHostDeclaration(t, hostUUID, decl.DeclarationUUID, "pending", "install", decl.Identifier)
 
-				report := fleet.MDMAppleDDMStatusReport{}
-				report.StatusItems.Management.Declarations.Configurations = []fleet.MDMAppleDDMStatusDeclaration{{
-					Active:      c.active,
-					Identifier:  decl.Identifier,
-					Valid:       c.valid,
-					ServerToken: token,
-					Reasons:     c.reasons,
-				}}
-				raw, err := json.Marshal(report)
+				raw, err := json.Marshal(c.report(configIdent, activationIdent, token))
 				require.NoError(t, err)
 
 				req := mdm.Request{Context: ctx, EnrollID: &mdm.EnrollID{ID: hostUUID}}
@@ -675,92 +724,6 @@ func TestDeclarativeManagement_DeclarationItems(t *testing.T) {
 				}
 			})
 		}
-	})
-
-	t.Run("CustomActivationIsServedInsteadOfGenerated", func(t *testing.T) {
-		hostUUID := "test-host-uuid-custom-act"
-		hardwareSerial := "ABC123-CUSTOMACT"
-
-		createHost(t, hostUUID, hardwareSerial)
-		setupDeviceAndEnrollment(t, hostUUID, hardwareSerial)
-
-		activationRaw := `{"Type":"com.apple.activation.simple","Identifier":"com.example.custom.act",` +
-			`"Payload":{"StandardConfigurations":["com.example.customact"],"Predicate":"@status(os.version.major) >= 15"}}`
-		decl, err := ds.NewMDMAppleDeclaration(ctx, &fleet.MDMAppleDeclaration{
-			Name:       "CustomActDecl",
-			Identifier: "com.example.customact",
-			RawJSON:    []byte(`{"Type":"com.apple.configuration.test","Identifier":"com.example.customact","Payload":{"Enabled":true}}`),
-			Scope:      fleet.PayloadScopeSystem,
-			Activation: &fleet.MDMAppleCustomActivation{
-				Identifier:              "com.example.custom.act",
-				RawJSON:                 []byte(activationRaw),
-				ConfigurationIdentifier: "com.example.customact",
-			},
-		}, nil)
-		require.NoError(t, err)
-		insertHostDeclaration(t, hostUUID, decl.DeclarationUUID, "pending", "install", decl.Identifier)
-
-		// The manifest advertises the admin's identifier, not a generated one.
-		manifest := callDeclarativeManagementAndVerify(t, hostUUID, 1, 1)
-		require.Equal(t, "com.example.custom.act", manifest.Declarations.Activations[0].Identifier)
-
-		// Fetching it returns the stored document, predicate intact.
-		req := mdm.Request{Context: ctx, EnrollID: &mdm.EnrollID{ID: hostUUID}}
-		dm := mdm.DeclarativeManagement{}
-		dm.UDID = hostUUID
-		dm.Endpoint = "declaration/activation/com.example.custom.act"
-		response, err := ddmService.DeclarativeManagement(&req, &dm)
-		require.NoError(t, err)
-
-		var served map[string]any
-		require.NoError(t, json.Unmarshal(response, &served))
-		require.Equal(t, "com.example.custom.act", served["Identifier"])
-		payload, ok := served["Payload"].(map[string]any)
-		require.True(t, ok)
-		require.Equal(t, "@status(os.version.major) >= 15", payload["Predicate"])
-		require.Equal(t, []any{"com.example.customact"}, payload["StandardConfigurations"])
-
-		// The generated name must not also resolve, or both would be valid.
-		dm.Endpoint = "declaration/activation/" + decl.DeclarationUUID + ".activation"
-		_, err = ddmService.DeclarativeManagement(&req, &dm)
-		require.Error(t, err)
-	})
-
-	t.Run("GeneratedActivationStillServedWhenNoCustomOne", func(t *testing.T) {
-		hostUUID := "test-host-uuid-gen-act"
-		hardwareSerial := "ABC123-GENACT"
-
-		createHost(t, hostUUID, hardwareSerial)
-		setupDeviceAndEnrollment(t, hostUUID, hardwareSerial)
-
-		decl, err := ds.NewMDMAppleDeclaration(ctx, &fleet.MDMAppleDeclaration{
-			Name:       "GenActDecl",
-			Identifier: "com.example.genact",
-			RawJSON:    []byte(`{"Type":"com.apple.configuration.test","Identifier":"com.example.genact","Payload":{"Enabled":true}}`),
-			Scope:      fleet.PayloadScopeSystem,
-		}, nil)
-		require.NoError(t, err)
-		insertHostDeclaration(t, hostUUID, decl.DeclarationUUID, "pending", "install", decl.Identifier)
-
-		manifest := callDeclarativeManagementAndVerify(t, hostUUID, 1, 1)
-		generated := decl.DeclarationUUID + ".activation"
-		require.Equal(t, generated, manifest.Declarations.Activations[0].Identifier)
-
-		req := mdm.Request{Context: ctx, EnrollID: &mdm.EnrollID{ID: hostUUID}}
-		dm := mdm.DeclarativeManagement{}
-		dm.UDID = hostUUID
-		dm.Endpoint = "declaration/activation/" + generated
-		response, err := ddmService.DeclarativeManagement(&req, &dm)
-		require.NoError(t, err)
-
-		var served map[string]any
-		require.NoError(t, json.Unmarshal(response, &served))
-		require.Equal(t, "com.apple.activation.simple", served["Type"])
-		require.Equal(t, generated, served["Identifier"])
-		payload, ok := served["Payload"].(map[string]any)
-		require.True(t, ok)
-		// still references the configuration by identifier, as before
-		require.Equal(t, []any{"com.example.genact"}, payload["StandardConfigurations"])
 	})
 
 	t.Run("CustomActivationIsScopedToHostsThatHaveTheDeclaration", func(t *testing.T) {

--- a/server/service/apple_mdm_ddm_test.go
+++ b/server/service/apple_mdm_ddm_test.go
@@ -894,6 +894,45 @@ func TestDeclarativeManagement_DeclarationItems(t *testing.T) {
 			"the served activation token must match the manifest")
 	})
 
+	t.Run("ActivationVariablesCheckedWhenDeclarationHasNone", func(t *testing.T) {
+		hostUUID, hardwareSerial := "test-host-uuid-actvar", "ACT-VAR"
+		createHost(t, hostUUID, hardwareSerial)
+		setupDeviceAndEnrollment(t, hostUUID, hardwareSerial)
+
+		teamID := uint(44)
+		decl, err := ds.NewMDMAppleDeclaration(ctx, &fleet.MDMAppleDeclaration{
+			Name:       "ActVarDecl",
+			Identifier: "com.example.actvar",
+			TeamID:     &teamID,
+			// No variables in the declaration itself.
+			RawJSON: []byte(`{"Type":"com.apple.configuration.test","Identifier":"com.example.actvar","Payload":{"Enabled":true}}`),
+			Scope:   fleet.PayloadScopeSystem,
+			Activation: &fleet.MDMAppleCustomActivation{
+				Identifier: "com.example.actvar.act",
+				// ...but the activation references a vital that doesn't exist.
+				RawJSON:                 []byte(`{"Type":"com.apple.activation.simple","Identifier":"com.example.actvar.act","Payload":{"StandardConfigurations":["com.example.actvar"],"Predicate":"$FLEET_HOST_VITAL_999999 == 'x'"}}`),
+				ConfigurationIdentifier: "com.example.actvar",
+			},
+		}, nil)
+		require.NoError(t, err)
+		insertHostDeclaration(t, hostUUID, decl.DeclarationUUID, "pending", "install", decl.Identifier)
+
+		// The activation's variables have to be checked on the activation itself.
+		// Gating on the declaration's variables_updated_at skipped this entirely,
+		// leaving the host with an activation it could never resolve.
+		manifest := callDeclarativeManagementAndVerify(t, hostUUID, 0, 0)
+		require.Empty(t, manifest.Declarations.Configurations)
+		require.Empty(t, manifest.Declarations.Activations)
+
+		var status string
+		mysqltest.ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			return sqlx.GetContext(ctx, q, &status,
+				`SELECT status FROM host_mdm_apple_declarations WHERE host_uuid = ? AND declaration_uuid = ?`,
+				hostUUID, decl.DeclarationUUID)
+		})
+		require.Equal(t, string(fleet.MDMDeliveryFailed), status)
+	})
+
 	t.Run("ManagementDeclarationRoutingAndEndpointGuard", func(t *testing.T) {
 		hostUUID := "test-host-uuid-mgmt"
 		hardwareSerial := "ABC123-MGMT"

--- a/server/service/apple_mdm_ddm_test.go
+++ b/server/service/apple_mdm_ddm_test.go
@@ -508,6 +508,17 @@ func TestDeclarativeManagement_DeclarationItems(t *testing.T) {
 		userDecl, err := ds.NewMDMAppleDeclaration(ctx, userDeclRaw, nil)
 		require.NoError(t, err)
 
+		// Apple supports management declarations on the user channel too, and
+		// nothing in Fleet scopes by declaration type, so it must ride along.
+		userMgmtDecl, err := ds.NewMDMAppleDeclaration(ctx, &fleet.MDMAppleDeclaration{
+			DeclarationUUID: "user-scope-user-mgmt",
+			Name:            "UserMgmtDecl",
+			Identifier:      "com.example.userscope.mgmt",
+			RawJSON:         []byte(`{"Type":"com.apple.management.organization-info","Identifier":"com.example.userscope.mgmt","Payload":{"Name":"Fleet"}}`),
+			Scope:           fleet.PayloadScopeUser,
+		}, nil)
+		require.NoError(t, err)
+
 		insertScopedHostDeclaration := func(declUUID, identifier string, scope fleet.PayloadScope) {
 			mysqltest.ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
 				var token string
@@ -524,6 +535,7 @@ func TestDeclarativeManagement_DeclarationItems(t *testing.T) {
 		}
 		insertScopedHostDeclaration(deviceDecl.DeclarationUUID, deviceDecl.Identifier, fleet.PayloadScopeSystem)
 		insertScopedHostDeclaration(userDecl.DeclarationUUID, userDecl.Identifier, fleet.PayloadScopeUser)
+		insertScopedHostDeclaration(userMgmtDecl.DeclarationUUID, userMgmtDecl.Identifier, fleet.PayloadScopeUser)
 
 		callChannel := func(enrollID *mdm.EnrollID) fleet.MDMAppleDDMDeclarationItemsResponse {
 			req := mdm.Request{Context: ctx, EnrollID: enrollID}
@@ -543,6 +555,7 @@ func TestDeclarativeManagement_DeclarationItems(t *testing.T) {
 		deviceResp := callChannel(&mdm.EnrollID{ID: hostUUID})
 		require.Len(t, deviceResp.Declarations.Configurations, 1)
 		require.Equal(t, deviceDecl.Identifier, deviceResp.Declarations.Configurations[0].Identifier)
+		require.Empty(t, deviceResp.Declarations.Management, "the user-scoped management declaration must not leak to the device channel")
 		sysToken, err := ds.MDMAppleDDMDeclarationsToken(ctx, hostUUID, fleet.PayloadScopeSystem)
 		require.NoError(t, err)
 		require.Equal(t, sysToken.DeclarationsToken, deviceResp.DeclarationsToken)
@@ -552,6 +565,8 @@ func TestDeclarativeManagement_DeclarationItems(t *testing.T) {
 		userResp := callChannel(&mdm.EnrollID{ID: userEnrollmentID, ParentID: hostUUID})
 		require.Len(t, userResp.Declarations.Configurations, 1)
 		require.Equal(t, userDecl.Identifier, userResp.Declarations.Configurations[0].Identifier)
+		require.Len(t, userResp.Declarations.Management, 1)
+		require.Equal(t, userMgmtDecl.Identifier, userResp.Declarations.Management[0].Identifier)
 		userToken, err := ds.MDMAppleDDMDeclarationsToken(ctx, hostUUID, fleet.PayloadScopeUser)
 		require.NoError(t, err)
 		require.Equal(t, userToken.DeclarationsToken, userResp.DeclarationsToken)

--- a/server/service/apple_mdm_ddm_test.go
+++ b/server/service/apple_mdm_ddm_test.go
@@ -716,6 +716,21 @@ func TestDeclarativeManagement_DeclarationItems(t *testing.T) {
 				wantStatus:  fleet.MDMDeliveryVerifying,
 			},
 			{
+				// Unknown means "not checked yet", but reasons mean something already
+				// went wrong -- without this it would wait for a verdict forever.
+				name: "unknown management declaration reporting errors is failed",
+				report: func(ident, _ string, token string) fleet.MDMAppleDDMStatusReport {
+					r := management(ident, token, fleet.MDMAppleDeclarationUnknown)
+					r.StatusItems.Management.Declarations.Management[0].Reasons = []fleet.MDMAppleDDMStatusErrorReason{{
+						Code:        "Error.InvalidPayload",
+						Description: "ManagementPayload (" + ident + ") has an invalid payload.",
+					}}
+					return r
+				},
+				declRawJSON: `{"Type":"com.apple.management.organization-info","Identifier":"%s","Payload":{"Name":"Fleet"}}`,
+				wantStatus:  fleet.MDMDeliveryFailed,
+			},
+			{
 				name:       "predicate excluded the host is verified, not failed",
 				report:     predicateFalse,
 				wantStatus: fleet.MDMDeliveryVerified,
@@ -834,6 +849,49 @@ func TestDeclarativeManagement_DeclarationItems(t *testing.T) {
 		outDM.Endpoint = "declaration/activation/com.example.scoped.act"
 		_, err = ddmService.DeclarativeManagement(&outReq, &outDM)
 		require.Error(t, err, "a host outside the declaration's scope must not resolve its activation")
+	})
+
+	t.Run("CustomActivationCarriesItsOwnToken", func(t *testing.T) {
+		hostUUID, hardwareSerial := "test-host-uuid-acttoken", "ACT-TOKEN"
+		createHost(t, hostUUID, hardwareSerial)
+		setupDeviceAndEnrollment(t, hostUUID, hardwareSerial)
+
+		teamID := uint(43)
+		decl, err := ds.NewMDMAppleDeclaration(ctx, &fleet.MDMAppleDeclaration{
+			Name:       "ActTokenDecl",
+			Identifier: "com.example.acttoken",
+			TeamID:     &teamID,
+			RawJSON:    []byte(`{"Type":"com.apple.configuration.test","Identifier":"com.example.acttoken","Payload":{"Enabled":true}}`),
+			Scope:      fleet.PayloadScopeSystem,
+			Activation: &fleet.MDMAppleCustomActivation{
+				Identifier:              "com.example.acttoken.act",
+				RawJSON:                 []byte(`{"Type":"com.apple.activation.simple","Identifier":"com.example.acttoken.act","Payload":{"StandardConfigurations":["com.example.acttoken"]}}`),
+				ConfigurationIdentifier: "com.example.acttoken",
+			},
+		}, nil)
+		require.NoError(t, err)
+		insertHostDeclaration(t, hostUUID, decl.DeclarationUUID, "pending", "install", decl.Identifier)
+
+		manifest := callDeclarativeManagementAndVerify(t, hostUUID, 1, 1)
+		advertised := manifest.Declarations.Activations[0].ServerToken
+
+		// The activation's token is its own, not the declaration's: otherwise
+		// editing the declaration would needlessly re-sync the activation.
+		require.NotEqual(t, manifest.Declarations.Configurations[0].ServerToken, advertised,
+			"a custom activation must not ride on the declaration's token")
+
+		// What the device fetches has to carry exactly what was advertised, or it
+		// re-fetches forever.
+		req := mdm.Request{Context: ctx, EnrollID: &mdm.EnrollID{ID: hostUUID}}
+		dm := mdm.DeclarativeManagement{}
+		dm.UDID = hostUUID
+		dm.Endpoint = "declaration/activation/com.example.acttoken.act"
+		served, err := ddmService.DeclarativeManagement(&req, &dm)
+		require.NoError(t, err)
+		var body map[string]any
+		require.NoError(t, json.Unmarshal(served, &body))
+		require.Equal(t, advertised, body["ServerToken"],
+			"the served activation token must match the manifest")
 	})
 
 	t.Run("ManagementDeclarationRoutingAndEndpointGuard", func(t *testing.T) {

--- a/server/service/apple_mdm_ddm_test.go
+++ b/server/service/apple_mdm_ddm_test.go
@@ -894,6 +894,54 @@ func TestDeclarativeManagement_DeclarationItems(t *testing.T) {
 			"the served activation token must match the manifest")
 	})
 
+	t.Run("ActivationTokenFoldsInVariablesUpdatedAt", func(t *testing.T) {
+		hostUUID, hardwareSerial := "test-host-uuid-acttok2", "ACT-TOK2"
+		createHost(t, hostUUID, hardwareSerial)
+		setupDeviceAndEnrollment(t, hostUUID, hardwareSerial)
+
+		teamID := uint(45)
+		decl, err := ds.NewMDMAppleDeclaration(ctx, &fleet.MDMAppleDeclaration{
+			Name:       "ActTokDecl",
+			Identifier: "com.example.acttok",
+			TeamID:     &teamID,
+			RawJSON:    []byte(`{"Type":"com.apple.configuration.test","Identifier":"com.example.acttok","Payload":{"Enabled":true}}`),
+			Scope:      fleet.PayloadScopeSystem,
+			Activation: &fleet.MDMAppleCustomActivation{
+				Identifier:              "com.example.acttok.act",
+				RawJSON:                 []byte(`{"Type":"com.apple.activation.simple","Identifier":"com.example.acttok.act","Payload":{"StandardConfigurations":["com.example.acttok"]}}`),
+				ConfigurationIdentifier: "com.example.acttok",
+			},
+		}, nil)
+		require.NoError(t, err)
+		insertHostDeclaration(t, hostUUID, decl.DeclarationUUID, "pending", "install", decl.Identifier)
+
+		before := callDeclarativeManagementAndVerify(t, hostUUID, 1, 1).Declarations.Activations[0].ServerToken
+
+		// A variable's value changing bumps variables_updated_at. The activation
+		// is expanded per host, so its token has to move too -- otherwise the host
+		// re-syncs, re-fetches the configuration, and keeps the stale activation.
+		mysqltest.ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			_, err := q.ExecContext(ctx,
+				`UPDATE host_mdm_apple_declarations SET variables_updated_at = ? WHERE host_uuid = ? AND declaration_uuid = ?`,
+				time.Now().UTC(), hostUUID, decl.DeclarationUUID)
+			return err
+		})
+
+		after := callDeclarativeManagementAndVerify(t, hostUUID, 1, 1).Declarations.Activations[0].ServerToken
+		require.NotEqual(t, before, after, "the activation token must change when variables_updated_at does")
+
+		// Delivery has to agree with the new advertised token.
+		req := mdm.Request{Context: ctx, EnrollID: &mdm.EnrollID{ID: hostUUID}}
+		dm := mdm.DeclarativeManagement{}
+		dm.UDID = hostUUID
+		dm.Endpoint = "declaration/activation/com.example.acttok.act"
+		served, err := ddmService.DeclarativeManagement(&req, &dm)
+		require.NoError(t, err)
+		var body map[string]any
+		require.NoError(t, json.Unmarshal(served, &body))
+		require.Equal(t, after, body["ServerToken"])
+	})
+
 	t.Run("ActivationVariablesCheckedWhenDeclarationHasNone", func(t *testing.T) {
 		hostUUID, hardwareSerial := "test-host-uuid-actvar", "ACT-VAR"
 		createHost(t, hostUUID, hardwareSerial)
@@ -1169,7 +1217,7 @@ func TestDeclarativeManagementOSUpdatesPendingThenResolved(t *testing.T) {
 
 	// === Phase 1: target not ready -> pending with detail, excluded from manifest ===
 
-	body, err := svc.handleConfigurationDeclaration(ctx, configParts, hostUUID, fleet.PayloadScopeSystem)
+	body, err := svc.handleConfigurationDeclaration(ctx, configParts, hostUUID, fleet.PayloadScopeSystem, false)
 	require.NoError(t, err)
 	require.Nil(t, body, "an unresolvable declaration is served as an empty 200")
 
@@ -1208,7 +1256,7 @@ func TestDeclarativeManagementOSUpdatesPendingThenResolved(t *testing.T) {
 
 	// === Phase 3: the declaration now resolves and is served with concrete values ===
 
-	body, err = svc.handleConfigurationDeclaration(ctx, configParts, hostUUID, fleet.PayloadScopeSystem)
+	body, err = svc.handleConfigurationDeclaration(ctx, configParts, hostUUID, fleet.PayloadScopeSystem, false)
 	require.NoError(t, err)
 	require.NotNil(t, body)
 	require.NotContains(t, string(body), "$FLEET_VAR")

--- a/server/service/apple_mdm_ddm_test.go
+++ b/server/service/apple_mdm_ddm_test.go
@@ -218,8 +218,39 @@ func TestDeclarativeManagement_DeclarationItems(t *testing.T) {
 		require.Equal(t, token, response.Declarations.Configurations[0].ServerToken)
 
 		// Verify the activations in the response
-		require.Equal(t, declaration.Identifier+".activation", response.Declarations.Activations[0].Identifier)
+		require.Equal(t, declaration.DeclarationUUID+".activation", response.Declarations.Activations[0].Identifier)
 		require.Equal(t, token, response.Declarations.Activations[0].ServerToken)
+	})
+
+	t.Run("ActivationUpdatedAtFoldsIntoToken", func(t *testing.T) {
+		hostUUID := "test-host-uuid-act"
+		hardwareSerial := "ABC123-ACT"
+
+		createHost(t, hostUUID, hardwareSerial)
+		declaration := createDeclaration(t, "test-declaration-uuid-act", "Test Declaration Act", "com.example.test.declaration.act")
+		setupDeviceAndEnrollment(t, hostUUID, hardwareSerial)
+		insertHostDeclaration(t, hostUUID, declaration.DeclarationUUID, "pending", "install", declaration.Identifier)
+
+		tokenBefore, err := ds.MDMAppleDDMDeclarationsToken(ctx, hostUUID, fleet.PayloadScopeSystem)
+		require.NoError(t, err)
+		respBefore := callDeclarativeManagementAndVerify(t, hostUUID, 1, 1)
+		require.Equal(t, tokenBefore.DeclarationsToken, respBefore.DeclarationsToken)
+
+		// Stamping activation_updated_at must move the token, and the SQL and Go
+		// computations must still agree. They are written independently, so a
+		// mismatch would re-sync every host on every check-in.
+		mysqltest.ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			_, err := q.ExecContext(ctx,
+				`UPDATE host_mdm_apple_declarations SET activation_updated_at = NOW(6) WHERE host_uuid = ?`, hostUUID)
+			return err
+		})
+
+		tokenAfter, err := ds.MDMAppleDDMDeclarationsToken(ctx, hostUUID, fleet.PayloadScopeSystem)
+		require.NoError(t, err)
+		respAfter := callDeclarativeManagementAndVerify(t, hostUUID, 1, 1)
+
+		require.Equal(t, tokenAfter.DeclarationsToken, respAfter.DeclarationsToken, "SQL and Go tokens must agree")
+		require.NotEqual(t, tokenBefore.DeclarationsToken, tokenAfter.DeclarationsToken, "activation change must move the token")
 	})
 
 	t.Run("NoDeclarations", func(t *testing.T) {
@@ -287,9 +318,9 @@ func TestDeclarativeManagement_DeclarationItems(t *testing.T) {
 			response.Declarations.Activations[0].Identifier,
 			response.Declarations.Activations[1].Identifier,
 		}
-		require.Contains(t, activationIdentifiers, declaration1.Identifier+".activation")
-		require.Contains(t, activationIdentifiers, declaration2.Identifier+".activation")
-		require.NotContains(t, activationIdentifiers, declaration3.Identifier+".activation")
+		require.Contains(t, activationIdentifiers, declaration1.DeclarationUUID+".activation")
+		require.Contains(t, activationIdentifiers, declaration2.DeclarationUUID+".activation")
+		require.NotContains(t, activationIdentifiers, declaration3.DeclarationUUID+".activation")
 	})
 
 	t.Run("RemoveDeclarationsWithNullStatus", func(t *testing.T) {
@@ -328,7 +359,7 @@ func TestDeclarativeManagement_DeclarationItems(t *testing.T) {
 		require.Equal(t, token1, response.Declarations.Configurations[0].ServerToken)
 
 		// Verify the activations in the response
-		require.Equal(t, declaration1.Identifier+".activation", response.Declarations.Activations[0].Identifier)
+		require.Equal(t, declaration1.DeclarationUUID+".activation", response.Declarations.Activations[0].Identifier)
 		require.Equal(t, token1, response.Declarations.Activations[0].ServerToken)
 
 		// Check that the remove declarations with NULL status were updated to "pending"
@@ -426,14 +457,14 @@ func TestDeclarativeManagement_DeclarationItems(t *testing.T) {
 		}
 
 		// Check that all activation identifiers are included
-		require.Contains(t, activationIdentifiers, declaration1.Identifier+".activation")
-		require.Contains(t, activationIdentifiers, declaration2.Identifier+".activation")
-		require.Contains(t, activationIdentifiers, declaration3.Identifier+".activation")
-		require.Contains(t, activationIdentifiers, declaration4.Identifier+".activation")
-		require.Contains(t, activationIdentifiers, declaration5.Identifier+".activation")
-		require.Contains(t, activationIdentifiers, declaration6.Identifier+".activation")
-		require.Contains(t, activationIdentifiers, declaration7.Identifier+".activation")
-		require.Contains(t, activationIdentifiers, declaration8.Identifier+".activation")
+		require.Contains(t, activationIdentifiers, declaration1.DeclarationUUID+".activation")
+		require.Contains(t, activationIdentifiers, declaration2.DeclarationUUID+".activation")
+		require.Contains(t, activationIdentifiers, declaration3.DeclarationUUID+".activation")
+		require.Contains(t, activationIdentifiers, declaration4.DeclarationUUID+".activation")
+		require.Contains(t, activationIdentifiers, declaration5.DeclarationUUID+".activation")
+		require.Contains(t, activationIdentifiers, declaration6.DeclarationUUID+".activation")
+		require.Contains(t, activationIdentifiers, declaration7.DeclarationUUID+".activation")
+		require.Contains(t, activationIdentifiers, declaration8.DeclarationUUID+".activation")
 
 		// Check that all activation tokens are included
 		require.Contains(t, activationTokens, token1)
@@ -562,6 +593,263 @@ func TestDeclarativeManagement_DeclarationItems(t *testing.T) {
 		require.NotContains(t, served, "PayloadScope", "PayloadScope must be stripped from the declaration served to the device")
 		require.Equal(t, "com.example.strip", served["Identifier"])
 		require.Contains(t, served, "ServerToken")
+	})
+
+	t.Run("PredicateStatusMapping", func(t *testing.T) {
+		cases := []struct {
+			name       string
+			reasons    []fleet.MDMAppleDDMStatusErrorReason
+			active     bool
+			valid      fleet.MDMAppleDeclarationValidity
+			wantStatus fleet.MDMDeliveryStatus
+			wantDetail string
+		}{
+			{
+				name:       "predicate false is verified, not failed",
+				reasons:    []fleet.MDMAppleDDMStatusErrorReason{{Code: fleet.MDMAppleDDMReasonPredicate, Details: map[string]any{"Predicate": `status.device.model.family == "MacbookPro18"`}}},
+				valid:      fleet.MDMAppleDeclarationValid,
+				wantStatus: fleet.MDMDeliveryVerified,
+				wantDetail: `Fleet verified, but predicate (status.device.model.family == "MacbookPro18") evaluated to false and settings were not applied to this host.`,
+			},
+			{
+				name:       "predicate failure is failed",
+				reasons:    []fleet.MDMAppleDDMStatusErrorReason{{Code: fleet.MDMAppleDDMReasonActivationFailed, Description: "bad predicate"}},
+				valid:      fleet.MDMAppleDeclarationInvalid,
+				wantStatus: fleet.MDMDeliveryFailed,
+			},
+			{
+				name:       "no predicate reason keeps existing mapping",
+				active:     true,
+				valid:      fleet.MDMAppleDeclarationValid,
+				wantStatus: fleet.MDMDeliveryVerified,
+			},
+		}
+
+		for i, c := range cases {
+			t.Run(c.name, func(t *testing.T) {
+				suffix := fmt.Sprintf("%d", i)
+				hostUUID := "test-host-uuid-pred-" + suffix
+				hardwareSerial := "PRED-" + suffix
+				createHost(t, hostUUID, hardwareSerial)
+				setupDeviceAndEnrollment(t, hostUUID, hardwareSerial)
+
+				decl, err := ds.NewMDMAppleDeclaration(ctx, &fleet.MDMAppleDeclaration{
+					Name:       "PredDecl-" + suffix,
+					Identifier: "com.example.pred." + suffix,
+					RawJSON:    []byte(`{"Type":"com.apple.configuration.test","Identifier":"com.example.pred","Payload":{"Enabled":true}}`),
+					Scope:      fleet.PayloadScopeSystem,
+				}, nil)
+				require.NoError(t, err)
+				token := insertHostDeclaration(t, hostUUID, decl.DeclarationUUID, "pending", "install", decl.Identifier)
+
+				report := fleet.MDMAppleDDMStatusReport{}
+				report.StatusItems.Management.Declarations.Configurations = []fleet.MDMAppleDDMStatusDeclaration{{
+					Active:      c.active,
+					Identifier:  decl.Identifier,
+					Valid:       c.valid,
+					ServerToken: token,
+					Reasons:     c.reasons,
+				}}
+				raw, err := json.Marshal(report)
+				require.NoError(t, err)
+
+				req := mdm.Request{Context: ctx, EnrollID: &mdm.EnrollID{ID: hostUUID}}
+				dm := mdm.DeclarativeManagement{Data: raw}
+				dm.UDID = hostUUID
+				dm.Endpoint = "status"
+				_, err = ddmService.DeclarativeManagement(&req, &dm)
+				require.NoError(t, err)
+
+				var got struct {
+					Status *string `db:"status"`
+					Detail string  `db:"detail"`
+				}
+				mysqltest.ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+					return sqlx.GetContext(ctx, q, &got,
+						`SELECT status, COALESCE(detail, '') AS detail FROM host_mdm_apple_declarations WHERE host_uuid = ?`, hostUUID)
+				})
+				require.NotNil(t, got.Status)
+				require.Equal(t, string(c.wantStatus), *got.Status)
+				if c.wantDetail != "" {
+					require.Equal(t, c.wantDetail, got.Detail)
+				}
+			})
+		}
+	})
+
+	t.Run("CustomActivationIsServedInsteadOfGenerated", func(t *testing.T) {
+		hostUUID := "test-host-uuid-custom-act"
+		hardwareSerial := "ABC123-CUSTOMACT"
+
+		createHost(t, hostUUID, hardwareSerial)
+		setupDeviceAndEnrollment(t, hostUUID, hardwareSerial)
+
+		activationRaw := `{"Type":"com.apple.activation.simple","Identifier":"com.example.custom.act",` +
+			`"Payload":{"StandardConfigurations":["com.example.customact"],"Predicate":"@status(os.version.major) >= 15"}}`
+		decl, err := ds.NewMDMAppleDeclaration(ctx, &fleet.MDMAppleDeclaration{
+			Name:       "CustomActDecl",
+			Identifier: "com.example.customact",
+			RawJSON:    []byte(`{"Type":"com.apple.configuration.test","Identifier":"com.example.customact","Payload":{"Enabled":true}}`),
+			Scope:      fleet.PayloadScopeSystem,
+			Activation: &fleet.MDMAppleCustomActivation{
+				Identifier:              "com.example.custom.act",
+				RawJSON:                 []byte(activationRaw),
+				ConfigurationIdentifier: "com.example.customact",
+			},
+		}, nil)
+		require.NoError(t, err)
+		insertHostDeclaration(t, hostUUID, decl.DeclarationUUID, "pending", "install", decl.Identifier)
+
+		// The manifest advertises the admin's identifier, not a generated one.
+		manifest := callDeclarativeManagementAndVerify(t, hostUUID, 1, 1)
+		require.Equal(t, "com.example.custom.act", manifest.Declarations.Activations[0].Identifier)
+
+		// Fetching it returns the stored document, predicate intact.
+		req := mdm.Request{Context: ctx, EnrollID: &mdm.EnrollID{ID: hostUUID}}
+		dm := mdm.DeclarativeManagement{}
+		dm.UDID = hostUUID
+		dm.Endpoint = "declaration/activation/com.example.custom.act"
+		response, err := ddmService.DeclarativeManagement(&req, &dm)
+		require.NoError(t, err)
+
+		var served map[string]any
+		require.NoError(t, json.Unmarshal(response, &served))
+		require.Equal(t, "com.example.custom.act", served["Identifier"])
+		payload, ok := served["Payload"].(map[string]any)
+		require.True(t, ok)
+		require.Equal(t, "@status(os.version.major) >= 15", payload["Predicate"])
+		require.Equal(t, []any{"com.example.customact"}, payload["StandardConfigurations"])
+
+		// The generated name must not also resolve, or both would be valid.
+		dm.Endpoint = "declaration/activation/" + decl.DeclarationUUID + ".activation"
+		_, err = ddmService.DeclarativeManagement(&req, &dm)
+		require.Error(t, err)
+	})
+
+	t.Run("GeneratedActivationStillServedWhenNoCustomOne", func(t *testing.T) {
+		hostUUID := "test-host-uuid-gen-act"
+		hardwareSerial := "ABC123-GENACT"
+
+		createHost(t, hostUUID, hardwareSerial)
+		setupDeviceAndEnrollment(t, hostUUID, hardwareSerial)
+
+		decl, err := ds.NewMDMAppleDeclaration(ctx, &fleet.MDMAppleDeclaration{
+			Name:       "GenActDecl",
+			Identifier: "com.example.genact",
+			RawJSON:    []byte(`{"Type":"com.apple.configuration.test","Identifier":"com.example.genact","Payload":{"Enabled":true}}`),
+			Scope:      fleet.PayloadScopeSystem,
+		}, nil)
+		require.NoError(t, err)
+		insertHostDeclaration(t, hostUUID, decl.DeclarationUUID, "pending", "install", decl.Identifier)
+
+		manifest := callDeclarativeManagementAndVerify(t, hostUUID, 1, 1)
+		generated := decl.DeclarationUUID + ".activation"
+		require.Equal(t, generated, manifest.Declarations.Activations[0].Identifier)
+
+		req := mdm.Request{Context: ctx, EnrollID: &mdm.EnrollID{ID: hostUUID}}
+		dm := mdm.DeclarativeManagement{}
+		dm.UDID = hostUUID
+		dm.Endpoint = "declaration/activation/" + generated
+		response, err := ddmService.DeclarativeManagement(&req, &dm)
+		require.NoError(t, err)
+
+		var served map[string]any
+		require.NoError(t, json.Unmarshal(response, &served))
+		require.Equal(t, "com.apple.activation.simple", served["Type"])
+		require.Equal(t, generated, served["Identifier"])
+		payload, ok := served["Payload"].(map[string]any)
+		require.True(t, ok)
+		// still references the configuration by identifier, as before
+		require.Equal(t, []any{"com.example.genact"}, payload["StandardConfigurations"])
+	})
+
+	t.Run("CustomActivationIsScopedToHostsThatHaveTheDeclaration", func(t *testing.T) {
+		inScopeUUID, inScopeSerial := "test-host-uuid-scoped-in", "SCOPE-IN"
+		outOfScopeUUID, outOfScopeSerial := "test-host-uuid-scoped-out", "SCOPE-OUT"
+
+		createHost(t, inScopeUUID, inScopeSerial)
+		setupDeviceAndEnrollment(t, inScopeUUID, inScopeSerial)
+		createHost(t, outOfScopeUUID, outOfScopeSerial)
+		setupDeviceAndEnrollment(t, outOfScopeUUID, outOfScopeSerial)
+
+		teamID := uint(42)
+		decl, err := ds.NewMDMAppleDeclaration(ctx, &fleet.MDMAppleDeclaration{
+			Name:       "ScopedDecl",
+			Identifier: "com.example.scoped",
+			TeamID:     &teamID,
+			RawJSON:    []byte(`{"Type":"com.apple.configuration.test","Identifier":"com.example.scoped","Payload":{"Enabled":true}}`),
+			Scope:      fleet.PayloadScopeSystem,
+			Activation: &fleet.MDMAppleCustomActivation{
+				Identifier:              "com.example.scoped.act",
+				RawJSON:                 []byte(`{"Type":"com.apple.activation.simple","Identifier":"com.example.scoped.act","Payload":{"StandardConfigurations":["com.example.scoped"]}}`),
+				ConfigurationIdentifier: "com.example.scoped",
+			},
+		}, nil)
+		require.NoError(t, err)
+
+		// Only the in-scope host gets a host_mdm_apple_declarations row, which is
+		// what team and label scoping ultimately produce.
+		insertHostDeclaration(t, inScopeUUID, decl.DeclarationUUID, "pending", "install", decl.Identifier)
+
+		manifest := callDeclarativeManagementAndVerify(t, inScopeUUID, 1, 1)
+		require.Equal(t, "com.example.scoped.act", manifest.Declarations.Activations[0].Identifier)
+
+		req := mdm.Request{Context: ctx, EnrollID: &mdm.EnrollID{ID: inScopeUUID}}
+		dm := mdm.DeclarativeManagement{}
+		dm.UDID = inScopeUUID
+		dm.Endpoint = "declaration/activation/com.example.scoped.act"
+		_, err = ddmService.DeclarativeManagement(&req, &dm)
+		require.NoError(t, err)
+
+		// The out-of-scope host sees nothing, and cannot fetch the activation by
+		// name even though it exists in the database.
+		outManifest := callDeclarativeManagementAndVerify(t, outOfScopeUUID, 0, 0)
+		require.Empty(t, outManifest.Declarations.Activations)
+
+		outReq := mdm.Request{Context: ctx, EnrollID: &mdm.EnrollID{ID: outOfScopeUUID}}
+		outDM := mdm.DeclarativeManagement{}
+		outDM.UDID = outOfScopeUUID
+		outDM.Endpoint = "declaration/activation/com.example.scoped.act"
+		_, err = ddmService.DeclarativeManagement(&outReq, &outDM)
+		require.Error(t, err, "a host outside the declaration's scope must not resolve its activation")
+	})
+
+	t.Run("ManagementDeclarationRoutingAndEndpointGuard", func(t *testing.T) {
+		hostUUID := "test-host-uuid-mgmt"
+		hardwareSerial := "ABC123-MGMT"
+
+		createHost(t, hostUUID, hardwareSerial)
+		setupDeviceAndEnrollment(t, hostUUID, hardwareSerial)
+
+		mgmt, err := ds.NewMDMAppleDeclaration(ctx, &fleet.MDMAppleDeclaration{
+			Name:       "MgmtDecl",
+			Identifier: "com.example.mgmt",
+			RawJSON:    []byte(`{"Type":"com.apple.management.organization-info","Identifier":"com.example.mgmt","Payload":{"Echo":"foo"}}`),
+			Scope:      fleet.PayloadScopeSystem,
+		}, nil)
+		require.NoError(t, err)
+		insertHostDeclaration(t, hostUUID, mgmt.DeclarationUUID, "pending", "install", mgmt.Identifier)
+
+		// Management declarations are never activated, so no activation is
+		// synthesized and they don't appear under Configurations.
+		manifest := callDeclarativeManagementAndVerify(t, hostUUID, 0, 0)
+		require.Len(t, manifest.Declarations.Management, 1)
+		require.Equal(t, mgmt.Identifier, manifest.Declarations.Management[0].Identifier)
+
+		req := mdm.Request{Context: ctx, EnrollID: &mdm.EnrollID{ID: hostUUID}}
+		dm := mdm.DeclarativeManagement{}
+		dm.UDID = hostUUID
+		dm.Endpoint = "declaration/management/" + mgmt.Identifier
+		response, err := ddmService.DeclarativeManagement(&req, &dm)
+		require.NoError(t, err)
+		var served map[string]any
+		require.NoError(t, json.Unmarshal(response, &served))
+		require.Equal(t, "com.apple.management.organization-info", served["Type"])
+
+		// The two endpoints must not serve each other's rows.
+		dm.Endpoint = "declaration/configuration/" + mgmt.Identifier
+		_, err = ddmService.DeclarativeManagement(&req, &dm)
+		require.Error(t, err)
 	})
 }
 

--- a/server/service/apple_mdm_ddm_test.go
+++ b/server/service/apple_mdm_ddm_test.go
@@ -669,12 +669,52 @@ func TestDeclarativeManagement_DeclarationItems(t *testing.T) {
 			return r
 		}
 
+		// Apple: "A management declaration has an active state which is always
+		// false and not part of the activation process", so these report
+		// Active:false even when fully applied. Grading them like configurations
+		// left every one of them stuck on verifying.
+		management := func(ident, token string, valid fleet.MDMAppleDeclarationValidity) fleet.MDMAppleDDMStatusReport {
+			var r fleet.MDMAppleDDMStatusReport
+			r.StatusItems.Management.Declarations.Management = []fleet.MDMAppleDDMStatusDeclaration{{
+				Identifier:  ident,
+				Active:      false,
+				Valid:       valid,
+				ServerToken: token,
+			}}
+			return r
+		}
+
 		cases := []struct {
-			name       string
-			report     func(configIdent, activationIdent, token string) fleet.MDMAppleDDMStatusReport
-			wantStatus fleet.MDMDeliveryStatus
-			wantDetail string
+			name        string
+			report      func(configIdent, activationIdent, token string) fleet.MDMAppleDDMStatusReport
+			declRawJSON string
+			wantStatus  fleet.MDMDeliveryStatus
+			wantDetail  string
 		}{
+			{
+				name: "valid management declaration is verified despite being inactive",
+				report: func(ident, _ string, token string) fleet.MDMAppleDDMStatusReport {
+					return management(ident, token, fleet.MDMAppleDeclarationValid)
+				},
+				declRawJSON: `{"Type":"com.apple.management.organization-info","Identifier":"%s","Payload":{"Name":"Fleet"}}`,
+				wantStatus:  fleet.MDMDeliveryVerified,
+			},
+			{
+				name: "invalid management declaration is failed",
+				report: func(ident, _ string, token string) fleet.MDMAppleDDMStatusReport {
+					return management(ident, token, fleet.MDMAppleDeclarationInvalid)
+				},
+				declRawJSON: `{"Type":"com.apple.management.organization-info","Identifier":"%s","Payload":{"Name":"Fleet"}}`,
+				wantStatus:  fleet.MDMDeliveryFailed,
+			},
+			{
+				name: "unchecked management declaration stays verifying",
+				report: func(ident, _ string, token string) fleet.MDMAppleDDMStatusReport {
+					return management(ident, token, fleet.MDMAppleDeclarationUnknown)
+				},
+				declRawJSON: `{"Type":"com.apple.management.organization-info","Identifier":"%s","Payload":{"Name":"Fleet"}}`,
+				wantStatus:  fleet.MDMDeliveryVerifying,
+			},
 			{
 				name:       "predicate excluded the host is verified, not failed",
 				report:     predicateFalse,
@@ -705,10 +745,14 @@ func TestDeclarativeManagement_DeclarationItems(t *testing.T) {
 
 				configIdent := "com.example.pred." + suffix
 				activationIdent := configIdent + ".custom"
+				rawJSON := `{"Type":"com.apple.configuration.test","Identifier":"` + configIdent + `","Payload":{"Enabled":true}}`
+				if c.declRawJSON != "" {
+					rawJSON = fmt.Sprintf(c.declRawJSON, configIdent)
+				}
 				decl, err := ds.NewMDMAppleDeclaration(ctx, &fleet.MDMAppleDeclaration{
 					Name:       "PredDecl-" + suffix,
 					Identifier: configIdent,
-					RawJSON:    []byte(`{"Type":"com.apple.configuration.test","Identifier":"` + configIdent + `","Payload":{"Enabled":true}}`),
+					RawJSON:    []byte(rawJSON),
 					Scope:      fleet.PayloadScopeSystem,
 				}, nil)
 				require.NoError(t, err)

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -471,6 +471,18 @@ func getProfilesContents(baseDir string, macProfiles, windowsProfiles, androidPr
 			}
 			extByName[name] = ext
 
+			var activationContents []byte
+			if profile.Activation != "" {
+				if platform != "macos" || ext != ".json" {
+					return nil, fmt.Errorf("%s: %s", prefixErrMsg,
+						"activation is only supported for declaration (DDM) profiles.")
+				}
+				activationContents, err = os.ReadFile(resolveApplyRelativePath(baseDir, profile.Activation))
+				if err != nil {
+					return nil, fmt.Errorf("%s: reading activation: %w", prefixErrMsg, err)
+				}
+			}
+
 			result = append(result, fleet.MDMProfileBatchPayload{
 				Name:             name,
 				Contents:         fileContents,
@@ -478,6 +490,7 @@ func getProfilesContents(baseDir string, macProfiles, windowsProfiles, androidPr
 				LabelsIncludeAll: profile.LabelsIncludeAll,
 				LabelsIncludeAny: profile.LabelsIncludeAny,
 				LabelsExcludeAny: profile.LabelsExcludeAny,
+				Activation:       activationContents,
 			})
 
 		}

--- a/server/service/client_profiles.go
+++ b/server/service/client_profiles.go
@@ -71,6 +71,21 @@ func (c *Client) GetProfileContents(profileID string) ([]byte, error) {
 	return nil, nil
 }
 
+// GetProfileActivation returns the custom activation attached to a declaration,
+// or nil if it has none. GetProfileContents can't serve this because alt=media
+// returns the declaration file itself, not the payload the activation rides on.
+func (c *Client) GetProfileActivation(profileID string) ([]byte, error) {
+	verb, path := "GET", "/api/latest/fleet/mdm/profiles/"+profileID
+	var responseBody getMDMConfigProfileResponse
+	if err := c.authenticatedRequest(nil, verb, path, &responseBody); err != nil {
+		return nil, err
+	}
+	if responseBody.MDMConfigProfilePayload == nil {
+		return nil, nil
+	}
+	return responseBody.MDMConfigProfilePayload.Activation, nil
+}
+
 // ListDDMAssets returns the Apple DDM assets for the given team.
 func (c *Client) ListDDMAssets(teamID *uint) ([]*fleet.DDMAsset, error) {
 	verb, path := "GET", "/api/latest/fleet/assets"

--- a/server/service/client_test.go
+++ b/server/service/client_test.go
@@ -1087,6 +1087,51 @@ func TestGetProfilesContents(t *testing.T) {
 	}
 }
 
+func TestGetProfilesContentsActivation(t *testing.T) {
+	tempDir := t.TempDir()
+
+	activation := []byte(`{"Type":"com.apple.activation.simple","Identifier":"com.example.act","Payload":{"StandardConfigurations":["com.example.decl"]}}`)
+	activationPath := filepath.Join(tempDir, "activation.json")
+	require.NoError(t, os.WriteFile(activationPath, activation, 0o644))
+
+	declPath := filepath.Join(tempDir, "decl.json")
+	require.NoError(t, os.WriteFile(declPath,
+		[]byte(`{"Type":"com.apple.configuration.passcode.settings","Identifier":"com.example.decl","Payload":{}}`), 0o644))
+
+	mobileconfigPath := filepath.Join(tempDir, "profile.mobileconfig")
+	require.NoError(t, os.WriteFile(mobileconfigPath, mobileconfigForTest("bar", "I"), 0o644))
+
+	t.Run("declaration carries the activation contents", func(t *testing.T) {
+		got, err := getProfilesContents(tempDir,
+			[]fleet.MDMProfileSpec{{Path: declPath, Activation: activationPath}}, nil, nil, false)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		require.Equal(t, activation, got[0].Activation)
+	})
+
+	t.Run("no activation leaves the payload field empty", func(t *testing.T) {
+		got, err := getProfilesContents(tempDir,
+			[]fleet.MDMProfileSpec{{Path: declPath}}, nil, nil, false)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		require.Empty(t, got[0].Activation)
+	})
+
+	t.Run("mobileconfig with an activation is rejected", func(t *testing.T) {
+		_, err := getProfilesContents(tempDir,
+			[]fleet.MDMProfileSpec{{Path: mobileconfigPath, Activation: activationPath}}, nil, nil, false)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "activation is only supported for declaration (DDM) profiles")
+	})
+
+	t.Run("unreadable activation file reports the path", func(t *testing.T) {
+		_, err := getProfilesContents(tempDir,
+			[]fleet.MDMProfileSpec{{Path: declPath, Activation: filepath.Join(tempDir, "missing.json")}}, nil, nil, false)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "reading activation")
+	})
+}
+
 func TestGitOpsErrors(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/server/service/integration_mdm_ddm_test.go
+++ b/server/service/integration_mdm_ddm_test.go
@@ -1830,8 +1830,8 @@ WHERE name = ?`
 
 	// Build expected declaration-items map with effective tokens (incorporating variables_updated_at)
 	declsByToken := map[string]fleet.MDMAppleDeclaration{
-		fleet.EffectiveDDMToken(dbDeclUUID.Token, varsUpdatedUUID, nil):     {Identifier: "com.fleet.var.uuid"},
-		fleet.EffectiveDDMToken(dbDeclSerial.Token, varsUpdatedSerial, nil): {Identifier: "com.fleet.var.serial"},
+		fleet.EffectiveDDMToken(dbDeclUUID.Token, varsUpdatedUUID, nil, nil):     {Identifier: "com.fleet.var.uuid"},
+		fleet.EffectiveDDMToken(dbDeclSerial.Token, varsUpdatedSerial, nil, nil): {Identifier: "com.fleet.var.serial"},
 		dbDeclPlain.Token: {Identifier: "com.fleet.plain"},
 	}
 
@@ -1873,8 +1873,8 @@ WHERE name = ?`
 	require.NotEmpty(t, lastSyncDeclToken)
 
 	declsByToken = map[string]fleet.MDMAppleDeclaration{
-		fleet.EffectiveDDMToken(dbDeclUUID.Token, varsUpdatedUUID, nil):     {Identifier: "com.fleet.var.uuid"},
-		fleet.EffectiveDDMToken(dbDeclSerial.Token, varsUpdatedSerial, nil): {Identifier: "com.fleet.var.serial"},
+		fleet.EffectiveDDMToken(dbDeclUUID.Token, varsUpdatedUUID, nil, nil):     {Identifier: "com.fleet.var.uuid"},
+		fleet.EffectiveDDMToken(dbDeclSerial.Token, varsUpdatedSerial, nil, nil): {Identifier: "com.fleet.var.serial"},
 		dbDeclPlain.Token: {Identifier: "com.fleet.plain"},
 		dbNewDecl.Token:   {Identifier: "com.fleet.new"},
 	}
@@ -1905,8 +1905,8 @@ WHERE name = ?`
 	checkNoCommands(mdmDevice2)
 
 	declsByToken = map[string]fleet.MDMAppleDeclaration{
-		fleet.EffectiveDDMToken(dbDeclUUID.Token, varsUpdatedUUID, nil):     {Identifier: "com.fleet.var.uuid"},
-		fleet.EffectiveDDMToken(dbDeclSerial.Token, varsUpdatedSerial, nil): {Identifier: "com.fleet.var.serial"},
+		fleet.EffectiveDDMToken(dbDeclUUID.Token, varsUpdatedUUID, nil, nil):     {Identifier: "com.fleet.var.uuid"},
+		fleet.EffectiveDDMToken(dbDeclSerial.Token, varsUpdatedSerial, nil, nil): {Identifier: "com.fleet.var.serial"},
 		dbDeclPlain.Token: {Identifier: "com.fleet.plain"},
 	}
 
@@ -2097,8 +2097,8 @@ WHERE name = ?`
 	// in the DeclarationsToken computation so that the token matches the
 	// SQL-computed token from the tokens endpoint.
 	declsByToken = map[string]fleet.MDMAppleDeclaration{
-		fleet.EffectiveDDMToken(dbDeclUUID.Token, latestVarsUpdatedUUID, nil):     {Identifier: "com.fleet.var.uuid"},
-		fleet.EffectiveDDMToken(dbDeclSerial.Token, latestVarsUpdatedSerial, nil): {Identifier: "com.fleet.var.serial"},
+		fleet.EffectiveDDMToken(dbDeclUUID.Token, latestVarsUpdatedUUID, nil, nil):     {Identifier: "com.fleet.var.uuid"},
+		fleet.EffectiveDDMToken(dbDeclSerial.Token, latestVarsUpdatedSerial, nil, nil): {Identifier: "com.fleet.var.serial"},
 		dbDeclPlain.Token: {Identifier: "com.fleet.plain"},
 	}
 

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -2614,6 +2614,24 @@ func (svc *Service) BatchSetMDMProfiles(
 		return ctxerr.Wrap(ctx, err, "validating macOS profiles")
 	}
 
+	// Activations are validated here rather than in getAppleProfiles, which is
+	// package-level and has no datastore to expand secrets with. appleDecls is
+	// keyed by the incoming profile's index.
+	for i, prof := range profilesWithSecrets {
+		decl := appleDecls[i]
+		if decl == nil {
+			if len(prof.Activation) > 0 {
+				return ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("activation", ActivationUnsupportedProfileErrorMsg))
+			}
+			continue
+		}
+		act, err := svc.validateActivation(ctx, prof.Activation, decl.Identifier, decl.Type)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "validating declaration activation")
+		}
+		decl.Activation = act
+	}
+
 	windowsProfiles, err := getWindowsProfiles(ctx, tmID, appCfg, profilesWithSecrets, labelMap, svc.config.MDM)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "validating Windows profiles")

--- a/tools/cloner-check/generated_files/appconfig.txt
+++ b/tools/cloner-check/generated_files/appconfig.txt
@@ -156,6 +156,7 @@ github.com/fleetdm/fleet/v4/server/fleet/MDM	MacOSSettings	fleet.MacOSSettings
 github.com/fleetdm/fleet/v4/server/fleet/MacOSSettings	CustomSettings	[]fleet.MDMProfileSpec
 github.com/fleetdm/fleet/v4/server/fleet/MDMProfileSpec	Path	string
 github.com/fleetdm/fleet/v4/server/fleet/MDMProfileSpec	Paths	string
+github.com/fleetdm/fleet/v4/server/fleet/MDMProfileSpec	Activation	string
 github.com/fleetdm/fleet/v4/server/fleet/MDMProfileSpec	Labels	[]string
 github.com/fleetdm/fleet/v4/server/fleet/MDMProfileSpec	LabelsIncludeAll	[]string
 github.com/fleetdm/fleet/v4/server/fleet/MDMProfileSpec	LabelsIncludeAny	[]string

--- a/tools/cloner-check/generated_files/mdmprofilespec.txt
+++ b/tools/cloner-check/generated_files/mdmprofilespec.txt
@@ -1,5 +1,6 @@
 github.com/fleetdm/fleet/v4/server/fleet/MDMProfileSpec	Path	string
 github.com/fleetdm/fleet/v4/server/fleet/MDMProfileSpec	Paths	string
+github.com/fleetdm/fleet/v4/server/fleet/MDMProfileSpec	Activation	string
 github.com/fleetdm/fleet/v4/server/fleet/MDMProfileSpec	Labels	[]string
 github.com/fleetdm/fleet/v4/server/fleet/MDMProfileSpec	LabelsIncludeAll	[]string
 github.com/fleetdm/fleet/v4/server/fleet/MDMProfileSpec	LabelsIncludeAny	[]string

--- a/tools/cloner-check/generated_files/teamconfig.txt
+++ b/tools/cloner-check/generated_files/teamconfig.txt
@@ -53,6 +53,7 @@ github.com/fleetdm/fleet/v4/server/fleet/TeamMDM	MacOSSettings	fleet.MacOSSettin
 github.com/fleetdm/fleet/v4/server/fleet/MacOSSettings	CustomSettings	[]fleet.MDMProfileSpec
 github.com/fleetdm/fleet/v4/server/fleet/MDMProfileSpec	Path	string
 github.com/fleetdm/fleet/v4/server/fleet/MDMProfileSpec	Paths	string
+github.com/fleetdm/fleet/v4/server/fleet/MDMProfileSpec	Activation	string
 github.com/fleetdm/fleet/v4/server/fleet/MDMProfileSpec	Labels	[]string
 github.com/fleetdm/fleet/v4/server/fleet/MDMProfileSpec	LabelsIncludeAll	[]string
 github.com/fleetdm/fleet/v4/server/fleet/MDMProfileSpec	LabelsIncludeAny	[]string

--- a/tools/cloner-check/generated_files/teammdm.txt
+++ b/tools/cloner-check/generated_files/teammdm.txt
@@ -24,6 +24,7 @@ github.com/fleetdm/fleet/v4/server/fleet/TeamMDM	MacOSSettings	fleet.MacOSSettin
 github.com/fleetdm/fleet/v4/server/fleet/MacOSSettings	CustomSettings	[]fleet.MDMProfileSpec
 github.com/fleetdm/fleet/v4/server/fleet/MDMProfileSpec	Path	string
 github.com/fleetdm/fleet/v4/server/fleet/MDMProfileSpec	Paths	string
+github.com/fleetdm/fleet/v4/server/fleet/MDMProfileSpec	Activation	string
 github.com/fleetdm/fleet/v4/server/fleet/MDMProfileSpec	Labels	[]string
 github.com/fleetdm/fleet/v4/server/fleet/MDMProfileSpec	LabelsIncludeAll	[]string
 github.com/fleetdm/fleet/v4/server/fleet/MDMProfileSpec	LabelsIncludeAny	[]string


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #49972

Adds custom DDM activations to the GitOps workflow. A profile entry can point at an activation file with a new `activation` key, the batch endpoint validates and stores it through the same code as the single-profile upload, and `fleetctl generate-gitops` exports it back out.

```yaml
controls:
  macos_settings:
    custom_settings:
      - path: ./lib/profiles/passcode.json
        activation: ./lib/activations/passcode.json
```

`activation` is only valid on a declaration (`.json`) profile, and can't be combined with `paths:` because an activation names exactly one declaration. Removing the key removes the stored activation.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually

Verified on an ADE-enrolled Mac: exported an existing declaration and its custom activation with `generate-gitops`, removed everything by applying a config with no profiles, then re-applied the exported files. All three declarations came back with the correct scopes, the activation attached to only its own declaration, and the predicate was reported correctly on the host.

## New Fleet configuration settings

- [x] Verified that the setting is exported via `fleetctl generate-gitops`
- [x] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [x] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
