### PR TITLE
Update Release from AB modal copy and route back to list hosts on Pending

### DIFF
--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -1771,7 +1771,12 @@ const HostDetailsPage = ({
               onExit={() => setShowReleaseFromABModal(false)}
               onRelease={() => {
                 if (host.mdm.enrollment_status === "Pending") {
-                  router.push(PATHS.MANAGE_HOSTS);
+                  router.push(
+                    filteredHostsPath ||
+                      getPathWithQueryParams(PATHS.MANAGE_HOSTS, {
+                        fleet_id: location.query.fleet_id,
+                      })
+                  );
                   return;
                 }
                 refetchHostDetails();

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -1763,9 +1763,17 @@ const HostDetailsPage = ({
           )}
           {!!host && showReleaseFromABModal && (
             <ReleaseFromABModal
-              host={{ display_name: host.display_name, id: host.id }}
+              host={{
+                display_name: host.display_name,
+                id: host.id,
+                enrollment_status: host.mdm.enrollment_status,
+              }}
               onExit={() => setShowReleaseFromABModal(false)}
               onRelease={() => {
+                if (host.mdm.enrollment_status === "Pending") {
+                  router.push(PATHS.MANAGE_HOSTS);
+                  return;
+                }
                 refetchHostDetails();
                 refetchPastActivities();
               }}

--- a/frontend/pages/hosts/details/HostDetailsPage/components/ReleaseFromABModal/ReleaseFromABModal.tests.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/components/ReleaseFromABModal/ReleaseFromABModal.tests.tsx
@@ -14,7 +14,11 @@ describe("Release from AB modal", () => {
   };
   it("disables release until checkbox is checked", async () => {
     const { user } = renderComponent({
-      host: { id: 1, display_name: "Test Host" },
+      host: {
+        id: 1,
+        display_name: "Test Host",
+        enrollment_status: "On (automatic)",
+      },
       onExit: jest.fn(),
       onRelease: jest.fn(),
     });
@@ -28,5 +32,21 @@ describe("Release from AB modal", () => {
     await user.click(checkbox);
 
     expect(releaseButton).toBeEnabled();
+  });
+
+  it("shows correct message when enrollment status is Pending", () => {
+    renderComponent({
+      host: {
+        id: 1,
+        display_name: "Test Host",
+        enrollment_status: "Pending",
+      },
+      onExit: jest.fn(),
+      onRelease: jest.fn(),
+    });
+
+    expect(
+      screen.getByText("This will also remove the host from Fleet.")
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/pages/hosts/details/HostDetailsPage/components/ReleaseFromABModal/ReleaseFromABModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/components/ReleaseFromABModal/ReleaseFromABModal.tsx
@@ -6,11 +6,15 @@ import ModalFooter from "components/ModalFooter";
 import Button from "components/buttons/Button";
 import mdmAbmAPI from "services/entities/mdm_apple_bm";
 import { notify } from "components/ToastNotification";
+import CustomLink from "components/CustomLink";
+import { LEARN_MORE_ABOUT_BASE_LINK } from "utilities/constants";
+import { MdmEnrollmentStatus } from "interfaces/mdm";
 import getErrorMessage from "./helpers";
 
 type SimpleHost = {
   id: number;
   display_name: string;
+  enrollment_status: MdmEnrollmentStatus | null;
 };
 
 export interface IReleaseFromABModalProps {
@@ -93,9 +97,19 @@ const ReleaseFromABModal = ({
       <div>
         <p>
           This removes <b>{host.display_name}</b> from your Apple Business and
-          can&apos;t be added back automatically.
+          can&apos;t be added back automatically.{" "}
+          <CustomLink
+            text="Learn More"
+            newTab
+            url={`${LEARN_MORE_ABOUT_BASE_LINK}/release-devices`}
+          />
         </p>
-        <p>This won&apos;t unenroll the host from Fleet.</p>
+        {host.enrollment_status === "Pending" ? (
+          <p>This will also remove the host from Fleet.</p>
+        ) : (
+          <p>This won&apos;t unenroll the host from Fleet.</p>
+        )}
+
         <div>
           <p>
             <b>Please check to confirm:</b>

--- a/frontend/pages/hosts/details/HostDetailsPage/components/ReleaseFromABModal/ReleaseFromABModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/components/ReleaseFromABModal/ReleaseFromABModal.tsx
@@ -99,7 +99,7 @@ const ReleaseFromABModal = ({
           This removes <b>{host.display_name}</b> from your Apple Business and
           can&apos;t be added back automatically.{" "}
           <CustomLink
-            text="Learn More"
+            text="Learn more"
             newTab
             url={`${LEARN_MORE_ABOUT_BASE_LINK}/release-devices`}
           />


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #50350 and Resolves #50358 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added enrollment-status messaging when releasing a host.
  * Pending-enrollment hosts now display a notice that they will also be removed from Fleet.
  * Added a “Learn More” link to release-device documentation.

* **Bug Fixes**
  * Improved navigation after releasing hosts with pending enrollment by returning to the hosts list.
  * Prevented unnecessary host details and activity refreshes when pending-enrollment hosts are released.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->