### PR TITLE
Exclude Adobe plugins from vulnerability scanning

### DIFF
--- a/changes/45414-adobe-plugins
+++ b/changes/45414-adobe-plugins
@@ -1,1 +1,2 @@
 - Added Adobe plugins to software inventory: Fleet now detects Adobe Creative Cloud plugins (CEP and UXP extensions) on macOS and Windows hosts and lists them on the Software page and host details with the software type "Plugin (Adobe)", including version and host count.
+- Adobe plugins are excluded from vulnerability scanning, so no vulnerabilities are reported for them. No vulnerability data source maps an Adobe CEP or UXP extension to a CVE; Adobe files CVEs against the host application (Photoshop, Acrobat, and so on), which Fleet already scans.

--- a/server/vulnerabilities/nvd/cpe.go
+++ b/server/vulnerabilities/nvd/cpe.go
@@ -864,8 +864,11 @@ func TranslateSoftwareToCPE(
 	nonOvalIterator, err := ds.AllSoftwareIterator(
 		ctx,
 		fleet.SoftwareIterQueryOptions{
-			// Also exclude iOS and iPadOS apps until we enable vulnerabilities support for them.
-			ExcludedSources: append(oval.SupportedSoftwareSources, "ios_apps", "ipados_apps"),
+			// Also exclude iOS and iPadOS apps until we enable vulnerabilities support for them,
+			// and Adobe plugins, for which no vulnerability data source exists: CVEs for Adobe
+			// CEP/UXP extensions are only ever filed against the host Adobe application, so any
+			// match here would be a false positive pinned to the wrong version.
+			ExcludedSources: append(oval.SupportedSoftwareSources, "ios_apps", "ipados_apps", "adobe_plugins"),
 		},
 	)
 	if err != nil {

--- a/server/vulnerabilities/nvd/cpe_test.go
+++ b/server/vulnerabilities/nvd/cpe_test.go
@@ -471,6 +471,37 @@ func TestTranslateSoftwareToCPE(t *testing.T) {
 	assert.True(t, iterator.closed)
 }
 
+// TestTranslateSoftwareToCPEExcludedSources tests that software from sources Fleet does not
+// scan for vulnerabilities never reaches the CPE translation step. Adobe plugins are excluded
+// because no CVE data source maps an Adobe CEP/UXP extension to a CVE, so any match would be
+// a false positive borrowed from the host Adobe application.
+func TestTranslateSoftwareToCPEExcludedSources(t *testing.T) {
+	tempDir := t.TempDir()
+
+	ds := new(mock.Store)
+
+	var excludedSources [][]string
+	ds.AllSoftwareIteratorFunc = func(ctx context.Context, q fleet.SoftwareIterQueryOptions) (fleet.SoftwareIterator, error) {
+		excludedSources = append(excludedSources, q.ExcludedSources)
+		return &fakeSoftwareIterator{}, nil
+	}
+
+	items, err := cpedict.Decode(strings.NewReader(XmlCPETestDict))
+	require.NoError(t, err)
+
+	dbPath := filepath.Join(tempDir, "cpe.sqlite")
+	err = GenerateCPEDB(dbPath, items.Items)
+	require.NoError(t, err)
+
+	err = TranslateSoftwareToCPE(t.Context(), ds, tempDir, slog.New(slog.DiscardHandler))
+	require.NoError(t, err)
+
+	require.NotEmpty(t, excludedSources)
+	require.Contains(t, excludedSources[0], "adobe_plugins")
+	require.Contains(t, excludedSources[0], "ios_apps")
+	require.Contains(t, excludedSources[0], "ipados_apps")
+}
+
 // TestTranslateSoftwareToCPEIgnoreEmptyVersion tests that TranslateSoftwareToCPE ignores
 // software that was ingested with an empty version field. The test will simulate a previous
 // version of Fleet storing an incorrect CPE for the software, to test that an upgrade


### PR DESCRIPTION
Closes #49061

Adobe plugins are inventory-only: no vulnerability data source maps an Adobe CEP or UXP extension to a CVE. Adobe files CVEs against the host application (Photoshop, Acrobat, and so on) keyed to that app's version, which Fleet already scans via the apps/programs sources, so any match on an extension row would be a false positive pinned to the wrong version.

- Added adobe_plugins to the excluded sources on the NVD/CPE software iterator so they are excluded from vuln scanning.
- Adobe plugins show as "Not supported" on the vulnerability column.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Adobe CEP and UXP plugins to software inventory on macOS and Windows.
  * Adobe plugins now display as “Plugin (Adobe)” with version and host details.
  * Adobe plugins show “Not supported” in vulnerability fields and are excluded from vulnerability scanning.
* **Bug Fixes**
  * Updated software and host views to consistently identify unsupported vulnerability sources.
  * Improved messaging for software types that do not support vulnerability detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->