### PR TITLE
Docs: note that Fleet doesn't scan Adobe plugins for vulnerabilities

### DIFF
--- a/articles/vulnerability-processing.md
+++ b/articles/vulnerability-processing.md
@@ -69,6 +69,8 @@ Vulnerabilities that only impact specific software configurations are still repo
 
 On macOS, Fleet reports vulnerabilities in the built-in Python. This version is managed exclusively by Apple, isn't intended for user workloads, and can't be patched, upgraded, or removed without breaking macOS system services. These vulnerabilities can be safely ignored.
 
+Fleet doesn't scan Adobe plugins for vulnerabilities. No vulnerability data source maps an Adobe CEP or UXP extension to a CVE. Adobe files CVEs against the host application, such as Photoshop or Acrobat, keyed to that application's version. Fleet detects those vulnerabilities through the application itself. Adobe plugins still appear in software inventory with no vulnerabilities listed.
+
 ## Advanced
 
 Fleet runs vulnerability downloading and processing via an internal scheduled cron job. [Learn more](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/architecture/security-compliance/vulnerability-processing.md). This internal mechanism is useful for frictionless deployments and is well-suited for most use cases. However, it is desirable to manage vulnerability processing externally in larger deployments where there can be dozens of Fleet server replicas sitting behind a load balancer.


### PR DESCRIPTION
No vulnerability data source maps an Adobe CEP or UXP extension to a CVE. Adobe files CVEs against the host application, which Fleet already scans, so the Vulnerabilities column stays empty for plugin rows.