### PR TITLE
AULD: Backend OS update cron + variable resolution

### DIFF
--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -2693,3 +2693,25 @@ func newCleanupExpiredADUEChallengesSchedule(
 
 	return s, nil
 }
+
+func newAppleMDMOSUpdatesSchedule(
+	ctx context.Context,
+	instanceID string,
+	ds fleet.Datastore,
+	logger *slog.Logger,
+) (*schedule.Schedule, error) {
+	const (
+		name            = string(fleet.CronAppleMDMOSUpdatesSchedule)
+		defaultInterval = 1 * time.Hour
+	)
+	logger = logger.With("cron", name)
+	s := schedule.New(
+		ctx, name, instanceID, defaultInterval, ds, ds,
+		schedule.WithLogger(logger),
+		schedule.WithJob("apple_mdm_os_updates", func(ctx context.Context) error {
+			return apple_mdm.HandleAppleMDMOSUpdates(ctx, ds, logger)
+		}),
+	)
+
+	return s, nil
+}

--- a/cmd/fleet/cron_registration.go
+++ b/cmd/fleet/cron_registration.go
@@ -287,6 +287,10 @@ func registerMDMCrons(ctx context.Context, deps cronSchedulesDeps) {
 			deps.logger,
 		)
 	})
+
+	deps.register("failed to register Apple MDM OS updates schedule", func() (fleet.CronSchedule, error) {
+		return newAppleMDMOSUpdatesSchedule(ctx, deps.instanceID, deps.ds, deps.logger)
+	})
 }
 
 // registerPremiumCrons covers the Fleet Premium schedules: iPhone/iPad

--- a/cmd/fleetctl/fleetctl/testdata/expectedHostDetailResponseJson.json
+++ b/cmd/fleetctl/fleetctl/testdata/expectedHostDetailResponseJson.json
@@ -55,6 +55,8 @@
     "mdm_enrollment_hardware_attested": false,
     "memory": 0,
     "orbit_version": null,
+    "os_update_deadline": null,
+    "os_update_minimum_version": null,
     "os_version": "",
     "osquery_version": "",
     "pack_stats": null,

--- a/cmd/fleetctl/fleetctl/testdata/expectedHostDetailResponseYaml.yml
+++ b/cmd/fleetctl/fleetctl/testdata/expectedHostDetailResponseYaml.yml
@@ -54,6 +54,8 @@ spec:
   mdm_enrollment_hardware_attested: false
   memory: 0
   orbit_version: null
+  os_update_deadline: null
+  os_update_minimum_version: null
   os_version: ""
   osquery_version: ""
   pack_stats: null

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -8678,7 +8678,8 @@ func (ds *Datastore) UpsertAppleOSUpdates(ctx context.Context, updates map[strin
 			ON DUPLICATE KEY UPDATE
 				posting_date = VALUES(posting_date),
 				expiration_date = VALUES(expiration_date),
-				supported_devices = VALUES(supported_devices)
+				supported_devices = VALUES(supported_devices),
+				updated_at = NOW(6)
 	`
 
 	args := []any{}
@@ -8755,7 +8756,7 @@ func (ds *Datastore) ListAppleOSUpdateAssets(ctx context.Context) (map[string][]
 	for _, class := range classes {
 		var assets []fleet.AppleSoftwareUpdateAsset
 		if err := sqlx.SelectContext(ctx, ds.reader(ctx), &assets, `
-			SELECT product_version, build, posting_date, expiration_date, supported_devices, first_seen_at
+			SELECT product_version, build, posting_date, expiration_date, supported_devices, first_seen_at, updated_at
 			FROM apple_software_update_assets
 			WHERE class = ?
 		`, class); err != nil {

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"slices"
 	"strings"
 	"time"
@@ -22,11 +23,13 @@ import (
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxdb"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	common_mdm "github.com/fleetdm/fleet/v4/server/mdm"
 	fleetmdm "github.com/fleetdm/fleet/v4/server/mdm"
 	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
 	"github.com/fleetdm/fleet/v4/server/mdm/apple/mobileconfig"
 	"github.com/fleetdm/fleet/v4/server/mdm/nanodep/godep"
 	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/mdm"
+
 	common_mysql "github.com/fleetdm/fleet/v4/server/platform/mysql"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/google/go-cmp/cmp"
@@ -8650,5 +8653,211 @@ func (ds *Datastore) InsertAppleSoftwareUpdateDeviceID(ctx context.Context, host
 		return ctxerr.Wrap(ctx, err, "inserting Apple software update device ID")
 	}
 
+	return nil
+}
+
+func (ds *Datastore) GetLastAppleOSUpdatesUpdate(ctx context.Context) (*time.Time, error) {
+	const stmt = `SELECT MAX(updated_at) FROM apple_software_update_assets`
+
+	var lastUpdate *time.Time
+	if err := sqlx.GetContext(ctx, ds.reader(ctx), &lastUpdate, stmt); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "getting last apple os updates update")
+	}
+
+	return lastUpdate, nil
+}
+
+func (ds *Datastore) UpsertAppleOSUpdates(ctx context.Context, updates map[string][]fleet.OSUpdateAsset) error {
+	stmt := `
+		INSERT INTO apple_software_update_assets (class, product_version, build, posting_date, expiration_date, supported_devices)
+			VALUES %s
+			ON DUPLICATE KEY UPDATE
+				posting_date = VALUES(posting_date),
+				expiration_date = VALUES(expiration_date),
+				supported_devices = VALUES(supported_devices)
+	`
+
+	args := []any{}
+	for class, assets := range updates {
+		for _, asset := range assets {
+			supportedDevices, err := json.Marshal(asset.SupportedDevices)
+			if err != nil {
+				return ctxerr.Wrap(ctx, err, "marshaling supported devices")
+			}
+			args = append(args,
+				class,
+				asset.ProductVersion,
+				asset.Build,
+				asset.PostingDate,
+				asset.ExpirationDate,
+				supportedDevices,
+			)
+
+		}
+	}
+
+	valueStrings := []string{}
+	for i := 0; i < len(args); i += 6 {
+		valueStrings = append(valueStrings, "(?, ?, ?, ?, ?, ?)")
+	}
+	stmt = fmt.Sprintf(stmt, strings.Join(valueStrings, ","))
+	if _, err := ds.writer(ctx).ExecContext(ctx, stmt, args...); err != nil {
+		return ctxerr.Wrap(ctx, err, "upserting apple os updates")
+	}
+
+	return nil
+}
+
+func (ds *Datastore) ListAppleOSUpdateAssets(ctx context.Context) (map[string][]fleet.AppleSoftwareUpdateAsset, error) {
+	// we do N selects, one for each class of OS updates
+	classes := []string{"macos", "ios"}
+
+	results := make(map[string][]fleet.AppleSoftwareUpdateAsset, len(classes))
+	for _, class := range classes {
+		var assets []fleet.AppleSoftwareUpdateAsset
+		if err := sqlx.SelectContext(ctx, ds.reader(ctx), &assets, `
+			SELECT product_version, build, posting_date, expiration_date, supported_devices, first_seen_at
+			FROM apple_software_update_assets
+			WHERE class = ?
+		`, class); err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "listing apple os update assets")
+		}
+		results[class] = assets
+	}
+
+	return results, nil
+}
+
+func (ds *Datastore) ListAppleOSUpdateHostsForReconcile(ctx context.Context, cursor string, batchSize int, teamsWithLatest map[string]map[uint]uint) ([]*fleet.AppleSoftwareUpdateHost, error) {
+	stmt := `
+		SELECT 
+			hmaou.host_uuid,
+			hmaou.software_update_device_id,
+			hmaou.target_os_version,
+			hmaou.target_deadline,
+			hmaou.resolved_at,
+			IFNULL(h.team_id, 0) AS team_id,
+			h.platform
+		FROM host_mdm_apple_os_updates hmaou
+			INNER JOIN hosts h ON h.uuid = hmaou.host_uuid
+		WHERE 
+			hmaou.host_uuid > ? AND (
+				(hmaou.target_os_version != '' OR hmaou.resolved_at IS NOT NULL) -- include hosts not part of a team that already has a target update configured`
+	var args []any
+	args = append(args, cursor)
+	if len(teamsWithLatest["darwin"]) > 0 {
+		teamIds := slices.Collect(maps.Keys(teamsWithLatest["darwin"]))
+		query, inArgs, err := sqlx.In(`
+			OR (h.platform = 'darwin' AND IFNULL(h.team_id, 0) IN (?))`, teamIds)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "building team filter for darwin updates")
+		}
+
+		stmt += query
+		args = append(args, inArgs...)
+	}
+	if len(teamsWithLatest["ios"]) > 0 {
+		teamIds := slices.Collect(maps.Keys(teamsWithLatest["ios"]))
+		query, inArgs, err := sqlx.In(`
+			OR (h.platform = 'ios' AND IFNULL(h.team_id, 0) IN (?))`, teamIds)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "building team filter for ios updates")
+		}
+
+		stmt += query
+		args = append(args, inArgs...)
+	}
+	if len(teamsWithLatest["ipados"]) > 0 {
+		teamIds := slices.Collect(maps.Keys(teamsWithLatest["ipados"]))
+		query, inArgs, err := sqlx.In(`
+			OR (h.platform = 'ipados' AND IFNULL(h.team_id, 0) IN (?))`, teamIds)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "building team filter for ipados updates")
+		}
+
+		stmt += query
+		args = append(args, inArgs...)
+	}
+
+	stmt += `
+	)
+		ORDER BY hmaou.host_uuid
+		LIMIT ?
+	`
+	args = append(args, batchSize)
+	var hosts []*fleet.AppleSoftwareUpdateHost
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &hosts, stmt, args...); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "listing apple os update hosts for reconcile")
+	}
+	return hosts, nil
+}
+
+func (ds *Datastore) SetAppleOSUpdateTargetsAndResend(ctx context.Context, targets []*fleet.ComputedAppleSoftwareUpdateHost) error {
+	targetsToResend := make([]*fleet.ComputedAppleSoftwareUpdateHost, 0, len(targets))
+
+	executeBatch := func(valuePart string, args []any) error {
+		valuePart = strings.TrimPrefix(valuePart, ",")
+		stmt := fmt.Sprintf(`
+		INSERT INTO host_mdm_apple_os_updates (host_uuid, target_os_version, target_deadline, resolved_at)
+		VALUES %s
+			ON DUPLICATE KEY UPDATE
+				target_os_version = VALUES(target_os_version),
+				target_deadline = VALUES(target_deadline),
+				resolved_at = VALUES(resolved_at)
+		`, valuePart)
+
+		if _, err := ds.writer(ctx).ExecContext(ctx, stmt, args...); err != nil {
+			return ctxerr.Wrap(ctx, err, "upserting apple os update targets")
+		}
+
+		return nil
+	}
+
+	updateGenerateValueArgs := func(target *fleet.ComputedAppleSoftwareUpdateHost) (string, []any) {
+		if target.Resend {
+			targetsToResend = append(targetsToResend, target)
+		}
+		resolvedAt := sql.NullTime{Valid: target.ResolvedAt != nil}
+		if resolvedAt.Valid {
+			resolvedAt.Time = *target.ResolvedAt
+		}
+		return ",(?, ?, ?, ?)", []any{
+			target.HostUUID,
+			target.TargetOSVersion,
+			target.TargetDeadline,
+			resolvedAt,
+		}
+	}
+
+	if err := batchProcessDB(targets, 1000, updateGenerateValueArgs, executeBatch); err != nil {
+		return ctxerr.Wrap(ctx, err, "batch processing apple os update targets")
+	}
+
+	if len(targetsToResend) == 0 {
+		return nil
+	}
+
+	var sb strings.Builder
+	sb.WriteString("UPDATE host_mdm_apple_declarations SET status=NULL, variables_updated_at = CASE host_uuid ")
+	args := make([]any, 0, len(targetsToResend)*2+len(targetsToResend))
+	for _, hu := range targetsToResend {
+		sb.WriteString("WHEN ? THEN ? ")
+		args = append(args, hu.HostUUID, hu.ResolvedAt)
+	}
+	sb.WriteString("END WHERE host_uuid IN (?)")
+	uuids := make([]string, len(targetsToResend))
+	for i, hu := range targetsToResend {
+		uuids[i] = hu.HostUUID
+	}
+	args = append(args, uuids)
+	stmt, args, err := sqlx.In(sb.String(), args...)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "building sql for updating apple os update hosts to resend")
+	}
+	stmt += ` AND declaration_name IN (?, ?, ?)`
+	args = append(args, common_mdm.FleetMacOSUpdatesProfileName, common_mdm.FleetIOSUpdatesProfileName, common_mdm.FleetIPadOSUpdatesProfileName)
+	if _, err := ds.writer(ctx).ExecContext(ctx, stmt, args...); err != nil {
+		return ctxerr.Wrap(ctx, err, "updating apple os update hosts to resend")
+	}
 	return nil
 }

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -8759,6 +8759,7 @@ func (ds *Datastore) ListAppleOSUpdateAssets(ctx context.Context) (map[string][]
 			SELECT product_version, build, posting_date, expiration_date, supported_devices, first_seen_at, updated_at
 			FROM apple_software_update_assets
 			WHERE class = ?
+			ORDER BY posting_date DESC
 		`, class); err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "listing apple os update assets")
 		}

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -8793,11 +8793,12 @@ func (ds *Datastore) ListAppleOSUpdateHostsForReconcile(ctx context.Context, cur
 }
 
 func (ds *Datastore) SetAppleOSUpdateTargetsAndResend(ctx context.Context, targets []*fleet.ComputedAppleSoftwareUpdateHost) error {
-	targetsToResend := make([]*fleet.ComputedAppleSoftwareUpdateHost, 0, len(targets))
+	return ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
+		targetsToResend := make([]*fleet.ComputedAppleSoftwareUpdateHost, 0, len(targets))
 
-	executeBatch := func(valuePart string, args []any) error {
-		valuePart = strings.TrimPrefix(valuePart, ",")
-		stmt := fmt.Sprintf(`
+		executeBatch := func(valuePart string, args []any) error {
+			valuePart = strings.TrimPrefix(valuePart, ",")
+			stmt := fmt.Sprintf(`
 		INSERT INTO host_mdm_apple_os_updates (host_uuid, target_os_version, target_deadline, resolved_at)
 		VALUES %s
 			ON DUPLICATE KEY UPDATE
@@ -8806,58 +8807,59 @@ func (ds *Datastore) SetAppleOSUpdateTargetsAndResend(ctx context.Context, targe
 				resolved_at = VALUES(resolved_at)
 		`, valuePart)
 
-		if _, err := ds.writer(ctx).ExecContext(ctx, stmt, args...); err != nil {
-			return ctxerr.Wrap(ctx, err, "upserting apple os update targets")
+			if _, err := tx.ExecContext(ctx, stmt, args...); err != nil {
+				return ctxerr.Wrap(ctx, err, "upserting apple os update targets")
+			}
+
+			return nil
 		}
 
+		updateGenerateValueArgs := func(target *fleet.ComputedAppleSoftwareUpdateHost) (string, []any) {
+			if target.Resend {
+				targetsToResend = append(targetsToResend, target)
+			}
+			resolvedAt := sql.NullTime{Valid: target.ResolvedAt != nil}
+			if resolvedAt.Valid {
+				resolvedAt.Time = *target.ResolvedAt
+			}
+			return ",(?, ?, ?, ?)", []any{
+				target.HostUUID,
+				target.TargetOSVersion,
+				target.TargetDeadline,
+				resolvedAt,
+			}
+		}
+
+		if err := batchProcessDB(targets, 1000, updateGenerateValueArgs, executeBatch); err != nil {
+			return ctxerr.Wrap(ctx, err, "batch processing apple os update targets")
+		}
+
+		if len(targetsToResend) == 0 {
+			return nil
+		}
+
+		var sb strings.Builder
+		sb.WriteString("UPDATE host_mdm_apple_declarations SET status=NULL, variables_updated_at = CASE host_uuid ")
+		args := make([]any, 0, len(targetsToResend)*2+len(targetsToResend))
+		for _, hu := range targetsToResend {
+			sb.WriteString("WHEN ? THEN ? ")
+			args = append(args, hu.HostUUID, hu.ResolvedAt)
+		}
+		sb.WriteString("END WHERE host_uuid IN (?)")
+		uuids := make([]string, len(targetsToResend))
+		for i, hu := range targetsToResend {
+			uuids[i] = hu.HostUUID
+		}
+		args = append(args, uuids)
+		stmt, args, err := sqlx.In(sb.String(), args...)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "building sql for updating apple os update hosts to resend")
+		}
+		stmt += ` AND declaration_name IN (?, ?, ?)`
+		args = append(args, common_mdm.FleetMacOSUpdatesProfileName, common_mdm.FleetIOSUpdatesProfileName, common_mdm.FleetIPadOSUpdatesProfileName)
+		if _, err := tx.ExecContext(ctx, stmt, args...); err != nil {
+			return ctxerr.Wrap(ctx, err, "updating apple os update hosts to resend")
+		}
 		return nil
-	}
-
-	updateGenerateValueArgs := func(target *fleet.ComputedAppleSoftwareUpdateHost) (string, []any) {
-		if target.Resend {
-			targetsToResend = append(targetsToResend, target)
-		}
-		resolvedAt := sql.NullTime{Valid: target.ResolvedAt != nil}
-		if resolvedAt.Valid {
-			resolvedAt.Time = *target.ResolvedAt
-		}
-		return ",(?, ?, ?, ?)", []any{
-			target.HostUUID,
-			target.TargetOSVersion,
-			target.TargetDeadline,
-			resolvedAt,
-		}
-	}
-
-	if err := batchProcessDB(targets, 1000, updateGenerateValueArgs, executeBatch); err != nil {
-		return ctxerr.Wrap(ctx, err, "batch processing apple os update targets")
-	}
-
-	if len(targetsToResend) == 0 {
-		return nil
-	}
-
-	var sb strings.Builder
-	sb.WriteString("UPDATE host_mdm_apple_declarations SET status=NULL, variables_updated_at = CASE host_uuid ")
-	args := make([]any, 0, len(targetsToResend)*2+len(targetsToResend))
-	for _, hu := range targetsToResend {
-		sb.WriteString("WHEN ? THEN ? ")
-		args = append(args, hu.HostUUID, hu.ResolvedAt)
-	}
-	sb.WriteString("END WHERE host_uuid IN (?)")
-	uuids := make([]string, len(targetsToResend))
-	for i, hu := range targetsToResend {
-		uuids[i] = hu.HostUUID
-	}
-	args = append(args, uuids)
-	stmt, args, err := sqlx.In(sb.String(), args...)
-	if err != nil {
-		return ctxerr.Wrap(ctx, err, "building sql for updating apple os update hosts to resend")
-	}
-	stmt += ` AND declaration_name IN (?, ?, ?)`
-	args = append(args, common_mdm.FleetMacOSUpdatesProfileName, common_mdm.FleetIOSUpdatesProfileName, common_mdm.FleetIPadOSUpdatesProfileName)
-	if _, err := ds.writer(ctx).ExecContext(ctx, stmt, args...); err != nil {
-		return ctxerr.Wrap(ctx, err, "updating apple os update hosts to resend")
-	}
-	return nil
+	})
 }

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -8863,3 +8863,29 @@ func (ds *Datastore) SetAppleOSUpdateTargetsAndResend(ctx context.Context, targe
 		return nil
 	})
 }
+
+func (ds *Datastore) GetAppleOSUpdateHostByUUID(ctx context.Context, hostUUID string) (*fleet.AppleSoftwareUpdateHost, error) {
+	const stmt = `
+		SELECT
+			hmaou.host_uuid,
+			hmaou.software_update_device_id,
+			hmaou.target_os_version,
+			hmaou.target_deadline,
+			hmaou.resolved_at,
+			IFNULL(h.team_id, 0) AS team_id,
+			h.platform
+		FROM host_mdm_apple_os_updates hmaou
+			INNER JOIN hosts h ON h.uuid = hmaou.host_uuid
+		WHERE hmaou.host_uuid = ?`
+
+	var host fleet.AppleSoftwareUpdateHost
+	if err := sqlx.GetContext(ctx, ds.reader(ctx), &host, stmt, hostUUID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			// No tracking row for this host yet; let the caller decide how to handle
+			// a missing host (the DDM service treats nil as "not found").
+			return nil, nil
+		}
+		return nil, ctxerr.Wrap(ctx, err, "getting apple os update host by uuid")
+	}
+	return &host, nil
+}

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -8668,6 +8668,10 @@ func (ds *Datastore) GetLastAppleOSUpdatesUpdate(ctx context.Context) (*time.Tim
 }
 
 func (ds *Datastore) UpsertAppleOSUpdates(ctx context.Context, updates map[string][]fleet.OSUpdateAsset) error {
+	if len(updates) == 0 {
+		return nil
+	}
+
 	stmt := `
 		INSERT INTO apple_software_update_assets (class, product_version, build, posting_date, expiration_date, supported_devices)
 			VALUES %s
@@ -8708,6 +8712,41 @@ func (ds *Datastore) UpsertAppleOSUpdates(ctx context.Context, updates map[strin
 	return nil
 }
 
+func (ds *Datastore) DeleteStaleAppleOSUpdates(ctx context.Context, updates map[string][]fleet.OSUpdateAsset) (int64, error) {
+	var deleted int64
+	for class, assets := range updates {
+		if len(assets) == 0 {
+			// Apple didn't report any asset for this class; assume the response was incomplete
+			// rather than deleting every cached asset for the class.
+			continue
+		}
+
+		// delete the cached assets for this class that are not in the set Apple currently reports
+		args := []any{class}
+		placeholders := make([]string, 0, len(assets))
+		for _, asset := range assets {
+			args = append(args, asset.ProductVersion, asset.Build)
+			placeholders = append(placeholders, "(?, ?)")
+		}
+		stmt := fmt.Sprintf(`
+			DELETE FROM apple_software_update_assets
+			WHERE class = ? AND (product_version, build) NOT IN (%s)
+		`, strings.Join(placeholders, ","))
+
+		res, err := ds.writer(ctx).ExecContext(ctx, stmt, args...)
+		if err != nil {
+			return deleted, ctxerr.Wrapf(ctx, err, "deleting stale apple os updates for class %s", class)
+		}
+		n, err := res.RowsAffected()
+		if err != nil {
+			return deleted, ctxerr.Wrapf(ctx, err, "counting deleted apple os updates for class %s", class)
+		}
+		deleted += n
+	}
+
+	return deleted, nil
+}
+
 func (ds *Datastore) ListAppleOSUpdateAssets(ctx context.Context) (map[string][]fleet.AppleSoftwareUpdateAsset, error) {
 	// we do N selects, one for each class of OS updates
 	classes := []string{"macos", "ios"}
@@ -8728,7 +8767,7 @@ func (ds *Datastore) ListAppleOSUpdateAssets(ctx context.Context) (map[string][]
 	return results, nil
 }
 
-func (ds *Datastore) ListAppleOSUpdateHostsForReconcile(ctx context.Context, cursor string, batchSize int, teamsWithLatest map[string]map[uint]uint) ([]*fleet.AppleSoftwareUpdateHost, error) {
+func (ds *Datastore) ListAppleOSUpdateHostsForReconcile(ctx context.Context, cursor string, batchSize int, teamsWithLatest map[string]map[uint]int) ([]*fleet.AppleSoftwareUpdateHost, error) {
 	stmt := `
 		SELECT 
 			hmaou.host_uuid,
@@ -8839,7 +8878,7 @@ func (ds *Datastore) SetAppleOSUpdateTargetsAndResend(ctx context.Context, targe
 		}
 
 		var sb strings.Builder
-		sb.WriteString("UPDATE host_mdm_apple_declarations SET status=NULL, variables_updated_at = CASE host_uuid ")
+		sb.WriteString("UPDATE host_mdm_apple_declarations SET status=NULL, detail='', variables_updated_at = CASE host_uuid ")
 		args := make([]any, 0, len(targetsToResend)*2+len(targetsToResend))
 		for _, hu := range targetsToResend {
 			sb.WriteString("WHEN ? THEN ? ")

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -108,6 +108,7 @@ func TestMDMApple(t *testing.T) {
 		{"IngestMDMAppleDevicesFromDEPSyncIOSIPadOS", testIngestMDMAppleDevicesFromDEPSyncIOSIPadOS},
 		{"MDMAppleProfilesOnIOSIPadOS", testMDMAppleProfilesOnIOSIPadOS},
 		{"ReconcileAppleProfilesDuplicateHostUUID", testReconcileAppleProfilesDuplicateHostUUID},
+		{"AppleOSUpdatesReconcile", testAppleOSUpdatesReconcile},
 		{"GetEnrollmentIDsWithPendingMDMAppleCommands", testGetEnrollmentIDsWithPendingMDMAppleCommands},
 		{"MDMAppleBootstrapPackageWithS3", testMDMAppleBootstrapPackageWithS3},
 		{"GetAndUpdateABMToken", testMDMAppleGetAndUpdateABMToken},
@@ -14073,4 +14074,142 @@ func testMDMAppleCustomActivations(t *testing.T, ds *Datastore) {
 	require.NoError(t, sqlx.GetContext(ctx, ds.reader(ctx), &varCount,
 		`SELECT COUNT(*) FROM mdm_configuration_profile_variables WHERE apple_ddm_activation_uuid = ?`, activationUUID))
 	require.Zero(t, varCount)
+}
+
+func testAppleOSUpdatesReconcile(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "os-updates-team"})
+	require.NoError(t, err)
+
+	newHost := func(hostUUID, platform, deviceID string) *fleet.Host {
+		h, err := ds.NewHost(ctx, &fleet.Host{
+			DetailUpdatedAt: time.Now(),
+			LabelUpdatedAt:  time.Now(),
+			PolicyUpdatedAt: time.Now(),
+			SeenTime:        time.Now(),
+			OsqueryHostID:   ptr.String(hostUUID),
+			NodeKey:         ptr.String(hostUUID),
+			UUID:            hostUUID,
+			Hostname:        hostUUID,
+			Platform:        platform,
+		})
+		require.NoError(t, err)
+		require.NoError(t, ds.InsertAppleSoftwareUpdateDeviceID(ctx, hostUUID, deviceID))
+		return h
+	}
+
+	// UUIDs are chosen so that lexical host_uuid order is mac-team, mac-noteam, ios-noteam.
+	hMacTeam := newHost("aaa-mac-team", "darwin", "Mac14,2")
+	hMacNoTeam := newHost("bbb-mac-noteam", "darwin", "Mac14,2")
+	hIOSNoTeam := newHost("ccc-ios-noteam", "ios", "iPhone15,2")
+	require.NoError(t, ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&team.ID, []uint{hMacTeam.ID})))
+
+	latest := func(darwin, ios, ipados map[uint]uint) map[string]map[uint]uint {
+		return map[string]map[uint]uint{"darwin": darwin, "ios": ios, "ipados": ipados}
+	}
+	uuidsOf := func(hosts []*fleet.AppleSoftwareUpdateHost) []string {
+		out := make([]string, len(hosts))
+		for i, h := range hosts {
+			out[i] = h.HostUUID
+		}
+		return out
+	}
+
+	t.Run("ListForReconcile filters by team and platform", func(t *testing.T) {
+		got, err := ds.ListAppleOSUpdateHostsForReconcile(ctx, "", 100, latest(map[uint]uint{team.ID: 2}, nil, nil))
+		require.NoError(t, err)
+		require.Equal(t, []string{hMacTeam.UUID}, uuidsOf(got))
+		require.Equal(t, "darwin", got[0].Platform)
+		require.EqualValues(t, team.ID, got[0].TeamID)
+	})
+
+	t.Run("ListForReconcile matches no-team hosts via team_id 0", func(t *testing.T) {
+		got, err := ds.ListAppleOSUpdateHostsForReconcile(ctx, "", 100, latest(map[uint]uint{0: 2}, nil, nil))
+		require.NoError(t, err)
+		require.Equal(t, []string{hMacNoTeam.UUID}, uuidsOf(got))
+		require.EqualValues(t, 0, got[0].TeamID)
+	})
+
+	t.Run("ListForReconcile returns hosts with an existing target even without a latest team", func(t *testing.T) {
+		deadline := time.Now().UTC().Truncate(time.Microsecond)
+		require.NoError(t, ds.SetAppleOSUpdateTargetsAndResend(ctx, []*fleet.ComputedAppleSoftwareUpdateHost{{
+			AppleSoftwareUpdateHost: fleet.AppleSoftwareUpdateHost{HostUUID: hIOSNoTeam.UUID, TargetOSVersion: "18.1", TargetDeadline: &deadline},
+		}}))
+		// No teams have latest configured, but the iOS host now has a target set,
+		// so the reconciler must still revisit it (to potentially clear it).
+		got, err := ds.ListAppleOSUpdateHostsForReconcile(ctx, "", 100, latest(nil, nil, nil))
+		require.NoError(t, err)
+		require.Equal(t, []string{hIOSNoTeam.UUID}, uuidsOf(got))
+		require.Equal(t, "18.1", got[0].TargetOSVersion)
+		require.NotNil(t, got[0].TargetDeadline)
+		require.True(t, deadline.Equal(*got[0].TargetDeadline))
+	})
+
+	t.Run("ListForReconcile paginates by host_uuid cursor", func(t *testing.T) {
+		all := latest(map[uint]uint{team.ID: 2, 0: 2}, map[uint]uint{0: 2}, nil)
+		page1, err := ds.ListAppleOSUpdateHostsForReconcile(ctx, "", 2, all)
+		require.NoError(t, err)
+		require.Equal(t, []string{hMacTeam.UUID, hMacNoTeam.UUID}, uuidsOf(page1))
+
+		page2, err := ds.ListAppleOSUpdateHostsForReconcile(ctx, page1[len(page1)-1].HostUUID, 2, all)
+		require.NoError(t, err)
+		require.Equal(t, []string{hIOSNoTeam.UUID}, uuidsOf(page2))
+	})
+
+	t.Run("SetTargetsAndResend upserts targets and resets only the OS-update declaration", func(t *testing.T) {
+		// Seed two declarations on the mac team host: one OS-update declaration
+		// (status should be reset for resend) and one unrelated declaration
+		// (must be left untouched).
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			for _, d := range []struct{ ident, name string }{
+				{"os-updates", fleetmdm.FleetMacOSUpdatesProfileName},
+				{"other", "Some Other Profile"},
+			} {
+				if _, err := q.ExecContext(ctx,
+					`INSERT INTO host_mdm_apple_declarations (host_uuid, status, operation_type, token, declaration_identifier, declaration_uuid, declaration_name, scope) VALUES (?, ?, ?, UNHEX(REPEAT('00', 16)), ?, ?, ?, 'System')`,
+					hMacTeam.UUID, fleet.MDMDeliveryVerified, fleet.MDMOperationTypeInstall, d.ident, uuid.NewString(), d.name); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+
+		resolvedAt := time.Now().UTC().Truncate(time.Microsecond)
+		deadline := resolvedAt.Add(48 * time.Hour)
+		require.NoError(t, ds.SetAppleOSUpdateTargetsAndResend(ctx, []*fleet.ComputedAppleSoftwareUpdateHost{{
+			AppleSoftwareUpdateHost: fleet.AppleSoftwareUpdateHost{
+				HostUUID: hMacTeam.UUID, TargetOSVersion: "15.1", TargetDeadline: &deadline, ResolvedAt: &resolvedAt,
+			},
+			Resend: true,
+		}}))
+
+		var row fleet.AppleSoftwareUpdateHost
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			return sqlx.GetContext(ctx, q, &row,
+				`SELECT host_uuid, target_os_version, target_deadline, resolved_at FROM host_mdm_apple_os_updates WHERE host_uuid = ?`, hMacTeam.UUID)
+		})
+		require.Equal(t, "15.1", row.TargetOSVersion)
+		require.NotNil(t, row.TargetDeadline)
+		require.True(t, deadline.Equal(*row.TargetDeadline))
+		require.NotNil(t, row.ResolvedAt)
+		require.True(t, resolvedAt.Equal(*row.ResolvedAt))
+
+		var decls []struct {
+			Name   string  `db:"declaration_name"`
+			Status *string `db:"status"`
+		}
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			return sqlx.SelectContext(ctx, q, &decls,
+				`SELECT declaration_name, status FROM host_mdm_apple_declarations WHERE host_uuid = ? ORDER BY declaration_name`, hMacTeam.UUID)
+		})
+		byName := map[string]*string{}
+		for _, d := range decls {
+			byName[d.Name] = d.Status
+		}
+		require.Contains(t, byName, fleetmdm.FleetMacOSUpdatesProfileName)
+		require.Nil(t, byName[fleetmdm.FleetMacOSUpdatesProfileName], "OS-update declaration status should be reset to NULL for resend")
+		require.Contains(t, byName, "Some Other Profile")
+		require.NotNil(t, byName["Some Other Profile"], "unrelated declaration should be untouched")
+	})
 }

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -109,6 +109,7 @@ func TestMDMApple(t *testing.T) {
 		{"MDMAppleProfilesOnIOSIPadOS", testMDMAppleProfilesOnIOSIPadOS},
 		{"ReconcileAppleProfilesDuplicateHostUUID", testReconcileAppleProfilesDuplicateHostUUID},
 		{"AppleOSUpdatesReconcile", testAppleOSUpdatesReconcile},
+		{"AppleOSUpdateAssets", testAppleOSUpdateAssets},
 		{"GetEnrollmentIDsWithPendingMDMAppleCommands", testGetEnrollmentIDsWithPendingMDMAppleCommands},
 		{"MDMAppleBootstrapPackageWithS3", testMDMAppleBootstrapPackageWithS3},
 		{"GetAndUpdateABMToken", testMDMAppleGetAndUpdateABMToken},
@@ -14105,8 +14106,8 @@ func testAppleOSUpdatesReconcile(t *testing.T, ds *Datastore) {
 	hIOSNoTeam := newHost("ccc-ios-noteam", "ios", "iPhone15,2")
 	require.NoError(t, ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&team.ID, []uint{hMacTeam.ID})))
 
-	latest := func(darwin, ios, ipados map[uint]uint) map[string]map[uint]uint {
-		return map[string]map[uint]uint{"darwin": darwin, "ios": ios, "ipados": ipados}
+	latest := func(darwin, ios, ipados map[uint]int) map[string]map[uint]int {
+		return map[string]map[uint]int{"darwin": darwin, "ios": ios, "ipados": ipados}
 	}
 	uuidsOf := func(hosts []*fleet.AppleSoftwareUpdateHost) []string {
 		out := make([]string, len(hosts))
@@ -14117,7 +14118,7 @@ func testAppleOSUpdatesReconcile(t *testing.T, ds *Datastore) {
 	}
 
 	t.Run("ListForReconcile filters by team and platform", func(t *testing.T) {
-		got, err := ds.ListAppleOSUpdateHostsForReconcile(ctx, "", 100, latest(map[uint]uint{team.ID: 2}, nil, nil))
+		got, err := ds.ListAppleOSUpdateHostsForReconcile(ctx, "", 100, latest(map[uint]int{team.ID: 2}, nil, nil))
 		require.NoError(t, err)
 		require.Equal(t, []string{hMacTeam.UUID}, uuidsOf(got))
 		require.Equal(t, "darwin", got[0].Platform)
@@ -14125,7 +14126,7 @@ func testAppleOSUpdatesReconcile(t *testing.T, ds *Datastore) {
 	})
 
 	t.Run("ListForReconcile matches no-team hosts via team_id 0", func(t *testing.T) {
-		got, err := ds.ListAppleOSUpdateHostsForReconcile(ctx, "", 100, latest(map[uint]uint{0: 2}, nil, nil))
+		got, err := ds.ListAppleOSUpdateHostsForReconcile(ctx, "", 100, latest(map[uint]int{0: 2}, nil, nil))
 		require.NoError(t, err)
 		require.Equal(t, []string{hMacNoTeam.UUID}, uuidsOf(got))
 		require.EqualValues(t, 0, got[0].TeamID)
@@ -14147,7 +14148,7 @@ func testAppleOSUpdatesReconcile(t *testing.T, ds *Datastore) {
 	})
 
 	t.Run("ListForReconcile paginates by host_uuid cursor", func(t *testing.T) {
-		all := latest(map[uint]uint{team.ID: 2, 0: 2}, map[uint]uint{0: 2}, nil)
+		all := latest(map[uint]int{team.ID: 2, 0: 2}, map[uint]int{0: 2}, nil)
 		page1, err := ds.ListAppleOSUpdateHostsForReconcile(ctx, "", 2, all)
 		require.NoError(t, err)
 		require.Equal(t, []string{hMacTeam.UUID, hMacNoTeam.UUID}, uuidsOf(page1))
@@ -14211,5 +14212,103 @@ func testAppleOSUpdatesReconcile(t *testing.T, ds *Datastore) {
 		require.Nil(t, byName[fleetmdm.FleetMacOSUpdatesProfileName], "OS-update declaration status should be reset to NULL for resend")
 		require.Contains(t, byName, "Some Other Profile")
 		require.NotNil(t, byName["Some Other Profile"], "unrelated declaration should be untouched")
+	})
+}
+
+func testAppleOSUpdateAssets(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	asset := func(version, build string) fleet.OSUpdateAsset {
+		return fleet.OSUpdateAsset{
+			ProductVersion:   version,
+			Build:            build,
+			PostingDate:      "2024-10-28",
+			ExpirationDate:   "2025-10-28",
+			SupportedDevices: []string{"Mac14,2"},
+		}
+	}
+	versionsOf := func(assets []fleet.AppleSoftwareUpdateAsset) []string {
+		out := make([]string, len(assets))
+		for i, a := range assets {
+			out[i] = a.ProductVersion
+		}
+		sort.Strings(out)
+		return out
+	}
+	listed := func() map[string][]fleet.AppleSoftwareUpdateAsset {
+		got, err := ds.ListAppleOSUpdateAssets(ctx)
+		require.NoError(t, err)
+		return got
+	}
+
+	require.NoError(t, ds.UpsertAppleOSUpdates(ctx, map[string][]fleet.OSUpdateAsset{
+		"macos": {asset("15.1", "24B83"), asset("14.7.1", "23H222"), asset("13.7.1", "22H221")},
+		"ios":   {asset("18.1", "22B83"), asset("17.7.1", "21H221")},
+	}))
+
+	t.Run("List returns the upserted assets per class", func(t *testing.T) {
+		got := listed()
+		require.Equal(t, []string{"13.7.1", "14.7.1", "15.1"}, versionsOf(got["macos"]))
+		require.Equal(t, []string{"17.7.1", "18.1"}, versionsOf(got["ios"]))
+		require.Equal(t, "2024-10-28", got["macos"][0].PostingDate.Format(time.DateOnly))
+		require.Equal(t, "2025-10-28", got["macos"][0].ExpirationDate.Format(time.DateOnly))
+		require.Equal(t, fleet.JSONStringArray{"Mac14,2"}, got["macos"][0].SupportedDevices)
+		require.False(t, got["macos"][0].FirstSeenAt.IsZero())
+	})
+
+	t.Run("DeleteStale removes the assets missing from the new set", func(t *testing.T) {
+		// 13.7.1 expired out of the macOS set and 17.7.1 out of the iOS set
+		deleted, err := ds.DeleteStaleAppleOSUpdates(ctx, map[string][]fleet.OSUpdateAsset{
+			"macos": {asset("15.1", "24B83"), asset("14.7.1", "23H222")},
+			"ios":   {asset("18.1", "22B83")},
+		})
+		require.NoError(t, err)
+		require.EqualValues(t, 2, deleted)
+
+		got := listed()
+		require.Equal(t, []string{"14.7.1", "15.1"}, versionsOf(got["macos"]))
+		require.Equal(t, []string{"18.1"}, versionsOf(got["ios"]))
+	})
+
+	t.Run("DeleteStale matches on build so a rebuilt version is replaced", func(t *testing.T) {
+		require.NoError(t, ds.UpsertAppleOSUpdates(ctx, map[string][]fleet.OSUpdateAsset{
+			"macos": {asset("15.1", "24B2083")},
+		}))
+		require.Len(t, listed()["macos"], 3)
+
+		deleted, err := ds.DeleteStaleAppleOSUpdates(ctx, map[string][]fleet.OSUpdateAsset{
+			"macos": {asset("15.1", "24B2083"), asset("14.7.1", "23H222")},
+		})
+		require.NoError(t, err)
+		require.EqualValues(t, 1, deleted, "the 15.1 asset with the superseded build is deleted")
+
+		var builds []string
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			return sqlx.SelectContext(ctx, q, &builds,
+				`SELECT build FROM apple_software_update_assets WHERE class = 'macos' AND product_version = '15.1'`)
+		})
+		require.Equal(t, []string{"24B2083"}, builds)
+	})
+
+	t.Run("DeleteStale keeps the cached assets of a class with no reported assets", func(t *testing.T) {
+		deleted, err := ds.DeleteStaleAppleOSUpdates(ctx, map[string][]fleet.OSUpdateAsset{
+			"macos": {},
+			"ios":   nil,
+		})
+		require.NoError(t, err)
+		require.EqualValues(t, 0, deleted)
+
+		got := listed()
+		require.Len(t, got["macos"], 2)
+		require.Len(t, got["ios"], 1)
+	})
+
+	t.Run("DeleteStale leaves the classes missing from the set untouched", func(t *testing.T) {
+		deleted, err := ds.DeleteStaleAppleOSUpdates(ctx, map[string][]fleet.OSUpdateAsset{
+			"macos": {asset("15.1", "24B2083"), asset("14.7.1", "23H222")},
+		})
+		require.NoError(t, err)
+		require.EqualValues(t, 0, deleted)
+		require.Len(t, listed()["ios"], 1)
 	})
 }

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -14089,8 +14089,8 @@ func testAppleOSUpdatesReconcile(t *testing.T, ds *Datastore) {
 			LabelUpdatedAt:  time.Now(),
 			PolicyUpdatedAt: time.Now(),
 			SeenTime:        time.Now(),
-			OsqueryHostID:   ptr.String(hostUUID),
-			NodeKey:         ptr.String(hostUUID),
+			OsqueryHostID:   new(hostUUID),
+			NodeKey:         new(hostUUID),
 			UUID:            hostUUID,
 			Hostname:        hostUUID,
 			Platform:        platform,
@@ -14122,14 +14122,14 @@ func testAppleOSUpdatesReconcile(t *testing.T, ds *Datastore) {
 		require.NoError(t, err)
 		require.Equal(t, []string{hMacTeam.UUID}, uuidsOf(got))
 		require.Equal(t, "darwin", got[0].Platform)
-		require.EqualValues(t, team.ID, got[0].TeamID)
+		require.Equal(t, team.ID, got[0].TeamID)
 	})
 
 	t.Run("ListForReconcile matches no-team hosts via team_id 0", func(t *testing.T) {
 		got, err := ds.ListAppleOSUpdateHostsForReconcile(ctx, "", 100, latest(map[uint]int{0: 2}, nil, nil))
 		require.NoError(t, err)
 		require.Equal(t, []string{hMacNoTeam.UUID}, uuidsOf(got))
-		require.EqualValues(t, 0, got[0].TeamID)
+		require.Equal(t, 0, got[0].TeamID)
 	})
 
 	t.Run("ListForReconcile returns hosts with an existing target even without a latest team", func(t *testing.T) {

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -14129,7 +14129,7 @@ func testAppleOSUpdatesReconcile(t *testing.T, ds *Datastore) {
 		got, err := ds.ListAppleOSUpdateHostsForReconcile(ctx, "", 100, latest(map[uint]int{0: 2}, nil, nil))
 		require.NoError(t, err)
 		require.Equal(t, []string{hMacNoTeam.UUID}, uuidsOf(got))
-		require.Equal(t, 0, got[0].TeamID)
+		require.Equal(t, uint(0), got[0].TeamID)
 	})
 
 	t.Run("ListForReconcile returns hosts with an existing target even without a latest team", func(t *testing.T) {
@@ -14252,8 +14252,22 @@ func testAppleOSUpdateAssets(t *testing.T, ds *Datastore) {
 		require.Equal(t, []string{"17.7.1", "18.1"}, versionsOf(got["ios"]))
 		require.Equal(t, "2024-10-28", got["macos"][0].PostingDate.Format(time.DateOnly))
 		require.Equal(t, "2025-10-28", got["macos"][0].ExpirationDate.Format(time.DateOnly))
-		require.Equal(t, fleet.JSONStringArray{"Mac14,2"}, got["macos"][0].SupportedDevices)
+		require.Equal(t, fleet.SliceString{"Mac14,2"}, got["macos"][0].SupportedDevices)
 		require.False(t, got["macos"][0].FirstSeenAt.IsZero())
+
+		// upserting without any changes, still updates updated_at
+		prev := got
+		require.NoError(t, ds.UpsertAppleOSUpdates(ctx, map[string][]fleet.OSUpdateAsset{
+			"macos": {asset("15.1", "24B83"), asset("14.7.1", "23H222"), asset("13.7.1", "22H221")},
+			"ios":   {asset("18.1", "22B83"), asset("17.7.1", "21H221")},
+		}))
+		// check that updated_at was updated
+		got = listed()
+		for class, assets := range got {
+			for i, a := range assets {
+				require.True(t, a.UpdatedAt.After(prev[class][i].UpdatedAt), "updated_at should be updated on upsert even if no changes")
+			}
+		}
 	})
 
 	t.Run("DeleteStale removes the assets missing from the new set", func(t *testing.T) {

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -1818,3 +1818,53 @@ type ABReleaseDeviceAuthz struct {
 func (a ABReleaseDeviceAuthz) AuthzType() string {
 	return "mdm_ab_release"
 }
+
+// OSUpdateAsset represents the metadata for an asset in the Apple Software Lookup Service[1][2].
+// Example:
+//
+//	{
+//	    "ProductVersion": "14.6.1",
+//	    "Build": "23G93",
+//	    "PostingDate": "2024-08-07",
+//	    "ExpirationDate": "2024-11-11",
+//	    "SupportedDevices": [
+//	        "J132AP",
+//	        "VMA2MACOSAP",
+//	        "VMM-x86_64"
+//	    ]
+//	}
+//
+// [1]: http://gdmf.apple.com/v2/pmv
+// [2]:
+// https://support.apple.com/guide/deployment/use-mdm-to-deploy-software-updates-depafd2fad80/web
+type OSUpdateAsset struct {
+	ProductVersion   string   `json:"ProductVersion"`
+	Build            string   `json:"Build"`
+	PostingDate      string   `json:"PostingDate"`
+	ExpirationDate   string   `json:"ExpirationDate"`
+	SupportedDevices []string `json:"SupportedDevices"`
+}
+
+type AppleSoftwareUpdateAsset struct {
+	ProductVersion   string          `db:"product_version"`
+	Build            string          `db:"build"`
+	PostingDate      string          `db:"posting_date"`
+	ExpirationDate   string          `db:"expiration_date"`
+	SupportedDevices JSONStringArray `db:"supported_devices"`
+	FirstSeenAt      time.Time       `db:"first_seen_at"`
+}
+
+type AppleSoftwareUpdateHost struct {
+	HostUUID               string     `db:"host_uuid"`
+	SoftwareUpdateDeviceID string     `db:"software_update_device_id"`
+	TargetOSVersion        string     `db:"target_os_version"`
+	TargetDeadline         *time.Time `db:"target_deadline"`
+	ResolvedAt             *time.Time `db:"resolved_at"`
+	TeamID                 uint       `db:"team_id"`
+	Platform               string     `db:"platform"`
+}
+
+type ComputedAppleSoftwareUpdateHost struct {
+	AppleSoftwareUpdateHost
+	Resend bool
+}

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -1846,12 +1846,13 @@ type OSUpdateAsset struct {
 }
 
 type AppleSoftwareUpdateAsset struct {
-	ProductVersion   string          `db:"product_version"`
-	Build            string          `db:"build"`
-	PostingDate      time.Time       `db:"posting_date"`
-	ExpirationDate   time.Time       `db:"expiration_date"`
-	SupportedDevices JSONStringArray `db:"supported_devices"`
-	FirstSeenAt      time.Time       `db:"first_seen_at"`
+	ProductVersion   string      `db:"product_version"`
+	Build            string      `db:"build"`
+	PostingDate      time.Time   `db:"posting_date"`
+	ExpirationDate   time.Time   `db:"expiration_date"`
+	SupportedDevices SliceString `db:"supported_devices"`
+	FirstSeenAt      time.Time   `db:"first_seen_at"`
+	UpdatedAt        time.Time   `db:"updated_at"`
 }
 
 type AppleSoftwareUpdateHost struct {

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -1848,8 +1848,8 @@ type OSUpdateAsset struct {
 type AppleSoftwareUpdateAsset struct {
 	ProductVersion   string          `db:"product_version"`
 	Build            string          `db:"build"`
-	PostingDate      string          `db:"posting_date"`
-	ExpirationDate   string          `db:"expiration_date"`
+	PostingDate      time.Time       `db:"posting_date"`
+	ExpirationDate   time.Time       `db:"expiration_date"`
 	SupportedDevices JSONStringArray `db:"supported_devices"`
 	FirstSeenAt      time.Time       `db:"first_seen_at"`
 }

--- a/server/fleet/cron_schedules.go
+++ b/server/fleet/cron_schedules.go
@@ -72,6 +72,7 @@ const (
 	CronAppleMDMWorker                          CronScheduleName = "apple_mdm_worker"
 	CronChartDataCollection                     CronScheduleName = "chart_data_collection" // Used by chart bounded context
 	CronCleanupExpiredADUEChallenges            CronScheduleName = "cleanup_expired_adue_challenges"
+	CronAppleMDMOSUpdatesSchedule               CronScheduleName = "apple_mdm_os_updates"
 )
 
 type CronSchedulesService interface {

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -3851,7 +3851,7 @@ type Datastore interface {
 	InsertAppleSoftwareUpdateDeviceID(ctx context.Context, hostUUID string, updateDeviceID string) error
 	// GetLastAppleOSUpdatesUpdate retrieves the timestamp of the last Apple OS updates update in the datastore.
 	GetLastAppleOSUpdatesUpdate(ctx context.Context) (*time.Time, error)
-	// UpsertAppleOSUpdateAssets inserts or updates the given Apple OS update assets in the datastore. updates map is grouped by platform
+	// UpsertAppleOSUpdates inserts or updates the given Apple OS update assets in the datastore. updates map is grouped by platform
 	UpsertAppleOSUpdates(ctx context.Context, updates map[string][]OSUpdateAsset) error
 	// DeleteStaleAppleOSUpdates deletes the cached Apple OS update assets that are no longer
 	// reported by Apple. The updates map is grouped by platform and holds the assets Apple
@@ -3859,7 +3859,7 @@ type Datastore interface {
 	DeleteStaleAppleOSUpdates(ctx context.Context, updates map[string][]OSUpdateAsset) (int64, error)
 	// ListAppleOSUpdateAssets retrieves all Apple OS update assets from the datastore, grouped by platform.
 	ListAppleOSUpdateAssets(ctx context.Context) (map[string][]AppleSoftwareUpdateAsset, error)
-	//  ListAppleOSUpdateHostsForReconcile retrieves a batch of Apple software update hosts for OS update reconciliation
+	// ListAppleOSUpdateHostsForReconcile retrieves a batch of Apple software update hosts for OS update reconciliation
 	ListAppleOSUpdateHostsForReconcile(ctx context.Context, cursor string, batchSize int, teamsWithLatest map[string]map[uint]int) ([]*AppleSoftwareUpdateHost, error)
 	// SetAppleOSUpdateTargetsAndResend sets the targets for Apple OS updates and triggers a resend for needed hosts.
 	SetAppleOSUpdateTargetsAndResend(ctx context.Context, targets []*ComputedAppleSoftwareUpdateHost) error

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -3849,6 +3849,11 @@ type Datastore interface {
 
 	// InsertAppleSoftwareUpdateDeviceID inserts a new Apple software update device ID for the given host UUID for per-host os update tracking.
 	InsertAppleSoftwareUpdateDeviceID(ctx context.Context, hostUUID string, updateDeviceID string) error
+	GetLastAppleOSUpdatesUpdate(ctx context.Context) (*time.Time, error)
+	UpsertAppleOSUpdates(ctx context.Context, updates map[string][]OSUpdateAsset) error
+	ListAppleOSUpdateAssets(ctx context.Context) (map[string][]AppleSoftwareUpdateAsset, error)
+	ListAppleOSUpdateHostsForReconcile(ctx context.Context, cursor string, batchSize int, teamsWithLatest map[string]map[uint]uint) ([]*AppleSoftwareUpdateHost, error)
+	SetAppleOSUpdateTargetsAndResend(ctx context.Context, targets []*ComputedAppleSoftwareUpdateHost) error
 }
 
 type AndroidDatastore interface {

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -3849,11 +3849,18 @@ type Datastore interface {
 
 	// InsertAppleSoftwareUpdateDeviceID inserts a new Apple software update device ID for the given host UUID for per-host os update tracking.
 	InsertAppleSoftwareUpdateDeviceID(ctx context.Context, hostUUID string, updateDeviceID string) error
+	// GetLastAppleOSUpdatesUpdate retrieves the timestamp of the last Apple OS updates update in the datastore.
 	GetLastAppleOSUpdatesUpdate(ctx context.Context) (*time.Time, error)
+	// UpsertAppleOSUpdateAssets inserts or updates the given Apple OS update assets in the datastore. updates map is grouped by platform
 	UpsertAppleOSUpdates(ctx context.Context, updates map[string][]OSUpdateAsset) error
+	// ListAppleOSUpdateAssets retrieves all Apple OS update assets from the datastore, grouped by platform.
 	ListAppleOSUpdateAssets(ctx context.Context) (map[string][]AppleSoftwareUpdateAsset, error)
+	//  ListAppleOSUpdateHostsForReconcile retrieves a batch of Apple software update hosts for OS update reconciliation
 	ListAppleOSUpdateHostsForReconcile(ctx context.Context, cursor string, batchSize int, teamsWithLatest map[string]map[uint]uint) ([]*AppleSoftwareUpdateHost, error)
+	// SetAppleOSUpdateTargetsAndResend sets the targets for Apple OS updates and triggers a resend for needed hosts.
 	SetAppleOSUpdateTargetsAndResend(ctx context.Context, targets []*ComputedAppleSoftwareUpdateHost) error
+	// GetAppleOSUpdateHostByUUID retrieves stored Apple software update configuration for a given host by its UUID.
+	GetAppleOSUpdateHostByUUID(ctx context.Context, hostUUID string) (*AppleSoftwareUpdateHost, error)
 }
 
 type AndroidDatastore interface {

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -3853,10 +3853,14 @@ type Datastore interface {
 	GetLastAppleOSUpdatesUpdate(ctx context.Context) (*time.Time, error)
 	// UpsertAppleOSUpdateAssets inserts or updates the given Apple OS update assets in the datastore. updates map is grouped by platform
 	UpsertAppleOSUpdates(ctx context.Context, updates map[string][]OSUpdateAsset) error
+	// DeleteStaleAppleOSUpdates deletes the cached Apple OS update assets that are no longer
+	// reported by Apple. The updates map is grouped by platform and holds the assets Apple
+	// currently reports. No values for the platform or less than 1 entry for a platform does a no-op to avoid deleting on an incomplete view.
+	DeleteStaleAppleOSUpdates(ctx context.Context, updates map[string][]OSUpdateAsset) (int64, error)
 	// ListAppleOSUpdateAssets retrieves all Apple OS update assets from the datastore, grouped by platform.
 	ListAppleOSUpdateAssets(ctx context.Context) (map[string][]AppleSoftwareUpdateAsset, error)
 	//  ListAppleOSUpdateHostsForReconcile retrieves a batch of Apple software update hosts for OS update reconciliation
-	ListAppleOSUpdateHostsForReconcile(ctx context.Context, cursor string, batchSize int, teamsWithLatest map[string]map[uint]uint) ([]*AppleSoftwareUpdateHost, error)
+	ListAppleOSUpdateHostsForReconcile(ctx context.Context, cursor string, batchSize int, teamsWithLatest map[string]map[uint]int) ([]*AppleSoftwareUpdateHost, error)
 	// SetAppleOSUpdateTargetsAndResend sets the targets for Apple OS updates and triggers a resend for needed hosts.
 	SetAppleOSUpdateTargetsAndResend(ctx context.Context, targets []*ComputedAppleSoftwareUpdateHost) error
 	// GetAppleOSUpdateHostByUUID retrieves stored Apple software update configuration for a given host by its UUID.

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -1135,6 +1135,9 @@ type HostDetail struct {
 	MDMEnrollmentHardwareAttested bool `json:"mdm_enrollment_hardware_attested"`
 
 	ConditionalAccessBypassed bool `json:"conditional_access_bypassed"`
+
+	OSUpdateMinimumVersion *string `json:"os_update_minimum_version"`
+	OSUpdateDeadline       *string `json:"os_update_deadline"`
 }
 
 type HostEndUser struct {

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -286,16 +286,16 @@ type SliceString []string
 
 func (c *SliceString) Scan(v interface{}) error {
 	if tv, ok := v.([]byte); ok {
-		return json.Unmarshal(tv, &c)
+		return json.Unmarshal(tv, c)
 	}
 	return errors.New("unsupported type")
 }
 
-func (j SliceString) Value() (driver.Value, error) {
-	if j == nil {
+func (c SliceString) Value() (driver.Value, error) {
+	if c == nil {
 		return nil, nil
 	}
-	return json.Marshal(j)
+	return json.Marshal(c)
 }
 
 // SoftwareVersion is an abstraction over the `software` table to support the

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -2,6 +2,7 @@ package fleet
 
 import (
 	"crypto/md5" //nolint:gosec // This hash is used as a DB optimization for software row lookup, not security
+	"database/sql/driver"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -288,6 +289,13 @@ func (c *SliceString) Scan(v interface{}) error {
 		return json.Unmarshal(tv, &c)
 	}
 	return errors.New("unsupported type")
+}
+
+func (j SliceString) Value() (driver.Value, error) {
+	if j == nil {
+		return nil, nil
+	}
+	return json.Marshal(j)
 }
 
 // SoftwareVersion is an abstraction over the `software` table to support the

--- a/server/fleet/utils.go
+++ b/server/fleet/utils.go
@@ -1,10 +1,8 @@
 package fleet
 
 import (
-	"database/sql/driver"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"regexp"
 	"strings"
@@ -108,26 +106,4 @@ func VersionToSemverVersion(version string) (*semver.Version, error) {
 		return nil, err
 	}
 	return ver, nil
-}
-
-// JSONStringArray is a []string that scans from a JSON-encoded MySQL column.
-type JSONStringArray []string
-
-func (j *JSONStringArray) Scan(val any) error {
-	if val == nil {
-		*j = nil
-		return nil
-	}
-	b, ok := val.([]byte)
-	if !ok {
-		return fmt.Errorf("JSONStringArray.Scan: expected []byte, got %T", val)
-	}
-	return json.Unmarshal(b, j)
-}
-
-func (j JSONStringArray) Value() (driver.Value, error) {
-	if j == nil {
-		return nil, nil
-	}
-	return json.Marshal(j)
 }

--- a/server/fleet/utils.go
+++ b/server/fleet/utils.go
@@ -1,8 +1,10 @@
 package fleet
 
 import (
+	"database/sql/driver"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"regexp"
 	"strings"
@@ -106,4 +108,26 @@ func VersionToSemverVersion(version string) (*semver.Version, error) {
 		return nil, err
 	}
 	return ver, nil
+}
+
+// JSONStringArray is a []string that scans from a JSON-encoded MySQL column.
+type JSONStringArray []string
+
+func (j *JSONStringArray) Scan(val any) error {
+	if val == nil {
+		*j = nil
+		return nil
+	}
+	b, ok := val.([]byte)
+	if !ok {
+		return fmt.Errorf("JSONStringArray.Scan: expected []byte, got %T", val)
+	}
+	return json.Unmarshal(b, j)
+}
+
+func (j JSONStringArray) Value() (driver.Value, error) {
+	if j == nil {
+		return nil, nil
+	}
+	return json.Marshal(j)
 }

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -2686,7 +2686,7 @@ func computeOSUpdatesTarget(ctx context.Context, logger *slog.Logger, hosts []*f
 
 		host.TargetOSVersion = latestAsset.ProductVersion
 		host.TargetDeadline = &targetDeadline
-		host.ResolvedAt = new(time.Now())
+		host.ResolvedAt = new(time.Now().UTC())
 
 		computedHosts = append(computedHosts, &fleet.ComputedAppleSoftwareUpdateHost{
 			AppleSoftwareUpdateHost: *host,

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -2489,3 +2489,185 @@ func MDMPushCertTopic(ctx context.Context, ds fleet.MDMAssetRetriever) (string, 
 
 	return mdmPushCertTopic, nil
 }
+
+func HandleAppleMDMOSUpdates(ctx context.Context, ds fleet.Datastore, logger *slog.Logger) error {
+	lastUpdatedAt, err := ds.GetLastAppleOSUpdatesUpdate(ctx)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "get last apple os updates update")
+	}
+
+	if lastUpdatedAt == nil || time.Since(*lastUpdatedAt) > 24*time.Hour {
+		logger.InfoContext(ctx, "pulling fresh apple os updates from gdmf")
+
+		assetMetadata, err := gdmf.GetAssetMetadata()
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "getting asset metadata from GDMF")
+		}
+
+		err = ds.UpsertAppleOSUpdates(ctx, map[string][]fleet.OSUpdateAsset{
+			"macos": assetMetadata.AssetSets.MacOS,
+			"ios":   assetMetadata.AssetSets.IOS,
+		})
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "upserting apple os updates")
+		}
+	} else {
+		logger.InfoContext(ctx, "apple os updates are less than 24 hours old, not pulling new os updates", "last_updated_at", *lastUpdatedAt)
+	}
+
+	appCfg, err := ds.AppConfig(ctx)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "fetching app config")
+	}
+
+	// Get a list of all teams that has latest configured for macOS, iOS, or iPadOS.
+	// We use admin global role to have access to all teams.
+	teams, err := ds.ListTeams(ctx, fleet.TeamFilter{User: &fleet.User{
+		GlobalRole: new("admin"),
+	}}, fleet.ListOptions{})
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "listing teams")
+	}
+
+	// platform -> map of team_id -> deadline_days
+	teamsWithLatest := map[string]map[uint]uint{}
+	teamsWithLatest["darwin"] = map[uint]uint{}
+	teamsWithLatest["ios"] = map[uint]uint{}
+	teamsWithLatest["ipados"] = map[uint]uint{}
+
+	for _, team := range teams {
+		if team.Config.MDM.MacOSUpdates.MinimumVersion.Value == "latest" {
+			teamsWithLatest["darwin"][team.ID] = 2 // TODO: team.Config.MDM.MacOSUpdates.DeadlineDays
+		}
+		if team.Config.MDM.IOSUpdates.MinimumVersion.Value == "latest" {
+			teamsWithLatest["ios"][team.ID] = 2 // TODO: team.Config.MDM.IOSUpdates.DeadlineDays
+		}
+		if team.Config.MDM.IPadOSUpdates.MinimumVersion.Value == "latest" {
+			teamsWithLatest["ipados"][team.ID] = 2 // TODO: team.Config.MDM.IPadOSUpdates.DeadlineDays
+		}
+	}
+
+	// We will replace 0 with NULL check when looking up hosts to reconcile and checking the team_id column
+	if appCfg.MDM.MacOSUpdates.MinimumVersion.Value == "latest" {
+		teamsWithLatest["darwin"][0] = 2 // TODO: appCfg.MDM.MacOSUpdates.DeadlineDays
+	}
+	if appCfg.MDM.IOSUpdates.MinimumVersion.Value == "latest" {
+		teamsWithLatest["ios"][0] = 2 // TODO: appCfg.MDM.IOSUpdates.DeadlineDays
+	}
+	if appCfg.MDM.IPadOSUpdates.MinimumVersion.Value == "latest" {
+		teamsWithLatest["ipados"][0] = 2 // TODO: appCfg.MDM.IPadOSUpdates.DeadlineDays
+	}
+
+	updateAssets, err := ds.ListAppleOSUpdateAssets(ctx)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "listing apple os update assets")
+	}
+	const batchSize = 1000
+	var cursor string
+	for {
+		hostBatch, err := ds.ListAppleOSUpdateHostsForReconcile(ctx, cursor, batchSize, teamsWithLatest)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "listing apple os update hosts for reconcile")
+		}
+		if len(hostBatch) == 0 {
+			break
+		}
+		logger.InfoContext(ctx, "recomputing target os version and deadline for hosts", "cursor", cursor, "end_cursor", hostBatch[len(hostBatch)-1].HostUUID, "count", len(hostBatch))
+
+		targets := computeOSUpdatesTarget(ctx, logger, hostBatch, updateAssets, teamsWithLatest)
+		logger.InfoContext(ctx, "updating target os version and deadline for hosts", "count", len(targets))
+		if err := ds.SetAppleOSUpdateTargetsAndResend(ctx, targets); err != nil {
+			return ctxerr.Wrap(ctx, err, "setting apple os update targets and resending profiles")
+		}
+
+		cursor = hostBatch[len(hostBatch)-1].HostUUID
+	}
+
+	return nil
+}
+
+func computeOSUpdatesTarget(ctx context.Context, logger *slog.Logger, hosts []*fleet.AppleSoftwareUpdateHost, updateAssets map[string][]fleet.AppleSoftwareUpdateAsset, teamsWithLatest map[string]map[uint]uint) []*fleet.ComputedAppleSoftwareUpdateHost {
+	var computedHosts []*fleet.ComputedAppleSoftwareUpdateHost
+	for _, host := range hosts {
+
+		var updateAssetsPlatform string
+		if host.Platform == "darwin" {
+			updateAssetsPlatform = "macos"
+		} else {
+			updateAssetsPlatform = "ios" // covers iPhone, iPad, iPod
+		}
+
+		// teamsWithLatest is configured per platform, one for macos, ios, ipados.
+		teamsWithLatestForPlatform, ok := teamsWithLatest[host.Platform]
+		if !ok {
+			logger.DebugContext(ctx, "unsupported os update platform", "platform", host.Platform, "host_uuid", host.HostUUID)
+			continue
+		}
+
+		deadlineDays, ok := teamsWithLatestForPlatform[host.TeamID]
+		if !ok {
+			// Host no longer has a team with latest set. Clear the target version and deadline, do NOT mark for resend as the reconciler will handle complete removal of profile.
+			host.TargetOSVersion = ""
+			host.TargetDeadline = nil
+			host.ResolvedAt = nil
+			computedHosts = append(computedHosts, &fleet.ComputedAppleSoftwareUpdateHost{
+				AppleSoftwareUpdateHost: *host,
+				Resend:                  false,
+			})
+			continue
+		}
+
+		// Host has a team with latest set. Compute the target OS version and deadline.
+
+		// Look up latest OS version from updateAssets
+		assets, ok := updateAssets[updateAssetsPlatform]
+		if !ok || len(assets) == 0 {
+			logger.DebugContext(ctx, "no update assets found for platform", "platform", updateAssetsPlatform, "host_uuid", host.HostUUID)
+			continue
+		}
+
+		var latestAsset *fleet.AppleSoftwareUpdateAsset
+		for _, asset := range assets {
+			if !slices.Contains(asset.SupportedDevices, host.SoftwareUpdateDeviceID) {
+				continue
+			}
+
+			if latestAsset == nil {
+				latestAsset = &asset
+			} else {
+				// Current latest is less than this asset, so update latestAsset to this one
+				if less, _ := IsLessThanVersion(latestAsset.ProductVersion, asset.ProductVersion); less {
+					latestAsset = &asset
+				}
+			}
+		}
+
+		if latestAsset == nil {
+			logger.DebugContext(ctx, "no update asset found for host's device id", "host_uuid", host.HostUUID, "device_id", host.SoftwareUpdateDeviceID)
+			continue
+		}
+
+		startDate, _ := time.Parse(time.DateOnly, latestAsset.PostingDate)
+		if latestAsset.FirstSeenAt.After(startDate) {
+			startDate = latestAsset.FirstSeenAt
+		}
+		targetDeadline := startDate.Add(time.Duration(deadlineDays) * 24 * time.Hour)
+
+		if latestAsset.ProductVersion == host.TargetOSVersion && (host.TargetDeadline != nil && targetDeadline.Equal(*host.TargetDeadline)) {
+			logger.DebugContext(ctx, "host target version and deadline unchanged", "host_uuid", host.HostUUID, "target_version", host.TargetOSVersion, "target_deadline", host.TargetDeadline)
+			continue
+		}
+
+		logger.DebugContext(ctx, "host target version and/or deadline changed", "host_uuid", host.HostUUID, "old_target_version", host.TargetOSVersion, "new_target_version", latestAsset.ProductVersion, "old_target_deadline", host.TargetDeadline, "new_target_deadline", targetDeadline)
+
+		host.TargetOSVersion = latestAsset.ProductVersion
+		host.TargetDeadline = &targetDeadline
+		host.ResolvedAt = new(time.Now())
+
+		computedHosts = append(computedHosts, &fleet.ComputedAppleSoftwareUpdateHost{
+			AppleSoftwareUpdateHost: *host,
+			Resend:                  true,
+		})
+	}
+	return computedHosts
+}

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -2558,25 +2558,25 @@ computeOSTargets:
 	teamsWithLatest["ipados"] = map[uint]int{}
 
 	for _, team := range teams {
-		if team.Config.MDM.MacOSUpdates.MinimumVersion.Value == "latest" {
+		if team.Config.MDM.MacOSUpdates.MinimumVersion.Value == fleet.AppleOSUpdateLatestVersion {
 			teamsWithLatest["darwin"][team.ID] = team.Config.MDM.MacOSUpdates.DeadlineDays.Value
 		}
-		if team.Config.MDM.IOSUpdates.MinimumVersion.Value == "latest" {
+		if team.Config.MDM.IOSUpdates.MinimumVersion.Value == fleet.AppleOSUpdateLatestVersion {
 			teamsWithLatest["ios"][team.ID] = team.Config.MDM.IOSUpdates.DeadlineDays.Value
 		}
-		if team.Config.MDM.IPadOSUpdates.MinimumVersion.Value == "latest" {
+		if team.Config.MDM.IPadOSUpdates.MinimumVersion.Value == fleet.AppleOSUpdateLatestVersion {
 			teamsWithLatest["ipados"][team.ID] = team.Config.MDM.IPadOSUpdates.DeadlineDays.Value
 		}
 	}
 
 	// We will replace 0 with NULL check when looking up hosts to reconcile and checking the team_id column
-	if appCfg.MDM.MacOSUpdates.MinimumVersion.Value == "latest" {
+	if appCfg.MDM.MacOSUpdates.MinimumVersion.Value == fleet.AppleOSUpdateLatestVersion {
 		teamsWithLatest["darwin"][0] = appCfg.MDM.MacOSUpdates.DeadlineDays.Value
 	}
-	if appCfg.MDM.IOSUpdates.MinimumVersion.Value == "latest" {
+	if appCfg.MDM.IOSUpdates.MinimumVersion.Value == fleet.AppleOSUpdateLatestVersion {
 		teamsWithLatest["ios"][0] = appCfg.MDM.IOSUpdates.DeadlineDays.Value
 	}
-	if appCfg.MDM.IPadOSUpdates.MinimumVersion.Value == "latest" {
+	if appCfg.MDM.IPadOSUpdates.MinimumVersion.Value == fleet.AppleOSUpdateLatestVersion {
 		teamsWithLatest["ipados"][0] = appCfg.MDM.IPadOSUpdates.DeadlineDays.Value
 	}
 

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -2610,7 +2610,16 @@ computeOSTargets:
 
 func computeOSUpdatesTarget(ctx context.Context, logger *slog.Logger, hosts []*fleet.AppleSoftwareUpdateHost, updateAssets map[string][]fleet.AppleSoftwareUpdateAsset, teamsWithLatest map[string]map[uint]int) []*fleet.ComputedAppleSoftwareUpdateHost {
 	var computedHosts []*fleet.ComputedAppleSoftwareUpdateHost
+
+	// Deduping hosts to avoid gnarly bugs
+	seen := make(map[string]struct{}, len(hosts))
+	var duplicateHosts int
 	for _, host := range hosts {
+		if _, ok := seen[host.HostUUID]; ok {
+			duplicateHosts++
+			continue
+		}
+		seen[host.HostUUID] = struct{}{}
 
 		var updateAssetsPlatform string
 		if host.Platform == "darwin" {
@@ -2693,5 +2702,11 @@ func computeOSUpdatesTarget(ctx context.Context, logger *slog.Logger, hosts []*f
 			Resend:                  true,
 		})
 	}
+
+	if duplicateHosts > 0 {
+		logger.WarnContext(ctx, "os updates reconcile: skipped rows for host UUIDs already seen in this batch; likely duplicate host rows sharing a UUID",
+			"skipped", duplicateHosts)
+	}
+
 	return computedHosts
 }

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -2501,20 +2501,42 @@ func HandleAppleMDMOSUpdates(ctx context.Context, ds fleet.Datastore, logger *sl
 
 		assetMetadata, err := gdmf.GetAssetMetadata()
 		if err != nil {
-			return ctxerr.Wrap(ctx, err, "getting asset metadata from GDMF")
+			logger.ErrorContext(ctx, "error getting asset metadata from GDMF", "error", err)
+			goto computeOSTargets
 		}
 
-		err = ds.UpsertAppleOSUpdates(ctx, map[string][]fleet.OSUpdateAsset{
-			"macos": assetMetadata.AssetSets.MacOS,
-			"ios":   assetMetadata.AssetSets.IOS,
-		})
+		updates := map[string][]fleet.OSUpdateAsset{
+			"macos": assetMetadata.PublicAssetSets.MacOS,
+			"ios":   assetMetadata.PublicAssetSets.IOS,
+		}
+
+		err = ds.UpsertAppleOSUpdates(ctx, updates)
 		if err != nil {
-			return ctxerr.Wrap(ctx, err, "upserting apple os updates")
+			logger.ErrorContext(ctx, "error upserting apple os updates", "error", err)
+			goto computeOSTargets
+		}
+
+		// Apple stops reporting versions once they expire, so drop the cached assets that are no
+		// longer in the set we just fetched. This only runs when the fetch succeeded, otherwise we
+		// would delete assets based on an incomplete view of what Apple currently publishes.
+		for class, assets := range updates {
+			if len(assets) == 0 {
+				logger.WarnContext(ctx, "gdmf returned no os updates for class, keeping cached assets", "class", class)
+			}
+		}
+		deleted, err := ds.DeleteStaleAppleOSUpdates(ctx, updates)
+		if err != nil {
+			logger.ErrorContext(ctx, "error deleting stale apple os updates", "error", err)
+			goto computeOSTargets
+		}
+		if deleted > 0 {
+			logger.InfoContext(ctx, "deleted apple os updates no longer reported by gdmf", "count", deleted)
 		}
 	} else {
 		logger.InfoContext(ctx, "apple os updates are less than 24 hours old, not pulling new os updates", "last_updated_at", *lastUpdatedAt)
 	}
 
+computeOSTargets:
 	appCfg, err := ds.AppConfig(ctx)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "fetching app config")
@@ -2530,32 +2552,32 @@ func HandleAppleMDMOSUpdates(ctx context.Context, ds fleet.Datastore, logger *sl
 	}
 
 	// platform -> map of team_id -> deadline_days
-	teamsWithLatest := map[string]map[uint]uint{}
-	teamsWithLatest["darwin"] = map[uint]uint{}
-	teamsWithLatest["ios"] = map[uint]uint{}
-	teamsWithLatest["ipados"] = map[uint]uint{}
+	teamsWithLatest := map[string]map[uint]int{}
+	teamsWithLatest["darwin"] = map[uint]int{}
+	teamsWithLatest["ios"] = map[uint]int{}
+	teamsWithLatest["ipados"] = map[uint]int{}
 
 	for _, team := range teams {
 		if team.Config.MDM.MacOSUpdates.MinimumVersion.Value == "latest" {
-			teamsWithLatest["darwin"][team.ID] = 2 // TODO: team.Config.MDM.MacOSUpdates.DeadlineDays
+			teamsWithLatest["darwin"][team.ID] = team.Config.MDM.MacOSUpdates.DeadlineDays.Value
 		}
 		if team.Config.MDM.IOSUpdates.MinimumVersion.Value == "latest" {
-			teamsWithLatest["ios"][team.ID] = 2 // TODO: team.Config.MDM.IOSUpdates.DeadlineDays
+			teamsWithLatest["ios"][team.ID] = team.Config.MDM.IOSUpdates.DeadlineDays.Value
 		}
 		if team.Config.MDM.IPadOSUpdates.MinimumVersion.Value == "latest" {
-			teamsWithLatest["ipados"][team.ID] = 2 // TODO: team.Config.MDM.IPadOSUpdates.DeadlineDays
+			teamsWithLatest["ipados"][team.ID] = team.Config.MDM.IPadOSUpdates.DeadlineDays.Value
 		}
 	}
 
 	// We will replace 0 with NULL check when looking up hosts to reconcile and checking the team_id column
 	if appCfg.MDM.MacOSUpdates.MinimumVersion.Value == "latest" {
-		teamsWithLatest["darwin"][0] = 2 // TODO: appCfg.MDM.MacOSUpdates.DeadlineDays
+		teamsWithLatest["darwin"][0] = appCfg.MDM.MacOSUpdates.DeadlineDays.Value
 	}
 	if appCfg.MDM.IOSUpdates.MinimumVersion.Value == "latest" {
-		teamsWithLatest["ios"][0] = 2 // TODO: appCfg.MDM.IOSUpdates.DeadlineDays
+		teamsWithLatest["ios"][0] = appCfg.MDM.IOSUpdates.DeadlineDays.Value
 	}
 	if appCfg.MDM.IPadOSUpdates.MinimumVersion.Value == "latest" {
-		teamsWithLatest["ipados"][0] = 2 // TODO: appCfg.MDM.IPadOSUpdates.DeadlineDays
+		teamsWithLatest["ipados"][0] = appCfg.MDM.IPadOSUpdates.DeadlineDays.Value
 	}
 
 	updateAssets, err := ds.ListAppleOSUpdateAssets(ctx)
@@ -2586,7 +2608,7 @@ func HandleAppleMDMOSUpdates(ctx context.Context, ds fleet.Datastore, logger *sl
 	return nil
 }
 
-func computeOSUpdatesTarget(ctx context.Context, logger *slog.Logger, hosts []*fleet.AppleSoftwareUpdateHost, updateAssets map[string][]fleet.AppleSoftwareUpdateAsset, teamsWithLatest map[string]map[uint]uint) []*fleet.ComputedAppleSoftwareUpdateHost {
+func computeOSUpdatesTarget(ctx context.Context, logger *slog.Logger, hosts []*fleet.AppleSoftwareUpdateHost, updateAssets map[string][]fleet.AppleSoftwareUpdateAsset, teamsWithLatest map[string]map[uint]int) []*fleet.ComputedAppleSoftwareUpdateHost {
 	var computedHosts []*fleet.ComputedAppleSoftwareUpdateHost
 	for _, host := range hosts {
 
@@ -2627,19 +2649,21 @@ func computeOSUpdatesTarget(ctx context.Context, logger *slog.Logger, hosts []*f
 		}
 
 		var latestAsset *fleet.AppleSoftwareUpdateAsset
-		for _, asset := range assets {
+		for i := range assets {
+			asset := &assets[i]
 			if !slices.Contains(asset.SupportedDevices, host.SoftwareUpdateDeviceID) {
 				continue
 			}
 
 			if latestAsset == nil {
-				latestAsset = &asset
-			} else {
-				// Current latest is less than this asset, so update latestAsset to this one
-				if less, _ := IsLessThanVersion(latestAsset.ProductVersion, asset.ProductVersion); less {
-					latestAsset = &asset
-				}
+				latestAsset = asset
+				continue
 			}
+			// Current latest is less than this asset, so update latestAsset to this one
+			if less, _ := IsLessThanVersion(latestAsset.ProductVersion, asset.ProductVersion); less {
+				latestAsset = asset
+			}
+
 		}
 
 		if latestAsset == nil {
@@ -2647,7 +2671,7 @@ func computeOSUpdatesTarget(ctx context.Context, logger *slog.Logger, hosts []*f
 			continue
 		}
 
-		startDate, _ := time.Parse(time.DateOnly, latestAsset.PostingDate)
+		startDate := latestAsset.PostingDate
 		if latestAsset.FirstSeenAt.After(startDate) {
 			startDate = latestAsset.FirstSeenAt
 		}

--- a/server/mdm/apple/gdmf/api.go
+++ b/server/mdm/apple/gdmf/api.go
@@ -87,24 +87,19 @@ func (a AssetMetadata) IsSupportedIOSVersion(version string, devicePrefix string
 }
 
 // GetLatestOSVersion returns the latest OS version for the given device. The device is matched
-// against the Apple Software Update Lookup Service[1][2] to find the latest version in the
-// PublicAssetSets. If no matching asset is found, an error is returned.
+// against the Apple Software Update Lookup Service[1][2] that is locally cached in the apple_software_update_assets table to find the latest version in the
+// updateAssets. If no matching asset is found, an error is returned.
 // [1]: http://gdmf.apple.com/v2/pmv
 // [2]: https://support.apple.com/guide/deployment/use-mdm-to-deploy-software-updates-depafd2fad80/web
-func GetLatestOSVersion(device fleet.MDMAppleMachineInfo) (*fleet.OSUpdateAsset, error) {
-	am, err := GetAssetMetadata()
-	if err != nil {
-		return nil, fmt.Errorf("retrieving asset metadata: %w", err)
-	}
-
-	assetSet := am.PublicAssetSets.MacOS // default to public asset set; note that if the device is not macOS, iPhone, iPad, or iPod we'll fail to match the supported device and return an error below
+func GetLatestOSVersion(device fleet.MDMAppleMachineInfo, updateAssets map[string][]fleet.AppleSoftwareUpdateAsset) (*fleet.AppleSoftwareUpdateAsset, error) {
+	assetSet := updateAssets["macos"] // default to public asset set; note that if the device is not macOS, iPhone, iPad, or iPod we'll fail to match the supported device and return an error below
 	if strings.HasPrefix(device.Product, "iPhone") ||
 		strings.HasPrefix(device.Product, "iPod") ||
 		strings.HasPrefix(device.Product, "iPad") ||
 		strings.HasPrefix(device.SoftwareUpdateDeviceID, "iPhone") ||
 		strings.HasPrefix(device.SoftwareUpdateDeviceID, "iPod") ||
 		strings.HasPrefix(device.SoftwareUpdateDeviceID, "iPad") {
-		assetSet = am.PublicAssetSets.IOS
+		assetSet = updateAssets["ios"]
 	}
 	latestIdx := -1
 	for i, s := range assetSet {

--- a/server/mdm/apple/gdmf/api.go
+++ b/server/mdm/apple/gdmf/api.go
@@ -22,38 +22,12 @@ import (
 
 const baseURL = "https://gdmf.apple.com/v2/pmv"
 
-// Asset represents the metadata for an asset in the Apple Software Lookup Service[1][2].
-// Example:
-//
-//	{
-//	    "ProductVersion": "14.6.1",
-//	    "Build": "23G93",
-//	    "PostingDate": "2024-08-07",
-//	    "ExpirationDate": "2024-11-11",
-//	    "SupportedDevices": [
-//	        "J132AP",
-//	        "VMA2MACOSAP",
-//	        "VMM-x86_64"
-//	    ]
-//	}
-//
-// [1]: http://gdmf.apple.com/v2/pmv
-// [2]:
-// https://support.apple.com/guide/deployment/use-mdm-to-deploy-software-updates-depafd2fad80/web
-type Asset struct {
-	ProductVersion   string   `json:"ProductVersion"`
-	Build            string   `json:"Build"`
-	PostingDate      string   `json:"PostingDate"`
-	ExpirationDate   string   `json:"ExpirationDate"`
-	SupportedDevices []string `json:"SupportedDevices"`
-}
-
 // AssetSets represents the metadata for a set of assets in the Apple Software Lookup Service[1][2].
 // [1]: http://gdmf.apple.com/v2/pmv
 // [2]: https://support.apple.com/guide/deployment/use-mdm-to-deploy-software-updates-depafd2fad80/web
 type AssetSets struct {
-	IOS   []Asset `json:"iOS"`
-	MacOS []Asset `json:"macOS"`
+	IOS   []fleet.OSUpdateAsset `json:"iOS"`
+	MacOS []fleet.OSUpdateAsset `json:"macOS"`
 	// VisionOS []Asset `json:"visionOS"` // Fleet doesn't support visionOS yet
 	// XROS     []Asset `json:"xrOS"`    // Fleet doesn't support xrOS yet
 }
@@ -117,7 +91,7 @@ func (a AssetMetadata) IsSupportedIOSVersion(version string, devicePrefix string
 // PublicAssetSets. If no matching asset is found, an error is returned.
 // [1]: http://gdmf.apple.com/v2/pmv
 // [2]: https://support.apple.com/guide/deployment/use-mdm-to-deploy-software-updates-depafd2fad80/web
-func GetLatestOSVersion(device fleet.MDMAppleMachineInfo) (*Asset, error) {
+func GetLatestOSVersion(device fleet.MDMAppleMachineInfo) (*fleet.OSUpdateAsset, error) {
 	am, err := GetAssetMetadata()
 	if err != nil {
 		return nil, fmt.Errorf("retrieving asset metadata: %w", err)

--- a/server/mdm/apple/gdmf/api_test.go
+++ b/server/mdm/apple/gdmf/api_test.go
@@ -1,10 +1,12 @@
 package gdmf
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/fleetdm/fleet/v4/server/dev_mode"
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -12,20 +14,49 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetLatest(t *testing.T) {
-	// test GetLatestOSVersion using a mock server that returns a known response
-	// and ensure the response is parsed correctly
+// testUpdateAssets loads the GDMF fixture and converts it to the platform-keyed map of cached
+// assets that GetLatestOSVersion takes. In production the same shape is produced by the OS updates
+// cron: it fetches the public asset sets from GDMF, upserts them into
+// apple_software_update_assets, and reads them back with Datastore.ListAppleOSUpdateAssets.
+func testUpdateAssets(t *testing.T) map[string][]fleet.AppleSoftwareUpdateAsset {
+	t.Helper()
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		// load the test data from the file
-		b, err := os.ReadFile("./testdata/gdmf.json")
-		require.NoError(t, err)
-		_, err = w.Write(b)
-		require.NoError(t, err)
-	}))
-	t.Cleanup(srv.Close)
-	dev_mode.SetOverride("FLEET_DEV_GDMF_URL", srv.URL, t)
+	b, err := os.ReadFile("./testdata/gdmf.json")
+	require.NoError(t, err)
+
+	var am AssetMetadata
+	require.NoError(t, json.Unmarshal(b, &am))
+
+	convert := func(assets []fleet.OSUpdateAsset) []fleet.AppleSoftwareUpdateAsset {
+		out := make([]fleet.AppleSoftwareUpdateAsset, 0, len(assets))
+		for _, a := range assets {
+			// the dates are stored in DATE columns, so they come back as time.Time
+			postingDate, err := time.Parse(time.DateOnly, a.PostingDate)
+			require.NoError(t, err)
+			expirationDate, err := time.Parse(time.DateOnly, a.ExpirationDate)
+			require.NoError(t, err)
+			out = append(out, fleet.AppleSoftwareUpdateAsset{
+				ProductVersion:   a.ProductVersion,
+				Build:            a.Build,
+				PostingDate:      postingDate,
+				ExpirationDate:   expirationDate,
+				SupportedDevices: a.SupportedDevices,
+			})
+		}
+		return out
+	}
+
+	return map[string][]fleet.AppleSoftwareUpdateAsset{
+		"macos": convert(am.PublicAssetSets.MacOS),
+		"ios":   convert(am.PublicAssetSets.IOS),
+	}
+}
+
+func TestGetLatest(t *testing.T) {
+	// test GetLatestOSVersion against a known set of cached assets and ensure the latest matching
+	// asset is returned for each device
+
+	updateAssets := testUpdateAssets(t)
 
 	// test the function
 	d := fleet.MDMAppleMachineInfo{
@@ -44,7 +75,7 @@ func TestGetLatest(t *testing.T) {
 	latestIOSVersion := "17.6.1"
 	latestIOSBuild := "21G93"
 
-	resp, err := GetLatestOSVersion(d)
+	resp, err := GetLatestOSVersion(d, updateAssets)
 	require.NoError(t, err)
 	require.Equal(t, latestMacOSVersion, resp.ProductVersion)
 	require.Equal(t, latestMacOSBuild, resp.Build)
@@ -53,8 +84,10 @@ func TestGetLatest(t *testing.T) {
 	// expected that the caller has already verified this value before calling GetLatestOSVersion.
 
 	tests := []struct {
-		name            string
-		machineInfo     fleet.MDMAppleMachineInfo
+		name        string
+		machineInfo fleet.MDMAppleMachineInfo
+		// updateAssets defaults to the assets loaded from the fixture when nil
+		updateAssets    map[string][]fleet.AppleSoftwareUpdateAsset
 		expectedVersion string
 		expectedBuild   string
 		expectError     bool
@@ -201,11 +234,38 @@ func TestGetLatest(t *testing.T) {
 			expectedBuild:   "",
 			expectError:     true,
 		},
+		{
+			// the cached assets are empty until the OS updates cron has run at least once
+			name: "no cached assets",
+			machineInfo: fleet.MDMAppleMachineInfo{
+				OSVersion:              "14.4.1",
+				Product:                "Mac15,7",
+				SoftwareUpdateDeviceID: "J516sAP",
+			},
+			updateAssets: map[string][]fleet.AppleSoftwareUpdateAsset{},
+			expectError:  true,
+		},
+		{
+			// only the asset set for the device's platform matters, so a macOS device errors when
+			// only iOS assets are cached
+			name: "cached assets for the other platform only",
+			machineInfo: fleet.MDMAppleMachineInfo{
+				OSVersion:              "14.4.1",
+				Product:                "Mac15,7",
+				SoftwareUpdateDeviceID: "J516sAP",
+			},
+			updateAssets: map[string][]fleet.AppleSoftwareUpdateAsset{"ios": updateAssets["ios"]},
+			expectError:  true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resp, err := GetLatestOSVersion(tt.machineInfo)
+			assets := tt.updateAssets
+			if assets == nil {
+				assets = updateAssets
+			}
+			resp, err := GetLatestOSVersion(tt.machineInfo, assets)
 			if tt.expectError {
 				require.Error(t, err)
 			} else {
@@ -215,6 +275,32 @@ func TestGetLatest(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetAssetMetadata(t *testing.T) {
+	// test GetAssetMetadata using a mock server that returns a known response and ensure the
+	// response is parsed correctly; this is the fetch the OS updates cron performs before caching
+	// the assets in the datastore
+
+	// load the test data from the file
+	b, err := os.ReadFile("./testdata/gdmf.json")
+	require.NoError(t, err)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write(b); err != nil {
+			t.Errorf("writing response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	dev_mode.SetOverride("FLEET_DEV_GDMF_URL", srv.URL, t)
+
+	am, err := GetAssetMetadata()
+	require.NoError(t, err)
+	require.NotEmpty(t, am.PublicAssetSets.MacOS)
+	require.NotEmpty(t, am.PublicAssetSets.IOS)
+	require.True(t, am.IsSupportedMacOSVersion("14.6.1", true))
+	require.True(t, am.IsSupportedIOSVersion("17.6.1", "iPhone", true))
 }
 
 func TestRetries(t *testing.T) {
@@ -228,18 +314,10 @@ func TestRetries(t *testing.T) {
 	t.Cleanup(srv.Close)
 	dev_mode.SetOverride("FLEET_DEV_GDMF_URL", srv.URL, t)
 
-	latest, err := GetLatestOSVersion(fleet.MDMAppleMachineInfo{
-		OSVersion:                "14.4.1",
-		Product:                  "Mac15,7",
-		Serial:                   "TESTSERIAL",
-		SoftwareUpdateDeviceID:   "J516sAP",
-		SupplementalBuildVersion: "23E224",
-		UDID:                     uuid.New().String(),
-		Version:                  "23E224",
-	})
+	am, err := GetAssetMetadata()
 
 	require.Error(t, err)
 	require.ErrorContains(t, err, "calling gdmf endpoint failed with status 400")
-	require.Nil(t, latest)
+	require.Nil(t, am)
 	require.Equal(t, 4, retryCount)
 }

--- a/server/mdm/apple/os_updates_reconcile_test.go
+++ b/server/mdm/apple/os_updates_reconcile_test.go
@@ -1,0 +1,124 @@
+package apple_mdm
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/stretchr/testify/require"
+)
+
+// TestComputeOSUpdatesTarget covers the in-memory decision logic that maps each
+// host to its target OS version / deadline / resend flag. It exercises the
+// branches independently of the datastore and GDMF: platform gate, removal when
+// a host's team no longer has "latest", version selection, deadline derivation,
+// and the unchanged-target short circuit.
+func TestComputeOSUpdatesTarget(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	ctx := t.Context()
+
+	const (
+		macDevice = "Mac14,2"
+		iosDevice = "iPhone15,2"
+	)
+
+	// Two macOS assets for the same device, higher version listed first so the
+	// test proves the reconciler picks the max version, not the last one seen.
+	updateAssets := map[string][]fleet.AppleSoftwareUpdateAsset{
+		"macos": {
+			{ProductVersion: "15.1", PostingDate: "2024-10-28", SupportedDevices: []string{macDevice}},
+			{ProductVersion: "14.6.1", PostingDate: "2024-08-07", SupportedDevices: []string{macDevice}},
+		},
+		"ios": {
+			{ProductVersion: "18.1", PostingDate: "2024-10-28", SupportedDevices: []string{iosDevice}},
+		},
+	}
+
+	// deadline = posting date + deadlineDays. Posting dates parse as midnight UTC.
+	macDeadline := time.Date(2024, 10, 30, 0, 0, 0, 0, time.UTC) // 2024-10-28 + 2d
+	iosDeadline := time.Date(2024, 10, 30, 0, 0, 0, 0, time.UTC) // 2024-10-28 + 2d
+
+	// teamsWithLatest is keyed by the three supported platforms; nil inner maps
+	// mean "no team on that platform has latest configured".
+	latest := func(darwin, ios, ipados map[uint]uint) map[string]map[uint]uint {
+		return map[string]map[uint]uint{"darwin": darwin, "ios": ios, "ipados": ipados}
+	}
+	compute := func(host *fleet.AppleSoftwareUpdateHost, teams map[string]map[uint]uint) []*fleet.ComputedAppleSoftwareUpdateHost {
+		return computeOSUpdatesTarget(ctx, logger, []*fleet.AppleSoftwareUpdateHost{host}, updateAssets, teams)
+	}
+
+	t.Run("macOS host in a team with latest gets highest version and posting-date deadline", func(t *testing.T) {
+		host := &fleet.AppleSoftwareUpdateHost{HostUUID: "h1", Platform: "darwin", TeamID: 0, SoftwareUpdateDeviceID: macDevice}
+		got := compute(host, latest(map[uint]uint{0: 2}, nil, nil))
+		require.Len(t, got, 1)
+		require.True(t, got[0].Resend)
+		require.Equal(t, "15.1", got[0].TargetOSVersion)
+		require.NotNil(t, got[0].TargetDeadline)
+		require.True(t, macDeadline.Equal(*got[0].TargetDeadline), "want %s got %s", macDeadline, got[0].TargetDeadline)
+		require.NotNil(t, got[0].ResolvedAt)
+	})
+
+	t.Run("iPadOS host resolves against the shared ios asset set", func(t *testing.T) {
+		host := &fleet.AppleSoftwareUpdateHost{HostUUID: "h2", Platform: "ipados", TeamID: 3, SoftwareUpdateDeviceID: iosDevice}
+		got := compute(host, latest(nil, nil, map[uint]uint{3: 2}))
+		require.Len(t, got, 1)
+		require.True(t, got[0].Resend)
+		require.Equal(t, "18.1", got[0].TargetOSVersion)
+		require.True(t, iosDeadline.Equal(*got[0].TargetDeadline))
+	})
+
+	t.Run("first_seen_at after posting date drives the deadline", func(t *testing.T) {
+		firstSeen := time.Date(2024, 11, 5, 12, 0, 0, 0, time.UTC)
+		assets := map[string][]fleet.AppleSoftwareUpdateAsset{
+			"macos": {{ProductVersion: "15.1", PostingDate: "2024-10-28", FirstSeenAt: firstSeen, SupportedDevices: []string{macDevice}}},
+		}
+		host := &fleet.AppleSoftwareUpdateHost{HostUUID: "h3", Platform: "darwin", TeamID: 0, SoftwareUpdateDeviceID: macDevice}
+		got := computeOSUpdatesTarget(ctx, logger, []*fleet.AppleSoftwareUpdateHost{host}, assets, latest(map[uint]uint{0: 2}, nil, nil))
+		require.Len(t, got, 1)
+		require.True(t, firstSeen.Add(2*24*time.Hour).Equal(*got[0].TargetDeadline))
+	})
+
+	t.Run("host whose team no longer has latest is cleared without resend", func(t *testing.T) {
+		deadline := macDeadline
+		host := &fleet.AppleSoftwareUpdateHost{
+			HostUUID: "h4", Platform: "darwin", TeamID: 5, SoftwareUpdateDeviceID: macDevice,
+			TargetOSVersion: "15.1", TargetDeadline: &deadline, ResolvedAt: &deadline,
+		}
+		// team 5 is not present in the darwin latest set.
+		got := compute(host, latest(map[uint]uint{0: 2}, nil, nil))
+		require.Len(t, got, 1)
+		require.False(t, got[0].Resend)
+		require.Empty(t, got[0].TargetOSVersion)
+		require.Nil(t, got[0].TargetDeadline)
+		require.Nil(t, got[0].ResolvedAt)
+	})
+
+	t.Run("unchanged target and deadline are skipped", func(t *testing.T) {
+		deadline := macDeadline
+		host := &fleet.AppleSoftwareUpdateHost{
+			HostUUID: "h5", Platform: "darwin", TeamID: 0, SoftwareUpdateDeviceID: macDevice,
+			TargetOSVersion: "15.1", TargetDeadline: &deadline,
+		}
+		got := compute(host, latest(map[uint]uint{0: 2}, nil, nil))
+		require.Empty(t, got)
+	})
+
+	t.Run("unsupported platform is skipped", func(t *testing.T) {
+		host := &fleet.AppleSoftwareUpdateHost{HostUUID: "h6", Platform: "tvos", TeamID: 0, SoftwareUpdateDeviceID: macDevice}
+		got := compute(host, latest(map[uint]uint{0: 2}, nil, nil))
+		require.Empty(t, got)
+	})
+
+	t.Run("no asset matches the host device id is skipped", func(t *testing.T) {
+		host := &fleet.AppleSoftwareUpdateHost{HostUUID: "h7", Platform: "darwin", TeamID: 0, SoftwareUpdateDeviceID: "Mac99,9"}
+		got := compute(host, latest(map[uint]uint{0: 2}, nil, nil))
+		require.Empty(t, got)
+	})
+
+	t.Run("no assets for the platform is skipped", func(t *testing.T) {
+		host := &fleet.AppleSoftwareUpdateHost{HostUUID: "h8", Platform: "darwin", TeamID: 0, SoftwareUpdateDeviceID: macDevice}
+		got := computeOSUpdatesTarget(ctx, logger, []*fleet.AppleSoftwareUpdateHost{host}, map[string][]fleet.AppleSoftwareUpdateAsset{}, latest(map[uint]uint{0: 2}, nil, nil))
+		require.Empty(t, got)
+	})
+}

--- a/server/mdm/apple/os_updates_reconcile_test.go
+++ b/server/mdm/apple/os_updates_reconcile_test.go
@@ -1,11 +1,18 @@
 package apple_mdm
 
 import (
+	"context"
+	"errors"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
+	"github.com/fleetdm/fleet/v4/server/dev_mode"
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,15 +30,23 @@ func TestComputeOSUpdatesTarget(t *testing.T) {
 		iosDevice = "iPhone15,2"
 	)
 
+	mustParseDate := func(s string) time.Time {
+		d, err := time.Parse("2006-01-02", s)
+		if err != nil {
+			t.Fatalf("failed to parse date %q: %v", s, err)
+		}
+		return d
+	}
+
 	// Two macOS assets for the same device, higher version listed first so the
 	// test proves the reconciler picks the max version, not the last one seen.
 	updateAssets := map[string][]fleet.AppleSoftwareUpdateAsset{
 		"macos": {
-			{ProductVersion: "15.1", PostingDate: "2024-10-28", SupportedDevices: []string{macDevice}},
-			{ProductVersion: "14.6.1", PostingDate: "2024-08-07", SupportedDevices: []string{macDevice}},
+			{ProductVersion: "15.1", PostingDate: mustParseDate("2024-10-28"), SupportedDevices: []string{macDevice}},
+			{ProductVersion: "14.6.1", PostingDate: mustParseDate("2024-08-07"), SupportedDevices: []string{macDevice}},
 		},
 		"ios": {
-			{ProductVersion: "18.1", PostingDate: "2024-10-28", SupportedDevices: []string{iosDevice}},
+			{ProductVersion: "18.1", PostingDate: mustParseDate("2024-10-28"), SupportedDevices: []string{iosDevice}},
 		},
 	}
 
@@ -41,16 +56,16 @@ func TestComputeOSUpdatesTarget(t *testing.T) {
 
 	// teamsWithLatest is keyed by the three supported platforms; nil inner maps
 	// mean "no team on that platform has latest configured".
-	latest := func(darwin, ios, ipados map[uint]uint) map[string]map[uint]uint {
-		return map[string]map[uint]uint{"darwin": darwin, "ios": ios, "ipados": ipados}
+	latest := func(darwin, ios, ipados map[uint]int) map[string]map[uint]int {
+		return map[string]map[uint]int{"darwin": darwin, "ios": ios, "ipados": ipados}
 	}
-	compute := func(host *fleet.AppleSoftwareUpdateHost, teams map[string]map[uint]uint) []*fleet.ComputedAppleSoftwareUpdateHost {
+	compute := func(host *fleet.AppleSoftwareUpdateHost, teams map[string]map[uint]int) []*fleet.ComputedAppleSoftwareUpdateHost {
 		return computeOSUpdatesTarget(ctx, logger, []*fleet.AppleSoftwareUpdateHost{host}, updateAssets, teams)
 	}
 
 	t.Run("macOS host in a team with latest gets highest version and posting-date deadline", func(t *testing.T) {
 		host := &fleet.AppleSoftwareUpdateHost{HostUUID: "h1", Platform: "darwin", TeamID: 0, SoftwareUpdateDeviceID: macDevice}
-		got := compute(host, latest(map[uint]uint{0: 2}, nil, nil))
+		got := compute(host, latest(map[uint]int{0: 2}, nil, nil))
 		require.Len(t, got, 1)
 		require.True(t, got[0].Resend)
 		require.Equal(t, "15.1", got[0].TargetOSVersion)
@@ -61,7 +76,7 @@ func TestComputeOSUpdatesTarget(t *testing.T) {
 
 	t.Run("iPadOS host resolves against the shared ios asset set", func(t *testing.T) {
 		host := &fleet.AppleSoftwareUpdateHost{HostUUID: "h2", Platform: "ipados", TeamID: 3, SoftwareUpdateDeviceID: iosDevice}
-		got := compute(host, latest(nil, nil, map[uint]uint{3: 2}))
+		got := compute(host, latest(nil, nil, map[uint]int{3: 2}))
 		require.Len(t, got, 1)
 		require.True(t, got[0].Resend)
 		require.Equal(t, "18.1", got[0].TargetOSVersion)
@@ -71,10 +86,10 @@ func TestComputeOSUpdatesTarget(t *testing.T) {
 	t.Run("first_seen_at after posting date drives the deadline", func(t *testing.T) {
 		firstSeen := time.Date(2024, 11, 5, 12, 0, 0, 0, time.UTC)
 		assets := map[string][]fleet.AppleSoftwareUpdateAsset{
-			"macos": {{ProductVersion: "15.1", PostingDate: "2024-10-28", FirstSeenAt: firstSeen, SupportedDevices: []string{macDevice}}},
+			"macos": {{ProductVersion: "15.1", PostingDate: mustParseDate("2024-10-28"), FirstSeenAt: firstSeen, SupportedDevices: []string{macDevice}}},
 		}
 		host := &fleet.AppleSoftwareUpdateHost{HostUUID: "h3", Platform: "darwin", TeamID: 0, SoftwareUpdateDeviceID: macDevice}
-		got := computeOSUpdatesTarget(ctx, logger, []*fleet.AppleSoftwareUpdateHost{host}, assets, latest(map[uint]uint{0: 2}, nil, nil))
+		got := computeOSUpdatesTarget(ctx, logger, []*fleet.AppleSoftwareUpdateHost{host}, assets, latest(map[uint]int{0: 2}, nil, nil))
 		require.Len(t, got, 1)
 		require.True(t, firstSeen.Add(2*24*time.Hour).Equal(*got[0].TargetDeadline))
 	})
@@ -86,7 +101,7 @@ func TestComputeOSUpdatesTarget(t *testing.T) {
 			TargetOSVersion: "15.1", TargetDeadline: &deadline, ResolvedAt: &deadline,
 		}
 		// team 5 is not present in the darwin latest set.
-		got := compute(host, latest(map[uint]uint{0: 2}, nil, nil))
+		got := compute(host, latest(map[uint]int{0: 2}, nil, nil))
 		require.Len(t, got, 1)
 		require.False(t, got[0].Resend)
 		require.Empty(t, got[0].TargetOSVersion)
@@ -100,25 +115,147 @@ func TestComputeOSUpdatesTarget(t *testing.T) {
 			HostUUID: "h5", Platform: "darwin", TeamID: 0, SoftwareUpdateDeviceID: macDevice,
 			TargetOSVersion: "15.1", TargetDeadline: &deadline,
 		}
-		got := compute(host, latest(map[uint]uint{0: 2}, nil, nil))
+		got := compute(host, latest(map[uint]int{0: 2}, nil, nil))
 		require.Empty(t, got)
 	})
 
 	t.Run("unsupported platform is skipped", func(t *testing.T) {
 		host := &fleet.AppleSoftwareUpdateHost{HostUUID: "h6", Platform: "tvos", TeamID: 0, SoftwareUpdateDeviceID: macDevice}
-		got := compute(host, latest(map[uint]uint{0: 2}, nil, nil))
+		got := compute(host, latest(map[uint]int{0: 2}, nil, nil))
 		require.Empty(t, got)
 	})
 
 	t.Run("no asset matches the host device id is skipped", func(t *testing.T) {
 		host := &fleet.AppleSoftwareUpdateHost{HostUUID: "h7", Platform: "darwin", TeamID: 0, SoftwareUpdateDeviceID: "Mac99,9"}
-		got := compute(host, latest(map[uint]uint{0: 2}, nil, nil))
+		got := compute(host, latest(map[uint]int{0: 2}, nil, nil))
 		require.Empty(t, got)
 	})
 
 	t.Run("no assets for the platform is skipped", func(t *testing.T) {
 		host := &fleet.AppleSoftwareUpdateHost{HostUUID: "h8", Platform: "darwin", TeamID: 0, SoftwareUpdateDeviceID: macDevice}
-		got := computeOSUpdatesTarget(ctx, logger, []*fleet.AppleSoftwareUpdateHost{host}, map[string][]fleet.AppleSoftwareUpdateAsset{}, latest(map[uint]uint{0: 2}, nil, nil))
+		got := computeOSUpdatesTarget(ctx, logger, []*fleet.AppleSoftwareUpdateHost{host}, map[string][]fleet.AppleSoftwareUpdateAsset{}, latest(map[uint]int{0: 2}, nil, nil))
 		require.Empty(t, got)
+	})
+}
+
+// TestHandleAppleMDMOSUpdatesAssetRefresh covers the asset-cache refresh at the top of the OS
+// updates cron: when the cache is stale it fetches from GDMF, caches the fetched assets, and
+// prunes the cached assets Apple no longer reports. The pruning must never run on a fetch we
+// didn't get, otherwise we'd delete assets based on an incomplete view of what Apple publishes.
+func TestHandleAppleMDMOSUpdatesAssetRefresh(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	ctx := t.Context()
+
+	gdmfFixture, err := os.ReadFile("./gdmf/testdata/gdmf.json")
+	require.NoError(t, err)
+
+	// newDS returns a store with the reconcile part of the cron stubbed out to a no-op, so only
+	// the asset refresh is under test. lastUpdatedAt nil means the cache is stale.
+	newDS := func(lastUpdatedAt *time.Time) *mock.Store {
+		ds := new(mock.Store)
+		ds.GetLastAppleOSUpdatesUpdateFunc = func(ctx context.Context) (*time.Time, error) {
+			return lastUpdatedAt, nil
+		}
+		ds.UpsertAppleOSUpdatesFunc = func(ctx context.Context, updates map[string][]fleet.OSUpdateAsset) error {
+			return nil
+		}
+		ds.DeleteStaleAppleOSUpdatesFunc = func(ctx context.Context, updates map[string][]fleet.OSUpdateAsset) (int64, error) {
+			return 0, nil
+		}
+		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+			return &fleet.AppConfig{}, nil
+		}
+		ds.ListTeamsFunc = func(ctx context.Context, filter fleet.TeamFilter, opt fleet.ListOptions) ([]*fleet.Team, error) {
+			return nil, nil
+		}
+		ds.ListAppleOSUpdateAssetsFunc = func(ctx context.Context) (map[string][]fleet.AppleSoftwareUpdateAsset, error) {
+			return nil, nil
+		}
+		ds.ListAppleOSUpdateHostsForReconcileFunc = func(ctx context.Context, cursor string, batchSize int, teamsWithLatest map[string]map[uint]int) ([]*fleet.AppleSoftwareUpdateHost, error) {
+			return nil, nil
+		}
+		return ds
+	}
+
+	serveGDMF := func(t *testing.T, body []byte) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			if _, err := w.Write(body); err != nil {
+				t.Errorf("writing response: %v", err)
+			}
+		}))
+		t.Cleanup(srv.Close)
+		dev_mode.SetOverride("FLEET_DEV_GDMF_URL", srv.URL, t)
+	}
+
+	t.Run("stale cache caches the fetched assets and prunes with the same set", func(t *testing.T) {
+		serveGDMF(t, gdmfFixture)
+
+		ds := newDS(nil)
+		var upserted, pruned map[string][]fleet.OSUpdateAsset
+		ds.UpsertAppleOSUpdatesFunc = func(ctx context.Context, updates map[string][]fleet.OSUpdateAsset) error {
+			upserted = updates
+			return nil
+		}
+		ds.DeleteStaleAppleOSUpdatesFunc = func(ctx context.Context, updates map[string][]fleet.OSUpdateAsset) (int64, error) {
+			pruned = updates
+			return 3, nil
+		}
+
+		require.NoError(t, HandleAppleMDMOSUpdates(ctx, ds, logger))
+		require.True(t, ds.UpsertAppleOSUpdatesFuncInvoked)
+		require.True(t, ds.DeleteStaleAppleOSUpdatesFuncInvoked)
+		require.NotEmpty(t, upserted["macos"])
+		require.NotEmpty(t, upserted["ios"])
+		// pruning against exactly what we cached is what makes the delete safe
+		require.Equal(t, upserted, pruned)
+	})
+
+	t.Run("fresh cache neither caches nor prunes", func(t *testing.T) {
+		// no GDMF override: a fetch would fail the test by trying to reach Apple
+		lastUpdatedAt := time.Now().Add(-time.Hour)
+		ds := newDS(&lastUpdatedAt)
+
+		require.NoError(t, HandleAppleMDMOSUpdates(ctx, ds, logger))
+		require.False(t, ds.UpsertAppleOSUpdatesFuncInvoked)
+		require.False(t, ds.DeleteStaleAppleOSUpdatesFuncInvoked)
+		require.True(t, ds.ListAppleOSUpdateAssetsFuncInvoked, "the reconcile still runs on the cached assets")
+	})
+
+	t.Run("failed fetch neither caches nor prunes", func(t *testing.T) {
+		serveGDMF(t, []byte("not valid json"))
+
+		ds := newDS(nil)
+
+		require.NoError(t, HandleAppleMDMOSUpdates(ctx, ds, logger))
+		require.False(t, ds.UpsertAppleOSUpdatesFuncInvoked)
+		require.False(t, ds.DeleteStaleAppleOSUpdatesFuncInvoked, "pruning on a failed fetch would delete assets Apple still publishes")
+		require.True(t, ds.ListAppleOSUpdateAssetsFuncInvoked, "the reconcile still runs on the cached assets")
+	})
+
+	t.Run("failed upsert does not prune", func(t *testing.T) {
+		serveGDMF(t, gdmfFixture)
+
+		ds := newDS(nil)
+		ds.UpsertAppleOSUpdatesFunc = func(ctx context.Context, updates map[string][]fleet.OSUpdateAsset) error {
+			return errors.New("upsert failed")
+		}
+
+		require.NoError(t, HandleAppleMDMOSUpdates(ctx, ds, logger))
+		require.True(t, ds.UpsertAppleOSUpdatesFuncInvoked)
+		require.False(t, ds.DeleteStaleAppleOSUpdatesFuncInvoked, "the cache is out of sync with the fetch, so pruning is unsafe")
+	})
+
+	t.Run("failed prune does not fail the cron", func(t *testing.T) {
+		serveGDMF(t, gdmfFixture)
+
+		ds := newDS(nil)
+		ds.DeleteStaleAppleOSUpdatesFunc = func(ctx context.Context, updates map[string][]fleet.OSUpdateAsset) (int64, error) {
+			return 0, errors.New("delete failed")
+		}
+
+		require.NoError(t, HandleAppleMDMOSUpdates(ctx, ds, logger))
+		require.True(t, ds.DeleteStaleAppleOSUpdatesFuncInvoked)
+		require.True(t, ds.ListAppleOSUpdateAssetsFuncInvoked, "the reconcile still runs on the cached assets")
 	})
 }

--- a/server/mdm/apple/os_updates_reconcile_test.go
+++ b/server/mdm/apple/os_updates_reconcile_test.go
@@ -136,6 +136,47 @@ func TestComputeOSUpdatesTarget(t *testing.T) {
 		got := computeOSUpdatesTarget(ctx, logger, []*fleet.AppleSoftwareUpdateHost{host}, map[string][]fleet.AppleSoftwareUpdateAsset{}, latest(map[uint]int{0: 2}, nil, nil))
 		require.Empty(t, got)
 	})
+
+	t.Run("duplicate host UUIDs in a batch are collapsed to the first row", func(t *testing.T) {
+		deadline := macDeadline
+		inTeamWithLatest := &fleet.AppleSoftwareUpdateHost{
+			HostUUID: "dup", Platform: "darwin", TeamID: 0, SoftwareUpdateDeviceID: macDevice,
+		}
+		// same UUID, but this row's team has no "latest" set, so on its own it would clear the
+		// target computed for the row above
+		inTeamWithoutLatest := &fleet.AppleSoftwareUpdateHost{
+			HostUUID: "dup", Platform: "darwin", TeamID: 5, SoftwareUpdateDeviceID: macDevice,
+			TargetOSVersion: "15.1", TargetDeadline: &deadline, ResolvedAt: &deadline,
+		}
+
+		got := computeOSUpdatesTarget(ctx, logger,
+			[]*fleet.AppleSoftwareUpdateHost{inTeamWithLatest, inTeamWithoutLatest},
+			updateAssets, latest(map[uint]int{0: 2}, nil, nil))
+		require.Len(t, got, 1)
+		require.Equal(t, "dup", got[0].HostUUID)
+		require.True(t, got[0].Resend)
+		require.Equal(t, "15.1", got[0].TargetOSVersion)
+		require.True(t, macDeadline.Equal(*got[0].TargetDeadline))
+
+		// order decides the winner, and either way only one row per UUID comes out
+		got = computeOSUpdatesTarget(ctx, logger,
+			[]*fleet.AppleSoftwareUpdateHost{inTeamWithoutLatest, inTeamWithLatest},
+			updateAssets, latest(map[uint]int{0: 2}, nil, nil))
+		require.Len(t, got, 1)
+		require.Equal(t, "dup", got[0].HostUUID)
+		require.False(t, got[0].Resend)
+		require.Empty(t, got[0].TargetOSVersion)
+	})
+
+	t.Run("duplicate host UUIDs are collapsed even when the first row produces nothing", func(t *testing.T) {
+		unsupported := &fleet.AppleSoftwareUpdateHost{HostUUID: "dup2", Platform: "tvos", TeamID: 0, SoftwareUpdateDeviceID: macDevice}
+		supported := &fleet.AppleSoftwareUpdateHost{HostUUID: "dup2", Platform: "darwin", TeamID: 0, SoftwareUpdateDeviceID: macDevice}
+
+		got := computeOSUpdatesTarget(ctx, logger,
+			[]*fleet.AppleSoftwareUpdateHost{unsupported, supported},
+			updateAssets, latest(map[uint]int{0: 2}, nil, nil))
+		require.Empty(t, got)
+	})
 }
 
 // TestHandleAppleMDMOSUpdatesAssetRefresh covers the asset-cache refresh at the top of the OS

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -2280,6 +2280,8 @@ type ListAppleOSUpdateHostsForReconcileFunc func(ctx context.Context, cursor str
 
 type SetAppleOSUpdateTargetsAndResendFunc func(ctx context.Context, targets []*fleet.ComputedAppleSoftwareUpdateHost) error
 
+type GetAppleOSUpdateHostByUUIDFunc func(ctx context.Context, hostUUID string) (*fleet.AppleSoftwareUpdateHost, error)
+
 type DataStore struct {
 	AppConfigFunc        AppConfigFunc
 	AppConfigFuncInvoked bool
@@ -5664,6 +5666,9 @@ type DataStore struct {
 
 	SetAppleOSUpdateTargetsAndResendFunc        SetAppleOSUpdateTargetsAndResendFunc
 	SetAppleOSUpdateTargetsAndResendFuncInvoked bool
+
+	GetAppleOSUpdateHostByUUIDFunc        GetAppleOSUpdateHostByUUIDFunc
+	GetAppleOSUpdateHostByUUIDFuncInvoked bool
 
 	mu sync.Mutex
 }
@@ -13562,4 +13567,11 @@ func (s *DataStore) SetAppleOSUpdateTargetsAndResend(ctx context.Context, target
 	s.SetAppleOSUpdateTargetsAndResendFuncInvoked = true
 	s.mu.Unlock()
 	return s.SetAppleOSUpdateTargetsAndResendFunc(ctx, targets)
+}
+
+func (s *DataStore) GetAppleOSUpdateHostByUUID(ctx context.Context, hostUUID string) (*fleet.AppleSoftwareUpdateHost, error) {
+	s.mu.Lock()
+	s.GetAppleOSUpdateHostByUUIDFuncInvoked = true
+	s.mu.Unlock()
+	return s.GetAppleOSUpdateHostByUUIDFunc(ctx, hostUUID)
 }

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -2274,9 +2274,11 @@ type GetLastAppleOSUpdatesUpdateFunc func(ctx context.Context) (*time.Time, erro
 
 type UpsertAppleOSUpdatesFunc func(ctx context.Context, updates map[string][]fleet.OSUpdateAsset) error
 
+type DeleteStaleAppleOSUpdatesFunc func(ctx context.Context, updates map[string][]fleet.OSUpdateAsset) (int64, error)
+
 type ListAppleOSUpdateAssetsFunc func(ctx context.Context) (map[string][]fleet.AppleSoftwareUpdateAsset, error)
 
-type ListAppleOSUpdateHostsForReconcileFunc func(ctx context.Context, cursor string, batchSize int, teamsWithLatest map[string]map[uint]uint) ([]*fleet.AppleSoftwareUpdateHost, error)
+type ListAppleOSUpdateHostsForReconcileFunc func(ctx context.Context, cursor string, batchSize int, teamsWithLatest map[string]map[uint]int) ([]*fleet.AppleSoftwareUpdateHost, error)
 
 type SetAppleOSUpdateTargetsAndResendFunc func(ctx context.Context, targets []*fleet.ComputedAppleSoftwareUpdateHost) error
 
@@ -5657,6 +5659,9 @@ type DataStore struct {
 
 	UpsertAppleOSUpdatesFunc        UpsertAppleOSUpdatesFunc
 	UpsertAppleOSUpdatesFuncInvoked bool
+
+	DeleteStaleAppleOSUpdatesFunc        DeleteStaleAppleOSUpdatesFunc
+	DeleteStaleAppleOSUpdatesFuncInvoked bool
 
 	ListAppleOSUpdateAssetsFunc        ListAppleOSUpdateAssetsFunc
 	ListAppleOSUpdateAssetsFuncInvoked bool
@@ -13548,6 +13553,13 @@ func (s *DataStore) UpsertAppleOSUpdates(ctx context.Context, updates map[string
 	return s.UpsertAppleOSUpdatesFunc(ctx, updates)
 }
 
+func (s *DataStore) DeleteStaleAppleOSUpdates(ctx context.Context, updates map[string][]fleet.OSUpdateAsset) (int64, error) {
+	s.mu.Lock()
+	s.DeleteStaleAppleOSUpdatesFuncInvoked = true
+	s.mu.Unlock()
+	return s.DeleteStaleAppleOSUpdatesFunc(ctx, updates)
+}
+
 func (s *DataStore) ListAppleOSUpdateAssets(ctx context.Context) (map[string][]fleet.AppleSoftwareUpdateAsset, error) {
 	s.mu.Lock()
 	s.ListAppleOSUpdateAssetsFuncInvoked = true
@@ -13555,7 +13567,7 @@ func (s *DataStore) ListAppleOSUpdateAssets(ctx context.Context) (map[string][]f
 	return s.ListAppleOSUpdateAssetsFunc(ctx)
 }
 
-func (s *DataStore) ListAppleOSUpdateHostsForReconcile(ctx context.Context, cursor string, batchSize int, teamsWithLatest map[string]map[uint]uint) ([]*fleet.AppleSoftwareUpdateHost, error) {
+func (s *DataStore) ListAppleOSUpdateHostsForReconcile(ctx context.Context, cursor string, batchSize int, teamsWithLatest map[string]map[uint]int) ([]*fleet.AppleSoftwareUpdateHost, error) {
 	s.mu.Lock()
 	s.ListAppleOSUpdateHostsForReconcileFuncInvoked = true
 	s.mu.Unlock()

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -2270,6 +2270,16 @@ type BatchSetAppleDDMAssetsFunc func(ctx context.Context, teamID *uint, assets [
 
 type InsertAppleSoftwareUpdateDeviceIDFunc func(ctx context.Context, hostUUID string, updateDeviceID string) error
 
+type GetLastAppleOSUpdatesUpdateFunc func(ctx context.Context) (*time.Time, error)
+
+type UpsertAppleOSUpdatesFunc func(ctx context.Context, updates map[string][]fleet.OSUpdateAsset) error
+
+type ListAppleOSUpdateAssetsFunc func(ctx context.Context) (map[string][]fleet.AppleSoftwareUpdateAsset, error)
+
+type ListAppleOSUpdateHostsForReconcileFunc func(ctx context.Context, cursor string, batchSize int, teamsWithLatest map[string]map[uint]uint) ([]*fleet.AppleSoftwareUpdateHost, error)
+
+type SetAppleOSUpdateTargetsAndResendFunc func(ctx context.Context, targets []*fleet.ComputedAppleSoftwareUpdateHost) error
+
 type DataStore struct {
 	AppConfigFunc        AppConfigFunc
 	AppConfigFuncInvoked bool
@@ -5639,6 +5649,21 @@ type DataStore struct {
 
 	InsertAppleSoftwareUpdateDeviceIDFunc        InsertAppleSoftwareUpdateDeviceIDFunc
 	InsertAppleSoftwareUpdateDeviceIDFuncInvoked bool
+
+	GetLastAppleOSUpdatesUpdateFunc        GetLastAppleOSUpdatesUpdateFunc
+	GetLastAppleOSUpdatesUpdateFuncInvoked bool
+
+	UpsertAppleOSUpdatesFunc        UpsertAppleOSUpdatesFunc
+	UpsertAppleOSUpdatesFuncInvoked bool
+
+	ListAppleOSUpdateAssetsFunc        ListAppleOSUpdateAssetsFunc
+	ListAppleOSUpdateAssetsFuncInvoked bool
+
+	ListAppleOSUpdateHostsForReconcileFunc        ListAppleOSUpdateHostsForReconcileFunc
+	ListAppleOSUpdateHostsForReconcileFuncInvoked bool
+
+	SetAppleOSUpdateTargetsAndResendFunc        SetAppleOSUpdateTargetsAndResendFunc
+	SetAppleOSUpdateTargetsAndResendFuncInvoked bool
 
 	mu sync.Mutex
 }
@@ -13502,4 +13527,39 @@ func (s *DataStore) InsertAppleSoftwareUpdateDeviceID(ctx context.Context, hostU
 	s.InsertAppleSoftwareUpdateDeviceIDFuncInvoked = true
 	s.mu.Unlock()
 	return s.InsertAppleSoftwareUpdateDeviceIDFunc(ctx, hostUUID, updateDeviceID)
+}
+
+func (s *DataStore) GetLastAppleOSUpdatesUpdate(ctx context.Context) (*time.Time, error) {
+	s.mu.Lock()
+	s.GetLastAppleOSUpdatesUpdateFuncInvoked = true
+	s.mu.Unlock()
+	return s.GetLastAppleOSUpdatesUpdateFunc(ctx)
+}
+
+func (s *DataStore) UpsertAppleOSUpdates(ctx context.Context, updates map[string][]fleet.OSUpdateAsset) error {
+	s.mu.Lock()
+	s.UpsertAppleOSUpdatesFuncInvoked = true
+	s.mu.Unlock()
+	return s.UpsertAppleOSUpdatesFunc(ctx, updates)
+}
+
+func (s *DataStore) ListAppleOSUpdateAssets(ctx context.Context) (map[string][]fleet.AppleSoftwareUpdateAsset, error) {
+	s.mu.Lock()
+	s.ListAppleOSUpdateAssetsFuncInvoked = true
+	s.mu.Unlock()
+	return s.ListAppleOSUpdateAssetsFunc(ctx)
+}
+
+func (s *DataStore) ListAppleOSUpdateHostsForReconcile(ctx context.Context, cursor string, batchSize int, teamsWithLatest map[string]map[uint]uint) ([]*fleet.AppleSoftwareUpdateHost, error) {
+	s.mu.Lock()
+	s.ListAppleOSUpdateHostsForReconcileFuncInvoked = true
+	s.mu.Unlock()
+	return s.ListAppleOSUpdateHostsForReconcileFunc(ctx, cursor, batchSize, teamsWithLatest)
+}
+
+func (s *DataStore) SetAppleOSUpdateTargetsAndResend(ctx context.Context, targets []*fleet.ComputedAppleSoftwareUpdateHost) error {
+	s.mu.Lock()
+	s.SetAppleOSUpdateTargetsAndResendFuncInvoked = true
+	s.mu.Unlock()
+	return s.SetAppleOSUpdateTargetsAndResendFunc(ctx, targets)
 }

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -1553,10 +1553,7 @@ type notReadyYetError struct {
 }
 
 func (e notReadyYetError) Error() string {
-	if e.Message != "" {
-		return e.Message
-	}
-	return e.error.Error()
+	return e.Message
 }
 
 // replaceDeclarationFleetVariables replaces $FLEET_VAR_* placeholders in a

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -1548,7 +1548,6 @@ func jsonEscapeString(s string) string {
 }
 
 type notReadyYetError struct {
-	error
 	Message string
 }
 

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -1708,7 +1708,7 @@ func (svc *MDMAppleDDMService) replaceDeclarationFleetVariables(
 			if fleet.FleetVarName(fleetVar) == fleet.FleetVarHostTargetOSVersion {
 				value = osHost.TargetOSVersion
 			} else {
-				value = fmt.Sprintf("%sT12:00:00", osHost.TargetDeadline.Format(time.DateOnly))
+				value = osHost.TargetDeadline.Format(time.DateOnly)
 			}
 		default:
 			return "", fmt.Errorf("Fleet variable $FLEET_VAR_%s is not supported in DDM declarations.", fleetVar)

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -7225,9 +7225,8 @@ func (svc *MDMAppleDDMService) handleDeclarationItems(ctx context.Context, hostU
 		if d.VariablesUpdatedAt != nil {
 			if d.RawJSON != nil {
 				if _, err := svc.replaceDeclarationFleetVariables(ctx, string(*d.RawJSON), hostUUID); err != nil {
-					var notReadyYetErr notReadyYetError
-					if errors.As(err, &notReadyYetErr) {
-						if err := svc.markDeclarationPending(ctx, hostUUID, d.DeclarationUUID, notReadyYetErr.Message); err != nil {
+					if nryErr, ok := errors.AsType[notReadyYetError](err); ok {
+						if err := svc.markDeclarationPending(ctx, hostUUID, d.DeclarationUUID, nryErr.Message); err != nil {
 							return nil, ctxerr.Wrap(ctx, err, "mark declaration as pending")
 						}
 						continue
@@ -7442,9 +7441,8 @@ func (svc *MDMAppleDDMService) handleConfigurationDeclaration(ctx context.Contex
 	// Replace Fleet variables with host-specific values
 	expanded, err = svc.replaceDeclarationFleetVariables(ctx, expanded, hostUUID)
 	if err != nil {
-		var notReadyYetErr notReadyYetError
-		if errors.As(err, &notReadyYetErr) {
-			if err := svc.markDeclarationPending(ctx, hostUUID, d.DeclarationUUID, notReadyYetErr.Message); err != nil {
+		if nryErr, ok := errors.AsType[notReadyYetError](err); ok {
+			if err := svc.markDeclarationPending(ctx, hostUUID, d.DeclarationUUID, nryErr.Message); err != nil {
 				return nil, ctxerr.Wrap(ctx, err, "mark declaration as pending")
 			}
 			return nil, nil

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -1547,6 +1547,11 @@ func jsonEscapeString(s string) string {
 	return string(b[1 : len(b)-1])
 }
 
+type notReadyYetError struct {
+	error
+	Message string
+}
+
 // replaceDeclarationFleetVariables replaces $FLEET_VAR_* placeholders in a
 // DDM declaration with host-specific values. Values are JSON-string-escaped
 // so they are safe inside JSON string fields.
@@ -1601,6 +1606,24 @@ func (svc *MDMAppleDDMService) replaceDeclarationFleetVariables(
 		}
 		idpUser = &users[0]
 		return idpUser, nil
+	}
+
+	var osUpdateHost *fleet.AppleSoftwareUpdateHost
+	resolveOSUpdateHost := func() (*fleet.AppleSoftwareUpdateHost, error) {
+		if osUpdateHost != nil {
+			return osUpdateHost, nil
+		}
+
+		osHost, err := svc.ds.GetAppleOSUpdateHostByUUID(ctx, hostUUID)
+		if err != nil {
+			return nil, fmt.Errorf("get Apple OS update host by UUID: %w", err)
+		}
+		if osHost == nil {
+			return nil, fmt.Errorf("Apple OS update host not found for UUID %s", hostUUID)
+		}
+
+		osUpdateHost = osHost
+		return osUpdateHost, nil
 	}
 
 	for _, fleetVar := range fleetVars {
@@ -1671,7 +1694,22 @@ func (svc *MDMAppleDDMService) replaceDeclarationFleetVariables(
 				return "", fmt.Errorf("There is no IdP full name for this host. Fleet couldn't populate $FLEET_VAR_%s.", fleetVar)
 			}
 			value = strings.TrimSpace(user.IdpFullName)
+		case fleet.FleetVarHostTargetOSDeadline, fleet.FleetVarHostTargetOSVersion:
+			osHost, err := resolveOSUpdateHost()
+			if err != nil {
+				return "", err
+			}
+			if osHost.TargetOSVersion == "" || osHost.TargetDeadline == nil {
+				return "", notReadyYetError{
+					Message: "The host's target OS version and deadline are not yet available, but will be within 1 hour. Fleet will automatically resend this profile once available.",
+				}
+			}
 
+			if fleet.FleetVarName(fleetVar) == fleet.FleetVarHostTargetOSVersion {
+				value = osHost.TargetOSVersion
+			} else {
+				value = fmt.Sprintf("%sT12:00:00", osHost.TargetDeadline.Format(time.DateOnly))
+			}
 		default:
 			return "", fmt.Errorf("Fleet variable $FLEET_VAR_%s is not supported in DDM declarations.", fleetVar)
 		}
@@ -1702,6 +1740,12 @@ func (svc *MDMAppleDDMService) replaceDeclarationFleetVariables(
 // markDeclarationFailed marks a DDM declaration as failed for a specific host.
 func (svc *MDMAppleDDMService) markDeclarationFailed(ctx context.Context, hostUUID string, declarationUUID string, detail string) error {
 	status := fleet.MDMDeliveryFailed
+	return svc.ds.SetHostMDMAppleDeclarationStatus(ctx, hostUUID, declarationUUID, &status, detail, nil)
+}
+
+// markDeclarationPending marks a DDM declaration as pending for a specific host, and relies on other factors (such as variable bump) to trigger a resend.
+func (svc *MDMAppleDDMService) markDeclarationPending(ctx context.Context, hostUUID string, declarationUUID string, detail string) error {
+	status := fleet.MDMDeliveryPending
 	return svc.ds.SetHostMDMAppleDeclarationStatus(ctx, hostUUID, declarationUUID, &status, detail, nil)
 }
 
@@ -7170,6 +7214,14 @@ func (svc *MDMAppleDDMService) handleDeclarationItems(ctx context.Context, hostU
 		if d.VariablesUpdatedAt != nil {
 			if d.RawJSON != nil {
 				if _, err := svc.replaceDeclarationFleetVariables(ctx, string(*d.RawJSON), hostUUID); err != nil {
+					var notReadyYetErr notReadyYetError
+					if errors.As(err, &notReadyYetErr) {
+						if err := svc.markDeclarationPending(ctx, hostUUID, d.DeclarationUUID, notReadyYetErr.Message); err != nil {
+							return nil, ctxerr.Wrap(ctx, err, "mark declaration as pending")
+						}
+						continue
+					}
+
 					if err := svc.markDeclarationFailed(ctx, hostUUID, d.DeclarationUUID, err.Error()); err != nil {
 						return nil, ctxerr.Wrap(ctx, err, "mark declaration as failed")
 					}
@@ -7379,6 +7431,14 @@ func (svc *MDMAppleDDMService) handleConfigurationDeclaration(ctx context.Contex
 	// Replace Fleet variables with host-specific values
 	expanded, err = svc.replaceDeclarationFleetVariables(ctx, expanded, hostUUID)
 	if err != nil {
+		var notReadyYetErr notReadyYetError
+		if errors.As(err, &notReadyYetErr) {
+			if err := svc.markDeclarationPending(ctx, hostUUID, d.DeclarationUUID, notReadyYetErr.Message); err != nil {
+				return nil, ctxerr.Wrap(ctx, err, "mark declaration as pending")
+			}
+			return nil, nil
+		}
+
 		// Mark this declaration as failed for this host, return empty 200
 		if err := svc.markDeclarationFailed(ctx, hostUUID, d.DeclarationUUID, err.Error()); err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "mark declaration as failed")

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -1552,6 +1552,13 @@ type notReadyYetError struct {
 	Message string
 }
 
+func (e notReadyYetError) Error() string {
+	if e.Message != "" {
+		return e.Message
+	}
+	return e.error.Error()
+}
+
 // replaceDeclarationFleetVariables replaces $FLEET_VAR_* placeholders in a
 // DDM declaration with host-specific values. Values are JSON-string-escaped
 // so they are safe inside JSON string fields.
@@ -3045,7 +3052,7 @@ func (svc *Service) CheckMDMAppleEnrollmentWithMinimumOSVersion(ctx context.Cont
 
 	// if the device should update based on appconfig settings, we also need to check what versions
 	// are actually available for the device from Apple
-	sur, err := svc.getAppleSoftwareUpdateRequiredForDEPEnrollment(*m)
+	sur, err := svc.getAppleSoftwareUpdateRequiredForDEPEnrollment(ctx, *m)
 	if err != nil {
 		// log for debugging but allow enrollment to proceed
 		svc.logger.InfoContext(ctx, "getting apple software update required", "serial", m.Serial, "err", err)
@@ -3118,8 +3125,12 @@ func (svc *Service) shouldOSUpdateForDEPEnrollment(ctx context.Context, m fleet.
 	return needsUpdate, nil
 }
 
-func (svc *Service) getAppleSoftwareUpdateRequiredForDEPEnrollment(m fleet.MDMAppleMachineInfo) (*fleet.MDMAppleSoftwareUpdateRequired, error) {
-	latest, err := gdmf.GetLatestOSVersion(m)
+func (svc *Service) getAppleSoftwareUpdateRequiredForDEPEnrollment(ctx context.Context, m fleet.MDMAppleMachineInfo) (*fleet.MDMAppleSoftwareUpdateRequired, error) {
+	updateAssets, err := svc.ds.ListAppleOSUpdateAssets(ctx)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "listing apple os update assets")
+	}
+	latest, err := gdmf.GetLatestOSVersion(m, updateAssets)
 	if err != nil {
 		return nil, err
 	}

--- a/server/service/apple_mdm_ddm_test.go
+++ b/server/service/apple_mdm_ddm_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql/mysqltest"
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	fleetmdm "github.com/fleetdm/fleet/v4/server/mdm"
 	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/mdm"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/jmoiron/sqlx"
@@ -562,4 +563,271 @@ func TestDeclarativeManagement_DeclarationItems(t *testing.T) {
 		require.Equal(t, "com.example.strip", served["Identifier"])
 		require.Contains(t, served, "ServerToken")
 	})
+}
+
+// osUpdatesDeclContents is a minimal DDM software-update declaration body that
+// references both host-target OS Fleet variables. It is used by the OS-updates
+// DDM sync tests below.
+const osUpdatesDeclContents = `{
+	"Type": "com.apple.configuration.softwareupdate.enforcement.specific",
+	"Identifier": "com.fleetdm.fleet.mdm.os-updates.macos",
+	"Payload": {
+		"TargetOSVersion": "$FLEET_VAR_HOST_TARGET_OS_VERSION",
+		"TargetLocalDateTime": "$FLEET_VAR_HOST_TARGET_OS_DEADLINE"
+	}
+}`
+
+// TestReplaceDeclarationFleetVariablesOSUpdateTargets covers the variable
+// resolution branch for the OS-update target variables:
+//   - the tracking row exists but the target hasn't been computed yet -> the
+//     declaration is deferred with a notReadyYetError (so the caller marks it
+//     pending, not failed),
+//   - the target is set -> the version and RFC3339 deadline are substituted,
+//   - there is no tracking row at all -> a hard error (marked failed).
+func TestReplaceDeclarationFleetVariablesOSUpdateTargets(t *testing.T) {
+	ctx := t.Context()
+	ds := mysqltest.CreateMySQLDS(t)
+	svc := MDMAppleDDMService{
+		ds:     ds,
+		logger: slog.New(slog.NewTextHandler(os.Stdout, nil)),
+	}
+
+	newHost := func(hostUUID string) *fleet.Host {
+		h, err := ds.NewHost(ctx, &fleet.Host{
+			UUID:            hostUUID,
+			Hostname:        hostUUID,
+			OsqueryHostID:   new(hostUUID),
+			NodeKey:         new(hostUUID),
+			Platform:        "darwin",
+			DetailUpdatedAt: time.Now(),
+			LabelUpdatedAt:  time.Now(),
+			PolicyUpdatedAt: time.Now(),
+			SeenTime:        time.Now(),
+		})
+		require.NoError(t, err)
+		return h
+	}
+
+	t.Run("target not yet computed defers with notReadyYetError", func(t *testing.T) {
+		h := newHost("os-var-notready")
+		// A tracking row exists (device id captured) but no target has been set.
+		require.NoError(t, ds.InsertAppleSoftwareUpdateDeviceID(ctx, h.UUID, "Mac14,2"))
+
+		_, err := svc.replaceDeclarationFleetVariables(ctx, osUpdatesDeclContents, h.UUID)
+		var notReady notReadyYetError
+		require.ErrorAs(t, err, &notReady)
+		require.Contains(t, notReady.Message, "not yet available")
+		require.Contains(t, notReady.Message, "resend this profile once available")
+	})
+
+	t.Run("target set substitutes version and DateOnly noon deadline", func(t *testing.T) {
+		h := newHost("os-var-ready")
+		require.NoError(t, ds.InsertAppleSoftwareUpdateDeviceID(ctx, h.UUID, "Mac14,2"))
+
+		deadline, _ := time.Parse(time.DateOnly, time.Now().UTC().Add(48*time.Hour).Format(time.DateOnly))
+		resolvedAt := time.Now().UTC().Truncate(time.Microsecond)
+		require.NoError(t, ds.SetAppleOSUpdateTargetsAndResend(ctx, []*fleet.ComputedAppleSoftwareUpdateHost{{
+			AppleSoftwareUpdateHost: fleet.AppleSoftwareUpdateHost{
+				HostUUID: h.UUID, TargetOSVersion: "15.1", TargetDeadline: &deadline, ResolvedAt: &resolvedAt,
+			},
+		}}))
+
+		out, err := svc.replaceDeclarationFleetVariables(ctx, osUpdatesDeclContents, h.UUID)
+		require.NoError(t, err)
+		require.NotContains(t, out, "$FLEET_VAR")
+
+		deadline = deadline.Add(12 * time.Hour) // noon local time
+
+		var parsed struct {
+			Payload struct {
+				TargetOSVersion     string
+				TargetLocalDateTime string
+			}
+		}
+		require.NoError(t, json.Unmarshal([]byte(out), &parsed))
+		require.Equal(t, "15.1", parsed.Payload.TargetOSVersion)
+		gotDeadline, err := time.Parse("2006-01-02T15:04:05", parsed.Payload.TargetLocalDateTime)
+		require.NoError(t, err)
+		require.True(t, deadline.Equal(gotDeadline), "want %s got %s", deadline, gotDeadline)
+	})
+
+	t.Run("missing tracking row is a hard error, not a defer", func(t *testing.T) {
+		h := newHost("os-var-missing") // no InsertAppleSoftwareUpdateDeviceID -> no tracking row
+
+		_, err := svc.replaceDeclarationFleetVariables(ctx, osUpdatesDeclContents, h.UUID)
+		require.Error(t, err)
+		var notReady notReadyYetError
+		require.NotErrorAs(t, err, &notReady, "a missing tracking row must not defer")
+		require.Contains(t, err.Error(), "not found")
+	})
+}
+
+// TestDeclarativeManagementOSUpdatesPendingThenResolved exercises the full
+// DDM-sync piece end to end at the handler layer: an OS-update declaration whose
+// target variables can't be resolved yet is marked pending (with a user-facing
+// detail) and excluded from the manifest; then, once the cron's datastore write
+// sets the target and bumps the declaration for resend, the same fetches resolve
+// and the declaration is served with concrete values.
+func TestDeclarativeManagementOSUpdatesPendingThenResolved(t *testing.T) {
+	ctx := t.Context()
+	ds := mysqltest.CreateMySQLDS(t)
+	svc := MDMAppleDDMService{
+		ds:     ds,
+		logger: slog.New(slog.NewTextHandler(os.Stdout, nil)),
+	}
+
+	const (
+		hostUUID       = "os-updates-ddm-host"
+		deviceID       = "Mac14,2"
+		declIdentifier = "com.fleetdm.fleet.mdm.os-updates.macos"
+	)
+
+	_, err := ds.NewHost(ctx, &fleet.Host{
+		UUID:            hostUUID,
+		Hostname:        hostUUID,
+		OsqueryHostID:   new(hostUUID),
+		NodeKey:         new(hostUUID),
+		Platform:        "darwin",
+		DetailUpdatedAt: time.Now(),
+		LabelUpdatedAt:  time.Now(),
+		PolicyUpdatedAt: time.Now(),
+		SeenTime:        time.Now(),
+	})
+	require.NoError(t, err)
+
+	// Fleet-managed OS-updates DDM declaration referencing the two target vars.
+	decl, err := ds.NewMDMAppleDeclaration(ctx, &fleet.MDMAppleDeclaration{
+		DeclarationUUID: "os-updates-decl-uuid",
+		Name:            fleetmdm.FleetMacOSUpdatesProfileName,
+		Identifier:      declIdentifier,
+		RawJSON:         []byte(osUpdatesDeclContents),
+		Scope:           fleet.PayloadScopeSystem,
+	}, []fleet.FleetVarName{fleet.FleetVarHostTargetOSVersion, fleet.FleetVarHostTargetOSDeadline})
+	require.NoError(t, err)
+
+	// Assign the declaration to the host. variables_updated_at is set (as the
+	// reconciler would) so the sync path attempts variable resolution; status
+	// starts NULL (freshly assigned, not yet delivered).
+	initialVarsUpdated := time.Now().UTC().Add(-time.Hour).Truncate(time.Microsecond)
+	mysqltest.ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		var token string
+		if err := sqlx.GetContext(ctx, q, &token,
+			"SELECT HEX(token) FROM mdm_apple_declarations WHERE declaration_uuid = ?", decl.DeclarationUUID); err != nil {
+			return err
+		}
+		_, err := q.ExecContext(ctx, `
+			INSERT INTO host_mdm_apple_declarations
+				(host_uuid, declaration_uuid, status, operation_type, token, declaration_identifier, declaration_name, scope, variables_updated_at)
+			VALUES (?, ?, NULL, 'install', UNHEX(?), ?, ?, 'System', ?)`,
+			hostUUID, decl.DeclarationUUID, token, declIdentifier, fleetmdm.FleetMacOSUpdatesProfileName, initialVarsUpdated)
+		return err
+	})
+
+	// Tracking row exists (device id captured) but the target isn't computed yet.
+	require.NoError(t, ds.InsertAppleSoftwareUpdateDeviceID(ctx, hostUUID, deviceID))
+
+	readHostDecl := func() (status *string, detail string) {
+		var row struct {
+			Status *string `db:"status"`
+			Detail string  `db:"detail"`
+		}
+		mysqltest.ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			return sqlx.GetContext(ctx, q, &row,
+				`SELECT status, COALESCE(detail, '') AS detail FROM host_mdm_apple_declarations WHERE host_uuid = ? AND declaration_uuid = ?`,
+				hostUUID, decl.DeclarationUUID)
+		})
+		return row.Status, row.Detail
+	}
+	readVarsUpdatedAt := func() *time.Time {
+		var vals []time.Time
+		mysqltest.ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			return sqlx.SelectContext(ctx, q, &vals,
+				`SELECT variables_updated_at FROM host_mdm_apple_declarations WHERE host_uuid = ? AND declaration_uuid = ? AND variables_updated_at IS NOT NULL`,
+				hostUUID, decl.DeclarationUUID)
+		})
+		if len(vals) == 0 {
+			return nil
+		}
+		return &vals[0]
+	}
+	configItems := func() []fleet.MDMAppleDDMManifest {
+		body, err := svc.handleDeclarationItems(ctx, hostUUID, fleet.PayloadScopeSystem)
+		require.NoError(t, err)
+		var resp fleet.MDMAppleDDMDeclarationItemsResponse
+		require.NoError(t, json.Unmarshal(body, &resp))
+		return resp.Declarations.Configurations
+	}
+
+	configParts := []string{"declaration", "configuration", declIdentifier}
+
+	// === Phase 1: target not ready -> pending with detail, excluded from manifest ===
+
+	body, err := svc.handleConfigurationDeclaration(ctx, configParts, hostUUID, fleet.PayloadScopeSystem)
+	require.NoError(t, err)
+	require.Nil(t, body, "an unresolvable declaration is served as an empty 200")
+
+	status, detail := readHostDecl()
+	require.NotNil(t, status)
+	require.Equal(t, string(fleet.MDMDeliveryPending), *status)
+	require.Contains(t, detail, "not yet available")
+
+	for _, c := range configItems() {
+		require.NotEqual(t, declIdentifier, c.Identifier, "unresolvable declaration must be excluded from the manifest")
+	}
+	// handleDeclarationItems also keeps it pending with the detail.
+	status, detail = readHostDecl()
+	require.NotNil(t, status)
+	require.Equal(t, string(fleet.MDMDeliveryPending), *status)
+	require.Contains(t, detail, "not yet available")
+
+	// === Phase 2: cron computes the target and bumps the declaration for resend ===
+
+	deadline, _ := time.Parse(time.DateOnly, time.Now().UTC().Add(48*time.Hour).Format(time.DateOnly))
+	deadline = deadline.Add(12 * time.Hour) // noon local time
+	resolvedAt := time.Now().UTC().Truncate(time.Microsecond)
+	require.NoError(t, ds.SetAppleOSUpdateTargetsAndResend(ctx, []*fleet.ComputedAppleSoftwareUpdateHost{{
+		AppleSoftwareUpdateHost: fleet.AppleSoftwareUpdateHost{
+			HostUUID: hostUUID, TargetOSVersion: "15.1", TargetDeadline: &deadline, ResolvedAt: &resolvedAt,
+		},
+		Resend: true,
+	}}))
+
+	// The resend signal: status cleared to NULL and variables_updated_at bumped.
+	status, _ = readHostDecl()
+	require.Nil(t, status, "resend resets status to NULL")
+	bumped := readVarsUpdatedAt()
+	require.NotNil(t, bumped)
+	require.True(t, bumped.After(initialVarsUpdated), "variables_updated_at should be bumped forward for resend")
+
+	// === Phase 3: the declaration now resolves and is served with concrete values ===
+
+	body, err = svc.handleConfigurationDeclaration(ctx, configParts, hostUUID, fleet.PayloadScopeSystem)
+	require.NoError(t, err)
+	require.NotNil(t, body)
+	require.NotContains(t, string(body), "$FLEET_VAR")
+
+	var served struct {
+		Identifier string
+		Payload    struct {
+			TargetOSVersion     string
+			TargetLocalDateTime string
+		}
+		ServerToken string
+	}
+	require.NoError(t, json.Unmarshal(body, &served))
+	require.Equal(t, declIdentifier, served.Identifier)
+	require.Equal(t, "15.1", served.Payload.TargetOSVersion)
+	require.NotEmpty(t, served.ServerToken)
+	gotDeadline, err := time.Parse("2006-01-02T15:04:05", served.Payload.TargetLocalDateTime)
+	require.NoError(t, err)
+	require.True(t, deadline.Equal(gotDeadline), "want %s got %s", deadline, gotDeadline)
+
+	// And it is now included in the declaration-items manifest.
+	found := false
+	for _, c := range configItems() {
+		if c.Identifier == declIdentifier {
+			found = true
+		}
+	}
+	require.True(t, found, "resolved OS-updates declaration should be present in declaration-items")
 }

--- a/server/service/apple_mdm_ddm_test.go
+++ b/server/service/apple_mdm_ddm_test.go
@@ -573,7 +573,7 @@ const osUpdatesDeclContents = `{
 	"Identifier": "com.fleetdm.fleet.mdm.os-updates.macos",
 	"Payload": {
 		"TargetOSVersion": "$FLEET_VAR_HOST_TARGET_OS_VERSION",
-		"TargetLocalDateTime": "$FLEET_VAR_HOST_TARGET_OS_DEADLINE"
+		"TargetLocalDateTime": "${FLEET_VAR_HOST_TARGET_OS_DEADLINE}T12:00:00"
 	}
 }`
 

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -36,10 +36,10 @@ import (
 	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql/mysqltest"
 	"github.com/fleetdm/fleet/v4/server/datastore/redis/redistest"
-	"github.com/fleetdm/fleet/v4/server/dev_mode"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	fleetmdm "github.com/fleetdm/fleet/v4/server/mdm"
 	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
+	"github.com/fleetdm/fleet/v4/server/mdm/apple/gdmf"
 	"github.com/fleetdm/fleet/v4/server/mdm/apple/mobileconfig"
 	mdmlifecycle "github.com/fleetdm/fleet/v4/server/mdm/lifecycle"
 	nanodep_client "github.com/fleetdm/fleet/v4/server/mdm/nanodep/client"
@@ -7598,19 +7598,52 @@ func TestShouldOSUpdateForDEPEnrollment(t *testing.T) {
 	}
 }
 
+// testAppleOSUpdateAssets loads the GDMF fixture and converts it to the platform-keyed map of
+// cached assets returned by Datastore.ListAppleOSUpdateAssets. In production the same shape is
+// produced by the OS updates cron: it fetches the public asset sets from GDMF and upserts them
+// into apple_software_update_assets.
+func testAppleOSUpdateAssets(t *testing.T) map[string][]fleet.AppleSoftwareUpdateAsset {
+	t.Helper()
+
+	b, err := os.ReadFile("../mdm/apple/gdmf/testdata/gdmf.json")
+	require.NoError(t, err)
+
+	var am gdmf.AssetMetadata
+	require.NoError(t, json.Unmarshal(b, &am))
+
+	convert := func(assets []fleet.OSUpdateAsset) []fleet.AppleSoftwareUpdateAsset {
+		out := make([]fleet.AppleSoftwareUpdateAsset, 0, len(assets))
+		for _, a := range assets {
+			// the dates are stored in DATE columns, so they come back as time.Time
+			postingDate, err := time.Parse(time.DateOnly, a.PostingDate)
+			require.NoError(t, err)
+			expirationDate, err := time.Parse(time.DateOnly, a.ExpirationDate)
+			require.NoError(t, err)
+			out = append(out, fleet.AppleSoftwareUpdateAsset{
+				ProductVersion:   a.ProductVersion,
+				Build:            a.Build,
+				PostingDate:      postingDate,
+				ExpirationDate:   expirationDate,
+				SupportedDevices: a.SupportedDevices,
+			})
+		}
+		return out
+	}
+
+	return map[string][]fleet.AppleSoftwareUpdateAsset{
+		"macos": convert(am.PublicAssetSets.MacOS),
+		"ios":   convert(am.PublicAssetSets.IOS),
+	}
+}
+
 func TestCheckMDMAppleEnrollmentWithMinimumOSVersion(t *testing.T) {
 	svc, ctx, ds, _ := setupAppleMDMService(t, &fleet.LicenseInfo{Tier: fleet.TierPremium})
 
-	gdmf := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		// load the test data from the file
-		b, err := os.ReadFile("../mdm/apple/gdmf/testdata/gdmf.json")
-		require.NoError(t, err)
-		_, err = w.Write(b)
-		require.NoError(t, err)
-	}))
-	defer gdmf.Close()
-	dev_mode.SetOverride("FLEET_DEV_GDMF_URL", gdmf.URL, t)
+	// the update assets come from the apple_software_update_assets cache, which the OS updates
+	// cron populates from GDMF; here we seed the cache with the GDMF fixture
+	ds.ListAppleOSUpdateAssetsFunc = func(ctx context.Context) (map[string][]fleet.AppleSoftwareUpdateAsset, error) {
+		return testAppleOSUpdateAssets(t), nil
+	}
 
 	latestMacOSVersion := "14.6.1"
 	latestIOSVersion := "17.6.1"
@@ -7980,8 +8013,10 @@ func TestCheckMDMAppleEnrollmentWithMinimumOSVersion(t *testing.T) {
 		})
 	}
 
-	t.Run("gdmf server is down", func(t *testing.T) {
-		gdmf.Close()
+	t.Run("no cached update assets", func(t *testing.T) {
+		ds.ListAppleOSUpdateAssetsFunc = func(ctx context.Context) (map[string][]fleet.AppleSoftwareUpdateAsset, error) {
+			return nil, nil
+		}
 
 		for _, tt := range testCases {
 			t.Run(tt.name, func(t *testing.T) {
@@ -7997,7 +8032,7 @@ func TestCheckMDMAppleEnrollmentWithMinimumOSVersion(t *testing.T) {
 					require.NoError(t, err)
 				}
 
-				require.Nil(t, sur) // if gdmf server is down, we don't enforce os updates for DEP
+				require.Nil(t, sur) // without cached assets, we don't enforce os updates for DEP
 			})
 		}
 	})

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -2002,6 +2002,11 @@ func (svc *Service) getHostDetails(ctx context.Context, host *fleet.Host, opts f
 		return nil, ctxerr.Wrap(ctx, err, "get custom host vitals for host")
 	}
 
+	osUpdateMinVersion, osUpdateDeadline, err := getOSUpdateForHostDetails(svc, ctx, host, ac)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "get os update for host details")
+	}
+
 	return &fleet.HostDetail{
 		Host:                          *host,
 		Labels:                        labels,
@@ -2014,7 +2019,69 @@ func (svc *Service) getHostDetails(ctx context.Context, host *fleet.Host, opts f
 		LastMDMCheckedInAt:            mdmLastCheckedIn,
 		MDMEnrollmentHardwareAttested: mdmHardwareAttested,
 		ConditionalAccessBypassed:     conditionalAccessBypassed,
+		OSUpdateMinimumVersion:        osUpdateMinVersion,
+		OSUpdateDeadline:              osUpdateDeadline,
 	}, nil
+}
+
+// getOSUpdateForHostDetails returns the minimum OS version and deadline for a host.
+// If OS updates is not configured it returns nil
+// if OS updates enforces latest we return the target version and deadline from the host's os_update_host record and "TBD" if the target version is not calculated
+// if OS updates does not enforce latest we return the minimum version and deadline from the config which is constants
+func getOSUpdateForHostDetails(svc *Service, ctx context.Context, host *fleet.Host, appConfig *fleet.AppConfig) (*string, *string, error) {
+	// Only Apple platforms have OS update settings here, so skip the (possibly
+	// team-scoped) config lookup entirely for everything else.
+	if !fleet.IsApplePlatform(host.Platform) {
+		return nil, nil, nil
+	}
+
+	macOSUpdates := appConfig.MDM.MacOSUpdates
+	iOSUpdates := appConfig.MDM.IOSUpdates
+	iPadOSUpdates := appConfig.MDM.IPadOSUpdates
+
+	if host.TeamID != nil {
+		team, err := svc.ds.TeamLite(ctx, *host.TeamID)
+		if err != nil {
+			return nil, nil, ctxerr.Wrap(ctx, err, "get team for host")
+		}
+		macOSUpdates = team.Config.MDM.MacOSUpdates
+		iOSUpdates = team.Config.MDM.IOSUpdates
+		iPadOSUpdates = team.Config.MDM.IPadOSUpdates
+	}
+
+	var relevantOSUpdates fleet.AppleOSUpdateSettings
+	switch host.Platform {
+	case "darwin":
+		relevantOSUpdates = macOSUpdates
+	case "ios":
+		relevantOSUpdates = iOSUpdates
+	case "ipados":
+		relevantOSUpdates = iPadOSUpdates
+	}
+
+	if !relevantOSUpdates.Configured() {
+		return nil, nil, nil
+	}
+
+	if relevantOSUpdates.EnforcesLatestVersion() {
+		osUpdateHost, err := svc.ds.GetAppleOSUpdateHostByUUID(ctx, host.UUID)
+		if err != nil {
+			return nil, nil, ctxerr.Wrap(ctx, err, "get apple os update host by uuid")
+		}
+
+		if osUpdateHost != nil && osUpdateHost.TargetOSVersion != "" && osUpdateHost.TargetDeadline != nil {
+			osUpdateMinVersion := &osUpdateHost.TargetOSVersion
+			osUpdateDeadlineStr := osUpdateHost.TargetDeadline.Format(time.DateOnly)
+			osUpdateDeadline := &osUpdateDeadlineStr
+			return osUpdateMinVersion, osUpdateDeadline, nil
+		}
+
+		return nil, nil, nil
+	}
+
+	// Extract from target and deadline from config.
+
+	return &relevantOSUpdates.MinimumVersion.Value, &relevantOSUpdates.Deadline.Value, nil
 }
 
 // populateManagedLocalAccountStatus fills in host.MDM.OSSettings.ManagedLocalAccount.

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -2002,7 +2002,7 @@ func (svc *Service) getHostDetails(ctx context.Context, host *fleet.Host, opts f
 		return nil, ctxerr.Wrap(ctx, err, "get custom host vitals for host")
 	}
 
-	osUpdateMinVersion, osUpdateDeadline, err := getOSUpdateForHostDetails(svc, ctx, host, ac)
+	osUpdateMinVersion, osUpdateDeadline, err := svc.getOSUpdateForHostDetails(ctx, host, ac)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "get os update for host details")
 	}
@@ -2028,7 +2028,7 @@ func (svc *Service) getHostDetails(ctx context.Context, host *fleet.Host, opts f
 // If OS updates is not configured it returns nil
 // if OS updates enforces latest we return the target version and deadline from the host's os_update_host record and "Pending" if the target version is not calculated
 // if OS updates does not enforce latest we return the minimum version and deadline from the config which is constants
-func getOSUpdateForHostDetails(svc *Service, ctx context.Context, host *fleet.Host, appConfig *fleet.AppConfig) (*string, *string, error) {
+func (svc *Service) getOSUpdateForHostDetails(ctx context.Context, host *fleet.Host, appConfig *fleet.AppConfig) (*string, *string, error) {
 	// Only Apple platforms have OS update settings here, so skip the (possibly
 	// team-scoped) config lookup entirely for everything else.
 	if !fleet.IsApplePlatform(host.Platform) {
@@ -2076,7 +2076,7 @@ func getOSUpdateForHostDetails(svc *Service, ctx context.Context, host *fleet.Ho
 			return osUpdateMinVersion, osUpdateDeadline, nil
 		}
 
-		// The host has not yet been computed it's target deadline and version.
+		// The host has not yet computed its target deadline and version.
 		pending := "Pending"
 		return &pending, &pending, nil
 	}

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -2026,7 +2026,7 @@ func (svc *Service) getHostDetails(ctx context.Context, host *fleet.Host, opts f
 
 // getOSUpdateForHostDetails returns the minimum OS version and deadline for a host.
 // If OS updates is not configured it returns nil
-// if OS updates enforces latest we return the target version and deadline from the host's os_update_host record and "TBD" if the target version is not calculated
+// if OS updates enforces latest we return the target version and deadline from the host's os_update_host record and "Pending" if the target version is not calculated
 // if OS updates does not enforce latest we return the minimum version and deadline from the config which is constants
 func getOSUpdateForHostDetails(svc *Service, ctx context.Context, host *fleet.Host, appConfig *fleet.AppConfig) (*string, *string, error) {
 	// Only Apple platforms have OS update settings here, so skip the (possibly
@@ -2076,7 +2076,9 @@ func getOSUpdateForHostDetails(svc *Service, ctx context.Context, host *fleet.Ho
 			return osUpdateMinVersion, osUpdateDeadline, nil
 		}
 
-		return nil, nil, nil
+		// The host has not yet been computed it's target deadline and version.
+		pending := "Pending"
+		return &pending, &pending, nil
 	}
 
 	// Extract from target and deadline from config.

--- a/server/service/hosts_test.go
+++ b/server/service/hosts_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/WatchBeam/clock"
+	"github.com/fleetdm/fleet/v4/pkg/optjson"
 	activity_api "github.com/fleetdm/fleet/v4/server/activity/api"
 	"github.com/fleetdm/fleet/v4/server/authz"
 	"github.com/fleetdm/fleet/v4/server/config"
@@ -1031,6 +1032,262 @@ func TestHostDetailsHostNameStatus(t *testing.T) {
 			return &fleet.AppConfig{MDM: fleet.MDM{EnabledAndConfigured: true}}, nil
 		}
 		ds.GetHostDeviceNameEnforcementFunc = func(ctx context.Context, hostUUID string) (*fleet.HostDeviceNameEnforcement, error) {
+			return nil, errors.New("db exploded")
+		}
+
+		ctx := license.NewContext(t.Context(), &fleet.LicenseInfo{Tier: fleet.TierPremium})
+		_, err := svc.getHostDetails(test.UserContext(ctx, test.UserAdmin),
+			&fleet.Host{ID: 42, Platform: "darwin", UUID: "test-uuid"}, fleet.HostDetailOptions{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "db exploded")
+	})
+}
+
+func TestHostDetailsOSUpdates(t *testing.T) {
+	ds := new(mock.Store)
+	svc := &Service{ds: ds}
+
+	ds.ListLabelsForHostFunc = func(ctx context.Context, hid uint) ([]*fleet.Label, error) { return nil, nil }
+	ds.ListPacksForHostFunc = func(ctx context.Context, hid uint) ([]*fleet.Pack, error) { return nil, nil }
+	ds.LoadHostSoftwareFunc = func(ctx context.Context, host *fleet.Host, includeCVEScores bool) error { return nil }
+	ds.ListPoliciesForHostFunc = func(ctx context.Context, host *fleet.Host) ([]*fleet.HostPolicy, error) { return nil, nil }
+	ds.ListHostBatteriesFunc = func(ctx context.Context, hostID uint) ([]*fleet.HostBattery, error) { return nil, nil }
+	ds.ListUpcomingHostMaintenanceWindowsFunc = func(ctx context.Context, hid uint) ([]*fleet.HostMaintenanceWindow, error) {
+		return nil, nil
+	}
+	ds.GetHostMDMMacOSSetupFunc = func(ctx context.Context, hid uint) (*fleet.HostMDMMacOSSetup, error) { return nil, nil }
+	ds.GetHostMDMAppleProfilesFunc = func(ctx context.Context, uuid string) ([]fleet.HostMDMAppleProfile, error) { return nil, nil }
+	ds.GetHostLockWipeStatusFunc = func(ctx context.Context, host *fleet.Host) (*fleet.HostLockWipeStatus, error) {
+		return &fleet.HostLockWipeStatus{}, nil
+	}
+	ds.ScimUserByHostIDFunc = func(ctx context.Context, hostID uint) (*fleet.ScimUser, error) { return nil, nil }
+	ds.ListHostDeviceMappingFunc = func(ctx context.Context, id uint) ([]*fleet.HostDeviceMapping, error) { return nil, nil }
+	ds.ConditionalAccessBypassedAtFunc = func(ctx context.Context, hostID uint) (*time.Time, error) { return nil, nil }
+	ds.GetHostCustomHostVitalsFunc = func(ctx context.Context, hostID uint) ([]fleet.HostCustomHostVital, error) {
+		return nil, nil
+	}
+	ds.IsHostDiskEncryptionKeyArchivedFunc = func(ctx context.Context, hostID uint) (bool, error) { return false, nil }
+	ds.GetNanoMDMEnrollmentDetailsFunc = func(ctx context.Context, hostUUID string) (*fleet.NanoMDMEnrollmentDetails, error) {
+		return &fleet.NanoMDMEnrollmentDetails{}, nil
+	}
+	ds.GetHostRecoveryLockPasswordStatusFunc = func(ctx context.Context, hostUUID string) (*fleet.HostMDMRecoveryLockPassword, error) {
+		return nil, nil
+	}
+	ds.GetHostManagedLocalAccountStatusFunc = func(ctx context.Context, hostUUID string) (*fleet.HostMDMManagedLocalAccount, error) {
+		return nil, nil
+	}
+	ds.GetHostDeviceNameEnforcementFunc = func(ctx context.Context, hostUUID string) (*fleet.HostDeviceNameEnforcement, error) {
+		return nil, nil
+	}
+
+	// enforceVersion builds settings pinned to a specific minimum version, the
+	// mode where the config itself carries the target and deadline.
+	enforceVersion := func(minimumVersion, deadline string) fleet.AppleOSUpdateSettings {
+		return fleet.AppleOSUpdateSettings{
+			MinimumVersion: optjson.SetString(minimumVersion),
+			Deadline:       optjson.SetString(deadline),
+		}
+	}
+	// enforceLatest builds "latest" settings, where the target version and
+	// deadline are resolved per host.
+	enforceLatest := func(deadlineDays int) fleet.AppleOSUpdateSettings {
+		return fleet.AppleOSUpdateSettings{
+			MinimumVersion: optjson.SetString(fleet.AppleOSUpdateLatestVersion),
+			DeadlineDays:   optjson.SetInt(deadlineDays),
+		}
+	}
+	deadline := time.Date(2026, 9, 15, 0, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name string
+		// mdm is the app config MDM settings; teamMDM, when non-nil, is what
+		// TeamLite reports for the host's team and must win over mdm.
+		mdm          fleet.MDM
+		teamMDM      *fleet.TeamMDM
+		platform     string
+		osUpdateHost *fleet.AppleSoftwareUpdateHost
+		// wantOSUpdateHostQueried asserts whether the per-host resolved row was
+		// looked up, which only happens in "latest" mode.
+		wantOSUpdateHostQueried bool
+		wantMinimumVersion      *string
+		wantDeadline            *string
+	}{
+		{
+			name:     "not configured",
+			mdm:      fleet.MDM{EnabledAndConfigured: true},
+			platform: "darwin",
+		},
+		{
+			name: "macOS specific version from app config",
+			mdm: fleet.MDM{
+				EnabledAndConfigured: true,
+				MacOSUpdates:         enforceVersion("15.6.1", "2026-09-15"),
+			},
+			platform:           "darwin",
+			wantMinimumVersion: new("15.6.1"),
+			wantDeadline:       new("2026-09-15"),
+		},
+		{
+			name: "iOS host reads the iOS settings",
+			mdm: fleet.MDM{
+				EnabledAndConfigured: true,
+				MacOSUpdates:         enforceVersion("15.6.1", "2026-09-15"),
+				IOSUpdates:           enforceVersion("18.7", "2026-10-01"),
+				IPadOSUpdates:        enforceVersion("18.6", "2026-11-01"),
+			},
+			platform:           "ios",
+			wantMinimumVersion: new("18.7"),
+			wantDeadline:       new("2026-10-01"),
+		},
+		{
+			name: "iPadOS host reads the iPadOS settings",
+			mdm: fleet.MDM{
+				EnabledAndConfigured: true,
+				MacOSUpdates:         enforceVersion("15.6.1", "2026-09-15"),
+				IOSUpdates:           enforceVersion("18.7", "2026-10-01"),
+				IPadOSUpdates:        enforceVersion("18.6", "2026-11-01"),
+			},
+			platform:           "ipados",
+			wantMinimumVersion: new("18.6"),
+			wantDeadline:       new("2026-11-01"),
+		},
+		{
+			name: "non-Apple platform never reports OS updates",
+			mdm: fleet.MDM{
+				EnabledAndConfigured: true,
+				MacOSUpdates:         enforceVersion("15.6.1", "2026-09-15"),
+			},
+			platform: "windows",
+		},
+		{
+			name: "latest with a resolved target",
+			mdm: fleet.MDM{
+				EnabledAndConfigured: true,
+				MacOSUpdates:         enforceLatest(14),
+			},
+			platform: "darwin",
+			osUpdateHost: &fleet.AppleSoftwareUpdateHost{
+				HostUUID:        "test-uuid",
+				TargetOSVersion: "26.1",
+				TargetDeadline:  &deadline,
+			},
+			wantOSUpdateHostQueried: true,
+			wantMinimumVersion:      new("26.1"),
+			wantDeadline:            new("2026-09-15"),
+		},
+		{
+			name: "latest with no row yet",
+			mdm: fleet.MDM{
+				EnabledAndConfigured: true,
+				MacOSUpdates:         enforceLatest(14),
+			},
+			platform:                "darwin",
+			wantOSUpdateHostQueried: true,
+		},
+		{
+			name: "latest with an unresolved target version",
+			mdm: fleet.MDM{
+				EnabledAndConfigured: true,
+				MacOSUpdates:         enforceLatest(14),
+			},
+			platform: "darwin",
+			osUpdateHost: &fleet.AppleSoftwareUpdateHost{
+				HostUUID:       "test-uuid",
+				TargetDeadline: &deadline,
+			},
+			wantOSUpdateHostQueried: true,
+		},
+		{
+			name: "latest with an unresolved deadline",
+			mdm: fleet.MDM{
+				EnabledAndConfigured: true,
+				MacOSUpdates:         enforceLatest(14),
+			},
+			platform: "darwin",
+			osUpdateHost: &fleet.AppleSoftwareUpdateHost{
+				HostUUID:        "test-uuid",
+				TargetOSVersion: "26.1",
+			},
+			wantOSUpdateHostQueried: true,
+		},
+		{
+			name: "team settings win over app config",
+			mdm: fleet.MDM{
+				EnabledAndConfigured: true,
+				MacOSUpdates:         enforceVersion("15.6.1", "2026-09-15"),
+			},
+			teamMDM:            &fleet.TeamMDM{MacOSUpdates: enforceVersion("26.0.1", "2026-12-24")},
+			platform:           "darwin",
+			wantMinimumVersion: new("26.0.1"),
+			wantDeadline:       new("2026-12-24"),
+		},
+		{
+			name: "team without OS updates configured overrides a configured app config",
+			mdm: fleet.MDM{
+				EnabledAndConfigured: true,
+				MacOSUpdates:         enforceVersion("15.6.1", "2026-09-15"),
+			},
+			teamMDM:  &fleet.TeamMDM{},
+			platform: "darwin",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+				return &fleet.AppConfig{MDM: c.mdm}, nil
+			}
+			ds.GetMDMWindowsBitLockerStatusFunc = func(ctx context.Context, host *fleet.Host) (*fleet.HostMDMDiskEncryption, error) {
+				return nil, nil
+			}
+			ds.TeamLiteFuncInvoked = false
+			ds.TeamLiteFunc = func(ctx context.Context, id uint) (*fleet.TeamLite, error) {
+				require.NotNil(t, c.teamMDM, "team config must not be loaded for a no-team host")
+				return &fleet.TeamLite{ID: id, Config: fleet.TeamConfigLite{MDM: *c.teamMDM}}, nil
+			}
+			ds.GetAppleOSUpdateHostByUUIDFuncInvoked = false
+			ds.GetAppleOSUpdateHostByUUIDFunc = func(ctx context.Context, hostUUID string) (*fleet.AppleSoftwareUpdateHost, error) {
+				require.Equal(t, "test-uuid", hostUUID)
+				return c.osUpdateHost, nil
+			}
+
+			host := &fleet.Host{ID: 42, Platform: c.platform, UUID: "test-uuid"}
+			if c.teamMDM != nil {
+				host.TeamID = new(uint(1))
+			}
+
+			ctx := license.NewContext(t.Context(), &fleet.LicenseInfo{Tier: fleet.TierPremium})
+			hd, err := svc.getHostDetails(test.UserContext(ctx, test.UserAdmin), host, fleet.HostDetailOptions{})
+			require.NoError(t, err)
+			require.NotNil(t, hd)
+
+			assert.Equal(t, c.teamMDM != nil, ds.TeamLiteFuncInvoked)
+			assert.Equal(t, c.wantOSUpdateHostQueried, ds.GetAppleOSUpdateHostByUUIDFuncInvoked)
+			assert.Equal(t, c.wantMinimumVersion, hd.OSUpdateMinimumVersion)
+			assert.Equal(t, c.wantDeadline, hd.OSUpdateDeadline)
+		})
+	}
+
+	t.Run("team lookup error propagates", func(t *testing.T) {
+		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+			return &fleet.AppConfig{MDM: fleet.MDM{EnabledAndConfigured: true}}, nil
+		}
+		ds.TeamLiteFunc = func(ctx context.Context, id uint) (*fleet.TeamLite, error) {
+			return nil, errors.New("no such team")
+		}
+
+		ctx := license.NewContext(t.Context(), &fleet.LicenseInfo{Tier: fleet.TierPremium})
+		_, err := svc.getHostDetails(test.UserContext(ctx, test.UserAdmin),
+			&fleet.Host{ID: 42, Platform: "darwin", UUID: "test-uuid", TeamID: new(uint(1))}, fleet.HostDetailOptions{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no such team")
+	})
+
+	t.Run("resolved OS update lookup error propagates", func(t *testing.T) {
+		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+			return &fleet.AppConfig{MDM: fleet.MDM{EnabledAndConfigured: true, MacOSUpdates: enforceLatest(14)}}, nil
+		}
+		ds.GetAppleOSUpdateHostByUUIDFunc = func(ctx context.Context, hostUUID string) (*fleet.AppleSoftwareUpdateHost, error) {
 			return nil, errors.New("db exploded")
 		}
 

--- a/server/service/hosts_test.go
+++ b/server/service/hosts_test.go
@@ -1183,32 +1183,8 @@ func TestHostDetailsOSUpdates(t *testing.T) {
 			},
 			platform:                "darwin",
 			wantOSUpdateHostQueried: true,
-		},
-		{
-			name: "latest with an unresolved target version",
-			mdm: fleet.MDM{
-				EnabledAndConfigured: true,
-				MacOSUpdates:         enforceLatest(14),
-			},
-			platform: "darwin",
-			osUpdateHost: &fleet.AppleSoftwareUpdateHost{
-				HostUUID:       "test-uuid",
-				TargetDeadline: &deadline,
-			},
-			wantOSUpdateHostQueried: true,
-		},
-		{
-			name: "latest with an unresolved deadline",
-			mdm: fleet.MDM{
-				EnabledAndConfigured: true,
-				MacOSUpdates:         enforceLatest(14),
-			},
-			platform: "darwin",
-			osUpdateHost: &fleet.AppleSoftwareUpdateHost{
-				HostUUID:        "test-uuid",
-				TargetOSVersion: "26.1",
-			},
-			wantOSUpdateHostQueried: true,
+			wantMinimumVersion:      new("Pending"),
+			wantDeadline:            new("Pending"),
 		},
 		{
 			name: "team settings win over app config",

--- a/server/service/integration_mdm_ddm_test.go
+++ b/server/service/integration_mdm_ddm_test.go
@@ -2512,6 +2512,7 @@ func (s *integrationMDMTestSuite) TestAppleDDMOSUpdatesTargetVariables() {
 
 	// === Phase 1: host syncs, target not ready -> pending with detail ===
 	_, _, initialVarsUpdated, identifier := readDecl()
+	require.NotNil(t, initialVarsUpdated)
 	resp, err := mdmDevice.DeclarativeManagement("declaration/configuration/" + identifier)
 	require.NoError(t, err)
 	body, err := io.ReadAll(resp.Body)

--- a/server/service/integration_mdm_ddm_test.go
+++ b/server/service/integration_mdm_ddm_test.go
@@ -8,14 +8,18 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/fleetdm/fleet/v4/pkg/mdm/mdmtest"
+	"github.com/fleetdm/fleet/v4/pkg/optjson"
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql/mysqltest"
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	fleetmdm "github.com/fleetdm/fleet/v4/server/mdm"
+	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
 	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/mdm"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/google/uuid"
@@ -2434,4 +2438,170 @@ func (s *integrationMDMTestSuite) TestAppleDDMCustomActivations() {
 		require.NoError(t, err)
 		require.JSONEq(t, string(content), string(decl.RawJSON))
 	})
+}
+
+// TestAppleDDMOSUpdatesTargetVariables is the end-to-end version of the OS-update
+// DDM sync flow against an enrolled macOS host:
+//  1. the host is assigned Fleet's macOS OS-updates declaration, which resolves
+//     $FLEET_VAR_HOST_TARGET_OS_VERSION / $FLEET_VAR_HOST_TARGET_OS_DEADLINE. Its
+//     target hasn't been computed yet, so the first DDM fetch defers the
+//     declaration: it is marked pending with a user-facing detail and served as
+//     an empty 200 (not failed).
+//  2. the reconcile cron (apple_mdm.HandleAppleMDMOSUpdates) computes the target
+//     from the cached Apple software-update assets and bumps the declaration for
+//     resend (status cleared, variables_updated_at advanced).
+//  3. the host re-syncs and now receives the fully resolved declaration.
+func (s *integrationMDMTestSuite) TestAppleDDMOSUpdatesTargetVariables() {
+	t := s.T()
+	ctx := t.Context()
+
+	// Enrolled macOS host, moved into a team configured for automatic OS updates.
+	host, mdmDevice := createHostThenEnrollMDM(s.ds, s.server.URL, t)
+
+	team := &fleet.Team{Name: t.Name() + "-team"}
+	var createTeamResp teamResponse
+	s.DoJSON("POST", "/api/latest/fleet/teams", team, http.StatusOK, &createTeamResp)
+	require.NotZero(t, createTeamResp.Team.ID)
+	team = createTeamResp.Team
+	s.Do("POST", "/api/v1/fleet/hosts/transfer",
+		addHostsToTeamRequest{TeamID: &team.ID, HostIDs: []uint{host.ID}}, http.StatusOK)
+
+	// Set the team's macOS updates to "latest" so the cron computes a per-host
+	// target. Written straight to the datastore to keep this test focused on the
+	// DDM sync piece rather than the settings endpoint's validation surface.
+	team.Config.MDM.MacOSUpdates = fleet.AppleOSUpdateSettings{
+		MinimumVersion: optjson.SetString("latest"),
+		Deadline:       optjson.SetString(""),
+	}
+	_, err := s.ds.SaveTeam(ctx, team)
+	require.NoError(t, err)
+
+	const (
+		deviceID       = "Mac14,2"
+		declIdentifier = "com.fleetdm.fleet.mdm.os-updates.macos"
+	)
+	rawDecl := []byte(fmt.Sprintf(`{
+	"Type": "com.apple.configuration.softwareupdate.enforcement.specific",
+	"Identifier": "%s",
+	"Payload": {
+		"TargetOSVersion": "$FLEET_VAR_HOST_TARGET_OS_VERSION",
+		"TargetLocalDateTime": "$FLEET_VAR_HOST_TARGET_OS_DEADLINE"
+	}
+}`, declIdentifier))
+
+	decl, err := s.ds.NewMDMAppleDeclaration(ctx, &fleet.MDMAppleDeclaration{
+		DeclarationUUID: uuid.NewString(),
+		TeamID:          &team.ID,
+		Name:            fleetmdm.FleetMacOSUpdatesProfileName,
+		Identifier:      declIdentifier,
+		RawJSON:         rawDecl,
+		Scope:           fleet.PayloadScopeSystem,
+	}, []fleet.FleetVarName{fleet.FleetVarHostTargetOSVersion, fleet.FleetVarHostTargetOSDeadline})
+	require.NoError(t, err)
+
+	// Assign the declaration to the host the way the reconciler would:
+	// variables_updated_at set (so the sync path attempts resolution), status NULL.
+	initialVarsUpdated := time.Now().UTC().Add(-time.Hour).Truncate(time.Microsecond)
+	mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		var token string
+		if err := sqlx.GetContext(ctx, q, &token,
+			"SELECT HEX(token) FROM mdm_apple_declarations WHERE declaration_uuid = ?", decl.DeclarationUUID); err != nil {
+			return err
+		}
+		_, err := q.ExecContext(ctx, `
+			INSERT INTO host_mdm_apple_declarations
+				(host_uuid, declaration_uuid, status, operation_type, token, declaration_identifier, declaration_name, scope, variables_updated_at)
+			VALUES (?, ?, NULL, 'install', UNHEX(?), ?, ?, 'System', ?)`,
+			host.UUID, decl.DeclarationUUID, token, declIdentifier, fleetmdm.FleetMacOSUpdatesProfileName, initialVarsUpdated)
+		return err
+	})
+
+	// The host's software-update device id is captured, but no target computed yet.
+	require.NoError(t, s.ds.InsertAppleSoftwareUpdateDeviceID(ctx, host.UUID, deviceID))
+
+	readDecl := func() (status *string, detail string, varsUpdatedAt *time.Time) {
+		var row struct {
+			Status      *string    `db:"status"`
+			Detail      string     `db:"detail"`
+			VariablesAt *time.Time `db:"variables_updated_at"`
+		}
+		mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+			return sqlx.GetContext(ctx, q, &row,
+				`SELECT status, COALESCE(detail, '') AS detail, variables_updated_at
+				 FROM host_mdm_apple_declarations WHERE host_uuid = ? AND declaration_uuid = ?`,
+				host.UUID, decl.DeclarationUUID)
+		})
+		return row.Status, row.Detail, row.VariablesAt
+	}
+
+	// === Phase 1: host syncs, target not ready -> pending with detail ===
+
+	resp, err := mdmDevice.DeclarativeManagement("declaration/configuration/" + declIdentifier)
+	require.NoError(t, err)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Empty(t, bytes.TrimSpace(body), "an unresolvable declaration is served as an empty 200")
+
+	status, detail, _ := readDecl()
+	require.NotNil(t, status)
+	require.Equal(t, string(fleet.MDMDeliveryPending), *status)
+	require.Contains(t, detail, "not yet available")
+
+	// === Phase 2: reconcile cron computes the target and bumps for resend ===
+
+	// Seed the cached Apple software-update assets so the cron resolves a version
+	// for the device without reaching out to GDMF (recent updated_at short-circuits
+	// the network fetch).
+	require.NoError(t, s.ds.UpsertAppleOSUpdates(ctx, map[string][]fleet.OSUpdateAsset{
+		"macos": {{
+			ProductVersion:   "15.1",
+			Build:            "23B74",
+			PostingDate:      "2024-10-28",
+			ExpirationDate:   "2025-10-28",
+			SupportedDevices: []string{deviceID},
+		}},
+	}))
+
+	require.NoError(t, apple_mdm.HandleAppleMDMOSUpdates(ctx, s.ds, slog.New(slog.NewTextHandler(io.Discard, nil))))
+
+	// The tracking row now carries a resolved target.
+	osHost, err := s.ds.GetAppleOSUpdateHostByUUID(ctx, host.UUID)
+	require.NoError(t, err)
+	require.NotNil(t, osHost)
+	require.Equal(t, "15.1", osHost.TargetOSVersion)
+	require.NotNil(t, osHost.TargetDeadline)
+	require.NotNil(t, osHost.ResolvedAt)
+
+	// The declaration was bumped for resend: status cleared, variables_updated_at advanced.
+	status, _, bumped := readDecl()
+	require.Nil(t, status, "resend clears status to NULL")
+	require.NotNil(t, bumped)
+	require.True(t, bumped.After(initialVarsUpdated), "variables_updated_at should be advanced for resend")
+
+	// === Phase 3: host re-syncs and receives the resolved declaration ===
+
+	resp, err = mdmDevice.DeclarativeManagement("declaration/configuration/" + declIdentifier)
+	require.NoError(t, err)
+	body, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.NotContains(t, string(body), "$FLEET_VAR")
+
+	var served struct {
+		Identifier string
+		Payload    struct {
+			TargetOSVersion     string
+			TargetLocalDateTime string
+		}
+		ServerToken string
+	}
+	require.NoError(t, json.Unmarshal(body, &served))
+	require.Equal(t, declIdentifier, served.Identifier)
+	require.Equal(t, "15.1", served.Payload.TargetOSVersion)
+	require.NotEmpty(t, served.ServerToken)
+	gotDeadline, err := time.Parse("2006-01-02T15:04:05", served.Payload.TargetLocalDateTime)
+	require.NoError(t, err)
+	wantDeadline := fmt.Sprintf("%sT12:00:00", osHost.TargetDeadline.Format(time.DateOnly))
+	require.Equal(t, wantDeadline, gotDeadline.Format("2006-01-02T15:04:05"), "want %s got %s", wantDeadline, gotDeadline)
 }

--- a/server/service/integration_mdm_ddm_test.go
+++ b/server/service/integration_mdm_ddm_test.go
@@ -2539,6 +2539,11 @@ func (s *integrationMDMTestSuite) TestAppleDDMOSUpdatesTargetVariables() {
 			SupportedDevices: []string{deviceID},
 		}},
 	}))
+	// Drop these synthetic assets afterwards; their recent updated_at would otherwise short-circuit
+	// the GDMF fetch for later tests in this suite that need the real asset set.
+	t.Cleanup(func() {
+		mysqltest.TruncateTables(t, s.ds, "apple_software_update_assets")
+	})
 
 	require.NoError(t, apple_mdm.HandleAppleMDMOSUpdates(ctx, s.ds, slog.New(slog.NewTextHandler(io.Discard, nil))))
 

--- a/server/service/integration_mdm_ddm_test.go
+++ b/server/service/integration_mdm_ddm_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/fleetdm/fleet/v4/pkg/optjson"
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql/mysqltest"
 	"github.com/fleetdm/fleet/v4/server/fleet"
-	fleetmdm "github.com/fleetdm/fleet/v4/server/mdm"
+	common_mdm "github.com/fleetdm/fleet/v4/server/mdm"
 	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
 	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/mdm"
 	"github.com/fleetdm/fleet/v4/server/ptr"
@@ -2466,84 +2466,60 @@ func (s *integrationMDMTestSuite) TestAppleDDMOSUpdatesTargetVariables() {
 	s.Do("POST", "/api/v1/fleet/hosts/transfer",
 		addHostsToTeamRequest{TeamID: &team.ID, HostIDs: []uint{host.ID}}, http.StatusOK)
 
-	// Set the team's macOS updates to "latest" so the cron computes a per-host
-	// target. Written straight to the datastore to keep this test focused on the
-	// DDM sync piece rather than the settings endpoint's validation surface.
-	team.Config.MDM.MacOSUpdates = fleet.AppleOSUpdateSettings{
-		MinimumVersion: optjson.SetString("latest"),
-		Deadline:       optjson.SetString(""),
+	var modifyTeamRes teamResponse
+	teamPayload := &fleet.TeamPayload{
+		MDM: &fleet.TeamPayloadMDM{
+			MacOSUpdates: &fleet.AppleOSUpdateSettings{
+				MinimumVersion: optjson.SetString("latest"),
+				DeadlineDays:   optjson.SetInt(2),
+			},
+		},
 	}
-	_, err := s.ds.SaveTeam(ctx, team)
+	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", team.ID), teamPayload, http.StatusOK, &modifyTeamRes)
+
+	// Fleet's macOS OS-updates declaration is scoped to the built-in "macOS 14+"
+	// dynamic label, so the host has to be a member of it for the reconciler to
+	// assign the declaration.
+	lblIDs, err := s.ds.LabelIDsByName(ctx, []string{fleet.BuiltinLabelMacOS14Plus}, fleet.TeamFilter{})
 	require.NoError(t, err)
+	require.Contains(t, lblIDs, fleet.BuiltinLabelMacOS14Plus)
+	require.NoError(t, s.ds.RecordLabelQueryExecutions(ctx, host,
+		map[uint]*bool{lblIDs[fleet.BuiltinLabelMacOS14Plus]: new(true)}, time.Now(), false))
 
-	const (
-		deviceID       = "Mac14,2"
-		declIdentifier = "com.fleetdm.fleet.mdm.os-updates.macos"
-	)
-	rawDecl := []byte(fmt.Sprintf(`{
-	"Type": "com.apple.configuration.softwareupdate.enforcement.specific",
-	"Identifier": "%s",
-	"Payload": {
-		"TargetOSVersion": "$FLEET_VAR_HOST_TARGET_OS_VERSION",
-		"TargetLocalDateTime": "$FLEET_VAR_HOST_TARGET_OS_DEADLINE"
-	}
-}`, declIdentifier))
+	// The reconcile cron assigns the declaration to the host.
+	s.awaitTriggerProfileSchedule(t)
 
-	decl, err := s.ds.NewMDMAppleDeclaration(ctx, &fleet.MDMAppleDeclaration{
-		DeclarationUUID: uuid.NewString(),
-		TeamID:          &team.ID,
-		Name:            fleetmdm.FleetMacOSUpdatesProfileName,
-		Identifier:      declIdentifier,
-		RawJSON:         rawDecl,
-		Scope:           fleet.PayloadScopeSystem,
-	}, []fleet.FleetVarName{fleet.FleetVarHostTargetOSVersion, fleet.FleetVarHostTargetOSDeadline})
-	require.NoError(t, err)
-
-	// Assign the declaration to the host the way the reconciler would:
-	// variables_updated_at set (so the sync path attempts resolution), status NULL.
-	initialVarsUpdated := time.Now().UTC().Add(-time.Hour).Truncate(time.Microsecond)
-	mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
-		var token string
-		if err := sqlx.GetContext(ctx, q, &token,
-			"SELECT HEX(token) FROM mdm_apple_declarations WHERE declaration_uuid = ?", decl.DeclarationUUID); err != nil {
-			return err
-		}
-		_, err := q.ExecContext(ctx, `
-			INSERT INTO host_mdm_apple_declarations
-				(host_uuid, declaration_uuid, status, operation_type, token, declaration_identifier, declaration_name, scope, variables_updated_at)
-			VALUES (?, ?, NULL, 'install', UNHEX(?), ?, ?, 'System', ?)`,
-			host.UUID, decl.DeclarationUUID, token, declIdentifier, fleetmdm.FleetMacOSUpdatesProfileName, initialVarsUpdated)
-		return err
-	})
+	const deviceID = "Mac14,2"
 
 	// The host's software-update device id is captured, but no target computed yet.
 	require.NoError(t, s.ds.InsertAppleSoftwareUpdateDeviceID(ctx, host.UUID, deviceID))
 
-	readDecl := func() (status *string, detail string, varsUpdatedAt *time.Time) {
+	readDecl := func() (status *string, detail string, varsUpdatedAt *time.Time, identifier string) {
 		var row struct {
 			Status      *string    `db:"status"`
 			Detail      string     `db:"detail"`
 			VariablesAt *time.Time `db:"variables_updated_at"`
+			Identifier  string     `db:"declaration_identifier"`
 		}
 		mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
 			return sqlx.GetContext(ctx, q, &row,
-				`SELECT status, COALESCE(detail, '') AS detail, variables_updated_at
-				 FROM host_mdm_apple_declarations WHERE host_uuid = ? AND declaration_uuid = ?`,
-				host.UUID, decl.DeclarationUUID)
+				`SELECT status, COALESCE(detail, '') AS detail, variables_updated_at, declaration_identifier
+				 FROM host_mdm_apple_declarations WHERE host_uuid = ? AND declaration_name = ?`,
+				host.UUID, common_mdm.FleetMacOSUpdatesProfileName)
 		})
-		return row.Status, row.Detail, row.VariablesAt
+		return row.Status, row.Detail, row.VariablesAt, row.Identifier
 	}
 
 	// === Phase 1: host syncs, target not ready -> pending with detail ===
-
-	resp, err := mdmDevice.DeclarativeManagement("declaration/configuration/" + declIdentifier)
+	_, _, initialVarsUpdated, identifier := readDecl()
+	resp, err := mdmDevice.DeclarativeManagement("declaration/configuration/" + identifier)
 	require.NoError(t, err)
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	require.NoError(t, resp.Body.Close())
 	require.Empty(t, bytes.TrimSpace(body), "an unresolvable declaration is served as an empty 200")
 
-	status, detail, _ := readDecl()
+	status, detail, _, _ := readDecl()
 	require.NotNil(t, status)
 	require.Equal(t, string(fleet.MDMDeliveryPending), *status)
 	require.Contains(t, detail, "not yet available")
@@ -2574,14 +2550,14 @@ func (s *integrationMDMTestSuite) TestAppleDDMOSUpdatesTargetVariables() {
 	require.NotNil(t, osHost.ResolvedAt)
 
 	// The declaration was bumped for resend: status cleared, variables_updated_at advanced.
-	status, _, bumped := readDecl()
+	status, _, bumped, _ := readDecl()
 	require.Nil(t, status, "resend clears status to NULL")
 	require.NotNil(t, bumped)
-	require.True(t, bumped.After(initialVarsUpdated), "variables_updated_at should be advanced for resend")
+	require.True(t, bumped.After(*initialVarsUpdated), "variables_updated_at should be advanced for resend")
 
 	// === Phase 3: host re-syncs and receives the resolved declaration ===
 
-	resp, err = mdmDevice.DeclarativeManagement("declaration/configuration/" + declIdentifier)
+	resp, err = mdmDevice.DeclarativeManagement("declaration/configuration/" + identifier)
 	require.NoError(t, err)
 	body, err = io.ReadAll(resp.Body)
 	require.NoError(t, err)
@@ -2597,7 +2573,7 @@ func (s *integrationMDMTestSuite) TestAppleDDMOSUpdatesTargetVariables() {
 		ServerToken string
 	}
 	require.NoError(t, json.Unmarshal(body, &served))
-	require.Equal(t, declIdentifier, served.Identifier)
+	require.Equal(t, identifier, served.Identifier)
 	require.Equal(t, "15.1", served.Payload.TargetOSVersion)
 	require.NotEmpty(t, served.ServerToken)
 	gotDeadline, err := time.Parse("2006-01-02T15:04:05", served.Payload.TargetLocalDateTime)

--- a/server/service/integration_mdm_dep_test.go
+++ b/server/service/integration_mdm_dep_test.go
@@ -2388,6 +2388,10 @@ func (s *integrationMDMTestSuite) TestEnforceMiniumOSVersion() {
 		}
 	}))
 	s.runDEPSchedule()
+	// The OS updates cron only pulls fresh assets from GDMF when the cached ones are missing or
+	// older than 24h, so any assets seeded by an earlier test in this suite would make it skip the
+	// fetch and leave us without the test data this test relies on.
+	mysqltest.TruncateTables(t, s.ds, "apple_software_update_assets")
 	s.runAppleOSUpdatesSchedule()
 
 	// confirm that the devices were created

--- a/server/service/integration_mdm_dep_test.go
+++ b/server/service/integration_mdm_dep_test.go
@@ -2388,6 +2388,7 @@ func (s *integrationMDMTestSuite) TestEnforceMiniumOSVersion() {
 		}
 	}))
 	s.runDEPSchedule()
+	s.runAppleOSUpdatesSchedule()
 
 	// confirm that the devices were created
 	listHostsRes := listHostsResponse{}

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -125,11 +125,13 @@ type integrationMDMTestSuite struct {
 	integrationsSchedule         *schedule.Schedule
 	cleanupsSchedule             *schedule.Schedule
 	appleMDMWorkerSchedule       *schedule.Schedule
+	appleOSUpdatesSchedule       *schedule.Schedule
 	onProfileJobDone             func() // function called when profileSchedule.Trigger() job completed
 	onAndroidProfileJobDone      func() // function called when androidProfileSchedule.Trigger() job completed
 	onIntegrationsScheduleDone   func() // function called when integrationsSchedule.Trigger() job completed
 	onCleanupScheduleDone        func() // function called when cleanupsSchedule.Trigger() job completed
 	onAppleMDMWorkerScheduleDone func() // function called when appleMDMWorkerSchedule.Trigger() job completed
+	onAppleOSUpdatesScheduleDone func() // function called when appleOSUpdatesSchedule.Trigger() job completed
 	mdmStorage                   *mysql.NanoMDMStorage
 	worker                       *worker.Worker
 	appleMDMWorker               *worker.Worker
@@ -301,6 +303,7 @@ func (s *integrationMDMTestSuite) SetupSuite() {
 	var cleanupsSchedule *schedule.Schedule
 	var androidProfileSchedule *schedule.Schedule
 	var appleMDMWorkerSchedule *schedule.Schedule
+	var appleOSUpdatesSchedule *schedule.Schedule
 	cronLog := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	if os.Getenv("FLEET_INTEGRATION_TESTS_DISABLE_LOG") != "" {
 		cronLog = slog.New(slog.DiscardHandler)
@@ -418,6 +421,23 @@ func (s *integrationMDMTestSuite) SetupSuite() {
 						}),
 					)
 					return appleMDMWorkerSchedule, nil
+				}
+			},
+			func(ctx context.Context, ds fleet.Datastore) fleet.NewCronScheduleFunc {
+				return func() (fleet.CronSchedule, error) {
+					const name = string(fleet.CronAppleMDMOSUpdatesSchedule)
+					logger := cronLog
+					appleOSUpdatesSchedule = schedule.New(
+						ctx, name, s.T().Name(), 1*time.Hour, ds, ds,
+						schedule.WithLogger(logger),
+						schedule.WithJob("apple_os_updates", func(ctx context.Context) error {
+							if s.onAppleOSUpdatesScheduleDone != nil {
+								defer s.onAppleOSUpdatesScheduleDone()
+							}
+							return apple_mdm.HandleAppleMDMOSUpdates(ctx, ds, logger)
+						}),
+					)
+					return appleOSUpdatesSchedule, nil
 				}
 			},
 			func(ctx context.Context, ds fleet.Datastore) fleet.NewCronScheduleFunc {
@@ -551,6 +571,7 @@ func (s *integrationMDMTestSuite) SetupSuite() {
 	s.cleanupsSchedule = cleanupsSchedule
 	s.androidProfileSchedule = androidProfileSchedule
 	s.appleMDMWorkerSchedule = appleMDMWorkerSchedule
+	s.appleOSUpdatesSchedule = appleOSUpdatesSchedule
 	s.mdmStorage = mdmStorage
 	s.mdmCommander = mdmCommander
 	s.logger = serverLogger
@@ -11107,6 +11128,30 @@ func (s *integrationMDMTestSuite) runDEPSchedule() {
 	fleetSyncer := apple_mdm.NewDEPService(s.ds, s.depStorage, s.logger)
 	err := fleetSyncer.RunAssigner(ctx)
 	require.NoError(s.T(), err)
+}
+
+func (s *integrationMDMTestSuite) runAppleOSUpdatesSchedule() {
+	ch := make(chan bool)
+	var once sync.Once
+	s.onAppleOSUpdatesScheduleDone = func() {
+		once.Do(func() { close(ch) })
+	}
+
+	var (
+		didTrigger bool
+		err        error
+	)
+	for range 10 {
+		_, didTrigger, err = s.appleOSUpdatesSchedule.Trigger(s.T().Context())
+		require.NoError(s.T(), err)
+		if didTrigger {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	require.True(s.T(), didTrigger, "apple os updates schedule did not trigger after 1 second of retries")
+
+	<-ch
 }
 
 func (s *integrationMDMTestSuite) runIntegrationsSchedule() {

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -11143,15 +11143,19 @@ func (s *integrationMDMTestSuite) runAppleOSUpdatesSchedule() {
 	)
 	for range 10 {
 		_, didTrigger, err = s.appleOSUpdatesSchedule.Trigger(s.T().Context())
-		require.NoError(s.T(), err)
+		s.Require().NoError(err)
 		if didTrigger {
 			break
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
-	require.True(s.T(), didTrigger, "apple os updates schedule did not trigger after 1 second of retries")
+	s.Require().True(didTrigger, "apple os updates schedule did not trigger after 1 second of retries")
 
-	<-ch
+	select {
+	case <-ch:
+	case <-time.After(30 * time.Second):
+		s.T().Fatal("apple os updates schedule did not complete")
+	}
 }
 
 func (s *integrationMDMTestSuite) runIntegrationsSchedule() {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #47715 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic Apple OS update synchronization and reconciliation.
  * Apple devices can receive targeted minimum OS versions and enforcement deadlines.
  * Host details now display applicable Apple OS update requirements.
  * Updates are selected based on device compatibility, platform, and team configuration.
  * Cached update information is refreshed and stale entries are removed.
  * Pending targets are retried, with declarations resent when resolved.
* **Bug Fixes**
  * Improved handling of unavailable targets and unsupported devices.
  * Prevented unresolved update declarations from being incorrectly marked as failed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->