### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/akiflow/darwin.json
+++ b/ee/maintained-apps/outputs/akiflow/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.78.16",
+      "version": "2.80.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.akiflow.akiflow';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.akiflow.akiflow' AND version_compare(bundle_short_version, '2.78.16') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.akiflow.akiflow' AND version_compare(bundle_short_version, '2.80.3') < 0);"
       },
-      "installer_url": "https://download.akiflow.com/builds/Akiflow-2.78.16-d29d46e9-universal.dmg",
+      "installer_url": "https://download.akiflow.com/builds/Akiflow-2.80.3-d68751d9-universal.dmg",
       "install_script_ref": "7d580667",
       "uninstall_script_ref": "9d10ecef",
-      "sha256": "61a20803fb8799bd2297cde9203c685eeac52b023140a642eca4bee9d633022e",
+      "sha256": "17564e664216c05dbee118b9581ec25a0c07d2d3769224ce87a81b6509dfa73f",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/firefox@nightly/darwin.json
+++ b/ee/maintained-apps/outputs/firefox@nightly/darwin.json
@@ -4,12 +4,12 @@
       "version": "155.0a1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15526.8.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15526.8.5') < 0);"
       },
-      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/08/2026-08-04-21-29-19-mozilla-central/firefox-155.0a1.en-US.mac.dmg",
+      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/08/2026-08-05-09-21-15-mozilla-central/firefox-155.0a1.en-US.mac.dmg",
       "install_script_ref": "d9c4cf87",
       "uninstall_script_ref": "0661f848",
-      "sha256": "8c2805d4d6d6611f1ecf864d6fc3ae30746aaf41eb3cccad480157ada03e9a3e",
+      "sha256": "7c5c2d78618692314a7ead5453c7e8bd6ebfde982eb82e4c4a8ce07f8f75c6b9",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/lulu/darwin.json
+++ b/ee/maintained-apps/outputs/lulu/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.5.0",
+      "version": "4.5.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.objective-see.lulu.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.objective-see.lulu.app' AND version_compare(bundle_short_version, '4.5.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.objective-see.lulu.app' AND version_compare(bundle_short_version, '4.5.1') < 0);"
       },
-      "installer_url": "https://github.com/objective-see/LuLu/releases/download/v4.5.0/LuLu_4.5.0.dmg",
+      "installer_url": "https://github.com/objective-see/LuLu/releases/download/v4.5.1/LuLu_4.5.1.dmg",
       "install_script_ref": "efe18b37",
       "uninstall_script_ref": "afb1dcbf",
-      "sha256": "33b624ccf3640d2708993885e2ae7a266c3ec4ee0c3784dc9036e95368664cb1",
+      "sha256": "98f4d3427f4c6fccf9680fed22879be90a5ae81e80eb8616c1d758755b6bb624",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/pdfsam-basic/darwin.json
+++ b/ee/maintained-apps/outputs/pdfsam-basic/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "6.0.4",
+      "version": "6.0.5",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.pdfsam.modules';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.pdfsam.modules' AND version_compare(bundle_short_version, '6.0.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.pdfsam.modules' AND version_compare(bundle_short_version, '6.0.5') < 0);"
       },
-      "installer_url": "https://github.com/torakiki/pdfsam/releases/download/v6.0.4/pdfsam-basic-6.0.4-macos-arm64.dmg",
+      "installer_url": "https://github.com/torakiki/pdfsam/releases/download/v6.0.5/pdfsam-basic-6.0.5-macos-arm64.dmg",
       "install_script_ref": "86d9663b",
       "uninstall_script_ref": "4ae3e223",
-      "sha256": "e42b053ccfc7172dc23bfb615eb9328d78585e61cbc43c16b6ca13734099046e",
+      "sha256": "61a1644dbe71b063e8b302c430e4285daf29c8013bdd729e7c3592cf9d0a915a",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/textexpander/darwin.json
+++ b/ee/maintained-apps/outputs/textexpander/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "8.4.5",
+      "version": "8.4.6",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.smileonmymac.textexpander';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.smileonmymac.textexpander' AND version_compare(bundle_short_version, '8.4.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.smileonmymac.textexpander' AND version_compare(bundle_short_version, '8.4.6') < 0);"
       },
-      "installer_url": "https://cdn.textexpander.com/mac/845.4/TextExpander_8.4.5.dmg",
+      "installer_url": "https://cdn.textexpander.com/mac/846.3/TextExpander_8.4.6.dmg",
       "install_script_ref": "b2126808",
       "uninstall_script_ref": "86a75cf4",
-      "sha256": "75815e541629f25cf1aa35ccf257f9c593d8def1d20335ecb1b3b3e1e9da6ef5",
+      "sha256": "e517d9e7d80541aecb1f56b94c0a7770fd7efb8c0ba5b32ec4ee47ecd3a30ef8",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated macOS app definitions for Akiflow, Firefox Nightly, LuLu, PDFsam Basic, and TextExpander to point to newer versions.
  * Refreshed download links, version checks, and checksums so installs use the latest available packages.
  * Kept existing install and uninstall behavior unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->