### PR TITLE
Unfreeze Comet (macOS)

### DIFF
--- a/ee/maintained-apps/inputs/homebrew/comet.json
+++ b/ee/maintained-apps/inputs/homebrew/comet.json
@@ -4,6 +4,5 @@
   "unique_identifier": "ai.perplexity.comet",
   "token": "comet",
   "installer_format": "dmg",
-  "default_categories": ["Browsers"],
-  "frozen": true
+  "default_categories": ["Browsers"]
 }

--- a/ee/maintained-apps/outputs/comet/darwin.json
+++ b/ee/maintained-apps/outputs/comet/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "148.0.7778.1016",
+      "version": "145.2.7632.4581",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'ai.perplexity.comet';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'ai.perplexity.comet' AND version_compare(bundle_short_version, '148.0.7778.1016') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'ai.perplexity.comet' AND version_compare(bundle_short_version, '145.2.7632.4581') < 0);"
       },
       "installer_url": "https://www.perplexity.ai/rest/browser/download?channel=stable&platform=mac_arm64",
       "install_script_ref": "702b27b8",


### PR DESCRIPTION
**Related issue:** NA

Automated unfreeze probe. Removes `"frozen": true` and regenerates the output manifest so
`test-fma-darwin-pr-only` can validate `comet/darwin` at its current upstream version.

Frozen since: 2026-08-03
Version: 148.0.7778.1016 -> 145.2.7632.4581

⚠️ Note: this regeneration moves the manifest *backwards*. The frozen output pinned a version
higher than the version Homebrew's cask currently declares, so merging this would downgrade the
manifest. Worth understanding why before merging, even if validation passes.

Draft until validation reports. Merge only if the FMA checks are green and the validate shard
actually ran for this slug.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5kBssP7AEw7yNmVmH8xfp)_