### PR TITLE
Unfreeze Disk Drill (macOS)

### DIFF
--- a/ee/maintained-apps/inputs/homebrew/disk-drill.json
+++ b/ee/maintained-apps/inputs/homebrew/disk-drill.json
@@ -6,6 +6,5 @@
   "slug": "disk-drill/darwin",
   "default_categories": [
     "Productivity"
-  ],
-  "frozen": true
+  ]
 }

--- a/ee/maintained-apps/outputs/disk-drill/darwin.json
+++ b/ee/maintained-apps/outputs/disk-drill/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "6.3",
+      "version": "6.2.2219",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.cleverfiles.DiskDrill-setapp';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.cleverfiles.DiskDrill-setapp' AND version_compare(bundle_short_version, '6.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.cleverfiles.DiskDrill-setapp' AND version_compare(bundle_short_version, '6.2.2219') < 0);"
       },
       "installer_url": "https://dl.cleverfiles.com/diskdrill.dmg",
       "install_script_ref": "3c6e58b0",


### PR DESCRIPTION
**Related issue:** NA

Automated unfreeze probe. Removes `"frozen": true` and regenerates the output manifest so
`test-fma-darwin-pr-only` can validate `disk-drill/darwin` at its current upstream version.

Frozen since: 2026-08-03
Version: 6.3 -> 6.2.2219

⚠️ Note: this regeneration moves the manifest *backwards*. The frozen output pinned a version
higher than the version Homebrew's cask currently declares, so merging this would downgrade the
manifest. Worth understanding why before merging, even if validation passes.

Draft until validation reports. Merge only if the FMA checks are green and the validate shard
actually ran for this slug.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5kBssP7AEw7yNmVmH8xfp)_