### PR TITLE
Unfreeze Visual Paradigm (macOS)

### DIFF
--- a/ee/maintained-apps/inputs/homebrew/visual-paradigm.json
+++ b/ee/maintained-apps/inputs/homebrew/visual-paradigm.json
@@ -6,6 +6,5 @@
   "slug": "visual-paradigm/darwin",
   "default_categories": [
     "Productivity"
-  ],
-  "frozen": true
+  ]
 }

--- a/ee/maintained-apps/outputs/visual-paradigm/darwin.json
+++ b/ee/maintained-apps/outputs/visual-paradigm/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "18.1",
+      "version": "18.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.install4j.1106-5897-7327-6550.5';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.install4j.1106-5897-7327-6550.5' AND version_compare(bundle_short_version, '18.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.install4j.1106-5897-7327-6550.5' AND version_compare(bundle_short_version, '18.0') < 0);"
       },
-      "installer_url": "https://usa15-dl.visual-paradigm.com/visual-paradigm/vp18.1/20260628/Visual_Paradigm_18_1_20260628_OSX_AArch64.dmg",
+      "installer_url": "https://www.visual-paradigm.com/downloads/vp18.0/20260521/Visual_Paradigm_18_0_20260521_OSX_AArch64.dmg",
       "install_script_ref": "03498242",
       "uninstall_script_ref": "f2a153c1",
-      "sha256": "665dcd9f3b74e8ee09201567429fd7e5105a8d72a3bb8804d72d0f4f13444cd5",
+      "sha256": "725c3c81d254d32c7a9f920d23d14a7694be30c52c99d28d09c457f2a24ddd24",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
**Related issue:** NA

Automated unfreeze probe. Removes `"frozen": true` and regenerates the output manifest so
`test-fma-darwin-pr-only` can validate `visual-paradigm/darwin` at its current upstream version.

Frozen since: 2026-08-03
Version: 18.1 -> 18.0

⚠️ Note: this regeneration moves the manifest *backwards*. The frozen output pinned 18.1 while
Homebrew's cask currently declares `18.0,20260521`, so merging this would downgrade the manifest.
Worth understanding why before merging, even if validation passes.

Draft until validation reports. Merge only if the FMA checks are green and the validate shard
actually ran for this slug.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5kBssP7AEw7yNmVmH8xfp)_