### PR TITLE
Unfreeze FireAlpaca (macOS)

### DIFF
--- a/ee/maintained-apps/inputs/homebrew/firealpaca.json
+++ b/ee/maintained-apps/inputs/homebrew/firealpaca.json
@@ -6,6 +6,5 @@
   "slug": "firealpaca/darwin",
   "default_categories": [
     "Productivity"
-  ],
-  "frozen": true
+  ]
 }

--- a/ee/maintained-apps/outputs/firealpaca/darwin.json
+++ b/ee/maintained-apps/outputs/firealpaca/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "2.15.2",
+      "version": "2.16.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.firealpaca';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.firealpaca' AND version_compare(bundle_short_version, '2.15.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.firealpaca' AND version_compare(bundle_short_version, '2.16.0') < 0);"
       },
       "installer_url": "https://firealpaca.com/download/mac",
       "install_script_ref": "a03f6a1f",


### PR DESCRIPTION
**Related issue:** NA

Automated unfreeze probe. Removes `"frozen": true` and regenerates the output manifest so
`test-fma-darwin-pr-only` can validate `firealpaca/darwin` at its current upstream version.

Frozen since: 2026-08-03
Version: 2.15.2 -> 2.16.0

Note on provenance: the branch for this probe was pushed by an earlier run of this routine on
2026-08-01 but never had a PR opened for it. Today's run regenerated the manifest independently and
confirmed the result is byte-identical to what is already on the branch, so this run opened the PR
on the existing commit rather than pushing a duplicate branch.

Unlike the other probes in today's batch, this one moves the version *forward*, so it is the most
likely of the batch to validate cleanly.

Draft until validation reports. Merge only if the FMA checks are green and the validate shard
actually ran for this slug.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5kBssP7AEw7yNmVmH8xfp)_