### PR TITLE
Add ai_skills schema table

### DIFF
--- a/schema/tables/ai_skills.yml
+++ b/schema/tables/ai_skills.yml
@@ -1,0 +1,81 @@
+name: ai_skills
+description: |-
+  Inventories individual AI capabilities via Skills. Each skill is a discrete capability that can be invoked by an AI tool or agent. Skills are extracted from MCP server manifests, agent instruction files, and IDE plugin manifests. Each row represents a single capability. Join against ai_tools via parent_identifier for tool-level context.
+platforms:
+  - darwin
+  - windows
+  - linux
+evented: false
+examples: |-
+  List all skills that can execute shell commands.
+
+  ```
+  SELECT skill_name, category, source, parent_identifier FROM ai_skills WHERE capability_tags LIKE '%shell_exec%';
+  ```
+
+  Skills exposed per MCP server.
+
+  ```
+  SELECT t.name, s.skill_name, s.capability_tags FROM ai_tools t LEFT JOIN ai_skills s ON t.identifier = s.parent_identifier WHERE t.type = 'mcp_server';
+  ```
+
+  High-danger skills running on the fleet.
+
+  ```
+  SELECT skill_name, danger_level, source, username FROM ai_skills WHERE danger_level IN ('high', 'critical');
+  ```
+
+  Who has credential access capabilities?
+
+  ```
+  SELECT username, skill_name, source, path FROM ai_skills WHERE category = 'credential_access';
+  ```
+columns:
+  - name: identifier
+    description: "Globally unique skill identifier (e.g. `mcp:files:read`, `agent:hermes:terminal`)."
+    type: text
+    required: true
+  - name: skill_name
+    description: Human-readable name of the skill/capability.
+    type: text
+    required: false
+  - name: category
+    description: "Semantic category: file_ops, shell_exec, network_egress, data_read, data_write, code_gen, browser_ctrl, email_ops, credential_access, system_config, unknown."
+    type: text
+    required: false
+  - name: capability_tags
+    description: "Comma-separated fine-grained capability tokens (e.g. `read_fs`,`write_fs`,`exec_shell`,`network_request`,`api_call`)."
+    type: text
+    required: false
+  - name: source
+    description: "Parent tool type that exposes this skill: mcp_server, ide_plugin, agent, app, browser_extension, instruction_file."
+    type: text
+    required: false
+  - name: parent_identifier
+    description: FK-style reference to ai_tools.identifier for the parent tool/agent that provides this skill.
+    type: text
+    required: false
+  - name: danger_level
+    description: "Pre-classified risk band: low, medium, high, critical. Based on capability category and observed data access patterns."
+    type: text
+    required: false
+  - name: parameters_json
+    description: "Compact JSON of the skill's input schema — argument names, types, required flags."
+    type: text
+    required: false
+  - name: path
+    description: File path where the skill definition lives (MCP config, plugin manifest, instruction file).
+    type: text
+    required: false
+  - name: uid
+    description: User ID of the owner.
+    type: text
+    required: false
+  - name: username
+    description: Username of the owner.
+    type: text
+    required: false
+  - name: enabled
+    description: Whether the skill is currently enabled/active (1 = yes, 0 = no).
+    type: integer
+    required: false


### PR DESCRIPTION
Adds schema/tables/ai_skills.yml documenting the proposed ai_skills osquery table, per #50244.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #50244
# Checklist for submitter
If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a structured inventory for tracking individual AI capabilities.
  * Captures capability details, classifications, risk levels, configuration parameters, source information, ownership context, parent tools, and enabled status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->