### PR TITLE
DO NOT MERGE (testing): Add August 2026 newsletter and 'newsletters' article category

### DIFF
--- a/articles/newsletter-2026-08.md
+++ b/articles/newsletter-2026-08.md
@@ -20,7 +20,7 @@ Two releases are scheduled for August: 4.90.0 and 4.91.0. These are planned, not
 
 - **Custom host vitals.** Define your own host fields, add, edit, and delete them, and use them in host name templates.
 - **Full Apple DDM support:** Complete coverage for all Apple declaration profiles, assets, and custom activations.
-- **macOS local accounts from any IdP.** Create the initial local account and sync its password from any identity provider that supports OAuth ROPG, moving out of experimental.
+-  **macOS local accounts via IdP**: Now officially out of experimental. Create local accounts and sync passwords using **any** identity provider that supports OAuth ROPG.
 
 _Also on deck: Certificate visibility, Android vulnerabilities, Python script-only packages, and Microsoft Entra conditional access._
 

--- a/articles/newsletter-2026-08.md
+++ b/articles/newsletter-2026-08.md
@@ -1,6 +1,6 @@
 # Fleet newsletter, August 2026
 
-An app updated itself and broke something. Now you can pin the version, or roll it back. That's Fleet 4.89.0, along with a fix for the stuck Windows setup screen and Google Workspace as a source of host vitals.
+Pin a Fleet-maintained app to the version you trust, or roll one back whenever you need to. Fleet 4.89.0 also adds Google Workspace as a source of IdP host vitals, and gives end users a clear path through Windows enrollment. Two more releases land this month.
 
 ## What shipped last month
 

--- a/articles/newsletter-2026-08.md
+++ b/articles/newsletter-2026-08.md
@@ -8,7 +8,7 @@ You aren't used to seeing a newsletter from us, and honestly, we aren't fans of 
 
 ## 🚀 What shipped last month
 
-- **Auto-update, pin, and roll back Fleet-maintained apps.** Pin an app to a specific version to stop it from auto-updating, or roll back to the previous version if a new release breaks something. Fleet checks for new versions hourly, so hosts you leave on auto-update stay current without you re-adding the app. Available in Fleet Premium.
+- **Introducing - App Rollbacks**: Pin or revert Fleet-maintained apps to bypass broken updates and maintain fleet stability. _Available in Fleet Premium._
 - **Windows setup experience: continue past a failed install.** When required setup software fails during Windows automatic enrollment, end users see exactly which app failed. If you haven't checked **Cancel setup if software fails**, they can continue and install it later from self-service. Either way they get a next step instead of a stuck screen. Available in Fleet Premium.
 - **IdP host vitals from Google Workspace.** Populate group, department, username, email, and full name straight from Google Workspace. Google Workspace doesn't support SCIM, so Fleet pulls directory data from Google's API on a schedule. Scope profiles, software, and policies with IdP labels the same way you would with Okta or Entra. Available in Fleet Premium.
 

--- a/articles/newsletter-2026-08.md
+++ b/articles/newsletter-2026-08.md
@@ -1,19 +1,14 @@
 # Fleet newsletter, August 2026
 
-July was a month about staying in control of what your hosts run. Fleet 4.89.0 lets you pin a Fleet-maintained app to a specific version, or roll it back when a new release causes trouble, so an automatic update never surprises you. Windows setup experience stopped being a dead end: when required software fails during enrollment, end users now see what failed and can keep going. Google Workspace joined Okta and Entra as a source of IdP host vitals, no custom integration required. August brings two releases, and the theme continues with custom host vitals you define yourself.
+An app updated itself and broke something. Now you can pin the version, or roll it back. That's Fleet 4.89.0, along with a fix for the stuck Windows setup screen and Google Workspace as a source of host vitals.
 
 ## What shipped last month
-
-Fleet 4.89.0 landed on July 15. [Read the full release notes](https://fleetdm.com/releases/fleet-4-89-0).
 
 - **Auto-update, pin, and roll back Fleet-maintained apps.** Pin an app to a specific version to stop it from auto-updating, or roll back to the previous version if a new release breaks something. Fleet checks for new versions hourly, so hosts you leave on auto-update stay current without you re-adding the app. Available in Fleet Premium.
 - **Windows setup experience: continue past a failed install.** When required setup software fails during Windows automatic enrollment, end users see exactly which app failed. If you haven't checked **Cancel setup if software fails**, they can continue and install it later from self-service. Either way they get a next step instead of a stuck screen. Available in Fleet Premium.
 - **IdP host vitals from Google Workspace.** Populate group, department, username, email, and full name straight from Google Workspace. Google Workspace doesn't support SCIM, so Fleet pulls directory data from Google's API on a schedule. Scope profiles, software, and policies with IdP labels the same way you would with Okta or Entra. Available in Fleet Premium.
-- **Android: host vital variables everywhere.** Use any host vital variable in Android configuration profiles, certificate templates, and managed app configuration. Pass a host's UUID to Duo as a trusted endpoint identifier, or a user's email as the identity for EAP-TLS Wi-Fi. When a variable's value changes, Fleet resends the certificate so it stays accurate.
-- **Policy status page.** See a historical view of policy automation runs: pass and fail status per host, next to the output of the software install or script the automation triggered. Troubleshooting a host that keeps failing a policy no longer means piecing together separate activity logs.
-- **Vulnerability exposure chart filters.** Filter the chart by software category, EPSS score, known active exploits (CISA KEV), and CVEs to exclude, then persist those defaults through GitOps. The chart reflects the risk registry you actually track. Available in Fleet Premium.
 
-Also shipped: Fleet 4.88.0 on July 2, with per-host enrollment permission tracking for personal (BYOD) Apple enrollments, so personal devices can't be remotely wiped or locked. Patch releases 4.89.1 and 4.89.2 followed.
+Three of eight highlights. For the rest, plus everything in 4.88.0, 4.89.1, and 4.89.2, see the [Fleet 4.89.0 release notes](https://fleetdm.com/releases/fleet-4-89-0).
 
 ## What we plan to ship this month
 
@@ -37,9 +32,8 @@ Fleet workshops are free, run about four hours, and cap at roughly seven people 
 - **GitOps, Melbourne.** August 24, 1pm to 5pm GMT+10. [Register](https://www.eventbrite.com/e/gitops-x-world-tickets-1992169896789)
 - **GitOps, Kansas City.** September 24, 8:30am to 10:30am EDT. [Register](https://www.eventbrite.com/e/speed-run-gitops-jnuc-tickets-1992170088362)
 - **GitOps, Gothenburg.** September 28, 1pm to 5pm GMT+2. [Register](https://www.eventbrite.com/e/gitops-macsysadmins-tickets-1993054810590)
-- **GitOps, Richmond.** October 13, 1pm to 5pm EDT. [Register](https://www.eventbrite.com/e/gitops-richmond-tickets-1993052268988)
 
-Nothing near you? You can [request a workshop](https://fleetdm.com/workshops).
+More dates are on the way, and nothing near you yet is worth telling us about. You can [request a workshop](https://fleetdm.com/workshops) in your city.
 
 ## Worth reading
 

--- a/articles/newsletter-2026-08.md
+++ b/articles/newsletter-2026-08.md
@@ -10,7 +10,7 @@ You aren't used to seeing a newsletter from us, and honestly, we aren't fans of 
 
 - **Introducing - App Rollbacks**: Pin or revert Fleet-maintained apps to bypass broken updates and maintain fleet stability. _Available in Fleet Premium._
 - **Windows setup experience: continue past a failed install.** When required setup software fails during Windows automatic enrollment, end users see exactly which app failed. If you haven't checked **Cancel setup if software fails**, they can continue and install it later from self-service. Either way they get a next step instead of a stuck screen. Available in Fleet Premium.
-- **IdP host vitals from Google Workspace.** Populate group, department, username, email, and full name straight from Google Workspace. Google Workspace doesn't support SCIM, so Fleet pulls directory data from Google's API on a schedule. Scope profiles, software, and policies with IdP labels the same way you would with Okta or Entra. Available in Fleet Premium.
+- **New native IdP support - Google Workspace:** Google Workspace joins the list of supported IdPs with a new native integration to connect with Fleet in order to populate users, groups and more to devices. _Available in Fleet Premium._
 
 Also shipped in July: host vital variables everywhere on Android, a policy status page that shows every automation run, vulnerability exposure chart filters you can save through GitOps, and BYOD enrollment permissions for Apple. [See every release](https://fleetdm.com/releases).
 

--- a/articles/newsletter-2026-08.md
+++ b/articles/newsletter-2026-08.md
@@ -1,0 +1,80 @@
+# Fleet newsletter, August 2026
+
+July was a month about staying in control of what your hosts run. Fleet 4.89.0 lets you pin a Fleet-maintained app to a specific version, or roll it back when a new release causes trouble, so an automatic update never surprises you. Windows setup experience stopped being a dead end: when required software fails during enrollment, end users now see what failed and can keep going. Google Workspace joined Okta and Entra as a source of IdP host vitals, no custom integration required. August brings two releases, and the theme continues with custom host vitals you define yourself.
+
+## What shipped last month
+
+Fleet 4.89.0 landed on July 15. [Read the full release notes](https://fleetdm.com/releases/fleet-4-89-0).
+
+- **Auto-update, pin, and roll back Fleet-maintained apps.** Pin an app to a specific version to stop it from auto-updating, or roll back to the previous version if a new release breaks something. Fleet checks for new versions hourly, so hosts you leave on auto-update stay current without you re-adding the app. Available in Fleet Premium.
+- **Windows setup experience: continue past a failed install.** When required setup software fails during Windows automatic enrollment, end users see exactly which app failed. If you haven't checked **Cancel setup if software fails**, they can continue and install it later from self-service. Either way they get a next step instead of a stuck screen. Available in Fleet Premium.
+- **IdP host vitals from Google Workspace.** Populate group, department, username, email, and full name straight from Google Workspace. Google Workspace doesn't support SCIM, so Fleet pulls directory data from Google's API on a schedule. Scope profiles, software, and policies with IdP labels the same way you would with Okta or Entra. Available in Fleet Premium.
+- **Android: host vital variables everywhere.** Use any host vital variable in Android configuration profiles, certificate templates, and managed app configuration. Pass a host's UUID to Duo as a trusted endpoint identifier, or a user's email as the identity for EAP-TLS Wi-Fi. When a variable's value changes, Fleet resends the certificate so it stays accurate.
+- **Policy status page.** See a historical view of policy automation runs: pass and fail status per host, next to the output of the software install or script the automation triggered. Troubleshooting a host that keeps failing a policy no longer means piecing together separate activity logs.
+- **Vulnerability exposure chart filters.** Filter the chart by software category, EPSS score, known active exploits (CISA KEV), and CVEs to exclude, then persist those defaults through GitOps. The chart reflects the risk registry you actually track. Available in Fleet Premium.
+
+Also shipped: Fleet 4.88.0 on July 2, with per-host enrollment permission tracking for personal (BYOD) Apple enrollments, so personal devices can't be remotely wiped or locked. Patch releases 4.89.1 and 4.89.2 followed.
+
+## What we plan to ship this month
+
+Two releases are scheduled for August: 4.90.0 and 4.91.0. These are planned, not promised, and scope changes as the releases come together.
+
+- **Custom host vitals.** Define your own host fields, add, edit, and delete them, and use them in host name templates.
+- **Full Apple declarative (DDM) profile support.** Support for all Apple declaration profiles and assets, plus custom activations.
+- **macOS local accounts from any IdP.** Create the initial local account and sync its password from any identity provider that supports OAuth ROPG, moving out of experimental.
+- **Certificate visibility.** View certificates in **Controls > OS settings**, and see certificates on the host details page for Windows hosts.
+- **Android software inventory.** Show Android OS versions and their vulnerabilities in **Software > OS**, alongside more Android host vitals.
+- **Python script-only packages.** Add Python to the script-only package options for software deployment.
+
+Want the wider view? The [July roadmap preview](https://fleetdm.com/announcements/roadmap-preview-july-2026) covers the next three months, including AI governance, patch policies, Windows local admin account rotation, and tvOS.
+
+## Upcoming workshops
+
+Fleet workshops are free, run about four hours, and cap at roughly seven people so everyone gets hands-on time. They lead to the Fleet level 1 certificate.
+
+- **GitOps, Atlanta.** August 11, 1pm to 5pm EDT. [Register](https://www.eventbrite.com/e/gitops-atlanta-tickets-1990879889342)
+- **Apple administrator, New York.** August 12, 1pm to 5pm EDT. [Register](https://www.eventbrite.com/e/apple-administrator-workshop-tickets-1993125028614)
+- **GitOps, Melbourne.** August 24, 1pm to 5pm GMT+10. [Register](https://www.eventbrite.com/e/gitops-x-world-tickets-1992169896789)
+- **GitOps, Kansas City.** September 24, 8:30am to 10:30am EDT. [Register](https://www.eventbrite.com/e/speed-run-gitops-jnuc-tickets-1992170088362)
+- **GitOps, Gothenburg.** September 28, 1pm to 5pm GMT+2. [Register](https://www.eventbrite.com/e/gitops-macsysadmins-tickets-1993054810590)
+- **GitOps, Richmond.** October 13, 1pm to 5pm EDT. [Register](https://www.eventbrite.com/e/gitops-richmond-tickets-1993052268988)
+
+Nothing near you? You can [request a workshop](https://fleetdm.com/workshops).
+
+## Worth reading
+
+### Customer stories
+
+- [How Hawx gets field technicians productive on hour one](https://fleetdm.com/articles/hawx). Hawx automated seasonal iOS onboarding and offboarding with Fleet, Tines, and Okta, ending start-of-season helpdesk floods in one month.
+- [How Primo built an HR-driven IT platform, powered by Fleet](https://fleetdm.com/articles/primo). Primo chose Fleet for the MDM layer inside its orchestration platform, scaling to 400 customers and 30,000 devices.
+
+### Articles
+
+- [Intune isn't free: what the Microsoft 365 bundle really costs in 2026](https://fleetdm.com/articles/intune-isnt-free-what-the-microsoft-365-bundle-really-costs). Microsoft's E7 tier and 2026 price increases expose the bundle fallacy. Price E3, E5, and E7 individually and rightsize device management.
+- [How Fleet keeps Fleet-maintained apps safe and up to date](https://fleetdm.com/articles/inside-fleet-maintained-apps). Vendor-direct downloads, pinned hashes, validation on real hardware, and human review, behind every app in the catalog.
+- [Take control of Apple beta programs with declarative device management](https://fleetdm.com/articles/control-apple-beta-programs-with-ddm). Use DDM software update settings to control beta enrollment, and automate fetching AppleSeed tokens from Apple Business Manager.
+
+### Guides
+
+- [Manage Windows updates with the Windows Update CSP](https://fleetdm.com/guides/custom-windows-updates). Enforce deadlines, build rollout rings, pin releases, and verify all of it.
+- [Use custom host vitals in scripts and configuration profiles](https://fleetdm.com/guides/custom-host-vitals). Define a custom field, set a value per host, and use it as a variable.
+- [Build a Linux self-service catalog with script-only packages](https://fleetdm.com/guides/build-your-own-linux-self-service-with-script-only-packages-guide). Turn apt and dnf commands into a self-service catalog your Linux users can install from.
+- [Detect and remove unwanted software installed by peripherals](https://fleetdm.com/guides/detect-and-remove-peripheral-software). Find and clean up the software docks and peripherals install without asking.
+
+## From the community
+
+- [Fleet](https://www.linkedin.com/company/fleetdm/) published [three ways to find Intel-only Mac apps](https://www.linkedin.com/feed/update/urn:li:activity:7485034063301627904) still running in your fleet, ahead of Apple ending Rosetta support.
+- [Zay Hanlon](https://www.linkedin.com/in/zayhanlon/) wrote about [taking the case study program in-house](https://www.linkedin.com/posts/zayhanlon_i-hijacked-the-case-study-program-from-marketing-share-7488595098134265856-WuPG) and what came out of the Hawx story.
+- [Allen Houchins](https://www.linkedin.com/in/allenhouchins/) asked what ["it's already included"](https://www.linkedin.com/posts/allenhouchins_its-already-included-might-be-the-most-share-7483936371141693440-IFIH) really costs, and shared a [sneak peek at patch policies](https://www.linkedin.com/posts/allenhouchins_who-doesnt-love-a-sneak-peek-the-patch-ugcPost-7486499772229615616-SM1r).
+- [Josh Roskos](https://www.linkedin.com/in/jroskos/) asked [an AI agent a compliance question](https://www.linkedin.com/posts/jroskos_i-asked-my-ai-agent-a-compliance-question-share-7486480039249747968-YJiZ) and posted what came back.
+
+Workshop attendees in Sydney, Toronto, Boston, and Sweden also posted about their sessions. Thanks to everyone who shared.
+
+<meta name="articleTitle" value="Fleet newsletter, August 2026">
+<meta name="authorFullName" value="Allen Houchins">
+<meta name="authorGitHubUsername" value="allenhouchins">
+<meta name="publishedOn" value="2026-08-03">
+<meta name="category" value="newsletters">
+<meta name="description" value="What shipped in Fleet 4.89.0, what's planned for 4.90.0 and 4.91.0, upcoming GitOps and Apple workshops, and July's best guides and customer stories.">
+<meta name="newsletterIssue" value="2026-08">
+<meta name="coversPeriod" value="2026-07">

--- a/articles/newsletter-2026-08.md
+++ b/articles/newsletter-2026-08.md
@@ -21,7 +21,7 @@ Two releases are scheduled for August: 4.90.0 and 4.91.0. These are planned, not
 - **Android software inventory.** Show Android OS versions and their vulnerabilities in **Software > OS**, alongside more Android host vitals.
 - **Python script-only packages.** Add Python to the script-only package options for software deployment.
 
-Want the wider view? The [July roadmap preview](https://fleetdm.com/announcements/roadmap-preview-july-2026) covers the next three months, including AI governance, patch policies, Windows local admin account rotation, and tvOS.
+Fleet plans releases in the open. The [release planning board](https://github.com/orgs/fleetdm/projects/87/views/10) shows what's queued for the releases after this one.
 
 ## Upcoming workshops
 

--- a/articles/newsletter-2026-08.md
+++ b/articles/newsletter-2026-08.md
@@ -8,7 +8,7 @@ Pin a Fleet-maintained app to the version you trust, or roll one back whenever y
 - **Windows setup experience: continue past a failed install.** When required setup software fails during Windows automatic enrollment, end users see exactly which app failed. If you haven't checked **Cancel setup if software fails**, they can continue and install it later from self-service. Either way they get a next step instead of a stuck screen. Available in Fleet Premium.
 - **IdP host vitals from Google Workspace.** Populate group, department, username, email, and full name straight from Google Workspace. Google Workspace doesn't support SCIM, so Fleet pulls directory data from Google's API on a schedule. Scope profiles, software, and policies with IdP labels the same way you would with Okta or Entra. Available in Fleet Premium.
 
-Three of eight highlights. For the rest, plus everything in 4.88.0, 4.89.1, and 4.89.2, see the [Fleet 4.89.0 release notes](https://fleetdm.com/releases/fleet-4-89-0).
+Also shipped in July: host vital variables everywhere on Android, a policy status page that shows every automation run, vulnerability exposure chart filters you can save through GitOps, and BYOD enrollment permissions for Apple. [See every release](https://fleetdm.com/releases).
 
 ## What we plan to ship this month
 

--- a/articles/newsletter-2026-08.md
+++ b/articles/newsletter-2026-08.md
@@ -22,7 +22,7 @@ Two releases are scheduled for August: 4.90.0 and 4.91.0. These are planned, not
 - **Full Apple DDM support:** Complete coverage for all Apple declaration profiles, assets, and custom activations.
 - **macOS local accounts from any IdP.** Create the initial local account and sync its password from any identity provider that supports OAuth ROPG, moving out of experimental.
 
-Also on deck: certificate visibility in **Controls > OS settings** and on Windows host details, Android OS versions and vulnerabilities in software inventory, Python script-only packages, and Entra conditional access for self-hosted deployments.
+_Also on deck: Certificate visibility, Android vulnerabilities, Python script-only packages, and Microsoft Entra conditional access._
 
 Fleet plans releases in the open. The [release planning board](https://github.com/orgs/fleetdm/projects/87/views/10) shows what's queued for the releases after this one.
 

--- a/articles/newsletter-2026-08.md
+++ b/articles/newsletter-2026-08.md
@@ -1,6 +1,10 @@
 # Fleet newsletter, August 2026
 
-Pin a Fleet-maintained app to the version you trust, or roll one back whenever you need to. Fleet 4.89.0 also adds Google Workspace as a source of IdP host vitals, and gives end users a clear path through Windows enrollment. Two more releases land this month.
+
+Hello from Fleet! 
+
+You aren't used to seeing a newsletter from us, and honestly, we aren't fans of average marketing emails either. Your inbox is loud enough. So, let's make a deal: we'll skip the fluff, and instead deliver a monthly brief covering all things Fleet, alongside the device management and endpoint security news that every IT admin, security pro, and tech leader needs on their radar.
+
 
 ## 🚀 What shipped last month
 

--- a/articles/newsletter-2026-08.md
+++ b/articles/newsletter-2026-08.md
@@ -18,6 +18,8 @@ Two releases are scheduled for August: 4.90.0 and 4.91.0. These are planned, not
 - **Full Apple declarative (DDM) profile support.** Support for all Apple declaration profiles and assets, plus custom activations.
 - **macOS local accounts from any IdP.** Create the initial local account and sync its password from any identity provider that supports OAuth ROPG, moving out of experimental.
 
+Also on deck: certificate visibility in **Controls > OS settings** and on Windows host details, Android OS versions and vulnerabilities in software inventory, Python script-only packages, and Entra conditional access for self-hosted deployments.
+
 Fleet plans releases in the open. The [release planning board](https://github.com/orgs/fleetdm/projects/87/views/10) shows what's queued for the releases after this one.
 
 ## 🎓 Upcoming workshops

--- a/articles/newsletter-2026-08.md
+++ b/articles/newsletter-2026-08.md
@@ -19,7 +19,7 @@ Also shipped in July: host vital variables everywhere on Android, a policy statu
 Two releases are scheduled for August: 4.90.0 and 4.91.0. These are planned, not promised, and scope changes as the releases come together.
 
 - **Custom host vitals.** Define your own host fields, add, edit, and delete them, and use them in host name templates.
-- **Full Apple declarative (DDM) profile support.** Support for all Apple declaration profiles and assets, plus custom activations.
+- **Full Apple DDM support:** Complete coverage for all Apple declaration profiles, assets, and custom activations.
 - **macOS local accounts from any IdP.** Create the initial local account and sync its password from any identity provider that supports OAuth ROPG, moving out of experimental.
 
 Also on deck: certificate visibility in **Controls > OS settings** and on Windows host details, Android OS versions and vulnerabilities in software inventory, Python script-only packages, and Entra conditional access for self-hosted deployments.

--- a/articles/newsletter-2026-08.md
+++ b/articles/newsletter-2026-08.md
@@ -2,7 +2,7 @@
 
 Pin a Fleet-maintained app to the version you trust, or roll one back whenever you need to. Fleet 4.89.0 also adds Google Workspace as a source of IdP host vitals, and gives end users a clear path through Windows enrollment. Two more releases land this month.
 
-## What shipped last month
+## 🚀 What shipped last month
 
 - **Auto-update, pin, and roll back Fleet-maintained apps.** Pin an app to a specific version to stop it from auto-updating, or roll back to the previous version if a new release breaks something. Fleet checks for new versions hourly, so hosts you leave on auto-update stay current without you re-adding the app. Available in Fleet Premium.
 - **Windows setup experience: continue past a failed install.** When required setup software fails during Windows automatic enrollment, end users see exactly which app failed. If you haven't checked **Cancel setup if software fails**, they can continue and install it later from self-service. Either way they get a next step instead of a stuck screen. Available in Fleet Premium.
@@ -10,20 +10,17 @@ Pin a Fleet-maintained app to the version you trust, or roll one back whenever y
 
 Also shipped in July: host vital variables everywhere on Android, a policy status page that shows every automation run, vulnerability exposure chart filters you can save through GitOps, and BYOD enrollment permissions for Apple. [See every release](https://fleetdm.com/releases).
 
-## What we plan to ship this month
+## 🗺️ What we plan to ship this month
 
 Two releases are scheduled for August: 4.90.0 and 4.91.0. These are planned, not promised, and scope changes as the releases come together.
 
 - **Custom host vitals.** Define your own host fields, add, edit, and delete them, and use them in host name templates.
 - **Full Apple declarative (DDM) profile support.** Support for all Apple declaration profiles and assets, plus custom activations.
 - **macOS local accounts from any IdP.** Create the initial local account and sync its password from any identity provider that supports OAuth ROPG, moving out of experimental.
-- **Certificate visibility.** View certificates in **Controls > OS settings**, and see certificates on the host details page for Windows hosts.
-- **Android software inventory.** Show Android OS versions and their vulnerabilities in **Software > OS**, alongside more Android host vitals.
-- **Python script-only packages.** Add Python to the script-only package options for software deployment.
 
 Fleet plans releases in the open. The [release planning board](https://github.com/orgs/fleetdm/projects/87/views/10) shows what's queued for the releases after this one.
 
-## Upcoming workshops
+## 🎓 Upcoming workshops
 
 Fleet workshops are free, run about four hours, and cap at roughly seven people so everyone gets hands-on time. They lead to the Fleet level 1 certificate.
 
@@ -35,7 +32,7 @@ Fleet workshops are free, run about four hours, and cap at roughly seven people 
 
 More dates are on the way, and nothing near you yet is worth telling us about. You can [request a workshop](https://fleetdm.com/workshops) in your city.
 
-## Worth reading
+## 📖 Worth reading
 
 ### Customer stories
 
@@ -55,7 +52,7 @@ More dates are on the way, and nothing near you yet is worth telling us about. Y
 - [Build a Linux self-service catalog with script-only packages](https://fleetdm.com/guides/build-your-own-linux-self-service-with-script-only-packages-guide). Turn apt and dnf commands into a self-service catalog your Linux users can install from.
 - [Detect and remove unwanted software installed by peripherals](https://fleetdm.com/guides/detect-and-remove-peripheral-software). Find and clean up the software docks and peripherals install without asking.
 
-## From the community
+## 💬 From the community
 
 - [Fleet](https://www.linkedin.com/company/fleetdm/) published [three ways to find Intel-only Mac apps](https://www.linkedin.com/feed/update/urn:li:activity:7485034063301627904) still running in your fleet, ahead of Apple ending Rosetta support.
 - [Zay Hanlon](https://www.linkedin.com/in/zayhanlon/) wrote about [taking the case study program in-house](https://www.linkedin.com/posts/zayhanlon_i-hijacked-the-case-study-program-from-marketing-share-7488595098134265856-WuPG) and what came out of the Hawx story.

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -654,7 +654,7 @@ module.exports = {
                   throw new Error(`Failed compiling markdown content: An article page is missing a category meta tag (<meta name="category" value="guides">) at "${path.join(topLvlRepoPath, pageSourcePath)}".  To resolve, add a meta tag with the category of the article`);
                 } else {
                   // Throwing an error if the article has an invalid category.
-                  let validArticleCategories = ['deploy', 'articles', 'security', 'engineering', 'announcements', 'guides', 'releases', 'podcasts', 'report', 'case study', 'comparison', 'whitepaper', 'webinar' ];
+                  let validArticleCategories = ['deploy', 'articles', 'security', 'engineering', 'announcements', 'guides', 'releases', 'podcasts', 'report', 'case study', 'comparison', 'whitepaper', 'webinar', 'newsletters' ];
                   if(!validArticleCategories.includes(embeddedMetadata.category)) {
                     throw new Error(`Failed compiling markdown content: An article page has an invalid category meta tag (<meta name="category" value="${embeddedMetadata.category}">) at "${path.join(topLvlRepoPath, pageSourcePath)}". To resolve, change the meta tag to a valid category, one of: ${validArticleCategories}`);
                   }


### PR DESCRIPTION
**Related issue:** NA

Adds Fleet's August 2026 newsletter, covering July, and introduces `newsletters` as an article category so it can render on fleetdm.com.

## What's here

- `articles/newsletter-2026-08.md`, the newsletter itself: what shipped in July, what's planned for August, upcoming workshops, July's customer stories, articles, and guides, and notable community posts.
- One line in `website/scripts/build-static-content.js`, adding `'newsletters'` to `validArticleCategories`. Without it the build throws on the new category.

The builder derives article URLs from the category, so this page lands at `fleetdm.com/newsletters/newsletter-2026-08` with no routing or template changes needed. It uses the standard article template.

## Open questions for reviewers

- **"What we plan to ship this month" needs a second look.** It was assembled from the 4.90.0 and 4.91.0 milestones filtered to `story` issues, not from the [release planning board](https://github.com/orgs/fleetdm/projects/87/views/10). 4.90.0 currently has 184 open issues against an August 5 due date, so some of this will slip. Cut anything that shouldn't be stated publicly.
- **Community section is mostly personal posts.** Only the Intel-only Mac apps post is from Fleet's company page. Happy to drop the personal ones if that's not the convention we want.
- **Article picks are editorial, not traffic-based.** July published 18 pieces and 9 are here. Reorder if analytics say otherwise.
- **No sidebar link.** `/articles` has a hardcoded category nav in `website/views/pages/articles/articles.ejs` and I didn't add "Newsletters" to it, to keep this diff small. Say the word and I'll add it.
- The Toronto workshop on August 4 is omitted, since it will have passed by any realistic send date.

## Checklist for submitter

- [x] Confirmed the new category passes the website build script's validation rules (required meta tags present, `publishedOn` ISO-formatted, `description` under 150 characters, no Vue-template curly braces in the markdown).
- [x] Verified every fleetdm.com link in the article returns 200.
- [ ] QA'd all new/changed functionality manually
