### PR TITLE
Unfreeze Binance (macOS)

### DIFF
--- a/ee/maintained-apps/inputs/homebrew/binance.json
+++ b/ee/maintained-apps/inputs/homebrew/binance.json
@@ -6,6 +6,5 @@
   "slug": "binance/darwin",
   "default_categories": [
     "Productivity"
-  ],
-  "frozen": true
+  ]
 }

--- a/ee/maintained-apps/outputs/binance/darwin.json
+++ b/ee/maintained-apps/outputs/binance/darwin.json
@@ -9,7 +9,7 @@
       "installer_url": "https://ftp.binance.com/electron-desktop/mac/production/binance-2.4.1-arm64.dmg",
       "install_script_ref": "17a1483e",
       "uninstall_script_ref": "6006366b",
-      "sha256": "2bb7e4c115a5bbef14c734f31ead811456e46a4863d3ec3303a66cb3e5c6e745",
+      "sha256": "19564f74e7d9d6cacd326d0ba2b64cef8aa24d47d78bdf3bd44bd513730919b8",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
**Related issue:** NA

Automated unfreeze probe. Removes `"frozen": true` and regenerates the output manifest so
`test-fma-darwin-pr-only` can validate `binance/darwin` at its current upstream version.

Frozen since: 2026-08-03
Version: 2.4.1 -> 2.4.1

Note: the version is **unchanged**. The only manifest change is `sha256` — Homebrew's cask now
declares a different checksum for the same version at the same installer URL, so the pinned
manifest's checksum is stale. This is not a version regression, but it is not a forward version
move either. The probe exists to find out whether validation passes at the current checksum.

Draft until validation reports. Merge only if the FMA checks are green and the validate shard
actually ran for this slug.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A12h3HLDssPznoTdJRGfhm)_