### PR TITLE
Unfreeze DBeaver Enterprise (macOS)

### DIFF
--- a/ee/maintained-apps/inputs/homebrew/dbeaver-enterprise.json
+++ b/ee/maintained-apps/inputs/homebrew/dbeaver-enterprise.json
@@ -4,6 +4,5 @@
   "token": "dbeaver-enterprise",
   "installer_format": "dmg",
   "slug": "dbeaver-enterprise/darwin",
-  "default_categories": ["Developer tools"],
-  "frozen": true
+  "default_categories": ["Developer tools"]
 }

--- a/ee/maintained-apps/outputs/dbeaver-enterprise/darwin.json
+++ b/ee/maintained-apps/outputs/dbeaver-enterprise/darwin.json
@@ -9,7 +9,7 @@
       "installer_url": "https://downloads.dbeaver.net/enterprise/26.1.0/dbeaver-ee-26.1.0-macos-aarch64.dmg",
       "install_script_ref": "b36e0de5",
       "uninstall_script_ref": "d32399ce",
-      "sha256": "60bcaa629809beb0de699797fd9e8ffeab082a91035b895b102da36cbc594888",
+      "sha256": "b6a9b6c17d136330c357f8f7de49653639304ab57e4f77199f7f96a0e00c9699",
       "default_categories": [
         "Developer tools"
       ]


### PR DESCRIPTION
**Related issue:** NA

Automated unfreeze probe. Removes `"frozen": true` and regenerates the output manifest so
`test-fma-darwin-pr-only` can validate `dbeaver-enterprise/darwin` at its current upstream version.

Frozen since: 2026-08-03
Version: 26.1.0 -> 26.1.0

Note: the version is **unchanged**. The only manifest change is `sha256` — the DBeaver download host
now serves different content for the same version at the same installer URL, so the pinned
manifest's checksum is stale. This is not a version regression, but it is not a forward version
move either. The probe exists to find out whether validation passes at the current checksum.

All three DBeaver editions (Enterprise, Lite, Ultimate) show the same pattern this run.

Draft until validation reports. Merge only if the FMA checks are green and the validate shard
actually ran for this slug.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A12h3HLDssPznoTdJRGfhm)_