### PR TITLE
Unfreeze DBeaver Lite (macOS)

### DIFF
--- a/ee/maintained-apps/inputs/homebrew/dbeaverlite.json
+++ b/ee/maintained-apps/inputs/homebrew/dbeaverlite.json
@@ -4,6 +4,5 @@
   "token": "dbeaverlite",
   "installer_format": "dmg",
   "slug": "dbeaverlite/darwin",
-  "default_categories": ["Developer tools"],
-  "frozen": true
+  "default_categories": ["Developer tools"]
 }

--- a/ee/maintained-apps/outputs/dbeaverlite/darwin.json
+++ b/ee/maintained-apps/outputs/dbeaverlite/darwin.json
@@ -9,7 +9,7 @@
       "installer_url": "https://downloads.dbeaver.net/lite/26.1.0/dbeaver-le-26.1.0-macos-aarch64.dmg",
       "install_script_ref": "3c86b0f4",
       "uninstall_script_ref": "4e5f63ae",
-      "sha256": "9821764efce6be58c9bc87e31730e6943d07bdb9fb1d2ccb358138b5709e0acf",
+      "sha256": "ddad856da3e39ef3ad33286fb27ff3782ff7e8892103d128d70494aa56f813cf",
       "default_categories": [
         "Developer tools"
       ]


### PR DESCRIPTION
**Related issue:** NA

Automated unfreeze probe. Removes `"frozen": true` and regenerates the output manifest so
`test-fma-darwin-pr-only` can validate `dbeaverlite/darwin` at its current upstream version.

Frozen since: 2026-08-03
Version: 26.1.0 -> 26.1.0

Note: the version is **unchanged**. The only manifest change is `sha256` — the DBeaver download host
now serves different content for the same version at the same installer URL, so the pinned
manifest's checksum is stale. This is not a version regression, but it is not a forward version
move either. The probe exists to find out whether validation passes at the current checksum.

All three DBeaver editions (Enterprise, Lite, Ultimate) show the same pattern this run.

Draft until validation reports. Merge only if the FMA checks are green and the validate shard
actually ran for this slug.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A12h3HLDssPznoTdJRGfhm)_