### PR TITLE
Unfreeze DBeaver Ultimate (macOS)

### DIFF
--- a/ee/maintained-apps/inputs/homebrew/dbeaverultimate.json
+++ b/ee/maintained-apps/inputs/homebrew/dbeaverultimate.json
@@ -4,6 +4,5 @@
   "token": "dbeaverultimate",
   "installer_format": "dmg",
   "slug": "dbeaverultimate/darwin",
-  "default_categories": ["Developer tools"],
-  "frozen": true
+  "default_categories": ["Developer tools"]
 }

--- a/ee/maintained-apps/outputs/dbeaverultimate/darwin.json
+++ b/ee/maintained-apps/outputs/dbeaverultimate/darwin.json
@@ -9,7 +9,7 @@
       "installer_url": "https://downloads.dbeaver.net/ultimate/26.1.0/dbeaver-ue-26.1.0-macos-aarch64.dmg",
       "install_script_ref": "a8066f3f",
       "uninstall_script_ref": "23b82863",
-      "sha256": "ac134703e8cf541e8489d61367f9c0d29bd8fa048a1f18239978fe7355957786",
+      "sha256": "20aacb0db1f818989cb4cb4a4e982c88a3ff6756ce4e0753d25c40920d8b76bb",
       "default_categories": [
         "Developer tools"
       ]


### PR DESCRIPTION
**Related issue:** NA

Automated unfreeze probe. Removes `"frozen": true` and regenerates the output manifest so
`test-fma-darwin-pr-only` can validate `dbeaverultimate/darwin` at its current upstream version.

Frozen since: 2026-08-03
Version: 26.1.0 -> 26.1.0

Note: the version is **unchanged**. The only manifest change is `sha256` — the DBeaver download host
now serves different content for the same version at the same installer URL, so the pinned
manifest's checksum is stale. This is not a version regression, but it is not a forward version
move either. The probe exists to find out whether validation passes at the current checksum.

All three DBeaver editions (Enterprise, Lite, Ultimate) show the same pattern this run.

Draft until validation reports. Merge only if the FMA checks are green and the validate shard
actually ran for this slug.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A12h3HLDssPznoTdJRGfhm)_