### PR TITLE
QA: dedicated Windows Autopilot setup experience test + blank enrollment step

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-qa.md
+++ b/.github/ISSUE_TEMPLATE/release-qa.md
@@ -336,7 +336,7 @@ Reference: https://fleetdm.com/pricing
 
 **Blank enrollment**
 
-3. Enroll an Auto-Pilot host into "No team" with nothing configured and verify the ESP completes.
+3. Enroll an Auto-Pilot host into "No fleet" with nothing configured and verify the ESP completes.
 
 </td>
 </tr>

--- a/.github/ISSUE_TEMPLATE/release-qa.md
+++ b/.github/ISSUE_TEMPLATE/release-qa.md
@@ -336,7 +336,7 @@ Reference: https://fleetdm.com/pricing
 
 **Blank enrollment**
 
-3. Enroll an Auto-Pilot host into "No team" with nothing configured and verify the ESP completes — it must not hang on "Account setup".
+3. Enroll an Auto-Pilot host into "No team" with nothing configured and verify the ESP completes.
 
 </td>
 </tr>

--- a/.github/ISSUE_TEMPLATE/release-qa.md
+++ b/.github/ISSUE_TEMPLATE/release-qa.md
@@ -314,7 +314,7 @@ Reference: https://fleetdm.com/pricing
 <tr><th>Test name</th><th>Step instructions</th><th>Expected result</th></tr>
 
 <tr>
-<td>Manual enrollment flow</td>
+<td>Manual enrollment</td>
 <td>Verify MDM enrollment, run MDM commands.</td>
 <td>
 
@@ -326,7 +326,7 @@ Reference: https://fleetdm.com/pricing
 
 <tr>
 <td>Autopilot enrollment</td>
-<td>Verify Windows enrollment via Autopilot/Entra OOBE enrollment, both fully configured and with nothing configured.</td>
+<td>Verify Windows Autopilot/Entra OOBE enrollment, both fully configured and with nothing configured.</td>
 <td>
 
 **Full configuration**
@@ -336,7 +336,7 @@ Reference: https://fleetdm.com/pricing
 
 **Blank enrollment**
 
-3. Enroll an Auto-Pilot host into "No fleet" with nothing configured and verify the ESP completes.
+3. Enroll an Auto-Pilot host into the "Unassigned" fleet with nothing configured and verify the ESP completes.
 
 </td>
 </tr>

--- a/.github/ISSUE_TEMPLATE/release-qa.md
+++ b/.github/ISSUE_TEMPLATE/release-qa.md
@@ -306,7 +306,7 @@ Reference: https://fleetdm.com/pricing
 - [ ] OS settings
 - [ ] Disk encryption
 - [ ] OS updates
-- [ ] Setup Experience
+- [ ] Setup experience (Autopilot enrollment)
 - [ ] Android
 - [ ] Fleet Free
 
@@ -368,12 +368,25 @@ Reference: https://fleetdm.com/pricing
 </tr>
 
 <tr>
-<td>Setup Experience</td>
-<td>Verify Windows Setup experience.</td>
+<td>Setup experience (Autopilot enrollment)</td>
+<td>Verify Windows Setup experience via Autopilot/Entra OOBE enrollment, both fully configured and with nothing configured.</td>
 <td>
 
-1. Configure End user authentication.
-2. Add software (FMA, Custom pkg).
+**Full configuration**
+1. Create a team and configure the setup experience so the enrollment exercises every setup-related item:
+   - End user authentication.
+   - A configuration profile.
+   - OS updates (Windows).
+   - Disk encryption (BitLocker).
+   - Software to install during setup (FMA, Custom pkg).
+2. Erase an Auto-Pilot-enabled Windows host and complete OOBE enrollment into the configured team.
+3. Verify the Enrollment Status Page (ESP) advances through Device preparation and Account setup and reaches the desktop.
+4. Verify the configuration profile, OS updates, disk encryption, and software are all applied.
+
+**Blank enrollment** (regression for [#49134](https://github.com/fleetdm/fleet/issues/49134))
+5. Erase an Auto-Pilot-enabled Windows host and enroll into "No team" with nothing configured (no config profiles, software, OS updates, or disk encryption).
+6. Repeat the blank enrollment 2-3 times — the original failure was an intermittent race, so a single pass does not prove correctness.
+7. Verify on every run that the ESP completes and the host reaches the desktop — it must not hang on "Account setup".
 
 </td>
 </tr>

--- a/.github/ISSUE_TEMPLATE/release-qa.md
+++ b/.github/ISSUE_TEMPLATE/release-qa.md
@@ -302,11 +302,11 @@ Reference: https://fleetdm.com/pricing
 
 **Progress**
 - [ ] MDM enrollment flow
+- [ ] Setup experience (Autopilot enrollment)
 - [ ] MDM migration flow
 - [ ] OS settings
 - [ ] Disk encryption
 - [ ] OS updates
-- [ ] Setup experience (Autopilot enrollment)
 - [ ] Android
 - [ ] Fleet Free
 
@@ -319,8 +319,33 @@ Reference: https://fleetdm.com/pricing
 <td>
 
 1. With Windows MDM turned On, enroll a Windows host and verify MDM is turned On for the host.
-2. Erase an Auto-Pilot enabled Windows host and complete automated enrollment flow.
-3. Verify able to run MDM commands on Windows hosts from the CLI.
+2. Verify able to run MDM commands on Windows hosts from the CLI.
+
+</td>
+</tr>
+
+<tr>
+<td>Setup experience (Autopilot enrollment)</td>
+<td>Verify Windows Setup experience via Autopilot/Entra OOBE enrollment, both fully configured and with nothing configured.</td>
+<td>
+
+**Full configuration**
+
+1. Create a team and configure the setup experience so the enrollment exercises every setup-related item:
+   - End user authentication.
+   - A configuration profile.
+   - OS updates (Windows).
+   - Disk encryption (BitLocker).
+   - Software to install during setup (FMA, Custom pkg).
+2. Erase an Auto-Pilot-enabled Windows host and complete OOBE enrollment into the configured team.
+3. Verify the Enrollment Status Page (ESP) advances through Device preparation and Account setup and reaches the desktop.
+4. Verify the configuration profile, OS updates, disk encryption, and software are all applied.
+
+**Blank enrollment** (regression for [#49134](https://github.com/fleetdm/fleet/issues/49134))
+
+5. Erase an Auto-Pilot-enabled Windows host and enroll into "No team" with nothing configured (no config profiles, software, OS updates, or disk encryption).
+6. Repeat the blank enrollment 2-3 times — the original failure was an intermittent race, so a single pass does not prove correctness.
+7. Verify on every run that the ESP completes and the host reaches the desktop — it must not hang on "Account setup".
 
 </td>
 </tr>
@@ -363,30 +388,6 @@ Reference: https://fleetdm.com/pricing
 <td>
 
 1. Configure OS updates (Windows).
-
-</td>
-</tr>
-
-<tr>
-<td>Setup experience (Autopilot enrollment)</td>
-<td>Verify Windows Setup experience via Autopilot/Entra OOBE enrollment, both fully configured and with nothing configured.</td>
-<td>
-
-**Full configuration**
-1. Create a team and configure the setup experience so the enrollment exercises every setup-related item:
-   - End user authentication.
-   - A configuration profile.
-   - OS updates (Windows).
-   - Disk encryption (BitLocker).
-   - Software to install during setup (FMA, Custom pkg).
-2. Erase an Auto-Pilot-enabled Windows host and complete OOBE enrollment into the configured team.
-3. Verify the Enrollment Status Page (ESP) advances through Device preparation and Account setup and reaches the desktop.
-4. Verify the configuration profile, OS updates, disk encryption, and software are all applied.
-
-**Blank enrollment** (regression for [#49134](https://github.com/fleetdm/fleet/issues/49134))
-5. Erase an Auto-Pilot-enabled Windows host and enroll into "No team" with nothing configured (no config profiles, software, OS updates, or disk encryption).
-6. Repeat the blank enrollment 2-3 times — the original failure was an intermittent race, so a single pass does not prove correctness.
-7. Verify on every run that the ESP completes and the host reaches the desktop — it must not hang on "Account setup".
 
 </td>
 </tr>

--- a/.github/ISSUE_TEMPLATE/release-qa.md
+++ b/.github/ISSUE_TEMPLATE/release-qa.md
@@ -331,21 +331,12 @@ Reference: https://fleetdm.com/pricing
 
 **Full configuration**
 
-1. Create a team and configure the setup experience so the enrollment exercises every setup-related item:
-   - End user authentication.
-   - A configuration profile.
-   - OS updates (Windows).
-   - Disk encryption (BitLocker).
-   - Software to install during setup (FMA, Custom pkg).
-2. Erase an Auto-Pilot-enabled Windows host and complete OOBE enrollment into the configured team.
-3. Verify the Enrollment Status Page (ESP) advances through Device preparation and Account setup and reaches the desktop.
-4. Verify the configuration profile, OS updates, disk encryption, and software are all applied.
+1. Configure a team's setup experience: a configuration profile, OS updates, disk encryption (BitLocker), software (FMA, Custom pkg), and end user authentication.
+2. Enroll an Auto-Pilot host via OOBE and verify the ESP completes and all configured items apply.
 
-**Blank enrollment** (regression for [#49134](https://github.com/fleetdm/fleet/issues/49134))
+**Blank enrollment**
 
-5. Erase an Auto-Pilot-enabled Windows host and enroll into "No team" with nothing configured (no config profiles, software, OS updates, or disk encryption).
-6. Repeat the blank enrollment 2-3 times — the original failure was an intermittent race, so a single pass does not prove correctness.
-7. Verify on every run that the ESP completes and the host reaches the desktop — it must not hang on "Account setup".
+3. Enroll an Auto-Pilot host into "No team" with nothing configured and verify the ESP completes — it must not hang on "Account setup".
 
 </td>
 </tr>

--- a/.github/ISSUE_TEMPLATE/release-qa.md
+++ b/.github/ISSUE_TEMPLATE/release-qa.md
@@ -301,7 +301,7 @@ Reference: https://fleetdm.com/pricing
 ### Power to PC
 
 **Progress**
-- [ ] Manual enrollment flow
+- [ ] Manual enrollment
 - [ ] Autopilot enrollment
 - [ ] MDM migration flow
 - [ ] OS settings
@@ -314,8 +314,8 @@ Reference: https://fleetdm.com/pricing
 <tr><th>Test name</th><th>Step instructions</th><th>Expected result</th></tr>
 
 <tr>
-<td>MDM enrollment flow</td>
-<td>Verify MDM enrollments, run MDM commands.</td>
+<td>Manual enrollment flow</td>
+<td>Verify MDM enrollment, run MDM commands.</td>
 <td>
 
 1. With Windows MDM turned on and the Setup experience configured (end user authentication and software installs), enroll a Windows host and verify MDM is turned on and the configured software installs.

--- a/.github/ISSUE_TEMPLATE/release-qa.md
+++ b/.github/ISSUE_TEMPLATE/release-qa.md
@@ -331,7 +331,7 @@ Reference: https://fleetdm.com/pricing
 
 **Full configuration**
 
-1. Configure a team's setup experience: a configuration profile, OS updates, disk encryption (BitLocker), software (FMA, Custom pkg), and end user authentication.
+1. Configure a fleet's setup experience: a configuration profile, OS updates, disk encryption (BitLocker), software (FMA, Custom pkg), and end user authentication.
 2. Enroll an Auto-Pilot host via OOBE and verify the ESP completes and all configured items apply.
 
 **Blank enrollment**

--- a/.github/ISSUE_TEMPLATE/release-qa.md
+++ b/.github/ISSUE_TEMPLATE/release-qa.md
@@ -301,8 +301,8 @@ Reference: https://fleetdm.com/pricing
 ### Power to PC
 
 **Progress**
-- [ ] MDM enrollment flow
-- [ ] Setup experience (Autopilot enrollment)
+- [ ] Manual enrollment flow
+- [ ] Autopilot enrollment
 - [ ] MDM migration flow
 - [ ] OS settings
 - [ ] Disk encryption
@@ -318,20 +318,20 @@ Reference: https://fleetdm.com/pricing
 <td>Verify MDM enrollments, run MDM commands.</td>
 <td>
 
-1. With Windows MDM turned On, enroll a Windows host and verify MDM is turned On for the host.
+1. With Windows MDM turned on and the Setup experience configured (end user authentication and software installs), enroll a Windows host and verify MDM is turned on and the configured software installs.
 2. Verify able to run MDM commands on Windows hosts from the CLI.
 
 </td>
 </tr>
 
 <tr>
-<td>Setup experience (Autopilot enrollment)</td>
-<td>Verify Windows Setup experience via Autopilot/Entra OOBE enrollment, both fully configured and with nothing configured.</td>
+<td>Autopilot enrollment</td>
+<td>Verify Windows enrollment via Autopilot/Entra OOBE enrollment, both fully configured and with nothing configured.</td>
 <td>
 
 **Full configuration**
 
-1. Configure a fleet's setup experience: a configuration profile, OS updates, disk encryption (BitLocker), software (FMA, Custom pkg), and end user authentication.
+1. Configure a fleet with setup experience items (enable EUA, add FMA & Custom package software), add a configuration profile, enable OS updates, and disk encryption (BitLocker).
 2. Enroll an Auto-Pilot host via OOBE and verify the ESP completes and all configured items apply.
 
 **Blank enrollment**


### PR DESCRIPTION
## What / why

Follow-up to [#49134](https://github.com/fleetdm/fleet/issues/49134) (Windows Autopilot ESP intermittently hanging on "Account setup" due to a user-scope ESP node race). Adjusts the release QA template so this failure mode is caught going forward.

## Changes

Builds out the **Power to PC → Setup experience** row into a dedicated **Windows Autopilot / Entra OOBE enrollment** test, mirroring the **Apple at Work → Setup experience** row:

- **Full configuration** run — specifies exactly what to configure so the enrollment exercises every setup-related item (end user auth, config profile, OS updates, disk encryption, software), enroll a real Autopilot host, and verify the ESP completes and all items apply.
- **Blank enrollment** run — enroll into "No team" with **nothing configured**, repeated **2-3 times**. Because the original bug was an intermittent race, a single pass doesn't prove correctness. The ESP must complete and reach the desktop every time (no "Account setup" hang).

The basic Autopilot enroll remains in "MDM enrollment flow" (mirrors Apple keeping basic ADE enroll there).

Docs-only change to `.github/ISSUE_TEMPLATE/release-qa.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)