### PR TITLE
Move batch activity host_ids out of stored details into webhook payloads

### DIFF
--- a/server/acl/activityacl/fleet_adapter.go
+++ b/server/acl/activityacl/fleet_adapter.go
@@ -133,7 +133,10 @@ func (a *FleetServiceAdapter) GetHostActivitiesWebhooks(ctx context.Context, hos
 	}
 	hooks := make([]activity.HostActivitiesWebhook, 0, len(settings))
 	for _, s := range settings {
-		hooks = append(hooks, activity.HostActivitiesWebhook{DestinationURL: s.DestinationURL})
+		hooks = append(hooks, activity.HostActivitiesWebhook{
+			DestinationURL: s.DestinationURL,
+			HostIDs:        s.HostIDs,
+		})
 	}
 	return hooks, nil
 }

--- a/server/activity/config.go
+++ b/server/activity/config.go
@@ -8,9 +8,12 @@ type ActivitiesWebhookSettings struct {
 	DestinationURL string
 }
 
-// HostActivitiesWebhook is one fleet's enabled host-activities webhook destination.
+// HostActivitiesWebhook is one fleet's enabled host-activities webhook
+// destination, together with the subset of the activity's hosts belonging to
+// the fleet(s) configured with it.
 type HostActivitiesWebhook struct {
 	DestinationURL string
+	HostIDs        []uint
 }
 
 // AppConfigProvider provides access to app configuration needed by the activity bounded context.

--- a/server/activity/internal/service/new_activity.go
+++ b/server/activity/internal/service/new_activity.go
@@ -65,13 +65,16 @@ func (s *Service) NewActivity(ctx context.Context, user *api.User, activity api.
 			}
 			// Per-fleet payloads carry host_ids for activities whose stored
 			// details don't already identify their hosts (batch automation
-			// activities). The list is injected at fire time only: batches can
+			// activities). The list is injected at fire time only — batches can
 			// span thousands of hosts, so storing it would bloat every affected
 			// host's feed response and expose the full batch to any user who
-			// can read one of its hosts. The global webhook payload above is
-			// intentionally left as stored (matching its pre-existing format).
-			webhookDetails := s.detailsWithHostIDs(ctx, activity, detailsBytes)
+			// can read one of its hosts — and each delivery gets only the host
+			// IDs belonging to the fleet(s) behind its destination, so one
+			// fleet's endpoint never sees another fleet's hosts. The global
+			// webhook payload above is intentionally left as stored (matching
+			// its pre-existing format).
 			for _, hook := range hooks {
+				webhookDetails := s.detailsWithHostIDs(ctx, activity.ActivityName(), detailsBytes, hook.HostIDs)
 				s.fireActivityWebhook(ctx, user, activity, webhookDetails, timestamp, hook.DestinationURL)
 			}
 		}
@@ -93,18 +96,12 @@ func (s *Service) NewActivity(ctx context.Context, user *api.User, activity api.
 	return s.store.NewActivity(ctx, user, activity, detailsBytes, timestamp)
 }
 
-// detailsWithHostIDs returns the details to use in per-fleet host activities
-// webhook payloads: for
-// host-linked activities whose details carry no host identifier of their own
-// (neither host_id nor host_ids), it returns a copy with the host_ids list
-// added. On any failure it falls back to the stored details rather than
-// blocking webhook delivery.
-func (s *Service) detailsWithHostIDs(ctx context.Context, activity api.ActivityDetails, detailsBytes []byte) []byte {
-	ah, ok := activity.(types.ActivityHosts)
-	if !ok {
-		return detailsBytes
-	}
-	hostIDs := ah.HostIDs()
+// detailsWithHostIDs returns the details to use in one per-fleet host
+// activities webhook delivery: when the stored details carry no host
+// identifier of their own (no host_id and no non-empty host_ids), it returns
+// a copy with the delivery's host_ids added. On any failure it falls back to
+// the stored details rather than blocking webhook delivery.
+func (s *Service) detailsWithHostIDs(ctx context.Context, activityName string, detailsBytes []byte, hostIDs []uint) []byte {
 	if len(hostIDs) == 0 {
 		return detailsBytes
 	}
@@ -112,14 +109,20 @@ func (s *Service) detailsWithHostIDs(ctx context.Context, activity api.ActivityD
 	var details map[string]json.RawMessage
 	if err := json.Unmarshal(detailsBytes, &details); err != nil {
 		s.logger.ErrorContext(ctx, "unmarshal details to inject host_ids",
-			slog.String("activity", activity.ActivityName()), slog.String("err", err.Error()))
+			slog.String("activity", activityName), slog.String("err", err.Error()))
 		return detailsBytes
 	}
 	if _, ok := details["host_id"]; ok {
 		return detailsBytes
 	}
-	if _, ok := details["host_ids"]; ok {
-		return detailsBytes
+	// A stored host_ids list is kept only when it actually identifies hosts:
+	// an empty or malformed one (e.g. a future type serializing an empty
+	// HostIDList) is replaced with the delivery's list.
+	if raw, ok := details["host_ids"]; ok {
+		var stored []uint
+		if err := json.Unmarshal(raw, &stored); err == nil && len(stored) > 0 {
+			return detailsBytes
+		}
 	}
 	if details == nil { // details were JSON null
 		details = make(map[string]json.RawMessage, 1)
@@ -128,14 +131,14 @@ func (s *Service) detailsWithHostIDs(ctx context.Context, activity api.ActivityD
 	idsBytes, err := json.Marshal(hostIDs)
 	if err != nil {
 		s.logger.ErrorContext(ctx, "marshal host_ids",
-			slog.String("activity", activity.ActivityName()), slog.String("err", err.Error()))
+			slog.String("activity", activityName), slog.String("err", err.Error()))
 		return detailsBytes
 	}
 	details["host_ids"] = idsBytes
 	withIDs, err := json.Marshal(details)
 	if err != nil {
 		s.logger.ErrorContext(ctx, "marshal details with host_ids",
-			slog.String("activity", activity.ActivityName()), slog.String("err", err.Error()))
+			slog.String("activity", activityName), slog.String("err", err.Error()))
 		return detailsBytes
 	}
 	return withIDs

--- a/server/activity/internal/service/new_activity.go
+++ b/server/activity/internal/service/new_activity.go
@@ -63,8 +63,16 @@ func (s *Service) NewActivity(ctx context.Context, user *api.User, activity api.
 				s.logger.ErrorContext(ctx, "get host activities webhooks",
 					slog.String("activity", activity.ActivityName()), slog.String("err", err.Error()))
 			}
+			// Per-fleet payloads carry host_ids for activities whose stored
+			// details don't already identify their hosts (batch automation
+			// activities). The list is injected at fire time only: batches can
+			// span thousands of hosts, so storing it would bloat every affected
+			// host's feed response and expose the full batch to any user who
+			// can read one of its hosts. The global webhook payload above is
+			// intentionally left as stored (matching its pre-existing format).
+			webhookDetails := s.detailsWithHostIDs(ctx, activity, detailsBytes)
 			for _, hook := range hooks {
-				s.fireActivityWebhook(ctx, user, activity, detailsBytes, timestamp, hook.DestinationURL)
+				s.fireActivityWebhook(ctx, user, activity, webhookDetails, timestamp, hook.DestinationURL)
 			}
 		}
 	}
@@ -83,6 +91,54 @@ func (s *Service) NewActivity(ctx context.Context, user *api.User, activity api.
 	ctx = context.WithValue(ctx, types.ActivityWebhookContextKey, true)
 
 	return s.store.NewActivity(ctx, user, activity, detailsBytes, timestamp)
+}
+
+// detailsWithHostIDs returns the details to use in per-fleet host activities
+// webhook payloads: for
+// host-linked activities whose details carry no host identifier of their own
+// (neither host_id nor host_ids), it returns a copy with the host_ids list
+// added. On any failure it falls back to the stored details rather than
+// blocking webhook delivery.
+func (s *Service) detailsWithHostIDs(ctx context.Context, activity api.ActivityDetails, detailsBytes []byte) []byte {
+	ah, ok := activity.(types.ActivityHosts)
+	if !ok {
+		return detailsBytes
+	}
+	hostIDs := ah.HostIDs()
+	if len(hostIDs) == 0 {
+		return detailsBytes
+	}
+
+	var details map[string]json.RawMessage
+	if err := json.Unmarshal(detailsBytes, &details); err != nil {
+		s.logger.ErrorContext(ctx, "unmarshal details to inject host_ids",
+			slog.String("activity", activity.ActivityName()), slog.String("err", err.Error()))
+		return detailsBytes
+	}
+	if _, ok := details["host_id"]; ok {
+		return detailsBytes
+	}
+	if _, ok := details["host_ids"]; ok {
+		return detailsBytes
+	}
+	if details == nil { // details were JSON null
+		details = make(map[string]json.RawMessage, 1)
+	}
+
+	idsBytes, err := json.Marshal(hostIDs)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "marshal host_ids",
+			slog.String("activity", activity.ActivityName()), slog.String("err", err.Error()))
+		return detailsBytes
+	}
+	details["host_ids"] = idsBytes
+	withIDs, err := json.Marshal(details)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "marshal details with host_ids",
+			slog.String("activity", activity.ActivityName()), slog.String("err", err.Error()))
+		return detailsBytes
+	}
+	return withIDs
 }
 
 // fireActivityWebhook sends the activity to the configured webhook URL asynchronously.

--- a/server/activity/internal/service/new_activity_test.go
+++ b/server/activity/internal/service/new_activity_test.go
@@ -85,6 +85,19 @@ type hostActivityNestedID struct {
 	Nested map[string]uint `json:"nested"`
 }
 
+// hostActivityStoredEmptyIDs serializes an empty host_ids of its own (e.g. a
+// future batch type whose HostIDList loses the json:"-" tag).
+type hostActivityStoredEmptyIDs struct {
+	hostActivity
+	StoredHostIDs []uint `json:"host_ids"`
+}
+
+// hostActivityMalformedIDs serializes a non-array host_ids of its own.
+type hostActivityMalformedIDs struct {
+	hostActivity
+	StoredHostIDs string `json:"host_ids"`
+}
+
 type aliasedActivity struct {
 	TeamID uint `json:"team_id" renameto:"fleet_id"`
 }
@@ -448,8 +461,8 @@ func TestNewActivityHostWebhook(t *testing.T) {
 				mockUserProvider: &mockUserProvider{},
 				mockHostProvider: &mockHostProvider{},
 				hostWebhooks: []activity.HostActivitiesWebhook{
-					{DestinationURL: srv.URL + "/fleet-a"},
-					{DestinationURL: srv.URL + "/fleet-b"},
+					{DestinationURL: srv.URL + "/fleet-a", HostIDs: []uint{42}},
+					{DestinationURL: srv.URL + "/fleet-b", HostIDs: []uint{43}},
 				},
 			},
 		}
@@ -472,6 +485,11 @@ func TestNewActivityHostWebhook(t *testing.T) {
 			}
 		}
 		require.Len(t, paths, 2)
+		// Each destination's payload carries only its own fleet's host IDs.
+		wantHostIDs := map[string][]any{
+			"/fleet-a": {float64(42)},
+			"/fleet-b": {float64(43)},
+		}
 		for _, path := range []string{"/fleet-a", "/fleet-b"} {
 			body, ok := paths[path]
 			require.True(t, ok, "expected a webhook POST to %s", path)
@@ -487,7 +505,7 @@ func TestNewActivityHostWebhook(t *testing.T) {
 			require.NoError(t, json.Unmarshal(*body.Details, &details))
 			assert.Equal(t, "host act", details["name"])
 			// host_ids is injected into the webhook payload at fire time...
-			assert.Equal(t, []any{float64(42), float64(43)}, details["host_ids"])
+			assert.Equal(t, wantHostIDs[path], details["host_ids"])
 		}
 		// ...but not into the stored details, which stay lean for API/feed
 		// responses.
@@ -504,7 +522,7 @@ func TestNewActivityHostWebhook(t *testing.T) {
 				mockUserProvider: &mockUserProvider{},
 				mockHostProvider: &mockHostProvider{},
 				hostWebhooks: []activity.HostActivitiesWebhook{
-					{DestinationURL: srv.URL + "/single-host"},
+					{DestinationURL: srv.URL + "/single-host", HostIDs: []uint{7}},
 				},
 			},
 		}
@@ -537,7 +555,7 @@ func TestNewActivityHostWebhook(t *testing.T) {
 				mockUserProvider: &mockUserProvider{},
 				mockHostProvider: &mockHostProvider{},
 				hostWebhooks: []activity.HostActivitiesWebhook{
-					{DestinationURL: srv.URL + "/nested"},
+					{DestinationURL: srv.URL + "/nested", HostIDs: []uint{5}},
 				},
 			},
 		}
@@ -559,6 +577,68 @@ func TestNewActivityHostWebhook(t *testing.T) {
 			// Only top-level keys count: the nested host_id must not
 			// suppress the injection.
 			assert.Equal(t, []any{float64(5)}, details["host_ids"])
+		}
+	})
+
+	t.Run("stored empty host_ids is replaced with the delivery's list", func(t *testing.T) {
+		ds := &newActivityMockDatastore{}
+		providers := &newActivityMockProviders{
+			mockDataProviders: mockDataProviders{
+				mockUserProvider: &mockUserProvider{},
+				mockHostProvider: &mockHostProvider{},
+				hostWebhooks: []activity.HostActivitiesWebhook{
+					{DestinationURL: srv.URL + "/stored-empty", HostIDs: []uint{11}},
+				},
+			},
+		}
+		svc := newTestServiceWithWebhook(ds, providers)
+
+		act := hostActivityStoredEmptyIDs{
+			hostActivity:  hostActivity{simpleActivity: simpleActivity{Name: "stored empty"}, hostIDs: []uint{11}},
+			StoredHostIDs: []uint{},
+		}
+		require.NoError(t, svc.NewActivity(t.Context(), user, act))
+
+		select {
+		case <-time.After(3 * time.Second):
+			t.Fatal("timeout waiting for host activities webhook")
+		case p := <-received:
+			require.Equal(t, "/stored-empty", p.path)
+			var details map[string]any
+			require.NoError(t, json.Unmarshal(*p.body.Details, &details))
+			// The stored empty list identifies nothing, so the delivery's
+			// list wins.
+			assert.Equal(t, []any{float64(11)}, details["host_ids"])
+		}
+	})
+
+	t.Run("malformed stored host_ids is replaced with the delivery's list", func(t *testing.T) {
+		ds := &newActivityMockDatastore{}
+		providers := &newActivityMockProviders{
+			mockDataProviders: mockDataProviders{
+				mockUserProvider: &mockUserProvider{},
+				mockHostProvider: &mockHostProvider{},
+				hostWebhooks: []activity.HostActivitiesWebhook{
+					{DestinationURL: srv.URL + "/stored-malformed", HostIDs: []uint{13}},
+				},
+			},
+		}
+		svc := newTestServiceWithWebhook(ds, providers)
+
+		act := hostActivityMalformedIDs{
+			hostActivity:  hostActivity{simpleActivity: simpleActivity{Name: "stored malformed"}, hostIDs: []uint{13}},
+			StoredHostIDs: "not-a-list",
+		}
+		require.NoError(t, svc.NewActivity(t.Context(), user, act))
+
+		select {
+		case <-time.After(3 * time.Second):
+			t.Fatal("timeout waiting for host activities webhook")
+		case p := <-received:
+			require.Equal(t, "/stored-malformed", p.path)
+			var details map[string]any
+			require.NoError(t, json.Unmarshal(*p.body.Details, &details))
+			assert.Equal(t, []any{float64(13)}, details["host_ids"])
 		}
 	})
 
@@ -650,7 +730,7 @@ func TestNewActivityHostWebhook(t *testing.T) {
 					DestinationURL: srv.URL + "/global",
 				},
 				hostWebhooks: []activity.HostActivitiesWebhook{
-					{DestinationURL: srv.URL + "/fleet-c"},
+					{DestinationURL: srv.URL + "/fleet-c", HostIDs: []uint{9}},
 				},
 			},
 		}

--- a/server/activity/internal/service/new_activity_test.go
+++ b/server/activity/internal/service/new_activity_test.go
@@ -71,6 +71,20 @@ type hostActivity struct {
 
 func (a hostActivity) HostIDs() []uint { return a.hostIDs }
 
+// hostActivityWithID mirrors the single-host activity types (ran_script,
+// locked_host, ...) whose details already carry host_id.
+type hostActivityWithID struct {
+	hostActivity
+	HostID uint `json:"host_id"`
+}
+
+// hostActivityNestedID has a host_id key only inside a nested object; the
+// top-level details carry no host identifier, so injection must still happen.
+type hostActivityNestedID struct {
+	hostActivity
+	Nested map[string]uint `json:"nested"`
+}
+
 type aliasedActivity struct {
 	TeamID uint `json:"team_id" renameto:"fleet_id"`
 }
@@ -469,9 +483,82 @@ func TestNewActivityHostWebhook(t *testing.T) {
 			assert.Equal(t, user.ID, *body.ActorID)
 			require.NotNil(t, body.ActorEmail)
 			assert.Equal(t, user.Email, *body.ActorEmail)
-			var details map[string]string
+			var details map[string]any
 			require.NoError(t, json.Unmarshal(*body.Details, &details))
 			assert.Equal(t, "host act", details["name"])
+			// host_ids is injected into the webhook payload at fire time...
+			assert.Equal(t, []any{float64(42), float64(43)}, details["host_ids"])
+		}
+		// ...but not into the stored details, which stay lean for API/feed
+		// responses.
+		var stored map[string]any
+		require.NoError(t, json.Unmarshal(ds.lastDetails, &stored))
+		_, hasHostIDs := stored["host_ids"]
+		assert.False(t, hasHostIDs, "host_ids must not be stored in details")
+	})
+
+	t.Run("details with their own host_id get no host_ids injected", func(t *testing.T) {
+		ds := &newActivityMockDatastore{}
+		providers := &newActivityMockProviders{
+			mockDataProviders: mockDataProviders{
+				mockUserProvider: &mockUserProvider{},
+				mockHostProvider: &mockHostProvider{},
+				hostWebhooks: []activity.HostActivitiesWebhook{
+					{DestinationURL: srv.URL + "/single-host"},
+				},
+			},
+		}
+		svc := newTestServiceWithWebhook(ds, providers)
+
+		act := hostActivityWithID{
+			hostActivity: hostActivity{simpleActivity: simpleActivity{Name: "single"}, hostIDs: []uint{7}},
+			HostID:       7,
+		}
+		err := svc.NewActivity(t.Context(), user, act)
+		require.NoError(t, err)
+
+		select {
+		case <-time.After(3 * time.Second):
+			t.Fatal("timeout waiting for host activities webhook")
+		case p := <-received:
+			require.Equal(t, "/single-host", p.path)
+			var details map[string]any
+			require.NoError(t, json.Unmarshal(*p.body.Details, &details))
+			assert.EqualValues(t, 7, details["host_id"])
+			_, hasHostIDs := details["host_ids"]
+			assert.False(t, hasHostIDs, "host_ids must not be injected when host_id is present")
+		}
+	})
+
+	t.Run("nested host_id keys do not suppress injection", func(t *testing.T) {
+		ds := &newActivityMockDatastore{}
+		providers := &newActivityMockProviders{
+			mockDataProviders: mockDataProviders{
+				mockUserProvider: &mockUserProvider{},
+				mockHostProvider: &mockHostProvider{},
+				hostWebhooks: []activity.HostActivitiesWebhook{
+					{DestinationURL: srv.URL + "/nested"},
+				},
+			},
+		}
+		svc := newTestServiceWithWebhook(ds, providers)
+
+		act := hostActivityNestedID{
+			hostActivity: hostActivity{simpleActivity: simpleActivity{Name: "nested"}, hostIDs: []uint{5}},
+			Nested:       map[string]uint{"host_id": 5},
+		}
+		require.NoError(t, svc.NewActivity(t.Context(), user, act))
+
+		select {
+		case <-time.After(3 * time.Second):
+			t.Fatal("timeout waiting for host activities webhook")
+		case p := <-received:
+			require.Equal(t, "/nested", p.path)
+			var details map[string]any
+			require.NoError(t, json.Unmarshal(*p.body.Details, &details))
+			// Only top-level keys count: the nested host_id must not
+			// suppress the injection.
+			assert.Equal(t, []any{float64(5)}, details["host_ids"])
 		}
 	})
 
@@ -585,7 +672,16 @@ func TestNewActivityHostWebhook(t *testing.T) {
 		require.Len(t, paths, 2)
 		assert.Contains(t, paths, "/global")
 		assert.Contains(t, paths, "/fleet-c")
-		// Identical payload on both destinations.
-		assert.Equal(t, paths["/global"], paths["/fleet-c"])
+		// Same envelope on both destinations, but host_ids is injected into
+		// the per-fleet payload only — the global payload keeps its
+		// pre-existing format (stored details, no host_ids).
+		var globalDetails, fleetDetails map[string]any
+		require.NoError(t, json.Unmarshal(*paths["/global"].Details, &globalDetails))
+		require.NoError(t, json.Unmarshal(*paths["/fleet-c"].Details, &fleetDetails))
+		assert.Equal(t, "both", globalDetails["name"])
+		assert.Equal(t, "both", fleetDetails["name"])
+		_, globalHasHostIDs := globalDetails["host_ids"]
+		assert.False(t, globalHasHostIDs, "global payload must not carry injected host_ids")
+		assert.Equal(t, []any{float64(9)}, fleetDetails["host_ids"])
 	})
 }

--- a/server/datastore/mysql/mysqltest/mysqltest.go
+++ b/server/datastore/mysql/mysqltest/mysqltest.go
@@ -883,7 +883,7 @@ func (t *testingLookupService) GetActivitiesWebhookSettings(ctx context.Context)
 	return appConfig.WebhookSettings.ActivitiesWebhook, nil
 }
 
-func (t *testingLookupService) GetHostActivitiesWebhookSettings(ctx context.Context, hostIDs []uint) ([]fleet.HostActivitiesWebhookSettings, error) {
+func (t *testingLookupService) GetHostActivitiesWebhookSettings(ctx context.Context, hostIDs []uint) ([]fleet.HostActivitiesWebhookDelivery, error) {
 	// Same resolution as production (server/service); no license gate because
 	// integration-test contexts carry no license.
 	return fleet.ResolveHostActivitiesWebhooks(ctx, t.ds, hostIDs)

--- a/server/datastore/mysql/testing_utils_test.go
+++ b/server/datastore/mysql/testing_utils_test.go
@@ -918,7 +918,7 @@ func (t *testingLookupService) GetActivitiesWebhookSettings(ctx context.Context)
 	return appConfig.WebhookSettings.ActivitiesWebhook, nil
 }
 
-func (t *testingLookupService) GetHostActivitiesWebhookSettings(ctx context.Context, hostIDs []uint) ([]fleet.HostActivitiesWebhookSettings, error) {
+func (t *testingLookupService) GetHostActivitiesWebhookSettings(ctx context.Context, hostIDs []uint) ([]fleet.HostActivitiesWebhookDelivery, error) {
 	// Host activities webhooks are not exercised through this test adapter.
 	return nil, nil
 }

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -2263,7 +2263,7 @@ func (a ActivityTypeDeletedSelfServiceCategory) ActivityName() string {
 // for Zendesk, TicketID holds the numeric ticket ID.
 type ActivityTypeRanAutomationTicket struct {
 	PolicyID   uint   `json:"policy_id"`
-	HostIDList []uint `json:"host_ids"`
+	HostIDList []uint `json:"-"`
 	Type       string `json:"type"`
 	TicketKey  string `json:"ticket_key,omitempty"`
 	TicketID   int64  `json:"ticket_id,omitempty"`
@@ -2287,7 +2287,7 @@ func (a ActivityTypeRanAutomationTicket) WasFromAutomation() bool {
 // failing-policy job targeted. The Type field is "jira" or "zendesk".
 type ActivityTypeFailedAutomationTicket struct {
 	PolicyID      uint   `json:"policy_id"`
-	HostIDList    []uint `json:"host_ids"`
+	HostIDList    []uint `json:"-"`
 	Type          string `json:"type"`
 	ErrorResponse string `json:"error_response"`
 }
@@ -2310,7 +2310,7 @@ func (a ActivityTypeFailedAutomationTicket) WasFromAutomation() bool {
 // failing calendar policy the host belongs to, associated with that host.
 type ActivityTypeFailedAutomationCalendarEvent struct {
 	PolicyID      uint   `json:"policy_id"`
-	HostIDList    []uint `json:"host_ids"`
+	HostIDList    []uint `json:"-"`
 	StatusCode    int    `json:"status_code,omitempty"`
 	ErrorResponse string `json:"error_response"`
 }
@@ -2334,7 +2334,7 @@ func (a ActivityTypeFailedAutomationCalendarEvent) WasFromAutomation() bool {
 // associated with that host.
 type ActivityTypeRanAutomationCalendarEvent struct {
 	PolicyID   uint   `json:"policy_id"`
-	HostIDList []uint `json:"host_ids"`
+	HostIDList []uint `json:"-"`
 }
 
 func (a ActivityTypeRanAutomationCalendarEvent) ActivityName() string {
@@ -2355,7 +2355,7 @@ func (a ActivityTypeRanAutomationCalendarEvent) WasFromAutomation() bool {
 // batch.
 type ActivityTypeFailedAutomationWebhook struct {
 	PolicyID      uint   `json:"policy_id"`
-	HostIDList    []uint `json:"host_ids"`
+	HostIDList    []uint `json:"-"`
 	StatusCode    int    `json:"status_code,omitempty"`
 	ErrorResponse string `json:"error_response"`
 }
@@ -2378,7 +2378,7 @@ func (a ActivityTypeFailedAutomationWebhook) WasFromAutomation() bool {
 // that batch. The activity name is "ran_automation_webhook".
 type ActivityTypeRanAutomationWebhook struct {
 	PolicyID   uint   `json:"policy_id"`
-	HostIDList []uint `json:"host_ids"`
+	HostIDList []uint `json:"-"`
 	StatusCode int    `json:"status_code,omitempty"`
 }
 
@@ -2401,7 +2401,7 @@ func (a ActivityTypeRanAutomationWebhook) WasFromAutomation() bool {
 // that host.
 type ActivityTypeFailedAutomationConditionalAccess struct {
 	PolicyID      uint   `json:"policy_id"`
-	HostIDList    []uint `json:"host_ids"`
+	HostIDList    []uint `json:"-"`
 	StatusCode    int    `json:"status_code,omitempty"`
 	ErrorResponse string `json:"error_response"`
 }
@@ -2425,7 +2425,7 @@ func (a ActivityTypeFailedAutomationConditionalAccess) WasFromAutomation() bool 
 // failing, associated with that host.
 type ActivityTypeRanAutomationConditionalAccess struct {
 	PolicyID   uint   `json:"policy_id"`
-	HostIDList []uint `json:"host_ids"`
+	HostIDList []uint `json:"-"`
 }
 
 func (a ActivityTypeRanAutomationConditionalAccess) ActivityName() string {

--- a/server/fleet/activities_test.go
+++ b/server/fleet/activities_test.go
@@ -57,17 +57,14 @@ func TestFailedAutomationTicketActivities(t *testing.T) {
 }
 
 func TestRanAutomationTicketActivities(t *testing.T) {
-	// assertHostIDsAndNoPolicyName checks that the marshaled details include
-	// the host_ids list (so webhook/API consumers can act on the affected
-	// hosts; see #50218) and still omit the policy name.
-	assertHostIDsAndNoPolicyName := func(t *testing.T, got map[string]any, want []uint) {
+	// assertNoHostIDsAndNoPolicyName checks that the marshaled (stored)
+	// details omit the host_ids list — it is injected into webhook payloads
+	// only at fire time (see #50218), keeping API/feed responses lean — and
+	// still omit the policy name.
+	assertNoHostIDsAndNoPolicyName := func(t *testing.T, got map[string]any) {
 		t.Helper()
-		raw, ok := got["host_ids"].([]any)
-		require.True(t, ok, "host_ids missing from details")
-		require.Len(t, raw, len(want))
-		for i, v := range raw {
-			assert.EqualValues(t, want[i], v)
-		}
+		_, hasHostIDs := got["host_ids"]
+		assert.False(t, hasHostIDs, "host_ids must not be stored in details")
 		_, hasPolicyName := got["policy_name"]
 		assert.False(t, hasPolicyName)
 	}
@@ -94,7 +91,7 @@ func TestRanAutomationTicketActivities(t *testing.T) {
 		// ticket_id omitted for jira
 		_, hasTicketID := got["ticket_id"]
 		assert.False(t, hasTicketID)
-		assertHostIDsAndNoPolicyName(t, got, []uint{11})
+		assertNoHostIDsAndNoPolicyName(t, got)
 	})
 
 	t.Run("ticket (zendesk)", func(t *testing.T) {
@@ -119,7 +116,7 @@ func TestRanAutomationTicketActivities(t *testing.T) {
 		// ticket_key omitted for zendesk
 		_, hasTicketKey := got["ticket_key"]
 		assert.False(t, hasTicketKey)
-		assertHostIDsAndNoPolicyName(t, got, []uint{12, 13})
+		assertNoHostIDsAndNoPolicyName(t, got)
 	})
 }
 
@@ -189,14 +186,10 @@ func TestFailedPolicyAutomationActivities(t *testing.T) {
 }
 
 func TestSuccessPolicyAutomationActivities(t *testing.T) {
-	assertHostIDsAndNoPolicyName := func(t *testing.T, got map[string]any, want []uint) {
+	assertNoHostIDsAndNoPolicyName := func(t *testing.T, got map[string]any) {
 		t.Helper()
-		raw, ok := got["host_ids"].([]any)
-		require.True(t, ok, "host_ids missing from details")
-		require.Len(t, raw, len(want))
-		for i, v := range raw {
-			assert.EqualValues(t, want[i], v)
-		}
+		_, hasHostIDs := got["host_ids"]
+		assert.False(t, hasHostIDs, "host_ids must not be stored in details")
 		_, hasPolicyName := got["policy_name"]
 		assert.False(t, hasPolicyName)
 	}
@@ -216,7 +209,7 @@ func TestSuccessPolicyAutomationActivities(t *testing.T) {
 		var got map[string]any
 		require.NoError(t, json.Unmarshal(b, &got))
 		assert.EqualValues(t, 14, got["policy_id"])
-		assertHostIDsAndNoPolicyName(t, got, []uint{42})
+		assertNoHostIDsAndNoPolicyName(t, got)
 	})
 
 	t.Run("webhook sent", func(t *testing.T) {
@@ -236,7 +229,7 @@ func TestSuccessPolicyAutomationActivities(t *testing.T) {
 		require.NoError(t, json.Unmarshal(b, &got))
 		assert.EqualValues(t, 7, got["policy_id"])
 		assert.EqualValues(t, 200, got["status_code"])
-		assertHostIDsAndNoPolicyName(t, got, []uint{10, 20, 30})
+		assertNoHostIDsAndNoPolicyName(t, got)
 	})
 
 	t.Run("webhook sent omits zero status code", func(t *testing.T) {
@@ -262,7 +255,7 @@ func TestSuccessPolicyAutomationActivities(t *testing.T) {
 		var got map[string]any
 		require.NoError(t, json.Unmarshal(b, &got))
 		assert.EqualValues(t, 15, got["policy_id"])
-		assertHostIDsAndNoPolicyName(t, got, []uint{43})
+		assertNoHostIDsAndNoPolicyName(t, got)
 	})
 }
 

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -113,7 +113,7 @@ type ActivityLookupService interface {
 	// GetHostActivitiesWebhookSettings returns the enabled host-activities
 	// webhook settings of the fleets the given hosts belong to, deduplicated by
 	// fleet. Returns nil on Fleet Free.
-	GetHostActivitiesWebhookSettings(ctx context.Context, hostIDs []uint) ([]HostActivitiesWebhookSettings, error)
+	GetHostActivitiesWebhookSettings(ctx context.Context, hostIDs []uint) ([]HostActivitiesWebhookDelivery, error)
 	// ActivateNextUpcomingActivityForHost activates the next upcoming activity for the given host.
 	ActivateNextUpcomingActivityForHost(ctx context.Context, hostID uint, fromCompletedExecID string) error
 }

--- a/server/fleet/teams.go
+++ b/server/fleet/teams.go
@@ -310,10 +310,17 @@ type HostActivitiesWebhookLookup interface {
 	TeamLite(ctx context.Context, tid uint) (*TeamLite, error)
 }
 
-// ResolveHostActivitiesWebhooks returns the enabled host-activities webhook
-// settings of the fleets the given hosts belong to, deduplicated by fleet and
-// by destination URL so one activity yields at most one delivery per endpoint.
-func ResolveHostActivitiesWebhooks(ctx context.Context, ds HostActivitiesWebhookLookup, hostIDs []uint) ([]HostActivitiesWebhookSettings, error) {
+// HostActivitiesWebhookDelivery is one fleet's resolved host-activities
+// webhook destination together with the subset of the activity's hosts that
+// belong to that fleet. Payloads are scoped this way so a delivery is always
+// exactly one fleet's subscription — it never mixes fleets' host IDs.
+type HostActivitiesWebhookDelivery struct {
+	DestinationURL string
+	HostIDs        []uint
+}
+
+// ResolveHostActivitiesWebhooks returns one enabled host-activities webhook delivery per fleet the given hosts belong to.
+func ResolveHostActivitiesWebhooks(ctx context.Context, ds HostActivitiesWebhookLookup, hostIDs []uint) ([]HostActivitiesWebhookDelivery, error) {
 	if len(hostIDs) == 0 {
 		return nil, nil
 	}
@@ -323,30 +330,34 @@ func ResolveHostActivitiesWebhooks(ctx context.Context, ds HostActivitiesWebhook
 		return nil, err
 	}
 
-	// Dedup by fleet: team ID 0 is reserved for "No fleet" so a nil TeamID maps
-	// to key 0 without colliding with a real fleet.
-	seenTeamIDs := make(map[uint]struct{})
-	seenURLs := make(map[string]struct{})
-	var settings []HostActivitiesWebhookSettings
+	// fleetKeys keeps delivery order deterministic (map iteration is
+	// randomized). Key 0 is reserved for "Unassigned" hosts (nil TeamID), so
+	// it can't collide with a real fleet.
+	fleetKeys := make([]uint, 0, len(hosts))
+	hostsByFleet := make(map[uint][]uint)
 	for _, host := range hosts {
-		var teamKey uint
+		var fleetKey uint
 		if host.TeamID != nil {
-			teamKey = *host.TeamID
+			fleetKey = *host.TeamID
 		}
-		if _, ok := seenTeamIDs[teamKey]; ok {
-			continue
+		if _, ok := hostsByFleet[fleetKey]; !ok {
+			fleetKeys = append(fleetKeys, fleetKey)
 		}
-		seenTeamIDs[teamKey] = struct{}{}
+		hostsByFleet[fleetKey] = append(hostsByFleet[fleetKey], host.ID)
+	}
 
+	// Resolve each fleet's webhook into its own delivery.
+	var deliveries []HostActivitiesWebhookDelivery
+	for _, fleetKey := range fleetKeys {
 		var webhook *HostActivitiesWebhookSettings
-		if teamKey == 0 {
+		if fleetKey == 0 {
 			config, err := ds.DefaultTeamConfig(ctx)
 			if err != nil {
 				return nil, err
 			}
 			webhook = config.WebhookSettings.HostActivitiesWebhook
 		} else {
-			team, err := ds.TeamLite(ctx, teamKey)
+			team, err := ds.TeamLite(ctx, fleetKey)
 			if err != nil {
 				// The host's fleet may have been deleted between the activity and
 				// this lookup; skip rather than fail the activity creation.
@@ -358,16 +369,16 @@ func ResolveHostActivitiesWebhooks(ctx context.Context, ds HostActivitiesWebhook
 			webhook = team.Config.WebhookSettings.HostActivitiesWebhook
 		}
 
-		if webhook != nil && webhook.Enable && webhook.DestinationURL != "" {
-			if _, dup := seenURLs[webhook.DestinationURL]; dup {
-				continue
-			}
-			seenURLs[webhook.DestinationURL] = struct{}{}
-			settings = append(settings, *webhook)
+		if webhook == nil || !webhook.Enable || webhook.DestinationURL == "" {
+			continue
 		}
+		deliveries = append(deliveries, HostActivitiesWebhookDelivery{
+			DestinationURL: webhook.DestinationURL,
+			HostIDs:        hostsByFleet[fleetKey],
+		})
 	}
 
-	return settings, nil
+	return deliveries, nil
 }
 
 // DefaultTeam represents the limited team information returned for team ID 0

--- a/server/mock/service/service_mock.go
+++ b/server/mock/service/service_mock.go
@@ -44,7 +44,7 @@ type GetHostLiteFunc func(ctx context.Context, id uint) (host *fleet.Host, err e
 
 type GetActivitiesWebhookSettingsFunc func(ctx context.Context) (fleet.ActivitiesWebhookSettings, error)
 
-type GetHostActivitiesWebhookSettingsFunc func(ctx context.Context, hostIDs []uint) ([]fleet.HostActivitiesWebhookSettings, error)
+type GetHostActivitiesWebhookSettingsFunc func(ctx context.Context, hostIDs []uint) ([]fleet.HostActivitiesWebhookDelivery, error)
 
 type ActivateNextUpcomingActivityForHostFunc func(ctx context.Context, hostID uint, fromCompletedExecID string) error
 
@@ -2523,7 +2523,7 @@ func (s *Service) GetActivitiesWebhookSettings(ctx context.Context) (fleet.Activ
 	return s.GetActivitiesWebhookSettingsFunc(ctx)
 }
 
-func (s *Service) GetHostActivitiesWebhookSettings(ctx context.Context, hostIDs []uint) ([]fleet.HostActivitiesWebhookSettings, error) {
+func (s *Service) GetHostActivitiesWebhookSettings(ctx context.Context, hostIDs []uint) ([]fleet.HostActivitiesWebhookDelivery, error) {
 	s.mu.Lock()
 	s.GetHostActivitiesWebhookSettingsFuncInvoked = true
 	s.mu.Unlock()

--- a/server/service/activities.go
+++ b/server/service/activities.go
@@ -30,7 +30,7 @@ func (svc *Service) GetActivitiesWebhookSettings(ctx context.Context) (fleet.Act
 // not. DefaultTeamConfig is served from the datastore cache but TeamLite is
 // not, so named-fleet hosts cost one lite host read plus one team read per
 // activity.
-func (svc *Service) GetHostActivitiesWebhookSettings(ctx context.Context, hostIDs []uint) ([]fleet.HostActivitiesWebhookSettings, error) {
+func (svc *Service) GetHostActivitiesWebhookSettings(ctx context.Context, hostIDs []uint) ([]fleet.HostActivitiesWebhookDelivery, error) {
 	if !license.IsPremium(ctx) {
 		return nil, nil
 	}

--- a/server/service/activities_test.go
+++ b/server/service/activities_test.go
@@ -291,6 +291,7 @@ func TestGetHostActivitiesWebhookSettings(t *testing.T) {
 		settings, err := svc.GetHostActivitiesWebhookSettings(newLicenseCtx(t, fleet.TierPremium), []uint{1, 2})
 		require.NoError(t, err)
 		require.Len(t, settings, 1)
+		require.Equal(t, []uint{1, 2}, settings[0].HostIDs)
 	})
 
 	t.Run("hosts across fleets return one webhook per enabled fleet", func(t *testing.T) {
@@ -305,14 +306,19 @@ func TestGetHostActivitiesWebhookSettings(t *testing.T) {
 		svc := &Service{ds: ds}
 		settings, err := svc.GetHostActivitiesWebhookSettings(newLicenseCtx(t, fleet.TierPremium), []uint{1, 2, 3})
 		require.NoError(t, err)
-		urls := make([]string, 0, len(settings))
+		// Each delivery carries only its own fleet's hosts (the fleet-2 host is
+		// absent entirely: that fleet's webhook is disabled).
+		hostsByURL := make(map[string][]uint, len(settings))
 		for _, s := range settings {
-			urls = append(urls, s.DestinationURL)
+			hostsByURL[s.DestinationURL] = s.HostIDs
 		}
-		require.ElementsMatch(t, []string{"https://example.com/a", "https://example.com/no-team"}, urls)
+		require.Equal(t, map[string][]uint{
+			"https://example.com/a":       {1},
+			"https://example.com/no-team": {3},
+		}, hostsByURL)
 	})
 
-	t.Run("fleets sharing a destination URL yield one entry", func(t *testing.T) {
+	t.Run("fleets sharing a destination URL yield separate scoped deliveries", func(t *testing.T) {
 		ds := newDS(
 			[]*fleet.Host{hostInTeam(1, &teamID1), hostInTeam(2, &teamID2)},
 			map[uint]*fleet.HostActivitiesWebhookSettings{
@@ -324,8 +330,27 @@ func TestGetHostActivitiesWebhookSettings(t *testing.T) {
 		svc := &Service{ds: ds}
 		settings, err := svc.GetHostActivitiesWebhookSettings(newLicenseCtx(t, fleet.TierPremium), []uint{1, 2})
 		require.NoError(t, err)
-		require.Len(t, settings, 1)
+		// A delivery is one fleet's subscription: sharing a URL must not merge
+		// fleets' host IDs into one payload.
+		require.Len(t, settings, 2)
 		require.Equal(t, "https://example.com/shared", settings[0].DestinationURL)
+		require.Equal(t, []uint{1}, settings[0].HostIDs)
+		require.Equal(t, "https://example.com/shared", settings[1].DestinationURL)
+		require.Equal(t, []uint{2}, settings[1].HostIDs)
+	})
+
+	t.Run("a fleet and no-fleet sharing a destination stay separate deliveries", func(t *testing.T) {
+		ds := newDS(
+			[]*fleet.Host{hostInTeam(1, &teamID1), hostInTeam(2, nil)},
+			map[uint]*fleet.HostActivitiesWebhookSettings{teamID1: enabled("https://example.com/shared")},
+			enabled("https://example.com/shared"),
+		)
+		svc := &Service{ds: ds}
+		settings, err := svc.GetHostActivitiesWebhookSettings(newLicenseCtx(t, fleet.TierPremium), []uint{1, 2})
+		require.NoError(t, err)
+		require.Len(t, settings, 2)
+		require.Equal(t, []uint{1}, settings[0].HostIDs)
+		require.Equal(t, []uint{2}, settings[1].HostIDs)
 	})
 
 	t.Run("no-team host uses the default team config", func(t *testing.T) {

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -3452,7 +3452,8 @@ func (s *integrationEnterpriseTestSuite) TestFailingPolicyAutomationFiresHostAct
 	}
 
 	// The per-fleet host activities webhook received the resulting
-	// ran_automation_webhook activity with host_ids in details.
+	// ran_automation_webhook activity with host_ids injected into the payload
+	// details at fire time.
 	select {
 	case p := <-hostActivitiesCalled:
 		require.Equal(t, "ran_automation_webhook", p.Type)
@@ -3467,11 +3468,136 @@ func (s *integrationEnterpriseTestSuite) TestFailingPolicyAutomationFiresHostAct
 		t.Fatal("timeout waiting for host activities webhook")
 	}
 
-	// The stored activity exposes the same host_ids via the activities API.
+	// The stored activity does NOT carry host_ids: the list is webhook-only,
+	// so API/feed responses stay lean and don't expose the batch's host IDs.
 	s.lastActivityMatches(
 		fleet.ActivityTypeRanAutomationWebhook{}.ActivityName(),
-		fmt.Sprintf(`{"policy_id": %d, "host_ids": [%d]}`, pol.ID, host.ID),
+		fmt.Sprintf(`{"policy_id": %d}`, pol.ID),
 		0)
+}
+
+// A failing GLOBAL policy batch spanning hosts of two fleets fires each
+// fleet's host activities webhook once, and each delivery carries the
+// complete batch host_ids list.
+func (s *integrationEnterpriseTestSuite) TestGlobalPolicyAutomationFiresEachFleetsHostActivitiesWebhook() {
+	t := s.T()
+	ctx := t.Context()
+
+	type hostActivitiesWebhookPayload struct {
+		Type    string          `json:"type"`
+		Details json.RawMessage `json:"details"`
+	}
+	received := make(chan struct {
+		path string
+		body hostActivitiesWebhookPayload
+	}, 4)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/fpw" {
+			_, _ = io.Copy(io.Discard, r.Body)
+			return
+		}
+		var p hostActivitiesWebhookPayload
+		if err := json.NewDecoder(r.Body).Decode(&p); err != nil {
+			t.Log(err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		received <- struct {
+			path string
+			body hostActivitiesWebhookPayload
+		}{path: r.URL.Path, body: p}
+	}))
+	t.Cleanup(srv.Close)
+
+	newHost := func(name string, teamID uint) *fleet.Host {
+		h, err := s.ds.NewHost(ctx, &fleet.Host{
+			DetailUpdatedAt: time.Now(),
+			LabelUpdatedAt:  time.Now(),
+			PolicyUpdatedAt: time.Now(),
+			SeenTime:        time.Now(),
+			NodeKey:         new(t.Name() + name + "-key"),
+			UUID:            t.Name() + name + "-uuid",
+			Hostname:        name,
+			Platform:        "ubuntu",
+			TeamID:          &teamID,
+		})
+		require.NoError(t, err)
+		return h
+	}
+
+	teamA, err := s.ds.NewTeam(ctx, &fleet.Team{Name: t.Name() + "-a"})
+	require.NoError(t, err)
+	teamB, err := s.ds.NewTeam(ctx, &fleet.Team{Name: t.Name() + "-b"})
+	require.NoError(t, err)
+	hostA := newHost("global-batch-host-a", teamA.ID)
+	hostB := newHost("global-batch-host-b", teamB.ID)
+
+	var tmResp teamResponse
+	for teamID, path := range map[uint]string{teamA.ID: "/fleet-a", teamB.ID: "/fleet-b"} {
+		s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", teamID), fleet.TeamPayload{WebhookSettings: &fleet.TeamWebhookSettings{
+			HostActivitiesWebhook: &fleet.HostActivitiesWebhookSettings{
+				Enable:         true,
+				DestinationURL: srv.URL + path,
+			},
+		}}, http.StatusOK, &tmResp)
+	}
+
+	// Global policy (no team) failing on both hosts.
+	gpol, err := s.ds.NewGlobalPolicy(ctx, nil, fleet.PolicyPayload{
+		Name:  "global-host-activities-webhook-failing-policy",
+		Query: "SELECT 1 WHERE 0",
+	})
+	require.NoError(t, err)
+
+	failingPolicySet := NewMemFailingPolicySet()
+	for _, h := range []*fleet.Host{hostA, hostB} {
+		require.NoError(t, failingPolicySet.AddHost(gpol.ID, fleet.PolicySetHost{
+			ID:       h.ID,
+			Hostname: h.Hostname,
+		}))
+	}
+	policy, err := s.ds.Policy(ctx, gpol.ID)
+	require.NoError(t, err)
+	serverURL, err := url.Parse("https://fleet.example.com")
+	require.NoError(t, err)
+	webhookURL, err := url.Parse(srv.URL + "/fpw")
+	require.NoError(t, err)
+
+	activitySvc := mysqltest.NewTestActivityService(t, s.ds)
+	require.NoError(t, webhooks.SendFailingPoliciesBatchedPOSTs(
+		ctx, policy, failingPolicySet, 0, serverURL, webhookURL, time.Now(),
+		slog.New(slog.DiscardHandler), activitySvc,
+	))
+
+	// One delivery per fleet destination, each carrying the complete batch.
+	deliveries := make(map[string]hostActivitiesWebhookPayload, 2)
+	for range 2 {
+		select {
+		case d := <-received:
+			deliveries[d.path] = d.body
+		case <-time.After(5 * time.Second):
+			t.Fatal("timeout waiting for host activities webhooks")
+		}
+	}
+	require.Len(t, deliveries, 2)
+	for _, path := range []string{"/fleet-a", "/fleet-b"} {
+		body, ok := deliveries[path]
+		require.True(t, ok, "expected a webhook POST to %s", path)
+		require.Equal(t, "ran_automation_webhook", body.Type)
+		var details struct {
+			PolicyID uint   `json:"policy_id"`
+			HostIDs  []uint `json:"host_ids"`
+		}
+		require.NoError(t, json.Unmarshal(body.Details, &details))
+		assert.Equal(t, gpol.ID, details.PolicyID)
+		assert.ElementsMatch(t, []uint{hostA.ID, hostB.ID}, details.HostIDs)
+	}
+	// No third delivery: one request per destination, not per host.
+	select {
+	case d := <-received:
+		t.Fatalf("unexpected extra webhook delivery to %s", d.path)
+	case <-time.After(500 * time.Millisecond):
+	}
 }
 
 func (s *integrationEnterpriseTestSuite) TestNoTeamFailingPolicyWebhookTrigger() {

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -3477,8 +3477,8 @@ func (s *integrationEnterpriseTestSuite) TestFailingPolicyAutomationFiresHostAct
 }
 
 // A failing GLOBAL policy batch spanning hosts of two fleets fires each
-// fleet's host activities webhook once, and each delivery carries the
-// complete batch host_ids list.
+// fleet's host activities webhook once, and each delivery carries only the
+// host IDs belonging to that fleet.
 func (s *integrationEnterpriseTestSuite) TestGlobalPolicyAutomationFiresEachFleetsHostActivitiesWebhook() {
 	t := s.T()
 	ctx := t.Context()
@@ -3569,7 +3569,7 @@ func (s *integrationEnterpriseTestSuite) TestGlobalPolicyAutomationFiresEachFlee
 		slog.New(slog.DiscardHandler), activitySvc,
 	))
 
-	// One delivery per fleet destination, each carrying the complete batch.
+	// One delivery per fleet destination, each scoped to that fleet's hosts.
 	deliveries := make(map[string]hostActivitiesWebhookPayload, 2)
 	for range 2 {
 		select {
@@ -3580,6 +3580,10 @@ func (s *integrationEnterpriseTestSuite) TestGlobalPolicyAutomationFiresEachFlee
 		}
 	}
 	require.Len(t, deliveries, 2)
+	wantHostIDs := map[string][]uint{
+		"/fleet-a": {hostA.ID},
+		"/fleet-b": {hostB.ID},
+	}
 	for _, path := range []string{"/fleet-a", "/fleet-b"} {
 		body, ok := deliveries[path]
 		require.True(t, ok, "expected a webhook POST to %s", path)
@@ -3590,7 +3594,8 @@ func (s *integrationEnterpriseTestSuite) TestGlobalPolicyAutomationFiresEachFlee
 		}
 		require.NoError(t, json.Unmarshal(body.Details, &details))
 		assert.Equal(t, gpol.ID, details.PolicyID)
-		assert.ElementsMatch(t, []uint{hostA.ID, hostB.ID}, details.HostIDs)
+		// Each fleet's endpoint only sees its own hosts.
+		assert.Equal(t, wantHostIDs[path], details.HostIDs)
 	}
 	// No third delivery: one request per destination, not per host.
 	select {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #50218

Follow-up to #50487: storing `host_ids` in batch automation activity details exposed potentially-huge cross-fleet host ID arrays in API/feed responses readable by any user with access to one of the batch's hosts (raised in [this thread](https://github.com/fleetdm/fleet/pull/50487#discussion_r3721973309) and [this one](https://github.com/fleetdm/fleet/pull/50487#discussion_r3721983336)).
This PR keeps stored details lean (as on `main`) and injects `host_ids` into the per-fleet webhook payload only, at fire time.

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually

Note that `host_ids` is not exposed in the `activities` API response but it's received on the webhook receiver process I'm running on a terminal.


https://github.com/user-attachments/assets/d136d98d-0199-47d7-bc14-cf9efc7e47f9





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Host activity webhook payloads now include relevant `host_ids` when individual host fields are unavailable.
  * Fleet-specific webhooks receive complete host information without changing stored activity details.
  * Global webhook payloads remain unchanged and avoid duplicate per-host deliveries.
* **Bug Fixes**
  * Existing host fields are preserved, preventing redundant or conflicting host ID data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->