### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/clion/darwin.json
+++ b/ee/maintained-apps/outputs/clion/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.2.0.1",
+      "version": "2026.2.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.CLion';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.CLion' AND version_compare(bundle_short_version, '2026.2.0.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.CLion' AND version_compare(bundle_short_version, '2026.2.1') < 0);"
       },
-      "installer_url": "https://download.jetbrains.com/cpp/CLion-2026.2.0.1-aarch64.dmg",
+      "installer_url": "https://download.jetbrains.com/cpp/CLion-2026.2.1-aarch64.dmg",
       "install_script_ref": "402571cd",
       "uninstall_script_ref": "9c00be7f",
-      "sha256": "9e4909f34adcd5b0291013194f4663650727864cc01b78b5a7d1a1414038813e",
+      "sha256": "5017110b817f95aa2128658e0cd069b16935be85c0585f6e01b4fadd6fc663d3",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/firefox@developer-edition/darwin.json
+++ b/ee/maintained-apps/outputs/firefox@developer-edition/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "154.0b6",
+      "version": "154.0b7",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefoxdeveloperedition';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefoxdeveloperedition' AND version_compare(bundle_version, '15426.8.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefoxdeveloperedition' AND version_compare(bundle_version, '15426.8.5') < 0);"
       },
-      "installer_url": "https://download-installer.cdn.mozilla.net/pub/devedition/releases/154.0b6/mac/en-US/Firefox%20154.0b6.dmg",
+      "installer_url": "https://download-installer.cdn.mozilla.net/pub/devedition/releases/154.0b7/mac/en-US/Firefox%20154.0b7.dmg",
       "install_script_ref": "b679ecd7",
       "uninstall_script_ref": "292c5733",
-      "sha256": "a0fdbd1e966fcb138e0f891cc798022131a5784bbdbde777be8c64e3d00d3066",
+      "sha256": "31e84c8b4a47bcb4bc6c411e23c542fa519afdb2fd3d6d75476f8c8147e1dfc2",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/gitkraken/darwin.json
+++ b/ee/maintained-apps/outputs/gitkraken/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.3.1",
+      "version": "12.4.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.axosoft.gitkraken';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.axosoft.gitkraken' AND version_compare(bundle_short_version, '12.3.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.axosoft.gitkraken' AND version_compare(bundle_short_version, '12.4.0') < 0);"
       },
-      "installer_url": "https://api.gitkraken.dev/releases/production/darwin/arm64/12.3.1/GitKraken-v12.3.1.zip",
+      "installer_url": "https://api.gitkraken.dev/releases/production/darwin/arm64/12.4.0/GitKraken-v12.4.0.zip",
       "install_script_ref": "d255d46a",
       "uninstall_script_ref": "da9e6343",
-      "sha256": "86097ff00dc5c94db41c40aa81e5d006eb77ea1edec3edd3465ee7da2e542f0a",
+      "sha256": "c7aec6ea8a5469d8f7d541866f8357aa22c4a813580ea20d085663e8840f8b1b",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/grammarly-desktop/darwin.json
+++ b/ee/maintained-apps/outputs/grammarly-desktop/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.180.0",
+      "version": "1.181.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama' AND version_compare(bundle_short_version, '1.180.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama' AND version_compare(bundle_short_version, '1.181.2') < 0);"
       },
-      "installer_url": "https://download-mac.grammarly.com/versions/1.180.0.0/Grammarly.dmg",
+      "installer_url": "https://download-mac.grammarly.com/versions/1.181.2.0/Grammarly.dmg",
       "install_script_ref": "8274b7dd",
       "uninstall_script_ref": "7dff0961",
-      "sha256": "b37f314d47e5a2da246513a6572983e47d98a86894f0fe8d604e9a9b0d5cbc62",
+      "sha256": "b9042477a8210f723a268d02b43980af562bde66064827f21e4ed5e86bbe5dfe",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/hive-app/darwin.json
+++ b/ee/maintained-apps/outputs/hive-app/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.2.25",
+      "version": "1.2.26",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app' AND version_compare(bundle_short_version, '1.2.25') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app' AND version_compare(bundle_short_version, '1.2.26') < 0);"
       },
-      "installer_url": "https://github.com/morapelker/hive/releases/download/v1.2.25/Hive-1.2.25-arm64.dmg",
+      "installer_url": "https://github.com/morapelker/hive/releases/download/v1.2.26/Hive-1.2.26-arm64.dmg",
       "install_script_ref": "3bd4ebe4",
       "uninstall_script_ref": "951b5587",
-      "sha256": "d32786794fa2d7e1a7fa04f0fd049d00cc3a2e8a70b870178639e7ad453a2b40",
+      "sha256": "768e77feca24426edd2bac1368f4c487ca580c772c978c81f5fec037a576978f",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/macpacker/darwin.json
+++ b/ee/maintained-apps/outputs/macpacker/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.18.1",
+      "version": "0.19.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.sarensx.MacPacker';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.sarensx.MacPacker' AND version_compare(bundle_short_version, '0.18.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.sarensx.MacPacker' AND version_compare(bundle_short_version, '0.19.0') < 0);"
       },
-      "installer_url": "https://macpacker-releases.s3.amazonaws.com/MacPacker_v0.18.1.zip",
+      "installer_url": "https://macpacker-releases.s3.amazonaws.com/MacPacker_v0.19.0.zip",
       "install_script_ref": "dd6b97de",
       "uninstall_script_ref": "fd696a74",
-      "sha256": "b8d9208f015377c13ceae84d8d09edef4fea0491baa3c7ac92c82fcc176be1b7",
+      "sha256": "ae19e28da057098c5dc13fe379ad7a7300ca51e5c368de5f564e5cbf9794bf46",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/pdf-expert/darwin.json
+++ b/ee/maintained-apps/outputs/pdf-expert/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.11.4",
+      "version": "3.12",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.readdle.PDFExpert-Mac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.readdle.PDFExpert-Mac' AND version_compare(bundle_short_version, '3.11.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.readdle.PDFExpert-Mac' AND version_compare(bundle_short_version, '3.12') < 0);"
       },
-      "installer_url": "https://downloads.pdfexpert.com/pem3/versions/1166/PDFExpert.zip",
+      "installer_url": "https://downloads.pdfexpert.com/pem3/versions/1168/PDFExpert.zip",
       "install_script_ref": "e1cf6e1d",
       "uninstall_script_ref": "bb48ed8b",
-      "sha256": "b86195335a9fc04c35c7efcad9ceff22ed6cc1e6b9518335647952a7694d012c",
+      "sha256": "9c28207c54e360610e2ab8423b556e05d86906e8d9df70660ef7bbea1cd879ca",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/postman/windows.json
+++ b/ee/maintained-apps/outputs/postman/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.22.2",
+      "version": "12.22.3",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.22.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.22.3') < 0);"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.22.2/windows_64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.22.3/windows_64",
       "install_script_ref": "8594f0bc",
       "uninstall_script_ref": "fd59d029",
-      "sha256": "1c562861d9d24a3ef53fd0a91b505c44f02f4f487e0d0e83aaf011f7a117c38b",
+      "sha256": "79289062c16bcb628408510784c52a4061dd873719bb4aa7bb7068968f956e5f",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/tailscale/windows.json
+++ b/ee/maintained-apps/outputs/tailscale/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.102.1",
+      "version": "1.102.2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Tailscale' AND publisher = 'Tailscale Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Tailscale' AND publisher = 'Tailscale Inc.' AND version_compare(version, '1.102.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Tailscale' AND publisher = 'Tailscale Inc.' AND version_compare(version, '1.102.2') < 0);"
       },
-      "installer_url": "https://pkgs.tailscale.com/stable/tailscale-setup-1.102.1-amd64.msi",
+      "installer_url": "https://pkgs.tailscale.com/stable/tailscale-setup-1.102.2-amd64.msi",
       "install_script_ref": "22e48c46",
       "uninstall_script_ref": "b665a7bd",
-      "sha256": "988a38ab854ad176778955b0c92b27b1af14bf5e0146ea43076d829496d7ac77",
+      "sha256": "d2eb69e103b08a5b77de9d7cb8555541aa99f7dfc6048850b2286a1048c885f9",
       "default_categories": [
         "Productivity"
       ],

--- a/ee/maintained-apps/outputs/webstorm/darwin.json
+++ b/ee/maintained-apps/outputs/webstorm/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.2.0.1",
+      "version": "2026.2.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.WebStorm';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.WebStorm' AND version_compare(bundle_short_version, '2026.2.0.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.WebStorm' AND version_compare(bundle_short_version, '2026.2.1') < 0);"
       },
-      "installer_url": "https://download.jetbrains.com/webstorm/WebStorm-2026.2.0.1-aarch64.dmg",
+      "installer_url": "https://download.jetbrains.com/webstorm/WebStorm-2026.2.1-aarch64.dmg",
       "install_script_ref": "2ae71299",
       "uninstall_script_ref": "6c5cf19b",
-      "sha256": "5adbcbec32eb721b0a94c3ebb187a5bb1a0fa3fb1705a530d163b59a5c6d1e47",
+      "sha256": "a0e7a65b5621312fc1390afe30ef45ebd8267ff07e605046230092f604692a01",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/zed/darwin.json
+++ b/ee/maintained-apps/outputs/zed/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.13.2",
+      "version": "1.14.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed' AND version_compare(bundle_short_version, '1.13.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed' AND version_compare(bundle_short_version, '1.14.2') < 0);"
       },
-      "installer_url": "https://zed.dev/api/releases/stable/1.13.2/Zed-aarch64.dmg",
+      "installer_url": "https://zed.dev/api/releases/stable/1.14.2/Zed-aarch64.dmg",
       "install_script_ref": "bdea8414",
       "uninstall_script_ref": "0436e2d8",
-      "sha256": "141971b98a99f788bbb29cbf9ee62240ae662221b79e508805862488de9cd91c",
+      "sha256": "f9df501f431c0e2ba028fb6f364d6332f2d31464175a11d6567e3f59990fe0d2",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/zed/windows.json
+++ b/ee/maintained-apps/outputs/zed/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.13.2",
+      "version": "1.14.2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Zed' AND publisher = 'Zed Industries';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Zed' AND publisher = 'Zed Industries' AND version_compare(version, '1.13.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Zed' AND publisher = 'Zed Industries' AND version_compare(version, '1.14.2') < 0);"
       },
-      "installer_url": "https://github.com/zed-industries/zed/releases/download/v1.13.2/Zed-x86_64.exe",
+      "installer_url": "https://github.com/zed-industries/zed/releases/download/v1.14.2/Zed-x86_64.exe",
       "install_script_ref": "e5193bc1",
       "uninstall_script_ref": "3b164442",
-      "sha256": "f9e73b28ed1d202832dc2ff1e5df1be46297d16ac7aa1762f230f7c9995fd5b3",
+      "sha256": "2ce4154072131dfa466fda5d2b8f61fa14a745010c23e10273f01cb05abfd46a",
       "default_categories": [
         "Developer tools"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated macOS application catalogs for CLion, Firefox Developer Edition, GitKraken, Grammarly Desktop, Hive, MacPacker, PDF Expert, WebStorm, and Zed to their latest releases.
  - Updated Windows application catalogs for Postman, Tailscale, and Zed to their latest releases.
  - Refreshed installer links, version checks, and SHA-256 checksums for each updated package.
  - Updated PDF Expert’s minimum version requirement to 3.12.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->