### PR TITLE
Add Microsoft Store apps in Windows self-service article and guide

### DIFF
--- a/articles/build-your-own-windows-self-service-with-winget-and-script-only-packages-guide.md
+++ b/articles/build-your-own-windows-self-service-with-winget-and-script-only-packages-guide.md
@@ -41,9 +41,11 @@ You need two identifiers, and they are not the same thing.
 These are the only two winget commands involved. Everything in Step 3 exists to get them running in the right place.
 
 ```powershell
-winget install --id 9WZDNCRFJ3PZ --source msstore --accept-package-agreements --accept-source-agreements
-winget uninstall --id 9WZDNCRFJ3PZ
+winget install --id 9WZDNCRFJ3PZ --source msstore --accept-package-agreements --accept-source-agreements --disable-interactivity
+winget uninstall --id 9WZDNCRFJ3PZ --accept-source-agreements --disable-interactivity
 ```
+
+> **Warning:** Keep the agreement flags on the uninstall too. winget [prompts for msstore source agreements even on uninstall](https://github.com/microsoft/winget-cli/issues/1736), and in an unattended script that prompt hangs forever. `--disable-interactivity` turns any remaining prompt into a failure instead.
 
 ## Step 3: Write the install script
 
@@ -53,14 +55,14 @@ Save this as `install-company-portal.ps1`.
 
 ```powershell
 $StoreId = "9WZDNCRFJ3PZ"
-$WingetArgs = "install --id $StoreId --source msstore --accept-package-agreements --accept-source-agreements"
+$WingetArgs = "install --id $StoreId --source msstore --accept-package-agreements --accept-source-agreements --disable-interactivity"
 
 $exitCode = 0
 $taskName = "fleet-store-$StoreId"
 
 try {
     $userName = (Get-CimInstance Win32_Process -Filter 'name = "explorer.exe"' |
-        Invoke-CimMethod -MethodName GetOwner).User
+        Invoke-CimMethod -MethodName GetOwner | Select-Object -First 1).User
     if (-not $userName) { throw "No logged-on user, so there is no session to install into." }
 
     $action = New-ScheduledTaskAction -Execute "winget.exe" -Argument $WingetArgs
@@ -98,7 +100,7 @@ Only the first two lines are app-specific. Inside the user's session, plain `win
 Copy the install script and change one line. Save it as `uninstall-company-portal.ps1`.
 
 ```powershell
-$WingetArgs = "uninstall --id $StoreId"
+$WingetArgs = "uninstall --id $StoreId --accept-source-agreements --disable-interactivity"
 ```
 
 > **Note:** If winget cannot match the installed package on uninstall, remove it directly with `Remove-AppxPackage` inside the same scheduled task, using the package family name from Step 1.
@@ -178,7 +180,7 @@ $exitCode = 0
 $taskName = "fleet-store-$StoreId"
 try {
     $userName = (Get-CimInstance Win32_Process -Filter 'name = "explorer.exe"' |
-        Invoke-CimMethod -MethodName GetOwner).User
+        Invoke-CimMethod -MethodName GetOwner | Select-Object -First 1).User
     if (-not $userName) { throw "No logged-on user, so there is no session to install into." }
     $action = New-ScheduledTaskAction -Execute "winget.exe" -Argument $WingetArgs
     $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries
@@ -205,13 +207,13 @@ exit $exitCode
 
 @"
 `$StoreId = "$StoreId"
-`$WingetArgs = "install --id `$StoreId --source msstore --accept-package-agreements --accept-source-agreements"
+`$WingetArgs = "install --id `$StoreId --source msstore --accept-package-agreements --accept-source-agreements --disable-interactivity"
 $body
 "@ | Set-Content "$dir/install-$slug.ps1" -Encoding UTF8
 
 @"
 `$StoreId = "$StoreId"
-`$WingetArgs = "uninstall --id `$StoreId"
+`$WingetArgs = "uninstall --id `$StoreId --accept-source-agreements --disable-interactivity"
 $body
 "@ | Set-Content "$dir/uninstall-$slug.ps1" -Encoding UTF8
 

--- a/articles/build-your-own-windows-self-service-with-winget-and-script-only-packages-guide.md
+++ b/articles/build-your-own-windows-self-service-with-winget-and-script-only-packages-guide.md
@@ -293,5 +293,5 @@ Self-service installs are per-user. If an app has to be present for every user o
 <meta name="authorFullName" value="Allen Houchins">
 <meta name="authorGitHubUsername" value="allenhouchins">
 <meta name="category" value="guides">
-<meta name="publishedOn" value="2026-08-05">
+<meta name="publishedOn" value="2026-08-07">
 <meta name="description" value="Use Fleet script-only .ps1 packages and winget to add Microsoft Store apps to Windows self-service, per-user or machine-wide.">

--- a/articles/build-your-own-windows-self-service-with-winget-and-script-only-packages-guide.md
+++ b/articles/build-your-own-windows-self-service-with-winget-and-script-only-packages-guide.md
@@ -1,0 +1,324 @@
+# Build a Windows self-service catalog with winget
+
+Fleet 4.89.0 gave script-only packages an uninstall script, a pre-install query, and a post-install script. That is enough to turn winget into a self-service software catalog for Windows, defined entirely in Git, with no `.msi` or `.exe` files to build or host. This guide walks through building one app end to end, then generating the rest from a winget package ID. It covers machine-scope installs from the community `winget` source, plus an optional path for user-scope apps.
+
+> **Warning:** Fleet runs Windows scripts as SYSTEM, and Microsoft [does not support the winget CLI in the system context](https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting). Step 1 works around that for machine-scope installs. Microsoft Store apps from the `msstore` source cannot be installed device-wide at all, so those need Step 7.
+
+## Prerequisites
+
+- Fleet 4.89.0 or later. The uninstall script, pre-install query, and post-install script on script-only packages were added in this release.
+- A GitOps repository connected to your Fleet instance. Software is defined per fleet in `fleets/<name>.yml`.
+- Windows hosts enrolled in Fleet with scripts enabled. See the [scripts guide](https://fleetdm.com/guides/scripts) if you deployed Fleet's agent without `--enable-scripts`.
+- App Installer present on those hosts, which provides winget. Windows Server and LTSC images often ship without it.
+- Fleet Desktop available to end users, so the self-service page is reachable from the Windows system tray.
+
+> **Note:** Script-only packages do not support an `install_script` key, because the file's contents already are the install script. They also do not support automatic install through a policy. Drive installs through self-service.
+
+## Step 1: Locate winget in the SYSTEM context
+
+The `winget` app execution alias lives in a per-user path, so SYSTEM has no `winget` command. The binary is still on disk inside the App Installer package directory. Resolve it there.
+
+The directory name embeds the version, so sort on the parsed version rather than the string. A plain descending sort puts `1.9` above `1.24`.
+
+```powershell
+$winget = Resolve-Path "$env:ProgramFiles\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction SilentlyContinue |
+    Sort-Object { [version](($_.Path -split '_')[1]) } |
+    Select-Object -Last 1 -ExpandProperty Path
+
+if (-not $winget) {
+    Write-Host "App Installer (winget) was not found on this host."
+    exit 1
+}
+```
+
+Both scripts below open with this block.
+
+## Step 2: Write the install script
+
+Save this as `install-7zip.ps1`.
+
+```powershell
+$PackageId = "7zip.7zip"
+
+$winget = Resolve-Path "$env:ProgramFiles\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction SilentlyContinue |
+    Sort-Object { [version](($_.Path -split '_')[1]) } |
+    Select-Object -Last 1 -ExpandProperty Path
+
+if (-not $winget) {
+    Write-Host "App Installer (winget) was not found on this host."
+    exit 1
+}
+
+Write-Host "Installing $PackageId with $winget"
+& $winget install --id $PackageId --exact --source winget `
+    --scope machine --silent `
+    --accept-package-agreements --accept-source-agreements `
+    --disable-interactivity
+$code = $LASTEXITCODE
+
+# 0 = installed. -1978335135 (0x8A150061) = already installed, which is not a failure.
+if ($code -eq 0 -or $code -eq -1978335135) {
+    Write-Host "$PackageId is installed."
+    exit 0
+}
+
+Write-Host "winget exited with $code"
+exit 1
+```
+
+Use `--exact` with `--id` so winget cannot resolve a fuzzy name match to the wrong package. The `--silent`, `--accept-package-agreements`, `--accept-source-agreements`, and `--disable-interactivity` flags keep the run unattended.
+
+> **Warning:** PowerShell ignores a native command's non-zero exit code. `$ErrorActionPreference` governs PowerShell errors, not process exit codes, so a failed `winget install` leaves your script exiting 0 and Fleet marking the install successful. Check `$LASTEXITCODE` and propagate it, as above.
+
+> **Note:** Microsoft documents that `--scope machine` is reliable for MSI and MSIX packages but not deterministic for EXE-based installers, where the scope arguments may not exist at all. Verify per app.
+
+## Step 3: Write the uninstall script
+
+Save this as `uninstall-7zip.ps1`. Removing something already absent is a successful no-op, so treat `-1978335212` as success.
+
+```powershell
+$PackageId = "7zip.7zip"
+
+$winget = Resolve-Path "$env:ProgramFiles\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction SilentlyContinue |
+    Sort-Object { [version](($_.Path -split '_')[1]) } |
+    Select-Object -Last 1 -ExpandProperty Path
+
+if (-not $winget) {
+    Write-Host "App Installer (winget) was not found on this host."
+    exit 1
+}
+
+& $winget uninstall --id $PackageId --exact --silent `
+    --accept-source-agreements --disable-interactivity
+$code = $LASTEXITCODE
+
+# -1978335212 (0x8A150014) = no packages found, so there is nothing to remove.
+if ($code -eq 0 -or $code -eq -1978335212) {
+    Write-Host "$PackageId is not installed."
+    exit 0
+}
+
+Write-Host "winget exited with $code"
+exit 1
+```
+
+## Step 4: Register the package in your fleet file
+
+Save both scripts under `lib/windows/scripts/` in your GitOps repo. Then register the package in the fleet where you want it available, in `fleets/<name>.yml` or `fleets/unassigned.yml`.
+
+```yaml
+software:
+  packages:
+    - path: ../lib/windows/scripts/install-7zip.ps1
+      display_name: 7-Zip
+      self_service: true
+      categories:
+        - "💻 Productivity"
+      uninstall_script:
+        path: ../lib/windows/scripts/uninstall-7zip.ps1
+```
+
+With `self_service: true`, the app appears on the end user's self-service page, reachable from the Fleet icon in the Windows system tray. When the user clicks install, Fleet's agent runs the install script as SYSTEM. When they remove it, the uninstall script runs.
+
+## Step 5: Target the right hosts with labels
+
+Define a dynamic label, then reference it on the package so only the intended hosts see the tile.
+
+```yaml
+labels:
+  - name: Windows
+    query: "SELECT 1 FROM os_version WHERE platform = 'windows';"
+    label_membership_type: dynamic
+```
+
+```yaml
+software:
+  packages:
+    - path: ../lib/windows/scripts/install-7zip.ps1
+      display_name: 7-Zip
+      self_service: true
+      labels_include_any:
+        - Windows
+      uninstall_script:
+        path: ../lib/windows/scripts/uninstall-7zip.ps1
+```
+
+Use labels to exclude the hosts winget cannot help, such as Windows Server and LTSC images without App Installer.
+
+> **Note:** Any label you reference on a package must be defined in the `labels` section first. Use `labels_include_any`, `labels_include_all`, or `labels_exclude_any`, but only one per package.
+
+## Step 6: Verify the install landed
+
+A post-install script runs after the install. A non-zero exit fails the install and triggers your uninstall script. Check the state of the machine rather than asking winget again, so a broken winget cannot vouch for itself.
+
+Save this as `verify-7zip.ps1`.
+
+```powershell
+$DisplayNamePattern = "7-Zip*"
+
+$paths = @(
+    "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*",
+    "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*"
+)
+
+$found = Get-ItemProperty -Path $paths -ErrorAction SilentlyContinue |
+    Where-Object { $_.DisplayName -like $DisplayNamePattern }
+
+if (-not $found) {
+    Write-Host "$DisplayNamePattern was not found in the uninstall registry."
+    exit 1
+}
+
+Write-Host "Found $($found[0].DisplayName) $($found[0].DisplayVersion)."
+exit 0
+```
+
+Reference it on the package:
+
+```yaml
+      post_install_script:
+        path: ../lib/windows/scripts/verify-7zip.ps1
+```
+
+> **Note:** For a user-scope install, `HKLM` is the wrong place to look. Those entries land under the user's own hive, so enumerate `HKEY_USERS` from SYSTEM. `HKCU` as SYSTEM points at the wrong profile.
+
+## Step 7: Install user-scope apps as the logged-on user (optional)
+
+Some apps refuse to install machine-wide. Squirrel-based Electron apps, anything from the Microsoft Store, and a long tail of `--scope user` packages all need a user profile to install into, and no SYSTEM-context workaround changes that.
+
+Run winget as the user instead. Create a short-lived scheduled task that runs as the owner of the `explorer.exe` process, start it, wait for it to finish, then unregister it. This is the same pattern Fleet uses for its own per-user Windows [Fleet-maintained apps](https://fleetdm.com/guides/fleet-maintained-apps).
+
+```powershell
+$PackageId = "Figma.Figma"
+$exitCode = 0
+$taskName = "fleet-install-$PackageId"
+
+try {
+    $userName = (Get-CimInstance Win32_Process -Filter 'name = "explorer.exe"' |
+        Invoke-CimMethod -MethodName GetOwner).User
+    if (-not $userName) { throw "No logged-on user found; cannot install a user-scope app." }
+
+    $args = "install --id $PackageId --exact --source winget --scope user --silent " +
+            "--accept-package-agreements --accept-source-agreements --disable-interactivity"
+    $action = New-ScheduledTaskAction -Execute "winget.exe" -Argument $args
+    $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries
+    $task = New-ScheduledTask -Action $action -Settings $settings
+
+    Register-ScheduledTask $taskName -InputObject $task -User $userName | Out-Null
+    Start-ScheduledTask -TaskName $taskName -TaskPath "\"
+
+    $startDate = Get-Date
+    do {
+        Start-Sleep -Seconds 5
+        $state = (Get-ScheduledTask -TaskName $taskName).State
+        Write-Host "Scheduled task is '$state'."
+        if ((New-TimeSpan -Start $startDate -End (Get-Date)).TotalSeconds -gt 600) {
+            throw "Timed out waiting for the install to finish."
+        }
+    } while ($state -eq "Running" -or $state -eq "Queued")
+} catch {
+    Write-Host "Error: $_"
+    $exitCode = 1
+} finally {
+    Unregister-ScheduledTask -TaskName $taskName -Confirm:$false -ErrorAction SilentlyContinue
+}
+
+exit $exitCode
+```
+
+Because the task runs in the user's session, plain `winget.exe` resolves through the app execution alias and no path hunting is needed. Swap `install` for `uninstall` to build the matching removal script.
+
+> **Warning:** The scheduled task's own exit code does not come back to your script, so this path reports success even when winget failed. The verification script in Step 6 is mandatory here, reading `HKEY_USERS` rather than `HKLM`.
+
+## Step 8: Generate new apps from a winget ID
+
+Once the pattern is settled, the only real input is the package ID. This generator writes both scripts and prints the YAML block to paste into your fleet file. Save it as `New-SelfServiceApp.ps1`.
+
+```powershell
+param(
+    [Parameter(Mandatory)][string]$PackageId,
+    [string]$DisplayName = $PackageId,
+    [string]$Category = "💻 Productivity"
+)
+
+$dir = "lib/windows/scripts"
+New-Item -ItemType Directory -Path $dir -Force | Out-Null
+$slug = $PackageId.ToLower().Replace(".", "-")
+
+$resolve = @'
+$winget = Resolve-Path "$env:ProgramFiles\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction SilentlyContinue |
+    Sort-Object { [version](($_.Path -split '_')[1]) } |
+    Select-Object -Last 1 -ExpandProperty Path
+if (-not $winget) { Write-Host "App Installer (winget) was not found."; exit 1 }
+'@
+
+@"
+`$PackageId = "$PackageId"
+$resolve
+& `$winget install --id `$PackageId --exact --source winget --scope machine --silent ``
+    --accept-package-agreements --accept-source-agreements --disable-interactivity
+`$code = `$LASTEXITCODE
+if (`$code -eq 0 -or `$code -eq -1978335135) { exit 0 }
+Write-Host "winget exited with `$code"
+exit 1
+"@ | Set-Content "$dir/install-$slug.ps1" -Encoding UTF8
+
+@"
+`$PackageId = "$PackageId"
+$resolve
+& `$winget uninstall --id `$PackageId --exact --silent ``
+    --accept-source-agreements --disable-interactivity
+`$code = `$LASTEXITCODE
+if (`$code -eq 0 -or `$code -eq -1978335212) { exit 0 }
+Write-Host "winget exited with `$code"
+exit 1
+"@ | Set-Content "$dir/uninstall-$slug.ps1" -Encoding UTF8
+
+@"
+
+# Add to your fleet's software.packages:
+    - path: ../$dir/install-$slug.ps1
+      display_name: $DisplayName
+      self_service: true
+      categories:
+        - "$Category"
+      uninstall_script:
+        path: ../$dir/uninstall-$slug.ps1
+"@
+```
+
+To onboard an app, find the ID with `winget search`, run the generator, paste the printed block into your fleet file, and open a pull request.
+
+```powershell
+./New-SelfServiceApp.ps1 -PackageId 7zip.7zip -DisplayName "7-Zip"
+```
+
+Write the verification script from Step 6 by hand. The display name in the registry rarely matches the winget ID closely enough to generate.
+
+## Troubleshoot
+
+**The install reports success but the app is not present.** Add the post-install verification script from Step 6. Without it, a script that swallows winget's exit code leaves the tile claiming success. This is the default failure mode on Windows, because PowerShell does not stop on a non-zero native exit code.
+
+**The script fails with "App Installer (winget) was not found on this host."** The host has no App Installer package, which is common on Windows Server and LTSC images. Exclude those hosts with a label, or install App Installer first.
+
+**The install fails with "Device wide install for msstore type is not supported under admin context."** The package is a Microsoft Store app, and Store packages cannot be installed device-wide. Use the community `winget` source if the app is published there, or follow Step 7.
+
+**The install hangs.** A prompt is waiting for input that will never come. Confirm `--silent`, `--accept-package-agreements`, `--accept-source-agreements`, and `--disable-interactivity` are all on the command.
+
+**The tile does not appear on a host's self-service page.** Check that the host matches the package's label. Confirm the label query returns the host in the Fleet UI under the label's host list.
+
+**A user-scope install does nothing.** No one is logged in, so there is no `explorer.exe` owner to run the task as. The script in Step 7 throws in that case rather than reporting success.
+
+## Further reading
+
+- [Deploy software guide](https://fleetdm.com/guides/deploy-software-packages) for full detail on script-only packages, pre-install queries, and uninstall scripts.
+- [Build your own Windows self-service with winget](https://fleetdm.com/articles/build-your-own-windows-self-service-with-winget-and-script-only-packages) for the reasoning behind this approach.
+- [winget troubleshooting](https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting) for Microsoft's guidance on the system context and installer scope.
+- [GitOps YAML reference](https://fleetdm.com/docs/configuration/yaml-files).
+
+<meta name="articleTitle" value="Build a Windows self-service catalog with winget">
+<meta name="authorFullName" value="Allen Houchins">
+<meta name="authorGitHubUsername" value="allenhouchins">
+<meta name="category" value="guides">
+<meta name="publishedOn" value="2026-08-05">
+<meta name="description" value="Use Fleet script-only .ps1 packages and winget to build a Windows self-service catalog, including the SYSTEM context workaround.">

--- a/articles/build-your-own-windows-self-service-with-winget-and-script-only-packages-guide.md
+++ b/articles/build-your-own-windows-self-service-with-winget-and-script-only-packages-guide.md
@@ -1,8 +1,8 @@
-# Build a Windows self-service catalog with winget
+# Add Microsoft Store apps to Windows self-service with winget
 
-Fleet 4.89.0 gave script-only packages an uninstall script, a pre-install query, and a post-install script. That is enough to turn winget into a self-service software catalog for Windows, defined entirely in Git, with no `.msi` or `.exe` files to build or host. This guide walks through building one app end to end, then generating the rest from a winget package ID. It covers machine-scope installs from the community `winget` source, plus an optional path for user-scope apps.
+Fleet 4.89.0 gave script-only packages an uninstall script, a pre-install query, and a post-install script. That is enough to put Microsoft Store apps on your end users' self-service page using winget, with no packages to host. This guide builds one Store app tile end to end, then generates the rest from a Store ID. It covers per-user Store installs driven through self-service, which is the only scope the Store supports through winget.
 
-> **Warning:** Fleet runs Windows scripts as SYSTEM, and Microsoft [does not support the winget CLI in the system context](https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting). Step 1 works around that for machine-scope installs. Microsoft Store apps from the `msstore` source cannot be installed device-wide at all, so those need Step 7.
+> **Warning:** `winget install --source msstore` cannot run as SYSTEM, and Fleet runs Windows scripts as SYSTEM. The Store rejects device-wide installs with "Device wide install for msstore type is not supported under admin context." Step 3 works around this by running winget in the logged-on user's session. If you need a Store app installed machine-wide for every user, see [Deploy a Store app machine-wide](#deploy-a-store-app-machine-wide) instead.
 
 ## Prerequisites
 
@@ -12,195 +12,58 @@ Fleet 4.89.0 gave script-only packages an uninstall script, a pre-install query,
 - App Installer present on those hosts, which provides winget. Windows Server and LTSC images often ship without it.
 - Fleet Desktop available to end users, so the self-service page is reachable from the Windows system tray.
 
-> **Note:** Script-only packages do not support an `install_script` key, because the file's contents already are the install script. They also do not support automatic install through a policy. Drive installs through self-service.
+> **Note:** Script-only packages do not support an `install_script` key, because the file's contents already are the install script. They also do not support automatic install through a policy. Drive these through self-service.
 
-## Step 1: Locate winget in the SYSTEM context
+## Step 1: Find the Store ID and package name
 
-The `winget` app execution alias lives in a per-user path, so SYSTEM has no `winget` command. The binary is still on disk inside the App Installer package directory. Resolve it there.
+You need two identifiers, and they are not the same thing.
 
-The directory name embeds the version, so sort on the parsed version rather than the string. A plain descending sort puts `1.9` above `1.24`.
+1. Get the **Store ID**, a twelve-character string winget uses to install the app.
 
-```powershell
-$winget = Resolve-Path "$env:ProgramFiles\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction SilentlyContinue |
-    Sort-Object { [version](($_.Path -split '_')[1]) } |
-    Select-Object -Last 1 -ExpandProperty Path
+   ```powershell
+   winget search --source msstore "company portal"
+   ```
 
-if (-not $winget) {
-    Write-Host "App Installer (winget) was not found on this host."
-    exit 1
-}
-```
+   For Company Portal, the ID is `9WZDNCRFJ3PZ`.
 
-Both scripts below open with this block.
+2. Install the app by hand on one machine, then get the **MSIX package name**, which you need for verification in Step 5.
 
-## Step 2: Write the install script
+   ```powershell
+   Get-AppxPackage | Select-Object Name, PackageFamilyName
+   ```
 
-Save this as `install-7zip.ps1`.
+   For Company Portal, the name is `Microsoft.CompanyPortal`.
 
-```powershell
-$PackageId = "7zip.7zip"
+> **Note:** Always pin to the Store ID rather than the app name. A name match can resolve to the wrong package, and nothing is watching the output when Fleet runs the script.
 
-$winget = Resolve-Path "$env:ProgramFiles\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction SilentlyContinue |
-    Sort-Object { [version](($_.Path -split '_')[1]) } |
-    Select-Object -Last 1 -ExpandProperty Path
+## Step 2: Confirm the commands you are wrapping
 
-if (-not $winget) {
-    Write-Host "App Installer (winget) was not found on this host."
-    exit 1
-}
-
-Write-Host "Installing $PackageId with $winget"
-& $winget install --id $PackageId --exact --source winget `
-    --scope machine --silent `
-    --accept-package-agreements --accept-source-agreements `
-    --disable-interactivity
-$code = $LASTEXITCODE
-
-# 0 = installed. -1978335135 (0x8A150061) = already installed, which is not a failure.
-if ($code -eq 0 -or $code -eq -1978335135) {
-    Write-Host "$PackageId is installed."
-    exit 0
-}
-
-Write-Host "winget exited with $code"
-exit 1
-```
-
-Use `--exact` with `--id` so winget cannot resolve a fuzzy name match to the wrong package. The `--silent`, `--accept-package-agreements`, `--accept-source-agreements`, and `--disable-interactivity` flags keep the run unattended.
-
-> **Warning:** PowerShell ignores a native command's non-zero exit code. `$ErrorActionPreference` governs PowerShell errors, not process exit codes, so a failed `winget install` leaves your script exiting 0 and Fleet marking the install successful. Check `$LASTEXITCODE` and propagate it, as above.
-
-> **Note:** Microsoft documents that `--scope machine` is reliable for MSI and MSIX packages but not deterministic for EXE-based installers, where the scope arguments may not exist at all. Verify per app.
-
-## Step 3: Write the uninstall script
-
-Save this as `uninstall-7zip.ps1`. Removing something already absent is a successful no-op, so treat `-1978335212` as success.
+These are the only two winget commands involved. Everything in Step 3 exists to get them running in the right place.
 
 ```powershell
-$PackageId = "7zip.7zip"
-
-$winget = Resolve-Path "$env:ProgramFiles\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction SilentlyContinue |
-    Sort-Object { [version](($_.Path -split '_')[1]) } |
-    Select-Object -Last 1 -ExpandProperty Path
-
-if (-not $winget) {
-    Write-Host "App Installer (winget) was not found on this host."
-    exit 1
-}
-
-& $winget uninstall --id $PackageId --exact --silent `
-    --accept-source-agreements --disable-interactivity
-$code = $LASTEXITCODE
-
-# -1978335212 (0x8A150014) = no packages found, so there is nothing to remove.
-if ($code -eq 0 -or $code -eq -1978335212) {
-    Write-Host "$PackageId is not installed."
-    exit 0
-}
-
-Write-Host "winget exited with $code"
-exit 1
+winget install --id 9WZDNCRFJ3PZ --source msstore --accept-package-agreements --accept-source-agreements
+winget uninstall --id 9WZDNCRFJ3PZ
 ```
 
-## Step 4: Register the package in your fleet file
+## Step 3: Write the install script
 
-Save both scripts under `lib/windows/scripts/` in your GitOps repo. Then register the package in the fleet where you want it available, in `fleets/<name>.yml` or `fleets/unassigned.yml`.
+Fleet runs the script as SYSTEM, where neither winget nor the Store will cooperate. Create a short-lived scheduled task owned by the logged-on user, start it, wait for it to finish, then remove it.
 
-```yaml
-software:
-  packages:
-    - path: ../lib/windows/scripts/install-7zip.ps1
-      display_name: 7-Zip
-      self_service: true
-      categories:
-        - "💻 Productivity"
-      uninstall_script:
-        path: ../lib/windows/scripts/uninstall-7zip.ps1
-```
-
-With `self_service: true`, the app appears on the end user's self-service page, reachable from the Fleet icon in the Windows system tray. When the user clicks install, Fleet's agent runs the install script as SYSTEM. When they remove it, the uninstall script runs.
-
-## Step 5: Target the right hosts with labels
-
-Define a dynamic label, then reference it on the package so only the intended hosts see the tile.
-
-```yaml
-labels:
-  - name: Windows
-    query: "SELECT 1 FROM os_version WHERE platform = 'windows';"
-    label_membership_type: dynamic
-```
-
-```yaml
-software:
-  packages:
-    - path: ../lib/windows/scripts/install-7zip.ps1
-      display_name: 7-Zip
-      self_service: true
-      labels_include_any:
-        - Windows
-      uninstall_script:
-        path: ../lib/windows/scripts/uninstall-7zip.ps1
-```
-
-Use labels to exclude the hosts winget cannot help, such as Windows Server and LTSC images without App Installer.
-
-> **Note:** Any label you reference on a package must be defined in the `labels` section first. Use `labels_include_any`, `labels_include_all`, or `labels_exclude_any`, but only one per package.
-
-## Step 6: Verify the install landed
-
-A post-install script runs after the install. A non-zero exit fails the install and triggers your uninstall script. Check the state of the machine rather than asking winget again, so a broken winget cannot vouch for itself.
-
-Save this as `verify-7zip.ps1`.
+Save this as `install-company-portal.ps1`.
 
 ```powershell
-$DisplayNamePattern = "7-Zip*"
+$StoreId = "9WZDNCRFJ3PZ"
+$WingetArgs = "install --id $StoreId --source msstore --accept-package-agreements --accept-source-agreements"
 
-$paths = @(
-    "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*",
-    "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*"
-)
-
-$found = Get-ItemProperty -Path $paths -ErrorAction SilentlyContinue |
-    Where-Object { $_.DisplayName -like $DisplayNamePattern }
-
-if (-not $found) {
-    Write-Host "$DisplayNamePattern was not found in the uninstall registry."
-    exit 1
-}
-
-Write-Host "Found $($found[0].DisplayName) $($found[0].DisplayVersion)."
-exit 0
-```
-
-Reference it on the package:
-
-```yaml
-      post_install_script:
-        path: ../lib/windows/scripts/verify-7zip.ps1
-```
-
-> **Note:** For a user-scope install, `HKLM` is the wrong place to look. Those entries land under the user's own hive, so enumerate `HKEY_USERS` from SYSTEM. `HKCU` as SYSTEM points at the wrong profile.
-
-## Step 7: Install user-scope apps as the logged-on user (optional)
-
-Some apps refuse to install machine-wide. Squirrel-based Electron apps, anything from the Microsoft Store, and a long tail of `--scope user` packages all need a user profile to install into, and no SYSTEM-context workaround changes that.
-
-Run winget as the user instead. Create a short-lived scheduled task that runs as the owner of the `explorer.exe` process, start it, wait for it to finish, then unregister it. This is the same pattern Fleet uses for its own per-user Windows [Fleet-maintained apps](https://fleetdm.com/guides/fleet-maintained-apps).
-
-```powershell
-$PackageId = "Figma.Figma"
 $exitCode = 0
-$taskName = "fleet-install-$PackageId"
+$taskName = "fleet-store-$StoreId"
 
 try {
     $userName = (Get-CimInstance Win32_Process -Filter 'name = "explorer.exe"' |
         Invoke-CimMethod -MethodName GetOwner).User
-    if (-not $userName) { throw "No logged-on user found; cannot install a user-scope app." }
+    if (-not $userName) { throw "No logged-on user, so there is no session to install into." }
 
-    $args = "install --id $PackageId --exact --source winget --scope user --silent " +
-            "--accept-package-agreements --accept-source-agreements --disable-interactivity"
-    $action = New-ScheduledTaskAction -Execute "winget.exe" -Argument $args
+    $action = New-ScheduledTaskAction -Execute "winget.exe" -Argument $WingetArgs
     $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries
     $task = New-ScheduledTask -Action $action -Settings $settings
 
@@ -213,7 +76,7 @@ try {
         $state = (Get-ScheduledTask -TaskName $taskName).State
         Write-Host "Scheduled task is '$state'."
         if ((New-TimeSpan -Start $startDate -End (Get-Date)).TotalSeconds -gt 600) {
-            throw "Timed out waiting for the install to finish."
+            throw "Timed out waiting for winget to finish."
         }
     } while ($state -eq "Running" -or $state -eq "Queued")
 } catch {
@@ -226,53 +89,139 @@ try {
 exit $exitCode
 ```
 
-Because the task runs in the user's session, plain `winget.exe` resolves through the app execution alias and no path hunting is needed. Swap `install` for `uninstall` to build the matching removal script.
+Only the first two lines are app-specific. Inside the user's session, plain `winget.exe` resolves through the app execution alias, so no path resolution is needed.
 
-> **Warning:** The scheduled task's own exit code does not come back to your script, so this path reports success even when winget failed. The verification script in Step 6 is mandatory here, reading `HKEY_USERS` rather than `HKLM`.
+> **Warning:** The scheduled task's exit code does not come back to this script, so it reports success whenever the task ran, whether or not winget installed anything. Step 5 is what catches that, and it is not optional here.
 
-## Step 8: Generate new apps from a winget ID
+## Step 4: Write the uninstall script
 
-Once the pattern is settled, the only real input is the package ID. This generator writes both scripts and prints the YAML block to paste into your fleet file. Save it as `New-SelfServiceApp.ps1`.
+Copy the install script and change one line. Save it as `uninstall-company-portal.ps1`.
+
+```powershell
+$WingetArgs = "uninstall --id $StoreId"
+```
+
+> **Note:** If winget cannot match the installed package on uninstall, remove it directly with `Remove-AppxPackage` inside the same scheduled task, using the package family name from Step 1.
+
+## Step 5: Verify the install landed
+
+Store apps do not register in `HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall`, so a registry check fails on a good install. Ask the MSIX subsystem instead. Fleet runs this as SYSTEM, which is elevated, so `-AllUsers` will see a package installed in a user's profile.
+
+Save this as `verify-company-portal.ps1`.
+
+```powershell
+$PackageName = "Microsoft.CompanyPortal"
+
+$pkg = Get-AppxPackage -AllUsers -Name $PackageName -ErrorAction SilentlyContinue
+if (-not $pkg) {
+    Write-Host "$PackageName is not installed for any user."
+    exit 1
+}
+
+Write-Host "Found $($pkg[0].Name) $($pkg[0].Version)."
+exit 0
+```
+
+A non-zero exit from the post-install script fails the install and triggers your uninstall script.
+
+## Step 6: Register the package in your fleet file
+
+Save all three scripts under `lib/windows/scripts/` in your GitOps repo. Then register the package in `fleets/<name>.yml` or `fleets/unassigned.yml`.
+
+```yaml
+labels:
+  - name: Windows
+    query: "SELECT 1 FROM os_version WHERE platform = 'windows';"
+    label_membership_type: dynamic
+```
+
+```yaml
+software:
+  packages:
+    - path: ../lib/windows/scripts/install-company-portal.ps1
+      display_name: Company Portal
+      self_service: true
+      categories:
+        - "💻 Productivity"
+      labels_include_any:
+        - Windows
+      uninstall_script:
+        path: ../lib/windows/scripts/uninstall-company-portal.ps1
+      post_install_script:
+        path: ../lib/windows/scripts/verify-company-portal.ps1
+```
+
+With `self_service: true`, the app appears on the end user's self-service page, reachable from the Fleet icon in the Windows system tray.
+
+> **Note:** Any label you reference on a package must be defined in the `labels` section first. Use `labels_include_any`, `labels_include_all`, or `labels_exclude_any`, but only one per package. Use a label to exclude hosts without App Installer, such as Windows Server and LTSC images.
+
+## Step 7: Generate new tiles from a Store ID
+
+Only two lines differ between apps, so the rest can be emitted. Fleet script-only packages are single files with no shared helper to import, so the boilerplate is inlined into each generated script.
+
+Save this as `New-StoreAppTile.ps1`.
 
 ```powershell
 param(
-    [Parameter(Mandatory)][string]$PackageId,
-    [string]$DisplayName = $PackageId,
+    [Parameter(Mandatory)][string]$StoreId,
+    [Parameter(Mandatory)][string]$DisplayName,
+    [Parameter(Mandatory)][string]$PackageName,
     [string]$Category = "💻 Productivity"
 )
 
 $dir = "lib/windows/scripts"
 New-Item -ItemType Directory -Path $dir -Force | Out-Null
-$slug = $PackageId.ToLower().Replace(".", "-")
+$slug = $DisplayName.ToLower() -replace '[^a-z0-9]+', '-'
 
-$resolve = @'
-$winget = Resolve-Path "$env:ProgramFiles\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction SilentlyContinue |
-    Sort-Object { [version](($_.Path -split '_')[1]) } |
-    Select-Object -Last 1 -ExpandProperty Path
-if (-not $winget) { Write-Host "App Installer (winget) was not found."; exit 1 }
+$body = @'
+$exitCode = 0
+$taskName = "fleet-store-$StoreId"
+try {
+    $userName = (Get-CimInstance Win32_Process -Filter 'name = "explorer.exe"' |
+        Invoke-CimMethod -MethodName GetOwner).User
+    if (-not $userName) { throw "No logged-on user, so there is no session to install into." }
+    $action = New-ScheduledTaskAction -Execute "winget.exe" -Argument $WingetArgs
+    $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries
+    $task = New-ScheduledTask -Action $action -Settings $settings
+    Register-ScheduledTask $taskName -InputObject $task -User $userName | Out-Null
+    Start-ScheduledTask -TaskName $taskName -TaskPath "\"
+    $startDate = Get-Date
+    do {
+        Start-Sleep -Seconds 5
+        $state = (Get-ScheduledTask -TaskName $taskName).State
+        Write-Host "Scheduled task is '$state'."
+        if ((New-TimeSpan -Start $startDate -End (Get-Date)).TotalSeconds -gt 600) {
+            throw "Timed out waiting for winget to finish."
+        }
+    } while ($state -eq "Running" -or $state -eq "Queued")
+} catch {
+    Write-Host "Error: $_"
+    $exitCode = 1
+} finally {
+    Unregister-ScheduledTask -TaskName $taskName -Confirm:$false -ErrorAction SilentlyContinue
+}
+exit $exitCode
 '@
 
 @"
-`$PackageId = "$PackageId"
-$resolve
-& `$winget install --id `$PackageId --exact --source winget --scope machine --silent ``
-    --accept-package-agreements --accept-source-agreements --disable-interactivity
-`$code = `$LASTEXITCODE
-if (`$code -eq 0 -or `$code -eq -1978335135) { exit 0 }
-Write-Host "winget exited with `$code"
-exit 1
+`$StoreId = "$StoreId"
+`$WingetArgs = "install --id `$StoreId --source msstore --accept-package-agreements --accept-source-agreements"
+$body
 "@ | Set-Content "$dir/install-$slug.ps1" -Encoding UTF8
 
 @"
-`$PackageId = "$PackageId"
-$resolve
-& `$winget uninstall --id `$PackageId --exact --silent ``
-    --accept-source-agreements --disable-interactivity
-`$code = `$LASTEXITCODE
-if (`$code -eq 0 -or `$code -eq -1978335212) { exit 0 }
-Write-Host "winget exited with `$code"
-exit 1
+`$StoreId = "$StoreId"
+`$WingetArgs = "uninstall --id `$StoreId"
+$body
 "@ | Set-Content "$dir/uninstall-$slug.ps1" -Encoding UTF8
+
+@"
+`$PackageName = "$PackageName"
+`$pkg = Get-AppxPackage -AllUsers -Name `$PackageName -ErrorAction SilentlyContinue
+if (-not `$pkg) { Write-Host "`$PackageName is not installed for any user."; exit 1 }
+Write-Host "Found `$(`$pkg[0].Name) `$(`$pkg[0].Version)."
+exit 0
+"@ | Set-Content "$dir/verify-$slug.ps1" -Encoding UTF8
 
 @"
 
@@ -282,43 +231,65 @@ exit 1
       self_service: true
       categories:
         - "$Category"
+      labels_include_any:
+        - Windows
       uninstall_script:
         path: ../$dir/uninstall-$slug.ps1
+      post_install_script:
+        path: ../$dir/verify-$slug.ps1
 "@
 ```
 
-To onboard an app, find the ID with `winget search`, run the generator, paste the printed block into your fleet file, and open a pull request.
+Run it with the two identifiers from Step 1, then paste the printed block into your fleet file and open a pull request.
 
 ```powershell
-./New-SelfServiceApp.ps1 -PackageId 7zip.7zip -DisplayName "7-Zip"
+./New-StoreAppTile.ps1 -StoreId 9WZDNCRFJ3PZ -DisplayName "Company Portal" -PackageName Microsoft.CompanyPortal
 ```
 
-Write the verification script from Step 6 by hand. The display name in the registry rarely matches the winget ID closely enough to generate.
+## Deploy a Store app machine-wide
+
+Self-service installs are per-user. If an app has to be present for every user on a host, provision it instead of installing it, which does work as SYSTEM.
+
+1. On an admin workstation, download the package and its license.
+
+   ```powershell
+   winget download --id 9WZDNCRFJ3PZ --source msstore --download-directory C:\staging
+   ```
+
+2. Provision it on the host.
+
+   ```powershell
+   Add-AppxProvisionedPackage -Online -PackagePath .\app.msixbundle -LicensePath .\9WZDNCRFJ3PZ_License.xml
+   ```
+
+> **Warning:** Downloading a Store package's license file [requires Entra ID authentication](https://learn.microsoft.com/en-us/windows/package-manager/winget/download) by an account with the Global Administrator, User Administrator, or License Administrator role. You also now have a file to deliver, so use a Fleet custom package rather than a script-only one.
+
+> **Note:** Do not reach for `winget install --scope machine` as a shortcut here. For a Store package it [installs under the SYSTEM account](https://github.com/microsoft/winget-cli/issues/4748) rather than provisioning the app, which looks like success and leaves no app for your users.
 
 ## Troubleshoot
 
-**The install reports success but the app is not present.** Add the post-install verification script from Step 6. Without it, a script that swallows winget's exit code leaves the tile claiming success. This is the default failure mode on Windows, because PowerShell does not stop on a non-zero native exit code.
+**The install fails with "Device wide install for msstore type is not supported under admin context."** The script is running winget as SYSTEM. Store apps are per-user, so wrap the call in the scheduled task from Step 3, or provision the app machine-wide instead.
 
-**The script fails with "App Installer (winget) was not found on this host."** The host has no App Installer package, which is common on Windows Server and LTSC images. Exclude those hosts with a label, or install App Installer first.
+**The install reports success but the app is not there.** The scheduled task ran and winget failed inside it. The task's exit code never reaches your script, so add the verification script from Step 5, which fails the install and triggers the uninstall.
 
-**The install fails with "Device wide install for msstore type is not supported under admin context."** The package is a Microsoft Store app, and Store packages cannot be installed device-wide. Use the community `winget` source if the app is published there, or follow Step 7.
+**Verification fails even though the app is installed.** Check that you are using `Get-AppxPackage -AllUsers` and the MSIX package name from Step 1, not the Store ID. Store apps never appear in the uninstall registry keys, so a registry-based check always fails here.
 
-**The install hangs.** A prompt is waiting for input that will never come. Confirm `--silent`, `--accept-package-agreements`, `--accept-source-agreements`, and `--disable-interactivity` are all on the command.
+**Nothing happens and the script throws "No logged-on user."** There is no `explorer.exe` owner to run the task as. This is expected on a host at the login screen, and self-service installs assume somebody is signed in.
 
-**The tile does not appear on a host's self-service page.** Check that the host matches the package's label. Confirm the label query returns the host in the Fleet UI under the label's host list.
+**The script fails because `winget` is not recognized.** The host has no App Installer package, which is common on Windows Server and LTSC images. Exclude those hosts with a label, or install App Installer first.
 
-**A user-scope install does nothing.** No one is logged in, so there is no `explorer.exe` owner to run the task as. The script in Step 7 throws in that case rather than reporting success.
+**The tile does not appear on a host's self-service page.** Confirm the host matches the package's label, and that the label query returns the host in the Fleet UI under the label's host list.
 
 ## Further reading
 
 - [Deploy software guide](https://fleetdm.com/guides/deploy-software-packages) for full detail on script-only packages, pre-install queries, and uninstall scripts.
-- [Build your own Windows self-service with winget](https://fleetdm.com/articles/build-your-own-windows-self-service-with-winget-and-script-only-packages) for the reasoning behind this approach.
-- [winget troubleshooting](https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting) for Microsoft's guidance on the system context and installer scope.
+- [Put Microsoft Store apps in Windows self-service with winget](https://fleetdm.com/articles/build-your-own-windows-self-service-with-winget-and-script-only-packages) for the reasoning behind this approach.
+- [winget troubleshooting](https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting) for Microsoft's guidance on the system context.
 - [GitOps YAML reference](https://fleetdm.com/docs/configuration/yaml-files).
 
-<meta name="articleTitle" value="Build a Windows self-service catalog with winget">
+<meta name="articleTitle" value="Add Microsoft Store apps to Windows self-service with winget">
 <meta name="authorFullName" value="Allen Houchins">
 <meta name="authorGitHubUsername" value="allenhouchins">
 <meta name="category" value="guides">
 <meta name="publishedOn" value="2026-08-05">
-<meta name="description" value="Use Fleet script-only .ps1 packages and winget to build a Windows self-service catalog, including the SYSTEM context workaround.">
+<meta name="description" value="Use Fleet script-only .ps1 packages and winget to add Microsoft Store apps to Windows self-service, per-user or machine-wide.">

--- a/articles/build-your-own-windows-self-service-with-winget-and-script-only-packages.md
+++ b/articles/build-your-own-windows-self-service-with-winget-and-script-only-packages.md
@@ -1,0 +1,334 @@
+# Build your own Windows self-service with winget
+
+_The same Fleet 4.89.0 additions that turned `apt-get install` into a Linux self-service catalog work on Windows with `.ps1` packages. Windows has one problem Linux doesn't: Microsoft says winget isn't supported in the SYSTEM context._
+
+## Key takeaways
+
+- **A `.ps1` script-only package is a full install lifecycle.** As of Fleet 4.89.0, a PowerShell script-only package can carry an uninstall script, a pre-install query, and a post-install script, which is everything you need to put a package manager behind a self-service tile.
+- **Fleet runs your script as SYSTEM, and winget does not officially run there.** App Installer ships as an MSIX package that can be registered for any user except `NT AUTHORITY\SYSTEM`, so `winget` is not on the PATH your script inherits. You resolve the executable yourself.
+- **Machine-scope apps from the `winget` source work well; Microsoft Store apps do not.** The community `winget` source installs machine-wide cleanly. The `msstore` source refuses device-wide installs outright, so a "Store app" tile needs a different approach.
+- **For per-user apps, hand the install to the logged-on user.** A short-lived scheduled task running as the console user is the same pattern Fleet uses for its own per-user Windows apps, and it's what makes user-scope winget installs possible at all.
+- **PowerShell won't fail the install for you.** Unlike `set -euo pipefail` in bash, PowerShell ignores a native command's non-zero exit code, so you have to propagate it yourself. And winget's "already installed" code isn't a failure.
+- **The per-app work is mechanical enough to generate.** Given a winget package ID, a generator emits the install script, the uninstall script, and the YAML block, so adding an app is one command and a pull request.
+
+<a purpose="cta-button" href="https://fleetdm.com/infrastructure-as-code">See it managed as code</a>
+
+[Fleet 4.89.0](https://fleetdm.com/releases/fleet-4.89.0) added an uninstall script, a pre-install query, and a post-install script to script-only packages. On Linux, that was enough to [build a self-service catalog on top of apt and dnf](https://fleetdm.com/articles/build-your-own-linux-self-service-with-script-only-packages) with no `.deb` files to host. Windows gets the same three additions for `.ps1` files, and Windows has a package manager of its own in winget.
+
+The recipe does not port over unchanged, though. On Linux, Fleet hands your script to a root shell and `apt-get` is right there on the PATH. On Windows, Fleet hands your script to PowerShell running as SYSTEM, and that is precisely the one account winget cannot be registered for. Everything interesting about building this on Windows follows from that one fact.
+
+## The building block: script-only packages on Windows
+
+A script-only package is a `.sh` file (Linux) or a `.ps1` file (Windows) that you add to Fleet as software. There is no installer binary and no metadata extraction. The file's contents are the install script, and Fleet runs them on the host when someone installs the "package."
+
+Since 4.89.0, a script-only package can also carry a pre-install query that must return at least one row before the install runs, a post-install script whose non-zero exit fails the install and triggers the uninstall, and an uninstall script that runs when an admin or end user removes the software. What it still cannot do is take an `install_script` key, because the file's contents already are the install script, or install automatically through a policy. Drive these through self-service.
+
+That's the shape of a package manager front end: put an app on, take it off, check your work.
+
+## Where the Linux recipe breaks: winget and the SYSTEM context
+
+Fleet's agent executes Windows scripts as `powershell -MTA -ExecutionPolicy Bypass -File <script>`, running as SYSTEM. Microsoft's own [winget troubleshooting documentation](https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting) is unambiguous about what that means: because winget is delivered through App Installer as a packaged MSIX application, and MSIX packages can be registered for any user except `NT AUTHORITY\SYSTEM`, the winget CLI is not supported in the system context.
+
+In practice that produces two separate problems, and they need separate answers.
+
+The first is cosmetic but fatal: the `winget` app execution alias lives in a per-user path, so SYSTEM has no `winget` command. The binary is still on disk inside the App Installer package directory, and calling it there works for machine-scope installs. This is the workaround the Windows admin community has converged on, and it's the one used below. Microsoft also notes that the `Microsoft.WinGet.Client` PowerShell module can be used in the system context for applications installed machine-wide, which is the supported path if you're willing to get that module onto every host first.
+
+The second problem is structural, and it's the one that matters if you came here wanting Microsoft Store apps. Store packages are inherently per-user, and winget's `msstore` source rejects device-wide installs with "Device wide install for msstore type is not supported under admin context." No amount of path resolution fixes that, because it isn't a path problem. If the app you want exists in the community `winget` source, use that source and read the next section. If it only exists in the Store, skip ahead to running the install as the logged-on user, and expect Store licensing and Entra ID authentication to complicate it further.
+
+## The install script: machine-scope apps
+
+Start by finding the executable. The App Installer directory name embeds the version, so sort on the parsed version rather than the string. A plain descending sort puts `1.9` above `1.24`.
+
+```powershell
+# install-7zip.ps1
+$PackageId = "7zip.7zip"
+
+$winget = Resolve-Path "$env:ProgramFiles\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction SilentlyContinue |
+    Sort-Object { [version](($_.Path -split '_')[1]) } |
+    Select-Object -Last 1 -ExpandProperty Path
+
+if (-not $winget) {
+    Write-Host "App Installer (winget) was not found on this host."
+    exit 1
+}
+
+Write-Host "Installing $PackageId with $winget"
+& $winget install --id $PackageId --exact --source winget `
+    --scope machine --silent `
+    --accept-package-agreements --accept-source-agreements `
+    --disable-interactivity
+$code = $LASTEXITCODE
+
+# 0 = installed. -1978335135 (0x8A150061) = already installed, which is not a failure.
+if ($code -eq 0 -or $code -eq -1978335135) {
+    Write-Host "$PackageId is installed."
+    exit 0
+}
+
+Write-Host "winget exited with $code"
+exit 1
+```
+
+Three details in there are doing real work.
+
+`--exact` with `--id` stops winget from resolving a fuzzy name match to the wrong package, which is a genuine risk when nobody is watching the output. `--silent`, `--accept-package-agreements`, `--accept-source-agreements`, and `--disable-interactivity` together are the Windows equivalent of `DEBIAN_FRONTEND=noninteractive`: without them a prompt waits forever for a user who isn't there.
+
+The explicit exit code handling is the part with no Linux counterpart. In bash, `set -euo pipefail` makes the script die the moment a command fails. PowerShell does not work that way. `$ErrorActionPreference` governs PowerShell errors, not native process exit codes, so a failed `winget install` leaves your script running happily and exiting 0. Fleet reads that 0 and marks the install successful. You have to check `$LASTEXITCODE` and propagate it, and while you're there, treat `-1978335135` as success, because a host that already has the app is not a failed install.
+
+One honest caveat on `--scope machine`: Microsoft [documents](https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting) that scope is reliable for MSI and MSIX packages but not deterministic for EXE-based installers, where the arguments to specify scope may not exist at all. Verify per app rather than assuming.
+
+## Add the uninstall
+
+The mirror image, with the same path resolution and the same care about exit codes. Removing something that was already absent is a successful no-op, so `-1978335212` (no packages found) exits 0.
+
+```powershell
+# uninstall-7zip.ps1
+$PackageId = "7zip.7zip"
+
+$winget = Resolve-Path "$env:ProgramFiles\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction SilentlyContinue |
+    Sort-Object { [version](($_.Path -split '_')[1]) } |
+    Select-Object -Last 1 -ExpandProperty Path
+
+if (-not $winget) {
+    Write-Host "App Installer (winget) was not found on this host."
+    exit 1
+}
+
+& $winget uninstall --id $PackageId --exact --silent `
+    --accept-source-agreements --disable-interactivity
+$code = $LASTEXITCODE
+
+# -1978335212 (0x8A150014) = no packages found, so there is nothing to remove.
+if ($code -eq 0 -or $code -eq -1978335212) {
+    Write-Host "$PackageId is not installed."
+    exit 0
+}
+
+Write-Host "winget exited with $code"
+exit 1
+```
+
+Save both under `lib/windows/scripts/` in your GitOps repo, then register the package in the fleet where you want it available. Software is defined per fleet, so this goes in `fleets/<name>.yml` or `fleets/unassigned.yml`:
+
+```yaml
+software:
+  packages:
+    - path: ../lib/windows/scripts/install-7zip.ps1
+      display_name: 7-Zip
+      self_service: true
+      categories:
+        - "💻 Productivity"
+      uninstall_script:
+        path: ../lib/windows/scripts/uninstall-7zip.ps1
+```
+
+With `self_service: true`, the app appears on the end user's self-service page, reachable from the Fleet icon in the Windows system tray. When they click install, Fleet's agent runs the install script as SYSTEM. When they remove it, the uninstall script runs.
+
+## Per-user apps: hand the install to the logged-on user
+
+Some apps refuse to install machine-wide at all. Squirrel-based Electron apps, anything from the Store, and a long tail of `--scope user` packages all fall in this bucket, and no SYSTEM-context trick makes them work, because the install genuinely needs a user profile to land in.
+
+The answer is to stop fighting it and run winget as the user. Fleet uses exactly this pattern for its own per-user Windows [Fleet-maintained apps](https://fleetdm.com/guides/fleet-maintained-apps): create a short-lived scheduled task that runs as the owner of the `explorer.exe` process, start it, wait for it to finish, then unregister it.
+
+```powershell
+# install-figma-user-scope.ps1
+$PackageId = "Figma.Figma"
+$exitCode = 0
+$taskName = "fleet-install-$PackageId"
+
+try {
+    $userName = (Get-CimInstance Win32_Process -Filter 'name = "explorer.exe"' |
+        Invoke-CimMethod -MethodName GetOwner).User
+    if (-not $userName) { throw "No logged-on user found; cannot install a user-scope app." }
+
+    $args = "install --id $PackageId --exact --source winget --scope user --silent " +
+            "--accept-package-agreements --accept-source-agreements --disable-interactivity"
+    $action = New-ScheduledTaskAction -Execute "winget.exe" -Argument $args
+    $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries
+    $task = New-ScheduledTask -Action $action -Settings $settings
+
+    Register-ScheduledTask $taskName -InputObject $task -User $userName | Out-Null
+    Start-ScheduledTask -TaskName $taskName -TaskPath "\"
+
+    $startDate = Get-Date
+    do {
+        Start-Sleep -Seconds 5
+        $state = (Get-ScheduledTask -TaskName $taskName).State
+        Write-Host "Scheduled task is '$state'."
+        if ((New-TimeSpan -Start $startDate -End (Get-Date)).TotalSeconds -gt 600) {
+            throw "Timed out waiting for the install to finish."
+        }
+    } while ($state -eq "Running" -or $state -eq "Queued")
+} catch {
+    Write-Host "Error: $_"
+    $exitCode = 1
+} finally {
+    Unregister-ScheduledTask -TaskName $taskName -Confirm:$false -ErrorAction SilentlyContinue
+}
+
+exit $exitCode
+```
+
+Because the task runs in the user's session, plain `winget.exe` resolves normally through the app execution alias and no path hunting is needed. The trade-off is real, though: this only works when someone is logged in, the scheduled task's own exit code doesn't come back to you, and you learn nothing about whether winget actually succeeded. That makes the verification step in the next section mandatory here rather than merely advisable.
+
+The same pattern also cleanly covers the uninstall, swapping `install` for `uninstall`. Sweep every user profile if the app may have been installed by more than one person.
+
+## Guardrails: targeting and verification
+
+### Target the right hosts with labels
+
+Define a dynamic label and reference it on the package so only the intended hosts see the tile:
+
+```yaml
+labels:
+  - name: Windows
+    query: "SELECT 1 FROM os_version WHERE platform = 'windows';"
+    label_membership_type: dynamic
+```
+
+```yaml
+software:
+  packages:
+    - path: ../lib/windows/scripts/install-7zip.ps1
+      display_name: 7-Zip
+      self_service: true
+      labels_include_any:
+        - Windows
+      uninstall_script:
+        path: ../lib/windows/scripts/uninstall-7zip.ps1
+```
+
+Any label you reference on a package has to be defined in the `labels` section first, and you can use only one of `labels_include_any`, `labels_include_all`, or `labels_exclude_any` per package. Labels also give you somewhere to put the hosts winget can't help: Windows Server and LTSC images often ship without App Installer at all, and excluding them is kinder than letting the script fail on every attempt.
+
+### Verify the install actually landed
+
+A post-install script runs after the install, and a non-zero exit fails the install and triggers your uninstall script. Check the state of the machine rather than asking winget again, so a broken winget can't vouch for itself:
+
+```powershell
+# verify-7zip.ps1
+$DisplayNamePattern = "7-Zip*"
+
+$paths = @(
+    "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*",
+    "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*"
+)
+
+$found = Get-ItemProperty -Path $paths -ErrorAction SilentlyContinue |
+    Where-Object { $_.DisplayName -like $DisplayNamePattern }
+
+if (-not $found) {
+    Write-Host "$DisplayNamePattern was not found in the uninstall registry."
+    exit 1
+}
+
+Write-Host "Found $($found[0].DisplayName) $($found[0].DisplayVersion)."
+exit 0
+```
+
+```yaml
+      post_install_script:
+        path: ../lib/windows/scripts/verify-7zip.ps1
+```
+
+For a user-scope install, `HKLM` is the wrong place to look. Those entries land under the user's own hive, so enumerate `HKEY_USERS` from SYSTEM instead of `HKCU`, which as SYSTEM points at the wrong profile entirely.
+
+A pre-install query can gate the install as well, proceeding only if the query returns a row. Labels are the better tool for platform targeting, so save the query for a genuine precondition.
+
+## Wire it into GitOps
+
+Every self-service app is a set of files in your repository:
+
+```
+lib/
+  windows/
+    scripts/
+      install-7zip.ps1
+      uninstall-7zip.ps1
+      verify-7zip.ps1
+fleets/
+  workstations.yml   # references the scripts under software.packages
+```
+
+Adding, changing, or removing an app is a pull request. Reviewers see the exact commands that will run as SYSTEM on every targeted host, the change ships through CI when it merges, and the catalog is auditable and reversible by design. [Turn on GitOps mode](https://fleetdm.com/learn-more-about/ui-gitops-mode) to make the Fleet UI reflect that these are code-managed. Fleet manages its own software this way, and the [it-and-security configuration](https://github.com/fleetdm/fleet/tree/main/it-and-security/fleets) is public if you want a real-world layout to borrow from.
+
+## Automate it: from a winget ID to a self-service tile
+
+Once the pattern settles, the only real input is the package ID. This generator writes both scripts and prints the YAML block:
+
+```powershell
+# New-SelfServiceApp.ps1 -PackageId 7zip.7zip -DisplayName "7-Zip"
+param(
+    [Parameter(Mandatory)][string]$PackageId,
+    [string]$DisplayName = $PackageId,
+    [string]$Category = "💻 Productivity"
+)
+
+$dir = "lib/windows/scripts"
+New-Item -ItemType Directory -Path $dir -Force | Out-Null
+$slug = $PackageId.ToLower().Replace(".", "-")
+
+$resolve = @'
+$winget = Resolve-Path "$env:ProgramFiles\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction SilentlyContinue |
+    Sort-Object { [version](($_.Path -split '_')[1]) } |
+    Select-Object -Last 1 -ExpandProperty Path
+if (-not $winget) { Write-Host "App Installer (winget) was not found."; exit 1 }
+'@
+
+@"
+`$PackageId = "$PackageId"
+$resolve
+& `$winget install --id `$PackageId --exact --source winget --scope machine --silent ``
+    --accept-package-agreements --accept-source-agreements --disable-interactivity
+`$code = `$LASTEXITCODE
+if (`$code -eq 0 -or `$code -eq -1978335135) { exit 0 }
+Write-Host "winget exited with `$code"
+exit 1
+"@ | Set-Content "$dir/install-$slug.ps1" -Encoding UTF8
+
+@"
+`$PackageId = "$PackageId"
+$resolve
+& `$winget uninstall --id `$PackageId --exact --silent ``
+    --accept-source-agreements --disable-interactivity
+`$code = `$LASTEXITCODE
+if (`$code -eq 0 -or `$code -eq -1978335212) { exit 0 }
+Write-Host "winget exited with `$code"
+exit 1
+"@ | Set-Content "$dir/uninstall-$slug.ps1" -Encoding UTF8
+
+@"
+
+# Add to your fleet's software.packages:
+    - path: ../$dir/install-$slug.ps1
+      display_name: $DisplayName
+      self_service: true
+      categories:
+        - "$Category"
+      uninstall_script:
+        path: ../$dir/uninstall-$slug.ps1
+"@
+```
+
+Onboarding an app becomes: find the ID with `winget search`, run `./New-SelfServiceApp.ps1 -PackageId 7zip.7zip -DisplayName "7-Zip"`, paste the printed block into your fleet file, and open a pull request. Write the verification script by hand, because the display name in the registry rarely matches the winget ID closely enough to generate.
+
+## The point
+
+Fleet didn't ship a Windows software store in 4.89.0. It shipped three small additions to script-only packages, and those are enough to build one on top of the package manager Microsoft already ships, with no installers to host and no per-app UI work.
+
+Windows makes you earn it in a way Linux doesn't. The SYSTEM context is a real constraint, not a bug you can wait out, and it forces a decision per app: machine scope through the resolved binary, or user scope through the logged-on user. Make that decision once, encode it in a script, and the rest is a naming convention in Git.
+
+## See it live
+
+- Follow the [step-by-step guide](https://fleetdm.com/guides/build-your-own-windows-self-service-with-winget-and-script-only-packages-guide) to build your first app end to end.
+- Read the [deploy software guide](https://fleetdm.com/guides/deploy-software-packages) for the full detail on script-only packages, pre-install queries, and uninstall scripts.
+- Get a demo: [fleetdm.com/contact](https://fleetdm.com/contact).
+- Join a free GitOps workshop: [fleetdm.com/workshops](https://fleetdm.com/workshops).
+
+_Managing devices as code, one pull request at a time. Start with the [GitOps reference](https://fleetdm.com/docs/configuration/yaml-files) or [talk to us](https://fleetdm.com/contact)._
+
+<meta name="articleTitle" value="Build your own Windows self-service with winget">
+<meta name="authorFullName" value="Allen Houchins">
+<meta name="authorGitHubUsername" value="allenhouchins">
+<meta name="category" value="articles">
+<meta name="publishedOn" value="2026-08-05">
+<meta name="description" value="Use Fleet script-only .ps1 packages to put winget behind a Windows self-service tile, including the SYSTEM context workaround.">

--- a/articles/build-your-own-windows-self-service-with-winget-and-script-only-packages.md
+++ b/articles/build-your-own-windows-self-service-with-winget-and-script-only-packages.md
@@ -1,149 +1,67 @@
-# Build your own Windows self-service with winget
+# Put Microsoft Store apps in Windows self-service with winget
 
-_The same Fleet 4.89.0 additions that turned `apt-get install` into a Linux self-service catalog work on Windows with `.ps1` packages. Windows has one problem Linux doesn't: Microsoft says winget isn't supported in the SYSTEM context._
+_Installing a Store app with winget is one command. Getting that one command to run from Fleet is the interesting part, because Fleet runs scripts as SYSTEM and the Microsoft Store does not._
 
 ## Key takeaways
 
-- **A `.ps1` script-only package is a full install lifecycle.** As of Fleet 4.89.0, a PowerShell script-only package can carry an uninstall script, a pre-install query, and a post-install script, which is everything you need to put a package manager behind a self-service tile.
-- **Fleet runs your script as SYSTEM, and winget does not officially run there.** App Installer ships as an MSIX package that can be registered for any user except `NT AUTHORITY\SYSTEM`, so `winget` is not on the PATH your script inherits. You resolve the executable yourself.
-- **Machine-scope apps from the `winget` source work well; Microsoft Store apps do not.** The community `winget` source installs machine-wide cleanly. The `msstore` source refuses device-wide installs outright, so a "Store app" tile needs a different approach.
-- **For per-user apps, hand the install to the logged-on user.** A short-lived scheduled task running as the console user is the same pattern Fleet uses for its own per-user Windows apps, and it's what makes user-scope winget installs possible at all.
-- **PowerShell won't fail the install for you.** Unlike `set -euo pipefail` in bash, PowerShell ignores a native command's non-zero exit code, so you have to propagate it yourself. And winget's "already installed" code isn't a failure.
-- **The per-app work is mechanical enough to generate.** Given a winget package ID, a generator emits the install script, the uninstall script, and the YAML block, so adding an app is one command and a pull request.
+- **The per-app work is genuinely one line.** A Store app is identified by its Store ID, and the install is `winget install --id <StoreId> --source msstore`. Everything else in the script is boilerplate you write once.
+- **That one line fails as SYSTEM, and no flag fixes it.** Fleet hands Windows scripts to PowerShell running as SYSTEM. The `msstore` source refuses device-wide installs outright, because Store packages are per-user by design.
+- **The fix is to run winget in the user's session, not to run it harder.** A short-lived scheduled task owned by the console user puts winget where the Store expects it, and `winget` resolves normally there with no path hunting.
+- **Verification has to read the MSIX world, not the registry.** Store apps never appear in the uninstall registry keys, so `Get-AppxPackage -AllUsers` is the check that tells you the truth.
+- **Machine-wide Store deployment exists, but it's a different tool.** Downloading the package and provisioning it with `Add-AppxProvisionedPackage` works as SYSTEM, at the cost of Entra ID licensing rights and a file to host.
+- **A Store ID is enough to generate the whole tile.** Given an ID, a generator emits the install script, the uninstall script, and the YAML, so onboarding an app is one command and a pull request.
 
 <a purpose="cta-button" href="https://fleetdm.com/infrastructure-as-code">See it managed as code</a>
 
-[Fleet 4.89.0](https://fleetdm.com/releases/fleet-4.89.0) added an uninstall script, a pre-install query, and a post-install script to script-only packages. On Linux, that was enough to [build a self-service catalog on top of apt and dnf](https://fleetdm.com/articles/build-your-own-linux-self-service-with-script-only-packages) with no `.deb` files to host. Windows gets the same three additions for `.ps1` files, and Windows has a package manager of its own in winget.
+[Fleet 4.89.0](https://fleetdm.com/releases/fleet-4.89.0) added an uninstall script, a pre-install query, and a post-install script to script-only packages. On Linux, that was enough to [build a self-service catalog on top of apt and dnf](https://fleetdm.com/articles/build-your-own-linux-self-service-with-script-only-packages). Windows gets the same three additions for `.ps1` files, and Windows already ships a package manager that can reach the Microsoft Store.
 
-The recipe does not port over unchanged, though. On Linux, Fleet hands your script to a root shell and `apt-get` is right there on the PATH. On Windows, Fleet hands your script to PowerShell running as SYSTEM, and that is precisely the one account winget cannot be registered for. Everything interesting about building this on Windows follows from that one fact.
+So the obvious move is a two-line script: `winget install` on the way in, `winget uninstall` on the way out. Those are the right commands. They won't run where Fleet puts them, though, and understanding why is what turns a broken tile into a working one.
 
-## The building block: script-only packages on Windows
+## What the install and uninstall actually are
 
-A script-only package is a `.sh` file (Linux) or a `.ps1` file (Windows) that you add to Fleet as software. There is no installer binary and no metadata extraction. The file's contents are the install script, and Fleet runs them on the host when someone installs the "package."
-
-Since 4.89.0, a script-only package can also carry a pre-install query that must return at least one row before the install runs, a post-install script whose non-zero exit fails the install and triggers the uninstall, and an uninstall script that runs when an admin or end user removes the software. What it still cannot do is take an `install_script` key, because the file's contents already are the install script, or install automatically through a policy. Drive these through self-service.
-
-That's the shape of a package manager front end: put an app on, take it off, check your work.
-
-## Where the Linux recipe breaks: winget and the SYSTEM context
-
-Fleet's agent executes Windows scripts as `powershell -MTA -ExecutionPolicy Bypass -File <script>`, running as SYSTEM. Microsoft's own [winget troubleshooting documentation](https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting) is unambiguous about what that means: because winget is delivered through App Installer as a packaged MSIX application, and MSIX packages can be registered for any user except `NT AUTHORITY\SYSTEM`, the winget CLI is not supported in the system context.
-
-In practice that produces two separate problems, and they need separate answers.
-
-The first is cosmetic but fatal: the `winget` app execution alias lives in a per-user path, so SYSTEM has no `winget` command. The binary is still on disk inside the App Installer package directory, and calling it there works for machine-scope installs. This is the workaround the Windows admin community has converged on, and it's the one used below. Microsoft also notes that the `Microsoft.WinGet.Client` PowerShell module can be used in the system context for applications installed machine-wide, which is the supported path if you're willing to get that module onto every host first.
-
-The second problem is structural, and it's the one that matters if you came here wanting Microsoft Store apps. Store packages are inherently per-user, and winget's `msstore` source rejects device-wide installs with "Device wide install for msstore type is not supported under admin context." No amount of path resolution fixes that, because it isn't a path problem. If the app you want exists in the community `winget` source, use that source and read the next section. If it only exists in the Store, skip ahead to running the install as the logged-on user, and expect Store licensing and Entra ID authentication to complicate it further.
-
-## The install script: machine-scope apps
-
-Start by finding the executable. The App Installer directory name embeds the version, so sort on the parsed version rather than the string. A plain descending sort puts `1.9` above `1.24`.
+Start with the destination, because it's short. Every Store app has a Store ID, a twelve-character string like `9WZDNCRFJ3PZ` for Company Portal. Find it with a search:
 
 ```powershell
-# install-7zip.ps1
-$PackageId = "7zip.7zip"
-
-$winget = Resolve-Path "$env:ProgramFiles\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction SilentlyContinue |
-    Sort-Object { [version](($_.Path -split '_')[1]) } |
-    Select-Object -Last 1 -ExpandProperty Path
-
-if (-not $winget) {
-    Write-Host "App Installer (winget) was not found on this host."
-    exit 1
-}
-
-Write-Host "Installing $PackageId with $winget"
-& $winget install --id $PackageId --exact --source winget `
-    --scope machine --silent `
-    --accept-package-agreements --accept-source-agreements `
-    --disable-interactivity
-$code = $LASTEXITCODE
-
-# 0 = installed. -1978335135 (0x8A150061) = already installed, which is not a failure.
-if ($code -eq 0 -or $code -eq -1978335135) {
-    Write-Host "$PackageId is installed."
-    exit 0
-}
-
-Write-Host "winget exited with $code"
-exit 1
+winget search --source msstore "company portal"
 ```
 
-Three details in there are doing real work.
-
-`--exact` with `--id` stops winget from resolving a fuzzy name match to the wrong package, which is a genuine risk when nobody is watching the output. `--silent`, `--accept-package-agreements`, `--accept-source-agreements`, and `--disable-interactivity` together are the Windows equivalent of `DEBIAN_FRONTEND=noninteractive`: without them a prompt waits forever for a user who isn't there.
-
-The explicit exit code handling is the part with no Linux counterpart. In bash, `set -euo pipefail` makes the script die the moment a command fails. PowerShell does not work that way. `$ErrorActionPreference` governs PowerShell errors, not native process exit codes, so a failed `winget install` leaves your script running happily and exiting 0. Fleet reads that 0 and marks the install successful. You have to check `$LASTEXITCODE` and propagate it, and while you're there, treat `-1978335135` as success, because a host that already has the app is not a failed install.
-
-One honest caveat on `--scope machine`: Microsoft [documents](https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting) that scope is reliable for MSI and MSIX packages but not deterministic for EXE-based installers, where the arguments to specify scope may not exist at all. Verify per app rather than assuming.
-
-## Add the uninstall
-
-The mirror image, with the same path resolution and the same care about exit codes. Removing something that was already absent is a successful no-op, so `-1978335212` (no packages found) exits 0.
+Given the ID, the two commands you need are these:
 
 ```powershell
-# uninstall-7zip.ps1
-$PackageId = "7zip.7zip"
-
-$winget = Resolve-Path "$env:ProgramFiles\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction SilentlyContinue |
-    Sort-Object { [version](($_.Path -split '_')[1]) } |
-    Select-Object -Last 1 -ExpandProperty Path
-
-if (-not $winget) {
-    Write-Host "App Installer (winget) was not found on this host."
-    exit 1
-}
-
-& $winget uninstall --id $PackageId --exact --silent `
-    --accept-source-agreements --disable-interactivity
-$code = $LASTEXITCODE
-
-# -1978335212 (0x8A150014) = no packages found, so there is nothing to remove.
-if ($code -eq 0 -or $code -eq -1978335212) {
-    Write-Host "$PackageId is not installed."
-    exit 0
-}
-
-Write-Host "winget exited with $code"
-exit 1
+winget install --id 9WZDNCRFJ3PZ --source msstore --accept-package-agreements --accept-source-agreements
+winget uninstall --id 9WZDNCRFJ3PZ
 ```
 
-Save both under `lib/windows/scripts/` in your GitOps repo, then register the package in the fleet where you want it available. Software is defined per fleet, so this goes in `fleets/<name>.yml` or `fleets/unassigned.yml`:
+Pin to the ID rather than the name. A name match can resolve to the wrong package, and nobody is watching the output when Fleet runs this. Everything from here on exists to get those two commands executed in a place where they work.
 
-```yaml
-software:
-  packages:
-    - path: ../lib/windows/scripts/install-7zip.ps1
-      display_name: 7-Zip
-      self_service: true
-      categories:
-        - "💻 Productivity"
-      uninstall_script:
-        path: ../lib/windows/scripts/uninstall-7zip.ps1
-```
+## Why the one-liner fails as SYSTEM
 
-With `self_service: true`, the app appears on the end user's self-service page, reachable from the Fleet icon in the Windows system tray. When they click install, Fleet's agent runs the install script as SYSTEM. When they remove it, the uninstall script runs.
+Fleet's agent executes Windows scripts as `powershell -MTA -ExecutionPolicy Bypass -File <script>`, running as SYSTEM. That collides with the Store in two separate ways.
 
-## Per-user apps: hand the install to the logged-on user
+The first is that winget itself isn't there. Microsoft's [winget troubleshooting documentation](https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting) states it plainly: winget ships through App Installer as a packaged MSIX application, MSIX packages can be registered for any user except `NT AUTHORITY\SYSTEM`, and so the winget CLI is not supported in the system context. The `winget` command simply doesn't resolve.
 
-Some apps refuse to install machine-wide at all. Squirrel-based Electron apps, anything from the Store, and a long tail of `--scope user` packages all fall in this bucket, and no SYSTEM-context trick makes them work, because the install genuinely needs a user profile to land in.
+The second is the one that matters here, and it survives every workaround. Even with the binary located, the `msstore` source rejects a device-wide install with "Device wide install for msstore type is not supported under admin context." Store packages are per-user by design, and there is [no supported way](https://github.com/microsoft/winget-cli/issues/3553) to install a user-scoped package as SYSTEM on behalf of a specific user. Asking for `--scope machine` doesn't help either: [it installs the package for the SYSTEM account](https://github.com/microsoft/winget-cli/issues/4748) instead of provisioning it, which is worse than failing, because it looks like it worked.
 
-The answer is to stop fighting it and run winget as the user. Fleet uses exactly this pattern for its own per-user Windows [Fleet-maintained apps](https://fleetdm.com/guides/fleet-maintained-apps): create a short-lived scheduled task that runs as the owner of the `explorer.exe` process, start it, wait for it to finish, then unregister it.
+Running winget in the system context in the first place remains [an open feature request](https://github.com/microsoft/winget-pkgs/issues/346975), not a solved problem you can flag your way around. So stop trying to install as SYSTEM.
+
+## Run winget in the user's session
+
+The way through is to let SYSTEM do what SYSTEM is good at, which is creating a scheduled task, and let the logged-on user do the install. Register a task owned by the owner of the `explorer.exe` process, start it, wait for it to finish, then remove it. Fleet uses this same pattern for its own per-user Windows [Fleet-maintained apps](https://fleetdm.com/guides/fleet-maintained-apps).
 
 ```powershell
-# install-figma-user-scope.ps1
-$PackageId = "Figma.Figma"
+# install-company-portal.ps1
+$StoreId = "9WZDNCRFJ3PZ"
+$WingetArgs = "install --id $StoreId --source msstore --accept-package-agreements --accept-source-agreements"
+
 $exitCode = 0
-$taskName = "fleet-install-$PackageId"
+$taskName = "fleet-store-$StoreId"
 
 try {
     $userName = (Get-CimInstance Win32_Process -Filter 'name = "explorer.exe"' |
         Invoke-CimMethod -MethodName GetOwner).User
-    if (-not $userName) { throw "No logged-on user found; cannot install a user-scope app." }
+    if (-not $userName) { throw "No logged-on user, so there is no session to install into." }
 
-    $args = "install --id $PackageId --exact --source winget --scope user --silent " +
-            "--accept-package-agreements --accept-source-agreements --disable-interactivity"
-    $action = New-ScheduledTaskAction -Execute "winget.exe" -Argument $args
+    $action = New-ScheduledTaskAction -Execute "winget.exe" -Argument $WingetArgs
     $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries
     $task = New-ScheduledTask -Action $action -Settings $settings
 
@@ -156,7 +74,7 @@ try {
         $state = (Get-ScheduledTask -TaskName $taskName).State
         Write-Host "Scheduled task is '$state'."
         if ((New-TimeSpan -Start $startDate -End (Get-Date)).TotalSeconds -gt 600) {
-            throw "Timed out waiting for the install to finish."
+            throw "Timed out waiting for winget to finish."
         }
     } while ($state -eq "Running" -or $state -eq "Queued")
 } catch {
@@ -169,15 +87,79 @@ try {
 exit $exitCode
 ```
 
-Because the task runs in the user's session, plain `winget.exe` resolves normally through the app execution alias and no path hunting is needed. The trade-off is real, though: this only works when someone is logged in, the scheduled task's own exit code doesn't come back to you, and you learn nothing about whether winget actually succeeded. That makes the verification step in the next section mandatory here rather than merely advisable.
+Only the first two lines change per app. Everything below them is the same in every script, which is what makes this generatable later.
 
-The same pattern also cleanly covers the uninstall, swapping `install` for `uninstall`. Sweep every user profile if the app may have been installed by more than one person.
+Because the task runs inside the user's session, plain `winget.exe` resolves through the app execution alias and the Store gets the user context it wants. The uninstall is the identical file with one line different:
 
-## Guardrails: targeting and verification
+```powershell
+$WingetArgs = "uninstall --id $StoreId"
+```
 
-### Target the right hosts with labels
+Two honest limits come with this approach. It needs somebody logged in, which is reasonable for self-service, since a user is clicking the tile. And the scheduled task's exit code doesn't come back to your script, so the script reports success as long as the task ran, whether or not winget did anything. That second one is why the next section isn't optional.
 
-Define a dynamic label and reference it on the package so only the intended hosts see the tile:
+## Verify against the MSIX world, not the registry
+
+If you have built self-service tiles for ordinary Windows installers before, the instinct is to check `HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall`. That is the wrong place for a Store app. MSIX packages don't register there at all, so a registry check fails on a perfectly good install.
+
+Ask the MSIX subsystem instead. Fleet runs the post-install script as SYSTEM, and SYSTEM is elevated, so `-AllUsers` is available and will see a package installed in a user's profile:
+
+```powershell
+# verify-company-portal.ps1
+$PackageName = "Microsoft.CompanyPortal"
+
+$pkg = Get-AppxPackage -AllUsers -Name $PackageName -ErrorAction SilentlyContinue
+if (-not $pkg) {
+    Write-Host "$PackageName is not installed for any user."
+    exit 1
+}
+
+Write-Host "Found $($pkg[0].Name) $($pkg[0].Version)."
+exit 0
+```
+
+The `Name` here is the MSIX package name, which is not the Store ID. Get it after a manual install with `Get-AppxPackage | Select-Object Name, PackageFamilyName`, or by matching on a wildcard the first time through.
+
+A non-zero exit from the post-install script fails the install and triggers your uninstall script, so this check is what converts "the scheduled task ran" into "the app is actually there."
+
+## If you need it machine-wide
+
+Sometimes per-user isn't acceptable and the app has to be on the image for everybody. Store apps can be deployed that way, but not through `winget install`. The route is to download the package once and provision it.
+
+On an admin workstation, download the package and its license:
+
+```powershell
+winget download --id 9WZDNCRFJ3PZ --source msstore --download-directory C:\staging
+```
+
+Then provision it on the host, which does work as SYSTEM:
+
+```powershell
+Add-AppxProvisionedPackage -Online -PackagePath .\app.msixbundle -LicensePath .\9WZDNCRFJ3PZ_License.xml
+```
+
+Two costs come with this. Downloading a Store package's license file [requires Entra ID authentication](https://learn.microsoft.com/en-us/windows/package-manager/winget/download) by an account holding Global Administrator, User Administrator, or License Administrator. And you now have a file to get onto the host, which means a Fleet custom package rather than a script-only one, and the "nothing to host" property of this whole approach is gone. Worth it for a handful of apps everyone needs, not for a self-service catalog.
+
+## Wire it into GitOps
+
+Register the package in the fleet where you want it available, in `fleets/<name>.yml` or `fleets/unassigned.yml`:
+
+```yaml
+software:
+  packages:
+    - path: ../lib/windows/scripts/install-company-portal.ps1
+      display_name: Company Portal
+      self_service: true
+      categories:
+        - "💻 Productivity"
+      labels_include_any:
+        - Windows
+      uninstall_script:
+        path: ../lib/windows/scripts/uninstall-company-portal.ps1
+      post_install_script:
+        path: ../lib/windows/scripts/verify-company-portal.ps1
+```
+
+The label keeps the tile off hosts that can't use it, and it has to be defined in the `labels` section first:
 
 ```yaml
 labels:
@@ -186,115 +168,76 @@ labels:
     label_membership_type: dynamic
 ```
 
-```yaml
-software:
-  packages:
-    - path: ../lib/windows/scripts/install-7zip.ps1
-      display_name: 7-Zip
-      self_service: true
-      labels_include_any:
-        - Windows
-      uninstall_script:
-        path: ../lib/windows/scripts/uninstall-7zip.ps1
-```
+With `self_service: true`, the app appears on the end user's self-service page, reachable from the Fleet icon in the Windows system tray. Every app is three files and a YAML block, so adding or removing one is a pull request. Reviewers see exactly what will run, and the catalog is auditable and reversible. [Turn on GitOps mode](https://fleetdm.com/learn-more-about/ui-gitops-mode) to make the Fleet UI reflect that these are code-managed.
 
-Any label you reference on a package has to be defined in the `labels` section first, and you can use only one of `labels_include_any`, `labels_include_all`, or `labels_exclude_any` per package. Labels also give you somewhere to put the hosts winget can't help: Windows Server and LTSC images often ship without App Installer at all, and excluding them is kinder than letting the script fail on every attempt.
+Script-only packages don't support automatic install through a policy, and they don't take an `install_script` key, because the file's contents already are the install script. Self-service is the delivery mechanism here, which suits Store apps anyway.
 
-### Verify the install actually landed
+## Generate the whole tile from a Store ID
 
-A post-install script runs after the install, and a non-zero exit fails the install and triggers your uninstall script. Check the state of the machine rather than asking winget again, so a broken winget can't vouch for itself:
+Since only two lines differ between apps, the rest can be emitted. Fleet script-only packages are single files with no shared helper to import, so the boilerplate has to be inlined into each one, which is exactly the kind of work worth handing to a generator.
 
 ```powershell
-# verify-7zip.ps1
-$DisplayNamePattern = "7-Zip*"
-
-$paths = @(
-    "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*",
-    "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*"
-)
-
-$found = Get-ItemProperty -Path $paths -ErrorAction SilentlyContinue |
-    Where-Object { $_.DisplayName -like $DisplayNamePattern }
-
-if (-not $found) {
-    Write-Host "$DisplayNamePattern was not found in the uninstall registry."
-    exit 1
-}
-
-Write-Host "Found $($found[0].DisplayName) $($found[0].DisplayVersion)."
-exit 0
-```
-
-```yaml
-      post_install_script:
-        path: ../lib/windows/scripts/verify-7zip.ps1
-```
-
-For a user-scope install, `HKLM` is the wrong place to look. Those entries land under the user's own hive, so enumerate `HKEY_USERS` from SYSTEM instead of `HKCU`, which as SYSTEM points at the wrong profile entirely.
-
-A pre-install query can gate the install as well, proceeding only if the query returns a row. Labels are the better tool for platform targeting, so save the query for a genuine precondition.
-
-## Wire it into GitOps
-
-Every self-service app is a set of files in your repository:
-
-```
-lib/
-  windows/
-    scripts/
-      install-7zip.ps1
-      uninstall-7zip.ps1
-      verify-7zip.ps1
-fleets/
-  workstations.yml   # references the scripts under software.packages
-```
-
-Adding, changing, or removing an app is a pull request. Reviewers see the exact commands that will run as SYSTEM on every targeted host, the change ships through CI when it merges, and the catalog is auditable and reversible by design. [Turn on GitOps mode](https://fleetdm.com/learn-more-about/ui-gitops-mode) to make the Fleet UI reflect that these are code-managed. Fleet manages its own software this way, and the [it-and-security configuration](https://github.com/fleetdm/fleet/tree/main/it-and-security/fleets) is public if you want a real-world layout to borrow from.
-
-## Automate it: from a winget ID to a self-service tile
-
-Once the pattern settles, the only real input is the package ID. This generator writes both scripts and prints the YAML block:
-
-```powershell
-# New-SelfServiceApp.ps1 -PackageId 7zip.7zip -DisplayName "7-Zip"
+# New-StoreAppTile.ps1 -StoreId 9WZDNCRFJ3PZ -DisplayName "Company Portal" -PackageName Microsoft.CompanyPortal
 param(
-    [Parameter(Mandatory)][string]$PackageId,
-    [string]$DisplayName = $PackageId,
+    [Parameter(Mandatory)][string]$StoreId,
+    [Parameter(Mandatory)][string]$DisplayName,
+    [Parameter(Mandatory)][string]$PackageName,
     [string]$Category = "💻 Productivity"
 )
 
 $dir = "lib/windows/scripts"
 New-Item -ItemType Directory -Path $dir -Force | Out-Null
-$slug = $PackageId.ToLower().Replace(".", "-")
+$slug = $DisplayName.ToLower() -replace '[^a-z0-9]+', '-'
 
-$resolve = @'
-$winget = Resolve-Path "$env:ProgramFiles\WindowsApps\Microsoft.DesktopAppInstaller_*_x64__8wekyb3d8bbwe\winget.exe" -ErrorAction SilentlyContinue |
-    Sort-Object { [version](($_.Path -split '_')[1]) } |
-    Select-Object -Last 1 -ExpandProperty Path
-if (-not $winget) { Write-Host "App Installer (winget) was not found."; exit 1 }
+$body = @'
+$exitCode = 0
+$taskName = "fleet-store-$StoreId"
+try {
+    $userName = (Get-CimInstance Win32_Process -Filter 'name = "explorer.exe"' |
+        Invoke-CimMethod -MethodName GetOwner).User
+    if (-not $userName) { throw "No logged-on user, so there is no session to install into." }
+    $action = New-ScheduledTaskAction -Execute "winget.exe" -Argument $WingetArgs
+    $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries
+    $task = New-ScheduledTask -Action $action -Settings $settings
+    Register-ScheduledTask $taskName -InputObject $task -User $userName | Out-Null
+    Start-ScheduledTask -TaskName $taskName -TaskPath "\"
+    $startDate = Get-Date
+    do {
+        Start-Sleep -Seconds 5
+        $state = (Get-ScheduledTask -TaskName $taskName).State
+        Write-Host "Scheduled task is '$state'."
+        if ((New-TimeSpan -Start $startDate -End (Get-Date)).TotalSeconds -gt 600) {
+            throw "Timed out waiting for winget to finish."
+        }
+    } while ($state -eq "Running" -or $state -eq "Queued")
+} catch {
+    Write-Host "Error: $_"
+    $exitCode = 1
+} finally {
+    Unregister-ScheduledTask -TaskName $taskName -Confirm:$false -ErrorAction SilentlyContinue
+}
+exit $exitCode
 '@
 
 @"
-`$PackageId = "$PackageId"
-$resolve
-& `$winget install --id `$PackageId --exact --source winget --scope machine --silent ``
-    --accept-package-agreements --accept-source-agreements --disable-interactivity
-`$code = `$LASTEXITCODE
-if (`$code -eq 0 -or `$code -eq -1978335135) { exit 0 }
-Write-Host "winget exited with `$code"
-exit 1
+`$StoreId = "$StoreId"
+`$WingetArgs = "install --id `$StoreId --source msstore --accept-package-agreements --accept-source-agreements"
+$body
 "@ | Set-Content "$dir/install-$slug.ps1" -Encoding UTF8
 
 @"
-`$PackageId = "$PackageId"
-$resolve
-& `$winget uninstall --id `$PackageId --exact --silent ``
-    --accept-source-agreements --disable-interactivity
-`$code = `$LASTEXITCODE
-if (`$code -eq 0 -or `$code -eq -1978335212) { exit 0 }
-Write-Host "winget exited with `$code"
-exit 1
+`$StoreId = "$StoreId"
+`$WingetArgs = "uninstall --id `$StoreId"
+$body
 "@ | Set-Content "$dir/uninstall-$slug.ps1" -Encoding UTF8
+
+@"
+`$PackageName = "$PackageName"
+`$pkg = Get-AppxPackage -AllUsers -Name `$PackageName -ErrorAction SilentlyContinue
+if (-not `$pkg) { Write-Host "`$PackageName is not installed for any user."; exit 1 }
+Write-Host "Found `$(`$pkg[0].Name) `$(`$pkg[0].Version)."
+exit 0
+"@ | Set-Content "$dir/verify-$slug.ps1" -Encoding UTF8
 
 @"
 
@@ -304,31 +247,35 @@ exit 1
       self_service: true
       categories:
         - "$Category"
+      labels_include_any:
+        - Windows
       uninstall_script:
         path: ../$dir/uninstall-$slug.ps1
+      post_install_script:
+        path: ../$dir/verify-$slug.ps1
 "@
 ```
 
-Onboarding an app becomes: find the ID with `winget search`, run `./New-SelfServiceApp.ps1 -PackageId 7zip.7zip -DisplayName "7-Zip"`, paste the printed block into your fleet file, and open a pull request. Write the verification script by hand, because the display name in the registry rarely matches the winget ID closely enough to generate.
+Onboarding an app becomes three lookups and a command: get the Store ID from `winget search --source msstore`, get the MSIX package name from `Get-AppxPackage` after installing it once by hand, then run the generator and paste the printed block into your fleet file.
 
 ## The point
 
-Fleet didn't ship a Windows software store in 4.89.0. It shipped three small additions to script-only packages, and those are enough to build one on top of the package manager Microsoft already ships, with no installers to host and no per-app UI work.
+A Store app install is one winget command, and the reason this piece isn't one paragraph long is that Fleet runs as SYSTEM and the Microsoft Store only deals in users. That gap is a real architectural constraint, not an oversight waiting on a flag, so the honest answer is a wrapper that hands the work to the session where it belongs.
 
-Windows makes you earn it in a way Linux doesn't. The SYSTEM context is a real constraint, not a bug you can wait out, and it forces a decision per app: machine scope through the resolved binary, or user scope through the logged-on user. Make that decision once, encode it in a script, and the rest is a naming convention in Git.
+Write that wrapper once, verify against `Get-AppxPackage` instead of the registry, and the marginal cost of the next Store app is a twelve-character ID in a pull request.
 
 ## See it live
 
-- Follow the [step-by-step guide](https://fleetdm.com/guides/build-your-own-windows-self-service-with-winget-and-script-only-packages-guide) to build your first app end to end.
+- Follow the [step-by-step guide](https://fleetdm.com/guides/build-your-own-windows-self-service-with-winget-and-script-only-packages-guide) to build your first Store app tile end to end.
 - Read the [deploy software guide](https://fleetdm.com/guides/deploy-software-packages) for the full detail on script-only packages, pre-install queries, and uninstall scripts.
 - Get a demo: [fleetdm.com/contact](https://fleetdm.com/contact).
 - Join a free GitOps workshop: [fleetdm.com/workshops](https://fleetdm.com/workshops).
 
 _Managing devices as code, one pull request at a time. Start with the [GitOps reference](https://fleetdm.com/docs/configuration/yaml-files) or [talk to us](https://fleetdm.com/contact)._
 
-<meta name="articleTitle" value="Build your own Windows self-service with winget">
+<meta name="articleTitle" value="Put Microsoft Store apps in Windows self-service with winget">
 <meta name="authorFullName" value="Allen Houchins">
 <meta name="authorGitHubUsername" value="allenhouchins">
 <meta name="category" value="articles">
 <meta name="publishedOn" value="2026-08-05">
-<meta name="description" value="Use Fleet script-only .ps1 packages to put winget behind a Windows self-service tile, including the SYSTEM context workaround.">
+<meta name="description" value="Use Fleet script-only .ps1 packages and winget to put Microsoft Store apps in Windows self-service, despite the SYSTEM context limit.">

--- a/articles/build-your-own-windows-self-service-with-winget-and-script-only-packages.md
+++ b/articles/build-your-own-windows-self-service-with-winget-and-script-only-packages.md
@@ -28,11 +28,11 @@ winget search --source msstore "company portal"
 Given the ID, the two commands you need are these:
 
 ```powershell
-winget install --id 9WZDNCRFJ3PZ --source msstore --accept-package-agreements --accept-source-agreements
-winget uninstall --id 9WZDNCRFJ3PZ
+winget install --id 9WZDNCRFJ3PZ --source msstore --accept-package-agreements --accept-source-agreements --disable-interactivity
+winget uninstall --id 9WZDNCRFJ3PZ --accept-source-agreements --disable-interactivity
 ```
 
-Pin to the ID rather than the name. A name match can resolve to the wrong package, and nobody is watching the output when Fleet runs this. Everything from here on exists to get those two commands executed in a place where they work.
+Pin to the ID rather than the name. A name match can resolve to the wrong package, and nobody is watching the output when Fleet runs this. The flags matter as much as the ID: winget [prompts for msstore source agreements even on uninstall](https://github.com/microsoft/winget-cli/issues/1736), and in an unattended script that prompt is a permanent hang. `--disable-interactivity` turns any prompt these flags miss into a failure instead. Everything from here on exists to get those two commands executed in a place where they work.
 
 ## Why the one-liner fails as SYSTEM
 
@@ -51,14 +51,14 @@ The way through is to let SYSTEM do what SYSTEM is good at, which is creating a 
 ```powershell
 # install-company-portal.ps1
 $StoreId = "9WZDNCRFJ3PZ"
-$WingetArgs = "install --id $StoreId --source msstore --accept-package-agreements --accept-source-agreements"
+$WingetArgs = "install --id $StoreId --source msstore --accept-package-agreements --accept-source-agreements --disable-interactivity"
 
 $exitCode = 0
 $taskName = "fleet-store-$StoreId"
 
 try {
     $userName = (Get-CimInstance Win32_Process -Filter 'name = "explorer.exe"' |
-        Invoke-CimMethod -MethodName GetOwner).User
+        Invoke-CimMethod -MethodName GetOwner | Select-Object -First 1).User
     if (-not $userName) { throw "No logged-on user, so there is no session to install into." }
 
     $action = New-ScheduledTaskAction -Execute "winget.exe" -Argument $WingetArgs
@@ -92,7 +92,7 @@ Only the first two lines change per app. Everything below them is the same in ev
 Because the task runs inside the user's session, plain `winget.exe` resolves through the app execution alias and the Store gets the user context it wants. The uninstall is the identical file with one line different:
 
 ```powershell
-$WingetArgs = "uninstall --id $StoreId"
+$WingetArgs = "uninstall --id $StoreId --accept-source-agreements --disable-interactivity"
 ```
 
 Two honest limits come with this approach. It needs somebody logged in, which is reasonable for self-service, since a user is clicking the tile. And the scheduled task's exit code doesn't come back to your script, so the script reports success as long as the task ran, whether or not winget did anything. That second one is why the next section isn't optional.
@@ -194,7 +194,7 @@ $exitCode = 0
 $taskName = "fleet-store-$StoreId"
 try {
     $userName = (Get-CimInstance Win32_Process -Filter 'name = "explorer.exe"' |
-        Invoke-CimMethod -MethodName GetOwner).User
+        Invoke-CimMethod -MethodName GetOwner | Select-Object -First 1).User
     if (-not $userName) { throw "No logged-on user, so there is no session to install into." }
     $action = New-ScheduledTaskAction -Execute "winget.exe" -Argument $WingetArgs
     $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries
@@ -221,13 +221,13 @@ exit $exitCode
 
 @"
 `$StoreId = "$StoreId"
-`$WingetArgs = "install --id `$StoreId --source msstore --accept-package-agreements --accept-source-agreements"
+`$WingetArgs = "install --id `$StoreId --source msstore --accept-package-agreements --accept-source-agreements --disable-interactivity"
 $body
 "@ | Set-Content "$dir/install-$slug.ps1" -Encoding UTF8
 
 @"
 `$StoreId = "$StoreId"
-`$WingetArgs = "uninstall --id `$StoreId"
+`$WingetArgs = "uninstall --id `$StoreId --accept-source-agreements --disable-interactivity"
 $body
 "@ | Set-Content "$dir/uninstall-$slug.ps1" -Encoding UTF8
 

--- a/articles/build-your-own-windows-self-service-with-winget-and-script-only-packages.md
+++ b/articles/build-your-own-windows-self-service-with-winget-and-script-only-packages.md
@@ -95,7 +95,7 @@ Because the task runs inside the user's session, plain `winget.exe` resolves thr
 $WingetArgs = "uninstall --id $StoreId --accept-source-agreements --disable-interactivity"
 ```
 
-Two honest limits come with this approach. It needs somebody logged in, which is reasonable for self-service, since a user is clicking the tile. And the scheduled task's exit code doesn't come back to your script, so the script reports success as long as the task ran, whether or not winget did anything. That second one is why the next section isn't optional.
+There are two limitations to be aware of with this approach. It needs somebody logged in, which is reasonable for self-service, since a user is clicking the tile. And the scheduled task's exit code doesn't come back to your script, so the script reports success as long as the task ran, whether or not winget did anything. That second one is why the next section isn't optional.
 
 ## Verify against the MSIX world, not the registry
 
@@ -137,7 +137,7 @@ Then provision it on the host, which does work as SYSTEM:
 Add-AppxProvisionedPackage -Online -PackagePath .\app.msixbundle -LicensePath .\9WZDNCRFJ3PZ_License.xml
 ```
 
-Two costs come with this. Downloading a Store package's license file [requires Entra ID authentication](https://learn.microsoft.com/en-us/windows/package-manager/winget/download) by an account holding Global Administrator, User Administrator, or License Administrator. And you now have a file to get onto the host, which means a Fleet custom package rather than a script-only one, and the "nothing to host" property of this whole approach is gone. Worth it for a handful of apps everyone needs, not for a self-service catalog.
+There is one important detail to keep in mind with this approach. Downloading a Store package's license file [requires Entra ID authentication](https://learn.microsoft.com/en-us/windows/package-manager/winget/download) by an account holding Global Administrator, User Administrator, or License Administrator. And you now have a file to get onto the host, which means a Fleet custom package rather than a script-only one, and the "nothing to host" property of this whole approach is gone. Worth it for a handful of apps everyone needs, not for a self-service catalog.
 
 ## Wire it into GitOps
 

--- a/articles/build-your-own-windows-self-service-with-winget-and-script-only-packages.md
+++ b/articles/build-your-own-windows-self-service-with-winget-and-script-only-packages.md
@@ -277,5 +277,5 @@ _Managing devices as code, one pull request at a time. Start with the [GitOps re
 <meta name="authorFullName" value="Allen Houchins">
 <meta name="authorGitHubUsername" value="allenhouchins">
 <meta name="category" value="articles">
-<meta name="publishedOn" value="2026-08-05">
+<meta name="publishedOn" value="2026-08-07">
 <meta name="description" value="Use Fleet script-only .ps1 packages and winget to put Microsoft Store apps in Windows self-service, despite the SYSTEM context limit.">


### PR DESCRIPTION
**Related issue:** NA

Adds an article and companion guide on putting **Microsoft Store apps** into Windows self-service using winget and `.ps1` script-only packages.

| File | Category | URL |
|---|---|---|
| `build-your-own-windows-self-service-with-winget-and-script-only-packages.md` | `articles` | `/articles/build-your-own-windows-self-service-with-winget-and-script-only-packages` |
| `build-your-own-windows-self-service-with-winget-and-script-only-packages-guide.md` | `guides` | `/guides/build-your-own-windows-self-service-with-winget-and-script-only-packages-guide` |

## What changed and why

Fleet 4.89.0 added an uninstall script, pre-install query, and post-install script to script-only packages. On Linux that was enough to build a [self-service catalog on apt and dnf](https://fleetdm.com/articles/build-your-own-linux-self-service-with-script-only-packages). These are the Windows counterparts, scoped specifically to Store apps.

The per-app work is two lines:

```powershell
winget install --id <StoreId> --source msstore --accept-package-agreements --accept-source-agreements --disable-interactivity
winget uninstall --id <StoreId> --accept-source-agreements --disable-interactivity
```

Everything else in each script is boilerplate, and the generator emits it.

## The constraint both pieces are built around

Fleet's agent runs Windows scripts as SYSTEM (`orbit/pkg/scripts/exec_windows.go:17`), and Store apps cannot be installed that way:

- The `msstore` source rejects device-wide installs outright: "Device wide install for msstore type is not supported under admin context" ([winget-cli#3553](https://github.com/microsoft/winget-cli/issues/3553)). Store packages are per-user by design.
- winget's CLI is [not supported in the system context](https://learn.microsoft.com/en-us/windows/package-manager/winget/troubleshooting) at all, because App Installer is an MSIX package that cannot be registered for `NT AUTHORITY\SYSTEM`.
- Running winget in the system context is still [an open feature request](https://github.com/microsoft/winget-pkgs/issues/346975).

So the scripts run winget inside the logged-on user's session via a short-lived scheduled task, mirroring the pattern already used by Fleet's own per-user Windows maintained apps (`ee/maintained-apps/inputs/winget/scripts/figma_install.ps1`).

## Two things worth a reviewer's attention

Both are corrections that fall out of the Store focus, and both would have produced silently wrong content:

1. **Verification uses `Get-AppxPackage -AllUsers`, not the registry.** Store apps never register in the HKLM uninstall keys, so a registry check fails on a perfectly good install. This is called out explicitly in the guide's Troubleshoot section, since it's a natural wrong instinct if you've built tiles for ordinary Windows installers.
2. **`winget install --scope machine` is documented as a trap, not a shortcut.** For a Store package it [installs under the SYSTEM account](https://github.com/microsoft/winget-cli/issues/4748) instead of provisioning the app, which reports success and leaves users with nothing.

The scheduled task's exit code also doesn't propagate back to the calling script, so the install reports success whenever the task ran. Both pieces treat the post-install verification as mandatory rather than optional because of this.

## Machine-wide path

For apps that must exist for every user, the content documents `winget download` plus `Add-AppxProvisionedPackage`, which does work as SYSTEM, along with its two costs: license download [requires Entra ID authentication](https://learn.microsoft.com/en-us/windows/package-manager/winget/download) by a Global Administrator, User Administrator, or License Administrator, and you now have a file to host, so it wants a Fleet custom package rather than a script-only one.

## Notes for reviewers

- **Content only.** No Go, frontend, migration, or config changes, so no changes file is needed and the code-focused template sections below are removed as the template instructs.
- **The PowerShell has not been executed.** There is no `pwsh` on the authoring machine. The generator's here-string escaping was traced by hand but not run. Worth one execution on a real Windows host before publish.
- **`Microsoft.CompanyPortal` / `9WZDNCRFJ3PZ`** are used as the worked example. Both identifiers are now verified (PackageFamilyName `Microsoft.CompanyPortal_8wekyb3d8bbwe`), and the guide still tells readers to derive both themselves.
- **A verification pass was run over every claim** (Fleet docs, Microsoft Learn, winget-cli issues). It caught one real bug: `winget uninstall` with no flags can hang on an msstore source-agreement prompt ([winget-cli#1736](https://github.com/microsoft/winget-cli/issues/1736)), invisible inside the scheduled task. All uninstalls now carry `--accept-source-agreements`, both directions carry `--disable-interactivity`, and the explorer.exe owner lookup takes the first result so multiple explorer processes can't break `Register-ScheduledTask`.
- **`articleImageUrl` is intentionally absent** from the article. The build treats it as optional, but the Linux article has one, so a `1200x627@2x.png` in `website/assets/images/articles/` plus the meta tag would bring it to parity. The guide has none, matching the Linux guide.
- **`publishedOn` is `2026-08-05`** on both. Update if these are being scheduled.

Checked against the build's enforced constraints (`website/scripts/build-static-content.js`): valid `category`, `articleTitle` matches each H1 exactly, descriptions are 133 and 125 characters (limit 150), `publishedOn` matches the required ISO pattern, no `@fleetdm.com` addresses. `check-pr-template` does not run on this PR, since it only triggers on `frontend/**`, `**/*.go`, `go.mod`, and `go.sum`.

# Checklist for submitter

## Testing

- [ ] QA'd all new/changed functionality manually

Not applicable to content-only changes. Verified instead by running the website build's own validation rules against both files, and by sourcing every technical claim to Microsoft Learn, `winget-cli` issues, or Fleet's docs and code. The PowerShell samples are unexecuted, as noted above.
