### PR TITLE
fix asset reference issue on ddm upsert with no change

### DIFF
--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -4827,39 +4827,12 @@ func (ds *Datastore) updateDeclarationsAssetAssociations(ctx context.Context, tx
 		if incoming == nil {
 			continue
 		}
-		refs := incoming.AssetReferenceUUIDs
 
-		// Remove references that are no longer present, keeping only the incoming set.
-		delStmt := `DELETE FROM mdm_apple_declaration_asset_references WHERE declaration_uuid = ?`
-		delArgs := []any{decl.DeclarationUUID}
-		if len(refs) > 0 {
-			delStmt, delArgs, err = sqlx.In(`DELETE FROM mdm_apple_declaration_asset_references
-				WHERE declaration_uuid = ? AND asset_uuid NOT IN (?)`, decl.DeclarationUUID, refs)
-			if err != nil {
-				return false, ctxerr.Wrap(ctx, err, "building delete stale asset references query")
-			}
+		updated, err := setMDMAppleDeclarationAssetReferencesDB(ctx, tx, decl.DeclarationUUID, incoming.AssetReferenceUUIDs)
+		if err != nil {
+			return false, err
 		}
-		if res, err := tx.ExecContext(ctx, delStmt, delArgs...); err != nil {
-			return false, ctxerr.Wrap(ctx, err, "deleting stale declaration asset references")
-		} else if aff, _ := res.RowsAffected(); aff > 0 {
-			updatedDB = true
-		}
-
-		if len(refs) == 0 {
-			continue
-		}
-
-		insStmt := `INSERT INTO mdm_apple_declaration_asset_references (declaration_uuid, asset_uuid) VALUES ` +
-			strings.Repeat("(?, ?),", len(refs)-1) + "(?, ?) ON DUPLICATE KEY UPDATE asset_uuid = VALUES(asset_uuid)"
-		insArgs := make([]any, 0, len(refs)*2)
-		for _, ref := range refs {
-			insArgs = append(insArgs, decl.DeclarationUUID, ref)
-		}
-		if res, err := tx.ExecContext(ctx, insStmt, insArgs...); err != nil {
-			return false, ctxerr.Wrap(ctx, err, "inserting declaration asset references")
-		} else if aff, _ := res.RowsAffected(); aff > 0 {
-			updatedDB = true
-		}
+		updatedDB = updatedDB || updated
 	}
 
 	return updatedDB, nil
@@ -5249,7 +5222,7 @@ func (ds *Datastore) insertOrUpsertMDMAppleDeclaration(ctx context.Context, insO
 			return ctxerr.Wrap(ctx, err, "reload apple mdm declaration")
 		}
 
-		if err := setMDMAppleDeclarationAssetReferencesDB(ctx, tx, declUUID, declaration.AssetReferenceUUIDs); err != nil {
+		if _, err := setMDMAppleDeclarationAssetReferencesDB(ctx, tx, declUUID, declaration.AssetReferenceUUIDs); err != nil {
 			return err
 		}
 
@@ -5316,23 +5289,25 @@ func (ds *Datastore) insertOrUpsertMDMAppleDeclaration(ctx context.Context, insO
 // single declaration against the incoming set, so an edit that drops an asset
 // doesn't leave the old reference behind. The declaration UUID must be the one
 // stored in mdm_apple_declarations (an upsert keeps the pre-existing UUID).
-func setMDMAppleDeclarationAssetReferencesDB(ctx context.Context, tx sqlx.ExtContext, declUUID string, assetRefs []string) error {
+func setMDMAppleDeclarationAssetReferencesDB(ctx context.Context, tx sqlx.ExtContext, declUUID string, assetRefs []string) (updatedDB bool, err error) {
+	// Remove references that are no longer present, keeping only the incoming set.
 	delStmt := `DELETE FROM mdm_apple_declaration_asset_references WHERE declaration_uuid = ?`
 	delArgs := []any{declUUID}
 	if len(assetRefs) > 0 {
-		var err error
 		delStmt, delArgs, err = sqlx.In(`DELETE FROM mdm_apple_declaration_asset_references
 			WHERE declaration_uuid = ? AND asset_uuid NOT IN (?)`, declUUID, assetRefs)
 		if err != nil {
-			return ctxerr.Wrap(ctx, err, "building delete stale apple mdm declaration asset references query")
+			return false, ctxerr.Wrap(ctx, err, "building delete stale declaration asset references query")
 		}
 	}
-	if _, err := tx.ExecContext(ctx, delStmt, delArgs...); err != nil {
-		return ctxerr.Wrap(ctx, err, "deleting stale apple mdm declaration asset references")
+	if res, err := tx.ExecContext(ctx, delStmt, delArgs...); err != nil {
+		return false, ctxerr.Wrap(ctx, err, "deleting stale declaration asset references")
+	} else if aff, _ := res.RowsAffected(); aff > 0 {
+		updatedDB = true
 	}
 
 	if len(assetRefs) == 0 {
-		return nil
+		return updatedDB, nil
 	}
 
 	insStmt := `INSERT INTO mdm_apple_declaration_asset_references (declaration_uuid, asset_uuid) VALUES ` +
@@ -5341,11 +5316,13 @@ func setMDMAppleDeclarationAssetReferencesDB(ctx context.Context, tx sqlx.ExtCon
 	for _, ref := range assetRefs {
 		insArgs = append(insArgs, declUUID, ref)
 	}
-	if _, err := tx.ExecContext(ctx, insStmt, insArgs...); err != nil {
-		return ctxerr.Wrap(ctx, err, "inserting apple mdm declaration asset references")
+	if res, err := tx.ExecContext(ctx, insStmt, insArgs...); err != nil {
+		return false, ctxerr.Wrap(ctx, err, "inserting declaration asset references")
+	} else if aff, _ := res.RowsAffected(); aff > 0 {
+		updatedDB = true
 	}
 
-	return nil
+	return updatedDB, nil
 }
 
 // Keyed on declaration_uuid rather than inserted fresh, so an edit keeps the

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -5243,23 +5243,14 @@ func (ds *Datastore) insertOrUpsertMDMAppleDeclaration(ctx context.Context, insO
 			}
 		}
 
-		if assetReferences := declaration.AssetReferenceUUIDs; len(assetReferences) > 0 {
-			assetRefStmt := `INSERT INTO mdm_apple_declaration_asset_references (declaration_uuid, asset_uuid)
-			VALUES ` + strings.Repeat("(?, ?),", len(assetReferences)-1) + "(?, ?) " + `
-			ON DUPLICATE KEY UPDATE asset_uuid = VALUES(asset_uuid)`
-
-			assetRefArgs := make([]any, 0, len(assetReferences)*2)
-			for _, assetRef := range assetReferences {
-				assetRefArgs = append(assetRefArgs, declUUID, assetRef)
-			}
-
-			if _, err := tx.ExecContext(ctx, assetRefStmt, assetRefArgs...); err != nil {
-				return ctxerr.Wrap(ctx, err, "inserting apple mdm declaration asset references")
-			}
-		}
-
+		// An upsert keeps the existing row's UUID, so everything keyed on the
+		// declaration must use the reloaded UUID, not the one generated above.
 		if err := sqlx.GetContext(ctx, tx, &declUUID, reloadStmt, declaration.Name, tmID); err != nil {
 			return ctxerr.Wrap(ctx, err, "reload apple mdm declaration")
+		}
+
+		if err := setMDMAppleDeclarationAssetReferencesDB(ctx, tx, declUUID, declaration.AssetReferenceUUIDs); err != nil {
+			return err
 		}
 
 		labels := make([]fleet.ConfigurationProfileLabel, 0,
@@ -5319,6 +5310,42 @@ func (ds *Datastore) insertOrUpsertMDMAppleDeclaration(ctx context.Context, insO
 
 	declaration.DeclarationUUID = declUUID
 	return declaration, nil
+}
+
+// setMDMAppleDeclarationAssetReferencesDB reconciles the asset references of a
+// single declaration against the incoming set, so an edit that drops an asset
+// doesn't leave the old reference behind. The declaration UUID must be the one
+// stored in mdm_apple_declarations (an upsert keeps the pre-existing UUID).
+func setMDMAppleDeclarationAssetReferencesDB(ctx context.Context, tx sqlx.ExtContext, declUUID string, assetRefs []string) error {
+	delStmt := `DELETE FROM mdm_apple_declaration_asset_references WHERE declaration_uuid = ?`
+	delArgs := []any{declUUID}
+	if len(assetRefs) > 0 {
+		var err error
+		delStmt, delArgs, err = sqlx.In(`DELETE FROM mdm_apple_declaration_asset_references
+			WHERE declaration_uuid = ? AND asset_uuid NOT IN (?)`, declUUID, assetRefs)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "building delete stale apple mdm declaration asset references query")
+		}
+	}
+	if _, err := tx.ExecContext(ctx, delStmt, delArgs...); err != nil {
+		return ctxerr.Wrap(ctx, err, "deleting stale apple mdm declaration asset references")
+	}
+
+	if len(assetRefs) == 0 {
+		return nil
+	}
+
+	insStmt := `INSERT INTO mdm_apple_declaration_asset_references (declaration_uuid, asset_uuid) VALUES ` +
+		strings.Repeat("(?, ?),", len(assetRefs)-1) + "(?, ?) ON DUPLICATE KEY UPDATE asset_uuid = VALUES(asset_uuid)"
+	insArgs := make([]any, 0, len(assetRefs)*2)
+	for _, ref := range assetRefs {
+		insArgs = append(insArgs, declUUID, ref)
+	}
+	if _, err := tx.ExecContext(ctx, insStmt, insArgs...); err != nil {
+		return ctxerr.Wrap(ctx, err, "inserting apple mdm declaration asset references")
+	}
+
+	return nil
 }
 
 // Keyed on declaration_uuid rather than inserted fresh, so an edit keeps the

--- a/server/datastore/mysql/apple_mdm_ddm_test.go
+++ b/server/datastore/mysql/apple_mdm_ddm_test.go
@@ -33,6 +33,7 @@ func TestMDMDDMApple(t *testing.T) {
 		{"GetAppleDDMAssetForDelivery", testGetAppleDDMAssetForDelivery},
 		{"GetAppleDDMAssetsReferencedByDeclarations", testGetAppleDDMAssetsReferencedByDeclarations},
 		{"AssetsUpdatedAtRoundTripAndToken", testDDMAssetsUpdatedAtRoundTripAndToken},
+		{"UpsertDeclarationAssetReferences", testUpsertDeclarationAssetReferences},
 	}
 
 	for _, c := range cases {
@@ -900,6 +901,61 @@ func testGetAppleDDMAssetsReferencedByDeclarations(t *testing.T, ds *Datastore) 
 		require.Len(t, got, 1)
 		require.Equal(t, asset1UUID, got[0].AssetUUID)
 	})
+}
+
+func testUpsertDeclarationAssetReferences(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	asset1UUID, err := ds.CreateAppleDDMAsset(ctx, "upsert-asset-one", "com.example.upsert.one", []byte(`{"a":1}`), nil)
+	require.NoError(t, err)
+	asset2UUID, err := ds.CreateAppleDDMAsset(ctx, "upsert-asset-two", "com.example.upsert.two", []byte(`{"a":2}`), nil)
+	require.NoError(t, err)
+
+	newDecl := func(refs []string) *fleet.MDMAppleDeclaration {
+		return &fleet.MDMAppleDeclaration{
+			Name:                "UpsertDecl",
+			Identifier:          "com.example.upsertDecl",
+			RawJSON:             []byte(`{"Type":"com.apple.configuration.test","Identifier":"com.example.upsertDecl"}`),
+			Scope:               fleet.PayloadScopeSystem,
+			AssetReferenceUUIDs: refs,
+		}
+	}
+
+	refsFor := func(declUUID string) []string {
+		var got []string
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			return sqlx.SelectContext(ctx, q, &got,
+				`SELECT asset_uuid FROM mdm_apple_declaration_asset_references WHERE declaration_uuid = ?`, declUUID)
+		})
+		return got
+	}
+
+	created, err := ds.SetOrUpdateMDMAppleDeclaration(ctx, newDecl([]string{asset1UUID}), nil)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{asset1UUID}, refsFor(created.DeclarationUUID))
+
+	// Re-sending identical contents keeps the existing declaration UUID; the
+	// references must be written against that UUID, not a freshly generated one.
+	updated, err := ds.SetOrUpdateMDMAppleDeclaration(ctx, newDecl([]string{asset1UUID}), nil)
+	require.NoError(t, err)
+	require.Equal(t, created.DeclarationUUID, updated.DeclarationUUID)
+	require.ElementsMatch(t, []string{asset1UUID}, refsFor(created.DeclarationUUID))
+
+	// Adding a reference on an edit.
+	updated, err = ds.SetOrUpdateMDMAppleDeclaration(ctx, newDecl([]string{asset1UUID, asset2UUID}), nil)
+	require.NoError(t, err)
+	require.Equal(t, created.DeclarationUUID, updated.DeclarationUUID)
+	require.ElementsMatch(t, []string{asset1UUID, asset2UUID}, refsFor(created.DeclarationUUID))
+
+	// Dropping a reference on an edit removes the stale row.
+	_, err = ds.SetOrUpdateMDMAppleDeclaration(ctx, newDecl([]string{asset2UUID}), nil)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{asset2UUID}, refsFor(created.DeclarationUUID))
+
+	// Dropping all references clears them.
+	_, err = ds.SetOrUpdateMDMAppleDeclaration(ctx, newDecl(nil), nil)
+	require.NoError(t, err)
+	require.Empty(t, refsFor(created.DeclarationUUID))
 }
 
 func testDDMAssetsUpdatedAtRoundTripAndToken(t *testing.T, ds *Datastore) {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves nothing, just something I found.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information. (None, as editing profiles is only just released)

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


TO test upload a DDM profile referencing an asset, then try to edit that profile with identical DDM contents and see mysql error, this PR fixes that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Apple device management declaration updates to preserve the existing declaration identity.
  * Correctly synchronizes linked asset references when declarations are updated, including removing outdated references and clearing all references when none remain.
* **Tests**
  * Added coverage for creating, preserving, updating, removing, and clearing declaration asset references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->