### PR TITLE
Cherry-pick #50379: Bump brace-expansion from 1.1.16 to 1.1.18

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4270,9 +4270,9 @@ bourbon@^4.2.6:
   integrity sha512-XY2nuWcgS5ODGVFHgE/SsjFb18ke1dPtxu32vDm2tue8v4RflmU0mp0jpdIvvyjEtYEv6oiSpQL2PRUsEqde4w==
 
 brace-expansion@^1.1.7:
-  version "1.1.16"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.16.tgz#723d3a30c0558c225abc9fc479a73e14e26c3c2f"
-  integrity sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==
+  version "1.1.18"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.18.tgz#3ce74d89885136be1535341f8c3d4425c29a5cab"
+  integrity sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"


### PR DESCRIPTION
Cherry-pick of #50379 into the RC branch. Resolves [code scanning alert 2520](https://github.com/fleetdm/fleet/security/code-scanning/2520) (CVE-2026-69152, brace-expansion DoS) on `rc-minor-fleet-v4.90.0`.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results