### PR TITLE
Dogfood: drop platform prefix from policy names

### DIFF
--- a/it-and-security/lib/all/labels/macos-screen-lock-exclusions.yml
+++ b/it-and-security/lib/all/labels/macos-screen-lock-exclusions.yml
@@ -1,6 +1,6 @@
 - name: macOS screen lock exclusions
   description: |
-    Hosts in this label are excluded from the "macOS - Screen lock after inactivity (15 minutes or less)"
+    Hosts in this label are excluded from the "Screen lock after inactivity (15 minutes or less)"
     policy and the corresponding screen-lock-inactivity.mobileconfig configuration profile.
     Add Fleet host IDs below to exclude a host (hardware_serial or uuid also work).
   label_membership_type: manual

--- a/it-and-security/lib/all/labels/windows-screen-lock-exclusions.yml
+++ b/it-and-security/lib/all/labels/windows-screen-lock-exclusions.yml
@@ -1,6 +1,6 @@
 - name: Windows screen lock exclusions
   description: |
-    Hosts in this label are excluded from the "Windows - Interactive logon screen lock timeout configured"
+    Hosts in this label are excluded from the "Interactive logon screen lock timeout configured"
     policy and the corresponding "Screen lock timeout.xml" configuration profile.
     Add Fleet host IDs below to exclude a host (hardware_serial or uuid also work).
   label_membership_type: manual

--- a/it-and-security/lib/all/policies/npm-user-npmrc-min-release-age.yml
+++ b/it-and-security/lib/all/policies/npm-user-npmrc-min-release-age.yml
@@ -1,4 +1,4 @@
-- name: macOS - User .npmrc min-release-age at least 0.5 days
+- name: User .npmrc min-release-age at least 0.5 days (macOS)
   query: |
     SELECT 1 WHERE NOT EXISTS (
       SELECT 1 FROM users u
@@ -77,7 +77,7 @@
   run_script:
     path: ../scripts/configure-npmrc-min-release-age.sh
 
-- name: Linux - User .npmrc min-release-age at least 0.5 days
+- name: User .npmrc min-release-age at least 0.5 days (Linux)
   query: |
     SELECT 1 WHERE NOT EXISTS (
       SELECT 1 FROM users u
@@ -154,7 +154,7 @@
   run_script:
     path: ../scripts/configure-npmrc-min-release-age.sh
 
-- name: Windows - User .npmrc min-release-age at least 0.5 days
+- name: User .npmrc min-release-age at least 0.5 days (Windows)
   query: |
     SELECT 1 WHERE NOT EXISTS (
       SELECT 1 FROM users u

--- a/it-and-security/lib/linux/policies/check-fleet-desktop-extension-enabled.yml
+++ b/it-and-security/lib/linux/policies/check-fleet-desktop-extension-enabled.yml
@@ -1,4 +1,4 @@
-- name: Linux - Fleet Desktop extensions enabled
+- name: Fleet Desktop extensions enabled
   critical: false
   description: This policy checks if the extension required for Fleet Desktop is installed and enabled.
   resolution: |

--- a/it-and-security/lib/linux/policies/disk-encryption-check.yml
+++ b/it-and-security/lib/linux/policies/disk-encryption-check.yml
@@ -1,4 +1,4 @@
-- name: Linux - Disk encryption enabled
+- name: Disk encryption enabled (Linux)
   query: SELECT 1 FROM mounts m, disk_encryption d WHERE m.device_alias = d.name AND d.encrypted = 1 AND m.path = '/';
   critical: false
   description: This policy checks if disk encryption is enabled.

--- a/it-and-security/lib/linux/policies/disk-space-check.yml
+++ b/it-and-security/lib/linux/policies/disk-space-check.yml
@@ -1,4 +1,4 @@
-- name: Linux - Sufficient disk space available
+- name: Sufficient disk space available (Linux)
   query: SELECT 1 FROM mounts WHERE path = '/' AND CAST(blocks_available AS REAL) / blocks > 0.10;
   critical: false
   description: >-

--- a/it-and-security/lib/linux/policies/removable-storage-read-only.yml
+++ b/it-and-security/lib/linux/policies/removable-storage-read-only.yml
@@ -1,4 +1,4 @@
-- name: Linux - Removable storage is read-only
+- name: Removable storage is read-only
   critical: false
   description: Enforces read-only access to USB removable storage (USB sticks, external HDD/SSD presented as removable, SD cards) on Linux hosts via a udev rule.
   resolution: |

--- a/it-and-security/lib/linux/policies/sshd-permitrootlogin-restricted.yml
+++ b/it-and-security/lib/linux/policies/sshd-permitrootlogin-restricted.yml
@@ -1,4 +1,4 @@
-- name: Linux - SSH PermitRootLogin not set to yes
+- name: SSH PermitRootLogin not set to yes
   query: |-
     SELECT 1 WHERE NOT EXISTS (
       SELECT 1 FROM augeas

--- a/it-and-security/lib/macos/policies/1password-emergency-kit-check.yml
+++ b/it-and-security/lib/macos/policies/1password-emergency-kit-check.yml
@@ -1,4 +1,4 @@
-- name: macOS - No 1Password emergency kit stored in desktop, documents, or downloads folders
+- name: No 1Password emergency kit stored in desktop, documents, or downloads folders
   query: SELECT 1 WHERE 
     NOT EXISTS (
       SELECT 1 FROM file WHERE 

--- a/it-and-security/lib/macos/policies/1password-installed.yml
+++ b/it-and-security/lib/macos/policies/1password-installed.yml
@@ -1,4 +1,4 @@
-- name: macOS - 1Password installed
+- name: 1Password installed (macOS)
   query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.1password.1password';
   # install_software:
   #   fleet_maintained_app_slug: 1password/darwin

--- a/it-and-security/lib/macos/policies/all-software-updates-installed.yml
+++ b/it-and-security/lib/macos/policies/all-software-updates-installed.yml
@@ -1,4 +1,4 @@
-- name: macOS - All available software updates installed
+- name: All available software updates installed
   query: SELECT 1 FROM software_update WHERE software_update_required = 0;
   critical: false
   description: This Mac may have outdated system software, which could lead to security vulnerabilities, performance issues, and incompatibility with other systems.

--- a/it-and-security/lib/macos/policies/battery-health-check.yml
+++ b/it-and-security/lib/macos/policies/battery-health-check.yml
@@ -1,4 +1,4 @@
-- name: macOS - Battery healthy
+- name: Battery healthy (macOS)
   query: |-
     SELECT 1 WHERE NOT EXISTS (
       SELECT 1 FROM battery

--- a/it-and-security/lib/macos/policies/disk-encryption-check.yml
+++ b/it-and-security/lib/macos/policies/disk-encryption-check.yml
@@ -1,4 +1,4 @@
-- name: macOS - Disk encryption enabled
+- name: Disk encryption enabled (macOS)
   query: SELECT 1 FROM filevault_status WHERE status LIKE '%on%';
   critical: false
   description: This policy checks if disk encryption is enabled.

--- a/it-and-security/lib/macos/policies/disk-space-check.yml
+++ b/it-and-security/lib/macos/policies/disk-space-check.yml
@@ -1,4 +1,4 @@
-- name: macOS - Sufficient disk space available
+- name: Sufficient disk space available (macOS)
   query: SELECT 1 FROM mounts WHERE path = '/' AND CAST(blocks_available AS REAL) / blocks > 0.10;
   critical: false
   description: >-

--- a/it-and-security/lib/macos/policies/firewall-enabled.yml
+++ b/it-and-security/lib/macos/policies/firewall-enabled.yml
@@ -1,4 +1,4 @@
-- name: macOS - Application firewall enabled
+- name: Application firewall enabled
   query: SELECT 1 FROM alf WHERE global_state >= 1;
   critical: false
   description: |-

--- a/it-and-security/lib/macos/policies/gatekeeper-enabled.yml
+++ b/it-and-security/lib/macos/policies/gatekeeper-enabled.yml
@@ -1,4 +1,4 @@
-- name: macOS - Gatekeeper enabled
+- name: Gatekeeper enabled
   query: SELECT 1 FROM gatekeeper WHERE assessments_enabled = 1;
   critical: false
   description: |-

--- a/it-and-security/lib/macos/policies/install-fleet-desktop-launch-agent.yml
+++ b/it-and-security/lib/macos/policies/install-fleet-desktop-launch-agent.yml
@@ -1,4 +1,4 @@
-- name: macOS - Fleet Desktop.app launch agent installed
+- name: Fleet Desktop.app launch agent installed
   query: SELECT 1 FROM file WHERE path = '/Library/LaunchAgents/com.fleetdm.fleet-desktop-hidden.plist' LIMIT 1;
   critical: false
   description: Ensures the Fleet Desktop.app launch agent plist is present on disk after the MDM profile is delivered.

--- a/it-and-security/lib/macos/policies/install-nudge-assets.yml
+++ b/it-and-security/lib/macos/policies/install-nudge-assets.yml
@@ -1,4 +1,4 @@
-- name: macOS - Nudge assets installed
+- name: Nudge assets installed
   query: SELECT 1 WHERE EXISTS (SELECT 1 FROM package_receipts WHERE package_id = "com.fleetdm.Nudge.assets");
   critical: true
   description: This policy ensures the Nudge assets are installed.

--- a/it-and-security/lib/macos/policies/install-santa-extension.yml
+++ b/it-and-security/lib/macos/policies/install-santa-extension.yml
@@ -1,4 +1,4 @@
-- name: macOS - Santa extension installed
+- name: Santa extension installed
   query: SELECT 1 WHERE EXISTS (SELECT * FROM file_lines WHERE path = "/var/osquery/extensions.load" AND line = "/var/fleet/extensions/santa.ext");
   critical: false
   description: This policy ensures the custom extension for santa is installed.

--- a/it-and-security/lib/macos/policies/latest-macos.yml
+++ b/it-and-security/lib/macos/policies/latest-macos.yml
@@ -1,4 +1,4 @@
-- name: macOS - Operating system up to date
+- name: Operating system up to date
   query: SELECT 1 FROM os_version WHERE version >= '26.4.1' OR version >= '15.7.5';
   critical: true
   description: Using an outdated macOS version risks exposure to security vulnerabilities and potential system instability.

--- a/it-and-security/lib/macos/policies/local-admin-count-reasonable.yml
+++ b/it-and-security/lib/macos/policies/local-admin-count-reasonable.yml
@@ -1,4 +1,4 @@
-- name: macOS - Local admin accounts within limit
+- name: Local admin accounts within limit
   query: |-
     SELECT 1 WHERE (
       SELECT COUNT(DISTINCT u.uid)

--- a/it-and-security/lib/macos/policies/nudge-installed.yml
+++ b/it-and-security/lib/macos/policies/nudge-installed.yml
@@ -1,4 +1,4 @@
-- name: macOS - Nudge installed
+- name: Nudge installed
   query: SELECT 1 FROM apps WHERE bundle_identifier = "com.github.macadmins.Nudge";
   critical: true
   description: This policy ensures Nudge is installed.

--- a/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
+++ b/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
@@ -1,4 +1,4 @@
-- name: macOS - Google Chrome up to date
+- name: Google Chrome up to date (macOS)
   description: The host may have an outdated version of Google Chrome, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Google Chrome's built-in update functionality."
   type: patch
@@ -6,7 +6,7 @@
   install_software: false
   labels_include_any:
     - Macs with Google Chrome installed
-- name: macOS - 1Password up to date
+- name: 1Password up to date (macOS)
   description: This device may have an outdated version of 1Password, potentially risking security vulnerabilities or compatibility issues.
   resolution: "1Password is managed by IT and should be updated automatically. If you are failing this policy, install the latest version from Self-service. If you are still failing after Refetch completes, drop a note in #help-it."
   type: patch
@@ -14,7 +14,7 @@
   install_software: true
   labels_include_any:
     - Macs with 1Password installed
-- name: macOS - Brave Browser up to date
+- name: Brave Browser up to date
   description: The host may have an outdated version of Brave Browser, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Brave Browser's built-in update functionality. You can also delete Brave Browser if you are no longer using it."
   type: patch
@@ -22,7 +22,7 @@
   install_software: false
   labels_include_any:
     - Macs with Brave Browser installed
-- name: macOS - Docker Desktop up to date
+- name: Docker Desktop up to date
   description: The host may have an outdated version of Docker Desktop, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Docker Desktop's built-in update functionality. You can also delete Docker Desktop if you are no longer using it."
   type: patch
@@ -30,7 +30,7 @@
   install_software: false
   labels_include_any:
     - Macs with Docker Desktop installed
-- name: macOS - Firefox up to date
+- name: Firefox up to date (macOS)
   description: The host may have an outdated version of Firefox, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service, otherwise the update will automatically install during an upcoming scheduled maintenance window. Check your calendar for details."
   type: patch
@@ -39,7 +39,7 @@
   calendar_events_enabled: true
   labels_include_any:
     - Macs with Firefox installed
-- name: macOS - Visual Studio Code up to date
+- name: Visual Studio Code up to date (macOS)
   description: The host may have an outdated version of Visual Studio Code, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Visual Studio Code's built-in update functionality. You can also delete Visual Studio Code if you are no longer using it."
   type: patch
@@ -47,7 +47,7 @@
   install_software: false
   labels_include_any:
     - Macs with Visual Studio Code installed
-- name: macOS - Slack up to date
+- name: Slack up to date (macOS)
   description: The host may have an outdated version of Slack, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Slack's built-in update functionality."
   type: patch
@@ -55,7 +55,7 @@
   install_software: false
   labels_include_any:
     - Macs with Slack installed
-- name: macOS - Zoom up to date
+- name: Zoom up to date (macOS)
   description: The host may have an outdated version of Zoom, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Zoom's built-in update functionality."
   type: patch
@@ -63,7 +63,7 @@
   install_software: false
   labels_include_any:
     - Macs with Zoom installed
-- name: macOS - Okta Verify up to date
+- name: Okta Verify up to date (macOS)
   description: The host may have an outdated version of Okta Verify, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Okta Verify is an app managed by IT and should be kept up to date automatically. If you are failing this policy, install the latest version from Self-service, then click Refetch. If you are still failing after Refetch completes, drop a note in #help-it."
   type: patch
@@ -71,7 +71,7 @@
   install_software: true
   labels_include_any:
     - Macs with Okta Verify installed
-- name: macOS - Santa up to date
+- name: Santa up to date
   description: The host may have an outdated version of Santa, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Santa is an app managed by IT and should be kept up to date automatically. If you are failing this policy, click Refetch. If you are still failing after Refetch completes, drop a note in #help-it."
   type: patch
@@ -79,7 +79,7 @@
   install_software: true
   labels_include_any:
     - Macs with Santa installed
-- name: macOS - Fleet Desktop up to date
+- name: Fleet Desktop up to date
   description: The host may have an outdated version of Fleet Desktop, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Fleet Desktop is an app managed by IT and should be kept up to date automatically. If you are failing this policy, install the latest version from Self-service, then click Refetch. If you are still failing after Refetch completes, drop a note in #help-it."
   type: patch
@@ -87,7 +87,7 @@
   install_software: true
   labels_include_any:
     - Macs with Fleet Desktop.app installed
-- name: macOS - Claude up to date
+- name: Claude up to date (macOS)
   description: The host may have an outdated version of Claude, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Claude's built-in update functionality. You can also delete Claude if you are no longer using it."
   type: patch
@@ -95,7 +95,7 @@
   install_software: false
   labels_include_any:
     - Macs with Claude installed
-- name: macOS - AWS VPN Client up to date
+- name: AWS VPN Client up to date
   description: The host may have an outdated version of AWS VPN Client, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using AWS VPN Client's built-in update functionality. You can also delete AWS VPN Client if you are no longer using it."
   type: patch
@@ -103,7 +103,7 @@
   install_software: false
   labels_include_any:
     - Macs with AWS VPN Client installed
-- name: macOS - GitHub Desktop up to date
+- name: GitHub Desktop up to date
   description: The host may have an outdated version of GitHub Desktop, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using GitHub Desktop's built-in update functionality. You can also delete GitHub Desktop if you are no longer using it."
   type: patch
@@ -111,7 +111,7 @@
   install_software: false
   labels_include_any:
     - Macs with GitHub Desktop installed
-- name: macOS - UTM up to date
+- name: UTM up to date
   description: The host may have an outdated version of UTM, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using UTM's built-in update functionality. You can also delete UTM if you are no longer using it."
   type: patch
@@ -119,7 +119,7 @@
   install_software: false
   labels_include_any:
     - Macs with UTM installed
-- name: macOS - Postman up to date
+- name: Postman up to date
   description: The host may have an outdated version of Postman, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Postman's built-in update functionality. You can also delete Postman if you are no longer using it."
   type: patch
@@ -127,7 +127,7 @@
   install_software: false
   labels_include_any:
     - Macs with Postman installed
-- name: macOS - Grammarly Desktop up to date
+- name: Grammarly Desktop up to date
   description: The host may have an outdated version of Grammarly Desktop, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Grammarly Desktop's built-in update functionality. You can also delete Grammarly Desktop if you are no longer using it."
   type: patch
@@ -135,7 +135,7 @@
   install_software: false
   labels_include_any:
     - Macs with Grammarly Desktop installed
-- name: macOS - iTerm2 up to date
+- name: iTerm2 up to date
   description: The host may have an outdated version of iTerm2, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using iTerm2's built-in update functionality. You can also delete iTerm2 if you are no longer using it."
   type: patch
@@ -143,7 +143,7 @@
   install_software: false
   labels_include_any:
     - Macs with iTerm2 installed
-- name: macOS - Sublime Text up to date
+- name: Sublime Text up to date
   description: The host may have an outdated version of Sublime Text, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Sublime Text's built-in update functionality. You can also delete Sublime Text if you are no longer using it."
   type: patch
@@ -151,7 +151,7 @@
   install_software: false
   labels_include_any:
     - Macs with Sublime Text installed
-- name: macOS - Parallels Desktop up to date
+- name: Parallels Desktop up to date
   description: The host may have an outdated version of Parallels Desktop, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Parallels Desktop's built-in update functionality. You can also delete Parallels Desktop if you are no longer using it."
   type: patch
@@ -159,7 +159,7 @@
   install_software: false
   labels_include_any:
     - Macs with Parallels Desktop installed
-- name: macOS - Loom up to date
+- name: Loom up to date
   description: The host may have an outdated version of Loom, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Loom's built-in update functionality. You can also delete Loom if you are no longer using it."
   type: patch
@@ -167,7 +167,7 @@
   install_software: false
   labels_include_any:
     - Macs with Loom installed
-- name: macOS - Spotify up to date
+- name: Spotify up to date
   description: The host may have an outdated version of Spotify, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Spotify's built-in update functionality. You can also delete Spotify if you are no longer using it."
   type: patch
@@ -175,7 +175,7 @@
   install_software: false
   labels_include_any:
     - Macs with Spotify installed
-- name: macOS - Rectangle up to date
+- name: Rectangle up to date
   description: The host may have an outdated version of Rectangle, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Rectangle's built-in update functionality. You can also delete Rectangle if you are no longer using it."
   type: patch
@@ -183,7 +183,7 @@
   install_software: false
   labels_include_any:
     - Macs with Rectangle installed
-- name: macOS - Logi Options+ up to date
+- name: Logi Options+ up to date
   description: The host may have an outdated version of Logi Options+, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Logi Options+'s built-in update functionality. You can also delete Logi Options+ if you are no longer using it."
   type: patch
@@ -191,7 +191,7 @@
   install_software: false
   labels_include_any:
     - Macs with Logi Options+ installed
-- name: macOS - Figma up to date
+- name: Figma up to date
   description: The host may have an outdated version of Figma, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Figma's built-in update functionality. You can also delete Figma if you are no longer using it."
   type: patch
@@ -199,7 +199,7 @@
   install_software: false
   labels_include_any:
     - Macs with Figma installed
-- name: macOS - WhatsApp up to date
+- name: WhatsApp up to date
   description: The host may have an outdated version of WhatsApp, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using WhatsApp's built-in update functionality. You can also delete WhatsApp if you are no longer using it."
   type: patch
@@ -207,7 +207,7 @@
   install_software: false
   labels_include_any:
     - Macs with WhatsApp installed
-- name: macOS - Android Studio up to date
+- name: Android Studio up to date
   description: The host may have an outdated version of Android Studio, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Android Studio's built-in update functionality. You can also delete Android Studio if you are no longer using it."
   type: patch
@@ -215,7 +215,7 @@
   install_software: false
   labels_include_any:
     - Macs with Android Studio installed
-- name: macOS - Zed up to date
+- name: Zed up to date
   description: The host may have an outdated version of Zed, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Zed's built-in update functionality. You can also delete Zed if you are no longer using it."
   type: patch
@@ -223,7 +223,7 @@
   install_software: false
   labels_include_any:
     - Macs with Zed installed
-- name: macOS - Obsidian up to date
+- name: Obsidian up to date
   description: The host may have an outdated version of Obsidian, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Obsidian's built-in update functionality. You can also delete Obsidian if you are no longer using it."
   type: patch
@@ -231,7 +231,7 @@
   install_software: false
   labels_include_any:
     - Macs with Obsidian installed
-- name: macOS - Google Drive up to date
+- name: Google Drive up to date
   description: The host may have an outdated version of Google Drive, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Google Drive's built-in update functionality. You can also delete Google Drive if you are no longer using it."
   type: patch
@@ -239,7 +239,7 @@
   install_software: false
   labels_include_any:
     - Macs with Google Drive installed
-- name: macOS - Cursor up to date
+- name: Cursor up to date
   description: The host may have an outdated version of Cursor, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Cursor's built-in update functionality. You can also delete Cursor if you are no longer using it."
   type: patch
@@ -247,7 +247,7 @@
   install_software: false
   labels_include_any:
     - Macs with Cursor installed
-- name: macOS - Nudge up to date
+- name: Nudge up to date
   description: The host may have an outdated version of Nudge, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Nudge is an app managed by IT and should be kept up to date automatically. If you are failing this policy, click Refetch. If you are still failing after Refetch completes, drop a note in #help-it."
   type: patch
@@ -255,7 +255,7 @@
   install_software: true
   labels_include_any:
     - Macs with Nudge installed
-- name: macOS - Adobe Acrobat Reader up to date
+- name: Adobe Acrobat Reader up to date (macOS)
   description: This device may have an outdated version of Adobe Acrobat Reader, posing a critical security risk. Adobe Reader is a frequent target for exploits and must be kept up to date at all times.
   resolution: "Adobe Acrobat Reader is managed by IT and should be updated automatically. If you are failing this policy, install the latest version from Self-service. If you are still failing after Refetch completes, drop a note in #help-it."
   critical: true
@@ -264,7 +264,7 @@
   install_software: true
   labels_include_any:
     - Macs with Adobe Acrobat Reader installed
-- name: macOS - Adobe Acrobat Pro up to date
+- name: Adobe Acrobat Pro up to date
   description: This device may have an outdated version of Adobe Acrobat Pro, posing a critical security risk. Adobe Acrobat is a frequent target for exploits and must be kept up to date at all times.
   resolution: "Adobe Acrobat Pro is managed by IT and should be updated automatically. If you are failing this policy, install the latest version from Self-service. If you are still failing after Refetch completes, drop a note in #help-it."
   critical: true

--- a/it-and-security/lib/macos/policies/remote-login-disabled.yml
+++ b/it-and-security/lib/macos/policies/remote-login-disabled.yml
@@ -1,4 +1,4 @@
-- name: macOS - Remote Login (SSH) disabled
+- name: Remote Login (SSH) disabled
   query: SELECT 1 FROM sharing_preferences WHERE CAST(remote_login AS INTEGER) = 0;
   critical: false
   description: |-

--- a/it-and-security/lib/macos/policies/santa-endpoint-security-extension-active.yml
+++ b/it-and-security/lib/macos/policies/santa-endpoint-security-extension-active.yml
@@ -1,4 +1,4 @@
-- name: macOS - Santa Endpoint Security extension active
+- name: Santa Endpoint Security extension active
   platform: darwin
   description: Santa is installed but its Endpoint Security system extension is missing or not in the activated enabled state.
   resolution: "Fleet can run the remediation script to request extension activation. If it still fails, please reach out to help-it in Slack."

--- a/it-and-security/lib/macos/policies/screen-lock-inactivity.yml
+++ b/it-and-security/lib/macos/policies/screen-lock-inactivity.yml
@@ -1,4 +1,4 @@
-- name: macOS - Screen lock after inactivity (15 minutes or less)
+- name: Screen lock after inactivity (15 minutes or less)
   query: |-
     SELECT 1 WHERE EXISTS (
       SELECT 1

--- a/it-and-security/lib/macos/policies/sip-enabled.yml
+++ b/it-and-security/lib/macos/policies/sip-enabled.yml
@@ -1,4 +1,4 @@
-- name: macOS - System Integrity Protection enabled
+- name: System Integrity Protection enabled
   query: SELECT 1 FROM sip_config WHERE config_flag = 'sip' AND enabled = 1;
   critical: true
   description: |-

--- a/it-and-security/lib/macos/policies/update-claude.yml
+++ b/it-and-security/lib/macos/policies/update-claude.yml
@@ -1,4 +1,4 @@
-- name: macOS - Claude up to date
+- name: Claude up to date (macOS)
   query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.1.9493') < 0);
   critical: false
   description: The host may have an outdated version of Claude, potentially risking security vulnerabilities or compatibility issues.

--- a/it-and-security/lib/macos/policies/update-safari.yml
+++ b/it-and-security/lib/macos/policies/update-safari.yml
@@ -1,4 +1,4 @@
-- name: macOS - Safari up to date
+- name: Safari up to date
   query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.apple.Safari') OR (EXISTS (SELECT 1 FROM os_version WHERE version LIKE '26.%') AND EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.apple.Safari' AND version_compare(bundle_short_version, '26.4') >= 0)) OR (EXISTS (SELECT 1 FROM os_version WHERE version LIKE '15.%') AND EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.apple.Safari' AND version_compare(bundle_short_version, '18.6') >= 0));
   critical: false
   description: The host may have an outdated version of Safari, potentially risking security vulnerabilities or compatibility issues.

--- a/it-and-security/lib/macos/policies/update-slack.yml
+++ b/it-and-security/lib/macos/policies/update-slack.yml
@@ -1,4 +1,4 @@
-- name: macOS - Slack up to date
+- name: Slack up to date (macOS)
   query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE name = 'Slack.app' AND version_compare(bundle_short_version, '4.48.100') < 0);
   critical: false
   description: The host may have an outdated version of Slack, potentially risking security vulnerabilities or compatibility issues.

--- a/it-and-security/lib/windows/policies/1password-installed.yml
+++ b/it-and-security/lib/windows/policies/1password-installed.yml
@@ -1,4 +1,4 @@
-- name: Windows - 1Password installed
+- name: 1Password installed (Windows)
   query: SELECT 1 FROM programs WHERE name = "1Password";
   # install_software:
   #   fleet_maintained_app_slug: 1password/windows

--- a/it-and-security/lib/windows/policies/all-windows-updates-installed.yml
+++ b/it-and-security/lib/windows/policies/all-windows-updates-installed.yml
@@ -1,4 +1,4 @@
-- name: Windows - All available updates installed
+- name: All available updates installed
   query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM windows_updates);
   critical: false
   description: This Windows device may have outdated system software, which could lead to security vulnerabilities, performance issues, and incompatibility with other systems.

--- a/it-and-security/lib/windows/policies/antivirus-signatures-up-to-date.yml
+++ b/it-and-security/lib/windows/policies/antivirus-signatures-up-to-date.yml
@@ -1,4 +1,4 @@
-- name: Windows - Antivirus signatures up to date
+- name: Antivirus signatures up to date
   query: SELECT 1 FROM windows_security_products WHERE name LIKE '%Microsoft Defender Antivirus%' AND signatures_up_to_date = 1;
   critical: false
   description: Checks the status of antivirus and signature updates from the Windows Security Center.

--- a/it-and-security/lib/windows/policies/battery-health-check.yml
+++ b/it-and-security/lib/windows/policies/battery-health-check.yml
@@ -1,4 +1,4 @@
-- name: Windows - Battery healthy
+- name: Battery healthy (Windows)
   query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM battery WHERE designed_capacity > 0 AND CAST(max_capacity AS REAL) / designed_capacity <= 0.80);
   critical: false
   description: >-

--- a/it-and-security/lib/windows/policies/disk-encryption-check.yml
+++ b/it-and-security/lib/windows/policies/disk-encryption-check.yml
@@ -1,4 +1,4 @@
-- name: Windows - Disk encryption enabled
+- name: Disk encryption enabled (Windows)
   query: SELECT 1 FROM bitlocker_info WHERE protection_status = 1;
   critical: false
   description: This policy checks if disk encryption is enabled.

--- a/it-and-security/lib/windows/policies/disk-space-check.yml
+++ b/it-and-security/lib/windows/policies/disk-space-check.yml
@@ -1,4 +1,4 @@
-- name: Windows - Sufficient disk space available
+- name: Sufficient disk space available (Windows)
   query: SELECT 1 WHERE (SELECT CAST(SUM(free_space) AS REAL) / SUM(size) FROM logical_drives WHERE file_system = 'NTFS') > 0.10;
   critical: false
   description: >-

--- a/it-and-security/lib/windows/policies/patch-fleet-maintained-apps.yml
+++ b/it-and-security/lib/windows/policies/patch-fleet-maintained-apps.yml
@@ -1,4 +1,4 @@
-- name: Windows - Slack up to date
+- name: Slack up to date (Windows)
   description: The host may have an outdated version of Slack, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Slack's built-in update functionality."
   type: patch
@@ -6,7 +6,7 @@
   install_software: false
   labels_include_any:
     - x86 Windows hosts with Slack installed
-- name: Windows - 1Password up to date
+- name: 1Password up to date (Windows)
   description: This device may have an outdated version of 1Password, potentially risking security vulnerabilities or compatibility issues.
   resolution: "1Password is managed by IT and should be updated automatically. If you are failing this policy, install the latest version from Self-service. If you are still failing after Refetch completes, drop a note in #help-it."
   type: patch
@@ -14,7 +14,7 @@
   install_software: true
   labels_include_any:
     - x86 Windows hosts with 1Password installed
-- name: Windows - Claude up to date
+- name: Claude up to date (Windows)
   description: The host may have an outdated version of Claude, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Claude's built-in update functionality. You can also uninstall Claude if you are no longer using it."
   type: patch
@@ -22,7 +22,7 @@
   install_software: false
   labels_include_any:
     - x86 Windows hosts with Claude installed
-- name: Windows - Firefox up to date
+- name: Firefox up to date (Windows)
   description: The host may have an outdated version of Firefox, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Firefox's built-in update functionality. You can also uninstall Firefox if you are no longer using it."
   type: patch
@@ -30,7 +30,7 @@
   install_software: false
   labels_include_any:
     - x86 Windows hosts with Firefox installed
-- name: Windows - Google Chrome up to date
+- name: Google Chrome up to date (Windows)
   description: The host may have an outdated version of Google Chrome, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Google Chrome's built-in update functionality."
   type: patch
@@ -38,7 +38,7 @@
   install_software: false
   labels_include_any:
     - x86 Windows hosts with Google Chrome installed
-- name: Windows - Zoom up to date
+- name: Zoom up to date (Windows)
   description: The host may have an outdated version of Zoom, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Zoom's built-in update functionality."
   type: patch
@@ -46,7 +46,7 @@
   install_software: false
   labels_include_any:
     - x86 Windows hosts with Zoom installed
-- name: Windows - Visual Studio Code up to date
+- name: Visual Studio Code up to date (Windows)
   description: The host may have an outdated version of Visual Studio Code, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Visual Studio Code's built-in update functionality. You can also uninstall Visual Studio Code if you are no longer using it."
   type: patch
@@ -54,7 +54,7 @@
   install_software: false
   labels_include_any:
     - x86 Windows hosts with Visual Studio Code installed
-- name: Windows - Okta Verify up to date
+- name: Okta Verify up to date (Windows)
   description: The host may have an outdated version of Okta Verify, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Okta Verify is an app managed by IT and should be kept up to date automatically. If you are failing this policy, install the latest version from Self-service, then click Refetch. If you are still failing after Refetch completes, drop a note in #help-it."
   type: patch
@@ -62,7 +62,7 @@
   install_software: true
   labels_include_any:
     - x86 Windows hosts with Okta Verify installed
-- name: Windows - Adobe Acrobat Reader up to date
+- name: Adobe Acrobat Reader up to date (Windows)
   description: This device may have an outdated version of Adobe Acrobat Reader, posing a critical security risk. Adobe Reader is a frequent target for exploits and must be kept up to date at all times.
   resolution: "Adobe Acrobat Reader is managed by IT and should be updated automatically. If you are failing this policy, install the latest version from Self-service. If you are still failing after Refetch completes, drop a note in #help-it."
   critical: true

--- a/it-and-security/lib/windows/policies/remote-desktop-disabled.yml
+++ b/it-and-security/lib/windows/policies/remote-desktop-disabled.yml
@@ -1,4 +1,4 @@
-- name: Windows - Remote Desktop disabled
+- name: Remote Desktop disabled
   query: |-
     SELECT 1 FROM registry
     WHERE key = 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Terminal Server'

--- a/it-and-security/lib/windows/policies/screen-lock-timeout-configured.yml
+++ b/it-and-security/lib/windows/policies/screen-lock-timeout-configured.yml
@@ -1,4 +1,4 @@
-- name: Windows - Interactive logon screen lock timeout configured
+- name: Interactive logon screen lock timeout configured
   query: |-
     SELECT 1 FROM registry
     WHERE key = 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System'

--- a/it-and-security/lib/windows/policies/secure-boot-enabled.yml
+++ b/it-and-security/lib/windows/policies/secure-boot-enabled.yml
@@ -1,4 +1,4 @@
-- name: Windows - Secure Boot enabled
+- name: Secure Boot enabled
   query: |-
     SELECT 1 FROM registry
     WHERE key = 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecureBoot\State'

--- a/it-and-security/lib/windows/policies/update-claude.yml
+++ b/it-and-security/lib/windows/policies/update-claude.yml
@@ -1,4 +1,4 @@
-- name: Windows - Claude up to date
+- name: Claude up to date (Windows)
   query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Claude' AND version_compare(version, '1.1.9310') < 0);
   critical: false
   description: The host may have an outdated version of Claude, potentially risking security vulnerabilities or compatibility issues.

--- a/it-and-security/lib/windows/policies/update-slack.yml
+++ b/it-and-security/lib/windows/policies/update-slack.yml
@@ -1,4 +1,4 @@
-- name: Windows - Slack up to date
+- name: Slack up to date (Windows)
   query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Slack' AND version_compare(version, '4.48.100') < 0);
   critical: false
   description: The host may have an outdated version of Slack, potentially risking security vulnerabilities or compatibility issues.

--- a/it-and-security/lib/windows/policies/windows-defender-compliance-check.yml
+++ b/it-and-security/lib/windows/policies/windows-defender-compliance-check.yml
@@ -1,4 +1,4 @@
-- name: Windows - Windows Defender compliance check
+- name: Windows Defender compliance check
   query: |
     WITH defender_service AS (
         SELECT


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** NA

The Fleet UI now displays a policy's targeted platform, so repeating it in the policy name is redundant. This strips the leading `macOS - ` / `Windows - ` / `Linux - ` from all 84 prefixed policies in `it-and-security`.

## Collisions

GitOps rejects duplicate policy names within a fleet ([`pkg/spec/gitops.go`](https://github.com/fleetdm/fleet/blob/main/pkg/spec/gitops.go#L2020)), and the Workstations fleet includes macOS, Windows, and Linux policies together. 14 stripped names would collide, so for those the platform moves to a trailing suffix instead of being dropped:

| Before | After |
|---|---|
| `macOS - Gatekeeper enabled` | `Gatekeeper enabled` |
| `Windows - Secure Boot enabled` | `Secure Boot enabled` |
| `Linux - Removable storage is read-only` | `Removable storage is read-only` |
| `macOS - Disk encryption enabled` | `Disk encryption enabled (macOS)` |
| `Windows - Disk encryption enabled` | `Disk encryption enabled (Windows)` |
| `Linux - Disk encryption enabled` | `Disk encryption enabled (Linux)` |

49 policies lose the platform entirely; 35 keep it as a suffix. The 14 suffixed names are: Disk encryption enabled, Sufficient disk space available, User .npmrc min-release-age at least 0.5 days, 1Password installed, Battery healthy, and the 9 patch policies that exist for both macOS and Windows (1Password, Google Chrome, Firefox, Slack, Zoom, Visual Studio Code, Okta Verify, Claude, Adobe Acrobat Reader).

Also updates the descriptions of `macos-screen-lock-exclusions` and `windows-screen-lock-exclusions`, which quote policy names.

## Notes for the reviewer

- **This is destructive on apply.** GitOps matches policies by name, so applying this deletes the 84 existing policies and creates new ones. Policy pass/fail history and host results reset. Automations defined in the policy YAML (calendar events, install/script triggers) carry over, but anything referencing these names outside the repo — saved filters, dashboards, Slack workflows — needs updating separately.
- `tools/fleet-slackbot/system-prompt.js:338` still documents the `<Platform> - <Description>` convention, and the `fleetctl new` macOS template still ships a prefixed name. Both left alone intentionally — out of scope for dogfood config.
- Four policy files appear unused by any fleet and were renamed only for consistency: `lib/{macos,windows}/policies/update-claude.yml` and `update-slack.yml`. Their names duplicate entries already in `patch-fleet-maintained-apps.yml` for the same platform. Worth deleting in a follow-up.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

  N/A — dogfood GitOps config only, no product code changes.

## Testing

- [x] QA'd all new/changed functionality manually

Verified locally:
- No `macOS - ` / `Windows - ` / `Linux - ` strings remain anywhere under `it-and-security/`.
- Every fleet passes the same uniqueness rule GitOps enforces — Workstations resolves to 78 policies with 0 duplicate names; all other fleets unchanged.
- All 73 touched/related YAML files parse.
- The diff touches only `- name:` lines plus the two label descriptions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Standardized policy and label names across macOS, Windows, and Linux.
  - Removed inconsistent platform prefixes and added platform suffixes where appropriate.
  - Updated references to renamed screen-lock policies.
  - Policy queries, enforcement behavior, descriptions, and configurations remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->