### PR TITLE
Validate NDES credentials when only the username or password changes

### DIFF
--- a/changes/50260-ndes-credential-validation.md
+++ b/changes/50260-ndes-credential-validation.md
@@ -1,0 +1,3 @@
+- Fixed editing only the username or only the password of an NDES SCEP certificate authority skipping validation against the NDES server. Fleet now verifies the credentials on save and returns an error if they're wrong, instead of saving a broken certificate authority whose misconfiguration only surfaced later as a profile failure on hosts.
+- Fixed editing only the SCEP URL of an NDES SCEP certificate authority failing with a `"password" must be set when modifying an existing certificate authority` error. The password field is now cleared when the SCEP URL changes, so it's re-entered and sent with the update.
+- Fixed an empty username or password being saved on an NDES SCEP certificate authority.

--- a/changes/50260-ndes-credential-validation.md
+++ b/changes/50260-ndes-credential-validation.md
@@ -2,3 +2,7 @@
 - Fixed editing only the SCEP URL of an NDES SCEP certificate authority failing with a `"password" must be set when modifying an existing certificate authority` error. The password field is now cleared when the SCEP URL changes, so it's re-entered and sent with the update.
 - Fixed an empty username or password being saved on an NDES SCEP certificate authority.
 - Fixed adding or editing a certificate authority with a bad NDES admin URL or credentials showing a generic "Please try again." message instead of "Invalid admin URL or credentials."
+- Fixed updating an NDES SCEP certificate authority with the masked password (`********`) returned by the GET endpoint sending the mask to the NDES server as the literal password and failing with a misleading "invalid credentials" error. The mask is now rejected with an invalid-password error, matching GitOps behavior.
+- Fleet now skips validating NDES credentials against the NDES server when an update leaves the admin URL, username, and password unchanged, so a no-op edit doesn't consume a slot in NDES's password cache.
+- Fixed an unreachable NDES admin URL (timeout, DNS failure, connection refused) being reported as "Invalid admin URL or credentials" when editing an NDES SCEP certificate authority. It's now reported as "Couldn't connect to admin URL."
+- Fixed the Save button staying enabled in the edit certificate authority modal after Fleet clears the unchanged NDES password, which let the form submit an empty password.

--- a/changes/50260-ndes-credential-validation.md
+++ b/changes/50260-ndes-credential-validation.md
@@ -1,3 +1,4 @@
 - Fixed editing only the username or only the password of an NDES SCEP certificate authority skipping validation against the NDES server. Fleet now verifies the credentials on save and returns an error if they're wrong, instead of saving a broken certificate authority whose misconfiguration only surfaced later as a profile failure on hosts.
 - Fixed editing only the SCEP URL of an NDES SCEP certificate authority failing with a `"password" must be set when modifying an existing certificate authority` error. The password field is now cleared when the SCEP URL changes, so it's re-entered and sent with the update.
 - Fixed an empty username or password being saved on an NDES SCEP certificate authority.
+- Fixed adding or editing a certificate authority with a bad NDES admin URL or credentials showing a generic "Please try again." message instead of "Invalid admin URL or credentials."

--- a/ee/server/service/certificate_authorities.go
+++ b/ee/server/service/certificate_authorities.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -1415,32 +1416,33 @@ func (svc *Service) validateNDESSCEPProxyUpdate(ctx context.Context, ndesSCEP *f
 			return &fleet.BadRequestError{Message: fmt.Sprintf("%sInvalid SCEP URL. Please correct and try again.", errPrefix)}
 		}
 	}
-	if ndesSCEP.AdminURL != nil {
-		if *ndesSCEP.AdminURL == "" {
-			return &fleet.BadRequestError{
-				Message: fmt.Sprintf("%sInvalid NDES SCEP admin URL. Please correct and try again.", errPrefix),
-			}
+	if ndesSCEP.AdminURL != nil && *ndesSCEP.AdminURL == "" {
+		return &fleet.BadRequestError{
+			Message: fmt.Sprintf("%sInvalid NDES SCEP admin URL. Please correct and try again.", errPrefix),
 		}
+	}
+	if ndesSCEP.Username != nil && *ndesSCEP.Username == "" {
+		return &fleet.BadRequestError{
+			Message: fmt.Sprintf("%sInvalid NDES SCEP username. Please correct and try again.", errPrefix),
+		}
+	}
+	if ndesSCEP.Password != nil && *ndesSCEP.Password == "" {
+		return &fleet.BadRequestError{
+			Message: fmt.Sprintf("%sInvalid NDES SCEP password. Please correct and try again.", errPrefix),
+		}
+	}
 
+	// The admin URL, username and password are used together to authenticate against NDES,
+	// so a change to any of them means the whole set has to be re-validated against the server.
+	if ndesSCEP.AdminURL != nil || ndesSCEP.Username != nil || ndesSCEP.Password != nil {
 		// We want to generate a NDESSCEPProxyCA struct with all required fields to verify the admin URL.
-		// If URL, Username or Password are not being updated we use the existing values from oldCA
+		// Any field that is not being updated uses the existing value from oldCA. The checks above
+		// reject blank updated values, so cmp.Or only ever falls back for a field left out of the update.
 		NDESProxy := fleet.NDESSCEPProxyCA{
-			AdminURL: *ndesSCEP.AdminURL,
-		}
-		if ndesSCEP.URL != nil {
-			NDESProxy.URL = *ndesSCEP.URL
-		} else {
-			NDESProxy.URL = *oldCA.URL
-		}
-		if ndesSCEP.Username != nil {
-			NDESProxy.Username = *ndesSCEP.Username
-		} else {
-			NDESProxy.Username = *oldCA.Username
-		}
-		if ndesSCEP.Password != nil {
-			NDESProxy.Password = *ndesSCEP.Password
-		} else {
-			NDESProxy.Password = *oldCA.Password
+			URL:      cmp.Or(ptr.ValOrZero(ndesSCEP.URL), ptr.ValOrZero(oldCA.URL)),
+			AdminURL: cmp.Or(ptr.ValOrZero(ndesSCEP.AdminURL), ptr.ValOrZero(oldCA.AdminURL)),
+			Username: cmp.Or(ptr.ValOrZero(ndesSCEP.Username), ptr.ValOrZero(oldCA.Username)),
+			Password: cmp.Or(ptr.ValOrZero(ndesSCEP.Password), ptr.ValOrZero(oldCA.Password)),
 		}
 
 		if err := svc.scepConfigService.ValidateNDESSCEPAdminURL(ctx, NDESProxy); err != nil {

--- a/ee/server/service/certificate_authorities.go
+++ b/ee/server/service/certificate_authorities.go
@@ -1426,7 +1426,10 @@ func (svc *Service) validateNDESSCEPProxyUpdate(ctx context.Context, ndesSCEP *f
 			Message: fmt.Sprintf("%sInvalid NDES SCEP username. Please correct and try again.", errPrefix),
 		}
 	}
-	if ndesSCEP.Password != nil && *ndesSCEP.Password == "" {
+	// The GET endpoint returns the password masked, so the mask is rejected along with the
+	// empty string (as in the GitOps batch path): changing NDES credentials always requires
+	// re-supplying the actual password.
+	if ndesSCEP.Password != nil && (*ndesSCEP.Password == "" || *ndesSCEP.Password == fleet.MaskedPassword) {
 		return &fleet.BadRequestError{
 			Message: fmt.Sprintf("%sInvalid NDES SCEP password. Please correct and try again.", errPrefix),
 		}
@@ -1445,6 +1448,15 @@ func (svc *Service) validateNDESSCEPProxyUpdate(ctx context.Context, ndesSCEP *f
 			Password: cmp.Or(ptr.ValOrZero(ndesSCEP.Password), ptr.ValOrZero(oldCA.Password)),
 		}
 
+		// If the merged set matches what's already stored there's nothing new to validate.
+		// Skip the round-trip so a no-op update doesn't consume a slot in NDES's password
+		// cache (each validation retrieves an enrollment challenge password).
+		if NDESProxy.AdminURL == ptr.ValOrZero(oldCA.AdminURL) &&
+			NDESProxy.Username == ptr.ValOrZero(oldCA.Username) &&
+			NDESProxy.Password == ptr.ValOrZero(oldCA.Password) {
+			return nil
+		}
+
 		if err := svc.scepConfigService.ValidateNDESSCEPAdminURL(ctx, NDESProxy); err != nil {
 			svc.logger.ErrorContext(ctx, "Failed to validate NDES SCEP admin URL", "err", err)
 			switch {
@@ -1452,8 +1464,12 @@ func (svc *Service) validateNDESSCEPProxyUpdate(ctx context.Context, ndesSCEP *f
 				return &fleet.BadRequestError{Message: fmt.Sprintf("%sThe NDES password cache is full. Please increase the number of cached passwords in NDES and try again.", errPrefix)}
 			case errors.As(err, &scep.NDESInsufficientPermissionsError{}):
 				return &fleet.BadRequestError{Message: fmt.Sprintf("%sInsufficient permissions for NDES SCEP admin URL. Please correct and try again.", errPrefix)}
-			default:
+			case errors.As(err, &scep.NDESInvalidError{}):
 				return &fleet.BadRequestError{Message: fmt.Sprintf("%sInvalid NDES SCEP admin URL or credentials. Please correct and try again.", errPrefix)}
+			default:
+				// anything else means the admin URL couldn't be reached at all (timeout, DNS
+				// failure, connection refused), not that the server rejected the credentials
+				return &fleet.BadRequestError{Message: fmt.Sprintf("%sCouldn't connect to NDES SCEP admin URL. Please correct and try again.", errPrefix)}
 			}
 		}
 	}

--- a/ee/server/service/certificate_authorities_test.go
+++ b/ee/server/service/certificate_authorities_test.go
@@ -1777,24 +1777,70 @@ func TestUpdatingCertificateAuthorities(t *testing.T) {
 			require.EqualError(t, err, "Couldn't edit certificate authority. Invalid NDES SCEP password. Please correct and try again.")
 		})
 
-		t.Run("Bad admin URL generic error", func(t *testing.T) {
+		t.Run("Masked password is rejected", func(t *testing.T) {
+			svc, ctx := baseSetupForCATests()
+
+			// changing NDES credentials requires re-supplying the actual password, so the
+			// mask the GET endpoint returns in place of the real one is not accepted
+			scepConfig := &scep_mock.SCEPConfigService{
+				ValidateNDESSCEPAdminURLFunc: func(_ context.Context, _ fleet.NDESSCEPProxyCA) error {
+					return errors.New("should not be called")
+				},
+			}
+			svc.scepConfigService = scepConfig
+
+			payload := fleet.CertificateAuthorityUpdatePayload{
+				NDESSCEPProxyCAUpdatePayload: &fleet.NDESSCEPProxyCAUpdatePayload{
+					Username: new("updated-username"),
+					Password: new(fleet.MaskedPassword),
+				},
+			}
+
+			err := svc.UpdateCertificateAuthority(ctx, ndesID, payload)
+			require.EqualError(t, err, "Couldn't edit certificate authority. Invalid NDES SCEP password. Please correct and try again.")
+			require.False(t, scepConfig.ValidateNDESSCEPAdminURLFuncInvoked)
+		})
+
+		t.Run("Unchanged credentials skip validation against the NDES server", func(t *testing.T) {
+			svc, ctx := baseSetupForCATests()
+
+			scepConfig := &scep_mock.SCEPConfigService{
+				ValidateNDESSCEPAdminURLFunc: func(_ context.Context, _ fleet.NDESSCEPProxyCA) error {
+					return errors.New("should not be called")
+				},
+			}
+			svc.scepConfigService = scepConfig
+
+			payload := fleet.CertificateAuthorityUpdatePayload{
+				NDESSCEPProxyCAUpdatePayload: &fleet.NDESSCEPProxyCAUpdatePayload{
+					Username: new("ndes-username"),
+					Password: new("ndes-password"),
+				},
+			}
+
+			err := svc.UpdateCertificateAuthority(ctx, ndesID, payload)
+			require.EqualError(t, err, "mock error to avoid NewActivity panic")
+			require.False(t, scepConfig.ValidateNDESSCEPAdminURLFuncInvoked)
+		})
+
+		t.Run("Unreachable admin URL", func(t *testing.T) {
 			svc, ctx := baseSetupForCATests()
 
 			svc.scepConfigService = &scep_mock.SCEPConfigService{
 				ValidateNDESSCEPAdminURLFunc: func(_ context.Context, _ fleet.NDESSCEPProxyCA) error {
-					return errors.New("some error")
+					return errors.New("sending request: dial tcp: connection refused")
 				},
 			}
 
 			payload := fleet.CertificateAuthorityUpdatePayload{
 				NDESSCEPProxyCAUpdatePayload: &fleet.NDESSCEPProxyCAUpdatePayload{
-					AdminURL: ptr.String("https://ndes.example.com"),
-					Password: ptr.String("updated-password"),
+					AdminURL: new("https://ndes.example.com"),
+					Password: new("updated-password"),
 				},
 			}
 
 			err := svc.UpdateCertificateAuthority(ctx, ndesID, payload)
-			require.EqualError(t, err, "Couldn't edit certificate authority. Invalid NDES SCEP admin URL or credentials. Please correct and try again.")
+			require.EqualError(t, err, "Couldn't edit certificate authority. Couldn't connect to NDES SCEP admin URL. Please correct and try again.")
 		})
 
 		t.Run("Bad admin URL NDES Invalid error", func(t *testing.T) {

--- a/ee/server/service/certificate_authorities_test.go
+++ b/ee/server/service/certificate_authorities_test.go
@@ -1736,6 +1736,47 @@ func TestUpdatingCertificateAuthorities(t *testing.T) {
 			require.EqualError(t, err, "Couldn't edit certificate authority. \"password\" must be set when modifying an existing certificate authority: NDES")
 		})
 
+		t.Run("Empty admin URL", func(t *testing.T) {
+			svc, ctx := baseSetupForCATests()
+
+			payload := fleet.CertificateAuthorityUpdatePayload{
+				NDESSCEPProxyCAUpdatePayload: &fleet.NDESSCEPProxyCAUpdatePayload{
+					AdminURL: new(""),
+					Password: new("updated-password"),
+				},
+			}
+
+			err := svc.UpdateCertificateAuthority(ctx, ndesID, payload)
+			require.EqualError(t, err, "Couldn't edit certificate authority. Invalid NDES SCEP admin URL. Please correct and try again.")
+		})
+
+		t.Run("Empty username", func(t *testing.T) {
+			svc, ctx := baseSetupForCATests()
+
+			payload := fleet.CertificateAuthorityUpdatePayload{
+				NDESSCEPProxyCAUpdatePayload: &fleet.NDESSCEPProxyCAUpdatePayload{
+					Username: new(""),
+					Password: new("updated-password"),
+				},
+			}
+
+			err := svc.UpdateCertificateAuthority(ctx, ndesID, payload)
+			require.EqualError(t, err, "Couldn't edit certificate authority. Invalid NDES SCEP username. Please correct and try again.")
+		})
+
+		t.Run("Empty password", func(t *testing.T) {
+			svc, ctx := baseSetupForCATests()
+
+			payload := fleet.CertificateAuthorityUpdatePayload{
+				NDESSCEPProxyCAUpdatePayload: &fleet.NDESSCEPProxyCAUpdatePayload{
+					Password: new(""),
+				},
+			}
+
+			err := svc.UpdateCertificateAuthority(ctx, ndesID, payload)
+			require.EqualError(t, err, "Couldn't edit certificate authority. Invalid NDES SCEP password. Please correct and try again.")
+		})
+
 		t.Run("Bad admin URL generic error", func(t *testing.T) {
 			svc, ctx := baseSetupForCATests()
 

--- a/ee/server/service/scep/sceptest/sceptest.go
+++ b/ee/server/service/scep/sceptest/sceptest.go
@@ -17,6 +17,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"unicode/utf16"
@@ -110,15 +111,8 @@ func NewTestNDESAdminServer(t *testing.T, responseTemplate string, _ int) *httpt
 	}))
 	t.Cleanup(ndesAdminServer.Close)
 
-	// We need to convert the HTML page to UTF-16 encoding, which is used by Windows servers
 	convertHTML := func(html []byte) []byte {
-		datUTF16, err := UTF16FromString(string(html))
-		require.NoError(t, err)
-		byteData := make([]byte, len(datUTF16)*2)
-		for i, v := range datUTF16 {
-			binary.LittleEndian.PutUint16(byteData[i*2:], v)
-		}
-		return byteData
+		return utf16LEEncode(t, html)
 	}
 
 	switch responseTemplate {
@@ -141,6 +135,53 @@ func NewTestNDESAdminServer(t *testing.T, responseTemplate string, _ int) *httpt
 	}
 
 	return ndesAdminServer
+}
+
+// NewTestNDESAdminServerWithAuth creates an httptest.Server that emulates the NDES admin
+// page protected by HTTP Basic auth. Requests without an Authorization header receive a
+// Basic challenge (the NTLM negotiator probes without credentials first and retries with
+// them). Requests whose credentials fail checkCreds receive a plain 401. Authenticated
+// requests are counted in authenticated (when non-nil) and served the canned
+// mscep_admin_password page, UTF-16 LE-encoded the way Windows servers serve it.
+func NewTestNDESAdminServerWithAuth(t *testing.T, checkCreds func(username, password string) bool, authenticated *atomic.Int64) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate", `Basic realm=ndes`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		username, password, ok := r.BasicAuth()
+		if !ok || !checkCreds(username, password) {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if authenticated != nil {
+			authenticated.Add(1)
+		}
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write(utf16LEEncode(t, mscepAdminPassword)); err != nil {
+			t.Errorf("write NDES admin response: %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	return server
+}
+
+// utf16LEEncode converts an HTML page to UTF-16 LE encoding, which is used by Windows
+// servers.
+func utf16LEEncode(t *testing.T, html []byte) []byte {
+	t.Helper()
+
+	datUTF16, err := UTF16FromString(string(html))
+	require.NoError(t, err)
+	byteData := make([]byte, len(datUTF16)*2)
+	for i, v := range datUTF16 {
+		binary.LittleEndian.PutUint16(byteData[i*2:], v)
+	}
+	return byteData
 }
 
 // NewTestDynamicChallengeServer creates an httptest.Server that emulates a

--- a/frontend/__mocks__/certificatesMock.ts
+++ b/frontend/__mocks__/certificatesMock.ts
@@ -1,9 +1,11 @@
 import {
   ICertificateAuthorityPartial,
+  ICertificatesNDES,
   IHostCertificate,
 } from "interfaces/certificates";
 import { ICertificate } from "services/entities/certificates";
 import { IGetHostCertificatesResponse } from "services/entities/hosts";
+import { UNCHANGED_PASSWORD_API_RESPONSE } from "utilities/constants";
 
 const DEFAULT_HOST_CERTIFICATE_MOCK: IHostCertificate = {
   id: 1,
@@ -57,6 +59,22 @@ const DEFAULT_CERT_AUTHORITY_PARTIAL_MOCK: ICertificateAuthorityPartial = {
   id: 1,
   name: "Test CA",
   type: "digicert",
+};
+
+const DEFAULT_NDES_CERT_AUTHORITY_MOCK: ICertificatesNDES = {
+  id: 1,
+  type: "ndes_scep_proxy",
+  url: "https://ndes.example.com/certsrv/mscep/mscep.dll",
+  admin_url: "https://ndes.example.com/certsrv/mscep_admin/",
+  username: "ndes-username",
+  // the API returns the password masked
+  password: UNCHANGED_PASSWORD_API_RESPONSE,
+};
+
+export const createMockNDESCertAuthority = (
+  overrides?: Partial<ICertificatesNDES>
+): ICertificatesNDES => {
+  return { ...DEFAULT_NDES_CERT_AUTHORITY_MOCK, ...overrides };
 };
 
 export const createMockCertificateAuthorityPartial = (

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/helpers.tests.ts
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/helpers.tests.ts
@@ -18,6 +18,27 @@ describe("AddCertAuthorityModal helpers", () => {
       );
     });
 
+    it.each([
+      [
+        "Couldn't edit certificate authority. Invalid NDES SCEP admin URL. Please correct and try again.",
+        "Invalid admin URL. Please correct and try again.",
+      ],
+      [
+        "Couldn't edit certificate authority. Invalid NDES SCEP username. Please correct and try again.",
+        "Invalid username. Please correct and try again.",
+      ],
+      [
+        "Couldn't edit certificate authority. Invalid NDES SCEP password. Please correct and try again.",
+        "Invalid password. Please correct and try again.",
+      ],
+      [
+        "Couldn't edit certificate authority. Couldn't connect to NDES SCEP admin URL. Please correct and try again.",
+        "Couldn't connect to admin URL. Please correct and try again.",
+      ],
+    ])("returns a specific error for: %s", (reason, expected) => {
+      expect(getDisplayErrMessage(apiError(reason))).toBe(expected);
+    });
+
     it("returns the SCEP URL error", () => {
       expect(
         getDisplayErrMessage(

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/helpers.tests.ts
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/helpers.tests.ts
@@ -1,0 +1,61 @@
+import { getDisplayErrMessage } from "./helpers";
+
+/** Builds an API error in the shape getErrorReason reads. */
+const apiError = (reason: string) => ({
+  errors: [{ name: "base", reason }],
+});
+
+describe("AddCertAuthorityModal helpers", () => {
+  describe("getDisplayErrMessage", () => {
+    // The server names the CA type in the message ("Invalid NDES SCEP admin URL or
+    // credentials"), so the match can't assume the reason starts with "invalid admin URL".
+    it.each([
+      "Couldn't add certificate authority. Invalid NDES SCEP admin URL or credentials. Please correct and try again.",
+      "Couldn't edit certificate authority. Invalid NDES SCEP admin URL or credentials. Please correct and try again.",
+    ])("returns the credentials error for: %s", (reason) => {
+      expect(getDisplayErrMessage(apiError(reason))).toBe(
+        "Invalid admin URL or credentials. Please correct and try again."
+      );
+    });
+
+    it("returns the SCEP URL error", () => {
+      expect(
+        getDisplayErrMessage(
+          apiError(
+            "Couldn't edit certificate authority. Invalid SCEP URL. Please correct and try again."
+          )
+        )
+      ).toBe("Invalid SCEP URL. Please correct and try again.");
+    });
+
+    it("returns the password cache error", () => {
+      expect(
+        getDisplayErrMessage(
+          apiError(
+            "Couldn't edit certificate authority. The NDES password cache is full. Please increase the number of cached passwords in NDES and try again."
+          )
+        )
+      ).toBe(
+        "The NDES password cache is full. Please increase the number of cached passwords in NDES and try again."
+      );
+    });
+
+    it("returns the challenge URL error for Smallstep", () => {
+      expect(
+        getDisplayErrMessage(
+          apiError(
+            "Couldn't edit certificate authority. Invalid challenge URL or credentials. Please correct and try again."
+          )
+        )
+      ).toBe(
+        "Invalid challenge URL or credentials. Please correct and try again."
+      );
+    });
+
+    it("falls back to the default error for an unrecognized reason", () => {
+      expect(getDisplayErrMessage(apiError("something unexpected"))).toBe(
+        "Please try again."
+      );
+    });
+  });
+});

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/helpers.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/helpers.tsx
@@ -203,6 +203,14 @@ const INVALID_SCEP_URL_ERROR =
   "Invalid SCEP URL. Please correct and try again.";
 const INVALID_ADMIN_URL_OR_CREDENTIALS_ERROR =
   "Invalid admin URL or credentials. Please correct and try again.";
+const INVALID_ADMIN_URL_ERROR =
+  "Invalid admin URL. Please correct and try again.";
+const INVALID_USERNAME_ERROR =
+  "Invalid username. Please correct and try again.";
+const INVALID_PASSWORD_ERROR =
+  "Invalid password. Please correct and try again.";
+const ADMIN_URL_CONNECTION_ERROR =
+  "Couldn't connect to admin URL. Please correct and try again.";
 const NDES_PASSWORD_CACHE_FULL_ERROR =
   "The NDES password cache is full. Please increase the number of cached passwords in NDES and try again.";
 const INVALID_CHALLENGE_ERROR =
@@ -231,10 +239,19 @@ export const getDisplayErrMessage = (err: unknown): string | JSX.Element => {
     message = PRIVATE_KEY_NOT_CONFIGURED_ERROR;
   } else if (reason.includes("invalid scep url")) {
     message = INVALID_SCEP_URL_ERROR;
+  } else if (reason.includes("admin url or credentials")) {
     // the server names the CA type in this message, e.g. "Invalid NDES SCEP admin URL or
     // credentials", so match on the part that doesn't vary
-  } else if (reason.includes("admin url or credentials")) {
     message = INVALID_ADMIN_URL_OR_CREDENTIALS_ERROR;
+  } else if (reason.includes("invalid ndes scep admin url")) {
+    // must be checked after "admin url or credentials", which contains this string
+    message = INVALID_ADMIN_URL_ERROR;
+  } else if (reason.includes("invalid ndes scep username")) {
+    message = INVALID_USERNAME_ERROR;
+  } else if (reason.includes("invalid ndes scep password")) {
+    message = INVALID_PASSWORD_ERROR;
+  } else if (reason.includes("couldn't connect to ndes scep admin url")) {
+    message = ADMIN_URL_CONNECTION_ERROR;
   } else if (reason.includes("password cache is full")) {
     message = NDES_PASSWORD_CACHE_FULL_ERROR;
   } else if (reason.includes("invalid challenge url")) {

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/helpers.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/helpers.tsx
@@ -231,7 +231,9 @@ export const getDisplayErrMessage = (err: unknown): string | JSX.Element => {
     message = PRIVATE_KEY_NOT_CONFIGURED_ERROR;
   } else if (reason.includes("invalid scep url")) {
     message = INVALID_SCEP_URL_ERROR;
-  } else if (reason.includes("invalid admin url or credentials")) {
+    // the server names the CA type in this message, e.g. "Invalid NDES SCEP admin URL or
+    // credentials", so match on the part that doesn't vary
+  } else if (reason.includes("admin url or credentials")) {
     message = INVALID_ADMIN_URL_OR_CREDENTIALS_ERROR;
   } else if (reason.includes("password cache is full")) {
     message = NDES_PASSWORD_CACHE_FULL_ERROR;

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EditCertAuthorityModal/helpers.tests.ts
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EditCertAuthorityModal/helpers.tests.ts
@@ -1,18 +1,11 @@
-import { ICertificatesNDES } from "interfaces/certificates";
+import { createMockNDESCertAuthority } from "__mocks__/certificatesMock";
 import { UNCHANGED_PASSWORD_API_RESPONSE } from "utilities/constants";
 
 import { INDESFormData } from "../NDESForm/NDESForm";
 
 import { generateEditCertAuthorityData, updateFormData } from "./helpers";
 
-const ndesCertAuthority: ICertificatesNDES = {
-  id: 1,
-  type: "ndes_scep_proxy",
-  url: "https://ndes.example.com/certsrv/mscep/mscep.dll",
-  admin_url: "https://ndes.example.com/certsrv/mscep_admin/",
-  username: "ndes-username",
-  password: UNCHANGED_PASSWORD_API_RESPONSE,
-};
+const ndesCertAuthority = createMockNDESCertAuthority();
 
 const ndesFormData: INDESFormData = {
   scepURL: ndesCertAuthority.url,
@@ -58,7 +51,7 @@ describe("EditCertAuthorityModal helpers", () => {
 
       expect(
         generateEditCertAuthorityData(ndesCertAuthority, formData)
-      ).toStrictEqual({
+      ).toEqual({
         ndes_scep_proxy: {
           url: "https://new.example.com/certsrv/mscep/mscep.dll",
           password: "entered-password",
@@ -74,7 +67,7 @@ describe("EditCertAuthorityModal helpers", () => {
 
       expect(
         generateEditCertAuthorityData(ndesCertAuthority, formData)
-      ).toStrictEqual({
+      ).toEqual({
         ndes_scep_proxy: { password: "entered-password" },
       });
     });

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EditCertAuthorityModal/helpers.tests.ts
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EditCertAuthorityModal/helpers.tests.ts
@@ -1,0 +1,82 @@
+import { ICertificatesNDES } from "interfaces/certificates";
+import { UNCHANGED_PASSWORD_API_RESPONSE } from "utilities/constants";
+
+import { INDESFormData } from "../NDESForm/NDESForm";
+
+import { generateEditCertAuthorityData, updateFormData } from "./helpers";
+
+const ndesCertAuthority: ICertificatesNDES = {
+  id: 1,
+  type: "ndes_scep_proxy",
+  url: "https://ndes.example.com/certsrv/mscep/mscep.dll",
+  admin_url: "https://ndes.example.com/certsrv/mscep_admin/",
+  username: "ndes-username",
+  password: UNCHANGED_PASSWORD_API_RESPONSE,
+};
+
+const ndesFormData: INDESFormData = {
+  scepURL: ndesCertAuthority.url,
+  adminURL: ndesCertAuthority.admin_url,
+  username: ndesCertAuthority.username,
+  password: UNCHANGED_PASSWORD_API_RESPONSE,
+};
+
+describe("EditCertAuthorityModal helpers", () => {
+  describe("updateFormData", () => {
+    // The NDES credentials are validated together against the NDES server, so any change
+    // to a field they're validated with has to be sent with the password.
+    it.each(["scepURL", "adminURL", "username"])(
+      "clears the unchanged NDES password when %s changes",
+      (fieldName) => {
+        const newFormData = updateFormData(ndesCertAuthority, ndesFormData, {
+          name: fieldName,
+          value: "new value",
+        }) as INDESFormData;
+
+        expect(newFormData.password).toBe("");
+      }
+    );
+
+    it("keeps an already entered NDES password when the SCEP URL changes", () => {
+      const newFormData = updateFormData(
+        ndesCertAuthority,
+        { ...ndesFormData, password: "entered-password" },
+        { name: "scepURL", value: "https://new.example.com" }
+      ) as INDESFormData;
+
+      expect(newFormData.password).toBe("entered-password");
+    });
+  });
+
+  describe("generateEditCertAuthorityData", () => {
+    it("includes the password with an NDES SCEP URL change", () => {
+      const formData: INDESFormData = {
+        ...ndesFormData,
+        scepURL: "https://new.example.com/certsrv/mscep/mscep.dll",
+        password: "entered-password",
+      };
+
+      expect(
+        generateEditCertAuthorityData(ndesCertAuthority, formData)
+      ).toStrictEqual({
+        ndes_scep_proxy: {
+          url: "https://new.example.com/certsrv/mscep/mscep.dll",
+          password: "entered-password",
+        },
+      });
+    });
+
+    it("sends only the password when only the NDES password changes", () => {
+      const formData: INDESFormData = {
+        ...ndesFormData,
+        password: "entered-password",
+      };
+
+      expect(
+        generateEditCertAuthorityData(ndesCertAuthority, formData)
+      ).toStrictEqual({
+        ndes_scep_proxy: { password: "entered-password" },
+      });
+    });
+  });
+});

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EditCertAuthorityModal/helpers.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EditCertAuthorityModal/helpers.tsx
@@ -253,7 +253,11 @@ export const updateFormData = (
     }
     case "ndes_scep_proxy": {
       const formData = prevFormData as INDESFormData;
-      if (update.name === "adminURL" || update.name === "username") {
+      if (
+        update.name === "scepURL" ||
+        update.name === "adminURL" ||
+        update.name === "username"
+      ) {
         return {
           ...newData,
           password:

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/NDESForm/NDESForm.tests.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/NDESForm/NDESForm.tests.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { noop } from "lodash";
 import { render, screen } from "@testing-library/react";
 import { renderWithSetup } from "test/test-utils";
@@ -12,6 +12,24 @@ const createTestFormData = (overrides?: Partial<INDESFormData>) => ({
   password: "password123",
   ...overrides,
 });
+
+// NDESForm is controlled by its parent, so exercising input changes requires
+// a harness that applies them to the form data like the add/edit modals do.
+const ControlledNDESForm = () => {
+  const [formData, setFormData] = useState(createTestFormData());
+  return (
+    <NDESForm
+      formData={formData}
+      isSubmitting={false}
+      submitBtnText="Submit"
+      onChange={({ name, value }) =>
+        setFormData((prev) => ({ ...prev, [name]: value }))
+      }
+      onSubmit={noop}
+      onCancel={noop}
+    />
+  );
+};
 
 describe("NDESForm", () => {
   it("render the custom button text", () => {
@@ -30,22 +48,38 @@ describe("NDESForm", () => {
   });
 
   it("enables and disables form submission depending on the form validation", async () => {
-    const { user } = renderWithSetup(
-      <NDESForm
-        formData={createTestFormData()}
-        isSubmitting={false}
-        submitBtnText="Submit"
-        onChange={noop}
-        onSubmit={noop}
-        onCancel={noop}
-      />
-    );
+    const { user } = renderWithSetup(<ControlledNDESForm />);
 
     // data is valid, so submit should be enabled
     expect(screen.getByRole("button", { name: "Submit" })).toBeEnabled();
 
     // scepURL input is invalidated, submit should be disabled
     await user.clear(screen.getByLabelText("SCEP URL"));
+    expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
+  });
+
+  it("re-validates when the parent changes the form data outside of an input change", () => {
+    const formProps = {
+      isSubmitting: false,
+      submitBtnText: "Submit",
+      onChange: noop,
+      onSubmit: noop,
+      onCancel: noop,
+    };
+    const { rerender } = render(
+      <NDESForm formData={createTestFormData()} {...formProps} />
+    );
+
+    expect(screen.getByRole("button", { name: "Submit" })).toBeEnabled();
+
+    // the edit modal clears the password itself when another credential field
+    // changes; the form has to pick that up even though no input changed
+    rerender(
+      <NDESForm
+        formData={createTestFormData({ password: "" })}
+        {...formProps}
+      />
+    );
     expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
   });
 

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/NDESForm/NDESForm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/NDESForm/NDESForm.tsx
@@ -1,10 +1,10 @@
-import React, { useState } from "react";
+import React from "react";
 
 import InputField from "components/forms/fields/InputField";
 import Button from "components/buttons/Button";
 import TooltipWrapper from "components/TooltipWrapper";
 
-import { INDESFormValidation, validateFormData } from "./helpers";
+import { validateFormData } from "./helpers";
 
 export interface INDESFormData {
   scepURL: string;
@@ -32,22 +32,16 @@ const NDESForm = ({
   onSubmit,
   onCancel,
 }: INDESFormProps) => {
-  const [formValidation, setFormValidation] = useState<INDESFormValidation>(
-    () => validateFormData(formData)
-  );
+  // derived from the formData prop (not kept in state) because the parent can
+  // change fields this form didn't touch, e.g. the edit modal clears an
+  // unchanged password when the SCEP URL, admin URL, or username changes
+  const formValidation = validateFormData(formData);
 
   const { scepURL, adminURL, username, password } = formData;
 
   const onSubmitForm = (evt: React.FormEvent<HTMLFormElement>) => {
     evt.preventDefault();
     onSubmit();
-  };
-
-  const onInputChange = (update: { name: string; value: string }) => {
-    setFormValidation(
-      validateFormData({ ...formData, [update.name]: update.value })
-    );
-    onChange(update);
   };
 
   return (
@@ -57,7 +51,7 @@ const NDESForm = ({
         name="scepURL"
         value={scepURL}
         error={formValidation.scepURL?.message}
-        onChange={onInputChange}
+        onChange={onChange}
         parseTarget
         placeholder="https://example.com/certsrv/mscep/mscep.dll"
         helpText="The URL used by client devices to request and retrieve certificates."
@@ -67,7 +61,7 @@ const NDESForm = ({
         name="adminURL"
         value={adminURL}
         error={formValidation.adminURL?.message}
-        onChange={onInputChange}
+        onChange={onChange}
         parseTarget
         placeholder="https://example.com/certsrv/mscep_admin/"
         helpText={
@@ -82,7 +76,7 @@ const NDESForm = ({
         label="Username"
         name="username"
         value={username}
-        onChange={onInputChange}
+        onChange={onChange}
         parseTarget
         placeholder="username@example.microsoft.com"
         helpText="For NDES, this is the username in the down-level logon name
@@ -93,7 +87,7 @@ const NDESForm = ({
         name="password"
         value={password}
         type="password"
-        onChange={onInputChange}
+        onChange={onChange}
         parseTarget
         blockAutoComplete
         helpText={

--- a/server/service/integration_certificate_authorities_test.go
+++ b/server/service/integration_certificate_authorities_test.go
@@ -1573,32 +1573,20 @@ func (s *integrationMDMTestSuite) TestUpdateNDESCertificateAuthority() {
 	t := s.T()
 
 	const (
-		ndesUsername = "ndes-username"
-		ndesPassword = "ndes-password"
+		ndesUsername    = "ndes-username"
+		ndesPassword    = "ndes-password"
+		newNdesUsername = "new-ndes-username"
+		newNdesPassword = "new-ndes-password" //nolint:gosec // G101: test value, not a real credential
 	)
 
 	scepServer := sceptest.NewTestSCEPServer(t)
 
 	// an NDES admin server that only serves a challenge to the credentials above
 	var authenticatedRequests atomic.Int64
-	ndesAdminServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("Authorization") == "" {
-			// The NTLM negotiator probes without credentials first. Answering with a Basic
-			// challenge makes it retry with the configured username and password.
-			w.Header().Set("WWW-Authenticate", `Basic realm=ndes`)
-			w.WriteHeader(http.StatusUnauthorized)
-			return
-		}
-		authenticatedRequests.Add(1)
-		if username, password, ok := r.BasicAuth(); !ok || username != ndesUsername || password != ndesPassword {
-			w.WriteHeader(http.StatusUnauthorized)
-			return
-		}
-		w.WriteHeader(http.StatusOK)
-		// Fleet parses the challenge out of this exact HTML shape (see GetNDESSCEPChallenge).
-		_, _ = w.Write([]byte(`<HTML><BODY>The enrollment challenge password is: <B> ABC123XYZ </B></BODY></HTML>`))
-	}))
-	t.Cleanup(ndesAdminServer.Close)
+	ndesAdminServer := sceptest.NewTestNDESAdminServerWithAuth(t, func(username, password string) bool {
+		return (username == ndesUsername || username == newNdesUsername) &&
+			(password == ndesPassword || password == newNdesPassword)
+	}, &authenticatedRequests)
 
 	var createResp createCertificateAuthorityResponse
 	s.DoJSON("POST", "/api/latest/fleet/certificate_authorities", fleet.CertificateAuthorityPayload{
@@ -1644,15 +1632,65 @@ func (s *integrationMDMTestSuite) TestUpdateNDESCertificateAuthority() {
 		require.Contains(t, extractServerErrorText(res.Body), "Invalid NDES SCEP admin URL or credentials")
 	})
 
+	t.Run("unreachable admin URL is reported as a connection problem", func(t *testing.T) {
+		unreachableServer := httptest.NewServer(http.NotFoundHandler())
+		unreachableServer.Close() // closed on purpose so the port refuses connections
+
+		res := patchNDES(fleet.NDESSCEPProxyCAUpdatePayload{
+			AdminURL: new(unreachableServer.URL + "/mscep_admin/"),
+			Password: new(ndesPassword),
+		}, http.StatusBadRequest)
+		require.Contains(t, extractServerErrorText(res.Body), "Couldn't connect to NDES SCEP admin URL")
+	})
+
 	t.Run("password change with valid credentials is validated and saved", func(t *testing.T) {
 		before := authenticatedRequests.Load()
 
 		patchNDES(fleet.NDESSCEPProxyCAUpdatePayload{
-			Password: new(ndesPassword),
+			Password: new(newNdesPassword),
 		}, http.StatusOK)
 
 		// The update is only valid because Fleet asked the NDES server about it.
 		require.Greater(t, authenticatedRequests.Load(), before)
+	})
+
+	t.Run("unchanged credentials are saved without asking the NDES server", func(t *testing.T) {
+		before := authenticatedRequests.Load()
+
+		patchNDES(fleet.NDESSCEPProxyCAUpdatePayload{
+			Username: new(ndesUsername),
+			Password: new(newNdesPassword), // saved by the previous subtest
+		}, http.StatusOK)
+
+		require.Equal(t, before, authenticatedRequests.Load())
+	})
+
+	t.Run("username change with valid credentials is validated and saved", func(t *testing.T) {
+		before := authenticatedRequests.Load()
+
+		patchNDES(fleet.NDESSCEPProxyCAUpdatePayload{
+			Username: new(newNdesUsername),
+			Password: new(newNdesPassword),
+		}, http.StatusOK)
+
+		require.Greater(t, authenticatedRequests.Load(), before)
+		requireStoredUsername(newNdesUsername)
+	})
+
+	t.Run("masked password is rejected", func(t *testing.T) {
+		before := authenticatedRequests.Load()
+
+		// The GET endpoint returns the password masked. Changing NDES credentials requires
+		// re-supplying the actual password, so PATCHing the mask back is rejected before
+		// Fleet ever contacts the NDES server.
+		res := patchNDES(fleet.NDESSCEPProxyCAUpdatePayload{
+			Username: new("some-other-username"),
+			Password: new(fleet.MaskedPassword),
+		}, http.StatusBadRequest)
+		require.Contains(t, extractServerErrorText(res.Body), "Invalid NDES SCEP password")
+
+		require.Equal(t, before, authenticatedRequests.Load())
+		requireStoredUsername(newNdesUsername) // saved by the previous subtest
 	})
 }
 

--- a/server/service/integration_certificate_authorities_test.go
+++ b/server/service/integration_certificate_authorities_test.go
@@ -1566,6 +1566,96 @@ func (s *integrationMDMTestSuite) checkAppliedCAs(t *testing.T, ds fleet.Datasto
 	}
 }
 
+// TestUpdateNDESCertificateAuthority covers PATCH /certificate_authorities/{id} for the NDES
+// CA. The admin URL, username and password authenticate against NDES as a set, so a change to
+// any of them has to be validated against the NDES server, not just a change to the admin URL.
+func (s *integrationMDMTestSuite) TestUpdateNDESCertificateAuthority() {
+	t := s.T()
+
+	const (
+		ndesUsername = "ndes-username"
+		ndesPassword = "ndes-password"
+	)
+
+	scepServer := sceptest.NewTestSCEPServer(t)
+
+	// an NDES admin server that only serves a challenge to the credentials above
+	var authenticatedRequests atomic.Int64
+	ndesAdminServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			// The NTLM negotiator probes without credentials first. Answering with a Basic
+			// challenge makes it retry with the configured username and password.
+			w.Header().Set("WWW-Authenticate", `Basic realm=ndes`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		authenticatedRequests.Add(1)
+		if username, password, ok := r.BasicAuth(); !ok || username != ndesUsername || password != ndesPassword {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		// Fleet parses the challenge out of this exact HTML shape (see GetNDESSCEPChallenge).
+		_, _ = w.Write([]byte(`<HTML><BODY>The enrollment challenge password is: <B> ABC123XYZ </B></BODY></HTML>`))
+	}))
+	t.Cleanup(ndesAdminServer.Close)
+
+	var createResp createCertificateAuthorityResponse
+	s.DoJSON("POST", "/api/latest/fleet/certificate_authorities", fleet.CertificateAuthorityPayload{
+		NDESSCEPProxy: &fleet.NDESSCEPProxyCA{
+			URL:      scepServer.URL + "/scep",
+			AdminURL: ndesAdminServer.URL + "/mscep_admin/",
+			Username: ndesUsername,
+			Password: ndesPassword,
+		},
+	}, http.StatusOK, &createResp)
+	require.NotZero(t, createResp.ID)
+	caPath := fmt.Sprintf("/api/latest/fleet/certificate_authorities/%d", createResp.ID)
+
+	patchNDES := func(update fleet.NDESSCEPProxyCAUpdatePayload, expectedStatus int) *http.Response {
+		return s.Do("PATCH", caPath, fleet.CertificateAuthorityUpdatePayload{
+			NDESSCEPProxyCAUpdatePayload: &update,
+		}, expectedStatus)
+	}
+
+	requireStoredUsername := func(expected string) {
+		var getResp getCertificateAuthorityResponse
+		s.DoJSON("GET", caPath, getCertificateAuthorityRequest{}, http.StatusOK, &getResp)
+		require.NotNil(t, getResp.Username)
+		require.Equal(t, expected, *getResp.Username)
+	}
+
+	t.Run("username change with invalid credentials is rejected", func(t *testing.T) {
+		// The password has to accompany a username change, so this is the smallest payload
+		// the UI sends when only the username is edited.
+		res := patchNDES(fleet.NDESSCEPProxyCAUpdatePayload{
+			Username: new("wrong-username"),
+			Password: new(ndesPassword),
+		}, http.StatusBadRequest)
+		require.Contains(t, extractServerErrorText(res.Body), "Invalid NDES SCEP admin URL or credentials")
+
+		requireStoredUsername(ndesUsername)
+	})
+
+	t.Run("password change with invalid credentials is rejected", func(t *testing.T) {
+		res := patchNDES(fleet.NDESSCEPProxyCAUpdatePayload{
+			Password: new("wrong-password"),
+		}, http.StatusBadRequest)
+		require.Contains(t, extractServerErrorText(res.Body), "Invalid NDES SCEP admin URL or credentials")
+	})
+
+	t.Run("password change with valid credentials is validated and saved", func(t *testing.T) {
+		before := authenticatedRequests.Load()
+
+		patchNDES(fleet.NDESSCEPProxyCAUpdatePayload{
+			Password: new(ndesPassword),
+		}, http.StatusOK)
+
+		// The update is only valid because Fleet asked the NDES server about it.
+		require.Greater(t, authenticatedRequests.Load(), before)
+	})
+}
+
 func (s *integrationMDMTestSuite) TestSCEPChallengeExpirationRetriesSmallStep() {
 	t := s.T()
 	ctx := context.Background()


### PR DESCRIPTION
Resolves #50260

The live NDES credential probe was gated on the admin URL being part of the update payload. Because the UI sends only changed fields, editing just the username or password skipped validation entirely and saved a broken CA, which only surfaced later as a profile failure on hosts.

Gate the probe on any of the admin URL, username, or password changing, matching what the Smallstep validator already does, and reject empty usernames and passwords. On the frontend, clear the masked password when the SCEP URL changes so the update carries the password the backend requires.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation when updating NDES SCEP certificate authority credentials.
  * Empty administrator URL, username, or password fields now show specific errors.
  * Invalid or unreachable administrator connections are reported separately.
  * Unchanged credentials no longer trigger unnecessary server validation.
  * Failed credential updates no longer alter existing certificate authority settings.

* **Improvements**
  * Changing the SCEP URL, administrator URL, or username clears an unchanged masked password.
  * Entered passwords are preserved and submitted correctly.
  * NDES form validation now updates reliably when values change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->