### PR TITLE
Fix false positive CVEs for JetBrains teamcity-cli installed via Homebrew

### DIFF
--- a/changes/48691-teamcity-cli-false-positive
+++ b/changes/48691-teamcity-cli-false-positive
@@ -1,0 +1,1 @@
+- Fixed false positive vulnerabilities reported for JetBrains `teamcity-cli` installed via Homebrew, which was incorrectly matched to the TeamCity CI server's CPE.

--- a/server/vulnerabilities/nvd/cpe_test.go
+++ b/server/vulnerabilities/nvd/cpe_test.go
@@ -2070,6 +2070,17 @@ func TestCPEFromSoftwareIntegration(t *testing.T) {
 			},
 			cpe: "cpe:2.3:a:snyk:snyk_security:2.4.9:*:*:*:*:intellij:*:*",
 		},
+		{
+			// teamcity-cli installs as "teamcity" via the JetBrains Homebrew tap, but it is a
+			// separate product from the TeamCity CI server and has no CPE of its own, so it must
+			// not inherit the server's vulnerabilities.
+			software: fleet.Software{
+				Name:    "teamcity",
+				Source:  "homebrew_packages",
+				Version: "1.2.1",
+			},
+			cpe: "",
+		},
 	}
 
 	// NVD_TEST_CPEDB_PATH can be used to speed up development (sync cpe.sqlite only once).

--- a/server/vulnerabilities/nvd/cpe_translations.json
+++ b/server/vulnerabilities/nvd/cpe_translations.json
@@ -340,6 +340,15 @@
   },
   {
     "software": {
+      "name": ["teamcity"],
+      "source": ["homebrew_packages"]
+    },
+    "filter": {
+      "skip": true
+    }
+  },
+  {
+    "software": {
       "name": ["ms-python.python"],
       "source": ["vscode_extensions"]
     },


### PR DESCRIPTION
Relsoves #48691

teamcity-cli installs under the Cellar name "teamcity" (JetBrains tap), so the NVD CPE search matched it to jetbrains:teamcity — the TeamCity CI server. Since the CLI's semver (e.g. 1.2.1) sorts below every year-based server version range, it inherited ~230 of the server's CVEs.

No CPE exists for teamcity-cli upstream, so the correct result is no vulnerabilities reported. Add a skip rule in cpe_translations.json scoped to name "teamcity" + source "homebrew_packages".

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented Homebrew’s JetBrains TeamCity CLI package from being incorrectly matched to the TeamCity server.
  * Eliminated false-positive vulnerability reports for affected installations.
* **Tests**
  * Added coverage confirming the package does not inherit vulnerabilities associated with the TeamCity server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->