### PR TITLE
Patch when closed: default continuous automation off for Force patch

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeployModal/DeployModal.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeployModal/DeployModal.tests.tsx
@@ -105,7 +105,7 @@ describe("DeployModal", () => {
         patch_software_title_id: 10,
         software_title_id: 10,
         patch_when_closed: false,
-        continuous_automations_enabled: true,
+        continuous_automations_enabled: false,
       })
     );
   });
@@ -180,7 +180,7 @@ describe("DeployModal", () => {
         team_id: 1,
         software_title_id: 10,
         patch_when_closed: false,
-        continuous_automations_enabled: true,
+        continuous_automations_enabled: false,
       })
     );
   });
@@ -216,7 +216,7 @@ describe("DeployModal", () => {
     );
   });
 
-  it("enables continuous automation when saving a migrated Force patch policy", async () => {
+  it("turns continuous automation off when saving a Force patch policy that has it on", async () => {
     const { user } = renderModal({
       softwarePackage: createMockSoftwarePackage({
         fleet_maintained_app_id: 1,
@@ -224,7 +224,7 @@ describe("DeployModal", () => {
           id: 22,
           name: "Firefox up to date",
           patch_when_closed: false,
-          continuous_automations_enabled: false,
+          continuous_automations_enabled: true,
         },
         automatic_install_policies: [
           { id: 22, name: "Firefox up to date", type: "patch" },
@@ -240,7 +240,7 @@ describe("DeployModal", () => {
         team_id: 1,
         software_title_id: 10,
         patch_when_closed: false,
-        continuous_automations_enabled: true,
+        continuous_automations_enabled: false,
       })
     );
   });

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareDeploySelector/SoftwareDeploySelector.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareDeploySelector/SoftwareDeploySelector.tsx
@@ -10,7 +10,7 @@ export type PatchOption = "closed" | "force" | "manual";
 
 export const getPatchPolicyFlags = (patchOption: PatchOption) => ({
   patch_when_closed: patchOption === "closed",
-  continuous_automations_enabled: patchOption !== "manual",
+  continuous_automations_enabled: patchOption === "closed",
 });
 
 interface ISoftwareDeploySelectorProps {

--- a/frontend/pages/policies/components/PolicyAutomationsFields/PolicyAutomationsFields.tests.tsx
+++ b/frontend/pages/policies/components/PolicyAutomationsFields/PolicyAutomationsFields.tests.tsx
@@ -366,7 +366,7 @@ describe("PolicyAutomationsFields — payload", () => {
     });
   });
 
-  it("maps Force patch to patch_when_closed false and continuous automation true", () => {
+  it("maps Force patch to patch_when_closed false and continuous automation off", () => {
     const handleRef: React.MutableRefObject<IPolicyAutomationsFieldsHandle | null> = {
       current: null,
     };
@@ -381,12 +381,18 @@ describe("PolicyAutomationsFields — payload", () => {
       { patchOption: "force" }
     );
 
+    // Switching a stored Patch when app is closed policy to Force patch clears
+    // continuous automation instead of carrying the stored value over.
+    expect(
+      screen.getByRole("checkbox", { name: "continuous-automations-enabled" })
+    ).toHaveAttribute("aria-checked", "false");
+
     expect(
       handleRef.current?.getAutomationsPayload().policyUpdate
     ).toMatchObject({
       software_title_id: 42,
       patch_when_closed: false,
-      continuous_automations_enabled: true,
+      continuous_automations_enabled: false,
     });
   });
 
@@ -450,22 +456,39 @@ describe("PolicyAutomationsFields — payload", () => {
   });
 
   it("keeps continuous automation editable for Force patch", async () => {
-    const onPatchOptionChange = jest.fn();
     const { user } = renderWithHandle(
       {
         type: "patch",
         patch_when_closed: false,
-        continuous_automations_enabled: true,
+        continuous_automations_enabled: false,
       },
       undefined,
-      { patchOption: "force", onPatchOptionChange }
+      { patchOption: "force" }
     );
 
     const continuous = screen.getByRole("checkbox", {
       name: "continuous-automations-enabled",
     });
     expect(continuous).toHaveAttribute("aria-disabled", "false");
+    expect(continuous).toHaveAttribute("aria-checked", "false");
+
     await user.click(continuous);
-    expect(onPatchOptionChange).toHaveBeenCalledWith("manual");
+    expect(continuous).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("does not clear continuous automation already stored on a Force patch policy", () => {
+    renderWithHandle(
+      {
+        type: "patch",
+        patch_when_closed: false,
+        continuous_automations_enabled: true,
+      },
+      undefined,
+      { patchOption: "force" }
+    );
+
+    expect(
+      screen.getByRole("checkbox", { name: "continuous-automations-enabled" })
+    ).toHaveAttribute("aria-checked", "true");
   });
 });

--- a/frontend/pages/policies/components/PolicyAutomationsFields/PolicyAutomationsFields.tsx
+++ b/frontend/pages/policies/components/PolicyAutomationsFields/PolicyAutomationsFields.tsx
@@ -88,7 +88,6 @@ interface IPolicyAutomationsFieldsProps {
   fleetName: string;
   /** Present only for patch policies on Premium. */
   patchOption?: PatchOption;
-  onPatchOptionChange?: (patchOption: PatchOption) => void;
   /** Rendered between the automation types and the continuous-automation
    *  checkbox — the edit-policy Patch radios (owned by PolicyForm). */
   patchSlot?: React.ReactNode;
@@ -107,7 +106,6 @@ const PolicyAutomationsFields = forwardRef<
       globalConfig,
       fleetName,
       patchOption,
-      onPatchOptionChange,
       patchSlot,
     },
     ref
@@ -171,7 +169,7 @@ const PolicyAutomationsFields = forwardRef<
       initialConditionalAccess
     );
     const [continuousEnabled, setContinuousEnabled] = useState(
-      initialContinuous
+      initialPatchWhenClosed ? false : initialContinuous
     );
     const patchWhenClosed = patchOption
       ? patchOption === "closed"
@@ -179,8 +177,8 @@ const PolicyAutomationsFields = forwardRef<
     let effectiveContinuousEnabled = continuousEnabled;
     if (patchWhenClosed) {
       effectiveContinuousEnabled = true;
-    } else if (patchOption) {
-      effectiveContinuousEnabled = patchOption === "force";
+    } else if (patchOption === "manual") {
+      effectiveContinuousEnabled = false;
     }
 
     const [softwareTitleId, setSoftwareTitleId] = useState<number | null>(
@@ -272,9 +270,6 @@ const PolicyAutomationsFields = forwardRef<
     };
     const handleToggleContinuous = (next: boolean) => {
       setContinuousEnabled(next);
-      if (patchOption) {
-        onPatchOptionChange?.(next ? "force" : "manual");
-      }
     };
 
     const canFetchTeamScopedLists =

--- a/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tests.tsx
+++ b/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tests.tsx
@@ -938,7 +938,7 @@ describe("PolicyForm - component", () => {
             team_id: 1,
             software_title_id: 42,
             patch_when_closed: false,
-            continuous_automations_enabled: true,
+            continuous_automations_enabled: false,
           })
         );
         expect(onUpdate).toHaveBeenCalledTimes(1);

--- a/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tsx
@@ -767,7 +767,6 @@ const PolicyForm = ({
                 patchOption={
                   isPremiumTier && isPatchPolicy ? patchOption : undefined
                 }
-                onPatchOptionChange={setPatchOption}
                 patchSlot={patchOptions}
               />
             </div>


### PR DESCRIPTION
- Sets continuous automations to off by default in the Deploy modal and Edit policy page 

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Continuous automation settings now behave consistently when creating or editing Force patch policies.
  - Manual patching disables continuous automation, while closed patching enables it.
  - Other patch selections preserve the current automation setting.
  - Saving existing policies now correctly retains the configured automation state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->