### PR TITLE
Add route for manual sync guide

### DIFF
--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -1380,7 +1380,7 @@ module.exports.routes = {
   'GET /learn-more-about/security-posture': 'https://developers.google.com/android/management/reference/rest/v1/enterprises.devices#DevicePosture',
   'GET /learn-more-about/software-update-status': 'https://developers.google.com/android/management/reference/rest/v1/enterprises.devices#SystemUpdateInfo',
   'GET /learn-more-about/removal-behavior': '/guides/custom-os-settings#removal-behavior',
-
+  'GET /learn-more-about/android-manual-sync': '/guides/how-to-manually-sync-an-android-device',
 
   // Sitemap
   // =============================================================================================================


### PR DESCRIPTION
**Related issue:** #50001


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a redirect from the Android manual sync learn-more page to the updated setup guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->