### PR TITLE
Unfreeze XnConvert (macOS)

### DIFF
--- a/ee/maintained-apps/inputs/homebrew/xnconvert.json
+++ b/ee/maintained-apps/inputs/homebrew/xnconvert.json
@@ -6,6 +6,5 @@
   "slug": "xnconvert/darwin",
   "default_categories": [
     "Productivity"
-  ],
-  "frozen": true
+  ]
 }

--- a/ee/maintained-apps/outputs/xnconvert/darwin.json
+++ b/ee/maintained-apps/outputs/xnconvert/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.112.0",
+      "version": "1.115.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.xnview.XnConvert';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.xnview.XnConvert' AND version_compare(bundle_short_version, '1.112.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.xnview.XnConvert' AND version_compare(bundle_short_version, '1.115.0') < 0);"
       },
-      "installer_url": "https://download.xnview.com/old_versions/XnConvert/XnConvert-1.112.0-mac.dmg",
+      "installer_url": "https://download.xnview.com/old_versions/XnConvert/XnConvert-1.115.0-mac.dmg",
       "install_script_ref": "c0e41d46",
       "uninstall_script_ref": "adec59f6",
-      "sha256": "7f9211670fe6af7705bdb4f93df73d0158d5436a29e70101108c6bfc84e09cb3",
+      "sha256": "47e7ae5822fc16335e842420e51805310d797aba694a333df2828982d211ee96",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated unfreeze probe. Removes `"frozen": true` and regenerates the output manifest so
test-fma-macos-pr-only can validate `xnconvert/darwin` at its current upstream version.

Frozen since: not recoverable from this checkout (squashed/shallow history — every input file is attributed to the same import commit)
Version: 1.112.0 -> 1.115.0

Draft until validation reports. Merge only if the FMA checks are green and the validate shard
actually ran for this slug.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hx5UA4Dhqh2UUCX8h6k6Vv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the XnConvert macOS package to version 1.115.0.
  * Refreshed the installer download information and checksum for the new release.
  * Removed the restriction that prevented automatic updates for XnConvert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->