### PR TITLE
OpenSpec for Windows Graph #43481

### DIFF
--- a/openspec/changes/windows-autopilot-pending-hosts/design.md
+++ b/openspec/changes/windows-autopilot-pending-hosts/design.md
@@ -33,9 +33,35 @@ controls:
       client_secret: $WINDOWS_ENTRA_CLIENT_SECRET_ACME
 ```
 
-API surface is `mdm.microsoft_graph_credentials` on `GET`/`PATCH /config`. The `$VAR` is ordinary GitOps environment interpolation
-(`ExpandEnv`, `pkg/spec/spec.go:301`), deliberately not a `$FLEET_SECRET_*` variable, since those are host-delivery variables and this value
-never leaves the server.
+The `$VAR` is ordinary GitOps environment interpolation (`ExpandEnv`, `pkg/spec/spec.go:301`), deliberately not a `$FLEET_SECRET_*`
+variable, since those are host-delivery variables and this value never leaves the server.
+
+### API surface is a dedicated resource, not a config field
+
+**[revised during implementation]** An earlier draft put the credential on `mdm.microsoft_graph_credentials` in `GET`/`PATCH /config`. It
+was built that way and then moved, because the config field cannot carry it cleanly:
+
+- The client secret is encrypted at rest, so it can never live in the `app_config_json` blob. The field therefore had to be hydrated from
+  the credentials table on **every** config read, which then needed a `cached_mysql` entry to pay for it, which then needed the sync cron to
+  invalidate that entry. All of that machinery existed only to make the field's location work.
+- No comparable feature does this. ABM, VPP, and certificate authorities all keep the credential **and** its per-instance status behind their
+  own endpoints; `grep CertificateAuthorities server/fleet/app.go` returns zero. What AppConfig carries for ABM and VPP is *assignment* data
+  (org name to fleet, location to fleets) with no runtime status, and that data lives in the blob, so it needs no hydration.
+- GitOps does not require an AppConfig field. `org_settings.certificate_authorities` is fully GitOps-managed and is applied through its own
+  endpoint, so the YAML contract is independent of where the data lives.
+
+| | |
+|---|---|
+| `GET /api/v1/fleet/microsoft_graph_credentials` | list credentials with per-tenant sync status; `client_secret` masked |
+| `PUT /api/v1/fleet/microsoft_graph_credentials` | declarative reconcile; accepts `dry_run` |
+
+`PUT` is declarative: a tenant absent from the body is deleted, and an empty list clears everything. There is no `DELETE`. Both endpoints
+authorize against `&fleet.AppConfig{}`, so the credential keeps exactly the permissions it had as a config field.
+
+The GitOps key stays `controls.microsoft_graph_credentials`. `DoGitOps` lifts it out of controls, decodes it, and `ApplyGroup` sends it to
+the endpoint, following `certificate_authorities`. The decode helper is deliberately **not** named `...Spec`: "spec" means `fleetctl apply`
+in this codebase, which was additive and could not remove, and this is the opposite. `fleetctl apply` does not manage this key at all, and
+the field on `spec.Group` is a pointer precisely so that an apply of a partial file leaves it nil and cannot delete a working credential.
 
 ### One credential per tenant
 
@@ -68,20 +94,29 @@ already been through this transition twice: `MDMAssetABMTokenDeprecated` (`serve
 Follow `abm_tokens` / `vpp_tokens` instead: a dedicated table with an encrypted secret column keyed on the external identity.
 
 ```sql
-CREATE TABLE `microsoft_graph_credentials` (
+CREATE TABLE `mdm_microsoft_graph_credentials` (
   `id`             int unsigned NOT NULL AUTO_INCREMENT,
   `tenant_id`      varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   `client_id`      varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   `client_secret`  blob NOT NULL,             -- encrypted with the server private key, as abm_tokens.token
-  `credential_invalid` tinyint(1) NOT NULL DEFAULT '0',   -- drives the app-wide banner, as abm_tokens.token_invalid
-  `last_synced_at` timestamp NULL DEFAULT NULL,
+  `credential_invalid` tinyint(1) NOT NULL DEFAULT '0',   -- feeds the app-wide banner, as abm_tokens.token_invalid
+  `last_synced_at` datetime(6) NULL DEFAULT NULL,
   `last_sync_error` text COLLATE utf8mb4_unicode_ci,
-  `created_at`     timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `updated_at`     timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `created_at`     datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at`     datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
   PRIMARY KEY (`id`),
-  UNIQUE KEY `idx_microsoft_graph_credentials_tenant_id` (`tenant_id`)
+  UNIQUE KEY `idx_mdm_microsoft_graph_credentials_tenant_id` (`tenant_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 ```
+
+The `mdm_` prefix matches `mdm_apple_*`: that slot holds a vendor name, and there is no product called "Windows Graph". Timestamps are
+`datetime(6)` throughout rather than `timestamp`.
+
+**Storing a credential resets all of its sync state** (`credential_invalid = 0`, `last_sync_error = NULL`, `last_synced_at = NULL`). The
+service verifies before it stores and skips the write entirely when nothing changed, so reaching the upsert means the credential was just
+proven good. Carrying the old state over would keep the banner up and display "client secret expired" beside the secret that just replaced
+the expired one. Clearing `last_synced_at` too means a rotated credential reads as "never synced" until the next cycle, which is accurate:
+the previous sync described a different credential.
 
 ### Validation, masking, premium
 
@@ -92,8 +127,9 @@ config-adjacent secret:
 - Premium gate: reject writes with `ErrMissingLicense` when not premium, alongside the existing `windows_entra_*` gates
   (`server/service/appconfig.go:2033-2038`).
 - Require `server.PrivateKey` to be configured when a new secret is supplied, matching `appconfig.go:831`.
-- Mask on read: extend `AppConfig.Obfuscate()` (`server/fleet/app.go:867`) to replace each entry's `client_secret` with
-  `fleet.MaskedPassword`. On write, an incoming value equal to the mask preserves the stored secret.
+- Mask on read: the list endpoint replaces each entry's `client_secret` with `fleet.MaskedPassword`. The read path uses a metadata query
+  that never decrypts, so a missing or rotated server private key cannot fail it. On write, an incoming value equal to the mask (or an
+  omitted secret) preserves the stored secret.
 - On a new or changed credential, call `VerifyCredential` (one token mint plus one page) and return `NewInvalidArgumentError` on failure,
   matching how Jira/Zendesk credentials are validated on config write.
 - Activities `added_`/`edited_`/`deleted_microsoft_graph_credential`, written through the activity service, never `ds.NewActivity` directly.
@@ -125,10 +161,20 @@ Requirements:
 
 1. Deduplicate by the Autopilot `id` while paging. `id` is the registration's own identifier and is distinct from
    `azureActiveDirectoryDeviceId`.
-2. Carry an explicit loop guard: stop when `nextLink` equals the URL just requested, when a page yields no previously unseen `id`, or on a
-   hard page cap. Log when a guard fires.
-3. Do not set a small `$top`. Use the service default.
-4. Never assume serial ordering or uniqueness anywhere in reconciliation.
+2. Carry an explicit loop guard for each observed failure: a `nextLink` equal to the URL just requested, a page that yields no previously
+   unseen `id`, and a hard page cap as a backstop.
+3. **[revised during implementation] A non-advancing cursor returns an error, it does not stop gracefully.** An earlier draft said "stop".
+   That is wrong, and dangerously so: stopping quietly hands the sync a silently truncated list, and the sync deletes the hosts that are
+   missing from what it is given. A tenant that trips the guard would lose pending hosts with no error anywhere. Failing the walk leaves the
+   existing hosts untouched, which is the safe direction. The sync must therefore not swallow this error or fall back to a partial list.
+4. **[revised during implementation] Pin `$top=1000` rather than using the service default.** An earlier draft said not to set `$top` at all.
+   Pinning it makes the round-trip count a property of Fleet's code instead of an undocumented service default Microsoft can change: at 1000
+   per page, a 100k-device tenant is ~101 requests, roughly 30-60s and ~25MB. The original concern was that a *small* `$top` aggravates the
+   inclusive-cursor duplication, which remains true.
+5. Never assume serial ordering or uniqueness anywhere in reconciliation.
+6. **[added during implementation] Validate that `@odata.nextLink` stays on the Graph origin.** The oauth2 transport attaches the bearer
+   token to whatever URL is requested, so a malformed or hostile next link is a token-exfiltration vector. This was not in the original
+   design and is not hypothetical hardening: the client follows a URL chosen by the remote service.
 
 ### Response shape
 
@@ -172,7 +218,7 @@ The precedent is exact and should be mirrored rather than reinvented:
 | `abm_tokens.token_invalid` (migration `20260721090128`) | `microsoft_graph_credentials.credential_invalid` |
 | `SetABMTokenInvalidForOrgName` / `IsABMTokenInvalidForOrgName` (`apple_mdm.go:6608`, `:6627`) | same pair keyed on `tenant_id` |
 | `ABMToken.TokenInvalid` json `token_invalid` (`server/fleet/mdm.go:200`) | `credential_invalid` on the credential response |
-| `hasInvalidABMToken` computed in `App.tsx:150` | same shape for the Graph credential |
+| `hasInvalidABMToken` computed in `App.tsx:150` | **not needed**: the server aggregates it into `mdm.microsoft_graph_credential_invalid` |
 | `<AppleBMTokenInvalidMessage orgNames={...} />` in the `MainContent.tsx` priority chain | new banner component in the same chain |
 
 `MainContent.tsx:59-83` shows exactly one banner at a time in a fixed priority order, and every banner except the APNs one sits inside the
@@ -180,8 +226,22 @@ The precedent is exact and should be mirrored rather than reinvented:
 placing it after the VPP banner and before the license-expiry banner is the natural default, since it is narrower in blast radius than the
 Apple MDM banners above it.
 
-The flag is set by the sync, not at config-write time. A credential is verified on write (see section 1), so it is valid when stored; it goes
-bad later through expiry, revocation, or a permission change. Set `credential_invalid = 1` on an authentication or authorization failure
+**[revised during implementation] The banner reads one stored boolean on the app config, not a computed scan of the credential list.**
+`mdm.microsoft_graph_credential_invalid` is a server-computed aggregate: true as soon as any tenant's credential is unhealthy, false once all
+are healthy. It lives on the app config because the banner is app-wide and the frontend already loads the config on every page, whereas the
+credentials endpoint is not on that path. It mirrors `AppleBMTermsExpired`, including the PATCH carry-over that makes it unsettable by a
+client.
+
+It is **stored** rather than derived on read, specifically so `GET /config` never joins the credentials table. The consequence is that it is
+only as fresh as its last recomputation, so **every path that can change a credential's health must recompute it**: the credential write
+paths do so directly, and the sync must do so after marking a credential invalid or clearing it. Miss that call and the table is correct, the
+credentials endpoint is correct, and the banner simply never appears — nothing errors. This is the one cross-subtask contract in the change.
+
+Only `credential_invalid` feeds the aggregate, never `last_sync_error`, for the same outage reason given below.
+
+The flag is set by the sync, not at write time. A credential is verified before it is stored (see section 1), so it is valid when saved; it
+goes bad later through expiry, revocation, or a permission change. Two consequences worth stating: saving a working credential clears the
+banner with no explicit dismiss affordance, and the banner can lag a real failure by up to one sync interval (default 5 minutes). Set `credential_invalid = 1` on an authentication or authorization failure
 (token-endpoint `AADSTS*` errors, Graph 401, Graph 403) and clear it on the next successful sync. Do **not** set it for transient 429 or 5xx,
 or a Microsoft outage would raise a credential alarm across every deployment.
 
@@ -234,7 +294,8 @@ New datastore method `IngestWindowsAutopilotDevices`, modeled on `IngestMDMApple
   instead.
 - "All Hosts" and "MS Windows" builtin label membership, so the host appears in host lists before osquery ever runs. Mirror
   `upsertMDMAppleHostLabelMembershipDB` (`apple_mdm.go:2120`), which looks labels up by name and tolerates their absence.
-- `host_autopilot_devices` row carrying the group tag, Autopilot `id`, AAD device ID, serial, and tenant.
+- `host_autopilot_devices` row carrying the group tag, Autopilot `id`, `entra_device_id`, serial, and tenant, written through
+  `BatchUpsertHostAutopilotDevices`.
 
 ### Removal
 
@@ -306,7 +367,7 @@ Consequences:
 - This retroactively strengthens the "separate table, not a column on `hosts`" decision. An 8 KB-capable column on Fleet's hottest table
   would be a genuine cost; in `host_autopilot_devices` it is not.
 
-`host_autopilot_devices` gains the Autopilot `id` alongside the AAD device ID, and reconciliation keys on `id`, which is stable for the life
+`host_autopilot_devices` gains the Autopilot `id` alongside `entra_device_id`, and reconciliation keys on `id`, which is stable for the life
 of the registration and unique, unlike the serial.
 
 Expose `group_tag` on both `GET /hosts` (list) and `GET /hosts/:id` (detail) via

--- a/openspec/changes/windows-autopilot-pending-hosts/design.md
+++ b/openspec/changes/windows-autopilot-pending-hosts/design.md
@@ -1,0 +1,272 @@
+# Design: Windows Autopilot pending hosts
+
+All Microsoft Graph behavior below was verified live against a real Entra tenant with five registered Autopilot devices on 2026-08-06.
+Findings marked **[verified]** were observed directly; findings marked **[inferred]** follow from an observed mechanism but were not
+reproduced.
+
+## 1. Credential model
+
+### Why not reuse `windows_entra_tenant_ids` / `windows_entra_client_ids`
+
+These are **inbound authorization allowlists**. At enrollment, Fleet validates the Entra JWT the device presents:
+`hasAuthorizedAzureTenant` (`server/service/microsoft_mdm.go:950`) matches the `tid` claim against the tenant list, and
+`hasAuthorizedAzureAudience` (`:921`) matches `aud` against the client ID list. They answer "who may enroll into me".
+
+The Graph sync runs the opposite direction: Fleet authenticating *as* one app *in* one tenant. The lists are unordered, not index-aligned
+with each other, and a single tenant may legitimately hold several allowlisted client IDs (cutover between app registrations, v1/v2 token
+transition). There is no unambiguous pair to read. Unifying them would also be a breaking change to two shipped fields that already have UI,
+GitOps, and activities.
+
+They also need not overlap. Under least privilege the customer registers a Graph-only app holding just
+`DeviceManagementServiceConfig.Read.All`, and that client ID must **not** be added to the enrollment allowlist, since it never issues an
+enrollment token.
+
+### Config shape
+
+```yaml
+controls:
+  windows_entra_tenant_ids: [...]      # unchanged, inbound
+  windows_entra_client_ids: [...]      # unchanged, inbound
+  microsoft_graph_credentials:         # new, outbound
+    - tenant_id: 5b1fc5b6-9502-4cf9-90cf-d0b656eaf7a4
+      client_id: 7f6b1665-51f5-48de-a9b6-ac17539583fb
+      client_secret: $WINDOWS_ENTRA_CLIENT_SECRET_ACME
+```
+
+API surface is `mdm.microsoft_graph_credentials` on `GET`/`PATCH /config`. The `$VAR` is ordinary GitOps environment interpolation
+(`ExpandEnv`, `pkg/spec/spec.go:301`), deliberately not a `$FLEET_SECRET_*` variable, since those are host-delivery variables and this value
+never leaves the server.
+
+### One credential per tenant
+
+**[verified]** Two different app registrations in the same tenant returned byte-identical device payloads. The Autopilot registry is scoped
+to the tenant, not the app, so a second credential for the same tenant reads the same data. Enforce `UNIQUE (tenant_id)` in the schema and
+reject a duplicate `tenant_id` in the incoming list with a 422.
+
+A duplicate would not create duplicate hosts (reconciliation is keyed on tenant plus device), but it doubles Graph calls against Microsoft's
+throttling limits and makes failure reporting incoherent: one revoked secret would surface errors for a tenant that is otherwise syncing.
+
+### Storage
+
+Do **not** use `mdm_config_assets`. It is keyed `UNIQUE (name, deletion_uuid)` and structurally holds one row per credential name. Fleet has
+already been through this transition twice: `MDMAssetABMTokenDeprecated` (`server/fleet/mdm.go:1044`) and `MDMAssetVPPTokenDeprecated`
+(`:1053`) are the residue of ABM and VPP tokens moving out to dedicated tables when they went multi-instance.
+
+Follow `abm_tokens` / `vpp_tokens` instead: a dedicated table with an encrypted secret column keyed on the external identity.
+
+```sql
+CREATE TABLE `microsoft_graph_credentials` (
+  `id`             int unsigned NOT NULL AUTO_INCREMENT,
+  `tenant_id`      varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `client_id`      varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `client_secret`  blob NOT NULL,             -- encrypted with the server private key, as abm_tokens.token
+  `last_synced_at` timestamp NULL DEFAULT NULL,
+  `last_sync_error` text COLLATE utf8mb4_unicode_ci,
+  `created_at`     timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at`     timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_microsoft_graph_credentials_tenant_id` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+```
+
+### Validation, masking, premium
+
+Mirror `apple_account_provisioning` (`server/service/appconfig.go:499-548`, `:801-854`), which is the closest and most recent precedent for a
+config-adjacent secret:
+
+- `tenant_id` and `client_id` must be GUIDs. Reuse `windowsEntraGUIDRegex` from `server/service/microsoft_mdm.go`.
+- Premium gate: reject writes with `ErrMissingLicense` when not premium, alongside the existing `windows_entra_*` gates
+  (`server/service/appconfig.go:2033-2038`).
+- Require `server.PrivateKey` to be configured when a new secret is supplied, matching `appconfig.go:831`.
+- Mask on read: extend `AppConfig.Obfuscate()` (`server/fleet/app.go:867`) to replace each entry's `client_secret` with
+  `fleet.MaskedPassword`. On write, an incoming value equal to the mask preserves the stored secret.
+- On a new or changed credential, call `VerifyCredential` (one token mint plus one page) and return `NewInvalidArgumentError` on failure,
+  matching how Jira/Zendesk credentials are validated on config write.
+- Activities `added_`/`edited_`/`deleted_microsoft_graph_credential`, written through the activity service, never `ds.NewActivity` directly.
+
+## 2. Microsoft Graph client
+
+New package `server/microsoft/msgraph`. Uses `golang.org/x/oauth2/clientcredentials` (`golang.org/x/oauth2 v0.36.0` is already in `go.mod`;
+this is its first use in the tree). Token URL `https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token`, scope
+`https://graph.microsoft.com/.default`. Transport via `fleethttp`, never a bare `http.Client`. Errors wrapped with `ctxerr`.
+
+Expose a factory taking a credential and returning a `Client`, mirroring `GoogleWorkspaceDirectoryFactory`
+(`server/cron/google_workspace_cron.go:28`), so the cron does not import the concrete client and tests can inject a fake.
+
+### Pagination is hazardous and must not be implemented naively
+
+`GET /v1.0/deviceManagement/windowsAutopilotDeviceIdentities` paginates with `$skiptoken=LastSerialNumber='<serial>'`, an **inclusive**
+cursor ordered by serial number.
+
+- **[verified]** At `$top=2`, following `@odata.nextLink` returned **7 rows for 5 devices**. The boundary device is repeated on the next
+  page.
+- **[verified]** At `$top=1`, the returned `@odata.nextLink` is **byte-identical to the URL just requested**. A loop that follows `nextLink`
+  until it is absent never terminates.
+- **[inferred]** Because the cursor is a serial and serials are not unique, a run of devices sharing one serial that meets or exceeds the
+  page size prevents the cursor from advancing, producing the same loop at any page size. This is not exotic: the test tenant contains a
+  device with serial `Default string`, which is a real GMKtec M5 PLUS mini-PC, not a VM, and Fleet already classifies that string as junk in
+  `placeholderHardwareSerials` (`server/fleet/hosts.go:67`).
+
+Requirements:
+
+1. Deduplicate by the Autopilot `id` while paging. `id` is the registration's own identifier and is distinct from
+   `azureActiveDirectoryDeviceId`.
+2. Carry an explicit loop guard: stop when `nextLink` equals the URL just requested, when a page yields no previously unseen `id`, or on a
+   hard page cap. Log when a guard fires.
+3. Do not set a small `$top`. Use the service default.
+4. Never assume serial ordering or uniqueness anywhere in reconciliation.
+
+### Response shape
+
+Fields present on every record **[verified]**: `id`, `groupTag`, `serialNumber`, `azureActiveDirectoryDeviceId`, `managedDeviceId`,
+`enrollmentState`, `manufacturer`, `model`, `systemFamily`, `skuNumber`, `productKey`, `purchaseOrderIdentifier`, `displayName`,
+`addressableUserName`, `userPrincipalName`, `resourceName`, `lastContactedDateTime`.
+
+Fleet consumes `id`, `serialNumber`, `groupTag`, `azureActiveDirectoryDeviceId`. Notes:
+
+- `managedDeviceId` uses the all-zeros GUID `00000000-0000-0000-0000-000000000000` as its "none" sentinel, not null.
+- `enrollmentState` reflects *Intune* enrollment, not Fleet enrollment. Do **not** filter on it: a device that once enrolled in Intune is
+  still a legitimate pending host for Fleet. The test tenant has one `enrolled` device and four `notContacted`.
+- Real serials observed span `0000-0000-4226-9691-9034-3814-15`, `VICTOR1776257483`, `Default string`, and
+  `VMware-56 4d 51 82 9a 05 fe b6-01 de 74 fe 6a 4b 4e c6` (53 characters, embedded spaces). Matching must be exact and space-preserving.
+
+### Failure taxonomy
+
+All statuses **[verified]** against the live tenant.
+
+| Layer | Signal | Meaning | Response |
+|---|---|---|---|
+| Entra token endpoint | `AADSTS7000215` | Wrong secret | Record on the credential, surface to admin |
+| Entra token endpoint | `AADSTS7000222` | Expired secret | Record on the credential, surface to admin |
+| Graph | 401 | Token rejected | Record, retry next cycle |
+| Graph | 403 | Valid token, permission or consent missing | Record with a distinct message, admin action |
+| Graph | 429 / 5xx | Transient | Retry quietly, honor `Retry-After` |
+
+Graph returns **two different error codes for the same 403 cause**: `Authorization_RequestDenied` on directory endpoints and `Forbidden` on
+Intune endpoints. Do not key permission detection on a single code string; key on the HTTP status.
+
+In every failure case the tenant's existing pending hosts are left untouched. Only a successful 200 may remove a host.
+
+## 3. Sync cron
+
+`CronMicrosoftAutopilotSync CronScheduleName = "microsoft_autopilot_sync"` in `server/fleet/cron_schedules.go`. New
+`server/cron/microsoft_autopilot_cron.go` modeled on `google_workspace_cron.go`, registered in `cmd/fleet/cron_registration.go` inside
+`registerMDMCrons`. Default interval 5 minutes.
+
+The job no-ops when no credentials are configured or the license is not premium. It then iterates credentials, one tenant at a time.
+
+- **Failures are isolated per tenant.** One bad credential must not stop the others, and must not affect that tenant's existing hosts.
+- **Empty-response guard.** A successful response listing zero devices must not delete every pending host for that tenant. Mirror the
+  `len(gwUsers) == 0` guard at `google_workspace_cron.go:209`. Note this is the legitimate steady state for a tenant with no registrations,
+  so it must log at most once, not every cycle.
+- Reconciliation per tenant: create new, update changed group tags in place (the tag is mutable in Intune), remove absent.
+
+### Placeholder serials
+
+A device whose `serialNumber` satisfies `fleet.IsPlaceholderHardwareSerial` must not be used to create or match a pending host by serial. Two
+such devices would otherwise collapse onto one host row. `tryLinkUnlinkedEnrollmentFromDevDetail` already skips these serials for the same
+reason (`server/service/microsoft_mdm.go`, the `IsPlaceholderHardwareSerial` check).
+
+Open decision for implementation: either skip such devices entirely (simplest, and they cannot be reconciled at enrollment anyway since the
+serial is the only join key available pre-osquery), or create the pending host but exclude it from serial matching. This design recommends
+**skipping with a logged count**, since a pending host that can never reconcile is worse than an absent one.
+
+## 4. Pending host lifecycle
+
+### Creation
+
+New datastore method `IngestWindowsAutopilotDevices`, modeled on `IngestMDMAppleDevicesFromDEPSync`
+(`server/datastore/mysql/apple_mdm.go:1901`). In a `withRetryTxx` transaction, per new device:
+
+- `hosts` row with `platform='windows'`, `hardware_serial` set, `osquery_host_id = NULL`, and `last_enrolled_at`/`detail_updated_at` at the
+  never-timestamp sentinel (`common_mysql.GetDefaultNonZeroTime()`) so `CleanupExpiredHosts` does not immediately delete it. Follow
+  `createHostFromMDMDB` (`apple_mdm.go:1688`).
+- `host_mdm` row with `enrolled=0, installed_from_dep=1`, which renders as `Pending` through the generated `enrollment_status` column
+  (`schema.sql:924`). That column and the `filterHostsByMDM` pending filter (`hosts.go:1649`) are already platform-agnostic, and the platform
+  guard at `hosts.go:1653` already includes `windows`.
+- **Do not reuse `upsertMDMAppleHostMDMInfoDB` verbatim.** It resolves `server_url` via `ResolveAppleMDMURL` (`apple_mdm.go:2079`) to the
+  Apple MDM path. `mobile_device_management_solutions` is keyed on `(name, server_url)`, so that would point the pending Windows host's
+  `mdm_id` at the *Apple* Fleet solution. Resolve the Windows path (`/api/mdm/microsoft`, `server/mdm/microsoft/microsoft_mdm.go:14`)
+  instead.
+- "All Hosts" and "MS Windows" builtin label membership, so the host appears in host lists before osquery ever runs. Mirror
+  `upsertMDMAppleHostLabelMembershipDB` (`apple_mdm.go:2120`), which looks labels up by name and tolerates their absence.
+- `host_autopilot_devices` row carrying the group tag, Autopilot `id`, AAD device ID, serial, and tenant.
+
+### Removal
+
+Mirror `DeleteHostDEPAssignments` (`apple_mdm.go:2463`): hard-delete hosts that are still pending; for devices that already enrolled,
+soft-delete only the `host_autopilot_devices` row and keep the host.
+
+### `installed_from_dep` audit
+
+Reusing the Apple marker drives the existing generated column with no schema change and correctly flips to `On (automatic)` on enrollment.
+Every reference must be audited (`grep -rn installed_from_dep server/`) to confirm no Windows pending host leaks into an Apple-only query.
+Spot checks already done: `apple_mdm.go:3857` is scoped `AND h.platform = 'darwin'`, and `filterHostsByMDMBootstrapPackageStatus`
+(`hosts.go:1977`) ends with `AND hh.platform = 'darwin'`. The load-bearing risk is the three Windows `host_mdm` writers below.
+
+## 5. Enrollment reconciliation
+
+A pending Autopilot host must merge with the enrolling device at whichever entry point arrives first. Three paths currently mishandle it.
+
+**1. Serial match (`matchHostDuringEnrollment`, `server/datastore/mysql/hosts.go:2297`).** The serial branch is restricted to
+`platform IN ('darwin','ios','ipados')` and gated on `isAppleMDMEnabled` (`:2338`). `EnrollOrbit` additionally blanks the serial outright for
+Windows (`:2401-2405`), as does `HostPreviouslyOrbitEnrolled` (`:2582-2585`).
+
+Add a Windows branch scoped strictly to pending Autopilot hosts, and stop blanking the serial only when such a host exists for it:
+
+```sql
+SELECT id, ..., 2 priority, platform FROM hosts h
+  JOIN host_mdm hm ON hm.host_id = h.id
+  JOIN host_autopilot_devices had ON had.host_id = h.id AND had.deleted_at IS NULL
+  WHERE h.hardware_serial = ? AND h.platform = 'windows'
+    AND hm.enrolled = 0 AND hm.installed_from_dep = 1
+  ORDER BY h.id LIMIT 1
+```
+
+The new branch must not depend on `isAppleMDMEnabled`. Note `orbitEnrollingWithOsqueryIdentifier` (`:2334`) suppresses serial matching
+entirely when orbit sends an osquery identifier, which happens only under `--host-identifier=instance`
+(`orbit/cmd/orbit/orbit.go:905-908`); the default path sends none, so the branch is reachable.
+
+**2. Windows MDM DevDetail link (`tryLinkUnlinkedEnrollmentFromDevDetail`, `server/service/microsoft_mdm.go:1672`).** Already resolves the
+host by serial and calls `LinkWindowsHostMDMEnrollment` (`server/service/osquery_utils/queries.go:3208`), which never sets `enrolled=1` and
+calls `UpdateMDMInstalledFromDEP(hostID, false)` when `MDMNotInOOBE` (`:3233`), clearing the pending marker. Linking to a pending Autopilot
+host must set `enrolled=1` and keep `installed_from_dep=1`.
+
+**3. osquery detail ingest (`directIngestMDMWindows`, `server/service/osquery_utils/queries.go:2800`).** Derives `automatic` from
+`aad_resource_id` presence and `MDMNotInOOBE`, and its comment at `:2826` asserts Pending is macOS-only. After a real Autopilot enrollment
+this resolves to `automatic=true` and is harmless, but a reconciled host must be verified to stay `enrolled=1, installed_from_dep=1` rather
+than being reset to `On (manual)`.
+
+The `host_autopilot_devices` row is keyed by `host_id`, so the group tag survives all three transitions for free.
+
+### Interaction with the Windows enrollment default fleet
+
+`maybeAssignWindowsEnrollmentDefaultFleet` (`server/service/osquery_utils/queries.go:3269`) assigns the configured default fleet only when
+`host.CreatedAt` is at or after the enrollment row's `CreatedAt`, on the assumption that MDM-first ordering means a freshly created host.
+
+Autopilot pending hosts invert that: the sync creates the host row potentially days before enrollment, so `host.CreatedAt` precedes the
+enrollment and the default fleet is **not** applied. That is the correct outcome for this story, since the whole point is that automation has
+already placed the host in the right fleet and must not be overridden. But it is a behavior change for anyone relying on the Windows
+enrollment default fleet who then turns on Autopilot sync: those hosts stop receiving the default fleet and stay in Unassigned unless the
+automation moves them. This must be called out in the feature guide.
+
+## 6. `group_tag` exposure
+
+**The column must be `varchar(2048)`, not `varchar(255)`.** Intune's documented maximum is 2048 characters, confirmed by the customer, and the
+test tenant now holds tags of 63, 127, 255, and 257 characters plus one empty. A `varchar(255)` column truncates silently.
+
+Consequences:
+
+- Do **not** index `group_tag`. At utf8mb4 a 2048-character column is 8192 bytes, over InnoDB's 3072-byte index key limit. If filtering by
+  group tag is ever wanted, it needs a prefix index such as `KEY (group_tag(191))`.
+- This retroactively strengthens the "separate table, not a column on `hosts`" decision. An 8 KB-capable column on Fleet's hottest table
+  would be a genuine cost; in `host_autopilot_devices` it is not.
+
+`host_autopilot_devices` gains the Autopilot `id` alongside the AAD device ID, and reconciliation keys on `id`, which is stable for the life
+of the registration and unique, unlike the serial.
+
+Expose `group_tag` on both `GET /hosts` (list) and `GET /hosts/:id` (detail) via
+`LEFT JOIN host_autopilot_devices had ON had.host_id = h.id AND had.deleted_at IS NULL`. The list endpoint is the one that matters: the
+customer's automation wants one paginated sweep followed by a batch transfer. Model the response field on `dep_assigned_to_fleet`
+(`server/fleet/hosts.go:463`). Empty is the normal case, so the field is omitted or empty when absent, and the host details row is hidden.
+Benchmark the list query to confirm the added join does not regress latency.

--- a/openspec/changes/windows-autopilot-pending-hosts/design.md
+++ b/openspec/changes/windows-autopilot-pending-hosts/design.md
@@ -27,7 +27,7 @@ enrollment token.
 controls:
   windows_entra_tenant_ids: [...]      # unchanged, inbound
   windows_entra_client_ids: [...]      # unchanged, inbound
-  microsoft_graph_credentials:         # new, outbound
+  microsoft_graph_credentials:         # new, outbound. List shape, max 1 entry for now.
     - tenant_id: 5b1fc5b6-9502-4cf9-90cf-d0b656eaf7a4
       client_id: 7f6b1665-51f5-48de-a9b6-ac17539583fb
       client_secret: $WINDOWS_ENTRA_CLIENT_SECRET_ACME
@@ -46,6 +46,19 @@ reject a duplicate `tenant_id` in the incoming list with a 422.
 A duplicate would not create duplicate hosts (reconciliation is keyed on tenant plus device), but it doubles Graph calls against Microsoft's
 throttling limits and makes failure reporting incoherent: one revoked secret would surface errors for a tenant that is otherwise syncing.
 
+### Capped at one credential for this release
+
+The list carries **at most one entry for now**. A configuration with two or more entries SHALL be rejected with a 422. Multi-tenant sync is
+deliberately deferred.
+
+The shape stays a list precisely so lifting the cap later is a validation change and nothing else: no key rename, no type change from scalar
+to list, no API break, and no migration, since the table is already keyed on `tenant_id` and the sync already iterates. This is the whole
+reason not to ship the scalar the merged docs describe, even though only one credential is supported today.
+
+Everything downstream is written to the multi-entry shape regardless: the table, the per-tenant sync loop, per-credential failure isolation,
+and `host_autopilot_devices.tenant_id`. The cap is enforced at exactly one place, config validation, so removing it is a one-line change plus
+the UI going from one form to a list.
+
 ### Storage
 
 Do **not** use `mdm_config_assets`. It is keyed `UNIQUE (name, deletion_uuid)` and structurally holds one row per credential name. Fleet has
@@ -60,6 +73,7 @@ CREATE TABLE `microsoft_graph_credentials` (
   `tenant_id`      varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   `client_id`      varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   `client_secret`  blob NOT NULL,             -- encrypted with the server private key, as abm_tokens.token
+  `credential_invalid` tinyint(1) NOT NULL DEFAULT '0',   -- drives the app-wide banner, as abm_tokens.token_invalid
   `last_synced_at` timestamp NULL DEFAULT NULL,
   `last_sync_error` text COLLATE utf8mb4_unicode_ci,
   `created_at`     timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -146,6 +160,36 @@ Graph returns **two different error codes for the same 403 cause**: `Authorizati
 Intune endpoints. Do not key permission detection on a single code string; key on the HTTP status.
 
 In every failure case the tenant's existing pending hosts are left untouched. Only a successful 200 may remove a host.
+
+### Surfacing a bad credential to the admin
+
+Product decision: use the **app-wide banner**, the same treatment as an invalid ABM token. Figma to follow.
+
+The precedent is exact and should be mirrored rather than reinvented:
+
+| ABM | Windows Graph |
+|---|---|
+| `abm_tokens.token_invalid` (migration `20260721090128`) | `microsoft_graph_credentials.credential_invalid` |
+| `SetABMTokenInvalidForOrgName` / `IsABMTokenInvalidForOrgName` (`apple_mdm.go:6608`, `:6627`) | same pair keyed on `tenant_id` |
+| `ABMToken.TokenInvalid` json `token_invalid` (`server/fleet/mdm.go:200`) | `credential_invalid` on the credential response |
+| `hasInvalidABMToken` computed in `App.tsx:150` | same shape for the Graph credential |
+| `<AppleBMTokenInvalidMessage orgNames={...} />` in the `MainContent.tsx` priority chain | new banner component in the same chain |
+
+`MainContent.tsx:59-83` shows exactly one banner at a time in a fixed priority order, and every banner except the APNs one sits inside the
+`isPremiumTier` branch. The Graph credential banner belongs in that premium branch. Its position in the priority order is a product call;
+placing it after the VPP banner and before the license-expiry banner is the natural default, since it is narrower in blast radius than the
+Apple MDM banners above it.
+
+The flag is set by the sync, not at config-write time. A credential is verified on write (see section 1), so it is valid when stored; it goes
+bad later through expiry, revocation, or a permission change. Set `credential_invalid = 1` on an authentication or authorization failure
+(token-endpoint `AADSTS*` errors, Graph 401, Graph 403) and clear it on the next successful sync. Do **not** set it for transient 429 or 5xx,
+or a Microsoft outage would raise a credential alarm across every deployment.
+
+**Open question for product.** The ABM banner names the offending token by `org_name`, which is human-readable. A Graph credential's only
+identity is the tenant GUID, which is not. Options: show the GUID, add an admin-supplied display label to the credential, or read the tenant
+name from Graph (`/organization`), which would require another permission and undercut the least-privilege setup. With the cap at one
+credential this barely matters, since the banner can simply say "the Microsoft Graph credential", but it needs deciding before the cap is
+lifted.
 
 ## 3. Sync cron
 

--- a/openspec/changes/windows-autopilot-pending-hosts/proposal.md
+++ b/openspec/changes/windows-autopilot-pending-hosts/proposal.md
@@ -17,7 +17,9 @@ automation has something to key on.
 ## What changes
 
 - A new **`mdm.microsoft_graph_credentials`** config: a list of `{tenant_id, client_id, client_secret}` entries, one per Entra tenant, that
-  Fleet uses to authenticate to Microsoft Graph. Premium only. Secrets stored encrypted and masked on read.
+  Fleet uses to authenticate to Microsoft Graph. **Capped at one entry for this release**; the list shape exists so lifting the cap later is
+  a validation change rather than an API break. Premium only. Secrets stored encrypted and masked on read.
+- An **app-wide banner** when the stored credential goes bad, mirroring the existing invalid-ABM-token banner.
 - A **Microsoft Graph client** that mints app-only tokens via OAuth2 client credentials and lists Windows Autopilot device identities.
 - A **periodic sync cron** that reconciles each tenant's Autopilot registrations into pending Windows hosts, and removes hosts that leave
   the Autopilot list.
@@ -37,11 +39,13 @@ automation has something to key on.
 
 Both need product sign-off before the docs subtask (#48852) lands.
 
-1. **The credential is a list, not a single token.** The merged docs PRs ([#50518](https://github.com/fleetdm/fleet/pull/50518),
-   [#50519](https://github.com/fleetdm/fleet/pull/50519)) define a scalar `controls.windows_entra_graph_api_token`. That cannot work for more
-   than one tenant, and Fleet deliberately supports multi-tenant Windows enrollment today (story #39214, QA'd with two tenants). An Autopilot
-   registry is per-tenant, so a scalar credential silently surfaces exactly one tenant's devices and no error anywhere explains the absence of
-   the rest. Both docs PRs need rewriting, not extending.
+1. **The credential is a list, not a single token, even though only one is supported today.** The merged docs PRs
+   ([#50518](https://github.com/fleetdm/fleet/pull/50518), [#50519](https://github.com/fleetdm/fleet/pull/50519)) define a scalar
+   `controls.windows_entra_graph_api_token`. A scalar cannot ever grow to more than one tenant without an API break, and Fleet deliberately
+   supports multi-tenant Windows enrollment today (story #39214, QA'd with two tenants), where an Autopilot registry is per-tenant. This
+   release caps the list at one entry, so the shipped capability matches the merged docs; only the wire shape differs, and it differs
+   specifically so that raising the cap later costs a validation change instead of a rename plus a type change. Both docs PRs need rewriting,
+   not extending.
 
 2. **Renamed.** `windows_entra_graph_api_token` becomes `microsoft_graph_credentials[].client_secret`. There is no Microsoft product called
    "Entra Graph": the API is Microsoft Graph, the data is Intune's, and the credential is an Entra app registration. "Entra" adds no
@@ -54,14 +58,17 @@ Both need product sign-off before the docs subtask (#48852) lands.
 
 ## Open questions for product
 
-- **Multi-tenant UI.** #48851 scoped three inputs and a Save button. A credential list needs add/delete rows like the existing tenant and
-  client ID lists on `WindowsAutomaticEnrollmentPage`. No Figma exists for this.
+- **Banner placement and wording.** Product chose the app-wide banner for a bad credential, matching the invalid-ABM-token treatment; Figma
+  to follow. Two details still need deciding: where it sits in `MainContent.tsx`'s single-banner priority order, and how it names the
+  offending credential. The ABM banner uses a human-readable `org_name`; a Graph credential's only identity is the tenant GUID. With the cap
+  at one, the banner can just say "the Microsoft Graph credential" and defer this, but it must be settled before the cap is lifted.
 - **"Multiple tags" in the test plan.** The story's edge cases say "including empty, renamed, and multiple tags". Graph returns `groupTag` as
   a single string and Microsoft's model is one tag per device, so this line is either about a comma-separated convention inside the one
   string, or is a misconception. Needs clarifying before QA writes against it.
-- **Proactive secret-expiry warning.** Client secrets expire (180 days default, 24 months max). Fleet cannot read the expiry without
-  `Application.Read.All`, a second permission. This proposal surfaces expiry as a sync failure after the fact. An admin-entered expiry date
-  would allow warning ahead of time, at the cost of relying on correct manual entry.
+- **Proactive secret-expiry warning.** Resolved for reactive detection: a bad credential raises the banner. Still open is whether Fleet
+  should warn *before* expiry. Client secrets expire (180 days default, 24 months max), and Fleet cannot read the expiry date without
+  `Application.Read.All`, a second permission that would undercut the least-privilege setup. An admin-entered expiry date would allow an
+  ahead-of-time warning at the cost of relying on correct manual entry.
 - **Filtering hosts by group tag.** Not requested; the automation sweeps the list endpoint. If it is ever wanted, `group_tag` needs a prefix
   index (see `design.md`).
 

--- a/openspec/changes/windows-autopilot-pending-hosts/proposal.md
+++ b/openspec/changes/windows-autopilot-pending-hosts/proposal.md
@@ -16,17 +16,21 @@ automation has something to key on.
 
 ## What changes
 
-- A new **`mdm.microsoft_graph_credentials`** config: a list of `{tenant_id, client_id, client_secret}` entries, one per Entra tenant, that
-  Fleet uses to authenticate to Microsoft Graph. **Capped at one entry for this release**; the list shape exists so lifting the cap later is
-  a validation change rather than an API break. Premium only. Secrets stored encrypted and masked on read.
-- An **app-wide banner** when the stored credential goes bad, mirroring the existing invalid-ABM-token banner.
+- A new **`/microsoft_graph_credentials`** resource (`GET` to read, declarative `PUT` to reconcile): a list of
+  `{tenant_id, client_id, client_secret}` entries, one per Entra tenant, that Fleet uses to authenticate to Microsoft Graph. **Capped at one
+  entry for this release**; the list shape exists so lifting the cap later is a validation change rather than an API break. Premium only.
+  Secrets stored encrypted in a dedicated table and masked on read. It is deliberately **not** a field on `AppConfig` — see `design.md`
+  section 1.
+- An **app-wide banner** when a stored credential goes bad, mirroring the existing invalid-ABM-token banner, driven by a single
+  server-computed `mdm.microsoft_graph_credential_invalid` boolean on the app config.
 - A **Microsoft Graph client** that mints app-only tokens via OAuth2 client credentials and lists Windows Autopilot device identities.
 - A **periodic sync cron** that reconciles each tenant's Autopilot registrations into pending Windows hosts, and removes hosts that leave
   the Autopilot list.
 - **Enrollment reconciliation** so a pending host is reused, not duplicated, when the device actually enrolls, across all three entry points
   that can arrive first.
 - **`group_tag`** exposed on the host list and host detail API responses, and shown read-only on host details.
-- **GitOps** support for the credential list under `controls`, with `generate-gitops` emitting a secret placeholder.
+- **GitOps** support for the credential list under `controls`, applied through the new endpoint rather than the app config (the
+  `certificate_authorities` pattern), with `generate-gitops` emitting a secret placeholder.
 
 ## What does not change
 
@@ -37,7 +41,8 @@ automation has something to key on.
 
 ## Deviations from the issue as written
 
-Both need product sign-off before the docs subtask (#48852) lands.
+Items 1 and 2 need product sign-off before the docs subtask (#48852) lands. Items 3 and 4 are engineering decisions recorded here for
+review, not sign-off gates.
 
 1. **The credential is a list, not a single token, even though only one is supported today.** The merged docs PRs
    ([#50518](https://github.com/fleetdm/fleet/pull/50518), [#50519](https://github.com/fleetdm/fleet/pull/50519)) define a scalar
@@ -52,7 +57,15 @@ Both need product sign-off before the docs subtask (#48852) lands.
    information once "graph" is present, and worse, visually groups an outbound credential with the two inbound allowlists it must be
    distinguished from. The value is a client secret, which PR #50519's own prose already calls it while the key said "token".
 
-3. **The auth model is client credentials, not a pasted token.** The story says "UI field for user to provide Microsoft Graph API
+3. **The credential is a dedicated resource, not a config field.** An earlier draft of this proposal put it on `GET`/`PATCH /config`. It was
+   built that way and then moved during implementation. The client secret is encrypted at rest, so it cannot live in `app_config_json`, which
+   meant the config field had to be hydrated from the credentials table on every config read, which needed a cache, which needed the sync to
+   invalidate that cache — machinery that existed only to hold the field in the wrong place. ABM, VPP, and certificate authorities all keep
+   the credential and its per-instance status behind their own endpoints, and `certificate_authorities` shows a key can stay in the GitOps
+   YAML while being applied through its own endpoint. The GitOps contract is unchanged; only the HTTP surface moved. This does **not** need
+   product sign-off, since the YAML the docs describe is unaffected, but the REST API doc must describe endpoints instead of config fields.
+
+4. **The auth model is client credentials, not a pasted token.** The story says "UI field for user to provide Microsoft Graph API
    authentication token". A Graph access token expires in ~60 minutes (measured: `expires_in: 3599`), so a pasted token breaks within the
    hour. Fleet stores an app-registration credential and mints tokens on demand.
 

--- a/openspec/changes/windows-autopilot-pending-hosts/proposal.md
+++ b/openspec/changes/windows-autopilot-pending-hosts/proposal.md
@@ -1,0 +1,73 @@
+# Show Windows Autopilot devices as "Pending" hosts
+
+Story: [#43481](https://github.com/fleetdm/fleet/issues/43481). Sub-tasks: #48849 (foundation), #48850 (sync and reconciliation),
+#48851 (frontend), #48852 (docs and QA).
+
+## Why
+
+IT admins register Windows devices with Windows Autopilot before those devices are ever powered on, and tag them at that moment with a
+**group tag** that encodes intent ("Engineering", "Sales"). Today Fleet knows nothing about a device until it enrolls, so there is no way to
+place it in the right fleet ahead of time. `easterwood` and `smither` both want to build automation that transfers hosts to the correct fleet
+*before* enrollment, and cannot, because the hosts do not exist in Fleet yet.
+
+Fleet already solves exactly this for Apple: ABM-assigned devices appear as `Pending` hosts before enrollment. This change brings the same
+capability to Windows, sourced from Microsoft Graph instead of Apple Business Manager, and carries the Autopilot group tag through so
+automation has something to key on.
+
+## What changes
+
+- A new **`mdm.microsoft_graph_credentials`** config: a list of `{tenant_id, client_id, client_secret}` entries, one per Entra tenant, that
+  Fleet uses to authenticate to Microsoft Graph. Premium only. Secrets stored encrypted and masked on read.
+- A **Microsoft Graph client** that mints app-only tokens via OAuth2 client credentials and lists Windows Autopilot device identities.
+- A **periodic sync cron** that reconciles each tenant's Autopilot registrations into pending Windows hosts, and removes hosts that leave
+  the Autopilot list.
+- **Enrollment reconciliation** so a pending host is reused, not duplicated, when the device actually enrolls, across all three entry points
+  that can arrive first.
+- **`group_tag`** exposed on the host list and host detail API responses, and shown read-only on host details.
+- **GitOps** support for the credential list under `controls`, with `generate-gitops` emitting a secret placeholder.
+
+## What does not change
+
+- The existing `mdm.windows_entra_tenant_ids` and `mdm.windows_entra_client_ids` allowlists keep their current shape and meaning. They
+  authorize *inbound* enrollment JWTs; the new credential is *outbound*. See `design.md` for why they are not unified.
+- Fleet does not act on the group tag. No auto-transfer, no built-in automation. The tag is data for the customer's automation to consume.
+- No fleetd/orbit changes.
+
+## Deviations from the issue as written
+
+Both need product sign-off before the docs subtask (#48852) lands.
+
+1. **The credential is a list, not a single token.** The merged docs PRs ([#50518](https://github.com/fleetdm/fleet/pull/50518),
+   [#50519](https://github.com/fleetdm/fleet/pull/50519)) define a scalar `controls.windows_entra_graph_api_token`. That cannot work for more
+   than one tenant, and Fleet deliberately supports multi-tenant Windows enrollment today (story #39214, QA'd with two tenants). An Autopilot
+   registry is per-tenant, so a scalar credential silently surfaces exactly one tenant's devices and no error anywhere explains the absence of
+   the rest. Both docs PRs need rewriting, not extending.
+
+2. **Renamed.** `windows_entra_graph_api_token` becomes `microsoft_graph_credentials[].client_secret`. There is no Microsoft product called
+   "Entra Graph": the API is Microsoft Graph, the data is Intune's, and the credential is an Entra app registration. "Entra" adds no
+   information once "graph" is present, and worse, visually groups an outbound credential with the two inbound allowlists it must be
+   distinguished from. The value is a client secret, which PR #50519's own prose already calls it while the key said "token".
+
+3. **The auth model is client credentials, not a pasted token.** The story says "UI field for user to provide Microsoft Graph API
+   authentication token". A Graph access token expires in ~60 minutes (measured: `expires_in: 3599`), so a pasted token breaks within the
+   hour. Fleet stores an app-registration credential and mints tokens on demand.
+
+## Open questions for product
+
+- **Multi-tenant UI.** #48851 scoped three inputs and a Save button. A credential list needs add/delete rows like the existing tenant and
+  client ID lists on `WindowsAutomaticEnrollmentPage`. No Figma exists for this.
+- **"Multiple tags" in the test plan.** The story's edge cases say "including empty, renamed, and multiple tags". Graph returns `groupTag` as
+  a single string and Microsoft's model is one tag per device, so this line is either about a comma-separated convention inside the one
+  string, or is a misconception. Needs clarifying before QA writes against it.
+- **Proactive secret-expiry warning.** Client secrets expire (180 days default, 24 months max). Fleet cannot read the expiry without
+  `Application.Read.All`, a second permission. This proposal surfaces expiry as a sync failure after the fact. An admin-entered expiry date
+  would allow warning ahead of time, at the cost of relying on correct manual entry.
+- **Filtering hosts by group tag.** Not requested; the automation sweeps the list endpoint. If it is ever wanted, `group_tag` needs a prefix
+  index (see `design.md`).
+
+## Risk
+
+Medium, concentrated in the shared Windows enrollment host-matching path (`matchHostDuringEnrollment`, `EnrollOrbit`, the Windows MDM
+DevDetail link, and osquery MDM ingest). A defect there merges the wrong hosts or duplicates a host at enrollment, affecting Windows hosts
+that have nothing to do with Autopilot. Mitigated by scoping every new match strictly to pending Autopilot hosts and by regression tests
+asserting legacy Windows enrollment is untouched.

--- a/openspec/changes/windows-autopilot-pending-hosts/specs/windows-autopilot-pending-hosts/spec.md
+++ b/openspec/changes/windows-autopilot-pending-hosts/specs/windows-autopilot-pending-hosts/spec.md
@@ -50,12 +50,26 @@ identical data while doubling API calls and making per-tenant failure reporting 
 - **THEN** the request SHALL be rejected with a validation error
 - **AND** neither entry SHALL be stored
 
-#### Scenario: Multiple distinct tenants are accepted
+### Requirement: At most one credential is accepted in this release
+
+Fleet SHALL reject a configuration containing more than one `microsoft_graph_credentials` entry. The field SHALL remain a list so that
+raising this cap later requires only a validation change, with no rename, no scalar-to-list type change, no API break, and no migration.
+Storage, the sync loop, per-credential failure handling, and `host_autopilot_devices.tenant_id` SHALL all be implemented for the multi-entry
+case regardless of the cap.
+
+#### Scenario: A second credential is rejected
 
 - **GIVEN** a Fleet Premium instance
-- **WHEN** an admin sends two entries with different `tenant_id` values
-- **THEN** both SHALL be stored
-- **AND** the sync SHALL pull Autopilot devices from both tenants
+- **WHEN** an admin sends `mdm.microsoft_graph_credentials` containing two entries with different `tenant_id` values
+- **THEN** the request SHALL be rejected with a validation error explaining that only one credential is supported
+- **AND** neither entry SHALL be stored
+
+#### Scenario: A single credential is accepted
+
+- **GIVEN** a Fleet Premium instance
+- **WHEN** an admin sends exactly one valid entry
+- **THEN** it SHALL be stored
+- **AND** the sync SHALL pull Autopilot devices from that tenant
 
 ### Requirement: Client secrets are stored encrypted and never returned
 
@@ -192,6 +206,42 @@ that tenant's pending hosts.
 - **WHEN** the sync runs
 - **THEN** Fleet SHALL honor `Retry-After`
 - **AND** SHALL NOT surface the condition to the admin as a credential problem
+
+### Requirement: A bad credential raises an app-wide banner
+
+Fleet SHALL mark a credential invalid when a sync fails to authenticate or is denied authorization, and SHALL surface that state as an
+app-wide banner, matching the existing invalid-ABM-token treatment. The flag SHALL be cleared on the next successful sync. Fleet SHALL NOT
+mark a credential invalid for transient failures, so that a Microsoft outage does not raise a credential alarm.
+
+The banner SHALL only render for Fleet Premium, consistent with every other MDM banner in the single-banner priority chain.
+
+#### Scenario: An expired secret raises the banner
+
+- **GIVEN** a stored credential whose client secret has expired
+- **WHEN** the sync runs and token acquisition fails
+- **THEN** the credential SHALL be marked invalid
+- **AND** an admin loading any page SHALL see the banner reporting the Microsoft Graph credential needs attention
+
+#### Scenario: A revoked permission raises the banner
+
+- **GIVEN** a stored credential whose Graph permission or admin consent has been removed
+- **WHEN** the sync runs and Graph responds 403
+- **THEN** the credential SHALL be marked invalid
+- **AND** the banner SHALL be shown
+
+#### Scenario: A transient outage does not raise the banner
+
+- **GIVEN** a stored, valid credential
+- **WHEN** the sync runs and Graph responds 429 or 5xx
+- **THEN** the credential SHALL NOT be marked invalid
+- **AND** no banner SHALL be shown
+
+#### Scenario: Fixing the credential clears the banner
+
+- **GIVEN** a credential marked invalid
+- **WHEN** an admin stores a working secret and the next sync succeeds
+- **THEN** the credential SHALL no longer be marked invalid
+- **AND** the banner SHALL no longer be shown
 
 ### Requirement: A pending Autopilot host is reused when the device enrolls
 

--- a/openspec/changes/windows-autopilot-pending-hosts/specs/windows-autopilot-pending-hosts/spec.md
+++ b/openspec/changes/windows-autopilot-pending-hosts/specs/windows-autopilot-pending-hosts/spec.md
@@ -1,0 +1,269 @@
+## ADDED Requirements
+
+### Requirement: Microsoft Graph credentials are configured per Entra tenant
+
+Fleet SHALL expose `microsoft_graph_credentials` under `AppConfig.MDM`, a list whose entries each contain `tenant_id`, `client_id`, and
+`client_secret`. Fleet SHALL use each entry to obtain app-only Microsoft Graph tokens via the OAuth2 client-credentials grant against
+`https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token` with scope `https://graph.microsoft.com/.default`.
+
+`tenant_id` and `client_id` SHALL be validated as GUIDs. The feature SHALL be Fleet Premium only.
+
+The existing `windows_entra_tenant_ids` and `windows_entra_client_ids` allowlists SHALL be unchanged, and Fleet SHALL NOT derive Graph
+credentials from them. A Graph `client_id` SHALL NOT be required to appear in `windows_entra_client_ids`.
+
+#### Scenario: Premium instance stores a credential
+
+- **GIVEN** a Fleet Premium instance with Windows MDM enabled
+- **WHEN** an admin sends `PATCH /config` with one `mdm.microsoft_graph_credentials` entry containing valid GUIDs and a working secret
+- **THEN** the credential SHALL be stored
+- **AND** an `added_microsoft_graph_credential` activity SHALL be recorded
+
+#### Scenario: Fleet Free rejects the write
+
+- **GIVEN** a Fleet Free instance
+- **WHEN** an admin sends `PATCH /config` with any `mdm.microsoft_graph_credentials` entry
+- **THEN** the request SHALL be rejected with `ErrMissingLicense`
+
+#### Scenario: Malformed GUID is rejected
+
+- **GIVEN** a Fleet Premium instance
+- **WHEN** an admin sends a credential whose `tenant_id` is not a GUID
+- **THEN** the request SHALL be rejected with a validation error naming `mdm.microsoft_graph_credentials`
+
+#### Scenario: Credential is verified before it is stored
+
+- **GIVEN** an admin supplies a new or changed credential
+- **WHEN** Fleet cannot obtain a token or cannot list a first page with it
+- **THEN** the request SHALL be rejected with an invalid-argument error
+- **AND** no credential SHALL be stored
+
+### Requirement: At most one credential per tenant
+
+Fleet SHALL enforce uniqueness on `tenant_id` in storage and SHALL reject a configuration containing a duplicate `tenant_id`. This is because
+the Windows Autopilot device registry is scoped to an Entra tenant rather than to an application, so two credentials for the same tenant read
+identical data while doubling API calls and making per-tenant failure reporting incoherent.
+
+#### Scenario: Duplicate tenant is rejected
+
+- **GIVEN** a Fleet Premium instance
+- **WHEN** an admin sends `mdm.microsoft_graph_credentials` containing two entries with the same `tenant_id` and different `client_id` values
+- **THEN** the request SHALL be rejected with a validation error
+- **AND** neither entry SHALL be stored
+
+#### Scenario: Multiple distinct tenants are accepted
+
+- **GIVEN** a Fleet Premium instance
+- **WHEN** an admin sends two entries with different `tenant_id` values
+- **THEN** both SHALL be stored
+- **AND** the sync SHALL pull Autopilot devices from both tenants
+
+### Requirement: Client secrets are stored encrypted and never returned
+
+Fleet SHALL store each `client_secret` encrypted at rest in a dedicated table rather than in `app_config_json` and rather than in
+`mdm_config_assets`. Fleet SHALL require a configured server private key before accepting a new secret. Fleet SHALL replace every
+`client_secret` with the masked value on read.
+
+#### Scenario: Secret is masked on read
+
+- **GIVEN** a stored credential
+- **WHEN** an admin calls `GET /config`
+- **THEN** the entry's `client_secret` SHALL be `********`
+- **AND** the plaintext secret SHALL NOT appear anywhere in the response
+
+#### Scenario: Resending the mask preserves the stored secret
+
+- **GIVEN** a stored credential
+- **WHEN** an admin sends `PATCH /config` with that entry's `client_secret` set to `********` and another field changed
+- **THEN** the stored secret SHALL be unchanged
+- **AND** no `edited_microsoft_graph_credential` activity SHALL be recorded for the secret alone
+
+#### Scenario: Missing server private key blocks a new secret
+
+- **GIVEN** a Fleet instance with no server private key configured
+- **WHEN** an admin supplies a new `client_secret`
+- **THEN** the request SHALL be rejected with an error directing the admin to configure the private key
+
+### Requirement: Graph pagination terminates and yields each device once
+
+Fleet SHALL NOT implement pagination as an unguarded "follow `@odata.nextLink` until absent" loop. Fleet SHALL deduplicate results by the
+Autopilot device `id`, SHALL terminate when `@odata.nextLink` equals the URL just requested or when a page yields no previously unseen `id`,
+and SHALL apply a hard page cap. Fleet SHALL NOT assume that serial numbers are unique or that results are ordered by anything it relies on.
+
+This is because the Autopilot device identities collection paginates with an inclusive `$skiptoken=LastSerialNumber='<serial>'` cursor ordered
+by serial number. Serial numbers are not unique, and the service can return an `@odata.nextLink` identical to the URL just requested.
+
+#### Scenario: A self-referential nextLink terminates the walk
+
+- **GIVEN** Graph returns a page whose `@odata.nextLink` is identical to the URL just requested
+- **WHEN** the client walks pages
+- **THEN** the walk SHALL terminate
+- **AND** the client SHALL log that a pagination guard fired
+
+#### Scenario: A device repeated across page boundaries is returned once
+
+- **GIVEN** Graph returns a device as the last item of one page and the first item of the next
+- **WHEN** the client walks pages
+- **THEN** that device SHALL appear exactly once in the result
+- **AND** the result count SHALL equal the number of distinct device `id` values
+
+#### Scenario: Devices sharing a serial number do not stall the walk
+
+- **GIVEN** several devices share one serial number
+- **WHEN** the client walks pages
+- **THEN** the walk SHALL terminate
+- **AND** every distinct device `id` SHALL appear in the result
+
+### Requirement: The sync reconciles Autopilot devices into pending Windows hosts
+
+A periodic cron SHALL, for each configured credential, list that tenant's Autopilot devices and reconcile them: create a pending host for a
+newly seen device, update a changed group tag in place, and remove a host for a device no longer present. The cron SHALL no-op when no
+credential is configured or the license is not premium.
+
+A device whose serial number is a known placeholder SHALL be skipped, with the skipped count logged, since such a host could never be matched
+at enrollment.
+
+#### Scenario: A new Autopilot device becomes a pending host
+
+- **GIVEN** a configured credential and a tenant containing an Autopilot device with a real serial
+- **WHEN** the sync runs
+- **THEN** a host SHALL exist with `platform = 'windows'`, `host_mdm.enrolled = 0`, `host_mdm.installed_from_dep = 1`,
+  `osquery_host_id IS NULL`, and `enrollment_status = 'Pending'`
+- **AND** its `mdm_id` SHALL reference the Windows Fleet MDM solution, not the Apple one
+- **AND** it SHALL be a member of the "All Hosts" and Windows builtin labels
+
+#### Scenario: A changed group tag updates in place
+
+- **GIVEN** a pending host synced from an Autopilot device
+- **WHEN** the tag changes in Intune and the sync runs again
+- **THEN** the stored group tag SHALL be the new value
+- **AND** no additional host SHALL be created
+
+#### Scenario: A device removed from Autopilot removes its pending host
+
+- **GIVEN** a still-pending host synced from an Autopilot device
+- **WHEN** the device is removed from Autopilot and the sync runs
+- **THEN** the host SHALL be deleted
+
+#### Scenario: An empty response never deletes pending hosts
+
+- **GIVEN** a tenant with existing pending Autopilot hosts
+- **WHEN** the sync receives a successful response listing zero devices
+- **THEN** no pending host SHALL be deleted
+
+#### Scenario: A placeholder serial is skipped
+
+- **GIVEN** an Autopilot device whose serial is a known placeholder such as `Default string`
+- **WHEN** the sync runs
+- **THEN** no pending host SHALL be created for it
+- **AND** the sync SHALL log that it skipped the device
+
+#### Scenario: One failing tenant does not affect another
+
+- **GIVEN** two configured credentials where one secret has been revoked
+- **WHEN** the sync runs
+- **THEN** the healthy tenant's devices SHALL reconcile normally
+- **AND** the failing tenant's existing pending hosts SHALL be left untouched
+- **AND** the failure SHALL be recorded against the failing credential only
+
+### Requirement: Sync failures are surfaced without destroying data
+
+Fleet SHALL record the outcome of each sync per credential. Fleet SHALL distinguish an authentication failure (bad or expired secret) from an
+authorization failure (missing permission or admin consent) from a transient failure. Permission detection SHALL key on the HTTP status
+rather than a single error-code string, because Graph returns different codes for the same 403 cause. In no failure case SHALL Fleet remove
+that tenant's pending hosts.
+
+#### Scenario: An expired secret is reported as a credential problem
+
+- **GIVEN** a credential whose client secret has expired
+- **WHEN** the sync runs
+- **THEN** the credential's last sync error SHALL identify it as an expired or invalid secret requiring admin action
+- **AND** the tenant's pending hosts SHALL remain
+
+#### Scenario: A missing permission is reported distinctly
+
+- **GIVEN** a credential whose app registration lacks `DeviceManagementServiceConfig.Read.All` or its admin consent
+- **WHEN** the sync runs and Graph responds 403
+- **THEN** the credential's last sync error SHALL identify it as a permission or consent problem
+- **AND** detection SHALL NOT depend on which error code string Graph returned
+
+#### Scenario: A transient failure is retried quietly
+
+- **GIVEN** Graph responds 429 with `Retry-After`
+- **WHEN** the sync runs
+- **THEN** Fleet SHALL honor `Retry-After`
+- **AND** SHALL NOT surface the condition to the admin as a credential problem
+
+### Requirement: A pending Autopilot host is reused when the device enrolls
+
+When a Windows device that has a pending Autopilot host enrolls, Fleet SHALL reuse the existing host record rather than creating a second
+one, at whichever entry point arrives first: orbit enrollment, the Windows MDM DevDetail serial link, or osquery detail ingest. The host
+SHALL become `enrolled = 1` while retaining `installed_from_dep = 1`, and SHALL retain its group tag and its fleet assignment.
+
+Serial matching for Windows SHALL be scoped strictly to hosts that are pending and have an Autopilot record. Windows hosts without one SHALL
+continue to match by UUID or osquery identifier only.
+
+#### Scenario: Orbit enrollment reuses the pending host
+
+- **GIVEN** a pending Autopilot host with serial S
+- **WHEN** a Windows device with serial S enrolls via orbit
+- **THEN** the same host `id` SHALL be reused
+- **AND** `enrollment_status` SHALL become `On (automatic)`
+- **AND** the group tag SHALL be retained
+
+#### Scenario: The Windows MDM DevDetail link reuses the pending host
+
+- **GIVEN** a pending Autopilot host with serial S
+- **WHEN** the Windows MDM session reports serial S via DevDetail
+- **THEN** the enrollment SHALL link to that host
+- **AND** the host SHALL be `enrolled = 1` with `installed_from_dep = 1`
+- **AND** the pending marker SHALL NOT be cleared
+
+#### Scenario: osquery ingest does not reset a reconciled host
+
+- **GIVEN** a reconciled Autopilot host
+- **WHEN** osquery detail ingest runs
+- **THEN** the host SHALL remain `enrolled = 1` with `installed_from_dep = 1`
+
+#### Scenario: A normal Windows host is never matched by serial
+
+- **GIVEN** a Windows host with no pending Autopilot record but a serial equal to another host's
+- **WHEN** it enrolls via orbit
+- **THEN** it SHALL match by UUID or osquery identifier only
+- **AND** it SHALL NOT be merged with the other host
+
+#### Scenario: A transferred pending host keeps its fleet through enrollment
+
+- **GIVEN** a pending Autopilot host that automation moved to a fleet
+- **WHEN** the device enrolls
+- **THEN** the host SHALL remain in that fleet
+- **AND** the Windows enrollment default fleet SHALL NOT override it
+
+### Requirement: The Autopilot group tag is exposed on host responses
+
+Fleet SHALL return `group_tag` on both the host list and host detail responses for hosts with an Autopilot record, and SHALL omit or empty it
+otherwise. The group tag SHALL be stored with capacity for Intune's documented maximum of 2048 characters.
+
+#### Scenario: Group tag is returned on the list endpoint
+
+- **GIVEN** a pending Autopilot host with a group tag
+- **WHEN** an admin calls `GET /hosts`
+- **THEN** the host entry SHALL include that `group_tag`
+
+#### Scenario: Group tag is returned on the detail endpoint
+
+- **GIVEN** a pending Autopilot host with a group tag
+- **WHEN** an admin calls `GET /hosts/:id`
+- **THEN** the response SHALL include that `group_tag`
+
+#### Scenario: A host with no group tag omits the field
+
+- **GIVEN** a host with no Autopilot record, or one whose tag is empty
+- **WHEN** an admin calls `GET /hosts` or `GET /hosts/:id`
+- **THEN** `group_tag` SHALL be absent or empty
+- **AND** the host details UI SHALL NOT render a Group tag row
+
+#### Scenario: A maximum-length tag round-trips without truncation
+
+- **GIVEN** an Autopilot device whose group tag is 2048 characters
+- **WHEN** the sync stores it and an admin reads the host
+- **THEN** the returned `group_tag` SHALL be all 2048 characters

--- a/openspec/changes/windows-autopilot-pending-hosts/specs/windows-autopilot-pending-hosts/spec.md
+++ b/openspec/changes/windows-autopilot-pending-hosts/specs/windows-autopilot-pending-hosts/spec.md
@@ -2,8 +2,18 @@
 
 ### Requirement: Microsoft Graph credentials are configured per Entra tenant
 
-Fleet SHALL expose `microsoft_graph_credentials` under `AppConfig.MDM`, a list whose entries each contain `tenant_id`, `client_id`, and
-`client_secret`. Fleet SHALL use each entry to obtain app-only Microsoft Graph tokens via the OAuth2 client-credentials grant against
+Fleet SHALL expose Microsoft Graph credentials through a dedicated resource, `GET` and `PUT /microsoft_graph_credentials`, whose body is a
+list whose entries each contain `tenant_id`, `client_id`, and `client_secret`. The credential SHALL NOT be a field on `AppConfig`, because
+the client secret is encrypted at rest and so cannot live in `app_config_json`; carrying it on the config would require joining the
+credentials table on every config read. This follows ABM, VPP, and certificate authorities, which all keep the credential and its
+per-instance status behind their own endpoints.
+
+`PUT` SHALL be declarative: a tenant absent from the body SHALL be deleted, and an empty list SHALL clear all stored credentials. There SHALL
+be no separate delete endpoint. `PUT` SHALL accept `dry_run`, validating and verifying without persisting.
+
+Both endpoints SHALL authorize against the app config subject, so the credential retains the permissions it had when it was a config field.
+
+Fleet SHALL use each entry to obtain app-only Microsoft Graph tokens via the OAuth2 client-credentials grant against
 `https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token` with scope `https://graph.microsoft.com/.default`.
 
 `tenant_id` and `client_id` SHALL be validated as GUIDs. The feature SHALL be Fleet Premium only.
@@ -14,21 +24,21 @@ credentials from them. A Graph `client_id` SHALL NOT be required to appear in `w
 #### Scenario: Premium instance stores a credential
 
 - **GIVEN** a Fleet Premium instance with Windows MDM enabled
-- **WHEN** an admin sends `PATCH /config` with one `mdm.microsoft_graph_credentials` entry containing valid GUIDs and a working secret
+- **WHEN** an admin sends `PUT /microsoft_graph_credentials` with one entry containing valid GUIDs and a working secret
 - **THEN** the credential SHALL be stored
 - **AND** an `added_microsoft_graph_credential` activity SHALL be recorded
 
 #### Scenario: Fleet Free rejects the write
 
 - **GIVEN** a Fleet Free instance
-- **WHEN** an admin sends `PATCH /config` with any `mdm.microsoft_graph_credentials` entry
+- **WHEN** an admin sends `PUT /microsoft_graph_credentials` with any entry
 - **THEN** the request SHALL be rejected with `ErrMissingLicense`
 
 #### Scenario: Malformed GUID is rejected
 
 - **GIVEN** a Fleet Premium instance
 - **WHEN** an admin sends a credential whose `tenant_id` is not a GUID
-- **THEN** the request SHALL be rejected with a validation error naming `mdm.microsoft_graph_credentials`
+- **THEN** the request SHALL be rejected with a validation error naming `microsoft_graph_credentials`
 
 #### Scenario: Credential is verified before it is stored
 
@@ -36,6 +46,20 @@ credentials from them. A Graph `client_id` SHALL NOT be required to appear in `w
 - **WHEN** Fleet cannot obtain a token or cannot list a first page with it
 - **THEN** the request SHALL be rejected with an invalid-argument error
 - **AND** no credential SHALL be stored
+
+#### Scenario: An absent tenant is deleted
+
+- **GIVEN** a stored credential for one tenant
+- **WHEN** an admin sends `PUT /microsoft_graph_credentials` with an empty list
+- **THEN** the credential SHALL be deleted
+- **AND** a `deleted_microsoft_graph_credential` activity SHALL be recorded
+
+#### Scenario: A dry run validates without persisting
+
+- **GIVEN** a Fleet Premium instance with no stored credential
+- **WHEN** an admin sends a valid entry with `dry_run` set
+- **THEN** the credential SHALL be verified against Microsoft Graph
+- **AND** nothing SHALL be stored
 
 ### Requirement: At most one credential per tenant
 
@@ -46,13 +70,13 @@ identical data while doubling API calls and making per-tenant failure reporting 
 #### Scenario: Duplicate tenant is rejected
 
 - **GIVEN** a Fleet Premium instance
-- **WHEN** an admin sends `mdm.microsoft_graph_credentials` containing two entries with the same `tenant_id` and different `client_id` values
+- **WHEN** an admin sends two entries with the same `tenant_id` and different `client_id` values
 - **THEN** the request SHALL be rejected with a validation error
 - **AND** neither entry SHALL be stored
 
 ### Requirement: At most one credential is accepted in this release
 
-Fleet SHALL reject a configuration containing more than one `microsoft_graph_credentials` entry. The field SHALL remain a list so that
+Fleet SHALL reject a request containing more than one `microsoft_graph_credentials` entry. The body SHALL remain a list so that
 raising this cap later requires only a validation change, with no rename, no scalar-to-list type change, no API break, and no migration.
 Storage, the sync loop, per-credential failure handling, and `host_autopilot_devices.tenant_id` SHALL all be implemented for the multi-entry
 case regardless of the cap.
@@ -60,7 +84,7 @@ case regardless of the cap.
 #### Scenario: A second credential is rejected
 
 - **GIVEN** a Fleet Premium instance
-- **WHEN** an admin sends `mdm.microsoft_graph_credentials` containing two entries with different `tenant_id` values
+- **WHEN** an admin sends two entries with different `tenant_id` values
 - **THEN** the request SHALL be rejected with a validation error explaining that only one credential is supported
 - **AND** neither entry SHALL be stored
 
@@ -75,21 +99,32 @@ case regardless of the cap.
 
 Fleet SHALL store each `client_secret` encrypted at rest in a dedicated table rather than in `app_config_json` and rather than in
 `mdm_config_assets`. Fleet SHALL require a configured server private key before accepting a new secret. Fleet SHALL replace every
-`client_secret` with the masked value on read.
+`client_secret` with the masked value on read, and the read path SHALL NOT decrypt, so that a missing or rotated server private key cannot
+fail it.
+
+Storing a credential SHALL reset that credential's sync state: its invalid flag, its last sync error, and its last sync time. A credential is
+verified before it is stored and an unchanged credential is not written at all, so a stored credential has just been proven good and any
+recorded failure describes the credential it replaced.
 
 #### Scenario: Secret is masked on read
 
 - **GIVEN** a stored credential
-- **WHEN** an admin calls `GET /config`
+- **WHEN** an admin calls `GET /microsoft_graph_credentials`
 - **THEN** the entry's `client_secret` SHALL be `********`
 - **AND** the plaintext secret SHALL NOT appear anywhere in the response
 
 #### Scenario: Resending the mask preserves the stored secret
 
 - **GIVEN** a stored credential
-- **WHEN** an admin sends `PATCH /config` with that entry's `client_secret` set to `********` and another field changed
+- **WHEN** an admin re-sends that entry with `client_secret` set to `********`
 - **THEN** the stored secret SHALL be unchanged
 - **AND** no `edited_microsoft_graph_credential` activity SHALL be recorded for the secret alone
+
+#### Scenario: Rotating a credential clears its recorded failure
+
+- **GIVEN** a stored credential marked invalid with a recorded sync error
+- **WHEN** an admin stores a working replacement secret
+- **THEN** the invalid flag, the last sync error, and the last sync time SHALL all be cleared
 
 #### Scenario: Missing server private key blocks a new secret
 
@@ -100,18 +135,30 @@ Fleet SHALL store each `client_secret` encrypted at rest in a dedicated table ra
 ### Requirement: Graph pagination terminates and yields each device once
 
 Fleet SHALL NOT implement pagination as an unguarded "follow `@odata.nextLink` until absent" loop. Fleet SHALL deduplicate results by the
-Autopilot device `id`, SHALL terminate when `@odata.nextLink` equals the URL just requested or when a page yields no previously unseen `id`,
-and SHALL apply a hard page cap. Fleet SHALL NOT assume that serial numbers are unique or that results are ordered by anything it relies on.
+Autopilot device `id`, SHALL detect a non-advancing cursor when `@odata.nextLink` equals the URL just requested or when a page yields no
+previously unseen `id`, and SHALL apply a hard page cap. Fleet SHALL NOT assume that serial numbers are unique or that results are ordered by
+anything it relies on.
+
+A non-advancing cursor SHALL cause the listing to **return an error**, not to return the devices gathered so far. A partial list is
+indistinguishable from a shrunken tenant to the caller, and the sync deletes hosts that are absent from the list it is given, so returning
+early would silently delete pending hosts. Failing leaves the tenant's existing hosts untouched. Callers SHALL NOT substitute a partial list
+when this error occurs.
+
+Fleet SHALL request an explicit page size rather than relying on the service default, so that the number of round trips is a property of
+Fleet's own code rather than of an undocumented default.
+
+Fleet SHALL reject an `@odata.nextLink` that does not resolve to the Microsoft Graph origin, and SHALL NOT issue a request to it. The OAuth2
+transport attaches the bearer token to whatever URL is requested, so a next link pointing elsewhere would disclose the token to that host.
 
 This is because the Autopilot device identities collection paginates with an inclusive `$skiptoken=LastSerialNumber='<serial>'` cursor ordered
 by serial number. Serial numbers are not unique, and the service can return an `@odata.nextLink` identical to the URL just requested.
 
-#### Scenario: A self-referential nextLink terminates the walk
+#### Scenario: A self-referential nextLink fails the walk
 
 - **GIVEN** Graph returns a page whose `@odata.nextLink` is identical to the URL just requested
 - **WHEN** the client walks pages
-- **THEN** the walk SHALL terminate
-- **AND** the client SHALL log that a pagination guard fired
+- **THEN** the walk SHALL return an error identifying the non-advancing cursor
+- **AND** it SHALL NOT return a partial device list
 
 #### Scenario: A device repeated across page boundaries is returned once
 
@@ -126,6 +173,13 @@ by serial number. Serial numbers are not unique, and the service can return an `
 - **WHEN** the client walks pages
 - **THEN** the walk SHALL terminate
 - **AND** every distinct device `id` SHALL appear in the result
+
+#### Scenario: A nextLink on another origin is refused
+
+- **GIVEN** Graph returns an `@odata.nextLink` pointing at a host other than the Graph origin
+- **WHEN** the client walks pages
+- **THEN** the walk SHALL return an error
+- **AND** no request carrying the access token SHALL be sent to that host
 
 ### Requirement: The sync reconciles Autopilot devices into pending Windows hosts
 
@@ -186,6 +240,10 @@ authorization failure (missing permission or admin consent) from a transient fai
 rather than a single error-code string, because Graph returns different codes for the same 403 cause. In no failure case SHALL Fleet remove
 that tenant's pending hosts.
 
+A listing that fails, including one that fails because the pagination cursor stopped advancing, SHALL abort that tenant's reconciliation.
+Fleet SHALL NOT treat a failed or partial listing as an authoritative device list, because reconciliation deletes hosts absent from the list
+it is given.
+
 #### Scenario: An expired secret is reported as a credential problem
 
 - **GIVEN** a credential whose client secret has expired
@@ -200,6 +258,13 @@ that tenant's pending hosts.
 - **THEN** the credential's last sync error SHALL identify it as a permission or consent problem
 - **AND** detection SHALL NOT depend on which error code string Graph returned
 
+#### Scenario: A non-advancing cursor does not delete hosts
+
+- **GIVEN** a tenant with existing pending Autopilot hosts
+- **WHEN** the listing fails because the pagination cursor stopped advancing
+- **THEN** that tenant's reconciliation SHALL be abandoned
+- **AND** none of its pending hosts SHALL be removed
+
 #### Scenario: A transient failure is retried quietly
 
 - **GIVEN** Graph responds 429 with `Retry-After`
@@ -212,6 +277,15 @@ that tenant's pending hosts.
 Fleet SHALL mark a credential invalid when a sync fails to authenticate or is denied authorization, and SHALL surface that state as an
 app-wide banner, matching the existing invalid-ABM-token treatment. The flag SHALL be cleared on the next successful sync. Fleet SHALL NOT
 mark a credential invalid for transient failures, so that a Microsoft outage does not raise a credential alarm.
+
+Fleet SHALL expose the banner state as `mdm.microsoft_graph_credential_invalid` on the app config: a single server-computed aggregate, true
+when any stored credential is invalid and false once all are healthy. It lives on the app config rather than behind the credentials endpoint
+because the banner is app-wide and the frontend already loads the config on every page. It SHALL NOT be settable through `PATCH /config`; a
+value supplied there SHALL be ignored rather than rejected, so that `fleetctl get config` output remains valid input.
+
+The aggregate SHALL be stored rather than computed on read, so that a config read never queries the credentials table. Consequently Fleet
+SHALL recompute it on every path that can change a credential's health: storing, editing, or deleting a credential, and the sync marking a
+credential invalid or clearing it. Only the per-credential invalid flag SHALL feed the aggregate; a recorded sync error SHALL NOT.
 
 The banner SHALL only render for Fleet Premium, consistent with every other MDM banner in the single-banner priority chain.
 
@@ -236,12 +310,25 @@ The banner SHALL only render for Fleet Premium, consistent with every other MDM 
 - **THEN** the credential SHALL NOT be marked invalid
 - **AND** no banner SHALL be shown
 
-#### Scenario: Fixing the credential clears the banner
+#### Scenario: Fixing the credential clears the banner immediately
 
 - **GIVEN** a credential marked invalid
-- **WHEN** an admin stores a working secret and the next sync succeeds
+- **WHEN** an admin stores a working secret
 - **THEN** the credential SHALL no longer be marked invalid
-- **AND** the banner SHALL no longer be shown
+- **AND** `mdm.microsoft_graph_credential_invalid` SHALL become false without waiting for the next sync
+
+#### Scenario: Deleting the last unhealthy credential clears the banner
+
+- **GIVEN** a single stored credential marked invalid
+- **WHEN** an admin deletes it
+- **THEN** `mdm.microsoft_graph_credential_invalid` SHALL become false
+
+#### Scenario: A client cannot raise the banner
+
+- **GIVEN** a Fleet instance with no unhealthy credential
+- **WHEN** an admin sends `PATCH /config` setting `mdm.microsoft_graph_credential_invalid` to true
+- **THEN** the stored value SHALL remain false
+- **AND** the request SHALL NOT be rejected
 
 ### Requirement: A pending Autopilot host is reused when the device enrolls
 

--- a/openspec/changes/windows-autopilot-pending-hosts/tasks.md
+++ b/openspec/changes/windows-autopilot-pending-hosts/tasks.md
@@ -7,44 +7,63 @@ the sub-issue as currently written and need the issue updated first.
 
 ### Schema
 
-- [ ] Migration `AddMicrosoftGraphCredentials`: table per `design.md` section 1, `UNIQUE (tenant_id)`, secret as encrypted `blob`.
-- [ ] Migration `AddHostAutopilotDevices`: keyed on `host_id`, FK cascade to `hosts`, index on `hardware_serial`.
-      **[spec change]** `group_tag` is `varchar(2048)` not `varchar(255)` (Intune max is 2048; test data already exceeds 255). Do not index
-      it. Add an `autopilot_device_id` column for the Graph `id` alongside `azure_ad_device_id`.
-- [ ] `_test.go` for each (`applyUpToPrev` → seed → `applyNext` → verify). `Down` is a no-op. Run `make dump-test-schema`.
-      **[spec change]** No app-config seed migration is needed: the credential lives in its own table, not in `app_config_json`.
+- [x] One migration `AddWindowsAutopilotTables` creating both tables. **[spec change]** A single migration, and **no `_test.go`** (per
+      Victor; note this contradicts `.claude/rules/fleet-database.md`). `Down` is a no-op. Run `make dump-test-schema`.
+- [x] `mdm_microsoft_graph_credentials`: `UNIQUE (tenant_id)`, secret as encrypted `blob`, `datetime(6)` timestamps.
+      **[spec change]** `mdm_` prefix, matching `mdm_apple_*`.
+- [x] `host_autopilot_devices`: keyed on `host_id`, index on `hardware_serial`, `datetime(6)` timestamps.
+      **[spec change]** `group_tag` is `varchar(2048)` not `varchar(255)`, unindexed, with a "do not narrow" comment (strict mode makes an
+      over-long tag an error that fails the whole batch, not a truncation). `autopilot_device_id` holds the Graph `id`. The AAD column is
+      named `entra_device_id`; only the Graph JSON tag keeps the legacy `azureActiveDirectoryDeviceId` spelling.
+- [x] **[spec change] No foreign key to `hosts`.** Fleet forbids them and CI enforces it. Add `host_autopilot_devices` to `hostRefs`
+      (`server/datastore/mysql/hosts.go`) **and seed it in `testHostsDeleteHosts`**, which asserts every `hostRefs` table has a row before
+      the delete and breaks otherwise.
 
 ### Types and datastore
 
-- [ ] `fleet.MicrosoftGraphCredential` and `fleet.HostAutopilotDevice` types. Add `MicrosoftGraphCredentials` to `AppConfig.MDM` and extend
-      `AppConfig.Clone()` (`server/fleet/app.go`).
-- [ ] Datastore methods for credential CRUD (list, upsert by tenant, delete, record sync result) and for
-      `UpsertHostAutopilotDevice` / `ListHostAutopilotDevices(tenantID)` / `GetHostAutopilotDevice(hostID)`.
-- [ ] `make generate-mock`, then `go test ./server/service/` (uninitialized mocks crash sibling tests).
+- [x] `fleet.MicrosoftGraphCredential` and `fleet.HostAutopilotDevice` types. **[spec change]** The Graph wire type
+      `WindowsAutopilotDevice` lives in `server/microsoft/msgraph`, not `server/fleet`.
+- [x] **[spec change]** No `MicrosoftGraphCredentials` field on `AppConfig.MDM`. Instead add `MDM.MicrosoftGraphCredentialInvalid`, a stored
+      server-computed banner aggregate, with a `PATCH /config` carry-over so a client cannot set it.
+- [x] Datastore methods for credential CRUD, plus a metadata read that decrypts nothing for the read path and the banner rollup.
+- [x] **[spec change]** Device writes are batched only: `BatchUpsertHostAutopilotDevices` and `BatchSoftDeleteHostAutopilotDevices`, 1000 per
+      statement via `common_mysql.BatchProcessSimple`. No single-row variant, since a 100k-device tenant would mean 100k round trips.
+      `BatchSoftDeleteHostAutopilotDevices` is new: nothing could previously write `deleted_at` even though both reads filter on it.
+- [x] **[spec change]** `RecordMicrosoftGraphSyncResult` takes `*string`, not `error`; the datastore stores a message, it does not classify.
+- [x] **[spec change]** `UpsertMicrosoftGraphCredential` resets all sync state, since the service verifies before storing.
+- [x] `make generate-mock`, then `go test ./server/service/` (uninitialized mocks crash sibling tests).
 
 ### Graph client
 
 - [ ] `server/microsoft/msgraph`: client-credentials auth, `fleethttp` transport, `ctxerr` wrapping, factory mirroring
       `GoogleWorkspaceDirectoryFactory`.
 - [ ] `VerifyCredential` (one token mint plus one page) and `ListWindowsAutopilotDevices`.
-- [ ] **[spec change]** Pagination guard, not naive `nextLink` following. Deduplicate by Autopilot `id`; stop when `nextLink` equals the URL
-      just requested, when a page yields no unseen `id`, or on a hard page cap; do not set a small `$top`.
-- [ ] Tests against `httptest` covering: token acquisition; `@odata.nextLink` paging; **a `nextLink` identical to the request URL terminates
-      instead of looping**; **a boundary device repeated across pages is emitted once**; `groupTag`/`serialNumber` parsing; a 2048-character
-      tag round-trips; 401 vs 403 vs 429 produce distinguishable wrapped errors.
+- [x] **[spec change]** Pagination guard, not naive `nextLink` following. Deduplicate by Autopilot `id`; detect a non-advancing cursor when
+      `nextLink` equals the URL just requested or a page yields no unseen `id`; hard page cap as a backstop.
+- [x] **[spec change]** A non-advancing cursor **returns an error**, it does not stop gracefully: a truncated list would make the sync delete
+      the missing hosts. Pin `$top=1000` rather than using the service default.
+- [x] **[spec change]** Reject a `nextLink` off the Graph origin without sending the token to it.
+- [x] Tests against `httptest` covering: token acquisition; `@odata.nextLink` paging; **a `nextLink` identical to the request URL errors
+      instead of looping**; **a boundary device repeated across pages is emitted once**; a foreign-origin next link is refused;
+      `groupTag`/`serialNumber` parsing; 401 vs 403 vs 429 produce distinguishable wrapped errors.
 
-### Config, premium, activities, GitOps
+### API, premium, activities, GitOps
 
-- [ ] Validate GUID format for `tenant_id`/`client_id`; reject duplicate `tenant_id` in the incoming list with a 422.
-- [ ] **Cap the list at one entry**, rejecting a second with a 422. Enforce in exactly one place (config validation) so lifting the cap is a
-      one-line change. Everything below is still built for the multi-entry case.
-- [ ] Premium gate with `ErrMissingLicense`; require `server.PrivateKey` when a new secret is supplied.
-- [ ] Extend `AppConfig.Obfuscate()` to mask each `client_secret`; preserve the stored secret when the masked value is sent back.
-- [ ] Call `VerifyCredential` on create/change; reject with `NewInvalidArgumentError` on failure.
-- [ ] Activities `added_`/`edited_`/`deleted_microsoft_graph_credential` via the activity service.
-- [ ] GitOps: `controls.microsoft_graph_credentials` applies through the AppConfig path; `generate-gitops` emits the list with a secret
-      placeholder plus a `SecretWarning` per entry, following `apple_account_provisioning.oauth_idp_client_secret`
-      (`cmd/fleetctl/fleetctl/generate_gitops.go:1470-1487`). Round-trip test.
+- [x] **[spec change]** Dedicated endpoints, not a config field: `GET /microsoft_graph_credentials` and a declarative
+      `PUT /microsoft_graph_credentials` accepting `dry_run`. Authorize both against the app config subject to preserve permissions.
+- [x] Validate GUID format for `tenant_id`/`client_id`; reject duplicate `tenant_id` in the incoming list with a 422.
+- [x] **Cap the list at one entry**, rejecting a second with a 422, enforced in exactly one place. Everything else is built for multi-entry.
+- [x] Premium gate with `ErrMissingLicense`; require `server.PrivateKey` when a new secret is supplied.
+- [x] Mask `client_secret` on the read endpoint; preserve the stored secret when the mask is sent back.
+- [x] Call `VerifyCredential` on create/change only, so re-applying an identical config makes no network call.
+- [x] Activities `added_`/`edited_`/`deleted_microsoft_graph_credential` via the activity service.
+- [x] **[spec change]** Recompute the banner aggregate after every credential write and delete.
+- [x] Authorization test covering the role matrix, including an anonymous caller (every authenticated role can read the config, so that is
+      the only case distinguishing "authorized" from "authorization skipped").
+- [x] GitOps: the YAML key `controls.microsoft_graph_credentials` is unchanged, but `DoGitOps` now lifts it out of controls and applies it
+      through the endpoint, following `certificate_authorities`. The `spec.Group` field is a **pointer** so `fleetctl apply` leaves it nil
+      and cannot delete a credential. The decode helper is not named `...Spec`. `generate-gitops` reads from the endpoint and emits a secret
+      placeholder plus a `SecretWarning` per entry.
 
 ## Track 2: sync and reconciliation (#48850)
 
@@ -56,7 +75,13 @@ the sub-issue as currently written and need the issue updated first.
       devices is a legitimate steady state.
 - [ ] Persist `last_synced_at` / `last_sync_error` per credential, distinguishing auth failure, permission failure, and transient errors.
 - [ ] Set `credential_invalid` on auth (`AADSTS*`, 401) or authorization (403) failure; clear it on the next successful sync; never set it on
-      429/5xx. Mirror `SetABMTokenInvalidForOrgName` (`server/datastore/mysql/apple_mdm.go:6608`), keyed on `tenant_id`.
+      429/5xx. Use `msgraph.Error`'s `IsAuthError` / `IsPermissionError` / `IsTransient` rather than re-classifying.
+- [ ] **[spec change] Recompute the banner aggregate after every `SetMicrosoftGraphCredentialInvalid` call.** `mdm.microsoft_graph_credential_invalid`
+      is stored, so it is only as fresh as its last recomputation. Track 1 covers the credential write paths and cannot cover the sync. Miss
+      this and the table is correct, the credentials endpoint is correct, and the banner simply never appears — nothing errors. Test both
+      directions end to end.
+- [ ] **[spec change]** Do not swallow the Graph client's non-advancing-cursor error or substitute a partial list; that error exists so the
+      sync never deletes against a truncated list.
 - [ ] **[spec change]** Skip devices whose serial satisfies `fleet.IsPlaceholderHardwareSerial`, with a logged count. Such a host could never
       reconcile at enrollment.
 
@@ -65,7 +90,12 @@ the sub-issue as currently written and need the issue updated first.
 - [ ] `IngestWindowsAutopilotDevices` per `design.md` section 4. Critically: resolve the **Windows** MDM solution URL
       (`/api/mdm/microsoft`), not `ResolveAppleMDMURL`, or `mdm_id` points at the Apple Fleet solution.
 - [ ] Builtin label membership ("All Hosts", "MS Windows") so pending hosts appear before osquery runs.
-- [ ] Removal: hard-delete still-pending hosts; soft-delete only the `host_autopilot_devices` row for already-enrolled devices.
+- [ ] Removal: hard-delete still-pending hosts; soft-delete only the `host_autopilot_devices` row for already-enrolled devices, via
+      `BatchSoftDeleteHostAutopilotDevices`.
+- [ ] **[spec change]** Use the batch datastore methods; there is no single-row variant. Diff against stored state and pass only changed
+      devices. Note MySQL already suppresses the write for an unchanged row, so the diff saves wire bytes and row locks rather than write
+      volume.
+- [ ] **[spec change]** No FK cleanup to add: `host_autopilot_devices` is cleaned up through `hostRefs`, not a cascade.
 - [ ] `installed_from_dep` audit documented, covering the three Windows `host_mdm` writers and the `mobile_device_management_solutions` row.
 
 ### Reconciliation
@@ -90,10 +120,14 @@ the sub-issue as currently written and need the issue updated first.
 
 - [ ] Single-credential form (tenant ID, client ID, client secret) on the Microsoft Entra section. The cap at one keeps #48851's original
       three-inputs-and-Save scope intact; no list UI is needed for this release.
-- [ ] **App-wide banner** when the credential is invalid. Add a component alongside `AppleBMTokenInvalidMessage`, wire the flag through
-      `App.tsx` the way `hasInvalidABMToken` is wired (`frontend/components/App/App.tsx:150`), and insert it into the premium branch of the
-      single-banner priority chain in `frontend/components/MainContent/MainContent.tsx:59-83`. **Blocked on Figma from Marko** for wording and
-      priority position.
+- [ ] **[spec change]** Read and write the credential through `GET`/`PUT /microsoft_graph_credentials`, not `configAPI`. It is not in
+      `AppContext`, so the section fetches on mount and refetches after save. `PUT` is declarative: clearing the credential means sending an
+      empty list, not calling a delete endpoint.
+- [ ] **App-wide banner** when the credential is invalid. Add a component alongside `AppleBMTokenInvalidMessage` and insert it into the
+      premium branch of the single-banner priority chain in `frontend/components/MainContent/MainContent.tsx:59-83`. **Blocked on Figma from
+      Marko** for wording and priority position.
+      **[spec change]** No client-side aggregation is needed: read the boolean `config.mdm.microsoft_graph_credential_invalid`, which
+      `AppContext` already carries. This is simpler than `hasInvalidABMToken`, which scans a token list.
 - [ ] Premium gating: keep `<PremiumFeatureMessage />` when `!isPremiumTier`.
 - [ ] Wrap controls in `GitOpsModeTooltipWrapper` so they are read-only under `gitops_mode_enabled`.
 - [ ] Masked secret placeholder; only send a new secret when the admin changes it.
@@ -101,23 +135,40 @@ the sub-issue as currently written and need the issue updated first.
 - [ ] "Group tag" read-only row on host details, shown only when present. Add `group_tag` to `frontend/interfaces/host.ts`.
 - [ ] Copy for labels, help text (link to the app-registration guide and the `DeviceManagementServiceConfig.Read.All` permission), and the
       save success/error flashes. New strings, no Figma; get approved before merge.
-- [ ] `yarn test` for premium gating, GitOps mode, config round trip, and the group tag row. `make lint-js` passes.
+- [ ] `yarn test` for premium gating, GitOps mode, the credential round trip through the endpoint, the banner reading the config
+      boolean, and the group tag row. `make lint-js` passes.
 
 ## Track 4: docs and QA (#48852)
 
 - [ ] **[spec change]** Rewrite the merged docs PRs [#50518](https://github.com/fleetdm/fleet/pull/50518) and
       [#50519](https://github.com/fleetdm/fleet/pull/50519): scalar `windows_entra_graph_api_token` becomes the
       `microsoft_graph_credentials` list. Needs product sign-off first.
+- [ ] **[spec change]** The REST API doc covers two **endpoints**, not config fields: `GET` and `PUT /microsoft_graph_credentials`. Call out
+      explicitly that `PUT` is declarative (absent tenant is deleted, empty list clears, no `DELETE` endpoint), that the credential is
+      verified against Graph before being stored, and that the masked secret round-trips.
+- [ ] **[spec change]** Also document `mdm.microsoft_graph_credential_invalid` on `GET /config` as read-only and server-computed: a value
+      sent to `PATCH /config` is ignored rather than rejected, so `fleetctl get config` output stays valid input.
+- [ ] **[spec change]** The YAML doc notes that `controls.microsoft_graph_credentials` is declarative (removing the key deletes the stored
+      credential) and that only `fleetctl gitops` manages it, never `fleetctl apply`.
 - [ ] Audit log doc: the three new activities.
 - [ ] Feature guide: app registration, `DeviceManagementServiceConfig.Read.All` with admin consent, Intune license requirement, and the
       transfer-on-pending automation. **Document the dedicated Graph-only app as the recommended setup** (verified least-privilege: 403 on
       `/users`, `/devices`, and `/deviceManagement/managedDevices`).
 - [ ] **[spec change]** Document that Autopilot pending hosts do not receive the Windows enrollment default fleet, and why.
 - [ ] Document client-secret expiry (180 days default, 24 months max) and that Fleet surfaces expiry as a sync failure after the fact.
+- [ ] **[spec change]** Document that the banner can lag a real failure by up to one sync interval, and that saving a working credential
+      clears it immediately.
+- [ ] **[spec change]** Document that rotating a credential resets its sync history: `last_synced_at`, `last_sync_error`, and the invalid
+      flag all clear, so the UI reads "never synced" until the next cycle. That is accurate, since the prior sync described a different
+      credential.
 - [ ] Usage statistics: no changes. State explicitly in the PR.
 - [ ] End-to-end QA on a real tenant: pending hosts appear with group tags; enrollment transitions Pending → On (automatic) with no duplicate
       host and the tag retained; removal from Autopilot removes the pending host; premium blocked on both frontend and backend; GitOps
       generate-then-apply round-trips the credentials.
+- [ ] **[spec change]** Credential-lifecycle QA, each covering an implementation decision: rotate the secret in Entra without updating Fleet
+      (banner raises, then clears on update); remove the API permission (reported as a permission problem, distinct copy); delete the
+      credential while pending hosts exist (document whatever happens); `fleetctl gitops` with the key removed deletes the credential while
+      `fleetctl apply` with an unrelated file leaves it untouched.
 - [ ] Confirmation comment on #43481.
 
 ## Blocked on product

--- a/openspec/changes/windows-autopilot-pending-hosts/tasks.md
+++ b/openspec/changes/windows-autopilot-pending-hosts/tasks.md
@@ -36,6 +36,8 @@ the sub-issue as currently written and need the issue updated first.
 ### Config, premium, activities, GitOps
 
 - [ ] Validate GUID format for `tenant_id`/`client_id`; reject duplicate `tenant_id` in the incoming list with a 422.
+- [ ] **Cap the list at one entry**, rejecting a second with a 422. Enforce in exactly one place (config validation) so lifting the cap is a
+      one-line change. Everything below is still built for the multi-entry case.
 - [ ] Premium gate with `ErrMissingLicense`; require `server.PrivateKey` when a new secret is supplied.
 - [ ] Extend `AppConfig.Obfuscate()` to mask each `client_secret`; preserve the stored secret when the masked value is sent back.
 - [ ] Call `VerifyCredential` on create/change; reject with `NewInvalidArgumentError` on failure.
@@ -53,6 +55,8 @@ the sub-issue as currently written and need the issue updated first.
 - [ ] Empty-response guard so a zero-device response never deletes that tenant's pending hosts. Log at most once per credential, since zero
       devices is a legitimate steady state.
 - [ ] Persist `last_synced_at` / `last_sync_error` per credential, distinguishing auth failure, permission failure, and transient errors.
+- [ ] Set `credential_invalid` on auth (`AADSTS*`, 401) or authorization (403) failure; clear it on the next successful sync; never set it on
+      429/5xx. Mirror `SetABMTokenInvalidForOrgName` (`server/datastore/mysql/apple_mdm.go:6608`), keyed on `tenant_id`.
 - [ ] **[spec change]** Skip devices whose serial satisfies `fleet.IsPlaceholderHardwareSerial`, with a logged count. Such a host could never
       reconcile at enrollment.
 
@@ -84,8 +88,12 @@ the sub-issue as currently written and need the issue updated first.
 
 ## Track 3: frontend (#48851)
 
-- [ ] **[spec change]** Credential **list** UI (add/delete rows) on the Microsoft Entra section, not three standalone inputs. Mirror the
-      existing tenant and client ID list widgets on `WindowsAutomaticEnrollmentPage`. **Blocked on Figma from Marko.**
+- [ ] Single-credential form (tenant ID, client ID, client secret) on the Microsoft Entra section. The cap at one keeps #48851's original
+      three-inputs-and-Save scope intact; no list UI is needed for this release.
+- [ ] **App-wide banner** when the credential is invalid. Add a component alongside `AppleBMTokenInvalidMessage`, wire the flag through
+      `App.tsx` the way `hasInvalidABMToken` is wired (`frontend/components/App/App.tsx:150`), and insert it into the premium branch of the
+      single-banner priority chain in `frontend/components/MainContent/MainContent.tsx:59-83`. **Blocked on Figma from Marko** for wording and
+      priority position.
 - [ ] Premium gating: keep `<PremiumFeatureMessage />` when `!isPremiumTier`.
 - [ ] Wrap controls in `GitOpsModeTooltipWrapper` so they are read-only under `gitops_mode_enabled`.
 - [ ] Masked secret placeholder; only send a new secret when the admin changes it.
@@ -114,6 +122,8 @@ the sub-issue as currently written and need the issue updated first.
 
 ## Blocked on product
 
-- [ ] Figma for the multi-tenant credential list UI.
-- [ ] Sign-off on the scalar → list config change and the rename, since both merged docs PRs must be rewritten.
+- [ ] Figma for the invalid-credential banner: wording, and where it sits in the single-banner priority order.
+- [ ] Sign-off on the scalar → list config change (capped at one) and the rename, since both merged docs PRs must be rewritten.
 - [ ] Clarify "multiple tags" in the story's edge cases. Graph returns `groupTag` as a single string.
+- [ ] Before the one-credential cap is ever lifted: decide how the banner names the offending credential. ABM uses a human-readable
+      `org_name`; a Graph credential has only a tenant GUID.

--- a/openspec/changes/windows-autopilot-pending-hosts/tasks.md
+++ b/openspec/changes/windows-autopilot-pending-hosts/tasks.md
@@ -1,0 +1,119 @@
+# Tasks: Windows Autopilot pending hosts
+
+Grouped to match the four sub-issues on [#43481](https://github.com/fleetdm/fleet/issues/43481). Items marked **[spec change]** deviate from
+the sub-issue as currently written and need the issue updated first.
+
+## Track 1: foundation (#48849)
+
+### Schema
+
+- [ ] Migration `AddMicrosoftGraphCredentials`: table per `design.md` section 1, `UNIQUE (tenant_id)`, secret as encrypted `blob`.
+- [ ] Migration `AddHostAutopilotDevices`: keyed on `host_id`, FK cascade to `hosts`, index on `hardware_serial`.
+      **[spec change]** `group_tag` is `varchar(2048)` not `varchar(255)` (Intune max is 2048; test data already exceeds 255). Do not index
+      it. Add an `autopilot_device_id` column for the Graph `id` alongside `azure_ad_device_id`.
+- [ ] `_test.go` for each (`applyUpToPrev` → seed → `applyNext` → verify). `Down` is a no-op. Run `make dump-test-schema`.
+      **[spec change]** No app-config seed migration is needed: the credential lives in its own table, not in `app_config_json`.
+
+### Types and datastore
+
+- [ ] `fleet.MicrosoftGraphCredential` and `fleet.HostAutopilotDevice` types. Add `MicrosoftGraphCredentials` to `AppConfig.MDM` and extend
+      `AppConfig.Clone()` (`server/fleet/app.go`).
+- [ ] Datastore methods for credential CRUD (list, upsert by tenant, delete, record sync result) and for
+      `UpsertHostAutopilotDevice` / `ListHostAutopilotDevices(tenantID)` / `GetHostAutopilotDevice(hostID)`.
+- [ ] `make generate-mock`, then `go test ./server/service/` (uninitialized mocks crash sibling tests).
+
+### Graph client
+
+- [ ] `server/microsoft/msgraph`: client-credentials auth, `fleethttp` transport, `ctxerr` wrapping, factory mirroring
+      `GoogleWorkspaceDirectoryFactory`.
+- [ ] `VerifyCredential` (one token mint plus one page) and `ListWindowsAutopilotDevices`.
+- [ ] **[spec change]** Pagination guard, not naive `nextLink` following. Deduplicate by Autopilot `id`; stop when `nextLink` equals the URL
+      just requested, when a page yields no unseen `id`, or on a hard page cap; do not set a small `$top`.
+- [ ] Tests against `httptest` covering: token acquisition; `@odata.nextLink` paging; **a `nextLink` identical to the request URL terminates
+      instead of looping**; **a boundary device repeated across pages is emitted once**; `groupTag`/`serialNumber` parsing; a 2048-character
+      tag round-trips; 401 vs 403 vs 429 produce distinguishable wrapped errors.
+
+### Config, premium, activities, GitOps
+
+- [ ] Validate GUID format for `tenant_id`/`client_id`; reject duplicate `tenant_id` in the incoming list with a 422.
+- [ ] Premium gate with `ErrMissingLicense`; require `server.PrivateKey` when a new secret is supplied.
+- [ ] Extend `AppConfig.Obfuscate()` to mask each `client_secret`; preserve the stored secret when the masked value is sent back.
+- [ ] Call `VerifyCredential` on create/change; reject with `NewInvalidArgumentError` on failure.
+- [ ] Activities `added_`/`edited_`/`deleted_microsoft_graph_credential` via the activity service.
+- [ ] GitOps: `controls.microsoft_graph_credentials` applies through the AppConfig path; `generate-gitops` emits the list with a secret
+      placeholder plus a `SecretWarning` per entry, following `apple_account_provisioning.oauth_idp_client_secret`
+      (`cmd/fleetctl/fleetctl/generate_gitops.go:1470-1487`). Round-trip test.
+
+## Track 2: sync and reconciliation (#48850)
+
+### Cron
+
+- [ ] `CronMicrosoftAutopilotSync` schedule name; `server/cron/microsoft_autopilot_cron.go`; register in `registerMDMCrons`.
+- [ ] No-op when unconfigured or not premium. Iterate credentials with **per-tenant failure isolation**.
+- [ ] Empty-response guard so a zero-device response never deletes that tenant's pending hosts. Log at most once per credential, since zero
+      devices is a legitimate steady state.
+- [ ] Persist `last_synced_at` / `last_sync_error` per credential, distinguishing auth failure, permission failure, and transient errors.
+- [ ] **[spec change]** Skip devices whose serial satisfies `fleet.IsPlaceholderHardwareSerial`, with a logged count. Such a host could never
+      reconcile at enrollment.
+
+### Pending host lifecycle
+
+- [ ] `IngestWindowsAutopilotDevices` per `design.md` section 4. Critically: resolve the **Windows** MDM solution URL
+      (`/api/mdm/microsoft`), not `ResolveAppleMDMURL`, or `mdm_id` points at the Apple Fleet solution.
+- [ ] Builtin label membership ("All Hosts", "MS Windows") so pending hosts appear before osquery runs.
+- [ ] Removal: hard-delete still-pending hosts; soft-delete only the `host_autopilot_devices` row for already-enrolled devices.
+- [ ] `installed_from_dep` audit documented, covering the three Windows `host_mdm` writers and the `mobile_device_management_solutions` row.
+
+### Reconciliation
+
+- [ ] Windows serial-match branch in `matchHostDuringEnrollment`, scoped to pending Autopilot hosts, independent of `isAppleMDMEnabled`.
+- [ ] Stop blanking the serial in `EnrollOrbit` and `HostPreviouslyOrbitEnrolled` only when a pending Autopilot host exists for it.
+- [ ] `tryLinkUnlinkedEnrollmentFromDevDetail` / `LinkWindowsHostMDMEnrollment`: set `enrolled=1` and keep `installed_from_dep=1` for a
+      pending Autopilot host, rather than clearing it via `UpdateMDMInstalledFromDEP`.
+- [ ] Verify `directIngestMDMWindows` leaves a reconciled host at `enrolled=1, installed_from_dep=1`.
+- [ ] Tests: same host `id` reused via `EnrollOrbit` with group tag retained; same via the DevDetail path; osquery ingest does not reset the
+      marker; **regression test that a Windows host with no pending Autopilot row still matches by UUID only, never by serial**.
+- [ ] **[spec change]** Test the default-fleet interaction: a pending Autopilot host is *not* moved by
+      `maybeAssignWindowsEnrollmentDefaultFleet`, because its `CreatedAt` precedes the enrollment row. Assert this deliberately so it cannot
+      regress silently.
+
+### Host responses
+
+- [ ] `group_tag` on `GET /hosts` and `GET /hosts/:id` via `LEFT JOIN host_autopilot_devices`. Omitted or empty when absent.
+- [ ] Benchmark the host-list query to confirm no latency regression.
+
+## Track 3: frontend (#48851)
+
+- [ ] **[spec change]** Credential **list** UI (add/delete rows) on the Microsoft Entra section, not three standalone inputs. Mirror the
+      existing tenant and client ID list widgets on `WindowsAutomaticEnrollmentPage`. **Blocked on Figma from Marko.**
+- [ ] Premium gating: keep `<PremiumFeatureMessage />` when `!isPremiumTier`.
+- [ ] Wrap controls in `GitOpsModeTooltipWrapper` so they are read-only under `gitops_mode_enabled`.
+- [ ] Masked secret placeholder; only send a new secret when the admin changes it.
+- [ ] Per-credential sync status and error surfaced on each row.
+- [ ] "Group tag" read-only row on host details, shown only when present. Add `group_tag` to `frontend/interfaces/host.ts`.
+- [ ] Copy for labels, help text (link to the app-registration guide and the `DeviceManagementServiceConfig.Read.All` permission), and the
+      save success/error flashes. New strings, no Figma; get approved before merge.
+- [ ] `yarn test` for premium gating, GitOps mode, config round trip, and the group tag row. `make lint-js` passes.
+
+## Track 4: docs and QA (#48852)
+
+- [ ] **[spec change]** Rewrite the merged docs PRs [#50518](https://github.com/fleetdm/fleet/pull/50518) and
+      [#50519](https://github.com/fleetdm/fleet/pull/50519): scalar `windows_entra_graph_api_token` becomes the
+      `microsoft_graph_credentials` list. Needs product sign-off first.
+- [ ] Audit log doc: the three new activities.
+- [ ] Feature guide: app registration, `DeviceManagementServiceConfig.Read.All` with admin consent, Intune license requirement, and the
+      transfer-on-pending automation. **Document the dedicated Graph-only app as the recommended setup** (verified least-privilege: 403 on
+      `/users`, `/devices`, and `/deviceManagement/managedDevices`).
+- [ ] **[spec change]** Document that Autopilot pending hosts do not receive the Windows enrollment default fleet, and why.
+- [ ] Document client-secret expiry (180 days default, 24 months max) and that Fleet surfaces expiry as a sync failure after the fact.
+- [ ] Usage statistics: no changes. State explicitly in the PR.
+- [ ] End-to-end QA on a real tenant: pending hosts appear with group tags; enrollment transitions Pending → On (automatic) with no duplicate
+      host and the tag retained; removal from Autopilot removes the pending host; premium blocked on both frontend and backend; GitOps
+      generate-then-apply round-trips the credentials.
+- [ ] Confirmation comment on #43481.
+
+## Blocked on product
+
+- [ ] Figma for the multi-tenant credential list UI.
+- [ ] Sign-off on the scalar → list config change and the rename, since both merged docs PRs must be rewritten.
+- [ ] Clarify "multiple tags" in the story's edge cases. Graph returns `groupTag` as a single string.


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #43481 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
