### PR TITLE
show user-scope icon for ios and ipados

### DIFF
--- a/changes/50687-show-user-icon-on-ios-ipados
+++ b/changes/50687-show-user-icon-on-ios-ipados
@@ -1,0 +1,1 @@
+- Fixed an issue where the user-scoped icon wasn't showing for iOS and iPadOS hosts.

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsNameCell/OSSettingsNameCell.tsx
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsNameCell/OSSettingsNameCell.tsx
@@ -19,11 +19,6 @@ const OSSettingsNameCell = ({
   scope,
   managedAccount,
 }: IOSSettingsNameCellProps) => {
-  console.log("OSSettingsNameCell rendered with props:", {
-    profileName,
-    scope,
-    managedAccount,
-  });
   return (
     <div className={baseClass}>
       <TooltipTruncatedTextCell

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsNameCell/OSSettingsNameCell.tsx
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsNameCell/OSSettingsNameCell.tsx
@@ -19,6 +19,11 @@ const OSSettingsNameCell = ({
   scope,
   managedAccount,
 }: IOSSettingsNameCellProps) => {
+  console.log("OSSettingsNameCell rendered with props:", {
+    profileName,
+    scope,
+    managedAccount,
+  });
   return (
     <div className={baseClass}>
       <TooltipTruncatedTextCell

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsTableConfig.tsx
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsTableConfig.tsx
@@ -64,16 +64,10 @@ const generateTableConfig = (
       disableSortBy: true,
       accessor: "name",
       Cell: (cellProps: ITableStringCellProps) => {
-        let scope = cellProps.row.original.scope;
-
-        if (isIPadOrIPhone(cellProps.row.original.platform)) {
-          scope = null; // Don't show user-scoped icon for iOS/iPadOS profiles, since we don't support user channels.
-        }
-
         return (
           <OSSettingsNameCell
             profileName={cellProps.cell.value}
-            scope={scope}
+            scope={cellProps.row.original.scope}
             managedAccount={cellProps.row.original.managed_local_account}
           />
         );


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #50687

<img width="549" height="236" alt="image" src="https://github.com/user-attachments/assets/a8131923-765f-4039-8728-452674fc6f3d" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where user-scoped icons were not displayed for iOS and iPadOS host profiles.
  * Profile scope information is now preserved correctly when displaying operating system settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->