### PR TITLE
Add guide: manage Fleet during a GitOps outage

### DIFF
--- a/articles/manage-fleet-during-a-gitops-outage.md
+++ b/articles/manage-fleet-during-a-gitops-outage.md
@@ -32,7 +32,7 @@ As soon as you can, commit the same change to your GitOps repository. This keeps
 
 Before you turn GitOps mode back on, confirm that a GitOps run has completed successfully with your mirrored change, either through CI or by running `fleetctl gitops` manually. Check the run's output for errors, and confirm the change is still in place in the Fleet UI.
 
-If you turn GitOps mode back on before confirming this, you lock the UI while the pipeline may still be broken, leaving you with no way to make further changes until it's fixed.
+If the run didn't succeed, leave GitOps mode off until it does. You can always turn it back on once you've confirmed the pipeline is working again.
 
 ## Turn GitOps mode back on
 

--- a/articles/manage-fleet-during-a-gitops-outage.md
+++ b/articles/manage-fleet-during-a-gitops-outage.md
@@ -28,9 +28,15 @@ As soon as you can, commit the same change to your GitOps repository. This keeps
 
 > **Note:** If CI is still down, you can commit the change to your repository now and run `fleetctl gitops` manually once you're able to, or wait until CI recovers. Either way, don't turn GitOps mode back on until the repository reflects the change.
 
+## Verify GitOps is applying successfully
+
+Before you turn GitOps mode back on, confirm that a GitOps run has completed successfully with your mirrored change, either through CI or by running `fleetctl gitops` manually. Check the run's output for errors, and confirm the change is still in place in the Fleet UI.
+
+If you turn GitOps mode back on before confirming this, you lock the UI while the pipeline may still be broken, leaving you with no way to make further changes until it's fixed.
+
 ## Turn GitOps mode back on
 
-Once your repository matches the change you made in the UI, go back to **Settings > Integrations > Change management** and turn **GitOps mode** on.
+Once you've confirmed GitOps is applying successfully, go back to **Settings > Integrations > Change management** and turn **GitOps mode** on.
 
 ## Further reading
 

--- a/articles/manage-fleet-during-a-gitops-outage.md
+++ b/articles/manage-fleet-during-a-gitops-outage.md
@@ -26,13 +26,11 @@ Make only the change required to resolve the urgent issue. Since this change isn
 
 As soon as you can, commit the same change to your GitOps repository. This keeps your repository and your live Fleet instance in sync, so the next GitOps run doesn't undo the fix you just made.
 
-> **Note:** If CI is still down, you can commit the change to your repository now and run `fleetctl gitops` manually once you're able to, or wait until CI recovers. Either way, don't turn GitOps mode back on until the repository reflects the change.
+> **Note:** If CI is still down, you can commit the change to your repository now and run `fleetctl gitops` manually once you're able to, or wait until CI recovers.
 
 ## Verify GitOps is applying successfully
 
 Before you turn GitOps mode back on, confirm that a GitOps run has completed successfully with your mirrored change, either through CI or by running `fleetctl gitops` manually. Check the run's output for errors, and confirm the change is still in place in the Fleet UI.
-
-If the run didn't succeed, leave GitOps mode off until it does. You can always turn it back on once you've confirmed the pipeline is working again.
 
 ## Turn GitOps mode back on
 

--- a/articles/manage-fleet-during-a-gitops-outage.md
+++ b/articles/manage-fleet-during-a-gitops-outage.md
@@ -1,0 +1,46 @@
+# Manage Fleet during a GitOps outage
+
+If your CI provider (like GitHub Actions) goes down, you can still make urgent changes to Fleet through the UI. This guide covers how to do that safely, and how to bring your git repository back in sync once CI is available again.
+
+## Prerequisites
+
+Check these before you start:
+
+- Fleet Premium, with [GitOps mode](https://fleetdm.com/guides/gitops-mode) enabled
+- Admin access to the Fleet UI
+
+> **Warning:** GitOps is your source of truth. Any change you make in the UI during the outage will be deleted or overwritten the next time GitOps runs, unless you also commit that change to your repository. Treat every UI change as temporary until it's mirrored in git.
+
+## Turn off GitOps mode
+
+1. Go to **Settings > Integrations > Change management**.
+2. Turn off **GitOps mode**.
+
+This unlocks the UI sections that GitOps mode normally makes read-only, so you can make the change you need.
+
+## Make the change in the Fleet UI
+
+Make only the change required to resolve the urgent issue. Since this change isn't in your repository yet, GitOps will revert it on its next run unless you also make it in git.
+
+## Mirror the change in your repository
+
+As soon as you can, commit the same change to your GitOps repository. This keeps your repository and your live Fleet instance in sync, so the next GitOps run doesn't undo the fix you just made.
+
+> **Note:** If CI is still down, you can commit the change to your repository now and run `fleetctl gitops` manually once you're able to, or wait until CI recovers. Either way, don't turn GitOps mode back on until the repository reflects the change.
+
+## Turn GitOps mode back on
+
+Once your repository matches the change you made in the UI, go back to **Settings > Integrations > Change management** and turn **GitOps mode** on.
+
+## Further reading
+
+- [GitOps mode](https://fleetdm.com/guides/gitops-mode)
+- [Preventing mistakes with GitOps](https://fleetdm.com/guides/preventing-mistakes-with-gitops)
+- [YAML file reference](https://fleetdm.com/docs/configuration/yaml-files)
+
+<meta name="articleTitle" value="Manage Fleet during a GitOps outage">
+<meta name="authorFullName" value="Kitzy">
+<meta name="authorGitHubUsername" value="kitzy">
+<meta name="publishedOn" value="2026-08-06">
+<meta name="category" value="guides">
+<meta name="description" value="What to do when your CI provider is down and you need to make an urgent change to Fleet outside of GitOps.">


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** NA

# Checklist for submitter

- [x] Docs-only change (new guide article); no code, tests, migrations, settings, or fleetd/orbit changes.

## Summary

Adds a new guide, `articles/manage-fleet-during-a-gitops-outage.md`, covering the business continuity workflow for making urgent changes in the Fleet UI when a CI provider (e.g. GitHub Actions) is down, and how to reconcile the GitOps repo afterward so the next automated run doesn't revert the fix.