### PR TITLE
Fix Genesys Cloud FMA: winget dropped x86, ship x64 MSI

### DIFF
--- a/ee/maintained-apps/inputs/winget/genesys-cloud.json
+++ b/ee/maintained-apps/inputs/winget/genesys-cloud.json
@@ -3,7 +3,7 @@
   "slug": "genesys-cloud/windows",
   "package_identifier": "Genesys.GenesysCloud",
   "unique_identifier": "GenesysCloud",
-  "installer_arch": "x86",
+  "installer_arch": "x64",
   "installer_type": "msi",
   "installer_scope": "machine",
   "default_categories": ["Communication"]

--- a/ee/maintained-apps/outputs/genesys-cloud/windows.json
+++ b/ee/maintained-apps/outputs/genesys-cloud/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.51.916.0",
+      "version": "2.53.923.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'GenesysCloud' AND publisher = 'Genesys Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'GenesysCloud' AND publisher = 'Genesys Inc.' AND version_compare(version, '2.51.916.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'GenesysCloud' AND publisher = 'Genesys Inc.' AND version_compare(version, '2.53.923.0') < 0);"
       },
-      "installer_url": "https://app.mypurecloud.com/directory-windows/build-assets/2.51.916-248/genesys-cloud-windows-2.51.916-x86.msi",
+      "installer_url": "https://app.mypurecloud.com/directory-windows/build-assets/2.53.923-257/genesys-cloud-windows-2.53.923-x64.msi",
       "install_script_ref": "22e48c46",
       "uninstall_script_ref": "3d56a699",
-      "sha256": "4c63a4b793684eb1d061ee46b82ca80442bd61f5118ea90cea86f3c1164ac3bb",
+      "sha256": "6129d0038ef441325c486e603c0977d2654891ede3982963f3c9ff6c754be079",
       "default_categories": [
         "Communication"
       ],


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] QA'd all new/changed functionality manually

# Details

The nightly maintained-apps ingestion job panicked with `failed to find installer for app` on Genesys Cloud:

```
{"time":"2026-08-07T03:17:22.787715966Z","level":"INFO","msg":"ingesting winget app","name":"Genesys Cloud"}
panic: ingesting winget app: failed to find installer for app
```

## Why

Genesys.GenesysCloud **2.53.923.0** stopped publishing x86 installers upstream. Previous versions (e.g. 2.51.916.0) shipped two x86 installers (a burn `.exe` and a wix `.msi`); the latest manifest ships only a single **x64** wix MSI. Our input pinned `installer_arch: "x86"`, so the ingester filtered out the only available installer and panicked.

## What changed

- `ee/maintained-apps/inputs/winget/genesys-cloud.json`: `installer_arch` `x86` → `x64`
- `ee/maintained-apps/outputs/genesys-cloud/windows.json`: regenerated with `go run ./cmd/maintained-apps -slug genesys-cloud/windows` — version 2.51.916.0 → 2.53.923.0, installer URL now the x64 MSI, sha256 matches the winget manifest's `InstallerSha256`

## Notes for reviewers

- Exists/patched queries are unchanged (still keyed on ARP `name = 'GenesysCloud'`, `publisher = 'Genesys Inc.'`), and install/uninstall script refs are identical since it's still a machine-scope MSI — detection and remediation carry over for existing installs.
- The MSI `UpgradeCode` is unchanged upstream (`{A0E8C487-C337-441C-83AF-90364DA4B793}`), so the x64 MSI upgrades existing x86 installs in place (ProductCode is new, install dir moves from `ProgramFiles(x86)` to `ProgramFiles`).
- The new manifest declares a `Microsoft.VCRedist.2015+.x64` dependency (the old x86 MSI declared the x86 variant). Fleet doesn't resolve winget dependencies; the FMA validator run on this PR will confirm whether the installer tolerates its absence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Genesys Cloud Windows package to version 2.53.923.0.
  * Switched the Windows installer configuration to the x64 version.
  * Updated installer download verification metadata for the new release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->