### PR TITLE
Self-service: "Install all" respects the search query

### DIFF
--- a/changes/50528-self-service-install-all-respects-search
+++ b/changes/50528-self-service-install-all-respects-search
@@ -1,0 +1,1 @@
+- Fixed the self-service "Install all" button so its count and install target scope to the current search query. Previously, typing a search would filter the visible list while "Install all" still counted (and queued) every item in the selected category, including software the search had filtered out.

--- a/docs/Contributing/reference/api-for-contributors.md
+++ b/docs/Contributing/reference/api-for-contributors.md
@@ -3764,10 +3764,6 @@ For VPP `InstallApplication` command results, `results_metadata` may include:
 
 Queues an install for every self-service software title available to the device that isn't already installed.
 
-If `category_id` is provided, only titles assigned to that [self-service category](https://fleetdm.com/docs/rest-api/rest-api#self-service-categories) on the device's fleet are queued.
-
-If `query` is provided, only titles whose name matches are queued (same match semantics as the self-service list endpoint).
-
 `POST /api/v1/fleet/device/{token}/software/install_all`
 
 ##### Parameters
@@ -3775,8 +3771,8 @@ If `query` is provided, only titles whose name matches are queued (same match se
 | Name        | Type    | In    | Description                                                                                                                                          |
 | ----------- | ------- | ----- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
 | token       | string  | path  | **Required**. The device's authentication token.                                                                                                     |
-| category_id | integer | query | Restrict the install to a single self-service category. Must reference a category that exists on the device's fleet. If omitted, all categories are included. |
-| query       | string  | query | Restrict the install to titles whose name matches. Uses the same match semantics as the self-service list endpoint. If omitted, no name filter is applied. |
+| category_id | integer | query | Restrict to a single [self-service category](https://fleetdm.com/docs/rest-api/rest-api#self-service-categories). Must exist on the device's fleet. If omitted, all categories are included. |
+| query       | string  | query | Restrict to titles whose name matches (same semantics as the self-service list endpoint). If omitted, no name filter is applied. |
 
 ##### Example
 

--- a/docs/Contributing/reference/api-for-contributors.md
+++ b/docs/Contributing/reference/api-for-contributors.md
@@ -3766,6 +3766,8 @@ Queues an install for every self-service software title available to the device 
 
 If `category_id` is provided, only titles assigned to that [self-service category](https://fleetdm.com/docs/rest-api/rest-api#self-service-categories) on the device's fleet are queued.
 
+If `query` is provided, only titles whose name matches are queued (same match semantics as the self-service list endpoint).
+
 `POST /api/v1/fleet/device/{token}/software/install_all`
 
 ##### Parameters
@@ -3774,10 +3776,11 @@ If `category_id` is provided, only titles assigned to that [self-service categor
 | ----------- | ------- | ----- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
 | token       | string  | path  | **Required**. The device's authentication token.                                                                                                     |
 | category_id | integer | query | Restrict the install to a single self-service category. Must reference a category that exists on the device's fleet. If omitted, all categories are included. |
+| query       | string  | query | Restrict the install to titles whose name matches. Uses the same match semantics as the self-service list endpoint. If omitted, no name filter is applied. |
 
 ##### Example
 
-`POST /api/v1/fleet/device/22aada07-dc73-41f2-8452-c0987543fd29/software/install_all?category_id=12`
+`POST /api/v1/fleet/device/22aada07-dc73-41f2-8452-c0987543fd29/software/install_all?category_id=12&query=zoom`
 
 ##### Default response
 

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -4233,9 +4233,9 @@ func (svc *Service) SelfServiceInstallSoftwareTitle(ctx context.Context, host *f
 	return err
 }
 
-func (svc *Service) SelfServiceInstallAllSoftwareTitles(ctx context.Context, host *fleet.Host, categoryID *uint) error {
+func (svc *Service) SelfServiceInstallAllSoftwareTitles(ctx context.Context, host *fleet.Host, categoryID *uint, matchQuery string) error {
 	// get available self-service titles sorted by name
-	titles, categoryName, err := svc.ds.GetSoftwareTitlesForInstallAll(ctx, host, categoryID)
+	titles, categoryName, err := svc.ds.GetSoftwareTitlesForInstallAll(ctx, host, categoryID, matchQuery)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "get software titles for install all")
 	}

--- a/ee/server/service/software_installers_test.go
+++ b/ee/server/service/software_installers_test.go
@@ -2553,7 +2553,7 @@ func TestSelfServiceInstallAllSoftwareTitles(t *testing.T) {
 
 	setup := func(fail failures) (*Service, *strings.Builder) {
 		ds := new(mock.Store)
-		ds.GetSoftwareTitlesForInstallAllFunc = func(ctx context.Context, host *fleet.Host, categoryID *uint) ([]*fleet.HostSoftwareWithInstaller, *string, error) {
+		ds.GetSoftwareTitlesForInstallAllFunc = func(ctx context.Context, host *fleet.Host, categoryID *uint, matchQuery string) ([]*fleet.HostSoftwareWithInstaller, *string, error) {
 			if fail.getTitles != nil {
 				return nil, nil, fail.getTitles
 			}
@@ -2593,13 +2593,13 @@ func TestSelfServiceInstallAllSoftwareTitles(t *testing.T) {
 
 	t.Run("returns the error when listing titles fails", func(t *testing.T) {
 		svc, _ := setup(failures{getTitles: errors.New("boom")})
-		err := svc.SelfServiceInstallAllSoftwareTitles(ctx, host, nil)
+		err := svc.SelfServiceInstallAllSoftwareTitles(ctx, host, nil, "")
 		require.ErrorContains(t, err, "get software titles for install all")
 	})
 
 	t.Run("logs per-title failures and continues instead of aborting the batch", func(t *testing.T) {
 		svc, logs := setup(failures{installTitle: errors.New("lookup failed")})
-		err := svc.SelfServiceInstallAllSoftwareTitles(ctx, host, nil)
+		err := svc.SelfServiceInstallAllSoftwareTitles(ctx, host, nil, "")
 		require.NoError(t, err) // a per-title failure is logged, not returned
 		// both titles were attempted (the loop continued past the first failure) and logged
 		require.Contains(t, logs.String(), "title_id=10")
@@ -2608,8 +2608,20 @@ func TestSelfServiceInstallAllSoftwareTitles(t *testing.T) {
 
 	t.Run("returns the error when the roll-up activity fails", func(t *testing.T) {
 		svc, _ := setup(failures{newActivity: errors.New("activity failed")})
-		err := svc.SelfServiceInstallAllSoftwareTitles(ctx, host, nil)
+		err := svc.SelfServiceInstallAllSoftwareTitles(ctx, host, nil, "")
 		require.ErrorContains(t, err, "creating installed all self-service software activity")
+	})
+
+	t.Run("passes the match query through to the datastore", func(t *testing.T) {
+		var seenMatch string
+		ds := new(mock.Store)
+		ds.GetSoftwareTitlesForInstallAllFunc = func(ctx context.Context, host *fleet.Host, categoryID *uint, matchQuery string) ([]*fleet.HostSoftwareWithInstaller, *string, error) {
+			seenMatch = matchQuery
+			return nil, nil, nil
+		}
+		svc, _ := newTestServiceWithMock(t, ds)
+		require.NoError(t, svc.SelfServiceInstallAllSoftwareTitles(ctx, host, nil, "zoom"))
+		require.Equal(t, "zoom", seenMatch)
 	})
 }
 

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceCard/SelfServiceCard.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceCard/SelfServiceCard.tests.tsx
@@ -455,6 +455,73 @@ describe("SelfServiceCard", () => {
     expect(installAllUrl).toContain("category_id=1");
   });
 
+  // Normalization must happen once at the SelfServiceCard level so the
+  // desktop table filter, count, and outgoing API call all share identical
+  // semantics. Whitespace-padded or whitespace-only queries would otherwise
+  // drift between react-table (raw) and the helper/API (trimmed).
+  it.each([
+    ["trailing/leading spaces", "  fox  ", "query=fox"],
+    ["whitespace-only", "   ", null],
+    ["empty string", "", null],
+  ])(
+    "normalizes queryParams.query (%s) into a single semantics for the POST",
+    async (_, urlQuery, expectedFragment) => {
+      let installAllUrl = "";
+      mockServer.use(
+        http.post(
+          baseUrl("/device/:token/software/install_all"),
+          ({ request }) => {
+            installAllUrl = request.url;
+            return new HttpResponse(null, { status: 202 });
+          }
+        )
+      );
+      mockServer.use(
+        listDeviceSelfServiceCategoriesHandler([{ id: 1, name: "🌎 Browsers" }])
+      );
+      const browserPackage = createMockHostSoftwarePackage({
+        categories: (["🌎 Browsers"] as string[]) as SoftwareCategory[],
+      });
+      const props = createTestProps({
+        queryParams: {
+          ...DEFAULT_QUERY_PARAMS,
+          category_id: 1,
+          query: urlQuery,
+        },
+        enhancedSoftware: [
+          {
+            ...createMockDeviceSoftware({
+              name: "Firefox",
+              software_package: browserPackage,
+            }),
+            ui_status: "uninstalled",
+          },
+        ],
+      });
+      const render = createCustomRenderer({ withBackendMock: true });
+      const user = userEvent.setup();
+
+      render(<SelfServiceCard {...props} />);
+
+      await user.click(
+        await screen.findByRole("button", { name: /Install all \(1\)/i })
+      );
+      await user.click(
+        await screen.findByRole("button", { name: /^Install all$/i })
+      );
+
+      await waitFor(() => {
+        expect(installAllUrl).toContain("category_id=1");
+      });
+      if (expectedFragment) {
+        expect(installAllUrl).toContain(expectedFragment);
+        expect(installAllUrl).not.toContain("query=%20");
+      } else {
+        expect(installAllUrl).not.toContain("query=");
+      }
+    }
+  );
+
   it("posts to install_all and fires onInstallAllSuccess when the confirm modal is submitted", async () => {
     let installAllCalled = false;
     let installAllUrl = "";

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceCard/SelfServiceCard.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceCard/SelfServiceCard.tests.tsx
@@ -404,6 +404,101 @@ describe("SelfServiceCard", () => {
     expect(button).toBeEnabled();
   });
 
+  // #50528: with a search query active, the install-all count and the
+  // request sent to the BE must match the visible (filtered) subset — not
+  // the entire category.
+  it("scopes the install-all count to the search query when both a category and a query are active", async () => {
+    mockServer.use(
+      listDeviceSelfServiceCategoriesHandler([{ id: 1, name: "🌎 Browsers" }])
+    );
+    const browserPackage = createMockHostSoftwarePackage({
+      categories: (["🌎 Browsers"] as string[]) as SoftwareCategory[],
+    });
+    const props = createTestProps({
+      queryParams: { ...DEFAULT_QUERY_PARAMS, category_id: 1, query: "fox" },
+      enhancedSoftware: [
+        {
+          ...createMockDeviceSoftware({
+            name: "Firefox",
+            software_package: browserPackage,
+          }),
+          ui_status: "uninstalled",
+        },
+        {
+          ...createMockDeviceSoftware({
+            name: "Google Chrome",
+            software_package: browserPackage,
+          }),
+          ui_status: "uninstalled",
+        },
+        {
+          ...createMockDeviceSoftware({
+            name: "Opera",
+            software_package: browserPackage,
+          }),
+          ui_status: "uninstalled",
+        },
+      ],
+    });
+    const render = createCustomRenderer({ withBackendMock: true });
+
+    render(<SelfServiceCard {...props} />);
+
+    // Only Firefox matches "fox".
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Install all \(1\)/i })
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("forwards the search query to install_all so the request matches the visible subset", async () => {
+    let installAllUrl = "";
+    mockServer.use(
+      http.post(
+        baseUrl("/device/:token/software/install_all"),
+        ({ request }) => {
+          installAllUrl = request.url;
+          return new HttpResponse(null, { status: 202 });
+        }
+      )
+    );
+    mockServer.use(
+      listDeviceSelfServiceCategoriesHandler([{ id: 1, name: "🌎 Browsers" }])
+    );
+    const browserPackage = createMockHostSoftwarePackage({
+      categories: (["🌎 Browsers"] as string[]) as SoftwareCategory[],
+    });
+    const props = createTestProps({
+      queryParams: { ...DEFAULT_QUERY_PARAMS, category_id: 1, query: "fox" },
+      enhancedSoftware: [
+        {
+          ...createMockDeviceSoftware({
+            name: "Firefox",
+            software_package: browserPackage,
+          }),
+          ui_status: "uninstalled",
+        },
+      ],
+    });
+    const render = createCustomRenderer({ withBackendMock: true });
+    const user = userEvent.setup();
+
+    render(<SelfServiceCard {...props} />);
+
+    await user.click(
+      await screen.findByRole("button", { name: /Install all \(1\)/i })
+    );
+    await user.click(
+      await screen.findByRole("button", { name: /^Install all$/i })
+    );
+
+    await waitFor(() => {
+      expect(installAllUrl).toContain("query=fox");
+    });
+    expect(installAllUrl).toContain("category_id=1");
+  });
+
   it("posts to install_all and fires onInstallAllSuccess when the confirm modal is submitted", async () => {
     let installAllCalled = false;
     let installAllUrl = "";

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceCard/SelfServiceCard.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceCard/SelfServiceCard.tests.tsx
@@ -404,54 +404,10 @@ describe("SelfServiceCard", () => {
     expect(button).toBeEnabled();
   });
 
-  // #50528: with a search query active, the install-all count and the
-  // request sent to the BE must match the visible (filtered) subset — not
-  // the entire category.
-  it("scopes the install-all count to the search query when both a category and a query are active", async () => {
-    mockServer.use(
-      listDeviceSelfServiceCategoriesHandler([{ id: 1, name: "🌎 Browsers" }])
-    );
-    const browserPackage = createMockHostSoftwarePackage({
-      categories: (["🌎 Browsers"] as string[]) as SoftwareCategory[],
-    });
-    const props = createTestProps({
-      queryParams: { ...DEFAULT_QUERY_PARAMS, category_id: 1, query: "fox" },
-      enhancedSoftware: [
-        {
-          ...createMockDeviceSoftware({
-            name: "Firefox",
-            software_package: browserPackage,
-          }),
-          ui_status: "uninstalled",
-        },
-        {
-          ...createMockDeviceSoftware({
-            name: "Google Chrome",
-            software_package: browserPackage,
-          }),
-          ui_status: "uninstalled",
-        },
-        {
-          ...createMockDeviceSoftware({
-            name: "Opera",
-            software_package: browserPackage,
-          }),
-          ui_status: "uninstalled",
-        },
-      ],
-    });
-    const render = createCustomRenderer({ withBackendMock: true });
-
-    render(<SelfServiceCard {...props} />);
-
-    // Only Firefox matches "fox".
-    await waitFor(() => {
-      expect(
-        screen.getByRole("button", { name: /Install all \(1\)/i })
-      ).toBeInTheDocument();
-    });
-  });
-
+  // With a search query active, the install-all count and the request sent to
+  // the BE must both match the visible (filtered) subset. The count math is
+  // covered at the helper level in helpers.tests.ts; here we only need to
+  // assert the count *renders* correctly and the query lands on the POST.
   it("forwards the search query to install_all so the request matches the visible subset", async () => {
     let installAllUrl = "";
     mockServer.use(

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceCard/SelfServiceCard.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceCard/SelfServiceCard.tsx
@@ -113,10 +113,9 @@ const SelfServiceCard = ({
     [enhancedSoftware, visibleCategories, queryParams.category_id]
   );
 
-  // #50528: the install-all button count and target must match what's on
-  // screen. Layer the search filter on top of the category filter so
-  // `uninstalledCount` and the request sent to install_all both reflect the
-  // filtered subset.
+  // The install-all button count and target must match what's on screen. Layer
+  // the search filter on top of the category filter so `uninstalledCount` and
+  // the request sent to install_all both reflect the filtered subset.
   const softwareInSelectedCategoryMatchingQuery = useMemo(
     () => filterSoftwareByQuery(softwareInSelectedCategory, queryParams.query),
     [softwareInSelectedCategory, queryParams.query]

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceCard/SelfServiceCard.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceCard/SelfServiceCard.tsx
@@ -24,6 +24,7 @@ import {
   countUninstalledForInstallAll,
   filterCategoriesWithSoftware,
   filterSoftwareByCustomCategory,
+  filterSoftwareByQuery,
   hasInProgressInstallAllItems,
 } from "../helpers";
 
@@ -112,14 +113,24 @@ const SelfServiceCard = ({
     [enhancedSoftware, visibleCategories, queryParams.category_id]
   );
 
+  // #50528: the install-all button count and target must match what's on
+  // screen. Layer the search filter on top of the category filter so
+  // `uninstalledCount` and the request sent to install_all both reflect the
+  // filtered subset.
+  const softwareInSelectedCategoryMatchingQuery = useMemo(
+    () => filterSoftwareByQuery(softwareInSelectedCategory, queryParams.query),
+    [softwareInSelectedCategory, queryParams.query]
+  );
+
   const uninstalledCount = useMemo(
-    () => countUninstalledForInstallAll(softwareInSelectedCategory),
-    [softwareInSelectedCategory]
+    () =>
+      countUninstalledForInstallAll(softwareInSelectedCategoryMatchingQuery),
+    [softwareInSelectedCategoryMatchingQuery]
   );
 
   const hasInProgress = useMemo(
-    () => hasInProgressInstallAllItems(softwareInSelectedCategory),
-    [softwareInSelectedCategory]
+    () => hasInProgressInstallAllItems(softwareInSelectedCategoryMatchingQuery),
+    [softwareInSelectedCategoryMatchingQuery]
   );
 
   const onClientSidePaginationChange = useCallback(
@@ -243,11 +254,7 @@ const SelfServiceCard = ({
 
   // Search query filter required for mobile view only ( desktop view has filter built into TableContainer)
   const filteredSoftware = isMobileView
-    ? softwareInSelectedCategory.filter((software) => {
-        const query = queryParams.query?.toLowerCase().trim() ?? "";
-        if (!query) return true;
-        return software.name.toLowerCase().includes(query);
-      })
+    ? softwareInSelectedCategoryMatchingQuery
     : softwareInSelectedCategory;
 
   // The button is shown on desktop ONLY when a specific category is selected
@@ -262,6 +269,7 @@ const SelfServiceCard = ({
         hasInProgressInCategory={hasInProgress}
         deviceToken={deviceToken}
         categoryId={queryParams.category_id}
+        query={queryParams.query}
         onSuccess={() => onInstallAllSuccess?.()}
       />
     ) : null;

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceCard/SelfServiceCard.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceCard/SelfServiceCard.tsx
@@ -113,12 +113,19 @@ const SelfServiceCard = ({
     [enhancedSoftware, visibleCategories, queryParams.category_id]
   );
 
+  // Trim the URL-supplied search once here so the desktop table filter, mobile
+  // list, install-all count, and install-all POST all share identical
+  // semantics. Without this, a deep-linked or trailing-space query like
+  // `?query=%20fox%20` would leave react-table matching the raw value while
+  // the helper/API used the trimmed one, contradicting the on-screen count.
+  const normalizedQuery = queryParams.query?.trim() ?? "";
+
   // The install-all button count and target must match what's on screen. Layer
   // the search filter on top of the category filter so `uninstalledCount` and
   // the request sent to install_all both reflect the filtered subset.
   const softwareInSelectedCategoryMatchingQuery = useMemo(
-    () => filterSoftwareByQuery(softwareInSelectedCategory, queryParams.query),
-    [softwareInSelectedCategory, queryParams.query]
+    () => filterSoftwareByQuery(softwareInSelectedCategory, normalizedQuery),
+    [softwareInSelectedCategory, normalizedQuery]
   );
 
   const uninstalledCount = useMemo(
@@ -268,7 +275,7 @@ const SelfServiceCard = ({
         hasInProgressInCategory={hasInProgress}
         deviceToken={deviceToken}
         categoryId={queryParams.category_id}
-        query={queryParams.query}
+        query={normalizedQuery}
         onSuccess={() => onInstallAllSuccess?.()}
       />
     ) : null;
@@ -325,7 +332,7 @@ const SelfServiceCard = ({
         <SelfServiceTable
           baseClass={baseClass}
           contactUrl={contactUrl}
-          queryParams={queryParams}
+          queryParams={{ ...queryParams, query: normalizedQuery }}
           enhancedSoftware={filteredSoftware}
           selfServiceData={selfServiceData}
           tableConfig={tableConfig}

--- a/frontend/pages/hosts/details/cards/Software/SelfService/components/InstallAllInCategoryButton/InstallAllInCategoryButton.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/components/InstallAllInCategoryButton/InstallAllInCategoryButton.tests.tsx
@@ -193,38 +193,37 @@ describe("InstallAllInCategoryButton", () => {
     expect(requestedUrl).toContain("category_id=1");
   });
 
-  it("omits the query param when the search query is empty or whitespace-only", async () => {
-    // Whitespace-only would otherwise reach the BE as `LIKE '% %'` and return
-    // zero results, contradicting the on-screen count.
-    for (const emptyish of ["", "   "]) {
-      let requestedUrl = "";
-      mockServer.use(
-        http.post(
-          baseUrl("/device/:token/software/install_all"),
-          ({ request }) => {
-            requestedUrl = request.url;
-            return new HttpResponse(null, { status: 202 });
-          }
-        )
-      );
-      const render = createCustomRenderer({ withBackendMock: true });
-      const user = userEvent.setup();
-      const { unmount } = render(
-        <InstallAllInCategoryButton {...baseProps} query={emptyish} />
-      );
+  // Whitespace-only queries don't filter the visible list, so they must also
+  // be dropped from the outgoing request; otherwise the BE and the on-screen
+  // count would disagree.
+  it.each([
+    ["empty", ""],
+    ["whitespace-only", "   "],
+  ])("omits the query param when the search query is %s", async (_, q) => {
+    let requestedUrl = "";
+    mockServer.use(
+      http.post(
+        baseUrl("/device/:token/software/install_all"),
+        ({ request }) => {
+          requestedUrl = request.url;
+          return new HttpResponse(null, { status: 202 });
+        }
+      )
+    );
+    const render = createCustomRenderer({ withBackendMock: true });
+    const user = userEvent.setup();
+    render(<InstallAllInCategoryButton {...baseProps} query={q} />);
 
-      await user.click(
-        screen.getByRole("button", { name: /Install all \(3\)/i })
-      );
-      await user.click(
-        await screen.findByRole("button", { name: /^Install all$/i })
-      );
+    await user.click(
+      screen.getByRole("button", { name: /Install all \(3\)/i })
+    );
+    await user.click(
+      await screen.findByRole("button", { name: /^Install all$/i })
+    );
 
-      await waitFor(() => {
-        expect(requestedUrl).not.toContain("query=");
-      });
-      unmount();
-    }
+    await waitFor(() => {
+      expect(requestedUrl).not.toContain("query=");
+    });
   });
 
   it("trims whitespace on the outgoing query param", async () => {

--- a/frontend/pages/hosts/details/cards/Software/SelfService/components/InstallAllInCategoryButton/InstallAllInCategoryButton.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/components/InstallAllInCategoryButton/InstallAllInCategoryButton.tests.tsx
@@ -193,13 +193,7 @@ describe("InstallAllInCategoryButton", () => {
     expect(requestedUrl).toContain("category_id=1");
   });
 
-  // Whitespace-only queries don't filter the visible list, so they must also
-  // be dropped from the outgoing request; otherwise the BE and the on-screen
-  // count would disagree.
-  it.each([
-    ["empty", ""],
-    ["whitespace-only", "   "],
-  ])("omits the query param when the search query is %s", async (_, q) => {
+  it("omits the query param when the caller passes an empty search", async () => {
     let requestedUrl = "";
     mockServer.use(
       http.post(
@@ -212,7 +206,7 @@ describe("InstallAllInCategoryButton", () => {
     );
     const render = createCustomRenderer({ withBackendMock: true });
     const user = userEvent.setup();
-    render(<InstallAllInCategoryButton {...baseProps} query={q} />);
+    render(<InstallAllInCategoryButton {...baseProps} query="" />);
 
     await user.click(
       screen.getByRole("button", { name: /Install all \(3\)/i })
@@ -224,37 +218,6 @@ describe("InstallAllInCategoryButton", () => {
     await waitFor(() => {
       expect(requestedUrl).not.toContain("query=");
     });
-  });
-
-  it("trims whitespace on the outgoing query param", async () => {
-    // Users type "  fox " on-screen; the visible filter trims before matching,
-    // so the outgoing query must trim too — otherwise the BE runs
-    // `LIKE '%  fox %'` and queues zero while the count says otherwise.
-    let requestedUrl = "";
-    mockServer.use(
-      http.post(
-        baseUrl("/device/:token/software/install_all"),
-        ({ request }) => {
-          requestedUrl = request.url;
-          return new HttpResponse(null, { status: 202 });
-        }
-      )
-    );
-    const render = createCustomRenderer({ withBackendMock: true });
-    const user = userEvent.setup();
-    render(<InstallAllInCategoryButton {...baseProps} query="  fox  " />);
-
-    await user.click(
-      screen.getByRole("button", { name: /Install all \(3\)/i })
-    );
-    await user.click(
-      await screen.findByRole("button", { name: /^Install all$/i })
-    );
-
-    await waitFor(() => {
-      expect(requestedUrl).toContain("query=fox");
-    });
-    expect(requestedUrl).not.toContain("query=%20");
   });
 
   it("omits category_id when categoryId is undefined ('All' selected)", async () => {

--- a/frontend/pages/hosts/details/cards/Software/SelfService/components/InstallAllInCategoryButton/InstallAllInCategoryButton.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/components/InstallAllInCategoryButton/InstallAllInCategoryButton.tests.tsx
@@ -163,8 +163,8 @@ describe("InstallAllInCategoryButton", () => {
     expect(requestedUrl).toContain("category_id=1");
   });
 
-  // #50528: when a search query is active, install_all must scope to the
-  // visible subset, not the entire category.
+  // When a search query is active, install_all must scope to the visible
+  // subset, not the entire category.
   it("forwards the query param on the POST when a search query is active", async () => {
     let requestedUrl = "";
     mockServer.use(
@@ -193,7 +193,44 @@ describe("InstallAllInCategoryButton", () => {
     expect(requestedUrl).toContain("category_id=1");
   });
 
-  it("omits the query param when the search query is empty", async () => {
+  it("omits the query param when the search query is empty or whitespace-only", async () => {
+    // Whitespace-only would otherwise reach the BE as `LIKE '% %'` and return
+    // zero results, contradicting the on-screen count.
+    for (const emptyish of ["", "   "]) {
+      let requestedUrl = "";
+      mockServer.use(
+        http.post(
+          baseUrl("/device/:token/software/install_all"),
+          ({ request }) => {
+            requestedUrl = request.url;
+            return new HttpResponse(null, { status: 202 });
+          }
+        )
+      );
+      const render = createCustomRenderer({ withBackendMock: true });
+      const user = userEvent.setup();
+      const { unmount } = render(
+        <InstallAllInCategoryButton {...baseProps} query={emptyish} />
+      );
+
+      await user.click(
+        screen.getByRole("button", { name: /Install all \(3\)/i })
+      );
+      await user.click(
+        await screen.findByRole("button", { name: /^Install all$/i })
+      );
+
+      await waitFor(() => {
+        expect(requestedUrl).not.toContain("query=");
+      });
+      unmount();
+    }
+  });
+
+  it("trims whitespace on the outgoing query param", async () => {
+    // Users type "  fox " on-screen; the visible filter trims before matching,
+    // so the outgoing query must trim too — otherwise the BE runs
+    // `LIKE '%  fox %'` and queues zero while the count says otherwise.
     let requestedUrl = "";
     mockServer.use(
       http.post(
@@ -206,7 +243,7 @@ describe("InstallAllInCategoryButton", () => {
     );
     const render = createCustomRenderer({ withBackendMock: true });
     const user = userEvent.setup();
-    render(<InstallAllInCategoryButton {...baseProps} query="" />);
+    render(<InstallAllInCategoryButton {...baseProps} query="  fox  " />);
 
     await user.click(
       screen.getByRole("button", { name: /Install all \(3\)/i })
@@ -216,8 +253,9 @@ describe("InstallAllInCategoryButton", () => {
     );
 
     await waitFor(() => {
-      expect(requestedUrl).not.toContain("query=");
+      expect(requestedUrl).toContain("query=fox");
     });
+    expect(requestedUrl).not.toContain("query=%20");
   });
 
   it("omits category_id when categoryId is undefined ('All' selected)", async () => {

--- a/frontend/pages/hosts/details/cards/Software/SelfService/components/InstallAllInCategoryButton/InstallAllInCategoryButton.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/components/InstallAllInCategoryButton/InstallAllInCategoryButton.tests.tsx
@@ -163,6 +163,63 @@ describe("InstallAllInCategoryButton", () => {
     expect(requestedUrl).toContain("category_id=1");
   });
 
+  // #50528: when a search query is active, install_all must scope to the
+  // visible subset, not the entire category.
+  it("forwards the query param on the POST when a search query is active", async () => {
+    let requestedUrl = "";
+    mockServer.use(
+      http.post(
+        baseUrl("/device/:token/software/install_all"),
+        ({ request }) => {
+          requestedUrl = request.url;
+          return new HttpResponse(null, { status: 202 });
+        }
+      )
+    );
+    const render = createCustomRenderer({ withBackendMock: true });
+    const user = userEvent.setup();
+    render(<InstallAllInCategoryButton {...baseProps} query="fox" />);
+
+    await user.click(
+      screen.getByRole("button", { name: /Install all \(3\)/i })
+    );
+    await user.click(
+      await screen.findByRole("button", { name: /^Install all$/i })
+    );
+
+    await waitFor(() => {
+      expect(requestedUrl).toContain("query=fox");
+    });
+    expect(requestedUrl).toContain("category_id=1");
+  });
+
+  it("omits the query param when the search query is empty", async () => {
+    let requestedUrl = "";
+    mockServer.use(
+      http.post(
+        baseUrl("/device/:token/software/install_all"),
+        ({ request }) => {
+          requestedUrl = request.url;
+          return new HttpResponse(null, { status: 202 });
+        }
+      )
+    );
+    const render = createCustomRenderer({ withBackendMock: true });
+    const user = userEvent.setup();
+    render(<InstallAllInCategoryButton {...baseProps} query="" />);
+
+    await user.click(
+      screen.getByRole("button", { name: /Install all \(3\)/i })
+    );
+    await user.click(
+      await screen.findByRole("button", { name: /^Install all$/i })
+    );
+
+    await waitFor(() => {
+      expect(requestedUrl).not.toContain("query=");
+    });
+  });
+
   it("omits category_id when categoryId is undefined ('All' selected)", async () => {
     let requestedUrl = "";
     mockServer.use(

--- a/frontend/pages/hosts/details/cards/Software/SelfService/components/InstallAllInCategoryButton/InstallAllInCategoryButton.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/components/InstallAllInCategoryButton/InstallAllInCategoryButton.tsx
@@ -21,6 +21,9 @@ export interface IInstallAllInCategoryButtonProps {
    * — the service omits the `category_id` query param and the BE installs
    * every uninstalled item the device user is entitled to. */
   categoryId?: number;
+  /** Current search query. When non-empty, forwarded to install_all so the
+   * request scopes to the filtered subset the user sees on screen (#50528). */
+  query?: string;
   /** Called after the install_all request resolves successfully. */
   onSuccess: () => void;
 }
@@ -30,6 +33,7 @@ const InstallAllInCategoryButton = ({
   hasInProgressInCategory,
   deviceToken,
   categoryId,
+  query,
   onSuccess,
 }: IInstallAllInCategoryButtonProps) => {
   const [showModal, setShowModal] = useState(false);
@@ -40,7 +44,8 @@ const InstallAllInCategoryButton = ({
     try {
       await deviceUserAPI.installAllSelfServiceSoftwareInCategory(
         deviceToken,
-        categoryId
+        categoryId,
+        query
       );
       setShowModal(false);
       onSuccess();
@@ -49,7 +54,7 @@ const InstallAllInCategoryButton = ({
     } finally {
       setIsSubmitting(false);
     }
-  }, [deviceToken, categoryId, onSuccess]);
+  }, [deviceToken, categoryId, query, onSuccess]);
 
   // Nothing eligible and no install_all batch running — drop the button from
   // the DOM. When a previous batch IS still running (count === 0 &&

--- a/frontend/pages/hosts/details/cards/Software/SelfService/components/InstallAllInCategoryButton/InstallAllInCategoryButton.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/components/InstallAllInCategoryButton/InstallAllInCategoryButton.tsx
@@ -22,7 +22,7 @@ export interface IInstallAllInCategoryButtonProps {
    * every uninstalled item the device user is entitled to. */
   categoryId?: number;
   /** Current search query. When non-empty, forwarded to install_all so the
-   * request scopes to the filtered subset the user sees on screen (#50528). */
+   * request scopes to the filtered subset the user sees on screen. */
   query?: string;
   /** Called after the install_all request resolves successfully. */
   onSuccess: () => void;

--- a/frontend/pages/hosts/details/cards/Software/SelfService/helpers.tests.ts
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/helpers.tests.ts
@@ -11,6 +11,7 @@ import {
   hasInProgressInstallAllItems,
   filterCategoriesWithSoftware,
   filterSoftwareByCustomCategory,
+  filterSoftwareByQuery,
 } from "./helpers";
 
 const makeItem = (
@@ -258,6 +259,40 @@ describe("filterSoftwareByCustomCategory", () => {
     expect(filterSoftwareByCustomCategory([security], categories, 1)).toEqual(
       []
     );
+  });
+});
+
+describe("filterSoftwareByQuery", () => {
+  const chrome = makeItem("uninstalled", { name: "Google Chrome" });
+  const firefox = makeItem("uninstalled", { name: "Firefox" });
+  const zoom = makeItem("uninstalled", { name: "Zoom" });
+
+  it("returns the input unchanged when the query is undefined or empty", () => {
+    expect(filterSoftwareByQuery([chrome, firefox], undefined)).toEqual([
+      chrome,
+      firefox,
+    ]);
+    expect(filterSoftwareByQuery([chrome, firefox], "")).toEqual([
+      chrome,
+      firefox,
+    ]);
+    expect(filterSoftwareByQuery([chrome, firefox], "   ")).toEqual([
+      chrome,
+      firefox,
+    ]);
+  });
+
+  it("matches case-insensitively on name (substring)", () => {
+    expect(filterSoftwareByQuery([chrome, firefox, zoom], "fox")).toEqual([
+      firefox,
+    ]);
+    expect(filterSoftwareByQuery([chrome, firefox, zoom], "OOM")).toEqual([
+      zoom,
+    ]);
+  });
+
+  it("returns [] when nothing matches", () => {
+    expect(filterSoftwareByQuery([chrome, firefox], "safari")).toEqual([]);
   });
 });
 

--- a/frontend/pages/hosts/details/cards/Software/SelfService/helpers.ts
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/helpers.ts
@@ -103,9 +103,9 @@ export const filterSoftwareByCustomCategory = (
 // Client-side name-match filter used by the desktop "Install all" count and
 // the mobile tile list. Kept in sync with `SelfServiceTable`'s
 // `searchQueryColumn="name"` (raw name, case-insensitive contains) and the
-// backend `MatchQuery` on `software_titles.name`. #50528: also drives the
-// `query` param sent to install_all so the button installs exactly what the
-// user sees on screen.
+// backend `MatchQuery` on `software_titles.name`. Also drives the `query`
+// param sent to install_all so the button installs exactly what the user
+// sees on screen.
 export const filterSoftwareByQuery = (
   software: IDeviceSoftwareWithUiStatus[],
   query: string | undefined

--- a/frontend/pages/hosts/details/cards/Software/SelfService/helpers.ts
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/helpers.ts
@@ -100,6 +100,21 @@ export const filterSoftwareByCustomCategory = (
   });
 };
 
+// Client-side name-match filter used by the desktop "Install all" count and
+// the mobile tile list. Kept in sync with `SelfServiceTable`'s
+// `searchQueryColumn="name"` (raw name, case-insensitive contains) and the
+// backend `MatchQuery` on `software_titles.name`. #50528: also drives the
+// `query` param sent to install_all so the button installs exactly what the
+// user sees on screen.
+export const filterSoftwareByQuery = (
+  software: IDeviceSoftwareWithUiStatus[],
+  query: string | undefined
+): IDeviceSoftwareWithUiStatus[] => {
+  const q = query?.toLowerCase().trim() ?? "";
+  if (!q) return software;
+  return software.filter((item) => item.name.toLowerCase().includes(q));
+};
+
 // Keeps only categories that have at least one software item. Membership is
 // resolved the same way as `filterSoftwareByCustomCategory` so the dropdown
 // stays consistent with what selecting a category shows.

--- a/frontend/services/entities/device_user.ts
+++ b/frontend/services/entities/device_user.ts
@@ -121,17 +121,13 @@ export default {
     query?: string
   ) => {
     const { DEVICE_SOFTWARE_INSTALL_ALL } = endpoints;
-    // When categoryId is undefined ("All" selected) we omit the query param;
-    // getPathWithQueryParams already drops undefined values, so the BE
-    // receives a bare POST and installs every uninstalled item.
-    // When `query` is passed through, install_all scopes to the same subset
-    // the user sees on screen. Trim + coerce empty to `undefined` so
-    // whitespace-only queries (which don't filter the visible list) don't
-    // land on the BE as `LIKE '% %'` and return no matches.
-    const trimmed = query?.trim();
+    // `getPathWithQueryParams` drops undefined values, so an omitted
+    // `categoryId` means "install all categories" and an omitted `query`
+    // means "no name filter" — matching the endpoint's optional semantics.
+    // Callers are expected to hand a trimmed query (or an empty string).
     const path = getPathWithQueryParams(
       DEVICE_SOFTWARE_INSTALL_ALL(deviceToken),
-      { category_id: categoryId, query: trimmed || undefined }
+      { category_id: categoryId, query: query || undefined }
     );
     return sendRequest("POST", path);
   },

--- a/frontend/services/entities/device_user.ts
+++ b/frontend/services/entities/device_user.ts
@@ -125,7 +125,7 @@ export default {
     // getPathWithQueryParams already drops undefined values, so the BE
     // receives a bare POST and installs every uninstalled item.
     // When `query` is passed through, install_all scopes to the same subset
-    // the user sees on screen (#50528). Trim + coerce empty to `undefined` so
+    // the user sees on screen. Trim + coerce empty to `undefined` so
     // whitespace-only queries (which don't filter the visible list) don't
     // land on the BE as `LIKE '% %'` and return no matches.
     const trimmed = query?.trim();

--- a/frontend/services/entities/device_user.ts
+++ b/frontend/services/entities/device_user.ts
@@ -125,11 +125,13 @@ export default {
     // getPathWithQueryParams already drops undefined values, so the BE
     // receives a bare POST and installs every uninstalled item.
     // When `query` is passed through, install_all scopes to the same subset
-    // the user sees on screen (#50528). Empty strings are stripped here so
-    // an unset search doesn't send `?query=` to the BE.
+    // the user sees on screen (#50528). Trim + coerce empty to `undefined` so
+    // whitespace-only queries (which don't filter the visible list) don't
+    // land on the BE as `LIKE '% %'` and return no matches.
+    const trimmed = query?.trim();
     const path = getPathWithQueryParams(
       DEVICE_SOFTWARE_INSTALL_ALL(deviceToken),
-      { category_id: categoryId, query: query || undefined }
+      { category_id: categoryId, query: trimmed || undefined }
     );
     return sendRequest("POST", path);
   },

--- a/frontend/services/entities/device_user.ts
+++ b/frontend/services/entities/device_user.ts
@@ -117,15 +117,19 @@ export default {
 
   installAllSelfServiceSoftwareInCategory: (
     deviceToken: string,
-    categoryId?: number
+    categoryId?: number,
+    query?: string
   ) => {
     const { DEVICE_SOFTWARE_INSTALL_ALL } = endpoints;
     // When categoryId is undefined ("All" selected) we omit the query param;
     // getPathWithQueryParams already drops undefined values, so the BE
     // receives a bare POST and installs every uninstalled item.
+    // When `query` is passed through, install_all scopes to the same subset
+    // the user sees on screen (#50528). Empty strings are stripped here so
+    // an unset search doesn't send `?query=` to the BE.
     const path = getPathWithQueryParams(
       DEVICE_SOFTWARE_INSTALL_ALL(deviceToken),
-      { category_id: categoryId }
+      { category_id: categoryId, query: query || undefined }
     );
     return sendRequest("POST", path);
   },

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -4635,7 +4635,7 @@ func (ds *Datastore) checkConflictingFleetMaintainedAppExists(ctx context.Contex
 	}
 }
 
-func (ds *Datastore) GetSoftwareTitlesForInstallAll(ctx context.Context, host *fleet.Host, categoryID *uint) ([]*fleet.HostSoftwareWithInstaller, *string, error) {
+func (ds *Datastore) GetSoftwareTitlesForInstallAll(ctx context.Context, host *fleet.Host, categoryID *uint, matchQuery string) ([]*fleet.HostSoftwareWithInstaller, *string, error) {
 	// get software category and check that it exists
 	var categoryName *string
 	if categoryID != nil {
@@ -4665,6 +4665,9 @@ func (ds *Datastore) GetSoftwareTitlesForInstallAll(ctx context.Context, host *f
 		IsMDMEnrolled:           mdmEnrolled,
 	}
 	opts.ListOptions.OrderKey = "name"
+	// Match the same MatchQuery semantics as the self-service list endpoint so
+	// "Install all" queues exactly what the user sees on screen (#50528).
+	opts.ListOptions.MatchQuery = matchQuery
 
 	software, _, err := ds.ListHostSoftware(ctx, host, opts)
 	if err != nil {

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -4666,8 +4666,10 @@ func (ds *Datastore) GetSoftwareTitlesForInstallAll(ctx context.Context, host *f
 	}
 	opts.ListOptions.OrderKey = "name"
 	// Match the same MatchQuery semantics as the self-service list endpoint so
-	// "Install all" queues exactly what the user sees on screen.
-	opts.ListOptions.MatchQuery = matchQuery
+	// "Install all" queues exactly what the user sees on screen. Trim so a
+	// whitespace-only query (e.g. from a direct API caller who bypassed the
+	// UI's normalization) is treated as no filter rather than as `LIKE '% %'`.
+	opts.ListOptions.MatchQuery = strings.TrimSpace(matchQuery)
 
 	software, _, err := ds.ListHostSoftware(ctx, host, opts)
 	if err != nil {

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -4666,7 +4666,7 @@ func (ds *Datastore) GetSoftwareTitlesForInstallAll(ctx context.Context, host *f
 	}
 	opts.ListOptions.OrderKey = "name"
 	// Match the same MatchQuery semantics as the self-service list endpoint so
-	// "Install all" queues exactly what the user sees on screen (#50528).
+	// "Install all" queues exactly what the user sees on screen.
 	opts.ListOptions.MatchQuery = matchQuery
 
 	software, _, err := ds.ListHostSoftware(ctx, host, opts)

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -6904,20 +6904,34 @@ func testGetSoftwareTitlesForInstallAll(t *testing.T, ds *Datastore) {
 
 	// no category: only the available titles, returned in alphabetical order by name.
 	// failed_install and failed_uninstall are included so install_all re-queues them.
-	got, categoryName, err := ds.GetSoftwareTitlesForInstallAll(ctx, host, nil)
+	got, categoryName, err := ds.GetSoftwareTitlesForInstallAll(ctx, host, nil, "")
 	require.NoError(t, err)
 	require.Nil(t, categoryName)
 	require.Equal(t, []string{"available", "failed", "failed-uninstall", "label-in", "uninstalled"}, names(got))
 
 	// scoped to a category: only the in-category title, and the name is returned
-	got, categoryName, err = ds.GetSoftwareTitlesForInstallAll(ctx, host, &cat.ID)
+	got, categoryName, err = ds.GetSoftwareTitlesForInstallAll(ctx, host, &cat.ID, "")
 	require.NoError(t, err)
 	require.NotNil(t, categoryName)
 	require.Equal(t, cat.Name, *categoryName)
 	require.Equal(t, []string{"available"}, names(got))
 
+	// scoped to a match query: the available set is narrowed to titles whose
+	// name matches (same LIKE semantics as the self-service list endpoint).
+	got, _, err = ds.GetSoftwareTitlesForInstallAll(ctx, host, nil, "failed")
+	require.NoError(t, err)
+	require.Equal(t, []string{"failed", "failed-uninstall"}, names(got))
+
+	// category + query stack: only titles that satisfy both
+	got, _, err = ds.GetSoftwareTitlesForInstallAll(ctx, host, &cat.ID, "avail")
+	require.NoError(t, err)
+	require.Equal(t, []string{"available"}, names(got))
+	got, _, err = ds.GetSoftwareTitlesForInstallAll(ctx, host, &cat.ID, "no-match")
+	require.NoError(t, err)
+	require.Empty(t, got)
+
 	// nonexistent category, or a category belonging to another team -> bad request
-	_, _, err = ds.GetSoftwareTitlesForInstallAll(ctx, host, new(uint(9_999_999)))
+	_, _, err = ds.GetSoftwareTitlesForInstallAll(ctx, host, new(uint(9_999_999)), "")
 	var bre *fleet.BadRequestError
 	require.ErrorAs(t, err, &bre)
 
@@ -6925,7 +6939,7 @@ func testGetSoftwareTitlesForInstallAll(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	teamCat, err := ds.NewSoftwareCategory(ctx, team.ID, "iall-team-cat")
 	require.NoError(t, err)
-	_, _, err = ds.GetSoftwareTitlesForInstallAll(ctx, host, &teamCat.ID)
+	_, _, err = ds.GetSoftwareTitlesForInstallAll(ctx, host, &teamCat.ID, "")
 	require.ErrorAs(t, err, &bre)
 
 	// team scoping: a team host sees only its team's self-service installer
@@ -6934,7 +6948,7 @@ func testGetSoftwareTitlesForInstallAll(t *testing.T, ds *Datastore) {
 	teamHost, err = ds.Host(ctx, teamHost.ID)
 	require.NoError(t, err)
 	newInstaller("team-app", true, nil, &team.ID, noLabels)
-	got, _, err = ds.GetSoftwareTitlesForInstallAll(ctx, teamHost, nil)
+	got, _, err = ds.GetSoftwareTitlesForInstallAll(ctx, teamHost, nil, "")
 	require.NoError(t, err)
 	require.Equal(t, []string{"team-app"}, names(got))
 
@@ -6980,7 +6994,7 @@ func testGetSoftwareTitlesForInstallAll(t *testing.T, ds *Datastore) {
 		},
 	}, &macTeam.ID)
 	require.NoError(t, err)
-	got, _, err = ds.GetSoftwareTitlesForInstallAll(ctx, macHost, nil)
+	got, _, err = ds.GetSoftwareTitlesForInstallAll(ctx, macHost, nil, "")
 	require.NoError(t, err)
 	require.Equal(t, []string{"chrome", "slack", "zoom"}, names(got))
 }

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -6922,6 +6922,12 @@ func testGetSoftwareTitlesForInstallAll(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	require.Equal(t, []string{"failed", "failed-uninstall"}, names(got))
 
+	// whitespace-only match query is treated as no filter (defense against
+	// direct API callers that bypass the UI's normalization).
+	got, _, err = ds.GetSoftwareTitlesForInstallAll(ctx, host, nil, "   ")
+	require.NoError(t, err)
+	require.Equal(t, []string{"available", "failed", "failed-uninstall", "label-in", "uninstalled"}, names(got))
+
 	// category + query stack: only titles that satisfy both
 	got, _, err = ds.GetSoftwareTitlesForInstallAll(ctx, host, &cat.ID, "avail")
 	require.NoError(t, err)

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -870,8 +870,9 @@ type Datastore interface {
 
 	// GetSoftwareTitlesForInstallAll returns the self-service software titles available
 	// to queue for the host's "install all" action, in alphabetical order, optionally
-	// scoped to a category.
-	GetSoftwareTitlesForInstallAll(ctx context.Context, host *Host, categoryID *uint) ([]*HostSoftwareWithInstaller, *string, error)
+	// scoped to a category and/or a name-match query (same semantics as the self-service
+	// list endpoint).
+	GetSoftwareTitlesForInstallAll(ctx context.Context, host *Host, categoryID *uint, matchQuery string) ([]*HostSoftwareWithInstaller, *string, error)
 
 	// AssociateMDMInstallToVerificationUUID updates the verification command UUID associated with the
 	// given install attempt (InstallApplication command).

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -815,8 +815,9 @@ type Service interface {
 
 	// SelfServiceInstallAllSoftwareTitles queues a self-service install for every available self-service software
 	// title on the host that isn't already installed. When categoryID is non-nil, only titles assigned to that
-	// self-service category on the host's fleet are queued.
-	SelfServiceInstallAllSoftwareTitles(ctx context.Context, host *Host, categoryID *uint) error
+	// self-service category on the host's fleet are queued. When matchQuery is non-empty, only titles whose name
+	// matches the query (same semantics as the self-service list endpoint) are queued.
+	SelfServiceInstallAllSoftwareTitles(ctx context.Context, host *Host, categoryID *uint, matchQuery string) error
 
 	// HasSelfServiceSoftwareInstallers returns whether the host has self-service software installers
 	HasSelfServiceSoftwareInstallers(ctx context.Context, host *Host) (bool, error)

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -620,7 +620,7 @@ type GetCategoriesForSoftwareTitlesFunc func(ctx context.Context, softwareTitleI
 
 type GetCategoriesForSoftwareInstallersFunc func(ctx context.Context, installerIDs []uint) (map[uint][]string, error)
 
-type GetSoftwareTitlesForInstallAllFunc func(ctx context.Context, host *fleet.Host, categoryID *uint) ([]*fleet.HostSoftwareWithInstaller, *string, error)
+type GetSoftwareTitlesForInstallAllFunc func(ctx context.Context, host *fleet.Host, categoryID *uint, matchQuery string) ([]*fleet.HostSoftwareWithInstaller, *string, error)
 
 type AssociateMDMInstallToVerificationUUIDFunc func(ctx context.Context, installUUID string, verifyCommandUUID string, hostUUID string) error
 
@@ -7794,11 +7794,11 @@ func (s *DataStore) GetCategoriesForSoftwareInstallers(ctx context.Context, inst
 	return s.GetCategoriesForSoftwareInstallersFunc(ctx, installerIDs)
 }
 
-func (s *DataStore) GetSoftwareTitlesForInstallAll(ctx context.Context, host *fleet.Host, categoryID *uint) ([]*fleet.HostSoftwareWithInstaller, *string, error) {
+func (s *DataStore) GetSoftwareTitlesForInstallAll(ctx context.Context, host *fleet.Host, categoryID *uint, matchQuery string) ([]*fleet.HostSoftwareWithInstaller, *string, error) {
 	s.mu.Lock()
 	s.GetSoftwareTitlesForInstallAllFuncInvoked = true
 	s.mu.Unlock()
-	return s.GetSoftwareTitlesForInstallAllFunc(ctx, host, categoryID)
+	return s.GetSoftwareTitlesForInstallAllFunc(ctx, host, categoryID, matchQuery)
 }
 
 func (s *DataStore) AssociateMDMInstallToVerificationUUID(ctx context.Context, installUUID string, verifyCommandUUID string, hostUUID string) error {

--- a/server/mock/service/service_mock.go
+++ b/server/mock/service/service_mock.go
@@ -510,7 +510,7 @@ type GetBatchSetSoftwareInstallersResultFunc func(ctx context.Context, tmName st
 
 type SelfServiceInstallSoftwareTitleFunc func(ctx context.Context, host *fleet.Host, softwareTitleID uint) error
 
-type SelfServiceInstallAllSoftwareTitlesFunc func(ctx context.Context, host *fleet.Host, categoryID *uint) error
+type SelfServiceInstallAllSoftwareTitlesFunc func(ctx context.Context, host *fleet.Host, categoryID *uint, matchQuery string) error
 
 type HasSelfServiceSoftwareInstallersFunc func(ctx context.Context, host *fleet.Host) (bool, error)
 
@@ -4164,11 +4164,11 @@ func (s *Service) SelfServiceInstallSoftwareTitle(ctx context.Context, host *fle
 	return s.SelfServiceInstallSoftwareTitleFunc(ctx, host, softwareTitleID)
 }
 
-func (s *Service) SelfServiceInstallAllSoftwareTitles(ctx context.Context, host *fleet.Host, categoryID *uint) error {
+func (s *Service) SelfServiceInstallAllSoftwareTitles(ctx context.Context, host *fleet.Host, categoryID *uint, matchQuery string) error {
 	s.mu.Lock()
 	s.SelfServiceInstallAllSoftwareTitlesFuncInvoked = true
 	s.mu.Unlock()
-	return s.SelfServiceInstallAllSoftwareTitlesFunc(ctx, host, categoryID)
+	return s.SelfServiceInstallAllSoftwareTitlesFunc(ctx, host, categoryID, matchQuery)
 }
 
 func (s *Service) HasSelfServiceSoftwareInstallers(ctx context.Context, host *fleet.Host) (bool, error) {

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -25706,9 +25706,9 @@ func (s *integrationMDMTestSuite) TestInstallAllSelfServiceSoftware() {
 		require.Equal(t, []string{"chrome", "slack", "zoom"}, macQueued)
 	})
 
-	// #50528: with a search query on the self-service page, install_all should
-	// queue only the titles whose name matches — matching what the user sees
-	// on screen.
+	// With a search query on the self-service page, install_all should queue
+	// only the titles whose name matches — matching what the user sees on
+	// screen.
 	t.Run("scopes to the query parameter when provided", func(t *testing.T) {
 		team, err := s.ds.NewTeam(ctx, &fleet.Team{Name: t.Name()})
 		require.NoError(t, err)

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -25706,6 +25706,29 @@ func (s *integrationMDMTestSuite) TestInstallAllSelfServiceSoftware() {
 		require.Equal(t, []string{"chrome", "slack", "zoom"}, macQueued)
 	})
 
+	// #50528: with a search query on the self-service page, install_all should
+	// queue only the titles whose name matches — matching what the user sees
+	// on screen.
+	t.Run("scopes to the query parameter when provided", func(t *testing.T) {
+		team, err := s.ds.NewTeam(ctx, &fleet.Team{Name: t.Name()})
+		require.NoError(t, err)
+		host := createOrbitEnrolledHost(t, "ubuntu", "ia-q", s.ds)
+		token := "ia-q-token" //nolint:gosec // G101: test value only
+		createDeviceTokenForHost(t, s.ds, host.ID, token)
+		require.NoError(t, s.ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&team.ID, []uint{host.ID})))
+
+		newInstaller("q-apple", &team.ID, true, fleet.LabelIdentsWithScope{})
+		newInstaller("q-banana", &team.ID, true, fleet.LabelIdentsWithScope{})
+		newInstaller("q-cherry", &team.ID, true, fleet.LabelIdentsWithScope{})
+
+		installAll(token, http.StatusAccepted, "query", "ban")
+		require.Equal(t, []string{"q-banana"}, queuedTitles(host.ID))
+
+		// blank query behaves like no query — all three queue
+		installAll(token, http.StatusAccepted, "query", "")
+		require.ElementsMatch(t, []string{"q-banana", "q-apple", "q-cherry"}, queuedTitles(host.ID))
+	})
+
 	t.Run("coexists with existing and incoming activities", func(t *testing.T) {
 		team, err := s.ds.NewTeam(ctx, &fleet.Team{Name: t.Name()})
 		require.NoError(t, err)

--- a/server/service/software_installers.go
+++ b/server/service/software_installers.go
@@ -979,6 +979,10 @@ func (svc *Service) SelfServiceInstallSoftwareTitle(ctx context.Context, host *f
 type fleetSelfServiceSoftwareInstallAllRequest struct {
 	Token      string `url:"token"`
 	CategoryID *uint  `query:"category_id,optional"`
+	// Query mirrors the `query` param on the self-service list endpoint. When
+	// set, only titles whose name matches are queued — so the button installs
+	// exactly what the user sees on screen (#50528).
+	Query string `query:"query,optional"`
 }
 
 func (r *fleetSelfServiceSoftwareInstallAllRequest) deviceAuthToken() string {
@@ -1000,14 +1004,14 @@ func submitSelfServiceSoftwareInstallAll(ctx context.Context, request any, svc f
 	}
 
 	req := request.(*fleetSelfServiceSoftwareInstallAllRequest)
-	if err := svc.SelfServiceInstallAllSoftwareTitles(ctx, host, req.CategoryID); err != nil {
+	if err := svc.SelfServiceInstallAllSoftwareTitles(ctx, host, req.CategoryID, req.Query); err != nil {
 		return submitSelfServiceSoftwareInstallAllResponse{Err: err}, nil
 	}
 
 	return submitSelfServiceSoftwareInstallAllResponse{}, nil
 }
 
-func (svc *Service) SelfServiceInstallAllSoftwareTitles(ctx context.Context, host *fleet.Host, categoryID *uint) error {
+func (svc *Service) SelfServiceInstallAllSoftwareTitles(ctx context.Context, host *fleet.Host, categoryID *uint, matchQuery string) error {
 	// skipauth: No authorization check needed due to implementation returning
 	// only license error.
 	svc.authz.SkipAuthorization(ctx)

--- a/server/service/software_installers.go
+++ b/server/service/software_installers.go
@@ -981,7 +981,7 @@ type fleetSelfServiceSoftwareInstallAllRequest struct {
 	CategoryID *uint  `query:"category_id,optional"`
 	// Query mirrors the `query` param on the self-service list endpoint. When
 	// set, only titles whose name matches are queued — so the button installs
-	// exactly what the user sees on screen (#50528).
+	// exactly what the user sees on screen.
 	Query string `query:"query,optional"`
 }
 


### PR DESCRIPTION
## Issue

Resolves #50528.

## Description

On the My device > Self-service page, with a category selected and a search query typed, the "Install all" button previously ignored the search: it counted (and queued) every uninstalled item in the category, including software the search had filtered out.

This PR scopes the button — count *and* install target — to the visible subset:

- **Backend:** `POST /device/{token}/software/install_all` now accepts a `query` param. It's threaded through `SelfServiceInstallAllSoftwareTitles` → `GetSoftwareTitlesForInstallAll` → `opts.ListOptions.MatchQuery` on `ListHostSoftware`, reusing the same LIKE-on-`software_titles.name` semantics as the self-service list endpoint.
- **Frontend:** new `filterSoftwareByQuery` helper layers on top of the category filter to drive `uninstalledCount` / `hasInProgress` and the value sent to install_all. Empty queries are stripped so the API isn't called with `?query=`.

`display_name` matching is deliberately out of scope — the search filter across BE list, desktop table, and mobile filter is all raw-`name`-only today, so broadening install_all alone would re-introduce a similar mismatch. Filed as a follow-up: #50750.

## Screen recording

In recording:
- (FE fix) showing that the UI is filtering out install all count to be only what's on the screen
- (BE fix) showing that the call to the API only queues up the install all for the installers shown on the screen when clicked


https://github.com/user-attachments/assets/aaae3d29-dccf-484d-910f-67ca335bf0e8



## Testing

- FE unit tests: `filterSoftwareByQuery` helper, `SelfServiceCard` count-with-query + POST-with-query, `InstallAllInCategoryButton` prop forwarding.
- BE unit test: EE service forwards the match query to the datastore.
- BE datastore test: query, category+query, empty-match cases.
- BE integration test: new "scopes to the query parameter when provided" subtest in `TestInstallAllSelfServiceSoftware`.

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * “Install all” now respects the active self-service search query.
  * Counts, progress indicators, and installation requests now reflect only software matching the current search and category filters.
  * Empty or whitespace-only searches continue to include all software in the selected category.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->