### PR TITLE
Detect VS Code bundled built-in extensions in ai_tools

### DIFF
--- a/orbit/pkg/table/ai_tools/internal/ide/ide.go
+++ b/orbit/pkg/table/ai_tools/internal/ide/ide.go
@@ -58,7 +58,14 @@ func Scan(ctx context.Context, hs []homes.Home) ([]Plugin, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	return append(out, scanVSCodeBuiltins(hs, seen)...), nil
+	out = append(out, scanVSCodeBuiltins(ctx, hs, seen)...)
+	// The bundled pass stops early on cancellation and hands back what it had, so
+	// re-check here: a partial inventory must be reported as the error it is, never
+	// as a complete result.
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // finish stamps ownership and the AI classification onto a plugin row. It is

--- a/orbit/pkg/table/ai_tools/internal/ide/ide.go
+++ b/orbit/pkg/table/ai_tools/internal/ide/ide.go
@@ -5,14 +5,24 @@
 package ide
 
 import (
+	"context"
+	"strings"
+
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/ai_tools/internal/classify"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/ai_tools/internal/homes"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/ai_tools/internal/paths"
 )
 
+// Scope values for Plugin.Scope.
+const (
+	scopeUser   = "user"   // installed under one user's home; attributed to that user
+	scopeSystem = "system" // installed machine-wide; available to every user
+)
+
 // Plugin is one installed editor extension/plugin.
 type Plugin struct {
 	UID, Username string
+	Scope         string // user | system
 	Editor        string // vscode, cursor, intellij-idea, zed, sublime, neovim, emacs, ...
 	EditorFamily  string // vscode | jetbrains | zed | sublime | vim | emacs
 	PluginID      string
@@ -24,28 +34,58 @@ type Plugin struct {
 	AICategory    string
 }
 
-// Scan returns every plugin discovered under the given home directory.
-func Scan(h homes.Home) []Plugin {
-	r := paths.For(h.Dir)
+// Scan returns every plugin discovered across the given homes.
+//
+// It takes all homes at once rather than one per call because not every plugin
+// belongs to a user: extensions bundled inside a machine-wide editor install are
+// a property of the host, so they are collected once, after the per-home pass,
+// and reported with system scope and no owner.
+func Scan(ctx context.Context, hs []homes.Home) ([]Plugin, error) {
 	var out []Plugin
-	out = append(out, scanVSCodeFamily(h, r)...)
-	out = append(out, scanJetBrains(h, r)...)
-	out = append(out, scanZed(h, r)...)
-	out = append(out, scanSublime(h, r)...)
-	out = append(out, scanVim(h)...)
-	out = append(out, scanEmacs(h)...)
-	return out
+	seen := map[string]struct{}{}
+	for _, h := range hs {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		r := paths.For(h.Dir)
+		out = append(out, scanVSCodeProfiles(h, seen)...)
+		out = append(out, scanJetBrains(h, r)...)
+		out = append(out, scanZed(h, r)...)
+		out = append(out, scanSublime(h, r)...)
+		out = append(out, scanVim(h)...)
+		out = append(out, scanEmacs(h)...)
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return append(out, scanVSCodeBuiltins(hs, seen)...), nil
 }
 
 // finish stamps ownership and the AI classification onto a plugin row. It is
 // only called for AI-classified plugins — non-AI plugins are skipped at the
 // scanner so the table surfaces AI tools only.
+//
+// A zero homes.Home leaves the owner columns empty, which is how a system-scoped
+// row says "installed for the whole host, not for one user".
 func (p Plugin) finish(h homes.Home, cat string) Plugin {
 	p.UID, p.Username = h.UID, h.Username
 	p.AICategory = cat
+	if p.Scope == "" {
+		p.Scope = scopeUser
+	}
 	return p
 }
 
 // classifyByName is the fallback classifier for editors without a curated id
 // map (Zed, Sublime, Vim, Emacs).
 func classifyByName(s string) (bool, string) { return classify.ByName(s) }
+
+// firstNonEmptyStr returns a unless it is empty or all whitespace, otherwise b.
+// Every family's scanner uses it to fall back from a manifest's display name to
+// its internal name.
+func firstNonEmptyStr(a, b string) string {
+	if strings.TrimSpace(a) != "" {
+		return a
+	}
+	return b
+}

--- a/orbit/pkg/table/ai_tools/internal/ide/ide_test.go
+++ b/orbit/pkg/table/ai_tools/internal/ide/ide_test.go
@@ -18,6 +18,16 @@ func write(t *testing.T, path, content string) {
 	}
 }
 
+// useAppRoots points the bundled-extension scan at fixture directories for the
+// duration of the test, so Scan never reads the applications actually installed
+// on the machine running the tests.
+func useAppRoots(t *testing.T, roots ...appRoot) {
+	t.Helper()
+	prev := vscodeAppRoots
+	vscodeAppRoots = func([]homes.Home) []appRoot { return roots }
+	t.Cleanup(func() { vscodeAppRoots = prev })
+}
+
 func TestScanVSCodeFamily(t *testing.T) {
 	home := t.TempDir()
 	extDir := filepath.Join(home, ".vscode", "extensions")
@@ -31,7 +41,12 @@ func TestScanVSCodeFamily(t *testing.T) {
 		`{"name":"ext","publisher":"old","version":"0.0.1","displayName":"Old"}`)
 	write(t, filepath.Join(extDir, ".obsolete"), `{"old.ext-0.0.1": true}`)
 
-	got := Scan(homes.Home{Dir: home, Username: "tester"})
+	useAppRoots(t) // no application installs: this test covers the profile scan only
+
+	got, err := Scan(t.Context(), []homes.Home{{Dir: home, Username: "tester"}})
+	if err != nil {
+		t.Fatal(err)
+	}
 	by := map[string]Plugin{}
 	for _, p := range got {
 		by[p.PluginID] = p
@@ -46,6 +61,10 @@ func TestScanVSCodeFamily(t *testing.T) {
 	}
 	if cop.Version != "1.250.0" || cop.Publisher != "github" || cop.EditorFamily != "vscode" {
 		t.Errorf("copilot metadata wrong: %+v", cop)
+	}
+	// A profile extension belongs to the user whose home it was found in.
+	if cop.Scope != scopeUser || cop.Username != "tester" {
+		t.Errorf("scope=%q username=%q want user/tester", cop.Scope, cop.Username)
 	}
 	// The table surfaces AI tools only: a non-AI extension (Prettier) must not appear.
 	if _, ok := by["esbenp.prettier-vscode"]; ok {

--- a/orbit/pkg/table/ai_tools/internal/ide/ide_test.go
+++ b/orbit/pkg/table/ai_tools/internal/ide/ide_test.go
@@ -1,6 +1,8 @@
 package ide
 
 import (
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -72,6 +74,45 @@ func TestScanVSCodeFamily(t *testing.T) {
 	}
 	if _, ok := by["old.ext"]; ok {
 		t.Error("obsolete extension old.ext should have been skipped")
+	}
+}
+
+// cancelAfterCtx reports itself cancelled only from its nth Err call onwards,
+// which lands the cancellation inside the bundled pass rather than at the checks
+// that precede it.
+type cancelAfterCtx struct {
+	context.Context
+	n     int
+	calls int
+}
+
+func (c *cancelAfterCtx) Err() error {
+	c.calls++
+	if c.calls >= c.n {
+		return context.Canceled
+	}
+	return nil
+}
+
+// A query cancelled while the bundled pass is walking application directories must
+// stop there and be reported as cancelled — never answered with a partial
+// inventory that reads like a complete one.
+func TestScanStopsOnCancellation(t *testing.T) {
+	apps := t.TempDir()
+	write(t, filepath.Join(apps, "Visual Studio Code.app", "Contents", "Resources", "app", "extensions", "copilot", "package.json"),
+		`{"name":"copilot-chat","publisher":"GitHub","version":"1.132.0","displayName":"GitHub Copilot"}`)
+	useAppRoots(t, appRoot{dir: apps, scope: scopeSystem})
+
+	// 3 clears the per-home and pre-bundled checks, so cancellation first bites
+	// once the bundled scan is already under way.
+	ctx := &cancelAfterCtx{Context: t.Context(), n: 3}
+
+	got, err := Scan(ctx, []homes.Home{{UID: "501", Username: "tester", Dir: t.TempDir()}})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("err=%v want context.Canceled", err)
+	}
+	if got != nil {
+		t.Errorf("got %+v, want no rows alongside the error", got)
 	}
 }
 

--- a/orbit/pkg/table/ai_tools/internal/ide/vscode.go
+++ b/orbit/pkg/table/ai_tools/internal/ide/vscode.go
@@ -9,7 +9,6 @@ import (
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/ai_tools/internal/classify"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/ai_tools/internal/fsutil"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/ai_tools/internal/homes"
-	"github.com/fleetdm/fleet/v4/orbit/pkg/table/ai_tools/internal/paths"
 )
 
 // vscodeEditor maps an editor label to the home-relative extensions directory
@@ -42,7 +41,10 @@ type vscodeManifest struct {
 	DisplayName string `json:"displayName"`
 }
 
-func scanVSCodeFamily(h homes.Home, _ paths.Roots) []Plugin {
+// scanVSCodeProfiles reports the AI extensions installed under one user's
+// profile. Keys of the rows it produces are added to seen so the bundled pass
+// (scanVSCodeBuiltins) can skip an extension that is already reported here.
+func scanVSCodeProfiles(h homes.Home, seen map[string]struct{}) []Plugin {
 	var out []Plugin
 	for _, ed := range vscodeEditors() {
 		dir := filepath.Join(h.Dir, ed.relPath)
@@ -64,28 +66,47 @@ func scanVSCodeFamily(h homes.Home, _ paths.Roots) []Plugin {
 			if !ok {
 				continue
 			}
-			id := strings.ToLower(m.Publisher + "." + m.Name)
-			if m.Publisher == "" {
-				id = strings.ToLower(m.Name)
-			}
-			isAI, cat := classify.VSCodePlugin(id, m.DisplayName)
-			if !isAI {
+			p, cat, ok := vscodePluginFromManifest(m, ed.editor, manifestPath, filepath.Join(dir, folder))
+			if !ok {
 				continue // AI tools only — skip non-AI extensions
 			}
-			p := Plugin{
-				Editor:       ed.editor,
-				EditorFamily: "vscode",
-				PluginID:     id,
-				Name:         firstNonEmptyStr(m.DisplayName, m.Name),
-				Version:      m.Version,
-				Publisher:    m.Publisher,
-				InstallPath:  filepath.Join(dir, folder),
-				ManifestPath: manifestPath,
-			}
+			seen[vscodePluginKey(ed.editor, p.PluginID)] = struct{}{}
 			out = append(out, p.finish(h, cat))
 		}
 	}
 	return out
+}
+
+// vscodePluginFromManifest derives a plugin row from a package.json, shared by
+// the user-profile and bundled-extension scanners. It reports false for anything
+// that is not an AI extension.
+//
+// TODO: classify on the capabilities a manifest declares, not just its id and
+// display name. An extension contributing chatParticipants, languageModels or
+// mcpServerDefinitionProviders is an AI extension by VS Code's own API surface,
+// whatever it calls itself — which is how we would catch vendor-bundled AI that
+// the KB has never seen (Cursor's and Windsurf's own built-ins) and extensions
+// whose only name signal is a localized placeholder. Name matching stays as the
+// fallback for extensions that predate those contribution points.
+func vscodePluginFromManifest(m vscodeManifest, editor, manifestPath, installPath string) (Plugin, string, bool) {
+	id := strings.ToLower(m.Publisher + "." + m.Name)
+	if m.Publisher == "" {
+		id = strings.ToLower(m.Name)
+	}
+	isAI, cat := classify.VSCodePlugin(id, m.DisplayName)
+	if !isAI {
+		return Plugin{}, "", false
+	}
+	return Plugin{
+		Editor:       editor,
+		EditorFamily: "vscode",
+		PluginID:     id,
+		Name:         firstNonEmptyStr(m.DisplayName, m.Name),
+		Version:      m.Version,
+		Publisher:    m.Publisher,
+		InstallPath:  installPath,
+		ManifestPath: manifestPath,
+	}, cat, true
 }
 
 func readVSCodeManifest(path string) (vscodeManifest, bool) {
@@ -118,11 +139,4 @@ func readObsolete(dir string) map[string]struct{} {
 		}
 	}
 	return out
-}
-
-func firstNonEmptyStr(a, b string) string {
-	if strings.TrimSpace(a) != "" {
-		return a
-	}
-	return b
 }

--- a/orbit/pkg/table/ai_tools/internal/ide/vscode.go
+++ b/orbit/pkg/table/ai_tools/internal/ide/vscode.go
@@ -70,11 +70,11 @@ func scanVSCodeProfiles(h homes.Home, seen map[string]struct{}) []Plugin {
 			if !ok {
 				continue // AI tools only — skip non-AI extensions
 			}
-			// A profile copy takes precedence over both this user's bundled copy
-			// and a machine-wide one, so it is recorded under both keys. Other
-			// users' homes are untouched: they key on their own home.
+			// Keyed on this home only. A profile copy takes precedence over the
+			// same user's bundled copy, but says nothing about anyone else: a
+			// machine-wide install is still available to every other account, and
+			// suppressing its row here would erase them from the inventory.
 			seen[vscodePluginKey(scopeUser, h.Dir, ed.editor, p.PluginID)] = struct{}{}
-			seen[vscodePluginKey(scopeSystem, "", ed.editor, p.PluginID)] = struct{}{}
 			out = append(out, p.finish(h, cat))
 		}
 	}

--- a/orbit/pkg/table/ai_tools/internal/ide/vscode.go
+++ b/orbit/pkg/table/ai_tools/internal/ide/vscode.go
@@ -70,7 +70,11 @@ func scanVSCodeProfiles(h homes.Home, seen map[string]struct{}) []Plugin {
 			if !ok {
 				continue // AI tools only — skip non-AI extensions
 			}
-			seen[vscodePluginKey(ed.editor, p.PluginID)] = struct{}{}
+			// A profile copy takes precedence over both this user's bundled copy
+			// and a machine-wide one, so it is recorded under both keys. Other
+			// users' homes are untouched: they key on their own home.
+			seen[vscodePluginKey(scopeUser, h.Dir, ed.editor, p.PluginID)] = struct{}{}
+			seen[vscodePluginKey(scopeSystem, "", ed.editor, p.PluginID)] = struct{}{}
 			out = append(out, p.finish(h, cat))
 		}
 	}

--- a/orbit/pkg/table/ai_tools/internal/ide/vscode_builtin.go
+++ b/orbit/pkg/table/ai_tools/internal/ide/vscode_builtin.go
@@ -1,0 +1,319 @@
+package ide
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/fleetdm/fleet/v4/orbit/pkg/table/ai_tools/internal/fsutil"
+	"github.com/fleetdm/fleet/v4/orbit/pkg/table/ai_tools/internal/homes"
+	"github.com/fleetdm/fleet/v4/orbit/pkg/table/ai_tools/internal/paths"
+)
+
+// Bundled ("built-in") extensions live inside the application install, not the
+// user profile's extensions directory. GitHub Copilot Chat is the reason this
+// matters: from VS Code 1.130 it ships bundled and the standalone marketplace
+// extension is deprecated, so a profile-only scan reports nothing for a user who
+// actively has Copilot enabled.
+
+// vscodeAppNames maps a normalized application directory name (see
+// vscodeEditorForApp) to the editor label the user-profile scanner already uses,
+// so both sources report the same `source` value. Entries cover the macOS bundle,
+// the Windows install folder, the Linux package directory, and the flatpak
+// application id for each product.
+//
+// Unrecognized directories are skipped rather than reported under a guessed
+// label: plenty of unrelated Electron apps also have a resources/app tree.
+var vscodeAppNames = map[string]string{
+	"visual studio code":             "vscode",
+	"microsoft vs code":              "vscode",
+	"code":                           "vscode",
+	"vscode":                         "vscode",
+	"com.visualstudio.code":          "vscode",
+	"visual studio code insiders":    "vscode-insiders",
+	"microsoft vs code insiders":     "vscode-insiders",
+	"code insiders":                  "vscode-insiders",
+	"vscode insiders":                "vscode-insiders",
+	"vscode insider":                 "vscode-insiders",
+	"com.visualstudio.code.insiders": "vscode-insiders",
+	"vscodium":                       "vscodium",
+	"codium":                         "vscodium",
+	"code oss":                       "vscodium", // distro build of the OSS source, shares ~/.vscode-oss
+	"com.vscodium.codium":            "vscodium",
+	"cursor":                         "cursor",
+	"windsurf":                       "windsurf",
+	"trae":                           "trae",
+	"antigravity":                    "antigravity",
+	"code server":                    "code-server",
+}
+
+// platformTokens name the build rather than the product. The archives published
+// on the download site unpack to a directory carrying them — "VSCode-win32-x64",
+// "VSCode-linux-arm64" — which is what a hand-installed copy is usually left in,
+// so they are dropped before the lookup.
+var platformTokens = map[string]struct{}{
+	"win32": {}, "win": {}, "windows": {}, "linux": {}, "darwin": {}, "mac": {}, "macos": {}, "osx": {},
+	"x64": {}, "x86": {}, "x86_64": {}, "amd64": {}, "ia32": {}, "arm": {}, "arm64": {}, "armhf": {}, "aarch64": {},
+}
+
+// vscodeEditorForApp resolves an application directory name to its editor label.
+//
+// Packagers spell the same product many ways — "Visual Studio Code.app",
+// "Visual Studio Code - Insiders", "visual-studio-code" (AUR), "code-insiders",
+// "VSCode-win32-x64" (the published zip) — so the name is folded to lowercase
+// words, stripped of build markers, and rejoined with single spaces before the
+// lookup, letting one table entry cover every spelling.
+func vscodeEditorForApp(dirName string) (string, bool) {
+	n := strings.TrimSuffix(strings.ToLower(dirName), ".app")
+	words := strings.Fields(strings.NewReplacer("-", " ", "_", " ").Replace(n))
+	kept := words[:0]
+	for _, w := range words {
+		if _, drop := platformTokens[w]; !drop {
+			kept = append(kept, w)
+		}
+	}
+	ed, ok := vscodeAppNames[strings.Join(kept, " ")]
+	return ed, ok
+}
+
+// vscodeBundledDirs returns the candidate bundled-extensions directories inside
+// an application directory. Every layout is tried on every platform — the ones
+// that don't apply simply do not exist, and not branching on runtime.GOOS keeps
+// this testable anywhere.
+func vscodeBundledDirs(appDir string) []string {
+	// Snap keeps the distro layout one level down, under a directory named after
+	// the snap itself.
+	snapName := strings.ToLower(filepath.Base(appDir))
+	return []string{
+		// macOS .app bundle.
+		filepath.Join(appDir, "Contents", "Resources", "app", "extensions"),
+		// Windows installs and Linux deb/rpm/tarball installs.
+		filepath.Join(appDir, "resources", "app", "extensions"),
+		// code-server embeds a whole VS Code under lib/vscode.
+		filepath.Join(appDir, "lib", "vscode", "extensions"),
+		// Snap and flatpak layouts are best-effort: a path that doesn't exist on a
+		// given host costs one failed ReadDir.
+		filepath.Join(appDir, "current", "usr", "share", snapName, "resources", "app", "extensions"),
+		filepath.Join(appDir, "current", "active", "files", "extra", "vscode", "resources", "app", "extensions"),
+	}
+}
+
+// appRoot is a directory whose immediate children may be VS Code-family
+// application installs, together with how rows found beneath it are attributed.
+// A system-scoped root has no owner: the install belongs to the host, not to a
+// user, and home is left zero so the uid/username columns come out empty.
+type appRoot struct {
+	dir   string
+	scope string
+	home  homes.Home
+}
+
+// vscodeAppRoots is a variable so tests can point the bundled scan at a fixture
+// instead of the host's real application directories.
+var vscodeAppRoots = defaultVSCodeAppRoots
+
+// defaultVSCodeAppRoots returns the directories to search for VS Code-family
+// installs. Per-user locations are derived from each home rather than from the
+// environment, matching the paths package: when running as root over another
+// user's home we cannot read their environment.
+func defaultVSCodeAppRoots(hs []homes.Home) []appRoot {
+	var out []appRoot
+	system := func(dirs ...string) {
+		for _, d := range dirs {
+			if d != "" {
+				out = append(out, appRoot{dir: d, scope: scopeSystem})
+			}
+		}
+	}
+	perUser := func(dir func(paths.Roots) string) {
+		for _, h := range hs {
+			if d := dir(paths.For(h.Dir)); d != "" {
+				out = append(out, appRoot{dir: d, scope: scopeUser, home: h})
+			}
+		}
+	}
+
+	switch runtime.GOOS {
+	case "darwin":
+		system("/Applications", "/Applications/Utilities")
+		perUser(func(r paths.Roots) string { return filepath.Join(r.Home, "Applications") })
+	case "windows":
+		system(os.Getenv("ProgramFiles"), os.Getenv("ProgramFiles(x86)"))
+		// The VS Code "user installer" — the download the site offers by default —
+		// installs under LocalAppData\Programs, not Program Files.
+		perUser(func(r paths.Roots) string { return filepath.Join(r.LocalAppData, "Programs") })
+	default: // linux and other unix
+		// deb/rpm packages land in /usr/share, tarball and AUR builds in /opt,
+		// distro builds of the OSS source in /usr/lib; snap and flatpak keep their
+		// own trees (the extra path layers are handled in vscodeBundledDirs).
+		system("/usr/share", "/usr/local/share", "/opt", "/usr/lib", "/snap", "/var/lib/flatpak/app")
+		perUser(func(r paths.Roots) string { return filepath.Join(r.XDGData, "flatpak", "app") })
+	}
+	return out
+}
+
+// vscodePluginKey identifies a plugin row within one editor, so a bundled
+// extension is not reported alongside a user-profile copy of the same id. VS Code
+// itself gives the profile copy precedence when both are present.
+func vscodePluginKey(editor, id string) string { return editor + "\x00" + id }
+
+// scanVSCodeBuiltins reports the AI extensions bundled inside every VS Code-family
+// application installed on the host. seen holds the keys already reported from
+// user profiles and is added to as rows are produced, so a given extension is
+// reported once per editor.
+func scanVSCodeBuiltins(hs []homes.Home, seen map[string]struct{}) []Plugin {
+	return scanVSCodeBuiltinsIn(vscodeAppRoots(hs), seen)
+}
+
+func scanVSCodeBuiltinsIn(roots []appRoot, seen map[string]struct{}) []Plugin {
+	var out []Plugin
+	for _, root := range roots {
+		entries, err := os.ReadDir(root.dir)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			if !e.IsDir() {
+				continue
+			}
+			editor, ok := vscodeEditorForApp(e.Name())
+			if !ok {
+				continue
+			}
+			out = append(out, scanVSCodeAppDir(filepath.Join(root.dir, e.Name()), editor, root, seen)...)
+		}
+	}
+	return out
+}
+
+// scanVSCodeAppDir reports the bundled extensions of one application install.
+//
+// The layouts in vscodeBundledDirs are tried against the application directory
+// first. Only when none of them exists are the directory's immediate children
+// tried as well, which is what VS Code 1.132 on Windows needs: it keeps just a
+// launcher and a build-id directory at the top level
+// (…\Microsoft VS Code\df53daabb1\resources\app\…), putting the application tree
+// one level below where earlier builds put it. Probing children finds it whatever
+// that directory is named, and the fallback stays free on the flat layouts —
+// which matters on macOS, where a case-insensitive volume would otherwise let
+// <app>/Contents/resources/... resolve onto the real Contents/Resources tree and
+// scan every manifest a second time.
+func scanVSCodeAppDir(appDir, editor string, root appRoot, seen map[string]struct{}) []Plugin {
+	var out []Plugin
+	var found bool
+	for _, dir := range vscodeBundledDirs(appDir) {
+		ps, ok := scanVSCodeBundledDir(dir, editor, root, seen)
+		out, found = append(out, ps...), found || ok
+	}
+	if found {
+		return out
+	}
+	children, err := os.ReadDir(appDir)
+	if err != nil {
+		return out
+	}
+	for _, c := range children {
+		if !c.IsDir() {
+			continue
+		}
+		for _, dir := range vscodeBundledDirs(filepath.Join(appDir, c.Name())) {
+			ps, _ := scanVSCodeBundledDir(dir, editor, root, seen)
+			out = append(out, ps...)
+		}
+	}
+	return out
+}
+
+// scanVSCodeBundledDir reports the AI extensions in one bundled-extensions
+// directory. The second return reports whether the directory existed at all,
+// which is how the caller tells "this layout is not the one" apart from "this
+// layout is right and holds no AI extensions".
+func scanVSCodeBundledDir(dir, editor string, root appRoot, seen map[string]struct{}) ([]Plugin, bool) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, false
+	}
+	var out []Plugin
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		extDir := filepath.Join(dir, e.Name())
+		manifestPath := filepath.Join(extDir, "package.json")
+		m, ok := readVSCodeManifest(manifestPath)
+		if !ok {
+			continue
+		}
+		m.DisplayName = vscodeDisplayName(extDir, m)
+		p, cat, ok := vscodePluginFromManifest(m, editor, manifestPath, extDir)
+		if !ok {
+			continue
+		}
+		key := vscodePluginKey(editor, p.PluginID)
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		p.Scope = root.scope
+		out = append(out, p.finish(root.home, cat))
+	}
+	return out, true
+}
+
+// vscodeDisplayName resolves a bundled manifest's localized display name.
+// Built-in manifests set displayName to an "%nlsKey%" placeholder resolved from
+// package.nls.json beside them (88 of the ~100 extensions VS Code 1.x bundles do
+// this). Surfacing the raw placeholder would both show up in the row's name and
+// rob classify of its only signal for an extension whose id is not in the KB, so
+// an unresolvable placeholder falls back to the manifest name.
+func vscodeDisplayName(extDir string, m vscodeManifest) string {
+	key, ok := nlsPlaceholder(m.DisplayName)
+	if !ok {
+		return m.DisplayName
+	}
+	if s := lookupVSCodeNLS(extDir, key); s != "" {
+		return s
+	}
+	return m.Name
+}
+
+// nlsPlaceholder reports whether s is an "%key%" localization placeholder, and
+// returns the key it references.
+func nlsPlaceholder(s string) (string, bool) {
+	if len(s) < 3 || !strings.HasPrefix(s, "%") || !strings.HasSuffix(s, "%") {
+		return "", false
+	}
+	return strings.TrimSuffix(strings.TrimPrefix(s, "%"), "%"), true
+}
+
+// lookupVSCodeNLS returns the string bound to key in extDir's package.nls.json,
+// or "" when the file is unreadable or the key is absent. A value is either a
+// plain string or a {"message": ..., "comment": [...]} object — vscode-nls
+// accepts both, and the bundled Copilot Chat manifest ships both forms.
+func lookupVSCodeNLS(extDir, key string) string {
+	b, err := fsutil.ReadFileBounded(filepath.Join(extDir, "package.nls.json"))
+	if err != nil {
+		return ""
+	}
+	var nls map[string]json.RawMessage
+	if err := json.Unmarshal(b, &nls); err != nil {
+		return ""
+	}
+	raw, ok := nls[key]
+	if !ok {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	var obj struct {
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(raw, &obj); err == nil {
+		return obj.Message
+	}
+	return ""
+}

--- a/orbit/pkg/table/ai_tools/internal/ide/vscode_builtin.go
+++ b/orbit/pkg/table/ai_tools/internal/ide/vscode_builtin.go
@@ -1,6 +1,7 @@
 package ide
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -154,22 +155,41 @@ func defaultVSCodeAppRoots(hs []homes.Home) []appRoot {
 	return out
 }
 
-// vscodePluginKey identifies a plugin row within one editor, so a bundled
-// extension is not reported alongside a user-profile copy of the same id. VS Code
-// itself gives the profile copy precedence when both are present.
-func vscodePluginKey(editor, id string) string { return editor + "\x00" + id }
+// vscodePluginKey identifies a plugin row for de-duplication within one editor,
+// so a bundled extension is not reported alongside a copy of the same id that was
+// already reported. VS Code itself gives the profile copy precedence when both are
+// present.
+//
+// Scope decides how wide the key reaches. A system-scoped install belongs to the
+// host, so one key covers the whole machine. A user-scoped one belongs to a single
+// account, so its home is part of the key: two users who each have the extension
+// really do each have it, and one user's copy must never hide another's.
+func vscodePluginKey(scope, home, editor, id string) string {
+	if scope == scopeSystem {
+		return editor + "\x00" + id
+	}
+	return home + "\x00" + editor + "\x00" + id
+}
 
 // scanVSCodeBuiltins reports the AI extensions bundled inside every VS Code-family
 // application installed on the host. seen holds the keys already reported from
 // user profiles and is added to as rows are produced, so a given extension is
 // reported once per editor.
-func scanVSCodeBuiltins(hs []homes.Home, seen map[string]struct{}) []Plugin {
-	return scanVSCodeBuiltinsIn(vscodeAppRoots(hs), seen)
+//
+// Traversal stops as soon as ctx is cancelled: reading every bundled manifest of
+// every editor installed on the host is the most I/O this collector does, so it
+// must not outlive the query that asked for it. The caller reports the
+// cancellation.
+func scanVSCodeBuiltins(ctx context.Context, hs []homes.Home, seen map[string]struct{}) []Plugin {
+	return scanVSCodeBuiltinsIn(ctx, vscodeAppRoots(hs), seen)
 }
 
-func scanVSCodeBuiltinsIn(roots []appRoot, seen map[string]struct{}) []Plugin {
+func scanVSCodeBuiltinsIn(ctx context.Context, roots []appRoot, seen map[string]struct{}) []Plugin {
 	var out []Plugin
 	for _, root := range roots {
+		if ctx.Err() != nil {
+			return out
+		}
 		entries, err := os.ReadDir(root.dir)
 		if err != nil {
 			continue
@@ -182,7 +202,7 @@ func scanVSCodeBuiltinsIn(roots []appRoot, seen map[string]struct{}) []Plugin {
 			if !ok {
 				continue
 			}
-			out = append(out, scanVSCodeAppDir(filepath.Join(root.dir, e.Name()), editor, root, seen)...)
+			out = append(out, scanVSCodeAppDir(ctx, filepath.Join(root.dir, e.Name()), editor, root, seen)...)
 		}
 	}
 	return out
@@ -200,11 +220,11 @@ func scanVSCodeBuiltinsIn(roots []appRoot, seen map[string]struct{}) []Plugin {
 // which matters on macOS, where a case-insensitive volume would otherwise let
 // <app>/Contents/resources/... resolve onto the real Contents/Resources tree and
 // scan every manifest a second time.
-func scanVSCodeAppDir(appDir, editor string, root appRoot, seen map[string]struct{}) []Plugin {
+func scanVSCodeAppDir(ctx context.Context, appDir, editor string, root appRoot, seen map[string]struct{}) []Plugin {
 	var out []Plugin
 	var found bool
 	for _, dir := range vscodeBundledDirs(appDir) {
-		ps, ok := scanVSCodeBundledDir(dir, editor, root, seen)
+		ps, ok := scanVSCodeBundledDir(ctx, dir, editor, root, seen)
 		out, found = append(out, ps...), found || ok
 	}
 	if found {
@@ -219,7 +239,7 @@ func scanVSCodeAppDir(appDir, editor string, root appRoot, seen map[string]struc
 			continue
 		}
 		for _, dir := range vscodeBundledDirs(filepath.Join(appDir, c.Name())) {
-			ps, _ := scanVSCodeBundledDir(dir, editor, root, seen)
+			ps, _ := scanVSCodeBundledDir(ctx, dir, editor, root, seen)
 			out = append(out, ps...)
 		}
 	}
@@ -230,7 +250,10 @@ func scanVSCodeAppDir(appDir, editor string, root appRoot, seen map[string]struc
 // directory. The second return reports whether the directory existed at all,
 // which is how the caller tells "this layout is not the one" apart from "this
 // layout is right and holds no AI extensions".
-func scanVSCodeBundledDir(dir, editor string, root appRoot, seen map[string]struct{}) ([]Plugin, bool) {
+func scanVSCodeBundledDir(ctx context.Context, dir, editor string, root appRoot, seen map[string]struct{}) ([]Plugin, bool) {
+	if ctx.Err() != nil {
+		return nil, false
+	}
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, false
@@ -251,7 +274,7 @@ func scanVSCodeBundledDir(dir, editor string, root appRoot, seen map[string]stru
 		if !ok {
 			continue
 		}
-		key := vscodePluginKey(editor, p.PluginID)
+		key := vscodePluginKey(root.scope, root.home.Dir, editor, p.PluginID)
 		if _, dup := seen[key]; dup {
 			continue
 		}

--- a/orbit/pkg/table/ai_tools/internal/ide/vscode_builtin.go
+++ b/orbit/pkg/table/ai_tools/internal/ide/vscode_builtin.go
@@ -158,12 +158,15 @@ func defaultVSCodeAppRoots(hs []homes.Home) []appRoot {
 // vscodePluginKey identifies a plugin row for de-duplication within one editor,
 // so a bundled extension is not reported alongside a copy of the same id that was
 // already reported. VS Code itself gives the profile copy precedence when both are
-// present.
+// present for the same user.
 //
-// Scope decides how wide the key reaches. A system-scoped install belongs to the
-// host, so one key covers the whole machine. A user-scoped one belongs to a single
-// account, so its home is part of the key: two users who each have the extension
-// really do each have it, and one user's copy must never hide another's.
+// Scope decides how wide the key reaches, and the two scopes never share a key
+// space. A system-scoped install belongs to the host, so one key covers the whole
+// machine. A user-scoped one belongs to a single account, so its home is part of
+// the key. Keeping them separate is what stops one account's copy from standing in
+// for everyone: two users who each have the extension really do each have it, and
+// a machine-wide install remains available to every account no matter who else
+// happens to have installed their own copy.
 func vscodePluginKey(scope, home, editor, id string) string {
 	if scope == scopeSystem {
 		return editor + "\x00" + id

--- a/orbit/pkg/table/ai_tools/internal/ide/vscode_builtin_test.go
+++ b/orbit/pkg/table/ai_tools/internal/ide/vscode_builtin_test.go
@@ -1,0 +1,297 @@
+package ide
+
+import (
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/orbit/pkg/table/ai_tools/internal/homes"
+)
+
+func TestVSCodeEditorForApp(t *testing.T) {
+	cases := []struct {
+		dirName string
+		want    string
+	}{
+		{"Visual Studio Code.app", "vscode"}, // macOS bundle
+		{"Microsoft VS Code", "vscode"},      // Windows install dir
+		{"code", "vscode"},                   // Linux /usr/share/code
+		{"visual-studio-code", "vscode"},     // AUR /opt/visual-studio-code
+		{"com.visualstudio.code", "vscode"},  // flatpak application id
+		{"Visual Studio Code - Insiders.app", "vscode-insiders"},
+		{"code-insiders", "vscode-insiders"},
+		{"visual_studio_code_insiders", "vscode-insiders"},
+		// The published archives unpack under a build-tagged name, which is where a
+		// hand-installed copy usually stays.
+		{"VSCode-win32-x64", "vscode"},
+		{"VSCode-linux-arm64", "vscode"},
+		{"vscode", "vscode"},
+		{"VSCode-win32-x64-insider", "vscode-insiders"},
+		{"VSCodium.app", "vscodium"},
+		{"codium", "vscodium"},
+		{"code-oss", "vscodium"},
+		{"Cursor.app", "cursor"},
+		{"Windsurf", "windsurf"},
+		{"code-server", "code-server"},
+
+		{"Safari.app", ""}, // not a VS Code family app
+		{"Slack", ""},      // Electron, but not an editor
+		{"", ""},
+	}
+	for _, c := range cases {
+		got, ok := vscodeEditorForApp(c.dirName)
+		if c.want == "" {
+			if ok {
+				t.Errorf("vscodeEditorForApp(%q)=%q,true want no match", c.dirName, got)
+			}
+			continue
+		}
+		if !ok || got != c.want {
+			t.Errorf("vscodeEditorForApp(%q)=%q,%v want %q,true", c.dirName, got, ok, c.want)
+		}
+	}
+}
+
+// TestScanVSCodeBuiltins covers the reported gap: Copilot Chat ships bundled
+// inside the application itself on VS Code 1.130+, so it never appears in the
+// user profile's extensions directory.
+func TestScanVSCodeBuiltins(t *testing.T) {
+	root := t.TempDir()
+
+	// macOS bundle layout.
+	codeExts := filepath.Join(root, "Visual Studio Code.app", "Contents", "Resources", "app", "extensions")
+	write(t, filepath.Join(codeExts, "copilot", "package.json"),
+		`{"name":"copilot-chat","publisher":"GitHub","version":"1.130.0","displayName":"%displayName%"}`)
+	write(t, filepath.Join(codeExts, "copilot", "package.nls.json"),
+		`{"displayName":"GitHub Copilot Chat","description":"AI chat"}`)
+	// A non-AI built-in must be dropped, like any other non-AI extension.
+	write(t, filepath.Join(codeExts, "git", "package.json"),
+		`{"name":"git","publisher":"vscode","version":"1.0.0","displayName":"Git"}`)
+
+	// Windows/Linux layout, same product family.
+	codiumExts := filepath.Join(root, "VSCodium", "resources", "app", "extensions")
+	write(t, filepath.Join(codiumExts, "continue", "package.json"),
+		`{"name":"continue","publisher":"Continue","version":"0.9.0","displayName":"Continue"}`)
+
+	// An unrelated application that happens to sit next to them.
+	write(t, filepath.Join(root, "Slack.app", "Contents", "Resources", "app", "extensions", "x", "package.json"),
+		`{"name":"copilot","publisher":"acme","version":"1.0.0"}`)
+
+	got := scanVSCodeBuiltinsIn([]appRoot{{dir: root, scope: scopeSystem}}, map[string]struct{}{})
+
+	by := map[string]Plugin{}
+	for _, p := range got {
+		by[p.PluginID] = p
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d plugins, want 2 (copilot chat + continue): %+v", len(got), got)
+	}
+
+	cop, ok := by["github.copilot-chat"]
+	if !ok {
+		t.Fatalf("bundled Copilot Chat not detected; got %+v", got)
+	}
+	if cop.Editor != "vscode" || cop.EditorFamily != "vscode" {
+		t.Errorf("editor=%q family=%q want vscode/vscode", cop.Editor, cop.EditorFamily)
+	}
+	// displayName is an nls placeholder in bundled manifests; it must be resolved.
+	if cop.Name != "GitHub Copilot Chat" {
+		t.Errorf("name=%q want %q resolved from package.nls.json", cop.Name, "GitHub Copilot Chat")
+	}
+	if cop.Version != "1.130.0" || cop.Publisher != "GitHub" {
+		t.Errorf("version=%q publisher=%q want 1.130.0/GitHub", cop.Version, cop.Publisher)
+	}
+	// A machine-wide install belongs to the host, not to any one user.
+	if cop.Scope != scopeSystem || cop.UID != "" || cop.Username != "" {
+		t.Errorf("scope=%q uid=%q username=%q want system with no owner", cop.Scope, cop.UID, cop.Username)
+	}
+	if cop.ManifestPath != filepath.Join(codeExts, "copilot", "package.json") {
+		t.Errorf("manifest_path=%q want the bundled manifest", cop.ManifestPath)
+	}
+	if cop.AICategory == "" {
+		t.Error("AICategory empty")
+	}
+
+	if _, ok := by["continue.continue"]; !ok {
+		t.Errorf("bundled extension under the plain layout not detected; got %+v", got)
+	}
+	if _, ok := by["vscode.git"]; ok {
+		t.Error("non-AI built-in should be dropped")
+	}
+	if _, ok := by["acme.copilot"]; ok {
+		t.Error("extensions under a non-editor application should be ignored")
+	}
+}
+
+// VS Code 1.132 on Windows keeps a launcher at the top of the install directory
+// and the application itself under a build-id directory, so the bundled tree sits
+// one level deeper than on earlier builds.
+func TestScanVSCodeBuiltinsBuildIDLayout(t *testing.T) {
+	root := t.TempDir()
+	install := filepath.Join(root, "Microsoft VS Code")
+	write(t, filepath.Join(install, "df53daabb1", "resources", "app", "extensions", "copilot", "package.json"),
+		`{"name":"copilot-chat","publisher":"GitHub","version":"1.132.0","displayName":"GitHub Copilot"}`)
+	// Siblings of the build-id directory must not confuse the probe.
+	write(t, filepath.Join(install, "bin", "code.cmd"), "@echo off")
+
+	h := homes.Home{UID: "S-1-5-21-1001", Username: "juan", Dir: t.TempDir()}
+	got := scanVSCodeBuiltinsIn([]appRoot{{dir: root, scope: scopeUser, home: h}}, map[string]struct{}{})
+	if len(got) != 1 {
+		t.Fatalf("got %d plugins, want 1 under the build-id layout: %+v", len(got), got)
+	}
+	if got[0].PluginID != "github.copilot-chat" || got[0].Editor != "vscode" {
+		t.Errorf("id=%q editor=%q want github.copilot-chat/vscode", got[0].PluginID, got[0].Editor)
+	}
+	if got[0].Username != "juan" || got[0].Scope != scopeUser {
+		t.Errorf("username=%q scope=%q want juan/user (a per-user installer)", got[0].Username, got[0].Scope)
+	}
+}
+
+// An editor installed into a user's own home is that user's, so its bundled
+// extensions are attributed to them rather than to the host.
+func TestScanVSCodeBuiltinsUserScope(t *testing.T) {
+	root := t.TempDir()
+	write(t, filepath.Join(root, "Cursor.app", "Contents", "Resources", "app", "extensions", "copilot", "package.json"),
+		`{"name":"copilot-chat","publisher":"GitHub","version":"1.0.0","displayName":"GitHub Copilot Chat"}`)
+
+	h := homes.Home{UID: "501", Username: "tester", Dir: t.TempDir()}
+	got := scanVSCodeBuiltinsIn([]appRoot{{dir: root, scope: scopeUser, home: h}}, map[string]struct{}{})
+	if len(got) != 1 {
+		t.Fatalf("got %d plugins, want 1: %+v", len(got), got)
+	}
+	if got[0].Scope != scopeUser || got[0].UID != "501" || got[0].Username != "tester" {
+		t.Errorf("scope=%q uid=%q username=%q want user/501/tester", got[0].Scope, got[0].UID, got[0].Username)
+	}
+	if got[0].Editor != "cursor" {
+		t.Errorf("editor=%q want cursor", got[0].Editor)
+	}
+}
+
+// A user-profile install of the same extension overrides the bundled copy in the
+// editor itself, so it must not be reported twice.
+func TestScanVSCodeBuiltinsSkipsAlreadySeen(t *testing.T) {
+	root := t.TempDir()
+	exts := filepath.Join(root, "code", "resources", "app", "extensions")
+	write(t, filepath.Join(exts, "copilot", "package.json"),
+		`{"name":"copilot-chat","publisher":"GitHub","version":"1.130.0","displayName":"Copilot Chat"}`)
+
+	seen := map[string]struct{}{
+		vscodePluginKey("vscode", "github.copilot-chat"): {},
+	}
+	if got := scanVSCodeBuiltinsIn([]appRoot{{dir: root, scope: scopeSystem}}, seen); len(got) != 0 {
+		t.Errorf("got %+v, want no rows: the user-profile copy was already reported", got)
+	}
+}
+
+// The bundled scan runs once for the host, not once per user: an extension inside
+// a machine-wide install must not be reported one time per account on the box,
+// and must not be attributed to accounts that never opened the editor.
+func TestScanReportsMachineWideBuiltinOnce(t *testing.T) {
+	apps := t.TempDir()
+	write(t, filepath.Join(apps, "Visual Studio Code.app", "Contents", "Resources", "app", "extensions", "copilot", "package.json"),
+		`{"name":"copilot-chat","publisher":"GitHub","version":"1.130.0","displayName":"GitHub Copilot Chat"}`)
+	useAppRoots(t, appRoot{dir: apps, scope: scopeSystem})
+
+	hs := []homes.Home{
+		{UID: "501", Username: "alice", Dir: t.TempDir()},
+		{UID: "502", Username: "bob", Dir: t.TempDir()},
+		{UID: "503", Username: "carol", Dir: t.TempDir()},
+	}
+	got, err := Scan(t.Context(), hs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d rows for %d homes, want 1 machine-wide row: %+v", len(got), len(hs), got)
+	}
+	if got[0].Scope != scopeSystem || got[0].UID != "" {
+		t.Errorf("scope=%q uid=%q want a system row with no owner", got[0].Scope, got[0].UID)
+	}
+}
+
+// The bundled pass consults what the profile pass reported across every home, so
+// an extension installed both ways yields one row — the user's.
+func TestScanDedupesBuiltinAgainstProfile(t *testing.T) {
+	apps := t.TempDir()
+	write(t, filepath.Join(apps, "Visual Studio Code.app", "Contents", "Resources", "app", "extensions", "copilot", "package.json"),
+		`{"name":"copilot-chat","publisher":"GitHub","version":"1.130.0","displayName":"GitHub Copilot Chat"}`)
+	useAppRoots(t, appRoot{dir: apps, scope: scopeSystem})
+
+	home := t.TempDir()
+	write(t, filepath.Join(home, ".vscode", "extensions", "github.copilot-chat-1.131.0", "package.json"),
+		`{"name":"copilot-chat","publisher":"GitHub","version":"1.131.0","displayName":"GitHub Copilot Chat"}`)
+
+	got, err := Scan(t.Context(), []homes.Home{{UID: "501", Username: "alice", Dir: home}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d rows, want 1 (profile copy wins over bundled): %+v", len(got), got)
+	}
+	if got[0].Version != "1.131.0" || got[0].Scope != scopeUser {
+		t.Errorf("version=%q scope=%q want the profile copy 1.131.0/user", got[0].Version, got[0].Scope)
+	}
+}
+
+func TestVSCodeDisplayName(t *testing.T) {
+	dir := t.TempDir()
+	write(t, filepath.Join(dir, "package.nls.json"), `{
+		"plain": "Plain String",
+		"obj": {"message": "Object Form", "comment": ["translators: ..."]},
+		"empty": ""
+	}`)
+
+	cases := []struct {
+		name        string
+		displayName string
+		manifest    string
+		want        string
+	}{
+		{"literal is kept as-is", "GitHub Copilot", "copilot-chat", "GitHub Copilot"},
+		{"string value is resolved", "%plain%", "copilot-chat", "Plain String"},
+		// vscode-nls also allows {"message": ...}; the bundled Copilot Chat manifest
+		// ships entries in that form.
+		{"object value is resolved", "%obj%", "copilot-chat", "Object Form"},
+		{"missing key falls back to name", "%nope%", "copilot-chat", "copilot-chat"},
+		{"empty value falls back to name", "%empty%", "copilot-chat", "copilot-chat"},
+		{"unreadable nls falls back to name", "%plain%", "other", "other"},
+		{"bare percent is not a placeholder", "%", "copilot-chat", "%"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			extDir := dir
+			if c.name == "unreadable nls falls back to name" {
+				extDir = filepath.Join(dir, "missing")
+			}
+			got := vscodeDisplayName(extDir, vscodeManifest{Name: c.manifest, DisplayName: c.displayName})
+			if got != c.want {
+				t.Errorf("vscodeDisplayName(%q) = %q want %q", c.displayName, got, c.want)
+			}
+		})
+	}
+}
+
+// An unresolvable placeholder must never reach the row, because classify uses the
+// display name as its fallback signal for ids that are not in the KB.
+func TestScanVSCodeBuiltinsUnresolvedPlaceholderUsesName(t *testing.T) {
+	root := t.TempDir()
+	// No package.nls.json beside it, and an id classify does not know.
+	write(t, filepath.Join(root, "Cursor.app", "Contents", "Resources", "app", "extensions", "x", "package.json"),
+		`{"name":"tabnine-chat","publisher":"Acme","version":"1.0.0","displayName":"%displayName%"}`)
+
+	got := scanVSCodeBuiltinsIn([]appRoot{{dir: root, scope: scopeSystem}}, map[string]struct{}{})
+	if len(got) != 1 {
+		t.Fatalf("got %d plugins, want 1 (classified via the manifest name): %+v", len(got), got)
+	}
+	if got[0].Name != "tabnine-chat" {
+		t.Errorf("name=%q want the manifest name, never a raw %%placeholder%%", got[0].Name)
+	}
+}
+
+func TestVSCodeBundledDirs(t *testing.T) {
+	got := vscodeBundledDirs(filepath.Join("/snap", "code"))
+	want := filepath.Join("/snap", "code", "current", "usr", "share", "code", "resources", "app", "extensions")
+	if !slices.Contains(got, want) {
+		t.Errorf("snap layout %q not among candidates %q", want, got)
+	}
+}

--- a/orbit/pkg/table/ai_tools/internal/ide/vscode_builtin_test.go
+++ b/orbit/pkg/table/ai_tools/internal/ide/vscode_builtin_test.go
@@ -264,27 +264,48 @@ func TestScanPerHomeProfileWinsOverUserBundled(t *testing.T) {
 	}
 }
 
-// The bundled pass consults what the profile pass reported across every home, so
-// an extension installed both ways yields one row — the user's.
-func TestScanDedupesBuiltinAgainstProfile(t *testing.T) {
+// One user having their own copy says nothing about anyone else, so it must not
+// suppress the machine-wide row: the editor is installed for the whole host and
+// every other account still has the extension it bundles.
+func TestScanUserCopyDoesNotShadowSystemCopy(t *testing.T) {
 	apps := t.TempDir()
 	write(t, filepath.Join(apps, "Visual Studio Code.app", "Contents", "Resources", "app", "extensions", "copilot", "package.json"),
 		`{"name":"copilot-chat","publisher":"GitHub","version":"1.130.0","displayName":"GitHub Copilot Chat"}`)
 	useAppRoots(t, appRoot{dir: apps, scope: scopeSystem})
 
-	home := t.TempDir()
-	write(t, filepath.Join(home, ".vscode", "extensions", "github.copilot-chat-1.131.0", "package.json"),
+	alice := t.TempDir()
+	write(t, filepath.Join(alice, ".vscode", "extensions", "github.copilot-chat-1.131.0", "package.json"),
 		`{"name":"copilot-chat","publisher":"GitHub","version":"1.131.0","displayName":"GitHub Copilot Chat"}`)
 
-	got, err := Scan(t.Context(), []homes.Home{{UID: "501", Username: "alice", Dir: home}})
+	got, err := Scan(t.Context(), []homes.Home{
+		{UID: "501", Username: "alice", Dir: alice},
+		{UID: "502", Username: "bob", Dir: t.TempDir()}, // no copy of his own
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(got) != 1 {
-		t.Fatalf("got %d rows, want 1 (profile copy wins over bundled): %+v", len(got), got)
+	if len(got) != 2 {
+		t.Fatalf("got %d rows, want alice's profile copy and the machine-wide one: %+v", len(got), got)
 	}
-	if got[0].Version != "1.131.0" || got[0].Scope != scopeUser {
-		t.Errorf("version=%q scope=%q want the profile copy 1.131.0/user", got[0].Version, got[0].Scope)
+	byScope := map[string]Plugin{}
+	for _, p := range got {
+		byScope[p.Scope] = p
+	}
+	user, ok := byScope[scopeUser]
+	if !ok {
+		t.Fatalf("alice's profile copy missing: %+v", got)
+	}
+	if user.Version != "1.131.0" || user.Username != "alice" {
+		t.Errorf("version=%q username=%q want alice's 1.131.0", user.Version, user.Username)
+	}
+	// Bob is covered by this row: it is what makes the extension visible for every
+	// account that has no copy of its own.
+	sys, ok := byScope[scopeSystem]
+	if !ok {
+		t.Fatalf("machine-wide copy suppressed by alice's; bob is now invisible: %+v", got)
+	}
+	if sys.Version != "1.130.0" || sys.UID != "" {
+		t.Errorf("version=%q uid=%q want the bundled 1.130.0 with no owner", sys.Version, sys.UID)
 	}
 }
 

--- a/orbit/pkg/table/ai_tools/internal/ide/vscode_builtin_test.go
+++ b/orbit/pkg/table/ai_tools/internal/ide/vscode_builtin_test.go
@@ -77,7 +77,7 @@ func TestScanVSCodeBuiltins(t *testing.T) {
 	write(t, filepath.Join(root, "Slack.app", "Contents", "Resources", "app", "extensions", "x", "package.json"),
 		`{"name":"copilot","publisher":"acme","version":"1.0.0"}`)
 
-	got := scanVSCodeBuiltinsIn([]appRoot{{dir: root, scope: scopeSystem}}, map[string]struct{}{})
+	got := scanVSCodeBuiltinsIn(t.Context(), []appRoot{{dir: root, scope: scopeSystem}}, map[string]struct{}{})
 
 	by := map[string]Plugin{}
 	for _, p := range got {
@@ -135,7 +135,7 @@ func TestScanVSCodeBuiltinsBuildIDLayout(t *testing.T) {
 	write(t, filepath.Join(install, "bin", "code.cmd"), "@echo off")
 
 	h := homes.Home{UID: "S-1-5-21-1001", Username: "juan", Dir: t.TempDir()}
-	got := scanVSCodeBuiltinsIn([]appRoot{{dir: root, scope: scopeUser, home: h}}, map[string]struct{}{})
+	got := scanVSCodeBuiltinsIn(t.Context(), []appRoot{{dir: root, scope: scopeUser, home: h}}, map[string]struct{}{})
 	if len(got) != 1 {
 		t.Fatalf("got %d plugins, want 1 under the build-id layout: %+v", len(got), got)
 	}
@@ -155,7 +155,7 @@ func TestScanVSCodeBuiltinsUserScope(t *testing.T) {
 		`{"name":"copilot-chat","publisher":"GitHub","version":"1.0.0","displayName":"GitHub Copilot Chat"}`)
 
 	h := homes.Home{UID: "501", Username: "tester", Dir: t.TempDir()}
-	got := scanVSCodeBuiltinsIn([]appRoot{{dir: root, scope: scopeUser, home: h}}, map[string]struct{}{})
+	got := scanVSCodeBuiltinsIn(t.Context(), []appRoot{{dir: root, scope: scopeUser, home: h}}, map[string]struct{}{})
 	if len(got) != 1 {
 		t.Fatalf("got %d plugins, want 1: %+v", len(got), got)
 	}
@@ -176,9 +176,9 @@ func TestScanVSCodeBuiltinsSkipsAlreadySeen(t *testing.T) {
 		`{"name":"copilot-chat","publisher":"GitHub","version":"1.130.0","displayName":"Copilot Chat"}`)
 
 	seen := map[string]struct{}{
-		vscodePluginKey("vscode", "github.copilot-chat"): {},
+		vscodePluginKey(scopeSystem, "", "vscode", "github.copilot-chat"): {},
 	}
-	if got := scanVSCodeBuiltinsIn([]appRoot{{dir: root, scope: scopeSystem}}, seen); len(got) != 0 {
+	if got := scanVSCodeBuiltinsIn(t.Context(), []appRoot{{dir: root, scope: scopeSystem}}, seen); len(got) != 0 {
 		t.Errorf("got %+v, want no rows: the user-profile copy was already reported", got)
 	}
 }
@@ -206,6 +206,61 @@ func TestScanReportsMachineWideBuiltinOnce(t *testing.T) {
 	}
 	if got[0].Scope != scopeSystem || got[0].UID != "" {
 		t.Errorf("scope=%q uid=%q want a system row with no owner", got[0].Scope, got[0].UID)
+	}
+}
+
+// Two users who each have their own copy of an editor each have the extension it
+// bundles, so both are reported. De-duplication is per home for user-scoped rows —
+// one account's copy must never hide another's.
+func TestScanVSCodeBuiltinsPerHomeDedup(t *testing.T) {
+	alice := homes.Home{UID: "501", Username: "alice", Dir: t.TempDir()}
+	bob := homes.Home{UID: "502", Username: "bob", Dir: t.TempDir()}
+
+	roots := make([]appRoot, 0, 2)
+	for _, h := range []homes.Home{alice, bob} {
+		appsDir := filepath.Join(h.Dir, "Applications")
+		write(t, filepath.Join(appsDir, "Visual Studio Code.app", "Contents", "Resources", "app", "extensions", "copilot", "package.json"),
+			`{"name":"copilot-chat","publisher":"GitHub","version":"1.132.0","displayName":"GitHub Copilot"}`)
+		roots = append(roots, appRoot{dir: appsDir, scope: scopeUser, home: h})
+	}
+
+	got := scanVSCodeBuiltinsIn(t.Context(), roots, map[string]struct{}{})
+	if len(got) != 2 {
+		t.Fatalf("got %d rows, want one per home: %+v", len(got), got)
+	}
+	byUser := map[string]Plugin{}
+	for _, p := range got {
+		byUser[p.Username] = p
+	}
+	for _, want := range []string{"alice", "bob"} {
+		if _, ok := byUser[want]; !ok {
+			t.Errorf("no row for %s; got %+v", want, got)
+		}
+	}
+}
+
+// The same user's profile copy still takes precedence over that user's bundled
+// copy — the per-home key is shared by both passes.
+func TestScanPerHomeProfileWinsOverUserBundled(t *testing.T) {
+	home := t.TempDir()
+	write(t, filepath.Join(home, ".vscode", "extensions", "github.copilot-chat-1.131.0", "package.json"),
+		`{"name":"copilot-chat","publisher":"GitHub","version":"1.131.0","displayName":"GitHub Copilot"}`)
+	appsDir := filepath.Join(home, "Applications")
+	write(t, filepath.Join(appsDir, "Visual Studio Code.app", "Contents", "Resources", "app", "extensions", "copilot", "package.json"),
+		`{"name":"copilot-chat","publisher":"GitHub","version":"1.132.0","displayName":"GitHub Copilot"}`)
+
+	h := homes.Home{UID: "501", Username: "alice", Dir: home}
+	useAppRoots(t, appRoot{dir: appsDir, scope: scopeUser, home: h})
+
+	got, err := Scan(t.Context(), []homes.Home{h})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d rows, want 1: %+v", len(got), got)
+	}
+	if got[0].Version != "1.131.0" {
+		t.Errorf("version=%q want the profile copy 1.131.0", got[0].Version)
 	}
 }
 
@@ -279,7 +334,7 @@ func TestScanVSCodeBuiltinsUnresolvedPlaceholderUsesName(t *testing.T) {
 	write(t, filepath.Join(root, "Cursor.app", "Contents", "Resources", "app", "extensions", "x", "package.json"),
 		`{"name":"tabnine-chat","publisher":"Acme","version":"1.0.0","displayName":"%displayName%"}`)
 
-	got := scanVSCodeBuiltinsIn([]appRoot{{dir: root, scope: scopeSystem}}, map[string]struct{}{})
+	got := scanVSCodeBuiltinsIn(t.Context(), []appRoot{{dir: root, scope: scopeSystem}}, map[string]struct{}{})
 	if len(got) != 1 {
 		t.Fatalf("got %d plugins, want 1 (classified via the manifest name): %+v", len(got), got)
 	}

--- a/orbit/pkg/table/ai_tools/tables.go
+++ b/orbit/pkg/table/ai_tools/tables.go
@@ -135,13 +135,12 @@ func generate(ctx context.Context, qc table.QueryContext) ([]map[string]string, 
 		}
 	}
 	if has("ide_plugins") {
-		for _, h := range hs {
-			if err := ctx.Err(); err != nil {
-				return nil, err
-			}
-			for _, p := range ide.Scan(h) {
-				rows = append(rows, ideRow(p))
-			}
+		plugins, err := ide.Scan(ctx, hs)
+		if err != nil {
+			return nil, err
+		}
+		for _, p := range plugins {
+			rows = append(rows, ideRow(p))
 		}
 	}
 	if has("agents") {
@@ -269,6 +268,10 @@ func ideRow(p ide.Plugin) map[string]string {
 		"editor_family": p.EditorFamily,
 		"publisher":     p.Publisher,
 		"manifest_path": p.ManifestPath,
+		// scope distinguishes an extension installed in this user's editor profile
+		// from one bundled inside a machine-wide editor install (which has no owner,
+		// so uid/username are empty).
+		"scope": p.Scope,
 	})
 }
 


### PR DESCRIPTION
Resolves #50705

The ide_plugins collector only scanned the user profile's extensions directory. GitHub Copilot Chat ships bundled inside the application from VS Code 1.130+ and the standalone marketplace extension is deprecated, so an actively-enabled Copilot returned zero rows.

Scan application install directories for bundled extensions, covering both the macOS .app/Contents/Resources/app/extensions layout and the Windows/Linux resources/app/extensions layout. Display names are resolved from package.nls.json, and rows are deduped against the user-profile pass since VS Code gives the profile copy precedence.

<img width="1728" height="686" alt="Screenshot 2026-08-10 at 8 51 29 AM" src="https://github.com/user-attachments/assets/fc9ae925-825a-4919-b499-b429ea7121fa" />

# Checklist for submitter

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [X] Confirmed that the fix is not expected to adversely impact load test results

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

* Added discovery of AI extensions bundled with VS Code-family applications.
* Supports bundled extension layouts across macOS, Windows, Linux, Snap, and Flatpak.
* Resolves localized extension names with fallbacks when unavailable.
* Identifies whether extensions are user-installed or system-provided.
* Scans multiple profiles and installations while preventing duplicates.

## Bug Fixes

* Excludes unrelated, invalid, or incomplete extensions.
* Preserves profile-installed extensions when bundled duplicates are found.
* Improved cancellation handling during extension scans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->