### PR TITLE
Fix gofmt formatting in teams_test.go

### DIFF
--- a/server/datastore/mysql/teams_test.go
+++ b/server/datastore/mysql/teams_test.go
@@ -1206,7 +1206,6 @@ func testDefaultTeamConfig(t *testing.T, ds *Datastore) {
 	assert.Equal(t, 50, finalConfig.WebhookSettings.FailingPoliciesWebhook.HostBatchSize)
 }
 
-
 func testTeamLitesByIDs(t *testing.T, ds *Datastore) {
 	ctx := t.Context()
 	teamA, err := ds.NewTeam(ctx, &fleet.Team{Name: "lites-a"})


### PR DESCRIPTION
**Related issue:** NA

`main` is currently failing the `lint` job on a stray double blank line in `server/datastore/mysql/teams_test.go`:

```
server/datastore/mysql/teams_test.go:1209:1: File is not properly formatted (gofmt)
```

This is the `gofmt -w` output and nothing else — one blank line removed, no code change.

# Checklist for submitter

## Testing

- [ ] QA'd all new/changed functionality manually

Whitespace-only change to a test file; no behaviour to QA. Verified `gofmt -l` on the file is empty and `go vet ./server/datastore/mysql/` is clean.
