### PR TITLE
Find per-user and MSIX-packaged AI apps in the ai_tools Windows collector

### DIFF
--- a/orbit/pkg/table/ai_tools/README.md
+++ b/orbit/pkg/table/ai_tools/README.md
@@ -28,9 +28,10 @@ exported `Columns()`/`Generate()` wrappers used to register the table in
   upstream's `HKEY_CURRENT_USER` read resolves to SYSTEM's own empty hive and
   finds nothing: the apps collector walks real users' loaded hives under
   `HKEY_USERS` for per-user uninstall entries, and additionally scans the
-  MSIX/Appx install root and per-user package directories, which no uninstall
-  key covers and which are read redundantly so that one being unreadable still
-  yields a row.
+  MSIX/Appx install root (`%ProgramFiles%\WindowsApps`), which no uninstall key
+  covers. Per-user package directories are read only to attribute scope, never to
+  report an app: they outlive an uninstall, so a row sourced from one would
+  assert an install that is no longer there.
 - **Security hardening** for running in-process in the root/SYSTEM orbit daemon:
   regular-file-only reads that never follow symlinks or block on FIFOs/devices
   (`internal/fsutil`), path-traversal containment for attacker-controlled

--- a/orbit/pkg/table/ai_tools/README.md
+++ b/orbit/pkg/table/ai_tools/README.md
@@ -24,6 +24,13 @@ exported `Columns()`/`Generate()` wrappers used to register the table in
 
 - **Lint compliance** with Fleet's linters (set types, modernize idioms,
   defensive nil guards); all behavior-preserving.
+- **Windows app detection** rewritten for a daemon running as SYSTEM, where
+  upstream's `HKEY_CURRENT_USER` read resolves to SYSTEM's own empty hive and
+  finds nothing: the apps collector walks real users' loaded hives under
+  `HKEY_USERS` for per-user uninstall entries, and additionally scans the
+  MSIX/Appx install root and per-user package directories, which no uninstall
+  key covers and which are read redundantly so that one being unreadable still
+  yields a row.
 - **Security hardening** for running in-process in the root/SYSTEM orbit daemon:
   regular-file-only reads that never follow symlinks or block on FIFOs/devices
   (`internal/fsutil`), path-traversal containment for attacker-controlled

--- a/orbit/pkg/table/ai_tools/internal/apps/apps.go
+++ b/orbit/pkg/table/ai_tools/internal/apps/apps.go
@@ -19,7 +19,7 @@ type App struct {
 	Path           string
 	BundleID       string
 	Version        string
-	PlatformSource string // applications | registry | appx | appx-user | desktop-file
+	PlatformSource string // applications | registry | appx | desktop-file
 	Scope          string // system | user
 	ServesLocalAPI int
 	APIPort        int

--- a/orbit/pkg/table/ai_tools/internal/apps/apps.go
+++ b/orbit/pkg/table/ai_tools/internal/apps/apps.go
@@ -19,7 +19,7 @@ type App struct {
 	Path           string
 	BundleID       string
 	Version        string
-	PlatformSource string // applications | registry | desktop-file
+	PlatformSource string // applications | registry | appx | appx-user | desktop-file
 	Scope          string // system | user
 	ServesLocalAPI int
 	APIPort        int

--- a/orbit/pkg/table/ai_tools/internal/apps/apps_windows.go
+++ b/orbit/pkg/table/ai_tools/internal/apps/apps_windows.go
@@ -7,21 +7,79 @@ import (
 	"golang.org/x/sys/windows/registry"
 )
 
-func scanApps(_ []homes.Home) []App {
-	seen := map[string]struct{}{}
-	var out []App
+// uninstallSubKeys are the uninstall-entry paths to read under each hive root.
+// The WOW6432Node variant only exists machine-wide, but reading a missing key
+// just fails and is skipped, so the same pair is used for every root.
+var uninstallSubKeys = []string{
+	`SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall`,
+	`SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall`,
+}
 
-	roots := []struct {
-		key   registry.Key
-		sub   string
-		scope string
-	}{
-		{registry.LOCAL_MACHINE, `SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall`, "system"},
-		{registry.LOCAL_MACHINE, `SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall`, "system"},
-		{registry.CURRENT_USER, `SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall`, "user"},
+type uninstallRoot struct {
+	key   registry.Key
+	sub   string
+	scope string
+}
+
+// uninstallRoots lists every hive to search for uninstall entries.
+//
+// HKEY_USERS matters because the extension runs as NT AUTHORITY\SYSTEM: in that
+// process CURRENT_USER resolves to SYSTEM's own effectively empty hive, never the
+// interactive user's. Per-user Electron/Squirrel installers (Ollama, ChatGPT
+// desktop, LM Studio) write only to the installing user's hive and offer no
+// machine-wide option, so without walking HKEY_USERS they are invisible. Only
+// hives of logged-in users are loaded there, which is the same liveness scope the
+// homes.Home enumeration gives the other platforms.
+//
+// CURRENT_USER is still read so the collector keeps working when the extension
+// runs unprivileged and cannot open other users' hives.
+//
+// Machine-wide roots come first so that an app installed both ways is reported
+// with scope "system", which is how the collector already behaved.
+func uninstallRoots() []uninstallRoot {
+	var roots []uninstallRoot
+	for _, sub := range uninstallSubKeys {
+		roots = append(roots, uninstallRoot{registry.LOCAL_MACHINE, sub, "system"})
+	}
+	for _, sub := range uninstallSubKeys {
+		roots = append(roots, uninstallRoot{registry.CURRENT_USER, sub, "user"})
 	}
 
-	for _, r := range roots {
+	for _, hive := range realUserHives() {
+		for _, sub := range uninstallSubKeys {
+			roots = append(roots, uninstallRoot{registry.USERS, hive + `\` + sub, "user"})
+		}
+	}
+	return roots
+}
+
+// realUserHives returns the HKEY_USERS subkey names of the loaded hives that
+// belong to a real user's account. Shared by the uninstall-key and MSIX scans,
+// which both need to attribute an install to a person rather than to a service
+// account.
+func realUserHives() []string {
+	hu, err := registry.OpenKey(registry.USERS, "", registry.ENUMERATE_SUB_KEYS)
+	if err != nil {
+		return nil
+	}
+	defer hu.Close()
+	names, err := hu.ReadSubKeyNames(-1)
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, name := range names {
+		if isRealUserHive(name) {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+func scanApps(homesList []homes.Home) []App {
+	c := newAppCollector()
+
+	for _, r := range uninstallRoots() {
 		k, err := registry.OpenKey(r.key, r.sub, registry.READ)
 		if err != nil {
 			continue
@@ -41,21 +99,21 @@ func scanApps(_ []homes.Home) []App {
 			if display == "" {
 				continue
 			}
-			ka, ok := matchKnown(display)
-			if _, dup := seen[ka.name]; !ok || dup {
-				continue
-			}
-			seen[ka.name] = struct{}{}
-			out = append(out, App{
-				Name:           ka.name,
-				Vendor:         pub,
-				Version:        version,
-				Path:           loc,
-				PlatformSource: "registry",
-				Scope:          r.scope,
+			c.add(appCandidate{
+				MatchTokens: []string{display},
+				Vendor:      pub,
+				Version:     version,
+				Path:        loc,
+				Scope:       r.scope,
+				Source:      "registry",
 			})
 		}
 		k.Close()
 	}
-	return out
+
+	// MSIX/Appx packages register nowhere near the uninstall keys, so they need a
+	// separate pass over the package repository. It shares the collector, so an
+	// app found both ways is reported once.
+	scanAppx(c, homesList)
+	return c.apps()
 }

--- a/orbit/pkg/table/ai_tools/internal/apps/appx.go
+++ b/orbit/pkg/table/ai_tools/internal/apps/appx.go
@@ -1,0 +1,312 @@
+package apps
+
+import (
+	"encoding/xml"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/fleetdm/fleet/v4/orbit/pkg/table/ai_tools/internal/fsutil"
+)
+
+// This file holds everything about MSIX/Appx detection that is not a Windows
+// path: the package-name parsing and the directory scan itself. It is
+// platform-neutral (rather than living in appx_windows.go) so the scan can be
+// driven against a temporary directory in tests on any platform; only the
+// Windows build calls it, and only appx_windows.go knows where the real
+// directories are.
+
+// appxPackage is the identity encoded in an MSIX/Appx package full name.
+type appxPackage struct {
+	Name        string // identity name, e.g. "OpenAI.ChatGPT-Desktop"
+	Version     string // e.g. "1.2024.30.0"
+	ResourceID  string // empty for the app itself; "split.*" for satellite packages
+	PublisherID string // 13-character publisher hash, e.g. "2p2nqsd0c76g0"
+}
+
+// FamilyName returns the package family name, "<Name>_<PublisherID>". That is
+// how a package's per-user data directory under %LOCALAPPDATA%\Packages is
+// named, which is what attributes an install to a specific user.
+func (p appxPackage) FamilyName() string {
+	if p.Name == "" || p.PublisherID == "" {
+		return ""
+	}
+	return p.Name + "_" + p.PublisherID
+}
+
+// isResourcePackage reports whether p's name marks it as a satellite resource
+// package (a scale or language split) rather than the app itself. Those repeat
+// the app's identity but point at a different install folder, so reporting one
+// would attribute the wrong path to the app.
+//
+// This is the name-only test, and it is not conclusive: the "split." prefix is
+// the modern convention, but older resource packages use a bare resource id
+// ("scale-100"). The manifest's Properties/ResourcePackage is authoritative and
+// is checked in scanAppxDirs once a candidate's manifest has been read; this
+// stays as the cheap pre-filter that avoids reading those manifests at all, and
+// as the fallback when a manifest cannot be read.
+func (p appxPackage) isResourcePackage() bool {
+	return strings.HasPrefix(p.ResourceID, "split.")
+}
+
+// parsePackageFullName splits an MSIX package full name into its identity
+// fields. The format is Name_Version_Architecture_ResourceId_PublisherId, and
+// none of those fields may itself contain an underscore, so splitting on "_" is
+// exact. Anything that does not parse is rejected rather than reported as a row.
+//
+// The package full name is the source of truth for identity and version because
+// the registry's DisplayName is usually an unresolved MUI indirect string (see
+// appxLiteral).
+func parsePackageFullName(pfn string) (appxPackage, bool) {
+	parts := strings.Split(pfn, "_")
+	if len(parts) != 5 {
+		return appxPackage{}, false
+	}
+	name, version, resourceID, publisherID := parts[0], parts[1], parts[3], parts[4]
+	if name == "" || publisherID == "" || !isDottedNumber(version) {
+		return appxPackage{}, false
+	}
+	return appxPackage{Name: name, Version: version, ResourceID: resourceID, PublisherID: publisherID}, true
+}
+
+// parsePackageFamilyName splits a package family name, "<Name>_<PublisherId>".
+// This is what per-user package directories are named, and unlike a package full
+// name it carries no version.
+func parsePackageFamilyName(family string) (name, publisherID string, ok bool) {
+	parts := strings.Split(family, "_")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
+}
+
+// appxManifest is the subset of AppxManifest.xml this collector reads. Elements
+// are matched by local name, so the manifest's XML namespace does not matter.
+type appxManifest struct {
+	Identity struct {
+		Publisher string `xml:"Publisher,attr"`
+	} `xml:"Identity"`
+	Properties struct {
+		DisplayName          string `xml:"DisplayName"`
+		PublisherDisplayName string `xml:"PublisherDisplayName"`
+		// ResourcePackage is the authoritative marker for a satellite package,
+		// covering the ones whose resource id lacks the "split." prefix.
+		ResourcePackage bool `xml:"ResourcePackage"`
+	} `xml:"Properties"`
+}
+
+// scanAppxDirs adds the AI apps installed as MSIX/Appx packages to c.
+//
+// Two independent sources are read, richest first:
+//
+//   - installRoot holds one directory per staged package, named by package full
+//     name, alongside the package manifest. This gives identity, version, and
+//     publisher, but the directory carries a restrictive ACL.
+//
+//   - userPkgDirs are the per-user package-state directories, named by package
+//     family name. No version, but they sit in the user's own profile, are
+//     readable without special rights, and exist for logged-off users too.
+//
+// Either source alone produces a row. That redundancy is deliberate: the exact
+// location of packaged-app state has moved between Windows releases, so a single
+// source that turns out to be wrong or unreadable would mean silently reporting
+// nothing at all.
+func scanAppxDirs(c *appCollector, installRoot string, userPkgDirs []string) {
+	userFamilies := appxUserFamilies(userPkgDirs)
+
+	for _, name := range readDirNames(installRoot) {
+		pkg, ok := parsePackageFullName(name)
+		if !ok || pkg.isResourcePackage() {
+			continue
+		}
+		// Match on the identity name before touching the package directory. A host
+		// carries several hundred packages and at most a couple are AI apps, so
+		// reading manifests first would mean hundreds of file reads per query for
+		// data that is then discarded.
+		if !c.wants(pkg.Name) {
+			continue
+		}
+		dir := filepath.Join(installRoot, name)
+		// Best effort: the row must not depend on the manifest being readable.
+		man := readAppxManifest(dir)
+		// The authoritative satellite check, which catches the resource packages
+		// whose id lacks the "split." prefix that isResourcePackage looks for.
+		// Safe to skip here because wants only reads the collector.
+		if man.Properties.ResourcePackage {
+			continue
+		}
+
+		scope := "system"
+		if _, isUser := userFamilies[pkg.FamilyName()]; isUser {
+			scope = "user"
+		}
+		c.add(appCandidate{
+			MatchTokens: []string{pkg.Name, appxLiteral(man.Properties.DisplayName)},
+			Vendor:      appxVendor(man.Properties.PublisherDisplayName, man.Identity.Publisher),
+			Version:     pkg.Version,
+			Path:        dir,
+			Scope:       scope,
+			Source:      "appx",
+		})
+	}
+
+	// Anything the install root did not yield. Sorted so that two family names
+	// matching one app resolve the same way on every run.
+	for _, family := range slices.Sorted(maps.Keys(userFamilies)) {
+		name, _, ok := parsePackageFamilyName(family)
+		if !ok || !c.wants(name) {
+			continue
+		}
+		// Path is left empty rather than pointing at the per-user state directory,
+		// which is not where the app is installed.
+		c.add(appCandidate{
+			MatchTokens: []string{name},
+			Scope:       "user",
+			Source:      "appx-user",
+		})
+	}
+}
+
+// appxUserFamilies returns the set of package family names that have per-user
+// state in any of dirs.
+func appxUserFamilies(dirs []string) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, dir := range dirs {
+		for _, name := range readDirNames(dir) {
+			out[name] = struct{}{}
+		}
+	}
+	return out
+}
+
+// readDirNames returns the names of the subdirectories of dir, or nil when dir
+// cannot be read. Every caller treats an unreadable directory as "nothing here".
+func readDirNames(dir string) []string {
+	if dir == "" {
+		return nil
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, e := range entries {
+		if e.IsDir() {
+			out = append(out, e.Name())
+		}
+	}
+	return out
+}
+
+// readAppxManifest reads a package's manifest for its display and publisher
+// names. A missing or malformed manifest yields a zero value rather than an
+// error: the package full name already carries identity and version, so the row
+// is still correct without it.
+func readAppxManifest(dir string) appxManifest {
+	var man appxManifest
+	b, err := fsutil.ReadFileBounded(filepath.Join(dir, "AppxManifest.xml"))
+	if err != nil {
+		return man
+	}
+	_ = xml.Unmarshal(b, &man)
+	return man
+}
+
+// isDottedNumber reports whether s looks like an Appx version quad: digits and
+// dots, with at least one digit.
+func isDottedNumber(s string) bool {
+	digit := false
+	for i := 0; i < len(s); i++ {
+		switch {
+		case s[i] >= '0' && s[i] <= '9':
+			digit = true
+		case s[i] == '.':
+		default:
+			return false
+		}
+	}
+	return digit
+}
+
+// appxLiteral returns s unless it is a MUI indirect string of the form
+// "@{PackageFullName?ms-resource://.../SomeName}". Those resolve only through
+// SHLoadIndirectString; the raw form is worse than nothing for token matching
+// (it embeds the package name, which would match against itself), so it is
+// reported as absent.
+func appxLiteral(s string) string {
+	if strings.HasPrefix(s, "@") {
+		return ""
+	}
+	return s
+}
+
+// appxVendor picks the best available publisher name: the package's
+// PublisherDisplayName when it is a literal string, otherwise the common name of
+// the signing certificate's distinguished name. Store packages very often carry
+// an indirect PublisherDisplayName, so without the fallback most rows would have
+// no vendor at all.
+func appxVendor(publisherDisplayName, publisherDN string) string {
+	if v := appxLiteral(publisherDisplayName); v != "" {
+		return v
+	}
+	return distinguishedNameCN(publisherDN)
+}
+
+// distinguishedNameCN extracts the CN value from a certificate distinguished
+// name such as "CN=Element Labs, Inc., O=Element Labs, C=US".
+//
+// Common names routinely contain commas ("..., Inc."), so a value ends only at a
+// comma that starts the next "Type=" attribute — not at the first comma.
+func distinguishedNameCN(dn string) string {
+	for i := 0; i < len(dn); {
+		j := i
+		for j < len(dn) && isAlpha(dn[j]) {
+			j++
+		}
+		if j == i || j >= len(dn) || dn[j] != '=' {
+			return "" // not a well-formed attribute; give up rather than guess
+		}
+		valStart := j + 1
+		end := dnAttributeEnd(dn, valStart)
+		if strings.EqualFold(dn[i:j], "CN") {
+			return strings.TrimSpace(dn[valStart:end])
+		}
+		i = end
+		if i < len(dn) && dn[i] == ',' {
+			i++
+		}
+		for i < len(dn) && dn[i] == ' ' {
+			i++
+		}
+	}
+	return ""
+}
+
+// dnAttributeEnd returns the index at which the attribute value starting at from
+// ends: the first comma that is followed by another "Type=" pair, or the end of
+// the string.
+func dnAttributeEnd(dn string, from int) int {
+	for i := from; i < len(dn); i++ {
+		if dn[i] != ',' {
+			continue
+		}
+		j := i + 1
+		for j < len(dn) && dn[j] == ' ' {
+			j++
+		}
+		k := j
+		for k < len(dn) && isAlpha(dn[k]) {
+			k++
+		}
+		if k > j && k < len(dn) && dn[k] == '=' {
+			return i
+		}
+	}
+	return len(dn)
+}
+
+func isAlpha(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
+}

--- a/orbit/pkg/table/ai_tools/internal/apps/appx.go
+++ b/orbit/pkg/table/ai_tools/internal/apps/appx.go
@@ -2,10 +2,8 @@ package apps
 
 import (
 	"encoding/xml"
-	"maps"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/ai_tools/internal/fsutil"
@@ -71,15 +69,35 @@ func parsePackageFullName(pfn string) (appxPackage, bool) {
 	return appxPackage{Name: name, Version: version, ResourceID: resourceID, PublisherID: publisherID}, true
 }
 
-// parsePackageFamilyName splits a package family name, "<Name>_<PublisherId>".
-// This is what per-user package directories are named, and unlike a package full
-// name it carries no version.
-func parsePackageFamilyName(family string) (name, publisherID string, ok bool) {
-	parts := strings.Split(family, "_")
-	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		return "", "", false
+// appxInstallDirName is the packaged-app install directory, under Program Files.
+// There is exactly one of them per host: unlike Win32 installers, packaged apps
+// are not subject to the "Program Files (x86)" split, and every architecture
+// stages here with x86/x64/arm64/neutral distinguished inside the package full
+// name instead.
+const appxInstallDirName = "WindowsApps"
+
+// appxInstallRootFrom resolves the packaged-app install root from the Windows
+// environment. It is split out from its Windows-only caller so the redirection
+// rule below is testable.
+//
+// %ProgramFiles% is redirected by process bitness: a 32-bit process on 64-bit
+// Windows sees "C:\Program Files (x86)", which holds no WindowsApps directory,
+// so trusting it would silently scan the wrong place and report nothing.
+// %ProgramW6432% is never redirected and always names the real 64-bit Program
+// Files; it is unset only on 32-bit Windows, where %ProgramFiles% is already
+// right.
+func appxInstallRootFrom(programW6432, programFiles, systemDrive string) string {
+	base := programW6432
+	if base == "" {
+		base = programFiles
 	}
-	return parts[0], parts[1], true
+	if base == "" {
+		if systemDrive == "" {
+			systemDrive = "C:"
+		}
+		base = filepath.Join(systemDrive+`\`, "Program Files")
+	}
+	return filepath.Join(base, appxInstallDirName)
 }
 
 // appxManifest is the subset of AppxManifest.xml this collector reads. Elements
@@ -99,20 +117,17 @@ type appxManifest struct {
 
 // scanAppxDirs adds the AI apps installed as MSIX/Appx packages to c.
 //
-// Two independent sources are read, richest first:
+// installRoot is the only source of rows: it holds one directory per staged
+// package, named by package full name and sitting alongside the package
+// manifest, which together give identity, version, publisher, and install path.
 //
-//   - installRoot holds one directory per staged package, named by package full
-//     name, alongside the package manifest. This gives identity, version, and
-//     publisher, but the directory carries a restrictive ACL.
-//
-//   - userPkgDirs are the per-user package-state directories, named by package
-//     family name. No version, but they sit in the user's own profile, are
-//     readable without special rights, and exist for logged-off users too.
-//
-// Either source alone produces a row. That redundancy is deliberate: the exact
-// location of packaged-app state has moved between Windows releases, so a single
-// source that turns out to be wrong or unreadable would mean silently reporting
-// nothing at all.
+// userPkgDirs are the per-user package-state directories, named by package
+// family name. They are read only to decide whether an install belongs to a user
+// or to the machine — never to report an app. That directory records that a
+// package once ran for a user, not that it is installed now: Windows leaves it
+// behind after an uninstall, so a row sourced from it would assert an install
+// with no version and no path to corroborate it, and would never expire. On an
+// inventory table a missing row is cheaper than a phantom one.
 func scanAppxDirs(c *appCollector, installRoot string, userPkgDirs []string) {
 	userFamilies := appxUserFamilies(userPkgDirs)
 
@@ -149,22 +164,6 @@ func scanAppxDirs(c *appCollector, installRoot string, userPkgDirs []string) {
 			Path:        dir,
 			Scope:       scope,
 			Source:      "appx",
-		})
-	}
-
-	// Anything the install root did not yield. Sorted so that two family names
-	// matching one app resolve the same way on every run.
-	for _, family := range slices.Sorted(maps.Keys(userFamilies)) {
-		name, _, ok := parsePackageFamilyName(family)
-		if !ok || !c.wants(name) {
-			continue
-		}
-		// Path is left empty rather than pointing at the per-user state directory,
-		// which is not where the app is installed.
-		c.add(appCandidate{
-			MatchTokens: []string{name},
-			Scope:       "user",
-			Source:      "appx-user",
 		})
 	}
 }

--- a/orbit/pkg/table/ai_tools/internal/apps/appx_scan_test.go
+++ b/orbit/pkg/table/ai_tools/internal/apps/appx_scan_test.go
@@ -154,10 +154,12 @@ func TestScanAppxDirsScopeFromUserDir(t *testing.T) {
 	}
 }
 
-// TestScanAppxDirsUserDirFallback is the defense-in-depth case: the install root
-// is unreadable or absent — the failure mode that made MSIX apps invisible on a
-// real host — and the per-user directories alone must still yield the app.
-func TestScanAppxDirsUserDirFallback(t *testing.T) {
+// TestScanAppxDirsNoRowsFromUserDirsAlone pins down that per-user package
+// directories never produce a row. That directory records that a package once
+// ran for a user and survives uninstall, so sourcing rows from it would report
+// removed apps forever, with no version or path to check them against. An
+// unreadable install root must report nothing rather than something unverified.
+func TestScanAppxDirsNoRowsFromUserDirsAlone(t *testing.T) {
 	userPkgs := t.TempDir()
 	mkPackageDir(t, userPkgs, "OpenAI.ChatGPT-Desktop_2p2nqsd0c76g0", "")
 	mkPackageDir(t, userPkgs, "Microsoft.WindowsCalculator_8wekyb3d8bbwe", "")
@@ -165,24 +167,34 @@ func TestScanAppxDirsUserDirFallback(t *testing.T) {
 	for _, installRoot := range []string{
 		"",
 		filepath.Join(t.TempDir(), "does-not-exist"),
+		t.TempDir(), // readable but empty
 	} {
 		c := newAppCollector()
 		scanAppxDirs(c, installRoot, []string{userPkgs})
 
-		got := c.apps()
-		if len(got) != 1 {
-			t.Fatalf("installRoot=%q: got %d apps, want 1: %+v", installRoot, len(got), got)
+		if got := c.apps(); len(got) != 0 {
+			t.Errorf("installRoot=%q: got %d apps, want 0: %+v", installRoot, len(got), got)
 		}
-		if got[0].Name != "chatgpt" || got[0].Scope != "user" {
-			t.Errorf("installRoot=%q: got name=%q scope=%q, want chatgpt/user", installRoot, got[0].Name, got[0].Scope)
-		}
-		if got[0].PlatformSource != "appx-user" {
-			t.Errorf("installRoot=%q: got source %q, want \"appx-user\" so the fallback is visible in results",
-				installRoot, got[0].PlatformSource)
-		}
-		if got[0].Version != "" {
-			t.Errorf("installRoot=%q: got version %q, want empty: a family name carries none", installRoot, got[0].Version)
-		}
+	}
+}
+
+// TestScanAppxDirsStaleUserDirIsNotAnInstall is the regression test for the
+// phantom row: a healthy host where the app was uninstalled but Windows left its
+// per-user state directory behind. The install root is authoritative, and it
+// does not list the package.
+func TestScanAppxDirsStaleUserDirIsNotAnInstall(t *testing.T) {
+	root := t.TempDir()
+	mkPackageDir(t, root, "Microsoft.WindowsCalculator_11.2210.0.0_x64__8wekyb3d8bbwe", "")
+	mkPackageDir(t, root, "Microsoft.VCLibs.140.00_14.0.30704.0_x64__8wekyb3d8bbwe", "")
+
+	userPkgs := t.TempDir()
+	mkPackageDir(t, userPkgs, "OpenAI.ChatGPT-Desktop_2p2nqsd0c76g0", "") // left over from an uninstall
+
+	c := newAppCollector()
+	scanAppxDirs(c, root, []string{userPkgs})
+
+	if got := c.apps(); len(got) != 0 {
+		t.Errorf("got %d apps, want 0: a leftover per-user directory is not an install: %+v", len(got), got)
 	}
 }
 

--- a/orbit/pkg/table/ai_tools/internal/apps/appx_scan_test.go
+++ b/orbit/pkg/table/ai_tools/internal/apps/appx_scan_test.go
@@ -1,0 +1,236 @@
+package apps
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const chatGPTPFN = "OpenAI.ChatGPT-Desktop_1.2026.190.0_arm64__2p2nqsd0c76g0"
+
+const chatGPTManifest = `<?xml version="1.0" encoding="utf-8"?>
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10">
+  <Identity Name="OpenAI.ChatGPT-Desktop" Publisher="CN=OpenAI, O=OpenAI OpCo, LLC, C=US" Version="1.2026.190.0" />
+  <Properties>
+    <DisplayName>ChatGPT</DisplayName>
+    <PublisherDisplayName>OpenAI</PublisherDisplayName>
+  </Properties>
+</Package>`
+
+// mkPackageDir creates <root>/<name>, writing an AppxManifest.xml when manifest
+// is non-empty.
+func mkPackageDir(t *testing.T, root, name, manifest string) string {
+	t.Helper()
+	dir := filepath.Join(root, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	if manifest != "" {
+		if err := os.WriteFile(filepath.Join(dir, "AppxManifest.xml"), []byte(manifest), 0o644); err != nil {
+			t.Fatalf("write manifest: %v", err)
+		}
+	}
+	return dir
+}
+
+func TestScanAppxDirsInstallRoot(t *testing.T) {
+	root := t.TempDir()
+	dir := mkPackageDir(t, root, chatGPTPFN, chatGPTManifest)
+	// Packages that must not produce rows.
+	mkPackageDir(t, root, "Microsoft.WindowsCalculator_11.2210.0.0_x64__8wekyb3d8bbwe", "")
+	mkPackageDir(t, root, "Microsoft.VCLibs.140.00_14.0.30704.0_x64__8wekyb3d8bbwe", "")
+	mkPackageDir(t, root, "NVIDIACorp.NVIDIAControlPanel_8.1.966.0_x64__56jybvy8sckqj", "")
+
+	c := newAppCollector()
+	scanAppxDirs(c, root, nil)
+
+	got := c.apps()
+	if len(got) != 1 {
+		t.Fatalf("got %d apps, want 1: %+v", len(got), got)
+	}
+	want := App{
+		Name: "chatgpt", Vendor: "OpenAI", Version: "1.2026.190.0",
+		Path: dir, Scope: "system", PlatformSource: "appx",
+	}
+	if got[0] != want {
+		t.Errorf("got %+v\nwant %+v", got[0], want)
+	}
+}
+
+// TestScanAppxDirsResourcePackageSkipped guards against a satellite package
+// winning the dedup race and contributing the wrong install path. That race is
+// real: os.ReadDir returns sorted names, and "..._neutral_scale-100_pub" sorts
+// before "..._x64__pub", so on an x64 host the satellite is seen first.
+func TestScanAppxDirsResourcePackageSkipped(t *testing.T) {
+	const resourceManifest = `<?xml version="1.0" encoding="utf-8"?>
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10">
+  <Identity Name="OpenAI.ChatGPT-Desktop" Publisher="CN=OpenAI, O=OpenAI OpCo, LLC, C=US" Version="1.2026.190.0" />
+  <Properties>
+    <DisplayName>ChatGPT</DisplayName>
+    <PublisherDisplayName>OpenAI</PublisherDisplayName>
+    <ResourcePackage>true</ResourcePackage>
+  </Properties>
+</Package>`
+
+	cases := []struct {
+		name     string
+		pfn      string
+		manifest string
+	}{
+		{
+			// Modern convention: caught by the name alone, no manifest needed.
+			name: "split prefix",
+			pfn:  "OpenAI.ChatGPT-Desktop_1.2026.190.0_neutral_split.scale-100_2p2nqsd0c76g0",
+		},
+		{
+			// Older convention: the resource id carries no "split." prefix, so only
+			// the manifest identifies it as a satellite.
+			name:     "bare resource id with manifest",
+			pfn:      "OpenAI.ChatGPT-Desktop_1.2026.190.0_neutral_scale-100_2p2nqsd0c76g0",
+			manifest: resourceManifest,
+		},
+		{
+			name:     "bare language resource id with manifest",
+			pfn:      "OpenAI.ChatGPT-Desktop_1.2026.190.0_neutral_language-en_2p2nqsd0c76g0",
+			manifest: resourceManifest,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			root := t.TempDir()
+			mkPackageDir(t, root, c.pfn, c.manifest)
+
+			col := newAppCollector()
+			scanAppxDirs(col, root, nil)
+			if got := col.apps(); len(got) != 0 {
+				t.Errorf("got %d apps from a resource package alone, want 0: %+v", len(got), got)
+			}
+		})
+	}
+}
+
+// TestScanAppxDirsResourcePackageLosesToMainPackage is the case the satellite
+// filter exists for: both packages present, the satellite sorted first, and the
+// app still reported at its real install path.
+func TestScanAppxDirsResourcePackageLosesToMainPackage(t *testing.T) {
+	root := t.TempDir()
+	mkPackageDir(t, root, "OpenAI.ChatGPT-Desktop_1.2026.190.0_neutral_split.scale-100_2p2nqsd0c76g0", "")
+	mainDir := mkPackageDir(t, root, "OpenAI.ChatGPT-Desktop_1.2026.190.0_x64__2p2nqsd0c76g0", chatGPTManifest)
+
+	c := newAppCollector()
+	scanAppxDirs(c, root, nil)
+
+	got := c.apps()
+	if len(got) != 1 {
+		t.Fatalf("got %d apps, want 1: %+v", len(got), got)
+	}
+	if got[0].Path != mainDir {
+		t.Errorf("got path %q, want the main package at %q", got[0].Path, mainDir)
+	}
+}
+
+// TestScanAppxDirsScopeFromUserDir covers attribution: a package with per-user
+// state belongs to a user, not to the machine.
+func TestScanAppxDirsScopeFromUserDir(t *testing.T) {
+	root := t.TempDir()
+	mkPackageDir(t, root, chatGPTPFN, chatGPTManifest)
+
+	userPkgs := t.TempDir()
+	mkPackageDir(t, userPkgs, "OpenAI.ChatGPT-Desktop_2p2nqsd0c76g0", "")
+
+	c := newAppCollector()
+	scanAppxDirs(c, root, []string{userPkgs})
+
+	got := c.apps()
+	if len(got) != 1 {
+		t.Fatalf("got %d apps, want 1: %+v", len(got), got)
+	}
+	if got[0].Scope != "user" {
+		t.Errorf("got scope %q, want \"user\"", got[0].Scope)
+	}
+	if got[0].PlatformSource != "appx" {
+		t.Errorf("got source %q, want \"appx\": the install root is richer and is read first", got[0].PlatformSource)
+	}
+}
+
+// TestScanAppxDirsUserDirFallback is the defense-in-depth case: the install root
+// is unreadable or absent — the failure mode that made MSIX apps invisible on a
+// real host — and the per-user directories alone must still yield the app.
+func TestScanAppxDirsUserDirFallback(t *testing.T) {
+	userPkgs := t.TempDir()
+	mkPackageDir(t, userPkgs, "OpenAI.ChatGPT-Desktop_2p2nqsd0c76g0", "")
+	mkPackageDir(t, userPkgs, "Microsoft.WindowsCalculator_8wekyb3d8bbwe", "")
+
+	for _, installRoot := range []string{
+		"",
+		filepath.Join(t.TempDir(), "does-not-exist"),
+	} {
+		c := newAppCollector()
+		scanAppxDirs(c, installRoot, []string{userPkgs})
+
+		got := c.apps()
+		if len(got) != 1 {
+			t.Fatalf("installRoot=%q: got %d apps, want 1: %+v", installRoot, len(got), got)
+		}
+		if got[0].Name != "chatgpt" || got[0].Scope != "user" {
+			t.Errorf("installRoot=%q: got name=%q scope=%q, want chatgpt/user", installRoot, got[0].Name, got[0].Scope)
+		}
+		if got[0].PlatformSource != "appx-user" {
+			t.Errorf("installRoot=%q: got source %q, want \"appx-user\" so the fallback is visible in results",
+				installRoot, got[0].PlatformSource)
+		}
+		if got[0].Version != "" {
+			t.Errorf("installRoot=%q: got version %q, want empty: a family name carries none", installRoot, got[0].Version)
+		}
+	}
+}
+
+// TestScanAppxDirsMissingManifest covers the manifest being unreadable, which
+// must cost only the vendor, never the row.
+func TestScanAppxDirsMissingManifest(t *testing.T) {
+	for _, manifest := range []string{"", "not xml at all <<<", "<Package><Identity/></Package>"} {
+		root := t.TempDir()
+		mkPackageDir(t, root, chatGPTPFN, manifest)
+
+		c := newAppCollector()
+		scanAppxDirs(c, root, nil)
+
+		got := c.apps()
+		if len(got) != 1 {
+			t.Fatalf("manifest=%q: got %d apps, want 1", manifest, len(got))
+		}
+		if got[0].Version != "1.2026.190.0" {
+			t.Errorf("manifest=%q: got version %q, want it from the package name", manifest, got[0].Version)
+		}
+		if got[0].Vendor != "" {
+			t.Errorf("manifest=%q: got vendor %q, want empty", manifest, got[0].Vendor)
+		}
+	}
+}
+
+// TestScanAppxDirsSharedWithUninstallScan covers the ordering the Windows
+// collector depends on: an app already found in the uninstall keys keeps that
+// richer entry instead of being replaced by a package directory.
+func TestScanAppxDirsSharedWithUninstallScan(t *testing.T) {
+	root := t.TempDir()
+	mkPackageDir(t, root, chatGPTPFN, chatGPTManifest)
+
+	c := newAppCollector()
+	c.add(appCandidate{
+		MatchTokens: []string{"ChatGPT"},
+		Version:     "1.2026.190",
+		Path:        `C:\Users\alice\AppData\Local\Programs\ChatGPT`,
+		Scope:       "user",
+		Source:      "registry",
+	})
+	scanAppxDirs(c, root, nil)
+
+	got := c.apps()
+	if len(got) != 1 {
+		t.Fatalf("got %d apps, want 1: %+v", len(got), got)
+	}
+	if got[0].PlatformSource != "registry" {
+		t.Errorf("got source %q, want \"registry\"", got[0].PlatformSource)
+	}
+}

--- a/orbit/pkg/table/ai_tools/internal/apps/appx_test.go
+++ b/orbit/pkg/table/ai_tools/internal/apps/appx_test.go
@@ -1,6 +1,9 @@
 package apps
 
-import "testing"
+import (
+	"path/filepath"
+	"testing"
+)
 
 func TestParsePackageFullName(t *testing.T) {
 	cases := []struct {
@@ -96,6 +99,50 @@ func TestAppxPackageFamilyName(t *testing.T) {
 	}
 	if got := (appxPackage{}).FamilyName(); got != "" {
 		t.Errorf("zero appxPackage FamilyName() = %q want \"\"", got)
+	}
+}
+
+// TestAppxInstallRootFrom covers the WOW64 trap: %ProgramFiles% is redirected to
+// "Program Files (x86)" for a 32-bit process, and that directory holds no
+// WindowsApps, so %ProgramW6432% must win whenever it is set.
+func TestAppxInstallRootFrom(t *testing.T) {
+	cases := []struct {
+		name                                 string
+		programW6432, programFiles, sysDrive string
+		want                                 string
+	}{
+		{
+			name:         "64-bit process: both set and identical",
+			programW6432: `C:\Program Files`, programFiles: `C:\Program Files`,
+			want: filepath.Join(`C:\Program Files`, "WindowsApps"),
+		},
+		{
+			name:         "32-bit process: ProgramFiles is redirected and must lose",
+			programW6432: `C:\Program Files`, programFiles: `C:\Program Files (x86)`,
+			want: filepath.Join(`C:\Program Files`, "WindowsApps"),
+		},
+		{
+			name:         "32-bit Windows: ProgramW6432 unset, ProgramFiles is correct",
+			programFiles: `C:\Program Files`,
+			want:         filepath.Join(`C:\Program Files`, "WindowsApps"),
+		},
+		{
+			name:     "no Program Files vars: fall back to the system drive",
+			sysDrive: "D:",
+			want:     filepath.Join(filepath.Join(`D:\`, "Program Files"), "WindowsApps"),
+		},
+		{
+			name: "nothing set at all",
+			want: filepath.Join(filepath.Join(`C:\`, "Program Files"), "WindowsApps"),
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := appxInstallRootFrom(c.programW6432, c.programFiles, c.sysDrive); got != c.want {
+				t.Errorf("appxInstallRootFrom(%q, %q, %q) = %q want %q",
+					c.programW6432, c.programFiles, c.sysDrive, got, c.want)
+			}
+		})
 	}
 }
 

--- a/orbit/pkg/table/ai_tools/internal/apps/appx_test.go
+++ b/orbit/pkg/table/ai_tools/internal/apps/appx_test.go
@@ -1,0 +1,182 @@
+package apps
+
+import "testing"
+
+func TestParsePackageFullName(t *testing.T) {
+	cases := []struct {
+		pfn        string
+		wantOK     bool
+		name       string
+		version    string
+		resourceID string
+	}{
+		{
+			pfn: "OpenAI.ChatGPT-Desktop_1.2024.30.0_x64__2p2nqsd0c76g0", wantOK: true,
+			name: "OpenAI.ChatGPT-Desktop", version: "1.2024.30.0",
+		},
+		{
+			pfn: "ElementLabs.LMStudio_0.3.9.0_x64__k1h2f0dnjkqp0", wantOK: true,
+			name: "ElementLabs.LMStudio", version: "0.3.9.0",
+		},
+		{
+			// Observed on a Windows 11 ARM64 host.
+			pfn: "OpenAI.ChatGPT-Desktop_1.2026.190.0_arm64__2p2nqsd0c76g0", wantOK: true,
+			name: "OpenAI.ChatGPT-Desktop", version: "1.2026.190.0",
+		},
+		{
+			// A package name may itself contain dots; only underscores delimit fields.
+			pfn: "Microsoft.VCLibs.140.00_14.0.30704.0_x64__8wekyb3d8bbwe", wantOK: true,
+			name: "Microsoft.VCLibs.140.00", version: "14.0.30704.0",
+		},
+		{
+			// Resource ("split") satellite packages carry the same identity as the
+			// main package but a non-empty resource id.
+			pfn: "Microsoft.WindowsCalculator_11.2210.0.0_neutral_split.scale-100_8wekyb3d8bbwe", wantOK: true,
+			name: "Microsoft.WindowsCalculator", version: "11.2210.0.0", resourceID: "split.scale-100",
+		},
+
+		// Malformed names must be rejected rather than yielding a garbage row.
+		{pfn: "", wantOK: false},
+		{pfn: "NotAPackage", wantOK: false},
+		{pfn: "A_B_C_D_E", wantOK: false},                   // version is not numeric
+		{pfn: "Foo_1.0.0.0_x64_", wantOK: false},            // truncated: no publisher id
+		{pfn: "Foo__x64__8wekyb3d8bbwe", wantOK: false},     // empty version
+		{pfn: "_1.0.0.0_x64__8wekyb3d8bbwe", wantOK: false}, // empty name
+	}
+
+	for _, c := range cases {
+		got, ok := parsePackageFullName(c.pfn)
+		if ok != c.wantOK {
+			t.Errorf("parsePackageFullName(%q) ok=%v want %v", c.pfn, ok, c.wantOK)
+			continue
+		}
+		if !ok {
+			continue
+		}
+		if got.Name != c.name || got.Version != c.version || got.ResourceID != c.resourceID {
+			t.Errorf("parsePackageFullName(%q) = %+v want name=%q version=%q resourceID=%q",
+				c.pfn, got, c.name, c.version, c.resourceID)
+		}
+	}
+}
+
+func TestAppxPackageIsResourcePackage(t *testing.T) {
+	cases := []struct {
+		resourceID string
+		want       bool
+	}{
+		{"", false},
+		{"split.scale-100", true},
+		{"split.language-en", true},
+	}
+	for _, c := range cases {
+		p := appxPackage{Name: "Some.App", Version: "1.0.0.0", ResourceID: c.resourceID}
+		if got := p.isResourcePackage(); got != c.want {
+			t.Errorf("appxPackage{ResourceID:%q}.isResourcePackage() = %v want %v", c.resourceID, got, c.want)
+		}
+	}
+}
+
+// TestAppxPackageFamilyName covers the identifier used to attribute an install
+// to a user: %LOCALAPPDATA%\Packages subdirectories are named by family name,
+// not by package full name.
+func TestAppxPackageFamilyName(t *testing.T) {
+	cases := []struct{ pfn, want string }{
+		{"OpenAI.ChatGPT-Desktop_1.2026.190.0_arm64__2p2nqsd0c76g0", "OpenAI.ChatGPT-Desktop_2p2nqsd0c76g0"},
+		{"Microsoft.WindowsCalculator_11.2210.0.0_x64__8wekyb3d8bbwe", "Microsoft.WindowsCalculator_8wekyb3d8bbwe"},
+	}
+	for _, c := range cases {
+		p, ok := parsePackageFullName(c.pfn)
+		if !ok {
+			t.Fatalf("parsePackageFullName(%q) failed", c.pfn)
+		}
+		if got := p.FamilyName(); got != c.want {
+			t.Errorf("FamilyName(%q) = %q want %q", c.pfn, got, c.want)
+		}
+	}
+	if got := (appxPackage{}).FamilyName(); got != "" {
+		t.Errorf("zero appxPackage FamilyName() = %q want \"\"", got)
+	}
+}
+
+func TestAppxLiteral(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"ChatGPT", "ChatGPT"},
+		{"LM Studio", "LM Studio"},
+		{"", ""},
+		// MUI indirect strings are unresolvable without SHLoadIndirectString and
+		// are useless for token matching, so they are discarded.
+		{"@{OpenAI.ChatGPT_1.0.0.0_x64__2p2nqsd0c76g0?ms-resource://OpenAI.ChatGPT/Resources/AppName}", ""},
+		{"@{Microsoft.WindowsCalculator?ms-resource://Foo}", ""},
+		{"@", ""},
+	}
+	for _, c := range cases {
+		if got := appxLiteral(c.in); got != c.want {
+			t.Errorf("appxLiteral(%q) = %q want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestAppxVendor(t *testing.T) {
+	cases := []struct {
+		display string
+		dn      string
+		want    string
+	}{
+		// A literal PublisherDisplayName always wins.
+		{"OpenAI", "CN=OpenAI, O=OpenAI OpCo, LLC, C=US", "OpenAI"},
+
+		// When it is an indirect string, fall back to the certificate common name.
+		{"@{Foo?ms-resource://Foo/PublisherDisplayName}", "CN=OpenAI, O=OpenAI OpCo, LLC, L=San Francisco, S=California, C=US", "OpenAI"},
+		{"", "CN=OpenAI, O=OpenAI OpCo, LLC, L=San Francisco, S=California, C=US", "OpenAI"},
+
+		// A comma inside the common name must not truncate it: only a comma that
+		// starts the next attribute (", O=") ends the value.
+		{"", "CN=Element Labs, Inc., O=Element Labs, C=US", "Element Labs, Inc."},
+		{"", "CN=Solo", "Solo"},
+
+		// Nothing usable.
+		{"", "O=NoCommonName, C=US", ""},
+		{"", "", ""},
+		{"@{Foo?ms-resource://x}", "", ""},
+	}
+	for _, c := range cases {
+		if got := appxVendor(c.display, c.dn); got != c.want {
+			t.Errorf("appxVendor(%q, %q) = %q want %q", c.display, c.dn, got, c.want)
+		}
+	}
+}
+
+// TestMatchKnownPackageNames locks in that MSIX package identity names match the
+// existing knownApps tokens on their own, so the collector does not need to
+// space-normalize them. That matters: normalizing "NVIDIA.NVIDIAControlPanel"
+// into "nvidia nvidiacontrolpanel" makes it match the "dia " token for the Dia
+// browser, and dotted package names avoid that collision entirely.
+func TestMatchKnownPackageNames(t *testing.T) {
+	cases := []struct {
+		pkgName string
+		wantOK  bool
+		want    string
+	}{
+		{"OpenAI.ChatGPT-Desktop", true, "chatgpt"},
+		{"ElementLabs.LMStudio", true, "lm-studio"},
+		{"Perplexity.Comet", true, "perplexity"},
+
+		{"Microsoft.WindowsCalculator", false, ""},
+		{"Microsoft.VCLibs.140.00", false, ""},
+		{"NVIDIA.NVIDIAControlPanel", false, ""},
+	}
+	for _, c := range cases {
+		k, ok := matchKnown(c.pkgName)
+		if ok != c.wantOK {
+			t.Errorf("matchKnown(%q) ok=%v want %v (matched %q)", c.pkgName, ok, c.wantOK, k.name)
+			continue
+		}
+		if ok && k.name != c.want {
+			t.Errorf("matchKnown(%q) = %q want %q", c.pkgName, k.name, c.want)
+		}
+	}
+}

--- a/orbit/pkg/table/ai_tools/internal/apps/appx_windows.go
+++ b/orbit/pkg/table/ai_tools/internal/apps/appx_windows.go
@@ -1,0 +1,56 @@
+//go:build windows
+
+package apps
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/fleetdm/fleet/v4/orbit/pkg/table/ai_tools/internal/homes"
+)
+
+// MSIX/Appx packages are why the uninstall-key scan is not enough on its own.
+// They never write an entry under CurrentVersion\Uninstall — that is the
+// convention of legacy Win32 installers — so a Store-distributed app is
+// invisible to that scan no matter which hive it walks. AI apps ship this way
+// (ChatGPT desktop among them).
+//
+// Detection reads directories rather than the registry. The
+// AppModel\Repository\Packages key that used to list packages is a Windows 8 /
+// early-Windows-10 artifact and is absent on current Windows, where package
+// state lives in the StateRepository database under
+// C:\ProgramData\Microsoft\Windows\AppRepository — a locked SQLite file owned by
+// a service, and not something a collector should open. The directories below
+// need no such machinery: they are named by package full name and package family
+// name, which carry the identity outright.
+const appxInstallDirName = "WindowsApps"
+
+// appxUserDataSubdir is a package's per-user state directory, relative to a home
+// directory and named by package family name.
+var appxUserDataSubdir = filepath.Join("AppData", "Local", "Packages")
+
+// scanAppx adds the AI apps installed as MSIX/Appx packages to c.
+//
+// It shares the caller's collector rather than building its own, so an app also
+// found in the uninstall keys keeps that entry: a real DisplayVersion and
+// InstallLocation beat a package directory.
+func scanAppx(c *appCollector, homesList []homes.Home) {
+	userDirs := make([]string, 0, len(homesList))
+	for _, h := range homesList {
+		userDirs = append(userDirs, filepath.Join(h.Dir, appxUserDataSubdir))
+	}
+	scanAppxDirs(c, appxInstallRoot(), userDirs)
+}
+
+// appxInstallRoot returns the packaged-app install root, normally
+// "C:\Program Files\WindowsApps".
+func appxInstallRoot() string {
+	if pf := os.Getenv("ProgramFiles"); pf != "" {
+		return filepath.Join(pf, appxInstallDirName)
+	}
+	drive := os.Getenv("SystemDrive")
+	if drive == "" {
+		drive = "C:"
+	}
+	return filepath.Join(drive+`\`, "Program Files", appxInstallDirName)
+}

--- a/orbit/pkg/table/ai_tools/internal/apps/appx_windows.go
+++ b/orbit/pkg/table/ai_tools/internal/apps/appx_windows.go
@@ -23,7 +23,6 @@ import (
 // a service, and not something a collector should open. The directories below
 // need no such machinery: they are named by package full name and package family
 // name, which carry the identity outright.
-const appxInstallDirName = "WindowsApps"
 
 // appxUserDataSubdir is a package's per-user state directory, relative to a home
 // directory and named by package family name.
@@ -45,12 +44,9 @@ func scanAppx(c *appCollector, homesList []homes.Home) {
 // appxInstallRoot returns the packaged-app install root, normally
 // "C:\Program Files\WindowsApps".
 func appxInstallRoot() string {
-	if pf := os.Getenv("ProgramFiles"); pf != "" {
-		return filepath.Join(pf, appxInstallDirName)
-	}
-	drive := os.Getenv("SystemDrive")
-	if drive == "" {
-		drive = "C:"
-	}
-	return filepath.Join(drive+`\`, "Program Files", appxInstallDirName)
+	return appxInstallRootFrom(
+		os.Getenv("ProgramW6432"),
+		os.Getenv("ProgramFiles"),
+		os.Getenv("SystemDrive"),
+	)
 }

--- a/orbit/pkg/table/ai_tools/internal/apps/collect.go
+++ b/orbit/pkg/table/ai_tools/internal/apps/collect.go
@@ -1,0 +1,79 @@
+package apps
+
+// This file holds the platform-neutral half of app collection: matching a
+// discovered candidate against the known-app list, and deciding which of several
+// discoveries of the same app wins.
+//
+// It lives outside the build-tagged files so those precedence rules can be
+// tested on any platform; only the Windows build calls it today, where a single
+// app can legitimately be discovered by two different scans of two different
+// registry namespaces.
+
+// appCandidate is one potential app a platform scan discovered, before it is
+// matched against the known-app list and deduplicated.
+type appCandidate struct {
+	MatchTokens []string // identifying strings matched against knownApps
+	Vendor      string
+	Version     string
+	Path        string
+	Scope       string // system | user
+	Source      string // PlatformSource
+}
+
+// appCollector accumulates candidates and keeps the first match for each known
+// app, so discovery order is what encodes precedence:
+//
+//   - machine-wide registry roots are scanned before per-user ones, so an app
+//     installed both ways is reported with scope "system";
+//   - uninstall entries are scanned before MSIX packages, so an app registered
+//     both ways keeps the richer DisplayVersion/InstallLocation metadata.
+//
+// Every scan on a platform shares one collector. Giving each scan its own would
+// let the same app be reported twice under the same name, which the table has no
+// way to reconcile.
+type appCollector struct {
+	seen map[string]struct{}
+	out  []App
+}
+
+func newAppCollector() *appCollector {
+	return &appCollector{seen: map[string]struct{}{}}
+}
+
+// wants reports whether tokens identify a known app that has not been collected
+// yet. Callers use it to skip expensive metadata reads for candidates that would
+// be discarded anyway.
+func (c *appCollector) wants(tokens ...string) bool {
+	k, ok := matchKnown(tokens...)
+	if !ok {
+		return false
+	}
+	_, dup := c.seen[k.name]
+	return !dup
+}
+
+// add records cand unless it matches no known app, or that app was already
+// collected by an earlier (higher-precedence) scan. It reports whether the
+// candidate was added.
+func (c *appCollector) add(cand appCandidate) bool {
+	k, ok := matchKnown(cand.MatchTokens...)
+	if !ok {
+		return false
+	}
+	if _, dup := c.seen[k.name]; dup {
+		return false
+	}
+	c.seen[k.name] = struct{}{}
+	c.out = append(c.out, App{
+		Name:           k.name,
+		Vendor:         cand.Vendor,
+		Version:        cand.Version,
+		Path:           cand.Path,
+		PlatformSource: cand.Source,
+		Scope:          cand.Scope,
+	})
+	return true
+}
+
+// apps returns the collected apps in discovery order.
+func (c *appCollector) apps() []App { return c.out }

--- a/orbit/pkg/table/ai_tools/internal/apps/collect_test.go
+++ b/orbit/pkg/table/ai_tools/internal/apps/collect_test.go
@@ -1,0 +1,121 @@
+package apps
+
+import "testing"
+
+// TestAppCollectorScopePrecedence covers the machine-wide-first ordering the
+// Windows scan relies on: an app installed both machine-wide and per-user must
+// be reported once, with scope "system".
+func TestAppCollectorScopePrecedence(t *testing.T) {
+	c := newAppCollector()
+	if !c.add(appCandidate{MatchTokens: []string{"Cursor"}, Scope: "system", Source: "registry", Version: "1.0"}) {
+		t.Fatal("first Cursor candidate was not added")
+	}
+	if c.add(appCandidate{MatchTokens: []string{"Cursor"}, Scope: "user", Source: "registry", Version: "2.0"}) {
+		t.Error("second Cursor candidate was added; the machine-wide one should win")
+	}
+
+	got := c.apps()
+	if len(got) != 1 {
+		t.Fatalf("got %d apps, want 1: %+v", len(got), got)
+	}
+	if got[0].Scope != "system" || got[0].Version != "1.0" {
+		t.Errorf("got scope=%q version=%q, want scope=\"system\" version=\"1.0\"", got[0].Scope, got[0].Version)
+	}
+}
+
+// TestAppCollectorSharedAcrossSources is the invariant that keeps the uninstall
+// and MSIX scans from double-reporting one app: they share a collector, and the
+// earlier scan's richer metadata wins.
+func TestAppCollectorSharedAcrossSources(t *testing.T) {
+	c := newAppCollector()
+	c.add(appCandidate{
+		MatchTokens: []string{"ChatGPT"},
+		Source:      "registry",
+		Version:     "1.2024.30",
+		Path:        `C:\Users\alice\AppData\Local\Programs\ChatGPT`,
+		Scope:       "user",
+	})
+	// The same app, discovered again as an MSIX package.
+	c.add(appCandidate{
+		MatchTokens: []string{"OpenAI.ChatGPT-Desktop"},
+		Source:      "appx",
+		Version:     "1.2024.30.0",
+		Path:        `C:\Program Files\WindowsApps\OpenAI.ChatGPT-Desktop_1.2024.30.0_x64__2p2nqsd0c76g0`,
+		Scope:       "user",
+	})
+
+	got := c.apps()
+	if len(got) != 1 {
+		t.Fatalf("got %d apps, want 1: %+v", len(got), got)
+	}
+	if got[0].PlatformSource != "registry" {
+		t.Errorf("got source %q, want \"registry\": the uninstall entry is scanned first and carries better metadata", got[0].PlatformSource)
+	}
+}
+
+func TestAppCollectorSkipsUnknown(t *testing.T) {
+	c := newAppCollector()
+	for _, tokens := range [][]string{
+		{"Microsoft.WindowsCalculator"},
+		{"7-Zip 23.01"},
+		{""},
+	} {
+		if c.add(appCandidate{MatchTokens: tokens, Source: "registry"}) {
+			t.Errorf("add(%q) reported a match against the known-app list", tokens)
+		}
+	}
+	if got := c.apps(); len(got) != 0 {
+		t.Errorf("got %d apps, want 0: %+v", len(got), got)
+	}
+}
+
+// TestAppCollectorWants covers the pre-check the MSIX scan uses to avoid reading
+// registry values for packages it would discard.
+func TestAppCollectorWants(t *testing.T) {
+	c := newAppCollector()
+
+	if !c.wants("OpenAI.ChatGPT-Desktop") {
+		t.Error("wants(ChatGPT package) = false before it is collected, want true")
+	}
+	if c.wants("Microsoft.WindowsCalculator") {
+		t.Error("wants(unknown package) = true, want false")
+	}
+
+	c.add(appCandidate{MatchTokens: []string{"OpenAI.ChatGPT-Desktop"}, Source: "appx"})
+	if c.wants("OpenAI.ChatGPT-Desktop") {
+		t.Error("wants(ChatGPT package) = true after it is collected, want false")
+	}
+	// A different discovery of the same app is also unwanted, not just the
+	// identical token.
+	if c.wants("ChatGPT") {
+		t.Error("wants(ChatGPT display name) = true after the package was collected, want false")
+	}
+}
+
+func TestAppCollectorPreservesOrderAndFields(t *testing.T) {
+	c := newAppCollector()
+	c.add(appCandidate{
+		MatchTokens: []string{"Ollama"},
+		Vendor:      "Ollama Inc.",
+		Version:     "0.5.7",
+		Path:        `C:\Users\alice\AppData\Local\Programs\Ollama`,
+		Scope:       "user",
+		Source:      "registry",
+	})
+	c.add(appCandidate{MatchTokens: []string{"Cursor"}, Source: "registry", Scope: "system"})
+
+	got := c.apps()
+	if len(got) != 2 {
+		t.Fatalf("got %d apps, want 2: %+v", len(got), got)
+	}
+	if got[0].Name != "ollama" || got[1].Name != "cursor" {
+		t.Errorf("got order [%q %q], want [\"ollama\" \"cursor\"]", got[0].Name, got[1].Name)
+	}
+	want := App{
+		Name: "ollama", Vendor: "Ollama Inc.", Version: "0.5.7",
+		Path: `C:\Users\alice\AppData\Local\Programs\Ollama`, Scope: "user", PlatformSource: "registry",
+	}
+	if got[0] != want {
+		t.Errorf("got %+v, want %+v", got[0], want)
+	}
+}

--- a/orbit/pkg/table/ai_tools/internal/apps/usersid.go
+++ b/orbit/pkg/table/ai_tools/internal/apps/usersid.go
@@ -1,0 +1,32 @@
+package apps
+
+import "strings"
+
+// Prefixes of the SIDs that belong to an actual person's account. Everything
+// else with a loaded hive under HKEY_USERS is a machine or service account that
+// never installs a desktop app.
+//
+// This lives in a platform-neutral file (rather than in apps_windows.go) so the
+// filter can be tested on any platform; only the Windows build calls it.
+var realUserSIDPrefixes = []string{
+	"s-1-5-21-", // local and domain accounts: machine/domain SID + account RID
+	"s-1-12-1-", // Entra ID (Azure AD) accounts
+}
+
+// isRealUserHive reports whether an HKEY_USERS subkey name is a real user's
+// loaded hive. Registry key names are case-insensitive, so the comparison is too.
+//
+// The "<SID>_Classes" hives are skipped: they hold the same user's per-user class
+// registrations, not a second account, and carry no uninstall entries.
+func isRealUserHive(name string) bool {
+	low := strings.ToLower(name)
+	if strings.HasSuffix(low, "_classes") {
+		return false
+	}
+	for _, p := range realUserSIDPrefixes {
+		if strings.HasPrefix(low, p) && len(low) > len(p) {
+			return true
+		}
+	}
+	return false
+}

--- a/orbit/pkg/table/ai_tools/internal/apps/usersid_test.go
+++ b/orbit/pkg/table/ai_tools/internal/apps/usersid_test.go
@@ -1,0 +1,40 @@
+package apps
+
+import "testing"
+
+func TestIsRealUserHive(t *testing.T) {
+	const localUser = "S-1-5-21-1111111111-2222222222-3333333333-1001"
+
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{localUser, true},
+		{"S-1-5-21-1111111111-2222222222-3333333333-500", true},        // built-in Administrator
+		{"S-1-12-1-1234567890-1234567890-1234567890-1234567890", true}, // Entra ID account
+		{"s-1-5-21-1111111111-2222222222-3333333333-1001", true},       // hive names are case-insensitive
+
+		// The interactive user's own class registrations, not a second user.
+		{localUser + "_Classes", false},
+
+		// Service and machine accounts always have a loaded hive, and none of
+		// them installs a desktop app.
+		{"S-1-5-18", false}, // NT AUTHORITY\SYSTEM
+		{"S-1-5-19", false}, // LOCAL SERVICE
+		{"S-1-5-20", false}, // NETWORK SERVICE
+		{"S-1-5-80-3139157870-2983391045-3678747466-658725712-1809340420", false}, // service SID
+		{"S-1-5-90-0-1", false}, // window manager
+		{"S-1-5-96-0-0", false}, // font driver host
+
+		{".DEFAULT", false}, // the default user profile template
+		{"", false},
+		{"NotASid", false},
+		{"S-1-5-21", false}, // prefix alone, no account RID
+	}
+
+	for _, c := range cases {
+		if got := isRealUserHive(c.name); got != c.want {
+			t.Errorf("isRealUserHive(%q)=%v want %v", c.name, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION

<img width="1896" height="686" alt="Screenshot 2026-08-07 at 3 32 25 PM" src="https://github.com/user-attachments/assets/719471b7-fcd2-4f7b-b5aa-54e7691521b7" />

Resolves #50704

scanApps read only HKLM plus the calling process's CURRENT_USER. Because fleetd runs as NT AUTHORITY\SYSTEM, CURRENT_USER resolves to SYSTEM's own empty hive, so per-user Electron/Squirrel installers (Ollama, ChatGPT desktop, LM Studio) were invisible — none of them offers a machine-wide install to begin with.

Walk the loaded hives under HKEY_USERS for real user SIDs, skipping _Classes hives and service accounts. Machine-wide roots are still searched first so an app installed both ways keeps scope "system".

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Windows MSIX/Appx discovery for installed and per-user packages.
  - App records now include improved vendor, version, installation path, source, and scope details.
  - Combined registry and MSIX/Appx scanning reduces duplicate application entries.
  - Expanded registry scanning across machine, current-user, and loaded real-user profiles.

- **Bug Fixes**
  - Unreadable registry locations, directories, and manifests no longer interrupt collection.
  - Resource-only packages and invalid metadata are filtered out.
  - Improved handling of package identity and publisher information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->