### PR TITLE
Add commit and since-commit to migration cleanup tool

### DIFF
--- a/changes/migration-cleanup-since-commit-commit-flags.md
+++ b/changes/migration-cleanup-since-commit-commit-flags.md
@@ -1,0 +1,1 @@
+- Added `--since-commit` and `--commit` flags to the `migration-cleanup` tool, allowing migration rename scans scoped to a commit range on `main` or a single commit, in addition to the existing `--branch` mode.

--- a/tools/migration-cleanup/CHANGELOG.md
+++ b/tools/migration-cleanup/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 2026-08-07
+
+- Add `--since-commit <ref>` to scan `main` from a given commit forward.
+- Add `--commit <ref>` to inspect a single commit for renames.
+- Exactly one of `--branch`, `--since-commit`, or `--commit` is now required;
+  providing more than one is an error.

--- a/tools/migration-cleanup/README.md
+++ b/tools/migration-cleanup/README.md
@@ -42,6 +42,12 @@ go build -o build/migration-cleanup ./tools/migration-cleanup
 
 SQL generation is the default mode and does not connect to MySQL.
 
+Exactly one of `--branch`, `--since-commit`, or `--commit` is required.
+
+### `--branch` (default mode)
+
+Scan a branch against `main` for migration renames:
+
 ```sh
 go run ./tools/migration-cleanup -b rc-minor-fleet-v4.86.0
 ```
@@ -64,6 +70,28 @@ go run ./tools/migration-cleanup \
 
 If the branch only exists on the remote, pass the plain branch name. The tool
 tries the local branch first, then `origin/<branch>`.
+
+### `--since-commit`
+
+Scan `main` from a given commit forward:
+
+```sh
+go run ./tools/migration-cleanup --since-commit abc1234
+```
+
+### `--commit`
+
+Inspect a single commit for renames:
+
+```sh
+go run ./tools/migration-cleanup --commit abc1234
+```
+
+Both `--since-commit` and `--commit` accept a full SHA, short SHA, or any ref
+`git rev-parse` understands.
+
+**Note:** `--commit` does not support merge commits (no renames will be
+reported). Use `--since-commit` or `--branch` for merge commits.
 
 ## Dry run
 
@@ -174,6 +202,7 @@ move.
 
 ## Notes
 
+- Exactly one of `--branch`, `--since-commit`, or `--commit` is required; providing more than one is an error.
 - `--branch` should point at the branch with the final migration filenames.
 - The generated SQL is the source of truth for SQL output, dry-run simulation,
   and apply mode.

--- a/tools/migration-cleanup/main.go
+++ b/tools/migration-cleanup/main.go
@@ -210,7 +210,8 @@ func run(ctx context.Context, configManager configpkg.Manager, opts options) err
 	}
 
 	var renames []migrationRename
-	if opts.branch != "" {
+	switch {
+	case opts.branch != "":
 		branch, err := resolveBranch(checkout, opts.branch)
 		if err != nil {
 			return exitError{code: exitGeneral, message: err.Error()}
@@ -245,7 +246,8 @@ func run(ctx context.Context, configManager configpkg.Manager, opts options) err
 			}
 			renames = append(renames, rs...)
 		}
-	} else if opts.sinceCommit != "" {
+
+	case opts.sinceCommit != "":
 		resolvedSHA, err := resolveRef(checkout, opts.sinceCommit)
 		if err != nil {
 			return exitError{code: exitGeneral, message: err.Error()}
@@ -254,7 +256,26 @@ func run(ctx context.Context, configManager configpkg.Manager, opts options) err
 			fmt.Fprintf(os.Stderr, "Resolved since-commit: %s\n", resolvedSHA)
 		}
 
-		commits, err := findRenameCommits(checkout, "origin/main", resolvedSHA)
+		mainRef, err := resolveMainRef(checkout)
+		if err != nil {
+			return exitError{code: exitGeneral, message: err.Error()}
+		}
+
+		if !isAncestor(checkout, resolvedSHA, mainRef) {
+			return exitError{code: exitGeneral, message: fmt.Sprintf("ERROR: %q is not an ancestor of %s", opts.sinceCommit, mainRef)}
+		}
+
+		// Include resolvedSHA itself in the scan, then scan descendants.
+		rs, err := extractRenames(checkout, resolvedSHA)
+		if err != nil {
+			return exitError{code: exitGeneral, message: err.Error()}
+		}
+		if opts.verbose {
+			fmt.Fprintf(os.Stderr, "  %s: %d rename(s)\n", shortSHA(resolvedSHA), len(rs))
+		}
+		renames = append(renames, rs...)
+
+		commits, err := findRenameCommits(checkout, mainRef, resolvedSHA)
 		if err != nil {
 			return exitError{code: exitGeneral, message: err.Error()}
 		}
@@ -272,7 +293,8 @@ func run(ctx context.Context, configManager configpkg.Manager, opts options) err
 			}
 			renames = append(renames, rs...)
 		}
-	} else if opts.commit != "" {
+
+	case opts.commit != "":
 		resolvedSHA, err := resolveRef(checkout, opts.commit)
 		if err != nil {
 			return exitError{code: exitGeneral, message: err.Error()}
@@ -417,6 +439,21 @@ func resolveRef(checkout, ref string) (string, error) {
 		return "", fmt.Errorf("cannot resolve ref %q: %w", ref, err)
 	}
 	return strings.TrimSpace(out), nil
+}
+
+func resolveMainRef(checkout string) (string, error) {
+	for _, candidate := range []string{"origin/main", "main"} {
+		_, err := git(checkout, "rev-parse", "--verify", candidate)
+		if err == nil {
+			return candidate, nil
+		}
+	}
+	return "", errors.New("cannot resolve main ref (neither origin/main nor main exists)")
+}
+
+func isAncestor(checkout, ancestor, descendant string) bool {
+	_, err := git(checkout, "merge-base", "--is-ancestor", ancestor, descendant)
+	return err == nil
 }
 
 func resolveBranch(checkout, branch string) (string, error) {

--- a/tools/migration-cleanup/main.go
+++ b/tools/migration-cleanup/main.go
@@ -64,12 +64,14 @@ type sqlStatements struct {
 }
 
 type options struct {
-	checkout string
-	branch   string
-	output   string
-	dryRun   bool
-	apply    bool
-	verbose  bool
+	checkout    string
+	branch      string
+	sinceCommit string
+	commit      string
+	output      string
+	dryRun      bool
+	apply       bool
+	verbose     bool
 
 	dbHost     string
 	dbPort     int
@@ -130,6 +132,8 @@ func newRootCmd(opts *options) *cobra.Command {
 	cmd.PersistentFlags().String("config", "", "Path to a Fleet configuration file")
 	cmd.Flags().StringVarP(&opts.checkout, "checkout", "c", ".", "Path to fleetdm/fleet git checkout")
 	cmd.Flags().StringVarP(&opts.branch, "branch", "b", "", "Branch name")
+	cmd.Flags().StringVarP(&opts.sinceCommit, "since-commit", "", "", "Scan main from this commit forward (hash or short ref)")
+	cmd.Flags().StringVarP(&opts.commit, "commit", "", "", "Inspect a single commit for renames")
 	cmd.Flags().StringVarP(&opts.output, "output", "o", "", "Write SQL to file instead of stdout")
 	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "Connect to MySQL, simulate the SQL, and verify the final state")
 	cmd.Flags().BoolVar(&opts.apply, "apply", false, "Execute SQL against the database in a transaction")
@@ -177,8 +181,8 @@ func hideUnneededFleetConfigFlags(cmd *cobra.Command) {
 }
 
 func run(ctx context.Context, configManager configpkg.Manager, opts options) error {
-	if opts.branch == "" {
-		return exitError{code: exitGeneral, message: "ERROR: --branch is required"}
+	if countModeFlags(opts) != 1 {
+		return exitError{code: exitGeneral, message: "ERROR: exactly one of --branch, --since-commit, or --commit is required"}
 	}
 	if opts.dryRun && opts.apply {
 		return exitError{code: exitGeneral, message: "ERROR: --dry-run and --apply are mutually exclusive"}
@@ -205,43 +209,87 @@ func run(ctx context.Context, configManager configpkg.Manager, opts options) err
 		return exitError{code: exitGeneral, message: err.Error()}
 	}
 
-	branch, err := resolveBranch(checkout, opts.branch)
-	if err != nil {
-		return exitError{code: exitGeneral, message: err.Error()}
-	}
-	if opts.verbose {
-		fmt.Fprintf(os.Stderr, "Resolved branch: %s\n", branch)
-	}
-
-	mergeBase, err := getMergeBase(checkout, branch)
-	if err != nil {
-		return exitError{code: exitGeneral, message: err.Error()}
-	}
-	if opts.verbose {
-		fmt.Fprintf(os.Stderr, "Merge base: %s\n", mergeBase)
-	}
-
-	commits, err := findRenameCommits(checkout, branch, mergeBase)
-	if err != nil {
-		return exitError{code: exitGeneral, message: err.Error()}
-	}
-	if opts.verbose {
-		fmt.Fprintf(os.Stderr, "Rename commits found: %d\n", len(commits))
-	}
-
 	var renames []migrationRename
-	for _, sha := range commits {
-		rs, err := extractRenames(checkout, sha)
+	if opts.branch != "" {
+		branch, err := resolveBranch(checkout, opts.branch)
 		if err != nil {
 			return exitError{code: exitGeneral, message: err.Error()}
 		}
 		if opts.verbose {
-			fmt.Fprintf(os.Stderr, "  %s: %d rename(s)\n", shortSHA(sha), len(rs))
+			fmt.Fprintf(os.Stderr, "Resolved branch: %s\n", branch)
 		}
-		renames = append(renames, rs...)
+
+		mergeBase, err := getMergeBase(checkout, branch)
+		if err != nil {
+			return exitError{code: exitGeneral, message: err.Error()}
+		}
+		if opts.verbose {
+			fmt.Fprintf(os.Stderr, "Merge base: %s\n", mergeBase)
+		}
+
+		commits, err := findRenameCommits(checkout, branch, mergeBase)
+		if err != nil {
+			return exitError{code: exitGeneral, message: err.Error()}
+		}
+		if opts.verbose {
+			fmt.Fprintf(os.Stderr, "Rename commits found: %d\n", len(commits))
+		}
+
+		for _, sha := range commits {
+			rs, err := extractRenames(checkout, sha)
+			if err != nil {
+				return exitError{code: exitGeneral, message: err.Error()}
+			}
+			if opts.verbose {
+				fmt.Fprintf(os.Stderr, "  %s: %d rename(s)\n", shortSHA(sha), len(rs))
+			}
+			renames = append(renames, rs...)
+		}
+	} else if opts.sinceCommit != "" {
+		resolvedSHA, err := resolveRef(checkout, opts.sinceCommit)
+		if err != nil {
+			return exitError{code: exitGeneral, message: err.Error()}
+		}
+		if opts.verbose {
+			fmt.Fprintf(os.Stderr, "Resolved since-commit: %s\n", resolvedSHA)
+		}
+
+		commits, err := findRenameCommits(checkout, "origin/main", resolvedSHA)
+		if err != nil {
+			return exitError{code: exitGeneral, message: err.Error()}
+		}
+		if opts.verbose {
+			fmt.Fprintf(os.Stderr, "Rename commits found: %d\n", len(commits))
+		}
+
+		for _, sha := range commits {
+			rs, err := extractRenames(checkout, sha)
+			if err != nil {
+				return exitError{code: exitGeneral, message: err.Error()}
+			}
+			if opts.verbose {
+				fmt.Fprintf(os.Stderr, "  %s: %d rename(s)\n", shortSHA(sha), len(rs))
+			}
+			renames = append(renames, rs...)
+		}
+	} else if opts.commit != "" {
+		resolvedSHA, err := resolveRef(checkout, opts.commit)
+		if err != nil {
+			return exitError{code: exitGeneral, message: err.Error()}
+		}
+		if opts.verbose {
+			fmt.Fprintf(os.Stderr, "Resolved commit: %s\n", resolvedSHA)
+		}
+
+		rs, err := extractRenames(checkout, resolvedSHA)
+		if err != nil {
+			return exitError{code: exitGeneral, message: err.Error()}
+		}
+		renames = rs
 	}
+
 	if len(renames) == 0 {
-		fmt.Println("No migration renumbering detected on this branch.")
+		fmt.Println("No migration renumbering detected in the selected scope.")
 		return nil
 	}
 	renames = dedupeRenames(renames)
@@ -347,6 +395,28 @@ func git(checkout string, args ...string) (string, error) {
 		return "", fmt.Errorf("git %s failed: %w", strings.Join(args, " "), err)
 	}
 	return string(out), nil
+}
+
+func countModeFlags(opts options) int {
+	n := 0
+	if opts.branch != "" {
+		n++
+	}
+	if opts.sinceCommit != "" {
+		n++
+	}
+	if opts.commit != "" {
+		n++
+	}
+	return n
+}
+
+func resolveRef(checkout, ref string) (string, error) {
+	out, err := git(checkout, "rev-parse", "--verify", ref+"^{commit}")
+	if err != nil {
+		return "", fmt.Errorf("cannot resolve ref %q: %w", ref, err)
+	}
+	return strings.TrimSpace(out), nil
 }
 
 func resolveBranch(checkout, branch string) (string, error) {

--- a/tools/migration-cleanup/main.go
+++ b/tools/migration-cleanup/main.go
@@ -122,6 +122,7 @@ func (e exitError) Error() string {
 	return e.message
 }
 
+// newRootCmd creates and configures the root cobra command with all flags.
 func newRootCmd(opts *options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "migration-cleanup",
@@ -152,6 +153,8 @@ func newRootCmd(opts *options) *cobra.Command {
 	return cmd
 }
 
+// hideUnneededFleetConfigFlags hides Fleet config flags that are not relevant
+// to this tool, keeping only the MySQL-related flags visible.
 func hideUnneededFleetConfigFlags(cmd *cobra.Command) {
 	visibleMysqlFlags := map[string]struct{}{
 		"mysql_protocol":            {},
@@ -180,6 +183,8 @@ func hideUnneededFleetConfigFlags(cmd *cobra.Command) {
 	})
 }
 
+// run executes the migration cleanup workflow: validates options, scans git
+// history for migration renames, generates SQL, and optionally dry-runs or applies.
 func run(ctx context.Context, configManager configpkg.Manager, opts options) error {
 	if countModeFlags(opts) != 1 {
 		return exitError{code: exitGeneral, message: "ERROR: exactly one of --branch, --since-commit, or --commit is required"}
@@ -385,6 +390,7 @@ func run(ctx context.Context, configManager configpkg.Manager, opts options) err
 	return nil
 }
 
+// validateTLSFlags checks that --tls-mode is a valid value.
 func validateTLSFlags(opts options) error {
 	switch opts.tlsMode {
 	case "", "skip-verify", "verify-ca", "verify-identity":
@@ -394,6 +400,8 @@ func validateTLSFlags(opts options) error {
 	return nil
 }
 
+// validateEffectiveTLSConfig validates the combined TLS configuration
+// after merging CLI flags and Fleet config.
 func validateEffectiveTLSConfig(conf configpkg.MysqlConfig, tlsMode string) error {
 	if tlsMode == "verify-ca" || tlsMode == "verify-identity" {
 		if conf.TLSCA == "" {
@@ -406,6 +414,7 @@ func validateEffectiveTLSConfig(conf configpkg.MysqlConfig, tlsMode string) erro
 	return nil
 }
 
+// git runs a git command in the given checkout directory and returns stdout.
 func git(checkout string, args ...string) (string, error) {
 	cmd := exec.Command("git", append([]string{"-C", checkout}, args...)...)
 	out, err := cmd.Output()
@@ -419,6 +428,8 @@ func git(checkout string, args ...string) (string, error) {
 	return string(out), nil
 }
 
+// countModeFlags returns the number of scan-mode flags set in opts.
+// Exactly one must be set; zero or more than one is an error.
 func countModeFlags(opts options) int {
 	n := 0
 	if opts.branch != "" {
@@ -433,6 +444,7 @@ func countModeFlags(opts options) int {
 	return n
 }
 
+// resolveRef resolves a git ref to a full commit SHA, peeling annotated tags.
 func resolveRef(checkout, ref string) (string, error) {
 	out, err := git(checkout, "rev-parse", "--verify", ref+"^{commit}")
 	if err != nil {
@@ -441,6 +453,8 @@ func resolveRef(checkout, ref string) (string, error) {
 	return strings.TrimSpace(out), nil
 }
 
+// resolveMainRef returns the best available ref for the main branch,
+// preferring origin/main (freshly fetched) over local main.
 func resolveMainRef(checkout string) (string, error) {
 	for _, candidate := range []string{"origin/main", "main"} {
 		_, err := git(checkout, "rev-parse", "--verify", candidate)
@@ -451,11 +465,13 @@ func resolveMainRef(checkout string) (string, error) {
 	return "", errors.New("cannot resolve main ref (neither origin/main nor main exists)")
 }
 
+// isAncestor reports whether ancestor is an ancestor of descendant.
 func isAncestor(checkout, ancestor, descendant string) bool {
 	_, err := git(checkout, "merge-base", "--is-ancestor", ancestor, descendant)
 	return err == nil
 }
 
+// resolveBranch resolves a branch name, trying local then origin/<branch>.
 func resolveBranch(checkout, branch string) (string, error) {
 	candidates := []string{branch, "origin/" + branch}
 	var lastErr error
@@ -474,11 +490,14 @@ func resolveBranch(checkout, branch string) (string, error) {
 	return "", fmt.Errorf("ERROR: cannot resolve branch %q", branch)
 }
 
+// getMergeBase returns the merge base between main and the given branch.
 func getMergeBase(checkout, branch string) (string, error) {
 	out, err := git(checkout, "merge-base", "main", branch)
 	return strings.TrimSpace(out), err
 }
 
+// findRenameCommits returns commit SHAs in mergeBase..branch that contain
+// renames in the migration directories.
 func findRenameCommits(checkout, branch, mergeBase string) ([]string, error) {
 	args := []string{"log", "-M", "--diff-filter=R", "--format=%H", mergeBase + ".." + branch, "--"}
 	args = append(args, migrationDirs...)
@@ -493,6 +512,8 @@ func findRenameCommits(checkout, branch, mergeBase string) ([]string, error) {
 	return strings.Split(out, "\n"), nil
 }
 
+// extractRenames parses a single commit for migration file renames and returns
+// the detected version ID changes.
 func extractRenames(checkout, commitSHA string) ([]migrationRename, error) {
 	out, err := git(checkout, "diff-tree", "-M", "-r", "--diff-filter=R", "--name-status", "--no-commit-id", commitSHA)
 	if err != nil {
@@ -545,6 +566,7 @@ func extractRenames(checkout, commitSHA string) ([]migrationRename, error) {
 	return renames, nil
 }
 
+// shortSHA returns the first 12 characters of a SHA, or the full string if shorter.
 func shortSHA(sha string) string {
 	if len(sha) < 12 {
 		return sha
@@ -552,6 +574,7 @@ func shortSHA(sha string) string {
 	return sha[:12]
 }
 
+// dedupeRenames removes duplicate renames based on migration type and version IDs.
 func dedupeRenames(renames []migrationRename) []migrationRename {
 	seen := map[string]struct{}{}
 	unique := make([]migrationRename, 0, len(renames))
@@ -566,6 +589,8 @@ func dedupeRenames(renames []migrationRename) []migrationRename {
 	return unique
 }
 
+// generateStatementGroups groups renames by migration type and generates
+// SQL statements for each table.
 func generateStatementGroups(renames []migrationRename) map[string][]string {
 	groups := map[string][]string{}
 	for _, item := range []struct {
@@ -590,6 +615,7 @@ func generateStatementGroups(renames []migrationRename) map[string][]string {
 	return groups
 }
 
+// computeSQLForTable builds the version ID remapping statements for a table.
 func computeSQLForTable(tableName string, renames []migrationRename) sqlStatements {
 	stmts := sqlStatements{tableName: tableName}
 	for _, r := range renames {
@@ -598,6 +624,8 @@ func computeSQLForTable(tableName string, renames []migrationRename) sqlStatemen
 	return stmts
 }
 
+// buildSQL generates the full SQL for a table: version remaps, dedup cleanup,
+// and ID shifts to maintain ordering.
 func buildSQL(tableName string, stmts sqlStatements, renames []migrationRename) []string {
 	lines := make([]string, 0)
 	for _, pair := range stmts.versionIDRemappings {
@@ -656,6 +684,7 @@ func buildSQL(tableName string, stmts sqlStatements, renames []migrationRename) 
 	return lines
 }
 
+// renderSQL formats statement groups into a complete SQL transaction.
 func renderSQL(groups map[string][]string) string {
 	if len(groups) == 0 {
 		return "-- No changes needed.\n"
@@ -678,6 +707,7 @@ func renderSQL(groups map[string][]string) string {
 	return b.String()
 }
 
+// queryTableRows fetches all rows from a migration status table.
 func queryTableRows(ctx context.Context, db *sqlx.DB, tableName string) ([]tableRow, error) {
 	var rows []tableRow
 	if err := sqlx.SelectContext(ctx, db, &rows, fmt.Sprintf("SELECT id, version_id, is_applied FROM `%s` ORDER BY id", tableName)); err != nil {
@@ -686,6 +716,8 @@ func queryTableRows(ctx context.Context, db *sqlx.DB, tableName string) ([]table
 	return rows, nil
 }
 
+// verifyDryRun simulates the generated SQL against real table data and reports
+// whether the final state would be valid.
 func verifyDryRun(renames []migrationRename, tableRows, dataRows []tableRow) (bool, []string) {
 	var issues []string
 	var messages []string
@@ -716,6 +748,8 @@ func verifyDryRun(renames []migrationRename, tableRows, dataRows []tableRow) (bo
 	return len(issues) == 0, append(messages, issues...)
 }
 
+// simulateTableSQL applies version remaps, dedup removal, and ID shifts to a
+// copy of the table rows, returning the simulated result plus messages and issues.
 func simulateTableSQL(tableName string, rows []tableRow, renames []migrationRename) ([]tableRow, []string, []string) {
 	var messages []string
 	var issues []string
@@ -849,6 +883,7 @@ func simulateTableSQL(tableName string, rows []tableRow, renames []migrationRena
 	return shifted, messages, issues
 }
 
+// rowsForVID returns all rows matching the given version ID.
 func rowsForVID(rows []tableRow, vid int64) []tableRow {
 	var out []tableRow
 	for _, row := range rows {
@@ -859,6 +894,7 @@ func rowsForVID(rows []tableRow, vid int64) []tableRow {
 	return out
 }
 
+// maxInt64 returns the maximum value from a slice of int64.
 func maxInt64(values []int64) int64 {
 	maxVal := values[0]
 	for _, val := range values[1:] {
@@ -869,6 +905,8 @@ func maxInt64(values []int64) int64 {
 	return maxVal
 }
 
+// shiftRows returns a copy of rows with IDs shifted by offset for rows whose
+// ID is in the given set.
 func shiftRows(rows []tableRow, ids map[int64]struct{}, offset int64) []tableRow {
 	shifted := make([]tableRow, 0, len(rows))
 	for _, row := range rows {
@@ -881,6 +919,8 @@ func shiftRows(rows []tableRow, ids map[int64]struct{}, offset int64) []tableRow
 	return shifted
 }
 
+// validateFinalTableState checks the simulated table for duplicate IDs,
+// duplicate applied version IDs, and ordering violations.
 func validateFinalTableState(tableName string, rows []tableRow) []string {
 	var issues []string
 	ids := map[int64][]int64{}
@@ -918,6 +958,8 @@ func validateFinalTableState(tableName string, rows []tableRow) []string {
 	return issues
 }
 
+// writerConfig merges CLI database options with Fleet config to produce
+// the effective MySQL configuration.
 func writerConfig(conf configpkg.MysqlConfig, opts options) (*configpkg.MysqlConfig, error) {
 	if opts.dbHost != "" {
 		conf.Address = fmt.Sprintf("%s:%d", opts.dbHost, opts.dbPort)
@@ -958,6 +1000,7 @@ func writerConfig(conf configpkg.MysqlConfig, opts options) (*configpkg.MysqlCon
 	return &conf, nil
 }
 
+// promptPassword reads a password from stdin, using secure terminal read if available.
 func promptPassword() (string, error) {
 	fmt.Fprint(os.Stderr, "MySQL password: ")
 	if term.IsTerminal(int(os.Stdin.Fd())) {
@@ -970,6 +1013,7 @@ func promptPassword() (string, error) {
 	return strings.TrimSpace(pass), err
 }
 
+// openWriterDB opens a connection to the MySQL database using the given config.
 func openWriterDB(conf *configpkg.MysqlConfig) (*sqlx.DB, error) {
 	if conf.PasswordPath != "" && conf.Password != "" {
 		return nil, errors.New("a MySQL password and password file were provided; specify only one")
@@ -1023,6 +1067,7 @@ func openWriterDB(conf *configpkg.MysqlConfig) (*sqlx.DB, error) {
 	}, "mysql")
 }
 
+// applyStatements executes all SQL statements in a transaction.
 func applyStatements(ctx context.Context, db *sqlx.DB, groups map[string][]string) error {
 	var statements []string
 	for _, tableName := range []string{tableStatusName, dataStatusName} {
@@ -1038,6 +1083,7 @@ func applyStatements(ctx context.Context, db *sqlx.DB, groups map[string][]strin
 	}, slog.New(slog.NewTextHandler(os.Stderr, nil)))
 }
 
+// writeOutput writes SQL to stdout or to a file if outputPath is set.
 func writeOutput(sqlText, outputPath string) error {
 	if outputPath == "" {
 		fmt.Print(sqlText)

--- a/tools/migration-cleanup/main_test.go
+++ b/tools/migration-cleanup/main_test.go
@@ -1,0 +1,220 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// setupTestRepo creates a minimal git repo with migration-like files and returns its path.
+func setupTestRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	runGit(t, dir, "init", "-b", "main")
+	runGit(t, dir, "config", "user.email", "test@test.com")
+	runGit(t, dir, "config", "user.name", "Test")
+
+	// Create migration directories
+	tablesDir := filepath.Join(dir, "server/datastore/mysql/migrations/tables")
+	dataDir := filepath.Join(dir, "server/datastore/mysql/migrations/data")
+	os.MkdirAll(tablesDir, 0o755)
+	os.MkdirAll(dataDir, 0o755)
+
+	// Initial commit with a migration file
+	writeFile(t, filepath.Join(tablesDir, "20250101000000_init.sql"), "CREATE TABLE t1;")
+	writeFile(t, filepath.Join(dataDir, "20250101000001_seed.sql"), "INSERT INTO t1;")
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-m", "initial migrations")
+
+	// Rename commit: move a table migration to a new version ID
+	os.Remove(filepath.Join(tablesDir, "20250101000000_init.sql"))
+	writeFile(t, filepath.Join(tablesDir, "20250201000000_init.sql"), "CREATE TABLE t1;")
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-m", "rename migration")
+
+	// Tag the rename commit with an annotated tag
+	renameSHA := lastCommitSHA(t, dir)
+	runGit(t, dir, "tag", "-a", "rename-tag", "-m", "annotated tag", renameSHA)
+
+	// Non-rename commit
+	writeFile(t, filepath.Join(tablesDir, "20250301000000_new.sql"), "CREATE TABLE t2;")
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-m", "add new migration")
+
+	return dir
+}
+
+func lastCommitSHA(t *testing.T, dir string) string {
+	t.Helper()
+	out, err := exec.Command("git", "-C", dir, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatalf("git rev-parse HEAD: %v", err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("writeFile: %v", err)
+	}
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+}
+
+func TestCountModeFlags(t *testing.T) {
+	tests := []struct {
+		name string
+		opts options
+		want int
+	}{
+		{"no flags", options{}, 0},
+		{"branch only", options{branch: "main"}, 1},
+		{"sinceCommit only", options{sinceCommit: "abc"}, 1},
+		{"commit only", options{commit: "abc"}, 1},
+		{"branch + sinceCommit", options{branch: "main", sinceCommit: "abc"}, 2},
+		{"branch + commit", options{branch: "main", commit: "abc"}, 2},
+		{"sinceCommit + commit", options{sinceCommit: "abc", commit: "def"}, 2},
+		{"all three", options{branch: "main", sinceCommit: "abc", commit: "def"}, 3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := countModeFlags(tt.opts); got != tt.want {
+				t.Errorf("countModeFlags() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveRef(t *testing.T) {
+	dir := setupTestRepo(t)
+
+	// Resolve a commit SHA
+	sha := lastCommitSHA(t, dir)
+	resolved, err := resolveRef(dir, sha)
+	if err != nil {
+		t.Fatalf("resolveRef(full SHA): %v", err)
+	}
+	if resolved != sha {
+		t.Errorf("resolveRef(full SHA) = %q, want %q", resolved, sha)
+	}
+
+	// Resolve HEAD
+	resolved, err = resolveRef(dir, "HEAD")
+	if err != nil {
+		t.Fatalf("resolveRef(HEAD): %v", err)
+	}
+	if resolved != sha {
+		t.Errorf("resolveRef(HEAD) = %q, want %q", resolved, sha)
+	}
+
+	// Resolve an annotated tag — must peel to the commit SHA (HEAD~1 is the rename commit)
+	out, _ := exec.Command("git", "-C", dir, "rev-parse", "HEAD~1").Output()
+	renameSHA := strings.TrimSpace(string(out))
+	resolved, err = resolveRef(dir, "rename-tag")
+	if err != nil {
+		t.Fatalf("resolveRef(annotated tag): %v", err)
+	}
+	if resolved != renameSHA {
+		t.Errorf("resolveRef(annotated tag) = %q, want %q", resolved, renameSHA)
+	}
+
+	// Invalid ref
+	_, err = resolveRef(dir, "nonexistent-ref-xyz")
+	if err == nil {
+		t.Fatal("resolveRef(invalid ref) expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "cannot resolve ref") {
+		t.Errorf("resolveRef(invalid ref) error = %v, want 'cannot resolve ref'", err)
+	}
+}
+
+func TestFindRenameCommitsRange(t *testing.T) {
+	dir := setupTestRepo(t)
+
+	// Get the SHA of the first commit (initial migrations)
+	out, err := exec.Command("git", "-C", dir, "rev-parse", "HEAD~2").Output()
+	if err != nil {
+		t.Fatalf("git rev-parse HEAD~2: %v", err)
+	}
+	initialSHA := strings.TrimSpace(string(out))
+
+	// findRenameCommits with range initialSHA..main should find the rename commit
+	commits, err := findRenameCommits(dir, "main", initialSHA)
+	if err != nil {
+		t.Fatalf("findRenameCommits: %v", err)
+	}
+	if len(commits) != 1 {
+		t.Errorf("findRenameCommits(range) = %d commits, want 1", len(commits))
+	}
+
+	// The rename commit should be the second commit (HEAD~1)
+	out, _ = exec.Command("git", "-C", dir, "rev-parse", "HEAD~1").Output()
+	expectedRenameSHA := strings.TrimSpace(string(out))
+	if commits[0] != expectedRenameSHA {
+		t.Errorf("findRenameCommits() = %q, want %q", commits[0], expectedRenameSHA)
+	}
+}
+
+func TestExtractRenames(t *testing.T) {
+	dir := setupTestRepo(t)
+
+	// Get the rename commit SHA
+	out, _ := exec.Command("git", "-C", dir, "rev-parse", "HEAD~1").Output()
+	renameSHA := strings.TrimSpace(string(out))
+
+	renames, err := extractRenames(dir, renameSHA)
+	if err != nil {
+		t.Fatalf("extractRenames(rename commit): %v", err)
+	}
+	if len(renames) != 1 {
+		t.Errorf("extractRenames(rename commit) = %d renames, want 1", len(renames))
+	}
+	if len(renames) > 0 {
+		if renames[0].oldVersionID != 20250101000000 {
+			t.Errorf("rename oldVersionID = %d, want %d", renames[0].oldVersionID, 20250101000000)
+		}
+		if renames[0].newVersionID != 20250201000000 {
+			t.Errorf("rename newVersionID = %d, want %d", renames[0].newVersionID, 20250201000000)
+		}
+	}
+
+	// Non-rename commit should produce no renames
+	out, _ = exec.Command("git", "-C", dir, "rev-parse", "HEAD").Output()
+	nonRenameSHA := strings.TrimSpace(string(out))
+
+	renames, err = extractRenames(dir, nonRenameSHA)
+	if err != nil {
+		t.Fatalf("extractRenames(non-rename commit): %v", err)
+	}
+	if len(renames) != 0 {
+		t.Errorf("extractRenames(non-rename commit) = %d renames, want 0", len(renames))
+	}
+}
+
+func TestExtractRenamesAnnotatedTag(t *testing.T) {
+	dir := setupTestRepo(t)
+
+	// resolveRef should peel the annotated tag to a commit SHA
+	resolved, err := resolveRef(dir, "rename-tag")
+	if err != nil {
+		t.Fatalf("resolveRef(rename-tag): %v", err)
+	}
+
+	renames, err := extractRenames(dir, resolved)
+	if err != nil {
+		t.Fatalf("extractRenames(resolved tag): %v", err)
+	}
+	if len(renames) != 1 {
+		t.Errorf("extractRenames(resolved tag) = %d renames, want 1", len(renames))
+	}
+}

--- a/tools/migration-cleanup/main_test.go
+++ b/tools/migration-cleanup/main_test.go
@@ -20,8 +20,12 @@ func setupTestRepo(t *testing.T) string {
 	// Create migration directories
 	tablesDir := filepath.Join(dir, "server/datastore/mysql/migrations/tables")
 	dataDir := filepath.Join(dir, "server/datastore/mysql/migrations/data")
-	os.MkdirAll(tablesDir, 0o755)
-	os.MkdirAll(dataDir, 0o755)
+	if err := os.MkdirAll(tablesDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll tables: %v", err)
+	}
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll data: %v", err)
+	}
 
 	// Initial commit with a migration file
 	writeFile(t, filepath.Join(tablesDir, "20250101000000_init.sql"), "CREATE TABLE t1;")
@@ -30,7 +34,9 @@ func setupTestRepo(t *testing.T) string {
 	runGit(t, dir, "commit", "-m", "initial migrations")
 
 	// Rename commit: move a table migration to a new version ID
-	os.Remove(filepath.Join(tablesDir, "20250101000000_init.sql"))
+	if err := os.Remove(filepath.Join(tablesDir, "20250101000000_init.sql")); err != nil {
+		t.Fatalf("Remove old migration: %v", err)
+	}
 	writeFile(t, filepath.Join(tablesDir, "20250201000000_init.sql"), "CREATE TABLE t1;")
 	runGit(t, dir, "add", ".")
 	runGit(t, dir, "commit", "-m", "rename migration")
@@ -118,7 +124,10 @@ func TestResolveRef(t *testing.T) {
 	}
 
 	// Resolve an annotated tag — must peel to the commit SHA (HEAD~1 is the rename commit)
-	out, _ := exec.Command("git", "-C", dir, "rev-parse", "HEAD~1").Output()
+	out, err := exec.Command("git", "-C", dir, "rev-parse", "HEAD~1").Output()
+	if err != nil {
+		t.Fatalf("git rev-parse HEAD~1: %v", err)
+	}
 	renameSHA := strings.TrimSpace(string(out))
 	resolved, err = resolveRef(dir, "rename-tag")
 	if err != nil {
@@ -158,7 +167,10 @@ func TestFindRenameCommitsRange(t *testing.T) {
 	}
 
 	// The rename commit should be the second commit (HEAD~1)
-	out, _ = exec.Command("git", "-C", dir, "rev-parse", "HEAD~1").Output()
+	out, err = exec.Command("git", "-C", dir, "rev-parse", "HEAD~1").Output()
+	if err != nil {
+		t.Fatalf("git rev-parse HEAD~1: %v", err)
+	}
 	expectedRenameSHA := strings.TrimSpace(string(out))
 	if commits[0] != expectedRenameSHA {
 		t.Errorf("findRenameCommits() = %q, want %q", commits[0], expectedRenameSHA)
@@ -169,7 +181,10 @@ func TestExtractRenames(t *testing.T) {
 	dir := setupTestRepo(t)
 
 	// Get the rename commit SHA
-	out, _ := exec.Command("git", "-C", dir, "rev-parse", "HEAD~1").Output()
+	out, err := exec.Command("git", "-C", dir, "rev-parse", "HEAD~1").Output()
+	if err != nil {
+		t.Fatalf("git rev-parse HEAD~1: %v", err)
+	}
 	renameSHA := strings.TrimSpace(string(out))
 
 	renames, err := extractRenames(dir, renameSHA)
@@ -189,7 +204,10 @@ func TestExtractRenames(t *testing.T) {
 	}
 
 	// Non-rename commit should produce no renames
-	out, _ = exec.Command("git", "-C", dir, "rev-parse", "HEAD").Output()
+	out, err = exec.Command("git", "-C", dir, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatalf("git rev-parse HEAD: %v", err)
+	}
 	nonRenameSHA := strings.TrimSpace(string(out))
 
 	renames, err = extractRenames(dir, nonRenameSHA)
@@ -216,5 +234,108 @@ func TestExtractRenamesAnnotatedTag(t *testing.T) {
 	}
 	if len(renames) != 1 {
 		t.Errorf("extractRenames(resolved tag) = %d renames, want 1", len(renames))
+	}
+}
+
+func TestIsAncestor(t *testing.T) {
+	dir := setupTestRepo(t)
+
+	// Get the initial commit (HEAD~2)
+	out, err := exec.Command("git", "-C", dir, "rev-parse", "HEAD~2").Output()
+	if err != nil {
+		t.Fatalf("git rev-parse HEAD~2: %v", err)
+	}
+	initialSHA := strings.TrimSpace(string(out))
+
+	// initialSHA is an ancestor of main
+	if !isAncestor(dir, initialSHA, "main") {
+		t.Errorf("isAncestor(%s, main) = false, want true", initialSHA)
+	}
+
+	// HEAD is an ancestor of itself
+	headSHA := lastCommitSHA(t, dir)
+	if !isAncestor(dir, headSHA, "main") {
+		t.Errorf("isAncestor(HEAD, main) = false, want true")
+	}
+
+	// Create a side branch commit not on main
+	runGit(t, dir, "checkout", "-b", "side", initialSHA)
+	writeFile(t, filepath.Join(dir, "side.txt"), "x")
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-m", "side")
+	sideSHA := lastCommitSHA(t, dir)
+
+	if isAncestor(dir, sideSHA, "main") {
+		t.Errorf("isAncestor(side, main) = true, want false")
+	}
+}
+
+func TestResolveMainRef(t *testing.T) {
+	dir := setupTestRepo(t)
+
+	ref, err := resolveMainRef(dir)
+	if err != nil {
+		t.Fatalf("resolveMainRef: %v", err)
+	}
+	if ref != "main" {
+		t.Errorf("resolveMainRef() = %q, want %q", ref, "main")
+	}
+}
+
+func TestSinceCommitScanIncludesSelectedCommit(t *testing.T) {
+	dir := setupTestRepo(t)
+
+	// Get the rename commit SHA (HEAD~1)
+	out, err := exec.Command("git", "-C", dir, "rev-parse", "HEAD~1").Output()
+	if err != nil {
+		t.Fatalf("git rev-parse HEAD~1: %v", err)
+	}
+	renameSHA := strings.TrimSpace(string(out))
+
+	// Replicate the since-commit scan sequence:
+	// 1. extractRenames on the selected commit itself
+	renames, err := extractRenames(dir, renameSHA)
+	if err != nil {
+		t.Fatalf("extractRenames(selected commit): %v", err)
+	}
+
+	// 2. findRenameCommits on the range (excludes the selected commit)
+	commits, err := findRenameCommits(dir, "main", renameSHA)
+	if err != nil {
+		t.Fatalf("findRenameCommits: %v", err)
+	}
+	for _, sha := range commits {
+		rs, err := extractRenames(dir, sha)
+		if err != nil {
+			t.Fatalf("extractRenames(descendant): %v", err)
+		}
+		renames = append(renames, rs...)
+	}
+
+	// The rename commit should be found (from step 1, not step 2)
+	if len(renames) != 1 {
+		t.Errorf("since-commit scan = %d renames, want 1", len(renames))
+	}
+}
+
+func TestSinceCommitRejectsNonAncestor(t *testing.T) {
+	dir := setupTestRepo(t)
+
+	// Create a side branch commit not on main
+	out, err := exec.Command("git", "-C", dir, "rev-parse", "HEAD~2").Output()
+	if err != nil {
+		t.Fatalf("git rev-parse HEAD~2: %v", err)
+	}
+	initialSHA := strings.TrimSpace(string(out))
+
+	runGit(t, dir, "checkout", "-b", "side", initialSHA)
+	writeFile(t, filepath.Join(dir, "side.txt"), "x")
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-m", "side")
+	sideSHA := lastCommitSHA(t, dir)
+
+	// sideSHA should not be an ancestor of main
+	if isAncestor(dir, sideSHA, "main") {
+		t.Fatalf("setup error: side commit should not be ancestor of main")
 	}
 }

--- a/tools/migration-cleanup/main_test.go
+++ b/tools/migration-cleanup/main_test.go
@@ -53,6 +53,7 @@ func setupTestRepo(t *testing.T) string {
 	return dir
 }
 
+// lastCommitSHA returns the full SHA of HEAD in the given git directory.
 func lastCommitSHA(t *testing.T, dir string) string {
 	t.Helper()
 	out, err := exec.Command("git", "-C", dir, "rev-parse", "HEAD").Output()
@@ -62,6 +63,7 @@ func lastCommitSHA(t *testing.T, dir string) string {
 	return strings.TrimSpace(string(out))
 }
 
+// writeFile writes content to path, failing the test on error.
 func writeFile(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
@@ -69,6 +71,7 @@ func writeFile(t *testing.T, path, content string) {
 	}
 }
 
+// runGit executes a git command in dir, failing the test on error.
 func runGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
 	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)

--- a/tools/migration-cleanup/main_test.go
+++ b/tools/migration-cleanup/main_test.go
@@ -175,7 +175,7 @@ func TestFindRenameCommitsRange(t *testing.T) {
 		t.Fatalf("git rev-parse HEAD~1: %v", err)
 	}
 	expectedRenameSHA := strings.TrimSpace(string(out))
-	if commits[0] != expectedRenameSHA {
+	if len(commits) > 0 && commits[0] != expectedRenameSHA {
 		t.Errorf("findRenameCommits() = %q, want %q", commits[0], expectedRenameSHA)
 	}
 }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added commit-based scanning options for migration cleanup, including scanning a selected commit range or a single commit.
  * Added support for resolving commit references, including annotated tags.
  * The command now requires exactly one scanning mode and clearly reports when no renumbering is found in the selected scope.
  * Improved detection and aggregation of migration renames across scanned commits.

* **Tests**
  * Added comprehensive coverage for scan modes, commit references, ranges, renames, and annotated tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->