### PR TITLE
Website: log number of android enterprise requests in the past minute

### DIFF
--- a/website/api/controllers/android-proxy/create-android-enrollment-token.js
+++ b/website/api/controllers/android-proxy/create-android-enrollment-token.js
@@ -59,6 +59,7 @@ module.exports = {
       let { google } = require('googleapis');
       let androidManagementConnection = google.androidmanagement({version: 'v1', auth: androidManagementAuthClient});
       // [?]: https://googleapis.dev/nodejs/googleapis/latest/androidmanagement/classes/Resource$Enterprises$Enrollmenttokens.html#create
+      sails.androidProxyApiRequestCount++;// Count this Android Management API request toward the per-minute total logged in api/hooks/custom/index.js.
       let enrollmentTokenCreateResponse = await androidManagementConnection.enterprises.enrollmentTokens.create({
         parent: `enterprises/${androidEnterpriseId}`,
         // Note: Typically, we use defined inputs instead of accessing req.body directly. This behavior should not be repeated in future Android proxy endpoints.

--- a/website/api/controllers/android-proxy/create-android-enterprise.js
+++ b/website/api/controllers/android-proxy/create-android-enterprise.js
@@ -135,6 +135,7 @@ module.exports = {
 
       // Now create the new enterprise for this Fleet server.
       // [?]: https://googleapis.dev/nodejs/googleapis/latest/androidmanagement/classes/Resource$Enterprises.html#create
+      sails.androidProxyApiRequestCount++;// Count this Android Management API request toward the per-minute total logged in api/hooks/custom/index.js.
       let createEnterpriseResponse = await androidManagementConnection.enterprises.create({
         agreementAccepted: true,
         enterpriseToken: enterpriseToken,

--- a/website/api/controllers/android-proxy/create-android-signup-url.js
+++ b/website/api/controllers/android-proxy/create-android-signup-url.js
@@ -63,6 +63,7 @@ module.exports = {
       let { google } = require('googleapis');
       let androidManagementConnection = google.androidmanagement({version: 'v1', auth: androidManagementAuthClient});
       // [?] https://googleapis.dev/nodejs/googleapis/latest/androidmanagement/classes/Resource$Signupurls.html#create
+      sails.androidProxyApiRequestCount++;// Count this Android Management API request toward the per-minute total logged in api/hooks/custom/index.js.
       let createSignupUrlResponse = await androidManagementConnection.signupUrls.create({
         // The callback URL that the admin will be redirected to after successfully creating an enterprise. Before redirecting there the system will add a query parameter to this URL named enterpriseToken which will contain an opaque token to be used for the create enterprise request. The URL will be parsed then reformatted in order to add the enterpriseToken parameter, so there may be some minor formatting changes.
         callbackUrl: callbackUrl,

--- a/website/api/controllers/android-proxy/create-enterprise-webapp.js
+++ b/website/api/controllers/android-proxy/create-enterprise-webapp.js
@@ -77,6 +77,7 @@ module.exports = {
       let { google } = require('googleapis');
       let androidManagementConnection = google.androidmanagement({version: 'v1', auth: androidManagementAuthClient});
       // [?]: https://googleapis.dev/nodejs/googleapis/latest/androidmanagement/classes/Resource$Enterprises$Webapps.html#create
+      sails.androidProxyApiRequestCount++;// Count this Android Management API request toward the per-minute total logged in api/hooks/custom/index.js.
       let createWebAppResponse = await androidManagementConnection.enterprises.webApps.create({
         parent: `enterprises/${androidEnterpriseId}`,
         requestBody: {

--- a/website/api/controllers/android-proxy/delete-android-device.js
+++ b/website/api/controllers/android-proxy/delete-android-device.js
@@ -67,6 +67,7 @@ module.exports = {
       let { google } = require('googleapis');
       let androidManagementConnection = google.androidmanagement({version: 'v1', auth: androidManagementAuthClient});
       // [?]: https://googleapis.dev/nodejs/googleapis/latest/androidmanagement/classes/Resource$Enterprises$Devices.html#delete
+      sails.androidProxyApiRequestCount++;// Count this Android Management API request toward the per-minute total logged in api/hooks/custom/index.js.
       await androidManagementConnection.enterprises.devices.delete({
         name: `enterprises/${androidEnterpriseId}/devices/${deviceId}`,
       });

--- a/website/api/controllers/android-proxy/delete-one-android-enterprise.js
+++ b/website/api/controllers/android-proxy/delete-one-android-enterprise.js
@@ -61,6 +61,7 @@ module.exports = {
         let { google } = require('googleapis');
         let androidManagementConnection = google.androidmanagement({version: 'v1', auth: androidManagementAuthClient});
         // Delete the android enterprise.
+        sails.androidProxyApiRequestCount++;// Count this Android Management API request toward the per-minute total logged in api/hooks/custom/index.js.
         await androidManagementConnection.enterprises.delete({
           name: `enterprises/${androidEnterpriseId}`,
         });

--- a/website/api/controllers/android-proxy/get-android-device.js
+++ b/website/api/controllers/android-proxy/get-android-device.js
@@ -67,6 +67,7 @@ module.exports = {
       let { google } = require('googleapis');
       let androidManagementConnection = google.androidmanagement({version: 'v1', auth: androidManagementAuthClient});
       // [?]: https://googleapis.dev/nodejs/googleapis/latest/androidmanagement/classes/Resource$Enterprises$Devices.html#get
+      sails.androidProxyApiRequestCount++;// Count this Android Management API request toward the per-minute total logged in api/hooks/custom/index.js.
       let getDeviceResult = await androidManagementConnection.enterprises.devices.get({
         name: `enterprises/${androidEnterpriseId}/devices/${deviceId}`,
       });

--- a/website/api/controllers/android-proxy/get-android-devices.js
+++ b/website/api/controllers/android-proxy/get-android-devices.js
@@ -74,6 +74,7 @@ module.exports = {
       let androidManagementConnection = google.androidmanagement({version: 'v1', auth: androidManagementAuthClient});
 
       // Get the Android devices list from Google
+      sails.androidProxyApiRequestCount++;// Count this Android Management API request toward the per-minute total logged in api/hooks/custom/index.js.
       let devicesResponse = await androidManagementConnection.enterprises.devices.list({
         parent: `enterprises/${thisAndroidEnterprise.androidEnterpriseId}`,
         pageSize: pageSize,

--- a/website/api/controllers/android-proxy/get-android-enterprises.js
+++ b/website/api/controllers/android-proxy/get-android-enterprises.js
@@ -64,6 +64,7 @@ module.exports = {
         let allEnterprises = [];
         let tokenForNextPageOfEnterprises;
         await sails.helpers.flow.until(async ()=>{
+          sails.androidProxyApiRequestCount++;// Count this Android Management API request toward the per-minute total logged in api/hooks/custom/index.js.
           let listEnterprisesResponse = await androidManagementConnection.enterprises.list({
             projectId: sails.config.custom.androidEnterpriseProjectId,
             pageSize: 100,

--- a/website/api/controllers/android-proxy/get-enterprise-applications.js
+++ b/website/api/controllers/android-proxy/get-enterprise-applications.js
@@ -65,6 +65,7 @@ module.exports = {
       let { google } = require('googleapis');
       let androidManagementConnection = google.androidmanagement({version: 'v1', auth: androidManagementAuthClient});
       // [?]: https://googleapis.dev/nodejs/googleapis/latest/androidmanagement/classes/Resource$Enterprises$Applications.html#get
+      sails.androidProxyApiRequestCount++;// Count this Android Management API request toward the per-minute total logged in api/hooks/custom/index.js.
       let getApplicationsResult = await androidManagementConnection.enterprises.applications.get({
         name: `enterprises/${androidEnterpriseId}/applications/${applicationId}`,
       });

--- a/website/api/controllers/android-proxy/issue-command-on-android-device.js
+++ b/website/api/controllers/android-proxy/issue-command-on-android-device.js
@@ -164,6 +164,7 @@ module.exports = {
       let { google } = require('googleapis');
       let androidManagementConnection = google.androidmanagement({version: 'v1', auth: androidManagementAuthClient});
       // [?]: https://googleapis.dev/nodejs/googleapis/latest/androidmanagement/classes/Resource$Enterprises$Devices.html#issueCommand
+      sails.androidProxyApiRequestCount++;// Count this Android Management API request toward the per-minute total logged in api/hooks/custom/index.js.
       let response = await androidManagementConnection.enterprises.devices.issueCommand({
         name: `enterprises/${androidEnterpriseId}/devices/${deviceId}`,
         requestBody: commandBody,

--- a/website/api/controllers/android-proxy/modify-android-device.js
+++ b/website/api/controllers/android-proxy/modify-android-device.js
@@ -69,6 +69,7 @@ module.exports = {
       let { google } = require('googleapis');
       let androidManagementConnection = google.androidmanagement({version: 'v1', auth: androidManagementAuthClient});
       // [?]: https://googleapis.dev/nodejs/googleapis/latest/androidmanagement/classes/Resource$Enterprises$Devices.html#patch
+      sails.androidProxyApiRequestCount++;// Count this Android Management API request toward the per-minute total logged in api/hooks/custom/index.js.
       let patchDeviceResponse = await androidManagementConnection.enterprises.devices.patch({
         name: `enterprises/${androidEnterpriseId}/devices/${deviceId}`,
         // Note: Typically, we use defined inputs instead of accessing req.body directly. We forward req.body here to prevent previously set values from being overwritten by undefined values.

--- a/website/api/controllers/android-proxy/modify-android-policies.js
+++ b/website/api/controllers/android-proxy/modify-android-policies.js
@@ -67,6 +67,7 @@ module.exports = {
       let { google } = require('googleapis');
       let androidManagementConnection = google.androidmanagement({version: 'v1', auth: androidManagementAuthClient});
       // [?]: https://googleapis.dev/nodejs/googleapis/latest/androidmanagement/classes/Resource$Enterprises$Policies.html#patch
+      sails.androidProxyApiRequestCount++;// Count this Android Management API request toward the per-minute total logged in api/hooks/custom/index.js.
       let patchPoliciesResponse = await androidManagementConnection.enterprises.policies.patch({
         name: `enterprises/${androidEnterpriseId}/policies/${policyId}`,
         // Note: Typically, we use defined inputs instead of accessing req.body directly. We forward req.body here to prevent previously set values from being overwritten by undefined values.

--- a/website/api/controllers/android-proxy/modify-enterprise-app-policy.js
+++ b/website/api/controllers/android-proxy/modify-enterprise-app-policy.js
@@ -79,6 +79,7 @@ module.exports = {
       let { google } = require('googleapis');
       let androidManagementConnection = google.androidmanagement({version: 'v1', auth: androidManagementAuthClient});
 
+      sails.androidProxyApiRequestCount++;// Count this Android Management API request toward the per-minute total logged in api/hooks/custom/index.js.
       switch (googleAction) {
         case 'removePolicyApplications': {
           let response = await androidManagementConnection.enterprises.policies.removePolicyApplications({

--- a/website/api/helpers/android-proxy/get-is-enterprise-managed-by-fleet.js
+++ b/website/api/helpers/android-proxy/get-is-enterprise-managed-by-fleet.js
@@ -44,6 +44,7 @@ module.exports = {
     let enterprises = [];
     let tokenForNextPageOfEnterprises;
     await sails.helpers.flow.until(async ()=>{
+      sails.androidProxyApiRequestCount++;// Count this Android Management API request toward the per-minute total logged in api/hooks/custom/index.js.
       let listEnterprisesResponse = await androidManagementConnection.enterprises.list({
         projectId: sails.config.custom.androidEnterpriseProjectId,
         pageSize: 100,

--- a/website/api/hooks/custom/index.js
+++ b/website/api/hooks/custom/index.js
@@ -139,7 +139,7 @@ will be disabled and/or hidden in the UI.
       // ... Any other app-specific setup code that needs to run on lift,
       // even in production, goes here ...
 
-      // Initialize an Android Management API) request counter. Each android-proxy
+      // Initialize an Android Management API request counter. Each android-proxy
       // endpoint (api/controllers/android-proxy/*) increments this every time it makes a request to
       // Google, and the repeating timer below logs the count and resets it once a minute so we can monitor the number of requests the proxy is making.
       sails.androidProxyApiRequestCount = 0;

--- a/website/api/hooks/custom/index.js
+++ b/website/api/hooks/custom/index.js
@@ -139,6 +139,31 @@ will be disabled and/or hidden in the UI.
       // ... Any other app-specific setup code that needs to run on lift,
       // even in production, goes here ...
 
+      // Initialize an Android Management API) request counter. Each android-proxy
+      // endpoint (api/controllers/android-proxy/*) increments this every time it makes a request to
+      // Google, and the repeating timer below logs the count and resets it once a minute so we can monitor the number of requests the proxy is making.
+      sails.androidProxyApiRequestCount = 0;
+      if (sails.config.custom.androidEnterpriseServiceAccountEmailAddress && sails.config.custom.androidEnterpriseServiceAccountPrivateKey) {
+        let logAndResetAndroidProxyApiRequestCount = ()=>{
+          let requestCountInLastMinute = sails.androidProxyApiRequestCount;
+          sails.androidProxyApiRequestCount = 0;// Reset for the next minute.
+          if (requestCountInLastMinute === 0) {
+            return;// Stay quiet on idle minutes so the metric lines are easy to grep.
+          }
+          sails.log.info(`Android proxy: ${requestCountInLastMinute} Android Management API request(s) in the last minute.`);
+        };
+        // Align the first tick to the top of the next minute so every web dyno logs on the same
+        // wall-clock cadence (e.g. all dynos log at :00) rather than at a random offset determined by
+        // when each dyno happened to boot.
+        let millisecondsUntilNextMinute = 60000 - (Date.now() % 60000);
+        let androidProxyMetricsStartTimeout = setTimeout(()=>{
+          logAndResetAndroidProxyApiRequestCount();
+          let androidProxyMetricsInterval = setInterval(logAndResetAndroidProxyApiRequestCount, 60 * 1000);
+          androidProxyMetricsInterval.unref();// Don't let this timer keep the process alive.
+        }, millisecondsUntilNextMinute);
+        androidProxyMetricsStartTimeout.unref();
+      }//ﬁ
+
       // In non-production environments, make `builtStaticContent.testimonials` optional so pages that use the <scrollable-tweets> component still render before the build-static-content script has been run.
       // To prevent the component from being empty whitespace on pages where it is used, we'll inject a single placeholder testimonial directing the user to run the build-static-content script.
       if (sails.config.environment !== 'production') {


### PR DESCRIPTION
Related to: https://github.com/fleetdm/fleet/issues/49212

Changes:
- Updated the custom hook to create `sails.androidProxyApiRequestCount`, and to log and reset the value every minute
- Updated android proxy endpoints to increment `sails.androidProxyApiRequestCount` every time a request to the Android management API is sent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Monitoring**
  * Added comprehensive tracking for Android Management API requests across enrollment, enterprise, device, application, policy, and command operations.
  * Added periodic request-count logging and automatic resets when Android Enterprise credentials are configured.
  * Improved reporting alignment with minute-based API limits while keeping logs quiet during periods without requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->