### PR TITLE
Keep FMA custom script comments admin-facing (new-fma skill)

### DIFF
--- a/.claude/skills/new-fma/SKILL.md
+++ b/.claude/skills/new-fma/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: new-fma
-description: Add a Fleet-maintained app (FMA) for macOS (Homebrew) and/or Windows (winget). Use when asked to "add X as a macOS/Windows FMA", "add a Fleet-maintained app", or to debug FMA validator failures. Emphasizes verifying installer metadata with real tools (msitools, plist) instead of guessing.
+description: Add a Fleet-maintained app (FMA) for macOS (Homebrew) and/or Windows (winget), or write/clean up an FMA's custom install or uninstall script. Use when asked to "add X as a macOS/Windows FMA", "add a Fleet-maintained app", to debug FMA validator failures, or to review comments in an FMA script. Emphasizes verifying installer metadata with real tools (msitools, plist) instead of guessing, and keeping shipped script comments admin-facing.
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, WebFetch, WebSearch
 model: opus
 effort: high
@@ -110,6 +110,41 @@ hdiutil detach "$MP" >/dev/null; rm -f app.dmg
 
 The ingester only auto-generates scripts for **machine-scope MSI**. Everything else needs custom `install_script_path` + `uninstall_script_path`. MSI success codes to treat as success: `0`, `3010` (reboot required), `1641` (reboot initiated).
 
+### Custom script comments: these ship to customers
+
+FMA install/uninstall scripts are not internal code. They're returned verbatim by `GET /fleet/software/fleet_maintained_apps/:id` and by the software title endpoint, and rendered in the "Install script" / "Uninstall script" editors of the Edit software modal ([AdvancedOptionsFields.tsx](../../../frontend/pages/SoftwarePage/components/forms/AdvancedOptionsFields/AdvancedOptionsFields.tsx)), where an admin reads them and can edit them. Every comment you leave is product copy — treat it like the app description, not like a commit message.
+
+Budget: the Fleet template header (`# Learn more about .exe install scripts:` + URL) if the script started from a template, then **at most ~4 lines** of app-specific comment. Of the 580 scripts in `inputs/*/scripts/`, only 51 open with a longer block than that — a big header is the exception you have to justify, not the norm.
+
+**Keep** a comment only if an admin who edits this script would break something without it, or would be surprised at install time:
+- Host-visible side effects: the app is force-quit, users are logged out, a reboot happens, existing config is preserved or deleted.
+- Scope and destructiveness decisions — e.g. [box-tools-uninstall.sh](../../../ee/maintained-apps/inputs/homebrew/scripts/box-tools-uninstall.sh): removal sweeps every local user's home, and only the Box Edit subdirectory goes because the parent is shared with Box Drive.
+- Constraints that must survive an edit: the required switch and why the obvious one is wrong (`/VERYSILENT` — this is Inno Setup, `/S` opens the GUI), removal ordering, "must run as the logged-in user."
+- Exit-code meanings (`1605` = not installed, `3010` = reboot required).
+
+**Cut** — this belongs in the PR description, not the shipped script:
+- Fleet's own tooling: "the validator's 10-minute timeout", "hangs in CI", "the ingester", "osquery's programs table". A customer has no validator.
+- Catalog archaeology: what winget/Homebrew metadata claimed vs. reality, `silentinstallhq.com` links, PR/issue numbers.
+- Debugging narrative: what you tried first and why it failed ("a plain `Start-Process -Wait` would block until killed").
+- First person ("we", "our", "ourselves") — describe what the script does, in present tense and sentence case.
+- Restating the next line (`# Prints the exit code` above a `Write-Host`).
+
+If the fact matters at run time rather than at edit time, `Write-Host`/`echo` it instead of commenting it — script output lands in the host's software install details, which is where an admin debugging a failure actually looks.
+
+Before/after — [darktable_install.ps1](../../../ee/maintained-apps/inputs/winget/scripts/darktable_install.ps1)'s 20-line header carries three admin-relevant facts and 16 lines of internal history:
+```powershell
+# Learn more about .exe install scripts:
+# http://fleetdm.com/learn-more-about/exe-install-scripts
+#
+# darktable uses an Inno Setup installer: it needs /VERYSILENT (the NSIS /S
+# switch winget's metadata implies does nothing) and installs machine-wide when
+# elevated. Its installer stays running after a silent install, so this script
+# waits for darktable to register in Programs and Features, then stops it.
+```
+Dropped: that winget mislabeled the installer type, that `PrivilegesRequiredOverridesAllowed=dialog` rules out `/ALLUSERS`, that the lingering process holds the installer file lock, what a plain `-Wait` did. All of it goes in the PR body, where reviewers need it and customers don't see it.
+
+Body comments follow the same rule — keep the one above a non-obvious registry match or a load-bearing helper, drop the rest. **When you touch an existing script for any reason, prune its comments in the same edit.**
+
 ### Generate, validate, finalize
 ```bash
 go run cmd/maintained-apps/main.go --slug="<app>/<platform>" --debug
@@ -165,6 +200,7 @@ if ($u -match '^\s*"([^"]+)"\s*(.*)$') {            # quoted
 - [ ] `unique_identifier` = registry DisplayName / bundle id; `program_publisher` set if needed.
 - [ ] Silent install/uninstall flags from winget `InstallerSwitches` or silentinstallhq, not invented.
 - [ ] Custom uninstall (non-MSI-machine) uses the defensive UninstallString parser.
+- [ ] Custom script comments are admin-facing and short (~4 lines past the template header): no validator/CI/ingester references, no catalog archaeology, no debugging narrative, no first person. Internal rationale moved to the PR body.
 - [ ] Version reconciles with osquery (or a documented validator exception applies — not a blanket skip).
 - [ ] Generated SHA matches the manifest; exists/patched queries reviewed; `apps.json` valid + description filled.
 - [ ] Icon exists or is generated.


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** NA

Updates the `new-fma` Claude Code skill so custom FMA install/uninstall scripts ship with short, admin-facing comments instead of internal engineering history.

## Why

FMA install and uninstall scripts are customer-visible and customer-editable:

- `MaintainedApp.InstallScript` / `UninstallScript` are JSON-exposed (`server/fleet/maintained_apps.go:19-20`) and returned by `GET /api/_version_/fleet/software/fleet_maintained_apps/{app_id}` (`server/service/maintained_apps.go:189`) and by the software title endpoint (`server/fleet/software_installer.go:92,102`).
- They render in Ace editors labeled "Install script" / "Uninstall script" in the Edit software modal (`frontend/pages/SoftwarePage/components/forms/AdvancedOptionsFields/AdvancedOptionsFields.tsx:93-127`), writable outside GitOps mode. FMAs aren't excluded from "Edit software."

So every comment in these scripts is product copy an admin reads. Today a number of shipped scripts open with headers about Fleet's own tooling instead — validator timeouts, "hangs in CI", the ingester, winget metadata archaeology, `silentinstallhq.com` links, and narratives of what was tried first and why it failed. None of that means anything to a customer reading the script in Fleet.

## What changed

One file: `.claude/skills/new-fma/SKILL.md`.

- New **"Custom script comments: these ship to customers"** section covering:
  - Why the scripts are customer-visible, with the API and UI surfaces named.
  - A length budget anchored to the existing corpus: template header plus ~4 lines of app-specific comment. Of the 580 scripts in `ee/maintained-apps/inputs/*/scripts/`, only 51 open with a longer block, so a big header is the exception to justify.
  - A **keep** list — a comment earns its place only if an editing admin would break something without it or be surprised at install time: host-visible side effects (force-quit, reboot, config deleted), scope/destructiveness decisions, load-bearing switches where the obvious choice is wrong, exit-code meanings.
  - A **cut** list drawn from what's actually in the scripts today: Fleet-tooling references, catalog archaeology and silentinstallhq/PR links, debugging narrative, first person, and comments restating the next line. These go in the PR body instead.
  - Runtime vs. edit-time: if the fact matters while installing, `Write-Host`/`echo` it, since install output surfaces in the host's software install details.
  - A worked before/after on `darktable_install.ps1` (20-line header to 4 lines), naming which facts survive and which move to the PR.
  - A prune-on-touch rule so existing bloated headers get cleaned up incrementally.
- New pre-ship checklist item for script comments.
- Widened the skill `description` so it also triggers on writing or cleaning up an FMA script, not just adding a new FMA.

## What this PR does not do

It does not rewrite the 51 over-budget scripts. Each needs its facts checked against the script it documents (as the darktable example was), so that's a separate reviewable change — likely letter-batched like the other FMA workstreams.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

  N/A — tooling/docs only. No product code, API, schema, or UI changes; nothing user-visible in a Fleet release.

## Testing

- [x] QA'd all new/changed functionality manually

  Verified the claims the guidance rests on before writing it: traced the script text from the datastore through both API responses to the Ace editors in the Edit software modal, and confirmed the editors are writable outside GitOps mode. Measured the comment-block distribution across all 580 scripts in `ee/maintained-apps/inputs/*/scripts/` for the length budget. Confirmed the three files the section links to exist, and checked that the condensed darktable header stays faithful to what that script actually does.

  No automated tests — the change is a Markdown skill file with no executable code.
