### PR TITLE
Fix website deploy race: concurrency group never matched on push events

### DIFF
--- a/.github/workflows/deploy-fleet-website.yml
+++ b/.github/workflows/deploy-fleet-website.yml
@@ -11,9 +11,12 @@ on:
       - 'schema/**'
       - "ee/maintained-apps/outputs/**"
 
-# This allows a subsequently queued workflow run to interrupt previous runs
+# Serialize deploys per branch: a newer push cancels any in-progress deploy so an
+# older build can never finish last and overwrite a newer release on Heroku.
+# (github.head_ref is empty on push events, so keying on it gave every run a
+# unique group and deploys raced.)
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id}}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 defaults:


### PR DESCRIPTION
**Related issue:** NA (incident: today's articles missing from fleetdm.com after successful deploys)

The website deploy workflow's concurrency group is keyed on `github.head_ref`, which is only populated on pull_request events. The workflow only runs on push, so the group always fell back to `github.run_id`, giving every run a unique group. Concurrent deploys were never serialized or cancelled.

Each deploy does `heroku repo:reset` and force-pushes its own checkout, so whichever run finishes last wins. Today (Aug 7), five commits merged within 15 minutes and the run for the oldest commit (`616f9ab`, 17:16 UTC) finished last at 18:04 UTC, releasing a build that predates three articles merged at 17:18–17:31 UTC. The site served that stale release (Heroku v12587) until the newest run was re-run.

This keys the group on `github.ref` so pushes to main share one group, and `cancel-in-progress: true` cancels the older in-flight deploy when a newer push arrives. An older build can no longer finish last and overwrite a newer release.

The same `head_ref || run_id` pattern is copy-pasted in ~70 other workflows. Those are test/build workflows where the failure mode is only wasted CI, not a stale deploy, so they're left for a follow-up sweep.

# Checklist for submitter

- [x] QA'd all new/changed functionality manually (verified the race from run timestamps of runs 31201497347 / 31201698662 / 31202703079; automated tests don't apply to workflow YAML)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment handling by grouping runs by workflow and branch.
  * Newer deployments now cancel older in-progress deployments for the same branch, reducing redundant releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->