### PR TITLE
Add VEX exclusions for `fleetdm/wix`

### DIFF
--- a/security/status.md
+++ b/security/status.md
@@ -899,6 +899,14 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2026-04-20 11:42:37
 
+### [CVE-2026-47178](https://nvd.nist.gov/vuln/detail/CVE-2026-47178)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not process HEIF/AVIF images (libheif) when using fleetdm/wix to generate MSI packages.
+- **Products:** `wix`,`pkg:deb/debian/libheif1`,`pkg:deb/debian/libheif-plugin-dav1d`,`pkg:deb/debian/libheif-plugin-libde265`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-08-07 19:58:48
+
 ### [CVE-2026-45447](https://nvd.nist.gov/vuln/detail/CVE-2026-45447)
 - **Author:** @lucasmrod
 - **Status:** `not_affected`
@@ -1035,6 +1043,14 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2026-04-08 11:01:10
 
+### [CVE-2026-32882](https://nvd.nist.gov/vuln/detail/CVE-2026-32882)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not process HEIF/AVIF images (libheif) when using fleetdm/wix to generate MSI packages.
+- **Products:** `wix`,`pkg:deb/debian/libheif1`,`pkg:deb/debian/libheif-plugin-dav1d`,`pkg:deb/debian/libheif-plugin-libde265`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-08-07 19:58:48
+
 ### [CVE-2026-32775](https://nvd.nist.gov/vuln/detail/CVE-2026-32775)
 - **Author:** @lucasmrod
 - **Status:** `not_affected`
@@ -1042,6 +1058,22 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Products:** `wix`,`pkg:deb/debian/libexif12`
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2026-05-19 10:16:53
+
+### [CVE-2026-32741](https://nvd.nist.gov/vuln/detail/CVE-2026-32741)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not process HEIF/AVIF images (libheif) when using fleetdm/wix to generate MSI packages.
+- **Products:** `wix`,`pkg:deb/debian/libheif1`,`pkg:deb/debian/libheif-plugin-dav1d`,`pkg:deb/debian/libheif-plugin-libde265`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-08-07 19:58:48
+
+### [CVE-2026-32740](https://nvd.nist.gov/vuln/detail/CVE-2026-32740)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not process HEIF/AVIF images (libheif) when using fleetdm/wix to generate MSI packages.
+- **Products:** `wix`,`pkg:deb/debian/libheif1`,`pkg:deb/debian/libheif-plugin-dav1d`,`pkg:deb/debian/libheif-plugin-libde265`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-08-07 19:58:48
 
 ### [CVE-2026-31789](https://nvd.nist.gov/vuln/detail/CVE-2026-31789)
 - **Author:** @lucasmrod
@@ -1162,6 +1194,14 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Products:** `wix`,`pkg:deb/debian/libjxl0.11`
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2026-07-10 11:44:26
+
+### [CVE-2025-68431](https://nvd.nist.gov/vuln/detail/CVE-2025-68431)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not process HEIF/AVIF images (libheif) when using fleetdm/wix to generate MSI packages.
+- **Products:** `wix`,`pkg:deb/debian/libheif1`,`pkg:deb/debian/libheif-plugin-dav1d`,`pkg:deb/debian/libheif-plugin-libde265`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-08-07 19:58:48
 
 ### [CVE-2025-66293](https://nvd.nist.gov/vuln/detail/CVE-2025-66293)
 - **Author:** @lucasmrod

--- a/security/status.md
+++ b/security/status.md
@@ -819,6 +819,38 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Justification:** `vulnerable_code_cannot_be_controlled_by_adversary`
 - **Timestamp:** 2026-07-31 09:46:22
 
+### [CVE-2026-56211](https://nvd.nist.gov/vuln/detail/CVE-2026-56211)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not process AV1 video (libaom3) when using fleetdm/wix to generate MSI packages.
+- **Products:** `wix`,`pkg:deb/debian/libaom3`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-08-07 19:50:41
+
+### [CVE-2026-56210](https://nvd.nist.gov/vuln/detail/CVE-2026-56210)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not process AV1 video (libaom3) when using fleetdm/wix to generate MSI packages.
+- **Products:** `wix`,`pkg:deb/debian/libaom3`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-08-07 19:50:41
+
+### [CVE-2026-56209](https://nvd.nist.gov/vuln/detail/CVE-2026-56209)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not process AV1 video (libaom3) when using fleetdm/wix to generate MSI packages.
+- **Products:** `wix`,`pkg:deb/debian/libaom3`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-08-07 19:50:41
+
+### [CVE-2026-56208](https://nvd.nist.gov/vuln/detail/CVE-2026-56208)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not process AV1 video (libaom3) when using fleetdm/wix to generate MSI packages.
+- **Products:** `wix`,`pkg:deb/debian/libaom3`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-08-07 19:50:41
+
 ### [CVE-2026-56131](https://nvd.nist.gov/vuln/detail/CVE-2026-56131)
 - **Author:** @lucasmrod
 - **Status:** `not_affected`

--- a/security/vex/wix/CVE-2025-68431.vex.json
+++ b/security/vex/wix/CVE-2025-68431.vex.json
@@ -1,0 +1,32 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-e3174d9c0071a29955c9e23ec6429c9accec6df9c5fe55d595ac6108e19d003c",
+  "author": "@lucasmrod",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-68431"
+      },
+      "products": [
+        {
+          "@id": "wix"
+        },
+        {
+          "@id": "pkg:deb/debian/libheif1"
+        },
+        {
+          "@id": "pkg:deb/debian/libheif-plugin-dav1d"
+        },
+        {
+          "@id": "pkg:deb/debian/libheif-plugin-libde265"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not process HEIF/AVIF images (libheif) when using fleetdm/wix to generate MSI packages",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "timestamp": "2026-08-07T19:58:48.058087Z"
+    }
+  ],
+  "timestamp": "2026-08-07T19:58:48Z"
+}

--- a/security/vex/wix/CVE-2026-32740.vex.json
+++ b/security/vex/wix/CVE-2026-32740.vex.json
@@ -1,0 +1,32 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-e7dd752cbff75750f9cbc413dea831d53edbf866628505a2e12aeb671aacc4f7",
+  "author": "@lucasmrod",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-32740"
+      },
+      "products": [
+        {
+          "@id": "wix"
+        },
+        {
+          "@id": "pkg:deb/debian/libheif1"
+        },
+        {
+          "@id": "pkg:deb/debian/libheif-plugin-dav1d"
+        },
+        {
+          "@id": "pkg:deb/debian/libheif-plugin-libde265"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not process HEIF/AVIF images (libheif) when using fleetdm/wix to generate MSI packages",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "timestamp": "2026-08-07T19:58:48.07516Z"
+    }
+  ],
+  "timestamp": "2026-08-07T19:58:48Z"
+}

--- a/security/vex/wix/CVE-2026-32741.vex.json
+++ b/security/vex/wix/CVE-2026-32741.vex.json
@@ -1,0 +1,32 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-9e4164ec79f6015db76e85c0fa08dcb3958883ecafdfda815daf2dae78f65632",
+  "author": "@lucasmrod",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-32741"
+      },
+      "products": [
+        {
+          "@id": "wix"
+        },
+        {
+          "@id": "pkg:deb/debian/libheif1"
+        },
+        {
+          "@id": "pkg:deb/debian/libheif-plugin-dav1d"
+        },
+        {
+          "@id": "pkg:deb/debian/libheif-plugin-libde265"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not process HEIF/AVIF images (libheif) when using fleetdm/wix to generate MSI packages",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "timestamp": "2026-08-07T19:58:48.092303Z"
+    }
+  ],
+  "timestamp": "2026-08-07T19:58:48Z"
+}

--- a/security/vex/wix/CVE-2026-32882.vex.json
+++ b/security/vex/wix/CVE-2026-32882.vex.json
@@ -1,0 +1,32 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-008fca61039cf60570f5ec50f5ad13b1fae877a871607ba66b845f0ed058c5c8",
+  "author": "@lucasmrod",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-32882"
+      },
+      "products": [
+        {
+          "@id": "wix"
+        },
+        {
+          "@id": "pkg:deb/debian/libheif1"
+        },
+        {
+          "@id": "pkg:deb/debian/libheif-plugin-dav1d"
+        },
+        {
+          "@id": "pkg:deb/debian/libheif-plugin-libde265"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not process HEIF/AVIF images (libheif) when using fleetdm/wix to generate MSI packages",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "timestamp": "2026-08-07T19:58:48.108672Z"
+    }
+  ],
+  "timestamp": "2026-08-07T19:58:48Z"
+}

--- a/security/vex/wix/CVE-2026-47178.vex.json
+++ b/security/vex/wix/CVE-2026-47178.vex.json
@@ -1,0 +1,32 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-606c7ff9b3e00b1a10ae27adbbbb2f72b4283195a4af1a1a7a333b77a632f4e3",
+  "author": "@lucasmrod",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-47178"
+      },
+      "products": [
+        {
+          "@id": "wix"
+        },
+        {
+          "@id": "pkg:deb/debian/libheif1"
+        },
+        {
+          "@id": "pkg:deb/debian/libheif-plugin-dav1d"
+        },
+        {
+          "@id": "pkg:deb/debian/libheif-plugin-libde265"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not process HEIF/AVIF images (libheif) when using fleetdm/wix to generate MSI packages",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "timestamp": "2026-08-07T19:58:48.124186Z"
+    }
+  ],
+  "timestamp": "2026-08-07T19:58:48Z"
+}

--- a/security/vex/wix/CVE-2026-56208.vex.json
+++ b/security/vex/wix/CVE-2026-56208.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-6e3c26bb67d55a7a2c9e178f3738a5b223a50ca26ce70a506bf97180ea1d7784",
+  "author": "@lucasmrod",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56208"
+      },
+      "products": [
+        {
+          "@id": "wix"
+        },
+        {
+          "@id": "pkg:deb/debian/libaom3"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not process AV1 video (libaom3) when using fleetdm/wix to generate MSI packages",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "timestamp": "2026-08-07T19:50:41.768471Z"
+    }
+  ],
+  "timestamp": "2026-08-07T19:50:41Z"
+}

--- a/security/vex/wix/CVE-2026-56209.vex.json
+++ b/security/vex/wix/CVE-2026-56209.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-d76593dbc8ade52adfef4f0ef218e1f0179dd6f26c3aabf02a60d31d9d329703",
+  "author": "@lucasmrod",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56209"
+      },
+      "products": [
+        {
+          "@id": "wix"
+        },
+        {
+          "@id": "pkg:deb/debian/libaom3"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not process AV1 video (libaom3) when using fleetdm/wix to generate MSI packages",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "timestamp": "2026-08-07T19:50:41.785336Z"
+    }
+  ],
+  "timestamp": "2026-08-07T19:50:41Z"
+}

--- a/security/vex/wix/CVE-2026-56210.vex.json
+++ b/security/vex/wix/CVE-2026-56210.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-fa0c5c3848e54e744952e3f3002b05eb9033580f1a7037d512c9d4f377c92c56",
+  "author": "@lucasmrod",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56210"
+      },
+      "products": [
+        {
+          "@id": "wix"
+        },
+        {
+          "@id": "pkg:deb/debian/libaom3"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not process AV1 video (libaom3) when using fleetdm/wix to generate MSI packages",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "timestamp": "2026-08-07T19:50:41.801656Z"
+    }
+  ],
+  "timestamp": "2026-08-07T19:50:41Z"
+}

--- a/security/vex/wix/CVE-2026-56211.vex.json
+++ b/security/vex/wix/CVE-2026-56211.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-78a9eb523b8a9c414d08245231a5799648c2c0331c8da6e28ae4fe6cf2603ac5",
+  "author": "@lucasmrod",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56211"
+      },
+      "products": [
+        {
+          "@id": "wix"
+        },
+        {
+          "@id": "pkg:deb/debian/libaom3"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not process AV1 video (libaom3) when using fleetdm/wix to generate MSI packages",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "timestamp": "2026-08-07T19:50:41.817286Z"
+    }
+  ],
+  "timestamp": "2026-08-07T19:50:41Z"
+}


### PR DESCRIPTION
Fixes: https://github.com/fleetdm/fleet/actions/runs/31153554311.

New run: https://github.com/fleetdm/fleet/actions/runs/31214011778.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Added vulnerability assessments for four CVEs affecting Debian `libaom3`.
  * Added assessments for five CVEs affecting Debian `libheif` packages.
  * Documented that the application is not affected because AV1, HEIF, and AVIF media processing is not part of MSI package generation.
  * Classified the vulnerable code as outside the application’s execution path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->