### PR TITLE
Distinguish API-only endpoint-restriction 403s from role-based permission denials

### DIFF
--- a/changes/50813-distinguish-api-only-endpoint-restriction-403s
+++ b/changes/50813-distinguish-api-only-endpoint-restriction-403s
@@ -1,0 +1,1 @@
+- Requests denied by an API-only user's endpoint restrictions now return a distinct 403 message ("endpoint not permitted for this API-only user") and are logged at info level with the route and denial reason, so they can be distinguished from role-based permission denials.

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -67,6 +67,7 @@ import (
 	commonCalendar "github.com/fleetdm/fleet/v4/server/service/calendar"
 	"github.com/fleetdm/fleet/v4/server/service/conditional_access_microsoft_proxy"
 	"github.com/fleetdm/fleet/v4/server/service/contract"
+	"github.com/fleetdm/fleet/v4/server/service/middleware/auth"
 	"github.com/fleetdm/fleet/v4/server/service/osquery_utils"
 	"github.com/fleetdm/fleet/v4/server/service/redis_lock"
 	"github.com/fleetdm/fleet/v4/server/service/schedule"
@@ -31520,6 +31521,14 @@ func (s *integrationEnterpriseTestSuite) TestAPIOnlyUserEndpointMiddleware() {
 		s.Do("GET", "/api/latest/fleet/hosts", nil, http.StatusOK)
 	})
 
+	// requireRestrictionDeniedBody asserts the 403 body carries the distinct
+	// endpoint-restriction message, distinguishing it from role-based denials.
+	requireRestrictionDeniedBody := func(t *testing.T, res *http.Response) {
+		body, err := io.ReadAll(res.Body)
+		require.NoError(t, err)
+		require.Contains(t, string(body), auth.EndpointRestrictionDeniedMessage)
+	}
+
 	// For api-only users with restrictions, requests to paths not in the API
 	// endpoint catalog are rejected by the middleware before reaching the
 	// service layer.
@@ -31527,7 +31536,8 @@ func (s *integrationEnterpriseTestSuite) TestAPIOnlyUserEndpointMiddleware() {
 		s.token = createAPIOnlyUser("api-only-mw-non-catalog-restricted", []map[string]any{
 			{"method": "GET", "path": "/api/v1/fleet/version"},
 		})
-		s.Do("PATCH", "/api/latest/fleet/users/api_only/1", map[string]any{"name": "x"}, http.StatusForbidden)
+		res := s.Do("PATCH", "/api/latest/fleet/users/api_only/1", map[string]any{"name": "x"}, http.StatusForbidden)
+		requireRestrictionDeniedBody(t, res)
 	})
 
 	// With endpoint restrictions, only explicitly allowed endpoints are reachable.
@@ -31540,8 +31550,10 @@ func (s *integrationEnterpriseTestSuite) TestAPIOnlyUserEndpointMiddleware() {
 		s.Do("GET", "/api/latest/fleet/version", nil, http.StatusOK)
 
 		// These are in the catalog but not in the user's allow list.
-		s.Do("GET", "/api/latest/fleet/config", nil, http.StatusForbidden)
-		s.Do("GET", "/api/latest/fleet/hosts", nil, http.StatusForbidden)
+		res := s.Do("GET", "/api/latest/fleet/config", nil, http.StatusForbidden)
+		requireRestrictionDeniedBody(t, res)
+		res = s.Do("GET", "/api/latest/fleet/hosts", nil, http.StatusForbidden)
+		requireRestrictionDeniedBody(t, res)
 	})
 
 	// Non-api-only users must not be affected by the middleware at all.

--- a/server/service/middleware/auth/api_only.go
+++ b/server/service/middleware/auth/api_only.go
@@ -57,11 +57,13 @@ func apiOnlyEndpointCheck(isInCatalog func(string) bool, next endpoint.Endpoint)
 		requestMethod, _ := ctx.Value(kithttp.ContextKeyRequestMethod).(string)
 		routeTemplate, _ := eu.RouteTemplateFromContext(ctx)
 
-		// A missing method or route template means the transport wasn't wired
-		// with RouteTemplateRequestFunc; fail closed with a reason that points
-		// at the misconfiguration instead of a misleading catalog miss.
-		if requestMethod == "" || routeTemplate == "" {
-			return nil, endpointRestrictionDenied(ctx, routeTemplate, "request method or route template missing from request context")
+		// Missing method or route template means the transport wasn't wired
+		// with RouteTemplateRequestFunc; fail closed naming the misconfiguration.
+		if requestMethod == "" {
+			return nil, endpointRestrictionDenied(ctx, routeTemplate, "request method missing from request context")
+		}
+		if routeTemplate == "" {
+			return nil, endpointRestrictionDenied(ctx, routeTemplate, "route template missing from request context")
 		}
 
 		fp := fleet.NewAPIEndpointFromTpl(requestMethod, routeTemplate).Fingerprint()
@@ -81,19 +83,14 @@ func apiOnlyEndpointCheck(isInCatalog func(string) bool, next endpoint.Endpoint)
 	}
 }
 
-// EndpointRestrictionDeniedMessage is returned in the 403 response body when a
-// request is denied by an API-only user's endpoint restrictions, so callers
-// can tell these denials apart from role-based permission denials. The
-// restriction list is not secret from the caller (they hold a valid token), so
-// naming the gate here discloses nothing.
+// EndpointRestrictionDeniedMessage is the 403 response body for
+// endpoint-restriction denials, distinct from role-based permission denials.
 const EndpointRestrictionDeniedMessage = "endpoint not permitted for this API-only user"
 
 // endpointRestrictionDenied rejects the request with a 403 that identifies the
-// endpoint restriction (rather than the user's role) as the gate. The denial
-// is surfaced on the request log line at info level — role-based 403s log at
-// debug, which is how endpoint-restriction denials went unnoticed during
-// debugging. The user email and request method are already logged on that
-// line; the route template and denial reason are added as extras.
+// endpoint restriction (rather than the user's role) as the gate, and forces
+// the request log line to info level (role-based 403s log at debug, which is
+// how these denials went unnoticed during debugging).
 func endpointRestrictionDenied(ctx context.Context, routeTemplate, reason string) error {
 	if ac, ok := authz.FromContext(ctx); ok {
 		ac.SetChecked()

--- a/server/service/middleware/auth/api_only.go
+++ b/server/service/middleware/auth/api_only.go
@@ -57,6 +57,13 @@ func apiOnlyEndpointCheck(isInCatalog func(string) bool, next endpoint.Endpoint)
 		requestMethod, _ := ctx.Value(kithttp.ContextKeyRequestMethod).(string)
 		routeTemplate, _ := eu.RouteTemplateFromContext(ctx)
 
+		// A missing method or route template means the transport wasn't wired
+		// with RouteTemplateRequestFunc; fail closed with a reason that points
+		// at the misconfiguration instead of a misleading catalog miss.
+		if requestMethod == "" || routeTemplate == "" {
+			return nil, endpointRestrictionDenied(ctx, routeTemplate, "request method or route template missing from request context")
+		}
+
 		fp := fleet.NewAPIEndpointFromTpl(requestMethod, routeTemplate).Fingerprint()
 
 		if !isInCatalog(fp) {

--- a/server/service/middleware/auth/api_only.go
+++ b/server/service/middleware/auth/api_only.go
@@ -2,9 +2,12 @@ package auth
 
 import (
 	"context"
+	"log/slog"
+	"net/http"
 
 	apiendpoints "github.com/fleetdm/fleet/v4/server/api_endpoints"
 	"github.com/fleetdm/fleet/v4/server/contexts/authz"
+	"github.com/fleetdm/fleet/v4/server/contexts/logging"
 	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	eu "github.com/fleetdm/fleet/v4/server/platform/endpointer"
@@ -34,9 +37,12 @@ var RouteTemplateRequestFunc = eu.RouteTemplateRequestFunc
 // For API-only users with a non-empty restriction list (rows in
 // user_api_endpoints), two checks are applied in order:
 //  1. The requested route must appear in the API endpoint catalog. If not, a
-//     permission error (403) is returned.
+//     403 with EndpointRestrictionDeniedMessage is returned.
 //  2. The route must match one of the user's allowed endpoints. If not, a
-//     permission error (403) is returned.
+//     403 with EndpointRestrictionDeniedMessage is returned.
+//
+// Both denials are logged at info level with the route template and denial
+// reason so they can be distinguished from role-based permission denials.
 func APIOnlyEndpointCheck(next endpoint.Endpoint) endpoint.Endpoint {
 	return apiOnlyEndpointCheck(apiendpoints.IsInCatalog, next)
 }
@@ -54,7 +60,7 @@ func apiOnlyEndpointCheck(isInCatalog func(string) bool, next endpoint.Endpoint)
 		fp := fleet.NewAPIEndpointFromTpl(requestMethod, routeTemplate).Fingerprint()
 
 		if !isInCatalog(fp) {
-			return nil, permissionDenied(ctx)
+			return nil, endpointRestrictionDenied(ctx, routeTemplate, "endpoint not in API endpoint catalog")
 		}
 
 		// Check whether the requested endpoint matches any of the user's allowed endpoints.
@@ -64,13 +70,39 @@ func apiOnlyEndpointCheck(isInCatalog func(string) bool, next endpoint.Endpoint)
 			}
 		}
 
-		return nil, permissionDenied(ctx)
+		return nil, endpointRestrictionDenied(ctx, routeTemplate, "endpoint not in user's allowed API endpoints")
 	}
 }
 
-func permissionDenied(ctx context.Context) error {
+// EndpointRestrictionDeniedMessage is returned in the 403 response body when a
+// request is denied by an API-only user's endpoint restrictions, so callers
+// can tell these denials apart from role-based permission denials. The
+// restriction list is not secret from the caller (they hold a valid token), so
+// naming the gate here discloses nothing.
+const EndpointRestrictionDeniedMessage = "endpoint not permitted for this API-only user"
+
+// endpointRestrictionDenied rejects the request with a 403 that identifies the
+// endpoint restriction (rather than the user's role) as the gate. The denial
+// is surfaced on the request log line at info level — role-based 403s log at
+// debug, which is how endpoint-restriction denials went unnoticed during
+// debugging. The user email and request method are already logged on that
+// line; the route template and denial reason are added as extras.
+func endpointRestrictionDenied(ctx context.Context, routeTemplate, reason string) error {
 	if ac, ok := authz.FromContext(ctx); ok {
 		ac.SetChecked()
 	}
-	return fleet.NewPermissionError("forbidden")
+	logging.WithLevel(ctx, slog.LevelInfo)
+	logging.WithExtras(ctx,
+		"denied_by", "api_only_endpoint_restriction",
+		"denial_reason", reason,
+		"route", routeTemplate,
+	)
+	// PermissionError alone won't do: the error encoder discards its message
+	// and renders a generic "Permission Denied" body. Wrapping it in a
+	// UserMessageError routes it through the encoder branch that includes the
+	// message in the response.
+	return fleet.NewUserMessageError(
+		fleet.NewPermissionError(EndpointRestrictionDeniedMessage),
+		http.StatusForbidden,
+	)
 }

--- a/server/service/middleware/auth/api_only_test.go
+++ b/server/service/middleware/auth/api_only_test.go
@@ -327,23 +327,33 @@ func TestAPIOnlyEndpointCheck(t *testing.T) {
 	t.Run("denial surfaces route and reason on the request log line at info level", func(t *testing.T) {
 		cases := []struct {
 			name       string
+			method     string
 			routeTpl   string
 			wantReason string
 		}{
 			{
 				name:       "endpoint not in catalog",
+				method:     "POST",
 				routeTpl:   muxTemplate("fleet/secret_admin_endpoint"),
 				wantReason: "endpoint not in API endpoint catalog",
 			},
 			{
 				name:       "endpoint not in allow-list",
+				method:     "POST",
 				routeTpl:   muxTemplate("fleet/scripts/run"),
 				wantReason: "endpoint not in user's allowed API endpoints",
 			},
 			{
+				name:       "request method missing from context",
+				method:     "",
+				routeTpl:   muxTemplate("fleet/scripts/run"),
+				wantReason: "request method missing from request context",
+			},
+			{
 				name:       "route template missing from context",
+				method:     "POST",
 				routeTpl:   "", // RouteTemplateRequestFunc not wired
-				wantReason: "request method or route template missing from request context",
+				wantReason: "route template missing from request context",
 			},
 		}
 		for _, c := range cases {
@@ -351,7 +361,9 @@ func TestAPIOnlyEndpointCheck(t *testing.T) {
 				next, called := newNext()
 				lc := &logging.LoggingContext{}
 				ctx := logging.NewContext(t.Context(), lc)
-				ctx = context.WithValue(ctx, kithttp.ContextKeyRequestMethod, "POST")
+				if c.method != "" {
+					ctx = context.WithValue(ctx, kithttp.ContextKeyRequestMethod, c.method)
+				}
 				if c.routeTpl != "" {
 					ctx = eu.WithRouteTemplate(ctx, c.routeTpl)
 				}
@@ -392,11 +404,6 @@ func TestAPIOnlyEndpointCheck(t *testing.T) {
 	})
 }
 
-// TestEndpointRestrictionDeniedEncoding pins the HTTP response an
-// endpoint-restriction denial encodes to: 403 with the distinct message in the
-// body. This guards the UserMessageError wrapping — a bare PermissionError's
-// message is discarded by the encoder and rendered as a generic "Permission
-// Denied" body.
 func TestEndpointRestrictionDeniedEncoding(t *testing.T) {
 	err := endpointRestrictionDenied(t.Context(), muxTemplate("fleet/hosts"), "endpoint not in user's allowed API endpoints")
 

--- a/server/service/middleware/auth/api_only_test.go
+++ b/server/service/middleware/auth/api_only_test.go
@@ -2,11 +2,13 @@ package auth
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	authzctx "github.com/fleetdm/fleet/v4/server/contexts/authz"
+	"github.com/fleetdm/fleet/v4/server/contexts/logging"
 	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	eu "github.com/fleetdm/fleet/v4/server/platform/endpointer"
@@ -44,6 +46,19 @@ func testIsInCatalog() func(string) bool {
 // what RouteTemplateRequestFunc would extract from mux.CurrentRoute(r).GetPathTemplate().
 func muxTemplate(pathSuffix string) string {
 	return muxVersionSegment + pathSuffix
+}
+
+// requireEndpointRestrictionDenied asserts that err is the 403 returned when an
+// API-only user's endpoint restrictions deny a request: a UserMessageError
+// carrying EndpointRestrictionDeniedMessage, distinguishable from a role-based
+// permission denial.
+func requireEndpointRestrictionDenied(t *testing.T, err error) {
+	t.Helper()
+	require.Error(t, err)
+	var umErr *fleet.UserMessageError
+	require.ErrorAs(t, err, &umErr)
+	require.Equal(t, http.StatusForbidden, umErr.StatusCode())
+	require.Equal(t, EndpointRestrictionDeniedMessage, umErr.UserMessage())
 }
 
 func TestAPIOnlyEndpointCheck(t *testing.T) {
@@ -139,8 +154,7 @@ func TestAPIOnlyEndpointCheck(t *testing.T) {
 		_, err := newEndpoint(next)(ctx, nil)
 		require.Error(t, err)
 		require.False(t, *called)
-		var permErr *fleet.PermissionError
-		require.ErrorAs(t, err, &permErr)
+		requireEndpointRestrictionDenied(t, err)
 	})
 
 	t.Run("api-only user with restrictions, missing route template in context is rejected", func(t *testing.T) {
@@ -156,8 +170,7 @@ func TestAPIOnlyEndpointCheck(t *testing.T) {
 		_, err := newEndpoint(next)(ctx, nil)
 		require.Error(t, err)
 		require.False(t, *called)
-		var permErr *fleet.PermissionError
-		require.ErrorAs(t, err, &permErr)
+		requireEndpointRestrictionDenied(t, err)
 	})
 
 	t.Run("api-only user with restrictions, missing method and template are both rejected", func(t *testing.T) {
@@ -172,8 +185,7 @@ func TestAPIOnlyEndpointCheck(t *testing.T) {
 		_, err := newEndpoint(next)(ctx, nil)
 		require.Error(t, err)
 		require.False(t, *called)
-		var permErr *fleet.PermissionError
-		require.ErrorAs(t, err, &permErr)
+		requireEndpointRestrictionDenied(t, err)
 	})
 
 	t.Run("api-only user, method normalization is case-insensitive", func(t *testing.T) {
@@ -255,8 +267,7 @@ func TestAPIOnlyEndpointCheck(t *testing.T) {
 		require.Error(t, err)
 		require.False(t, *called)
 
-		var permErr *fleet.PermissionError
-		require.ErrorAs(t, err, &permErr)
+		requireEndpointRestrictionDenied(t, err)
 	})
 
 	t.Run("api-only user, allow-list entry for non-catalog endpoint is still denied", func(t *testing.T) {
@@ -274,8 +285,7 @@ func TestAPIOnlyEndpointCheck(t *testing.T) {
 		_, err := newEndpoint(next)(ctx, nil)
 		require.Error(t, err)
 		require.False(t, *called)
-		var permErr *fleet.PermissionError
-		require.ErrorAs(t, err, &permErr)
+		requireEndpointRestrictionDenied(t, err)
 	})
 
 	t.Run("api-only user, wrong method for catalog endpoint is rejected at catalog step", func(t *testing.T) {
@@ -292,8 +302,7 @@ func TestAPIOnlyEndpointCheck(t *testing.T) {
 		_, err := newEndpoint(next)(ctx, nil)
 		require.Error(t, err)
 		require.False(t, *called)
-		var permErr *fleet.PermissionError
-		require.ErrorAs(t, err, &permErr)
+		requireEndpointRestrictionDenied(t, err)
 	})
 
 	t.Run("api-only user with restrictions, chart endpoint not in allow-list is rejected", func(t *testing.T) {
@@ -312,8 +321,51 @@ func TestAPIOnlyEndpointCheck(t *testing.T) {
 		_, err := newEndpoint(next)(ctx, nil)
 		require.Error(t, err)
 		require.False(t, *called)
-		var permErr *fleet.PermissionError
-		require.ErrorAs(t, err, &permErr)
+		requireEndpointRestrictionDenied(t, err)
+	})
+
+	t.Run("denial surfaces route and reason on the request log line at info level", func(t *testing.T) {
+		cases := []struct {
+			name       string
+			routeTpl   string
+			wantReason string
+		}{
+			{
+				name:       "endpoint not in catalog",
+				routeTpl:   muxTemplate("fleet/secret_admin_endpoint"),
+				wantReason: "endpoint not in API endpoint catalog",
+			},
+			{
+				name:       "endpoint not in allow-list",
+				routeTpl:   muxTemplate("fleet/scripts/run"),
+				wantReason: "endpoint not in user's allowed API endpoints",
+			},
+		}
+		for _, c := range cases {
+			t.Run(c.name, func(t *testing.T) {
+				next, called := newNext()
+				lc := &logging.LoggingContext{}
+				ctx := logging.NewContext(context.Background(), lc)
+				ctx = context.WithValue(ctx, kithttp.ContextKeyRequestMethod, "POST")
+				ctx = eu.WithRouteTemplate(ctx, c.routeTpl)
+				ctx = viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{
+					APIOnly:      true,
+					APIEndpoints: []fleet.APIEndpointRef{{Method: "GET", Path: "/api/v1/fleet/hosts"}},
+				}})
+
+				_, err := newEndpoint(next)(ctx, nil)
+				requireEndpointRestrictionDenied(t, err)
+				require.False(t, *called)
+
+				require.NotNil(t, lc.ForceLevel)
+				require.Equal(t, slog.LevelInfo, *lc.ForceLevel)
+				require.Equal(t, []any{
+					"denied_by", "api_only_endpoint_restriction",
+					"denial_reason", c.wantReason,
+					"route", c.routeTpl,
+				}, lc.Extras)
+			})
+		}
 	})
 
 	t.Run("api-only user with multiple allowed endpoints, accessing one of them", func(t *testing.T) {

--- a/server/service/middleware/auth/api_only_test.go
+++ b/server/service/middleware/auth/api_only_test.go
@@ -340,6 +340,11 @@ func TestAPIOnlyEndpointCheck(t *testing.T) {
 				routeTpl:   muxTemplate("fleet/scripts/run"),
 				wantReason: "endpoint not in user's allowed API endpoints",
 			},
+			{
+				name:       "route template missing from context",
+				routeTpl:   "", // RouteTemplateRequestFunc not wired
+				wantReason: "request method or route template missing from request context",
+			},
 		}
 		for _, c := range cases {
 			t.Run(c.name, func(t *testing.T) {
@@ -347,7 +352,9 @@ func TestAPIOnlyEndpointCheck(t *testing.T) {
 				lc := &logging.LoggingContext{}
 				ctx := logging.NewContext(t.Context(), lc)
 				ctx = context.WithValue(ctx, kithttp.ContextKeyRequestMethod, "POST")
-				ctx = eu.WithRouteTemplate(ctx, c.routeTpl)
+				if c.routeTpl != "" {
+					ctx = eu.WithRouteTemplate(ctx, c.routeTpl)
+				}
 				ctx = viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{
 					APIOnly:      true,
 					APIEndpoints: []fleet.APIEndpointRef{{Method: "GET", Path: "/api/v1/fleet/hosts"}},
@@ -383,6 +390,21 @@ func TestAPIOnlyEndpointCheck(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, *called)
 	})
+}
+
+// TestEndpointRestrictionDeniedEncoding pins the HTTP response an
+// endpoint-restriction denial encodes to: 403 with the distinct message in the
+// body. This guards the UserMessageError wrapping — a bare PermissionError's
+// message is discarded by the encoder and rendered as a generic "Permission
+// Denied" body.
+func TestEndpointRestrictionDeniedEncoding(t *testing.T) {
+	err := endpointRestrictionDenied(t.Context(), muxTemplate("fleet/hosts"), "endpoint not in user's allowed API endpoints")
+
+	rec := httptest.NewRecorder()
+	eu.EncodeError(t.Context(), err, rec, nil)
+
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	require.Contains(t, rec.Body.String(), EndpointRestrictionDeniedMessage)
 }
 
 func TestRouteTemplateRequestFunc(t *testing.T) {

--- a/server/service/middleware/auth/api_only_test.go
+++ b/server/service/middleware/auth/api_only_test.go
@@ -345,7 +345,7 @@ func TestAPIOnlyEndpointCheck(t *testing.T) {
 			t.Run(c.name, func(t *testing.T) {
 				next, called := newNext()
 				lc := &logging.LoggingContext{}
-				ctx := logging.NewContext(context.Background(), lc)
+				ctx := logging.NewContext(t.Context(), lc)
 				ctx = context.WithValue(ctx, kithttp.ContextKeyRequestMethod, "POST")
 				ctx = eu.WithRouteTemplate(ctx, c.routeTpl)
 				ctx = viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{


### PR DESCRIPTION
**Related issue:** Resolves #50813

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually

## Details

`apiOnlyEndpointCheck` returned the same generic `fleet.NewPermissionError("forbidden")` for both endpoint-restriction failure modes, making these 403s indistinguishable from role-based permission denials in both the response body and server logs.

This PR makes endpoint-restriction denials identifiable in two places:

**403 response body.** The denial now returns a `UserMessageError` wrapping the permission error, so the message survives encoding (the error encoder discards `PermissionError` messages and renders a generic "Permission Denied" body):

```json
{
  "message": "Forbidden",
  "errors": [
    { "name": "base", "reason": "endpoint not permitted for this API-only user" }
  ],
  "uuid": "..."
}
```

Role-based denials are unchanged (`"forbidden"`). The restriction list is not secret from the caller (they already hold a valid token), so naming the gate discloses nothing.

**Server logs.** The denial is surfaced on the request log line at info level (role-based 403s log at debug, which is how these went unnoticed) with a denial marker, the reason, and the matched route template. User email and request method were already on the line:

```
level=INFO user=slackbot@example.com method=GET uri=/api/latest/fleet/labels/foo denied_by=api_only_endpoint_restriction denial_reason="endpoint not in user's allowed API endpoints" route=/api/{fleetversion:(?:v1|2022-04|latest)}/fleet/labels/{name} err="endpoint not permitted for this API-only user"
```

The two failure modes (route not in the API endpoint catalog vs. route not on the user's allowlist) get distinct `denial_reason` values in the log; the response body message is the same for both.

Verified the encoded response by running the error through the real `endpointer.EncodeError` path. Existing integration tests assert only the 403 status, which is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - API-only endpoint restriction denials now return a distinct 403 message.
  - Catalog, allowlist, and other restriction denials are clearly differentiated.
  - Denials are logged at info level with the affected route and reason, improving visibility into access decisions.
  - Enterprise responses now consistently include the restriction-specific error message.
- **Documentation**
  - Added a changelog entry describing the updated 403 response and logging behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->