### PR TITLE
Stop guessing Windows FMA open-query process names for multi-word titles

### DIFF
--- a/changes/windows-open-query-drop-multiword-guess
+++ b/changes/windows-open-query-drop-multiword-guess
@@ -1,0 +1,1 @@
+- Fixed Fleet-maintained apps on Windows generating an "app open" pre-install check that could never match: multi-word app names without a known process name (e.g. "Mozilla Firefox", "Microsoft Visual C++ 2015-2022 Redistributable (x64)") no longer produce a guessed `<name>.exe` process check. Apps with a curated process-name mapping keep their check.

--- a/ee/maintained-apps/maintained_apps.go
+++ b/ee/maintained-apps/maintained_apps.go
@@ -19,7 +19,7 @@ const OutputPath = "ee/maintained-apps/outputs"
 type FMAQueries struct {
 	Exists  string `json:"exists"`
 	Patched string `json:"patched"`
-	Open    string `json:"open"`
+	Open    string `json:"open,omitempty"`
 }
 
 type FMAManifestApp struct {

--- a/pkg/patch_policy/patch_policy.go
+++ b/pkg/patch_policy/patch_policy.go
@@ -179,6 +179,17 @@ func defaultWindowsOpenQuery(softwareTitle string) string {
 		return fmt.Sprintf(windowsOpenQueryPrefix, query)
 	}
 
+	// Multi-word catalog names ("Mozilla Firefox", "XnSoft XnConvert", "Microsoft
+	// Visual C++ 2015-2022 Redistributable (x64)") almost never equal the process
+	// image name — vendor prefixes, editions, and version suffixes produce a query
+	// that can never match, which silently defeats the app-open gate. Runtime,
+	// driver, and redistributable packages have no user-facing process at all.
+	// Emit no open query rather than a wrong one; add a windowsOpenQueryOverrides
+	// entry when the real binary name is known.
+	if strings.Contains(softwareTitle, " ") {
+		return ""
+	}
+
 	// Match a process named "<title>.exe"
 	// alternatives considered:
 	// - join programs.install_location with processes.path - install_location is unreliable (especially for MSI installers)

--- a/pkg/patch_policy/patch_policy_test.go
+++ b/pkg/patch_policy/patch_policy_test.go
@@ -99,6 +99,12 @@ func TestGenerateOpenQuery(t *testing.T) {
 	got = patch_policy.GenerateOpenQuery("windows", "", "Microsoft Teams")
 	require.Equal(t, "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) IN ('teams.exe','ms-teams.exe'));", got)
 
+	// A multi-word title without an override yields no query: the derived
+	// "<title>.exe" ("xnsoft xnconvert.exe") would never match a real process,
+	// silently defeating the app-open gate.
+	require.Empty(t, patch_policy.GenerateOpenQuery("windows", "", "XnSoft XnConvert"))
+	require.Empty(t, patch_policy.GenerateOpenQuery("windows", "", "Microsoft Visual C++ 2015-2022 Redistributable (x64)"))
+
 	// Unknown platform yields no query.
 	require.Empty(t, patch_policy.GenerateOpenQuery("linux", "com.example.foo", ""))
 }


### PR DESCRIPTION
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually

## Details

The generated Windows "app open" pre-install query (`FMAQueries.Open`) falls back to guessing the process name as `<lowercased catalog name>.exe` when the app has no entry in `windowsOpenQueryOverrides` (`pkg/patch_policy/patch_policy.go`). For multi-word catalog names the guess is essentially never the real process image name — vendor prefixes, editions, and version suffixes produce queries like `'mozilla firefox.exe'`, `'vlc media player.exe'`, `'sql server management studio.exe'`, or `'microsoft visual c++ 2015-2022 redistributable (x64).exe'`. Runtime/driver/redistributable packages (JDKs, .NET runtimes, ODBC drivers, VC++ redists) have no user-facing process at all.

A never-matching open query silently defeats the `patch_when_closed` gate: osquery always reports "not open," so Fleet will patch the app while it's running — while the UI shows a plausible-looking read-only pre-install query.

This PR stops the guessing for multi-word names: if the title contains a space and has no curated override, no open query is emitted (`open` is now `omitempty` in the output manifests). An absent open query means "no gate," which is the same behavior these apps effectively had, minus the false pretense. Single-word fallbacks (e.g. `slack.exe`) and all 51 curated overrides are unchanged. macOS is unaffected (it resolves the app path via bundle identifier instead of guessing names).

**Scope of impact on `main` today: 183 of 434 Windows FMAs** carry (or would next be generated with) a never-matching guessed open query. Full list below.

Outputs are not regenerated in this PR to avoid conflicting with #50811; the daily ingest run rewrites every unfrozen output, so the bogus queries drop out automatically on the next `Update Fleet-maintained apps` PR after this merges. Frozen apps keep their current output until unfrozen (benign — the query never matches).

**Follow-up (not in this PR):** add curated `windowsOpenQueryOverrides` entries for high-value multi-word apps so the gate actually works for them, e.g. Mozilla Firefox → `firefox.exe`, VLC media player → `vlc.exe`, SQL Server Management Studio → `ssms.exe`, MySQL Workbench → `mysqlworkbench.exe`, Power BI → `pbidesktop.exe`, Visual Studio 2022 → `devenv.exe`, GitHub Desktop → `githubdesktop.exe`, Docker Desktop → `'docker desktop.exe'`.

<details>
<summary>All 183 affected apps (name → guessed process that never matches)</summary>

- `010-editor/windows` — 010 Editor (guessed `010 editor.exe`)
- `3df-zephyr-free/windows` — 3DF Zephyr Free (guessed `3df zephyr free.exe`)
- `4k-video-downloader-plus/windows` — 4K Video Downloader+ (guessed `4k video downloader+.exe`)
- `8x8-work/windows` — 8x8 Work (guessed `8x8 work.exe`)
- `aomei-backupper-standard/windows` — AOMEI Backupper Standard (guessed `aomei backupper standard.exe`)
- `avs-image-converter/windows` — AVS Image Converter (guessed `avs image converter.exe`)
- `avs-media-player/windows` — AVS Media Player (guessed `avs media player.exe`)
- `aws-vpn-client/windows` — AWS Client VPN (guessed `aws client vpn.exe`)
- `aws-cli/windows` — AWS Command Line Interface v2 (guessed `aws command line interface v2.exe`)
- `aws-sam-cli/windows` — AWS SAM Command Line Interface (guessed `aws sam command line interface.exe`)
- `aws-session-manager-plugin/windows` — AWS Session Manager Plugin (guessed `aws session manager plugin.exe`)
- `adobe-acrobat-pro/windows` — Adobe Acrobat Pro (guessed `adobe acrobat pro.exe`)
- `adobe-acrobat-reader/windows` — Adobe Acrobat Reader (guessed `adobe acrobat reader.exe`)
- `adobe-creative-cloud/windows` — Adobe Creative Cloud (guessed `adobe creative cloud.exe`)
- `advanced-installer/windows` — Advanced Installer (guessed `advanced installer.exe`)
- `agent-ransack/windows` — Agent Ransack (guessed `agent ransack.exe`)
- `air-explorer/windows` — Air Explorer (guessed `air explorer.exe`)
- `allway-sync/windows` — Allway Sync (guessed `allway sync.exe`)
- `amazon-corretto-11/windows` — Amazon Corretto 11 (guessed `amazon corretto 11.exe`)
- `amazon-corretto-17/windows` — Amazon Corretto 17 (guessed `amazon corretto 17.exe`)
- `amazon-corretto-21/windows` — Amazon Corretto 21 (guessed `amazon corretto 21.exe`)
- `amazon-corretto-24/windows` — Amazon Corretto 24 (guessed `amazon corretto 24.exe`)
- `amazon-corretto-25/windows` — Amazon Corretto 25 (guessed `amazon corretto 25.exe`)
- `amazon-corretto-26/windows` — Amazon Corretto 26 (guessed `amazon corretto 26.exe`)
- `amazon-corretto-8/windows` — Amazon Corretto 8 (guessed `amazon corretto 8.exe`)
- `amazon-corretto-jre-8/windows` — Amazon Corretto JRE 8 (guessed `amazon corretto jre 8.exe`)
- `amazon-dcv-client/windows` — Amazon DCV Client (guessed `amazon dcv client.exe`)
- `amazon-dcv-server/windows` — Amazon DCV Server (guessed `amazon dcv server.exe`)
- `amazon-redshift-odbc-driver/windows` — Amazon Redshift ODBC Driver (guessed `amazon redshift odbc driver.exe`)
- `amazon-workspaces/windows` — Amazon WorkSpaces (guessed `amazon workspaces.exe`)
- `another-redis-desktop-manager/windows` — Another Redis Desktop Manager (guessed `another redis desktop manager.exe`)
- `arduino-ide/windows` — Arduino IDE (guessed `arduino ide.exe`)
- `azul-zulu-25-jdk/windows` — Azul Zulu JDK 25 (guessed `azul zulu jdk 25.exe`)
- `azul-zulu-25-jre/windows` — Azul Zulu JRE 25 (guessed `azul zulu jre 25.exe`)
- `azure-data-studio/windows` — Azure Data Studio (guessed `azure data studio.exe`)
- `azure-functions-core-tools/windows` — Azure Functions Core Tools (guessed `azure functions core tools.exe`)
- `beekeeper-studio/windows` — Beekeeper Studio (guessed `beekeeper studio.exe`)
- `bitwig-studio/windows` — Bitwig Studio (guessed `bitwig studio.exe`)
- `box-drive/windows` — Box Drive (guessed `box drive.exe`)
- `box-tools/windows` — Box Tools (guessed `box tools.exe`)
- `bulk-crap-uninstaller/windows` — Bulk Crap Uninstaller (guessed `bulk crap uninstaller.exe`)
- `burp-suite-community/windows` — Burp Suite Community Edition (guessed `burp suite community edition.exe`)
- `burp-suite-professional/windows` — Burp Suite Professional (guessed `burp suite professional.exe`)
- `certify-the-web/windows` — Certify The Web (guessed `certify the web.exe`)
- `chef-workstation/windows` — Chef Workstation (guessed `chef workstation.exe`)
- `cherry-keys/windows` — Cherry Keys (guessed `cherry keys.exe`)
- `chrome-remote-desktop/windows` — Chrome Remote Desktop (guessed `chrome remote desktop.exe`)
- `cinc/windows` — Cinc Workstation (guessed `cinc workstation.exe`)
- `cisco-jabber/windows` — Cisco Jabber (guessed `cisco jabber.exe`)
- `cisco-webex-recorder-and-player/windows` — Cisco Webex Recorder and Player (guessed `cisco webex recorder and player.exe`)
- `clockify/windows` — Clockify Desktop (guessed `clockify desktop.exe`)
- `cloudflare-warp/windows` — Cloudflare One (guessed `cloudflare one.exe`)
- `codemeter-runtime-kit/windows` — CodeMeter Runtime Kit (guessed `codemeter runtime kit.exe`)
- `colour-contrast-analyser/windows` — Colour Contrast Analyser (guessed `colour contrast analyser.exe`)
- `creative-force-kelvin/windows` — Creative Force Kelvin (guessed `creative force kelvin.exe`)
- `creative-force-triad/windows` — Creative Force Triad (guessed `creative force triad.exe`)
- `crestron-airmedia/windows` — Crestron AirMedia (guessed `crestron airmedia.exe`)
- `crestron-airmedia-peripherals/windows` — Crestron AirMedia Peripherals (guessed `crestron airmedia peripherals.exe`)
- `cribl-edge/windows` — Cribl Edge (guessed `cribl edge.exe`)
- `cube-browser/windows` — Cube Browser (guessed `cube browser.exe`)
- `cyberduck-cli/windows` — Cyberduck CLI (guessed `cyberduck cli.exe`)
- `db-browser-for-sqlite/windows` — DB Browser for SQLite (guessed `db browser for sqlite.exe`)
- `dymo-id/windows` — DYMO ID (guessed `dymo id.exe`)
- `delinea-connection-manager/windows` — Delinea Connection Manager (guessed `delinea connection manager.exe`)
- `dell-display-and-peripheral-manager/windows` — Dell Display and Peripheral Manager (guessed `dell display and peripheral manager.exe`)
- `devolutions-launcher/windows` — Devolutions Launcher (guessed `devolutions launcher.exe`)
- `devolutions-workspace/windows` — Devolutions Workspace (guessed `devolutions workspace.exe`)
- `directory-opus/windows` — Directory Opus (guessed `directory opus.exe`)
- `docker/windows` — Docker Desktop (guessed `docker desktop.exe`)
- `draftable-desktop/windows` — Draftable Desktop (guessed `draftable desktop.exe`)
- `druva-insync/windows` — Druva inSync (guessed `druva insync.exe`)
- `duo-desktop/windows` — Duo Desktop (guessed `duo desktop.exe`)
- `eclipse-temurin-jdk-11/windows` — Eclipse Temurin JDK 11 (guessed `eclipse temurin jdk 11.exe`)
- `eclipse-temurin-jdk-17/windows` — Eclipse Temurin JDK 17 (guessed `eclipse temurin jdk 17.exe`)
- `eclipse-temurin-jdk-21/windows` — Eclipse Temurin JDK 21 (guessed `eclipse temurin jdk 21.exe`)
- `eclipse-temurin-jdk-8/windows` — Eclipse Temurin JDK 8 (guessed `eclipse temurin jdk 8.exe`)
- `eclipse-temurin-jre-11/windows` — Eclipse Temurin JRE 11 (guessed `eclipse temurin jre 11.exe`)
- `eclipse-temurin-jre-17/windows` — Eclipse Temurin JRE 17 (guessed `eclipse temurin jre 17.exe`)
- `eclipse-temurin-jre-21/windows` — Eclipse Temurin JRE 21 (guessed `eclipse temurin jre 21.exe`)
- `eclipse-temurin-jre-8/windows` — Eclipse Temurin JRE 8 (guessed `eclipse temurin jre 8.exe`)
- `egnyte-webedit/windows` — Egnyte WebEdit (guessed `egnyte webedit.exe`)
- `elevate-uc/windows` — Elevate UC (guessed `elevate uc.exe`)
- `elgato-control-center/windows` — Elgato Control Center (guessed `elgato control center.exe`)
- `elgato-stream-deck/windows` — Elgato Stream Deck (guessed `elgato stream deck.exe`)
- `epic-games/windows` — Epic Games Launcher (guessed `epic games launcher.exe`)
- `flexwhere/windows` — FlexWhere for Desktop (guessed `flexwhere for desktop.exe`)
- `foxit-pdf-editor/windows` — Foxit PDF Editor (guessed `foxit pdf editor.exe`)
- `foxit-pdf-reader/windows` — Foxit PDF Reader (guessed `foxit pdf reader.exe`)
- `gnupg/windows` — GNU Privacy Guard (guessed `gnu privacy guard.exe`)
- `gog-galaxy/windows` — GOG Galaxy (guessed `gog galaxy.exe`)
- `galaxy-modeler/windows` — Galaxy Modeler (guessed `galaxy modeler.exe`)
- `garmin-basecamp/windows` — Garmin BaseCamp (guessed `garmin basecamp.exe`)
- `genesys-cloud/windows` — Genesys Cloud (guessed `genesys cloud.exe`)
- `geogebra-classic/windows` — GeoGebra Classic (guessed `geogebra classic.exe`)
- `git-extensions/windows` — Git Extensions (guessed `git extensions.exe`)
- `github-desktop/windows` — GitHub Desktop (guessed `github desktop.exe`)
- `goanywhere-openpgp-studio/windows` — GoAnywhere OpenPGP Studio (guessed `goanywhere openpgp studio.exe`)
- `google-ads-editor/windows` — Google Ads Editor (guessed `google ads editor.exe`)
- `google-credential-provider-for-windows/windows` — Google Credential Provider for Windows (guessed `google credential provider for windows.exe`)
- `google-drive/windows` — Google Drive (guessed `google drive.exe`)
- `google-earth-pro/windows` — Google Earth Pro (guessed `google earth pro.exe`)
- `google-web-designer/windows` — Google Web Designer (guessed `google web designer.exe`)
- `groove-omnidialer/windows` — Groove OmniDialer (guessed `groove omnidialer.exe`)
- `hp-prime-virtual-calculator/windows` — HP Prime Virtual Calculator (guessed `hp prime virtual calculator.exe`)
- `ibm-semeru-jdk-11/windows` — IBM Semeru Runtime Open Edition JDK 11 (guessed `ibm semeru runtime open edition jdk 11.exe`)
- `ibm-semeru-jdk-17/windows` — IBM Semeru Runtime Open Edition JDK 17 (guessed `ibm semeru runtime open edition jdk 17.exe`)
- `ibm-semeru-jdk-21/windows` — IBM Semeru Runtime Open Edition JDK 21 (guessed `ibm semeru runtime open edition jdk 21.exe`)
- `ibm-semeru-jdk-8/windows` — IBM Semeru Runtime Open Edition JDK 8 (guessed `ibm semeru runtime open edition jdk 8.exe`)
- `ibm-semeru-jre-11/windows` — IBM Semeru Runtime Open Edition JRE 11 (guessed `ibm semeru runtime open edition jre 11.exe`)
- `ibm-semeru-jre-17/windows` — IBM Semeru Runtime Open Edition JRE 17 (guessed `ibm semeru runtime open edition jre 17.exe`)
- `ibm-semeru-jre-21/windows` — IBM Semeru Runtime Open Edition JRE 21 (guessed `ibm semeru runtime open edition jre 21.exe`)
- `ibm-semeru-jre-8/windows` — IBM Semeru Runtime Open Edition JRE 8 (guessed `ibm semeru runtime open edition jre 8.exe`)
- `infix-pdf-editor/windows` — Infix PDF Editor (guessed `infix pdf editor.exe`)
- `ironpython/windows` — IronPython 3 (guessed `ironpython 3.exe`)
- `jabra-direct/windows` — Jabra Direct (guessed `jabra direct.exe`)
- `lenovo-system-update/windows` — Lenovo System Update (guessed `lenovo system update.exe`)
- `logi-options+/windows` — Logi Options+ (guessed `logi options+.exe`)
- `logitech-unifying-software/windows` — Logitech Unifying Software (guessed `logitech unifying software.exe`)
- `microsoft-dotnet-desktop-runtime-10/windows` — Microsoft .NET Desktop Runtime 10 (guessed `microsoft .net desktop runtime 10.exe`)
- `microsoft-dotnet-runtime-10/windows` — Microsoft .NET Runtime 10 (guessed `microsoft .net runtime 10.exe`)
- `microsoft-dotnet-runtime-8/windows` — Microsoft .NET Runtime 8 (guessed `microsoft .net runtime 8.exe`)
- `microsoft-access-database-engine-2016/windows` — Microsoft Access Database Engine 2016 Redistributable (guessed `microsoft access database engine 2016 redistributable.exe`)
- `microsoft-odbc-driver-17/windows` — Microsoft ODBC Driver 17 for SQL Server (guessed `microsoft odbc driver 17 for sql server.exe`)
- `microsoft-odbc-driver-18/windows` — Microsoft ODBC Driver 18 for SQL Server (guessed `microsoft odbc driver 18 for sql server.exe`)
- `microsoft-office/windows` — Microsoft Office (guessed `microsoft office.exe`)
- `vc-redist-2013-x64/windows` — Microsoft Visual C++ 2013 Redistributable (x64) (guessed `microsoft visual c++ 2013 redistributable (x64).exe`)
- `vc-redist-x64/windows` — Microsoft Visual C++ 2015-2022 Redistributable (x64) (guessed `microsoft visual c++ 2015-2022 redistributable (x64).exe`)
- `mongodb-compass/windows` — MongoDB Compass (guessed `mongodb compass.exe`)
- `firefox/windows` — Mozilla Firefox (guessed `mozilla firefox.exe`)
- `firefox@developer-edition/windows` — Mozilla Firefox Developer Edition (guessed `mozilla firefox developer edition.exe`)
- `firefox@esr/windows` — Mozilla Firefox ESR (guessed `mozilla firefox esr.exe`)
- `firefox@nightly/windows` — Mozilla Firefox Nightly (guessed `mozilla firefox nightly.exe`)
- `mozilla-vpn/windows` — Mozilla VPN (guessed `mozilla vpn.exe`)
- `mullvad-browser/windows` — Mullvad Browser (guessed `mullvad browser.exe`)
- `mysqlworkbench/windows` — MySQL Workbench (guessed `mysql workbench.exe`)
- `nessus-agent/windows` — Nessus Agent (guessed `nessus agent.exe`)
- `nosql-workbench/windows` — NoSQL Workbench (guessed `nosql workbench.exe`)
- `omnissa-horizon-client/windows` — Omnissa Horizon Client (guessed `omnissa horizon client.exe`)
- `openvpn-connect/windows` — OpenVPN Connect (guessed `openvpn connect.exe`)
- `pdfsam-basic/windows` — PDFsam Basic (guessed `pdfsam basic.exe`)
- `podman-desktop/windows` — Podman Desktop (guessed `podman desktop.exe`)
- `postgresql-15/windows` — PostgreSQL 15 (guessed `postgresql 15.exe`)
- `postgresql-16/windows` — PostgreSQL 16 (guessed `postgresql 16.exe`)
- `postgresql-17/windows` — PostgreSQL 17 (guessed `postgresql 17.exe`)
- `postgresql-18/windows` — PostgreSQL 18 (guessed `postgresql 18.exe`)
- `power-bi/windows` — Power BI (guessed `power bi.exe`)
- `prisma-browser/windows` — Prisma Browser (guessed `prisma browser.exe`)
- `proton-drive/windows` — Proton Drive (guessed `proton drive.exe`)
- `python-3.13/windows` — Python 3.13 (guessed `python 3.13.exe`)
- `python-3.14/windows` — Python 3.14 (guessed `python 3.14.exe`)
- `r/windows` — R for Windows (guessed `r for windows.exe`)
- `rancher/windows` — Rancher Desktop (guessed `rancher desktop.exe`)
- `vnc-viewer/windows` — RealVNC Connect Viewer (guessed `realvnc connect viewer.exe`)
- `remote-desktop-manager/windows` — Remote Desktop Manager (guessed `remote desktop manager.exe`)
- `royal-tsx/windows` — Royal TSX (guessed `royal tsx.exe`)
- `sql-server-management-studio/windows` — SQL Server Management Studio (guessed `sql server management studio.exe`)
- `safe-exam-browser/windows` — Safe Exam Browser (guessed `safe exam browser.exe`)
- `sonicwall-netextender/windows` — SonicWall NetExtender (guessed `sonicwall netextender.exe`)
- `standard-notes/windows` — Standard Notes (guessed `standard notes.exe`)
- `tableau-desktop/windows` — Tableau Desktop (guessed `tableau desktop.exe`)
- `teamviewer-host/windows` — TeamViewer Host (guessed `teamviewer host.exe`)
- `teleport-connect/windows` — Teleport Connect (guessed `teleport connect.exe`)
- `thorium/windows` — Thorium Reader (guessed `thorium reader.exe`)
- `topaz-gigapixel-ai/windows` — Topaz Gigapixel AI (guessed `topaz gigapixel ai.exe`)
- `topaz-photo-ai/windows` — Topaz Photo AI (guessed `topaz photo ai.exe`)
- `ultimaker-cura/windows` — UltiMaker Cura (guessed `ultimaker cura.exe`)
- `vlc/windows` — VLC media player (guessed `vlc media player.exe`)
- `vnc-server/windows` — VNC Server (guessed `vnc server.exe`)
- `vernier-spectral-analysis/windows` — Vernier Spectral Analysis (guessed `vernier spectral analysis.exe`)
- `visual-studio-2022-community/windows` — Visual Studio Community 2022 (guessed `visual studio community 2022.exe`)
- `visual-studio-2022-enterprise/windows` — Visual Studio Enterprise 2022 (guessed `visual studio enterprise 2022.exe`)
- `visual-studio-2022-professional/windows` — Visual Studio Professional 2022 (guessed `visual studio professional 2022.exe`)
- `wave/windows` — Wave Terminal (guessed `wave terminal.exe`)
- `xnconvert/windows` — XnSoft XnConvert (guessed `xnsoft xnconvert.exe`)
- `yubico-authenticator/windows` — Yubico Authenticator (guessed `yubico authenticator.exe`)
- `yubico-yubikey-manager/windows` — Yubikey Manager (guessed `yubikey manager.exe`)
- `zen-browser/windows` — Zen Browser (guessed `zen browser.exe`)
- `zoom-outlook-plugin/windows` — Zoom Outlook Plugin (guessed `zoom outlook plugin.exe`)
- `zoom-rooms/windows` — Zoom Rooms (guessed `zoom rooms.exe`)
- `digiseal-reader/windows` — digiSeal Reader (guessed `digiseal reader.exe`)
- `emclient/windows` — eM Client (guessed `em client.exe`)
- `imazing-heic-converter/windows` — iMazing HEIC Converter (guessed `imazing heic converter.exe`)
- `imazing-profile-editor/windows` — iMazing Profile Editor (guessed `imazing profile editor.exe`)

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows application detection for multi-word app names.
  - Prevented invalid executable checks when no known process mapping exists.
  - Preserved process checks for applications with explicit mappings.
  - Omitted empty application query values from serialized results.

- **Tests**
  - Added coverage for multi-word Windows application names without process mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->