### PR TITLE
Fix label_updated_at reset

### DIFF
--- a/changes/fix-apple-mdm-reset-label-updated-at
+++ b/changes/fix-apple-mdm-reset-label-updated-at
@@ -1,0 +1,1 @@
+- Fixed a bug where hosts that re-enrolled via DEP would sometimes have profiles with exclude-any labels attached installed before they had actually reported label results 

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -8097,6 +8097,14 @@ func (ds *Datastore) MDMAppleResetOnReenrollment(ctx context.Context, hostUUID s
 			return ctxerr.Wrap(ctx, err, "restore builtin label memberships for mdm reset", "host_uuid", hostUUID)
 		}
 
+		// Reset label_updated_at to the "never" sentinel (2000-01-01 UTC) so the
+		// exclude-any dynamic-label guard treats the cleared memberships as
+		// not-yet-reported instead of trusting them until the next label report.
+		if _, err := tx.ExecContext(ctx, `UPDATE hosts SET label_updated_at = ? WHERE id = ?`,
+			common_mysql.GetDefaultNonZeroTime(), host.ID); err != nil {
+			return ctxerr.Wrap(ctx, err, "reset label_updated_at for mdm reset", "host_uuid", hostUUID)
+		}
+
 		// Clear the PSSO registration (keys cascade) so an ADE re-enrollment
 		// starts from fresh device keys.
 		if _, err := tx.ExecContext(ctx, "DELETE FROM mdm_apple_psso_devices WHERE host_uuid = ?", hostUUID); err != nil {

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -6004,6 +6004,13 @@ func testMDMAppleResetOnReenrollment(t *testing.T, ds *Datastore) {
 		}
 		return names
 	}
+	labelUpdatedAt := func(t *testing.T, h *fleet.Host) time.Time {
+		var ts time.Time
+		require.NoError(t, sqlx.GetContext(ctx, ds.writer(ctx), &ts,
+			`SELECT label_updated_at FROM hosts WHERE id = ?`, h.ID))
+		return ts
+	}
+	neverSentinel := common_mysql.GetDefaultNonZeroTime()
 	seeded := counts{label: 3, upcoming: 1, pssoDevice: 1, pssoKey: 1}
 
 	t.Run("clears expected tables and leaves other hosts untouched", func(t *testing.T) {
@@ -6012,19 +6019,26 @@ func testMDMAppleResetOnReenrollment(t *testing.T, ds *Datastore) {
 		seedHostData(t, hostA)
 		seedHostData(t, hostB)
 
-		// sanity: both hosts start fully seeded
+		// sanity: both hosts start fully seeded, with label_updated_at set by
+		// NewHost to a real (non-sentinel) time.
 		require.Equal(t, seeded, countRows(t, hostA))
 		require.Equal(t, seeded, countRows(t, hostB))
+		require.False(t, labelUpdatedAt(t, hostA).Equal(neverSentinel))
+		hostBLabelUpdatedAt := labelUpdatedAt(t, hostB)
+		require.False(t, hostBLabelUpdatedAt.Equal(neverSentinel))
 
 		require.NoError(t, ds.MDMAppleResetOnReenrollment(ctx, hostA.UUID, true))
 
-		// Host A keeps only its built-in memberships.
+		// Host A keeps only its built-in memberships, and its label_updated_at
+		// is reset to the "never" sentinel since its label results are gone.
 		assert.Equal(t, counts{label: 2}, countRows(t, hostA))
 		assert.ElementsMatch(t, []string{fleet.BuiltinLabelNameAllHosts, fleet.BuiltinLabelIPadOS}, labelNames(t, hostA))
+		assert.True(t, labelUpdatedAt(t, hostA).Equal(neverSentinel))
 
-		// Host B is untouched, including its custom membership.
+		// Host B is untouched, including its custom membership and timestamp.
 		assert.Equal(t, seeded, countRows(t, hostB))
 		assert.ElementsMatch(t, []string{fleet.BuiltinLabelNameAllHosts, fleet.BuiltinLabelNameMacOS, "label-" + hostB.UUID}, labelNames(t, hostB))
+		assert.True(t, labelUpdatedAt(t, hostB).Equal(hostBLabelUpdatedAt))
 	})
 
 	t.Run("returns error and changes nothing when host UUID does not exist", func(t *testing.T) {
@@ -6039,6 +6053,7 @@ func testMDMAppleResetOnReenrollment(t *testing.T, ds *Datastore) {
 		// host A's seeded data must still be present - the failed call must
 		// not have any side effects.
 		assert.Equal(t, seeded, countRows(t, hostA))
+		assert.False(t, labelUpdatedAt(t, hostA).Equal(neverSentinel))
 	})
 
 	// seedHostActivityData seeds the rows whose deletion is gated by the

--- a/server/service/integration_mdm_profiles_test.go
+++ b/server/service/integration_mdm_profiles_test.go
@@ -6603,9 +6603,7 @@ func (s *integrationMDMTestSuite) TestHostMDMProfilesExcludeLabels() {
 	appleHost2, _ := createHostThenEnrollMDM(s.ds, s.server.URL, t)
 	// simulate reporting label results for the new host, otherwise exclude-any
 	// profiles are withheld until label membership is known
-	appleHost2.LabelUpdatedAt = time.Now()
-	err = s.ds.UpdateHost(ctx, appleHost2)
-	require.NoError(t, err)
+	require.NoError(t, s.ds.AsyncBatchUpdateLabelTimestamp(ctx, []uint{appleHost2.ID}, time.Now()))
 	s.awaitRunAppleMDMWorkerSchedule()
 	err = s.keyValueStore.Delete(ctx, fleet.MDMProfileProcessingKeyPrefix+":"+appleHost2.UUID)
 	require.NoError(t, err)

--- a/server/service/integration_mdm_profiles_test.go
+++ b/server/service/integration_mdm_profiles_test.go
@@ -6601,6 +6601,11 @@ func (s *integrationMDMTestSuite) TestHostMDMProfilesExcludeLabels() {
 
 	// it also doesn't get installed to a new host not a member of any labels
 	appleHost2, _ := createHostThenEnrollMDM(s.ds, s.server.URL, t)
+	// simulate reporting label results for the new host, otherwise exclude-any
+	// profiles are withheld until label membership is known
+	appleHost2.LabelUpdatedAt = time.Now()
+	err = s.ds.UpdateHost(ctx, appleHost2)
+	require.NoError(t, err)
 	s.awaitRunAppleMDMWorkerSchedule()
 	err = s.keyValueStore.Delete(ctx, fleet.MDMProfileProcessingKeyPrefix+":"+appleHost2.UUID)
 	require.NoError(t, err)


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #50878 

Resets label_updated_at to the "never" sentinel (2000-01-01 UTC) so that the exclude-any dynamic-label guard treats the cleared memberships as not-yet-reported instead of trusting them until the next label report.

Prior to this fix, hosts could see profiles get installed on enrollment, then relatively quickly removed once labels actually got calculated, as opposed to having them withheld until the exclude label query could be ran.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where profiles with exclude-any labels could be installed before label results were available after DEP re-enrollment.
  * Label status now resets correctly during re-enrollment while preserving unaffected hosts’ label information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->