### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/cisco-jabber/darwin.json
+++ b/ee/maintained-apps/outputs/cisco-jabber/darwin.json
@@ -7,10 +7,10 @@
         "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.cisco.jabber' AND version_compare(bundle_short_version, '15.2.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.cisco.jabber');"
       },
-      "installer_url": "https://binaries.webex.com/jabberclientmac/20260122074039/Install_Cisco-Jabber-Mac.pkg",
+      "installer_url": "https://binaries.webex.com/jabberclientmac/20260722023311/Install_Cisco-Jabber-Mac.pkg",
       "install_script_ref": "edbec29c",
       "uninstall_script_ref": "fe0e9261",
-      "sha256": "5644700e420febc1eca304c0a0f24bcff1e64b424112e1beda025d2eb78e16de",
+      "sha256": "bb71f8686049930033710f88698712e6aee6ed469516f3a73e48df8cecda4d61",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/codexbar/darwin.json
+++ b/ee/maintained-apps/outputs/codexbar/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "0.48.1",
+      "version": "0.49.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.steipete.codexbar';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.steipete.codexbar' AND version_compare(bundle_short_version, '0.48.1') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.steipete.codexbar' AND version_compare(bundle_short_version, '0.49.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.steipete.codexbar');"
       },
-      "installer_url": "https://github.com/steipete/CodexBar/releases/download/v0.48.1/CodexBar-macos-universal-0.48.1.zip",
+      "installer_url": "https://github.com/steipete/CodexBar/releases/download/v0.49.0/CodexBar-macos-universal-0.49.0.zip",
       "install_script_ref": "6993c93e",
       "uninstall_script_ref": "efcab822",
-      "sha256": "2a42fd6cd019df64d1f134eb3dcd73f59d9545487680b24273e19ea7b0ae2e72",
+      "sha256": "972b1f300b1265c175e9c6f6c5b7183063217a97f0a5fcc1f5d3ef06a526064f",
       "default_categories": [
         "Utilities"
       ]

--- a/ee/maintained-apps/outputs/firefox@nightly/darwin.json
+++ b/ee/maintained-apps/outputs/firefox@nightly/darwin.json
@@ -4,13 +4,13 @@
       "version": "155.0a1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15526.8.8') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15526.8.9') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'org.mozilla.nightly');"
       },
-      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/08/2026-08-08-21-05-18-mozilla-central/firefox-155.0a1.en-US.mac.dmg",
+      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/08/2026-08-09-09-46-48-mozilla-central/firefox-155.0a1.en-US.mac.dmg",
       "install_script_ref": "d9c4cf87",
       "uninstall_script_ref": "0661f848",
-      "sha256": "3ee30eda588087940837f7687a403a2abc31bc81c076b077ec7a7c370c610892",
+      "sha256": "9773d3d251751cab77a7d6ac689036449a567fb242e1fb60f6eb1972ced19b73",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/firefox@nightly/windows.json
+++ b/ee/maintained-apps/outputs/firefox@nightly/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "155.2607.2809.0",
+      "version": "155.2608.909.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Firefox Nightly' AND publisher = 'Mozilla Corporation';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Firefox Nightly' AND publisher = 'Mozilla Corporation' AND version_compare(version, '155.2607.2809.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Firefox Nightly' AND publisher = 'Mozilla Corporation' AND version_compare(version, '155.2608.909.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'mozilla firefox nightly.exe');"
       },
-      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/07/2026-07-28-09-52-22-mozilla-central/firefox-155.0a1.multi.win64.installer.msix",
+      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/08/2026-08-09-09-46-48-mozilla-central/firefox-155.0a1.multi.win64.installer.msix",
       "install_script_ref": "255e7c51",
       "uninstall_script_ref": "f0d0fed1",
-      "sha256": "af08912825d1b32e06fdb9066f649a4338a7e562e3fe51550955667892405d29",
+      "sha256": "adcfb36c78bc737cecddc19c95fe5c2dc03dc52b0da0d1b935b0770020e596b6",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/glyphs/darwin.json
+++ b/ee/maintained-apps/outputs/glyphs/darwin.json
@@ -7,10 +7,10 @@
         "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.GeorgSeifert.Glyphs3' AND version_compare(bundle_short_version, '3.5') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.GeorgSeifert.Glyphs3');"
       },
-      "installer_url": "https://updates.glyphsapp.com/Glyphs3.5-3530.zip",
+      "installer_url": "https://updates.glyphsapp.com/Glyphs3.5-3531.zip",
       "install_script_ref": "82042f03",
       "uninstall_script_ref": "b1245f10",
-      "sha256": "1f74005b720fbf0b0aa9b0546c0fe1381cbab5f1ad3ef5f48ddeed140872b999",
+      "sha256": "1f8b0de72f1d6c10c5ab93994fcf01db148b2c896fff11e80b379abb77b42c66",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/hive-app/darwin.json
+++ b/ee/maintained-apps/outputs/hive-app/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.2.26",
+      "version": "1.2.27",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app' AND version_compare(bundle_short_version, '1.2.26') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app' AND version_compare(bundle_short_version, '1.2.27') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.hive.app');"
       },
-      "installer_url": "https://github.com/morapelker/hive/releases/download/v1.2.26/Hive-1.2.26-arm64.dmg",
+      "installer_url": "https://github.com/morapelker/hive/releases/download/v1.2.27/Hive-1.2.27-arm64.dmg",
       "install_script_ref": "3bd4ebe4",
       "uninstall_script_ref": "951b5587",
-      "sha256": "768e77feca24426edd2bac1368f4c487ca580c772c978c81f5fec037a576978f",
+      "sha256": "334ceed26873ef8917f890de1511af0da14e9f1442b413f71f1ec8aa4a34425c",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/readest/windows.json
+++ b/ee/maintained-apps/outputs/readest/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "0.11.20",
+      "version": "0.12.1",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Readest' AND publisher = 'bilingify';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Readest' AND publisher = 'bilingify' AND version_compare(version, '0.11.20') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Readest' AND publisher = 'bilingify' AND version_compare(version, '0.12.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'readest.exe');"
       },
-      "installer_url": "https://github.com/readest/readest/releases/download/v0.11.20/Readest_0.11.20_x64-setup.exe",
+      "installer_url": "https://github.com/readest/readest/releases/download/v0.12.1/Readest_0.12.1_x64-setup.exe",
       "install_script_ref": "2b4dd196",
       "uninstall_script_ref": "36b7aeaf",
-      "sha256": "df8c9e2763cc9ec3e453cce6320df442798d115f9127c0c6ba831b800cbdb7dd",
+      "sha256": "f759ab19dcc1be5df734d84fae7c71de9321fe9bf50dfcf35c91015f6b0a1dcc",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated Cisco Jabber 15.2.1 for macOS with refreshed installation details.
  * Updated CodexBar for macOS from 0.48.1 to 0.49.0.
  * Updated Firefox Nightly installers for macOS and Windows.
  * Updated Glyphs 3.5 for macOS to build 3531.
  * Updated Hive for macOS from 1.2.26 to 1.2.27.
  * Updated Readest for Windows from 0.11.20 to 0.12.1.
  * Refreshed installer links and verification data across the updated packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->