### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/cisco-jabber/darwin.json
+++ b/ee/maintained-apps/outputs/cisco-jabber/darwin.json
@@ -7,10 +7,10 @@
         "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.cisco.jabber' AND version_compare(bundle_short_version, '15.2.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.cisco.jabber');"
       },
-      "installer_url": "https://binaries.webex.com/jabberclientmac/20260122074039/Install_Cisco-Jabber-Mac.pkg",
+      "installer_url": "https://binaries.webex.com/jabberclientmac/20260722023311/Install_Cisco-Jabber-Mac.pkg",
       "install_script_ref": "edbec29c",
       "uninstall_script_ref": "fe0e9261",
-      "sha256": "5644700e420febc1eca304c0a0f24bcff1e64b424112e1beda025d2eb78e16de",
+      "sha256": "bb71f8686049930033710f88698712e6aee6ed469516f3a73e48df8cecda4d61",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/codexbar/darwin.json
+++ b/ee/maintained-apps/outputs/codexbar/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "0.48.1",
+      "version": "0.49.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.steipete.codexbar';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.steipete.codexbar' AND version_compare(bundle_short_version, '0.48.1') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.steipete.codexbar' AND version_compare(bundle_short_version, '0.49.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.steipete.codexbar');"
       },
-      "installer_url": "https://github.com/steipete/CodexBar/releases/download/v0.48.1/CodexBar-macos-universal-0.48.1.zip",
+      "installer_url": "https://github.com/steipete/CodexBar/releases/download/v0.49.1/CodexBar-macos-universal-0.49.1.zip",
       "install_script_ref": "6993c93e",
       "uninstall_script_ref": "efcab822",
-      "sha256": "2a42fd6cd019df64d1f134eb3dcd73f59d9545487680b24273e19ea7b0ae2e72",
+      "sha256": "36a23aa7c584b3043b0effb1be2236faccf7b19b755dcbe994e7ac391ad48998",
       "default_categories": [
         "Utilities"
       ]

--- a/ee/maintained-apps/outputs/firefox@nightly/darwin.json
+++ b/ee/maintained-apps/outputs/firefox@nightly/darwin.json
@@ -4,13 +4,13 @@
       "version": "155.0a1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15526.8.8') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15526.8.9') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'org.mozilla.nightly');"
       },
-      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/08/2026-08-08-21-05-18-mozilla-central/firefox-155.0a1.en-US.mac.dmg",
+      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/08/2026-08-09-21-46-38-mozilla-central/firefox-155.0a1.en-US.mac.dmg",
       "install_script_ref": "d9c4cf87",
       "uninstall_script_ref": "0661f848",
-      "sha256": "3ee30eda588087940837f7687a403a2abc31bc81c076b077ec7a7c370c610892",
+      "sha256": "948e5d6d5d1df11598e447a790a5ffdfe4977bc9d0a0207412260f9f46a4f8fa",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/firefox@nightly/windows.json
+++ b/ee/maintained-apps/outputs/firefox@nightly/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "155.2607.2809.0",
+      "version": "155.2608.909.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Firefox Nightly' AND publisher = 'Mozilla Corporation';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Firefox Nightly' AND publisher = 'Mozilla Corporation' AND version_compare(version, '155.2607.2809.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Firefox Nightly' AND publisher = 'Mozilla Corporation' AND version_compare(version, '155.2608.909.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'mozilla firefox nightly.exe');"
       },
-      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/07/2026-07-28-09-52-22-mozilla-central/firefox-155.0a1.multi.win64.installer.msix",
+      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/08/2026-08-09-09-46-48-mozilla-central/firefox-155.0a1.multi.win64.installer.msix",
       "install_script_ref": "255e7c51",
       "uninstall_script_ref": "f0d0fed1",
-      "sha256": "af08912825d1b32e06fdb9066f649a4338a7e562e3fe51550955667892405d29",
+      "sha256": "adcfb36c78bc737cecddc19c95fe5c2dc03dc52b0da0d1b935b0770020e596b6",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/gitify/darwin.json
+++ b/ee/maintained-apps/outputs/gitify/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "7.3.1",
+      "version": "7.3.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.gitify';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.gitify' AND version_compare(bundle_short_version, '7.3.1') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.gitify' AND version_compare(bundle_short_version, '7.3.2') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.electron.gitify');"
       },
-      "installer_url": "https://github.com/gitify-app/gitify/releases/download/v7.3.1/Gitify-7.3.1-universal-mac.zip",
+      "installer_url": "https://github.com/gitify-app/gitify/releases/download/v7.3.2/Gitify-7.3.2-universal-mac.zip",
       "install_script_ref": "335acee0",
       "uninstall_script_ref": "33618979",
-      "sha256": "9719ce89f60003f07ae0bfb30b45c8b1bf83cdb969404b553ec2523561e9a48a",
+      "sha256": "439de9ef5cb615316d70af978268065264122fbe89e94b8fd9f27aa5311d2809",
       "default_categories": [
         "Utilities"
       ]

--- a/ee/maintained-apps/outputs/glyphs/darwin.json
+++ b/ee/maintained-apps/outputs/glyphs/darwin.json
@@ -7,10 +7,10 @@
         "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.GeorgSeifert.Glyphs3' AND version_compare(bundle_short_version, '3.5') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.GeorgSeifert.Glyphs3');"
       },
-      "installer_url": "https://updates.glyphsapp.com/Glyphs3.5-3530.zip",
+      "installer_url": "https://updates.glyphsapp.com/Glyphs3.5-3531.zip",
       "install_script_ref": "82042f03",
       "uninstall_script_ref": "b1245f10",
-      "sha256": "1f74005b720fbf0b0aa9b0546c0fe1381cbab5f1ad3ef5f48ddeed140872b999",
+      "sha256": "1f8b0de72f1d6c10c5ab93994fcf01db148b2c896fff11e80b379abb77b42c66",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/hive-app/darwin.json
+++ b/ee/maintained-apps/outputs/hive-app/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.2.26",
+      "version": "1.2.28",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app' AND version_compare(bundle_short_version, '1.2.26') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app' AND version_compare(bundle_short_version, '1.2.28') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.hive.app');"
       },
-      "installer_url": "https://github.com/morapelker/hive/releases/download/v1.2.26/Hive-1.2.26-arm64.dmg",
+      "installer_url": "https://github.com/morapelker/hive/releases/download/v1.2.28/Hive-1.2.28-arm64.dmg",
       "install_script_ref": "3bd4ebe4",
       "uninstall_script_ref": "951b5587",
-      "sha256": "768e77feca24426edd2bac1368f4c487ca580c772c978c81f5fec037a576978f",
+      "sha256": "28a7895ef90b664ac4eb39a428405f6da91f40c350b0fe6f27cb37ed6bcc76d1",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/melodics/darwin.json
+++ b/ee/maintained-apps/outputs/melodics/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "5.0.993",
+      "version": "5.0.1001",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.melodics.Melodics';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.melodics.Melodics' AND version_compare(bundle_short_version, '5.0.993') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.melodics.Melodics' AND version_compare(bundle_short_version, '5.0.1001') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.melodics.Melodics');"
       },
-      "installer_url": "https://web-cdn.melodics.com/download/65B6631F-18C9-47BE-8140-D8181BED5E26.zip",
+      "installer_url": "https://web-cdn.melodics.com/download/CA99927E-3E83-4860-B595-3E78A340F227.zip",
       "install_script_ref": "fa7d6756",
       "uninstall_script_ref": "4abaa93b",
-      "sha256": "c4f3b4f98189167ab55f4598e46c3c6e506b471ae612dbd153d7e93b99ea271a",
+      "sha256": "2d95db885a69880dc24fd7ddd033be1123b20fe4647b2628c218063319e798b3",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/openaudible/darwin.json
+++ b/ee/maintained-apps/outputs/openaudible/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "4.8.7",
+      "version": "4.8.8",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.openaudible.openaudible';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.openaudible.openaudible' AND version_compare(bundle_short_version, '4.8.7') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.openaudible.openaudible' AND version_compare(bundle_short_version, '4.8.8') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'org.openaudible.openaudible');"
       },
-      "installer_url": "https://github.com/openaudible/openaudible/releases/download/v4.8.7/OpenAudible_4.8.7.dmg",
+      "installer_url": "https://github.com/openaudible/openaudible/releases/download/v4.8.8/OpenAudible_4.8.8.dmg",
       "install_script_ref": "843c34d8",
       "uninstall_script_ref": "5a6b6749",
-      "sha256": "0fd35949777c55b01d50c412b97dd11e90d9719ace79ec3ae221742a1c2c8522",
+      "sha256": "a9197f15293e9fac29a4ace0412423d24ff63ad411a54ef7da3d901f83990acc",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/readest/windows.json
+++ b/ee/maintained-apps/outputs/readest/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "0.11.20",
+      "version": "0.12.1",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Readest' AND publisher = 'bilingify';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Readest' AND publisher = 'bilingify' AND version_compare(version, '0.11.20') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Readest' AND publisher = 'bilingify' AND version_compare(version, '0.12.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'readest.exe');"
       },
-      "installer_url": "https://github.com/readest/readest/releases/download/v0.11.20/Readest_0.11.20_x64-setup.exe",
+      "installer_url": "https://github.com/readest/readest/releases/download/v0.12.1/Readest_0.12.1_x64-setup.exe",
       "install_script_ref": "2b4dd196",
       "uninstall_script_ref": "36b7aeaf",
-      "sha256": "df8c9e2763cc9ec3e453cce6320df442798d115f9127c0c6ba831b800cbdb7dd",
+      "sha256": "f759ab19dcc1be5df734d84fae7c71de9321fe9bf50dfcf35c91015f6b0a1dcc",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/rize/darwin.json
+++ b/ee/maintained-apps/outputs/rize/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "3.0.26",
+      "version": "3.0.45",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'io.rize';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.rize' AND version_compare(bundle_short_version, '3.0.26') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.rize' AND version_compare(bundle_short_version, '3.0.45') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'io.rize');"
       },
-      "installer_url": "https://github.com/rize-io/lua/releases/download/v3.0.26/Rize-3.0.26-arm64.dmg",
+      "installer_url": "https://github.com/rize-io/lua/releases/download/v3.0.45/Rize-3.0.45-arm64.dmg",
       "install_script_ref": "24fc8184",
       "uninstall_script_ref": "fe9839a4",
-      "sha256": "87b0a137f0c7cf4f680f09c9e5da3a8e8cdd32d05904f46fe0f81bbce4548788",
+      "sha256": "e632dcf1155811f907a044463a0317be6ed6fcf37ad4ea8392a3d8c5cb5beb42",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Refreshed macOS installers for Cisco Jabber, CodexBar, Firefox Nightly, Gitify, Glyphs, Hive, Melodics, OpenAudible, and Rize.
  - Refreshed the Windows installers for Firefox Nightly and Readest.
  - Updated release versions, installer sources, and verification checksums to the latest available builds.
  - Installation and removal workflows remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->