### PR TITLE
Don't let Turn off MDM run twice on the same host

### DIFF
--- a/changes/50103-turn-off-mdm-repeat
+++ b/changes/50103-turn-off-mdm-repeat
@@ -1,0 +1,1 @@
+- Fixed "Turn off MDM" being available again after it succeeded, which let an offline host be sent duplicate unenroll commands and record duplicate activities. The host page now refreshes when MDM is turned off, and Fleet rejects the request if MDM is already off for that host.

--- a/changes/50103-turn-off-mdm-repeat
+++ b/changes/50103-turn-off-mdm-repeat
@@ -1,1 +1,1 @@
-- Fixed "Turn off MDM" being available again after it succeeded, which let an offline host be sent duplicate unenroll commands and record duplicate activities. The host page now refreshes when MDM is turned off, and Fleet rejects the request if MDM is already off for that host.
+- Fixed "Turn off MDM" being available again after it succeeded, which let an offline host be sent duplicate unenroll commands.

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -1810,6 +1810,14 @@ const HostDetailsPage = ({
               hostName={host.display_name}
               enrollmentStatus={host.mdm.enrollment_status}
               onClose={toggleUnenrollMdmModal}
+              onSuccess={() => {
+                // The server marks the host unenrolled immediately, so refresh
+                // to drop the action from the dropdown. Otherwise it stays
+                // offered until the window regains focus, and each extra
+                // confirmation queues another unenroll.
+                refetchHostDetails();
+                refetchPastActivities();
+              }}
             />
           )}
           {showDiskEncryptionModal && host && (

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/UnenrollMdmModal/UnenrollMdmModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/UnenrollMdmModal/UnenrollMdmModal.tsx
@@ -6,6 +6,7 @@ import Modal from "components/Modal";
 import { notify } from "components/ToastNotification";
 
 import mdmAPI from "services/entities/mdm";
+import { getErrorReason, hasStatusKey } from "interfaces/errors";
 import { isAndroid, isIPadOrIPhone } from "interfaces/platform";
 import {
   isAutomaticDeviceEnrollment,
@@ -22,8 +23,6 @@ interface IUnenrollMdmModalProps {
   hostName: string;
   enrollmentStatus: MdmEnrollmentStatus | null;
   onClose: () => void;
-  /** Called after MDM is successfully turned off, so the caller can refresh the
-   * host. Without it the page keeps offering the action against stale data. */
   onSuccess: () => void;
 }
 
@@ -58,15 +57,24 @@ const UnenrollMdmModal = ({
       onSuccess();
       onClose();
     } catch (unenrollMdmError: unknown) {
-      const errorMessage =
-        isIPadOrIPhone(hostPlatform) || isAndroid(hostPlatform) ? (
-          "Couldn't unenroll. Please try again."
-        ) : (
-          <>
-            Failed to turn off MDM for <b>{hostName}</b>. Please try again.
-          </>
-        );
-      notify.error(errorMessage, { response: unenrollMdmError });
+      // A 409 means MDM is already off for this host, so "please try again"
+      // would send the user in a loop. It also means this page was working from
+      // stale data, so refresh it to drop the action.
+      if (hasStatusKey(unenrollMdmError) && unenrollMdmError.status === 409) {
+        notify.error(getErrorReason(unenrollMdmError));
+        onSuccess();
+        onClose();
+      } else {
+        const errorMessage =
+          isIPadOrIPhone(hostPlatform) || isAndroid(hostPlatform) ? (
+            "Couldn't unenroll. Please try again."
+          ) : (
+            <>
+              Failed to turn off MDM for <b>{hostName}</b>. Please try again.
+            </>
+          );
+        notify.error(errorMessage, { response: unenrollMdmError });
+      }
     }
     setRequestState(undefined);
   };

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/UnenrollMdmModal/UnenrollMdmModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/UnenrollMdmModal/UnenrollMdmModal.tsx
@@ -22,6 +22,9 @@ interface IUnenrollMdmModalProps {
   hostName: string;
   enrollmentStatus: MdmEnrollmentStatus | null;
   onClose: () => void;
+  /** Called after MDM is successfully turned off, so the caller can refresh the
+   * host. Without it the page keeps offering the action against stale data. */
+  onSuccess: () => void;
 }
 
 const UnenrollMdmModal = ({
@@ -30,6 +33,7 @@ const UnenrollMdmModal = ({
   hostName,
   enrollmentStatus,
   onClose,
+  onSuccess,
 }: IUnenrollMdmModalProps) => {
   const [requestState, setRequestState] = useState<
     undefined | "unenrolling" | "error"
@@ -51,6 +55,7 @@ const UnenrollMdmModal = ({
           </>
         );
       notify.success(successMessage);
+      onSuccess();
       onClose();
     } catch (unenrollMdmError: unknown) {
       const errorMessage =

--- a/server/fleet/errors.go
+++ b/server/fleet/errors.go
@@ -28,7 +28,7 @@ var (
 	AppleOSVersionUnsupportedMessage             = "The minimum version isn't supported by Apple."
 	AppleOSVersionDeadlineInvalidMessage         = "The deadline isn't a valid date."
 	CantTurnOffMDMForWindowsHostsMessage         = "Can't turn off MDM for Windows hosts."
-	MDMAlreadyTurnedOffMessage                   = "MDM is already off for this host."
+	CantTurnOffMDMAlreadyTurnedOffMessage        = "Couldn't turn off MDM. This host already has MDM turned off."
 	CantTurnOffMDMForPersonalHostsMessage        = "Couldn't turn off MDM. This command isn't available for personal hosts."
 	CantWipePersonalHostsMessage                 = "Couldn't wipe. This command isn't available for personal hosts."
 	CantLockPersonalHostsMessage                 = "Couldn't lock. This command isn't available for personal hosts."

--- a/server/fleet/errors.go
+++ b/server/fleet/errors.go
@@ -28,6 +28,7 @@ var (
 	AppleOSVersionUnsupportedMessage             = "The minimum version isn't supported by Apple."
 	AppleOSVersionDeadlineInvalidMessage         = "The deadline isn't a valid date."
 	CantTurnOffMDMForWindowsHostsMessage         = "Can't turn off MDM for Windows hosts."
+	MDMAlreadyTurnedOffMessage                   = "MDM is already off for this host."
 	CantTurnOffMDMForPersonalHostsMessage        = "Couldn't turn off MDM. This command isn't available for personal hosts."
 	CantWipePersonalHostsMessage                 = "Couldn't wipe. This command isn't available for personal hosts."
 	CantLockPersonalHostsMessage                 = "Couldn't lock. This command isn't available for personal hosts."

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -2365,6 +2365,10 @@ func TestMDMCommandAuthz(t *testing.T) {
 		return &fleet.HostMDMCheckinInfo{Platform: "darwin"}, nil
 	}
 
+	ds.GetHostMDMFunc = func(ctx context.Context, hostID uint) (*fleet.HostMDM, error) {
+		return &fleet.HostMDM{HostID: hostID, Enrolled: true}, nil
+	}
+
 	ds.MDMTurnOffFunc = func(ctx context.Context, uuid string) ([]*fleet.User, []fleet.ActivityDetails, error) {
 		return nil, nil, nil
 	}
@@ -2745,6 +2749,10 @@ func TestAppleMDMUnenrollment(t *testing.T) {
 		return &fleet.HostMDMCheckinInfo{Platform: "darwin"}, nil
 	}
 
+	ds.GetHostMDMFunc = func(ctx context.Context, hostID uint) (*fleet.HostMDM, error) {
+		return &fleet.HostMDM{HostID: hostID, Enrolled: true}, nil
+	}
+
 	ds.MDMTurnOffFunc = func(ctx context.Context, uuid string) ([]*fleet.User, []fleet.ActivityDetails, error) {
 		return nil, nil, nil
 	}
@@ -2771,6 +2779,23 @@ func TestAppleMDMUnenrollment(t *testing.T) {
 	t.Run("Unenrolls personal ios device", func(t *testing.T) {
 		err := svc.UnenrollMDM(ctx, hostOne.ID) // personal host
 		require.NoError(t, err)
+	})
+
+	// An offline host keeps its nano enrollment enabled until it receives the
+	// removal command, so the enrollment check alone lets every repeat call
+	// through -- each one queueing another RemoveProfile and logging another
+	// unenroll activity. See #50103.
+	t.Run("Refuses to turn off MDM that is already off", func(t *testing.T) {
+		ds.GetHostMDMFunc = func(ctx context.Context, hostID uint) (*fleet.HostMDM, error) {
+			return &fleet.HostMDM{HostID: hostID, Enrolled: false}, nil
+		}
+		ds.MDMTurnOffFuncInvoked = false
+
+		err := svc.UnenrollMDM(ctx, hostGlobal.ID)
+
+		var conflict *fleet.ConflictError
+		require.ErrorAs(t, err, &conflict)
+		require.False(t, ds.MDMTurnOffFuncInvoked, "must not re-run turn off for an already unenrolled host")
 	})
 }
 

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -2733,6 +2733,7 @@ func TestAppleMDMUnenrollment(t *testing.T) {
 
 	hostOne := &fleet.Host{ID: 1, UUID: "test-host-no-team-2", Platform: "ios"}
 	hostGlobal := &fleet.Host{ID: 42, UUID: "test-host-no-team", Platform: "darwin"}
+	hostLinux := &fleet.Host{ID: 7, UUID: "test-host-linux", Platform: "ubuntu"}
 
 	ds.HostLiteFunc = func(ctx context.Context, hostID uint) (*fleet.Host, error) {
 		switch hostID {
@@ -2740,6 +2741,8 @@ func TestAppleMDMUnenrollment(t *testing.T) {
 			return hostOne, nil
 		case hostGlobal.ID:
 			return hostGlobal, nil
+		case hostLinux.ID:
+			return hostLinux, nil
 		default:
 			return nil, errors.New("not found")
 		}
@@ -2796,6 +2799,21 @@ func TestAppleMDMUnenrollment(t *testing.T) {
 		var conflict *fleet.ConflictError
 		require.ErrorAs(t, err, &conflict)
 		require.False(t, ds.MDMTurnOffFuncInvoked, "must not re-run turn off for an already unenrolled host")
+	})
+
+	// An unsupported host has no enrolled host_mdm row either, so the
+	// already-off check would happily claim that instead of saying the platform
+	// isn't supported. The platform has to be rejected first.
+	t.Run("Reports an unsupported platform rather than already off", func(t *testing.T) {
+		ds.GetHostMDMFunc = func(ctx context.Context, hostID uint) (*fleet.HostMDM, error) {
+			return &fleet.HostMDM{HostID: hostID, Enrolled: false}, nil
+		}
+
+		err := svc.UnenrollMDM(ctx, hostLinux.ID)
+
+		var badRequest *fleet.BadRequestError
+		require.ErrorAs(t, err, &badRequest)
+		require.Contains(t, badRequest.Message, "not supported for this host platform")
 	})
 }
 

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -2174,8 +2174,10 @@ func (s *integrationMDMTestSuite) TestMDMAppleUnenroll() {
 	// 3 profiles added + 1 profile with fleetd configuration + 1 root CA config
 	require.Len(t, *hostResp.Host.MDM.Profiles, 5)
 
-	// returns success, but this is effectively a no-op because the host isn't enrolled yet.
-	s.Do("DELETE", fmt.Sprintf("/api/latest/fleet/hosts/%d/mdm", h.ID), nil, http.StatusNoContent)
+	// The error cases below have to run while the host is still enrolled: a
+	// failed push returns before MDM is turned off, so the host stays enrolled
+	// and each case gets a fresh attempt. Once a turn off succeeds, further
+	// requests are rejected as a conflict.
 
 	// we're going to modify this mock, make sure we restore its default
 	originalPushMock := s.pushProvider.PushFunc

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -4404,12 +4404,29 @@ func (svc *Service) UnenrollMDM(ctx context.Context, hostID uint) error {
 		return err
 	}
 
-	installedFromDEP := false
-	switch host.Platform {
-	case "windows":
+	if host.Platform == "windows" {
 		return &fleet.BadRequestError{
 			Message: fleet.CantTurnOffMDMForWindowsHostsMessage,
 		}
+	}
+
+	// Turning MDM off clears Fleet's enrolled flag right away, but the device
+	// only checks out once it actually receives the removal command. On an
+	// offline host that can be days, and until then the nano-enrollment guard
+	// in enqueueMDMAppleCommandRemoveEnrollmentProfile still sees an enabled
+	// enrollment, so every repeat call queues another removal command and logs
+	// another unenroll activity. Fleet's own flag is the one that flips
+	// immediately, so it's what makes this operation refusable when repeated.
+	hostMDM, err := svc.ds.GetHostMDM(ctx, hostID)
+	switch {
+	case err != nil && !fleet.IsNotFound(err):
+		return ctxerr.Wrap(ctx, err, "getting host MDM info for unenroll")
+	case err != nil || !hostMDM.Enrolled:
+		return ctxerr.Wrap(ctx, &fleet.ConflictError{Message: fleet.MDMAlreadyTurnedOffMessage})
+	}
+
+	installedFromDEP := false
+	switch host.Platform {
 	case "ios", "ipados", "darwin":
 		if err := svc.enqueueMDMAppleCommandRemoveEnrollmentProfile(ctx, host); err != nil {
 			return ctxerr.Wrap(ctx, err, "unenrolling apple host")

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -4404,30 +4404,32 @@ func (svc *Service) UnenrollMDM(ctx context.Context, hostID uint) error {
 		return err
 	}
 
-	if host.Platform == "windows" {
+	installedFromDEP := false
+	switch host.Platform {
+	case "windows":
 		return &fleet.BadRequestError{
 			Message: fleet.CantTurnOffMDMForWindowsHostsMessage,
 		}
-	}
-
-	// Turning MDM off clears Fleet's enrolled flag right away, but the device
-	// only checks out once it actually receives the removal command. On an
-	// offline host that can be days, and until then the nano-enrollment guard
-	// in enqueueMDMAppleCommandRemoveEnrollmentProfile still sees an enabled
-	// enrollment, so every repeat call queues another removal command and logs
-	// another unenroll activity. Fleet's own flag is the one that flips
-	// immediately, so it's what makes this operation refusable when repeated.
-	hostMDM, err := svc.ds.GetHostMDM(ctx, hostID)
-	switch {
-	case err != nil && !fleet.IsNotFound(err):
-		return ctxerr.Wrap(ctx, err, "getting host MDM info for unenroll")
-	case err != nil || !hostMDM.Enrolled:
-		return ctxerr.Wrap(ctx, &fleet.ConflictError{Message: fleet.MDMAlreadyTurnedOffMessage})
-	}
-
-	installedFromDEP := false
-	switch host.Platform {
 	case "ios", "ipados", "darwin":
+		// Turning MDM off clears Fleet's enrolled flag right away, but the
+		// device only checks out once it actually receives the removal command.
+		// On an offline host that can be days, and until then the
+		// nano-enrollment guard in
+		// enqueueMDMAppleCommandRemoveEnrollmentProfile still sees an enabled
+		// enrollment, so every repeat call queues another removal command and
+		// logs another unenroll activity. Fleet's own flag is the one that
+		// flips immediately, so it's what makes this refusable when repeated.
+		//
+		// Apple only: Android keeps enrolled = 1 until AMAPI acknowledges, so
+		// the flag says nothing about whether a turn off is already under way.
+		hostMDM, err := svc.ds.GetHostMDM(ctx, hostID)
+		switch {
+		case err != nil && !fleet.IsNotFound(err):
+			return ctxerr.Wrap(ctx, err, "getting host MDM info for unenroll")
+		case err != nil || !hostMDM.Enrolled:
+			return ctxerr.Wrap(ctx, &fleet.ConflictError{Message: fleet.CantTurnOffMDMAlreadyTurnedOffMessage}, "turning off MDM")
+		}
+
 		if err := svc.enqueueMDMAppleCommandRemoveEnrollmentProfile(ctx, host); err != nil {
 			return ctxerr.Wrap(ctx, err, "unenrolling apple host")
 		}

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -4411,17 +4411,7 @@ func (svc *Service) UnenrollMDM(ctx context.Context, hostID uint) error {
 			Message: fleet.CantTurnOffMDMForWindowsHostsMessage,
 		}
 	case "ios", "ipados", "darwin":
-		// Turning MDM off clears Fleet's enrolled flag right away, but the
-		// device only checks out once it actually receives the removal command.
-		// On an offline host that can be days, and until then the
-		// nano-enrollment guard in
-		// enqueueMDMAppleCommandRemoveEnrollmentProfile still sees an enabled
-		// enrollment, so every repeat call queues another removal command and
-		// logs another unenroll activity. Fleet's own flag is the one that
-		// flips immediately, so it's what makes this refusable when repeated.
-		//
-		// Apple only: Android keeps enrolled = 1 until AMAPI acknowledges, so
-		// the flag says nothing about whether a turn off is already under way.
+		// Turning MDM off clears Fleet's enrolled flag right away, so check the flag here to avoid re-enqueuing another unenroll.
 		hostMDM, err := svc.ds.GetHostMDM(ctx, hostID)
 		switch {
 		case err != nil && !fleet.IsNotFound(err):


### PR DESCRIPTION
**Related issue:** Resolves #50103

Turning MDM off marks the host unenrolled in Fleet immediately, but the device only checks out once it actually receives the removal command. On an offline host that gap can last days.

The existing guard in `enqueueMDMAppleCommandRemoveEnrollmentProfile` keys on the device's enrollment, so until the device checks out it still sees an enabled enrollment and lets every repeat request through. Each one queues another `RemoveProfile` and logs another unenroll activity. Separately, the host page never refreshed after a successful turn off, so the action stayed in the Actions dropdown and could be confirmed again.

- The service now rejects the request with a 409 when Fleet already has MDM off for the host. Fleet's own enrolled flag is the one that flips right away, so it complements the device-side check rather than replacing it.
- The Windows rejection moved out of the platform switch into an early return so it keeps priority over the new check. Same message and status code as before.
- `UnenrollMdmModal` takes an `onSuccess` callback and the host page refetches host details and past activities on it. `onClose` was the wrong hook, since it also fires on cancel.

Reproduced locally against an ADE-enrolled Mac held offline: six turn off requests were accepted on a host already marked Off, producing six queued removal commands and six activity entries.

Note this is a race rather than an offline-only bug. On an online host the device checks out within seconds, so the window is short but not zero.

`TestMDMAppleUnenroll` needed restructuring. It turned MDM off once up front and then reused the same host for the push-failure cases and the successful turn off, which only worked because repeat requests were accepted. With them rejected, every later case got a conflict instead of reaching the code it was testing. A failed push returns before MDM is turned off, so the error cases now run first against a live enrollment.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented repeated “Turn off MDM” actions from creating duplicate unenrollment commands or activity records.
  * Displays a conflict when MDM is already disabled or enrollment information is unavailable.
  * Refreshes host details and activity history automatically after a successful unenrollment.
  * Keeps “Turn off MDM” unavailable after a successful unenrollment to prevent duplicate actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->