### PR TITLE
hide turn on MDM banner until details have been fetched

### DIFF
--- a/changes/50124-hide-turn-on-mdm-if-not-fetched
+++ b/changes/50124-hide-turn-on-mdm-if-not-fetched
@@ -1,0 +1,1 @@
+- Fixed an issue where Fleet would show a turn on MDM banner before knowing the device state.

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -731,6 +731,7 @@ const DeviceUserPage = ({
             diskEncryptionKeyAvailable={host.mdm.encryption_key_available}
             mdmManualEnrolmentUrl={mdmManualEnrollUrl}
             lastMdmEnrolledAt={host.last_mdm_enrolled_at}
+            detailUpdatedAt={host.detail_updated_at}
           />
           <HostHeader
             summaryData={summaryData}

--- a/frontend/pages/hosts/details/DeviceUserPage/components/DeviceUserBanners/DeviceUserBanners.tests.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/components/DeviceUserBanners/DeviceUserBanners.tests.tsx
@@ -20,6 +20,7 @@ describe("Device User Banners", () => {
         connectedToFleetMdm
         macDiskEncryptionStatus={null}
         diskEncryptionActionRequired={null}
+        detailUpdatedAt="2025-01-15T10:00:00Z"
         onTriggerEscrowLinuxKey={noop}
         onClickCreatePIN={noop}
         onClickTurnOnMdm={noop}
@@ -199,5 +200,43 @@ describe("Device User Banners", () => {
     expect(
       screen.queryByText(resetNonLinuxDiskEncryptKeyExpectedText)
     ).not.toBeInTheDocument();
+  });
+
+  it("hides the Turn on MDM banner for never-fetched devices", () => {
+    render(
+      <DeviceUserBanners
+        hostPlatform="darwin"
+        mdmEnrollmentStatus="Off"
+        mdmEnabledAndConfigured
+        connectedToFleetMdm={false}
+        macDiskEncryptionStatus={null}
+        diskEncryptionActionRequired={null}
+        detailUpdatedAt="0001-01-01T00:00:00Z"
+        onTriggerEscrowLinuxKey={noop}
+        onClickCreatePIN={noop}
+        onClickTurnOnMdm={noop}
+      />
+    );
+
+    expect(screen.queryByText(turnOnMdmExpcetedText)).not.toBeInTheDocument();
+  });
+
+  it("renders the Turn on MDM banner for unenrolled macOS hosts that have updated its detail", () => {
+    render(
+      <DeviceUserBanners
+        hostPlatform="darwin"
+        mdmEnrollmentStatus="Off"
+        mdmEnabledAndConfigured
+        connectedToFleetMdm={false}
+        macDiskEncryptionStatus={null}
+        diskEncryptionActionRequired={null}
+        detailUpdatedAt="2025-01-15T10:00:00Z"
+        onTriggerEscrowLinuxKey={noop}
+        onClickCreatePIN={noop}
+        onClickTurnOnMdm={noop}
+      />
+    );
+
+    expect(screen.getByText(turnOnMdmExpcetedText)).toBeInTheDocument();
   });
 });

--- a/frontend/pages/hosts/details/DeviceUserPage/components/DeviceUserBanners/DeviceUserBanners.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/components/DeviceUserBanners/DeviceUserBanners.tsx
@@ -8,6 +8,7 @@ import { IHostBannersBaseProps } from "pages/hosts/details/HostDetailsPage/compo
 import CustomLink from "components/CustomLink";
 import { isDiskEncryptionSupportedLinuxPlatform } from "interfaces/platform";
 import { isAutomaticDeviceEnrollment } from "interfaces/mdm";
+import { INITIAL_FLEET_DATE } from "utilities/constants";
 
 const baseClass = "device-user-banners";
 
@@ -36,6 +37,7 @@ const DeviceUserBanners = ({
   diskEncryptionKeyAvailable,
   onTriggerEscrowLinuxKey,
   lastMdmEnrolledAt,
+  detailUpdatedAt,
 }: IDeviceUserBannersProps) => {
   const isMdmUnenrolled =
     mdmEnrollmentStatus === "Off" || mdmEnrollmentStatus === null;
@@ -43,7 +45,11 @@ const DeviceUserBanners = ({
   const mdmEnabledAndConnected = mdmEnabledAndConfigured && connectedToFleetMdm;
 
   const showTurnOnAppleMdmBanner =
-    hostPlatform === "darwin" && isMdmUnenrolled && mdmEnabledAndConfigured;
+    hostPlatform === "darwin" &&
+    isMdmUnenrolled &&
+    mdmEnabledAndConfigured &&
+    detailUpdatedAt &&
+    detailUpdatedAt > INITIAL_FLEET_DATE;
 
   const isNewMdmEnrollment =
     !isMdmUnenrolled &&

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -1470,7 +1470,7 @@ const HostDetailsPage = ({
               diskIsEncrypted={host?.disk_encryption_enabled}
               diskEncryptionKeyAvailable={host?.mdm.encryption_key_available}
               lastMdmEnrolledAt={host?.last_mdm_enrolled_at}
-              detailUpdatedAt={host.detail_updated_at}
+              detailUpdatedAt={host?.detail_updated_at}
             />
           )}
           <div className={`${baseClass}__header-links`}>

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -1470,6 +1470,7 @@ const HostDetailsPage = ({
               diskIsEncrypted={host?.disk_encryption_enabled}
               diskEncryptionKeyAvailable={host?.mdm.encryption_key_available}
               lastMdmEnrolledAt={host?.last_mdm_enrolled_at}
+              detailUpdatedAt={host.detail_updated_at}
             />
           )}
           <div className={`${baseClass}__header-links`}>

--- a/frontend/pages/hosts/details/HostDetailsPage/components/HostDetailsBanners/HostDetailsBanners.tests.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/components/HostDetailsBanners/HostDetailsBanners.tests.tsx
@@ -78,4 +78,36 @@ describe("Host Details Banners", () => {
     ).not.toBeInTheDocument();
     expect(screen.queryByText(logOutExpectedText)).not.toBeInTheDocument();
   });
+
+  it("hides the Turn on MDM banner for never-updated devices", () => {
+    const turnOnMdmText = /To enforce settings, OS updates, disk encryption, and more/;
+
+    render(
+      <HostDetailsBanners
+        hostPlatform="darwin"
+        mdmEnrollmentStatus="Off"
+        connectedToFleetMdm={false}
+        macDiskEncryptionStatus={null}
+        detailUpdatedAt="0001-01-01T00:00:00Z"
+      />
+    );
+
+    expect(screen.queryByText(turnOnMdmText)).not.toBeInTheDocument();
+  });
+
+  it("renders the Turn on MDM banner for unenrolled macOS hosts that have updated its detail", () => {
+    const turnOnMdmText = /To enforce settings, OS updates, disk encryption, and more/;
+
+    render(
+      <HostDetailsBanners
+        hostPlatform="darwin"
+        mdmEnrollmentStatus="Off"
+        connectedToFleetMdm={false}
+        macDiskEncryptionStatus={null}
+        detailUpdatedAt="2025-01-15T10:00:00Z"
+      />
+    );
+
+    expect(screen.getByText(turnOnMdmText)).toBeInTheDocument();
+  });
 });

--- a/frontend/pages/hosts/details/HostDetailsPage/components/HostDetailsBanners/HostDetailsBanners.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/components/HostDetailsBanners/HostDetailsBanners.tsx
@@ -37,7 +37,7 @@ export interface IHostBannersBaseProps {
   diskEncryptionKeyAvailable?: boolean;
   /** The timestamp of the last MDM enrollment */
   lastMdmEnrolledAt?: string;
-  /** The timestamp of the last communication */
+  /** The timestamp of the last detail update */
   detailUpdatedAt?: string;
 }
 /**

--- a/frontend/pages/hosts/details/HostDetailsPage/components/HostDetailsBanners/HostDetailsBanners.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/components/HostDetailsBanners/HostDetailsBanners.tsx
@@ -15,7 +15,10 @@ import {
 
 import InfoBanner from "components/InfoBanner";
 import CustomLink from "components/CustomLink";
-import { LEARN_MORE_ABOUT_BASE_LINK } from "utilities/constants";
+import {
+  INITIAL_FLEET_DATE,
+  LEARN_MORE_ABOUT_BASE_LINK,
+} from "utilities/constants";
 
 const baseClass = "host-details-banners";
 
@@ -34,6 +37,8 @@ export interface IHostBannersBaseProps {
   diskEncryptionKeyAvailable?: boolean;
   /** The timestamp of the last MDM enrollment */
   lastMdmEnrolledAt?: string;
+  /** The timestamp of the last communication */
+  detailUpdatedAt?: string;
 }
 /**
  * Handles the displaying of banners on the host details page
@@ -48,6 +53,7 @@ const HostDetailsBanners = ({
   diskIsEncrypted,
   diskEncryptionKeyAvailable,
   lastMdmEnrolledAt,
+  detailUpdatedAt,
 }: IHostBannersBaseProps) => {
   const { config } = useContext(AppContext);
 
@@ -63,7 +69,9 @@ const HostDetailsBanners = ({
   const showTurnOnMdmInfoBanner =
     hostPlatform === "darwin" &&
     isMdmUnenrolled &&
-    config?.mdm.enabled_and_configured;
+    config?.mdm.enabled_and_configured &&
+    detailUpdatedAt &&
+    detailUpdatedAt > INITIAL_FLEET_DATE;
 
   const showMacDiskEncryptionUserActionRequired =
     config?.mdm.enabled_and_configured &&


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #50124

<img width="1465" height="149" alt="image" src="https://github.com/user-attachments/assets/21e611a8-2c6d-464a-a986-ffabc9893725" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the “Turn on MDM” banner from appearing before a host’s device details have been fetched.
  * The banner continues to appear for eligible unenrolled macOS hosts once current device details are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->