### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/cisco-jabber/darwin.json
+++ b/ee/maintained-apps/outputs/cisco-jabber/darwin.json
@@ -7,10 +7,10 @@
         "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.cisco.jabber' AND version_compare(bundle_short_version, '15.2.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.cisco.jabber');"
       },
-      "installer_url": "https://binaries.webex.com/jabberclientmac/20260122074039/Install_Cisco-Jabber-Mac.pkg",
+      "installer_url": "https://binaries.webex.com/jabberclientmac/20260722023311/Install_Cisco-Jabber-Mac.pkg",
       "install_script_ref": "edbec29c",
       "uninstall_script_ref": "fe0e9261",
-      "sha256": "5644700e420febc1eca304c0a0f24bcff1e64b424112e1beda025d2eb78e16de",
+      "sha256": "bb71f8686049930033710f88698712e6aee6ed469516f3a73e48df8cecda4d61",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/nordpass/darwin.json
+++ b/ee/maintained-apps/outputs/nordpass/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "7.9.4",
+      "version": "7.9.5",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.nordsec.nordpass';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.nordsec.nordpass' AND version_compare(bundle_short_version, '7.9.4') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.nordsec.nordpass' AND version_compare(bundle_short_version, '7.9.5') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.nordsec.nordpass');"
       },
       "installer_url": "https://downloads.npass.app/mac/arm/NordPass.dmg",


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the Cisco Jabber macOS installer to a newer package build.
  * Updated NordPass for macOS from version 7.9.4 to 7.9.5.
  * Refreshed package verification details for both applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->