### PR TITLE
Fix invalid JSON payload in TUF root Slack notification

### DIFF
--- a/.github/workflows/check-updates-timestamps.yml
+++ b/.github/workflows/check-updates-timestamps.yml
@@ -164,7 +164,7 @@ jobs:
         with:
           payload: |
             {
-              "text": "${{ job.status }},
+              "text": "${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head.html_url }}",
               "blocks": [
                 {
                   "type": "section",


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->

Fixes the "Slack root notification" step in the `TUF expiration check: updates.fleetdm.com` workflow, which failed with `Error: Need to provide valid JSON payload` in [this run](https://github.com/fleetdm/fleet/actions/runs/31379218985). The payload's top-level `"text"` field was an unterminated string, so the slackapi action rejected it — meaning the warning that `root.json` is within 30 days of expiring never reached Slack. Restored the line to match the other three notification steps in the same workflow.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] QA'd all new/changed functionality manually (verified all four Slack payloads in the workflow parse as valid JSON after expression substitution; this PR itself triggers the workflow since it touches the file)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Slack root notifications now include a direct link to the related pull request or workflow after the job status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->