### PR TITLE
Support display name for Fleet-maintained apps in GitOps

### DIFF
--- a/changes/50694-fma-gitops-display-name
+++ b/changes/50694-fma-gitops-display-name
@@ -1,0 +1,1 @@
+- Added support for `display_name` on Fleet-maintained apps in GitOps.

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -13,6 +13,7 @@ import (
 	"slices"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/bmatcuk/doublestar/v4"
 	"github.com/fleetdm/fleet/v4/pkg/optjson"
@@ -2407,7 +2408,7 @@ func parseSoftware(top map[string]json.RawMessage, result *GitOps, baseDir strin
 		}
 
 		// Validate display_name length (matches database VARCHAR(255))
-		if len(item.DisplayName) > 255 {
+		if utf8.RuneCountInString(item.DisplayName) > 255 {
 			multiError = multierror.Append(multiError, fmt.Errorf("app_store_id %q display_name is too long (max 255 characters)", item.AppStoreID))
 			continue
 		}
@@ -2434,7 +2435,7 @@ func parseSoftware(top map[string]json.RawMessage, result *GitOps, baseDir strin
 		}
 
 		// Validate display_name length (matches database VARCHAR(255))
-		if len(maintainedAppSpec.DisplayName) > 255 {
+		if utf8.RuneCountInString(maintainedAppSpec.DisplayName) > 255 {
 			multiError = multierror.Append(multiError, fmt.Errorf("fleet maintained app %q display_name is too long (max 255 characters)", maintainedAppSpec.Slug))
 			continue
 		}
@@ -2634,7 +2635,7 @@ func parseSoftware(top map[string]json.RawMessage, result *GitOps, baseDir strin
 			}
 
 			// Validate display_name length (matches database VARCHAR(255))
-			if len(softwarePackageSpec.DisplayName) > 255 {
+			if utf8.RuneCountInString(softwarePackageSpec.DisplayName) > 255 {
 				multiError = multierror.Append(multiError, fmt.Errorf("software package %q display_name is too long (max 255 characters)", softwarePackageSpec.URL))
 				continue
 			}

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -2433,6 +2433,12 @@ func parseSoftware(top map[string]json.RawMessage, result *GitOps, baseDir strin
 			continue
 		}
 
+		// Validate display_name length (matches database VARCHAR(255))
+		if len(maintainedAppSpec.DisplayName) > 255 {
+			multiError = multierror.Append(multiError, fmt.Errorf("fleet maintained app %q display_name is too long (max 255 characters)", maintainedAppSpec.Slug))
+			continue
+		}
+
 		maintainedAppSpec = maintainedAppSpec.ResolveSoftwarePackagePaths(baseDir)
 
 		// handle secrets

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -2735,6 +2735,19 @@ software:
 		assert.ErrorContains(t, err, "display_name is too long (max 255 characters)")
 	})
 
+	t.Run("fleet_maintained_app_display_name_too_long", func(t *testing.T) {
+		config := getTeamConfig([]string{"name", "software"})
+		config += `name: Test Team
+software:
+  fleet_maintained_apps:
+    - slug: 1password/darwin
+      display_name: "` + longDisplayName + `"
+`
+		path, basePath := createTempFile(t, "", config)
+		_, err := GitOpsFromFile(path, basePath, appConfig, nopLogf)
+		assert.ErrorContains(t, err, "display_name is too long (max 255 characters)")
+	})
+
 	t.Run("valid_display_name", func(t *testing.T) {
 		config := getTeamConfig([]string{"name", "software"})
 		// Use hash instead of URL to avoid network calls, and no scripts required
@@ -2746,6 +2759,9 @@ software:
   app_store_apps:
     - app_store_id: "12345"
       display_name: "Custom VPP App Name"
+  fleet_maintained_apps:
+    - slug: 1password/darwin
+      display_name: "Custom FMA Name"
 `
 		path, basePath := createTempFile(t, "", config)
 		result, err := GitOpsFromFile(path, basePath, appConfig, nopLogf)
@@ -2754,6 +2770,12 @@ software:
 		assert.Equal(t, "Custom Package Name", result.Software.Packages[0].DisplayName)
 		require.Len(t, result.Software.AppStoreApps, 1)
 		assert.Equal(t, "Custom VPP App Name", result.Software.AppStoreApps[0].DisplayName)
+		require.Len(t, result.Software.FleetMaintainedApps, 1)
+		assert.Equal(t, "Custom FMA Name", result.Software.FleetMaintainedApps[0].DisplayName)
+
+		// the FMA display name must survive the conversion to the package spec used
+		// to build the batch payload
+		assert.Equal(t, "Custom FMA Name", result.Software.FleetMaintainedApps[0].ToSoftwarePackageSpec().DisplayName)
 	})
 }
 

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -2748,6 +2748,34 @@ software:
 		assert.ErrorContains(t, err, "display_name is too long (max 255 characters)")
 	})
 
+	t.Run("multibyte_display_name_at_rune_limit", func(t *testing.T) {
+		// 255 multibyte characters fit the utf8mb4 varchar(255) column, so they
+		// must be accepted even though they take more than 255 bytes
+		multibyteDisplayName := strings.Repeat("é", 255)
+		config := getTeamConfig([]string{"name", "software"})
+		config += `name: Test Team
+software:
+  packages:
+    - hash_sha256: "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234"
+      display_name: "` + multibyteDisplayName + `"
+  app_store_apps:
+    - app_store_id: "12345"
+      display_name: "` + multibyteDisplayName + `"
+  fleet_maintained_apps:
+    - slug: 1password/darwin
+      display_name: "` + multibyteDisplayName + `"
+`
+		path, basePath := createTempFile(t, "", config)
+		result, err := GitOpsFromFile(path, basePath, appConfig, nopLogf)
+		require.NoError(t, err)
+		require.Len(t, result.Software.Packages, 1)
+		assert.Equal(t, multibyteDisplayName, result.Software.Packages[0].DisplayName)
+		require.Len(t, result.Software.AppStoreApps, 1)
+		assert.Equal(t, multibyteDisplayName, result.Software.AppStoreApps[0].DisplayName)
+		require.Len(t, result.Software.FleetMaintainedApps, 1)
+		assert.Equal(t, multibyteDisplayName, result.Software.FleetMaintainedApps[0].DisplayName)
+	})
+
 	t.Run("valid_display_name", func(t *testing.T) {
 		config := getTeamConfig([]string{"name", "software"})
 		// Use hash instead of URL to avoid network calls, and no scripts required

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -2775,7 +2775,8 @@ software:
 
 		// the FMA display name must survive the conversion to the package spec used
 		// to build the batch payload
-		assert.Equal(t, "Custom FMA Name", result.Software.FleetMaintainedApps[0].ToSoftwarePackageSpec().DisplayName)
+		packageSpec := result.Software.FleetMaintainedApps[0].ToSoftwarePackageSpec()
+		assert.Equal(t, "Custom FMA Name", packageSpec.DisplayName)
 	})
 }
 

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -1076,6 +1076,7 @@ type MaintainedAppSpec struct {
 	LabelsExcludeAny        []string              `json:"labels_exclude_any"`
 	LabelsIncludeAll        []string              `json:"labels_include_all"`
 	Categories              optjson.Slice[string] `json:"categories,omitzero"`
+	DisplayName             string                `json:"display_name,omitempty"`
 	InstallDuringSetup      optjson.Bool          `json:"setup_experience"`
 	SetupExperiencePlatform optjson.String        `json:"setup_experience_platform,omitzero"`
 	Icon                    TeamSpecSoftwareAsset `json:"icon"`
@@ -1097,6 +1098,7 @@ func (spec MaintainedAppSpec) ToSoftwarePackageSpec() SoftwarePackageSpec {
 		InstallDuringSetup:      spec.InstallDuringSetup,
 		Icon:                    spec.Icon,
 		Categories:              spec.Categories,
+		DisplayName:             spec.DisplayName,
 	}
 }
 

--- a/tools/cloner-check/generated_files/teamconfig.txt
+++ b/tools/cloner-check/generated_files/teamconfig.txt
@@ -160,6 +160,7 @@ github.com/fleetdm/fleet/v4/server/fleet/MaintainedAppSpec	LabelsIncludeAny	[]st
 github.com/fleetdm/fleet/v4/server/fleet/MaintainedAppSpec	LabelsExcludeAny	[]string
 github.com/fleetdm/fleet/v4/server/fleet/MaintainedAppSpec	LabelsIncludeAll	[]string
 github.com/fleetdm/fleet/v4/server/fleet/MaintainedAppSpec	Categories	optjson.Slice[string]
+github.com/fleetdm/fleet/v4/server/fleet/MaintainedAppSpec	DisplayName	string
 github.com/fleetdm/fleet/v4/server/fleet/MaintainedAppSpec	InstallDuringSetup	optjson.Bool
 github.com/fleetdm/fleet/v4/server/fleet/MaintainedAppSpec	SetupExperiencePlatform	optjson.String
 github.com/fleetdm/fleet/v4/server/fleet/MaintainedAppSpec	Icon	fleet.TeamSpecSoftwareAsset

--- a/tools/gitops-auto-complete/generated-schema.json
+++ b/tools/gitops-auto-complete/generated-schema.json
@@ -2819,6 +2819,9 @@
             "null"
           ]
         },
+        "deadline_days": {
+          "description": "DeadlineDays is the number of days after an OS version's release date\nbefore the update is enforced. It is only valid when MinimumVersion is\n\"latest\", where the deadline is relative to each version's release rather\nthan a fixed calendar date.\n\ntype: `integer`"
+        },
         "minimum_version": {
           "description": "MinimumVersion is the required minimum operating system version.\n\ntype: `string`",
           "type": [
@@ -3441,7 +3444,7 @@
           ]
         },
         "continuous_automations_enabled": {
-          "description": "ContinuousAutomationsEnabled indicates whether software/script automations\nshould run on every failing policy result, not just on pass→fail transitions.\n\nOnly applies to team policies.\n\ntype: `boolean`",
+          "description": "Shadows PolicySpec.ContinuousAutomationsEnabled to tell whether the key was set\nexplicitly vs. omitted, which patch_when_closed validation needs.\n\ntype: `boolean`",
           "type": [
             "boolean",
             "null"
@@ -3547,6 +3550,13 @@
         "name": {
           "description": "Name is the name of the policy.\n\ntype: `string`",
           "type": "string"
+        },
+        "patch_when_closed": {
+          "description": "PatchWhenClosed skips the install while the app is open, via the managed pre-install query.\n\ntype: `boolean`",
+          "type": [
+            "boolean",
+            "null"
+          ]
         },
         "path": {
           "type": [
@@ -3742,6 +3752,30 @@
           ]
         },
         "vulnerabilities": {
+          "description": "type: `boolean`",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "HostActivitiesWebhookSettings": {
+      "additionalProperties": false,
+      "description": "HostActivitiesWebhookSettings is the per-fleet webhook fired when an activity linked to one of the fleet's hosts is created.",
+      "properties": {
+        "destination_url": {
+          "description": "type: `string`",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "enable_host_activities_webhook": {
           "description": "type: `boolean`",
           "type": [
             "boolean",
@@ -4196,6 +4230,13 @@
             "null"
           ]
         },
+        "windows_enrollment": {
+          "description": "WindowsEnrollment configures behavior for new user-driven Windows MDM enrollments. The DB row backing it is the\nsource of truth (by fleet id); this field carries the setting through the config API and GitOps by fleet name.\n\ntype: `object`",
+          "type": [
+            "object",
+            "null"
+          ]
+        },
         "windows_entra_client_ids": {
           "description": "WindowsEntraClientIDs is the allowlist of Entra application client IDs (GUIDs) whose tokens are accepted for\nWindows automatic enrollment.\n\ntype: `array\u003cstring\u003e`",
           "items": {
@@ -4299,6 +4340,13 @@
       "additionalProperties": false,
       "description": "MDMProfileSpec represents the spec used to define configuration profiles via yaml files.",
       "properties": {
+        "activation": {
+          "description": "Activation is a path to a custom activation JSON file, only valid\nalongside an Apple declaration.\n\ntype: `string`",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "labels": {
           "description": "Deprecated: the Labels field is now deprecated, it is superseded by\nLabelsIncludeAll, so any value set via this field will be transferred to\nLabelsIncludeAll.\n\ntype: `array\u003cstring\u003e`",
           "items": {
@@ -4407,7 +4455,7 @@
       "description": "MacOSSettings contains settings specific to macOS.",
       "properties": {
         "assets": {
-          "description": "Assets is a slice of Apple DDM asset (com.apple.asset) declaration file\npaths. Unlike CustomSettings, assets are not stored on the AppConfig/team\nspec: this field is only populated while parsing a GitOps file so the\nassets can be applied via their own batch endpoint. It is intentionally\nomitted from ToMap/FromMap.\n\ntype: `array\u003cMDMProfileSpec\u003e`",
+          "description": "Assets is a slice of Apple DDM asset (com.apple.asset) declaration file\npaths. Unlike CustomSettings, assets are not stored on the AppConfig/team\nspec: this field is only populated while parsing a GitOps file so the\nassets can be applied via their own batch endpoint. It is intentionally\nomitted from FromMap; ToMap includes it only so the key passes the team\nspec's strict key validation (see applyTeamSpecsRequest.DecodeBody).\n\ntype: `array\u003cMDMProfileSpec\u003e`",
           "items": {
             "$ref": "#/$defs/MDMProfileSpec"
           },
@@ -4629,6 +4677,13 @@
             "null"
           ]
         },
+        "display_name": {
+          "description": "type: `string`",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "icon": {
           "$ref": "#/$defs/TeamSpecSoftwareAsset",
           "description": "type: `TeamSpecSoftwareAsset`"
@@ -4717,6 +4772,23 @@
           "description": "type: `string`",
           "type": [
             "string",
+            "null"
+          ]
+        }
+      },
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "ManagedLocalAccountSettings": {
+      "additionalProperties": false,
+      "description": "ManagedLocalAccountSettings configures the hidden managed local admin account for one platform.",
+      "properties": {
+        "enabled": {
+          "description": "type: `boolean`",
+          "type": [
+            "boolean",
             "null"
           ]
         }
@@ -5781,6 +5853,10 @@
           "$ref": "#/$defs/FailingPoliciesWebhookSettings",
           "description": "type: `FailingPoliciesWebhookSettings`"
         },
+        "host_activities_webhook": {
+          "$ref": "#/$defs/HostActivitiesWebhookSettings",
+          "description": "HostActivitiesWebhook is nil when not provided so partial updates and\nteam specs can leave the stored value untouched.\n\ntype: `HostActivitiesWebhookSettings`"
+        },
         "host_status_webhook": {
           "$ref": "#/$defs/HostStatusWebhookSettings",
           "description": "HostStatusWebhook can be nil to match the TeamSpec webhook settings\n\ntype: `HostStatusWebhookSettings`"
@@ -5979,6 +6055,10 @@
             "array",
             "null"
           ]
+        },
+        "managed_local_account_settings": {
+          "$ref": "#/$defs/ManagedLocalAccountSettings",
+          "description": "ManagedLocalAccountSettings configures the hidden managed local admin account created by\nfleetd on Windows hosts during Autopilot/OOBE enrollment.\n\ntype: `ManagedLocalAccountSettings`"
         }
       },
       "type": [


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #50694

- Added support for GitOps to parse `display_name` under `software.fleet_maintained_apps`
- Regenerated tools/gitops-auto-complete/generated-schema.json

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [x] Verified that the setting is exported via `fleetctl generate-gitops`
- [x] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
  - https://github.com/fleetdm/fleet/pull/50880
- [x] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Fleet-maintained apps configured through GitOps can now include a custom display name.
  - Display names are carried through to software package details and GitOps configuration assistance.

- **Bug Fixes**
  - GitOps now validates display-name length by character count and rejects names exceeding 255 characters.

- **Documentation**
  - Updated GitOps configuration guidance and schema support for operating system, policy, MDM, webhook, software, enrollment, and account settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->