### PR TITLE
Rename the custom activations setting to mdm.allow_custom_activations

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -995,10 +995,10 @@ type MDMConfig struct {
 	// EnableCustomDiskEncryption is a cross-platform alias for EnableCustomFileVault.
 	EnableCustomDiskEncryption bool `yaml:"enable_custom_disk_encryption"`
 	AllowAllDeclarations       bool `yaml:"allow_all_declarations"`
-	// EnableCustomActivations opts in to custom DDM activations. Off by default
+	// AllowCustomActivations opts in to custom DDM activations. Off by default
 	// because a predicate Fleet cannot validate can wedge a host's MDM
 	// subsystem beyond remote recovery -- see Apple FB24193230 and #50764.
-	EnableCustomActivations bool `yaml:"enable_custom_activations"`
+	AllowCustomActivations bool `yaml:"allow_custom_activations"`
 
 	// AllowOrbitEndUserAuthBypass controls whether an Orbit/fleetd host that does
 	// not complete end user authentication is allowed to enroll into a team that
@@ -1913,7 +1913,7 @@ func (man Manager) addConfigs() {
 	man.addConfigBool("mdm.enable_custom_filevault", false, "Allows usage of custom Apple MDM profiles for FileVault (Fleet Premium required)")
 	man.addConfigBool("mdm.enable_custom_disk_encryption", false, "Allows usage of custom Apple MDM profiles for FileVault and custom Windows profiles for BitLocker (Fleet Premium required)")
 	man.addConfigBool("mdm.allow_all_declarations", false, "Allows all MDM declaration types to be sent, bypassing safety checks")
-	man.addConfigBool("mdm.enable_custom_activations", false, "Allows custom activations to be uploaded for Apple declaration (DDM) profiles")
+	man.addConfigBool("mdm.allow_custom_activations", false, "Allows custom activations to be uploaded for Apple declaration (DDM) profiles")
 	man.addConfigBool("mdm.allow_orbit_end_user_auth_bypass", true, "Allow Orbit hosts that do not complete end user authentication to enroll into teams that require it; set to false to strictly enforce end user authentication for Orbit enrollments")
 	man.addConfigString("mdm.android_agent.package", "com.fleetdm.agent", "Package name for the Fleet Android agent")
 	man.addConfigString("mdm.android_agent.signing_sha256", "x+IyvrwVbQEBYV/ojWmLavJE0VIZE1RAT2JmxeI5sFw=", "Signing certificate SHA256 fingerprint for the Fleet Android agent")
@@ -2275,7 +2275,7 @@ func (man Manager) LoadConfig() FleetConfig {
 			EnableCustomFileVault:             man.getConfigBool("mdm.enable_custom_filevault"),
 			EnableCustomDiskEncryption:        man.getConfigBool("mdm.enable_custom_disk_encryption"),
 			AllowAllDeclarations:              man.getConfigBool("mdm.allow_all_declarations"),
-			EnableCustomActivations:           man.getConfigBool("mdm.enable_custom_activations"),
+			AllowCustomActivations:            man.getConfigBool("mdm.allow_custom_activations"),
 			AllowOrbitEndUserAuthBypass:       man.getConfigBool("mdm.allow_orbit_end_user_auth_bypass"),
 			AndroidAgent: AndroidAgentConfig{
 				Package:       man.getConfigString("mdm.android_agent.package"),

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -70,7 +70,7 @@ const (
 	ActivationUnsupportedManagementErrorMsg = "Activations are only supported for configuration declarations (com.apple.configuration.)."
 	ActivationEmptyFileErrorMsg             = "Activation must contain a declaration. To remove the activation, send an empty activation field."
 	ActivationConflictingPartsErrorMsg      = "Send either an activation file to replace it or an empty activation field to remove it, not both."
-	ActivationsDisabledErrorMsg             = "Custom activations aren't available. Set FLEET_MDM_ENABLE_CUSTOM_ACTIVATIONS=1 on the Fleet server to turn them on."
+	ActivationsDisabledErrorMsg             = "Custom activations aren't available. Set FLEET_MDM_ALLOW_CUSTOM_ACTIVATIONS=1 on the Fleet server to turn them on."
 )
 
 // TODO(HCA): Can we come up with a clearer name? This looks like any variables not in this slice is not supported,
@@ -978,7 +978,7 @@ func (svc *Service) validateActivation(ctx context.Context, activation []byte, c
 	// (Apple FB24193230). Until that's fixed, uploading an activation takes an
 	// explicit opt-in. Removing a stored activation deliberately doesn't reach
 	// here, so an operator can always undo one.
-	if !svc.config.MDM.EnableCustomActivations {
+	if !svc.config.MDM.AllowCustomActivations {
 		return nil, ctxerr.Wrap(ctx,
 			fleet.NewInvalidArgumentError("activation", ActivationsDisabledErrorMsg),
 			"custom activations are not enabled")

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -79,7 +79,7 @@ func setupAppleMDMService(t *testing.T, license *fleet.LicenseInfo, tweakCfg ...
 	cfg := config.TestConfig()
 	// Custom activations are opt-in on the server (#50764). Tests that exercise
 	// them need them on; pass a tweak to turn them back off.
-	cfg.MDM.EnableCustomActivations = true
+	cfg.MDM.AllowCustomActivations = true
 	for _, fn := range tweakCfg {
 		fn(&cfg)
 	}
@@ -10082,7 +10082,7 @@ func TestNewMDMAppleDeclarationWithActivation(t *testing.T) {
 	// the server explicitly opts in.
 	t.Run("activation is refused when the server hasn't enabled activations", func(t *testing.T) {
 		svc, ctx, ds, _ := setupAppleMDMService(t, &fleet.LicenseInfo{Tier: fleet.TierPremium},
-			func(c *config.FleetConfig) { c.MDM.EnableCustomActivations = false })
+			func(c *config.FleetConfig) { c.MDM.AllowCustomActivations = false })
 		ctx = viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{GlobalRole: new(fleet.RoleAdmin)}})
 		ds.NewMDMAppleDeclarationFunc = func(ctx context.Context, d *fleet.MDMAppleDeclaration, usesFleetVars []fleet.FleetVarName) (*fleet.MDMAppleDeclaration, error) {
 			return d, nil

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -208,7 +208,7 @@ func (s *integrationMDMTestSuite) SetupSuite() {
 	fleetCfg.MDM.AppleConnectJWT = "fake-token" // skip as we test VPP auth elsewhere
 	// Custom activations are opt-in on the server (#50764); the DDM suite covers
 	// them, so this suite runs with them on.
-	fleetCfg.MDM.EnableCustomActivations = true
+	fleetCfg.MDM.AllowCustomActivations = true
 	testCert, testKey, err := apple_mdm.NewSCEPCACertKey()
 	require.NoError(s.T(), err)
 	testCertPEM := tokenpki.PEMCertificate(testCert.Raw)


### PR DESCRIPTION
**Related issue:** Resolves #50764

Renames the setting added in #50863 from `mdm.enable_custom_activations` to `mdm.allow_custom_activations`, so it reads as the safety override it is — alongside `mdm.allow_all_declarations` — rather than as a feature toggle like the `mdm.enable_custom_*` settings.

The environment variable is now `FLEET_MDM_ALLOW_CUSTOM_ACTIVATIONS`, and the error text shown on a blocked upload was updated to match. Nothing has shipped with the old name, so no compatibility handling is needed.

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests

- [ ] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Renamed the MDM custom activation setting to `allow_custom_activations`.
  * Preserved the existing default value and behavior.

* **Bug Fixes**
  * Updated activation validation and error messaging to use the renamed setting consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->