### PR TITLE
Update apps.json when an FMA manifest's name or unique_identifier changes

### DIFF
--- a/cmd/maintained-apps/main.go
+++ b/cmd/maintained-apps/main.go
@@ -157,42 +157,61 @@ func updateAppsListFile(ctx context.Context, outApp *maintained_apps.FMAManifest
 		return ctxerr.Wrap(ctx, err, "unmarshaling output apps list file")
 	}
 
-	var found bool
-	for _, a := range outputAppsFile.Apps {
-		if a.Slug == outApp.Slug {
-			found = true
-			break
-		}
+	platform := outApp.Platform()
+	if platform == "" {
+		return ctxerr.New(ctx, fmt.Sprintf("invalid platform found for slug %s", outApp.Slug))
 	}
 
-	if !found {
-		platform := outApp.Platform()
-		if platform == "" {
-			return ctxerr.New(ctx, fmt.Sprintf("invalid platform found for slug %s", outApp.Slug))
-		}
-
+	var changed bool
+	idx := slices.IndexFunc(outputAppsFile.Apps, func(a maintained_apps.FMAListFileApp) bool { return a.Slug == outApp.Slug })
+	switch idx {
+	case -1:
 		outputAppsFile.Apps = append(outputAppsFile.Apps, maintained_apps.FMAListFileApp{
 			Name:             outApp.Name,
 			Slug:             outApp.Slug,
 			Platform:         platform,
 			UniqueIdentifier: outApp.UniqueIdentifier,
 		})
+		changed = true
 
 		// Keep existing order
 		slices.SortFunc(outputAppsFile.Apps, func(a, b maintained_apps.FMAListFileApp) int { return strings.Compare(a.Slug, b.Slug) })
-
-		var buf bytes.Buffer
-		encoder := json.NewEncoder(&buf)
-		encoder.SetEscapeHTML(false)
-		encoder.SetIndent("", "  ")
-		if err := encoder.Encode(outputAppsFile); err != nil {
-			return ctxerr.Wrap(ctx, err, "marshaling updated output apps file")
+	default:
+		// The app is already listed, but the input manifest is the source of truth for its
+		// identity fields, so pick up any edits to them. apps.json is what the Fleet server syncs
+		// into fleet_maintained_apps, so leaving a stale unique_identifier here ships the stale
+		// value even though the per-app manifest was regenerated. Description has no manifest
+		// counterpart, so it is left untouched.
+		existing := &outputAppsFile.Apps[idx]
+		if existing.Name != outApp.Name {
+			existing.Name = outApp.Name
+			changed = true
 		}
-		updatedFile := buf.Bytes()
-
-		if err := os.WriteFile(appListFilePath, updatedFile, 0o644); err != nil {
-			return ctxerr.Wrap(ctx, err, "writing updated output apps file")
+		if existing.UniqueIdentifier != outApp.UniqueIdentifier {
+			existing.UniqueIdentifier = outApp.UniqueIdentifier
+			changed = true
 		}
+		if existing.Platform != platform {
+			existing.Platform = platform
+			changed = true
+		}
+	}
+
+	if !changed {
+		return nil
+	}
+
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(outputAppsFile); err != nil {
+		return ctxerr.Wrap(ctx, err, "marshaling updated output apps file")
+	}
+	updatedFile := buf.Bytes()
+
+	if err := os.WriteFile(appListFilePath, updatedFile, 0o644); err != nil {
+		return ctxerr.Wrap(ctx, err, "writing updated output apps file")
 	}
 
 	return nil

--- a/cmd/maintained-apps/main_test.go
+++ b/cmd/maintained-apps/main_test.go
@@ -3,8 +3,13 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"os"
+	"path"
 	"strings"
 	"testing"
+
+	maintained_apps "github.com/fleetdm/fleet/v4/ee/maintained-apps"
+	"github.com/stretchr/testify/require"
 )
 
 func TestJSONEncoderPreservesHTML(t *testing.T) {
@@ -44,4 +49,151 @@ func TestJSONEncoderPreservesHTML(t *testing.T) {
 	}
 
 	t.Logf("Successfully preserved HTML in JSON output: %s", result)
+}
+
+// existingAppsList is written in compact form so that any rewrite of the file is detectable: the
+// encoder in updateAppsListFile always emits indented JSON with a trailing newline.
+const existingAppsList = `{"version":2,"apps":[` +
+	`{"name":"Docker Desktop","slug":"docker-desktop/darwin","platform":"darwin","unique_identifier":"com.docker.docker","description":"Containers & microservices — <b>fast</b>."},` +
+	`{"name":"Zoom","slug":"zoom/darwin","platform":"darwin","unique_identifier":"us.zoom.xos","description":"Zoom is a video conferencing tool."}` +
+	`]}`
+
+// setupAppsListFile makes a temp directory the working directory and seeds it with an apps.json
+// holding the given contents, since updateAppsListFile resolves its path relative to the CWD.
+func setupAppsListFile(t *testing.T, contents string) string {
+	t.Helper()
+
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(path.Join(root, maintained_apps.OutputPath), 0o755))
+	t.Chdir(root)
+
+	appListFilePath := path.Join(maintained_apps.OutputPath, "apps.json")
+	require.NoError(t, os.WriteFile(appListFilePath, []byte(contents), 0o644))
+
+	return appListFilePath
+}
+
+func readAppsListFile(t *testing.T, appListFilePath string) (maintained_apps.FMAListFile, string) {
+	t.Helper()
+
+	rawBytes, err := os.ReadFile(appListFilePath)
+	require.NoError(t, err)
+
+	var appsList maintained_apps.FMAListFile
+	require.NoError(t, json.Unmarshal(rawBytes, &appsList))
+
+	return appsList, string(rawBytes)
+}
+
+// requireAppsListNotWritten asserts apps.json was left alone. The seeded file is compact, while
+// every write from updateAppsListFile emits indented JSON, so the absence of newlines means no
+// rewrite happened. (A JSON-equality comparison can't show this: a rewrite is semantically equal.)
+func requireAppsListNotWritten(t *testing.T, appListFilePath string) {
+	t.Helper()
+
+	rawBytes, err := os.ReadFile(appListFilePath)
+	require.NoError(t, err)
+	require.NotContains(t, string(rawBytes), "\n")
+	require.Len(t, rawBytes, len(existingAppsList))
+}
+
+func TestUpdateAppsListFile(t *testing.T) {
+	// Cannot run t.Parallel(): these subtests t.Chdir.
+
+	t.Run("new app is appended", func(t *testing.T) {
+		appListFilePath := setupAppsListFile(t, existingAppsList)
+
+		err := updateAppsListFile(t.Context(), &maintained_apps.FMAManifestApp{
+			Name:             "Firefox",
+			Slug:             "firefox/darwin",
+			UniqueIdentifier: "org.mozilla.firefox",
+		})
+		require.NoError(t, err)
+
+		appsList, raw := readAppsListFile(t, appListFilePath)
+		require.Equal(t, 2, appsList.Version)
+		require.Len(t, appsList.Apps, 3)
+
+		// Sorted by slug.
+		require.Equal(t, []string{"docker-desktop/darwin", "firefox/darwin", "zoom/darwin"}, []string{
+			appsList.Apps[0].Slug, appsList.Apps[1].Slug, appsList.Apps[2].Slug,
+		})
+		require.Equal(t, maintained_apps.FMAListFileApp{
+			Name:             "Firefox",
+			Slug:             "firefox/darwin",
+			Platform:         "darwin",
+			UniqueIdentifier: "org.mozilla.firefox",
+		}, appsList.Apps[1])
+
+		// Existing entries, including descriptions (which have no manifest counterpart), are
+		// untouched, and non-ASCII/HTML characters are not escaped.
+		require.Equal(t, "Containers & microservices — <b>fast</b>.", appsList.Apps[0].Description)
+		require.Equal(t, "Zoom is a video conferencing tool.", appsList.Apps[2].Description)
+		require.Contains(t, raw, "Containers & microservices — <b>fast</b>.")
+		require.NotContains(t, raw, `\u`)
+	})
+
+	t.Run("existing app with a changed unique_identifier is updated", func(t *testing.T) {
+		appListFilePath := setupAppsListFile(t, existingAppsList)
+
+		err := updateAppsListFile(t.Context(), &maintained_apps.FMAManifestApp{
+			Name:             "Docker Desktop",
+			Slug:             "docker-desktop/darwin",
+			UniqueIdentifier: "com.electron.dockerdesktop",
+		})
+		require.NoError(t, err)
+
+		appsList, _ := readAppsListFile(t, appListFilePath)
+		require.Len(t, appsList.Apps, 2)
+		require.Equal(t, maintained_apps.FMAListFileApp{
+			Name:             "Docker Desktop",
+			Slug:             "docker-desktop/darwin",
+			Platform:         "darwin",
+			UniqueIdentifier: "com.electron.dockerdesktop",
+			Description:      "Containers & microservices — <b>fast</b>.",
+		}, appsList.Apps[0])
+		require.Equal(t, "us.zoom.xos", appsList.Apps[1].UniqueIdentifier)
+	})
+
+	t.Run("existing app with a changed name is updated", func(t *testing.T) {
+		appListFilePath := setupAppsListFile(t, existingAppsList)
+
+		err := updateAppsListFile(t.Context(), &maintained_apps.FMAManifestApp{
+			Name:             "Zoom Workplace",
+			Slug:             "zoom/darwin",
+			UniqueIdentifier: "us.zoom.xos",
+		})
+		require.NoError(t, err)
+
+		appsList, _ := readAppsListFile(t, appListFilePath)
+		require.Len(t, appsList.Apps, 2)
+		require.Equal(t, "Zoom Workplace", appsList.Apps[1].Name)
+		require.Equal(t, "us.zoom.xos", appsList.Apps[1].UniqueIdentifier)
+	})
+
+	t.Run("unchanged app is not written", func(t *testing.T) {
+		appListFilePath := setupAppsListFile(t, existingAppsList)
+
+		err := updateAppsListFile(t.Context(), &maintained_apps.FMAManifestApp{
+			Name:             "Zoom",
+			Slug:             "zoom/darwin",
+			UniqueIdentifier: "us.zoom.xos",
+		})
+		require.NoError(t, err)
+
+		requireAppsListNotWritten(t, appListFilePath)
+	})
+
+	t.Run("slug without a platform is rejected", func(t *testing.T) {
+		appListFilePath := setupAppsListFile(t, existingAppsList)
+
+		err := updateAppsListFile(t.Context(), &maintained_apps.FMAManifestApp{
+			Name:             "Firefox",
+			Slug:             "firefox",
+			UniqueIdentifier: "org.mozilla.firefox",
+		})
+		require.ErrorContains(t, err, "invalid platform found for slug firefox")
+
+		requireAppsListNotWritten(t, appListFilePath)
+	})
 }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Related to #50875 (this is the tooling fix behind the hand-edit that issue required; it does not resolve it)

`updateAppsListFile` in `cmd/maintained-apps/main.go` looked up the app by slug and, on a match, returned without writing anything:

```go
var found bool
for _, a := range outputAppsFile.Apps {
    if a.Slug == outApp.Slug { found = true; break }
}
if !found { /* append + write */ }
```

So editing `unique_identifier` (or `name`) in an input manifest under `ee/maintained-apps/inputs/` and re-running `go run ./cmd/maintained-apps -slug <slug>` regenerated `outputs/<slug>/<platform>.json` but silently left `ee/maintained-apps/outputs/apps.json` carrying the **old** identifier. `apps.json` is what the Fleet server syncs into `fleet_maintained_apps`, so the stale value is the one that ships. Fixing the Docker Desktop bundle identifier (#50875) required hand-editing `apps.json`.

## What changed

- Existing entries are now reconciled against the manifest — `name`, `unique_identifier`, and `platform` are updated when they differ — instead of short-circuiting on a slug match.
- The write happens once, after the branch, and only when something actually changed, so a no-op run still doesn't touch the file.
- Platform validation moved above the branch since both paths need it. For an existing entry the slug already matched a well-formed one, so this can't newly fail in practice.
- `description` is deliberately left untouched: it's the one field on `FMAListFileApp` with no counterpart on `FMAManifestApp`, so treating the manifest as the source of truth for it would wipe all 1396 descriptions.
- Slug sort order and `encoder.SetEscapeHTML(false)` are unchanged, so diffs stay additions/edits-only and non-ASCII characters in descriptions aren't escaped.

## Notes for the reviewer

- **Frozen apps.** `updateAppsListFile` is called for frozen apps too (before the `app.Frozen` write guard). That's correct here: both ingesters take `name`/`unique_identifier` from the input manifest, not from upstream brew/winget, so a frozen app's identity fields should still track the manifest even though its version data stays pinned.
- **No empty-value guard.** Both ingesters reject a manifest with an empty `unique_identifier` or `name` at parse time (`ingesters/homebrew/ingester.go:71`, `ingesters/winget/ingester.go:76`), so an update can't blank out a populated field.
- **No changes file** — dev tooling only, no user-visible behavior change.

Verified end-to-end against the real 1396-entry `apps.json`: a no-op call leaves it byte-identical, and a changed identifier yields exactly a one-line diff with no formatting or escaping churn elsewhere.

```
@@ -2630,7 +2630,7 @@
       "name": "Docker Desktop",
       "slug": "docker-desktop/darwin",
       "platform": "darwin",
-      "unique_identifier": "com.electron.dockerdesktop",
+      "unique_identifier": "com.docker.docker",
       "description": "Docker Desktop provides a seamless environment for ...",
```

# Checklist for submitter

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information. — N/A, dev tooling only

## Testing

- [x] Added/updated automated tests

`TestUpdateAppsListFile` in `cmd/maintained-apps/main_test.go` seeds a temp working directory (the function resolves `apps.json` relative to the CWD) and covers:

- new app appended in slug order, with existing descriptions and non-ASCII/HTML characters preserved
- existing app with a changed `unique_identifier` updated
- existing app with a changed `name` updated
- unchanged app produces no write
- slug without a platform rejected, with no write

The two update subtests fail against the pre-fix `main.go` and pass with it; the others pass under both.

One note on the no-write assertion: it compares raw formatting rather than using `require.JSONEq`, which testifylint suggests. `JSONEq` would pass even when the file *was* rewritten, since a rewrite is semantically identical JSON. The reasoning is recorded in a comment on `requireAppsListNotWritten`.

- [x] QA'd all new/changed functionality manually

`make lint-go-incremental` is clean; `go test ./cmd/maintained-apps/...` passes.
