### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/cisco-jabber/darwin.json
+++ b/ee/maintained-apps/outputs/cisco-jabber/darwin.json
@@ -7,10 +7,10 @@
         "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.cisco.jabber' AND version_compare(bundle_short_version, '15.2.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.cisco.jabber');"
       },
-      "installer_url": "https://binaries.webex.com/jabberclientmac/20260722023311/Install_Cisco-Jabber-Mac.pkg",
+      "installer_url": "https://binaries.webex.com/jabberclientmac/20260122074039/Install_Cisco-Jabber-Mac.pkg",
       "install_script_ref": "edbec29c",
       "uninstall_script_ref": "fe0e9261",
-      "sha256": "bb71f8686049930033710f88698712e6aee6ed469516f3a73e48df8cecda4d61",
+      "sha256": "5644700e420febc1eca304c0a0f24bcff1e64b424112e1beda025d2eb78e16de",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/cisco-jabber/darwin.json
+++ b/ee/maintained-apps/outputs/cisco-jabber/darwin.json
@@ -7,10 +7,10 @@
         "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.cisco.jabber' AND version_compare(bundle_short_version, '15.2.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.cisco.jabber');"
       },
-      "installer_url": "https://binaries.webex.com/jabberclientmac/20260122074039/Install_Cisco-Jabber-Mac.pkg",
+      "installer_url": "https://binaries.webex.com/jabberclientmac/20260722023311/Install_Cisco-Jabber-Mac.pkg",
       "install_script_ref": "edbec29c",
       "uninstall_script_ref": "fe0e9261",
-      "sha256": "5644700e420febc1eca304c0a0f24bcff1e64b424112e1beda025d2eb78e16de",
+      "sha256": "bb71f8686049930033710f88698712e6aee6ed469516f3a73e48df8cecda4d61",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/downie/darwin.json
+++ b/ee/maintained-apps/outputs/downie/darwin.json
@@ -7,10 +7,10 @@
         "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.charliemonroe.Downie-4' AND version_compare(bundle_short_version, '4.12.12') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.charliemonroe.Downie-4');"
       },
-      "installer_url": "https://software.charliemonroe.net/trial/downie/v4/Downie_4_5229.dmg",
+      "installer_url": "https://software.charliemonroe.net/trial/downie/v4/Downie_4_5231.dmg",
       "install_script_ref": "4f6dd0e2",
       "uninstall_script_ref": "24e71e3c",
-      "sha256": "86ded4981846e81b32f9eddb7658f8705b4ba74f88b3b53192db1bc2bd84f798",
+      "sha256": "d715a8c0bb903dd5113d5b5069f60e561bea97add695a4bd034a97d4e7634f64",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/firefox@nightly/darwin.json
+++ b/ee/maintained-apps/outputs/firefox@nightly/darwin.json
@@ -4,13 +4,13 @@
       "version": "155.0a1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15526.8.9') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15526.8.10') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'org.mozilla.nightly');"
       },
-      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/08/2026-08-09-21-46-38-mozilla-central/firefox-155.0a1.en-US.mac.dmg",
+      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/08/2026-08-10-09-30-15-mozilla-central/firefox-155.0a1.en-US.mac.dmg",
       "install_script_ref": "d9c4cf87",
       "uninstall_script_ref": "0661f848",
-      "sha256": "948e5d6d5d1df11598e447a790a5ffdfe4977bc9d0a0207412260f9f46a4f8fa",
+      "sha256": "d71c1e39201452b3b6f46a671b264e61603ae6983609da4f37620b3651564749",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/goland/darwin.json
+++ b/ee/maintained-apps/outputs/goland/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "2026.2.0.1",
+      "version": "2026.2.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.goland';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.goland' AND version_compare(bundle_short_version, '2026.2.0.1') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.goland' AND version_compare(bundle_short_version, '2026.2.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.jetbrains.goland');"
       },
-      "installer_url": "https://download.jetbrains.com/go/goland-2026.2.0.1-aarch64.dmg",
+      "installer_url": "https://download.jetbrains.com/go/goland-2026.2.1-aarch64.dmg",
       "install_script_ref": "d74419ae",
       "uninstall_script_ref": "beccbf96",
-      "sha256": "ceb400b0e391e0e8405e779bc27464ddd6b88781a2d2df1ff9221a1008b03344",
+      "sha256": "0c8a472efb13c61f60cbda06345ffd97675a997d14ac6a7f8abdb5c5c0759251",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/grammarly-desktop/darwin.json
+++ b/ee/maintained-apps/outputs/grammarly-desktop/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.181.2",
+      "version": "1.182.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama' AND version_compare(bundle_short_version, '1.181.2') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama' AND version_compare(bundle_short_version, '1.182.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.grammarly.ProjectLlama');"
       },
-      "installer_url": "https://download-mac.grammarly.com/versions/1.181.2.0/Grammarly.dmg",
+      "installer_url": "https://download-mac.grammarly.com/versions/1.182.0.0/Grammarly.dmg",
       "install_script_ref": "8274b7dd",
       "uninstall_script_ref": "7dff0961",
-      "sha256": "b9042477a8210f723a268d02b43980af562bde66064827f21e4ed5e86bbe5dfe",
+      "sha256": "3616e9cf9c9ed9e3c7ba00953a8532a142a2ddd3fc5f3608d4d82675244aa72c",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/intellij-idea/darwin.json
+++ b/ee/maintained-apps/outputs/intellij-idea/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "2026.2.0.1",
+      "version": "2026.2.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.intellij';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.intellij' AND version_compare(bundle_short_version, '2026.2.0.1') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.intellij' AND version_compare(bundle_short_version, '2026.2.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.jetbrains.intellij');"
       },
-      "installer_url": "https://download.jetbrains.com/idea/ideaIU-2026.2.0.1-aarch64.dmg",
+      "installer_url": "https://download.jetbrains.com/idea/ideaIU-2026.2.1-aarch64.dmg",
       "install_script_ref": "b853eec2",
       "uninstall_script_ref": "2a100e79",
-      "sha256": "bcddb055a33957d1f95e7ae3bfd308293d0f812250aab9399164163aa118399f",
+      "sha256": "b9c521ba766f7e5372e9d05f6d68442ada13f34ce758af318ca21f017c0bb19f",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/maccy/darwin.json
+++ b/ee/maintained-apps/outputs/maccy/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "2.7.0",
+      "version": "2.7.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.p0deje.Maccy';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.p0deje.Maccy' AND version_compare(bundle_short_version, '2.7.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.p0deje.Maccy' AND version_compare(bundle_short_version, '2.7.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'org.p0deje.Maccy');"
       },
-      "installer_url": "https://github.com/p0deje/Maccy/releases/download/2.7.0/Maccy.app.zip",
+      "installer_url": "https://github.com/p0deje/Maccy/releases/download/2.7.1/Maccy.app.zip",
       "install_script_ref": "624a6947",
       "uninstall_script_ref": "a8ff99d4",
-      "sha256": "9e2ff4393059a71dcdcd27c5d111de31673080ae2c18fec44ba65c1ab264383c",
+      "sha256": "f388aee34de09a0c7531631303785d9938bef9a92130e21ce1049c8f56aad077",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/marked-app/darwin.json
+++ b/ee/maintained-apps/outputs/marked-app/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "3.1.19",
+      "version": "3.1.20",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.brettterpstra.marked';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.brettterpstra.marked' AND version_compare(bundle_short_version, '3.1.19') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.brettterpstra.marked' AND version_compare(bundle_short_version, '3.1.20') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.brettterpstra.marked');"
       },
-      "installer_url": "https://updates.markedapp.com/updates/Marked%203.1.19-1202.zip",
+      "installer_url": "https://updates.markedapp.com/updates/Marked%203.1.20-1204.zip",
       "install_script_ref": "23ea6da3",
       "uninstall_script_ref": "57b4bcf2",
-      "sha256": "bc2f0d38b54c8937ceb1d00f2c5046c2e9fb3347378292ff161cd392a0f03b63",
+      "sha256": "346e8e1b01f8165d65ab50a40abc708e3d2ee01c030f2e5bf72338bac09bc25c",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/microsoft-edge/darwin.json
+++ b/ee/maintained-apps/outputs/microsoft-edge/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "151.0.4129.72",
+      "version": "151.0.4129.78",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.edgemac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.edgemac' AND version_compare(bundle_short_version, '151.0.4129.72') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.edgemac' AND version_compare(bundle_short_version, '151.0.4129.78') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.microsoft.edgemac');"
       },
-      "installer_url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/9153ab01-16c7-4aef-a5ca-0a99e41c6a3e/MicrosoftEdge-151.0.4129.72.dmg",
+      "installer_url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/22fc461b-2c80-45d5-bbb6-613d00dbc8fb/MicrosoftEdge-151.0.4129.78.dmg",
       "install_script_ref": "4c051c40",
       "uninstall_script_ref": "afe8f338",
-      "sha256": "fb9915a53d469a983f4fa5a37a26e98a2e32375c1d7be6ba8d71b392ebcebfc3",
+      "sha256": "0d4b2511cf490765e32579c3025f461f6b78c6e5dc40c112834602cc4db8a9bb",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/nordpass/darwin.json
+++ b/ee/maintained-apps/outputs/nordpass/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "7.9.4",
+      "version": "7.9.5",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.nordsec.nordpass';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.nordsec.nordpass' AND version_compare(bundle_short_version, '7.9.4') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.nordsec.nordpass' AND version_compare(bundle_short_version, '7.9.5') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.nordsec.nordpass');"
       },
       "installer_url": "https://downloads.npass.app/mac/arm/NordPass.dmg",

--- a/ee/maintained-apps/outputs/ollama/darwin.json
+++ b/ee/maintained-apps/outputs/ollama/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "0.32.6",
+      "version": "0.32.7",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.ollama';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.ollama' AND version_compare(bundle_short_version, '0.32.6') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.ollama' AND version_compare(bundle_short_version, '0.32.7') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.electron.ollama');"
       },
-      "installer_url": "https://github.com/ollama/ollama/releases/download/v0.32.6/Ollama-darwin.zip",
+      "installer_url": "https://github.com/ollama/ollama/releases/download/v0.32.7/Ollama-darwin.zip",
       "install_script_ref": "dd889e18",
       "uninstall_script_ref": "ecec947d",
-      "sha256": "cc708ee7a9366b73b97d3f2999e25bb24b0a86feb41a0d2ced784ff4d4855e6d",
+      "sha256": "2dbf637dd0e9bd1bff58cceef021b6b300b33e200e450ed21710200427d50996",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/portfolioperformance/windows.json
+++ b/ee/maintained-apps/outputs/portfolioperformance/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "0.86.0",
+      "version": "0.86.1",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Portfolio Performance' AND publisher = 'Andreas Buchen';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Portfolio Performance' AND publisher = 'Andreas Buchen' AND version_compare(version, '0.86.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Portfolio Performance' AND publisher = 'Andreas Buchen' AND version_compare(version, '0.86.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'portfolioperformance.exe');"
       },
-      "installer_url": "https://github.com/portfolio-performance/portfolio/releases/download/0.86.0/PortfolioPerformance-0.86.0-setup.exe",
+      "installer_url": "https://github.com/portfolio-performance/portfolio/releases/download/0.86.1/PortfolioPerformance-0.86.1-setup.exe",
       "install_script_ref": "efa25f6a",
       "uninstall_script_ref": "1d78c875",
-      "sha256": "eb7fd19031ee54864d8d05cc98c71e63a465cf4fc9543e2b1446ae0ee6dff876",
+      "sha256": "d8bf1c79c69defa219c59d35f288e573ee4378583769691e478581979f540f12",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/sabnzbd/darwin.json
+++ b/ee/maintained-apps/outputs/sabnzbd/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "5.0.4",
+      "version": "5.1.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.sabnzbd.sabnzbd';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.sabnzbd.sabnzbd' AND version_compare(bundle_short_version, '5.0.4') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.sabnzbd.sabnzbd' AND version_compare(bundle_short_version, '5.1.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'org.sabnzbd.sabnzbd');"
       },
-      "installer_url": "https://github.com/sabnzbd/sabnzbd/releases/download/5.0.4/SABnzbd-5.0.4-macos.dmg",
+      "installer_url": "https://github.com/sabnzbd/sabnzbd/releases/download/5.1.0/SABnzbd-5.1.0-macos.dmg",
       "install_script_ref": "cef073f6",
       "uninstall_script_ref": "8b107d86",
-      "sha256": "a926acfc8bc4004f705c54f67682e8e12cf09195f6a140d96c10c9ec215ad1f1",
+      "sha256": "ac7ba4bd3a561b07e82d7e3ab774f802c74c623cfab758026a0ecce0689b1777",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/surge/darwin.json
+++ b/ee/maintained-apps/outputs/surge/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "6.8.0",
+      "version": "6.8.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.nssurge.surge-mac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.nssurge.surge-mac' AND version_compare(bundle_short_version, '6.8.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.nssurge.surge-mac' AND version_compare(bundle_short_version, '6.8.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.nssurge.surge-mac');"
       },
-      "installer_url": "https://dl.nssurge.com/mac/v6/Surge-6.8.0-11990-f036c2c1b04dd8ce81d8aec114ccfdcf.zip",
+      "installer_url": "https://dl.nssurge.com/mac/v6/Surge-6.8.1-12010-eb73e613f5ff5c87c5422ca691ce136d.zip",
       "install_script_ref": "591d4936",
       "uninstall_script_ref": "73bb9941",
-      "sha256": "fa4391417cca53a1efba5c67944af28c28445ac314c1bdf53d99c0314863e125",
+      "sha256": "ad975f4869632b1cb8808c020bdb0a39a239f05edf6fc5088ce08068efc7efb5",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated macOS installer details and checksums for Cisco Jabber, Downie, Firefox Nightly, GoLand, Grammarly Desktop, IntelliJ IDEA, Maccy, Marked, Microsoft Edge, NordPass, Ollama, SABnzbd, and Surge.
  * Updated Portfolio Performance for Windows to version 0.86.1.
  * Added support for the latest available app releases, improving version detection and installation reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->