### PR TITLE
check local MDM enrollment status before firing MDM migration webhook…

### DIFF
--- a/orbit/changes/49889-account-for-local-state-before-firing-webhook
+++ b/orbit/changes/49889-account-for-local-state-before-firing-webhook
@@ -1,0 +1,1 @@
+- Check local MDM enrollment status on macOS before firing Migrate MDM webhook to prevent showing an error.

--- a/orbit/pkg/profiles/profiles_darwin.go
+++ b/orbit/pkg/profiles/profiles_darwin.go
@@ -130,10 +130,10 @@ func IsEnrolledInMDM() (bool, string, error) {
 // ParseMDMEnrollmentStatus runs the `profiles` command to get the current MDM
 // enrollment information and reports if the host is enrolled via DEP or not.
 // Which is used to check for manual enrollment or not.
-func ParseMDMEnrollmentStatus() (enrolledViaDEP bool, err error) {
+func ParseMDMEnrollmentStatus() (enrolledViaDEP bool, isEnrolled bool, err error) {
 	out, err := getMDMInfoFromProfilesCmd()
 	if err != nil {
-		return false, fmt.Errorf("calling /usr/bin/profiles: %w", err)
+		return false, false, fmt.Errorf("calling /usr/bin/profiles: %w", err)
 	}
 
 	// The output of the command is in the form:
@@ -151,14 +151,20 @@ func ParseMDMEnrollmentStatus() (enrolledViaDEP bool, err error) {
 	// 2. The first row contains "Yes" or "No"
 	lines := bytes.Split(bytes.TrimSpace(out), []byte("\n"))
 	if len(lines) < 2 {
-		return false, fmt.Errorf("Got %d lines of output, when expected at least 2 or more", len(lines))
+		return false, false, fmt.Errorf("Got %d lines of output, when expected at least 2 or more", len(lines))
 	}
 
+	var isDepEnrolled bool
 	if strings.Contains(string(lines[0]), "Yes") {
-		return true, nil
+		isDepEnrolled = true
 	}
 
-	return false, nil
+	var isMDMEnrolled bool
+	if strings.Contains(string(lines[1]), "Yes") {
+		isMDMEnrolled = true
+	}
+
+	return isDepEnrolled, isMDMEnrolled, nil
 }
 
 // getMDMInfoFromProfilesCmd is declared as a variable so it can be overwritten by tests.

--- a/orbit/pkg/profiles/profiles_darwin_test.go
+++ b/orbit/pkg/profiles/profiles_darwin_test.go
@@ -331,16 +331,17 @@ func TestParseMDMEnrollmentStatus(t *testing.T) {
 	cases := []struct {
 		cmdOut  *string
 		cmdErr  error
-		want    bool
+		wantDEP bool
+		wantMDM bool
 		wantErr bool
 	}{
-		{nil, errors.New("test error"), false, true},
-		{ptr.String(""), nil, false, true},
-		{ptr.String("Enrolled via DEP: No\nMDM Enrollment: No"), nil, false, false},
-		{ptr.String("Enrolled via DEP: Yes\nMDM Enrollment: No"), nil, true, false},
-		{ptr.String("Enrolled via DEP: No\nMDM Enrollment: Yes (User Approved)"), nil, false, false},
-		{ptr.String("Enrolled via DEP: No\nMDM Enrollment: Yes (User Approved)\nMDM Server: https://mdm.example.com"), nil, false, false},
-		{ptr.String("Enrolled via DEP: Yes\nMDM Enrollment: Yes\nMDM Server: https://mdm.example.com"), nil, true, false},
+		{nil, errors.New("test error"), false, false, true},
+		{ptr.String(""), nil, false, false, true},
+		{ptr.String("Enrolled via DEP: No\nMDM Enrollment: No"), nil, false, false, false},
+		{ptr.String("Enrolled via DEP: Yes\nMDM Enrollment: No"), nil, true, false, false},
+		{ptr.String("Enrolled via DEP: No\nMDM Enrollment: Yes (User Approved)"), nil, false, true, false},
+		{ptr.String("Enrolled via DEP: No\nMDM Enrollment: Yes (User Approved)\nMDM Server: https://mdm.example.com"), nil, false, true, false},
+		{ptr.String("Enrolled via DEP: Yes\nMDM Enrollment: Yes\nMDM Server: https://mdm.example.com"), nil, true, true, false},
 	}
 
 	origCmd := getMDMInfoFromProfilesCmd
@@ -356,13 +357,14 @@ func TestParseMDMEnrollmentStatus(t *testing.T) {
 			return buf.Bytes(), nil
 		}
 
-		got, err := ParseMDMEnrollmentStatus()
+		gotDEP, gotMDM, err := ParseMDMEnrollmentStatus()
 		if c.wantErr {
 			require.Error(t, err)
 		} else {
 			require.NoError(t, err)
 		}
-		require.Equal(t, c.want, got)
+		require.Equal(t, c.wantDEP, gotDEP)
+		require.Equal(t, c.wantMDM, gotMDM)
 	}
 }
 

--- a/orbit/pkg/useraction/mdm_migration_darwin.go
+++ b/orbit/pkg/useraction/mdm_migration_darwin.go
@@ -240,6 +240,8 @@ type swiftDialogMDMMigrator struct {
 	// showCh is shared with the offline watcher and used to ensure only one dialog is open at a time
 	showCh chan struct{}
 
+	// testParseEnrollmentStatusFn is used in tests to mock profiles.ParseMDMEnrollmentStatus
+	testParseEnrollmentStatusFn func() (bool, bool, error)
 	// testEnrollmentCheckFileFn is used in tests to mock the call to verify
 	// the enrollment status of the host
 	testEnrollmentCheckFileFn func() (bool, error)
@@ -412,7 +414,13 @@ func (m *swiftDialogMDMMigrator) waitForUnenrollment(isADEMigration bool) error 
 
 func (m *swiftDialogMDMMigrator) renderMigration() error {
 	log.Debug().Msg("checking current enrollment status")
-	enrolledViaDEP, err := profiles.ParseMDMEnrollmentStatus()
+	var enrolledViaDEP, mdmEnrolled bool
+	var err error
+	if m.testParseEnrollmentStatusFn != nil {
+		enrolledViaDEP, mdmEnrolled, err = m.testParseEnrollmentStatusFn()
+	} else {
+		enrolledViaDEP, mdmEnrolled, err = profiles.ParseMDMEnrollmentStatus()
+	}
 	if err != nil {
 		return err
 	}
@@ -473,21 +481,25 @@ func (m *swiftDialogMDMMigrator) renderMigration() error {
 			// show the loading spinner
 			m.renderLoadingSpinner(isPreSonoma, isManualMigration)
 
-			// send the API call
-			if notifyErr := m.handler.NotifyRemote(); notifyErr != nil {
-				m.baseDialog.Exit()
-				errDialogExitChan, errDialogErrChan := m.renderError()
-				select {
-				case <-errDialogExitChan:
-					// return the error after showing the
-					// dialog so it can be caught upstream.
-					return notifyErr
-				case err := <-errDialogErrChan:
-					return fmt.Errorf("rendering error dialog: %w", err)
+			if mdmEnrolled {
+				// send the API call
+				if notifyErr := m.handler.NotifyRemote(); notifyErr != nil {
+					m.baseDialog.Exit()
+					errDialogExitChan, errDialogErrChan := m.renderError()
+					select {
+					case <-errDialogExitChan:
+						// return the error after showing the
+						// dialog so it can be caught upstream.
+						return notifyErr
+					case err := <-errDialogErrChan:
+						return fmt.Errorf("rendering error dialog: %w", err)
+					}
 				}
+				log.Info().Msg("webhook sent, checking for unenrollment")
+			} else {
+				log.Info().Msg("device is not enrolled in MDM locally, skipping webhook")
 			}
 
-			log.Info().Msg("webhook sent, checking for unenrollment")
 			if err := m.waitForUnenrollment(isADEMigration); err != nil {
 				m.baseDialog.Exit()
 				errDialogExitChan, errDialogErrChan := m.renderError()

--- a/orbit/pkg/useraction/mdm_migration_darwin_test.go
+++ b/orbit/pkg/useraction/mdm_migration_darwin_test.go
@@ -182,6 +182,11 @@ func TestShouldSendWebhookUntilUnmanaged(t *testing.T) {
 				},
 			}
 
+			// Mock the initial enrollment status check - device is enrolled
+			m.testParseEnrollmentStatusFn = func() (bool, bool, error) {
+				return typ == constant.MDMMigrationTypeADE, true, nil
+			}
+
 			// Set up enrollment check functions - device stays enrolled throughout
 			m.testEnrollmentCheckFileFn = func() (bool, error) {
 				return true, nil // Always enrolled (file exists)
@@ -259,6 +264,18 @@ func TestShouldSendWebhookUntilUnmanaged(t *testing.T) {
 			// Should succeed without error
 			require.NoError(t, err)
 			require.Equal(t, 3, handler.TimeCalled) // webhook was not called
+
+			// Device is locally not enrolled - should also skip webhook even if IsUnmanaged is false
+			m.props.IsUnmanaged = false
+			m.testParseEnrollmentStatusFn = func() (bool, bool, error) {
+				return false, false, nil // not enrolled locally
+			}
+
+			mockDialog.exitWithCode(0)
+			err = m.renderMigration()
+
+			require.NoError(t, err)
+			require.Equal(t, 3, handler.TimeCalled) // webhook was NOT called
 		})
 	}
 }


### PR DESCRIPTION
Cherry pick of #50866

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #49889 

It now jumps directly to the My Device page if the migration flow sees the device being unmanaged locally, even if Fleet carries stale data.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
See [Changes
files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

## fleetd/orbit/Fleet Desktop

- [x] Verified compatibility with the latest released version of Fleet (see [Must
rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [x] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [x] Verified that fleetd runs on macOS, Linux and Windows
- [x] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
* Improved macOS MDM migration handling by checking the device’s local enrollment status before sending migration webhook notifications.
* Webhook notifications are now skipped when the device is not locally enrolled, preventing unnecessary migration events.
  * Improved detection of separate DEP and MDM enrollment states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
