### PR TITLE
Recover vulnerability counts after interrupted table swaps

### DIFF
--- a/changes/45100-vulnerability-host-count-swap-recovery
+++ b/changes/45100-vulnerability-host-count-swap-recovery
@@ -1,0 +1,1 @@
+- Made vulnerability host count updates recover automatically after an interrupted table swap.

--- a/server/datastore/mysql/vulnerabilities.go
+++ b/server/datastore/mysql/vulnerabilities.go
@@ -817,7 +817,12 @@ func (ds *Datastore) atomicTableSwapVulnerabilityCounts(ctx context.Context, cou
 
 	// Atomic table swap using RENAME TABLE
 	return ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
-		_, err := tx.ExecContext(ctx, fmt.Sprintf(`
+		_, err := tx.ExecContext(ctx, "DROP TABLE IF EXISTS vulnerability_host_counts_old")
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "dropping stale old table")
+		}
+
+		_, err = tx.ExecContext(ctx, fmt.Sprintf(`
 			RENAME TABLE
 				vulnerability_host_counts TO vulnerability_host_counts_old,
 				%s TO vulnerability_host_counts

--- a/server/datastore/mysql/vulnerabilities_test.go
+++ b/server/datastore/mysql/vulnerabilities_test.go
@@ -3,9 +3,11 @@ package mysql
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 	"time"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	common_mysql "github.com/fleetdm/fleet/v4/server/platform/mysql"
 	"github.com/fleetdm/fleet/v4/server/ptr"
@@ -13,6 +15,30 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/require"
 )
+
+func TestAtomicTableSwapVulnerabilityCountsDropsStaleOldTable(t *testing.T) {
+	mock, ds := mockDatastore(t)
+	defer ds.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta("DROP TABLE IF EXISTS vulnerability_host_counts_swap")).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(regexp.QuoteMeta(vulnerabilityHostCountsSwapTableSchema)).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta("DROP TABLE IF EXISTS vulnerability_host_counts_old")).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(`(?s)RENAME TABLE\s+vulnerability_host_counts TO vulnerability_host_counts_old,\s+vulnerability_host_counts_swap TO vulnerability_host_counts`).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(regexp.QuoteMeta("DROP TABLE vulnerability_host_counts_old")).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+
+	require.NoError(t, ds.atomicTableSwapVulnerabilityCounts(t.Context(), vulnerabilityCounts{}))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
 
 func TestVulnerabilities(t *testing.T) {
 	ds := CreateMySQLDS(t)
@@ -34,6 +60,7 @@ func TestVulnerabilities(t *testing.T) {
 		{"TestCountVulnerabilities", testCountVulnerabilities},
 		{"TestInsertVulnerabilityCounts", testInsertVulnerabilityCounts},
 		{"TestVulnerabilityHostCountBatchInserts", testVulnerabilityHostCountBatchInserts},
+		{"TestVulnerabilityHostCountSwapRecovery", testVulnerabilityHostCountSwapRecovery},
 		{"TestListVulnerabilitiesCursorPagination", testListVulnerabilitiesCursorPagination},
 	}
 
@@ -966,6 +993,46 @@ func testVulnerabilityHostCountBatchInserts(t *testing.T, ds *Datastore) {
 	for _, vuln := range list {
 		require.Equal(t, uint(2), vuln.HostsCount)
 	}
+}
+
+func testVulnerabilityHostCountSwapRecovery(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+	writer := ds.writer(ctx)
+	defer func() {
+		_, err := writer.ExecContext(ctx, "DROP TABLE IF EXISTS vulnerability_host_counts_old")
+		require.NoError(t, err)
+	}()
+
+	_, err := writer.ExecContext(ctx, "DROP TABLE IF EXISTS vulnerability_host_counts_old")
+	require.NoError(t, err)
+	_, err = writer.ExecContext(ctx, "CREATE TABLE vulnerability_host_counts_old LIKE vulnerability_host_counts")
+	require.NoError(t, err)
+
+	counts := vulnerabilityCounts{
+		Global: []hostCount{{
+			CVE:         "CVE-2026-45100",
+			HostCount:   2,
+			GlobalStats: true,
+		}},
+	}
+	require.NoError(t, ds.atomicTableSwapVulnerabilityCounts(ctx, counts))
+
+	var got []hostCount
+	err = sqlx.SelectContext(ctx, ds.reader(ctx), &got, `
+		SELECT team_id, cve, host_count, global_stats
+		FROM vulnerability_host_counts
+	`)
+	require.NoError(t, err)
+	require.Equal(t, counts.Global, got)
+
+	var oldTableCount int
+	err = sqlx.GetContext(ctx, ds.reader(ctx), &oldTableCount, `
+		SELECT COUNT(*)
+		FROM information_schema.tables
+		WHERE table_schema = DATABASE() AND table_name = 'vulnerability_host_counts_old'
+	`)
+	require.NoError(t, err)
+	require.Zero(t, oldTableCount)
 }
 
 func testOSVersionsByCVEFailsGracefullyWithNoOSVersionRows(t *testing.T, ds *Datastore) {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #45100

## What changed

Remove a stale `vulnerability_host_counts_old` table immediately before the atomic rename. If an earlier run was interrupted after the rename but before cleanup, the next vulnerability processing run can now recover instead of failing on the existing backup table.

The regression coverage verifies both the SQL ordering and the recovery path against MySQL with a pre-existing stale table.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops

## Testing

- [x] Added/updated automated tests

- [ ] QA'd all new/changed functionality manually

Manual QA was not run because a local MySQL test service was unavailable. The SQL sequencing regression passed locally, and a MySQL integration regression is included for CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery of vulnerability host-count updates after interrupted table swaps.
  * Automatically removes stale temporary tables before retrying the update, helping ensure accurate vulnerability counts.
  * Added safeguards so cleanup failures are reported clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->