### PR TITLE
Enhance os_version.yml with policy query and notes

### DIFF
--- a/schema/tables/os_version.yml
+++ b/schema/tables/os_version.yml
@@ -9,7 +9,18 @@ examples: |-
   example)
 
   ```
-  SELECT arch, version FROM os_version;
+  SELECT arch, version FROM os_version; 
+  ```
+  
+  Create a policy query that causes a Mac to fail a policy if the macOS version is older than 26.6.1 & either Screen Sharing or Remote Management is enabled -
+
+  ```
+  SELECT 1 WHERE NOT EXISTS (
+    SELECT 1
+    FROM os_version, sharing_preferences
+    WHERE version < '26.6.1'
+    AND (sharing_preferences.screen_sharing = 1 OR sharing_preferences.remote_management = 1)
+  );
   ```
 columns:
   - name: install_date
@@ -22,4 +33,5 @@ columns:
     platforms:
       - linux
 notes: |-
+  - Though the `os_version` table `version` column VALUE type is STRING, osquery correctly handles semantic-version ordering via collate="version" in this table column the same way it handles `version` columns in many other tables. (i.e., codegen declares the `version` column as ... COLLATE VERSION in the CREATE TABLE statement it hands to SQLite when registering the virtual table.) This means the `version` column can be used for OS version comparisions without need of using the `major`, `minor` or `patch` columns.
   - On ChromeOS, this table requires the [fleetd Chrome extension](https://fleetdm.com/docs/using-fleet/chromeos).

--- a/schema/tables/os_version.yml
+++ b/schema/tables/os_version.yml
@@ -15,12 +15,10 @@ examples: |-
   Create a policy query that causes a Mac to fail a policy if the macOS version is older than 26.6.1 & either Screen Sharing or Remote Management is enabled -
 
   ```
-  SELECT 1 WHERE NOT EXISTS (
-    SELECT 1
-    FROM os_version, sharing_preferences
-    WHERE version < '26.6.1'
-    AND (sharing_preferences.screen_sharing = 1 OR sharing_preferences.remote_management = 1)
-  );
+  SELECT 1
+  FROM os_version, sharing_preferences
+  WHERE version < '26.6.1'
+  AND (sharing_preferences.screen_sharing = 1 OR sharing_preferences.remote_management = 1);
   ```
 columns:
   - name: install_date

--- a/schema/tables/os_version.yml
+++ b/schema/tables/os_version.yml
@@ -31,5 +31,5 @@ columns:
     platforms:
       - linux
 notes: |-
-  - Though the `os_version` table `version` column VALUE type is STRING, osquery correctly handles semantic-version ordering via collate="version" in this table column the same way it handles `version` columns in many other tables. (i.e., codegen declares the `version` column as ... COLLATE VERSION in the CREATE TABLE statement it hands to SQLite when registering the virtual table.) This means the `version` column can be used for OS version comparisions without need of using the `major`, `minor` or `patch` columns.
+  - Though the `os_version` table `version` column VALUE type is STRING, osquery correctly handles semantic-version ordering via collate="version" in this table column the same way it handles `version` columns in many other tables. (i.e., codegen declares the `version` column as ... COLLATE VERSION in the CREATE TABLE statement it hands to SQLite when registering the virtual table.) This means the `version` column can be used for OS version comparisons without needing the `major`, `minor` or `patch` columns.
   - On ChromeOS, this table requires the [fleetd Chrome extension](https://fleetdm.com/docs/using-fleet/chromeos).


### PR DESCRIPTION
Added a policy query for macOS version checks and updated notes on version column handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added queries for checking operating system architecture and version.
  * Added a policy check for outdated macOS versions with Screen Sharing or Remote Management enabled.
  * Clarified semantic-version ordering for operating system versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->