### PR TITLE
Document refetch activity in audit logs

### DIFF
--- a/docs/Contributing/reference/audit-logs.md
+++ b/docs/Contributing/reference/audit-logs.md
@@ -3181,6 +3181,23 @@ This activity contains the following fields:
 }
 ```
 
+## refetch
+
+Generated every hour when Fleet collects fresh vitals for Android hosts.
+
+This activity contains the following fields:
+- "host_id": ID of the host.
+- "host_display_name": Display name of the host.
+
+#### Example
+
+```json
+{
+  "host_id": 1,
+  "host_display_name": "Anna's Android"
+}
+```
+
 
 <meta name="title" value="Audit logs">
 <meta name="pageOrderInSection" value="1400">


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** #43922

Documents the `refetch` activity (generated hourly when Fleet collects fresh vitals for Android hosts) in the audit logs reference.