### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/android-studio/darwin.json
+++ b/ee/maintained-apps/outputs/android-studio/darwin.json
@@ -7,10 +7,10 @@
         "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.android.studio' AND version_compare(bundle_short_version, '2026.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.google.android.studio');"
       },
-      "installer_url": "https://edgedl.me.gvt1.com/android/studio/install/2026.1.3.7/android-studio-quail3-mac_arm.dmg",
+      "installer_url": "https://edgedl.me.gvt1.com/android/studio/install/2026.1.3.8/android-studio-quail3-patch1-mac_arm.dmg",
       "install_script_ref": "2f5a5ada",
       "uninstall_script_ref": "aa386b1a",
-      "sha256": "e43fb8f880a419208f821befea17eb9ec1b00c5c2a20227db29c495411c5f99d",
+      "sha256": "aa77ef6919b22be51566dcd79603c323f7c403fa91dc79dc413eed7f6a05c048",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/chatgpt/darwin.json
+++ b/ee/maintained-apps/outputs/chatgpt/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "26.803.41515",
+      "version": "26.803.61601",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.chat';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.chat' AND version_compare(bundle_short_version, '26.803.41515') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.chat' AND version_compare(bundle_short_version, '26.803.61601') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.openai.chat');"
       },
-      "installer_url": "https://persistent.oaistatic.com/codex-app-prod/ChatGPT-darwin-arm64-26.803.41515.zip",
+      "installer_url": "https://persistent.oaistatic.com/codex-app-prod/ChatGPT-darwin-arm64-26.803.61601.zip",
       "install_script_ref": "cbce2d7d",
       "uninstall_script_ref": "678e6cf0",
-      "sha256": "8abd46bf063bc27cbadcbc2863007ac44365b13a23ede17ceaee81fb9eeaeb9a",
+      "sha256": "d96e2fc6d3ecfd7889cfa82827f431a99540028c6a5bf551dc06e569006db600",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/cisco-jabber/darwin.json
+++ b/ee/maintained-apps/outputs/cisco-jabber/darwin.json
@@ -7,10 +7,10 @@
         "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.cisco.jabber' AND version_compare(bundle_short_version, '15.2.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.cisco.jabber');"
       },
-      "installer_url": "https://binaries.webex.com/jabberclientmac/20260122074039/Install_Cisco-Jabber-Mac.pkg",
+      "installer_url": "https://binaries.webex.com/jabberclientmac/20260722023311/Install_Cisco-Jabber-Mac.pkg",
       "install_script_ref": "edbec29c",
       "uninstall_script_ref": "fe0e9261",
-      "sha256": "5644700e420febc1eca304c0a0f24bcff1e64b424112e1beda025d2eb78e16de",
+      "sha256": "bb71f8686049930033710f88698712e6aee6ed469516f3a73e48df8cecda4d61",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/cloudflare-warp/windows.json
+++ b/ee/maintained-apps/outputs/cloudflare-warp/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "26.6.880.0",
+      "version": "26.6.905.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Cloudflare One Client' AND publisher = 'Cloudflare, Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Cloudflare One Client' AND publisher = 'Cloudflare, Inc.' AND version_compare(version, '26.6.880.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Cloudflare One Client' AND publisher = 'Cloudflare, Inc.' AND version_compare(version, '26.6.905.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'cloudflare one.exe');"
       },
-      "installer_url": "https://downloads.cloudflareclient.com/v1/download/windows/version/2026.6.880.0",
+      "installer_url": "https://downloads.cloudflareclient.com/v1/download/windows/version/2026.6.905.0",
       "install_script_ref": "22e48c46",
       "uninstall_script_ref": "cee7bc51",
-      "sha256": "ffcd1d803d774409ae54e565e85b7e03cd96450fd1654eee44f8a9e463078030",
+      "sha256": "d6c58ac9c18e2459d7173cf071812ebfdb1014ac6b9f041f4e1c37c7859c20f1",
       "default_categories": [
         "Productivity"
       ],

--- a/ee/maintained-apps/outputs/drawio/windows.json
+++ b/ee/maintained-apps/outputs/drawio/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "31.1.5",
+      "version": "31.1.8",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'draw.io' AND publisher = 'JGraph';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'draw.io' AND publisher = 'JGraph' AND version_compare(version, '31.1.5') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'draw.io' AND publisher = 'JGraph' AND version_compare(version, '31.1.8') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'draw.io.exe');"
       },
-      "installer_url": "https://github.com/jgraph/drawio-desktop/releases/download/v31.1.5/draw.io-31.1.5-windows-installer.exe",
+      "installer_url": "https://github.com/jgraph/drawio-desktop/releases/download/v31.1.8/draw.io-31.1.8-windows-installer.exe",
       "install_script_ref": "51038703",
       "uninstall_script_ref": "63a061f9",
-      "sha256": "dbb7efd2c06f9102fc7e80e38ed9a99e5b8d23257bfbdf81994c7686f830c971",
+      "sha256": "5e62b50085714032c75b2dd35fcc61b6d01294916b2d49f74ea9bf684aec9bb6",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/dropbox/darwin.json
+++ b/ee/maintained-apps/outputs/dropbox/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "264.4.3385",
+      "version": "264.4.3421",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.getdropbox.dropbox';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.getdropbox.dropbox' AND version_compare(bundle_short_version, '264.4.3385') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.getdropbox.dropbox' AND version_compare(bundle_short_version, '264.4.3421') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.getdropbox.dropbox');"
       },
-      "installer_url": "https://edge.dropboxstatic.com/dbx-releng/client/Dropbox%20264.4.3385.arm64.dmg",
+      "installer_url": "https://edge.dropboxstatic.com/dbx-releng/client/Dropbox%20264.4.3421.arm64.dmg",
       "install_script_ref": "dcd0d19e",
       "uninstall_script_ref": "3af4988a",
-      "sha256": "e4c8b5735ac893a03838a4c0fa27bfb6d2dd3c7cc513235294ae69279b8d4748",
+      "sha256": "0a2213393bfc15362bdd1f3a08876119084fbe2dc2f95aad3d35df1da3c372d4",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/firefox@developer-edition/darwin.json
+++ b/ee/maintained-apps/outputs/firefox@developer-edition/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "154.0b8",
+      "version": "154.0b9",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefoxdeveloperedition';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefoxdeveloperedition' AND version_compare(bundle_version, '15426.8.7') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefoxdeveloperedition' AND version_compare(bundle_version, '15426.8.10') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'org.mozilla.firefoxdeveloperedition');"
       },
-      "installer_url": "https://download-installer.cdn.mozilla.net/pub/devedition/releases/154.0b8/mac/en-US/Firefox%20154.0b8.dmg",
+      "installer_url": "https://download-installer.cdn.mozilla.net/pub/devedition/releases/154.0b9/mac/en-US/Firefox%20154.0b9.dmg",
       "install_script_ref": "b679ecd7",
       "uninstall_script_ref": "292c5733",
-      "sha256": "fb371168991370f5652614a5d6df96ecb7a9fb2d19aa6b2f8255f439cd26942b",
+      "sha256": "5ed2ade76d64ed7aaa8bf49a51decc96df52f776916426b8adaa3eca89b5fd3b",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/firefox@nightly/darwin.json
+++ b/ee/maintained-apps/outputs/firefox@nightly/darwin.json
@@ -7,10 +7,10 @@
         "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15526.8.10') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'org.mozilla.nightly');"
       },
-      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/08/2026-08-10-09-30-15-mozilla-central/firefox-155.0a1.en-US.mac.dmg",
+      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/08/2026-08-10-15-48-37-mozilla-central/firefox-155.0a1.en-US.mac.dmg",
       "install_script_ref": "d9c4cf87",
       "uninstall_script_ref": "0661f848",
-      "sha256": "d71c1e39201452b3b6f46a671b264e61603ae6983609da4f37620b3651564749",
+      "sha256": "a35a4543a9037af6b9551cb5a8f82b1433900955bce895ef2f9d493db8321228",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/hive-app/darwin.json
+++ b/ee/maintained-apps/outputs/hive-app/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.2.28",
+      "version": "1.2.29",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app' AND version_compare(bundle_short_version, '1.2.28') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app' AND version_compare(bundle_short_version, '1.2.29') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.hive.app');"
       },
-      "installer_url": "https://github.com/morapelker/hive/releases/download/v1.2.28/Hive-1.2.28-arm64.dmg",
+      "installer_url": "https://github.com/morapelker/hive/releases/download/v1.2.29/Hive-1.2.29-arm64.dmg",
       "install_script_ref": "3bd4ebe4",
       "uninstall_script_ref": "951b5587",
-      "sha256": "28a7895ef90b664ac4eb39a428405f6da91f40c350b0fe6f27cb37ed6bcc76d1",
+      "sha256": "a8cc14e2a8b8d617fc0e821e4475d32bd344da99b4645acb48e629e734dc31fa",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/lenovo-system-update/windows.json
+++ b/ee/maintained-apps/outputs/lenovo-system-update/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "5.08.03.59",
+      "version": "5.08.04.85",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Lenovo System Update';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Lenovo System Update' AND version_compare(version, '5.08.03.59') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Lenovo System Update' AND version_compare(version, '5.08.04.85') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'lenovo system update.exe');"
       },
-      "installer_url": "https://download.lenovo.com/pccbbs/thinkvantage_en/system_update_5.08.03.59.exe",
+      "installer_url": "https://download.lenovo.com/pccbbs/thinkvantage_en/system_update_5.08.04.85.exe",
       "install_script_ref": "04c67509",
       "uninstall_script_ref": "aca82ee7",
-      "sha256": "e66794dc561a3e58e3dc68556eb053ee32b674ac9d99638e473ef7322f353e0d",
+      "sha256": "4f044c4a1cece3fe4be22408da7e1d8e8338eeaae4491ce18fdaa5b655dc9585",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/localsend/darwin.json
+++ b/ee/maintained-apps/outputs/localsend/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.17.0",
+      "version": "1.18.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.localsend.localsendApp';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.localsend.localsendApp' AND version_compare(bundle_short_version, '1.17.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.localsend.localsendApp' AND version_compare(bundle_short_version, '1.18.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'org.localsend.localsendApp');"
       },
-      "installer_url": "https://github.com/localsend/localsend/releases/download/v1.17.0/LocalSend-1.17.0.dmg",
+      "installer_url": "https://github.com/localsend/localsend/releases/download/v1.18.0/LocalSend-1.18.0.dmg",
       "install_script_ref": "f3e3757e",
       "uninstall_script_ref": "59b942e3",
-      "sha256": "fdf1a42ee13eb9fdd6ae94dc5883981e8a09599e758bde23f6e677c4fab5c93c",
+      "sha256": "93ab884c2703a0fabd72611097b2616c0def86c4256cea2add7a0ff36dd76b3a",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/nvidia-geforce-now/darwin.json
+++ b/ee/maintained-apps/outputs/nvidia-geforce-now/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "2.0.87.131",
+      "version": "2.0.87.134",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.nvidia.gfnpc.mall';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.nvidia.gfnpc.mall' AND version_compare(bundle_short_version, '2.0.87.131') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.nvidia.gfnpc.mall' AND version_compare(bundle_short_version, '2.0.87.134') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.nvidia.gfnpc.mall');"
       },
       "installer_url": "https://download.nvidia.com/gfnpc/GeForceNOW-release.dmg",

--- a/ee/maintained-apps/outputs/obsidian/darwin.json
+++ b/ee/maintained-apps/outputs/obsidian/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.13.4",
+      "version": "1.13.6",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'md.obsidian';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'md.obsidian' AND version_compare(bundle_short_version, '1.13.4') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'md.obsidian' AND version_compare(bundle_short_version, '1.13.6') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'md.obsidian');"
       },
-      "installer_url": "https://github.com/obsidianmd/obsidian-releases/releases/download/v1.13.4/Obsidian-1.13.4.dmg",
+      "installer_url": "https://github.com/obsidianmd/obsidian-releases/releases/download/v1.13.6/Obsidian-1.13.6.dmg",
       "install_script_ref": "2a90e12f",
       "uninstall_script_ref": "06bfea71",
-      "sha256": "e84b9595aba5e50221c97e43d3e3f437416edfbf4c4a84c379461e70f854d78f",
+      "sha256": "8bb75d1553e11b4a640947d9cca7211a842b703a5b7d5b688d68920155c24f74",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/onedrive/darwin.json
+++ b/ee/maintained-apps/outputs/onedrive/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "26.119.0622.0003",
+      "version": "26.134.0713.0007",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.OneDrive';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.OneDrive' AND version_compare(bundle_short_version, '26.119.0622.0003') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.OneDrive' AND version_compare(bundle_short_version, '26.134.0713.0007') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.microsoft.OneDrive');"
       },
-      "installer_url": "https://oneclient.sfx.ms/Mac/Installers/26.119.0622.0003/universal/OneDrive.pkg",
+      "installer_url": "https://oneclient.sfx.ms/Mac/Installers/26.134.0713.0007/universal/OneDrive.pkg",
       "install_script_ref": "dce2d064",
       "uninstall_script_ref": "b1c16fe2",
-      "sha256": "ed8037715552d25538207786b36503ead1be5d5c8cd457c4cabba67df7a11e35",
+      "sha256": "9d7be342f73c72c26564e25fdf59c0fcc0725d6e83b89d5a62e31a462777605d",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/phpstorm/darwin.json
+++ b/ee/maintained-apps/outputs/phpstorm/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "2026.2.0.1",
+      "version": "2026.2.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.PhpStorm';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.PhpStorm' AND version_compare(bundle_short_version, '2026.2.0.1') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.PhpStorm' AND version_compare(bundle_short_version, '2026.2.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.jetbrains.PhpStorm');"
       },
-      "installer_url": "https://download.jetbrains.com/webide/PhpStorm-2026.2.0.1-aarch64.dmg",
+      "installer_url": "https://download.jetbrains.com/webide/PhpStorm-2026.2.1-aarch64.dmg",
       "install_script_ref": "fc06193f",
       "uninstall_script_ref": "d37d13f0",
-      "sha256": "7c8eb4c49f78a27997033241cb7f865079c91fefee9104c2b94da3decd59239a",
+      "sha256": "6986b320cee2da75075b3a99dd8fea79e8eee843e1f1f7652012949a21e56111",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/rocket-chat/darwin.json
+++ b/ee/maintained-apps/outputs/rocket-chat/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "4.15.6",
+      "version": "4.16.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'chat.rocket';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'chat.rocket' AND version_compare(bundle_short_version, '4.15.6') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'chat.rocket' AND version_compare(bundle_short_version, '4.16.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'chat.rocket');"
       },
-      "installer_url": "https://github.com/RocketChat/Rocket.Chat.Electron/releases/download/4.15.6/rocketchat-4.15.6-mac.dmg",
+      "installer_url": "https://github.com/RocketChat/Rocket.Chat.Electron/releases/download/4.16.0/rocketchat-4.16.0-mac.dmg",
       "install_script_ref": "56506355",
       "uninstall_script_ref": "36b46743",
-      "sha256": "cef12bcb3e59251132b2195357c1251601af5be54e0120cc2d33a91c09460ceb",
+      "sha256": "9635eda6fe78a49a3ca1c8a31c88d6e2d13e5c022963cea957025dec1b44ca72",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/shapr3d/darwin.json
+++ b/ee/maintained-apps/outputs/shapr3d/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "26.142.0.11496",
+      "version": "26.143.0.11521",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.shapr3d.shapr';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.shapr3d.shapr' AND version_compare(bundle_short_version, '26.142.0.11496') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.shapr3d.shapr' AND version_compare(bundle_short_version, '26.143.0.11521') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.shapr3d.shapr');"
       },
-      "installer_url": "https://download.shapr3d.com/mac/Shapr3D-26.142.0.11496.dmg",
+      "installer_url": "https://download.shapr3d.com/mac/Shapr3D-26.143.0.11521.dmg",
       "install_script_ref": "aa7e3fbc",
       "uninstall_script_ref": "261544b8",
-      "sha256": "b8c2fa6644856c631d942f61d2f4922185f3344325d66d1f1bdfb3e1ea68244a",
+      "sha256": "c5c79388084fd23af505c81ff30c6a44832749f33297078ffa207485edd3bafb",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/shift/darwin.json
+++ b/ee/maintained-apps/outputs/shift/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "9.6.7.1268",
+      "version": "9.6.8.1270",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.rdbrck.shift';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.rdbrck.shift' AND version_compare(bundle_short_version, '9.6.7.1268') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.rdbrck.shift' AND version_compare(bundle_short_version, '9.6.8.1270') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.rdbrck.shift');"
       },
-      "installer_url": "https://updates.tryshift.com/v9.6.7/stable/shift-v9.6.7.1268-stable-arm64.dmg",
+      "installer_url": "https://updates.tryshift.com/v9.6.8/stable/shift-v9.6.8.1270-stable-arm64.dmg",
       "install_script_ref": "526e5310",
       "uninstall_script_ref": "c93f6ce6",
-      "sha256": "8a70d9e5a86511d5ac025e582faf18a506f38117c48fa4c337de3f5b3c97a40a",
+      "sha256": "1b567995c2dd75168dee38118a79ff807f7a9622c68efd34e923b9bc9862a981",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/shift/windows.json
+++ b/ee/maintained-apps/outputs/shift/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "9.6.7.1268",
+      "version": "9.6.8.1270",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Shift' AND publisher = 'Shift Technologies, Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Shift' AND publisher = 'Shift Technologies, Inc.' AND version_compare(version, '9.6.7.1268') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Shift' AND publisher = 'Shift Technologies, Inc.' AND version_compare(version, '9.6.8.1270') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'shift.exe');"
       },
-      "installer_url": "https://updates.tryshift.com/v9.6.7/stable/shift-v9.6.7.1268-stable-x64.exe",
+      "installer_url": "https://updates.tryshift.com/v9.6.8/stable/shift-v9.6.8.1270-stable-x64.exe",
       "install_script_ref": "fbf50bbc",
       "uninstall_script_ref": "c5cc1d5a",
-      "sha256": "5a4b5f629c3a9fc06d573edbbd74d6a52fa655642a8b24a58997ac4cf8b48b3b",
+      "sha256": "a340976691a87748172bdb46ac959940a21ef520fd143da91d26c2395d0f0d69",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/slack/darwin.json
+++ b/ee/maintained-apps/outputs/slack/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "4.51.180",
+      "version": "4.51.185",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.tinyspeck.slackmacgap';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.tinyspeck.slackmacgap' AND version_compare(bundle_short_version, '4.51.180') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.tinyspeck.slackmacgap' AND version_compare(bundle_short_version, '4.51.185') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.tinyspeck.slackmacgap');"
       },
       "installer_url": "https://slack.com/api/desktop.latestRelease?redirect=1&variant=pkg&arch=universal",

--- a/ee/maintained-apps/outputs/surge/darwin.json
+++ b/ee/maintained-apps/outputs/surge/darwin.json
@@ -7,10 +7,10 @@
         "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.nssurge.surge-mac' AND version_compare(bundle_short_version, '6.8.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.nssurge.surge-mac');"
       },
-      "installer_url": "https://dl.nssurge.com/mac/v6/Surge-6.8.1-12010-eb73e613f5ff5c87c5422ca691ce136d.zip",
+      "installer_url": "https://dl.nssurge.com/mac/v6/Surge-6.8.1-12030-69f4be88db9663476f31a6b264109f0b.zip",
       "install_script_ref": "591d4936",
       "uninstall_script_ref": "73bb9941",
-      "sha256": "ad975f4869632b1cb8808c020bdb0a39a239f05edf6fc5088ce08068efc7efb5",
+      "sha256": "ad99691d823b2f7d4504a39170b01bf4f8639da7c6857c583a57cdf46e5c05c4",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/termius/windows.json
+++ b/ee/maintained-apps/outputs/termius/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "9.42.2",
+      "version": "9.43.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Termius' AND publisher = 'Termius Corporation';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Termius' AND publisher = 'Termius Corporation' AND version_compare(version, '9.42.2') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Termius' AND publisher = 'Termius Corporation' AND version_compare(version, '9.43.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'termius.exe');"
       },
       "installer_url": "https://autoupdate.termius.com/windows/Install%20Termius.exe",
       "install_script_ref": "df65625a",
       "uninstall_script_ref": "362c320f",
-      "sha256": "9d6fb0b32fcef989762e7c268f298ebcfb46e042920847681418e38a1a6752d0",
+      "sha256": "5f769089cec36c686cac6878fc08312c56fcae28f460c004bf6b05f226a24805",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/zen/darwin.json
+++ b/ee/maintained-apps/outputs/zen/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.21.12b",
+      "version": "1.21.13b",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'app.zen-browser.zen';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.zen-browser.zen' AND version_compare(bundle_short_version, '1.21.12b') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.zen-browser.zen' AND version_compare(bundle_short_version, '1.21.13b') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'app.zen-browser.zen');"
       },
-      "installer_url": "https://github.com/zen-browser/desktop/releases/download/1.21.12b/zen.macos-universal.dmg",
+      "installer_url": "https://github.com/zen-browser/desktop/releases/download/1.21.13b/zen.macos-universal.dmg",
       "install_script_ref": "67e0fe5c",
       "uninstall_script_ref": "6fa48a6f",
-      "sha256": "dba6a9674d3199ac9b1ea8753c5f08486fe91de36ff113f7339f34423ffe5ea0",
+      "sha256": "6ee7eb09ae3f92ef56d14340acc7948b45d76806d232a54de23a8cd348361b09",
       "default_categories": [
         "Browsers"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Maintenance Updates**
  - Updated installer metadata, release versions, download links, and checksums for 25 applications across macOS and Windows.
  - Included updates for Android Studio, ChatGPT, Cisco Jabber, Cloudflare WARP, draw.io, Dropbox, Firefox, Hive, Lenovo System Update, LocalSend, Obsidian, OneDrive, PhpStorm, Rocket.Chat, Shapr3D, Shift, Slack, Surge, Termius, Zen, and others.
  - Ensured package records reference the latest available application builds for installation and update workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->