### PR TITLE
Docs: recommend scoping the Vanta API-only user to specific endpoints

### DIFF
--- a/website/assets/styles/pages/connect-vanta.less
+++ b/website/assets/styles/pages/connect-vanta.less
@@ -13,6 +13,15 @@
     padding: 24px;
     margin-top: 32px;
     margin-bottom: 32px;
+    code {
+      color: @core-fleet-black-75;
+      font-family: @code-font;
+      font-weight: 400;
+      font-size: 14px;
+      line-height: 150%;
+      border: none;
+    }
+
   }
 
   [purpose='vanta-form'] {

--- a/website/views/pages/connect-vanta.ejs
+++ b/website/views/pages/connect-vanta.ejs
@@ -9,6 +9,16 @@
         <li>The integration currently only supports macOS and Windows hosts.</li>
         <li>We are currently unable to provide screen lock status. In Vanta, all hosts will appear as false. <a href="/queries/screen-lock-enabled-mac-os" target="_blank">Use this query for macOS hosts</a>, and <a href="/queries/screen-lock-enabled-windows" target="_blank">this query for Windows hosts</a> to see the true list of hosts with screen lock turned on via MDM.</li>
         <li>This integration is only available to Fleet Premium customers.</li>
+        <li>To reduce risk, set the API-only user's <strong>API access</strong> to <strong>Specific API endpoints</strong> instead of <strong>All API endpoints</strong>. This integration only needs these five read-only endpoints:
+          <ul>
+            <li>Get current user &mdash; <code>GET /api/v1/fleet/me</code></li>
+            <li>Get Fleet configuration &mdash; <code>GET /api/v1/fleet/config</code></li>
+            <li>List users &mdash; <code>GET /api/v1/fleet/users</code></li>
+            <li>List hosts &mdash; <code>GET /api/v1/fleet/hosts</code></li>
+            <li>Get host &mdash; <code>GET /api/v1/fleet/hosts/:id</code></li>
+          </ul>
+          Scoping endpoints limits the blast radius if the token leaks. It does not grant permissions the user's role forbids, so the user still needs the Admin role.
+        </li>
       </ul>
     </div>
     <div class="card card-body" purpose="vanta-form">


### PR DESCRIPTION
The `/connect-vanta` setup page asks for an admin API-only user token, but never mentions that Fleet Premium can scope an API-only user to a specific list of endpoints ([Scoped API-only users](https://fleetdm.com/releases/fleet-4.85.0), Fleet 4.85.0). As written, every Vanta integration ends up running on a token with unrestricted access to the whole Fleet API.

The integration only ever calls five read-only endpoints:

| Method | Path | Called from |
|---|---|---|
| `GET` | `/api/v1/fleet/me` | `website/api/controllers/create-vanta-authorization-request.js:111` |
| `GET` | `/api/v1/fleet/config` | `website/api/controllers/create-vanta-authorization-request.js:137` |
| `GET` | `/api/v1/fleet/users` | `website/scripts/send-data-to-vanta.js:68` |
| `GET` | `/api/v1/fleet/hosts` | `website/scripts/send-data-to-vanta.js:141` |
| `GET` | `/api/v1/fleet/hosts/:id` | `website/scripts/send-data-to-vanta.js:225, 329` |

Methods, paths, and display names match the catalog in `server/api_endpoints/api_endpoints.yml`, so they can be found directly in the "Select API endpoints" search.

This PR adds a note to the "Please note" list recommending **Specific API endpoints** with exactly that list. The Admin role is still required (`create-vanta-authorization-request.js:132` rejects any token whose `global_role !== 'admin'`), and endpoint scoping never grants permissions the user's role forbids so this is purely a reduction in blast radius if the token leaks.

Docs-only change, so no changes file per [committing-changes.md](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#what-does-not-need-a-changes-file).

I have tested this over 4-5 days and Vanta integration kept working fine.

Thanks to @jc0b for the idea.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring the Vanta API-only user with required read-only Fleet API access.
  * Clarified that the Admin role must be retained during setup.
* **Style**
  * Improved formatting and readability for API endpoint references in the Vanta setup notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->