### PR TITLE
Website: Update Vanta script error handling

### DIFF
--- a/website/scripts/send-data-to-vanta.js
+++ b/website/scripts/send-data-to-vanta.js
@@ -81,6 +81,13 @@ module.exports = {
         return;
       }
 
+      // If the Fleet instance's /users endpoint did not return an array of users, we'll add an error to the errorReportById object and bail early for this connection.
+      // This prevents a "TypeError: responseFromUserEndpoint.users is not iterable" error in the for...of loop below when the response is missing or has an unexpected shape.
+      if(!responseFromUserEndpoint || !_.isArray(responseFromUserEndpoint.users)) {
+        errorReportById[connectionIdAsString] = new Error(`When sending a request to the /users endpoint of a Fleet instance for a VantaConnection (id: ${connectionIdAsString}), the Fleet instance returned an unexpected response that did not contain an array of users.`);
+        return;
+      }
+
       let usersToSyncWithVanta = [];
       // Iterate through the users list, creating user objects to send to Vanta.
       for(let user of responseFromUserEndpoint.users) {

--- a/website/scripts/send-data-to-vanta.js
+++ b/website/scripts/send-data-to-vanta.js
@@ -81,8 +81,7 @@ module.exports = {
         return;
       }
 
-      // If the Fleet instance's /users endpoint did not return an array of users, we'll add an error to the errorReportById object and bail early for this connection.
-      // This prevents a "TypeError: responseFromUserEndpoint.users is not iterable" error in the for...of loop below when the response is missing or has an unexpected shape.
+      // If the response from the Fleet instance's /users endpoint did not return an array of users, add an error to the errorReportById object, with this connections ID set as the key, and bail early for this Vanta connection.
       if(!responseFromUserEndpoint || !_.isArray(responseFromUserEndpoint.users)) {
         errorReportById[connectionIdAsString] = new Error(`When sending a request to the /users endpoint of a Fleet instance for a VantaConnection (id: ${connectionIdAsString}), the Fleet instance returned an unexpected response that did not contain an array of users.`);
         return;


### PR DESCRIPTION
Changes:
- updated the send-data-to-vanta script to log an error and stop running for a Vanta connection if the response from a Fleet instance's `/api/v1/fleet/users` endpoint does not contain an array of users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for Fleet user data before synchronization.
  * Invalid or missing user data now records an error and stops processing safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->