### PR TITLE
MariaDB compatibility: fix correlated derived tables, JSON syntax, and run test suites against MariaDB

### DIFF
--- a/.github/workflows/test-go-suite.yaml
+++ b/.github/workflows/test-go-suite.yaml
@@ -104,6 +104,13 @@ jobs:
           echo "NEED_DOCKER=1" >> $GITHUB_ENV
         fi
 
+    - name: Select MariaDB compose override
+      # docker-compose-mariadb.yml overrides the image and command of the same
+      # mysql_test/mysql_replica_test services, so nothing downstream changes.
+      if: ${{ startsWith(inputs.mysql, 'mariadb') }}
+      run: |
+        echo "DOCKER_COMMAND=${DOCKER_COMMAND/-f docker-compose.yml/-f docker-compose.yml -f docker-compose-mariadb.yml}" >> $GITHUB_ENV
+
     - name: Compute artifact prefix
       run: |
         PREFIX="${{ inputs.suite }}"
@@ -186,8 +193,9 @@ jobs:
               return 1
             fi
 
-            # Try to connect to MySQL
-            output=$(docker compose exec -T $container_name sh -c "mysql -uroot -p\"\${MYSQL_ROOT_PASSWORD}\" -e \"SELECT 1=1\" fleet" 2>&1)
+            # Try to connect. MariaDB 11.x ships only the `mariadb` client, so
+            # pick whichever of the two the image provides.
+            output=$(docker compose exec -T $container_name sh -c "\$(command -v mysql || command -v mariadb) -uroot -p\"\${MYSQL_ROOT_PASSWORD}\" -e \"SELECT 1=1\" fleet" 2>&1)
             exit_code=$?
 
             # Log the attempt

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -106,6 +106,31 @@ jobs:
       SLACK_G_HELP_ENGINEERING_WEBHOOK_URL: ${{ secrets.SLACK_G_HELP_ENGINEERING_WEBHOOK_URL }}
 
   # ──────────────────────────────────────────────────────────────────────────
+  # MariaDB coverage: only on the nightly cron schedule.
+  #
+  # MariaDB is not a supported database. This leg exists to track how far from
+  # working it is without slowing down every push, so it is cron-only and
+  # continue-on-error. See https://github.com/fleetdm/fleet/issues/31288.
+  # ──────────────────────────────────────────────────────────────────────────
+  test-go-mariadb:
+    if: github.event_name == 'schedule'
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: ["integration-core", "integration-enterprise", "integration-mdm", "fleetctl", "main", "mysql", "service", "vuln"]
+        mysql: ["mariadb:11.4"]
+    uses: ./.github/workflows/test-go-suite.yaml
+    with:
+      suite: ${{ matrix.suite }}
+      mysql: ${{ matrix.mysql }}
+      is_cron: true
+    secrets:
+      FLEET_RELEASE_GITHUB_PAT: ${{ secrets.FLEET_RELEASE_GITHUB_PAT }}
+      # Deliberately not wired to Slack: MariaDB is experimental and its
+      # failures should not page the team.
+
+  # ──────────────────────────────────────────────────────────────────────────
   # Extended Redis/Valkey coverage: only on the nightly cron schedule.
   # Runs the Redis-touching suites against newer Redis versions and Valkey, in
   # both standalone and cluster mode. MySQL is pinned to the always-run version

--- a/changes/31288-mariadb-compatibility
+++ b/changes/31288-mariadb-compatibility
@@ -1,0 +1,1 @@
+- Fixed several datastore queries that failed on MariaDB, by replacing correlated derived tables with correlated `EXISTS` subqueries and replacing MySQL-only JSON syntax (`->`, `->>`, `CAST(... AS JSON)`) with portable equivalents. MariaDB remains unsupported, but the Go test suites can now be run against it.

--- a/docker-compose-mariadb.yml
+++ b/docker-compose-mariadb.yml
@@ -1,0 +1,61 @@
+---
+# Docker Compose override file for MariaDB support
+# Usage: docker compose -f docker-compose.yml -f docker-compose-mariadb.yml up
+services:
+  database:
+    image: mariadb:11.6
+    platform: linux/x86_64
+    volumes:
+      - mariadb-persistent-volume:/var/lib/mysql
+    command: [
+        "mariadbd",
+        "--datadir=/var/lib/mysql",
+        "--log-bin=bin.log",
+        "--server-id=1",
+        "--max_allowed_packet=536870912",
+        "--sql-mode=",  # <-- delete this line to turn on ONLY_FULL_GROUP_BY
+      ]
+    environment: &mariadb-default-environment
+      MARIADB_ROOT_PASSWORD: toor
+      MARIADB_DATABASE: fleet
+      MARIADB_USER: fleet
+      MARIADB_PASSWORD: insecure
+
+  database_test:
+    image: mariadb:11.6
+    platform: linux/x86_64
+    command: [
+        "mariadbd",
+        "--datadir=/tmpfs",
+        "--slow_query_log=1",
+        "--log_output=TABLE",
+        "--log-queries-not-using-indexes",
+        "--innodb-file-per-table=OFF",
+        "--table-definition-cache=8192",
+        "--log-bin=bin.log",
+        "--server-id=1",
+        "--max_allowed_packet=536870912",
+        "--sql-mode=",  # <-- delete this line to turn on ONLY_FULL_GROUP_BY
+      ]
+    environment: *mariadb-default-environment
+
+  database_replica_test:
+    image: mariadb:11.6
+    platform: linux/x86_64
+    command: [
+        "mariadbd",
+        "--datadir=/tmpfs",
+        "--slow_query_log=1",
+        "--log_output=TABLE",
+        "--log-queries-not-using-indexes",
+        "--innodb-file-per-table=OFF",
+        "--table-definition-cache=8192",
+        "--log-bin=bin.log",
+        "--server-id=2",
+        "--max_allowed_packet=536870912",
+        "--sql-mode=",  # <-- delete this line to turn on ONLY_FULL_GROUP_BY
+      ]
+    environment: *mariadb-default-environment
+
+volumes:
+  mariadb-persistent-volume:

--- a/docker-compose-mariadb.yml
+++ b/docker-compose-mariadb.yml
@@ -1,29 +1,35 @@
 ---
-# Docker Compose override file for MariaDB support
-# Usage: docker compose -f docker-compose.yml -f docker-compose-mariadb.yml up
+# Overrides the MySQL services in docker-compose.yml to run MariaDB instead.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose-mariadb.yml up -d mysql_test
+#
+# Only `image` and `command` are overridden -- the service names, ports, tmpfs
+# and environment are inherited, so everything that talks to mysql_test keeps
+# working unchanged. The MariaDB image accepts the MYSQL_* environment
+# variables as legacy aliases, so the shared environment anchor is reused.
+#
+# The commands differ from their MySQL counterparts in three ways:
+#   * the server binary is `mariadbd`;
+#   * `--enforce-gtid-consistency` and `--binlog-expire-logs-seconds` do not
+#     exist in MariaDB (`--expire-logs-days` is the equivalent of the latter);
+#   * `--sql-mode=` clears ONLY_FULL_GROUP_BY, which MariaDB enables by default
+#     and MySQL does not. Delete that line to test with it enabled.
 services:
-  database:
-    image: mariadb:11.6
-    platform: linux/x86_64
-    volumes:
-      - mariadb-persistent-volume:/var/lib/mysql
+  mysql:
+    image: ${FLEET_MYSQL_IMAGE:-mariadb:11.4}
     command: [
         "mariadbd",
-        "--datadir=/var/lib/mysql",
+        "--datadir=/tmp/mysqldata",
         "--log-bin=bin.log",
         "--server-id=1",
         "--max_allowed_packet=536870912",
-        "--sql-mode=",  # <-- delete this line to turn on ONLY_FULL_GROUP_BY
+        "--expire-logs-days=1",
+        "--sql-mode=",
       ]
-    environment: &mariadb-default-environment
-      MARIADB_ROOT_PASSWORD: toor
-      MARIADB_DATABASE: fleet
-      MARIADB_USER: fleet
-      MARIADB_PASSWORD: insecure
 
-  database_test:
-    image: mariadb:11.6
-    platform: linux/x86_64
+  mysql_test:
+    image: ${FLEET_MYSQL_IMAGE:-mariadb:11.4}
     command: [
         "mariadbd",
         "--datadir=/tmpfs",
@@ -35,13 +41,12 @@ services:
         "--log-bin=bin.log",
         "--server-id=1",
         "--max_allowed_packet=536870912",
-        "--sql-mode=",  # <-- delete this line to turn on ONLY_FULL_GROUP_BY
+        "--expire-logs-days=1",
+        "--sql-mode=",
       ]
-    environment: *mariadb-default-environment
 
-  database_replica_test:
-    image: mariadb:11.6
-    platform: linux/x86_64
+  mysql_replica_test:
+    image: ${FLEET_MYSQL_IMAGE:-mariadb:11.4}
     command: [
         "mariadbd",
         "--datadir=/tmpfs",
@@ -53,9 +58,6 @@ services:
         "--log-bin=bin.log",
         "--server-id=2",
         "--max_allowed_packet=536870912",
-        "--sql-mode=",  # <-- delete this line to turn on ONLY_FULL_GROUP_BY
+        "--expire-logs-days=1",
+        "--sql-mode=",
       ]
-    environment: *mariadb-default-environment
-
-volumes:
-  mariadb-persistent-volume:

--- a/server/datastore/mysql/activities.go
+++ b/server/datastore/mysql/activities.go
@@ -86,11 +86,11 @@ func (ds *Datastore) ListHostUpcomingActivities(ctx context.Context, hostID uint
 		// list pending scripts
 		`SELECT
 			ua.execution_id as uuid,
-			IF(ua.fleet_initiated, 'Fleet', COALESCE(u.name, ua.payload->>'$.user.name')) as name,
+			IF(ua.fleet_initiated, 'Fleet', COALESCE(u.name, JSON_UNQUOTE(JSON_EXTRACT(ua.payload, '$.user.name')))) as name,
 			u.id as user_id,
 			u.api_only as api_only,
-			COALESCE(u.gravatar_url, ua.payload->>'$.user.gravatar_url') as gravatar_url,
-			COALESCE(u.email, ua.payload->>'$.user.email') as user_email,
+			COALESCE(u.gravatar_url, JSON_UNQUOTE(JSON_EXTRACT(ua.payload, '$.user.gravatar_url'))) as gravatar_url,
+			COALESCE(u.email, JSON_UNQUOTE(JSON_EXTRACT(ua.payload, '$.user.email'))) as user_email,
 			:ran_script_type as activity_type,
 			ua.created_at as created_at,
 			JSON_OBJECT(
@@ -99,7 +99,7 @@ func (ds *Datastore) ListHostUpcomingActivities(ctx context.Context, hostID uint
 				'script_name', COALESCE(ses.name, scr.name, ''),
 				'script_execution_id', ua.execution_id,
 				'batch_execution_id', bahr.batch_execution_id,
-				'async', NOT ua.payload->'$.sync_request',
+				'async', NOT JSON_EXTRACT(ua.payload, '$.sync_request'),
 				'policy_id', sua.policy_id,
 				'policy_name', p.name
 			) as details,
@@ -129,22 +129,22 @@ func (ds *Datastore) ListHostUpcomingActivities(ctx context.Context, hostID uint
 		// list pending software installs
 		`SELECT
 			ua.execution_id as uuid,
-			IF(ua.fleet_initiated, 'Fleet', COALESCE(u.name, ua.payload->>'$.user.name')) AS name,
+			IF(ua.fleet_initiated, 'Fleet', COALESCE(u.name, JSON_UNQUOTE(JSON_EXTRACT(ua.payload, '$.user.name')))) AS name,
 			ua.user_id as user_id,
 			u.api_only as api_only,
-			COALESCE(u.gravatar_url, ua.payload->>'$.user.gravatar_url') as gravatar_url,
-			COALESCE(u.email, ua.payload->>'$.user.email') as user_email,
+			COALESCE(u.gravatar_url, JSON_UNQUOTE(JSON_EXTRACT(ua.payload, '$.user.gravatar_url'))) as gravatar_url,
+			COALESCE(u.email, JSON_UNQUOTE(JSON_EXTRACT(ua.payload, '$.user.email'))) as user_email,
 			:installed_software_type as activity_type,
 			ua.created_at as created_at,
 			JSON_OBJECT(
 				'host_id', ua.host_id,
 				'host_display_name', COALESCE(hdn.display_name, ''),
-				'software_title', COALESCE(st.name, ua.payload->>'$.software_title_name', ''),
-				'software_package', COALESCE(si.filename, ua.payload->>'$.installer_filename', ''),
+				'software_title', COALESCE(st.name, JSON_UNQUOTE(JSON_EXTRACT(ua.payload, '$.software_title_name')), ''),
+				'software_package', COALESCE(si.filename, JSON_UNQUOTE(JSON_EXTRACT(ua.payload, '$.installer_filename')), ''),
 				'install_uuid', ua.execution_id,
 				'status', 'pending_install',
-				'self_service', ua.payload->'$.self_service' IS TRUE,
-				'source', COALESCE(st.source, ua.payload->>'$.source'),
+				'self_service', JSON_EXTRACT(ua.payload, '$.self_service') IS TRUE,
+				'source', COALESCE(st.source, JSON_UNQUOTE(JSON_EXTRACT(ua.payload, '$.source'))),
 				'policy_id', siua.policy_id,
 				'policy_name', p.name
 			) as details,
@@ -172,21 +172,21 @@ func (ds *Datastore) ListHostUpcomingActivities(ctx context.Context, hostID uint
 		// list pending software uninstalls
 		`SELECT
 			ua.execution_id as uuid,
-			IF(ua.fleet_initiated, 'Fleet', COALESCE(u.name, ua.payload->>'$.user.name')) AS name,
+			IF(ua.fleet_initiated, 'Fleet', COALESCE(u.name, JSON_UNQUOTE(JSON_EXTRACT(ua.payload, '$.user.name')))) AS name,
 			ua.user_id as user_id,
 			u.api_only as api_only,
-			COALESCE(u.gravatar_url, ua.payload->>'$.user.gravatar_url') as gravatar_url,
-			COALESCE(u.email, ua.payload->>'$.user.email') as user_email,
+			COALESCE(u.gravatar_url, JSON_UNQUOTE(JSON_EXTRACT(ua.payload, '$.user.gravatar_url'))) as gravatar_url,
+			COALESCE(u.email, JSON_UNQUOTE(JSON_EXTRACT(ua.payload, '$.user.email'))) as user_email,
 			:uninstalled_software_type as activity_type,
 			ua.created_at as created_at,
 			JSON_OBJECT(
 				'host_id', ua.host_id,
 				'host_display_name', COALESCE(hdn.display_name, ''),
-				'software_title', COALESCE(st.name, ua.payload->>'$.software_title_name', ''),
+				'software_title', COALESCE(st.name, JSON_UNQUOTE(JSON_EXTRACT(ua.payload, '$.software_title_name')), ''),
 				'script_execution_id', ua.execution_id,
 				'status', 'pending_uninstall',
-				'self_service', COALESCE(ua.payload->'$.self_service', FALSE) IS TRUE,
-				'source', COALESCE(st.source, ua.payload->>'$.source'),
+				'self_service', COALESCE(JSON_EXTRACT(ua.payload, '$.self_service'), FALSE) IS TRUE,
+				'source', COALESCE(st.source, JSON_UNQUOTE(JSON_EXTRACT(ua.payload, '$.source'))),
 				'policy_id', siua.policy_id,
 				'policy_name', p.name
 			) as details,
@@ -214,11 +214,11 @@ func (ds *Datastore) ListHostUpcomingActivities(ctx context.Context, hostID uint
 		// list pending VPP apps
 		`SELECT
 			ua.execution_id AS uuid,
-			IF(ua.fleet_initiated, 'Fleet', COALESCE(u.name, ua.payload->>'$.user.name')) AS name,
+			IF(ua.fleet_initiated, 'Fleet', COALESCE(u.name, JSON_UNQUOTE(JSON_EXTRACT(ua.payload, '$.user.name')))) AS name,
 			u.id AS user_id,
 			u.api_only as api_only,
-			COALESCE(u.gravatar_url, ua.payload->>'$.user.gravatar_url') as gravatar_url,
-			COALESCE(u.email, ua.payload->>'$.user.email') as user_email,
+			COALESCE(u.gravatar_url, JSON_UNQUOTE(JSON_EXTRACT(ua.payload, '$.user.gravatar_url'))) as gravatar_url,
+			COALESCE(u.email, JSON_UNQUOTE(JSON_EXTRACT(ua.payload, '$.user.email'))) as user_email,
 			:installed_app_store_app_type AS activity_type,
 			ua.created_at AS created_at,
 			JSON_OBJECT(
@@ -227,7 +227,7 @@ func (ds *Datastore) ListHostUpcomingActivities(ctx context.Context, hostID uint
 				'software_title', COALESCE(st.name, ''),
 				'app_store_id', vaua.adam_id,
 				'command_uuid', ua.execution_id,
-				'self_service', ua.payload->'$.self_service' IS TRUE,
+				'self_service', JSON_EXTRACT(ua.payload, '$.self_service') IS TRUE,
 				'status', 'pending_install',
 				'host_platform', h.platform
 			) AS details,
@@ -255,11 +255,11 @@ func (ds *Datastore) ListHostUpcomingActivities(ctx context.Context, hostID uint
 		// list pending in-house apps
 		`SELECT
 			ua.execution_id AS uuid,
-			IF(ua.fleet_initiated, 'Fleet', COALESCE(u.name, ua.payload->>'$.user.name')) AS name,
+			IF(ua.fleet_initiated, 'Fleet', COALESCE(u.name, JSON_UNQUOTE(JSON_EXTRACT(ua.payload, '$.user.name')))) AS name,
 			u.id AS user_id,
 			u.api_only as api_only,
-			COALESCE(u.gravatar_url, ua.payload->>'$.user.gravatar_url') as gravatar_url,
-			COALESCE(u.email, ua.payload->>'$.user.email') as user_email,
+			COALESCE(u.gravatar_url, JSON_UNQUOTE(JSON_EXTRACT(ua.payload, '$.user.gravatar_url'))) as gravatar_url,
+			COALESCE(u.email, JSON_UNQUOTE(JSON_EXTRACT(ua.payload, '$.user.email'))) as user_email,
 			:installed_software_type as activity_type,
 			ua.created_at AS created_at,
 			JSON_OBJECT(
@@ -267,7 +267,7 @@ func (ds *Datastore) ListHostUpcomingActivities(ctx context.Context, hostID uint
 				'host_display_name', COALESCE(hdn.display_name, ''),
 				'software_title', COALESCE(st.name, ''),
 				'command_uuid', ua.execution_id,
-				'self_service', ua.payload->'$.self_service' IS TRUE,
+				'self_service', JSON_EXTRACT(ua.payload, '$.self_service') IS TRUE,
 				'status', 'pending_install'
 			) AS details,
 			IF(ua.activated_at IS NULL, 0, 1) as topmost,
@@ -525,7 +525,7 @@ func (ds *Datastore) cancelHostUpcomingActivity(ctx context.Context, tx sqlx.Ext
 		ua.activity_type,
 		ua.host_id,
 		COALESCE(hdn.display_name, '') as host_display_name,
-		COALESCE(st.name, ua.payload->>'$.software_title_name', '') as canceled_name, -- software title name in this case
+		COALESCE(st.name, JSON_UNQUOTE(JSON_EXTRACT(ua.payload, '$.software_title_name')), '') as canceled_name, -- software title name in this case
 		st.id as canceled_id,
 		IF(ua.activated_at IS NULL, 0, 1) as activated
 	FROM
@@ -549,7 +549,7 @@ func (ds *Datastore) cancelHostUpcomingActivity(ctx context.Context, tx sqlx.Ext
 		ua.activity_type,
 		ua.host_id,
 		COALESCE(hdn.display_name, '') as host_display_name,
-		COALESCE(st.name, ua.payload->>'$.software_title_name', '') as canceled_name, -- software title name in this case
+		COALESCE(st.name, JSON_UNQUOTE(JSON_EXTRACT(ua.payload, '$.software_title_name')), '') as canceled_name, -- software title name in this case
 		st.id as canceled_id,
 		IF(ua.activated_at IS NULL, 0, 1) as activated
 	FROM
@@ -1158,9 +1158,9 @@ SELECT
 	sua.script_id,
 	sua.policy_id,
 	ua.user_id,
-	COALESCE(ua.payload->'$.sync_request', 0),
+	COALESCE(JSON_EXTRACT(ua.payload, '$.sync_request'), 0),
 	sua.setup_experience_script_id,
-	COALESCE(ua.payload->'$.is_internal', 0)
+	COALESCE(JSON_EXTRACT(ua.payload, '$.is_internal'), 0)
 FROM
 	upcoming_activities ua
 	INNER JOIN script_upcoming_activities sua
@@ -1196,19 +1196,19 @@ SELECT
 	ua.host_id,
 	siua.software_installer_id,
 	ua.user_id,
-	COALESCE(ua.payload->'$.self_service', 0),
+	COALESCE(JSON_EXTRACT(ua.payload, '$.self_service'), 0),
 	siua.policy_id,
-	COALESCE(si.filename, ua.payload->>'$.installer_filename', '[deleted installer]'),
-	COALESCE(si.version, ua.payload->>'$.version', 'unknown'),
+	COALESCE(si.filename, JSON_UNQUOTE(JSON_EXTRACT(ua.payload, '$.installer_filename')), '[deleted installer]'),
+	COALESCE(si.version, JSON_UNQUOTE(JSON_EXTRACT(ua.payload, '$.version')), 'unknown'),
 	COALESCE(si.title_id, siua.software_title_id),
-	COALESCE(st.name, ua.payload->>'$.software_title_name', '[deleted title]'),
+	COALESCE(st.name, JSON_UNQUOTE(JSON_EXTRACT(ua.payload, '$.software_title_name')), '[deleted title]'),
 	-- Compute the attempt number for this activation. Each retry creates a
 	-- new upcoming_activity (via InsertSoftwareInstallRequest), so when that
 	-- new activity activates, COUNT(*) of previous completed attempts gives
 	-- the number of prior tries. +1 makes this the next attempt in sequence:
 	-- first install = 1, first retry = 2, second retry = 3, etc.
 	CASE
-		WHEN siua.policy_id IS NULL AND COALESCE(ua.payload->'$.with_retries', 0) = 1 THEN (
+		WHEN siua.policy_id IS NULL AND COALESCE(JSON_EXTRACT(ua.payload, '$.with_retries'), 0) = 1 THEN (
 			SELECT COUNT(*) + 1
 			FROM host_software_installs hsi2
 			WHERE hsi2.host_id = ua.host_id
@@ -1286,8 +1286,8 @@ SELECT
 	1,  -- uninstall
 	'', -- no installer_filename for uninstalls
 	COALESCE(si.title_id, siua.software_title_id),
-	COALESCE(st.name, ua.payload->>'$.software_title_name', '[deleted title]'),
-	COALESCE(ua.payload->>'$.self_service', FALSE),
+	COALESCE(st.name, JSON_UNQUOTE(JSON_EXTRACT(ua.payload, '$.software_title_name')), '[deleted title]'),
+	COALESCE(JSON_UNQUOTE(JSON_EXTRACT(ua.payload, '$.self_service')), FALSE),
 	'unknown'
 FROM
 	upcoming_activities ua
@@ -1342,8 +1342,8 @@ SELECT
 	vaua.platform,
 	ua.execution_id,
 	ua.user_id,
-	ua.payload->>'$.associated_event_id',
-	COALESCE(ua.payload->'$.self_service', 0),
+	JSON_UNQUOTE(JSON_EXTRACT(ua.payload, '$.associated_event_id')),
+	COALESCE(JSON_EXTRACT(ua.payload, '$.self_service'), 0),
 	vaua.policy_id
 FROM
 	upcoming_activities ua
@@ -1388,7 +1388,7 @@ SELECT
 	ua.execution_id,
 	ua.user_id,
 	iha.platform,
-	COALESCE(ua.payload->'$.self_service', 0)
+	COALESCE(JSON_EXTRACT(ua.payload, '$.self_service'), 0)
 FROM
 	upcoming_activities ua
 	INNER JOIN in_house_app_upcoming_activities ihua
@@ -1672,7 +1672,7 @@ var policyAutomationTaskBranches = []policyAutomationTaskBranch{
 		joins: `
             INNER JOIN host_script_results hsr
                 ON  hsr.host_id      = ahp.host_id
-                AND hsr.execution_id = ap.details->>'$.script_execution_id'
+                AND hsr.execution_id = JSON_UNQUOTE(JSON_EXTRACT(ap.details, '$.script_execution_id'))
                 AND hsr.policy_id    = ?`,
 		errorCond:   "hsr.exit_code IS NOT NULL AND hsr.exit_code != 0",
 		successCond: "hsr.exit_code = 0",
@@ -1686,7 +1686,7 @@ var policyAutomationTaskBranches = []policyAutomationTaskBranch{
 		joins: `
             INNER JOIN host_software_installs hsi
                 ON  hsi.host_id      = ahp.host_id
-                AND hsi.execution_id = ap.details->>'$.install_uuid'
+                AND hsi.execution_id = JSON_UNQUOTE(JSON_EXTRACT(ap.details, '$.install_uuid'))
                 AND hsi.policy_id    = ?`,
 		// Outcome comes from the recorded details.status (a historical snapshot),
 		// not the live host_software_installs status, which goes NULL once the row
@@ -1697,13 +1697,13 @@ var policyAutomationTaskBranches = []policyAutomationTaskBranch{
 		// 'failed_install' is treated as the sole failure and anything else (an
 		// unexpected or empty status) as success, so errorCond and successCond are
 		// null-safe complements that exactly partition what statusCols reports.
-		errorCond:   "ap.details->>'$.status' = 'failed_install'",
-		successCond: "NOT (ap.details->>'$.status' <=> 'failed_install')",
+		errorCond:   "JSON_UNQUOTE(JSON_EXTRACT(ap.details, '$.status')) = 'failed_install'",
+		successCond: "NOT (JSON_UNQUOTE(JSON_EXTRACT(ap.details, '$.status')) <=> 'failed_install')",
 		// A software install can fail at the pre-install query, install script, or
 		// post-install script stage, so surface all three outputs; the modal shows
 		// them as separate sections.
 		statusCols: statusOutputCols{
-			status:            "IF(ap.details->>'$.status' = 'failed_install', 'error', 'success')",
+			status:            "IF(JSON_UNQUOTE(JSON_EXTRACT(ap.details, '$.status')) = 'failed_install', 'error', 'success')",
 			output:            "hsi.install_script_output",
 			preInstallOutput:  "hsi.pre_install_query_output",
 			postInstallOutput: "hsi.post_install_script_output",
@@ -1714,7 +1714,7 @@ var policyAutomationTaskBranches = []policyAutomationTaskBranch{
 		joins: `
             INNER JOIN host_vpp_software_installs hvsi
                 ON  hvsi.host_id      = ahp.host_id
-                AND hvsi.command_uuid = ap.details->>'$.command_uuid'
+                AND hvsi.command_uuid = JSON_UNQUOTE(JSON_EXTRACT(ap.details, '$.command_uuid'))
                 AND hvsi.policy_id    = ?`,
 		// Like installed_software, a VPP activity is only written in a terminal
 		// state — either on a command error (apple_mdm.go) or once the install is
@@ -1725,12 +1725,12 @@ var policyAutomationTaskBranches = []policyAutomationTaskBranch{
 		// removed. 'failed_install' is the sole failure; everything else is a
 		// success. error and success conditions are null-safe complements that
 		// exactly partition what statusCols reports.
-		errorCond:   "ap.details->>'$.status' = 'failed_install'",
-		successCond: "NOT (ap.details->>'$.status' <=> 'failed_install')",
+		errorCond:   "JSON_UNQUOTE(JSON_EXTRACT(ap.details, '$.status')) = 'failed_install'",
+		successCond: "NOT (JSON_UNQUOTE(JSON_EXTRACT(ap.details, '$.status')) <=> 'failed_install')",
 		// VPP apps are installed via MDM command, not a script, so there is no
 		// script output to surface.
 		statusCols: statusOutputCols{
-			status: "IF(ap.details->>'$.status' = 'failed_install', 'error', 'success')",
+			status: "IF(JSON_UNQUOTE(JSON_EXTRACT(ap.details, '$.status')) = 'failed_install', 'error', 'success')",
 			output: "NULL",
 		},
 	},
@@ -1760,7 +1760,7 @@ func buildPolicyAutomationBranches(ds *Datastore, policyID uint, filter fleet.Te
 	}
 	namedSQL, namedArgs, err := sqlx.In(fmt.Sprintf(`SELECT %s, %s FROM activity_past ap %s
         WHERE ap.activity_type IN (?)
-          AND ap.details->>'$.policy_id' = ?
+          AND JSON_UNQUOTE(JSON_EXTRACT(ap.details, '$.policy_id')) = ?
           AND %s`, policyAutomationCols, policyAutomationNamedStatusCols.sql(), policyAutomationHostJoin, teamFilterSQL), namedTypes, policyID)
 	if err != nil {
 		return nil, err

--- a/server/datastore/mysql/android.go
+++ b/server/datastore/mysql/android.go
@@ -881,9 +881,9 @@ func (ds *Datastore) UpdateMDMAndroidConfigProfile(ctx context.Context, cp fleet
 			// Preserve uploaded_at on unchanged content (matching the batch
 			// upsert) so a no-op edit doesn't read as a fresh upload. The IF sees
 			// the pre-update raw_json (SET evaluates left to right), and the
-			// parameter must be CAST to JSON -- a json column never equals a
+			// comparison must be dialect-aware -- a json column never equals a
 			// bare string.
-			stmt := `UPDATE mdm_android_configuration_profiles SET uploaded_at = IF(raw_json = CAST(? AS JSON), uploaded_at, CURRENT_TIMESTAMP()), raw_json = ? WHERE profile_uuid = ? AND name = ?`
+			stmt := `UPDATE mdm_android_configuration_profiles SET uploaded_at = IF(` + ds.dialect.JSONEquals("raw_json", "?") + `, uploaded_at, CURRENT_TIMESTAMP()), raw_json = ? WHERE profile_uuid = ? AND name = ?`
 			res, err := tx.ExecContext(ctx, stmt, cp.RawJSON, cp.RawJSON, cp.ProfileUUID, cp.Name)
 			if err != nil {
 				return ctxerr.Wrap(ctx, err, "updating android mdm config profile contents")
@@ -2375,11 +2375,11 @@ WHERE
 
 // HasAndroidAppConfigurationChanged checks if the new configuration for an Android app
 // identified by application_id and global_or_team_id is different from the existing one. This
-// is a datastore method so that we rely on mysql's canonicalisation of JSON for comparison.
+// is a datastore method so that we rely on the database's canonicalisation of JSON for comparison.
 func (ds *Datastore) HasAndroidAppConfigurationChanged(ctx context.Context, applicationID string, teamID uint, newConfig []byte) (bool, error) {
-	const stmt = `
+	stmt := `
 SELECT
-	CAST(? AS JSON) != configuration AS has_changed
+	` + ds.dialect.JSONNotEquals("configuration", "?") + ` AS has_changed
 FROM
 	android_app_configurations
 WHERE

--- a/server/datastore/mysql/app_configs.go
+++ b/server/datastore/mysql/app_configs.go
@@ -201,10 +201,19 @@ func applyEnrollSecretsDB(ctx context.Context, q sqlx.ExtContext, teamID *uint, 
 		args = append(args, *teamID)
 	}
 
-	// first, load the existing secrets and their created_at timestamp
+	// First, load the existing secrets and their created_at timestamp.
+	//
+	// This read is locking (FOR UPDATE) because the rows it returns are the very
+	// rows deleted and re-inserted below. Without the lock the SELECT is a
+	// consistent-snapshot read, so a concurrent writer can modify a row between
+	// the read and the DELETE. MariaDB reports that as
+	// Error 1020 (ER_CHECKREAD) "Record has changed since last read in table
+	// 'enroll_secrets'" and fails the transaction; MySQL silently proceeds and
+	// can carry over a stale created_at. Locking the rows up front makes the
+	// read-delete-insert sequence atomic on both engines.
 	const loadStmt = `SELECT secret, created_at FROM enroll_secrets WHERE `
 	var existingSecrets []*fleet.EnrollSecret
-	if err := sqlx.SelectContext(ctx, q, &existingSecrets, loadStmt+teamWhere, args...); err != nil {
+	if err := sqlx.SelectContext(ctx, q, &existingSecrets, loadStmt+teamWhere+` FOR UPDATE`, args...); err != nil {
 		return ctxerr.Wrap(ctx, err, "load existing secrets")
 	}
 	secretsCreatedAt := make(map[string]*time.Time, len(existingSecrets))

--- a/server/datastore/mysql/apple_device_names.go
+++ b/server/datastore/mysql/apple_device_names.go
@@ -54,7 +54,7 @@ const deviceNameEligibleHostsWhere = `
 // matching the empty-string semantics the Go optjson value uses.
 const deviceNameNoTeamTemplateExpr = `(SELECT IF(
 	JSON_TYPE(JSON_EXTRACT(json_value, '$.mdm.name_template')) = 'STRING',
-	json_value->>'$.mdm.name_template', '') FROM app_config_json LIMIT 1)`
+	JSON_UNQUOTE(JSON_EXTRACT(json_value, '$.mdm.name_template')), '') FROM app_config_json LIMIT 1)`
 
 func deviceNameTeamScope(teamID *uint) (filter string, args []any) {
 	if teamID != nil && *teamID > 0 {
@@ -328,7 +328,7 @@ func (ds *Datastore) resendDeviceNamesForSecretChange(ctx context.Context, chang
 	// Teams whose template references a changed secret.
 	var teamIDs []uint
 	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &teamIDs,
-		`SELECT id FROM teams WHERE COALESCE(config->>'$.mdm.name_template', '') REGEXP ?`, pattern); err != nil {
+		`SELECT id FROM teams WHERE COALESCE(JSON_UNQUOTE(JSON_EXTRACT(config, '$.mdm.name_template')), '') REGEXP ?`, pattern); err != nil {
 		return ctxerr.Wrap(ctx, err, "select teams using changed secret in device name template")
 	}
 
@@ -366,7 +366,7 @@ func resendDeviceNameForCustomHostVital(ctx context.Context, tx sqlx.ExtContext,
 		SELECT COALESCE(
 			CASE WHEN h.team_id IS NULL
 				THEN `+deviceNameNoTeamTemplateExpr+`
-				ELSE (SELECT t.config->>'$.mdm.name_template' FROM teams t WHERE t.id = h.team_id)
+				ELSE (SELECT JSON_UNQUOTE(JSON_EXTRACT(t.config, '$.mdm.name_template')) FROM teams t WHERE t.id = h.team_id)
 			END, '')
 		FROM hosts h WHERE h.id = ?`, hostID)
 	if err != nil {
@@ -451,7 +451,7 @@ func reconcileHostDeviceNamesForHostsDB(ctx context.Context, tx sqlx.ExtContext,
 		AND COALESCE(
 			CASE WHEN h.team_id IS NULL
 				THEN `+deviceNameNoTeamTemplateExpr+`
-				ELSE (SELECT t.config->>'$.mdm.name_template' FROM teams t WHERE t.id = h.team_id)
+				ELSE (SELECT JSON_UNQUOTE(JSON_EXTRACT(t.config, '$.mdm.name_template')) FROM teams t WHERE t.id = h.team_id)
 			END, '') != ''`)
 }
 
@@ -470,7 +470,7 @@ func reconcileHostDeviceNamesForTeamDB(ctx context.Context, tx sqlx.ExtContext, 
 	var tmpl string
 	if teamID != nil && *teamID > 0 {
 		if err := sqlx.GetContext(ctx, tx, &tmpl,
-			`SELECT COALESCE(config->>'$.mdm.name_template', '') FROM teams WHERE id = ?`, *teamID); err != nil {
+			`SELECT COALESCE(JSON_UNQUOTE(JSON_EXTRACT(config, '$.mdm.name_template')), '') FROM teams WHERE id = ?`, *teamID); err != nil {
 			return ctxerr.Wrap(ctx, err, "resolve team name template")
 		}
 	} else if err := sqlx.GetContext(ctx, tx, &tmpl,

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -9847,9 +9847,9 @@ func TestGetMDMAppleOSUpdatesSettingsByHostSerial(t *testing.T) {
 	getConfigSettings := func(teamID uint, key string) *fleet.AppleOSUpdateSettings {
 		var settings fleet.AppleOSUpdateSettings
 		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
-			stmt := fmt.Sprintf(`SELECT json_value->'$.mdm.%s_updates' FROM app_config_json`, key)
+			stmt := fmt.Sprintf(`SELECT JSON_EXTRACT(json_value, '$.mdm.%s_updates') FROM app_config_json`, key)
 			if teamID > 0 {
-				stmt = fmt.Sprintf(`SELECT config->'$.mdm.%s_updates' FROM teams WHERE id = %d`, key, teamID)
+				stmt = fmt.Sprintf(`SELECT JSON_EXTRACT(config, '$.mdm.%s_updates') FROM teams WHERE id = %d`, key, teamID)
 			}
 			var raw json.RawMessage
 			if err := sqlx.GetContext(context.Background(), q, &raw, stmt); err != nil {

--- a/server/datastore/mysql/custom_host_vitals.go
+++ b/server/datastore/mysql/custom_host_vitals.go
@@ -238,14 +238,14 @@ func (ds *Datastore) customHostVitalUsedBy(ctx context.Context, tx sqlx.ExtConte
 		{
 			desc: "get host name template contents",
 			stmt: `SELECT 'host_name_template' AS entity, 'Host name' AS name,
-				t.name AS team_name, t.config->>'$.mdm.name_template' AS contents
+				t.name AS team_name, JSON_UNQUOTE(JSON_EXTRACT(t.config, '$.mdm.name_template')) AS contents
 				FROM teams t
-				WHERE COALESCE(t.config->>'$.mdm.name_template', '') != ''
+				WHERE COALESCE(JSON_UNQUOTE(JSON_EXTRACT(t.config, '$.mdm.name_template')), '') != ''
 				UNION ALL
 				SELECT 'host_name_template' AS entity, 'Host name' AS name,
-				'Unassigned' AS team_name, json_value->>'$.mdm.name_template' AS contents
+				'Unassigned' AS team_name, JSON_UNQUOTE(JSON_EXTRACT(json_value, '$.mdm.name_template')) AS contents
 				FROM app_config_json
-				WHERE COALESCE(json_value->>'$.mdm.name_template', '') != '';`,
+				WHERE COALESCE(JSON_UNQUOTE(JSON_EXTRACT(json_value, '$.mdm.name_template')), '') != '';`,
 		},
 	}
 

--- a/server/datastore/mysql/dialect.go
+++ b/server/datastore/mysql/dialect.go
@@ -1,0 +1,148 @@
+package mysql
+
+import (
+	"database/sql"
+	"strings"
+	"sync"
+)
+
+type DBDialect int
+
+const (
+	DialectUnknown DBDialect = iota
+	DialectMySQL
+	DialectMariaDB
+)
+
+func (d DBDialect) String() string {
+	switch d {
+	case DialectMySQL:
+		return "MySQL"
+	case DialectMariaDB:
+		return "MariaDB"
+	default:
+		return "Unknown"
+	}
+}
+
+type dialectDetector struct {
+	mu      sync.RWMutex
+	dialect DBDialect
+	version string
+}
+
+var globalDialect = &dialectDetector{
+	dialect: DialectUnknown,
+}
+
+// DetectDialect detects whether the database is MySQL or MariaDB
+func DetectDialect(db *sql.DB) (DBDialect, string, error) {
+	globalDialect.mu.RLock()
+	if globalDialect.dialect != DialectUnknown {
+		defer globalDialect.mu.RUnlock()
+		return globalDialect.dialect, globalDialect.version, nil
+	}
+	globalDialect.mu.RUnlock()
+
+	globalDialect.mu.Lock()
+	defer globalDialect.mu.Unlock()
+
+	if globalDialect.dialect != DialectUnknown {
+		return globalDialect.dialect, globalDialect.version, nil
+	}
+
+	var version string
+	err := db.QueryRow("SELECT VERSION()").Scan(&version)
+	if err != nil {
+		return DialectUnknown, "", err
+	}
+
+	// MariaDB version strings contain "MariaDB"
+	// Example: "11.6.2-MariaDB-1:11.6.2+maria~ubu2404"
+	// MySQL version strings look like: "8.0.36"
+	dialect := DialectMySQL
+	if strings.Contains(version, "MariaDB") {
+		dialect = DialectMariaDB
+	}
+
+	globalDialect.dialect = dialect
+	globalDialect.version = version
+	return dialect, version, nil
+}
+
+func IsMariaDB(db *sql.DB) bool {
+	dialect, _, _ := DetectDialect(db)
+	return dialect == DialectMariaDB
+}
+
+func IsMySQL(db *sql.DB) bool {
+	dialect, _, _ := DetectDialect(db)
+	return dialect == DialectMySQL
+}
+
+type SQLDialect struct {
+	db *sql.DB
+}
+
+func NewSQLDialect(db *sql.DB) *SQLDialect {
+	return &SQLDialect{db: db}
+}
+
+// JSONBoolTrue returns the SQL for a true boolean value in JSON context
+// MySQL: CAST(TRUE AS JSON)
+// MariaDB: true
+func (s *SQLDialect) JSONBoolTrue() string {
+	if IsMariaDB(s.db) {
+		return "true"
+	}
+	return "CAST(TRUE AS JSON)"
+}
+
+// JSONBoolFalse returns the SQL for a false boolean value in JSON context
+// MySQL: CAST(FALSE AS JSON)
+// MariaDB: false
+func (s *SQLDialect) JSONBoolFalse() string {
+	if IsMariaDB(s.db) {
+		return "false"
+	}
+	return "CAST(FALSE AS JSON)"
+}
+
+// GeneratedColumnStoredSuffix returns the suffix for generated stored columns
+// MySQL: STORED or STORED NOT NULL
+// MariaDB: STORED only (doesn't support NOT NULL after STORED)
+func (s *SQLDialect) GeneratedColumnStoredSuffix(nullable bool) string {
+	if IsMariaDB(s.db) {
+		return "STORED"
+	}
+	if nullable {
+		return "STORED"
+	}
+	return "STORED NOT NULL"
+}
+
+//////////
+//
+// TODO maybe use these maybe don't
+//
+/////////
+
+// JSONExtractText returns SQL to extract a text value from a JSON path
+// MySQL: column->>'$.path' (shorthand for JSON_UNQUOTE(JSON_EXTRACT(...)))
+// MariaDB: JSON_UNQUOTE(JSON_EXTRACT(column, '$.path'))
+// func (s *SQLDialect) JSONExtractText(column, path string) string {
+// 	if IsMariaDB(s.db) {
+// 		return "JSON_UNQUOTE(JSON_EXTRACT(" + column + ", '" + path + "'))"
+// 	}
+// 	return column + "->>" + "'" + path + "'"
+// }
+
+// JSONExtract returns SQL to extract a JSON value from a JSON path
+// MySQL: column->'$.path' (shorthand for JSON_EXTRACT(...))
+// MariaDB: JSON_EXTRACT(column, '$.path')
+// func (s *SQLDialect) JSONExtract(column, path string) string {
+// 	if IsMariaDB(s.db) {
+// 		return "JSON_EXTRACT(" + column + ", '" + path + "')"
+// 	}
+// 	return column + "->" + "'" + path + "'"
+//}

--- a/server/datastore/mysql/dialect.go
+++ b/server/datastore/mysql/dialect.go
@@ -121,28 +121,27 @@ func (s *SQLDialect) GeneratedColumnStoredSuffix(nullable bool) string {
 	return "STORED NOT NULL"
 }
 
-//////////
+// JSONEquals returns SQL comparing two JSON expressions for semantic equality,
+// ignoring key order and insignificant whitespace.
 //
-// TODO maybe use these maybe don't
+// MySQL stores JSON in a native binary type, so comparing the column against
+// CAST(expr AS JSON) compares parsed values. MariaDB has no JSON type -- JSON is
+// an alias for LONGTEXT -- so CAST(... AS JSON) is a syntax error and a bare
+// comparison would be a raw string compare. JSON_NORMALIZE puts both sides into
+// a canonical form so the comparison stays semantic.
 //
-/////////
+// Note that on MariaDB this wraps the column, so it cannot use an index on it.
+func (s *SQLDialect) JSONEquals(left, right string) string {
+	if IsMariaDB(s.db) {
+		return "JSON_NORMALIZE(" + left + ") = JSON_NORMALIZE(" + right + ")"
+	}
+	return left + " = CAST(" + right + " AS JSON)"
+}
 
-// JSONExtractText returns SQL to extract a text value from a JSON path
-// MySQL: column->>'$.path' (shorthand for JSON_UNQUOTE(JSON_EXTRACT(...)))
-// MariaDB: JSON_UNQUOTE(JSON_EXTRACT(column, '$.path'))
-// func (s *SQLDialect) JSONExtractText(column, path string) string {
-// 	if IsMariaDB(s.db) {
-// 		return "JSON_UNQUOTE(JSON_EXTRACT(" + column + ", '" + path + "'))"
-// 	}
-// 	return column + "->>" + "'" + path + "'"
-// }
-
-// JSONExtract returns SQL to extract a JSON value from a JSON path
-// MySQL: column->'$.path' (shorthand for JSON_EXTRACT(...))
-// MariaDB: JSON_EXTRACT(column, '$.path')
-// func (s *SQLDialect) JSONExtract(column, path string) string {
-// 	if IsMariaDB(s.db) {
-// 		return "JSON_EXTRACT(" + column + ", '" + path + "')"
-// 	}
-// 	return column + "->" + "'" + path + "'"
-//}
+// JSONNotEquals is the negation of JSONEquals.
+func (s *SQLDialect) JSONNotEquals(left, right string) string {
+	if IsMariaDB(s.db) {
+		return "JSON_NORMALIZE(" + left + ") != JSON_NORMALIZE(" + right + ")"
+	}
+	return left + " != CAST(" + right + " AS JSON)"
+}

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -888,7 +888,7 @@ SELECT
   hoi.desktop_version AS fleet_desktop_version,
   hoi.scripts_enabled AS scripts_enabled,
   IF(hdep.host_id AND ISNULL(hdep.deleted_at), true, false) AS dep_assigned_to_fleet
-  ` + hostMDMSelect + `
+  ` + ds.hostMDMSelect() + `
 FROM
   hosts h
   LEFT JOIN teams t ON (h.team_id = t.id)
@@ -994,15 +994,18 @@ func queryStatsToScheduledQueryStats(queriesStats []fleet.QueryStats, packName s
 	return scheduledQueriesStats
 }
 
-// hostMDMSelect is the SQL fragment used to construct the JSON object
-// of MDM host data. It assumes that hostMDMJoin is included in the query.
-const hostMDMSelect = `,
+// hostMDMSelect generates the SQL fragment used to construct the JSON object
+// of MDM host data. It uses dialect-specific helpers for boolean values, since
+// MariaDB has no JSON type and so rejects CAST(... AS JSON).
+// It assumes that hostMDMJoin is included in the query.
+func (ds *Datastore) hostMDMSelect() string {
+	return `,
 	JSON_OBJECT(
 		'enrollment_status', hmdm.enrollment_status,
 		'dep_profile_error',
 		CASE
-			WHEN hdep.assign_profile_response IN ('` + string(fleet.DEPAssignProfileResponseFailed) + `', '` + string(fleet.DEPAssignProfileResponseThrottled) + `') THEN CAST(TRUE AS JSON)
-			ELSE CAST(FALSE AS JSON)
+			WHEN hdep.assign_profile_response IN ('` + string(fleet.DEPAssignProfileResponseFailed) + `', '` + string(fleet.DEPAssignProfileResponseThrottled) + `') THEN ` + ds.dialect.JSONBoolTrue() + `
+			ELSE ` + ds.dialect.JSONBoolFalse() + `
 		END,
 		'server_url',
 		CASE
@@ -1016,8 +1019,8 @@ const hostMDMSelect = `,
 			* unmarshaller was having problems converting int values to
 			* booleans.
 			*/
-			WHEN hdek.decryptable IS NULL OR hdek.decryptable = 0 THEN CAST(FALSE AS JSON)
-			ELSE CAST(TRUE AS JSON)
+			WHEN hdek.decryptable IS NULL OR hdek.decryptable = 0 THEN ` + ds.dialect.JSONBoolFalse() + `
+			ELSE ` + ds.dialect.JSONBoolTrue() + `
 		END,
 		'raw_decryptable',
 		CASE
@@ -1027,42 +1030,43 @@ const hostMDMSelect = `,
 		'connected_to_fleet',
 		CASE
 			WHEN h.platform = 'windows' THEN (` +
-	// NOTE: if you change any of the conditions in this
-	// query, please update the AreHostsConnectedToFleetMDM
-	// datastore method and any relevant filters.
-	`SELECT CASE WHEN EXISTS (
+		// NOTE: if you change any of the conditions in this
+		// query, please update the AreHostsConnectedToFleetMDM
+		// datastore method and any relevant filters.
+		`SELECT CASE WHEN EXISTS (
 				    SELECT mwe.host_uuid
 				    FROM mdm_windows_enrollments mwe
 				    WHERE mwe.host_uuid = h.uuid
 				    AND mwe.device_state = '` + microsoft_mdm.MDMDeviceStateEnrolled + `'
 				    AND hmdm.enrolled = 1
 				)
-				THEN CAST(TRUE AS JSON)
-				ELSE CAST(FALSE AS JSON)
+				THEN ` + ds.dialect.JSONBoolTrue() + `
+				ELSE ` + ds.dialect.JSONBoolFalse() + `
 				END
 			)
 			WHEN h.platform = 'android' THEN
-				CASE WHEN hmdm.enrolled = 1 THEN CAST(TRUE AS JSON) ELSE CAST(FALSE AS JSON) END
+				CASE WHEN hmdm.enrolled = 1 THEN ` + ds.dialect.JSONBoolTrue() + ` ELSE ` + ds.dialect.JSONBoolFalse() + ` END
 			WHEN h.platform IN ('ios', 'ipados', 'darwin') THEN (` +
-	// NOTE: if you change any of the conditions in this
-	// query, please update the AreHostsConnectedToFleetMDM
-	// datastore method and any relevant filters.
-	`SELECT CASE WHEN EXISTS (
+		// NOTE: if you change any of the conditions in this
+		// query, please update the AreHostsConnectedToFleetMDM
+		// datastore method and any relevant filters.
+		`SELECT CASE WHEN EXISTS (
 				    SELECT ne.id FROM nano_enrollments ne
 				    WHERE ne.id = h.uuid
 				    AND ne.enabled = 1
 				    AND ne.type IN ('Device', 'User Enrollment (Device)')
 				    AND hmdm.enrolled = 1
 				)
-				THEN CAST(TRUE AS JSON)
-				ELSE CAST(FALSE AS JSON)
+				THEN ` + ds.dialect.JSONBoolTrue() + `
+				ELSE ` + ds.dialect.JSONBoolFalse() + `
 				END
 			)
-			ELSE CAST(FALSE AS JSON)
+			ELSE ` + ds.dialect.JSONBoolFalse() + `
 		END,
 		'name', hmdm.name
 	) mdm_host_data
 	`
+}
 
 // hostMDMJoin is the SQL fragment used to join MDM-related tables to the hosts table. It is a
 // dependency of the hostMDMSelect fragment.
@@ -1170,7 +1174,7 @@ func (ds *Datastore) ListHosts(ctx context.Context, filter fleet.TeamFilter, opt
     hoi.desktop_version AS fleet_desktop_version
 	`
 
-	sql += hostMDMSelect
+	sql += ds.hostMDMSelect()
 
 	if opt.DeviceMapping {
 		// Use a correlated subquery in the SELECT list (rather than a derived-table
@@ -3263,7 +3267,7 @@ func (ds *Datastore) SearchHosts(ctx context.Context, filter fleet.TeamFilter, m
     hd.gigs_all_disk_space as gigs_all_disk_space,
     COALESCE(hst.seen_time, h.created_at) AS seen_time,
 	COALESCE(hu.software_updated_at, h.created_at) AS software_updated_at
-	` + hostMDMSelect + `
+	` + ds.hostMDMSelect() + `
   FROM hosts h
   LEFT JOIN host_seen_times hst ON (h.id = hst.host_id)
   LEFT JOIN host_updates hu ON (h.id = hu.host_id)
@@ -3504,7 +3508,7 @@ func (ds *Datastore) HostByIdentifier(ctx context.Context, identifier string) (*
       COALESCE(hd.gigs_total_disk_space, 0) as gigs_total_disk_space,
       COALESCE(hst.seen_time, h.created_at) AS seen_time,
       COALESCE(hu.software_updated_at, h.created_at) AS software_updated_at
-    ` + hostMDMSelect + `
+    ` + ds.hostMDMSelect() + `
     FROM hosts h
     LEFT JOIN teams t ON t.id = h.team_id
     LEFT JOIN host_seen_times hst ON (h.id = hst.host_id)
@@ -3583,7 +3587,7 @@ func (ds *Datastore) HostByUUID(ctx context.Context, uuid string) (*fleet.Host, 
       COALESCE(hd.gigs_total_disk_space, 0) as gigs_total_disk_space,
       COALESCE(hst.seen_time, h.created_at) AS seen_time,
       COALESCE(hu.software_updated_at, h.created_at) AS software_updated_at
-    ` + hostMDMSelect + `
+    ` + ds.hostMDMSelect() + `
     FROM hosts h
     LEFT JOIN teams t ON t.id = h.team_id
     LEFT JOIN host_seen_times hst ON (h.id = hst.host_id)

--- a/server/datastore/mysql/jobs.go
+++ b/server/datastore/mysql/jobs.go
@@ -149,9 +149,9 @@ func (ds *Datastore) CleanupWorkerJobs(ctx context.Context, failedSince, complet
 // is handling thrash from rapid user action such as quickly disabling
 // and re-enabling a chart dataset multiple times.
 func (ds *Datastore) HasQueuedJobWithArgs(ctx context.Context, name string, args json.RawMessage) (bool, error) {
-	const query = `
+	query := `
 SELECT 1 FROM jobs
-WHERE name = ? AND state = ? AND args = CAST(? AS JSON)
+WHERE name = ? AND state = ? AND ` + ds.dialect.JSONEquals("args", "?") + `
 LIMIT 1`
 	var found int
 	ctx = ctxdb.RequirePrimary(ctx, true)

--- a/server/datastore/mysql/labels.go
+++ b/server/datastore/mysql/labels.go
@@ -1282,7 +1282,7 @@ func (ds *Datastore) ListHostsInLabel(ctx context.Context, filter fleet.TeamFilt
 	}
 
 	query := fmt.Sprintf(
-		queryFmt, hostMDMSelect, failingIssuesSelect, deviceMappingSelect, hostMDMJoin, failingIssuesJoin, deviceMappingJoin,
+		queryFmt, ds.hostMDMSelect(), failingIssuesSelect, deviceMappingSelect, hostMDMJoin, failingIssuesJoin, deviceMappingJoin,
 	)
 
 	query, params, err := ds.applyHostLabelFilters(ctx, filter, lid, query, opt)

--- a/server/datastore/mysql/mdm.go
+++ b/server/datastore/mysql/mdm.go
@@ -2265,7 +2265,7 @@ func (ds *Datastore) AreHostsConnectedToFleetMDM(ctx context.Context, hosts []*f
 	}
 
 	// NOTE: if you change any of the conditions in this query, please
-	// update the `hostMDMSelect` constant too, which has a
+	// update the Datastore.hostMDMSelect() method too, which has a
 	// `connected_to_fleet` condition, any relevant filters, and the
 	// query used in isAppleHostConnectedToFleetMDM.
 	const appleStmt = `
@@ -2283,7 +2283,7 @@ func (ds *Datastore) AreHostsConnectedToFleetMDM(ctx context.Context, hosts []*f
 	}
 
 	// NOTE: if you change any of the conditions in this query, please
-	// update the `hostMDMSelect` constant too, which has a
+	// update the Datastore.hostMDMSelect() method too, which has a
 	// `connected_to_fleet` condition, and any relevant filters, and the
 	// query used in isWindowsHostConnectedToFleetMDM.
 	const winStmt = `

--- a/server/datastore/mysql/migrations/tables/migration_test.go
+++ b/server/datastore/mysql/migrations/tables/migration_test.go
@@ -94,6 +94,17 @@ func getMigrationVersion(t *testing.T) int64 {
 //
 // It returns the database connection to perform additional queries and migrations.
 func applyUpToPrev(t *testing.T) *sqlx.DB {
+	// Reaching any given migration means replaying every migration before it,
+	// and the pre-2025 migrations do not run on MariaDB (the first failure is
+	// 20240905200000_UninstallPackages). Applied migrations cannot be rewritten,
+	// so per-migration tests are MySQL-only; MariaDB coverage comes from the
+	// other suites, which start from the schema-mariadb.sql baseline.
+	//
+	// See https://github.com/fleetdm/fleet/issues/34952.
+	if os.Getenv("FLEET_DB_CLIENT") == "mariadb" {
+		t.Skip("replaying migration history is not supported on MariaDB; see fleetdm/fleet#34952")
+	}
+
 	// Run migration tests up to 2 months old. Our releases are on a 3-week
 	// cadence so this safely catches every migration in the release with a bit
 	// of buffer in case of delayed releases.

--- a/server/datastore/mysql/migrations_test.go
+++ b/server/datastore/mysql/migrations_test.go
@@ -15,7 +15,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// skipIfMariaDB skips tests that replay the whole migration history.
+//
+// Migrations written before MariaDB was considered do not run on it. The first
+// failure is 20240905200000_UninstallPackages, which uses the MySQL-only
+// `GENERATED ALWAYS AS (...) STORED NULL` spelling, and there are more after
+// it. Rewriting migrations that have already been applied to production
+// databases is not an option, so MariaDB is brought up from the
+// schema-mariadb.sql baseline instead (see testing_utils.LoadDefaultSchema).
+// Only migrations added after that baseline have to stay MariaDB-compatible,
+// and those are covered by every other suite running against MariaDB.
+//
+// See https://github.com/fleetdm/fleet/issues/34952.
+func skipIfMariaDB(t *testing.T) {
+	t.Helper()
+	if testing_utils.IsMariaDB() {
+		t.Skip("replaying migration history is not supported on MariaDB; see fleetdm/fleet#34952")
+	}
+}
+
 func TestMigrationStatus(t *testing.T) {
+	skipIfMariaDB(t)
 	ds := createMySQLDSForMigrationTests(t, t.Name())
 	t.Cleanup(func() {
 		ds.Close()
@@ -59,6 +79,7 @@ func TestMigrationStatus(t *testing.T) {
 }
 
 func TestV4732MigrationFix(t *testing.T) {
+	skipIfMariaDB(t)
 	ds := createMySQLDSForMigrationTests(t, t.Name())
 	t.Cleanup(func() {
 		ds.Close()
@@ -148,6 +169,7 @@ func recreate4732BadState(t *testing.T, ds *Datastore) {
 }
 
 func TestMigrations(t *testing.T) {
+	skipIfMariaDB(t)
 	// Create the database (must use raw MySQL client to do this)
 	ds := createMySQLDSForMigrationTests(t, t.Name())
 	defer ds.Close()
@@ -167,7 +189,7 @@ func TestMigrations(t *testing.T) {
 	cmd := exec.Command( // nolint:gosec // Waive G204 since this is a test file
 		"docker", "compose", "exec", "-T", "mysql_test",
 		// Command run inside container
-		"mysqldump", "-u"+testing_utils.TestUsername, "-p"+testing_utils.TestPassword, "TestMigrations", "--compact", "--skip-comments",
+		testing_utils.DBDumpClient(), "-u"+testing_utils.TestUsername, "-p"+testing_utils.TestPassword, "TestMigrations", "--compact", "--skip-comments",
 	)
 
 	output, err := cmd.CombinedOutput()

--- a/server/datastore/mysql/mysql.go
+++ b/server/datastore/mysql/mysql.go
@@ -100,6 +100,9 @@ type Datastore struct {
 	// certificates and keys.
 	serverPrivateKey string
 
+	// dialect generates SQL that differs between MySQL and MariaDB.
+	dialect *SQLDialect
+
 	// knownSoftwareTitleKeys caches title keys that are known to exist in software_titles.
 	// This eliminates redundant INSERT IGNORE statements during concurrent software ingestion,
 	// preventing lock convoys on the unique index when many hosts report the same software catalog.
@@ -343,11 +346,16 @@ func NewDatastore(conns *common_mysql.DBConnections, cfg config.MysqlConfig, c c
 		stmtCache:              make(map[string]*sqlx.Stmt),
 		minLastOpenedAtDiff:    conns.Options.MinLastOpenedAtDiff,
 		serverPrivateKey:       conns.Options.PrivateKey,
+		dialect:                NewSQLDialect(conns.Primary.DB),
 		knownSoftwareTitleKeys: make(map[string]struct{}),
 		Datastore:              NewAndroidDatastore(conns.Options.Logger, conns.Primary, conns.Replica),
 	}
 
 	go ds.writeChanLoop()
+
+	if dialect, version, err := DetectDialect(conns.Primary.DB); err == nil {
+		conns.Options.Logger.Info("detected database dialect", "dialect", dialect.String(), "version", version)
+	}
 
 	return ds, nil
 }

--- a/server/datastore/mysql/mysqltest/mysqltest.go
+++ b/server/datastore/mysql/mysqltest/mysqltest.go
@@ -318,7 +318,7 @@ func setupRealReplica(t testing.TB, testName string, ds *mysql.Datastore, option
 		func() {
 			if out, err := exec.Command(
 				"docker", "compose", "exec", "-T", "mysql_replica_test",
-				"mysql",
+				testing_utils.DBClient(),
 				"-u"+testing_utils.TestUsername, "-p"+testing_utils.TestPassword,
 				"-e",
 				"STOP REPLICA; RESET REPLICA ALL;",
@@ -375,7 +375,7 @@ func setupRealReplica(t testing.TB, testName string, ds *mysql.Datastore, option
 
 	if out, err := exec.Command(
 		"docker", "compose", "exec", "-T", "mysql_replica_test",
-		"mysql",
+		testing_utils.DBClient(),
 		"-u"+testing_utils.TestUsername, "-p"+testing_utils.TestPassword,
 		"-e",
 		fmt.Sprintf(

--- a/server/datastore/mysql/operating_system_vulnerabilities.go
+++ b/server/datastore/mysql/operating_system_vulnerabilities.go
@@ -984,26 +984,33 @@ func (ds *Datastore) ListVulnsByMultipleOSVersions(
 			GROUP BY os_version_id`
 
 		case maxVulnerabilities != nil && *maxVulnerabilities > 0:
-			// Use LATERAL JOIN + CTE for optimal performance:
-			// 1. Computing counts via GROUP BY (fast)
-			// 2. Fetching only N CVEs per os_version_id via LATERAL LIMIT (fast)
+			// Counts via GROUP BY, then the top N CVEs per os_version_id.
+			//
+			// Upstream does the second half with CROSS JOIN LATERAL, which MariaDB does
+			// not support -- it fails with a syntax error at the derived table. A ranking
+			// window function expresses the same "N rows per group" and runs on both.
+			idPlaceholders := strings.TrimSuffix(strings.Repeat("?,", len(linuxOSVersionIDs)), ",")
 			kernelQuery = `
 			WITH counts AS (
 				SELECT os_version_id, COUNT(*) as total_count
 				FROM operating_system_version_vulnerabilities
-				WHERE os_version_id IN (` + strings.TrimSuffix(strings.Repeat("?,", len(linuxOSVersionIDs)), ",") + `)` + teamFilter + `
+				WHERE os_version_id IN (` + idPlaceholders + `)` + teamFilter + `
 				GROUP BY os_version_id
-			)
-			SELECT counts.os_version_id, v.cve, v.resolved_in_version, v.created_at, counts.total_count
-			FROM counts
-			CROSS JOIN LATERAL (
-				SELECT cve, resolved_in_version, created_at
+			), ranked AS (
+				SELECT
+					os_version_id, cve, resolved_in_version, created_at,
+					ROW_NUMBER() OVER (PARTITION BY os_version_id ORDER BY cve DESC) AS rn
 				FROM operating_system_version_vulnerabilities
-				WHERE os_version_id = counts.os_version_id` + teamFilter + `
-				ORDER BY cve DESC
-				LIMIT ?
-			) v`
-			// teamFilter is used twice in the query above (CTE and LATERAL), so add teamID again if needed
+				WHERE os_version_id IN (` + idPlaceholders + `)` + teamFilter + `
+			)
+			SELECT counts.os_version_id, ranked.cve, ranked.resolved_in_version, ranked.created_at, counts.total_count
+			FROM counts
+			JOIN ranked ON ranked.os_version_id = counts.os_version_id
+			WHERE ranked.rn <= ?`
+			// The id list and team filter appear in both CTEs, so their arguments repeat.
+			for _, id := range linuxOSVersionIDs {
+				kargs = append(kargs, id)
+			}
 			if teamID != nil {
 				kargs = append(kargs, *teamID)
 			}

--- a/server/datastore/mysql/query_results.go
+++ b/server/datastore/mysql/query_results.go
@@ -375,15 +375,21 @@ func (ds *Datastore) ListHostReports(
 
 	countStmt := "SELECT COUNT(*) FROM queries q " + whereClause
 
-	// Do a LATERAL subquery for each row in queries q so that everything stays in index space
+	// Aggregate this host's results per query, then join on query_id. The
+	// natural spelling is LEFT JOIN LATERAL ... ON TRUE correlated on q.id, but
+	// MariaDB has no LATERAL. A derived table cannot be correlated either, so
+	// the subquery groups by query_id instead of filtering per row -- equivalent
+	// for a single host, and it keeps the qr_stats alias the ordering and
+	// cursor-pagination expressions below are written against.
 	listStmt := `
 		SELECT q.id, q.name, q.description, q.discard_data, q.logging_type, qr_stats.last_result_fetched
 		FROM queries q
-		LEFT JOIN LATERAL (
-			SELECT MAX(last_fetched) AS last_result_fetched
+		LEFT JOIN (
+			SELECT query_id, MAX(last_fetched) AS last_result_fetched
 			FROM query_results
-			WHERE query_id = q.id AND host_id = ?
-		) qr_stats ON TRUE
+			WHERE host_id = ?
+			GROUP BY query_id
+		) qr_stats ON qr_stats.query_id = q.id
 	` + whereClause
 	listArgs := append([]any{hostID}, whereArgs...)
 

--- a/server/datastore/mysql/schema-mariadb.sql
+++ b/server/datastore/mysql/schema-mariadb.sql
@@ -1,0 +1,2974 @@
+SET FOREIGN_KEY_CHECKS=0;
+SET SESSION sql_mode='';
+
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `abm_tokens` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `organization_name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `apple_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `terms_expired` tinyint(1) NOT NULL DEFAULT '0',
+  `renew_at` timestamp NOT NULL,
+  `token` blob NOT NULL,
+  `macos_default_team_id` int unsigned DEFAULT NULL,
+  `ios_default_team_id` int unsigned DEFAULT NULL,
+  `ipados_default_team_id` int unsigned DEFAULT NULL,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_abm_tokens_organization_name` (`organization_name`),
+  KEY `fk_abm_tokens_macos_default_team_id` (`macos_default_team_id`),
+  KEY `fk_abm_tokens_ios_default_team_id` (`ios_default_team_id`),
+  KEY `fk_abm_tokens_ipados_default_team_id` (`ipados_default_team_id`),
+  CONSTRAINT `fk_abm_tokens_ios_default_team_id` FOREIGN KEY (`ios_default_team_id`) REFERENCES `teams` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `fk_abm_tokens_ipados_default_team_id` FOREIGN KEY (`ipados_default_team_id`) REFERENCES `teams` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `fk_abm_tokens_macos_default_team_id` FOREIGN KEY (`macos_default_team_id`) REFERENCES `teams` (`id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `activities` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `user_id` int unsigned DEFAULT NULL,
+  `user_name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `activity_type` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `details` json DEFAULT NULL,
+  `streamed` tinyint(1) NOT NULL DEFAULT '0',
+  `user_email` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `fleet_initiated` tinyint(1) NOT NULL DEFAULT '0',
+  `host_only` tinyint(1) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`),
+  KEY `fk_activities_user_id` (`user_id`),
+  KEY `activities_streamed_idx` (`streamed`),
+  KEY `activities_created_at_idx` (`created_at`),
+  CONSTRAINT `activities_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `aggregated_stats` (
+  `id` bigint unsigned NOT NULL,
+  `type` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `json_value` json NOT NULL,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `global_stats` tinyint(1) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`,`type`,`global_stats`),
+  KEY `idx_aggregated_stats_updated_at` (`updated_at`),
+  KEY `aggregated_stats_type_idx` (`type`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `android_devices` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `host_id` int unsigned NOT NULL,
+  `device_id` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `enterprise_specific_id` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `last_policy_sync_time` datetime(3) DEFAULT NULL,
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  `applied_policy_id` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `applied_policy_version` int DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_android_devices_host_id` (`host_id`),
+  UNIQUE KEY `idx_android_devices_device_id` (`device_id`),
+  UNIQUE KEY `idx_android_devices_enterprise_specific_id` (`enterprise_specific_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `android_enterprises` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `signup_name` varchar(63) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `enterprise_id` varchar(63) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `created_at` datetime(6) DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` datetime(6) DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  `signup_token` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `pubsub_topic_id` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `user_id` int unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `android_policy_requests` (
+  `request_uuid` varchar(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `request_name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `policy_id` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `payload` json NOT NULL,
+  `status_code` int NOT NULL,
+  `error_details` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `applied_policy_version` int DEFAULT NULL,
+  `policy_version` int DEFAULT NULL,
+  `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`request_uuid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `app_config_json` (
+  `id` int unsigned NOT NULL DEFAULT '1',
+  `json_value` json NOT NULL,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+INSERT INTO `app_config_json` VALUES (1,'{\"mdm\": {\"ios_updates\": {\"deadline\": null, \"minimum_version\": null}, \"macos_setup\": {\"script\": null, \"software\": null, \"bootstrap_package\": null, \"manual_agent_install\": null, \"macos_setup_assistant\": null, \"require_all_software_macos\": false, \"enable_end_user_authentication\": false, \"enable_release_device_manually\": false}, \"macos_updates\": {\"deadline\": null, \"minimum_version\": null}, \"ipados_updates\": {\"deadline\": null, \"minimum_version\": null}, \"macos_settings\": {\"custom_settings\": null}, \"macos_migration\": {\"mode\": \"\", \"enable\": false, \"webhook_url\": \"\"}, \"windows_updates\": {\"deadline_days\": null, \"grace_period_days\": null}, \"android_settings\": {\"custom_settings\": null}, \"apple_server_url\": \"\", \"windows_settings\": {\"custom_settings\": null}, \"apple_bm_terms_expired\": false, \"apple_business_manager\": null, \"enable_disk_encryption\": false, \"enabled_and_configured\": false, \"end_user_authentication\": {\"idp_name\": \"\", \"metadata\": \"\", \"entity_id\": \"\", \"issuer_uri\": \"\", \"metadata_url\": \"\"}, \"volume_purchasing_program\": null, \"windows_migration_enabled\": false, \"windows_require_bitlocker_pin\": null, \"android_enabled_and_configured\": false, \"windows_enabled_and_configured\": false, \"apple_bm_enabled_and_configured\": false}, \"gitops\": {\"repository_url\": \"\", \"gitops_mode_enabled\": false}, \"scripts\": null, \"features\": {\"enable_host_users\": true, \"enable_software_inventory\": false}, \"org_info\": {\"org_name\": \"\", \"contact_url\": \"\", \"org_logo_url\": \"\", \"org_logo_url_light_background\": \"\"}, \"integrations\": {\"jira\": null, \"zendesk\": null, \"google_calendar\": null, \"conditional_access_enabled\": null}, \"sso_settings\": {\"idp_name\": \"\", \"metadata\": \"\", \"entity_id\": \"\", \"enable_sso\": false, \"issuer_uri\": \"\", \"metadata_url\": \"\", \"idp_image_url\": \"\", \"sso_server_url\": \"\", \"enable_jit_role_sync\": false, \"enable_sso_idp_login\": false, \"enable_jit_provisioning\": false}, \"agent_options\": {\"config\": {\"options\": {\"logger_plugin\": \"tls\", \"pack_delimiter\": \"/\", \"logger_tls_period\": 10, \"distributed_plugin\": \"tls\", \"disable_distributed\": false, \"logger_tls_endpoint\": \"/api/osquery/log\", \"distributed_interval\": 10, \"distributed_tls_max_attempts\": 3}, \"decorators\": {\"load\": [\"SELECT uuid AS host_uuid FROM system_info;\", \"SELECT hostname AS hostname FROM system_info;\"]}}, \"overrides\": {}}, \"fleet_desktop\": {\"transparency_url\": \"\"}, \"smtp_settings\": {\"port\": 587, \"domain\": \"\", \"server\": \"\", \"password\": \"\", \"user_name\": \"\", \"configured\": false, \"enable_smtp\": false, \"enable_ssl_tls\": true, \"sender_address\": \"\", \"enable_start_tls\": true, \"verify_ssl_certs\": true, \"authentication_type\": \"0\", \"authentication_method\": \"0\"}, \"server_settings\": {\"server_url\": \"\", \"enable_analytics\": false, \"query_report_cap\": 0, \"scripts_disabled\": false, \"deferred_save_host\": false, \"live_query_disabled\": false, \"ai_features_disabled\": false, \"query_reports_disabled\": false}, \"webhook_settings\": {\"interval\": \"0s\", \"activities_webhook\": {\"destination_url\": \"\", \"enable_activities_webhook\": false}, \"host_status_webhook\": {\"days_count\": 0, \"destination_url\": \"\", \"host_percentage\": 0, \"enable_host_status_webhook\": false}, \"vulnerabilities_webhook\": {\"destination_url\": \"\", \"host_batch_size\": 0, \"enable_vulnerabilities_webhook\": false}, \"failing_policies_webhook\": {\"policy_ids\": null, \"destination_url\": \"\", \"host_batch_size\": 0, \"enable_failing_policies_webhook\": false}}, \"host_expiry_settings\": {\"host_expiry_window\": 0, \"host_expiry_enabled\": false}, \"vulnerability_settings\": {\"databases_path\": \"\"}, \"activity_expiry_settings\": {\"activity_expiry_window\": 0, \"activity_expiry_enabled\": false}}','2020-01-01 01:01:01','2020-01-01 01:01:01');
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `batch_activities` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `script_id` int unsigned NOT NULL,
+  `execution_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `user_id` int unsigned DEFAULT NULL,
+  `job_id` int unsigned DEFAULT NULL,
+  `status` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `activity_type` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `num_targeted` int unsigned DEFAULT NULL,
+  `num_pending` int unsigned DEFAULT NULL,
+  `num_ran` int unsigned DEFAULT NULL,
+  `num_errored` int unsigned DEFAULT NULL,
+  `num_incompatible` int unsigned DEFAULT NULL,
+  `num_canceled` int unsigned DEFAULT NULL,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `started_at` datetime DEFAULT NULL,
+  `finished_at` datetime DEFAULT NULL,
+  `canceled` tinyint(1) DEFAULT '0',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_batch_script_executions_execution_id` (`execution_id`),
+  KEY `batch_script_executions_script_id` (`script_id`),
+  KEY `idx_batch_activities_status` (`status`),
+  CONSTRAINT `batch_script_executions_script_id` FOREIGN KEY (`script_id`) REFERENCES `scripts` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `batch_activity_host_results` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `batch_execution_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `host_id` int unsigned NOT NULL,
+  `host_execution_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `error` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `unique_batch_host_results_execution_hostid` (`batch_execution_id`,`host_id`),
+  KEY `idx_batch_script_execution_host_result_execution_id` (`batch_execution_id`),
+  CONSTRAINT `batch_script_batch_id` FOREIGN KEY (`batch_execution_id`) REFERENCES `batch_activities` (`execution_id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `ca_config_assets` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `type` enum('digicert','custom_scep_proxy') COLLATE utf8mb4_unicode_ci NOT NULL,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `value` blob NOT NULL,
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_ca_config_assets_name` (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `calendar_events` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `email` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `start_time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `end_time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `event` json NOT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `timezone` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `uuid_bin` binary(16) NOT NULL,
+  `uuid` varchar(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci GENERATED ALWAYS AS (insert(insert(insert(insert(hex(`uuid_bin`),9,0,_utf8mb4'-'),14,0,_utf8mb4'-'),19,0,_utf8mb4'-'),24,0,_utf8mb4'-')) VIRTUAL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_one_calendar_event_per_email` (`email`),
+  UNIQUE KEY `idx_calendar_events_uuid_bin_unique` (`uuid_bin`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `carve_blocks` (
+  `metadata_id` int unsigned NOT NULL,
+  `block_id` int NOT NULL,
+  `data` longblob,
+  PRIMARY KEY (`metadata_id`,`block_id`),
+  CONSTRAINT `carve_blocks_ibfk_1` FOREIGN KEY (`metadata_id`) REFERENCES `carve_metadata` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `carve_metadata` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `host_id` int unsigned NOT NULL,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `block_count` int unsigned NOT NULL,
+  `block_size` int unsigned NOT NULL,
+  `carve_size` bigint unsigned NOT NULL,
+  `carve_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `request_id` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `session_id` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `expired` tinyint DEFAULT '0',
+  `max_block` int DEFAULT '-1',
+  `error` text COLLATE utf8mb4_unicode_ci,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_session_id` (`session_id`),
+  UNIQUE KEY `idx_name` (`name`),
+  KEY `host_id` (`host_id`),
+  CONSTRAINT `carve_metadata_ibfk_1` FOREIGN KEY (`host_id`) REFERENCES `hosts` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `certificate_authorities` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `type` enum('digicert','ndes_scep_proxy','custom_scep_proxy','hydrant','smallstep') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `url` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `api_token_encrypted` blob,
+  `profile_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `certificate_common_name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `certificate_user_principal_names` json DEFAULT NULL,
+  `certificate_seat_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `admin_url` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `username` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `password_encrypted` blob,
+  `challenge_url` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `challenge_encrypted` blob,
+  `client_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `client_secret_encrypted` blob,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_ca_type_name` (`type`,`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `challenges` (
+  `challenge` char(32) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` timestamp(6) NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` timestamp(6) NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`challenge`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `cron_stats` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `instance` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `stats_type` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `status` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `errors` json DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `idx_cron_stats_name_created_at` (`name`,`created_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `cve_meta` (
+  `cve` varchar(20) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `cvss_score` double DEFAULT NULL,
+  `epss_probability` double DEFAULT NULL,
+  `cisa_known_exploit` tinyint(1) DEFAULT NULL,
+  `published` timestamp NULL DEFAULT NULL,
+  `description` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  PRIMARY KEY (`cve`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `default_team_config_json` (
+  `id` int unsigned NOT NULL DEFAULT '1',
+  `json_value` json NOT NULL,
+  `created_at` timestamp(6) NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` timestamp(6) NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `id` (`id`),
+  CONSTRAINT `default_team_config_id` CHECK ((`id` = 1))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+INSERT INTO `default_team_config_json` VALUES (1,'{\"mdm\": {\"macos_setup\": {\"bootstrap_package\": null, \"macos_setup_assistant\": null, \"enable_end_user_authentication\": false, \"enable_release_device_manually\": false}, \"macos_updates\": {\"deadline\": null, \"minimum_version\": null}, \"macos_settings\": {\"custom_settings\": null, \"enable_end_user_authentication\": false}, \"windows_updates\": {\"deadline_days\": null, \"grace_period_days\": null}, \"windows_settings\": {\"custom_settings\": null}, \"enable_disk_encryption\": false}, \"scripts\": null, \"features\": {\"enable_host_users\": true, \"additional_queries\": null, \"detail_query_overrides\": null, \"enable_software_inventory\": true, \"enable_host_software_via_scan\": true, \"enable_host_operating_system_details\": true}, \"software\": null, \"integrations\": {\"jira\": null, \"zendesk\": null, \"google_calendar\": null}, \"agent_options\": null, \"webhook_settings\": {\"host_status_webhook\": null, \"failing_policies_webhook\": {\"policy_ids\": [], \"destination_url\": \"\", \"host_batch_size\": 0, \"enable_failing_policies_webhook\": false}}, \"host_expiry_settings\": {\"jitter_percent\": 0, \"host_expiry_window\": 0, \"host_expiry_enabled\": false}}','2020-01-01 01:01:01.000000','2020-01-01 01:01:01.000000');
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `distributed_query_campaign_targets` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `type` int DEFAULT NULL,
+  `distributed_query_campaign_id` int unsigned DEFAULT NULL,
+  `target_id` int unsigned DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `idx_distributed_query_campaign_targets_campaign_id` (`distributed_query_campaign_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `distributed_query_campaigns` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `query_id` int unsigned DEFAULT NULL,
+  `status` int DEFAULT NULL,
+  `user_id` int unsigned DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `email_changes` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `user_id` int unsigned NOT NULL,
+  `token` varchar(128) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `new_email` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_unique_email_changes_token` (`token`) USING BTREE,
+  KEY `fk_email_changes_users` (`user_id`),
+  CONSTRAINT `fk_email_changes_users` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `enroll_secrets` (
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `secret` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+  `team_id` int unsigned DEFAULT NULL,
+  PRIMARY KEY (`secret`),
+  KEY `fk_enroll_secrets_team_id` (`team_id`),
+  CONSTRAINT `enroll_secrets_ibfk_1` FOREIGN KEY (`team_id`) REFERENCES `teams` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `eulas` (
+  `id` int unsigned NOT NULL,
+  `token` varchar(36) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `bytes` longblob,
+  `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `sha256` binary(32) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `fleet_maintained_apps` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `slug` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `platform` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `unique_identifier` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` timestamp(6) NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` timestamp(6) NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_fleet_library_apps_token` (`slug`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `fleet_variables` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `is_prefix` tinyint(1) NOT NULL DEFAULT '0',
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_fleet_variables_name_is_prefix` (`name`,`is_prefix`)
+) ENGINE=InnoDB AUTO_INCREMENT=17 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+INSERT INTO `fleet_variables` VALUES (1,'FLEET_VAR_NDES_SCEP_CHALLENGE',0,'2025-04-22 00:00:00.000000'),(2,'FLEET_VAR_NDES_SCEP_PROXY_URL',0,'2025-04-22 00:00:00.000000'),(3,'FLEET_VAR_HOST_END_USER_EMAIL_IDP',0,'2025-04-22 00:00:00.000000'),(4,'FLEET_VAR_HOST_HARDWARE_SERIAL',0,'2025-04-22 00:00:00.000000'),(5,'FLEET_VAR_HOST_END_USER_IDP_USERNAME',0,'2025-04-22 00:00:00.000000'),(6,'FLEET_VAR_HOST_END_USER_IDP_USERNAME_LOCAL_PART',0,'2025-04-22 00:00:00.000000'),(7,'FLEET_VAR_HOST_END_USER_IDP_GROUPS',0,'2025-04-22 00:00:00.000000'),(8,'FLEET_VAR_DIGICERT_DATA_',1,'2025-04-22 00:00:00.000000'),(9,'FLEET_VAR_DIGICERT_PASSWORD_',1,'2025-04-22 00:00:00.000000'),(10,'FLEET_VAR_CUSTOM_SCEP_CHALLENGE_',1,'2025-04-22 00:00:00.000000'),(11,'FLEET_VAR_CUSTOM_SCEP_PROXY_URL_',1,'2025-04-22 00:00:00.000000'),(12,'FLEET_VAR_SCEP_RENEWAL_ID',0,'2025-04-30 00:00:00.000000'),(13,'FLEET_VAR_HOST_END_USER_IDP_DEPARTMENT',0,'2025-06-27 00:00:00.000000'),(14,'FLEET_VAR_HOST_UUID',0,'2025-08-08 00:00:00.000000'),(15,'FLEET_VAR_HOST_END_USER_IDP_FULL_NAME',0,'2025-08-25 00:00:00.000000'),(16,'FLEET_VAR_SCEP_WINDOWS_CERTIFICATE_ID',0,'2025-10-22 00:00:00.000000');
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_activities` (
+  `host_id` int unsigned NOT NULL,
+  `activity_id` int unsigned NOT NULL,
+  PRIMARY KEY (`host_id`,`activity_id`),
+  KEY `fk_host_activities_activity_id` (`activity_id`),
+  CONSTRAINT `host_activities_ibfk_1` FOREIGN KEY (`activity_id`) REFERENCES `activities` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_additional` (
+  `host_id` int unsigned NOT NULL,
+  `additional` json DEFAULT NULL,
+  PRIMARY KEY (`host_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_batteries` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `host_id` int unsigned NOT NULL,
+  `serial_number` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `cycle_count` int NOT NULL,
+  `health` varchar(40) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_host_batteries_host_id_serial_number` (`host_id`,`serial_number`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_calendar_events` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `host_id` int unsigned NOT NULL,
+  `calendar_event_id` int unsigned NOT NULL,
+  `webhook_status` tinyint NOT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_one_calendar_event_per_host` (`host_id`),
+  KEY `calendar_event_id` (`calendar_event_id`),
+  CONSTRAINT `host_calendar_events_ibfk_1` FOREIGN KEY (`calendar_event_id`) REFERENCES `calendar_events` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_certificate_sources` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `host_certificate_id` bigint unsigned NOT NULL,
+  `source` enum('system','user') COLLATE utf8mb4_unicode_ci NOT NULL,
+  `username` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_host_certificate_sources_unique` (`host_certificate_id`,`source`,`username`),
+  CONSTRAINT `fk_host_certificate_sources_host_certificate_id` FOREIGN KEY (`host_certificate_id`) REFERENCES `host_certificates` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_certificates` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `host_id` int unsigned NOT NULL,
+  `not_valid_after` datetime(6) NOT NULL,
+  `not_valid_before` datetime(6) NOT NULL,
+  `certificate_authority` tinyint(1) NOT NULL,
+  `common_name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `key_algorithm` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `key_strength` int NOT NULL,
+  `key_usage` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `serial` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `signing_algorithm` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `subject_country` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `subject_org` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `subject_org_unit` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `subject_common_name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `issuer_country` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `issuer_org` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `issuer_org_unit` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `issuer_common_name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `sha1_sum` binary(20) NOT NULL,
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `deleted_at` datetime(6) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `idx_host_certs_hid_cn` (`host_id`,`common_name`),
+  KEY `idx_host_certs_not_valid_after` (`host_id`,`not_valid_after`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_dep_assignments` (
+  `host_id` int unsigned NOT NULL,
+  `added_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `deleted_at` timestamp NULL DEFAULT NULL,
+  `profile_uuid` varchar(37) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `assign_profile_response` varchar(15) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `response_updated_at` timestamp NULL DEFAULT NULL,
+  `retry_job_id` int unsigned NOT NULL DEFAULT '0',
+  `abm_token_id` int unsigned DEFAULT NULL,
+  `mdm_migration_deadline` timestamp(6) NULL DEFAULT NULL,
+  `mdm_migration_completed` timestamp(6) NULL DEFAULT NULL,
+  PRIMARY KEY (`host_id`),
+  KEY `idx_hdep_response` (`assign_profile_response`,`response_updated_at`),
+  KEY `fk_host_dep_assignments_abm_token_id` (`abm_token_id`),
+  CONSTRAINT `fk_host_dep_assignments_abm_token_id` FOREIGN KEY (`abm_token_id`) REFERENCES `abm_tokens` (`id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_device_auth` (
+  `host_id` int unsigned NOT NULL,
+  `token` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`host_id`),
+  UNIQUE KEY `idx_host_device_auth_token` (`token`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_disk_encryption_keys` (
+  `host_id` int unsigned NOT NULL,
+  `base64_encrypted` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  `base64_encrypted_salt` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `key_slot` tinyint unsigned DEFAULT NULL,
+  `decryptable` tinyint(1) DEFAULT NULL,
+  `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` timestamp(6) NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  `reset_requested` tinyint(1) NOT NULL DEFAULT '0',
+  `client_error` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  PRIMARY KEY (`host_id`),
+  KEY `idx_host_disk_encryption_keys_decryptable` (`decryptable`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_disk_encryption_keys_archive` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `host_id` int unsigned NOT NULL,
+  `hardware_serial` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `base64_encrypted` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `base64_encrypted_salt` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `key_slot` tinyint unsigned DEFAULT NULL,
+  `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`id`),
+  KEY `idx_host_disk_encryption_keys_archive_host_created_at` (`host_id`,`created_at` DESC)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_disks` (
+  `host_id` int unsigned NOT NULL,
+  `gigs_disk_space_available` decimal(10,2) NOT NULL DEFAULT '0.00',
+  `percent_disk_space_available` decimal(10,2) NOT NULL DEFAULT '0.00',
+  `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` timestamp(6) NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  `encrypted` tinyint(1) DEFAULT NULL,
+  `gigs_total_disk_space` decimal(10,2) NOT NULL DEFAULT '0.00',
+  `tpm_pin_set` tinyint(1) DEFAULT '0',
+  `gigs_all_disk_space` decimal(10,2) DEFAULT NULL,
+  PRIMARY KEY (`host_id`),
+  KEY `idx_host_disks_gigs_disk_space_available` (`gigs_disk_space_available`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_display_names` (
+  `host_id` int unsigned NOT NULL,
+  `display_name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  PRIMARY KEY (`host_id`),
+  KEY `display_name` (`display_name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_emails` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `host_id` int unsigned NOT NULL,
+  `email` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `source` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `idx_host_emails_host_id_email` (`host_id`,`email`),
+  KEY `idx_host_emails_email` (`email`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_identity_scep_certificates` (
+  `serial` bigint unsigned NOT NULL,
+  `host_id` int unsigned DEFAULT NULL,
+  `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `not_valid_before` datetime NOT NULL,
+  `not_valid_after` datetime NOT NULL,
+  `certificate_pem` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `public_key_raw` varbinary(100) NOT NULL,
+  `revoked` tinyint(1) NOT NULL DEFAULT '0',
+  `created_at` datetime(6) DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` datetime(6) DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`serial`),
+  KEY `idx_host_id_scep_name` (`name`),
+  KEY `idx_host_id_scep_host_id` (`host_id`),
+  CONSTRAINT `host_identity_scep_certificates_ibfk_1` FOREIGN KEY (`serial`) REFERENCES `host_identity_scep_serials` (`serial`),
+  CONSTRAINT `host_identity_scep_certificates_chk_1` CHECK ((substr(`certificate_pem`,1,27) = _utf8mb4'-----BEGIN CERTIFICATE-----'))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_identity_scep_serials` (
+  `serial` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `created_at` datetime(6) DEFAULT CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`serial`)
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_in_house_software_installs` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `host_id` int unsigned NOT NULL,
+  `in_house_app_id` int unsigned NOT NULL,
+  `command_uuid` varchar(127) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `user_id` int unsigned DEFAULT NULL,
+  `platform` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `removed` tinyint NOT NULL DEFAULT '0',
+  `canceled` tinyint NOT NULL DEFAULT '0',
+  `verification_command_uuid` varchar(127) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `verification_at` datetime(6) DEFAULT NULL,
+  `verification_failed_at` datetime(6) DEFAULT NULL,
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_host_in_house_software_installs_command_uuid` (`command_uuid`),
+  KEY `fk_host_in_house_software_installs_user_id` (`user_id`),
+  KEY `fk_host_in_house_software_installs_in_house_app_id` (`in_house_app_id`),
+  CONSTRAINT `fk_host_in_house_software_installs_in_house_app_id` FOREIGN KEY (`in_house_app_id`) REFERENCES `in_house_apps` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_host_in_house_software_installs_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_issues` (
+  `host_id` int unsigned NOT NULL,
+  `failing_policies_count` int unsigned NOT NULL DEFAULT '0',
+  `critical_vulnerabilities_count` int unsigned NOT NULL DEFAULT '0',
+  `total_issues_count` int unsigned NOT NULL DEFAULT '0',
+  `created_at` timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  `updated_at` timestamp(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+  PRIMARY KEY (`host_id`),
+  KEY `total_issues_count` (`total_issues_count`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_mdm` (
+  `host_id` int unsigned NOT NULL,
+  `enrolled` tinyint(1) NOT NULL DEFAULT '0',
+  `server_url` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `installed_from_dep` tinyint(1) NOT NULL DEFAULT '0',
+  `mdm_id` int unsigned DEFAULT NULL,
+  `is_server` tinyint(1) DEFAULT NULL,
+  `fleet_enroll_ref` varchar(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `enrollment_status` enum('On (manual)','On (automatic)','Pending','Off','On (personal)') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci GENERATED ALWAYS AS ((case when (`is_server` = 1) then NULL when ((`enrolled` = 1) and (`installed_from_dep` = 0) and (`is_personal_enrollment` = 1)) then _utf8mb4'On (personal)' when ((`enrolled` = 1) and (`installed_from_dep` = 0) and (`is_personal_enrollment` = 0)) then _utf8mb4'On (manual)' when ((`enrolled` = 1) and (`installed_from_dep` = 1) and (`is_personal_enrollment` = 0)) then _utf8mb4'On (automatic)' when ((`enrolled` = 0) and (`installed_from_dep` = 1)) then _utf8mb4'Pending' when ((`enrolled` = 0) and (`installed_from_dep` = 0)) then _utf8mb4'Off' else NULL end)) VIRTUAL,
+  `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  `is_personal_enrollment` tinyint(1) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`host_id`),
+  KEY `host_mdm_mdm_id_idx` (`mdm_id`),
+  KEY `host_mdm_enrolled_installed_from_dep_is_personal_enrollment_idx` (`enrolled`,`installed_from_dep`,`is_personal_enrollment`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_mdm_actions` (
+  `host_id` int unsigned NOT NULL,
+  `lock_ref` varchar(36) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `wipe_ref` varchar(36) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `unlock_pin` varchar(6) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `unlock_ref` varchar(36) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `fleet_platform` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  PRIMARY KEY (`host_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_mdm_android_profiles` (
+  `host_uuid` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `status` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `operation_type` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `detail` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `profile_uuid` varchar(37) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `profile_name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `policy_request_uuid` varchar(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `device_request_uuid` varchar(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `request_fail_count` tinyint unsigned NOT NULL DEFAULT '0',
+  `included_in_policy_version` int DEFAULT NULL,
+  `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`host_uuid`,`profile_uuid`),
+  KEY `status` (`status`),
+  KEY `operation_type` (`operation_type`),
+  KEY `policy_request_uuid` (`policy_request_uuid`),
+  KEY `device_request_uuid` (`device_request_uuid`),
+  CONSTRAINT `host_mdm_android_profiles_ibfk_1` FOREIGN KEY (`status`) REFERENCES `mdm_delivery_status` (`status`) ON UPDATE CASCADE,
+  CONSTRAINT `host_mdm_android_profiles_ibfk_2` FOREIGN KEY (`operation_type`) REFERENCES `mdm_operation_types` (`operation_type`) ON UPDATE CASCADE,
+  CONSTRAINT `host_mdm_android_profiles_ibfk_3` FOREIGN KEY (`policy_request_uuid`) REFERENCES `android_policy_requests` (`request_uuid`) ON DELETE SET NULL,
+  CONSTRAINT `host_mdm_android_profiles_ibfk_4` FOREIGN KEY (`device_request_uuid`) REFERENCES `android_policy_requests` (`request_uuid`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_mdm_apple_awaiting_configuration` (
+  `host_uuid` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `awaiting_configuration` tinyint(1) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`host_uuid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_mdm_apple_bootstrap_packages` (
+  `host_uuid` varchar(127) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `command_uuid` varchar(127) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  PRIMARY KEY (`host_uuid`),
+  KEY `command_uuid` (`command_uuid`),
+  CONSTRAINT `host_mdm_apple_bootstrap_packages_ibfk_1` FOREIGN KEY (`command_uuid`) REFERENCES `nano_commands` (`command_uuid`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_mdm_apple_declarations` (
+  `host_uuid` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `status` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `operation_type` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `detail` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `token` binary(16) NOT NULL,
+  `declaration_uuid` varchar(37) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `declaration_identifier` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `declaration_name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `secrets_updated_at` datetime(6) DEFAULT NULL,
+  `resync` tinyint(1) NOT NULL DEFAULT '0',
+  `scope` enum('System','User') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'System',
+  PRIMARY KEY (`host_uuid`,`declaration_uuid`),
+  KEY `status` (`status`),
+  KEY `operation_type` (`operation_type`),
+  KEY `idx_token` (`token`),
+  CONSTRAINT `host_mdm_apple_declarations_ibfk_1` FOREIGN KEY (`status`) REFERENCES `mdm_delivery_status` (`status`) ON UPDATE CASCADE,
+  CONSTRAINT `host_mdm_apple_declarations_ibfk_2` FOREIGN KEY (`operation_type`) REFERENCES `mdm_operation_types` (`operation_type`) ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_mdm_apple_profiles` (
+  `profile_identifier` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `host_uuid` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `status` varchar(20) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `operation_type` varchar(20) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `detail` text COLLATE utf8mb4_unicode_ci,
+  `command_uuid` varchar(127) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `profile_name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `checksum` binary(16) NOT NULL,
+  `retries` tinyint unsigned NOT NULL DEFAULT '0',
+  `profile_uuid` varchar(37) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  `secrets_updated_at` datetime(6) DEFAULT NULL,
+  `ignore_error` tinyint(1) NOT NULL DEFAULT '0',
+  `variables_updated_at` datetime(6) DEFAULT NULL,
+  `scope` enum('System','User') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'System',
+  PRIMARY KEY (`host_uuid`,`profile_uuid`),
+  KEY `status` (`status`),
+  KEY `operation_type` (`operation_type`),
+  CONSTRAINT `host_mdm_apple_profiles_ibfk_1` FOREIGN KEY (`status`) REFERENCES `mdm_delivery_status` (`status`) ON UPDATE CASCADE,
+  CONSTRAINT `host_mdm_apple_profiles_ibfk_2` FOREIGN KEY (`operation_type`) REFERENCES `mdm_operation_types` (`operation_type`) ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_mdm_commands` (
+  `host_id` int unsigned NOT NULL,
+  `command_type` varchar(31) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` timestamp(6) NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` timestamp(6) NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`host_id`,`command_type`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_mdm_idp_accounts` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `host_uuid` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `account_uuid` varchar(36) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_host_mdm_idp_accounts` (`host_uuid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_mdm_managed_certificates` (
+  `host_uuid` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `profile_uuid` varchar(37) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `type` enum('digicert','custom_scep_proxy','ndes','smallstep') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'ndes',
+  `ca_name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'NDES',
+  `challenge_retrieved_at` timestamp(6) NULL DEFAULT NULL,
+  `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  `not_valid_after` datetime(6) DEFAULT NULL,
+  `serial` varchar(40) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `not_valid_before` datetime(6) DEFAULT NULL,
+  PRIMARY KEY (`host_uuid`,`profile_uuid`,`ca_name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_mdm_windows_profiles` (
+  `host_uuid` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `status` varchar(20) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `operation_type` varchar(20) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `detail` text COLLATE utf8mb4_unicode_ci,
+  `command_uuid` varchar(127) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `profile_name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `retries` tinyint unsigned NOT NULL DEFAULT '0',
+  `profile_uuid` varchar(37) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `checksum` binary(16) NOT NULL DEFAULT '0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0',
+  `secrets_updated_at` datetime(6) DEFAULT NULL,
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`host_uuid`,`profile_uuid`),
+  KEY `status` (`status`),
+  KEY `operation_type` (`operation_type`),
+  CONSTRAINT `host_mdm_windows_profiles_ibfk_1` FOREIGN KEY (`status`) REFERENCES `mdm_delivery_status` (`status`) ON UPDATE CASCADE,
+  CONSTRAINT `host_mdm_windows_profiles_ibfk_2` FOREIGN KEY (`operation_type`) REFERENCES `mdm_operation_types` (`operation_type`) ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_munki_info` (
+  `host_id` int unsigned NOT NULL,
+  `version` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `deleted_at` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`host_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_munki_issues` (
+  `host_id` int unsigned NOT NULL,
+  `munki_issue_id` int unsigned NOT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`host_id`,`munki_issue_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_operating_system` (
+  `host_id` int unsigned NOT NULL,
+  `os_id` int unsigned NOT NULL,
+  PRIMARY KEY (`host_id`),
+  KEY `idx_host_operating_system_id` (`os_id`),
+  CONSTRAINT `host_operating_system_ibfk_1` FOREIGN KEY (`os_id`) REFERENCES `operating_systems` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_orbit_info` (
+  `host_id` int unsigned NOT NULL,
+  `version` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `desktop_version` varchar(50) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `scripts_enabled` tinyint(1) DEFAULT NULL,
+  PRIMARY KEY (`host_id`),
+  KEY `idx_host_orbit_info_version` (`version`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_scim_user` (
+  `host_id` int unsigned NOT NULL,
+  `scim_user_id` int unsigned NOT NULL,
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`host_id`),
+  KEY `fk_host_scim_scim_user_id` (`scim_user_id`),
+  CONSTRAINT `fk_host_scim_scim_user_id` FOREIGN KEY (`scim_user_id`) REFERENCES `scim_users` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_script_results` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `host_id` int unsigned NOT NULL,
+  `execution_id` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `output` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  `runtime` int unsigned NOT NULL DEFAULT '0',
+  `exit_code` int DEFAULT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `script_id` int unsigned DEFAULT NULL,
+  `user_id` int unsigned DEFAULT NULL,
+  `sync_request` tinyint(1) NOT NULL DEFAULT '0',
+  `script_content_id` int unsigned DEFAULT NULL,
+  `host_deleted_at` timestamp NULL DEFAULT NULL,
+  `timeout` int DEFAULT NULL,
+  `policy_id` int unsigned DEFAULT NULL,
+  `setup_experience_script_id` int unsigned DEFAULT NULL,
+  `is_internal` tinyint(1) DEFAULT '0',
+  `canceled` tinyint(1) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_host_script_results_execution_id` (`execution_id`),
+  KEY `idx_host_script_results_host_exit_created` (`host_id`,`exit_code`,`created_at`),
+  KEY `fk_host_script_results_script_id` (`script_id`),
+  KEY `fk_host_script_results_user_id` (`user_id`),
+  KEY `script_content_id` (`script_content_id`),
+  KEY `fk_script_result_policy_id` (`policy_id`),
+  KEY `fk_host_script_results_setup_experience_id` (`setup_experience_script_id`),
+  KEY `idx_host_script_canceled_created_at` (`host_id`,`script_id`,`canceled`,`created_at` DESC),
+  CONSTRAINT `fk_host_script_results_script_id` FOREIGN KEY (`script_id`) REFERENCES `scripts` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `fk_host_script_results_setup_experience_id` FOREIGN KEY (`setup_experience_script_id`) REFERENCES `setup_experience_scripts` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `fk_host_script_results_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `host_script_results_ibfk_1` FOREIGN KEY (`script_content_id`) REFERENCES `script_contents` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `host_script_results_ibfk_2` FOREIGN KEY (`policy_id`) REFERENCES `policies` (`id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_seen_times` (
+  `host_id` int unsigned NOT NULL,
+  `seen_time` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`host_id`),
+  KEY `idx_host_seen_times_seen_time` (`seen_time`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_software` (
+  `host_id` int unsigned NOT NULL,
+  `software_id` bigint unsigned NOT NULL,
+  `last_opened_at` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`host_id`,`software_id`),
+  KEY `host_software_software_fk` (`software_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_software_installed_paths` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `host_id` int unsigned NOT NULL,
+  `software_id` bigint unsigned NOT NULL,
+  `installed_path` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  `team_identifier` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `executable_sha256` char(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `host_id_software_id_idx` (`host_id`,`software_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_software_installs` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `execution_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `host_id` int unsigned NOT NULL,
+  `software_installer_id` int unsigned DEFAULT NULL,
+  `pre_install_query_output` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `install_script_output` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `install_script_exit_code` int DEFAULT NULL,
+  `post_install_script_output` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `post_install_script_exit_code` int DEFAULT NULL,
+  `user_id` int unsigned DEFAULT NULL,
+  `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  `self_service` tinyint(1) NOT NULL DEFAULT '0',
+  `host_deleted_at` timestamp(6) NULL DEFAULT NULL,
+  `removed` tinyint NOT NULL DEFAULT '0',
+  `uninstall_script_output` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `uninstall_script_exit_code` int DEFAULT NULL,
+  `uninstall` tinyint unsigned NOT NULL DEFAULT '0',
+  `status` enum('pending_install','failed_install','installed','pending_uninstall','failed_uninstall','canceled_install','canceled_uninstall') COLLATE utf8mb4_unicode_ci GENERATED ALWAYS AS ((case when (`removed` = 1) then NULL when ((`canceled` = 1) and (`uninstall` = 0)) then _utf8mb4'canceled_install' when ((`canceled` = 1) and (`uninstall` = 1)) then _utf8mb4'canceled_uninstall' when ((`post_install_script_exit_code` is not null) and (`post_install_script_exit_code` = 0)) then _utf8mb4'installed' when ((`post_install_script_exit_code` is not null) and (`post_install_script_exit_code` <> 0)) then _utf8mb4'failed_install' when ((`install_script_exit_code` is not null) and (`install_script_exit_code` = 0)) then _utf8mb4'installed' when ((`install_script_exit_code` is not null) and (`install_script_exit_code` <> 0)) then _utf8mb4'failed_install' when ((`pre_install_query_output` is not null) and (`pre_install_query_output` = _utf8mb4'')) then _utf8mb4'failed_install' when ((`host_id` is not null) and (`uninstall` = 0)) then _utf8mb4'pending_install' when ((`uninstall_script_exit_code` is not null) and (`uninstall_script_exit_code` <> 0)) then _utf8mb4'failed_uninstall' when ((`uninstall_script_exit_code` is not null) and (`uninstall_script_exit_code` = 0)) then NULL when ((`host_id` is not null) and (`uninstall` = 1)) then _utf8mb4'pending_uninstall' else NULL end)) STORED,
+  `policy_id` int unsigned DEFAULT NULL,
+  `installer_filename` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '[deleted installer]',
+  `version` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'unknown',
+  `software_title_id` int unsigned DEFAULT NULL,
+  `software_title_name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '[deleted title]',
+  `execution_status` enum('pending_install','failed_install','installed','pending_uninstall','failed_uninstall','canceled_install','canceled_uninstall') COLLATE utf8mb4_unicode_ci GENERATED ALWAYS AS ((case when ((`canceled` = 1) and (`uninstall` = 0)) then _utf8mb4'canceled_install' when ((`canceled` = 1) and (`uninstall` = 1)) then _utf8mb4'canceled_uninstall' when ((`post_install_script_exit_code` is not null) and (`post_install_script_exit_code` = 0)) then _utf8mb4'installed' when ((`post_install_script_exit_code` is not null) and (`post_install_script_exit_code` <> 0)) then _utf8mb4'failed_install' when ((`install_script_exit_code` is not null) and (`install_script_exit_code` = 0)) then _utf8mb4'installed' when ((`install_script_exit_code` is not null) and (`install_script_exit_code` <> 0)) then _utf8mb4'failed_install' when ((`pre_install_query_output` is not null) and (`pre_install_query_output` = _utf8mb4'')) then _utf8mb4'failed_install' when ((`host_id` is not null) and (`uninstall` = 0)) then _utf8mb4'pending_install' when ((`uninstall_script_exit_code` is not null) and (`uninstall_script_exit_code` <> 0)) then _utf8mb4'failed_uninstall' when ((`uninstall_script_exit_code` is not null) and (`uninstall_script_exit_code` = 0)) then NULL when ((`host_id` is not null) and (`uninstall` = 1)) then _utf8mb4'pending_uninstall' else NULL end)) VIRTUAL,
+  `canceled` tinyint(1) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_host_software_installs_execution_id` (`execution_id`),
+  KEY `fk_host_software_installs_user_id` (`user_id`),
+  KEY `idx_host_software_installs_host_installer` (`host_id`,`software_installer_id`),
+  KEY `fk_software_install_policy_id` (`policy_id`),
+  KEY `fk_host_software_installs_installer_id` (`software_installer_id`),
+  KEY `fk_host_software_installs_software_title_id` (`software_title_id`),
+  CONSTRAINT `fk_host_software_installs_installer_id` FOREIGN KEY (`software_installer_id`) REFERENCES `software_installers` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
+  CONSTRAINT `fk_host_software_installs_software_title_id` FOREIGN KEY (`software_title_id`) REFERENCES `software_titles` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
+  CONSTRAINT `fk_host_software_installs_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `host_software_installs_ibfk_1` FOREIGN KEY (`policy_id`) REFERENCES `policies` (`id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_updates` (
+  `host_id` int unsigned NOT NULL,
+  `software_updated_at` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`host_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_users` (
+  `host_id` int unsigned NOT NULL,
+  `uid` int unsigned NOT NULL,
+  `username` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `groupname` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `removed_at` timestamp NULL DEFAULT NULL,
+  `user_type` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `shell` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT '',
+  PRIMARY KEY (`host_id`,`uid`,`username`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_vpp_software_installs` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `host_id` int unsigned NOT NULL,
+  `adam_id` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `command_uuid` varchar(127) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `user_id` int unsigned DEFAULT NULL,
+  `self_service` tinyint(1) NOT NULL DEFAULT '0',
+  `associated_event_id` varchar(36) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `platform` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `removed` tinyint NOT NULL DEFAULT '0',
+  `vpp_token_id` int unsigned DEFAULT NULL,
+  `policy_id` int unsigned DEFAULT NULL,
+  `canceled` tinyint(1) NOT NULL DEFAULT '0',
+  `verification_command_uuid` varchar(127) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `verification_at` datetime(6) DEFAULT NULL,
+  `verification_failed_at` datetime(6) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_host_vpp_software_installs_command_uuid` (`command_uuid`),
+  KEY `user_id` (`user_id`),
+  KEY `adam_id` (`adam_id`,`platform`),
+  KEY `fk_host_vpp_software_installs_vpp_token_id` (`vpp_token_id`),
+  KEY `fk_host_vpp_software_installs_policy_id` (`policy_id`),
+  CONSTRAINT `fk_host_vpp_software_installs_vpp_token_id` FOREIGN KEY (`vpp_token_id`) REFERENCES `vpp_tokens` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `host_vpp_software_installs_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `host_vpp_software_installs_ibfk_3` FOREIGN KEY (`adam_id`, `platform`) REFERENCES `vpp_apps` (`adam_id`, `platform`) ON DELETE CASCADE,
+  CONSTRAINT `host_vpp_software_installs_ibfk_4` FOREIGN KEY (`policy_id`) REFERENCES `policies` (`id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `hosts` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `osquery_host_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `detail_updated_at` timestamp NULL DEFAULT NULL,
+  `node_key` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL,
+  `hostname` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `uuid` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `platform` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `osquery_version` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `os_version` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `build` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `platform_like` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `code_name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `uptime` bigint NOT NULL DEFAULT '0',
+  `memory` bigint NOT NULL DEFAULT '0',
+  `cpu_type` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `cpu_subtype` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `cpu_brand` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `cpu_physical_cores` int NOT NULL DEFAULT '0',
+  `cpu_logical_cores` int NOT NULL DEFAULT '0',
+  `hardware_vendor` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `hardware_model` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `hardware_version` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `hardware_serial` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `computer_name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `primary_ip_id` int unsigned DEFAULT NULL,
+  `distributed_interval` int DEFAULT '0',
+  `logger_tls_period` int DEFAULT '0',
+  `config_tls_refresh` int DEFAULT '0',
+  `primary_ip` varchar(45) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `primary_mac` varchar(17) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `label_updated_at` timestamp NOT NULL DEFAULT '2000-01-01 00:00:00',
+  `last_enrolled_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `refetch_requested` tinyint(1) NOT NULL DEFAULT '0',
+  `team_id` int unsigned DEFAULT NULL,
+  `policy_updated_at` timestamp NOT NULL DEFAULT '2000-01-01 00:00:00',
+  `public_ip` varchar(45) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `orbit_node_key` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL,
+  `refetch_critical_queries_until` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_osquery_host_id` (`osquery_host_id`),
+  UNIQUE KEY `idx_host_unique_nodekey` (`node_key`),
+  UNIQUE KEY `idx_host_unique_orbitnodekey` (`orbit_node_key`),
+  KEY `fk_hosts_team_id` (`team_id`),
+  KEY `hosts_platform_idx` (`platform`),
+  KEY `idx_hosts_hardware_serial` (`hardware_serial`),
+  KEY `idx_hosts_uuid` (`uuid`),
+  CONSTRAINT `hosts_ibfk_1` FOREIGN KEY (`team_id`) REFERENCES `teams` (`id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `in_house_app_labels` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `in_house_app_id` int unsigned NOT NULL,
+  `label_id` int unsigned NOT NULL,
+  `exclude` tinyint(1) NOT NULL DEFAULT '0',
+  `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `id_in_house_app_labels_in_house_app_id_label_id` (`in_house_app_id`,`label_id`),
+  KEY `label_id` (`label_id`),
+  CONSTRAINT `in_house_app_labels_ibfk_1` FOREIGN KEY (`in_house_app_id`) REFERENCES `in_house_apps` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `in_house_app_labels_ibfk_2` FOREIGN KEY (`label_id`) REFERENCES `labels` (`id`) ON DELETE RESTRICT
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `in_house_app_upcoming_activities` (
+  `upcoming_activity_id` bigint unsigned NOT NULL,
+  `in_house_app_id` int unsigned NOT NULL,
+  `software_title_id` int unsigned DEFAULT NULL,
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`upcoming_activity_id`),
+  KEY `fk_in_house_app_upcoming_activities_in_house_app_id` (`in_house_app_id`),
+  KEY `fk_in_house_app_upcoming_activities_software_title_id` (`software_title_id`),
+  CONSTRAINT `fk_in_house_app_upcoming_activities_in_house_app_id` FOREIGN KEY (`in_house_app_id`) REFERENCES `in_house_apps` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_in_house_app_upcoming_activities_software_title_id` FOREIGN KEY (`software_title_id`) REFERENCES `software_titles` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
+  CONSTRAINT `fk_in_house_app_upcoming_activities_upcoming_activity_id` FOREIGN KEY (`upcoming_activity_id`) REFERENCES `upcoming_activities` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `in_house_apps` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `title_id` int unsigned DEFAULT NULL,
+  `team_id` int unsigned DEFAULT NULL,
+  `global_or_team_id` int unsigned NOT NULL DEFAULT '0',
+  `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `version` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `storage_id` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `platform` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `bundle_identifier` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `global_or_team_id` (`global_or_team_id`,`name`,`platform`),
+  KEY `fk_in_house_apps_title` (`title_id`),
+  CONSTRAINT `fk_in_house_apps_title` FOREIGN KEY (`title_id`) REFERENCES `software_titles` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `invite_teams` (
+  `invite_id` int unsigned NOT NULL,
+  `team_id` int unsigned NOT NULL,
+  `role` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL,
+  PRIMARY KEY (`invite_id`,`team_id`),
+  KEY `fk_team_id` (`team_id`),
+  CONSTRAINT `invite_teams_ibfk_1` FOREIGN KEY (`invite_id`) REFERENCES `invites` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `invite_teams_ibfk_2` FOREIGN KEY (`team_id`) REFERENCES `teams` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `invites` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `invited_by` int unsigned NOT NULL,
+  `email` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `position` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `token` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `sso_enabled` tinyint(1) NOT NULL DEFAULT '0',
+  `global_role` varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `mfa_enabled` tinyint(1) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_invite_unique_email` (`email`),
+  UNIQUE KEY `idx_invite_unique_key` (`token`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `jobs` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `args` json DEFAULT NULL,
+  `state` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `retries` int NOT NULL DEFAULT '0',
+  `error` text COLLATE utf8mb4_unicode_ci,
+  `not_before` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `idx_jobs_state_not_before_updated_at` (`state`,`not_before`,`updated_at`),
+  KEY `idx_jobs_name_state` (`name`,`state`)
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+INSERT INTO `jobs` VALUES (1,'2024-03-20 00:00:00','2024-03-20 00:00:00','macos_setup_assistant','{\"task\": \"update_all_profiles\"}','queued',0,'','2024-03-20 00:00:00');
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `kernel_host_counts` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `software_title_id` int unsigned DEFAULT NULL,
+  `software_id` int unsigned DEFAULT NULL,
+  `os_version_id` int unsigned DEFAULT NULL,
+  `hosts_count` int unsigned NOT NULL,
+  `team_id` int unsigned NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_kernels_unique_mapping` (`os_version_id`,`team_id`,`software_id`),
+  KEY `software_title_id` (`software_title_id`),
+  KEY `idx_kernel_host_counts_os_version_software` (`os_version_id`,`software_id`,`hosts_count`),
+  CONSTRAINT `kernel_host_counts_ibfk_1` FOREIGN KEY (`software_title_id`) REFERENCES `software_titles` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `label_membership` (
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `label_id` int unsigned NOT NULL,
+  `host_id` int unsigned NOT NULL,
+  PRIMARY KEY (`host_id`,`label_id`),
+  KEY `idx_lm_label_id` (`label_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `labels` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `description` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `query` mediumtext COLLATE utf8mb4_unicode_ci NOT NULL,
+  `platform` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `label_type` int unsigned NOT NULL DEFAULT '1',
+  `label_membership_type` int unsigned NOT NULL DEFAULT '0',
+  `author_id` int unsigned DEFAULT NULL,
+  `criteria` json DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_label_unique_name` (`name`),
+  KEY `author_id` (`author_id`),
+  FULLTEXT KEY `labels_search` (`name`),
+  CONSTRAINT `labels_ibfk_1` FOREIGN KEY (`author_id`) REFERENCES `users` (`id`) ON DELETE SET NULL
+) ENGINE=InnoDB AUTO_INCREMENT=6 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+INSERT INTO `labels` VALUES (1,'2024-04-03 00:00:00','2025-10-09 00:00:00','macOS 14+ (Sonoma+)','macOS hosts with version 14 and above','select 1 from os_version where platform = \'darwin\' and major >= 14;','',1,0,NULL,NULL),(2,'2024-06-28 00:00:00','2025-10-09 00:00:00','iOS','All iOS hosts','','',1,1,NULL,NULL),(3,'2024-06-28 00:00:00','2025-10-09 00:00:00','iPadOS','All iPadOS hosts','','',1,1,NULL,NULL),(4,'2024-09-27 00:00:00','2025-10-09 00:00:00','Fedora Linux','All Fedora hosts','select 1 from os_version where name = \'Fedora Linux\';','',1,0,NULL,NULL),(5,'2025-02-25 00:00:00','2025-10-09 00:00:00','Android','All Android hosts','','',1,1,NULL,NULL);
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `legacy_host_filevault_profiles` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `host_uuid` varchar(36) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `status` varchar(20) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `operation_type` varchar(20) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `profile_uuid` varchar(37) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `detail` text COLLATE utf8mb4_unicode_ci,
+  `command_uuid` varchar(127) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `scope` enum('System','User') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'System',
+  `created_at` timestamp(6) NOT NULL,
+  `updated_at` timestamp(6) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `legacy_host_mdm_enroll_refs` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `host_uuid` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `enroll_ref` varchar(36) COLLATE utf8mb4_unicode_ci NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `idx_legacy_enroll_refs_host_uuid` (`host_uuid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `legacy_host_mdm_idp_accounts` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `host_uuid` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `email` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `account_uuid` varchar(36) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `host_id` int unsigned DEFAULT NULL,
+  `email_id` int unsigned DEFAULT NULL,
+  `email_created_at` datetime DEFAULT NULL,
+  `email_updated_at` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `locks` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `owner` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `expires_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_name` (`name`)
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `mdm_android_configuration_profiles` (
+  `profile_uuid` varchar(37) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `team_id` int unsigned NOT NULL DEFAULT '0',
+  `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `raw_json` json NOT NULL,
+  `auto_increment` bigint NOT NULL AUTO_INCREMENT,
+  `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `uploaded_at` timestamp(6) NULL DEFAULT CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`profile_uuid`),
+  UNIQUE KEY `auto_increment` (`auto_increment`),
+  UNIQUE KEY `idx_mdm_android_configuration_profiles_team_id_name` (`team_id`,`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `mdm_apple_bootstrap_packages` (
+  `team_id` int unsigned NOT NULL,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `sha256` binary(32) NOT NULL,
+  `bytes` longblob,
+  `token` varchar(36) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`team_id`),
+  UNIQUE KEY `idx_token` (`token`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `mdm_apple_configuration_profiles` (
+  `profile_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `team_id` int unsigned NOT NULL DEFAULT '0',
+  `identifier` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `mobileconfig` mediumblob NOT NULL,
+  `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `uploaded_at` timestamp(6) NULL DEFAULT NULL,
+  `checksum` binary(16) NOT NULL,
+  `profile_uuid` varchar(37) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `secrets_updated_at` datetime(6) DEFAULT NULL,
+  `scope` enum('System','User') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'System',
+  PRIMARY KEY (`profile_uuid`),
+  UNIQUE KEY `idx_mdm_apple_config_prof_team_identifier` (`team_id`,`identifier`),
+  UNIQUE KEY `idx_mdm_apple_config_prof_team_name` (`team_id`,`name`),
+  UNIQUE KEY `idx_mdm_apple_config_prof_id` (`profile_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `mdm_apple_declaration_activation_references` (
+  `declaration_uuid` varchar(37) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `reference` varchar(37) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  PRIMARY KEY (`declaration_uuid`,`reference`),
+  KEY `reference` (`reference`),
+  CONSTRAINT `mdm_apple_declaration_activation_references_ibfk_1` FOREIGN KEY (`declaration_uuid`) REFERENCES `mdm_apple_declarations` (`declaration_uuid`) ON UPDATE CASCADE,
+  CONSTRAINT `mdm_apple_declaration_activation_references_ibfk_2` FOREIGN KEY (`reference`) REFERENCES `mdm_apple_declarations` (`declaration_uuid`) ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `mdm_apple_declarations` (
+  `declaration_uuid` varchar(37) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `team_id` int unsigned NOT NULL DEFAULT '0',
+  `identifier` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `raw_json` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `uploaded_at` timestamp(6) NULL DEFAULT NULL,
+  `auto_increment` bigint NOT NULL AUTO_INCREMENT,
+  `secrets_updated_at` datetime(6) DEFAULT NULL,
+  `token` binary(16) GENERATED ALWAYS AS (unhex(md5(concat(`raw_json`,ifnull(`secrets_updated_at`,_utf8mb4''))))) STORED,
+  `scope` enum('System','User') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'System',
+  PRIMARY KEY (`declaration_uuid`),
+  UNIQUE KEY `idx_mdm_apple_declaration_team_identifier` (`team_id`,`identifier`),
+  UNIQUE KEY `idx_mdm_apple_declaration_team_name` (`team_id`,`name`),
+  UNIQUE KEY `auto_increment` (`auto_increment`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `mdm_apple_declarative_requests` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `enrollment_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `message_type` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `raw_json` text COLLATE utf8mb4_unicode_ci,
+  PRIMARY KEY (`id`),
+  KEY `mdm_apple_declarative_requests_enrollment_id` (`enrollment_id`),
+  CONSTRAINT `mdm_apple_declarative_requests_enrollment_id` FOREIGN KEY (`enrollment_id`) REFERENCES `nano_enrollments` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `mdm_apple_default_setup_assistants` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `team_id` int unsigned DEFAULT NULL,
+  `global_or_team_id` int unsigned NOT NULL DEFAULT '0',
+  `profile_uuid` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `abm_token_id` int unsigned DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_mdm_default_setup_assistant_global_or_team_id_abm_token_id` (`global_or_team_id`,`abm_token_id`),
+  KEY `fk_mdm_default_setup_assistant_team_id` (`team_id`),
+  KEY `fk_mdm_default_setup_assistant_abm_token_id` (`abm_token_id`),
+  CONSTRAINT `fk_mdm_default_setup_assistant_abm_token_id` FOREIGN KEY (`abm_token_id`) REFERENCES `abm_tokens` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `mdm_apple_default_setup_assistants_ibfk_1` FOREIGN KEY (`team_id`) REFERENCES `teams` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `mdm_apple_enrollment_profiles` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `token` varchar(36) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `type` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'automatic',
+  `dep_profile` json DEFAULT NULL,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_type` (`type`),
+  UNIQUE KEY `idx_token` (`token`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `mdm_apple_installers` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `size` bigint NOT NULL,
+  `manifest` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  `installer` longblob,
+  `url_token` varchar(36) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `mdm_apple_setup_assistant_profiles` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `setup_assistant_id` int unsigned NOT NULL,
+  `abm_token_id` int unsigned NOT NULL,
+  `profile_uuid` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_mdm_apple_setup_assistant_profiles_asst_id_tok_id` (`setup_assistant_id`,`abm_token_id`),
+  KEY `fk_mdm_apple_setup_assistant_profiles_abm_token_id` (`abm_token_id`),
+  CONSTRAINT `fk_mdm_apple_setup_assistant_profiles_abm_token_id` FOREIGN KEY (`abm_token_id`) REFERENCES `abm_tokens` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_mdm_apple_setup_assistant_profiles_setup_assistant_id` FOREIGN KEY (`setup_assistant_id`) REFERENCES `mdm_apple_setup_assistants` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `mdm_apple_setup_assistants` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `team_id` int unsigned DEFAULT NULL,
+  `global_or_team_id` int unsigned NOT NULL DEFAULT '0',
+  `name` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  `profile` json NOT NULL,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_mdm_setup_assistant_global_or_team_id` (`global_or_team_id`),
+  KEY `fk_mdm_setup_assistant_team_id` (`team_id`),
+  CONSTRAINT `mdm_apple_setup_assistants_ibfk_1` FOREIGN KEY (`team_id`) REFERENCES `teams` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `mdm_config_assets` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(256) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `value` longblob NOT NULL,
+  `deleted_at` timestamp NULL DEFAULT NULL,
+  `deletion_uuid` varchar(127) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `md5_checksum` binary(16) NOT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_mdm_config_assets_name_deletion_uuid` (`name`,`deletion_uuid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `mdm_configuration_profile_labels` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `apple_profile_uuid` varchar(37) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `windows_profile_uuid` varchar(37) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `label_name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `label_id` int unsigned DEFAULT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `exclude` tinyint(1) NOT NULL DEFAULT '0',
+  `require_all` tinyint(1) NOT NULL DEFAULT '0',
+  `android_profile_uuid` varchar(37) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_mdm_configuration_profile_labels_apple_label_name` (`apple_profile_uuid`,`label_name`),
+  UNIQUE KEY `idx_mdm_configuration_profile_labels_windows_label_name` (`windows_profile_uuid`,`label_name`),
+  UNIQUE KEY `idx_mdm_configuration_profile_labels_android_label_name` (`android_profile_uuid`,`label_name`),
+  KEY `label_id` (`label_id`),
+  CONSTRAINT `mdm_configuration_profile_labels_ibfk_1` FOREIGN KEY (`apple_profile_uuid`) REFERENCES `mdm_apple_configuration_profiles` (`profile_uuid`) ON DELETE CASCADE,
+  CONSTRAINT `mdm_configuration_profile_labels_ibfk_2` FOREIGN KEY (`windows_profile_uuid`) REFERENCES `mdm_windows_configuration_profiles` (`profile_uuid`) ON DELETE CASCADE,
+  CONSTRAINT `mdm_configuration_profile_labels_ibfk_3` FOREIGN KEY (`label_id`) REFERENCES `labels` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `mdm_configuration_profile_labels_ibfk_4` FOREIGN KEY (`android_profile_uuid`) REFERENCES `mdm_android_configuration_profiles` (`profile_uuid`) ON DELETE CASCADE,
+  CONSTRAINT `ck_mdm_configuration_profile_labels_profile_uuid` CHECK ((((if((`apple_profile_uuid` is null),0,1) + if((`windows_profile_uuid` is null),0,1)) + if((`android_profile_uuid` is null),0,1)) = 1))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `mdm_configuration_profile_variables` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `apple_profile_uuid` varchar(37) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `windows_profile_uuid` varchar(37) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `fleet_variable_id` int unsigned NOT NULL,
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_mdm_configuration_profile_variables_apple_variable` (`apple_profile_uuid`,`fleet_variable_id`),
+  UNIQUE KEY `idx_mdm_configuration_profile_variables_windows_label_name` (`windows_profile_uuid`,`fleet_variable_id`),
+  KEY `mdm_configuration_profile_variables_fleet_variable_id` (`fleet_variable_id`),
+  CONSTRAINT `fk_mdm_configuration_profile_variables_apple_profile_uuid` FOREIGN KEY (`apple_profile_uuid`) REFERENCES `mdm_apple_configuration_profiles` (`profile_uuid`) ON DELETE CASCADE,
+  CONSTRAINT `fk_mdm_configuration_profile_variables_windows_profile_uuid` FOREIGN KEY (`windows_profile_uuid`) REFERENCES `mdm_windows_configuration_profiles` (`profile_uuid`) ON DELETE CASCADE,
+  CONSTRAINT `mdm_configuration_profile_variables_fleet_variable_id` FOREIGN KEY (`fleet_variable_id`) REFERENCES `fleet_variables` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `ck_mdm_configuration_profile_variables_apple_or_windows` CHECK (((`apple_profile_uuid` is null) <> (`windows_profile_uuid` is null)))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `mdm_declaration_labels` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `apple_declaration_uuid` varchar(37) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `label_name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `label_id` int unsigned DEFAULT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `uploaded_at` timestamp NULL DEFAULT NULL,
+  `exclude` tinyint(1) NOT NULL DEFAULT '0',
+  `require_all` tinyint(1) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_mdm_declaration_labels_label_name` (`apple_declaration_uuid`,`label_name`),
+  KEY `label_id` (`label_id`),
+  CONSTRAINT `mdm_declaration_labels_ibfk_1` FOREIGN KEY (`apple_declaration_uuid`) REFERENCES `mdm_apple_declarations` (`declaration_uuid`) ON DELETE CASCADE,
+  CONSTRAINT `mdm_declaration_labels_ibfk_3` FOREIGN KEY (`label_id`) REFERENCES `labels` (`id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `mdm_delivery_status` (
+  `status` varchar(20) COLLATE utf8mb4_unicode_ci NOT NULL,
+  PRIMARY KEY (`status`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+INSERT INTO `mdm_delivery_status` VALUES ('failed'),('pending'),('verified'),('verifying');
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `mdm_idp_accounts` (
+  `uuid` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `username` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `fullname` varchar(256) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `email` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`uuid`),
+  UNIQUE KEY `unique_idp_email` (`email`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `mdm_operation_types` (
+  `operation_type` varchar(20) COLLATE utf8mb4_unicode_ci NOT NULL,
+  PRIMARY KEY (`operation_type`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+INSERT INTO `mdm_operation_types` VALUES ('install'),('remove');
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `mdm_windows_configuration_profiles` (
+  `team_id` int unsigned NOT NULL DEFAULT '0',
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `syncml` mediumblob NOT NULL,
+  `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `uploaded_at` timestamp(6) NULL DEFAULT NULL,
+  `profile_uuid` varchar(37) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `auto_increment` bigint NOT NULL AUTO_INCREMENT,
+  `checksum` binary(16) GENERATED ALWAYS AS (unhex(md5(`syncml`))) STORED,
+  `secrets_updated_at` datetime(6) DEFAULT NULL,
+  PRIMARY KEY (`profile_uuid`),
+  UNIQUE KEY `idx_mdm_windows_configuration_profiles_team_id_name` (`team_id`,`name`),
+  UNIQUE KEY `auto_increment` (`auto_increment`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `mdm_windows_enrollments` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `mdm_device_id` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `mdm_hardware_id` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `device_state` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `device_type` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `device_name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `enroll_type` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `enroll_user_id` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `enroll_proto_version` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `enroll_client_version` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `not_in_oobe` tinyint(1) NOT NULL DEFAULT '0',
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `host_uuid` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_type` (`mdm_hardware_id`),
+  KEY `idx_mdm_windows_enrollments_mdm_device_id` (`mdm_device_id`),
+  KEY `idx_mdm_windows_enrollments_host_uuid` (`host_uuid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `microsoft_compliance_partner_host_statuses` (
+  `host_id` int unsigned NOT NULL,
+  `device_id` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `user_principal_name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `managed` tinyint(1) DEFAULT NULL,
+  `compliant` tinyint(1) DEFAULT NULL,
+  `created_at` datetime(6) DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` datetime(6) DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`host_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `microsoft_compliance_partner_integrations` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `tenant_id` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `proxy_server_secret` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `setup_done` tinyint(1) NOT NULL DEFAULT '0',
+  `created_at` datetime(6) DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` datetime(6) DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_microsoft_compliance_partner_tenant_id` (`tenant_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `migration_status_tables` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `version_id` bigint NOT NULL,
+  `is_applied` tinyint(1) NOT NULL,
+  `tstamp` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=433 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+INSERT INTO `migration_status_tables` VALUES (1,0,1,'2020-01-01 01:01:01'),(2,20161118193812,1,'2020-01-01 01:01:01'),(3,20161118211713,1,'2020-01-01 01:01:01'),(4,20161118212436,1,'2020-01-01 01:01:01'),(5,20161118212515,1,'2020-01-01 01:01:01'),(6,20161118212528,1,'2020-01-01 01:01:01'),(7,20161118212538,1,'2020-01-01 01:01:01'),(8,20161118212549,1,'2020-01-01 01:01:01'),(9,20161118212557,1,'2020-01-01 01:01:01'),(10,20161118212604,1,'2020-01-01 01:01:01'),(11,20161118212613,1,'2020-01-01 01:01:01'),(12,20161118212621,1,'2020-01-01 01:01:01'),(13,20161118212630,1,'2020-01-01 01:01:01'),(14,20161118212641,1,'2020-01-01 01:01:01'),(15,20161118212649,1,'2020-01-01 01:01:01'),(16,20161118212656,1,'2020-01-01 01:01:01'),(17,20161118212758,1,'2020-01-01 01:01:01'),(18,20161128234849,1,'2020-01-01 01:01:01'),(19,20161230162221,1,'2020-01-01 01:01:01'),(20,20170104113816,1,'2020-01-01 01:01:01'),(21,20170105151732,1,'2020-01-01 01:01:01'),(22,20170108191242,1,'2020-01-01 01:01:01'),(23,20170109094020,1,'2020-01-01 01:01:01'),(24,20170109130438,1,'2020-01-01 01:01:01'),(25,20170110202752,1,'2020-01-01 01:01:01'),(26,20170111133013,1,'2020-01-01 01:01:01'),(27,20170117025759,1,'2020-01-01 01:01:01'),(28,20170118191001,1,'2020-01-01 01:01:01'),(29,20170119234632,1,'2020-01-01 01:01:01'),(30,20170124230432,1,'2020-01-01 01:01:01'),(31,20170127014618,1,'2020-01-01 01:01:01'),(32,20170131232841,1,'2020-01-01 01:01:01'),(33,20170223094154,1,'2020-01-01 01:01:01'),(34,20170306075207,1,'2020-01-01 01:01:01'),(35,20170309100733,1,'2020-01-01 01:01:01'),(36,20170331111922,1,'2020-01-01 01:01:01'),(37,20170502143928,1,'2020-01-01 01:01:01'),(38,20170504130602,1,'2020-01-01 01:01:01'),(39,20170509132100,1,'2020-01-01 01:01:01'),(40,20170519105647,1,'2020-01-01 01:01:01'),(41,20170519105648,1,'2020-01-01 01:01:01'),(42,20170831234300,1,'2020-01-01 01:01:01'),(43,20170831234301,1,'2020-01-01 01:01:01'),(44,20170831234303,1,'2020-01-01 01:01:01'),(45,20171116163618,1,'2020-01-01 01:01:01'),(46,20171219164727,1,'2020-01-01 01:01:01'),(47,20180620164811,1,'2020-01-01 01:01:01'),(48,20180620175054,1,'2020-01-01 01:01:01'),(49,20180620175055,1,'2020-01-01 01:01:01'),(50,20191010101639,1,'2020-01-01 01:01:01'),(51,20191010155147,1,'2020-01-01 01:01:01'),(52,20191220130734,1,'2020-01-01 01:01:01'),(53,20200311140000,1,'2020-01-01 01:01:01'),(54,20200405120000,1,'2020-01-01 01:01:01'),(55,20200407120000,1,'2020-01-01 01:01:01'),(56,20200420120000,1,'2020-01-01 01:01:01'),(57,20200504120000,1,'2020-01-01 01:01:01'),(58,20200512120000,1,'2020-01-01 01:01:01'),(59,20200707120000,1,'2020-01-01 01:01:01'),(60,20201011162341,1,'2020-01-01 01:01:01'),(61,20201021104586,1,'2020-01-01 01:01:01'),(62,20201102112520,1,'2020-01-01 01:01:01'),(63,20201208121729,1,'2020-01-01 01:01:01'),(64,20201215091637,1,'2020-01-01 01:01:01'),(65,20210119174155,1,'2020-01-01 01:01:01'),(66,20210326182902,1,'2020-01-01 01:01:01'),(67,20210421112652,1,'2020-01-01 01:01:01'),(68,20210506095025,1,'2020-01-01 01:01:01'),(69,20210513115729,1,'2020-01-01 01:01:01'),(70,20210526113559,1,'2020-01-01 01:01:01'),(71,20210601000001,1,'2020-01-01 01:01:01'),(72,20210601000002,1,'2020-01-01 01:01:01'),(73,20210601000003,1,'2020-01-01 01:01:01'),(74,20210601000004,1,'2020-01-01 01:01:01'),(75,20210601000005,1,'2020-01-01 01:01:01'),(76,20210601000006,1,'2020-01-01 01:01:01'),(77,20210601000007,1,'2020-01-01 01:01:01'),(78,20210601000008,1,'2020-01-01 01:01:01'),(79,20210606151329,1,'2020-01-01 01:01:01'),(80,20210616163757,1,'2020-01-01 01:01:01'),(81,20210617174723,1,'2020-01-01 01:01:01'),(82,20210622160235,1,'2020-01-01 01:01:01'),(83,20210623100031,1,'2020-01-01 01:01:01'),(84,20210623133615,1,'2020-01-01 01:01:01'),(85,20210708143152,1,'2020-01-01 01:01:01'),(86,20210709124443,1,'2020-01-01 01:01:01'),(87,20210712155608,1,'2020-01-01 01:01:01'),(88,20210714102108,1,'2020-01-01 01:01:01'),(89,20210719153709,1,'2020-01-01 01:01:01'),(90,20210721171531,1,'2020-01-01 01:01:01'),(91,20210723135713,1,'2020-01-01 01:01:01'),(92,20210802135933,1,'2020-01-01 01:01:01'),(93,20210806112844,1,'2020-01-01 01:01:01'),(94,20210810095603,1,'2020-01-01 01:01:01'),(95,20210811150223,1,'2020-01-01 01:01:01'),(96,20210818151827,1,'2020-01-01 01:01:01'),(97,20210818151828,1,'2020-01-01 01:01:01'),(98,20210818182258,1,'2020-01-01 01:01:01'),(99,20210819131107,1,'2020-01-01 01:01:01'),(100,20210819143446,1,'2020-01-01 01:01:01'),(101,20210903132338,1,'2020-01-01 01:01:01'),(102,20210915144307,1,'2020-01-01 01:01:01'),(103,20210920155130,1,'2020-01-01 01:01:01'),(104,20210927143115,1,'2020-01-01 01:01:01'),(105,20210927143116,1,'2020-01-01 01:01:01'),(106,20211013133706,1,'2020-01-01 01:01:01'),(107,20211013133707,1,'2020-01-01 01:01:01'),(108,20211102135149,1,'2020-01-01 01:01:01'),(109,20211109121546,1,'2020-01-01 01:01:01'),(110,20211110163320,1,'2020-01-01 01:01:01'),(111,20211116184029,1,'2020-01-01 01:01:01'),(112,20211116184030,1,'2020-01-01 01:01:01'),(113,20211202092042,1,'2020-01-01 01:01:01'),(114,20211202181033,1,'2020-01-01 01:01:01'),(115,20211207161856,1,'2020-01-01 01:01:01'),(116,20211216131203,1,'2020-01-01 01:01:01'),(117,20211221110132,1,'2020-01-01 01:01:01'),(118,20220107155700,1,'2020-01-01 01:01:01'),(119,20220125105650,1,'2020-01-01 01:01:01'),(120,20220201084510,1,'2020-01-01 01:01:01'),(121,20220208144830,1,'2020-01-01 01:01:01'),(122,20220208144831,1,'2020-01-01 01:01:01'),(123,20220215152203,1,'2020-01-01 01:01:01'),(124,20220223113157,1,'2020-01-01 01:01:01'),(125,20220307104655,1,'2020-01-01 01:01:01'),(126,20220309133956,1,'2020-01-01 01:01:01'),(127,20220316155700,1,'2020-01-01 01:01:01'),(128,20220323152301,1,'2020-01-01 01:01:01'),(129,20220330100659,1,'2020-01-01 01:01:01'),(130,20220404091216,1,'2020-01-01 01:01:01'),(131,20220419140750,1,'2020-01-01 01:01:01'),(132,20220428140039,1,'2020-01-01 01:01:01'),(133,20220503134048,1,'2020-01-01 01:01:01'),(134,20220524102918,1,'2020-01-01 01:01:01'),(135,20220526123327,1,'2020-01-01 01:01:01'),(136,20220526123328,1,'2020-01-01 01:01:01'),(137,20220526123329,1,'2020-01-01 01:01:01'),(138,20220608113128,1,'2020-01-01 01:01:01'),(139,20220627104817,1,'2020-01-01 01:01:01'),(140,20220704101843,1,'2020-01-01 01:01:01'),(141,20220708095046,1,'2020-01-01 01:01:01'),(142,20220713091130,1,'2020-01-01 01:01:01'),(143,20220802135510,1,'2020-01-01 01:01:01'),(144,20220818101352,1,'2020-01-01 01:01:01'),(145,20220822161445,1,'2020-01-01 01:01:01'),(146,20220831100036,1,'2020-01-01 01:01:01'),(147,20220831100151,1,'2020-01-01 01:01:01'),(148,20220908181826,1,'2020-01-01 01:01:01'),(149,20220914154915,1,'2020-01-01 01:01:01'),(150,20220915165115,1,'2020-01-01 01:01:01'),(151,20220915165116,1,'2020-01-01 01:01:01'),(152,20220928100158,1,'2020-01-01 01:01:01'),(153,20221014084130,1,'2020-01-01 01:01:01'),(154,20221027085019,1,'2020-01-01 01:01:01'),(155,20221101103952,1,'2020-01-01 01:01:01'),(156,20221104144401,1,'2020-01-01 01:01:01'),(157,20221109100749,1,'2020-01-01 01:01:01'),(158,20221115104546,1,'2020-01-01 01:01:01'),(159,20221130114928,1,'2020-01-01 01:01:01'),(160,20221205112142,1,'2020-01-01 01:01:01'),(161,20221216115820,1,'2020-01-01 01:01:01'),(162,20221220195934,1,'2020-01-01 01:01:01'),(163,20221220195935,1,'2020-01-01 01:01:01'),(164,20221223174807,1,'2020-01-01 01:01:01'),(165,20221227163855,1,'2020-01-01 01:01:01'),(166,20221227163856,1,'2020-01-01 01:01:01'),(167,20230202224725,1,'2020-01-01 01:01:01'),(168,20230206163608,1,'2020-01-01 01:01:01'),(169,20230214131519,1,'2020-01-01 01:01:01'),(170,20230303135738,1,'2020-01-01 01:01:01'),(171,20230313135301,1,'2020-01-01 01:01:01'),(172,20230313141819,1,'2020-01-01 01:01:01'),(173,20230315104937,1,'2020-01-01 01:01:01'),(174,20230317173844,1,'2020-01-01 01:01:01'),(175,20230320133602,1,'2020-01-01 01:01:01'),(176,20230330100011,1,'2020-01-01 01:01:01'),(177,20230330134823,1,'2020-01-01 01:01:01'),(178,20230405232025,1,'2020-01-01 01:01:01'),(179,20230408084104,1,'2020-01-01 01:01:01'),(180,20230411102858,1,'2020-01-01 01:01:01'),(181,20230421155932,1,'2020-01-01 01:01:01'),(182,20230425082126,1,'2020-01-01 01:01:01'),(183,20230425105727,1,'2020-01-01 01:01:01'),(184,20230501154913,1,'2020-01-01 01:01:01'),(185,20230503101418,1,'2020-01-01 01:01:01'),(186,20230515144206,1,'2020-01-01 01:01:01'),(187,20230517140952,1,'2020-01-01 01:01:01'),(188,20230517152807,1,'2020-01-01 01:01:01'),(189,20230518114155,1,'2020-01-01 01:01:01'),(190,20230520153236,1,'2020-01-01 01:01:01'),(191,20230525151159,1,'2020-01-01 01:01:01'),(192,20230530122103,1,'2020-01-01 01:01:01'),(193,20230602111827,1,'2020-01-01 01:01:01'),(194,20230608103123,1,'2020-01-01 01:01:01'),(195,20230629140529,1,'2020-01-01 01:01:01'),(196,20230629140530,1,'2020-01-01 01:01:01'),(197,20230711144622,1,'2020-01-01 01:01:01'),(198,20230721135421,1,'2020-01-01 01:01:01'),(199,20230721161508,1,'2020-01-01 01:01:01'),(200,20230726115701,1,'2020-01-01 01:01:01'),(201,20230807100822,1,'2020-01-01 01:01:01'),(202,20230814150442,1,'2020-01-01 01:01:01'),(203,20230823122728,1,'2020-01-01 01:01:01'),(204,20230906152143,1,'2020-01-01 01:01:01'),(205,20230911163618,1,'2020-01-01 01:01:01'),(206,20230912101759,1,'2020-01-01 01:01:01'),(207,20230915101341,1,'2020-01-01 01:01:01'),(208,20230918132351,1,'2020-01-01 01:01:01'),(209,20231004144339,1,'2020-01-01 01:01:01'),(210,20231009094541,1,'2020-01-01 01:01:01'),(211,20231009094542,1,'2020-01-01 01:01:01'),(212,20231009094543,1,'2020-01-01 01:01:01'),(213,20231009094544,1,'2020-01-01 01:01:01'),(214,20231016091915,1,'2020-01-01 01:01:01'),(215,20231024174135,1,'2020-01-01 01:01:01'),(216,20231025120016,1,'2020-01-01 01:01:01'),(217,20231025160156,1,'2020-01-01 01:01:01'),(218,20231031165350,1,'2020-01-01 01:01:01'),(219,20231106144110,1,'2020-01-01 01:01:01'),(220,20231107130934,1,'2020-01-01 01:01:01'),(221,20231109115838,1,'2020-01-01 01:01:01'),(222,20231121054530,1,'2020-01-01 01:01:01'),(223,20231122101320,1,'2020-01-01 01:01:01'),(224,20231130132828,1,'2020-01-01 01:01:01'),(225,20231130132931,1,'2020-01-01 01:01:01'),(226,20231204155427,1,'2020-01-01 01:01:01'),(227,20231206142340,1,'2020-01-01 01:01:01'),(228,20231207102320,1,'2020-01-01 01:01:01'),(229,20231207102321,1,'2020-01-01 01:01:01'),(230,20231207133731,1,'2020-01-01 01:01:01'),(231,20231212094238,1,'2020-01-01 01:01:01'),(232,20231212095734,1,'2020-01-01 01:01:01'),(233,20231212161121,1,'2020-01-01 01:01:01'),(234,20231215122713,1,'2020-01-01 01:01:01'),(235,20231219143041,1,'2020-01-01 01:01:01'),(236,20231224070653,1,'2020-01-01 01:01:01'),(237,20240110134315,1,'2020-01-01 01:01:01'),(238,20240119091637,1,'2020-01-01 01:01:01'),(239,20240126020642,1,'2020-01-01 01:01:01'),(240,20240126020643,1,'2020-01-01 01:01:01'),(241,20240129162819,1,'2020-01-01 01:01:01'),(242,20240130115133,1,'2020-01-01 01:01:01'),(243,20240131083822,1,'2020-01-01 01:01:01'),(244,20240205095928,1,'2020-01-01 01:01:01'),(245,20240205121956,1,'2020-01-01 01:01:01'),(246,20240209110212,1,'2020-01-01 01:01:01'),(247,20240212111533,1,'2020-01-01 01:01:01'),(248,20240221112844,1,'2020-01-01 01:01:01'),(249,20240222073518,1,'2020-01-01 01:01:01'),(250,20240222135115,1,'2020-01-01 01:01:01'),(251,20240226082255,1,'2020-01-01 01:01:01'),(252,20240228082706,1,'2020-01-01 01:01:01'),(253,20240301173035,1,'2020-01-01 01:01:01'),(254,20240302111134,1,'2020-01-01 01:01:01'),(255,20240312103753,1,'2020-01-01 01:01:01'),(256,20240313143416,1,'2020-01-01 01:01:01'),(257,20240314085226,1,'2020-01-01 01:01:01'),(258,20240314151747,1,'2020-01-01 01:01:01'),(259,20240320145650,1,'2020-01-01 01:01:01'),(260,20240327115530,1,'2020-01-01 01:01:01'),(261,20240327115617,1,'2020-01-01 01:01:01'),(262,20240408085837,1,'2020-01-01 01:01:01'),(263,20240415104633,1,'2020-01-01 01:01:01'),(264,20240430111727,1,'2020-01-01 01:01:01'),(265,20240515200020,1,'2020-01-01 01:01:01'),(266,20240521143023,1,'2020-01-01 01:01:01'),(267,20240521143024,1,'2020-01-01 01:01:01'),(268,20240601174138,1,'2020-01-01 01:01:01'),(269,20240607133721,1,'2020-01-01 01:01:01'),(270,20240612150059,1,'2020-01-01 01:01:01'),(271,20240613162201,1,'2020-01-01 01:01:01'),(272,20240613172616,1,'2020-01-01 01:01:01'),(273,20240618142419,1,'2020-01-01 01:01:01'),(274,20240625093543,1,'2020-01-01 01:01:01'),(275,20240626195531,1,'2020-01-01 01:01:01'),(276,20240702123921,1,'2020-01-01 01:01:01'),(277,20240703154849,1,'2020-01-01 01:01:01'),(278,20240707134035,1,'2020-01-01 01:01:01'),(279,20240707134036,1,'2020-01-01 01:01:01'),(280,20240709124958,1,'2020-01-01 01:01:01'),(281,20240709132642,1,'2020-01-01 01:01:01'),(282,20240709183940,1,'2020-01-01 01:01:01'),(283,20240710155623,1,'2020-01-01 01:01:01'),(284,20240723102712,1,'2020-01-01 01:01:01'),(285,20240725152735,1,'2020-01-01 01:01:01'),(286,20240725182118,1,'2020-01-01 01:01:01'),(287,20240726100517,1,'2020-01-01 01:01:01'),(288,20240730171504,1,'2020-01-01 01:01:01'),(289,20240730174056,1,'2020-01-01 01:01:01'),(290,20240730215453,1,'2020-01-01 01:01:01'),(291,20240730374423,1,'2020-01-01 01:01:01'),(292,20240801115359,1,'2020-01-01 01:01:01'),(293,20240802101043,1,'2020-01-01 01:01:01'),(294,20240802113716,1,'2020-01-01 01:01:01'),(295,20240814135330,1,'2020-01-01 01:01:01'),(296,20240815000000,1,'2020-01-01 01:01:01'),(297,20240815000001,1,'2020-01-01 01:01:01'),(298,20240816103247,1,'2020-01-01 01:01:01'),(299,20240820091218,1,'2020-01-01 01:01:01'),(300,20240826111228,1,'2020-01-01 01:01:01'),(301,20240826160025,1,'2020-01-01 01:01:01'),(302,20240829165448,1,'2020-01-01 01:01:01'),(303,20240829165605,1,'2020-01-01 01:01:01'),(304,20240829165715,1,'2020-01-01 01:01:01'),(305,20240829165930,1,'2020-01-01 01:01:01'),(306,20240829170023,1,'2020-01-01 01:01:01'),(307,20240829170033,1,'2020-01-01 01:01:01'),(308,20240829170044,1,'2020-01-01 01:01:01'),(309,20240905105135,1,'2020-01-01 01:01:01'),(310,20240905140514,1,'2020-01-01 01:01:01'),(311,20240905200000,1,'2020-01-01 01:01:01'),(312,20240905200001,1,'2020-01-01 01:01:01'),(313,20241002104104,1,'2020-01-01 01:01:01'),(314,20241002104105,1,'2020-01-01 01:01:01'),(315,20241002104106,1,'2020-01-01 01:01:01'),(316,20241002210000,1,'2020-01-01 01:01:01'),(317,20241003145349,1,'2020-01-01 01:01:01'),(318,20241004005000,1,'2020-01-01 01:01:01'),(319,20241008083925,1,'2020-01-01 01:01:01'),(320,20241009090010,1,'2020-01-01 01:01:01'),(321,20241017163402,1,'2020-01-01 01:01:01'),(322,20241021224359,1,'2020-01-01 01:01:01'),(323,20241022140321,1,'2020-01-01 01:01:01'),(324,20241025111236,1,'2020-01-01 01:01:01'),(325,20241025112748,1,'2020-01-01 01:01:01'),(326,20241025141855,1,'2020-01-01 01:01:01'),(327,20241110152839,1,'2020-01-01 01:01:01'),(328,20241110152840,1,'2020-01-01 01:01:01'),(329,20241110152841,1,'2020-01-01 01:01:01'),(330,20241116233322,1,'2020-01-01 01:01:01'),(331,20241122171434,1,'2020-01-01 01:01:01'),(332,20241125150614,1,'2020-01-01 01:01:01'),(333,20241203125346,1,'2020-01-01 01:01:01'),(334,20241203130032,1,'2020-01-01 01:01:01'),(335,20241205122800,1,'2020-01-01 01:01:01'),(336,20241209164540,1,'2020-01-01 01:01:01'),(337,20241210140021,1,'2020-01-01 01:01:01'),(338,20241219180042,1,'2020-01-01 01:01:01'),(339,20241220100000,1,'2020-01-01 01:01:01'),(340,20241220114903,1,'2020-01-01 01:01:01'),(341,20241220114904,1,'2020-01-01 01:01:01'),(342,20241224000000,1,'2020-01-01 01:01:01'),(343,20241230000000,1,'2020-01-01 01:01:01'),(344,20241231112624,1,'2020-01-01 01:01:01'),(345,20250102121439,1,'2020-01-01 01:01:01'),(346,20250121094045,1,'2020-01-01 01:01:01'),(347,20250121094500,1,'2020-01-01 01:01:01'),(348,20250121094600,1,'2020-01-01 01:01:01'),(349,20250121094700,1,'2020-01-01 01:01:01'),(350,20250124194347,1,'2020-01-01 01:01:01'),(351,20250127162751,1,'2020-01-01 01:01:01'),(352,20250213104005,1,'2020-01-01 01:01:01'),(353,20250214205657,1,'2020-01-01 01:01:01'),(354,20250217093329,1,'2020-01-01 01:01:01'),(355,20250219090511,1,'2020-01-01 01:01:01'),(356,20250219100000,1,'2020-01-01 01:01:01'),(357,20250219142401,1,'2020-01-01 01:01:01'),(358,20250224184002,1,'2020-01-01 01:01:01'),(359,20250225085436,1,'2020-01-01 01:01:01'),(360,20250226000000,1,'2020-01-01 01:01:01'),(361,20250226153445,1,'2020-01-01 01:01:01'),(362,20250304162702,1,'2020-01-01 01:01:01'),(363,20250306144233,1,'2020-01-01 01:01:01'),(364,20250313163430,1,'2020-01-01 01:01:01'),(365,20250317130944,1,'2020-01-01 01:01:01'),(366,20250318165922,1,'2020-01-01 01:01:01'),(367,20250320132525,1,'2020-01-01 01:01:01'),(368,20250320200000,1,'2020-01-01 01:01:01'),(369,20250326161930,1,'2020-01-01 01:01:01'),(370,20250326161931,1,'2020-01-01 01:01:01'),(371,20250331042354,1,'2020-01-01 01:01:01'),(372,20250331154206,1,'2020-01-01 01:01:01'),(373,20250401155831,1,'2020-01-01 01:01:01'),(374,20250408133233,1,'2020-01-01 01:01:01'),(375,20250410104321,1,'2020-01-01 01:01:01'),(376,20250421085116,1,'2020-01-01 01:01:01'),(377,20250422095806,1,'2020-01-01 01:01:01'),(378,20250424153059,1,'2020-01-01 01:01:01'),(379,20250430103833,1,'2020-01-01 01:01:01'),(380,20250430112622,1,'2020-01-01 01:01:01'),(381,20250501162727,1,'2020-01-01 01:01:01'),(382,20250502154517,1,'2020-01-01 01:01:01'),(383,20250502222222,1,'2020-01-01 01:01:01'),(384,20250507170845,1,'2020-01-01 01:01:01'),(385,20250513162912,1,'2020-01-01 01:01:01'),(386,20250519161614,1,'2020-01-01 01:01:01'),(387,20250519170000,1,'2020-01-01 01:01:01'),(388,20250520153848,1,'2020-01-01 01:01:01'),(389,20250528115932,1,'2020-01-01 01:01:01'),(390,20250529102706,1,'2020-01-01 01:01:01'),(391,20250603105558,1,'2020-01-01 01:01:01'),(392,20250609102714,1,'2020-01-01 01:01:01'),(393,20250609112613,1,'2020-01-01 01:01:01'),(394,20250613103810,1,'2020-01-01 01:01:01'),(395,20250616193950,1,'2020-01-01 01:01:01'),(396,20250624140757,1,'2020-01-01 01:01:01'),(397,20250626130239,1,'2020-01-01 01:01:01'),(398,20250629131032,1,'2020-01-01 01:01:01'),(399,20250701155654,1,'2020-01-01 01:01:01'),(400,20250707095725,1,'2020-01-01 01:01:01'),(401,20250716152435,1,'2020-01-01 01:01:01'),(402,20250718091828,1,'2020-01-01 01:01:01'),(403,20250728122229,1,'2020-01-01 01:01:01'),(404,20250731122715,1,'2020-01-01 01:01:01'),(405,20250731151000,1,'2020-01-01 01:01:01'),(406,20250803000000,1,'2020-01-01 01:01:01'),(407,20250805083116,1,'2020-01-01 01:01:01'),(408,20250807140441,1,'2020-01-01 01:01:01'),(409,20250808000000,1,'2020-01-01 01:01:01'),(410,20250811155036,1,'2020-01-01 01:01:01'),(411,20250813205039,1,'2020-01-01 01:01:01'),(412,20250814123333,1,'2020-01-01 01:01:01'),(413,20250815130115,1,'2020-01-01 01:01:01'),(414,20250816115553,1,'2020-01-01 01:01:01'),(415,20250817154557,1,'2020-01-01 01:01:01'),(416,20250825113751,1,'2020-01-01 01:01:01'),(417,20250827113140,1,'2020-01-01 01:01:01'),(418,20250828120836,1,'2020-01-01 01:01:01'),(419,20250902112642,1,'2020-01-01 01:01:01'),(420,20250904091745,1,'2020-01-01 01:01:01'),(421,20250905090000,1,'2020-01-01 01:01:01'),(422,20250922083056,1,'2020-01-01 01:01:01'),(423,20250923120000,1,'2020-01-01 01:01:01'),(424,20250926123048,1,'2020-01-01 01:01:01'),(425,20251015103505,1,'2020-01-01 01:01:01'),(426,20251015103600,1,'2020-01-01 01:01:01'),(427,20251015103700,1,'2020-01-01 01:01:01'),(428,20251015103800,1,'2020-01-01 01:01:01'),(429,20251015103900,1,'2020-01-01 01:01:01'),(430,20251022123456,1,'2020-01-01 01:01:01'),(431,20251027101151,1,'2020-01-01 01:01:01'),(432,20251027101155,1,'2020-01-01 01:01:01');
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `mobile_device_management_solutions` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `server_url` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_mobile_device_management_solutions_name` (`name`,`server_url`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `munki_issues` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `issue_type` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_munki_issues_name` (`name`,`issue_type`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `nano_cert_auth_associations` (
+  `id` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `sha256` char(64) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `cert_not_valid_after` timestamp NULL DEFAULT NULL,
+  `renew_command_uuid` varchar(127) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  PRIMARY KEY (`id`,`sha256`),
+  KEY `renew_command_uuid_fk` (`renew_command_uuid`),
+  CONSTRAINT `renew_command_uuid_fk` FOREIGN KEY (`renew_command_uuid`) REFERENCES `nano_commands` (`command_uuid`),
+  CONSTRAINT `nano_cert_auth_associations_chk_1` CHECK ((`id` <> _utf8mb4'')),
+  CONSTRAINT `nano_cert_auth_associations_chk_2` CHECK ((`sha256` <> _utf8mb4''))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `nano_command_results` (
+  `id` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `command_uuid` varchar(127) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `status` varchar(31) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `result` mediumtext COLLATE utf8mb4_unicode_ci NOT NULL,
+  `not_now_at` timestamp NULL DEFAULT NULL,
+  `not_now_tally` int NOT NULL DEFAULT '0',
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`,`command_uuid`),
+  KEY `command_uuid` (`command_uuid`),
+  KEY `status` (`status`),
+  CONSTRAINT `nano_command_results_ibfk_1` FOREIGN KEY (`id`) REFERENCES `nano_enrollments` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `nano_command_results_ibfk_2` FOREIGN KEY (`command_uuid`) REFERENCES `nano_commands` (`command_uuid`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `nano_command_results_chk_1` CHECK ((`status` <> _utf8mb4'')),
+  CONSTRAINT `nano_command_results_chk_2` CHECK ((substr(`result`,1,5) = _utf8mb4'<?xml'))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `nano_commands` (
+  `command_uuid` varchar(127) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `request_type` varchar(63) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `command` mediumtext COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` timestamp(6) NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` timestamp(6) NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  `subtype` enum('None','ProfileWithSecrets') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'None',
+  PRIMARY KEY (`command_uuid`),
+  CONSTRAINT `nano_commands_chk_1` CHECK ((`command_uuid` <> _utf8mb4'')),
+  CONSTRAINT `nano_commands_chk_2` CHECK ((`request_type` <> _utf8mb4''))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `nano_dep_names` (
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `consumer_key` text COLLATE utf8mb4_unicode_ci,
+  `consumer_secret` text COLLATE utf8mb4_unicode_ci,
+  `access_token` text COLLATE utf8mb4_unicode_ci,
+  `access_secret` text COLLATE utf8mb4_unicode_ci,
+  `access_token_expiry` timestamp NULL DEFAULT NULL,
+  `config_base_url` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `tokenpki_cert_pem` text COLLATE utf8mb4_unicode_ci,
+  `tokenpki_key_pem` text COLLATE utf8mb4_unicode_ci,
+  `syncer_cursor` varchar(1024) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `syncer_cursor_at` timestamp NULL DEFAULT NULL,
+  `assigner_profile_uuid` text COLLATE utf8mb4_unicode_ci,
+  `assigner_profile_uuid_at` timestamp NULL DEFAULT NULL,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`name`),
+  CONSTRAINT `nano_dep_names_chk_1` CHECK (((`tokenpki_cert_pem` is null) or (substr(`tokenpki_cert_pem`,1,27) = _utf8mb4'-----BEGIN CERTIFICATE-----'))),
+  CONSTRAINT `nano_dep_names_chk_2` CHECK (((`tokenpki_key_pem` is null) or (substr(`tokenpki_key_pem`,1,5) = _utf8mb4'-----')))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `nano_devices` (
+  `id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `identity_cert` text COLLATE utf8mb4_unicode_ci,
+  `serial_number` varchar(127) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `unlock_token` mediumblob,
+  `unlock_token_at` timestamp NULL DEFAULT NULL,
+  `authenticate` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  `authenticate_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `token_update` text COLLATE utf8mb4_unicode_ci,
+  `token_update_at` timestamp NULL DEFAULT NULL,
+  `bootstrap_token_b64` text COLLATE utf8mb4_unicode_ci,
+  `bootstrap_token_at` timestamp NULL DEFAULT NULL,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `platform` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `enroll_team_id` int unsigned DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `serial_number` (`serial_number`),
+  KEY `fk_nano_devices_team_id` (`enroll_team_id`),
+  CONSTRAINT `fk_nano_devices_team_id` FOREIGN KEY (`enroll_team_id`) REFERENCES `teams` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `nano_devices_chk_1` CHECK (((`identity_cert` is null) or (substr(`identity_cert`,1,27) = _utf8mb4'-----BEGIN CERTIFICATE-----'))),
+  CONSTRAINT `nano_devices_chk_2` CHECK (((`serial_number` is null) or (`serial_number` <> _utf8mb4''))),
+  CONSTRAINT `nano_devices_chk_3` CHECK (((`unlock_token` is null) or (length(`unlock_token`) > 0))),
+  CONSTRAINT `nano_devices_chk_4` CHECK ((`authenticate` <> _utf8mb4'')),
+  CONSTRAINT `nano_devices_chk_5` CHECK (((`token_update` is null) or (`token_update` <> _utf8mb4''))),
+  CONSTRAINT `nano_devices_chk_6` CHECK (((`bootstrap_token_b64` is null) or (`bootstrap_token_b64` <> _utf8mb4'')))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `nano_enrollment_queue` (
+  `id` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `command_uuid` varchar(127) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `active` tinyint(1) NOT NULL DEFAULT '1',
+  `priority` tinyint NOT NULL DEFAULT '0',
+  `created_at` timestamp(6) NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` timestamp(6) NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`id`,`command_uuid`),
+  KEY `command_uuid` (`command_uuid`),
+  KEY `priority` (`priority` DESC,`created_at`),
+  CONSTRAINT `nano_enrollment_queue_ibfk_1` FOREIGN KEY (`id`) REFERENCES `nano_enrollments` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `nano_enrollment_queue_ibfk_2` FOREIGN KEY (`command_uuid`) REFERENCES `nano_commands` (`command_uuid`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `nano_enrollments` (
+  `id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `device_id` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `user_id` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `type` varchar(31) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `topic` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `push_magic` varchar(127) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `token_hex` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `enabled` tinyint(1) NOT NULL DEFAULT '1',
+  `token_update_tally` int NOT NULL DEFAULT '1',
+  `last_seen_at` timestamp NOT NULL,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `enrolled_from_migration` tinyint unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `user_id` (`user_id`),
+  KEY `device_id` (`device_id`),
+  KEY `type` (`type`),
+  CONSTRAINT `nano_enrollments_ibfk_1` FOREIGN KEY (`device_id`) REFERENCES `nano_devices` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `nano_enrollments_ibfk_2` FOREIGN KEY (`user_id`) REFERENCES `nano_users` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `nano_enrollments_chk_1` CHECK ((`id` <> _utf8mb4'')),
+  CONSTRAINT `nano_enrollments_chk_2` CHECK ((`type` <> _utf8mb4'')),
+  CONSTRAINT `nano_enrollments_chk_3` CHECK ((`topic` <> _utf8mb4'')),
+  CONSTRAINT `nano_enrollments_chk_4` CHECK ((`push_magic` <> _utf8mb4'')),
+  CONSTRAINT `nano_enrollments_chk_5` CHECK ((`token_hex` <> _utf8mb4''))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `nano_push_certs` (
+  `topic` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `cert_pem` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  `key_pem` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  `stale_token` int NOT NULL,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`topic`),
+  CONSTRAINT `nano_push_certs_chk_1` CHECK ((`topic` <> _utf8mb4'')),
+  CONSTRAINT `nano_push_certs_chk_2` CHECK ((substr(`cert_pem`,1,27) = _utf8mb4'-----BEGIN CERTIFICATE-----')),
+  CONSTRAINT `nano_push_certs_chk_3` CHECK ((substr(`key_pem`,1,5) = _utf8mb4'-----'))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `nano_users` (
+  `id` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `device_id` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `user_short_name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `user_long_name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `token_update` text COLLATE utf8mb4_unicode_ci,
+  `token_update_at` timestamp NULL DEFAULT NULL,
+  `user_authenticate` text COLLATE utf8mb4_unicode_ci,
+  `user_authenticate_at` timestamp NULL DEFAULT NULL,
+  `user_authenticate_digest` text COLLATE utf8mb4_unicode_ci,
+  `user_authenticate_digest_at` timestamp NULL DEFAULT NULL,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`,`device_id`),
+  UNIQUE KEY `idx_unique_id` (`id`),
+  KEY `device_id` (`device_id`),
+  CONSTRAINT `nano_users_ibfk_1` FOREIGN KEY (`device_id`) REFERENCES `nano_devices` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `nano_users_chk_1` CHECK (((`user_short_name` is null) or (`user_short_name` <> _utf8mb4''))),
+  CONSTRAINT `nano_users_chk_2` CHECK (((`user_long_name` is null) or (`user_long_name` <> _utf8mb4''))),
+  CONSTRAINT `nano_users_chk_3` CHECK (((`token_update` is null) or (`token_update` <> _utf8mb4''))),
+  CONSTRAINT `nano_users_chk_4` CHECK (((`user_authenticate` is null) or (`user_authenticate` <> _utf8mb4''))),
+  CONSTRAINT `nano_users_chk_5` CHECK (((`user_authenticate_digest` is null) or (`user_authenticate_digest` <> _utf8mb4'')))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+SET @saved_cs_client     = @@character_set_client;
+/*!50503 SET character_set_client = utf8mb4 */;
+/*!50001 CREATE VIEW `nano_view_queue` AS SELECT 
+ 1 AS `id`,
+ 1 AS `created_at`,
+ 1 AS `active`,
+ 1 AS `priority`,
+ 1 AS `command_uuid`,
+ 1 AS `request_type`,
+ 1 AS `command`,
+ 1 AS `result_updated_at`,
+ 1 AS `status`,
+ 1 AS `result`*/;
+SET character_set_client = @saved_cs_client;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `network_interfaces` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `host_id` int unsigned NOT NULL,
+  `mac` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `ip_address` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `broadcast` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `ibytes` bigint NOT NULL DEFAULT '0',
+  `interface` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `ipackets` bigint NOT NULL DEFAULT '0',
+  `last_change` bigint NOT NULL DEFAULT '0',
+  `mask` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `metric` int NOT NULL DEFAULT '0',
+  `mtu` int NOT NULL DEFAULT '0',
+  `obytes` bigint NOT NULL DEFAULT '0',
+  `ierrors` bigint NOT NULL DEFAULT '0',
+  `oerrors` bigint NOT NULL DEFAULT '0',
+  `opackets` bigint NOT NULL DEFAULT '0',
+  `point_to_point` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `type` int NOT NULL DEFAULT '0',
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_network_interfaces_unique_ip_host_intf` (`ip_address`,`host_id`,`interface`),
+  KEY `idx_network_interfaces_hosts_fk` (`host_id`),
+  FULLTEXT KEY `ip_address_search` (`ip_address`),
+  CONSTRAINT `network_interfaces_ibfk_1` FOREIGN KEY (`host_id`) REFERENCES `hosts` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `operating_system_vulnerabilities` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `operating_system_id` int unsigned NOT NULL,
+  `cve` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `source` smallint DEFAULT '0',
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `resolved_in_version` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_os_vulnerabilities_unq_os_id_cve` (`operating_system_id`,`cve`),
+  KEY `idx_os_vulnerabilities_cve` (`cve`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `operating_systems` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `version` varchar(150) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `arch` varchar(150) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `kernel_version` varchar(150) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `platform` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `display_version` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `os_version_id` int unsigned DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_unique_os` (`name`,`version`,`arch`,`kernel_version`,`platform`,`display_version`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `osquery_options` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `override_type` int NOT NULL,
+  `override_identifier` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `options` json NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+INSERT INTO `osquery_options` VALUES (1,0,'','{\"options\": {\"logger_plugin\": \"tls\", \"pack_delimiter\": \"/\", \"logger_tls_period\": 10, \"distributed_plugin\": \"tls\", \"disable_distributed\": false, \"logger_tls_endpoint\": \"/api/v1/osquery/log\", \"distributed_interval\": 10, \"distributed_tls_max_attempts\": 3}, \"decorators\": {\"load\": [\"SELECT uuid AS host_uuid FROM system_info;\", \"SELECT hostname AS hostname FROM system_info;\"]}}');
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `pack_targets` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `pack_id` int unsigned DEFAULT NULL,
+  `type` int DEFAULT NULL,
+  `target_id` int unsigned NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `constraint_pack_target_unique` (`pack_id`,`target_id`,`type`),
+  CONSTRAINT `pack_targets_ibfk_1` FOREIGN KEY (`pack_id`) REFERENCES `packs` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `packs` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `disabled` tinyint(1) NOT NULL DEFAULT '0',
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `description` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `platform` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `pack_type` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_pack_unique_name` (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `password_reset_requests` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `expires_at` timestamp NOT NULL,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `user_id` int unsigned NOT NULL,
+  `token` varchar(1024) COLLATE utf8mb4_unicode_ci NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `policies` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `team_id` int unsigned DEFAULT NULL,
+  `resolution` text COLLATE utf8mb4_unicode_ci,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `query` mediumtext COLLATE utf8mb4_unicode_ci NOT NULL,
+  `description` mediumtext COLLATE utf8mb4_unicode_ci NOT NULL,
+  `author_id` int unsigned DEFAULT NULL,
+  `platforms` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `critical` tinyint(1) NOT NULL DEFAULT '0',
+  `checksum` binary(16) NOT NULL,
+  `calendar_events_enabled` tinyint unsigned NOT NULL DEFAULT '0',
+  `software_installer_id` int unsigned DEFAULT NULL,
+  `script_id` int unsigned DEFAULT NULL,
+  `vpp_apps_teams_id` int unsigned DEFAULT NULL,
+  `conditional_access_enabled` tinyint unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_policies_checksum` (`checksum`),
+  KEY `idx_policies_author_id` (`author_id`),
+  KEY `idx_policies_team_id` (`team_id`),
+  KEY `fk_policies_software_installer_id` (`software_installer_id`),
+  KEY `fk_policies_script_id` (`script_id`),
+  KEY `fk_policies_vpp_apps_team_id` (`vpp_apps_teams_id`),
+  CONSTRAINT `policies_ibfk_3` FOREIGN KEY (`software_installer_id`) REFERENCES `software_installers` (`id`),
+  CONSTRAINT `policies_ibfk_4` FOREIGN KEY (`script_id`) REFERENCES `scripts` (`id`),
+  CONSTRAINT `policies_ibfk_5` FOREIGN KEY (`vpp_apps_teams_id`) REFERENCES `vpp_apps_teams` (`id`),
+  CONSTRAINT `policies_queries_ibfk_1` FOREIGN KEY (`author_id`) REFERENCES `users` (`id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `policy_automation_iterations` (
+  `policy_id` int unsigned NOT NULL,
+  `iteration` int NOT NULL,
+  PRIMARY KEY (`policy_id`),
+  CONSTRAINT `policy_automation_iterations_ibfk_1` FOREIGN KEY (`policy_id`) REFERENCES `policies` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `policy_labels` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `policy_id` int unsigned NOT NULL,
+  `label_id` int unsigned NOT NULL,
+  `exclude` tinyint(1) NOT NULL DEFAULT '0',
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_policy_labels_policy_label` (`policy_id`,`label_id`),
+  KEY `policy_labels_label_id` (`label_id`),
+  CONSTRAINT `policy_labels_label_id` FOREIGN KEY (`label_id`) REFERENCES `labels` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `policy_labels_policy_id` FOREIGN KEY (`policy_id`) REFERENCES `policies` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `policy_membership` (
+  `policy_id` int unsigned NOT NULL,
+  `host_id` int unsigned NOT NULL,
+  `passes` tinyint(1) DEFAULT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `automation_iteration` int DEFAULT NULL,
+  PRIMARY KEY (`policy_id`,`host_id`),
+  KEY `idx_policy_membership_passes` (`passes`),
+  KEY `idx_policy_membership_host_id_passes` (`host_id`,`passes`),
+  CONSTRAINT `policy_membership_ibfk_1` FOREIGN KEY (`policy_id`) REFERENCES `policies` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `policy_stats` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `policy_id` int unsigned NOT NULL,
+  `inherited_team_id` int unsigned DEFAULT NULL,
+  `passing_host_count` mediumint unsigned NOT NULL DEFAULT '0',
+  `failing_host_count` mediumint unsigned NOT NULL DEFAULT '0',
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `inherited_team_id_char` char(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci GENERATED ALWAYS AS (if((`inherited_team_id` is null),_utf8mb4'global',cast(`inherited_team_id` as char charset utf8mb4))) VIRTUAL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `policy_id` (`policy_id`,`inherited_team_id_char`),
+  CONSTRAINT `policy_stats_ibfk_1` FOREIGN KEY (`policy_id`) REFERENCES `policies` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `queries` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `saved` tinyint(1) NOT NULL DEFAULT '0',
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `description` mediumtext COLLATE utf8mb4_unicode_ci NOT NULL,
+  `query` mediumtext COLLATE utf8mb4_unicode_ci NOT NULL,
+  `author_id` int unsigned DEFAULT NULL,
+  `observer_can_run` tinyint(1) NOT NULL DEFAULT '0',
+  `team_id` int unsigned DEFAULT NULL,
+  `team_id_char` char(10) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `platform` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `min_osquery_version` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `schedule_interval` int unsigned NOT NULL DEFAULT '0',
+  `automations_enabled` tinyint unsigned NOT NULL DEFAULT '0',
+  `logging_type` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'snapshot',
+  `discard_data` tinyint(1) NOT NULL DEFAULT '1',
+  `is_scheduled` tinyint(1) GENERATED ALWAYS AS ((`schedule_interval` > 0)) STORED,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_team_id_name_unq` (`team_id_char`,`name`),
+  UNIQUE KEY `idx_name_team_id_unq` (`name`,`team_id_char`),
+  KEY `author_id` (`author_id`),
+  KEY `idx_team_id_saved_auto_interval` (`team_id`,`saved`,`automations_enabled`,`schedule_interval`),
+  KEY `idx_queries_schedule_automations` (`is_scheduled`,`automations_enabled`),
+  CONSTRAINT `queries_ibfk_1` FOREIGN KEY (`author_id`) REFERENCES `users` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `queries_ibfk_2` FOREIGN KEY (`team_id`) REFERENCES `teams` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `query_labels` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `query_id` int unsigned NOT NULL,
+  `label_id` int unsigned NOT NULL,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_query_labels_query_label` (`query_id`,`label_id`),
+  KEY `query_labels_label_id` (`label_id`),
+  CONSTRAINT `query_labels_label_id` FOREIGN KEY (`label_id`) REFERENCES `labels` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `query_labels_query_id` FOREIGN KEY (`query_id`) REFERENCES `queries` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `query_results` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `query_id` int unsigned NOT NULL,
+  `host_id` int unsigned NOT NULL,
+  `osquery_version` varchar(50) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `error` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `last_fetched` timestamp NOT NULL,
+  `data` json DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `idx_query_id_host_id_last_fetched` (`query_id`,`host_id`,`last_fetched`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `scep_certificates` (
+  `serial` bigint NOT NULL,
+  `name` varchar(1024) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `not_valid_before` datetime NOT NULL,
+  `not_valid_after` datetime NOT NULL,
+  `certificate_pem` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  `revoked` tinyint(1) NOT NULL DEFAULT '0',
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`serial`),
+  CONSTRAINT `scep_certificates_ibfk_1` FOREIGN KEY (`serial`) REFERENCES `scep_serials` (`serial`),
+  CONSTRAINT `scep_certificates_chk_1` CHECK ((substr(`certificate_pem`,1,27) = _utf8mb4'-----BEGIN CERTIFICATE-----')),
+  CONSTRAINT `scep_certificates_chk_2` CHECK (((`name` is null) or (`name` <> _utf8mb4'')))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `scep_serials` (
+  `serial` bigint NOT NULL AUTO_INCREMENT,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`serial`)
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `scheduled_queries` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `pack_id` int unsigned DEFAULT NULL,
+  `query_id` int unsigned DEFAULT NULL,
+  `interval` int unsigned DEFAULT NULL,
+  `snapshot` tinyint(1) DEFAULT NULL,
+  `removed` tinyint(1) DEFAULT NULL,
+  `platform` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT '',
+  `version` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT '',
+  `shard` int unsigned DEFAULT NULL,
+  `query_name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `description` varchar(1023) COLLATE utf8mb4_unicode_ci DEFAULT '',
+  `denylist` tinyint(1) DEFAULT NULL,
+  `team_id_char` char(10) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `unique_names_in_packs` (`name`,`pack_id`),
+  KEY `scheduled_queries_pack_id` (`pack_id`),
+  KEY `scheduled_queries_query_name` (`query_name`),
+  KEY `fk_scheduled_queries_queries` (`team_id_char`,`query_name`),
+  CONSTRAINT `scheduled_queries_ibfk_1` FOREIGN KEY (`team_id_char`, `query_name`) REFERENCES `queries` (`team_id_char`, `name`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `scheduled_queries_pack_id` FOREIGN KEY (`pack_id`) REFERENCES `packs` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `scheduled_query_stats` (
+  `host_id` int unsigned NOT NULL,
+  `scheduled_query_id` int unsigned NOT NULL,
+  `average_memory` bigint unsigned NOT NULL,
+  `denylisted` tinyint(1) DEFAULT NULL,
+  `executions` bigint unsigned NOT NULL,
+  `schedule_interval` int DEFAULT NULL,
+  `last_executed` timestamp NULL DEFAULT NULL,
+  `output_size` bigint unsigned NOT NULL,
+  `system_time` bigint unsigned NOT NULL,
+  `user_time` bigint unsigned NOT NULL,
+  `wall_time` bigint unsigned NOT NULL,
+  `query_type` tinyint NOT NULL DEFAULT '0',
+  PRIMARY KEY (`host_id`,`scheduled_query_id`,`query_type`),
+  KEY `scheduled_query_id` (`scheduled_query_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `scim_groups` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `external_id` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `display_name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_scim_groups_display_name` (`display_name`),
+  KEY `idx_scim_groups_external_id` (`external_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `scim_last_request` (
+  `id` tinyint unsigned NOT NULL DEFAULT '1',
+  `status` varchar(31) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `details` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `scim_user_emails` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `scim_user_id` int unsigned NOT NULL,
+  `email` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `primary` tinyint(1) DEFAULT NULL,
+  `type` varchar(31) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`id`),
+  KEY `idx_scim_user_emails_email_type` (`type`,`email`),
+  KEY `fk_scim_user_emails_scim_user_id` (`scim_user_id`),
+  CONSTRAINT `fk_scim_user_emails_scim_user_id` FOREIGN KEY (`scim_user_id`) REFERENCES `scim_users` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `scim_user_group` (
+  `scim_user_id` int unsigned NOT NULL,
+  `group_id` int unsigned NOT NULL,
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`scim_user_id`,`group_id`),
+  KEY `fk_scim_user_group_group_id` (`group_id`),
+  CONSTRAINT `fk_scim_user_group_group_id` FOREIGN KEY (`group_id`) REFERENCES `scim_groups` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_scim_user_group_scim_user_id` FOREIGN KEY (`scim_user_id`) REFERENCES `scim_users` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `scim_users` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `external_id` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `user_name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `given_name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `family_name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `active` tinyint(1) DEFAULT NULL,
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  `department` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_scim_users_user_name` (`user_name`),
+  KEY `idx_scim_users_external_id` (`external_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `script_contents` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `md5_checksum` binary(16) NOT NULL,
+  `contents` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_script_contents_md5_checksum` (`md5_checksum`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `script_upcoming_activities` (
+  `upcoming_activity_id` bigint unsigned NOT NULL,
+  `script_id` int unsigned DEFAULT NULL,
+  `script_content_id` int unsigned DEFAULT NULL,
+  `policy_id` int unsigned DEFAULT NULL,
+  `setup_experience_script_id` int unsigned DEFAULT NULL,
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`upcoming_activity_id`),
+  KEY `fk_script_upcoming_activities_script_id` (`script_id`),
+  KEY `fk_script_upcoming_activities_script_content_id` (`script_content_id`),
+  KEY `fk_script_upcoming_activities_policy_id` (`policy_id`),
+  KEY `fk_script_upcoming_activities_setup_experience_script_id` (`setup_experience_script_id`),
+  CONSTRAINT `fk_script_upcoming_activities_policy_id` FOREIGN KEY (`policy_id`) REFERENCES `policies` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `fk_script_upcoming_activities_script_content_id` FOREIGN KEY (`script_content_id`) REFERENCES `script_contents` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_script_upcoming_activities_script_id` FOREIGN KEY (`script_id`) REFERENCES `scripts` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `fk_script_upcoming_activities_setup_experience_script_id` FOREIGN KEY (`setup_experience_script_id`) REFERENCES `setup_experience_scripts` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `fk_script_upcoming_activities_upcoming_activity_id` FOREIGN KEY (`upcoming_activity_id`) REFERENCES `upcoming_activities` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `scripts` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `team_id` int unsigned DEFAULT NULL,
+  `global_or_team_id` int unsigned NOT NULL DEFAULT '0',
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `script_content_id` int unsigned DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_scripts_global_or_team_id_name` (`global_or_team_id`,`name`),
+  UNIQUE KEY `idx_scripts_team_name` (`team_id`,`name`),
+  KEY `script_content_id` (`script_content_id`),
+  CONSTRAINT `scripts_ibfk_1` FOREIGN KEY (`team_id`) REFERENCES `teams` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `scripts_ibfk_2` FOREIGN KEY (`script_content_id`) REFERENCES `script_contents` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `secret_variables` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `value` blob NOT NULL,
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_secret_variables_name` (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `sessions` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `accessed_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `user_id` int unsigned NOT NULL,
+  `key` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_session_unique_key` (`key`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `setup_experience_scripts` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `team_id` int unsigned DEFAULT NULL,
+  `global_or_team_id` int unsigned NOT NULL DEFAULT '0',
+  `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `script_content_id` int unsigned DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_setup_experience_scripts_global_or_team_id` (`global_or_team_id`),
+  KEY `idx_script_content_id` (`script_content_id`),
+  KEY `fk_setup_experience_scripts_ibfk_1` (`team_id`),
+  CONSTRAINT `fk_setup_experience_scripts_ibfk_1` FOREIGN KEY (`team_id`) REFERENCES `teams` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `fk_setup_experience_scripts_ibfk_2` FOREIGN KEY (`script_content_id`) REFERENCES `script_contents` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `setup_experience_status_results` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `host_uuid` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `status` enum('pending','running','success','failure','cancelled') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `software_installer_id` int unsigned DEFAULT NULL,
+  `host_software_installs_execution_id` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `vpp_app_team_id` int unsigned DEFAULT NULL,
+  `nano_command_uuid` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `setup_experience_script_id` int unsigned DEFAULT NULL,
+  `script_execution_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `error` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `idx_setup_experience_scripts_host_uuid` (`host_uuid`),
+  KEY `idx_setup_experience_scripts_hsi_id` (`host_software_installs_execution_id`),
+  KEY `idx_setup_experience_scripts_nano_command_uuid` (`nano_command_uuid`),
+  KEY `idx_setup_experience_scripts_script_execution_id` (`script_execution_id`),
+  KEY `fk_setup_experience_status_results_si_id` (`software_installer_id`),
+  KEY `fk_setup_experience_status_results_va_id` (`vpp_app_team_id`),
+  KEY `fk_setup_experience_status_results_ses_id` (`setup_experience_script_id`),
+  CONSTRAINT `fk_setup_experience_status_results_ses_id` FOREIGN KEY (`setup_experience_script_id`) REFERENCES `setup_experience_scripts` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_setup_experience_status_results_si_id` FOREIGN KEY (`software_installer_id`) REFERENCES `software_installers` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_setup_experience_status_results_va_id` FOREIGN KEY (`vpp_app_team_id`) REFERENCES `vpp_apps_teams` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `software` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `version` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `source` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `bundle_identifier` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT '',
+  `release` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `vendor_old` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `arch` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `vendor` varchar(114) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `extension_for` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `extension_id` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `title_id` int unsigned DEFAULT NULL,
+  `checksum` binary(16) NOT NULL,
+  `name_source` enum('basic','bundle_4.67') COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'basic',
+  `application_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_software_checksum` (`checksum`),
+  KEY `software_source_vendor_idx` (`source`,`vendor_old`),
+  KEY `title_id` (`title_id`),
+  KEY `idx_sw_name_source_browser` (`name`,`source`,`extension_for`),
+  KEY `software_listing_idx` (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `software_categories` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(63) COLLATE utf8mb4_unicode_ci NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_software_categories_name` (`name`)
+) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+INSERT INTO `software_categories` VALUES (2,'Browsers'),(3,'Communication'),(4,'Developer tools'),(1,'Productivity');
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `software_cpe` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `software_id` bigint unsigned DEFAULT NULL,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `cpe` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `unq_software_id` (`software_id`),
+  KEY `software_cpe_cpe_idx` (`cpe`),
+  CONSTRAINT `software_cpe_ibfk_1` FOREIGN KEY (`software_id`) REFERENCES `software` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `software_cve` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `cve` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `source` int DEFAULT '0',
+  `software_id` bigint unsigned DEFAULT NULL,
+  `resolved_in_version` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `unq_software_id_cve` (`software_id`,`cve`),
+  KEY `idx_software_cve_cve` (`cve`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `software_host_counts` (
+  `software_id` bigint unsigned NOT NULL,
+  `hosts_count` int unsigned NOT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `team_id` int unsigned NOT NULL DEFAULT '0',
+  `global_stats` tinyint unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`software_id`,`team_id`,`global_stats`),
+  KEY `idx_software_host_counts_updated_at_software_id` (`updated_at`,`software_id`),
+  KEY `idx_software_host_counts_team_id_hosts_count_software_id` (`team_id`,`hosts_count`,`software_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `software_install_upcoming_activities` (
+  `upcoming_activity_id` bigint unsigned NOT NULL,
+  `software_installer_id` int unsigned DEFAULT NULL,
+  `policy_id` int unsigned DEFAULT NULL,
+  `software_title_id` int unsigned DEFAULT NULL,
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`upcoming_activity_id`),
+  KEY `fk_software_install_upcoming_activities_software_installer_id` (`software_installer_id`),
+  KEY `fk_software_install_upcoming_activities_policy_id` (`policy_id`),
+  KEY `fk_software_install_upcoming_activities_software_title_id` (`software_title_id`),
+  CONSTRAINT `fk_software_install_upcoming_activities_policy_id` FOREIGN KEY (`policy_id`) REFERENCES `policies` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `fk_software_install_upcoming_activities_software_installer_id` FOREIGN KEY (`software_installer_id`) REFERENCES `software_installers` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
+  CONSTRAINT `fk_software_install_upcoming_activities_software_title_id` FOREIGN KEY (`software_title_id`) REFERENCES `software_titles` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
+  CONSTRAINT `fk_software_install_upcoming_activities_upcoming_activity_id` FOREIGN KEY (`upcoming_activity_id`) REFERENCES `upcoming_activities` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `software_installer_labels` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `software_installer_id` int unsigned NOT NULL,
+  `label_id` int unsigned NOT NULL,
+  `exclude` tinyint(1) NOT NULL DEFAULT '0',
+  `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_software_installer_labels_software_installer_id_label_id` (`software_installer_id`,`label_id`),
+  KEY `label_id` (`label_id`),
+  CONSTRAINT `software_installer_labels_ibfk_1` FOREIGN KEY (`software_installer_id`) REFERENCES `software_installers` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `software_installer_labels_ibfk_2` FOREIGN KEY (`label_id`) REFERENCES `labels` (`id`) ON DELETE RESTRICT
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `software_installer_software_categories` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `software_category_id` int unsigned NOT NULL,
+  `software_installer_id` int unsigned NOT NULL,
+  `created_at` datetime(6) DEFAULT CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_unique_software_installer_id_software_category_id` (`software_installer_id`,`software_category_id`),
+  KEY `software_category_id` (`software_category_id`),
+  CONSTRAINT `software_installer_software_categories_ibfk_1` FOREIGN KEY (`software_installer_id`) REFERENCES `software_installers` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `software_installer_software_categories_ibfk_2` FOREIGN KEY (`software_category_id`) REFERENCES `software_categories` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `software_installers` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `team_id` int unsigned DEFAULT NULL,
+  `global_or_team_id` int unsigned NOT NULL DEFAULT '0',
+  `title_id` int unsigned DEFAULT NULL,
+  `filename` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `version` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `platform` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `pre_install_query` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `install_script_content_id` int unsigned NOT NULL,
+  `post_install_script_content_id` int unsigned DEFAULT NULL,
+  `storage_id` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `uploaded_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `self_service` tinyint(1) NOT NULL DEFAULT '0',
+  `user_id` int unsigned DEFAULT NULL,
+  `user_name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `user_email` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `url` varchar(4095) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `package_ids` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `extension` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `uninstall_script_content_id` int unsigned NOT NULL,
+  `updated_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  `fleet_maintained_app_id` int unsigned DEFAULT NULL,
+  `install_during_setup` tinyint(1) NOT NULL DEFAULT '0',
+  `upgrade_code` varchar(48) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_software_installers_team_id_title_id` (`global_or_team_id`,`title_id`),
+  KEY `fk_software_installers_title` (`title_id`),
+  KEY `fk_software_installers_install_script_content_id` (`install_script_content_id`),
+  KEY `fk_software_installers_post_install_script_content_id` (`post_install_script_content_id`),
+  KEY `fk_software_installers_team_id` (`team_id`),
+  KEY `idx_software_installers_platform_title_id` (`platform`,`title_id`),
+  KEY `fk_software_installers_user_id` (`user_id`),
+  KEY `fk_uninstall_script_content_id` (`uninstall_script_content_id`),
+  KEY `fk_software_installers_fleet_library_app_id` (`fleet_maintained_app_id`),
+  CONSTRAINT `fk_software_installers_install_script_content_id` FOREIGN KEY (`install_script_content_id`) REFERENCES `script_contents` (`id`) ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT `fk_software_installers_post_install_script_content_id` FOREIGN KEY (`post_install_script_content_id`) REFERENCES `script_contents` (`id`) ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT `fk_software_installers_team_id` FOREIGN KEY (`team_id`) REFERENCES `teams` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `fk_software_installers_title` FOREIGN KEY (`title_id`) REFERENCES `software_titles` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
+  CONSTRAINT `fk_software_installers_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `fk_uninstall_script_content_id` FOREIGN KEY (`uninstall_script_content_id`) REFERENCES `script_contents` (`id`) ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT `software_installers_ibfk_1` FOREIGN KEY (`fleet_maintained_app_id`) REFERENCES `fleet_maintained_apps` (`id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `software_title_icons` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `team_id` int unsigned NOT NULL,
+  `software_title_id` int unsigned NOT NULL,
+  `storage_id` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `filename` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_unique_team_id_title_id_storage_id` (`team_id`,`software_title_id`),
+  KEY `idx_storage_id_team_id` (`storage_id`,`team_id`),
+  KEY `software_title_id` (`software_title_id`),
+  CONSTRAINT `software_title_icons_ibfk_1` FOREIGN KEY (`software_title_id`) REFERENCES `software_titles` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `software_titles` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `source` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `extension_for` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `bundle_identifier` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `additional_identifier` tinyint unsigned GENERATED ALWAYS AS ((case when (`source` = _utf8mb4'ios_apps') then 1 when (`source` = _utf8mb4'ipados_apps') then 2 when (`bundle_identifier` is not null) then 0 else NULL end)) VIRTUAL,
+  `is_kernel` tinyint(1) NOT NULL DEFAULT '0',
+  `application_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `unique_identifier` varchar(255) COLLATE utf8mb4_unicode_ci GENERATED ALWAYS AS (coalesce(`bundle_identifier`,`application_id`,`name`)) VIRTUAL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_software_titles_bundle_identifier` (`bundle_identifier`,`additional_identifier`),
+  UNIQUE KEY `idx_unique_sw_titles` (`unique_identifier`,`source`,`extension_for`),
+  KEY `idx_sw_titles` (`name`,`source`,`extension_for`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `software_titles_host_counts` (
+  `software_title_id` int unsigned NOT NULL,
+  `hosts_count` int unsigned NOT NULL,
+  `team_id` int unsigned NOT NULL DEFAULT '0',
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `global_stats` tinyint unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`software_title_id`,`team_id`,`global_stats`),
+  KEY `idx_software_titles_host_counts_team_counts_title` (`team_id`,`hosts_count`,`software_title_id`),
+  KEY `idx_software_titles_host_counts_updated_at_software_title_id` (`updated_at`,`software_title_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `statistics` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `anonymous_identifier` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `teams` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `description` varchar(1023) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `config` json DEFAULT NULL,
+  `name_bin` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin GENERATED ALWAYS AS (`name`) VIRTUAL,
+  `filename` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_teams_filename` (`filename`),
+  UNIQUE KEY `idx_name_bin` (`name_bin`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `upcoming_activities` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `host_id` int unsigned NOT NULL,
+  `priority` int NOT NULL DEFAULT '0',
+  `user_id` int unsigned DEFAULT NULL,
+  `fleet_initiated` tinyint(1) NOT NULL DEFAULT '0',
+  `activity_type` enum('script','software_install','software_uninstall','vpp_app_install','in_house_app_install') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `execution_id` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `payload` json NOT NULL,
+  `activated_at` datetime(6) DEFAULT NULL,
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_upcoming_activities_execution_id` (`execution_id`),
+  KEY `idx_upcoming_activities_host_id_priority_created_at` (`host_id`,`priority`,`created_at`),
+  KEY `idx_upcoming_activities_host_id_activity_type` (`activity_type`,`host_id`),
+  KEY `fk_upcoming_activities_user_id` (`user_id`),
+  CONSTRAINT `fk_upcoming_activities_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `user_teams` (
+  `user_id` int unsigned NOT NULL,
+  `team_id` int unsigned NOT NULL,
+  `role` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL,
+  PRIMARY KEY (`user_id`,`team_id`),
+  KEY `fk_user_teams_team_id` (`team_id`),
+  CONSTRAINT `user_teams_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `user_teams_ibfk_2` FOREIGN KEY (`team_id`) REFERENCES `teams` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `users` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `password` varbinary(255) NOT NULL,
+  `salt` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `email` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `admin_forced_password_reset` tinyint(1) NOT NULL DEFAULT '0',
+  `gravatar_url` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `position` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `sso_enabled` tinyint NOT NULL DEFAULT '0',
+  `global_role` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `api_only` tinyint(1) NOT NULL DEFAULT '0',
+  `mfa_enabled` tinyint(1) NOT NULL DEFAULT '0',
+  `settings` json NOT NULL DEFAULT (json_object()),
+  `invite_id` int unsigned DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_user_unique_email` (`email`),
+  UNIQUE KEY `invite_id` (`invite_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `users_deleted` (
+  `id` int unsigned NOT NULL,
+  `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `email` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` datetime(6) DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` datetime(6) DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `verification_tokens` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `user_id` int unsigned NOT NULL,
+  `token` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `token` (`token`),
+  KEY `verification_tokens_users` (`user_id`),
+  CONSTRAINT `verification_tokens_users` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `vpp_app_team_labels` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `vpp_app_team_id` int unsigned NOT NULL,
+  `label_id` int unsigned NOT NULL,
+  `exclude` tinyint(1) NOT NULL DEFAULT '0',
+  `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_vpp_app_team_labels_vpp_app_team_id_label_id` (`vpp_app_team_id`,`label_id`),
+  KEY `label_id` (`label_id`),
+  CONSTRAINT `vpp_app_team_labels_ibfk_1` FOREIGN KEY (`vpp_app_team_id`) REFERENCES `vpp_apps_teams` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `vpp_app_team_labels_ibfk_2` FOREIGN KEY (`label_id`) REFERENCES `labels` (`id`) ON DELETE RESTRICT
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `vpp_app_team_software_categories` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `software_category_id` int unsigned NOT NULL,
+  `vpp_app_team_id` int unsigned NOT NULL,
+  `created_at` datetime(6) DEFAULT CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_unique_vpp_app_team_id_software_category_id` (`vpp_app_team_id`,`software_category_id`),
+  KEY `software_category_id` (`software_category_id`),
+  CONSTRAINT `vpp_app_team_software_categories_ibfk_1` FOREIGN KEY (`vpp_app_team_id`) REFERENCES `vpp_apps_teams` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `vpp_app_team_software_categories_ibfk_2` FOREIGN KEY (`software_category_id`) REFERENCES `software_categories` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `vpp_app_upcoming_activities` (
+  `upcoming_activity_id` bigint unsigned NOT NULL,
+  `adam_id` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `platform` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `vpp_token_id` int unsigned DEFAULT NULL,
+  `policy_id` int unsigned DEFAULT NULL,
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`upcoming_activity_id`),
+  KEY `fk_vpp_app_upcoming_activities_adam_id_platform` (`adam_id`,`platform`),
+  KEY `fk_vpp_app_upcoming_activities_vpp_token_id` (`vpp_token_id`),
+  KEY `fk_vpp_app_upcoming_activities_policy_id` (`policy_id`),
+  CONSTRAINT `fk_vpp_app_upcoming_activities_adam_id_platform` FOREIGN KEY (`adam_id`, `platform`) REFERENCES `vpp_apps` (`adam_id`, `platform`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vpp_app_upcoming_activities_policy_id` FOREIGN KEY (`policy_id`) REFERENCES `policies` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `fk_vpp_app_upcoming_activities_upcoming_activity_id` FOREIGN KEY (`upcoming_activity_id`) REFERENCES `upcoming_activities` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vpp_app_upcoming_activities_vpp_token_id` FOREIGN KEY (`vpp_token_id`) REFERENCES `vpp_tokens` (`id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `vpp_apps` (
+  `adam_id` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `title_id` int unsigned DEFAULT NULL,
+  `bundle_identifier` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `icon_url` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `latest_version` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `platform` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  PRIMARY KEY (`adam_id`,`platform`),
+  KEY `fk_vpp_apps_title` (`title_id`),
+  CONSTRAINT `fk_vpp_apps_title` FOREIGN KEY (`title_id`) REFERENCES `software_titles` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `vpp_apps_teams` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `adam_id` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `team_id` int unsigned DEFAULT NULL,
+  `global_or_team_id` int NOT NULL DEFAULT '0',
+  `platform` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `self_service` tinyint(1) NOT NULL DEFAULT '0',
+  `vpp_token_id` int unsigned NOT NULL,
+  `install_during_setup` tinyint(1) NOT NULL DEFAULT '0',
+  `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_global_or_team_id_adam_id` (`global_or_team_id`,`adam_id`,`platform`),
+  KEY `team_id` (`team_id`),
+  KEY `adam_id` (`adam_id`,`platform`),
+  KEY `fk_vpp_apps_teams_vpp_token_id` (`vpp_token_id`),
+  CONSTRAINT `fk_vpp_apps_teams_vpp_token_id` FOREIGN KEY (`vpp_token_id`) REFERENCES `vpp_tokens` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `vpp_apps_teams_ibfk_2` FOREIGN KEY (`team_id`) REFERENCES `teams` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `vpp_apps_teams_ibfk_3` FOREIGN KEY (`adam_id`, `platform`) REFERENCES `vpp_apps` (`adam_id`, `platform`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `vpp_token_teams` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `vpp_token_id` int unsigned NOT NULL,
+  `team_id` int unsigned DEFAULT NULL,
+  `null_team_type` enum('none','allteams','noteam') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT 'none',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_vpp_token_teams_team_id` (`team_id`),
+  KEY `fk_vpp_token_teams_vpp_token_id` (`vpp_token_id`),
+  CONSTRAINT `fk_vpp_token_teams_team_id` FOREIGN KEY (`team_id`) REFERENCES `teams` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_vpp_token_teams_vpp_token_id` FOREIGN KEY (`vpp_token_id`) REFERENCES `vpp_tokens` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `vpp_tokens` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `organization_name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `location` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `renew_at` timestamp NOT NULL,
+  `token` blob NOT NULL,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_vpp_tokens_location` (`location`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `vulnerability_host_counts` (
+  `cve` varchar(20) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `team_id` int unsigned NOT NULL DEFAULT '0',
+  `host_count` int unsigned NOT NULL DEFAULT '0',
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `global_stats` tinyint(1) NOT NULL DEFAULT '0',
+  UNIQUE KEY `cve_team_id_global_stats` (`cve`,`team_id`,`global_stats`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `windows_mdm_command_queue` (
+  `enrollment_id` int unsigned NOT NULL,
+  `command_uuid` varchar(127) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`enrollment_id`,`command_uuid`),
+  KEY `command_uuid` (`command_uuid`),
+  CONSTRAINT `windows_mdm_command_queue_ibfk_1` FOREIGN KEY (`enrollment_id`) REFERENCES `mdm_windows_enrollments` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `windows_mdm_command_queue_ibfk_2` FOREIGN KEY (`command_uuid`) REFERENCES `windows_mdm_commands` (`command_uuid`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `windows_mdm_command_results` (
+  `enrollment_id` int unsigned NOT NULL,
+  `command_uuid` varchar(127) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `raw_result` mediumtext COLLATE utf8mb4_unicode_ci NOT NULL,
+  `response_id` int unsigned NOT NULL,
+  `status_code` varchar(31) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`enrollment_id`,`command_uuid`),
+  KEY `command_uuid` (`command_uuid`),
+  KEY `response_id` (`response_id`),
+  CONSTRAINT `windows_mdm_command_results_ibfk_1` FOREIGN KEY (`enrollment_id`) REFERENCES `mdm_windows_enrollments` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `windows_mdm_command_results_ibfk_2` FOREIGN KEY (`command_uuid`) REFERENCES `windows_mdm_commands` (`command_uuid`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `windows_mdm_command_results_ibfk_3` FOREIGN KEY (`response_id`) REFERENCES `windows_mdm_responses` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `windows_mdm_commands` (
+  `command_uuid` varchar(127) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `raw_command` mediumtext COLLATE utf8mb4_unicode_ci NOT NULL,
+  `target_loc_uri` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`command_uuid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `windows_mdm_responses` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `enrollment_id` int unsigned NOT NULL,
+  `raw_response` mediumtext COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `enrollment_id` (`enrollment_id`),
+  CONSTRAINT `windows_mdm_responses_ibfk_1` FOREIGN KEY (`enrollment_id`) REFERENCES `mdm_windows_enrollments` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `windows_updates` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `host_id` int unsigned NOT NULL,
+  `date_epoch` int unsigned NOT NULL,
+  `kb_id` int unsigned NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_unique_windows_updates` (`host_id`,`kb_id`),
+  KEY `idx_update_date` (`host_id`,`date_epoch`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `wstep_cert_auth_associations` (
+  `id` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `sha256` char(64) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`,`sha256`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `wstep_certificates` (
+  `serial` bigint unsigned NOT NULL,
+  `name` varchar(1024) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `not_valid_before` datetime NOT NULL,
+  `not_valid_after` datetime NOT NULL,
+  `certificate_pem` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  `revoked` tinyint(1) NOT NULL DEFAULT '0',
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`serial`),
+  CONSTRAINT `wstep_certificates_ibfk_1` FOREIGN KEY (`serial`) REFERENCES `wstep_serials` (`serial`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `wstep_serials` (
+  `serial` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`serial`)
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `yara_rules` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `contents` mediumtext COLLATE utf8mb4_unicode_ci NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_yara_rules_name` (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!50001 DROP VIEW IF EXISTS `nano_view_queue`*/;
+/*!50001 SET @saved_cs_client          = @@character_set_client */;
+/*!50001 SET @saved_cs_results         = @@character_set_results */;
+/*!50001 SET @saved_col_connection     = @@collation_connection */;
+/*!50001 SET character_set_client      = utf8mb4 */;
+/*!50001 SET character_set_results     = utf8mb4 */;
+/*!50001 SET collation_connection      = utf8mb4_unicode_ci */;
+/*!50001 CREATE ALGORITHM=UNDEFINED */
+/*!50013 DEFINER=`root`@`%` SQL SECURITY INVOKER */
+/*!50001 VIEW `nano_view_queue` AS select (`q`.`id` collate utf8mb4_unicode_ci) AS `id`,`q`.`created_at` AS `created_at`,`q`.`active` AS `active`,`q`.`priority` AS `priority`,(`c`.`command_uuid` collate utf8mb4_unicode_ci) AS `command_uuid`,(`c`.`request_type` collate utf8mb4_unicode_ci) AS `request_type`,(`c`.`command` collate utf8mb4_unicode_ci) AS `command`,`r`.`updated_at` AS `result_updated_at`,(`r`.`status` collate utf8mb4_unicode_ci) AS `status`,(`r`.`result` collate utf8mb4_unicode_ci) AS `result` from ((`nano_enrollment_queue` `q` join `nano_commands` `c` on((`q`.`command_uuid` = `c`.`command_uuid`))) left join `nano_command_results` `r` on(((`r`.`command_uuid` = `q`.`command_uuid`) and (`r`.`id` = `q`.`id`)))) order by `q`.`priority` desc,`q`.`created_at` */;
+/*!50001 SET character_set_client      = @saved_cs_client */;
+/*!50001 SET character_set_results     = @saved_cs_results */;
+/*!50001 SET collation_connection      = @saved_col_connection */;
+
+SET FOREIGN_KEY_CHECKS=1;

--- a/server/datastore/mysql/schema-mariadb.sql
+++ b/server/datastore/mysql/schema-mariadb.sql
@@ -15,19 +15,113 @@ CREATE TABLE `abm_tokens` (
   `ipados_default_team_id` int unsigned DEFAULT NULL,
   `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `byod_default_team_id` int unsigned DEFAULT NULL,
+  `enrollment_url_token` varbinary(64) NOT NULL,
+  `token_invalid` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_abm_tokens_organization_name` (`organization_name`),
+  UNIQUE KEY `idx_abm_tokens_enrollment_url_token` (`enrollment_url_token`),
   KEY `fk_abm_tokens_macos_default_team_id` (`macos_default_team_id`),
   KEY `fk_abm_tokens_ios_default_team_id` (`ios_default_team_id`),
   KEY `fk_abm_tokens_ipados_default_team_id` (`ipados_default_team_id`),
+  KEY `abm_tokens_byod_team_fk` (`byod_default_team_id`),
+  CONSTRAINT `abm_tokens_byod_team_fk` FOREIGN KEY (`byod_default_team_id`) REFERENCES `teams` (`id`) ON DELETE SET NULL,
   CONSTRAINT `fk_abm_tokens_ios_default_team_id` FOREIGN KEY (`ios_default_team_id`) REFERENCES `teams` (`id`) ON DELETE SET NULL,
   CONSTRAINT `fk_abm_tokens_ipados_default_team_id` FOREIGN KEY (`ipados_default_team_id`) REFERENCES `teams` (`id`) ON DELETE SET NULL,
-  CONSTRAINT `fk_abm_tokens_macos_default_team_id` FOREIGN KEY (`macos_default_team_id`) REFERENCES `teams` (`id`) ON DELETE SET NULL
+  CONSTRAINT `fk_abm_tokens_macos_default_team_id` FOREIGN KEY (`macos_default_team_id`) REFERENCES `teams` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `abm_tokens_enroll_url_length` CHECK ((length(`enrollment_url_token`) > 32))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
-CREATE TABLE `activities` (
+CREATE TABLE `acme_accounts` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `acme_enrollment_id` int unsigned NOT NULL,
+  `json_web_key` json NOT NULL,
+  `json_web_key_thumbprint` varchar(45) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `revoked` tinyint(1) NOT NULL DEFAULT '0',
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_enrollment_id_thumbprint` (`acme_enrollment_id`,`json_web_key_thumbprint`),
+  CONSTRAINT `acme_accounts_ibfk_1` FOREIGN KEY (`acme_enrollment_id`) REFERENCES `acme_enrollments` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `acme_authorizations` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `identifier_type` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `identifier_value` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `acme_order_id` int unsigned NOT NULL,
+  `status` enum('pending','valid','invalid','deactivated','expired','revoked') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'pending',
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `acme_order_id` (`acme_order_id`),
+  CONSTRAINT `acme_authorizations_ibfk_1` FOREIGN KEY (`acme_order_id`) REFERENCES `acme_orders` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `acme_challenges` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `challenge_type` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `token` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `acme_authorization_id` int unsigned NOT NULL,
+  `status` enum('pending','valid','invalid','processing') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'pending',
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `acme_authorization_id` (`acme_authorization_id`),
+  CONSTRAINT `acme_challenges_ibfk_1` FOREIGN KEY (`acme_authorization_id`) REFERENCES `acme_authorizations` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `acme_enrollments` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `path_identifier` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `host_identifier` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `not_valid_after` datetime DEFAULT NULL,
+  `revoked` tinyint(1) NOT NULL DEFAULT '0',
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_path_identifier` (`path_identifier`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `acme_orders` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `acme_account_id` int unsigned NOT NULL,
+  `finalized` tinyint(1) NOT NULL DEFAULT '0',
+  `certificate_signing_request` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `identifiers` json NOT NULL,
+  `status` enum('pending','ready','processing','valid','invalid') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'pending',
+  `issued_certificate_serial` bigint DEFAULT NULL,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_issued_certificate_serial` (`issued_certificate_serial`),
+  KEY `acme_account_id` (`acme_account_id`),
+  CONSTRAINT `acme_orders_ibfk_1` FOREIGN KEY (`acme_account_id`) REFERENCES `acme_accounts` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `activity_host_past` (
+  `host_id` int unsigned NOT NULL,
+  `activity_id` int unsigned NOT NULL,
+  PRIMARY KEY (`host_id`,`activity_id`),
+  KEY `fk_host_activities_activity_id` (`activity_id`),
+  CONSTRAINT `activity_host_past_ibfk_1` FOREIGN KEY (`activity_id`) REFERENCES `activity_past` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `activity_past` (
   `id` int unsigned NOT NULL AUTO_INCREMENT,
   `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
   `user_id` int unsigned DEFAULT NULL,
@@ -42,7 +136,11 @@ CREATE TABLE `activities` (
   KEY `fk_activities_user_id` (`user_id`),
   KEY `activities_streamed_idx` (`streamed`),
   KEY `activities_created_at_idx` (`created_at`),
-  CONSTRAINT `activities_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL
+  KEY `idx_activities_user_name` (`user_name`),
+  KEY `idx_activities_user_email` (`user_email`),
+  KEY `idx_activities_activity_type` (`activity_type`),
+  KEY `idx_activities_type_created` (`activity_type`,`created_at`),
+  CONSTRAINT `activity_past_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -61,6 +159,22 @@ CREATE TABLE `aggregated_stats` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `android_app_configurations` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `application_id` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `team_id` int unsigned DEFAULT NULL,
+  `global_or_team_id` int NOT NULL DEFAULT '0',
+  `configuration` json NOT NULL,
+  `created_at` timestamp(6) NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` timestamp(6) NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_global_or_team_id_application_id` (`global_or_team_id`,`application_id`),
+  KEY `team_id` (`team_id`),
+  CONSTRAINT `android_app_configurations_ibfk_1` FOREIGN KEY (`team_id`) REFERENCES `teams` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `android_devices` (
   `id` int unsigned NOT NULL AUTO_INCREMENT,
   `host_id` int unsigned NOT NULL,
@@ -71,10 +185,15 @@ CREATE TABLE `android_devices` (
   `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
   `applied_policy_id` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `applied_policy_version` int DEFAULT NULL,
+  `team_id` int unsigned DEFAULT NULL,
+  `last_pubsub_message_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `last_pubsub_event_time` timestamp(6) NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_android_devices_host_id` (`host_id`),
   UNIQUE KEY `idx_android_devices_device_id` (`device_id`),
-  UNIQUE KEY `idx_android_devices_enterprise_specific_id` (`enterprise_specific_id`)
+  UNIQUE KEY `idx_android_devices_enterprise_specific_id` (`enterprise_specific_id`),
+  KEY `fk_android_devices_team_id` (`team_id`),
+  CONSTRAINT `fk_android_devices_team_id` FOREIGN KEY (`team_id`) REFERENCES `teams` (`id`) ON DELETE SET NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -117,7 +236,24 @@ CREATE TABLE `app_config_json` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
-INSERT INTO `app_config_json` VALUES (1,'{\"mdm\": {\"ios_updates\": {\"deadline\": null, \"minimum_version\": null}, \"macos_setup\": {\"script\": null, \"software\": null, \"bootstrap_package\": null, \"manual_agent_install\": null, \"macos_setup_assistant\": null, \"require_all_software_macos\": false, \"enable_end_user_authentication\": false, \"enable_release_device_manually\": false}, \"macos_updates\": {\"deadline\": null, \"minimum_version\": null}, \"ipados_updates\": {\"deadline\": null, \"minimum_version\": null}, \"macos_settings\": {\"custom_settings\": null}, \"macos_migration\": {\"mode\": \"\", \"enable\": false, \"webhook_url\": \"\"}, \"windows_updates\": {\"deadline_days\": null, \"grace_period_days\": null}, \"android_settings\": {\"custom_settings\": null}, \"apple_server_url\": \"\", \"windows_settings\": {\"custom_settings\": null}, \"apple_bm_terms_expired\": false, \"apple_business_manager\": null, \"enable_disk_encryption\": false, \"enabled_and_configured\": false, \"end_user_authentication\": {\"idp_name\": \"\", \"metadata\": \"\", \"entity_id\": \"\", \"issuer_uri\": \"\", \"metadata_url\": \"\"}, \"volume_purchasing_program\": null, \"windows_migration_enabled\": false, \"windows_require_bitlocker_pin\": null, \"android_enabled_and_configured\": false, \"windows_enabled_and_configured\": false, \"apple_bm_enabled_and_configured\": false}, \"gitops\": {\"repository_url\": \"\", \"gitops_mode_enabled\": false}, \"scripts\": null, \"features\": {\"enable_host_users\": true, \"enable_software_inventory\": false}, \"org_info\": {\"org_name\": \"\", \"contact_url\": \"\", \"org_logo_url\": \"\", \"org_logo_url_light_background\": \"\"}, \"integrations\": {\"jira\": null, \"zendesk\": null, \"google_calendar\": null, \"conditional_access_enabled\": null}, \"sso_settings\": {\"idp_name\": \"\", \"metadata\": \"\", \"entity_id\": \"\", \"enable_sso\": false, \"issuer_uri\": \"\", \"metadata_url\": \"\", \"idp_image_url\": \"\", \"sso_server_url\": \"\", \"enable_jit_role_sync\": false, \"enable_sso_idp_login\": false, \"enable_jit_provisioning\": false}, \"agent_options\": {\"config\": {\"options\": {\"logger_plugin\": \"tls\", \"pack_delimiter\": \"/\", \"logger_tls_period\": 10, \"distributed_plugin\": \"tls\", \"disable_distributed\": false, \"logger_tls_endpoint\": \"/api/osquery/log\", \"distributed_interval\": 10, \"distributed_tls_max_attempts\": 3}, \"decorators\": {\"load\": [\"SELECT uuid AS host_uuid FROM system_info;\", \"SELECT hostname AS hostname FROM system_info;\"]}}, \"overrides\": {}}, \"fleet_desktop\": {\"transparency_url\": \"\"}, \"smtp_settings\": {\"port\": 587, \"domain\": \"\", \"server\": \"\", \"password\": \"\", \"user_name\": \"\", \"configured\": false, \"enable_smtp\": false, \"enable_ssl_tls\": true, \"sender_address\": \"\", \"enable_start_tls\": true, \"verify_ssl_certs\": true, \"authentication_type\": \"0\", \"authentication_method\": \"0\"}, \"server_settings\": {\"server_url\": \"\", \"enable_analytics\": false, \"query_report_cap\": 0, \"scripts_disabled\": false, \"deferred_save_host\": false, \"live_query_disabled\": false, \"ai_features_disabled\": false, \"query_reports_disabled\": false}, \"webhook_settings\": {\"interval\": \"0s\", \"activities_webhook\": {\"destination_url\": \"\", \"enable_activities_webhook\": false}, \"host_status_webhook\": {\"days_count\": 0, \"destination_url\": \"\", \"host_percentage\": 0, \"enable_host_status_webhook\": false}, \"vulnerabilities_webhook\": {\"destination_url\": \"\", \"host_batch_size\": 0, \"enable_vulnerabilities_webhook\": false}, \"failing_policies_webhook\": {\"policy_ids\": null, \"destination_url\": \"\", \"host_batch_size\": 0, \"enable_failing_policies_webhook\": false}}, \"host_expiry_settings\": {\"host_expiry_window\": 0, \"host_expiry_enabled\": false}, \"vulnerability_settings\": {\"databases_path\": \"\"}, \"activity_expiry_settings\": {\"activity_expiry_window\": 0, \"activity_expiry_enabled\": false}}','2020-01-01 01:01:01','2020-01-01 01:01:01');
+INSERT INTO `app_config_json` VALUES (1,'{\"mdm\": {\"ios_updates\": {\"deadline\": null, \"deadline_days\": null, \"minimum_version\": null, \"update_new_hosts\": null}, \"macos_setup\": {\"script\": null, \"software\": null, \"bootstrap_package\": null, \"lock_end_user_info\": false, \"manual_agent_install\": null, \"macos_setup_assistant\": null, \"require_all_software_macos\": false, \"end_user_local_account_type\": \"admin\", \"enable_managed_local_account\": false, \"require_all_software_windows\": false, \"enable_end_user_authentication\": false, \"enable_release_device_manually\": false}, \"macos_updates\": {\"deadline\": null, \"deadline_days\": null, \"minimum_version\": null, \"update_new_hosts\": false}, \"name_template\": null, \"ipados_updates\": {\"deadline\": null, \"deadline_days\": null, \"minimum_version\": null, \"update_new_hosts\": null}, \"macos_settings\": {\"custom_settings\": null}, \"macos_migration\": {\"mode\": \"\", \"enable\": false, \"webhook_url\": \"\"}, \"windows_updates\": {\"deadline_days\": null, \"grace_period_days\": null}, \"android_settings\": {\"certificates\": null, \"custom_settings\": null}, \"apple_server_url\": \"\", \"windows_settings\": {\"custom_settings\": null, \"managed_local_account_settings\": {\"enabled\": false}}, \"windows_enrollment\": null, \"apple_bm_terms_expired\": false, \"apple_business_manager\": null, \"enable_disk_encryption\": false, \"enabled_and_configured\": false, \"end_user_authentication\": {\"idp_name\": \"\", \"metadata\": \"\", \"entity_id\": \"\", \"issuer_uri\": \"\", \"metadata_url\": \"\"}, \"windows_entra_client_ids\": [], \"windows_entra_tenant_ids\": [], \"volume_purchasing_program\": null, \"windows_migration_enabled\": false, \"apple_account_provisioning\": {\"oauth_idp_client_id\": null, \"oauth_idp_token_url\": null, \"oauth_idp_client_secret\": null}, \"enable_recovery_lock_password\": false, \"windows_require_bitlocker_pin\": null, \"android_enabled_and_configured\": false, \"windows_enabled_and_configured\": false, \"apple_bm_enabled_and_configured\": false, \"apple_require_hardware_attestation\": false, \"enable_turn_on_windows_mdm_manually\": false}, \"gitops\": {\"exceptions\": {\"labels\": true, \"secrets\": true, \"software\": false}, \"repository_url\": \"\", \"gitops_mode_enabled\": false}, \"scripts\": null, \"features\": {\"historical_data\": {\"uptime\": true, \"vulnerabilities\": true}, \"enable_host_users\": true, \"enable_software_inventory\": false}, \"org_info\": {\"org_name\": \"\", \"contact_url\": \"\", \"org_logo_url\": \"\", \"org_logo_url_dark_mode\": \"\", \"org_logo_url_light_mode\": \"\", \"org_logo_url_light_background\": \"\"}, \"integrations\": {\"jira\": null, \"zendesk\": null, \"google_calendar\": null, \"conditional_access_enabled\": null}, \"sso_settings\": {\"idp_name\": \"\", \"metadata\": \"\", \"entity_id\": \"\", \"enable_sso\": false, \"issuer_uri\": \"\", \"metadata_url\": \"\", \"idp_image_url\": \"\", \"sso_server_url\": \"\", \"enable_jit_role_sync\": false, \"enable_sso_idp_login\": false, \"enable_jit_provisioning\": false}, \"agent_options\": {\"config\": {\"options\": {\"logger_plugin\": \"tls\", \"pack_delimiter\": \"/\", \"logger_tls_period\": 10, \"distributed_plugin\": \"tls\", \"disable_distributed\": false, \"logger_tls_endpoint\": \"/api/osquery/log\", \"distributed_interval\": 10, \"distributed_tls_max_attempts\": 3}, \"decorators\": {\"load\": [\"SELECT uuid AS host_uuid FROM system_info;\", \"SELECT hostname AS hostname FROM system_info;\"]}}, \"overrides\": {}}, \"fleet_desktop\": {\"transparency_url\": \"\", \"alternative_browser_host\": \"\"}, \"smtp_settings\": {\"port\": 587, \"domain\": \"\", \"server\": \"\", \"password\": \"\", \"user_name\": \"\", \"configured\": false, \"enable_smtp\": false, \"enable_ssl_tls\": true, \"sender_address\": \"\", \"enable_start_tls\": true, \"verify_ssl_certs\": true, \"authentication_type\": \"0\", \"authentication_method\": \"0\"}, \"server_settings\": {\"server_url\": \"\", \"enable_analytics\": false, \"query_report_cap\": 0, \"scripts_disabled\": false, \"deferred_save_host\": false, \"live_query_disabled\": false, \"ai_features_disabled\": false, \"query_reports_disabled\": false}, \"webhook_settings\": {\"interval\": \"0s\", \"activities_webhook\": {\"destination_url\": \"\", \"enable_activities_webhook\": false}, \"host_status_webhook\": {\"days_count\": 0, \"destination_url\": \"\", \"host_percentage\": 0, \"enable_host_status_webhook\": false}, \"vulnerabilities_webhook\": {\"destination_url\": \"\", \"host_batch_size\": 0, \"enable_vulnerabilities_webhook\": false}, \"failing_policies_webhook\": {\"policy_ids\": null, \"destination_url\": \"\", \"host_batch_size\": 0, \"enable_failing_policies_webhook\": false}}, \"host_expiry_settings\": {\"host_expiry_window\": 0, \"host_expiry_enabled\": false}, \"vulnerability_settings\": {\"databases_path\": \"\"}, \"activity_expiry_settings\": {\"activity_expiry_window\": 0, \"activity_expiry_enabled\": false, \"preserve_host_activities_on_reenrollment\": false}}','2020-01-01 01:01:01','2020-01-01 01:01:01');
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `apple_software_update_assets` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `class` enum('macos','ios') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `product_version` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `build` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `posting_date` date DEFAULT NULL,
+  `expiration_date` date DEFAULT NULL,
+  `supported_devices` json NOT NULL,
+  `first_seen_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_asset_class_version_build` (`class`,`product_version`,`build`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `batch_activities` (
@@ -230,7 +366,7 @@ CREATE TABLE `carve_metadata` (
 /*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `certificate_authorities` (
   `id` int NOT NULL AUTO_INCREMENT,
-  `type` enum('digicert','ndes_scep_proxy','custom_scep_proxy','hydrant','smallstep') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `type` enum('digicert','ndes_scep_proxy','custom_scep_proxy','hydrant','smallstep','custom_est_proxy') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `url` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `api_token_encrypted` blob,
@@ -253,12 +389,55 @@ CREATE TABLE `certificate_authorities` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `certificate_templates` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `team_id` int unsigned NOT NULL,
+  `certificate_authority_id` int NOT NULL,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `subject_name` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `subject_alternative_name` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_cert_team_name` (`team_id`,`name`),
+  KEY `certificate_authority_id` (`certificate_authority_id`),
+  CONSTRAINT `certificate_templates_ibfk_2` FOREIGN KEY (`certificate_authority_id`) REFERENCES `certificate_authorities` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `challenges` (
   `challenge` char(32) COLLATE utf8mb4_unicode_ci NOT NULL,
   `created_at` timestamp(6) NULL DEFAULT CURRENT_TIMESTAMP(6),
   `updated_at` timestamp(6) NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
   PRIMARY KEY (`challenge`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `conditional_access_scep_certificates` (
+  `serial` bigint unsigned NOT NULL,
+  `host_id` int unsigned NOT NULL,
+  `name` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `not_valid_before` datetime NOT NULL,
+  `not_valid_after` datetime NOT NULL,
+  `certificate_pem` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `revoked` tinyint(1) NOT NULL DEFAULT '0',
+  `created_at` datetime(6) DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` datetime(6) DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`serial`),
+  KEY `idx_conditional_access_host_id` (`host_id`),
+  CONSTRAINT `conditional_access_scep_certificates_ibfk_1` FOREIGN KEY (`serial`) REFERENCES `conditional_access_scep_serials` (`serial`),
+  CONSTRAINT `conditional_access_scep_certificates_chk_1` CHECK ((substr(`certificate_pem`,1,27) = _utf8mb4'-----BEGIN CERTIFICATE-----'))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `conditional_access_scep_serials` (
+  `serial` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `created_at` datetime(6) DEFAULT CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`serial`)
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
@@ -277,6 +456,17 @@ CREATE TABLE `cron_stats` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `custom_host_vitals` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_custom_host_vitals_name` (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `cve_meta` (
   `cve` varchar(20) COLLATE utf8mb4_unicode_ci NOT NULL,
   `cvss_score` double DEFAULT NULL,
@@ -284,7 +474,9 @@ CREATE TABLE `cve_meta` (
   `cisa_known_exploit` tinyint(1) DEFAULT NULL,
   `published` timestamp NULL DEFAULT NULL,
   `description` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  PRIMARY KEY (`cve`)
+  PRIMARY KEY (`cve`),
+  KEY `idx_cve_meta_exploit` (`cisa_known_exploit`,`cve`),
+  KEY `idx_cve_meta_cvss_score` (`cvss_score`,`cve`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -382,19 +574,9 @@ CREATE TABLE `fleet_variables` (
   `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_fleet_variables_name_is_prefix` (`name`,`is_prefix`)
-) ENGINE=InnoDB AUTO_INCREMENT=17 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=21 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
-INSERT INTO `fleet_variables` VALUES (1,'FLEET_VAR_NDES_SCEP_CHALLENGE',0,'2025-04-22 00:00:00.000000'),(2,'FLEET_VAR_NDES_SCEP_PROXY_URL',0,'2025-04-22 00:00:00.000000'),(3,'FLEET_VAR_HOST_END_USER_EMAIL_IDP',0,'2025-04-22 00:00:00.000000'),(4,'FLEET_VAR_HOST_HARDWARE_SERIAL',0,'2025-04-22 00:00:00.000000'),(5,'FLEET_VAR_HOST_END_USER_IDP_USERNAME',0,'2025-04-22 00:00:00.000000'),(6,'FLEET_VAR_HOST_END_USER_IDP_USERNAME_LOCAL_PART',0,'2025-04-22 00:00:00.000000'),(7,'FLEET_VAR_HOST_END_USER_IDP_GROUPS',0,'2025-04-22 00:00:00.000000'),(8,'FLEET_VAR_DIGICERT_DATA_',1,'2025-04-22 00:00:00.000000'),(9,'FLEET_VAR_DIGICERT_PASSWORD_',1,'2025-04-22 00:00:00.000000'),(10,'FLEET_VAR_CUSTOM_SCEP_CHALLENGE_',1,'2025-04-22 00:00:00.000000'),(11,'FLEET_VAR_CUSTOM_SCEP_PROXY_URL_',1,'2025-04-22 00:00:00.000000'),(12,'FLEET_VAR_SCEP_RENEWAL_ID',0,'2025-04-30 00:00:00.000000'),(13,'FLEET_VAR_HOST_END_USER_IDP_DEPARTMENT',0,'2025-06-27 00:00:00.000000'),(14,'FLEET_VAR_HOST_UUID',0,'2025-08-08 00:00:00.000000'),(15,'FLEET_VAR_HOST_END_USER_IDP_FULL_NAME',0,'2025-08-25 00:00:00.000000'),(16,'FLEET_VAR_SCEP_WINDOWS_CERTIFICATE_ID',0,'2025-10-22 00:00:00.000000');
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
-CREATE TABLE `host_activities` (
-  `host_id` int unsigned NOT NULL,
-  `activity_id` int unsigned NOT NULL,
-  PRIMARY KEY (`host_id`,`activity_id`),
-  KEY `fk_host_activities_activity_id` (`activity_id`),
-  CONSTRAINT `host_activities_ibfk_1` FOREIGN KEY (`activity_id`) REFERENCES `activities` (`id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-/*!40101 SET character_set_client = @saved_cs_client */;
+INSERT INTO `fleet_variables` VALUES (1,'FLEET_VAR_NDES_SCEP_CHALLENGE',0,'2025-04-22 00:00:00.000000'),(2,'FLEET_VAR_NDES_SCEP_PROXY_URL',0,'2025-04-22 00:00:00.000000'),(3,'FLEET_VAR_HOST_END_USER_EMAIL_IDP',0,'2025-04-22 00:00:00.000000'),(4,'FLEET_VAR_HOST_HARDWARE_SERIAL',0,'2025-04-22 00:00:00.000000'),(5,'FLEET_VAR_HOST_END_USER_IDP_USERNAME',0,'2025-04-22 00:00:00.000000'),(6,'FLEET_VAR_HOST_END_USER_IDP_USERNAME_LOCAL_PART',0,'2025-04-22 00:00:00.000000'),(7,'FLEET_VAR_HOST_END_USER_IDP_GROUPS',0,'2025-04-22 00:00:00.000000'),(8,'FLEET_VAR_DIGICERT_DATA_',1,'2025-04-22 00:00:00.000000'),(9,'FLEET_VAR_DIGICERT_PASSWORD_',1,'2025-04-22 00:00:00.000000'),(10,'FLEET_VAR_CUSTOM_SCEP_CHALLENGE_',1,'2025-04-22 00:00:00.000000'),(11,'FLEET_VAR_CUSTOM_SCEP_PROXY_URL_',1,'2025-04-22 00:00:00.000000'),(12,'FLEET_VAR_SCEP_RENEWAL_ID',0,'2025-04-30 00:00:00.000000'),(13,'FLEET_VAR_HOST_END_USER_IDP_DEPARTMENT',0,'2025-06-27 00:00:00.000000'),(14,'FLEET_VAR_HOST_UUID',0,'2025-08-08 00:00:00.000000'),(15,'FLEET_VAR_HOST_END_USER_IDP_FULL_NAME',0,'2025-08-25 00:00:00.000000'),(16,'FLEET_VAR_SCEP_WINDOWS_CERTIFICATE_ID',0,'2025-10-22 00:00:00.000000'),(17,'FLEET_VAR_HOST_PLATFORM',0,'2025-11-19 00:00:00.000000'),(18,'FLEET_VAR_PSSO_DEVICE_REGISTRATION_TOKEN',0,'2026-06-19 00:00:00.000000'),(19,'FLEET_VAR_HOST_TARGET_OS_VERSION',0,'2026-07-27 00:00:00.000000'),(20,'FLEET_VAR_HOST_TARGET_OS_DEADLINE',0,'2026-07-27 00:00:00.000000');
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `host_additional` (
@@ -447,6 +629,31 @@ CREATE TABLE `host_certificate_sources` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_certificate_templates` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `host_uuid` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `certificate_template_id` int unsigned NOT NULL,
+  `fleet_challenge` char(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `status` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'pending',
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `detail` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `operation_type` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'install',
+  `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `uuid` binary(16) DEFAULT NULL,
+  `not_valid_before` datetime DEFAULT NULL,
+  `not_valid_after` datetime DEFAULT NULL,
+  `serial` varchar(40) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `retry_count` int unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_host_certificate_templates_host_template` (`host_uuid`,`certificate_template_id`),
+  KEY `fk_host_certificate_templates_operation_type` (`operation_type`),
+  KEY `idx_host_certificate_templates_not_valid_after` (`not_valid_after`),
+  CONSTRAINT `fk_host_certificate_templates_operation_type` FOREIGN KEY (`operation_type`) REFERENCES `mdm_operation_types` (`operation_type`) ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `host_certificates` (
   `id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `host_id` int unsigned NOT NULL,
@@ -470,9 +677,38 @@ CREATE TABLE `host_certificates` (
   `sha1_sum` binary(20) NOT NULL,
   `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
   `deleted_at` datetime(6) DEFAULT NULL,
+  `origin` enum('osquery','mdm') COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'osquery',
   PRIMARY KEY (`id`),
   KEY `idx_host_certs_hid_cn` (`host_id`,`common_name`),
-  KEY `idx_host_certs_not_valid_after` (`host_id`,`not_valid_after`)
+  KEY `idx_host_certs_not_valid_after` (`host_id`,`not_valid_after`),
+  KEY `idx_host_certs_origin_deleted` (`origin`,`deleted_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_conditional_access` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `host_id` int unsigned NOT NULL,
+  `bypassed_at` timestamp NULL DEFAULT NULL,
+  `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_host_conditional_access_host_id` (`host_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_custom_host_vitals` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `host_id` int unsigned NOT NULL,
+  `custom_host_vital_id` int unsigned NOT NULL,
+  `value` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_host_custom_host_vitals_host_vital` (`host_id`,`custom_host_vital_id`),
+  KEY `fk_host_custom_host_vitals_custom_host_vital_id` (`custom_host_vital_id`),
+  CONSTRAINT `fk_host_custom_host_vitals_custom_host_vital_id` FOREIGN KEY (`custom_host_vital_id`) REFERENCES `custom_host_vitals` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -488,9 +724,11 @@ CREATE TABLE `host_dep_assignments` (
   `abm_token_id` int unsigned DEFAULT NULL,
   `mdm_migration_deadline` timestamp(6) NULL DEFAULT NULL,
   `mdm_migration_completed` timestamp(6) NULL DEFAULT NULL,
+  `hardware_serial` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   PRIMARY KEY (`host_id`),
   KEY `idx_hdep_response` (`assign_profile_response`,`response_updated_at`),
   KEY `fk_host_dep_assignments_abm_token_id` (`abm_token_id`),
+  KEY `idx_hdep_hardware_serial` (`hardware_serial`),
   CONSTRAINT `fk_host_dep_assignments_abm_token_id` FOREIGN KEY (`abm_token_id`) REFERENCES `abm_tokens` (`id`) ON DELETE SET NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
@@ -501,8 +739,10 @@ CREATE TABLE `host_device_auth` (
   `token` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `previous_token` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`host_id`),
-  UNIQUE KEY `idx_host_device_auth_token` (`token`)
+  UNIQUE KEY `idx_host_device_auth_token` (`token`),
+  KEY `idx_host_device_auth_previous_token` (`previous_token`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -547,6 +787,7 @@ CREATE TABLE `host_disks` (
   `gigs_total_disk_space` decimal(10,2) NOT NULL DEFAULT '0.00',
   `tpm_pin_set` tinyint(1) DEFAULT '0',
   `gigs_all_disk_space` decimal(10,2) DEFAULT NULL,
+  `bitlocker_protection_status` tinyint(1) DEFAULT NULL,
   PRIMARY KEY (`host_id`),
   KEY `idx_host_disks_gigs_disk_space_available` (`gigs_disk_space_available`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -618,6 +859,7 @@ CREATE TABLE `host_in_house_software_installs` (
   `verification_failed_at` datetime(6) DEFAULT NULL,
   `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
   `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  `self_service` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_host_in_house_software_installs_command_uuid` (`command_uuid`),
   KEY `fk_host_in_house_software_installs_user_id` (`user_id`),
@@ -641,6 +883,40 @@ CREATE TABLE `host_issues` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_last_known_locations` (
+  `host_id` int unsigned NOT NULL,
+  `latitude` decimal(10,8) DEFAULT NULL,
+  `longitude` decimal(11,8) DEFAULT NULL,
+  `created_at` timestamp(6) NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` timestamp(6) NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`host_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_managed_local_account_passwords` (
+  `host_uuid` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `encrypted_password` blob,
+  `command_uuid` varchar(127) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `status` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  `account_uuid` varchar(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `auto_rotate_at` timestamp(6) NULL DEFAULT NULL,
+  `pending_encrypted_password` blob,
+  `pending_command_uuid` varchar(127) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `initiated_by_fleet` tinyint(1) NOT NULL DEFAULT '0',
+  `client_error` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `deleted` tinyint(1) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`host_uuid`),
+  KEY `idx_hmlap_command_uuid` (`command_uuid`),
+  KEY `fk_hmlap_status` (`status`),
+  KEY `idx_hmlap_auto_rotate_at` (`auto_rotate_at`),
+  CONSTRAINT `fk_hmlap_status` FOREIGN KEY (`status`) REFERENCES `mdm_delivery_status` (`status`) ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `host_mdm` (
   `host_id` int unsigned NOT NULL,
   `enrolled` tinyint(1) NOT NULL DEFAULT '0',
@@ -649,10 +925,11 @@ CREATE TABLE `host_mdm` (
   `mdm_id` int unsigned DEFAULT NULL,
   `is_server` tinyint(1) DEFAULT NULL,
   `fleet_enroll_ref` varchar(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `enrollment_status` enum('On (manual)','On (automatic)','Pending','Off','On (personal)') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci GENERATED ALWAYS AS ((case when (`is_server` = 1) then NULL when ((`enrolled` = 1) and (`installed_from_dep` = 0) and (`is_personal_enrollment` = 1)) then _utf8mb4'On (personal)' when ((`enrolled` = 1) and (`installed_from_dep` = 0) and (`is_personal_enrollment` = 0)) then _utf8mb4'On (manual)' when ((`enrolled` = 1) and (`installed_from_dep` = 1) and (`is_personal_enrollment` = 0)) then _utf8mb4'On (automatic)' when ((`enrolled` = 0) and (`installed_from_dep` = 1)) then _utf8mb4'Pending' when ((`enrolled` = 0) and (`installed_from_dep` = 0)) then _utf8mb4'Off' else NULL end)) VIRTUAL,
+  `managed_apple_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
   `updated_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
   `is_personal_enrollment` tinyint(1) NOT NULL DEFAULT '0',
+  `enrollment_status` enum('On (manual)','On (automatic)','Pending','Off','On (manual - personal)') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci GENERATED ALWAYS AS ((case when (`is_server` = 1) then NULL when ((`enrolled` = 1) and (`installed_from_dep` = 0) and (`is_personal_enrollment` = 1)) then _utf8mb4'On (manual - personal)' when ((`enrolled` = 1) and (`installed_from_dep` = 0) and (`is_personal_enrollment` = 0)) then _utf8mb4'On (manual)' when ((`enrolled` = 1) and (`installed_from_dep` = 1) and (`is_personal_enrollment` = 0)) then _utf8mb4'On (automatic)' when ((`enrolled` = 0) and (`installed_from_dep` = 1)) then _utf8mb4'Pending' when ((`enrolled` = 0) and (`installed_from_dep` = 0)) then _utf8mb4'Off' else NULL end)) VIRTUAL,
   PRIMARY KEY (`host_id`),
   KEY `host_mdm_mdm_id_idx` (`mdm_id`),
   KEY `host_mdm_enrolled_installed_from_dep_is_personal_enrollment_idx` (`enrolled`,`installed_from_dep`,`is_personal_enrollment`)
@@ -667,6 +944,7 @@ CREATE TABLE `host_mdm_actions` (
   `unlock_pin` varchar(6) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `unlock_ref` varchar(36) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `fleet_platform` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `clear_passcode_ref` varchar(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`host_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
@@ -685,6 +963,8 @@ CREATE TABLE `host_mdm_android_profiles` (
   `included_in_policy_version` int DEFAULT NULL,
   `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
   `updated_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  `can_reverify` tinyint(1) NOT NULL DEFAULT '0',
+  `checksum` binary(16) NOT NULL DEFAULT '0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0',
   PRIMARY KEY (`host_uuid`,`profile_uuid`),
   KEY `status` (`status`),
   KEY `operation_type` (`operation_type`),
@@ -708,10 +988,12 @@ CREATE TABLE `host_mdm_apple_awaiting_configuration` (
 /*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `host_mdm_apple_bootstrap_packages` (
   `host_uuid` varchar(127) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `command_uuid` varchar(127) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `command_uuid` varchar(127) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `skipped` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`host_uuid`),
   KEY `command_uuid` (`command_uuid`),
-  CONSTRAINT `host_mdm_apple_bootstrap_packages_ibfk_1` FOREIGN KEY (`command_uuid`) REFERENCES `nano_commands` (`command_uuid`) ON DELETE CASCADE
+  CONSTRAINT `host_mdm_apple_bootstrap_packages_ibfk_1` FOREIGN KEY (`command_uuid`) REFERENCES `nano_commands` (`command_uuid`) ON DELETE CASCADE,
+  CONSTRAINT `ck_skipped_or_commanduuid` CHECK (((`skipped` = 0) = (`command_uuid` is not null)))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -728,12 +1010,90 @@ CREATE TABLE `host_mdm_apple_declarations` (
   `secrets_updated_at` datetime(6) DEFAULT NULL,
   `resync` tinyint(1) NOT NULL DEFAULT '0',
   `scope` enum('System','User') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'System',
+  `variables_updated_at` datetime(6) DEFAULT NULL,
+  `assets_updated_at` datetime(6) DEFAULT NULL,
+  `activation_updated_at` datetime(6) DEFAULT NULL,
   PRIMARY KEY (`host_uuid`,`declaration_uuid`),
   KEY `status` (`status`),
   KEY `operation_type` (`operation_type`),
   KEY `idx_token` (`token`),
   CONSTRAINT `host_mdm_apple_declarations_ibfk_1` FOREIGN KEY (`status`) REFERENCES `mdm_delivery_status` (`status`) ON UPDATE CASCADE,
   CONSTRAINT `host_mdm_apple_declarations_ibfk_2` FOREIGN KEY (`operation_type`) REFERENCES `mdm_operation_types` (`operation_type`) ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_mdm_apple_device_names` (
+  `host_uuid` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `status` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `command_uuid` varchar(127) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `expected_device_name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `detail` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`host_uuid`),
+  KEY `idx_host_mdm_apple_device_names_status` (`status`),
+  KEY `idx_host_mdm_apple_device_names_command_uuid` (`command_uuid`),
+  CONSTRAINT `host_mdm_apple_device_names_status` FOREIGN KEY (`status`) REFERENCES `mdm_delivery_status` (`status`) ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_mdm_apple_device_vitals` (
+  `host_uuid` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `udid` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `model_number` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `modem_firmware_version` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `supplemental_build_version` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `supplemental_os_version_extra` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `bluetooth_mac` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `wifi_mac` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `eas_device_identifier` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `itunes_store_account_hash` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `push_token` blob,
+  `battery_level` double DEFAULT NULL,
+  `cellular_technology` int DEFAULT NULL,
+  `app_analytics_enabled` tinyint(1) DEFAULT NULL,
+  `awaiting_configuration` tinyint(1) DEFAULT NULL,
+  `data_roaming_enabled` tinyint(1) DEFAULT NULL,
+  `diagnostic_submission_enabled` tinyint(1) DEFAULT NULL,
+  `is_cloud_backup_enabled` tinyint(1) DEFAULT NULL,
+  `is_device_locator_service_enabled` tinyint(1) DEFAULT NULL,
+  `is_do_not_disturb_in_effect` tinyint(1) DEFAULT NULL,
+  `is_mdm_lost_mode_enabled` tinyint(1) DEFAULT NULL,
+  `is_network_tethered` tinyint(1) DEFAULT NULL,
+  `itunes_store_account_is_active` tinyint(1) DEFAULT NULL,
+  `personal_hotspot_enabled` tinyint(1) DEFAULT NULL,
+  `last_cloud_backup_date` datetime(6) DEFAULT NULL,
+  `accessibility_settings` json DEFAULT NULL,
+  `organization_info` json DEFAULT NULL,
+  `mdm_options` json DEFAULT NULL,
+  `device_properties_attestation` json DEFAULT NULL,
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`host_uuid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_mdm_apple_enrollment_permissions` (
+  `host_uuid` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `access_rights` int NOT NULL DEFAULT '8191',
+  `delivered_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`host_uuid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_mdm_apple_os_updates` (
+  `host_uuid` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `software_update_device_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `target_os_version` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `target_deadline` datetime(6) DEFAULT NULL,
+  `resolved_at` datetime(6) DEFAULT NULL,
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`host_uuid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -755,11 +1115,37 @@ CREATE TABLE `host_mdm_apple_profiles` (
   `ignore_error` tinyint(1) NOT NULL DEFAULT '0',
   `variables_updated_at` datetime(6) DEFAULT NULL,
   `scope` enum('System','User') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'System',
+  `has_acme_payload` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`host_uuid`,`profile_uuid`),
   KEY `status` (`status`),
   KEY `operation_type` (`operation_type`),
   CONSTRAINT `host_mdm_apple_profiles_ibfk_1` FOREIGN KEY (`status`) REFERENCES `mdm_delivery_status` (`status`) ON UPDATE CASCADE,
   CONSTRAINT `host_mdm_apple_profiles_ibfk_2` FOREIGN KEY (`operation_type`) REFERENCES `mdm_operation_types` (`operation_type`) ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_mdm_apple_service_subscriptions` (
+  `host_uuid` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `slot` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `carrier_settings_version` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `current_carrier_network` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `current_mcc` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `current_mnc` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `eid` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `iccid` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `imei` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `is_data_preferred` tinyint(1) DEFAULT NULL,
+  `is_roaming` tinyint(1) DEFAULT NULL,
+  `is_voice_preferred` tinyint(1) DEFAULT NULL,
+  `label` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `label_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `meid` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `phone_number` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `subscriber_carrier_network` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`host_uuid`,`slot`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -789,7 +1175,7 @@ CREATE TABLE `host_mdm_idp_accounts` (
 CREATE TABLE `host_mdm_managed_certificates` (
   `host_uuid` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `profile_uuid` varchar(37) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `type` enum('digicert','custom_scep_proxy','ndes','smallstep') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'ndes',
+  `type` enum('digicert','custom_scep_proxy','ndes','smallstep') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `ca_name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'NDES',
   `challenge_retrieved_at` timestamp(6) NULL DEFAULT NULL,
   `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
@@ -818,8 +1204,19 @@ CREATE TABLE `host_mdm_windows_profiles` (
   PRIMARY KEY (`host_uuid`,`profile_uuid`),
   KEY `status` (`status`),
   KEY `operation_type` (`operation_type`),
+  KEY `idx_host_mdm_windows_profiles_profile_uuid_checksum` (`profile_uuid`,`checksum`),
   CONSTRAINT `host_mdm_windows_profiles_ibfk_1` FOREIGN KEY (`status`) REFERENCES `mdm_delivery_status` (`status`) ON UPDATE CASCADE,
   CONSTRAINT `host_mdm_windows_profiles_ibfk_2` FOREIGN KEY (`operation_type`) REFERENCES `mdm_operation_types` (`operation_type`) ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_mdm_windows_profiles_status` (
+  `host_uuid` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `status` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`host_uuid`),
+  KEY `idx_host_mdm_windows_profiles_status_status` (`status`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -863,6 +1260,47 @@ CREATE TABLE `host_orbit_info` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_recovery_key_passwords` (
+  `host_uuid` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `encrypted_password` blob NOT NULL,
+  `status` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `operation_type` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `error_message` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `deleted` tinyint(1) NOT NULL DEFAULT '0',
+  `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  `pending_encrypted_password` blob,
+  `pending_error_message` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `auto_rotate_at` timestamp(6) NULL DEFAULT NULL,
+  PRIMARY KEY (`host_uuid`),
+  KEY `status` (`status`),
+  KEY `operation_type` (`operation_type`),
+  KEY `deleted` (`deleted`),
+  KEY `idx_auto_rotate_at` (`auto_rotate_at`),
+  CONSTRAINT `host_recovery_key_passwords_ibfk_1` FOREIGN KEY (`status`) REFERENCES `mdm_delivery_status` (`status`) ON UPDATE CASCADE,
+  CONSTRAINT `host_recovery_key_passwords_ibfk_2` FOREIGN KEY (`operation_type`) REFERENCES `mdm_operation_types` (`operation_type`) ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `host_scd_data` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `dataset` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `entity_id` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `host_bitmap` mediumblob NOT NULL,
+  `valid_from` datetime NOT NULL,
+  `valid_to` datetime NOT NULL DEFAULT '9999-12-31 00:00:00',
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `encoding_type` tinyint NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uniq_entity_bucket` (`dataset`,`entity_id`,`valid_from`),
+  KEY `idx_dataset_range` (`dataset`,`valid_from`,`valid_to`),
+  KEY `idx_valid_to_dataset` (`valid_to`,`dataset`,`entity_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `host_scim_user` (
   `host_id` int unsigned NOT NULL,
   `scim_user_id` int unsigned NOT NULL,
@@ -893,6 +1331,7 @@ CREATE TABLE `host_script_results` (
   `setup_experience_script_id` int unsigned DEFAULT NULL,
   `is_internal` tinyint(1) DEFAULT '0',
   `canceled` tinyint(1) NOT NULL DEFAULT '0',
+  `attempt_number` int DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_host_script_results_execution_id` (`execution_id`),
   KEY `idx_host_script_results_host_exit_created` (`host_id`,`exit_code`,`created_at`),
@@ -902,6 +1341,7 @@ CREATE TABLE `host_script_results` (
   KEY `fk_script_result_policy_id` (`policy_id`),
   KEY `fk_host_script_results_setup_experience_id` (`setup_experience_script_id`),
   KEY `idx_host_script_canceled_created_at` (`host_id`,`script_id`,`canceled`,`created_at` DESC),
+  KEY `idx_host_script_results_host_policy` (`host_id`,`policy_id`),
   CONSTRAINT `fk_host_script_results_script_id` FOREIGN KEY (`script_id`) REFERENCES `scripts` (`id`) ON DELETE SET NULL,
   CONSTRAINT `fk_host_script_results_setup_experience_id` FOREIGN KEY (`setup_experience_script_id`) REFERENCES `setup_experience_scripts` (`id`) ON DELETE SET NULL,
   CONSTRAINT `fk_host_script_results_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL,
@@ -925,7 +1365,7 @@ CREATE TABLE `host_software` (
   `software_id` bigint unsigned NOT NULL,
   `last_opened_at` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`host_id`,`software_id`),
-  KEY `host_software_software_fk` (`software_id`)
+  KEY `idx_host_software_software_id` (`software_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -936,7 +1376,9 @@ CREATE TABLE `host_software_installed_paths` (
   `software_id` bigint unsigned NOT NULL,
   `installed_path` text COLLATE utf8mb4_unicode_ci NOT NULL,
   `team_identifier` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `cdhash_sha256` char(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `executable_sha256` char(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `executable_path` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   PRIMARY KEY (`id`),
   KEY `host_id_software_id_idx` (`host_id`,`software_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -962,14 +1404,15 @@ CREATE TABLE `host_software_installs` (
   `uninstall_script_output` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `uninstall_script_exit_code` int DEFAULT NULL,
   `uninstall` tinyint unsigned NOT NULL DEFAULT '0',
-  `status` enum('pending_install','failed_install','installed','pending_uninstall','failed_uninstall','canceled_install','canceled_uninstall') COLLATE utf8mb4_unicode_ci GENERATED ALWAYS AS ((case when (`removed` = 1) then NULL when ((`canceled` = 1) and (`uninstall` = 0)) then _utf8mb4'canceled_install' when ((`canceled` = 1) and (`uninstall` = 1)) then _utf8mb4'canceled_uninstall' when ((`post_install_script_exit_code` is not null) and (`post_install_script_exit_code` = 0)) then _utf8mb4'installed' when ((`post_install_script_exit_code` is not null) and (`post_install_script_exit_code` <> 0)) then _utf8mb4'failed_install' when ((`install_script_exit_code` is not null) and (`install_script_exit_code` = 0)) then _utf8mb4'installed' when ((`install_script_exit_code` is not null) and (`install_script_exit_code` <> 0)) then _utf8mb4'failed_install' when ((`pre_install_query_output` is not null) and (`pre_install_query_output` = _utf8mb4'')) then _utf8mb4'failed_install' when ((`host_id` is not null) and (`uninstall` = 0)) then _utf8mb4'pending_install' when ((`uninstall_script_exit_code` is not null) and (`uninstall_script_exit_code` <> 0)) then _utf8mb4'failed_uninstall' when ((`uninstall_script_exit_code` is not null) and (`uninstall_script_exit_code` = 0)) then NULL when ((`host_id` is not null) and (`uninstall` = 1)) then _utf8mb4'pending_uninstall' else NULL end)) STORED,
   `policy_id` int unsigned DEFAULT NULL,
   `installer_filename` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '[deleted installer]',
   `version` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'unknown',
   `software_title_id` int unsigned DEFAULT NULL,
   `software_title_name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '[deleted title]',
-  `execution_status` enum('pending_install','failed_install','installed','pending_uninstall','failed_uninstall','canceled_install','canceled_uninstall') COLLATE utf8mb4_unicode_ci GENERATED ALWAYS AS ((case when ((`canceled` = 1) and (`uninstall` = 0)) then _utf8mb4'canceled_install' when ((`canceled` = 1) and (`uninstall` = 1)) then _utf8mb4'canceled_uninstall' when ((`post_install_script_exit_code` is not null) and (`post_install_script_exit_code` = 0)) then _utf8mb4'installed' when ((`post_install_script_exit_code` is not null) and (`post_install_script_exit_code` <> 0)) then _utf8mb4'failed_install' when ((`install_script_exit_code` is not null) and (`install_script_exit_code` = 0)) then _utf8mb4'installed' when ((`install_script_exit_code` is not null) and (`install_script_exit_code` <> 0)) then _utf8mb4'failed_install' when ((`pre_install_query_output` is not null) and (`pre_install_query_output` = _utf8mb4'')) then _utf8mb4'failed_install' when ((`host_id` is not null) and (`uninstall` = 0)) then _utf8mb4'pending_install' when ((`uninstall_script_exit_code` is not null) and (`uninstall_script_exit_code` <> 0)) then _utf8mb4'failed_uninstall' when ((`uninstall_script_exit_code` is not null) and (`uninstall_script_exit_code` = 0)) then NULL when ((`host_id` is not null) and (`uninstall` = 1)) then _utf8mb4'pending_uninstall' else NULL end)) VIRTUAL,
   `canceled` tinyint(1) NOT NULL DEFAULT '0',
+  `execution_status` enum('pending_install','failed_install','installed','pending_uninstall','failed_uninstall','canceled_install','canceled_uninstall') COLLATE utf8mb4_unicode_ci GENERATED ALWAYS AS ((case when ((`canceled` = 1) and (`uninstall` = 0)) then _utf8mb4'canceled_install' when ((`canceled` = 1) and (`uninstall` = 1)) then _utf8mb4'canceled_uninstall' when ((`install_script_exit_code` is not null) and (`install_script_exit_code` <> 0)) then _utf8mb4'failed_install' when ((`post_install_script_exit_code` is not null) and (`post_install_script_exit_code` = 0)) then _utf8mb4'installed' when ((`post_install_script_exit_code` is not null) and (`post_install_script_exit_code` <> 0)) then _utf8mb4'failed_install' when ((`install_script_exit_code` is not null) and (`install_script_exit_code` = 0)) then _utf8mb4'installed' when ((`pre_install_query_output` is not null) and (`pre_install_query_output` = _utf8mb4'')) then _utf8mb4'failed_install' when ((`host_id` is not null) and (`uninstall` = 0)) then _utf8mb4'pending_install' when ((`uninstall_script_exit_code` is not null) and (`uninstall_script_exit_code` <> 0)) then _utf8mb4'failed_uninstall' when ((`uninstall_script_exit_code` is not null) and (`uninstall_script_exit_code` = 0)) then NULL when ((`host_id` is not null) and (`uninstall` = 1)) then _utf8mb4'pending_uninstall' else NULL end)) VIRTUAL,
+  `status` enum('pending_install','failed_install','installed','pending_uninstall','failed_uninstall','canceled_install','canceled_uninstall') COLLATE utf8mb4_unicode_ci GENERATED ALWAYS AS ((case when (`removed` = 1) then NULL when ((`canceled` = 1) and (`uninstall` = 0)) then _utf8mb4'canceled_install' when ((`canceled` = 1) and (`uninstall` = 1)) then _utf8mb4'canceled_uninstall' when ((`install_script_exit_code` is not null) and (`install_script_exit_code` <> 0)) then _utf8mb4'failed_install' when ((`post_install_script_exit_code` is not null) and (`post_install_script_exit_code` = 0)) then _utf8mb4'installed' when ((`post_install_script_exit_code` is not null) and (`post_install_script_exit_code` <> 0)) then _utf8mb4'failed_install' when ((`install_script_exit_code` is not null) and (`install_script_exit_code` = 0)) then _utf8mb4'installed' when ((`pre_install_query_output` is not null) and (`pre_install_query_output` = _utf8mb4'')) then _utf8mb4'failed_install' when ((`host_id` is not null) and (`uninstall` = 0)) then _utf8mb4'pending_install' when ((`uninstall_script_exit_code` is not null) and (`uninstall_script_exit_code` <> 0)) then _utf8mb4'failed_uninstall' when ((`uninstall_script_exit_code` is not null) and (`uninstall_script_exit_code` = 0)) then NULL when ((`host_id` is not null) and (`uninstall` = 1)) then _utf8mb4'pending_uninstall' else NULL end)) STORED,
+  `attempt_number` int DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_host_software_installs_execution_id` (`execution_id`),
   KEY `fk_host_software_installs_user_id` (`user_id`),
@@ -977,6 +1420,7 @@ CREATE TABLE `host_software_installs` (
   KEY `fk_software_install_policy_id` (`policy_id`),
   KEY `fk_host_software_installs_installer_id` (`software_installer_id`),
   KEY `fk_host_software_installs_software_title_id` (`software_title_id`),
+  KEY `idx_host_software_installs_host_policy` (`host_id`,`policy_id`),
   CONSTRAINT `fk_host_software_installs_installer_id` FOREIGN KEY (`software_installer_id`) REFERENCES `software_installers` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
   CONSTRAINT `fk_host_software_installs_software_title_id` FOREIGN KEY (`software_title_id`) REFERENCES `software_titles` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
   CONSTRAINT `fk_host_software_installs_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL,
@@ -1010,7 +1454,7 @@ CREATE TABLE `host_users` (
 CREATE TABLE `host_vpp_software_installs` (
   `id` int unsigned NOT NULL AUTO_INCREMENT,
   `host_id` int unsigned NOT NULL,
-  `adam_id` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `adam_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `command_uuid` varchar(127) COLLATE utf8mb4_unicode_ci NOT NULL,
   `user_id` int unsigned DEFAULT NULL,
   `self_service` tinyint(1) NOT NULL DEFAULT '0',
@@ -1025,6 +1469,7 @@ CREATE TABLE `host_vpp_software_installs` (
   `verification_command_uuid` varchar(127) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `verification_at` datetime(6) DEFAULT NULL,
   `verification_failed_at` datetime(6) DEFAULT NULL,
+  `retry_count` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_host_vpp_software_installs_command_uuid` (`command_uuid`),
   KEY `user_id` (`user_id`),
@@ -1080,6 +1525,9 @@ CREATE TABLE `hosts` (
   `public_ip` varchar(45) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `orbit_node_key` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL,
   `refetch_critical_queries_until` timestamp NULL DEFAULT NULL,
+  `last_restarted_at` datetime(6) DEFAULT '0001-01-01 00:00:00.000000',
+  `timezone` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `orbit_debug_until` timestamp(6) NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_osquery_host_id` (`osquery_host_id`),
   UNIQUE KEY `idx_host_unique_nodekey` (`node_key`),
@@ -1088,7 +1536,59 @@ CREATE TABLE `hosts` (
   KEY `hosts_platform_idx` (`platform`),
   KEY `idx_hosts_hardware_serial` (`hardware_serial`),
   KEY `idx_hosts_uuid` (`uuid`),
+  KEY `idx_hosts_hostname` (`hostname`),
   CONSTRAINT `hosts_ibfk_1` FOREIGN KEY (`team_id`) REFERENCES `teams` (`id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `identity_certificates` (
+  `serial` bigint NOT NULL,
+  `name` varchar(1024) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `not_valid_before` datetime NOT NULL,
+  `not_valid_after` datetime NOT NULL,
+  `certificate_pem` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  `revoked` tinyint(1) NOT NULL DEFAULT '0',
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`serial`),
+  CONSTRAINT `identity_certificates_ibfk_1` FOREIGN KEY (`serial`) REFERENCES `identity_serials` (`serial`),
+  CONSTRAINT `identity_certificates_chk_1` CHECK ((substr(`certificate_pem`,1,27) = _utf8mb4'-----BEGIN CERTIFICATE-----')),
+  CONSTRAINT `identity_certificates_chk_2` CHECK (((`name` is null) or (`name` <> _utf8mb4'')))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `identity_serials` (
+  `serial` bigint NOT NULL AUTO_INCREMENT,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`serial`)
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `in_house_app_configurations` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `in_house_app_id` int unsigned NOT NULL,
+  `configuration` mediumtext COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_in_house_app_config_app` (`in_house_app_id`),
+  CONSTRAINT `fk_in_house_app_configurations_app` FOREIGN KEY (`in_house_app_id`) REFERENCES `in_house_apps` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `in_house_app_install_tokens` (
+  `token` varchar(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `software_title_id` int unsigned NOT NULL,
+  `team_id` int unsigned NOT NULL,
+  `host_id` int unsigned NOT NULL,
+  `expires_at` datetime(6) NOT NULL,
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`token`),
+  KEY `idx_in_house_app_install_tokens_expires_at` (`expires_at`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1100,11 +1600,26 @@ CREATE TABLE `in_house_app_labels` (
   `exclude` tinyint(1) NOT NULL DEFAULT '0',
   `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
   `updated_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  `require_all` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `id_in_house_app_labels_in_house_app_id_label_id` (`in_house_app_id`,`label_id`),
   KEY `label_id` (`label_id`),
   CONSTRAINT `in_house_app_labels_ibfk_1` FOREIGN KEY (`in_house_app_id`) REFERENCES `in_house_apps` (`id`) ON DELETE CASCADE,
   CONSTRAINT `in_house_app_labels_ibfk_2` FOREIGN KEY (`label_id`) REFERENCES `labels` (`id`) ON DELETE RESTRICT
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `in_house_app_software_categories` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `software_category_id` int unsigned NOT NULL,
+  `in_house_app_id` int unsigned NOT NULL,
+  `created_at` datetime(6) DEFAULT CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_unique_in_house_app_id_software_category_id` (`in_house_app_id`,`software_category_id`),
+  KEY `in_house_app_software_categories_ibfk_2` (`software_category_id`),
+  CONSTRAINT `in_house_app_software_categories_ibfk_1` FOREIGN KEY (`in_house_app_id`) REFERENCES `in_house_apps` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `in_house_app_software_categories_ibfk_2` FOREIGN KEY (`software_category_id`) REFERENCES `software_categories` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1130,15 +1645,17 @@ CREATE TABLE `in_house_apps` (
   `title_id` int unsigned DEFAULT NULL,
   `team_id` int unsigned DEFAULT NULL,
   `global_or_team_id` int unsigned NOT NULL DEFAULT '0',
-  `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `filename` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `version` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `storage_id` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   `platform` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `bundle_identifier` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `self_service` tinyint(1) NOT NULL DEFAULT '0',
+  `url` varchar(4095) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   PRIMARY KEY (`id`),
-  UNIQUE KEY `global_or_team_id` (`global_or_team_id`,`name`,`platform`),
+  UNIQUE KEY `global_or_team_id` (`global_or_team_id`,`filename`,`platform`),
   KEY `fk_in_house_apps_title` (`title_id`),
   CONSTRAINT `fk_in_house_apps_title` FOREIGN KEY (`title_id`) REFERENCES `software_titles` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -1204,8 +1721,7 @@ CREATE TABLE `kernel_host_counts` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_kernels_unique_mapping` (`os_version_id`,`team_id`,`software_id`),
   KEY `software_title_id` (`software_title_id`),
-  KEY `idx_kernel_host_counts_os_version_software` (`os_version_id`,`software_id`,`hosts_count`),
-  CONSTRAINT `kernel_host_counts_ibfk_1` FOREIGN KEY (`software_title_id`) REFERENCES `software_titles` (`id`) ON DELETE CASCADE
+  KEY `idx_kernel_host_counts_os_version_software` (`os_version_id`,`software_id`,`hosts_count`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1233,14 +1749,17 @@ CREATE TABLE `labels` (
   `label_membership_type` int unsigned NOT NULL DEFAULT '0',
   `author_id` int unsigned DEFAULT NULL,
   `criteria` json DEFAULT NULL,
+  `team_id` int unsigned DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_label_unique_name` (`name`),
   KEY `author_id` (`author_id`),
+  KEY `team_id` (`team_id`),
   FULLTEXT KEY `labels_search` (`name`),
-  CONSTRAINT `labels_ibfk_1` FOREIGN KEY (`author_id`) REFERENCES `users` (`id`) ON DELETE SET NULL
+  CONSTRAINT `labels_ibfk_1` FOREIGN KEY (`author_id`) REFERENCES `users` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `labels_ibfk_2` FOREIGN KEY (`team_id`) REFERENCES `teams` (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=6 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
-INSERT INTO `labels` VALUES (1,'2024-04-03 00:00:00','2025-10-09 00:00:00','macOS 14+ (Sonoma+)','macOS hosts with version 14 and above','select 1 from os_version where platform = \'darwin\' and major >= 14;','',1,0,NULL,NULL),(2,'2024-06-28 00:00:00','2025-10-09 00:00:00','iOS','All iOS hosts','','',1,1,NULL,NULL),(3,'2024-06-28 00:00:00','2025-10-09 00:00:00','iPadOS','All iPadOS hosts','','',1,1,NULL,NULL),(4,'2024-09-27 00:00:00','2025-10-09 00:00:00','Fedora Linux','All Fedora hosts','select 1 from os_version where name = \'Fedora Linux\';','',1,0,NULL,NULL),(5,'2025-02-25 00:00:00','2025-10-09 00:00:00','Android','All Android hosts','','',1,1,NULL,NULL);
+INSERT INTO `labels` VALUES (1,'2024-04-03 00:00:00','2025-10-09 00:00:00','macOS 14+ (Sonoma+)','macOS hosts with version 14 and above','select 1 from os_version where platform = \'darwin\' and major >= 14;','',1,0,NULL,NULL,NULL),(2,'2024-06-28 00:00:00','2025-10-09 00:00:00','iOS','All iOS hosts','','',1,1,NULL,NULL,NULL),(3,'2024-06-28 00:00:00','2025-10-09 00:00:00','iPadOS','All iPadOS hosts','','',1,1,NULL,NULL,NULL),(4,'2024-09-27 00:00:00','2025-10-09 00:00:00','Fedora Linux','All Fedora hosts','select 1 from os_version where name = \'Fedora Linux\';','',1,0,NULL,NULL,NULL),(5,'2025-02-25 00:00:00','2025-10-09 00:00:00','Android','All Android hosts','','',1,1,NULL,NULL,NULL);
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `legacy_host_filevault_profiles` (
@@ -1294,6 +1813,44 @@ CREATE TABLE `locks` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `mdm_adue_enrollment_challenges` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `challenge` varbinary(64) NOT NULL,
+  `idp_account_uuid` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `abm_token_id` int unsigned DEFAULT NULL,
+  `expires_at` timestamp(6) NOT NULL,
+  `used_at` timestamp(6) NULL DEFAULT NULL,
+  `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_mdm_adue_challenge` (`challenge`),
+  KEY `idx_mdm_adue_expires` (`expires_at`),
+  KEY `mdm_adue_abm_token_fk` (`abm_token_id`),
+  KEY `mdm_adue_idp_account_fk` (`idp_account_uuid`),
+  CONSTRAINT `mdm_adue_abm_token_fk` FOREIGN KEY (`abm_token_id`) REFERENCES `abm_tokens` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `mdm_adue_idp_account_fk` FOREIGN KEY (`idp_account_uuid`) REFERENCES `mdm_idp_accounts` (`uuid`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `mdm_android_commands` (
+  `command_uuid` varchar(36) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `host_uuid` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `operation_name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `command_type` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `status` enum('pending','acknowledged','error') COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'pending',
+  `error_code` varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `error_message` varchar(1024) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`command_uuid`),
+  UNIQUE KEY `idx_mdm_android_commands_operation_name` (`operation_name`),
+  KEY `idx_mdm_android_commands_host_uuid` (`host_uuid`),
+  KEY `idx_mdm_android_commands_status_created_at` (`status`,`created_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `mdm_android_configuration_profiles` (
   `profile_uuid` varchar(37) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `team_id` int unsigned NOT NULL DEFAULT '0',
@@ -1302,6 +1859,7 @@ CREATE TABLE `mdm_android_configuration_profiles` (
   `auto_increment` bigint NOT NULL AUTO_INCREMENT,
   `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
   `uploaded_at` timestamp(6) NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `checksum` binary(16) GENERATED ALWAYS AS (unhex(md5(cast(`raw_json` as char charset utf8mb4)))) STORED,
   PRIMARY KEY (`profile_uuid`),
   UNIQUE KEY `auto_increment` (`auto_increment`),
   UNIQUE KEY `idx_mdm_android_configuration_profiles_team_id_name` (`team_id`,`name`)
@@ -1343,13 +1901,50 @@ CREATE TABLE `mdm_apple_configuration_profiles` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
-CREATE TABLE `mdm_apple_declaration_activation_references` (
-  `declaration_uuid` varchar(37) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `reference` varchar(37) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  PRIMARY KEY (`declaration_uuid`,`reference`),
-  KEY `reference` (`reference`),
-  CONSTRAINT `mdm_apple_declaration_activation_references_ibfk_1` FOREIGN KEY (`declaration_uuid`) REFERENCES `mdm_apple_declarations` (`declaration_uuid`) ON UPDATE CASCADE,
-  CONSTRAINT `mdm_apple_declaration_activation_references_ibfk_2` FOREIGN KEY (`reference`) REFERENCES `mdm_apple_declarations` (`declaration_uuid`) ON UPDATE CASCADE
+CREATE TABLE `mdm_apple_ddm_activations` (
+  `activation_uuid` varchar(37) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `team_id` int unsigned NOT NULL DEFAULT '0',
+  `identifier` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `raw_json` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `declaration_uuid` varchar(37) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `configuration_identifier` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `secrets_updated_at` datetime(6) DEFAULT NULL,
+  `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `uploaded_at` timestamp(6) NULL DEFAULT NULL,
+  `token` binary(16) GENERATED ALWAYS AS (unhex(md5(concat(`raw_json`,ifnull(`secrets_updated_at`,_utf8mb4''))))) STORED,
+  PRIMARY KEY (`activation_uuid`),
+  UNIQUE KEY `idx_mdm_apple_ddm_activation_team_identifier` (`team_id`,`identifier`),
+  UNIQUE KEY `idx_mdm_apple_ddm_activation_team_config` (`team_id`,`configuration_identifier`),
+  UNIQUE KEY `idx_mdm_apple_ddm_activation_declaration` (`declaration_uuid`),
+  CONSTRAINT `fk_mdm_apple_ddm_activations_declaration_uuid` FOREIGN KEY (`declaration_uuid`) REFERENCES `mdm_apple_declarations` (`declaration_uuid`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `mdm_apple_declaration_asset_references` (
+  `declaration_uuid` varchar(37) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `asset_uuid` varchar(37) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  PRIMARY KEY (`declaration_uuid`,`asset_uuid`),
+  KEY `asset_uuid` (`asset_uuid`),
+  CONSTRAINT `mdm_apple_declaration_asset_references_ibfk_1` FOREIGN KEY (`declaration_uuid`) REFERENCES `mdm_apple_declarations` (`declaration_uuid`) ON DELETE CASCADE,
+  CONSTRAINT `mdm_apple_declaration_asset_references_ibfk_2` FOREIGN KEY (`asset_uuid`) REFERENCES `mdm_apple_declaration_assets` (`asset_uuid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `mdm_apple_declaration_assets` (
+  `asset_uuid` varchar(37) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `team_id` int unsigned NOT NULL,
+  `identifier` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `raw_json` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `secrets_updated_at` datetime(6) DEFAULT NULL,
+  `token` binary(16) GENERATED ALWAYS AS (unhex(md5(concat(`raw_json`,ifnull(`secrets_updated_at`,_utf8mb4''))))) STORED,
+  `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `uploaded_at` timestamp(6) NULL DEFAULT NULL,
+  PRIMARY KEY (`asset_uuid`),
+  UNIQUE KEY `idx_mdm_apple_decl_asset_team_identifier` (`team_id`,`identifier`),
+  UNIQUE KEY `idx_mdm_apple_decl_asset_team_name` (`team_id`,`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1431,6 +2026,29 @@ CREATE TABLE `mdm_apple_installers` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `mdm_apple_psso_devices` (
+  `host_uuid` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`host_uuid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `mdm_apple_psso_keys` (
+  `kid` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `host_uuid` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `key_type` enum('signing','encryption') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `pem` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`kid`),
+  KEY `fk_mdm_apple_psso_keys_host_uuid` (`host_uuid`),
+  CONSTRAINT `fk_mdm_apple_psso_keys_host_uuid` FOREIGN KEY (`host_uuid`) REFERENCES `mdm_apple_psso_devices` (`host_uuid`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `mdm_apple_setup_assistant_profiles` (
   `id` int unsigned NOT NULL AUTO_INCREMENT,
   `setup_assistant_id` int unsigned NOT NULL,
@@ -1492,12 +2110,27 @@ CREATE TABLE `mdm_configuration_profile_labels` (
   UNIQUE KEY `idx_mdm_configuration_profile_labels_apple_label_name` (`apple_profile_uuid`,`label_name`),
   UNIQUE KEY `idx_mdm_configuration_profile_labels_windows_label_name` (`windows_profile_uuid`,`label_name`),
   UNIQUE KEY `idx_mdm_configuration_profile_labels_android_label_name` (`android_profile_uuid`,`label_name`),
-  KEY `label_id` (`label_id`),
+  KEY `mdm_configuration_profile_labels_ibfk_label` (`label_id`),
   CONSTRAINT `mdm_configuration_profile_labels_ibfk_1` FOREIGN KEY (`apple_profile_uuid`) REFERENCES `mdm_apple_configuration_profiles` (`profile_uuid`) ON DELETE CASCADE,
   CONSTRAINT `mdm_configuration_profile_labels_ibfk_2` FOREIGN KEY (`windows_profile_uuid`) REFERENCES `mdm_windows_configuration_profiles` (`profile_uuid`) ON DELETE CASCADE,
-  CONSTRAINT `mdm_configuration_profile_labels_ibfk_3` FOREIGN KEY (`label_id`) REFERENCES `labels` (`id`) ON DELETE SET NULL,
   CONSTRAINT `mdm_configuration_profile_labels_ibfk_4` FOREIGN KEY (`android_profile_uuid`) REFERENCES `mdm_android_configuration_profiles` (`profile_uuid`) ON DELETE CASCADE,
+  CONSTRAINT `mdm_configuration_profile_labels_ibfk_label` FOREIGN KEY (`label_id`) REFERENCES `labels` (`id`) ON DELETE RESTRICT,
   CONSTRAINT `ck_mdm_configuration_profile_labels_profile_uuid` CHECK ((((if((`apple_profile_uuid` is null),0,1) + if((`windows_profile_uuid` is null),0,1)) + if((`android_profile_uuid` is null),0,1)) = 1))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `mdm_configuration_profile_update_settings` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `windows_profile_uuid` varchar(37) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `apple_declaration_uuid` varchar(37) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_mdm_config_profile_update_settings_apple_decl` (`apple_declaration_uuid`),
+  UNIQUE KEY `idx_mdm_config_profile_update_settings_windows_profile` (`windows_profile_uuid`),
+  CONSTRAINT `fk_mdm_config_profile_update_settings_apple_decl_uuid` FOREIGN KEY (`apple_declaration_uuid`) REFERENCES `mdm_apple_declarations` (`declaration_uuid`) ON DELETE CASCADE,
+  CONSTRAINT `fk_mdm_config_profile_update_settings_windows_profile_uuid` FOREIGN KEY (`windows_profile_uuid`) REFERENCES `mdm_windows_configuration_profiles` (`profile_uuid`) ON DELETE CASCADE,
+  CONSTRAINT `ck_mdm_config_profile_update_settings_exactly_one` CHECK (((if((`apple_declaration_uuid` is null),0,1) + if((`windows_profile_uuid` is null),0,1)) = 1))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1508,14 +2141,29 @@ CREATE TABLE `mdm_configuration_profile_variables` (
   `windows_profile_uuid` varchar(37) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `fleet_variable_id` int unsigned NOT NULL,
   `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `apple_declaration_uuid` varchar(37) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `android_profile_uuid` varchar(37) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `certificate_template_id` int unsigned DEFAULT NULL,
+  `android_app_configuration_id` int unsigned DEFAULT NULL,
+  `apple_ddm_activation_uuid` varchar(37) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_mdm_configuration_profile_variables_apple_variable` (`apple_profile_uuid`,`fleet_variable_id`),
   UNIQUE KEY `idx_mdm_configuration_profile_variables_windows_label_name` (`windows_profile_uuid`,`fleet_variable_id`),
+  UNIQUE KEY `idx_mdm_config_profile_vars_apple_decl_variable` (`apple_declaration_uuid`,`fleet_variable_id`),
+  UNIQUE KEY `idx_mdm_configuration_profile_variables_android_variable` (`android_profile_uuid`,`fleet_variable_id`),
+  UNIQUE KEY `idx_mdm_configuration_profile_variables_cert_template_variable` (`certificate_template_id`,`fleet_variable_id`),
+  UNIQUE KEY `idx_mdm_configuration_profile_variables_app_config_variable` (`android_app_configuration_id`,`fleet_variable_id`),
+  UNIQUE KEY `idx_mdm_config_profile_vars_ddm_activation_variable` (`apple_ddm_activation_uuid`,`fleet_variable_id`),
   KEY `mdm_configuration_profile_variables_fleet_variable_id` (`fleet_variable_id`),
+  CONSTRAINT `fk_mdm_configuration_profile_variables_android_profile_uuid` FOREIGN KEY (`android_profile_uuid`) REFERENCES `mdm_android_configuration_profiles` (`profile_uuid`) ON DELETE CASCADE,
+  CONSTRAINT `fk_mdm_configuration_profile_variables_app_config_id` FOREIGN KEY (`android_app_configuration_id`) REFERENCES `android_app_configurations` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_mdm_configuration_profile_variables_apple_declaration_uuid` FOREIGN KEY (`apple_declaration_uuid`) REFERENCES `mdm_apple_declarations` (`declaration_uuid`) ON DELETE CASCADE,
   CONSTRAINT `fk_mdm_configuration_profile_variables_apple_profile_uuid` FOREIGN KEY (`apple_profile_uuid`) REFERENCES `mdm_apple_configuration_profiles` (`profile_uuid`) ON DELETE CASCADE,
+  CONSTRAINT `fk_mdm_configuration_profile_variables_cert_template_id` FOREIGN KEY (`certificate_template_id`) REFERENCES `certificate_templates` (`id`) ON DELETE CASCADE,
   CONSTRAINT `fk_mdm_configuration_profile_variables_windows_profile_uuid` FOREIGN KEY (`windows_profile_uuid`) REFERENCES `mdm_windows_configuration_profiles` (`profile_uuid`) ON DELETE CASCADE,
+  CONSTRAINT `mdm_config_profile_variables_ddm_activation_fk` FOREIGN KEY (`apple_ddm_activation_uuid`) REFERENCES `mdm_apple_ddm_activations` (`activation_uuid`) ON DELETE CASCADE,
   CONSTRAINT `mdm_configuration_profile_variables_fleet_variable_id` FOREIGN KEY (`fleet_variable_id`) REFERENCES `fleet_variables` (`id`) ON DELETE CASCADE,
-  CONSTRAINT `ck_mdm_configuration_profile_variables_apple_or_windows` CHECK (((`apple_profile_uuid` is null) <> (`windows_profile_uuid` is null)))
+  CONSTRAINT `ck_mdm_configuration_profile_variables_exactly_one` CHECK ((((((((if((`apple_profile_uuid` is null),0,1) + if((`windows_profile_uuid` is null),0,1)) + if((`apple_declaration_uuid` is null),0,1)) + if((`android_profile_uuid` is null),0,1)) + if((`certificate_template_id` is null),0,1)) + if((`android_app_configuration_id` is null),0,1)) + if((`apple_ddm_activation_uuid` is null),0,1)) = 1))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1533,7 +2181,7 @@ CREATE TABLE `mdm_declaration_labels` (
   UNIQUE KEY `idx_mdm_declaration_labels_label_name` (`apple_declaration_uuid`,`label_name`),
   KEY `label_id` (`label_id`),
   CONSTRAINT `mdm_declaration_labels_ibfk_1` FOREIGN KEY (`apple_declaration_uuid`) REFERENCES `mdm_apple_declarations` (`declaration_uuid`) ON DELETE CASCADE,
-  CONSTRAINT `mdm_declaration_labels_ibfk_3` FOREIGN KEY (`label_id`) REFERENCES `labels` (`id`) ON DELETE SET NULL
+  CONSTRAINT `mdm_declaration_labels_ibfk_label` FOREIGN KEY (`label_id`) REFERENCES `labels` (`id`) ON DELETE RESTRICT
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1584,6 +2232,30 @@ CREATE TABLE `mdm_windows_configuration_profiles` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `mdm_windows_configuration_profiles_prior_content` (
+  `profile_uuid` varchar(37) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `checksum` binary(16) NOT NULL,
+  `syncml` mediumblob NOT NULL,
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`profile_uuid`,`checksum`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `mdm_windows_enrollment_config` (
+  `id` int unsigned NOT NULL,
+  `default_team_id` int unsigned DEFAULT NULL,
+  `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`id`),
+  KEY `fk_mdm_windows_enrollment_config_default_team_id` (`default_team_id`),
+  CONSTRAINT `fk_mdm_windows_enrollment_config_default_team_id` FOREIGN KEY (`default_team_id`) REFERENCES `teams` (`id`) ON DELETE SET NULL,
+  CONSTRAINT `ck_mdm_windows_enrollment_config_singleton` CHECK ((`id` = 1))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+INSERT INTO `mdm_windows_enrollment_config` VALUES (1,NULL,'2026-08-03 00:00:00.000000','2026-08-03 00:00:00.000000');
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `mdm_windows_enrollments` (
   `id` int unsigned NOT NULL AUTO_INCREMENT,
   `mdm_device_id` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
@@ -1599,10 +2271,19 @@ CREATE TABLE `mdm_windows_enrollments` (
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   `host_uuid` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `credentials_hash` binary(16) DEFAULT NULL,
+  `credentials_acknowledged` tinyint(1) NOT NULL DEFAULT '0',
+  `awaiting_configuration` tinyint(1) NOT NULL DEFAULT '0',
+  `awaiting_configuration_at` datetime(6) DEFAULT NULL,
+  `poll_schedule_relaxed` tinyint(1) NOT NULL DEFAULT '0',
+  `has_pending_commands` tinyint(1) NOT NULL DEFAULT '0',
+  `fleetd_sync_capable` tinyint(1) NOT NULL DEFAULT '0',
+  `managed_local_account_escrowed` tinyint(1) NOT NULL DEFAULT '0',
+  `hardware_serial` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_type` (`mdm_hardware_id`),
   KEY `idx_mdm_windows_enrollments_mdm_device_id` (`mdm_device_id`),
-  KEY `idx_mdm_windows_enrollments_host_uuid` (`host_uuid`)
+  KEY `idx_mdm_windows_enrollments_host_uuid_hardware_serial` (`host_uuid`,`hardware_serial`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1639,9 +2320,9 @@ CREATE TABLE `migration_status_tables` (
   `is_applied` tinyint(1) NOT NULL,
   `tstamp` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=433 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=589 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
-INSERT INTO `migration_status_tables` VALUES (1,0,1,'2020-01-01 01:01:01'),(2,20161118193812,1,'2020-01-01 01:01:01'),(3,20161118211713,1,'2020-01-01 01:01:01'),(4,20161118212436,1,'2020-01-01 01:01:01'),(5,20161118212515,1,'2020-01-01 01:01:01'),(6,20161118212528,1,'2020-01-01 01:01:01'),(7,20161118212538,1,'2020-01-01 01:01:01'),(8,20161118212549,1,'2020-01-01 01:01:01'),(9,20161118212557,1,'2020-01-01 01:01:01'),(10,20161118212604,1,'2020-01-01 01:01:01'),(11,20161118212613,1,'2020-01-01 01:01:01'),(12,20161118212621,1,'2020-01-01 01:01:01'),(13,20161118212630,1,'2020-01-01 01:01:01'),(14,20161118212641,1,'2020-01-01 01:01:01'),(15,20161118212649,1,'2020-01-01 01:01:01'),(16,20161118212656,1,'2020-01-01 01:01:01'),(17,20161118212758,1,'2020-01-01 01:01:01'),(18,20161128234849,1,'2020-01-01 01:01:01'),(19,20161230162221,1,'2020-01-01 01:01:01'),(20,20170104113816,1,'2020-01-01 01:01:01'),(21,20170105151732,1,'2020-01-01 01:01:01'),(22,20170108191242,1,'2020-01-01 01:01:01'),(23,20170109094020,1,'2020-01-01 01:01:01'),(24,20170109130438,1,'2020-01-01 01:01:01'),(25,20170110202752,1,'2020-01-01 01:01:01'),(26,20170111133013,1,'2020-01-01 01:01:01'),(27,20170117025759,1,'2020-01-01 01:01:01'),(28,20170118191001,1,'2020-01-01 01:01:01'),(29,20170119234632,1,'2020-01-01 01:01:01'),(30,20170124230432,1,'2020-01-01 01:01:01'),(31,20170127014618,1,'2020-01-01 01:01:01'),(32,20170131232841,1,'2020-01-01 01:01:01'),(33,20170223094154,1,'2020-01-01 01:01:01'),(34,20170306075207,1,'2020-01-01 01:01:01'),(35,20170309100733,1,'2020-01-01 01:01:01'),(36,20170331111922,1,'2020-01-01 01:01:01'),(37,20170502143928,1,'2020-01-01 01:01:01'),(38,20170504130602,1,'2020-01-01 01:01:01'),(39,20170509132100,1,'2020-01-01 01:01:01'),(40,20170519105647,1,'2020-01-01 01:01:01'),(41,20170519105648,1,'2020-01-01 01:01:01'),(42,20170831234300,1,'2020-01-01 01:01:01'),(43,20170831234301,1,'2020-01-01 01:01:01'),(44,20170831234303,1,'2020-01-01 01:01:01'),(45,20171116163618,1,'2020-01-01 01:01:01'),(46,20171219164727,1,'2020-01-01 01:01:01'),(47,20180620164811,1,'2020-01-01 01:01:01'),(48,20180620175054,1,'2020-01-01 01:01:01'),(49,20180620175055,1,'2020-01-01 01:01:01'),(50,20191010101639,1,'2020-01-01 01:01:01'),(51,20191010155147,1,'2020-01-01 01:01:01'),(52,20191220130734,1,'2020-01-01 01:01:01'),(53,20200311140000,1,'2020-01-01 01:01:01'),(54,20200405120000,1,'2020-01-01 01:01:01'),(55,20200407120000,1,'2020-01-01 01:01:01'),(56,20200420120000,1,'2020-01-01 01:01:01'),(57,20200504120000,1,'2020-01-01 01:01:01'),(58,20200512120000,1,'2020-01-01 01:01:01'),(59,20200707120000,1,'2020-01-01 01:01:01'),(60,20201011162341,1,'2020-01-01 01:01:01'),(61,20201021104586,1,'2020-01-01 01:01:01'),(62,20201102112520,1,'2020-01-01 01:01:01'),(63,20201208121729,1,'2020-01-01 01:01:01'),(64,20201215091637,1,'2020-01-01 01:01:01'),(65,20210119174155,1,'2020-01-01 01:01:01'),(66,20210326182902,1,'2020-01-01 01:01:01'),(67,20210421112652,1,'2020-01-01 01:01:01'),(68,20210506095025,1,'2020-01-01 01:01:01'),(69,20210513115729,1,'2020-01-01 01:01:01'),(70,20210526113559,1,'2020-01-01 01:01:01'),(71,20210601000001,1,'2020-01-01 01:01:01'),(72,20210601000002,1,'2020-01-01 01:01:01'),(73,20210601000003,1,'2020-01-01 01:01:01'),(74,20210601000004,1,'2020-01-01 01:01:01'),(75,20210601000005,1,'2020-01-01 01:01:01'),(76,20210601000006,1,'2020-01-01 01:01:01'),(77,20210601000007,1,'2020-01-01 01:01:01'),(78,20210601000008,1,'2020-01-01 01:01:01'),(79,20210606151329,1,'2020-01-01 01:01:01'),(80,20210616163757,1,'2020-01-01 01:01:01'),(81,20210617174723,1,'2020-01-01 01:01:01'),(82,20210622160235,1,'2020-01-01 01:01:01'),(83,20210623100031,1,'2020-01-01 01:01:01'),(84,20210623133615,1,'2020-01-01 01:01:01'),(85,20210708143152,1,'2020-01-01 01:01:01'),(86,20210709124443,1,'2020-01-01 01:01:01'),(87,20210712155608,1,'2020-01-01 01:01:01'),(88,20210714102108,1,'2020-01-01 01:01:01'),(89,20210719153709,1,'2020-01-01 01:01:01'),(90,20210721171531,1,'2020-01-01 01:01:01'),(91,20210723135713,1,'2020-01-01 01:01:01'),(92,20210802135933,1,'2020-01-01 01:01:01'),(93,20210806112844,1,'2020-01-01 01:01:01'),(94,20210810095603,1,'2020-01-01 01:01:01'),(95,20210811150223,1,'2020-01-01 01:01:01'),(96,20210818151827,1,'2020-01-01 01:01:01'),(97,20210818151828,1,'2020-01-01 01:01:01'),(98,20210818182258,1,'2020-01-01 01:01:01'),(99,20210819131107,1,'2020-01-01 01:01:01'),(100,20210819143446,1,'2020-01-01 01:01:01'),(101,20210903132338,1,'2020-01-01 01:01:01'),(102,20210915144307,1,'2020-01-01 01:01:01'),(103,20210920155130,1,'2020-01-01 01:01:01'),(104,20210927143115,1,'2020-01-01 01:01:01'),(105,20210927143116,1,'2020-01-01 01:01:01'),(106,20211013133706,1,'2020-01-01 01:01:01'),(107,20211013133707,1,'2020-01-01 01:01:01'),(108,20211102135149,1,'2020-01-01 01:01:01'),(109,20211109121546,1,'2020-01-01 01:01:01'),(110,20211110163320,1,'2020-01-01 01:01:01'),(111,20211116184029,1,'2020-01-01 01:01:01'),(112,20211116184030,1,'2020-01-01 01:01:01'),(113,20211202092042,1,'2020-01-01 01:01:01'),(114,20211202181033,1,'2020-01-01 01:01:01'),(115,20211207161856,1,'2020-01-01 01:01:01'),(116,20211216131203,1,'2020-01-01 01:01:01'),(117,20211221110132,1,'2020-01-01 01:01:01'),(118,20220107155700,1,'2020-01-01 01:01:01'),(119,20220125105650,1,'2020-01-01 01:01:01'),(120,20220201084510,1,'2020-01-01 01:01:01'),(121,20220208144830,1,'2020-01-01 01:01:01'),(122,20220208144831,1,'2020-01-01 01:01:01'),(123,20220215152203,1,'2020-01-01 01:01:01'),(124,20220223113157,1,'2020-01-01 01:01:01'),(125,20220307104655,1,'2020-01-01 01:01:01'),(126,20220309133956,1,'2020-01-01 01:01:01'),(127,20220316155700,1,'2020-01-01 01:01:01'),(128,20220323152301,1,'2020-01-01 01:01:01'),(129,20220330100659,1,'2020-01-01 01:01:01'),(130,20220404091216,1,'2020-01-01 01:01:01'),(131,20220419140750,1,'2020-01-01 01:01:01'),(132,20220428140039,1,'2020-01-01 01:01:01'),(133,20220503134048,1,'2020-01-01 01:01:01'),(134,20220524102918,1,'2020-01-01 01:01:01'),(135,20220526123327,1,'2020-01-01 01:01:01'),(136,20220526123328,1,'2020-01-01 01:01:01'),(137,20220526123329,1,'2020-01-01 01:01:01'),(138,20220608113128,1,'2020-01-01 01:01:01'),(139,20220627104817,1,'2020-01-01 01:01:01'),(140,20220704101843,1,'2020-01-01 01:01:01'),(141,20220708095046,1,'2020-01-01 01:01:01'),(142,20220713091130,1,'2020-01-01 01:01:01'),(143,20220802135510,1,'2020-01-01 01:01:01'),(144,20220818101352,1,'2020-01-01 01:01:01'),(145,20220822161445,1,'2020-01-01 01:01:01'),(146,20220831100036,1,'2020-01-01 01:01:01'),(147,20220831100151,1,'2020-01-01 01:01:01'),(148,20220908181826,1,'2020-01-01 01:01:01'),(149,20220914154915,1,'2020-01-01 01:01:01'),(150,20220915165115,1,'2020-01-01 01:01:01'),(151,20220915165116,1,'2020-01-01 01:01:01'),(152,20220928100158,1,'2020-01-01 01:01:01'),(153,20221014084130,1,'2020-01-01 01:01:01'),(154,20221027085019,1,'2020-01-01 01:01:01'),(155,20221101103952,1,'2020-01-01 01:01:01'),(156,20221104144401,1,'2020-01-01 01:01:01'),(157,20221109100749,1,'2020-01-01 01:01:01'),(158,20221115104546,1,'2020-01-01 01:01:01'),(159,20221130114928,1,'2020-01-01 01:01:01'),(160,20221205112142,1,'2020-01-01 01:01:01'),(161,20221216115820,1,'2020-01-01 01:01:01'),(162,20221220195934,1,'2020-01-01 01:01:01'),(163,20221220195935,1,'2020-01-01 01:01:01'),(164,20221223174807,1,'2020-01-01 01:01:01'),(165,20221227163855,1,'2020-01-01 01:01:01'),(166,20221227163856,1,'2020-01-01 01:01:01'),(167,20230202224725,1,'2020-01-01 01:01:01'),(168,20230206163608,1,'2020-01-01 01:01:01'),(169,20230214131519,1,'2020-01-01 01:01:01'),(170,20230303135738,1,'2020-01-01 01:01:01'),(171,20230313135301,1,'2020-01-01 01:01:01'),(172,20230313141819,1,'2020-01-01 01:01:01'),(173,20230315104937,1,'2020-01-01 01:01:01'),(174,20230317173844,1,'2020-01-01 01:01:01'),(175,20230320133602,1,'2020-01-01 01:01:01'),(176,20230330100011,1,'2020-01-01 01:01:01'),(177,20230330134823,1,'2020-01-01 01:01:01'),(178,20230405232025,1,'2020-01-01 01:01:01'),(179,20230408084104,1,'2020-01-01 01:01:01'),(180,20230411102858,1,'2020-01-01 01:01:01'),(181,20230421155932,1,'2020-01-01 01:01:01'),(182,20230425082126,1,'2020-01-01 01:01:01'),(183,20230425105727,1,'2020-01-01 01:01:01'),(184,20230501154913,1,'2020-01-01 01:01:01'),(185,20230503101418,1,'2020-01-01 01:01:01'),(186,20230515144206,1,'2020-01-01 01:01:01'),(187,20230517140952,1,'2020-01-01 01:01:01'),(188,20230517152807,1,'2020-01-01 01:01:01'),(189,20230518114155,1,'2020-01-01 01:01:01'),(190,20230520153236,1,'2020-01-01 01:01:01'),(191,20230525151159,1,'2020-01-01 01:01:01'),(192,20230530122103,1,'2020-01-01 01:01:01'),(193,20230602111827,1,'2020-01-01 01:01:01'),(194,20230608103123,1,'2020-01-01 01:01:01'),(195,20230629140529,1,'2020-01-01 01:01:01'),(196,20230629140530,1,'2020-01-01 01:01:01'),(197,20230711144622,1,'2020-01-01 01:01:01'),(198,20230721135421,1,'2020-01-01 01:01:01'),(199,20230721161508,1,'2020-01-01 01:01:01'),(200,20230726115701,1,'2020-01-01 01:01:01'),(201,20230807100822,1,'2020-01-01 01:01:01'),(202,20230814150442,1,'2020-01-01 01:01:01'),(203,20230823122728,1,'2020-01-01 01:01:01'),(204,20230906152143,1,'2020-01-01 01:01:01'),(205,20230911163618,1,'2020-01-01 01:01:01'),(206,20230912101759,1,'2020-01-01 01:01:01'),(207,20230915101341,1,'2020-01-01 01:01:01'),(208,20230918132351,1,'2020-01-01 01:01:01'),(209,20231004144339,1,'2020-01-01 01:01:01'),(210,20231009094541,1,'2020-01-01 01:01:01'),(211,20231009094542,1,'2020-01-01 01:01:01'),(212,20231009094543,1,'2020-01-01 01:01:01'),(213,20231009094544,1,'2020-01-01 01:01:01'),(214,20231016091915,1,'2020-01-01 01:01:01'),(215,20231024174135,1,'2020-01-01 01:01:01'),(216,20231025120016,1,'2020-01-01 01:01:01'),(217,20231025160156,1,'2020-01-01 01:01:01'),(218,20231031165350,1,'2020-01-01 01:01:01'),(219,20231106144110,1,'2020-01-01 01:01:01'),(220,20231107130934,1,'2020-01-01 01:01:01'),(221,20231109115838,1,'2020-01-01 01:01:01'),(222,20231121054530,1,'2020-01-01 01:01:01'),(223,20231122101320,1,'2020-01-01 01:01:01'),(224,20231130132828,1,'2020-01-01 01:01:01'),(225,20231130132931,1,'2020-01-01 01:01:01'),(226,20231204155427,1,'2020-01-01 01:01:01'),(227,20231206142340,1,'2020-01-01 01:01:01'),(228,20231207102320,1,'2020-01-01 01:01:01'),(229,20231207102321,1,'2020-01-01 01:01:01'),(230,20231207133731,1,'2020-01-01 01:01:01'),(231,20231212094238,1,'2020-01-01 01:01:01'),(232,20231212095734,1,'2020-01-01 01:01:01'),(233,20231212161121,1,'2020-01-01 01:01:01'),(234,20231215122713,1,'2020-01-01 01:01:01'),(235,20231219143041,1,'2020-01-01 01:01:01'),(236,20231224070653,1,'2020-01-01 01:01:01'),(237,20240110134315,1,'2020-01-01 01:01:01'),(238,20240119091637,1,'2020-01-01 01:01:01'),(239,20240126020642,1,'2020-01-01 01:01:01'),(240,20240126020643,1,'2020-01-01 01:01:01'),(241,20240129162819,1,'2020-01-01 01:01:01'),(242,20240130115133,1,'2020-01-01 01:01:01'),(243,20240131083822,1,'2020-01-01 01:01:01'),(244,20240205095928,1,'2020-01-01 01:01:01'),(245,20240205121956,1,'2020-01-01 01:01:01'),(246,20240209110212,1,'2020-01-01 01:01:01'),(247,20240212111533,1,'2020-01-01 01:01:01'),(248,20240221112844,1,'2020-01-01 01:01:01'),(249,20240222073518,1,'2020-01-01 01:01:01'),(250,20240222135115,1,'2020-01-01 01:01:01'),(251,20240226082255,1,'2020-01-01 01:01:01'),(252,20240228082706,1,'2020-01-01 01:01:01'),(253,20240301173035,1,'2020-01-01 01:01:01'),(254,20240302111134,1,'2020-01-01 01:01:01'),(255,20240312103753,1,'2020-01-01 01:01:01'),(256,20240313143416,1,'2020-01-01 01:01:01'),(257,20240314085226,1,'2020-01-01 01:01:01'),(258,20240314151747,1,'2020-01-01 01:01:01'),(259,20240320145650,1,'2020-01-01 01:01:01'),(260,20240327115530,1,'2020-01-01 01:01:01'),(261,20240327115617,1,'2020-01-01 01:01:01'),(262,20240408085837,1,'2020-01-01 01:01:01'),(263,20240415104633,1,'2020-01-01 01:01:01'),(264,20240430111727,1,'2020-01-01 01:01:01'),(265,20240515200020,1,'2020-01-01 01:01:01'),(266,20240521143023,1,'2020-01-01 01:01:01'),(267,20240521143024,1,'2020-01-01 01:01:01'),(268,20240601174138,1,'2020-01-01 01:01:01'),(269,20240607133721,1,'2020-01-01 01:01:01'),(270,20240612150059,1,'2020-01-01 01:01:01'),(271,20240613162201,1,'2020-01-01 01:01:01'),(272,20240613172616,1,'2020-01-01 01:01:01'),(273,20240618142419,1,'2020-01-01 01:01:01'),(274,20240625093543,1,'2020-01-01 01:01:01'),(275,20240626195531,1,'2020-01-01 01:01:01'),(276,20240702123921,1,'2020-01-01 01:01:01'),(277,20240703154849,1,'2020-01-01 01:01:01'),(278,20240707134035,1,'2020-01-01 01:01:01'),(279,20240707134036,1,'2020-01-01 01:01:01'),(280,20240709124958,1,'2020-01-01 01:01:01'),(281,20240709132642,1,'2020-01-01 01:01:01'),(282,20240709183940,1,'2020-01-01 01:01:01'),(283,20240710155623,1,'2020-01-01 01:01:01'),(284,20240723102712,1,'2020-01-01 01:01:01'),(285,20240725152735,1,'2020-01-01 01:01:01'),(286,20240725182118,1,'2020-01-01 01:01:01'),(287,20240726100517,1,'2020-01-01 01:01:01'),(288,20240730171504,1,'2020-01-01 01:01:01'),(289,20240730174056,1,'2020-01-01 01:01:01'),(290,20240730215453,1,'2020-01-01 01:01:01'),(291,20240730374423,1,'2020-01-01 01:01:01'),(292,20240801115359,1,'2020-01-01 01:01:01'),(293,20240802101043,1,'2020-01-01 01:01:01'),(294,20240802113716,1,'2020-01-01 01:01:01'),(295,20240814135330,1,'2020-01-01 01:01:01'),(296,20240815000000,1,'2020-01-01 01:01:01'),(297,20240815000001,1,'2020-01-01 01:01:01'),(298,20240816103247,1,'2020-01-01 01:01:01'),(299,20240820091218,1,'2020-01-01 01:01:01'),(300,20240826111228,1,'2020-01-01 01:01:01'),(301,20240826160025,1,'2020-01-01 01:01:01'),(302,20240829165448,1,'2020-01-01 01:01:01'),(303,20240829165605,1,'2020-01-01 01:01:01'),(304,20240829165715,1,'2020-01-01 01:01:01'),(305,20240829165930,1,'2020-01-01 01:01:01'),(306,20240829170023,1,'2020-01-01 01:01:01'),(307,20240829170033,1,'2020-01-01 01:01:01'),(308,20240829170044,1,'2020-01-01 01:01:01'),(309,20240905105135,1,'2020-01-01 01:01:01'),(310,20240905140514,1,'2020-01-01 01:01:01'),(311,20240905200000,1,'2020-01-01 01:01:01'),(312,20240905200001,1,'2020-01-01 01:01:01'),(313,20241002104104,1,'2020-01-01 01:01:01'),(314,20241002104105,1,'2020-01-01 01:01:01'),(315,20241002104106,1,'2020-01-01 01:01:01'),(316,20241002210000,1,'2020-01-01 01:01:01'),(317,20241003145349,1,'2020-01-01 01:01:01'),(318,20241004005000,1,'2020-01-01 01:01:01'),(319,20241008083925,1,'2020-01-01 01:01:01'),(320,20241009090010,1,'2020-01-01 01:01:01'),(321,20241017163402,1,'2020-01-01 01:01:01'),(322,20241021224359,1,'2020-01-01 01:01:01'),(323,20241022140321,1,'2020-01-01 01:01:01'),(324,20241025111236,1,'2020-01-01 01:01:01'),(325,20241025112748,1,'2020-01-01 01:01:01'),(326,20241025141855,1,'2020-01-01 01:01:01'),(327,20241110152839,1,'2020-01-01 01:01:01'),(328,20241110152840,1,'2020-01-01 01:01:01'),(329,20241110152841,1,'2020-01-01 01:01:01'),(330,20241116233322,1,'2020-01-01 01:01:01'),(331,20241122171434,1,'2020-01-01 01:01:01'),(332,20241125150614,1,'2020-01-01 01:01:01'),(333,20241203125346,1,'2020-01-01 01:01:01'),(334,20241203130032,1,'2020-01-01 01:01:01'),(335,20241205122800,1,'2020-01-01 01:01:01'),(336,20241209164540,1,'2020-01-01 01:01:01'),(337,20241210140021,1,'2020-01-01 01:01:01'),(338,20241219180042,1,'2020-01-01 01:01:01'),(339,20241220100000,1,'2020-01-01 01:01:01'),(340,20241220114903,1,'2020-01-01 01:01:01'),(341,20241220114904,1,'2020-01-01 01:01:01'),(342,20241224000000,1,'2020-01-01 01:01:01'),(343,20241230000000,1,'2020-01-01 01:01:01'),(344,20241231112624,1,'2020-01-01 01:01:01'),(345,20250102121439,1,'2020-01-01 01:01:01'),(346,20250121094045,1,'2020-01-01 01:01:01'),(347,20250121094500,1,'2020-01-01 01:01:01'),(348,20250121094600,1,'2020-01-01 01:01:01'),(349,20250121094700,1,'2020-01-01 01:01:01'),(350,20250124194347,1,'2020-01-01 01:01:01'),(351,20250127162751,1,'2020-01-01 01:01:01'),(352,20250213104005,1,'2020-01-01 01:01:01'),(353,20250214205657,1,'2020-01-01 01:01:01'),(354,20250217093329,1,'2020-01-01 01:01:01'),(355,20250219090511,1,'2020-01-01 01:01:01'),(356,20250219100000,1,'2020-01-01 01:01:01'),(357,20250219142401,1,'2020-01-01 01:01:01'),(358,20250224184002,1,'2020-01-01 01:01:01'),(359,20250225085436,1,'2020-01-01 01:01:01'),(360,20250226000000,1,'2020-01-01 01:01:01'),(361,20250226153445,1,'2020-01-01 01:01:01'),(362,20250304162702,1,'2020-01-01 01:01:01'),(363,20250306144233,1,'2020-01-01 01:01:01'),(364,20250313163430,1,'2020-01-01 01:01:01'),(365,20250317130944,1,'2020-01-01 01:01:01'),(366,20250318165922,1,'2020-01-01 01:01:01'),(367,20250320132525,1,'2020-01-01 01:01:01'),(368,20250320200000,1,'2020-01-01 01:01:01'),(369,20250326161930,1,'2020-01-01 01:01:01'),(370,20250326161931,1,'2020-01-01 01:01:01'),(371,20250331042354,1,'2020-01-01 01:01:01'),(372,20250331154206,1,'2020-01-01 01:01:01'),(373,20250401155831,1,'2020-01-01 01:01:01'),(374,20250408133233,1,'2020-01-01 01:01:01'),(375,20250410104321,1,'2020-01-01 01:01:01'),(376,20250421085116,1,'2020-01-01 01:01:01'),(377,20250422095806,1,'2020-01-01 01:01:01'),(378,20250424153059,1,'2020-01-01 01:01:01'),(379,20250430103833,1,'2020-01-01 01:01:01'),(380,20250430112622,1,'2020-01-01 01:01:01'),(381,20250501162727,1,'2020-01-01 01:01:01'),(382,20250502154517,1,'2020-01-01 01:01:01'),(383,20250502222222,1,'2020-01-01 01:01:01'),(384,20250507170845,1,'2020-01-01 01:01:01'),(385,20250513162912,1,'2020-01-01 01:01:01'),(386,20250519161614,1,'2020-01-01 01:01:01'),(387,20250519170000,1,'2020-01-01 01:01:01'),(388,20250520153848,1,'2020-01-01 01:01:01'),(389,20250528115932,1,'2020-01-01 01:01:01'),(390,20250529102706,1,'2020-01-01 01:01:01'),(391,20250603105558,1,'2020-01-01 01:01:01'),(392,20250609102714,1,'2020-01-01 01:01:01'),(393,20250609112613,1,'2020-01-01 01:01:01'),(394,20250613103810,1,'2020-01-01 01:01:01'),(395,20250616193950,1,'2020-01-01 01:01:01'),(396,20250624140757,1,'2020-01-01 01:01:01'),(397,20250626130239,1,'2020-01-01 01:01:01'),(398,20250629131032,1,'2020-01-01 01:01:01'),(399,20250701155654,1,'2020-01-01 01:01:01'),(400,20250707095725,1,'2020-01-01 01:01:01'),(401,20250716152435,1,'2020-01-01 01:01:01'),(402,20250718091828,1,'2020-01-01 01:01:01'),(403,20250728122229,1,'2020-01-01 01:01:01'),(404,20250731122715,1,'2020-01-01 01:01:01'),(405,20250731151000,1,'2020-01-01 01:01:01'),(406,20250803000000,1,'2020-01-01 01:01:01'),(407,20250805083116,1,'2020-01-01 01:01:01'),(408,20250807140441,1,'2020-01-01 01:01:01'),(409,20250808000000,1,'2020-01-01 01:01:01'),(410,20250811155036,1,'2020-01-01 01:01:01'),(411,20250813205039,1,'2020-01-01 01:01:01'),(412,20250814123333,1,'2020-01-01 01:01:01'),(413,20250815130115,1,'2020-01-01 01:01:01'),(414,20250816115553,1,'2020-01-01 01:01:01'),(415,20250817154557,1,'2020-01-01 01:01:01'),(416,20250825113751,1,'2020-01-01 01:01:01'),(417,20250827113140,1,'2020-01-01 01:01:01'),(418,20250828120836,1,'2020-01-01 01:01:01'),(419,20250902112642,1,'2020-01-01 01:01:01'),(420,20250904091745,1,'2020-01-01 01:01:01'),(421,20250905090000,1,'2020-01-01 01:01:01'),(422,20250922083056,1,'2020-01-01 01:01:01'),(423,20250923120000,1,'2020-01-01 01:01:01'),(424,20250926123048,1,'2020-01-01 01:01:01'),(425,20251015103505,1,'2020-01-01 01:01:01'),(426,20251015103600,1,'2020-01-01 01:01:01'),(427,20251015103700,1,'2020-01-01 01:01:01'),(428,20251015103800,1,'2020-01-01 01:01:01'),(429,20251015103900,1,'2020-01-01 01:01:01'),(430,20251022123456,1,'2020-01-01 01:01:01'),(431,20251027101151,1,'2020-01-01 01:01:01'),(432,20251027101155,1,'2020-01-01 01:01:01');
+INSERT INTO `migration_status_tables` VALUES (1,0,1,'2020-01-01 01:01:01'),(2,20161118193812,1,'2020-01-01 01:01:01'),(3,20161118211713,1,'2020-01-01 01:01:01'),(4,20161118212436,1,'2020-01-01 01:01:01'),(5,20161118212515,1,'2020-01-01 01:01:01'),(6,20161118212528,1,'2020-01-01 01:01:01'),(7,20161118212538,1,'2020-01-01 01:01:01'),(8,20161118212549,1,'2020-01-01 01:01:01'),(9,20161118212557,1,'2020-01-01 01:01:01'),(10,20161118212604,1,'2020-01-01 01:01:01'),(11,20161118212613,1,'2020-01-01 01:01:01'),(12,20161118212621,1,'2020-01-01 01:01:01'),(13,20161118212630,1,'2020-01-01 01:01:01'),(14,20161118212641,1,'2020-01-01 01:01:01'),(15,20161118212649,1,'2020-01-01 01:01:01'),(16,20161118212656,1,'2020-01-01 01:01:01'),(17,20161118212758,1,'2020-01-01 01:01:01'),(18,20161128234849,1,'2020-01-01 01:01:01'),(19,20161230162221,1,'2020-01-01 01:01:01'),(20,20170104113816,1,'2020-01-01 01:01:01'),(21,20170105151732,1,'2020-01-01 01:01:01'),(22,20170108191242,1,'2020-01-01 01:01:01'),(23,20170109094020,1,'2020-01-01 01:01:01'),(24,20170109130438,1,'2020-01-01 01:01:01'),(25,20170110202752,1,'2020-01-01 01:01:01'),(26,20170111133013,1,'2020-01-01 01:01:01'),(27,20170117025759,1,'2020-01-01 01:01:01'),(28,20170118191001,1,'2020-01-01 01:01:01'),(29,20170119234632,1,'2020-01-01 01:01:01'),(30,20170124230432,1,'2020-01-01 01:01:01'),(31,20170127014618,1,'2020-01-01 01:01:01'),(32,20170131232841,1,'2020-01-01 01:01:01'),(33,20170223094154,1,'2020-01-01 01:01:01'),(34,20170306075207,1,'2020-01-01 01:01:01'),(35,20170309100733,1,'2020-01-01 01:01:01'),(36,20170331111922,1,'2020-01-01 01:01:01'),(37,20170502143928,1,'2020-01-01 01:01:01'),(38,20170504130602,1,'2020-01-01 01:01:01'),(39,20170509132100,1,'2020-01-01 01:01:01'),(40,20170519105647,1,'2020-01-01 01:01:01'),(41,20170519105648,1,'2020-01-01 01:01:01'),(42,20170831234300,1,'2020-01-01 01:01:01'),(43,20170831234301,1,'2020-01-01 01:01:01'),(44,20170831234303,1,'2020-01-01 01:01:01'),(45,20171116163618,1,'2020-01-01 01:01:01'),(46,20171219164727,1,'2020-01-01 01:01:01'),(47,20180620164811,1,'2020-01-01 01:01:01'),(48,20180620175054,1,'2020-01-01 01:01:01'),(49,20180620175055,1,'2020-01-01 01:01:01'),(50,20191010101639,1,'2020-01-01 01:01:01'),(51,20191010155147,1,'2020-01-01 01:01:01'),(52,20191220130734,1,'2020-01-01 01:01:01'),(53,20200311140000,1,'2020-01-01 01:01:01'),(54,20200405120000,1,'2020-01-01 01:01:01'),(55,20200407120000,1,'2020-01-01 01:01:01'),(56,20200420120000,1,'2020-01-01 01:01:01'),(57,20200504120000,1,'2020-01-01 01:01:01'),(58,20200512120000,1,'2020-01-01 01:01:01'),(59,20200707120000,1,'2020-01-01 01:01:01'),(60,20201011162341,1,'2020-01-01 01:01:01'),(61,20201021104586,1,'2020-01-01 01:01:01'),(62,20201102112520,1,'2020-01-01 01:01:01'),(63,20201208121729,1,'2020-01-01 01:01:01'),(64,20201215091637,1,'2020-01-01 01:01:01'),(65,20210119174155,1,'2020-01-01 01:01:01'),(66,20210326182902,1,'2020-01-01 01:01:01'),(67,20210421112652,1,'2020-01-01 01:01:01'),(68,20210506095025,1,'2020-01-01 01:01:01'),(69,20210513115729,1,'2020-01-01 01:01:01'),(70,20210526113559,1,'2020-01-01 01:01:01'),(71,20210601000001,1,'2020-01-01 01:01:01'),(72,20210601000002,1,'2020-01-01 01:01:01'),(73,20210601000003,1,'2020-01-01 01:01:01'),(74,20210601000004,1,'2020-01-01 01:01:01'),(75,20210601000005,1,'2020-01-01 01:01:01'),(76,20210601000006,1,'2020-01-01 01:01:01'),(77,20210601000007,1,'2020-01-01 01:01:01'),(78,20210601000008,1,'2020-01-01 01:01:01'),(79,20210606151329,1,'2020-01-01 01:01:01'),(80,20210616163757,1,'2020-01-01 01:01:01'),(81,20210617174723,1,'2020-01-01 01:01:01'),(82,20210622160235,1,'2020-01-01 01:01:01'),(83,20210623100031,1,'2020-01-01 01:01:01'),(84,20210623133615,1,'2020-01-01 01:01:01'),(85,20210708143152,1,'2020-01-01 01:01:01'),(86,20210709124443,1,'2020-01-01 01:01:01'),(87,20210712155608,1,'2020-01-01 01:01:01'),(88,20210714102108,1,'2020-01-01 01:01:01'),(89,20210719153709,1,'2020-01-01 01:01:01'),(90,20210721171531,1,'2020-01-01 01:01:01'),(91,20210723135713,1,'2020-01-01 01:01:01'),(92,20210802135933,1,'2020-01-01 01:01:01'),(93,20210806112844,1,'2020-01-01 01:01:01'),(94,20210810095603,1,'2020-01-01 01:01:01'),(95,20210811150223,1,'2020-01-01 01:01:01'),(96,20210818151827,1,'2020-01-01 01:01:01'),(97,20210818151828,1,'2020-01-01 01:01:01'),(98,20210818182258,1,'2020-01-01 01:01:01'),(99,20210819131107,1,'2020-01-01 01:01:01'),(100,20210819143446,1,'2020-01-01 01:01:01'),(101,20210903132338,1,'2020-01-01 01:01:01'),(102,20210915144307,1,'2020-01-01 01:01:01'),(103,20210920155130,1,'2020-01-01 01:01:01'),(104,20210927143115,1,'2020-01-01 01:01:01'),(105,20210927143116,1,'2020-01-01 01:01:01'),(106,20211013133706,1,'2020-01-01 01:01:01'),(107,20211013133707,1,'2020-01-01 01:01:01'),(108,20211102135149,1,'2020-01-01 01:01:01'),(109,20211109121546,1,'2020-01-01 01:01:01'),(110,20211110163320,1,'2020-01-01 01:01:01'),(111,20211116184029,1,'2020-01-01 01:01:01'),(112,20211116184030,1,'2020-01-01 01:01:01'),(113,20211202092042,1,'2020-01-01 01:01:01'),(114,20211202181033,1,'2020-01-01 01:01:01'),(115,20211207161856,1,'2020-01-01 01:01:01'),(116,20211216131203,1,'2020-01-01 01:01:01'),(117,20211221110132,1,'2020-01-01 01:01:01'),(118,20220107155700,1,'2020-01-01 01:01:01'),(119,20220125105650,1,'2020-01-01 01:01:01'),(120,20220201084510,1,'2020-01-01 01:01:01'),(121,20220208144830,1,'2020-01-01 01:01:01'),(122,20220208144831,1,'2020-01-01 01:01:01'),(123,20220215152203,1,'2020-01-01 01:01:01'),(124,20220223113157,1,'2020-01-01 01:01:01'),(125,20220307104655,1,'2020-01-01 01:01:01'),(126,20220309133956,1,'2020-01-01 01:01:01'),(127,20220316155700,1,'2020-01-01 01:01:01'),(128,20220323152301,1,'2020-01-01 01:01:01'),(129,20220330100659,1,'2020-01-01 01:01:01'),(130,20220404091216,1,'2020-01-01 01:01:01'),(131,20220419140750,1,'2020-01-01 01:01:01'),(132,20220428140039,1,'2020-01-01 01:01:01'),(133,20220503134048,1,'2020-01-01 01:01:01'),(134,20220524102918,1,'2020-01-01 01:01:01'),(135,20220526123327,1,'2020-01-01 01:01:01'),(136,20220526123328,1,'2020-01-01 01:01:01'),(137,20220526123329,1,'2020-01-01 01:01:01'),(138,20220608113128,1,'2020-01-01 01:01:01'),(139,20220627104817,1,'2020-01-01 01:01:01'),(140,20220704101843,1,'2020-01-01 01:01:01'),(141,20220708095046,1,'2020-01-01 01:01:01'),(142,20220713091130,1,'2020-01-01 01:01:01'),(143,20220802135510,1,'2020-01-01 01:01:01'),(144,20220818101352,1,'2020-01-01 01:01:01'),(145,20220822161445,1,'2020-01-01 01:01:01'),(146,20220831100036,1,'2020-01-01 01:01:01'),(147,20220831100151,1,'2020-01-01 01:01:01'),(148,20220908181826,1,'2020-01-01 01:01:01'),(149,20220914154915,1,'2020-01-01 01:01:01'),(150,20220915165115,1,'2020-01-01 01:01:01'),(151,20220915165116,1,'2020-01-01 01:01:01'),(152,20220928100158,1,'2020-01-01 01:01:01'),(153,20221014084130,1,'2020-01-01 01:01:01'),(154,20221027085019,1,'2020-01-01 01:01:01'),(155,20221101103952,1,'2020-01-01 01:01:01'),(156,20221104144401,1,'2020-01-01 01:01:01'),(157,20221109100749,1,'2020-01-01 01:01:01'),(158,20221115104546,1,'2020-01-01 01:01:01'),(159,20221130114928,1,'2020-01-01 01:01:01'),(160,20221205112142,1,'2020-01-01 01:01:01'),(161,20221216115820,1,'2020-01-01 01:01:01'),(162,20221220195934,1,'2020-01-01 01:01:01'),(163,20221220195935,1,'2020-01-01 01:01:01'),(164,20221223174807,1,'2020-01-01 01:01:01'),(165,20221227163855,1,'2020-01-01 01:01:01'),(166,20221227163856,1,'2020-01-01 01:01:01'),(167,20230202224725,1,'2020-01-01 01:01:01'),(168,20230206163608,1,'2020-01-01 01:01:01'),(169,20230214131519,1,'2020-01-01 01:01:01'),(170,20230303135738,1,'2020-01-01 01:01:01'),(171,20230313135301,1,'2020-01-01 01:01:01'),(172,20230313141819,1,'2020-01-01 01:01:01'),(173,20230315104937,1,'2020-01-01 01:01:01'),(174,20230317173844,1,'2020-01-01 01:01:01'),(175,20230320133602,1,'2020-01-01 01:01:01'),(176,20230330100011,1,'2020-01-01 01:01:01'),(177,20230330134823,1,'2020-01-01 01:01:01'),(178,20230405232025,1,'2020-01-01 01:01:01'),(179,20230408084104,1,'2020-01-01 01:01:01'),(180,20230411102858,1,'2020-01-01 01:01:01'),(181,20230421155932,1,'2020-01-01 01:01:01'),(182,20230425082126,1,'2020-01-01 01:01:01'),(183,20230425105727,1,'2020-01-01 01:01:01'),(184,20230501154913,1,'2020-01-01 01:01:01'),(185,20230503101418,1,'2020-01-01 01:01:01'),(186,20230515144206,1,'2020-01-01 01:01:01'),(187,20230517140952,1,'2020-01-01 01:01:01'),(188,20230517152807,1,'2020-01-01 01:01:01'),(189,20230518114155,1,'2020-01-01 01:01:01'),(190,20230520153236,1,'2020-01-01 01:01:01'),(191,20230525151159,1,'2020-01-01 01:01:01'),(192,20230530122103,1,'2020-01-01 01:01:01'),(193,20230602111827,1,'2020-01-01 01:01:01'),(194,20230608103123,1,'2020-01-01 01:01:01'),(195,20230629140529,1,'2020-01-01 01:01:01'),(196,20230629140530,1,'2020-01-01 01:01:01'),(197,20230711144622,1,'2020-01-01 01:01:01'),(198,20230721135421,1,'2020-01-01 01:01:01'),(199,20230721161508,1,'2020-01-01 01:01:01'),(200,20230726115701,1,'2020-01-01 01:01:01'),(201,20230807100822,1,'2020-01-01 01:01:01'),(202,20230814150442,1,'2020-01-01 01:01:01'),(203,20230823122728,1,'2020-01-01 01:01:01'),(204,20230906152143,1,'2020-01-01 01:01:01'),(205,20230911163618,1,'2020-01-01 01:01:01'),(206,20230912101759,1,'2020-01-01 01:01:01'),(207,20230915101341,1,'2020-01-01 01:01:01'),(208,20230918132351,1,'2020-01-01 01:01:01'),(209,20231004144339,1,'2020-01-01 01:01:01'),(210,20231009094541,1,'2020-01-01 01:01:01'),(211,20231009094542,1,'2020-01-01 01:01:01'),(212,20231009094543,1,'2020-01-01 01:01:01'),(213,20231009094544,1,'2020-01-01 01:01:01'),(214,20231016091915,1,'2020-01-01 01:01:01'),(215,20231024174135,1,'2020-01-01 01:01:01'),(216,20231025120016,1,'2020-01-01 01:01:01'),(217,20231025160156,1,'2020-01-01 01:01:01'),(218,20231031165350,1,'2020-01-01 01:01:01'),(219,20231106144110,1,'2020-01-01 01:01:01'),(220,20231107130934,1,'2020-01-01 01:01:01'),(221,20231109115838,1,'2020-01-01 01:01:01'),(222,20231121054530,1,'2020-01-01 01:01:01'),(223,20231122101320,1,'2020-01-01 01:01:01'),(224,20231130132828,1,'2020-01-01 01:01:01'),(225,20231130132931,1,'2020-01-01 01:01:01'),(226,20231204155427,1,'2020-01-01 01:01:01'),(227,20231206142340,1,'2020-01-01 01:01:01'),(228,20231207102320,1,'2020-01-01 01:01:01'),(229,20231207102321,1,'2020-01-01 01:01:01'),(230,20231207133731,1,'2020-01-01 01:01:01'),(231,20231212094238,1,'2020-01-01 01:01:01'),(232,20231212095734,1,'2020-01-01 01:01:01'),(233,20231212161121,1,'2020-01-01 01:01:01'),(234,20231215122713,1,'2020-01-01 01:01:01'),(235,20231219143041,1,'2020-01-01 01:01:01'),(236,20231224070653,1,'2020-01-01 01:01:01'),(237,20240110134315,1,'2020-01-01 01:01:01'),(238,20240119091637,1,'2020-01-01 01:01:01'),(239,20240126020642,1,'2020-01-01 01:01:01'),(240,20240126020643,1,'2020-01-01 01:01:01'),(241,20240129162819,1,'2020-01-01 01:01:01'),(242,20240130115133,1,'2020-01-01 01:01:01'),(243,20240131083822,1,'2020-01-01 01:01:01'),(244,20240205095928,1,'2020-01-01 01:01:01'),(245,20240205121956,1,'2020-01-01 01:01:01'),(246,20240209110212,1,'2020-01-01 01:01:01'),(247,20240212111533,1,'2020-01-01 01:01:01'),(248,20240221112844,1,'2020-01-01 01:01:01'),(249,20240222073518,1,'2020-01-01 01:01:01'),(250,20240222135115,1,'2020-01-01 01:01:01'),(251,20240226082255,1,'2020-01-01 01:01:01'),(252,20240228082706,1,'2020-01-01 01:01:01'),(253,20240301173035,1,'2020-01-01 01:01:01'),(254,20240302111134,1,'2020-01-01 01:01:01'),(255,20240312103753,1,'2020-01-01 01:01:01'),(256,20240313143416,1,'2020-01-01 01:01:01'),(257,20240314085226,1,'2020-01-01 01:01:01'),(258,20240314151747,1,'2020-01-01 01:01:01'),(259,20240320145650,1,'2020-01-01 01:01:01'),(260,20240327115530,1,'2020-01-01 01:01:01'),(261,20240327115617,1,'2020-01-01 01:01:01'),(262,20240408085837,1,'2020-01-01 01:01:01'),(263,20240415104633,1,'2020-01-01 01:01:01'),(264,20240430111727,1,'2020-01-01 01:01:01'),(265,20240515200020,1,'2020-01-01 01:01:01'),(266,20240521143023,1,'2020-01-01 01:01:01'),(267,20240521143024,1,'2020-01-01 01:01:01'),(268,20240601174138,1,'2020-01-01 01:01:01'),(269,20240607133721,1,'2020-01-01 01:01:01'),(270,20240612150059,1,'2020-01-01 01:01:01'),(271,20240613162201,1,'2020-01-01 01:01:01'),(272,20240613172616,1,'2020-01-01 01:01:01'),(273,20240618142419,1,'2020-01-01 01:01:01'),(274,20240625093543,1,'2020-01-01 01:01:01'),(275,20240626195531,1,'2020-01-01 01:01:01'),(276,20240702123921,1,'2020-01-01 01:01:01'),(277,20240703154849,1,'2020-01-01 01:01:01'),(278,20240707134035,1,'2020-01-01 01:01:01'),(279,20240707134036,1,'2020-01-01 01:01:01'),(280,20240709124958,1,'2020-01-01 01:01:01'),(281,20240709132642,1,'2020-01-01 01:01:01'),(282,20240709183940,1,'2020-01-01 01:01:01'),(283,20240710155623,1,'2020-01-01 01:01:01'),(284,20240723102712,1,'2020-01-01 01:01:01'),(285,20240725152735,1,'2020-01-01 01:01:01'),(286,20240725182118,1,'2020-01-01 01:01:01'),(287,20240726100517,1,'2020-01-01 01:01:01'),(288,20240730171504,1,'2020-01-01 01:01:01'),(289,20240730174056,1,'2020-01-01 01:01:01'),(290,20240730215453,1,'2020-01-01 01:01:01'),(291,20240730374423,1,'2020-01-01 01:01:01'),(292,20240801115359,1,'2020-01-01 01:01:01'),(293,20240802101043,1,'2020-01-01 01:01:01'),(294,20240802113716,1,'2020-01-01 01:01:01'),(295,20240814135330,1,'2020-01-01 01:01:01'),(296,20240815000000,1,'2020-01-01 01:01:01'),(297,20240815000001,1,'2020-01-01 01:01:01'),(298,20240816103247,1,'2020-01-01 01:01:01'),(299,20240820091218,1,'2020-01-01 01:01:01'),(300,20240826111228,1,'2020-01-01 01:01:01'),(301,20240826160025,1,'2020-01-01 01:01:01'),(302,20240829165448,1,'2020-01-01 01:01:01'),(303,20240829165605,1,'2020-01-01 01:01:01'),(304,20240829165715,1,'2020-01-01 01:01:01'),(305,20240829165930,1,'2020-01-01 01:01:01'),(306,20240829170023,1,'2020-01-01 01:01:01'),(307,20240829170033,1,'2020-01-01 01:01:01'),(308,20240829170044,1,'2020-01-01 01:01:01'),(309,20240905105135,1,'2020-01-01 01:01:01'),(310,20240905140514,1,'2020-01-01 01:01:01'),(311,20240905200000,1,'2020-01-01 01:01:01'),(312,20240905200001,1,'2020-01-01 01:01:01'),(313,20241002104104,1,'2020-01-01 01:01:01'),(314,20241002104105,1,'2020-01-01 01:01:01'),(315,20241002104106,1,'2020-01-01 01:01:01'),(316,20241002210000,1,'2020-01-01 01:01:01'),(317,20241003145349,1,'2020-01-01 01:01:01'),(318,20241004005000,1,'2020-01-01 01:01:01'),(319,20241008083925,1,'2020-01-01 01:01:01'),(320,20241009090010,1,'2020-01-01 01:01:01'),(321,20241017163402,1,'2020-01-01 01:01:01'),(322,20241021224359,1,'2020-01-01 01:01:01'),(323,20241022140321,1,'2020-01-01 01:01:01'),(324,20241025111236,1,'2020-01-01 01:01:01'),(325,20241025112748,1,'2020-01-01 01:01:01'),(326,20241025141855,1,'2020-01-01 01:01:01'),(327,20241110152839,1,'2020-01-01 01:01:01'),(328,20241110152840,1,'2020-01-01 01:01:01'),(329,20241110152841,1,'2020-01-01 01:01:01'),(330,20241116233322,1,'2020-01-01 01:01:01'),(331,20241122171434,1,'2020-01-01 01:01:01'),(332,20241125150614,1,'2020-01-01 01:01:01'),(333,20241203125346,1,'2020-01-01 01:01:01'),(334,20241203130032,1,'2020-01-01 01:01:01'),(335,20241205122800,1,'2020-01-01 01:01:01'),(336,20241209164540,1,'2020-01-01 01:01:01'),(337,20241210140021,1,'2020-01-01 01:01:01'),(338,20241219180042,1,'2020-01-01 01:01:01'),(339,20241220100000,1,'2020-01-01 01:01:01'),(340,20241220114903,1,'2020-01-01 01:01:01'),(341,20241220114904,1,'2020-01-01 01:01:01'),(342,20241224000000,1,'2020-01-01 01:01:01'),(343,20241230000000,1,'2020-01-01 01:01:01'),(344,20241231112624,1,'2020-01-01 01:01:01'),(345,20250102121439,1,'2020-01-01 01:01:01'),(346,20250121094045,1,'2020-01-01 01:01:01'),(347,20250121094500,1,'2020-01-01 01:01:01'),(348,20250121094600,1,'2020-01-01 01:01:01'),(349,20250121094700,1,'2020-01-01 01:01:01'),(350,20250124194347,1,'2020-01-01 01:01:01'),(351,20250127162751,1,'2020-01-01 01:01:01'),(352,20250213104005,1,'2020-01-01 01:01:01'),(353,20250214205657,1,'2020-01-01 01:01:01'),(354,20250217093329,1,'2020-01-01 01:01:01'),(355,20250219090511,1,'2020-01-01 01:01:01'),(356,20250219100000,1,'2020-01-01 01:01:01'),(357,20250219142401,1,'2020-01-01 01:01:01'),(358,20250224184002,1,'2020-01-01 01:01:01'),(359,20250225085436,1,'2020-01-01 01:01:01'),(360,20250226000000,1,'2020-01-01 01:01:01'),(361,20250226153445,1,'2020-01-01 01:01:01'),(362,20250304162702,1,'2020-01-01 01:01:01'),(363,20250306144233,1,'2020-01-01 01:01:01'),(364,20250313163430,1,'2020-01-01 01:01:01'),(365,20250317130944,1,'2020-01-01 01:01:01'),(366,20250318165922,1,'2020-01-01 01:01:01'),(367,20250320132525,1,'2020-01-01 01:01:01'),(368,20250320200000,1,'2020-01-01 01:01:01'),(369,20250326161930,1,'2020-01-01 01:01:01'),(370,20250326161931,1,'2020-01-01 01:01:01'),(371,20250331042354,1,'2020-01-01 01:01:01'),(372,20250331154206,1,'2020-01-01 01:01:01'),(373,20250401155831,1,'2020-01-01 01:01:01'),(374,20250408133233,1,'2020-01-01 01:01:01'),(375,20250410104321,1,'2020-01-01 01:01:01'),(376,20250421085116,1,'2020-01-01 01:01:01'),(377,20250422095806,1,'2020-01-01 01:01:01'),(378,20250424153059,1,'2020-01-01 01:01:01'),(379,20250430103833,1,'2020-01-01 01:01:01'),(380,20250430112622,1,'2020-01-01 01:01:01'),(381,20250501162727,1,'2020-01-01 01:01:01'),(382,20250502154517,1,'2020-01-01 01:01:01'),(383,20250502222222,1,'2020-01-01 01:01:01'),(384,20250507170845,1,'2020-01-01 01:01:01'),(385,20250513162912,1,'2020-01-01 01:01:01'),(386,20250519161614,1,'2020-01-01 01:01:01'),(387,20250519170000,1,'2020-01-01 01:01:01'),(388,20250520153848,1,'2020-01-01 01:01:01'),(389,20250528115932,1,'2020-01-01 01:01:01'),(390,20250529102706,1,'2020-01-01 01:01:01'),(391,20250603105558,1,'2020-01-01 01:01:01'),(392,20250609102714,1,'2020-01-01 01:01:01'),(393,20250609112613,1,'2020-01-01 01:01:01'),(394,20250613103810,1,'2020-01-01 01:01:01'),(395,20250616193950,1,'2020-01-01 01:01:01'),(396,20250624140757,1,'2020-01-01 01:01:01'),(397,20250626130239,1,'2020-01-01 01:01:01'),(398,20250629131032,1,'2020-01-01 01:01:01'),(399,20250701155654,1,'2020-01-01 01:01:01'),(400,20250707095725,1,'2020-01-01 01:01:01'),(401,20250716152435,1,'2020-01-01 01:01:01'),(402,20250718091828,1,'2020-01-01 01:01:01'),(403,20250728122229,1,'2020-01-01 01:01:01'),(404,20250731122715,1,'2020-01-01 01:01:01'),(405,20250731151000,1,'2020-01-01 01:01:01'),(406,20250803000000,1,'2020-01-01 01:01:01'),(407,20250805083116,1,'2020-01-01 01:01:01'),(408,20250807140441,1,'2020-01-01 01:01:01'),(409,20250808000000,1,'2020-01-01 01:01:01'),(410,20250811155036,1,'2020-01-01 01:01:01'),(411,20250813205039,1,'2020-01-01 01:01:01'),(412,20250814123333,1,'2020-01-01 01:01:01'),(413,20250815130115,1,'2020-01-01 01:01:01'),(414,20250816115553,1,'2020-01-01 01:01:01'),(415,20250817154557,1,'2020-01-01 01:01:01'),(416,20250825113751,1,'2020-01-01 01:01:01'),(417,20250827113140,1,'2020-01-01 01:01:01'),(418,20250828120836,1,'2020-01-01 01:01:01'),(419,20250902112642,1,'2020-01-01 01:01:01'),(420,20250904091745,1,'2020-01-01 01:01:01'),(421,20250905090000,1,'2020-01-01 01:01:01'),(422,20250922083056,1,'2020-01-01 01:01:01'),(423,20250923120000,1,'2020-01-01 01:01:01'),(424,20250926123048,1,'2020-01-01 01:01:01'),(425,20251015103505,1,'2020-01-01 01:01:01'),(426,20251015103600,1,'2020-01-01 01:01:01'),(427,20251015103700,1,'2020-01-01 01:01:01'),(428,20251015103800,1,'2020-01-01 01:01:01'),(429,20251015103900,1,'2020-01-01 01:01:01'),(430,20251028140000,1,'2020-01-01 01:01:01'),(431,20251028140100,1,'2020-01-01 01:01:01'),(432,20251028140110,1,'2020-01-01 01:01:01'),(433,20251028140200,1,'2020-01-01 01:01:01'),(434,20251028140300,1,'2020-01-01 01:01:01'),(435,20251028140400,1,'2020-01-01 01:01:01'),(436,20251031154558,1,'2020-01-01 01:01:01'),(437,20251103160848,1,'2020-01-01 01:01:01'),(438,20251104112849,1,'2020-01-01 01:01:01'),(439,20251106000000,1,'2020-01-01 01:01:01'),(440,20251107164629,1,'2020-01-01 01:01:01'),(441,20251107170854,1,'2020-01-01 01:01:01'),(442,20251110172137,1,'2020-01-01 01:01:01'),(443,20251111153133,1,'2020-01-01 01:01:01'),(444,20251117020000,1,'2020-01-01 01:01:01'),(445,20251117020100,1,'2020-01-01 01:01:01'),(446,20251117020200,1,'2020-01-01 01:01:01'),(447,20251121100000,1,'2020-01-01 01:01:01'),(448,20251121124239,1,'2020-01-01 01:01:01'),(449,20251124090450,1,'2020-01-01 01:01:01'),(450,20251124135808,1,'2020-01-01 01:01:01'),(451,20251124140138,1,'2020-01-01 01:01:01'),(452,20251124162948,1,'2020-01-01 01:01:01'),(453,20251127113559,1,'2020-01-01 01:01:01'),(454,20251202162232,1,'2020-01-01 01:01:01'),(455,20251203170808,1,'2020-01-01 01:01:01'),(456,20251207050413,1,'2020-01-01 01:01:01'),(457,20251208215800,1,'2020-01-01 01:01:01'),(458,20251209221730,1,'2020-01-01 01:01:01'),(459,20251209221850,1,'2020-01-01 01:01:01'),(460,20251215163721,1,'2020-01-01 01:01:01'),(461,20251217000000,1,'2020-01-01 01:01:01'),(462,20251217120000,1,'2020-01-01 01:01:01'),(463,20251229000000,1,'2020-01-01 01:01:01'),(464,20251229000010,1,'2020-01-01 01:01:01'),(465,20251229000020,1,'2020-01-01 01:01:01'),(466,20260106000000,1,'2020-01-01 01:01:01'),(467,20260108200708,1,'2020-01-01 01:01:01'),(468,20260108214732,1,'2020-01-01 01:01:01'),(469,20260109231821,1,'2020-01-01 01:01:01'),(470,20260113012054,1,'2020-01-01 01:01:01'),(471,20260124200020,1,'2020-01-01 01:01:01'),(472,20260126150840,1,'2020-01-01 01:01:01'),(473,20260126210724,1,'2020-01-01 01:01:01'),(474,20260202151756,1,'2020-01-01 01:01:01'),(475,20260205184907,1,'2020-01-01 01:01:01'),(476,20260210151544,1,'2020-01-01 01:01:01'),(477,20260210155109,1,'2020-01-01 01:01:01'),(478,20260210181120,1,'2020-01-01 01:01:01'),(479,20260211200153,1,'2020-01-01 01:01:01'),(480,20260217141240,1,'2020-01-01 01:01:01'),(481,20260217200906,1,'2020-01-01 01:01:01'),(482,20260218175704,1,'2020-01-01 01:01:01'),(483,20260314120000,1,'2020-01-01 01:01:01'),(484,20260316120000,1,'2020-01-01 01:01:01'),(485,20260316120001,1,'2020-01-01 01:01:01'),(486,20260316120002,1,'2020-01-01 01:01:01'),(487,20260316120003,1,'2020-01-01 01:01:01'),(488,20260316120004,1,'2020-01-01 01:01:01'),(489,20260316120005,1,'2020-01-01 01:01:01'),(490,20260316120006,1,'2020-01-01 01:01:01'),(491,20260316120007,1,'2020-01-01 01:01:01'),(492,20260316120008,1,'2020-01-01 01:01:01'),(493,20260316120009,1,'2020-01-01 01:01:01'),(494,20260316120010,1,'2020-01-01 01:01:01'),(495,20260317120000,1,'2020-01-01 01:01:01'),(496,20260318184559,1,'2020-01-01 01:01:01'),(497,20260319120000,1,'2020-01-01 01:01:01'),(498,20260323144117,1,'2020-01-01 01:01:01'),(499,20260324161944,1,'2020-01-01 01:01:01'),(500,20260324223334,1,'2020-01-01 01:01:01'),(501,20260326131501,1,'2020-01-01 01:01:01'),(502,20260326210603,1,'2020-01-01 01:01:01'),(503,20260331000000,1,'2020-01-01 01:01:01'),(504,20260401153000,1,'2020-01-01 01:01:01'),(505,20260401153001,1,'2020-01-01 01:01:01'),(506,20260401153503,1,'2020-01-01 01:01:01'),(507,20260403120000,1,'2020-01-01 01:01:01'),(508,20260409153713,1,'2020-01-01 01:01:01'),(509,20260409153714,1,'2020-01-01 01:01:01'),(510,20260409153715,1,'2020-01-01 01:01:01'),(511,20260409153716,1,'2020-01-01 01:01:01'),(512,20260409153717,1,'2020-01-01 01:01:01'),(513,20260409183610,1,'2020-01-01 01:01:01'),(514,20260410173222,1,'2020-01-01 01:01:01'),(515,20260422181702,1,'2020-01-01 01:01:01'),(516,20260423161823,1,'2020-01-01 01:01:01'),(517,20260423161824,1,'2020-01-01 01:01:01'),(518,20260518194422,1,'2020-01-01 01:01:01'),(519,20260522195224,1,'2020-01-01 01:01:01'),(520,20260522195225,1,'2020-01-01 01:01:01'),(521,20260522195226,1,'2020-01-01 01:01:01'),(522,20260522195227,1,'2020-01-01 01:01:01'),(523,20260522195229,1,'2020-01-01 01:01:01'),(524,20260522195230,1,'2020-01-01 01:01:01'),(525,20260522195231,1,'2020-01-01 01:01:01'),(526,20260522195232,1,'2020-01-01 01:01:01'),(527,20260522195233,1,'2020-01-01 01:01:01'),(528,20260522195234,1,'2020-01-01 01:01:01'),(529,20260522195235,1,'2020-01-01 01:01:01'),(530,20260527215817,1,'2020-01-01 01:01:01'),(531,20260527215818,1,'2020-01-01 01:01:01'),(532,20260528201143,1,'2020-01-01 01:01:01'),(533,20260528201150,1,'2020-01-01 01:01:01'),(534,20260528211626,1,'2020-01-01 01:01:01'),(535,20260528213326,1,'2020-01-01 01:01:01'),(536,20260529091823,1,'2020-01-01 01:01:01'),(537,20260529120000,1,'2020-01-01 01:01:01'),(538,20260601200727,1,'2020-01-01 01:01:01'),(539,20260603101320,1,'2020-01-01 01:01:01'),(540,20260603120000,1,'2020-01-01 01:01:01'),(541,20260604221206,1,'2020-01-01 01:01:01'),(542,20260605195941,1,'2020-01-01 01:01:01'),(543,20260606051849,1,'2020-01-01 01:01:01'),(544,20260608160653,1,'2020-01-01 01:01:01'),(545,20260608202705,1,'2020-01-01 01:01:01'),(546,20260608210432,1,'2020-01-01 01:01:01'),(547,20260610172952,1,'2020-01-01 01:01:01'),(548,20260624210253,1,'2020-01-01 01:01:01'),(549,20260624210311,1,'2020-01-01 01:01:01'),(550,20260626120000,1,'2020-01-01 01:01:01'),(551,20260702013055,1,'2020-01-01 01:01:01'),(552,20260702013056,1,'2020-01-01 01:01:01'),(553,20260702013057,1,'2020-01-01 01:01:01'),(554,20260702013058,1,'2020-01-01 01:01:01'),(555,20260702013059,1,'2020-01-01 01:01:01'),(556,20260702013100,1,'2020-01-01 01:01:01'),(557,20260702013101,1,'2020-01-01 01:01:01'),(558,20260702013102,1,'2020-01-01 01:01:01'),(559,20260702164518,1,'2020-01-01 01:01:01'),(560,20260717152653,1,'2020-01-01 01:01:01'),(561,20260723181401,1,'2020-01-01 01:01:01'),(562,20260723181402,1,'2020-01-01 01:01:01'),(563,20260723181403,1,'2020-01-01 01:01:01'),(564,20260723181404,1,'2020-01-01 01:01:01'),(565,20260723181405,1,'2020-01-01 01:01:01'),(566,20260723181406,1,'2020-01-01 01:01:01'),(567,20260723181407,1,'2020-01-01 01:01:01'),(568,20260723181408,1,'2020-01-01 01:01:01'),(569,20260723181409,1,'2020-01-01 01:01:01'),(570,20260723181410,1,'2020-01-01 01:01:01'),(571,20260723181411,1,'2020-01-01 01:01:01'),(572,20260724134801,1,'2020-01-01 01:01:01'),(573,20260727083533,1,'2020-01-01 01:01:01'),(574,20260727084359,1,'2020-01-01 01:01:01'),(575,20260729110229,1,'2020-01-01 01:01:01'),(576,20260729115013,1,'2020-01-01 01:01:01'),(577,20260731100711,1,'2020-01-01 01:01:01'),(578,20260731213352,1,'2020-01-01 01:01:01'),(579,20260803135530,1,'2020-01-01 01:01:01'),(580,20260803182251,1,'2020-01-01 01:01:01'),(581,20260805161502,1,'2020-01-01 01:01:01'),(582,20260806154139,1,'2020-01-01 01:01:01'),(583,20260806154150,1,'2020-01-01 01:01:01'),(584,20260806210232,1,'2020-01-01 01:01:01'),(585,20260807120050,1,'2020-01-01 01:01:01'),(586,20260807140831,1,'2020-01-01 01:01:01'),(587,20260807151355,1,'2020-01-01 01:01:01'),(588,20260810152924,1,'2020-01-01 01:01:01');
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `mobile_device_management_solutions` (
@@ -1695,6 +2376,7 @@ CREATE TABLE `nano_command_results` (
   PRIMARY KEY (`id`,`command_uuid`),
   KEY `command_uuid` (`command_uuid`),
   KEY `status` (`status`),
+  KEY `idx_ncr_lookup` (`id`,`command_uuid`,`status`),
   CONSTRAINT `nano_command_results_ibfk_1` FOREIGN KEY (`id`) REFERENCES `nano_enrollments` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `nano_command_results_ibfk_2` FOREIGN KEY (`command_uuid`) REFERENCES `nano_commands` (`command_uuid`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `nano_command_results_chk_1` CHECK ((`status` <> _utf8mb4'')),
@@ -1710,6 +2392,7 @@ CREATE TABLE `nano_commands` (
   `created_at` timestamp(6) NULL DEFAULT CURRENT_TIMESTAMP(6),
   `updated_at` timestamp(6) NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
   `subtype` enum('None','ProfileWithSecrets') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'None',
+  `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`command_uuid`),
   CONSTRAINT `nano_commands_chk_1` CHECK ((`command_uuid` <> _utf8mb4'')),
   CONSTRAINT `nano_commands_chk_2` CHECK ((`request_type` <> _utf8mb4''))
@@ -1780,6 +2463,8 @@ CREATE TABLE `nano_enrollment_queue` (
   PRIMARY KEY (`id`,`command_uuid`),
   KEY `command_uuid` (`command_uuid`),
   KEY `priority` (`priority` DESC,`created_at`),
+  KEY `idx_neq_filter` (`active`,`priority`,`created_at`),
+  KEY `idx_neq_next_command` (`id`,`active`,`priority` DESC,`created_at`),
   CONSTRAINT `nano_enrollment_queue_ibfk_1` FOREIGN KEY (`id`) REFERENCES `nano_enrollments` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `nano_enrollment_queue_ibfk_2` FOREIGN KEY (`command_uuid`) REFERENCES `nano_commands` (`command_uuid`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -1800,6 +2485,7 @@ CREATE TABLE `nano_enrollments` (
   `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   `enrolled_from_migration` tinyint unsigned NOT NULL DEFAULT '0',
+  `hardware_attested` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `user_id` (`user_id`),
   KEY `device_id` (`device_id`),
@@ -1864,6 +2550,7 @@ SET @saved_cs_client     = @@character_set_client;
  1 AS `command_uuid`,
  1 AS `request_type`,
  1 AS `command`,
+ 1 AS `name`,
  1 AS `result_updated_at`,
  1 AS `status`,
  1 AS `result`*/;
@@ -1900,6 +2587,22 @@ CREATE TABLE `network_interfaces` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `operating_system_version_vulnerabilities` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `os_version_id` int unsigned NOT NULL,
+  `cve` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `team_id` int unsigned DEFAULT NULL,
+  `source` smallint DEFAULT '0',
+  `resolved_in_version` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`id`),
+  KEY `idx_os_version_vulnerabilities_os_version_team_cve` (`team_id`,`os_version_id`,`cve`),
+  KEY `idx_os_version_vulnerabilities_updated_at` (`updated_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `operating_system_vulnerabilities` (
   `id` int unsigned NOT NULL AUTO_INCREMENT,
   `operating_system_id` int unsigned NOT NULL,
@@ -1919,13 +2622,23 @@ CREATE TABLE `operating_systems` (
   `id` int unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   `version` varchar(150) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `arch` varchar(150) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `arch` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `kernel_version` varchar(150) COLLATE utf8mb4_unicode_ci NOT NULL,
   `platform` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,
   `display_version` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `os_version_id` int unsigned DEFAULT NULL,
+  `installation_type` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   PRIMARY KEY (`id`),
-  UNIQUE KEY `idx_unique_os` (`name`,`version`,`arch`,`kernel_version`,`platform`,`display_version`)
+  UNIQUE KEY `idx_unique_os` (`name`,`version`,`arch`,`kernel_version`,`platform`,`display_version`,`installation_type`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `org_logo` (
+  `mode` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `data` mediumblob NOT NULL,
+  `uploaded_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`mode`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -1974,7 +2687,7 @@ CREATE TABLE `password_reset_requests` (
   `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   `user_id` int unsigned NOT NULL,
-  `token` varchar(1024) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `token` varchar(1024) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
@@ -1998,13 +2711,21 @@ CREATE TABLE `policies` (
   `script_id` int unsigned DEFAULT NULL,
   `vpp_apps_teams_id` int unsigned DEFAULT NULL,
   `conditional_access_enabled` tinyint unsigned NOT NULL DEFAULT '0',
+  `type` enum('dynamic','patch') COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'dynamic',
+  `patch_software_title_id` int unsigned DEFAULT NULL,
+  `needs_full_membership_cleanup` tinyint(1) NOT NULL DEFAULT '0',
+  `continuous_automations_enabled` tinyint(1) NOT NULL DEFAULT '0',
+  `patch_when_closed` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_policies_checksum` (`checksum`),
+  UNIQUE KEY `idx_team_id_patch_software_title_id` (`team_id`,`patch_software_title_id`),
   KEY `idx_policies_author_id` (`author_id`),
   KEY `idx_policies_team_id` (`team_id`),
   KEY `fk_policies_software_installer_id` (`software_installer_id`),
   KEY `fk_policies_script_id` (`script_id`),
   KEY `fk_policies_vpp_apps_team_id` (`vpp_apps_teams_id`),
+  KEY `fk_patch_software_title_id` (`patch_software_title_id`),
+  CONSTRAINT `fk_patch_software_title_id` FOREIGN KEY (`patch_software_title_id`) REFERENCES `software_titles` (`id`) ON DELETE CASCADE,
   CONSTRAINT `policies_ibfk_3` FOREIGN KEY (`software_installer_id`) REFERENCES `software_installers` (`id`),
   CONSTRAINT `policies_ibfk_4` FOREIGN KEY (`script_id`) REFERENCES `scripts` (`id`),
   CONSTRAINT `policies_ibfk_5` FOREIGN KEY (`vpp_apps_teams_id`) REFERENCES `vpp_apps_teams` (`id`),
@@ -2029,6 +2750,7 @@ CREATE TABLE `policy_labels` (
   `exclude` tinyint(1) NOT NULL DEFAULT '0',
   `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `require_all` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_policy_labels_policy_label` (`policy_id`,`label_id`),
   KEY `policy_labels_label_id` (`label_id`),
@@ -2106,6 +2828,7 @@ CREATE TABLE `query_labels` (
   `label_id` int unsigned NOT NULL,
   `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `require_all` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_query_labels_query_label` (`query_id`,`label_id`),
   KEY `query_labels_label_id` (`label_id`),
@@ -2123,34 +2846,11 @@ CREATE TABLE `query_results` (
   `error` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `last_fetched` timestamp NOT NULL,
   `data` json DEFAULT NULL,
+  `has_data` tinyint(1) GENERATED ALWAYS AS ((`data` is not null)) VIRTUAL,
   PRIMARY KEY (`id`),
-  KEY `idx_query_id_host_id_last_fetched` (`query_id`,`host_id`,`last_fetched`)
+  KEY `idx_query_id_host_id_last_fetched` (`query_id`,`host_id`,`last_fetched`),
+  KEY `idx_query_id_has_data_host_id_last_fetched` (`query_id`,`has_data`,`host_id`,`last_fetched`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-/*!40101 SET character_set_client = @saved_cs_client */;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
-CREATE TABLE `scep_certificates` (
-  `serial` bigint NOT NULL,
-  `name` varchar(1024) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `not_valid_before` datetime NOT NULL,
-  `not_valid_after` datetime NOT NULL,
-  `certificate_pem` text COLLATE utf8mb4_unicode_ci NOT NULL,
-  `revoked` tinyint(1) NOT NULL DEFAULT '0',
-  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
-  `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  PRIMARY KEY (`serial`),
-  CONSTRAINT `scep_certificates_ibfk_1` FOREIGN KEY (`serial`) REFERENCES `scep_serials` (`serial`),
-  CONSTRAINT `scep_certificates_chk_1` CHECK ((substr(`certificate_pem`,1,27) = _utf8mb4'-----BEGIN CERTIFICATE-----')),
-  CONSTRAINT `scep_certificates_chk_2` CHECK (((`name` is null) or (`name` <> _utf8mb4'')))
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-/*!40101 SET character_set_client = @saved_cs_client */;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
-CREATE TABLE `scep_serials` (
-  `serial` bigint NOT NULL AUTO_INCREMENT,
-  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY (`serial`)
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
@@ -2197,6 +2897,18 @@ CREATE TABLE `scheduled_query_stats` (
   `query_type` tinyint NOT NULL DEFAULT '0',
   PRIMARY KEY (`host_id`,`scheduled_query_id`,`query_type`),
   KEY `scheduled_query_id` (`scheduled_query_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `scim_group_group` (
+  `parent_group_id` int unsigned NOT NULL,
+  `child_group_id` int unsigned NOT NULL,
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`parent_group_id`,`child_group_id`),
+  KEY `idx_scim_group_group_child` (`child_group_id`),
+  CONSTRAINT `fk_scim_group_group_child` FOREIGN KEY (`child_group_id`) REFERENCES `scim_groups` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_scim_group_group_parent` FOREIGN KEY (`parent_group_id`) REFERENCES `scim_groups` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -2363,6 +3075,18 @@ CREATE TABLE `setup_experience_scripts` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `setup_experience_software_installers` (
+  `software_installer_id` int unsigned NOT NULL,
+  `platform` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `global_or_team_id` int unsigned NOT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`software_installer_id`,`platform`),
+  KEY `idx_seti_team_platform` (`global_or_team_id`,`platform`),
+  CONSTRAINT `fk_seti_installer` FOREIGN KEY (`software_installer_id`) REFERENCES `software_installers` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `setup_experience_status_results` (
   `id` int unsigned NOT NULL AUTO_INCREMENT,
   `host_uuid` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
@@ -2375,6 +3099,7 @@ CREATE TABLE `setup_experience_status_results` (
   `setup_experience_script_id` int unsigned DEFAULT NULL,
   `script_execution_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `error` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `policy_gated` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `idx_setup_experience_scripts_host_uuid` (`host_uuid`),
   KEY `idx_setup_experience_scripts_hsi_id` (`host_software_installs_execution_id`),
@@ -2406,24 +3131,29 @@ CREATE TABLE `software` (
   `checksum` binary(16) NOT NULL,
   `name_source` enum('basic','bundle_4.67') COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'basic',
   `application_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `upgrade_code` char(38) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_software_checksum` (`checksum`),
   KEY `software_source_vendor_idx` (`source`,`vendor_old`),
   KEY `title_id` (`title_id`),
   KEY `idx_sw_name_source_browser` (`name`,`source`,`extension_for`),
-  KEY `software_listing_idx` (`name`)
+  KEY `software_listing_idx` (`name`),
+  KEY `idx_software_bundle_identifier` (`bundle_identifier`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `software_categories` (
   `id` int unsigned NOT NULL AUTO_INCREMENT,
-  `name` varchar(63) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `team_id` int unsigned NOT NULL DEFAULT '0',
+  `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
   PRIMARY KEY (`id`),
-  UNIQUE KEY `idx_software_categories_name` (`name`)
-) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+  UNIQUE KEY `idx_software_categories_team_id_name` (`team_id`,`name`)
+) ENGINE=InnoDB AUTO_INCREMENT=8 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
-INSERT INTO `software_categories` VALUES (2,'Browsers'),(3,'Communication'),(4,'Developer tools'),(1,'Productivity');
+INSERT INTO `software_categories` VALUES (1,'🖥️ Productivity',0,'2026-05-29 00:00:00.000000','2026-05-29 00:00:00.000000'),(2,'🌎 Browsers',0,'2026-05-29 00:00:00.000000','2026-05-29 00:00:00.000000'),(3,'👬 Communication',0,'2026-05-29 00:00:00.000000','2026-05-29 00:00:00.000000'),(4,'🧰 Developer tools',0,'2026-05-29 00:00:00.000000','2026-05-29 00:00:00.000000'),(5,'🔐 Security',0,'2026-05-29 00:00:00.000000','2026-05-29 00:00:00.000000'),(6,'🛠️ Utilities',0,'2026-05-29 00:00:00.000000','2026-05-29 00:00:00.000000'),(7,'🛟 Support',0,'2026-05-29 00:00:00.000000','2026-05-29 00:00:00.000000');
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `software_cpe` (
@@ -2464,7 +3194,8 @@ CREATE TABLE `software_host_counts` (
   `global_stats` tinyint unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`software_id`,`team_id`,`global_stats`),
   KEY `idx_software_host_counts_updated_at_software_id` (`updated_at`,`software_id`),
-  KEY `idx_software_host_counts_team_id_hosts_count_software_id` (`team_id`,`hosts_count`,`software_id`)
+  KEY `idx_software_host_counts_team_global_hosts_desc` (`team_id`,`global_stats`,`hosts_count` DESC,`software_id`),
+  CONSTRAINT `software_host_counts_chk_1` CHECK ((`hosts_count` > 0))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -2495,6 +3226,7 @@ CREATE TABLE `software_installer_labels` (
   `exclude` tinyint(1) NOT NULL DEFAULT '0',
   `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
   `updated_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  `require_all` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_software_installer_labels_software_installer_id_label_id` (`software_installer_id`,`label_id`),
   KEY `label_id` (`label_id`),
@@ -2543,16 +3275,21 @@ CREATE TABLE `software_installers` (
   `fleet_maintained_app_id` int unsigned DEFAULT NULL,
   `install_during_setup` tinyint(1) NOT NULL DEFAULT '0',
   `upgrade_code` varchar(48) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `is_active` tinyint(1) NOT NULL DEFAULT '0',
+  `patch_query` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `http_etag` varchar(512) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `dedup_token` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci GENERATED ALWAYS AS (if((`fleet_maintained_app_id` is null),`storage_id`,`version`)) VIRTUAL,
+  `app_open_query` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT (_utf8mb4''),
   PRIMARY KEY (`id`),
-  UNIQUE KEY `idx_software_installers_team_id_title_id` (`global_or_team_id`,`title_id`),
+  UNIQUE KEY `idx_software_installers_dedup` (`global_or_team_id`,`title_id`,`dedup_token`),
   KEY `fk_software_installers_title` (`title_id`),
   KEY `fk_software_installers_install_script_content_id` (`install_script_content_id`),
   KEY `fk_software_installers_post_install_script_content_id` (`post_install_script_content_id`),
   KEY `fk_software_installers_team_id` (`team_id`),
-  KEY `idx_software_installers_platform_title_id` (`platform`,`title_id`),
   KEY `fk_software_installers_user_id` (`user_id`),
   KEY `fk_uninstall_script_content_id` (`uninstall_script_content_id`),
   KEY `fk_software_installers_fleet_library_app_id` (`fleet_maintained_app_id`),
+  KEY `idx_software_installers_team_url` (`global_or_team_id`,`url`(255)),
   CONSTRAINT `fk_software_installers_install_script_content_id` FOREIGN KEY (`install_script_content_id`) REFERENCES `script_contents` (`id`) ON DELETE RESTRICT ON UPDATE CASCADE,
   CONSTRAINT `fk_software_installers_post_install_script_content_id` FOREIGN KEY (`post_install_script_content_id`) REFERENCES `script_contents` (`id`) ON DELETE RESTRICT ON UPDATE CASCADE,
   CONSTRAINT `fk_software_installers_team_id` FOREIGN KEY (`team_id`) REFERENCES `teams` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
@@ -2560,6 +3297,20 @@ CREATE TABLE `software_installers` (
   CONSTRAINT `fk_software_installers_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL,
   CONSTRAINT `fk_uninstall_script_content_id` FOREIGN KEY (`uninstall_script_content_id`) REFERENCES `script_contents` (`id`) ON DELETE RESTRICT ON UPDATE CASCADE,
   CONSTRAINT `software_installers_ibfk_1` FOREIGN KEY (`fleet_maintained_app_id`) REFERENCES `fleet_maintained_apps` (`id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `software_title_display_names` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `team_id` int unsigned NOT NULL,
+  `software_title_id` int unsigned NOT NULL,
+  `display_name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_unique_team_id_title_id` (`team_id`,`software_title_id`),
+  KEY `software_title_id` (`software_title_id`),
+  CONSTRAINT `software_title_display_names_ibfk_1` FOREIGN KEY (`software_title_id`) REFERENCES `software_titles` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -2580,6 +3331,18 @@ CREATE TABLE `software_title_icons` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `software_title_team_pins` (
+  `team_id` int unsigned NOT NULL,
+  `title_id` int unsigned NOT NULL,
+  `pinned_version` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `updated_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`team_id`,`title_id`),
+  KEY `fk_pin_title` (`title_id`),
+  CONSTRAINT `fk_pin_title` FOREIGN KEY (`title_id`) REFERENCES `software_titles` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `software_titles` (
   `id` int unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
@@ -2589,7 +3352,8 @@ CREATE TABLE `software_titles` (
   `additional_identifier` tinyint unsigned GENERATED ALWAYS AS ((case when (`source` = _utf8mb4'ios_apps') then 1 when (`source` = _utf8mb4'ipados_apps') then 2 when (`bundle_identifier` is not null) then 0 else NULL end)) VIRTUAL,
   `is_kernel` tinyint(1) NOT NULL DEFAULT '0',
   `application_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `unique_identifier` varchar(255) COLLATE utf8mb4_unicode_ci GENERATED ALWAYS AS (coalesce(`bundle_identifier`,`application_id`,`name`)) VIRTUAL,
+  `upgrade_code` varchar(38) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `unique_identifier` varchar(255) COLLATE utf8mb4_unicode_ci GENERATED ALWAYS AS (coalesce(`bundle_identifier`,`application_id`,nullif(`upgrade_code`,_utf8mb4''),`name`)) VIRTUAL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_software_titles_bundle_identifier` (`bundle_identifier`,`additional_identifier`),
   UNIQUE KEY `idx_unique_sw_titles` (`unique_identifier`,`source`,`extension_for`),
@@ -2606,8 +3370,24 @@ CREATE TABLE `software_titles_host_counts` (
   `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   `global_stats` tinyint unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`software_title_id`,`team_id`,`global_stats`),
-  KEY `idx_software_titles_host_counts_team_counts_title` (`team_id`,`hosts_count`,`software_title_id`),
-  KEY `idx_software_titles_host_counts_updated_at_software_title_id` (`updated_at`,`software_title_id`)
+  KEY `idx_software_titles_host_counts_updated_at_software_title_id` (`updated_at`,`software_title_id`),
+  KEY `idx_software_titles_host_counts_team_global_hosts` (`team_id`,`global_stats`,`hosts_count`,`software_title_id`),
+  CONSTRAINT `software_titles_host_counts_chk_1` CHECK ((`hosts_count` > 0))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `software_update_schedules` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `team_id` int unsigned NOT NULL,
+  `title_id` int unsigned NOT NULL,
+  `enabled` tinyint(1) NOT NULL DEFAULT '0',
+  `start_time` char(5) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `end_time` char(5) COLLATE utf8mb4_unicode_ci NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_team_title` (`team_id`,`title_id`),
+  KEY `title_id` (`title_id`),
+  CONSTRAINT `software_update_schedules_ibfk_1` FOREIGN KEY (`title_id`) REFERENCES `software_titles` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -2637,6 +3417,21 @@ CREATE TABLE `teams` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `trace_sampler_settings` (
+  `id` tinyint unsigned NOT NULL,
+  `high_volume_ratio` double NOT NULL DEFAULT '0.001',
+  `standard_ratio` double NOT NULL DEFAULT '0.02',
+  `force_full` tinyint(1) NOT NULL DEFAULT '0',
+  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  CONSTRAINT `ck_trace_sampler_settings_high_range` CHECK ((`high_volume_ratio` between 0 and 1)),
+  CONSTRAINT `ck_trace_sampler_settings_singleton` CHECK ((`id` = 1)),
+  CONSTRAINT `ck_trace_sampler_settings_std_range` CHECK ((`standard_ratio` between 0 and 1))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+INSERT INTO `trace_sampler_settings` VALUES (1,0.001,0.02,0,'2026-06-01 00:00:00');
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `upcoming_activities` (
   `id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `host_id` int unsigned NOT NULL,
@@ -2655,6 +3450,17 @@ CREATE TABLE `upcoming_activities` (
   KEY `idx_upcoming_activities_host_id_activity_type` (`activity_type`,`host_id`),
   KEY `fk_upcoming_activities_user_id` (`user_id`),
   CONSTRAINT `fk_upcoming_activities_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `user_api_endpoints` (
+  `user_id` int unsigned NOT NULL,
+  `path` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `method` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`user_id`,`path`,`method`),
+  CONSTRAINT `user_api_endpoints_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -2690,7 +3496,8 @@ CREATE TABLE `users` (
   `invite_id` int unsigned DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_user_unique_email` (`email`),
-  UNIQUE KEY `invite_id` (`invite_id`)
+  UNIQUE KEY `invite_id` (`invite_id`),
+  KEY `idx_users_name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -2719,6 +3526,22 @@ CREATE TABLE `verification_tokens` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `vpp_app_configurations` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `application_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `team_id` int unsigned NOT NULL,
+  `platform` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `configuration` mediumtext COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_vpp_app_config_team_app_platform` (`team_id`,`application_id`,`platform`),
+  KEY `fk_vpp_app_configurations_app` (`application_id`,`platform`),
+  CONSTRAINT `fk_vpp_app_configurations_app` FOREIGN KEY (`application_id`, `platform`) REFERENCES `vpp_apps` (`adam_id`, `platform`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `vpp_app_team_labels` (
   `id` int unsigned NOT NULL AUTO_INCREMENT,
   `vpp_app_team_id` int unsigned NOT NULL,
@@ -2726,6 +3549,7 @@ CREATE TABLE `vpp_app_team_labels` (
   `exclude` tinyint(1) NOT NULL DEFAULT '0',
   `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
   `updated_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  `require_all` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_vpp_app_team_labels_vpp_app_team_id_label_id` (`vpp_app_team_id`,`label_id`),
   KEY `label_id` (`label_id`),
@@ -2751,17 +3575,17 @@ CREATE TABLE `vpp_app_team_software_categories` (
 /*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `vpp_app_upcoming_activities` (
   `upcoming_activity_id` bigint unsigned NOT NULL,
-  `adam_id` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `adam_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `platform` varchar(10) COLLATE utf8mb4_unicode_ci NOT NULL,
   `vpp_token_id` int unsigned DEFAULT NULL,
   `policy_id` int unsigned DEFAULT NULL,
   `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
   `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
   PRIMARY KEY (`upcoming_activity_id`),
-  KEY `fk_vpp_app_upcoming_activities_adam_id_platform` (`adam_id`,`platform`),
   KEY `fk_vpp_app_upcoming_activities_vpp_token_id` (`vpp_token_id`),
   KEY `fk_vpp_app_upcoming_activities_policy_id` (`policy_id`),
-  CONSTRAINT `fk_vpp_app_upcoming_activities_adam_id_platform` FOREIGN KEY (`adam_id`, `platform`) REFERENCES `vpp_apps` (`adam_id`, `platform`) ON DELETE CASCADE,
+  KEY `fk_vpp_app_upcoming_activities_adam_id_platform` (`adam_id`,`platform`),
+  CONSTRAINT `fk_vpp_app_upcoming_activities_adam_id_platform` FOREIGN KEY (`adam_id`, `platform`) REFERENCES `vpp_apps` (`adam_id`, `platform`),
   CONSTRAINT `fk_vpp_app_upcoming_activities_policy_id` FOREIGN KEY (`policy_id`) REFERENCES `policies` (`id`) ON DELETE SET NULL,
   CONSTRAINT `fk_vpp_app_upcoming_activities_upcoming_activity_id` FOREIGN KEY (`upcoming_activity_id`) REFERENCES `upcoming_activities` (`id`) ON DELETE CASCADE,
   CONSTRAINT `fk_vpp_app_upcoming_activities_vpp_token_id` FOREIGN KEY (`vpp_token_id`) REFERENCES `vpp_tokens` (`id`) ON DELETE SET NULL
@@ -2770,7 +3594,7 @@ CREATE TABLE `vpp_app_upcoming_activities` (
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `vpp_apps` (
-  `adam_id` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `adam_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `title_id` int unsigned DEFAULT NULL,
   `bundle_identifier` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `icon_url` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
@@ -2779,6 +3603,7 @@ CREATE TABLE `vpp_apps` (
   `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   `platform` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `country_code` varchar(4) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`adam_id`,`platform`),
   KEY `fk_vpp_apps_title` (`title_id`),
   CONSTRAINT `fk_vpp_apps_title` FOREIGN KEY (`title_id`) REFERENCES `software_titles` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
@@ -2788,12 +3613,12 @@ CREATE TABLE `vpp_apps` (
 /*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `vpp_apps_teams` (
   `id` int unsigned NOT NULL AUTO_INCREMENT,
-  `adam_id` varchar(16) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `adam_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `team_id` int unsigned DEFAULT NULL,
   `global_or_team_id` int NOT NULL DEFAULT '0',
   `platform` varchar(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `self_service` tinyint(1) NOT NULL DEFAULT '0',
-  `vpp_token_id` int unsigned NOT NULL,
+  `vpp_token_id` int unsigned DEFAULT NULL,
   `install_during_setup` tinyint(1) NOT NULL DEFAULT '0',
   `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
   `updated_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
@@ -2802,9 +3627,25 @@ CREATE TABLE `vpp_apps_teams` (
   KEY `team_id` (`team_id`),
   KEY `adam_id` (`adam_id`,`platform`),
   KEY `fk_vpp_apps_teams_vpp_token_id` (`vpp_token_id`),
-  CONSTRAINT `fk_vpp_apps_teams_vpp_token_id` FOREIGN KEY (`vpp_token_id`) REFERENCES `vpp_tokens` (`id`) ON DELETE CASCADE,
   CONSTRAINT `vpp_apps_teams_ibfk_2` FOREIGN KEY (`team_id`) REFERENCES `teams` (`id`) ON DELETE CASCADE,
   CONSTRAINT `vpp_apps_teams_ibfk_3` FOREIGN KEY (`adam_id`, `platform`) REFERENCES `vpp_apps` (`adam_id`, `platform`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `vpp_client_users` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `vpp_token_id` int unsigned NOT NULL,
+  `managed_apple_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `client_user_id` varchar(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `apple_user_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `status` enum('pending','registered','retired') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'pending',
+  `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_vpp_client_users_token_apple_id` (`vpp_token_id`,`managed_apple_id`),
+  UNIQUE KEY `idx_vpp_client_users_token_client_user_id` (`vpp_token_id`,`client_user_id`),
+  CONSTRAINT `fk_vpp_client_users_vpp_token_id` FOREIGN KEY (`vpp_token_id`) REFERENCES `vpp_tokens` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -2831,6 +3672,7 @@ CREATE TABLE `vpp_tokens` (
   `token` blob NOT NULL,
   `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `country_code` varchar(4) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_vpp_tokens_location` (`location`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -2844,7 +3686,8 @@ CREATE TABLE `vulnerability_host_counts` (
   `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   `global_stats` tinyint(1) NOT NULL DEFAULT '0',
-  UNIQUE KEY `cve_team_id_global_stats` (`cve`,`team_id`,`global_stats`)
+  UNIQUE KEY `cve_team_id_global_stats` (`cve`,`team_id`,`global_stats`),
+  KEY `idx_vhc_scope_cve` (`global_stats`,`team_id`,`host_count`,`cve`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -2854,8 +3697,11 @@ CREATE TABLE `windows_mdm_command_queue` (
   `command_uuid` varchar(127) COLLATE utf8mb4_unicode_ci NOT NULL,
   `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `acked_at` datetime(6) DEFAULT NULL,
   PRIMARY KEY (`enrollment_id`,`command_uuid`),
   KEY `command_uuid` (`command_uuid`),
+  KEY `idx_win_mdm_cmd_queue_enrollment_acked` (`enrollment_id`,`acked_at`),
+  KEY `idx_win_mdm_cmd_queue_acked` (`acked_at`),
   CONSTRAINT `windows_mdm_command_queue_ibfk_1` FOREIGN KEY (`enrollment_id`) REFERENCES `mdm_windows_enrollments` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `windows_mdm_command_queue_ibfk_2` FOREIGN KEY (`command_uuid`) REFERENCES `windows_mdm_commands` (`command_uuid`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -2874,7 +3720,6 @@ CREATE TABLE `windows_mdm_command_results` (
   KEY `command_uuid` (`command_uuid`),
   KEY `response_id` (`response_id`),
   CONSTRAINT `windows_mdm_command_results_ibfk_1` FOREIGN KEY (`enrollment_id`) REFERENCES `mdm_windows_enrollments` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `windows_mdm_command_results_ibfk_2` FOREIGN KEY (`command_uuid`) REFERENCES `windows_mdm_commands` (`command_uuid`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `windows_mdm_command_results_ibfk_3` FOREIGN KEY (`response_id`) REFERENCES `windows_mdm_responses` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
@@ -2894,24 +3739,12 @@ CREATE TABLE `windows_mdm_commands` (
 CREATE TABLE `windows_mdm_responses` (
   `id` int unsigned NOT NULL AUTO_INCREMENT,
   `enrollment_id` int unsigned NOT NULL,
-  `raw_response` mediumtext COLLATE utf8mb4_unicode_ci NOT NULL,
   `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `raw_response_gz` mediumblob NOT NULL,
   PRIMARY KEY (`id`),
   KEY `enrollment_id` (`enrollment_id`),
   CONSTRAINT `windows_mdm_responses_ibfk_1` FOREIGN KEY (`enrollment_id`) REFERENCES `mdm_windows_enrollments` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-/*!40101 SET character_set_client = @saved_cs_client */;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!50503 SET character_set_client = utf8mb4 */;
-CREATE TABLE `windows_updates` (
-  `id` int unsigned NOT NULL AUTO_INCREMENT,
-  `host_id` int unsigned NOT NULL,
-  `date_epoch` int unsigned NOT NULL,
-  `kb_id` int unsigned NOT NULL,
-  PRIMARY KEY (`id`),
-  UNIQUE KEY `idx_unique_windows_updates` (`host_id`,`kb_id`),
-  KEY `idx_update_date` (`host_id`,`date_epoch`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
@@ -2966,7 +3799,7 @@ CREATE TABLE `yara_rules` (
 /*!50001 SET collation_connection      = utf8mb4_unicode_ci */;
 /*!50001 CREATE ALGORITHM=UNDEFINED */
 /*!50013 DEFINER=`root`@`%` SQL SECURITY INVOKER */
-/*!50001 VIEW `nano_view_queue` AS select (`q`.`id` collate utf8mb4_unicode_ci) AS `id`,`q`.`created_at` AS `created_at`,`q`.`active` AS `active`,`q`.`priority` AS `priority`,(`c`.`command_uuid` collate utf8mb4_unicode_ci) AS `command_uuid`,(`c`.`request_type` collate utf8mb4_unicode_ci) AS `request_type`,(`c`.`command` collate utf8mb4_unicode_ci) AS `command`,`r`.`updated_at` AS `result_updated_at`,(`r`.`status` collate utf8mb4_unicode_ci) AS `status`,(`r`.`result` collate utf8mb4_unicode_ci) AS `result` from ((`nano_enrollment_queue` `q` join `nano_commands` `c` on((`q`.`command_uuid` = `c`.`command_uuid`))) left join `nano_command_results` `r` on(((`r`.`command_uuid` = `q`.`command_uuid`) and (`r`.`id` = `q`.`id`)))) order by `q`.`priority` desc,`q`.`created_at` */;
+/*!50001 VIEW `nano_view_queue` AS select (`q`.`id` collate utf8mb4_unicode_ci) AS `id`,`q`.`created_at` AS `created_at`,`q`.`active` AS `active`,`q`.`priority` AS `priority`,(`c`.`command_uuid` collate utf8mb4_unicode_ci) AS `command_uuid`,(`c`.`request_type` collate utf8mb4_unicode_ci) AS `request_type`,(`c`.`command` collate utf8mb4_unicode_ci) AS `command`,`c`.`name` AS `name`,`r`.`updated_at` AS `result_updated_at`,(`r`.`status` collate utf8mb4_unicode_ci) AS `status`,(`r`.`result` collate utf8mb4_unicode_ci) AS `result` from ((`nano_enrollment_queue` `q` join `nano_commands` `c` on((`q`.`command_uuid` = `c`.`command_uuid`))) left join `nano_command_results` `r` on(((`r`.`command_uuid` = `q`.`command_uuid`) and (`r`.`id` = `q`.`id`)))) order by `q`.`priority` desc,`q`.`created_at` */;
 /*!50001 SET character_set_client      = @saved_cs_client */;
 /*!50001 SET character_set_results     = @saved_cs_results */;
 /*!50001 SET collation_connection      = @saved_col_connection */;

--- a/server/datastore/mysql/schema-mariadb.sql
+++ b/server/datastore/mysql/schema-mariadb.sql
@@ -3804,4 +3804,29 @@ CREATE TABLE `yara_rules` (
 /*!50001 SET character_set_results     = @saved_cs_results */;
 /*!50001 SET collation_connection      = @saved_col_connection */;
 
+DROP FUNCTION IF EXISTS UUID_TO_BIN;
+DROP FUNCTION IF EXISTS BIN_TO_UUID;
+
+CREATE FUNCTION UUID_TO_BIN(uuid CHAR(36), swap BOOLEAN)
+RETURNS BINARY(16) DETERMINISTIC
+RETURN UNHEX(
+  IF(swap,
+    CONCAT(SUBSTRING(uuid,15,4), SUBSTRING(uuid,10,4), SUBSTRING(uuid,1,8),
+           SUBSTRING(uuid,20,4), SUBSTRING(uuid,25,12)),
+    CONCAT(SUBSTRING(uuid,1,8), SUBSTRING(uuid,10,4), SUBSTRING(uuid,15,4),
+           SUBSTRING(uuid,20,4), SUBSTRING(uuid,25,12))
+  )
+);
+
+CREATE FUNCTION BIN_TO_UUID(b BINARY(16), swap BOOLEAN)
+RETURNS CHAR(36) DETERMINISTIC
+RETURN LOWER(
+  IF(swap,
+    CONCAT(SUBSTRING(HEX(b),9,8), '-', SUBSTRING(HEX(b),5,4), '-', SUBSTRING(HEX(b),1,4), '-',
+           SUBSTRING(HEX(b),17,4), '-', SUBSTRING(HEX(b),21,12)),
+    CONCAT(SUBSTRING(HEX(b),1,8), '-', SUBSTRING(HEX(b),9,4), '-', SUBSTRING(HEX(b),13,4), '-',
+           SUBSTRING(HEX(b),17,4), '-', SUBSTRING(HEX(b),21,12))
+  )
+);
+
 SET FOREIGN_KEY_CHECKS=1;

--- a/server/datastore/mysql/scim.go
+++ b/server/datastore/mysql/scim.go
@@ -1842,7 +1842,7 @@ func triggerResendDeviceNamesForIDPChange(ctx context.Context, tx sqlx.ExtContex
 		WHERE h.id IN (?)
 			AND COALESCE(CASE WHEN h.team_id IS NULL
 				THEN ` + deviceNameNoTeamTemplateExpr + `
-				ELSE t.config->>'$.mdm.name_template' END, '') REGEXP ?`
+				ELSE JSON_UNQUOTE(JSON_EXTRACT(t.config, '$.mdm.name_template')) END, '') REGEXP ?`
 
 	// The trailing word boundary keeps a changed HOST_END_USER_IDP_USERNAME from
 	// matching a template that only uses HOST_END_USER_IDP_USERNAME_LOCAL_PART, the

--- a/server/datastore/mysql/scripts.go
+++ b/server/datastore/mysql/scripts.go
@@ -72,7 +72,7 @@ func (ds *Datastore) newHostScriptExecutionRequest(ctx context.Context, tx sqlx.
 		getStmt = `
 SELECT
 	ua.id, ua.host_id, ua.execution_id, ua.created_at, sua.script_id, sua.policy_id, ua.user_id,
-	payload->'$.sync_request' AS sync_request,
+	JSON_EXTRACT(payload, '$.sync_request') AS sync_request,
 	sc.contents as script_contents, sua.setup_experience_script_id
 FROM
 	upcoming_activities ua
@@ -320,7 +320,7 @@ func (ds *Datastore) listUpcomingHostScriptExecutions(ctx context.Context, hostI
 	extraWhere := ""
 	if onlyShowInternal {
 		// software_uninstalls are implicitly internal
-		extraWhere = " AND COALESCE(ua.payload->'$.is_internal', 1) = 1"
+		extraWhere = " AND COALESCE(JSON_EXTRACT(ua.payload, '$.is_internal'), 1) = 1"
 	}
 	if onlyReadyToExecute {
 		extraWhere += " AND ua.activated_at IS NOT NULL"
@@ -459,7 +459,7 @@ func (ds *Datastore) getHostScriptExecutionResultDB(ctx context.Context, q sqlx.
 		NULL as timeout,
 		ua.created_at,
 		ua.user_id,
-		COALESCE(ua.payload->'$.sync_request', 0) as sync_request,
+		COALESCE(JSON_EXTRACT(ua.payload, '$.sync_request'), 0) as sync_request,
 		NULL as host_deleted_at,
 		sua.setup_experience_script_id,
 		0 as canceled,
@@ -838,7 +838,7 @@ func (ds *Datastore) DeleteScript(ctx context.Context, id uint) error {
 			WHERE sua.script_id = ? AND
 				ua.activity_type = 'script' AND
 				ua.activated_at IS NOT NULL AND
-				(ua.payload->'$.sync_request' = 0 OR
+				(JSON_EXTRACT(ua.payload, '$.sync_request') = 0 OR
 					ua.created_at >= NOW() - INTERVAL ? SECOND)`
 		var affectedHosts []uint
 		if err := sqlx.SelectContext(ctx, tx, &affectedHosts, loadAffectedHostsStmt,
@@ -853,7 +853,7 @@ func (ds *Datastore) DeleteScript(ctx context.Context, id uint) error {
 					ON upcoming_activities.id = sua.upcoming_activity_id
 			WHERE sua.script_id = ? AND
 				upcoming_activities.activity_type = 'script' AND
-				(upcoming_activities.payload->'$.sync_request' = 0 OR
+				(JSON_EXTRACT(upcoming_activities.payload, '$.sync_request') = 0 OR
 					upcoming_activities.created_at >= NOW() - INTERVAL ? SECOND)
 			`,
 			id, int(constants.MaxServerWaitTime.Seconds()),
@@ -1205,7 +1205,7 @@ WHERE
 		WHERE
 			ua.activity_type = 'script'
 			AND ua.activated_at IS NOT NULL
-			AND (ua.payload->'$.sync_request' = 0 OR ua.created_at >= NOW() - INTERVAL ? SECOND)
+			AND (JSON_EXTRACT(ua.payload, '$.sync_request') = 0 OR ua.created_at >= NOW() - INTERVAL ? SECOND)
 			AND sua.script_id IN (SELECT id FROM scripts WHERE global_or_team_id = ?)`
 
 	const clearAllPendingExecutionsUA = `DELETE FROM upcoming_activities
@@ -1215,7 +1215,7 @@ WHERE
 				ON upcoming_activities.id = sua.upcoming_activity_id
 		WHERE
 			upcoming_activities.activity_type = 'script'
-			AND (upcoming_activities.payload->'$.sync_request' = 0 OR upcoming_activities.created_at >= NOW() - INTERVAL ? SECOND)
+			AND (JSON_EXTRACT(upcoming_activities.payload, '$.sync_request') = 0 OR upcoming_activities.created_at >= NOW() - INTERVAL ? SECOND)
 			AND sua.script_id IN (SELECT id FROM scripts WHERE global_or_team_id = ?)`
 
 	const unsetScriptsNotInListFromPolicies = `
@@ -1245,7 +1245,7 @@ WHERE
 		WHERE
 			ua.activity_type = 'script'
 			AND ua.activated_at IS NOT NULL
-			AND (ua.payload->'$.sync_request' = 0 OR ua.created_at >= NOW() - INTERVAL ? SECOND)
+			AND (JSON_EXTRACT(ua.payload, '$.sync_request') = 0 OR ua.created_at >= NOW() - INTERVAL ? SECOND)
 			AND sua.script_id IN (SELECT id FROM scripts WHERE global_or_team_id = ? AND name NOT IN (?))`
 
 	const clearPendingExecutionsNotInListUA = `DELETE FROM upcoming_activities
@@ -1255,7 +1255,7 @@ WHERE
 				ON upcoming_activities.id = sua.upcoming_activity_id
 		WHERE
 			upcoming_activities.activity_type = 'script'
-			AND (upcoming_activities.payload->'$.sync_request' = 0 OR upcoming_activities.created_at >= NOW() - INTERVAL ? SECOND)
+			AND (JSON_EXTRACT(upcoming_activities.payload, '$.sync_request') = 0 OR upcoming_activities.created_at >= NOW() - INTERVAL ? SECOND)
 			AND sua.script_id IN (SELECT id FROM scripts WHERE global_or_team_id = ? AND name NOT IN (?))`
 
 	const insertNewOrEditedScript = `
@@ -1283,7 +1283,7 @@ ON DUPLICATE KEY UPDATE
 		WHERE
 			ua.activity_type = 'script'
 			AND ua.activated_at IS NOT NULL
-			AND (ua.payload->'$.sync_request' = 0 OR ua.created_at >= NOW() - INTERVAL ? SECOND)
+			AND (JSON_EXTRACT(ua.payload, '$.sync_request') = 0 OR ua.created_at >= NOW() - INTERVAL ? SECOND)
 			AND sua.script_id = ? AND sua.script_content_id != ?`
 
 	const clearPendingExecutionsWithObsoleteScriptUA = `DELETE FROM upcoming_activities
@@ -1293,7 +1293,7 @@ ON DUPLICATE KEY UPDATE
 				ON upcoming_activities.id = sua.upcoming_activity_id
 		WHERE
 			upcoming_activities.activity_type = 'script'
-			AND (upcoming_activities.payload->'$.sync_request' = 0 OR upcoming_activities.created_at >= NOW() - INTERVAL ? SECOND)
+			AND (JSON_EXTRACT(upcoming_activities.payload, '$.sync_request') = 0 OR upcoming_activities.created_at >= NOW() - INTERVAL ? SECOND)
 			AND sua.script_id = ? AND sua.script_content_id != ?`
 
 	const loadInsertedScripts = `SELECT id, team_id, name FROM scripts WHERE global_or_team_id = ?`

--- a/server/datastore/mysql/secret_variables.go
+++ b/server/datastore/mysql/secret_variables.go
@@ -336,14 +336,14 @@ func (ds *Datastore) DeleteSecretVariable(ctx context.Context, id uint) (secretN
 			// optjson that serializes to null when unset, so filter both on a
 			// non-empty resolved value rather than IS NOT NULL.
 			`SELECT 'host_name_template' AS entity, 'Host name' AS name,
-			t.name AS team_name, t.config->>'$.mdm.name_template' AS contents
+			t.name AS team_name, JSON_UNQUOTE(JSON_EXTRACT(t.config, '$.mdm.name_template')) AS contents
 			FROM teams t
-			WHERE COALESCE(t.config->>'$.mdm.name_template', '') != ''
+			WHERE COALESCE(JSON_UNQUOTE(JSON_EXTRACT(t.config, '$.mdm.name_template')), '') != ''
 			UNION ALL
 			SELECT 'host_name_template' AS entity, 'Host name' AS name,
-			'Unassigned' AS team_name, json_value->>'$.mdm.name_template' AS contents
+			'Unassigned' AS team_name, JSON_UNQUOTE(JSON_EXTRACT(json_value, '$.mdm.name_template')) AS contents
 			FROM app_config_json
-			WHERE COALESCE(json_value->>'$.mdm.name_template', '') != '';`,
+			WHERE COALESCE(JSON_UNQUOTE(JSON_EXTRACT(json_value, '$.mdm.name_template')), '') != '';`,
 		); err != nil {
 			return ctxerr.Wrap(ctx, err, "get host name template contents")
 		}

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -6411,195 +6411,193 @@ func (ds *Datastore) ListHostSoftware(ctx context.Context, host *fleet.Host, opt
 				( si.id IS NOT NULL OR vat.platform = :host_platform OR iha.id IS NOT NULL ) AND
 				-- label membership check
 				(
-					-- do the label membership check for software installers and VPP apps and in-house apps
-						EXISTS (
+					-- Label membership check.
+					--
+					-- Each arm below was an arm of a UNION inside
+					-- EXISTS (SELECT 1 FROM ( ... ) t). A derived table is
+					-- evaluated independently of its enclosing query, so it
+					-- cannot see the si/vat/iha aliases; MariaDB rejects that
+					-- with "Unknown column 'si.id' in 'WHERE'". A correlated
+					-- EXISTS may reference them on both engines.
+					--
+					-- The derived table produced a row exactly when at least
+					-- one arm did, so the UNION becomes a disjunction. Each
+					-- arm's HAVING is restated over the aggregates directly,
+					-- because SELECT 1 exposes no column aliases to HAVING.
 
-						SELECT 1 FROM (
+					-- no labels for any type of installer
+					(
+						NOT EXISTS (SELECT 1 FROM software_installer_labels sil WHERE sil.software_installer_id = si.id) AND
+						NOT EXISTS (SELECT 1 FROM vpp_app_team_labels vatl WHERE vatl.vpp_app_team_id = vat.id) AND
+						NOT EXISTS (SELECT 1 FROM in_house_app_labels ihl WHERE ihl.in_house_app_id = iha.id)
+					)
 
-							-- no labels for any type of installer
-							SELECT 0 AS count_installer_labels, 0 AS count_host_labels, 0 as count_host_updated_after_labels
-							WHERE
-								NOT EXISTS (SELECT 1 FROM software_installer_labels sil WHERE sil.software_installer_id = si.id) AND
-								NOT EXISTS (SELECT 1 FROM vpp_app_team_labels vatl WHERE vatl.vpp_app_team_id = vat.id) AND
-								NOT EXISTS (SELECT 1 FROM in_house_app_labels ihl WHERE ihl.in_house_app_id = iha.id)
+					OR
 
-							UNION
+					-- include any for software installers
+					EXISTS (
+						SELECT 1
+						FROM
+							software_installer_labels sil
+							LEFT OUTER JOIN label_membership lm ON lm.label_id = sil.label_id
+							AND lm.host_id = :host_id
+						WHERE
+							sil.software_installer_id = si.id
+							AND sil.exclude = 0
+							AND sil.require_all = 0
+						HAVING
+							COUNT(*) > 0 AND COUNT(lm.label_id) > 0
+					)
 
-							-- include any for software installers
-							SELECT
-								COUNT(*) AS count_installer_labels,
-								COUNT(lm.label_id) AS count_host_labels,
-								0 as count_host_updated_after_labels
-							FROM
-								software_installer_labels sil
-								LEFT OUTER JOIN label_membership lm ON lm.label_id = sil.label_id
-								AND lm.host_id = :host_id
-							WHERE
-								sil.software_installer_id = si.id
-								AND sil.exclude = 0
-								AND sil.require_all = 0
-							HAVING
-								count_installer_labels > 0 AND count_host_labels > 0
+					OR
 
-							UNION
+					-- exclude any for software installers, ignore software that depends on labels created
+					-- _after_ the label_updated_at timestamp of the host (because
+					-- we don't have results for that label yet, the host may or may
+					-- not be a member).
+					EXISTS (
+						SELECT 1
+						FROM
+							software_installer_labels sil
+							LEFT OUTER JOIN labels lbl
+								ON lbl.id = sil.label_id
+							LEFT OUTER JOIN label_membership lm
+								ON lm.label_id = sil.label_id AND lm.host_id = :host_id
+						WHERE
+							sil.software_installer_id = si.id
+							AND sil.exclude = 1
+							AND sil.require_all = 0
+						HAVING
+							COUNT(*) > 0 AND COUNT(*) = SUM(
+								CASE WHEN lbl.label_membership_type <> 1 AND lbl.created_at IS NOT NULL AND :host_label_updated_at >= lbl.created_at THEN 1
+								WHEN lbl.label_membership_type = 1 AND lbl.created_at IS NOT NULL THEN 1
+								ELSE 0 END) AND COUNT(lm.label_id) = 0
+					)
 
-							-- exclude any for software installers, ignore software that depends on labels created
-							-- _after_ the label_updated_at timestamp of the host (because
-							-- we don't have results for that label yet, the host may or may
-							-- not be a member).
-							SELECT
-								COUNT(*) AS count_installer_labels,
-								COUNT(lm.label_id) AS count_host_labels,
-								SUM(
-									CASE WHEN lbl.label_membership_type <> 1 AND lbl.created_at IS NOT NULL AND :host_label_updated_at >= lbl.created_at THEN 1
-									WHEN lbl.label_membership_type = 1 AND lbl.created_at IS NOT NULL THEN 1
-									ELSE 0 END) as count_host_updated_after_labels
-							FROM
-								software_installer_labels sil
-								LEFT OUTER JOIN labels lbl
-									ON lbl.id = sil.label_id
-								LEFT OUTER JOIN label_membership lm
-									ON lm.label_id = sil.label_id AND lm.host_id = :host_id
-							WHERE
-								sil.software_installer_id = si.id
-								AND sil.exclude = 1
-								AND sil.require_all = 0
-							HAVING
-								count_installer_labels > 0 AND count_installer_labels = count_host_updated_after_labels AND count_host_labels = 0
+					OR
 
-							UNION
+					-- include all for software installers
+					EXISTS (
+						SELECT 1
+						FROM
+							software_installer_labels sil
+							LEFT OUTER JOIN label_membership lm ON lm.label_id = sil.label_id
+							AND lm.host_id = :host_id
+						WHERE
+							sil.software_installer_id = si.id
+							AND sil.exclude = 0
+							AND sil.require_all = 1
+						HAVING
+							COUNT(*) > 0 AND COUNT(lm.label_id) = COUNT(*)
+					)
 
-							-- include all for software installers
-							SELECT
-								COUNT(*) AS count_installer_labels,
-								COUNT(lm.label_id) AS count_host_labels,
-								0 as count_host_updated_after_labels
-							FROM
-								software_installer_labels sil
-								LEFT OUTER JOIN label_membership lm ON lm.label_id = sil.label_id
-								AND lm.host_id = :host_id
-							WHERE
-								sil.software_installer_id = si.id
-								AND sil.exclude = 0
-								AND sil.require_all = 1
-							HAVING
-								count_installer_labels > 0 AND count_host_labels = count_installer_labels
+					OR
 
-							UNION
+					-- include any for VPP apps
+					EXISTS (
+						SELECT 1
+						FROM
+							vpp_app_team_labels vatl
+							LEFT OUTER JOIN label_membership lm ON lm.label_id = vatl.label_id
+							AND lm.host_id = :host_id
+						WHERE
+							vatl.vpp_app_team_id = vat.id
+							AND vatl.exclude = 0
+							AND vatl.require_all = 0
+						HAVING
+							COUNT(*) > 0 AND COUNT(lm.label_id) > 0
+					)
 
-							-- include any for VPP apps
-							SELECT
-								COUNT(*) AS count_installer_labels,
-								COUNT(lm.label_id) AS count_host_labels,
-								0 as count_host_updated_after_labels
-							FROM
-								vpp_app_team_labels vatl
-								LEFT OUTER JOIN label_membership lm ON lm.label_id = vatl.label_id
-								AND lm.host_id = :host_id
-							WHERE
-								vatl.vpp_app_team_id = vat.id
-								AND vatl.exclude = 0
-								AND vatl.require_all = 0
-							HAVING
-								count_installer_labels > 0 AND count_host_labels > 0
+					OR
 
-							UNION
-
-							-- exclude any for VPP apps
-							SELECT
-								COUNT(*) AS count_installer_labels,
-								COUNT(lm.label_id) AS count_host_labels,
-								SUM(CASE
+					-- exclude any for VPP apps
+					EXISTS (
+						SELECT 1
+						FROM
+							vpp_app_team_labels vatl
+							LEFT OUTER JOIN labels lbl
+								ON lbl.id = vatl.label_id
+							LEFT OUTER JOIN label_membership lm
+								ON lm.label_id = vatl.label_id AND lm.host_id = :host_id
+						WHERE
+							vatl.vpp_app_team_id = vat.id
+							AND vatl.exclude = 1
+							AND vatl.require_all = 0
+						HAVING
+							COUNT(*) > 0 AND COUNT(*) = SUM(CASE
 								WHEN lbl.created_at IS NOT NULL AND lbl.label_membership_type = 0 AND :host_label_updated_at >= lbl.created_at THEN 1
 								WHEN lbl.created_at IS NOT NULL AND lbl.label_membership_type = 1 THEN 1
-								ELSE 0 END) as count_host_updated_after_labels
-							FROM
-								vpp_app_team_labels vatl
-								LEFT OUTER JOIN labels lbl
-									ON lbl.id = vatl.label_id
-								LEFT OUTER JOIN label_membership lm
-									ON lm.label_id = vatl.label_id AND lm.host_id = :host_id
-							WHERE
-								vatl.vpp_app_team_id = vat.id
-								AND vatl.exclude = 1
-								AND vatl.require_all = 0
-							HAVING
-								count_installer_labels > 0 AND count_installer_labels = count_host_updated_after_labels AND count_host_labels = 0
+								ELSE 0 END) AND COUNT(lm.label_id) = 0
+					)
 
-							UNION
+					OR
 
-							-- include all for VPP apps
-							SELECT
-								COUNT(*) AS count_installer_labels,
-								COUNT(lm.label_id) AS count_host_labels,
-								0 as count_host_updated_after_labels
-							FROM
-								vpp_app_team_labels vatl
-								LEFT OUTER JOIN label_membership lm ON lm.label_id = vatl.label_id
-								AND lm.host_id = :host_id
-							WHERE
-								vatl.vpp_app_team_id = vat.id
-								AND vatl.exclude = 0
-								AND vatl.require_all = 1
-							HAVING
-								count_installer_labels > 0 AND count_host_labels = count_installer_labels
+					-- include all for VPP apps
+					EXISTS (
+						SELECT 1
+						FROM
+							vpp_app_team_labels vatl
+							LEFT OUTER JOIN label_membership lm ON lm.label_id = vatl.label_id
+							AND lm.host_id = :host_id
+						WHERE
+							vatl.vpp_app_team_id = vat.id
+							AND vatl.exclude = 0
+							AND vatl.require_all = 1
+						HAVING
+							COUNT(*) > 0 AND COUNT(lm.label_id) = COUNT(*)
+					)
 
-							UNION
+					OR
 
-							-- include any for in-house apps
-							SELECT
-								COUNT(*) AS count_installer_labels,
-								COUNT(lm.label_id) AS count_host_labels,
-								0 as count_host_updated_after_labels
-							FROM
-								in_house_app_labels ihl
-								LEFT OUTER JOIN label_membership lm ON lm.label_id = ihl.label_id AND lm.host_id = :host_id
-							WHERE
-								ihl.in_house_app_id = iha.id
-								AND ihl.exclude = 0
-								AND ihl.require_all = 0
-							HAVING
-								count_installer_labels > 0 AND count_host_labels > 0
+					-- include any for in-house apps
+					EXISTS (
+						SELECT 1
+						FROM
+							in_house_app_labels ihl
+							LEFT OUTER JOIN label_membership lm ON lm.label_id = ihl.label_id AND lm.host_id = :host_id
+						WHERE
+							ihl.in_house_app_id = iha.id
+							AND ihl.exclude = 0
+							AND ihl.require_all = 0
+						HAVING
+							COUNT(*) > 0 AND COUNT(lm.label_id) > 0
+					)
 
-							UNION
+					OR
 
-							-- exclude any for in-house apps
-							SELECT
-								COUNT(*) AS count_installer_labels,
-								COUNT(lm.label_id) AS count_host_labels,
-								SUM(CASE
+					-- exclude any for in-house apps
+					EXISTS (
+						SELECT 1
+						FROM
+							in_house_app_labels ihl
+							LEFT OUTER JOIN labels lbl ON lbl.id = ihl.label_id
+							LEFT OUTER JOIN label_membership lm ON lm.label_id = ihl.label_id AND lm.host_id = :host_id
+						WHERE
+							ihl.in_house_app_id = iha.id
+							AND ihl.exclude = 1
+							AND ihl.require_all = 0
+						HAVING
+							COUNT(*) > 0 AND COUNT(*) = SUM(CASE
 								WHEN lbl.created_at IS NOT NULL AND lbl.label_membership_type = 0 AND :host_label_updated_at >= lbl.created_at THEN 1
 								WHEN lbl.created_at IS NOT NULL AND lbl.label_membership_type = 1 THEN 1
-								ELSE 0 END) as count_host_updated_after_labels
-							FROM
-								in_house_app_labels ihl
-								LEFT OUTER JOIN labels lbl ON lbl.id = ihl.label_id
-								LEFT OUTER JOIN label_membership lm ON lm.label_id = ihl.label_id AND lm.host_id = :host_id
-							WHERE
-								ihl.in_house_app_id = iha.id
-								AND ihl.exclude = 1
-								AND ihl.require_all = 0
-							HAVING
-								count_installer_labels > 0 AND count_installer_labels = count_host_updated_after_labels AND count_host_labels = 0
+								ELSE 0 END) AND COUNT(lm.label_id) = 0
+					)
 
-							UNION
+					OR
 
-							-- include all for in-house apps
-							SELECT
-								COUNT(*) AS count_installer_labels,
-								COUNT(lm.label_id) AS count_host_labels,
-								0 as count_host_updated_after_labels
-							FROM
-								in_house_app_labels ihl
-								LEFT OUTER JOIN label_membership lm ON lm.label_id = ihl.label_id AND lm.host_id = :host_id
-							WHERE
-								ihl.in_house_app_id = iha.id
-								AND ihl.exclude = 0
-								AND ihl.require_all = 1
-							HAVING
-								count_installer_labels > 0 AND count_host_labels = count_installer_labels
-							) t
-						)
+					-- include all for in-house apps
+					EXISTS (
+						SELECT 1
+						FROM
+							in_house_app_labels ihl
+							LEFT OUTER JOIN label_membership lm ON lm.label_id = ihl.label_id AND lm.host_id = :host_id
+						WHERE
+							ihl.in_house_app_id = iha.id
+							AND ihl.exclude = 0
+							AND ihl.require_all = 1
+						HAVING
+							COUNT(*) > 0 AND COUNT(lm.label_id) = COUNT(*)
+					)
 				)
 			`
 			if opts.SelfServiceOnly {

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -100,7 +100,7 @@ func (ds *Datastore) GetSoftwareInstallDetails(ctx context.Context, executionId 
     ua.host_id AS host_id,
     ua.execution_id AS execution_id,
     siua.software_installer_id AS installer_id,
-		ua.payload->'$.self_service' AS self_service,
+		JSON_EXTRACT(ua.payload, '$.self_service') AS self_service,
     COALESCE(si.pre_install_query, '') AS pre_install_condition,
     si.app_open_query AS app_open_query,
     COALESCE(p.patch_when_closed, 0) AS patch_when_closed,
@@ -2246,16 +2246,16 @@ SELECT
 	NULL AS post_install_script_output,
 	NULL AS install_script_output,
 	ua.host_id AS host_id,
-	COALESCE(st.name, ua.payload->>'$.software_title_name') AS software_title,
+	COALESCE(st.name, JSON_UNQUOTE(JSON_EXTRACT(ua.payload, '$.software_title_name'))) AS software_title,
 	siua.software_title_id,
 	siua.software_installer_id,
 	si.storage_id AS hash_sha256,
 	'pending_install' AS status,
-	ua.payload->>'$.installer_filename' AS software_package,
+	JSON_UNQUOTE(JSON_EXTRACT(ua.payload, '$.installer_filename')) AS software_package,
 	ua.user_id AS user_id,
 	NULL AS post_install_script_exit_code,
 	NULL AS install_script_exit_code,
-	ua.payload->'$.self_service' AS self_service,
+	JSON_EXTRACT(ua.payload, '$.self_service') AS self_service,
 	NULL AS host_deleted_at,
 	siua.policy_id AS policy_id,
 	ua.created_at as created_at,
@@ -3931,7 +3931,7 @@ func (ds *Datastore) GetDetailsForUninstallFromExecutionID(ctx context.Context, 
 
 	UNION
 
-	SELECT st.name, COALESCE(ua.payload->'$.self_service', FALSE) self_service
+	SELECT st.name, COALESCE(JSON_EXTRACT(ua.payload, '$.self_service'), FALSE) self_service
 	FROM
 		software_titles st
 		INNER JOIN software_installers si ON si.title_id = st.id

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -4226,60 +4226,67 @@ func (ds *Datastore) isSoftwareLabelScoped(ctx context.Context, softwareID, host
 	return res, nil
 }
 
-const labelScopedFilter = `
-SELECT
-	1
-FROM (
+// labelScopedFilter is a boolean SQL expression -- not a subquery -- reporting
+// whether the host aliased `h` in the enclosing query is in label scope for the
+// given %[1]s_id. Callers interpolate it directly into a WHERE clause, and must
+// supply the software id three times (once per branch, in order).
+//
+// It is written as a disjunction of correlated EXISTS subqueries rather than as
+// a single derived table over a UNION. A derived table is materialized
+// independently of the enclosing query, so it cannot see the outer `h` alias:
+// MariaDB rejects that with `Unknown column 'h.id' in 'ON'`. A correlated
+// EXISTS may reference the outer alias on both engines. The branches are
+// equivalent to the UNION arms they replace -- the derived table yielded a row
+// exactly when at least one arm did -- with each arm's HAVING conditions
+// restated over the aggregates directly, since `SELECT 1` exposes no aliases.
+const labelScopedFilter = `(
 		-- no labels
-		SELECT
-			0 AS count_installer_labels,
-			0 AS count_host_labels,
-			0 AS count_host_updated_after_labels
-		WHERE NOT EXISTS ( SELECT 1 FROM %[1]s_labels sil WHERE sil.%[1]s_id = ?)
+		NOT EXISTS ( SELECT 1 FROM %[1]s_labels sil WHERE sil.%[1]s_id = ?)
 
-		UNION
+		OR
 
 		-- include any
-		SELECT
-			COUNT(*) AS count_installer_labels,
-			COUNT(lm.label_id) AS count_host_labels,
-			0 AS count_host_updated_after_labels
-		FROM
-			%[1]s_labels sil
-		LEFT OUTER JOIN label_membership lm ON lm.label_id = sil.label_id
-		AND lm.host_id = h.id
-		WHERE
-			sil.%[1]s_id = ?
-			AND sil.exclude = 0
-		HAVING
-			count_installer_labels > 0
-			AND count_host_labels > 0
+		EXISTS (
+			SELECT
+				1
+			FROM
+				%[1]s_labels sil
+			LEFT OUTER JOIN label_membership lm ON lm.label_id = sil.label_id
+			AND lm.host_id = h.id
+			WHERE
+				sil.%[1]s_id = ?
+				AND sil.exclude = 0
+			HAVING
+				COUNT(*) > 0
+				AND COUNT(lm.label_id) > 0
+		)
 
-		UNION
+		OR
 
 		-- exclude any, ignore software that depends on labels created
 		-- _after_ the label_updated_at timestamp of the host (because
 		-- we don't have results for that label yet, the host may or may
 		-- not be a member).
-		SELECT
-			COUNT(*) AS count_installer_labels,
-			COUNT(lm.label_id) AS count_host_labels,
-			SUM(
-				CASE
-				WHEN lbl.created_at IS NOT NULL AND lbl.label_membership_type = 0 AND (SELECT label_updated_at FROM hosts WHERE id = h.id) >= lbl.created_at THEN 1
-				WHEN lbl.created_at IS NOT NULL AND lbl.label_membership_type = 1 THEN 1
-				ELSE 0 END) AS count_host_updated_after_labels
-		FROM
-			%[1]s_labels sil
-		LEFT OUTER JOIN labels lbl ON lbl.id = sil.label_id
-		LEFT OUTER JOIN label_membership lm ON lm.label_id = sil.label_id AND lm.host_id = h.id
-WHERE
-	sil.%[1]s_id = ?
-	AND sil.exclude = 1
-HAVING
-	count_installer_labels > 0
-	AND count_installer_labels = count_host_updated_after_labels
-	AND count_host_labels = 0) t`
+		EXISTS (
+			SELECT
+				1
+			FROM
+				%[1]s_labels sil
+			LEFT OUTER JOIN labels lbl ON lbl.id = sil.label_id
+			LEFT OUTER JOIN label_membership lm ON lm.label_id = sil.label_id AND lm.host_id = h.id
+			WHERE
+				sil.%[1]s_id = ?
+				AND sil.exclude = 1
+			HAVING
+				COUNT(*) > 0
+				AND COUNT(*) = SUM(
+					CASE
+					WHEN lbl.created_at IS NOT NULL AND lbl.label_membership_type = 0 AND (SELECT label_updated_at FROM hosts WHERE id = h.id) >= lbl.created_at THEN 1
+					WHEN lbl.created_at IS NOT NULL AND lbl.label_membership_type = 1 THEN 1
+					ELSE 0 END)
+				AND COUNT(lm.label_id) = 0
+		)
+	)`
 
 func (ds *Datastore) GetIncludedHostIDMapForSoftwareInstaller(ctx context.Context, installerID uint) (map[uint]struct{}, error) {
 	return ds.getIncludedHostIDMapForSoftware(ctx, ds.writer(ctx), installerID, softwareTypeInstaller)
@@ -4292,7 +4299,7 @@ func (ds *Datastore) getIncludedHostIDMapForSoftware(ctx context.Context, tx sql
 FROM
 	hosts h
 WHERE
-	EXISTS (%s)
+	%s
 `, filter)
 
 	var hostIDs []uint
@@ -4322,7 +4329,7 @@ FROM
 		JOIN android_devices ad ON ad.enterprise_specific_id = h.uuid
 		JOIN vpp_apps_teams vat ON vat.team_id <=> h.team_id AND vat.id = ?
 WHERE
-		EXISTS (%s)
+		%s
 		AND h.platform = 'android'
 `, filter)
 
@@ -4354,7 +4361,7 @@ func (ds *Datastore) getExcludedHostIDMapForSoftware(ctx context.Context, softwa
 FROM
 	hosts h
 WHERE
-	NOT EXISTS (%s)
+	NOT %s
 `, filter)
 
 	var hostIDs []uint

--- a/server/datastore/mysql/teams.go
+++ b/server/datastore/mysql/teams.go
@@ -620,7 +620,7 @@ func amountTeamsDB(ctx context.Context, db sqlx.QueryerContext) (int, error) {
 
 // TeamAgentOptions loads the agents options of a team.
 func (ds *Datastore) TeamAgentOptions(ctx context.Context, tid uint) (*json.RawMessage, error) {
-	stmt := fmt.Sprintf(`SELECT config->'$.agent_options' FROM teams WHERE id = %d`, tid) // safe because uint
+	stmt := fmt.Sprintf(`SELECT JSON_EXTRACT(config, '$.agent_options') FROM teams WHERE id = %d`, tid) // safe because uint
 	var agentOptions *json.RawMessage
 	if err := sqlx.GetContext(ctx, ds.reader(ctx), &agentOptions, stmt); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "select team")
@@ -634,7 +634,7 @@ func (ds *Datastore) TeamFeatures(ctx context.Context, tid uint) (*fleet.Feature
 }
 
 func teamFeaturesDB(ctx context.Context, q sqlx.QueryerContext, tid uint) (*fleet.Features, error) {
-	stmt := fmt.Sprintf(`SELECT config->'$.features' as features FROM teams WHERE id = %d`, tid) // safe due to uint
+	stmt := fmt.Sprintf(`SELECT JSON_EXTRACT(config, '$.features') as features FROM teams WHERE id = %d`, tid) // safe due to uint
 	var raw *json.RawMessage
 	if err := sqlx.GetContext(ctx, q, &raw, stmt); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "get team config features")
@@ -651,7 +651,7 @@ func teamFeaturesDB(ctx context.Context, q sqlx.QueryerContext, tid uint) (*flee
 }
 
 func (ds *Datastore) TeamMDMConfig(ctx context.Context, tid uint) (*fleet.TeamMDM, error) {
-	sql := `SELECT config->'$.mdm' AS mdm FROM teams WHERE id = ?`
+	sql := `SELECT JSON_EXTRACT(config, '$.mdm') AS mdm FROM teams WHERE id = ?`
 	var raw *json.RawMessage
 	if err := sqlx.GetContext(ctx, ds.reader(ctx), &raw, sql, tid); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "select team MDM config")
@@ -724,7 +724,7 @@ func (ds *Datastore) TeamIDsWithSetupExperienceIdPEnabled(ctx context.Context) (
 			teams
 		WHERE
 			config IS NOT NULL AND
-			config->'$.mdm.macos_setup.enable_end_user_authentication' = TRUE
+			JSON_EXTRACT(config, '$.mdm.macos_setup.enable_end_user_authentication') = TRUE
 
 		UNION
 
@@ -733,7 +733,7 @@ func (ds *Datastore) TeamIDsWithSetupExperienceIdPEnabled(ctx context.Context) (
 		FROM
 			app_config_json
 		WHERE
-			json_value->'$.mdm.macos_setup.enable_end_user_authentication' = TRUE
+			JSON_EXTRACT(json_value, '$.mdm.macos_setup.enable_end_user_authentication') = TRUE
 `
 	var teamIDs []uint
 	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &teamIDs, stmt); err != nil {

--- a/server/datastore/mysql/testing_utils_test.go
+++ b/server/datastore/mysql/testing_utils_test.go
@@ -271,7 +271,7 @@ func setupRealReplica(t testing.TB, testName string, ds *Datastore, options *com
 			if out, err := exec.Command(
 				"docker", "compose", "exec", "-T", "mysql_replica_test",
 				// Command run inside container
-				"mysql",
+				testing_utils.DBClient(),
 				"-u"+testing_utils.TestUsername, "-p"+testing_utils.TestPassword,
 				"-e",
 				"STOP REPLICA; RESET REPLICA ALL;",
@@ -331,7 +331,7 @@ func setupRealReplica(t testing.TB, testName string, ds *Datastore, options *com
 	if out, err := exec.Command(
 		"docker", "compose", "exec", "-T", "mysql_replica_test",
 		// Command run inside container
-		"mysql",
+		testing_utils.DBClient(),
 		"-u"+testing_utils.TestUsername, "-p"+testing_utils.TestPassword,
 		"-e",
 		fmt.Sprintf(

--- a/server/datastore/mysql/vpp.go
+++ b/server/datastore/mysql/vpp.go
@@ -1483,7 +1483,7 @@ VALUES
 //     lookup works either before or after ds.CancelHostUpcomingActivity.
 //  2. Pre-activation install — host_vpp_software_installs has no row (it's
 //     created at activation time), and the reservation lives only in
-//     upcoming_activities.payload->>'$.associated_event_id' +
+//     JSON_UNQUOTE(JSON_EXTRACT(upcoming_activities.payload, '$.associated_event_id')) +
 //     vpp_app_upcoming_activities.adam_id. The cancel transaction
 //     unconditionally deletes the upcoming_activities row, so callers MUST
 //     invoke this BEFORE ds.CancelHostUpcomingActivity for the

--- a/server/datastore/mysql/vulnerabilities.go
+++ b/server/datastore/mysql/vulnerabilities.go
@@ -309,6 +309,32 @@ func (ds *Datastore) ListVulnerabilities(ctx context.Context, opt fleet.VulnList
 // That falls back to the legacy single-statement form (preserved verbatim
 // below) — performance is unchanged for that specific sort, but every
 // other sort key benefits from the two-stage refactor.
+// minCVECreatedAtExpr returns a SQL expression for the earliest created_at
+// recorded against alias.cve across software_cve and
+// operating_system_vulnerabilities.
+//
+// It deliberately avoids the more direct
+//
+//	(SELECT MIN(created_at) FROM (
+//	    SELECT created_at FROM software_cve WHERE cve = <alias>.cve
+//	    UNION ALL
+//	    SELECT created_at FROM operating_system_vulnerabilities WHERE cve = <alias>.cve
+//	) AS combined_dates)
+//
+// because that derived table is correlated on the enclosing query's alias. A
+// derived table is evaluated independently of its enclosing query, so it cannot
+// see that alias; MariaDB rejects it with `Unknown column '<alias>.cve' in
+// 'WHERE'`. Correlated scalar subqueries are accepted by both engines.
+//
+// The COALESCE pair keeps the result correct when the CVE is recorded in only
+// one of the two tables, since LEAST returns NULL if any argument is NULL. When
+// both sides are NULL the expression is NULL, matching MIN over an empty union.
+func minCVECreatedAtExpr(alias string) string {
+	sc := "(SELECT MIN(created_at) FROM software_cve WHERE cve = " + alias + ".cve)"
+	osv := "(SELECT MIN(created_at) FROM operating_system_vulnerabilities WHERE cve = " + alias + ".cve)"
+	return "LEAST(COALESCE(" + sc + ", " + osv + "), COALESCE(" + osv + ", " + sc + "))"
+}
+
 func buildListVulnerabilitiesSQL(opt *fleet.VulnListOptions) (string, []any, error) {
 	if opt.ListOptions.OrderKey == "created_at" {
 		return buildListVulnerabilitiesLegacySQL(opt)
@@ -377,11 +403,7 @@ func buildListVulnerabilitiesSQL(opt *fleet.VulnListOptions) (string, []any, err
 	outer.WriteString(`
 		SELECT
 			p.cve,
-			(SELECT MIN(created_at) FROM (
-				SELECT created_at FROM software_cve WHERE cve = p.cve
-				UNION ALL
-				SELECT created_at FROM operating_system_vulnerabilities WHERE cve = p.cve
-			) AS combined_dates) AS created_at,
+			` + minCVECreatedAtExpr("p") + ` AS created_at,
 			COALESCE(
 				(SELECT source FROM software_cve WHERE cve = p.cve LIMIT 1),
 				(SELECT source FROM operating_system_vulnerabilities WHERE cve = p.cve LIMIT 1)
@@ -432,11 +454,7 @@ func buildListVulnerabilitiesLegacySQL(opt *fleet.VulnListOptions) (string, []an
 	eeSelectStmt := `
 		SELECT
 			vhc.cve as cve,
-			(SELECT MIN(created_at) FROM (
-				SELECT created_at FROM software_cve WHERE cve = vhc.cve
-				UNION ALL
-				SELECT created_at FROM operating_system_vulnerabilities WHERE cve = vhc.cve
-			) AS combined_dates) as created_at,
+			` + minCVECreatedAtExpr("vhc") + ` as created_at,
 			COALESCE(
 				(SELECT source FROM software_cve WHERE cve = vhc.cve LIMIT 1),
 				(SELECT source FROM operating_system_vulnerabilities WHERE cve = vhc.cve LIMIT 1)
@@ -459,11 +477,7 @@ func buildListVulnerabilitiesLegacySQL(opt *fleet.VulnListOptions) (string, []an
 	freeSelectStmt := `
 		SELECT
 			vhc.cve as cve,
-			(SELECT MIN(created_at) FROM (
-				SELECT created_at FROM software_cve WHERE cve = vhc.cve
-				UNION ALL
-				SELECT created_at FROM operating_system_vulnerabilities WHERE cve = vhc.cve
-			) AS combined_dates) as created_at,
+			` + minCVECreatedAtExpr("vhc") + ` as created_at,
 			COALESCE(
 				(SELECT source FROM software_cve WHERE cve = vhc.cve LIMIT 1),
 				(SELECT source FROM operating_system_vulnerabilities WHERE cve = vhc.cve LIMIT 1)

--- a/server/platform/mysql/common.go
+++ b/server/platform/mysql/common.go
@@ -7,6 +7,9 @@ import (
 	"fmt"
 	"log/slog"
 	"net/url"
+	"os"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/XSAM/otelsql"
@@ -27,7 +30,26 @@ type ConnectorFactory func(dsn string, logger *slog.Logger) (driver.Connector, e
 // We add all MySQL 8.0 default strict modes to match production behavior
 // Note: The value needs to be wrapped in single quotes when passed to MySQL DSN due to comma separation
 // Reference: https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html
-const TestSQLMode = "'REAL_AS_FLOAT,PIPES_AS_CONCAT,ANSI_QUOTES,IGNORE_SPACE,ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'"
+var TestSQLMode = buildTestSQLMode()
+
+func buildTestSQLMode() string {
+	modes := []string{
+		"REAL_AS_FLOAT", "PIPES_AS_CONCAT", "ANSI_QUOTES", "IGNORE_SPACE", "ONLY_FULL_GROUP_BY",
+		"STRICT_TRANS_TABLES", "NO_ZERO_IN_DATE", "NO_ZERO_DATE", "ERROR_FOR_DIVISION_BY_ZERO",
+		"NO_ENGINE_SUBSTITUTION",
+	}
+	if os.Getenv("FLEET_DB_CLIENT") == "mariadb" {
+		// MySQL's ONLY_FULL_GROUP_BY recognises columns that are functionally
+		// dependent on the grouped columns (through a unique key) and allows
+		// selecting them. MariaDB's implementation does not, so queries that
+		// are valid on MySQL fail there with Error 1055
+		// ER_WRONG_FIELD_WITH_GROUP. Drop just this mode for MariaDB runs
+		// rather than rewrite every aggregate query; the strict modes that
+		// guard against silent data loss still apply.
+		modes = slices.DeleteFunc(modes, func(m string) bool { return m == "ONLY_FULL_GROUP_BY" })
+	}
+	return "'" + strings.Join(modes, ",") + "'"
+}
 
 type DBOptions struct {
 	// MaxAttempts configures the number of retries to connect to the DB

--- a/server/platform/mysql/testing_utils/testing_utils.go
+++ b/server/platform/mysql/testing_utils/testing_utils.go
@@ -22,6 +22,30 @@ const (
 	TestReplicaDatabaseSuffix = "_replica"
 )
 
+// IsMariaDB reports whether the test database container is running MariaDB
+// rather than MySQL. Set FLEET_DB_CLIENT=mariadb when bringing the containers
+// up with docker-compose-mariadb.yml.
+func IsMariaDB() bool {
+	return os.Getenv("FLEET_DB_CLIENT") == "mariadb"
+}
+
+// DBClient is the command line client to invoke inside the test database
+// container. MariaDB 11.x dropped the `mysql` symlink, shipping only `mariadb`.
+func DBClient() string {
+	if IsMariaDB() {
+		return "mariadb"
+	}
+	return "mysql"
+}
+
+// DBDumpClient is the schema dump client matching DBClient.
+func DBDumpClient() string {
+	if IsMariaDB() {
+		return "mariadb-dump"
+	}
+	return "mysqldump"
+}
+
 var TestReplicaAddress = getTestReplicaAddress()
 
 // getTestReplicaAddress returns the MySQL replica test server address from environment variable
@@ -121,7 +145,14 @@ type DatastoreTestOptions struct {
 // LoadDefaultSchema loads the default database schema for testing.
 func LoadDefaultSchema(t testing.TB, testName string, opts *DatastoreTestOptions) {
 	_, thisFile, _, _ := runtime.Caller(0)
-	schemaPath := filepath.Join(filepath.Dir(thisFile), "../../../datastore/mysql/schema.sql")
+	// The migration history does not replay on MariaDB -- it fails partway
+	// through 2024 -- so MariaDB starts from a converted point-in-time dump of
+	// the same schema instead. Regenerate it with tools/mariadb/fix-mariadb-schema.sh.
+	schemaFile := "schema.sql"
+	if IsMariaDB() {
+		schemaFile = "schema-mariadb.sql"
+	}
+	schemaPath := filepath.Join(filepath.Dir(thisFile), "../../../datastore/mysql/"+schemaFile)
 	LoadSchema(t, testName, opts, schemaPath)
 }
 
@@ -149,7 +180,7 @@ func LoadSchema(t testing.TB, testName string, opts *DatastoreTestOptions, schem
 		cmd := exec.Command(
 			"docker", "compose", "exec", "-T", "mysql_test",
 			// Command run inside container
-			"mysql",
+			DBClient(),
 			"--default-character-set=utf8mb4",
 			"-u"+TestUsername, "-p"+TestPassword,
 		)
@@ -171,7 +202,7 @@ func LoadSchema(t testing.TB, testName string, opts *DatastoreTestOptions, schem
 		cmd := exec.Command(
 			"docker", "compose", "exec", "-T", "mysql_replica_test",
 			// Command run inside container
-			"mysql",
+			DBClient(),
 			"--default-character-set=utf8mb4",
 			"-u"+TestUsername, "-p"+TestPassword,
 		)

--- a/tools/mariadb/README.md
+++ b/tools/mariadb/README.md
@@ -1,0 +1,58 @@
+# MariaDB Support
+
+Fleet primarily uses MySQL as its database, but also has some basic support for MariaDB >= 11.6.
+Not all features may be supported, and there may some subtle bugs throughout the application.
+
+## Quick Start
+
+### Docker Services
+
+The service names are database-agnostic:
+- `database` - Main development database
+- `database_test` - Test database
+- `database_replica_test` - Replica test database
+
+These services run MySQL by default, or MariaDB when using the override docker-compose-mariadb.yml file.
+
+### Persistent Volumes
+
+Data is stored in separate volumes to allow switching between databases:
+- `mysql-persistent-volume` - MySQL data
+- `mariadb-persistent-volume` - MariaDB data
+
+This prevents data corruption and allows you to switch between MySQL and MariaDB without losing data.
+
+### Starting services
+
+#### MySQL (default)
+```bash
+docker compose up
+```
+
+### MariaDB
+```bash
+docker compose -f docker-compose.yml -f docker-compose-mariadb.yml up
+```
+
+## Schema Conversion
+
+MariaDB has some SQL syntax differences from MySQL. The `fix-mariadb-schema.sh` script automatically converts the MySQL schema to be MariaDB-compatible.
+
+### Usage
+
+```bash
+./tools/mariadb/fix-mariadb-schema.sh
+```
+
+This creates `server/datastore/mysql/schema-mariadb.sql`.
+The migrations contained in `server/datastore/mysql/migrations/tables/` are not compatabile with mariadb syntax, so you cannot use the `prepare db` command you would use to typically. You need to create your development database with the `schema-mariadb.sql` file.
+This `schema-mariadb.sql` file is also used when running tests. The schema file is selected by the test infrastructure based on the `FLEET_DB_CLIENT` environment variable.
+
+It is important to note that there are data migrations in `server/datastore/mysql/migrations/data`. These are not included in the `schema-mariadb.sql` file. After you import the `schema-mariadb.sql` file into your mariaDB, you will still need to run `./build/fleet prepare db --dev`. This will run the data migrations and import data that is critical to having fleet run correctly.
+
+## Tests with MariaDB
+
+```bash
+# Run tests
+FLEET_DB_CLIENT=mariadb MYSQL_TEST=1 go test ./server/datastore/mysql/...
+```

--- a/tools/mariadb/fix-mariadb-schema.sh
+++ b/tools/mariadb/fix-mariadb-schema.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Script to convert schema.sql to MariaDB-compatible format
+
+set -e
+
+INPUT="server/datastore/mysql/schema.sql"
+OUTPUT="server/datastore/mysql/schema-mariadb.sql"
+
+echo "Converting schema.sql to MariaDB-compatible format..."
+
+cat > "$OUTPUT" << 'EOF'
+SET FOREIGN_KEY_CHECKS=0;
+SET SESSION sql_mode='';
+
+EOF
+
+cat "$INPUT" >> "$OUTPUT"
+
+cat >> "$OUTPUT" << 'EOF'
+
+SET FOREIGN_KEY_CHECKS=1;
+EOF
+
+# Remove the functional indexes - MariaDB doesn't support this
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  sed -i '' '/KEY `idx_host_vpp_software_installs_verification`/d' "$OUTPUT"
+  sed -i '' '/KEY `idx_host_in_house_software_installs_verification`/d' "$OUTPUT"
+else
+  sed -i '/KEY `idx_host_vpp_software_installs_verification`/d' "$OUTPUT"
+  sed -i '/KEY `idx_host_in_house_software_installs_verification`/d' "$OUTPUT"
+fi
+
+# Remove TABLESPACE directives - MariaDB handles these differently
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  sed -i '' 's/\/\*!50100 TABLESPACE `innodb_system` \*\/ //g' "$OUTPUT"
+else
+  sed -i 's/\/\*!50100 TABLESPACE `innodb_system` \*\/ //g' "$OUTPUT"
+fi
+
+# Fix STORED NOT NULL -> just STORED (MariaDB supports theses just different syntax)
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  sed -i '' 's/) STORED NOT NULL/) STORED/g' "$OUTPUT"
+else
+  sed -i 's/) STORED NOT NULL/) STORED/g' "$OUTPUT"
+fi
+
+echo "✓ MariaDB-compatible schema created at: $OUTPUT"
+echo ""
+echo "To import into MariaDB, run:"
+echo "mysql --host localhost --user root --protocol=tcp -P 3306 --password fleet < $OUTPUT"

--- a/tools/mariadb/fix-mariadb-schema.sh
+++ b/tools/mariadb/fix-mariadb-schema.sh
@@ -1,5 +1,28 @@
 #!/bin/bash
-# Script to convert schema.sql to MariaDB-compatible format
+# Convert schema.sql (a MySQL mysqldump) into a MariaDB-loadable schema.
+#
+# This produces the point-in-time baseline used to stand up a MariaDB database
+# without replaying the full migration history, which does not run on MariaDB
+# (see https://github.com/fleetdm/fleet/issues/34952).
+#
+# Transformations applied, all of them things MySQL accepts and MariaDB does not:
+#
+#   1. Functional (expression) indexes are dropped -- MariaDB has no equivalent.
+#      They are matched structurally rather than by name, since the set of them
+#      grows over time. NOTE that dropping a functional UNIQUE KEY also drops
+#      the uniqueness constraint it enforced.
+#   2. TABLESPACE directives are dropped; MariaDB handles them differently.
+#   3. `) STORED NOT NULL` becomes `) STORED`. MariaDB accepts a generated
+#      stored column but rejects a nullability clause after STORED.
+#   4. Generated columns that reference a column declared later in the same
+#      CREATE TABLE are moved down past that column. MySQL resolves such forward
+#      references; MariaDB rejects them with error 1901.
+#   5. A CHAR column referenced by an *indexed* generated column is widened to
+#      VARCHAR of the same length. MariaDB refuses to index a generated column
+#      whose expression mixes CHAR and VARCHAR operands, reporting error 1901
+#      against the whole expression. CHAR(n) right-pads on storage and strips
+#      the padding on retrieval, so for the fixed-width values these columns
+#      hold the two types are interchangeable.
 
 set -e
 
@@ -8,43 +31,112 @@ OUTPUT="server/datastore/mysql/schema-mariadb.sql"
 
 echo "Converting schema.sql to MariaDB-compatible format..."
 
-cat > "$OUTPUT" << 'EOF'
-SET FOREIGN_KEY_CHECKS=0;
-SET SESSION sql_mode='';
+python3 - "$INPUT" "$OUTPUT" << 'PYEOF'
+import re, sys
 
-EOF
+src, dst = sys.argv[1], sys.argv[2]
+lines = open(src).readlines()
 
-cat "$INPUT" >> "$OUTPUT"
+FUNCTIONAL_INDEX = re.compile(r'^\s*(?:UNIQUE |FULLTEXT |SPATIAL )?KEY `[^`]+` \(\(')
+COLUMN_DEF = re.compile(r'^\s*`(?P<name>[^`]+)`\s')
+GENERATED = re.compile(r'GENERATED ALWAYS AS')
 
-cat >> "$OUTPUT" << 'EOF'
+dropped = 0
+out = []
+i = 0
+while i < len(lines):
+    line = lines[i]
 
-SET FOREIGN_KEY_CHECKS=1;
-EOF
+    if not line.startswith('CREATE TABLE '):
+        out.append(line)
+        i += 1
+        continue
 
-# Remove the functional indexes - MariaDB doesn't support this
-if [[ "$OSTYPE" == "darwin"* ]]; then
-  sed -i '' '/KEY `idx_host_vpp_software_installs_verification`/d' "$OUTPUT"
-  sed -i '' '/KEY `idx_host_in_house_software_installs_verification`/d' "$OUTPUT"
-else
-  sed -i '/KEY `idx_host_vpp_software_installs_verification`/d' "$OUTPUT"
-  sed -i '/KEY `idx_host_in_house_software_installs_verification`/d' "$OUTPUT"
-fi
+    # Collect the whole CREATE TABLE statement.
+    start = i
+    while not lines[i].startswith(')'):
+        i += 1
+    end = i  # line index of the closing ") ENGINE=..." line
 
-# Remove TABLESPACE directives - MariaDB handles these differently
-if [[ "$OSTYPE" == "darwin"* ]]; then
-  sed -i '' 's/\/\*!50100 TABLESPACE `innodb_system` \*\/ //g' "$OUTPUT"
-else
-  sed -i 's/\/\*!50100 TABLESPACE `innodb_system` \*\/ //g' "$OUTPUT"
-fi
+    body = lines[start + 1:end]
+    kept = []
+    for b in body:
+        if FUNCTIONAL_INDEX.match(b):
+            dropped += 1
+            continue
+        b = b.replace('/*!50100 TABLESPACE `innodb_system` */ ', '')
+        b = b.replace(') STORED NOT NULL', ') STORED')
+        kept.append(b)
 
-# Fix STORED NOT NULL -> just STORED (MariaDB supports theses just different syntax)
-if [[ "$OSTYPE" == "darwin"* ]]; then
-  sed -i '' 's/) STORED NOT NULL/) STORED/g' "$OUTPUT"
-else
-  sed -i 's/) STORED NOT NULL/) STORED/g' "$OUTPUT"
-fi
+    # Reorder generated columns that forward-reference a later column. Only
+    # column definitions move; keys and constraints keep their relative order.
+    positions = {}
+    for idx, b in enumerate(kept):
+        m = COLUMN_DEF.match(b)
+        if m:
+            positions.setdefault(m.group('name'), idx)
+
+    moved = True
+    guard = 0
+    while moved and guard < 100:
+        moved = False
+        guard += 1
+        for idx, b in enumerate(kept):
+            m = COLUMN_DEF.match(b)
+            if not m or not GENERATED.search(b):
+                continue
+            # every other column this expression names
+            refs = [r for r in re.findall(r'`([^`]+)`', b)[1:] if r in positions]
+            latest = max((positions[r] for r in refs), default=-1)
+            if latest > idx:
+                col = kept.pop(idx)
+                kept.insert(latest, col)
+                positions = {}
+                for j, bb in enumerate(kept):
+                    mm = COLUMN_DEF.match(bb)
+                    if mm:
+                        positions.setdefault(mm.group('name'), j)
+                moved = True
+                break
+
+    # Widen CHAR columns feeding an indexed generated column (see header note 5).
+    indexed = set()
+    for b in kept:
+        m = re.match(r'^\s*(?:UNIQUE |FULLTEXT |SPATIAL )?KEY `[^`]+` \((.*)\)', b)
+        if m:
+            indexed.update(re.findall(r'`([^`]+)`', m.group(1)))
+    needs_varchar = set()
+    for b in kept:
+        m = COLUMN_DEF.match(b)
+        if m and GENERATED.search(b) and m.group('name') in indexed:
+            needs_varchar.update(re.findall(r'`([^`]+)`', b)[1:])
+    for idx, b in enumerate(kept):
+        m = COLUMN_DEF.match(b)
+        if m and m.group('name') in needs_varchar:
+            kept[idx] = re.sub(r'(`[^`]+`\s+)char\((\d+)\)', r'\1varchar(\2)', b, count=1)
+
+    # A removed or moved line can leave a dangling comma on the final item.
+    for idx in range(len(kept) - 1, -1, -1):
+        if kept[idx].strip():
+            kept[idx] = re.sub(r',(\s*)$', r'\1', kept[idx])
+            break
+
+    closing = lines[end].replace('/*!50100 TABLESPACE `innodb_system` */ ', '')
+
+    out.append(lines[start])
+    out.extend(kept)
+    out.append(closing)
+    i = end + 1
+
+with open(dst, 'w') as f:
+    f.write("SET FOREIGN_KEY_CHECKS=0;\nSET SESSION sql_mode='';\n\n")
+    f.writelines(out)
+    f.write("\nSET FOREIGN_KEY_CHECKS=1;\n")
+
+print(f"removed {dropped} functional index definition(s)", file=sys.stderr)
+PYEOF
 
 echo "✓ MariaDB-compatible schema created at: $OUTPUT"
 echo ""
 echo "To import into MariaDB, run:"
-echo "mysql --host localhost --user root --protocol=tcp -P 3306 --password fleet < $OUTPUT"
+echo "mariadb --host localhost --user root --protocol=tcp -P 3306 --password fleet < $OUTPUT"

--- a/tools/mariadb/fix-mariadb-schema.sh
+++ b/tools/mariadb/fix-mariadb-schema.sh
@@ -17,7 +17,11 @@
 #   4. Generated columns that reference a column declared later in the same
 #      CREATE TABLE are moved down past that column. MySQL resolves such forward
 #      references; MariaDB rejects them with error 1901.
-#   5. A CHAR column referenced by an *indexed* generated column is widened to
+#   5. UUID_TO_BIN/BIN_TO_UUID are emitted as stored functions. They are MySQL 8
+#      built-ins that MariaDB does not provide, and Fleet's certificate-template
+#      queries call them; defining them in the schema fixes every call site
+#      without touching the queries.
+#   6. A CHAR column referenced by an *indexed* generated column is widened to
 #      VARCHAR of the same length. MariaDB refuses to index a generated column
 #      whose expression mixes CHAR and VARCHAR operands, reporting error 1901
 #      against the whole expression. CHAR(n) right-pads on storage and strips
@@ -128,9 +132,41 @@ while i < len(lines):
     out.append(closing)
     i = end + 1
 
+# MySQL 8 provides UUID_TO_BIN/BIN_TO_UUID as built-ins; MariaDB does not, and
+# Fleet's certificate-template queries call them (Error 1305 otherwise). The
+# swap flag reorders the time fields (time_high, time_mid, time_low) exactly as
+# MySQL does, which is the form Fleet uses.
+UUID_FUNCS = """
+DROP FUNCTION IF EXISTS UUID_TO_BIN;
+DROP FUNCTION IF EXISTS BIN_TO_UUID;
+
+CREATE FUNCTION UUID_TO_BIN(uuid CHAR(36), swap BOOLEAN)
+RETURNS BINARY(16) DETERMINISTIC
+RETURN UNHEX(
+  IF(swap,
+    CONCAT(SUBSTRING(uuid,15,4), SUBSTRING(uuid,10,4), SUBSTRING(uuid,1,8),
+           SUBSTRING(uuid,20,4), SUBSTRING(uuid,25,12)),
+    CONCAT(SUBSTRING(uuid,1,8), SUBSTRING(uuid,10,4), SUBSTRING(uuid,15,4),
+           SUBSTRING(uuid,20,4), SUBSTRING(uuid,25,12))
+  )
+);
+
+CREATE FUNCTION BIN_TO_UUID(b BINARY(16), swap BOOLEAN)
+RETURNS CHAR(36) DETERMINISTIC
+RETURN LOWER(
+  IF(swap,
+    CONCAT(SUBSTRING(HEX(b),9,8), '-', SUBSTRING(HEX(b),5,4), '-', SUBSTRING(HEX(b),1,4), '-',
+           SUBSTRING(HEX(b),17,4), '-', SUBSTRING(HEX(b),21,12)),
+    CONCAT(SUBSTRING(HEX(b),1,8), '-', SUBSTRING(HEX(b),9,4), '-', SUBSTRING(HEX(b),13,4), '-',
+           SUBSTRING(HEX(b),17,4), '-', SUBSTRING(HEX(b),21,12))
+  )
+);
+"""
+
 with open(dst, 'w') as f:
     f.write("SET FOREIGN_KEY_CHECKS=0;\nSET SESSION sql_mode='';\n\n")
     f.writelines(out)
+    f.write(UUID_FUNCS)
     f.write("\nSET FOREIGN_KEY_CHECKS=1;\n")
 
 print(f"removed {dropped} functional index definition(s)", file=sys.stderr)


### PR DESCRIPTION
**Related issue:** part of #31288. Fixes #34813, #34814, #34862, #34816, #34952.

This rebuilds the MariaDB work from the closed #34663 on top of current `main` (~7600 commits of drift), and fixes the five remaining open sub-tasks.

MariaDB is **not** made a supported database here. The goal is narrower: get the Go test suites running against MariaDB so the remaining gap is visible and measurable, without changing any behaviour on MySQL.

---

## The short version

Four of the five open sub-tasks turned out to be **one bug wearing four hats**.

Fleet has a query shape that looks like this:

```sql
SELECT h.id FROM hosts h
WHERE EXISTS (
    SELECT 1 FROM (
        SELECT ... WHERE lm.host_id = h.id    -- ← reaches out to `h`
        UNION
        SELECT ... WHERE lm.host_id = h.id
    ) t
)
```

The inner `FROM ( ... ) t` is a **derived table**. A derived table is computed on its own, before the query around it, so it cannot see `h`. MySQL quietly resolves the reference anyway. MariaDB does not, and reports:

```
ERROR 1054 (42S22): Unknown column 'h.id' in 'ON'
```

The fix is the same in each case: a `UNION` inside `EXISTS` produces a row exactly when *at least one* of its arms does, so it can be rewritten as a plain **OR of correlated `EXISTS` subqueries** — and a correlated `EXISTS` *is* allowed to reference the outer query on both engines.

```sql
SELECT h.id FROM hosts h
WHERE (
    EXISTS (SELECT 1 FROM ... WHERE lm.host_id = h.id)   -- arm 1
    OR
    EXISTS (SELECT 1 FROM ... WHERE lm.host_id = h.id)   -- arm 2
)
```

No behaviour change on MySQL. Same rows, same order, same NULLs — verified below.

| Before | After |
|---|---|
| `EXISTS (SELECT 1 FROM (A UNION B) t)` | `EXISTS(A) OR EXISTS(B)` |
| arm filters via `HAVING count_alias > 0` | `HAVING COUNT(*) > 0` (a `SELECT 1` exposes no aliases) |
| `col->'$.x'` / `col->>'$.x'` | `JSON_EXTRACT(col,'$.x')` / `JSON_UNQUOTE(JSON_EXTRACT(col,'$.x'))` |
| `CAST(TRUE AS JSON)` | dialect helper — MariaDB has no JSON type |
| `args = CAST(? AS JSON)` | `JSON_NORMALIZE(args) = JSON_NORMALIZE(?)` on MariaDB |

---

## Issue by issue

### #34814 — `Unknown column 'h.id' in 'ON'`

`labelScopedFilter` in `software_installers.go`. Rewritten as described above. It is now a boolean expression rather than a subquery, so its three call sites changed from `EXISTS (%s)` / `NOT EXISTS (%s)` to `%s` / `NOT %s`.

### #34813 — `Unknown column 'vhc.cve' in 'WHERE'`

`ListVulnerabilities` computed the earliest `created_at` with `(SELECT MIN(created_at) FROM ( ... UNION ALL ... ) AS combined_dates)`, correlated on the outer alias. Replaced by `minCVECreatedAtExpr()`, which uses two correlated scalar subqueries:

```sql
LEAST(COALESCE(sc_min, os_min), COALESCE(os_min, sc_min))
```

The `COALESCE` pair matters: `LEAST` returns `NULL` if any argument is `NULL`, so this keeps the result correct when the CVE is recorded in only one of the two tables, and `NULL` when in neither — matching `MIN` over an empty union.

The issue mentions the two statements in the legacy builder; there is **a third occurrence** in `buildListVulnerabilitiesSQL` (correlated on `p`) that has the same defect. All three are fixed.

### #34862 — `Unknown column 'si.id' in 'WHERE'`

The label-membership check in `ListHostSoftware`'s `stmtAvailable` — the same shape with **ten** `UNION` arms across installers, VPP apps and in-house apps.

⚠️ The arms are **not** interchangeable: the installer exclude-arm tests `lbl.label_membership_type <> 1` where the VPP and in-house arms test `= 0`. Each arm is therefore reproduced verbatim rather than generated from a shared template, which would have silently changed behaviour.

### #34816 — `Error 1020 (ER_CHECKREAD)`

`applyEnrollSecretsDB` reads the existing secrets, deletes them, and re-inserts them inside one transaction, to preserve `created_at`. The initial read was non-locking, so a concurrent writer can change a row between the read and the `DELETE`; MariaDB fails the transaction, MySQL proceeds and can carry a stale `created_at`. The read is now `... FOR UPDATE`.

**Caveat:** unlike the three above, I could not reproduce 1020 locally — it needs concurrent transactions under load. This fix is reasoned from the error semantics rather than demonstrated, so it deserves a closer look than the others.

### #34952 — migration tests

Confirmed: replaying migration history on MariaDB dies at `20240905200000_UninstallPackages.go`, on

```sql
ADD COLUMN status ENUM(...) GENERATED ALWAYS AS (CASE ...) STORED NULL
```

MySQL accepts a nullability clause after `STORED`; MariaDB's parser does not. Applied migrations can't be rewritten, so this takes the approach the issue proposes: **MariaDB starts from a point-in-time schema dump.** `LoadDefaultSchema` loads `schema-mariadb.sql` instead of `schema.sql`, and the three history-replaying tests skip with a message pointing here.

`tools/mariadb/fix-mariadb-schema.sh` had drifted badly (it hardcoded two functional-index names; `main` now has three) and is rewritten. It now handles, structurally:

1. functional indexes — dropped, MariaDB has no equivalent *(note: this drops one `UNIQUE` constraint)*;
2. `TABLESPACE` directives;
3. `) STORED NOT NULL` → `) STORED`;
4. generated columns that forward-reference a later column — moved past it;
5. **a `CHAR` column feeding an indexed generated column — widened to `VARCHAR`.**

Number 5 was the surprising one and cost the most time, so it's worth writing down. MariaDB refuses to *index* a generated column whose `COALESCE` mixes `CHAR` and `VARCHAR` operands:

```
ERROR 1901 (HY000): Function or expression
'coalesce(`bundle_identifier`,`application_id`,nullif(`upgrade_code`,_utf8mb4''),`name`)'
cannot be used in the GENERATED ALWAYS AS clause of `unique_identifier`
```

The message blames the whole expression, which sends you down the wrong path. It is *not* `NULLIF`, not the charset introducer, and not the column ordering — the error survives rewriting `NULLIF` as `CASE` or `IF`, switching `VIRTUAL` to `STORED`, and reordering the columns. It is purely that `software_titles.upgrade_code` is `char(38)` while its siblings are `varchar(255)`. Widen it and the original expression is accepted unchanged. `CHAR(n)` right-pads on storage and strips on retrieval, so for these fixed-width values the two types are interchangeable.

---

## Reproducing this

Everything below runs against the containers already in the repo.

**See the failures on `main`** — start MariaDB and run any suite:

```sh
docker compose -f docker-compose.yml -f docker-compose-mariadb.yml up -d mysql_test
FLEET_DB_CLIENT=mariadb MYSQL_TEST=1 go test ./server/datastore/mysql/ -run TestVulnerabilities -count=1
```

**Confirm the migration wall independently** (no checkout needed):

```sh
docker run -d --name mdb -e MARIADB_ROOT_PASSWORD=t -e MARIADB_DATABASE=fleet mariadb:11.4
docker run --rm --network host -e FLEET_MYSQL_ADDRESS=127.0.0.1:3306 \
  -e FLEET_MYSQL_USERNAME=root -e FLEET_MYSQL_PASSWORD=t -e FLEET_MYSQL_DATABASE=fleet \
  fleetdm/fleet:v4.90.0 fleet prepare db --no-prompt
# → FAIL 20240905200000_UninstallPackages.go ... near 'NULL, MODIFY COLUMN created_at ...'
```

**Regenerate the baseline** after adding migrations:

```sh
./tools/mariadb/fix-mariadb-schema.sh   # schema.sql → schema-mariadb.sql
```

---

## How the rewrites were verified

Each rewritten query was checked by **differential testing** against live MySQL 8.4 and MariaDB 11.4 containers: run the old and new form on MySQL and diff the result sets, then run the new form on MariaDB, then confirm the old form reproduces the exact error from the issue.

| Query | Cases | MySQL old = new | MariaDB new | Old on MariaDB |
|---|---|---|---|---|
| `labelScopedFilter` | 6 label configs × positive/negated | 12/12 identical | passes | `Unknown column 'h.id' in 'ON'` |
| CVE `created_at` | both tables / one / neither / multi-row | identical incl. `NULL` | passes | `Unknown column 'vhc.cve' in 'WHERE'` |
| host software label scope | 12 titles: no-labels, include-any, include-all, exclude-any, stale-label timestamps, installer + VPP + in-house | identical | passes | `Unknown column 'si.id' in 'WHERE'` |

The regenerated baseline imports cleanly into MariaDB 11.4 and matches the MySQL schema: **228 tables, 1779 columns, 193 foreign keys**, with indexes differing by exactly the 3 dropped functional indexes.

Suite status:

```
FLEET_DB_CLIENT=mariadb MYSQL_TEST=1 go test ./server/datastore/mysql/ -run TestVulnerabilities   → ok
MYSQL_TEST=1 go test ./server/datastore/mysql/ -run 'TestVulnerabilities|TestMigrationStatus'     → ok (MySQL unaffected)
```

---

## Notes for reviewers

- **`ONLY_FULL_GROUP_BY` is dropped for MariaDB test runs.** MySQL's implementation recognises columns functionally dependent on the grouped columns via a unique key; MariaDB's does not, so valid-on-MySQL aggregates fail with `Error 1055`. Dropping the one mode was preferred over rewriting every aggregate query. The strict modes that guard against silent data loss still apply. This is test-only.
- **No compose services were renamed.** #34663 renamed `mysql_test` → `database_test` (43 references across 17 files); `docker-compose-mariadb.yml` here instead overrides the `image` and `command` of the existing services, so nothing else changes.
- **CI is cron-only and `continue-on-error`,** and deliberately not wired to Slack — MariaDB is experimental and shouldn't page anyone.
- MariaDB 11.x ships only the `mariadb` client, not the `mysql` symlink, so shell-outs pick whichever exists. Go `sql.Open` driver names stay `"mysql"` — go-sql-driver handles both engines.
- The dialect helpers select SQL at query-build time from a single `SELECT VERSION()` probe; the MySQL path emits byte-identical SQL to before.

### Still not working

This does not make MariaDB usable. Known remaining gaps:

- Migration history cannot be replayed; MariaDB is baseline-only, so a MariaDB deployment has no upgrade path yet.
- Per-migration tests in `migrations/tables` are MySQL-only for the same reason, so new migrations aren't automatically checked against MariaDB.
- The full suite has not been run green end-to-end — the nightly job exists to find what's left.
- Dropping the functional `UNIQUE KEY` means one uniqueness constraint is not enforced on MariaDB.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Compatibility**
  * Improved MariaDB 11.4 compatibility across database queries, JSON handling, software labels, host reports, and schema setup.
  * Added automatic database-client and schema selection for MySQL and MariaDB environments.
  * Added tooling to prepare MySQL schemas for MariaDB.

* **Reliability**
  * Improved consistency when updating enrollment secrets during concurrent changes.
  * Enhanced vulnerability and activity query behavior across supported database configurations.

* **Tests**
  * Added nightly MariaDB coverage for database-dependent test suites.

* **Documentation**
  * Documented MariaDB compatibility updates and current support limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->