### PR TITLE
fix outdated osquery schema

### DIFF
--- a/schema/osquery_fleet_schema.json
+++ b/schema/osquery_fleet_schema.json
@@ -19693,8 +19693,8 @@
     ],
     "evented": false,
     "cacheable": false,
-    "notes": "- On ChromeOS, this table requires the [fleetd Chrome extension](https://fleetdm.com/docs/using-fleet/chromeos).",
-    "examples": "See the OS version as well as the CPU architecture in use (X86 vs ARM for\nexample)\n\n```\nSELECT arch, version FROM os_version;\n```",
+    "notes": "- Though the `os_version` table `version` column VALUE type is STRING, osquery correctly handles semantic-version ordering via collate=\"version\" in this table column the same way it handles `version` columns in many other tables. (i.e., codegen declares the `version` column as ... COLLATE VERSION in the CREATE TABLE statement it hands to SQLite when registering the virtual table.) This means the `version` column can be used for OS version comparisons without needing the `major`, `minor` or `patch` columns.\n- On ChromeOS, this table requires the [fleetd Chrome extension](https://fleetdm.com/docs/using-fleet/chromeos).",
+    "examples": "See the OS version as well as the CPU architecture in use (X86 vs ARM for\nexample)\n\n```\nSELECT arch, version FROM os_version; \n```\n\nCreate a policy query that causes a Mac to fail a policy if the macOS version is older than 26.6.1 & either Screen Sharing or Remote Management is enabled -\n\n```\nSELECT 1\nFROM os_version, sharing_preferences\nWHERE version < '26.6.1'\nAND (sharing_preferences.screen_sharing = 1 OR sharing_preferences.remote_management = 1);\n```",
     "columns": [
       {
         "name": "name",


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves  failing CI

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how operating system versions are ordered and compared.
  * Added a macOS policy query example combining version and sharing settings.
  * Improved formatting for existing SQL examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->