### PR TITLE
Document GitOps behavior for the get host by identifier endpoint

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -4330,6 +4330,8 @@ If `hostname` is specified when there is more than one host with the same hostna
 
 > In Fleet, hostnames are fully qualified domain names (FQDNs). `hostname` (e.g. johns-macbook-air.local) is **not** the same as `display_name` (e.g. John's MacBook Air).
 
+> Note: GitOps users don't have host read access. For them, this endpoint returns the host's `id` and nothing else, rather than an error like [Get host](#get-host) does.
+
 `GET /api/v1/fleet/hosts/identifier/:identifier`
 
 #### Parameters


### PR DESCRIPTION
Documents the API behavior changed in #50945: since GitOps users have no host read access, `GET /hosts/identifier/:identifier` returns the host's `id` and nothing else for them, rather than an error like Get host does.