### PR TITLE
Allow users to filter the Dashboard by severity (CVSS score)

### DIFF
--- a/changes/47326-filter-vulnerability-exposure-by-severity
+++ b/changes/47326-filter-vulnerability-exposure-by-severity
@@ -1,0 +1,2 @@
+- Added a severity (CVSS) filter to the vulnerability exposure chart, defaulting to critical severity.
+- Updated the severity (CVSS) filter on the software, host details, and my device pages so the min and max score inputs appear only when custom severity is selected.

--- a/changes/47326-filter-vulnerability-exposure-by-severity
+++ b/changes/47326-filter-vulnerability-exposure-by-severity
@@ -1,5 +1,1 @@
-- Added a severity (CVSS) filter to the vulnerability exposure chart, defaulting to critical severity.
-- Updated the severity (CVSS) filter on the software, host details, and my device pages so the min and max score inputs appear only when custom severity is selected.
-- The Vulnerability exposure chart API now applies the `severity_min` and `severity_max` parameters, and echoes the applied bounds in the response's `filters` object. 
-- `GET /api/v1/fleet/charts/cve` now requires a Fleet Premium license and returns HTTP 402 without one.
-- Fleet Free installs no longer collect vulnerability exposure history, since the chart that reads it is available only with Fleet Premium.
+- Added a severity (CVSS score) filter to the Vulnerability exposure dashboard chart, which now requires Fleet Premium, and updated the severity filter on the **Software**, **Host details**, and **My device** pages so the min and max score inputs appear only when custom severity is selected.

--- a/changes/47326-filter-vulnerability-exposure-by-severity
+++ b/changes/47326-filter-vulnerability-exposure-by-severity
@@ -1,2 +1,5 @@
 - Added a severity (CVSS) filter to the vulnerability exposure chart, defaulting to critical severity.
 - Updated the severity (CVSS) filter on the software, host details, and my device pages so the min and max score inputs appear only when custom severity is selected.
+- The Vulnerability exposure chart API now applies the `severity_min` and `severity_max` parameters, and echoes the applied bounds in the response's `filters` object. 
+- `GET /api/v1/fleet/charts/cve` now requires a Fleet Premium license and returns HTTP 402 without one.
+- Fleet Free installs no longer collect vulnerability exposure history, since the chart that reads it is available only with Fleet Premium.

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -1627,11 +1627,15 @@ func newCleanupsAndAggregationSchedule(
 }
 
 // buildChartScopeResolver returns a per-dataset scope resolver for the chart
-// collection cron. It computes (skip, disabledFleetIDs) from the global and
-// per-team historical-data flags. Extracted from the cron closure so it can be
-// unit-tested without spinning up a schedule.
-func buildChartScopeResolver(appCfg *fleet.AppConfig, teams []*fleet.Team, logger *slog.Logger) chart_api.CollectScopeFn {
+// collection cron. It computes (skip, disabledFleetIDs) from the license and the
+// global and per-team historical-data flags. Extracted from the cron closure so
+// it can be unit-tested without spinning up a schedule.
+func buildChartScopeResolver(appCfg *fleet.AppConfig, teams []*fleet.Team, isPremium bool, logger *slog.Logger) chart_api.CollectScopeFn {
 	return func(name string) (skip bool, disabledFleetIDs []uint) {
+		if name == chart_api.MetricCVE && !isPremium {
+			return true, nil
+		}
+
 		ok, err := appCfg.Features.HistoricalData.Enabled(name)
 		if err != nil {
 			// Unknown dataset — fall back to enabled with no team filter.
@@ -1662,6 +1666,7 @@ func newChartDataCollectionSchedule(
 	instanceID string,
 	ds fleet.Datastore,
 	chartSvc chart_api.Service,
+	isPremium bool,
 	logger *slog.Logger,
 ) (*schedule.Schedule, error) {
 	const (
@@ -1690,7 +1695,7 @@ func newChartDataCollectionSchedule(
 				logger.ErrorContext(ctx, "list teams for chart scope", "err", err)
 				return ctxerr.Wrap(ctx, err, "list teams for chart scope")
 			}
-			return chartSvc.CollectDatasets(ctx, time.Now(), buildChartScopeResolver(appCfg, teams, logger))
+			return chartSvc.CollectDatasets(ctx, time.Now(), buildChartScopeResolver(appCfg, teams, isPremium, logger))
 		}),
 	)
 

--- a/cmd/fleet/cron_registration.go
+++ b/cmd/fleet/cron_registration.go
@@ -86,7 +86,8 @@ func startCronSchedules(ctx context.Context, deps cronSchedulesDeps) {
 func registerCleanupAndMaintenanceCrons(ctx context.Context, deps cronSchedulesDeps) {
 	if os.Getenv("FLEET_SKIP_CHART_DATA_COLLECTION") == "" {
 		deps.register("failed to register chart_data_collection schedule", func() (fleet.CronSchedule, error) {
-			return newChartDataCollectionSchedule(ctx, deps.instanceID, deps.ds, deps.chartSvc, deps.logger)
+			return newChartDataCollectionSchedule(ctx, deps.instanceID, deps.ds, deps.chartSvc,
+				deps.license != nil && deps.license.IsPremium(), deps.logger)
 		})
 	} else {
 		deps.logger.InfoContext(ctx, "skipping chart data collection cron (FLEET_SKIP_CHART_DATA_COLLECTION is set)")

--- a/cmd/fleet/cron_test.go
+++ b/cmd/fleet/cron_test.go
@@ -269,14 +269,14 @@ func TestBuildChartScopeResolver(t *testing.T) {
 	}
 
 	t.Run("global off → skip", func(t *testing.T) {
-		scope := buildChartScopeResolver(makeAppCfg(false, true), nil, nil)
+		scope := buildChartScopeResolver(makeAppCfg(false, true), nil, true, nil)
 		skip, disabled := scope("uptime")
 		require.True(t, skip)
 		require.Nil(t, disabled)
 	})
 
 	t.Run("global on, no teams → no scoping", func(t *testing.T) {
-		scope := buildChartScopeResolver(makeAppCfg(true, true), nil, nil)
+		scope := buildChartScopeResolver(makeAppCfg(true, true), nil, true, nil)
 		skip, disabled := scope("uptime")
 		require.False(t, skip)
 		require.Nil(t, disabled)
@@ -286,6 +286,7 @@ func TestBuildChartScopeResolver(t *testing.T) {
 		scope := buildChartScopeResolver(
 			makeAppCfg(true, true),
 			[]*fleet.Team{makeTeam(1, true, true), makeTeam(2, true, true)},
+			true,
 			nil,
 		)
 		skip, disabled := scope("uptime")
@@ -302,6 +303,7 @@ func TestBuildChartScopeResolver(t *testing.T) {
 				makeTeam(3, true, true),
 				makeTeam(4, false, true), // uptime disabled on team 4
 			},
+			true,
 			nil,
 		)
 		skip, disabled := scope("uptime")
@@ -317,6 +319,7 @@ func TestBuildChartScopeResolver(t *testing.T) {
 				makeTeam(2, false, true), // uptime only on team 2
 				makeTeam(3, true, true),
 			},
+			true,
 			nil,
 		)
 		skipU, disabledU := scope("uptime")
@@ -332,6 +335,7 @@ func TestBuildChartScopeResolver(t *testing.T) {
 		scope := buildChartScopeResolver(
 			makeAppCfg(true, false),
 			[]*fleet.Team{makeTeam(1, true, true)},
+			true,
 			nil,
 		)
 		skip, disabled := scope("cve")
@@ -340,8 +344,39 @@ func TestBuildChartScopeResolver(t *testing.T) {
 	})
 
 	t.Run("unknown dataset name falls through to no-scope", func(t *testing.T) {
-		scope := buildChartScopeResolver(makeAppCfg(true, true), nil, nil)
+		scope := buildChartScopeResolver(makeAppCfg(true, true), nil, true, nil)
 		skip, disabled := scope("unknown_dataset")
+		require.False(t, skip)
+		require.Nil(t, disabled)
+	})
+
+	t.Run("free tier skips cve even when the config enables it", func(t *testing.T) {
+		scope := buildChartScopeResolver(
+			makeAppCfg(true, true),
+			[]*fleet.Team{makeTeam(1, true, true)},
+			false,
+			nil,
+		)
+		skip, disabled := scope("cve")
+		require.True(t, skip)
+		require.Nil(t, disabled)
+	})
+
+	t.Run("free tier still collects uptime", func(t *testing.T) {
+		scope := buildChartScopeResolver(
+			makeAppCfg(true, true),
+			[]*fleet.Team{makeTeam(1, true, true), makeTeam(2, false, true)},
+			false,
+			nil,
+		)
+		skip, disabled := scope("uptime")
+		require.False(t, skip)
+		require.ElementsMatch(t, []uint{2}, disabled, "per-fleet uptime scoping is unaffected by the license")
+	})
+
+	t.Run("premium with cve enabled collects it", func(t *testing.T) {
+		scope := buildChartScopeResolver(makeAppCfg(true, true), nil, true, nil)
+		skip, disabled := scope("cve")
 		require.False(t, skip)
 		require.Nil(t, disabled)
 	})

--- a/frontend/components/SeverityFilter/SeverityFilter.tests.tsx
+++ b/frontend/components/SeverityFilter/SeverityFilter.tests.tsx
@@ -1,0 +1,281 @@
+import React, { useState } from "react";
+import { render, screen } from "@testing-library/react";
+import { noop } from "lodash";
+
+import { renderWithSetup } from "test/test-utils";
+
+import SeverityFilter, { ISeverityFilterValue } from "./SeverityFilter";
+import { SEVERITY_SCORE_RANGE_ERROR, validateSeverityScores } from "./helpers";
+
+const ControlledSeverityFilter = ({
+  severity = "any",
+  minScore = "",
+  maxScore = "",
+  onChange,
+  validate = false,
+}: Partial<ISeverityFilterValue> & {
+  onChange?: (next: ISeverityFilterValue) => void;
+  validate?: boolean;
+}) => {
+  const [value, setValue] = useState<ISeverityFilterValue>({
+    severity,
+    minScore,
+    maxScore,
+  });
+
+  return (
+    <SeverityFilter
+      {...value}
+      errors={validate ? validateSeverityScores(value) : undefined}
+      onChange={(next) => {
+        setValue(next);
+        onChange?.(next);
+      }}
+    />
+  );
+};
+
+const selectSeverity = async (
+  user: ReturnType<typeof renderWithSetup>["user"],
+  label: string
+) => {
+  await user.click(screen.getByRole("combobox", { name: "Severity" }));
+  const option = screen
+    .getAllByTestId("dropdown-option")
+    .find((el) => el.textContent?.startsWith(label));
+  if (!option) {
+    throw new Error(`No severity option matching "${label}"`);
+  }
+  await user.click(option);
+};
+
+const getMinInput = () => screen.getByLabelText(/Min score/i);
+const getMaxInput = () => screen.getByLabelText(/Max score/i);
+const querySeverityLabel = (label: RegExp) => screen.queryByText(label);
+
+describe("SeverityFilter", () => {
+  it("renders the dropdown with its tooltip label and help text", () => {
+    render(
+      <SeverityFilter severity="any" minScore="" maxScore="" onChange={noop} />
+    );
+
+    expect(screen.getByText("Severity")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "CVSS scores (v3) range from 0.0 to 10.0 in 0.1 increments."
+      )
+    ).toBeInTheDocument();
+  });
+
+  describe("option labels", () => {
+    it("shows the plain label for the active selection", () => {
+      const { rerender } = render(
+        <SeverityFilter
+          severity="critical"
+          minScore="9"
+          maxScore="10"
+          onChange={noop}
+        />
+      );
+
+      expect(screen.getByText("Critical severity")).toBeInTheDocument();
+      expect(
+        screen.queryByText("Critical (9.0 to 10)")
+      ).not.toBeInTheDocument();
+
+      rerender(
+        <SeverityFilter
+          severity="custom"
+          minScore="2.5"
+          maxScore="6"
+          onChange={noop}
+        />
+      );
+
+      expect(screen.getByText("Custom severity")).toBeInTheDocument();
+      expect(screen.queryByText("Custom (2.5 to 6)")).not.toBeInTheDocument();
+    });
+
+    it("opens the menu focused on the current selection, not the first row", async () => {
+      const onChange = jest.fn();
+      const { user } = renderWithSetup(
+        <SeverityFilter
+          severity="critical"
+          minScore="9"
+          maxScore="10"
+          onChange={onChange}
+        />
+      );
+
+      await user.click(screen.getByRole("combobox", { name: "Severity" }));
+      await user.keyboard("{Enter}");
+
+      expect(onChange).toHaveBeenCalledWith({
+        severity: "critical",
+        minScore: "9",
+        maxScore: "10",
+      });
+    });
+  });
+
+  it("hides the score inputs for every preset and shows them only for Custom", async () => {
+    const { user } = renderWithSetup(<ControlledSeverityFilter />);
+
+    expect(screen.queryByLabelText(/Min score/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/Max score/i)).not.toBeInTheDocument();
+
+    await selectSeverity(user, "Critical severity");
+    expect(screen.queryByLabelText(/Min score/i)).not.toBeInTheDocument();
+
+    await selectSeverity(user, "High severity");
+    expect(screen.queryByLabelText(/Min score/i)).not.toBeInTheDocument();
+
+    await selectSeverity(user, "Medium severity");
+    expect(screen.queryByLabelText(/Min score/i)).not.toBeInTheDocument();
+
+    await selectSeverity(user, "Low severity");
+    expect(screen.queryByLabelText(/Min score/i)).not.toBeInTheDocument();
+
+    await selectSeverity(user, "Custom severity");
+    expect(getMinInput()).toBeInTheDocument();
+    expect(getMaxInput()).toBeInTheDocument();
+  });
+
+  it("populates min/max from the selected preset", async () => {
+    const onChange = jest.fn();
+    const { user } = renderWithSetup(
+      <ControlledSeverityFilter onChange={onChange} />
+    );
+
+    await selectSeverity(user, "High severity");
+
+    expect(onChange).toHaveBeenLastCalledWith({
+      severity: "high",
+      minScore: "7",
+      maxScore: "8.9",
+    });
+
+    await selectSeverity(user, "Custom severity");
+    expect(onChange).toHaveBeenLastCalledWith({
+      severity: "custom",
+      minScore: "",
+      maxScore: "",
+    });
+    expect(getMinInput()).toHaveValue(null);
+    expect(getMaxInput()).toHaveValue(null);
+  });
+
+  it("starts Custom empty from a preset that was seeded, not clicked", async () => {
+    const { user } = renderWithSetup(
+      <ControlledSeverityFilter severity="medium" minScore="4" maxScore="6.9" />
+    );
+
+    await selectSeverity(user, "Custom severity");
+
+    expect(getMinInput()).toHaveValue(null);
+    expect(getMaxInput()).toHaveValue(null);
+  });
+
+  it("clears min/max when Any severity is selected", async () => {
+    const onChange = jest.fn();
+    const { user } = renderWithSetup(
+      <ControlledSeverityFilter
+        severity="high"
+        minScore="7"
+        maxScore="8.9"
+        onChange={onChange}
+      />
+    );
+
+    await selectSeverity(user, "Any severity");
+
+    expect(onChange).toHaveBeenLastCalledWith({
+      severity: "any",
+      minScore: "",
+      maxScore: "",
+    });
+
+    await selectSeverity(user, "Custom severity");
+    expect(getMinInput()).toHaveValue(null);
+    expect(getMaxInput()).toHaveValue(null);
+  });
+
+  describe("typing never changes the dropdown", () => {
+    const renderCustom = () =>
+      renderWithSetup(<ControlledSeverityFilter severity="custom" />);
+
+    const expectStillCustom = () => {
+      expect(querySeverityLabel(/^Custom\b/)).toBeInTheDocument();
+      expect(
+        querySeverityLabel(/^(Any|Critical|High|Medium|Low)\b/)
+      ).toBeNull();
+      expect(getMinInput()).toBeInTheDocument();
+      expect(getMaxInput()).toBeInTheDocument();
+    };
+
+    const typedCases: { label: string; min?: string; max?: string }[] = [
+      { label: "a lone 0 in Min", min: "0" },
+      { label: "a lone 9 in Min", min: "9" },
+      { label: "a lone 10 in Max", max: "10" },
+      { label: "a range matching a preset", min: "7", max: "8.9" },
+      { label: "decimals, one character at a time", min: "0.5", max: "9.5" },
+    ];
+
+    it.each(typedCases)(
+      "keeps Custom while typing $label",
+      async ({ min, max }) => {
+        const { user } = renderCustom();
+
+        if (min) await user.type(getMinInput(), min);
+        if (max) await user.type(getMaxInput(), max);
+
+        expectStillCustom();
+        expect(getMinInput()).toHaveValue(min ? Number(min) : null);
+        expect(getMaxInput()).toHaveValue(max ? Number(max) : null);
+      }
+    );
+
+    it("keeps Custom when both fields are cleared", async () => {
+      const { user } = renderWithSetup(
+        <ControlledSeverityFilter
+          severity="custom"
+          minScore="7"
+          maxScore="8.9"
+        />
+      );
+
+      await user.clear(getMinInput());
+      await user.clear(getMaxInput());
+
+      expectStillCustom();
+      expect(getMinInput()).toHaveValue(null);
+      expect(getMaxInput()).toHaveValue(null);
+    });
+  });
+
+  it("surfaces per-field errors from the validation helper", async () => {
+    const { user } = renderWithSetup(
+      <ControlledSeverityFilter severity="custom" validate />
+    );
+
+    await user.type(getMinInput(), "5.55");
+
+    expect(screen.getByText(SEVERITY_SCORE_RANGE_ERROR)).toBeInTheDocument();
+  });
+
+  it("disables the dropdown and the score inputs", () => {
+    render(
+      <SeverityFilter
+        severity="custom"
+        minScore=""
+        maxScore=""
+        onChange={noop}
+        disabled
+      />
+    );
+
+    expect(screen.getByRole("combobox", { name: "Severity" })).toBeDisabled();
+    expect(getMinInput()).toBeDisabled();
+    expect(getMaxInput()).toBeDisabled();
+  });
+});

--- a/frontend/components/SeverityFilter/SeverityFilter.tsx
+++ b/frontend/components/SeverityFilter/SeverityFilter.tsx
@@ -1,0 +1,124 @@
+import React from "react";
+import { SingleValue } from "react-select-5";
+
+import { IInputFieldParseTarget } from "interfaces/form_field";
+
+import DropdownWrapper from "components/forms/fields/DropdownWrapper";
+import { CustomOptionType } from "components/forms/fields/DropdownWrapper/DropdownWrapper";
+import InputField from "components/forms/fields/InputField";
+import TooltipWrapper from "components/TooltipWrapper";
+
+import {
+  CUSTOM_SEVERITY_VALUE,
+  getSeverityBand,
+  getSeverityOption,
+  ISeverityFieldErrors,
+  ISeverityFilterValue,
+  SEVERITY_DROPDOWN_OPTIONS,
+  SEVERITY_HELP_TEXT,
+  SeverityScoreField,
+} from "./helpers";
+
+const baseClass = "severity-filter";
+
+export type { ISeverityFilterValue };
+
+interface ISeverityFilterProps extends ISeverityFilterValue {
+  onChange: (next: ISeverityFilterValue) => void;
+  disabled?: boolean;
+  errors?: ISeverityFieldErrors;
+  onScoreBlur?: (field: SeverityScoreField) => void;
+  onScoreFocus?: (field: SeverityScoreField) => void;
+}
+
+const SeverityFilter = ({
+  severity,
+  minScore,
+  maxScore,
+  onChange,
+  disabled = false,
+  errors,
+  onScoreBlur,
+  onScoreFocus,
+}: ISeverityFilterProps) => {
+  const onChangeSeverity = (selected: SingleValue<CustomOptionType>) => {
+    const option = getSeverityOption(selected?.value);
+    if (!option) {
+      return;
+    }
+    const band = getSeverityBand(option.value);
+    onChange({
+      severity: option.value,
+      minScore: band ? String(band.min) : "",
+      maxScore: band ? String(band.max) : "",
+    });
+  };
+
+  const onScoreChange = ({ name, value }: IInputFieldParseTarget) => {
+    onChange({ severity, minScore, maxScore, [name]: value as string });
+  };
+
+  const renderLabel = () => (
+    <TooltipWrapper
+      tipContent="The worst case impact across different environments (CVSS version 3.x base score)."
+      clickable={false}
+    >
+      Severity
+    </TooltipWrapper>
+  );
+
+  return (
+    <div className={baseClass}>
+      <DropdownWrapper
+        name="severity-filter"
+        ariaLabel="Severity"
+        label={renderLabel()}
+        options={SEVERITY_DROPDOWN_OPTIONS}
+        value={severity}
+        onChange={onChangeSeverity}
+        placeholder="Any severity"
+        className={`${baseClass}__dropdown`}
+        isDisabled={disabled}
+        helpText={SEVERITY_HELP_TEXT}
+      />
+      {severity === CUSTOM_SEVERITY_VALUE && (
+        <div className={`${baseClass}__cvss-range`}>
+          <InputField
+            label="Min score"
+            onChange={onScoreChange}
+            onBlur={() => onScoreBlur?.("minScore")}
+            onFocus={() => onScoreFocus?.("minScore")}
+            name="minScore"
+            value={minScore}
+            disabled={disabled}
+            type="number"
+            placeholder="0.0"
+            min={0}
+            max={10}
+            step={0.1}
+            parseTarget
+            error={errors?.minScore}
+          />
+          <InputField
+            label="Max score"
+            onChange={onScoreChange}
+            onBlur={() => onScoreBlur?.("maxScore")}
+            onFocus={() => onScoreFocus?.("maxScore")}
+            name="maxScore"
+            value={maxScore}
+            disabled={disabled}
+            type="number"
+            placeholder="10.0"
+            min={0}
+            max={10}
+            step={0.1}
+            parseTarget
+            error={errors?.maxScore}
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SeverityFilter;

--- a/frontend/components/SeverityFilter/_styles.scss
+++ b/frontend/components/SeverityFilter/_styles.scss
@@ -1,0 +1,10 @@
+.severity-filter {
+  display: flex;
+  flex-direction: column;
+  gap: $pad-medium;
+
+  &__cvss-range {
+    display: flex;
+    gap: $pad-medium;
+  }
+}

--- a/frontend/components/SeverityFilter/helpers.tests.ts
+++ b/frontend/components/SeverityFilter/helpers.tests.ts
@@ -1,0 +1,136 @@
+import {
+  ANY_SEVERITY_VALUE,
+  SEVERITY_RANGE_INVALID_MSG,
+  SEVERITY_SCORE_RANGE_ERROR,
+  severityFilters,
+  severityForRange,
+  severityValueLabel,
+  SeverityValue,
+  validateSeverityScores,
+} from "./helpers";
+
+describe("severityForRange", () => {
+  it("treats an unset range as Any severity", () => {
+    expect(severityForRange(undefined, undefined)).toBe(ANY_SEVERITY_VALUE);
+  });
+
+  it("matches a preset when both bounds line up", () => {
+    expect(severityForRange(7, 8.9)).toBe("high");
+    expect(severityForRange(9, 10)).toBe("critical");
+  });
+
+  it("resolves the whole scale back to Any, not to a Custom 0-10", () => {
+    expect(severityForRange(0, 10)).toBe(ANY_SEVERITY_VALUE);
+  });
+
+  it("falls back to Custom for anything that is not a band", () => {
+    expect(severityForRange(7, undefined)).toBe("custom");
+    expect(severityForRange(undefined, 0)).toBe("custom");
+    expect(severityForRange(0, 6.5)).toBe("custom");
+    expect(severityForRange(2.5, 6)).toBe("custom");
+  });
+});
+
+describe("severityFilters", () => {
+  it("is empty when neither bound is entered", () => {
+    expect(severityFilters({ minScore: "", maxScore: "" })).toStrictEqual({});
+  });
+
+  it("is empty for the whole scale, which narrows nothing", () => {
+    expect(severityFilters({ minScore: "0", maxScore: "10" })).toStrictEqual(
+      {}
+    );
+  });
+
+  it("reads a preset's bounds straight off the scores it carries", () => {
+    expect(severityFilters({ minScore: "9", maxScore: "10" })).toStrictEqual({
+      min: 9,
+      max: 10,
+    });
+  });
+
+  it("omits a bound left empty, leaving that end open", () => {
+    expect(severityFilters({ minScore: "2.5", maxScore: "" })).toStrictEqual({
+      min: 2.5,
+    });
+    expect(severityFilters({ minScore: "", maxScore: "6" })).toStrictEqual({
+      max: 6,
+    });
+    expect(severityFilters({ minScore: "", maxScore: "10" })).toStrictEqual({
+      max: 10,
+    });
+  });
+
+  it("keeps an explicit 0 bound", () => {
+    expect(severityFilters({ minScore: "0", maxScore: "6" })).toStrictEqual({
+      min: 0,
+      max: 6,
+    });
+    expect(severityFilters({ minScore: "0", maxScore: "" })).toStrictEqual({
+      min: 0,
+    });
+  });
+});
+
+describe("severityValueLabel", () => {
+  const label = (severity: SeverityValue, minScore = "", maxScore = "") =>
+    severityValueLabel({ severity, minScore, maxScore });
+
+  it("names a preset and nothing more", () => {
+    expect(label("critical")).toBe("Critical");
+    expect(label("high")).toBe("High");
+    expect(label("medium")).toBe("Medium");
+    expect(label("low")).toBe("Low");
+    expect(label("any")).toBe("Any");
+  });
+
+  it("keeps the entered range for Custom, whose name alone says nothing", () => {
+    expect(label("custom", "2.5", "6")).toBe("Custom (2.5 to 6)");
+  });
+
+  it("widens a half-open Custom range to the end of the scale", () => {
+    expect(label("custom", "2.5", "")).toBe("Custom (2.5 to 10)");
+    expect(label("custom", "", "6")).toBe("Custom (0 to 6)");
+    expect(label("custom", "0", "0")).toBe("Custom (0 to 0)");
+  });
+
+  it("names no range for a Custom selection that narrows nothing", () => {
+    expect(label("custom", "", "")).toBe("Custom");
+    expect(label("custom", "0", "10")).toBe("Custom");
+  });
+});
+
+describe("validateSeverityScores", () => {
+  it("returns no errors for empty or valid scores", () => {
+    expect(validateSeverityScores({ minScore: "", maxScore: "" })).toEqual({});
+    expect(
+      validateSeverityScores({ minScore: "0.1", maxScore: "9.9" })
+    ).toEqual({});
+  });
+
+  it("flags out-of-range and over-precise scores per field", () => {
+    expect(validateSeverityScores({ minScore: "11", maxScore: "" })).toEqual({
+      minScore: SEVERITY_SCORE_RANGE_ERROR,
+    });
+    expect(validateSeverityScores({ minScore: "", maxScore: "5.55" })).toEqual({
+      maxScore: SEVERITY_SCORE_RANGE_ERROR,
+    });
+  });
+
+  it("attaches an inverted range to the maximum, the dependent field", () => {
+    expect(validateSeverityScores({ minScore: "7", maxScore: "3" })).toEqual({
+      maxScore: SEVERITY_RANGE_INVALID_MSG,
+    });
+  });
+
+  it("does not let an inverted range displace a field's own error", () => {
+    expect(validateSeverityScores({ minScore: "7", maxScore: "5.55" })).toEqual(
+      {
+        maxScore: SEVERITY_SCORE_RANGE_ERROR,
+      }
+    );
+    expect(validateSeverityScores({ minScore: "11", maxScore: "3" })).toEqual({
+      minScore: SEVERITY_SCORE_RANGE_ERROR,
+    });
+  });
+});

--- a/frontend/components/SeverityFilter/helpers.ts
+++ b/frontend/components/SeverityFilter/helpers.ts
@@ -1,0 +1,189 @@
+import { isEmpty } from "lodash";
+
+import numberUtils from "utilities/numbers";
+import stringUtils from "utilities/strings/stringUtils";
+
+export const ANY_SEVERITY_VALUE = "any";
+export const CUSTOM_SEVERITY_VALUE = "custom";
+
+export type SeverityValue =
+  | "any"
+  | "critical"
+  | "high"
+  | "medium"
+  | "low"
+  | "custom";
+
+export const SEVERITY_HELP_TEXT =
+  "CVSS scores (v3) range from 0.0 to 10.0 in 0.1 increments.";
+
+export interface ISeverityOption {
+  label: string;
+  value: SeverityValue;
+  helpText: string;
+  /** Bounds the option applies. Undefined on Custom, which reads the inputs. */
+  minSeverity?: number;
+  maxSeverity?: number;
+}
+
+/** The severity selection a parent holds. Scores are raw input strings. */
+export interface ISeverityFilterValue {
+  severity: SeverityValue;
+  minScore: string;
+  maxScore: string;
+}
+
+const severityName = (severity: SeverityValue) =>
+  stringUtils.capitalize(severity);
+
+const severityOptionLabel = (severity: SeverityValue) =>
+  `${severityName(severity)} severity`;
+
+const bandHelpText = (min: number, max: number) =>
+  `CVSS score ${min.toFixed(1)}-${max}`;
+
+const SEVERITY_BANDS: { value: SeverityValue; min: number; max: number }[] = [
+  { value: "critical", min: 9.0, max: 10 },
+  { value: "high", min: 7.0, max: 8.9 },
+  { value: "medium", min: 4.0, max: 6.9 },
+  { value: "low", min: 0.1, max: 3.9 },
+];
+
+const CUSTOM_SEVERITY_OPTION: ISeverityOption = {
+  label: severityOptionLabel(CUSTOM_SEVERITY_VALUE),
+  value: CUSTOM_SEVERITY_VALUE,
+  helpText: "Custom CVSS score range",
+};
+
+const ANY_SEVERITY_OPTION: ISeverityOption = {
+  label: severityOptionLabel(ANY_SEVERITY_VALUE),
+  value: ANY_SEVERITY_VALUE,
+  helpText: "CVSS score 0-10",
+  minSeverity: 0,
+  maxSeverity: 10,
+};
+
+export const SEVERITY_DROPDOWN_OPTIONS: ISeverityOption[] = [
+  ANY_SEVERITY_OPTION,
+  ...SEVERITY_BANDS.map(({ value, min, max }) => ({
+    label: severityOptionLabel(value),
+    value,
+    helpText: bandHelpText(min, max),
+    minSeverity: min,
+    maxSeverity: max,
+  })),
+  CUSTOM_SEVERITY_OPTION,
+];
+
+export const getSeverityOption = (
+  severity?: string
+): ISeverityOption | undefined =>
+  SEVERITY_DROPDOWN_OPTIONS.find((option) => option.value === severity);
+
+export const getSeverityBand = (severity: SeverityValue) =>
+  SEVERITY_BANDS.find((band) => band.value === severity);
+
+/** The ends of the CVSS scale. A range spanning both narrows nothing. */
+const SCORE_MIN = 0;
+const SCORE_MAX = 10;
+
+export const severityForRange = (
+  minSeverityValue: number | undefined,
+  maxSeverityValue: number | undefined
+): SeverityValue => {
+  // Loose == so a null from query-param parsing reads as unset too.
+  if (minSeverityValue == null && maxSeverityValue == null) {
+    return ANY_SEVERITY_VALUE;
+  }
+  if (minSeverityValue === SCORE_MIN && maxSeverityValue === SCORE_MAX) {
+    return ANY_SEVERITY_VALUE;
+  }
+  const preset = SEVERITY_BANDS.find(
+    (band) => band.min === minSeverityValue && band.max === maxSeverityValue
+  );
+  return preset ? preset.value : CUSTOM_SEVERITY_VALUE;
+};
+
+/** The CVSS bounds a selection narrows by. Either both keys, one, or neither. */
+export interface ISeverityFilters {
+  min?: number;
+  max?: number;
+}
+
+export const severityFilters = ({
+  minScore,
+  maxScore,
+}: ISeverityScores): ISeverityFilters => {
+  const min = minScore === "" ? undefined : Number(minScore);
+  const max = maxScore === "" ? undefined : Number(maxScore);
+
+  if (min === SCORE_MIN && max === SCORE_MAX) {
+    return {};
+  }
+  return {
+    ...(min !== undefined && { min }),
+    ...(max !== undefined && { max }),
+  };
+};
+
+// How a selection reads where it is summarized away from the control itself.
+export const severityValueLabel = ({
+  severity,
+  minScore,
+  maxScore,
+}: ISeverityFilterValue): string => {
+  const name = severityName(severity);
+
+  if (
+    severity === CUSTOM_SEVERITY_VALUE &&
+    !isEmpty(severityFilters({ minScore, maxScore }))
+  ) {
+    const min = minScore === "" ? 0 : Number(minScore);
+    const max = maxScore === "" ? 10 : Number(maxScore);
+    return `${name} (${min} to ${max})`;
+  }
+
+  return name;
+};
+
+export const SEVERITY_SCORE_RANGE_ERROR = `Must be from ${SCORE_MIN} to ${SCORE_MAX} in 0.1 increments`;
+export const SEVERITY_RANGE_INVALID_MSG = "Must be at or above the minimum";
+
+export type SeverityScoreField = "minScore" | "maxScore";
+
+export type ISeverityScores = Pick<
+  ISeverityFilterValue,
+  "minScore" | "maxScore"
+>;
+
+export type ISeverityFieldErrors = Partial<Record<SeverityScoreField, string>>;
+
+export const validateSeverityScores = ({
+  minScore,
+  maxScore,
+}: ISeverityScores): ISeverityFieldErrors => {
+  const isValidScore = (n: number) =>
+    numberUtils.isValidNumber(n, SCORE_MIN, SCORE_MAX) &&
+    numberUtils.hasAtMostOneDecimal(n);
+
+  const errors: ISeverityFieldErrors = {};
+  const min = minScore ? parseFloat(minScore) : undefined;
+  const max = maxScore ? parseFloat(maxScore) : undefined;
+
+  if (min !== undefined && !isValidScore(min)) {
+    errors.minScore = SEVERITY_SCORE_RANGE_ERROR;
+  }
+  if (max !== undefined && !isValidScore(max)) {
+    errors.maxScore = SEVERITY_SCORE_RANGE_ERROR;
+  }
+  if (
+    min !== undefined &&
+    max !== undefined &&
+    !errors.minScore &&
+    !errors.maxScore &&
+    min > max
+  ) {
+    errors.maxScore = SEVERITY_RANGE_INVALID_MSG;
+  }
+  return errors;
+};

--- a/frontend/components/SeverityFilter/index.ts
+++ b/frontend/components/SeverityFilter/index.ts
@@ -1,0 +1,17 @@
+export { default } from "./SeverityFilter";
+export type { ISeverityFilterValue } from "./SeverityFilter";
+export {
+  ANY_SEVERITY_VALUE,
+  getSeverityBand,
+  SEVERITY_RANGE_INVALID_MSG,
+  SEVERITY_SCORE_RANGE_ERROR,
+  severityFilters,
+  severityForRange,
+  severityValueLabel,
+  validateSeverityScores,
+} from "./helpers";
+export type {
+  ISeverityFieldErrors,
+  SeverityScoreField,
+  SeverityValue,
+} from "./helpers";

--- a/frontend/interfaces/charts.ts
+++ b/frontend/interfaces/charts.ts
@@ -54,8 +54,8 @@ export const ALL_CVE_SOFTWARE_CATEGORY_VALUES = CVE_SOFTWARE_CATEGORIES.map(
 // built-in default" for that control, while a present field seeds it. EPSS
 // bounds are expressed as 0–100 (matching the UI; the chart API call converts
 // to 0–1). Categories use the CVE_SOFTWARE_CATEGORIES values. cvss_min/cvss_max
-// are persisted but not yet consumed by the dashboard (the severity control
-// lands in #47326).
+// are 0–10 scores that seed the severity control, resolving to a preset when
+// they match one and to a custom range otherwise.
 export interface IVulnExposureFilterDefaults {
   software_filters?: string[];
   cvss_min?: number;

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tests.tsx
@@ -5,12 +5,8 @@ import { http, HttpResponse } from "msw";
 
 import { createCustomRenderer, baseUrl } from "test/test-utils";
 import mockServer from "test/mock-server";
-import { ALL_CVE_SOFTWARE_CATEGORY_VALUES } from "interfaces/charts";
 
-import ChartCard, {
-  buildInitialChartFilters,
-  hostFilterLines,
-} from "./ChartCard";
+import ChartCard from "./ChartCard";
 
 // Mock ResizeObserver for CheckerboardViz
 const MOCK_WIDTH = 600;
@@ -225,86 +221,180 @@ describe("ChartCard", () => {
     expect(requestedPlatforms).toBeNull();
     expect(screen.queryByText("Filtered")).not.toBeInTheDocument();
   });
-});
 
-describe("buildInitialChartFilters", () => {
-  it("uses built-in defaults when no persisted defaults are provided", () => {
-    const filters = buildInitialChartFilters(undefined);
-    expect(filters.softwareFilters).toEqual([
-      ...ALL_CVE_SOFTWARE_CATEGORY_VALUES,
-    ]);
-    expect(filters.knownExploit).toBe(false);
-    expect(filters.epssMin).toBe("");
-    expect(filters.epssMax).toBe("");
-    expect(filters.excludeCVEs).toEqual([]);
-  });
+  describe("vulnerability exposure severity filter", () => {
+    // Captures the query params of the last /charts/cve request.
+    const useCveHandler = () => {
+      const captured: { params: URLSearchParams | null } = { params: null };
+      mockServer.use(
+        http.get(baseUrl("/charts/:metric"), ({ params, request }) => {
+          if (params.metric === "cve") {
+            captured.params = new URL(request.url).searchParams;
+          }
+          return HttpResponse.json(
+            generateMockChartResponse(params.metric as string, 30)
+          );
+        })
+      );
+      return captured;
+    };
 
-  it("seeds present fields and falls back per-field for absent ones", () => {
-    const filters = buildInitialChartFilters({
-      software_filters: ["browsers"],
-      has_known_exploit: true,
+    const renderPremium = (
+      props: React.ComponentProps<typeof ChartCard> = {}
+    ) =>
+      createCustomRenderer({
+        withBackendMock: true,
+        context: { app: { isPremiumTier: true } },
+      })(<ChartCard {...props} />);
+
+    // react-select renders its options as plain divs, so target them by the
+    // testid the shared custom Option component sets rather than by role.
+    const selectDataset = async (
+      user: ReturnType<typeof renderPremium>["user"],
+      label: string
+    ) => {
+      // Let the initial chart request settle first — the re-render it triggers
+      // closes the menu again if it lands between opening and picking.
+      await waitFor(() => {
+        expect(document.querySelectorAll("rect").length).toBeGreaterThan(0);
+      });
+      await user.click(screen.getByRole("combobox", { name: "dataset" }));
+      const option = screen
+        .getAllByTestId("dropdown-option")
+        .find((el) => el.textContent?.startsWith(label));
+      if (!option) {
+        throw new Error(`No dataset option matching "${label}"`);
+      }
+      await user.click(option);
+    };
+
+    // Which bounds a selection resolves to is severityFilters' contract. What
+    // only a real request shows is the wiring either side: that they land on
+    // severity_min / severity_max, and that buildQueryStringFromParams keeps an
+    // explicit 0 rather than dropping it as empty.
+    const boundsCases: {
+      label: string;
+      filterDefaults: React.ComponentProps<typeof ChartCard>["filterDefaults"];
+      min: string | null;
+      max: string | null;
+    }[] = [
+      {
+        label: "the built-in critical default",
+        filterDefaults: undefined,
+        min: "9",
+        max: "10",
+      },
+      {
+        label: "a custom range with a 0 minimum",
+        filterDefaults: { cvss_min: 0, cvss_max: 6.5 },
+        min: "0",
+        max: "6.5",
+      },
+      {
+        label: "Any severity",
+        filterDefaults: { cvss_min: 0, cvss_max: 10 },
+        min: null,
+        max: null,
+      },
+    ];
+
+    it.each(boundsCases)(
+      "requests $label as severity bounds",
+      async ({ filterDefaults, min, max }) => {
+        const captured = useCveHandler();
+        const { user } = renderPremium({ filterDefaults });
+
+        await selectDataset(user, "Vulnerability exposure");
+
+        await waitFor(() => expect(captured.params).not.toBeNull());
+        expect(captured.params?.get("severity_min")).toBe(min);
+        expect(captured.params?.get("severity_max")).toBe(max);
+      }
+    );
+
+    it("does not flag a seeded default as Filtered", async () => {
+      useCveHandler();
+      const { user } = renderPremium({
+        filterDefaults: { cvss_min: 7, cvss_max: 8.9 },
+      });
+
+      await selectDataset(user, "Vulnerability exposure");
+
+      // High severity genuinely narrows the data, but it is the chart's
+      // baseline rather than something the user chose, so the pill has nothing
+      // to report yet.
+      expect(screen.queryByText("Filtered")).not.toBeInTheDocument();
     });
-    expect(filters.softwareFilters).toEqual(["browsers"]);
-    expect(filters.knownExploit).toBe(true);
-    expect(filters.epssMin).toBe("");
-    expect(filters.epssMax).toBe("");
-    expect(filters.excludeCVEs).toEqual([]);
-  });
 
-  it("converts numeric EPSS bounds (0-100) to strings", () => {
-    const filters = buildInitialChartFilters({ epss_min: 0, epss_max: 90 });
-    expect(filters.epssMin).toBe("0");
-    expect(filters.epssMax).toBe("90");
-  });
+    it("lights the Filtered pill once a filter is changed off the baseline", async () => {
+      useCveHandler();
+      const { user } = renderPremium();
 
-  it("honors an explicit empty software_filters list as 'none'", () => {
-    const filters = buildInitialChartFilters({ software_filters: [] });
-    expect(filters.softwareFilters).toEqual([]);
-  });
+      await selectDataset(user, "Vulnerability exposure");
+      expect(screen.queryByText("Filtered")).not.toBeInTheDocument();
 
-  it("seeds the exclude-CVE list", () => {
-    const filters = buildInitialChartFilters({
-      exclude_vulnerabilities: ["CVE-2025-50897"],
+      // Narrow the categories, which no default touched.
+      await user.click(
+        screen.getByRole("button", { name: /Configure chart filters/i })
+      );
+      await user.click(screen.getByRole("tab", { name: /Software/i }));
+      await user.click(screen.getByRole("checkbox", { name: "category-os" }));
+      await user.click(screen.getByRole("button", { name: /^Apply$/i }));
+
+      // Only the pill itself: react-tooltip does not mount its content in
+      // jsdom, and softwareFilterLines' tests cover the text.
+      await waitFor(() => {
+        expect(screen.getByText("Filtered")).toBeInTheDocument();
+      });
     });
-    expect(filters.excludeCVEs).toEqual(["CVE-2025-50897"]);
-  });
-});
 
-describe("hostFilterLines", () => {
-  const filtersWithPlatforms = (platforms: string[]) => ({
-    ...buildInitialChartFilters(undefined),
-    platforms,
-  });
+    it("opens the Advanced section when the modal is reached from the pill", async () => {
+      useCveHandler();
+      const { user } = renderPremium();
 
-  it("preserves branded platform casing (macOS, iOS, iPadOS)", () => {
-    const [line] = hostFilterLines(
-      filtersWithPlatforms(["darwin", "ios", "ipados"])
-    );
-    expect(line).toBe("macOS, iOS, and iPadOS");
-    // Guards the reported bug: no word-capitalized variants.
-    expect(line).not.toMatch(/MacOS|Ios|Ipados/);
-  });
+      await selectDataset(user, "Vulnerability exposure");
 
-  it("renders a single platform without mangling its casing", () => {
-    expect(hostFilterLines(filtersWithPlatforms(["darwin"]))).toEqual([
-      "macOS",
-    ]);
-  });
+      // Light the pill by narrowing the categories, then close and reopen
+      // through it.
+      await user.click(
+        screen.getByRole("button", { name: /Configure chart filters/i })
+      );
+      await user.click(screen.getByRole("tab", { name: /Software/i }));
+      await user.click(screen.getByRole("checkbox", { name: "category-os" }));
+      await user.click(screen.getByRole("button", { name: /^Apply$/i }));
+      await waitFor(() => {
+        expect(screen.getByText("Filtered")).toBeInTheDocument();
+      });
 
-  it("maps every filterable platform to its correct display name", () => {
-    const [line] = hostFilterLines(
-      filtersWithPlatforms([
-        "darwin",
-        "windows",
-        "linux",
-        "chrome",
-        "ios",
-        "ipados",
-        "android",
-      ])
-    );
-    expect(line).toBe(
-      "macOS, Windows, Linux, ChromeOS, iOS, iPadOS, and Android"
-    );
+      await user.click(screen.getByText("Filtered"));
+      expect(screen.getByText("Probability of exploit")).toBeInTheDocument();
+    });
+
+    it("leaves the Advanced section collapsed when opened from the gear", async () => {
+      useCveHandler();
+      const { user } = renderPremium();
+
+      await selectDataset(user, "Vulnerability exposure");
+      await user.click(
+        screen.getByRole("button", { name: /Configure chart filters/i })
+      );
+      await user.click(screen.getByRole("tab", { name: /Software/i }));
+
+      expect(
+        screen.queryByText("Probability of exploit")
+      ).not.toBeInTheDocument();
+    });
+
+    it("no longer advertises the severity filter as coming soon", async () => {
+      useCveHandler();
+      const { user } = renderPremium();
+
+      await selectDataset(user, "Vulnerability exposure");
+
+      expect(screen.queryByText(/coming soon/i)).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(/All critical vulnerabilities/i)
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
@@ -1,6 +1,7 @@
 import React, { useContext, useEffect, useState, useMemo } from "react";
 import { useQuery } from "react-query";
 import { format, parseISO } from "date-fns";
+import { isEqual } from "lodash";
 import { SingleValue } from "react-select-5";
 
 import chartsAPI, {
@@ -9,7 +10,6 @@ import chartsAPI, {
   IChartQueryKey,
 } from "services/entities/charts";
 import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
-import { PLATFORM_DISPLAY_NAMES } from "interfaces/platform";
 
 import Button from "components/buttons/Button";
 import Spinner from "components/Spinner";
@@ -18,7 +18,7 @@ import DropdownWrapper from "components/forms/fields/DropdownWrapper";
 import { CustomOptionType } from "components/forms/fields/DropdownWrapper/DropdownWrapper";
 import Icon from "components/Icon";
 import TooltipWrapper from "components/TooltipWrapper";
-import CustomLink from "components/CustomLink";
+import { severityFilters } from "components/SeverityFilter";
 
 import {
   IDataSet,
@@ -26,7 +26,6 @@ import {
   DATASET_CONFIG_KEY,
   DATASET_LABEL,
   HistoricalDataConfigKey,
-  CVE_SOFTWARE_CATEGORIES,
   ALL_CVE_SOFTWARE_CATEGORY_VALUES,
   IVulnExposureFilterDefaults,
 } from "interfaces/charts";
@@ -37,7 +36,14 @@ import ChartFilterModal, {
   IChartFilterState,
   ChartFilterTab,
 } from "./ChartFilterModal";
-import { isEpssActive } from "./ChartFilterModal/SoftwareFilters/helpers";
+import {
+  buildInitialChartFilters,
+  hasActiveHostFilters,
+  hasActiveSoftwareFilters,
+  hostFilterLines,
+  severitySelection,
+  softwareFilterLines,
+} from "./helpers";
 import LineChartViz from "./LineChartViz";
 import CheckerboardViz from "./CheckerboardViz";
 import DataCollectionDisabledState from "./DataCollectionDisabledState";
@@ -47,127 +53,6 @@ const baseClass = "chart-card";
 // All charts are currently fixed at a 30-day window. When the server supports
 // configurable ranges we'll add UI and request-param plumbing for this.
 const CHART_DAYS = 30;
-
-const DEFAULT_CHART_FILTERS: IChartFilterState = {
-  labelIDs: [],
-  platforms: [],
-  hostFilterMode: "none",
-  selectedHosts: [],
-  softwareFilters: [...ALL_CVE_SOFTWARE_CATEGORY_VALUES],
-  knownExploit: false,
-  epssMin: "",
-  epssMax: "",
-  excludeCVEs: [],
-};
-
-// Seed the chart's initial filter state from the persisted, GitOps-managed
-// defaults. Sparse/per-field: an undefined field falls back to the built-in
-// DEFAULT_CHART_FILTERS value, while a present field (including an explicit
-// empty software_filters list, meaning "no categories") is respected. EPSS
-// bounds are numbers (0–100) in the config and strings in the filter state.
-// cvss_min/cvss_max are intentionally NOT wired — there is no severity control
-// yet (#47326).
-export const buildInitialChartFilters = (
-  defaults?: IVulnExposureFilterDefaults
-): IChartFilterState => {
-  if (!defaults) return DEFAULT_CHART_FILTERS;
-  return {
-    ...DEFAULT_CHART_FILTERS,
-    softwareFilters:
-      defaults.software_filters !== undefined
-        ? [...defaults.software_filters]
-        : DEFAULT_CHART_FILTERS.softwareFilters,
-    knownExploit:
-      defaults.has_known_exploit !== undefined
-        ? defaults.has_known_exploit
-        : DEFAULT_CHART_FILTERS.knownExploit,
-    epssMin:
-      defaults.epss_min !== undefined
-        ? String(defaults.epss_min)
-        : DEFAULT_CHART_FILTERS.epssMin,
-    epssMax:
-      defaults.epss_max !== undefined
-        ? String(defaults.epss_max)
-        : DEFAULT_CHART_FILTERS.epssMax,
-    excludeCVEs:
-      defaults.exclude_vulnerabilities !== undefined
-        ? [...defaults.exclude_vulnerabilities]
-        : DEFAULT_CHART_FILTERS.excludeCVEs,
-  };
-};
-
-const hasActiveHostFilters = (filters: IChartFilterState): boolean => {
-  const hasHostFilter =
-    filters.hostFilterMode !== "none" && filters.selectedHosts.length > 0;
-  return (
-    filters.labelIDs.length > 0 || filters.platforms.length > 0 || hasHostFilter
-  );
-};
-
-const hasActiveSoftwareFilters = (filters: IChartFilterState): boolean =>
-  filters.softwareFilters.length !== ALL_CVE_SOFTWARE_CATEGORY_VALUES.length ||
-  filters.knownExploit ||
-  isEpssActive(filters.epssMin, filters.epssMax) ||
-  filters.excludeCVEs.length > 0;
-
-// Human-readable "a, b, and c". Items must already be correctly cased —
-// don't force-capitalize here or branded names like "macOS"/"iOS" break.
-const formatList = (items: string[]): string => {
-  if (items.length <= 1) return items.join("");
-  if (items.length === 2) return `${items[0]} and ${items[1]}`;
-  return `${items.slice(0, -1).join(", ")}, and ${items[items.length - 1]}`;
-};
-
-// A string-indexable view of the display-name map. Platform filter values are
-// arbitrary strings, so an unknown one indexes to undefined and we fall back to
-// the raw value below.
-const PLATFORM_LABELS: Record<string, string> = PLATFORM_DISPLAY_NAMES;
-
-export const hostFilterLines = (filters: IChartFilterState): string[] => {
-  const lines: string[] = [];
-  if (filters.platforms.length > 0) {
-    lines.push(
-      formatList(filters.platforms.map((p) => PLATFORM_LABELS[p] ?? p))
-    );
-  }
-  if (filters.labelIDs.length > 0) lines.push("Labels");
-  if (
-    filters.hostFilterMode === "include" &&
-    filters.selectedHosts.length > 0
-  ) {
-    lines.push("Specific hosts");
-  }
-  if (
-    filters.hostFilterMode === "exclude" &&
-    filters.selectedHosts.length > 0
-  ) {
-    lines.push("Excluded hosts");
-  }
-  return lines;
-};
-
-const softwareFilterLines = (filters: IChartFilterState): string[] => {
-  const lines: string[] = [];
-  // Only surface category text when the user has actually narrowed the
-  // selection — all categories are selected by default, so an unnarrowed
-  // selection isn't an active filter and shouldn't show a Software section.
-  const categoriesNarrowed =
-    filters.softwareFilters.length !== ALL_CVE_SOFTWARE_CATEGORY_VALUES.length;
-  const cats = CVE_SOFTWARE_CATEGORIES.filter((c) =>
-    filters.softwareFilters.includes(c.value)
-  ).map((c) => c.tooltipLabel);
-  if (categoriesNarrowed) {
-    lines.push(cats.length ? formatList(cats) : "No software categories");
-  }
-  if (filters.knownExploit) lines.push("Known exploits only");
-  if (
-    isEpssActive(filters.epssMin, filters.epssMax) ||
-    filters.excludeCVEs.length > 0
-  ) {
-    lines.push("Advanced filters");
-  }
-  return lines;
-};
 
 // A single consolidated tooltip summarizing every active filter, grouped into
 // "Hosts" and "Software" sections. Each section is omitted when it has no
@@ -213,12 +98,23 @@ const ChartCard = ({
   const [selectedMetric, setSelectedMetric] = useState("uptime");
   const [showFilterModal, setShowFilterModal] = useState(false);
   const [initialTab, setInitialTab] = useState<ChartFilterTab>("hosts");
-  const [chartFilters, setChartFilters] = useState<IChartFilterState>(() =>
-    buildInitialChartFilters(filterDefaults)
+  const [showAdvancedOnOpen, setShowAdvancedOnOpen] = useState(false);
+  // The chart's baseline. Nothing in it was chosen by the user, so the
+  // "Filtered" pill keys on differing from it rather than on filters being set.
+  const initialChartFilters = useMemo(
+    () => buildInitialChartFilters(filterDefaults),
+    [filterDefaults]
+  );
+  const [chartFilters, setChartFilters] = useState<IChartFilterState>(
+    initialChartFilters
   );
 
-  const openFilterModal = (tab: ChartFilterTab = "hosts") => {
+  const openFilterModal = (
+    tab: ChartFilterTab = "hosts",
+    showAdvanced = false
+  ) => {
     setInitialTab(tab);
+    setShowAdvancedOnOpen(showAdvanced);
     setShowFilterModal(true);
   };
 
@@ -257,16 +153,11 @@ const ChartCard = ({
       defaultChartType: "checkerboard",
       description: (
         <>
-          All critical vulnerabilities.
+          The number of hosts with at least one vulnerability matching the
+          chart&apos;s filters.
           <br />
           <br />
-          Want more control? Severity (CVSS) filter is{" "}
-          <CustomLink
-            newTab
-            text="coming soon "
-            variant="tooltip-link"
-            url="https://github.com/fleetdm/fleet/issues/47326"
-          />
+          Severity is filtered to critical by default.
         </>
       ),
       tooltipFormatter: ({ value }: { value: number }) =>
@@ -287,15 +178,20 @@ const ChartCard = ({
   // or once the config/fleet data finishes loading. This also discards any
   // ephemeral UI edits, matching the "UI edits are not saved" behavior.
   useEffect(() => {
-    setChartFilters(buildInitialChartFilters(filterDefaults));
-  }, [currentTeamId, filterDefaults]);
+    setChartFilters(initialChartFilters);
+  }, [currentTeamId, initialChartFilters]);
 
   const currentDataset = getDataset(selectedMetric);
 
   const isCVE = currentDataset.name === "cve";
   const hostFiltersActive = hasActiveHostFilters(chartFilters);
   const softwareFiltersActive = isCVE && hasActiveSoftwareFilters(chartFilters);
-  const anyFiltersActive = hostFiltersActive || softwareFiltersActive;
+  // A seeded default is how the chart always looks, so flagging it as
+  // "Filtered" on load would say nothing. Once shown, the tooltip lists
+  // everything narrowing the data, defaults included.
+  const filtersEdited = !isEqual(chartFilters, initialChartFilters);
+  const anyFiltersActive =
+    filtersEdited && (hostFiltersActive || softwareFiltersActive);
 
   const datasetConfigKey = DATASET_CONFIG_KEY[currentDataset.name];
   // If a dataset has no config-key mapping (future addition), treat it as
@@ -319,6 +215,11 @@ const ChartCard = ({
       isCVE &&
       chartFilters.epssMax !== "" &&
       Number(chartFilters.epssMax) < 100;
+
+    // filterEmptyParams drops undefined/""/null, so a legitimate 0 survives.
+    const severityBounds = isCVE
+      ? severityFilters(severitySelection(chartFilters))
+      : {};
 
     return {
       // Add an extra day to ensure we get the full # of calendar days
@@ -348,6 +249,8 @@ const ChartCard = ({
       has_known_exploit: isCVE && chartFilters.knownExploit ? true : undefined,
       epss_min: epssMinActive ? Number(chartFilters.epssMin) / 100 : undefined,
       epss_max: epssMaxActive ? Number(chartFilters.epssMax) / 100 : undefined,
+      severity_min: severityBounds.min,
+      severity_max: severityBounds.max,
       exclude_vulnerabilities:
         isCVE && chartFilters.excludeCVEs.length
           ? chartFilters.excludeCVEs.join(",")
@@ -471,7 +374,10 @@ const ChartCard = ({
                 type="button"
                 className={`${baseClass}__filter-pill`}
                 onClick={() =>
-                  openFilterModal(hostFiltersActive ? "hosts" : "software")
+                  openFilterModal(
+                    hostFiltersActive ? "hosts" : "software",
+                    true
+                  )
                 }
               >
                 Filtered
@@ -498,6 +404,7 @@ const ChartCard = ({
           currentTeamId={currentTeamId}
           metric={selectedMetric}
           initialTab={initialTab}
+          initialShowAdvanced={showAdvancedOnOpen}
           onApply={(newFilters) => {
             setChartFilters(newFilters);
             setShowFilterModal(false);

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/ChartFilterModal.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/ChartFilterModal.tests.tsx
@@ -1,4 +1,21 @@
-import { PLATFORM_OPTIONS } from "./ChartFilterModal";
+import React from "react";
+import { screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { noop } from "lodash";
+
+import { createCustomRenderer, baseUrl } from "test/test-utils";
+import mockServer from "test/mock-server";
+import { ALL_CVE_SOFTWARE_CATEGORY_VALUES } from "interfaces/charts";
+
+import {
+  SEVERITY_RANGE_INVALID_MSG,
+  SeverityValue,
+} from "components/SeverityFilter";
+
+import ChartFilterModal, {
+  IChartFilterState,
+  PLATFORM_OPTIONS,
+} from "./ChartFilterModal";
 
 describe("ChartFilterModal PLATFORM_OPTIONS", () => {
   it("offers mobile platforms (iOS, iPadOS, Android) alongside desktop", () => {
@@ -20,5 +37,293 @@ describe("ChartFilterModal PLATFORM_OPTIONS", () => {
     expect(labelFor("ios")).toBe("iOS");
     expect(labelFor("ipados")).toBe("iPadOS");
     expect(labelFor("android")).toBe("Android");
+  });
+});
+
+describe("ChartFilterModal severity", () => {
+  const baseFilters: IChartFilterState = {
+    labelIDs: [],
+    platforms: [],
+    hostFilterMode: "none",
+    selectedHosts: [],
+    softwareFilters: [...ALL_CVE_SOFTWARE_CATEGORY_VALUES],
+    knownExploit: false,
+    epssMin: "",
+    epssMax: "",
+    // A preset carries its own bounds — see IChartFilterState.
+    severity: "critical",
+    cvssMin: "9",
+    cvssMax: "10",
+    excludeCVEs: [],
+  };
+
+  beforeEach(() => {
+    mockServer.use(
+      http.get(baseUrl("/hosts"), () =>
+        HttpResponse.json({ hosts: [], software: null })
+      ),
+      http.get(baseUrl("/labels/summary"), () =>
+        HttpResponse.json({ labels: [] })
+      ),
+      http.get(baseUrl("/vulnerabilities"), () =>
+        HttpResponse.json({
+          count: 0,
+          counts_updated_at: "",
+          vulnerabilities: [],
+          meta: { has_next_results: false, has_previous_results: false },
+        })
+      )
+    );
+  });
+
+  const renderModal = (
+    props: Partial<React.ComponentProps<typeof ChartFilterModal>> = {}
+  ) =>
+    createCustomRenderer({ withBackendMock: true })(
+      <ChartFilterModal
+        filters={baseFilters}
+        metric="cve"
+        initialTab="software"
+        onApply={noop}
+        onCancel={noop}
+        {...props}
+      />
+    );
+
+  it("applies the current severity selection", async () => {
+    const onApply = jest.fn();
+    const { user } = renderModal({ onApply });
+
+    await user.click(screen.getByRole("button", { name: /Apply/i }));
+
+    expect(onApply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        severity: "critical",
+        cvssMin: "9",
+        cvssMax: "10",
+      })
+    );
+  });
+
+  it("resets severity to Any on Clear all and hides the button", async () => {
+    const { user } = renderModal();
+
+    // The Critical default is an active filter, so Clear all is offered.
+    const clearAll = screen.getByRole("button", { name: /Clear all/i });
+    await user.click(clearAll);
+
+    // The severity control lives behind the Advanced options reveal.
+    await user.click(screen.getByRole("button", { name: /Advanced options/i }));
+    expect(screen.getByText("Any severity")).toBeInTheDocument();
+
+    // Nothing is filtered anymore, so there is nothing left to clear.
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: /Clear all/i })
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("offers no Clear all for a Custom range with no bounds entered", () => {
+    renderModal({
+      filters: { ...baseFilters, severity: "custom", cvssMin: "", cvssMax: "" },
+    });
+
+    // Custom without bounds sends nothing to the API, so it must not count as
+    // an active filter — otherwise Clear all would appear over unfiltered data.
+    expect(
+      screen.queryByRole("button", { name: /Clear all/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("clears to Any severity, which applies with no bounds", async () => {
+    const onApply = jest.fn();
+    const { user } = renderModal({ onApply });
+
+    await user.click(screen.getByRole("button", { name: /Clear all/i }));
+    await user.click(screen.getByRole("button", { name: /Apply/i }));
+
+    expect(onApply).toHaveBeenCalledWith(
+      expect.objectContaining({ severity: "any", cvssMin: "", cvssMax: "" })
+    );
+  });
+
+  // Per frontend/docs/patterns.md#data-validation: Apply stays enabled, errors
+  // appear on blur of a dirty field or on a submit attempt, and clear on focus.
+  describe("validation lifecycle", () => {
+    const invalidCustom = {
+      ...baseFilters,
+      severity: "custom" as SeverityValue,
+      cvssMin: "9",
+      cvssMax: "3",
+    };
+
+    // Once an error replaces the label, getByLabelText can no longer find the
+    // field, so address the score inputs by name.
+    const maxScoreInput = () =>
+      document.querySelector('input[name="maxScore"]') as HTMLInputElement;
+
+    // Retypes Max so it stays inverted against Min 9, marking the field dirty.
+    const editMaxToInvalid = async (
+      user: ReturnType<typeof renderModal>["user"]
+    ) => {
+      await user.clear(maxScoreInput());
+      await user.type(maxScoreInput(), "1");
+    };
+
+    it("keeps Apply enabled with invalid input", () => {
+      renderModal({ filters: invalidCustom });
+
+      expect(screen.getByRole("button", { name: /Apply/i })).toBeEnabled();
+    });
+
+    it("shows no error for a seeded invalid value until it is touched", async () => {
+      const { user } = renderModal({ filters: invalidCustom });
+
+      await user.click(
+        screen.getByRole("button", { name: /Advanced options/i })
+      );
+
+      // The range is inverted, but the user has not edited it — a GitOps-seeded
+      // value must not greet them with an error.
+      expect(
+        screen.queryByText(SEVERITY_RANGE_INVALID_MSG)
+      ).not.toBeInTheDocument();
+
+      // Tabbing through without editing is still not "dirty".
+      await user.click(screen.getByLabelText(/Max score/i));
+      await user.tab();
+      expect(
+        screen.queryByText(SEVERITY_RANGE_INVALID_MSG)
+      ).not.toBeInTheDocument();
+    });
+
+    it("surfaces the error on blur once the field is dirty, and clears it on focus", async () => {
+      const { user } = renderModal({ filters: invalidCustom });
+
+      await user.click(
+        screen.getByRole("button", { name: /Advanced options/i })
+      );
+
+      await editMaxToInvalid(user);
+      // Still nothing while typing.
+      expect(
+        screen.queryByText(SEVERITY_RANGE_INVALID_MSG)
+      ).not.toBeInTheDocument();
+
+      await user.tab();
+      expect(screen.getByText(SEVERITY_RANGE_INVALID_MSG)).toBeInTheDocument();
+
+      // Focusing the field again restores its label immediately, without
+      // waiting for a valid value.
+      await user.click(maxScoreInput());
+      expect(
+        screen.queryByText(SEVERITY_RANGE_INVALID_MSG)
+      ).not.toBeInTheDocument();
+      expect(screen.getByLabelText(/Max score/i)).toBeInTheDocument();
+    });
+
+    it("shows every error and does not apply when Apply is clicked with invalid input", async () => {
+      const onApply = jest.fn();
+      const { user } = renderModal({ filters: invalidCustom, onApply });
+
+      await user.click(screen.getByRole("button", { name: /^Apply$/i }));
+
+      expect(onApply).not.toHaveBeenCalled();
+      // Submit bypasses the dirty gate, and the field it names is reachable:
+      // Advanced options opens itself rather than hiding the error.
+      expect(screen.getByText(SEVERITY_RANGE_INVALID_MSG)).toBeInTheDocument();
+    });
+
+    it("switches to the Software tab so a submit-surfaced error is visible", async () => {
+      const { user } = renderModal({
+        filters: invalidCustom,
+        initialTab: "hosts",
+      });
+
+      await user.click(screen.getByRole("button", { name: /^Apply$/i }));
+
+      expect(screen.getByText(SEVERITY_RANGE_INVALID_MSG)).toBeInTheDocument();
+    });
+
+    it("clears a score error when the severity option changes", async () => {
+      const { user } = renderModal({ filters: invalidCustom });
+
+      await user.click(
+        screen.getByRole("button", { name: /Advanced options/i })
+      );
+      await editMaxToInvalid(user);
+      await user.tab();
+      expect(screen.getByText(SEVERITY_RANGE_INVALID_MSG)).toBeInTheDocument();
+
+      // High severity rewrites both bounds, so the error describes nothing.
+      await user.click(screen.getByRole("combobox", { name: "Severity" }));
+      const high = screen
+        .getAllByTestId("dropdown-option")
+        .find((el) => el.textContent?.startsWith("High severity"));
+      if (!high) {
+        throw new Error("No High severity option");
+      }
+      await user.click(high);
+
+      expect(
+        screen.queryByText(SEVERITY_RANGE_INVALID_MSG)
+      ).not.toBeInTheDocument();
+    });
+
+    it("submits on Enter from a score input", async () => {
+      const onApply = jest.fn();
+      const { user } = renderModal({ onApply });
+
+      await user.click(
+        screen.getByRole("button", { name: /Advanced options/i })
+      );
+      await user.click(screen.getByRole("combobox", { name: "Severity" }));
+      const custom = screen
+        .getAllByTestId("dropdown-option")
+        .find((el) => el.textContent?.startsWith("Custom severity"));
+      if (!custom) {
+        throw new Error("No Custom severity option");
+      }
+      await user.click(custom);
+
+      await user.type(maxScoreInput(), "{Enter}");
+
+      expect(onApply).toHaveBeenCalled();
+    });
+
+    it("does not submit on Enter from a search field", async () => {
+      const onApply = jest.fn();
+      const { user } = renderModal({ onApply, initialTab: "hosts" });
+
+      // Enter mid-search would apply the filters and close the modal, which is
+      // not what "press Enter after typing a search" should do.
+      await user.type(
+        screen.getByPlaceholderText(/Search name, hostname/i),
+        "web{Enter}"
+      );
+
+      expect(onApply).not.toHaveBeenCalled();
+    });
+
+    it("applies once the input is valid", async () => {
+      const onApply = jest.fn();
+      const { user } = renderModal({ filters: invalidCustom, onApply });
+
+      await user.click(
+        screen.getByRole("button", { name: /Advanced options/i })
+      );
+      await user.clear(maxScoreInput());
+      await user.type(maxScoreInput(), "10");
+      await user.click(screen.getByRole("button", { name: /^Apply$/i }));
+
+      expect(onApply).toHaveBeenCalledWith(
+        expect.objectContaining({
+          severity: "custom",
+          cvssMin: "9",
+          cvssMax: "10",
+        })
+      );
+    });
   });
 });

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/ChartFilterModal.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/ChartFilterModal.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useQuery } from "react-query";
 import { Tab, TabList, TabPanel, Tabs } from "react-tabs";
 import { useDebouncedCallback } from "use-debounce";
+import { isEmpty } from "lodash";
 
 import { IHost } from "interfaces/host";
 import { ILabelSummary } from "interfaces/label";
@@ -12,7 +13,6 @@ import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
 
 import Modal from "components/Modal";
 import Button from "components/buttons/Button";
-import TooltipWrapper from "components/TooltipWrapper";
 import TabNav from "components/TabNav";
 import TabText from "components/TabText";
 import Checkbox from "components/forms/fields/Checkbox";
@@ -21,15 +21,28 @@ import SearchField from "components/forms/fields/SearchField";
 // @ts-ignore
 import Dropdown from "components/forms/fields/Dropdown";
 
+import {
+  ANY_SEVERITY_VALUE,
+  ISeverityFilterValue,
+  severityFilters,
+  SeverityValue,
+} from "components/SeverityFilter";
+
 import SoftwareFilters from "./SoftwareFilters";
 import {
-  getSoftwareFilterApplyError,
   isEpssActive,
+  ISoftwareFilterErrors,
+  NO_CATEGORIES_MSG,
+  SoftwareFilterField,
+  validateSoftwareFilters,
 } from "./SoftwareFilters/helpers";
 
 const baseClass = "chart-filter-modal";
 
 export type ChartFilterTab = "hosts" | "software";
+
+const HOSTS_TAB_INDEX = 0;
+const SOFTWARE_TAB_INDEX = 1;
 
 // Exported for testing.
 export const PLATFORM_OPTIONS = [
@@ -56,6 +69,12 @@ export interface IChartFilterState {
   knownExploit: boolean;
   epssMin: string;
   epssMax: string;
+  // Severity (CVSS). `severity` is the SeverityFilter option value; cvssMin /
+  // cvssMax are the raw 0–10 score strings behind it, and they always mirror
+  // the selection — a preset carries its own bounds, Any and Custom carry none.
+  severity: SeverityValue;
+  cvssMin: string;
+  cvssMax: string;
   excludeCVEs: string[];
 }
 
@@ -65,6 +84,7 @@ interface IChartFilterModalProps {
   // metric drives whether the Software tab is shown (cve only).
   metric: string;
   initialTab?: ChartFilterTab;
+  initialShowAdvanced?: boolean;
   onApply: (filters: IChartFilterState) => void;
   onCancel: () => void;
 }
@@ -77,11 +97,14 @@ const ChartFilterModal = ({
   currentTeamId,
   metric,
   initialTab = "hosts",
+  initialShowAdvanced = false,
   onApply,
   onCancel,
 }: IChartFilterModalProps): JSX.Element => {
   const isCVE = metric === "cve";
-  const [activeTab, setActiveTab] = useState(initialTab === "software" ? 1 : 0);
+  const [activeTab, setActiveTab] = useState(
+    initialTab === "software" ? SOFTWARE_TAB_INDEX : HOSTS_TAB_INDEX
+  );
 
   // Software (cve) filter state.
   const [softwareFilters, setSoftwareFilters] = useState<string[]>(
@@ -92,7 +115,22 @@ const ChartFilterModal = ({
   );
   const [epssMin, setEpssMin] = useState<string>(filters.epssMin);
   const [epssMax, setEpssMax] = useState<string>(filters.epssMax);
+  const [severityFilter, setSeverityFilter] = useState<ISeverityFilterValue>({
+    severity: filters.severity,
+    minScore: filters.cvssMin,
+    maxScore: filters.cvssMax,
+  });
   const [excludeCVEs, setExcludeCVEs] = useState<string[]>(filters.excludeCVEs);
+
+  // Only the errors currently being shown — never everything that is invalid.
+  // See frontend/docs/patterns.md#data-validation.
+  const [softwareErrors, setSoftwareErrors] = useState<ISoftwareFilterErrors>(
+    {}
+  );
+  // A field is dirty once the user has edited it. Seeded values that happen to
+  // be invalid must not error on a mere tab through. A ref because it gates
+  // handlers only.
+  const dirtyFields = useRef(new Set<SoftwareFilterField>());
 
   const [selectedLabelIDs, setSelectedLabelIDs] = useState<number[]>(
     filters.labelIDs
@@ -191,7 +229,95 @@ const ChartFilterModal = ({
       value: l.id,
     }));
 
-  const handleApply = () => {
+  const softwareFormData = {
+    categories: softwareFilters,
+    epssMin,
+    epssMax,
+    minScore: severityFilter.minScore,
+    maxScore: severityFilter.maxScore,
+  };
+
+  const markDirty = (field: SoftwareFilterField) => {
+    dirtyFields.current.add(field);
+  };
+
+  // Blur validates that one field and nothing else.
+  const onFieldBlur = (field: SoftwareFilterField) => {
+    if (!dirtyFields.current.has(field)) {
+      return;
+    }
+    const { [field]: fieldError } = validateSoftwareFilters(softwareFormData);
+    setSoftwareErrors((prev) => ({ ...prev, [field]: fieldError }));
+  };
+
+  // Focus clears immediately so the label returns while the user edits.
+  const onFieldFocus = (field: SoftwareFilterField) => {
+    setSoftwareErrors((prev) =>
+      prev[field] ? { ...prev, [field]: undefined } : prev
+    );
+  };
+
+  const onChangeEpssMin = (value: string) => {
+    markDirty("epssMin");
+    setEpssMin(value);
+  };
+
+  const onChangeEpssMax = (value: string) => {
+    markDirty("epssMax");
+    setEpssMax(value);
+  };
+
+  const onChangeSeverityFilter = (next: ISeverityFilterValue) => {
+    if (next.severity === severityFilter.severity) {
+      // Same option means the user typed in a score input.
+      if (next.minScore !== severityFilter.minScore) markDirty("cvssMin");
+      if (next.maxScore !== severityFilter.maxScore) markDirty("cvssMax");
+    } else {
+      // Switching options rewrites both bounds, so any error on them no longer
+      // describes anything.
+      setSoftwareErrors((prev) => ({
+        ...prev,
+        cvssMin: undefined,
+        cvssMax: undefined,
+      }));
+    }
+    setSeverityFilter(next);
+  };
+
+  const onChangeCategories = (next: string[]) => {
+    markDirty("categories");
+    // A selection control has no blur to validate on, and going from one
+    // category to none is unambiguous, so this one resolves on change.
+    setSoftwareErrors((prev) => ({
+      ...prev,
+      categories: next.length === 0 ? NO_CATEGORIES_MSG : undefined,
+    }));
+    setSoftwareFilters(next);
+  };
+
+  const handleSubmit = (evt: React.FormEvent<HTMLFormElement>) => {
+    evt.preventDefault();
+
+    // Enter submits a native form from any field in it, and applying part-way
+    // through typing a search would be a surprise. Clicking Apply moves focus to
+    // the button, so a still-focused text input means Enter came from a
+    // SearchField — ignore it. The number inputs keep Enter-to-apply.
+    const focused = document.activeElement as HTMLInputElement | null;
+    if (focused?.tagName === "INPUT" && focused.type === "text") {
+      return;
+    }
+    // Submit is a checkpoint: validate everything regardless of dirty state,
+    // show all the errors at once, and return without applying.
+    if (isCVE) {
+      const errors = validateSoftwareFilters(softwareFormData);
+      if (Object.keys(errors).length > 0) {
+        setSoftwareErrors(errors);
+        // The errors are all on the Software tab, so show it.
+        setActiveTab(SOFTWARE_TAB_INDEX);
+        return;
+      }
+    }
+
     onApply({
       labelIDs: selectedLabelIDs,
       platforms: selectedPlatforms,
@@ -201,6 +327,9 @@ const ChartFilterModal = ({
       knownExploit,
       epssMin,
       epssMax,
+      severity: severityFilter.severity,
+      cvssMin: severityFilter.minScore,
+      cvssMax: severityFilter.maxScore,
       excludeCVEs,
     });
   };
@@ -220,7 +349,17 @@ const ChartFilterModal = ({
     setKnownExploit(false);
     setEpssMin("");
     setEpssMax("");
+    // Clear all resets severity to Any, not to the Critical seed — otherwise
+    // the filters would still be active and the Clear all button would never
+    // disappear after being clicked.
+    setSeverityFilter({
+      severity: ANY_SEVERITY_VALUE,
+      minScore: "",
+      maxScore: "",
+    });
     setExcludeCVEs([]);
+    setSoftwareErrors({});
+    dirtyFields.current.clear();
   };
 
   const handleTabChange = (index: number) => {
@@ -245,6 +384,7 @@ const ChartFilterModal = ({
     (softwareFilters.length !== ALL_CVE_SOFTWARE_CATEGORY_VALUES.length ||
       knownExploit ||
       isEpssActive(epssMin, epssMax) ||
+      !isEmpty(severityFilters(severityFilter)) ||
       excludeCVEs.length > 0);
 
   const hasFilters =
@@ -255,14 +395,6 @@ const ChartFilterModal = ({
 
   // Inner host include/exclude tab.
   const tabIndex = hostFilterMode === "include" ? 1 : 0;
-
-  // Block Apply when the Software tab is invalid — no category selected or bad
-  // EPSS input — and surface the reason as a tooltip.
-  const applyError = isCVE
-    ? getSoftwareFilterApplyError(softwareFilters, epssMin, epssMax)
-    : null;
-  const applyDisabled = applyError !== null;
-  const applyTooltip = applyError ?? "";
 
   const renderHostSearch = () => (
     <div className={`${baseClass}__host-search`}>
@@ -377,65 +509,68 @@ const ChartFilterModal = ({
 
   return (
     <Modal title="Settings" onExit={onCancel} className={baseClass}>
-      {isCVE ? (
-        <TabNav>
-          <Tabs selectedIndex={activeTab} onSelect={setActiveTab}>
-            <TabList>
-              <Tab>
-                <TabText>Hosts</TabText>
-              </Tab>
-              <Tab>
-                <TabText>Software</TabText>
-              </Tab>
-            </TabList>
-            <TabPanel>{renderHostFilters()}</TabPanel>
-            <TabPanel>
-              {/* Wrap in __form so the Software tab gets the same bottom
-                  spacing before the action buttons as the Hosts tab. */}
-              <div className={`${baseClass}__form`}>
-                <SoftwareFilters
-                  currentTeamId={currentTeamId}
-                  categories={softwareFilters}
-                  knownExploit={knownExploit}
-                  epssMin={epssMin}
-                  epssMax={epssMax}
-                  excludeCVEs={excludeCVEs}
-                  setCategories={setSoftwareFilters}
-                  setKnownExploit={setKnownExploit}
-                  setEpssMin={setEpssMin}
-                  setEpssMax={setEpssMax}
-                  setExcludeCVEs={setExcludeCVEs}
-                />
-              </div>
-            </TabPanel>
-          </Tabs>
-        </TabNav>
-      ) : (
-        renderHostFilters()
-      )}
-      <div className={`${baseClass}__btn-wrap`}>
-        {hasFilters && (
-          <Button variant="secondary" onClick={handleClear}>
-            Clear all
-          </Button>
+      <form onSubmit={handleSubmit}>
+        {isCVE ? (
+          <TabNav>
+            <Tabs selectedIndex={activeTab} onSelect={setActiveTab}>
+              <TabList>
+                <Tab>
+                  <TabText>Hosts</TabText>
+                </Tab>
+                <Tab>
+                  <TabText>Software</TabText>
+                </Tab>
+              </TabList>
+              <TabPanel>{renderHostFilters()}</TabPanel>
+              <TabPanel>
+                {/* Wrap in __form so the Software tab gets the same bottom
+                    spacing before the action buttons as the Hosts tab. */}
+                <div className={`${baseClass}__form`}>
+                  <SoftwareFilters
+                    currentTeamId={currentTeamId}
+                    categories={softwareFilters}
+                    knownExploit={knownExploit}
+                    epssMin={epssMin}
+                    epssMax={epssMax}
+                    severityFilter={severityFilter}
+                    initialShowAdvanced={initialShowAdvanced}
+                    errors={softwareErrors}
+                    excludeCVEs={excludeCVEs}
+                    setCategories={onChangeCategories}
+                    setKnownExploit={setKnownExploit}
+                    setEpssMin={onChangeEpssMin}
+                    setEpssMax={onChangeEpssMax}
+                    setSeverityFilter={onChangeSeverityFilter}
+                    setExcludeCVEs={setExcludeCVEs}
+                    onFieldBlur={onFieldBlur}
+                    onFieldFocus={onFieldFocus}
+                  />
+                </div>
+              </TabPanel>
+            </Tabs>
+          </TabNav>
+        ) : (
+          renderHostFilters()
         )}
-        <div className={`${baseClass}__btn-actions`}>
-          <Button variant="secondary" onClick={onCancel}>
-            Cancel
-          </Button>
-          {applyDisabled ? (
-            <TooltipWrapper tipContent={applyTooltip} underline={false}>
-              <Button variant="default" disabled>
-                Apply
-              </Button>
-            </TooltipWrapper>
-          ) : (
-            <Button variant="default" onClick={handleApply}>
-              Apply
+        <div className={`${baseClass}__btn-wrap`}>
+          {hasFilters && (
+            <Button variant="secondary" onClick={handleClear}>
+              Clear all
             </Button>
           )}
+          <div className="modal-cta-wrap">
+            {/* Always enabled: submitting with invalid input is what surfaces
+            the inline errors. See
+            frontend/docs/patterns.md#submit-button-state. */}
+            <Button type="submit" variant="default">
+              Apply
+            </Button>
+            <Button variant="secondary" onClick={onCancel}>
+              Cancel
+            </Button>
+          </div>
         </div>
-      </div>
+      </form>
     </Modal>
   );
 };

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/SoftwareFilters/SoftwareFilters.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/SoftwareFilters/SoftwareFilters.tests.tsx
@@ -5,8 +5,10 @@ import { http, HttpResponse } from "msw";
 import { createCustomRenderer, baseUrl } from "test/test-utils";
 import mockServer from "test/mock-server";
 import { ALL_CVE_SOFTWARE_CATEGORY_VALUES } from "interfaces/charts";
+import { SEVERITY_SCORE_RANGE_ERROR } from "components/SeverityFilter";
 
 import SoftwareFilters from "./SoftwareFilters";
+import { EPSS_RANGE_HELP, NO_CATEGORIES_MSG } from "./helpers";
 
 const emptyVulnsHandler = http.get(baseUrl("/vulnerabilities"), () =>
   HttpResponse.json({
@@ -17,17 +19,22 @@ const emptyVulnsHandler = http.get(baseUrl("/vulnerabilities"), () =>
   })
 );
 
-const baseProps = {
+const baseProps: React.ComponentProps<typeof SoftwareFilters> = {
   categories: [...ALL_CVE_SOFTWARE_CATEGORY_VALUES],
   knownExploit: false,
   epssMin: "",
   epssMax: "",
+  severityFilter: { severity: "critical", minScore: "9", maxScore: "10" },
+  errors: {},
   excludeCVEs: [],
   setCategories: jest.fn(),
   setKnownExploit: jest.fn(),
   setEpssMin: jest.fn(),
   setEpssMax: jest.fn(),
+  setSeverityFilter: jest.fn(),
   setExcludeCVEs: jest.fn(),
+  onFieldBlur: jest.fn(),
+  onFieldFocus: jest.fn(),
 };
 
 const render = createCustomRenderer({ withBackendMock: true });
@@ -74,20 +81,23 @@ describe("SoftwareFilters", () => {
     );
   });
 
-  it("shows a validation error when no category is selected", () => {
-    render(<SoftwareFilters {...baseProps} categories={[]} />);
+  // Errors are owned by the parent, which decides when a field has earned one.
+  it("renders the category error the parent is showing", () => {
+    render(
+      <SoftwareFilters
+        {...baseProps}
+        categories={[]}
+        errors={{ categories: NO_CATEGORIES_MSG }}
+      />
+    );
 
-    expect(
-      screen.getByText("Select at least one software category.")
-    ).toBeInTheDocument();
+    expect(screen.getByText(NO_CATEGORIES_MSG)).toBeInTheDocument();
   });
 
-  it("does not show the category error when a category is selected", () => {
-    render(<SoftwareFilters {...baseProps} categories={["os"]} />);
+  it("shows no category error while the parent is reporting none", () => {
+    render(<SoftwareFilters {...baseProps} categories={[]} />);
 
-    expect(
-      screen.queryByText("Select at least one software category.")
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(NO_CATEGORIES_MSG)).not.toBeInTheDocument();
   });
 
   it("keeps Advanced options collapsed until toggled", async () => {
@@ -100,17 +110,56 @@ describe("SoftwareFilters", () => {
     await user.click(screen.getByRole("button", { name: /Advanced options/i }));
 
     expect(screen.getByText("Probability of exploit")).toBeInTheDocument();
+    expect(screen.getByText("Severity")).toBeInTheDocument();
     expect(
       screen.getByText("Exclude vulnerabilities (CVEs)")
     ).toBeInTheDocument();
+
+    // And back, since nothing is holding it open.
+    await user.click(screen.getByRole("button", { name: /Advanced options/i }));
+    expect(
+      screen.queryByText("Probability of exploit")
+    ).not.toBeInTheDocument();
   });
 
-  it("surfaces an EPSS range error for out-of-range input", async () => {
-    const { user } = render(<SoftwareFilters {...baseProps} epssMin="-1" />);
+  it("opens Advanced options on mount when asked, and still collapses", async () => {
+    const { user } = render(
+      <SoftwareFilters {...baseProps} initialShowAdvanced />
+    );
+
+    expect(screen.getByText("Probability of exploit")).toBeInTheDocument();
+
+    // Only the starting state, not a lock — nothing is holding it open.
+    await user.click(screen.getByRole("button", { name: /Advanced options/i }));
+    expect(
+      screen.queryByText("Probability of exploit")
+    ).not.toBeInTheDocument();
+  });
+
+  // A collapsed reveal would hide the only thing standing between the user and
+  // a successful Apply.
+  it("force-opens Advanced options over an error and refuses to collapse", async () => {
+    const { user } = render(
+      <SoftwareFilters
+        {...baseProps}
+        epssMin="-1"
+        severityFilter={{ severity: "custom", minScore: "11", maxScore: "" }}
+        errors={{
+          epssMin: EPSS_RANGE_HELP,
+          cvssMin: SEVERITY_SCORE_RANGE_ERROR,
+        }}
+      />
+    );
+
+    // Open on mount, with no click. Matched by message, since FormField renders
+    // an error in the label's place.
+    expect(screen.getByText(EPSS_RANGE_HELP)).toBeInTheDocument();
+    expect(screen.getByText(SEVERITY_SCORE_RANGE_ERROR)).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: /Advanced options/i }));
 
-    expect(screen.getByText("Must be from 0 to 100")).toBeInTheDocument();
+    expect(screen.getByText(EPSS_RANGE_HELP)).toBeInTheDocument();
+    expect(screen.getByText(SEVERITY_SCORE_RANGE_ERROR)).toBeInTheDocument();
   });
 
   it("renders excluded CVEs as removable pills", async () => {

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/SoftwareFilters/SoftwareFilters.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/SoftwareFilters/SoftwareFilters.tsx
@@ -15,9 +15,12 @@ import RevealButton from "components/buttons/RevealButton";
 import SearchField from "components/forms/fields/SearchField";
 // @ts-ignore
 import InputField from "components/forms/fields/InputField";
+import SeverityFilter, {
+  ISeverityFilterValue,
+} from "components/SeverityFilter";
 
 import TooltipWrapper from "components/TooltipWrapper/TooltipWrapper";
-import { getEpssError, NO_CATEGORIES_MSG } from "./helpers";
+import { ISoftwareFilterErrors, SoftwareFilterField } from "./helpers";
 
 const baseClass = "software-filters";
 
@@ -30,12 +33,22 @@ interface ISoftwareFiltersProps {
   knownExploit: boolean;
   epssMin: string;
   epssMax: string;
+  severityFilter: ISeverityFilterValue;
+  /** Start with the Advanced section open. For entry points that mean "show me
+   * what is filtered" — most of what narrows the chart lives in there. */
+  initialShowAdvanced?: boolean;
+  /** The errors currently being shown. The parent decides when a field has
+   * earned one — see frontend/docs/patterns.md#data-validation. */
+  errors: ISoftwareFilterErrors;
   excludeCVEs: string[];
   setCategories: (categories: string[]) => void;
   setKnownExploit: (value: boolean) => void;
   setEpssMin: (value: string) => void;
   setEpssMax: (value: string) => void;
+  setSeverityFilter: (next: ISeverityFilterValue) => void;
   setExcludeCVEs: (cves: string[]) => void;
+  onFieldBlur: (field: SoftwareFilterField) => void;
+  onFieldFocus: (field: SoftwareFilterField) => void;
 }
 
 const SoftwareFilters = ({
@@ -44,14 +57,31 @@ const SoftwareFilters = ({
   knownExploit,
   epssMin,
   epssMax,
+  severityFilter,
+  initialShowAdvanced = false,
+  errors,
   excludeCVEs,
   setCategories,
   setKnownExploit,
   setEpssMin,
   setEpssMax,
+  setSeverityFilter,
   setExcludeCVEs,
+  onFieldBlur,
+  onFieldFocus,
 }: ISoftwareFiltersProps): JSX.Element => {
-  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [showAdvanced, setShowAdvanced] = useState(initialShowAdvanced);
+  // Every field that can error lives in this section, so Apply would otherwise
+  // surface errors behind a collapsed reveal. Keyed on the errors being shown,
+  // not on the raw values.
+  const hasAdvancedError = !!(
+    errors.epssMin ||
+    errors.epssMax ||
+    errors.cvssMin ||
+    errors.cvssMax
+  );
+  const advancedVisible = showAdvanced || hasAdvancedError;
+
   const [searchInput, setSearchInput] = useState("");
   const [searchQuery, setSearchQuery] = useState("");
   const [pageCount, setPageCount] = useState(1);
@@ -87,8 +117,8 @@ const SoftwareFilters = ({
         query: searchQuery || undefined,
       }),
     // The CVE search UI lives entirely inside the Advanced section, so don't
-    // fetch until the user opens it.
-    { keepPreviousData: true, staleTime: 30000, enabled: showAdvanced }
+    // fetch until it is on screen.
+    { keepPreviousData: true, staleTime: 30000, enabled: advancedVisible }
   );
 
   const cves: IVulnerability[] = vulnData?.vulnerabilities ?? [];
@@ -140,9 +170,9 @@ const SoftwareFilters = ({
             {cat.label}
           </Checkbox>
         ))}
-        {categories.length === 0 && (
+        {errors.categories && (
           <div className={`${baseClass}__categories-error`} role="alert">
-            {NO_CATEGORIES_MSG}
+            {errors.categories}
           </div>
         )}
       </div>
@@ -163,14 +193,16 @@ const SoftwareFilters = ({
 
       <RevealButton
         className={`${baseClass}__advanced-toggle`}
-        isShowing={showAdvanced}
+        isShowing={advancedVisible}
         showText="Advanced options"
         hideText="Advanced options"
         caretPosition="after"
-        onClick={() => setShowAdvanced((prev) => !prev)}
+        // Toggle from what's displayed, not from internal state, so the button
+        // stays in step while an error holds the section open.
+        onClick={() => setShowAdvanced(!advancedVisible)}
       />
 
-      {showAdvanced && (
+      {advancedVisible && (
         <div className={`${baseClass}__advanced`}>
           <div className={`${baseClass}__epss`}>
             <h3 className={`${baseClass}__section-title`}>
@@ -197,8 +229,10 @@ const SoftwareFilters = ({
                 type="number"
                 value={epssMin}
                 placeholder="0"
-                error={getEpssError(epssMin)}
+                error={errors.epssMin}
                 onChange={setEpssMin}
+                onBlur={() => onFieldBlur("epssMin")}
+                onFocus={() => onFieldFocus("epssMin")}
               />
               <InputField
                 label="Max"
@@ -206,11 +240,29 @@ const SoftwareFilters = ({
                 type="number"
                 value={epssMax}
                 placeholder="100"
-                error={getEpssError(epssMax)}
+                error={errors.epssMax}
                 onChange={setEpssMax}
+                onBlur={() => onFieldBlur("epssMax")}
+                onFocus={() => onFieldFocus("epssMax")}
               />
             </div>
           </div>
+
+          {/* SeverityFilter renders its own label and spacing, and its label
+          already matches __section-title, so it needs no section wrapper. */}
+          <SeverityFilter
+            severity={severityFilter.severity}
+            minScore={severityFilter.minScore}
+            maxScore={severityFilter.maxScore}
+            onChange={setSeverityFilter}
+            errors={{ minScore: errors.cvssMin, maxScore: errors.cvssMax }}
+            onScoreBlur={(field) =>
+              onFieldBlur(field === "minScore" ? "cvssMin" : "cvssMax")
+            }
+            onScoreFocus={(field) =>
+              onFieldFocus(field === "minScore" ? "cvssMin" : "cvssMax")
+            }
+          />
 
           <div className={`${baseClass}__exclude-cves`}>
             <h3 className={`${baseClass}__section-title`}>

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/SoftwareFilters/helpers.tests.ts
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/SoftwareFilters/helpers.tests.ts
@@ -1,13 +1,13 @@
+import { SEVERITY_SCORE_RANGE_ERROR } from "components/SeverityFilter";
+
 import {
   EPSS_RANGE_HELP,
-  EPSS_RANGE_HELP_MSG,
   EPSS_RANGE_INVALID_MSG,
   getEpssError,
-  getSoftwareFilterApplyError,
-  hasEpssErrors,
   isEpssActive,
   isEpssRangeInvalid,
   NO_CATEGORIES_MSG,
+  validateSoftwareFilters,
 } from "./helpers";
 
 describe("SoftwareFilters helpers", () => {
@@ -43,19 +43,6 @@ describe("SoftwareFilters helpers", () => {
     });
   });
 
-  describe("hasEpssErrors", () => {
-    it("is true for any field error or inverted range", () => {
-      expect(hasEpssErrors("-1", "")).toBe(true);
-      expect(hasEpssErrors("", "200")).toBe(true);
-      expect(hasEpssErrors("10", "5")).toBe(true);
-    });
-
-    it("is false for valid/empty input", () => {
-      expect(hasEpssErrors("", "")).toBe(false);
-      expect(hasEpssErrors("5", "90")).toBe(false);
-    });
-  });
-
   describe("isEpssActive", () => {
     it("treats empty or the full 0–100 range as inactive", () => {
       expect(isEpssActive("", "")).toBe(false);
@@ -68,29 +55,83 @@ describe("SoftwareFilters helpers", () => {
     });
   });
 
-  describe("getSoftwareFilterApplyError", () => {
-    it("blocks Apply when no category is selected", () => {
-      expect(getSoftwareFilterApplyError([], "", "")).toBe(NO_CATEGORIES_MSG);
-      // The category error takes precedence over EPSS errors.
-      expect(getSoftwareFilterApplyError([], "10", "5")).toBe(
-        NO_CATEGORIES_MSG
-      );
-    });
+  describe("validateSoftwareFilters", () => {
+    const valid = {
+      categories: ["os"],
+      epssMin: "",
+      epssMax: "",
+      minScore: "",
+      maxScore: "",
+    };
 
-    it("returns null when at least one category is selected and EPSS is valid", () => {
-      expect(getSoftwareFilterApplyError(["os"], "", "")).toBeNull();
+    it("reports nothing when every field is valid or unset", () => {
+      expect(validateSoftwareFilters(valid)).toEqual({});
       expect(
-        getSoftwareFilterApplyError(["os", "adobe"], "5", "90")
-      ).toBeNull();
+        validateSoftwareFilters({
+          ...valid,
+          categories: ["os", "adobe"],
+          epssMin: "5",
+          epssMax: "90",
+          minScore: "0.1",
+          maxScore: "9.9",
+        })
+      ).toEqual({});
     });
 
-    it("surfaces EPSS errors once a category is selected", () => {
-      expect(getSoftwareFilterApplyError(["os"], "10", "5")).toBe(
-        EPSS_RANGE_INVALID_MSG
-      );
-      expect(getSoftwareFilterApplyError(["os"], "-1", "")).toBe(
-        EPSS_RANGE_HELP_MSG
-      );
+    it("reports an empty category selection", () => {
+      expect(validateSoftwareFilters({ ...valid, categories: [] })).toEqual({
+        categories: NO_CATEGORIES_MSG,
+      });
+    });
+
+    it("reports out-of-range EPSS values per field", () => {
+      expect(
+        validateSoftwareFilters({ ...valid, epssMin: "-1", epssMax: "200" })
+      ).toEqual({
+        epssMin: EPSS_RANGE_HELP,
+        epssMax: EPSS_RANGE_HELP,
+      });
+    });
+
+    it("attaches an inverted EPSS range to the maximum, the dependent field", () => {
+      expect(
+        validateSoftwareFilters({ ...valid, epssMin: "10", epssMax: "5" })
+      ).toEqual({ epssMax: EPSS_RANGE_INVALID_MSG });
+    });
+
+    it("prefers an EPSS field's own format error over the range check", () => {
+      // Showing "maximum at or above the minimum" for an unparseable bound
+      // would describe the wrong problem.
+      expect(
+        validateSoftwareFilters({ ...valid, epssMin: "abc", epssMax: "5" })
+      ).toEqual({ epssMin: EPSS_RANGE_HELP });
+    });
+
+    // The CVSS rules belong to validateSeverityScores. All this module does is
+    // rename its two fields, so one case pins that.
+    it("renames the severity errors to the Software tab's field names", () => {
+      expect(
+        validateSoftwareFilters({ ...valid, minScore: "11", maxScore: "5.55" })
+      ).toEqual({
+        cvssMin: SEVERITY_SCORE_RANGE_ERROR,
+        cvssMax: SEVERITY_SCORE_RANGE_ERROR,
+      });
+    });
+
+    it("reports every invalid field at once, for the submit checkpoint", () => {
+      expect(
+        validateSoftwareFilters({
+          categories: [],
+          epssMin: "-1",
+          epssMax: "",
+          minScore: "11",
+          maxScore: "",
+        })
+      ).toEqual({
+        categories: NO_CATEGORIES_MSG,
+        epssMin: EPSS_RANGE_HELP,
+        cvssMin: SEVERITY_SCORE_RANGE_ERROR,
+      });
     });
   });
 });

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/SoftwareFilters/helpers.ts
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/SoftwareFilters/helpers.ts
@@ -1,19 +1,21 @@
+import { validateSeverityScores } from "components/SeverityFilter";
+
 // EPSS inputs are entered as a 0–100 percentage; the chart API takes 0.0–1.0.
 export const EPSS_MIN_PCT = 0;
 export const EPSS_MAX_PCT = 100;
 
-export const EPSS_RANGE_HELP = `Must be from ${EPSS_MIN_PCT} to ${EPSS_MAX_PCT}`;
+// Error copy follows the verb + object + constraint register, with no terminal
+// period — see frontend/docs/patterns.md#error-message-copy-register.
+export const EPSS_RANGE_HELP = `Enter a probability from ${EPSS_MIN_PCT} to ${EPSS_MAX_PCT}`;
 export const EPSS_RANGE_INVALID_MSG =
-  "Minimum EPSS probability cannot be greater than the maximum EPSS probability.";
+  "Enter a maximum probability at or above the minimum";
 
 // At least one software category must stay selected: an empty set is
 // indistinguishable from "no filter" on the wire, so the chart would show every
-// category instead of none. Block Apply and surface this message instead.
-export const NO_CATEGORIES_MSG = "Select at least one software category.";
-export const EPSS_RANGE_HELP_MSG = "Enter EPSS values from 0 to 100.";
+// category instead of none.
+export const NO_CATEGORIES_MSG = "Select at least one software category";
 
-// Returns an error string when the raw value is out of the 0–100 range, or null
-// when it's empty (unset) or valid.
+// Empty is "unset" and never errors.
 export const getEpssError = (raw: string): string | null => {
   if (raw.trim() === "") {
     return null;
@@ -25,7 +27,6 @@ export const getEpssError = (raw: string): string | null => {
   return null;
 };
 
-// True when both bounds are present, individually valid, and min > max.
 export const isEpssRangeInvalid = (min: string, max: string): boolean => {
   if (min.trim() === "" || max.trim() === "") {
     return false;
@@ -36,13 +37,6 @@ export const isEpssRangeInvalid = (min: string, max: string): boolean => {
   return Number(min) > Number(max);
 };
 
-// The Software filters are invalid (Apply blocked) when any EPSS field is out of
-// range or the min/max are inverted.
-export const hasEpssErrors = (min: string, max: string): boolean =>
-  getEpssError(min) !== null ||
-  getEpssError(max) !== null ||
-  isEpssRangeInvalid(min, max);
-
 // An EPSS bound only narrows when min > 0 or max < 100; empty or 0–100 is "all".
 export const isEpssActive = (min: string, max: string): boolean => {
   const minActive = min.trim() !== "" && Number(min) > EPSS_MIN_PCT;
@@ -50,23 +44,54 @@ export const isEpssActive = (min: string, max: string): boolean => {
   return minActive || maxActive;
 };
 
-// Returns the reason Apply should be blocked for the Software tab, or null when
-// the filters are valid. Used both to disable the Apply button and as its
-// tooltip text. Categories are checked first since an empty set is the more
-// fundamental error.
-export const getSoftwareFilterApplyError = (
-  categories: string[],
-  epssMin: string,
-  epssMax: string
-): string | null => {
+export type SoftwareFilterField =
+  | "categories"
+  | "epssMin"
+  | "epssMax"
+  | "cvssMin"
+  | "cvssMax";
+
+export type ISoftwareFilterErrors = Partial<
+  Record<SoftwareFilterField, string>
+>;
+
+export interface ISoftwareFilterFormData {
+  categories: string[];
+  epssMin: string;
+  epssMax: string;
+  minScore: string;
+  maxScore: string;
+}
+
+/**
+ * The Software tab's validate function — see
+ * frontend/docs/patterns.md#how-to-validate.
+ */
+export const validateSoftwareFilters = ({
+  categories,
+  epssMin,
+  epssMax,
+  minScore,
+  maxScore,
+}: ISoftwareFilterFormData): ISoftwareFilterErrors => {
+  const errors: ISoftwareFilterErrors = {};
+
   if (categories.length === 0) {
-    return NO_CATEGORIES_MSG;
+    errors.categories = NO_CATEGORIES_MSG;
   }
-  if (isEpssRangeInvalid(epssMin, epssMax)) {
-    return EPSS_RANGE_INVALID_MSG;
+
+  const epssMinError = getEpssError(epssMin);
+  const epssMaxError = getEpssError(epssMax);
+  if (epssMinError) errors.epssMin = epssMinError;
+  if (epssMaxError) errors.epssMax = epssMaxError;
+  if (!epssMinError && !epssMaxError && isEpssRangeInvalid(epssMin, epssMax)) {
+    errors.epssMax = EPSS_RANGE_INVALID_MSG;
   }
-  if (hasEpssErrors(epssMin, epssMax)) {
-    return EPSS_RANGE_HELP_MSG;
-  }
-  return null;
+
+  // Already placed per field; only this tab's names for the two inputs differ.
+  const severity = validateSeverityScores({ minScore, maxScore });
+  if (severity.minScore) errors.cvssMin = severity.minScore;
+  if (severity.maxScore) errors.cvssMax = severity.maxScore;
+
+  return errors;
 };

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartFilterModal/_styles.scss
@@ -12,9 +12,12 @@
     align-items: center;
   }
 
-  &__btn-actions {
-    display: flex;
-    gap: $pad-small;
+  // The shared modal action-button styles, minus the standalone spacing they
+  // assume: this row already sits at the bottom of the modal and holds Clear all
+  // opposite the actions.
+  .modal-cta-wrap {
+    margin-top: 0;
+    align-self: auto;
     margin-left: auto;
   }
 

--- a/frontend/pages/DashboardPage/cards/ChartCard/helpers.tests.ts
+++ b/frontend/pages/DashboardPage/cards/ChartCard/helpers.tests.ts
@@ -1,0 +1,173 @@
+import { SeverityValue } from "components/SeverityFilter";
+import { ALL_CVE_SOFTWARE_CATEGORY_VALUES } from "interfaces/charts";
+
+import {
+  buildInitialChartFilters,
+  hostFilterLines,
+  softwareFilterLines,
+} from "./helpers";
+
+describe("buildInitialChartFilters", () => {
+  it("uses built-in defaults when no persisted defaults are provided", () => {
+    const filters = buildInitialChartFilters(undefined);
+    expect(filters.softwareFilters).toEqual([
+      ...ALL_CVE_SOFTWARE_CATEGORY_VALUES,
+    ]);
+    expect(filters.knownExploit).toBe(false);
+    expect(filters.epssMin).toBe("");
+    expect(filters.epssMax).toBe("");
+    expect(filters.severity).toBe("critical");
+    expect(filters.cvssMin).toBe("9");
+    expect(filters.cvssMax).toBe("10");
+    expect(filters.excludeCVEs).toEqual([]);
+  });
+
+  it("keeps the critical severity default when no CVSS bounds are persisted", () => {
+    const filters = buildInitialChartFilters({ has_known_exploit: true });
+    expect(filters.severity).toBe("critical");
+    expect(filters.cvssMin).toBe("9");
+    expect(filters.cvssMax).toBe("10");
+  });
+
+  it("seeds a preset with its own bounds, which is what gets sent to the API", () => {
+    expect(
+      buildInitialChartFilters({ cvss_min: 7, cvss_max: 8.9 })
+    ).toMatchObject({ severity: "high", cvssMin: "7", cvssMax: "8.9" });
+    // Any narrows nothing, so it carries no bounds.
+    expect(
+      buildInitialChartFilters({ cvss_min: 0, cvss_max: 10 })
+    ).toMatchObject({ severity: "any", cvssMin: "", cvssMax: "" });
+  });
+
+  it("seeds a custom range when only one CVSS bound is persisted", () => {
+    expect(buildInitialChartFilters({ cvss_min: 7 })).toMatchObject({
+      severity: "custom",
+      cvssMin: "7",
+      cvssMax: "10",
+    });
+  });
+
+  it("seeds present fields and falls back per-field for absent ones", () => {
+    const filters = buildInitialChartFilters({
+      software_filters: ["browsers"],
+      has_known_exploit: true,
+    });
+    expect(filters.softwareFilters).toEqual(["browsers"]);
+    expect(filters.knownExploit).toBe(true);
+    expect(filters.epssMin).toBe("");
+    expect(filters.epssMax).toBe("");
+    expect(filters.excludeCVEs).toEqual([]);
+  });
+
+  it("converts numeric EPSS bounds (0-100) to strings", () => {
+    const filters = buildInitialChartFilters({ epss_min: 0, epss_max: 90 });
+    expect(filters.epssMin).toBe("0");
+    expect(filters.epssMax).toBe("90");
+  });
+
+  it("honors an explicit empty software_filters list as 'none'", () => {
+    const filters = buildInitialChartFilters({ software_filters: [] });
+    expect(filters.softwareFilters).toEqual([]);
+  });
+
+  it("seeds the exclude-CVE list", () => {
+    const filters = buildInitialChartFilters({
+      exclude_vulnerabilities: ["CVE-2025-50897"],
+    });
+    expect(filters.excludeCVEs).toEqual(["CVE-2025-50897"]);
+  });
+});
+
+describe("softwareFilterLines", () => {
+  // The bounds always mirror the selection, so a preset here is given its own —
+  // the same state the app can actually produce.
+  const filtersWithSeverity = (
+    severity: SeverityValue,
+    cvssMin = "",
+    cvssMax = ""
+  ) => ({
+    ...buildInitialChartFilters(undefined),
+    severity,
+    cvssMin,
+    cvssMax,
+  });
+
+  // How a selection reads is severityValueLabel's contract, covered by its own
+  // tests. What belongs here is the line: its prefix, and the gate deciding
+  // whether there is one at all.
+  it("gives the active severity a prefixed line of its own", () => {
+    expect(
+      softwareFilterLines(filtersWithSeverity("critical", "9", "10"))
+    ).toEqual(["Severity: Critical"]);
+    expect(
+      softwareFilterLines(filtersWithSeverity("custom", "2.5", "6"))
+    ).toEqual(["Severity: Custom (2.5 to 6)"]);
+  });
+
+  it("omits the severity line for Any severity", () => {
+    expect(softwareFilterLines(filtersWithSeverity("any"))).toEqual([]);
+  });
+
+  it("omits the severity line for a Custom range that narrows nothing", () => {
+    // Nothing is sent to the API in either state, so claiming a severity filter
+    // would describe the chart as narrower than it is.
+    expect(softwareFilterLines(filtersWithSeverity("custom"))).toEqual([]);
+    // Typing both ends of the scale into Custom is the same as not filtering,
+    // even though the dropdown still reads Custom — typing never re-derives it.
+    expect(
+      softwareFilterLines(filtersWithSeverity("custom", "0", "10"))
+    ).toEqual([]);
+    // A single bound is enough to be a real filter.
+    expect(
+      softwareFilterLines(filtersWithSeverity("custom", "", "6"))
+    ).toEqual(["Severity: Custom (0 to 6)"]);
+  });
+
+  it("keeps severity separate from the generic Advanced filters line", () => {
+    expect(
+      softwareFilterLines({
+        ...filtersWithSeverity("high", "7", "8.9"),
+        excludeCVEs: ["CVE-2025-0001"],
+      })
+    ).toEqual(["Severity: High", "Advanced filters"]);
+  });
+});
+
+describe("hostFilterLines", () => {
+  const filtersWithPlatforms = (platforms: string[]) => ({
+    ...buildInitialChartFilters(undefined),
+    platforms,
+  });
+
+  it("preserves branded platform casing (macOS, iOS, iPadOS)", () => {
+    const [line] = hostFilterLines(
+      filtersWithPlatforms(["darwin", "ios", "ipados"])
+    );
+    expect(line).toBe("macOS, iOS, and iPadOS");
+    // Guards the reported bug: no word-capitalized variants.
+    expect(line).not.toMatch(/MacOS|Ios|Ipados/);
+  });
+
+  it("renders a single platform without mangling its casing", () => {
+    expect(hostFilterLines(filtersWithPlatforms(["darwin"]))).toEqual([
+      "macOS",
+    ]);
+  });
+
+  it("maps every filterable platform to its correct display name", () => {
+    const [line] = hostFilterLines(
+      filtersWithPlatforms([
+        "darwin",
+        "windows",
+        "linux",
+        "chrome",
+        "ios",
+        "ipados",
+        "android",
+      ])
+    );
+    expect(line).toBe(
+      "macOS, Windows, Linux, ChromeOS, iOS, iPadOS, and Android"
+    );
+  });
+});

--- a/frontend/pages/DashboardPage/cards/ChartCard/helpers.ts
+++ b/frontend/pages/DashboardPage/cards/ChartCard/helpers.ts
@@ -1,0 +1,179 @@
+import { isEmpty } from "lodash";
+
+import { PLATFORM_DISPLAY_NAMES } from "interfaces/platform";
+import {
+  CVE_SOFTWARE_CATEGORIES,
+  ALL_CVE_SOFTWARE_CATEGORY_VALUES,
+  IVulnExposureFilterDefaults,
+} from "interfaces/charts";
+import {
+  ANY_SEVERITY_VALUE,
+  getSeverityBand,
+  ISeverityFilterValue,
+  severityFilters,
+  severityForRange,
+  severityValueLabel,
+} from "components/SeverityFilter";
+
+import { IChartFilterState } from "./ChartFilterModal";
+import { isEpssActive } from "./ChartFilterModal/SoftwareFilters/helpers";
+
+const DEFAULT_CHART_FILTERS: IChartFilterState = {
+  labelIDs: [],
+  platforms: [],
+  hostFilterMode: "none",
+  selectedHosts: [],
+  softwareFilters: [...ALL_CVE_SOFTWARE_CATEGORY_VALUES],
+  knownExploit: false,
+  epssMin: "",
+  epssMax: "",
+  // The chart is filtered to critical severity by default. The bounds always
+  // mirror the selection (see IChartFilterState), so they carry critical's.
+  severity: "critical",
+  cvssMin: "9",
+  cvssMax: "10",
+  excludeCVEs: [],
+};
+
+// Bounds are materialized for every option except Any, which holds none — the
+// same invariant SeverityFilter maintains when the user picks an option.
+const seedSeverity = (defaults: IVulnExposureFilterDefaults) => {
+  if (defaults.cvss_min === undefined && defaults.cvss_max === undefined) {
+    return {
+      severity: DEFAULT_CHART_FILTERS.severity,
+      cvssMin: DEFAULT_CHART_FILTERS.cvssMin,
+      cvssMax: DEFAULT_CHART_FILTERS.cvssMax,
+    };
+  }
+  const severity = severityForRange(defaults.cvss_min, defaults.cvss_max);
+  if (severity === ANY_SEVERITY_VALUE) {
+    return { severity, cvssMin: "", cvssMax: "" };
+  }
+  // A Custom range widens a missing bound to that end of the scale. `??`, not
+  // `||`: `cvss_max: 0` means "only 0.0", not "up to 10".
+  const band = getSeverityBand(severity);
+  return {
+    severity,
+    cvssMin: String(band?.min ?? defaults.cvss_min ?? 0),
+    cvssMax: String(band?.max ?? defaults.cvss_max ?? 10),
+  };
+};
+
+// Seeds from the GitOps-managed defaults, per field: an undefined field falls
+// back to DEFAULT_CHART_FILTERS, while a present one is respected — including
+// an explicit empty software_filters list, which means "no categories".
+export const buildInitialChartFilters = (
+  defaults?: IVulnExposureFilterDefaults
+): IChartFilterState => {
+  if (!defaults) return DEFAULT_CHART_FILTERS;
+  return {
+    ...DEFAULT_CHART_FILTERS,
+    ...seedSeverity(defaults),
+    softwareFilters:
+      defaults.software_filters !== undefined
+        ? [...defaults.software_filters]
+        : DEFAULT_CHART_FILTERS.softwareFilters,
+    knownExploit:
+      defaults.has_known_exploit !== undefined
+        ? defaults.has_known_exploit
+        : DEFAULT_CHART_FILTERS.knownExploit,
+    epssMin:
+      defaults.epss_min !== undefined
+        ? String(defaults.epss_min)
+        : DEFAULT_CHART_FILTERS.epssMin,
+    epssMax:
+      defaults.epss_max !== undefined
+        ? String(defaults.epss_max)
+        : DEFAULT_CHART_FILTERS.epssMax,
+    excludeCVEs:
+      defaults.exclude_vulnerabilities !== undefined
+        ? [...defaults.exclude_vulnerabilities]
+        : DEFAULT_CHART_FILTERS.excludeCVEs,
+  };
+};
+
+// The chart state spells the scores cvssMin/cvssMax; SeverityFilter's helpers
+// take minScore/maxScore.
+export const severitySelection = (
+  filters: IChartFilterState
+): ISeverityFilterValue => ({
+  severity: filters.severity,
+  minScore: filters.cvssMin,
+  maxScore: filters.cvssMax,
+});
+
+export const hasActiveHostFilters = (filters: IChartFilterState): boolean => {
+  const hasHostFilter =
+    filters.hostFilterMode !== "none" && filters.selectedHosts.length > 0;
+  return (
+    filters.labelIDs.length > 0 || filters.platforms.length > 0 || hasHostFilter
+  );
+};
+
+export const hasActiveSoftwareFilters = (filters: IChartFilterState): boolean =>
+  filters.softwareFilters.length !== ALL_CVE_SOFTWARE_CATEGORY_VALUES.length ||
+  filters.knownExploit ||
+  isEpssActive(filters.epssMin, filters.epssMax) ||
+  !isEmpty(severityFilters(severitySelection(filters))) ||
+  filters.excludeCVEs.length > 0;
+
+// Human-readable "a, b, and c". Items must already be correctly cased —
+// don't force-capitalize here or branded names like "macOS"/"iOS" break.
+const formatList = (items: string[]): string => {
+  if (items.length <= 1) return items.join("");
+  if (items.length === 2) return `${items[0]} and ${items[1]}`;
+  return `${items.slice(0, -1).join(", ")}, and ${items[items.length - 1]}`;
+};
+
+// String-indexable, since a platform filter value is an arbitrary string — an
+// unknown one indexes to undefined and falls back to the raw value below.
+const PLATFORM_LABELS: Record<string, string> = PLATFORM_DISPLAY_NAMES;
+
+export const hostFilterLines = (filters: IChartFilterState): string[] => {
+  const lines: string[] = [];
+  if (filters.platforms.length > 0) {
+    lines.push(
+      formatList(filters.platforms.map((p) => PLATFORM_LABELS[p] ?? p))
+    );
+  }
+  if (filters.labelIDs.length > 0) lines.push("Labels");
+  if (
+    filters.hostFilterMode === "include" &&
+    filters.selectedHosts.length > 0
+  ) {
+    lines.push("Specific hosts");
+  }
+  if (
+    filters.hostFilterMode === "exclude" &&
+    filters.selectedHosts.length > 0
+  ) {
+    lines.push("Excluded hosts");
+  }
+  return lines;
+};
+
+export const softwareFilterLines = (filters: IChartFilterState): string[] => {
+  const lines: string[] = [];
+  // All categories are selected by default, so an unnarrowed selection is not
+  // an active filter and gets no line.
+  const categoriesNarrowed =
+    filters.softwareFilters.length !== ALL_CVE_SOFTWARE_CATEGORY_VALUES.length;
+  const cats = CVE_SOFTWARE_CATEGORIES.filter((c) =>
+    filters.softwareFilters.includes(c.value)
+  ).map((c) => c.tooltipLabel);
+  if (categoriesNarrowed) {
+    lines.push(cats.length ? formatList(cats) : "No software categories");
+  }
+  if (filters.knownExploit) lines.push("Known exploits only");
+  const selection = severitySelection(filters);
+  if (!isEmpty(severityFilters(selection))) {
+    lines.push(`Severity: ${severityValueLabel(selection)}`);
+  }
+  if (
+    isEpssActive(filters.epssMin, filters.epssMax) ||
+    filters.excludeCVEs.length > 0
+  ) {
+    lines.push("Advanced filters");
+  }
+  return lines;
+};

--- a/frontend/pages/SoftwarePage/SoftwareInventory/SoftwareInventoryTable/helpers.tests.ts
+++ b/frontend/pages/SoftwarePage/SoftwareInventory/SoftwareInventoryTable/helpers.tests.ts
@@ -1,4 +1,4 @@
-import { getVulnerabilities } from "./helpers";
+import { getVulnerabilities, getVulnFilterRenderDetails } from "./helpers";
 
 const versions = [
   {
@@ -48,5 +48,67 @@ describe("getVulnerabilities", () => {
 
   it("returns an empty array if no versions are given", () => {
     expect(getVulnerabilities([])).toEqual([]);
+  });
+});
+
+describe("getVulnFilterRenderDetails", () => {
+  // Only the CVSS bounds are stored, so the severity line is recovered from
+  // them by the same helpers the chart's filter summary uses.
+  const withSeverity = (minCvssScore?: number, maxCvssScore?: number) => {
+    const details = getVulnFilterRenderDetails({
+      vulnerable: true,
+      minCvssScore,
+      maxCvssScore,
+    });
+    return {
+      filterCount: details.filterCount,
+      // Each entry is a <span>{line}<br /></span> keyed by uniqueId, so the
+      // text is the first child.
+      lines: details.tooltipText.map((line) => line.props.children[0]),
+    };
+  };
+
+  it("counts nothing but the vulnerable filter when no scores are set", () => {
+    expect(withSeverity()).toEqual({
+      filterCount: 1,
+      lines: ["Vulnerable software"],
+    });
+  });
+
+  it("names a preset without restating its band", () => {
+    expect(withSeverity(9, 10).lines).toContain("Severity: Critical");
+    expect(withSeverity(0.1, 3.9).lines).toContain("Severity: Low");
+  });
+
+  it("spells out a Custom range, widening a half-open one", () => {
+    expect(withSeverity(2.5, 6).lines).toContain("Severity: Custom (2.5 to 6)");
+    expect(withSeverity(2.5, undefined).lines).toContain(
+      "Severity: Custom (2.5 to 10)"
+    );
+  });
+
+  it("counts a lone 0 minimum, which is a real bound", () => {
+    // The modal submits min 0 with no max, so this reaches the URL through the
+    // UI. A truthiness test here dropped it and under-reported the count.
+    const { filterCount, lines } = withSeverity(0, undefined);
+    expect(filterCount).toBe(2);
+    expect(lines).toContain("Severity: Custom (0 to 10)");
+  });
+
+  it("does not count the whole 0-10 scale as a severity filter", () => {
+    // It spans the scale, so it narrows nothing.
+    const { filterCount, lines } = withSeverity(0, 10);
+    expect(filterCount).toBe(1);
+    expect(lines).not.toContainEqual(expect.stringContaining("Severity"));
+  });
+
+  it("ignores severity entirely when the vulnerable filter is off", () => {
+    const { filterCount, buttonText } = getVulnFilterRenderDetails({
+      vulnerable: false,
+      minCvssScore: 9,
+      maxCvssScore: 10,
+    });
+    expect(filterCount).toBe(0);
+    expect(buttonText).toBe("Add filters");
   });
 });

--- a/frontend/pages/SoftwarePage/SoftwareInventory/SoftwareInventoryTable/helpers.ts
+++ b/frontend/pages/SoftwarePage/SoftwareInventory/SoftwareInventoryTable/helpers.ts
@@ -1,64 +1,18 @@
+import { isEmpty } from "lodash";
+
 import { QueryParams, parseQueryValueToNumberOrUndefined } from "utilities/url";
 import stringUtils from "utilities/strings/stringUtils";
 import { tooltipTextWithLineBreaks } from "utilities/helpers";
 import numberUtils from "utilities/numbers";
 
+import {
+  ISeverityFilterValue,
+  severityFilters,
+  severityForRange,
+  severityValueLabel,
+} from "components/SeverityFilter";
+
 const { isValidNumber } = numberUtils;
-
-export const CUSTOM_SEVERITY_OPTION = {
-  disabled: false,
-  label: "Custom severity",
-  value: "custom",
-  helpText: "Custom CVSS score range",
-  minSeverity: undefined,
-  maxSeverity: undefined,
-};
-
-export const ANY_SEVERITY_OPTION = {
-  disabled: false,
-  label: "Any severity",
-  value: "any",
-  helpText: "CVSS score 0-10",
-  minSeverity: 0,
-  maxSeverity: 10,
-};
-
-export const SEVERITY_DROPDOWN_OPTIONS = [
-  ANY_SEVERITY_OPTION,
-  {
-    disabled: false,
-    label: "Critical severity",
-    value: "critical",
-    helpText: "CVSS score 9.0-10",
-    minSeverity: 9.0,
-    maxSeverity: 10,
-  },
-  {
-    disabled: false,
-    label: "High severity",
-    value: "high",
-    helpText: "CVSS score 7.0-8.9",
-    minSeverity: 7.0,
-    maxSeverity: 8.9,
-  },
-  {
-    disabled: false,
-    label: "Medium severity",
-    value: "medium",
-    helpText: "CVSS score 4.0-6.9",
-    minSeverity: 4.0,
-    maxSeverity: 6.9,
-  },
-  {
-    disabled: false,
-    label: "Low severity",
-    value: "low",
-    helpText: "CVSS score 0.1-3.9",
-    minSeverity: 0.1,
-    maxSeverity: 3.9,
-  },
-  CUSTOM_SEVERITY_OPTION,
-];
 
 export const getSoftwareVulnFiltersFromQueryParams = (
   queryParams: QueryParams
@@ -108,34 +62,6 @@ export const buildSoftwareVulnFiltersQueryParams = (
   };
 };
 
-export const findOptionBySeverityRange = (
-  minSeverityValue: number | undefined,
-  maxSeverityValue: number | undefined
-) => {
-  // Check for "empty" (undefined/null) min and max, treat as "Any severity"
-  if (
-    (minSeverityValue === undefined || minSeverityValue === null) &&
-    (maxSeverityValue === undefined || maxSeverityValue === null)
-  ) {
-    return ANY_SEVERITY_OPTION;
-  }
-
-  const severityOption = SEVERITY_DROPDOWN_OPTIONS.find(
-    (option) =>
-      option.minSeverity === minSeverityValue &&
-      option.maxSeverity === maxSeverityValue
-  ) || {
-    disabled: true,
-    label: "Custom severity",
-    value: "custom",
-    helpText: `CVSS score ${minSeverityValue || 0}-${maxSeverityValue || 10}`,
-    minSeverity: minSeverityValue || 0,
-    maxSeverity: maxSeverityValue || 10,
-  };
-
-  return severityOption;
-};
-
 export const getVulnFilterRenderDetails = (
   vulnFilters?: ISoftwareVulnFiltersParams
 ) => {
@@ -147,14 +73,17 @@ export const getVulnFilterRenderDetails = (
       filterCount += 1;
       tooltipText.push("Vulnerable software");
 
-      if (vulnFilters.minCvssScore || vulnFilters.maxCvssScore) {
-        filterCount += 1;
-        const severityOption = findOptionBySeverityRange(
+      const severity: ISeverityFilterValue = {
+        severity: severityForRange(
           vulnFilters.minCvssScore,
           vulnFilters.maxCvssScore
-        );
-        const severityText = stringUtils.capitalize(severityOption?.value);
-        tooltipText.push(`Severity: ${severityText}`);
+        ),
+        minScore: vulnFilters.minCvssScore?.toString() ?? "",
+        maxScore: vulnFilters.maxCvssScore?.toString() ?? "",
+      };
+      if (!isEmpty(severityFilters(severity))) {
+        filterCount += 1;
+        tooltipText.push(`Severity: ${severityValueLabel(severity)}`);
       }
 
       if (vulnFilters.exploit) {

--- a/frontend/pages/SoftwarePage/components/modals/SoftwareFiltersModal/SoftwareFiltersModal.tests.tsx
+++ b/frontend/pages/SoftwarePage/components/modals/SoftwareFiltersModal/SoftwareFiltersModal.tests.tsx
@@ -1,7 +1,12 @@
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { renderWithSetup } from "test/test-utils";
 import { noop } from "lodash";
+
+import {
+  SEVERITY_RANGE_INVALID_MSG,
+  SEVERITY_SCORE_RANGE_ERROR,
+} from "components/SeverityFilter";
 
 import SoftwareFiltersModal from "./SoftwareFiltersModal";
 
@@ -23,21 +28,51 @@ const renderModal = (props = {}) =>
     />
   );
 
+const setUpModal = (props = {}) =>
+  renderWithSetup(
+    <SoftwareFiltersModal
+      onExit={noop}
+      onSubmit={noop}
+      vulnFilters={vulnFiltersDefault}
+      isPremiumTier
+      {...props}
+    />
+  );
+
+// react-select renders its options as plain divs, so target them by the testid
+// the shared custom Option component sets rather than by role.
+const selectSeverity = async (
+  user: ReturnType<typeof renderWithSetup>["user"],
+  label: string
+) => {
+  await user.click(screen.getByRole("combobox", { name: "Severity" }));
+  const option = screen
+    .getAllByTestId("dropdown-option")
+    .find((el) => el.textContent?.startsWith(label));
+  if (!option) {
+    throw new Error(`No severity option matching "${label}"`);
+  }
+  await user.click(option);
+};
+
 describe("SoftwareFiltersModal component", () => {
   it("renders modal title and form fields", () => {
     renderModal();
     expect(screen.getByText(/Filters/i)).toBeInTheDocument();
     expect(screen.getByText(/Vulnerable software/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/Min score/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/Max score/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("combobox", { name: "Severity" })
+    ).toBeInTheDocument();
     expect(screen.getByText(/Has known exploit/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Apply/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Cancel/i })).toBeInTheDocument();
   });
 
   it("disables input fields when Vulnerable software is off", () => {
-    renderModal();
-    expect(screen.getByRole("combobox")).toBeDisabled(); // Disabled dropdown
+    renderModal({
+      vulnFilters: { ...vulnFiltersDefault, minCvssScore: 2 },
+    });
+    expect(screen.getByRole("combobox", { name: "Severity" })).toBeDisabled();
     expect(screen.getByLabelText(/Min score/i)).toBeDisabled();
     expect(screen.getByLabelText(/Max score/i)).toBeDisabled();
     const checkbox = screen.getByRole("checkbox", {
@@ -47,16 +82,11 @@ describe("SoftwareFiltersModal component", () => {
   });
 
   it("enables input fields when Vulnerable software is toggled on", async () => {
-    const { user } = renderWithSetup(
-      <SoftwareFiltersModal
-        onExit={noop}
-        onSubmit={noop}
-        vulnFilters={vulnFiltersDefault}
-        isPremiumTier
-      />
-    );
+    const { user } = setUpModal({
+      vulnFilters: { ...vulnFiltersDefault, minCvssScore: 2 },
+    });
     await user.click(screen.getByRole("switch"));
-    expect(screen.getByRole("combobox")).toBeEnabled(); // Enabled dropdown
+    expect(screen.getByRole("combobox", { name: "Severity" })).toBeEnabled();
     expect(screen.getByLabelText(/Min score/i)).toBeEnabled();
     expect(screen.getByLabelText(/Max score/i)).toBeEnabled();
     const checkbox = screen.getByRole("checkbox", {
@@ -65,66 +95,123 @@ describe("SoftwareFiltersModal component", () => {
     expect(checkbox).toHaveAttribute("aria-disabled", "false");
   });
 
-  it("shows validation errors for non-numeric or out-of-range scores", async () => {
-    const { user } = renderWithSetup(
-      <SoftwareFiltersModal
-        onExit={noop}
-        onSubmit={noop}
-        vulnFilters={vulnFiltersDefault}
-        isPremiumTier
-      />
-    );
-    await user.click(screen.getByRole("switch"));
-    const minInput = screen.getByLabelText(/Min score/i);
-    const maxInput = screen.getByLabelText(/Max score/i);
+  // Per frontend/docs/patterns.md#data-validation: Apply stays enabled, errors
+  // appear on blur of a dirty field or on a submit attempt, and clear on focus.
+  describe("validation lifecycle", () => {
+    // Once an error replaces the label, getByLabelText can no longer find the
+    // field, so address the score inputs by name.
+    const scoreInput = (field: "minScore" | "maxScore") =>
+      document.querySelector(`input[name="${field}"]`) as HTMLInputElement;
 
-    // Out of range
-    await user.type(minInput, "11");
-    expect(screen.getByText(/Must be from 0-10/i)).toBeInTheDocument();
+    const setUpCustom = async () => {
+      const rendered = setUpModal();
+      await rendered.user.click(screen.getByRole("switch"));
+      await selectSeverity(rendered.user, "Custom severity");
+      return rendered;
+    };
 
-    await user.clear(minInput);
-    await user.type(minInput, "-1");
-    expect(screen.getByText(/Must be from 0-10/i)).toBeInTheDocument();
+    it("keeps Apply enabled with invalid input", async () => {
+      const { user } = await setUpCustom();
 
-    await user.clear(minInput);
-    await user.type(minInput, "5.55");
-    expect(screen.getByText(/Must be from 0-10/i)).toBeInTheDocument();
+      await user.type(scoreInput("minScore"), "11");
 
-    // Valid value, but min > max
-    await user.clear(minInput);
-    await user.type(minInput, "7");
-    await user.clear(maxInput);
-    await user.type(maxInput, "3");
-
-    const applyButton = screen.getByRole("button", { name: /Apply/i });
-
-    await user.hover(applyButton);
-    await waitFor(() => {
-      expect(
-        screen.getByText(/Minimum CVSS score cannot be greater/i)
-      ).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /Apply/i })).toBeEnabled();
     });
-    expect(screen.getByRole("button", { name: /Apply/i })).toBeDisabled();
+
+    it("shows nothing while typing, then the error on blur", async () => {
+      const { user } = await setUpCustom();
+
+      await user.type(scoreInput("minScore"), "11");
+      expect(
+        screen.queryByText(SEVERITY_SCORE_RANGE_ERROR)
+      ).not.toBeInTheDocument();
+
+      await user.tab();
+      expect(screen.getByText(SEVERITY_SCORE_RANGE_ERROR)).toBeInTheDocument();
+    });
+
+    it("clears the error on focus, restoring the label", async () => {
+      const { user } = await setUpCustom();
+
+      await user.type(scoreInput("minScore"), "11");
+      await user.tab();
+      expect(screen.getByText(SEVERITY_SCORE_RANGE_ERROR)).toBeInTheDocument();
+
+      await user.click(scoreInput("minScore"));
+      expect(
+        screen.queryByText(SEVERITY_SCORE_RANGE_ERROR)
+      ).not.toBeInTheDocument();
+      expect(screen.getByLabelText(/Min score/i)).toBeInTheDocument();
+    });
+
+    it("shows an inverted range on the maximum, the dependent field", async () => {
+      const { user } = await setUpCustom();
+
+      await user.type(scoreInput("minScore"), "7");
+      await user.type(scoreInput("maxScore"), "3");
+      await user.tab();
+
+      expect(screen.getByText(SEVERITY_RANGE_INVALID_MSG)).toBeInTheDocument();
+      // Attached to Max, so Min keeps its label.
+      expect(screen.getByLabelText(/Min score/i)).toBeInTheDocument();
+    });
+
+    it("surfaces every error and does not submit when Apply is clicked", async () => {
+      const onSubmitSpy = jest.fn();
+      const rendered = setUpModal({ onSubmit: onSubmitSpy });
+      const { user } = rendered;
+      await user.click(screen.getByRole("switch"));
+      await selectSeverity(user, "Custom severity");
+
+      await user.type(scoreInput("minScore"), "11");
+      await user.click(screen.getByRole("button", { name: /Apply/i }));
+
+      expect(onSubmitSpy).not.toHaveBeenCalled();
+      expect(screen.getByText(SEVERITY_SCORE_RANGE_ERROR)).toBeInTheDocument();
+    });
+
+    it("drops the error when Vulnerable software is switched off", async () => {
+      const onSubmitSpy = jest.fn();
+      const { user } = await setUpCustom();
+
+      await user.type(scoreInput("minScore"), "11");
+      await user.tab();
+      expect(screen.getByText(SEVERITY_SCORE_RANGE_ERROR)).toBeInTheDocument();
+
+      // Disabled fields are never in an error state, and the scores are not
+      // submitted while the filter is off.
+      await user.click(screen.getByRole("switch"));
+      expect(
+        screen.queryByText(SEVERITY_SCORE_RANGE_ERROR)
+      ).not.toBeInTheDocument();
+      expect(onSubmitSpy).not.toHaveBeenCalled();
+    });
+
+    it("clears a score error when the severity option changes", async () => {
+      const { user } = await setUpCustom();
+
+      await user.type(scoreInput("minScore"), "11");
+      await user.tab();
+      expect(screen.getByText(SEVERITY_SCORE_RANGE_ERROR)).toBeInTheDocument();
+
+      await selectSeverity(user, "High severity");
+
+      expect(
+        screen.queryByText(SEVERITY_SCORE_RANGE_ERROR)
+      ).not.toBeInTheDocument();
+    });
   });
 
   it("calls onSubmit with the correct values when form is valid", async () => {
     const onSubmitSpy = jest.fn();
-    const { user } = renderWithSetup(
-      <SoftwareFiltersModal
-        onExit={noop}
-        onSubmit={onSubmitSpy}
-        vulnFilters={vulnFiltersDefault}
-        isPremiumTier
-      />
-    );
+    const { user } = setUpModal({ onSubmit: onSubmitSpy });
     await user.click(screen.getByRole("switch"));
+    await selectSeverity(user, "Custom severity");
 
     const minInput = screen.getByLabelText(/Min score/i);
     const maxInput = screen.getByLabelText(/Max score/i);
 
-    await user.clear(minInput);
     await user.type(minInput, "3");
-    await user.clear(maxInput);
     await user.type(maxInput, "8.5");
 
     // Enable "Has known exploit"
@@ -141,25 +228,70 @@ describe("SoftwareFiltersModal component", () => {
     });
   });
 
-  it("shows and resets severity dropdown according to score inputs", async () => {
-    const { user } = renderWithSetup(
-      <SoftwareFiltersModal
-        onExit={noop}
-        onSubmit={noop}
-        vulnFilters={vulnFiltersDefault}
-        isPremiumTier
-      />
-    );
+  it("submits the bounds of the selected preset", async () => {
+    const onSubmitSpy = jest.fn();
+    const { user } = setUpModal({ onSubmit: onSubmitSpy });
     await user.click(screen.getByRole("switch"));
+    await selectSeverity(user, "High severity");
 
-    // If both min/max are cleared, selects "Any severity".
-    const minInput = screen.getByLabelText(/Min score/i);
-    const maxInput = screen.getByLabelText(/Max score/i);
+    await user.click(screen.getByRole("button", { name: /Apply/i }));
 
-    await user.clear(minInput);
-    await user.clear(maxInput);
+    expect(onSubmitSpy).toHaveBeenCalledWith({
+      vulnerable: true,
+      exploit: undefined,
+      minCvssScore: 7,
+      maxCvssScore: 8.9,
+    });
+  });
 
-    // The severity select should now show "Any severity"
-    expect(screen.getByText(/Any severity/i)).toBeInTheDocument();
+  it("submits no CVSS bounds for Any severity", async () => {
+    const onSubmitSpy = jest.fn();
+    const { user } = setUpModal({
+      onSubmit: onSubmitSpy,
+      vulnFilters: {
+        ...vulnFiltersDefault,
+        minCvssScore: 7,
+        maxCvssScore: 8.9,
+      },
+    });
+    await user.click(screen.getByRole("switch"));
+    await selectSeverity(user, "Any severity");
+
+    await user.click(screen.getByRole("button", { name: /Apply/i }));
+
+    expect(onSubmitSpy).toHaveBeenCalledWith({
+      vulnerable: true,
+      exploit: undefined,
+      minCvssScore: undefined,
+      maxCvssScore: undefined,
+    });
+  });
+
+  it("submits a lone 0 minimum rather than clearing the filter", async () => {
+    const onSubmitSpy = jest.fn();
+    const { user } = setUpModal({ onSubmit: onSubmitSpy });
+    await user.click(screen.getByRole("switch"));
+    await selectSeverity(user, "Custom severity");
+
+    // A lone "0" in Min used to collapse the control to "Any severity" while
+    // still submitting min_cvss_score=0.
+    await user.type(screen.getByLabelText(/Min score/i), "0");
+    await user.click(screen.getByRole("button", { name: /Apply/i }));
+
+    expect(onSubmitSpy).toHaveBeenCalledWith({
+      vulnerable: true,
+      exploit: undefined,
+      minCvssScore: 0,
+      maxCvssScore: undefined,
+    });
+  });
+
+  it("hides the severity filter on Fleet Free", () => {
+    renderModal({ isPremiumTier: false });
+
+    expect(
+      screen.queryByRole("combobox", { name: "Severity" })
+    ).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/Min score/i)).not.toBeInTheDocument();
   });
 });

--- a/frontend/pages/SoftwarePage/components/modals/SoftwareFiltersModal/SoftwareFiltersModal.tsx
+++ b/frontend/pages/SoftwarePage/components/modals/SoftwareFiltersModal/SoftwareFiltersModal.tsx
@@ -1,23 +1,19 @@
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 
-import { SingleValue } from "react-select-5";
-import { IInputFieldParseTarget } from "interfaces/form_field";
-
-import DropdownWrapper from "components/forms/fields/DropdownWrapper";
-import { CustomOptionType } from "components/forms/fields/DropdownWrapper/DropdownWrapper";
 import Modal from "components/Modal";
 import Button from "components/buttons/Button";
 import Slider from "components/forms/fields/Slider";
 import Checkbox from "components/forms/fields/Checkbox";
-import InputField from "components/forms/fields/InputField";
-import TooltipWrapper from "components/TooltipWrapper";
-import {
-  ANY_SEVERITY_OPTION,
-  CUSTOM_SEVERITY_OPTION,
-  findOptionBySeverityRange,
-  ISoftwareVulnFiltersParams,
-  SEVERITY_DROPDOWN_OPTIONS,
-} from "pages/SoftwarePage/SoftwareInventory/SoftwareInventoryTable/helpers";
+import SeverityFilter, {
+  ISeverityFieldErrors,
+  ISeverityFilterValue,
+  severityFilters,
+  severityForRange,
+  SeverityScoreField,
+  SeverityValue,
+  validateSeverityScores,
+} from "components/SeverityFilter";
+import { ISoftwareVulnFiltersParams } from "pages/SoftwarePage/SoftwareInventory/SoftwareInventoryTable/helpers";
 
 const baseClass = "software-filters-modal";
 
@@ -33,62 +29,6 @@ type IFormData = {
   maxScore: string;
 };
 
-type IFormErrors = {
-  minScore?: string;
-  maxScore?: string;
-  disableApplyButton?: React.ReactNode;
-};
-
-const hasAtMostOneDecimal = (n: number) =>
-  Number.isFinite(n) && Number((n * 10).toFixed(0)) / 10 === n;
-
-const isBetween0and10 = (n: number) => n >= 0 && n <= 10;
-
-const validate = (data: IFormData): IFormErrors => {
-  const errors: IFormErrors = {};
-  const min = data.minScore ? parseFloat(data.minScore) : undefined;
-  const max = data.maxScore ? parseFloat(data.maxScore) : undefined;
-
-  if (data.minScore) {
-    if (
-      typeof min !== "number" ||
-      !hasAtMostOneDecimal(min) ||
-      !isBetween0and10(min)
-    ) {
-      errors.minScore = "Must be from 0-10 in 0.1 increments";
-    }
-  }
-  if (data.maxScore) {
-    if (
-      max === undefined ||
-      !hasAtMostOneDecimal(max) ||
-      !isBetween0and10(max)
-    ) {
-      errors.maxScore = "Must be from 0-10 in 0.1 increments";
-    }
-  }
-  if (
-    data.minScore &&
-    data.maxScore &&
-    !errors.minScore &&
-    !errors.maxScore &&
-    min !== undefined &&
-    max !== undefined &&
-    min > max
-  ) {
-    // Manual <br /> so the first line runs longer than the second — balance
-    // would even them out, which reads more awkwardly here than the deliberate
-    // top-heavy shape.
-    errors.disableApplyButton = (
-      <>
-        Minimum CVSS score cannot be greater <br />
-        than the maximum CVSS score.
-      </>
-    );
-  }
-  return errors;
-};
-
 const SoftwareFiltersModal = ({
   onExit,
   onSubmit,
@@ -98,11 +38,8 @@ const SoftwareFiltersModal = ({
   const [vulnSoftwareFilterEnabled, setVulnSoftwareFilterEnabled] = useState(
     vulnFilters.vulnerable || false
   );
-  const [severity, setSeverity] = useState(
-    findOptionBySeverityRange(
-      vulnFilters.minCvssScore,
-      vulnFilters.maxCvssScore
-    )
+  const [severity, setSeverity] = useState<SeverityValue>(
+    severityForRange(vulnFilters.minCvssScore, vulnFilters.maxCvssScore)
   );
   // Unified form state:
   const [formData, setFormData] = useState<IFormData>({
@@ -110,86 +47,67 @@ const SoftwareFiltersModal = ({
     maxScore: vulnFilters.maxCvssScore?.toString() ?? "",
   });
   const [hasKnownExploit, setHasKnownExploit] = useState(vulnFilters.exploit);
-  const [formErrors, setFormErrors] = useState<IFormErrors>({});
+  const [formErrors, setFormErrors] = useState<ISeverityFieldErrors>({});
+  const dirtyFields = useRef(new Set<SeverityScoreField>());
 
-  const onChangeSeverity = (
-    selectedSeverity: SingleValue<CustomOptionType>
-  ) => {
-    const selectedOption = SEVERITY_DROPDOWN_OPTIONS.find(
-      (option) => option.value === selectedSeverity?.value
-    );
-    if (selectedOption) {
-      setSeverity(selectedOption);
-      // Auto populate severity range except for custom severity
-      if (selectedOption.value === "any") {
-        setFormData({ minScore: "", maxScore: "" });
-      } else if (selectedOption.value !== "custom") {
-        setFormData({
-          minScore: selectedOption.minSeverity?.toString() ?? "",
-          maxScore: selectedOption.maxSeverity?.toString() ?? "",
-        });
-      }
+  const onChangeSeverity = ({
+    severity: nextSeverity,
+    minScore,
+    maxScore,
+  }: ISeverityFilterValue) => {
+    if (nextSeverity === severity) {
+      if (minScore !== formData.minScore) dirtyFields.current.add("minScore");
+      if (maxScore !== formData.maxScore) dirtyFields.current.add("maxScore");
+    } else {
+      setFormErrors({});
     }
+    setSeverity(nextSeverity);
+    setFormData({ minScore, maxScore });
   };
 
-  const onScoreChange = ({ name, value }: IInputFieldParseTarget) => {
-    // Prepare new form data
-    const newFormData = { ...formData, [name]: value as string };
-
-    // If both fields are empty, reset to "Any severity"
-    if (!newFormData.minScore && !newFormData.maxScore) {
-      setSeverity(ANY_SEVERITY_OPTION);
-      setFormData({ minScore: "", maxScore: "" });
-      setFormErrors({});
+  // Blur validates that one field and nothing else.
+  const onScoreBlur = (field: SeverityScoreField) => {
+    if (!dirtyFields.current.has(field)) {
       return;
     }
+    const { [field]: fieldError } = validateSeverityScores(formData);
+    setFormErrors((prev) => ({ ...prev, [field]: fieldError }));
+  };
 
-    // Parse values for matching severity option
-    const minVal = parseFloat(newFormData.minScore || "0");
-    const maxVal = parseFloat(newFormData.maxScore || "10");
-
-    const selectedOption = SEVERITY_DROPDOWN_OPTIONS.find(
-      (option) => option.minSeverity === minVal && option.maxSeverity === maxVal
+  // Focus clears immediately so the label returns while the user edits.
+  const onScoreFocus = (field: SeverityScoreField) => {
+    setFormErrors((prev) =>
+      prev[field] ? { ...prev, [field]: undefined } : prev
     );
-    setSeverity(selectedOption || CUSTOM_SEVERITY_OPTION);
-    setFormData(newFormData);
-    // InputField only allows numbers
-    // Only errors if number outside range or multiple decimals
-    setFormErrors(validate(newFormData));
+  };
+
+  const onToggleVulnSoftware = () => {
+    const next = !vulnSoftwareFilterEnabled;
+    if (!next) {
+      setFormErrors({});
+    }
+    setVulnSoftwareFilterEnabled(next);
   };
 
   const handleSubmit = (evt: React.FormEvent<HTMLFormElement>) => {
     evt.preventDefault();
-    const errors = validate(formData);
-    if (Object.keys(errors).length > 0) {
-      setFormErrors(errors);
-      return;
+    if (vulnSoftwareFilterEnabled) {
+      const errors = validateSeverityScores(formData);
+      if (Object.keys(errors).length > 0) {
+        setFormErrors(errors);
+        return;
+      }
     }
-    const min = formData.minScore ? parseFloat(formData.minScore) : undefined;
-    const max = formData.maxScore ? parseFloat(formData.maxScore) : undefined;
+    // A 0-10 range clears the severity filter rather than submitting bounds
+    // that narrow nothing — severityFilters comes back empty for it.
+    const { min, max } = severityFilters(formData);
 
     onSubmit({
       vulnerable: vulnSoftwareFilterEnabled,
       exploit: hasKnownExploit || undefined,
-      minCvssScore: min === 0 && max === 10 ? undefined : min, // Only clear severity if set to 0-10
-      maxCvssScore: min === 0 && max === 10 ? undefined : max, // Only clear severity if set to 0-10
+      minCvssScore: min,
+      maxCvssScore: max,
     });
-  };
-
-  const renderSeverityLabel = () => {
-    return (
-      <TooltipWrapper
-        tipContent={
-          <>
-            The worst case impact across different environments (CVSS version
-            3.x base score).
-          </>
-        }
-        clickable={false}
-      >
-        Severity
-      </TooltipWrapper>
-    );
   };
 
   const renderModalContent = () => {
@@ -197,56 +115,22 @@ const SoftwareFiltersModal = ({
       <form onSubmit={handleSubmit}>
         <Slider
           value={vulnSoftwareFilterEnabled}
-          onChange={() =>
-            setVulnSoftwareFilterEnabled(!vulnSoftwareFilterEnabled)
-          }
+          onChange={onToggleVulnSoftware}
           inactiveText="Vulnerable software"
           activeText="Vulnerable software"
         />
         {isPremiumTier && (
           <>
-            <DropdownWrapper
-              name="severity-filter"
-              label={renderSeverityLabel()}
-              options={SEVERITY_DROPDOWN_OPTIONS}
-              value={severity}
+            <SeverityFilter
+              severity={severity}
+              minScore={formData.minScore}
+              maxScore={formData.maxScore}
               onChange={onChangeSeverity}
-              placeholder="Any severity"
-              className={`${baseClass}__select-severity`}
-              isDisabled={!vulnSoftwareFilterEnabled}
-              helpText="CVSS scores (v3) range from 0.0 to 10.0 in 0.1 increments."
+              disabled={!vulnSoftwareFilterEnabled}
+              errors={formErrors}
+              onScoreBlur={onScoreBlur}
+              onScoreFocus={onScoreFocus}
             />
-
-            <div className={`${baseClass}__cvss-range`}>
-              <InputField
-                label="Min score"
-                onChange={onScoreChange}
-                name="minScore"
-                value={formData.minScore}
-                disabled={!vulnSoftwareFilterEnabled}
-                type="number"
-                placeholder="0.0"
-                min={0}
-                max={10}
-                step={0.1}
-                parseTarget
-                error={formErrors.minScore}
-              />
-              <InputField
-                label="Max score"
-                onChange={onScoreChange}
-                name="maxScore"
-                value={formData.maxScore}
-                disabled={!vulnSoftwareFilterEnabled}
-                type="number"
-                placeholder="10.0"
-                min={0}
-                max={10}
-                step={0.1}
-                parseTarget
-                error={formErrors.maxScore}
-              />
-            </div>
             <Checkbox
               onChange={({ value }: { value: boolean }) =>
                 setHasKnownExploit(value)
@@ -262,25 +146,7 @@ const SoftwareFiltersModal = ({
           </>
         )}
         <div className="modal-cta-wrap">
-          <TooltipWrapper
-            tipContent={formErrors.disableApplyButton}
-            disableTooltip={!formErrors.disableApplyButton}
-            showArrow
-            position="top"
-            tipOffset={8}
-            underline={false}
-          >
-            <Button
-              type="submit"
-              disabled={
-                !!formErrors.disableApplyButton ||
-                !!formErrors.minScore ||
-                !!formErrors.maxScore
-              }
-            >
-              Apply
-            </Button>
-          </TooltipWrapper>
+          <Button type="submit">Apply</Button>
           <Button variant="secondary" onClick={onExit}>
             Cancel
           </Button>

--- a/frontend/pages/SoftwarePage/components/modals/SoftwareFiltersModal/_styles.scss
+++ b/frontend/pages/SoftwarePage/components/modals/SoftwareFiltersModal/_styles.scss
@@ -12,9 +12,4 @@
   .Select-menu {
     padding-bottom: $pad-medium;
   }
-
-  &__cvss-range {
-    display: flex;
-    gap: $pad-medium;
-  }
 }

--- a/frontend/utilities/numbers/numberUtils.ts
+++ b/frontend/utilities/numbers/numberUtils.ts
@@ -14,4 +14,7 @@ const isValidNumber = (
   );
 };
 
-export default { isValidNumber };
+const hasAtMostOneDecimal = (n: number) =>
+  Number((n * 10).toFixed(0)) / 10 === n;
+
+export default { isValidNumber, hasAtMostOneDecimal };

--- a/server/chart/api/chart.go
+++ b/server/chart/api/chart.go
@@ -179,8 +179,9 @@ type RequestOpts struct {
 	// no bound. The frontend converts its 0–100 % input before sending.
 	EPSSMin *float64
 	EPSSMax *float64
-	// Severity (CVSS) bounds are accepted but ignored this round — the service
-	// forces critical-only [9.0, 10.0]. See the severity TODO in the service.
+	// Severity bounds are CVSS v3 base scores, 0.0–10.0; nil means no bound on
+	// that side, which drops the predicate rather than widening it to the full
+	// range.
 	SeverityMin *float64
 	SeverityMax *float64
 	// ExcludeCVEs is a subtractive filter — these CVEs are removed from the

--- a/server/chart/internal/mysql/charts.go
+++ b/server/chart/internal/mysql/charts.go
@@ -311,17 +311,30 @@ func (ds *Datastore) CollectibleCVEs(ctx context.Context) ([]string, error) {
 // the curated universe with the filter's predicates (software category, CVSS
 // range, EPSS range, known-exploit) and subtracting any excluded CVEs.
 //
-// With the default filter (CVSS 9.0–10.0, all categories, no EPSS bound, no
-// known-exploit, no exclusions) this reproduces the iteration-1 "tracked
-// critical CVEs" set, so the chart's default display is unchanged.
+// Filtering on any cve_meta column (CVSS, EPSS, known-exploit) requires that
+// row to exist, so those filters exclude CVEs Fleet has no NVD metadata for.
+// When no such filter is set the join is dropped and they resolve. NULL fails
+// every comparison, so an explicit 0.0–10.0 CVSS range still excludes a CVE
+// whose cvss_score is NULL, while no CVSS bound at all includes it.
 //
 // Returns a non-nil empty slice when the filter resolves to nothing, so callers
-// never pass nil to GetSCDData (which would mean "all collected", leaking
-// lower-severity CVEs into the chart).
+// never pass nil to GetSCDData, which would mean "no entity filter" and widen
+// the chart to everything the collector recorded.
 func (ds *Datastore) ResolveCVEChartEntities(ctx context.Context, filter types.CVEChartFilter) ([]string, error) {
-	set := make(map[string]struct{})
 	cats := categorySet(filter.Categories) // nil == all categories
 	metaClause, metaArgs := cveMetaPredicate(filter)
+
+	if cats == nil && metaClause == "" && len(filter.ExcludeCVEs) == 0 {
+		return ds.CollectibleCVEs(ctx)
+	}
+
+	set := make(map[string]struct{})
+
+	swMetaJoin, osMetaJoin := "", ""
+	if metaClause != "" {
+		swMetaJoin = "JOIN cve_meta cm ON cm.cve = sc.cve"
+		osMetaJoin = "JOIN cve_meta cm ON cm.cve = osv.cve"
+	}
 
 	// Software-side: skip entirely when no matcher falls in the selected
 	// categories (e.g. only the OS category is selected).
@@ -331,7 +344,7 @@ func (ds *Datastore) ResolveCVEChartEntities(ctx context.Context, filter types.C
 			SELECT DISTINCT sc.cve
 			FROM software_cve sc
 			JOIN software s  ON s.id = sc.software_id
-			JOIN cve_meta cm ON cm.cve = sc.cve
+			` + swMetaJoin + `
 			WHERE ` + swClause + metaClause
 		expanded, expandedArgs, err := sqlx.In(swQuery, args...)
 		if err != nil {
@@ -348,7 +361,7 @@ func (ds *Datastore) ResolveCVEChartEntities(ctx context.Context, filter types.C
 		osQuery := `
 			SELECT DISTINCT osv.cve
 			FROM operating_system_vulnerabilities osv
-			JOIN cve_meta cm ON cm.cve = osv.cve
+			` + osMetaJoin + `
 			WHERE 1=1` + metaClause
 		expanded, expandedArgs, err := sqlx.In(osQuery, metaArgs...)
 		if err != nil {
@@ -396,11 +409,21 @@ func softwareMatcherClause(categories map[string]struct{}) (clause string, args 
 }
 
 // cveMetaPredicate builds the cve_meta WHERE fragment (with a leading " AND ")
-// shared by the software- and OS-side resolve queries, plus its args. The CVSS
-// range is always applied; EPSS bounds and the known-exploit flag are optional.
+// shared by the software- and OS-side resolve queries, plus its args. Every
+// predicate is optional: CVSS and EPSS bounds are applied only when set, and
+// the known-exploit flag only when true. Returns an empty fragment when no
+// predicate applies, so callers must not assume a leading " AND ".
 func cveMetaPredicate(filter types.CVEChartFilter) (string, []any) {
-	clauses := []string{"cm.cvss_score >= ?", "cm.cvss_score <= ?"}
-	args := []any{filter.CVSSMin, filter.CVSSMax}
+	var clauses []string
+	var args []any
+	if filter.CVSSMin != nil {
+		clauses = append(clauses, "cm.cvss_score >= ?")
+		args = append(args, *filter.CVSSMin)
+	}
+	if filter.CVSSMax != nil {
+		clauses = append(clauses, "cm.cvss_score <= ?")
+		args = append(args, *filter.CVSSMax)
+	}
 	if filter.EPSSMin != nil {
 		clauses = append(clauses, "cm.epss_probability >= ?")
 		args = append(args, *filter.EPSSMin)
@@ -411,6 +434,9 @@ func cveMetaPredicate(filter types.CVEChartFilter) (string, []any) {
 	}
 	if filter.KnownExploit {
 		clauses = append(clauses, "cm.cisa_known_exploit = 1")
+	}
+	if len(clauses) == 0 {
+		return "", nil
 	}
 	return " AND " + strings.Join(clauses, " AND "), args
 }

--- a/server/chart/internal/mysql/cve_filter_test.go
+++ b/server/chart/internal/mysql/cve_filter_test.go
@@ -54,6 +54,18 @@ func seedCVEMeta(t *testing.T, tdb *testutils.TestDB, cve string, cvss, epss flo
 	require.NoError(t, err)
 }
 
+// seedCVEMetaNoScore inserts cve_meta with a NULL cvss_score, which is what
+// Fleet stores for a CVE that NVD has no CVSS v3 base score for. Such a CVE is
+// invisible to any cvss_score comparison, so it only resolves when no severity
+// bound is set at all.
+func seedCVEMetaNoScore(t *testing.T, tdb *testutils.TestDB, cve string, epss float64, knownExploit bool) {
+	t.Helper()
+	_, err := tdb.DB.ExecContext(t.Context(),
+		`INSERT INTO cve_meta (cve, cvss_score, epss_probability, cisa_known_exploit) VALUES (?, NULL, ?, ?)`,
+		cve, epss, knownExploit)
+	require.NoError(t, err)
+}
+
 // TestCollectibleCVEs verifies the wide collection set: all severities on
 // tracked software and OS vulnerabilities are collected (even without cve_meta),
 // while CVEs on untracked software are excluded.
@@ -88,6 +100,9 @@ func TestCollectibleCVEs(t *testing.T) {
 //	CVE-D  kernel-x (rpm, OS)  cvss 9.1  epss 0.50  kev=false
 //	CVE-E  OS vuln (OS)        cvss 9.7  epss 0.90  kev=true
 //	CVE-F  Slack (untracked)   cvss 10.0 epss 0.99  kev=true   (never tracked)
+//	CVE-G  Chrome (browsers)   cvss NULL epss 0.40  kev=false  (no CVSS score)
+//	CVE-H  Chrome (browsers)   no cve_meta row at all         (no NVD metadata)
+//	CVE-I  OS vuln (OS)        no cve_meta row at all         (no NVD metadata)
 func TestResolveCVEChartEntities(t *testing.T) {
 	tdb := testutils.SetupTestDB(t, "chart_mysql")
 	defer tdb.TruncateTables(t)
@@ -106,9 +121,12 @@ func TestResolveCVEChartEntities(t *testing.T) {
 	seedCVEMeta(t, tdb, "CVE-E", 9.7, 0.90, true)
 	seedSoftware(t, tdb, "Slack", "apps", "CVE-F")
 	seedCVEMeta(t, tdb, "CVE-F", 10.0, 0.99, true)
+	seedSoftware(t, tdb, "Google Chrome", "apps", "CVE-G")
+	seedCVEMetaNoScore(t, tdb, "CVE-G", 0.40, false)
+	seedSoftware(t, tdb, "Google Chrome", "apps", "CVE-H")
+	seedOSVuln(t, tdb, 1, "CVE-I")
 
-	// critical is the default service-forced severity band.
-	const critMin, critMax = 9.0, 10.0
+	critMin, critMax := new(9.0), new(10.0)
 	allCats := types.CVEChartFilter{CVSSMin: critMin, CVSSMax: critMax}
 
 	cases := []struct {
@@ -155,6 +173,60 @@ func TestResolveCVEChartEntities(t *testing.T) {
 			name:   "combined: browsers AND known-exploit",
 			filter: types.CVEChartFilter{CVSSMin: critMin, CVSSMax: critMax, Categories: []string{api.CVECategoryBrowsers}, KnownExploit: true},
 			want:   []string{"CVE-A"},
+		},
+		{
+			// No cve_meta predicate at all: the cvss_score comparison is gone, and
+			// so is the cve_meta join, so CVEs with a NULL score (G) and CVEs with
+			// no metadata row whatsoever (H software-side, I OS-side) all resolve.
+			name:   "no severity bound includes every severity, unscored, and unknown-metadata CVEs",
+			filter: types.CVEChartFilter{},
+			want:   []string{"CVE-A", "CVE-B", "CVE-C", "CVE-D", "CVE-E", "CVE-G", "CVE-H", "CVE-I"},
+		},
+		{
+			// Pins the OS-side join drop on its own: the software side is skipped
+			// except for the kernel matcher, so CVE-I can only resolve if the OS
+			// query dropped its cve_meta join too. Without this case the OS branch
+			// is indistinguishable from an unconditional join.
+			name:   "OS category with no bounds keeps unknown-metadata OS vulns",
+			filter: types.CVEChartFilter{Categories: []string{api.CVECategoryOS}},
+			want:   []string{"CVE-D", "CVE-E", "CVE-I"},
+		},
+		{
+			// Filtering on any cve_meta column requires the row to exist, so an
+			// unknown-metadata CVE drops out even though the predicate is
+			// unrelated to severity.
+			name:   "a known-exploit filter still requires cve_meta",
+			filter: types.CVEChartFilter{KnownExploit: true},
+			want:   []string{"CVE-A", "CVE-E"},
+		},
+		{
+			name:   "an EPSS bound alone still requires cve_meta",
+			filter: types.CVEChartFilter{EPSSMin: new(0.30)},
+			want:   []string{"CVE-A", "CVE-D", "CVE-E", "CVE-G"},
+		},
+		{
+			// Category narrowing is a software-side predicate, so it does not
+			// reintroduce the cve_meta requirement.
+			name:   "category narrowing alone keeps unknown-metadata CVEs",
+			filter: types.CVEChartFilter{Categories: []string{api.CVECategoryBrowsers}},
+			want:   []string{"CVE-A", "CVE-B", "CVE-G", "CVE-H"},
+		},
+		{
+			// The counterpart: an explicit full range is still a comparison, and
+			// NULL fails every comparison, so the unscored CVE drops out.
+			name:   "explicit full range excludes unscored CVEs",
+			filter: types.CVEChartFilter{CVSSMin: new(0.0), CVSSMax: new(10.0)},
+			want:   []string{"CVE-A", "CVE-B", "CVE-C", "CVE-D", "CVE-E"},
+		},
+		{
+			name:   "lower bound only",
+			filter: types.CVEChartFilter{CVSSMin: new(9.0)},
+			want:   []string{"CVE-A", "CVE-C", "CVE-D", "CVE-E"},
+		},
+		{
+			name:   "upper bound only",
+			filter: types.CVEChartFilter{CVSSMax: new(3.9)},
+			want:   []string{"CVE-B"},
 		},
 	}
 

--- a/server/chart/internal/service/service.go
+++ b/server/chart/internal/service/service.go
@@ -3,8 +3,11 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
+	"math"
+	"net/http"
 	"time"
 
 	"github.com/RoaringBitmap/roaring"
@@ -12,8 +15,16 @@ import (
 	"github.com/fleetdm/fleet/v4/server/chart/api"
 	"github.com/fleetdm/fleet/v4/server/chart/internal/types"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/contexts/license"
 	platform_authz "github.com/fleetdm/fleet/v4/server/platform/authz"
 	platform_http "github.com/fleetdm/fleet/v4/server/platform/http"
+)
+
+const (
+	cvssMinScore = 0.0
+	cvssMaxScore = 10.0
+	epssMinScore = 0.0
+	epssMaxScore = 1.0
 )
 
 // Service is the chart bounded context service implementation.
@@ -97,6 +108,13 @@ func (s *Service) GetChartData(ctx context.Context, metric string, opts api.Requ
 		return nil, &platform_http.BadRequestError{Message: fmt.Sprintf("unknown chart metric: %s", metric)}
 	}
 
+	if metric == api.MetricCVE && !license.IsPremium(ctx) {
+		return nil, platform_http.NewUserMessageError(
+			errors.New("the vulnerability exposure chart requires a Fleet Premium license"),
+			http.StatusPaymentRequired,
+		)
+	}
+
 	// Don't allow requesting more days than the charts are designed to handle.
 	// This mostly prevents expensive queries for large day ranges.
 	if opts.Days < 1 || opts.Days > 31 {
@@ -106,6 +124,15 @@ func (s *Service) GetChartData(ctx context.Context, metric string, opts api.Requ
 	// Resolution must be 0 or a positive divisor of 24.
 	if opts.Resolution < 0 || (opts.Resolution != 0 && 24%opts.Resolution != 0) {
 		return nil, &platform_http.BadRequestError{Message: fmt.Sprintf("invalid resolution value: %d (must be 0 or a positive divisor of 24)", opts.Resolution)}
+	}
+
+	if metric == api.MetricCVE {
+		if err := validateScoreBounds("severity", opts.SeverityMin, opts.SeverityMax, cvssMinScore, cvssMaxScore); err != nil {
+			return nil, err
+		}
+		if err := validateScoreBounds("epss", opts.EPSSMin, opts.EPSSMax, epssMinScore, epssMaxScore); err != nil {
+			return nil, err
+		}
 	}
 
 	hours := opts.Resolution
@@ -140,17 +167,19 @@ func (s *Service) GetChartData(ctx context.Context, metric string, opts api.Requ
 
 	// entityIDs semantics at the storage layer: nil = no filter (all entities);
 	// non-nil empty = match nothing (zero-valued buckets). For the CVE metric we
-	// always resolve a concrete allow-set — never nil — so that lower-severity
-	// CVEs (now collected for all severities) never leak into the chart.
+	// always resolve a concrete allow-set — never nil — so the chart is always
+	// scoped to the curated tracked-software universe rather than to everything
+	// the collector happens to have recorded.
 	var entityIDs []string
 	if metric == api.MetricCVE {
-		// Severity is plumbed through the API (opts.SeverityMin/Max) but forced
-		// to critical-only this round; the severity UI lands in a follow-up.
-		// TODO(#47326): honor opts.SeverityMin/Max instead of hard-coding.
+		// Severity bounds pass through untouched, including nil. A nil bound
+		// drops the CVSS predicate rather than substituting the full 0.0–10.0
+		// range, which matters because cve_meta.cvss_score is nullable: the full
+		// range still excludes unscored CVEs, while no predicate includes them.
 		cveFilter := types.CVEChartFilter{
 			Categories:   opts.SoftwareFilters,
-			CVSSMin:      9.0,
-			CVSSMax:      10.0,
+			CVSSMin:      opts.SeverityMin,
+			CVSSMax:      opts.SeverityMax,
 			EPSSMin:      opts.EPSSMin,
 			EPSSMax:      opts.EPSSMax,
 			KnownExploit: opts.KnownExploit,
@@ -184,14 +213,32 @@ func (s *Service) GetChartData(ctx context.Context, metric string, opts api.Requ
 			KnownExploit:    opts.KnownExploit,
 			EPSSMin:         opts.EPSSMin,
 			EPSSMax:         opts.EPSSMax,
-			// Severity is not echoed: it's forced to critical-only this round
-			// (see above), so echoing the client's requested severity_min/max
-			// would misrepresent what was actually applied. It returns to the
-			// echo when severity becomes a real filter (#47326).
-			ExcludeCVEs: opts.ExcludeCVEs,
+			SeverityMin:     opts.SeverityMin,
+			SeverityMax:     opts.SeverityMax,
+			ExcludeCVEs:     opts.ExcludeCVEs,
 		},
 		Data: data,
 	}, nil
+}
+
+func validateScoreBounds(label string, minScore, maxScore *float64, lo, hi float64) error {
+	if minScore != nil && (math.IsNaN(*minScore) || *minScore < lo || *minScore > hi) {
+		return &platform_http.BadRequestError{
+			Message: fmt.Sprintf("invalid %s_min value: %v (must be between %v and %v)", label, *minScore, lo, hi),
+		}
+	}
+	if maxScore != nil && (math.IsNaN(*maxScore) || *maxScore < lo || *maxScore > hi) {
+		return &platform_http.BadRequestError{
+			Message: fmt.Sprintf("invalid %s_max value: %v (must be between %v and %v)", label, *maxScore, lo, hi),
+		}
+	}
+	if minScore != nil && maxScore != nil && *minScore > *maxScore {
+		return &platform_http.BadRequestError{
+			Message: fmt.Sprintf("invalid %s range: %s_min (%v) must not be greater than %s_max (%v)",
+				label, label, *minScore, label, *maxScore),
+		}
+	}
+	return nil
 }
 
 // effectiveTeamIDs decides the team scope applied at SQL time.

--- a/server/chart/internal/service/service_test.go
+++ b/server/chart/internal/service/service_test.go
@@ -3,6 +3,8 @@ package service
 import (
 	"context"
 	"errors"
+	"math"
+	"net/http"
 	"testing"
 	"time"
 
@@ -10,7 +12,9 @@ import (
 	"github.com/fleetdm/fleet/v4/server/chart"
 	"github.com/fleetdm/fleet/v4/server/chart/api"
 	"github.com/fleetdm/fleet/v4/server/chart/internal/types"
+	"github.com/fleetdm/fleet/v4/server/contexts/license"
 	platform_authz "github.com/fleetdm/fleet/v4/server/platform/authz"
+	platform_http "github.com/fleetdm/fleet/v4/server/platform/http"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -55,7 +59,40 @@ func (m *mockViewerProvider) ViewerScope(_ context.Context) (bool, []uint, error
 // globalViewer returns a viewer provider for a global user (sees everything).
 func globalViewer() *mockViewerProvider { return &mockViewerProvider{isGlobal: true} }
 
-// mockDatastore implements types.Datastore for unit tests.
+// stubLicense implements license.LicenseChecker. The chart context can't import
+// server/fleet (arch_test forbids it, tests included), so tests can't build a
+// real fleet.LicenseInfo and stub the interface instead.
+type stubLicense struct{ premium bool }
+
+func (s stubLicense) IsPremium() bool               { return s.premium }
+func (s stubLicense) IsAllowDisableTelemetry() bool { return false }
+func (s stubLicense) GetTier() string {
+	if s.premium {
+		return "premium"
+	}
+	return "free"
+}
+func (s stubLicense) GetOrganization() string { return "test" }
+func (s stubLicense) GetDeviceCount() int     { return 1 }
+
+func requirePremiumRequired(t *testing.T, err error) {
+	t.Helper()
+	var msgErr *platform_http.UserMessageError
+	require.ErrorAs(t, err, &msgErr)
+	require.Equal(t, http.StatusPaymentRequired, msgErr.StatusCode())
+	require.Contains(t, err.Error(), "Fleet Premium")
+}
+
+func premiumCtx(t *testing.T) context.Context {
+	t.Helper()
+	return license.NewContext(t.Context(), stubLicense{premium: true})
+}
+
+func freeCtx(t *testing.T) context.Context {
+	t.Helper()
+	return license.NewContext(t.Context(), stubLicense{premium: false})
+}
+
 type mockDatastore struct {
 	getSCDDataFunc          func(ctx context.Context, dataset string, startDate, endDate time.Time, bucketSize time.Duration, strategy api.SampleStrategy, filterMask *roaring.Bitmap, entityIDs []string) ([]api.DataPoint, error)
 	getHostIDsForFilterFunc func(ctx context.Context, hostFilter *types.HostFilter) ([]uint, error)
@@ -296,7 +333,7 @@ func TestGetChartDataCVEResolution(t *testing.T) {
 				return nil, nil
 			}
 
-			resp, err := svc.GetChartData(t.Context(), "cve", api.RequestOpts{Days: 30, Resolution: tc.resolution})
+			resp, err := svc.GetChartData(premiumCtx(t), "cve", api.RequestOpts{Days: 30, Resolution: tc.resolution})
 			require.NoError(t, err)
 			assert.Equal(t, tc.resolutionStr, resp.Resolution)
 			assert.Equal(t, tc.bucketSize, gotBucketSize)
@@ -326,23 +363,61 @@ func TestGetChartDataUptimePassesNilEntityIDs(t *testing.T) {
 	assert.True(t, gotEntityIDsIsNil, "uptime must pass nil entityIDs — the CVE branch must not leak")
 }
 
-// TestGetChartDataCVEAlwaysResolvesEntities verifies the two load-bearing
-// read-path guarantees for the CVE metric: (1) entity resolution always runs
-// and its result is forwarded to GetSCDData as a concrete (never-nil) set, so
-// newly collected lower-severity CVEs can't leak into the chart; and (2) the
-// severity bounds are forced to critical [9.0, 10.0] this round regardless of
-// any client-supplied severity_min/severity_max.
+func newCVEService(ds *mockDatastore) *Service {
+	svc := NewService(&mockAuthorizer{}, ds, globalViewer(), nil)
+	svc.RegisterDataset(&chart.CVEDataset{})
+	return svc
+}
+
+func captureCVEFilter(ds *mockDatastore) *types.CVEChartFilter {
+	got := &types.CVEChartFilter{}
+	ds.resolveCVEEntitiesFn = func(_ context.Context, filter types.CVEChartFilter) ([]string, error) {
+		*got = filter
+		return []string{}, nil
+	}
+	return got
+}
+
+func TestGetChartDataCVESeverityPassthrough(t *testing.T) {
+	cases := []struct {
+		name     string
+		min, max *float64
+	}{
+		{name: "no bounds"},
+		{name: "both bounds", min: new(1.0), max: new(5.0)},
+		{name: "lower bound only", min: new(7.0)},
+		{name: "upper bound only", max: new(3.9)},
+		{name: "full range is not the same as no bounds", min: new(0.0), max: new(10.0)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ds := &mockDatastore{}
+			got := captureCVEFilter(ds)
+
+			resp, err := newCVEService(ds).GetChartData(premiumCtx(t), "cve", api.RequestOpts{
+				Days:        7,
+				SeverityMin: tc.min,
+				SeverityMax: tc.max,
+			})
+			require.NoError(t, err)
+
+			require.Equal(t, tc.min, got.CVSSMin, "severity_min must reach the resolver unchanged")
+			require.Equal(t, tc.max, got.CVSSMax, "severity_max must reach the resolver unchanged")
+
+			// What was applied is what gets echoed, on every case.
+			require.Equal(t, tc.min, resp.Filters.SeverityMin)
+			require.Equal(t, tc.max, resp.Filters.SeverityMax)
+		})
+	}
+}
+
 func TestGetChartDataCVEAlwaysResolvesEntities(t *testing.T) {
 	t.Run("no filters still resolves a concrete set", func(t *testing.T) {
 		ds := &mockDatastore{}
-		svc := NewService(&mockAuthorizer{}, ds, globalViewer(), nil)
-		svc.RegisterDataset(&chart.CVEDataset{})
-
-		var gotFilter types.CVEChartFilter
 		resolveCalled := false
-		ds.resolveCVEEntitiesFn = func(_ context.Context, filter types.CVEChartFilter) ([]string, error) {
+		ds.resolveCVEEntitiesFn = func(_ context.Context, _ types.CVEChartFilter) ([]string, error) {
 			resolveCalled = true
-			gotFilter = filter
 			return []string{"CVE-2026-0001"}, nil
 		}
 		var gotEntityIDs []string
@@ -351,45 +426,15 @@ func TestGetChartDataCVEAlwaysResolvesEntities(t *testing.T) {
 			return nil, nil
 		}
 
-		_, err := svc.GetChartData(t.Context(), "cve", api.RequestOpts{Days: 7})
+		_, err := newCVEService(ds).GetChartData(premiumCtx(t), "cve", api.RequestOpts{Days: 7})
 		require.NoError(t, err)
-		assert.True(t, resolveCalled, "the CVE metric must always resolve its entity set")
-		assert.Equal(t, []string{"CVE-2026-0001"}, gotEntityIDs, "resolved set must be forwarded to GetSCDData, never nil")
-		assert.InDelta(t, 9.0, gotFilter.CVSSMin, 0, "severity is forced to critical")
-		assert.InDelta(t, 10.0, gotFilter.CVSSMax, 0, "severity is forced to critical")
-	})
-
-	t.Run("client severity bounds are overridden to critical", func(t *testing.T) {
-		ds := &mockDatastore{}
-		svc := NewService(&mockAuthorizer{}, ds, globalViewer(), nil)
-		svc.RegisterDataset(&chart.CVEDataset{})
-
-		var gotFilter types.CVEChartFilter
-		ds.resolveCVEEntitiesFn = func(_ context.Context, filter types.CVEChartFilter) ([]string, error) {
-			gotFilter = filter
-			return []string{}, nil
-		}
-
-		_, err := svc.GetChartData(t.Context(), "cve", api.RequestOpts{
-			Days:        7,
-			SeverityMin: new(1.0),
-			SeverityMax: new(5.0),
-		})
-		require.NoError(t, err)
-		assert.InDelta(t, 9.0, gotFilter.CVSSMin, 0, "client severity_min must be ignored this round")
-		assert.InDelta(t, 10.0, gotFilter.CVSSMax, 0, "client severity_max must be ignored this round")
+		require.True(t, resolveCalled, "the CVE metric must always resolve its entity set")
+		require.Equal(t, []string{"CVE-2026-0001"}, gotEntityIDs, "resolved set must be forwarded to GetSCDData, never nil")
 	})
 
 	t.Run("entity filters are forwarded to the resolver", func(t *testing.T) {
 		ds := &mockDatastore{}
-		svc := NewService(&mockAuthorizer{}, ds, globalViewer(), nil)
-		svc.RegisterDataset(&chart.CVEDataset{})
-
-		var gotFilter types.CVEChartFilter
-		ds.resolveCVEEntitiesFn = func(_ context.Context, filter types.CVEChartFilter) ([]string, error) {
-			gotFilter = filter
-			return []string{}, nil
-		}
+		gotFilter := captureCVEFilter(ds)
 
 		opts := api.RequestOpts{
 			Days:            7,
@@ -399,14 +444,206 @@ func TestGetChartDataCVEAlwaysResolvesEntities(t *testing.T) {
 			EPSSMax:         new(1.0),
 			ExcludeCVEs:     []string{"CVE-2026-9999"},
 		}
-		_, err := svc.GetChartData(t.Context(), "cve", opts)
+		_, err := newCVEService(ds).GetChartData(premiumCtx(t), "cve", opts)
 		require.NoError(t, err)
-		assert.Equal(t, []string{api.CVECategoryBrowsers, api.CVECategoryAdobe}, gotFilter.Categories)
-		assert.True(t, gotFilter.KnownExploit)
-		require.NotNil(t, gotFilter.EPSSMin)
-		assert.InDelta(t, 0.5, *gotFilter.EPSSMin, 0)
-		assert.Equal(t, []string{"CVE-2026-9999"}, gotFilter.ExcludeCVEs)
+		require.Equal(t, []string{api.CVECategoryBrowsers, api.CVECategoryAdobe}, gotFilter.Categories)
+		require.True(t, gotFilter.KnownExploit)
+		require.Equal(t, new(0.5), gotFilter.EPSSMin)
+		require.Equal(t, []string{"CVE-2026-9999"}, gotFilter.ExcludeCVEs)
 	})
+}
+
+func TestGetChartDataCVERequiresPremium(t *testing.T) {
+	// The uptime dataset is registered alongside CVE so the "other metrics"
+	// case exercises a real free-tier chart rather than an unknown metric.
+	newSvc := func(ds *mockDatastore) *Service {
+		svc := newCVEService(ds)
+		svc.RegisterDataset(&chart.UptimeDataset{})
+		return svc
+	}
+
+	t.Run("free tier is refused before any query runs", func(t *testing.T) {
+		ds := &mockDatastore{}
+		resolveCalled := false
+		ds.resolveCVEEntitiesFn = func(_ context.Context, _ types.CVEChartFilter) ([]string, error) {
+			resolveCalled = true
+			return []string{}, nil
+		}
+
+		_, err := newSvc(ds).GetChartData(freeCtx(t), "cve", api.RequestOpts{Days: 7})
+		requirePremiumRequired(t, err)
+		require.False(t, resolveCalled, "the gate must short-circuit before entity resolution")
+	})
+
+	t.Run("a missing license is treated as free", func(t *testing.T) {
+		_, err := newSvc(&mockDatastore{}).GetChartData(t.Context(), "cve", api.RequestOpts{Days: 7})
+		requirePremiumRequired(t, err)
+	})
+
+	t.Run("the license is checked before request validation", func(t *testing.T) {
+		// Ordering matters: an unlicensed caller gets the license error, not a
+		// validation error that would tell them how the filter behaves.
+		_, err := newSvc(&mockDatastore{}).GetChartData(freeCtx(t), "cve", api.RequestOpts{
+			Days:        7,
+			SeverityMin: new(8.0),
+			SeverityMax: new(2.0), // inverted, would otherwise be a 400
+		})
+		requirePremiumRequired(t, err)
+	})
+
+	t.Run("premium is allowed", func(t *testing.T) {
+		ds := &mockDatastore{}
+		captureCVEFilter(ds)
+		_, err := newSvc(ds).GetChartData(premiumCtx(t), "cve", api.RequestOpts{Days: 7})
+		require.NoError(t, err)
+	})
+
+	t.Run("the gate does not apply to other metrics", func(t *testing.T) {
+		_, err := newSvc(&mockDatastore{}).GetChartData(freeCtx(t), "uptime", api.RequestOpts{Days: 7})
+		require.NoError(t, err, "only the cve metric is premium-gated")
+	})
+}
+
+func TestGetChartDataSeverityValidation(t *testing.T) {
+	cases := []struct {
+		name    string
+		min     *float64
+		max     *float64
+		wantErr bool
+	}{
+		{name: "no bounds", wantErr: false},
+		{name: "full range", min: new(0.0), max: new(10.0), wantErr: false},
+		{name: "equal bounds", min: new(5.0), max: new(5.0), wantErr: false},
+		{name: "min only", min: new(7.0), wantErr: false},
+		{name: "max only", max: new(3.9), wantErr: false},
+		{name: "min above range", min: new(10.1), wantErr: true},
+		{name: "max above range", max: new(11.0), wantErr: true},
+		{name: "min below range", min: new(-1.0), wantErr: true},
+		{name: "max below range", max: new(-0.1), wantErr: true},
+		{name: "min greater than max", min: new(8.0), max: new(2.0), wantErr: true},
+		{name: "min is NaN", min: new(math.NaN()), wantErr: true},
+		{name: "max is NaN", max: new(math.NaN()), wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ds := &mockDatastore{}
+			resolveCalled := false
+			ds.resolveCVEEntitiesFn = func(_ context.Context, _ types.CVEChartFilter) ([]string, error) {
+				resolveCalled = true
+				return []string{}, nil
+			}
+
+			_, err := newCVEService(ds).GetChartData(premiumCtx(t), "cve", api.RequestOpts{
+				Days:        7,
+				SeverityMin: tc.min,
+				SeverityMax: tc.max,
+			})
+			if !tc.wantErr {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			var badReq *platform_http.BadRequestError
+			require.ErrorAs(t, err, &badReq)
+			require.False(t, resolveCalled, "an invalid bound must be rejected before any query runs")
+		})
+	}
+
+	t.Run("non-CVE metrics ignore invalid severity bounds", func(t *testing.T) {
+		svc := NewService(&mockAuthorizer{}, &mockDatastore{}, globalViewer(), nil)
+		svc.RegisterDataset(&chart.UptimeDataset{})
+
+		_, err := svc.GetChartData(t.Context(), "uptime", api.RequestOpts{
+			Days:        7,
+			SeverityMin: new(99.0),
+			SeverityMax: new(-1.0),
+		})
+		require.NoError(t, err)
+	})
+}
+
+func TestGetChartDataEPSSValidation(t *testing.T) {
+	cases := []struct {
+		name    string
+		min     *float64
+		max     *float64
+		wantErr bool
+	}{
+		{name: "no bounds", wantErr: false},
+		{name: "full range", min: new(0.0), max: new(1.0), wantErr: false},
+		{name: "equal bounds", min: new(0.5), max: new(0.5), wantErr: false},
+		{name: "min only", min: new(0.85), wantErr: false},
+		{name: "max only", max: new(0.1), wantErr: false},
+		{name: "unconverted percentage", min: new(50.0), wantErr: true},
+		{name: "min above range", min: new(1.1), wantErr: true},
+		{name: "max above range", max: new(100.0), wantErr: true},
+		{name: "min below range", min: new(-0.1), wantErr: true},
+		{name: "max below range", max: new(-1.0), wantErr: true},
+		{name: "min greater than max", min: new(0.9), max: new(0.2), wantErr: true},
+		{name: "min is NaN", min: new(math.NaN()), wantErr: true},
+		{name: "max is NaN", max: new(math.NaN()), wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ds := &mockDatastore{}
+			resolveCalled := false
+			ds.resolveCVEEntitiesFn = func(_ context.Context, _ types.CVEChartFilter) ([]string, error) {
+				resolveCalled = true
+				return []string{}, nil
+			}
+			svc := NewService(&mockAuthorizer{}, ds, globalViewer(), nil)
+			svc.RegisterDataset(&chart.CVEDataset{})
+
+			_, err := svc.GetChartData(premiumCtx(t), "cve", api.RequestOpts{
+				Days:    7,
+				EPSSMin: tc.min,
+				EPSSMax: tc.max,
+			})
+			if !tc.wantErr {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			var badReq *platform_http.BadRequestError
+			require.ErrorAs(t, err, &badReq)
+			require.False(t, resolveCalled, "an invalid bound must be rejected before any query runs")
+		})
+	}
+
+	t.Run("non-CVE metrics ignore invalid EPSS bounds", func(t *testing.T) {
+		svc := NewService(&mockAuthorizer{}, &mockDatastore{}, globalViewer(), nil)
+		svc.RegisterDataset(&chart.UptimeDataset{})
+
+		_, err := svc.GetChartData(t.Context(), "uptime", api.RequestOpts{
+			Days:    7,
+			EPSSMin: new(50.0),
+			EPSSMax: new(-1.0),
+		})
+		require.NoError(t, err)
+	})
+}
+
+func TestGetChartDataOmitsUnsetSeverityFromEcho(t *testing.T) {
+	ds := &mockDatastore{}
+	ds.resolveCVEEntitiesFn = func(_ context.Context, _ types.CVEChartFilter) ([]string, error) {
+		return []string{}, nil
+	}
+	svc := NewService(&mockAuthorizer{}, ds, globalViewer(), nil)
+	svc.RegisterDataset(&chart.CVEDataset{})
+
+	resp, err := svc.GetChartData(premiumCtx(t), "cve", api.RequestOpts{Days: 7})
+	require.NoError(t, err)
+	require.Nil(t, resp.Filters.SeverityMin)
+	require.Nil(t, resp.Filters.SeverityMax)
+
+	// A one-sided request echoes only the side that was set.
+	resp, err = svc.GetChartData(premiumCtx(t), "cve", api.RequestOpts{Days: 7, SeverityMax: new(3.9)})
+	require.NoError(t, err)
+	require.Nil(t, resp.Filters.SeverityMin)
+	require.NotNil(t, resp.Filters.SeverityMax)
+	require.InDelta(t, 3.9, *resp.Filters.SeverityMax, 0)
 }
 
 func TestGetChartDataWithHostFilters(t *testing.T) {

--- a/server/chart/internal/types/chart.go
+++ b/server/chart/internal/types/chart.go
@@ -32,14 +32,17 @@ type HostFilter struct {
 // CVE IDs. All predicates AND together (intersect); ExcludeCVEs are subtracted
 // afterward. Excluding a CVE that isn't in the set is a harmless no-op.
 //
-// Categories empty means "all categories" (no narrowing). CVSSMin/CVSSMax are
-// always set by the service (forced to 9.0/10.0 this round — see the severity
-// TODO in the service). EPSSMin/EPSSMax are nil when no bound was requested;
-// values are 0.0–1.0 to match cve_meta.epss_probability.
+// Categories empty means "all categories" (no narrowing). CVSSMin/CVSSMax and
+// EPSSMin/EPSSMax are nil when no bound was requested, which drops the
+// corresponding predicate entirely rather than substituting the full range.
+// That distinction is load-bearing for CVSS: cve_meta.cvss_score is nullable,
+// so a 0.0–10.0 bound still excludes CVEs with no score, while a nil bound
+// includes them. CVSS values are 0.0–10.0; EPSS values are 0.0–1.0 to match
+// cve_meta.epss_probability.
 type CVEChartFilter struct {
 	Categories   []string
-	CVSSMin      float64
-	CVSSMax      float64
+	CVSSMin      *float64
+	CVSSMax      *float64
 	EPSSMin      *float64
 	EPSSMax      *float64
 	KnownExploit bool


### PR DESCRIPTION
**Related issue:** Resolves #47326

Add severity (CVSS) filtering to the vulnerability exposure chart

Adds a severity control to the chart, and wires up the cvss_min/cvss_max keys that were previously accepted and ignored. The dropdown and its score inputs move into a shared SeverityFilter component, also used by the Software, Host details, and My device filters, where the inputs now appear only for custom severity. Typing no longer derives the dropdown: with the inputs rendered conditionally, that would unmount the field under the cursor as soon as the typed values matched a preset.

The API applies severity_min/severity_max and echoes them back. An absent bound stays nil and drops the CVSS predicate rather than widening to 0.0-10.0, because cve_meta.cvss_score is nullable and a full explicit range still excludes unscored CVEs. For the same reason the cve_meta join is built only when something filters on it. Bounds are validated as 0.0-10.0 with min <= max, rejecting NaN and out-of-range input with 400.

The cve metric now requires a premium license, returning 402 on Fleet Free, which also stops collecting data nothing can read.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [X] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [X] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CVSS severity filtering to the Vulnerability Exposure dashboard for Fleet Premium.
  * Added preset severity options and custom minimum/maximum CVSS score ranges.
  * Added severity filtering to Software, Host details, and My device filters.
  * Added validation for invalid, out-of-range, and reversed score ranges.
* **Bug Fixes**
  * Preserved explicit zero scores and correctly handled unbounded severity ranges.
  * Fleet Free instances no longer attempt premium vulnerability chart processing.
* **Documentation**
  * Updated severity filter and CVSS range guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->