### PR TITLE
Fleet UI: Align technician empty state with EmptyState styling on configuration profiles and assets

### DIFF
--- a/changes/49461-technician-empty-state
+++ b/changes/49461-technician-empty-state
@@ -1,0 +1,1 @@
+- Aligned the configuration profiles and assets empty states for technicians with the shared EmptyState styling.

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/ConfigurationProfiles.tests.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/ConfigurationProfiles.tests.tsx
@@ -106,4 +106,30 @@ describe("ConfigurationProfiles Profiles-tab header", () => {
       screen.queryByRole("button", { name: /Add profile$/i })
     ).not.toBeInTheDocument();
   });
+
+  it("renders the EmptyState heading without Add profile for technicians when there are no profiles", async () => {
+    mockServer.use(emptyProfilesHandler);
+
+    const render = createCustomRenderer({
+      withBackendMock: true,
+      context: {
+        app: {
+          isGlobalTechnician: true,
+          config: mdmEnabledConfig,
+        },
+      },
+    });
+
+    render(<ConfigurationProfiles {...baseProps} />);
+
+    expect(
+      await screen.findByRole("heading", { name: /No configuration profiles/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/No configuration profiles have been added\./i)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Add profile$/i })
+    ).not.toBeInTheDocument();
+  });
 });

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/ConfigurationProfiles.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/ConfigurationProfiles.tsx
@@ -12,7 +12,6 @@ import { IMdmProfile } from "interfaces/mdm";
 
 import mdmAPI, { IMdmProfilesResponse } from "services/entities/mdm";
 
-import Card from "components/Card/Card";
 import CustomLink from "components/CustomLink";
 import SectionHeader from "components/SectionHeader";
 import PageDescription from "components/PageDescription";
@@ -67,6 +66,7 @@ const ConfigurationProfiles = ({
   } = useContext(AppContext);
 
   const isTechnician = isGlobalTechnician || isTeamTechnician;
+  const canAddConfigurationProfile = !isTechnician;
   // The "Turn on" button links to /settings/integrations/mdm, which is
   // gated to global admins only (AuthGlobalAdminRoutes).
   const canTurnOnMdm = !!isGlobalAdmin;
@@ -212,29 +212,28 @@ const ConfigurationProfiles = ({
     }
 
     if (!profiles?.length) {
-      if (isTechnician) {
-        return (
-          <Card className="empty-profiles">
-            No configuration profiles have been added.
-          </Card>
-        );
-      }
       return (
         <EmptyState
           variant="header-list"
           header="No configuration profiles"
-          info="Add a configuration profile to enforce custom settings on your hosts."
+          info={
+            canAddConfigurationProfile
+              ? "Add a configuration profile to enforce custom settings on your hosts."
+              : "No configuration profiles have been added."
+          }
           primaryButton={
-            <GitOpsModeTooltipWrapper
-              renderChildren={(disableChildren) => (
-                <Button
-                  disabled={disableChildren}
-                  onClick={() => setShowAddProfileModal(true)}
-                >
-                  Add profile
-                </Button>
-              )}
-            />
+            canAddConfigurationProfile ? (
+              <GitOpsModeTooltipWrapper
+                renderChildren={(disableChildren) => (
+                  <Button
+                    disabled={disableChildren}
+                    onClick={() => setShowAddProfileModal(true)}
+                  >
+                    Add profile
+                  </Button>
+                )}
+              />
+            ) : undefined
           }
         />
       );
@@ -282,7 +281,7 @@ const ConfigurationProfiles = ({
     </>
   );
 
-  const showAddProfileButton = mdmEnabled && !isTechnician;
+  const showAddProfileButton = mdmEnabled && canAddConfigurationProfile;
 
   return (
     <div className={baseClass}>

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/_styles.scss
@@ -1,11 +1,6 @@
 .configuration-profiles {
   @include vertical-card-layout;
 
-  .empty-profiles {
-    font-size: px-to-rem(14);
-    text-align: center;
-  }
-
   .upload-list {
     &__list {
       .list-item__label-count {

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/AssetsTab/AssetsTab.tests.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/AssetsTab/AssetsTab.tests.tsx
@@ -116,6 +116,32 @@ describe("AssetsTab", () => {
     );
   });
 
+  it("renders the EmptyState heading without Add asset for technicians when there are no assets", async () => {
+    (mdmAPI.getAssets as jest.Mock).mockResolvedValue({ assets: [] });
+    const render = createCustomRenderer({
+      withBackendMock: true,
+      context: {
+        app: {
+          isPremiumTier: true,
+          isGlobalTechnician: true,
+          config: mdmEnabledConfig,
+        },
+      },
+    });
+
+    render(<AssetsTab currentTeamId={0} router={createMockRouter()} />);
+
+    expect(
+      await screen.findByRole("heading", { name: /No assets/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/No assets have been added\./i)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Add asset$/i })
+    ).not.toBeInTheDocument();
+  });
+
   it("renders the tab-header description and Add asset button above the list", async () => {
     (mdmAPI.getAssets as jest.Mock).mockResolvedValue({
       assets: [

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/AssetsTab/AssetsTab.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/AssetsTab/AssetsTab.tsx
@@ -11,7 +11,6 @@ import { IMdmAsset } from "interfaces/mdm";
 import mdmAPI, { IListAssetsResponse } from "services/entities/mdm";
 
 import Button from "components/buttons/Button";
-import Card from "components/Card/Card";
 import DataError from "components/DataError";
 import EmptyState from "components/EmptyState";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
@@ -41,6 +40,7 @@ const AssetsTab = ({ currentTeamId, router }: IAssetsTabProps) => {
   } = useContext(AppContext);
 
   const isTechnician = isGlobalTechnician || isTeamTechnician;
+  const canAddAsset = !isTechnician;
   // Team admins can reach /settings/integrations/mdm/apple, but only global
   // admins can actually turn on Apple MDM there.
   const canTurnOnMdm = !!isGlobalAdmin;
@@ -131,25 +131,28 @@ const AssetsTab = ({ currentTeamId, router }: IAssetsTabProps) => {
     }
 
     if (!assets?.length) {
-      if (isTechnician) {
-        return <Card className="empty-assets">No assets have been added.</Card>;
-      }
       return (
         <EmptyState
           variant="header-list"
           header="No assets"
-          info="Add an asset to make it available for reference in Apple DDM declarations."
+          info={
+            canAddAsset
+              ? "Add an asset to make it available for reference in Apple DDM declarations."
+              : "No assets have been added."
+          }
           primaryButton={
-            <GitOpsModeTooltipWrapper
-              renderChildren={(disableChildren) => (
-                <Button
-                  disabled={disableChildren}
-                  onClick={() => setShowAddAssetModal(true)}
-                >
-                  Add asset
-                </Button>
-              )}
-            />
+            canAddAsset ? (
+              <GitOpsModeTooltipWrapper
+                renderChildren={(disableChildren) => (
+                  <Button
+                    disabled={disableChildren}
+                    onClick={() => setShowAddAssetModal(true)}
+                  >
+                    Add asset
+                  </Button>
+                )}
+              />
+            ) : undefined
           }
         />
       );
@@ -170,7 +173,7 @@ const AssetsTab = ({ currentTeamId, router }: IAssetsTabProps) => {
     );
   };
 
-  const showAddAssetButton = isPremiumTier && mdmAppleEnabled && !isTechnician;
+  const showAddAssetButton = isPremiumTier && mdmAppleEnabled && canAddAsset;
 
   return (
     <div className={baseClass}>

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/AssetsTab/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/AssetsTab/_styles.scss
@@ -4,10 +4,4 @@
   &__tab-header {
     @include tab-header;
   }
-
-  .empty-assets {
-    display: flex;
-    justify-content: center;
-    color: $ui-fleet-black-75;
-  }
 }


### PR DESCRIPTION
## Issue
Closes #49461

## Description
- Bug fix (root cause): the initial #49461 fix moved Admin/Maintainer users to the shared `EmptyState` on the Profiles and Assets tabs but kept Technicians on the old plain `<Card>` message, so Technicians still saw the inconsistent styling the issue was originally filed for.
- Technicians now render the same `EmptyState variant="header-list"` with the "No configuration profiles" / "No assets" heading. The prior technician copy ("No X have been added.") is preserved as the `info` prop, and the Add button is omitted since technicians can't add.
- Introduced `canAddConfigurationProfile` and `canAddAsset` role-capability variables (mirroring the existing `canTurnOnMdm` pattern) so widening beyond `!isTechnician` later is a one-line change.
- Removed the now-unused `Card` imports and orphaned `.empty-profiles` / `.empty-assets` SCSS rules.

## Screenrecording
- Technician view of Profiles + Assets empty state

https://github.com/user-attachments/assets/a5fdeab0-688d-4b46-b797-bd8ceda16ac1


## Testing



- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated empty states for configuration profiles and assets with consistent styling and clearer messaging.
  - Technicians now see informational empty states without profile or asset creation actions.
  - Users with permission to add profiles or assets retain the relevant actions in empty states and page headers.

- **Tests**
  - Added coverage for technician-specific empty states and hidden creation buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->