### PR TITLE
Honor severity (CVSS) bounds on the vulnerability exposure chart

### DIFF
--- a/changes/47326-filter-vulnerability-exposure-by-severity
+++ b/changes/47326-filter-vulnerability-exposure-by-severity
@@ -1,2 +1,5 @@
 - Added a severity (CVSS) filter to the vulnerability exposure chart, defaulting to critical severity.
 - Updated the severity (CVSS) filter on the software, host details, and my device pages so the min and max score inputs appear only when custom severity is selected.
+- The Vulnerability exposure chart API now applies the `severity_min` and `severity_max` parameters, and echoes the applied bounds in the response's `filters` object. 
+- `GET /api/v1/fleet/charts/cve` now requires a Fleet Premium license and returns HTTP 402 without one.
+- Fleet Free installs no longer collect vulnerability exposure history, since the chart that reads it is available only with Fleet Premium.

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -1627,11 +1627,15 @@ func newCleanupsAndAggregationSchedule(
 }
 
 // buildChartScopeResolver returns a per-dataset scope resolver for the chart
-// collection cron. It computes (skip, disabledFleetIDs) from the global and
-// per-team historical-data flags. Extracted from the cron closure so it can be
-// unit-tested without spinning up a schedule.
-func buildChartScopeResolver(appCfg *fleet.AppConfig, teams []*fleet.Team, logger *slog.Logger) chart_api.CollectScopeFn {
+// collection cron. It computes (skip, disabledFleetIDs) from the license and the
+// global and per-team historical-data flags. Extracted from the cron closure so
+// it can be unit-tested without spinning up a schedule.
+func buildChartScopeResolver(appCfg *fleet.AppConfig, teams []*fleet.Team, isPremium bool, logger *slog.Logger) chart_api.CollectScopeFn {
 	return func(name string) (skip bool, disabledFleetIDs []uint) {
+		if name == chart_api.MetricCVE && !isPremium {
+			return true, nil
+		}
+
 		ok, err := appCfg.Features.HistoricalData.Enabled(name)
 		if err != nil {
 			// Unknown dataset — fall back to enabled with no team filter.
@@ -1662,6 +1666,7 @@ func newChartDataCollectionSchedule(
 	instanceID string,
 	ds fleet.Datastore,
 	chartSvc chart_api.Service,
+	isPremium bool,
 	logger *slog.Logger,
 ) (*schedule.Schedule, error) {
 	const (
@@ -1690,7 +1695,7 @@ func newChartDataCollectionSchedule(
 				logger.ErrorContext(ctx, "list teams for chart scope", "err", err)
 				return ctxerr.Wrap(ctx, err, "list teams for chart scope")
 			}
-			return chartSvc.CollectDatasets(ctx, time.Now(), buildChartScopeResolver(appCfg, teams, logger))
+			return chartSvc.CollectDatasets(ctx, time.Now(), buildChartScopeResolver(appCfg, teams, isPremium, logger))
 		}),
 	)
 

--- a/cmd/fleet/cron_registration.go
+++ b/cmd/fleet/cron_registration.go
@@ -85,7 +85,8 @@ func startCronSchedules(ctx context.Context, deps cronSchedulesDeps) {
 func registerCleanupAndMaintenanceCrons(ctx context.Context, deps cronSchedulesDeps) {
 	if os.Getenv("FLEET_SKIP_CHART_DATA_COLLECTION") == "" {
 		deps.register("failed to register chart_data_collection schedule", func() (fleet.CronSchedule, error) {
-			return newChartDataCollectionSchedule(ctx, deps.instanceID, deps.ds, deps.chartSvc, deps.logger)
+			return newChartDataCollectionSchedule(ctx, deps.instanceID, deps.ds, deps.chartSvc,
+				deps.license != nil && deps.license.IsPremium(), deps.logger)
 		})
 	} else {
 		deps.logger.InfoContext(ctx, "skipping chart data collection cron (FLEET_SKIP_CHART_DATA_COLLECTION is set)")

--- a/cmd/fleet/cron_test.go
+++ b/cmd/fleet/cron_test.go
@@ -269,14 +269,14 @@ func TestBuildChartScopeResolver(t *testing.T) {
 	}
 
 	t.Run("global off → skip", func(t *testing.T) {
-		scope := buildChartScopeResolver(makeAppCfg(false, true), nil, nil)
+		scope := buildChartScopeResolver(makeAppCfg(false, true), nil, true, nil)
 		skip, disabled := scope("uptime")
 		require.True(t, skip)
 		require.Nil(t, disabled)
 	})
 
 	t.Run("global on, no teams → no scoping", func(t *testing.T) {
-		scope := buildChartScopeResolver(makeAppCfg(true, true), nil, nil)
+		scope := buildChartScopeResolver(makeAppCfg(true, true), nil, true, nil)
 		skip, disabled := scope("uptime")
 		require.False(t, skip)
 		require.Nil(t, disabled)
@@ -286,6 +286,7 @@ func TestBuildChartScopeResolver(t *testing.T) {
 		scope := buildChartScopeResolver(
 			makeAppCfg(true, true),
 			[]*fleet.Team{makeTeam(1, true, true), makeTeam(2, true, true)},
+			true,
 			nil,
 		)
 		skip, disabled := scope("uptime")
@@ -302,6 +303,7 @@ func TestBuildChartScopeResolver(t *testing.T) {
 				makeTeam(3, true, true),
 				makeTeam(4, false, true), // uptime disabled on team 4
 			},
+			true,
 			nil,
 		)
 		skip, disabled := scope("uptime")
@@ -317,6 +319,7 @@ func TestBuildChartScopeResolver(t *testing.T) {
 				makeTeam(2, false, true), // uptime only on team 2
 				makeTeam(3, true, true),
 			},
+			true,
 			nil,
 		)
 		skipU, disabledU := scope("uptime")
@@ -332,6 +335,7 @@ func TestBuildChartScopeResolver(t *testing.T) {
 		scope := buildChartScopeResolver(
 			makeAppCfg(true, false),
 			[]*fleet.Team{makeTeam(1, true, true)},
+			true,
 			nil,
 		)
 		skip, disabled := scope("cve")
@@ -340,8 +344,39 @@ func TestBuildChartScopeResolver(t *testing.T) {
 	})
 
 	t.Run("unknown dataset name falls through to no-scope", func(t *testing.T) {
-		scope := buildChartScopeResolver(makeAppCfg(true, true), nil, nil)
+		scope := buildChartScopeResolver(makeAppCfg(true, true), nil, true, nil)
 		skip, disabled := scope("unknown_dataset")
+		require.False(t, skip)
+		require.Nil(t, disabled)
+	})
+
+	t.Run("free tier skips cve even when the config enables it", func(t *testing.T) {
+		scope := buildChartScopeResolver(
+			makeAppCfg(true, true),
+			[]*fleet.Team{makeTeam(1, true, true)},
+			false,
+			nil,
+		)
+		skip, disabled := scope("cve")
+		require.True(t, skip)
+		require.Nil(t, disabled)
+	})
+
+	t.Run("free tier still collects uptime", func(t *testing.T) {
+		scope := buildChartScopeResolver(
+			makeAppCfg(true, true),
+			[]*fleet.Team{makeTeam(1, true, true), makeTeam(2, false, true)},
+			false,
+			nil,
+		)
+		skip, disabled := scope("uptime")
+		require.False(t, skip)
+		require.ElementsMatch(t, []uint{2}, disabled, "per-fleet uptime scoping is unaffected by the license")
+	})
+
+	t.Run("premium with cve enabled collects it", func(t *testing.T) {
+		scope := buildChartScopeResolver(makeAppCfg(true, true), nil, true, nil)
+		skip, disabled := scope("cve")
 		require.False(t, skip)
 		require.Nil(t, disabled)
 	})

--- a/server/chart/api/chart.go
+++ b/server/chart/api/chart.go
@@ -179,8 +179,9 @@ type RequestOpts struct {
 	// no bound. The frontend converts its 0–100 % input before sending.
 	EPSSMin *float64
 	EPSSMax *float64
-	// Severity (CVSS) bounds are accepted but ignored this round — the service
-	// forces critical-only [9.0, 10.0]. See the severity TODO in the service.
+	// Severity bounds are CVSS v3 base scores, 0.0–10.0; nil means no bound on
+	// that side, which drops the predicate rather than widening it to the full
+	// range.
 	SeverityMin *float64
 	SeverityMax *float64
 	// ExcludeCVEs is a subtractive filter — these CVEs are removed from the

--- a/server/chart/internal/mysql/charts.go
+++ b/server/chart/internal/mysql/charts.go
@@ -311,17 +311,29 @@ func (ds *Datastore) CollectibleCVEs(ctx context.Context) ([]string, error) {
 // the curated universe with the filter's predicates (software category, CVSS
 // range, EPSS range, known-exploit) and subtracting any excluded CVEs.
 //
-// With the default filter (CVSS 9.0–10.0, all categories, no EPSS bound, no
-// known-exploit, no exclusions) this reproduces the iteration-1 "tracked
-// critical CVEs" set, so the chart's default display is unchanged.
+// A CVSS range of 9.0–10.0 with no other narrowing reproduces the "tracked
+// critical CVEs" set, which is what the UI seeds by default.
+//
+// Filtering on any cve_meta column (CVSS, EPSS, known-exploit) requires that
+// row to exist, so those filters exclude CVEs Fleet has no NVD metadata for.
+// When no such filter is set the join is dropped and they resolve, matching
+// what the collector records. Note NULL fails every comparison, so an explicit
+// 0.0–10.0 CVSS range still excludes a CVE whose cvss_score is NULL, while no
+// CVSS bound at all includes it.
 //
 // Returns a non-nil empty slice when the filter resolves to nothing, so callers
-// never pass nil to GetSCDData (which would mean "all collected", leaking
-// lower-severity CVEs into the chart).
+// never pass nil to GetSCDData, which would mean "no entity filter" and widen
+// the chart to everything the collector recorded.
 func (ds *Datastore) ResolveCVEChartEntities(ctx context.Context, filter types.CVEChartFilter) ([]string, error) {
 	set := make(map[string]struct{})
 	cats := categorySet(filter.Categories) // nil == all categories
 	metaClause, metaArgs := cveMetaPredicate(filter)
+
+	swMetaJoin, osMetaJoin := "", ""
+	if metaClause != "" {
+		swMetaJoin = "JOIN cve_meta cm ON cm.cve = sc.cve"
+		osMetaJoin = "JOIN cve_meta cm ON cm.cve = osv.cve"
+	}
 
 	// Software-side: skip entirely when no matcher falls in the selected
 	// categories (e.g. only the OS category is selected).
@@ -331,7 +343,7 @@ func (ds *Datastore) ResolveCVEChartEntities(ctx context.Context, filter types.C
 			SELECT DISTINCT sc.cve
 			FROM software_cve sc
 			JOIN software s  ON s.id = sc.software_id
-			JOIN cve_meta cm ON cm.cve = sc.cve
+			` + swMetaJoin + `
 			WHERE ` + swClause + metaClause
 		expanded, expandedArgs, err := sqlx.In(swQuery, args...)
 		if err != nil {
@@ -348,7 +360,7 @@ func (ds *Datastore) ResolveCVEChartEntities(ctx context.Context, filter types.C
 		osQuery := `
 			SELECT DISTINCT osv.cve
 			FROM operating_system_vulnerabilities osv
-			JOIN cve_meta cm ON cm.cve = osv.cve
+			` + osMetaJoin + `
 			WHERE 1=1` + metaClause
 		expanded, expandedArgs, err := sqlx.In(osQuery, metaArgs...)
 		if err != nil {
@@ -396,11 +408,21 @@ func softwareMatcherClause(categories map[string]struct{}) (clause string, args 
 }
 
 // cveMetaPredicate builds the cve_meta WHERE fragment (with a leading " AND ")
-// shared by the software- and OS-side resolve queries, plus its args. The CVSS
-// range is always applied; EPSS bounds and the known-exploit flag are optional.
+// shared by the software- and OS-side resolve queries, plus its args. Every
+// predicate is optional: CVSS and EPSS bounds are applied only when set, and
+// the known-exploit flag only when true. Returns an empty fragment when no
+// predicate applies, so callers must not assume a leading " AND ".
 func cveMetaPredicate(filter types.CVEChartFilter) (string, []any) {
-	clauses := []string{"cm.cvss_score >= ?", "cm.cvss_score <= ?"}
-	args := []any{filter.CVSSMin, filter.CVSSMax}
+	var clauses []string
+	var args []any
+	if filter.CVSSMin != nil {
+		clauses = append(clauses, "cm.cvss_score >= ?")
+		args = append(args, *filter.CVSSMin)
+	}
+	if filter.CVSSMax != nil {
+		clauses = append(clauses, "cm.cvss_score <= ?")
+		args = append(args, *filter.CVSSMax)
+	}
 	if filter.EPSSMin != nil {
 		clauses = append(clauses, "cm.epss_probability >= ?")
 		args = append(args, *filter.EPSSMin)
@@ -411,6 +433,9 @@ func cveMetaPredicate(filter types.CVEChartFilter) (string, []any) {
 	}
 	if filter.KnownExploit {
 		clauses = append(clauses, "cm.cisa_known_exploit = 1")
+	}
+	if len(clauses) == 0 {
+		return "", nil
 	}
 	return " AND " + strings.Join(clauses, " AND "), args
 }

--- a/server/chart/internal/mysql/charts.go
+++ b/server/chart/internal/mysql/charts.go
@@ -311,23 +311,24 @@ func (ds *Datastore) CollectibleCVEs(ctx context.Context) ([]string, error) {
 // the curated universe with the filter's predicates (software category, CVSS
 // range, EPSS range, known-exploit) and subtracting any excluded CVEs.
 //
-// A CVSS range of 9.0–10.0 with no other narrowing reproduces the "tracked
-// critical CVEs" set, which is what the UI seeds by default.
-//
 // Filtering on any cve_meta column (CVSS, EPSS, known-exploit) requires that
 // row to exist, so those filters exclude CVEs Fleet has no NVD metadata for.
-// When no such filter is set the join is dropped and they resolve, matching
-// what the collector records. Note NULL fails every comparison, so an explicit
-// 0.0–10.0 CVSS range still excludes a CVE whose cvss_score is NULL, while no
-// CVSS bound at all includes it.
+// When no such filter is set the join is dropped and they resolve. NULL fails
+// every comparison, so an explicit 0.0–10.0 CVSS range still excludes a CVE
+// whose cvss_score is NULL, while no CVSS bound at all includes it.
 //
 // Returns a non-nil empty slice when the filter resolves to nothing, so callers
 // never pass nil to GetSCDData, which would mean "no entity filter" and widen
 // the chart to everything the collector recorded.
 func (ds *Datastore) ResolveCVEChartEntities(ctx context.Context, filter types.CVEChartFilter) ([]string, error) {
-	set := make(map[string]struct{})
 	cats := categorySet(filter.Categories) // nil == all categories
 	metaClause, metaArgs := cveMetaPredicate(filter)
+
+	if cats == nil && metaClause == "" && len(filter.ExcludeCVEs) == 0 {
+		return ds.CollectibleCVEs(ctx)
+	}
+
+	set := make(map[string]struct{})
 
 	swMetaJoin, osMetaJoin := "", ""
 	if metaClause != "" {

--- a/server/chart/internal/mysql/cve_filter_test.go
+++ b/server/chart/internal/mysql/cve_filter_test.go
@@ -54,6 +54,18 @@ func seedCVEMeta(t *testing.T, tdb *testutils.TestDB, cve string, cvss, epss flo
 	require.NoError(t, err)
 }
 
+// seedCVEMetaNoScore inserts cve_meta with a NULL cvss_score, which is what
+// Fleet stores for a CVE that NVD has no CVSS v3 base score for. Such a CVE is
+// invisible to any cvss_score comparison, so it only resolves when no severity
+// bound is set at all.
+func seedCVEMetaNoScore(t *testing.T, tdb *testutils.TestDB, cve string, epss float64, knownExploit bool) {
+	t.Helper()
+	_, err := tdb.DB.ExecContext(t.Context(),
+		`INSERT INTO cve_meta (cve, cvss_score, epss_probability, cisa_known_exploit) VALUES (?, NULL, ?, ?)`,
+		cve, epss, knownExploit)
+	require.NoError(t, err)
+}
+
 // TestCollectibleCVEs verifies the wide collection set: all severities on
 // tracked software and OS vulnerabilities are collected (even without cve_meta),
 // while CVEs on untracked software are excluded.
@@ -88,6 +100,9 @@ func TestCollectibleCVEs(t *testing.T) {
 //	CVE-D  kernel-x (rpm, OS)  cvss 9.1  epss 0.50  kev=false
 //	CVE-E  OS vuln (OS)        cvss 9.7  epss 0.90  kev=true
 //	CVE-F  Slack (untracked)   cvss 10.0 epss 0.99  kev=true   (never tracked)
+//	CVE-G  Chrome (browsers)   cvss NULL epss 0.40  kev=false  (no CVSS score)
+//	CVE-H  Chrome (browsers)   no cve_meta row at all         (no NVD metadata)
+//	CVE-I  OS vuln (OS)        no cve_meta row at all         (no NVD metadata)
 func TestResolveCVEChartEntities(t *testing.T) {
 	tdb := testutils.SetupTestDB(t, "chart_mysql")
 	defer tdb.TruncateTables(t)
@@ -106,9 +121,18 @@ func TestResolveCVEChartEntities(t *testing.T) {
 	seedCVEMeta(t, tdb, "CVE-E", 9.7, 0.90, true)
 	seedSoftware(t, tdb, "Slack", "apps", "CVE-F")
 	seedCVEMeta(t, tdb, "CVE-F", 10.0, 0.99, true)
+	seedSoftware(t, tdb, "Google Chrome", "apps", "CVE-G")
+	seedCVEMetaNoScore(t, tdb, "CVE-G", 0.40, false)
+	// No cve_meta row at all — the collector records these (severity unknown),
+	// so the resolver must be able to return them when nothing is filtered on
+	// cve_meta. Seeded on both sides because the software- and OS-side joins are
+	// built independently, so one side dropping the join proves nothing about
+	// the other.
+	seedSoftware(t, tdb, "Google Chrome", "apps", "CVE-H")
+	seedOSVuln(t, tdb, 1, "CVE-I")
 
-	// critical is the default service-forced severity band.
-	const critMin, critMax = 9.0, 10.0
+	// critical is what the UI seeds by default, so it's the band most cases use.
+	critMin, critMax := new(9.0), new(10.0)
 	allCats := types.CVEChartFilter{CVSSMin: critMin, CVSSMax: critMax}
 
 	cases := []struct {
@@ -155,6 +179,60 @@ func TestResolveCVEChartEntities(t *testing.T) {
 			name:   "combined: browsers AND known-exploit",
 			filter: types.CVEChartFilter{CVSSMin: critMin, CVSSMax: critMax, Categories: []string{api.CVECategoryBrowsers}, KnownExploit: true},
 			want:   []string{"CVE-A"},
+		},
+		{
+			// No cve_meta predicate at all: the cvss_score comparison is gone, and
+			// so is the cve_meta join, so CVEs with a NULL score (G) and CVEs with
+			// no metadata row whatsoever (H software-side, I OS-side) all resolve.
+			name:   "no severity bound includes every severity, unscored, and unknown-metadata CVEs",
+			filter: types.CVEChartFilter{},
+			want:   []string{"CVE-A", "CVE-B", "CVE-C", "CVE-D", "CVE-E", "CVE-G", "CVE-H", "CVE-I"},
+		},
+		{
+			// Pins the OS-side join drop on its own: the software side is skipped
+			// except for the kernel matcher, so CVE-I can only resolve if the OS
+			// query dropped its cve_meta join too. Without this case the OS branch
+			// is indistinguishable from an unconditional join.
+			name:   "OS category with no bounds keeps unknown-metadata OS vulns",
+			filter: types.CVEChartFilter{Categories: []string{api.CVECategoryOS}},
+			want:   []string{"CVE-D", "CVE-E", "CVE-I"},
+		},
+		{
+			// Filtering on any cve_meta column requires the row to exist, so an
+			// unknown-metadata CVE drops out even though the predicate is
+			// unrelated to severity.
+			name:   "a known-exploit filter still requires cve_meta",
+			filter: types.CVEChartFilter{KnownExploit: true},
+			want:   []string{"CVE-A", "CVE-E"},
+		},
+		{
+			name:   "an EPSS bound alone still requires cve_meta",
+			filter: types.CVEChartFilter{EPSSMin: new(0.30)},
+			want:   []string{"CVE-A", "CVE-D", "CVE-E", "CVE-G"},
+		},
+		{
+			// Category narrowing is a software-side predicate, so it does not
+			// reintroduce the cve_meta requirement.
+			name:   "category narrowing alone keeps unknown-metadata CVEs",
+			filter: types.CVEChartFilter{Categories: []string{api.CVECategoryBrowsers}},
+			want:   []string{"CVE-A", "CVE-B", "CVE-G", "CVE-H"},
+		},
+		{
+			// The counterpart: an explicit full range is still a comparison, and
+			// NULL fails every comparison, so the unscored CVE drops out.
+			name:   "explicit full range excludes unscored CVEs",
+			filter: types.CVEChartFilter{CVSSMin: new(0.0), CVSSMax: new(10.0)},
+			want:   []string{"CVE-A", "CVE-B", "CVE-C", "CVE-D", "CVE-E"},
+		},
+		{
+			name:   "lower bound only",
+			filter: types.CVEChartFilter{CVSSMin: new(9.0)},
+			want:   []string{"CVE-A", "CVE-C", "CVE-D", "CVE-E"},
+		},
+		{
+			name:   "upper bound only",
+			filter: types.CVEChartFilter{CVSSMax: new(3.9)},
+			want:   []string{"CVE-B"},
 		},
 	}
 

--- a/server/chart/internal/mysql/cve_filter_test.go
+++ b/server/chart/internal/mysql/cve_filter_test.go
@@ -123,15 +123,9 @@ func TestResolveCVEChartEntities(t *testing.T) {
 	seedCVEMeta(t, tdb, "CVE-F", 10.0, 0.99, true)
 	seedSoftware(t, tdb, "Google Chrome", "apps", "CVE-G")
 	seedCVEMetaNoScore(t, tdb, "CVE-G", 0.40, false)
-	// No cve_meta row at all — the collector records these (severity unknown),
-	// so the resolver must be able to return them when nothing is filtered on
-	// cve_meta. Seeded on both sides because the software- and OS-side joins are
-	// built independently, so one side dropping the join proves nothing about
-	// the other.
 	seedSoftware(t, tdb, "Google Chrome", "apps", "CVE-H")
 	seedOSVuln(t, tdb, 1, "CVE-I")
 
-	// critical is what the UI seeds by default, so it's the band most cases use.
 	critMin, critMax := new(9.0), new(10.0)
 	allCats := types.CVEChartFilter{CVSSMin: critMin, CVSSMax: critMax}
 

--- a/server/chart/internal/service/service.go
+++ b/server/chart/internal/service/service.go
@@ -3,8 +3,11 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
+	"math"
+	"net/http"
 	"time"
 
 	"github.com/RoaringBitmap/roaring"
@@ -12,6 +15,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/chart/api"
 	"github.com/fleetdm/fleet/v4/server/chart/internal/types"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/contexts/license"
 	platform_authz "github.com/fleetdm/fleet/v4/server/platform/authz"
 	platform_http "github.com/fleetdm/fleet/v4/server/platform/http"
 )
@@ -97,6 +101,15 @@ func (s *Service) GetChartData(ctx context.Context, metric string, opts api.Requ
 		return nil, &platform_http.BadRequestError{Message: fmt.Sprintf("unknown chart metric: %s", metric)}
 	}
 
+	// The vulnerability exposure chart is premium-only. Gate it here rather than
+	// at the transport layer so every caller goes through the same check.
+	if metric == api.MetricCVE && !license.IsPremium(ctx) {
+		return nil, platform_http.NewUserMessageError(
+			errors.New("the vulnerability exposure chart requires a Fleet Premium license"),
+			http.StatusPaymentRequired,
+		)
+	}
+
 	// Don't allow requesting more days than the charts are designed to handle.
 	// This mostly prevents expensive queries for large day ranges.
 	if opts.Days < 1 || opts.Days > 31 {
@@ -106,6 +119,16 @@ func (s *Service) GetChartData(ctx context.Context, metric string, opts api.Requ
 	// Resolution must be 0 or a positive divisor of 24.
 	if opts.Resolution < 0 || (opts.Resolution != 0 && 24%opts.Resolution != 0) {
 		return nil, &platform_http.BadRequestError{Message: fmt.Sprintf("invalid resolution value: %d (must be 0 or a positive divisor of 24)", opts.Resolution)}
+	}
+
+	// This check is scoped to the CVE metric because severity is only applied there. Other
+	// metrics ignore the bounds, as they already ignore the rest of the CVE
+	// entity filters, so rejecting a value that would have no effect would be
+	// surprising.
+	if metric == api.MetricCVE {
+		if err := validateSeverityBounds(opts.SeverityMin, opts.SeverityMax); err != nil {
+			return nil, err
+		}
 	}
 
 	hours := opts.Resolution
@@ -140,17 +163,19 @@ func (s *Service) GetChartData(ctx context.Context, metric string, opts api.Requ
 
 	// entityIDs semantics at the storage layer: nil = no filter (all entities);
 	// non-nil empty = match nothing (zero-valued buckets). For the CVE metric we
-	// always resolve a concrete allow-set — never nil — so that lower-severity
-	// CVEs (now collected for all severities) never leak into the chart.
+	// always resolve a concrete allow-set — never nil — so the chart is always
+	// scoped to the curated tracked-software universe rather than to everything
+	// the collector happens to have recorded.
 	var entityIDs []string
 	if metric == api.MetricCVE {
-		// Severity is plumbed through the API (opts.SeverityMin/Max) but forced
-		// to critical-only this round; the severity UI lands in a follow-up.
-		// TODO(#47326): honor opts.SeverityMin/Max instead of hard-coding.
+		// Severity bounds pass through untouched, including nil. A nil bound
+		// drops the CVSS predicate rather than substituting the full 0.0–10.0
+		// range, which matters because cve_meta.cvss_score is nullable: the full
+		// range still excludes unscored CVEs, while no predicate includes them.
 		cveFilter := types.CVEChartFilter{
 			Categories:   opts.SoftwareFilters,
-			CVSSMin:      9.0,
-			CVSSMax:      10.0,
+			CVSSMin:      opts.SeverityMin,
+			CVSSMax:      opts.SeverityMax,
 			EPSSMin:      opts.EPSSMin,
 			EPSSMax:      opts.EPSSMax,
 			KnownExploit: opts.KnownExploit,
@@ -184,14 +209,40 @@ func (s *Service) GetChartData(ctx context.Context, metric string, opts api.Requ
 			KnownExploit:    opts.KnownExploit,
 			EPSSMin:         opts.EPSSMin,
 			EPSSMax:         opts.EPSSMax,
-			// Severity is not echoed: it's forced to critical-only this round
-			// (see above), so echoing the client's requested severity_min/max
-			// would misrepresent what was actually applied. It returns to the
-			// echo when severity becomes a real filter (#47326).
-			ExcludeCVEs: opts.ExcludeCVEs,
+			SeverityMin:     opts.SeverityMin,
+			SeverityMax:     opts.SeverityMax,
+			ExcludeCVEs:     opts.ExcludeCVEs,
 		},
 		Data: data,
 	}, nil
+}
+
+// cvssMinScore and cvssMaxScore bound a CVSS v3 base score.
+const (
+	cvssMinScore = 0.0
+	cvssMaxScore = 10.0
+)
+
+// validateSeverityBounds checks that each supplied severity bound is a valid
+// CVSS v3 base score and that the range isn't inverted. A nil bound is valid
+// and means "unbounded on that side".
+func validateSeverityBounds(minScore, maxScore *float64) error {
+	if minScore != nil && (math.IsNaN(*minScore) || *minScore < cvssMinScore || *minScore > cvssMaxScore) {
+		return &platform_http.BadRequestError{
+			Message: fmt.Sprintf("invalid severity_min value: %v (must be between %v and %v)", *minScore, cvssMinScore, cvssMaxScore),
+		}
+	}
+	if maxScore != nil && (math.IsNaN(*maxScore) || *maxScore < cvssMinScore || *maxScore > cvssMaxScore) {
+		return &platform_http.BadRequestError{
+			Message: fmt.Sprintf("invalid severity_max value: %v (must be between %v and %v)", *maxScore, cvssMinScore, cvssMaxScore),
+		}
+	}
+	if minScore != nil && maxScore != nil && *minScore > *maxScore {
+		return &platform_http.BadRequestError{
+			Message: fmt.Sprintf("invalid severity range: severity_min (%v) must not be greater than severity_max (%v)", *minScore, *maxScore),
+		}
+	}
+	return nil
 }
 
 // effectiveTeamIDs decides the team scope applied at SQL time.

--- a/server/chart/internal/service/service.go
+++ b/server/chart/internal/service/service.go
@@ -108,8 +108,6 @@ func (s *Service) GetChartData(ctx context.Context, metric string, opts api.Requ
 		return nil, &platform_http.BadRequestError{Message: fmt.Sprintf("unknown chart metric: %s", metric)}
 	}
 
-	// The vulnerability exposure chart is premium-only. Gate it here rather than
-	// at the transport layer so every caller goes through the same check.
 	if metric == api.MetricCVE && !license.IsPremium(ctx) {
 		return nil, platform_http.NewUserMessageError(
 			errors.New("the vulnerability exposure chart requires a Fleet Premium license"),

--- a/server/chart/internal/service/service.go
+++ b/server/chart/internal/service/service.go
@@ -20,6 +20,13 @@ import (
 	platform_http "github.com/fleetdm/fleet/v4/server/platform/http"
 )
 
+const (
+	cvssMinScore = 0.0
+	cvssMaxScore = 10.0
+	epssMinScore = 0.0
+	epssMaxScore = 1.0
+)
+
 // Service is the chart bounded context service implementation.
 type Service struct {
 	authz     platform_authz.Authorizer
@@ -121,12 +128,11 @@ func (s *Service) GetChartData(ctx context.Context, metric string, opts api.Requ
 		return nil, &platform_http.BadRequestError{Message: fmt.Sprintf("invalid resolution value: %d (must be 0 or a positive divisor of 24)", opts.Resolution)}
 	}
 
-	// This check is scoped to the CVE metric because severity is only applied there. Other
-	// metrics ignore the bounds, as they already ignore the rest of the CVE
-	// entity filters, so rejecting a value that would have no effect would be
-	// surprising.
 	if metric == api.MetricCVE {
-		if err := validateSeverityBounds(opts.SeverityMin, opts.SeverityMax); err != nil {
+		if err := validateScoreBounds("severity", opts.SeverityMin, opts.SeverityMax, cvssMinScore, cvssMaxScore); err != nil {
+			return nil, err
+		}
+		if err := validateScoreBounds("epss", opts.EPSSMin, opts.EPSSMax, epssMinScore, epssMaxScore); err != nil {
 			return nil, err
 		}
 	}
@@ -217,29 +223,21 @@ func (s *Service) GetChartData(ctx context.Context, metric string, opts api.Requ
 	}, nil
 }
 
-// cvssMinScore and cvssMaxScore bound a CVSS v3 base score.
-const (
-	cvssMinScore = 0.0
-	cvssMaxScore = 10.0
-)
-
-// validateSeverityBounds checks that each supplied severity bound is a valid
-// CVSS v3 base score and that the range isn't inverted. A nil bound is valid
-// and means "unbounded on that side".
-func validateSeverityBounds(minScore, maxScore *float64) error {
-	if minScore != nil && (math.IsNaN(*minScore) || *minScore < cvssMinScore || *minScore > cvssMaxScore) {
+func validateScoreBounds(label string, minScore, maxScore *float64, lo, hi float64) error {
+	if minScore != nil && (math.IsNaN(*minScore) || *minScore < lo || *minScore > hi) {
 		return &platform_http.BadRequestError{
-			Message: fmt.Sprintf("invalid severity_min value: %v (must be between %v and %v)", *minScore, cvssMinScore, cvssMaxScore),
+			Message: fmt.Sprintf("invalid %s_min value: %v (must be between %v and %v)", label, *minScore, lo, hi),
 		}
 	}
-	if maxScore != nil && (math.IsNaN(*maxScore) || *maxScore < cvssMinScore || *maxScore > cvssMaxScore) {
+	if maxScore != nil && (math.IsNaN(*maxScore) || *maxScore < lo || *maxScore > hi) {
 		return &platform_http.BadRequestError{
-			Message: fmt.Sprintf("invalid severity_max value: %v (must be between %v and %v)", *maxScore, cvssMinScore, cvssMaxScore),
+			Message: fmt.Sprintf("invalid %s_max value: %v (must be between %v and %v)", label, *maxScore, lo, hi),
 		}
 	}
 	if minScore != nil && maxScore != nil && *minScore > *maxScore {
 		return &platform_http.BadRequestError{
-			Message: fmt.Sprintf("invalid severity range: severity_min (%v) must not be greater than severity_max (%v)", *minScore, *maxScore),
+			Message: fmt.Sprintf("invalid %s range: %s_min (%v) must not be greater than %s_max (%v)",
+				label, label, *minScore, label, *maxScore),
 		}
 	}
 	return nil

--- a/server/chart/internal/service/service_test.go
+++ b/server/chart/internal/service/service_test.go
@@ -75,10 +75,6 @@ func (s stubLicense) GetTier() string {
 func (s stubLicense) GetOrganization() string { return "test" }
 func (s stubLicense) GetDeviceCount() int     { return 1 }
 
-// requirePremiumRequired asserts err is the premium-license refusal. The
-// service returns a generic UserMessageError rather than a dedicated type, so
-// the 402 status is what identifies it — assert on that, not on the type, which
-// any 422 would also satisfy.
 func requirePremiumRequired(t *testing.T, err error) {
 	t.Helper()
 	var msgErr *platform_http.UserMessageError
@@ -87,20 +83,16 @@ func requirePremiumRequired(t *testing.T, err error) {
 	require.Contains(t, err.Error(), "Fleet Premium")
 }
 
-// premiumCtx returns a context carrying a premium license, as the server's base
-// context does in production.
 func premiumCtx(t *testing.T) context.Context {
 	t.Helper()
 	return license.NewContext(t.Context(), stubLicense{premium: true})
 }
 
-// freeCtx returns a context carrying a free-tier license.
 func freeCtx(t *testing.T) context.Context {
 	t.Helper()
 	return license.NewContext(t.Context(), stubLicense{premium: false})
 }
 
-// mockDatastore implements types.Datastore for unit tests.
 type mockDatastore struct {
 	getSCDDataFunc          func(ctx context.Context, dataset string, startDate, endDate time.Time, bucketSize time.Duration, strategy api.SampleStrategy, filterMask *roaring.Bitmap, entityIDs []string) ([]api.DataPoint, error)
 	getHostIDsForFilterFunc func(ctx context.Context, hostFilter *types.HostFilter) ([]uint, error)
@@ -371,17 +363,12 @@ func TestGetChartDataUptimePassesNilEntityIDs(t *testing.T) {
 	assert.True(t, gotEntityIDsIsNil, "uptime must pass nil entityIDs — the CVE branch must not leak")
 }
 
-// newCVEService builds a service with the CVE dataset registered, which is the
-// setup nearly every CVE read-path test needs.
 func newCVEService(ds *mockDatastore) *Service {
 	svc := NewService(&mockAuthorizer{}, ds, globalViewer(), nil)
 	svc.RegisterDataset(&chart.CVEDataset{})
 	return svc
 }
 
-// captureCVEFilter points the resolver at a recorder so a test can assert on
-// the filter the service built. Returns a pointer the caller reads after the
-// service call.
 func captureCVEFilter(ds *mockDatastore) *types.CVEChartFilter {
 	got := &types.CVEChartFilter{}
 	ds.resolveCVEEntitiesFn = func(_ context.Context, filter types.CVEChartFilter) ([]string, error) {
@@ -391,10 +378,6 @@ func captureCVEFilter(ds *mockDatastore) *types.CVEChartFilter {
 	return got
 }
 
-// TestGetChartDataCVESeverityPassthrough verifies severity bounds reach the
-// resolver untouched and are echoed back unchanged. An absent bound must stay
-// nil rather than being filled in with the range endpoint: nil drops the CVSS
-// predicate, while 0.0 or 10.0 would still exclude CVEs that have no score.
 func TestGetChartDataCVESeverityPassthrough(t *testing.T) {
 	cases := []struct {
 		name     string
@@ -429,10 +412,6 @@ func TestGetChartDataCVESeverityPassthrough(t *testing.T) {
 	}
 }
 
-// TestGetChartDataCVEAlwaysResolvesEntities verifies that entity resolution
-// always runs for the CVE metric and its result is forwarded to GetSCDData as a
-// concrete (never-nil) set, so the chart never falls back to "all collected
-// entities", and that the remaining entity filters are forwarded intact.
 func TestGetChartDataCVEAlwaysResolvesEntities(t *testing.T) {
 	t.Run("no filters still resolves a concrete set", func(t *testing.T) {
 		ds := &mockDatastore{}
@@ -474,9 +453,6 @@ func TestGetChartDataCVEAlwaysResolvesEntities(t *testing.T) {
 	})
 }
 
-// TestGetChartDataCVERequiresPremium verifies the CVE metric is gated on a
-// premium license at the service layer, not just hidden in the UI, and that the
-// gate is scoped to that metric so the free-tier uptime chart keeps working.
 func TestGetChartDataCVERequiresPremium(t *testing.T) {
 	// The uptime dataset is registered alongside CVE so the "other metrics"
 	// case exercises a real free-tier chart rather than an unknown metric.
@@ -528,9 +504,6 @@ func TestGetChartDataCVERequiresPremium(t *testing.T) {
 	})
 }
 
-// TestGetChartDataSeverityValidation verifies severity bounds are validated as
-// a 0.0–10.0 CVSS range with min <= max, rejecting bad input rather than
-// clamping it, and that the guards only reject genuinely invalid input.
 func TestGetChartDataSeverityValidation(t *testing.T) {
 	cases := []struct {
 		name    string
@@ -548,11 +521,6 @@ func TestGetChartDataSeverityValidation(t *testing.T) {
 		{name: "min below range", min: new(-1.0), wantErr: true},
 		{name: "max below range", max: new(-0.1), wantErr: true},
 		{name: "min greater than max", min: new(8.0), max: new(2.0), wantErr: true},
-		// strconv.ParseFloat accepts "NaN", so a client can reach this with
-		// ?severity_min=NaN. Every ordered comparison against NaN is false, so
-		// the range and inversion guards let it through unless NaN is rejected
-		// explicitly — and a NaN in the response's filters echo fails to
-		// JSON-encode, turning a bad request into a server error.
 		{name: "min is NaN", min: new(math.NaN()), wantErr: true},
 		{name: "max is NaN", max: new(math.NaN()), wantErr: true},
 	}
@@ -582,9 +550,6 @@ func TestGetChartDataSeverityValidation(t *testing.T) {
 		})
 	}
 
-	// Severity is applied only to the CVE metric, so other metrics ignore the
-	// bounds rather than rejecting them, matching how software_filters,
-	// has_known_exploit, and the EPSS bounds are already ignored for uptime.
 	t.Run("non-CVE metrics ignore invalid severity bounds", func(t *testing.T) {
 		svc := NewService(&mockAuthorizer{}, &mockDatastore{}, globalViewer(), nil)
 		svc.RegisterDataset(&chart.UptimeDataset{})
@@ -660,11 +625,6 @@ func TestGetChartDataEPSSValidation(t *testing.T) {
 	})
 }
 
-// TestGetChartDataOmitsUnsetSeverityFromEcho verifies the response's filters
-// object reports absent bounds as absent. The echo is what the client reads back
-// to seed its controls, so filling in 0.0/10.0 here would claim a narrowing that
-// was never applied — and 0.0–10.0 is not equivalent to no bound, since it
-// excludes CVEs with no CVSS score.
 func TestGetChartDataOmitsUnsetSeverityFromEcho(t *testing.T) {
 	ds := &mockDatastore{}
 	ds.resolveCVEEntitiesFn = func(_ context.Context, _ types.CVEChartFilter) ([]string, error) {

--- a/server/chart/internal/service/service_test.go
+++ b/server/chart/internal/service/service_test.go
@@ -3,6 +3,8 @@ package service
 import (
 	"context"
 	"errors"
+	"math"
+	"net/http"
 	"testing"
 	"time"
 
@@ -10,7 +12,9 @@ import (
 	"github.com/fleetdm/fleet/v4/server/chart"
 	"github.com/fleetdm/fleet/v4/server/chart/api"
 	"github.com/fleetdm/fleet/v4/server/chart/internal/types"
+	"github.com/fleetdm/fleet/v4/server/contexts/license"
 	platform_authz "github.com/fleetdm/fleet/v4/server/platform/authz"
+	platform_http "github.com/fleetdm/fleet/v4/server/platform/http"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -54,6 +58,47 @@ func (m *mockViewerProvider) ViewerScope(_ context.Context) (bool, []uint, error
 
 // globalViewer returns a viewer provider for a global user (sees everything).
 func globalViewer() *mockViewerProvider { return &mockViewerProvider{isGlobal: true} }
+
+// stubLicense implements license.LicenseChecker. The chart context can't import
+// server/fleet (arch_test forbids it, tests included), so tests can't build a
+// real fleet.LicenseInfo and stub the interface instead.
+type stubLicense struct{ premium bool }
+
+func (s stubLicense) IsPremium() bool               { return s.premium }
+func (s stubLicense) IsAllowDisableTelemetry() bool { return false }
+func (s stubLicense) GetTier() string {
+	if s.premium {
+		return "premium"
+	}
+	return "free"
+}
+func (s stubLicense) GetOrganization() string { return "test" }
+func (s stubLicense) GetDeviceCount() int     { return 1 }
+
+// requirePremiumRequired asserts err is the premium-license refusal. The
+// service returns a generic UserMessageError rather than a dedicated type, so
+// the 402 status is what identifies it — assert on that, not on the type, which
+// any 422 would also satisfy.
+func requirePremiumRequired(t *testing.T, err error) {
+	t.Helper()
+	var msgErr *platform_http.UserMessageError
+	require.ErrorAs(t, err, &msgErr)
+	require.Equal(t, http.StatusPaymentRequired, msgErr.StatusCode())
+	require.Contains(t, err.Error(), "Fleet Premium")
+}
+
+// premiumCtx returns a context carrying a premium license, as the server's base
+// context does in production.
+func premiumCtx(t *testing.T) context.Context {
+	t.Helper()
+	return license.NewContext(t.Context(), stubLicense{premium: true})
+}
+
+// freeCtx returns a context carrying a free-tier license.
+func freeCtx(t *testing.T) context.Context {
+	t.Helper()
+	return license.NewContext(t.Context(), stubLicense{premium: false})
+}
 
 // mockDatastore implements types.Datastore for unit tests.
 type mockDatastore struct {
@@ -296,7 +341,7 @@ func TestGetChartDataCVEResolution(t *testing.T) {
 				return nil, nil
 			}
 
-			resp, err := svc.GetChartData(t.Context(), "cve", api.RequestOpts{Days: 30, Resolution: tc.resolution})
+			resp, err := svc.GetChartData(premiumCtx(t), "cve", api.RequestOpts{Days: 30, Resolution: tc.resolution})
 			require.NoError(t, err)
 			assert.Equal(t, tc.resolutionStr, resp.Resolution)
 			assert.Equal(t, tc.bucketSize, gotBucketSize)
@@ -326,23 +371,74 @@ func TestGetChartDataUptimePassesNilEntityIDs(t *testing.T) {
 	assert.True(t, gotEntityIDsIsNil, "uptime must pass nil entityIDs — the CVE branch must not leak")
 }
 
-// TestGetChartDataCVEAlwaysResolvesEntities verifies the two load-bearing
-// read-path guarantees for the CVE metric: (1) entity resolution always runs
-// and its result is forwarded to GetSCDData as a concrete (never-nil) set, so
-// newly collected lower-severity CVEs can't leak into the chart; and (2) the
-// severity bounds are forced to critical [9.0, 10.0] this round regardless of
-// any client-supplied severity_min/severity_max.
+// newCVEService builds a service with the CVE dataset registered, which is the
+// setup nearly every CVE read-path test needs.
+func newCVEService(ds *mockDatastore) *Service {
+	svc := NewService(&mockAuthorizer{}, ds, globalViewer(), nil)
+	svc.RegisterDataset(&chart.CVEDataset{})
+	return svc
+}
+
+// captureCVEFilter points the resolver at a recorder so a test can assert on
+// the filter the service built. Returns a pointer the caller reads after the
+// service call.
+func captureCVEFilter(ds *mockDatastore) *types.CVEChartFilter {
+	got := &types.CVEChartFilter{}
+	ds.resolveCVEEntitiesFn = func(_ context.Context, filter types.CVEChartFilter) ([]string, error) {
+		*got = filter
+		return []string{}, nil
+	}
+	return got
+}
+
+// TestGetChartDataCVESeverityPassthrough verifies severity bounds reach the
+// resolver untouched and are echoed back unchanged. An absent bound must stay
+// nil rather than being filled in with the range endpoint: nil drops the CVSS
+// predicate, while 0.0 or 10.0 would still exclude CVEs that have no score.
+func TestGetChartDataCVESeverityPassthrough(t *testing.T) {
+	cases := []struct {
+		name     string
+		min, max *float64
+	}{
+		{name: "no bounds"},
+		{name: "both bounds", min: new(1.0), max: new(5.0)},
+		{name: "lower bound only", min: new(7.0)},
+		{name: "upper bound only", max: new(3.9)},
+		{name: "full range is not the same as no bounds", min: new(0.0), max: new(10.0)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ds := &mockDatastore{}
+			got := captureCVEFilter(ds)
+
+			resp, err := newCVEService(ds).GetChartData(premiumCtx(t), "cve", api.RequestOpts{
+				Days:        7,
+				SeverityMin: tc.min,
+				SeverityMax: tc.max,
+			})
+			require.NoError(t, err)
+
+			require.Equal(t, tc.min, got.CVSSMin, "severity_min must reach the resolver unchanged")
+			require.Equal(t, tc.max, got.CVSSMax, "severity_max must reach the resolver unchanged")
+
+			// What was applied is what gets echoed, on every case.
+			require.Equal(t, tc.min, resp.Filters.SeverityMin)
+			require.Equal(t, tc.max, resp.Filters.SeverityMax)
+		})
+	}
+}
+
+// TestGetChartDataCVEAlwaysResolvesEntities verifies that entity resolution
+// always runs for the CVE metric and its result is forwarded to GetSCDData as a
+// concrete (never-nil) set, so the chart never falls back to "all collected
+// entities", and that the remaining entity filters are forwarded intact.
 func TestGetChartDataCVEAlwaysResolvesEntities(t *testing.T) {
 	t.Run("no filters still resolves a concrete set", func(t *testing.T) {
 		ds := &mockDatastore{}
-		svc := NewService(&mockAuthorizer{}, ds, globalViewer(), nil)
-		svc.RegisterDataset(&chart.CVEDataset{})
-
-		var gotFilter types.CVEChartFilter
 		resolveCalled := false
-		ds.resolveCVEEntitiesFn = func(_ context.Context, filter types.CVEChartFilter) ([]string, error) {
+		ds.resolveCVEEntitiesFn = func(_ context.Context, _ types.CVEChartFilter) ([]string, error) {
 			resolveCalled = true
-			gotFilter = filter
 			return []string{"CVE-2026-0001"}, nil
 		}
 		var gotEntityIDs []string
@@ -351,45 +447,15 @@ func TestGetChartDataCVEAlwaysResolvesEntities(t *testing.T) {
 			return nil, nil
 		}
 
-		_, err := svc.GetChartData(t.Context(), "cve", api.RequestOpts{Days: 7})
+		_, err := newCVEService(ds).GetChartData(premiumCtx(t), "cve", api.RequestOpts{Days: 7})
 		require.NoError(t, err)
-		assert.True(t, resolveCalled, "the CVE metric must always resolve its entity set")
-		assert.Equal(t, []string{"CVE-2026-0001"}, gotEntityIDs, "resolved set must be forwarded to GetSCDData, never nil")
-		assert.InDelta(t, 9.0, gotFilter.CVSSMin, 0, "severity is forced to critical")
-		assert.InDelta(t, 10.0, gotFilter.CVSSMax, 0, "severity is forced to critical")
-	})
-
-	t.Run("client severity bounds are overridden to critical", func(t *testing.T) {
-		ds := &mockDatastore{}
-		svc := NewService(&mockAuthorizer{}, ds, globalViewer(), nil)
-		svc.RegisterDataset(&chart.CVEDataset{})
-
-		var gotFilter types.CVEChartFilter
-		ds.resolveCVEEntitiesFn = func(_ context.Context, filter types.CVEChartFilter) ([]string, error) {
-			gotFilter = filter
-			return []string{}, nil
-		}
-
-		_, err := svc.GetChartData(t.Context(), "cve", api.RequestOpts{
-			Days:        7,
-			SeverityMin: new(1.0),
-			SeverityMax: new(5.0),
-		})
-		require.NoError(t, err)
-		assert.InDelta(t, 9.0, gotFilter.CVSSMin, 0, "client severity_min must be ignored this round")
-		assert.InDelta(t, 10.0, gotFilter.CVSSMax, 0, "client severity_max must be ignored this round")
+		require.True(t, resolveCalled, "the CVE metric must always resolve its entity set")
+		require.Equal(t, []string{"CVE-2026-0001"}, gotEntityIDs, "resolved set must be forwarded to GetSCDData, never nil")
 	})
 
 	t.Run("entity filters are forwarded to the resolver", func(t *testing.T) {
 		ds := &mockDatastore{}
-		svc := NewService(&mockAuthorizer{}, ds, globalViewer(), nil)
-		svc.RegisterDataset(&chart.CVEDataset{})
-
-		var gotFilter types.CVEChartFilter
-		ds.resolveCVEEntitiesFn = func(_ context.Context, filter types.CVEChartFilter) ([]string, error) {
-			gotFilter = filter
-			return []string{}, nil
-		}
+		gotFilter := captureCVEFilter(ds)
 
 		opts := api.RequestOpts{
 			Days:            7,
@@ -399,14 +465,163 @@ func TestGetChartDataCVEAlwaysResolvesEntities(t *testing.T) {
 			EPSSMax:         new(1.0),
 			ExcludeCVEs:     []string{"CVE-2026-9999"},
 		}
-		_, err := svc.GetChartData(t.Context(), "cve", opts)
+		_, err := newCVEService(ds).GetChartData(premiumCtx(t), "cve", opts)
 		require.NoError(t, err)
-		assert.Equal(t, []string{api.CVECategoryBrowsers, api.CVECategoryAdobe}, gotFilter.Categories)
-		assert.True(t, gotFilter.KnownExploit)
-		require.NotNil(t, gotFilter.EPSSMin)
-		assert.InDelta(t, 0.5, *gotFilter.EPSSMin, 0)
-		assert.Equal(t, []string{"CVE-2026-9999"}, gotFilter.ExcludeCVEs)
+		require.Equal(t, []string{api.CVECategoryBrowsers, api.CVECategoryAdobe}, gotFilter.Categories)
+		require.True(t, gotFilter.KnownExploit)
+		require.Equal(t, new(0.5), gotFilter.EPSSMin)
+		require.Equal(t, []string{"CVE-2026-9999"}, gotFilter.ExcludeCVEs)
 	})
+}
+
+// TestGetChartDataCVERequiresPremium verifies the CVE metric is gated on a
+// premium license at the service layer, not just hidden in the UI, and that the
+// gate is scoped to that metric so the free-tier uptime chart keeps working.
+func TestGetChartDataCVERequiresPremium(t *testing.T) {
+	// The uptime dataset is registered alongside CVE so the "other metrics"
+	// case exercises a real free-tier chart rather than an unknown metric.
+	newSvc := func(ds *mockDatastore) *Service {
+		svc := newCVEService(ds)
+		svc.RegisterDataset(&chart.UptimeDataset{})
+		return svc
+	}
+
+	t.Run("free tier is refused before any query runs", func(t *testing.T) {
+		ds := &mockDatastore{}
+		resolveCalled := false
+		ds.resolveCVEEntitiesFn = func(_ context.Context, _ types.CVEChartFilter) ([]string, error) {
+			resolveCalled = true
+			return []string{}, nil
+		}
+
+		_, err := newSvc(ds).GetChartData(freeCtx(t), "cve", api.RequestOpts{Days: 7})
+		requirePremiumRequired(t, err)
+		require.False(t, resolveCalled, "the gate must short-circuit before entity resolution")
+	})
+
+	t.Run("a missing license is treated as free", func(t *testing.T) {
+		_, err := newSvc(&mockDatastore{}).GetChartData(t.Context(), "cve", api.RequestOpts{Days: 7})
+		requirePremiumRequired(t, err)
+	})
+
+	t.Run("the license is checked before request validation", func(t *testing.T) {
+		// Ordering matters: an unlicensed caller gets the license error, not a
+		// validation error that would tell them how the filter behaves.
+		_, err := newSvc(&mockDatastore{}).GetChartData(freeCtx(t), "cve", api.RequestOpts{
+			Days:        7,
+			SeverityMin: new(8.0),
+			SeverityMax: new(2.0), // inverted, would otherwise be a 400
+		})
+		requirePremiumRequired(t, err)
+	})
+
+	t.Run("premium is allowed", func(t *testing.T) {
+		ds := &mockDatastore{}
+		captureCVEFilter(ds)
+		_, err := newSvc(ds).GetChartData(premiumCtx(t), "cve", api.RequestOpts{Days: 7})
+		require.NoError(t, err)
+	})
+
+	t.Run("the gate does not apply to other metrics", func(t *testing.T) {
+		_, err := newSvc(&mockDatastore{}).GetChartData(freeCtx(t), "uptime", api.RequestOpts{Days: 7})
+		require.NoError(t, err, "only the cve metric is premium-gated")
+	})
+}
+
+// TestGetChartDataSeverityValidation verifies severity bounds are validated as
+// a 0.0–10.0 CVSS range with min <= max, rejecting bad input rather than
+// clamping it, and that the guards only reject genuinely invalid input.
+func TestGetChartDataSeverityValidation(t *testing.T) {
+	cases := []struct {
+		name    string
+		min     *float64
+		max     *float64
+		wantErr bool
+	}{
+		{name: "no bounds", wantErr: false},
+		{name: "full range", min: new(0.0), max: new(10.0), wantErr: false},
+		{name: "equal bounds", min: new(5.0), max: new(5.0), wantErr: false},
+		{name: "min only", min: new(7.0), wantErr: false},
+		{name: "max only", max: new(3.9), wantErr: false},
+		{name: "min above range", min: new(10.1), wantErr: true},
+		{name: "max above range", max: new(11.0), wantErr: true},
+		{name: "min below range", min: new(-1.0), wantErr: true},
+		{name: "max below range", max: new(-0.1), wantErr: true},
+		{name: "min greater than max", min: new(8.0), max: new(2.0), wantErr: true},
+		// strconv.ParseFloat accepts "NaN", so a client can reach this with
+		// ?severity_min=NaN. Every ordered comparison against NaN is false, so
+		// the range and inversion guards let it through unless NaN is rejected
+		// explicitly — and a NaN in the response's filters echo fails to
+		// JSON-encode, turning a bad request into a server error.
+		{name: "min is NaN", min: new(math.NaN()), wantErr: true},
+		{name: "max is NaN", max: new(math.NaN()), wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ds := &mockDatastore{}
+			resolveCalled := false
+			ds.resolveCVEEntitiesFn = func(_ context.Context, _ types.CVEChartFilter) ([]string, error) {
+				resolveCalled = true
+				return []string{}, nil
+			}
+
+			_, err := newCVEService(ds).GetChartData(premiumCtx(t), "cve", api.RequestOpts{
+				Days:        7,
+				SeverityMin: tc.min,
+				SeverityMax: tc.max,
+			})
+			if !tc.wantErr {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			var badReq *platform_http.BadRequestError
+			require.ErrorAs(t, err, &badReq)
+			require.False(t, resolveCalled, "an invalid bound must be rejected before any query runs")
+		})
+	}
+
+	// Severity is applied only to the CVE metric, so other metrics ignore the
+	// bounds rather than rejecting them, matching how software_filters,
+	// has_known_exploit, and the EPSS bounds are already ignored for uptime.
+	t.Run("non-CVE metrics ignore invalid severity bounds", func(t *testing.T) {
+		svc := NewService(&mockAuthorizer{}, &mockDatastore{}, globalViewer(), nil)
+		svc.RegisterDataset(&chart.UptimeDataset{})
+
+		_, err := svc.GetChartData(t.Context(), "uptime", api.RequestOpts{
+			Days:        7,
+			SeverityMin: new(99.0),
+			SeverityMax: new(-1.0),
+		})
+		require.NoError(t, err)
+	})
+}
+
+// TestGetChartDataOmitsUnsetSeverityFromEcho verifies the response's filters
+// object reports absent bounds as absent. The echo is what the client reads back
+// to seed its controls, so filling in 0.0/10.0 here would claim a narrowing that
+// was never applied — and 0.0–10.0 is not equivalent to no bound, since it
+// excludes CVEs with no CVSS score.
+func TestGetChartDataOmitsUnsetSeverityFromEcho(t *testing.T) {
+	ds := &mockDatastore{}
+	ds.resolveCVEEntitiesFn = func(_ context.Context, _ types.CVEChartFilter) ([]string, error) {
+		return []string{}, nil
+	}
+	svc := NewService(&mockAuthorizer{}, ds, globalViewer(), nil)
+	svc.RegisterDataset(&chart.CVEDataset{})
+
+	resp, err := svc.GetChartData(premiumCtx(t), "cve", api.RequestOpts{Days: 7})
+	require.NoError(t, err)
+	require.Nil(t, resp.Filters.SeverityMin)
+	require.Nil(t, resp.Filters.SeverityMax)
+
+	// A one-sided request echoes only the side that was set.
+	resp, err = svc.GetChartData(premiumCtx(t), "cve", api.RequestOpts{Days: 7, SeverityMax: new(3.9)})
+	require.NoError(t, err)
+	require.Nil(t, resp.Filters.SeverityMin)
+	require.NotNil(t, resp.Filters.SeverityMax)
+	require.InDelta(t, 3.9, *resp.Filters.SeverityMax, 0)
 }
 
 func TestGetChartDataWithHostFilters(t *testing.T) {

--- a/server/chart/internal/service/service_test.go
+++ b/server/chart/internal/service/service_test.go
@@ -598,6 +598,68 @@ func TestGetChartDataSeverityValidation(t *testing.T) {
 	})
 }
 
+func TestGetChartDataEPSSValidation(t *testing.T) {
+	cases := []struct {
+		name    string
+		min     *float64
+		max     *float64
+		wantErr bool
+	}{
+		{name: "no bounds", wantErr: false},
+		{name: "full range", min: new(0.0), max: new(1.0), wantErr: false},
+		{name: "equal bounds", min: new(0.5), max: new(0.5), wantErr: false},
+		{name: "min only", min: new(0.85), wantErr: false},
+		{name: "max only", max: new(0.1), wantErr: false},
+		{name: "unconverted percentage", min: new(50.0), wantErr: true},
+		{name: "min above range", min: new(1.1), wantErr: true},
+		{name: "max above range", max: new(100.0), wantErr: true},
+		{name: "min below range", min: new(-0.1), wantErr: true},
+		{name: "max below range", max: new(-1.0), wantErr: true},
+		{name: "min greater than max", min: new(0.9), max: new(0.2), wantErr: true},
+		{name: "min is NaN", min: new(math.NaN()), wantErr: true},
+		{name: "max is NaN", max: new(math.NaN()), wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ds := &mockDatastore{}
+			resolveCalled := false
+			ds.resolveCVEEntitiesFn = func(_ context.Context, _ types.CVEChartFilter) ([]string, error) {
+				resolveCalled = true
+				return []string{}, nil
+			}
+			svc := NewService(&mockAuthorizer{}, ds, globalViewer(), nil)
+			svc.RegisterDataset(&chart.CVEDataset{})
+
+			_, err := svc.GetChartData(premiumCtx(t), "cve", api.RequestOpts{
+				Days:    7,
+				EPSSMin: tc.min,
+				EPSSMax: tc.max,
+			})
+			if !tc.wantErr {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			var badReq *platform_http.BadRequestError
+			require.ErrorAs(t, err, &badReq)
+			require.False(t, resolveCalled, "an invalid bound must be rejected before any query runs")
+		})
+	}
+
+	t.Run("non-CVE metrics ignore invalid EPSS bounds", func(t *testing.T) {
+		svc := NewService(&mockAuthorizer{}, &mockDatastore{}, globalViewer(), nil)
+		svc.RegisterDataset(&chart.UptimeDataset{})
+
+		_, err := svc.GetChartData(t.Context(), "uptime", api.RequestOpts{
+			Days:    7,
+			EPSSMin: new(50.0),
+			EPSSMax: new(-1.0),
+		})
+		require.NoError(t, err)
+	})
+}
+
 // TestGetChartDataOmitsUnsetSeverityFromEcho verifies the response's filters
 // object reports absent bounds as absent. The echo is what the client reads back
 // to seed its controls, so filling in 0.0/10.0 here would claim a narrowing that

--- a/server/chart/internal/types/chart.go
+++ b/server/chart/internal/types/chart.go
@@ -32,14 +32,17 @@ type HostFilter struct {
 // CVE IDs. All predicates AND together (intersect); ExcludeCVEs are subtracted
 // afterward. Excluding a CVE that isn't in the set is a harmless no-op.
 //
-// Categories empty means "all categories" (no narrowing). CVSSMin/CVSSMax are
-// always set by the service (forced to 9.0/10.0 this round — see the severity
-// TODO in the service). EPSSMin/EPSSMax are nil when no bound was requested;
-// values are 0.0–1.0 to match cve_meta.epss_probability.
+// Categories empty means "all categories" (no narrowing). CVSSMin/CVSSMax and
+// EPSSMin/EPSSMax are nil when no bound was requested, which drops the
+// corresponding predicate entirely rather than substituting the full range.
+// That distinction is load-bearing for CVSS: cve_meta.cvss_score is nullable,
+// so a 0.0–10.0 bound still excludes CVEs with no score, while a nil bound
+// includes them. CVSS values are 0.0–10.0; EPSS values are 0.0–1.0 to match
+// cve_meta.epss_probability.
 type CVEChartFilter struct {
 	Categories   []string
-	CVSSMin      float64
-	CVSSMax      float64
+	CVSSMin      *float64
+	CVSSMax      *float64
 	EPSSMin      *float64
 	EPSSMax      *float64
 	KnownExploit bool


### PR DESCRIPTION
Resolves #50946.

severity_min and severity_max were already accepted by the API but discarded — every request was forced to critical-only (9.0-10.0) and the bounds were withheld from the echoed filters. Both now work.

CVSSMin/CVSSMax become optional pointers, applied only when set. A nil bound drops the predicate rather than widening to 0.0-10.0: cve_meta .cvss_score is nullable, so an explicit full range still excludes unscored CVEs while no predicate includes them. For the same reason the cve_meta join is now built only when something filters on it — the join selects no columns, so it was acting purely as a hidden filter, excluding CVEs with no NVD metadata that the collector deliberately records. Bounds are validated as 0.0-10.0 with min <= max, rejecting bad input with 400 instead of clamping.

The cve metric is now gated on a premium license, returning 402 on Fleet Free — it was documented as premium but served to any authenticated user. Adds LicenseRequiredError to server/platform/http, since the chart bounded context cannot import server/fleet.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [X] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional minimum and maximum severity filters for vulnerability exposure charts.
  * Responses now reflect the severity filters applied.
  * Unscored vulnerabilities are included when no severity bounds are specified.

* **Access Changes**
  * Vulnerability exposure charts now require Fleet Premium and return an appropriate payment-required response without a license.
  * Free installations no longer collect vulnerability exposure history; uptime history remains unchanged.

* **Bug Fixes**
  * Improved handling of vulnerabilities without metadata and validation of invalid severity ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->