### PR TITLE
Fix disabled-state bypass for host-targeted and team-targeted packs

### DIFF
--- a/changes/16791-fix-disabled-pack-targeting
+++ b/changes/16791-fix-disabled-pack-targeting
@@ -1,0 +1,1 @@
+- Fixed an issue where disabled packs could still be applied to hosts in certain targeting configurations.

--- a/server/datastore/mysql/packs.go
+++ b/server/datastore/mysql/packs.go
@@ -508,7 +508,7 @@ func listPacksForHost(ctx context.Context, db sqlx.QueryerContext, hid uint) ([]
 	(
 		SELECT p.* FROM packs p
 		JOIN pack_targets pt ON (p.id = pt.pack_id AND pt.type = ? AND pt.target_id = ?)
-		WHERE p.pack_type IS NULL
+		WHERE NOT p.disabled AND p.pack_type IS NULL
 	)
 	UNION ALL
 	(
@@ -516,7 +516,7 @@ func listPacksForHost(ctx context.Context, db sqlx.QueryerContext, hid uint) ([]
 		FROM packs p
 		JOIN pack_targets pt
 		ON (p.id = pt.pack_id AND pt.type = ? AND pt.target_id = (SELECT team_id FROM hosts WHERE id = ?))
-		WHERE p.pack_type IS NULL
+		WHERE NOT p.disabled AND p.pack_type IS NULL
 	)) packs`
 
 	packs := []*fleet.Pack{}

--- a/server/datastore/mysql/packs_test.go
+++ b/server/datastore/mysql/packs_test.go
@@ -637,4 +637,31 @@ func testListForHostExcludesDisabledPacks(t *testing.T, ds *Datastore) {
 	packs, err = ds.ListPacksForHost(ctx, h1.ID)
 	require.NoError(t, err)
 	assert.Len(t, packs, 0)
+
+	// Also verify the team-targeted branch: create a team, assign the host,
+	// create a team-targeted pack, then disable it.
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "team_for_pack_test"})
+	require.NoError(t, err)
+	require.NoError(t, ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&team.ID, []uint{h1.ID})))
+
+	teamPack, err := ds.NewPack(ctx, &fleet.Pack{
+		Name:    "team_targeted_pack",
+		TeamIDs: []uint{team.ID},
+	})
+	require.NoError(t, err)
+
+	// The team-targeted pack should appear for the host.
+	packs, err = ds.ListPacksForHost(ctx, h1.ID)
+	require.NoError(t, err)
+	require.Len(t, packs, 1)
+	assert.Equal(t, "team_targeted_pack", packs[0].Name)
+
+	// Disable the team-targeted pack.
+	teamPack.Disabled = true
+	require.NoError(t, ds.SavePack(ctx, teamPack))
+
+	// The disabled team-targeted pack should no longer appear.
+	packs, err = ds.ListPacksForHost(ctx, h1.ID)
+	require.NoError(t, err)
+	assert.Len(t, packs, 0)
 }

--- a/server/datastore/mysql/packs_test.go
+++ b/server/datastore/mysql/packs_test.go
@@ -636,7 +636,7 @@ func testListForHostExcludesDisabledPacks(t *testing.T, ds *Datastore) {
 	// The disabled pack should no longer appear.
 	packs, err = ds.ListPacksForHost(ctx, h1.ID)
 	require.NoError(t, err)
-	assert.Len(t, packs, 0)
+	assert.Empty(t, packs)
 
 	// Also verify the team-targeted branch: create a team, assign the host,
 	// create a team-targeted pack, then disable it.
@@ -663,5 +663,5 @@ func testListForHostExcludesDisabledPacks(t *testing.T, ds *Datastore) {
 	// The disabled team-targeted pack should no longer appear.
 	packs, err = ds.ListPacksForHost(ctx, h1.ID)
 	require.NoError(t, err)
-	assert.Len(t, packs, 0)
+	assert.Empty(t, packs)
 }

--- a/server/datastore/mysql/packs_test.go
+++ b/server/datastore/mysql/packs_test.go
@@ -34,6 +34,7 @@ func TestPacks(t *testing.T) {
 		{"ApplyStatsNotLocking", testPacksApplyStatsNotLocking},
 		{"ApplyStatsNotLockingTryTwo", testPacksApplyStatsNotLockingTryTwo},
 		{"ListForHostIncludesOnlyUserPacks", testListForHostIncludesOnlyUserPacks},
+		{"ListForHostExcludesDisabledPacks", testListForHostExcludesDisabledPacks},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -606,4 +607,34 @@ func testListForHostIncludesOnlyUserPacks(t *testing.T, ds *Datastore) {
 	if assert.Len(t, packs, 1) {
 		assert.Equal(t, "foo_pack", packs[0].Name)
 	}
+}
+
+func testListForHostExcludesDisabledPacks(t *testing.T, ds *Datastore) {
+	mockClock := clock.NewMockClock()
+	ctx := context.Background()
+
+	h1 := test.NewHost(t, ds, "h1.local", "10.10.10.1", "1", "1", mockClock.Now())
+
+	// Create a pack targeted at the host via host_ids.
+	pack, err := ds.NewPack(ctx, &fleet.Pack{
+		Name:    "host_targeted_pack",
+		HostIDs: []uint{h1.ID},
+	})
+	require.NoError(t, err)
+
+	// The pack should appear when listing packs for the host.
+	packs, err := ds.ListPacksForHost(ctx, h1.ID)
+	require.NoError(t, err)
+	require.Len(t, packs, 1)
+	assert.Equal(t, "host_targeted_pack", packs[0].Name)
+
+	// Disable the pack.
+	pack.Disabled = true
+	err = ds.SavePack(ctx, pack)
+	require.NoError(t, err)
+
+	// The disabled pack should no longer appear.
+	packs, err = ds.ListPacksForHost(ctx, h1.ID)
+	require.NoError(t, err)
+	assert.Len(t, packs, 0)
 }


### PR DESCRIPTION
Closes fleetdm/confidential#16791

## Reproduction

1. Start a local Fleet server
2. Enroll a host
3. Create a host-targeted pack:
```
curl -X POST /api/latest/fleet/packs -d '{"name":"test-pack","disabled":false,"host_ids":[1]}'
```
4. Disable the pack:
```
curl -X PATCH /api/latest/fleet/packs/1 -d '{"disabled":true,"host_ids":[1]}'
```
5. Run the `listPacksForHost` SQL directly:
```sql
SELECT p.* FROM packs p
JOIN pack_targets pt ON (p.id = pt.pack_id AND pt.type = 1 AND pt.target_id = 1)
WHERE p.pack_type IS NULL;
```
6. The disabled pack is still returned (bug). Label-targeted packs correctly filter with `NOT p.disabled`, but host-targeted and team-targeted branches do not.

## Fix

Added `NOT p.disabled AND` to the WHERE clause of the host-targeted and team-targeted branches in `listPacksForHost`, matching the existing label-targeted branch.

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled packs are no longer applied to hosts through host- or team-targeted configurations.
  * Enabled targeted packs continue to appear and apply as expected.

* **Documentation**
  * Added a changelog entry describing the disabled pack targeting fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->