### PR TITLE
update DDM asset auth error

### DIFF
--- a/changes/update-asset-auth-error
+++ b/changes/update-asset-auth-error
@@ -1,0 +1,1 @@
+- Update DDM asset error message when providing `Authentication` key to inform Fleet defaults to `MDM` authentication.

--- a/ee/server/service/apple_mdm.go
+++ b/ee/server/service/apple_mdm.go
@@ -222,7 +222,7 @@ func (svc *Service) validateAppleDDMAsset(ctx context.Context, data []byte) (ide
 
 	// We disallow authentication, as we force MDM auth when serving the assets.
 	if rawAsset.Payload.Authentication != nil {
-		return "", "", &fleet.BadRequestError{Message: "Asset payload must not contain an authentication key"}
+		return "", "", &fleet.BadRequestError{Message: "Asset payload must not contain an authentication key. Fleet defaults to 'MDM' authentication."}
 	}
 
 	if rawAsset.Payload.Reference.DataURL == "" {

--- a/ee/server/service/apple_mdm.go
+++ b/ee/server/service/apple_mdm.go
@@ -222,7 +222,7 @@ func (svc *Service) validateAppleDDMAsset(ctx context.Context, data []byte) (ide
 
 	// We disallow authentication, as we force MDM auth when serving the assets.
 	if rawAsset.Payload.Authentication != nil {
-		return "", "", &fleet.BadRequestError{Message: "Asset payload must not contain an authentication key. Fleet defaults to 'MDM' authentication."}
+		return "", "", &fleet.BadRequestError{Message: "Asset payload must not contain an authentication key. Fleet enforces 'MDM' authentication."}
 	}
 
 	if rawAsset.Payload.Reference.DataURL == "" {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves, reported by customer and a quick change so I just put up a PR

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated Apple DDM asset validation errors to clearly state that Fleet enforces MDM authentication.
  - Explicit authentication keys are now identified as unsupported, making configuration issues easier to understand and resolve.

- **Documentation**
  - Added a changelog entry documenting the revised Apple DDM authentication error message and the applicable authentication behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->