### PR TITLE
Fix case-variant name bypass for built-in label overwrite

### DIFF
--- a/changes/label-builtin-name-case-bypass
+++ b/changes/label-builtin-name-case-bypass
@@ -1,0 +1,1 @@
+* Fixed built-in labels being overwritten, renamed, or deleted by supplying a label name that differs from the built-in name only in letter casing.

--- a/server/datastore/mysql/labels.go
+++ b/server/datastore/mysql/labels.go
@@ -167,10 +167,11 @@ func (ds *Datastore) ApplyLabelSpecsWithAuthor(ctx context.Context, specs []*fle
 	}
 
 	type existingLabel struct {
-		ID       uint   `db:"id"`
-		Name     string `db:"name"`
-		Platform string `db:"platform"`
-		TeamID   *uint  `db:"team_id"`
+		ID        uint            `db:"id"`
+		Name      string          `db:"name"`
+		Platform  string          `db:"platform"`
+		TeamID    *uint           `db:"team_id"`
+		LabelType fleet.LabelType `db:"label_type"`
 	}
 	existingLabels := make(map[string]existingLabel, len(specs))
 
@@ -179,13 +180,13 @@ func (ds *Datastore) ApplyLabelSpecsWithAuthor(ctx context.Context, specs []*fle
 	// should've been cleaned up by SetAsideLabels).
 
 	err = ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
-		// TODO: do we want to allow on duplicate updating label_type or
-		// label_membership_type or should those always be immutable?
-		// are we ok depending solely on the caller to ensure that these fields
-		// are not changed?
+		// TODO: do we want to allow on duplicate updating label_membership_type
+		// or should that always be immutable?
+		// are we ok depending solely on the caller to ensure that field
+		// is not changed?
 
 		if len(labelNames) > 0 {
-			stmt := `SELECT id, name, platform, team_id FROM labels WHERE name IN (?)`
+			stmt := `SELECT id, name, platform, team_id, label_type FROM labels WHERE name IN (?)`
 			stmt, args, err := sqlx.In(stmt, labelNames)
 			if err != nil {
 				return ctxerr.Wrap(ctx, err, "build existing labels query")
@@ -201,10 +202,20 @@ func (ds *Datastore) ApplyLabelSpecsWithAuthor(ctx context.Context, specs []*fle
 			}
 
 			for _, spec := range specs {
-				if existingLabel, ok := existingLabels[strings.ToLower(spec.Name)]; ok &&
-					(existingLabel.TeamID != nil && spec.TeamID == nil ||
-						existingLabel.TeamID == nil && spec.TeamID != nil ||
-						(existingLabel.TeamID != nil && spec.TeamID != nil && *existingLabel.TeamID != *spec.TeamID)) {
+				existingLabel, ok := existingLabels[strings.ToLower(spec.Name)]
+				if !ok {
+					continue
+				}
+				// The lookup above and the unique index the upsert keys on both inherit
+				// the case-insensitive collation of labels.name, so a spec named as a
+				// case variant of a built-in would overwrite that built-in row in place
+				// and demote it to a regular label.
+				if existingLabel.LabelType == fleet.LabelTypeBuiltIn && spec.LabelType != fleet.LabelTypeBuiltIn {
+					return ctxerr.Errorf(ctx, "cannot modify built-in label '%s'", existingLabel.Name)
+				}
+				if existingLabel.TeamID != nil && spec.TeamID == nil ||
+					existingLabel.TeamID == nil && spec.TeamID != nil ||
+					(existingLabel.TeamID != nil && spec.TeamID != nil && *existingLabel.TeamID != *spec.TeamID) {
 					return ctxerr.New(ctx, "one or more specified labels exists on another team")
 				}
 			}

--- a/server/datastore/mysql/labels.go
+++ b/server/datastore/mysql/labels.go
@@ -202,15 +202,17 @@ func (ds *Datastore) ApplyLabelSpecsWithAuthor(ctx context.Context, specs []*fle
 			}
 
 			for _, spec := range specs {
+				if spec.LabelType == fleet.LabelTypeBuiltIn {
+					return ctxerr.Errorf(ctx, "cannot modify or add built-in label '%s'", spec.Name)
+				}
 				existingLabel, ok := existingLabels[strings.ToLower(spec.Name)]
 				if !ok {
 					continue
 				}
 				// The lookup above and the unique index the upsert keys on both inherit
-				// the case-insensitive collation of labels.name, so a spec named as a
-				// case variant of a built-in would overwrite that built-in row in place
-				// and demote it to a regular label.
-				if existingLabel.LabelType == fleet.LabelTypeBuiltIn && spec.LabelType != fleet.LabelTypeBuiltIn {
+				// the case-insensitive collation of labels.name, so even a spec merely
+				// named as a case variant of a built-in resolves to that built-in row.
+				if existingLabel.LabelType == fleet.LabelTypeBuiltIn {
 					return ctxerr.Errorf(ctx, "cannot modify built-in label '%s'", existingLabel.Name)
 				}
 				if existingLabel.TeamID != nil && spec.TeamID == nil ||

--- a/server/datastore/mysql/labels_test.go
+++ b/server/datastore/mysql/labels_test.go
@@ -110,7 +110,7 @@ func TestLabels(t *testing.T) {
 		{"SetAsideLabels", testSetAsideLabels},
 		{"ApplyLabelSpecsWithManualTeamLabels", testApplyLabelSpecsWithManualTeamLabels},
 		{"ApplyLabelSpecsErrorsWhenLabelExistsOnAnotherTeam", testApplyLabelSpecsErrorsWhenLabelExistsOnAnotherTeam},
-		{"ApplyLabelSpecsCannotDemoteBuiltInLabel", testApplyLabelSpecsCannotDemoteBuiltInLabel},
+		{"ApplyLabelSpecsCannotModifyBuiltInLabel", testApplyLabelSpecsCannotModifyBuiltInLabel},
 		{"ApplyLabelSpecsManualNilHosts", testApplyLabelSpecsManualNilHosts},
 		{"ListLabelsOrderKeys", testListLabelsOrderKeys},
 		{"LabelMembershipHostIDs", testLabelMembershipHostIDs},
@@ -255,19 +255,21 @@ func testLabelsSearch(t *testing.T, db *Datastore) {
 		{ID: 9, Name: "bar7"},
 		{ID: 10, Name: "bar8"},
 		{ID: 11, Name: "bar9"},
-		{
-			ID:        12,
-			Name:      "All Hosts",
-			LabelType: fleet.LabelTypeBuiltIn,
-		},
 	}
 	err := db.ApplyLabelSpecs(context.Background(), specs)
 	require.Nil(t, err)
 
+	// built-in labels are created by migrations; ApplyLabelSpecs refuses them, so create it here.
+	allHosts, err := db.NewLabel(context.Background(), &fleet.Label{
+		Name:      "All Hosts",
+		LabelType: fleet.LabelTypeBuiltIn,
+	})
+	require.NoError(t, err)
+
 	user := &fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)}
 	filter := fleet.TeamFilter{User: user}
 
-	all, _, err := db.Label(context.Background(), specs[len(specs)-1].ID, filter)
+	all, _, err := db.Label(context.Background(), allHosts.ID, filter)
 	require.Nil(t, err)
 	l3, _, err := db.Label(context.Background(), specs[2].ID, filter)
 	require.Nil(t, err)
@@ -826,11 +828,36 @@ func setupLabelSpecsTest(t *testing.T, ds fleet.Datastore) []*fleet.LabelSpec {
 			},
 		},
 	}
-	err := ds.ApplyLabelSpecs(context.Background(), expectedSpecs)
+	// built-in labels are created by migrations; ApplyLabelSpecs refuses them, so create it here.
+	err := ds.ApplyLabelSpecs(context.Background(), regularLabelSpecs(expectedSpecs))
 	require.Nil(t, err)
+	for _, s := range expectedSpecs {
+		if s.LabelType != fleet.LabelTypeBuiltIn {
+			continue
+		}
+		_, err := ds.NewLabel(context.Background(), &fleet.Label{
+			Name:                s.Name,
+			Description:         s.Description,
+			Query:               s.Query,
+			Platform:            s.Platform,
+			LabelType:           s.LabelType,
+			LabelMembershipType: s.LabelMembershipType,
+		})
+		require.NoError(t, err)
+	}
 
 	expectedSpecs[4].Hosts = []string{"1", "2", "3", "4"} //nolint:gosec // dismiss G602
 	return expectedSpecs
+}
+
+func regularLabelSpecs(specs []*fleet.LabelSpec) []*fleet.LabelSpec {
+	regular := make([]*fleet.LabelSpec, 0, len(specs))
+	for _, s := range specs {
+		if s.LabelType != fleet.LabelTypeBuiltIn {
+			regular = append(regular, s)
+		}
+	}
+	return regular
 }
 
 func testLabelsGetSpec(t *testing.T, ds *Datastore) {
@@ -854,8 +881,8 @@ func testLabelsApplySpecsRoundtrip(t *testing.T, ds *Datastore) {
 	require.Nil(t, err)
 	test.ElementsMatchSkipTimestampsID(t, globalSpecs, specs)
 
-	// Should be idempotent
-	err = ds.ApplyLabelSpecs(context.Background(), globalSpecs)
+	// Should be idempotent for the regular specs; built-in ones are refused
+	err = ds.ApplyLabelSpecs(context.Background(), regularLabelSpecs(globalSpecs))
 	require.Nil(t, err)
 	specs, err = ds.GetLabelSpecs(context.Background(), globalOnlyFilter)
 	require.Nil(t, err)
@@ -3721,33 +3748,78 @@ func testApplyLabelSpecsErrorsWhenLabelExistsOnAnotherTeam(t *testing.T, ds *Dat
 	require.NoError(t, err)
 }
 
-func testApplyLabelSpecsCannotDemoteBuiltInLabel(t *testing.T, ds *Datastore) {
+func testApplyLabelSpecsCannotModifyBuiltInLabel(t *testing.T, ds *Datastore) {
 	ctx := t.Context()
 
 	builtIn, err := ds.NewLabel(ctx, &fleet.Label{
 		Name:                "All Hosts",
+		Description:         "All hosts enrolled in Fleet",
 		Query:               "select 1;",
 		LabelType:           fleet.LabelTypeBuiltIn,
 		LabelMembershipType: fleet.LabelMembershipTypeDynamic,
 	})
 	require.NoError(t, err)
 
-	err = ds.ApplyLabelSpecs(ctx, []*fleet.LabelSpec{
-		{Name: "all hosts", Query: "select 'BYPASSED';", LabelType: fleet.LabelTypeRegular},
-	})
-	require.ErrorContains(t, err, "cannot modify built-in label 'All Hosts'")
+	exact := fleet.LabelSpec{
+		Name:                "All Hosts",
+		Description:         "All hosts enrolled in Fleet",
+		Query:               "select 1;",
+		LabelType:           fleet.LabelTypeBuiltIn,
+		LabelMembershipType: fleet.LabelMembershipTypeDynamic,
+	}
 
-	stored, _, err := ds.Label(ctx, builtIn.ID, fleet.TeamFilter{User: test.UserAdmin})
-	require.NoError(t, err)
-	require.Equal(t, "All Hosts", stored.Name)
-	require.Equal(t, fleet.LabelTypeBuiltIn, stored.LabelType)
-	require.Equal(t, "select 1;", stored.Query)
+	for _, tc := range []struct {
+		name    string
+		spec    fleet.LabelSpec
+		wantErr string
+	}{
+		// a built-in spec is refused outright, so not even an unchanged one can reach
+		// the upsert
+		{
+			name:    "exact reapplication",
+			spec:    exact,
+			wantErr: "cannot modify or add built-in label 'All Hosts'",
+		},
+		{
+			name:    "changed query",
+			spec:    func() fleet.LabelSpec { s := exact; s.Query = "select 'BYPASSED';"; return s }(),
+			wantErr: "cannot modify or add built-in label 'All Hosts'",
+		},
+		{
+			name:    "built-in label that does not exist yet",
+			spec:    fleet.LabelSpec{Name: "Brand New Built In", Query: "select 1;", LabelType: fleet.LabelTypeBuiltIn},
+			wantErr: "cannot modify or add built-in label 'Brand New Built In'",
+		},
+		// a regular spec still resolves to the built-in row, by exact name or by a
+		// case variant the collation treats as equal
+		{
+			name:    "regular label with a built-in name",
+			spec:    fleet.LabelSpec{Name: "All Hosts", Query: "select 'BYPASSED';", LabelType: fleet.LabelTypeRegular},
+			wantErr: "cannot modify built-in label 'All Hosts'",
+		},
+		{
+			name:    "regular label with a case variant of a built-in name",
+			spec:    fleet.LabelSpec{Name: "all hosts", Query: "select 'BYPASSED';", LabelType: fleet.LabelTypeRegular},
+			wantErr: "cannot modify built-in label 'All Hosts'",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ds.ApplyLabelSpecs(ctx, []*fleet.LabelSpec{&tc.spec})
+			require.ErrorContains(t, err, tc.wantErr)
 
-	// re-applying the built-in unchanged is still allowed
-	err = ds.ApplyLabelSpecs(ctx, []*fleet.LabelSpec{
-		{Name: "All Hosts", Query: "select 1;", LabelType: fleet.LabelTypeBuiltIn, LabelMembershipType: fleet.LabelMembershipTypeDynamic},
-	})
-	require.NoError(t, err)
+			stored, _, err := ds.Label(ctx, builtIn.ID, fleet.TeamFilter{User: test.UserAdmin})
+			require.NoError(t, err)
+			require.Equal(t, "All Hosts", stored.Name)
+			require.Equal(t, "All hosts enrolled in Fleet", stored.Description)
+			require.Equal(t, "select 1;", stored.Query)
+			require.Empty(t, stored.Platform)
+			require.Equal(t, fleet.LabelTypeBuiltIn, stored.LabelType)
+			require.Equal(t, fleet.LabelMembershipTypeDynamic, stored.LabelMembershipType)
+		})
+	}
+
+	_, err = ds.LabelByName(ctx, "Brand New Built In", fleet.TeamFilter{User: test.UserAdmin})
+	require.True(t, fleet.IsNotFound(err), "rejected built-in spec must not create a label")
 }
 
 func testApplyLabelSpecsWithManualTeamLabels(t *testing.T, ds *Datastore) {

--- a/server/datastore/mysql/labels_test.go
+++ b/server/datastore/mysql/labels_test.go
@@ -110,6 +110,7 @@ func TestLabels(t *testing.T) {
 		{"SetAsideLabels", testSetAsideLabels},
 		{"ApplyLabelSpecsWithManualTeamLabels", testApplyLabelSpecsWithManualTeamLabels},
 		{"ApplyLabelSpecsErrorsWhenLabelExistsOnAnotherTeam", testApplyLabelSpecsErrorsWhenLabelExistsOnAnotherTeam},
+		{"ApplyLabelSpecsCannotDemoteBuiltInLabel", testApplyLabelSpecsCannotDemoteBuiltInLabel},
 		{"ApplyLabelSpecsManualNilHosts", testApplyLabelSpecsManualNilHosts},
 		{"ListLabelsOrderKeys", testListLabelsOrderKeys},
 		{"LabelMembershipHostIDs", testLabelMembershipHostIDs},
@@ -3716,6 +3717,35 @@ func testApplyLabelSpecsErrorsWhenLabelExistsOnAnotherTeam(t *testing.T, ds *Dat
 	// Updating the original label on the same team should still work
 	err = ds.ApplyLabelSpecs(ctx, []*fleet.LabelSpec{
 		{Name: "conflicting-label", Query: "SELECT 1 updated", TeamID: &team1.ID},
+	})
+	require.NoError(t, err)
+}
+
+func testApplyLabelSpecsCannotDemoteBuiltInLabel(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	builtIn, err := ds.NewLabel(ctx, &fleet.Label{
+		Name:                "All Hosts",
+		Query:               "select 1;",
+		LabelType:           fleet.LabelTypeBuiltIn,
+		LabelMembershipType: fleet.LabelMembershipTypeDynamic,
+	})
+	require.NoError(t, err)
+
+	err = ds.ApplyLabelSpecs(ctx, []*fleet.LabelSpec{
+		{Name: "all hosts", Query: "select 'BYPASSED';", LabelType: fleet.LabelTypeRegular},
+	})
+	require.ErrorContains(t, err, "cannot modify built-in label 'All Hosts'")
+
+	stored, _, err := ds.Label(ctx, builtIn.ID, fleet.TeamFilter{User: test.UserAdmin})
+	require.NoError(t, err)
+	require.Equal(t, "All Hosts", stored.Name)
+	require.Equal(t, fleet.LabelTypeBuiltIn, stored.LabelType)
+	require.Equal(t, "select 1;", stored.Query)
+
+	// re-applying the built-in unchanged is still allowed
+	err = ds.ApplyLabelSpecs(ctx, []*fleet.LabelSpec{
+		{Name: "All Hosts", Query: "select 1;", LabelType: fleet.LabelTypeBuiltIn, LabelMembershipType: fleet.LabelMembershipTypeDynamic},
 	})
 	require.NoError(t, err)
 }

--- a/server/fleet/labels.go
+++ b/server/fleet/labels.go
@@ -332,6 +332,17 @@ func ReservedLabelNames() map[string]struct{} {
 	}
 }
 
+// IsReservedLabelName reports whether name refers to a built-in label, returning
+// the canonical built-in name. The comparison is case-insensitive.
+func IsReservedLabelName(name string) (string, bool) {
+	for reserved := range ReservedLabelNames() {
+		if strings.EqualFold(name, reserved) {
+			return reserved, true
+		}
+	}
+	return "", false
+}
+
 // DetectMissingLabels returns a list of labels present in the unvalidatedLabels list that could not be found in the validLabelMap.
 func DetectMissingLabels(validLabelMap map[string]uint, unvalidatedLabels []string) []string {
 	missingLabels := make([]string, 0, len(unvalidatedLabels))

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -5403,9 +5403,11 @@ func (s *integrationTestSuite) TestLabels() {
 		errMsg := extractServerErrorText(res.Body)
 		require.Contains(t, errMsg, `Only one of "criteria", "query" or "hosts/host_ids" can be included in the request.`)
 
-		// create invalid label, conflicts with builtin name
+		// create invalid label, conflicts with builtin name (case-insensitive)
 		for n := range builtinsMap {
 			s.DoJSON("POST", "/api/latest/fleet/labels", &fleet.LabelPayload{Name: n, Query: "select 1"}, http.StatusUnprocessableEntity, &createResp)
+			s.DoJSON("POST", "/api/latest/fleet/labels", &fleet.LabelPayload{Name: strings.ToLower(n), Query: "select 1"}, http.StatusUnprocessableEntity, &createResp)
+			s.DoJSON("POST", "/api/latest/fleet/labels", &fleet.LabelPayload{Name: strings.ToUpper(n), Query: "select 1"}, http.StatusUnprocessableEntity, &createResp)
 		}
 
 		// try to create a label with an invalid platform
@@ -5514,6 +5516,8 @@ func (s *integrationTestSuite) TestLabels() {
 		// attempt to modify a label to a reserved name
 		for n := range builtinsMap {
 			s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/labels/%d", lbl1.ID), &fleet.ModifyLabelPayload{Name: ptr.String(n)}, http.StatusUnprocessableEntity, &modResp)
+			s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/labels/%d", lbl1.ID), &fleet.ModifyLabelPayload{Name: new(strings.ToLower(n))}, http.StatusUnprocessableEntity, &modResp)
+			s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/labels/%d", lbl1.ID), &fleet.ModifyLabelPayload{Name: new(strings.ToUpper(n))}, http.StatusUnprocessableEntity, &modResp)
 		}
 
 		// modify a non-existing label
@@ -5795,6 +5799,24 @@ func (s *integrationTestSuite) TestLabels() {
 
 		// delete a non-existing label by name
 		s.DoJSON("DELETE", fmt.Sprintf("/api/latest/fleet/labels/%s", url.PathEscape(lbl2.Name)), nil, http.StatusNotFound, &delResp)
+
+		// delete a built-in label by name (case-insensitive)
+		for n := range builtinsMap {
+			for _, variant := range []string{n, strings.ToLower(n), strings.ToUpper(n)} {
+				res = s.Do("DELETE", fmt.Sprintf("/api/latest/fleet/labels/%s", url.PathEscape(variant)), nil, http.StatusUnprocessableEntity)
+				errMsg = extractServerErrorText(res.Body)
+				require.Contains(t, errMsg, "cannot delete built-in label")
+			}
+		}
+		listResp = fleet.ListLabelsResponse{}
+		s.DoJSON("GET", "/api/latest/fleet/labels", nil, http.StatusOK, &listResp)
+		var remainingBuiltIns int
+		for _, lbl := range listResp.Labels {
+			if _, ok := builtinsMap[lbl.Name]; ok {
+				remainingBuiltIns++
+			}
+		}
+		require.Equal(t, len(builtinsMap), remainingBuiltIns)
 
 		// delete a manual label by id
 		s.DoJSON("DELETE", fmt.Sprintf("/api/latest/fleet/labels/id/%d", manualLbl1.ID), nil, http.StatusOK, &delIDResp)

--- a/server/service/labels.go
+++ b/server/service/labels.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"slices"
 	"strconv"
+	"strings"
 
 	"github.com/fleetdm/fleet/v4/server"
 	"github.com/fleetdm/fleet/v4/server/authz"
@@ -728,7 +729,7 @@ func (svc *Service) ApplyLabelSpecs(ctx context.Context, specs []*fleet.LabelSpe
 			continue
 		}
 		for name := range fleet.ReservedLabelNames() {
-			if spec.Name == name {
+			if strings.EqualFold(spec.Name, name) {
 				return fleet.NewUserMessageError(
 					ctxerr.Errorf(
 						ctx,

--- a/server/service/labels.go
+++ b/server/service/labels.go
@@ -8,7 +8,6 @@ import (
 	"reflect"
 	"slices"
 	"strconv"
-	"strings"
 
 	"github.com/fleetdm/fleet/v4/server"
 	"github.com/fleetdm/fleet/v4/server/authz"
@@ -108,10 +107,8 @@ func (svc *Service) NewLabel(ctx context.Context, p fleet.LabelPayload) (*fleet.
 		return nil, nil, err
 	}
 
-	for name := range fleet.ReservedLabelNames() {
-		if label.Name == name {
-			return nil, nil, fleet.NewInvalidArgumentError("name", fmt.Sprintf("cannot add label '%s' because it conflicts with the name of a built-in label", name))
-		}
+	if reserved, ok := fleet.IsReservedLabelName(label.Name); ok {
+		return nil, nil, fleet.NewInvalidArgumentError("name", fmt.Sprintf("cannot add label '%s' because it conflicts with the name of a built-in label", reserved))
 	}
 
 	// For a manual label, resolve the target hosts and verify the caller is
@@ -266,11 +263,8 @@ func (svc *Service) ModifyLabel(ctx context.Context, id uint, payload fleet.Modi
 		return nil, nil, fleet.NewInvalidArgumentError("label_type", fmt.Sprintf("cannot modify built-in label '%s'", label.Name))
 	}
 	if payload.Name != nil {
-		// Check if the new name is a reserved label name
-		for name := range fleet.ReservedLabelNames() {
-			if *payload.Name == name {
-				return nil, nil, fleet.NewInvalidArgumentError("name", fmt.Sprintf("cannot rename label to '%s' because it conflicts with the name of a built-in label", name))
-			}
+		if reserved, ok := fleet.IsReservedLabelName(*payload.Name); ok {
+			return nil, nil, fleet.NewInvalidArgumentError("name", fmt.Sprintf("cannot rename label to '%s' because it conflicts with the name of a built-in label", reserved))
 		}
 		label.Name = *payload.Name
 	}
@@ -569,11 +563,9 @@ func (svc *Service) DeleteLabel(ctx context.Context, name string) error {
 	}
 
 	// check if the label is a built-in label
-	for n := range fleet.ReservedLabelNames() {
-		if n == name {
-			svc.SkipAuth(ctx)
-			return fleet.NewInvalidArgumentError("name", fmt.Sprintf("cannot delete built-in label '%s'", name))
-		}
+	if reserved, ok := fleet.IsReservedLabelName(name); ok {
+		svc.SkipAuth(ctx)
+		return fleet.NewInvalidArgumentError("name", fmt.Sprintf("cannot delete built-in label '%s'", reserved))
 	}
 
 	filter := fleet.TeamFilter{User: vc.User}
@@ -649,10 +641,8 @@ func (svc *Service) DeleteLabelByID(ctx context.Context, id uint) error {
 	if label.LabelType == fleet.LabelTypeBuiltIn {
 		return fleet.NewInvalidArgumentError("label_type", fmt.Sprintf("cannot delete built-in label '%s'", label.Name))
 	}
-	for name := range fleet.ReservedLabelNames() {
-		if label.Name == name {
-			return fleet.NewInvalidArgumentError("name", fmt.Sprintf("cannot delete built-in label '%s'", label.Name))
-		}
+	if reserved, ok := fleet.IsReservedLabelName(label.Name); ok {
+		return fleet.NewInvalidArgumentError("name", fmt.Sprintf("cannot delete built-in label '%s'", reserved))
 	}
 
 	if err := svc.ds.DeleteLabel(ctx, label.Name, filter); err != nil {
@@ -728,15 +718,13 @@ func (svc *Service) ApplyLabelSpecs(ctx context.Context, specs []*fleet.LabelSpe
 			builtInSpecNames = append(builtInSpecNames, spec.Name)
 			continue
 		}
-		for name := range fleet.ReservedLabelNames() {
-			if strings.EqualFold(spec.Name, name) {
-				return fleet.NewUserMessageError(
-					ctxerr.Errorf(
-						ctx,
-						"cannot add label '%s' because it conflicts with the name of a built-in label",
-						name,
-					), http.StatusUnprocessableEntity)
-			}
+		if reserved, ok := fleet.IsReservedLabelName(spec.Name); ok {
+			return fleet.NewUserMessageError(
+				ctxerr.Errorf(
+					ctx,
+					"cannot add label '%s' because it conflicts with the name of a built-in label",
+					reserved,
+				), http.StatusUnprocessableEntity)
 		}
 
 		if slices.Contains(namesToMove, spec.Name) {

--- a/server/service/labels_test.go
+++ b/server/service/labels_test.go
@@ -491,6 +491,19 @@ func TestApplyLabelSpecsWithBuiltInLabels(t *testing.T) {
 			fmt.Sprintf("cannot add label '%s' because it conflicts with the name of a built-in label", name))
 	}
 
+	// case-variant names should also be rejected (MySQL collation is case-insensitive,
+	// so a case-variant name would overwrite the built-in label row)
+	for _, variant := range []string{"all hosts", "ALL HOSTS", "All hosts"} {
+		err = svc.ApplyLabelSpecs(ctx, []*fleet.LabelSpec{
+			{
+				Name:      variant,
+				Query:     "select 1;",
+				LabelType: fleet.LabelTypeRegular,
+			},
+		}, nil, nil)
+		assert.ErrorContains(t, err, "conflicts with the name of a built-in label", "case variant %q should be rejected", variant)
+	}
+
 	const errorMessage = "cannot modify or add built-in label"
 	// not ok -- built-in label name doesn't exist
 	name = "not-foo"

--- a/server/service/labels_test.go
+++ b/server/service/labels_test.go
@@ -491,9 +491,9 @@ func TestApplyLabelSpecsWithBuiltInLabels(t *testing.T) {
 			fmt.Sprintf("cannot add label '%s' because it conflicts with the name of a built-in label", name))
 	}
 
-	// case-variant names should also be rejected (MySQL collation is case-insensitive,
-	// so a case-variant name would overwrite the built-in label row)
-	for _, variant := range []string{"all hosts", "ALL HOSTS", "All hosts"} {
+	// case-variant names must also be rejected: labels.name has a case-insensitive
+	// collation, so the upsert would overwrite the built-in label row.
+	for _, variant := range []string{"all hosts", "ALL HOSTS", "All hosts", "fedora linux", "MS WINDOWS"} {
 		err = svc.ApplyLabelSpecs(ctx, []*fleet.LabelSpec{
 			{
 				Name:      variant,
@@ -501,7 +501,7 @@ func TestApplyLabelSpecsWithBuiltInLabels(t *testing.T) {
 				LabelType: fleet.LabelTypeRegular,
 			},
 		}, nil, nil)
-		assert.ErrorContains(t, err, "conflicts with the name of a built-in label", "case variant %q should be rejected", variant)
+		require.ErrorContains(t, err, "conflicts with the name of a built-in label", "case variant %q should be rejected", variant)
 	}
 
 	const errorMessage = "cannot modify or add built-in label"
@@ -541,6 +541,45 @@ func TestApplyLabelSpecsWithBuiltInLabels(t *testing.T) {
 	}
 	err = svc.ApplyLabelSpecs(ctx, []*fleet.LabelSpec{spec}, nil, nil)
 	assert.ErrorIs(t, err, assert.AnError)
+}
+
+func TestBuiltInLabelNameCaseVariants(t *testing.T) {
+	t.Parallel()
+	ds := new(mock.Store)
+	svc, ctx := newTestService(t, ds, nil, nil)
+	ctx = viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{ID: 1, GlobalRole: new(fleet.RoleAdmin)}})
+
+	ds.NewLabelFunc = func(ctx context.Context, lbl *fleet.Label, opts ...fleet.OptionalArg) (*fleet.Label, error) {
+		lbl.ID = 1
+		return lbl, nil
+	}
+	ds.LabelFunc = func(ctx context.Context, lid uint, teamFilter fleet.TeamFilter) (*fleet.LabelWithTeamName, []uint, error) {
+		return &fleet.LabelWithTeamName{
+			Label: fleet.Label{ID: lid, Name: "a regular label", Query: "select 1;", LabelType: fleet.LabelTypeRegular},
+		}, nil, nil
+	}
+	ds.DeleteLabelFunc = func(ctx context.Context, name string, filter fleet.TeamFilter) error {
+		return nil
+	}
+	ds.SaveLabelFunc = func(ctx context.Context, label *fleet.Label, hostIDs []uint, teamFilter fleet.TeamFilter) (*fleet.LabelWithTeamName, []uint, error) {
+		return &fleet.LabelWithTeamName{Label: *label}, nil, nil
+	}
+
+	for _, variant := range []string{"all hosts", "ALL HOSTS", "aLl HoStS"} {
+		t.Run(variant, func(t *testing.T) {
+			_, _, err := svc.NewLabel(ctx, fleet.LabelPayload{Name: variant, Query: "select 1;"})
+			require.ErrorContains(t, err, "cannot add label 'All Hosts' because it conflicts with the name of a built-in label")
+			require.False(t, ds.NewLabelFuncInvoked)
+
+			_, _, err = svc.ModifyLabel(ctx, 1, fleet.ModifyLabelPayload{Name: &variant})
+			require.ErrorContains(t, err, "cannot rename label to 'All Hosts' because it conflicts with the name of a built-in label")
+			require.False(t, ds.SaveLabelFuncInvoked)
+
+			err = svc.DeleteLabel(ctx, variant)
+			require.ErrorContains(t, err, "cannot delete built-in label 'All Hosts'")
+			require.False(t, ds.DeleteLabelFuncInvoked)
+		})
+	}
 }
 
 func TestApplyLabelSpecsCustomHostVitalCriteria(t *testing.T) {


### PR DESCRIPTION
# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

---

## Summary

The `ApplyLabelSpecs` service method checked incoming label names against built-in/reserved names using Go's case-sensitive `==` operator. However, MySQL's default `utf8mb4_unicode_ci` collation matches names case-insensitively, so a spec with name `"all hosts"` (lowercase) bypasses the Go guard and the `INSERT ... ON DUPLICATE KEY UPDATE` overwrites the built-in `"All Hosts"` row.

## Fix

Changed `spec.Name == name` to `strings.EqualFold(spec.Name, name)`.

## Reproduction

### Before fix

1. Start Fleet server normally.
2. Save the following as `label-bypass-test.yml`:

```yaml
apiVersion: v1
kind: label
spec:
  name: "all hosts"
  query: "select 'BYPASSED';"
```

3. Apply the spec:

```
$ fleetctl apply -f label-bypass-test.yml
[+] applied 1 labels
```

4. Verify the built-in label was overwritten:

```
$ fleetctl get labels | grep -i "all hosts"
| all hosts     |     |     | select 'BYPASSED';  |
```

The built-in "All Hosts" label's name and query have been replaced.

### After fix

```
$ fleetctl apply -f label-bypass-test.yml
Error: applying labels: POST /api/latest/fleet/spec/labels received status 422 Unprocessable Entity:
  cannot add label 'All Hosts' because it conflicts with the name of a built-in label
```

The case-variant name is now correctly rejected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Built-in labels are now protected regardless of capitalization.
  * Attempts to overwrite, rename, or delete built-in labels using different letter casing are rejected.
  * Existing built-in labels and their queries remain unchanged when conflicting updates are attempted.
  * Error messages now identify the canonical built-in label name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->