### PR TITLE
OKF POC

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -110,6 +110,15 @@ All Fleet documentation lives in this repo. Check these sources before searching
 - **`handbook/`** — Internal procedures: engineering practices, company policies, product design
 - **`articles/`** — Blog posts and tutorials
 
+## Knowledge graph
+
+A precomputed knowledge graph lives in `.okf/knowledge/`. **Check it before exploring the codebase** — it maps API endpoints to service code to documentation, saving you from grepping.
+
+- **API endpoints:** Read `.okf/knowledge/api-endpoints/index.md` to find any REST API endpoint, its handler function, service file, and link to REST API docs. Example: look up `GET /api/v1/fleet/hosts/:id` → find `getHostEndpoint` in `server/service/hosts.go:848`.
+- **Article/guide links:** Read `.okf/knowledge/article-links/index.md` to find which articles link to which docs and guides.
+- **Code concepts:** `.okf/knowledge/server/service/*.go.md` files list every function, import, and symbol in that source file with line numbers — read these instead of scanning large `.go` files.
+- **Search:** Run `okf search -q "<term>"` to find relevant concepts across the graph.
+
 ## Other references
 
 - Linter config: `.golangci.yml`

--- a/tools/okf/layer1-api-mapping.sh
+++ b/tools/okf/layer1-api-mapping.sh
@@ -1,0 +1,258 @@
+#!/bin/bash
+# Layer 1: Map REST API docs <-> handler.go routes <-> service files
+# Generates OKF concept files in .okf/knowledge/api-endpoints/
+#
+# Parses:
+#   1. server/service/handler.go — route registrations (method, path, endpointFunc)
+#   2. docs/REST API/rest-api.md — endpoint documentation (heading, method, path)
+#   3. server/service/*.go — endpoint function locations (file, line)
+#
+# Joins on normalized (HTTP method, path) to produce one concept per endpoint.
+
+set -euo pipefail
+
+DRY_RUN=0
+if [ "${1:-}" = "--dry-run" ] || [ "${1:-}" = "-n" ]; then
+    DRY_RUN=1
+fi
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+HANDLER="$REPO_ROOT/server/service/handler.go"
+API_DOC="$REPO_ROOT/docs/REST API/rest-api.md"
+OUT_DIR="$REPO_ROOT/.okf/knowledge/api-endpoints"
+SERVICE_DIR="$REPO_ROOT/server/service"
+
+TMPDIR_WORK="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_WORK"' EXIT
+
+if [ "$DRY_RUN" -eq 0 ]; then
+    mkdir -p "$OUT_DIR"
+fi
+
+# --- Step 1: Extract routes from handler.go ---
+# Output: METHOD|normalized_path|endpointFunc (sorted, deduped)
+extract_routes() {
+    # Captures all registrars: ue, ne, oe, mdmAppleMW, mdmAnyMW, neAppleMDM, etc.
+    grep -E '\.(GET|POST|PATCH|DELETE|PUT|HEAD)\(' "$HANDLER" \
+        | perl -nle 'if (/\.(GET|POST|PATCH|DELETE|PUT|HEAD)\("([^"]+)",\s*(\w+)/) { print "$1|$2|$3" }' \
+        | sed 's|_version_|v1|g' \
+        | sed -E 's/\{[^}]+\}/:id/g'
+}
+
+# --- Step 2: Extract endpoint docs from rest-api.md ---
+# Output: METHOD|normalized_path|heading|original_path
+# Only emits the first backtick endpoint line per ### heading (definition, not example)
+extract_doc_endpoints() {
+    local current_heading=""
+    local seen_endpoint_for_heading=0
+    while IFS= read -r line; do
+        if echo "$line" | grep -qE '^### '; then
+            current_heading="$(echo "$line" | sed 's/^### //' | sed 's/[[:space:]]*$//')"
+            seen_endpoint_for_heading=0
+        fi
+        if [ "$seen_endpoint_for_heading" -eq 0 ] && echo "$line" | grep -qE '^\`(GET|POST|PATCH|DELETE|PUT|HEAD) /api/v1/fleet/'; then
+            method="$(echo "$line" | sed -E 's/^\`(GET|POST|PATCH|DELETE|PUT|HEAD) .*/\1/')"
+            path="$(echo "$line" | sed -E 's/^\`[A-Z]+ ([^\`]+)\`/\1/')"
+            normalized_path="$(echo "$path" | sed -E 's/:[a-z_]+/:id/g')"
+            echo "${method}|${normalized_path}|${current_heading}|${path}"
+            seen_endpoint_for_heading=1
+        fi
+    done < "$API_DOC"
+}
+
+# --- Step 3: Find which .go file defines each endpoint function ---
+find_endpoint_file() {
+    local func_name="$1"
+    grep -rn "func ${func_name}(" "$SERVICE_DIR"/*.go 2>/dev/null \
+        | head -1 \
+        | sed -E 's/^.*\/(server\/service\/[^:]+):([0-9]+):.*/\1:\2/' \
+        || true
+}
+
+# --- Step 4: Build lookup files and join ---
+
+echo "Extracting routes from handler.go..."
+extract_routes | sort -t'|' -k1,2 -u > "$TMPDIR_WORK/routes.tsv"
+route_count="$(wc -l < "$TMPDIR_WORK/routes.tsv" | tr -d ' ')"
+echo "  Found $route_count routes"
+
+echo "Extracting endpoints from rest-api.md..."
+extract_doc_endpoints | sort -t'|' -k1,2 -u > "$TMPDIR_WORK/docs.tsv"
+doc_count="$(wc -l < "$TMPDIR_WORK/docs.tsv" | tr -d ' ')"
+echo "  Found $doc_count documented endpoints"
+
+echo "Joining routes with docs..."
+matched=0
+code_only=0
+
+while IFS='|' read -r method norm_path func; do
+    key="${method}|${norm_path}"
+
+    # Look up doc info
+    doc_line="$(grep -F "$key" "$TMPDIR_WORK/docs.tsv" | head -1 || true)"
+    if [ -n "$doc_line" ]; then
+        matched=$((matched + 1))
+    else
+        code_only=$((code_only + 1))
+    fi
+done < "$TMPDIR_WORK/routes.tsv"
+
+# Count doc-only endpoints (documented but no code route)
+doc_only=0
+while IFS='|' read -r method norm_path heading orig_path; do
+    key="${method}|${norm_path}"
+    if ! grep -qF "$key" "$TMPDIR_WORK/routes.tsv"; then
+        doc_only=$((doc_only + 1))
+    fi
+done < "$TMPDIR_WORK/docs.tsv"
+
+total_to_write=$((matched + code_only))
+
+echo ""
+echo "=== Layer 1 Results ==="
+echo "Matched (code + docs):  $matched"
+echo "Code only (no docs):    $code_only"
+echo "Docs only (no code):    $doc_only"
+echo "Files to write:         $total_to_write"
+echo "Output directory:       $OUT_DIR"
+
+if [ "$DRY_RUN" -eq 1 ]; then
+    echo ""
+    echo "[DRY RUN] No files written. Run without --dry-run to generate concept files."
+    echo ""
+    echo "Sample matches:"
+    head -5 "$TMPDIR_WORK/routes.tsv" | while IFS='|' read -r method norm_path func; do
+        doc_line="$(grep -F "${method}|${norm_path}" "$TMPDIR_WORK/docs.tsv" | head -1 || true)"
+        if [ -n "$doc_line" ]; then
+            heading="$(echo "$doc_line" | cut -d'|' -f3)"
+            echo "  ✓ $method $norm_path → $func → doc: \"$heading\""
+        else
+            echo "  ✗ $method $norm_path → $func → (no docs)"
+        fi
+    done
+    exit 0
+fi
+
+# --- Generate concept files ---
+echo ""
+echo "Writing concept files..."
+
+while IFS='|' read -r method norm_path func; do
+    key="${method}|${norm_path}"
+
+    # Look up doc info
+    doc_line="$(grep -F "$key" "$TMPDIR_WORK/docs.tsv" | head -1 || true)"
+    heading=""
+    orig_path="$norm_path"
+    if [ -n "$doc_line" ]; then
+        heading="$(echo "$doc_line" | cut -d'|' -f3)"
+        orig_path="$(echo "$doc_line" | cut -d'|' -f4)"
+    else
+        heading="$func"
+    fi
+
+    # Find service file location
+    location="$(find_endpoint_file "$func")"
+    service_file=""
+    service_line=""
+    if [ -n "$location" ]; then
+        service_file="${location%%:*}"
+        service_line="${location##*:}"
+    fi
+
+    # Generate slug for filename
+    slug="$(echo "${method}-${orig_path}" | tr '[:upper:]' '[:lower:]' | sed -E 's|/api/v1/fleet/||' | sed 's|[/:{}]|-|g' | sed 's|--*|-|g' | sed 's|-$||')"
+
+    # Lowercase method for tag
+    method_lower="$(echo "$method" | tr '[:upper:]' '[:lower:]')"
+
+    # Build concept file
+    cat > "$OUT_DIR/${slug}.md" <<CONCEPT_EOF
+---
+type: API Endpoint
+title: "${heading}"
+description: "${method} ${orig_path}"
+resource: "${orig_path}"
+tags:
+    - api
+    - ${method_lower}
+    - generated
+    - layer1
+generated: true
+generator: tools/okf/layer1-api-mapping.sh
+---
+
+## ${heading}
+
+\`${method} ${orig_path}\`
+
+### Code
+
+- **Endpoint function:** \`${func}\`
+CONCEPT_EOF
+
+    if [ -n "$service_file" ]; then
+        cat >> "$OUT_DIR/${slug}.md" <<CONCEPT_EOF
+- **Service file:** [${service_file}](../../${service_file})
+- **Line:** ${service_line}
+CONCEPT_EOF
+    fi
+
+    if [ -n "$doc_line" ]; then
+        anchor="$(echo "$heading" | tr '[:upper:]' '[:lower:]' | sed 's/ /-/g' | sed 's/[^a-z0-9-]//g')"
+        cat >> "$OUT_DIR/${slug}.md" <<CONCEPT_EOF
+
+### Documentation
+
+- [REST API docs](../../docs/REST%20API/rest-api.md#${anchor})
+CONCEPT_EOF
+    fi
+
+done < "$TMPDIR_WORK/routes.tsv"
+
+# --- Generate index.md ---
+cat > "$OUT_DIR/index.md" <<INDEX_HEADER
+---
+type: index
+title: API Endpoints
+description: Index of all Fleet REST API endpoints mapped to service code
+tags:
+    - api
+    - index
+    - generated
+    - layer1
+generated: true
+generator: tools/okf/layer1-api-mapping.sh
+---
+
+# API Endpoints
+
+${matched} endpoints matched to docs, ${code_only} code-only (undocumented).
+
+| Method | Path | Title | Service File |
+|--------|------|-------|-------------|
+INDEX_HEADER
+
+while IFS='|' read -r method norm_path func; do
+    key="${method}|${norm_path}"
+    doc_line="$(grep -F "$key" "$TMPDIR_WORK/docs.tsv" | head -1 || true)"
+    heading=""
+    orig_path="$norm_path"
+    if [ -n "$doc_line" ]; then
+        heading="$(echo "$doc_line" | cut -d'|' -f3)"
+        orig_path="$(echo "$doc_line" | cut -d'|' -f4)"
+    else
+        heading="$func"
+    fi
+    slug="$(echo "${method}-${orig_path}" | tr '[:upper:]' '[:lower:]' | sed -E 's|/api/v1/fleet/||' | sed 's|[/:{}]|-|g' | sed 's|--*|-|g' | sed 's|-$||')"
+
+    location="$(find_endpoint_file "$func")"
+    service_file=""
+    if [ -n "$location" ]; then
+        service_file="${location%%:*}"
+    fi
+
+    echo "| ${method} | \`${orig_path}\` | [${heading}](${slug}.md) | ${service_file} |" >> "$OUT_DIR/index.md"
+done < "$TMPDIR_WORK/routes.tsv"
+
+echo "Done. Wrote $total_to_write concept files + index.md to $OUT_DIR"

--- a/tools/okf/layer2-article-links.sh
+++ b/tools/okf/layer2-article-links.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+# Layer 2: Extract outbound links from articles to docs and guides
+# Generates OKF concept files in .okf/knowledge/article-links/
+#
+# Scans articles/*.md for links matching:
+#   - fleetdm.com/docs/...  → maps to docs/ directory
+#   - fleetdm.com/guides/... → maps to articles/ directory (guides are articles with category=guides)
+#
+# Produces one concept file per article that has outbound links,
+# plus an index.md for progressive disclosure.
+
+set -euo pipefail
+
+DRY_RUN=0
+if [ "${1:-}" = "--dry-run" ] || [ "${1:-}" = "-n" ]; then
+    DRY_RUN=1
+fi
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+ARTICLES_DIR="$REPO_ROOT/articles"
+DOCS_DIR="$REPO_ROOT/docs"
+OUT_DIR="$REPO_ROOT/.okf/knowledge/article-links"
+
+TMPDIR_WORK="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_WORK"' EXIT
+
+# --- Step 1: For each article, extract outbound doc/guide links ---
+# Output: article_file|link_type|url|local_path
+extract_links() {
+    for article in "$ARTICLES_DIR"/*.md; do
+        filename="$(basename "$article" .md)"
+
+        # Extract fleetdm.com/docs/ and /guides/ links
+        { grep -oE 'https://fleetdm\.com/(docs|guides)/[^ )"'"'"']*' "$article" 2>/dev/null || true; } | sort -u | while read -r url; do
+            # Strip trailing punctuation and anchors for file resolution
+            clean_url="$(echo "$url" | sed 's/#.*//' | sed 's/[.,;:)]*$//')"
+
+            if echo "$url" | grep -q 'fleetdm\.com/guides/'; then
+                # guides/slug → articles/slug.md
+                slug="$(echo "$clean_url" | sed 's|.*/guides/||')"
+                local_path="articles/${slug}.md"
+                link_type="guide"
+            else
+                # docs/section/slug → docs/Section/slug.md (case-insensitive lookup)
+                url_path="$(echo "$clean_url" | sed 's|.*/docs/||')"
+                # Try to find the file case-insensitively
+                local_path="$(find "$DOCS_DIR" -ipath "*/${url_path}.md" 2>/dev/null | head -1 | sed "s|$REPO_ROOT/||")"
+                if [ -z "$local_path" ]; then
+                    # Try without the section prefix (e.g., docs/rest-api/rest-api → docs/REST API/rest-api.md)
+                    slug="$(basename "$url_path")"
+                    local_path="$(find "$DOCS_DIR" -iname "${slug}.md" 2>/dev/null | head -1 | sed "s|$REPO_ROOT/||")"
+                fi
+                link_type="doc"
+            fi
+
+            echo "${filename}|${link_type}|${url}|${local_path}"
+        done
+    done
+}
+
+echo "Scanning articles for doc/guide links..."
+extract_links > "$TMPDIR_WORK/all_links.tsv"
+
+total_links="$(wc -l < "$TMPDIR_WORK/all_links.tsv" | tr -d ' ')"
+articles_with_links="$(cut -d'|' -f1 "$TMPDIR_WORK/all_links.tsv" | sort -u | wc -l | tr -d ' ')"
+doc_links="$(grep '|doc|' "$TMPDIR_WORK/all_links.tsv" | wc -l | tr -d ' ')"
+guide_links="$(grep '|guide|' "$TMPDIR_WORK/all_links.tsv" | wc -l | tr -d ' ')"
+resolved="$(awk -F'|' '$4 != ""' "$TMPDIR_WORK/all_links.tsv" | wc -l | tr -d ' ')"
+unresolved="$(awk -F'|' '$4 == ""' "$TMPDIR_WORK/all_links.tsv" | wc -l | tr -d ' ')"
+
+echo ""
+echo "=== Layer 2 Results ==="
+echo "Articles with links:    $articles_with_links"
+echo "Total links found:      $total_links"
+echo "  Doc links:            $doc_links"
+echo "  Guide links:          $guide_links"
+echo "Resolved to local file: $resolved"
+echo "Unresolved:             $unresolved"
+echo "Files to write:         $articles_with_links (+ index.md)"
+echo "Output directory:       $OUT_DIR"
+
+if [ "$DRY_RUN" -eq 1 ]; then
+    echo ""
+    echo "[DRY RUN] No files written. Run without --dry-run to generate concept files."
+    echo ""
+    echo "Sample (first 10 articles with links):"
+    cut -d'|' -f1 "$TMPDIR_WORK/all_links.tsv" | sort -u | head -10 | while read -r article; do
+        count="$(grep -c "^${article}|" "$TMPDIR_WORK/all_links.tsv")"
+        echo "  ${article}.md → ${count} links"
+    done
+    echo ""
+    echo "Sample unresolved links:"
+    awk -F'|' '$4 == ""' "$TMPDIR_WORK/all_links.tsv" | head -5 | while IFS='|' read -r article type url path; do
+        echo "  ${article}: ${url}"
+    done
+    exit 0
+fi
+
+# --- Generate concept files ---
+echo ""
+echo "Writing concept files..."
+mkdir -p "$OUT_DIR"
+
+cut -d'|' -f1 "$TMPDIR_WORK/all_links.tsv" | sort -u | while read -r article; do
+    # Get title from first heading in the article
+    title="$(head -5 "$ARTICLES_DIR/${article}.md" | grep -m1 '^# ' | sed 's/^# //' || echo "$article")"
+    if [ -z "$title" ]; then
+        title="$article"
+    fi
+
+    cat > "$OUT_DIR/${article}.md" <<CONCEPT_EOF
+---
+type: Article
+title: "${title}"
+description: "Links from articles/${article}.md to docs and guides"
+resource: "articles/${article}.md"
+tags:
+    - article
+    - generated
+    - layer2
+generated: true
+generator: tools/okf/layer2-article-links.sh
+---
+
+## ${title}
+
+Source: [articles/${article}.md](../../articles/${article}.md)
+
+### Links to docs and guides
+
+CONCEPT_EOF
+
+    grep "^${article}|" "$TMPDIR_WORK/all_links.tsv" | while IFS='|' read -r _ link_type url local_path; do
+        if [ -n "$local_path" ]; then
+            echo "- [${url}](../../${local_path})" >> "$OUT_DIR/${article}.md"
+        else
+            echo "- ${url} *(unresolved)*" >> "$OUT_DIR/${article}.md"
+        fi
+    done
+done
+
+# --- Generate index.md ---
+cat > "$OUT_DIR/index.md" <<INDEX_HEADER
+---
+type: index
+title: Article Links
+description: Index of Fleet articles and their outbound links to docs and guides
+tags:
+    - article
+    - index
+    - generated
+    - layer2
+generated: true
+generator: tools/okf/layer2-article-links.sh
+---
+
+# Article Links
+
+${articles_with_links} articles link to docs or guides. ${total_links} total links (${doc_links} to docs, ${guide_links} to guides).
+
+| Article | Doc Links | Guide Links | Total |
+|---------|-----------|-------------|-------|
+INDEX_HEADER
+
+cut -d'|' -f1 "$TMPDIR_WORK/all_links.tsv" | sort -u | while read -r article; do
+    d="$(grep -c "^${article}|doc|" "$TMPDIR_WORK/all_links.tsv" 2>/dev/null || echo 0)"
+    g="$(grep -c "^${article}|guide|" "$TMPDIR_WORK/all_links.tsv" 2>/dev/null || echo 0)"
+    t=$((d + g))
+    echo "| [${article}](${article}.md) | ${d} | ${g} | ${t} |" >> "$OUT_DIR/index.md"
+done
+
+echo "Done. Wrote $articles_with_links concept files + index.md to $OUT_DIR"


### PR DESCRIPTION
## OKF Knowledge Graph POC for Fleet

### What is this?

A proof-of-concept using Google's [Open Knowledge Format (OKF)](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) to build a precomputed knowledge graph for the Fleet codebase. The graph maps REST API endpoints → Go service code → documentation → articles, so AI coding agents can navigate the codebase by reading a few small index files instead of grepping through thousands of files.

### Why?

In benchmarks, Claude Code with the OKF graph completed the same task **~30% cheaper and ~5x faster** than without it:

| | Baseline | With OKF | Delta |
|---|---|---|---|
| Avg cost | $0.499 | $0.348 | **-30%** |
| Time | ~10 min | ~2 min | **-80%** |

### Prerequisites

```bash
# Install the OKF CLI
go install github.com/superops-team/okf/cmd/okf@latest

# 1. Initialize the code knowledge graph (~8 min, generates ~13K concept files)
okf init

# 2. Run Layer 1: map REST API docs ↔ handler.go routes ↔ service files
bash tools/okf/layer1-api-mapping.sh --dry-run   # preview
bash tools/okf/layer1-api-mapping.sh              # write 428 endpoint concepts

# 3. Run Layer 2: extract article → doc/guide links
bash tools/okf/layer2-article-links.sh --dry-run  # preview
bash tools/okf/layer2-article-links.sh             # write 287 article concepts

### setup
# 1. Initialize the code knowledge graph (~8 min, generates ~13K concept files)
okf init

# 2. Run Layer 1: map REST API docs ↔ handler.go routes ↔ service files
bash tools/okf/layer1-api-mapping.sh --dry-run   # preview
bash tools/okf/layer1-api-mapping.sh              # write 428 endpoint concepts

# 3. Run Layer 2: extract article → doc/guide links
bash tools/okf/layer2-article-links.sh --dry-run  # preview
bash tools/okf/layer2-article-links.sh             # write 287 article concepts
```

### what it produces
```
.okf/knowledge/
├── api-endpoints/          ← Layer 1: one concept per API route
│   ├── index.md            ← lookup table: method, path, title, service file
│   ├── get-hosts-id.md     ← links to service code + REST API docs
│   └── ...                 (428 files)
├── article-links/          ← Layer 2: one concept per article with outbound links
│   ├── index.md            ← lookup table: article, doc links, guide links
│   ├── apple-mdm-setup.md  ← links to referenced docs and guides
│   └── ...                 (287 files)
└── server/service/         ← okf init: code concepts with symbols + line numbers
    ├── activities.go.md
    └── ...                 (~13K files mirroring repo structure)
```


### How claude uses it
The Knowledge graph section in .claude/CLAUDE.md tells Claude to check .okf/knowledge/ before exploring the codebase. Example flow:


Agent gets task about GET /api/v1/fleet/hosts/:id
  → reads .okf/knowledge/api-endpoints/index.md (finds the row)
  → reads api-endpoints/get-hosts-id.md (gets: getHostEndpoint, hosts.go:848, doc link)
  → goes directly to server/service/hosts.go:848
  (skips: grepping handler.go, scanning 4586-line hosts.go, searching for docs)

### gaps
- Large files skipped — okf init doesn't index files above a size threshold (e.g., hosts.go, handler.go). No config to change this yet.
- 24 unmatched API endpoints — multi-line route registrations, SCIM endpoints in a separate router, path normalization edge cases. All mechanically fixable.
- 127 unresolved article links — stale URLs from docs reorganization and article renames.
- Layer 3 not implemented — keyword-based article → feature area tagging (stretch goal).
- No exclude option for okf init — can't skip directories like handbook/.
