### PR TITLE
Add Windows and macOS MDM enrollment count metrics to Datadog

### DIFF
--- a/website/scripts/send-aggregated-metrics-to-datadog.js
+++ b/website/scripts/send-aggregated-metrics-to-datadog.js
@@ -548,6 +548,52 @@ module.exports = {
       tags: [`license_tier:free`],
     });
 
+    // numHostsFleetMDMEnrolledWindows
+    let totalNumHostsFleetMDMEnrolledWindowsByPremiumInstances = _.sum(_.pluck(_.filter(latestStatisticsReportedByReleasedFleetVersions, {licenseTier: 'premium'}), 'numHostsFleetMDMEnrolledWindows'));
+    metricsToReport.push({
+      metric: 'usage_statistics.total_num_hosts_fleet_mdm_enrolled_windows',
+      type: 3,
+      points: [{
+        timestamp: timestampForTheseMetrics,
+        value: totalNumHostsFleetMDMEnrolledWindowsByPremiumInstances
+      }],
+      tags: [`license_tier:premium`],
+    });
+
+    let totalNumHostsFleetMDMEnrolledWindowsByFreeInstances = _.sum(_.pluck(_.filter(latestStatisticsReportedByReleasedFleetVersions, {licenseTier: 'free'}), 'numHostsFleetMDMEnrolledWindows'));
+    metricsToReport.push({
+      metric: 'usage_statistics.total_num_hosts_fleet_mdm_enrolled_windows',
+      type: 3,
+      points: [{
+        timestamp: timestampForTheseMetrics,
+        value: totalNumHostsFleetMDMEnrolledWindowsByFreeInstances
+      }],
+      tags: [`license_tier:free`],
+    });
+
+    // numHostsFleetMDMEnrolledMacOS
+    let totalNumHostsFleetMDMEnrolledMacOSByPremiumInstances = _.sum(_.pluck(_.filter(latestStatisticsReportedByReleasedFleetVersions, {licenseTier: 'premium'}), 'numHostsFleetMDMEnrolledMacOS'));
+    metricsToReport.push({
+      metric: 'usage_statistics.total_num_hosts_fleet_mdm_enrolled_macos',
+      type: 3,
+      points: [{
+        timestamp: timestampForTheseMetrics,
+        value: totalNumHostsFleetMDMEnrolledMacOSByPremiumInstances
+      }],
+      tags: [`license_tier:premium`],
+    });
+
+    let totalNumHostsFleetMDMEnrolledMacOSByFreeInstances = _.sum(_.pluck(_.filter(latestStatisticsReportedByReleasedFleetVersions, {licenseTier: 'free'}), 'numHostsFleetMDMEnrolledMacOS'));
+    metricsToReport.push({
+      metric: 'usage_statistics.total_num_hosts_fleet_mdm_enrolled_macos',
+      type: 3,
+      points: [{
+        timestamp: timestampForTheseMetrics,
+        value: totalNumHostsFleetMDMEnrolledMacOSByFreeInstances
+      }],
+      tags: [`license_tier:free`],
+    });
+
     // numUsers
     let fleetInstancesThatReportedNumUsers = _.filter(latestStatisticsReportedByReleasedFleetVersions, (statistics)=>{
       return statistics.numUsers > 0;
@@ -925,6 +971,56 @@ module.exports = {
       points: [{
         timestamp: timestampForTheseMetrics,
         value: highestNumberOfHostsFleetDesktopEnabled
+      }],
+    });
+
+    // numHostsFleetMDMEnrolledWindows
+    let fleetInstancesThatReportedNumHostsFleetMDMEnrolledWindows = _.filter(latestStatisticsReportedByReleasedFleetVersions, (statistics)=>{
+      return statistics.numHostsFleetMDMEnrolledWindows > 0;
+    });
+
+    let averageNumberOfHostsFleetMDMEnrolledWindows = Math.floor(_.sum(_.pluck(fleetInstancesThatReportedNumHostsFleetMDMEnrolledWindows, 'numHostsFleetMDMEnrolledWindows')) / fleetInstancesThatReportedNumHostsFleetMDMEnrolledWindows.length);
+    metricsToReport.push({
+      metric: 'usage_statistics.avg_num_hosts_fleet_mdm_enrolled_windows',
+      type: 1,
+      points: [{
+        timestamp: timestampForTheseMetrics,
+        value: averageNumberOfHostsFleetMDMEnrolledWindows
+      }],
+    });
+
+    let highestNumberOfHostsFleetMDMEnrolledWindows = _.max(_.pluck(fleetInstancesThatReportedNumHostsFleetMDMEnrolledWindows, 'numHostsFleetMDMEnrolledWindows'));
+    metricsToReport.push({
+      metric: 'usage_statistics.max_num_hosts_fleet_mdm_enrolled_windows',
+      type: 1,
+      points: [{
+        timestamp: timestampForTheseMetrics,
+        value: highestNumberOfHostsFleetMDMEnrolledWindows
+      }],
+    });
+
+    // numHostsFleetMDMEnrolledMacOS
+    let fleetInstancesThatReportedNumHostsFleetMDMEnrolledMacOS = _.filter(latestStatisticsReportedByReleasedFleetVersions, (statistics)=>{
+      return statistics.numHostsFleetMDMEnrolledMacOS > 0;
+    });
+
+    let averageNumberOfHostsFleetMDMEnrolledMacOS = Math.floor(_.sum(_.pluck(fleetInstancesThatReportedNumHostsFleetMDMEnrolledMacOS, 'numHostsFleetMDMEnrolledMacOS')) / fleetInstancesThatReportedNumHostsFleetMDMEnrolledMacOS.length);
+    metricsToReport.push({
+      metric: 'usage_statistics.avg_num_hosts_fleet_mdm_enrolled_macos',
+      type: 1,
+      points: [{
+        timestamp: timestampForTheseMetrics,
+        value: averageNumberOfHostsFleetMDMEnrolledMacOS
+      }],
+    });
+
+    let highestNumberOfHostsFleetMDMEnrolledMacOS = _.max(_.pluck(fleetInstancesThatReportedNumHostsFleetMDMEnrolledMacOS, 'numHostsFleetMDMEnrolledMacOS'));
+    metricsToReport.push({
+      metric: 'usage_statistics.max_num_hosts_fleet_mdm_enrolled_macos',
+      type: 1,
+      points: [{
+        timestamp: timestampForTheseMetrics,
+        value: highestNumberOfHostsFleetMDMEnrolledMacOS
       }],
     });
 


### PR DESCRIPTION
Closes #50975

Adds `numHostsFleetMDMEnrolledWindows` and `numHostsFleetMDMEnrolledMacOS` to the Datadog aggregation script. These fields are already collected and stored in `HistoricalUsageSnapshot` (PR #48840) but were not being forwarded to Datadog.

New metrics:
- `usage_statistics.total_num_hosts_fleet_mdm_enrolled_windows` (by license tier)
- `usage_statistics.total_num_hosts_fleet_mdm_enrolled_macos` (by license tier)
- `usage_statistics.avg_num_hosts_fleet_mdm_enrolled_windows`
- `usage_statistics.max_num_hosts_fleet_mdm_enrolled_windows`
- `usage_statistics.avg_num_hosts_fleet_mdm_enrolled_macos`
- `usage_statistics.max_num_hosts_fleet_mdm_enrolled_macos`

Follows the same pattern as existing numeric field metrics.

# Checklist for submitter

- [x] No user-visible changes (internal tooling only)

## Testing

- [ ] Verify metrics appear in Datadog after the next weekly aggregation run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added aggregated monitoring metrics for Windows and macOS devices enrolled through Fleet MDM.
  * Metrics are separated by premium and free license tiers.
  * Added average and maximum device-count metrics for each instance, excluding reports with zero or negative values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->