### PR TITLE
Fix Apple MDM reconciler resetting cursor too early

### DIFF
--- a/changes/fix-apple-mdm-batched-reconcile-cursor-wrap
+++ b/changes/fix-apple-mdm-batched-reconcile-cursor-wrap
@@ -1,0 +1,1 @@
+- Fixed a bug where the batched Apple MDM profile and declaration reconcilers could skip hosts on deployments with more than 5000 Apple MDM hosts and one or more duplicate hosts.

--- a/server/datastore/mysql/apple_mdm_batched.go
+++ b/server/datastore/mysql/apple_mdm_batched.go
@@ -18,6 +18,13 @@ import (
 // by uuid, along with the fields the batched reconciler needs to compute
 // desired state in memory.
 //
+// pageFull reports whether the underlying SQL page hit batchSize BEFORE the
+// Go-side dedupe below. Callers paginating with a cursor must use pageFull —
+// not len(hosts) — to decide whether more hosts may remain: duplicate-UUID
+// rows are collapsed after the LIMIT, so a full page can come back shorter
+// than batchSize, and treating that as the end of the host universe would
+// wrap the cursor early and starve every host later in the UUID ordering.
+//
 // Selection criteria mirror the host-side filters in the legacy desired-
 // state query (generateDesiredStateQuery): platform in (darwin, ios, ipados),
 // an enabled nano_enrollment of type Device or "User Enrollment (Device)",
@@ -27,7 +34,7 @@ func (ds *Datastore) listAppleMDMHostsForReconcileBatchTransaction(
 	tx common_mysql.DBReadTx,
 	afterHostUUID string,
 	batchSize int,
-) ([]*fleet.AppleHostReconcileInfo, error) {
+) (hosts []*fleet.AppleHostReconcileInfo, pageFull bool, err error) {
 	const stmt = `
 		SELECT
 			h.id              AS id,
@@ -53,9 +60,8 @@ func (ds *Datastore) listAppleMDMHostsForReconcileBatchTransaction(
 		LIMIT ?
 	`
 
-	var hosts []*fleet.AppleHostReconcileInfo
 	if err := sqlx.SelectContext(ctx, tx, &hosts, stmt, afterHostUUID, batchSize); err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "list apple mdm hosts for reconcile batch")
+		return nil, false, ctxerr.Wrap(ctx, err, "list apple mdm hosts for reconcile batch")
 	}
 
 	// In the rare case multiple hosts rows share the same UUID (e.g. from past bugs
@@ -63,7 +69,7 @@ func (ds *Datastore) listAppleMDMHostsForReconcileBatchTransaction(
 	// We dedupe in Go, keeping the highest host ID. The ORDER BY h.id DESC ensures
 	// that if a duplicate UUID lands on a page boundary, the highest-ID row is the
 	// one that makes it into the page.
-	return dedupeHostsByUUID(hosts), nil
+	return dedupeHostsByUUID(hosts), len(hosts) >= batchSize, nil
 }
 
 // dedupeHostsByUUID collapses reconcile records that share a UUID down to one,
@@ -419,11 +425,12 @@ func (ds *Datastore) GetAppleProfileReconcileSnapshot(
 	allProfiles []*fleet.AppleProfileForReconcile,
 	hostLabels map[uint]map[uint]struct{},
 	currentByHost map[string][]*fleet.MDMAppleProfilePayload,
+	pageFull bool,
 	err error,
 ) {
 	err = ds.withReadTx(ctx, func(tx common_mysql.DBReadTx) error {
 		var inner error
-		hosts, inner = ds.listAppleMDMHostsForReconcileBatchTransaction(ctx, tx, afterHostUUID, batchSize)
+		hosts, pageFull, inner = ds.listAppleMDMHostsForReconcileBatchTransaction(ctx, tx, afterHostUUID, batchSize)
 		if inner != nil {
 			return inner
 		}
@@ -470,9 +477,9 @@ func (ds *Datastore) GetAppleProfileReconcileSnapshot(
 		return inner
 	})
 	if err != nil {
-		return nil, nil, nil, nil, ctxerr.Wrap(ctx, err, "apple profile reconcile snapshot")
+		return nil, nil, nil, nil, false, ctxerr.Wrap(ctx, err, "apple profile reconcile snapshot")
 	}
-	return hosts, allProfiles, hostLabels, currentByHost, nil
+	return hosts, allProfiles, hostLabels, currentByHost, pageFull, nil
 }
 
 // GetMDMAppleReconcileCursor returns the persisted host_uuid cursor used by
@@ -911,11 +918,12 @@ func (ds *Datastore) GetAppleDeclarationReconcileSnapshot(
 	allDecls []*fleet.AppleDeclarationForReconcile,
 	hostLabels map[uint]map[uint]struct{},
 	currentByHost map[string][]*fleet.MDMAppleHostDeclaration,
+	pageFull bool,
 	err error,
 ) {
 	err = ds.withReadTx(ctx, func(tx common_mysql.DBReadTx) error {
 		var inner error
-		hosts, inner = ds.listAppleMDMHostsForReconcileBatchTransaction(ctx, tx, afterHostUUID, batchSize)
+		hosts, pageFull, inner = ds.listAppleMDMHostsForReconcileBatchTransaction(ctx, tx, afterHostUUID, batchSize)
 		if inner != nil {
 			return inner
 		}
@@ -962,9 +970,9 @@ func (ds *Datastore) GetAppleDeclarationReconcileSnapshot(
 		return inner
 	})
 	if err != nil {
-		return nil, nil, nil, nil, ctxerr.Wrap(ctx, err, "apple declaration reconcile snapshot")
+		return nil, nil, nil, nil, false, ctxerr.Wrap(ctx, err, "apple declaration reconcile snapshot")
 	}
-	return hosts, allDecls, hostLabels, currentByHost, nil
+	return hosts, allDecls, hostLabels, currentByHost, pageFull, nil
 }
 
 // GetMDMAppleDeclarationReconcileCursor / SetMDMAppleDeclarationReconcileCursor

--- a/server/datastore/mysql/apple_mdm_batched_test.go
+++ b/server/datastore/mysql/apple_mdm_batched_test.go
@@ -43,7 +43,7 @@ func TestGetAppleProfileReconcileSnapshotChecksMDMStatus(t *testing.T) {
 	// host_mdm.enrolled = 0 -> should NOT be returned.
 	notEnrolledHost := newEnrolledHost("not-enrolled", false)
 
-	hosts, _, _, _, err := ds.GetAppleProfileReconcileSnapshot(ctx, "", 100)
+	hosts, _, _, _, _, err := ds.GetAppleProfileReconcileSnapshot(ctx, "", 100)
 	require.NoError(t, err)
 
 	gotUUIDs := make(map[string]struct{}, len(hosts))
@@ -53,6 +53,80 @@ func TestGetAppleProfileReconcileSnapshotChecksMDMStatus(t *testing.T) {
 
 	require.Contains(t, gotUUIDs, enrolledHost.UUID, "host with host_mdm.enrolled = 1 should be returned")
 	require.NotContains(t, gotUUIDs, notEnrolledHost.UUID, "host with host_mdm.enrolled = 0 should not be returned")
+}
+
+func TestGetAppleProfileReconcileSnapshotPageFullWithDuplicateUUIDs(t *testing.T) {
+	ds := CreateMySQLDS(t)
+	ctx := t.Context()
+
+	newHost := func(suffix, uuid string) *fleet.Host {
+		h, err := ds.NewHost(ctx, &fleet.Host{
+			DetailUpdatedAt: time.Now(),
+			LabelUpdatedAt:  time.Now(),
+			PolicyUpdatedAt: time.Now(),
+			SeenTime:        time.Now(),
+			OsqueryHostID:   new("osquery-" + suffix),
+			NodeKey:         new("nodekey-" + suffix),
+			UUID:            uuid,
+			Hostname:        "hostname-" + suffix,
+			HardwareSerial:  "serial-" + suffix,
+			Platform:        "darwin",
+		})
+		require.NoError(t, err)
+		err = ds.SetOrUpdateMDMData(ctx, h.ID, false, true, "https://example.com", true, fleet.WellKnownMDMFleet, "", false)
+		require.NoError(t, err)
+		return h
+	}
+
+	// Three UUIDs in cursor order; the middle one has two hosts rows — the
+	// duplicate-enrollment state DEP re-enrollment can leave behind. The single
+	// nano enrollment for the shared UUID joins both rows, so the window query
+	// yields four raw rows: uuid-a, uuid-b (x2), uuid-c.
+	hA := newHost("a", "uuid-a")
+	nanoEnroll(t, ds, hA, false)
+	newHost("b1", "uuid-b")
+	hB2 := newHost("b2", "uuid-b")
+	nanoEnroll(t, ds, hB2, false)
+	hC := newHost("c", "uuid-c")
+	nanoEnroll(t, ds, hC, false)
+
+	// batchSize 3 fills the raw page with [uuid-a, uuid-b, uuid-b], which
+	// dedupes down to two hosts. pageFull must still report true: deciding
+	// end-of-universe from the deduped length wraps the cursor early and
+	// permanently starves every host past this page (here, uuid-c).
+	hosts, _, _, _, pageFull, err := ds.GetAppleProfileReconcileSnapshot(ctx, "", 3)
+	require.NoError(t, err)
+	require.Len(t, hosts, 2)
+	require.Equal(t, "uuid-a", hosts[0].UUID)
+	require.Equal(t, "uuid-b", hosts[1].UUID)
+	require.Equal(t, hB2.ID, hosts[1].HostID, "dedupe keeps the highest host id")
+	require.True(t, pageFull, "raw page hit the SQL limit, more hosts may remain")
+
+	// Resuming from the last deduped host reaches the previously-starved host.
+	hosts, _, _, _, pageFull, err = ds.GetAppleProfileReconcileSnapshot(ctx, hosts[len(hosts)-1].UUID, 3)
+	require.NoError(t, err)
+	require.Len(t, hosts, 1)
+	require.Equal(t, hC.UUID, hosts[0].UUID)
+	require.False(t, pageFull)
+
+	// The DDM snapshot shares the same host window; verify the same semantics.
+	dHosts, _, _, _, dPageFull, err := ds.GetAppleDeclarationReconcileSnapshot(ctx, "", 3)
+	require.NoError(t, err)
+	require.Len(t, dHosts, 2)
+	require.True(t, dPageFull, "raw page hit the SQL limit, more hosts may remain")
+
+	// A raw page made up entirely of one duplicated UUID still makes progress:
+	// pageFull is true, and the strict uuid > cursor pagination moves past
+	// every row sharing that UUID on the next call.
+	hosts, _, _, _, pageFull, err = ds.GetAppleProfileReconcileSnapshot(ctx, "uuid-a", 2)
+	require.NoError(t, err)
+	require.Len(t, hosts, 1)
+	require.Equal(t, "uuid-b", hosts[0].UUID)
+	require.True(t, pageFull, "raw page hit the SQL limit, more hosts may remain")
+	hosts, _, _, _, _, err = ds.GetAppleProfileReconcileSnapshot(ctx, hosts[0].UUID, 2)
+	require.NoError(t, err)
+	require.Len(t, hosts, 1)
+	require.Equal(t, hC.UUID, hosts[0].UUID)
 }
 
 func TestGetAppleMDMHostForReconcileIgnoresHostMDMStatus(t *testing.T) {

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -8662,7 +8662,7 @@ func testReconcileAppleProfilesDuplicateHostUUID(t *testing.T, ds *Datastore) {
 
 	// Source dedup: the reconcile snapshot must surface the UUID exactly once,
 	// keeping the highest host id.
-	hosts, _, _, _, err := ds.GetAppleProfileReconcileSnapshot(ctx, "", 5000)
+	hosts, _, _, _, _, err := ds.GetAppleProfileReconcileSnapshot(ctx, "", 5000)
 	require.NoError(t, err)
 	var forUUID []*fleet.AppleHostReconcileInfo
 	for _, h := range hosts {
@@ -8676,7 +8676,7 @@ func testReconcileAppleProfilesDuplicateHostUUID(t *testing.T, ds *Datastore) {
 	// Force the duplicate group across a batch boundary: with batchSize=1 the
 	// query returns a single row, and the h.id DESC tiebreak must make it the
 	// highest-id host rather than an arbitrary one.
-	boundaryHosts, _, _, _, err := ds.GetAppleProfileReconcileSnapshot(ctx, "", 1)
+	boundaryHosts, _, _, _, _, err := ds.GetAppleProfileReconcileSnapshot(ctx, "", 1)
 	require.NoError(t, err)
 	require.Len(t, boundaryHosts, 1)
 	require.Equal(t, hHigh.ID, boundaryHosts[0].HostID)

--- a/server/datastore/mysql/custom_host_vitals_test.go
+++ b/server/datastore/mysql/custom_host_vitals_test.go
@@ -772,7 +772,7 @@ func testReconcileSnapshotMarksVitalDeclarations(t *testing.T, ds *Datastore) {
 	}, nil)
 	require.NoError(t, err)
 
-	_, allDecls, _, _, err := ds.GetAppleDeclarationReconcileSnapshot(ctx, "", 100)
+	_, allDecls, _, _, _, err := ds.GetAppleDeclarationReconcileSnapshot(ctx, "", 100)
 	require.NoError(t, err)
 
 	byUUID := make(map[string]*fleet.AppleDeclarationForReconcile, len(allDecls))

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2605,7 +2605,10 @@ type Datastore interface {
 	// profiles, and current host_mdm_apple_profiles rows for the host window.
 	// All reads run inside a single read-only MySQL transaction so they
 	// observe one snapshot. If the host window is empty the remaining slices
-	// and maps are nil.
+	// and maps are nil. pageFull reports whether the underlying host page hit
+	// batchSize before same-UUID rows were deduplicated; cursor-paginating
+	// callers must use it (not len(hosts)) to decide whether more hosts may
+	// remain past this window.
 	GetAppleProfileReconcileSnapshot(
 		ctx context.Context,
 		afterHostUUID string,
@@ -2615,6 +2618,7 @@ type Datastore interface {
 		allProfiles []*AppleProfileForReconcile,
 		hostLabels map[uint]map[uint]struct{},
 		currentByHost map[string][]*MDMAppleProfilePayload,
+		pageFull bool,
 		err error,
 	)
 
@@ -2636,7 +2640,8 @@ type Datastore interface {
 	// declarations, and current host_mdm_apple_declarations rows for the
 	// host window. All reads run inside a single read-only MySQL
 	// transaction. If the host window is empty the remaining slices and
-	// maps are nil.
+	// maps are nil. pageFull has the same semantics as on
+	// GetAppleProfileReconcileSnapshot.
 	GetAppleDeclarationReconcileSnapshot(
 		ctx context.Context,
 		afterHostUUID string,
@@ -2646,6 +2651,7 @@ type Datastore interface {
 		allDecls []*AppleDeclarationForReconcile,
 		hostLabels map[uint]map[uint]struct{},
 		currentByHost map[string][]*MDMAppleHostDeclaration,
+		pageFull bool,
 		err error,
 	)
 

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1512,13 +1512,13 @@ type BulkGetHostLabelMembershipsFunc func(ctx context.Context, hostIDs []uint, l
 
 type BulkGetHostMDMAppleProfilesByUUIDsFunc func(ctx context.Context, hostUUIDs []string) (map[string][]*fleet.MDMAppleProfilePayload, error)
 
-type GetAppleProfileReconcileSnapshotFunc func(ctx context.Context, afterHostUUID string, batchSize int) (hosts []*fleet.AppleHostReconcileInfo, allProfiles []*fleet.AppleProfileForReconcile, hostLabels map[uint]map[uint]struct{}, currentByHost map[string][]*fleet.MDMAppleProfilePayload, err error)
+type GetAppleProfileReconcileSnapshotFunc func(ctx context.Context, afterHostUUID string, batchSize int) (hosts []*fleet.AppleHostReconcileInfo, allProfiles []*fleet.AppleProfileForReconcile, hostLabels map[uint]map[uint]struct{}, currentByHost map[string][]*fleet.MDMAppleProfilePayload, pageFull bool, err error)
 
 type GetMDMAppleReconcileCursorFunc func(ctx context.Context) (string, error)
 
 type SetMDMAppleReconcileCursorFunc func(ctx context.Context, cursor string) error
 
-type GetAppleDeclarationReconcileSnapshotFunc func(ctx context.Context, afterHostUUID string, batchSize int) (hosts []*fleet.AppleHostReconcileInfo, allDecls []*fleet.AppleDeclarationForReconcile, hostLabels map[uint]map[uint]struct{}, currentByHost map[string][]*fleet.MDMAppleHostDeclaration, err error)
+type GetAppleDeclarationReconcileSnapshotFunc func(ctx context.Context, afterHostUUID string, batchSize int) (hosts []*fleet.AppleHostReconcileInfo, allDecls []*fleet.AppleDeclarationForReconcile, hostLabels map[uint]map[uint]struct{}, currentByHost map[string][]*fleet.MDMAppleHostDeclaration, pageFull bool, err error)
 
 type BulkUpsertMDMAppleHostDeclarationsFunc func(ctx context.Context, rows []*fleet.MDMAppleHostDeclaration) error
 
@@ -10941,7 +10941,7 @@ func (s *DataStore) BulkGetHostMDMAppleProfilesByUUIDs(ctx context.Context, host
 	return s.BulkGetHostMDMAppleProfilesByUUIDsFunc(ctx, hostUUIDs)
 }
 
-func (s *DataStore) GetAppleProfileReconcileSnapshot(ctx context.Context, afterHostUUID string, batchSize int) (hosts []*fleet.AppleHostReconcileInfo, allProfiles []*fleet.AppleProfileForReconcile, hostLabels map[uint]map[uint]struct{}, currentByHost map[string][]*fleet.MDMAppleProfilePayload, err error) {
+func (s *DataStore) GetAppleProfileReconcileSnapshot(ctx context.Context, afterHostUUID string, batchSize int) (hosts []*fleet.AppleHostReconcileInfo, allProfiles []*fleet.AppleProfileForReconcile, hostLabels map[uint]map[uint]struct{}, currentByHost map[string][]*fleet.MDMAppleProfilePayload, pageFull bool, err error) {
 	s.mu.Lock()
 	s.GetAppleProfileReconcileSnapshotFuncInvoked = true
 	s.mu.Unlock()
@@ -10962,7 +10962,7 @@ func (s *DataStore) SetMDMAppleReconcileCursor(ctx context.Context, cursor strin
 	return s.SetMDMAppleReconcileCursorFunc(ctx, cursor)
 }
 
-func (s *DataStore) GetAppleDeclarationReconcileSnapshot(ctx context.Context, afterHostUUID string, batchSize int) (hosts []*fleet.AppleHostReconcileInfo, allDecls []*fleet.AppleDeclarationForReconcile, hostLabels map[uint]map[uint]struct{}, currentByHost map[string][]*fleet.MDMAppleHostDeclaration, err error) {
+func (s *DataStore) GetAppleDeclarationReconcileSnapshot(ctx context.Context, afterHostUUID string, batchSize int) (hosts []*fleet.AppleHostReconcileInfo, allDecls []*fleet.AppleDeclarationForReconcile, hostLabels map[uint]map[uint]struct{}, currentByHost map[string][]*fleet.MDMAppleHostDeclaration, pageFull bool, err error) {
 	s.mu.Lock()
 	s.GetAppleDeclarationReconcileSnapshotFuncInvoked = true
 	s.mu.Unlock()

--- a/server/service/apple_mdm_batched.go
+++ b/server/service/apple_mdm_batched.go
@@ -62,7 +62,7 @@ func ReconcileAppleProfilesBatched(
 		cursor = ""
 	}
 
-	hosts, allProfiles, hostLabels, currentByHost, err := ds.GetAppleProfileReconcileSnapshot(ctx, cursor, reconcileAppleProfilesBatchSize)
+	hosts, allProfiles, hostLabels, currentByHost, pageFull, err := ds.GetAppleProfileReconcileSnapshot(ctx, cursor, reconcileAppleProfilesBatchSize)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "loading apple profile reconcile snapshot")
 	}
@@ -79,8 +79,13 @@ func ReconcileAppleProfilesBatched(
 		return nil
 	}
 
+	// Advance the cursor whenever the underlying host page was full. Deciding
+	// from len(hosts) is wrong: duplicate-UUID host rows are collapsed after
+	// the SQL LIMIT, so a full page can dedupe to fewer than batchSize hosts —
+	// treating that as the end of the host universe wraps the cursor early and
+	// permanently starves every host later in the UUID ordering.
 	var nextCursor string
-	if len(hosts) >= reconcileAppleProfilesBatchSize {
+	if pageFull {
 		nextCursor = hosts[len(hosts)-1].UUID
 	}
 

--- a/server/service/apple_mdm_batched_test.go
+++ b/server/service/apple_mdm_batched_test.go
@@ -1,0 +1,76 @@
+package service
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
+	"github.com/fleetdm/fleet/v4/server/mdm/nanodep/tokenpki"
+	"github.com/fleetdm/fleet/v4/server/mock"
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReconcileAppleProfilesBatchedCursorAdvance(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	testCert, _, err := apple_mdm.NewSCEPCACertKey()
+	require.NoError(t, err)
+	testCertPEM := tokenpki.PEMCertificate(testCert.Raw)
+
+	newMockDS := func(snapshotHosts []*fleet.AppleHostReconcileInfo, pageFull bool) (*mock.Store, *string) {
+		ds := new(mock.Store)
+		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+			return &fleet.AppConfig{MDM: fleet.MDM{EnabledAndConfigured: true}}, nil
+		}
+		ds.GetAllMDMConfigAssetsByNameFunc = func(ctx context.Context, assetNames []fleet.MDMAssetName, _ sqlx.QueryerContext) (map[fleet.MDMAssetName]fleet.MDMConfigAsset, error) {
+			return map[fleet.MDMAssetName]fleet.MDMConfigAsset{
+				fleet.MDMAssetCACert: {Name: fleet.MDMAssetCACert, Value: testCertPEM},
+			}, nil
+		}
+		ds.AggregateEnrollSecretPerTeamFunc = func(ctx context.Context) ([]*fleet.EnrollSecret, error) {
+			return nil, nil
+		}
+		ds.BulkUpsertMDMAppleConfigProfilesFunc = func(ctx context.Context, payload []*fleet.MDMAppleConfigProfile) error {
+			return nil
+		}
+		ds.GetMDMAppleReconcileCursorFunc = func(ctx context.Context) (string, error) {
+			return "", nil
+		}
+		var savedCursor string
+		ds.SetMDMAppleReconcileCursorFunc = func(ctx context.Context, cursor string) error {
+			savedCursor = cursor
+			return nil
+		}
+		ds.GetAppleProfileReconcileSnapshotFunc = func(ctx context.Context, afterHostUUID string, batchSize int) ([]*fleet.AppleHostReconcileInfo, []*fleet.AppleProfileForReconcile, map[uint]map[uint]struct{}, map[string][]*fleet.MDMAppleProfilePayload, bool, error) {
+			return snapshotHosts, nil, nil, nil, pageFull, nil
+		}
+		return ds, &savedCursor
+	}
+
+	t.Run("full raw page that deduped below batch size still advances the cursor", func(t *testing.T) {
+		// One host survives dedupe out of a raw page that hit the SQL limit
+		// (duplicate-UUID rows collapsed). The cursor must advance to that
+		// host's UUID; wrapping to "" here is the bug that permanently starves
+		// every host later in the UUID ordering.
+		hosts := []*fleet.AppleHostReconcileInfo{{HostID: 2, UUID: "uuid-dup", Platform: "darwin"}}
+		ds, savedCursor := newMockDS(hosts, true)
+
+		require.NoError(t, ReconcileAppleProfilesBatched(ctx, ds, nil, nil, logger, 0))
+		require.True(t, ds.SetMDMAppleReconcileCursorFuncInvoked)
+		require.Equal(t, "uuid-dup", *savedCursor)
+	})
+
+	t.Run("short raw page wraps the cursor", func(t *testing.T) {
+		hosts := []*fleet.AppleHostReconcileInfo{{HostID: 2, UUID: "uuid-last", Platform: "darwin"}}
+		ds, _ := newMockDS(hosts, false)
+
+		require.NoError(t, ReconcileAppleProfilesBatched(ctx, ds, nil, nil, logger, 0))
+		// cursor was already "" and the page was short, so it stays "" (no write).
+		require.False(t, ds.SetMDMAppleReconcileCursorFuncInvoked)
+	})
+}

--- a/server/service/apple_mdm_declarations_batched.go
+++ b/server/service/apple_mdm_declarations_batched.go
@@ -49,7 +49,7 @@ func ReconcileAppleDeclarationsBatched(
 		cursor = ""
 	}
 
-	hosts, allDecls, hostLabels, currentByHost, err := ds.GetAppleDeclarationReconcileSnapshot(ctx, cursor, reconcileAppleDeclarationsBatchSize)
+	hosts, allDecls, hostLabels, currentByHost, pageFull, err := ds.GetAppleDeclarationReconcileSnapshot(ctx, cursor, reconcileAppleDeclarationsBatchSize)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "loading apple declaration reconcile snapshot")
 	}
@@ -66,8 +66,13 @@ func ReconcileAppleDeclarationsBatched(
 		return nil
 	}
 
+	// Advance the cursor whenever the underlying host page was full — not when
+	// len(hosts) hits the batch size. Duplicate-UUID host rows are collapsed
+	// after the SQL LIMIT, so a full page can dedupe to fewer than batchSize
+	// hosts; treating that as the end of the host universe wraps the cursor
+	// early and permanently starves every host later in the UUID ordering.
 	var nextCursor string
-	if len(hosts) >= reconcileAppleDeclarationsBatchSize {
+	if pageFull {
 		nextCursor = hosts[len(hosts)-1].UUID
 	}
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #50982

Fixes a bug where the reconciler would treat a batch as being the end of the list when there was a duplicate in it because after deduplication, fewer hosts than the page size would be returned, causing the cursor to wrap and be reset. Now the snapshot fetching function returns a boolean indicating whether or not the page was full before deduplication so that the caller can continue paginating rather than relying solely on the number of returned results

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually

Tested manually by decreasing the page size to 3(I have a bunch of UUIDs locally between VMs and devices) and adding a duplicate to the first page and confirming the reconciler kept traversing through all pages


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed batched Apple MDM profile and declaration reconciliation skipping hosts when deployments exceed 5,000 hosts and contain duplicate records.
  * Improved pagination so duplicate entries no longer cause reconciliation to stop prematurely.
  * Added safeguards to ensure cursors advance correctly across full batches and wrap appropriately at the end.

* **Tests**
  * Added coverage for duplicate records, cursor progression, deduplication, and large deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->