### PR TITLE
Orbit file download stall timeout and 30s context timeout

### DIFF
--- a/client/base_client.go
+++ b/client/base_client.go
@@ -296,9 +296,8 @@ func (f *FileResponse) Handle(resp *http.Response) error {
 	// unblock the io.Copy below. We surface the result as a DeadlineExceeded so
 	// callers treat it as transient/retryable (installer.isNetworkOrTransientError).
 	var stalled atomic.Bool
+	stopWatchdog := make(chan struct{})
 	if f.StallTimeout > 0 {
-		stopWatchdog := make(chan struct{})
-		defer close(stopWatchdog)
 		checkInterval := f.stallCheckInterval
 		if checkInterval <= 0 {
 			checkInterval = defaultStallCheckInterval
@@ -322,6 +321,10 @@ func (f *FileResponse) Handle(resp *http.Response) error {
 	}
 
 	_, err = io.Copy(destFile, respBodyReader)
+	// Once io.Copy returns, stop the watchdog goroutine so it doesn't leak.
+	if f.StallTimeout > 0 {
+		close(stopWatchdog)
+	}
 	if stalled.Load() {
 		return fmt.Errorf("download stalled: no data received for %s: %w", f.StallTimeout, context.DeadlineExceeded)
 	}

--- a/client/base_client.go
+++ b/client/base_client.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
@@ -14,6 +15,8 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
+	"time"
 
 	"github.com/fleetdm/fleet/v4/pkg/fleethttp"
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -21,6 +24,11 @@ import (
 )
 
 var ErrInvalidScheme = errors.New("address must start with https:// for remote connections")
+
+// defaultStallCheckInterval is the floor for how often the download stall
+// watchdog polls for progress. The watchdog ticks at max(StallTimeout/4, floor),
+// so it only takes effect for sub-4s timeouts (i.e. tests).
+const defaultStallCheckInterval = time.Second
 
 // HTTPClient interface allows the HTTP methods to be mocked.
 type HTTPClient interface {
@@ -226,6 +234,14 @@ type FileResponse struct {
 	DestFilePath  string
 	SkipMediaType bool
 	ProgressFunc  func(n int)
+	// StallTimeout, if > 0, aborts the download when no bytes are read for this
+	// duration. Any read resets the clock, so a slow-but-progressing transfer is
+	// never aborted; only a silently stalled connection (e.g. a network filter
+	// dropping packets) is. Zero disables the watchdog.
+	StallTimeout time.Duration
+	// stallCheckInterval overrides the stall watchdog's poll floor. Zero uses
+	// defaultStallCheckInterval; tests set it small to exercise the watchdog fast.
+	stallCheckInterval time.Duration
 }
 
 func (f *FileResponse) Handle(resp *http.Response) error {
@@ -256,15 +272,59 @@ func (f *FileResponse) Handle(resp *http.Response) error {
 	}
 	defer destFile.Close()
 
+	// Track the time of the last read so a stall watchdog can distinguish a
+	// silently stalled connection from a slow-but-progressing one.
+	var lastProgress atomic.Int64
+	lastProgress.Store(time.Now().UnixNano())
+
 	var respBodyReader io.Reader = resp.Body
-	if f.ProgressFunc != nil {
+	if f.ProgressFunc != nil || f.StallTimeout > 0 {
 		respBodyReader = &progressReader{
-			Reader:       respBodyReader,
-			progressFunc: f.ProgressFunc,
+			Reader: respBodyReader,
+			progressFunc: func(n int) {
+				if n > 0 {
+					lastProgress.Store(time.Now().UnixNano())
+				}
+				if f.ProgressFunc != nil {
+					f.ProgressFunc(n)
+				}
+			},
 		}
 	}
 
+	// Stall watchdog: if no bytes are read for StallTimeout, close the body to
+	// unblock the io.Copy below. We surface the result as a DeadlineExceeded so
+	// callers treat it as transient/retryable (installer.isNetworkOrTransientError).
+	var stalled atomic.Bool
+	if f.StallTimeout > 0 {
+		stopWatchdog := make(chan struct{})
+		defer close(stopWatchdog)
+		checkInterval := f.stallCheckInterval
+		if checkInterval <= 0 {
+			checkInterval = defaultStallCheckInterval
+		}
+		go func() {
+			ticker := time.NewTicker(max(f.StallTimeout/4, checkInterval))
+			defer ticker.Stop()
+			for {
+				select {
+				case <-stopWatchdog:
+					return
+				case <-ticker.C:
+					if time.Since(time.Unix(0, lastProgress.Load())) >= f.StallTimeout {
+						stalled.Store(true)
+						resp.Body.Close()
+						return
+					}
+				}
+			}
+		}()
+	}
+
 	_, err = io.Copy(destFile, respBodyReader)
+	if stalled.Load() {
+		return fmt.Errorf("download stalled: no data received for %s: %w", f.StallTimeout, context.DeadlineExceeded)
+	}
 	if err != nil {
 		return fmt.Errorf("copying from http stream to file: %w", err)
 	}

--- a/client/base_client.go
+++ b/client/base_client.go
@@ -212,6 +212,7 @@ func NewBaseClient(
 	if signerWrapper != nil {
 		httpClient = signerWrapper(httpClient)
 	}
+
 	client := &BaseClient{
 		BaseURL:            baseURL,
 		HTTP:               httpClient,
@@ -272,10 +273,7 @@ func (f *FileResponse) Handle(resp *http.Response) error {
 	}
 	defer destFile.Close()
 
-	// Track the time of the last read so a stall watchdog can distinguish a
-	// silently stalled connection from a slow-but-progressing one.
-	var lastProgress atomic.Int64
-	lastProgress.Store(time.Now().UnixNano())
+	var bytesRead atomic.Int64
 
 	var respBodyReader io.Reader = resp.Body
 	if f.ProgressFunc != nil || f.StallTimeout > 0 {
@@ -283,7 +281,7 @@ func (f *FileResponse) Handle(resp *http.Response) error {
 			Reader: respBodyReader,
 			progressFunc: func(n int) {
 				if n > 0 {
-					lastProgress.Store(time.Now().UnixNano())
+					bytesRead.Add(int64(n))
 				}
 				if f.ProgressFunc != nil {
 					f.ProgressFunc(n)
@@ -305,15 +303,26 @@ func (f *FileResponse) Handle(resp *http.Response) error {
 		go func() {
 			ticker := time.NewTicker(max(f.StallTimeout/4, checkInterval))
 			defer ticker.Stop()
+			lastSeen := bytesRead.Load()
+			var stalledAt time.Time
 			for {
 				select {
 				case <-stopWatchdog:
 					return
 				case <-ticker.C:
-					if time.Since(time.Unix(0, lastProgress.Load())) >= f.StallTimeout {
-						stalled.Store(true)
-						resp.Body.Close()
-						return
+					current := bytesRead.Load()
+					if current == lastSeen {
+						if stalledAt.IsZero() {
+							stalledAt = time.Now()
+						}
+						if time.Since(stalledAt) >= f.StallTimeout {
+							stalled.Store(true)
+							resp.Body.Close()
+							return
+						}
+					} else {
+						lastSeen = current
+						stalledAt = time.Time{}
 					}
 				}
 			}
@@ -325,10 +334,10 @@ func (f *FileResponse) Handle(resp *http.Response) error {
 	if f.StallTimeout > 0 {
 		close(stopWatchdog)
 	}
-	if stalled.Load() {
-		return fmt.Errorf("download stalled: no data received for %s: %w", f.StallTimeout, context.DeadlineExceeded)
-	}
 	if err != nil {
+		if stalled.Load() {
+			return fmt.Errorf("download stalled: no data received for %s: %w", f.StallTimeout, context.DeadlineExceeded)
+		}
 		return fmt.Errorf("copying from http stream to file: %w", err)
 	}
 

--- a/client/base_client_stall_test.go
+++ b/client/base_client_stall_test.go
@@ -1,0 +1,108 @@
+package client
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// blockingReader serves `data`, then blocks every subsequent Read until Close
+// is called — simulating a connection that stalls mid-download.
+type blockingReader struct {
+	data      []byte
+	pos       int
+	closed    chan struct{}
+	closeOnce sync.Once
+}
+
+func (r *blockingReader) Read(p []byte) (int, error) {
+	if r.pos < len(r.data) {
+		n := copy(p, r.data[r.pos:])
+		r.pos += n
+		return n, nil
+	}
+	<-r.closed // block until the stall watchdog closes the body
+	return 0, io.ErrClosedPipe
+}
+
+func (r *blockingReader) Close() error {
+	r.closeOnce.Do(func() { close(r.closed) })
+	return nil
+}
+
+// trickleReader delivers `chunks` single bytes, sleeping `delay` before each —
+// simulating a slow-but-healthy download.
+type trickleReader struct {
+	chunks int
+	delay  time.Duration
+	sent   int
+}
+
+func (r *trickleReader) Read(p []byte) (int, error) {
+	if r.sent >= r.chunks {
+		return 0, io.EOF
+	}
+	time.Sleep(r.delay)
+	r.sent++
+	p[0] = 'x'
+	return 1, nil
+}
+
+func (r *trickleReader) Close() error { return nil }
+
+func fileResp(dir string, body io.ReadCloser, stall time.Duration) (*FileResponse, *http.Response) {
+	fr := &FileResponse{DestPath: dir, StallTimeout: stall}
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       body,
+		Header:     http.Header{"Content-Disposition": []string{`attachment;filename="installer.pkg"`}},
+	}
+	return fr, resp
+}
+
+func TestFileResponseStallTimeout(t *testing.T) {
+	t.Run("aborts a stalled download as a retryable timeout", func(t *testing.T) {
+		fr, resp := fileResp(t.TempDir(), &blockingReader{data: []byte("partial"), closed: make(chan struct{})}, 500*time.Millisecond)
+		// Shorten the watchdog poll floor so the sub-second stall is caught fast.
+		fr.stallCheckInterval = 50 * time.Millisecond
+
+		start := time.Now()
+		err := fr.Handle(resp)
+		elapsed := time.Since(start)
+
+		require.Error(t, err)
+		// Must be classified transient so the installer retries instead of failing setup.
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.GreaterOrEqual(t, elapsed, 400*time.Millisecond, "should wait ~StallTimeout before aborting")
+		require.Less(t, elapsed, 3*time.Second, "should abort, not hang")
+	})
+
+	t.Run("does not abort a slow-but-progressing download", func(t *testing.T) {
+		// Bytes arrive every 200ms, well under the 1s stall timeout.
+		fr, resp := fileResp(t.TempDir(), &trickleReader{chunks: 5, delay: 200 * time.Millisecond}, 1*time.Second)
+
+		err := fr.Handle(resp)
+		require.NoError(t, err)
+
+		data, err := os.ReadFile(fr.DestFilePath)
+		require.NoError(t, err)
+		require.Len(t, data, 5, "the full download should have completed")
+	})
+
+	t.Run("disabled when StallTimeout is zero (progress path unchanged)", func(t *testing.T) {
+		fr, resp := fileResp(t.TempDir(), &trickleReader{chunks: 3, delay: 10 * time.Millisecond}, 0)
+
+		err := fr.Handle(resp)
+		require.NoError(t, err)
+
+		data, err := os.ReadFile(fr.DestFilePath)
+		require.NoError(t, err)
+		require.Len(t, data, 3)
+	})
+}

--- a/client/orbit_client.go
+++ b/client/orbit_client.go
@@ -115,10 +115,12 @@ func (oc *OrbitClient) SetOpenSSOWindowFunc(f func() error) {
 }
 
 func (oc *OrbitClient) request(verb string, path string, params any, resp any) error {
-	return oc.requestWithExternal(context.Background(), verb, path, params, resp, false)
-}
-
-func (oc *OrbitClient) requestWithContext(ctx context.Context, verb string, path string, params any, resp any) error {
+	ctx := context.Background()
+	if _, ok := resp.(BodyHandler); ok {
+		timeoutCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+		ctx = timeoutCtx
+	}
 	return oc.requestWithExternal(ctx, verb, path, params, resp, false)
 }
 
@@ -759,15 +761,7 @@ func (oc *OrbitClient) authenticatedRequest(verb string, path string, params any
 	s := params.(fleet.SetOrbitNodeKeyer)
 	s.SetOrbitNodeKey(nodeKey)
 
-	if _, ok := resp.(*FileResponse); ok {
-		// Handle file response here if needed
-		err = oc.request(verb, path, params, resp)
-	} else {
-		// if not FileResponse, set context with timeout of 30 seconds for all other requests.
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-		err = oc.requestWithContext(ctx, verb, path, params, resp)
-	}
+	err = oc.request(verb, path, params, resp)
 	switch {
 	case err == nil:
 		oc.setEnrolled(true)

--- a/client/orbit_client.go
+++ b/client/orbit_client.go
@@ -115,12 +115,16 @@ func (oc *OrbitClient) SetOpenSSOWindowFunc(f func() error) {
 }
 
 func (oc *OrbitClient) request(verb string, path string, params any, resp any) error {
-	return oc.requestWithExternal(verb, path, params, resp, false)
+	return oc.requestWithExternal(context.Background(), verb, path, params, resp, false)
+}
+
+func (oc *OrbitClient) requestWithContext(ctx context.Context, verb string, path string, params any, resp any) error {
+	return oc.requestWithExternal(ctx, verb, path, params, resp, false)
 }
 
 // requestWithExternal is used to make requests to Fleet or external URLs. If external is true, the pathOrURL
 // is used as the full URL to make the request to.
-func (oc *OrbitClient) requestWithExternal(verb string, pathOrURL string, params any, resp any, external bool) error {
+func (oc *OrbitClient) requestWithExternal(ctx context.Context, verb string, pathOrURL string, params any, resp any, external bool) error {
 	var bodyBytes []byte
 	var err error
 	if params != nil {
@@ -132,7 +136,6 @@ func (oc *OrbitClient) requestWithExternal(verb string, pathOrURL string, params
 
 	oc.closeIdleConnections()
 
-	ctx := context.Background()
 	if os.Getenv("FLEETD_TEST_HTTPTRACE") == "1" {
 		ctx = httptrace.WithClientTrace(ctx, testStdoutHTTPTracer)
 	}
@@ -193,6 +196,10 @@ var (
 	configRetryOnNetworkError          = 30 * time.Second
 	defaultOrbitConfigReceiverInterval = 30 * time.Second
 	maxConfigBackoff                   = 5 * time.Minute
+	// downloadStallTimeout bounds a software-installer download that makes no
+	// progress (e.g. a network filter dropping packets mid-transfer). It resets
+	// on any received bytes, so slow-but-healthy downloads are unaffected.
+	downloadStallTimeout = 60 * time.Second
 )
 
 // NewOrbitClient creates a new OrbitClient.
@@ -499,6 +506,7 @@ func (oc *OrbitClient) DownloadSoftwareInstaller(installerID uint, downloadDirec
 	resp := FileResponse{
 		DestPath:     downloadDirectory,
 		ProgressFunc: progressFunc,
+		StallTimeout: downloadStallTimeout,
 	}
 	if err := oc.authenticatedRequest(verb, path, &fleet.OrbitDownloadSoftwareInstallerRequest{
 		InstallerID: installerID,
@@ -514,8 +522,9 @@ func (oc *OrbitClient) DownloadSoftwareInstallerFromURL(url string, filename str
 		DestFile:      filename,
 		SkipMediaType: true,
 		ProgressFunc:  progressFunc,
+		StallTimeout:  downloadStallTimeout,
 	}
-	if err := oc.requestWithExternal("GET", url, nil, &resp, true); err != nil {
+	if err := oc.requestWithExternal(context.Background(), "GET", url, nil, &resp, true); err != nil {
 		return "", err
 	}
 	return resp.GetFilePath(), nil
@@ -750,7 +759,15 @@ func (oc *OrbitClient) authenticatedRequest(verb string, path string, params any
 	s := params.(fleet.SetOrbitNodeKeyer)
 	s.SetOrbitNodeKey(nodeKey)
 
-	err = oc.request(verb, path, params, resp)
+	if _, ok := resp.(*FileResponse); ok {
+		// Handle file response here if needed
+		err = oc.request(verb, path, params, resp)
+	} else {
+		// if not FileResponse, set context with timeout of 30 seconds for all other requests.
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		err = oc.requestWithContext(ctx, verb, path, params, resp)
+	}
 	switch {
 	case err == nil:
 		oc.setEnrolled(true)

--- a/client/orbit_client.go
+++ b/client/orbit_client.go
@@ -116,7 +116,7 @@ func (oc *OrbitClient) SetOpenSSOWindowFunc(f func() error) {
 
 func (oc *OrbitClient) request(verb string, path string, params any, resp any) error {
 	ctx := context.Background()
-	if _, ok := resp.(BodyHandler); ok {
+	if _, ok := resp.(BodyHandler); !ok {
 		timeoutCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
 		ctx = timeoutCtx

--- a/orbit/changes/46801-context-timeout-stall-file-download
+++ b/orbit/changes/46801-context-timeout-stall-file-download
@@ -1,0 +1,2 @@
+- Added 30s context timeout to all orbit requests to avoid stalling by retrying requests.
+- Added 60s stall timeout to file downloads to avoid stalling by retrying requests.

--- a/pkg/fleethttp/fleethttp.go
+++ b/pkg/fleethttp/fleethttp.go
@@ -264,6 +264,8 @@ func NewTransport(opts ...TransportOpt) *http.Transport {
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,
 	})
+	// Timeout on response headers missing after fully sending the request if 30 seconds pass.
+	tr.ResponseHeaderTimeout = 30 * time.Second
 	return tr
 }
 

--- a/pkg/fleethttp/fleethttp.go
+++ b/pkg/fleethttp/fleethttp.go
@@ -264,8 +264,8 @@ func NewTransport(opts ...TransportOpt) *http.Transport {
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,
 	})
-	// Timeout on response headers missing after fully sending the request if 30 seconds pass.
-	tr.ResponseHeaderTimeout = 30 * time.Second
+	// Timeout on response headers missing after fully sending the request if 45 seconds pass.
+	tr.ResponseHeaderTimeout = 45 * time.Second
 	return tr
 }
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #46801


The 30s context timeout can be tested with the package in the issue. The speculative software download stall timeout I was unable to repro with actual packages/files.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File downloads now detect stalled transfers and stop after a configurable timeout.
  * Download progress continues to be reported while data is received.
  * Installer downloads enforce a 60-second no-progress timeout.
* **Bug Fixes**
  * Requests that stop responding now time out after 30 seconds.
  * Response headers time out after 45 seconds.
  * Slow downloads that continue making progress can complete successfully.
* **Documentation**
  * Added guidance on request and download timeout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->