### PR TITLE
Fix malformed JSON examples and status lines in REST API docs

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -7366,7 +7366,7 @@ List all assets available for the "Unassigned" fleet.
       "identifier": "com.example.asset1",
       "created_at": "2023-03-31T00:00:00Z",
       "updated_at": "2023-03-31T00:00:00Z",
-      "checksum": "dGVzdAo=",
+      "checksum": "dGVzdAo="
     },
     {
       "asset_uuid": "39f6cbbc-fe7b-4adc-b7a9-542d1af89c63",
@@ -7374,9 +7374,9 @@ List all assets available for the "Unassigned" fleet.
       "identifier": "com.example.asset2",
       "created_at": "2023-03-31T00:00:00Z",
       "updated_at": "2023-03-31T00:00:00Z",
-      "checksum": "dGVzdAo=",
-    },
-  ],
+      "checksum": "dGVzdAo="
+    }
+  ]
 }
 ```
 
@@ -7618,7 +7618,7 @@ If a host is missing the IdP data a variable needs, that host's rename fails. A 
 
 ##### Default response
 
-`204`
+`Status: 204`
 
 ### Resend host name template
 
@@ -8525,9 +8525,7 @@ Edit managed local account enforcement settings for eligible hosts.
 
 `POST /api/v1/fleet/managed_local_account`
 
-##### Default response
-
-`204`
+##### Request body
 
 ```json
 {
@@ -8536,6 +8534,10 @@ Edit managed local account enforcement settings for eligible hosts.
   "end_user_local_account_type": "admin"
 }
 ```
+
+##### Default response
+
+`Status: 204`
 
 ---
 
@@ -13682,7 +13684,7 @@ To get the results of an Apple App Store app install, use the [List MDM commands
    "host_id": 123,
    "host_display_name": "Marko's MacBook Pro",
    "status": "failed_install",
-   "output": "Installing software...\nError: The operation can’t be completed because the item "Falcon" is in use.",
+   "output": "Installing software...\nError: The operation can’t be completed because the item \"Falcon\" is in use.",
    "pre_install_query_output": "Query returned result\nSuccess",
    "post_install_script_output": "Running script...\nExit code: 1 (Failed)\nRolling back software install...\nSuccess"
  }
@@ -14380,7 +14382,7 @@ _Available in Fleet Premium_
         ],
         "managed_local_account_settings": {
           "enabled": true
-        },
+        }
       },
       "windows_settings": {
         "custom_settings": [
@@ -14397,7 +14399,7 @@ _Available in Fleet Premium_
         ],
         "managed_local_account_settings": {
           "enabled": true
-        },
+        }
       },
       "macos_setup": {
         "bootstrap_package": "",


### PR DESCRIPTION
Fixes five malformed examples in the REST API reference, four introduced in the v4.90.0 doc changes (#48141) and one from the v4.85.0 doc changes (#41153):

- **List Apple asset declarations**: trailing commas in the response example JSON
- **Get software install result**: unescaped double quotes inside a JSON string value
- **Get fleet**: trailing commas after both `managed_local_account_settings` objects
- **Update host name template**: response documented as `` `204` `` instead of `` `Status: 204` ``
- **Update managed local account**: the request body example was nested under the "Default response" heading with a bare `` `204` ``; moved it to a "Request body" section and fixed the status line

These render as invalid JSON on fleetdm.com today, and they fail the OpenAPI generator in #50359. Merging these docs fixes separately keeps main's docs correct regardless of when that PR lands.

# Checklist for submitter

- [x] Manually verified the affected sections still render correctly (docs-only change; no code affected)
