### PR TITLE
Move orbit changelog entries for #50114 and #50996 into orbit/changes

### DIFF
--- a/changes/41470-python-script-only-followups
+++ b/changes/41470-python-script-only-followups
@@ -3,4 +3,3 @@
 - Allowed `.py` script-only packages to be assigned a `setup_experience_platform` (`darwin` or `linux`), matching `.sh`.
 - Added a diagnostic message when an install script can't be run (exit code -1) — e.g. when the interpreter in its shebang is missing on the host — instead of reporting no output.
 - Fixed the install rejection message for `.sh`/`.py` script packages to say they can be installed on macOS and Linux hosts, rather than Linux only.
-- Fixed `.py` package install scripts being written to the host with a `.sh` extension, which produced misleading Python tracebacks.

--- a/orbit/changes/50114-py-script-temp-file-extension
+++ b/orbit/changes/50114-py-script-temp-file-extension
@@ -1,0 +1,1 @@
+* Fixed `.py` package install scripts being written to the host with a `.sh` extension, which produced misleading Python tracebacks.

--- a/orbit/changes/50996-surface-execve-error
+++ b/orbit/changes/50996-surface-execve-error
@@ -1,0 +1,1 @@
+* Added the underlying execution error to an install script's output when the script can't be run at all (exit code -1), so the failure names the interpreter that couldn't be resolved instead of reporting nothing.


### PR DESCRIPTION
**Related issues:** Resolves #50114, Resolves #50996

Changelog-only. The behavior changes already merged in #50143 (`a442d7af3a`); this PR files their changelog entries under `orbit/changes/` so they land in the fleetd release notes instead of the Fleet server changelog, and so each one is pinned to a fleetd milestone. Same correction as #50208.

Both changes are agent-side and reach hosts with **fleetd 1.60.0** — `a442d7af3a` is in `rc-minor-fleetd-v1.60.0` (cut Aug 10) but not in `rc-minor-fleetd-v1.59.0` (cut Jul 20), and `git tag --contains a442d7af3a` is empty.

- `orbit/changes/50114-py-script-temp-file-extension` — orbit names each install/post-install/rollback temp script from its own shebang, so a `.py` package's script is written as `install-script.py` (#50114). This is entirely orbit; its bullet is removed from `changes/41470-python-script-only-followups`.
- `orbit/changes/50996-surface-execve-error` — orbit folds the execve error into the install-script output when a script can't run at all (exit code `-1`), so the server's diagnostic names the interpreter that failed to resolve (#50996, the orbit half of #50108).

`changes/41470-python-script-only-followups` keeps the four server/frontend bullets, including #50108's — the `-1` diagnostic copy (`SoftwareInstallerScriptCouldNotRunCopy`) is rendered server-side and does ship in 4.91.0; only the trailing detail comes from the agent.

Verification of #50114 on a host (2026-08-10), against orbit built from `main` (`50114.1.1022`, commit `3b47482cbc392c89f9f830c58428cbcb01a93dcf`); the same host on released orbit 1.57.0 beforehand reproduced the old `.sh` name:

```
FLEET-QA-50114 argv0   = /tmp/323012496/install-script.py
FLEET-QA-50114 listing = ['fleet-qa-50114-boom.py', 'install-script.py']
Traceback (most recent call last):
  File "/tmp/323012496/install-script.py", line 8, in <module>
    fleet_qa_50114_undefined_symbol
NameError: name 'fleet_qa_50114_undefined_symbol' is not defined
```

Regressions on the same build: a `.sh` script package still gets `install-script.sh` and installs; a `.deb` still installs; a `.py` package with a failing post-install produces `install-script.py` + `post-install-script.sh` + `rollback-script.sh`.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually

No code changes, so no new automated tests; the merged behavior is covered by `TestScriptFileExtension`, `TestAttemptInstallScriptExtension` and `TestRunInstallerScriptSurfacesExecveError` in `orbit/pkg/installer/installer_test.go`.

## fleetd/orbit/Fleet Desktop

- [x] Verified compatibility with the latest released version of Fleet (changelog only; the server↔agent `SoftwareInstallDetails` contract is unchanged)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that Python package installation scripts are written with a `.py` extension, avoiding misleading shell-script traceback references.
  - Documented that installation-script failures with exit code `-1` now include the underlying execution error, such as an unavailable interpreter.
  - Removed an outdated note describing Python scripts as being written with a `.sh` extension.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->