### PR TITLE
For fleetd 1.60 RC: Move orbit changelog entries for #50114 and #50996 into orbit/changes

### DIFF
--- a/changes/41470-python-script-only-followups
+++ b/changes/41470-python-script-only-followups
@@ -3,4 +3,3 @@
 - Allowed `.py` script-only packages to be assigned a `setup_experience_platform` (`darwin` or `linux`), matching `.sh`.
 - Added a diagnostic message when an install script can't be run (exit code -1) — e.g. when the interpreter in its shebang is missing on the host — instead of reporting no output.
 - Fixed the install rejection message for `.sh`/`.py` script packages to say they can be installed on macOS and Linux hosts, rather than Linux only.
-- Fixed `.py` package install scripts being written to the host with a `.sh` extension, which produced misleading Python tracebacks.

--- a/orbit/changes/50114-py-script-temp-file-extension
+++ b/orbit/changes/50114-py-script-temp-file-extension
@@ -1,0 +1,1 @@
+* Fixed `.py` package install scripts being written to the host with a `.sh` extension, which produced misleading Python tracebacks.

--- a/orbit/changes/50996-surface-execve-error
+++ b/orbit/changes/50996-surface-execve-error
@@ -1,0 +1,1 @@
+* Added the underlying execution error to an install script's output when the script can't be run at all (exit code -1), so the failure names the interpreter that couldn't be resolved instead of reporting nothing.


### PR DESCRIPTION
Cherry-pick of #50999 into the fleetd 1.60.0 RC branch, so `make changelog-orbit` picks up both entries when the fleetd 1.60.0 release notes are generated.

Changelog-only; the behavior changes already merged in #50143 (`a442d7af3a`), which is in this RC branch. Same move as `fd6e72005d` ("For 4.90 RC: Moved changes file to proper place", cherry-picking #50208).