### PR TITLE
[Docs] Document custom activation process for configurations

### DIFF
--- a/articles/custom-os-settings.md
+++ b/articles/custom-os-settings.md
@@ -24,6 +24,24 @@ The following configuration declarations are not supported:
 - com.apple.configuration.app.managed
 - com.apple.configuration.package
 
+#### Activations (`com.apple.activation.simple`)
+For advanced setups, you can provide a custom activation instead of having Fleet automatically create the activation when you upload a configuration profile.
+
+The activation must include `Type`, `Identifier`, and `Payload` key. `Payload` must have a `StandardConfiguration` containing a reference to a **single** configuration profile that already exists in Fleet. Adding a `Predicate` is allowed, however, best practices is to use labels for scoping.
+
+Example:
+```json
+{
+  "Type": "com.apple.activation.simple",
+  "Identifier": "myIdentifier",
+  "Payload": {
+    "StandardConfigurations": [
+	  "myConfgiurationIdentifier"
+	]
+  }
+}
+```
+
 #### Assets (`com.apple.asset.*`)
 Deploy credentials, certificates, and other assets referenced by configurations.
 

--- a/articles/custom-os-settings.md
+++ b/articles/custom-os-settings.md
@@ -36,7 +36,7 @@ Example:
   "Identifier": "myIdentifier",
   "Payload": {
     "StandardConfigurations": [
-	  "myConfgiurationIdentifier"
+	  "myConfigurationIdentifier"
 	]
   }
 }


### PR DESCRIPTION
Added details about custom activation for advanced setups, including required keys and an example JSON structure.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #48222
