### PR TITLE
Fixed Windows config profile not deleted properly

### DIFF
--- a/changes/49002-50698-50907-windows-profile-shared-locuri-row-cleanup
+++ b/changes/49002-50698-50907-windows-profile-shared-locuri-row-cleanup
@@ -1,0 +1,1 @@
+- Fixed a Windows configuration profile staying listed on Host details > OS settings when it stopped applying to a host but another profile on that host still enforced all of the same settings. This affected deleting or renaming a profile, and transferring a host between fleets with matching profiles.

--- a/server/service/integration_mdm_profiles_test.go
+++ b/server/service/integration_mdm_profiles_test.go
@@ -5092,6 +5092,105 @@ func (s *integrationMDMTestSuite) TestWindowsProfileManagement() {
 		_, err = mdmDevice.SendResponse()
 		require.NoError(t, err)
 	})
+
+	t.Run("delete_profile_fully_protected_removes_host_row", func(t *testing.T) {
+		// If profile A and profile B enforce the same LocURI and A is deleted, there is no <Delete> to send because B still
+		// enforces it. The host's row for A must still be cleaned up, otherwise the deleted profile stays listed on the host
+		// forever. This is the common rename case: a rename is a delete plus a create with a new profile UUID.
+		sharedProfile := `<Replace><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Config/Privacy/AllowInputPersonalization</LocURI></Target><Meta><Format xmlns="syncml:metinf">int</Format></Meta><Data>0</Data></Item></Replace>`
+		s.Do("POST", "/api/v1/fleet/mdm/profiles/batch",
+			batchSetMDMProfilesRequest{Profiles: []fleet.MDMProfileBatchPayload{
+				{Name: "fully-protected-A", Contents: []byte(sharedProfile)},
+				{Name: "fully-protected-B", Contents: []byte(sharedProfile)},
+			}}, http.StatusNoContent, "team_id", fmt.Sprint(tm.ID))
+
+		drainCommands := func() map[string]fleet.ProtoCmdOperation {
+			s.awaitTriggerProfileSchedule(t)
+			cmds, err := mdmDevice.StartManagementSession()
+			require.NoError(t, err)
+			msgID, err := mdmDevice.GetCurrentMsgID()
+			require.NoError(t, err)
+			for _, c := range cmds {
+				cmdID := c.Cmd.CmdID
+				status := syncml.CmdStatusOK
+				mdmDevice.AppendResponse(fleet.SyncMLCmd{
+					XMLName: xml.Name{Local: fleet.CmdStatus},
+					MsgRef:  &msgID,
+					CmdRef:  &cmdID.Value,
+					Cmd:     new(c.Verb),
+					Data:    &status,
+					CmdID:   fleet.CmdID{Value: uuid.NewString()},
+				})
+			}
+			_, err = mdmDevice.SendResponse()
+			require.NoError(t, err)
+			return cmds
+		}
+
+		// Deliver both profiles so profile A has a host row to leak.
+		drainCommands()
+
+		var profileAUUID string
+		mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+			return sqlx.GetContext(context.Background(), q, &profileAUUID,
+				`SELECT profile_uuid FROM mdm_windows_configuration_profiles WHERE name = ? AND team_id = ?`, "fully-protected-A", tm.ID)
+		})
+		hostProfileRowCount := func(profileUUID string) int {
+			var count int
+			mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+				return sqlx.GetContext(context.Background(), q, &count,
+					`SELECT COUNT(*) FROM host_mdm_windows_profiles WHERE host_uuid = ? AND profile_uuid = ?`, host.UUID, profileUUID)
+			})
+			return count
+		}
+		require.Equal(t, 1, hostProfileRowCount(profileAUUID))
+
+		// Delete profile A by batch-setting only profile B, which keeps the shared LocURI enforced.
+		s.Do("POST", "/api/v1/fleet/mdm/profiles/batch",
+			batchSetMDMProfilesRequest{Profiles: []fleet.MDMProfileBatchPayload{
+				{Name: "fully-protected-B", Contents: []byte(sharedProfile)},
+			}}, http.StatusNoContent, "team_id", fmt.Sprint(tm.ID))
+
+		// No <Delete> goes out, since profile B still enforces the LocURI.
+		for _, c := range drainCommands() {
+			require.NotContains(t, c.Cmd.GetTargetURI(), "AllowInputPersonalization",
+				"should NOT delete AllowInputPersonalization because profile B still enforces it")
+		}
+
+		// The host's row for the deleted profile must be gone even though no command was ever sent, so the deleted profile
+		// stops showing up in the host's OS settings.
+		require.Zero(t, hostProfileRowCount(profileAUUID))
+		var gotHostResp getHostResponse
+		s.DoJSON("GET", fmt.Sprintf("/api/v1/fleet/hosts/%d", host.ID), nil, http.StatusOK, &gotHostResp)
+		require.NotNil(t, gotHostResp.Host.MDM.Profiles)
+		for _, p := range *gotHostResp.Host.MDM.Profiles {
+			require.NotEqual(t, "fully-protected-A", p.Name, "deleted profile must not remain listed on the host")
+		}
+
+		// The per-host rollup must be refreshed off the remaining rows rather than left reflecting the deleted profile.
+		var rollupStatus, recomputedStatus string
+		mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+			if err := sqlx.GetContext(context.Background(), q, &rollupStatus,
+				`SELECT status FROM host_mdm_windows_profiles_status WHERE host_uuid = ?`, host.UUID); err != nil {
+				return err
+			}
+			stmt, args, err := sqlx.In(`
+				SELECT CASE
+					WHEN SUM(status = 'failed' AND profile_name NOT IN (?)) > 0 THEN 'failed'
+					WHEN SUM((status IS NULL OR status = 'pending') AND profile_name NOT IN (?)) > 0 THEN 'pending'
+					WHEN SUM(operation_type = 'install' AND status = 'verifying' AND profile_name NOT IN (?)) > 0 THEN 'verifying'
+					WHEN SUM(operation_type = 'install' AND status = 'verified' AND profile_name NOT IN (?)) > 0 THEN 'verified'
+					ELSE '' END
+				FROM host_mdm_windows_profiles WHERE host_uuid = ?`,
+				servermdm.ListFleetReservedWindowsProfileNames(), servermdm.ListFleetReservedWindowsProfileNames(),
+				servermdm.ListFleetReservedWindowsProfileNames(), servermdm.ListFleetReservedWindowsProfileNames(), host.UUID)
+			if err != nil {
+				return err
+			}
+			return sqlx.GetContext(context.Background(), q, &recomputedStatus, stmt, args...)
+		})
+		require.Equal(t, recomputedStatus, rollupStatus)
+	})
 }
 
 func (s *integrationMDMTestSuite) TestApplyTeamsMDMWindowsProfiles() {

--- a/server/service/integration_mdm_profiles_test.go
+++ b/server/service/integration_mdm_profiles_test.go
@@ -5167,29 +5167,9 @@ func (s *integrationMDMTestSuite) TestWindowsProfileManagement() {
 			require.NotEqual(t, "fully-protected-A", p.Name, "deleted profile must not remain listed on the host")
 		}
 
-		// The per-host rollup must be refreshed off the remaining rows rather than left reflecting the deleted profile.
-		var rollupStatus, recomputedStatus string
-		mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
-			if err := sqlx.GetContext(context.Background(), q, &rollupStatus,
-				`SELECT status FROM host_mdm_windows_profiles_status WHERE host_uuid = ?`, host.UUID); err != nil {
-				return err
-			}
-			stmt, args, err := sqlx.In(`
-				SELECT CASE
-					WHEN SUM(status = 'failed' AND profile_name NOT IN (?)) > 0 THEN 'failed'
-					WHEN SUM((status IS NULL OR status = 'pending') AND profile_name NOT IN (?)) > 0 THEN 'pending'
-					WHEN SUM(operation_type = 'install' AND status = 'verifying' AND profile_name NOT IN (?)) > 0 THEN 'verifying'
-					WHEN SUM(operation_type = 'install' AND status = 'verified' AND profile_name NOT IN (?)) > 0 THEN 'verified'
-					ELSE '' END
-				FROM host_mdm_windows_profiles WHERE host_uuid = ?`,
-				servermdm.ListFleetReservedWindowsProfileNames(), servermdm.ListFleetReservedWindowsProfileNames(),
-				servermdm.ListFleetReservedWindowsProfileNames(), servermdm.ListFleetReservedWindowsProfileNames(), host.UUID)
-			if err != nil {
-				return err
-			}
-			return sqlx.GetContext(context.Background(), q, &recomputedStatus, stmt, args...)
-		})
-		require.Equal(t, recomputedStatus, rollupStatus)
+		// The rollup refresh that BulkDeleteMDMWindowsHostsConfigProfiles performs on delete is covered discriminatingly in
+		// testWindowsProfilesStatusRollup (a failed profile deleted -> the host recomputes to verified), so it is not
+		// re-asserted here: every row left on this host is in the same state, so a stale rollup and a fresh one look identical.
 	})
 }
 

--- a/server/service/integration_mdm_profiles_test.go
+++ b/server/service/integration_mdm_profiles_test.go
@@ -4532,6 +4532,31 @@ func (s *integrationMDMTestSuite) TestWindowsProfileManagement() {
 		verifyHostProfileStatus(atomicInstallCmds, mdmResponseStatus)
 	}
 
+	// drainCommands triggers the profile schedule, then acks every command the device is handed with 200 OK and returns them.
+	// Several subtests below need the device brought to a clean state before exercising the behaviour they actually assert on.
+	drainCommands := func(device *mdmtest.TestWindowsMDMClient) map[string]fleet.ProtoCmdOperation {
+		s.awaitTriggerProfileSchedule(t)
+		cmds, err := device.StartManagementSession()
+		require.NoError(t, err)
+		msgID, err := device.GetCurrentMsgID()
+		require.NoError(t, err)
+		for _, c := range cmds {
+			cmdID := c.Cmd.CmdID
+			status := syncml.CmdStatusOK
+			device.AppendResponse(fleet.SyncMLCmd{
+				XMLName: xml.Name{Local: fleet.CmdStatus},
+				MsgRef:  &msgID,
+				CmdRef:  &cmdID.Value,
+				Cmd:     new(c.Verb),
+				Data:    &status,
+				CmdID:   fleet.CmdID{Value: uuid.NewString()},
+			})
+		}
+		_, err = device.SendResponse()
+		require.NoError(t, err)
+		return cmds
+	}
+
 	checkHostsProfilesMatch := func(host *fleet.Host, wantUUIDs []string) {
 		var gotUUIDs []string
 		mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
@@ -4869,24 +4894,7 @@ func (s *integrationMDMTestSuite) TestWindowsProfileManagement() {
 		tmResp := teamResponse{}
 		s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", tm.ID), json.RawMessage(`{"mdm": { "windows_updates": {"deadline_days": null, "grace_period_days": null} }}`), http.StatusOK, &tmResp)
 		// Drain any OS updates removal commands
-		s.awaitTriggerProfileSchedule(t)
-		cmds, err := mdmDevice.StartManagementSession()
-		require.NoError(t, err)
-		msgID, err := mdmDevice.GetCurrentMsgID()
-		require.NoError(t, err)
-		for _, c := range cmds {
-			cmdID := c.Cmd.CmdID
-			mdmDevice.AppendResponse(fleet.SyncMLCmd{
-				XMLName: xml.Name{Local: fleet.CmdStatus},
-				MsgRef:  &msgID,
-				CmdRef:  &cmdID.Value,
-				Cmd:     ptr.String(c.Verb),
-				Data:    ptr.String(syncml.CmdStatusOK),
-				CmdID:   fleet.CmdID{Value: uuid.NewString()},
-			})
-		}
-		_, err = mdmDevice.SendResponse()
-		require.NoError(t, err)
+		drainCommands(mdmDevice)
 		verifyProfiles(mdmDevice, 0, false) // drain remaining
 
 		// Create a team with no profiles
@@ -4941,25 +4949,7 @@ func (s *integrationMDMTestSuite) TestWindowsProfileManagement() {
 
 		// Trigger profile sync: device gets the new profile + delete commands for old profiles.
 		// Drain all commands from the device without asserting exact counts (cleanup varies).
-		s.awaitTriggerProfileSchedule(t)
-		cmds, err := mdmDevice.StartManagementSession()
-		require.NoError(t, err)
-		msgID, err := mdmDevice.GetCurrentMsgID()
-		require.NoError(t, err)
-		for _, c := range cmds {
-			cmdID := c.Cmd.CmdID
-			status := syncml.CmdStatusOK
-			mdmDevice.AppendResponse(fleet.SyncMLCmd{
-				XMLName: xml.Name{Local: fleet.CmdStatus},
-				MsgRef:  &msgID,
-				CmdRef:  &cmdID.Value,
-				Cmd:     ptr.String(c.Verb),
-				Data:    &status,
-				CmdID:   fleet.CmdID{Value: uuid.NewString()},
-			})
-		}
-		_, err = mdmDevice.SendResponse()
-		require.NoError(t, err)
+		drainCommands(mdmDevice)
 
 		// Drain any remaining commands until the device is clean.
 		verifyProfiles(mdmDevice, 0, false)
@@ -4976,12 +4966,12 @@ func (s *integrationMDMTestSuite) TestWindowsProfileManagement() {
 		// - 1 Atomic install for the updated profile (from reconciler checksum mismatch)
 		// Total: 2 Status + 1 Delete + 1 Atomic = 4 commands
 		s.awaitTriggerProfileSchedule(t)
-		cmds, err = mdmDevice.StartManagementSession()
+		cmds, err := mdmDevice.StartManagementSession()
 		require.NoError(t, err)
 		require.Len(t, cmds, 4, "expected 2 status + 1 delete + 1 install")
 
 		var gotDelete, gotInstall bool
-		msgID, err = mdmDevice.GetCurrentMsgID()
+		msgID, err := mdmDevice.GetCurrentMsgID()
 		require.NoError(t, err)
 		for _, c := range cmds {
 			cmdID := c.Cmd.CmdID
@@ -5036,25 +5026,7 @@ func (s *integrationMDMTestSuite) TestWindowsProfileManagement() {
 			}}, http.StatusNoContent, "team_id", fmt.Sprint(tm.ID))
 
 		// Drain install commands.
-		s.awaitTriggerProfileSchedule(t)
-		cmds, err := mdmDevice.StartManagementSession()
-		require.NoError(t, err)
-		msgID, err := mdmDevice.GetCurrentMsgID()
-		require.NoError(t, err)
-		for _, c := range cmds {
-			cmdID := c.Cmd.CmdID
-			status := syncml.CmdStatusOK
-			mdmDevice.AppendResponse(fleet.SyncMLCmd{
-				XMLName: xml.Name{Local: fleet.CmdStatus},
-				MsgRef:  &msgID,
-				CmdRef:  &cmdID.Value,
-				Cmd:     ptr.String(c.Verb),
-				Data:    &status,
-				CmdID:   fleet.CmdID{Value: uuid.NewString()},
-			})
-		}
-		_, err = mdmDevice.SendResponse()
-		require.NoError(t, err)
+		drainCommands(mdmDevice)
 		verifyProfiles(mdmDevice, 0, false)
 
 		// Edit profile A to remove AllowCamera (shared with B), keep only AllowCortana.
@@ -5068,10 +5040,10 @@ func (s *integrationMDMTestSuite) TestWindowsProfileManagement() {
 		// Trigger sync: should get an install for the updated A, but NO delete
 		// for AllowCamera since profile B still uses it.
 		s.awaitTriggerProfileSchedule(t)
-		cmds, err = mdmDevice.StartManagementSession()
+		cmds, err := mdmDevice.StartManagementSession()
 		require.NoError(t, err)
 
-		msgID, err = mdmDevice.GetCurrentMsgID()
+		msgID, err := mdmDevice.GetCurrentMsgID()
 		require.NoError(t, err)
 		for _, c := range cmds {
 			if c.Verb == "Delete" {
@@ -5095,8 +5067,7 @@ func (s *integrationMDMTestSuite) TestWindowsProfileManagement() {
 
 	t.Run("delete_profile_fully_protected_removes_host_row", func(t *testing.T) {
 		// If profile A and profile B enforce the same LocURI and A is deleted, there is no <Delete> to send because B still
-		// enforces it. The host's row for A must still be cleaned up, otherwise the deleted profile stays listed on the host
-		// forever. This is the common rename case: a rename is a delete plus a create with a new profile UUID.
+		// enforces it. The host's row for A must still be cleaned up.
 		sharedProfile := `<Replace><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Config/Privacy/AllowInputPersonalization</LocURI></Target><Meta><Format xmlns="syncml:metinf">int</Format></Meta><Data>0</Data></Item></Replace>`
 		s.Do("POST", "/api/v1/fleet/mdm/profiles/batch",
 			batchSetMDMProfilesRequest{Profiles: []fleet.MDMProfileBatchPayload{
@@ -5104,31 +5075,8 @@ func (s *integrationMDMTestSuite) TestWindowsProfileManagement() {
 				{Name: "fully-protected-B", Contents: []byte(sharedProfile)},
 			}}, http.StatusNoContent, "team_id", fmt.Sprint(tm.ID))
 
-		drainCommands := func() map[string]fleet.ProtoCmdOperation {
-			s.awaitTriggerProfileSchedule(t)
-			cmds, err := mdmDevice.StartManagementSession()
-			require.NoError(t, err)
-			msgID, err := mdmDevice.GetCurrentMsgID()
-			require.NoError(t, err)
-			for _, c := range cmds {
-				cmdID := c.Cmd.CmdID
-				status := syncml.CmdStatusOK
-				mdmDevice.AppendResponse(fleet.SyncMLCmd{
-					XMLName: xml.Name{Local: fleet.CmdStatus},
-					MsgRef:  &msgID,
-					CmdRef:  &cmdID.Value,
-					Cmd:     new(c.Verb),
-					Data:    &status,
-					CmdID:   fleet.CmdID{Value: uuid.NewString()},
-				})
-			}
-			_, err = mdmDevice.SendResponse()
-			require.NoError(t, err)
-			return cmds
-		}
-
 		// Deliver both profiles so profile A has a host row to leak.
-		drainCommands()
+		drainCommands(mdmDevice)
 
 		var profileAUUID string
 		mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
@@ -5152,7 +5100,7 @@ func (s *integrationMDMTestSuite) TestWindowsProfileManagement() {
 			}}, http.StatusNoContent, "team_id", fmt.Sprint(tm.ID))
 
 		// No <Delete> goes out, since profile B still enforces the LocURI.
-		for _, c := range drainCommands() {
+		for _, c := range drainCommands(mdmDevice) {
 			require.NotContains(t, c.Cmd.GetTargetURI(), "AllowInputPersonalization",
 				"should NOT delete AllowInputPersonalization because profile B still enforces it")
 		}
@@ -5166,10 +5114,6 @@ func (s *integrationMDMTestSuite) TestWindowsProfileManagement() {
 		for _, p := range *gotHostResp.Host.MDM.Profiles {
 			require.NotEqual(t, "fully-protected-A", p.Name, "deleted profile must not remain listed on the host")
 		}
-
-		// The rollup refresh that BulkDeleteMDMWindowsHostsConfigProfiles performs on delete is covered discriminatingly in
-		// testWindowsProfilesStatusRollup (a failed profile deleted -> the host recomputes to verified), so it is not
-		// re-asserted here: every row left on this host is in the same state, so a stale rollup and a fresh one look identical.
 	})
 }
 

--- a/server/service/microsoft_mdm.go
+++ b/server/service/microsoft_mdm.go
@@ -4297,6 +4297,10 @@ func executeWindowsProfileReconcileBatch(
 		return uris
 	}
 
+	// Host rows for removes whose <Delete> was fully suppressed by LocURI protection, accumulated across every removed profile in
+	// this batch and deleted in one call below.
+	var suppressedRemoveRows []*fleet.MDMWindowsProfilePayload
+
 	for profUUID, target := range removeTargets {
 		if _, ok := profileContents[profUUID]; !ok {
 			// No retained content for this removed profile, so we can't build its <Delete> this tick. This is normally a transient
@@ -4379,7 +4383,19 @@ func executeWindowsProfileReconcileBatch(
 				continue
 			}
 			if command == nil {
-				// Every LocURI of the removed profile is still enforced by another profile on these hosts; nothing to send.
+				// Every LocURI of the removed profile is still enforced by another profile on these hosts, so there is no
+				// <Delete> to send and no command ack will ever arrive to clean these rows up. Collect the rows and delete
+				// them after the loop, or the removed profile stays listed on the host (and counted in the profile summary)
+				// forever. Batching matters: replacing a whole team's profile set with same-LocURI profiles suppresses every
+				// remove at once, and the datastore call recomputes the status rollup for each host it is given.
+				for _, hostUUID := range g.hostUUIDs {
+					suppressedRemoveRows = append(suppressedRemoveRows, &fleet.MDMWindowsProfilePayload{
+						ProfileUUID: profUUID,
+						HostUUID:    hostUUID,
+					})
+				}
+				logger.DebugContext(ctx, "removed profile fully protected by other profiles, deleting host rows",
+					"profile_uuid", profUUID, "host_count", len(g.hostUUIDs))
 				continue
 			}
 
@@ -4408,6 +4424,12 @@ func executeWindowsProfileReconcileBatch(
 			if err := ds.MDMWindowsInsertCommandAndUpsertHostProfilesForHosts(ctx, g.hostUUIDs, command, removePayloadsForCommand); err != nil {
 				return ctxerr.Wrap(ctx, err, "inserting remove commands for hosts")
 			}
+		}
+	}
+
+	if len(suppressedRemoveRows) > 0 {
+		if err := ds.BulkDeleteMDMWindowsHostsConfigProfiles(ctx, suppressedRemoveRows); err != nil {
+			return ctxerr.Wrap(ctx, err, "deleting host profiles whose remove command was fully suppressed")
 		}
 	}
 

--- a/server/service/microsoft_mdm.go
+++ b/server/service/microsoft_mdm.go
@@ -4385,9 +4385,7 @@ func executeWindowsProfileReconcileBatch(
 			if command == nil {
 				// Every LocURI of the removed profile is still enforced by another profile on these hosts, so there is no
 				// <Delete> to send and no command ack will ever arrive to clean these rows up. Collect the rows and delete
-				// them after the loop, or the removed profile stays listed on the host (and counted in the profile summary)
-				// forever. Batching matters: replacing a whole team's profile set with same-LocURI profiles suppresses every
-				// remove at once, and the datastore call recomputes the status rollup for each host it is given.
+				// them after the loop.
 				for _, hostUUID := range g.hostUUIDs {
 					suppressedRemoveRows = append(suppressedRemoveRows, &fleet.MDMWindowsProfilePayload{
 						ProfileUUID: profUUID,

--- a/server/service/microsoft_mdm_test.go
+++ b/server/service/microsoft_mdm_test.go
@@ -1081,6 +1081,300 @@ func TestReconcileWindowsProfilesSkipsDeletedProfile(t *testing.T) {
 		"no zombie row should be written when the profile is gone")
 }
 
+// TestReconcileWindowsProfilesDeletesFullyProtectedRemoveRows covers a profile that is removed from a host while every one of its
+// LocURIs is still enforced by a profile that remains applicable to that host. There is no <Delete> to send, so no command ack will
+// ever arrive to clean the host's row up; the reconciler has to delete the row itself or the removed profile stays listed on the
+// host (and counted in the profile summary) forever.
+func TestReconcileWindowsProfilesDeletesFullyProtectedRemoveRows(t *testing.T) {
+	ctx := context.Background()
+	ds := new(mock.Store)
+	logger := slog.New(slog.DiscardHandler)
+
+	const (
+		hostUUID       = "host-a"
+		keptProfile    = "kept-profile-uuid"
+		removedProfile = "removed-profile-uuid"
+	)
+	// Both profiles enforce the same single LocURI, so the removed one is fully protected by the kept one.
+	sharedSyncML := []byte(`<Replace><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Config/Experience/AllowCortana</LocURI></Target><Data>0</Data></Item></Replace>`)
+	checksum := []byte("test-checksum")
+
+	setupReconcilerTest(ds, map[string]*fleet.MDMWindowsConfigProfile{})
+
+	// One host in team 1. Only the kept profile is live, so the host's existing row for the removed profile becomes a remove
+	// target. The kept profile's row already matches the live checksum, so nothing is re-installed this tick.
+	ds.GetWindowsProfileReconcileSnapshotFunc = func(ctx context.Context, after string, batch int) (
+		[]*fleet.WindowsHostReconcileInfo,
+		[]*fleet.WindowsProfileForReconcile,
+		map[uint]map[uint]struct{},
+		map[string][]*fleet.MDMWindowsProfilePayload,
+		error,
+	) {
+		if after != "" {
+			return nil, nil, nil, nil, nil
+		}
+		teamID := uint(1)
+		hosts := []*fleet.WindowsHostReconcileInfo{{HostID: 1, UUID: hostUUID, TeamID: &teamID}}
+		profiles := []*fleet.WindowsProfileForReconcile{
+			{ProfileUUID: keptProfile, ProfileName: "Kept", TeamID: teamID, Checksum: checksum},
+		}
+		current := map[string][]*fleet.MDMWindowsProfilePayload{
+			hostUUID: {
+				{
+					ProfileUUID: keptProfile, ProfileName: "Kept", HostUUID: hostUUID,
+					OperationType: fleet.MDMOperationTypeInstall, Status: &fleet.MDMDeliveryVerified, Checksum: checksum,
+				},
+				{
+					ProfileUUID: removedProfile, ProfileName: "Removed", HostUUID: hostUUID,
+					OperationType: fleet.MDMOperationTypeInstall, Status: &fleet.MDMDeliveryVerified, Checksum: checksum,
+				},
+			},
+		}
+		return hosts, profiles, nil, current, nil
+	}
+
+	ds.GetMDMWindowsProfilesContentsFunc = func(ctx context.Context, profileUUIDs []string) (map[string]fleet.MDMWindowsProfileContents, error) {
+		out := make(map[string]fleet.MDMWindowsProfileContents, len(profileUUIDs))
+		for _, uuid := range profileUUIDs {
+			out[uuid] = fleet.MDMWindowsProfileContents{SyncML: sharedSyncML, Checksum: checksum}
+		}
+		return out, nil
+	}
+
+	var enqueuedCommands []*fleet.MDMWindowsCommand
+	ds.MDMWindowsInsertCommandAndUpsertHostProfilesForHostsFunc = func(ctx context.Context, hostUUIDs []string, cmd *fleet.MDMWindowsCommand, updates []*fleet.MDMWindowsBulkUpsertHostProfilePayload) error {
+		enqueuedCommands = append(enqueuedCommands, cmd)
+		return nil
+	}
+
+	var deletedRows []*fleet.MDMWindowsProfilePayload
+	ds.BulkDeleteMDMWindowsHostsConfigProfilesFunc = func(ctx context.Context, payload []*fleet.MDMWindowsProfilePayload) error {
+		deletedRows = append(deletedRows, payload...)
+		return nil
+	}
+
+	require.NoError(t, ReconcileWindowsProfiles(ctx, ds, logger))
+
+	for _, cmd := range enqueuedCommands {
+		require.NotContains(t, string(cmd.RawCommand), "<Delete",
+			"no <Delete> can be sent while another profile still enforces the LocURI")
+	}
+	require.True(t, ds.BulkDeleteMDMWindowsHostsConfigProfilesFuncInvoked,
+		"the suppressed remove must delete the host's row instead of leaving it behind")
+	require.Len(t, deletedRows, 1)
+	require.Equal(t, removedProfile, deletedRows[0].ProfileUUID)
+	require.Equal(t, hostUUID, deletedRows[0].HostUUID)
+}
+
+// TestReconcileWindowsProfilesDeletesRowAfterTransferToMirroredTeam covers transferring a host between two teams whose profiles
+// enforce the same LocURIs. The outgoing team's profile still exists (it just no longer applies to this host), and the incoming
+// team's profile protects every one of its LocURIs, so no <Delete> is sent. The outgoing profile's host row still has to go, or the
+// same setting is listed twice on Host details > OS settings with no way to clear it short of unenforcing the setting.
+func TestReconcileWindowsProfilesDeletesRowAfterTransferToMirroredTeam(t *testing.T) {
+	ctx := context.Background()
+	ds := new(mock.Store)
+	logger := slog.New(slog.DiscardHandler)
+
+	const (
+		hostUUID     = "transferred-host"
+		teamAProfile = "team-a-profile-uuid"
+		teamBProfile = "team-b-profile-uuid"
+	)
+	// Mirrored profiles: two distinct profiles, in two distinct teams, enforcing an identical LocURI set.
+	mirroredSyncML := []byte(`<Replace><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Config/Experience/AllowCortana</LocURI></Target><Data>0</Data></Item></Replace>`)
+	checksum := []byte("test-checksum")
+
+	setupReconcilerTest(ds, map[string]*fleet.MDMWindowsConfigProfile{})
+
+	// The host has already been moved to team B. It still carries the verified row for team A's profile, and team B's mirrored
+	// profile is not installed on it yet, so this tick both installs B's profile and makes A's profile a remove target.
+	ds.GetWindowsProfileReconcileSnapshotFunc = func(ctx context.Context, after string, batch int) (
+		[]*fleet.WindowsHostReconcileInfo,
+		[]*fleet.WindowsProfileForReconcile,
+		map[uint]map[uint]struct{},
+		map[string][]*fleet.MDMWindowsProfilePayload,
+		error,
+	) {
+		if after != "" {
+			return nil, nil, nil, nil, nil
+		}
+		teamBID := uint(2)
+		hosts := []*fleet.WindowsHostReconcileInfo{{HostID: 1, UUID: hostUUID, TeamID: &teamBID}}
+		profiles := []*fleet.WindowsProfileForReconcile{
+			{ProfileUUID: teamBProfile, ProfileName: "Mirrored", TeamID: teamBID, Checksum: checksum},
+		}
+		current := map[string][]*fleet.MDMWindowsProfilePayload{
+			hostUUID: {
+				{
+					ProfileUUID: teamAProfile, ProfileName: "Mirrored", HostUUID: hostUUID,
+					OperationType: fleet.MDMOperationTypeInstall, Status: &fleet.MDMDeliveryVerified, Checksum: checksum,
+				},
+			},
+		}
+		return hosts, profiles, nil, current, nil
+	}
+
+	ds.GetMDMWindowsProfilesContentsFunc = func(ctx context.Context, profileUUIDs []string) (map[string]fleet.MDMWindowsProfileContents, error) {
+		out := make(map[string]fleet.MDMWindowsProfileContents, len(profileUUIDs))
+		for _, uuid := range profileUUIDs {
+			out[uuid] = fleet.MDMWindowsProfileContents{SyncML: mirroredSyncML, Checksum: checksum}
+		}
+		return out, nil
+	}
+
+	// Both profiles still exist; only the host's team membership changed. This is what separates this case from a deleted profile.
+	ds.GetExistingMDMWindowsProfileUUIDsFunc = func(ctx context.Context, profileUUIDs []string) (map[string]struct{}, error) {
+		out := make(map[string]struct{}, len(profileUUIDs))
+		for _, u := range profileUUIDs {
+			out[u] = struct{}{}
+		}
+		return out, nil
+	}
+
+	var enqueuedCommands []*fleet.MDMWindowsCommand
+	ds.MDMWindowsInsertCommandAndUpsertHostProfilesForHostsFunc = func(ctx context.Context, hostUUIDs []string, cmd *fleet.MDMWindowsCommand, updates []*fleet.MDMWindowsBulkUpsertHostProfilePayload) error {
+		enqueuedCommands = append(enqueuedCommands, cmd)
+		return nil
+	}
+	ds.MDMWindowsBulkInsertCommandsFunc = func(ctx context.Context, cmds []*fleet.MDMWindowsCommand) error {
+		enqueuedCommands = append(enqueuedCommands, cmds...)
+		return nil
+	}
+
+	var deletedRows []*fleet.MDMWindowsProfilePayload
+	ds.BulkDeleteMDMWindowsHostsConfigProfilesFunc = func(ctx context.Context, payload []*fleet.MDMWindowsProfilePayload) error {
+		deletedRows = append(deletedRows, payload...)
+		return nil
+	}
+
+	require.NoError(t, ReconcileWindowsProfiles(ctx, ds, logger))
+
+	// The setting is never lifted from the device: team B's profile installs and no <Delete> goes out for the shared LocURI.
+	for _, cmd := range enqueuedCommands {
+		require.NotContains(t, string(cmd.RawCommand), "<Delete",
+			"the transfer must not open an enforcement gap on a LocURI the incoming profile still enforces")
+	}
+	// Only the outgoing team's row is dropped, keyed by (profile, host), so the profile itself and other hosts still in team A
+	// are untouched.
+	require.True(t, ds.BulkDeleteMDMWindowsHostsConfigProfilesFuncInvoked,
+		"the outgoing team's row must not stay listed alongside the incoming team's profile")
+	require.Len(t, deletedRows, 1)
+	require.Equal(t, teamAProfile, deletedRows[0].ProfileUUID)
+	require.Equal(t, hostUUID, deletedRows[0].HostUUID)
+}
+
+// TestReconcileWindowsProfilesDeletesSuppressedRemoveRowsInOneBatch covers batch-replacing a team's whole profile set with
+// differently-named profiles carrying the same LocURIs. Every removed profile is fully protected by its replacement, so every
+// remove is suppressed at once. All the stale rows have to go, and they should go in a single datastore call: that call recomputes
+// the status rollup for every host it is handed, so one call per removed profile would redo the same rollup work for the same hosts
+// once per profile.
+func TestReconcileWindowsProfilesDeletesSuppressedRemoveRowsInOneBatch(t *testing.T) {
+	ctx := context.Background()
+	ds := new(mock.Store)
+	logger := slog.New(slog.DiscardHandler)
+
+	const (
+		profileCount = 25
+		hostCount    = 4
+	)
+	checksum := []byte("test-checksum")
+	// Each old profile is replaced by a differently-named new profile targeting the identical LocURI.
+	syncMLFor := func(i int) []byte {
+		return []byte(fmt.Sprintf(
+			`<Replace><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Config/Experience/Setting%d</LocURI></Target><Data>0</Data></Item></Replace>`, i))
+	}
+	oldProfileUUID := func(i int) string { return fmt.Sprintf("old-profile-%d", i) }
+	newProfileUUID := func(i int) string { return fmt.Sprintf("new-profile-%d", i) }
+	hostUUIDFor := func(i int) string { return fmt.Sprintf("host-%d", i) }
+
+	setupReconcilerTest(ds, map[string]*fleet.MDMWindowsConfigProfile{})
+
+	ds.GetWindowsProfileReconcileSnapshotFunc = func(ctx context.Context, after string, batch int) (
+		[]*fleet.WindowsHostReconcileInfo,
+		[]*fleet.WindowsProfileForReconcile,
+		map[uint]map[uint]struct{},
+		map[string][]*fleet.MDMWindowsProfilePayload,
+		error,
+	) {
+		if after != "" {
+			return nil, nil, nil, nil, nil
+		}
+		teamID := uint(1)
+		hosts := make([]*fleet.WindowsHostReconcileInfo, 0, hostCount)
+		current := make(map[string][]*fleet.MDMWindowsProfilePayload, hostCount)
+		for h := range hostCount {
+			hosts = append(hosts, &fleet.WindowsHostReconcileInfo{HostID: uint(h + 1), UUID: hostUUIDFor(h), TeamID: &teamID})
+			rows := make([]*fleet.MDMWindowsProfilePayload, 0, profileCount)
+			for p := range profileCount {
+				// Only the old set is installed; the new set has just been applied and is not on the hosts yet.
+				rows = append(rows, &fleet.MDMWindowsProfilePayload{
+					ProfileUUID: oldProfileUUID(p), ProfileName: fmt.Sprintf("Old %d", p), HostUUID: hostUUIDFor(h),
+					OperationType: fleet.MDMOperationTypeInstall, Status: &fleet.MDMDeliveryVerified, Checksum: checksum,
+				})
+			}
+			current[hostUUIDFor(h)] = rows
+		}
+		profiles := make([]*fleet.WindowsProfileForReconcile, 0, profileCount)
+		for p := range profileCount {
+			profiles = append(profiles, &fleet.WindowsProfileForReconcile{
+				ProfileUUID: newProfileUUID(p), ProfileName: fmt.Sprintf("New %d", p), TeamID: teamID, Checksum: checksum,
+			})
+		}
+		return hosts, profiles, nil, current, nil
+	}
+
+	ds.GetMDMWindowsProfilesContentsFunc = func(ctx context.Context, profileUUIDs []string) (map[string]fleet.MDMWindowsProfileContents, error) {
+		out := make(map[string]fleet.MDMWindowsProfileContents, len(profileUUIDs))
+		for _, uuid := range profileUUIDs {
+			var idx int
+			if _, err := fmt.Sscanf(uuid, "old-profile-%d", &idx); err != nil {
+				if _, err := fmt.Sscanf(uuid, "new-profile-%d", &idx); err != nil {
+					continue
+				}
+			}
+			out[uuid] = fleet.MDMWindowsProfileContents{SyncML: syncMLFor(idx), Checksum: checksum}
+		}
+		return out, nil
+	}
+
+	var enqueuedCommands []*fleet.MDMWindowsCommand
+	ds.MDMWindowsInsertCommandAndUpsertHostProfilesForHostsFunc = func(ctx context.Context, hostUUIDs []string, cmd *fleet.MDMWindowsCommand, updates []*fleet.MDMWindowsBulkUpsertHostProfilePayload) error {
+		enqueuedCommands = append(enqueuedCommands, cmd)
+		return nil
+	}
+	ds.MDMWindowsBulkInsertCommandsFunc = func(ctx context.Context, cmds []*fleet.MDMWindowsCommand) error {
+		enqueuedCommands = append(enqueuedCommands, cmds...)
+		return nil
+	}
+
+	var deleteCallCount int
+	var deletedRows []*fleet.MDMWindowsProfilePayload
+	ds.BulkDeleteMDMWindowsHostsConfigProfilesFunc = func(ctx context.Context, payload []*fleet.MDMWindowsProfilePayload) error {
+		deleteCallCount++
+		deletedRows = append(deletedRows, payload...)
+		return nil
+	}
+
+	require.NoError(t, ReconcileWindowsProfiles(ctx, ds, logger))
+
+	for _, cmd := range enqueuedCommands {
+		require.NotContains(t, string(cmd.RawCommand), "<Delete",
+			"every removed LocURI is still enforced by its replacement, so no <Delete> may be sent")
+	}
+	// Every (old profile, host) pair is cleaned up, and the whole batch goes out in one call.
+	require.Len(t, deletedRows, profileCount*hostCount)
+	require.Equal(t, 1, deleteCallCount, "suppressed removes must be deleted in one batch, not one call per profile")
+	gotPairs := make(map[string]struct{}, len(deletedRows))
+	for _, row := range deletedRows {
+		gotPairs[row.ProfileUUID+"|"+row.HostUUID] = struct{}{}
+	}
+	for p := range profileCount {
+		for h := range hostCount {
+			require.Contains(t, gotPairs, oldProfileUUID(p)+"|"+hostUUIDFor(h))
+		}
+	}
+}
+
 // TestReconcileWindowsProfilesSkipsInsertLag covers the asymmetric race
 // where a profile was just inserted on the primary but the replica
 // hasn't caught up: GetMDMWindowsProfilesContents (replica) misses the

--- a/server/service/microsoft_mdm_test.go
+++ b/server/service/microsoft_mdm_test.go
@@ -1081,293 +1081,258 @@ func TestReconcileWindowsProfilesSkipsDeletedProfile(t *testing.T) {
 		"no zombie row should be written when the profile is gone")
 }
 
+// windowsReconcileSnapshot is the state one ReconcileWindowsProfiles tick sees: the hosts, the profiles live for their teams, the
+// rows already on those hosts, and the SyncML behind every profile UUID either side references.
+type windowsReconcileSnapshot struct {
+	hosts    []*fleet.WindowsHostReconcileInfo
+	profiles []*fleet.WindowsProfileForReconcile
+	current  map[string][]*fleet.MDMWindowsProfilePayload
+	contents map[string][]byte
+}
+
+// windowsReconcileResult is what the reconciler did with that snapshot: the commands it enqueued and the host rows it deleted.
+type windowsReconcileResult struct {
+	commands    []*fleet.MDMWindowsCommand
+	deletedRows []*fleet.MDMWindowsProfilePayload
+	deleteCalls int
+}
+
+// deletedPairs returns the deleted rows as a "profileUUID|hostUUID" set, which is how the tests below assert on them.
+func (r windowsReconcileResult) deletedPairs() map[string]struct{} {
+	out := make(map[string]struct{}, len(r.deletedRows))
+	for _, row := range r.deletedRows {
+		out[row.ProfileUUID+"|"+row.HostUUID] = struct{}{}
+	}
+	return out
+}
+
+// requireNoDeleteCommands asserts the tick sent no <Delete> at all. Every suppressed-remove test needs this: the whole point of
+// LocURI protection is that the setting stays enforced on the device, so cleaning up the host row must not open an enforcement gap.
+func (r windowsReconcileResult) requireNoDeleteCommands(t *testing.T, msg string) {
+	t.Helper()
+	for _, cmd := range r.commands {
+		require.NotContains(t, string(cmd.RawCommand), "<Delete", msg)
+	}
+}
+
+const windowsReconcileTestChecksum = "test-checksum"
+
+// runWindowsReconcileOnce drives a single ReconcileWindowsProfiles tick over the given snapshot. The suppressed-remove tests below
+// differ only in the snapshot they set up and the assertions they make, so the mock wiring lives here.
+func runWindowsReconcileOnce(t *testing.T, snapshot windowsReconcileSnapshot) windowsReconcileResult {
+	t.Helper()
+	ctx := context.Background()
+	ds := new(mock.Store)
+	setupReconcilerTest(ds, map[string]*fleet.MDMWindowsConfigProfile{})
+
+	ds.GetWindowsProfileReconcileSnapshotFunc = func(ctx context.Context, after string, batch int) (
+		[]*fleet.WindowsHostReconcileInfo,
+		[]*fleet.WindowsProfileForReconcile,
+		map[uint]map[uint]struct{},
+		map[string][]*fleet.MDMWindowsProfilePayload,
+		error,
+	) {
+		// Everything is delivered in the first window; a non-empty cursor ends the drain.
+		if after != "" {
+			return nil, nil, nil, nil, nil
+		}
+		return snapshot.hosts, snapshot.profiles, nil, snapshot.current, nil
+	}
+
+	ds.GetMDMWindowsProfilesContentsFunc = func(ctx context.Context, profileUUIDs []string) (map[string]fleet.MDMWindowsProfileContents, error) {
+		out := make(map[string]fleet.MDMWindowsProfileContents, len(profileUUIDs))
+		for _, profUUID := range profileUUIDs {
+			if syncML, ok := snapshot.contents[profUUID]; ok {
+				out[profUUID] = fleet.MDMWindowsProfileContents{SyncML: syncML, Checksum: []byte(windowsReconcileTestChecksum)}
+			}
+		}
+		return out, nil
+	}
+
+	var result windowsReconcileResult
+	ds.MDMWindowsInsertCommandAndUpsertHostProfilesForHostsFunc = func(ctx context.Context, hostUUIDs []string, cmd *fleet.MDMWindowsCommand, updates []*fleet.MDMWindowsBulkUpsertHostProfilePayload) error {
+		result.commands = append(result.commands, cmd)
+		return nil
+	}
+	ds.MDMWindowsBulkInsertCommandsFunc = func(ctx context.Context, cmds []*fleet.MDMWindowsCommand) error {
+		result.commands = append(result.commands, cmds...)
+		return nil
+	}
+	ds.BulkDeleteMDMWindowsHostsConfigProfilesFunc = func(ctx context.Context, payload []*fleet.MDMWindowsProfilePayload) error {
+		result.deleteCalls++
+		result.deletedRows = append(result.deletedRows, payload...)
+		return nil
+	}
+
+	require.NoError(t, ReconcileWindowsProfiles(ctx, ds, slog.New(slog.DiscardHandler)))
+	return result
+}
+
+// installedRow builds a verified install row, the shape a profile already delivered to a host has.
+func installedRow(profileUUID, profileName, hostUUID string) *fleet.MDMWindowsProfilePayload {
+	return &fleet.MDMWindowsProfilePayload{
+		ProfileUUID:   profileUUID,
+		ProfileName:   profileName,
+		HostUUID:      hostUUID,
+		OperationType: fleet.MDMOperationTypeInstall,
+		Status:        &fleet.MDMDeliveryVerified,
+		Checksum:      []byte(windowsReconcileTestChecksum),
+	}
+}
+
+// windowsTestProfileSyncML returns a single-<Replace> profile targeting the named policy node.
+func windowsTestProfileSyncML(setting string) []byte {
+	return []byte(`<Replace><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Config/` + setting +
+		`</LocURI></Target><Data>0</Data></Item></Replace>`)
+}
+
 // TestReconcileWindowsProfilesDeletesFullyProtectedRemoveRows covers a profile that is removed from a host while every one of its
 // LocURIs is still enforced by a profile that remains applicable to that host. There is no <Delete> to send, so no command ack will
 // ever arrive to clean the host's row up; the reconciler has to delete the row itself or the removed profile stays listed on the
 // host (and counted in the profile summary) forever.
 func TestReconcileWindowsProfilesDeletesFullyProtectedRemoveRows(t *testing.T) {
-	ctx := context.Background()
-	ds := new(mock.Store)
-	logger := slog.New(slog.DiscardHandler)
-
 	const (
 		hostUUID       = "host-a"
 		keptProfile    = "kept-profile-uuid"
 		removedProfile = "removed-profile-uuid"
 	)
 	// Both profiles enforce the same single LocURI, so the removed one is fully protected by the kept one.
-	sharedSyncML := []byte(`<Replace><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Config/Experience/AllowCortana</LocURI></Target><Data>0</Data></Item></Replace>`)
-	checksum := []byte("test-checksum")
+	shared := windowsTestProfileSyncML("Experience/AllowCortana")
+	teamID := uint(1)
 
-	setupReconcilerTest(ds, map[string]*fleet.MDMWindowsConfigProfile{})
-
-	// One host in team 1. Only the kept profile is live, so the host's existing row for the removed profile becomes a remove
-	// target. The kept profile's row already matches the live checksum, so nothing is re-installed this tick.
-	ds.GetWindowsProfileReconcileSnapshotFunc = func(ctx context.Context, after string, batch int) (
-		[]*fleet.WindowsHostReconcileInfo,
-		[]*fleet.WindowsProfileForReconcile,
-		map[uint]map[uint]struct{},
-		map[string][]*fleet.MDMWindowsProfilePayload,
-		error,
-	) {
-		if after != "" {
-			return nil, nil, nil, nil, nil
-		}
-		teamID := uint(1)
-		hosts := []*fleet.WindowsHostReconcileInfo{{HostID: 1, UUID: hostUUID, TeamID: &teamID}}
-		profiles := []*fleet.WindowsProfileForReconcile{
-			{ProfileUUID: keptProfile, ProfileName: "Kept", TeamID: teamID, Checksum: checksum},
-		}
-		current := map[string][]*fleet.MDMWindowsProfilePayload{
+	// Only the kept profile is live, so the host's row for the removed profile becomes a remove target. The kept profile's row
+	// already matches the live checksum, so nothing is re-installed this tick.
+	result := runWindowsReconcileOnce(t, windowsReconcileSnapshot{
+		hosts: []*fleet.WindowsHostReconcileInfo{{HostID: 1, UUID: hostUUID, TeamID: &teamID}},
+		profiles: []*fleet.WindowsProfileForReconcile{
+			{ProfileUUID: keptProfile, ProfileName: "Kept", TeamID: teamID, Checksum: []byte(windowsReconcileTestChecksum)},
+		},
+		current: map[string][]*fleet.MDMWindowsProfilePayload{
 			hostUUID: {
-				{
-					ProfileUUID: keptProfile, ProfileName: "Kept", HostUUID: hostUUID,
-					OperationType: fleet.MDMOperationTypeInstall, Status: &fleet.MDMDeliveryVerified, Checksum: checksum,
-				},
-				{
-					ProfileUUID: removedProfile, ProfileName: "Removed", HostUUID: hostUUID,
-					OperationType: fleet.MDMOperationTypeInstall, Status: &fleet.MDMDeliveryVerified, Checksum: checksum,
-				},
+				installedRow(keptProfile, "Kept", hostUUID),
+				installedRow(removedProfile, "Removed", hostUUID),
 			},
-		}
-		return hosts, profiles, nil, current, nil
-	}
+		},
+		contents: map[string][]byte{keptProfile: shared, removedProfile: shared},
+	})
 
-	ds.GetMDMWindowsProfilesContentsFunc = func(ctx context.Context, profileUUIDs []string) (map[string]fleet.MDMWindowsProfileContents, error) {
-		out := make(map[string]fleet.MDMWindowsProfileContents, len(profileUUIDs))
-		for _, uuid := range profileUUIDs {
-			out[uuid] = fleet.MDMWindowsProfileContents{SyncML: sharedSyncML, Checksum: checksum}
-		}
-		return out, nil
-	}
+	result.requireNoDeleteCommands(t, "no <Delete> can be sent while another profile still enforces the LocURI")
+	require.Len(t, result.deletedRows, 1, "the suppressed remove must delete the host's row instead of leaving it behind")
+	require.Contains(t, result.deletedPairs(), removedProfile+"|"+hostUUID)
+}
 
-	var enqueuedCommands []*fleet.MDMWindowsCommand
-	ds.MDMWindowsInsertCommandAndUpsertHostProfilesForHostsFunc = func(ctx context.Context, hostUUIDs []string, cmd *fleet.MDMWindowsCommand, updates []*fleet.MDMWindowsBulkUpsertHostProfilePayload) error {
-		enqueuedCommands = append(enqueuedCommands, cmd)
-		return nil
-	}
+// TestReconcileWindowsProfilesDeletesRemoveRowsWithNoLocURIs covers a removed profile whose content yields no LocURIs, so the
+// command comes back nil for a reason other than LocURI protection and the row would be stuck just the same. The parser's own
+// handling of empty, malformed, and Replace/Add-free content is covered by TestExtractLocURIsFromProfileBytes; all the reconciler
+// needs to handle is the empty result.
+func TestReconcileWindowsProfilesDeletesRemoveRowsWithNoLocURIs(t *testing.T) {
+	const (
+		hostUUID       = "host-a"
+		keptProfile    = "kept-profile-uuid"
+		removedProfile = "removed-profile-uuid"
+	)
+	teamID := uint(1)
 
-	var deletedRows []*fleet.MDMWindowsProfilePayload
-	ds.BulkDeleteMDMWindowsHostsConfigProfilesFunc = func(ctx context.Context, payload []*fleet.MDMWindowsProfilePayload) error {
-		deletedRows = append(deletedRows, payload...)
-		return nil
-	}
+	// The kept profile shares no LocURI with the removed one, so protection plays no part: the only reason there is no <Delete>
+	// is that the removed profile has no LocURIs to target.
+	result := runWindowsReconcileOnce(t, windowsReconcileSnapshot{
+		hosts: []*fleet.WindowsHostReconcileInfo{{HostID: 1, UUID: hostUUID, TeamID: &teamID}},
+		profiles: []*fleet.WindowsProfileForReconcile{
+			{ProfileUUID: keptProfile, ProfileName: "Kept", TeamID: teamID, Checksum: []byte(windowsReconcileTestChecksum)},
+		},
+		current: map[string][]*fleet.MDMWindowsProfilePayload{
+			hostUUID: {
+				installedRow(keptProfile, "Kept", hostUUID),
+				installedRow(removedProfile, "Removed", hostUUID),
+			},
+		},
+		contents: map[string][]byte{
+			keptProfile:    windowsTestProfileSyncML("Camera/AllowCamera"),
+			removedProfile: []byte(""),
+		},
+	})
 
-	require.NoError(t, ReconcileWindowsProfiles(ctx, ds, logger))
-
-	for _, cmd := range enqueuedCommands {
-		require.NotContains(t, string(cmd.RawCommand), "<Delete",
-			"no <Delete> can be sent while another profile still enforces the LocURI")
-	}
-	require.True(t, ds.BulkDeleteMDMWindowsHostsConfigProfilesFuncInvoked,
-		"the suppressed remove must delete the host's row instead of leaving it behind")
-	require.Len(t, deletedRows, 1)
-	require.Equal(t, removedProfile, deletedRows[0].ProfileUUID)
-	require.Equal(t, hostUUID, deletedRows[0].HostUUID)
+	require.Len(t, result.deletedRows, 1, "a profile with no LocURIs must not stay stuck on the host")
+	require.Contains(t, result.deletedPairs(), removedProfile+"|"+hostUUID)
 }
 
 // TestReconcileWindowsProfilesDeletesRowAfterTransferToMirroredTeam covers transferring a host between two teams whose profiles
-// enforce the same LocURIs. The outgoing team's profile still exists (it just no longer applies to this host), and the incoming
-// team's profile protects every one of its LocURIs, so no <Delete> is sent. The outgoing profile's host row still has to go, or the
-// same setting is listed twice on Host details > OS settings with no way to clear it short of unenforcing the setting.
+// enforce the same LocURIs. Unlike the deleted-profile case, the outgoing profile still exists (it just no longer applies here)
+// and the protecting profile is not installed yet: it is only desired, and it installs on this same tick. That is what makes this
+// distinct — protection has to come from the desired set, not from what is already on the host.
 func TestReconcileWindowsProfilesDeletesRowAfterTransferToMirroredTeam(t *testing.T) {
-	ctx := context.Background()
-	ds := new(mock.Store)
-	logger := slog.New(slog.DiscardHandler)
-
 	const (
 		hostUUID     = "transferred-host"
 		teamAProfile = "team-a-profile-uuid"
 		teamBProfile = "team-b-profile-uuid"
 	)
 	// Mirrored profiles: two distinct profiles, in two distinct teams, enforcing an identical LocURI set.
-	mirroredSyncML := []byte(`<Replace><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Config/Experience/AllowCortana</LocURI></Target><Data>0</Data></Item></Replace>`)
-	checksum := []byte("test-checksum")
+	mirrored := windowsTestProfileSyncML("Experience/AllowCortana")
+	teamBID := uint(2)
 
-	setupReconcilerTest(ds, map[string]*fleet.MDMWindowsConfigProfile{})
+	// The host has already been moved to team B, still carrying the verified row for team A's profile.
+	result := runWindowsReconcileOnce(t, windowsReconcileSnapshot{
+		hosts: []*fleet.WindowsHostReconcileInfo{{HostID: 1, UUID: hostUUID, TeamID: &teamBID}},
+		profiles: []*fleet.WindowsProfileForReconcile{
+			{ProfileUUID: teamBProfile, ProfileName: "Mirrored", TeamID: teamBID, Checksum: []byte(windowsReconcileTestChecksum)},
+		},
+		current: map[string][]*fleet.MDMWindowsProfilePayload{
+			hostUUID: {installedRow(teamAProfile, "Mirrored", hostUUID)},
+		},
+		contents: map[string][]byte{teamAProfile: mirrored, teamBProfile: mirrored},
+	})
 
-	// The host has already been moved to team B. It still carries the verified row for team A's profile, and team B's mirrored
-	// profile is not installed on it yet, so this tick both installs B's profile and makes A's profile a remove target.
-	ds.GetWindowsProfileReconcileSnapshotFunc = func(ctx context.Context, after string, batch int) (
-		[]*fleet.WindowsHostReconcileInfo,
-		[]*fleet.WindowsProfileForReconcile,
-		map[uint]map[uint]struct{},
-		map[string][]*fleet.MDMWindowsProfilePayload,
-		error,
-	) {
-		if after != "" {
-			return nil, nil, nil, nil, nil
-		}
-		teamBID := uint(2)
-		hosts := []*fleet.WindowsHostReconcileInfo{{HostID: 1, UUID: hostUUID, TeamID: &teamBID}}
-		profiles := []*fleet.WindowsProfileForReconcile{
-			{ProfileUUID: teamBProfile, ProfileName: "Mirrored", TeamID: teamBID, Checksum: checksum},
-		}
-		current := map[string][]*fleet.MDMWindowsProfilePayload{
-			hostUUID: {
-				{
-					ProfileUUID: teamAProfile, ProfileName: "Mirrored", HostUUID: hostUUID,
-					OperationType: fleet.MDMOperationTypeInstall, Status: &fleet.MDMDeliveryVerified, Checksum: checksum,
-				},
-			},
-		}
-		return hosts, profiles, nil, current, nil
-	}
-
-	ds.GetMDMWindowsProfilesContentsFunc = func(ctx context.Context, profileUUIDs []string) (map[string]fleet.MDMWindowsProfileContents, error) {
-		out := make(map[string]fleet.MDMWindowsProfileContents, len(profileUUIDs))
-		for _, uuid := range profileUUIDs {
-			out[uuid] = fleet.MDMWindowsProfileContents{SyncML: mirroredSyncML, Checksum: checksum}
-		}
-		return out, nil
-	}
-
-	// Both profiles still exist; only the host's team membership changed. This is what separates this case from a deleted profile.
-	ds.GetExistingMDMWindowsProfileUUIDsFunc = func(ctx context.Context, profileUUIDs []string) (map[string]struct{}, error) {
-		out := make(map[string]struct{}, len(profileUUIDs))
-		for _, u := range profileUUIDs {
-			out[u] = struct{}{}
-		}
-		return out, nil
-	}
-
-	var enqueuedCommands []*fleet.MDMWindowsCommand
-	ds.MDMWindowsInsertCommandAndUpsertHostProfilesForHostsFunc = func(ctx context.Context, hostUUIDs []string, cmd *fleet.MDMWindowsCommand, updates []*fleet.MDMWindowsBulkUpsertHostProfilePayload) error {
-		enqueuedCommands = append(enqueuedCommands, cmd)
-		return nil
-	}
-	ds.MDMWindowsBulkInsertCommandsFunc = func(ctx context.Context, cmds []*fleet.MDMWindowsCommand) error {
-		enqueuedCommands = append(enqueuedCommands, cmds...)
-		return nil
-	}
-
-	var deletedRows []*fleet.MDMWindowsProfilePayload
-	ds.BulkDeleteMDMWindowsHostsConfigProfilesFunc = func(ctx context.Context, payload []*fleet.MDMWindowsProfilePayload) error {
-		deletedRows = append(deletedRows, payload...)
-		return nil
-	}
-
-	require.NoError(t, ReconcileWindowsProfiles(ctx, ds, logger))
-
-	// The setting is never lifted from the device: team B's profile installs and no <Delete> goes out for the shared LocURI.
-	for _, cmd := range enqueuedCommands {
-		require.NotContains(t, string(cmd.RawCommand), "<Delete",
-			"the transfer must not open an enforcement gap on a LocURI the incoming profile still enforces")
-	}
+	result.requireNoDeleteCommands(t, "the transfer must not open an enforcement gap on a LocURI the incoming profile still enforces")
 	// Only the outgoing team's row is dropped, keyed by (profile, host), so the profile itself and other hosts still in team A
 	// are untouched.
-	require.True(t, ds.BulkDeleteMDMWindowsHostsConfigProfilesFuncInvoked,
-		"the outgoing team's row must not stay listed alongside the incoming team's profile")
-	require.Len(t, deletedRows, 1)
-	require.Equal(t, teamAProfile, deletedRows[0].ProfileUUID)
-	require.Equal(t, hostUUID, deletedRows[0].HostUUID)
+	require.Len(t, result.deletedRows, 1, "the outgoing team's row must not stay listed alongside the incoming team's profile")
+	require.Contains(t, result.deletedPairs(), teamAProfile+"|"+hostUUID)
 }
 
 // TestReconcileWindowsProfilesDeletesSuppressedRemoveRowsInOneBatch covers batch-replacing a team's whole profile set with
-// differently-named profiles carrying the same LocURIs. Every removed profile is fully protected by its replacement, so every
-// remove is suppressed at once. All the stale rows have to go, and they should go in a single datastore call: that call recomputes
-// the status rollup for every host it is handed, so one call per removed profile would redo the same rollup work for the same hosts
-// once per profile.
+// differently-named profiles carrying the same LocURIs, which suppresses every remove at once. All the stale rows have to go, and
+// they should go in a single datastore call: that call recomputes the status rollup for every host it is handed, so one call per
+// removed profile would redo the same rollup work for the same hosts once per profile.
 func TestReconcileWindowsProfilesDeletesSuppressedRemoveRowsInOneBatch(t *testing.T) {
-	ctx := context.Background()
-	ds := new(mock.Store)
-	logger := slog.New(slog.DiscardHandler)
-
 	const (
 		profileCount = 25
 		hostCount    = 4
 	)
-	checksum := []byte("test-checksum")
-	// Each old profile is replaced by a differently-named new profile targeting the identical LocURI.
-	syncMLFor := func(i int) []byte {
-		return []byte(fmt.Sprintf(
-			`<Replace><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Config/Experience/Setting%d</LocURI></Target><Data>0</Data></Item></Replace>`, i))
-	}
 	oldProfileUUID := func(i int) string { return fmt.Sprintf("old-profile-%d", i) }
 	newProfileUUID := func(i int) string { return fmt.Sprintf("new-profile-%d", i) }
 	hostUUIDFor := func(i int) string { return fmt.Sprintf("host-%d", i) }
+	teamID := uint(1)
 
-	setupReconcilerTest(ds, map[string]*fleet.MDMWindowsConfigProfile{})
-
-	ds.GetWindowsProfileReconcileSnapshotFunc = func(ctx context.Context, after string, batch int) (
-		[]*fleet.WindowsHostReconcileInfo,
-		[]*fleet.WindowsProfileForReconcile,
-		map[uint]map[uint]struct{},
-		map[string][]*fleet.MDMWindowsProfilePayload,
-		error,
-	) {
-		if after != "" {
-			return nil, nil, nil, nil, nil
-		}
-		teamID := uint(1)
-		hosts := make([]*fleet.WindowsHostReconcileInfo, 0, hostCount)
-		current := make(map[string][]*fleet.MDMWindowsProfilePayload, hostCount)
-		for h := range hostCount {
-			hosts = append(hosts, &fleet.WindowsHostReconcileInfo{HostID: uint(h + 1), UUID: hostUUIDFor(h), TeamID: &teamID})
-			rows := make([]*fleet.MDMWindowsProfilePayload, 0, profileCount)
-			for p := range profileCount {
-				// Only the old set is installed; the new set has just been applied and is not on the hosts yet.
-				rows = append(rows, &fleet.MDMWindowsProfilePayload{
-					ProfileUUID: oldProfileUUID(p), ProfileName: fmt.Sprintf("Old %d", p), HostUUID: hostUUIDFor(h),
-					OperationType: fleet.MDMOperationTypeInstall, Status: &fleet.MDMDeliveryVerified, Checksum: checksum,
-				})
-			}
-			current[hostUUIDFor(h)] = rows
-		}
-		profiles := make([]*fleet.WindowsProfileForReconcile, 0, profileCount)
+	snapshot := windowsReconcileSnapshot{
+		current:  make(map[string][]*fleet.MDMWindowsProfilePayload, hostCount),
+		contents: make(map[string][]byte, profileCount*2),
+	}
+	for h := range hostCount {
+		snapshot.hosts = append(snapshot.hosts, &fleet.WindowsHostReconcileInfo{HostID: uint(h + 1), UUID: hostUUIDFor(h), TeamID: &teamID})
+		rows := make([]*fleet.MDMWindowsProfilePayload, 0, profileCount)
 		for p := range profileCount {
-			profiles = append(profiles, &fleet.WindowsProfileForReconcile{
-				ProfileUUID: newProfileUUID(p), ProfileName: fmt.Sprintf("New %d", p), TeamID: teamID, Checksum: checksum,
-			})
+			// Only the old set is installed; the new set has just been applied and is not on the hosts yet.
+			rows = append(rows, installedRow(oldProfileUUID(p), fmt.Sprintf("Old %d", p), hostUUIDFor(h)))
 		}
-		return hosts, profiles, nil, current, nil
+		snapshot.current[hostUUIDFor(h)] = rows
+	}
+	for p := range profileCount {
+		snapshot.profiles = append(snapshot.profiles, &fleet.WindowsProfileForReconcile{
+			ProfileUUID: newProfileUUID(p), ProfileName: fmt.Sprintf("New %d", p), TeamID: teamID,
+			Checksum: []byte(windowsReconcileTestChecksum),
+		})
+		// Each old profile is replaced by a differently-named new profile targeting the identical LocURI.
+		shared := windowsTestProfileSyncML(fmt.Sprintf("Experience/Setting%d", p))
+		snapshot.contents[oldProfileUUID(p)] = shared
+		snapshot.contents[newProfileUUID(p)] = shared
 	}
 
-	ds.GetMDMWindowsProfilesContentsFunc = func(ctx context.Context, profileUUIDs []string) (map[string]fleet.MDMWindowsProfileContents, error) {
-		out := make(map[string]fleet.MDMWindowsProfileContents, len(profileUUIDs))
-		for _, uuid := range profileUUIDs {
-			var idx int
-			if _, err := fmt.Sscanf(uuid, "old-profile-%d", &idx); err != nil {
-				if _, err := fmt.Sscanf(uuid, "new-profile-%d", &idx); err != nil {
-					continue
-				}
-			}
-			out[uuid] = fleet.MDMWindowsProfileContents{SyncML: syncMLFor(idx), Checksum: checksum}
-		}
-		return out, nil
-	}
+	result := runWindowsReconcileOnce(t, snapshot)
 
-	var enqueuedCommands []*fleet.MDMWindowsCommand
-	ds.MDMWindowsInsertCommandAndUpsertHostProfilesForHostsFunc = func(ctx context.Context, hostUUIDs []string, cmd *fleet.MDMWindowsCommand, updates []*fleet.MDMWindowsBulkUpsertHostProfilePayload) error {
-		enqueuedCommands = append(enqueuedCommands, cmd)
-		return nil
-	}
-	ds.MDMWindowsBulkInsertCommandsFunc = func(ctx context.Context, cmds []*fleet.MDMWindowsCommand) error {
-		enqueuedCommands = append(enqueuedCommands, cmds...)
-		return nil
-	}
-
-	var deleteCallCount int
-	var deletedRows []*fleet.MDMWindowsProfilePayload
-	ds.BulkDeleteMDMWindowsHostsConfigProfilesFunc = func(ctx context.Context, payload []*fleet.MDMWindowsProfilePayload) error {
-		deleteCallCount++
-		deletedRows = append(deletedRows, payload...)
-		return nil
-	}
-
-	require.NoError(t, ReconcileWindowsProfiles(ctx, ds, logger))
-
-	for _, cmd := range enqueuedCommands {
-		require.NotContains(t, string(cmd.RawCommand), "<Delete",
-			"every removed LocURI is still enforced by its replacement, so no <Delete> may be sent")
-	}
-	// Every (old profile, host) pair is cleaned up, and the whole batch goes out in one call.
-	require.Len(t, deletedRows, profileCount*hostCount)
-	require.Equal(t, 1, deleteCallCount, "suppressed removes must be deleted in one batch, not one call per profile")
-	gotPairs := make(map[string]struct{}, len(deletedRows))
-	for _, row := range deletedRows {
-		gotPairs[row.ProfileUUID+"|"+row.HostUUID] = struct{}{}
-	}
+	result.requireNoDeleteCommands(t, "every removed LocURI is still enforced by its replacement, so no <Delete> may be sent")
+	require.Len(t, result.deletedRows, profileCount*hostCount)
+	require.Equal(t, 1, result.deleteCalls, "suppressed removes must be deleted in one batch, not one call per profile")
+	gotPairs := result.deletedPairs()
 	for p := range profileCount {
 		for h := range hostCount {
 			require.Contains(t, gotPairs, oldProfileUUID(p)+"|"+hostUUIDFor(h))

--- a/server/service/microsoft_mdm_test.go
+++ b/server/service/microsoft_mdm_test.go
@@ -1097,17 +1097,16 @@ type windowsReconcileResult struct {
 	deleteCalls int
 }
 
-// deletedPairs returns the deleted rows as a "profileUUID|hostUUID" set, which is how the tests below assert on them.
-func (r windowsReconcileResult) deletedPairs() map[string]struct{} {
-	out := make(map[string]struct{}, len(r.deletedRows))
+// deletedPairs returns the deleted rows as a set of (host, profile) keys, which is how the tests below assert on them.
+func (r windowsReconcileResult) deletedPairs() map[hostProfileKey]struct{} {
+	out := make(map[hostProfileKey]struct{}, len(r.deletedRows))
 	for _, row := range r.deletedRows {
-		out[row.ProfileUUID+"|"+row.HostUUID] = struct{}{}
+		out[hostProfileKey{hostUUID: row.HostUUID, profileUUID: row.ProfileUUID}] = struct{}{}
 	}
 	return out
 }
 
-// requireNoDeleteCommands asserts the tick sent no <Delete> at all. Every suppressed-remove test needs this: the whole point of
-// LocURI protection is that the setting stays enforced on the device, so cleaning up the host row must not open an enforcement gap.
+// requireNoDeleteCommands asserts the tick sent no <Delete> at all.
 func (r windowsReconcileResult) requireNoDeleteCommands(t *testing.T, msg string) {
 	t.Helper()
 	for _, cmd := range r.commands {
@@ -1121,7 +1120,7 @@ const windowsReconcileTestChecksum = "test-checksum"
 // differ only in the snapshot they set up and the assertions they make, so the mock wiring lives here.
 func runWindowsReconcileOnce(t *testing.T, snapshot windowsReconcileSnapshot) windowsReconcileResult {
 	t.Helper()
-	ctx := context.Background()
+	ctx := t.Context()
 	ds := new(mock.Store)
 	setupReconcilerTest(ds, map[string]*fleet.MDMWindowsConfigProfile{})
 
@@ -1186,45 +1185,103 @@ func windowsTestProfileSyncML(setting string) []byte {
 		`</LocURI></Target><Data>0</Data></Item></Replace>`)
 }
 
-// TestReconcileWindowsProfilesDeletesFullyProtectedRemoveRows covers a profile that is removed from a host while every one of its
-// LocURIs is still enforced by a profile that remains applicable to that host. There is no <Delete> to send, so no command ack will
-// ever arrive to clean the host's row up; the reconciler has to delete the row itself or the removed profile stays listed on the
-// host (and counted in the profile summary) forever.
-func TestReconcileWindowsProfilesDeletesFullyProtectedRemoveRows(t *testing.T) {
-	const (
-		hostUUID       = "host-a"
-		keptProfile    = "kept-profile-uuid"
-		removedProfile = "removed-profile-uuid"
-	)
-	// Both profiles enforce the same single LocURI, so the removed one is fully protected by the kept one.
-	shared := windowsTestProfileSyncML("Experience/AllowCortana")
-	teamID := uint(1)
-
-	// Only the kept profile is live, so the host's row for the removed profile becomes a remove target. The kept profile's row
-	// already matches the live checksum, so nothing is re-installed this tick.
-	result := runWindowsReconcileOnce(t, windowsReconcileSnapshot{
-		hosts: []*fleet.WindowsHostReconcileInfo{{HostID: 1, UUID: hostUUID, TeamID: &teamID}},
-		profiles: []*fleet.WindowsProfileForReconcile{
-			{ProfileUUID: keptProfile, ProfileName: "Kept", TeamID: teamID, Checksum: []byte(windowsReconcileTestChecksum)},
-		},
-		current: map[string][]*fleet.MDMWindowsProfilePayload{
-			hostUUID: {
-				installedRow(keptProfile, "Kept", hostUUID),
-				installedRow(removedProfile, "Removed", hostUUID),
+// TestReconcileWindowsProfilesDeletesSuppressedRemoveRows covers profiles removed from a host while every one of their LocURIs is
+// still enforced by a profile that remains applicable to that host. There is no <Delete> to send, so no command ack will ever
+// arrive to clean the host rows up; the reconciler has to delete them itself.
+func TestReconcileWindowsProfilesDeletesSuppressedRemoveRows(t *testing.T) {
+	// singleProfileReplaced: one host, one removed profile fully protected by the one profile still live on its team.
+	singleProfileReplaced := func() (windowsReconcileSnapshot, []hostProfileKey) {
+		const (
+			hostUUID       = "host-a"
+			keptProfile    = "kept-profile-uuid"
+			removedProfile = "removed-profile-uuid"
+		)
+		// Both profiles enforce the same single LocURI, so the removed one is fully protected by the kept one. The kept profile is
+		// already installed here, which is what makes this the minimal case: the tick sends nothing at all.
+		shared := windowsTestProfileSyncML("Experience/AllowCortana")
+		teamID := uint(1)
+		return windowsReconcileSnapshot{
+			hosts: []*fleet.WindowsHostReconcileInfo{{HostID: 1, UUID: hostUUID, TeamID: &teamID}},
+			profiles: []*fleet.WindowsProfileForReconcile{
+				{ProfileUUID: keptProfile, ProfileName: "Kept", TeamID: teamID, Checksum: []byte(windowsReconcileTestChecksum)},
 			},
-		},
-		contents: map[string][]byte{keptProfile: shared, removedProfile: shared},
-	})
+			current: map[string][]*fleet.MDMWindowsProfilePayload{
+				hostUUID: {
+					installedRow(keptProfile, "Kept", hostUUID),
+					installedRow(removedProfile, "Removed", hostUUID),
+				},
+			},
+			contents: map[string][]byte{keptProfile: shared, removedProfile: shared},
+		}, []hostProfileKey{{hostUUID: hostUUID, profileUUID: removedProfile}}
+	}
 
-	result.requireNoDeleteCommands(t, "no <Delete> can be sent while another profile still enforces the LocURI")
-	require.Len(t, result.deletedRows, 1, "the suppressed remove must delete the host's row instead of leaving it behind")
-	require.Contains(t, result.deletedPairs(), removedProfile+"|"+hostUUID)
+	// wholeSetReplaced: a team's entire profile set batch-replaced by differently-named profiles carrying the same LocURIs, so
+	// every remove is suppressed on the same tick. The replacements are not installed yet, so they install on this tick too and
+	// the no-<Delete> check has real commands to scan.
+	wholeSetReplaced := func() (windowsReconcileSnapshot, []hostProfileKey) {
+		const (
+			profileCount = 25
+			hostCount    = 4
+		)
+		oldProfileUUID := func(i int) string { return fmt.Sprintf("old-profile-%d", i) }
+		newProfileUUID := func(i int) string { return fmt.Sprintf("new-profile-%d", i) }
+		hostUUIDFor := func(i int) string { return fmt.Sprintf("host-%d", i) }
+		teamID := uint(1)
+
+		snapshot := windowsReconcileSnapshot{
+			current:  make(map[string][]*fleet.MDMWindowsProfilePayload, hostCount),
+			contents: make(map[string][]byte, profileCount*2),
+		}
+		var want []hostProfileKey
+		for h := range hostCount {
+			snapshot.hosts = append(snapshot.hosts, &fleet.WindowsHostReconcileInfo{HostID: uint(h + 1), UUID: hostUUIDFor(h), TeamID: &teamID})
+			rows := make([]*fleet.MDMWindowsProfilePayload, 0, profileCount)
+			for p := range profileCount {
+				// Only the old set is installed; the new set has just been applied and is not on the hosts yet.
+				rows = append(rows, installedRow(oldProfileUUID(p), fmt.Sprintf("Old %d", p), hostUUIDFor(h)))
+				want = append(want, hostProfileKey{hostUUID: hostUUIDFor(h), profileUUID: oldProfileUUID(p)})
+			}
+			snapshot.current[hostUUIDFor(h)] = rows
+		}
+		for p := range profileCount {
+			snapshot.profiles = append(snapshot.profiles, &fleet.WindowsProfileForReconcile{
+				ProfileUUID: newProfileUUID(p), ProfileName: fmt.Sprintf("New %d", p), TeamID: teamID,
+				Checksum: []byte(windowsReconcileTestChecksum),
+			})
+			// Each old profile is replaced by a differently-named new profile targeting the identical LocURI.
+			shared := windowsTestProfileSyncML(fmt.Sprintf("Experience/Setting%d", p))
+			snapshot.contents[oldProfileUUID(p)] = shared
+			snapshot.contents[newProfileUUID(p)] = shared
+		}
+		return snapshot, want
+	}
+
+	for _, tc := range []struct {
+		name  string
+		build func() (windowsReconcileSnapshot, []hostProfileKey)
+	}{
+		{name: "single profile replaced", build: singleProfileReplaced},
+		{name: "whole profile set replaced", build: wholeSetReplaced},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			snapshot, wantPairs := tc.build()
+
+			result := runWindowsReconcileOnce(t, snapshot)
+
+			result.requireNoDeleteCommands(t, "no <Delete> may be sent while another profile still enforces the LocURI")
+			require.Len(t, result.deletedRows, len(wantPairs),
+				"every suppressed remove must delete its host row instead of leaving it behind")
+			require.Equal(t, 1, result.deleteCalls, "suppressed removes must be deleted in one batch, not one call per profile")
+			gotPairs := result.deletedPairs()
+			for _, want := range wantPairs {
+				require.Contains(t, gotPairs, want)
+			}
+		})
+	}
 }
 
 // TestReconcileWindowsProfilesDeletesRemoveRowsWithNoLocURIs covers a removed profile whose content yields no LocURIs, so the
-// command comes back nil for a reason other than LocURI protection and the row would be stuck just the same. The parser's own
-// handling of empty, malformed, and Replace/Add-free content is covered by TestExtractLocURIsFromProfileBytes; all the reconciler
-// needs to handle is the empty result.
+// command comes back nil for a reason other than LocURI protection.
 func TestReconcileWindowsProfilesDeletesRemoveRowsWithNoLocURIs(t *testing.T) {
 	const (
 		hostUUID       = "host-a"
@@ -1248,18 +1305,17 @@ func TestReconcileWindowsProfilesDeletesRemoveRowsWithNoLocURIs(t *testing.T) {
 		},
 		contents: map[string][]byte{
 			keptProfile:    windowsTestProfileSyncML("Camera/AllowCamera"),
-			removedProfile: []byte(""),
+			removedProfile: []byte(""), // empty (no LocURIs)
 		},
 	})
 
 	require.Len(t, result.deletedRows, 1, "a profile with no LocURIs must not stay stuck on the host")
-	require.Contains(t, result.deletedPairs(), removedProfile+"|"+hostUUID)
+	require.Contains(t, result.deletedPairs(), hostProfileKey{hostUUID: hostUUID, profileUUID: removedProfile})
 }
 
 // TestReconcileWindowsProfilesDeletesRowAfterTransferToMirroredTeam covers transferring a host between two teams whose profiles
 // enforce the same LocURIs. Unlike the deleted-profile case, the outgoing profile still exists (it just no longer applies here)
-// and the protecting profile is not installed yet: it is only desired, and it installs on this same tick. That is what makes this
-// distinct — protection has to come from the desired set, not from what is already on the host.
+// and the protecting profile is not installed yet: it is only desired, and it installs on this same tick.
 func TestReconcileWindowsProfilesDeletesRowAfterTransferToMirroredTeam(t *testing.T) {
 	const (
 		hostUUID     = "transferred-host"
@@ -1283,61 +1339,9 @@ func TestReconcileWindowsProfilesDeletesRowAfterTransferToMirroredTeam(t *testin
 	})
 
 	result.requireNoDeleteCommands(t, "the transfer must not open an enforcement gap on a LocURI the incoming profile still enforces")
-	// Only the outgoing team's row is dropped, keyed by (profile, host), so the profile itself and other hosts still in team A
-	// are untouched.
+	// Only the outgoing team's row is dropped, keyed by (profile, host), so the profile itself and other hosts still in team A are untouched.
 	require.Len(t, result.deletedRows, 1, "the outgoing team's row must not stay listed alongside the incoming team's profile")
-	require.Contains(t, result.deletedPairs(), teamAProfile+"|"+hostUUID)
-}
-
-// TestReconcileWindowsProfilesDeletesSuppressedRemoveRowsInOneBatch covers batch-replacing a team's whole profile set with
-// differently-named profiles carrying the same LocURIs, which suppresses every remove at once. All the stale rows have to go, and
-// they should go in a single datastore call: that call recomputes the status rollup for every host it is handed, so one call per
-// removed profile would redo the same rollup work for the same hosts once per profile.
-func TestReconcileWindowsProfilesDeletesSuppressedRemoveRowsInOneBatch(t *testing.T) {
-	const (
-		profileCount = 25
-		hostCount    = 4
-	)
-	oldProfileUUID := func(i int) string { return fmt.Sprintf("old-profile-%d", i) }
-	newProfileUUID := func(i int) string { return fmt.Sprintf("new-profile-%d", i) }
-	hostUUIDFor := func(i int) string { return fmt.Sprintf("host-%d", i) }
-	teamID := uint(1)
-
-	snapshot := windowsReconcileSnapshot{
-		current:  make(map[string][]*fleet.MDMWindowsProfilePayload, hostCount),
-		contents: make(map[string][]byte, profileCount*2),
-	}
-	for h := range hostCount {
-		snapshot.hosts = append(snapshot.hosts, &fleet.WindowsHostReconcileInfo{HostID: uint(h + 1), UUID: hostUUIDFor(h), TeamID: &teamID})
-		rows := make([]*fleet.MDMWindowsProfilePayload, 0, profileCount)
-		for p := range profileCount {
-			// Only the old set is installed; the new set has just been applied and is not on the hosts yet.
-			rows = append(rows, installedRow(oldProfileUUID(p), fmt.Sprintf("Old %d", p), hostUUIDFor(h)))
-		}
-		snapshot.current[hostUUIDFor(h)] = rows
-	}
-	for p := range profileCount {
-		snapshot.profiles = append(snapshot.profiles, &fleet.WindowsProfileForReconcile{
-			ProfileUUID: newProfileUUID(p), ProfileName: fmt.Sprintf("New %d", p), TeamID: teamID,
-			Checksum: []byte(windowsReconcileTestChecksum),
-		})
-		// Each old profile is replaced by a differently-named new profile targeting the identical LocURI.
-		shared := windowsTestProfileSyncML(fmt.Sprintf("Experience/Setting%d", p))
-		snapshot.contents[oldProfileUUID(p)] = shared
-		snapshot.contents[newProfileUUID(p)] = shared
-	}
-
-	result := runWindowsReconcileOnce(t, snapshot)
-
-	result.requireNoDeleteCommands(t, "every removed LocURI is still enforced by its replacement, so no <Delete> may be sent")
-	require.Len(t, result.deletedRows, profileCount*hostCount)
-	require.Equal(t, 1, result.deleteCalls, "suppressed removes must be deleted in one batch, not one call per profile")
-	gotPairs := result.deletedPairs()
-	for p := range profileCount {
-		for h := range hostCount {
-			require.Contains(t, gotPairs, oldProfileUUID(p)+"|"+hostUUIDFor(h))
-		}
-	}
+	require.Contains(t, result.deletedPairs(), hostProfileKey{hostUUID: hostUUID, profileUUID: teamAProfile})
 }
 
 // TestReconcileWindowsProfilesSkipsInsertLag covers the asymmetric race


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:**
Resolves #50907
Resolves #50698
Resolves #49002

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Fixed stale Windows configuration profiles remaining in Host details after profile deletion, renaming, or host fleet transfers.
- Host OS settings now accurately reflect the profiles still enforcing each setting.
- Host status summaries are recalculated correctly after profile changes.
- Prevented unnecessary device delete commands when another profile still protects the same settings.
- Removed obsolete profile entries even when no device command is required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->