### PR TITLE
Add osquery-perf Apple MDM profile tracking

### DIFF
--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -512,6 +512,14 @@ type agent struct {
 	// already responded NotNow to, so the redelivered command is acknowledged.
 	notNowProfiles map[string]bool
 
+	// installedProfiles tracks the configuration profiles this agent has
+	// acknowledged installing, keyed by channel ("device" or "user") + "/" +
+	// payload identifier. The MDM loop goroutine writes it while the osquery
+	// query goroutines read it to answer profile verification queries (see
+	// mdmConfigProfilesMac), hence the mutex.
+	installedProfilesMu sync.Mutex
+	installedProfiles   map[string]installedMDMProfile
+
 	disableScriptExec   bool
 	disableFleetDesktop bool
 	loggerTLSMaxLines   int
@@ -918,6 +926,7 @@ func (a *agent) runLoop(i int, onlyAlreadyEnrolled bool) {
 	if a.macMDMClient != nil {
 		mdmEnrollWithRetry("macOS", a.stats.IncrementMDMErrors, a.macMDMClient.Enroll)
 		a.setMDMEnrolled()
+		a.seedEnrollmentProfile()
 		a.stats.IncrementMDMEnrollments()
 
 		if rand.Float64() < a.mdmUserProb {
@@ -1286,6 +1295,127 @@ func (a *agent) runOrbitLoop() {
 	}
 }
 
+// installedMDMProfile is a configuration profile a simulated device has
+// acknowledged installing via MDM.
+type installedMDMProfile struct {
+	identifier  string
+	displayName string
+	installDate time.Time
+}
+
+// installProfilePayload returns the raw (unsigned) mobileconfig carried by a
+// delivered InstallProfile command, or nil if the command is not an
+// InstallProfile or cannot be parsed.
+func installProfilePayload(cmd *mdm.Command) []byte {
+	var full micromdm.CommandPayload
+	if err := plist.Unmarshal(cmd.Raw, &full); err != nil || full.Command.InstallProfile == nil {
+		return nil
+	}
+	profile := full.Command.InstallProfile.Payload
+	// The mobileconfig may be PKCS7-signed; unwrap to the raw XML plist.
+	if !bytes.HasPrefix(profile, []byte("<?xml")) {
+		p7, err := pkcs7.Parse(profile)
+		if err != nil {
+			return nil
+		}
+		profile = p7.Content
+	}
+	return profile
+}
+
+// parseInstallProfileCommand extracts the payload identifier and display name
+// of the profile carried by a delivered InstallProfile command.
+func parseInstallProfileCommand(cmd *mdm.Command) (identifier, displayName string, ok bool) {
+	profile := installProfilePayload(cmd)
+	if profile == nil {
+		return "", "", false
+	}
+	var parsed struct {
+		PayloadIdentifier  string `plist:"PayloadIdentifier"`
+		PayloadDisplayName string `plist:"PayloadDisplayName"`
+	}
+	if err := plist.Unmarshal(profile, &parsed); err != nil || parsed.PayloadIdentifier == "" {
+		return "", "", false
+	}
+	if parsed.PayloadDisplayName == "" {
+		parsed.PayloadDisplayName = parsed.PayloadIdentifier
+	}
+	return parsed.PayloadIdentifier, parsed.PayloadDisplayName, true
+}
+
+// removeProfileIdentifier returns the payload identifier targeted by a
+// delivered RemoveProfile command, or "" if the command cannot be parsed.
+func removeProfileIdentifier(cmd *mdm.Command) string {
+	var full micromdm.CommandPayload
+	if err := plist.Unmarshal(cmd.Raw, &full); err != nil || full.Command.RemoveProfile == nil {
+		return ""
+	}
+	return full.Command.RemoveProfile.Identifier
+}
+
+// profileNotFoundErrChain is the error a real Apple device reports when asked
+// to remove a profile that is not installed. The server treats it as a
+// successful removal (see apple_mdm.IsProfileNotFoundError).
+func profileNotFoundErrChain(identifier string) []mdm.ErrorChain {
+	return []mdm.ErrorChain{
+		{
+			ErrorCode:            89,
+			ErrorDomain:          "MDMClientError",
+			LocalizedDescription: fmt.Sprintf("Profile with identifier '%s' not found.", identifier),
+		},
+	}
+}
+
+// recordInstalledProfile tracks the profile carried by an acknowledged
+// InstallProfile command as installed on the given channel.
+func (a *agent) recordInstalledProfile(channel string, cmd *mdm.Command) {
+	identifier, displayName, ok := parseInstallProfileCommand(cmd)
+	if !ok {
+		return
+	}
+	a.installedProfilesMu.Lock()
+	defer a.installedProfilesMu.Unlock()
+	if a.installedProfiles == nil {
+		a.installedProfiles = make(map[string]installedMDMProfile)
+	}
+	a.installedProfiles[channel+"/"+identifier] = installedMDMProfile{
+		identifier:  identifier,
+		displayName: displayName,
+		installDate: time.Now(),
+	}
+}
+
+// removeInstalledProfile untracks the given profile identifier on the given
+// channel, reporting whether it was installed (i.e. whether a RemoveProfile
+// command for it should succeed).
+func (a *agent) removeInstalledProfile(channel, identifier string) bool {
+	a.installedProfilesMu.Lock()
+	defer a.installedProfilesMu.Unlock()
+	key := channel + "/" + identifier
+	if _, ok := a.installedProfiles[key]; !ok {
+		return false
+	}
+	delete(a.installedProfiles, key)
+	return true
+}
+
+// seedEnrollmentProfile tracks the Fleet enrollment profile as installed on
+// the device channel. It is installed during enrollment rather than via an
+// InstallProfile command, and the server sends a RemoveProfile for it when a
+// host is unenrolled, so it must be tracked for that removal to succeed.
+func (a *agent) seedEnrollmentProfile() {
+	a.installedProfilesMu.Lock()
+	defer a.installedProfilesMu.Unlock()
+	if a.installedProfiles == nil {
+		a.installedProfiles = make(map[string]installedMDMProfile)
+	}
+	a.installedProfiles["device/"+apple_mdm.FleetPayloadIdentifier] = installedMDMProfile{
+		identifier:  apple_mdm.FleetPayloadIdentifier,
+		displayName: "Enrollment Profile",
+		installDate: time.Now(),
+	}
+}
+
 // profileNotNowRequested reports whether the delivered InstallProfile command
 // carries a profile whose decoded content contains the marker string "NotNow"
 // and this agent has not yet responded NotNow to that profile identifier on
@@ -1293,20 +1423,8 @@ func (a *agent) runOrbitLoop() {
 // redelivered command is acknowledged. Only called from the MDM loop
 // goroutine, so notNowProfiles needs no locking.
 func (a *agent) profileNotNowRequested(cmd *mdm.Command, channel string) bool {
-	var full micromdm.CommandPayload
-	if err := plist.Unmarshal(cmd.Raw, &full); err != nil || full.Command.InstallProfile == nil {
-		return false
-	}
-	profile := full.Command.InstallProfile.Payload
-	// The mobileconfig may be PKCS7-signed; unwrap to the raw XML plist.
-	if !bytes.HasPrefix(profile, []byte("<?xml")) {
-		p7, err := pkcs7.Parse(profile)
-		if err != nil {
-			return false
-		}
-		profile = p7.Content
-	}
-	if !bytes.Contains(profile, []byte("NotNow")) {
+	profile := installProfilePayload(cmd)
+	if profile == nil || !bytes.Contains(profile, []byte("NotNow")) {
 		return false
 	}
 	var parsed struct {
@@ -1386,12 +1504,27 @@ func (a *agent) runMacosMDMLoop() {
 						}
 					}
 
+					a.recordInstalledProfile("device", mdmCommandPayload)
+
 					mdmCommandPayload, err = a.macMDMClient.Acknowledge(mdmCommandPayload.CommandUUID)
 					if err != nil {
 						log.Printf("MDM Acknowledge request failed: %s", err)
 						a.stats.IncrementMDMErrors()
 						break INNER_FOR_LOOP
 					}
+				}
+
+			case "RemoveProfile":
+				identifier := removeProfileIdentifier(mdmCommandPayload)
+				if identifier != "" && a.removeInstalledProfile("device", identifier) {
+					mdmCommandPayload, err = a.macMDMClient.Acknowledge(mdmCommandPayload.CommandUUID)
+				} else {
+					mdmCommandPayload, err = a.macMDMClient.Err(mdmCommandPayload.CommandUUID, profileNotFoundErrChain(identifier))
+				}
+				if err != nil {
+					log.Printf("MDM RemoveProfile response failed: %s", err)
+					a.stats.IncrementMDMErrors()
+					break INNER_FOR_LOOP
 				}
 
 			case "DeclarativeManagement":
@@ -1566,12 +1699,27 @@ func (a *agent) runMacosMDMLoop() {
 							continue
 						}
 
+						a.recordInstalledProfile("user", mdmCommandPayload)
+
 						mdmCommandPayload, err = a.macMDMClient.UserAcknowledge(mdmCommandPayload.CommandUUID)
 						if err != nil {
 							log.Printf("MDM Acknowledge request failed: %s", err)
 							a.stats.IncrementMDMUserErrors()
 							break INNER_FOR_LOOP_USER
 						}
+					}
+
+				case "RemoveProfile":
+					identifier := removeProfileIdentifier(mdmCommandPayload)
+					if identifier != "" && a.removeInstalledProfile("user", identifier) {
+						mdmCommandPayload, err = a.macMDMClient.UserAcknowledge(mdmCommandPayload.CommandUUID)
+					} else {
+						mdmCommandPayload, err = a.macMDMClient.UserChannelErr(mdmCommandPayload.CommandUUID, profileNotFoundErrChain(identifier))
+					}
+					if err != nil {
+						log.Printf("MDM RemoveProfile response failed: %s", err)
+						a.stats.IncrementMDMUserErrors()
+						break INNER_FOR_LOOP_USER
 					}
 
 				case "DeclarativeManagement":
@@ -2926,14 +3074,23 @@ func (a *agent) mdmMac() []map[string]string {
 	}
 }
 
+// mdmConfigProfilesMac returns the profiles this agent has acknowledged
+// installing on the device and user channels, merged as the server's
+// mdm_config_profiles_darwin_with_user query does with the macos_profiles and
+// macos_user_profiles tables.
 func (a *agent) mdmConfigProfilesMac() []map[string]string {
-	return []map[string]string{
-		{
-			"identifier":   "osquery-perf",
-			"display_name": "OSQuery Perf Agent",
-			"install_date": "2006-01-02 15:04:05 -0700",
-		},
+	a.installedProfilesMu.Lock()
+	defer a.installedProfilesMu.Unlock()
+
+	results := make([]map[string]string, 0, len(a.installedProfiles))
+	for _, profile := range a.installedProfiles {
+		results = append(results, map[string]string{
+			"identifier":   profile.identifier,
+			"display_name": profile.displayName,
+			"install_date": profile.installDate.Format("2006-01-02 15:04:05 -0700"),
+		})
 	}
+	return results
 }
 
 func (a *agent) entraConditionalAccess() []map[string]string {
@@ -3283,7 +3440,13 @@ func (a *agent) processQuery(name, query string, cachedResults *cachedResults) (
 			ss = statusNotOK
 		}
 		return true, results, &ss, nil, nil
-	case name == hostDetailQueryPrefix+"mdm_config_profiles_darwin_with_user", name == hostDetailQueryPrefix+"mdm_config_profiles_darwin":
+	case name == hostDetailQueryPrefix+"mdm_config_profiles_darwin":
+		// Simulated fleetd has the macos_user_profiles table, so this legacy
+		// query's discovery fails (it requires the table to NOT exist) and
+		// only mdm_config_profiles_darwin_with_user runs. Report no results
+		// and no status, as osquery does for queries whose discovery fails.
+		return true, nil, nil, nil, nil
+	case name == hostDetailQueryPrefix+"mdm_config_profiles_darwin_with_user":
 		ss := statusOK
 		if rand.Intn(10) > 0 { // 90% success
 			results = a.mdmConfigProfilesMac()
@@ -3842,6 +4005,13 @@ func (a *mdmAgent) runAppleIDeviceMDMLoop(mdmSCEPChallenge string) {
 
 	a.stats.IncrementMDMEnrollments()
 
+	// installedProfiles tracks the profiles this device has acknowledged
+	// installing, so RemoveProfile commands succeed or fail like on a real
+	// device. Seeded with the enrollment profile, which is installed during
+	// enrollment rather than via an InstallProfile command. Only this
+	// goroutine touches it, so it needs no locking.
+	installedProfiles := map[string]struct{}{apple_mdm.FleetPayloadIdentifier: {}}
+
 	mdmCheckInTicker := time.Tick(a.MDMCheckInInterval)
 
 	for range mdmCheckInTicker {
@@ -3881,7 +4051,18 @@ func (a *mdmAgent) runAppleIDeviceMDMLoop(mdmSCEPChallenge string) {
 					}
 					mdmCommandPayload, err = mdmClient.Err(mdmCommandPayload.CommandUUID, errChain)
 				} else {
+					if identifier, _, ok := parseInstallProfileCommand(mdmCommandPayload); ok {
+						installedProfiles[identifier] = struct{}{}
+					}
 					mdmCommandPayload, err = mdmClient.Acknowledge(mdmCommandPayload.CommandUUID)
+				}
+			case "RemoveProfile":
+				identifier := removeProfileIdentifier(mdmCommandPayload)
+				if _, ok := installedProfiles[identifier]; identifier != "" && ok {
+					delete(installedProfiles, identifier)
+					mdmCommandPayload, err = mdmClient.Acknowledge(mdmCommandPayload.CommandUUID)
+				} else {
+					mdmCommandPayload, err = mdmClient.Err(mdmCommandPayload.CommandUUID, profileNotFoundErrChain(identifier))
 				}
 
 			default:

--- a/cmd/osquery-perf/agent_test.go
+++ b/cmd/osquery-perf/agent_test.go
@@ -1,21 +1,26 @@
 package main
 
 import (
+	cryptorand "crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/base64"
 	"fmt"
+	"math/big"
 	"testing"
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
 	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/mdm"
+	"github.com/smallstep/pkcs7"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func installProfileCommand(t *testing.T, identifier, displayName string) *mdm.Command {
-	t.Helper()
-	mobileconfig := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+func mobileconfigPayload(identifier, displayName string) []byte {
+	return fmt.Appendf(nil, `<?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
 	<key>PayloadIdentifier</key>
@@ -26,6 +31,9 @@ func installProfileCommand(t *testing.T, identifier, displayName string) *mdm.Co
 	<string>Configuration</string>
 </dict>
 </plist>`, identifier, displayName)
+}
+
+func installProfileCommandWithPayload(payload []byte) *mdm.Command {
 	raw := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0">
 <dict>
@@ -39,8 +47,13 @@ func installProfileCommand(t *testing.T, identifier, displayName string) *mdm.Co
 		<data>%s</data>
 	</dict>
 </dict>
-</plist>`, base64.StdEncoding.EncodeToString([]byte(mobileconfig)))
+</plist>`, base64.StdEncoding.EncodeToString(payload))
 	return &mdm.Command{Raw: []byte(raw)}
+}
+
+func installProfileCommand(t *testing.T, identifier, displayName string) *mdm.Command {
+	t.Helper()
+	return installProfileCommandWithPayload(mobileconfigPayload(identifier, displayName))
 }
 
 func removeProfileCommand(identifier string) *mdm.Command {
@@ -80,6 +93,38 @@ func TestParseInstallProfileCommand(t *testing.T) {
 	// garbage payload
 	_, _, ok = parseInstallProfileCommand(&mdm.Command{Raw: []byte("not a plist")})
 	assert.False(t, ok)
+}
+
+// TestParseInstallProfileCommandSigned covers the PKCS7 branch of
+// installProfilePayload. Fleet always signs profiles before sending them (see
+// MDMAppleCommander.SignAndEncodeInstallProfile), so this is the path every
+// real InstallProfile command takes.
+func TestParseInstallProfileCommandSigned(t *testing.T) {
+	key, err := rsa.GenerateKey(cryptorand.Reader, 2048)
+	require.NoError(t, err)
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "osquery-perf test signer"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(cryptorand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+
+	signedData, err := pkcs7.NewSignedData(mobileconfigPayload("com.example.signed", "Signed Profile"))
+	require.NoError(t, err)
+	require.NoError(t, signedData.AddSigner(cert, key, pkcs7.SignerInfoConfig{}))
+	signed, err := signedData.Finish()
+	require.NoError(t, err)
+
+	identifier, displayName, ok := parseInstallProfileCommand(installProfileCommandWithPayload(signed))
+	require.True(t, ok)
+	assert.Equal(t, "com.example.signed", identifier)
+	assert.Equal(t, "Signed Profile", displayName)
 }
 
 func TestRemoveProfileIdentifier(t *testing.T) {

--- a/cmd/osquery-perf/agent_test.go
+++ b/cmd/osquery-perf/agent_test.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"encoding/base64"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
+	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/mdm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func installProfileCommand(t *testing.T, identifier, displayName string) *mdm.Command {
+	t.Helper()
+	mobileconfig := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>PayloadIdentifier</key>
+	<string>%s</string>
+	<key>PayloadDisplayName</key>
+	<string>%s</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+</dict>
+</plist>`, identifier, displayName)
+	raw := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>CommandUUID</key>
+	<string>cmd-uuid</string>
+	<key>Command</key>
+	<dict>
+		<key>RequestType</key>
+		<string>InstallProfile</string>
+		<key>Payload</key>
+		<data>%s</data>
+	</dict>
+</dict>
+</plist>`, base64.StdEncoding.EncodeToString([]byte(mobileconfig)))
+	return &mdm.Command{Raw: []byte(raw)}
+}
+
+func removeProfileCommand(identifier string) *mdm.Command {
+	raw := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>CommandUUID</key>
+	<string>cmd-uuid</string>
+	<key>Command</key>
+	<dict>
+		<key>RequestType</key>
+		<string>RemoveProfile</string>
+		<key>Identifier</key>
+		<string>%s</string>
+	</dict>
+</dict>
+</plist>`, identifier)
+	return &mdm.Command{Raw: []byte(raw)}
+}
+
+func TestParseInstallProfileCommand(t *testing.T) {
+	identifier, displayName, ok := parseInstallProfileCommand(installProfileCommand(t, "com.example.test", "Test Profile"))
+	require.True(t, ok)
+	assert.Equal(t, "com.example.test", identifier)
+	assert.Equal(t, "Test Profile", displayName)
+
+	// display name falls back to the identifier when absent
+	identifier, displayName, ok = parseInstallProfileCommand(installProfileCommand(t, "com.example.noname", ""))
+	require.True(t, ok)
+	assert.Equal(t, "com.example.noname", identifier)
+	assert.Equal(t, "com.example.noname", displayName)
+
+	// not an InstallProfile command
+	_, _, ok = parseInstallProfileCommand(removeProfileCommand("com.example.test"))
+	assert.False(t, ok)
+
+	// garbage payload
+	_, _, ok = parseInstallProfileCommand(&mdm.Command{Raw: []byte("not a plist")})
+	assert.False(t, ok)
+}
+
+func TestRemoveProfileIdentifier(t *testing.T) {
+	assert.Equal(t, "com.example.test", removeProfileIdentifier(removeProfileCommand("com.example.test")))
+	assert.Empty(t, removeProfileIdentifier(installProfileCommand(t, "com.example.test", "Test Profile")))
+	assert.Empty(t, removeProfileIdentifier(&mdm.Command{Raw: []byte("not a plist")}))
+}
+
+func TestInstalledProfileTracking(t *testing.T) {
+	a := &agent{}
+
+	// nothing installed yet
+	assert.Empty(t, a.mdmConfigProfilesMac())
+	assert.False(t, a.removeInstalledProfile("device", "com.example.test"))
+
+	a.seedEnrollmentProfile()
+	a.recordInstalledProfile("device", installProfileCommand(t, "com.example.device", "Device Profile"))
+	a.recordInstalledProfile("user", installProfileCommand(t, "com.example.user", "User Profile"))
+
+	results := a.mdmConfigProfilesMac()
+	require.Len(t, results, 3)
+	byIdentifier := make(map[string]map[string]string, len(results))
+	for _, row := range results {
+		byIdentifier[row["identifier"]] = row
+	}
+	require.Contains(t, byIdentifier, apple_mdm.FleetPayloadIdentifier)
+	require.Contains(t, byIdentifier, "com.example.device")
+	require.Contains(t, byIdentifier, "com.example.user")
+	assert.Equal(t, "Device Profile", byIdentifier["com.example.device"]["display_name"])
+
+	// install_date must be in the format the server's
+	// parseMacOSProfileInstallDate expects, and recent
+	installDate, err := time.Parse("2006-01-02 15:04:05 -0700", byIdentifier["com.example.device"]["install_date"])
+	require.NoError(t, err)
+	assert.WithinDuration(t, time.Now(), installDate, time.Minute)
+
+	// removal is channel-scoped
+	assert.False(t, a.removeInstalledProfile("user", "com.example.device"))
+	assert.True(t, a.removeInstalledProfile("device", "com.example.device"))
+	assert.False(t, a.removeInstalledProfile("device", "com.example.device"))
+	assert.True(t, a.removeInstalledProfile("user", "com.example.user"))
+	assert.True(t, a.removeInstalledProfile("device", apple_mdm.FleetPayloadIdentifier))
+	assert.Empty(t, a.mdmConfigProfilesMac())
+}
+
+func TestProcessQueryMDMConfigProfiles(t *testing.T) {
+	a := &agent{}
+	a.seedEnrollmentProfile()
+	var cached cachedResults
+
+	// The legacy device-only query simulates a failed osquery discovery:
+	// handled, but nothing submitted for it.
+	handled, results, status, message, stats := a.processQuery("fleet_detail_query_mdm_config_profiles_darwin", "SELECT 1;", &cached)
+	assert.True(t, handled)
+	assert.Nil(t, results)
+	assert.Nil(t, status)
+	assert.Nil(t, message)
+	assert.Nil(t, stats)
+
+	// The with-user query reports the tracked profiles. It simulates a failed
+	// query ~10% of the time, so retry until a success is observed.
+	sawSuccess := false
+	for i := 0; i < 100 && !sawSuccess; i++ {
+		handled, results, status, _, _ := a.processQuery("fleet_detail_query_mdm_config_profiles_darwin_with_user", "SELECT 1;", &cached)
+		require.True(t, handled)
+		require.NotNil(t, status)
+		if *status == fleet.StatusOK {
+			require.Len(t, results, 1)
+			assert.Equal(t, apple_mdm.FleetPayloadIdentifier, results[0]["identifier"])
+			sawSuccess = true
+		} else {
+			assert.Empty(t, results)
+		}
+	}
+	assert.True(t, sawSuccess)
+}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #50575

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

No changes file needed

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added tracking for acknowledged macOS MDM configuration profiles across device and user channels.
  - Added support for installing, removing, and querying profiles on simulated iOS and iPadOS devices.
  - Enrollment profiles are retained and reflected in profile queries.
  - Profile details now include display names and formatted installation dates.

- **Bug Fixes**
  - Improved validation for profile installation and removal commands.
  - Profile removal is correctly scoped to the applicable device or user channel.
  - Added retry handling for intermittent profile-query failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->