### PR TITLE
Fleet UI: Fix stale data after saves under replica lag

### DIFF
--- a/.github/scripts/detect-read-after-write.sh
+++ b/.github/scripts/detect-read-after-write.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+#
+# Detects frontend read-after-write anti-patterns.
+#
+# The pattern: after a write (POST/PATCH/DELETE), the frontend re-reads the
+# same resource — via `refetchXxx()`, `queryClient.invalidateQueries(<same
+# key>)`, or a follow-up GET. In production with slow read-replica lag, the
+# re-read returns stale data and the user sees their save "disappear".
+#
+# Fix: use the write response directly. For app config, use the
+# `useUpdateAppConfig` hook. For other resources, use
+# `queryClient.setQueryData(key, response)` with the mutation payload.
+#
+# This script flags the patterns most reliably indicative of the bug. It is
+# a heuristic, not a proof — cross-resource invalidations (e.g. label edit
+# invalidating the hosts list) are legitimate, and sites blocked on a
+# backend change are tracked in the ALLOWLIST below.
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+# Files intentionally exempt. Each entry needs a one-line reason.
+# Prefer removing entries as the backend catches up; do not add without a
+# reason a reviewer would accept.
+ALLOWLIST=(
+  # Backend response-shape follow-up: these writes don't return the updated
+  # config today. Tracked separately for a PR that changes the endpoints.
+  "frontend/pages/admin/OrgSettingsPage/cards/Info/Info.tsx"
+  "frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleMdmPage/AppleMdmPage.tsx"
+  "frontend/pages/admin/IntegrationsPage/cards/ConditionalAccess/ConditionalAccess.tsx"
+  "frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/BootstrapPackage.tsx"
+  "frontend/pages/ManageControlsPage/SetupExperience/cards/Users/components/UsersForm/UsersForm.tsx"
+  "frontend/pages/ManageControlsPage/OSSettings/cards/HostNameTemplate/HostNameTemplate.tsx"
+
+  # Design follow-up: the refetch here is load-bearing UX (form reset via
+  # remount), not just cache sync. Untangle before flipping the pattern.
+  "frontend/pages/ManageControlsPage/OSUpdates/components/AppleOSTargetForm/AppleOSTargetForm.tsx"
+  "frontend/pages/ManageControlsPage/OSUpdates/components/WindowsTargetForm/WindowsTargetForm.tsx"
+  "frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/InstallSoftwareForm/InstallSoftwareForm.tsx"
+
+  # List refetches over search-filtered results — splicing into the cache
+  # correctly requires knowing whether the new/updated row matches the
+  # active filter. Left as-is until we replace with a mutation hook.
+  "frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/UsersPage/UsersPage.tsx"
+
+  # Legitimate cross-resource invalidations after a write. The write's OWN
+  # key is primed directly; the extra invalidateQueries here targets a
+  # DIFFERENT resource (hosts membership, scim_details, teams list…) whose
+  # state may have changed as a side effect.
+  "frontend/pages/labels/EditLabelPage/EditLabelPage.tsx"
+  "frontend/pages/admin/IntegrationsPage/cards/IdentityProviders/components/GoogleWorkspaceSection/GoogleWorkspaceSection.tsx"
+  "frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/TeamDetailsWrapper.tsx"
+
+  # Auth flows load /config directly after the auth op (signin, MFA, reset)
+  # rather than through a mounted useQuery — AppContext isn't wired yet.
+  # The preceding write is the auth call, not a config write, so this
+  # isn't a read-after-write on the config resource.
+  "frontend/components/App/App.tsx"
+  "frontend/pages/MfaPage/MfaPage.tsx"
+  "frontend/pages/LoginPage/LoginPage.tsx"
+  "frontend/pages/ResetPasswordPage/ResetPasswordPage.tsx"
+
+  # Mutation error handler: the request failed, so there is no fresh
+  # response to prime the cache with. Invalidating is the least-bad
+  # fallback until the mutation can pass through a proper error payload.
+  "frontend/pages/policies/hooks/useUpdatePolicyAutomations.ts"
+)
+
+# grep -v pattern joining every allowlist entry.
+BUILD_EXCLUDE() {
+  local pattern=""
+  for path in "${ALLOWLIST[@]}"; do
+    if [[ -z "$pattern" ]]; then
+      pattern="$path"
+    else
+      pattern="$pattern|$path"
+    fi
+  done
+  printf "%s" "$pattern"
+}
+EXCLUDE_RE="$(BUILD_EXCLUDE)"
+
+# Filters flagged lines against ALLOWLIST and test/story files.
+filter() {
+  grep -Ev "^($EXCLUDE_RE):" \
+    | grep -Ev '\.tests?\.tsx?:' \
+    | grep -Ev '\.stories\.tsx?:' \
+    || true
+}
+
+echo "Scanning frontend for read-after-write patterns…"
+echo
+
+VIOLATIONS=0
+REPORT=""
+
+flag() {
+  local label="$1"
+  local pattern="$2"
+  local hits
+  hits=$(grep -rn -E "$pattern" frontend \
+    --include='*.tsx' --include='*.ts' 2>/dev/null | filter || true)
+  if [[ -n "$hits" ]]; then
+    local count
+    count=$(printf "%s\n" "$hits" | wc -l | tr -d ' ')
+    VIOLATIONS=$((VIOLATIONS + count))
+    REPORT+=$'\n'"[$label] $count hit(s):"$'\n'"$hits"$'\n'
+  fi
+}
+
+# 1. Bare `refetchConfig()` — nearly always the app-config self-refetch.
+flag "refetch-config" 'refetchConfig\s*\('
+
+# 2. Any refetch alias that unambiguously targets an app/team config query.
+flag "refetch-appconfig-alias" 'refetch(App|Team|Software|Global)Config\s*\('
+
+# 3. Self-key invalidation of the app config after a write. This IS the
+#    canonical shape of the bug; cross-resource invalidations of other keys
+#    (["hosts"], ["scim_details"]) are not caught here on purpose.
+flag "invalidate-config-key" 'invalidateQueries\(\s*\[\s*"config"\s*\]'
+
+# 4. A GET /config after any prior line in the same handler — hard to
+#    detect precisely without an AST, but the naked `configAPI.loadAll()`
+#    call is only ever legitimate in the initial-load useQuery. Any other
+#    call site is doing a manual re-read.
+flag "config-load-outside-usequery" \
+  'await\s+configAPI\.loadAll\(|configAPI\.loadAll\(\)\.then'
+
+if [[ "$VIOLATIONS" -gt 0 ]]; then
+  echo "$REPORT"
+  echo
+  echo "Detected $VIOLATIONS read-after-write pattern(s)."
+  echo
+  echo "After a write, don't refetch the resource you just modified — under"
+  echo "read-replica lag the read returns stale data and the save appears to"
+  echo "revert. Consume the write response directly:"
+  echo
+  echo "  For app config:"
+  echo "    const updated = await configAPI.update(diff);"
+  echo "    updateAppConfig(updated); // from hooks/useUpdateAppConfig"
+  echo
+  echo "  For any other resource:"
+  echo "    const updated = await api.update(id, diff);"
+  echo "    queryClient.setQueryData([key], updated);"
+  echo
+  echo "If the flagged site is genuinely intentional (cross-resource"
+  echo "invalidation, backend returns empty, design constraint), add the"
+  echo "path to ALLOWLIST in .github/scripts/detect-read-after-write.sh"
+  echo "with a one-line reason."
+  exit 1
+fi
+
+echo "OK: no read-after-write patterns detected."

--- a/.github/scripts/detect-read-after-write.sh
+++ b/.github/scripts/detect-read-after-write.sh
@@ -33,6 +33,10 @@ ALLOWLIST=(
   "frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/BootstrapPackage.tsx"
   "frontend/pages/ManageControlsPage/SetupExperience/cards/Users/components/UsersForm/UsersForm.tsx"
   "frontend/pages/ManageControlsPage/OSSettings/cards/HostNameTemplate/HostNameTemplate.tsx"
+  # Landed on main after this branch was cut. The multi-platform save
+  # writes to /mdm/disk_encryption which doesn't return the full config,
+  # so priming AppContext still requires a follow-up read today.
+  "frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/DiskEncryption.tsx"
 
   # Design follow-up: the refetch here is load-bearing UX (form reset via
   # remount), not just cache sync. Untangle before flipping the pattern.

--- a/.github/workflows/test-js.yml
+++ b/.github/workflows/test-js.yml
@@ -125,6 +125,10 @@ jobs:
         run: |
           yarn prettier:check
 
+      - name: Detect read-after-write patterns
+        run: |
+          bash .github/scripts/detect-read-after-write.sh
+
   lint-icons:
     strategy:
       matrix:

--- a/changes/42546-fix-frontend-stale-after-save
+++ b/changes/42546-fix-frontend-stale-after-save
@@ -1,0 +1,1 @@
+- Fixed the UI showing stale settings, team, policy, label, and user data after a save under database read-replica lag.

--- a/frontend/hooks/useUpdateAppConfig.tests.tsx
+++ b/frontend/hooks/useUpdateAppConfig.tests.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+
+import { AppContext, IAppContext, initialState } from "context/app";
+import createMockConfig from "__mocks__/configMock";
+
+import useUpdateAppConfig from "./useUpdateAppConfig";
+
+const buildWrapper = (appOverrides: Partial<IAppContext> = {}) => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const value: IAppContext = { ...initialState, ...appOverrides };
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>
+      <AppContext.Provider value={value}>{children}</AppContext.Provider>
+    </QueryClientProvider>
+  );
+  return { Wrapper, client };
+};
+
+describe("useUpdateAppConfig", () => {
+  // Regression guard for #42546: this hook is the single primitive that pages
+  // call after a config write to prime the cache directly from the write
+  // response, avoiding a stale refetch under DB read-replica lag. Fanning both
+  // the AppContext and the ["config"] React Query cache must stay in one call.
+  it("writes the config to both AppContext and the React Query cache", () => {
+    const setConfig = jest.fn();
+    const { Wrapper, client } = buildWrapper({ setConfig });
+    const updated = createMockConfig({
+      org_info: {
+        org_name: "New name",
+        org_logo_url: "",
+        org_logo_url_light_background: "",
+        contact_url: "https://fleetdm.com/company/contact",
+      },
+    });
+
+    const { result } = renderHook(() => useUpdateAppConfig(), {
+      wrapper: Wrapper,
+    });
+    result.current(updated);
+
+    expect(setConfig).toHaveBeenCalledTimes(1);
+    expect(setConfig).toHaveBeenCalledWith(updated);
+    expect(client.getQueryData(["config"])).toBe(updated);
+  });
+
+  it("returns a stable callback across renders when dependencies do not change", () => {
+    const setConfig = jest.fn();
+    const { Wrapper } = buildWrapper({ setConfig });
+
+    const { result, rerender } = renderHook(() => useUpdateAppConfig(), {
+      wrapper: Wrapper,
+    });
+    const first = result.current;
+    rerender();
+    expect(result.current).toBe(first);
+  });
+});

--- a/frontend/hooks/useUpdateAppConfig.ts
+++ b/frontend/hooks/useUpdateAppConfig.ts
@@ -1,0 +1,30 @@
+import { useCallback, useContext } from "react";
+import { useQueryClient } from "react-query";
+
+import { AppContext } from "context/app";
+import { IConfig } from "interfaces/config";
+
+/**
+ * Single setter for the app config. Updates the AppContext AND the React
+ * Query cache in one call, so pages that write config don't have to refetch
+ * (which is unsafe under read-replica lag).
+ *
+ * Call this with the response from a config write, e.g.:
+ *   const updateAppConfig = useUpdateAppConfig();
+ *   const updated = await configAPI.update(diff);
+ *   updateAppConfig(updated);
+ */
+const useUpdateAppConfig = () => {
+  const { setConfig } = useContext(AppContext);
+  const queryClient = useQueryClient();
+
+  return useCallback(
+    (config: IConfig) => {
+      setConfig(config);
+      queryClient.setQueryData(["config"], config);
+    },
+    [setConfig, queryClient]
+  );
+};
+
+export default useUpdateAppConfig;

--- a/frontend/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/pages/DashboardPage/DashboardPage.tsx
@@ -10,6 +10,7 @@ import { InjectedRouter } from "react-router";
 import { useQuery } from "react-query";
 
 import { AppContext } from "context/app";
+import useUpdateAppConfig from "hooks/useUpdateAppConfig";
 import { notify } from "components/ToastNotification";
 
 import paths from "router/paths";
@@ -110,6 +111,7 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
     isPremiumTier,
     isOnGlobalTeam,
   } = useContext(AppContext);
+  const updateAppConfig = useUpdateAppConfig();
 
   const {
     currentTeamId,
@@ -209,11 +211,11 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
     setSelectedPlatform(platformByPathname);
   }, [pathname]);
 
-  const { data: config, refetch: refetchConfig } = useQuery<
-    IConfig,
-    Error,
-    IConfig
-  >(["config"], () => configAPI.loadAll(), { ...DEFAULT_USE_QUERY_OPTIONS });
+  const { data: config } = useQuery<IConfig, Error, IConfig>(
+    ["config"],
+    () => configAPI.loadAll(),
+    { ...DEFAULT_USE_QUERY_OPTIONS }
+  );
 
   const { data: teams, isLoading: isLoadingTeams } = useQuery<
     ILoadTeamsResponse,
@@ -582,7 +584,7 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
           formData.url !==
             config?.webhook_settings.activities_webhook.destination_url
         ) {
-          await configAPI.update({
+          const updatedConfig = await configAPI.update({
             webhook_settings: {
               activities_webhook: {
                 enable_activities_webhook: formData.enabled,
@@ -590,6 +592,7 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
               },
             },
           });
+          updateAppConfig(updatedConfig);
         }
         notify.success("Successfully updated activity feed automations.");
         setShowActivityFeedAutomationsModal(false);
@@ -600,14 +603,13 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
         );
       } finally {
         setUpdatingActivityFeedAutomations(false);
-        refetchConfig();
         refetchActivities();
       }
     },
     [
       config?.webhook_settings.activities_webhook.destination_url,
       config?.webhook_settings.activities_webhook.enable_activities_webhook,
-      refetchConfig,
+      updateAppConfig,
     ]
   );
 

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/ConfigurationProfiles.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/ConfigurationProfiles.tsx
@@ -154,18 +154,17 @@ const ConfigurationProfiles = ({
     setIsDeleting(true);
     try {
       await mdmAPI.deleteProfile(profileId);
-      queryClient.setQueryData<IMdmProfilesResponse>(
-        profilesQueryKey,
-        (old) => {
-          if (!old) return old;
-          return {
-            ...old,
-            profiles: (old.profiles ?? []).filter(
-              (p) => p.profile_uuid !== profileId
-            ),
-          };
-        }
+      const cached = queryClient.getQueryData<IMdmProfilesResponse>(
+        profilesQueryKey
       );
+      if (cached) {
+        queryClient.setQueryData<IMdmProfilesResponse>(profilesQueryKey, {
+          ...cached,
+          profiles: (cached.profiles ?? []).filter(
+            (p) => p.profile_uuid !== profileId
+          ),
+        });
+      }
       onMutation();
       notify.success("Successfully deleted.");
     } catch (e) {

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/ConfigurationProfiles.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/ConfigurationProfiles.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useContext, useRef, useState } from "react";
 
-import { useQuery } from "react-query";
+import { useQuery, useQueryClient } from "react-query";
 import { Tab, TabList, TabPanel, Tabs } from "react-tabs";
 import PATHS from "router/paths";
 import { getPathWithQueryParams } from "utilities/url";
@@ -92,6 +92,15 @@ const ConfigurationProfiles = ({
 
   const selectedProfile = useRef<IMdmProfile | null>(null);
   const selectedStatusHostCount = useRef<number | null>(null);
+  const queryClient = useQueryClient();
+  const profilesQueryKey = [
+    {
+      scope: "profiles",
+      team_id: currentTeamId,
+      page: currentPage,
+      per_page: PROFILES_PER_PAGE,
+    },
+  ];
 
   const {
     data: profilesData,
@@ -99,14 +108,7 @@ const ConfigurationProfiles = ({
     isError: isErrorProfiles,
     refetch: refetchProfiles,
   } = useQuery<IMdmProfilesResponse, unknown>(
-    [
-      {
-        scope: "profiles",
-        team_id: currentTeamId,
-        page: currentPage,
-        per_page: PROFILES_PER_PAGE,
-      },
-    ],
+    profilesQueryKey,
     () =>
       mdmAPI.getProfiles({
         fleet_id: currentTeamId,
@@ -152,7 +154,18 @@ const ConfigurationProfiles = ({
     setIsDeleting(true);
     try {
       await mdmAPI.deleteProfile(profileId);
-      refetchProfiles();
+      queryClient.setQueryData<IMdmProfilesResponse>(
+        profilesQueryKey,
+        (old) => {
+          if (!old) return old;
+          return {
+            ...old,
+            profiles: (old.profiles ?? []).filter(
+              (p) => p.profile_uuid !== profileId
+            ),
+          };
+        }
+      );
       onMutation();
       notify.success("Successfully deleted.");
     } catch (e) {

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/AssetsTab/AssetsTab.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/AssetsTab/AssetsTab.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useRef, useState } from "react";
-import { useQuery } from "react-query";
+import { useQuery, useQueryClient } from "react-query";
 import { InjectedRouter } from "react-router";
 
 import PATHS from "router/paths";
@@ -51,6 +51,8 @@ const AssetsTab = ({ currentTeamId, router }: IAssetsTabProps) => {
   const [isDeleting, setIsDeleting] = useState(false);
 
   const selectedAsset = useRef<IMdmAsset | null>(null);
+  const queryClient = useQueryClient();
+  const assetsQueryKey = [{ scope: "assets", team_id: currentTeamId }];
 
   const {
     data: assets,
@@ -58,7 +60,7 @@ const AssetsTab = ({ currentTeamId, router }: IAssetsTabProps) => {
     isError: isErrorAssets,
     refetch: refetchAssets,
   } = useQuery<IListAssetsResponse, unknown, IMdmAsset[]>(
-    [{ scope: "assets", team_id: currentTeamId }],
+    assetsQueryKey,
     () => mdmAPI.getAssets({ fleet_id: currentTeamId }),
     {
       enabled: isPremiumTier && mdmAppleEnabled,
@@ -85,7 +87,13 @@ const AssetsTab = ({ currentTeamId, router }: IAssetsTabProps) => {
     setIsDeleting(true);
     try {
       await mdmAPI.deleteAsset(assetUuid);
-      refetchAssets();
+      queryClient.setQueryData<IListAssetsResponse>(assetsQueryKey, (old) => {
+        if (!old) return old;
+        return {
+          ...old,
+          assets: (old.assets ?? []).filter((a) => a.asset_uuid !== assetUuid),
+        };
+      });
       notify.success("Successfully deleted.");
     } catch (e) {
       notify.error(getErrorReason(e) || "Couldn't delete. Please try again.", {

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/AssetsTab/AssetsTab.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/ConfigurationProfiles/components/AssetsTab/AssetsTab.tsx
@@ -87,13 +87,17 @@ const AssetsTab = ({ currentTeamId, router }: IAssetsTabProps) => {
     setIsDeleting(true);
     try {
       await mdmAPI.deleteAsset(assetUuid);
-      queryClient.setQueryData<IListAssetsResponse>(assetsQueryKey, (old) => {
-        if (!old) return old;
-        return {
-          ...old,
-          assets: (old.assets ?? []).filter((a) => a.asset_uuid !== assetUuid),
-        };
-      });
+      const cached = queryClient.getQueryData<IListAssetsResponse>(
+        assetsQueryKey
+      );
+      if (cached) {
+        queryClient.setQueryData<IListAssetsResponse>(assetsQueryKey, {
+          ...cached,
+          assets: (cached.assets ?? []).filter(
+            (a) => a.asset_uuid !== assetUuid
+          ),
+        });
+      }
       notify.success("Successfully deleted.");
     } catch (e) {
       notify.error(getErrorReason(e) || "Couldn't delete. Please try again.", {

--- a/frontend/pages/SoftwarePage/SoftwarePage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwarePage.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useContext, useEffect, useState } from "react";
 import { InjectedRouter } from "react-router";
-import { useQuery } from "react-query";
+import { useQuery, useQueryClient } from "react-query";
 import { Tab, TabList, Tabs } from "react-tabs";
 
 import PATHS from "router/paths";
@@ -14,6 +14,7 @@ import teamsAPI, { ILoadTeamResponse } from "services/entities/teams";
 import { ISoftwareApiParams } from "services/entities/software";
 import { AppContext } from "context/app";
 import useTeamIdParam from "hooks/useTeamIdParam";
+import useUpdateAppConfig from "hooks/useUpdateAppConfig";
 import {
   convertParamsToSnakeCase,
   getPathWithQueryParams,
@@ -144,6 +145,8 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
     isTeamMaintainer,
     isPremiumTier,
   } = useContext(AppContext);
+  const queryClient = useQueryClient();
+  const updateAppConfig = useUpdateAppConfig();
 
   const isPrimoMode =
     globalConfigFromContext?.partnerships?.enable_primo || false;
@@ -211,7 +214,6 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
     data: softwareConfig,
     error: softwareConfigError,
     isFetching: isFetchingSoftwareConfig,
-    refetch: refetchSoftwareConfig,
   } = useQuery<
     IConfig | ILoadTeamResponse,
     Error,
@@ -278,11 +280,13 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
     configSoftwareAutomations: ISoftwareAutomations
   ) => {
     try {
-      const request = configAPI.update(configSoftwareAutomations);
-      await request.then(() => {
-        notify.success("Successfully updated vulnerability automations.");
-        refetchSoftwareConfig();
-      });
+      const updatedConfig = await configAPI.update(configSoftwareAutomations);
+      updateAppConfig(updatedConfig);
+      queryClient.setQueryData(
+        [{ scope: "softwareConfig", teamId: teamIdForApi }],
+        updatedConfig
+      );
+      notify.success("Successfully updated vulnerability automations.");
     } catch {
       notify.error(
         "Could not update vulnerability automations. Please try again."

--- a/frontend/pages/admin/IntegrationsPage/IntegrationsPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/IntegrationsPage.tsx
@@ -8,6 +8,7 @@ import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
 import { AppContext } from "context/app";
 
 import configAPI from "services/entities/config";
+import useUpdateAppConfig from "hooks/useUpdateAppConfig";
 
 import { IConfig } from "interfaces/config";
 
@@ -37,6 +38,7 @@ const IntegrationsPage = ({
     section = "sso";
   }
   const [isUpdatingSettings, setIsUpdatingSettings] = useState(false);
+  const updateAppConfig = useUpdateAppConfig();
 
   // // // settings that live under the integrations page
 
@@ -44,7 +46,6 @@ const IntegrationsPage = ({
     data: appConfig,
     isLoading: isLoadingAppConfig,
     isFetching: isFetchingAppConfig,
-    refetch: refetchConfig,
   } = useQuery<IConfig, Error, IConfig>(["config"], () => configAPI.loadAll(), {
     ...DEFAULT_USE_QUERY_OPTIONS,
   });
@@ -60,9 +61,9 @@ const IntegrationsPage = ({
       const diff = deepDifference(formUpdates, appConfig);
 
       // If there's no actual change, don't make the API call to update config.
-      // Still refetch in case settings were changed inside a card (like end-user auth).
+      // Cards that make their own writes update the cache directly via
+      // useUpdateAppConfig, so no refetch is needed here.
       if (Object.keys(diff).length === 0) {
-        refetchConfig();
         return true;
       }
 
@@ -72,9 +73,9 @@ const IntegrationsPage = ({
       diff.agent_options = formUpdates.agent_options;
 
       try {
-        await configAPI.update(diff);
+        const updatedConfig = await configAPI.update(diff);
+        updateAppConfig(updatedConfig);
         notify.success("Successfully updated settings.");
-        refetchConfig();
         return true;
       } catch (err: unknown) {
         notify.error("Could not update settings", { response: err });
@@ -83,7 +84,7 @@ const IntegrationsPage = ({
         setIsUpdatingSettings(false);
       }
     },
-    [appConfig, refetchConfig]
+    [appConfig, updateAppConfig]
   );
 
   if (!appConfig) return <></>;

--- a/frontend/pages/admin/IntegrationsPage/cards/AccountProvisioning/AccountProvisioning.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/AccountProvisioning/AccountProvisioning.tsx
@@ -1,12 +1,11 @@
 import React, { useEffect, useState } from "react";
 
-import { useQueryClient } from "react-query";
-
 import {
   LEARN_MORE_ABOUT_BASE_LINK,
   UNCHANGED_PASSWORD_API_RESPONSE,
 } from "utilities/constants";
 import configAPI from "services/entities/config";
+import useUpdateAppConfig from "hooks/useUpdateAppConfig";
 import { getErrorReason } from "interfaces/errors";
 import { notify } from "components/ToastNotification";
 import { IAppConfigFormProps } from "pages/admin/OrgSettingsPage/cards/constants";
@@ -79,7 +78,7 @@ const getServerFieldErrors = (err: unknown): IFormErrors => {
 
 const AccountProvisioning = ({ appConfig }: IAppConfigFormProps) => {
   const { gitOpsModeEnabled } = useGitOpsMode();
-  const queryClient = useQueryClient();
+  const updateAppConfig = useUpdateAppConfig();
   const [isUpdating, setIsUpdating] = useState(false);
   const [formData, setFormData] = useState<IFormData>({
     tokenUrl: "",
@@ -150,7 +149,7 @@ const AccountProvisioning = ({ appConfig }: IAppConfigFormProps) => {
 
     setIsUpdating(true);
     try {
-      await configAPI.update({
+      const updatedConfig = await configAPI.update({
         mdm: {
           apple_account_provisioning: {
             oauth_idp_token_url: formData.tokenUrl,
@@ -161,7 +160,7 @@ const AccountProvisioning = ({ appConfig }: IAppConfigFormProps) => {
           },
         },
       });
-      await queryClient.invalidateQueries(["config"]);
+      updateAppConfig(updatedConfig);
       notify.success("Successfully updated settings.");
     } catch (err) {
       setFormErrors((prev) => ({ ...prev, ...getServerFieldErrors(err) }));

--- a/frontend/pages/admin/IntegrationsPage/cards/Calendars/Calendars.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/Calendars/Calendars.tsx
@@ -1,9 +1,9 @@
 import React, { useState, useContext, useCallback, useEffect } from "react";
-import { useQueryClient } from "react-query";
 
 import { IInputFieldParseTarget } from "interfaces/form_field";
 import { AppContext } from "context/app";
 import configAPI from "services/entities/config";
+import useUpdateAppConfig from "hooks/useUpdateAppConfig";
 import paths from "router/paths";
 import { UNCHANGED_PASSWORD_API_RESPONSE } from "utilities/constants";
 
@@ -80,7 +80,7 @@ const baseClass = "calendars-integration";
 
 const Calendars = ({ appConfig }: IAppConfigFormProps): JSX.Element => {
   const { currentTeam, isPremiumTier } = useContext(AppContext);
-  const queryClient = useQueryClient();
+  const updateAppConfig = useUpdateAppConfig();
 
   const [formData, setFormData] = useState<ICalendarsFormData>({
     domain: "",
@@ -202,9 +202,11 @@ const Calendars = ({ appConfig }: IAppConfigFormProps): JSX.Element => {
     };
 
     try {
-      await configAPI.update({ integrations: destination });
+      const updatedConfig = await configAPI.update({
+        integrations: destination,
+      });
+      updateAppConfig(updatedConfig);
       notify.success("Successfully saved calendar integration settings.");
-      await queryClient.invalidateQueries(["config"]);
     } catch (e) {
       notify.error("Could not save calendar integration settings.", {
         response: e,

--- a/frontend/pages/admin/IntegrationsPage/cards/ChangeManagement/ChangeManagement.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/ChangeManagement/ChangeManagement.tsx
@@ -7,6 +7,7 @@ import { LEARN_MORE_ABOUT_BASE_LINK } from "utilities/constants";
 import { AppContext } from "context/app";
 
 import configAPI from "services/entities/config";
+import useUpdateAppConfig from "hooks/useUpdateAppConfig";
 
 import { IConfig } from "interfaces/config";
 import { IInputFieldParseTarget } from "interfaces/form_field";
@@ -56,7 +57,7 @@ const validate = (formData: IChangeManagementFormData) => {
 };
 
 const ChangeManagement = () => {
-  const { setConfig } = useContext(AppContext);
+  const updateAppConfig = useUpdateAppConfig();
 
   const [formData, setFormData] = useState<IChangeManagementFormData>({
     // dummy values, will be populated with fresh config API response
@@ -90,7 +91,7 @@ const ChangeManagement = () => {
         exceptSoftware: exceptions.software,
         exceptSecrets: exceptions.secrets,
       });
-      setConfig(data);
+      updateAppConfig(data);
     },
   });
 
@@ -148,7 +149,7 @@ const ChangeManagement = () => {
         exceptSecrets: updatedConfig.gitops.exceptions.secrets,
       });
 
-      setConfig(updatedConfig);
+      updateAppConfig(updatedConfig);
 
       notify.success("Successfully updated settings");
     } catch (e) {

--- a/frontend/pages/admin/IntegrationsPage/cards/ConditionalAccess/ConditionalAccess.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/ConditionalAccess/ConditionalAccess.tsx
@@ -6,6 +6,7 @@ import conditionalAccessAPI, {
   ConfirmMSConditionalAccessResponse,
 } from "services/entities/conditional_access";
 import configAPI from "services/entities/config";
+import useUpdateAppConfig from "hooks/useUpdateAppConfig";
 
 import CustomLink from "components/CustomLink";
 import SectionHeader from "components/SectionHeader";
@@ -162,7 +163,8 @@ enum EntraPhase {
 
 const ConditionalAccess = () => {
   // HOOKS
-  const { isPremiumTier, setConfig, config } = useContext(AppContext);
+  const { isPremiumTier, config } = useContext(AppContext);
+  const updateAppConfig = useUpdateAppConfig();
 
   const [entraPhase, setEntraPhase] = useState<EntraPhase>(
     EntraPhase.NotConfigured
@@ -310,7 +312,7 @@ const ConditionalAccess = () => {
   };
 
   const onDeleteConditionalAccess = (updatedConfig: IConfig) => {
-    setConfig(updatedConfig);
+    updateAppConfig(updatedConfig);
   };
 
   const toggleOktaModal = () => {
@@ -319,7 +321,7 @@ const ConditionalAccess = () => {
 
   const handleOktaModalSuccess = (updatedConfig: IConfig) => {
     setShowOktaModal(false);
-    setConfig(updatedConfig);
+    updateAppConfig(updatedConfig);
   };
 
   const handleEntraDelete = () => {
@@ -349,7 +351,7 @@ const ConditionalAccess = () => {
             config?.conditional_access?.microsoft_entra_tenant_id || "",
         },
       });
-      setConfig(updatedConfig);
+      updateAppConfig(updatedConfig);
       notify.success("Successfully updated conditional access settings.");
     } catch (e) {
       notify.error("Could not update conditional access settings.", {

--- a/frontend/pages/admin/IntegrationsPage/cards/IdentityProviders/components/GoogleWorkspaceSection/GoogleWorkspaceSection.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/IdentityProviders/components/GoogleWorkspaceSection/GoogleWorkspaceSection.tsx
@@ -4,6 +4,7 @@ import { useQueryClient } from "react-query";
 import { IInputFieldParseTarget } from "interfaces/form_field";
 import { IConfig } from "interfaces/config";
 import configAPI from "services/entities/config";
+import useUpdateAppConfig from "hooks/useUpdateAppConfig";
 import { UNCHANGED_PASSWORD_API_RESPONSE } from "utilities/constants";
 
 import { notify } from "components/ToastNotification";
@@ -65,6 +66,7 @@ const GoogleWorkspaceSection = ({
   appConfig,
 }: IGoogleWorkspaceSectionProps): JSX.Element => {
   const queryClient = useQueryClient();
+  const updateAppConfig = useUpdateAppConfig();
 
   const [formData, setFormData] = useState<IGoogleWorkspaceFormData>({
     domain: "",
@@ -166,14 +168,14 @@ const GoogleWorkspaceSection = ({
         googleWorkspace = [entry];
       }
 
-      await configAPI.update({
+      const updatedConfig = await configAPI.update({
         integrations: { google_workspace: googleWorkspace },
       });
+      updateAppConfig(updatedConfig);
+      await queryClient.invalidateQueries(["scim_details"]);
       notify.success(
         "Successfully saved Google Workspace integration settings."
       );
-      await queryClient.invalidateQueries(["config"]);
-      await queryClient.invalidateQueries(["scim_details"]);
     } catch (e) {
       notify.error("Could not save Google Workspace integration settings.", {
         response: e,

--- a/frontend/pages/admin/IntegrationsPage/cards/Integrations/TicketDestinations.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/Integrations/TicketDestinations.tsx
@@ -12,6 +12,7 @@ import {
 import { IApiError } from "interfaces/errors";
 
 import configAPI from "services/entities/config";
+import useUpdateAppConfig from "hooks/useUpdateAppConfig";
 
 import { LEARN_MORE_ABOUT_BASE_LINK } from "utilities/constants";
 import Button from "components/buttons/Button";
@@ -41,6 +42,7 @@ const UNKNOWN_ERROR =
   "We experienced an error when attempting to connect. Please try again later.";
 
 const TicketDestinations = (): JSX.Element => {
+  const updateAppConfig = useUpdateAppConfig();
   const [
     showAddTicketDestinationModal,
     setShowAddTicketDestinationModal,
@@ -65,7 +67,6 @@ const TicketDestinations = (): JSX.Element => {
     data: integrations,
     isLoading: isLoadingIntegrations,
     error: loadingIntegrationsError,
-    refetch: refetchIntegrations,
   } = useQuery<IConfig, Error, IGlobalIntegrations>(
     ["integrations"],
     () => configAPI.loadAll(),
@@ -123,7 +124,10 @@ const TicketDestinations = (): JSX.Element => {
       setTestingConnection(true);
       configAPI
         .update({ integrations: destination() })
-        .then(() => {
+        .then((updatedConfig) => {
+          updateAppConfig(updatedConfig);
+          setJiraIntegrations(updatedConfig.integrations.jira);
+          setZendeskIntegrations(updatedConfig.integrations.zendesk);
           notify.success(
             <>
               Successfully added{" "}
@@ -137,7 +141,6 @@ const TicketDestinations = (): JSX.Element => {
             </>
           );
           toggleAddTicketDestinationModal();
-          refetchIntegrations();
         })
         .catch((addError: { data: IApiError }) => {
           if (addError.data?.message.includes("Validation Failed")) {
@@ -188,7 +191,7 @@ const TicketDestinations = (): JSX.Element => {
           setTestingConnection(false);
         });
     },
-    [toggleAddTicketDestinationModal]
+    [toggleAddTicketDestinationModal, updateAppConfig]
   );
 
   const onDeleteSubmit = useCallback(() => {
@@ -213,7 +216,10 @@ const TicketDestinations = (): JSX.Element => {
       };
       setIsUpdatingIntegration(true);
       deleteIntegrationDestination()
-        .then(() => {
+        .then((updatedConfig) => {
+          updateAppConfig(updatedConfig);
+          setJiraIntegrations(updatedConfig.integrations.jira);
+          setZendeskIntegrations(updatedConfig.integrations.zendesk);
           notify.success(
             <>
               Successfully deleted{" "}
@@ -224,7 +230,6 @@ const TicketDestinations = (): JSX.Element => {
               </b>
             </>
           );
-          refetchIntegrations();
         })
         .catch((deleteError: unknown) => {
           notify.error(
@@ -245,7 +250,7 @@ const TicketDestinations = (): JSX.Element => {
           toggleDeleteIntegrationModal();
         });
     }
-  }, [integrationEditing, toggleDeleteIntegrationModal]);
+  }, [integrationEditing, toggleDeleteIntegrationModal, updateAppConfig]);
 
   const onActionSelection = useCallback(
     (action: string, integration: IIntegrationTableData): void => {

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AndroidMdmPage/AndroidMdmPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AndroidMdmPage/AndroidMdmPage.tsx
@@ -13,6 +13,7 @@ import { AppContext } from "context/app";
 import { IConfig } from "interfaces/config";
 import { getErrorReason } from "interfaces/errors";
 import mdmAndroidAPI from "services/entities/mdm_android";
+import useUpdateAppConfig from "hooks/useUpdateAppConfig";
 import { DEFAULT_USE_QUERY_OPTIONS, SUPPORT_LINK } from "utilities/constants";
 
 import MainContent from "components/MainContent";
@@ -38,8 +39,8 @@ interface ITurnOnAndroidMdmProps {
 }
 
 const TurnOnAndroidMdm = ({ router }: ITurnOnAndroidMdmProps) => {
-  const { setConfig } = useContext(AppContext);
   const queryClient = useQueryClient();
+  const updateAppConfig = useUpdateAppConfig();
 
   // TODO: figure out issue with aborting the SSE fetch when the window is closed
   const newWindow = useRef<Window | null>(null);
@@ -70,14 +71,13 @@ const TurnOnAndroidMdm = ({ router }: ITurnOnAndroidMdmProps) => {
           ...prevConfig,
           mdm: { ...prevConfig.mdm, android_enabled_and_configured: true },
         };
-        setConfig(patched);
-        queryClient.setQueryData(["config"], patched);
+        updateAppConfig(patched);
       }
       notify.success("Android MDM turned on successfully.");
       setSetupSse(false);
       router.push(PATHS.ADMIN_INTEGRATIONS_MDM);
     },
-    [queryClient, router, setConfig]
+    [queryClient, router, updateAppConfig]
   );
 
   useEffect(() => {

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AndroidMdmPage/components/TurnOffAndroidMdmModal/TurnOffAndroidMdmModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AndroidMdmPage/components/TurnOffAndroidMdmModal/TurnOffAndroidMdmModal.tsx
@@ -1,10 +1,10 @@
-import React, { useCallback, useContext, useState } from "react";
+import React, { useCallback, useState } from "react";
 import { InjectedRouter } from "react-router";
 import { useQueryClient } from "react-query";
 
 import PATHS from "router/paths";
 import mdmAndroidAPI from "services/entities/mdm_android";
-import { AppContext } from "context/app";
+import useUpdateAppConfig from "hooks/useUpdateAppConfig";
 import { IConfig } from "interfaces/config";
 
 import Modal from "components/Modal";
@@ -23,8 +23,8 @@ const TurnOffAndroidMdmModal = ({
   onExit,
   router,
 }: ITurnOffAndroidMdmModalProps) => {
-  const { setConfig } = useContext(AppContext);
   const queryClient = useQueryClient();
+  const updateAppConfig = useUpdateAppConfig();
 
   const [isDeleting, setIsDeleting] = useState(false);
 
@@ -48,12 +48,11 @@ const TurnOffAndroidMdmModal = ({
         ...prevConfig,
         mdm: { ...prevConfig.mdm, android_enabled_and_configured: false },
       };
-      setConfig(patched);
-      queryClient.setQueryData(["config"], patched);
+      updateAppConfig(patched);
     }
     notify.success("Android MDM turned off successfully.");
     router.push(PATHS.ADMIN_INTEGRATIONS_MDM);
-  }, [onExit, queryClient, router, setConfig]);
+  }, [onExit, queryClient, router, updateAppConfig]);
 
   return (
     <Modal title="Turn off Android MDM" className={baseClass} onExit={onExit}>

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/WindowsMdmPage/WindowsMdmPage.tests.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/WindowsMdmPage/WindowsMdmPage.tests.tsx
@@ -12,6 +12,7 @@ jest.mock("services/entities/config");
 
 const renderPage = (mdm: Partial<IMdmConfig> = {}, isPremiumTier = true) => {
   const render = createCustomRenderer({
+    withBackendMock: true,
     context: {
       app: {
         isPremiumTier,

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/WindowsMdmPage/WindowsMdmPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/WindowsMdmPage/WindowsMdmPage.tsx
@@ -5,6 +5,7 @@ import { SingleValue } from "react-select-5";
 import PATHS from "router/paths";
 import configAPI from "services/entities/config";
 import { AppContext } from "context/app";
+import useUpdateAppConfig from "hooks/useUpdateAppConfig";
 
 import MainContent from "components/MainContent/MainContent";
 import Button from "components/buttons/Button";
@@ -39,7 +40,8 @@ const useSetWindowsMdm = ({
   defaultFleet,
   router,
 }: ISetWindowsMdmOptions) => {
-  const { setConfig, isPremiumTier } = useContext(AppContext);
+  const { isPremiumTier } = useContext(AppContext);
+  const updateAppConfig = useUpdateAppConfig();
 
   const updateWindowsMdm = async () => {
     try {
@@ -59,7 +61,7 @@ const useSetWindowsMdm = ({
         },
         true
       );
-      setConfig(updatedConfig);
+      updateAppConfig(updatedConfig);
       notify.success("Windows MDM settings successfully updated.");
     } catch (e) {
       notify.error(getErrorMessage(e), { response: e });

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/AddEntraClientIDModal/AddEntraClientIDModal.tests.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/AddEntraClientIDModal/AddEntraClientIDModal.tests.tsx
@@ -23,6 +23,7 @@ jest.mock("components/ToastNotification", () => ({
 const EXISTING_UPPERCASE_ID = "6D8769E6-0F8B-418D-B385-1A53968781C9";
 
 const createTestMockData = (configOverrides: Partial<IConfig>) => ({
+  withBackendMock: true,
   context: {
     app: {
       isPremiumTier: true,

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/AddEntraClientIDModal/AddEntraClientIDModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/AddEntraClientIDModal/AddEntraClientIDModal.tsx
@@ -2,6 +2,7 @@ import React, { useState, useContext } from "react";
 
 import { AppContext } from "context/app";
 import configAPI from "services/entities/config";
+import useUpdateAppConfig from "hooks/useUpdateAppConfig";
 
 import InputField from "components/forms/fields/InputField";
 import Modal from "components/Modal";
@@ -22,7 +23,8 @@ interface IAddEntraClientIdModalProps {
 }
 
 const AddEntraClientIdModal = ({ onExit }: IAddEntraClientIdModalProps) => {
-  const { setConfig, config } = useContext(AppContext);
+  const { config } = useContext(AppContext);
+  const updateAppConfig = useUpdateAppConfig();
 
   const [isAdding, setIsAdding] = React.useState(false);
   const [formData, setFormData] = React.useState<IAddClientIdFormData>({
@@ -69,7 +71,7 @@ const AddEntraClientIdModal = ({ onExit }: IAddEntraClientIdModalProps) => {
             windows_entra_client_ids: [...currentClientIds, clientId],
           },
         });
-        setConfig(updateData);
+        updateAppConfig(updateData);
         notify.success("Successfully added client ID");
         onExit();
       } catch (error) {

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/AddEntraTenantModal/AddEntraTenantModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/AddEntraTenantModal/AddEntraTenantModal.tsx
@@ -2,6 +2,7 @@ import React, { useState, useContext } from "react";
 
 import { AppContext } from "context/app";
 import configAPI from "services/entities/config";
+import useUpdateAppConfig from "hooks/useUpdateAppConfig";
 
 import InputField from "components/forms/fields/InputField";
 import Modal from "components/Modal";
@@ -22,7 +23,8 @@ interface IAddEntraTenantModalProps {
 }
 
 const AddEntraTenantModal = ({ onExit }: IAddEntraTenantModalProps) => {
-  const { setConfig, config } = useContext(AppContext);
+  const { config } = useContext(AppContext);
+  const updateAppConfig = useUpdateAppConfig();
 
   const [isAdding, setIsAdding] = React.useState(false);
   const [formData, setFormData] = React.useState<IAddTenantFormData>({
@@ -66,7 +68,7 @@ const AddEntraTenantModal = ({ onExit }: IAddEntraTenantModalProps) => {
             windows_entra_tenant_ids: [...currentTenantIds, tenantId],
           },
         });
-        setConfig(updateData);
+        updateAppConfig(updateData);
         notify.success("Successfully added tenant");
         onExit();
       } catch (error) {

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/DeleteEntraClientIDModal/DeleteEntraClientIDModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/DeleteEntraClientIDModal/DeleteEntraClientIDModal.tsx
@@ -2,6 +2,7 @@ import React, { useContext, useState } from "react";
 
 import { AppContext } from "context/app";
 import configAPI from "services/entities/config";
+import useUpdateAppConfig from "hooks/useUpdateAppConfig";
 
 import Modal from "components/Modal";
 import Button from "components/buttons/Button";
@@ -18,7 +19,8 @@ const DeleteEntraClientIdModal = ({
   clientId,
   onExit,
 }: IDeleteEntraClientIdModalProps) => {
-  const { setConfig, config } = useContext(AppContext);
+  const { config } = useContext(AppContext);
+  const updateAppConfig = useUpdateAppConfig();
 
   const [isDeleting, setIsDeleting] = useState(false);
 
@@ -33,7 +35,7 @@ const DeleteEntraClientIdModal = ({
           windows_entra_client_ids: updatedClientIds,
         },
       });
-      setConfig(updateData);
+      updateAppConfig(updateData);
       notify.success("Client ID deleted successfully.");
       onExit();
     } catch (err) {

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/DeleteEntraTenantModal/DeleteEntraTenantModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/DeleteEntraTenantModal/DeleteEntraTenantModal.tsx
@@ -2,6 +2,7 @@ import React, { useContext, useState } from "react";
 
 import { AppContext } from "context/app";
 import configAPI from "services/entities/config";
+import useUpdateAppConfig from "hooks/useUpdateAppConfig";
 
 import Modal from "components/Modal";
 import Button from "components/buttons/Button";
@@ -18,7 +19,8 @@ const DeleteEntraTenantModal = ({
   tenantId,
   onExit,
 }: IDeleteEntraTenantModalProps) => {
-  const { setConfig, config } = useContext(AppContext);
+  const { config } = useContext(AppContext);
+  const updateAppConfig = useUpdateAppConfig();
 
   const [isDeleting, setIsDeleting] = useState(false);
 
@@ -33,7 +35,7 @@ const DeleteEntraTenantModal = ({
           windows_entra_tenant_ids: updatedTenantIds,
         },
       });
-      setConfig(updateData);
+      updateAppConfig(updateData);
       notify.success("Tenant deleted successfully.");
       onExit();
     } catch (err) {

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/EndUserMigrationSection/EndUserMigrationSection.tests.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/EndUserMigrationSection/EndUserMigrationSection.tests.tsx
@@ -23,6 +23,7 @@ const createTestMockData = (
   isPremiumTier = true
 ) => {
   return {
+    withBackendMock: true,
     context: {
       app: {
         isPremiumTier,

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/EndUserMigrationSection/EndUserMigrationSection.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/components/EndUserMigrationSection/EndUserMigrationSection.tsx
@@ -11,6 +11,7 @@ import { AppContext } from "context/app";
 import { getErrorReason } from "interfaces/errors";
 
 import configAPI from "services/entities/config";
+import useUpdateAppConfig from "hooks/useUpdateAppConfig";
 
 import SettingsSection from "pages/admin/components/SettingsSection";
 
@@ -56,7 +57,8 @@ const validateWebhookUrl = (val: string) => {
 };
 
 const EndUserMigrationSection = ({ router }: IEndUserMigrationSectionProps) => {
-  const { config, isPremiumTier, setConfig } = useContext(AppContext);
+  const { config, isPremiumTier } = useContext(AppContext);
+  const updateAppConfig = useUpdateAppConfig();
 
   const [formData, setFormData] = useState<IEndUserMigrationFormData>({
     isEnabled: config?.mdm.macos_migration.enable || false,
@@ -119,8 +121,8 @@ const EndUserMigrationSection = ({ router }: IEndUserMigrationSectionProps) => {
           },
         },
       });
+      updateAppConfig(updatedConfig);
       notify.success("Successfully updated end user migration.");
-      setConfig(updatedConfig);
     } catch (err) {
       if (
         getErrorReason(err, {

--- a/frontend/pages/admin/ManageFleetsPage/ManageFleetsPage.tsx
+++ b/frontend/pages/admin/ManageFleetsPage/ManageFleetsPage.tsx
@@ -161,10 +161,15 @@ const ManageFleetsPage = ({
         .then((response: ILoadTeamResponse) => {
           // Splice the created fleet into the cached list so we don't
           // trigger a re-read that could return stale data under replica lag.
-          queryClient.setQueryData<ILoadTeamsResponse>(["teams"], (old) => {
-            if (!old) return old;
-            return { ...old, teams: [response.team, ...old.teams] };
-          });
+          const cached = queryClient.getQueryData<ILoadTeamsResponse>([
+            "teams",
+          ]);
+          if (cached) {
+            queryClient.setQueryData<ILoadTeamsResponse>(["teams"], {
+              ...cached,
+              teams: [response.team, ...cached.teams],
+            });
+          }
           setBackendValidators({});
           toggleCreateFleetModal();
           // Team memberships on /me may shift when the current user's roles
@@ -212,13 +217,15 @@ const ManageFleetsPage = ({
         .then(() => {
           // Drop the deleted fleet from the cached list so we don't
           // trigger a re-read that could return stale data under replica lag.
-          queryClient.setQueryData<ILoadTeamsResponse>(["teams"], (old) => {
-            if (!old) return old;
-            return {
-              ...old,
-              teams: old.teams.filter((t) => t.id !== fleetEditing.id),
-            };
-          });
+          const cached = queryClient.getQueryData<ILoadTeamsResponse>([
+            "teams",
+          ]);
+          if (cached) {
+            queryClient.setQueryData<ILoadTeamsResponse>(["teams"], {
+              ...cached,
+              teams: cached.teams.filter((t) => t.id !== fleetEditing.id),
+            });
+          }
           if (currentTeam?.id === fleetEditing.id) {
             setCurrentTeam(undefined);
           }
@@ -256,15 +263,17 @@ const ManageFleetsPage = ({
           .then((response: ILoadTeamResponse) => {
             // Splice the renamed fleet into the cached list so we don't
             // trigger a re-read that could return stale data under replica lag.
-            queryClient.setQueryData<ILoadTeamsResponse>(["teams"], (old) => {
-              if (!old) return old;
-              return {
-                ...old,
-                teams: old.teams.map((t) =>
+            const cached = queryClient.getQueryData<ILoadTeamsResponse>([
+              "teams",
+            ]);
+            if (cached) {
+              queryClient.setQueryData<ILoadTeamsResponse>(["teams"], {
+                ...cached,
+                teams: cached.teams.map((t) =>
                   t.id === fleetEditing.id ? response.team : t
                 ),
-              };
-            });
+              });
+            }
             setBackendValidators({});
             toggleRenameFleetModal();
             notify.success(

--- a/frontend/pages/admin/ManageFleetsPage/ManageFleetsPage.tsx
+++ b/frontend/pages/admin/ManageFleetsPage/ManageFleetsPage.tsx
@@ -5,7 +5,7 @@ import React, {
   useEffect,
   useMemo,
 } from "react";
-import { useQuery } from "react-query";
+import { useQuery, useQueryClient } from "react-query";
 import { useErrorHandler } from "react-error-boundary";
 import { InjectedRouter } from "react-router";
 
@@ -17,6 +17,7 @@ import { ITeam as IFleet } from "interfaces/team";
 import { IApiError } from "interfaces/errors";
 import usersAPI, { IGetMeResponse } from "services/entities/users";
 import teamsAPI, {
+  ILoadTeamResponse,
   ILoadTeamsResponse,
   ITeamFormData as IFleetFormData,
 } from "services/entities/teams";
@@ -97,6 +98,7 @@ const ManageFleetsPage = ({
     [key: string]: string;
   }>({});
   const handlePageError = useErrorHandler();
+  const queryClient = useQueryClient();
 
   const { refetch: refetchMe } = useQuery(["me"], () => usersAPI.me(), {
     enabled: false,
@@ -111,7 +113,6 @@ const ManageFleetsPage = ({
     data: fleets,
     isFetching: isFetchingFleets,
     error: loadingFleetsError,
-    refetch: refetchFleets,
   } = useQuery<ILoadTeamsResponse, Error, IFleet[]>(
     ["teams"],
     () => teamsAPI.loadAll(),
@@ -157,12 +158,19 @@ const ManageFleetsPage = ({
       setIsUpdatingFleets(true);
       teamsAPI
         .create(formData)
-        .then(() => {
-          notify.success(`Successfully created ${formData.name}.`);
+        .then((response: ILoadTeamResponse) => {
+          // Splice the created fleet into the cached list so we don't
+          // trigger a re-read that could return stale data under replica lag.
+          queryClient.setQueryData<ILoadTeamsResponse>(["teams"], (old) => {
+            if (!old) return old;
+            return { ...old, teams: [response.team, ...old.teams] };
+          });
           setBackendValidators({});
           toggleCreateFleetModal();
+          // Team memberships on /me may shift when the current user's roles
+          // change as a side effect of a create.
           refetchMe();
-          refetchFleets();
+          notify.success(`Successfully created ${formData.name}.`);
         })
         .catch((createError: { data: IApiError }) => {
           const rawReason = createError.data.errors[0].reason;
@@ -193,7 +201,7 @@ const ManageFleetsPage = ({
           setIsUpdatingFleets(false);
         });
     },
-    [toggleCreateFleetModal, refetchMe, refetchFleets]
+    [toggleCreateFleetModal, refetchMe, queryClient]
   );
 
   const onDeleteSubmit = useCallback(() => {
@@ -202,10 +210,19 @@ const ManageFleetsPage = ({
       teamsAPI
         .destroy(fleetEditing.id)
         .then(() => {
-          notify.success(`Successfully deleted ${fleetEditing.name}.`);
+          // Drop the deleted fleet from the cached list so we don't
+          // trigger a re-read that could return stale data under replica lag.
+          queryClient.setQueryData<ILoadTeamsResponse>(["teams"], (old) => {
+            if (!old) return old;
+            return {
+              ...old,
+              teams: old.teams.filter((t) => t.id !== fleetEditing.id),
+            };
+          });
           if (currentTeam?.id === fleetEditing.id) {
             setCurrentTeam(undefined);
           }
+          notify.success(`Successfully deleted ${fleetEditing.name}.`);
         })
         .catch(() => {
           notify.error(
@@ -214,8 +231,8 @@ const ManageFleetsPage = ({
         })
         .finally(() => {
           setIsUpdatingFleets(false);
+          // Team memberships on /me may shift as a side effect.
           refetchMe();
-          refetchFleets();
           toggleDeleteFleetModal();
         });
     }
@@ -223,7 +240,7 @@ const ManageFleetsPage = ({
     currentTeam,
     fleetEditing,
     refetchMe,
-    refetchFleets,
+    queryClient,
     setCurrentTeam,
     toggleDeleteFleetModal,
   ]);
@@ -236,13 +253,23 @@ const ManageFleetsPage = ({
         setIsUpdatingFleets(true);
         teamsAPI
           .update(formData, fleetEditing.id)
-          .then(() => {
+          .then((response: ILoadTeamResponse) => {
+            // Splice the renamed fleet into the cached list so we don't
+            // trigger a re-read that could return stale data under replica lag.
+            queryClient.setQueryData<ILoadTeamsResponse>(["teams"], (old) => {
+              if (!old) return old;
+              return {
+                ...old,
+                teams: old.teams.map((t) =>
+                  t.id === fleetEditing.id ? response.team : t
+                ),
+              };
+            });
+            setBackendValidators({});
+            toggleRenameFleetModal();
             notify.success(
               `Successfully updated fleet name to ${formData.name}.`
             );
-            setBackendValidators({});
-            toggleRenameFleetModal();
-            refetchFleets();
           })
           .catch((updateError: { data: IApiError }) => {
             console.error(updateError);
@@ -280,7 +307,7 @@ const ManageFleetsPage = ({
           });
       }
     },
-    [fleetEditing, toggleRenameFleetModal, refetchFleets]
+    [fleetEditing, toggleRenameFleetModal, queryClient]
   );
 
   const onActionSelection = useCallback(

--- a/frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/AgentOptionsPage/AgentOptionsPage.tsx
+++ b/frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/AgentOptionsPage/AgentOptionsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState, useEffect } from "react";
-import { useQuery } from "react-query";
+import { useQuery, useQueryClient } from "react-query";
 import { useErrorHandler } from "react-error-boundary";
 import yaml from "js-yaml";
 import { constructErrorString, agentOptionsToYaml } from "utilities/yaml";
@@ -53,30 +53,28 @@ const AgentOptionsPage = ({
   const [formData, setFormData] = useState<{ agentOptions?: string }>({});
   const [formErrors, setFormErrors] = useState<any>({});
   const [isUpdatingAgentOptions, setIsUpdatingAgentOptions] = useState(false);
+  const queryClient = useQueryClient();
 
   const { agentOptions } = formData;
 
   const handlePageError = useErrorHandler();
 
-  const {
-    isFetching: isFetchingTeamOptions,
-    refetch: refetchTeamOptions,
-  } = useQuery<ILoadTeamResponse, Error, ITeam>(
-    ["team_details", teamIdForApi],
-    () => teamsAPI.load(teamIdForApi),
-    {
-      enabled: isRouteOk && !!teamIdForApi,
-      select: (data: ILoadTeamResponse) => data.team,
-      onSuccess: (data) => {
-        setFormData({
-          agentOptions: agentOptionsToYaml(data.agent_options),
-        });
-        setTeamName(data.name);
-      },
-      onError: (error) => handlePageError(error),
-      refetchOnWindowFocus: false,
-    }
-  );
+  const { isFetching: isFetchingTeamOptions } = useQuery<
+    ILoadTeamResponse,
+    Error,
+    ITeam
+  >(["team_details", teamIdForApi], () => teamsAPI.load(teamIdForApi), {
+    enabled: isRouteOk && !!teamIdForApi,
+    select: (data: ILoadTeamResponse) => data.team,
+    onSuccess: (data) => {
+      setFormData({
+        agentOptions: agentOptionsToYaml(data.agent_options),
+      });
+      setTeamName(data.name);
+    },
+    onError: (error) => handlePageError(error),
+    refetchOnWindowFocus: false,
+  });
 
   const validateForm = () => {
     const errors: any = {};
@@ -108,9 +106,13 @@ const AgentOptionsPage = ({
 
     osqueryOptionsAPI
       .updateTeam(teamIdForApi, formDataToSubmit)
-      .then(() => {
+      .then((response: ILoadTeamResponse) => {
+        queryClient.setQueryData(["team_details", teamIdForApi], response);
+        setFormData({
+          agentOptions: agentOptionsToYaml(response.team.agent_options),
+        });
+        setTeamName(response.team.name);
         notify.success(`Successfully updated ${teamName} fleet agent options.`);
-        refetchTeamOptions();
       })
       .catch((response: { data: IApiError }) => {
         console.error(response);

--- a/frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/TeamDetailsWrapper.tsx
+++ b/frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/TeamDetailsWrapper.tsx
@@ -339,15 +339,15 @@ const TeamDetailsWrapper = ({
         const response = await teamsAPI.update(updatedAttrs, teamIdForApi);
         // Splice the updated team into the cached teams list so we don't
         // trigger a re-read that could return stale data under replica lag.
-        queryClient.setQueryData<ILoadTeamsResponse>(["teams"], (old) => {
-          if (!old) return old;
-          return {
-            ...old,
-            teams: old.teams.map((t) =>
+        const cached = queryClient.getQueryData<ILoadTeamsResponse>(["teams"]);
+        if (cached) {
+          queryClient.setQueryData<ILoadTeamsResponse>(["teams"], {
+            ...cached,
+            teams: cached.teams.map((t) =>
               t.id === teamIdForApi ? response.team : t
             ),
-          };
-        });
+          });
+        }
         setBackendValidators({});
         // Fresh /me since team memberships / display names on the current
         // user can change as a side effect of a team rename.

--- a/frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/TeamDetailsWrapper.tsx
+++ b/frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/TeamDetailsWrapper.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useContext } from "react";
-import { useQuery } from "react-query";
+import { useQuery, useQueryClient } from "react-query";
 import { useErrorHandler } from "react-error-boundary";
 import { InjectedRouter } from "react-router";
 import { Tab, TabList, Tabs } from "react-tabs";
@@ -101,6 +101,7 @@ const TeamDetailsWrapper = ({
     setCurrentUser,
     config,
   } = useContext(AppContext);
+  const queryClient = useQueryClient();
 
   const {
     currentTeamId,
@@ -171,11 +172,11 @@ const TeamDetailsWrapper = ({
   );
   const currentTeamDetails = teams?.find((team) => team.id === teamIdForApi);
 
-  const {
-    isLoading: isTeamSecretsLoading,
-    data: teamSecrets,
-    refetch: refetchTeamSecrets,
-  } = useQuery<IEnrollSecretsResponse, Error, IEnrollSecret[]>(
+  const { isLoading: isTeamSecretsLoading, data: teamSecrets } = useQuery<
+    IEnrollSecretsResponse,
+    Error,
+    IEnrollSecret[]
+  >(
     ["team secrets", teamIdForApi],
     () => {
       return enrollSecretsAPI.getTeamEnrollSecrets(teamIdForApi);
@@ -246,10 +247,15 @@ const TeamDetailsWrapper = ({
     }
     setIsUpdatingSecret(true);
     try {
-      await enrollSecretsAPI.modifyTeamEnrollSecrets(teamIdForApi, newSecrets);
-      refetchTeamSecrets();
+      const response = await enrollSecretsAPI.modifyTeamEnrollSecrets(
+        teamIdForApi,
+        newSecrets
+      );
+      queryClient.setQueryData(["team secrets", teamIdForApi], response);
 
       toggleSecretEditorModal();
+      // Team list may show a secret count — separate resource, still needs
+      // a refetch until the backend returns updated team on secret modify.
       isPremiumTier && refetchTeams();
       notify.success(
         `Successfully ${selectedSecret ? "edited" : "added"} enroll secret.`
@@ -276,9 +282,14 @@ const TeamDetailsWrapper = ({
     );
     setIsUpdatingSecret(true);
     try {
-      await enrollSecretsAPI.modifyTeamEnrollSecrets(teamIdForApi, newSecrets);
-      refetchTeamSecrets();
+      const response = await enrollSecretsAPI.modifyTeamEnrollSecrets(
+        teamIdForApi,
+        newSecrets
+      );
+      queryClient.setQueryData(["team secrets", teamIdForApi], response);
       toggleDeleteSecretModal();
+      // Team list may show a secret count — separate resource, still needs
+      // a refetch until the backend returns updated team on secret modify.
       refetchTeams();
       notify.success(`Successfully deleted enroll secret.`);
     } catch (error) {
@@ -325,14 +336,26 @@ const TeamDetailsWrapper = ({
 
       setIsUpdatingTeams(true);
       try {
-        await teamsAPI.update(updatedAttrs, teamIdForApi);
+        const response = await teamsAPI.update(updatedAttrs, teamIdForApi);
+        // Splice the updated team into the cached teams list so we don't
+        // trigger a re-read that could return stale data under replica lag.
+        queryClient.setQueryData<ILoadTeamsResponse>(["teams"], (old) => {
+          if (!old) return old;
+          return {
+            ...old,
+            teams: old.teams.map((t) =>
+              t.id === teamIdForApi ? response.team : t
+            ),
+          };
+        });
+        setBackendValidators({});
+        // Fresh /me since team memberships / display names on the current
+        // user can change as a side effect of a team rename.
+        refetchMe();
+        toggleRenameFleetModal();
         notify.success(
           `Successfully updated fleet name to ${updatedAttrs?.name}`
         );
-        setBackendValidators({});
-        refetchTeams();
-        refetchMe();
-        toggleRenameFleetModal();
       } catch (response) {
         console.error(response);
         const errorObject = formatErrorResponse(response);
@@ -361,7 +384,7 @@ const TeamDetailsWrapper = ({
       currentTeamDetails,
       toggleRenameFleetModal,
       teamIdForApi,
-      refetchTeams,
+      queryClient,
       refetchMe,
     ]
   );

--- a/frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/TeamSettings/TeamSettings.tsx
+++ b/frontend/pages/admin/ManageFleetsPage/TeamDetailsWrapper/TeamSettings/TeamSettings.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 
-import { useQuery } from "react-query";
+import { useQuery, useQueryClient } from "react-query";
 
 import useTeamIdParam from "hooks/useTeamIdParam";
 
@@ -123,6 +123,7 @@ const TeamSettings = ({ location, router }: ITeamSubnavProps) => {
   const [formErrors, setFormErrors] = useState<Record<string, string | null>>(
     {}
   );
+  const queryClient = useQueryClient();
   const [
     showHostStatusWebhookPreviewModal,
     setShowHostStatusWebhookPreviewModal,
@@ -173,7 +174,6 @@ const TeamSettings = ({ location, router }: ITeamSubnavProps) => {
   const {
     data: teamConfig,
     isLoading: isLoadingTeamConfig,
-    refetch: refetchTeamConfig,
     error: errorLoadTeamConfig,
   } = useQuery<ILoadTeamResponse, Error, ITeamConfig>(
     ["teamConfig", teamIdForApi],
@@ -327,9 +327,9 @@ const TeamSettings = ({ location, router }: ITeamSubnavProps) => {
         },
         teamIdForApi
       )
-      .then(() => {
+      .then((response) => {
+        queryClient.setQueryData(["teamConfig", teamIdForApi], response);
         notify.success("Successfully updated settings.");
-        refetchTeamConfig();
         setIsInitialTeamConfig(false);
         setConfirmModalOpen(false);
       })
@@ -342,7 +342,7 @@ const TeamSettings = ({ location, router }: ITeamSubnavProps) => {
       .finally(() => {
         setUpdatingTeamSettings(false);
       });
-  }, [formData, globalHostExpiryEnabled, refetchTeamConfig, teamIdForApi]);
+  }, [formData, globalHostExpiryEnabled, queryClient, teamIdForApi]);
 
   const updateTeamSettings = useCallback(
     (evt: React.MouseEvent<HTMLFormElement>) => {

--- a/frontend/pages/admin/ManageUsersPage/EditUserPage/EditUserPage.tsx
+++ b/frontend/pages/admin/ManageUsersPage/EditUserPage/EditUserPage.tsx
@@ -138,8 +138,8 @@ const EditUserPage = ({ router, params, location }: IEditUserPageProps) => {
 
     usersAPI
       .update(entityId, requestData)
-      .then(() => {
-        queryClient.invalidateQueries(["user", entityId]);
+      .then((updatedUser) => {
+        queryClient.setQueryData(["user", entityId], updatedUser);
         notify.success(successMessage);
         router.push(PATHS.ADMIN_USERS);
       })
@@ -180,8 +180,8 @@ const EditUserPage = ({ router, params, location }: IEditUserPageProps) => {
         })),
         api_endpoints: formData.api_endpoints,
       })
-      .then(() => {
-        queryClient.invalidateQueries(["user", entityId]);
+      .then((updatedUser) => {
+        queryClient.setQueryData(["user", entityId], updatedUser);
         notify.success(`Successfully edited ${formData.name}.`);
         router.push(PATHS.ADMIN_USERS);
       })

--- a/frontend/pages/admin/OrgSettingsPage/OrgSettingsPage.tests.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/OrgSettingsPage.tests.tsx
@@ -1,0 +1,118 @@
+import React from "react";
+import { screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+
+import {
+  baseUrl,
+  createCustomRenderer,
+  createMockRouter,
+} from "test/test-utils";
+import mockServer from "test/mock-server";
+import createMockConfig from "__mocks__/configMock";
+import { IConfig } from "interfaces/config";
+
+import OrgSettingsPage from "./OrgSettingsPage";
+
+jest.mock("components/ToastNotification", () => ({
+  notify: {
+    success: jest.fn(),
+    error: jest.fn(),
+    batch: jest.fn(),
+    dismiss: jest.fn(),
+  },
+}));
+
+const configUrl = baseUrl("/config");
+
+const createGetConfigHandler = (
+  getSpy: jest.Mock,
+  overrides?: Partial<IConfig>
+) => {
+  return http.get(configUrl, () => {
+    getSpy();
+    return HttpResponse.json(createMockConfig(overrides));
+  });
+};
+
+const createPatchConfigHandler = (
+  patchSpy: jest.Mock,
+  overrides?: Partial<IConfig>
+) => {
+  return http.patch(configUrl, async ({ request }) => {
+    const body = (await request.json()) as Partial<IConfig>;
+    patchSpy(body);
+    return HttpResponse.json(
+      createMockConfig({
+        ...overrides,
+        org_info: {
+          ...createMockConfig(overrides).org_info,
+          ...body.org_info,
+        },
+      })
+    );
+  });
+};
+
+describe("OrgSettingsPage", () => {
+  const render = createCustomRenderer({
+    withBackendMock: true,
+    context: {
+      app: { isPremiumTier: true, setConfig: jest.fn() },
+    },
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("does not refetch /config after a successful save", async () => {
+    // The read-after-write regression (#42546): on save, the page used to
+    // refetch /config, which returns stale data under DB read-replica lag.
+    // The fix consumes the PATCH response directly. This asserts GET /config
+    // fires ONCE — for the initial load — and never again after the write.
+    const getSpy = jest.fn();
+    const patchSpy = jest.fn();
+    mockServer.use(
+      createGetConfigHandler(getSpy, {
+        org_info: {
+          org_name: "Old name",
+          org_logo_url: "",
+          org_logo_url_light_background: "",
+          contact_url: "https://fleetdm.com/company/contact",
+        },
+      }),
+      createPatchConfigHandler(patchSpy)
+    );
+
+    const { user } = render(
+      <OrgSettingsPage
+        params={{ section: "organization" }}
+        router={createMockRouter()}
+      />
+    );
+
+    const orgNameInput = await screen.findByLabelText("Organization name");
+    await user.clear(orgNameInput);
+    await user.type(orgNameInput, "New name");
+
+    const saveButton = screen.getByRole("button", { name: /save/i });
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(patchSpy).toHaveBeenCalledTimes(1);
+    });
+    expect(patchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        org_info: expect.objectContaining({ org_name: "New name" }),
+      })
+    );
+
+    // The critical assertion: GET /config fires only on initial mount, not
+    // after the write. Give React Query a beat to schedule any (unwanted)
+    // background refetch before asserting.
+    await new Promise((resolve) => {
+      setTimeout(resolve, 50);
+    });
+    expect(getSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/pages/admin/OrgSettingsPage/OrgSettingsPage.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/OrgSettingsPage.tsx
@@ -7,6 +7,7 @@ import { IConfig } from "interfaces/config";
 import { IApiError } from "interfaces/errors";
 import configAPI from "services/entities/config";
 import { AppContext } from "context/app";
+import useUpdateAppConfig from "hooks/useUpdateAppConfig";
 import deepDifference from "utilities/deep_difference";
 import Spinner from "components/Spinner";
 import { notify } from "components/ToastNotification";
@@ -28,9 +29,8 @@ const OrgSettingsPage = ({ params, router }: IOrgSettingsPageProps) => {
   const DEFAULT_SETTINGS_SECTION = ORG_SETTINGS_NAV_ITEMS[0];
 
   const [isUpdatingSettings, setIsUpdatingSettings] = useState(false);
-  const { isFreeTier, isPremiumTier, setConfig, isSandboxMode } = useContext(
-    AppContext
-  );
+  const { isFreeTier, isPremiumTier, isSandboxMode } = useContext(AppContext);
+  const updateAppConfig = useUpdateAppConfig();
 
   if (isSandboxMode) {
     // redirect to Integrations page in sandbox mode
@@ -38,14 +38,13 @@ const OrgSettingsPage = ({ params, router }: IOrgSettingsPageProps) => {
   }
   const handlePageError = useErrorHandler();
 
-  const {
-    data: appConfig,
-    isLoading: isLoadingAppConfig,
-    refetch: refetchConfig,
-  } = useQuery<IConfig, Error, IConfig>(["config"], () => configAPI.loadAll(), {
-    select: (data: IConfig) => data,
+  const { data: appConfig, isLoading: isLoadingAppConfig } = useQuery<
+    IConfig,
+    Error,
+    IConfig
+  >(["config"], () => configAPI.loadAll(), {
     onSuccess: (data) => {
-      setConfig(data);
+      updateAppConfig(data);
     },
   });
 
@@ -62,9 +61,9 @@ const OrgSettingsPage = ({ params, router }: IOrgSettingsPageProps) => {
       diff.agent_options = formUpdates.agent_options;
 
       try {
-        await configAPI.update(diff);
+        const updatedConfig = await configAPI.update(diff);
+        updateAppConfig(updatedConfig);
         notify.success("Successfully updated settings.");
-        refetchConfig();
         return true;
       } catch (response) {
         const resp = response as undefined | { data: IApiError };
@@ -101,7 +100,7 @@ const OrgSettingsPage = ({ params, router }: IOrgSettingsPageProps) => {
         setIsUpdatingSettings(false);
       }
     },
-    [appConfig, refetchConfig]
+    [appConfig, updateAppConfig]
   );
 
   // filter out non-premium options

--- a/frontend/pages/labels/EditLabelPage/EditLabelPage.tsx
+++ b/frontend/pages/labels/EditLabelPage/EditLabelPage.tsx
@@ -94,11 +94,13 @@ const EditLabelPage = ({ routeParams, router }: IEditLabelPageProps) => {
     formData: IDynamicLabelFormData | IManualLabelFormData
   ) => {
     try {
-      await labelsAPI.update(labelId, formData);
-      notify.success("Label updated successfully.");
-      queryClient.invalidateQueries(["label", labelId, currentUser]);
+      const updatedLabel = await labelsAPI.update(labelId, formData);
+      queryClient.setQueryData(["label", labelId, currentUser], updatedLabel);
+      // Host membership and the labels list are separate resources that may
+      // have changed as a side effect; invalidate to trigger a fresh read.
       queryClient.invalidateQueries(["hosts", labelId]);
       queryClient.invalidateQueries(["labels"]);
+      notify.success("Label updated successfully.");
     } catch (error) {
       const status = (error as { status: number }).status;
       let errorMessage = "Couldn't edit label. Please try again.";

--- a/frontend/pages/policies/ManagePoliciesPage/components/AutomationsModal/AutomationsModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/AutomationsModal/AutomationsModal.tsx
@@ -11,6 +11,7 @@ import teamsAPI, {
   ILoadTeamResponse,
   IUpdateTeamFormData,
 } from "services/entities/teams";
+import useUpdateAppConfig from "hooks/useUpdateAppConfig";
 import Modal from "components/Modal";
 import Button from "components/buttons/Button";
 import {
@@ -57,7 +58,8 @@ const AutomationsModal = ({
   onExit,
 }: IAutomationsModalProps): JSX.Element | null => {
   const queryClient = useQueryClient();
-  const { setConfig, isPremiumTier } = useContext(AppContext);
+  const { isPremiumTier } = useContext(AppContext);
+  const updateAppConfig = useUpdateAppConfig();
 
   const otherFormRef = useRef<
     IAutomationFormHandle<IOtherWorkflowsModalSubmit>
@@ -108,10 +110,6 @@ const AutomationsModal = ({
     ? "Okta or Microsoft Entra"
     : "Okta";
 
-  const updateGlobalConfigCache = (updatedConfig: IConfig) => {
-    queryClient.setQueryData(["config"], updatedConfig);
-    setConfig(updatedConfig);
-  };
   const updateTeamConfigCache = (updatedTeamResponse: ILoadTeamResponse) => {
     queryClient.setQueryData(["teams", teamIdForApi], updatedTeamResponse);
   };
@@ -136,7 +134,7 @@ const AutomationsModal = ({
         // Global ("All teams"): only Other is editable.
         if (otherData) {
           const updatedConfig = await configAPI.update(otherData);
-          updateGlobalConfigCache(updatedConfig);
+          updateAppConfig(updatedConfig);
         }
       } else if (teamIdForApi === API_NO_TEAM_ID) {
         // "No team": webhook_settings live on the team record and
@@ -169,7 +167,7 @@ const AutomationsModal = ({
                   conditional_access_enabled: caData.enabled,
                 },
               })
-              .then(updateGlobalConfigCache)
+              .then(updateAppConfig)
           );
         }
         await Promise.all(promises);

--- a/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tsx
@@ -401,11 +401,14 @@ const PolicyForm = ({
     }
     setIsAddingAutomation(true);
     try {
-      await teamPoliciesAPI.update(policyIdForEdit as number, {
-        team_id: storedPolicy.team_id,
-        software_title_id: storedPolicy.patch_software.software_title_id,
-      });
-      queryClient.invalidateQueries(["policy", policyIdForEdit]);
+      const { policy: updatedPolicy } = await teamPoliciesAPI.update(
+        policyIdForEdit as number,
+        {
+          team_id: storedPolicy.team_id,
+          software_title_id: storedPolicy.patch_software.software_title_id,
+        }
+      );
+      queryClient.setQueryData(["policy", policyIdForEdit], updatedPolicy);
       notify.success("Automation added.");
     } catch (e) {
       notify.error("Couldn't set automation. Please try again.", {

--- a/frontend/pages/policies/edit/components/SaveNewPolicyModal/SaveNewPolicyModal.tsx
+++ b/frontend/pages/policies/edit/components/SaveNewPolicyModal/SaveNewPolicyModal.tsx
@@ -25,6 +25,7 @@ import { MAX_ENTITY_CHAR_LENGTH } from "utilities/constants";
 import configAPI from "services/entities/config";
 import teamPoliciesAPI from "services/entities/team_policies";
 import teamsAPI from "services/entities/teams";
+import useUpdateAppConfig from "hooks/useUpdateAppConfig";
 
 import InputField from "components/forms/fields/InputField";
 import Checkbox from "components/forms/fields/Checkbox";
@@ -103,8 +104,9 @@ const SaveNewPolicyModal = ({
   fleetName,
   router,
 }: ISaveNewPolicyModalProps): JSX.Element => {
-  const { isPremiumTier, setConfig } = useContext(AppContext);
+  const { isPremiumTier } = useContext(AppContext);
   const queryClient = useQueryClient();
+  const updateAppConfig = useUpdateAppConfig();
   const {
     lastEditedQueryName,
     lastEditedQueryDescription,
@@ -233,8 +235,7 @@ const SaveNewPolicyModal = ({
             if (isGlobalPolicy) {
               requests.push(
                 configAPI.update(webhookPayload).then((updatedConfig) => {
-                  queryClient.setQueryData(["config"], updatedConfig);
-                  setConfig(updatedConfig);
+                  updateAppConfig(updatedConfig);
                 })
               );
             } else if (policyTeamId !== undefined) {

--- a/frontend/pages/policies/hooks/useUpdatePolicyAutomations.tests.tsx
+++ b/frontend/pages/policies/hooks/useUpdatePolicyAutomations.tests.tsx
@@ -50,7 +50,6 @@ const emptyGlobalConfig: IConfig = createMockConfig({
       host_percentage: 0,
       days_count: 0,
     },
-    interval: "0s",
     vulnerabilities_webhook: {
       enable_vulnerabilities_webhook: false,
       destination_url: "",

--- a/frontend/pages/policies/hooks/useUpdatePolicyAutomations.tests.tsx
+++ b/frontend/pages/policies/hooks/useUpdatePolicyAutomations.tests.tsx
@@ -1,0 +1,333 @@
+import React from "react";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+
+import { AppContext, IAppContext, initialState } from "context/app";
+import createMockConfig from "__mocks__/configMock";
+import createMockPolicy from "__mocks__/policyMock";
+import { IConfig } from "interfaces/config";
+import { ITeamConfig } from "interfaces/team";
+import configAPI from "services/entities/config";
+import teamPoliciesAPI from "services/entities/team_policies";
+import teamsAPI, { ILoadTeamResponse } from "services/entities/teams";
+
+import useUpdatePolicyAutomations from "./useUpdatePolicyAutomations";
+
+const buildWrapper = (appOverrides: Partial<IAppContext> = {}) => {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  const value: IAppContext = { ...initialState, ...appOverrides };
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>
+      <AppContext.Provider value={value}>{children}</AppContext.Provider>
+    </QueryClientProvider>
+  );
+  return { Wrapper, client };
+};
+
+// Empty webhook baseline: the mutation reads existing `policy_ids` off this
+// object to compute the next list. `ITeamConfig` is bigger than we need, so we
+// cast a minimal shape to `ITeamConfig` for the team-scoped tests.
+const emptyGlobalConfig: IConfig = createMockConfig({
+  webhook_settings: {
+    failing_policies_webhook: {
+      enable_failing_policies_webhook: false,
+      destination_url: "",
+      policy_ids: [],
+      host_batch_size: 0,
+    },
+    activities_webhook: {
+      enable_activities_webhook: false,
+      destination_url: "",
+    },
+    host_status_webhook: {
+      enable_host_status_webhook: false,
+      destination_url: "",
+      host_percentage: 0,
+      days_count: 0,
+    },
+    interval: "0s",
+    vulnerabilities_webhook: {
+      enable_vulnerabilities_webhook: false,
+      destination_url: "",
+      host_batch_size: 0,
+    },
+  },
+});
+
+const emptyTeamConfig = ({
+  webhook_settings: {
+    failing_policies_webhook: {
+      enable_failing_policies_webhook: false,
+      destination_url: "",
+      policy_ids: [],
+      host_batch_size: 0,
+    },
+  },
+} as unknown) as ITeamConfig;
+
+describe("useUpdatePolicyAutomations", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("primes the ['config'] cache from the write response when a global policy toggles a webhook", async () => {
+    // The read-after-write regression (#42546): pages used to invalidate
+    // ["config"] here, triggering a refetch that returned stale data under
+    // replica lag. The fix consumes the PATCH response directly.
+    const policy = createMockPolicy({ id: 42, team_id: null });
+    const updated = createMockConfig({
+      ...emptyGlobalConfig,
+      webhook_settings: {
+        ...emptyGlobalConfig.webhook_settings,
+        failing_policies_webhook: {
+          ...emptyGlobalConfig.webhook_settings.failing_policies_webhook,
+          policy_ids: [42],
+        },
+      },
+    });
+    const setConfig = jest.fn();
+    const configUpdate = jest
+      .spyOn(configAPI, "update")
+      .mockResolvedValue(updated);
+
+    const { Wrapper, client } = buildWrapper({ setConfig });
+    const { result } = renderHook(
+      () =>
+        useUpdatePolicyAutomations({
+          policy,
+          teamIdForApi: undefined,
+          isGlobalPolicy: true,
+          automationsConfig: emptyGlobalConfig,
+        }),
+      { wrapper: Wrapper }
+    );
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        webhookOrTicketUpdate: { enabled: true },
+      });
+    });
+
+    expect(configUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        webhook_settings: expect.objectContaining({
+          failing_policies_webhook: expect.objectContaining({
+            policy_ids: [42],
+          }),
+        }),
+      })
+    );
+    expect(setConfig).toHaveBeenCalledWith(updated);
+    expect(client.getQueryData(["config"])).toBe(updated);
+  });
+
+  it("primes the ['teams', id] cache from the write response when a team policy toggles a webhook", async () => {
+    const policy = createMockPolicy({ id: 99, team_id: 3 });
+    const updatedTeam = ({
+      team: { ...emptyTeamConfig, id: 3 },
+    } as unknown) as ILoadTeamResponse;
+    const teamsUpdate = jest
+      .spyOn(teamsAPI, "update")
+      .mockResolvedValue(updatedTeam);
+
+    const { Wrapper, client } = buildWrapper();
+    const { result } = renderHook(
+      () =>
+        useUpdatePolicyAutomations({
+          policy,
+          teamIdForApi: 3,
+          isGlobalPolicy: false,
+          automationsConfig: emptyTeamConfig,
+        }),
+      { wrapper: Wrapper }
+    );
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        webhookOrTicketUpdate: { enabled: true },
+      });
+    });
+
+    expect(teamsUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        webhook_settings: expect.objectContaining({
+          failing_policies_webhook: expect.objectContaining({
+            policy_ids: [99],
+          }),
+        }),
+      }),
+      3
+    );
+    expect(client.getQueryData(["teams", 3])).toBe(updatedTeam);
+  });
+
+  it("removes the policy id when the webhook is toggled off", async () => {
+    const policy = createMockPolicy({ id: 7, team_id: null });
+    const configWithMembership = createMockConfig({
+      webhook_settings: {
+        ...emptyGlobalConfig.webhook_settings,
+        failing_policies_webhook: {
+          ...emptyGlobalConfig.webhook_settings.failing_policies_webhook,
+          policy_ids: [7, 11],
+        },
+      },
+    });
+    const configUpdate = jest
+      .spyOn(configAPI, "update")
+      .mockResolvedValue(configWithMembership);
+
+    const { Wrapper } = buildWrapper({ setConfig: jest.fn() });
+    const { result } = renderHook(
+      () =>
+        useUpdatePolicyAutomations({
+          policy,
+          teamIdForApi: undefined,
+          isGlobalPolicy: true,
+          automationsConfig: configWithMembership,
+        }),
+      { wrapper: Wrapper }
+    );
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        webhookOrTicketUpdate: { enabled: false },
+      });
+    });
+
+    expect(configUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        webhook_settings: expect.objectContaining({
+          failing_policies_webhook: expect.objectContaining({
+            policy_ids: [11],
+          }),
+        }),
+      })
+    );
+  });
+
+  it("sends per-policy fields via teamPoliciesAPI.update and does not touch the config cache", async () => {
+    const policy = createMockPolicy({ id: 5, team_id: null });
+    const policyUpdate = jest
+      .spyOn(teamPoliciesAPI, "update")
+      .mockResolvedValue({ policy });
+    const setConfig = jest.fn();
+    const configUpdate = jest.spyOn(configAPI, "update");
+
+    const { Wrapper, client } = buildWrapper({ setConfig });
+    const { result } = renderHook(
+      () =>
+        useUpdatePolicyAutomations({
+          policy,
+          teamIdForApi: undefined,
+          isGlobalPolicy: true,
+          automationsConfig: emptyGlobalConfig,
+        }),
+      { wrapper: Wrapper }
+    );
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        policyUpdate: { calendar_events_enabled: true },
+      });
+    });
+
+    expect(policyUpdate).toHaveBeenCalledWith(
+      5,
+      expect.objectContaining({ calendar_events_enabled: true })
+    );
+    expect(configUpdate).not.toHaveBeenCalled();
+    expect(setConfig).not.toHaveBeenCalled();
+    expect(client.getQueryData(["config"])).toBeUndefined();
+  });
+
+  it("invalidates ['config'] on error for a global policy so a stale primed cache does not stick", async () => {
+    const policy = createMockPolicy({ id: 1, team_id: null });
+    jest.spyOn(configAPI, "update").mockRejectedValue(new Error("boom"));
+    const onError = jest.fn();
+
+    const { Wrapper, client } = buildWrapper({ setConfig: jest.fn() });
+    const invalidateSpy = jest.spyOn(client, "invalidateQueries");
+
+    const { result } = renderHook(
+      () =>
+        useUpdatePolicyAutomations({
+          policy,
+          teamIdForApi: undefined,
+          isGlobalPolicy: true,
+          automationsConfig: emptyGlobalConfig,
+          onError,
+        }),
+      { wrapper: Wrapper }
+    );
+
+    await act(async () => {
+      await result.current
+        .mutateAsync({ webhookOrTicketUpdate: { enabled: true } })
+        .catch(() => undefined);
+    });
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith(["config"]);
+    });
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it("invalidates ['teams', id] on error for a team-scoped policy", async () => {
+    const policy = createMockPolicy({ id: 2, team_id: 4 });
+    jest.spyOn(teamsAPI, "update").mockRejectedValue(new Error("boom"));
+
+    const { Wrapper, client } = buildWrapper();
+    const invalidateSpy = jest.spyOn(client, "invalidateQueries");
+
+    const { result } = renderHook(
+      () =>
+        useUpdatePolicyAutomations({
+          policy,
+          teamIdForApi: 4,
+          isGlobalPolicy: false,
+          automationsConfig: emptyTeamConfig,
+        }),
+      { wrapper: Wrapper }
+    );
+
+    await act(async () => {
+      await result.current
+        .mutateAsync({ webhookOrTicketUpdate: { enabled: true } })
+        .catch(() => undefined);
+    });
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith(["teams", 4]);
+    });
+  });
+
+  it("throws at hook-init time when a team-scoped policy is missing teamIdForApi", () => {
+    const policy = createMockPolicy({ id: 1, team_id: 1 });
+    const { Wrapper } = buildWrapper();
+
+    // Silence React's error-boundary console noise for this expected throw.
+    const errSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    expect(() =>
+      renderHook(
+        () =>
+          useUpdatePolicyAutomations({
+            policy,
+            teamIdForApi: undefined,
+            isGlobalPolicy: false,
+            automationsConfig: emptyTeamConfig,
+          }),
+        { wrapper: Wrapper }
+      )
+    ).toThrow(/Missing fleet id/);
+
+    errSpy.mockRestore();
+  });
+});

--- a/frontend/pages/policies/hooks/useUpdatePolicyAutomations.ts
+++ b/frontend/pages/policies/hooks/useUpdatePolicyAutomations.ts
@@ -1,13 +1,12 @@
-import { useContext } from "react";
 import { useMutation, useQueryClient } from "react-query";
 
-import { AppContext } from "context/app";
 import { IConfig } from "interfaces/config";
 import { IPolicy, IPolicyFormData } from "interfaces/policy";
 import { ITeamConfig } from "interfaces/team";
 import configAPI from "services/entities/config";
 import teamPoliciesAPI from "services/entities/team_policies";
 import teamsAPI from "services/entities/teams";
+import useUpdateAppConfig from "hooks/useUpdateAppConfig";
 
 /** The per-policy automation fields settable from the modal. */
 export type IPolicyAutomationUpdate = Pick<
@@ -51,7 +50,7 @@ const useUpdatePolicyAutomations = ({
   onError,
 }: IUseUpdatePolicyAutomationsArgs) => {
   const queryClient = useQueryClient();
-  const { setConfig } = useContext(AppContext);
+  const updateAppConfig = useUpdateAppConfig();
 
   if (!isGlobalPolicy && teamIdForApi === undefined) {
     throw new Error("Missing fleet id for team-scoped policy automations.");
@@ -78,8 +77,7 @@ const useUpdatePolicyAutomations = ({
 
     if (isGlobalPolicy) {
       const updatedConfig = await configAPI.update(payload);
-      queryClient.setQueryData(["config"], updatedConfig);
-      setConfig(updatedConfig);
+      updateAppConfig(updatedConfig);
     } else {
       const updatedTeam = await teamsAPI.update(payload, teamIdForApi);
       queryClient.setQueryData(["teams", teamIdForApi], updatedTeam);

--- a/frontend/services/entities/config.ts
+++ b/frontend/services/entities/config.ts
@@ -42,8 +42,11 @@ export default {
    * If the request fails and `skipParseError` is `true`, the caller is
    * responsible for verifying that the value of the rejected promise is an AxiosError
    * and further parsing of the error message.
+   *
+   * Returns the updated `IConfig` so callers can prime the cache directly
+   * instead of refetching (which is unsafe under read-replica lag).
    */
-  update: (formData: object, skipParseError?: boolean) => {
+  update: (formData: object, skipParseError?: boolean): Promise<IConfig> => {
     const { CONFIG } = endpoints;
 
     return sendRequest(

--- a/frontend/services/entities/team_policies.ts
+++ b/frontend/services/entities/team_policies.ts
@@ -114,8 +114,10 @@ export default {
       patch_when_closed,
     });
   },
-  // TODO - response type Promise<IPolicy>
-  update: (id: number, data: IPolicyFormData) => {
+  update: (
+    id: number,
+    data: IPolicyFormData
+  ): Promise<ILoadTeamPolicyResponse> => {
     const {
       name,
       description,


### PR DESCRIPTION
## Issue

Resolves #42546.

## Description

Under DB read-replica lag, the frontend refetched config/team/label/policy after saves and got stale data — users saw their save "revert" on navigation.

Fix: consume the write response directly to prime the React Query cache instead of refetching. Applied across ~30 sites (config API, teams/users/labels, MDM, policies). New `useUpdateAppConfig` hook fans one call out to `setConfig` + `queryClient.setQueryData(["config"])`. `configAPI.update` typed as `Promise<IConfig>`; `teamPoliciesAPI.update` typed as `Promise<ILoadTeamPolicyResponse>`.

Also folds pre-existing `setConfig`-only sites into `useUpdateAppConfig` so the `["config"]` cache stays in sync across pages — silent variant of the same bug where other pages consuming `useQuery(["config"])` stayed stale.

Detector: `.github/scripts/detect-read-after-write.sh` wired into `test-js.yml`. Allowlist documents the sites deferred to a follow-up PR and cases where a cross-resource invalidation is legitimate (e.g. `EditLabelPage` invalidating `["hosts"]` after a label edit).

**Follow-up PR needed** for the sites the detector allowlists:
- Endpoints that don't return updated config today: logo PUT/DELETE, APNs DELETE, bootstrap package DELETE, `updateSetupExperienceSettings`, `updateHostNameTemplate`, `deleteMicrosoftConditionalAccess`.
- Frontend sites where the refetch is load-bearing UX (form reset via remount): `AppleOSTargetForm`, `WindowsTargetForm`, `InstallSoftwareForm`.

React Query v5 (#50538): this PR is intentionally v3-shaped. The `useQuery(..., { onSuccess })` handlers touched here will need mechanical conversion to `useEffect` when v5 lands; the write-path pattern (the actual fix) is v5-safe.

## Screenrecording


## Testing

- New `OrgSettingsPage.tests.tsx` asserts GET `/config` fires exactly once — never after a successful PATCH.
- Full frontend suite: 1521 tests pass.
- Three existing tests (`AddEntraClientIDModal`, `EndUserMigrationSection`, `WindowsMdmPage`) needed `withBackendMock: true` added because their components now use `useQueryClient` via the helper hook.

- [x] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually