### PR TITLE
Fleet UI: Fix undersized icons on default-size buttons

### DIFF
--- a/.claude/rules/fleet-frontend.md
+++ b/.claude/rules/fleet-frontend.md
@@ -88,6 +88,9 @@ Use helpers from `frontend/utilities/strings/stringUtils.ts`:
 - `stripQuotes(str)`, `strToBool(str)` — input parsing
 - `enforceFleetSentenceCasing(str)` — respects Fleet stylization rules
 
+## Buttons
+Prefer `<Button icon="name">` over `<Button><Icon /></Button>` — the prop auto-sizes (16px default, 12px small) and auto-colors; the child pattern is only for a genuinely non-default color or an Icon `className`, and icon-only buttons must set `ariaLabel`.
+
 ## Software titles
 
 ### Display name

--- a/.claude/rules/fleet-frontend.md
+++ b/.claude/rules/fleet-frontend.md
@@ -89,7 +89,7 @@ Use helpers from `frontend/utilities/strings/stringUtils.ts`:
 - `enforceFleetSentenceCasing(str)` — respects Fleet stylization rules
 
 ## Buttons
-Prefer `<Button icon="name">` over `<Button><Icon /></Button>` — the prop auto-sizes (16px default, 12px small) and auto-colors; the child pattern is only for a genuinely non-default color or an Icon `className`, and icon-only buttons must set `ariaLabel`.
+Always use `<Button icon="name">` — the `<Button><Icon /></Button>` child pattern is not allowed; icon-only buttons must set `ariaLabel`.
 
 ## Software titles
 

--- a/frontend/components/InfoBanner/InfoBanner.tsx
+++ b/frontend/components/InfoBanner/InfoBanner.tsx
@@ -69,6 +69,7 @@ const InfoBanner = ({
             <Button
               variant="subdued"
               icon="close"
+              ariaLabel="Close"
               onClick={() => setHideBanner(true)}
               className={`${baseClass}__close`}
             />

--- a/frontend/components/InfoBanner/InfoBanner.tsx
+++ b/frontend/components/InfoBanner/InfoBanner.tsx
@@ -66,14 +66,12 @@ const InfoBanner = ({
         <div className={`${baseClass}__cta`}>
           {cta}
           {closable && (
-            <Button variant="subdued" onClick={() => setHideBanner(true)}>
-              <Icon
-                name="close"
-                color="core-fleet-black"
-                size="small"
-                className={`${baseClass}__close`}
-              />
-            </Button>
+            <Button
+              variant="subdued"
+              icon="close"
+              onClick={() => setHideBanner(true)}
+              className={`${baseClass}__close`}
+            />
           )}
         </div>
       )}

--- a/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/SelfServiceCategoriesPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/SelfServiceCategoriesPage.tsx
@@ -17,7 +17,6 @@ import Button from "components/buttons/Button";
 import CustomLink from "components/CustomLink";
 import DataError from "components/DataError";
 import EmptyState from "components/EmptyState";
-import Icon from "components/Icon";
 import MainContent from "components/MainContent";
 import PageDescription from "components/PageDescription";
 import PremiumFeatureMessage from "components/PremiumFeatureMessage";
@@ -243,17 +242,15 @@ const SelfServiceCategoriesPage = ({
                   onClick={() => setCategoryToEdit(listItem)}
                   ariaLabel={`Edit ${listItem.name}`}
                   title="Edit"
-                >
-                  <Icon name="pencil" />
-                </Button>
+                  icon="pencil"
+                />
                 <Button
                   variant="secondary"
                   onClick={() => setCategoryToDelete(listItem)}
                   ariaLabel={`Delete ${listItem.name}`}
                   title="Delete"
-                >
-                  <Icon name="trash" />
-                </Button>
+                  icon="trash"
+                />
               </div>
             )}
           </div>

--- a/frontend/pages/hosts/details/cards/HostHeader/HostHeader.tsx
+++ b/frontend/pages/hosts/details/cards/HostHeader/HostHeader.tsx
@@ -4,7 +4,6 @@ import classnames from "classnames";
 import { isAndroid, isIPadOrIPhone } from "interfaces/platform";
 
 import Button from "components/buttons/Button";
-import Icon from "components/Icon/Icon";
 import { HumanTimeDiffWithFleetLaunchCutoff } from "components/HumanTimeDiffWithDateTip";
 import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
 import { useCheckTruncatedElement } from "hooks/useCheckTruncatedElement";
@@ -59,8 +58,8 @@ const RefetchButton = ({
             disabled={isDisabled || isFetching}
             onClick={onRefetchHost}
             variant="secondary"
+            icon="refresh"
           >
-            <Icon name="refresh" color="ui-fleet-black-75" size="small" />
             {buttonText}
           </Button>
         </div>

--- a/frontend/pages/hosts/details/cards/Vitals/Vitals.tsx
+++ b/frontend/pages/hosts/details/cards/Vitals/Vitals.tsx
@@ -700,9 +700,8 @@ export const buildHostVitals = ({
           size="small"
           onClick={() => onEditCustomHostVital(vital)}
           ariaLabel={`Edit ${vital.name}`}
-        >
-          <Icon name="pencil" size="small" />
-        </Button>
+          icon="pencil"
+        />
       </span>
     ) : (
       vital.name


### PR DESCRIPTION
## Issue

Resolves #34377.

## Description

Follow-up to #50195 — QA originally tagged only `HostHeader.tsx` (Host details Refetch button), but sweeping for the same pattern turned up three more sites still on the legacy `<Icon>` child inside `<Button>`. All four migrated to `icon="..."` on the Button, which auto-sizes to 16x16 on default-size buttons and picks up the variant's default text color.

- **`HostHeader.tsx` Refetch button** — the site QA reported. Had `color="ui-fleet-black-75"` which looked custom but IS the secondary variant's default, so #50195's earlier "keep child pattern for custom colors" carve-out skipped it for a false-positive reason. Now renders 16x16 per spec.
- **`Vitals.tsx` custom-vital edit** and **`SelfServiceCategoriesPage.tsx` edit/delete row actions** — icon-only children with no custom color at all; just weren't migrated in the earlier sweep.
- **`InfoBanner.tsx` close button** — had `color="core-fleet-black"` (darker than the standard `ui-fleet-black-75` used everywhere else on subdued) and `size="small"`. Both were divergences from the design system; the new prop pattern reads the correct color and size from the variant. The `__close` positioning className moves from the Icon to the Button, where it semantically belongs (it's a negative margin to offset button padding). `ariaLabel="Close"` added since the button is now icon-only.

Also added a terse rule to `.claude/rules/fleet-frontend.md` covering the `icon` prop pattern — the child pattern is not allowed anywhere, no exceptions for color or className. This is the second batch of misses since #50195 landed, so tightening the guidance closes the door on further drift.

## Screenrecording


## Testing

- Existing InfoBanner, HostHeader, Vitals, and SelfServiceCategoriesPage tests continue to pass.

- [ ] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually