### PR TITLE
Document mdm.allow_custom_activations

### DIFF
--- a/docs/Configuration/fleet-server-configuration.md
+++ b/docs/Configuration/fleet-server-configuration.md
@@ -3748,7 +3748,7 @@ For Windows, allows users to add custom Windows profiles for BitLocker.
 
 ### mdm.allow_all_declarations
 
-> Enable this feature flag to deploy any device-scoped, configuration [declaration (DDM profile)](https://developer.apple.com/documentation/devicemanagement/devicemanagement-declarations) with Fleet. Assets and user-scoped declarations are [coming in Fleet 4.90](https://github.com/fleetdm/fleet/issues/38986). At the same time, Fleet will enable this feature flag out-of-the-box. Custom activations are [coming in Fleet 4.91.0](https://github.com/fleetdm/fleet/issues/48222).
+> Enable this feature flag to deploy any device-scoped, configuration [declaration (DDM profile)](https://developer.apple.com/documentation/devicemanagement/devicemanagement-declarations) with Fleet. Assets and user-scoped declarations are [coming in Fleet 4.90](https://github.com/fleetdm/fleet/issues/38986). At the same time, Fleet will enable this feature flag out-of-the-box. Custom activations require [`mdm.allow_custom_activations`](#mdm-allow-custom-activations).
 
 If disabled (default), Fleet doesn't allow [these configurations](https://github.com/fleetdm/fleet/blob/9589631a7f25a342ed24571c08deffbc959661ec/server/fleet/apple_mdm.go#L704-L717).
 
@@ -3762,6 +3762,24 @@ Enabling this bypasses checks for forbidden declaration types, reserved identifi
   ```yaml
   mdm:
     allow_all_declarations: true
+  ```
+
+### mdm.allow_custom_activations
+
+*Available in Fleet Premium.*
+
+> On macOS 26.5, an invalid predicate can leave a host unmanageable, and you can't recover it remotely. Apple tracks this as FB24193230. Test each predicate on one host before you add the profile to more hosts.
+
+Allows users to add custom [activations](https://developer.apple.com/documentation/devicemanagement/activationsimple) to Apple configuration declarations (DDM profiles), using the API or GitOps. Apple defines predicate syntax, so Fleet can't check a predicate before it reaches a host.
+
+You can remove an activation you already added, whether or not this setting is turned on.
+
+- Default value: `false`
+- Environment variable: `FLEET_MDM_ALLOW_CUSTOM_ACTIVATIONS`
+- Config file format:
+  ```yaml
+  mdm:
+    allow_custom_activations: true
   ```
 
 ### mdm.allow_orbit_end_user_auth_bypass


### PR DESCRIPTION
**Related issue:** #50764

Documents `mdm.allow_custom_activations`, added in #50863 and renamed in #50879.

Reopened against `docs-v4.91.0` — the earlier PR (#50930) targeted `main` by mistake. Content is unchanged from the version reviewed there, including Magnus's feedback to trim it and move the bug into a `>` callout.

The section covers what the setting allows and why it's off by default: an invalid predicate can leave a macOS 26.5 host unmanageable with no remote recovery (Apple FB24193230). It also notes that an activation already uploaded can be removed whether or not the setting is on, since that's the only way out for anyone affected.

It also corrects a line in the `mdm.allow_all_declarations` section, which said custom activations were "coming in Fleet 4.91.0" and read as though that flag was enough to get them. The two are independent gates, so it now points at the new setting.

# Checklist for submitter

- [x] Documentation added for a user-visible change
