### PR TITLE
Show the profile detail on a verified profile's tooltip

### DIFF
--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingStatusCell/OSSettingStatusCell.tests.tsx
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingStatusCell/OSSettingStatusCell.tests.tsx
@@ -289,4 +289,71 @@ describe("OS setting status cell", () => {
       });
     });
   });
+
+  describe("verified profiles with a detail", () => {
+    // A custom activation's predicate can exclude a host. Fleet delivered the
+    // profile correctly so the status is Verified, but the settings were not
+    // applied, and the generic tooltip claims the opposite.
+    it("shows the detail instead of the generic verified text", async () => {
+      const customRender = createCustomRenderer();
+
+      const detail =
+        'Fleet verified, but predicate ("ASSET-002" == "ASSET-001") evaluated to false and settings were not applied to this host.';
+      const profile = createMockHostMdmProfile({
+        name: "Passcode",
+        platform: "darwin",
+        operation_type: "install",
+        status: "verified",
+        detail,
+      });
+
+      const { user } = customRender(
+        <OSSettingStatusCell
+          profileName="Passcode"
+          status="verified"
+          operationType="install"
+          hostPlatform="darwin"
+          profile={profile}
+        />
+      );
+
+      await user.hover(screen.getByText("Verified"));
+
+      await waitFor(() => {
+        expect(screen.getByText(detail)).toBeInTheDocument();
+      });
+      expect(
+        screen.queryByText("The host applied the setting. Fleet verified.")
+      ).not.toBeInTheDocument();
+    });
+
+    it("keeps the generic verified tooltip when there is no detail", async () => {
+      const customRender = createCustomRenderer();
+
+      const profile = createMockHostMdmProfile({
+        name: "Passcode",
+        platform: "darwin",
+        operation_type: "install",
+        status: "verified",
+        detail: "",
+      });
+
+      const { user } = customRender(
+        <OSSettingStatusCell
+          profileName="Passcode"
+          status="verified"
+          operationType="install"
+          hostPlatform="darwin"
+          profile={profile}
+        />
+      );
+
+      await user.hover(screen.getByText("Verified"));
+      await waitFor(() => {
+        expect(
+          screen.getByText("The host applied the setting. Fleet verified.")
+        ).toBeInTheDocument();
+      });
+    });
+  });
 });

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingStatusCell/OSSettingStatusCell.tsx
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingStatusCell/OSSettingStatusCell.tsx
@@ -136,16 +136,22 @@ const OSSettingStatusCell = ({
 
     // For failed status, use the error detail as tooltip content
     const errorTooltip = profile ? generateErrorTooltip(profile) : null;
-    // For pending profiles, prefer a backend-provided detail message (e.g.
-    // Android Wi-Fi profiles waiting for their certificate) over the generic
-    // "Enforcing" tooltip.
-    const pendingDetailTooltip =
-      profile?.status === "pending" && profile.detail ? profile.detail : null;
+    // Prefer a backend-provided detail message over the generic status text.
+    // Pending profiles use it for e.g. Android Wi-Fi profiles waiting on their
+    // certificate. Verified profiles use it when a custom activation's
+    // predicate excluded this host: Fleet delivered the profile correctly, but
+    // the settings were deliberately not applied, so the generic "the host
+    // applied the setting" would be untrue.
+    const detailTooltip =
+      (profile?.status === "pending" || profile?.status === "verified") &&
+      profile.detail
+        ? profile.detail
+        : null;
 
     let tipContent: React.ReactNode;
-    if (pendingDetailTooltip) {
+    if (detailTooltip) {
       tipContent = (
-        <span className="tooltip__tooltip-text">{pendingDetailTooltip}</span>
+        <span className="tooltip__tooltip-text">{detailTooltip}</span>
       );
     } else if (tooltip) {
       if (status !== "action_required") {


### PR DESCRIPTION
**Related issue:** #50764

Part of the custom activations story. The OS settings status cell has fixed tooltip text for Verified profiles ("The host applied the setting. Fleet verified."), and only falls back to `profile.detail` for failed and pending profiles.

That becomes wrong once activations exist. When an activation's predicate excludes a host, Fleet delivers the profile correctly and marks it Verified, but the settings are deliberately not applied — so the generic text says the opposite of what happened. Fleet already stores the explanation in `profile.detail`:

> Fleet verified, but predicate ("ASSET-002" == "ASSET-001") evaluated to false and settings were not applied to this host.

This extends the existing pending-detail branch to cover verified, so a detail is shown whenever one is set.

Two tests: a verified profile with a detail shows it instead of the generic text, and one without a detail keeps the generic text. Confirmed the first fails without the change.

No changes file — activations are gated off behind `mdm.allow_custom_activations` and unreleased, so this state can't occur on a default install yet.

# Checklist for submitter

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Verified and pending profile statuses now display detailed backend-provided tooltip messages when available.
  * Verified profiles can show specific activation-exclusion details instead of a generic message.

* **Bug Fixes**
  * Preserved the standard verified tooltip when no additional detail is provided.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->
