### PR TITLE
Fixed Windows config profile not deleted properly (#51005)

### DIFF
--- a/changes/49002-50698-50907-windows-profile-shared-locuri-row-cleanup
+++ b/changes/49002-50698-50907-windows-profile-shared-locuri-row-cleanup
@@ -1,0 +1,1 @@
+- Fixed a Windows configuration profile staying listed on Host details > OS settings when it stopped applying to a host but another profile on that host still enforced all of the same settings. This affected deleting or renaming a profile, and transferring a host between fleets with matching profiles.

--- a/server/service/integration_mdm_profiles_test.go
+++ b/server/service/integration_mdm_profiles_test.go
@@ -4532,6 +4532,31 @@ func (s *integrationMDMTestSuite) TestWindowsProfileManagement() {
 		verifyHostProfileStatus(atomicInstallCmds, mdmResponseStatus)
 	}
 
+	// drainCommands triggers the profile schedule, then acks every command the device is handed with 200 OK and returns them.
+	// Several subtests below need the device brought to a clean state before exercising the behaviour they actually assert on.
+	drainCommands := func(device *mdmtest.TestWindowsMDMClient) map[string]fleet.ProtoCmdOperation {
+		s.awaitTriggerProfileSchedule(t)
+		cmds, err := device.StartManagementSession()
+		require.NoError(t, err)
+		msgID, err := device.GetCurrentMsgID()
+		require.NoError(t, err)
+		for _, c := range cmds {
+			cmdID := c.Cmd.CmdID
+			status := syncml.CmdStatusOK
+			device.AppendResponse(fleet.SyncMLCmd{
+				XMLName: xml.Name{Local: fleet.CmdStatus},
+				MsgRef:  &msgID,
+				CmdRef:  &cmdID.Value,
+				Cmd:     new(c.Verb),
+				Data:    &status,
+				CmdID:   fleet.CmdID{Value: uuid.NewString()},
+			})
+		}
+		_, err = device.SendResponse()
+		require.NoError(t, err)
+		return cmds
+	}
+
 	checkHostsProfilesMatch := func(host *fleet.Host, wantUUIDs []string) {
 		var gotUUIDs []string
 		mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
@@ -4869,24 +4894,7 @@ func (s *integrationMDMTestSuite) TestWindowsProfileManagement() {
 		tmResp := teamResponse{}
 		s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", tm.ID), json.RawMessage(`{"mdm": { "windows_updates": {"deadline_days": null, "grace_period_days": null} }}`), http.StatusOK, &tmResp)
 		// Drain any OS updates removal commands
-		s.awaitTriggerProfileSchedule(t)
-		cmds, err := mdmDevice.StartManagementSession()
-		require.NoError(t, err)
-		msgID, err := mdmDevice.GetCurrentMsgID()
-		require.NoError(t, err)
-		for _, c := range cmds {
-			cmdID := c.Cmd.CmdID
-			mdmDevice.AppendResponse(fleet.SyncMLCmd{
-				XMLName: xml.Name{Local: fleet.CmdStatus},
-				MsgRef:  &msgID,
-				CmdRef:  &cmdID.Value,
-				Cmd:     ptr.String(c.Verb),
-				Data:    ptr.String(syncml.CmdStatusOK),
-				CmdID:   fleet.CmdID{Value: uuid.NewString()},
-			})
-		}
-		_, err = mdmDevice.SendResponse()
-		require.NoError(t, err)
+		drainCommands(mdmDevice)
 		verifyProfiles(mdmDevice, 0, false) // drain remaining
 
 		// Create a team with no profiles
@@ -4941,25 +4949,7 @@ func (s *integrationMDMTestSuite) TestWindowsProfileManagement() {
 
 		// Trigger profile sync: device gets the new profile + delete commands for old profiles.
 		// Drain all commands from the device without asserting exact counts (cleanup varies).
-		s.awaitTriggerProfileSchedule(t)
-		cmds, err := mdmDevice.StartManagementSession()
-		require.NoError(t, err)
-		msgID, err := mdmDevice.GetCurrentMsgID()
-		require.NoError(t, err)
-		for _, c := range cmds {
-			cmdID := c.Cmd.CmdID
-			status := syncml.CmdStatusOK
-			mdmDevice.AppendResponse(fleet.SyncMLCmd{
-				XMLName: xml.Name{Local: fleet.CmdStatus},
-				MsgRef:  &msgID,
-				CmdRef:  &cmdID.Value,
-				Cmd:     ptr.String(c.Verb),
-				Data:    &status,
-				CmdID:   fleet.CmdID{Value: uuid.NewString()},
-			})
-		}
-		_, err = mdmDevice.SendResponse()
-		require.NoError(t, err)
+		drainCommands(mdmDevice)
 
 		// Drain any remaining commands until the device is clean.
 		verifyProfiles(mdmDevice, 0, false)
@@ -4976,12 +4966,12 @@ func (s *integrationMDMTestSuite) TestWindowsProfileManagement() {
 		// - 1 Atomic install for the updated profile (from reconciler checksum mismatch)
 		// Total: 2 Status + 1 Delete + 1 Atomic = 4 commands
 		s.awaitTriggerProfileSchedule(t)
-		cmds, err = mdmDevice.StartManagementSession()
+		cmds, err := mdmDevice.StartManagementSession()
 		require.NoError(t, err)
 		require.Len(t, cmds, 4, "expected 2 status + 1 delete + 1 install")
 
 		var gotDelete, gotInstall bool
-		msgID, err = mdmDevice.GetCurrentMsgID()
+		msgID, err := mdmDevice.GetCurrentMsgID()
 		require.NoError(t, err)
 		for _, c := range cmds {
 			cmdID := c.Cmd.CmdID
@@ -5036,25 +5026,7 @@ func (s *integrationMDMTestSuite) TestWindowsProfileManagement() {
 			}}, http.StatusNoContent, "team_id", fmt.Sprint(tm.ID))
 
 		// Drain install commands.
-		s.awaitTriggerProfileSchedule(t)
-		cmds, err := mdmDevice.StartManagementSession()
-		require.NoError(t, err)
-		msgID, err := mdmDevice.GetCurrentMsgID()
-		require.NoError(t, err)
-		for _, c := range cmds {
-			cmdID := c.Cmd.CmdID
-			status := syncml.CmdStatusOK
-			mdmDevice.AppendResponse(fleet.SyncMLCmd{
-				XMLName: xml.Name{Local: fleet.CmdStatus},
-				MsgRef:  &msgID,
-				CmdRef:  &cmdID.Value,
-				Cmd:     ptr.String(c.Verb),
-				Data:    &status,
-				CmdID:   fleet.CmdID{Value: uuid.NewString()},
-			})
-		}
-		_, err = mdmDevice.SendResponse()
-		require.NoError(t, err)
+		drainCommands(mdmDevice)
 		verifyProfiles(mdmDevice, 0, false)
 
 		// Edit profile A to remove AllowCamera (shared with B), keep only AllowCortana.
@@ -5068,10 +5040,10 @@ func (s *integrationMDMTestSuite) TestWindowsProfileManagement() {
 		// Trigger sync: should get an install for the updated A, but NO delete
 		// for AllowCamera since profile B still uses it.
 		s.awaitTriggerProfileSchedule(t)
-		cmds, err = mdmDevice.StartManagementSession()
+		cmds, err := mdmDevice.StartManagementSession()
 		require.NoError(t, err)
 
-		msgID, err = mdmDevice.GetCurrentMsgID()
+		msgID, err := mdmDevice.GetCurrentMsgID()
 		require.NoError(t, err)
 		for _, c := range cmds {
 			if c.Verb == "Delete" {
@@ -5091,6 +5063,57 @@ func (s *integrationMDMTestSuite) TestWindowsProfileManagement() {
 		}
 		_, err = mdmDevice.SendResponse()
 		require.NoError(t, err)
+	})
+
+	t.Run("delete_profile_fully_protected_removes_host_row", func(t *testing.T) {
+		// If profile A and profile B enforce the same LocURI and A is deleted, there is no <Delete> to send because B still
+		// enforces it. The host's row for A must still be cleaned up.
+		sharedProfile := `<Replace><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Config/Privacy/AllowInputPersonalization</LocURI></Target><Meta><Format xmlns="syncml:metinf">int</Format></Meta><Data>0</Data></Item></Replace>`
+		s.Do("POST", "/api/v1/fleet/mdm/profiles/batch",
+			batchSetMDMProfilesRequest{Profiles: []fleet.MDMProfileBatchPayload{
+				{Name: "fully-protected-A", Contents: []byte(sharedProfile)},
+				{Name: "fully-protected-B", Contents: []byte(sharedProfile)},
+			}}, http.StatusNoContent, "team_id", fmt.Sprint(tm.ID))
+
+		// Deliver both profiles so profile A has a host row to leak.
+		drainCommands(mdmDevice)
+
+		var profileAUUID string
+		mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+			return sqlx.GetContext(context.Background(), q, &profileAUUID,
+				`SELECT profile_uuid FROM mdm_windows_configuration_profiles WHERE name = ? AND team_id = ?`, "fully-protected-A", tm.ID)
+		})
+		hostProfileRowCount := func(profileUUID string) int {
+			var count int
+			mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+				return sqlx.GetContext(context.Background(), q, &count,
+					`SELECT COUNT(*) FROM host_mdm_windows_profiles WHERE host_uuid = ? AND profile_uuid = ?`, host.UUID, profileUUID)
+			})
+			return count
+		}
+		require.Equal(t, 1, hostProfileRowCount(profileAUUID))
+
+		// Delete profile A by batch-setting only profile B, which keeps the shared LocURI enforced.
+		s.Do("POST", "/api/v1/fleet/mdm/profiles/batch",
+			batchSetMDMProfilesRequest{Profiles: []fleet.MDMProfileBatchPayload{
+				{Name: "fully-protected-B", Contents: []byte(sharedProfile)},
+			}}, http.StatusNoContent, "team_id", fmt.Sprint(tm.ID))
+
+		// No <Delete> goes out, since profile B still enforces the LocURI.
+		for _, c := range drainCommands(mdmDevice) {
+			require.NotContains(t, c.Cmd.GetTargetURI(), "AllowInputPersonalization",
+				"should NOT delete AllowInputPersonalization because profile B still enforces it")
+		}
+
+		// The host's row for the deleted profile must be gone even though no command was ever sent, so the deleted profile
+		// stops showing up in the host's OS settings.
+		require.Zero(t, hostProfileRowCount(profileAUUID))
+		var gotHostResp getHostResponse
+		s.DoJSON("GET", fmt.Sprintf("/api/v1/fleet/hosts/%d", host.ID), nil, http.StatusOK, &gotHostResp)
+		require.NotNil(t, gotHostResp.Host.MDM.Profiles)
+		for _, p := range *gotHostResp.Host.MDM.Profiles {
+			require.NotEqual(t, "fully-protected-A", p.Name, "deleted profile must not remain listed on the host")
+		}
 	})
 }
 

--- a/server/service/microsoft_mdm.go
+++ b/server/service/microsoft_mdm.go
@@ -4297,6 +4297,10 @@ func executeWindowsProfileReconcileBatch(
 		return uris
 	}
 
+	// Host rows for removes whose <Delete> was fully suppressed by LocURI protection, accumulated across every removed profile in
+	// this batch and deleted in one call below.
+	var suppressedRemoveRows []*fleet.MDMWindowsProfilePayload
+
 	for profUUID, target := range removeTargets {
 		if _, ok := profileContents[profUUID]; !ok {
 			// No retained content for this removed profile, so we can't build its <Delete> this tick. This is normally a transient
@@ -4379,7 +4383,17 @@ func executeWindowsProfileReconcileBatch(
 				continue
 			}
 			if command == nil {
-				// Every LocURI of the removed profile is still enforced by another profile on these hosts; nothing to send.
+				// Every LocURI of the removed profile is still enforced by another profile on these hosts, so there is no
+				// <Delete> to send and no command ack will ever arrive to clean these rows up. Collect the rows and delete
+				// them after the loop.
+				for _, hostUUID := range g.hostUUIDs {
+					suppressedRemoveRows = append(suppressedRemoveRows, &fleet.MDMWindowsProfilePayload{
+						ProfileUUID: profUUID,
+						HostUUID:    hostUUID,
+					})
+				}
+				logger.DebugContext(ctx, "removed profile fully protected by other profiles, deleting host rows",
+					"profile_uuid", profUUID, "host_count", len(g.hostUUIDs))
 				continue
 			}
 
@@ -4408,6 +4422,12 @@ func executeWindowsProfileReconcileBatch(
 			if err := ds.MDMWindowsInsertCommandAndUpsertHostProfilesForHosts(ctx, g.hostUUIDs, command, removePayloadsForCommand); err != nil {
 				return ctxerr.Wrap(ctx, err, "inserting remove commands for hosts")
 			}
+		}
+	}
+
+	if len(suppressedRemoveRows) > 0 {
+		if err := ds.BulkDeleteMDMWindowsHostsConfigProfiles(ctx, suppressedRemoveRows); err != nil {
+			return ctxerr.Wrap(ctx, err, "deleting host profiles whose remove command was fully suppressed")
 		}
 	}
 

--- a/server/service/microsoft_mdm_test.go
+++ b/server/service/microsoft_mdm_test.go
@@ -1081,6 +1081,269 @@ func TestReconcileWindowsProfilesSkipsDeletedProfile(t *testing.T) {
 		"no zombie row should be written when the profile is gone")
 }
 
+// windowsReconcileSnapshot is the state one ReconcileWindowsProfiles tick sees: the hosts, the profiles live for their teams, the
+// rows already on those hosts, and the SyncML behind every profile UUID either side references.
+type windowsReconcileSnapshot struct {
+	hosts    []*fleet.WindowsHostReconcileInfo
+	profiles []*fleet.WindowsProfileForReconcile
+	current  map[string][]*fleet.MDMWindowsProfilePayload
+	contents map[string][]byte
+}
+
+// windowsReconcileResult is what the reconciler did with that snapshot: the commands it enqueued and the host rows it deleted.
+type windowsReconcileResult struct {
+	commands    []*fleet.MDMWindowsCommand
+	deletedRows []*fleet.MDMWindowsProfilePayload
+	deleteCalls int
+}
+
+// deletedPairs returns the deleted rows as a set of (host, profile) keys, which is how the tests below assert on them.
+func (r windowsReconcileResult) deletedPairs() map[hostProfileKey]struct{} {
+	out := make(map[hostProfileKey]struct{}, len(r.deletedRows))
+	for _, row := range r.deletedRows {
+		out[hostProfileKey{hostUUID: row.HostUUID, profileUUID: row.ProfileUUID}] = struct{}{}
+	}
+	return out
+}
+
+// requireNoDeleteCommands asserts the tick sent no <Delete> at all.
+func (r windowsReconcileResult) requireNoDeleteCommands(t *testing.T, msg string) {
+	t.Helper()
+	for _, cmd := range r.commands {
+		require.NotContains(t, string(cmd.RawCommand), "<Delete", msg)
+	}
+}
+
+const windowsReconcileTestChecksum = "test-checksum"
+
+// runWindowsReconcileOnce drives a single ReconcileWindowsProfiles tick over the given snapshot. The suppressed-remove tests below
+// differ only in the snapshot they set up and the assertions they make, so the mock wiring lives here.
+func runWindowsReconcileOnce(t *testing.T, snapshot windowsReconcileSnapshot) windowsReconcileResult {
+	t.Helper()
+	ctx := t.Context()
+	ds := new(mock.Store)
+	setupReconcilerTest(ds, map[string]*fleet.MDMWindowsConfigProfile{})
+
+	ds.GetWindowsProfileReconcileSnapshotFunc = func(ctx context.Context, after string, batch int) (
+		[]*fleet.WindowsHostReconcileInfo,
+		[]*fleet.WindowsProfileForReconcile,
+		map[uint]map[uint]struct{},
+		map[string][]*fleet.MDMWindowsProfilePayload,
+		error,
+	) {
+		// Everything is delivered in the first window; a non-empty cursor ends the drain.
+		if after != "" {
+			return nil, nil, nil, nil, nil
+		}
+		return snapshot.hosts, snapshot.profiles, nil, snapshot.current, nil
+	}
+
+	ds.GetMDMWindowsProfilesContentsFunc = func(ctx context.Context, profileUUIDs []string) (map[string]fleet.MDMWindowsProfileContents, error) {
+		out := make(map[string]fleet.MDMWindowsProfileContents, len(profileUUIDs))
+		for _, profUUID := range profileUUIDs {
+			if syncML, ok := snapshot.contents[profUUID]; ok {
+				out[profUUID] = fleet.MDMWindowsProfileContents{SyncML: syncML, Checksum: []byte(windowsReconcileTestChecksum)}
+			}
+		}
+		return out, nil
+	}
+
+	var result windowsReconcileResult
+	ds.MDMWindowsInsertCommandAndUpsertHostProfilesForHostsFunc = func(ctx context.Context, hostUUIDs []string, cmd *fleet.MDMWindowsCommand, updates []*fleet.MDMWindowsBulkUpsertHostProfilePayload) error {
+		result.commands = append(result.commands, cmd)
+		return nil
+	}
+	ds.MDMWindowsBulkInsertCommandsFunc = func(ctx context.Context, cmds []*fleet.MDMWindowsCommand) error {
+		result.commands = append(result.commands, cmds...)
+		return nil
+	}
+	ds.BulkDeleteMDMWindowsHostsConfigProfilesFunc = func(ctx context.Context, payload []*fleet.MDMWindowsProfilePayload) error {
+		result.deleteCalls++
+		result.deletedRows = append(result.deletedRows, payload...)
+		return nil
+	}
+
+	require.NoError(t, ReconcileWindowsProfiles(ctx, ds, slog.New(slog.DiscardHandler)))
+	return result
+}
+
+// installedRow builds a verified install row, the shape a profile already delivered to a host has.
+func installedRow(profileUUID, profileName, hostUUID string) *fleet.MDMWindowsProfilePayload {
+	return &fleet.MDMWindowsProfilePayload{
+		ProfileUUID:   profileUUID,
+		ProfileName:   profileName,
+		HostUUID:      hostUUID,
+		OperationType: fleet.MDMOperationTypeInstall,
+		Status:        &fleet.MDMDeliveryVerified,
+		Checksum:      []byte(windowsReconcileTestChecksum),
+	}
+}
+
+// windowsTestProfileSyncML returns a single-<Replace> profile targeting the named policy node.
+func windowsTestProfileSyncML(setting string) []byte {
+	return []byte(`<Replace><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Config/` + setting +
+		`</LocURI></Target><Data>0</Data></Item></Replace>`)
+}
+
+// TestReconcileWindowsProfilesDeletesSuppressedRemoveRows covers profiles removed from a host while every one of their LocURIs is
+// still enforced by a profile that remains applicable to that host. There is no <Delete> to send, so no command ack will ever
+// arrive to clean the host rows up; the reconciler has to delete them itself.
+func TestReconcileWindowsProfilesDeletesSuppressedRemoveRows(t *testing.T) {
+	// singleProfileReplaced: one host, one removed profile fully protected by the one profile still live on its team.
+	singleProfileReplaced := func() (windowsReconcileSnapshot, []hostProfileKey) {
+		const (
+			hostUUID       = "host-a"
+			keptProfile    = "kept-profile-uuid"
+			removedProfile = "removed-profile-uuid"
+		)
+		// Both profiles enforce the same single LocURI, so the removed one is fully protected by the kept one. The kept profile is
+		// already installed here, which is what makes this the minimal case: the tick sends nothing at all.
+		shared := windowsTestProfileSyncML("Experience/AllowCortana")
+		teamID := uint(1)
+		return windowsReconcileSnapshot{
+			hosts: []*fleet.WindowsHostReconcileInfo{{HostID: 1, UUID: hostUUID, TeamID: &teamID}},
+			profiles: []*fleet.WindowsProfileForReconcile{
+				{ProfileUUID: keptProfile, ProfileName: "Kept", TeamID: teamID, Checksum: []byte(windowsReconcileTestChecksum)},
+			},
+			current: map[string][]*fleet.MDMWindowsProfilePayload{
+				hostUUID: {
+					installedRow(keptProfile, "Kept", hostUUID),
+					installedRow(removedProfile, "Removed", hostUUID),
+				},
+			},
+			contents: map[string][]byte{keptProfile: shared, removedProfile: shared},
+		}, []hostProfileKey{{hostUUID: hostUUID, profileUUID: removedProfile}}
+	}
+
+	// wholeSetReplaced: a team's entire profile set batch-replaced by differently-named profiles carrying the same LocURIs, so
+	// every remove is suppressed on the same tick. The replacements are not installed yet, so they install on this tick too and
+	// the no-<Delete> check has real commands to scan.
+	wholeSetReplaced := func() (windowsReconcileSnapshot, []hostProfileKey) {
+		const (
+			profileCount = 25
+			hostCount    = 4
+		)
+		oldProfileUUID := func(i int) string { return fmt.Sprintf("old-profile-%d", i) }
+		newProfileUUID := func(i int) string { return fmt.Sprintf("new-profile-%d", i) }
+		hostUUIDFor := func(i int) string { return fmt.Sprintf("host-%d", i) }
+		teamID := uint(1)
+
+		snapshot := windowsReconcileSnapshot{
+			current:  make(map[string][]*fleet.MDMWindowsProfilePayload, hostCount),
+			contents: make(map[string][]byte, profileCount*2),
+		}
+		var want []hostProfileKey
+		for h := range hostCount {
+			snapshot.hosts = append(snapshot.hosts, &fleet.WindowsHostReconcileInfo{HostID: uint(h + 1), UUID: hostUUIDFor(h), TeamID: &teamID})
+			rows := make([]*fleet.MDMWindowsProfilePayload, 0, profileCount)
+			for p := range profileCount {
+				// Only the old set is installed; the new set has just been applied and is not on the hosts yet.
+				rows = append(rows, installedRow(oldProfileUUID(p), fmt.Sprintf("Old %d", p), hostUUIDFor(h)))
+				want = append(want, hostProfileKey{hostUUID: hostUUIDFor(h), profileUUID: oldProfileUUID(p)})
+			}
+			snapshot.current[hostUUIDFor(h)] = rows
+		}
+		for p := range profileCount {
+			snapshot.profiles = append(snapshot.profiles, &fleet.WindowsProfileForReconcile{
+				ProfileUUID: newProfileUUID(p), ProfileName: fmt.Sprintf("New %d", p), TeamID: teamID,
+				Checksum: []byte(windowsReconcileTestChecksum),
+			})
+			// Each old profile is replaced by a differently-named new profile targeting the identical LocURI.
+			shared := windowsTestProfileSyncML(fmt.Sprintf("Experience/Setting%d", p))
+			snapshot.contents[oldProfileUUID(p)] = shared
+			snapshot.contents[newProfileUUID(p)] = shared
+		}
+		return snapshot, want
+	}
+
+	for _, tc := range []struct {
+		name  string
+		build func() (windowsReconcileSnapshot, []hostProfileKey)
+	}{
+		{name: "single profile replaced", build: singleProfileReplaced},
+		{name: "whole profile set replaced", build: wholeSetReplaced},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			snapshot, wantPairs := tc.build()
+
+			result := runWindowsReconcileOnce(t, snapshot)
+
+			result.requireNoDeleteCommands(t, "no <Delete> may be sent while another profile still enforces the LocURI")
+			require.Len(t, result.deletedRows, len(wantPairs),
+				"every suppressed remove must delete its host row instead of leaving it behind")
+			require.Equal(t, 1, result.deleteCalls, "suppressed removes must be deleted in one batch, not one call per profile")
+			gotPairs := result.deletedPairs()
+			for _, want := range wantPairs {
+				require.Contains(t, gotPairs, want)
+			}
+		})
+	}
+}
+
+// TestReconcileWindowsProfilesDeletesRemoveRowsWithNoLocURIs covers a removed profile whose content yields no LocURIs, so the
+// command comes back nil for a reason other than LocURI protection.
+func TestReconcileWindowsProfilesDeletesRemoveRowsWithNoLocURIs(t *testing.T) {
+	const (
+		hostUUID       = "host-a"
+		keptProfile    = "kept-profile-uuid"
+		removedProfile = "removed-profile-uuid"
+	)
+	teamID := uint(1)
+
+	// The kept profile shares no LocURI with the removed one, so protection plays no part: the only reason there is no <Delete>
+	// is that the removed profile has no LocURIs to target.
+	result := runWindowsReconcileOnce(t, windowsReconcileSnapshot{
+		hosts: []*fleet.WindowsHostReconcileInfo{{HostID: 1, UUID: hostUUID, TeamID: &teamID}},
+		profiles: []*fleet.WindowsProfileForReconcile{
+			{ProfileUUID: keptProfile, ProfileName: "Kept", TeamID: teamID, Checksum: []byte(windowsReconcileTestChecksum)},
+		},
+		current: map[string][]*fleet.MDMWindowsProfilePayload{
+			hostUUID: {
+				installedRow(keptProfile, "Kept", hostUUID),
+				installedRow(removedProfile, "Removed", hostUUID),
+			},
+		},
+		contents: map[string][]byte{
+			keptProfile:    windowsTestProfileSyncML("Camera/AllowCamera"),
+			removedProfile: []byte(""), // empty (no LocURIs)
+		},
+	})
+
+	require.Len(t, result.deletedRows, 1, "a profile with no LocURIs must not stay stuck on the host")
+	require.Contains(t, result.deletedPairs(), hostProfileKey{hostUUID: hostUUID, profileUUID: removedProfile})
+}
+
+// TestReconcileWindowsProfilesDeletesRowAfterTransferToMirroredTeam covers transferring a host between two teams whose profiles
+// enforce the same LocURIs. Unlike the deleted-profile case, the outgoing profile still exists (it just no longer applies here)
+// and the protecting profile is not installed yet: it is only desired, and it installs on this same tick.
+func TestReconcileWindowsProfilesDeletesRowAfterTransferToMirroredTeam(t *testing.T) {
+	const (
+		hostUUID     = "transferred-host"
+		teamAProfile = "team-a-profile-uuid"
+		teamBProfile = "team-b-profile-uuid"
+	)
+	// Mirrored profiles: two distinct profiles, in two distinct teams, enforcing an identical LocURI set.
+	mirrored := windowsTestProfileSyncML("Experience/AllowCortana")
+	teamBID := uint(2)
+
+	// The host has already been moved to team B, still carrying the verified row for team A's profile.
+	result := runWindowsReconcileOnce(t, windowsReconcileSnapshot{
+		hosts: []*fleet.WindowsHostReconcileInfo{{HostID: 1, UUID: hostUUID, TeamID: &teamBID}},
+		profiles: []*fleet.WindowsProfileForReconcile{
+			{ProfileUUID: teamBProfile, ProfileName: "Mirrored", TeamID: teamBID, Checksum: []byte(windowsReconcileTestChecksum)},
+		},
+		current: map[string][]*fleet.MDMWindowsProfilePayload{
+			hostUUID: {installedRow(teamAProfile, "Mirrored", hostUUID)},
+		},
+		contents: map[string][]byte{teamAProfile: mirrored, teamBProfile: mirrored},
+	})
+
+	result.requireNoDeleteCommands(t, "the transfer must not open an enforcement gap on a LocURI the incoming profile still enforces")
+	// Only the outgoing team's row is dropped, keyed by (profile, host), so the profile itself and other hosts still in team A are untouched.
+	require.Len(t, result.deletedRows, 1, "the outgoing team's row must not stay listed alongside the incoming team's profile")
+	require.Contains(t, result.deletedPairs(), hostProfileKey{hostUUID: hostUUID, profileUUID: teamAProfile})
+}
+
 // TestReconcileWindowsProfilesSkipsInsertLag covers the asymmetric race
 // where a profile was just inserted on the primary but the replica
 // hasn't caught up: GetMDMWindowsProfilesContents (replica) misses the


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:**
Resolves #50907
Resolves #50698
Resolves #49002

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
See [Changes
files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host
isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Fixed stale Windows configuration profiles remaining in Host details after profile deletion, renaming, or host fleet transfers.
- Host OS settings now accurately reflect the profiles still enforcing each setting.
- Host status summaries are recalculated correctly after profile changes.
- Prevented unnecessary device delete commands when another profile still protects the same settings.
- Removed obsolete profile entries even when no device command is required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

(cherry picked from commit 244262caabd7ac2e0fe038c787aafeee907bd66c)
