### PR TITLE
For R.C. - Fleet UI: Fix undersized icons on default-size buttons (#51015)

### DIFF
--- a/.claude/rules/fleet-frontend.md
+++ b/.claude/rules/fleet-frontend.md
@@ -88,6 +88,9 @@ Use helpers from `frontend/utilities/strings/stringUtils.ts`:
 - `stripQuotes(str)`, `strToBool(str)` — input parsing
 - `enforceFleetSentenceCasing(str)` — respects Fleet stylization rules
 
+## Buttons
+Always use `<Button icon="name">` — the `<Button><Icon /></Button>` child pattern is not allowed; icon-only buttons must set `ariaLabel`.
+
 ## Software titles
 
 ### Display name

--- a/frontend/components/InfoBanner/InfoBanner.tsx
+++ b/frontend/components/InfoBanner/InfoBanner.tsx
@@ -66,14 +66,13 @@ const InfoBanner = ({
         <div className={`${baseClass}__cta`}>
           {cta}
           {closable && (
-            <Button variant="subdued" onClick={() => setHideBanner(true)}>
-              <Icon
-                name="close"
-                color="core-fleet-black"
-                size="small"
-                className={`${baseClass}__close`}
-              />
-            </Button>
+            <Button
+              variant="subdued"
+              icon="close"
+              ariaLabel="Close"
+              onClick={() => setHideBanner(true)}
+              className={`${baseClass}__close`}
+            />
           )}
         </div>
       )}

--- a/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/SelfServiceCategoriesPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/SelfServiceCategoriesPage.tsx
@@ -17,7 +17,6 @@ import Button from "components/buttons/Button";
 import CustomLink from "components/CustomLink";
 import DataError from "components/DataError";
 import EmptyState from "components/EmptyState";
-import Icon from "components/Icon";
 import MainContent from "components/MainContent";
 import PageDescription from "components/PageDescription";
 import PremiumFeatureMessage from "components/PremiumFeatureMessage";
@@ -243,17 +242,15 @@ const SelfServiceCategoriesPage = ({
                   onClick={() => setCategoryToEdit(listItem)}
                   ariaLabel={`Edit ${listItem.name}`}
                   title="Edit"
-                >
-                  <Icon name="pencil" />
-                </Button>
+                  icon="pencil"
+                />
                 <Button
                   variant="secondary"
                   onClick={() => setCategoryToDelete(listItem)}
                   ariaLabel={`Delete ${listItem.name}`}
                   title="Delete"
-                >
-                  <Icon name="trash" />
-                </Button>
+                  icon="trash"
+                />
               </div>
             )}
           </div>

--- a/frontend/pages/hosts/details/cards/HostHeader/HostHeader.tsx
+++ b/frontend/pages/hosts/details/cards/HostHeader/HostHeader.tsx
@@ -4,7 +4,6 @@ import classnames from "classnames";
 import { isAndroid, isIPadOrIPhone } from "interfaces/platform";
 
 import Button from "components/buttons/Button";
-import Icon from "components/Icon/Icon";
 import { HumanTimeDiffWithFleetLaunchCutoff } from "components/HumanTimeDiffWithDateTip";
 import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
 import { useCheckTruncatedElement } from "hooks/useCheckTruncatedElement";
@@ -59,8 +58,8 @@ const RefetchButton = ({
             disabled={isDisabled || isFetching}
             onClick={onRefetchHost}
             variant="secondary"
+            icon="refresh"
           >
-            <Icon name="refresh" color="ui-fleet-black-75" size="small" />
             {buttonText}
           </Button>
         </div>

--- a/frontend/pages/hosts/details/cards/Vitals/Vitals.tsx
+++ b/frontend/pages/hosts/details/cards/Vitals/Vitals.tsx
@@ -700,9 +700,8 @@ export const buildHostVitals = ({
           size="small"
           onClick={() => onEditCustomHostVital(vital)}
           ariaLabel={`Edit ${vital.name}`}
-        >
-          <Icon name="pencil" size="small" />
-        </Button>
+          icon="pencil"
+        />
       </span>
     ) : (
       vital.name


### PR DESCRIPTION
## Issue
Closes #34377

## Description
- Previously merged into `main` with #51015
- This is for the 4.91.0 R.C.

## Testing
- [x] QA'd all new/changed functionality manually