### PR TITLE
Fix Android load testing harness bugs

### DIFF
--- a/cmd/android-amapi-mock/handlers.go
+++ b/cmd/android-amapi-mock/handlers.go
@@ -47,25 +47,20 @@ func handleRegister(store *deviceStore) http.HandlerFunc {
 			PolicyName:           req.PolicyName,
 			PolicyVersion:        req.PolicyVersion,
 		}
-		// A device that registers again after this process lost its state (restart) reports
-		// the policy it last observed. Keep it, otherwise the device would tell Fleet its
-		// applied policy regressed to the default at version 0.
+		// A device that registers again after this process lost its state (restart) reports the
+		// policy it last observed, so it doesn't tell Fleet its applied policy regressed.
 		//
 		// A version outside the restorable range is a bug in the caller rather than recovered
 		// state, and must not be reported to Fleet: Fleet verifies profiles whose
 		// included_in_policy_version is <= the applied version, so an absurdly high version
-		// would flip every pending profile to Verified. Fall back to a fresh registration.
-		restorable := d.PolicyVersion >= 0 && d.PolicyVersion <= maxRestorablePolicyVersion
-		if !restorable {
+		// would flip every pending profile to Verified. Drop the reported policy in that case;
+		// store.register then keeps whatever policy it already has for the device, or starts a
+		// new device on the default policy.
+		if d.PolicyVersion < 0 || d.PolicyVersion > maxRestorablePolicyVersion {
 			log.Printf("Ignoring out-of-range policy version %d reported by device %s", d.PolicyVersion, d.EnterpriseSpecificID) // #nosec G706 -- load testing tool
-		}
-		if d.PolicyName == "" || !restorable {
-			d.PolicyVersion = 0
 			d.PolicyName = ""
-			if d.EnterpriseID != "" {
-				d.PolicyName = fmt.Sprintf("enterprises/%s/policies/default", d.EnterpriseID)
-			}
-		} else {
+			d.PolicyVersion = 0
+		} else if d.PolicyName != "" {
 			store.raisePolicyVersionCounter(d.PolicyVersion)
 		}
 

--- a/cmd/android-amapi-mock/handlers.go
+++ b/cmd/android-amapi-mock/handlers.go
@@ -9,25 +9,61 @@ import (
 	"sort"
 	"strconv"
 
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mdm/android"
 	"github.com/google/uuid"
 )
 
 // ---- Coordination API handlers ----
 
+// registerRequest is the coordination API's registration body. It is deliberately narrower
+// than fakeDevice: only these fields come from the agent, so pending commands and pending
+// certificates can't be injected through it.
+type registerRequest struct {
+	EnterpriseSpecificID string `json:"enterprise_specific_id"`
+	DeviceName           string `json:"device_name"`
+	EnterpriseID         string `json:"enterprise_id"`
+	// PolicyName and PolicyVersion are sent only by a device registering again after this
+	// process lost its state; they carry the policy the device last observed.
+	PolicyName    string `json:"policy_name"`
+	PolicyVersion int64  `json:"policy_version"`
+}
+
 func handleRegister(store *deviceStore) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		var d fakeDevice
-		if err := json.NewDecoder(r.Body).Decode(&d); err != nil {
+		var req registerRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			http.Error(w, "invalid json: "+err.Error(), http.StatusBadRequest)
 			return
 		}
-		if d.EnterpriseSpecificID == "" || d.DeviceName == "" {
+		if req.EnterpriseSpecificID == "" || req.DeviceName == "" {
 			http.Error(w, "enterprise_specific_id and device_name required", http.StatusBadRequest)
 			return
 		}
-		d.PolicyVersion = 0
-		if d.EnterpriseID != "" {
-			d.PolicyName = fmt.Sprintf("enterprises/%s/policies/default", d.EnterpriseID)
+		// A device Fleet deleted through AMAPI was genuinely unenrolled; letting it register
+		// again would resurrect it and re-enroll the host.
+		if store.wasDeleted(req.EnterpriseSpecificID) {
+			http.Error(w, "device was deleted", http.StatusGone)
+			return
+		}
+
+		d := fakeDevice{
+			EnterpriseSpecificID: req.EnterpriseSpecificID,
+			DeviceName:           req.DeviceName,
+			EnterpriseID:         req.EnterpriseID,
+			PolicyName:           req.PolicyName,
+			PolicyVersion:        req.PolicyVersion,
+		}
+		// A device that registers again after this process lost its state (restart) reports
+		// the policy it last observed. Keep it, otherwise the device would tell Fleet its
+		// applied policy regressed to the default at version 0.
+		if d.PolicyName == "" {
+			d.PolicyVersion = 0
+			if d.EnterpriseID != "" {
+				d.PolicyName = fmt.Sprintf("enterprises/%s/policies/default", d.EnterpriseID)
+			}
+		} else {
+			store.raisePolicyVersionCounter(d.PolicyVersion)
 		}
 		store.register(&d)
 		log.Printf("Registered fake device: %s (name: %s)", d.EnterpriseSpecificID, d.DeviceName)
@@ -40,6 +76,12 @@ func handleGetState(store *deviceStore) http.HandlerFunc {
 		esid := r.PathValue("esid")
 		d := store.getByESID(esid)
 		if d == nil {
+			// Distinguish "this process forgot the device" (the agent should register again)
+			// from "Fleet deleted the device" (the agent must stop).
+			if store.wasDeleted(esid) {
+				http.Error(w, "device was deleted", http.StatusGone)
+				return
+			}
 			http.Error(w, "device not found", http.StatusNotFound)
 			return
 		}
@@ -144,13 +186,9 @@ func handleDevicesDelete(store *deviceStore) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		name := deviceName(r)
 
-		store.mu.Lock()
-		if d, ok := store.byName[name]; ok {
-			delete(store.byName, name)
-			delete(store.byESID, d.EnterpriseSpecificID)
+		if d, ok := store.markDeleted(name); ok {
 			log.Printf("Deleted fake device: %q (ESID: %q)", name, d.EnterpriseSpecificID) // #nosec G706 -- load testing tool
 		}
-		store.mu.Unlock()
 
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprint(w, "{}")
@@ -245,7 +283,7 @@ func handleDevicesList(store *deviceStore, google *googleForwarder) http.Handler
 func handlePoliciesPatch(store *deviceStore, google *googleForwarder) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		name := policyName(r)
-		hostUUID := r.PathValue("pid")
+		hostUUID := policyID(r)
 
 		// Check if this policy is for a fake device (hostUUID == enterpriseSpecificID).
 		// If it's not a fake device and we have Google credentials, forward to real AMAPI.
@@ -256,8 +294,7 @@ func handlePoliciesPatch(store *deviceStore, google *googleForwarder) http.Handl
 			return
 		}
 
-		version := policyVersionCounter.Add(1)
-		store.setPolicyVersion(name, version)
+		version := store.nextPolicyVersion(name)
 
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
@@ -271,7 +308,9 @@ func handlePoliciesPatch(store *deviceStore, google *googleForwarder) http.Handl
 func handlePolicyAction(store *deviceStore) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		name := policyName(r)
-		pid := r.PathValue("pid")
+		// policyID strips the action suffix, without which the device lookup in
+		// extractAndStoreCertTemplateIDs never matches.
+		hostUUID := policyID(r)
 
 		// Try to extract cert template IDs from the request body
 		var bodyBytes []byte
@@ -279,11 +318,10 @@ func handlePolicyAction(store *deviceStore) http.HandlerFunc {
 			bodyBytes, _ = io.ReadAll(r.Body)
 		}
 		if len(bodyBytes) > 0 {
-			extractAndStoreCertTemplateIDs(store, pid, bodyBytes)
+			extractAndStoreCertTemplateIDs(store, hostUUID, bodyBytes)
 		}
 
-		version := policyVersionCounter.Add(1)
-		store.setPolicyVersion(name, version)
+		version := store.nextPolicyVersion(name)
 
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
@@ -361,43 +399,39 @@ func extractAndStoreCertTemplateIDs(store *deviceStore, hostUUID string, body []
 		return
 	}
 
+	// Keep looking after a change that carries no install operation: returning early here
+	// dropped certificates that were listed in a later change.
+	var certIDs []uint
 	for _, change := range req.Changes {
 		if change.Application.ManagedConfiguration == nil {
 			continue
 		}
-		var config struct {
-			CertificateTemplateIDs []struct {
-				ID        uint   `json:"id"`
-				Status    string `json:"status"`
-				Operation string `json:"operation"`
-			} `json:"certificate_templates"`
-		}
+		var config android.AgentManagedConfiguration
 		if err := json.Unmarshal(change.Application.ManagedConfiguration, &config); err != nil {
 			continue
 		}
-		if len(config.CertificateTemplateIDs) == 0 {
-			continue
-		}
 
-		var certIDs []uint
 		for _, ct := range config.CertificateTemplateIDs {
-			if ct.Operation == "install" {
+			if ct.Operation == string(fleet.MDMOperationTypeInstall) {
 				certIDs = append(certIDs, ct.ID)
 			}
 		}
-		if len(certIDs) == 0 {
-			return
-		}
-
-		// The hostUUID from the policy path is the enterpriseSpecificID for android devices.
-		d := store.getByESID(hostUUID)
-		if d != nil {
-			d.mu.Lock()
-			d.PendingCertificates = certIDs
-			d.mu.Unlock()
-		}
+	}
+	if len(certIDs) == 0 {
 		return
 	}
+
+	// The hostUUID from the policy path is the enterpriseSpecificID for android devices.
+	// A real device's policy action reaches this handler too (it is never forwarded), so
+	// this is expected in a mixed real + fake run.
+	d := store.getByESID(hostUUID)
+	if d == nil {
+		log.Printf("Policy %q is not a registered fake device; dropping %d pending certificate(s)", hostUUID, len(certIDs)) // #nosec G706 -- load testing tool
+		return
+	}
+	d.mu.Lock()
+	d.PendingCertificates = certIDs
+	d.mu.Unlock()
 }
 
 func handleCatchAll(_ *googleForwarder) http.HandlerFunc {

--- a/cmd/android-amapi-mock/handlers.go
+++ b/cmd/android-amapi-mock/handlers.go
@@ -40,13 +40,6 @@ func handleRegister(store *deviceStore) http.HandlerFunc {
 			http.Error(w, "enterprise_specific_id and device_name required", http.StatusBadRequest)
 			return
 		}
-		// A device Fleet deleted through AMAPI was genuinely unenrolled; letting it register
-		// again would resurrect it and re-enroll the host.
-		if store.wasDeleted(req.EnterpriseSpecificID) {
-			http.Error(w, "device was deleted", http.StatusGone)
-			return
-		}
-
 		d := fakeDevice{
 			EnterpriseSpecificID: req.EnterpriseSpecificID,
 			DeviceName:           req.DeviceName,
@@ -57,15 +50,31 @@ func handleRegister(store *deviceStore) http.HandlerFunc {
 		// A device that registers again after this process lost its state (restart) reports
 		// the policy it last observed. Keep it, otherwise the device would tell Fleet its
 		// applied policy regressed to the default at version 0.
-		if d.PolicyName == "" {
+		//
+		// A version outside the restorable range is a bug in the caller rather than recovered
+		// state, and must not be reported to Fleet: Fleet verifies profiles whose
+		// included_in_policy_version is <= the applied version, so an absurdly high version
+		// would flip every pending profile to Verified. Fall back to a fresh registration.
+		restorable := d.PolicyVersion >= 0 && d.PolicyVersion <= maxRestorablePolicyVersion
+		if !restorable {
+			log.Printf("Ignoring out-of-range policy version %d reported by device %s", d.PolicyVersion, d.EnterpriseSpecificID) // #nosec G706 -- load testing tool
+		}
+		if d.PolicyName == "" || !restorable {
 			d.PolicyVersion = 0
+			d.PolicyName = ""
 			if d.EnterpriseID != "" {
 				d.PolicyName = fmt.Sprintf("enterprises/%s/policies/default", d.EnterpriseID)
 			}
 		} else {
 			store.raisePolicyVersionCounter(d.PolicyVersion)
 		}
-		store.register(&d)
+
+		// A device Fleet deleted through AMAPI was genuinely unenrolled; letting it register
+		// again would resurrect it and re-enroll the host.
+		if !store.register(&d) {
+			http.Error(w, "device was deleted", http.StatusGone)
+			return
+		}
 		log.Printf("Registered fake device: %s (name: %s)", d.EnterpriseSpecificID, d.DeviceName)
 		w.WriteHeader(http.StatusOK)
 	}
@@ -89,10 +98,16 @@ func handleGetState(store *deviceStore) http.HandlerFunc {
 		d.mu.Lock()
 		policyVersion := d.PolicyVersion
 		if d.PolicyName != "" {
-			if v := store.getPolicyVersion(d.PolicyName); v > 0 {
+			// Report the higher of the version this process issued for the policy and the
+			// version the device already observed (which is higher after a restart, since the
+			// version counter starts over). Reporting a lower version would tell Fleet the
+			// device's applied policy went backwards, and Fleet only verifies profiles whose
+			// included_in_policy_version is <= the applied version — so profiles delivered
+			// before the restart would be stuck Pending.
+			if v := store.getPolicyVersion(d.PolicyName); v > policyVersion {
 				policyVersion = v
-				d.PolicyVersion = v
 			}
+			d.PolicyVersion = policyVersion
 		}
 		state := struct {
 			PolicyVersion       int64    `json:"policy_version"`
@@ -164,11 +179,14 @@ func handleDevicesPatch(store *deviceStore) http.HandlerFunc {
 		var appliedVersion int64
 		if d != nil {
 			d.mu.Lock()
-			if reqBody.PolicyName != "" {
+			if reqBody.PolicyName != "" && reqBody.PolicyName != d.PolicyName {
+				// The version the device holds belongs to the policy it is moving off of.
 				d.PolicyName = reqBody.PolicyName
+				d.PolicyVersion = 0
 			}
 			if d.PolicyName != "" {
-				appliedVersion = store.getPolicyVersion(d.PolicyName)
+				// As in handleGetState, never lower the version the device already observed.
+				appliedVersion = max(d.PolicyVersion, store.getPolicyVersion(d.PolicyName))
 				d.PolicyVersion = appliedVersion
 			}
 			d.mu.Unlock()

--- a/cmd/android-amapi-mock/handlers_test.go
+++ b/cmd/android-amapi-mock/handlers_test.go
@@ -1,0 +1,412 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mdm/android"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/androidmanagement/v1"
+)
+
+const (
+	testESID         = "35B8F9A0-4C2E-4B1D-9F3A-7E6D5C4B3A21"
+	testEnterpriseID = "LC01"
+	testDeviceName   = "enterprises/LC01/devices/fakedevice"
+)
+
+func testPolicyName(esid string) string {
+	return fmt.Sprintf("enterprises/%s/policies/%s", testEnterpriseID, esid)
+}
+
+// newTestMux builds the real route table with latency and simulated errors disabled.
+func newTestMux(t *testing.T) (*http.ServeMux, *deviceStore) {
+	t.Helper()
+	store := newDeviceStore()
+	return newMux(store, nil, 0, 0), store
+}
+
+// registerTestDevice registers a fake device through the coordination API the way
+// osquery-perf's Android agents do, and asserts the expected status.
+func registerTestDevice(t *testing.T, mux *http.ServeMux, req registerRequest, wantStatus int) {
+	t.Helper()
+	payload, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest("POST", "/mock/devices/register", bytes.NewReader(payload)))
+	require.Equal(t, wantStatus, rr.Code, "register response: %s", rr.Body.String())
+}
+
+func defaultRegisterRequest() registerRequest {
+	return registerRequest{
+		EnterpriseSpecificID: testESID,
+		DeviceName:           testDeviceName,
+		EnterpriseID:         testEnterpriseID,
+	}
+}
+
+// certChangesBody builds a modifyPolicyApplications body from the same types Fleet uses to
+// send one, so a change to either wire format fails to compile here.
+func certChangesBody(t *testing.T, configs ...android.AgentManagedConfiguration) []byte {
+	t.Helper()
+	req := androidmanagement.ModifyPolicyApplicationsRequest{}
+	for _, cfg := range configs {
+		managedConfig, err := json.Marshal(cfg)
+		require.NoError(t, err)
+		req.Changes = append(req.Changes, &androidmanagement.ApplicationPolicyChange{
+			Application: &androidmanagement.ApplicationPolicy{
+				PackageName:          "com.fleetdm.agent",
+				ManagedConfiguration: managedConfig,
+			},
+		})
+	}
+	body, err := json.Marshal(req)
+	require.NoError(t, err)
+	return body
+}
+
+func certConfig(templates ...android.AgentCertificateTemplate) android.AgentManagedConfiguration {
+	return android.AgentManagedConfiguration{
+		ServerURL:              "https://fleet.example.com",
+		HostUUID:               testESID,
+		EnrollSecret:           "secret",
+		CertificateTemplateIDs: templates,
+	}
+}
+
+func certTemplate(id uint, operation fleet.MDMOperationType) android.AgentCertificateTemplate {
+	return android.AgentCertificateTemplate{ID: id, Status: "pending", Operation: string(operation)}
+}
+
+func postPolicyAction(t *testing.T, mux *http.ServeMux, policyPath string, body []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest("POST", policyPath, bytes.NewReader(body)))
+	return rr
+}
+
+// TestHandlePolicyActionStoresPendingCertificates covers the load-testing bug where the
+// policy action suffix was left on the path value used to look up the device, so pending
+// certificates were dropped and cert-backed profiles stayed Pending forever.
+func TestHandlePolicyActionStoresPendingCertificates(t *testing.T) {
+	// Any AMAPI custom method must resolve to the same policy, including one the mock has
+	// never heard of.
+	for _, action := range []string{"modifyPolicyApplications", "removePolicyApplications", "someFutureAction"} {
+		t.Run(action, func(t *testing.T) {
+			mux, store := newTestMux(t)
+			registerTestDevice(t, mux, defaultRegisterRequest(), http.StatusOK)
+
+			body := certChangesBody(t, certConfig(certTemplate(7, fleet.MDMOperationTypeInstall)))
+			rr := postPolicyAction(t, mux, fmt.Sprintf("/v1/enterprises/%s/policies/%s:%s", testEnterpriseID, testESID, action), body)
+			require.Equal(t, http.StatusOK, rr.Code, "policy action response: %s", rr.Body.String())
+
+			d := store.getByESID(testESID)
+			require.NotNil(t, d, "device must be findable by its bare enterpriseSpecificID")
+			assert.Equal(t, []uint{7}, d.PendingCertificates)
+
+			// The policy version must be keyed to the suffix-stripped policy name, otherwise
+			// the version the device reports never matches what Fleet recorded.
+			assert.Positive(t, store.getPolicyVersion(testPolicyName(testESID)))
+			assert.Zero(t, store.getPolicyVersion(testPolicyName(testESID+":"+action)))
+		})
+	}
+}
+
+func TestExtractAndStoreCertTemplateIDs(t *testing.T) {
+	testCases := []struct {
+		name     string
+		configs  []android.AgentManagedConfiguration
+		expected []uint
+	}{
+		{
+			name: "install ops in a later change are not dropped",
+			configs: []android.AgentManagedConfiguration{
+				certConfig(),
+				certConfig(certTemplate(11, fleet.MDMOperationTypeInstall)),
+			},
+			expected: []uint{11},
+		},
+		{
+			name: "a change with no install op does not stop later changes",
+			configs: []android.AgentManagedConfiguration{
+				certConfig(certTemplate(3, fleet.MDMOperationTypeRemove)),
+				certConfig(certTemplate(4, fleet.MDMOperationTypeInstall)),
+			},
+			expected: []uint{4},
+		},
+		{
+			name: "several install ops in one change are all collected",
+			configs: []android.AgentManagedConfiguration{
+				certConfig(
+					certTemplate(1, fleet.MDMOperationTypeInstall),
+					certTemplate(2, fleet.MDMOperationTypeInstall),
+				),
+			},
+			expected: []uint{1, 2},
+		},
+		{
+			name: "non-install ops are ignored",
+			configs: []android.AgentManagedConfiguration{
+				certConfig(certTemplate(6, fleet.MDMOperationTypeRemove)),
+			},
+			expected: nil,
+		},
+		{
+			name:     "no managed configuration at all",
+			configs:  nil,
+			expected: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mux, store := newTestMux(t)
+			registerTestDevice(t, mux, defaultRegisterRequest(), http.StatusOK)
+
+			rr := postPolicyAction(t, mux,
+				fmt.Sprintf("/v1/enterprises/%s/policies/%s:modifyPolicyApplications", testEnterpriseID, testESID),
+				certChangesBody(t, tc.configs...))
+			require.Equal(t, http.StatusOK, rr.Code)
+
+			d := store.getByESID(testESID)
+			require.NotNil(t, d)
+			assert.Equal(t, tc.expected, d.PendingCertificates)
+		})
+	}
+}
+
+// TestGetStateReportsPendingCertificates checks the full path a fake agent takes: a policy
+// action delivers cert templates, and the next state poll hands them to the device.
+func TestGetStateReportsPendingCertificates(t *testing.T) {
+	mux, _ := newTestMux(t)
+	registerTestDevice(t, mux, defaultRegisterRequest(), http.StatusOK)
+
+	body := certChangesBody(t, certConfig(certTemplate(42, fleet.MDMOperationTypeInstall)))
+	rr := postPolicyAction(t, mux,
+		fmt.Sprintf("/v1/enterprises/%s/policies/%s:modifyPolicyApplications", testEnterpriseID, testESID), body)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	state := getTestState(t, mux, testESID, http.StatusOK)
+	assert.Equal(t, []uint{42}, state.PendingCertificates)
+}
+
+type testDeviceState struct {
+	PolicyVersion       int64    `json:"policy_version"`
+	PolicyName          string   `json:"policy_name"`
+	PendingCommands     []string `json:"pending_commands"`
+	PendingCertificates []uint   `json:"pending_certificates"`
+}
+
+func getTestState(t *testing.T, mux *http.ServeMux, esid string, wantStatus int) testDeviceState {
+	t.Helper()
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest("GET", "/mock/devices/"+esid+"/state", nil))
+	require.Equal(t, wantStatus, rr.Code, "state response: %s", rr.Body.String())
+
+	var state testDeviceState
+	if wantStatus == http.StatusOK {
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &state))
+	}
+	return state
+}
+
+// TestPoliciesPatchIdentifiesFakeDeviceByPolicyID guards the fake-vs-real routing decision,
+// which also reads the policy ID out of the path.
+func TestPoliciesPatchIdentifiesFakeDeviceByPolicyID(t *testing.T) {
+	mux, store := newTestMux(t)
+	registerTestDevice(t, mux, defaultRegisterRequest(), http.StatusOK)
+
+	rr := patchPolicy(t, mux, testESID)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var resp struct {
+		Name    string `json:"name"`
+		Version string `json:"version"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.Equal(t, testPolicyName(testESID), resp.Name)
+	assert.Positive(t, store.getPolicyVersion(testPolicyName(testESID)))
+}
+
+func patchPolicy(t *testing.T, mux *http.ServeMux, policyID string) *httptest.ResponseRecorder {
+	t.Helper()
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest("PATCH",
+		fmt.Sprintf("/v1/enterprises/%s/policies/%s", testEnterpriseID, policyID),
+		bytes.NewReader([]byte(`{}`))))
+	return rr
+}
+
+// TestRegisterRestoresPolicyState covers recovery after this process is restarted: the agent
+// registers again reporting the policy state it last observed, and the mock must keep it
+// instead of resetting the device to the default policy at version 0. Reporting a regressed
+// policy would make Fleet see already-applied profiles as un-applied.
+func TestRegisterRestoresPolicyState(t *testing.T) {
+	t.Run("reported policy state is kept", func(t *testing.T) {
+		mux, store := newTestMux(t)
+		req := defaultRegisterRequest()
+		req.PolicyName = testPolicyName(testESID)
+		req.PolicyVersion = 57
+		registerTestDevice(t, mux, req, http.StatusOK)
+
+		d := store.getByESID(testESID)
+		require.NotNil(t, d)
+		assert.Equal(t, testPolicyName(testESID), d.PolicyName)
+		assert.Equal(t, int64(57), d.PolicyVersion)
+
+		// The device reports the version it last observed, so profiles Fleet already
+		// delivered are not seen as un-applied.
+		state := getTestState(t, mux, testESID, http.StatusOK)
+		assert.Equal(t, int64(57), state.PolicyVersion)
+		assert.Equal(t, testPolicyName(testESID), state.PolicyName)
+	})
+
+	// A restored version must NOT be recorded as the policy's current version: Fleet verifies
+	// profiles whose included_in_policy_version is <= the applied version, so a device
+	// claiming a version this process never issued would flip pending profiles to Verified
+	// without the policy ever being applied — hiding stuck-in-Pending bugs.
+	t.Run("a restored version is not recorded as the policy version", func(t *testing.T) {
+		mux, store := newTestMux(t)
+		req := defaultRegisterRequest()
+		req.PolicyName = testPolicyName(testESID)
+		req.PolicyVersion = 1000
+		registerTestDevice(t, mux, req, http.StatusOK)
+
+		assert.Zero(t, store.getPolicyVersion(testPolicyName(testESID)),
+			"no version was issued for this policy by this process")
+	})
+
+	// Versions issued after a restore must still be above what the device already reported,
+	// so the version the device reports never goes backwards.
+	t.Run("later versions stay above the restored version", func(t *testing.T) {
+		mux, store := newTestMux(t)
+		req := defaultRegisterRequest()
+		req.PolicyName = testPolicyName(testESID)
+		req.PolicyVersion = 57
+		registerTestDevice(t, mux, req, http.StatusOK)
+
+		require.Equal(t, http.StatusOK, patchPolicy(t, mux, testESID).Code)
+		assert.Greater(t, store.getPolicyVersion(testPolicyName(testESID)), int64(57))
+	})
+
+	t.Run("a first registration gets the default policy", func(t *testing.T) {
+		mux, store := newTestMux(t)
+		registerTestDevice(t, mux, defaultRegisterRequest(), http.StatusOK)
+
+		d := store.getByESID(testESID)
+		require.NotNil(t, d)
+		assert.Equal(t, "enterprises/LC01/policies/default", d.PolicyName)
+		assert.Zero(t, d.PolicyVersion)
+	})
+
+	// A bogus version must not push the counter near overflow: the next issued version would
+	// wrap negative and every version after it would be negative and decreasing.
+	t.Run("an absurd version cannot overflow the counter", func(t *testing.T) {
+		mux, store := newTestMux(t)
+		req := defaultRegisterRequest()
+		req.PolicyName = testPolicyName(testESID)
+		req.PolicyVersion = 1<<62 + 1
+		registerTestDevice(t, mux, req, http.StatusOK)
+
+		require.Equal(t, http.StatusOK, patchPolicy(t, mux, testESID).Code)
+		assert.Positive(t, store.getPolicyVersion(testPolicyName(testESID)),
+			"issued versions must stay positive")
+		assert.Less(t, store.getPolicyVersion(testPolicyName(testESID)), int64(maxRestorablePolicyVersion)+1)
+	})
+
+	// Re-registration must not discard state other handlers already attached to the device.
+	t.Run("re-registration keeps pending state", func(t *testing.T) {
+		mux, store := newTestMux(t)
+		registerTestDevice(t, mux, defaultRegisterRequest(), http.StatusOK)
+
+		body := certChangesBody(t, certConfig(certTemplate(9, fleet.MDMOperationTypeInstall)))
+		require.Equal(t, http.StatusOK, postPolicyAction(t, mux,
+			fmt.Sprintf("/v1/enterprises/%s/policies/%s:modifyPolicyApplications", testEnterpriseID, testESID), body).Code)
+
+		req := defaultRegisterRequest()
+		req.PolicyName = testPolicyName(testESID)
+		req.PolicyVersion = 5
+		registerTestDevice(t, mux, req, http.StatusOK)
+
+		d := store.getByESID(testESID)
+		require.NotNil(t, d)
+		assert.Equal(t, []uint{9}, d.PendingCertificates, "pending certificates must survive")
+		assert.Equal(t, testPolicyName(testESID), d.PolicyName)
+		assert.Len(t, store.allDeviceNames(), 1, "the device must not be duplicated")
+	})
+}
+
+// TestRegisterRejectsInjectedPendingState pins that the registration body can only carry the
+// fields the agent sends: pending commands would otherwise be acked to Fleet as if issued.
+func TestRegisterRejectsInjectedPendingState(t *testing.T) {
+	mux, store := newTestMux(t)
+
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest("POST", "/mock/devices/register", bytes.NewReader([]byte(`{
+		"enterprise_specific_id": "`+testESID+`",
+		"device_name": "`+testDeviceName+`",
+		"enterprise_id": "`+testEnterpriseID+`",
+		"pending_commands": ["enterprises/LC01/devices/fakedevice/operations/injected"],
+		"pending_certificates": [99]
+	}`))))
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	d := store.getByESID(testESID)
+	require.NotNil(t, d)
+	assert.Empty(t, d.PendingCommands)
+	assert.Empty(t, d.PendingCertificates)
+}
+
+// TestDeletedDeviceStaysDeleted covers the resurrection bug: Fleet unenrolls a non-BYO
+// Android host by deleting the device through AMAPI, so a device that registers again after
+// being deleted would re-appear in the device list the reconciler reads and re-enroll the
+// host, flip-flopping between mdm_unenrolled and mdm_enrolled.
+func TestDeletedDeviceStaysDeleted(t *testing.T) {
+	mux, store := newTestMux(t)
+	registerTestDevice(t, mux, defaultRegisterRequest(), http.StatusOK)
+
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest("DELETE", "/v1/"+testDeviceName, nil))
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Empty(t, store.allDeviceNames())
+
+	// The agent is told the device is gone for good, not merely forgotten.
+	getTestState(t, mux, testESID, http.StatusGone)
+
+	// Registering again must not bring it back.
+	registerTestDevice(t, mux, defaultRegisterRequest(), http.StatusGone)
+	assert.Nil(t, store.getByESID(testESID))
+	assert.Empty(t, store.allDeviceNames(), "a deleted device must stay out of the AMAPI device list")
+}
+
+// TestGetStateUnknownDeviceReturns404 pins the status code the agent relies on to tell that
+// this process lost its registration and that it should register again.
+func TestGetStateUnknownDeviceReturns404(t *testing.T) {
+	mux, _ := newTestMux(t)
+	getTestState(t, mux, testESID, http.StatusNotFound)
+}
+
+// TestDevicesListIncludesFakeDevices pins what the reconciler reads: a registered device must
+// be listed, since Fleet marks any enrolled device missing from this list as unenrolled.
+func TestDevicesListIncludesFakeDevices(t *testing.T) {
+	mux, _ := newTestMux(t)
+	registerTestDevice(t, mux, defaultRegisterRequest(), http.StatusOK)
+
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest("GET",
+		"/v1/enterprises/"+testEnterpriseID+"/devices?pageSize=100&fields=nextPageToken,devices/name", nil))
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var resp androidmanagement.ListDevicesResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	require.Len(t, resp.Devices, 1)
+	assert.Equal(t, testDeviceName, resp.Devices[0].Name)
+	assert.Empty(t, resp.NextPageToken)
+}

--- a/cmd/android-amapi-mock/handlers_test.go
+++ b/cmd/android-amapi-mock/handlers_test.go
@@ -355,6 +355,45 @@ func TestRegisterRestoresPolicyState(t *testing.T) {
 		})
 	}
 
+	// A registration that reports no policy must not clobber the policy this process already
+	// has for the device: reporting the default policy at version 0 is exactly the regression
+	// that strands every already-delivered profile.
+	t.Run("a registration without a policy keeps the known policy", func(t *testing.T) {
+		mux, store := newTestMux(t)
+		req := defaultRegisterRequest()
+		req.PolicyName = testPolicyName(testESID)
+		req.PolicyVersion = 57
+		registerTestDevice(t, mux, req, http.StatusOK)
+
+		// Same device registers again, reporting nothing (e.g. a freshly started agent).
+		registerTestDevice(t, mux, defaultRegisterRequest(), http.StatusOK)
+
+		d := store.getByESID(testESID)
+		require.NotNil(t, d)
+		assert.Equal(t, testPolicyName(testESID), d.PolicyName)
+		assert.Equal(t, int64(57), d.PolicyVersion)
+		assert.Equal(t, int64(57), getTestState(t, mux, testESID, http.StatusOK).PolicyVersion)
+	})
+
+	// Same protection when the reported version is rejected as out of range.
+	t.Run("an out-of-range version keeps the known policy", func(t *testing.T) {
+		mux, store := newTestMux(t)
+		req := defaultRegisterRequest()
+		req.PolicyName = testPolicyName(testESID)
+		req.PolicyVersion = 57
+		registerTestDevice(t, mux, req, http.StatusOK)
+
+		bogus := defaultRegisterRequest()
+		bogus.PolicyName = testPolicyName(testESID)
+		bogus.PolicyVersion = maxRestorablePolicyVersion + 1
+		registerTestDevice(t, mux, bogus, http.StatusOK)
+
+		d := store.getByESID(testESID)
+		require.NotNil(t, d)
+		assert.Equal(t, testPolicyName(testESID), d.PolicyName)
+		assert.Equal(t, int64(57), d.PolicyVersion)
+	})
+
 	// Re-registration must not discard state other handlers already attached to the device.
 	t.Run("re-registration keeps pending state", func(t *testing.T) {
 		mux, store := newTestMux(t)

--- a/cmd/android-amapi-mock/handlers_test.go
+++ b/cmd/android-amapi-mock/handlers_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -296,6 +297,25 @@ func TestRegisterRestoresPolicyState(t *testing.T) {
 		assert.Greater(t, store.getPolicyVersion(testPolicyName(testESID)), int64(57))
 	})
 
+	// A policy patched before the device registers again leaves this process holding a low
+	// version for that policy. Reporting it would tell Fleet the device's applied version
+	// went backwards, and Fleet only verifies profiles whose included_in_policy_version is
+	// <= the applied version — so every profile delivered before the restart would be stuck
+	// Pending until some later patch happened to exceed the pre-restart version.
+	t.Run("a version issued before the restore does not regress the reported version", func(t *testing.T) {
+		mux, _ := newTestMux(t)
+		require.Equal(t, http.StatusOK, patchPolicy(t, mux, testESID).Code)
+
+		req := defaultRegisterRequest()
+		req.PolicyName = testPolicyName(testESID)
+		req.PolicyVersion = 57
+		registerTestDevice(t, mux, req, http.StatusOK)
+
+		state := getTestState(t, mux, testESID, http.StatusOK)
+		assert.GreaterOrEqual(t, state.PolicyVersion, int64(57),
+			"the reported version must never go backwards")
+	})
+
 	t.Run("a first registration gets the default policy", func(t *testing.T) {
 		mux, store := newTestMux(t)
 		registerTestDevice(t, mux, defaultRegisterRequest(), http.StatusOK)
@@ -306,20 +326,34 @@ func TestRegisterRestoresPolicyState(t *testing.T) {
 		assert.Zero(t, d.PolicyVersion)
 	})
 
-	// A bogus version must not push the counter near overflow: the next issued version would
-	// wrap negative and every version after it would be negative and decreasing.
-	t.Run("an absurd version cannot overflow the counter", func(t *testing.T) {
-		mux, store := newTestMux(t)
-		req := defaultRegisterRequest()
-		req.PolicyName = testPolicyName(testESID)
-		req.PolicyVersion = 1<<62 + 1
-		registerTestDevice(t, mux, req, http.StatusOK)
+	// An out-of-range version must not reach Fleet at all. Fleet verifies profiles whose
+	// included_in_policy_version is <= the applied version, so an absurdly high version would
+	// flip every pending profile to Verified; a negative one would verify nothing ever.
+	for _, version := range []int64{1<<62 + 1, maxRestorablePolicyVersion + 1, -1} {
+		t.Run(fmt.Sprintf("an out-of-range version %d is ignored", version), func(t *testing.T) {
+			mux, store := newTestMux(t)
+			req := defaultRegisterRequest()
+			req.PolicyName = testPolicyName(testESID)
+			req.PolicyVersion = version
+			registerTestDevice(t, mux, req, http.StatusOK)
 
-		require.Equal(t, http.StatusOK, patchPolicy(t, mux, testESID).Code)
-		assert.Positive(t, store.getPolicyVersion(testPolicyName(testESID)),
-			"issued versions must stay positive")
-		assert.Less(t, store.getPolicyVersion(testPolicyName(testESID)), int64(maxRestorablePolicyVersion)+1)
-	})
+			d := store.getByESID(testESID)
+			require.NotNil(t, d)
+			assert.Zero(t, d.PolicyVersion, "the bogus version must not be kept on the device")
+			assert.Equal(t, "enterprises/LC01/policies/default", d.PolicyName,
+				"the device falls back to a fresh registration")
+
+			// And it must not be reported to Fleet either.
+			state := getTestState(t, mux, testESID, http.StatusOK)
+			assert.Zero(t, state.PolicyVersion)
+
+			// The version counter must still issue sane, positive versions.
+			require.Equal(t, http.StatusOK, patchPolicy(t, mux, testESID).Code)
+			issued := store.getPolicyVersion(testPolicyName(testESID))
+			assert.Positive(t, issued, "issued versions must stay positive")
+			assert.LessOrEqual(t, issued, int64(maxRestorablePolicyVersion))
+		})
+	}
 
 	// Re-registration must not discard state other handlers already attached to the device.
 	t.Run("re-registration keeps pending state", func(t *testing.T) {
@@ -384,6 +418,116 @@ func TestDeletedDeviceStaysDeleted(t *testing.T) {
 	registerTestDevice(t, mux, defaultRegisterRequest(), http.StatusGone)
 	assert.Nil(t, store.getByESID(testESID))
 	assert.Empty(t, store.allDeviceNames(), "a deleted device must stay out of the AMAPI device list")
+}
+
+// TestDeleteOfUnknownDeviceStaysDeleted covers the delete that lands while this process has
+// forgotten the device — i.e. exactly the restart window this change is about. The ESID isn't
+// known then, so the deletion is recorded by resource name and the agent's next registration
+// must still be refused. Otherwise the device resurrects, and if Fleet also deleted the host
+// the next STATUS_REPORT re-creates it as a ghost.
+func TestDeleteOfUnknownDeviceStaysDeleted(t *testing.T) {
+	mux, store := newTestMux(t)
+
+	// No device is registered: this process restarted and the agent has not come back yet.
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest("DELETE", "/v1/"+testDeviceName, nil))
+	require.Equal(t, http.StatusNotFound, rr.Code, "an unknown device is reported as absent")
+
+	// The agent polls (404, since the ESID was never seen), then tries to register.
+	getTestState(t, mux, testESID, http.StatusNotFound)
+	registerTestDevice(t, mux, defaultRegisterRequest(), http.StatusGone)
+
+	assert.Nil(t, store.getByESID(testESID))
+	assert.Empty(t, store.allDeviceNames(), "a deleted device must stay out of the AMAPI device list")
+}
+
+// TestDevicesPatchDoesNotLowerReportedVersion covers the device patch after a restart: the
+// policy has no version in this process yet, and zeroing the device's restored version would
+// make it report applied version 0, verifying nothing.
+func TestDevicesPatchDoesNotLowerReportedVersion(t *testing.T) {
+	mux, store := newTestMux(t)
+	req := defaultRegisterRequest()
+	req.PolicyName = testPolicyName(testESID)
+	req.PolicyVersion = 57
+	registerTestDevice(t, mux, req, http.StatusOK)
+
+	body := fmt.Sprintf(`{"policyName":%q,"state":"ACTIVE"}`, testPolicyName(testESID))
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest("PATCH", "/v1/"+testDeviceName, bytes.NewReader([]byte(body))))
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var resp struct {
+		AppliedPolicyVersion string `json:"appliedPolicyVersion"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.Equal(t, "57", resp.AppliedPolicyVersion)
+
+	d := store.getByESID(testESID)
+	require.NotNil(t, d)
+	assert.Equal(t, int64(57), d.PolicyVersion)
+	assert.Equal(t, int64(57), getTestState(t, mux, testESID, http.StatusOK).PolicyVersion)
+}
+
+// TestDevicesPatchToNewPolicyUsesNewPolicyVersion pins the other direction: moving a device to
+// a different policy must not carry the old policy's version over, which would over-verify.
+func TestDevicesPatchToNewPolicyUsesNewPolicyVersion(t *testing.T) {
+	mux, store := newTestMux(t)
+	req := defaultRegisterRequest()
+	req.PolicyName = testPolicyName("old-policy")
+	req.PolicyVersion = 57
+	registerTestDevice(t, mux, req, http.StatusOK)
+
+	// Fleet patches the new policy first, then points the device at it.
+	require.Equal(t, http.StatusOK, patchPolicy(t, mux, testESID).Code)
+	issued := store.getPolicyVersion(testPolicyName(testESID))
+	require.Positive(t, issued)
+
+	body := fmt.Sprintf(`{"policyName":%q,"state":"ACTIVE"}`, testPolicyName(testESID))
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, httptest.NewRequest("PATCH", "/v1/"+testDeviceName, bytes.NewReader([]byte(body))))
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	d := store.getByESID(testESID)
+	require.NotNil(t, d)
+	assert.Equal(t, testPolicyName(testESID), d.PolicyName)
+	assert.Equal(t, issued, d.PolicyVersion, "the old policy's version must not carry over")
+}
+
+// TestStoreConcurrentAccess exercises the store from several goroutines so the race detector
+// has something to look at: every other test drives it from a single goroutine.
+func TestStoreConcurrentAccess(t *testing.T) {
+	mux, store := newTestMux(t)
+	registerTestDevice(t, mux, defaultRegisterRequest(), http.StatusOK)
+
+	var wg sync.WaitGroup
+	for i := range 8 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			switch i % 4 {
+			case 0:
+				payload, err := json.Marshal(defaultRegisterRequest())
+				require.NoError(t, err)
+				rr := httptest.NewRecorder()
+				mux.ServeHTTP(rr, httptest.NewRequest("POST", "/mock/devices/register", bytes.NewReader(payload)))
+			case 1:
+				rr := httptest.NewRecorder()
+				mux.ServeHTTP(rr, httptest.NewRequest("GET", "/mock/devices/"+testESID+"/state", nil))
+			case 2:
+				patchPolicy(t, mux, testESID)
+			case 3:
+				rr := httptest.NewRecorder()
+				mux.ServeHTTP(rr, httptest.NewRequest("POST",
+					fmt.Sprintf("/v1/enterprises/%s/policies/%s:modifyPolicyApplications", testEnterpriseID, testESID),
+					bytes.NewReader(certChangesBody(t, certConfig(certTemplate(1, fleet.MDMOperationTypeInstall))))))
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// The store is still coherent: the device is present exactly once.
+	assert.Len(t, store.allDeviceNames(), 1)
+	assert.NotNil(t, store.getByESID(testESID))
 }
 
 // TestGetStateUnknownDeviceReturns404 pins the status code the agent relies on to tell that

--- a/cmd/android-amapi-mock/handlers_test.go
+++ b/cmd/android-amapi-mock/handlers_test.go
@@ -499,28 +499,35 @@ func TestStoreConcurrentAccess(t *testing.T) {
 	mux, store := newTestMux(t)
 	registerTestDevice(t, mux, defaultRegisterRequest(), http.StatusOK)
 
+	// Everything the goroutines need is built up front: assertions may only run on the test's
+	// own goroutine, so the workers just drive requests.
+	registerPayload, err := json.Marshal(defaultRegisterRequest())
+	require.NoError(t, err)
+	certBody := certChangesBody(t, certConfig(certTemplate(1, fleet.MDMOperationTypeInstall)))
+	policyActionPath := fmt.Sprintf("/v1/enterprises/%s/policies/%s:modifyPolicyApplications", testEnterpriseID, testESID)
+	policyPatchPath := fmt.Sprintf("/v1/enterprises/%s/policies/%s", testEnterpriseID, testESID)
+
+	newRequest := []func() *http.Request{
+		func() *http.Request {
+			return httptest.NewRequest("POST", "/mock/devices/register", bytes.NewReader(registerPayload))
+		},
+		func() *http.Request {
+			return httptest.NewRequest("GET", "/mock/devices/"+testESID+"/state", nil)
+		},
+		func() *http.Request {
+			return httptest.NewRequest("PATCH", policyPatchPath, bytes.NewReader([]byte(`{}`)))
+		},
+		func() *http.Request {
+			return httptest.NewRequest("POST", policyActionPath, bytes.NewReader(certBody))
+		},
+	}
+
 	var wg sync.WaitGroup
 	for i := range 8 {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			switch i % 4 {
-			case 0:
-				payload, err := json.Marshal(defaultRegisterRequest())
-				require.NoError(t, err)
-				rr := httptest.NewRecorder()
-				mux.ServeHTTP(rr, httptest.NewRequest("POST", "/mock/devices/register", bytes.NewReader(payload)))
-			case 1:
-				rr := httptest.NewRecorder()
-				mux.ServeHTTP(rr, httptest.NewRequest("GET", "/mock/devices/"+testESID+"/state", nil))
-			case 2:
-				patchPolicy(t, mux, testESID)
-			case 3:
-				rr := httptest.NewRecorder()
-				mux.ServeHTTP(rr, httptest.NewRequest("POST",
-					fmt.Sprintf("/v1/enterprises/%s/policies/%s:modifyPolicyApplications", testEnterpriseID, testESID),
-					bytes.NewReader(certChangesBody(t, certConfig(certTemplate(1, fleet.MDMOperationTypeInstall))))))
-			}
+			mux.ServeHTTP(httptest.NewRecorder(), newRequest[i%len(newRequest)]())
 		}(i)
 	}
 	wg.Wait()

--- a/cmd/android-amapi-mock/main.go
+++ b/cmd/android-amapi-mock/main.go
@@ -292,10 +292,8 @@ func newMux(store *deviceStore, google *googleForwarder, latencyMean time.Durati
 // would silently reintroduce the resource-lookup bug the moment AMAPI grows another one.
 // Resource IDs themselves are UUIDs or numeric IDs and never contain a colon.
 func trimAction(resourceID string) string {
-	if i := strings.IndexByte(resourceID, ':'); i >= 0 {
-		return resourceID[:i]
-	}
-	return resourceID
+	id, _, _ := strings.Cut(resourceID, ":")
+	return id
 }
 
 // deviceName builds the AMAPI resource name from path values.

--- a/cmd/android-amapi-mock/main.go
+++ b/cmd/android-amapi-mock/main.go
@@ -49,11 +49,18 @@ type deviceStore struct {
 	byESID map[string]*fakeDevice
 	// byName maps AMAPI device resource name -> device
 	byName map[string]*fakeDevice
-	// deletedESIDs records devices Fleet deleted through AMAPI. Deletion is a real
-	// unenrollment, not lost state, so such a device must never come back: a device that
+	// deletedESIDs and deletedNames record devices Fleet deleted through AMAPI. Deletion is a
+	// real unenrollment, not lost state, so such a device must never come back: a device that
 	// registered again after being deleted would re-enroll itself in Fleet and produce an
 	// unenroll/enroll flip-flop.
+	//
+	// Both keys are needed. A delete that arrives while this process has forgotten the device
+	// (restarted, and the agent has not registered again yet) can only be recorded by resource
+	// name, since the ESID is not known then; the agent's next registration is matched on
+	// either key. Devices are never removed from these sets, which is bounded by how many
+	// devices a load test deletes.
 	deletedESIDs map[string]struct{}
+	deletedNames map[string]struct{}
 
 	// policyVersions tracks the latest version for each policy name.
 	// Fleet uses per-device policies named enterprises/{id}/policies/{hostUUID}.
@@ -69,6 +76,7 @@ func newDeviceStore() *deviceStore {
 		byESID:         make(map[string]*fakeDevice),
 		byName:         make(map[string]*fakeDevice),
 		deletedESIDs:   make(map[string]struct{}),
+		deletedNames:   make(map[string]struct{}),
 		policyVersions: make(map[string]int64),
 		policyVersion:  1,
 	}
@@ -113,9 +121,19 @@ func (ds *deviceStore) raisePolicyVersionCounter(version int64) {
 // register adds a device, or updates the identity and policy fields of one that is already
 // known. An existing device is updated in place so that state other handlers hold a pointer
 // to (pending commands, pending certificates) survives a device registering again.
-func (ds *deviceStore) register(d *fakeDevice) {
+//
+// It reports false, and registers nothing, for a device that was deleted. The check shares
+// the write lock with the insert so a delete can't land between the two.
+func (ds *deviceStore) register(d *fakeDevice) bool {
 	ds.mu.Lock()
 	defer ds.mu.Unlock()
+
+	if _, ok := ds.deletedESIDs[d.EnterpriseSpecificID]; ok {
+		return false
+	}
+	if _, ok := ds.deletedNames[d.DeviceName]; ok {
+		return false
+	}
 
 	if existing, ok := ds.byESID[d.EnterpriseSpecificID]; ok {
 		existing.mu.Lock()
@@ -126,17 +144,22 @@ func (ds *deviceStore) register(d *fakeDevice) {
 		existing.PolicyVersion = d.PolicyVersion
 		existing.mu.Unlock()
 		ds.byName[existing.DeviceName] = existing
-		return
+		return true
 	}
 
 	ds.byESID[d.EnterpriseSpecificID] = d
 	ds.byName[d.DeviceName] = d
+	return true
 }
 
-// markDeleted removes a device and records that it was deleted, not merely forgotten.
+// markDeleted records that the device with this resource name was deleted, not merely
+// forgotten, and removes it if it is currently known. The name is recorded either way: a
+// delete that arrives after this process lost its state has no other identifier to key on,
+// and the device must still not be able to register again.
 func (ds *deviceStore) markDeleted(name string) (*fakeDevice, bool) {
 	ds.mu.Lock()
 	defer ds.mu.Unlock()
+	ds.deletedNames[name] = struct{}{}
 	d, ok := ds.byName[name]
 	if !ok {
 		return nil, false

--- a/cmd/android-amapi-mock/main.go
+++ b/cmd/android-amapi-mock/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -122,6 +123,12 @@ func (ds *deviceStore) raisePolicyVersionCounter(version int64) {
 // known. An existing device is updated in place so that state other handlers hold a pointer
 // to (pending commands, pending certificates) survives a device registering again.
 //
+// A device's policy is only changed by a registration that actually reports one (d.PolicyName
+// is set). A registration without a policy — a freshly started agent, or one whose reported
+// version was rejected — leaves the known policy alone: overwriting it with the default policy
+// at version 0 would tell Fleet the applied policy regressed and strand every profile already
+// delivered. A new device with no reported policy starts on the default policy.
+//
 // It reports false, and registers nothing, for a device that was deleted. The check shares
 // the write lock with the insert so a delete can't land between the two.
 func (ds *deviceStore) register(d *fakeDevice) bool {
@@ -140,13 +147,25 @@ func (ds *deviceStore) register(d *fakeDevice) bool {
 		delete(ds.byName, existing.DeviceName)
 		existing.DeviceName = d.DeviceName
 		existing.EnterpriseID = d.EnterpriseID
-		existing.PolicyName = d.PolicyName
-		existing.PolicyVersion = d.PolicyVersion
+		switch {
+		case d.PolicyName == "":
+			// Nothing reported: keep what we already know.
+		case d.PolicyName == existing.PolicyName:
+			// Same policy: never lower the version the device already observed.
+			existing.PolicyVersion = max(existing.PolicyVersion, d.PolicyVersion)
+		default:
+			existing.PolicyName = d.PolicyName
+			existing.PolicyVersion = d.PolicyVersion
+		}
 		existing.mu.Unlock()
 		ds.byName[existing.DeviceName] = existing
 		return true
 	}
 
+	if d.PolicyName == "" && d.EnterpriseID != "" {
+		d.PolicyName = fmt.Sprintf("enterprises/%s/policies/default", d.EnterpriseID)
+		d.PolicyVersion = 0
+	}
 	ds.byESID[d.EnterpriseSpecificID] = d
 	ds.byName[d.DeviceName] = d
 	return true

--- a/cmd/android-amapi-mock/main.go
+++ b/cmd/android-amapi-mock/main.go
@@ -37,6 +37,11 @@ type fakeDevice struct {
 	PendingCertificates  []uint   `json:"pending_certificates"`
 }
 
+// maxRestorablePolicyVersion bounds the policy version a device may report when it
+// registers again, so a bogus value can't push the version counter near overflow and turn
+// every later version negative. It is far above any version a load test will reach.
+const maxRestorablePolicyVersion = 1 << 40
+
 // deviceStore is the in-memory registry of fake devices and policy versions.
 type deviceStore struct {
 	mu sync.RWMutex
@@ -44,25 +49,39 @@ type deviceStore struct {
 	byESID map[string]*fakeDevice
 	// byName maps AMAPI device resource name -> device
 	byName map[string]*fakeDevice
+	// deletedESIDs records devices Fleet deleted through AMAPI. Deletion is a real
+	// unenrollment, not lost state, so such a device must never come back: a device that
+	// registered again after being deleted would re-enroll itself in Fleet and produce an
+	// unenroll/enroll flip-flop.
+	deletedESIDs map[string]struct{}
 
 	// policyVersions tracks the latest version for each policy name.
 	// Fleet uses per-device policies named enterprises/{id}/policies/{hostUUID}.
+	// policyVersion is the counter versions are issued from; it is guarded by policyMu so
+	// issuing a version and recording it against a policy is one atomic step.
 	policyMu       sync.RWMutex
 	policyVersions map[string]int64
+	policyVersion  int64
 }
 
 func newDeviceStore() *deviceStore {
 	return &deviceStore{
 		byESID:         make(map[string]*fakeDevice),
 		byName:         make(map[string]*fakeDevice),
+		deletedESIDs:   make(map[string]struct{}),
 		policyVersions: make(map[string]int64),
+		policyVersion:  1,
 	}
 }
 
-func (ds *deviceStore) setPolicyVersion(policyName string, version int64) {
+// nextPolicyVersion issues the next version and records it as the current version of
+// policyName.
+func (ds *deviceStore) nextPolicyVersion(policyName string) int64 {
 	ds.policyMu.Lock()
 	defer ds.policyMu.Unlock()
-	ds.policyVersions[policyName] = version
+	ds.policyVersion++
+	ds.policyVersions[policyName] = ds.policyVersion
+	return ds.policyVersion
 }
 
 func (ds *deviceStore) getPolicyVersion(policyName string) int64 {
@@ -71,11 +90,69 @@ func (ds *deviceStore) getPolicyVersion(policyName string) int64 {
 	return ds.policyVersions[policyName]
 }
 
+// raisePolicyVersionCounter pulls the counter up to a version a device reports when it
+// registers again after this process lost its state, so versions issued from here on stay
+// above the version the device already told Fleet about.
+//
+// It deliberately does NOT record the version against the policy: doing so would let a
+// device claim a high applied version that this process never issued, and Fleet verifies
+// profiles whose included_in_policy_version is <= the applied version — so pending profiles
+// would flip to Verified without the policy ever having been applied, hiding the very
+// "stuck in Pending" bugs this harness exists to find.
+func (ds *deviceStore) raisePolicyVersionCounter(version int64) {
+	if version <= 0 || version > maxRestorablePolicyVersion {
+		return
+	}
+	ds.policyMu.Lock()
+	defer ds.policyMu.Unlock()
+	if ds.policyVersion < version {
+		ds.policyVersion = version
+	}
+}
+
+// register adds a device, or updates the identity and policy fields of one that is already
+// known. An existing device is updated in place so that state other handlers hold a pointer
+// to (pending commands, pending certificates) survives a device registering again.
 func (ds *deviceStore) register(d *fakeDevice) {
 	ds.mu.Lock()
 	defer ds.mu.Unlock()
+
+	if existing, ok := ds.byESID[d.EnterpriseSpecificID]; ok {
+		existing.mu.Lock()
+		delete(ds.byName, existing.DeviceName)
+		existing.DeviceName = d.DeviceName
+		existing.EnterpriseID = d.EnterpriseID
+		existing.PolicyName = d.PolicyName
+		existing.PolicyVersion = d.PolicyVersion
+		existing.mu.Unlock()
+		ds.byName[existing.DeviceName] = existing
+		return
+	}
+
 	ds.byESID[d.EnterpriseSpecificID] = d
 	ds.byName[d.DeviceName] = d
+}
+
+// markDeleted removes a device and records that it was deleted, not merely forgotten.
+func (ds *deviceStore) markDeleted(name string) (*fakeDevice, bool) {
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
+	d, ok := ds.byName[name]
+	if !ok {
+		return nil, false
+	}
+	delete(ds.byName, name)
+	delete(ds.byESID, d.EnterpriseSpecificID)
+	ds.deletedESIDs[d.EnterpriseSpecificID] = struct{}{}
+	return d, true
+}
+
+// wasDeleted reports whether this process deleted the device with the given ESID.
+func (ds *deviceStore) wasDeleted(esid string) bool {
+	ds.mu.RLock()
+	defer ds.mu.RUnlock()
+	_, ok := ds.deletedESIDs[esid]
+	return ok
 }
 
 func (ds *deviceStore) getByESID(esid string) *fakeDevice {
@@ -100,9 +177,6 @@ func (ds *deviceStore) allDeviceNames() []string {
 	return names
 }
 
-// policyVersionCounter is a global atomic counter for policy versions.
-var policyVersionCounter atomic.Int64
-
 // hasSeenRealDevice indicates that a real device has been seen.
 var hasSeenRealDevice atomic.Bool
 
@@ -119,8 +193,6 @@ func main() {
 		credJSON = os.Getenv("GOOGLE_CREDENTIALS")
 	}
 
-	policyVersionCounter.Store(1)
-
 	store := newDeviceStore()
 
 	// Set up authenticated Google API client for real device forwarding
@@ -134,6 +206,21 @@ func main() {
 		log.Printf("Google credentials loaded — forwarding real device requests to Google AMAPI")
 	}
 
+	mux := newMux(store, google, *latencyMean, *errorRate)
+
+	srv := &http.Server{
+		Addr:         *listen,
+		Handler:      mux,
+		ReadTimeout:  30 * time.Second,
+		WriteTimeout: 30 * time.Second,
+	}
+	log.Printf("Mock AMAPI proxy listening on %s", *listen)
+	log.Fatal(srv.ListenAndServe())
+}
+
+// newMux registers every mock route. Route patterns matter to the handlers (they read path
+// values), so this is shared between main and the tests rather than duplicated.
+func newMux(store *deviceStore, google *googleForwarder, latencyMean time.Duration, errorRate float64) *http.ServeMux {
 	mux := http.NewServeMux()
 
 	// ---- Health check ----
@@ -147,7 +234,7 @@ func main() {
 
 	// sim wraps AMAPI handlers with simulated latency and occasional errors
 	sim := func(h http.HandlerFunc) http.HandlerFunc {
-		return simulateLatencyAndErrors(*latencyMean, *errorRate, h)
+		return simulateLatencyAndErrors(latencyMean, errorRate, h)
 	}
 
 	// ---- AMAPI: Devices ----
@@ -171,29 +258,36 @@ func main() {
 	// Catch-all for unmatched /v1/ requests
 	mux.HandleFunc("/v1/", handleCatchAll(google))
 
-	srv := &http.Server{
-		Addr:         *listen,
-		Handler:      mux,
-		ReadTimeout:  30 * time.Second,
-		WriteTimeout: 30 * time.Second,
-	}
-	log.Printf("Mock AMAPI proxy listening on %s", *listen)
-	log.Fatal(srv.ListenAndServe())
+	return mux
 }
 
 // ---- Route helpers ----
 
+// trimAction removes an AMAPI custom method suffix (":issueCommand",
+// ":modifyPolicyApplications", ...) from a resource ID. Every action is routed to a single
+// handler per method, so the suffix is stripped generically: naming the known actions here
+// would silently reintroduce the resource-lookup bug the moment AMAPI grows another one.
+// Resource IDs themselves are UUIDs or numeric IDs and never contain a colon.
+func trimAction(resourceID string) string {
+	if i := strings.IndexByte(resourceID, ':'); i >= 0 {
+		return resourceID[:i]
+	}
+	return resourceID
+}
+
 // deviceName builds the AMAPI resource name from path values.
 func deviceName(r *http.Request) string {
-	did := r.PathValue("did")
-	did = strings.TrimSuffix(did, ":issueCommand")
-	return "enterprises/" + r.PathValue("eid") + "/devices/" + did
+	return "enterprises/" + r.PathValue("eid") + "/devices/" + trimAction(r.PathValue("did"))
+}
+
+// policyID returns the policy ID from path values with any action suffix removed.
+// Fleet names per-device policies after the host UUID (the enterpriseSpecificID for
+// Android), so callers can use this to look up the fake device the policy belongs to.
+func policyID(r *http.Request) string {
+	return trimAction(r.PathValue("pid"))
 }
 
 // policyName builds the AMAPI policy resource name from path values.
 func policyName(r *http.Request) string {
-	pid := r.PathValue("pid")
-	pid = strings.TrimSuffix(pid, ":modifyPolicyApplications")
-	pid = strings.TrimSuffix(pid, ":removePolicyApplications")
-	return "enterprises/" + r.PathValue("eid") + "/policies/" + pid
+	return "enterprises/" + r.PathValue("eid") + "/policies/" + policyID(r)
 }

--- a/cmd/android-amapi-mock/middleware.go
+++ b/cmd/android-amapi-mock/middleware.go
@@ -60,6 +60,14 @@ func forwardForRealDevice(store *deviceStore, google *googleForwarder) func(http
 				next(w, r)
 				return
 			}
+			// An unknown device is normally a real one, but it is also what every fake device
+			// looks like after this process restarts. Record a delete for it either way: if it
+			// was a forgotten fake device, its agent must not be able to register it again and
+			// resurrect a host Fleet just unenrolled. Recording a real device's name here is
+			// harmless, since only fake devices ever register.
+			if r.Method == http.MethodDelete {
+				store.markDeleted(name)
+			}
 			// Real device — forward via Google SDK if available
 			if google != nil {
 				hasSeenRealDevice.Store(true)

--- a/cmd/osquery-perf/android_agent.go
+++ b/cmd/osquery-perf/android_agent.go
@@ -25,6 +25,14 @@ import (
 // androidAgent simulates a single Android device for load testing.
 // It communicates with Fleet via PubSub messages (enrollment, status reports, command acks)
 // and coordinates with a mock AMAPI proxy to get policy versions and pending commands.
+//
+// The proxy keeps devices in memory only, so a proxy restart leaves it listing no devices
+// until each agent registers again. Registering again only happens on the next status-report
+// tick, so a restart exposes a window of up to one --android_status_interval in which Fleet's
+// device reconciler can see the fleet as absent and unenroll it (one mdm_unenrolled activity
+// per host) before the next status report re-enrolls it. Keep that interval short when
+// restarting the proxy mid-test; closing the window entirely means persisting the proxy's
+// device store across restarts.
 type androidAgent struct {
 	agentIndex    int
 	serverAddress string
@@ -60,8 +68,9 @@ type androidAgent struct {
 	statusReportInterval time.Duration
 
 	// lastState is the most recent state successfully polled from the mock proxy. It is
-	// reused when a later poll fails so the agent keeps reporting instead of going silent,
-	// which Fleet's device reconciler would eventually treat as an unenrollment.
+	// reused when a later poll fails so the agent keeps reporting instead of going silent.
+	// Fleet's device reconciler unenrolls hosts that the proxy stops listing, and a status
+	// report is what re-enrolls one, so an agent that goes quiet cannot recover.
 	// staleStateReports counts how many consecutive reports have used it.
 	lastState         *proxyDeviceState
 	staleStateReports int
@@ -399,8 +408,7 @@ var errProxyDeviceUnknown = errors.New("device not registered with proxy")
 var errProxyDeviceDeleted = errors.New("device was deleted from the proxy")
 
 // maxStaleStateReports bounds how many consecutive status reports may be sent from a stale
-// cached state. Reporting forever would keep a dead agent looking healthy and would re-drive
-// Fleet's certificate API with the same templates every cycle.
+// cached state, so a permanently broken agent stops looking healthy.
 const maxStaleStateReports = 10
 
 // pollProxyState asks the mock proxy for the current state this device should report.
@@ -430,9 +438,11 @@ func (a *androidAgent) pollProxyState() (*proxyDeviceState, error) {
 }
 
 // currentState polls the mock proxy for this device's state, recovering from a proxy that
-// lost its in-memory registration by registering again. If the state still can't be
-// fetched, the last known state is reused so the agent keeps sending status reports: going
-// silent makes Fleet's hourly device reconciler mark the host unenrolled.
+// lost its in-memory registration by registering again. If the state still can't be fetched,
+// the last known state is reused so the agent keeps sending status reports. Fleet's hourly
+// device reconciler unenrolls hosts the proxy no longer lists — which is every fake device
+// until it registers again after a proxy restart — and a status report is what re-enrolls
+// one, so an agent that goes quiet stays unenrolled.
 //
 // The returned bool reports whether the state is stale (reused rather than freshly polled),
 // so the caller can still count the failure instead of reporting a healthy load test.
@@ -475,8 +485,8 @@ func (a *androidAgent) lastKnownState(err error) (*proxyDeviceState, bool, error
 	// send duplicate operation results to Fleet.
 	stale := *a.lastState
 	stale.PendingCommands = nil
-	// Certificates were already handled against the earlier state; re-serving them would
-	// re-drive Fleet's certificate API every cycle for as long as the proxy is unreachable.
+	// Certificates can't have changed while the proxy is unreachable, so there is nothing to
+	// act on; the agent re-checks them as usual once a real state comes back.
 	stale.PendingCertificates = nil
 	return &stale, true, nil
 }

--- a/cmd/osquery-perf/android_agent.go
+++ b/cmd/osquery-perf/android_agent.go
@@ -59,6 +59,13 @@ type androidAgent struct {
 	// Timing
 	statusReportInterval time.Duration
 
+	// lastState is the most recent state successfully polled from the mock proxy. It is
+	// reused when a later poll fails so the agent keeps reporting instead of going silent,
+	// which Fleet's device reconciler would eventually treat as an unenrollment.
+	// staleStateReports counts how many consecutive reports have used it.
+	lastState         *proxyDeviceState
+	staleStateReports int
+
 	// Non-compliance probability (fraction of STATUS_REPORTs that include non-compliance details)
 	nonComplianceProb float64
 }
@@ -253,11 +260,21 @@ func (a *androidAgent) runLoop() {
 
 	for range statusTicker.C {
 		// Poll proxy for current state (policy version, pending commands)
-		state, err := a.pollProxyState()
+		state, stale, err := a.currentState()
+		if errors.Is(err, errProxyDeviceDeleted) {
+			// Fleet unenrolled this host, so there is nothing left to simulate.
+			log.Printf("Android agent %d: device was deleted, stopping", a.agentIndex)
+			return
+		}
 		if err != nil {
 			log.Printf("Android agent %d: failed to poll proxy: %v", a.agentIndex, err)
 			a.stats.IncrementAndroidErrors()
 			continue
+		}
+		if stale {
+			// Still report, so the device doesn't look dead to Fleet's reconciler, but count
+			// it: the state being reported is fabricated.
+			a.stats.IncrementAndroidErrors()
 		}
 
 		// Send STATUS_REPORT
@@ -338,10 +355,18 @@ func (a *androidAgent) registerWithProxy() error {
 		EnterpriseSpecificID string `json:"enterprise_specific_id"`
 		DeviceName           string `json:"device_name"`
 		EnterpriseID         string `json:"enterprise_id"`
+		PolicyName           string `json:"policy_name,omitempty"`
+		PolicyVersion        int64  `json:"policy_version,omitempty"`
 	}{
 		EnterpriseSpecificID: a.enterpriseSpecificID,
 		DeviceName:           a.deviceName,
 		EnterpriseID:         a.enterpriseID,
+	}
+	// When registering again after the proxy lost its in-memory state, hand back the policy
+	// we last observed so the proxy doesn't report a regressed policy to Fleet.
+	if a.lastState != nil {
+		body.PolicyName = a.lastState.PolicyName
+		body.PolicyVersion = a.lastState.PolicyVersion
 	}
 	data, err := json.Marshal(body)
 	if err != nil {
@@ -354,12 +379,29 @@ func (a *androidAgent) registerWithProxy() error {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusGone {
+		return errProxyDeviceDeleted
+	}
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("register returned %d: %s", resp.StatusCode, string(respBody))
 	}
 	return nil
 }
+
+// errProxyDeviceUnknown means the mock proxy has no registration for this device, which
+// happens when the proxy is restarted since it only keeps devices in memory.
+var errProxyDeviceUnknown = errors.New("device not registered with proxy")
+
+// errProxyDeviceDeleted means Fleet deleted this device through AMAPI, i.e. the host was
+// unenrolled. Unlike errProxyDeviceUnknown this is terminal: the device is gone on purpose
+// and must not register again.
+var errProxyDeviceDeleted = errors.New("device was deleted from the proxy")
+
+// maxStaleStateReports bounds how many consecutive status reports may be sent from a stale
+// cached state. Reporting forever would keep a dead agent looking healthy and would re-drive
+// Fleet's certificate API with the same templates every cycle.
+const maxStaleStateReports = 10
 
 // pollProxyState asks the mock proxy for the current state this device should report.
 func (a *androidAgent) pollProxyState() (*proxyDeviceState, error) {
@@ -369,6 +411,12 @@ func (a *androidAgent) pollProxyState() (*proxyDeviceState, error) {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, errProxyDeviceUnknown
+	}
+	if resp.StatusCode == http.StatusGone {
+		return nil, errProxyDeviceDeleted
+	}
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("poll state returned %d: %s", resp.StatusCode, string(respBody))
@@ -379,6 +427,58 @@ func (a *androidAgent) pollProxyState() (*proxyDeviceState, error) {
 		return nil, fmt.Errorf("decode state: %w", err)
 	}
 	return &state, nil
+}
+
+// currentState polls the mock proxy for this device's state, recovering from a proxy that
+// lost its in-memory registration by registering again. If the state still can't be
+// fetched, the last known state is reused so the agent keeps sending status reports: going
+// silent makes Fleet's hourly device reconciler mark the host unenrolled.
+//
+// The returned bool reports whether the state is stale (reused rather than freshly polled),
+// so the caller can still count the failure instead of reporting a healthy load test.
+// errProxyDeviceDeleted is returned as-is: that device is gone on purpose.
+func (a *androidAgent) currentState() (*proxyDeviceState, bool, error) {
+	state, err := a.pollProxyState()
+	if errors.Is(err, errProxyDeviceUnknown) {
+		log.Printf("Android agent %d: proxy lost our registration, registering again", a.agentIndex)
+		if rerr := a.registerWithProxy(); rerr != nil {
+			if errors.Is(rerr, errProxyDeviceDeleted) {
+				return nil, false, rerr
+			}
+			return a.lastKnownState(fmt.Errorf("re-register with proxy: %w", rerr))
+		}
+		state, err = a.pollProxyState()
+	}
+	if errors.Is(err, errProxyDeviceDeleted) {
+		return nil, false, err
+	}
+	if err != nil {
+		return a.lastKnownState(err)
+	}
+	a.lastState = state
+	a.staleStateReports = 0
+	return state, false, nil
+}
+
+// lastKnownState returns the previously polled state, or err if there is none yet or the
+// state has been reused too many times in a row.
+func (a *androidAgent) lastKnownState(err error) (*proxyDeviceState, bool, error) {
+	if a.lastState == nil {
+		return nil, false, err
+	}
+	if a.staleStateReports >= maxStaleStateReports {
+		return nil, false, fmt.Errorf("proxy state stale for %d consecutive reports: %w", a.staleStateReports, err)
+	}
+	a.staleStateReports++
+	log.Printf("Android agent %d: reusing last known proxy state (%d in a row): %v", a.agentIndex, a.staleStateReports, err)
+	// Pending commands were already acked against the earlier state; re-acking them would
+	// send duplicate operation results to Fleet.
+	stale := *a.lastState
+	stale.PendingCommands = nil
+	// Certificates were already handled against the earlier state; re-serving them would
+	// re-drive Fleet's certificate API every cycle for as long as the proxy is unreachable.
+	stale.PendingCertificates = nil
+	return &stale, true, nil
 }
 
 // sendEnrollment sends an ENROLLMENT PubSub message to Fleet.

--- a/cmd/osquery-perf/android_agent_test.go
+++ b/cmd/osquery-perf/android_agent_test.go
@@ -1,0 +1,363 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeProxy is a stand-in for the android-amapi-mock coordination API.
+type fakeProxy struct {
+	mu sync.Mutex
+	// registered is false until a device registers, mimicking a proxy that lost its
+	// in-memory state.
+	registered bool
+	// state is served on a successful poll.
+	state proxyDeviceState
+	// pollStatus, when non-zero, overrides the status code of a poll for a registered device.
+	pollStatus int
+	// registerStatus, when non-zero, is the status code returned to a registration.
+	registerStatus int
+
+	registrations []registeredDevice
+	pollCount     int
+}
+
+type registeredDevice struct {
+	EnterpriseSpecificID string `json:"enterprise_specific_id"`
+	DeviceName           string `json:"device_name"`
+	EnterpriseID         string `json:"enterprise_id"`
+	PolicyName           string `json:"policy_name"`
+	PolicyVersion        int64  `json:"policy_version"`
+}
+
+func (p *fakeProxy) server(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /mock/devices/register", func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		var d registeredDevice
+		if err := json.Unmarshal(body, &d); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		p.mu.Lock()
+		p.registrations = append(p.registrations, d)
+		status := p.registerStatus
+		if status == 0 {
+			p.registered = true
+			status = http.StatusOK
+		}
+		p.mu.Unlock()
+		w.WriteHeader(status)
+	})
+	mux.HandleFunc("GET /mock/devices/{esid}/state", func(w http.ResponseWriter, _ *http.Request) {
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		p.pollCount++
+		if !p.registered {
+			http.Error(w, "device not found", http.StatusNotFound)
+			return
+		}
+		if p.pollStatus != 0 {
+			http.Error(w, "simulated failure", p.pollStatus)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(p.state)
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func (p *fakeProxy) registrationsMade() []registeredDevice {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]registeredDevice(nil), p.registrations...)
+}
+
+func (p *fakeProxy) set(mutate func(*fakeProxy)) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	mutate(p)
+}
+
+func newTestAndroidAgent(proxyAddress string) *androidAgent {
+	return &androidAgent{
+		agentIndex:           1,
+		proxyAddress:         proxyAddress,
+		enterpriseSpecificID: "35B8F9A0-4C2E-4B1D-9F3A-7E6D5C4B3A21",
+		enterpriseID:         "LC01",
+		deviceName:           "enterprises/LC01/devices/fakedevice",
+	}
+}
+
+func testState() proxyDeviceState {
+	return proxyDeviceState{
+		PolicyVersion: 12,
+		PolicyName:    "enterprises/LC01/policies/host-uuid",
+	}
+}
+
+// TestCurrentStateRecoversLostRegistration covers the load-testing bug where a proxy that
+// lost its in-memory device state left the agent polling a 404 forever. The agent stopped
+// sending status reports, so Fleet's hourly reconciler marked the host unenrolled and MDM
+// status went to Off.
+func TestCurrentStateRecoversLostRegistration(t *testing.T) {
+	proxy := &fakeProxy{state: testState()}
+	srv := proxy.server(t)
+	agent := newTestAndroidAgent(srv.URL)
+
+	// The proxy has no record of this device, so the first poll 404s.
+	state, stale, err := agent.currentState()
+	require.NoError(t, err, "the agent must recover by registering again")
+	require.NotNil(t, state)
+	assert.False(t, stale)
+	assert.Equal(t, int64(12), state.PolicyVersion)
+	assert.Equal(t, "enterprises/LC01/policies/host-uuid", state.PolicyName)
+
+	registrations := proxy.registrationsMade()
+	require.Len(t, registrations, 1, "exactly one re-registration")
+	assert.Equal(t, agent.enterpriseSpecificID, registrations[0].EnterpriseSpecificID)
+	assert.Equal(t, agent.deviceName, registrations[0].DeviceName)
+	assert.Equal(t, agent.enterpriseID, registrations[0].EnterpriseID)
+
+	// A later poll succeeds directly, without registering again.
+	state, stale, err = agent.currentState()
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.False(t, stale)
+	assert.Len(t, proxy.registrationsMade(), 1, "a healthy poll must not re-register")
+}
+
+// TestCurrentStateReRegistersWithLastKnownPolicy checks that recovery reports the policy the
+// agent last observed, so the proxy doesn't tell Fleet the applied policy regressed.
+func TestCurrentStateReRegistersWithLastKnownPolicy(t *testing.T) {
+	proxy := &fakeProxy{
+		registered: true,
+		state:      proxyDeviceState{PolicyVersion: 57, PolicyName: "enterprises/LC01/policies/host-uuid"},
+	}
+	srv := proxy.server(t)
+	agent := newTestAndroidAgent(srv.URL)
+
+	// Establish a known state.
+	_, _, err := agent.currentState()
+	require.NoError(t, err)
+
+	// The proxy restarts and forgets the device.
+	proxy.set(func(p *fakeProxy) { p.registered = false })
+
+	state, _, err := agent.currentState()
+	require.NoError(t, err)
+	require.NotNil(t, state)
+
+	registrations := proxy.registrationsMade()
+	require.Len(t, registrations, 1)
+	assert.Equal(t, "enterprises/LC01/policies/host-uuid", registrations[0].PolicyName)
+	assert.Equal(t, int64(57), registrations[0].PolicyVersion)
+}
+
+// TestCurrentStateStopsWhenDeviceDeleted covers the other half of the recovery: a device
+// Fleet deleted through AMAPI (a real unenrollment) must NOT be registered again, or it would
+// resurrect itself and re-enroll the host.
+func TestCurrentStateStopsWhenDeviceDeleted(t *testing.T) {
+	t.Run("a deleted device is terminal on poll", func(t *testing.T) {
+		proxy := &fakeProxy{registered: true, pollStatus: http.StatusGone, state: testState()}
+		srv := proxy.server(t)
+		agent := newTestAndroidAgent(srv.URL)
+
+		state, stale, err := agent.currentState()
+		require.ErrorIs(t, err, errProxyDeviceDeleted)
+		assert.Nil(t, state)
+		assert.False(t, stale)
+		assert.Empty(t, proxy.registrationsMade(), "a deleted device must not register again")
+	})
+
+	// Even with a usable cached state, a delete must not fall back to reporting.
+	t.Run("a deleted device does not fall back to stale state", func(t *testing.T) {
+		proxy := &fakeProxy{registered: true, state: testState()}
+		srv := proxy.server(t)
+		agent := newTestAndroidAgent(srv.URL)
+
+		_, _, err := agent.currentState()
+		require.NoError(t, err)
+		require.NotNil(t, agent.lastState)
+
+		proxy.set(func(p *fakeProxy) { p.pollStatus = http.StatusGone })
+
+		state, _, err := agent.currentState()
+		require.ErrorIs(t, err, errProxyDeviceDeleted)
+		assert.Nil(t, state)
+	})
+
+	// If the proxy forgot the device AND refuses the registration as deleted, that is still
+	// terminal — not a transient failure to paper over with stale state.
+	t.Run("a registration refused as deleted is terminal", func(t *testing.T) {
+		proxy := &fakeProxy{registered: true, state: testState()}
+		srv := proxy.server(t)
+		agent := newTestAndroidAgent(srv.URL)
+
+		_, _, err := agent.currentState()
+		require.NoError(t, err)
+
+		proxy.set(func(p *fakeProxy) {
+			p.registered = false
+			p.registerStatus = http.StatusGone
+		})
+
+		state, _, err := agent.currentState()
+		require.ErrorIs(t, err, errProxyDeviceDeleted)
+		assert.Nil(t, state)
+	})
+}
+
+func TestCurrentStateFallsBackToLastKnownState(t *testing.T) {
+	t.Run("a transient failure reuses the last known state", func(t *testing.T) {
+		state := testState()
+		state.PendingCertificates = []uint{7}
+		state.PendingCommands = []string{"enterprises/LC01/devices/fakedevice/operations/op1"}
+		proxy := &fakeProxy{registered: true, state: state}
+		srv := proxy.server(t)
+		agent := newTestAndroidAgent(srv.URL)
+
+		_, _, err := agent.currentState()
+		require.NoError(t, err)
+
+		proxy.set(func(p *fakeProxy) { p.pollStatus = http.StatusInternalServerError })
+
+		got, stale, err := agent.currentState()
+		require.NoError(t, err, "the agent must keep reporting so it isn't reconciled as unenrolled")
+		require.NotNil(t, got)
+		assert.True(t, stale, "the caller must be able to count this as an error")
+		assert.Equal(t, int64(12), got.PolicyVersion)
+		assert.Empty(t, got.PendingCommands, "already-acked commands must not be acked again")
+		assert.Empty(t, got.PendingCertificates, "already-handled certificates must not be re-driven")
+	})
+
+	t.Run("no state yet returns the error", func(t *testing.T) {
+		proxy := &fakeProxy{registered: true, pollStatus: http.StatusInternalServerError}
+		srv := proxy.server(t)
+		agent := newTestAndroidAgent(srv.URL)
+
+		state, stale, err := agent.currentState()
+		require.Error(t, err)
+		assert.Nil(t, state)
+		assert.False(t, stale)
+	})
+
+	// The proxy forgot the device and registering fails for a transient reason: fall back
+	// rather than going silent, and confirm the re-registration was actually attempted.
+	t.Run("a failed re-registration falls back to stale state", func(t *testing.T) {
+		proxy := &fakeProxy{registered: true, state: testState()}
+		srv := proxy.server(t)
+		agent := newTestAndroidAgent(srv.URL)
+
+		_, _, err := agent.currentState()
+		require.NoError(t, err)
+
+		proxy.set(func(p *fakeProxy) {
+			p.registered = false
+			p.registerStatus = http.StatusInternalServerError
+		})
+
+		state, stale, err := agent.currentState()
+		require.NoError(t, err)
+		require.NotNil(t, state)
+		assert.True(t, stale)
+		assert.Equal(t, int64(12), state.PolicyVersion)
+		require.Len(t, proxy.registrationsMade(), 1, "the re-registration must have been attempted")
+	})
+
+	// Reusing stale state forever would keep a dead agent looking healthy.
+	t.Run("stale state is not reused forever", func(t *testing.T) {
+		proxy := &fakeProxy{registered: true, state: testState()}
+		srv := proxy.server(t)
+		agent := newTestAndroidAgent(srv.URL)
+
+		_, _, err := agent.currentState()
+		require.NoError(t, err)
+
+		proxy.set(func(p *fakeProxy) { p.pollStatus = http.StatusInternalServerError })
+
+		for i := range maxStaleStateReports {
+			state, stale, err := agent.currentState()
+			require.NoError(t, err, "fallback %d must still be allowed", i+1)
+			require.NotNil(t, state)
+			require.True(t, stale)
+		}
+
+		state, _, err := agent.currentState()
+		require.Error(t, err, "the fallback must be bounded")
+		assert.Nil(t, state)
+
+		// A healthy poll clears the budget.
+		proxy.set(func(p *fakeProxy) { p.pollStatus = 0 })
+		_, stale, err := agent.currentState()
+		require.NoError(t, err)
+		require.False(t, stale)
+		assert.Zero(t, agent.staleStateReports)
+	})
+}
+
+// TestCurrentStateDoesNotMutateCachedState guards against the fallback clearing pending
+// commands on the cached state itself, which would drop commands on a later healthy poll.
+func TestCurrentStateDoesNotMutateCachedState(t *testing.T) {
+	state := testState()
+	state.PendingCommands = []string{"enterprises/LC01/devices/fakedevice/operations/op1"}
+	state.PendingCertificates = []uint{7}
+	proxy := &fakeProxy{registered: true, state: state}
+	srv := proxy.server(t)
+	agent := newTestAndroidAgent(srv.URL)
+
+	got, _, err := agent.currentState()
+	require.NoError(t, err)
+	require.Len(t, got.PendingCommands, 1)
+
+	proxy.set(func(p *fakeProxy) { p.pollStatus = http.StatusInternalServerError })
+
+	_, _, err = agent.currentState()
+	require.NoError(t, err)
+
+	require.NotNil(t, agent.lastState)
+	assert.Len(t, agent.lastState.PendingCommands, 1, "the cached state must be left intact")
+	assert.Len(t, agent.lastState.PendingCertificates, 1, "the cached state must be left intact")
+}
+
+func TestPollProxyStateClassifiesFailures(t *testing.T) {
+	proxy := &fakeProxy{}
+	srv := proxy.server(t)
+	agent := newTestAndroidAgent(srv.URL)
+
+	// Unregistered: recoverable by registering again.
+	_, err := agent.pollProxyState()
+	require.ErrorIs(t, err, errProxyDeviceUnknown)
+
+	// Deleted: terminal.
+	proxy.set(func(p *fakeProxy) {
+		p.registered = true
+		p.pollStatus = http.StatusGone
+	})
+	_, err = agent.pollProxyState()
+	require.ErrorIs(t, err, errProxyDeviceDeleted)
+
+	// Anything else is just an error, and must not be mistaken for either.
+	proxy.set(func(p *fakeProxy) { p.pollStatus = http.StatusTooManyRequests })
+	_, err = agent.pollProxyState()
+	require.Error(t, err)
+	require.NotErrorIs(t, err, errProxyDeviceUnknown, "only a 404 means the registration was lost")
+	require.NotErrorIs(t, err, errProxyDeviceDeleted, "only a 410 means the device was deleted")
+	assert.True(t, strings.Contains(err.Error(), "429"), "error should carry the status code: %v", err)
+}

--- a/cmd/osquery-perf/android_agent_test.go
+++ b/cmd/osquery-perf/android_agent_test.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"sync"
 	"testing"
 
@@ -359,5 +358,5 @@ func TestPollProxyStateClassifiesFailures(t *testing.T) {
 	require.Error(t, err)
 	require.NotErrorIs(t, err, errProxyDeviceUnknown, "only a 404 means the registration was lost")
 	require.NotErrorIs(t, err, errProxyDeviceDeleted, "only a 410 means the device was deleted")
-	assert.True(t, strings.Contains(err.Error(), "429"), "error should carry the status code: %v", err)
+	assert.Contains(t, err.Error(), "429", "error should carry the status code")
 }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #50464

Fixes the two load-testing harness bugs reported in the issue. Both are in dev tooling
(`cmd/android-amapi-mock`, `cmd/osquery-perf`) — no product code is touched, so there is no
user-visible change.

## Config profiles stuck in Pending

`handlePolicyAction` passed the raw `{pid}` path value into the device lookup, so
`extractAndStoreCertTemplateIDs` received `{esid}:modifyPolicyApplications` and never matched
the device registered under the bare `enterpriseSpecificID`. Pending certificate templates were
dropped, the fake agent never reported them verified, and cert-backed profiles stayed Pending
forever.

The action suffix is now stripped generically (cut at the first colon) rather than by naming
known actions — every AMAPI custom method routes to one handler, so naming them would
reintroduce the bug the moment AMAPI grows another. Cert extraction also keeps scanning after a
change that carries no install operation, which previously dropped certificates listed in a
later change.

## MDM status turning off about an hour in

The mock keeps devices in memory only. After it restarted, an agent's state poll returned 404
forever: the agent logged the error and skipped the cycle, so it never registered again and
never sent another status report. The device was then absent from the AMAPI device list, and
`mdm_android_device_reconciler` correctly marked the host unenrolled.

- A **404** now means "this process lost the registration": the agent registers again, reporting
  the policy it last observed so it does not tell Fleet its applied policy regressed to the
  default at version 0.
- A **410** means Fleet deleted the device through AMAPI, which is a real unenrollment. Deleted
  devices are remembered as deleted and both the state poll and registration return 410, so a
  recovering agent cannot resurrect a host Fleet deliberately unenrolled (non-BYO unenroll calls
  `EnterprisesDevicesDelete`) and cause an unenroll/enroll flip-flop. Deletions are recorded by
  resource name as well as by `enterpriseSpecificID`, and recorded even when this process does
  not know the device — a delete arriving in the restart window would otherwise leave no record.
- If the state still can't be fetched, the agent reuses the last known state so a transient blip
  can't make a device look dead — but the staleness is reported back so it is counted as an
  error instead of showing a healthy load test, pending commands/certificates are cleared to
  avoid duplicate acks and re-driving the certificate API, and the reuse is bounded.

## Policy versions must never go backwards

Fleet verifies profiles whose `included_in_policy_version` is `<=` the device's applied version,
which makes the reported version load-bearing in both directions:

- A restored version is **not** recorded as the policy's current version. A device claiming a
  version this process never issued would flip every pending profile to Verified without the
  policy having been applied, hiding the very stuck-in-Pending bugs this harness exists to find.
- The state poll and the device patch report the **higher** of the version this process issued
  and the version the device already observed. After a restart the version counter starts over,
  so if Fleet patched a policy before the device registered again, reporting the newly issued
  low version would tell Fleet the applied version regressed and strand every profile delivered
  before the restart. Moving a device to a different policy still takes the new policy's version,
  so a stale version can't over-verify.
- The version a device reports is validated. Bounding the version counter did not bound what
  reached Fleet: an out-of-range value now falls back to a fresh registration.

Version issuance moved under the store's policy lock so issuing a version and recording it is
one step; registration decodes into an explicit request struct so `pending_commands` can't be
injected through it; and re-registration updates the existing device in place so pending state
survives.

The route table was extracted into `newMux()` so tests exercise the real `{pid}` path-value
parsing, which is where the bug lived. Route patterns, ordering and middleware wrapping are
unchanged.

## Testing

```
go test -count=1 -race ./cmd/osquery-perf/ ./cmd/android-amapi-mock/
```

Neither package had any tests before; both are now covered without external deps.
`currentState`/`lastKnownState` are at 100% statement coverage. Each fix was verified by
reverting it and confirming a specific test fails. Test bodies are built from the real
`androidmanagement.ModifyPolicyApplicationsRequest`, `android.AgentManagedConfiguration` and
`fleet.MDMOperationTypeInstall` types, so a wire-format change fails to compile rather than
silently passing.

### Verified on a live load test

Two fake Android hosts, `--android_status_interval 30s`, mock with Google credentials so the
real device in the same enterprise kept working:

- **Profiles reach a terminal state.** Both hosts went to `verified` at the mock-issued policy
  versions (`included_in_policy_version` 3 and 4, matching `applied_policy_version`) — the
  behaviour the issue asked for.
- **Mock restart recovery**, exercised twice: a ~6s restart and an unplanned ~2min outage. Both
  agents re-registered within 1–6s of the mock coming back, logged by the mock as
  `Registered fake device`. Across each restart the reported policy version stayed 3/4 rather
  than resetting to 0, the reported policy name stayed the per-host policy rather than reverting
  to `…/policies/default`, `applied_policy_id`/`applied_policy_version` were unchanged, both
  profiles stayed `verified`, `host_mdm.enrolled` stayed 1, and both devices were present in the
  AMAPI device list the reconciler reads. Before this change both agents would have 404'd forever
  and been unenrolled.
- **Stale-state fallback**, during the ~2min outage: with the mock process dead, both agents kept
  sending status reports from cached state, so both hosts stayed enrolled and verified through
  the outage instead of going quiet. On the mock's return the devices correctly reported 404
  ("this process forgot you"), not 410.
- **Unenroll is terminal — no resurrection.** `DELETE /api/v1/fleet/hosts/15/mdm` on one host
  (the other kept as a control): the mock dropped it from the device list, its state poll
  returned **410**, and its agent stopped. Over the next 90s (3 ticks) the control host's
  `last_policy_sync_time` advanced three times while the unenrolled host's stayed frozen at its
  pre-unenroll value, the state poll stayed 410, and the device never reappeared in the device
  list. Without the deleted-device tombstone the agent would have read this as lost state,
  registered again, and re-enrolled a host that was just deliberately unenrolled.

  Note `host_mdm.enrolled` stays 1 immediately after: non-BYO Android unenroll only deletes the
  device via AMAPI, and the flip comes from a DELETED Pub/Sub notification or the hourly
  reconciler. A stopped agent correctly sends neither, so the reconciler is the backstop.

### Not yet covered

- **Certificate delivery end to end.** The original stuck-in-Pending path is covered by unit
  tests but has not been exercised against a running Fleet — it needs a CA and a certificate
  template assigned to the team so Fleet sends `certificate_templates` in the agent's managed
  configuration, and the fake agent then PUTs `verified` back.
- **Scale.** Verified with 2 hosts; not run at a realistic load-test host count.

### A note for anyone reproducing this

`FLEET_DEV_ANDROID_GOOGLE_CLIENT=1` overrides `FLEET_DEV_ANDROID_PROXY_ENDPOINT`
(`newAMAPIClient`, `server/mdm/android/service/service.go`), so Fleet talks to real AMAPI and
every fake-device request 404s with Google's `The device does not exist.`. Set it to `0` when
using the mock. A Fleet server started without `FLEET_SERVER_PRIVATE_KEY` also rejects every
STATUS_REPORT with `crypto/aes: invalid key size 0`, which looks identical to profiles never
verifying. Both cost time to diagnose here.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  N/A — load-testing tooling only, no user-visible change.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops

## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)
- [x] QA'd all new/changed functionality manually — profile verification, mock-restart recovery,
  the stale-state fallback and the unenroll/410 terminal path were all QA'd on a live load test.
  Certificate delivery is covered by unit tests only. See "Not yet covered" above.

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Android agents now recover automatically when proxy registration state is lost.
  - Temporary proxy outages can reuse the last known device state.
  - Certificate actions and policy versions remain consistent across policy changes and restarts.

- **Bug Fixes**
  - Deleted devices remain unavailable and are handled distinctly from unknown devices.
  - Prevented duplicate commands, invalid registration state, and policy-version regressions.
  - Improved device updates, policy reporting, certificate tracking, and concurrent state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->