### PR TITLE
Fix Worksheet Crafter homebrew ingestion after upstream cask rename

### DIFF
--- a/ee/maintained-apps/inputs/homebrew/worksheet-crafter.json
+++ b/ee/maintained-apps/inputs/homebrew/worksheet-crafter.json
@@ -1,7 +1,7 @@
 {
   "name": "Worksheet Crafter",
   "unique_identifier": "com.SchoolCraft.WillBeReplacedByQMake",
-  "token": "worksheet-crafter",
+  "token": "worksheetcrafter",
   "installer_format": "pkg",
   "slug": "worksheet-crafter/darwin",
   "default_categories": [


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** N/A — fixes a failing scheduled workflow ([Ingest maintained apps](https://github.com/fleetdm/fleet/actions/workflows/ingest-maintained-apps.yml))

## What's happening

The `Ingest maintained apps` workflow panics on every run:

```
{"level":"INFO","msg":"ingesting homebrew app","name":"Worksheet Crafter"}
panic: ingesting homebrew app: app not found in brew API
```

The homebrew ingester aborts on the first failing app, so no FMA update PR is generated at all — the failure is not limited to Worksheet Crafter's own data.

## Root cause

Homebrew renamed the cask from `worksheet-crafter` to `worksheetcrafter`. The old token now 404s, which `fetchCask` treats (correctly) as a non-transient, fatal error at [ingester.go:533](https://github.com/fleetdm/fleet/blob/main/ee/maintained-apps/ingesters/homebrew/ingester.go#L533).

The upstream cask records the rename itself:

```json
{
  "token": "worksheetcrafter",
  "old_tokens": ["worksheet-crafter"],
  "name": ["WorksheetCrafter"],
  "version": "2026.2.5"
}
```

The app is not gone from Homebrew, and it is unrelated to the app being `frozen` — `frozen: true` only gates the *output write* in [main.go:106](https://github.com/fleetdm/fleet/blob/main/cmd/maintained-apps/main.go#L106); the ingester still fetches the cask for every input, so a frozen app with a dead token still takes the whole run down.

## The fix

Point the input at the new token:

```diff
-  "token": "worksheet-crafter",
+  "token": "worksheetcrafter",
```

Deliberately unchanged:

- **`slug` stays `worksheet-crafter/darwin`.** It is user-facing and already published in `apps.json`, and the validator derives the input file path from the slug (`isFrozen()` in [app_commander.go:36](https://github.com/fleetdm/fleet/blob/main/cmd/maintained-apps/validate/app_commander.go#L36) reads `inputs/homebrew/<slug-name>.json`), so the input file keeps its current name too.
- **`name` stays `Worksheet Crafter`.** The output's `name` comes from the input, not the cask, so adopting the cask's new `WorksheetCrafter` spelling would only churn the display name for existing users.
- **`frozen: true` stays.** The freeze predates this (#49055) and is a separate question; this PR is scoped to unbreaking the workflow. The output stays at 2026.2.4 while upstream is at 2026.2.5.

## Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

No changes file: this is FMA manifest data, consistent with previous FMA data fixes (e.g. #51022).

## Testing

- [x] QA'd all new/changed functionality manually

The affected slug now ingests cleanly where it previously panicked, and writes nothing (it is frozen and its output already exists):

```
go run ./cmd/maintained-apps -slug worksheet-crafter/darwin
```

Because the run aborts on the first failure, a fix for one app can just move the panic to the next one. Two checks against that:

1. Every homebrew input token was cross-checked against the full brew cask index (`https://formulae.brew.sh/api/cask.json`, 7691 casks). `worksheet-crafter` was the only token missing — no other input is at risk of a 404.
2. The whole homebrew leg was run end to end (`-slug /darwin` matches all 962 homebrew inputs and no winget inputs). It completed with exit 0. `outputs/worksheet-crafter/darwin.json` was untouched, as expected for a frozen app; the other output changes were ordinary upstream version bumps and were reverted rather than included here, since they belong to the automated update PR.

### Unrelated issue noticed while verifying

The full run logged, without failing:

```
Error enriching app net.whatsapp.WhatsApp: Expected WhatsApp version to start with '2.' but found '26.32.15'
```

This is pre-existing, not something this PR touches. WhatsApp has moved to a `26.x` version scheme, so `whats_app_version_shortener.go`'s `2.`-prefix assumption no longer holds. `EnrichManifest` only prints the error and moves on ([main.go:118](https://github.com/fleetdm/fleet/blob/main/ee/maintained-apps/ingesters/homebrew/external_refs/main.go#L118)), so the shortener is skipped and the unshortened version ships — `outputs/whatsapp/darwin.json` is already on `26.32.12`. Worth a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Homebrew app token to use the correct identifier for Worksheet Crafter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->