### PR TITLE
Move Microsoft Graph credential logic to ee/

### DIFF
--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -513,7 +513,6 @@ func runServeCmd(cmd *cobra.Command, configManager configpkg.Manager, debug, dev
 		redis_key_value.New(redisPool),
 		androidSvc,
 		orgLogoStore,
-		msgraph.NewClient,
 	)
 	if err != nil {
 		initFatal(err, "initializing service")
@@ -622,6 +621,7 @@ func runServeCmd(cmd *cobra.Command, configManager configpkg.Manager, debug, dev
 			androidSvc,
 			hydrantService,
 			psso.NewRedisNonceStore(redisPool),
+			msgraph.NewClient,
 		)
 		if err != nil {
 			initFatal(err, "initial Fleet Premium service")

--- a/cmd/fleetctl/fleetctl/gitops.go
+++ b/cmd/fleetctl/fleetctl/gitops.go
@@ -401,6 +401,18 @@ func gitopsCommand() *cli.Command {
 				}
 
 				if !appConfig.License.IsPremium() {
+					if creds, ok := config.OrgSettings["microsoft_graph_credentials"]; ok {
+						parsed, err := fleet.ParseMicrosoftGraphCredentials(creds)
+						if err != nil {
+							return fmt.Errorf("invalid microsoft_graph_credentials: %w", err)
+						}
+						if len(parsed) > 0 {
+							return fmt.Errorf(
+								"Couldn't edit %q at \"microsoft_graph_credentials\": Missing or invalid license. Microsoft Graph credentials are available in Fleet Premium only.",
+								filepath.Base(flFilename))
+						}
+					}
+
 					// Targeting queries against labels is a Premium feature only
 					for _, query := range config.Queries {
 						if len(query.LabelsIncludeAny) > 0 {

--- a/ee/server/service/mdm_external_test.go
+++ b/ee/server/service/mdm_external_test.go
@@ -130,8 +130,6 @@ func setupMockDatastorePremiumService(t testing.TB) (*mock.Store, *eeservice.Ser
 		nil,
 		nil,
 		nil,
-		// A nil factory would be replaced with the real msgraph.NewClient, leaving this fixture holding a live Graph
-		// client that would reach login.microsoftonline.com if a test ever exercised credential verification.
 		noopGraphClientFactory,
 	)
 	if err != nil {

--- a/ee/server/service/mdm_external_test.go
+++ b/ee/server/service/mdm_external_test.go
@@ -100,7 +100,6 @@ func setupMockDatastorePremiumService(t testing.TB) (*mock.Store, *eeservice.Ser
 		nil,
 		nil,
 		nil,
-		nil,
 	)
 	if err != nil {
 		panic(err)
@@ -130,6 +129,7 @@ func setupMockDatastorePremiumService(t testing.TB) (*mock.Store, *eeservice.Ser
 		nil,
 		nil,
 		nil,
+		nil, // msGraphClientFactory
 	)
 	if err != nil {
 		panic(err)

--- a/ee/server/service/mdm_external_test.go
+++ b/ee/server/service/mdm_external_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/mdm/apple/mobileconfig"
 	nanodep_client "github.com/fleetdm/fleet/v4/server/mdm/nanodep/client"
 	mdmtesting "github.com/fleetdm/fleet/v4/server/mdm/testing_utils"
+	"github.com/fleetdm/fleet/v4/server/microsoft/msgraph"
 	"github.com/fleetdm/fleet/v4/server/mock"
 	nanodep_mock "github.com/fleetdm/fleet/v4/server/mock/nanodep"
 	"github.com/fleetdm/fleet/v4/server/ptr"
@@ -129,12 +130,18 @@ func setupMockDatastorePremiumService(t testing.TB) (*mock.Store, *eeservice.Ser
 		nil,
 		nil,
 		nil,
-		nil, // msGraphClientFactory
+		// A nil factory would be replaced with the real msgraph.NewClient, leaving this fixture holding a live Graph
+		// client that would reach login.microsoftonline.com if a test ever exercised credential verification.
+		noopGraphClientFactory,
 	)
 	if err != nil {
 		panic(err)
 	}
 	return ds, svc, ctx
+}
+
+func noopGraphClientFactory(*fleet.MicrosoftGraphCredential) (msgraph.Client, error) {
+	return nil, nil
 }
 
 func TestGetOrCreatePreassignTeam(t *testing.T) {

--- a/ee/server/service/microsoft_graph_credentials.go
+++ b/ee/server/service/microsoft_graph_credentials.go
@@ -248,6 +248,11 @@ func microsoftGraphVerifyMessage(err error) string {
 
 // persistMicrosoftGraphCredentials reconciles stored credentials to match the supplied list, and reports which tenants
 // were added, edited, or deleted so the caller can emit one activity apiece.
+//
+// storedByTenant distinguishes nil from empty, and the difference is load-bearing: nil means "the caller did not read
+// the stored credentials", so this function reads them itself to work out what to delete. A non-nil empty map means
+// "the caller read them and there are none". Passing an empty map when the caller has not actually read would silently
+// skip every delete, so callers must pass nil rather than an empty map when they skipped the read.
 func (svc *Service) persistMicrosoftGraphCredentials(
 	ctx context.Context,
 	creds []fleet.MicrosoftGraphCredential,
@@ -259,7 +264,7 @@ func (svc *Service) persistMicrosoftGraphCredentials(
 			storedTenants[tenantID] = struct{}{}
 		}
 	} else {
-		// The clear-everything path. We need to get what we need to delete.
+		// The caller skipped the read (empty incoming list), so read what is stored to work out the deletes.
 		storedMeta, err := svc.ds.ListMicrosoftGraphCredentialMetadata(ctx)
 		if err != nil {
 			return nil, nil, nil, ctxerr.Wrap(ctx, err, "list microsoft graph credential metadata")

--- a/ee/server/service/microsoft_graph_credentials.go
+++ b/ee/server/service/microsoft_graph_credentials.go
@@ -1,0 +1,330 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/fleetdm/fleet/v4/server/authz"
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxdb"
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/microsoft/msgraph"
+)
+
+// maxMicrosoftGraphCredentials caps how many Graph credentials may be configured. Fleet's data model, sync loop, and
+// storage are all built for the multi-tenant case. We limit it now for initial rollout.
+const maxMicrosoftGraphCredentials = 1
+
+// ListMicrosoftGraphCredentials returns the stored credentials with their per-tenant sync status. Client secrets are
+// never decrypted on this path.
+func (svc *Service) ListMicrosoftGraphCredentials(ctx context.Context) ([]*fleet.MicrosoftGraphCredential, error) {
+	if err := svc.authz.Authorize(ctx, &fleet.AppConfig{}, fleet.ActionRead); err != nil {
+		return nil, err
+	}
+
+	creds, err := svc.ds.ListMicrosoftGraphCredentialMetadata(ctx)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "list microsoft graph credential metadata")
+	}
+	return creds, nil
+}
+
+// ApplyMicrosoftGraphCredentials reconciles the stored credentials to match the supplied list. It is declarative: a
+// tenant absent from the list is deleted. Every credential that is new or whose values changed is verified against Graph
+// before anything is written, so a bad credential is rejected at write time instead of failing silently on the next
+// sync. Unchanged credentials are skipped entirely: re-applying an identical GitOps config makes no network call,
+// performs no write, and emits no activity.
+func (svc *Service) ApplyMicrosoftGraphCredentials(ctx context.Context, incoming []fleet.MicrosoftGraphCredential, dryRun bool) error {
+	if err := svc.authz.Authorize(ctx, &fleet.AppConfig{}, fleet.ActionWrite); err != nil {
+		return err
+	}
+
+	invalid := &fleet.InvalidArgumentError{}
+
+	var err error
+	var stored map[string]*fleet.MicrosoftGraphCredential
+	if len(incoming) > 0 {
+		// Read the stored credentials once.
+		if stored, err = svc.storedMicrosoftGraphCredentialsByTenant(ctx); err != nil {
+			return err
+		}
+	}
+
+	resolved, err := svc.resolveMicrosoftGraphCredentials(incoming, invalid, stored)
+	if err != nil {
+		return err
+	}
+	if !invalid.HasErrors() {
+		if err := svc.verifyMicrosoftGraphCredentials(ctx, resolved, invalid, stored); err != nil {
+			return err
+		}
+	}
+	if invalid.HasErrors() {
+		return ctxerr.Wrap(ctx, invalid)
+	}
+
+	if dryRun {
+		return nil
+	}
+
+	added, edited, deleted, err := svc.persistMicrosoftGraphCredentials(ctx, resolved, stored)
+	if err != nil {
+		return err
+	}
+
+	if len(added)+len(edited)+len(deleted) == 0 {
+		return nil
+	}
+
+	// A credential that was just verified is healthy, and a deleted one can no longer be unhealthy, so the aggregate is
+	// recomputed after a change.
+	if err := svc.refreshMicrosoftGraphCredentialInvalid(ctx); err != nil {
+		return err
+	}
+
+	for _, act := range newMicrosoftGraphCredentialActivities(added, edited, deleted) {
+		if err := svc.NewActivity(ctx, authz.UserFromContext(ctx), act); err != nil {
+			return ctxerr.Wrap(ctx, err, "create microsoft graph credential activity")
+		}
+	}
+
+	return nil
+}
+
+// refreshMicrosoftGraphCredentialInvalid recomputes MDM.MicrosoftGraphCredentialInvalid from the stored credentials
+// and saves the app config only when it actually changed. The flag is stored rather than derived on read so that GET /config does not
+// have to join the credentials table on every page load.
+func (svc *Service) refreshMicrosoftGraphCredentialInvalid(ctx context.Context) error {
+	// Callers reach this immediately after writing the credentials, so a replica read can miss the write.
+	ctx = ctxdb.RequirePrimary(ctx, true)
+	stored, err := svc.ds.ListMicrosoftGraphCredentialMetadata(ctx)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "list microsoft graph credential metadata")
+	}
+
+	var anyInvalid bool
+	for _, cred := range stored {
+		if cred.CredentialInvalid {
+			anyInvalid = true
+			break
+		}
+	}
+
+	appCfg, err := svc.ds.AppConfig(ctx)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "get app config")
+	}
+	if appCfg.MDM.MicrosoftGraphCredentialInvalid == anyInvalid {
+		return nil
+	}
+
+	appCfg.MDM.MicrosoftGraphCredentialInvalid = anyInvalid
+	if err := svc.ds.SaveAppConfig(ctx, appCfg); err != nil {
+		return ctxerr.Wrap(ctx, err, "save app config with microsoft graph credential status")
+	}
+	return nil
+}
+
+// resolveMicrosoftGraphCredentials validates the incoming credential list and returns it with every client secret
+// resolved to a usable value. Omitting the secret for an already-stored credential means "keep the stored secret"; the
+// standard masked placeholder is accepted as the same thing.
+//
+// Validation failures are accumulated on invalid rather than returned, so one bad entry does not mask another. The
+// returned slice only contains entries that validated.
+func (svc *Service) resolveMicrosoftGraphCredentials(
+	incoming []fleet.MicrosoftGraphCredential,
+	invalid *fleet.InvalidArgumentError,
+	storedByTenant map[string]*fleet.MicrosoftGraphCredential,
+) ([]fleet.MicrosoftGraphCredential, error) {
+	if len(incoming) == 0 {
+		return nil, nil
+	}
+
+	if len(incoming) > maxMicrosoftGraphCredentials {
+		invalid.Append("microsoft_graph_credentials",
+			fmt.Sprintf("Only %d Microsoft Graph credential can be configured.", maxMicrosoftGraphCredentials))
+		return nil, nil
+	}
+
+	seen := make(map[string]struct{}, len(incoming))
+	resolved := make([]fleet.MicrosoftGraphCredential, 0, len(incoming))
+
+	for _, cred := range incoming {
+		// Entra emits these lower-cased but admins paste them either way. Normalizing keeps the unique key on
+		// tenant_id meaningful and makes the stored-credential lookup below reliable.
+		cred.TenantID = strings.ToLower(strings.TrimSpace(cred.TenantID))
+		cred.ClientID = strings.ToLower(strings.TrimSpace(cred.ClientID))
+		cred.ClientSecret = strings.TrimSpace(cred.ClientSecret)
+
+		if !fleet.IsValidEntraGUID(cred.TenantID) {
+			invalid.Append("microsoft_graph_credentials.tenant_id", fmt.Sprintf("Invalid Entra tenant ID: %s", cred.TenantID))
+			continue
+		}
+		if !fleet.IsValidEntraGUID(cred.ClientID) {
+			invalid.Append("microsoft_graph_credentials.client_id", fmt.Sprintf("Invalid Entra client ID: %s", cred.ClientID))
+			continue
+		}
+		if _, dup := seen[cred.TenantID]; dup {
+			// Two credentials for one tenant would read an identical Autopilot list, because the registry is scoped to
+			// the tenant and not to the application.
+			invalid.Append("microsoft_graph_credentials.tenant_id",
+				fmt.Sprintf("Duplicate Entra tenant ID: %s. Only one credential per tenant is supported.", cred.TenantID))
+			continue
+		}
+		seen[cred.TenantID] = struct{}{}
+
+		if cred.ClientSecret == "" || cred.ClientSecret == fleet.MaskedPassword {
+			// The mask means "keep the secret for this credential", and a credential's identity is the app registration:
+			// tenant plus client.
+			existing, ok := storedByTenant[cred.TenantID]
+			if !ok || existing.ClientSecret == "" || !strings.EqualFold(existing.ClientID, cred.ClientID) {
+				invalid.Append("microsoft_graph_credentials.client_secret",
+					"client_secret must be provided when adding a Microsoft Graph credential or changing its tenant or client ID")
+				continue
+			}
+			cred.ClientSecret = existing.ClientSecret
+		} else if svc.config.Server.PrivateKey == "" {
+			invalid.Append("microsoft_graph_credentials",
+				"Missing required private key. Learn how to configure the private key here: https://fleetdm.com/learn-more-about/fleet-server-private-key")
+			continue
+		}
+
+		resolved = append(resolved, cred)
+	}
+
+	return resolved, nil
+}
+
+// verifyMicrosoftGraphCredentials mints a token and reads one page for every credential that is new or whose values
+// changed, so a bad credential is rejected at write time instead of failing silently on the next sync. Unchanged
+// credentials are skipped: re-applying an identical GitOps config should not make a network call.
+func (svc *Service) verifyMicrosoftGraphCredentials(
+	ctx context.Context,
+	creds []fleet.MicrosoftGraphCredential,
+	invalid *fleet.InvalidArgumentError,
+	storedByTenant map[string]*fleet.MicrosoftGraphCredential,
+) error {
+	for _, cred := range creds {
+		if existing, ok := storedByTenant[cred.TenantID]; ok && existing.Equal(cred) {
+			continue
+		}
+
+		client, err := svc.msGraphClientFactory(&cred)
+		if err != nil {
+			invalid.Append("microsoft_graph_credentials", fmt.Sprintf("Couldn't use Microsoft Graph credential: %s", err))
+			continue
+		}
+		if err := client.VerifyCredential(ctx); err != nil {
+			invalid.Append("microsoft_graph_credentials", microsoftGraphVerifyMessage(err))
+			continue
+		}
+	}
+
+	return nil
+}
+
+// microsoftGraphVerifyMessage turns a Graph failure into something an admin can act on. The three cases have genuinely
+// different remedies, and Graph reports a missing permission under different error codes depending on the endpoint
+// family, so the classification keys on the HTTP status rather than the code string.
+func microsoftGraphVerifyMessage(err error) string {
+	graphErr, ok := errors.AsType[*msgraph.Error](err)
+	if !ok {
+		return fmt.Sprintf("Couldn't connect to Microsoft Graph: %s", err)
+	}
+	switch {
+	case graphErr.IsPermissionError():
+		return "Microsoft Graph denied the request. Grant the app registration the DeviceManagementServiceConfig.Read.All " +
+			"application permission and grant admin consent for your tenant."
+	case graphErr.IsAuthError():
+		return "Microsoft Graph rejected the credential. Check the tenant ID, client ID, and client secret."
+	case graphErr.IsTransient():
+		return fmt.Sprintf("Microsoft Graph is temporarily unavailable (%d). Please try again.", graphErr.StatusCode)
+	default:
+		return fmt.Sprintf("Couldn't verify the Microsoft Graph credential: %s", graphErr)
+	}
+}
+
+// persistMicrosoftGraphCredentials reconciles stored credentials to match the supplied list, and reports which tenants
+// were added, edited, or deleted so the caller can emit one activity apiece.
+func (svc *Service) persistMicrosoftGraphCredentials(
+	ctx context.Context,
+	creds []fleet.MicrosoftGraphCredential,
+	storedByTenant map[string]*fleet.MicrosoftGraphCredential,
+) (added, edited, deleted []string, err error) {
+	storedTenants := make(map[string]struct{}, len(storedByTenant))
+	if storedByTenant != nil {
+		for tenantID := range storedByTenant {
+			storedTenants[tenantID] = struct{}{}
+		}
+	} else {
+		// The clear-everything path. We need to get what we need to delete.
+		storedMeta, err := svc.ds.ListMicrosoftGraphCredentialMetadata(ctx)
+		if err != nil {
+			return nil, nil, nil, ctxerr.Wrap(ctx, err, "list microsoft graph credential metadata")
+		}
+		for _, cred := range storedMeta {
+			storedTenants[strings.ToLower(cred.TenantID)] = struct{}{}
+		}
+	}
+
+	incomingByTenant := make(map[string]struct{}, len(creds))
+	var toUpsert []*fleet.MicrosoftGraphCredential
+	for _, cred := range creds {
+		incomingByTenant[cred.TenantID] = struct{}{}
+
+		existing, ok := storedByTenant[cred.TenantID]
+		switch {
+		case !ok:
+			added = append(added, cred.TenantID)
+		case existing.Equal(cred):
+			// Nothing changed: skip the write so re-applying an identical GitOps config emits no activity.
+			continue
+		default:
+			edited = append(edited, cred.TenantID)
+		}
+
+		toUpsert = append(toUpsert, &cred)
+	}
+
+	for tenantID := range storedTenants {
+		if _, ok := incomingByTenant[tenantID]; ok {
+			continue
+		}
+		deleted = append(deleted, tenantID)
+	}
+
+	if err := svc.ds.ReplaceMicrosoftGraphCredentials(ctx, toUpsert, deleted); err != nil {
+		return nil, nil, nil, ctxerr.Wrap(ctx, err, "replace microsoft graph credentials")
+	}
+
+	return added, edited, deleted, nil
+}
+
+func (svc *Service) storedMicrosoftGraphCredentialsByTenant(ctx context.Context) (map[string]*fleet.MicrosoftGraphCredential, error) {
+	stored, err := svc.ds.ListMicrosoftGraphCredentials(ctx)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "list microsoft graph credentials")
+	}
+	byTenant := make(map[string]*fleet.MicrosoftGraphCredential, len(stored))
+	for _, cred := range stored {
+		byTenant[strings.ToLower(cred.TenantID)] = cred
+	}
+	return byTenant, nil
+}
+
+// newMicrosoftGraphCredentialActivities builds the activities for one reconciliation pass.
+func newMicrosoftGraphCredentialActivities(added, edited, deleted []string) []fleet.ActivityDetails {
+	acts := make([]fleet.ActivityDetails, 0, len(added)+len(edited)+len(deleted))
+	for _, tenantID := range added {
+		acts = append(acts, fleet.ActivityTypeAddedMicrosoftGraphCredential{TenantID: tenantID})
+	}
+	for _, tenantID := range edited {
+		acts = append(acts, fleet.ActivityTypeEditedMicrosoftGraphCredential{TenantID: tenantID})
+	}
+	for _, tenantID := range deleted {
+		acts = append(acts, fleet.ActivityTypeDeletedMicrosoftGraphCredential{TenantID: tenantID})
+	}
+	return acts
+}

--- a/ee/server/service/microsoft_graph_credentials_test.go
+++ b/ee/server/service/microsoft_graph_credentials_test.go
@@ -9,9 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// The end-to-end behavior of the credential endpoints is covered in server/service, which builds the full core plus
-// premium stack. This covers the message classification directly, because it is unexported and the three cases have
-// genuinely different remedies for the admin.
 func TestMicrosoftGraphVerifyMessage(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {

--- a/ee/server/service/microsoft_graph_credentials_test.go
+++ b/ee/server/service/microsoft_graph_credentials_test.go
@@ -1,0 +1,31 @@
+package service
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/server/microsoft/msgraph"
+	"github.com/stretchr/testify/assert"
+)
+
+// The end-to-end behavior of the credential endpoints is covered in server/service, which builds the full core plus
+// premium stack. This covers the message classification directly, because it is unexported and the three cases have
+// genuinely different remedies for the admin.
+func TestMicrosoftGraphVerifyMessage(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name     string
+		err      error
+		contains string
+	}{
+		{"permission", &msgraph.Error{StatusCode: http.StatusForbidden}, "DeviceManagementServiceConfig.Read.All"},
+		{"auth", &msgraph.Error{StatusCode: http.StatusUnauthorized}, "rejected the credential"},
+		{"transient", &msgraph.Error{StatusCode: http.StatusBadGateway}, "temporarily unavailable"},
+		{"non-graph error", errors.New("dial tcp: timeout"), "Couldn't connect to Microsoft Graph"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Contains(t, microsoftGraphVerifyMessage(tc.err), tc.contains)
+		})
+	}
+}

--- a/ee/server/service/service.go
+++ b/ee/server/service/service.go
@@ -47,9 +47,7 @@ type Service struct {
 	digiCertService        fleet.DigiCertService
 	androidModule          android.Service
 	estService             fleet.ESTService
-
-	// msGraphClientFactory builds the Microsoft Graph client used to verify a credential when it is written.
-	msGraphClientFactory msgraph.ClientFactory
+	msGraphClientFactory   msgraph.ClientFactory
 }
 
 func NewService(

--- a/ee/server/service/service.go
+++ b/ee/server/service/service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/mdm/android"
 	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
 	"github.com/fleetdm/fleet/v4/server/mdm/nanodep/storage"
+	"github.com/fleetdm/fleet/v4/server/microsoft/msgraph"
 	"github.com/fleetdm/fleet/v4/server/sso"
 )
 
@@ -46,6 +47,9 @@ type Service struct {
 	digiCertService        fleet.DigiCertService
 	androidModule          android.Service
 	estService             fleet.ESTService
+
+	// msGraphClientFactory builds the Microsoft Graph client used to verify a credential when it is written.
+	msGraphClientFactory msgraph.ClientFactory
 }
 
 func NewService(
@@ -69,10 +73,16 @@ func NewService(
 	androidService android.Service,
 	estService fleet.ESTService,
 	pssoNonceStore fleet.PSSONonceStore,
+	msGraphClientFactory msgraph.ClientFactory,
 ) (*Service, error) {
 	authorizer, err := authz.NewAuthorizer()
 	if err != nil {
 		return nil, fmt.Errorf("new authorizer: %w", err)
+	}
+
+	// Default to the real Graph client.
+	if msGraphClientFactory == nil {
+		msGraphClientFactory = msgraph.NewClient
 	}
 
 	eeservice := &Service{
@@ -97,6 +107,7 @@ func NewService(
 		androidModule:          androidService,
 		estService:             estService,
 		pssoNonceStore:         pssoNonceStore,
+		msGraphClientFactory:   msGraphClientFactory,
 	}
 
 	// Override methods that can't be easily overriden via

--- a/server/fleet/microsoft_graph.go
+++ b/server/fleet/microsoft_graph.go
@@ -3,9 +3,21 @@ package fleet
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 )
+
+// entraGUIDRegex matches an Azure/Entra GUID in 8-4-4-4-12 form, case-insensitively. Entra emits IDs in lower case but
+// admins paste them either way, so the match is deliberately case-insensitive.
+var entraGUIDRegex = regexp.MustCompile("^[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$")
+
+// IsValidEntraGUID reports whether s is a well-formed Microsoft Entra identifier: a tenant ID, an application (client)
+// ID, or any other Entra object ID. It lives here rather than in a service package because both the core app config
+// validation and the premium Graph credential validation need it.
+func IsValidEntraGUID(s string) bool {
+	return entraGUIDRegex.MatchString(s)
+}
 
 // MicrosoftGraphCredential is the Entra app-registration credential Fleet authenticates with when calling Microsoft Graph.
 type MicrosoftGraphCredential struct {

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -1912,12 +1912,6 @@ func (svc *Service) HasCustomSetupAssistantConfigurationWebURL(ctx context.Conte
 	return ok, nil
 }
 
-// windowsEntraGUIDRegex matches an Azure/Entra GUID in 8-4-4-4-12 form, case-insensitively. Entra emits IDs in
-// lower-case, but admins may paste them in upper-case, so we accept either case here and normalize at comparison time
-// instead. We can't use the standard UUID parser here as it accepts non-standard forms; Entra tenant IDs and application
-// client IDs are both validated against this so the two checks cannot drift.
-var windowsEntraGUIDRegex = regexp.MustCompile("^[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$")
-
 // googleWorkspaceActivity returns the activity to record when the Google
 // Workspace IdP integration is added, edited, or removed, or nil when it is
 // unchanged. Only the (non-secret) domain is compared/recorded.
@@ -2321,12 +2315,12 @@ func (svc *Service) validateMDM(
 
 	// Validate Windows Entra tenant IDs and application client IDs are in the correct GUID format.
 	for _, tenantID := range mdm.WindowsEntraTenantIDs.Value {
-		if !windowsEntraGUIDRegex.MatchString(tenantID) {
+		if !fleet.IsValidEntraGUID(tenantID) {
 			invalid.Append("mdm.windows_entra_tenant_ids", fmt.Sprintf("Invalid Entra tenant ID: %s", tenantID))
 		}
 	}
 	for _, clientID := range mdm.WindowsEntraClientIDs.Value {
-		if !windowsEntraGUIDRegex.MatchString(clientID) {
+		if !fleet.IsValidEntraGUID(clientID) {
 			invalid.Append("mdm.windows_entra_client_ids", fmt.Sprintf("Invalid Entra client ID: %s", clientID))
 		}
 	}

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -634,7 +634,8 @@ func (c *Client) ApplyGroup(
 		}
 	}
 
-	if specs.MicrosoftGraphCredentials != nil {
+	// The endpoint is Premium only.
+	if specs.MicrosoftGraphCredentials != nil && appconfig != nil && appconfig.License != nil && appconfig.License.IsPremium() {
 		if err := c.ApplyMicrosoftGraphCredentials(*specs.MicrosoftGraphCredentials, opts.ApplySpecOptions.DryRun); err != nil {
 			// The server answers 402, which ParseResponse converts to client.ErrMissingLicense.
 			if errors.Is(err, client.ErrMissingLicense) && viaGitOps && filename != nil {

--- a/server/service/microsoft_graph_credentials.go
+++ b/server/service/microsoft_graph_credentials.go
@@ -2,21 +2,9 @@ package service
 
 import (
 	"context"
-	"errors"
-	"fmt"
-	"strings"
 
-	"github.com/fleetdm/fleet/v4/server/authz"
-	"github.com/fleetdm/fleet/v4/server/contexts/ctxdb"
-	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
-	"github.com/fleetdm/fleet/v4/server/contexts/license"
 	"github.com/fleetdm/fleet/v4/server/fleet"
-	"github.com/fleetdm/fleet/v4/server/microsoft/msgraph"
 )
-
-// maxMicrosoftGraphCredentials caps how many Graph credentials may be configured. Fleet's data model, sync loop, and
-// storage are all built for the multi-tenant case. We limit it now for initial rollout.
-const maxMicrosoftGraphCredentials = 1
 
 /////////////////////////////////////////////////////////////////////////////////
 // GET /microsoft_graph_credentials
@@ -37,22 +25,10 @@ func listMicrosoftGraphCredentialsEndpoint(ctx context.Context, _ any, svc fleet
 	return listMicrosoftGraphCredentialsResponse{MicrosoftGraphCredentials: creds}, nil
 }
 
-// ListMicrosoftGraphCredentials returns the stored credentials with their per-tenant sync status. Client secrets are
-// never decrypted on this path.
 func (svc *Service) ListMicrosoftGraphCredentials(ctx context.Context) ([]*fleet.MicrosoftGraphCredential, error) {
-	if err := svc.authz.Authorize(ctx, &fleet.AppConfig{}, fleet.ActionRead); err != nil {
-		return nil, err
-	}
-
-	if !license.IsPremium(ctx) {
-		return nil, fleet.ErrMissingLicense
-	}
-
-	creds, err := svc.ds.ListMicrosoftGraphCredentialMetadata(ctx)
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "list microsoft graph credential metadata")
-	}
-	return creds, nil
+	// skipauth: No authorization check needed due to implementation returning only license error.
+	svc.authz.SkipAuthorization(ctx)
+	return nil, fleet.ErrMissingLicense
 }
 
 /////////////////////////////////////////////////////////////////////////////////
@@ -78,305 +54,18 @@ func applyMicrosoftGraphCredentialsEndpoint(ctx context.Context, request any, sv
 	return applyMicrosoftGraphCredentialsResponse{}, nil
 }
 
-// ApplyMicrosoftGraphCredentials reconciles the stored credentials to match the supplied list. It is declarative: a
-// tenant absent from the list is deleted. Every credential that is new or whose values changed is verified against Graph
-// before anything is written, so a bad credential is rejected at write time instead of failing silently on the next
-// sync. Unchanged credentials are skipped entirely: re-applying an identical GitOps config makes no network call,
-// performs no write, and emits no activity.
-func (svc *Service) ApplyMicrosoftGraphCredentials(ctx context.Context, incoming []fleet.MicrosoftGraphCredential, dryRun bool) error {
+func (svc *Service) ApplyMicrosoftGraphCredentials(ctx context.Context, incoming []fleet.MicrosoftGraphCredential, _ bool) error {
 	if err := svc.authz.Authorize(ctx, &fleet.AppConfig{}, fleet.ActionWrite); err != nil {
 		return err
 	}
 
-	// Configuring a credential requires premium. Having none never does, which is why the guard is on the length.
-	if len(incoming) > 0 && !license.IsPremium(ctx) {
-		return fleet.ErrMissingLicense
-	}
-
-	invalid := &fleet.InvalidArgumentError{}
-
-	var err error
-	var stored map[string]*fleet.MicrosoftGraphCredential
-	if len(incoming) > 0 {
-		// Read the stored credentials once.
-		if stored, err = svc.storedMicrosoftGraphCredentialsByTenant(ctx); err != nil {
-			return err
-		}
-	}
-
-	resolved, err := svc.resolveMicrosoftGraphCredentials(incoming, invalid, stored)
-	if err != nil {
-		return err
-	}
-	if !invalid.HasErrors() {
-		if err := svc.verifyMicrosoftGraphCredentials(ctx, resolved, invalid, stored); err != nil {
-			return err
-		}
-	}
-	if invalid.HasErrors() {
-		return ctxerr.Wrap(ctx, invalid)
-	}
-
-	if dryRun {
-		return nil
-	}
-
-	added, edited, deleted, err := svc.persistMicrosoftGraphCredentials(ctx, resolved, stored)
-	if err != nil {
-		return err
-	}
-
-	if len(added)+len(edited)+len(deleted) == 0 {
-		return nil
-	}
-
-	// A credential that was just verified is healthy, and a deleted one can no longer be unhealthy, so the aggregate is
-	// recomputed after a change.
-	if err := svc.refreshMicrosoftGraphCredentialInvalid(ctx); err != nil {
-		return err
-	}
-
-	for _, act := range newMicrosoftGraphCredentialActivities(added, edited, deleted) {
-		if err := svc.NewActivity(ctx, authz.UserFromContext(ctx), act); err != nil {
-			return ctxerr.Wrap(ctx, err, "create microsoft graph credential activity")
-		}
-	}
-
-	return nil
-}
-
-// refreshMicrosoftGraphCredentialInvalid recomputes MDM.MicrosoftGraphCredentialInvalid from the stored credentials
-// and saves the app config only when it actually changed. The flag is stored rather than derived on read so that GET /config does not
-// have to join the credentials table on every page load.
-func (svc *Service) refreshMicrosoftGraphCredentialInvalid(ctx context.Context) error {
-	// Callers reach this immediately after writing the credentials, so a replica read can miss the write.
-	ctx = ctxdb.RequirePrimary(ctx, true)
-	stored, err := svc.ds.ListMicrosoftGraphCredentialMetadata(ctx)
-	if err != nil {
-		return ctxerr.Wrap(ctx, err, "list microsoft graph credential metadata")
-	}
-
-	var anyInvalid bool
-	for _, cred := range stored {
-		if cred.CredentialInvalid {
-			anyInvalid = true
-			break
-		}
-	}
-
-	appCfg, err := svc.ds.AppConfig(ctx)
-	if err != nil {
-		return ctxerr.Wrap(ctx, err, "get app config")
-	}
-	if appCfg.MDM.MicrosoftGraphCredentialInvalid == anyInvalid {
-		return nil
-	}
-
-	appCfg.MDM.MicrosoftGraphCredentialInvalid = anyInvalid
-	if err := svc.ds.SaveAppConfig(ctx, appCfg); err != nil {
-		return ctxerr.Wrap(ctx, err, "save app config with microsoft graph credential status")
-	}
-	return nil
-}
-
-// resolveMicrosoftGraphCredentials validates the incoming credential list and returns it with every client secret
-// resolved to a usable value. Omitting the secret for an already-stored credential means "keep the stored secret"; the
-// standard masked placeholder is accepted as the same thing.
-//
-// Validation failures are accumulated on invalid rather than returned, so one bad entry does not mask another. The
-// returned slice only contains entries that validated.
-func (svc *Service) resolveMicrosoftGraphCredentials(
-	incoming []fleet.MicrosoftGraphCredential,
-	invalid *fleet.InvalidArgumentError,
-	storedByTenant map[string]*fleet.MicrosoftGraphCredential,
-) ([]fleet.MicrosoftGraphCredential, error) {
+	// Configuring a credential requires premium. Having none never does, so an empty list is a no-op rather than a
+	// license error: GitOps reaches this endpoint on every run, sending an empty list whenever default.yml omits
+	// microsoft_graph_credentials, and a free-tier run that never configured Microsoft Graph must succeed. This mirrors
+	// BatchApplyCertificateAuthorities, which returns nil for an empty payload for the same reason.
 	if len(incoming) == 0 {
-		return nil, nil
+		return nil
 	}
 
-	if len(incoming) > maxMicrosoftGraphCredentials {
-		invalid.Append("microsoft_graph_credentials",
-			fmt.Sprintf("Only %d Microsoft Graph credential can be configured.", maxMicrosoftGraphCredentials))
-		return nil, nil
-	}
-
-	seen := make(map[string]struct{}, len(incoming))
-	resolved := make([]fleet.MicrosoftGraphCredential, 0, len(incoming))
-
-	for _, cred := range incoming {
-		// Entra emits these lower-cased but admins paste them either way. Normalizing keeps the unique key on
-		// tenant_id meaningful and makes the stored-credential lookup below reliable.
-		cred.TenantID = strings.ToLower(strings.TrimSpace(cred.TenantID))
-		cred.ClientID = strings.ToLower(strings.TrimSpace(cred.ClientID))
-		cred.ClientSecret = strings.TrimSpace(cred.ClientSecret)
-
-		if !windowsEntraGUIDRegex.MatchString(cred.TenantID) {
-			invalid.Append("microsoft_graph_credentials.tenant_id", fmt.Sprintf("Invalid Entra tenant ID: %s", cred.TenantID))
-			continue
-		}
-		if !windowsEntraGUIDRegex.MatchString(cred.ClientID) {
-			invalid.Append("microsoft_graph_credentials.client_id", fmt.Sprintf("Invalid Entra client ID: %s", cred.ClientID))
-			continue
-		}
-		if _, dup := seen[cred.TenantID]; dup {
-			// Two credentials for one tenant would read an identical Autopilot list, because the registry is scoped to
-			// the tenant and not to the application.
-			invalid.Append("microsoft_graph_credentials.tenant_id",
-				fmt.Sprintf("Duplicate Entra tenant ID: %s. Only one credential per tenant is supported.", cred.TenantID))
-			continue
-		}
-		seen[cred.TenantID] = struct{}{}
-
-		if cred.ClientSecret == "" || cred.ClientSecret == fleet.MaskedPassword {
-			// The mask means "keep the secret for this credential", and a credential's identity is the app registration:
-			// tenant plus client.
-			existing, ok := storedByTenant[cred.TenantID]
-			if !ok || existing.ClientSecret == "" || !strings.EqualFold(existing.ClientID, cred.ClientID) {
-				invalid.Append("microsoft_graph_credentials.client_secret",
-					"client_secret must be provided when adding a Microsoft Graph credential or changing its tenant or client ID")
-				continue
-			}
-			cred.ClientSecret = existing.ClientSecret
-		} else if svc.config.Server.PrivateKey == "" {
-			invalid.Append("microsoft_graph_credentials",
-				"Missing required private key. Learn how to configure the private key here: https://fleetdm.com/learn-more-about/fleet-server-private-key")
-			continue
-		}
-
-		resolved = append(resolved, cred)
-	}
-
-	return resolved, nil
-}
-
-// verifyMicrosoftGraphCredentials mints a token and reads one page for every credential that is new or whose values
-// changed, so a bad credential is rejected at write time instead of failing silently on the next sync. Unchanged
-// credentials are skipped: re-applying an identical GitOps config should not make a network call.
-func (svc *Service) verifyMicrosoftGraphCredentials(
-	ctx context.Context,
-	creds []fleet.MicrosoftGraphCredential,
-	invalid *fleet.InvalidArgumentError,
-	storedByTenant map[string]*fleet.MicrosoftGraphCredential,
-) error {
-	for _, cred := range creds {
-		if existing, ok := storedByTenant[cred.TenantID]; ok && existing.Equal(cred) {
-			continue
-		}
-
-		client, err := svc.msGraphClientFactory(&cred)
-		if err != nil {
-			invalid.Append("microsoft_graph_credentials", fmt.Sprintf("Couldn't use Microsoft Graph credential: %s", err))
-			continue
-		}
-		if err := client.VerifyCredential(ctx); err != nil {
-			invalid.Append("microsoft_graph_credentials", microsoftGraphVerifyMessage(err))
-			continue
-		}
-	}
-
-	return nil
-}
-
-// microsoftGraphVerifyMessage turns a Graph failure into something an admin can act on. The three cases have genuinely
-// different remedies, and Graph reports a missing permission under different error codes depending on the endpoint
-// family, so the classification keys on the HTTP status rather than the code string.
-func microsoftGraphVerifyMessage(err error) string {
-	graphErr, ok := errors.AsType[*msgraph.Error](err)
-	if !ok {
-		return fmt.Sprintf("Couldn't connect to Microsoft Graph: %s", err)
-	}
-	switch {
-	case graphErr.IsPermissionError():
-		return "Microsoft Graph denied the request. Grant the app registration the DeviceManagementServiceConfig.Read.All " +
-			"application permission and grant admin consent for your tenant."
-	case graphErr.IsAuthError():
-		return "Microsoft Graph rejected the credential. Check the tenant ID, client ID, and client secret."
-	case graphErr.IsTransient():
-		return fmt.Sprintf("Microsoft Graph is temporarily unavailable (%d). Please try again.", graphErr.StatusCode)
-	default:
-		return fmt.Sprintf("Couldn't verify the Microsoft Graph credential: %s", graphErr)
-	}
-}
-
-// persistMicrosoftGraphCredentials reconciles stored credentials to match the supplied list, and reports which tenants
-// were added, edited, or deleted so the caller can emit one activity apiece.
-func (svc *Service) persistMicrosoftGraphCredentials(
-	ctx context.Context,
-	creds []fleet.MicrosoftGraphCredential,
-	storedByTenant map[string]*fleet.MicrosoftGraphCredential,
-) (added, edited, deleted []string, err error) {
-	storedTenants := make(map[string]struct{}, len(storedByTenant))
-	if storedByTenant != nil {
-		for tenantID := range storedByTenant {
-			storedTenants[tenantID] = struct{}{}
-		}
-	} else {
-		// The clear-everything path. We need to get what we need to delete.
-		storedMeta, err := svc.ds.ListMicrosoftGraphCredentialMetadata(ctx)
-		if err != nil {
-			return nil, nil, nil, ctxerr.Wrap(ctx, err, "list microsoft graph credential metadata")
-		}
-		for _, cred := range storedMeta {
-			storedTenants[strings.ToLower(cred.TenantID)] = struct{}{}
-		}
-	}
-
-	incomingByTenant := make(map[string]struct{}, len(creds))
-	var toUpsert []*fleet.MicrosoftGraphCredential
-	for _, cred := range creds {
-		incomingByTenant[cred.TenantID] = struct{}{}
-
-		existing, ok := storedByTenant[cred.TenantID]
-		switch {
-		case !ok:
-			added = append(added, cred.TenantID)
-		case existing.Equal(cred):
-			// Nothing changed: skip the write so re-applying an identical GitOps config emits no activity.
-			continue
-		default:
-			edited = append(edited, cred.TenantID)
-		}
-
-		toUpsert = append(toUpsert, &cred)
-	}
-
-	for tenantID := range storedTenants {
-		if _, ok := incomingByTenant[tenantID]; ok {
-			continue
-		}
-		deleted = append(deleted, tenantID)
-	}
-
-	if err := svc.ds.ReplaceMicrosoftGraphCredentials(ctx, toUpsert, deleted); err != nil {
-		return nil, nil, nil, ctxerr.Wrap(ctx, err, "replace microsoft graph credentials")
-	}
-
-	return added, edited, deleted, nil
-}
-
-func (svc *Service) storedMicrosoftGraphCredentialsByTenant(ctx context.Context) (map[string]*fleet.MicrosoftGraphCredential, error) {
-	stored, err := svc.ds.ListMicrosoftGraphCredentials(ctx)
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "list microsoft graph credentials")
-	}
-	byTenant := make(map[string]*fleet.MicrosoftGraphCredential, len(stored))
-	for _, cred := range stored {
-		byTenant[strings.ToLower(cred.TenantID)] = cred
-	}
-	return byTenant, nil
-}
-
-// newMicrosoftGraphCredentialActivities builds the activities for one reconciliation pass.
-func newMicrosoftGraphCredentialActivities(added, edited, deleted []string) []fleet.ActivityDetails {
-	acts := make([]fleet.ActivityDetails, 0, len(added)+len(edited)+len(deleted))
-	for _, tenantID := range added {
-		acts = append(acts, fleet.ActivityTypeAddedMicrosoftGraphCredential{TenantID: tenantID})
-	}
-	for _, tenantID := range edited {
-		acts = append(acts, fleet.ActivityTypeEditedMicrosoftGraphCredential{TenantID: tenantID})
-	}
-	for _, tenantID := range deleted {
-		acts = append(acts, fleet.ActivityTypeDeletedMicrosoftGraphCredential{TenantID: tenantID})
-	}
-	return acts
+	return fleet.ErrMissingLicense
 }

--- a/server/service/microsoft_graph_credentials.go
+++ b/server/service/microsoft_graph_credentials.go
@@ -59,10 +59,7 @@ func (svc *Service) ApplyMicrosoftGraphCredentials(ctx context.Context, incoming
 		return err
 	}
 
-	// Configuring a credential requires premium. Having none never does, so an empty list is a no-op rather than a
-	// license error: GitOps reaches this endpoint on every run, sending an empty list whenever default.yml omits
-	// microsoft_graph_credentials, and a free-tier run that never configured Microsoft Graph must succeed. This mirrors
-	// BatchApplyCertificateAuthorities, which returns nil for an empty payload for the same reason.
+	// Configuring a credential requires premium. Having none never does, so an empty list is a no-op.
 	if len(incoming) == 0 {
 		return nil
 	}

--- a/server/service/microsoft_graph_credentials.go
+++ b/server/service/microsoft_graph_credentials.go
@@ -54,15 +54,8 @@ func applyMicrosoftGraphCredentialsEndpoint(ctx context.Context, request any, sv
 	return applyMicrosoftGraphCredentialsResponse{}, nil
 }
 
-func (svc *Service) ApplyMicrosoftGraphCredentials(ctx context.Context, incoming []fleet.MicrosoftGraphCredential, _ bool) error {
-	if err := svc.authz.Authorize(ctx, &fleet.AppConfig{}, fleet.ActionWrite); err != nil {
-		return err
-	}
-
-	// Configuring a credential requires premium. Having none never does, so an empty list is a no-op.
-	if len(incoming) == 0 {
-		return nil
-	}
-
+func (svc *Service) ApplyMicrosoftGraphCredentials(ctx context.Context, _ []fleet.MicrosoftGraphCredential, _ bool) error {
+	// skipauth: No authorization check needed due to implementation returning only license error.
+	svc.authz.SkipAuthorization(ctx)
 	return fleet.ErrMissingLicense
 }

--- a/server/service/microsoft_graph_credentials_test.go
+++ b/server/service/microsoft_graph_credentials_test.go
@@ -370,24 +370,6 @@ func TestListMicrosoftGraphCredentials(t *testing.T) {
 		"the read must not decrypt secrets it is about to mask")
 }
 
-func TestMicrosoftGraphVerifyMessage(t *testing.T) {
-	t.Parallel()
-	for _, tc := range []struct {
-		name     string
-		err      error
-		contains string
-	}{
-		{"permission", &msgraph.Error{StatusCode: http.StatusForbidden}, "DeviceManagementServiceConfig.Read.All"},
-		{"auth", &msgraph.Error{StatusCode: http.StatusUnauthorized}, "rejected the credential"},
-		{"transient", &msgraph.Error{StatusCode: http.StatusBadGateway}, "temporarily unavailable"},
-		{"non-graph error", errors.New("dial tcp: timeout"), "Couldn't connect to Microsoft Graph"},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Contains(t, microsoftGraphVerifyMessage(tc.err), tc.contains)
-		})
-	}
-}
-
 func TestMicrosoftGraphCredentialsAuth(t *testing.T) {
 	t.Parallel()
 	env := setupGraphCredsTest(t, fleet.TierPremium, "test-private-key", nil)

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -22,7 +22,6 @@ import (
 	nanodep_storage "github.com/fleetdm/fleet/v4/server/mdm/nanodep/storage"
 	nanomdm_push "github.com/fleetdm/fleet/v4/server/mdm/nanomdm/push"
 	nanomdm_storage "github.com/fleetdm/fleet/v4/server/mdm/nanomdm/storage"
-	"github.com/fleetdm/fleet/v4/server/microsoft/msgraph"
 	"github.com/fleetdm/fleet/v4/server/service/async"
 	"github.com/fleetdm/fleet/v4/server/service/conditional_access_microsoft_proxy"
 	"github.com/fleetdm/fleet/v4/server/sso"
@@ -80,9 +79,6 @@ type Service struct {
 
 	// activitySvc is the activity bounded context service for write operations.
 	activitySvc fleet.ActivityWriteService
-
-	// msGraphClientFactory builds the Microsoft Graph client used to verify a credential when it is written to the config.
-	msGraphClientFactory msgraph.ClientFactory
 
 	// acmeSvc is the ACME service module for write operations.
 	acmeSvc fleet.ACMEWriteService
@@ -164,16 +160,10 @@ func NewService(
 	keyValueStore fleet.KeyValueStore,
 	androidSvc android.Service,
 	orgLogoStore fleet.OrgLogoStore,
-	msGraphClientFactory msgraph.ClientFactory,
 ) (fleet.Service, error) {
 	authorizer, err := authz.NewAuthorizer()
 	if err != nil {
 		return nil, fmt.Errorf("new authorizer: %w", err)
-	}
-
-	// Default to the real Graph client.
-	if msGraphClientFactory == nil {
-		msGraphClientFactory = msgraph.NewClient
 	}
 
 	svc := &Service{
@@ -211,7 +201,6 @@ func NewService(
 		packConfigCache:                 gocache.New(1*time.Minute, 5*time.Minute),
 		androidSvc:                      androidSvc,
 		orgLogoStore:                    orgLogoStore,
-		msGraphClientFactory:            msGraphClientFactory,
 	}
 	return validationMiddleware{svc, ds, sso}, nil
 }

--- a/server/service/svctest/service.go
+++ b/server/service/svctest/service.go
@@ -227,7 +227,6 @@ func newTestServiceWithConfig(t *testing.T, ds fleet.Datastore, fleetConfig conf
 		keyValueStore,
 		androidService,
 		orgLogoStore,
-		msGraphClientFactory,
 	)
 	if err != nil {
 		panic(err)
@@ -269,6 +268,7 @@ func newTestServiceWithConfig(t *testing.T, ds fleet.Datastore, fleetConfig conf
 			androidModule,
 			estCAService,
 			nil, // PSSO nonce store; integration tests don't exercise PSSO
+			msGraphClientFactory,
 		)
 		if err != nil {
 			panic(err)

--- a/server/service/testing_utils_test.go
+++ b/server/service/testing_utils_test.go
@@ -308,7 +308,6 @@ func newTestServiceWithConfig(t *testing.T, ds fleet.Datastore, fleetConfig conf
 		keyValueStore,
 		androidService,
 		orgLogoStore,
-		msGraphClientFactory,
 	)
 	if err != nil {
 		panic(err)
@@ -350,6 +349,7 @@ func newTestServiceWithConfig(t *testing.T, ds fleet.Datastore, fleetConfig conf
 			androidModule,
 			estCAService,
 			pssoNonceStore,
+			msGraphClientFactory,
 		)
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #48849

Refactoring only. No functional changes.

# Checklist for submitter

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

* Added Microsoft Graph credential management for Premium services, including validation, verification, declarative updates, dry runs, deletion, and status tracking.
* Added validation for Microsoft Entra tenant and client identifiers.
* Added clearer guidance for authentication, permission, connection, and temporary service issues.

## Bug Fixes

* Preserved unchanged or masked secrets during credential updates and avoided unnecessary writes.
* Added safeguards against duplicate or invalid credential configurations.
* GitOps now validates Microsoft Graph credentials and reports Premium licensing requirements for non-Premium services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->