### PR TITLE
Fleet UI: Fix "Advanced options" not expanding for .msix packages

### DIFF
--- a/changes/45957-msix-advanced-options-reveal.md
+++ b/changes/45957-msix-advanced-options-reveal.md
@@ -1,0 +1,1 @@
+- Fixed the "Advanced options" reveal button on the Edit software modal not expanding for `.msix` packages (e.g., Claude, Slack on Windows), which prevented users from viewing or editing install/uninstall scripts.

--- a/frontend/interfaces/package_type.ts
+++ b/frontend/interfaces/package_type.ts
@@ -1,6 +1,6 @@
 const fleetMaintainedPackageTypes = ["dmg", "zip"] as const;
 const unixPackageTypes = ["pkg", "deb", "rpm", "dmg", "zip", "tar.gz"] as const;
-const windowsPackageTypes = ["msi", "exe", "zip"] as const;
+const windowsPackageTypes = ["msi", "msix", "exe", "zip"] as const;
 const scriptOnlyPackageTypes = ["sh", "ps1", "py"] as const;
 const iosIpadosPackageTypes = ["ipa"] as const;
 export const packageTypes = [

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/_styles.scss
@@ -27,6 +27,12 @@
     }
   }
 
+  &__advanced-options {
+    display: flex;
+    flex-direction: column;
+    gap: $pad-medium;
+  }
+
   &__advanced-options-section {
     display: flex;
     flex-direction: column;

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/_styles.scss
@@ -28,9 +28,7 @@
   }
 
   &__advanced-options {
-    display: flex;
-    flex-direction: column;
-    gap: $pad-medium;
+    @include flex-column-16px-gap;
     align-items: flex-start;
   }
 

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/_styles.scss
@@ -32,10 +32,6 @@
     align-items: flex-start;
   }
 
-  &__advanced-options-fields {
-    width: 100%;
-  }
-
   &__action-buttons {
     display: flex;
     flex-direction: row-reverse;

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/_styles.scss
@@ -31,6 +31,7 @@
     display: flex;
     flex-direction: column;
     gap: $pad-medium;
+    align-items: flex-start;
   }
 
   &__advanced-options-fields {

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/_styles.scss
@@ -33,13 +33,6 @@
     gap: $pad-medium;
   }
 
-  &__advanced-options-section {
-    display: flex;
-    flex-direction: column;
-    gap: $pad-large;
-    align-items: flex-start;
-  }
-
   &__advanced-options-fields {
     width: 100%;
   }

--- a/frontend/pages/SoftwarePage/components/forms/AdvancedOptionsFields/_styles.scss
+++ b/frontend/pages/SoftwarePage/components/forms/AdvancedOptionsFields/_styles.scss
@@ -1,5 +1,4 @@
 .advanced-options-fields {
-  display: flex;
-  flex-direction: column;
-  gap: $pad-medium;
+  @include flex-column-16px-gap;
+  width: 100%;
 }

--- a/frontend/pages/SoftwarePage/components/forms/PackageAdvancedOptions/PackageAdvancedOptions.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageAdvancedOptions/PackageAdvancedOptions.tsx
@@ -32,6 +32,7 @@ const PKG_TYPE_TO_ID_TEXT = {
   deb: "package name",
   rpm: "package name",
   msi: "product code",
+  msix: "product code or package family name",
   exe: "software name",
   zip: "software name",
   sh: "package name",

--- a/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tests.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tests.tsx
@@ -82,6 +82,27 @@ describe("PackageForm", () => {
     });
   });
 
+  describe("Advanced options section", () => {
+    it("reveals install/uninstall scripts when clicked for a .msix package", async () => {
+      renderForm({
+        isEditingSoftware: true,
+        defaultSoftware: createMockSoftwarePackage({ name: "Claude.msix" }),
+        defaultInstallScript: "Add-AppxProvisionedPackage -Online",
+        defaultUninstallScript: "Remove-AppxProvisionedPackage -Online",
+      });
+
+      // Scripts hidden until the reveal button is clicked.
+      expect(screen.queryByText("Install script")).not.toBeInTheDocument();
+
+      await userEvent.click(
+        screen.getByRole("button", { name: /Advanced options/i })
+      );
+
+      expect(screen.getByText("Install script")).toBeInTheDocument();
+      expect(screen.getByText("Uninstall script")).toBeInTheDocument();
+    });
+  });
+
   describe("Maximum package size", () => {
     afterEach(() => {
       jest.restoreAllMocks();


### PR DESCRIPTION
## Issue

Resolves #45957.

## Description

On the Edit software modal for `.msix` FMAs (Claude, Slack for Windows), clicking the "Advanced options" reveal button did nothing — no scripts, no caret change from the user's perspective. Root cause: `packageTypes` in `frontend/interfaces/package_type.ts` didn't include `"msix"`, so `isPackageType("msix")` returned `false` inside `PackageAdvancedOptions.renderAdvancedOptions()` and the function early-returned `null`. The reveal button *did* toggle state, but the child render short-circuited.

Fix:
- Added `"msix"` to `windowsPackageTypes` so `isPackageType("msix")` returns `true` and `isWindowsPackageType("msix")` gives the correct "PowerShell scripts are supported" copy.
- Added `msix: "product code or package family name"` to `PKG_TYPE_TO_ID_TEXT` for the uninstall help text — matches the winget ingester's fallback of `PackageFamilyName` when `ProductCode` is empty (`ee/maintained-apps/ingesters/winget/ingester.go:409`).

The comment on the null-return branch (`this should never happen`) is now correct for user-uploaded packages; msix is FMA-only.

## Screenrecording


https://github.com/user-attachments/assets/9dc1e893-dd8a-4d5c-bc5e-fd9789564b86

<img width="1165" height="492" alt="Screenshot 2026-08-12 at 10 55 53 AM" src="https://github.com/user-attachments/assets/6a4aecec-15ee-4f3b-96e4-aacf98b282a4" />


## Testing

- Added `PackageForm.tests.tsx` case: reveal button on a `.msix` package now shows Install/Uninstall script fields when clicked.
- All 7 PackageForm tests pass.

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Windows MSIX packages, including product code and package family name identification.
  * Added advanced options for MSIX package editing, with install and uninstall scripts available when expanded.

* **Style**
  * Improved layout and spacing for advanced package options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->