### PR TITLE
Bind fleet_id to the target report on schedule endpoints

### DIFF
--- a/changes/schedule-report-scope-binding
+++ b/changes/schedule-report-scope-binding
@@ -1,0 +1,1 @@
+* Fixed the fleet and global schedule endpoints accepting reports that belong to a different fleet, and made them return the same "not found" response for a report outside the caller's access as for one that doesn't exist.

--- a/server/authz/authz.go
+++ b/server/authz/authz.go
@@ -133,30 +133,30 @@ func (a *Authorizer) Authorize(ctx context.Context, object, action interface{}) 
 	return nil
 }
 
-// AuthorizeOrNotFound authorizes writeAction on writeObject. If that fails,
-// it also checks fleet.ActionRead on readObject; if the caller can't even
-// read it, notFoundErr is returned instead of the write failure, so a
-// resource entirely outside the caller's visibility is indistinguishable
-// from one that doesn't exist. If the caller CAN read it, or notFoundErr is
-// nil, the original write-authorization failure is returned unchanged: in
-// the first case no new information is disclosed by it (the caller already
-// knows the resource exists); in the second, masking would incorrectly
-// return nil (success) for a caller who was never authorized.
-func (a *Authorizer) AuthorizeOrNotFound(ctx context.Context, writeObject, writeAction, readObject any, notFoundErr error) error {
-	writeErr := a.Authorize(ctx, writeObject, writeAction)
-	if writeErr == nil {
+// AuthorizeOrNotFound authorizes action on object. If that fails, it also
+// checks fleet.ActionRead on the same object; if the caller can't even read
+// it, notFoundErr is returned instead of the original failure, so a resource
+// entirely outside the caller's visibility is indistinguishable from one that
+// doesn't exist. If the caller CAN read it, or notFoundErr is nil, the
+// original authorization failure is returned unchanged: in the first case no
+// new information is disclosed by it (the caller already knows the resource
+// exists); in the second, masking would incorrectly return nil (success) for
+// a caller who was never authorized.
+func (a *Authorizer) AuthorizeOrNotFound(ctx context.Context, object, action any, notFoundErr error) error {
+	actionErr := a.Authorize(ctx, object, action)
+	if actionErr == nil {
 		return nil
 	}
 
-	if readErr := a.Authorize(ctx, readObject, fleet.ActionRead); readErr == nil || notFoundErr == nil {
-		return writeErr
+	if readErr := a.Authorize(ctx, object, fleet.ActionRead); readErr == nil || notFoundErr == nil {
+		return actionErr
 	}
 
 	// The caller can't read this resource either: report notFoundErr instead
-	// of writeErr, so its existence isn't disclosed. Still record the real
+	// of actionErr, so its existence isn't disclosed. Still record the real
 	// cause for observability, so a systemic authz/policy failure isn't
 	// silently reported as "not found" for every caller.
-	ctxerr.Handle(ctx, writeErr)
+	ctxerr.Handle(ctx, actionErr)
 	return notFoundErr
 }
 

--- a/server/authz/authz_test.go
+++ b/server/authz/authz_test.go
@@ -15,7 +15,7 @@ func TestAuthorizeOrNotFound(t *testing.T) {
 
 	t.Run("write allowed", func(t *testing.T) {
 		ctx := test.UserContext(t.Context(), &fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 1}, Role: fleet.RoleAdmin}}})
-		err := auth.AuthorizeOrNotFound(ctx, teamHost, fleet.ActionWrite, teamHost, notFoundErr)
+		err := auth.AuthorizeOrNotFound(ctx, teamHost, fleet.ActionWrite, notFoundErr)
 		require.NoError(t, err)
 	})
 
@@ -24,7 +24,7 @@ func TestAuthorizeOrNotFound(t *testing.T) {
 		// an existence oracle (the caller already knows the host exists), so
 		// the real Forbidden should surface, not notFoundErr.
 		ctx := test.UserContext(t.Context(), &fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 1}, Role: fleet.RoleObserver}}})
-		err := auth.AuthorizeOrNotFound(ctx, teamHost, fleet.ActionWrite, teamHost, notFoundErr)
+		err := auth.AuthorizeOrNotFound(ctx, teamHost, fleet.ActionWrite, notFoundErr)
 		require.Error(t, err)
 		require.NotErrorIs(t, err, notFoundErr)
 		var forbidden *Forbidden
@@ -36,7 +36,7 @@ func TestAuthorizeOrNotFound(t *testing.T) {
 		// write it: masking as notFoundErr prevents them from learning the
 		// host exists on some other team via a distinguishable Forbidden.
 		ctx := test.UserContext(t.Context(), &fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 2}, Role: fleet.RoleObserver}}})
-		err := auth.AuthorizeOrNotFound(ctx, teamHost, fleet.ActionWrite, teamHost, notFoundErr)
+		err := auth.AuthorizeOrNotFound(ctx, teamHost, fleet.ActionWrite, notFoundErr)
 		require.Error(t, err)
 		require.ErrorIs(t, err, notFoundErr)
 	})
@@ -46,7 +46,7 @@ func TestAuthorizeOrNotFound(t *testing.T) {
 		// never get nil (success) back for a caller who can neither read nor
 		// write the resource: that would silently bypass authorization.
 		ctx := test.UserContext(t.Context(), &fleet.User{Teams: []fleet.UserTeam{{Team: fleet.Team{ID: 2}, Role: fleet.RoleObserver}}})
-		err := auth.AuthorizeOrNotFound(ctx, teamHost, fleet.ActionWrite, teamHost, nil)
+		err := auth.AuthorizeOrNotFound(ctx, teamHost, fleet.ActionWrite, nil)
 		require.Error(t, err)
 		var forbidden *Forbidden
 		require.ErrorAs(t, err, &forbidden)

--- a/server/service/global_schedule.go
+++ b/server/service/global_schedule.go
@@ -134,10 +134,11 @@ func modifyGlobalScheduleEndpoint(ctx context.Context, request interface{}, svc 
 }
 
 func (svc *Service) ModifyGlobalScheduledQueries(ctx context.Context, id uint, scheduledQueryPayload fleet.ScheduledQueryPayload) (*fleet.ScheduledQuery, error) {
-	if _, err := svc.scheduledQueryInScope(ctx, id, nil); err != nil {
+	scoped, err := svc.scheduledQueryInScope(ctx, id, nil)
+	if err != nil {
 		return nil, err
 	}
-	query, err := svc.ModifyQuery(ctx, id, fleet.ScheduledQueryPayloadToQueryPayloadForModifyQuery(scheduledQueryPayload))
+	query, err := svc.modifyLoadedQuery(ctx, scoped, fleet.ScheduledQueryPayloadToQueryPayloadForModifyQuery(scheduledQueryPayload))
 	if err != nil {
 		return nil, err
 	}
@@ -169,8 +170,9 @@ func deleteGlobalScheduleEndpoint(ctx context.Context, request interface{}, svc 
 }
 
 func (svc *Service) DeleteGlobalScheduledQueries(ctx context.Context, id uint) error {
-	if _, err := svc.scheduledQueryInScope(ctx, id, nil); err != nil {
+	scoped, err := svc.scheduledQueryInScope(ctx, id, nil)
+	if err != nil {
 		return err
 	}
-	return svc.DeleteQueryByID(ctx, id)
+	return svc.deleteLoadedQuery(ctx, scoped)
 }

--- a/server/service/global_schedule.go
+++ b/server/service/global_schedule.go
@@ -88,14 +88,13 @@ func globalScheduleQueryEndpoint(ctx context.Context, request interface{}, svc f
 }
 
 func (svc *Service) GlobalScheduleQuery(ctx context.Context, scheduledQuery *fleet.ScheduledQuery) (*fleet.ScheduledQuery, error) {
-	originalQuery, err := svc.ds.Query(ctx, scheduledQuery.QueryID)
-	if err != nil {
-		setAuthCheckedOnPreAuthErr(ctx)
-		return nil, ctxerr.Wrap(ctx, err, "get query")
+	// Authorize before loading the source report; see TeamScheduleQuery.
+	if err := svc.authz.Authorize(ctx, fleet.Query{}, fleet.ActionWrite); err != nil {
+		return nil, err
 	}
-	if originalQuery.TeamID != nil {
-		setAuthCheckedOnPreAuthErr(ctx)
-		return nil, ctxerr.New(ctx, "cannot create a global schedule from a team query")
+	originalQuery, err := svc.scheduledQueryInScope(ctx, scheduledQuery.QueryID, nil)
+	if err != nil {
+		return nil, err
 	}
 	originalQuery.Name = nameForCopiedQuery(originalQuery.Name)
 	newQuery, err := svc.NewQuery(ctx, fleet.ScheduledQueryToQueryPayloadForNewQuery(originalQuery, scheduledQuery))
@@ -135,6 +134,9 @@ func modifyGlobalScheduleEndpoint(ctx context.Context, request interface{}, svc 
 }
 
 func (svc *Service) ModifyGlobalScheduledQueries(ctx context.Context, id uint, scheduledQueryPayload fleet.ScheduledQueryPayload) (*fleet.ScheduledQuery, error) {
+	if _, err := svc.scheduledQueryInScope(ctx, id, nil); err != nil {
+		return nil, err
+	}
 	query, err := svc.ModifyQuery(ctx, id, fleet.ScheduledQueryPayloadToQueryPayloadForModifyQuery(scheduledQueryPayload))
 	if err != nil {
 		return nil, err
@@ -167,5 +169,8 @@ func deleteGlobalScheduleEndpoint(ctx context.Context, request interface{}, svc 
 }
 
 func (svc *Service) DeleteGlobalScheduledQueries(ctx context.Context, id uint) error {
+	if _, err := svc.scheduledQueryInScope(ctx, id, nil); err != nil {
+		return err
+	}
 	return svc.DeleteQueryByID(ctx, id)
 }

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -919,7 +919,7 @@ func (svc *Service) checkWriteForHostIDs(ctx context.Context, ids []uint) error 
 		}
 
 		notFoundErr := ctxerr.Wrap(ctx, common_mysql.NotFound("Host").WithID(id), "get host for delete")
-		if err := svc.authz.AuthorizeOrNotFound(ctx, host, fleet.ActionWrite, host, notFoundErr); err != nil {
+		if err := svc.authz.AuthorizeOrNotFound(ctx, host, fleet.ActionWrite, notFoundErr); err != nil {
 			return err
 		}
 	}
@@ -1146,7 +1146,7 @@ func (svc *Service) DeleteHost(ctx context.Context, id uint) error {
 	// rather than a forbidden that would confirm the host exists on some
 	// other team.
 	notFoundErr := ctxerr.Wrap(ctx, common_mysql.NotFound("Host").WithID(id), "get host for delete")
-	if err := svc.authz.AuthorizeOrNotFound(ctx, host, fleet.ActionWrite, host, notFoundErr); err != nil {
+	if err := svc.authz.AuthorizeOrNotFound(ctx, host, fleet.ActionWrite, notFoundErr); err != nil {
 		return err
 	}
 

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -8184,16 +8184,19 @@ func (s *integrationEnterpriseTestSuite) TestGitOpsUserActions() {
 	// Attempt to delete own query, should allow.
 	s.DoJSON("DELETE", fmt.Sprintf("/api/latest/fleet/queries/id/%d", tcqr.Query.ID), fleet.DeleteQueryByIDRequest{}, http.StatusOK, &fleet.DeleteQueryByIDResponse{})
 
-	// Attempt to edit query created by somebody else, should fail.
+	// Attempt to edit query created by somebody else, should fail. A team
+	// GitOps user can't read global queries either (unlike every other team
+	// role), so this reports not-found rather than forbidden: a forbidden
+	// would confirm the global query exists to a caller with no view of it.
 	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/queries/%d", cqr4.Query.ID), fleet.ModifyQueryRequest{
 		QueryPayload: fleet.QueryPayload{
 			Name:  new("foo4"),
 			Query: new("SELECT * FROM system_info;"),
 		},
-	}, http.StatusForbidden, &fleet.ModifyQueryResponse{})
+	}, http.StatusNotFound, &fleet.ModifyQueryResponse{})
 
 	// Attempt to delete query created by somebody else, should fail.
-	s.DoJSON("DELETE", fmt.Sprintf("/api/latest/fleet/queries/id/%d", cqr4.Query.ID), fleet.DeleteQueryByIDRequest{}, http.StatusForbidden, &fleet.DeleteQueryByIDResponse{})
+	s.DoJSON("DELETE", fmt.Sprintf("/api/latest/fleet/queries/id/%d", cqr4.Query.ID), fleet.DeleteQueryByIDRequest{}, http.StatusNotFound, &fleet.DeleteQueryByIDResponse{})
 
 	// Attempt to read the global schedule, should fail.
 	s.DoJSON("GET", "/api/latest/fleet/schedule", nil, http.StatusForbidden, &getGlobalScheduleResponse{})

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -23474,8 +23474,12 @@ func (s *integrationMDMTestSuite) TestTechnicianPermissions() {
 		},
 	}, http.StatusForbidden, &ttsqr)
 
-	// Attempt to remove a query from the team's schedule, should fail.
-	s.DoJSON("DELETE", fmt.Sprintf("/api/latest/fleet/teams/%d/schedule/%d", t1.ID, q1.ID), deleteTeamScheduleRequest{}, http.StatusForbidden, &deleteTeamScheduleResponse{})
+	// Attempt to remove a query from the team's schedule, should fail. q1 is a
+	// global query, so it is not in t1's schedule at all: the fleet_id in the
+	// path no longer matches the report, and the response is the same
+	// not-found a nonexistent report would get rather than a forbidden that
+	// would confirm the report exists outside this fleet.
+	s.DoJSON("DELETE", fmt.Sprintf("/api/latest/fleet/teams/%d/schedule/%d", t1.ID, q1.ID), deleteTeamScheduleRequest{}, http.StatusNotFound, &deleteTeamScheduleResponse{})
 
 	// Attempt to add/remove a manual label from a team host, should allow.
 	s.DoJSON("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/labels", team1Host.ID), addLabelsToHostRequest{

--- a/server/service/queries.go
+++ b/server/service/queries.go
@@ -12,6 +12,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/contexts/logging"
 	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	common_mysql "github.com/fleetdm/fleet/v4/server/platform/mysql"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 )
 
@@ -371,7 +372,9 @@ func (svc *Service) ModifyQuery(ctx context.Context, id uint, p fleet.QueryPaylo
 		setAuthCheckedOnPreAuthErr(ctx)
 		return nil, err
 	}
-	if err := svc.authz.Authorize(ctx, query, fleet.ActionWrite); err != nil {
+	
+	notFoundErr := ctxerr.Wrap(ctx, common_mysql.NotFound("Report").WithID(id), "get query to modify")
+	if err := svc.authz.AuthorizeOrNotFound(ctx, query, fleet.ActionWrite, notFoundErr); err != nil {
 		return nil, err
 	}
 
@@ -537,7 +540,8 @@ func (svc *Service) DeleteQuery(ctx context.Context, teamID *uint, name string) 
 		setAuthCheckedOnPreAuthErr(ctx)
 		return err
 	}
-	if err := svc.authz.Authorize(ctx, query, fleet.ActionWrite); err != nil {
+	notFoundErr := ctxerr.Wrap(ctx, common_mysql.NotFound("Report").WithName(name), "get query to delete")
+	if err := svc.authz.AuthorizeOrNotFound(ctx, query, fleet.ActionWrite, notFoundErr); err != nil {
 		return err
 	}
 
@@ -605,7 +609,8 @@ func (svc *Service) DeleteQueryByID(ctx context.Context, id uint) error {
 		setAuthCheckedOnPreAuthErr(ctx)
 		return ctxerr.Wrap(ctx, err, "lookup query by ID")
 	}
-	if err := svc.authz.Authorize(ctx, query, fleet.ActionWrite); err != nil {
+	notFoundErr := ctxerr.Wrap(ctx, common_mysql.NotFound("Report").WithID(id), "lookup query by ID")
+	if err := svc.authz.AuthorizeOrNotFound(ctx, query, fleet.ActionWrite, notFoundErr); err != nil {
 		return err
 	}
 
@@ -675,7 +680,8 @@ func (svc *Service) DeleteQueries(ctx context.Context, ids []uint) (uint, error)
 			setAuthCheckedOnPreAuthErr(ctx)
 			return 0, ctxerr.Wrap(ctx, err, "lookup query by ID")
 		}
-		if err := svc.authz.Authorize(ctx, query, fleet.ActionWrite); err != nil {
+		notFoundErr := ctxerr.Wrap(ctx, common_mysql.NotFound("Report").WithID(id), "lookup query by ID")
+		if err := svc.authz.AuthorizeOrNotFound(ctx, query, fleet.ActionWrite, notFoundErr); err != nil {
 			return 0, err
 		}
 

--- a/server/service/queries.go
+++ b/server/service/queries.go
@@ -372,8 +372,13 @@ func (svc *Service) ModifyQuery(ctx context.Context, id uint, p fleet.QueryPaylo
 		setAuthCheckedOnPreAuthErr(ctx)
 		return nil, err
 	}
-	
-	notFoundErr := ctxerr.Wrap(ctx, common_mysql.NotFound("Report").WithID(id), "get query to modify")
+	return svc.modifyLoadedQuery(ctx, query, p)
+}
+
+// modifyLoadedQuery is ModifyQuery for callers that already hold the query,
+// so the schedule endpoints don't load it a second time to scope-check it.
+func (svc *Service) modifyLoadedQuery(ctx context.Context, query *fleet.Query, p fleet.QueryPayload) (*fleet.Query, error) {
+	notFoundErr := ctxerr.Wrap(ctx, common_mysql.NotFound("Report").WithID(query.ID), "get query to modify")
 	if err := svc.authz.AuthorizeOrNotFound(ctx, query, fleet.ActionWrite, notFoundErr); err != nil {
 		return nil, err
 	}
@@ -464,8 +469,7 @@ func (svc *Service) ModifyQuery(ctx context.Context, id uint, p fleet.QueryPaylo
 	// If the query was modified in a way that requires discarding results,
 	// reset the Redis count as well.
 	if shouldDiscardQueryResults && svc.liveQueryStore != nil {
-		err = svc.liveQueryStore.SetQueryResultsCount(query.ID, 0)
-		if err != nil {
+		if err := svc.liveQueryStore.SetQueryResultsCount(query.ID, 0); err != nil {
 			// Log the error but don't fail the request; this will get cleaned up
 			// in the "query_results_cleanup" job.
 			svc.logger.ErrorContext(ctx, "failed to set query results count", "err", err, "query_id", query.ID)
@@ -551,7 +555,7 @@ func (svc *Service) DeleteQuery(ctx context.Context, teamID *uint, name string) 
 
 	// Delete the Redis counter for query results
 	if svc.liveQueryStore != nil {
-		if err = svc.liveQueryStore.DeleteQueryResultsCount(query.ID); err != nil {
+		if err := svc.liveQueryStore.DeleteQueryResultsCount(query.ID); err != nil {
 			// Log the error but don't fail the request; this will get cleaned up
 			// in the "query_results_cleanup" job.
 			svc.logger.ErrorContext(ctx, "failed to delete query results count", "err", err, "query_id", query.ID)
@@ -609,7 +613,13 @@ func (svc *Service) DeleteQueryByID(ctx context.Context, id uint) error {
 		setAuthCheckedOnPreAuthErr(ctx)
 		return ctxerr.Wrap(ctx, err, "lookup query by ID")
 	}
-	notFoundErr := ctxerr.Wrap(ctx, common_mysql.NotFound("Report").WithID(id), "lookup query by ID")
+	return svc.deleteLoadedQuery(ctx, query)
+}
+
+// deleteLoadedQuery is DeleteQueryByID for callers that already hold the
+// query, so the schedule endpoints don't load it a second time.
+func (svc *Service) deleteLoadedQuery(ctx context.Context, query *fleet.Query) error {
+	notFoundErr := ctxerr.Wrap(ctx, common_mysql.NotFound("Report").WithID(query.ID), "lookup query by ID")
 	if err := svc.authz.AuthorizeOrNotFound(ctx, query, fleet.ActionWrite, notFoundErr); err != nil {
 		return err
 	}
@@ -620,7 +630,7 @@ func (svc *Service) DeleteQueryByID(ctx context.Context, id uint) error {
 
 	// Delete the Redis counter for query results
 	if svc.liveQueryStore != nil {
-		if err = svc.liveQueryStore.DeleteQueryResultsCount(query.ID); err != nil {
+		if err := svc.liveQueryStore.DeleteQueryResultsCount(query.ID); err != nil {
 			// Log the error but don't fail the request; this will get cleaned up
 			// in the "query_results_cleanup" job.
 			svc.logger.ErrorContext(ctx, "failed to delete query results count", "err", err, "query_id", query.ID)

--- a/server/service/queries_test.go
+++ b/server/service/queries_test.go
@@ -441,6 +441,22 @@ func TestQueryPayloadValidationModify(t *testing.T) {
 	}
 }
 
+// checkQueryWriteAuthErr asserts the result of a query-mutation authorization
+// check. A caller with no read visibility into the query at all must see a
+// NotFound (masking existence), not a Forbidden that would confirm the query
+// exists on some other team; a caller who CAN read the query (e.g. same-team
+// observer) still gets the normal Forbidden, since no new information is
+// disclosed by it.
+func checkQueryWriteAuthErr(t *testing.T, shouldFailWrite, shouldFailRead bool, err error) {
+	t.Helper()
+	if shouldFailWrite && shouldFailRead {
+		require.Error(t, err)
+		assert.True(t, fleet.IsNotFound(err), "expected a not-found error, got: %v", err)
+		return
+	}
+	checkAuthErr(t, shouldFailWrite, err)
+}
+
 func TestQueryAuth(t *testing.T) {
 	ds := new(mock.Store)
 	svc, ctx := newTestService(t, ds, nil, nil)
@@ -808,16 +824,16 @@ func TestQueryAuth(t *testing.T) {
 			checkAuthErr(t, tt.shouldFailNew, err)
 
 			_, err = svc.ModifyQuery(ctx, tt.qid, fleet.QueryPayload{})
-			checkAuthErr(t, tt.shouldFailWrite, err)
+			checkQueryWriteAuthErr(t, tt.shouldFailWrite, tt.shouldFailRead, err)
 
 			err = svc.DeleteQuery(ctx, query.TeamID, query.Name)
-			checkAuthErr(t, tt.shouldFailWrite, err)
+			checkQueryWriteAuthErr(t, tt.shouldFailWrite, tt.shouldFailRead, err)
 
 			err = svc.DeleteQueryByID(ctx, tt.qid)
-			checkAuthErr(t, tt.shouldFailWrite, err)
+			checkQueryWriteAuthErr(t, tt.shouldFailWrite, tt.shouldFailRead, err)
 
 			_, err = svc.DeleteQueries(ctx, []uint{tt.qid})
-			checkAuthErr(t, tt.shouldFailWrite, err)
+			checkQueryWriteAuthErr(t, tt.shouldFailWrite, tt.shouldFailRead, err)
 
 			_, err = svc.GetQuery(ctx, tt.qid)
 			checkAuthErr(t, tt.shouldFailRead, err)

--- a/server/service/team_schedule.go
+++ b/server/service/team_schedule.go
@@ -186,10 +186,11 @@ func (svc Service) ModifyTeamScheduledQueries(
 	scheduledQueryID uint,
 	scheduledQueryPayload fleet.ScheduledQueryPayload,
 ) (*fleet.ScheduledQuery, error) {
-	if _, err := svc.scheduledQueryInScope(ctx, scheduledQueryID, teamIDOrNilForGlobal(teamID)); err != nil {
+	scoped, err := svc.scheduledQueryInScope(ctx, scheduledQueryID, teamIDOrNilForGlobal(teamID))
+	if err != nil {
 		return nil, err
 	}
-	query, err := svc.ModifyQuery(ctx, scheduledQueryID, fleet.ScheduledQueryPayloadToQueryPayloadForModifyQuery(scheduledQueryPayload))
+	query, err := svc.modifyLoadedQuery(ctx, scoped, fleet.ScheduledQueryPayloadToQueryPayloadForModifyQuery(scheduledQueryPayload))
 	if err != nil {
 		return nil, err
 	}
@@ -222,8 +223,9 @@ func deleteTeamScheduleEndpoint(ctx context.Context, request interface{}, svc fl
 }
 
 func (svc Service) DeleteTeamScheduledQueries(ctx context.Context, teamID uint, scheduledQueryID uint) error {
-	if _, err := svc.scheduledQueryInScope(ctx, scheduledQueryID, teamIDOrNilForGlobal(teamID)); err != nil {
+	scoped, err := svc.scheduledQueryInScope(ctx, scheduledQueryID, teamIDOrNilForGlobal(teamID))
+	if err != nil {
 		return err
 	}
-	return svc.DeleteQueryByID(ctx, scheduledQueryID)
+	return svc.deleteLoadedQuery(ctx, scoped)
 }

--- a/server/service/team_schedule.go
+++ b/server/service/team_schedule.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	common_mysql "github.com/fleetdm/fleet/v4/server/platform/mysql"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"gopkg.in/guregu/null.v3"
 )
@@ -42,12 +43,16 @@ func getTeamScheduleEndpoint(ctx context.Context, request interface{}, svc fleet
 	return resp, nil
 }
 
-func (svc Service) GetTeamScheduledQueries(ctx context.Context, teamID uint, opts fleet.ListOptions) ([]*fleet.ScheduledQuery, error) {
-	var teamID_ *uint
-	if teamID != 0 {
-		teamID_ = &teamID
+// The team schedule routes spell the global schedule as fleet_id 0.
+func teamIDOrNilForGlobal(teamID uint) *uint {
+	if teamID == 0 {
+		return nil
 	}
-	queries, _, _, _, err := svc.ListQueries(ctx, opts, teamID_, ptr.Bool(true), false, nil)
+	return &teamID
+}
+
+func (svc Service) GetTeamScheduledQueries(ctx context.Context, teamID uint, opts fleet.ListOptions) ([]*fleet.ScheduledQuery, error) {
+	queries, _, _, _, err := svc.ListQueries(ctx, opts, teamIDOrNilForGlobal(teamID), new(true), false, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -111,15 +116,35 @@ func nameForCopiedQuery(originalName string) string {
 	return "Copy of " + originalName + " (" + fmt.Sprintf("%d", time.Now().Unix()) + ")"
 }
 
-func (svc Service) TeamScheduleQuery(ctx context.Context, teamID uint, scheduledQuery *fleet.ScheduledQuery) (*fleet.ScheduledQuery, error) {
-	originalQuery, err := svc.ds.Query(ctx, scheduledQuery.QueryID)
+// scheduledQueryInScope loads scheduledQueryID and rejects it unless it
+// belongs to teamID (nil for the global schedule). The schedule endpoints
+// carry their scope in the URL path but address the report by a globally
+// unique ID, so without this the path scope is decorative: a report can be
+// reached through any schedule's URL. A mismatch returns the same not-found
+// error as a report that doesn't exist, so probing can't distinguish the two.
+func (svc Service) scheduledQueryInScope(ctx context.Context, scheduledQueryID uint, teamID *uint) (*fleet.Query, error) {
+	query, err := svc.ds.Query(ctx, scheduledQueryID)
 	if err != nil {
 		setAuthCheckedOnPreAuthErr(ctx)
-		return nil, ctxerr.Wrap(ctx, err, "get query from id")
+		return nil, ctxerr.Wrap(ctx, err, "get scheduled query")
 	}
-	if originalQuery.TeamID != nil {
+	if !ptr.Equal(query.TeamID, teamID) {
 		setAuthCheckedOnPreAuthErr(ctx)
-		return nil, ctxerr.New(ctx, "cannot create a team schedule from a team query")
+		return nil, ctxerr.Wrap(ctx, common_mysql.NotFound("Report").WithID(scheduledQueryID), "get scheduled query")
+	}
+	return query, nil
+}
+
+func (svc Service) TeamScheduleQuery(ctx context.Context, teamID uint, scheduledQuery *fleet.ScheduledQuery) (*fleet.ScheduledQuery, error) {
+	// Authorize before loading the source report, so a caller who can't create
+	// anything here learns nothing about which source IDs exist.
+	if err := svc.authz.Authorize(ctx, fleet.Query{TeamID: &teamID}, fleet.ActionWrite); err != nil {
+		return nil, err
+	}
+	// nil scope: only a global report may be used as the source.
+	originalQuery, err := svc.scheduledQueryInScope(ctx, scheduledQuery.QueryID, nil)
+	if err != nil {
+		return nil, err
 	}
 	originalQuery.Name = nameForCopiedQuery(originalQuery.Name)
 	originalQuery.TeamID = &teamID
@@ -155,13 +180,15 @@ func modifyTeamScheduleEndpoint(ctx context.Context, request interface{}, svc fl
 	return modifyTeamScheduleResponse{}, nil
 }
 
-// teamID is not used because of mismatch between old internal representation and API.
 func (svc Service) ModifyTeamScheduledQueries(
 	ctx context.Context,
 	teamID uint,
 	scheduledQueryID uint,
 	scheduledQueryPayload fleet.ScheduledQueryPayload,
 ) (*fleet.ScheduledQuery, error) {
+	if _, err := svc.scheduledQueryInScope(ctx, scheduledQueryID, teamIDOrNilForGlobal(teamID)); err != nil {
+		return nil, err
+	}
 	query, err := svc.ModifyQuery(ctx, scheduledQueryID, fleet.ScheduledQueryPayloadToQueryPayloadForModifyQuery(scheduledQueryPayload))
 	if err != nil {
 		return nil, err
@@ -194,7 +221,9 @@ func deleteTeamScheduleEndpoint(ctx context.Context, request interface{}, svc fl
 	return deleteTeamScheduleResponse{}, nil
 }
 
-// teamID is not used because of mismatch between old internal representation and API.
 func (svc Service) DeleteTeamScheduledQueries(ctx context.Context, teamID uint, scheduledQueryID uint) error {
+	if _, err := svc.scheduledQueryInScope(ctx, scheduledQueryID, teamIDOrNilForGlobal(teamID)); err != nil {
+		return err
+	}
 	return svc.DeleteQueryByID(ctx, scheduledQueryID)
 }

--- a/server/service/team_schedule_test.go
+++ b/server/service/team_schedule_test.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"testing"
 
+	"github.com/fleetdm/fleet/v4/server/authz"
 	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mock"
+	common_mysql "github.com/fleetdm/fleet/v4/server/platform/mysql"
 	"github.com/fleetdm/fleet/v4/server/ptr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTeamScheduleAuth(t *testing.T) {
@@ -161,10 +165,196 @@ func TestTeamScheduleAuth(t *testing.T) {
 			checkAuthErr(t, tt.shouldFailWrite, err)
 
 			_, err = svc.ModifyTeamScheduledQueries(ctx, 1, 99, fleet.ScheduledQueryPayload{})
-			checkAuthErr(t, tt.shouldFailWrite, err)
+			checkQueryWriteAuthErr(t, tt.shouldFailWrite, tt.shouldFailRead, err)
 
 			err = svc.DeleteTeamScheduledQueries(ctx, 1, 99)
-			checkAuthErr(t, tt.shouldFailWrite, err)
+			checkQueryWriteAuthErr(t, tt.shouldFailWrite, tt.shouldFailRead, err)
 		})
 	}
+}
+
+// requireIndistinguishableNotFound asserts that the error for a report the
+// caller may not see is identical to the error for one that doesn't exist.
+// Matching HTTP status is not enough: the rendered body carries the
+// NotFoundError's resource name, so a synthetic not-found that names a
+// different resource than the datastore's real one still answers the
+// attacker's question.
+func requireIndistinguishableNotFound(t *testing.T, existingErr, missingErr error) {
+	t.Helper()
+	require.Error(t, existingErr)
+	require.Error(t, missingErr)
+	assert.True(t, fleet.IsNotFound(existingErr), "got: %v", existingErr)
+	assert.True(t, fleet.IsNotFound(missingErr), "got: %v", missingErr)
+
+	var existingNotFound, missingNotFound *common_mysql.NotFoundError
+	require.ErrorAs(t, existingErr, &existingNotFound)
+	require.ErrorAs(t, missingErr, &missingNotFound)
+	assert.Equal(t, missingNotFound.ResourceType, existingNotFound.ResourceType,
+		"the masked not-found must name the same resource as the datastore's real one")
+}
+
+func TestScheduleWritesAreBoundToPathScope(t *testing.T) {
+	const (
+		targetTeamID   = 1
+		otherTeamID    = 3
+		targetQueryID  = 10
+		otherQueryID   = 30
+		globalQueryID  = 70
+		missingQueryID = 99
+	)
+
+	ds := new(mock.Store)
+	svc, ctx := newTestService(t, ds, nil, nil)
+
+	ds.QueryFunc = func(ctx context.Context, id uint) (*fleet.Query, error) {
+		query := &fleet.Query{ID: id, Name: "foobar", Query: "SELECT 1;"}
+		switch id {
+		case targetQueryID:
+			query.TeamID = new(uint(targetTeamID))
+		case otherQueryID:
+			query.TeamID = new(uint(otherTeamID))
+		case globalQueryID:
+			query.TeamID = nil
+		default:
+			// Must mirror the real datastore's wording (see the Query method in
+			// datastore/mysql/queries.go): the masking is only airtight if the
+			// synthetic not-found is byte-identical to the genuine one.
+			return nil, common_mysql.NotFound("Report").WithID(id)
+		}
+		return query, nil
+	}
+	ds.SaveQueryFunc = func(ctx context.Context, query *fleet.Query, shouldDiscardResults bool, shouldDeleteStats bool) error {
+		return nil
+	}
+	ds.DeleteQueryFunc = func(ctx context.Context, teamID *uint, name string) error {
+		return nil
+	}
+	ds.NewQueryFunc = func(ctx context.Context, query *fleet.Query, opts ...fleet.OptionalArg) (*fleet.Query, error) {
+		return &fleet.Query{}, nil
+	}
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return &fleet.AppConfig{}, nil
+	}
+
+	globalAdminCtx := viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{GlobalRole: new(fleet.RoleAdmin)}})
+
+	otherTeamMaintainerCtx := viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{
+		Teams: []fleet.UserTeam{{Team: fleet.Team{ID: otherTeamID}, Role: fleet.RoleMaintainer}},
+	}})
+
+	t.Run("report from another fleet is not reachable through this fleet's path", func(t *testing.T) {
+		_, err := svc.ModifyTeamScheduledQueries(globalAdminCtx, targetTeamID, otherQueryID, fleet.ScheduledQueryPayload{})
+		require.Error(t, err)
+		assert.True(t, fleet.IsNotFound(err), "got: %v", err)
+
+		err = svc.DeleteTeamScheduledQueries(globalAdminCtx, targetTeamID, otherQueryID)
+		require.Error(t, err)
+		assert.True(t, fleet.IsNotFound(err), "got: %v", err)
+	})
+
+	t.Run("write access to a report does not make it reachable through another fleet's path", func(t *testing.T) {
+		// This caller is a maintainer of the report's own fleet, so it may
+		// legitimately modify and delete it -- but only
+		// through that fleet's own path.
+		// Addressing it through a fleet the caller has no access to must fail, or the path scope means nothing.
+		_, err := svc.ModifyTeamScheduledQueries(otherTeamMaintainerCtx, targetTeamID, otherQueryID, fleet.ScheduledQueryPayload{})
+		require.Error(t, err)
+		assert.True(t, fleet.IsNotFound(err), "got: %v", err)
+
+		err = svc.DeleteTeamScheduledQueries(otherTeamMaintainerCtx, targetTeamID, otherQueryID)
+		require.Error(t, err)
+		assert.True(t, fleet.IsNotFound(err), "got: %v", err)
+	})
+
+	t.Run("fleet maintainer still reaches its own report through its own path", func(t *testing.T) {
+		// The counterpart to the subtest above: the same caller and the same
+		// report, addressed through the fleet the report actually belongs to.
+		_, err := svc.TeamScheduleQuery(otherTeamMaintainerCtx, otherTeamID, &fleet.ScheduledQuery{QueryID: globalQueryID, Interval: 10})
+		require.NoError(t, err)
+
+		_, err = svc.ModifyTeamScheduledQueries(otherTeamMaintainerCtx, otherTeamID, otherQueryID, fleet.ScheduledQueryPayload{})
+		require.NoError(t, err)
+
+		err = svc.DeleteTeamScheduledQueries(otherTeamMaintainerCtx, otherTeamID, otherQueryID)
+		require.NoError(t, err)
+	})
+
+	t.Run("existing out-of-scope report is indistinguishable from a missing one", func(t *testing.T) {
+		_, existingErr := svc.ModifyTeamScheduledQueries(otherTeamMaintainerCtx, targetTeamID, targetQueryID, fleet.ScheduledQueryPayload{})
+		_, missingErr := svc.ModifyTeamScheduledQueries(otherTeamMaintainerCtx, targetTeamID, missingQueryID, fleet.ScheduledQueryPayload{})
+		requireIndistinguishableNotFound(t, existingErr, missingErr)
+
+		existingErr = svc.DeleteTeamScheduledQueries(otherTeamMaintainerCtx, targetTeamID, targetQueryID)
+		missingErr = svc.DeleteTeamScheduledQueries(otherTeamMaintainerCtx, targetTeamID, missingQueryID)
+		requireIndistinguishableNotFound(t, existingErr, missingErr)
+	})
+
+	t.Run("fleet report is not reachable through the global schedule path", func(t *testing.T) {
+		_, err := svc.ModifyGlobalScheduledQueries(globalAdminCtx, targetQueryID, fleet.ScheduledQueryPayload{})
+		require.Error(t, err)
+		assert.True(t, fleet.IsNotFound(err), "got: %v", err)
+
+		err = svc.DeleteGlobalScheduledQueries(globalAdminCtx, targetQueryID)
+		require.Error(t, err)
+		assert.True(t, fleet.IsNotFound(err), "got: %v", err)
+	})
+
+	t.Run("global report is not reachable through a fleet schedule path", func(t *testing.T) {
+		_, err := svc.ModifyTeamScheduledQueries(globalAdminCtx, targetTeamID, globalQueryID, fleet.ScheduledQueryPayload{})
+		require.Error(t, err)
+		assert.True(t, fleet.IsNotFound(err), "got: %v", err)
+
+		err = svc.DeleteTeamScheduledQueries(globalAdminCtx, targetTeamID, globalQueryID)
+		require.Error(t, err)
+		assert.True(t, fleet.IsNotFound(err), "got: %v", err)
+	})
+
+	t.Run("schedule create does not disclose which source reports exist", func(t *testing.T) {
+		// Only a global report can be scheduled, so a fleet-scoped source and a nonexistent one must answer alike.
+		_, fleetScopedErr := svc.TeamScheduleQuery(globalAdminCtx, targetTeamID, &fleet.ScheduledQuery{QueryID: otherQueryID, Interval: 10})
+		_, missingErr := svc.TeamScheduleQuery(globalAdminCtx, targetTeamID, &fleet.ScheduledQuery{QueryID: missingQueryID, Interval: 10})
+		require.Error(t, fleetScopedErr)
+		require.Error(t, missingErr)
+		assert.True(t, fleet.IsNotFound(fleetScopedErr), "got: %v", fleetScopedErr)
+		assert.True(t, fleet.IsNotFound(missingErr), "got: %v", missingErr)
+
+		_, fleetScopedErr = svc.GlobalScheduleQuery(globalAdminCtx, &fleet.ScheduledQuery{QueryID: otherQueryID, Interval: 10})
+		_, missingErr = svc.GlobalScheduleQuery(globalAdminCtx, &fleet.ScheduledQuery{QueryID: missingQueryID, Interval: 10})
+		require.Error(t, fleetScopedErr)
+		require.Error(t, missingErr)
+		assert.True(t, fleet.IsNotFound(fleetScopedErr), "got: %v", fleetScopedErr)
+		assert.True(t, fleet.IsNotFound(missingErr), "got: %v", missingErr)
+	})
+
+	t.Run("schedule create authorizes before touching the source report", func(t *testing.T) {
+		// A caller who can't create a report on the target fleet must be
+		// refused on that basis alone, without the source report ID reaching
+		// the datastore to produce a distinguishable answer.
+		ds.QueryFuncInvoked = false
+		_, err := svc.TeamScheduleQuery(otherTeamMaintainerCtx, targetTeamID, &fleet.ScheduledQuery{QueryID: globalQueryID, Interval: 10})
+		require.Error(t, err)
+		var forbidden *authz.Forbidden
+		require.ErrorAs(t, err, &forbidden)
+		assert.False(t, ds.QueryFuncInvoked, "source report must not be looked up for an unauthorized caller")
+	})
+
+	t.Run("matching scope still works", func(t *testing.T) {
+		_, err := svc.TeamScheduleQuery(globalAdminCtx, targetTeamID, &fleet.ScheduledQuery{QueryID: globalQueryID, Interval: 10})
+		require.NoError(t, err)
+
+		_, err = svc.GlobalScheduleQuery(globalAdminCtx, &fleet.ScheduledQuery{QueryID: globalQueryID, Interval: 10})
+		require.NoError(t, err)
+
+		_, err = svc.ModifyTeamScheduledQueries(globalAdminCtx, targetTeamID, targetQueryID, fleet.ScheduledQueryPayload{})
+		require.NoError(t, err)
+
+		err = svc.DeleteTeamScheduledQueries(globalAdminCtx, targetTeamID, targetQueryID)
+		require.NoError(t, err)
+
+		_, err = svc.ModifyGlobalScheduledQueries(globalAdminCtx, globalQueryID, fleet.ScheduledQueryPayload{})
+		require.NoError(t, err)
+
+		err = svc.DeleteGlobalScheduledQueries(globalAdminCtx, globalQueryID)
+		require.NoError(t, err)
+	})
 }

--- a/server/service/team_schedule_test.go
+++ b/server/service/team_schedule_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/fleetdm/fleet/v4/server/authz"
@@ -186,10 +187,16 @@ func requireIndistinguishableNotFound(t *testing.T, existingErr, missingErr erro
 	assert.True(t, fleet.IsNotFound(existingErr), "got: %v", existingErr)
 	assert.True(t, fleet.IsNotFound(missingErr), "got: %v", missingErr)
 
-	var existingNotFound, missingNotFound *common_mysql.NotFoundError
-	require.ErrorAs(t, existingErr, &existingNotFound)
-	require.ErrorAs(t, missingErr, &missingNotFound)
-	assert.Equal(t, missingNotFound.ResourceType, existingNotFound.ResourceType,
+	notFoundResource := func(err error) string {
+		var notFound *common_mysql.NotFoundError
+		if !errors.As(err, &notFound) || notFound == nil {
+			return ""
+		}
+		return notFound.ResourceType
+	}
+	existingResource := notFoundResource(existingErr)
+	require.NotEmpty(t, existingResource, "expected a NotFoundError, got: %v", existingErr)
+	assert.Equal(t, notFoundResource(missingErr), existingResource,
 		"the masked not-found must name the same resource as the datastore's real one")
 }
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
The fleet and global schedule modify/delete endpoints accepted a scope in the URL path but never enforced it against the report being written, so a report was reachable through any schedule's URL. Authorization also ran only after loading the report by ID, so an existing report the caller could not access answered differently from one that did not exist.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved report and schedule access controls across fleet, team, and global scopes.
  * Reports outside a user’s access now return “Not Found,” matching nonexistent reports.
  * Schedule creation, modification, and deletion now validate report scope consistently.
  * Users with read access but insufficient write permissions continue to receive authorization errors.
  * Added consistent validation for global and team schedule operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->