### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/beekeeper-studio/windows.json
+++ b/ee/maintained-apps/outputs/beekeeper-studio/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "5.9.3",
+      "version": "6.0.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Beekeeper Studio' AND publisher = 'Beekeeper Studio Team';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Beekeeper Studio' AND publisher = 'Beekeeper Studio Team' AND version_compare(version, '5.9.3') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Beekeeper Studio' AND publisher = 'Beekeeper Studio Team' AND version_compare(version, '6.0.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'beekeeper studio.exe');"
       },
-      "installer_url": "https://github.com/beekeeper-studio/beekeeper-studio/releases/download/v5.9.3/Beekeeper-Studio-Setup-5.9.3.exe",
+      "installer_url": "https://github.com/beekeeper-studio/beekeeper-studio/releases/download/v6.0.0/Beekeeper-Studio-Setup-6.0.0.exe",
       "install_script_ref": "13334753",
       "uninstall_script_ref": "44e6f772",
-      "sha256": "7627dde785d05ef4c20bacf6d2c3a88fcbeb6d30f8bfde344ab09aaecfe15c4e",
+      "sha256": "9fc6287d9334c43e93e767ecc7c2caedbad597acae50d4f86548d6fc9919dba5",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/ollama/windows.json
+++ b/ee/maintained-apps/outputs/ollama/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "0.32.8",
+      "version": "0.32.9",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Ollama' AND publisher = 'Ollama';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Ollama' AND publisher = 'Ollama' AND version_compare(version, '0.32.8') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Ollama' AND publisher = 'Ollama' AND version_compare(version, '0.32.9') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) IN ('ollama.exe','ollama app.exe'));"
       },
-      "installer_url": "https://github.com/ollama/ollama/releases/download/v0.32.8/OllamaSetup.exe",
+      "installer_url": "https://github.com/ollama/ollama/releases/download/v0.32.9/OllamaSetup.exe",
       "install_script_ref": "e14c71ee",
       "uninstall_script_ref": "3f049b5d",
-      "sha256": "cba870e7111bd141623531faa694a77af2c66a414832de712f8bc1d67a7b163c",
+      "sha256": "57fde2adad686d2b7bcb01a4c083e5112417410945a2f0c8fb3328d9b21d8990",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/retrobatch/darwin.json
+++ b/ee/maintained-apps/outputs/retrobatch/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "2.3.1",
+      "version": "2.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.flyingmeat.Retrobatch';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.flyingmeat.Retrobatch' AND version_compare(bundle_short_version, '2.3.1') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.flyingmeat.Retrobatch' AND version_compare(bundle_short_version, '2.4') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.flyingmeat.Retrobatch');"
       },
-      "installer_url": "https://flyingmeat.com/download/Retrobatch-2.3.1.zip",
+      "installer_url": "https://flyingmeat.com/download/Retrobatch-2.4.zip",
       "install_script_ref": "24543d98",
       "uninstall_script_ref": "355d274a",
-      "sha256": "732088dfde0d659bd4eabbdcd7ab587dfb57af9989c2cccd19788e86d1130dc6",
+      "sha256": "13a4688c142605bce32d118bf96cd7e133b5c24374b7668d70a942c82787d2ef",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/scratch/darwin.json
+++ b/ee/maintained-apps/outputs/scratch/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "3.32.0",
+      "version": "3.32.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'edu.mit.scratch.scratch-desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'edu.mit.scratch.scratch-desktop' AND version_compare(bundle_short_version, '3.32.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'edu.mit.scratch.scratch-desktop' AND version_compare(bundle_short_version, '3.32.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'edu.mit.scratch.scratch-desktop');"
       },
-      "installer_url": "https://downloads.scratch.mit.edu/desktop/Scratch%203.32.0.dmg",
+      "installer_url": "https://downloads.scratch.mit.edu/desktop/Scratch%203.32.1.dmg",
       "install_script_ref": "cf2699f4",
       "uninstall_script_ref": "2c381ac2",
-      "sha256": "e28ec141cd34c2976600923a63d1d663329c5819798f69e0dd389e92c5339f1f",
+      "sha256": "a0184df50e26ba3fbffd665b972108dfa3f0d7ce07b3fa7096a7c6749af3ff29",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/spokenly/darwin.json
+++ b/ee/maintained-apps/outputs/spokenly/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "2.27.14",
+      "version": "2.27.16",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'app.spokenly';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.spokenly' AND version_compare(bundle_short_version, '2.27.14') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.spokenly' AND version_compare(bundle_short_version, '2.27.16') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'app.spokenly');"
       },
-      "installer_url": "https://cdn.spokenly.app/releases/macos/Spokenly-2.27.14.dmg",
+      "installer_url": "https://cdn.spokenly.app/releases/macos/Spokenly-2.27.16.dmg",
       "install_script_ref": "11a51e11",
       "uninstall_script_ref": "99a71452",
-      "sha256": "5d98ef239a30094bc60b20d8513113b1a454853d5326bbb8b36cb0aed3e794c9",
+      "sha256": "8bc0840bd139eeb59c3d36e633927aa45e379b39a4f2d04a100aa4317c36c7dc",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/superhuman/darwin.json
+++ b/ee/maintained-apps/outputs/superhuman/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1041.0.29",
+      "version": "1041.0.30",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.superhuman.mail';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.superhuman.mail' AND version_compare(bundle_short_version, '1041.0.29') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.superhuman.mail' AND version_compare(bundle_short_version, '1041.0.30') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.superhuman.mail');"
       },
-      "installer_url": "https://storage.googleapis.com/download.superhuman.com/supertron-update/Superhuman-1041.0.29-arm64-latest-mac.zip",
+      "installer_url": "https://storage.googleapis.com/download.superhuman.com/supertron-update/Superhuman-1041.0.30-arm64-latest-mac.zip",
       "install_script_ref": "7e74bd96",
       "uninstall_script_ref": "1809183d",
-      "sha256": "b4c2582da79eb9a6aa09bc362a8cc966a888e64cbe7996ca6c614625ec89e461",
+      "sha256": "66bc986cf84ca03c8347068aec6df122802a0a826189c433b0e9b1db8ab1aefc",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/termius/darwin.json
+++ b/ee/maintained-apps/outputs/termius/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "9.43.0",
+      "version": "9.43.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.termius-dmg.mac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.termius-dmg.mac' AND version_compare(bundle_short_version, '9.43.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.termius-dmg.mac' AND version_compare(bundle_short_version, '9.43.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.termius-dmg.mac');"
       },
       "installer_url": "https://autoupdate.termius.com/mac-arm64/Termius.dmg",

--- a/ee/maintained-apps/outputs/thunderbird/darwin.json
+++ b/ee/maintained-apps/outputs/thunderbird/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "153.0.2",
+      "version": "153.0.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.thunderbird';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.thunderbird' AND version_compare(bundle_short_version, '153.0.2') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.thunderbird' AND version_compare(bundle_short_version, '153.0.3') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'org.mozilla.thunderbird');"
       },
-      "installer_url": "https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/153.0.2/mac/en-US/Thunderbird%20153.0.2.dmg",
+      "installer_url": "https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/153.0.3/mac/en-US/Thunderbird%20153.0.3.dmg",
       "install_script_ref": "7ab956d5",
       "uninstall_script_ref": "907ef18f",
-      "sha256": "8e5e46242201a843070872e371acfb7467be34b48c982691b779a52bdc80b775",
+      "sha256": "9f1ce443c8c79f53822f83c4d278b21026de420afa3c7131740e9e711e6b33db",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/thunderbird/windows.json
+++ b/ee/maintained-apps/outputs/thunderbird/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "153.0.2",
+      "version": "153.0.3",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Mozilla Thunderbird (x64 en-US)' AND publisher = 'Mozilla';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Mozilla Thunderbird (x64 en-US)' AND publisher = 'Mozilla' AND version_compare(version, '153.0.2') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Mozilla Thunderbird (x64 en-US)' AND publisher = 'Mozilla' AND version_compare(version, '153.0.3') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'thunderbird.exe');"
       },
-      "installer_url": "https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/153.0.2/win64/en-US/Thunderbird%20Setup%20153.0.2.exe",
+      "installer_url": "https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/153.0.3/win64/en-US/Thunderbird%20Setup%20153.0.3.exe",
       "install_script_ref": "26f2daf8",
       "uninstall_script_ref": "96113731",
-      "sha256": "aaa4fbe7e605594c5d75d5c97392e7226c77ecc1683abfb7f26b81d1a1d5da1e",
+      "sha256": "f8078deceb1f80b05d75eec92399ce01ab3027fe719fbe2aed612001bea24ad3",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/visual-studio-code/darwin.json
+++ b/ee/maintained-apps/outputs/visual-studio-code/darwin.json
@@ -1,13 +1,13 @@
 {
   "versions": [
     {
-      "version": "1.132.0",
+      "version": "1.133.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.VSCode';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.VSCode' AND version_compare(bundle_short_version, '1.132.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.VSCode' AND version_compare(bundle_short_version, '1.133.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.microsoft.VSCode');"
       },
-      "installer_url": "https://update.code.visualstudio.com/1.132.0/darwin-universal/stable",
+      "installer_url": "https://update.code.visualstudio.com/1.133.0/darwin-universal/stable",
       "install_script_ref": "58ade691",
       "uninstall_script_ref": "38d65803",
       "sha256": "no_check",

--- a/ee/maintained-apps/outputs/vivaldi/darwin.json
+++ b/ee/maintained-apps/outputs/vivaldi/darwin.json
@@ -1,13 +1,13 @@
 {
   "versions": [
     {
-      "version": "8.1.4087.62",
+      "version": "8.1.4087.64",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.vivaldi.Vivaldi';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.vivaldi.Vivaldi' AND version_compare(bundle_short_version, '8.1.4087.62') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.vivaldi.Vivaldi' AND version_compare(bundle_short_version, '8.1.4087.64') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.vivaldi.Vivaldi');"
       },
-      "installer_url": "https://downloads.vivaldi.com/stable/Vivaldi.8.1.4087.62.universal.dmg",
+      "installer_url": "https://downloads.vivaldi.com/stable/Vivaldi.8.1.4087.64.universal.dmg",
       "install_script_ref": "cae29ed4",
       "uninstall_script_ref": "7c1876ca",
       "sha256": "no_check",

--- a/ee/maintained-apps/outputs/voiceink/darwin.json
+++ b/ee/maintained-apps/outputs/voiceink/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "2.1",
+      "version": "2.11",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.prakashjoshipax.VoiceInk';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.prakashjoshipax.VoiceInk' AND version_compare(bundle_short_version, '2.1') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.prakashjoshipax.VoiceInk' AND version_compare(bundle_short_version, '2.11') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.prakashjoshipax.VoiceInk');"
       },
-      "installer_url": "https://github.com/Beingpax/VoiceInk/releases/download/v2.1/VoiceInk.dmg",
+      "installer_url": "https://github.com/Beingpax/VoiceInk/releases/download/v2.11/VoiceInk.dmg",
       "install_script_ref": "e5610cbe",
       "uninstall_script_ref": "97305c00",
-      "sha256": "327db721d0223cc7a6fa8f25929f49850d2a4b058da23deddba72a316222c53e",
+      "sha256": "5ce81126399ce06d6e1579a5e0512aa012d59863d305e382a9f47a5783aa8fee",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated application packages to the latest available releases across Windows and macOS.
  * Updated Beekeeper Studio (6.0.0), Ollama (0.32.9), Retrobatch (2.4), Scratch Desktop (3.32.1), Spokenly (2.27.16), Superhuman (1041.0.30), Termius (9.43.1), Thunderbird (153.0.3), Visual Studio Code (1.133.0), Vivaldi (8.1.4087.64), and VoiceInk (2.11).
  * Refreshed download details and version detection so installations and upgrades target the correct releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->