### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/postman/windows.json
+++ b/ee/maintained-apps/outputs/postman/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "12.23.1",
+      "version": "12.23.2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.23.1') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.23.2') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'postman.exe');"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.23.1/windows_64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.23.2/windows_64",
       "install_script_ref": "8594f0bc",
       "uninstall_script_ref": "fd59d029",
-      "sha256": "cb51813e0ad74967780569ecadd90d7cffe73126d1e13da3a7e9265a003b53a9",
+      "sha256": "a1179debe78e20585b581589090a77d99b6b8f5ac85a3b02fe8539aea768a5d9",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/teamviewer-host/windows.json
+++ b/ee/maintained-apps/outputs/teamviewer-host/windows.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "15.80.4",
+      "version": "15.80.6",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'TeamViewer Host' AND publisher = 'TeamViewer';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'TeamViewer Host' AND publisher = 'TeamViewer' AND version_compare(version, '15.80.4') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'TeamViewer Host' AND publisher = 'TeamViewer' AND version_compare(version, '15.80.6') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'teamviewer host.exe');"
       },
       "installer_url": "https://download.teamviewer.com/download/version_15x/TeamViewer_Host_Setup_x64.exe",

--- a/ee/maintained-apps/outputs/wavebox/darwin.json
+++ b/ee/maintained-apps/outputs/wavebox/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "151.2.148.2",
+      "version": "151.2.154.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'io.wavebox.wavebox';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.wavebox.wavebox' AND version_compare(bundle_short_version, '151.2.148.2') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.wavebox.wavebox' AND version_compare(bundle_short_version, '151.2.154.2') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'io.wavebox.wavebox');"
       },
-      "installer_url": "https://download.wavebox.app/stable/macarm64/Wavebox_151.2.148.2.zip",
+      "installer_url": "https://download.wavebox.app/stable/macarm64/Wavebox_151.2.154.2.zip",
       "install_script_ref": "316254ed",
       "uninstall_script_ref": "ecfbed36",
-      "sha256": "e15e313f30ad3555b43e8c26a6ca19ad4fdf3a46ba1a977d759b3cd9bed89116",
+      "sha256": "13e670070481e9d4f4ac5d73d6af3276f40879f5d8cba37e4297e25d8bec1591",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/whatsapp/darwin.json
+++ b/ee/maintained-apps/outputs/whatsapp/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "26.32.15",
+      "version": "26.32.17",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp' AND version_compare(bundle_short_version, '26.32.15') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp' AND version_compare(bundle_short_version, '26.32.17') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'net.whatsapp.WhatsApp');"
       },
       "installer_url": "https://web.whatsapp.com/desktop/mac_native/release/?configuration=Release&src=whatsapp_downloads_page",

--- a/ee/maintained-apps/outputs/wispr-flow/darwin.json
+++ b/ee/maintained-apps/outputs/wispr-flow/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.6.447",
+      "version": "1.6.492",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.wispr-flow';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.wispr-flow' AND version_compare(bundle_short_version, '1.6.447') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.wispr-flow' AND version_compare(bundle_short_version, '1.6.492') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.electron.wispr-flow');"
       },
-      "installer_url": "https://dl.wisprflow.com/wispr-flow/darwin/arm64/dmgs/Flow-v1.6.447.dmg",
+      "installer_url": "https://dl.wisprflow.com/wispr-flow/darwin/arm64/dmgs/Flow-v1.6.492.dmg",
       "install_script_ref": "a95fa7bb",
       "uninstall_script_ref": "e0cf2e96",
-      "sha256": "6ed96fad603b80d731cce142a631062a62c4d7687a3e1406f79f7dd837339c47",
+      "sha256": "48f4e5e45ef858ec18f55c10106ebde79a0276eb92f29cd39bb028056eefc9ff",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/workflowy/darwin.json
+++ b/ee/maintained-apps/outputs/workflowy/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "4.3.2608101547",
+      "version": "4.3.2608112347",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.workflowy.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.workflowy.desktop' AND version_compare(bundle_short_version, '4.3.2608101547') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.workflowy.desktop' AND version_compare(bundle_short_version, '4.3.2608112347') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.workflowy.desktop');"
       },
-      "installer_url": "https://github.com/workflowy/desktop/releases/download/v4.3.2608101547/WorkFlowy.zip",
+      "installer_url": "https://github.com/workflowy/desktop/releases/download/v4.3.2608112347/WorkFlowy.zip",
       "install_script_ref": "b65ecb27",
       "uninstall_script_ref": "71fe81c3",
-      "sha256": "e355a8a426b431b2cdacd006b2a2086cbab02e405c2c4c5b4985780e21020c96",
+      "sha256": "db1e38367f869f6a3d1384fc804d0ddc9a3e3477305a4c36e77db1d4cf3c3d72",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated Postman for Windows to version 12.23.2.
  * Updated TeamViewer Host for Windows to version 15.80.6.
  * Updated Wavebox for macOS ARM64 to version 151.2.154.2.
  * Updated WhatsApp for macOS to version 26.32.17.
  * Updated Wispr Flow for macOS to version 1.6.492.
  * Updated Workflowy for macOS to version 4.3.2608112347.
  * Refreshed download details and version detection to support the latest releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->