### PR TITLE
Fleet UI: Fix fleets dropdown menu position on Software detail pages

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/_styles.scss
@@ -4,10 +4,6 @@
 
   &__fleet-row {
     align-self: stretch;
-
-    .fleet-dropdown-wrapper {
-      @include normalize-team-header;
-    }
   }
 
   &__premium-card {

--- a/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/_styles.scss
@@ -1,10 +1,6 @@
 .software-os-details-page {
   @include vertical-page-layout;
 
-  .fleet-dropdown-wrapper {
-    @include normalize-team-header;
-  }
-
   h2 {
     font-size: $small;
   }

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/_styles.scss
@@ -1,10 +1,6 @@
 .software-title-details-page {
   @include vertical-page-layout;
 
-  .fleet-dropdown-wrapper {
-    @include normalize-team-header;
-  }
-
   h2 {
     font-size: $small;
     margin: 0;

--- a/frontend/pages/SoftwarePage/SoftwareVersionDetailsPage/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareVersionDetailsPage/_styles.scss
@@ -1,10 +1,6 @@
 .software-version-details-page {
   @include vertical-page-layout;
 
-  .fleet-dropdown-wrapper {
-    @include normalize-team-header;
-  }
-
   h2 {
     font-size: $small;
   }

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/_styles.scss
@@ -1,10 +1,6 @@
 .software-vulnerability-details-page {
   @include vertical-page-layout;
 
-  .fleet-dropdown-wrapper {
-    @include normalize-team-header;
-  }
-
   * > h1,
   h1 {
     font-size: $large;

--- a/frontend/styles/var/mixins.scss
+++ b/frontend/styles/var/mixins.scss
@@ -25,7 +25,10 @@ $max-width: 2560px;
   }
 }
 
-// Used to normalize styling of team header wrapper on various pages
+// Apply to the outer header row that contains TeamsHeader + action buttons,
+// NOT to .fleet-dropdown-wrapper itself — the wrapper needs its own
+// `display: inline-block` so FleetsDropdown's absolutely-positioned menu
+// anchors under the button.
 @mixin normalize-team-header {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Issue
Closes #50597

## Description
- Bug fix (root cause): the `FleetsDropdown` wrapper is intentionally `display: inline-block; position: relative` so its absolutely-positioned menu (`left: 0` of the react-select root) anchors under the button. Five Software SCSS files were overriding the wrapper with `@include normalize-team-header`, which applies `display: flex; justify-content: space-between; align-items: center; height: 38px`. Because the current wrapper has two flex children (the `<Button>` label and the `<Select>` root) — vs. the pre-#49690 `TeamsDropdown` which only had one — `space-between` pushed the react-select root to the far right of the wrapper, and the absolutely-positioned menu (still `left: 0` of that root) rendered at the far-right edge of the viewport.
- Fix: remove `.fleet-dropdown-wrapper { @include normalize-team-header; }` from Software Title, OS, Version, Vulnerability details pages, and Self-service categories. The wrapper's own inline-block styling is the intended behavior; on these pages `TeamsHeader` is a solo child of its container so there are no siblings to distribute with `space-between` anyway. `normalize-team-header` remains applied to outer `&__header` rows on other pages (Dashboard, ManageHosts, ManagePolicies, ManageQueries, ManageLabels, ManageControls, SoftwarePage), which is the correct usage.

## Screenrecording
- Opening the fleets dropdown on a Software title / OS / version / vulnerability details page


https://github.com/user-attachments/assets/43708039-95f2-4f4a-aa6c-92725eb2930b




## Testing

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Removed outdated dropdown wrapper styling from the software library, OS details, title details, version details, and vulnerability details pages.
  - Standardized page presentation by eliminating redundant header-specific styling.
  - Clarified header styling guidance to preserve correct dropdown menu positioning and maintain consistent behavior across software pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->