### PR TITLE
Fleet UI: Add edit button to Software installer rows

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/LibraryItemAccordion/LibraryItemAccordion.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/LibraryItemAccordion/LibraryItemAccordion.tests.tsx
@@ -440,6 +440,38 @@ describe("LibraryItemAccordion", () => {
     });
   });
 
+  describe("edit button", () => {
+    it("fires onEditClick when clicked", async () => {
+      const onEditClick = jest.fn();
+      const { user } = renderAccordion({ onEditClick });
+
+      await user.click(screen.getByRole("button", { expanded: false }));
+      await user.click(screen.getByRole("button", { name: "Edit software" }));
+      expect(onEditClick).toHaveBeenCalledTimes(1);
+    });
+
+    it("is hidden when canEditSoftware is false", async () => {
+      const { user } = renderAccordion({
+        canEditSoftware: false,
+        onEditClick: jest.fn(),
+      });
+
+      await user.click(screen.getByRole("button", { expanded: false }));
+      expect(
+        screen.queryByRole("button", { name: "Edit software" })
+      ).not.toBeInTheDocument();
+    });
+
+    it("is hidden when onEditClick is not wired", async () => {
+      const { user } = renderAccordion({ onEditClick: undefined });
+
+      await user.click(screen.getByRole("button", { expanded: false }));
+      expect(
+        screen.queryByRole("button", { name: "Edit software" })
+      ).not.toBeInTheDocument();
+    });
+  });
+
   describe("download button", () => {
     it("fires onDownloadClick when clicked", async () => {
       const onDownloadClick = jest.fn();

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/LibraryItemAccordion/LibraryItemAccordion.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/LibraryItemAccordion/LibraryItemAccordion.tsx
@@ -108,6 +108,10 @@ export interface ILibraryItemAccordionProps {
   /** Click on the labels list in the expanded panel — opens the edit software
    * modal. Wired as a CustomLink-style underline button via TruncatedTextList. */
   onLabelsClick?: () => void;
+  /** Click handler for the pencil "Edit" button in the expanded panel — opens
+   * the same edit software modal reached via the label-count badge. Gated on
+   * `canEditSoftware`; when omitted the button is hidden. */
+  onEditClick?: () => void;
   onDownloadClick?: () => void;
   onTrashClick?: () => void;
 
@@ -166,6 +170,7 @@ const LibraryItemAccordion = ({
   onBadgeClick,
   onLabelCountClick,
   onLabelsClick,
+  onEditClick,
   onDownloadClick,
   onTrashClick,
   canActivateMultiplePackages = false,
@@ -573,7 +578,7 @@ const LibraryItemAccordion = ({
 
   const renderTrashButtonBody = (disabled: boolean) => (
     <Button
-      variant="subdued"
+      variant="secondary"
       disabled={disabled}
       onClick={onTrashClick}
       ariaLabel="Delete this version"
@@ -725,9 +730,18 @@ const LibraryItemAccordion = ({
           </div>
 
           <div className={`${baseClass}__actions-column`}>
+            {canEditSoftware && onEditClick && (
+              <Button
+                variant="secondary"
+                onClick={onEditClick}
+                ariaLabel="Edit software"
+                className={`${baseClass}__edit-button`}
+                icon="pencil"
+              />
+            )}
             {canDownload && (
               <Button
-                variant="subdued"
+                variant="secondary"
                 onClick={onDownloadClick}
                 ariaLabel="Download installer"
                 className={`${baseClass}__download-button`}

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/LibraryItemAccordion/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/LibraryItemAccordion/_styles.scss
@@ -186,7 +186,7 @@
   &__actions-column {
     display: flex;
     align-items: flex-start;
-    gap: $pad-medium;
+    gap: $gap-action-elements;
     flex-shrink: 0;
   }
 

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
@@ -331,6 +331,7 @@ const SoftwareTitleDetailsPage = ({
           failedPath={statusPath("failed")}
           onLabelCountClick={openEditModal}
           onLabelsClick={openEditModal}
+          onEditClick={openEditModal}
           onTrashClick={openDeleteModal}
         />
       );
@@ -402,6 +403,7 @@ const SoftwareTitleDetailsPage = ({
           }
           onLabelCountClick={() => openEditModal(pkg.installer_id)}
           onLabelsClick={() => openEditModal(pkg.installer_id)}
+          onEditClick={() => openEditModal(pkg.installer_id)}
           onDownloadClick={() => onDownloadInstaller(pkg)}
           onTrashClick={() => openDeleteModal(pkg.installer_id)}
           onSelfServiceClick={() => openEditModal(pkg.installer_id)}

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
@@ -329,10 +329,10 @@ const SoftwareTitleDetailsPage = ({
           installedPath={statusPath("installed")}
           pendingPath={statusPath("pending")}
           failedPath={statusPath("failed")}
-          onLabelCountClick={openEditModal}
-          onLabelsClick={openEditModal}
-          onEditClick={openEditModal}
-          onTrashClick={openDeleteModal}
+          onLabelCountClick={() => openEditModal()}
+          onLabelsClick={() => openEditModal()}
+          onEditClick={() => openEditModal()}
+          onTrashClick={() => openDeleteModal()}
         />
       );
     };


### PR DESCRIPTION
## Issue
Closes #50510

## Description
- Adds a pencil-icon Edit button to the expanded Software installer row on the title details page, next to Download and Delete.
- Order matches ScriptListItem: edit → download → delete. All three buttons switched to `variant="secondary"` (were `subdued`) so they read as actions, matching Scripts. Action-column `gap` swapped to `$gap-action-elements`.
- Gated on `canEditSoftware` — observers don't see it. Wired to `openEditModal` on both the app-store row and per-package rows (same handler as the label-count badge; GitOps disable stays in the modal, matching the existing badge/dropdown pattern).

## Screenrecording


https://github.com/user-attachments/assets/32fa2495-113e-432b-8953-a70397c1853b



## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an Edit control to expanded software library items when editing is permitted.
  - App Store and custom package entries now open the appropriate edit dialog, including the selected package.

- **Style**
  - Updated action button styling and spacing for improved consistency.

- **Tests**
  - Added coverage for editing actions and visibility when editing is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->