### PR TITLE
Software: Fix label color for script fields in advanced options

### DIFF
--- a/changes/48211-editor-label-color
+++ b/changes/48211-editor-label-color
@@ -1,0 +1,1 @@
+- Fixed label color for install/post-install/uninstall script fields in software package advanced options to match Fleet's standard form label color.

--- a/frontend/components/Editor/_styles.scss
+++ b/frontend/components/Editor/_styles.scss
@@ -2,9 +2,7 @@
   position: relative; // needed for copy button
 
   &__label {
-    font-size: $x-small;
-    font-weight: $bold;
-    color: $core-fleet-black;
+    @include form-label;
 
     &--error {
       color: $core-vibrant-red;

--- a/frontend/components/Editor/_styles.scss
+++ b/frontend/components/Editor/_styles.scss
@@ -4,6 +4,7 @@
   &__label {
     font-size: $x-small;
     font-weight: $bold;
+    color: $core-fleet-black;
 
     &--error {
       color: $core-vibrant-red;

--- a/frontend/components/SQLEditor/_styles.scss
+++ b/frontend/components/SQLEditor/_styles.scss
@@ -1,8 +1,6 @@
 .sql-editor {
   &__label {
-    font-size: $x-small;
-    font-weight: $bold;
-    color: $core-fleet-black;
+    @include form-label;
 
     &--error {
       color: $core-vibrant-red;

--- a/frontend/components/forms/fields/InputFieldWithIcon/_styles.scss
+++ b/frontend/components/forms/fields/InputFieldWithIcon/_styles.scss
@@ -119,10 +119,8 @@
   }
 
   &__label {
+    @include form-label;
     display: block;
-    font-size: $x-small;
-    font-weight: $bold;
-    color: $core-fleet-black;
 
     &[data-has-tooltip="true"] {
       margin-bottom: $pad-small;

--- a/frontend/pages/admin/IntegrationsPage/cards/Integrations/components/IntegrationForm/_styles.scss
+++ b/frontend/pages/admin/IntegrationsPage/cards/Integrations/components/IntegrationForm/_styles.scss
@@ -18,9 +18,7 @@
       margin-top: 5px;
 
       &__label {
-        font-size: $x-small;
-        font-weight: $bold;
-        color: $core-fleet-black;
+        @include form-label;
       }
     }
   }
@@ -43,9 +41,7 @@
   }
 
   &__label {
-    color: $core-fleet-black;
-    font-size: $x-small;
-    font-weight: $bold;
+    @include form-label;
     margin-bottom: $pad-small;
   }
 

--- a/frontend/pages/admin/ManageUsersPage/components/UserForm/_styles.scss
+++ b/frontend/pages/admin/ManageUsersPage/components/UserForm/_styles.scss
@@ -8,9 +8,7 @@
       margin-top: 5px;
 
       &__label {
-        font-size: $x-small;
-        font-weight: $bold;
-        color: $core-fleet-black;
+        @include form-label;
       }
     }
   }

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/ManagedAccountModal/_styles.scss
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/ManagedAccountModal/_styles.scss
@@ -7,9 +7,7 @@
   }
 
   &__label {
-    font-size: $x-small;
-    font-weight: $bold;
-    color: $core-fleet-black;
+    @include form-label;
   }
 
   &__value {

--- a/frontend/styles/global/_global.scss
+++ b/frontend/styles/global/_global.scss
@@ -171,9 +171,7 @@ form,
   overflow-wrap: break-word; // allow long words to break to avoid overflow
 
   &__label {
-    font-size: $x-small;
-    font-weight: $bold;
-    color: $core-fleet-black;
+    @include form-label;
     line-height: $line-height;
 
     // compensate for height added by tooltip wrapper underline

--- a/frontend/styles/var/mixins.scss
+++ b/frontend/styles/var/mixins.scss
@@ -147,6 +147,12 @@ $max-width: 2560px;
   }
 }
 
+@mixin form-label {
+  font-size: $x-small;
+  font-weight: $bold;
+  color: $core-fleet-black;
+}
+
 @mixin link {
   color: $ui-fleet-black-75;
   font-weight: $bold;


### PR DESCRIPTION
## Issue
Closes #48211

## Description
- Bug fix (root cause): `.editor__label` in `frontend/components/Editor/_styles.scss` didn't set `color`, so Install / Post-install / Uninstall script labels inherited a lighter color than the Pre-install query label (which uses `SQLEditor` and correctly sets `color: $core-fleet-black`). Added the missing declaration so all four labels match Fleet's standard `.form-field__label` color defined in `frontend/styles/global/_global.scss`.
- Swept every other `&__label` rule in `frontend/` to confirm no other form-field labels are missing the base color — Editor was the sole outlier.

## Screenshot
- Advanced options section on Add software > Custom package, showing all labels rendered in `$core-fleet-black`
- 
<img width="617" height="880" alt="Screenshot 2026-08-12 at 2 55 42 PM" src="https://github.com/user-attachments/assets/6d47dad5-3d7c-4cad-931c-84398c166f30" />



## Testing

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected script-field label colors in software package advanced options to match Fleet’s standard form label color.
  - Standardized form label styling across editors, forms, integration settings, user management, and host account dialogs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->