### PR TITLE
Attribute ai_tools Windows rows from ProfileList, not the directory owner

### DIFF
--- a/orbit/pkg/table/ai_tools/README.md
+++ b/orbit/pkg/table/ai_tools/README.md
@@ -36,8 +36,9 @@ exported `Columns()`/`Generate()` wrappers used to register the table in
   regular-file-only reads that never follow symlinks or block on FIFOs/devices
   (`internal/fsutil`), path-traversal containment for attacker-controlled
   config/manifest/plist fields, removal of outbound DNS resolution of untrusted
-  MCP hostnames (`internal/netsock`), owner-based (not name-based) uid/username
-  attribution (`internal/homes`), and panic recovery at the `Generate` boundary.
+  MCP hostnames (`internal/netsock`), OS-attested (never name-based) uid/username
+  attribution cross-checked against on-disk ownership (`internal/homes`), and
+  panic recovery at the `Generate` boundary.
 
 ## License
 

--- a/orbit/pkg/table/ai_tools/internal/homes/homes.go
+++ b/orbit/pkg/table/ai_tools/internal/homes/homes.go
@@ -8,13 +8,17 @@ package homes
 
 import (
 	"os"
-	"os/user"
 	"path/filepath"
 	"runtime"
 	"strings"
 )
 
-// Home is a single user's account and home directory.
+// Home is a single user's account and home directory. UID is the numeric uid on
+// Unix and the account SID on Windows; UID and Username are both empty when the
+// home could not be attributed to a user account. Username alone may be empty
+// when the owner is known but cannot be named: a uid with no passwd entry on
+// Unix, a profile SID the host cannot resolve (unreachable domain controller,
+// offline Entra ID) on Windows.
 type Home struct {
 	UID      string
 	Username string
@@ -27,21 +31,64 @@ func All() []Home {
 	seen := map[string]struct{}{}
 	var out []Home
 
-	add := func(dir string) {
+	// admit reports whether dir is a directory that exists and has not been
+	// recorded yet, returning it cleaned along with its FileInfo and marking it
+	// seen.
+	admit := func(dir string) (string, os.FileInfo, bool) {
 		if dir == "" {
-			return
+			return "", nil, false
 		}
+
 		dir = filepath.Clean(dir)
-		if _, ok := seen[dir]; ok {
-			return
+
+		key := dir
+		if runtime.GOOS == "windows" {
+			key = strings.ToLower(dir)
+		}
+
+		if _, ok := seen[key]; ok {
+			return "", nil, false
 		}
 		fi, err := os.Stat(dir)
 		if err != nil || !fi.IsDir() {
+			return "", nil, false
+		}
+		seen[key] = struct{}{}
+		return dir, fi, true
+	}
+
+	// add records a home found by path alone, deriving its owner from the
+	// directory itself. When ownership can't be established it stays unknown
+	// ("", "")
+	add := func(dir string) {
+		dir, fi, ok := admit(dir)
+		if !ok {
 			return
 		}
-		seen[dir] = struct{}{}
-		uid, username := owner(dir, fi)
+		uid, username, ok := statOwner(dir, fi)
+		if !ok {
+			uid, username = "", ""
+		}
 		out = append(out, Home{UID: uid, Username: username, Dir: dir})
+	}
+
+	// addKnown records a home the platform enumerated together with its owner,
+	// which is authoritative and needs no derivation.
+	addKnown := func(h Home) {
+		dir, _, ok := admit(h.Dir)
+		if !ok {
+			return
+		}
+		h.Dir = dir
+		out = append(out, h)
+	}
+
+	// Homes the OS itself records against an account come first, so that where a
+	// directory is found both ways the authoritative attribution wins. This also
+	// reaches profiles the directory listings below miss entirely, such as one
+	// redirected off the system drive. Only Windows has such a record.
+	for _, h := range platformHomes() {
+		addKnown(h)
 	}
 
 	switch runtime.GOOS {
@@ -65,26 +112,6 @@ func All() []Home {
 		add(h)
 	}
 	return out
-}
-
-// owner returns the uid/username to attribute rows under dir to. It derives
-// them from the directory's actual owner — the numeric owner uid on Unix, the
-// owner SID on Windows — rather than the directory name, so a low-privilege user
-// who creates a directory named after another account (e.g. /Users/root or
-// C:\Users\Administrator2) cannot forge the uid/username attribution columns.
-//
-// When ownership can't be read, it reports it as unknown ("", "") and never
-// falls back to the (attacker-influenced) directory name.
-func owner(dir string, fi os.FileInfo) (uid, username string) {
-	ownerUID, ok := statOwnerUID(dir, fi)
-	if !ok {
-		return "", ""
-	}
-	// user.LookupId resolves a numeric uid on Unix and a SID string on Windows.
-	if u, err := user.LookupId(ownerUID); err == nil {
-		return ownerUID, u.Username
-	}
-	return ownerUID, ""
 }
 
 func listChildren(parent string, skipLower []string, add func(string)) {

--- a/orbit/pkg/table/ai_tools/internal/homes/homes_windows_test.go
+++ b/orbit/pkg/table/ai_tools/internal/homes/homes_windows_test.go
@@ -1,0 +1,282 @@
+//go:build windows
+
+package homes
+
+import (
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestAllNeverAttributesToANonUserSID(t *testing.T) {
+	for _, h := range All() {
+		if h.UID == "" {
+			// Ownership could not be established. Both columns stay empty, which
+			// is the documented outcome — checked below.
+			if h.Username != "" {
+				t.Errorf("home %q has username %q with no uid", h.Dir, h.Username)
+			}
+			continue
+		}
+		if _, res := resolveUserAccount(h.UID); res == resolvedNonUser {
+			t.Errorf("home %q attributed to %q, which is not a user account", h.Dir, h.UID)
+		}
+	}
+}
+
+func TestAllAttributesTheCurrentUsersHome(t *testing.T) {
+	cur, err := user.Current()
+	if err != nil {
+		t.Fatalf("user.Current: %v", err)
+	}
+	if _, res := resolveUserAccount(cur.Uid); res != resolvedUser {
+		t.Skipf("running as %s, which does not resolve as a user account; no profile to attribute", cur.Username)
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("os.UserHomeDir: %v", err)
+	}
+
+	var got *Home
+	for _, h := range All() {
+		if strings.EqualFold(h.Dir, home) {
+			got = &h
+			break
+		}
+	}
+	if got == nil {
+		t.Fatalf("All() did not include the current user's home %q", home)
+	}
+	if got.UID != cur.Uid {
+		t.Errorf("uid = %q, want the current account's SID %q", got.UID, cur.Uid)
+	}
+	// os/user formats Username as DOMAIN\account; the table reports the bare
+	// account name, which is what osquery's own users table carries.
+	if want := cur.Username[strings.LastIndex(cur.Username, `\`)+1:]; got.Username != want {
+		t.Errorf("username = %q, want %q", got.Username, want)
+	}
+}
+
+// ownerOf reads dir's security-descriptor OWNER, failing the test when it
+// can't be read.
+func ownerOf(t *testing.T, dir string) *windows.SID {
+	t.Helper()
+	owner, ok := securityDescriptorOwner(dir)
+	if !ok {
+		t.Fatalf("could not read the owner of %q", dir)
+	}
+	return owner
+}
+
+func TestStatOwnerNeverReportsANonUserOwner(t *testing.T) {
+	dir := t.TempDir()
+	admins, err := windows.CreateWellKnownSid(windows.WinBuiltinAdministratorsSid)
+	if err != nil {
+		t.Fatalf("CreateWellKnownSid: %v", err)
+	}
+	if err := windows.SetNamedSecurityInfo(dir, windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION,
+		admins, nil, nil, nil); err != nil {
+		t.Skipf("cannot make the directory Administrators-owned (needs an elevated token): %v", err)
+	}
+	if uid, username, ok := statOwner(dir, nil); ok {
+		t.Errorf("statOwner = %q/%q for an Administrators-owned directory, want no owner", uid, username)
+	}
+}
+
+func TestDiskConsistent(t *testing.T) {
+	dir := t.TempDir()
+	owner := ownerOf(t, dir)
+	_, ownerIsUser := userAccountForSID(owner)
+
+	if diskConsistent(sidLocalUser, filepath.Join(dir, "missing")) {
+		t.Error("a path with no directory behind it was accepted")
+	}
+	if !diskConsistent(owner.String(), dir) {
+		t.Errorf("a claim matching the on-disk owner %s was rejected", owner)
+	}
+	// sidLocalUser is a fabricated SID that exists on no host, so it never
+	// matches the real owner: the claim must be rejected exactly when the owner
+	// is itself a user account (which then contradicts the claim).
+	if got := diskConsistent(sidLocalUser, dir); got != !ownerIsUser {
+		t.Errorf("diskConsistent with a mismatched claim = %v; directory owner %s (user account: %v)",
+			got, owner, ownerIsUser)
+	}
+}
+
+func TestDiskConsistentRejectsReparsePoints(t *testing.T) {
+	target := t.TempDir()
+	junction := filepath.Join(t.TempDir(), "junction")
+	if out, err := exec.Command("cmd", "/c", "mklink", "/J", junction, target).CombinedOutput(); err != nil {
+		t.Skipf("mklink /J: %v (%s)", err, out)
+	}
+	if diskConsistent(ownerOf(t, target).String(), junction) {
+		t.Error("a junction was accepted as a profile directory")
+	}
+}
+
+// The SIDs below are the shapes that really show up under ProfileList. Only the
+// first two name a person's account; the rest are what makes the raw key
+// unusable as-is.
+const (
+	sidLocalUser  = "S-1-5-21-4207797923-693487475-3254343130-1001"
+	sidEntraUser  = "S-1-12-1-1234567890-1234567890-1234567890-1234567890"
+	sidDeletedAcc = "S-1-5-21-4207797923-693487475-3254343130-1002"
+	sidDomainUsrs = "S-1-5-21-4207797923-693487475-3254343130-513"
+	sidSystem     = "S-1-5-18"
+	sidLocalSvc   = "S-1-5-19"
+)
+
+// accountLookup stands in for LookupAccountSid so tests can construct accounts
+// the runner doesn't have: SIDs in users resolve as user accounts, SIDs listed
+// as unresolvable fail outright (unreachable domain controller, deleted
+// account), and every other SID resolves as a group or well-known account,
+// which is how the SidTypeUser gate sees them on a live host.
+func accountLookup(users map[string]string, unresolvable ...string) func(string) (string, accountResolution) {
+	return func(sid string) (string, accountResolution) {
+		if name, ok := users[sid]; ok {
+			return name, resolvedUser
+		}
+		if slices.Contains(unresolvable, sid) {
+			return "", unresolved
+		}
+		return "", resolvedNonUser
+	}
+}
+
+// diskAlwaysConsistent stands in for the on-disk verification, for tests
+// exercising the other gates.
+func diskAlwaysConsistent(string, string) bool { return true }
+
+// checkProfileHomes runs profileHomes over entries and reports any deviation
+// from exactly the homes wanted (nil to require rejection).
+func checkProfileHomes(t *testing.T, entries []profileEntry, lookup func(string) (string, accountResolution), verified func(sid, dir string) bool, want []Home) {
+	t.Helper()
+	if got := profileHomes(entries, lookup, verified); !slices.Equal(got, want) {
+		t.Errorf("profileHomes(%+v) = %+v, want %+v", entries, got, want)
+	}
+}
+
+func TestProfileHomes(t *testing.T) {
+	lookup := accountLookup(map[string]string{
+		sidLocalUser: "xpkoa",
+		sidEntraUser: "bob",
+	}, sidDeletedAcc)
+
+	entries := []profileEntry{
+		// Service profiles. Every host has these, and none belongs to a person.
+		{SID: sidSystem, Path: `C:\Windows\system32\config\systemprofile`},
+		{SID: sidLocalSvc, Path: `C:\Windows\ServiceProfiles\LocalService`},
+
+		{SID: sidLocalUser, Path: `C:\Users\xpkoa`},
+
+		// A domain group SID: same S-1-5-21-<authority> shape as a user, so only
+		// the account-type gate rejects it.
+		{SID: sidDomainUsrs, Path: `C:\Users\domainusers`},
+
+		// BUILTIN\Administrators
+		{SID: "S-1-5-32-544", Path: `C:\Users\admins`},
+
+		// Entra ID account whose profile was redirected off the system drive —
+		// the directory listing of C:\Users never sees this one.
+		{SID: sidEntraUser, Path: `D:\Profiles\bob`},
+
+		// Leftover entry for an account the host can no longer resolve: the SID
+		// still identifies the profile's owner, so it is kept, unnamed.
+		{SID: sidDeletedAcc, Path: `C:\Users\departed`},
+
+		// Present but with no ProfileImagePath value.
+		{SID: sidLocalUser, Path: ""},
+	}
+
+	checkProfileHomes(t, entries, lookup, diskAlwaysConsistent, []Home{
+		{UID: sidLocalUser, Username: "xpkoa", Dir: `C:\Users\xpkoa`},
+		{UID: sidEntraUser, Username: "bob", Dir: `D:\Profiles\bob`},
+		{UID: sidDeletedAcc, Username: "", Dir: `C:\Users\departed`},
+	})
+}
+
+func TestProfileHomesRejectsNonLocalPaths(t *testing.T) {
+	lookup := accountLookup(map[string]string{sidLocalUser: "xpkoa"})
+
+	for _, path := range []string{
+		``,
+		`C:`,
+		`C:\`,
+		`Users\xpkoa`,
+		`\Users\xpkoa`,
+		`\\fileserver\profiles\xpkoa`,
+		`C:/Users/xpkoa`,
+		`%SystemDrive%\Users\xpkoa`,
+	} {
+		checkProfileHomes(t, []profileEntry{{SID: sidLocalUser, Path: path}}, lookup, diskAlwaysConsistent, nil)
+	}
+}
+
+func TestProfileHomesRejectsNonUserSIDs(t *testing.T) {
+	var looked []string
+	lookup := func(sid string) (string, accountResolution) {
+		looked = append(looked, sid)
+		return "resolved", resolvedUser
+	}
+
+	for _, sid := range []string{
+		"S-1-5-18", // LocalSystem — observed resolving as a user on a real host
+		"S-1-5-19",
+		"S-1-5-20",
+		"S-1-5-32-544", // BUILTIN\Administrators
+		"S-1-5-80-956008885-3418522649-1831038044-1853292631-2271478464",
+		"S-1-5-82-3006700770-424185619-1745488364-794895919-4004696415",
+		"S-1-5-83-1-2-3-4-5",
+		"s-1-5-82-3006700770-424185619-1745488364-794895919-4004696415", // case must not matter
+		"S-1-5-90-0-1",
+		"S-1-5-96-0-0",
+	} {
+		checkProfileHomes(t, []profileEntry{{SID: sid, Path: `C:\Users\svcprofile`}}, lookup, diskAlwaysConsistent, nil)
+	}
+	if len(looked) != 0 {
+		t.Errorf("profileHomes() resolved non-user SIDs %v; the by-value gate must reject them before any lookup", looked)
+	}
+}
+
+func TestProfileHomesRequiresOnDiskConsistency(t *testing.T) {
+	lookup := accountLookup(map[string]string{
+		sidLocalUser: "xpkoa",
+		sidEntraUser: "bob",
+	}, sidDeletedAcc)
+
+	var checked []profileEntry
+	verify := func(sid, dir string) bool {
+		checked = append(checked, profileEntry{SID: sid, Path: dir})
+		return sid == sidLocalUser
+	}
+
+	entries := []profileEntry{
+		{SID: sidLocalUser, Path: `C:\Users\xpkoa`},
+		{SID: sidEntraUser, Path: `D:\Profiles\bob`}, // fails verification: planted or replaced
+		{SID: sidSystem, Path: `C:\Windows\system32\config\systemprofile`},
+		// The consistency check is not waived for a SID the lookup couldn't
+		// resolve: it too must survive verification, and here it doesn't.
+		{SID: sidDeletedAcc, Path: `C:\Users\departed`},
+	}
+
+	checkProfileHomes(t, entries, lookup, verify,
+		[]Home{{UID: sidLocalUser, Username: "xpkoa", Dir: `C:\Users\xpkoa`}})
+
+	// Every entry that survived the lookup gate was checked against the disk,
+	// with the SID and path the registry paired; the SYSTEM entry never got
+	// that far.
+	wantChecked := []profileEntry{
+		{SID: sidLocalUser, Path: `C:\Users\xpkoa`},
+		{SID: sidEntraUser, Path: `D:\Profiles\bob`},
+		{SID: sidDeletedAcc, Path: `C:\Users\departed`},
+	}
+	if !slices.Equal(checked, wantChecked) {
+		t.Errorf("on-disk verification saw %+v, want %+v", checked, wantChecked)
+	}
+}

--- a/orbit/pkg/table/ai_tools/internal/homes/owner_other.go
+++ b/orbit/pkg/table/ai_tools/internal/homes/owner_other.go
@@ -4,7 +4,11 @@ package homes
 
 import "os"
 
-// statOwnerUID has no implementation on platforms that are neither Unix (no
-// syscall.Stat_t) nor Windows. owner() then reports ownership as unknown rather
+// statOwner has no implementation on platforms that are neither Unix (no
+// syscall.Stat_t) nor Windows. All() then reports ownership as unknown rather
 // than trusting the directory name.
-func statOwnerUID(_ string, _ os.FileInfo) (string, bool) { return "", false }
+func statOwner(_ string, _ os.FileInfo) (uid, username string, ok bool) { return "", "", false }
+
+// platformHomes has nothing to return here either: only Windows keeps a record
+// of homes by account (see owner_windows.go).
+func platformHomes() []Home { return nil }

--- a/orbit/pkg/table/ai_tools/internal/homes/owner_unix.go
+++ b/orbit/pkg/table/ai_tools/internal/homes/owner_unix.go
@@ -4,18 +4,32 @@ package homes
 
 import (
 	"os"
+	"os/user"
 	"strconv"
 	"syscall"
 )
 
-// statOwnerUID returns the owning uid of the file described by fi, read from the
-// underlying stat. This is the OS's own record of ownership, so it cannot be
-// forged by naming a directory after another account. The dir path is unused on
-// Unix (the FileInfo already carries the owner).
-func statOwnerUID(_ string, fi os.FileInfo) (string, bool) {
-	st, ok := fi.Sys().(*syscall.Stat_t)
-	if !ok {
-		return "", false
+// statOwner returns the owning uid of the file described by fi, read from the
+// underlying stat, and the account name that uid resolves to. The uid is the
+// OS's own record of ownership, so it cannot be forged by naming a directory
+// after another account. Naming it is best-effort: a uid with no passwd entry
+// still identifies the owner and is reported with an empty username. The dir
+// path is unused on Unix (the FileInfo already carries the owner).
+func statOwner(_ string, fi os.FileInfo) (uid, username string, ok bool) {
+	st, sok := fi.Sys().(*syscall.Stat_t)
+	if !sok {
+		return "", "", false
 	}
-	return strconv.FormatUint(uint64(st.Uid), 10), true
+	uid = strconv.FormatUint(uint64(st.Uid), 10)
+	if u, err := user.LookupId(uid); err == nil {
+		username = u.Username
+	}
+	return uid, username, true
 }
+
+// platformHomes has nothing to return on Unix. passwd records a user's home
+// directory, but All() already reaches those accounts by listing the
+// directories that hold them, and the owner uid it reads from a directory there
+// is the OS's own record of a *user* — no separate source is needed to
+// establish who a home belongs to. Only Windows has one (see owner_windows.go).
+func platformHomes() []Home { return nil }

--- a/orbit/pkg/table/ai_tools/internal/homes/owner_unix_test.go
+++ b/orbit/pkg/table/ai_tools/internal/homes/owner_unix_test.go
@@ -30,7 +30,10 @@ func TestOwnerUsesStatNotName(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	uid, username := owner(dir, fi)
+	uid, username, ok := statOwner(dir, fi)
+	if !ok {
+		t.Fatalf("statOwner could not read the owner of %q", dir)
+	}
 	if uid != cur.Uid {
 		t.Errorf("uid = %q, want the real owner %q (must be read from stat, not the name)", uid, cur.Uid)
 	}

--- a/orbit/pkg/table/ai_tools/internal/homes/owner_windows.go
+++ b/orbit/pkg/table/ai_tools/internal/homes/owner_windows.go
@@ -4,26 +4,318 @@ package homes
 
 import (
 	"os"
+	"strings"
 
 	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/registry"
 )
 
-// statOwnerUID reads the owning account of dir from its security descriptor and
-// returns the owner SID as a string. os/user.LookupId resolves a SID to an
-// account on Windows, so owner() maps it to a username the same way it maps a
-// numeric uid on Unix — and, crucially, without trusting the directory name, so
-// a folder named after another account can't forge the attribution.
-//
-// The FileInfo is unused: Win32 file attributes don't carry ownership, so the
-// security descriptor must be queried by path.
-func statOwnerUID(dir string, _ os.FileInfo) (string, bool) {
+// statOwner reads the owning account of dir from its security descriptor and
+// returns the owner SID as a string together with its account name, for a home
+// that ProfileList does not record (see platformHomes below, which is where
+// ownership normally comes from). The SID is reported only if it names a user
+// account.
+func statOwner(dir string, _ os.FileInfo) (uid, username string, ok bool) {
+	sid, ok := securityDescriptorOwner(dir)
+	if !ok {
+		return "", "", false
+	}
+	account, isUser := userAccountForSID(sid)
+	if !isUser {
+		return "", "", false
+	}
+	return sid.String(), account, true
+}
+
+// securityDescriptorOwner reads the OWNER field of dir's security descriptor.
+func securityDescriptorOwner(dir string) (*windows.SID, bool) {
 	sd, err := windows.GetNamedSecurityInfo(dir, windows.SE_FILE_OBJECT, windows.OWNER_SECURITY_INFORMATION)
 	if err != nil {
-		return "", false
+		return nil, false
 	}
 	sid, _, err := sd.Owner()
 	if err != nil || sid == nil {
+		return nil, false
+	}
+	return sid, true
+}
+
+// diskConsistent reports whether the directory on disk is consistent with
+// ProfileList's claim that it is profileSID's profile. The registry entry is an
+// assertion about a path, not about the directory now occupying it, so before
+// it is trusted the directory must:
+//
+//   - be a real directory reached without a reparse point in the final
+//     component — a junction or symlink here would attribute whatever tree it
+//     points at (creating either needs no privilege) to profileSID, and
+//   - not be OWNED by a different user account. Ownership is kernel-recorded
+//     and settable only to SIDs in the setter's own token, so a directory an
+//     unprivileged user planted at a stale or redirected entry's path is owned
+//     by its creator and contradicts the claim. A group or service owner
+//     (BUILTIN\Administrators on real admin profiles — the normal case) says
+//     nothing about which user the profile belongs to and contradicts nothing.
+//
+// An owner that cannot be read counts as inconsistent: this check exists to
+// veto forgery, and unverifiable is not verified.
+func diskConsistent(profileSID, dir string) bool {
+	claim, err := windows.StringToSid(profileSID)
+	if err != nil {
+		return false
+	}
+	fi, err := os.Lstat(dir)
+	if err != nil || fi.Mode()&(os.ModeSymlink|os.ModeIrregular) != 0 || !fi.IsDir() {
+		return false
+	}
+	owner, ok := securityDescriptorOwner(dir)
+	if !ok {
+		return false
+	}
+	if owner.Equals(claim) {
+		return true
+	}
+	_, ownerIsUser := userAccountForSID(owner)
+	return !ownerIsUser
+}
+
+// resolveUserAccount resolves a SID string to its account name, distinguishing
+// a SID that positively names a non-user (dropped by profileHomes) from one
+// the host simply cannot resolve right now (kept, unnamed). A malformed SID —
+// ProfileList grows "<SID>.bak" subkeys, which are duplicates of real entries —
+// counts as a non-user.
+func resolveUserAccount(sid string) (string, accountResolution) {
+	if isNonUserSID(sid) {
+		return "", resolvedNonUser
+	}
+	s, err := windows.StringToSid(sid)
+	if err != nil {
+		return "", resolvedNonUser
+	}
+	account, _, accType, err := s.LookupAccount("")
+	if err != nil {
+		return "", unresolved
+	}
+	if accType != windows.SidTypeUser {
+		return "", resolvedNonUser
+	}
+	return account, resolvedUser
+}
+
+// userAccountForSID returns the bare account name for sid, reporting false
+// unless the account is a user — established by SID value first (see
+// nonUserSIDs) and by the reported account type second.
+//
+// The name is deliberately bare: os/user formats Username as DOMAIN\account,
+// whereas osquery's own users table carries the account name alone, and these
+// columns exist to be lined up with that table.
+func userAccountForSID(sid *windows.SID) (string, bool) {
+	if isNonUserSID(sid.String()) {
 		return "", false
 	}
-	return sid.String(), true
+	account, _, accType, err := sid.LookupAccount("")
+	if err != nil || accType != windows.SidTypeUser {
+		return "", false
+	}
+	return account, true
+}
+
+// Windows records which user a profile directory belongs to in
+// HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList: one subkey per
+// account, named by SID, holding the profile's path in ProfileImagePath.
+const profileListKey = `SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList`
+
+// maxProfileListEntries bounds how many ProfileList records are read. Every
+// entry can cost an account lookup, and on a domain-joined host with an
+// unreachable domain controller each unresolvable SID is a network timeout —
+// long-lived terminal servers accumulate stale entries in the hundreds. The
+// bound is far above the number of live profiles a healthy host carries.
+const maxProfileListEntries = 512
+
+// profileEntry is one raw ProfileList record: the account SID naming the subkey
+// and the profile directory that subkey points at.
+type profileEntry struct {
+	SID  string
+	Path string
+}
+
+// accountResolution is what a SID lookup established about an account.
+type accountResolution int
+
+const (
+	// resolvedUser: the SID names a user account, whose name came back with it.
+	resolvedUser accountResolution = iota
+	// resolvedNonUser: the SID names something that is not a user — a group, a
+	// well-known account like SYSTEM, a service identity — or is malformed.
+	resolvedNonUser
+	// unresolved: the lookup failed outright, saying nothing about the account:
+	// an unreachable domain controller, an Entra ID SID with no line to
+	// resolve it, an account since deleted.
+	unresolved
+)
+
+// nonUserSIDs and nonUserSIDPrefixes name the machine and service accounts that
+// never belong to a person.
+var (
+	nonUserSIDs = []string{
+		"S-1-5-18", // LocalSystem
+		"S-1-5-19", // LocalService
+		"S-1-5-20", // NetworkService
+	}
+	nonUserSIDPrefixes = []string{
+		"S-1-5-32-", // BUILTIN aliases: Administrators, Users, ...
+		"S-1-5-80-", // NT SERVICE virtual accounts
+		"S-1-5-82-", // IIS application pool identities
+		"S-1-5-83-", // NT VIRTUAL MACHINE accounts
+		"S-1-5-90-", // Window Manager (DWM-*)
+		"S-1-5-96-", // Font Driver Host (UMFD-*)
+	}
+)
+
+// platformHomes returns the profile directories Windows records against a user
+// account. See the ProfileList comment above for why the registry, not the
+// filesystem, is the source of truth for ownership.
+func platformHomes() []Home {
+	entries := readProfileList()
+	for i := range entries {
+		// Canonicalize to the long-name spelling: a ProfileImagePath stored in
+		// 8.3 short form (migrated hosts) would otherwise evade the case-folded
+		// de-duplication in All() and the same profile would be reported twice.
+		entries[i].Path = longPathName(entries[i].Path)
+	}
+	return profileHomes(entries, resolveUserAccount, diskConsistent)
+}
+
+// profileHomes converts raw ProfileList records into homes, keeping only the
+// ones that verifiably belong to a user account. lookup and verified are
+// injected so tests can construct hosts the runner doesn't have (domain groups,
+// unreachable domain controllers, planted directories); production wires in
+// resolveUserAccount and diskConsistent. Each entry must pass, in order:
+//
+//   - a path shape check: absolute, on a local drive letter, with at least one
+//     component under the root. This drops empty and unexpanded values, and UNC
+//     paths, which would otherwise send a SYSTEM process authenticating to a
+//     remote share.
+//   - not a machine, service, or builtin SID (see nonUserSIDs). Checked by
+//     value before lookup so no account resolution is spent on them.
+//   - lookup must not resolve the SID as a non-user. A SID that resolves as a
+//     group or well-known account (every host has service profiles under
+//     ProfileList, and none belongs to a person) is dropped: a column
+//     documented as a user ID is better left empty than filled with a group
+//     SID. A SID the lookup cannot resolve at all — unreachable domain
+//     controller, offline Entra ID, deleted account — is kept with an empty
+//     username: it is still the profile's admin-attested owner (only accounts
+//     that log on get ProfileList subkeys, never groups), and reporting it
+//     keeps offline correlation against the users table working.
+//   - verified reports the directory on disk is consistent with the entry — a
+//     real directory (not a reparse point) whose OWNER does not name a
+//     different user (see diskConsistent).
+func profileHomes(entries []profileEntry, lookup func(sid string) (string, accountResolution), verified func(sid, dir string) bool) []Home {
+	var out []Home
+	for _, e := range entries {
+		if !isLocalDriveAbs(e.Path) {
+			continue
+		}
+		if isNonUserSID(e.SID) {
+			continue
+		}
+		username, res := lookup(e.SID)
+		if res == resolvedNonUser {
+			continue
+		}
+		if !verified(e.SID, e.Path) {
+			continue
+		}
+		out = append(out, Home{UID: e.SID, Username: username, Dir: e.Path})
+	}
+	return out
+}
+
+// isLocalDriveAbs reports whether path has the shape of an absolute path on a
+// local drive letter naming something under the drive root (`X:\name...`).
+// Deliberately stricter than filepath.IsAbs, which also accepts the UNC paths
+// this must reject. It remains a shape check: a drive letter mapped to a
+// network share still passes, and the on-disk ownership check is the backstop
+// there.
+func isLocalDriveAbs(path string) bool {
+	if len(path) < 4 || path[1] != ':' || path[2] != '\\' {
+		return false
+	}
+	c := path[0]
+	return 'A' <= c && c <= 'Z' || 'a' <= c && c <= 'z'
+}
+
+// isNonUserSID reports whether sid names a machine, service, or builtin
+// account by SID value alone (see nonUserSIDs).
+func isNonUserSID(sid string) bool {
+	for _, s := range nonUserSIDs {
+		if strings.EqualFold(sid, s) {
+			return true
+		}
+	}
+	for _, p := range nonUserSIDPrefixes {
+		if len(sid) >= len(p) && strings.EqualFold(sid[:len(p)], p) {
+			return true
+		}
+	}
+	return false
+}
+
+// readProfileList returns raw ProfileList records, bounded by
+// maxProfileListEntries. The key is readable by any account, so this works
+// whether or not the daemon is elevated.
+func readProfileList() []profileEntry {
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, profileListKey, registry.ENUMERATE_SUB_KEYS)
+	if err != nil {
+		return nil
+	}
+	defer k.Close()
+
+	// With a positive bound, reaching the end of the key before the bound
+	// reports io.EOF. Any other error can only leave a partial listing, which
+	// is still worth attributing homes from, so the names are used regardless.
+	sids, _ := k.ReadSubKeyNames(maxProfileListEntries)
+	out := make([]profileEntry, 0, len(sids))
+	for _, sid := range sids {
+		sk, err := registry.OpenKey(k, sid, registry.QUERY_VALUE)
+		if err != nil {
+			continue
+		}
+		path, valType, err := sk.GetStringValue("ProfileImagePath")
+		sk.Close()
+		if err != nil {
+			continue
+		}
+		if valType == registry.EXPAND_SZ {
+			expanded, err := registry.ExpandString(path)
+			if err != nil {
+				continue
+			}
+			path = expanded
+		}
+		out = append(out, profileEntry{SID: sid, Path: path})
+	}
+	return out
+}
+
+// longPathName returns the long-name spelling of path, best-effort: on any
+// failure (path missing, buffer trouble) the path is returned as given and the
+// later gates decide its fate.
+func longPathName(path string) string {
+	p, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return path
+	}
+	buf := make([]uint16, windows.MAX_PATH)
+	n, err := windows.GetLongPathName(p, &buf[0], uint32(len(buf))) //nolint:gosec // G115: len(buf) is MAX_PATH here, or the size the API itself asked for below
+	if err != nil || n == 0 {
+		return path
+	}
+	if int(n) > len(buf) {
+		// n is the required buffer size, terminator included.
+		buf = make([]uint16, n)
+		n, err = windows.GetLongPathName(p, &buf[0], uint32(len(buf))) //nolint:gosec // G115: len(buf) == n, a uint32 the API reported
+		if err != nil || n == 0 || int(n) > len(buf) {
+			return path
+		}
+	}
+	return windows.UTF16ToString(buf[:n])
 }


### PR DESCRIPTION

Resolves #51061

A profile directory's security-descriptor OWNER is an ACL field naming whoever administers the object, not the profile's user — on an administrator's profile it is commonly BUILTIN\Administrators. That put the group SID S-1-5-32-544 in uid and left username blank on every user-scoped row.

Enumerate HKLM\...\ProfileList instead, which is where Windows records which account a profile belongs to, so a home arrives with its SID already attached. The key is admin-only-writable, preserving the anti-spoofing property the owner read was chosen for. The owner read stays as a fallback for homes the key does not record, now gated on the SID naming a user account so a group or well-known SID reports empty rather than a misleading value.

<img width="1697" height="682" alt="Screenshot 2026-08-12 at 4 27 36 PM" src="https://github.com/user-attachments/assets/c52ba4ab-3055-4134-b37b-7510d9375d48" />

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved home-directory discovery and deduplication across supported platforms.
  * Improved ownership detection on Unix systems, including graceful handling of unresolved accounts.
  * On Windows, profile directories are now validated more reliably, including path, account type, drive, and on-disk ownership checks.
  * Prevented invalid, redirected, reparse-point, or non-user profile paths from being incorrectly reported as home directories.
* **Tests**
  * Added comprehensive coverage for Windows profile discovery and ownership scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->