### PR TITLE
For R.C. - Fleet UI: Fix fleets dropdown menu position on Software detail pages (#51074)

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareLibrary/SelfServiceCategoriesPage/_styles.scss
@@ -4,10 +4,6 @@
 
   &__fleet-row {
     align-self: stretch;
-
-    .fleet-dropdown-wrapper {
-      @include normalize-team-header;
-    }
   }
 
   &__premium-card {

--- a/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/_styles.scss
@@ -1,10 +1,6 @@
 .software-os-details-page {
   @include vertical-page-layout;
 
-  .fleet-dropdown-wrapper {
-    @include normalize-team-header;
-  }
-
   h2 {
     font-size: $small;
   }

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/_styles.scss
@@ -1,10 +1,6 @@
 .software-title-details-page {
   @include vertical-page-layout;
 
-  .fleet-dropdown-wrapper {
-    @include normalize-team-header;
-  }
-
   h2 {
     font-size: $small;
     margin: 0;

--- a/frontend/pages/SoftwarePage/SoftwareVersionDetailsPage/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareVersionDetailsPage/_styles.scss
@@ -1,10 +1,6 @@
 .software-version-details-page {
   @include vertical-page-layout;
 
-  .fleet-dropdown-wrapper {
-    @include normalize-team-header;
-  }
-
   h2 {
     font-size: $small;
   }

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/_styles.scss
@@ -1,10 +1,6 @@
 .software-vulnerability-details-page {
   @include vertical-page-layout;
 
-  .fleet-dropdown-wrapper {
-    @include normalize-team-header;
-  }
-
   * > h1,
   h1 {
     font-size: $large;

--- a/frontend/styles/var/mixins.scss
+++ b/frontend/styles/var/mixins.scss
@@ -25,7 +25,10 @@ $max-width: 2560px;
   }
 }
 
-// Used to normalize styling of team header wrapper on various pages
+// Apply to the outer header row that contains TeamsHeader + action buttons,
+// NOT to .fleet-dropdown-wrapper itself — the wrapper needs its own
+// `display: inline-block` so FleetsDropdown's absolutely-positioned menu
+// anchors under the button.
 @mixin normalize-team-header {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Issue
Closes #50597

## Description
- Previously merged into `main` with #51074
- This is for the 4.91.0 R.C.

## Testing
- [ ] QA'd all new/changed functionality manually