### PR TITLE
Fleet UI: Fix self-service reinstall/uninstall stuck disabled after cancelling uninstall modal

### DIFF
--- a/changes/50856-self-service-uninstall-modal-cancel
+++ b/changes/50856-self-service-uninstall-modal-cancel
@@ -1,0 +1,1 @@
+- Fixed self-service reinstall and uninstall buttons remaining disabled after cancelling the uninstall confirmation modal.

--- a/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostInstallerActionCell/HostInstallerActionCell.tests.tsx
+++ b/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostInstallerActionCell/HostInstallerActionCell.tests.tsx
@@ -1024,4 +1024,37 @@ describe("HostInstallerActionCell dropdown on My Device page", () => {
       expect(uninstallBtn.closest("button")).toBeEnabled();
     }
   );
+
+  it("leaves reinstall/uninstall buttons enabled after clicking Uninstall on My Device (fleet#50856)", async () => {
+    // Empty installed_versions surfaces Uninstall as a standalone button rather
+    // than under the More dropdown, so we can click it directly in a test.
+    const { user } = renderWithSetup(
+      <HostInstallerActionCell
+        software={{
+          ...createMockHostSoftware({
+            software_package: mockSoftwarePackage,
+            installed_versions: [],
+          }),
+          status: "installed",
+          ui_status: "installed",
+        }}
+        onClickInstallAction={noop}
+        onClickUninstallAction={noop}
+        baseClass={baseClass}
+        hostScriptsEnabled
+        hostMDMEnrolled
+        isMyDevicePage
+      />
+    );
+
+    const uninstallBtn = screen.getByTestId(
+      `${baseClass}__uninstall-button--test`
+    );
+    const installBtn = screen.getByTestId(`${baseClass}__install-button--test`);
+
+    await user.click(uninstallBtn);
+
+    expect(uninstallBtn.closest("button")).toBeEnabled();
+    expect(installBtn.closest("button")).toBeEnabled();
+  });
 });

--- a/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostInstallerActionCell/HostInstallerActionCell.tsx
+++ b/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostInstallerActionCell/HostInstallerActionCell.tsx
@@ -316,7 +316,12 @@ export const HostInstallerActionCell = ({
 
   const handleUninstallClick = () => {
     if (uninstallDisabled || isInstallUninstallPendingLocal) return;
-    setIsInstallUninstallPendingLocal(true);
+    // On My Device, uninstall opens a confirmation modal instead of calling the
+    // API directly. Skip the optimistic pending flag so cancelling the modal
+    // doesn't leave the row's buttons stuck disabled (#50856).
+    if (!isMyDevicePage) {
+      setIsInstallUninstallPendingLocal(true);
+    }
     onClickUninstallAction();
   };
 


### PR DESCRIPTION
## Issue
Closes #50856

## Description
- Bug fix (root cause): On My Device (self-service), `handleUninstallClick` in `HostInstallerActionCell` optimistically sets a local pending flag to disable the button during the API round-trip. That was written for Host details > Library, where `onClickUninstallAction` calls the API directly — but on self-service, `onClickUninstallAction` just opens the confirmation modal. If the user cancels the modal (or clicks outside it), `status` never transitions to `pending_uninstall`, so the `useEffect` that clears the flag never fires, and both Reinstall and Uninstall stay disabled until page refresh.
- Skip the optimistic pending flag when `isMyDevicePage` is true. The modal's own loading state covers the API round-trip after confirm, and polling picks up `pending_uninstall` from there. Host details > Library behavior is unchanged.

## Screenrecording
- Uninstall from self-service, click outside modal, verify Reinstall + Uninstall stay enabled


https://github.com/user-attachments/assets/0974ea5e-59d8-4322-bf2b-20287cfd52fc




## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where cancelling a self-service uninstall confirmation could leave the Uninstall and Reinstall buttons disabled.
  * Buttons now remain available after cancelling an uninstall action on the My Device page.

* **Tests**
  * Added regression coverage to verify the buttons stay enabled after cancelling an uninstall confirmation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->