### PR TITLE
Website: update thrown error in get-one-compliance-status-result

### DIFF
--- a/website/api/controllers/microsoft-proxy/get-one-compliance-status-result.js
+++ b/website/api/controllers/microsoft-proxy/get-one-compliance-status-result.js
@@ -50,7 +50,7 @@ module.exports = {
         'Authorization': `Bearer ${accessToken}`
       }
     }).intercept((err)=>{
-      return new Error({error: `An error occurred when retrieving a compliance status result of a device for a Microsoft compliance tenant. Full error: ${require('util').inspect(err, {depth: 3})}`});
+      return new Error(`An error occurred when retrieving a compliance status result of a device for a Microsoft compliance tenant. Full error: ${require('util').inspect(err, {depth: 3})}`);
     });
 
     // Log responses from Micrsoft APIs for Fleet's integration


### PR DESCRIPTION
Related to: https://github.com/fleetdm/fleet/issues/51103

Changes:
- Updated the error that is thrown when a request to a Microsoft API to get the status of a device compliance update returns a non-2xx response.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for Microsoft compliance status requests by returning clearer, standard error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->