### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/amie/darwin.json
+++ b/ee/maintained-apps/outputs/amie/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "260722.1.0",
+      "version": "260812.0.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'so.amie.electron-app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'so.amie.electron-app' AND version_compare(bundle_short_version, '260722.1.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'so.amie.electron-app' AND version_compare(bundle_short_version, '260812.0.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'so.amie.electron-app');"
       },
-      "installer_url": "https://github.com/amieso/electron-releases/releases/download/v260722.1.0/Amie-260722.1.0-arm64-mac.zip",
+      "installer_url": "https://github.com/amieso/electron-releases/releases/download/v260812.0.0/Amie-260812.0.0-arm64-mac.zip",
       "install_script_ref": "be47fa85",
       "uninstall_script_ref": "44125419",
-      "sha256": "aaa8b9a0ab008f03efcb7ae1e9417fd7060d96849fb0a4a36220c1c7ecc41fd7",
+      "sha256": "84576e8dac9cb59a288048a05dff6b4e2f0c5152b9e22db5158657b512a8d541",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/antigravity-ide/darwin.json
+++ b/ee/maintained-apps/outputs/antigravity-ide/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "2.1.1",
+      "version": "2.5.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.antigravity-ide';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.antigravity-ide' AND version_compare(bundle_short_version, '2.1.1') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.antigravity-ide' AND version_compare(bundle_short_version, '2.5.2') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.google.antigravity-ide');"
       },
-      "installer_url": "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/2.1.1-6123990880747520/darwin-arm/Antigravity%20IDE.dmg",
+      "installer_url": "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/2.5.2-6697361355964416/darwin-arm/Antigravity%20IDE.dmg",
       "install_script_ref": "4037de63",
       "uninstall_script_ref": "3457f3ae",
-      "sha256": "e0a132f335c368e2df874662f589eafca29697a51402017aeb7471026bdd1b29",
+      "sha256": "e751a1bb551f73665b33398f13d2b90d6b07c6931318d34c0b49792bd8a949d6",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/antigravity-ide/windows.json
+++ b/ee/maintained-apps/outputs/antigravity-ide/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "2.1.1",
+      "version": "2.5.2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Antigravity IDE %' AND publisher = 'Google';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Antigravity IDE %' AND publisher = 'Google' AND version_compare(version, '2.1.1') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Antigravity IDE %' AND publisher = 'Google' AND version_compare(version, '2.5.2') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'antigravity.exe');"
       },
-      "installer_url": "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/2.1.1-6123990880747520/windows-x64/Antigravity%20IDE.exe",
+      "installer_url": "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/2.5.2-6697361355964416/windows-x64/Antigravity%20IDE.exe",
       "install_script_ref": "8b15c4d0",
       "uninstall_script_ref": "65cab11a",
-      "sha256": "d6d17a8f91c70f349505086847a79f60271a6ecdd851252e95ff0469dd5ad985",
+      "sha256": "dc69c801b018e16e90c38322a4ce622adc6e31dedf95c6fee9a46dd6ee41b4aa",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/beeper/darwin.json
+++ b/ee/maintained-apps/outputs/beeper/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "4.3.20",
+      "version": "4.3.34",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.automattic.beeper.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.automattic.beeper.desktop' AND version_compare(bundle_short_version, '4.3.20') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.automattic.beeper.desktop' AND version_compare(bundle_short_version, '4.3.34') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.automattic.beeper.desktop');"
       },
-      "installer_url": "https://beeper-desktop.download.beeper.com/builds/Beeper-4.3.20-arm64-mac.zip",
+      "installer_url": "https://beeper-desktop.download.beeper.com/builds/Beeper-4.3.34-arm64-mac.zip",
       "install_script_ref": "403ed251",
       "uninstall_script_ref": "978d30f8",
-      "sha256": "afddf6ba63bf9980a63567c9fd165dd3c5b19d091d1bbc8361b21b9c291455ef",
+      "sha256": "9ac64e0f220e351e54faa7410a471ba6766d8d86642a6a235c05eda47aa982b0",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/firefox@nightly/darwin.json
+++ b/ee/maintained-apps/outputs/firefox@nightly/darwin.json
@@ -7,10 +7,10 @@
         "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15526.8.12') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'org.mozilla.nightly');"
       },
-      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/08/2026-08-12-09-36-59-mozilla-central/firefox-155.0a1.en-US.mac.dmg",
+      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/08/2026-08-12-20-20-37-mozilla-central/firefox-155.0a1.en-US.mac.dmg",
       "install_script_ref": "d9c4cf87",
       "uninstall_script_ref": "0661f848",
-      "sha256": "80e0a76afbac40e27a86b6ff8f1a8d3582a92991a06a2041f007f41209da8bd6",
+      "sha256": "962d42591990a0110dc7cb155ec4de7fe437e67ba7be86757fe03a745d89fe11",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/kiro-cli/darwin.json
+++ b/ee/maintained-apps/outputs/kiro-cli/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "2.17.0",
+      "version": "2.18.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kiro.cli';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kiro.cli' AND version_compare(bundle_short_version, '2.17.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kiro.cli' AND version_compare(bundle_short_version, '2.18.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'dev.kiro.cli');"
       },
-      "installer_url": "https://desktop-release.q.us-east-1.amazonaws.com/2.17.0/Kiro%20CLI.dmg",
+      "installer_url": "https://desktop-release.q.us-east-1.amazonaws.com/2.18.0/Kiro%20CLI.dmg",
       "install_script_ref": "21bed962",
       "uninstall_script_ref": "ed98f0de",
-      "sha256": "39a154901d7f21db42a025bd8fb78227092fc44593b944848c2016f0df5fa54f",
+      "sha256": "5af50db253ac8032d8fac1cb9fa4432d42dd81e8c68a71d23bf4d508c8bfca45",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/opencode-desktop/darwin.json
+++ b/ee/maintained-apps/outputs/opencode-desktop/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.18.17",
+      "version": "1.18.18",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'ai.opencode.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'ai.opencode.desktop' AND version_compare(bundle_short_version, '1.18.17') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'ai.opencode.desktop' AND version_compare(bundle_short_version, '1.18.18') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'ai.opencode.desktop');"
       },
-      "installer_url": "https://github.com/anomalyco/opencode/releases/download/v1.18.17/opencode-desktop-mac-arm64.dmg",
+      "installer_url": "https://github.com/anomalyco/opencode/releases/download/v1.18.18/opencode-desktop-mac-arm64.dmg",
       "install_script_ref": "d2ce7b1a",
       "uninstall_script_ref": "99fcb3f1",
-      "sha256": "1b04a42ba335bb1ee8589fb04483013a028f3ecdf4c5d60f234f36637b2bcc72",
+      "sha256": "ad618b8d3abf66e4af57e960d596d9d693a8ce9db7c9b9041b80115e1ef2baeb",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/rectangle-pro/darwin.json
+++ b/ee/maintained-apps/outputs/rectangle-pro/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "3.82",
+      "version": "3.87",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.knollsoft.Hookshot';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.knollsoft.Hookshot' AND version_compare(bundle_short_version, '3.82') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.knollsoft.Hookshot' AND version_compare(bundle_short_version, '3.87') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.knollsoft.Hookshot');"
       },
-      "installer_url": "https://rectangleapp.com/pro/downloads/Rectangle%20Pro%203.82.dmg",
+      "installer_url": "https://rectangleapp.com/pro/downloads/Rectangle%20Pro%203.87.dmg",
       "install_script_ref": "10bd873b",
       "uninstall_script_ref": "861394ab",
-      "sha256": "98bd28e7588e9daee673d0299fef793f1ca88b37ba31950c068e91f0a3b50651",
+      "sha256": "d083fe0f31d22987bfde0c8a40e15339a3cca659e0feb7a02a09e3b83a16b15e",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated release information for Amie, Antigravity IDE, Beeper Desktop, Kiro CLI, OpenCode Desktop, and Rectangle Pro.
  - Updated Firefox Nightly’s macOS build information to the latest available release.
  - Refreshed download links, version checks, and verification checksums for the listed applications across macOS and Windows.
  - Existing installation and uninstallation behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->