### PR TITLE
always run loadtest with --dev

### DIFF
--- a/infrastructure/loadtesting/terraform/ecs.tf
+++ b/infrastructure/loadtesting/terraform/ecs.tf
@@ -113,6 +113,7 @@ resource "aws_ecs_task_definition" "backend" {
             awslogs-stream-prefix = "fleet"
           }
         },
+        command = ["fleet", "serve", "--dev"]
         secrets = concat([
           {
             name      = "FLEET_MYSQL_PASSWORD"

--- a/infrastructure/loadtesting/terraform/infra/internal_alb.tf
+++ b/infrastructure/loadtesting/terraform/infra/internal_alb.tf
@@ -31,6 +31,13 @@ resource "aws_lb" "internal" {
     prefix  = local.customer
     enabled = true
   }
+
+  # log_s3_bucket_id only carries a dependency on the bucket itself, not on its
+  # bucket policy. Enabling access logs makes ELB test-write to the bucket, so
+  # without this the internal ALB (which has few other dependencies and is
+  # therefore scheduled early) can be created before the log delivery policy is
+  # attached and fail with "Access Denied for bucket: <prefix>-alb-logs".
+  depends_on = [module.logging_alb]
 }
 
 resource "aws_lb_listener" "internal" {

--- a/infrastructure/loadtesting/terraform/infra/locals.tf
+++ b/infrastructure/loadtesting/terraform/infra/locals.tf
@@ -56,6 +56,9 @@ locals {
       FLEET_MYSQL_TLS_CA                  = local.cert_path
       FLEET_MYSQL_READ_REPLICA_TLS_CA     = local.cert_path
       FLEET_MYSQL_READ_REPLICA_TLS_CONFIG = "custom"
+
+      # Skip backfilling S3 config with dev values for load testing
+      FLEET_DEV_SKIP_S3_CONFIG = "1"
     },
     local.otel_environment_variables,
     local.elastic_apm_environment_variables


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves nothing, but makes `FLEET_DEV_*` available in loadtests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the ECS backend startup command to run the service in development mode.
  * Improved load-testing configuration by preventing development S3 settings from being applied automatically.
* **Bug Fixes**
  * Improved load-testing infrastructure setup by ensuring access logging is configured before the internal load balancer is created.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->