### PR TITLE
Support custom APNs URL in dev mode

### DIFF
--- a/cmd/fleet/mdm_apple.go
+++ b/cmd/fleet/mdm_apple.go
@@ -59,12 +59,23 @@ func initAppleMDMPushService(mdmStorage *mysql.NanoMDMStorage, logger *slog.Logg
 		return nopPusher{}
 	}
 	nanoMDMLogger := service.NewNanoMDMLogger(logger.With("component", "apple-mdm-push"))
-	pushProviderFactory := buford.NewPushProviderFactory(buford.WithNewClient(func(cert *tls.Certificate) (*http.Client, error) {
-		return fleethttp.NewClient(fleethttp.WithTLSClientConfig(&tls.Config{
-			Certificates: []tls.Certificate{*cert},
-			MinVersion:   tls.VersionTLS12, // Apple APNs requires TLS 1.2+
-		})), nil
-	}))
+
+	opts := []buford.Option{
+		buford.WithNewClient(func(cert *tls.Certificate) (*http.Client, error) {
+			return fleethttp.NewClient(fleethttp.WithTLSClientConfig(&tls.Config{
+				Certificates: []tls.Certificate{*cert},
+				MinVersion:   tls.VersionTLS12, // Apple APNs requires TLS 1.2+
+			})), nil
+		}),
+	}
+
+	devPushServer := dev_mode.Env("FLEET_DEV_MDM_APPLE_PUSH_SERVER_URL")
+	if devPushServer != "" {
+		logger.InfoContext(context.Background(), "using dev push server URL", "url", devPushServer)
+		opts = append(opts, buford.WithPushServerURL(devPushServer))
+	}
+
+	pushProviderFactory := buford.NewPushProviderFactory(opts...)
 	return nanomdm_pushsvc.New(mdmStorage, mdmStorage, pushProviderFactory, nanoMDMLogger)
 }
 

--- a/cmd/fleet/mdm_apple_test.go
+++ b/cmd/fleet/mdm_apple_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql"
 	"github.com/fleetdm/fleet/v4/server/dev_mode"
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	nanomdm_pushsvc "github.com/fleetdm/fleet/v4/server/mdm/nanomdm/push/service"
+
 	"github.com/fleetdm/fleet/v4/server/mock"
 	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/require"
@@ -44,6 +46,14 @@ func TestInitAppleMDMPushService_DevModeReturnsNopPusher(t *testing.T) {
 
 	pusher := initAppleMDMPushService(nil, discardLogger())
 	require.IsType(t, nopPusher{}, pusher)
+}
+
+func TestInitAppleMDMPushService_DevModeCustomPushServerURL(t *testing.T) {
+	// SetOverride enables dev mode and registers cleanup via t.
+	dev_mode.SetOverride("FLEET_DEV_MDM_APPLE_PUSH_SERVER_URL", "http://localhost:8378", t)
+
+	pusher := initAppleMDMPushService(nil, discardLogger())
+	require.IsType(t, &nanomdm_pushsvc.PushService{}, pusher)
 }
 
 func TestCheckMDMAssetsExist(t *testing.T) {

--- a/docs/Contributing/product-groups/mdm/apple-apns-mock.md
+++ b/docs/Contributing/product-groups/mdm/apple-apns-mock.md
@@ -51,9 +51,11 @@ Target is 300k concurrent connections. The token registry is sharded 256 ways to
 
 Debugging aid: `tools/mdm/apple/apnspush -direct` sends raw pushes from a Fleet database to any APNs endpoint (real, sandbox, or this mock) and dumps the raw response. Its `-fake` flag derives mdmtest-style tokens for hosts that aren't in `nano_enrollments`.
 
-## Fleet server changes (#31311)
+## Configuring Fleet to use a custom APNs server
 
-To be written when the wiring lands. Plan: a dev-mode env var that switches the buford host from `bufordpush.Production` (`server/mdm/nanomdm/push/buford/buford.go`) to the mock's URL. Note that `fleethttp` blocks loopback and private addresses unless the server runs with `--dev` or `FLEET_SERVER_BYPASS_NETWORK_BLOCKING=1`.
+To configure Fleet to use the mock APNs server, set `FLEET_DEV_MDM_APPLE_PUSH_SERVER_URL` to the base URL of the mock server. 
+
+This requires Fleet to be started with `--dev`, and does **not** work alongside `FLEET_DEV_MDM_APPLE_DISABLE_PUSH`.
 
 ## osquery-perf changes (#31313)
 

--- a/server/mdm/nanomdm/push/buford/buford.go
+++ b/server/mdm/nanomdm/push/buford/buford.go
@@ -22,6 +22,7 @@ type bufordFactory struct {
 	workers           uint
 	expiration        time.Duration
 	newClientCallback NewClient
+	pushServerURL     *string
 }
 
 type Option func(*bufordFactory)
@@ -49,6 +50,13 @@ func WithNewClient(newClientCallback NewClient) Option {
 	}
 }
 
+// WithPushServerURL sets the APNs server URL for the push notifications.
+func WithPushServerURL(pushServerURL string) Option {
+	return func(f *bufordFactory) {
+		f.pushServerURL = &pushServerURL
+	}
+}
+
 // NewPushProviderFactory creates a new instance that can spawn buford Services
 func NewPushProviderFactory(opts ...Option) *bufordFactory {
 	factory := &bufordFactory{
@@ -72,8 +80,13 @@ func (f *bufordFactory) NewPushProvider(cert *tls.Certificate) (push.PushProvide
 	if err != nil {
 		return nil, err
 	}
+	host := bufordpush.Production
+	if f.pushServerURL != nil {
+		host = *f.pushServerURL
+	}
+
 	prov := &bufordPushProvider{
-		service:    bufordpush.NewService(client, bufordpush.Production),
+		service:    bufordpush.NewService(client, host),
 		expiration: f.expiration,
 		workers:    f.workers,
 	}

--- a/server/mdm/nanomdm/push/nanopush/nanopush.go
+++ b/server/mdm/nanomdm/push/nanopush/nanopush.go
@@ -44,9 +44,10 @@ func defaultNewClient(cert *tls.Certificate) (*http.Client, error) {
 
 // Factory instantiates new PushProviders.
 type Factory struct {
-	newClient  NewClient
-	expiration time.Duration
-	workers    int
+	newClient     NewClient
+	expiration    time.Duration
+	workers       int
+	pushServerURL *string
 }
 
 type Option func(*Factory)
@@ -77,6 +78,13 @@ func WithWorkers(workers int) Option {
 	}
 }
 
+// WithPushServerURL sets the APNs server URL for the push notifications.
+func WithPushServerURL(pushServerURL string) Option {
+	return func(f *Factory) {
+		f.pushServerURL = &pushServerURL
+	}
+}
+
 // NewFactory creates a new Factory.
 func NewFactory(opts ...Option) *Factory {
 	f := &Factory{
@@ -91,10 +99,14 @@ func NewFactory(opts ...Option) *Factory {
 
 // NewPushProvider generates a new PushProvider given a tls keypair.
 func (f *Factory) NewPushProvider(cert *tls.Certificate) (push.PushProvider, error) {
+	baseURL := Production
+	if f.pushServerURL != nil {
+		baseURL = *f.pushServerURL
+	}
 	p := &Provider{
 		expiration: f.expiration,
 		workers:    f.workers,
-		baseURL:    Production,
+		baseURL:    baseURL,
 	}
 	var err error
 	p.client, err = f.newClient(cert)

--- a/tools/mdm/apple/apnspush/main.go
+++ b/tools/mdm/apple/apnspush/main.go
@@ -29,6 +29,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/hex"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -168,9 +169,11 @@ func pushDirect(ctx context.Context, mdmStorage *mysql.NanoMDMStorage, baseURL s
 			// Same deterministic scheme mdmtest clients use in TokenUpdate
 			// (pkg/mdm/mdmtest/apple.go), so fake pushes line up with what
 			// simulated devices derive for themselves.
+			hexToken := make([]byte, hex.EncodedLen(len("token"+uuid)))
+			_ = hex.Encode(hexToken, []byte("token"+uuid))
 			pushInfo = &mdm.Push{
 				PushMagic: "pushmagic" + uuid,
-				Token:     []byte("token" + uuid),
+				Token:     hexToken,
 				Topic:     "com.apple.mgmt.External." + uuid,
 			}
 			provenance = "not in nano_enrollments — derived fake (mdmtest scheme)"

--- a/tools/mdm/apple/apnspush/main.go
+++ b/tools/mdm/apple/apnspush/main.go
@@ -29,7 +29,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
-	"encoding/hex"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -169,11 +168,9 @@ func pushDirect(ctx context.Context, mdmStorage *mysql.NanoMDMStorage, baseURL s
 			// Same deterministic scheme mdmtest clients use in TokenUpdate
 			// (pkg/mdm/mdmtest/apple.go), so fake pushes line up with what
 			// simulated devices derive for themselves.
-			hexToken := make([]byte, hex.EncodedLen(len("token"+uuid)))
-			_ = hex.Encode(hexToken, []byte("token"+uuid))
 			pushInfo = &mdm.Push{
 				PushMagic: "pushmagic" + uuid,
-				Token:     hexToken,
+				Token:     []byte("token" + uuid),
 				Topic:     "com.apple.mgmt.External." + uuid,
 			}
 			provenance = "not in nano_enrollments — derived fake (mdmtest scheme)"


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #31311 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information. Internal test change only.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a custom Apple MDM push server URL.
  * Production push service behavior remains unchanged by default.
  * Development environments can now direct push notifications to an alternate server.

* **Bug Fixes**
  * Preserved the custom TLS 1.2 client configuration when initializing the Apple MDM push service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->