### PR TITLE
[Docs] Fix patch policy flag name in installed_software activity

### DIFF
--- a/docs/Contributing/reference/audit-logs.md
+++ b/docs/Contributing/reference/audit-logs.md
@@ -1658,7 +1658,7 @@ This activity contains the following fields:
 - "command_uuid": ID of the in-house app installation.
 - "from_setup_experience": Whether the installation was triggered as part of the setup experience.
 - "failure_reason": Reason the installation failed before reaching the device (e.g. an unresolvable Fleet variable in the managed app configuration). Only present when "status" is "failed_install" and Fleet failed the install pre-flight; omitted otherwise.
-- "skipped_install": Whether the install was skipped because the app was open. This is `true` when the Fleet-maintained app is installed by the patch policy's automation, when `patch_only_when_closed` is set. Only present when "status" is "failed_install" and the install was skipped for this reason, omitted otherwise.
+- "skipped_install": Whether the install was skipped because the app was open. This is `true` when the Fleet-maintained app is installed by the patch policy's automation, when `patch_when_closed` is set. Only present when "status" is "failed_install" and the install was skipped for this reason, omitted otherwise.
 
 #### Example
 


### PR DESCRIPTION
**Related issue:** #51052

The `installed_software` activity reference cross-referenced the patch policy field as `patch_only_when_closed`. The field has always been `patch_when_closed` in GitOps and the API — the old name only ever existed in docs. `yaml-files.md` was corrected during review; this line was missed and carried onto this branch by #49106.

The `skipped_install` key documented on the same line is already correct and unchanged — that name is what fleetdm/fleet#51102 renames the code to match.

Docs-only, one line.

# Checklist for submitter

## Testing
- [ ] QA'd all new/changed functionality manually
