### PR TITLE
Install in-house apps during iOS/iPadOS setup experience

### DIFF
--- a/changes/33995-ipa-setup-experience
+++ b/changes/33995-ipa-setup-experience
@@ -1,0 +1,1 @@
+- Added support for automatically installing in-house apps (`.ipa`) on iOS and iPadOS hosts when they enroll to Fleet, via Controls > Setup experience > Install software or GitOps (`setup_experience_platform`).

--- a/changes/33995-ipa-setup-experience
+++ b/changes/33995-ipa-setup-experience
@@ -1,1 +1,1 @@
-- Added support for automatically installing in-house apps (`.ipa`) on iOS and iPadOS hosts when they enroll to Fleet, via Controls > Setup experience > Install software or GitOps (`setup_experience_platform`).
+- Added support for automatically installing in-house apps (`.ipa`) on iOS and iPadOS hosts when they enroll into Fleet.

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -1272,6 +1272,7 @@ func newAppleMDMWorkerSchedule(
 	commander *apple_mdm.MDMAppleCommander,
 	bootstrapPackageStore fleet.MDMBootstrapPackageStore,
 	vppInstaller fleet.AppleMDMVPPInstaller,
+	inHouseAppInstaller fleet.AppleMDMInHouseAppInstaller,
 	newActivityFn fleet.NewActivityFunc,
 ) (*schedule.Schedule, error) {
 	const (
@@ -1290,6 +1291,7 @@ func newAppleMDMWorkerSchedule(
 		Commander:             commander,
 		BootstrapPackageStore: bootstrapPackageStore,
 		VPPInstaller:          vppInstaller,
+		InHouseAppInstaller:   inHouseAppInstaller,
 		NewActivityFn:         newActivityFn,
 	}
 

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -1272,7 +1272,7 @@ func newAppleMDMWorkerSchedule(
 	commander *apple_mdm.MDMAppleCommander,
 	bootstrapPackageStore fleet.MDMBootstrapPackageStore,
 	vppInstaller fleet.AppleMDMVPPInstaller,
-	inHouseAppInstaller fleet.AppleMDMInHouseAppInstaller,
+	inHouseAppInstaller worker.InHouseAppInstaller,
 	newActivityFn fleet.NewActivityFunc,
 ) (*schedule.Schedule, error) {
 	const (

--- a/cmd/fleet/cron_registration.go
+++ b/cmd/fleet/cron_registration.go
@@ -215,8 +215,8 @@ func registerWorkerCrons(ctx context.Context, deps cronSchedulesDeps) {
 func registerMDMCrons(ctx context.Context, deps cronSchedulesDeps) {
 	deps.register("failed to register apple_mdm_worker schedule", func() (fleet.CronSchedule, error) {
 		vppInstaller := deps.svc.(fleet.AppleMDMVPPInstaller)
-		inHouseAppInstaller := deps.svc.(fleet.AppleMDMInHouseAppInstaller)
-		return newAppleMDMWorkerSchedule(ctx, deps.instanceID, deps.ds, deps.logger, deps.commander, deps.bootstrapPackageStore, vppInstaller, inHouseAppInstaller, deps.svc.NewActivity)
+		// deps.svc satisfies the worker's consumer-side interface directly, no assertion needed
+		return newAppleMDMWorkerSchedule(ctx, deps.instanceID, deps.ds, deps.logger, deps.commander, deps.bootstrapPackageStore, vppInstaller, deps.svc, deps.svc.NewActivity)
 	})
 
 	deps.register("failed to register apple_mdm_dep_profile_assigner schedule", func() (fleet.CronSchedule, error) {

--- a/cmd/fleet/cron_registration.go
+++ b/cmd/fleet/cron_registration.go
@@ -215,7 +215,8 @@ func registerWorkerCrons(ctx context.Context, deps cronSchedulesDeps) {
 func registerMDMCrons(ctx context.Context, deps cronSchedulesDeps) {
 	deps.register("failed to register apple_mdm_worker schedule", func() (fleet.CronSchedule, error) {
 		vppInstaller := deps.svc.(fleet.AppleMDMVPPInstaller)
-		return newAppleMDMWorkerSchedule(ctx, deps.instanceID, deps.ds, deps.logger, deps.commander, deps.bootstrapPackageStore, vppInstaller, deps.svc.NewActivity)
+		inHouseAppInstaller := deps.svc.(fleet.AppleMDMInHouseAppInstaller)
+		return newAppleMDMWorkerSchedule(ctx, deps.instanceID, deps.ds, deps.logger, deps.commander, deps.bootstrapPackageStore, vppInstaller, inHouseAppInstaller, deps.svc.NewActivity)
 	})
 
 	deps.register("failed to register apple_mdm_dep_profile_assigner schedule", func() (fleet.CronSchedule, error) {

--- a/cmd/fleet/cron_registration.go
+++ b/cmd/fleet/cron_registration.go
@@ -215,7 +215,6 @@ func registerWorkerCrons(ctx context.Context, deps cronSchedulesDeps) {
 func registerMDMCrons(ctx context.Context, deps cronSchedulesDeps) {
 	deps.register("failed to register apple_mdm_worker schedule", func() (fleet.CronSchedule, error) {
 		vppInstaller := deps.svc.(fleet.AppleMDMVPPInstaller)
-		// deps.svc satisfies the worker's consumer-side interface directly, no assertion needed
 		return newAppleMDMWorkerSchedule(ctx, deps.instanceID, deps.ds, deps.logger, deps.commander, deps.bootstrapPackageStore, vppInstaller, deps.svc, deps.svc.NewActivity)
 	})
 

--- a/ee/server/service/setup_experience.go
+++ b/ee/server/service/setup_experience.go
@@ -412,6 +412,16 @@ func (svc *Service) SetupExperienceNextStep(ctx context.Context, host *fleet.Hos
 					return false, ctxerr.Wrap(ctx, err, "updating setup experience with vpp install command uuid")
 				}
 			}
+		case sw.InHouseAppID != nil:
+			// In-house apps only install during setup experience on iOS/iPadOS,
+			// which is driven in one pass by the worker and never reaches this
+			// poll-driven flow. Fail the item instead of letting it fall through
+			// the switch silently and stall the queue.
+			sw.Status = fleet.SetupExperienceStatusFailure
+			if err := svc.ds.UpdateSetupExperienceStatusResult(ctx, sw); err != nil {
+				return false, ctxerr.Wrap(ctx, err, "updating setup experience status result to failure")
+			}
+			svc.logger.ErrorContext(ctx, "unexpected in-house app setup experience item in poll-driven flow", "status_id", sw.ID)
 		}
 	case softwareRunning == 0 && len(scriptsPending) > 0:
 		// enqueue scripts

--- a/ee/server/service/setup_experience.go
+++ b/ee/server/service/setup_experience.go
@@ -418,6 +418,7 @@ func (svc *Service) SetupExperienceNextStep(ctx context.Context, host *fleet.Hos
 			// poll-driven flow. Fail the item instead of letting it fall through
 			// the switch silently and stall the queue.
 			sw.Status = fleet.SetupExperienceStatusFailure
+			sw.Error = new("In-house apps can only be installed during setup experience on iOS and iPadOS.")
 			if err := svc.ds.UpdateSetupExperienceStatusResult(ctx, sw); err != nil {
 				return false, ctxerr.Wrap(ctx, err, "updating setup experience status result to failure")
 			}

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -1749,7 +1749,8 @@ func (svc *Service) InstallSoftwareTitle(ctx context.Context, hostID uint, softw
 			}
 			switch err := svc.precheckAppConfigResolvable(ctx, host, cfg); {
 			case errors.Is(err, apple_mdm.ErrUnresolvableAppConfigVar):
-				return svc.recordFailedInHouseInstall(ctx, host.ID, iha.InstallerID, opts, unresolvableAppConfigFailureReason(err))
+				_, err := svc.recordFailedInHouseInstall(ctx, host.ID, iha.InstallerID, opts, unresolvableAppConfigFailureReason(err))
+				return err
 			case err != nil:
 				return ctxerr.Wrap(ctx, err, "pre-flight substitute fleet variables in in-house app configuration")
 			}
@@ -1961,19 +1962,50 @@ func (svc *Service) recordFailedVPPInstall(ctx context.Context, host *fleet.Host
 }
 
 // recordFailedInHouseInstall is the in-house (.ipa) counterpart of
-// recordFailedVPPInstall.
-func (svc *Service) recordFailedInHouseInstall(ctx context.Context, hostID, inHouseAppID uint, opts fleet.HostSoftwareInstallOptions, reason string) error {
+// recordFailedVPPInstall. Like it, the setup-experience driver needs an error
+// signal to transition the step to Failure, so ForSetupExperience returns a
+// *fleet.PreflightInstallFailedError (see that type's doc).
+func (svc *Service) recordFailedInHouseInstall(ctx context.Context, hostID, inHouseAppID uint, opts fleet.HostSoftwareInstallOptions, reason string) (string, error) {
 	cmdUUID := uuid.NewString()
 	user, act, err := svc.ds.RecordFailedInHouseAppInstall(ctx, hostID, inHouseAppID, cmdUUID, reason, opts)
 	if err != nil {
-		return ctxerr.Wrap(ctx, err, "record failed in-house install")
+		return "", ctxerr.Wrap(ctx, err, "record failed in-house install")
 	}
 	if act != nil {
 		if err := svc.NewActivity(ctx, user, act); err != nil {
-			return ctxerr.Wrap(ctx, err, "create activity for failed in-house install")
+			return "", ctxerr.Wrap(ctx, err, "create activity for failed in-house install")
 		}
 	}
-	return nil
+	if opts.ForSetupExperience {
+		return cmdUUID, &fleet.PreflightInstallFailedError{Reason: reason}
+	}
+	return cmdUUID, nil
+}
+
+// InstallInHouseAppForSetupExperience enqueues an in-house app (.ipa) install
+// for a host held in Setup Assistant. Unlike the manual install path above, it
+// deliberately skips IsInHouseAppLabelScoped: labels don't apply during setup
+// experience for any software type, and a freshly-enrolled host has no
+// computed label membership yet anyway.
+func (svc *Service) InstallInHouseAppForSetupExperience(ctx context.Context, host *fleet.Host, inHouseAppID uint, softwareTitleID uint) (string, error) {
+	opts := fleet.HostSoftwareInstallOptions{SelfService: false, ForSetupExperience: true}
+
+	cfg, err := svc.ds.GetInHouseAppConfiguration(ctx, inHouseAppID)
+	if err != nil && !fleet.IsNotFound(err) {
+		return "", ctxerr.Wrap(ctx, err, "get in-house app configuration for pre-flight check")
+	}
+	switch err := svc.precheckAppConfigResolvable(ctx, host, cfg); {
+	case errors.Is(err, apple_mdm.ErrUnresolvableAppConfigVar):
+		return svc.recordFailedInHouseInstall(ctx, host.ID, inHouseAppID, opts, unresolvableAppConfigFailureReason(err))
+	case err != nil:
+		return "", ctxerr.Wrap(ctx, err, "pre-flight substitute fleet variables in in-house app configuration")
+	}
+
+	cmdUUID := uuid.NewString()
+	if err := svc.ds.InsertHostInHouseAppInstall(ctx, host.ID, inHouseAppID, softwareTitleID, cmdUUID, opts); err != nil {
+		return "", ctxerr.Wrap(ctx, err, "insert in-house app install for setup experience")
+	}
+	return cmdUUID, nil
 }
 
 func (svc *Service) InstallVPPAppPostValidation(ctx context.Context, host *fleet.Host, vppApp *fleet.VPPApp, token string, opts fleet.HostSoftwareInstallOptions) (string, error) {
@@ -4470,7 +4502,8 @@ func (svc *Service) selfServiceInstallInHouseApp(ctx context.Context, host *flee
 	}
 	switch err := svc.precheckAppConfigResolvable(ctx, host, cfg); {
 	case errors.Is(err, apple_mdm.ErrUnresolvableAppConfigVar):
-		return svc.recordFailedInHouseInstall(ctx, host.ID, iha.InstallerID, opts, unresolvableAppConfigFailureReason(err))
+		_, err := svc.recordFailedInHouseInstall(ctx, host.ID, iha.InstallerID, opts, unresolvableAppConfigFailureReason(err))
+		return err
 	case err != nil:
 		return ctxerr.Wrap(ctx, err, "pre-flight substitute fleet variables in in-house app configuration")
 	}

--- a/server/datastore/mysql/setup_experience.go
+++ b/server/datastore/mysql/setup_experience.go
@@ -202,6 +202,7 @@ SELECT
 	'pending' AS status,
 	si.id AS software_installer_id,
 	NULL AS vpp_app_team_id,
+	NULL AS in_house_app_id,
 	-- policy_gated: true when the installer has at least one policy whose install-software automation points at it (a gating policy
 	-- used as a gate during setup experience). A policy's software_installer_id already uniquely identifies the installer (and its
 	-- team), so no team check is needed; only gate on Windows/Linux. The specific policy ids are derived from the installer at
@@ -267,6 +268,7 @@ SELECT
 	'pending' AS status,
 	si.id AS software_installer_id,
 	NULL AS vpp_app_team_id,
+	NULL AS in_house_app_id,
 	FALSE AS policy_gated,
 	COALESCE(stdn.display_name, st.name) AS sort_name,
 	st.id AS software_title_id
@@ -303,6 +305,7 @@ SELECT
 	'pending' AS status,
 	NULL AS software_installer_id,
 	vat.id AS vpp_app_team_id,
+	NULL AS in_house_app_id,
 	FALSE AS policy_gated,
 	COALESCE(stdn.display_name, st.name) AS sort_name,
 	st.id AS software_title_id
@@ -330,6 +333,43 @@ AND %s`
 		}
 	}
 
+	// In-house apps (.ipa) install during setup on iOS/iPadOS only. Deliberately
+	// no in_house_app_labels join: labels don't apply during setup (see the
+	// comment on the INSERT below), and a freshly-enrolled host has no computed
+	// label membership yet anyway.
+	if fleetPlatform == "ios" || fleetPlatform == "ipados" {
+		inHouseSelect := `
+SELECT
+	? AS host_uuid,
+	st.name AS name,
+	'pending' AS status,
+	NULL AS software_installer_id,
+	NULL AS vpp_app_team_id,
+	iha.id AS in_house_app_id,
+	FALSE AS policy_gated,
+	COALESCE(stdn.display_name, st.name) AS sort_name,
+	st.id AS software_title_id
+FROM in_house_apps iha
+INNER JOIN software_titles st
+	ON iha.title_id = st.id
+LEFT JOIN software_title_display_names stdn
+	ON stdn.software_title_id = st.id AND stdn.team_id = ?
+WHERE iha.install_during_setup = true
+AND iha.global_or_team_id = ?
+AND iha.platform = ?
+AND %s`
+		if resetFailedSetupSteps {
+			inHouseSelect = fmt.Sprintf(inHouseSelect, "iha.id NOT IN (SELECT in_house_app_id FROM setup_experience_status_results WHERE host_uuid = ? AND status = 'success' AND in_house_app_id IS NOT NULL)")
+		} else {
+			inHouseSelect = fmt.Sprintf(inHouseSelect, "TRUE")
+		}
+		softwareUnionParts = append(softwareUnionParts, inHouseSelect)
+		softwareArgs = append(softwareArgs, hostUUID, teamID, teamID, fleetPlatform)
+		if resetFailedSetupSteps {
+			softwareArgs = append(softwareArgs, hostUUID)
+		}
+	}
+
 	var stmtSoftwareCombined string
 	if len(softwareUnionParts) > 0 {
 		// A title can now hold several packages, and more than one can be flagged for setup. Queue only
@@ -342,9 +382,10 @@ INSERT INTO setup_experience_status_results (
 	status,
 	software_installer_id,
 	vpp_app_team_id,
+	in_house_app_id,
 	policy_gated
 )
-SELECT host_uuid, name, status, software_installer_id, vpp_app_team_id, policy_gated FROM (
+SELECT host_uuid, name, status, software_installer_id, vpp_app_team_id, in_house_app_id, policy_gated FROM (
 	SELECT combined.*, ROW_NUMBER() OVER (
 		PARTITION BY software_title_id
 		ORDER BY (software_installer_id IS NULL), software_installer_id ASC
@@ -353,7 +394,7 @@ SELECT host_uuid, name, status, software_installer_id, vpp_app_team_id, policy_g
 	) AS combined
 ) AS deduped
 WHERE software_installer_id IS NULL OR first_added_rank = 1
-ORDER BY sort_name ASC, COALESCE(software_installer_id, vpp_app_team_id, 0)`, strings.Join(softwareUnionParts, " UNION ALL "))
+ORDER BY sort_name ASC, COALESCE(software_installer_id, vpp_app_team_id, in_house_app_id, 0)`, strings.Join(softwareUnionParts, " UNION ALL "))
 	}
 
 	stmtSetupScripts := `
@@ -820,16 +861,18 @@ SELECT
 	sesr.host_software_installs_execution_id,
 	sesr.vpp_app_team_id,
 	sesr.nano_command_uuid,
+	sesr.in_house_app_id,
 	sesr.setup_experience_script_id,
 	sesr.script_execution_id,
 	sesr.policy_gated,
 	NULLIF(va.adam_id, '') AS vpp_app_adam_id,
 	NULLIF(va.platform, '') AS vpp_app_platform,
 	ses.script_content_id,
-	COALESCE(si.title_id, COALESCE(va.title_id, NULL)) AS software_title_id,
+	COALESCE(si.title_id, va.title_id, iha.title_id) AS software_title_id,
 	COALESCE(
 		(SELECT source FROM software_titles WHERE id = si.title_id),
-		(SELECT source FROM software_titles WHERE id = va.title_id)
+		(SELECT source FROM software_titles WHERE id = va.title_id),
+		(SELECT source FROM software_titles WHERE id = iha.title_id)
 	) AS source,
     CASE
         WHEN hsi.execution_status = 'failed_install' THEN
@@ -849,6 +892,7 @@ LEFT JOIN host_software_installs hsi ON hsi.execution_id = sesr.host_software_in
 LEFT JOIN host_script_results hsr ON hsr.execution_id = sesr.script_execution_id
 LEFT JOIN vpp_apps_teams vat ON vat.id = sesr.vpp_app_team_id
 LEFT JOIN vpp_apps va ON vat.adam_id = va.adam_id AND vat.platform = va.platform
+LEFT JOIN in_house_apps iha ON iha.id = sesr.in_house_app_id
 WHERE host_uuid = ?
 ORDER BY sesr.id
 	`

--- a/server/datastore/mysql/setup_experience_test.go
+++ b/server/datastore/mysql/setup_experience_test.go
@@ -44,6 +44,7 @@ func TestSetupExperience(t *testing.T) {
 		{"CrossPlatformPyScripts", testSetupExperienceCrossPlatformPyScripts},
 		{"FirstAddedPerTitleNoDoubleQueue", testEnqueueSetupExperienceFirstAddedPerTitle},
 		{"InHouseApps", testSetupExperienceInHouseApps},
+		{"EnqueueInHouseApps", testEnqueueSetupExperienceInHouseApps},
 	}
 
 	for _, c := range cases {
@@ -1371,6 +1372,95 @@ func testSetupExperienceInHouseApps(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	err = ds.DeleteInHouseApp(ctx, iosAppID)
 	require.True(t, fleet.IsNotFound(err))
+}
+
+func testEnqueueSetupExperienceInHouseApps(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "team1"})
+	require.NoError(t, err)
+	user1 := test.NewUser(t, ds, "Alice", "alice@example.com", true)
+
+	// .ipa upload creates iOS and iPadOS rows; select only the iOS one
+	iosAppID, iosTitleID, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+		TeamID:           &team.ID,
+		UserID:           user1.ID,
+		Title:            "Acme",
+		Filename:         "acme.ipa",
+		BundleIdentifier: "com.acme.app",
+		StorageID:        "acme-storage",
+		Platform:         string(fleet.IOSPlatform),
+		Extension:        "ipa",
+		Version:          "1.0",
+		ValidatedLabels:  &fleet.LabelIdentsWithScope{},
+	})
+	require.NoError(t, err)
+	err = ds.SetSetupExperienceSoftwareTitles(ctx, "ios", team.ID, []uint{iosTitleID})
+	require.NoError(t, err)
+
+	iphone, err := ds.NewHost(ctx, &fleet.Host{
+		Hostname:       "iphone-test",
+		OsqueryHostID:  new("osquery-iphone"),
+		NodeKey:        new("node-key-iphone"),
+		UUID:           "iphone-uuid",
+		Platform:       "ios",
+		HardwareSerial: "serial-iphone",
+		TeamID:         &team.ID,
+	})
+	require.NoError(t, err)
+	_, err = ds.NewHost(ctx, &fleet.Host{
+		Hostname:       "ipad-test",
+		OsqueryHostID:  new("osquery-ipad"),
+		NodeKey:        new("node-key-ipad"),
+		UUID:           "ipad-uuid",
+		Platform:       "ipados",
+		HardwareSerial: "serial-ipad",
+		TeamID:         &team.ID,
+	})
+	require.NoError(t, err)
+
+	// give the app an include-any label the host does not match, so
+	// IsInHouseAppLabelScoped rejects the host; setup experience must still
+	// enqueue the app — labels don't apply during setup. This assertion fails
+	// if a label join is ever reintroduced in the enqueue query.
+	label, err := ds.NewLabel(ctx, &fleet.Label{Name: "no-members"})
+	require.NoError(t, err)
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		_, err := q.ExecContext(ctx,
+			`INSERT INTO in_house_app_labels (in_house_app_id, label_id, exclude) VALUES (?, ?, 0)`, iosAppID, label.ID)
+		return err
+	})
+	scoped, err := ds.IsInHouseAppLabelScoped(ctx, iosAppID, iphone.ID)
+	require.NoError(t, err)
+	require.False(t, scoped, "precondition: the host must be out of label scope for this test to be meaningful")
+
+	// enrolling iPhone gets exactly one item, the in-house app
+	enqueued, err := ds.EnqueueSetupExperienceItems(ctx, "ios", "ios", "iphone-uuid", team.ID)
+	require.NoError(t, err)
+	require.True(t, enqueued)
+	results, err := ds.ListSetupExperienceResultsByHostUUID(ctx, "iphone-uuid", team.ID)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.NotNil(t, results[0].InHouseAppID)
+	require.Equal(t, iosAppID, *results[0].InHouseAppID)
+	require.True(t, results[0].IsForInHouseApp())
+	require.True(t, results[0].IsForSoftware())
+	require.Equal(t, fleet.SetupExperienceStatusPending, results[0].Status)
+	require.NotNil(t, results[0].SoftwareTitleID)
+	require.Equal(t, iosTitleID, *results[0].SoftwareTitleID)
+	require.NotNil(t, results[0].Source)
+	require.Equal(t, "ios_apps", *results[0].Source)
+	awaitingConfig, err := ds.GetHostAwaitingConfiguration(ctx, "iphone-uuid")
+	require.NoError(t, err)
+	require.True(t, awaitingConfig)
+
+	// enrolling iPad gets nothing: only the iOS sibling is selected
+	enqueued, err = ds.EnqueueSetupExperienceItems(ctx, "ipados", "ipados", "ipad-uuid", team.ID)
+	require.NoError(t, err)
+	require.False(t, enqueued)
+	results, err = ds.ListSetupExperienceResultsByHostUUID(ctx, "ipad-uuid", team.ID)
+	require.NoError(t, err)
+	require.Empty(t, results)
 }
 
 func testSetSetupExperienceTitles(t *testing.T, ds *Datastore) {

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -1698,6 +1698,19 @@ type AppleMDMVPPInstaller interface {
 	InstallVPPAppPostValidation(ctx context.Context, host *Host, vppApp *VPPApp, token string, opts HostSoftwareInstallOptions) (string, error)
 }
 
+// AppleMDMInHouseAppInstaller is the subset of the Fleet service used by the
+// Apple MDM worker to install in-house apps (.ipa) during setup experience.
+// Like AppleMDMVPPInstaller, it exists because the install logic lives in the
+// premium service, which the worker package cannot import.
+type AppleMDMInHouseAppInstaller interface {
+	// InstallInHouseAppForSetupExperience validates the in-house app's managed
+	// configuration for the host and enqueues its InstallApplication command,
+	// returning the command UUID. An unresolvable Fleet variable in the
+	// configuration records the failed install (and its activity) and returns
+	// a *PreflightInstallFailedError.
+	InstallInHouseAppForSetupExperience(ctx context.Context, host *Host, inHouseAppID uint, softwareTitleID uint) (string, error)
+}
+
 const (
 	DeviceLocationCmdName       = "DeviceLocation"
 	EnableLostModeCmdName       = "EnableLostMode"

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -1698,19 +1698,6 @@ type AppleMDMVPPInstaller interface {
 	InstallVPPAppPostValidation(ctx context.Context, host *Host, vppApp *VPPApp, token string, opts HostSoftwareInstallOptions) (string, error)
 }
 
-// AppleMDMInHouseAppInstaller is the subset of the Fleet service used by the
-// Apple MDM worker to install in-house apps (.ipa) during setup experience.
-// Like AppleMDMVPPInstaller, it exists because the install logic lives in the
-// premium service, which the worker package cannot import.
-type AppleMDMInHouseAppInstaller interface {
-	// InstallInHouseAppForSetupExperience validates the in-house app's managed
-	// configuration for the host and enqueues its InstallApplication command,
-	// returning the command UUID. An unresolvable Fleet variable in the
-	// configuration records the failed install (and its activity) and returns
-	// a *PreflightInstallFailedError.
-	InstallInHouseAppForSetupExperience(ctx context.Context, host *Host, inHouseAppID uint, softwareTitleID uint) (string, error)
-}
-
 const (
 	DeviceLocationCmdName       = "DeviceLocation"
 	EnableLostModeCmdName       = "EnableLostMode"

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -805,6 +805,10 @@ type Service interface {
 	// InstallVPPAppPostValidation installs a VPP app, assuming that GetVPPTokenIfCanInstallVPPApps has passed and provided a VPP token
 	InstallVPPAppPostValidation(ctx context.Context, host *Host, vppApp *VPPApp, token string, opts HostSoftwareInstallOptions) (string, error)
 
+	// InstallInHouseAppForSetupExperience validates the in-house app's managed configuration for the
+	// host and enqueues its InstallApplication command during setup experience, returning the command UUID.
+	InstallInHouseAppForSetupExperience(ctx context.Context, host *Host, inHouseAppID uint, softwareTitleID uint) (string, error)
+
 	// UninstallSoftwareTitle uninstalls a software title in the given host.
 	UninstallSoftwareTitle(ctx context.Context, hostID uint, softwareTitleID uint) error
 

--- a/server/fleet/setup_experience.go
+++ b/server/fleet/setup_experience.go
@@ -33,9 +33,10 @@ func (s SetupExperienceStatusResultStatus) IsTerminalStatus() bool {
 	}
 }
 
-// SetupExperienceStatusResult represents the status of a particular step in the macOS setup
+// SetupExperienceStatusResult represents the status of a particular step in the setup
 // experience process for a particular host. These steps can either be a software installer
-// installation, a VPP app installation, or a script execution.
+// installation, a VPP app installation, an in-house app (.ipa) installation, or a script
+// execution.
 type SetupExperienceStatusResult struct {
 	ID                              uint                              `db:"id" json:"-" `
 	HostUUID                        string                            `db:"host_uuid" json:"-" `
@@ -47,6 +48,7 @@ type SetupExperienceStatusResult struct {
 	VPPAppAdamID                    *string                           `db:"vpp_app_adam_id" json:"-"`
 	VPPAppPlatform                  *string                           `db:"vpp_app_platform" json:"-"`
 	NanoCommandUUID                 *string                           `db:"nano_command_uuid" json:"-" `
+	InHouseAppID                    *uint                             `db:"in_house_app_id" json:"-"`
 	SetupExperienceScriptID         *uint                             `db:"setup_experience_script_id" json:"-" `
 	ScriptContentID                 *uint                             `db:"script_content_id" json:"-"`
 	ScriptExecutionID               *string                           `db:"script_execution_id" json:"execution_id,omitempty" `
@@ -82,6 +84,13 @@ func (s *SetupExperienceStatusResult) IsValid() error {
 		colsSet++
 		if s.HostSoftwareInstallsExecutionID != nil || s.ScriptExecutionID != nil {
 			return fmt.Errorf("invalid setup experience status row, vpp_app_team set with incorrect secondary value column: %d", s.ID)
+		}
+	}
+	if s.InHouseAppID != nil {
+		// like VPP apps, in-house apps pair with nano_command_uuid
+		colsSet++
+		if s.HostSoftwareInstallsExecutionID != nil || s.ScriptExecutionID != nil {
+			return fmt.Errorf("invalid setup experience status row, in_house_app_id set with incorrect secondary value column: %d", s.ID)
 		}
 	}
 	if s.SetupExperienceScriptID != nil {
@@ -120,10 +129,10 @@ func (s *SetupExperienceStatusResult) IsForScript() bool {
 	return s.SetupExperienceScriptID != nil
 }
 
-// IsForSoftware indicates if this result is for a setup experience software step: either a software
-// installer or a VPP app.
+// IsForSoftware indicates if this result is for a setup experience software step: a software
+// installer, a VPP app, or an in-house app.
 func (s *SetupExperienceStatusResult) IsForSoftware() bool {
-	return s.VPPAppTeamID != nil || s.SoftwareInstallerID != nil
+	return s.VPPAppTeamID != nil || s.SoftwareInstallerID != nil || s.InHouseAppID != nil
 }
 
 // IsForSoftwarePackage indicates if this result is for a setup experience software installer step.
@@ -133,6 +142,11 @@ func (s *SetupExperienceStatusResult) IsForSoftwarePackage() bool {
 
 func (s *SetupExperienceStatusResult) IsForVPPApp() bool {
 	return s.VPPAppTeamID != nil
+}
+
+// IsForInHouseApp indicates if this result is for a setup experience in-house app (.ipa) step.
+func (s *SetupExperienceStatusResult) IsForInHouseApp() bool {
+	return s.InHouseAppID != nil
 }
 
 func (s *SetupExperienceStatusResult) ForMyDevicePage(token string) {

--- a/server/fleet/setup_experience_test.go
+++ b/server/fleet/setup_experience_test.go
@@ -157,6 +157,61 @@ func TestSetupExperienceStatusResultIsValid(t *testing.T) {
 			Valid: false,
 			Name:  "policy_gated on script (no software installer)",
 		},
+		{
+			Case: SetupExperienceStatusResult{
+				InHouseAppID: id,
+			},
+			Valid: true,
+			Name:  "just in-house app",
+		},
+		{
+			Case: SetupExperienceStatusResult{
+				InHouseAppID:    id,
+				NanoCommandUUID: str,
+			},
+			Valid: true,
+			Name:  "in-house app and result",
+		},
+		{
+			Case: SetupExperienceStatusResult{
+				InHouseAppID:                    id,
+				HostSoftwareInstallsExecutionID: str,
+			},
+			Valid: false,
+			Name:  "in-house app and installer secondary",
+		},
+		{
+			Case: SetupExperienceStatusResult{
+				InHouseAppID:      id,
+				ScriptExecutionID: str,
+			},
+			Valid: false,
+			Name:  "in-house app and script secondary",
+		},
+		{
+			Case: SetupExperienceStatusResult{
+				InHouseAppID: id,
+				VPPAppTeamID: id,
+			},
+			Valid: false,
+			Name:  "in-house app and vpp",
+		},
+		{
+			Case: SetupExperienceStatusResult{
+				InHouseAppID:        id,
+				SoftwareInstallerID: id,
+			},
+			Valid: false,
+			Name:  "in-house app and installer",
+		},
+		{
+			Case: SetupExperienceStatusResult{
+				InHouseAppID: id,
+				PolicyGated:  true,
+			},
+			Valid: false,
+			Name:  "policy_gated on in-house app (no software installer)",
+		},
 	} {
 		err := tc.Case.IsValid()
 		if tc.Valid {

--- a/server/mock/service/service_mock.go
+++ b/server/mock/service/service_mock.go
@@ -503,6 +503,8 @@ type GetVPPTokenIfCanInstallVPPAppsFunc func(ctx context.Context, appleDevice bo
 
 type InstallVPPAppPostValidationFunc func(ctx context.Context, host *fleet.Host, vppApp *fleet.VPPApp, token string, opts fleet.HostSoftwareInstallOptions) (string, error)
 
+type InstallInHouseAppForSetupExperienceFunc func(ctx context.Context, host *fleet.Host, inHouseAppID uint, softwareTitleID uint) (string, error)
+
 type UninstallSoftwareTitleFunc func(ctx context.Context, hostID uint, softwareTitleID uint) error
 
 type GetSoftwareInstallResultsFunc func(ctx context.Context, installUUID string) (*fleet.HostSoftwareInstallerResult, error)
@@ -1720,6 +1722,9 @@ type Service struct {
 
 	InstallVPPAppPostValidationFunc        InstallVPPAppPostValidationFunc
 	InstallVPPAppPostValidationFuncInvoked bool
+
+	InstallInHouseAppForSetupExperienceFunc        InstallInHouseAppForSetupExperienceFunc
+	InstallInHouseAppForSetupExperienceFuncInvoked bool
 
 	UninstallSoftwareTitleFunc        UninstallSoftwareTitleFunc
 	UninstallSoftwareTitleFuncInvoked bool
@@ -4150,6 +4155,13 @@ func (s *Service) InstallVPPAppPostValidation(ctx context.Context, host *fleet.H
 	s.InstallVPPAppPostValidationFuncInvoked = true
 	s.mu.Unlock()
 	return s.InstallVPPAppPostValidationFunc(ctx, host, vppApp, token, opts)
+}
+
+func (s *Service) InstallInHouseAppForSetupExperience(ctx context.Context, host *fleet.Host, inHouseAppID uint, softwareTitleID uint) (string, error) {
+	s.mu.Lock()
+	s.InstallInHouseAppForSetupExperienceFuncInvoked = true
+	s.mu.Unlock()
+	return s.InstallInHouseAppForSetupExperienceFunc(ctx, host, inHouseAppID, softwareTitleID)
 }
 
 func (s *Service) UninstallSoftwareTitle(ctx context.Context, hostID uint, softwareTitleID uint) error {

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -5328,7 +5328,22 @@ func (svc *MDMAppleCheckinAndCommandService) CommandAndReportResults(r *mdm.Requ
 			user, act, err := svc.ds.GetPastActivityDataForVPPAppInstall(r.Context, cmdResult)
 			if err != nil {
 				if fleet.IsNotFound(err) {
-					// Then this isn't a VPP install, so no activity generated
+					// Not a VPP install; it may be an in-house app (.ipa) install.
+					inHouseUser, inHouseAct, inHouseErr := svc.ds.GetPastActivityDataForInHouseAppInstall(r.Context, cmdResult)
+					if inHouseErr != nil {
+						if fleet.IsNotFound(inHouseErr) {
+							// Not an in-house install either, so no activity generated
+							return nil, nil
+						}
+						return nil, ctxerr.Wrap(r.Context, inHouseErr, "fetching data for installed in-house app activity")
+					}
+					if inHouseAct == nil {
+						return nil, nil
+					}
+					inHouseAct.FromSetupExperience = fromSetupExperience
+					if err := svc.newActivityFn(r.Context, inHouseUser, inHouseAct); err != nil {
+						return nil, ctxerr.Wrap(r.Context, err, "creating activity for installed in-house app")
+					}
 					return nil, nil
 				}
 

--- a/server/service/apple_mdm_cmd_results.go
+++ b/server/service/apple_mdm_cmd_results.go
@@ -228,8 +228,15 @@ func NewInstalledApplicationListResultsHandler(
 			setter := installStatusSetter{
 				ds.SetInHouseAppInstallAsVerified,
 				ds.SetInHouseAppInstallAsFailed,
-				func(ctx context.Context, results *mdm.CommandResults, _ bool, _ bool) (*fleet.User, fleet.ActivityDetails, error) {
-					return ds.GetPastActivityDataForInHouseAppInstall(ctx, results)
+				// fromAutoUpdate is ignored: in-house apps have no auto-update flow
+				// and ActivityTypeInstalledSoftware has no field for it.
+				func(ctx context.Context, results *mdm.CommandResults, fromSetupExp bool, _ bool) (*fleet.User, fleet.ActivityDetails, error) {
+					user, act, err := ds.GetPastActivityDataForInHouseAppInstall(ctx, results)
+					if err != nil {
+						return nil, nil, err
+					}
+					act.FromSetupExperience = fromSetupExp
+					return user, act, nil
 				},
 			}
 			if err := setStatusForExpectedInstall(expectedInstall, setter); err != nil {

--- a/server/service/integration_mdm_setup_experience_test.go
+++ b/server/service/integration_mdm_setup_experience_test.go
@@ -3139,7 +3139,7 @@ func (s *integrationMDMTestSuite) runDEPEnrollReleaseMobileDeviceWithVPPTest(t *
 	require.Equal(t, false, unexpectedProfileSeen)
 
 	require.Equal(t, totalAppsToInstall, installAppCount)
-	require.Equal(t, totalAppsToInstall, len(installedApps))
+	require.Len(t, installedApps, totalAppsToInstall)
 
 	// Each expected app should be installed exactly once
 	for _, app := range opts.VppAppsToInstall {

--- a/server/service/integration_mdm_setup_experience_test.go
+++ b/server/service/integration_mdm_setup_experience_test.go
@@ -2722,6 +2722,146 @@ func (s *integrationMDMTestSuite) TestSetupExperienceIOSAndIPadOS() {
 	}
 }
 
+// TestSetupExperienceIOSInHouseApp runs the end-to-end iOS setup experience
+// flow with a mixed payload: an in-house app (.ipa) and a VPP app on the same
+// enrolling iPhone. Both must install while the device is held in Setup
+// Assistant, drive the release, and be recorded with setup-experience
+// attribution.
+func (s *integrationMDMTestSuite) TestSetupExperienceIOSInHouseApp() {
+	t := s.T()
+	s.setSkipWorkerJobs(t)
+	ctx := context.Background()
+	abmOrgName := "fleet_ade_ios_in_house_test"
+
+	s.enableABM(abmOrgName)
+
+	team, err := s.ds.NewTeam(ctx, &fleet.Team{Name: "team in-house se"})
+	require.NoError(t, err)
+
+	var acResp appConfigResponse
+	s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(fmt.Sprintf(`{
+			"mdm": {
+			       "apple_business_manager": [{
+			         "organization_name": %q,
+			         "macos_team": %q,
+			         "ios_team": %q,
+			         "ipados_team": %q
+			       }]
+			}
+		}`, abmOrgName, team.Name, team.Name, team.Name)), http.StatusOK, &acResp)
+
+	// VPP token for the App Store half of the payload
+	orgName := "Fleet Device Management Inc."
+	token := "mycooltoken"
+	expTime := time.Now().Add(200 * time.Hour).UTC().Round(time.Second)
+	expDate := expTime.Format(fleet.VPPTimeFormat)
+	tokenJSON := fmt.Sprintf(`{"expDate":"%s","token":"%s","orgName":"%s"}`, expDate, token, orgName)
+	dev_mode.SetOverride("FLEET_DEV_VPP_URL", s.appleVPPConfigSrv.URL, t)
+	var validToken uploadVPPTokenResponse
+	s.uploadDataViaForm("/api/latest/fleet/vpp_tokens", "token", "token.vpptoken", []byte(base64.StdEncoding.EncodeToString([]byte(tokenJSON))), http.StatusAccepted, "", &validToken)
+	var getVPPTokenResp getVPPTokensResponse
+	s.DoJSON("GET", "/api/latest/fleet/vpp_tokens", &getVPPTokensRequest{}, http.StatusOK, &getVPPTokenResp)
+	var resPatchVPP patchVPPTokensTeamsResponse
+	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/vpp_tokens/%d/teams", getVPPTokenResp.Tokens[0].ID), patchVPPTokensTeamsRequest{TeamIDs: []uint{team.ID}}, http.StatusOK, &resPatchVPP)
+
+	iOSApp := &fleet.VPPApp{
+		VPPAppTeam:       fleet.VPPAppTeam{VPPAppID: fleet.VPPAppID{AdamID: "2", Platform: fleet.IOSPlatform}},
+		Name:             "App 2",
+		BundleIdentifier: "b-2",
+		LatestVersion:    "2.0.0",
+	}
+	var addAppResp addAppStoreAppResponse
+	s.DoJSON("POST", "/api/latest/fleet/software/app_store_apps",
+		&addAppStoreAppRequest{TeamID: &team.ID, AppStoreID: iOSApp.AdamID, Platform: iOSApp.Platform},
+		http.StatusOK, &addAppResp)
+	var vppTitleID uint
+	mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, q, &vppTitleID, `SELECT title_id FROM vpp_apps WHERE adam_id = ? AND platform = ?`, iOSApp.AdamID, iOSApp.Platform)
+	})
+
+	// upload the .ipa (creates the iOS and iPadOS titles) and select the iOS title
+	s.uploadSoftwareInstaller(t, &fleet.UploadSoftwareInstallerPayload{Filename: "ipa_test.ipa", TeamID: &team.ID}, http.StatusOK, "")
+	var ipaTitleID uint
+	mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, q, &ipaTitleID, `SELECT title_id FROM in_house_apps WHERE global_or_team_id = ? AND platform = 'ios'`, team.ID)
+	})
+
+	var swInstallResp putSetupExperienceSoftwareResponse
+	s.DoJSON("PUT", "/api/v1/fleet/setup_experience/software", putSetupExperienceSoftwareRequest{
+		Platform: "ios",
+		TeamID:   team.ID,
+		TitleIDs: []uint{vppTitleID, ipaTitleID},
+	}, http.StatusOK, &swInstallResp)
+
+	// custom profile, expected by the enroll/release helper
+	teamProfile := mobileconfigForTest("N1", "I1")
+	s.Do("POST", "/api/v1/fleet/mdm/apple/profiles/batch", batchSetMDMAppleProfilesRequest{Profiles: [][]byte{teamProfile}}, http.StatusNoContent, "team_id", fmt.Sprint(team.ID))
+
+	device := godep.Device{
+		Model:        "iPhone 16 Pro",
+		OS:           "iOS",
+		DeviceFamily: "iPhone",
+		OpType:       "added",
+		SerialNumber: "iphone-inhouse-1",
+	}
+	s.appleVPPConfigSrvConfig.SerialNumbers = append(s.appleVPPConfigSrvConfig.SerialNumbers, device.SerialNumber)
+
+	// wrapped in t.Run so the helper's cleanups run before the suite teardown
+	t.Run("iPhoneInHouseSetupExperience", func(t *testing.T) {
+		s.runDEPEnrollReleaseMobileDeviceWithVPPTest(t, device, DEPEnrollMobileTestOpts{
+			ABMOrg:             abmOrgName,
+			TeamID:             &team.ID,
+			CustomProfileIdent: "N1",
+			VppAppsToInstall:   []*fleet.VPPApp{iOSApp},
+			InHouseAppsToInstall: []fleet.Software{
+				{BundleIdentifier: "com.ipa-test.ipa-test", Name: "ipa_test", Version: "1.0"},
+			},
+		})
+
+		// both setup experience items reached success, and the in-house row carries
+		// its app pointer and MDM command UUID
+		listHostsRes := listHostsResponse{}
+		s.DoJSON("GET", "/api/latest/fleet/hosts", nil, http.StatusOK, &listHostsRes)
+		require.Len(t, listHostsRes.Hosts, 1)
+		hostUUID := listHostsRes.Hosts[0].UUID
+		results, err := s.ds.ListSetupExperienceResultsByHostUUID(ctx, hostUUID, team.ID)
+		require.NoError(t, err)
+		require.Len(t, results, 2)
+		var inHouseSeen, vppSeen bool
+		for _, res := range results {
+			require.Equal(t, fleet.SetupExperienceStatusSuccess, res.Status)
+			switch {
+			case res.IsForInHouseApp():
+				inHouseSeen = true
+				require.NotNil(t, res.NanoCommandUUID)
+			case res.IsForVPPApp():
+				vppSeen = true
+			}
+		}
+		require.True(t, inHouseSeen)
+		require.True(t, vppSeen)
+
+		// the verified in-house install is recorded with setup-experience attribution
+		var activitiesResp listActivitiesResponse
+		s.DoJSON("GET", "/api/latest/fleet/activities", nil, http.StatusOK, &activitiesResp, "per_page", "50", "order_key", "id", "order_direction", "desc")
+		var inHouseActivitySeen bool
+		for _, act := range activitiesResp.Activities {
+			if act.Type != (fleet.ActivityTypeInstalledSoftware{}).ActivityName() || act.Details == nil {
+				continue
+			}
+			var details fleet.ActivityTypeInstalledSoftware
+			require.NoError(t, json.Unmarshal(*act.Details, &details))
+			if details.SoftwareTitle != "ipa_test" {
+				continue
+			}
+			inHouseActivitySeen = true
+			require.True(t, details.FromSetupExperience)
+			require.Equal(t, string(fleet.SoftwareInstalled), details.Status)
+		}
+		require.True(t, inHouseActivitySeen, "expected an installed_software activity for the in-house app")
+	})
+}
+
 type DEPEnrollMobileTestOpts struct {
 	ABMOrg                            string
 	EnableReleaseManually             bool
@@ -2729,6 +2869,9 @@ type DEPEnrollMobileTestOpts struct {
 	CustomProfileIdent                string
 	EnrollmentProfileFromDEPUsingPost bool
 	VppAppsToInstall                  []*fleet.VPPApp
+	// InHouseAppsToInstall lists in-house apps (.ipa) expected to install during
+	// setup, as the device would report them in InstalledApplicationList.
+	InHouseAppsToInstall []fleet.Software
 }
 
 func (s *integrationMDMTestSuite) runDEPEnrollReleaseMobileDeviceWithVPPTest(t *testing.T, device godep.Device, opts DEPEnrollMobileTestOpts) {
@@ -2852,10 +2995,12 @@ func (s *integrationMDMTestSuite) runDEPEnrollReleaseMobileDeviceWithVPPTest(t *
 	cmd, err := mdmDevice.Idle()
 	require.NoError(t, err)
 
+	totalAppsToInstall := len(opts.VppAppsToInstall) + len(opts.InHouseAppsToInstall)
 	// For reporting back via InstalledApplicationList
-	installedVPPApps := make([]fleet.Software, 0, len(opts.VppAppsToInstall))
+	installedVPPApps := make([]fleet.Software, 0, totalAppsToInstall)
 	// For verifying number of installs
-	installedApps := make(map[string]int, len(opts.VppAppsToInstall))
+	installedApps := make(map[string]int, totalAppsToInstall)
+	var inHouseInstallCount int
 
 	var installProfileCount, installAppCount, refetchVerifyCount, otherCount int
 	var profileCustomSeen, profileFleetCASeen, unexpectedProfileSeen bool
@@ -2896,14 +3041,29 @@ func (s *integrationMDMTestSuite) runDEPEnrollReleaseMobileDeviceWithVPPTest(t *
 				unexpectedProfileSeen = true
 			}
 		case "InstallApplication":
-			if logCommands {
-				fmt.Println(">>>> device received command: ", cmd.CommandUUID, cmd.Command.RequestType, fmt.Sprint(*fullCmd.Command.InstallApplication.ITunesStoreID))
-			}
-			for _, app := range opts.VppAppsToInstall {
-				if app.AdamID == fmt.Sprint(*fullCmd.Command.InstallApplication.ITunesStoreID) {
-					installedVPPApps = append(installedVPPApps, fleet.Software{BundleIdentifier: app.BundleIdentifier, Name: app.Name, Version: app.LatestVersion, Installed: true})
-					installedApps[app.AdamID]++
+			if fullCmd.Command.InstallApplication.ITunesStoreID != nil {
+				if logCommands {
+					fmt.Println(">>>> device received command: ", cmd.CommandUUID, cmd.Command.RequestType, fmt.Sprint(*fullCmd.Command.InstallApplication.ITunesStoreID))
 				}
+				for _, app := range opts.VppAppsToInstall {
+					if app.AdamID == fmt.Sprint(*fullCmd.Command.InstallApplication.ITunesStoreID) {
+						installedVPPApps = append(installedVPPApps, fleet.Software{BundleIdentifier: app.BundleIdentifier, Name: app.Name, Version: app.LatestVersion, Installed: true})
+						installedApps[app.AdamID]++
+					}
+				}
+			} else {
+				// in-house app (.ipa) installs carry a manifest URL instead of an App Store ID
+				require.NotNil(t, fullCmd.Command.InstallApplication.ManifestURL)
+				if logCommands {
+					fmt.Println(">>>> device received command: ", cmd.CommandUUID, cmd.Command.RequestType, *fullCmd.Command.InstallApplication.ManifestURL)
+				}
+				require.Contains(t, *fullCmd.Command.InstallApplication.ManifestURL, "/in_house_app/manifest/")
+				require.Less(t, inHouseInstallCount, len(opts.InHouseAppsToInstall), "unexpected extra in-house app install command")
+				sw := opts.InHouseAppsToInstall[inHouseInstallCount]
+				sw.Installed = true
+				installedVPPApps = append(installedVPPApps, sw)
+				installedApps["inhouse:"+sw.BundleIdentifier]++
+				inHouseInstallCount++
 			}
 			installAppCount++
 
@@ -2923,7 +3083,7 @@ func (s *integrationMDMTestSuite) runDEPEnrollReleaseMobileDeviceWithVPPTest(t *
 			// InstalledApplicationList command instead of an InstallApplication command.
 			require.NoError(t, plist.Unmarshal(cmd.Raw, &fullCmd))
 			// Hold off on verifying the last install until later so we can ensure it waits for verification
-			if len(installedVPPApps) == len(opts.VppAppsToInstall) {
+			if len(installedVPPApps) == totalAppsToInstall {
 				installedVPPApps[len(installedVPPApps)-1].Installed = false
 			}
 			cmd, err = mdmDevice.AcknowledgeInstalledApplicationList(
@@ -2971,19 +3131,22 @@ func (s *integrationMDMTestSuite) runDEPEnrollReleaseMobileDeviceWithVPPTest(t *
 
 	// expected commands: install CA, install profile (only the custom one),
 	// not expected: account configuration, since enrollment_reference not set
-	require.Len(t, cmds, 2+len(opts.VppAppsToInstall))
+	require.Len(t, cmds, 2+totalAppsToInstall)
 
 	require.Equal(t, 2, installProfileCount)
 	require.True(t, profileCustomSeen)
 	require.True(t, profileFleetCASeen)
 	require.Equal(t, false, unexpectedProfileSeen)
 
-	require.Equal(t, len(opts.VppAppsToInstall), installAppCount)
-	require.Equal(t, len(opts.VppAppsToInstall), len(installedApps))
+	require.Equal(t, totalAppsToInstall, installAppCount)
+	require.Equal(t, totalAppsToInstall, len(installedApps))
 
 	// Each expected app should be installed exactly once
 	for _, app := range opts.VppAppsToInstall {
 		require.Equal(t, 1, installedApps[app.AdamID])
+	}
+	for _, sw := range opts.InHouseAppsToInstall {
+		require.Equal(t, 1, installedApps["inhouse:"+sw.BundleIdentifier])
 	}
 
 	require.Equal(t, 0, otherCount)

--- a/server/service/integration_mdm_setup_experience_test.go
+++ b/server/service/integration_mdm_setup_experience_test.go
@@ -3001,11 +3001,6 @@ func (s *integrationMDMTestSuite) runDEPEnrollReleaseMobileDeviceWithVPPTest(t *
 	// For verifying number of installs
 	installedApps := make(map[string]int, totalAppsToInstall)
 	var inHouseInstallCount int
-	// Index of the entry withheld from the first InstalledApplicationList to
-	// prove release waits for verification. Pinned to a VPP entry so the
-	// coverage doesn't depend on the order install commands arrive in a mixed
-	// VPP + in-house payload; -1 falls back to the last reported entry.
-	withheldAppIdx := -1
 
 	var installProfileCount, installAppCount, refetchVerifyCount, otherCount int
 	var profileCustomSeen, profileFleetCASeen, unexpectedProfileSeen bool
@@ -3054,7 +3049,6 @@ func (s *integrationMDMTestSuite) runDEPEnrollReleaseMobileDeviceWithVPPTest(t *
 					if app.AdamID == fmt.Sprint(*fullCmd.Command.InstallApplication.ITunesStoreID) {
 						reportedInstalledApps = append(reportedInstalledApps, fleet.Software{BundleIdentifier: app.BundleIdentifier, Name: app.Name, Version: app.LatestVersion, Installed: true})
 						installedApps[app.AdamID]++
-						withheldAppIdx = len(reportedInstalledApps) - 1
 					}
 				}
 			} else {
@@ -3088,13 +3082,14 @@ func (s *integrationMDMTestSuite) runDEPEnrollReleaseMobileDeviceWithVPPTest(t *
 			// If we are polling to verify the install, we should get an
 			// InstalledApplicationList command instead of an InstallApplication command.
 			require.NoError(t, plist.Unmarshal(cmd.Raw, &fullCmd))
-			// Hold off on verifying one install until later so we can ensure it waits for verification
-			holdIdx := withheldAppIdx
-			if holdIdx == -1 {
-				holdIdx = len(reportedInstalledApps) - 1
-			}
+			// Withhold the last install from the completed report so release
+			// provably waits for verification. Only the last entry can be
+			// withheld, whatever its kind: installs activate one at a time
+			// through the host's activity queue, so withholding an earlier one
+			// stalls the remaining install commands, and earlier apps are
+			// already verified by their own post-ack round by now.
 			if len(reportedInstalledApps) == totalAppsToInstall {
-				reportedInstalledApps[holdIdx].Installed = false
+				reportedInstalledApps[len(reportedInstalledApps)-1].Installed = false
 			}
 			cmd, err = mdmDevice.AcknowledgeInstalledApplicationList(
 				mdmDevice.UUID,
@@ -3102,7 +3097,7 @@ func (s *integrationMDMTestSuite) runDEPEnrollReleaseMobileDeviceWithVPPTest(t *
 				reportedInstalledApps,
 			)
 			// flip the status back for later
-			reportedInstalledApps[holdIdx].Installed = true
+			reportedInstalledApps[len(reportedInstalledApps)-1].Installed = true
 			require.NoError(t, err)
 			// TODO: We don't actually normally get a command back from the acknowledgement of the InstalledAppList
 			// but we'll get additional install commands if we follow it up with an idle. Is this a bug? I think it

--- a/server/service/integration_mdm_setup_experience_test.go
+++ b/server/service/integration_mdm_setup_experience_test.go
@@ -3001,6 +3001,11 @@ func (s *integrationMDMTestSuite) runDEPEnrollReleaseMobileDeviceWithVPPTest(t *
 	// For verifying number of installs
 	installedApps := make(map[string]int, totalAppsToInstall)
 	var inHouseInstallCount int
+	// Index of the entry withheld from the first InstalledApplicationList to
+	// prove release waits for verification. Pinned to a VPP entry so the
+	// coverage doesn't depend on the order install commands arrive in a mixed
+	// VPP + in-house payload; -1 falls back to the last reported entry.
+	withheldAppIdx := -1
 
 	var installProfileCount, installAppCount, refetchVerifyCount, otherCount int
 	var profileCustomSeen, profileFleetCASeen, unexpectedProfileSeen bool
@@ -3049,6 +3054,7 @@ func (s *integrationMDMTestSuite) runDEPEnrollReleaseMobileDeviceWithVPPTest(t *
 					if app.AdamID == fmt.Sprint(*fullCmd.Command.InstallApplication.ITunesStoreID) {
 						reportedInstalledApps = append(reportedInstalledApps, fleet.Software{BundleIdentifier: app.BundleIdentifier, Name: app.Name, Version: app.LatestVersion, Installed: true})
 						installedApps[app.AdamID]++
+						withheldAppIdx = len(reportedInstalledApps) - 1
 					}
 				}
 			} else {
@@ -3082,9 +3088,13 @@ func (s *integrationMDMTestSuite) runDEPEnrollReleaseMobileDeviceWithVPPTest(t *
 			// If we are polling to verify the install, we should get an
 			// InstalledApplicationList command instead of an InstallApplication command.
 			require.NoError(t, plist.Unmarshal(cmd.Raw, &fullCmd))
-			// Hold off on verifying the last install until later so we can ensure it waits for verification
+			// Hold off on verifying one install until later so we can ensure it waits for verification
+			holdIdx := withheldAppIdx
+			if holdIdx == -1 {
+				holdIdx = len(reportedInstalledApps) - 1
+			}
 			if len(reportedInstalledApps) == totalAppsToInstall {
-				reportedInstalledApps[len(reportedInstalledApps)-1].Installed = false
+				reportedInstalledApps[holdIdx].Installed = false
 			}
 			cmd, err = mdmDevice.AcknowledgeInstalledApplicationList(
 				mdmDevice.UUID,
@@ -3092,7 +3102,7 @@ func (s *integrationMDMTestSuite) runDEPEnrollReleaseMobileDeviceWithVPPTest(t *
 				reportedInstalledApps,
 			)
 			// flip the status back for later
-			reportedInstalledApps[len(reportedInstalledApps)-1].Installed = true
+			reportedInstalledApps[holdIdx].Installed = true
 			require.NoError(t, err)
 			// TODO: We don't actually normally get a command back from the acknowledgement of the InstalledAppList
 			// but we'll get additional install commands if we follow it up with an idle. Is this a bug? I think it

--- a/server/service/integration_mdm_setup_experience_test.go
+++ b/server/service/integration_mdm_setup_experience_test.go
@@ -2997,7 +2997,7 @@ func (s *integrationMDMTestSuite) runDEPEnrollReleaseMobileDeviceWithVPPTest(t *
 
 	totalAppsToInstall := len(opts.VppAppsToInstall) + len(opts.InHouseAppsToInstall)
 	// For reporting back via InstalledApplicationList
-	installedVPPApps := make([]fleet.Software, 0, totalAppsToInstall)
+	reportedInstalledApps := make([]fleet.Software, 0, totalAppsToInstall)
 	// For verifying number of installs
 	installedApps := make(map[string]int, totalAppsToInstall)
 	var inHouseInstallCount int
@@ -3047,7 +3047,7 @@ func (s *integrationMDMTestSuite) runDEPEnrollReleaseMobileDeviceWithVPPTest(t *
 				}
 				for _, app := range opts.VppAppsToInstall {
 					if app.AdamID == fmt.Sprint(*fullCmd.Command.InstallApplication.ITunesStoreID) {
-						installedVPPApps = append(installedVPPApps, fleet.Software{BundleIdentifier: app.BundleIdentifier, Name: app.Name, Version: app.LatestVersion, Installed: true})
+						reportedInstalledApps = append(reportedInstalledApps, fleet.Software{BundleIdentifier: app.BundleIdentifier, Name: app.Name, Version: app.LatestVersion, Installed: true})
 						installedApps[app.AdamID]++
 					}
 				}
@@ -3061,7 +3061,7 @@ func (s *integrationMDMTestSuite) runDEPEnrollReleaseMobileDeviceWithVPPTest(t *
 				require.Less(t, inHouseInstallCount, len(opts.InHouseAppsToInstall), "unexpected extra in-house app install command")
 				sw := opts.InHouseAppsToInstall[inHouseInstallCount]
 				sw.Installed = true
-				installedVPPApps = append(installedVPPApps, sw)
+				reportedInstalledApps = append(reportedInstalledApps, sw)
 				installedApps["inhouse:"+sw.BundleIdentifier]++
 				inHouseInstallCount++
 			}
@@ -3083,16 +3083,16 @@ func (s *integrationMDMTestSuite) runDEPEnrollReleaseMobileDeviceWithVPPTest(t *
 			// InstalledApplicationList command instead of an InstallApplication command.
 			require.NoError(t, plist.Unmarshal(cmd.Raw, &fullCmd))
 			// Hold off on verifying the last install until later so we can ensure it waits for verification
-			if len(installedVPPApps) == totalAppsToInstall {
-				installedVPPApps[len(installedVPPApps)-1].Installed = false
+			if len(reportedInstalledApps) == totalAppsToInstall {
+				reportedInstalledApps[len(reportedInstalledApps)-1].Installed = false
 			}
 			cmd, err = mdmDevice.AcknowledgeInstalledApplicationList(
 				mdmDevice.UUID,
 				cmd.CommandUUID,
-				installedVPPApps,
+				reportedInstalledApps,
 			)
 			// flip the status back for later
-			installedVPPApps[len(installedVPPApps)-1].Installed = true
+			reportedInstalledApps[len(reportedInstalledApps)-1].Installed = true
 			require.NoError(t, err)
 			// TODO: We don't actually normally get a command back from the acknowledgement of the InstalledAppList
 			// but we'll get additional install commands if we follow it up with an idle. Is this a bug? I think it
@@ -3220,7 +3220,7 @@ func (s *integrationMDMTestSuite) runDEPEnrollReleaseMobileDeviceWithVPPTest(t *
 			cmd, err = mdmDevice.AcknowledgeInstalledApplicationList(
 				mdmDevice.UUID,
 				cmd.CommandUUID,
-				installedVPPApps,
+				reportedInstalledApps,
 			)
 			require.NoError(t, err)
 			// See above comment about cmd==nil, just want to make sure we don't get any additional

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -558,6 +558,7 @@ func (s *integrationMDMTestSuite) SetupSuite() {
 	// This is a bit of a code smell but I don't see a better way to initialize this for the tests. The
 	// initialization pattern works fine in our normal fleet server setup
 	appleMDMJob.VPPInstaller = svc
+	appleMDMJob.InHouseAppInstaller = svc
 
 	users, server := RunServerForTestsWithServiceWithDS(s.T(), ctx, s.ds, svc, &serverConfig)
 

--- a/server/service/mdm_install_reaper.go
+++ b/server/service/mdm_install_reaper.go
@@ -60,13 +60,13 @@ func ReapStuckMDMInstalls(ctx context.Context, ds fleet.Datastore, logger *slog.
 func recordReapedMDMInstall(ctx context.Context, ds fleet.Datastore, install fleet.ReapedMDMInstall,
 	newActivityFn fleet.NewActivityFunc,
 ) error {
+	// A reaped install can be a setup experience step — App Store apps on any Apple platform,
+	// in-house apps on iOS/iPadOS. Skipping the update would leave the step running for good
+	// and, on macOS, never cancel the rest of the setup experience.
 	var errs []error
 	var act fleet.ActivityDetails
 	switch {
 	case install.AppStoreActivity != nil:
-		// In-house apps cannot be part of the setup experience, so only App Store installs
-		// need this. Skipping it would leave the step running for good and, on macOS, never
-		// cancel the rest of the setup experience.
 		updated, err := maybeUpdateSetupExperienceStatus(ctx, ds, fleet.SetupExperienceVPPInstallResult{
 			HostUUID:      install.HostUUID,
 			CommandUUID:   install.CommandUUID,
@@ -79,6 +79,15 @@ func recordReapedMDMInstall(ctx context.Context, ds fleet.Datastore, install fle
 		act = install.AppStoreActivity
 
 	case install.InHouseActivity != nil:
+		updated, err := maybeUpdateSetupExperienceStatus(ctx, ds, fleet.SetupExperienceVPPInstallResult{
+			HostUUID:      install.HostUUID,
+			CommandUUID:   install.CommandUUID,
+			CommandStatus: fleet.MDMAppleStatusError,
+		}, newActivityFn)
+		if err != nil {
+			errs = append(errs, ctxerr.Wrap(ctx, err, "updating setup experience status from reaped in-house app install"))
+		}
+		install.InHouseActivity.FromSetupExperience = updated
 		act = install.InHouseActivity
 
 	default:

--- a/server/service/mdm_install_reaper_test.go
+++ b/server/service/mdm_install_reaper_test.go
@@ -104,7 +104,7 @@ func TestReapStuckMDMInstalls(t *testing.T) {
 		assert.True(t, act.FromSetupExperience)
 	})
 
-	t.Run("in-house installs skip the setup experience update", func(t *testing.T) {
+	t.Run("in-house installs fail the setup experience step and flag the activity", func(t *testing.T) {
 		ds := setupMockDS()
 		ds.ReapStuckActivatedMDMInstallsFunc = func(_ context.Context, _ time.Duration, _ int) ([]fleet.ReapedMDMInstall, error) {
 			return []fleet.ReapedMDMInstall{{
@@ -114,6 +114,23 @@ func TestReapStuckMDMInstalls(t *testing.T) {
 				InHouseActivity: &fleet.ActivityTypeInstalledSoftware{HostID: hostID, CommandUUID: commandUUID},
 			}}, nil
 		}
+		// In-house apps install during iOS/iPadOS setup experience; a reaped one must fail its
+		// step or the row stays running for good (the queue row is gone, so no command result
+		// will ever flip it).
+		var gotHostUUID, gotCmdUUID string
+		var gotStatus fleet.SetupExperienceStatusResultStatus
+		ds.MaybeUpdateSetupExperienceVPPStatusFunc = func(_ context.Context, hUUID, cmdUUID string,
+			status fleet.SetupExperienceStatusResultStatus,
+		) (bool, error) {
+			gotHostUUID, gotCmdUUID, gotStatus = hUUID, cmdUUID, status
+			return true, nil
+		}
+		ds.HostByIdentifierFunc = func(_ context.Context, _ string) (*fleet.Host, error) {
+			return &fleet.Host{ID: hostID, UUID: hostUUID, Platform: "ios"}, nil
+		}
+		ds.ListSetupExperienceResultsByHostUUIDFunc = func(_ context.Context, _ string, _ uint) ([]*fleet.SetupExperienceStatusResult, error) {
+			return nil, nil
+		}
 
 		var gotActivity fleet.ActivityDetails
 		newActivityFn := func(_ context.Context, _ *fleet.User, act fleet.ActivityDetails) error {
@@ -122,10 +139,13 @@ func TestReapStuckMDMInstalls(t *testing.T) {
 		}
 
 		require.NoError(t, ReapStuckMDMInstalls(ctx, ds, logger, newActivityFn, 24*time.Hour, 500))
-		_, ok := gotActivity.(*fleet.ActivityTypeInstalledSoftware)
+		assert.Equal(t, hostUUID, gotHostUUID)
+		assert.Equal(t, commandUUID, gotCmdUUID)
+		assert.Equal(t, fleet.SetupExperienceStatusFailure, gotStatus)
+
+		act, ok := gotActivity.(*fleet.ActivityTypeInstalledSoftware)
 		require.True(t, ok)
-		assert.False(t, ds.MaybeUpdateSetupExperienceVPPStatusFuncInvoked,
-			"in-house apps cannot be part of the setup experience")
+		assert.True(t, act.FromSetupExperience)
 	})
 
 	t.Run("records the installs a partially failed run did reap", func(t *testing.T) {

--- a/server/service/software_installers.go
+++ b/server/service/software_installers.go
@@ -751,6 +751,10 @@ func (svc *Service) InstallVPPAppPostValidation(ctx context.Context, host *fleet
 	return "", fleet.ErrMissingLicense // called downstream of auth checks so doesn't need skipauth
 }
 
+func (svc *Service) InstallInHouseAppForSetupExperience(ctx context.Context, host *fleet.Host, inHouseAppID uint, softwareTitleID uint) (string, error) {
+	return "", fleet.ErrMissingLicense // called downstream of auth checks so doesn't need skipauth
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // Uninstall software
 ////////////////////////////////////////////////////////////////////////////////

--- a/server/worker/apple_mdm.go
+++ b/server/worker/apple_mdm.go
@@ -52,6 +52,7 @@ type AppleMDM struct {
 	Commander             *apple_mdm.MDMAppleCommander
 	BootstrapPackageStore fleet.MDMBootstrapPackageStore
 	VPPInstaller          fleet.AppleMDMVPPInstaller
+	InHouseAppInstaller   fleet.AppleMDMInHouseAppInstaller
 	NewActivityFn         fleet.NewActivityFunc
 }
 
@@ -134,7 +135,7 @@ func (a *AppleMDM) runPostManualEnrollment(ctx context.Context, args appleMDMArg
 		// We shouldn't have any setup experience steps if we're not on a premium license,
 		// but best to check anyway plus it saves some db queries.
 		if license.IsPremium(ctx) {
-			_, err := a.installSetupExperienceVPPAppsOnIosIpadOS(ctx, args.HostUUID, ptr.ValOrZero(args.TeamID))
+			_, err := a.installSetupExperienceAppsOnIosIpadOS(ctx, args.HostUUID, ptr.ValOrZero(args.TeamID))
 			if err != nil {
 				return ctxerr.Wrap(ctx, err, "installing setup experience VPP apps on iOS/iPadOS")
 			}
@@ -201,7 +202,7 @@ func (a *AppleMDM) runPostDEPEnrollment(ctx context.Context, args appleMDMArgs) 
 			}
 		}
 	} else {
-		commandUUIDs, err := a.installSetupExperienceVPPAppsOnIosIpadOS(ctx, args.HostUUID, ptr.ValOrZero(args.TeamID))
+		commandUUIDs, err := a.installSetupExperienceAppsOnIosIpadOS(ctx, args.HostUUID, ptr.ValOrZero(args.TeamID))
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "installing setup experience VPP apps on iOS/iPadOS")
 		}
@@ -572,13 +573,14 @@ func (a *AppleMDM) installFleetd(ctx context.Context, hostUUID string) (string, 
 	return cmdUUID, nil
 }
 
-func (a *AppleMDM) installSetupExperienceVPPAppsOnIosIpadOS(ctx context.Context, hostUUID string, teamID uint) ([]string, error) {
+func (a *AppleMDM) installSetupExperienceAppsOnIosIpadOS(ctx context.Context, hostUUID string, teamID uint) ([]string, error) {
 	statuses, err := a.Datastore.ListSetupExperienceResultsByHostUUID(ctx, hostUUID, teamID)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "retrieving setup experience status results for next step")
 	}
 
 	var appsPending []*fleet.SetupExperienceStatusResult
+	var inHousePending []*fleet.SetupExperienceStatusResult
 	commandUUIDs := []string{}
 	for _, status := range statuses {
 		if err := status.IsValid(); err != nil {
@@ -590,14 +592,53 @@ func (a *AppleMDM) installSetupExperienceVPPAppsOnIosIpadOS(ctx context.Context,
 			if status.Status == fleet.SetupExperienceStatusPending {
 				appsPending = append(appsPending, status)
 			}
+		case status.InHouseAppID != nil:
+			if status.Status == fleet.SetupExperienceStatusPending {
+				inHousePending = append(inHousePending, status)
+			}
 		case status.SetupExperienceScriptID != nil, status.SoftwareInstallerID != nil:
 			status.Status = fleet.SetupExperienceStatusFailure
 			err = a.Datastore.UpdateSetupExperienceStatusResult(ctx, status)
 			if err != nil {
 				return nil, ctxerr.Wrap(ctx, err, "updating setup experience status result to failure")
 			}
-			// If we enqueued a non-VPP item for an iOS/iPadOS device, it likely a code bug
-			a.Log.ErrorContext(ctx, "unexpected setup experience item for iOS/iPadOS device, only VPP apps are supported", "host_uuid", hostUUID, "status_id", status.ID)
+			// If we enqueued a script or software-installer item for an iOS/iPadOS device, it's likely a code bug
+			a.Log.ErrorContext(ctx, "unexpected setup experience item for iOS/iPadOS device, only VPP and in-house apps are supported", "host_uuid", hostUUID, "status_id", status.ID)
+		}
+	}
+
+	if len(inHousePending) > 0 {
+		host, err := a.Datastore.HostByIdentifier(ctx, hostUUID)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "retrieving host by UUID")
+		}
+		if a.InHouseAppInstaller == nil {
+			// Should not happen in the normal course of events but can happen in
+			// tests and likely indicates things weren't initialized properly.
+			return nil, errors.New("in-house app installer not configured")
+		}
+		for _, app := range inHousePending {
+			if app.SoftwareTitleID == nil {
+				return nil, ctxerr.Errorf(ctx, "setup experience software title id missing from in-house app install request: %d", app.ID)
+			}
+
+			cmdUUID, err := a.InHouseAppInstaller.InstallInHouseAppForSetupExperience(ctx, host, *app.InHouseAppID, *app.SoftwareTitleID)
+			if err != nil {
+				// fail the item so setup experience isn't blocked. No activity is
+				// emitted here: the pre-flight failure path (unresolvable Fleet
+				// variable, *fleet.PreflightInstallFailedError) already recorded the
+				// failed install and its activity in the service layer.
+				a.Log.ErrorContext(ctx, "got an error when attempting to enqueue in-house app install", "err", err, "in_house_app_id", *app.InHouseAppID)
+				app.Status = fleet.SetupExperienceStatusFailure
+				app.Error = new(err.Error())
+			} else {
+				app.NanoCommandUUID = &cmdUUID
+				app.Status = fleet.SetupExperienceStatusRunning
+				commandUUIDs = append(commandUUIDs, cmdUUID)
+			}
+			if err := a.Datastore.UpdateSetupExperienceStatusResult(ctx, app); err != nil {
+				return nil, ctxerr.Wrap(ctx, err, "updating setup experience with in-house install command uuid")
+			}
 		}
 	}
 

--- a/server/worker/apple_mdm.go
+++ b/server/worker/apple_mdm.go
@@ -137,7 +137,7 @@ func (a *AppleMDM) runPostManualEnrollment(ctx context.Context, args appleMDMArg
 		if license.IsPremium(ctx) {
 			_, err := a.installSetupExperienceAppsOnIosIpadOS(ctx, args.HostUUID, ptr.ValOrZero(args.TeamID))
 			if err != nil {
-				return ctxerr.Wrap(ctx, err, "installing setup experience VPP apps on iOS/iPadOS")
+				return ctxerr.Wrap(ctx, err, "installing setup experience apps on iOS/iPadOS")
 			}
 		}
 		// Refetch is handled by the iphone_ipad_refetcher cron, which now

--- a/server/worker/apple_mdm.go
+++ b/server/worker/apple_mdm.go
@@ -204,7 +204,7 @@ func (a *AppleMDM) runPostDEPEnrollment(ctx context.Context, args appleMDMArgs) 
 	} else {
 		commandUUIDs, err := a.installSetupExperienceAppsOnIosIpadOS(ctx, args.HostUUID, ptr.ValOrZero(args.TeamID))
 		if err != nil {
-			return ctxerr.Wrap(ctx, err, "installing setup experience VPP apps on iOS/iPadOS")
+			return ctxerr.Wrap(ctx, err, "installing setup experience apps on iOS/iPadOS")
 		}
 		awaitCmdUUIDs = append(awaitCmdUUIDs, commandUUIDs...)
 	}

--- a/server/worker/apple_mdm.go
+++ b/server/worker/apple_mdm.go
@@ -622,8 +622,7 @@ func (a *AppleMDM) installSetupExperienceAppsOnIosIpadOS(ctx context.Context, ho
 		return commandUUIDs, nil
 	}
 
-	// TODO Is there a better way to get a host by UUID? This is a somewhat "wide" search which feels unnecessary
-	host, err := a.Datastore.HostByIdentifier(ctx, hostUUID)
+	host, err := a.Datastore.HostByUUID(ctx, hostUUID)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "retrieving host by UUID")
 	}

--- a/server/worker/apple_mdm.go
+++ b/server/worker/apple_mdm.go
@@ -39,6 +39,20 @@ const (
 	AppleMDMPostDEPReleaseDeviceTask AppleMDMTask = "post_dep_release_device"
 )
 
+// InHouseAppInstaller is the subset of the Fleet service this worker needs to
+// install in-house apps (.ipa) during setup experience. Declared on the
+// consumer so callers hand over the full fleet.Service without a type
+// assertion; the install logic lives in the premium service, which this
+// package cannot import.
+type InHouseAppInstaller interface {
+	// InstallInHouseAppForSetupExperience validates the in-house app's managed
+	// configuration for the host and enqueues its InstallApplication command,
+	// returning the command UUID. An unresolvable Fleet variable in the
+	// configuration records the failed install (and its activity) and returns
+	// a *fleet.PreflightInstallFailedError.
+	InstallInHouseAppForSetupExperience(ctx context.Context, host *fleet.Host, inHouseAppID uint, softwareTitleID uint) (string, error)
+}
+
 // AppleMDM is the job processor for the apple_mdm job.
 // CertProfilesLimit is the per-tick CA-profile throttle used by the
 // shared apple_mdm.ReconcileProfilesForEnrollingHost path. Set by the cron
@@ -52,7 +66,7 @@ type AppleMDM struct {
 	Commander             *apple_mdm.MDMAppleCommander
 	BootstrapPackageStore fleet.MDMBootstrapPackageStore
 	VPPInstaller          fleet.AppleMDMVPPInstaller
-	InHouseAppInstaller   fleet.AppleMDMInHouseAppInstaller
+	InHouseAppInstaller   InHouseAppInstaller
 	NewActivityFn         fleet.NewActivityFunc
 }
 
@@ -579,8 +593,9 @@ func (a *AppleMDM) installSetupExperienceAppsOnIosIpadOS(ctx context.Context, ho
 		return nil, ctxerr.Wrap(ctx, err, "retrieving setup experience status results for next step")
 	}
 
-	var appsPending []*fleet.SetupExperienceStatusResult
-	var inHousePending []*fleet.SetupExperienceStatusResult
+	// Collected in row order: rows are enqueued in alphabetical display-name
+	// order, and setup experience software is documented to install in that order.
+	var pendingApps []*fleet.SetupExperienceStatusResult
 	commandUUIDs := []string{}
 	for _, status := range statuses {
 		if err := status.IsValid(); err != nil {
@@ -588,13 +603,9 @@ func (a *AppleMDM) installSetupExperienceAppsOnIosIpadOS(ctx context.Context, ho
 		}
 
 		switch {
-		case status.VPPAppTeamID != nil:
+		case status.VPPAppTeamID != nil, status.InHouseAppID != nil:
 			if status.Status == fleet.SetupExperienceStatusPending {
-				appsPending = append(appsPending, status)
-			}
-		case status.InHouseAppID != nil:
-			if status.Status == fleet.SetupExperienceStatusPending {
-				inHousePending = append(inHousePending, status)
+				pendingApps = append(pendingApps, status)
 			}
 		case status.SetupExperienceScriptID != nil, status.SoftwareInstallerID != nil:
 			status.Status = fleet.SetupExperienceStatusFailure
@@ -607,103 +618,101 @@ func (a *AppleMDM) installSetupExperienceAppsOnIosIpadOS(ctx context.Context, ho
 		}
 	}
 
-	if len(inHousePending) > 0 {
-		host, err := a.Datastore.HostByIdentifier(ctx, hostUUID)
-		if err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "retrieving host by UUID")
-		}
-		if a.InHouseAppInstaller == nil {
-			// Should not happen in the normal course of events but can happen in
-			// tests and likely indicates things weren't initialized properly.
-			return nil, errors.New("in-house app installer not configured")
-		}
-		for _, app := range inHousePending {
-			if app.SoftwareTitleID == nil {
-				return nil, ctxerr.Errorf(ctx, "setup experience software title id missing from in-house app install request: %d", app.ID)
-			}
-
-			cmdUUID, err := a.InHouseAppInstaller.InstallInHouseAppForSetupExperience(ctx, host, *app.InHouseAppID, *app.SoftwareTitleID)
-			if err != nil {
-				// fail the item so setup experience isn't blocked. No activity is
-				// emitted here: the pre-flight failure path (unresolvable Fleet
-				// variable, *fleet.PreflightInstallFailedError) already recorded the
-				// failed install and its activity in the service layer.
-				a.Log.ErrorContext(ctx, "got an error when attempting to enqueue in-house app install", "err", err, "in_house_app_id", *app.InHouseAppID)
-				app.Status = fleet.SetupExperienceStatusFailure
-				app.Error = new(err.Error())
-			} else {
-				app.NanoCommandUUID = &cmdUUID
-				app.Status = fleet.SetupExperienceStatusRunning
-				commandUUIDs = append(commandUUIDs, cmdUUID)
-			}
-			if err := a.Datastore.UpdateSetupExperienceStatusResult(ctx, app); err != nil {
-				return nil, ctxerr.Wrap(ctx, err, "updating setup experience with in-house install command uuid")
-			}
-		}
+	if len(pendingApps) == 0 {
+		return commandUUIDs, nil
 	}
 
-	if len(appsPending) > 0 {
-		// enqueue vpp apps
-		// TODO Is there a better way to get a host by UUID? This is a somewhat "wide" search which feels unnecessary
-		host, err := a.Datastore.HostByIdentifier(ctx, hostUUID)
-		if err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "retrieving host by UUID")
-		}
-		for _, app := range appsPending {
+	// TODO Is there a better way to get a host by UUID? This is a somewhat "wide" search which feels unnecessary
+	host, err := a.Datastore.HostByIdentifier(ctx, hostUUID)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "retrieving host by UUID")
+	}
+
+	for _, app := range pendingApps {
+		isVPPApp := app.VPPAppTeamID != nil
+
+		// Any per-app error fails just that item so one bad app can neither
+		// block setup experience nor abort the whole enrollment job; only
+		// datastore errors persisting the result abort the run, since a retry
+		// can help there.
+		var cmdUUID string
+		var installErr error
+		switch {
+		case app.SoftwareTitleID == nil:
+			installErr = ctxerr.Errorf(ctx, "setup experience software title id missing from app install request: %d", app.ID)
+
+		case isVPPApp:
 			vppAppID, err := app.VPPAppID()
 			if err != nil {
-				return nil, ctxerr.Wrap(ctx, err, "constructing vpp app details for installation")
+				installErr = ctxerr.Wrap(ctx, err, "constructing vpp app details for installation")
+				break
 			}
-
-			if app.SoftwareTitleID == nil {
-				return nil, ctxerr.Errorf(ctx, "setup experience software title id missing from vpp app install request: %d", app.ID)
-			}
-
 			vppApp := &fleet.VPPApp{
 				TitleID: *app.SoftwareTitleID,
 				VPPAppTeam: fleet.VPPAppTeam{
 					VPPAppID: *vppAppID,
 				},
 			}
-
 			opts := fleet.HostSoftwareInstallOptions{
 				SelfService:        false,
 				ForSetupExperience: true,
 			}
+			cmdUUID, installErr = a.installSoftwareFromVPP(ctx, host, vppApp, true, opts)
 
-			cmdUUID, err := a.installSoftwareFromVPP(ctx, host, vppApp, true, opts)
+		default: // in-house app (.ipa)
+			if a.InHouseAppInstaller == nil {
+				// Should not happen in the normal course of events but can happen in
+				// tests and likely indicates things weren't initialized properly.
+				installErr = errors.New("in-house app installer not configured")
+				break
+			}
+			cmdUUID, installErr = a.InHouseAppInstaller.InstallInHouseAppForSetupExperience(ctx, host, *app.InHouseAppID, *app.SoftwareTitleID)
+		}
 
-			failedBeforeCommandSend := err != nil
-			if err != nil {
-				// if we get an error (e.g. no available licenses) while attempting to enqueue the
-				// install, then we should immediately go to an error state so setup experience
-				// isn't blocked.
-				a.Log.ErrorContext(ctx, "got an error when attempting to enqueue VPP app install", "err", err, "adam_id", app.VPPAppAdamID)
-				app.Status = fleet.SetupExperienceStatusFailure
-				app.Error = ptr.String(err.Error())
-			} else {
-				app.NanoCommandUUID = &cmdUUID
-				app.Status = fleet.SetupExperienceStatusRunning
-				commandUUIDs = append(commandUUIDs, cmdUUID)
+		if installErr != nil {
+			a.Log.ErrorContext(ctx, "got an error when attempting to enqueue app install", "err", installErr, "status_id", app.ID)
+			app.Status = fleet.SetupExperienceStatusFailure
+			app.Error = new(installErr.Error())
+		} else {
+			app.NanoCommandUUID = &cmdUUID
+			app.Status = fleet.SetupExperienceStatusRunning
+			commandUUIDs = append(commandUUIDs, cmdUUID)
+		}
+		if err := a.Datastore.UpdateSetupExperienceStatusResult(ctx, app); err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "updating setup experience with install command uuid")
+		}
+
+		if installErr == nil || a.NewActivityFn == nil {
+			continue
+		}
+		// A *fleet.PreflightInstallFailedError means the service layer already
+		// recorded the failed install and its activity.
+		var failActivity fleet.ActivityDetails
+		if isVPPApp {
+			failActivity = fleet.ActivityInstalledAppStoreApp{
+				HostID:              host.ID,
+				HostDisplayName:     host.DisplayName(),
+				SoftwareTitle:       app.Name,
+				AppStoreID:          ptr.ValOrZero(app.VPPAppAdamID),
+				Status:              string(fleet.SoftwareInstallFailed),
+				HostPlatform:        host.Platform,
+				FromSetupExperience: true,
 			}
-			if err := a.Datastore.UpdateSetupExperienceStatusResult(ctx, app); err != nil {
-				return nil, ctxerr.Wrap(ctx, err, "updating setup experience with vpp install command uuid")
+		} else {
+			if _, ok := errors.AsType[*fleet.PreflightInstallFailedError](installErr); ok {
+				continue
 			}
-			// Emit activity for the VPP app install failure, if one occurred
-			if failedBeforeCommandSend && a.NewActivityFn != nil {
-				failActivity := fleet.ActivityInstalledAppStoreApp{
-					HostID:              host.ID,
-					HostDisplayName:     host.DisplayName(),
-					SoftwareTitle:       app.Name,
-					AppStoreID:          ptr.ValOrZero(app.VPPAppAdamID),
-					Status:              string(fleet.SoftwareInstallFailed),
-					HostPlatform:        host.Platform,
-					FromSetupExperience: true,
-				}
-				if actErr := a.NewActivityFn(ctx, nil, failActivity); actErr != nil {
-					a.Log.WarnContext(ctx, "failed to create activity for VPP app install failure during setup experience", "err", actErr)
-				}
+			failActivity = fleet.ActivityTypeInstalledSoftware{
+				HostID:              host.ID,
+				HostDisplayName:     host.DisplayName(),
+				SoftwareTitle:       app.Name,
+				Source:              app.Source,
+				Status:              string(fleet.SoftwareInstallFailed),
+				FromSetupExperience: true,
 			}
+		}
+		if actErr := a.NewActivityFn(ctx, nil, failActivity); actErr != nil {
+			a.Log.WarnContext(ctx, "failed to create activity for app install failure during setup experience", "err", actErr)
 		}
 	}
 

--- a/server/worker/apple_mdm_test.go
+++ b/server/worker/apple_mdm_test.go
@@ -64,6 +64,26 @@ func (m *mockVPPInstaller) GetVPPTokenIfCanInstallVPPApps(ctx context.Context, a
 	return "valid-token", nil
 }
 
+type mockInHouseInstall struct {
+	hostID          uint
+	inHouseAppID    uint
+	softwareTitleID uint
+}
+
+type mockInHouseAppInstaller struct {
+	cmdUUID  string
+	err      error
+	installs []mockInHouseInstall
+}
+
+func (m *mockInHouseAppInstaller) InstallInHouseAppForSetupExperience(ctx context.Context, host *fleet.Host, inHouseAppID uint, softwareTitleID uint) (string, error) {
+	m.installs = append(m.installs, mockInHouseInstall{hostID: host.ID, inHouseAppID: inHouseAppID, softwareTitleID: softwareTitleID})
+	if m.err != nil {
+		return "", m.err
+	}
+	return m.cmdUUID, nil
+}
+
 func (m *mockVPPInstaller) InstallVPPAppPostValidation(ctx context.Context, host *fleet.Host, vppApp *fleet.VPPApp, token string, opts fleet.HostSoftwareInstallOptions) (string, error) {
 	require.True(m.t, opts.ForSetupExperience)
 	resp, ok := m.appInstallResponses[vppApp.AdamID]
@@ -1543,6 +1563,142 @@ VALUES (?, ?, ?, ?)`, h.UUID, vppAppWithTeam.Name, fleet.SetupExperienceStatusPe
 		assert.Equal(t, h.Platform, act.HostPlatform)
 		assert.True(t, act.FromSetupExperience)
 		assert.False(t, act.SelfService)
+	})
+
+	t.Run("installs in-house apps during iOS setup experience", func(t *testing.T) {
+		mysqltest.SetTestABMAssets(t, ds, testOrgName)
+		defer mysqltest.TruncateTables(t, ds)
+
+		tm, err := ds.NewTeam(ctx, &fleet.Team{Name: "test"})
+		require.NoError(t, err)
+		user1 := test.NewUser(t, ds, "Alice", "alice@example.com", true)
+
+		h := createEnrolledHost(t, 1, &tm.ID, true, "ios")
+
+		iosAppID, iosTitleID, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+			TeamID:           &tm.ID,
+			UserID:           user1.ID,
+			Title:            "Acme",
+			Filename:         "acme.ipa",
+			BundleIdentifier: "com.acme.app",
+			StorageID:        "acme-storage",
+			Platform:         "ios",
+			Extension:        "ipa",
+			Version:          "1.0",
+			ValidatedLabels:  &fleet.LabelIdentsWithScope{},
+		})
+		require.NoError(t, err)
+
+		mysqltest.ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			_, err = q.ExecContext(ctx, `
+INSERT INTO setup_experience_status_results (host_uuid, name, status, in_house_app_id)
+VALUES (?, ?, ?, ?)`, h.UUID, "Acme", fleet.SetupExperienceStatusPending, iosAppID)
+			return err
+		})
+
+		installer := &mockInHouseAppInstaller{cmdUUID: "inhouse-cmd-1"}
+		var capturedActivities []fleet.ActivityDetails
+		mdmWorker := &AppleMDM{
+			InHouseAppInstaller: installer,
+			Datastore:           ds,
+			Log:                 slogLog,
+			Commander:           apple_mdm.NewMDMAppleCommander(mdmStorage, mockPusher{}),
+			NewActivityFn: func(_ context.Context, _ *fleet.User, activity fleet.ActivityDetails) error {
+				capturedActivities = append(capturedActivities, activity)
+				return nil
+			},
+		}
+		w := NewWorker(ds, slogLog)
+		w.Register(mdmWorker)
+
+		err = QueueAppleMDMJob(ctx, ds, slogLog, AppleMDMPostDEPEnrollmentTask, h.UUID, h.Platform, &tm.ID, "", true, false)
+		require.NoError(t, err)
+		err = w.ProcessJobs(ctx)
+		require.NoError(t, err)
+
+		require.Equal(t, []mockInHouseInstall{{hostID: h.ID, inHouseAppID: iosAppID, softwareTitleID: iosTitleID}}, installer.installs)
+
+		// the item is running and carries the MDM command UUID so the release
+		// job waits for it
+		results, err := ds.ListSetupExperienceResultsByHostUUID(ctx, h.UUID, tm.ID)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		require.Equal(t, fleet.SetupExperienceStatusRunning, results[0].Status)
+		require.NotNil(t, results[0].NanoCommandUUID)
+		require.Equal(t, "inhouse-cmd-1", *results[0].NanoCommandUUID)
+		require.Empty(t, capturedActivities)
+
+		jobs, err := ds.GetQueuedJobs(ctx, 10, time.Now().UTC().Add(time.Minute))
+		require.NoError(t, err)
+		require.Len(t, jobs, 1)
+		require.Contains(t, string(*jobs[0].Args), AppleMDMPostDEPReleaseDeviceTask)
+		require.Contains(t, string(*jobs[0].Args), "inhouse-cmd-1")
+	})
+
+	t.Run("fails the in-house item on pre-flight error without blocking release", func(t *testing.T) {
+		mysqltest.SetTestABMAssets(t, ds, testOrgName)
+		defer mysqltest.TruncateTables(t, ds)
+
+		tm, err := ds.NewTeam(ctx, &fleet.Team{Name: "test"})
+		require.NoError(t, err)
+		user1 := test.NewUser(t, ds, "Alice", "alice@example.com", true)
+
+		h := createEnrolledHost(t, 1, &tm.ID, true, "ios")
+
+		iosAppID, _, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+			TeamID:           &tm.ID,
+			UserID:           user1.ID,
+			Title:            "Acme",
+			Filename:         "acme.ipa",
+			BundleIdentifier: "com.acme.app",
+			StorageID:        "acme-storage",
+			Platform:         "ios",
+			Extension:        "ipa",
+			Version:          "1.0",
+			ValidatedLabels:  &fleet.LabelIdentsWithScope{},
+		})
+		require.NoError(t, err)
+
+		mysqltest.ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			_, err = q.ExecContext(ctx, `
+INSERT INTO setup_experience_status_results (host_uuid, name, status, in_house_app_id)
+VALUES (?, ?, ?, ?)`, h.UUID, "Acme", fleet.SetupExperienceStatusPending, iosAppID)
+			return err
+		})
+
+		// the pre-flight failure path records the failed install and its
+		// activity in the service layer, so the worker must fail the item
+		// without emitting a second activity
+		installer := &mockInHouseAppInstaller{err: &fleet.PreflightInstallFailedError{Reason: "Couldn't resolve $FLEET_VAR_HOST_END_USER_EMAIL_IDP"}}
+		var capturedActivities []fleet.ActivityDetails
+		mdmWorker := &AppleMDM{
+			InHouseAppInstaller: installer,
+			Datastore:           ds,
+			Log:                 slogLog,
+			Commander:           apple_mdm.NewMDMAppleCommander(mdmStorage, mockPusher{}),
+			NewActivityFn: func(_ context.Context, _ *fleet.User, activity fleet.ActivityDetails) error {
+				capturedActivities = append(capturedActivities, activity)
+				return nil
+			},
+		}
+		w := NewWorker(ds, slogLog)
+		w.Register(mdmWorker)
+
+		err = QueueAppleMDMJob(ctx, ds, slogLog, AppleMDMPostDEPEnrollmentTask, h.UUID, h.Platform, &tm.ID, "", true, false)
+		require.NoError(t, err)
+		err = w.ProcessJobs(ctx)
+		require.NoError(t, err)
+
+		// the item reached a terminal state with the user-facing reason, so
+		// the release job is not gated on a command that will never arrive
+		results, err := ds.ListSetupExperienceResultsByHostUUID(ctx, h.UUID, tm.ID)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		require.Equal(t, fleet.SetupExperienceStatusFailure, results[0].Status)
+		require.NotNil(t, results[0].Error)
+		require.Contains(t, *results[0].Error, "Couldn't resolve")
+		require.Nil(t, results[0].NanoCommandUUID)
+		require.Empty(t, capturedActivities)
 	})
 
 	t.Run("treats NotNow status as a finished command status that does not block device release", func(t *testing.T) {

--- a/server/worker/apple_mdm_test.go
+++ b/server/worker/apple_mdm_test.go
@@ -1701,6 +1701,73 @@ VALUES (?, ?, ?, ?)`, h.UUID, "Acme", fleet.SetupExperienceStatusPending, iosApp
 		require.Empty(t, capturedActivities)
 	})
 
+	t.Run("emits an activity when the in-house enqueue fails outside pre-flight", func(t *testing.T) {
+		mysqltest.SetTestABMAssets(t, ds, testOrgName)
+		defer mysqltest.TruncateTables(t, ds)
+
+		tm, err := ds.NewTeam(ctx, &fleet.Team{Name: "test"})
+		require.NoError(t, err)
+		user1 := test.NewUser(t, ds, "Alice", "alice@example.com", true)
+
+		h := createEnrolledHost(t, 1, &tm.ID, true, "ios")
+
+		iosAppID, _, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+			TeamID:           &tm.ID,
+			UserID:           user1.ID,
+			Title:            "Acme",
+			Filename:         "acme.ipa",
+			BundleIdentifier: "com.acme.app",
+			StorageID:        "acme-storage",
+			Platform:         "ios",
+			Extension:        "ipa",
+			Version:          "1.0",
+			ValidatedLabels:  &fleet.LabelIdentsWithScope{},
+		})
+		require.NoError(t, err)
+
+		mysqltest.ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			_, err = q.ExecContext(ctx, `
+INSERT INTO setup_experience_status_results (host_uuid, name, status, in_house_app_id)
+VALUES (?, ?, ?, ?)`, h.UUID, "Acme", fleet.SetupExperienceStatusPending, iosAppID)
+			return err
+		})
+
+		// a non-preflight error was not recorded by the service layer, so the
+		// worker must emit the failed-install activity itself
+		installer := &mockInHouseAppInstaller{err: errors.New("insert in-house app install: boom")}
+		var capturedActivities []fleet.ActivityDetails
+		mdmWorker := &AppleMDM{
+			InHouseAppInstaller: installer,
+			Datastore:           ds,
+			Log:                 slogLog,
+			Commander:           apple_mdm.NewMDMAppleCommander(mdmStorage, mockPusher{}),
+			NewActivityFn: func(_ context.Context, _ *fleet.User, activity fleet.ActivityDetails) error {
+				capturedActivities = append(capturedActivities, activity)
+				return nil
+			},
+		}
+		w := NewWorker(ds, slogLog)
+		w.Register(mdmWorker)
+
+		err = QueueAppleMDMJob(ctx, ds, slogLog, AppleMDMPostDEPEnrollmentTask, h.UUID, h.Platform, &tm.ID, "", true, false)
+		require.NoError(t, err)
+		err = w.ProcessJobs(ctx)
+		require.NoError(t, err)
+
+		results, err := ds.ListSetupExperienceResultsByHostUUID(ctx, h.UUID, tm.ID)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		require.Equal(t, fleet.SetupExperienceStatusFailure, results[0].Status)
+
+		require.Len(t, capturedActivities, 1)
+		act, ok := capturedActivities[0].(fleet.ActivityTypeInstalledSoftware)
+		require.True(t, ok, "expected ActivityTypeInstalledSoftware, got %T", capturedActivities[0])
+		assert.Equal(t, h.ID, act.HostID)
+		assert.Equal(t, "Acme", act.SoftwareTitle)
+		assert.Equal(t, string(fleet.SoftwareInstallFailed), act.Status)
+		assert.True(t, act.FromSetupExperience)
+	})
+
 	t.Run("treats NotNow status as a finished command status that does not block device release", func(t *testing.T) {
 		mysqltest.SetTestABMAssets(t, ds, testOrgName)
 		defer mysqltest.TruncateTables(t, ds)


### PR DESCRIPTION
**Related issue:** Resolves #50629

> **Stacked on #51124** (base branch `50628-setup-experience-ipa-crud`) — review only this PR's commits.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

## Details

Final sub-task of #33995: a selected `.ipa` now actually installs while an iOS/iPadOS device is held in Setup Assistant, and its result drives the device release.

- **Types**: `SetupExperienceStatusResult.InHouseAppID` as a fourth mutually exclusive item kind; pairs with `nano_command_uuid` like VPP (`IsValid` table extended).
- **Enqueue**: fourth UNION branch in `enqueueSetupExperienceItems` for flagged in-house apps (iOS/iPadOS only), mirrored in the reset-after-failure variant. Deliberately no `in_house_app_labels` join — labels don't apply during setup experience for any software type, and a regression test asserts an out-of-scope host still gets the item, so reintroducing the check fails CI.
- **Install**: the iOS/iPadOS setup driver (renamed `installSetupExperienceAppsOnIosIpadOS`, formerly `...VPPApps...` — it force-failed any non-VPP row) enqueues in-house installs through a new `fleet.AppleMDMInHouseAppInstaller` interface, since the logic lives in the premium service which the worker can't import (same pattern as `AppleMDMVPPInstaller`). The ee implementation pre-flights `$FLEET_VAR_*` in the managed app configuration; an unresolvable variable records the failed install + activity and returns `*fleet.PreflightInstallFailedError`, so the worker fails the item with the user-facing reason without emitting a duplicate activity and the device still releases. The command UUID lands in `nano_command_uuid`, so the existing terminal-status update (`MaybeUpdateSetupExperienceVPPStatus`) and the release gate work unchanged. (Left that method's "VPP" name alone to keep interface/mock churn out of this PR — happy to rename in a follow-up if preferred.)
- **`SetupExperienceNextStep` guard**: an in-house row can never legitimately reach the poll-driven (macOS) flow; it now fails the item instead of falling through the switch silently and stalling the queue.
- **Command results**: a device-reported `InstallApplication` failure for an in-house app previously produced no activity (the error branch only knew VPP); it now falls back to `GetPastActivityDataForInHouseAppInstall`. Verified installs are now tagged `from_setup_experience` (the in-house `activityFn` dropped the flag). `fromAutoUpdate` is intentionally not plumbed: `ActivityTypeInstalledSoftware` has no such field and in-house apps have no auto-update flow.

Tests: end-to-end integration test (`TestSetupExperienceIOSInHouseApp`: ABM-enrolled iPhone with a mixed .ipa + VPP payload — both install via InstallApplication (ManifestURL vs iTunesStoreID), verify via InstalledApplicationList, gate DeviceConfigured, and the verified install is recorded with `from_setup_experience: true`); `IsValid` table cases; datastore enqueue (iPhone gets the row with `in_house_app_id`, iPad doesn't when only iOS is selected, label-scope-ignored canary); two worker subtests (success path asserts the command UUID gates the release job; pre-flight failure path asserts terminal failure with reason and no duplicate activity).

Remaining before un-draft: manual QA on real devices (signed `.ipa` pending).

Note: `TestIntegrations/TestPasswordReset` fails locally on `main` too (environmental) — unrelated.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Setup Experience now automatically installs eligible in-house `.ipa` apps on enrolling iOS and iPadOS devices.
  * In-house apps are supported alongside App Store and VPP apps, with installation status, ordering, deduplication, and result tracking.
  * Installation progress and failures are reflected in device activity and Setup Experience results.

* **Bug Fixes**
  * Prevented unsupported or failed app installations from silently blocking Setup Experience progression.
  * Improved reporting for installation failures, re-enrollment scenarios, and completed device setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->