### PR TITLE
update loadtest with mock apns server

### DIFF
--- a/.github/workflows/loadtest-infra.yml
+++ b/.github/workflows/loadtest-infra.yml
@@ -65,6 +65,14 @@ on:
         type: string
         default: "redis7"
         required: false
+      mock_apns_server:
+        description: "Deploy the mock Apple APNs push server and point Fleet's MDM pushes at it? When no, pushes are disabled entirely."
+        type: choice
+        options:
+        - "no"
+        - "yes"
+        default: "no"
+        required: false
       terraform_action:
         description: Dry run only? No "terraform apply"
         type: choice
@@ -100,6 +108,7 @@ env:
   TF_VAR_redis_engine: "${{ inputs.fleet_redis_engine }}"
   TF_VAR_redis_engine_version: "${{ inputs.fleet_redis_engine_version }}"
   TF_VAR_redis_parameter_group_family: "${{ inputs.fleet_redis_parameter_group_family }}"
+  TF_VAR_enable_apple_mdm: "${{ inputs.mock_apns_server == 'yes' }}"
 
 permissions:
   id-token: write

--- a/docs/Contributing/product-groups/mdm/apple-apns-mock.md
+++ b/docs/Contributing/product-groups/mdm/apple-apns-mock.md
@@ -66,6 +66,12 @@ For macOS if user enrollments is enabled, it will start two sessions against the
 It should still keep us way below the 8GB limit on osquery-perf containers, even at 5k each.
 
 
-## Terraform and load test (#31314)
+## Load testing with mock APNS server
 
-To be written when the infrastructure lands.
+To spin up a mock APNs server alongside Fleet in a loadtest environment, you need to select `yes` for the "Deploy the mock Apple APNs push server and point Fleet's MDM pushes at it?" option.
+
+This will internally create a container and a sub-url that routes the traffic to it, and configure Fleet containers with `FLEET_DEV_MDM_APPLE_PUSH_SERVER_URL` pointing to it.
+
+osquery-perf loadtesting needs the regular MDM knobs, but also now the `--mdm_apns_url=...` set to the base url. With this it should auto initiate sessions and listen for pings to do MDM check-ins.
+
+

--- a/infrastructure/loadtesting/terraform/docker/apple-apns-mock.Dockerfile
+++ b/infrastructure/loadtesting/terraform/docker/apple-apns-mock.Dockerfile
@@ -1,4 +1,7 @@
-FROM golang:1.26.4-alpine3.23@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f
+# Must be >= the `go` directive in the cloned repo's go.mod. The official Go
+# images set GOTOOLCHAIN=local, so a lower version here does not silently
+# download a newer toolchain -- it fails the build.
+FROM golang:1.26.5-alpine3.23@sha256:622e56dbc11a8cfe87cafa2331e9a201877271cbff918af53d3be315f3da88cc
 ARG TAG
 RUN apk add git
 RUN git clone -b $TAG --depth=1 --no-tags --progress --no-recurse-submodules https://github.com/fleetdm/fleet.git

--- a/infrastructure/loadtesting/terraform/docker/apple-apns-mock.Dockerfile
+++ b/infrastructure/loadtesting/terraform/docker/apple-apns-mock.Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:1.26.4-alpine3.23@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f
+ARG TAG
+RUN apk add git
+RUN git clone -b $TAG --depth=1 --no-tags --progress --no-recurse-submodules https://github.com/fleetdm/fleet.git
+RUN cd /go/fleet && go build -o /go/bin/apple-apns-mock ./cmd/apple-apns-mock
+
+FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
+LABEL maintainer="Fleet Developers"
+
+RUN addgroup -S apple-apns-mock && adduser -S apple-apns-mock -G apple-apns-mock
+
+COPY --from=0 /go/bin/apple-apns-mock /go/apple-apns-mock
+
+WORKDIR /go
+USER apple-apns-mock
+
+ENTRYPOINT ["/go/apple-apns-mock"]

--- a/infrastructure/loadtesting/terraform/docker/apple-apns-mock.Dockerfile
+++ b/infrastructure/loadtesting/terraform/docker/apple-apns-mock.Dockerfile
@@ -4,7 +4,7 @@
 FROM golang:1.26.5-alpine3.23@sha256:622e56dbc11a8cfe87cafa2331e9a201877271cbff918af53d3be315f3da88cc
 ARG TAG
 RUN apk add git
-RUN git clone -b $TAG --depth=1 --no-tags --progress --no-recurse-submodules https://github.com/fleetdm/fleet.git
+RUN git clone -b "$TAG" --depth=1 --no-tags --progress --no-recurse-submodules https://github.com/fleetdm/fleet.git
 RUN cd /go/fleet && go build -o /go/bin/apple-apns-mock ./cmd/apple-apns-mock
 
 FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11

--- a/infrastructure/loadtesting/terraform/infra/apple_apns_mock.tf
+++ b/infrastructure/loadtesting/terraform/infra/apple_apns_mock.tf
@@ -151,9 +151,9 @@ resource "aws_ecs_task_definition" "apple_apns_mock" {
 # ---- ECS Service ----
 
 resource "aws_ecs_service" "apple_apns_mock" {
-  count           = var.enable_apple_mdm ? 1 : 0
-  name            = "${local.customer}-apple-apns-mock"
-  cluster         = module.loadtest.byo-db.byo-ecs.service.cluster
+  count = var.enable_apple_mdm ? 1 : 0
+  name  = "${local.customer}-apple-apns-mock"
+  cluster         = module.loadtest.byo-db.cluster.cluster_name
   task_definition = aws_ecs_task_definition.apple_apns_mock[0].arn
   desired_count   = 1
   launch_type     = "FARGATE"

--- a/infrastructure/loadtesting/terraform/infra/apple_apns_mock.tf
+++ b/infrastructure/loadtesting/terraform/infra/apple_apns_mock.tf
@@ -1,0 +1,234 @@
+# Mock Apple APNs push server, deployed when var.enable_apple_mdm is true.
+#
+# Pushing at real Apple infrastructure with thousands of fake device UUIDs
+# would get us rate limited, so the only two sane options are "no pushes at
+# all" or "pushes to this". local.mdm_apple_environment_variables picks
+# whichever matches var.enable_apple_mdm.
+#
+# This lives in the infra module rather than in its own root module so a single
+# terraform apply brings it up alongside the Fleet server it serves. A separate
+# root module would mean a second apply, a second state file, and a window
+# where Fleet is configured to push at a hostname that does not exist yet.
+
+# ---- ECR + Docker image ----
+
+resource "aws_ecr_repository" "apple_apns_mock" {
+  count                = var.enable_apple_mdm ? 1 : 0
+  name                 = "${local.customer}-apple-apns-mock"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  force_delete = true
+}
+
+resource "docker_image" "apple_apns_mock" {
+  count = var.enable_apple_mdm ? 1 : 0
+  name  = "${aws_ecr_repository.apple_apns_mock[0].repository_url}:${var.tag}"
+
+  build {
+    context    = "${path.module}/../docker/"
+    dockerfile = "apple-apns-mock.Dockerfile"
+    platform   = "linux/amd64"
+    build_args = {
+      TAG = var.tag
+    }
+  }
+}
+
+resource "docker_tag" "apple_apns_mock" {
+  count        = var.enable_apple_mdm ? 1 : 0
+  source_image = docker_image.apple_apns_mock[0].name
+  target_image = "${aws_ecr_repository.apple_apns_mock[0].repository_url}:${var.tag}"
+}
+
+resource "docker_registry_image" "apple_apns_mock" {
+  count         = var.enable_apple_mdm ? 1 : 0
+  name          = docker_tag.apple_apns_mock[0].target_image
+  keep_remotely = true
+}
+
+# ---- CloudWatch Logs ----
+
+resource "aws_cloudwatch_log_group" "apple_apns_mock" {
+  count             = var.enable_apple_mdm ? 1 : 0
+  name              = "${local.customer}-apple-apns-mock"
+  retention_in_days = 30
+}
+
+# ---- Security Group ----
+
+resource "aws_security_group" "apple_apns_mock" {
+  count       = var.enable_apple_mdm ? 1 : 0
+  name_prefix = "${local.customer}-apple-apns-mock-"
+  vpc_id      = data.terraform_remote_state.shared.outputs.vpc.vpc_id
+  description = "Apple APNS mock - allows HTTP from internal ALB"
+
+  ingress {
+    description     = "HTTP from internal ALB"
+    from_port       = local.apple_apns_mock_port
+    to_port         = local.apple_apns_mock_port
+    protocol        = "tcp"
+    security_groups = [aws_security_group.internal.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# ---- ECS Task Definition ----
+
+resource "aws_ecs_task_definition" "apple_apns_mock" {
+  count                    = var.enable_apple_mdm ? 1 : 0
+  family                   = "${local.customer}-apple-apns-mock"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = 2048
+  memory                   = 4096
+  execution_role_arn       = module.loadtest.byo-db.byo-ecs.execution_iam_role_arn
+  task_role_arn            = module.loadtest.byo-db.byo-ecs.iam_role_arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "apple-apns-mock"
+      image     = docker_registry_image.apple_apns_mock[0].name
+      essential = true
+
+      portMappings = [
+        {
+          containerPort = local.apple_apns_mock_port
+          protocol      = "tcp"
+        }
+      ]
+
+      # One open SSE stream per simulated host, each burning a file
+      # descriptor. Fargate's default of 65535 would cap us well short of the
+      # 300k hosts this is sized for, so raise it to the platform maximum.
+      ulimits = [
+        {
+          name      = "nofile"
+          softLimit = 1048576
+          hardLimit = 1048576
+        }
+      ]
+
+      command = ["--listen", ":${local.apple_apns_mock_port}"]
+
+      # Go does not read the cgroup limit, so without GOMEMLIMIT the GC sizes
+      # the heap against the host and lets RSS sail past the task limit until
+      # ECS OOM-kills the container -- taking every open SSE stream with it.
+      # 90% leaves headroom for stacks and non-heap allocations.
+      environment = [
+        {
+          name  = "GOMEMLIMIT"
+          value = "${floor(4096 * 0.9)}MiB"
+        }
+      ]
+      secrets = []
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.apple_apns_mock[0].name
+          "awslogs-region"        = data.aws_region.current.region
+          "awslogs-stream-prefix" = "apple-apns-mock"
+        }
+      }
+    }
+  ])
+}
+
+# ---- ECS Service ----
+
+resource "aws_ecs_service" "apple_apns_mock" {
+  count           = var.enable_apple_mdm ? 1 : 0
+  name            = "${local.customer}-apple-apns-mock"
+  cluster         = module.loadtest.byo-db.byo-ecs.service.cluster
+  task_definition = aws_ecs_task_definition.apple_apns_mock[0].arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets         = data.terraform_remote_state.shared.outputs.vpc.private_subnets
+    security_groups = [aws_security_group.apple_apns_mock[0].id]
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.apple_apns_mock[0].arn
+    container_name   = "apple-apns-mock"
+    container_port   = local.apple_apns_mock_port
+  }
+
+  depends_on = [
+    aws_lb_listener_rule.apple_apns_mock,
+  ]
+}
+
+# ---- ALB target group + host-based listener rule ----
+
+resource "aws_lb_target_group" "apple_apns_mock" {
+  count                = var.enable_apple_mdm ? 1 : 0
+  name                 = "${local.customer}-apple-apns-mock"
+  protocol             = "HTTP"
+  port                 = local.apple_apns_mock_port
+  target_type          = "ip"
+  vpc_id               = data.terraform_remote_state.shared.outputs.vpc.vpc_id
+  deregistration_delay = 10
+
+  health_check {
+    path                = "/healthz"
+    matcher             = "200"
+    timeout             = 5
+    interval            = 30
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+  }
+}
+
+# The zone is public but the ALB is internal, so this resolves to VPC-private
+# addresses; only callers inside the VPC (Fleet, osquery-perf) can reach it.
+resource "aws_route53_record" "apple_apns_mock" {
+  count   = var.enable_apple_mdm ? 1 : 0
+  zone_id = data.aws_route53_zone.main.id
+  name    = local.apple_apns_mock_hostname
+  type    = "A"
+
+  alias {
+    name                   = aws_lb.internal.dns_name
+    zone_id                = aws_lb.internal.zone_id
+    evaluate_target_health = true
+  }
+}
+
+# Host-based rather than path-based routing: the mock's paths (/healthz,
+# /stats, /events, /3/device/*) would otherwise collide with Fleet's own routes
+# on this shared internal ALB -- /healthz in particular is the health check
+# path for the Fleet target group in internal_alb.tf. Matching on Host means
+# every path on this hostname reaches the mock and nothing else is affected.
+resource "aws_lb_listener_rule" "apple_apns_mock" {
+  count        = var.enable_apple_mdm ? 1 : 0
+  listener_arn = aws_lb_listener.internal.arn
+  # Priorities 20/21 on this listener belong to the android_amapi_mock module.
+  priority = 30
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.apple_apns_mock[0].arn
+  }
+
+  condition {
+    host_header {
+      values = [local.apple_apns_mock_hostname]
+    }
+  }
+}

--- a/infrastructure/loadtesting/terraform/infra/apple_apns_mock.tf
+++ b/infrastructure/loadtesting/terraform/infra/apple_apns_mock.tf
@@ -178,7 +178,7 @@ resource "aws_ecs_service" "apple_apns_mock" {
 
 resource "aws_lb_target_group" "apple_apns_mock" {
   count                = var.enable_apple_mdm ? 1 : 0
-  name                 = "${local.customer}-apple-apns-mock"
+  name                 = "${local.customer}-apnsm"
   protocol             = "HTTP"
   port                 = local.apple_apns_mock_port
   target_type          = "ip"

--- a/infrastructure/loadtesting/terraform/infra/apple_apns_mock.tf
+++ b/infrastructure/loadtesting/terraform/infra/apple_apns_mock.tf
@@ -151,8 +151,8 @@ resource "aws_ecs_task_definition" "apple_apns_mock" {
 # ---- ECS Service ----
 
 resource "aws_ecs_service" "apple_apns_mock" {
-  count = var.enable_apple_mdm ? 1 : 0
-  name  = "${local.customer}-apple-apns-mock"
+  count           = var.enable_apple_mdm ? 1 : 0
+  name            = "${local.customer}-apple-apns-mock"
   cluster         = module.loadtest.byo-db.cluster.cluster_name
   task_definition = aws_ecs_task_definition.apple_apns_mock[0].arn
   desired_count   = 1

--- a/infrastructure/loadtesting/terraform/infra/locals.tf
+++ b/infrastructure/loadtesting/terraform/infra/locals.tf
@@ -13,16 +13,42 @@ locals {
   } : {}
 
   elastic_apm_environment_variables = var.enable_otel ? {} : {
-    ELASTIC_APM_SERVER_URL                              = "https://loadtest.fleetdm.com:8200"
-    ELASTIC_APM_SERVICE_NAME                            = "fleet"
-    ELASTIC_APM_ENVIRONMENT                             = "${terraform.workspace}"
-    ELASTIC_APM_TRANSACTION_SAMPLE_RATE                 = "0.004"
-    ELASTIC_APM_SERVICE_VERSION                         = "${var.tag}-${split(":", data.docker_registry_image.dockerhub.sha256_digest)[1]}"
-    FLEET_LOGGING_TRACING_ENABLED                       = "true"
-    FLEET_LOGGING_TRACING_TYPE                          = "elasticapm"
-    FLEET_DEV_MDM_APPLE_DISABLE_PUSH                    = "1"
-    FLEET_DEV_MDM_APPLE_DISABLE_DEVICE_INFO_CERT_VERIFY = "1"
+    ELASTIC_APM_SERVER_URL              = "https://loadtest.fleetdm.com:8200"
+    ELASTIC_APM_SERVICE_NAME            = "fleet"
+    ELASTIC_APM_ENVIRONMENT             = "${terraform.workspace}"
+    ELASTIC_APM_TRANSACTION_SAMPLE_RATE = "0.004"
+    ELASTIC_APM_SERVICE_VERSION         = "${var.tag}-${split(":", data.docker_registry_image.dockerhub.sha256_digest)[1]}"
+    FLEET_LOGGING_TRACING_ENABLED       = "true"
+    FLEET_LOGGING_TRACING_TYPE          = "elasticapm"
   }
+
+  # Single label under loadtest.fleetdm.com so the *.loadtest.fleetdm.com
+  # wildcard cert would cover it if the mock ever moves to the HTTPS listener.
+  # A nested name would not: wildcards match exactly one label.
+  apple_apns_mock_hostname = "${local.customer}-apns-mock.loadtest.fleetdm.com"
+  apple_apns_mock_port     = 8378
+
+  # MDM behaviours we always want in a loadtest. These were previously buried
+  # in the Elastic APM branch above, which meant they silently vanished
+  # whenever enable_otel was true.
+  mdm_apple_environment_variables = merge(
+    {
+      # Skip verification of Apple certificates for OTA enrollments.
+      FLEET_DEV_MDM_APPLE_DISABLE_DEVICE_INFO_CERT_VERIFY = "1"
+    },
+    # Push traffic must never reach real Apple infrastructure, which would
+    # rate-limit us for pushing to thousands of fake device UUIDs. Either it
+    # goes to the mock, or it goes nowhere.
+    #
+    # These two are mutually exclusive: DISABLE_PUSH short-circuits
+    # initAppleMDMPushService to a nopPusher before the push URL is ever read,
+    # so setting both would silently make the mock unreachable.
+    var.enable_apple_mdm ? {
+      FLEET_DEV_MDM_APPLE_PUSH_SERVER_URL = "http://${local.apple_apns_mock_hostname}"
+      } : {
+      FLEET_DEV_MDM_APPLE_DISABLE_PUSH = "1"
+    }
+  )
 
   extra_environment_variables = merge(
     {
@@ -61,7 +87,8 @@ locals {
       FLEET_DEV_SKIP_S3_CONFIG = "1"
     },
     local.otel_environment_variables,
-    local.elastic_apm_environment_variables
+    local.elastic_apm_environment_variables,
+    local.mdm_apple_environment_variables
   )
   extra_secrets = {
     FLEET_LICENSE_KEY = data.aws_secretsmanager_secret.license.arn

--- a/infrastructure/loadtesting/terraform/infra/locals.tf
+++ b/infrastructure/loadtesting/terraform/infra/locals.tf
@@ -76,7 +76,7 @@ locals {
       FLEET_AUTH_SSO_SESSION_VALIDITY_PERIOD         = "15m"
       FLEET_MDM_SSO_RATE_LIMIT_PER_MINUTE            = "500"
       FLEET_SERVER_GZIP_RESPONSES                    = "true"
-      FLEET_DEV_ANDROID_PROXY_ENDPOINT = "http://${resource.aws_lb.internal.dns_name}/"
+      FLEET_DEV_ANDROID_PROXY_ENDPOINT               = "http://${resource.aws_lb.internal.dns_name}/"
 
       # Load TLS Certificate for RDS Authentication
       FLEET_MYSQL_TLS_CA                  = local.cert_path

--- a/infrastructure/loadtesting/terraform/infra/main.tf
+++ b/infrastructure/loadtesting/terraform/infra/main.tf
@@ -94,8 +94,9 @@ module "loadtest" {
     }
   }
   fleet_config = {
-    image               = local.fleet_image
-    family              = local.customer
+    image  = local.fleet_image
+    family = local.customer
+    command             = ["fleet", "serve", "--dev"]
     mem                 = var.fleet_task_memory
     cpu                 = var.fleet_task_cpu
     security_group_name = local.customer

--- a/infrastructure/loadtesting/terraform/infra/main.tf
+++ b/infrastructure/loadtesting/terraform/infra/main.tf
@@ -94,8 +94,8 @@ module "loadtest" {
     }
   }
   fleet_config = {
-    image  = local.fleet_image
-    family = local.customer
+    image               = local.fleet_image
+    family              = local.customer
     command             = ["fleet", "serve", "--dev"]
     mem                 = var.fleet_task_memory
     cpu                 = var.fleet_task_cpu

--- a/infrastructure/loadtesting/terraform/infra/outputs.tf
+++ b/infrastructure/loadtesting/terraform/infra/outputs.tf
@@ -87,3 +87,13 @@ output "rds_security_group_id" {
   description = "Security group ID for the RDS cluster"
   value       = module.loadtest.rds.security_group_id
 }
+
+output "apple_apns_mock_url" {
+  description = "Internal URL of the Apple APNs mock, or null when var.enable_apple_mdm is false. Fleet is already pointed at this; use it for osquery-perf or for curling /stats from inside the VPC."
+  value       = var.enable_apple_mdm ? "http://${local.apple_apns_mock_hostname}" : null
+}
+
+output "apple_apns_mock_hostname" {
+  description = "Hostname the Apple APNs mock claims on the internal ALB, or null when var.enable_apple_mdm is false."
+  value       = var.enable_apple_mdm ? local.apple_apns_mock_hostname : null
+}

--- a/infrastructure/loadtesting/terraform/infra/variables.tf
+++ b/infrastructure/loadtesting/terraform/infra/variables.tf
@@ -109,3 +109,14 @@ variable "enable_otel" {
   type        = bool
   default     = false
 }
+
+variable "enable_apple_mdm" {
+  description = <<-EOT
+    Spin up the mock Apple APNs push server and point the Fleet server's
+    pushes at it. When false, pushes are disabled outright
+    (FLEET_DEV_MDM_APPLE_DISABLE_PUSH) so that a loadtest never sends traffic
+    to real Apple infrastructure.
+  EOT
+  type        = bool
+  default     = false
+}

--- a/infrastructure/loadtesting/terraform/readme.md
+++ b/infrastructure/loadtesting/terraform/readme.md
@@ -67,6 +67,7 @@ export TF_VAR_fleet_config='{"FLEET_DEV_MDM_APPLE_DISABLE_PUSH":"1","FLEET_DEV_M
 - The value set in `FLEET_MDM_APPLE_SCEP_CHALLENGE` must match whatever you set in `osquery-perf`'s `mdm_scep_challenge` argument.
 - The above `export TF_VAR_fleet_config=...` command was tested on `bash`. It did not work in `zsh`.
 - Note that we are also setting `FLEET_DEV_MDM_APPLE_DISABLE_PUSH=1`. We don't want to generate push notifications against fake UUIDs (otherwise it may cause Apple to rate limit due to invalid requests).
+  - We now support push notifications for Apple MDM enrollments via the mock APNs server. To configure it, set the `FLEET_DEV_MDM_APPLE_PUSH_SERVER_URL` to the base URL of the mock APNs server.
 - Note that we are also setting `FLEET_DEV_MDM_APPLE_DISABLE_DEVICE_INFO_CERT_VERIFY=1` to skip verification of Apple certificates for OTA enrollments.
 This has an impact on real devices because they will not be notified of any command to execute (it may take a reboot for them to reach out to Fleet for more commands).
 

--- a/infrastructure/loadtesting/terraform/readme.md
+++ b/infrastructure/loadtesting/terraform/readme.md
@@ -66,8 +66,7 @@ export TF_VAR_fleet_config='{"FLEET_DEV_MDM_APPLE_DISABLE_PUSH":"1","FLEET_DEV_M
 - The above is needed because the newline characters in the certificate/key/token files.
 - The value set in `FLEET_MDM_APPLE_SCEP_CHALLENGE` must match whatever you set in `osquery-perf`'s `mdm_scep_challenge` argument.
 - The above `export TF_VAR_fleet_config=...` command was tested on `bash`. It did not work in `zsh`.
-- Note that we are also setting `FLEET_DEV_MDM_APPLE_DISABLE_PUSH=1`. We don't want to generate push notifications against fake UUIDs (otherwise it may cause Apple to rate limit due to invalid requests).
-  - We now support push notifications for Apple MDM enrollments via the mock APNs server. To configure it, set the `FLEET_DEV_MDM_APPLE_PUSH_SERVER_URL` to the base URL of the mock APNs server.
+- Note that we are also setting `FLEET_DEV_MDM_APPLE_DISABLE_PUSH=1`. We don't want to generate push notifications against fake UUIDs (otherwise it may cause Apple to rate limit due to invalid requests). To test Apple MDM pushes in load testing, deploy the mock APNs server and set `FLEET_DEV_MDM_APPLE_PUSH_SERVER_URL` (base URL) instead of `FLEET_DEV_MDM_APPLE_DISABLE_PUSH`.
 - Note that we are also setting `FLEET_DEV_MDM_APPLE_DISABLE_DEVICE_INFO_CERT_VERIFY=1` to skip verification of Apple certificates for OTA enrollments.
 This has an impact on real devices because they will not be notified of any command to execute (it may take a reboot for them to reach out to Fleet for more commands).
 

--- a/tools/mdm/apple/apnspush/main.go
+++ b/tools/mdm/apple/apnspush/main.go
@@ -29,6 +29,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/hex"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -168,9 +169,11 @@ func pushDirect(ctx context.Context, mdmStorage *mysql.NanoMDMStorage, baseURL s
 			// Same deterministic scheme mdmtest clients use in TokenUpdate
 			// (pkg/mdm/mdmtest/apple.go), so fake pushes line up with what
 			// simulated devices derive for themselves.
+			hexToken := make([]byte, hex.EncodedLen(len("token"+uuid)))
+			_ = hex.Encode(hexToken, []byte("token"+uuid))
 			pushInfo = &mdm.Push{
 				PushMagic: "pushmagic" + uuid,
-				Token:     []byte("token" + uuid),
+				Token:     hexToken,
 				Topic:     "com.apple.mgmt.External." + uuid,
 			}
 			provenance = "not in nano_enrollments — derived fake (mdmtest scheme)"

--- a/tools/mdm/apple/apnspush/main.go
+++ b/tools/mdm/apple/apnspush/main.go
@@ -29,7 +29,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
-	"encoding/hex"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -169,11 +168,9 @@ func pushDirect(ctx context.Context, mdmStorage *mysql.NanoMDMStorage, baseURL s
 			// Same deterministic scheme mdmtest clients use in TokenUpdate
 			// (pkg/mdm/mdmtest/apple.go), so fake pushes line up with what
 			// simulated devices derive for themselves.
-			hexToken := make([]byte, hex.EncodedLen(len("token"+uuid)))
-			_ = hex.Encode(hexToken, []byte("token"+uuid))
 			pushInfo = &mdm.Push{
 				PushMagic: "pushmagic" + uuid,
-				Token:     hexToken,
+				Token:     []byte("token" + uuid),
 				Topic:     "com.apple.mgmt.External." + uuid,
 			}
 			provenance = "not in nano_enrollments — derived fake (mdmtest scheme)"


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #31314

Verified it all tied together, by spinning up this branch as the workflow and image tag, creates a mock APNS server if set to yes in the github CI.

Spinning up osquery perf container, with the configured `--mdm_apns_url=...` checks in, creates active connections (can be verified via VPN and hitting the mock APNS url and `/stats`), also verified both device and user channels function.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information. Internal only change.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional mock Apple Push Notification service for load testing.
  * Added support for routing Apple push traffic to the mock service.
  * Added outputs exposing the mock service’s internal URL and hostname when enabled.
  * Added a workflow option to enable the mock service during load-test setup.

* **Configuration**
  * The mock service is disabled by default.
  * When disabled, real Apple push traffic is turned off for the load test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->