### PR TITLE
Reject host lists on dynamic labels regardless of length

### DIFF
--- a/changes/label-dynamic-membership-clear
+++ b/changes/label-dynamic-membership-clear
@@ -1,0 +1,1 @@
+* Fixed the modify label endpoint so that a dynamic label's membership can no longer be cleared by sending an empty `hosts` or `host_ids` list, which is now rejected like a non-empty one.

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -5629,6 +5629,23 @@ func (s *integrationTestSuite) TestLabels() {
 		assert.Equal(t, lbl2Hosts[1].ID, listHostsResp.Hosts[0].ID)
 		assert.Equal(t, lbl2Hosts[2].ID, listHostsResp.Hosts[1].ID)
 
+		// a dynamic label's membership cannot be replaced, and an empty list is a
+		// replacement too (it would clear all of its members)
+		for _, payload := range []fleet.ModifyLabelPayload{
+			{HostIDs: []uint{}},
+			{HostIDs: []uint{lbl2Hosts[0].ID}},
+			{Hosts: []string{}},
+			{Hosts: []string{lbl2Hosts[0].UUID}},
+		} {
+			res = s.Do("PATCH", fmt.Sprintf("/api/latest/fleet/labels/%d", lbl2.ID), &payload, http.StatusUnprocessableEntity)
+			errMsg = extractServerErrorText(res.Body)
+			require.Contains(t, errMsg, "cannot provide a list of hosts for a dynamic label")
+		}
+
+		listHostsResp = listHostsResponse{}
+		s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/labels/%d/hosts", lbl2.ID), nil, http.StatusOK, &listHostsResp)
+		assert.Len(t, listHostsResp.Hosts, len(lbl2Hosts))
+
 		// list hosts in manual label 1
 		listHostsResp = listHostsResponse{}
 		s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/labels/%d/hosts", manualLbl1.ID), nil, http.StatusOK, &listHostsResp, "order_key", "id")

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -5639,7 +5639,7 @@ func (s *integrationTestSuite) TestLabels() {
 		} {
 			res = s.Do("PATCH", fmt.Sprintf("/api/latest/fleet/labels/%d", lbl2.ID), &payload, http.StatusUnprocessableEntity)
 			errMsg = extractServerErrorText(res.Body)
-			require.Contains(t, errMsg, "cannot provide a list of hosts for a dynamic label")
+			require.Contains(t, errMsg, `"hosts" or "host_ids" can only be provided for a manual label`)
 		}
 
 		listHostsResp = listHostsResponse{}

--- a/server/service/labels.go
+++ b/server/service/labels.go
@@ -265,7 +265,7 @@ func (svc *Service) ModifyLabel(ctx context.Context, id uint, payload fleet.Modi
 		return nil, nil, fleet.NewInvalidArgumentError("label_type", fmt.Sprintf("cannot modify built-in label '%s'", label.Name))
 	}
 	if label.LabelMembershipType != fleet.LabelMembershipTypeManual && (payload.Hosts != nil || payload.HostIDs != nil) {
-		return nil, nil, fleet.NewInvalidArgumentError("hosts", "cannot provide a list of hosts for a dynamic label")
+		return nil, nil, fleet.NewInvalidArgumentError("hosts", `"hosts" or "host_ids" can only be provided for a manual label`)
 	}
 	if payload.Name != nil {
 		// Check if the new name is a reserved label name

--- a/server/service/labels.go
+++ b/server/service/labels.go
@@ -264,6 +264,9 @@ func (svc *Service) ModifyLabel(ctx context.Context, id uint, payload fleet.Modi
 	if label.LabelType == fleet.LabelTypeBuiltIn {
 		return nil, nil, fleet.NewInvalidArgumentError("label_type", fmt.Sprintf("cannot modify built-in label '%s'", label.Name))
 	}
+	if label.LabelMembershipType != fleet.LabelMembershipTypeManual && (payload.Hosts != nil || payload.HostIDs != nil) {
+		return nil, nil, fleet.NewInvalidArgumentError("hosts", "cannot provide a list of hosts for a dynamic label")
+	}
 	if payload.Name != nil {
 		// Check if the new name is a reserved label name
 		for name := range fleet.ReservedLabelNames() {
@@ -288,10 +291,6 @@ func (svc *Service) ModifyLabel(ctx context.Context, id uint, payload fleet.Modi
 		// If an empry list was provided, create an empty list of IDs
 		// so that we can remove all hosts from the label.
 		hostIDs = make([]uint, 0)
-	}
-
-	if len(hostIDs) > 0 && label.LabelMembershipType != fleet.LabelMembershipTypeManual {
-		return nil, nil, fleet.NewInvalidArgumentError("hosts", "cannot provide a list of hosts for a dynamic label")
 	}
 
 	// Verify the caller is authorized to write labels to each target host

--- a/server/service/labels_test.go
+++ b/server/service/labels_test.go
@@ -1223,6 +1223,68 @@ func TestModifyManualLabel(t *testing.T) {
 	})
 }
 
+func TestModifyLabelRejectsHostsForComputedMembership(t *testing.T) {
+	ds := new(mock.Store)
+	svc, ctx := newTestService(t, ds, nil, nil)
+	ctx = viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{GlobalRole: new(fleet.RoleAdmin)}})
+
+	membershipType := fleet.LabelMembershipTypeDynamic
+	ds.LabelFunc = func(ctx context.Context, lid uint, teamFilter fleet.TeamFilter) (*fleet.LabelWithTeamName, []uint, error) {
+		return &fleet.LabelWithTeamName{
+			Label: fleet.Label{
+				ID:                  lid,
+				LabelMembershipType: membershipType,
+			},
+		}, nil, nil
+	}
+	ds.SaveLabelFunc = func(ctx context.Context, lbl *fleet.Label, hostIDs []uint, filter fleet.TeamFilter) (*fleet.LabelWithTeamName, []uint, error) {
+		return &fleet.LabelWithTeamName{Label: *lbl}, hostIDs, nil
+	}
+	ds.HostIDsByIdentifierFunc = func(ctx context.Context, filter fleet.TeamFilter, hostnames []string) ([]uint, error) {
+		return []uint{99}, nil
+	}
+	mockListHostsLiteByIDs(ds)
+
+	computedTypes := []struct {
+		name           string
+		membershipType fleet.LabelMembershipType
+	}{
+		{"dynamic", fleet.LabelMembershipTypeDynamic},
+		{"host vitals", fleet.LabelMembershipTypeHostVitals},
+	}
+	payloads := []struct {
+		name    string
+		payload fleet.ModifyLabelPayload
+	}{
+		{"empty host IDs", fleet.ModifyLabelPayload{HostIDs: []uint{}}},
+		{"host IDs", fleet.ModifyLabelPayload{HostIDs: []uint{1}}},
+		{"empty hostnames", fleet.ModifyLabelPayload{Hosts: []string{}}},
+		{"hostnames", fleet.ModifyLabelPayload{Hosts: []string{"host1"}}},
+	}
+
+	for _, lblType := range computedTypes {
+		for _, tc := range payloads {
+			t.Run(lblType.name+"/"+tc.name, func(t *testing.T) {
+				membershipType = lblType.membershipType
+				ds.SaveLabelFuncInvoked = false
+
+				_, _, err := svc.ModifyLabel(ctx, 1, tc.payload)
+				require.ErrorContains(t, err, "cannot provide a list of hosts for a dynamic label")
+				require.False(t, ds.SaveLabelFuncInvoked)
+			})
+		}
+	}
+
+	t.Run("manual label can still be cleared", func(t *testing.T) {
+		membershipType = fleet.LabelMembershipTypeManual
+		ds.SaveLabelFuncInvoked = false
+
+		_, _, err := svc.ModifyLabel(ctx, 1, fleet.ModifyLabelPayload{HostIDs: []uint{}})
+		require.NoError(t, err)
+		require.True(t, ds.SaveLabelFuncInvoked)
+	})
+}
+
 func TestNewHostVitalsLabel(t *testing.T) {
 	ds := new(mock.Store)
 	svc, ctx := newTestService(t, ds, nil, nil)

--- a/server/service/labels_test.go
+++ b/server/service/labels_test.go
@@ -1245,13 +1245,15 @@ func TestModifyLabelRejectsHostsForComputedMembership(t *testing.T) {
 	}
 	mockListHostsLiteByIDs(ds)
 
-	computedTypes := []struct {
+	type labelTypeCase struct {
 		name           string
 		membershipType fleet.LabelMembershipType
-	}{
+	}
+	computedTypes := []labelTypeCase{
 		{"dynamic", fleet.LabelMembershipTypeDynamic},
 		{"host vitals", fleet.LabelMembershipTypeHostVitals},
 	}
+	manualType := labelTypeCase{"manual", fleet.LabelMembershipTypeManual}
 	payloads := []struct {
 		name    string
 		payload fleet.ModifyLabelPayload
@@ -1269,15 +1271,37 @@ func TestModifyLabelRejectsHostsForComputedMembership(t *testing.T) {
 				ds.SaveLabelFuncInvoked = false
 
 				_, _, err := svc.ModifyLabel(ctx, 1, tc.payload)
-				require.ErrorContains(t, err, "cannot provide a list of hosts for a dynamic label")
+				require.ErrorContains(t, err, `"hosts" or "host_ids" can only be provided for a manual label`)
 				require.False(t, ds.SaveLabelFuncInvoked)
 			})
 		}
 	}
 
+	// SaveLabel only replaces membership when it gets a non-nil list, so a request
+	// that omits both host fields must reach it as nil.
+	for _, lblType := range append(computedTypes, manualType) {
+		t.Run(lblType.name+"/rename without host fields", func(t *testing.T) {
+			membershipType = lblType.membershipType
+			ds.SaveLabelFuncInvoked = false
+			ds.SaveLabelFunc = func(ctx context.Context, lbl *fleet.Label, hostIDs []uint, filter fleet.TeamFilter) (*fleet.LabelWithTeamName, []uint, error) {
+				require.Nil(t, hostIDs)
+				return &fleet.LabelWithTeamName{Label: *lbl}, hostIDs, nil
+			}
+
+			_, _, err := svc.ModifyLabel(ctx, 1, fleet.ModifyLabelPayload{Name: new("renamed")})
+			require.NoError(t, err)
+			require.True(t, ds.SaveLabelFuncInvoked)
+		})
+	}
+
 	t.Run("manual label can still be cleared", func(t *testing.T) {
 		membershipType = fleet.LabelMembershipTypeManual
 		ds.SaveLabelFuncInvoked = false
+		ds.SaveLabelFunc = func(ctx context.Context, lbl *fleet.Label, hostIDs []uint, filter fleet.TeamFilter) (*fleet.LabelWithTeamName, []uint, error) {
+			require.NotNil(t, hostIDs)
+			require.Empty(t, hostIDs)
+			return &fleet.LabelWithTeamName{Label: *lbl}, hostIDs, nil
+		}
 
 		_, _, err := svc.ModifyLabel(ctx, 1, fleet.ModifyLabelPayload{HostIDs: []uint{}})
 		require.NoError(t, err)


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->

The modify label endpoint rejected a non-empty `hosts`/`host_ids` list for a label whose membership is computed, but accepted an empty one and passed it through to the membership replacement logic. Because a present-but-empty list means "replace membership with nothing", `{"host_ids": []}` cleared every member of a dynamic label and returned 200. Any user who can edit a label could therefore wipe the targeting that configuration profiles, policies, and scheduled queries depend on.
This PR introduces a check to prevent that.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented dynamic labels from having their automatically managed membership cleared through empty host lists.
  * Rejects host or host ID updates for dynamic and host-vitals labels with a clear validation error.
  * Manual labels can still be cleared as expected.
  * Rejected updates leave existing label membership unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->