### PR TITLE
Document that host lists are rejected for dynamic labels

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -6475,6 +6475,8 @@ Updates the specified label. Note: Label queries, platforms, and fleets are immu
 | hosts       | array   | body | If updating a manual label: the list of host identifiers (`hardware_serial` or `uuid`). The label will apply to any host with a matching identifier. The provided list fully replaces the previous list.  Only one of either `hosts` or `host_ids` can be included in the request.  |
 | host_ids    | array   | body | If updating a manual label: the list of Fleet host IDs the label will apply to. The provided list fully replaces the previous list. Only one of either `hosts` or `host_ids` can be included in the request.
 
+`hosts` and `host_ids` can only be used to update a manual label. Including either one when updating a dynamic label returns an error, even if the list is empty.
+
 The `hostname` host identifier is deprecated. Please use `host_ids`, `hardware_serial`, or `uuid` instead.
 
 #### Example


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->

Reference for the modify label endpoint said `hosts` and `host_ids` apply "if updating a manual label", but didn't state what happens when either is sent for a dynamic label. Both are now rejected, empty list included, so the parameter reference needs to say so explicitly.

Documents the API behavior change in https://github.com/fleetdm/fleet/pull/51137.
