### PR TITLE
Add article: What ChatGPT's new Linux desktop app means for shadow AI on developer machines

### DIFF
--- a/articles/chatgpt-linux-desktop-app-shadow-ai.md
+++ b/articles/chatgpt-linux-desktop-app-shadow-ai.md
@@ -7,10 +7,10 @@
 - **A third major AI vendor just closed its Linux gap.** OpenAI shipped a native ChatGPT (and Codex) desktop app for Linux in preview on August 11, 2026, about a month after Anthropic's Claude desktop app made the same move, so Linux developer machines are now a first-class target for every major AI client, not an afterthought.
 - **Linux developer workstations are already the blind spot.** They're where most cloud infrastructure gets built, and they're also the machines least likely to sit under the same MDM and inventory controls as company-issued Macs and PCs.
 - **Fleet's agent already inventories what lands on those machines.** Installed packages, MCP client configurations, and IDE extensions all show up in Fleet's cross-platform software inventory, on Linux the same as macOS and Windows.
-- **You don't need a new detection for this one.** The app ships as a standard `.deb` or `.rpm` package, so it's visible through the same package queries you already run for everything else, no special-cased rule required.
+- **You don't need a new detection for this one.** The app ships as a standard `.deb` or `.rpm` package, so it's visible through the same package queries you already run for everything else.
 - **Visibility here compounds with the rest of your AI governance.** Once this app (or any other AI client) shows up in inventory, it's the same starting point for policy enforcement, patch tracking, and CVE matching as any other piece of software.
 
-<a purpose="cta-button" href="/reports">Explore the reports library</a>
+<a purpose="cta-button" href="/linux-management">See Linux management in Fleet</a>
 
 Developers have been asking OpenAI for a native Linux client for a while, and now they have one: a preview release with `.deb` and `.rpm` packages for Ubuntu, Debian, and Fedora, bundling ChatGPT and OpenAI's Codex coding agent. It's a good, overdue release for anyone doing agentic development on Linux.
 

--- a/articles/chatgpt-linux-desktop-app-shadow-ai.md
+++ b/articles/chatgpt-linux-desktop-app-shadow-ai.md
@@ -10,7 +10,7 @@
 - **You don't need a new detection for this one.** The app ships as a standard `.deb` or `.rpm` package, so it's visible through the same package queries you already run for everything else.
 - **Visibility here compounds with the rest of your AI governance.** Once this app (or any other AI client) shows up in inventory, it's the same starting point for policy enforcement, patch tracking, and CVE matching as any other piece of software.
 
-<a purpose="cta-button" href="/linux-management">See Linux management in Fleet</a>
+<a purpose="cta-button" href="https://fleetdm.com/linux-management">See Linux management in Fleet</a>
 
 Developers have been asking OpenAI for a native Linux client for a while, and now they have one: a preview release with `.deb` and `.rpm` packages for Ubuntu, Debian, and Fedora, bundling ChatGPT and OpenAI's Codex coding agent. It's a good, overdue release for anyone doing agentic development on Linux.
 

--- a/articles/chatgpt-linux-desktop-app-shadow-ai.md
+++ b/articles/chatgpt-linux-desktop-app-shadow-ai.md
@@ -1,0 +1,79 @@
+# What ChatGPT's new Linux desktop app means for shadow AI on developer machines
+
+*OpenAI just shipped a native ChatGPT desktop app for Linux, giving developers another AI client to install on the machines IT and security teams already see the least of.*
+
+## Key takeaways
+
+- **A third major AI vendor just closed its Linux gap.** OpenAI shipped a native ChatGPT (and Codex) desktop app for Linux in preview on August 11, 2026, about a month after Anthropic's Claude desktop app made the same move, so Linux developer machines are now a first-class target for every major AI client, not an afterthought.
+- **Linux developer workstations are already the blind spot.** They're where most cloud infrastructure gets built, and they're also the machines least likely to sit under the same MDM and inventory controls as company-issued Macs and PCs.
+- **Fleet's agent already inventories what lands on those machines.** Installed packages, MCP client configurations, and IDE extensions all show up in Fleet's cross-platform software inventory, on Linux the same as macOS and Windows.
+- **You don't need a new detection for this one.** The app ships as a standard `.deb` or `.rpm` package, so it's visible through the same package queries you already run for everything else, no special-cased rule required.
+- **Visibility here compounds with the rest of your AI governance.** Once this app (or any other AI client) shows up in inventory, it's the same starting point for policy enforcement, patch tracking, and CVE matching as any other piece of software.
+
+<a purpose="cta-button" href="/reports">Explore the reports library</a>
+
+Developers have been asking OpenAI for a native Linux client for a while, and now they have one: a preview release with `.deb` and `.rpm` packages for Ubuntu, Debian, and Fedora, bundling ChatGPT and OpenAI's Codex coding agent. It's a good, overdue release for anyone doing agentic development on Linux.
+
+It's also one more AI client that can land on a developer's machine the same day it ships, on exactly the machines that tend to have the least oversight. That's not a reason to block it. It's a reason to make sure you'd actually see it.
+
+## A new native app, a familiar pattern
+
+OpenAI's ChatGPT desktop app for Linux went into preview on August 11, 2026, offering native `.deb` and `.rpm` packages for Ubuntu 24.04 and 26.04 LTS, Debian 13, and Fedora 43 and 44, on both x64 and ARM64. The release bundles ChatGPT, ChatGPT Work, and a preview of Codex, OpenAI's coding agent, giving Linux users the same desktop experience macOS and Windows users have had for a while.
+
+The timing matters as much as the release. This lands about a month after Anthropic shipped a Claude desktop client for Linux, which means two of the largest AI vendors have shipped native Linux clients within weeks of each other. That's a signal: Linux is no longer the platform AI vendors get to last. It's shipping alongside macOS and Windows, which means the pace of new AI clients landing on developer machines just picked up across all three.
+
+## Linux developer machines are where the visibility gap is worst
+
+Linux workstations are disproportionately where the most sensitive development work happens: cloud infrastructure, backend services, and increasingly, agentic coding with real access to source code and credentials. They're also, in a lot of organizations, the machines least likely to sit in the same device management program as a company-issued Mac or Windows laptop. Maybe it's a BYOD exception, a self-provisioned dev box, or a server-turned-workstation nobody thought to inventory.
+
+That combination, high-value machines with comparatively thin oversight, is exactly why a new native AI client showing up there matters more than the same release landing on a well-managed Mac fleet. If you can't answer "did this get installed, and where" for your Linux developers today, a Codex-capable agent with credential access on an unmanaged box is a hard thing to explain after the fact.
+
+## Catching it the day it lands
+
+The good news is that this app doesn't require any new detection work. It installs through the same package managers Fleet already inventories, so it shows up in standard software queries without a special case:
+
+```sql
+-- Debian/Ubuntu hosts
+SELECT name, version, source
+FROM deb_packages
+WHERE name LIKE '%chatgpt%' OR name LIKE '%codex%' OR name LIKE '%openai%';
+
+-- Fedora/RHEL-family hosts
+SELECT name, version
+FROM rpm_packages
+WHERE name LIKE '%chatgpt%' OR name LIKE '%codex%' OR name LIKE '%openai%';
+```
+
+Check the exact package name against a test install for your distro before you turn this into a saved policy, since vendors don't always ship under the name you'd guess. The same pattern (installed-package inventory, cross-platform, queryable live) is what you'd use for any new AI client that ships next month, not just this one.
+
+If you want the fuller picture, Fleet also reads MCP client configuration files and inventories IDE extensions across macOS, Windows, and Linux, which catches the agentic tooling that doesn't arrive as a native app at all. We covered that starter pack of reports in [Shadow AI is already on your fleet](https://fleetdm.com/articles/shadow-ai-is-already-on-your-fleet).
+
+## From "it's installed" to "it's governed"
+
+Seeing that the app landed is the first step, not the whole job. Once it shows up in Fleet's software inventory, it's subject to the same handling as everything else: matched against CVE data as vulnerabilities surface, flagged by a policy if it's not sanctioned for a given team, and remediated with a script if you decide to pull it. None of that is special-purpose AI tooling. It's the same detection-to-remediation loop Fleet already runs for every other piece of software on the fleet, and because policies live in Git as YAML, adding "flag unsanctioned AI clients on developer Linux boxes" is a reviewable pull request, not an undocumented change six months from now.
+
+## The pace isn't slowing down
+
+Two major AI vendors shipping native Linux clients within a month of each other is a preview of what's coming, not a one-off. More vendors will follow, and each one is a new line item that can land on a developer's machine before anyone files a ticket. The teams in a good position aren't the ones trying to block every new client. They're the ones who already know what's installed on every OS they manage, so a new arrival is a query away from an answer instead of a surprise.
+
+## See it live
+
+- **[Read the shadow AI reports](https://fleetdm.com/articles/shadow-ai-is-already-on-your-fleet)** for the full set of queries that surface AI apps, MCP configurations, and IDE extensions across your fleet.
+- **Get a demo** → [fleetdm.com/contact](https://fleetdm.com/contact)
+- **Join a GitOps training session** → [fleetdm.com/gitops-workshop](https://fleetdm.com/gitops-workshop)
+
+## Sources
+
+- TechCrunch, [OpenAI launches ChatGPT desktop app for Linux](https://techcrunch.com/2026/08/11/openai-launches-chatgpt-desktop-app-for-linux/).
+- Phoronix, [OpenAI Brings ChatGPT Desktop App To Linux](https://www.phoronix.com/news/ChatGPT-Desktop-Linux-Preview).
+- Linuxiac, [OpenAI Launches Official ChatGPT Desktop App for Linux in Preview](https://linuxiac.com/openai-launches-official-chatgpt-desktop-app-for-linux-in-preview/).
+
+---
+*Fleet is the open-source endpoint management platform for macOS, Windows, Linux, and more. Want to see what AI tooling is running on your fleet?* [*Get a demo*](https://fleetdm.com/contact) *or explore the* [*reports library*](https://fleetdm.com/reports)*.*
+
+<meta name="articleTitle" value="What ChatGPT's new Linux desktop app means for shadow AI on developer machines">
+<meta name="authorFullName" value="Allen Houchins">
+<meta name="authorGitHubUsername" value="allenhouchins">
+<meta name="category" value="articles">
+<meta name="publishedOn" value="2026-08-13">
+<meta name="description" value="OpenAI's new Linux ChatGPT app is one more AI client for developer machines. Here's how to see it land, the day it ships.">


### PR DESCRIPTION
**Related issue:** NA

New thought-leadership article pegged to OpenAI shipping a native ChatGPT (and Codex) desktop app for Linux in preview on August 11, 2026, about a month after Anthropic's Claude Linux client. The angle: Linux developer workstations are already an inventory blind spot, and every new native AI client (this one included) is something IT/security should be able to see land, not discover after the fact.

Notes for reviewers:

- News facts (release date, supported distros/architectures, bundled apps, timing vs. Anthropic's Claude Linux client) were checked against TechCrunch, Phoronix, and Linuxiac, all cited in the Sources section.
- Capability claims are scoped to what's shipped today: standard `deb_packages`/`rpm_packages` inventory for the new app itself, plus a pointer to the MCP client config and `vscode_extensions` reports already documented in `shadow-ai-is-already-on-your-fleet.md`, which this piece links to and builds on. The example queries use `LIKE` against a guessed package name and explicitly tell the reader to confirm the exact name against a test install, since the real package identifier wasn't verified.
- `publishedOn` is set to `2026-08-13`. Bump if this merges later.
- Byline is set to Allen Houchins, matching the existing convention for articles sourced from the `#_content-news-digest` pipeline.
- Pitched and approved in `#_content-news-digest` in Slack.

# Checklist for submitter

- [ ] Content reviewed for Fleet voice and style (`content-style`) and article format (`fleet-article-formatting`)
- [ ] Package-name guesses in the example queries verified against a real install
- [ ] Source attribution confirmed for the OpenAI Linux release facts
- [ ] Article renders correctly on the website

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjxwLZwUpuRM4bxbVCaHa1)_