### PR TITLE
Update migration test guidance for Claude

### DIFF
--- a/.claude/rules/fleet-database.md
+++ b/.claude/rules/fleet-database.md
@@ -8,7 +8,9 @@ paths:
 ## Migration Files
 - Location: `server/datastore/mysql/migrations/tables/`
 - Naming: `YYYYMMDDHHMMSS_CamelCaseName.go` (timestamp + descriptive CamelCase)
-- Every migration MUST have a corresponding `_test.go` file
+- Every migration that modifies data MUST have a corresponding `_test.go` file. That means changing existing data, adding new data, or
+  populating a table
+- Simple migrations that only add a table, column, or index do not need one
 - Structure:
   ```go
   func init() {

--- a/.claude/skills/new-migration/SKILL.md
+++ b/.claude/skills/new-migration/SKILL.md
@@ -43,7 +43,10 @@ func Down_{TIMESTAMP}(tx *sql.Tx) error {
 }
 ```
 
-### 3. Create Test File
+### 3. Create Test File (data migrations only)
+Only needed when the migration modifies data: changing existing data, adding new data, or populating a table. A migration that only adds a
+table, column, or index does not need a test file, since asserting the object exists afterwards only restates the DDL.
+
 Location: `server/datastore/mysql/migrations/tables/{TIMESTAMP}_{Name}_test.go`
 
 ```go

--- a/.claude/skills/new-migration/SKILL.md
+++ b/.claude/skills/new-migration/SKILL.md
@@ -45,7 +45,7 @@ func Down_{TIMESTAMP}(tx *sql.Tx) error {
 
 ### 3. Create Test File (data migrations only)
 Only needed when the migration modifies data: changing existing data, adding new data, or populating a table. A migration that only adds a
-table, column, or index does not need a test file, since asserting the object exists afterwards only restates the DDL.
+table, column, or index does not need a test file.
 
 Location: `server/datastore/mysql/migrations/tables/{TIMESTAMP}_{Name}_test.go`
 


### PR DESCRIPTION
Following our existing codebase patterns, we don't create tests for trivial migrations such as adding a column to a table.