### PR TITLE
Document fleetdm/security repo in handbook

### DIFF
--- a/handbook/company/communications.md
+++ b/handbook/company/communications.md
@@ -237,8 +237,6 @@ Fleet uses these levels to standardize a commitment to minimal esotericism acros
 - **Confidential:**  _Share only with team members who've signed an NDA, consulting agreement, or employment agreement_
 - **Classified:**  _Share only with the CEO, Executive Assistant, Head of People, GTM Systems Architect, and/or the people involved.  e.g., US social security numbers during hiring_
 
-> Application security reports (vulnerabilities, pen test findings, responsible disclosures) are tracked in the private [fleetdm/security](https://github.com/fleetdm/security) repo. Every Fleet team member has access, and keeping it separate from [fleetdm/confidential](https://github.com/fleetdm/confidential) lets outside security consultants work on security issues without seeing customer, people, or finance matters. Any customer-identifying context stays in fleetdm/confidential and is linked, never copied. To file a report, use the [security report issue form](https://github.com/fleetdm/security/issues/new?template=security-report.yml).
-
 
 ### Document titles
 

--- a/handbook/company/communications.md
+++ b/handbook/company/communications.md
@@ -237,6 +237,8 @@ Fleet uses these levels to standardize a commitment to minimal esotericism acros
 - **Confidential:**  _Share only with team members who've signed an NDA, consulting agreement, or employment agreement_
 - **Classified:**  _Share only with the CEO, Executive Assistant, Head of People, GTM Systems Architect, and/or the people involved.  e.g., US social security numbers during hiring_
 
+> Application security reports (vulnerabilities, pen test findings, responsible disclosures) are tracked in the private [fleetdm/security](https://github.com/fleetdm/security) repo, where access is granted per-person rather than company-wide. Any customer-identifying context stays in [fleetdm/confidential](https://github.com/fleetdm/confidential) and is linked, never copied. To file a report, use the [security report issue form](https://github.com/fleetdm/security/issues/new?template=security-report.yml).
+
 
 ### Document titles
 

--- a/handbook/company/communications.md
+++ b/handbook/company/communications.md
@@ -237,7 +237,7 @@ Fleet uses these levels to standardize a commitment to minimal esotericism acros
 - **Confidential:**  _Share only with team members who've signed an NDA, consulting agreement, or employment agreement_
 - **Classified:**  _Share only with the CEO, Executive Assistant, Head of People, GTM Systems Architect, and/or the people involved.  e.g., US social security numbers during hiring_
 
-> Application security reports (vulnerabilities, pen test findings, responsible disclosures) are tracked in the private [fleetdm/security](https://github.com/fleetdm/security) repo, where access is granted per-person rather than company-wide. Any customer-identifying context stays in [fleetdm/confidential](https://github.com/fleetdm/confidential) and is linked, never copied. To file a report, use the [security report issue form](https://github.com/fleetdm/security/issues/new?template=security-report.yml).
+> Application security reports (vulnerabilities, pen test findings, responsible disclosures) are tracked in the private [fleetdm/security](https://github.com/fleetdm/security) repo. Every Fleet team member has access, and keeping it separate from [fleetdm/confidential](https://github.com/fleetdm/confidential) lets outside security consultants work on security issues without seeing customer, people, or finance matters. Any customer-identifying context stays in fleetdm/confidential and is linked, never copied. To file a report, use the [security report issue form](https://github.com/fleetdm/security/issues/new?template=security-report.yml).
 
 
 ### Document titles

--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -78,7 +78,11 @@ All bug fix pull requests should reference the issue they resolve with the issue
 
 #### Handle a security report
 
-Security reports come in through the [confidential repo](https://github.com/fleetdm/confidential). Not every report is a fire drill — the severity determines the timing, not the urgency the reporter feels.
+Security reports come in through the private [fleetdm/security](https://github.com/fleetdm/security) repo. Whatever the source — GitHub security advisory, pen test finding, bug bounty, disclosure email, or scan result — file it with the [security report issue form](https://github.com/fleetdm/security/issues/new?template=security-report.yml), which standardizes the format for the engineers reviewing it and cross-links the original report. Issues labeled `security` are added to the [🔓 :help-security project](https://github.com/orgs/fleetdm/projects/113) automatically.
+
+If a report names or otherwise identifies a Fleet customer, keep that context in [fleetdm/confidential](https://github.com/fleetdm/confidential) and link to it — never copy customer-identifying details or `customer-*` labels into fleetdm/security.
+
+Not every report is a fire drill — the severity determines the timing, not the urgency the reporter feels.
 
 **Initial review:** An engineer or Engineering Manager reviews every new security report within **one business day** to confirm the report, assign a severity, and decide on a remediation path.
 
@@ -97,7 +101,7 @@ When a patch release branch has already been cut to ship previously fixed High i
 
 #### Stage a fix for a security report
 
-All conversation about an unfixed vulnerability stays in the confidential repo — never cross-post details, reproduction steps, or affected components into the public `fleet` repo.
+All conversation about an unfixed vulnerability stays in the private [fleetdm/security](https://github.com/fleetdm/security) repo — never cross-post details, reproduction steps, or affected components into the public `fleet` repo.
 
 **Keep the fix obscure in public history.** Fleet's commit log and open PRs are public, so anyone watching can correlate a vague commit with the upcoming release. Write the PR title and commit message so a reader cannot identify the vulnerability:
 
@@ -105,11 +109,11 @@ All conversation about an unfixed vulnerability stays in the confidential repo �
 - Do not describe the bug or its impact in terms a reporter would recognize.
 - Frame the change as a routine refactor, hardening, or input-validation improvement — whatever is least surprising for the files touched.
 - Keep the diff scoped to the fix; avoid bundling unrelated cleanup that makes the change look larger or more interesting than it is.
-- Do not use `Resolves: #<ticket>` or any other link back to the confidential ticket — that would expose the ticket number publicly.
+- Do not use `Resolves: #<ticket>` or any other link back to the security ticket — that would expose the ticket number publicly.
 
 **Private security advisory fork.** If the fix itself would tip off an attacker (for example, the patch is small and the vulnerable code path is obvious from the diff), develop it in the private fork attached to a GitHub [security advisory](https://docs.github.com/en/code-security/security-advisories/working-with-repository-security-advisories/about-repository-security-advisories) instead of an open PR. Either way, once the PR merges to `main` the change is in public history — coordinate the merge with the patch release so the fix ships immediately.
 
-**Link the PR back to the confidential ticket.** Since the PR description can't reference the confidential issue, post a comment on the confidential ticket with the PR URL when the PR opens (and again when it merges). That's how we maintain the audit trail without exposing the link publicly.
+**Link the PR back to the security ticket.** Since the PR description can't reference the security issue, post a comment on the fleetdm/security ticket with the PR URL when the PR opens (and again when it merges). That's how we maintain the audit trail without exposing the link publicly.
 
 
 ### Community contributions

--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -82,8 +82,6 @@ Security reports come in through the private [fleetdm/security](https://github.c
 
 If a report names or otherwise identifies a Fleet customer, keep that context in [fleetdm/confidential](https://github.com/fleetdm/confidential) and link to it — never copy customer-identifying details or `customer-*` labels into fleetdm/security.
 
-Not every report is a fire drill — the severity determines the timing, not the urgency the reporter feels.
-
 **Initial review:** An engineer or Engineering Manager reviews every new security report within **one business day** to confirm the report, assign a severity, and decide on a remediation path.
 
 **Severity timelines:**


### PR DESCRIPTION
Fleet now tracks application security reports (vulnerabilities, pen test findings, responsible disclosures) in the dedicated private fleetdm/security repo instead of fleetdm/confidential, so security work can be shared with outside security consultants without exposing broader confidential matters (customers, people ops, finance).

This PR updates the handbook to match:

- **Handbook: Engineering → Handle a security report** — intake now points at fleetdm/security with a direct link to the standardized [security report issue form](https://github.com/fleetdm/security/issues/new?template=security-report.yml), notes that `security`-labeled issues are automatically added to the :help-security project, and states the boundary rule: customer-identifying context stays in fleetdm/confidential and is linked, never copied.
- **Handbook: Engineering → Stage a fix for a security report** — references to the confidential repo/ticket updated to fleetdm/security.

🤖 Generated with [Claude Code](https://claude.com/claude-code)