### PR TITLE
Validate policy scope when ingesting distributed/write results

### DIFF
--- a/changes/policy-results-out-of-scope-injection
+++ b/changes/policy-results-out-of-scope-injection
@@ -1,0 +1,1 @@
+* Fixed policy result ingestion so a host can no longer report results for policies it is not assigned, preventing forged policy membership across fleet, platform, and label scopes.

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -32196,6 +32196,92 @@ func (s *integrationEnterpriseTestSuite) TestPolicyLabelsIncludeAll() {
 	}
 }
 
+// A host authenticates with its node key and fully controls the fleet_policy_query_<id> keys it
+// sends to distributed/write, so results for policies outside its scope must never be persisted.
+func (s *integrationEnterpriseTestSuite) TestPolicyResultsForOutOfScopePoliciesAreRejected() {
+	t := s.T()
+	ctx := t.Context()
+
+	var lblResp fleet.CreateLabelResponse
+	s.DoJSON("POST", "/api/latest/fleet/labels", fleet.LabelPayload{Name: uuid.NewString(), Query: "SELECT 1"}, http.StatusOK, &lblResp)
+	lbl := lblResp.Label
+
+	team, err := s.ds.NewTeam(ctx, &fleet.Team{Name: t.Name()})
+	require.NoError(t, err)
+
+	// The victim host: darwin, no team, not a member of lbl.
+	host, err := s.ds.NewHost(ctx, &fleet.Host{
+		DetailUpdatedAt: time.Now(),
+		LabelUpdatedAt:  time.Now(),
+		PolicyUpdatedAt: time.Now(),
+		SeenTime:        time.Now(),
+		OsqueryHostID:   new(t.Name()),
+		NodeKey:         new(t.Name()),
+		UUID:            uuid.New().String(),
+		Hostname:        t.Name() + ".local",
+		Platform:        "darwin",
+	})
+	require.NoError(t, err)
+
+	inScope, err := s.ds.NewGlobalPolicy(ctx, nil, fleet.PolicyPayload{Name: "in-scope-" + t.Name(), Query: "SELECT 1"})
+	require.NoError(t, err)
+
+	// Out of scope three different ways:
+	// 1. another fleet
+	otherFleet, err := s.ds.NewTeamPolicy(ctx, team.ID, nil, fleet.PolicyPayload{Name: "other-fleet-" + t.Name(), Query: "SELECT 1"})
+	require.NoError(t, err)
+	// 2. another platform
+	otherPlatform, err := s.ds.NewGlobalPolicy(ctx, nil, fleet.PolicyPayload{
+		Name: "other-platform-" + t.Name(), Query: "SELECT 1", Platform: "linux",
+	})
+	require.NoError(t, err)
+	// 3. label the host lacks
+	otherLabel, err := s.ds.NewGlobalPolicy(ctx, nil, fleet.PolicyPayload{
+		Name: "other-label-" + t.Name(), Query: "SELECT 1", LabelsIncludeAny: []string{lbl.Name},
+	})
+	require.NoError(t, err)
+
+	// Only the in-scope policy is distributed to the host.
+	distributedQueries, err := s.ds.PolicyQueriesForHost(ctx, host)
+	require.NoError(t, err)
+	require.Contains(t, distributedQueries, fmt.Sprint(inScope.ID))
+	for _, p := range []*fleet.Policy{otherFleet, otherPlatform, otherLabel} {
+		require.NotContains(t, distributedQueries, fmt.Sprint(p.ID))
+	}
+
+	// Forge the write: the payload keys are entirely host-controlled, so a node key plus a hand-rolled body is
+	// enough to claim a failing result for all four policies -- including the three never distributed above.
+	// The write is accepted (200) and the out-of-scope results are dropped during ingestion rather than
+	// rejecting the whole check-in, which would also discard the host's legitimate results.
+	var distributedResp submitDistributedQueryResultsResponse
+	s.DoJSON("POST", "/api/osquery/distributed/write", genDistributedReqWithPolicyResults(host, map[uint]*bool{
+		inScope.ID:       new(false),
+		otherFleet.ID:    new(false),
+		otherPlatform.ID: new(false),
+		otherLabel.ID:    new(false),
+	}), http.StatusOK, &distributedResp)
+
+	// Nothing was persisted for the out-of-scope policies. This asserts on policy_membership rather than
+	// ListPoliciesForHost because the latter re-applies the scope filter on read and would hide the rows.
+	var storedPolicyIDs []uint
+	mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		return sqlx.SelectContext(ctx, q, &storedPolicyIDs, `SELECT policy_id FROM policy_membership WHERE host_id = ?`, host.ID)
+	})
+	require.Equal(t, []uint{inScope.ID}, storedPolicyIDs)
+
+	// The forged results do not surface the host in policy-filtered host listings either.
+	countFailingHosts := func(policyID uint) int {
+		var listResp listHostsResponse
+		s.DoJSON("GET", "/api/latest/fleet/hosts", nil, http.StatusOK, &listResp,
+			"policy_id", fmt.Sprint(policyID), "policy_response", "failing")
+		return len(listResp.Hosts)
+	}
+	require.Equal(t, 1, countFailingHosts(inScope.ID))
+	for _, p := range []*fleet.Policy{otherFleet, otherPlatform, otherLabel} {
+		require.Zero(t, countFailingHosts(p.ID), "policy %s", p.Name)
+	}
+}
+
 // TestQueryLabelsIncludeAll mirrors TestPolicyLabelsIncludeAll for queries (reports),
 // covering the new LabelsIncludeAll field. Reports do not support exclude_any,
 // so the 2-way mutex (include_any vs include_all) is exercised here.

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -32198,7 +32198,7 @@ func (s *integrationEnterpriseTestSuite) TestPolicyLabelsIncludeAll() {
 
 // A host authenticates with its node key and fully controls the fleet_policy_query_<id> keys it
 // sends to distributed/write, so results for policies outside its scope must never be persisted.
-func (s *integrationEnterpriseTestSuite) TestPolicyResultsForOutOfScopePoliciesAreRejected() {
+func (s *integrationEnterpriseTestSuite) TestPolicyResultsForOutOfScopePoliciesAreDiscarded() {
 	t := s.T()
 	ctx := t.Context()
 

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -918,6 +918,28 @@ func (svc *Service) hasSetupExperiencePendingOrRunningItems(ctx context.Context,
 	return false, nil
 }
 
+// discardOutOfScopePolicyResults removes, in place, the results for policies that are not in scope for the host.
+//
+// A host authenticates with its node key and fully controls the fleet_policy_query_<id> keys it submits, so a result is
+// only trustworthy for a policy the host is actually assigned (by team, platform and label). Without this, any enrolled
+// host could forge membership for policies it was never sent, including policies belonging to another fleet.
+func (svc *Service) discardOutOfScopePolicyResults(ctx context.Context, host *fleet.Host, policyResults map[uint]*bool) error {
+	if len(policyResults) == 0 {
+		return nil
+	}
+	hostPolicyQueries, err := svc.ds.PolicyQueriesForHost(ctx, host)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "retrieve policy queries")
+	}
+	for policyID := range policyResults {
+		if _, ok := hostPolicyQueries[fmt.Sprint(policyID)]; !ok {
+			svc.logger.DebugContext(ctx, "discarding result for out-of-scope policy", "policyID", policyID, "hostID", host.ID)
+			delete(policyResults, policyID)
+		}
+	}
+	return nil
+}
+
 // cleanupOutOfScopePolicyMembership deletes the host's policy_membership rows
 // for the given stale policies: policies with a stored row but no result in the
 // host's incoming distributed write (as returned by RecordPolicyQueryExecutions).
@@ -1263,6 +1285,10 @@ func (svc *Service) SubmitDistributedQueryResults(
 		if err := svc.task.RecordLabelQueryExecutions(ctx, host, labelResults, svc.clock.Now(), ac.ServerSettings.DeferredSaveHost); err != nil {
 			logging.WithErr(ctx, err)
 		}
+	}
+
+	if err := svc.discardOutOfScopePolicyResults(ctx, host, policyResults); err != nil {
+		return ctxerr.Wrap(ctx, err, "discard out-of-scope policy results")
 	}
 
 	if len(policyResults) > 0 {

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -923,16 +923,51 @@ func (svc *Service) hasSetupExperiencePendingOrRunningItems(ctx context.Context,
 // A host authenticates with its node key and fully controls the fleet_policy_query_<id> keys it submits, so a result is
 // only trustworthy for a policy the host is actually assigned (by team, platform and label). Without this, any enrolled
 // host could forge membership for policies it was never sent, including policies belonging to another fleet.
+//
+// The allowed set mirrors the one policyQueriesForHost builds for this host's distributed/read response, including the
+// narrower subset used during setup experience, so the write accepts exactly what Fleet was willing to hand out.
 func (svc *Service) discardOutOfScopePolicyResults(ctx context.Context, host *fleet.Host, policyResults map[uint]*bool) error {
-	if len(policyResults) == 0 {
-		return nil
+	candidateIDs := make([]uint, 0, len(policyResults))
+	for policyID := range policyResults {
+		candidateIDs = append(candidateIDs, policyID)
 	}
-	hostPolicyQueries, err := svc.ds.PolicyQueriesForHost(ctx, host)
+
+	// Not fatal: a host that cannot be resolved for setup experience (no osquery_host_id) cannot be in it, so the
+	// full in-scope set below is both the correct answer and the safe one -- it still enforces fleet, platform and
+	// label scope.
+	inSetupExperience, err := svc.hostIsInSetupExperience(ctx, host)
+	if err != nil {
+		logging.WithErr(ctx, ctxerr.Wrap(ctx, err, "check if host is in setup experience"))
+		inSetupExperience = false
+	}
+	if inSetupExperience {
+		// Fleet answers this host's distributed/read with only the policies gating its pending setup-experience
+		// items, leaving its other policies skipped so unrelated automations do not fire mid-setup (see
+		// policyQueriesForHost). Accepting a result for one of those skipped policies here would fire them anyway.
+		hostUUID, err := fleet.HostUUIDForSetupExperience(host)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "get host uuid for setup experience policy queries")
+		}
+		gatingPolicyIDs, err := svc.ds.GetSetupExperiencePolicyIDsForHost(ctx, hostUUID)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "get setup experience policy ids for host")
+		}
+		gating := make(map[uint]struct{}, len(gatingPolicyIDs))
+		for _, policyID := range gatingPolicyIDs {
+			gating[policyID] = struct{}{}
+		}
+		candidateIDs = slices.DeleteFunc(candidateIDs, func(policyID uint) bool {
+			_, ok := gating[policyID]
+			return !ok
+		})
+	}
+
+	inScope, err := svc.ds.PolicyQueriesForHostFiltered(ctx, host, candidateIDs)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "retrieve policy queries")
 	}
 	for policyID := range policyResults {
-		if _, ok := hostPolicyQueries[fmt.Sprint(policyID)]; !ok {
+		if _, ok := inScope[fmt.Sprint(policyID)]; !ok {
 			svc.logger.DebugContext(ctx, "discarding result for out-of-scope policy", "policyID", policyID, "hostID", host.ID)
 			delete(policyResults, policyID)
 		}
@@ -1287,8 +1322,16 @@ func (svc *Service) SubmitDistributedQueryResults(
 		}
 	}
 
-	if err := svc.discardOutOfScopePolicyResults(ctx, host, policyResults); err != nil {
-		return ctxerr.Wrap(ctx, err, "discard out-of-scope policy results")
+	// Keep separate from the block below: this can empty policyResults, and an empty (rather than absent) result set
+	// makes RecordPolicyQueryExecutions treat every stored policy_membership row for the host as stale.
+	if len(policyResults) > 0 {
+		if err := svc.discardOutOfScopePolicyResults(ctx, host, policyResults); err != nil {
+			// Drop this cycle's policy results instead of failing the whole write: the host reports them again on
+			// its next check-in, whereas the detail and additional results from this same payload are only written
+			// further down (SaveHostAdditional, UpdateHost) and returning here would discard them.
+			logging.WithErr(ctx, ctxerr.Wrap(ctx, err, "discard out-of-scope policy results"))
+			clear(policyResults)
+		}
 	}
 
 	if len(policyResults) > 0 {

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -924,42 +924,16 @@ func (svc *Service) hasSetupExperiencePendingOrRunningItems(ctx context.Context,
 // only trustworthy for a policy the host is actually assigned (by team, platform and label). Without this, any enrolled
 // host could forge membership for policies it was never sent, including policies belonging to another fleet.
 //
-// The allowed set mirrors the one policyQueriesForHost builds for this host's distributed/read response, including the
-// narrower subset used during setup experience, so the write accepts exactly what Fleet was willing to hand out.
+// The lookup is restricted to the reported IDs rather than loading the host's whole in-scope set, since every
+// policy-reporting check-in pays for it.
+//
+// A host in setup experience is sent a subset of its in-scope policies, but it is checked against the full set: those
+// policies are legitimately the host's, so a result for one of them is worth keeping even if setup experience had not
+// asked for it yet.
 func (svc *Service) discardOutOfScopePolicyResults(ctx context.Context, host *fleet.Host, policyResults map[uint]*bool) error {
 	candidateIDs := make([]uint, 0, len(policyResults))
 	for policyID := range policyResults {
 		candidateIDs = append(candidateIDs, policyID)
-	}
-
-	// Not fatal: a host that cannot be resolved for setup experience (no osquery_host_id) cannot be in it, so the
-	// full in-scope set below is both the correct answer and the safe one -- it still enforces fleet, platform and
-	// label scope.
-	inSetupExperience, err := svc.hostIsInSetupExperience(ctx, host)
-	if err != nil {
-		logging.WithErr(ctx, ctxerr.Wrap(ctx, err, "check if host is in setup experience"))
-		inSetupExperience = false
-	}
-	if inSetupExperience {
-		// Fleet answers this host's distributed/read with only the policies gating its pending setup-experience
-		// items, leaving its other policies skipped so unrelated automations do not fire mid-setup (see
-		// policyQueriesForHost). Accepting a result for one of those skipped policies here would fire them anyway.
-		hostUUID, err := fleet.HostUUIDForSetupExperience(host)
-		if err != nil {
-			return ctxerr.Wrap(ctx, err, "get host uuid for setup experience policy queries")
-		}
-		gatingPolicyIDs, err := svc.ds.GetSetupExperiencePolicyIDsForHost(ctx, hostUUID)
-		if err != nil {
-			return ctxerr.Wrap(ctx, err, "get setup experience policy ids for host")
-		}
-		gating := make(map[uint]struct{}, len(gatingPolicyIDs))
-		for _, policyID := range gatingPolicyIDs {
-			gating[policyID] = struct{}{}
-		}
-		candidateIDs = slices.DeleteFunc(candidateIDs, func(policyID uint) bool {
-			_, ok := gating[policyID]
-			return !ok
-		})
 	}
 
 	inScope, err := svc.ds.PolicyQueriesForHostFiltered(ctx, host, candidateIDs)

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -3705,10 +3705,6 @@ func TestPolicyMembershipOutOfScopeCleanup(t *testing.T) {
 		return map[string]string{"1": "select 1"}, nil
 	}
 	mockPolicyQueriesForHostFiltered(ds)
-	// Policy 1 gates this host's setup experience, so its result is accepted in both the in-setup and normal cases.
-	ds.GetSetupExperiencePolicyIDsForHostFunc = func(ctx context.Context, hostUUID string) ([]uint, error) {
-		return []uint{1}, nil
-	}
 	stalePolicyIDs := []uint{7, 9}
 	ds.RecordPolicyQueryExecutionsFunc = func(ctx context.Context, gotHost *fleet.Host, results map[uint]*bool, updated time.Time,
 		deferred bool, newlyPassingPolicyIDs []uint,
@@ -3757,15 +3753,14 @@ func TestPolicyMembershipOutOfScopeCleanup(t *testing.T) {
 	require.False(t, ds.ClearHostPolicyMembershipForPoliciesFuncInvoked)
 	require.False(t, ds.UpdateHostIssuesFailingPoliciesForSingleHostFuncInvoked)
 
-	// No stale policies: nothing is deleted. The setup experience gate is still checked, because the incoming
-	// results have to be scoped against what setup experience would have distributed (see
-	// discardOutOfScopePolicyResults); that check is the one extra lookup a policy-reporting write now pays for.
+	// No stale policies: nothing is deleted and the setup experience gate is
+	// not even checked.
 	resetInvoked()
 	inSetupExperience = false
 	stalePolicyIDs = nil
 	submit(policyResults)
 	require.False(t, ds.ClearHostPolicyMembershipForPoliciesFuncInvoked)
-	require.True(t, ds.GetHostAwaitingConfigurationFuncInvoked)
+	require.False(t, ds.GetHostAwaitingConfigurationFuncInvoked)
 
 	// The "no policies in scope" wildcard also cleans up stale rows.
 	resetInvoked()
@@ -3830,6 +3825,8 @@ func TestOutOfScopePolicyResultsAreDiscarded(t *testing.T) {
 		ds.PolicyQueriesForHostFuncInvoked = false
 		ds.UpdateHostFuncInvoked = false
 		ds.SaveHostAdditionalFuncInvoked = false
+		ds.GetHostAwaitingConfigurationFuncInvoked = false
+		ds.GetSetupExperiencePolicyIDsForHostFuncInvoked = false
 		err := svc.SubmitDistributedQueryResults(ctx, results, statuses, map[string]string{}, map[string]*fleet.Stats{})
 		require.NoError(t, err)
 	}
@@ -3889,10 +3886,10 @@ func TestOutOfScopePolicyResultsAreDiscarded(t *testing.T) {
 		require.Equal(t, map[uint]*bool{1: new(true)}, recordedResults)
 	})
 
-	// A host in setup experience is sent only the policies gating its pending items; its other in-scope policies stay
-	// skipped so unrelated automations do not fire mid-setup. A result for one of those skipped policies must
-	// therefore be rejected even though the policy genuinely belongs to the host.
-	t.Run("during setup experience only gating policies are accepted", func(t *testing.T) {
+	// A host in setup experience is sent only the policies gating its pending items, but results are checked against
+	// its full in-scope set: those policies are legitimately the host's, so a result for one is worth keeping even if
+	// setup experience had not asked for it yet. Setup experience is therefore not consulted on this path at all.
+	t.Run("setup experience does not narrow the accepted set", func(t *testing.T) {
 		inSetupExperience = true
 		setupExperiencePolicyIDs = []uint{1}
 		t.Cleanup(func() {
@@ -3901,13 +3898,16 @@ func TestOutOfScopePolicyResultsAreDiscarded(t *testing.T) {
 		})
 
 		submit(map[string][]map[string]string{
-			hostPolicyQueryPrefix + "1":  {{"col1": "val1"}}, // gates a pending setup item, so Fleet did send it
-			hostPolicyQueryPrefix + "2":  {},                 // in scope, but Fleet withholds it until setup ends
+			hostPolicyQueryPrefix + "1":  {{"col1": "val1"}}, // gates a pending setup item
+			hostPolicyQueryPrefix + "2":  {{"col1": "val1"}}, // in scope, but not gating one
 			hostPolicyQueryPrefix + "99": {},                 // not in scope for this host at all
 		}, map[string]fleet.OsqueryStatus{})
 
-		require.Equal(t, map[uint]*bool{1: new(true)}, recordedResults)
-		require.Equal(t, []uint{1}, filteredForIDs)
+		require.Equal(t, map[uint]*bool{1: new(true), 2: new(true)}, recordedResults)
+		require.ElementsMatch(t, []uint{1, 2, 99}, filteredForIDs)
+		// No setup-experience lookup: a policy-reporting check-in pays for the scope query and nothing else.
+		require.False(t, ds.GetHostAwaitingConfigurationFuncInvoked)
+		require.False(t, ds.GetSetupExperiencePolicyIDsForHostFuncInvoked)
 	})
 
 	t.Run("scope lookup failure drops policy results without failing the write", func(t *testing.T) {
@@ -3962,17 +3962,6 @@ func TestOutOfScopePolicyResultsAreDiscarded(t *testing.T) {
 		require.JSONEq(t, `{"extra_bits":[{"n":"1"}]}`, string(*savedAdditional))
 	})
 
-	t.Run("setup experience host with no gating policies records nothing", func(t *testing.T) {
-		inSetupExperience = true
-		setupExperiencePolicyIDs = nil
-		t.Cleanup(func() { inSetupExperience = false })
-
-		submit(map[string][]map[string]string{
-			hostPolicyQueryPrefix + "1": {{"col1": "val1"}},
-		}, map[string]fleet.OsqueryStatus{})
-
-		require.False(t, ds.RecordPolicyQueryExecutionsFuncInvoked)
-	})
 }
 
 func TestPolicyQueriesDuringSetupExperience(t *testing.T) {

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -3828,6 +3828,8 @@ func TestOutOfScopePolicyResultsAreDiscarded(t *testing.T) {
 		ds.RecordPolicyQueryExecutionsFuncInvoked = false
 		ds.PolicyQueriesForHostFilteredFuncInvoked = false
 		ds.PolicyQueriesForHostFuncInvoked = false
+		ds.UpdateHostFuncInvoked = false
+		ds.SaveHostAdditionalFuncInvoked = false
 		err := svc.SubmitDistributedQueryResults(ctx, results, statuses, map[string]string{}, map[string]*fleet.Stats{})
 		require.NoError(t, err)
 	}
@@ -3924,21 +3926,40 @@ func TestOutOfScopePolicyResultsAreDiscarded(t *testing.T) {
 				return filterPolicyQueries(inScopePolicies, policyIDs), nil
 			}
 		})
+		var savedHost *fleet.Host
+		ds.UpdateHostFunc = func(ctx context.Context, gotHost *fleet.Host) error {
+			savedHost = gotHost
+			return nil
+		}
+		var savedAdditional *json.RawMessage
+		ds.SaveHostAdditionalFunc = func(ctx context.Context, hostID uint, additional *json.RawMessage) error {
+			savedAdditional = additional
+			return nil
+		}
 		ds.RecordLabelQueryExecutionsFuncInvoked = false
 
-		// The same write carries a label result and a policy result. submit asserts the write itself succeeds.
+		// One write carrying a label, a policy, a detail and an additional result. submit asserts it succeeds.
 		submit(map[string][]map[string]string{
-			hostLabelQueryPrefix + "5":  {{"col1": "val1"}},
-			hostPolicyQueryPrefix + "1": {{"col1": "val1"}},
+			hostLabelQueryPrefix + "5":               {{"col1": "val1"}},
+			hostPolicyQueryPrefix + "1":              {{"col1": "val1"}},
+			hostDetailQueryPrefix + "osquery_info":   {{"version": "5.99.0"}},
+			hostAdditionalQueryPrefix + "extra_bits": {{"n": "1"}},
 		}, map[string]fleet.OsqueryStatus{})
 
 		// Policy results are dropped, so nothing unvalidated is persisted. RecordPolicyQueryExecutions is where
 		// hosts.policy_updated_at is advanced, so not calling it also leaves the host due to report again.
 		require.False(t, ds.RecordPolicyQueryExecutionsFuncInvoked)
-		// The write completes instead of erroring out, so the rest of the payload is still processed. (Label results
-		// are recorded before the policy stage either way; what a returned error would actually cost is the detail
-		// and additional results written after it.)
+
 		require.True(t, ds.RecordLabelQueryExecutionsFuncInvoked)
+
+		// The detail and additional results are still persisted.
+		require.True(t, ds.UpdateHostFuncInvoked)
+		require.NotNil(t, savedHost)
+		require.Equal(t, "5.99.0", savedHost.OsqueryVersion)
+
+		require.True(t, ds.SaveHostAdditionalFuncInvoked)
+		require.NotNil(t, savedAdditional)
+		require.JSONEq(t, `{"extra_bits":[{"n":"1"}]}`, string(*savedAdditional))
 	})
 
 	t.Run("setup experience host with no gating policies records nothing", func(t *testing.T) {

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -2595,6 +2595,7 @@ func TestDistributedQueryResults(t *testing.T) {
 	ds.PolicyQueriesForHostFunc = func(ctx context.Context, host *fleet.Host) (map[string]string, error) {
 		return map[string]string{}, nil
 	}
+	mockPolicyQueriesForHostFiltered(ds)
 	host := &fleet.Host{
 		ID:            1,
 		Platform:      "windows",
@@ -3455,6 +3456,31 @@ func TestTeamMaintainerCanRunNewDistributedCampaigns(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// filterPolicyQueries narrows a host's in-scope policy queries to the requested IDs, as the real
+// PolicyQueriesForHostFiltered does.
+func filterPolicyQueries(inScope map[string]string, policyIDs []uint) map[string]string {
+	filtered := make(map[string]string, len(policyIDs))
+	for _, policyID := range policyIDs {
+		if query, ok := inScope[fmt.Sprint(policyID)]; ok {
+			filtered[fmt.Sprint(policyID)] = query
+		}
+	}
+	return filtered
+}
+
+// mockPolicyQueriesForHostFiltered wires PolicyQueriesForHostFiltered to the store's already-configured
+// PolicyQueriesForHost mock -- the same relationship the real datastore has between the two. distributed/write
+// validates incoming policy results through the filtered variant, so tests that submit policy results need it.
+func mockPolicyQueriesForHostFiltered(ds *mock.Store) {
+	ds.PolicyQueriesForHostFilteredFunc = func(ctx context.Context, host *fleet.Host, policyIDs []uint) (map[string]string, error) {
+		inScope, err := ds.PolicyQueriesForHostFunc(ctx, host)
+		if err != nil {
+			return nil, err
+		}
+		return filterPolicyQueries(inScope, policyIDs), nil
+	}
+}
+
 func TestPolicyQueries(t *testing.T) {
 	mockClock := clock.NewMockClock()
 	ds := new(mock.Store)
@@ -3490,6 +3516,7 @@ func TestPolicyQueries(t *testing.T) {
 	ds.PolicyQueriesForHostFunc = func(ctx context.Context, host *fleet.Host) (map[string]string, error) {
 		return map[string]string{"1": "select 1", "2": "select 42;"}, nil
 	}
+	mockPolicyQueriesForHostFiltered(ds)
 	recordedResults := make(map[uint]*bool)
 	ds.RecordPolicyQueryExecutionsFunc = func(ctx context.Context, gotHost *fleet.Host, results map[uint]*bool, updated time.Time,
 		deferred bool, newlyPassingPolicyIDs []uint,
@@ -3677,6 +3704,11 @@ func TestPolicyMembershipOutOfScopeCleanup(t *testing.T) {
 	ds.PolicyQueriesForHostFunc = func(ctx context.Context, host *fleet.Host) (map[string]string, error) {
 		return map[string]string{"1": "select 1"}, nil
 	}
+	mockPolicyQueriesForHostFiltered(ds)
+	// Policy 1 gates this host's setup experience, so its result is accepted in both the in-setup and normal cases.
+	ds.GetSetupExperiencePolicyIDsForHostFunc = func(ctx context.Context, hostUUID string) ([]uint, error) {
+		return []uint{1}, nil
+	}
 	stalePolicyIDs := []uint{7, 9}
 	ds.RecordPolicyQueryExecutionsFunc = func(ctx context.Context, gotHost *fleet.Host, results map[uint]*bool, updated time.Time,
 		deferred bool, newlyPassingPolicyIDs []uint,
@@ -3725,14 +3757,15 @@ func TestPolicyMembershipOutOfScopeCleanup(t *testing.T) {
 	require.False(t, ds.ClearHostPolicyMembershipForPoliciesFuncInvoked)
 	require.False(t, ds.UpdateHostIssuesFailingPoliciesForSingleHostFuncInvoked)
 
-	// No stale policies: nothing is deleted and the setup experience gate is
-	// not even checked.
+	// No stale policies: nothing is deleted. The setup experience gate is still checked, because the incoming
+	// results have to be scoped against what setup experience would have distributed (see
+	// discardOutOfScopePolicyResults); that check is the one extra lookup a policy-reporting write now pays for.
 	resetInvoked()
 	inSetupExperience = false
 	stalePolicyIDs = nil
 	submit(policyResults)
 	require.False(t, ds.ClearHostPolicyMembershipForPoliciesFuncInvoked)
-	require.False(t, ds.GetHostAwaitingConfigurationFuncInvoked)
+	require.True(t, ds.GetHostAwaitingConfigurationFuncInvoked)
 
 	// The "no policies in scope" wildcard also cleans up stale rows.
 	resetInvoked()
@@ -3757,13 +3790,23 @@ func TestOutOfScopePolicyResultsAreDiscarded(t *testing.T) {
 	ds.TeamLiteFunc = func(ctx context.Context, id uint) (*fleet.TeamLite, error) {
 		return &fleet.TeamLite{ID: 0}, nil
 	}
+	inSetupExperience := false
 	ds.GetHostAwaitingConfigurationFunc = func(ctx context.Context, hostUUID string) (bool, error) {
-		return false, nil
+		return inSetupExperience, nil
+	}
+	var setupExperiencePolicyIDs []uint
+	ds.GetSetupExperiencePolicyIDsForHostFunc = func(ctx context.Context, hostUUID string) ([]uint, error) {
+		return setupExperiencePolicyIDs, nil
 	}
 	inScopePolicies := map[string]string{"1": "select 1", "2": "select 2"}
-	ds.PolicyQueriesForHostFunc = func(ctx context.Context, gotHost *fleet.Host) (map[string]string, error) {
+	// Set directly rather than via mockPolicyQueriesForHostFiltered: that helper reads through
+	// PolicyQueriesForHostFunc, which this test asserts is never invoked. filteredForIDs records the IDs the scope
+	// lookup was asked about.
+	var filteredForIDs []uint
+	ds.PolicyQueriesForHostFilteredFunc = func(ctx context.Context, gotHost *fleet.Host, policyIDs []uint) (map[string]string, error) {
 		require.Equal(t, host.ID, gotHost.ID)
-		return inScopePolicies, nil
+		filteredForIDs = policyIDs
+		return filterPolicyQueries(inScopePolicies, policyIDs), nil
 	}
 	var flippingResults map[uint]*bool
 	ds.FlippingPoliciesForHostFunc = func(ctx context.Context, hostID uint, incomingResults map[uint]*bool) ([]uint, []uint, error) {
@@ -3781,11 +3824,25 @@ func TestOutOfScopePolicyResultsAreDiscarded(t *testing.T) {
 	ctx = hostctx.NewContext(ctx, host)
 
 	submit := func(results map[string][]map[string]string, statuses map[string]fleet.OsqueryStatus) {
-		flippingResults, recordedResults = nil, nil
+		flippingResults, recordedResults, filteredForIDs = nil, nil, nil
 		ds.RecordPolicyQueryExecutionsFuncInvoked = false
+		ds.PolicyQueriesForHostFilteredFuncInvoked = false
+		ds.PolicyQueriesForHostFuncInvoked = false
 		err := svc.SubmitDistributedQueryResults(ctx, results, statuses, map[string]string{}, map[string]*fleet.Stats{})
 		require.NoError(t, err)
 	}
+
+	t.Run("scope lookup is restricted to the reported policy IDs", func(t *testing.T) {
+		submit(map[string][]map[string]string{
+			hostPolicyQueryPrefix + "1":  {{"col1": "val1"}},
+			hostPolicyQueryPrefix + "99": {},
+		}, map[string]fleet.OsqueryStatus{})
+
+		// Never the host's whole policy set: this runs on every policy-reporting check-in.
+		require.True(t, ds.PolicyQueriesForHostFilteredFuncInvoked)
+		require.False(t, ds.PolicyQueriesForHostFuncInvoked)
+		require.ElementsMatch(t, []uint{1, 99}, filteredForIDs)
+	})
 
 	t.Run("forged policy IDs are dropped, in-scope results kept", func(t *testing.T) {
 		submit(map[string][]map[string]string{
@@ -3828,6 +3885,72 @@ func TestOutOfScopePolicyResultsAreDiscarded(t *testing.T) {
 		}, map[string]fleet.OsqueryStatus{})
 
 		require.Equal(t, map[uint]*bool{1: new(true)}, recordedResults)
+	})
+
+	// A host in setup experience is sent only the policies gating its pending items; its other in-scope policies stay
+	// skipped so unrelated automations do not fire mid-setup. A result for one of those skipped policies must
+	// therefore be rejected even though the policy genuinely belongs to the host.
+	t.Run("during setup experience only gating policies are accepted", func(t *testing.T) {
+		inSetupExperience = true
+		setupExperiencePolicyIDs = []uint{1}
+		t.Cleanup(func() {
+			inSetupExperience = false
+			setupExperiencePolicyIDs = nil
+		})
+
+		submit(map[string][]map[string]string{
+			hostPolicyQueryPrefix + "1":  {{"col1": "val1"}}, // gates a pending setup item, so Fleet did send it
+			hostPolicyQueryPrefix + "2":  {},                 // in scope, but Fleet withholds it until setup ends
+			hostPolicyQueryPrefix + "99": {},                 // not in scope for this host at all
+		}, map[string]fleet.OsqueryStatus{})
+
+		require.Equal(t, map[uint]*bool{1: new(true)}, recordedResults)
+		require.Equal(t, []uint{1}, filteredForIDs)
+	})
+
+	t.Run("scope lookup failure drops policy results without failing the write", func(t *testing.T) {
+		ds.PolicyQueriesForHostFilteredFunc = func(ctx context.Context, gotHost *fleet.Host, policyIDs []uint) (map[string]string, error) {
+			return nil, errors.New("database is on fire")
+		}
+		ds.LabelQueriesForHostFunc = func(ctx context.Context, gotHost *fleet.Host) (map[string]string, error) {
+			return map[string]string{"5": "select 5"}, nil
+		}
+		ds.RecordLabelQueryExecutionsFunc = func(ctx context.Context, gotHost *fleet.Host, results map[uint]*bool, t time.Time, deferred bool) error {
+			return nil
+		}
+		t.Cleanup(func() {
+			ds.PolicyQueriesForHostFilteredFunc = func(ctx context.Context, gotHost *fleet.Host, policyIDs []uint) (map[string]string, error) {
+				filteredForIDs = policyIDs
+				return filterPolicyQueries(inScopePolicies, policyIDs), nil
+			}
+		})
+		ds.RecordLabelQueryExecutionsFuncInvoked = false
+
+		// The same write carries a label result and a policy result. submit asserts the write itself succeeds.
+		submit(map[string][]map[string]string{
+			hostLabelQueryPrefix + "5":  {{"col1": "val1"}},
+			hostPolicyQueryPrefix + "1": {{"col1": "val1"}},
+		}, map[string]fleet.OsqueryStatus{})
+
+		// Policy results are dropped, so nothing unvalidated is persisted. RecordPolicyQueryExecutions is where
+		// hosts.policy_updated_at is advanced, so not calling it also leaves the host due to report again.
+		require.False(t, ds.RecordPolicyQueryExecutionsFuncInvoked)
+		// The write completes instead of erroring out, so the rest of the payload is still processed. (Label results
+		// are recorded before the policy stage either way; what a returned error would actually cost is the detail
+		// and additional results written after it.)
+		require.True(t, ds.RecordLabelQueryExecutionsFuncInvoked)
+	})
+
+	t.Run("setup experience host with no gating policies records nothing", func(t *testing.T) {
+		inSetupExperience = true
+		setupExperiencePolicyIDs = nil
+		t.Cleanup(func() { inSetupExperience = false })
+
+		submit(map[string][]map[string]string{
+			hostPolicyQueryPrefix + "1": {{"col1": "val1"}},
+		}, map[string]fleet.OsqueryStatus{})
+
+		require.False(t, ds.RecordPolicyQueryExecutionsFuncInvoked)
 	})
 }
 
@@ -3983,6 +4106,7 @@ func TestPolicyWebhooks(t *testing.T) {
 			"3": "select 1 where 1 = 0;",           // failing policy
 		}, nil
 	}
+	mockPolicyQueriesForHostFiltered(ds)
 	recordedResults := make(map[uint]*bool)
 	ds.RecordPolicyQueryExecutionsFunc = func(ctx context.Context, gotHost *fleet.Host, results map[uint]*bool, updated time.Time,
 		deferred bool, newlyPassingPolicyIDs []uint,
@@ -4284,6 +4408,7 @@ func TestLiveQueriesFailing(t *testing.T) {
 	ds.PolicyQueriesForHostFunc = func(ctx context.Context, host *fleet.Host) (map[string]string, error) {
 		return map[string]string{}, nil
 	}
+	mockPolicyQueriesForHostFiltered(ds)
 	ds.GetHostAwaitingConfigurationFunc = func(ctx context.Context, hostuuid string) (bool, error) {
 		return false, nil
 	}

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -3674,6 +3674,9 @@ func TestPolicyMembershipOutOfScopeCleanup(t *testing.T) {
 	ds.TeamLiteFunc = func(ctx context.Context, id uint) (*fleet.TeamLite, error) {
 		return &fleet.TeamLite{ID: 0}, nil
 	}
+	ds.PolicyQueriesForHostFunc = func(ctx context.Context, host *fleet.Host) (map[string]string, error) {
+		return map[string]string{"1": "select 1"}, nil
+	}
 	stalePolicyIDs := []uint{7, 9}
 	ds.RecordPolicyQueryExecutionsFunc = func(ctx context.Context, gotHost *fleet.Host, results map[uint]*bool, updated time.Time,
 		deferred bool, newlyPassingPolicyIDs []uint,
@@ -3739,6 +3742,93 @@ func TestPolicyMembershipOutOfScopeCleanup(t *testing.T) {
 	})
 	require.Equal(t, []uint{7}, clearedPolicyIDs)
 	require.True(t, ds.UpdateHostIssuesFailingPoliciesForSingleHostFuncInvoked)
+}
+
+func TestOutOfScopePolicyResultsAreDiscarded(t *testing.T) {
+	ds := new(mock.Store)
+	lq := live_query_mock.New(t)
+	svc, ctx := newTestService(t, ds, nil, lq)
+
+	host := &fleet.Host{ID: 42, Platform: "darwin"}
+
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return &fleet.AppConfig{}, nil
+	}
+	ds.TeamLiteFunc = func(ctx context.Context, id uint) (*fleet.TeamLite, error) {
+		return &fleet.TeamLite{ID: 0}, nil
+	}
+	ds.GetHostAwaitingConfigurationFunc = func(ctx context.Context, hostUUID string) (bool, error) {
+		return false, nil
+	}
+	inScopePolicies := map[string]string{"1": "select 1", "2": "select 2"}
+	ds.PolicyQueriesForHostFunc = func(ctx context.Context, gotHost *fleet.Host) (map[string]string, error) {
+		require.Equal(t, host.ID, gotHost.ID)
+		return inScopePolicies, nil
+	}
+	var flippingResults map[uint]*bool
+	ds.FlippingPoliciesForHostFunc = func(ctx context.Context, hostID uint, incomingResults map[uint]*bool) ([]uint, []uint, error) {
+		flippingResults = incomingResults
+		return nil, nil, nil
+	}
+	var recordedResults map[uint]*bool
+	ds.RecordPolicyQueryExecutionsFunc = func(ctx context.Context, gotHost *fleet.Host, results map[uint]*bool, updated time.Time,
+		deferred bool, newlyPassingPolicyIDs []uint,
+	) ([]uint, error) {
+		recordedResults = results
+		return nil, nil
+	}
+
+	ctx = hostctx.NewContext(ctx, host)
+
+	submit := func(results map[string][]map[string]string, statuses map[string]fleet.OsqueryStatus) {
+		flippingResults, recordedResults = nil, nil
+		ds.RecordPolicyQueryExecutionsFuncInvoked = false
+		err := svc.SubmitDistributedQueryResults(ctx, results, statuses, map[string]string{}, map[string]*fleet.Stats{})
+		require.NoError(t, err)
+	}
+
+	t.Run("forged policy IDs are dropped, in-scope results kept", func(t *testing.T) {
+		submit(map[string][]map[string]string{
+			hostPolicyQueryPrefix + "1":  {{"col1": "val1"}}, // in scope, passes
+			hostPolicyQueryPrefix + "2":  {},                 // in scope, fails
+			hostPolicyQueryPrefix + "99": {},                 // not in scope: another fleet's policy
+		}, map[string]fleet.OsqueryStatus{})
+
+		require.True(t, ds.RecordPolicyQueryExecutionsFuncInvoked)
+		require.Equal(t, map[uint]*bool{1: new(true), 2: new(false)}, recordedResults)
+		require.Equal(t, map[uint]*bool{1: new(true), 2: new(false)}, flippingResults)
+	})
+
+	t.Run("failed results for forged policy IDs are dropped too", func(t *testing.T) {
+		submit(map[string][]map[string]string{
+			hostPolicyQueryPrefix + "1":  {{"col1": "val1"}},
+			hostPolicyQueryPrefix + "99": {},
+		}, map[string]fleet.OsqueryStatus{
+			hostPolicyQueryPrefix + "99": 1, // reported as errored, which records a nil (unknown) result
+		})
+
+		require.Equal(t, map[uint]*bool{1: new(true)}, recordedResults)
+	})
+
+	t.Run("payload of only forged policy IDs records nothing", func(t *testing.T) {
+		submit(map[string][]map[string]string{
+			hostPolicyQueryPrefix + "99": {},
+		}, map[string]fleet.OsqueryStatus{})
+
+		require.False(t, ds.RecordPolicyQueryExecutionsFuncInvoked)
+	})
+
+	t.Run("policy that fell out of scope between read and write is dropped", func(t *testing.T) {
+		inScopePolicies = map[string]string{"1": "select 1"}
+		t.Cleanup(func() { inScopePolicies = map[string]string{"1": "select 1", "2": "select 2"} })
+
+		submit(map[string][]map[string]string{
+			hostPolicyQueryPrefix + "1": {{"col1": "val1"}},
+			hostPolicyQueryPrefix + "2": {{"col1": "val1"}},
+		}, map[string]fleet.OsqueryStatus{})
+
+		require.Equal(t, map[uint]*bool{1: new(true)}, recordedResults)
+	})
 }
 
 func TestPolicyQueriesDuringSetupExperience(t *testing.T) {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
A host authenticates to `/api/osquery/distributed/write` with its node key and fully controls the `fleet_policy_query_<id>` keys in the payload. Fleet persisted a result for any ID it was handed, without checking the policy was actually assigned to that host.
**An enrolled host could therefore forge policy membership across fleet, platform and label scope -- e.g. a no-team host recording itself as failing another fleet's policy, which then surfaced in that fleet's host listings and compliance views.**

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented policy results from being recorded when they come from policies outside a host’s assigned fleet, platform, or label scope.
  * Ensured out-of-scope failed results are excluded from policy-related host listings.
  * Preserved processing for valid in-scope policy results while cleaning up stale policy memberships appropriately.

* **Tests**
  * Added coverage for policy scope changes and out-of-scope result handling across supported assignment types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->