### PR TITLE
Push the release due date when unreleased bugs remain in the release candidate

### DIFF
--- a/handbook/engineering/releases.md
+++ b/handbook/engineering/releases.md
@@ -78,6 +78,24 @@ If there is partially merged feature work when the release candidate is created,
 > This exception process should be avoided whenever possible. Any feature work merged into the release candidate will likely result in a significant release delay.
 
 
+## Freeze the release candidate before release
+
+To keep release dates from slipping, the release candidate enters a **final freeze 2 business days before the expected release date**. This applies to both minor and patch releases.
+
+Before the freeze, merges into the release candidate follow the normal rules ([unreleased bug fixes only](#merge-unreleased-bug-fixes-into-the-release-candidate), with EM and QA approval, plus the [feature merge exception process](#request-release-candidate-feature-merge-exception) where applicable). The freeze adds a hard final gate on top of those rules.
+
+Once the release candidate is frozen:
+
+- Nothing else merges in, including unreleased bug fixes that would otherwise qualify for cherry-pick. This is the point where even unreleased bugs stop coming in.
+- The only exception is a `P0`, and it requires approval from both the product group EM and the QA lead before it merges.
+- Any high-priority issue found after the freeze is scheduled for the next release (the next patch, or the next minor), not squeezed into the in-flight one. This gives EMs a clear, dated line to defer non-critical work to the next release timeline.
+
+When the freeze begins, the [release ritual DRI](https://fleetdm.com/handbook/engineering#rituals) announces it in two places:
+
+1. The release candidate's existing [#help-releases thread](#discuss-release-dates) for the matching release version, stating that the RC is now frozen and no further merges will be accepted without EM and QA approval.
+2. A heads-up in #help-engineering, so engineers and EMs across product groups know the freeze is in effect.
+
+
 ## Confirm latest versions of dependencies
 
 Before kicking off release QA, confirm that we are using the latest versions of dependencies we want to keep up-to-date with each release. Currently, those dependencies are:

--- a/handbook/engineering/releases.md
+++ b/handbook/engineering/releases.md
@@ -66,7 +66,7 @@ Only merge unreleased bug fixes during the release candidate period to minimize 
 
 This process ensures your bug fix is included in `main` for future releases, as well as the release candidate branch for the pending release.
 
-> If unreleased bugs are still open 2 business days before the release due date, push the due date. Set the new date by estimating how long the remaining bug fixes will take, then adding 2 business days for smoke and load testing. Communicate the new date in the [#help-releases thread](#discuss-release-dates) for the release.
+> If unreleased bugs are still open 2 business days before the release due date, contact the release ritual DRI and request they push the target release date. Set the new date by estimating how long the remaining bug fixes will take, then adding 2 business days for smoke and load testing. Communicate the new date in the [#help-releases thread](#discuss-release-dates) for the release.
 
 If there is partially merged feature work when the release candidate is created, the previously merged code must be reverted. If there is an exceptional, business-critical need to merge feature work into the release candidate, as determined by the [release ritual DRI](https://fleetdm.com/handbook/engineering#rituals), the release candidate [feature merge exception process](#request-release-candidate-feature-merge-exception) may be followed.
 

--- a/handbook/engineering/releases.md
+++ b/handbook/engineering/releases.md
@@ -66,6 +66,8 @@ Only merge unreleased bug fixes during the release candidate period to minimize 
 
 This process ensures your bug fix is included in `main` for future releases, as well as the release candidate branch for the pending release.
 
+> If unreleased bugs are still open 2 business days before the release due date, push the due date. Set the new date by estimating how long the remaining bug fixes will take, then adding 2 business days for smoke and load testing. Communicate the new date in the [#help-releases thread](#discuss-release-dates) for the release.
+
 If there is partially merged feature work when the release candidate is created, the previously merged code must be reverted. If there is an exceptional, business-critical need to merge feature work into the release candidate, as determined by the [release ritual DRI](https://fleetdm.com/handbook/engineering#rituals), the release candidate [feature merge exception process](#request-release-candidate-feature-merge-exception) may be followed.
 
 
@@ -76,24 +78,6 @@ If there is partially merged feature work when the release candidate is created,
 3. EM, QA lead, and [release ritual DRI](https://fleetdm.com/handbook/engineering#rituals) must all approve the feature work PR before it is merged into the release candidate branch.
 
 > This exception process should be avoided whenever possible. Any feature work merged into the release candidate will likely result in a significant release delay.
-
-
-## Freeze the release candidate before release
-
-To keep release dates from slipping, the release candidate enters a **final freeze 2 business days before the expected release date**. This applies to both minor and patch releases.
-
-Before the freeze, merges into the release candidate follow the normal rules ([unreleased bug fixes only](#merge-unreleased-bug-fixes-into-the-release-candidate), with EM and QA approval, plus the [feature merge exception process](#request-release-candidate-feature-merge-exception) where applicable). The freeze adds a hard final gate on top of those rules.
-
-Once the release candidate is frozen:
-
-- Nothing else merges in, any remaining unreleased bugs that have not merged flag the release due date to shift until they are completed.
-- The only exception is a `P0`, and it requires approval from both the product group EM and the QA lead before it merges.
-- Any high-priority issue found after the freeze is scheduled for the next release (the next patch, or the next minor), not squeezed into the in-flight one. This gives EMs a clear, dated line to defer non-critical work to the next release timeline.
-
-When the freeze begins, the [release ritual DRI](https://fleetdm.com/handbook/engineering#rituals) announces it in two places:
-
-1. The release candidate's existing [#help-releases thread](#discuss-release-dates) for the matching release version, stating that the RC is now frozen and no further merges will be accepted without EM and QA approval.
-2. A heads-up in #help-engineering, so engineers and EMs across product groups know the freeze is in effect.
 
 
 ## Confirm latest versions of dependencies

--- a/handbook/engineering/releases.md
+++ b/handbook/engineering/releases.md
@@ -86,7 +86,7 @@ Before the freeze, merges into the release candidate follow the normal rules ([u
 
 Once the release candidate is frozen:
 
-- Nothing else merges in, including unreleased bug fixes that would otherwise qualify for cherry-pick. This is the point where even unreleased bugs stop coming in.
+- Nothing else merges in, any remaining unreleased bugs that have not merged flag the release due date to shift until they are completed.
 - The only exception is a `P0`, and it requires approval from both the product group EM and the QA lead before it merges.
 - Any high-priority issue found after the freeze is scheduled for the next release (the next patch, or the next minor), not squeezed into the in-flight one. This gives EMs a clear, dated line to defer non-critical work to the next release timeline.
 


### PR DESCRIPTION
**Related issue:** Resolves #45637

## What this does

Adds a note to the [Merge unreleased bug fixes into the release candidate](https://fleetdm.com/handbook/engineering/releases#merge-unreleased-bug-fixes-into-the-release-candidate) section of the engineering handbook:

If unreleased bugs are still open 2 business days before the release due date, the due date is pushed. The new date is set by estimating how long the remaining bug fixes will take, plus 2 business days for smoke and load testing, and is communicated in the release's #help-releases thread.

Earlier revisions of this PR added a standalone "RC freeze" section. Per review feedback that this was too much process, it was removed in favor of this note in the existing section.

# Checklist for submitter

- [x] Documentation change only (engineering handbook); no code, tests, migrations, or config settings affected.
