### PR TITLE
Fix doc to call out ACME endpoint as required

### DIFF
--- a/articles/what-api-endpoints-to-expose-to-the-public-internet.md
+++ b/articles/what-api-endpoints-to-expose-to-the-public-internet.md
@@ -30,6 +30,7 @@ If you would like to use the fleetctl CLI from outside of your network, the foll
 If you would like to use Fleet's macOS MDM features, the following endpoints need to be exposed:
 
 - `/mdm/apple/scep`: Allows hosts to obtain a SCEP certificate.
+- `/api/mdm/apple/acme/*`: Allows hosts to obtain an ACME certificate(required if Hardware Attestation is enabled)
 - `/mdm/apple/mdm`: Allows hosts to reach the server using the MDM protocol.
 - `/api/mdm/apple/enroll`: If you use automatic enrollment, allows hosts to get an enrollment profile.
 - `/api/*/fleet/device/*`: Provides end users access to their **My device** page.


### PR DESCRIPTION
This was apparently missed or unintentionally reverted when we added ACME support. It is required for customers to use the feature for Apple MDM enrollments