### PR TITLE
Docs: Add frontend test coverage rule + expand testing patterns

### DIFF
--- a/.claude/rules/fleet-frontend.md
+++ b/.claude/rules/fleet-frontend.md
@@ -156,22 +156,16 @@ If you edit `frontend/router/paths.ts` or `frontend/router/index.tsx`, add a new
 
 ## Test coverage
 
-Ship tests with:
-- **New reusable components, hooks, or utilities** — co-located `ComponentName.tests.tsx`.
-- **Bug fixes** — one `it("...")` named for the regression so an issue-number grep finds it. Must fail without the fix.
-- **New user-visible logic in an app widget or page** — submit flow, validation, filter/sort, empty/loading/error, tier/permission gating.
+Ship tests with new reusable components/hooks/utilities (co-located `*.tests.tsx`), bug fixes (one `it("...")` named for the regression, fails without the fix), and new user-visible logic in a widget or page (submit, validation, filter/sort, empty/loading/error, tier/permission). Skip copy-only, styling-only, and presentational refactors.
 
-Skip tests for copy-only edits, styling-only tweaks, and presentational refactors that don't change user-visible behavior.
-
-**Function coverage:** Codecov reports per-flag frontend coverage on every PR (informational, not gating — see `codecov.yml`). New reusable code (components, hooks, utilities) should not lower the frontend function-coverage delta on the PR. Legacy files without tests are grandfathered — don't retrofit unless you're already touching them.
+New reusable code shouldn't lower the frontend function-coverage delta on the PR (Codecov `frontend` flag, informational — see `codecov.yml`). Legacy files without tests are grandfathered; don't retrofit unless you're already touching them.
 
 **Do not:**
 - Snapshot-test as a substitute for behavior assertions.
 - Assert on class names, internal state, or private handlers.
-- Delete a failing test to unblock CI — update the assertion if behavior legitimately changed; otherwise the test caught a regression.
-- Test React Query internals — assert on rendered UI once data resolves.
+- Delete a failing test to unblock CI — update the assertion if behavior changed; otherwise the test just caught a regression.
 
-Mechanics (`renderWithSetup` vs `createCustomRenderer`, MSW handler setup, entity mocks, semantic queries, `userEvent`) live in [frontend/docs/patterns.md#testing](../../frontend/docs/patterns.md#testing).
+Mechanics (`renderWithSetup` vs `createCustomRenderer`, MSW handlers, entity mocks, semantic queries, `userEvent`, React Query assertion style) live in [frontend/docs/patterns.md#testing](../../frontend/docs/patterns.md#testing).
 
 ## Linting & Formatting
 - ESLint: extends airbnb + typescript-eslint + prettier

--- a/.claude/rules/fleet-frontend.md
+++ b/.claude/rules/fleet-frontend.md
@@ -154,6 +154,25 @@ Editing inside already-gated code (adding a field to a premium-only form, fixing
 ## Command palette
 If you edit `frontend/router/paths.ts` or `frontend/router/index.tsx`, add a new MDM connector / singleton config, add a new global create / automation / settings action, or add a new picker action, load the `command-palette` skill before finishing — these changes almost always need a matching entry under `frontend/components/CommandPalette/groups/`. The palette is for navigation and global actions — not per-entity (row-level) operations, bulk-select actions, or per-view UI toggles.
 
+## Test coverage
+
+Ship tests with:
+- **New reusable components, hooks, or utilities** — co-located `ComponentName.tests.tsx`.
+- **Bug fixes** — one `it("...")` named for the regression so an issue-number grep finds it. Must fail without the fix.
+- **New user-visible logic in an app widget or page** — submit flow, validation, filter/sort, empty/loading/error, tier/permission gating.
+
+Skip tests for copy-only edits, styling-only tweaks, and presentational refactors that don't change user-visible behavior.
+
+**Function coverage:** Codecov reports per-flag frontend coverage on every PR (informational, not gating — see `codecov.yml`). New reusable code (components, hooks, utilities) should not lower the frontend function-coverage delta on the PR. Legacy files without tests are grandfathered — don't retrofit unless you're already touching them.
+
+**Do not:**
+- Snapshot-test as a substitute for behavior assertions.
+- Assert on class names, internal state, or private handlers.
+- Delete a failing test to unblock CI — update the assertion if behavior legitimately changed; otherwise the test caught a regression.
+- Test React Query internals — assert on rendered UI once data resolves.
+
+Mechanics (`renderWithSetup` vs `createCustomRenderer`, MSW handler setup, entity mocks, semantic queries, `userEvent`) live in [frontend/docs/patterns.md#testing](../../frontend/docs/patterns.md#testing).
+
 ## Linting & Formatting
 - ESLint: extends airbnb + typescript-eslint + prettier
 - Prettier: default config (`.prettierrc.json`)

--- a/frontend/docs/patterns.md
+++ b/frontend/docs/patterns.md
@@ -1043,6 +1043,7 @@ Both live in [`frontend/test/test-utils.tsx`](../test/test-utils.tsx).
 - User-visible behavior for each meaningful prop branch — empty / loading / error states, disabled variants, `isPremiumTier` on/off, permission gating.
 - Forms: submit disabled on invalid, exact error copy (matches the field-error [copy rules](#data-validation)), submit handler called with the expected payload.
 - Split `it(...)` blocks by behavior — one giant "renders and works" hides which assertion failed.
+- Don't assert on React Query internals (query cache state, `isFetching`, `refetch` counts). Assert on the rendered UI once data resolves.
 
 ## Security considerations
 

--- a/frontend/docs/patterns.md
+++ b/frontend/docs/patterns.md
@@ -1019,6 +1019,31 @@ data being passed to it.
 
 At a bare minimum, critical bugs released involving the UI will have automated testing discussed at the critical bug post-mortem with a frontend engineer and an engineering manager. We make every effort to add an automated test to either the unit, integration, or E2E layer to prevent the critical bug from resurfacing.
 
+Frontend coverage is reported to Codecov (`frontend` flag) on every PR — informational, not gating. See `codecov.yml` at the repo root for flag paths and carry-forward rules. Coverage report is the source of truth for both backend and frontend across a PR.
+
+### Choosing a render helper
+
+Both live in [`frontend/test/test-utils.tsx`](../test/test-utils.tsx).
+
+- `renderWithSetup(component)` — simple prop-driven components with no context or API dependency. Returns `{ user, ...renderResult }` where `user` is a `userEvent` instance.
+- `createCustomRenderer({ context, withBackendMock })` — components that read `AppContext` / `PolicyContext` / `QueryContext`, or fetch data via React Query. Pass `withBackendMock: true` to wrap in a `QueryClientProvider` with retries disabled. Pass `context: { app: { currentUser: ... } }` to seed context.
+
+### Queries and interactions
+
+- Prefer semantic queries: `getByRole`, `getByLabelText`, `getByText`. Reach for `getByTestId` only when nothing semantic exists.
+- Drive interactions with `userEvent` (from `renderWithSetup`'s returned `user`), never `fireEvent` — `userEvent` more closely models real browser events (focus, keydown sequences, etc.).
+
+### Fixtures and API mocks
+
+- Use entity fixtures from [`frontend/__mocks__/`](../__mocks__/) — e.g. `createMockHost`, `createMockUser`, `createMockConfig`. Don't hand-roll minimal `{ id: 1, ... }` shapes inline; they drift from the real interface.
+- Default MSW handlers live in [`frontend/test/default-handlers.ts`](../test/default-handlers.ts). Custom handlers live under [`frontend/test/handlers/`](../test/handlers/) and are applied per-test with `mockServer.use(customHandler)`.
+
+### What to assert
+
+- User-visible behavior for each meaningful prop branch — empty / loading / error states, disabled variants, `isPremiumTier` on/off, permission gating.
+- Forms: submit disabled on invalid, exact error copy (matches the field-error [copy rules](#data-validation)), submit handler called with the expected payload.
+- Split `it(...)` blocks by behavior — one giant "renders and works" hides which assertion failed.
+
 ## Security considerations
 
 ### Sanitization for `dangerouslySetInnerHTML`


### PR DESCRIPTION
## Issue
No linked issue — meta-work on Claude rules + supporting frontend patterns doc.

## Description
- New **Test coverage** section in `.claude/rules/fleet-frontend.md` — policy only: when tests ship (new reusable components/hooks/utilities, bug fixes, new user-visible widget/page logic), what to skip (copy-only, styling-only, presentational refactors), and do-nots (snapshot-as-substitute, class-name/internal-state asserts, deleting failing tests to unblock CI, testing React Query internals).
- Function-coverage guidance: Codecov (`codecov.yml`) already reports the `frontend` flag on every PR informationally. New reusable code shouldn't lower the delta; legacy files without tests are grandfathered.
- Mechanics moved out of the rule into `frontend/docs/patterns.md` #testing so the rule stays scannable: choosing `renderWithSetup` vs `createCustomRenderer`, semantic queries + `userEvent` over `fireEvent`, entity fixtures from `frontend/__mocks__/`, MSW handler layout, and what-to-assert (prop-branch coverage, form submit/error copy, split-by-behavior `it` blocks).

## Screenrecording
- N/A — docs-only change.


## Testing

- [x] QA'd all new/changed functionality manually