### PR TITLE
Unfreeze Fire Alpaca (darwin)

### DIFF
--- a/ee/maintained-apps/inputs/homebrew/firealpaca.json
+++ b/ee/maintained-apps/inputs/homebrew/firealpaca.json
@@ -6,6 +6,5 @@
   "slug": "firealpaca/darwin",
   "default_categories": [
     "Productivity"
-  ],
-  "frozen": true
+  ]
 }

--- a/ee/maintained-apps/outputs/firealpaca/darwin.json
+++ b/ee/maintained-apps/outputs/firealpaca/darwin.json
@@ -1,10 +1,11 @@
 {
   "versions": [
     {
-      "version": "2.15.2",
+      "version": "2.16.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.firealpaca';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.firealpaca' AND version_compare(bundle_short_version, '2.15.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.firealpaca' AND version_compare(bundle_short_version, '2.16.0') < 0);",
+        "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.firealpaca');"
       },
       "installer_url": "https://firealpaca.com/download/mac",
       "install_script_ref": "a03f6a1f",


### PR DESCRIPTION
Automated unfreeze probe. Removes `"frozen": true` and regenerates the output manifest so
`test-fma-darwin-pr-only` can validate `firealpaca/darwin` at its current upstream version.

Frozen since: 2026-06-15 (464d741c24, "Update Fleet-maintained apps (#47645)")
Version: 2.15.2 -> 2.16.0

Draft until validation reports. Merge only if the FMA checks are green and the validate shard
actually ran for this slug.

---
_Generated by [Claude Code](https://claude.ai/code/session_014X7XNQ12G5CK1U3MP4Bpyd)_