### PR TITLE
Website: Update error handling in get-one-compliance-status-result.js

### DIFF
--- a/website/api/controllers/microsoft-proxy/get-one-compliance-status-result.js
+++ b/website/api/controllers/microsoft-proxy/get-one-compliance-status-result.js
@@ -25,7 +25,9 @@ module.exports = {
 
   exits: {
     success: { description: 'A compliance status update result was returned to the Fleet instance.', outputType: {} },
-    tenantNotFound: {description: 'No existing Microsoft compliance tenant was found for the Fleet instance that sent the request.', responseType: 'unauthorized'}
+    tenantNotFound: {description: 'No existing Microsoft compliance tenant was found for the Fleet instance that sent the request.', responseType: 'unauthorized'},
+    microsoftApiRequestFailed: {decription: 'An error occurred when sending a request to the Microsoft API.'},
+    microsoftApiError: {decription: 'The Microsoft API returned an unexpected response.'},
   },
 
 
@@ -49,8 +51,15 @@ module.exports = {
       headers: {
         'Authorization': `Bearer ${accessToken}`
       }
-    }).intercept((err)=>{
-      return new Error(`An error occurred when retrieving a compliance status result of a device for a Microsoft compliance tenant. Full error: ${require('util').inspect(err, {depth: 3})}`);
+    })
+    .intercept('requestFailed', ()=>{
+      // If a request to the microsoft API fails with a requestFailed error, return a microsoftApiRequestFailed response to the Fleet server
+      return 'microsoftApiRequestFailed';
+    })
+    .intercept((err)=>{
+      // If the request to the Microsoft API returns a non-2xx response, log a warning and return a microsoftApiError response
+      sails.log.warn(`An error occurred when retrieving a compliance status result of a device for a Microsoft compliance tenant. Full error: ${require('util').inspect(err, {depth: 3})}`);
+      return 'microsoftApiError'
     });
 
     // Log responses from Micrsoft APIs for Fleet's integration

--- a/website/api/controllers/microsoft-proxy/get-one-compliance-status-result.js
+++ b/website/api/controllers/microsoft-proxy/get-one-compliance-status-result.js
@@ -26,8 +26,8 @@ module.exports = {
   exits: {
     success: { description: 'A compliance status update result was returned to the Fleet instance.', outputType: {} },
     tenantNotFound: {description: 'No existing Microsoft compliance tenant was found for the Fleet instance that sent the request.', responseType: 'unauthorized'},
-    microsoftApiRequestFailed: {decription: 'An error occurred when sending a request to the Microsoft API.'},
-    microsoftApiError: {decription: 'The Microsoft API returned an unexpected response.'},
+    microsoftApiRequestFailed: {description: 'An error occurred when sending a request to the Microsoft API.'},
+    microsoftApiError: {description: 'The Microsoft API returned an unexpected response.'},
   },
 
 

--- a/website/api/controllers/microsoft-proxy/get-one-compliance-status-result.js
+++ b/website/api/controllers/microsoft-proxy/get-one-compliance-status-result.js
@@ -59,7 +59,7 @@ module.exports = {
     .intercept((err)=>{
       // If the request to the Microsoft API returns a non-2xx response, log a warning and return a microsoftApiError response
       sails.log.warn(`An error occurred when retrieving a compliance status result of a device for a Microsoft compliance tenant. Full error: ${require('util').inspect(err, {depth: 3})}`);
-      return 'microsoftApiError'
+      return 'microsoftApiError';
     });
 
     // Log responses from Micrsoft APIs for Fleet's integration


### PR DESCRIPTION
Related to: https://github.com/fleetdm/fleet/issues/51103 & https://github.com/fleetdm/fleet/issues/51168

Changes:
- Added two new exits to the get-one-compliance-status-result action that are used when requests to the Microsoft API fail (`microsoftApiRequestFailed`), or when the Microsoft API returns a non-2xx response (`microsoftApiError`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Microsoft API request failures.
  * Added clearer error outcomes for failed requests and non-successful API responses.
  * Non-successful responses are now logged appropriately instead of producing misleading errors.
  * Improved reliability and clarity when checking compliance status through Microsoft services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->