### PR TITLE
Website: update errors returned by update-one-devices-compliance-status

### DIFF
--- a/website/api/controllers/microsoft-proxy/get-one-compliance-status-result.js
+++ b/website/api/controllers/microsoft-proxy/get-one-compliance-status-result.js
@@ -25,7 +25,7 @@ module.exports = {
 
   exits: {
     success: { description: 'A compliance status update result was returned to the Fleet instance.', outputType: {} },
-    tenantNotFound: {description: 'No existing Microsoft compliance tenant was found for the Fleet instance that sent the request.', responseType: 'unauthorized'},
+    unauthorized: { description: 'A request contained an invalid entraTenantId/fleetServerSecret combination.', responseType: 'unauthorized'},
     microsoftApiRequestFailed: {description: 'An error occurred when sending a request to the Microsoft API.'},
     microsoftApiError: {description: 'The Microsoft API returned an unexpected response.'},
   },
@@ -35,7 +35,7 @@ module.exports = {
 
     let informationAboutThisTenant = await MicrosoftComplianceTenant.findOne({entraTenantId: entraTenantId, fleetServerSecret: fleetServerSecret});
     if(!informationAboutThisTenant) {
-      return new Error({error: 'No MicrosoftComplianceTenant record was found that matches the provided entra_tenant_id and fleet_server_secret combination.'});
+      throw 'unauthorized';
     }
 
     let tokenAndApiUrls = await sails.helpers.microsoftProxy.getAccessTokenAndApiUrls.with({

--- a/website/api/controllers/microsoft-proxy/update-one-devices-compliance-status.js
+++ b/website/api/controllers/microsoft-proxy/update-one-devices-compliance-status.js
@@ -57,7 +57,7 @@ module.exports = {
   exits: {
     success: { description: 'A devices compliance status was successfully sent to an entra tenants instance'},
     missingUserPrincipalName: { description: 'A request to update a macOS device\'s complaince status was missing a userPrincipalName value.', responseType: 'badRequest'},
-
+    unauthorized: { description: 'A request contained an invalid entraTenantId/fleetServerSecret combination.', responseType: 'unauthorized'},
   },
 
 
@@ -66,7 +66,7 @@ module.exports = {
 
     let informationAboutThisTenant = await MicrosoftComplianceTenant.findOne({entraTenantId: entraTenantId, fleetServerSecret: fleetServerSecret});
     if(!informationAboutThisTenant) {
-      return new Error('No MicrosoftComplianceTenant record was found that matches the provided entra_tenant_id and fleet_server_secret combination.');
+      throw 'unauthorized';
     }
 
     if(os.toLowerCase() === 'windows') {
@@ -133,7 +133,7 @@ module.exports = {
       });
 
       if(!informationAboutThisUser.id) {
-        return new Error(`An error occurred when getting information about a user (${userPrincipalName}). The response from the Microsoft graph API did not include an ID.`);
+        throw new Error(`An error occurred when getting information about a user (${userPrincipalName}). The response from the Microsoft graph API did not include an ID.`);
       }
 
       let lastUpdateTime = new Date().toISOString();

--- a/website/api/controllers/microsoft-proxy/update-one-devices-compliance-status.js
+++ b/website/api/controllers/microsoft-proxy/update-one-devices-compliance-status.js
@@ -98,7 +98,7 @@ module.exports = {
           isCompliant: compliant
         }
       }).intercept((err)=>{
-        return new Error({error: `An error occurred when sending a request to sync a Windows device's compliance status for a Microsoft compliance tenant. Full error: ${require('util').inspect(err, {depth: 3})}`});
+        return new Error(`An error occurred when sending a request to sync a Windows device's compliance status for a Microsoft compliance tenant. Full error: ${require('util').inspect(err, {depth: 3})}`);
       });
 
       // Return a 200 response to the Fleet server.

--- a/website/api/controllers/microsoft-proxy/update-one-devices-compliance-status.js
+++ b/website/api/controllers/microsoft-proxy/update-one-devices-compliance-status.js
@@ -56,7 +56,8 @@ module.exports = {
 
   exits: {
     success: { description: 'A devices compliance status was successfully sent to an entra tenants instance'},
-    missingUserPrincipalName: { description: 'A request to update a macOS device\'s complaince status was missing a userPrincipalName value.', responseType: 'badRequest'}
+    missingUserPrincipalName: { description: 'A request to update a macOS device\'s complaince status was missing a userPrincipalName value.', responseType: 'badRequest'},
+
   },
 
 
@@ -65,7 +66,7 @@ module.exports = {
 
     let informationAboutThisTenant = await MicrosoftComplianceTenant.findOne({entraTenantId: entraTenantId, fleetServerSecret: fleetServerSecret});
     if(!informationAboutThisTenant) {
-      return new Error({error: 'No MicrosoftComplianceTenant record was found that matches the provided entra_tenant_id and fleet_server_secret combination.'});
+      return new Error('No MicrosoftComplianceTenant record was found that matches the provided entra_tenant_id and fleet_server_secret combination.');
     }
 
     if(os.toLowerCase() === 'windows') {

--- a/website/api/controllers/microsoft-proxy/update-one-devices-compliance-status.js
+++ b/website/api/controllers/microsoft-proxy/update-one-devices-compliance-status.js
@@ -129,7 +129,7 @@ module.exports = {
           'Authorization': `Bearer ${graphAccessToken}`
         }
       }).intercept((err)=>{
-        return new Error(`An error occurred when getting a user ID from a user principal name (${userPrincipalName}) for a complaince status update. Full error: ${require('util').inspect(err, {depth: 3})}`);
+        return new Error(`An error occurred when getting a user ID from a user principal name (${userPrincipalName}) for a compliance status update. Full error: ${require('util').inspect(err, {depth: 3})}`);
       });
 
       if(!informationAboutThisUser.id) {

--- a/website/api/controllers/microsoft-proxy/update-one-devices-compliance-status.js
+++ b/website/api/controllers/microsoft-proxy/update-one-devices-compliance-status.js
@@ -128,11 +128,11 @@ module.exports = {
           'Authorization': `Bearer ${graphAccessToken}`
         }
       }).intercept((err)=>{
-        return new Error({error: `An error occurred when getting a user ID from a user principal name (${userPrincipalName}) for a complaince status update. Full error: ${require('util').inspect(err, {depth: 3})}`});
+        return new Error(`An error occurred when getting a user ID from a user principal name (${userPrincipalName}) for a complaince status update. Full error: ${require('util').inspect(err, {depth: 3})}`);
       });
 
       if(!informationAboutThisUser.id) {
-        return new Error({error: `An error occurred when getting information about a user (${userPrincipalName}). The response from the Microsoft graph API did not include an ID.`});
+        return new Error(`An error occurred when getting information about a user (${userPrincipalName}). The response from the Microsoft graph API did not include an ID.`);
       }
 
       let lastUpdateTime = new Date().toISOString();
@@ -181,7 +181,7 @@ module.exports = {
           Content: JSON.stringify(complianceUpdateContent),
         }
       }).intercept((err)=>{
-        return new Error({error: `An error occurred when sending a request to sync a device's compliance status for a Microsoft compliance tenant. Full error: ${require('util').inspect(err, {depth: 3})}`});
+        return new Error(`An error occurred when sending a request to sync a device's compliance status for a Microsoft compliance tenant. Full error: ${require('util').inspect(err, {depth: 3})}`);
       });
       // Log responses from Micrsoft APIs for Fleet's integration
       if(informationAboutThisTenant.fleetInstanceUrl === 'https://dogfood.fleetdm.com') {


### PR DESCRIPTION
Changes:
- Updated the errors returned by the update-one-devices-compliance-status to not be wrapped in a dictionary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for device compliance updates and user lookups.
  * Standardized error messages across Windows and macOS compliance workflows.
  * Invalid tenant credentials now return a clear unauthorized response when checking compliance status.
  * Missing user information and unavailable tenant records are reported more consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->