### PR TITLE
Fix enrollment URL spacing on iOS & iPadOS tab of Add hosts modal

### DIFF
--- a/changes/51195-add-hosts-ios-url-spacing
+++ b/changes/51195-add-hosts-ios-url-spacing
@@ -1,0 +1,1 @@
+* Fixed inconsistent spacing around the enrollment URL on the iOS & iPadOS tab of the **Add hosts** modal, so it now matches the macOS and Android tabs.

--- a/frontend/components/AddHostsModal/PlatformWrapper/IosIpadosPanel/_styles.scss
+++ b/frontend/components/AddHostsModal/PlatformWrapper/IosIpadosPanel/_styles.scss
@@ -1,7 +1,4 @@
 .ios-ipados-panel {
-  .input-field {
-    padding: 7px 36px 7px 12px;
-  }
   &__spinner {
     margin: $pad-xxlarge auto;
   }


### PR DESCRIPTION
**Related issue:** Resolves #51195

The **iOS & iPadOS** panel of the **Add hosts** modal overrode the shared `.input-field` padding:

```scss
.ios-ipados-panel {
  .input-field {
    padding: 7px 36px 7px 12px;
  }
  ...
}
```

The base `.input-field` is `padding: $pad-small $pad-medium` (8px 16px), which is what the macOS and Android panels use — neither overrides it. So the enrollment URL on the iOS & iPadOS tab was inset 12px on the left instead of 16px and reserved 36px of empty space on the right, making it visibly out of line with the other tabs.

**Why the override is stale:** it was added in #22645 (Oct 2024), when the copy button was absolutely positioned *on top of* the input — the 36px kept the URL text from running underneath it. #43906 ("Update input action buttons app wide", first released in v4.85.0) reworked `InputField` so that with `enableCopy` the button renders as a **sibling** of the `<input>` in a flex row (`__input-container--has-actions`). Nothing overlaps the input anymore, so the override only reserves dead space.

This PR deletes the override so the panel inherits the same padding as every other input in the modal. No change to the shared `InputField` is needed.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [ ] QA'd all new/changed functionality manually

CSS-only change, so there is nothing meaningful to cover with an automated test — Jest maps `.scss` to `identity-obj-proxy` and never evaluates the styles.

Needs a visual check before merge: open **Add hosts** with Apple and Android MDM turned on, and confirm the enrollment URL on the **iOS & iPadOS** tab now lines up with the **macOS** and **Android** tabs, and that the copy button still sits correctly outside the input box.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected spacing in enrollment URLs shown in the iOS and iPadOS **Add hosts** modal.

* **Documentation**
  * Updated the changelog to reflect the enrollment URL spacing correction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->