### PR TITLE
Add Windows CSP guides to docs further learning list

### DIFF
--- a/docs/Get started/tutorials-and-guides.md
+++ b/docs/Get started/tutorials-and-guides.md
@@ -31,6 +31,10 @@ A collection of guides to help you with Fleet.
 
 [Enforce disk encryption](https://fleetdm.com/guides/enforce-disk-encryption)
 
+[Create Windows configuration profiles (CSPs)](https://fleetdm.com/guides/creating-windows-csps)
+
+[Build and validate configuration profiles with AI](https://fleetdm.com/guides/build-configuration-profiles-with-ai)
+
 [Automatically run scripts](https://fleetdm.com/guides/policy-automation-run-script)
 
 <!--Installing software-->


### PR DESCRIPTION
**Related issue:** Resolves https://fleetdm.slack.com/archives/C01ALP02RB5/p1786589104696339?thread_ts=1786570743.851029&cid=C01ALP02RB5

Surfaces our Windows configuration profile guides higher in the docs browsing experience, per feedback in #help-marketing.