### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/chatgpt/darwin.json
+++ b/ee/maintained-apps/outputs/chatgpt/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "26.803.81509",
+      "version": "26.810.41047",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.chat';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.chat' AND version_compare(bundle_short_version, '26.803.81509') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.chat' AND version_compare(bundle_short_version, '26.810.41047') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.openai.chat');"
       },
-      "installer_url": "https://persistent.oaistatic.com/codex-app-prod/ChatGPT-darwin-arm64-26.803.81509.zip",
+      "installer_url": "https://persistent.oaistatic.com/codex-app-prod/ChatGPT-darwin-arm64-26.810.41047.zip",
       "install_script_ref": "cbce2d7d",
       "uninstall_script_ref": "678e6cf0",
-      "sha256": "34c7e629678ad5d63a639ec694a5b83b85f4e1bd7c21ee2abcfefbb041095b9c",
+      "sha256": "b8e82ade7b1f0161f1aec50c165bc97083ae5592703f8df3bff5850f57aaf287",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/chatwise/darwin.json
+++ b/ee/maintained-apps/outputs/chatwise/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "26.7.8",
+      "version": "26.8.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'app.chatwise';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.chatwise' AND version_compare(bundle_short_version, '26.7.8') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.chatwise' AND version_compare(bundle_short_version, '26.8.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'app.chatwise');"
       },
-      "installer_url": "https://releases.chatwise.app/26.7.8/ChatWise-26.7.8-arm64.dmg",
+      "installer_url": "https://releases.chatwise.app/26.8.0/ChatWise-26.8.0-arm64.dmg",
       "install_script_ref": "292ab15f",
       "uninstall_script_ref": "da509fe4",
-      "sha256": "ef3e8c0e8685c690bd692bd1d0449f40aa10bb1051af534f00a381271a447d64",
+      "sha256": "afd61ac56b6c65627bb2ee313d7dd46070d1d4dcd6bf56b2dc907415d6405284",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/claude/darwin.json
+++ b/ee/maintained-apps/outputs/claude/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.30096.0",
+      "version": "1.30096.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.30096.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.30096.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.anthropic.claudefordesktop');"
       },
-      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.30096.0/Claude-9460abac2f81d2d850c906f30c565a77e388b7d3.zip",
+      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.30096.1/Claude-194d93c2558cfbfcd2b8b7a90e02774c489d1875.zip",
       "install_script_ref": "6e4c028b",
       "uninstall_script_ref": "421baa98",
-      "sha256": "826c1b669b35a3625a98d3a2fe9c55ea08a1badee644c830ed956dfd5c9ce719",
+      "sha256": "918408fa9af5bcfddeb9f6b854bf4784fcd2fdf0c4b52931e86a41affb5c347b",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/claude/windows.json
+++ b/ee/maintained-apps/outputs/claude/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.25927.0",
+      "version": "1.30096.1",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Claude' AND publisher = 'Anthropic, PBC';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Claude' AND publisher = 'Anthropic, PBC' AND version_compare(version, '1.25927.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Claude' AND publisher = 'Anthropic, PBC' AND version_compare(version, '1.30096.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'claude.exe');"
       },
-      "installer_url": "https://downloads.claude.ai/releases/win32/x64/1.25927.0/Claude-003700efafbc2ccb4b1177a5e637b14da381799e.msix",
+      "installer_url": "https://downloads.claude.ai/releases/win32/x64/1.30096.1/Claude-194d93c2558cfbfcd2b8b7a90e02774c489d1875.msix",
       "install_script_ref": "16c020cc",
       "uninstall_script_ref": "03f72055",
-      "sha256": "faa838788186542ba74c914ad4d21f62f77e8dd1020a9d638320e9632a8164f3",
+      "sha256": "91355db2152f96ec14bd2eca036f6e456e3d1dff39e8f9a1283240785a4deec7",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/firefox@nightly/darwin.json
+++ b/ee/maintained-apps/outputs/firefox@nightly/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "155.0a1",
+      "version": "156.0a1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15526.8.13') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15626.8.13') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'org.mozilla.nightly');"
       },
-      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/08/2026-08-13-09-53-18-mozilla-central/firefox-155.0a1.en-US.mac.dmg",
+      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/08/2026-08-13-20-09-18-mozilla-central/firefox-156.0a1.en-US.mac.dmg",
       "install_script_ref": "d9c4cf87",
       "uninstall_script_ref": "0661f848",
-      "sha256": "eacabe1183cd023b21e57811640d255cf9144342bf6b7f4c031563aad4f6ad46",
+      "sha256": "7ab92173507de9a7b2e194a6f4a0ba0369b985afc2d8016d5fb113dd74c9c3ca",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/logi-options+/windows.json
+++ b/ee/maintained-apps/outputs/logi-options+/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "2.5.926888",
+      "version": "2.6.944893",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Logi Options+' AND publisher = 'Logitech';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Logi Options+' AND publisher = 'Logitech' AND version_compare(version, '2.5.926888') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Logi Options+' AND publisher = 'Logitech' AND version_compare(version, '2.6.944893') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'logi options+.exe');"
       },
       "installer_url": "https://download01.logi.com/web/ftp/pub/techsupport/optionsplus/logioptionsplus_installer.exe",
       "install_script_ref": "ca441859",
       "uninstall_script_ref": "f957f3f8",
-      "sha256": "ddb00ffa1b0294d5a352dc7fd6dd764b944cb504516119bbbccc0d51950b5935",
+      "sha256": "edd4f0b81ba321414ddd7690d795215abe5150f548d62ac7e4d1b4e72c160f34",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/microsoft-office/windows.json
+++ b/ee/maintained-apps/outputs/microsoft-office/windows.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "16.0.20131.20090",
+      "version": "16.0.20228.20124",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE (name LIKE 'Microsoft 365 Apps %' OR name LIKE 'Microsoft Office %') AND publisher = 'Microsoft Corporation';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE ((name LIKE 'Microsoft 365 Apps %' OR name LIKE 'Microsoft Office %') AND publisher = 'Microsoft Corporation') AND version_compare(version, '16.0.20131.20090') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE ((name LIKE 'Microsoft 365 Apps %' OR name LIKE 'Microsoft Office %') AND publisher = 'Microsoft Corporation') AND version_compare(version, '16.0.20228.20124') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'microsoft office.exe');"
       },
       "installer_url": "https://officecdn.microsoft.com/pr/wsus/setup.exe",

--- a/ee/maintained-apps/outputs/openvpn-connect/windows.json
+++ b/ee/maintained-apps/outputs/openvpn-connect/windows.json
@@ -7,7 +7,7 @@
         "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'OpenVPN Connect %' AND publisher = 'OpenVPN Inc.' AND version_compare(version, '3.9.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'openvpn connect.exe');"
       },
-      "installer_url": "https://packages.openvpn.net/connect/v3/openvpn-connect-3.9.0.5008_signed.msi",
+      "installer_url": "https://packages.openv.pn/connect/v3/openvpn-connect-3.9.0.5008_signed.msi",
       "install_script_ref": "22e48c46",
       "uninstall_script_ref": "9f994a0b",
       "sha256": "31347812dd37dbbb69bc47de842eb179827266e9dfb45e7f6ce10c5d71a5bad6",


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated ChatGPT, ChatWise, and Claude Desktop to their latest macOS versions.
  * Updated Claude Desktop for Windows to version 1.30096.1.
  * Updated Firefox Nightly for macOS to version 156.0a1.
  * Updated Logi Options+ for Windows to version 2.6.944893.
  * Updated Microsoft Office version detection for the latest Windows release.
* **Bug Fixes**
  * Corrected the OpenVPN Connect Windows installer download address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->