### PR TITLE
Fix autofilled inputs rendering white in dark mode

### DIFF
--- a/changes/51050-autofill-dark-mode.md
+++ b/changes/51050-autofill-dark-mode.md
@@ -1,0 +1,1 @@
+- Fixed autofilled inputs showing a white background in dark mode. The autofill style now uses theme colors instead of a hardcoded white, and covers Firefox via the standard `:autofill` selector.

--- a/frontend/styles/global/_global.scss
+++ b/frontend/styles/global/_global.scss
@@ -240,9 +240,16 @@ textarea,
 button {
   font-family: "Inter", sans-serif;
 
-  &:-webkit-autofill {
-    -webkit-box-shadow: 0 0 0 1000px #fff inset;
+  // Browsers paint their own background on autofilled fields, so cover it with
+  // an inset shadow in the themed surface color. Both selectors are needed:
+  // `:autofill` is the standard (Firefox), `:-webkit-autofill` the legacy
+  // prefix. The colors are theme tokens, so this follows light/dark mode
+  // instead of forcing white.
+  &:-webkit-autofill,
+  &:autofill {
+    box-shadow: 0 0 0 1000px $core-fleet-white inset;
     -webkit-text-fill-color: $core-fleet-black !important; //sass-lint:disable-line no-important
+    caret-color: $core-fleet-black;
   }
 }
 


### PR DESCRIPTION
**Related issue:** Resolves #51050

Autofilled inputs render with a white background regardless of theme, so in dark mode they appear as bright white boxes. The text in those fields is already themed to a light color, which leaves it close to unreadable.

## Root cause

The autofill rule in `frontend/styles/global/_global.scss` covered the browser's own background with an inset shadow hardcoded to `#fff`:

```scss
&:-webkit-autofill {
  -webkit-box-shadow: 0 0 0 1000px #fff inset;
  -webkit-text-fill-color: $core-fleet-black !important;
}
```

Two separate problems:

1. **The background was the only hardcoded part.** `-webkit-text-fill-color` already used `$core-fleet-black`, a theme token that flips to a light color in dark mode. So the text was correct all along and only the background was pinned to white — which is why the field reads as a white box with barely-visible text rather than simply being the wrong color.
2. **Firefox was never covered.** Only the `-webkit-` prefixed selector was present, so Firefox never matched this rule and applied its own white fill.

## Changes

- `#fff` → `$core-fleet-white`, the token that already pairs with `$core-fleet-black` here.
- Added the standard `:autofill` selector alongside `:-webkit-autofill`.
- Added `caret-color` so the text cursor stays visible against the themed background.
- Dropped the redundant `-webkit-box-shadow` — autoprefixer emits prefixes from the project's browserslist, and I confirmed the compiled output is identical with and without it.

No new variables. Both colors are existing tokens that already flip:

| | `--core-fleet-white` | `--core-fleet-black` |
| --- | --- | --- |
| `:root` (light) | `#ffffff` | `#192147` |
| `body.dark-mode` | `#1a1c21` | `#e2e4ea` |

## Testing

Verified manually in Firefox against a local dev server, which is the browser and scenario the issue reports:

1. Signed in and saved the credentials in Firefox's password manager.
2. Switched Fleet to dark mode and signed out, landing back on `/login` in dark mode.
3. Let Firefox autofill the Email and Password fields.

Before this change the autofilled fields render as white rectangles. With the change they take the dark surface color and sit flush with the login card, with the light text legible.

<img width="892" height="534" alt="Screenshot from 2026-08-14 16-23-35" src="https://github.com/user-attachments/assets/e308222b-4b67-43e0-b14e-d21c1e1b04d8" />



I also checked the compiled stylesheet rather than relying on the source alone. The rule builds to:

```css
input:-webkit-autofill, input:autofill,
textarea:-webkit-autofill, textarea:autofill,
button:-webkit-autofill, button:autofill {
  box-shadow: 0 0 0 1000px var(--core-fleet-white) inset;
  -webkit-text-fill-color: var(--core-fleet-black) !important;
  caret-color: var(--core-fleet-black);
}
```

with a `-webkit-`-only fallback rule emitted alongside it, so browsers that don't understand `:autofill` don't discard the whole selector list. `body.dark-mode` redefines both custom properties in the same output, so under dark mode the rule resolves to a `#1a1c21` surface with `#e2e4ea` text.

## How to verify

1. Open Fleet in Firefox with a saved login for the instance.
2. Switch to dark mode (avatar menu → My account → theme, or `Ctrl+K` → "dark").
3. Sign out to land on `/login`. The theme is stored in `localStorage`, so it persists while signed out.
4. Click into the Email field to trigger the autofill. Both fields should sit on the dark card with light text instead of appearing as white rectangles.
5. Worth a pass in Chrome in light mode to confirm no regression there, since the `:-webkit-autofill` path changed from a literal `#fff` to a token that resolves to `#ffffff`.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [ ] Added/updated automated tests

Not added — this is a stylesheet change and the frontend test suite doesn't assert on compiled CSS. Covered by the manual check and the build-output inspection above.

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved autofilled input and textarea styling with theme-aware inset shadows.
  * Added support for standard and WebKit autofill behavior.
  * Removed the hardcoded white autofill background for more consistent appearance across themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->