### PR TITLE
Move toast notifications to bottom center

### DIFF
--- a/changes/51220-toast-bottom-center.md
+++ b/changes/51220-toast-bottom-center.md
@@ -1,0 +1,1 @@
+* Moved toast notifications to the bottom center of the screen so they no longer cover buttons in the bottom-right of pages and modals.

--- a/frontend/components/ToastNotification/ToastNotification.tsx
+++ b/frontend/components/ToastNotification/ToastNotification.tsx
@@ -52,7 +52,7 @@ const ToastNotification = ({
   return (
     <Toaster
       className={classes}
-      position="bottom-right"
+      position="bottom-center"
       visibleToasts={VISIBLE_TOASTS}
     />
   );


### PR DESCRIPTION
**Related issue:** Resolves #51220

Moves toast notifications from the bottom-right to the bottom center of the screen, so they no longer cover buttons in the bottom-right of pages and modals.

Sonner handles the horizontal centering and slide-in direction from the `position` prop, so no CSS changes were needed — the card styles in `_styles.scss` are position-agnostic.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Toast notifications now appear at the bottom-center of the screen instead of the bottom-right.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Screenshoots

<img width="1492" height="929" alt="Screenshot 2026-08-14 at 13 37 38" src="https://github.com/user-attachments/assets/b3d212a8-a091-49e9-934b-d5e0b989c423" />

<img width="1492" height="929" alt="Screenshot 2026-08-14 at 13 37 54" src="https://github.com/user-attachments/assets/f8130cfb-5c0c-4562-9e68-f0603aa36c17" />

<img width="1492" height="929" alt="Screenshot 2026-08-14 at 13 38 30" src="https://github.com/user-attachments/assets/ba7ec71b-66ca-4d6c-80e1-13caa7a7eba5" />

<img width="1492" height="929" alt="Screenshot 2026-08-14 at 13 38 46" src="https://github.com/user-attachments/assets/d280a916-2525-407e-be94-0377e698496a" />

<img width="1492" height="929" alt="Screenshot 2026-08-14 at 13 39 40" src="https://github.com/user-attachments/assets/7bee91e7-754b-4f50-9eb0-944f23204835" />
