### PR TITLE
Show the CA-specific invalid URL error instead of a generic one

### DIFF
--- a/changes/46966-invalid-ca-url-error
+++ b/changes/46966-invalid-ca-url-error
@@ -1,0 +1,1 @@
+- Fixed the add/edit certificate authority modals showing a generic "Please try again." error instead of the invalid URL error returned by the server. The error now names the certificate authority, for example "Invalid Hydrant URL. Please correct and try again."

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/helpers.tests.ts
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/helpers.tests.ts
@@ -39,6 +39,35 @@ describe("AddCertAuthorityModal helpers", () => {
       expect(getDisplayErrMessage(apiError(reason))).toBe(expected);
     });
 
+    it.each([
+      [
+        "Couldn't add certificate authority. Invalid Hydrant URL. Please correct and try again.",
+        "Invalid Hydrant URL. Please correct and try again.",
+      ],
+      [
+        "Couldn't add certificate authority. Invalid DigiCert URL. Please correct and try again.",
+        "Invalid DigiCert URL. Please correct and try again.",
+      ],
+      [
+        "Couldn't add certificate authority. Invalid EST URL. Please correct and try again.",
+        "Invalid EST URL. Please correct and try again.",
+      ],
+      [
+        "Couldn't add certificate authority. Invalid NDES SCEP URL. Please correct and try again.",
+        "Invalid NDES SCEP URL. Please correct and try again.",
+      ],
+      [
+        "Couldn't add certificate authority. Invalid Smallstep SCEP URL. Please correct and try again.",
+        "Invalid Smallstep SCEP URL. Please correct and try again.",
+      ],
+      [
+        "Couldn't edit certificate authority. Invalid Hydrant URL. Please correct and try again.",
+        "Invalid Hydrant URL. Please correct and try again.",
+      ],
+    ])("names the CA type in the URL error for: %s", (reason, expected) => {
+      expect(getDisplayErrMessage(apiError(reason))).toBe(expected);
+    });
+
     it("returns the SCEP URL error", () => {
       expect(
         getDisplayErrMessage(
@@ -47,6 +76,16 @@ describe("AddCertAuthorityModal helpers", () => {
           )
         )
       ).toBe("Invalid SCEP URL. Please correct and try again.");
+    });
+
+    it("returns the generic URL error when the CA type isn't named", () => {
+      expect(
+        getDisplayErrMessage(
+          apiError(
+            'Couldn\'t add certificate authority. Post "https://example.com": dial tcp: lookup example.com: no such host'
+          )
+        )
+      ).toBe("Invalid URL. Please correct and try again.");
     });
 
     it("returns the password cache error", () => {
@@ -61,14 +100,12 @@ describe("AddCertAuthorityModal helpers", () => {
       );
     });
 
-    it("returns the challenge URL error for Smallstep", () => {
-      expect(
-        getDisplayErrMessage(
-          apiError(
-            "Couldn't edit certificate authority. Invalid challenge URL or credentials. Please correct and try again."
-          )
-        )
-      ).toBe(
+    // These name a URL too, so they'd be captured by the CA-type URL match if it ran first.
+    it.each([
+      "Couldn't edit certificate authority. Invalid challenge URL or credentials. Please correct and try again.",
+      "Couldn't edit certificate authority. Invalid Challenge URL. Please correct and try again.",
+    ])("returns the challenge URL error for Smallstep: %s", (reason) => {
+      expect(getDisplayErrMessage(apiError(reason))).toBe(
         "Invalid challenge URL or credentials. Please correct and try again."
       );
     });

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/helpers.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/helpers.tsx
@@ -199,8 +199,6 @@ const PRIVATE_KEY_NOT_CONFIGURED_ERROR = (
     />
   </>
 );
-const INVALID_SCEP_URL_ERROR =
-  "Invalid SCEP URL. Please correct and try again.";
 const INVALID_ADMIN_URL_OR_CREDENTIALS_ERROR =
   "Invalid admin URL or credentials. Please correct and try again.";
 const INVALID_ADMIN_URL_ERROR =
@@ -219,26 +217,27 @@ const INVALID_CHALLENGE_URL_OR_CREDENTIALS_ERROR =
   "Invalid challenge URL or credentials. Please correct and try again.";
 
 /**
+ * Matches the server's URL errors, which name the CA type inside the message (e.g. "Invalid
+ * Hydrant URL.").
+ */
+const INVALID_URL_PATTERN = /Invalid [\w ]*URL\./;
+
+/**
  * Gets the error message we want to display from the api error message.
  * This is used in both add and edit certificate authority flows.
  */
 export const getDisplayErrMessage = (err: unknown): string | JSX.Element => {
   let message: string | JSX.Element = DEFAULT_ERROR;
-  const reason = getErrorReason(err).toLowerCase();
+  const rawReason = getErrorReason(err);
+  const reason = rawReason.toLowerCase();
+  const invalidUrlMatch = rawReason.match(INVALID_URL_PATTERN);
 
   if (reason.includes("invalid api token")) {
     message = INVALID_API_TOKEN_ERROR;
   } else if (reason.includes("invalid profile guid")) {
     message = INVALID_PROFILE_GUID_ERROR;
-  } else if (
-    reason.includes("invalid url") ||
-    reason.includes("no such host")
-  ) {
-    message = INVALID_URL_ERROR;
   } else if (reason.includes("private key")) {
     message = PRIVATE_KEY_NOT_CONFIGURED_ERROR;
-  } else if (reason.includes("invalid scep url")) {
-    message = INVALID_SCEP_URL_ERROR;
   } else if (reason.includes("admin url or credentials")) {
     // the server names the CA type in this message, e.g. "Invalid NDES SCEP admin URL or
     // credentials", so match on the part that doesn't vary
@@ -258,6 +257,13 @@ export const getDisplayErrMessage = (err: unknown): string | JSX.Element => {
     message = INVALID_CHALLENGE_URL_OR_CREDENTIALS_ERROR;
   } else if (reason.includes("invalid challenge")) {
     message = INVALID_CHALLENGE_ERROR;
+  } else if (invalidUrlMatch) {
+    message = `${invalidUrlMatch[0]} Please correct and try again.`;
+  } else if (
+    reason.includes("invalid url") ||
+    reason.includes("no such host")
+  ) {
+    message = INVALID_URL_ERROR;
   } else {
     message = DEFAULT_ERROR;
   }


### PR DESCRIPTION
Resolves #46966

For CA URL errors, match the server's URL errors with a pattern and echo the matched sentence back, naming the CA that's misconfigured.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Certificate authority add and edit forms now display specific invalid URL errors, including the certificate authority name, instead of a generic retry message.
  * Improved URL error handling for Hydrant, DigiCert, Custom EST, NDES SCEP, and Smallstep SCEP integrations.
  * Added clearer fallback messaging for unnamed or unrecognized URL errors, including expanded challenge URL validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->