### PR TITLE
always show managed account rotation banners

### DIFF
--- a/changes/50585-always-show-managed-account-rotation-banner
+++ b/changes/50585-always-show-managed-account-rotation-banner
@@ -1,0 +1,1 @@
+- Fixed an issue where Observer, Observer+ and Technician could not see the managed account rotation banner.

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/ManagedAccountModal/ManagedAccountModal.tests.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/ManagedAccountModal/ManagedAccountModal.tests.tsx
@@ -56,7 +56,7 @@ describe("ManagedAccountModal", () => {
     render(
       <ManagedAccountModal
         hostId={7}
-        canRotatePassword
+        canRotatePassword={false}
         onCancel={jest.fn()}
         onRotate={jest.fn()}
       />
@@ -156,7 +156,7 @@ describe("ManagedAccountModal", () => {
     render(
       <ManagedAccountModal
         hostId={7}
-        canRotatePassword
+        canRotatePassword={false}
         onCancel={jest.fn()}
         onRotate={jest.fn()}
       />

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/ManagedAccountModal/ManagedAccountModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/ManagedAccountModal/ManagedAccountModal.tsx
@@ -98,19 +98,18 @@ const ManagedAccountModal = ({
               value={managedAccountData?.password ?? ""}
               name="Password"
             />
-            {canRotatePassword &&
-              (showPendingRotationBanner ? (
+            {showPendingRotationBanner ? (
+              <InfoBanner color="yellow">
+                Password will rotate once the host acknowledges the request.
+              </InfoBanner>
+            ) : (
+              autoRotateAt && (
                 <InfoBanner color="yellow">
-                  Password will rotate once the host acknowledges the request.
+                  Password rotates automatically after{" "}
+                  {monthDayTimeFormat(autoRotateAt)}.
                 </InfoBanner>
-              ) : (
-                autoRotateAt && (
-                  <InfoBanner color="yellow">
-                    Password rotates automatically after{" "}
-                    {monthDayTimeFormat(autoRotateAt)}.
-                  </InfoBanner>
-                )
-              ))}
+              )
+            )}
             <div className="modal-cta-wrap">
               <Button onClick={onCancel}>Close</Button>
               {canRotatePassword && (


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #50585

<img width="697" height="419" alt="image" src="https://github.com/user-attachments/assets/c6b48f01-f833-4eaf-a485-27fe2040967a" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Observer, Observer+, and Technician roles can now view managed account rotation banners.
  - Rotation status information is displayed even when users cannot manually rotate passwords.
  - The rotate action remains restricted to users with the appropriate permission.

- **Bug Fixes**
  - Improved visibility of pending and automatic rotation notices while keeping them mutually exclusive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->