### PR TITLE
delete host_dep_assignment if apple business is not configured when deleting a host

### DIFF
--- a/changes/50773-delete-host-dep-if-ab-not-configured-on-host-deletion
+++ b/changes/50773-delete-host-dep-if-ab-not-configured-on-host-deletion
@@ -1,0 +1,1 @@
+- Fixed an issue where deleting an ADE device after turning off Apple Business, could leave orphaned rows.

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -2423,7 +2423,7 @@ func (ds *Datastore) GetHostDEPAssignment(ctx context.Context, hostID uint) (*fl
 	var res fleet.HostDEPAssignment
 	err := sqlx.GetContext(ctx, ds.reader(ctx), &res, `
 		SELECT host_id, added_at, deleted_at, abm_token_id, mdm_migration_deadline, mdm_migration_completed,
-		       profile_uuid, assign_profile_response, response_updated_at
+		       profile_uuid, assign_profile_response, response_updated_at, hardware_serial
 		FROM host_dep_assignments hdep WHERE hdep.host_id = ?`, hostID)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -2622,6 +2622,14 @@ func (ds *Datastore) DeleteHostDEPAssignments(ctx context.Context, abmTokenID ui
 
 		return deleteHosts(ctx, tx, pendingHostIDs)
 	})
+}
+
+func (ds *Datastore) MarkHostDEPAssignmentDeleted(ctx context.Context, hostID uint) error {
+	_, err := ds.writer(ctx).ExecContext(ctx, `
+		UPDATE host_dep_assignments
+		SET deleted_at = NOW(), mdm_migration_deadline = NULL, mdm_migration_completed = NULL
+		WHERE host_id = ? AND deleted_at IS NULL`, hostID)
+	return ctxerr.Wrap(ctx, err, "mark host dep assignment deleted")
 }
 
 func (ds *Datastore) RestoreMDMApplePendingDEPHost(ctx context.Context, host *fleet.Host) error {

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2110,6 +2110,10 @@ type Datastore interface {
 	// host_dep_assignments for host with matching serials only if the entry is associated to the provided ABM token.
 	DeleteHostDEPAssignments(ctx context.Context, abmTokenID uint, serials []string) error
 
+	// MarkHostDEPAssignmentDeleted marks as deleted the host_dep_assignments entry for the provided host ID.
+	// Only use when we no longer have a host row, if we do use `DeleteHostDEPAssignments` instead.
+	MarkHostDEPAssignmentDeleted(ctx context.Context, hostID uint) error
+
 	// UpdateHostDEPAssignProfileResponses receives a profile UUID and threes lists of serials, each representing
 	// one of the three possible responses, and updates the host_dep_assignments table with the corresponding responses. For each response, it also sets the ABM token id in the table to the provided value.
 	UpdateHostDEPAssignProfileResponses(ctx context.Context, resp *godep.ProfileResponse, abmTokenID uint) error

--- a/server/mdm/lifecycle/lifecycle.go
+++ b/server/mdm/lifecycle/lifecycle.go
@@ -357,9 +357,9 @@ func (t *HostLifecycle) deleteApple(ctx context.Context, opts HostOptions) error
 			return nil
 		}
 
-		// if ABM is not enabled and configured, delete the host_dep_assignment row to avoid orphaned rows.
+		// If ABM is not enabled and configured, mark the host_dep_assignments row as deleted to avoid orphaned rows.
 		if err = t.ds.MarkHostDEPAssignmentDeleted(ctx, opts.Host.ID); err != nil {
-			return ctxerr.Wrap(ctx, err, "delete host dep assignment")
+			return ctxerr.Wrap(ctx, err, "mark host dep assignment deleted")
 		}
 
 		return nil

--- a/server/mdm/lifecycle/lifecycle.go
+++ b/server/mdm/lifecycle/lifecycle.go
@@ -344,14 +344,25 @@ func (t *HostLifecycle) deleteApple(ctx context.Context, opts HostOptions) error
 	ac, err := t.ds.AppConfig(ctx)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "get app config")
-	} else if !ac.MDM.AppleBMEnabledAndConfigured {
-		// if ABM is not enabled and configured, nothing more to do
-		return nil
 	}
 
 	dep, err := t.ds.GetHostDEPAssignment(ctx, opts.Host.ID)
 	if err != nil && !fleet.IsNotFound(err) {
 		return ctxerr.Wrap(ctx, err, "get host dep assignment")
+	}
+
+	if !ac.MDM.AppleBMEnabledAndConfigured {
+		if fleet.IsNotFound(err) || dep == nil || dep.DeletedAt != nil {
+			// Nothing to delete
+			return nil
+		}
+
+		// if ABM is not enabled and configured, delete the host_dep_assignment row to avoid orphaned rows.
+		if err = t.ds.MarkHostDEPAssignmentDeleted(ctx, opts.Host.ID); err != nil {
+			return ctxerr.Wrap(ctx, err, "delete host dep assignment")
+		}
+
+		return nil
 	}
 
 	if dep != nil && dep.DeletedAt == nil {

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1274,6 +1274,8 @@ type DeleteHostDEPAssignmentsFromAnotherABMFunc func(ctx context.Context, abmTok
 
 type DeleteHostDEPAssignmentsFunc func(ctx context.Context, abmTokenID uint, serials []string) error
 
+type MarkHostDEPAssignmentDeletedFunc func(ctx context.Context, hostID uint) error
+
 type UpdateHostDEPAssignProfileResponsesFunc func(ctx context.Context, resp *godep.ProfileResponse, abmTokenID uint) error
 
 type UpdateHostDEPAssignProfileResponsesSameABMFunc func(ctx context.Context, resp *godep.ProfileResponse) error
@@ -4203,6 +4205,9 @@ type DataStore struct {
 
 	DeleteHostDEPAssignmentsFunc        DeleteHostDEPAssignmentsFunc
 	DeleteHostDEPAssignmentsFuncInvoked bool
+
+	MarkHostDEPAssignmentDeletedFunc        MarkHostDEPAssignmentDeletedFunc
+	MarkHostDEPAssignmentDeletedFuncInvoked bool
 
 	UpdateHostDEPAssignProfileResponsesFunc        UpdateHostDEPAssignProfileResponsesFunc
 	UpdateHostDEPAssignProfileResponsesFuncInvoked bool
@@ -10161,6 +10166,13 @@ func (s *DataStore) DeleteHostDEPAssignments(ctx context.Context, abmTokenID uin
 	s.DeleteHostDEPAssignmentsFuncInvoked = true
 	s.mu.Unlock()
 	return s.DeleteHostDEPAssignmentsFunc(ctx, abmTokenID, serials)
+}
+
+func (s *DataStore) MarkHostDEPAssignmentDeleted(ctx context.Context, hostID uint) error {
+	s.mu.Lock()
+	s.MarkHostDEPAssignmentDeletedFuncInvoked = true
+	s.mu.Unlock()
+	return s.MarkHostDEPAssignmentDeletedFunc(ctx, hostID)
 }
 
 func (s *DataStore) UpdateHostDEPAssignProfileResponses(ctx context.Context, resp *godep.ProfileResponse, abmTokenID uint) error {

--- a/server/service/integration_mdm_dep_test.go
+++ b/server/service/integration_mdm_dep_test.go
@@ -2932,6 +2932,52 @@ func (s *integrationMDMTestSuite) TestDeleteMultipleHostsPendingDEP() {
 	}
 }
 
+// Deleting a host while ABM is turned off must still mark its host_dep_assignments
+// row as deleted, otherwise the row is left orphaned pointing at a host that no
+// longer exists.
+func (s *integrationMDMTestSuite) TestDeleteHostWithABMDisabledDeletesDEPAssignment() {
+	t := s.T()
+	ctx := t.Context()
+
+	s.enableABM(t.Name())
+	abmTok, err := s.ds.GetABMTokenByOrgName(ctx, t.Name())
+	require.NoError(t, err)
+
+	serial := mdmtest.RandSerialNumber()
+	host, err := s.ds.NewHost(ctx, &fleet.Host{
+		Hostname:        "dep-host-abm-off",
+		HardwareSerial:  serial,
+		UUID:            uuid.NewString(),
+		Platform:        "darwin",
+		OsqueryHostID:   new(uuid.NewString()),
+		NodeKey:         new(uuid.NewString()),
+		LastEnrolledAt:  time.Now(),
+		DetailUpdatedAt: time.Now(),
+	})
+	require.NoError(t, err)
+	require.NoError(t, s.ds.UpsertMDMAppleHostDEPAssignments(ctx, []fleet.Host{*host}, abmTok.ID, nil))
+
+	dep, err := s.ds.GetHostDEPAssignment(ctx, host.ID)
+	require.NoError(t, err)
+	require.Nil(t, dep.DeletedAt)
+
+	// turn ABM off
+	appCfg, err := s.ds.AppConfig(ctx)
+	require.NoError(t, err)
+	origCfg := appCfg.Copy()
+	t.Cleanup(func() {
+		require.NoError(t, s.ds.SaveAppConfig(context.Background(), origCfg))
+	})
+	appCfg.MDM.AppleBMEnabledAndConfigured = false
+	require.NoError(t, s.ds.SaveAppConfig(ctx, appCfg))
+
+	s.DoJSON("DELETE", fmt.Sprintf("/api/latest/fleet/hosts/%d", host.ID), nil, http.StatusOK, &deleteHostResponse{})
+
+	dep, err = s.ds.GetHostDEPAssignment(ctx, host.ID)
+	require.NoError(t, err)
+	require.NotNil(t, dep.DeletedAt)
+}
+
 // This test case covers the bug https://github.com/fleetdm/fleet/issues/26879
 //
 // It simulates an automation transferring a host to a team after MDM enrollment,


### PR DESCRIPTION


<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #50773 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed host deletion when Apple Business Manager is disabled so related device enrollment assignments are properly marked as deleted.
  * Prevented orphaned enrollment assignment records from remaining after host removal.

* **Tests**
  * Added integration coverage validating assignment cleanup during host deletion with Apple Business Manager disabled.

* **Documentation**
  * Added a changelog entry describing the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->