### PR TITLE
Fleet UI: Fix clipped Vulnerabilities column and empty version state in software info modal

### DIFF
--- a/frontend/pages/hosts/details/components/InventoryVersions/InventoryVersions.tsx
+++ b/frontend/pages/hosts/details/components/InventoryVersions/InventoryVersions.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
 import { dateAgo } from "utilities/date_format";
 
 import {
@@ -53,7 +54,11 @@ const InventoryVersion = ({
       borderRadiusSize="medium"
     >
       <div className={`${baseClass}__row`}>
-        <DataSet title="Version" value={version.version} textOnly />
+        <DataSet
+          title="Version"
+          value={version.version || DEFAULT_EMPTY_CELL_VALUE}
+          textOnly
+        />
         <DataSet
           title="Type"
           value={formatSoftwareType({ source, extension_for })}

--- a/frontend/pages/hosts/details/components/InventoryVersions/_styles.scss
+++ b/frontend/pages/hosts/details/components/InventoryVersions/_styles.scss
@@ -25,9 +25,12 @@
   }
 
   // Fill the row so TruncatedTextList has a bounded width to measure against.
+  // min-width sets the narrowest width where a "CVE-YYYY-NNNNN, +N more" row
+  // still fits — below that, flex-wrap on the parent bumps Vulnerabilities to
+  // its own row so it doesn't get squeezed by neighboring DataSets.
   &__vulnerabilities {
     flex: 1;
-    min-width: 0;
+    min-width: 200px;
 
     // dd is display:flex, so TruncatedTextList's outer div would size to its
     // content by default and truncate too early. Stretch it to fill.


### PR DESCRIPTION
## Issue
Closes #50818

## Description
- Bug fix (root cause): In the software info modal, `.inventory-versions__vulnerabilities` had `min-width: 0`, so when Bundle identifier was present (macOS apps) the 5-column inline row squeezed Vulnerabilities to ~50px. `TruncatedTextList` couldn't fit even its `+N more` pill, and the row overflowed horizontally — the modal's `overflow-y: auto` forces `overflow-x: auto`, so the CVE column clipped visibly. Setting `min-width: 200px` lets the parent's `flex-wrap: wrap` bump Vulnerabilities to its own full-width row only when it can't fit alongside the metadata columns; otherwise it stays inline.
- Bug fix (root cause): Empty/null `version.version` rendered as a blank cell. Fall back to `DEFAULT_EMPTY_CELL_VALUE` (`---`) — same convention as the other empty-state cells in host details.
- Same modal is used by both `DeviceUserPage` (My Device) and `HostDetailsPage`, so the fix covers both entry points.

## Screenrecording
- Both bugs demoed in the software info modal on the My Device page

<img width="1175" height="694" alt="Screenshot 2026-08-14 at 9 41 50 AM" src="https://github.com/user-attachments/assets/8f24e29a-3fd7-4c87-9529-a9976b8b9492" />
<img width="1191" height="679" alt="Screenshot 2026-08-14 at 9 35 26 AM" src="https://github.com/user-attachments/assets/cada3d36-0d11-4ffc-9a7e-0ab19819797e" />


## Testing

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Displays a consistent placeholder when installed software version information is unavailable.
  * Improves vulnerability section layout by maintaining a minimum width and better supporting text wrapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->