### PR TITLE
Fix misleading local installer store log

### DIFF
--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -579,7 +579,7 @@ func runServeCmd(cmd *cobra.Command, configManager configpkg.Manager, debug, dev
 			} else {
 				softwareInstallStore = store
 				logger.InfoContext(ctx,
-					"using local filesystem software installer store, this is not suitable for production use", "directory",
+					"using local filesystem software installer store, this is not suitable for multi-container deployments", "directory",
 					installerDir)
 			}
 


### PR DESCRIPTION
**Related issue:** Resolves #39896

Updates the local filesystem software installer store log per [Marko's comment](https://github.com/fleetdm/fleet/issues/39896#issuecomment-5179609603). Local storage is supported on Render, as documented in #50489, so the log now warns about multi-container deployments instead of production.

# Checklist for submitter

## Testing

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the installer startup message to clarify that the local filesystem store is not suitable for multi-container deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->