### PR TITLE
Require a screenshot or recording on frontend PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,6 +24,10 @@ For unreleased bug fixes in a release candidate, one of:
 - [ ] Confirmed that the fix is not expected to adversely impact load test results
 - [ ] Alerted the release DRI if additional load testing is needed
 
+## Frontend
+
+- [ ] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.
+
 ## Database migrations
 
 - [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.

--- a/.github/workflows/check-pr-template.yml
+++ b/.github/workflows/check-pr-template.yml
@@ -7,6 +7,7 @@ on:
       - "**/*.go"
       - "go.mod"
       - "go.sum"
+      - ".github/workflows/check-pr-template.yml"
 permissions:
   pull-requests: read
 jobs:
@@ -41,3 +42,47 @@ jobs:
             exit 1
           fi
           echo "PR template present."
+
+  # Separate job so a missing screenshot reads as its own signal rather than
+  # "you didn't paste the template."
+  check-frontend-screenshot:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Verify PR body shows user-visible frontend changes
+        env:
+          BODY: ${{ github.event.pull_request.body }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Only nudge when the PR touches files that change what a user sees.
+          # Tests, stories, and mocks don't render, so they don't count.
+          files=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files" --jq '.[].filename')
+          visual=$(grep -E '^frontend/.*\.(tsx|jsx|scss|css)$' <<< "$files" \
+            | grep -vE '\.(tests|stories)\.(tsx|jsx)$' \
+            | grep -vE '^frontend/(__mocks__|services/mock_service)/' || true)
+          if [ -z "$visual" ]; then
+            echo "No user-visible frontend files changed; skipping screenshot check."
+            exit 0
+          fi
+
+          echo "User-visible frontend files changed:"
+          sed 's/^/  /' <<< "$visual"
+
+          # Accept a ticked checkbox, an actual attachment, or an explicit N/A.
+          if grep -qiE '^[[:space:]]*-[[:space:]]*\[[[:space:]]*x[[:space:]]*\].*(screenshot|screen recording)' <<< "$BODY"; then
+            echo "Screenshot checklist item is checked."
+            exit 0
+          fi
+          if grep -qE '(user-attachments/|!\[[^]]*\]\(|<img |<video )' <<< "$BODY"; then
+            echo "PR body contains an image or video."
+            exit 0
+          fi
+          if grep -qiE '(screenshot|screen recording).*\bn/a\b' <<< "$BODY"; then
+            echo "Screenshot checklist item is marked N/A."
+            exit 0
+          fi
+
+          echo "::error::This PR changes user-visible frontend files. Add a screenshot or screen recording and check the Frontend box in the description. If the change isn't user-visible, say so instead, for example: 'Screenshot: N/A, refactor only'."
+          exit 1


### PR DESCRIPTION
**Related issue:** NA. Action item from the 4.91 retrospective (2026-08-12).

Adds a `Frontend` section to the pull request template with a single item: attach a screenshot or screen recording of each user-visible change, and show the before and after when changing existing UI.

The 4.91 retro noted that a lot of frontend PRs arrive without a screenshot or recording, which slows review down. The template had no frontend section at all, so this expectation wasn't written down anywhere a submitter would see it.

The section sits after `Testing` and before `Database migrations`, so the evidence-of-manual-QA items stay next to each other.

Note for reviewers: `check-pr-template` greps the PR body for the line `QA'd all new/changed functionality manually`. That line is unchanged, so this doesn't affect the check. That workflow also only runs on `frontend/**`, `**/*.go`, `go.mod`, and `go.sum`, so it won't run on this PR.

# Checklist for submitter

## Testing

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved pull request validation for changes affecting the user interface.
  * Added automated checks to confirm that relevant visual updates include screenshots, videos, or an explicit indication that visual evidence is not applicable.
  * Non-visual changes and test-only updates are excluded from screenshot requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->