### PR TITLE
Add onTargetEarnings to Infra eng

### DIFF
--- a/handbook/company/open-positions.yml
+++ b/handbook/company/open-positions.yml
@@ -179,6 +179,7 @@
   hiringManagerName: Zay Hanlon
   hiringManagerLinkedInUrl: https://www.linkedin.com/in/zayhanlon/
   hiringManagerGithubUsername: zayhanlon
+  onTargetEarnings: $150,000 - $200,000 based on experience
   responsibilities: |
     - 🧑‍🔬 Manage the architecture, development, and implementation of Fleet's internal and customer infrastructure.
     - 💭 Manage and optimize scalable distributed systems in the cloud, including tri-weekly cloud upgrades. 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Information**
  * Added on-target earnings information of $150,000–$200,000, based on experience, to the Infrastructure Engineer job listing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->