### PR TITLE
Website: Send android management API metrics to datadog

### DIFF
--- a/website/api/hooks/custom/index.js
+++ b/website/api/hooks/custom/index.js
@@ -171,7 +171,7 @@ will be disabled and/or hidden in the UI.
               },
             }).exec((err)=>{
               if (err) {
-                sails.log.warn(`Android proxy: failed to send AMAPI request-count metric to Datadog. Full error: ${require('util').inspect(err)}`);
+                sails.log.warn(`Background task failed: failed to send AMAPI request-count metric to Datadog. Full error: ${require('util').inspect(err)}`);
               }
             });//_∏_
           }//ﬁ

--- a/website/api/hooks/custom/index.js
+++ b/website/api/hooks/custom/index.js
@@ -150,6 +150,32 @@ will be disabled and/or hidden in the UI.
           if (requestCountInLastMinute === 0) {
             return;// Stay quiet on idle minutes so the metric lines are easy to grep.
           }
+
+          // Send the number of requests to Datadog.
+          if (sails.config.environment === 'production' && sails.config.custom.datadogApiKey) {
+            let timestampInSeconds = Math.floor(Date.now() / 1000);
+            let thisDyno = process.env.DYNO;
+            sails.helpers.http.post.with({
+              url: 'https://api.us5.datadoghq.com/api/v2/series',
+              data: {
+                series: [{
+                  metric: 'android_proxy.amapi_request_count',
+                  type: 1,// count
+                  points: [{ timestamp: timestampInSeconds, value: requestCountInLastMinute }],
+                  tags: [`dyno:${thisDyno}`],
+                }],
+              },
+              headers: {
+                'DD-API-KEY': sails.config.custom.datadogApiKey,
+                'Content-Type': 'application/json',
+              },
+            }).exec((err)=>{
+              if (err) {
+                sails.log.warn(`Android proxy: failed to send AMAPI request-count metric to Datadog. Full error: ${require('util').inspect(err)}`);
+              }
+            });//_∏_
+          }//ﬁ
+
           sails.log.info(`Android proxy: ${requestCountInLastMinute} Android Management API request(s) in the last minute.`);
         };
         // Align the first tick to the top of the next minute so every web dyno logs on the same

--- a/website/api/hooks/custom/index.js
+++ b/website/api/hooks/custom/index.js
@@ -161,6 +161,7 @@ will be disabled and/or hidden in the UI.
                 series: [{
                   metric: 'android_proxy.amapi_request_count',
                   type: 1,// count
+                  interval: 60,
                   points: [{ timestamp: timestampInSeconds, value: requestCountInLastMinute }],
                   tags: [`dyno:${thisDyno}`],
                 }],


### PR DESCRIPTION
Changes:
- Updated the website's custom hook to send the number of Android Enterprise requests in the past minute to Datadog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added production monitoring for Android proxy API request counts through Datadog.
  * Metrics include request totals, timestamps, and deployment context when monitoring is configured.
  * Monitoring data is sent automatically at regular intervals to support operational visibility.

* **Bug Fixes**
  * Monitoring delivery failures are logged as warnings without interrupting normal request-count logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->