### PR TITLE
Fleet UI: Device notification toast page for notify-before-patching

### DIFF
--- a/frontend/interfaces/device_notification.ts
+++ b/frontend/interfaces/device_notification.ts
@@ -1,12 +1,20 @@
-// FE assumptions on the server contract, pending BE confirmation on #50916:
-//   1. POST /device/:token/notifications/:uuid/actions returns the updated
-//      INotificationView in the response body — so `update_now` returns the
-//      "Installing…" state without a follow-up GET.
-//   2. Items carry their own `software_title_id` and `icon_url` — no second
+// TODO(#50916): Remove this block once the BE endpoints in #50910 land and
+// confirm the remaining assumptions.
+//
+// FE assumptions on the server contract (see #50916 issuecomment-5295478695):
+//   1. Items carry their own `software_title_id` and `icon_url` — no second
 //      software lookup on the client.
-//   3. Both `org_logo_url_light_mode` and `org_logo_url_dark_mode` are always
+//   2. Both `org_logo_url_light_mode` and `org_logo_url_dark_mode` are always
 //      set (BE falls back to Fleet's default logo when the admin hasn't
 //      uploaded one). No deprecated aliases — this is a new endpoint.
+//
+// Confirmed by Rachel with the team on 2026-08-17:
+//   * POST /device/:token/notifications/:uuid/actions returns the updated
+//     NotificationView in the response body, so `update_now` transitions
+//     to "Installing…" without a follow-up GET.
+//   * 1-hour and 5-minute reminder share the same notification UUID; the
+//     server flips its render output on an internal `reminder` flag
+//     (#50912, #50913). The FE stays generic — no `kind` field needed.
 
 export interface INotificationItem {
   software_title_id: number;
@@ -41,8 +49,11 @@ export interface INotificationView {
 /** JS → Swift bridge message ids. Distinct from server-side action ids. */
 export type BridgeAction = "ready" | "resize" | "primary" | "dismiss" | "error";
 
+/** Bump when the bridge envelope shape changes; Swift keys off `v` to route. */
+export const BRIDGE_VERSION = 1 as const;
+
 export interface IBridgeMessage {
-  v: 1;
+  v: typeof BRIDGE_VERSION;
   action: BridgeAction;
   payload: Record<string, unknown>;
 }

--- a/frontend/interfaces/device_notification.ts
+++ b/frontend/interfaces/device_notification.ts
@@ -1,0 +1,48 @@
+// FE assumptions on the server contract, pending BE confirmation on #50916:
+//   1. POST /device/:token/notifications/:uuid/actions returns the updated
+//      INotificationView in the response body — so `update_now` returns the
+//      "Installing…" state without a follow-up GET.
+//   2. Items carry their own `software_title_id` and `icon_url` — no second
+//      software lookup on the client.
+//   3. Both `org_logo_url_light_mode` and `org_logo_url_dark_mode` are always
+//      set (BE falls back to Fleet's default logo when the admin hasn't
+//      uploaded one). No deprecated aliases — this is a new endpoint.
+
+export interface INotificationItem {
+  software_title_id: number;
+  /** Icon URL if present; <SoftwareIcon> falls back to `name` when null. */
+  icon_url: string | null;
+  /** Raw name — passed to <SoftwareIcon> unchanged for icon fallback matching. */
+  name: string;
+  display_name?: string;
+  /** Optional right-aligned status label, e.g. "Installing…". */
+  status?: string;
+}
+
+/** Server-declared actions rendered bottom-right. The last action is primary. */
+export interface INotificationAction {
+  /** Sent verbatim in the POST body, e.g. "update_now", "remind", "dismiss". */
+  id: string;
+  label: string;
+}
+
+export interface INotificationView {
+  uuid: string;
+  org_logo_url_light_mode: string;
+  org_logo_url_dark_mode: string;
+  /** May contain **bold** markup. */
+  title: string;
+  /** May contain **bold** markup. */
+  description: string;
+  items: INotificationItem[];
+  actions: INotificationAction[];
+}
+
+/** JS → Swift bridge message ids. Distinct from server-side action ids. */
+export type BridgeAction = "ready" | "resize" | "primary" | "dismiss" | "error";
+
+export interface IBridgeMessage {
+  v: 1;
+  action: BridgeAction;
+  payload: Record<string, unknown>;
+}

--- a/frontend/interfaces/device_notification.ts
+++ b/frontend/interfaces/device_notification.ts
@@ -1,21 +1,3 @@
-// TODO(#50916): Remove this block once the BE endpoints in #50910 land and
-// confirm the remaining assumptions.
-//
-// FE assumptions on the server contract (see #50916 issuecomment-5295478695):
-//   1. Items carry their own `software_title_id` and `icon_url` — no second
-//      software lookup on the client.
-//   2. Both `org_logo_url_light_mode` and `org_logo_url_dark_mode` are always
-//      set (BE falls back to Fleet's default logo when the admin hasn't
-//      uploaded one). No deprecated aliases — this is a new endpoint.
-//
-// Confirmed by Rachel with the team on 2026-08-17:
-//   * POST /device/:token/notifications/:uuid/actions returns the updated
-//     NotificationView in the response body, so `update_now` transitions
-//     to "Installing…" without a follow-up GET.
-//   * 1-hour and 5-minute reminder share the same notification UUID; the
-//     server flips its render output on an internal `reminder` flag
-//     (#50912, #50913). The FE stays generic — no `kind` field needed.
-
 export interface INotificationItem {
   software_title_id: number;
   /** Icon URL if present; <SoftwareIcon> falls back to `name` when null. */

--- a/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tests.tsx
+++ b/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tests.tsx
@@ -230,6 +230,34 @@ describe("DeviceNotificationPage", () => {
     expect(primaryCalls).toHaveLength(0);
   });
 
+  it("posts `dismiss` (not `primary`) when the sole action's id is `dismiss` — Installing-state Hide", async () => {
+    // Post-`update_now` view: single Hide action whose id is `dismiss`. It is
+    // positionally the primary (last of 1) but semantically closes the toast.
+    mockServer.use(
+      customDeviceNotificationHandler(
+        createMockNotificationView({
+          actions: [{ id: "dismiss", label: "Hide" }],
+        })
+      ),
+      defaultDeviceNotificationActionHandler
+    );
+
+    const { user } = renderPage();
+
+    const hide = await screen.findByRole("button", { name: "Hide" });
+    await user.click(hide);
+
+    await waitFor(() => {
+      expect(postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ action: "dismiss" })
+      );
+    });
+    const primaryCalls = postMessage.mock.calls.filter(
+      ([msg]) => msg.action === "primary"
+    );
+    expect(primaryCalls).toHaveLength(0);
+  });
+
   it("surfaces an inline error when the action POST fails", async () => {
     mockServer.use(
       customDeviceNotificationHandler(),

--- a/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tests.tsx
+++ b/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tests.tsx
@@ -118,4 +118,65 @@ describe("DeviceNotificationPage", () => {
 
     expect(await screen.findByText(/apps will close/i)).toBeInTheDocument();
   });
+
+  it("renders **bold** markup in title and description as <strong>", async () => {
+    mockServer.use(
+      customDeviceNotificationHandler(
+        createMockNotificationView({
+          title: "Apps will close in **1 hour**",
+          description: "Save your **work** first.",
+        })
+      )
+    );
+
+    const { container } = renderPage();
+
+    await screen.findByText(/Apps will close in/);
+    const strongs = container.querySelectorAll("strong");
+    const strongText = Array.from(strongs).map((el) => el.textContent);
+    expect(strongText).toContain("1 hour");
+    expect(strongText).toContain("work");
+  });
+
+  it("marks the last action as primary", async () => {
+    mockServer.use(
+      customDeviceNotificationHandler(
+        createMockNotificationView({
+          actions: [
+            { id: "remind", label: "Remind me in 1 hour" },
+            { id: "update_now", label: "Update now" },
+          ],
+        })
+      )
+    );
+
+    renderPage();
+
+    const primary = await screen.findByRole("button", { name: "Update now" });
+    const secondary = screen.getByRole("button", {
+      name: "Remind me in 1 hour",
+    });
+    expect(primary.className).toMatch(/--primary/);
+    expect(secondary.className).not.toMatch(/--primary/);
+  });
+
+  it("renders both light-mode and dark-mode logo sources", async () => {
+    mockServer.use(
+      customDeviceNotificationHandler(
+        createMockNotificationView({
+          org_logo_url_light_mode: "https://example.com/light.png",
+          org_logo_url_dark_mode: "https://example.com/dark.png",
+        })
+      )
+    );
+
+    const { container } = renderPage();
+
+    await screen.findByText(/apps will close/i);
+    const source = container.querySelector("source");
+    const img = container.querySelector("picture img");
+    expect(source?.getAttribute("srcset")).toBe("https://example.com/dark.png");
+    expect(source?.getAttribute("media")).toBe("(prefers-color-scheme: dark)");
+    expect(img?.getAttribute("src")).toBe("https://example.com/light.png");
+  });
 });

--- a/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tests.tsx
+++ b/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tests.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+
+import { createCustomRenderer } from "test/test-utils";
+
+import DeviceNotificationPage from "./DeviceNotificationPage";
+
+describe("DeviceNotificationPage", () => {
+  it("renders the route params (scaffold)", () => {
+    const render = createCustomRenderer();
+
+    render(
+      <DeviceNotificationPage
+        params={{
+          device_auth_token: "test-token",
+          notification_uuid: "test-uuid",
+        }}
+      />
+    );
+
+    expect(screen.getByText(/test-token/)).toBeInTheDocument();
+    expect(screen.getByText(/test-uuid/)).toBeInTheDocument();
+  });
+});

--- a/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tests.tsx
+++ b/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tests.tsx
@@ -1,24 +1,121 @@
 import React from "react";
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 
+import mockServer from "test/mock-server";
 import { createCustomRenderer } from "test/test-utils";
+import {
+  createMockNotificationView,
+  customDeviceNotificationHandler,
+  errorDeviceNotificationHandler,
+  notFoundDeviceNotificationHandler,
+} from "test/handlers/device-notifications-handlers";
 
 import DeviceNotificationPage from "./DeviceNotificationPage";
 
-describe("DeviceNotificationPage", () => {
-  it("renders the route params (scaffold)", () => {
-    const render = createCustomRenderer();
+const renderPage = () => {
+  const render = createCustomRenderer({ withBackendMock: true });
+  return render(
+    <DeviceNotificationPage
+      params={{
+        device_auth_token: "test-token",
+        notification_uuid: "test-uuid",
+      }}
+    />
+  );
+};
 
-    render(
-      <DeviceNotificationPage
-        params={{
-          device_auth_token: "test-token",
-          notification_uuid: "test-uuid",
-        }}
-      />
+describe("DeviceNotificationPage", () => {
+  const postMessage = jest.fn();
+
+  beforeEach(() => {
+    postMessage.mockClear();
+    window.webkit = {
+      messageHandlers: { fleetDesktop: { postMessage } },
+    };
+  });
+
+  afterEach(() => {
+    delete window.webkit;
+  });
+
+  it("renders the fetched notification and posts `ready` once", async () => {
+    mockServer.use(
+      customDeviceNotificationHandler(
+        createMockNotificationView({
+          title: "Apps will close in 1 hour",
+          description: "Save your work.",
+          items: [
+            {
+              software_title_id: 1,
+              name: "1Password 8",
+              display_name: "1Password",
+              icon_url: null,
+            },
+          ],
+          actions: [
+            { id: "remind", label: "Remind me in 1 hour" },
+            { id: "update_now", label: "Update now" },
+          ],
+        })
+      )
     );
 
-    expect(screen.getByText(/test-token/)).toBeInTheDocument();
-    expect(screen.getByText(/test-uuid/)).toBeInTheDocument();
+    renderPage();
+
+    expect(
+      await screen.findByText("Apps will close in 1 hour")
+    ).toBeInTheDocument();
+    expect(screen.getByText("Save your work.")).toBeInTheDocument();
+    expect(screen.getByText("1Password")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Remind me in 1 hour" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Update now" })
+    ).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ action: "ready" })
+      );
+    });
+    const readyCalls = postMessage.mock.calls.filter(
+      ([msg]) => msg.action === "ready"
+    );
+    expect(readyCalls).toHaveLength(1);
+  });
+
+  it("posts `error` and renders nothing on a 404", async () => {
+    mockServer.use(notFoundDeviceNotificationHandler);
+
+    const { container } = renderPage();
+
+    await waitFor(() => {
+      expect(postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ action: "error" })
+      );
+    });
+    expect(container.querySelector(".device-notification-page")).toBeNull();
+  });
+
+  it("posts `error` on a 500", async () => {
+    mockServer.use(errorDeviceNotificationHandler);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ action: "error" })
+      );
+    });
+  });
+
+  it("does not throw when window.webkit is absent (browser dev)", async () => {
+    delete window.webkit;
+    mockServer.use(customDeviceNotificationHandler());
+
+    renderPage();
+
+    expect(await screen.findByText(/apps will close/i)).toBeInTheDocument();
   });
 });

--- a/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tests.tsx
+++ b/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tests.tsx
@@ -87,10 +87,7 @@ describe("DeviceNotificationPage", () => {
     expect(readyCalls).toHaveLength(1);
   });
 
-  // TEMP: while DeviceNotificationPage falls back to a mock during local
-  // preview, the error paths still post `error` but no longer render null.
-  // Restore this and the 500 test when the mock fallback is removed.
-  it.skip("posts `error` and renders nothing on a 404", async () => {
+  it("posts `error` and renders nothing on a 404", async () => {
     mockServer.use(notFoundDeviceNotificationHandler);
 
     const { container } = renderPage();

--- a/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tests.tsx
+++ b/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tests.tsx
@@ -270,7 +270,7 @@ describe("DeviceNotificationPage", () => {
     await user.click(primary);
 
     expect(await screen.findByRole("alert")).toHaveTextContent(
-      /something went wrong/i
+      /please try again/i
     );
     // A failed POST must not silently send the outcome bridge messages.
     const primaryCalls = postMessage.mock.calls.filter(

--- a/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tests.tsx
+++ b/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tests.tsx
@@ -138,7 +138,7 @@ describe("DeviceNotificationPage", () => {
     expect(strongText).toContain("work");
   });
 
-  it("marks the last action as primary", async () => {
+  it("renders the last action as the default Button variant and others as subdued", async () => {
     mockServer.use(
       customDeviceNotificationHandler(
         createMockNotificationView({
@@ -156,8 +156,8 @@ describe("DeviceNotificationPage", () => {
     const secondary = screen.getByRole("button", {
       name: "Remind me in 1 hour",
     });
-    expect(primary.className).toMatch(/--primary/);
-    expect(secondary.className).not.toMatch(/--primary/);
+    expect(primary.className).toMatch(/button--default/);
+    expect(secondary.className).toMatch(/button--subdued/);
   });
 
   it("renders both light-mode and dark-mode logo sources", async () => {

--- a/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tests.tsx
+++ b/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tests.tsx
@@ -6,6 +6,8 @@ import { createCustomRenderer } from "test/test-utils";
 import {
   createMockNotificationView,
   customDeviceNotificationHandler,
+  defaultDeviceNotificationActionHandler,
+  errorDeviceNotificationActionHandler,
   errorDeviceNotificationHandler,
   notFoundDeviceNotificationHandler,
 } from "test/handlers/device-notifications-handlers";
@@ -85,7 +87,10 @@ describe("DeviceNotificationPage", () => {
     expect(readyCalls).toHaveLength(1);
   });
 
-  it("posts `error` and renders nothing on a 404", async () => {
+  // TEMP: while DeviceNotificationPage falls back to a mock during local
+  // preview, the error paths still post `error` but no longer render null.
+  // Restore this and the 500 test when the mock fallback is removed.
+  it.skip("posts `error` and renders nothing on a 404", async () => {
     mockServer.use(notFoundDeviceNotificationHandler);
 
     const { container } = renderPage();
@@ -160,6 +165,96 @@ describe("DeviceNotificationPage", () => {
     expect(secondary.className).toMatch(/button--subdued/);
   });
 
+  it("posts `primary` bridge and transitions to Installing on the primary action", async () => {
+    mockServer.use(
+      customDeviceNotificationHandler(
+        createMockNotificationView({
+          actions: [
+            { id: "remind", label: "Remind me in 1 hour" },
+            { id: "update_now", label: "Update now" },
+          ],
+        })
+      ),
+      defaultDeviceNotificationActionHandler
+    );
+
+    const { user } = renderPage();
+
+    const primary = await screen.findByRole("button", { name: "Update now" });
+    await user.click(primary);
+
+    // Server returns the Installing… view (statuses on every item), which
+    // we render by writing the response into the query cache.
+    const installing = await screen.findAllByText("Installing…");
+    expect(installing.length).toBeGreaterThan(0);
+
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "primary" })
+    );
+    // update_now keeps the window open — no dismiss bridge on this path.
+    const dismissCalls = postMessage.mock.calls.filter(
+      ([msg]) => msg.action === "dismiss"
+    );
+    expect(dismissCalls).toHaveLength(0);
+  });
+
+  it("posts `dismiss` bridge on a secondary action", async () => {
+    mockServer.use(
+      customDeviceNotificationHandler(
+        createMockNotificationView({
+          actions: [
+            { id: "remind", label: "Remind me in 1 hour" },
+            { id: "update_now", label: "Update now" },
+          ],
+        })
+      ),
+      defaultDeviceNotificationActionHandler
+    );
+
+    const { user } = renderPage();
+
+    const secondary = await screen.findByRole("button", {
+      name: "Remind me in 1 hour",
+    });
+    await user.click(secondary);
+
+    await waitFor(() => {
+      expect(postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ action: "dismiss" })
+      );
+    });
+    // Secondary is not the primary — no `primary` bridge.
+    const primaryCalls = postMessage.mock.calls.filter(
+      ([msg]) => msg.action === "primary"
+    );
+    expect(primaryCalls).toHaveLength(0);
+  });
+
+  it("surfaces an inline error when the action POST fails", async () => {
+    mockServer.use(
+      customDeviceNotificationHandler(),
+      errorDeviceNotificationActionHandler
+    );
+
+    const { user } = renderPage();
+
+    const primary = await screen.findByRole("button", { name: "Update now" });
+    await user.click(primary);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /something went wrong/i
+    );
+    // A failed POST must not silently send the outcome bridge messages.
+    const primaryCalls = postMessage.mock.calls.filter(
+      ([msg]) => msg.action === "primary"
+    );
+    const dismissCalls = postMessage.mock.calls.filter(
+      ([msg]) => msg.action === "dismiss"
+    );
+    expect(primaryCalls).toHaveLength(0);
+    expect(dismissCalls).toHaveLength(0);
+  });
+
   it("renders both light-mode and dark-mode logo sources", async () => {
     mockServer.use(
       customDeviceNotificationHandler(
@@ -172,11 +267,13 @@ describe("DeviceNotificationPage", () => {
 
     const { container } = renderPage();
 
-    await screen.findByText(/apps will close/i);
+    // Wait for the MSW response to replace the TEMP fallback logo urls.
+    await waitFor(() => {
+      const src = container.querySelector("picture img")?.getAttribute("src");
+      expect(src).toBe("https://example.com/light.png");
+    });
     const source = container.querySelector("source");
-    const img = container.querySelector("picture img");
     expect(source?.getAttribute("srcset")).toBe("https://example.com/dark.png");
     expect(source?.getAttribute("media")).toBe("(prefers-color-scheme: dark)");
-    expect(img?.getAttribute("src")).toBe("https://example.com/light.png");
   });
 });

--- a/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tests.tsx
+++ b/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tests.tsx
@@ -14,6 +14,8 @@ import {
 
 import DeviceNotificationPage from "./DeviceNotificationPage";
 
+const baseClass = "device-notification-page";
+
 const renderPage = () => {
   const render = createCustomRenderer({ withBackendMock: true });
   return render(
@@ -38,6 +40,7 @@ describe("DeviceNotificationPage", () => {
 
   afterEach(() => {
     delete window.webkit;
+    localStorage.removeItem("fleet-theme");
   });
 
   it("renders the fetched notification and posts `ready` once", async () => {
@@ -280,7 +283,7 @@ describe("DeviceNotificationPage", () => {
     expect(dismissCalls).toHaveLength(0);
   });
 
-  it("renders both light-mode and dark-mode logo sources", async () => {
+  it("renders the light-mode logo in light mode and the dark-mode logo in dark mode", async () => {
     mockServer.use(
       customDeviceNotificationHandler(
         createMockNotificationView({
@@ -290,15 +293,45 @@ describe("DeviceNotificationPage", () => {
       )
     );
 
-    const { container } = renderPage();
+    const light = renderPage();
 
     // Wait for the MSW response to replace the TEMP fallback logo urls.
     await waitFor(() => {
-      const src = container.querySelector("picture img")?.getAttribute("src");
+      const src = light.container
+        .querySelector(`.${baseClass}__logo`)
+        ?.getAttribute("src");
       expect(src).toBe("https://example.com/light.png");
     });
-    const source = container.querySelector("source");
-    expect(source?.getAttribute("srcset")).toBe("https://example.com/dark.png");
-    expect(source?.getAttribute("media")).toBe("(prefers-color-scheme: dark)");
+    light.unmount();
+
+    localStorage.setItem("fleet-theme", "dark");
+    const dark = renderPage();
+
+    await waitFor(() => {
+      const src = dark.container
+        .querySelector(`.${baseClass}__logo`)
+        ?.getAttribute("src");
+      expect(src).toBe("https://example.com/dark.png");
+    });
+  });
+
+  // An org that never uploaded a logo gets empty urls from the server, and OrgLogoIcon
+  // substitutes Fleet's own logo rather than rendering a broken image.
+  it("renders Fleet's logo when the org has not set one", async () => {
+    mockServer.use(
+      customDeviceNotificationHandler(
+        createMockNotificationView({
+          org_logo_url_light_mode: "",
+          org_logo_url_dark_mode: "",
+        })
+      )
+    );
+
+    const { container } = renderPage();
+
+    await waitFor(() => {
+      const logo = container.querySelector(`.${baseClass}__logo`);
+      expect(logo).toHaveClass("default-fleet-logo");
+    });
   });
 });

--- a/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tests.tsx
+++ b/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tests.tsx
@@ -295,7 +295,6 @@ describe("DeviceNotificationPage", () => {
 
     const light = renderPage();
 
-    // Wait for the MSW response to replace the TEMP fallback logo urls.
     await waitFor(() => {
       const src = light.container
         .querySelector(`.${baseClass}__logo`)

--- a/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tsx
+++ b/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect, useRef } from "react";
-import { useQuery } from "react-query";
+import { useMutation, useQuery, useQueryClient } from "react-query";
 
 import Button from "components/buttons/Button";
 import SoftwareIcon from "pages/SoftwarePage/components/icons/SoftwareIcon";
 
 import deviceNotificationsAPI from "services/entities/device_notifications";
 import {
+  INotificationAction,
   INotificationItem,
   INotificationView,
 } from "interfaces/device_notification";
@@ -13,6 +14,41 @@ import {
 import { postBridgeMessage } from "./fleetDesktopBridge";
 
 const baseClass = "device-notification-page";
+
+// TEMP local-preview mock — the BE endpoints in #50910 don't exist yet, so
+// visiting the URL against `make serve` would 404 and render nothing. Delete
+// this block and remove the fallback below before pushing this branch.
+const TEMP_MOCK_VIEW: INotificationView = {
+  uuid: "temp-preview",
+  org_logo_url_light_mode: "/assets/images/fleet-mark-color-40x40@2x.png",
+  org_logo_url_dark_mode: "/assets/images/fleet-mark-color-40x40@2x.png",
+  title: "These apps will close and update in **1 hour**",
+  description: "Save your work. You can also **update now** to skip the wait.",
+  items: [
+    {
+      software_title_id: 1,
+      name: "1Password 8",
+      display_name: "1Password",
+      icon_url: null,
+    },
+    {
+      software_title_id: 2,
+      name: "Slack",
+      display_name: "Slack",
+      icon_url: null,
+    },
+    {
+      software_title_id: 3,
+      name: "Docker Desktop",
+      display_name: "Docker Desktop",
+      icon_url: null,
+    },
+  ],
+  actions: [
+    { id: "remind", label: "Remind me in 1 hour" },
+    { id: "update_now", label: "Update now" },
+  ],
+};
 
 interface IDeviceNotificationPageParams {
   device_auth_token: string;
@@ -39,7 +75,7 @@ const renderBoldMarkup = (text: string): React.ReactNode => {
 
 const NotificationItemRow = ({ item }: { item: INotificationItem }) => (
   <li className={`${baseClass}__item`}>
-    <SoftwareIcon name={item.name} url={item.icon_url} />
+    <SoftwareIcon name={item.name} url={item.icon_url} size="small" />
     <span className={`${baseClass}__item-name`}>
       {item.display_name ?? item.name}
     </span>
@@ -54,9 +90,16 @@ const DeviceNotificationPage = ({
 }: IDeviceNotificationPageProps): JSX.Element | null => {
   const readyPostedRef = useRef(false);
   const cardRef = useRef<HTMLDivElement>(null);
+  const queryClient = useQueryClient();
+
+  const queryKey = [
+    "device-notification",
+    device_auth_token,
+    notification_uuid,
+  ];
 
   const { data, isSuccess, isError } = useQuery<INotificationView, Error>(
-    ["device-notification", device_auth_token, notification_uuid],
+    queryKey,
     () =>
       deviceNotificationsAPI.getNotification(
         device_auth_token,
@@ -67,6 +110,39 @@ const DeviceNotificationPage = ({
       refetchOnMount: false,
       refetchOnReconnect: false,
       refetchOnWindowFocus: false,
+    }
+  );
+
+  const {
+    mutate: postAction,
+    isError: isPostError,
+    isLoading: isPosting,
+  } = useMutation<
+    INotificationView,
+    Error,
+    { action: INotificationAction; isPrimary: boolean }
+  >(
+    ({ action }) =>
+      deviceNotificationsAPI.postNotificationAction({
+        deviceToken: device_auth_token,
+        notificationUuid: notification_uuid,
+        action: action.id,
+      }),
+    {
+      onSuccess: (updatedView, { isPrimary }) => {
+        // Server owns the post-action state (e.g. Installing…). Replace the
+        // cached view so re-render happens without a follow-up GET.
+        queryClient.setQueryData(queryKey, updatedView);
+        if (isPrimary) {
+          // The end user picked the primary action; the window stays open
+          // so they can watch the installs start.
+          postBridgeMessage("primary");
+        } else {
+          // Secondaries close the toast via the bridge; the native window
+          // handles the actual close on receiving `dismiss`.
+          postBridgeMessage("dismiss");
+        }
+      },
     }
   );
 
@@ -97,41 +173,67 @@ const DeviceNotificationPage = ({
     return () => observer.disconnect();
   }, [data]);
 
-  if (isError || !data) {
-    return null;
-  }
+  // TEMP: fall back to the mock during local preview. Remove `?? TEMP_MOCK_VIEW`
+  // and restore `if (isError || !data)` before pushing.
+  const view = data ?? TEMP_MOCK_VIEW;
 
-  const actions = data.actions;
+  const actions = view.actions;
   const primaryAction = actions[actions.length - 1];
   const secondaryActions = actions.slice(0, -1);
 
   return (
     <div className={baseClass}>
       <div className={`${baseClass}__card`} ref={cardRef}>
-        <picture className={`${baseClass}__logo`}>
-          <source
-            srcSet={data.org_logo_url_dark_mode}
-            media="(prefers-color-scheme: dark)"
-          />
-          <img src={data.org_logo_url_light_mode} alt="" />
-        </picture>
-        <p className={`${baseClass}__title`}>{renderBoldMarkup(data.title)}</p>
-        <p className={`${baseClass}__description`}>
-          {renderBoldMarkup(data.description)}
-        </p>
+        <div className={`${baseClass}__header`}>
+          <div className={`${baseClass}__header-text`}>
+            <p className={`${baseClass}__title`}>
+              {renderBoldMarkup(view.title)}
+            </p>
+            <p className={`${baseClass}__description`}>
+              {renderBoldMarkup(view.description)}
+            </p>
+          </div>
+          <picture className={`${baseClass}__logo`}>
+            <source
+              srcSet={view.org_logo_url_dark_mode}
+              media="(prefers-color-scheme: dark)"
+            />
+            <img src={view.org_logo_url_light_mode} alt="" />
+          </picture>
+        </div>
         <ul className={`${baseClass}__item-list`}>
-          {data.items.map((item) => (
+          {view.items.map((item) => (
             <NotificationItemRow key={item.software_title_id} item={item} />
           ))}
         </ul>
+        {isPostError && (
+          <p className={`${baseClass}__action-error`} role="alert">
+            Something went wrong. Please try again.
+          </p>
+        )}
         <div className={`${baseClass}__actions`}>
           {secondaryActions.map((action) => (
-            <Button key={action.id} variant="subdued">
+            <Button
+              key={action.id}
+              variant="subdued"
+              size="small"
+              disabled={isPosting}
+              onClick={() => postAction({ action, isPrimary: false })}
+            >
               {action.label}
             </Button>
           ))}
           {primaryAction && (
-            <Button key={primaryAction.id}>{primaryAction.label}</Button>
+            <Button
+              key={primaryAction.id}
+              size="small"
+              disabled={isPosting}
+              onClick={() =>
+                postAction({ action: primaryAction, isPrimary: true })
+              }
+            >
+              {primaryAction.label}
+            </Button>
           )}
         </div>
       </div>

--- a/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tsx
+++ b/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tsx
@@ -1,4 +1,10 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
+import { useQuery } from "react-query";
+
+import deviceNotificationsAPI from "services/entities/device_notifications";
+import { INotificationView } from "interfaces/device_notification";
+
+import { postBridgeMessage } from "./fleetDesktopBridge";
 
 const baseClass = "device-notification-page";
 
@@ -13,11 +19,64 @@ interface IDeviceNotificationPageProps {
 
 const DeviceNotificationPage = ({
   params: { device_auth_token, notification_uuid },
-}: IDeviceNotificationPageProps): JSX.Element => {
+}: IDeviceNotificationPageProps): JSX.Element | null => {
+  const readyPostedRef = useRef(false);
+
+  const { data, isSuccess, isError } = useQuery<INotificationView, Error>(
+    ["device-notification", device_auth_token, notification_uuid],
+    () =>
+      deviceNotificationsAPI.getNotification(
+        device_auth_token,
+        notification_uuid
+      ),
+    {
+      // One-shot fetch — the toast opens, fetches once, and is dismissed.
+      // Server owns retries via the exit-code-driven notification pipeline.
+      retry: false,
+      refetchOnMount: false,
+      refetchOnReconnect: false,
+      refetchOnWindowFocus: false,
+    }
+  );
+
+  useEffect(() => {
+    if (isSuccess && !readyPostedRef.current) {
+      readyPostedRef.current = true;
+      // `ready` unblocks the ToastWindow.loadTimeout (30s in Fleet Desktop);
+      // without it the notification script would report exit code 30.
+      postBridgeMessage("ready");
+    }
+  }, [isSuccess]);
+
+  useEffect(() => {
+    if (isError) {
+      postBridgeMessage("error");
+    }
+  }, [isError]);
+
+  if (isError || !data) {
+    return null;
+  }
+
   return (
     <div className={baseClass}>
-      <p>Device: {device_auth_token}</p>
-      <p>Notification: {notification_uuid}</p>
+      <p>{data.title}</p>
+      <p>{data.description}</p>
+      <ul>
+        {data.items.map((item) => (
+          <li key={item.software_title_id}>
+            {item.display_name ?? item.name}
+            {item.status ? ` — ${item.status}` : ""}
+          </li>
+        ))}
+      </ul>
+      <div>
+        {data.actions.map((action) => (
+          <button key={action.id} type="button">
+            {action.label}
+          </button>
+        ))}
+      </div>
     </div>
   );
 };

--- a/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tsx
+++ b/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tsx
@@ -143,10 +143,11 @@ const DeviceNotificationPage = ({
     if (!node || !data) return undefined;
     // Native ToastWindow starts at 525x318 and resizes to fit the card. Every
     // height change (list scroll, action swap after update_now) posts back so
-    // the window follows without an assumed fixed height.
-    const observer = new ResizeObserver((entries) => {
-      const height = entries[0]?.contentRect.height ?? 0;
-      postBridgeMessage("resize", { height });
+    // the window follows without an assumed fixed height. Use `offsetHeight`
+    // (border box) so the reported height includes the card's 24px padding —
+    // `contentRect.height` reports the content box and would clip the buttons.
+    const observer = new ResizeObserver(() => {
+      postBridgeMessage("resize", { height: node.offsetHeight });
     });
     observer.observe(node);
     return () => observer.disconnect();
@@ -165,21 +166,12 @@ const DeviceNotificationPage = ({
     <div className={baseClass}>
       <div className={`${baseClass}__card`} ref={cardRef}>
         <div className={`${baseClass}__header`}>
-          <div className={`${baseClass}__header-text`}>
-            <p className={`${baseClass}__title`}>
-              {renderBoldMarkup(view.title)}
-            </p>
-            <p className={`${baseClass}__description`}>
-              {renderBoldMarkup(view.description)}
-            </p>
-          </div>
-          <picture className={`${baseClass}__logo`}>
-            <source
-              srcSet={view.org_logo_url_dark_mode}
-              media="(prefers-color-scheme: dark)"
-            />
-            <img src={view.org_logo_url_light_mode} alt="" />
-          </picture>
+          <p className={`${baseClass}__title`}>
+            {renderBoldMarkup(view.title)}
+          </p>
+          <p className={`${baseClass}__description`}>
+            {renderBoldMarkup(view.description)}
+          </p>
         </div>
         <List
           data={view.items}
@@ -187,6 +179,13 @@ const DeviceNotificationPage = ({
           renderItemRow={renderNotificationItemRow}
         />
         <div className={`${baseClass}__actions`}>
+          <picture className={`${baseClass}__logo`}>
+            <source
+              srcSet={view.org_logo_url_dark_mode}
+              media="(prefers-color-scheme: dark)"
+            />
+            <img src={view.org_logo_url_light_mode} alt="" />
+          </picture>
           {isPostError && (
             <div className={`${baseClass}__action-error`} role="alert">
               <DataError

--- a/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tsx
+++ b/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from "react";
 import { useQuery } from "react-query";
 
+import Button from "components/buttons/Button";
 import SoftwareIcon from "pages/SoftwarePage/components/icons/SoftwareIcon";
 
 import deviceNotificationsAPI from "services/entities/device_notifications";
@@ -125,22 +126,12 @@ const DeviceNotificationPage = ({
         </ul>
         <div className={`${baseClass}__actions`}>
           {secondaryActions.map((action) => (
-            <button
-              key={action.id}
-              type="button"
-              className={`${baseClass}__action`}
-            >
+            <Button key={action.id} variant="subdued">
               {action.label}
-            </button>
+            </Button>
           ))}
           {primaryAction && (
-            <button
-              key={primaryAction.id}
-              type="button"
-              className={`${baseClass}__action ${baseClass}__action--primary`}
-            >
-              {primaryAction.label}
-            </button>
+            <Button key={primaryAction.id}>{primaryAction.label}</Button>
           )}
         </div>
       </div>

--- a/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tsx
+++ b/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tsx
@@ -1,8 +1,13 @@
 import React, { useEffect, useRef } from "react";
 import { useQuery } from "react-query";
 
+import SoftwareIcon from "pages/SoftwarePage/components/icons/SoftwareIcon";
+
 import deviceNotificationsAPI from "services/entities/device_notifications";
-import { INotificationView } from "interfaces/device_notification";
+import {
+  INotificationItem,
+  INotificationView,
+} from "interfaces/device_notification";
 
 import { postBridgeMessage } from "./fleetDesktopBridge";
 
@@ -17,10 +22,37 @@ interface IDeviceNotificationPageProps {
   params: IDeviceNotificationPageParams;
 }
 
+// The server sends inline `**bold**` in title and description. This is the
+// only markup, so a small splitter is cheaper than pulling in react-markdown.
+const renderBoldMarkup = (text: string): React.ReactNode => {
+  const parts = text.split(/(\*\*[^*]+\*\*)/g);
+  return parts.map((part, i) => {
+    if (part.startsWith("**") && part.endsWith("**")) {
+      // eslint-disable-next-line react/no-array-index-key
+      return <strong key={i}>{part.slice(2, -2)}</strong>;
+    }
+    // eslint-disable-next-line react/no-array-index-key
+    return <React.Fragment key={i}>{part}</React.Fragment>;
+  });
+};
+
+const NotificationItemRow = ({ item }: { item: INotificationItem }) => (
+  <li className={`${baseClass}__item`}>
+    <SoftwareIcon name={item.name} url={item.icon_url} />
+    <span className={`${baseClass}__item-name`}>
+      {item.display_name ?? item.name}
+    </span>
+    {item.status && (
+      <span className={`${baseClass}__item-status`}>{item.status}</span>
+    )}
+  </li>
+);
+
 const DeviceNotificationPage = ({
   params: { device_auth_token, notification_uuid },
 }: IDeviceNotificationPageProps): JSX.Element | null => {
   const readyPostedRef = useRef(false);
+  const cardRef = useRef<HTMLDivElement>(null);
 
   const { data, isSuccess, isError } = useQuery<INotificationView, Error>(
     ["device-notification", device_auth_token, notification_uuid],
@@ -30,8 +62,6 @@ const DeviceNotificationPage = ({
         notification_uuid
       ),
     {
-      // One-shot fetch — the toast opens, fetches once, and is dismissed.
-      // Server owns retries via the exit-code-driven notification pipeline.
       retry: false,
       refetchOnMount: false,
       refetchOnReconnect: false,
@@ -42,8 +72,6 @@ const DeviceNotificationPage = ({
   useEffect(() => {
     if (isSuccess && !readyPostedRef.current) {
       readyPostedRef.current = true;
-      // `ready` unblocks the ToastWindow.loadTimeout (30s in Fleet Desktop);
-      // without it the notification script would report exit code 30.
       postBridgeMessage("ready");
     }
   }, [isSuccess]);
@@ -54,28 +82,67 @@ const DeviceNotificationPage = ({
     }
   }, [isError]);
 
+  useEffect(() => {
+    const node = cardRef.current;
+    if (!node || !data) return undefined;
+    // Native ToastWindow starts at 525x318 and resizes to fit the card. Every
+    // height change (list scroll, action swap after update_now) posts back so
+    // the window follows without an assumed fixed height.
+    const observer = new ResizeObserver((entries) => {
+      const height = entries[0]?.contentRect.height ?? 0;
+      postBridgeMessage("resize", { height });
+    });
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [data]);
+
   if (isError || !data) {
     return null;
   }
 
+  const actions = data.actions;
+  const primaryAction = actions[actions.length - 1];
+  const secondaryActions = actions.slice(0, -1);
+
   return (
     <div className={baseClass}>
-      <p>{data.title}</p>
-      <p>{data.description}</p>
-      <ul>
-        {data.items.map((item) => (
-          <li key={item.software_title_id}>
-            {item.display_name ?? item.name}
-            {item.status ? ` — ${item.status}` : ""}
-          </li>
-        ))}
-      </ul>
-      <div>
-        {data.actions.map((action) => (
-          <button key={action.id} type="button">
-            {action.label}
-          </button>
-        ))}
+      <div className={`${baseClass}__card`} ref={cardRef}>
+        <picture className={`${baseClass}__logo`}>
+          <source
+            srcSet={data.org_logo_url_dark_mode}
+            media="(prefers-color-scheme: dark)"
+          />
+          <img src={data.org_logo_url_light_mode} alt="" />
+        </picture>
+        <p className={`${baseClass}__title`}>{renderBoldMarkup(data.title)}</p>
+        <p className={`${baseClass}__description`}>
+          {renderBoldMarkup(data.description)}
+        </p>
+        <ul className={`${baseClass}__item-list`}>
+          {data.items.map((item) => (
+            <NotificationItemRow key={item.software_title_id} item={item} />
+          ))}
+        </ul>
+        <div className={`${baseClass}__actions`}>
+          {secondaryActions.map((action) => (
+            <button
+              key={action.id}
+              type="button"
+              className={`${baseClass}__action`}
+            >
+              {action.label}
+            </button>
+          ))}
+          {primaryAction && (
+            <button
+              key={primaryAction.id}
+              type="button"
+              className={`${baseClass}__action ${baseClass}__action--primary`}
+            >
+              {primaryAction.label}
+            </button>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tsx
+++ b/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tsx
@@ -129,19 +129,17 @@ const DeviceNotificationPage = ({
         action: action.id,
       }),
     {
-      onSuccess: (updatedView, { isPrimary }) => {
+      onSuccess: (updatedView, { action, isPrimary }) => {
         // Server owns the post-action state (e.g. Installing…). Replace the
         // cached view so re-render happens without a follow-up GET.
         queryClient.setQueryData(queryKey, updatedView);
-        if (isPrimary) {
-          // The end user picked the primary action; the window stays open
-          // so they can watch the installs start.
-          postBridgeMessage("primary");
-        } else {
-          // Secondaries close the toast via the bridge; the native window
-          // handles the actual close on receiving `dismiss`.
-          postBridgeMessage("dismiss");
-        }
+        // `dismiss` id always closes the toast, regardless of position — the
+        // server reuses it for any "close" action, including the lone `Hide`
+        // in the Installing state where positionally it would otherwise be
+        // the primary. Only real primary CTAs (e.g. `update_now`) keep the
+        // window open.
+        const shouldClose = action.id === "dismiss" || !isPrimary;
+        postBridgeMessage(shouldClose ? "dismiss" : "primary");
       },
     }
   );

--- a/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tsx
+++ b/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+
+const baseClass = "device-notification-page";
+
+interface IDeviceNotificationPageParams {
+  device_auth_token: string;
+  notification_uuid: string;
+}
+
+interface IDeviceNotificationPageProps {
+  params: IDeviceNotificationPageParams;
+}
+
+const DeviceNotificationPage = ({
+  params: { device_auth_token, notification_uuid },
+}: IDeviceNotificationPageProps): JSX.Element => {
+  return (
+    <div className={baseClass}>
+      <p>Device: {device_auth_token}</p>
+      <p>Notification: {notification_uuid}</p>
+    </div>
+  );
+};
+
+export default DeviceNotificationPage;

--- a/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tsx
+++ b/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef } from "react";
 import { useMutation, useQuery, useQueryClient } from "react-query";
 
 import Button from "components/buttons/Button";
+import DataError from "components/DataError";
 import List from "components/List";
 import TooltipTruncatedText from "components/TooltipTruncatedText";
 import SoftwareIcon from "pages/SoftwarePage/components/icons/SoftwareIcon";
@@ -240,12 +241,16 @@ const DeviceNotificationPage = ({
           idKey="software_title_id"
           renderItemRow={renderNotificationItemRow}
         />
-        {isPostError && (
-          <p className={`${baseClass}__action-error`} role="alert">
-            Something went wrong. Please try again.
-          </p>
-        )}
         <div className={`${baseClass}__actions`}>
+          {isPostError && (
+            <div className={`${baseClass}__action-error`} role="alert">
+              <DataError
+                singleCustomLine
+                description="Please try again."
+                excludeIssueLink
+              />
+            </div>
+          )}
           {secondaryActions.map((action) => (
             <Button
               key={action.id}

--- a/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tsx
+++ b/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tsx
@@ -19,61 +19,6 @@ import { postBridgeMessage } from "./fleetDesktopBridge";
 
 const baseClass = "device-notification-page";
 
-// TODO(#50916): Replace this mock with the real API response once the BE
-// endpoints in #50910 land. Right now the fetch 404s against `make serve`
-// because those endpoints don't exist yet, so the fallback below lets the
-// layout be previewed locally. Remove this block and the `?? TEMP_MOCK_VIEW`
-// fallback before merging.
-const TEMP_MOCK_VIEW: INotificationView = {
-  uuid: "temp-preview",
-  org_logo_url_light_mode: "/assets/images/fleet-mark-color-40x40@2x.png",
-  org_logo_url_dark_mode: "/assets/images/fleet-mark-color-40x40@2x.png",
-  title: "Save your work 💾",
-  description: "These apps will close and update in **1 hour**.",
-  items: [
-    {
-      software_title_id: 1,
-      name: "1Password 8",
-      display_name: "1Password",
-      icon_url: null,
-    },
-    {
-      software_title_id: 2,
-      name: "Slack",
-      display_name: "Slack",
-      icon_url: null,
-    },
-    {
-      software_title_id: 3,
-      name: "Docker Desktop",
-      display_name: "Docker Desktop",
-      icon_url: null,
-    },
-    {
-      software_title_id: 4,
-      name: "Google Chrome",
-      display_name: "Google Chrome",
-      icon_url: null,
-    },
-    {
-      software_title_id: 5,
-      name: "Zoom",
-      display_name: "Zoom",
-      icon_url: null,
-    },
-    {
-      software_title_id: 6,
-      name: "Microsoft Visual Studio Code — Insiders",
-      display_name: "Microsoft Visual Studio Code — Insiders",
-      icon_url: null,
-    },
-  ],
-  actions: [
-    { id: "remind", label: "Remind me in 1 hour" },
-    { id: "update_now", label: "Update now" },
-  ],
-};
-
 interface IDeviceNotificationPageParams {
   device_auth_token: string;
   notification_uuid: string;
@@ -207,11 +152,11 @@ const DeviceNotificationPage = ({
     return () => observer.disconnect();
   }, [data]);
 
-  // TODO(#50916): Replace with the real API response once #50910 lands.
-  // Remove `?? TEMP_MOCK_VIEW` and restore `if (isError || !data) return null;`
-  // above.
-  const view = data ?? TEMP_MOCK_VIEW;
+  if (isError || !data) {
+    return null;
+  }
 
+  const view = data;
   const actions = view.actions;
   const primaryAction = actions[actions.length - 1];
   const secondaryActions = actions.slice(0, -1);

--- a/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tsx
+++ b/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tsx
@@ -2,7 +2,10 @@ import React, { useEffect, useRef } from "react";
 import { useMutation, useQuery, useQueryClient } from "react-query";
 
 import Button from "components/buttons/Button";
+import List from "components/List";
+import TooltipTruncatedText from "components/TooltipTruncatedText";
 import SoftwareIcon from "pages/SoftwarePage/components/icons/SoftwareIcon";
+import { getDisplayedSoftwareName } from "pages/SoftwarePage/helpers";
 
 import deviceNotificationsAPI from "services/entities/device_notifications";
 import {
@@ -15,15 +18,17 @@ import { postBridgeMessage } from "./fleetDesktopBridge";
 
 const baseClass = "device-notification-page";
 
-// TEMP local-preview mock — the BE endpoints in #50910 don't exist yet, so
-// visiting the URL against `make serve` would 404 and render nothing. Delete
-// this block and remove the fallback below before pushing this branch.
+// TODO(#50916): Replace this mock with the real API response once the BE
+// endpoints in #50910 land. Right now the fetch 404s against `make serve`
+// because those endpoints don't exist yet, so the fallback below lets the
+// layout be previewed locally. Remove this block and the `?? TEMP_MOCK_VIEW`
+// fallback before merging.
 const TEMP_MOCK_VIEW: INotificationView = {
   uuid: "temp-preview",
   org_logo_url_light_mode: "/assets/images/fleet-mark-color-40x40@2x.png",
   org_logo_url_dark_mode: "/assets/images/fleet-mark-color-40x40@2x.png",
-  title: "These apps will close and update in **1 hour**",
-  description: "Save your work. You can also **update now** to skip the wait.",
+  title: "Save your work 💾",
+  description: "These apps will close and update in **1 hour**.",
   items: [
     {
       software_title_id: 1,
@@ -41,6 +46,24 @@ const TEMP_MOCK_VIEW: INotificationView = {
       software_title_id: 3,
       name: "Docker Desktop",
       display_name: "Docker Desktop",
+      icon_url: null,
+    },
+    {
+      software_title_id: 4,
+      name: "Google Chrome",
+      display_name: "Google Chrome",
+      icon_url: null,
+    },
+    {
+      software_title_id: 5,
+      name: "Zoom",
+      display_name: "Zoom",
+      icon_url: null,
+    },
+    {
+      software_title_id: 6,
+      name: "Microsoft Visual Studio Code — Insiders",
+      display_name: "Microsoft Visual Studio Code — Insiders",
       icon_url: null,
     },
   ],
@@ -73,16 +96,24 @@ const renderBoldMarkup = (text: string): React.ReactNode => {
   });
 };
 
-const NotificationItemRow = ({ item }: { item: INotificationItem }) => (
-  <li className={`${baseClass}__item`}>
-    <SoftwareIcon name={item.name} url={item.icon_url} size="small" />
-    <span className={`${baseClass}__item-name`}>
-      {item.display_name ?? item.name}
+// Rendered as the child of Fleet's <List> row (`.list__row`), which owns the
+// row's flex layout, padding, and dividers. We supply the left slot
+// (icon + name) and the optional right slot (status), split by List's
+// `justify-content: space-between`.
+const renderNotificationItemRow = (item: INotificationItem) => (
+  <>
+    <span className={`${baseClass}__item-left`}>
+      <SoftwareIcon name={item.name} url={item.icon_url} size="small" />
+      <span className={`${baseClass}__item-name`}>
+        <TooltipTruncatedText
+          value={getDisplayedSoftwareName(item.name, item.display_name)}
+        />
+      </span>
     </span>
     {item.status && (
       <span className={`${baseClass}__item-status`}>{item.status}</span>
     )}
-  </li>
+  </>
 );
 
 const DeviceNotificationPage = ({
@@ -106,8 +137,12 @@ const DeviceNotificationPage = ({
         notification_uuid
       ),
     {
+      // One-shot fetch — the toast opens, fetches once, and dismisses. Server
+      // owns retries via exit codes. We DO want refetchOnMount at its default
+      // (`true`) because the toast reopens every ~55 minutes with a fresh
+      // device auth token (tokens rotate every 30m), and we should never
+      // serve a cached view from a previous open.
       retry: false,
-      refetchOnMount: false,
       refetchOnReconnect: false,
       refetchOnWindowFocus: false,
     }
@@ -171,8 +206,9 @@ const DeviceNotificationPage = ({
     return () => observer.disconnect();
   }, [data]);
 
-  // TEMP: fall back to the mock during local preview. Remove `?? TEMP_MOCK_VIEW`
-  // and restore `if (isError || !data)` before pushing.
+  // TODO(#50916): Replace with the real API response once #50910 lands.
+  // Remove `?? TEMP_MOCK_VIEW` and restore `if (isError || !data) return null;`
+  // above.
   const view = data ?? TEMP_MOCK_VIEW;
 
   const actions = view.actions;
@@ -199,11 +235,11 @@ const DeviceNotificationPage = ({
             <img src={view.org_logo_url_light_mode} alt="" />
           </picture>
         </div>
-        <ul className={`${baseClass}__item-list`}>
-          {view.items.map((item) => (
-            <NotificationItemRow key={item.software_title_id} item={item} />
-          ))}
-        </ul>
+        <List
+          data={view.items}
+          idKey="software_title_id"
+          renderItemRow={renderNotificationItemRow}
+        />
         {isPostError && (
           <p className={`${baseClass}__action-error`} role="alert">
             Something went wrong. Please try again.

--- a/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tsx
+++ b/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tsx
@@ -1,9 +1,11 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "react-query";
 
 import Button from "components/buttons/Button";
 import DataError from "components/DataError";
 import List from "components/List";
+// @ts-ignore
+import OrgLogoIcon from "components/icons/OrgLogoIcon";
 import TooltipTruncatedText from "components/TooltipTruncatedText";
 import SoftwareIcon from "pages/SoftwarePage/components/icons/SoftwareIcon";
 import { getDisplayedSoftwareName } from "pages/SoftwarePage/helpers";
@@ -14,6 +16,8 @@ import {
   INotificationItem,
   INotificationView,
 } from "interfaces/device_notification";
+
+import { isDarkMode } from "utilities/theme";
 
 import { postBridgeMessage } from "./fleetDesktopBridge";
 
@@ -68,6 +72,16 @@ const DeviceNotificationPage = ({
   const readyPostedRef = useRef(false);
   const cardRef = useRef<HTMLDivElement>(null);
   const queryClient = useQueryClient();
+  const [darkMode, setDarkMode] = useState(() => isDarkMode());
+
+  useEffect(() => {
+    const onThemeChange = (e: Event) => {
+      setDarkMode((e as CustomEvent).detail.dark);
+    };
+    window.addEventListener("fleet-theme-change", onThemeChange);
+    return () =>
+      window.removeEventListener("fleet-theme-change", onThemeChange);
+  }, []);
 
   const queryKey = [
     "device-notification",
@@ -161,6 +175,9 @@ const DeviceNotificationPage = ({
   const actions = view.actions;
   const primaryAction = actions[actions.length - 1];
   const secondaryActions = actions.slice(0, -1);
+  const orgLogoURL = darkMode
+    ? view.org_logo_url_dark_mode
+    : view.org_logo_url_light_mode;
 
   return (
     <div className={baseClass}>
@@ -179,13 +196,7 @@ const DeviceNotificationPage = ({
           renderItemRow={renderNotificationItemRow}
         />
         <div className={`${baseClass}__actions`}>
-          <picture className={`${baseClass}__logo`}>
-            <source
-              srcSet={view.org_logo_url_dark_mode}
-              media="(prefers-color-scheme: dark)"
-            />
-            <img src={view.org_logo_url_light_mode} alt="" />
-          </picture>
+          <OrgLogoIcon className={`${baseClass}__logo`} src={orgLogoURL} />
           {isPostError && (
             <div className={`${baseClass}__action-error`} role="alert">
               <DataError

--- a/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tsx
+++ b/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tsx
@@ -32,8 +32,8 @@ interface IDeviceNotificationPageProps {
   params: IDeviceNotificationPageParams;
 }
 
-// The server sends inline `**bold**` in title and description. This is the
-// only markup, so a small splitter is cheaper than pulling in react-markdown.
+// Title/description carry inline `**bold**` as the only markup. Avoid pulling
+// in react-markdown for one construct.
 const renderBoldMarkup = (text: string): React.ReactNode => {
   const parts = text.split(/(\*\*[^*]+\*\*)/g);
   return parts.map((part, i) => {
@@ -46,10 +46,6 @@ const renderBoldMarkup = (text: string): React.ReactNode => {
   });
 };
 
-// Rendered as the child of Fleet's <List> row (`.list__row`), which owns the
-// row's flex layout, padding, and dividers. We supply the left slot
-// (icon + name) and the optional right slot (status), split by List's
-// `justify-content: space-between`.
 const renderNotificationItemRow = (item: INotificationItem) => (
   <>
     <span className={`${baseClass}__item-left`}>
@@ -97,11 +93,8 @@ const DeviceNotificationPage = ({
         notification_uuid
       ),
     {
-      // One-shot fetch — the toast opens, fetches once, and dismisses. Server
-      // owns retries via exit codes. We DO want refetchOnMount at its default
-      // (`true`) because the toast reopens every ~55 minutes with a fresh
-      // device auth token (tokens rotate every 30m), and we should never
-      // serve a cached view from a previous open.
+      // Keep refetchOnMount at its default: the toast reopens with a fresh
+      // 30-min auth token, and a cached view from a previous open would be stale.
       retry: false,
       refetchOnReconnect: false,
       refetchOnWindowFocus: false,
@@ -125,14 +118,11 @@ const DeviceNotificationPage = ({
       }),
     {
       onSuccess: (updatedView, { action, isPrimary }) => {
-        // Server owns the post-action state (e.g. Installing…). Replace the
-        // cached view so re-render happens without a follow-up GET.
+        // Server returns the post-action view; write it back so we re-render
+        // without a follow-up GET.
         queryClient.setQueryData(queryKey, updatedView);
-        // `dismiss` id always closes the toast, regardless of position — the
-        // server reuses it for any "close" action, including the lone `Hide`
-        // in the Installing state where positionally it would otherwise be
-        // the primary. Only real primary CTAs (e.g. `update_now`) keep the
-        // window open.
+        // `dismiss` id always closes, even when it's positionally primary
+        // (e.g. the lone `Hide` in the Installing state).
         const shouldClose = action.id === "dismiss" || !isPrimary;
         postBridgeMessage(shouldClose ? "dismiss" : "primary");
       },
@@ -155,11 +145,8 @@ const DeviceNotificationPage = ({
   useEffect(() => {
     const node = cardRef.current;
     if (!node || !data) return undefined;
-    // Native ToastWindow starts at 525x318 and resizes to fit the card. Every
-    // height change (list scroll, action swap after update_now) posts back so
-    // the window follows without an assumed fixed height. Use `offsetHeight`
-    // (border box) so the reported height includes the card's 24px padding —
-    // `contentRect.height` reports the content box and would clip the buttons.
+    // Use `offsetHeight` (border box) so the reported height includes the
+    // card's padding; `contentRect.height` reports content box and clips buttons.
     const observer = new ResizeObserver(() => {
       postBridgeMessage("resize", { height: node.offsetHeight });
     });

--- a/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tsx
+++ b/frontend/pages/DeviceNotificationPage/DeviceNotificationPage.tsx
@@ -159,9 +159,9 @@ const DeviceNotificationPage = ({
   }
 
   const view = data;
-  const actions = view.actions;
+  const { actions } = view;
   const primaryAction = actions[actions.length - 1];
-  const secondaryActions = actions.slice(0, -1);
+  const secondaryAction = actions.length > 1 ? actions[0] : null;
   const orgLogoURL = darkMode
     ? view.org_logo_url_dark_mode
     : view.org_logo_url_light_mode;
@@ -193,20 +193,20 @@ const DeviceNotificationPage = ({
               />
             </div>
           )}
-          {secondaryActions.map((action) => (
+          {secondaryAction && (
             <Button
-              key={action.id}
               variant="subdued"
               size="small"
               disabled={isPosting}
-              onClick={() => postAction({ action, isPrimary: false })}
+              onClick={() =>
+                postAction({ action: secondaryAction, isPrimary: false })
+              }
             >
-              {action.label}
+              {secondaryAction.label}
             </Button>
-          ))}
+          )}
           {primaryAction && (
             <Button
-              key={primaryAction.id}
               size="small"
               disabled={isPosting}
               onClick={() =>

--- a/frontend/pages/DeviceNotificationPage/_styles.scss
+++ b/frontend/pages/DeviceNotificationPage/_styles.scss
@@ -1,0 +1,3 @@
+.device-notification-page {
+  // Styles land with the toast layout implementation in #50916.
+}

--- a/frontend/pages/DeviceNotificationPage/_styles.scss
+++ b/frontend/pages/DeviceNotificationPage/_styles.scss
@@ -12,31 +12,28 @@
   &__card {
     background-color: $core-fleet-white;
     color: $core-fleet-black;
-    border-radius: $border-radius-xlarge;
+    border-radius: $border-radius-large;
     padding: $pad-large;
     @include flex-column-24px-gap;
   }
 
   &__header {
-    display: flex;
-    align-items: flex-start;
-    gap: $pad-medium;
-  }
-
-  &__header-text {
-    flex: 1;
-    min-width: 0;
     @include flex-column-8px-gap;
   }
 
+  // App/org logo sits in the bottom-left slot of the actions row.
+  // `margin-right: auto` eats free space to its right so the logo hugs the
+  // left edge while the error slot and buttons stay packed on the right
+  // under `justify-content: flex-end`. Uses <picture> for dark-mode swap.
   &__logo {
+    margin-right: auto;
     flex-shrink: 0;
-    width: 32px;
-    height: 32px;
+    width: 28px;
+    height: 28px;
 
     img {
-      width: 32px;
-      height: 32px;
+      width: 28px;
+      height: 28px;
       object-fit: contain;
     }
   }
@@ -110,13 +107,9 @@
     gap: $pad-small;
   }
 
-  // The error slot lives inside the actions row, left of the buttons, so
-  // showing it doesn't shift the row vertically. `margin-right: auto` eats
-  // the free space to its right, keeping the buttons right-aligned even
-  // while the actions row uses `justify-content: flex-end`.
+  // The error slot sits immediately left of the buttons so showing it doesn't
+  // shift the row vertically.
   &__action-error {
-    margin-right: auto;
-
     // DataError's single-line variant ships with $pad-large vertical padding
     // for stand-alone page use. Strip it here so the icon+text sits flush
     // against the buttons and the actions row keeps a stable height.

--- a/frontend/pages/DeviceNotificationPage/_styles.scss
+++ b/frontend/pages/DeviceNotificationPage/_styles.scss
@@ -53,31 +53,42 @@
     color: $ui-fleet-black-75;
   }
 
-  // Rounded bordered container with 1px dividers between rows. Shows four
-  // full rows and a half; the half is the affordance signaling more content
-  // below (Figma dev note 5546:42433).
-  &__item-list {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-    border: 1px solid $ui-fleet-black-10;
-    border-radius: $border-radius-large;
-    overflow-y: auto;
+  // Item list is Fleet's <List> — it owns the rounded container, border, and
+  // per-row dividers. Toast-scoped overrides only: cap the height so 4.5 rows
+  // show (the half row is the "more below" affordance from Figma dev note
+  // 5546:42433), suppress the default row hover (toast rows aren't clickable),
+  // and bump SoftwareIcon to Figma's 32×32 (no preset for it).
+  .list__list {
     max-height: calc(4.5 * 48px);
+    overflow-y: auto;
   }
 
-  &__item {
-    background-color: $core-fleet-white;
+  .list__row {
+    height: 32px;
+
+    &:hover {
+      background: $core-fleet-white;
+    }
+
+    .software-icon {
+      width: 32px;
+      height: 32px;
+      flex-shrink: 0;
+
+      > svg,
+      > img {
+        width: 32px;
+        height: 32px;
+      }
+    }
+  }
+
+  &__item-left {
     display: flex;
     align-items: center;
     gap: $pad-small;
-    padding: $pad-small;
-    height: 48px;
-    border-bottom: 1px solid $ui-fleet-black-10;
-
-    &:last-child {
-      border-bottom: none;
-    }
+    min-width: 0;
+    flex: 1;
   }
 
   &__item-name {
@@ -89,6 +100,7 @@
   &__item-status {
     font-size: $x-small;
     color: $ui-fleet-black-75;
+    flex-shrink: 0;
   }
 
   &__actions {

--- a/frontend/pages/DeviceNotificationPage/_styles.scss
+++ b/frontend/pages/DeviceNotificationPage/_styles.scss
@@ -83,25 +83,7 @@
     display: flex;
     justify-content: flex-end;
     gap: 8px;
-  }
-
-  &__action {
-    padding: 8px 16px;
-    border-radius: 6px;
-    border: 1px solid rgba(0, 0, 0, 0.15);
-    background: transparent;
-    color: inherit;
-    cursor: pointer;
-    font-size: 13px;
-
-    @media (prefers-color-scheme: dark) {
-      border-color: rgba(255, 255, 255, 0.2);
-    }
-
-    &--primary {
-      background: #2f56aa;
-      border-color: #2f56aa;
-      color: #ffffff;
-    }
+    // Buttons themselves are Fleet's <Button> — default variant for the
+    // primary action, `variant="subdued"` for secondaries.
   }
 }

--- a/frontend/pages/DeviceNotificationPage/_styles.scss
+++ b/frontend/pages/DeviceNotificationPage/_styles.scss
@@ -110,10 +110,18 @@
     gap: $pad-small;
   }
 
+  // The error slot lives inside the actions row, left of the buttons, so
+  // showing it doesn't shift the row vertically. `margin-right: auto` eats
+  // the free space to its right, keeping the buttons right-aligned even
+  // while the actions row uses `justify-content: flex-end`.
   &__action-error {
-    margin: 0;
-    font-size: $xx-small;
-    color: $ui-error;
-    text-align: right;
+    margin-right: auto;
+
+    // DataError's single-line variant ships with $pad-large vertical padding
+    // for stand-alone page use. Strip it here so the icon+text sits flush
+    // against the buttons and the actions row keeps a stable height.
+    .data-error__header--single-line {
+      padding: 0;
+    }
   }
 }

--- a/frontend/pages/DeviceNotificationPage/_styles.scss
+++ b/frontend/pages/DeviceNotificationPage/_styles.scss
@@ -1,89 +1,107 @@
-// Placeholder palette and spacing — refine to match Figma
-// (nodes 5546:42428, 5546:42432, 5555:46491) in a designer-review pass.
+// Layout matches the Figma toast (nodes 5546:42302 for the frame, 5546:42315
+// for the list). The native ToastWindow supplies the outer shadow and window
+// corners (ToastWindow.swift:43,47), so the card doesn't add its own shadow.
 
 .device-notification-page {
-  // Page background is transparent — the native ToastWindow supplies the
-  // rounded corners and shadow (ToastWindow.swift:43, :47). A page-level
-  // background would square the corners off.
+  // Page background stays transparent — the native window supplies rounded
+  // corners; a page-level background would square them off.
   background: transparent;
   margin: 0;
   padding: 0;
 
   &__card {
-    background: #ffffff;
-    color: #14181f;
-    border-radius: 12px;
-    padding: 20px;
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
+    background-color: $core-fleet-white;
+    color: $core-fleet-black;
+    border-radius: $border-radius-xlarge;
+    padding: $pad-large;
+    @include flex-column-24px-gap;
+  }
 
-    // Follow system appearance, not Fleet's stored theme preference.
-    // The WebKit view inherits the OS setting.
-    @media (prefers-color-scheme: dark) {
-      background: #1c1e22;
-      color: #f4f5f7;
-    }
+  &__header {
+    display: flex;
+    align-items: flex-start;
+    gap: $pad-medium;
+  }
+
+  &__header-text {
+    flex: 1;
+    min-width: 0;
+    @include flex-column-8px-gap;
   }
 
   &__logo {
-    align-self: flex-end;
-    max-height: 24px;
+    flex-shrink: 0;
+    width: 32px;
+    height: 32px;
 
     img {
-      max-height: 24px;
-      max-width: 160px;
+      width: 32px;
+      height: 32px;
+      object-fit: contain;
     }
   }
 
   &__title {
-    font-size: 15px;
-    font-weight: 600;
+    font-size: $small;
+    font-weight: $bold;
     margin: 0;
   }
 
   &__description {
-    font-size: 13px;
+    font-size: $x-small;
     margin: 0;
-    opacity: 0.85;
+    color: $ui-fleet-black-75;
   }
 
-  // Four-and-a-half rows of items visible, then scroll. The half row is the
-  // affordance signaling more content below (Figma dev note 5546:42433).
+  // Rounded bordered container with 1px dividers between rows. Shows four
+  // full rows and a half; the half is the affordance signaling more content
+  // below (Figma dev note 5546:42433).
   &__item-list {
     list-style: none;
     padding: 0;
     margin: 0;
-    display: flex;
-    flex-direction: column;
-    max-height: calc(4.5 * 44px);
+    border: 1px solid $ui-fleet-black-10;
+    border-radius: $border-radius-large;
     overflow-y: auto;
+    max-height: calc(4.5 * 48px);
   }
 
   &__item {
+    background-color: $core-fleet-white;
     display: flex;
     align-items: center;
-    gap: 10px;
-    padding: 6px 0;
-    min-height: 44px;
+    gap: $pad-small;
+    padding: $pad-small;
+    height: 48px;
+    border-bottom: 1px solid $ui-fleet-black-10;
+
+    &:last-child {
+      border-bottom: none;
+    }
   }
 
   &__item-name {
     flex: 1;
     min-width: 0;
-    font-size: 13px;
+    font-size: $x-small;
   }
 
   &__item-status {
-    opacity: 0.6;
-    font-size: 12px;
+    font-size: $x-small;
+    color: $ui-fleet-black-75;
   }
 
   &__actions {
     display: flex;
     justify-content: flex-end;
-    gap: 8px;
-    // Buttons themselves are Fleet's <Button> — default variant for the
-    // primary action, `variant="subdued"` for secondaries.
+    align-items: center;
+    gap: $pad-small;
+  }
+
+  &__action-error {
+    margin: 0;
+    font-size: $xx-small;
+    color: $ui-error;
+    text-align: right;
   }
 }

--- a/frontend/pages/DeviceNotificationPage/_styles.scss
+++ b/frontend/pages/DeviceNotificationPage/_styles.scss
@@ -1,3 +1,107 @@
+// Placeholder palette and spacing — refine to match Figma
+// (nodes 5546:42428, 5546:42432, 5555:46491) in a designer-review pass.
+
 .device-notification-page {
-  // Styles land with the toast layout implementation in #50916.
+  // Page background is transparent — the native ToastWindow supplies the
+  // rounded corners and shadow (ToastWindow.swift:43, :47). A page-level
+  // background would square the corners off.
+  background: transparent;
+  margin: 0;
+  padding: 0;
+
+  &__card {
+    background: #ffffff;
+    color: #14181f;
+    border-radius: 12px;
+    padding: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+
+    // Follow system appearance, not Fleet's stored theme preference.
+    // The WebKit view inherits the OS setting.
+    @media (prefers-color-scheme: dark) {
+      background: #1c1e22;
+      color: #f4f5f7;
+    }
+  }
+
+  &__logo {
+    align-self: flex-end;
+    max-height: 24px;
+
+    img {
+      max-height: 24px;
+      max-width: 160px;
+    }
+  }
+
+  &__title {
+    font-size: 15px;
+    font-weight: 600;
+    margin: 0;
+  }
+
+  &__description {
+    font-size: 13px;
+    margin: 0;
+    opacity: 0.85;
+  }
+
+  // Four-and-a-half rows of items visible, then scroll. The half row is the
+  // affordance signaling more content below (Figma dev note 5546:42433).
+  &__item-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    max-height: calc(4.5 * 44px);
+    overflow-y: auto;
+  }
+
+  &__item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 6px 0;
+    min-height: 44px;
+  }
+
+  &__item-name {
+    flex: 1;
+    min-width: 0;
+    font-size: 13px;
+  }
+
+  &__item-status {
+    opacity: 0.6;
+    font-size: 12px;
+  }
+
+  &__actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+  }
+
+  &__action {
+    padding: 8px 16px;
+    border-radius: 6px;
+    border: 1px solid rgba(0, 0, 0, 0.15);
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    font-size: 13px;
+
+    @media (prefers-color-scheme: dark) {
+      border-color: rgba(255, 255, 255, 0.2);
+    }
+
+    &--primary {
+      background: #2f56aa;
+      border-color: #2f56aa;
+      color: #ffffff;
+    }
+  }
 }

--- a/frontend/pages/DeviceNotificationPage/_styles.scss
+++ b/frontend/pages/DeviceNotificationPage/_styles.scss
@@ -21,17 +21,19 @@
     @include flex-column-8px-gap;
   }
 
-  // `margin-right: auto` holds the bottom-left slot; buttons stay right-aligned.
-  &__logo {
+  // `margin-right: auto` holds the bottom-left slot; `.org-logo-icon` qualifier outranks that component's default sizing.
+  &__logo.org-logo-icon {
     margin-right: auto;
     flex-shrink: 0;
     width: 28px;
     height: 28px;
+    min-height: 28px;
+    max-height: 28px;
+    padding: 0;
+    object-fit: contain;
 
-    img {
-      width: 28px;
-      height: 28px;
-      object-fit: contain;
+    &.default-fleet-logo {
+      transform: none;
     }
   }
 

--- a/frontend/pages/DeviceNotificationPage/_styles.scss
+++ b/frontend/pages/DeviceNotificationPage/_styles.scss
@@ -21,10 +21,7 @@
     @include flex-column-8px-gap;
   }
 
-  // App/org logo sits in the bottom-left slot of the actions row.
-  // `margin-right: auto` eats free space to its right so the logo hugs the
-  // left edge while the error slot and buttons stay packed on the right
-  // under `justify-content: flex-end`. Uses <picture> for dark-mode swap.
+  // `margin-right: auto` holds the bottom-left slot; buttons stay right-aligned.
   &__logo {
     margin-right: auto;
     flex-shrink: 0;

--- a/frontend/pages/DeviceNotificationPage/_styles.scss
+++ b/frontend/pages/DeviceNotificationPage/_styles.scss
@@ -1,10 +1,7 @@
-// Layout matches the Figma toast (nodes 5546:42302 for the frame, 5546:42315
-// for the list). The native ToastWindow supplies the outer shadow and window
-// corners (ToastWindow.swift:43,47), so the card doesn't add its own shadow.
+// The native ToastWindow supplies the outer shadow and rounded corners, so
+// the card adds no shadow and the page stays transparent.
 
 .device-notification-page {
-  // Page background stays transparent — the native window supplies rounded
-  // corners; a page-level background would square them off.
   background: transparent;
   margin: 0;
   padding: 0;
@@ -21,7 +18,6 @@
     @include flex-column-8px-gap;
   }
 
-  // `margin-right: auto` holds the bottom-left slot; `.org-logo-icon` qualifier outranks that component's default sizing.
   &__logo.org-logo-icon {
     margin-right: auto;
     flex-shrink: 0;
@@ -49,11 +45,7 @@
     color: $ui-fleet-black-75;
   }
 
-  // Item list is Fleet's <List> — it owns the rounded container, border, and
-  // per-row dividers. Toast-scoped overrides only: cap the height so 4.5 rows
-  // show (the half row is the "more below" affordance from Figma dev note
-  // 5546:42433), suppress the default row hover (toast rows aren't clickable),
-  // and bump SoftwareIcon to Figma's 32×32 (no preset for it).
+  // Cap at 4.5 rows for a "more below" affordance; suppress hover (rows aren't clickable).
   .list__list {
     max-height: calc(4.5 * 48px);
     overflow-y: auto;
@@ -106,12 +98,8 @@
     gap: $pad-small;
   }
 
-  // The error slot sits immediately left of the buttons so showing it doesn't
-  // shift the row vertically.
   &__action-error {
-    // DataError's single-line variant ships with $pad-large vertical padding
-    // for stand-alone page use. Strip it here so the icon+text sits flush
-    // against the buttons and the actions row keeps a stable height.
+    // Strip DataError's stand-alone-page padding so the actions row keeps a stable height.
     .data-error__header--single-line {
       padding: 0;
     }

--- a/frontend/pages/DeviceNotificationPage/fleetDesktopBridge.tests.ts
+++ b/frontend/pages/DeviceNotificationPage/fleetDesktopBridge.tests.ts
@@ -1,0 +1,41 @@
+import { postBridgeMessage } from "./fleetDesktopBridge";
+
+describe("fleetDesktopBridge", () => {
+  afterEach(() => {
+    delete window.webkit;
+  });
+
+  it("no-ops when window.webkit is missing (browser dev context)", () => {
+    expect(() => postBridgeMessage("ready")).not.toThrow();
+  });
+
+  it("posts a versioned message with the given action and payload", () => {
+    const postMessage = jest.fn();
+    window.webkit = {
+      messageHandlers: { fleetDesktop: { postMessage } },
+    };
+
+    postBridgeMessage("resize", { height: 400 });
+
+    expect(postMessage).toHaveBeenCalledWith({
+      v: 1,
+      action: "resize",
+      payload: { height: 400 },
+    });
+  });
+
+  it("defaults payload to an empty object", () => {
+    const postMessage = jest.fn();
+    window.webkit = {
+      messageHandlers: { fleetDesktop: { postMessage } },
+    };
+
+    postBridgeMessage("ready");
+
+    expect(postMessage).toHaveBeenCalledWith({
+      v: 1,
+      action: "ready",
+      payload: {},
+    });
+  });
+});

--- a/frontend/pages/DeviceNotificationPage/fleetDesktopBridge.ts
+++ b/frontend/pages/DeviceNotificationPage/fleetDesktopBridge.ts
@@ -1,4 +1,8 @@
-import { BridgeAction, IBridgeMessage } from "interfaces/device_notification";
+import {
+  BRIDGE_VERSION,
+  BridgeAction,
+  IBridgeMessage,
+} from "interfaces/device_notification";
 
 // Fleet Desktop's WKWebView injects `window.webkit.messageHandlers.fleetDesktop`.
 // The same page opened in a normal browser during development does not have it,
@@ -24,6 +28,6 @@ export const postBridgeMessage = (
   if (!handler) {
     return;
   }
-  const message: IBridgeMessage = { v: 1, action, payload };
+  const message: IBridgeMessage = { v: BRIDGE_VERSION, action, payload };
   handler.postMessage(message);
 };

--- a/frontend/pages/DeviceNotificationPage/fleetDesktopBridge.ts
+++ b/frontend/pages/DeviceNotificationPage/fleetDesktopBridge.ts
@@ -1,0 +1,29 @@
+import { BridgeAction, IBridgeMessage } from "interfaces/device_notification";
+
+// Fleet Desktop's WKWebView injects `window.webkit.messageHandlers.fleetDesktop`.
+// The same page opened in a normal browser during development does not have it,
+// so every bridge call must guard for the handler being absent.
+declare global {
+  interface Window {
+    webkit?: {
+      messageHandlers?: {
+        fleetDesktop?: {
+          postMessage: (message: unknown) => void;
+        };
+      };
+    };
+  }
+}
+
+// eslint-disable-next-line import/prefer-default-export
+export const postBridgeMessage = (
+  action: BridgeAction,
+  payload: Record<string, unknown> = {}
+): void => {
+  const handler = window.webkit?.messageHandlers?.fleetDesktop;
+  if (!handler) {
+    return;
+  }
+  const message: IBridgeMessage = { v: 1, action, payload };
+  handler.postMessage(message);
+};

--- a/frontend/pages/DeviceNotificationPage/fleetDesktopBridge.ts
+++ b/frontend/pages/DeviceNotificationPage/fleetDesktopBridge.ts
@@ -4,9 +4,7 @@ import {
   IBridgeMessage,
 } from "interfaces/device_notification";
 
-// Fleet Desktop's WKWebView injects `window.webkit.messageHandlers.fleetDesktop`.
-// The same page opened in a normal browser during development does not have it,
-// so every bridge call must guard for the handler being absent.
+// The WKWebView handler is absent in a normal browser (dev), so guard every call.
 declare global {
   interface Window {
     webkit?: {

--- a/frontend/pages/DeviceNotificationPage/fleetDesktopBridge.ts
+++ b/frontend/pages/DeviceNotificationPage/fleetDesktopBridge.ts
@@ -26,6 +26,13 @@ export const postBridgeMessage = (
 ): void => {
   const handler = window.webkit?.messageHandlers?.fleetDesktop;
   if (!handler) {
+    if (process.env.NODE_ENV !== "production") {
+      // eslint-disable-next-line no-console
+      console.debug("[fleet-desktop-bridge] window.webkit handler missing", {
+        action,
+        payload,
+      });
+    }
     return;
   }
   const message: IBridgeMessage = { v: BRIDGE_VERSION, action, payload };

--- a/frontend/pages/DeviceNotificationPage/index.ts
+++ b/frontend/pages/DeviceNotificationPage/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DeviceNotificationPage";

--- a/frontend/router/index.tsx
+++ b/frontend/router/index.tsx
@@ -29,6 +29,7 @@ import ConfirmSSOInvitePage from "pages/ConfirmSSOInvitePage";
 import MfaPage from "pages/MfaPage";
 import CoreLayout from "layouts/CoreLayout";
 import DashboardPage from "pages/DashboardPage";
+import DeviceNotificationPage from "pages/DeviceNotificationPage";
 import DeviceUserPage from "pages/hosts/details/DeviceUserPage";
 import EditPackPage from "pages/packs/EditPackPage";
 import EmailTokenRedirect from "components/EmailTokenRedirect";
@@ -456,6 +457,13 @@ const routes = (
       </Route>
       <Route path="device">
         <IndexRedirect to=":device_auth_token" />
+        {/* Standalone toast route — kept outside the DeviceUserPage wrapper so
+        the Fleet Desktop notification window doesn't inherit the My device
+        header, nav, or chrome. */}
+        <Route
+          path=":device_auth_token/notifications/:notification_uuid"
+          component={DeviceNotificationPage}
+        />
         <Route component={DeviceUserPage}>
           <Route path=":device_auth_token" component={DeviceUserPage}>
             <Route path="self-service" component={DeviceUserPage} />

--- a/frontend/router/paths.ts
+++ b/frontend/router/paths.ts
@@ -198,6 +198,12 @@ export default {
   DEVICE_TRANSPARENCY: (deviceAuthToken: string): string => {
     return `${URL_PREFIX}/api/v1/fleet/device/${deviceAuthToken}/transparency`;
   },
+  DEVICE_NOTIFICATION: (
+    deviceAuthToken: string,
+    notificationUuid: string
+  ): string => {
+    return `${URL_PREFIX}/device/${deviceAuthToken}/notifications/${notificationUuid}`;
+  },
 
   FLEET_DETAILS_USERS: (teamId?: number): string => {
     if (teamId !== undefined && teamId > 0) {

--- a/frontend/services/entities/device_notifications.ts
+++ b/frontend/services/entities/device_notifications.ts
@@ -1,0 +1,36 @@
+import { INotificationView } from "interfaces/device_notification";
+import sendRequest from "services";
+import endpoints from "utilities/endpoints";
+
+export interface IPostDeviceNotificationActionParams {
+  deviceToken: string;
+  notificationUuid: string;
+  /** Action id declared by the server on INotificationAction, sent verbatim. */
+  action: string;
+}
+
+export default {
+  getNotification: (
+    deviceToken: string,
+    notificationUuid: string
+  ): Promise<INotificationView> => {
+    const { DEVICE_NOTIFICATION } = endpoints;
+    return sendRequest(
+      "GET",
+      DEVICE_NOTIFICATION(deviceToken, notificationUuid)
+    );
+  },
+
+  postNotificationAction: ({
+    deviceToken,
+    notificationUuid,
+    action,
+  }: IPostDeviceNotificationActionParams): Promise<INotificationView> => {
+    const { DEVICE_NOTIFICATION_ACTIONS } = endpoints;
+    return sendRequest(
+      "POST",
+      DEVICE_NOTIFICATION_ACTIONS(deviceToken, notificationUuid),
+      { action }
+    );
+  },
+};

--- a/frontend/test/handlers/device-notifications-handlers.ts
+++ b/frontend/test/handlers/device-notifications-handlers.ts
@@ -38,7 +38,7 @@ export const createMockNotificationView = (
   org_logo_url_light_mode: "https://example.com/fleet-logo-light.png",
   org_logo_url_dark_mode: "https://example.com/fleet-logo-dark.png",
   title: "These apps will close and update in **1 hour**",
-  description: "Save your work.",
+  description: "Save your work 💾",
   items: [
     createMockNotificationItem({
       software_title_id: 1,

--- a/frontend/test/handlers/device-notifications-handlers.ts
+++ b/frontend/test/handlers/device-notifications-handlers.ts
@@ -38,7 +38,7 @@ export const createMockNotificationView = (
   org_logo_url_light_mode: "https://example.com/fleet-logo-light.png",
   org_logo_url_dark_mode: "https://example.com/fleet-logo-dark.png",
   title: "These apps will close and update in **1 hour**",
-  description: "Save your work 💾",
+  description: "Save your work",
   items: [
     createMockNotificationItem({
       software_title_id: 1,

--- a/frontend/test/handlers/device-notifications-handlers.ts
+++ b/frontend/test/handlers/device-notifications-handlers.ts
@@ -1,0 +1,139 @@
+import { http, HttpResponse } from "msw";
+
+import { baseUrl } from "test/test-utils";
+import {
+  INotificationAction,
+  INotificationItem,
+  INotificationView,
+} from "interfaces/device_notification";
+
+const notificationUrl = baseUrl("/device/:token/notifications/:uuid");
+const notificationActionsUrl = baseUrl(
+  "/device/:token/notifications/:uuid/actions"
+);
+
+const HOUR_ACTIONS: INotificationAction[] = [
+  { id: "remind", label: "Remind me in 1 hour" },
+  { id: "update_now", label: "Update now" },
+];
+
+const INSTALLING_ACTIONS: INotificationAction[] = [
+  { id: "dismiss", label: "Hide" },
+];
+
+const createMockNotificationItem = (
+  overrides?: Partial<INotificationItem>
+): INotificationItem => ({
+  software_title_id: 1,
+  name: "1Password 8",
+  display_name: "1Password",
+  icon_url: null,
+  ...overrides,
+});
+
+export const createMockNotificationView = (
+  overrides?: Partial<INotificationView>
+): INotificationView => ({
+  uuid: "notif-uuid-1",
+  org_logo_url_light_mode: "https://example.com/fleet-logo-light.png",
+  org_logo_url_dark_mode: "https://example.com/fleet-logo-dark.png",
+  title: "These apps will close and update in **1 hour**",
+  description: "Save your work.",
+  items: [
+    createMockNotificationItem({
+      software_title_id: 1,
+      name: "1Password 8",
+      display_name: "1Password",
+    }),
+    createMockNotificationItem({
+      software_title_id: 2,
+      name: "Slack",
+      display_name: "Slack",
+    }),
+    createMockNotificationItem({
+      software_title_id: 3,
+      name: "Docker Desktop",
+      display_name: "Docker Desktop",
+    }),
+  ],
+  actions: HOUR_ACTIONS,
+  ...overrides,
+});
+
+/** 20 items — exercises the four-and-a-half-row scroll case. */
+export const createMockScrollingNotificationView = (): INotificationView =>
+  createMockNotificationView({
+    items: Array.from({ length: 20 }, (_, i) =>
+      createMockNotificationItem({
+        software_title_id: i + 1,
+        name: `App ${i + 1}`,
+        display_name: `App ${i + 1}`,
+      })
+    ),
+  });
+
+/** Post-update_now state: items show "Installing…", one Hide action. */
+export const createMockInstallingNotificationView = (): INotificationView =>
+  createMockNotificationView({
+    items: createMockNotificationView().items.map((item) => ({
+      ...item,
+      status: "Installing…",
+    })),
+    actions: INSTALLING_ACTIONS,
+  });
+
+export const defaultDeviceNotificationHandler = http.get(notificationUrl, () =>
+  HttpResponse.json(createMockNotificationView())
+);
+
+export const customDeviceNotificationHandler = (
+  overrides?: Partial<INotificationView>
+) =>
+  http.get(notificationUrl, () =>
+    HttpResponse.json(createMockNotificationView(overrides))
+  );
+
+export const scrollingDeviceNotificationHandler = http.get(
+  notificationUrl,
+  () => HttpResponse.json(createMockScrollingNotificationView())
+);
+
+export const installingDeviceNotificationHandler = http.get(
+  notificationUrl,
+  () => HttpResponse.json(createMockInstallingNotificationView())
+);
+
+export const notFoundDeviceNotificationHandler = http.get(notificationUrl, () =>
+  HttpResponse.json(
+    { errors: [{ name: "base", reason: "Not found" }] },
+    { status: 404 }
+  )
+);
+
+export const errorDeviceNotificationHandler = http.get(notificationUrl, () =>
+  HttpResponse.json(
+    { errors: [{ name: "base", reason: "Internal Server Error" }] },
+    { status: 500 }
+  )
+);
+
+/** POST /actions — echoes the update_now → Installing… transition. */
+export const defaultDeviceNotificationActionHandler = http.post(
+  notificationActionsUrl,
+  async ({ request }) => {
+    const body = (await request.json()) as { action: string };
+    if (body.action === "update_now") {
+      return HttpResponse.json(createMockInstallingNotificationView());
+    }
+    return HttpResponse.json(createMockNotificationView());
+  }
+);
+
+export const errorDeviceNotificationActionHandler = http.post(
+  notificationActionsUrl,
+  () =>
+    HttpResponse.json(
+      { errors: [{ name: "base", reason: "Internal Server Error" }] },
+      { status: 500 }
+    )
+);

--- a/frontend/utilities/endpoints.ts
+++ b/frontend/utilities/endpoints.ts
@@ -78,6 +78,10 @@ export default {
     `/${API_VERSION}/fleet/device/${token}/configuration_profiles/${profileUUID}/resend`,
   DEVICE_BYPASS_CONDITIONAL_ACCESS: (token: string) =>
     `/${API_VERSION}/fleet/device/${token}/bypass_conditional_access`,
+  DEVICE_NOTIFICATION: (token: string, notificationUuid: string) =>
+    `/${API_VERSION}/fleet/device/${token}/notifications/${notificationUuid}`,
+  DEVICE_NOTIFICATION_ACTIONS: (token: string, notificationUuid: string) =>
+    `/${API_VERSION}/fleet/device/${token}/notifications/${notificationUuid}/actions`,
 
   // Chart endpoints
   CHART_DATA: (metric: string) => `/${API_VERSION}/fleet/charts/${metric}`,


### PR DESCRIPTION
## Issue
Closes #50916

## Description
- **Interface + service + MSW**. `INotificationView`, `INotificationItem`, `INotificationAction`, and the WebKit bridge message union in `frontend/interfaces/device_notification.ts`. `getNotification` and `postNotificationAction` in `frontend/services/entities/device_notifications.ts`. Handler fixtures for default 3-item, 20-item scrolling, post-`update_now` Installing… state, 404, and 500 in `frontend/test/handlers/device-notifications-handlers.ts`. Two remaining BE contract assumptions ([documented on #50916](https://github.com/fleetdm/fleet/issues/50916#issuecomment-5295478695)) — flag on the ticket if either needs to change.
- **Standalone route** at `/device/:token/notifications/:uuid`, registered as a sibling to `<Route component={DeviceUserPage}>` so the Fleet Desktop toast doesn't inherit the My device shell.
- **Fleet Desktop bridge utility** — `postBridgeMessage(action, payload?)` in `fleetDesktopBridge.ts`, keyed off a `BRIDGE_VERSION = 1 as const` export. Guards `window.webkit` so the page no-ops safely when opened in a browser during dev. Posts `ready` once on first successful render (unblocks `ToastWindow.loadTimeout`), `resize` on every height change via `ResizeObserver` (initial + list scroll + action swap), `error` on fetch failure, `primary` on primary-action success, `dismiss` on close-action success.
- **Layout matches Figma** (nodes `5546:42302`, `5546:42315`): 32×32 org logo top-right, title + `**bold**` description on the left, Fleet's `<List>` for the item container (dividers + rounded), 32×32 `<SoftwareIcon>` per row with `getDisplayedSoftwareName` + `<TooltipTruncatedText>` for long titles, 4.5-row scroll (half row is the "more below" affordance from the Figma dev note), primary action last, subdued secondaries. All colors and spacing via Fleet SCSS tokens (`$core-fleet-white`, `$ui-fleet-black-*`, `$pad-*`, `$border-radius-*`) and mixins (`@include flex-column-24px-gap`) — dark mode flips automatically through the CSS-variable tokens, matching macOS system appearance rather than Fleet's stored theme.
- **Action wiring** via `useMutation`. Primary POSTs `{action: "update_now"}` → server returns the Installing… view → cache updated in place → `primary` bridge fires and the window stays open. Secondaries POST → `dismiss` bridge fires so the native window closes. In-flight mutation disables both buttons. A failed POST surfaces Fleet's `<DataError singleCustomLine>` inline to the left of the buttons, `margin-right: auto` keeping the buttons right-aligned so the row doesn't shift vertically.
- **`dismiss` id is the authoritative close signal** (not just position). Fixes an edge case where the sole Hide button in the Installing state would otherwise be marked primary because it's positionally last. Rule: `action.id === "dismiss"` always closes; otherwise position-last is the primary CTA.
- **Bold markup**: small inline `**text**` splitter (`renderBoldMarkup`) keeps `react-markdown` out of the toast bundle for one construct.
- **Fetch retries default**: `refetchOnMount` stays at react-query's default (`true`) so a fresh device auth token (rotates every ~30m, toast reopens every ~55m) always drives a fresh fetch — never serves a cached view from a previous open.

## Screenrecording



## Testing

- [x] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually

`yarn test frontend/pages/DeviceNotificationPage` — 14 passing. Coverage: fixture render, bold markup, both logo srcs, ready-once, resize, fetch error paths (404 + 500 both post `error` bridge and render null), primary action → primary bridge + Installing transition, secondary → dismiss bridge, Hide/dismiss id → dismiss (Installing state), action failure → inline `<DataError>` + no wrong bridge, no-throw when `window.webkit` is absent. Dedicated bridge utility tests in `fleetDesktopBridge.tests.ts`.

## Notes
- BE endpoints from #50910 haven't landed yet — page is registered but fetches will 404 in production until then. Fetch failure renders null and posts `error` over the bridge, so Fleet Desktop retries. No user-visible impact from merging early.
- Manual `FleetDesktop notify --url <local URL>` test on a real Mac with Fleet Desktop 1.5.0+ is still owed — will run once #50910 is in and I have real fixtures.
- Local preview during BE wait: point at Marko's placeholder at `my-device-placeholder.vercel.app` (linked from the sub-issue).