### PR TITLE
Website: Homepage bottom CTA: Shorten ticker words, cut back on things

### DIFF
--- a/website/views/pages/homepage.ejs
+++ b/website/views/pages/homepage.ejs
@@ -576,9 +576,8 @@
               <span purpose="bottom-cta-ticker-option">AI governance</span>
               <span purpose="bottom-cta-ticker-option">endpoint modernization</span>
               <span purpose="bottom-cta-ticker-option">patch management</span>
-              <span purpose="bottom-cta-ticker-option">vulnerability management</span>
+              <!--<span purpose="bottom-cta-ticker-option">vulnerability management</span>-->
               <span purpose="bottom-cta-ticker-option">employee experience</span>
-              <span purpose="bottom-cta-ticker-option">new hire automation</span>
               <span purpose="bottom-cta-ticker-option">hardware rightsizing</span>
               <span purpose="bottom-cta-ticker-option">software license savings</span>
               <span purpose="bottom-cta-ticker-option">actual software usage</span>
@@ -593,20 +592,24 @@
               <span purpose="bottom-cta-ticker-option">kernel vulnerabilities</span>
               <!--<span purpose="bottom-cta-ticker-option">detection &amp; response</span>-->
               <span purpose="bottom-cta-ticker-option">endpoint telemetry</span>
-              <!--<span purpose="bottom-cta-ticker-option">real-time visibility</span>-->
-              <span purpose="bottom-cta-ticker-option">policy automation</span>
-              <span purpose="bottom-cta-ticker-option">conditional access</span>
-              <span purpose="bottom-cta-ticker-option">compliance benchmarks</span>
-              <span purpose="bottom-cta-ticker-option">self service</span>
-              <span purpose="bottom-cta-ticker-option">OS updates</span>
+              <span purpose="bottom-cta-ticker-option">real-time visibility</span>
+              <span purpose="bottom-cta-ticker-option">new hire automation</span>
               <span purpose="bottom-cta-ticker-option">zero-touch onboarding</span>
               <span purpose="bottom-cta-ticker-option">Platform SSO</span>
+              <span purpose="bottom-cta-ticker-option">policy automation</span>
+              <!--<span purpose="bottom-cta-ticker-option">conditional access</span>-->
+              <!--<span purpose="bottom-cta-ticker-option">compliance benchmarks</span>-->
+              <span purpose="bottom-cta-ticker-option">OS updates</span>
+              <span purpose="bottom-cta-ticker-option">every OS</span>
+              <span purpose="bottom-cta-ticker-option">every integration</span>
+              <span purpose="bottom-cta-ticker-option">patching 1,000+ apps</span>
+              <span purpose="bottom-cta-ticker-option">self service</span>
               <!--<span purpose="bottom-cta-ticker-option">certificate deployment</span>-->
               <!--<span purpose="bottom-cta-ticker-option">BYOD</span>-->
-              <span purpose="bottom-cta-ticker-option">Windows, Apple, Linux</span>
+              <!--<span purpose="bottom-cta-ticker-option">Windows, Apple, Linux</span>-->
               <span purpose="bottom-cta-ticker-option">DDM &amp; .mobileconfig</span>
               <span purpose="bottom-cta-ticker-option">CSP &amp; .admx</span>
-              <span purpose="bottom-cta-ticker-option">MDM &amp; UEM</span>
+              <span purpose="bottom-cta-ticker-option">MDM, UEM, DEX</span>
               <!-- FUTURE: Consider ticker per-landing page.  so much good stuff in here, but kinda too much for any one place on the website.  Too many concepts rapidly switching in front of my eyes makes me feel like an overstimulated pig in the middle of pep rally -->
             </div>
           </div>

--- a/website/views/pages/homepage.ejs
+++ b/website/views/pages/homepage.ejs
@@ -574,28 +574,40 @@
             <div purpose="option-container" class="pl-2 d-flex flex-column">
               <span purpose="bottom-cta-ticker-option" class="visible">device management</span>
               <span purpose="bottom-cta-ticker-option">AI governance</span>
+              <span purpose="bottom-cta-ticker-option">endpoint modernization</span>
               <span purpose="bottom-cta-ticker-option">patch management</span>
-              <span purpose="bottom-cta-ticker-option">OS updates</span>
-              <span purpose="bottom-cta-ticker-option">Windows, Linux, and Apple</span>
-              <span purpose="bottom-cta-ticker-option">Platform SSO</span>
-              <span purpose="bottom-cta-ticker-option">digital employee experience</span>
-              <span purpose="bottom-cta-ticker-option">self service</span>
-              <span purpose="bottom-cta-ticker-option">zero-touch onboarding</span>
-              <span purpose="bottom-cta-ticker-option">conditional access</span>
-              <span purpose="bottom-cta-ticker-option">shadow IT</span>
-              <span purpose="bottom-cta-ticker-option">shadow AI</span>
-              <span purpose="bottom-cta-ticker-option">BYOD</span>
-              <span purpose="bottom-cta-ticker-option">detection and response</span>
-              <span purpose="bottom-cta-ticker-option">MCPs and IDE extensions</span>
-              <span purpose="bottom-cta-ticker-option">browser plugins</span>
-              <span purpose="bottom-cta-ticker-option">npm and homebrew packages</span>
+              <span purpose="bottom-cta-ticker-option">vulnerability management</span>
+              <span purpose="bottom-cta-ticker-option">employee experience</span>
+              <span purpose="bottom-cta-ticker-option">new hire automation</span>
               <span purpose="bottom-cta-ticker-option">hardware rightsizing</span>
               <span purpose="bottom-cta-ticker-option">software license savings</span>
-              <span purpose="bottom-cta-ticker-option">real-time visibility</span>
-              <span purpose="bottom-cta-ticker-option">security telemetry</span>
-              <span purpose="bottom-cta-ticker-option">compliance benchmarks</span>
+              <span purpose="bottom-cta-ticker-option">actual software usage</span>
+              <!--<span purpose="bottom-cta-ticker-option">license cost savings</span>-->
+              <span purpose="bottom-cta-ticker-option">shadow AI / IT</span>
+              <span purpose="bottom-cta-ticker-option">MCPs &amp; IDE extensions</span>
+              <span purpose="bottom-cta-ticker-option">browser plugins</span>
+              <span purpose="bottom-cta-ticker-option">local agent sessions</span>
+              <!--<span purpose="bottom-cta-ticker-option">Adobe plugins</span>-->
+              <span purpose="bottom-cta-ticker-option">npm, homebrew, etc</span>
+              <span purpose="bottom-cta-ticker-option">critical CVEs</span>
+              <span purpose="bottom-cta-ticker-option">kernel vulnerabilities</span>
+              <!--<span purpose="bottom-cta-ticker-option">detection &amp; response</span>-->
+              <span purpose="bottom-cta-ticker-option">endpoint telemetry</span>
+              <!--<span purpose="bottom-cta-ticker-option">real-time visibility</span>-->
               <span purpose="bottom-cta-ticker-option">policy automation</span>
-              <span purpose="bottom-cta-ticker-option">vulnerability management</span>
+              <span purpose="bottom-cta-ticker-option">conditional access</span>
+              <span purpose="bottom-cta-ticker-option">compliance benchmarks</span>
+              <span purpose="bottom-cta-ticker-option">self service</span>
+              <span purpose="bottom-cta-ticker-option">OS updates</span>
+              <span purpose="bottom-cta-ticker-option">zero-touch onboarding</span>
+              <span purpose="bottom-cta-ticker-option">Platform SSO</span>
+              <!--<span purpose="bottom-cta-ticker-option">certificate deployment</span>-->
+              <!--<span purpose="bottom-cta-ticker-option">BYOD</span>-->
+              <span purpose="bottom-cta-ticker-option">Windows, Apple, Linux</span>
+              <span purpose="bottom-cta-ticker-option">DDM &amp; .mobileconfig</span>
+              <span purpose="bottom-cta-ticker-option">CSP &amp; .admx</span>
+              <span purpose="bottom-cta-ticker-option">MDM &amp; UEM</span>
+              <!-- FUTURE: Consider ticker per-landing page.  so much good stuff in here, but kinda too much for any one place on the website.  Too many concepts rapidly switching in front of my eyes makes me feel like an overstimulated pig in the middle of pep rally -->
             </div>
           </div>
         </h1>


### PR DESCRIPTION
Mostly fixing word length to play nicer on mobile.

Also, it's tempting to make this a mile long, so trying out cutting back


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Content Updates**
  * Expanded the homepage CTA ticker with endpoint, AI, telemetry, vulnerability, platform, onboarding, patching, and device-management terms.
  * Updated terminology for technologies, package ecosystems, detection, compliance, access, BYOD, and operating systems.
  * Refined the ticker’s displayed entries by replacing, renaming, and removing select items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->