### PR TITLE
Coverage info for 'Let's get you set up' calls 

### DIFF
--- a/handbook/company/go-to-market-operations.md
+++ b/handbook/company/go-to-market-operations.md
@@ -328,8 +328,13 @@ Monitor hourly, sorted by Created Date (newest first). No lead untouched > 60 mi
 
 ## "Let's get you set up" calls
 
-"Let's get you set up" calls happen every Friday at 10 AM and 2 PM US Central time. [Dave Siederer](https://www.linkedin.com/in/siederer/) _([@ds0x](https://github.com/ds0x))_ on the Solutions Consulting team is point person for these calls. He will be on these calls as his schedule allows and coordinates coverage when he is unable to attend. Every call includes a Solutions Consultant and a Solutions Specialist.
+"Let's get you set up" calls are open to all (with attendee limits) and happen every Friday at 10 AM and 2 PM US Central time. [Dave Siederer](https://www.linkedin.com/in/siederer/) *([@ds0x](https://github.com/ds0x))* on the Solutions Consulting team is point person for these calls. He will be on these calls as his schedule allows and coordinates coverage when unable to attend. Every call includes a Solutions Consultant and a Solutions Specialist.
 
+### Coverage for "Let's get you set up" calls
+
+When the point person is out of office or otherwise unable to attend, they will arrange coverage by posting in the [#help-solutions-consulting](https://fleetdm.slack.com/archives/C05HZ2LHEL8) Slack channel and `@`-mentioning the Solutions Consultants. Preference is given to available Solutions Consultants during their working hours. 
+
+The Solutions Specialist side of the call coordinates its own coverage within the [Solutions Specialist team](https://fleetdm.com/handbook/company/go-to-market-operations#enterprise).
 
 ## Proof of value (POV)
 


### PR DESCRIPTION
Added coverage details for 'Let's get you set up' calls, clarified attendance and routing when unavailable.