### PR TITLE
Unfreeze Pritunl (darwin)

### DIFF
--- a/ee/maintained-apps/inputs/homebrew/pritunl.json
+++ b/ee/maintained-apps/inputs/homebrew/pritunl.json
@@ -4,6 +4,5 @@
   "token": "pritunl",
   "installer_format": "zip",
   "slug": "pritunl/darwin",
-  "default_categories": ["Productivity"],
-  "frozen": true
+  "default_categories": ["Productivity"]
 }

--- a/ee/maintained-apps/outputs/pritunl/darwin.json
+++ b/ee/maintained-apps/outputs/pritunl/darwin.json
@@ -1,15 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.3.4686.95",
+      "version": "1.3.4696.56",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.pritunl';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.pritunl' AND version_compare(bundle_short_version, '1.3.4686.95') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.pritunl' AND version_compare(bundle_short_version, '1.3.4696.56') < 0);",
+        "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.electron.pritunl');"
       },
-      "installer_url": "https://github.com/pritunl/pritunl-client-electron/releases/download/1.3.4686.95/Pritunl.pkg.zip",
+      "installer_url": "https://github.com/pritunl/pritunl-client-electron/releases/download/1.3.4696.56/Pritunl.pkg.zip",
       "install_script_ref": "d5a06183",
       "uninstall_script_ref": "13c4767e",
-      "sha256": "b991bb63a7820914c4898b4f657753062f2a0ebf7959371ca6d03bd390ec982c",
+      "sha256": "474f3be3103c30624e58ea6d3ad131c488c098f8c5444f59d91ede070cad80c4",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated unfreeze probe. Removes `"frozen": true` and regenerates the output manifest so
`test-fma-darwin-pr-only` can validate `pritunl/darwin` at its current upstream version.

Frozen since: 2026-07-23 (d138998d84, "Update Fleet-maintained apps (#49857)")
Version: 1.3.4686.95 -> 1.3.4696.56

Draft until validation reports. Merge only if the FMA checks are green and the validate shard
actually ran for this slug.

---
_Generated by [Claude Code](https://claude.ai/code/session_01636MYN5nWWXVA4f6sKkhCD)_