### PR TITLE
Website: Update bottom ticker styles on homepage

### DIFF
--- a/website/assets/styles/pages/homepage.less
+++ b/website/assets/styles/pages/homepage.less
@@ -1640,7 +1640,7 @@
     //   font-size: 12px;
     // }
     [purpose='option-container'] {
-      height: 104px;
+      height: 68px;
     }
     [purpose='hero-ticker-option'], [purpose='bottom-cta-ticker-option'] {
       color: #515774;


### PR DESCRIPTION
Changes:
- Reduced the height of the ticker option container on the homepage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the homepage layout on screens up to 375px wide by reducing the ticker option container height.
  * Provides a more compact mobile presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->