### PR TITLE
Restrict dogfood ALB to canonical host (dogfood.fleetdm.com)

### DIFF
--- a/infrastructure/dogfood/terraform/aws-tf-module/main.tf
+++ b/infrastructure/dogfood/terraform/aws-tf-module/main.tf
@@ -390,6 +390,32 @@ module "main" {
       enabled = true
     }
     idle_timeout = 905
+
+    # Only serve requests addressed to the canonical hostname. Any other Host
+    # (raw ALB IP, spoofed Host, scanners) is rejected at the edge with a 403 so
+    # that hostname-scoped WAF rules cannot be bypassed by hitting the load
+    # balancer directly. See fleetdm/confidential#17178.
+    https_listener_rules = [{
+      priority = 100
+      conditions = [{
+        host_headers = ["dogfood.fleetdm.com"]
+      }]
+      actions = [{
+        type               = "forward"
+        target_group_index = 0
+      }]
+    }]
+
+    # Replace the default forward action (which forwards every request regardless
+    # of Host) with a fixed 403. Matching traffic is forwarded by the rule above.
+    https_overrides = {
+      forward = null
+      fixed_response = {
+        content_type = "text/plain"
+        message_body = "Forbidden"
+        status_code  = "403"
+      }
+    }
     #    extra_target_groups = [
     #      {
     #        name             = module.saml_auth_proxy.name

--- a/infrastructure/dogfood/terraform/aws-tf-module/main.tf
+++ b/infrastructure/dogfood/terraform/aws-tf-module/main.tf
@@ -394,28 +394,36 @@ module "main" {
     # Only serve requests addressed to the canonical hostname. Any other Host
     # (raw ALB IP, spoofed Host, scanners) is rejected at the edge with a 403 so
     # that hostname-scoped WAF rules cannot be bypassed by hitting the load
-    # balancer directly. See fleetdm/confidential#17178.
-    https_listener_rules = [{
-      priority = 100
-      conditions = [{
-        host_headers = ["dogfood.fleetdm.com"]
-      }]
-      actions = [{
-        type               = "forward"
-        target_group_index = 0
-      }]
-    }]
-
-    # Replace the default forward action (which forwards every request regardless
-    # of Host) with a fixed 403. Matching traffic is forwarded by the rule above.
-    https_overrides = {
-      forward = null
-      fixed_response = {
-        content_type = "text/plain"
-        message_body = "Forbidden"
-        status_code  = "403"
-      }
-    }
+    # balancer directly.
+    #
+    # This is done with two listener rules rather than by overriding the default
+    # action: the underlying terraform-aws-modules/alb module always emits a
+    # forward default action, so the lower-priority catch-all rule below is what
+    # actually rejects non-canonical traffic (the default action is never hit).
+    https_listener_rules = [
+      {
+        priority = 100
+        conditions = [{
+          host_headers = ["dogfood.fleetdm.com"]
+        }]
+        actions = [{
+          type               = "forward"
+          target_group_index = 0
+        }]
+      },
+      {
+        priority = 200
+        conditions = [{
+          path_patterns = ["/*"]
+        }]
+        actions = [{
+          type         = "fixed-response"
+          content_type = "text/plain"
+          message_body = "Forbidden"
+          status_code  = "403"
+        }]
+      },
+    ]
     #    extra_target_groups = [
     #      {
     #        name             = module.saml_auth_proxy.name


### PR DESCRIPTION
## Problem

`dogfood.fleetdm.com` is an A-alias straight to its ALB, and the ALB's HTTPS listener forwards **every** request to the Fleet target group regardless of `Host`. Verified live: `https://<ALB-IP>/` returns 200 and serves the full Fleet app over the valid ACM cert, and an arbitrary `Host:` header (e.g. `totallybogus.example.com`) also returns 200.

Because the app answers on the raw IP / any Host, hostname-scoped WAF rules can be bypassed by sending traffic directly to the load balancer.

## Fix

In `infrastructure/dogfood/terraform/aws-tf-module/main.tf`, `alb_config.https_listener_rules` gets two rules:

- **priority 100** — `Host == dogfood.fleetdm.com` → forward to the Fleet target group.
- **priority 200** — catch-all (`/*`) → `fixed-response` 403.

The canonical-host rule takes precedence, so non-matching traffic falls through to the 403. The module's default forward action stays in place but is never reached.

> Note: an earlier revision used `https_overrides = { forward = null, ... }` to swap the default action. That does **not** work with `terraform-aws-modules/alb` 9.17.0 — the listener default action is built with `for_each = try([each.value.forward], [])`, so `forward = null` becomes `[null]` and the module still emits a (broken) forward default action. The fleet-terraform wrapper also always sets a forward default action, and `merge()` can't remove it. The two-rule approach avoids touching the default action entirely.

## Why this is safe

- **Agents / MDM / fleetd / fleetctl unaffected** — they connect to `dogfood.fleetdm.com`, match the priority-100 rule, and forward normally. Only wrong-Host traffic gets 403.
- **Health checks unaffected** — ALB target-group health checks hit targets directly, not through the listener.
- **403 is a 4xx, not 5xx** — won't trip the `HTTPCode_ELB_5XX_Count` monitoring alarm.
- **HTTP→HTTPS (port 80) redirect unchanged.**

## Before merging

- [ ] Review `terraform plan`: expect two new `aws_lb_listener_rule` resources and no change to the listener default action.
- [ ] `terraform fmt`/`validate` — could not run locally (terraform not installed in authoring env).
- [ ] After apply, confirm: on a raw ALB IP, `curl -sk -H 'Host: bogus' https://<IP>/ -o /dev/null -w '%{http_code}'` returns 403, and normal browser + agent access still works.