### PR TITLE
Handbook: update AI code review options (remove Claude, add Qodo)

### DIFF
--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -168,9 +168,7 @@ Fleet uses AI code review tools to supplement human review on pull requests. Thr
 
 1. **GitHub Copilot**: Automatically reviews every PR for contributors with a Copilot seat. No action needed.
 2. **CodeRabbit**: Available for free as an open source project. To request a review, add a comment on the PR: `@coderabbitai full review`.
-3. **Claude**: A more thorough review that takes about 30 minutes and costs $20–$25 per review. Claude often finds issues the other AI reviews miss. Use this option judiciously given the cost.
-
-> **Tip:** When requesting a Claude review, use `@claude review once` instead of `@claude review`. There is currently no way to stop a Claude review once started, and each run takes ~45 minutes. Using `@claude review` causes it to re-run on every new commit (including minor or stale changes), leading to unnecessary long-running review cycles and added cost.
+3. **Qodo**: Available for free as an open source project. Qodo does not review PRs automatically. To request a review, add a comment on the PR: `/agentic_review`.
 
 
 #### AI coding tools


### PR DESCRIPTION
## Details

The engineering handbook's "AI code review" section listed Claude as a review option, but Claude PR review has been disabled. Meanwhile, Qodo review is available (configured in `.pr_agent.toml` since #43668) but was undocumented.

This PR:
- Removes the Claude review option and the `@claude review once` tip
- Adds Qodo, noting it doesn't run automatically and is triggered by commenting `/agentic_review` on a PR (verified against recent PRs, e.g. #51005)

🤖 Generated with [Claude Code](https://claude.com/claude-code)