### PR TITLE
Website: Track new key events for signups

### DIFF
--- a/website/api/controllers/entrance/signup.js
+++ b/website/api/controllers/entrance/signup.js
@@ -138,10 +138,11 @@ the account verification message.)`,
       return { employer: undefined, person: undefined};
     });
 
-
+    let isIcpUser = false;
     let fleetPremiumTrialType = 'local trial';
     if(enrichmentInformation.employer && enrichmentInformation.employer.numberOfEmployees > 700) {
       fleetPremiumTrialType = 'render trial';
+      isIcpUser = true;
     }//ﬁ
 
     if(emailDomain === 'fleetdm.com') {
@@ -279,7 +280,9 @@ the account verification message.)`,
     } else {
       sails.log.info('Skipping new account email verification... (since `verifyEmailAddresses` is disabled)');
     }
-    return;
+    return {
+      isIcpUser
+    };
 
   }
 

--- a/website/assets/js/pages/entrance/login.page.js
+++ b/website/assets/js/pages/entrance/login.page.js
@@ -95,7 +95,7 @@ parasails.registerPage('login', {
       }
     },
 
-    submittedSignupForm: async function(){
+    submittedSignupForm: async function(cloudResponse){
       this.syncing = true;
       // Track a "key event" in Google Analytics.
       // > Naming convention:  (like sails config)
@@ -108,6 +108,14 @@ parasails.registerPage('login', {
           'value': 1.0,
           'currency': 'USD'
         });
+        // Track a second key event depending the type of Fleet Premium trial they received.
+        if(cloudResponse.isIcpUser) {
+          // For users with a hosted Render trial
+          window.gtag('event','fleet_website__sign_up__icp');
+        } else {
+          // For users with a local Fleet Premium trial.
+          window.gtag('event','fleet_website__sign_up__non_icp');
+        }
       }
 
       // Track a "conversion" in LinkedIn Campaign Manager.

--- a/website/views/pages/entrance/login.ejs
+++ b/website/views/pages/entrance/login.ejs
@@ -360,7 +360,7 @@
               I don't have an account
             </label>
           </div>
-          <ajax-form action="signup" purpose="modal-form" class="self-service-register" :syncing.sync="syncing" :cloud-error.sync="cloudError" :form-errors.sync="signupFormErrors" :form-data="signupFormData" :form-rules="signupFormRules" @submitted="submittedSignupForm()" v-if="formToDisplay === 'signup'">
+          <ajax-form action="signup" purpose="modal-form" class="self-service-register" :syncing.sync="syncing" :cloud-error.sync="cloudError" :form-errors.sync="signupFormErrors" :form-data="signupFormData" :form-rules="signupFormRules" @submitted="submittedSignupForm($event)" v-if="formToDisplay === 'signup'">
             <div class="form-group">
               <label purpose="modal-form-label" for="email-address">Work email *</label>
               <input tabindex="1" purpose="modal-form-input" class="form-control" id="email-address"  :class="[signupFormErrors.emailAddress ? 'is-invalid' : '']" v-model.trim="signupFormData.emailAddress" @input="typeClearOneFormError('emailAddress')">


### PR DESCRIPTION
Changes:
- Updated the register & login page's page script to track a new event when users create a new account (`fleet_website__sign_up__icp` or `fleet_website__sign_up__non_icp`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Signup now identifies whether an account qualifies for an ICP or non-ICP Fleet Premium trial based on employer size.
  * Signup results now include trial eligibility information for improved post-signup handling.
* **Analytics**
  * Signup tracking now records which Fleet Premium trial type was assigned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->