### PR TITLE
Fix enrolled hosts chart including pending hosts in platform counts

### DIFF
--- a/changes/48880-enrolled-hosts-pending
+++ b/changes/48880-enrolled-hosts-pending
@@ -1,1 +1,1 @@
-Fixed "Enrolled hosts" chart on the Hosts page to exclude pending hosts from per-platform counts.
+Fixed "Hosts enrolled" chart on the dashboard page to exclude pending hosts from per-platform counts.

--- a/changes/48880-enrolled-hosts-pending
+++ b/changes/48880-enrolled-hosts-pending
@@ -1,0 +1,1 @@
+Fixed "Enrolled hosts" chart on the Hosts page to exclude pending hosts from per-platform counts.

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -2240,9 +2240,10 @@ func (ds *Datastore) GenerateHostStatusStatistics(ctx context.Context, filter fl
 			  COUNT(*) total,
 			  h.platform
 			FROM hosts h
-			WHERE %s
+			%s
+			WHERE %s AND (hmdm.enrollment_status IS NULL OR hmdm.enrollment_status != 'Pending')
 			GROUP BY h.platform
-		`, whereClause)
+		`, hostMdmJoin, whereClause)
 
 	var platforms []*fleet.HostSummaryPlatform
 	stmt, args, err = sqlx.In(sqlStatement, args...)

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -3673,8 +3673,8 @@ func testHostsGenerateStatusStatisticsPlatformBreakdownExcludesPending(t *testin
 
 	// Create one enrolled darwin host.
 	enrolledHost, err := ds.NewHost(ctx, &fleet.Host{
-		OsqueryHostID:   ptr.String("plat-enrolled-1"),
-		NodeKey:         ptr.String("plat-enrolled-key-1"),
+		OsqueryHostID:   new("plat-enrolled-1"),
+		NodeKey:         new("plat-enrolled-key-1"),
 		DetailUpdatedAt: now,
 		LabelUpdatedAt:  now,
 		PolicyUpdatedAt: now,
@@ -3689,8 +3689,8 @@ func testHostsGenerateStatusStatisticsPlatformBreakdownExcludesPending(t *testin
 
 	// Create one pending darwin host.
 	pendingHost, err := ds.NewHost(ctx, &fleet.Host{
-		OsqueryHostID:   ptr.String("plat-pending-1"),
-		NodeKey:         ptr.String("plat-pending-key-1"),
+		OsqueryHostID:   new("plat-pending-1"),
+		NodeKey:         new("plat-pending-key-1"),
 		DetailUpdatedAt: now,
 		LabelUpdatedAt:  now,
 		PolicyUpdatedAt: now,
@@ -3705,8 +3705,8 @@ func testHostsGenerateStatusStatisticsPlatformBreakdownExcludesPending(t *testin
 
 	// Create one host with no MDM data (should always be counted).
 	_, err = ds.NewHost(ctx, &fleet.Host{
-		OsqueryHostID:   ptr.String("plat-nomdm-1"),
-		NodeKey:         ptr.String("plat-nomdm-key-1"),
+		OsqueryHostID:   new("plat-nomdm-1"),
+		NodeKey:         new("plat-nomdm-key-1"),
 		DetailUpdatedAt: now,
 		LabelUpdatedAt:  now,
 		PolicyUpdatedAt: now,

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -106,6 +106,7 @@ func TestHosts(t *testing.T) {
 		{"GenerateStatusStatisticsABMPendingExclusion", testHostsGenerateStatusStatisticsABMPendingExclusion},
 		{"GenerateStatusStatisticsDEPErrors", testHostsGenerateStatusStatisticsDEPErrors},
 		{"GenerateStatusStatisticsDeletedDEPAssignment", testHostsGenerateStatusStatisticsDeletedDEPAssignment},
+		{"GenerateStatusStatisticsPlatformBreakdownExcludesPending", testHostsGenerateStatusStatisticsPlatformBreakdownExcludesPending},
 		{"LowDiskSpaceFilterExcludesSentinel", testHostsLowDiskSpaceFilterExcludesSentinel},
 		{"MarkSeen", testHostsMarkSeen},
 		{"MarkSeenMany", testHostsMarkSeenMany},
@@ -3652,6 +3653,85 @@ func testHostsGenerateStatusStatisticsDeletedDEPAssignment(t *testing.T, ds *Dat
 	require.NoError(t, err)
 	assert.Equal(t, uint(3), summary.TotalsHostsCount)
 	assert.Equal(t, summary.TotalsHostsCount, platformSum(summary))
+}
+
+// testHostsGenerateStatusStatisticsPlatformBreakdownExcludesPending is a regression test for #48880:
+// the per-platform breakdown query did not exclude pending hosts, causing the "Enrolled hosts" chart
+// to include hosts that hadn't actually enrolled yet.
+func testHostsGenerateStatusStatisticsPlatformBreakdownExcludesPending(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+	filter := fleet.TeamFilter{User: test.UserAdmin}
+	now := time.Now()
+
+	platformSum := func(s *fleet.HostSummary) uint {
+		var total uint
+		for _, p := range s.Platforms {
+			total += p.HostsCount
+		}
+		return total
+	}
+
+	// Create one enrolled darwin host.
+	enrolledHost, err := ds.NewHost(ctx, &fleet.Host{
+		OsqueryHostID:   ptr.String("plat-enrolled-1"),
+		NodeKey:         ptr.String("plat-enrolled-key-1"),
+		DetailUpdatedAt: now,
+		LabelUpdatedAt:  now,
+		PolicyUpdatedAt: now,
+		SeenTime:        now,
+		Platform:        "darwin",
+	})
+	require.NoError(t, err)
+
+	// Mark it as enrolled via MDM (On (automatic)).
+	err = ds.SetOrUpdateMDMData(ctx, enrolledHost.ID, false, true, "https://fleet.example.com", true, fleet.WellKnownMDMFleet, "", false)
+	require.NoError(t, err)
+
+	// Create one pending darwin host.
+	pendingHost, err := ds.NewHost(ctx, &fleet.Host{
+		OsqueryHostID:   ptr.String("plat-pending-1"),
+		NodeKey:         ptr.String("plat-pending-key-1"),
+		DetailUpdatedAt: now,
+		LabelUpdatedAt:  now,
+		PolicyUpdatedAt: now,
+		SeenTime:        now,
+		Platform:        "darwin",
+	})
+	require.NoError(t, err)
+
+	// Mark it as pending (enrolled=false, installed_from_dep=true => Pending).
+	err = ds.SetOrUpdateMDMData(ctx, pendingHost.ID, false, false, "https://fleet.example.com", true, fleet.WellKnownMDMFleet, "", false)
+	require.NoError(t, err)
+
+	// Create one host with no MDM data (should always be counted).
+	_, err = ds.NewHost(ctx, &fleet.Host{
+		OsqueryHostID:   ptr.String("plat-nomdm-1"),
+		NodeKey:         ptr.String("plat-nomdm-key-1"),
+		DetailUpdatedAt: now,
+		LabelUpdatedAt:  now,
+		PolicyUpdatedAt: now,
+		SeenTime:        now,
+		Platform:        "windows",
+	})
+	require.NoError(t, err)
+
+	summary, err := ds.GenerateHostStatusStatistics(ctx, filter, now, nil, nil)
+	require.NoError(t, err)
+
+	// Total count includes ALL hosts (including pending) -- this is intentional per product decision.
+	assert.Equal(t, uint(3), summary.TotalsHostsCount, "total should include pending hosts")
+
+	// Platform breakdown should EXCLUDE pending hosts.
+	// Expected: darwin=1 (only the enrolled host), windows=1 (no MDM data, counted).
+	assert.Equal(t, uint(2), platformSum(summary), "platform breakdown should exclude pending hosts")
+
+	// Verify individual platform counts.
+	platformCounts := make(map[string]uint)
+	for _, p := range summary.Platforms {
+		platformCounts[p.Platform] = p.HostsCount
+	}
+	assert.Equal(t, uint(1), platformCounts["darwin"], "darwin platform count should exclude pending host")
+	assert.Equal(t, uint(1), platformCounts["windows"], "windows platform count should include host with no MDM data")
 }
 
 func testHostsMarkSeen(t *testing.T, ds *Datastore) {


### PR DESCRIPTION
**Related issue:** Resolves https://github.com/fleetdm/fleet/issues/48880

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results

---

## What

The "Enrolled hosts" chart on the Hosts page was incorrectly including pending hosts in its per-platform counts (macOS, Windows, etc.).

## Why

In `GenerateHostStatusStatistics()`, the summary stats query (total/mia/missing counts) correctly joins `host_mdm` and filters out `enrollment_status = 'Pending'`. However, the **platform breakdown query** (which feeds the "Enrolled hosts" chart) did a simple `COUNT(*)` from `hosts` grouped by platform with no pending filter.

## Fix

Added `LEFT JOIN host_mdm` and `WHERE (hmdm.enrollment_status IS NULL OR hmdm.enrollment_status != 'Pending')` to the platform breakdown query, matching the pattern already used by the summary stats query in the same function.

The `total` host count intentionally still includes pending hosts (per product decision).

## Impact analysis

`GenerateHostStatusStatistics()` has a single caller: the `GET /api/latest/fleet/host_summary` endpoint (via `countHostsEndpoint` -> `svc.CountHosts` -> `ds.GenerateHostStatusStatistics`). No other code path uses this function. The change only affects the `Platforms` field in the `HostSummary` response; the `TotalsHostsCount` field remains unchanged and still includes pending hosts.

## Reproduction

Reproduced locally against a test MySQL instance by creating hosts with mixed enrollment statuses and running both the buggy and fixed SQL queries side-by-side:

```sql
-- Setup: 5 macOS hosts (3 enrolled, 2 pending), 3 Windows (2 enrolled, 1 pending), 2 Linux (no MDM)

-- BUGGY (old) platform breakdown: counts all hosts including pending
SELECT COUNT(*) total, h.platform FROM hosts h GROUP BY h.platform;
-- Result: darwin=5, windows=3, linux=2

-- FIXED platform breakdown: excludes pending hosts
SELECT COUNT(*) total, h.platform
FROM hosts h
LEFT JOIN host_mdm hmdm ON h.id = hmdm.host_id
WHERE (hmdm.enrollment_status IS NULL OR hmdm.enrollment_status != 'Pending')
GROUP BY h.platform;
-- Result: darwin=3, windows=2, linux=2
```

After applying the fix, re-running the same test data confirmed the platform counts correctly exclude pending hosts while the total still includes them.

## Testing performed

- All 6 existing `GenerateStatusStatistics*` integration tests pass (no regressions)
- Added a new regression test (`TestHosts/GenerateStatusStatisticsPlatformBreakdownExcludesPending`) that:
  - Creates 3 hosts: 1 enrolled darwin, 1 pending darwin, 1 windows with no MDM data
  - Verifies `TotalsHostsCount` is 3 (includes pending)
  - Verifies platform breakdown sum is 2 (excludes pending)
  - Verifies darwin=1, windows=1 in per-platform counts

## QA test plan

1. Set up a Fleet instance with MDM enabled
2. Enroll hosts via ADE (automatic enrollment) so some remain in "Pending" status
3. Navigate to the **Hosts** page and view the "Enrolled hosts" chart
4. Hover over a platform (e.g., macOS) to see its host count
5. **Verify:** Pending hosts are NOT included in the per-platform counts
6. **Verify:** Drilling into the filtered list also excludes pending hosts
7. **Verify:** The "Total hosts" card still includes pending hosts (this is intentional)
8. **Verify:** Hosts with no MDM data (e.g., Linux/osquery-only) are still counted normally
9. **Verify:** When pending hosts exist, the "Total hosts" count will be higher than the sum of the per-platform counts in the "Enrolled hosts" chart. This is expected and correct, since "Total hosts" includes pending while the chart does not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the “Enrolled hosts” chart to exclude hosts with pending MDM enrollment from platform-specific counts.
  * Ensured platform breakdowns accurately reflect enrolled and MDM-unmanaged hosts while preserving overall host totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->