### PR TITLE
Windows: Match Intune's behavior of deferring user profiles until use…

### DIFF
--- a/openspec/changes/defer-windows-user-scoped-profiles/.openspec.yaml
+++ b/openspec/changes/defer-windows-user-scoped-profiles/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-14

--- a/openspec/changes/defer-windows-user-scoped-profiles/design.md
+++ b/openspec/changes/defer-windows-user-scoped-profiles/design.md
@@ -1,0 +1,167 @@
+## Context
+
+Fleet has no notion of channel scope for Windows profiles. Unlike Apple profiles, which carry `fleet.PayloadScopeUser`, a Windows profile is just SyncML, and `ReconcileWindowsProfiles` enqueues it for every applicable host as soon as it exists. Whether its LocURIs target `./Device/` or `./User/` never enters the decision.
+
+On Windows there is no separate user session to wait for. Per [MS-MDM], the OMA-DM client normally runs a "mixed" session in which the server may send both device and user settings in one exchange (only AVD splits device and user sessions). So the gate cannot be "wait for a user-context connection to arrive"; it has to be a per-session read of what the device reports.
+
+Windows reports it two ways, both at the start of each session (DM package #1):
+
+1. Generic alert `1224` with `<Type>com.microsoft/MDM/LoginStatus</Type>`, values `user`, `others`, `none`. Microsoft documents this under the heading "Determine when a user is logged in through polling".
+2. Alert `1224` with type `com.microsoft/MDM/AADUserToken`, plus an `Authorization: Bearer <Entra user token>` HTTP header. Microsoft's instruction to MDM vendors is explicit: "The management server should check if the token is missing and only send device policies in such case."
+
+Fleet already receives the first signal and throws it away. `processIncomingAlertsCommands` switches on `1201`, `1200`, and `1226`; `syncml.CmdAlertClientEvent = "1224"` is defined but never handled. Fleet's own test client already emits `LoginStatus=user` (`pkg/mdm/mdmtest/windows.go`), and it resends the same body with credentials after the auth challenge, so the alert is present in the trusted message where pending commands are built.
+
+Fleet also never persists the message that carries the alert. `ShouldBeTracked` returns false when `CmdRef` is `"0"`, so a message containing only alerts plus a SyncHdr status has `HasCommands() == false` and `MDMWindowsSaveResponse` is skipped. Any durable record of user context has to be written deliberately.
+
+Two enrollment-level signals separate the paths, and the Autopilot run shows they agree. `enroll_type` is `Device` for Entra join during OOBE and `Full` for programmatic fleetd enrollment. `enroll_user_id` is a real UPN for the former and the orbit node key for the latter. This design keys on UPN-ness through the existing `microsoft_mdm.IsValidUPN` helper, already used at two call sites, because it answers the question that matters directly: whether an MDM user identity can ever be bound to this enrollment. `enroll_type` corroborates but describes the enrollment flavor rather than the user context.
+
+An earlier draft of this design claimed `EnrollmentType` is always `Full` and therefore useless. That was an artifact of the dev database, whose 2412 rows are all programmatic enrollments. The Autopilot measurement disproves it. The conclusion (do not gate on `enroll_type`) stands, but for a different reason than originally written.
+
+### Verified on hardware, Autopilot
+
+Measured 2026-08-14 on a user-driven Autopilot enrollment with Entra join during OOBE, Windows 11 Pro 25H2 build 10.0.26200.8038, capturing all 112 raw SyncML messages across 9 sessions:
+
+- **The LoginStatus alert is sent, in every session.** It appears in MsgID 1 and MsgID 2, and not in MsgID 3. Fleet answers MsgID 1 with a challenge, and the device repeats every alert in the authenticated MsgID 2, so the value is readable inside Fleet's normal authenticated path with no change to the challenge short-circuit.
+- **The OOBE value is `others`, not `none`.** During ESP the signed-in account is `defaultuser0`, which is a signed-in user with no MDM account. The value flips to `user` when the Entra user's profile becomes active. A gate keyed on `none`, or on the alert being absent, would never engage.
+- The transition was 63 seconds after the enrollment session, on a session Windows opened unprompted carrying alert `1201`.
+- The `AADUserToken` alert and the `Authorization: Bearer` header were absent for all 31 messages of the OOBE session and present from the next session onward, both carrying the same 2063 byte token. Either signal would work; LoginStatus is preferred (see D2).
+- `enroll_type` was `Device` and `enroll_user_id` was a real UPN. `not_in_oobe` stayed `0` for hours after the device reached the desktop, so it is not usable as a user-context signal.
+- A user-scoped `Replace` on a Pro-supported node returned **200** once user context was present, alongside device-scoped controls that also returned 200.
+
+Two results from that run need care:
+
+- A user-scoped write was **never attempted during the `others` window** on this run, so the status code a `./User/` write receives on an Entra enrollment before sign-in is still unmeasured. The customer report and the non-Entra run below are the evidence that it fails.
+- A user-scoped `Replace` on `Experience/AllowWindowsSpotlight` returned **405 with user context present and an Entra token on the wire**. That node is documented unsupported on Windows Pro, so it is read-only regardless of who is signed in. A 405 is therefore not proof of missing user context. See D5.
+
+### Verified on hardware, non-Entra
+
+Measured on the `bl-fix-test` Azure VM on 2026-08-14, against the local dev server over the `meeple.top` tunnel:
+
+- A user-scoped SCEP profile produced exactly the reported signature: root node `Add` returns **500**, all 8 sibling `Add`s and the `Exec` return **216** (atomic rollback OK), and the enclosing `Atomic` returns **507**.
+- It failed with an interactive user signed in. `quser` showed the local account `fleetadmin` active on the console. So the failure is not "no user is logged in"; it is "no MDM user identity is bound to this enrollment".
+- The device is genuinely non-Entra: `dsregcmd /status` reports `AzureAdJoined: NO`, `DomainJoined: NO`, `WorkplaceJoined: NO`, and the enrollment registry key has an empty `UPN` with `EnrollmentType: 0`.
+- The device-side CSP `License check` and `CSP Allow check` for `./User/Vendor/MSFT/ClientCertificateInstall/SCEP` both succeed, so the rejection happens at node creation in the user tree, not at CSP permission.
+- The retry was consumed **26 seconds** after the first attempt, with an identical status signature. Both attempts are stored in `windows_mdm_responses` (ids 565702 and 565703).
+- The `DeviceManagement-Enterprise-Diagnostics-Provider/Debug` channel logs function traces and CSP operations, not SyncML bodies, so it cannot confirm whether this device emits the `1224` LoginStatus alert.
+
+The consequence that shapes this design: on an enrollment with no bound MDM user identity, a user-scoped write fails permanently. Holding such a profile would strand it in Pending forever, and exempting it from the retry counter would resend it forever.
+
+### When the hold actually engages
+
+The Autopilot run did not reproduce the bug, and the reason is structural rather than luck. Fleet cannot queue profiles for a Windows host until the enrollment is linked to a host record, and on an Entra-join enrollment that linkage waits for fleetd. On the measured run the enrollment was created unlinked at 23:35:33, fleetd enrolled and linked the host at 23:36:38, and LoginStatus flipped to `user` in that same second. The window in which profiles were queue-eligible but user context was missing had zero width.
+
+So the failure in #50196 requires linkage to **precede** user context. Three ways that happens:
+
+1. The host record already exists in Fleet, so the reverse link resolves immediately instead of waiting for a fresh fleetd enrollment. Re-enrollment and any device Fleet has seen before fall here.
+2. A slower ESP, or any delay between linkage and sign-in.
+3. A self-deploying or pre-provisioning Autopilot flow, where no user signs in at all. This is also the only flow that exercises the `none` value.
+
+This narrows where the bug bites without weakening the fix. The hold is cheap, it engages only in the situations that produce the failure, and case 3 is a state the current code has no answer for at all: profiles queued against a device that will never have a user.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A user-scoped profile assigned before first sign-in on an Autopilot or Entra-join-during-OOBE host delivers automatically on the first session that reports a user context, instead of failing terminally.
+- No retry budget is spent on a condition that has not had a chance to change.
+- Where a user-scoped profile can never be delivered, the host reports an actionable reason instead of a raw SyncML status code, and Fleet stops resending.
+- Device-scoped profile behavior is byte-for-byte unchanged.
+
+**Non-Goals:**
+
+- Userless Windows enrollment (story #48931). That is the reason a programmatic enrollment has no bound user identity, and fixing it is a separate client-side change.
+- Splitting a mixed-scope profile so its device half can deliver early.
+- Consuming the Entra user token. It arrives in an HTTP header, and `SyncMLReqMsgContainer.DecodeBody` receives only the body, query parameters, and client certificates.
+- Changing the ESP user-scope release path (`handleESPUserReleaseRetry`), which solves the same problem for one specific node and keeps its current behavior.
+
+## Decisions
+
+### D1: Model three user-context states, keyed on whether a user context can ever arrive
+
+| State | How Fleet decides | Behavior for user-scoped profiles |
+| --- | --- | --- |
+| Present | the current or a prior session reported `LoginStatus=user` | deliver normally |
+| Can arrive | `enroll_user_id` is a valid UPN and `user` has not been observed | hold, do not spend retries |
+| Cannot arrive | `enroll_user_id` is not a valid UPN, so no MDM user identity is bound | fail fast with an explanatory detail, do not resend |
+
+**Release only on `user`.** The "can arrive" state covers three distinct observations that all mean the same thing operationally: `others` (someone is signed in without an MDM account, which is what OOBE reports), `none` (nobody is signed in), and no observation recorded yet. The Autopilot run makes this concrete: the value during ESP is `others`, so a gate that engaged only on `none` would never fire on the exact flow the issue is about, and a gate that engaged only when the alert is missing would never fire at all.
+
+Rationale: the non-Entra run proves "cannot arrive" is a real and permanent state, so a single hold-everything rule is wrong. Separating the two waiting cases is what keeps Pending honest and keeps the retry exemption from becoming an infinite resend loop.
+
+Alternatives considered:
+
+- Hold on every enrollment until `LoginStatus=user`. Rejected: on a non-Entra host the alert may never report `user`, leaving the profile Pending forever with no explanation. Silent and worse than today's failure.
+- Keep sending and retrying everywhere (status quo). Rejected: wastes the retry budget in 26 seconds and reports opaque 500/507 to admins.
+- Gate on the MS-MDE2 `EnrollmentType` context item. Rejected: always `Full`, so it cannot separate Entra-join-during-OOBE from fleetd enrollment.
+
+### D2: Read LoginStatus from the SyncML body, not the Authorization header
+
+Handling alert `1224` in `processIncomingAlertsCommands` needs no plumbing, and the existing test client already produces it, so both states are drivable in integration tests today. The header route would require threading `http.Header` into the SyncML decoder for every management request.
+
+The Autopilot run confirms both signals track user context identically, so this is a choice between two working options rather than a bet. LoginStatus wins on three counts: it is a three-state value that distinguishes "no MDM user" from "wrong user" where token presence is only a boolean, it needs no header plumbing, and it keeps a bearer token off a code path that logs.
+
+The alert is read from the authenticated message. The device repeats its alerts in MsgID 2 after Fleet's challenge, so the existing early return on the challenge path stays as it is.
+
+### D3: Persist the observed user-context state on `mdm_windows_enrollments`
+
+The alert appears only in DM package #1, later messages in the same session do not repeat it, Fleet does not persist the message that carries it, and the reconciler cron runs outside any session. A column is the only place all three readers can agree on. Store the last observed value and its timestamp so the value can be interpreted (and so a stale observation is visible in debugging).
+
+### D4: Hold at enqueue time in the reconciler, not at send time
+
+The reconciler consults the persisted state and does not enqueue a held profile, leaving the profile row Pending with a detail explaining what is being waited on and no command UUID.
+
+Rationale: the command queue stays free of commands that are known to be undeliverable, which avoids interacting with the `has_pending_commands` flag accounting and the poll-schedule relaxation logic in `getManagementResponse`. Convergence is fast regardless: Fleet already provisions `AllUsersPollOnFirstLogin = true`, so Windows starts a session at first sign-in, that session persists the new state, and the 30 second profile cron enqueues on its next tick.
+
+The Autopilot run confirms the convergence assumption. Windows opened a session unprompted 63 seconds after the enrollment session, carrying alert `1201` and the flipped LoginStatus, with nothing pushed from the server. Worst-case added latency after sign-in is therefore that session plus one cron tick.
+
+Alternative considered: filter user-scoped commands out of `getPendingMDMCmds` so the same session that reports `LoginStatus=user` ships them immediately. Rejected for now because it leaves undeliverable rows queued and complicates the per-session `has_pending_commands` refresh, for a saving of at most one cron interval.
+
+### D5: Let the state carry the retry exemption, not the status code
+
+A rejection of a user-scoped command skips the `retries` increment in `MDMWindowsSaveResponse` **only while the enrollment is in the "can arrive" state**. In the "present" and "cannot arrive" states the normal accounting applies, and "cannot arrive" is failed fast before a command is ever sent.
+
+The state is what carries this decision, not the status code, because no status code reliably means "user context is missing". The evidence now spans three codes with three different causes:
+
+| Code | Observed | Cause |
+| --- | --- | --- |
+| 500 | non-Entra device, SCEP root node `Add` | no MDM user identity bound |
+| 405 | ESP user-scope release during OOBE | user MDM context not yet initialized |
+| 405 | Autopilot device, `AllowWindowsSpotlight`, **user context present** | node unsupported on Windows Pro |
+
+A rule keyed on "405 or 500 on a user-scoped LocURI" would misread that third row as a user-context problem and exempt a genuinely unsupported node from retry accounting. Gating on state instead bounds the damage: an unsupported node in the "can arrive" window gets its retries deferred rather than forgiven, and normal accounting resumes the moment `user` is observed.
+
+This must not disturb the existing nested-418 resend path. The non-Entra VM shows a SCEP `Atomic` legitimately returning 507 because a nested `Add` returned 418 (already exists), which `handleResendingAlreadyExistsCommands` converts into a `Replace` and which then reaches Verified. A 507 on the `Atomic` is therefore not by itself evidence of a user-context problem either; the nested per-LocURI statuses are what distinguish the two.
+
+### D6: Classify scope with the same normalization the delivery path uses
+
+Derive scope from `ExtractLocURIsFromProfileBytes` over the `WrapSCEPProfileInAtomic`-normalized bytes, and treat a profile as user-scoped if any canonicalized target resolves under `./User/`. Persist the result on the profile row and backfill existing rows in the migration, so the reconciler does not re-parse XML and the API can expose scope later.
+
+Rationale: a raw `strings.HasPrefix("./User/")` is bypassable. Scope-less spellings exist, and CDATA, comments, and nested elements can split LocURI text, which is the parser differential fixed in PR #49715 and the reserved-node canonicalization work in #48752. Classification and delivery must not be able to disagree.
+
+## Risks / Trade-offs
+
+- **Classification and delivery disagree, so a profile classified device-scoped ships a `./User/` write** → classify using the same normalization and parser as delivery, and add a property test that asserts every profile whose delivered SyncML contains a canonicalized `./User/` target is classified user-scoped.
+- **A held profile sits in Pending forever because the device never reports a user context** → the Autopilot run retires this for user-driven flows: the alert arrives in every session and flips to `user` 63 seconds after enrollment. It remains live for self-deploying and pre-provisioning Autopilot, where no user ever signs in and the value should read `none`. Those hosts are exactly the ones whose user-scoped profiles cannot be delivered, so Pending with an explanatory detail is the honest state, but it needs a decision on whether a hold that never releases should eventually surface as a failure.
+- **An unsupported CSP node is mistaken for missing user context** → the state gate, not the status code, controls the exemption (D5). A node that is unsupported on the device SKU returns 405 with user context present, which the "present" state routes to normal accounting.
+- **The retry exemption becomes an infinite resend** → the exemption is scoped to the waiting state (D5); the terminal path for "cannot arrive" fails fast and does not resend.
+- **UPN-ness of `enroll_user_id` is an imperfect proxy for a bound MDM user identity** → now measured on both sides: the non-Entra enrollment stored an orbit node key with an empty registry `UPN` and failed permanently, and the Autopilot enrollment stored a real UPN and succeeded once user context arrived. `enroll_type` (`Full` versus `Device`) agrees with the proxy on both paths and is available as a cross-check.
+- **Mixed-scope profiles hold their device settings too** → accepted and documented. It matches the all-or-nothing semantics `WrapSCEPProfileInAtomic` already imposes, and splitting would break the atomicity SCEP profiles depend on.
+- **Pending is overloaded** → a held profile is Pending for a reason an admin cannot guess, so the detail message carries the explanation. Whether this deserves a distinct UI state is an open question.
+- **ESP interaction** → none intended. The ESP hold blocks on software install failures only, and its own user-scope release retry is untouched.
+
+## Migration Plan
+
+1. Migration adds the user-context columns to `mdm_windows_enrollments` and the scope column to `mdm_windows_configuration_profiles`, then backfills scope for existing profiles.
+2. Deploy is additive. A NULL user-context observation reads as "never observed", which reproduces current behavior, so a partially rolled out fleet behaves as it does today until each enrollment reports in.
+3. Rollback is a code revert; the columns can stay. No profile state is destroyed, and held profiles are Pending rather than Failed, so a revert resends them normally.
+
+## Open Questions
+
+Answered by the Autopilot run on 2026-08-14: the alert is emitted in every session, in MsgID 1 and MsgID 2, with `others` during OOBE and `user` once the Entra user's profile is active.
+
+Still open:
+
+- **What status does a `./User/` write get on an Entra enrollment during the `others` window?** The measured run never attempted one, because linkage and user context arrived in the same second. The customer report and the non-Entra 500 are the evidence that it fails, but the code on that exact path is unmeasured. Reproducing it needs one of the three linkage-before-user-context cases above.
+- **Does a self-deploying or pre-provisioning Autopilot flow report `none`, and does it ever flip?** This is the only flow that exercises `none`, and it is the one where a hold could legitimately never release.
+- **Should a hold that will never release eventually become a failure?** For a device that never gets a user, Pending is honest but silent. A deadline that converts the hold into an explanatory failure would trade one imperfect state for another, and the choice depends on the answer to the previous question.
+- Should a held profile surface a distinct state in the UI and API rather than Pending plus a detail string?

--- a/openspec/changes/defer-windows-user-scoped-profiles/proposal.md
+++ b/openspec/changes/defer-windows-user-scoped-profiles/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+Fleet queues Windows user-scoped profiles (`./User/Vendor/MSFT/...`) as soon as they apply to a host, without checking whether the device has an MDM user context yet. During Autopilot and Entra-join-during-OOBE there is no MDM user context, so the write fails, the enclosing `Atomic` rolls back, and the profile lands terminally Failed. It is never re-sent after the user signs in, even though the same write would then succeed. This blocks user-channel SCEP certificates for VPN client auth and IdP device attestation (issue #50196, customer-thumper).
+
+The single automatic retry does not help. It is consumed against the identical condition seconds later, so both attempts fail the same way and the retry budget is spent before a user could possibly appear. Measured on hardware, the two attempts were 26 seconds apart with identical status codes.
+
+The window is narrower than it first appears, which scopes the fix rather than weakening it. Profiles only become eligible once the enrollment is linked to a host record, and on a first-time Autopilot enrollment that linkage waits for fleetd, which in a measured run landed in the same second as first sign-in. The failure needs linkage to precede user context: a device Fleet has already seen, a slower ESP, or a self-deploying flow where nobody signs in at all.
+
+## What Changes
+
+- Fleet reads the OMA-DM generic alert `1224` with type `com.microsoft/MDM/LoginStatus` from each management session and persists the reported user-context state on the enrollment. Fleet already receives this alert and silently discards it.
+- Windows profiles gain a notion of channel scope, derived from their canonicalized `Add`/`Replace` LocURIs. A profile is user-scoped if any of its targets resolve to `./User/`.
+- User-scoped profiles are **held** (left Pending, not enqueued) on enrollments where an MDM user context can still arrive, and are delivered automatically on the first session that reports one.
+- User-scoped profiles **fail fast with an explanatory message** on enrollments that have no bound MDM user identity, where the write can never succeed. Today these retry once and then report raw SyncML status codes with no explanation.
+- A user-context rejection no longer consumes the profile's retry budget while Fleet is holding and waiting for a user context.
+- Mixed-scope profiles (both `./Device/` and `./User/` targets) are held or failed as a unit, matching the all-or-nothing semantics that `WrapSCEPProfileInAtomic` already imposes.
+- Documentation states which enrollment types support user-channel profiles and what Pending means for them.
+
+No API or schema-breaking changes. The observable behavior change is that a user-scoped profile which previously went to Failed within a minute of OOBE enrollment now stays Pending until first sign-in, then reports Verified.
+
+## Capabilities
+
+### New Capabilities
+
+- `windows-user-scoped-profiles`: how Fleet classifies Windows profiles by channel scope, how it learns the device's MDM user context from the OMA-DM session, and the delivery, hold, failure, and retry-accounting rules that follow from it.
+
+### Modified Capabilities
+
+None. `openspec/specs/` has no accepted specs yet, so there are no existing requirements to amend.
+
+## Impact
+
+Affected code:
+
+- `server/service/microsoft_mdm.go`: `processIncomingAlertsCommands` (add the `1224` case), `getPendingMDMCmds` (hold user-scoped commands), `ReconcileWindowsProfiles` and `executeWindowsProfileReconcileBatch` (scope-aware enqueue).
+- `server/fleet/windows_mdm.go` and `server/fleet/microsoft_mdm.go`: scope classification built on the existing LocURI canonicalization helpers.
+- `server/datastore/mysql/microsoft_mdm.go`: retry accounting in `MDMWindowsSaveResponse` (the `MaxWindowsProfileRetries` branch), plus persistence of the observed user-context state.
+- New migration: user-context columns on `mdm_windows_enrollments`.
+- `server/mdm/microsoft/syncml/syncml.go`: alert type constant for `com.microsoft/MDM/LoginStatus`.
+
+Affected behavior and surfaces:
+
+- Host details and profile summaries show Pending (not Failed) for held profiles, with a detail message explaining what is being waited on.
+- Windows Autopilot and Entra-join-during-OOBE flows. The Enrollment Status Page is unaffected: it already holds only on software install failures, and its own user-scope release path (`handleESPUserReleaseRetry`) keeps its existing behavior.
+
+Docs to update: `articles/custom-os-settings.md`, `articles/creating-windows-csps.md`, `docs/Contributing/architecture/mdm/windows-mdm-architecture.md`, and the header comment in `docs/solutions/windows/configuration-profiles/install Okta attestation certificate - [Bundle].xml`.
+
+Not in scope: userless Windows enrollment (story #48931), which would let a programmatic enrollment bind a user identity and is the separate reason user-channel profiles cannot work on that path today.

--- a/openspec/changes/defer-windows-user-scoped-profiles/specs/windows-user-scoped-profiles/spec.md
+++ b/openspec/changes/defer-windows-user-scoped-profiles/specs/windows-user-scoped-profiles/spec.md
@@ -1,0 +1,158 @@
+## ADDED Requirements
+
+### Requirement: Windows profile channel scope classification
+
+Fleet SHALL classify every Windows configuration profile as device-scoped or user-scoped, derived from the canonicalized `Add` and `Replace` target LocURIs of the SyncML that Fleet actually delivers. A profile whose delivered SyncML contains at least one target resolving under `./User/` SHALL be classified user-scoped. Classification MUST use the same normalization and parser as the delivery path, so that classification and delivery cannot disagree.
+
+#### Scenario: Profile with only device targets
+
+- **WHEN** a profile's targets all resolve under `./Device/` or the scope-less `./Vendor/MSFT/` form
+- **THEN** Fleet classifies the profile as device-scoped
+
+#### Scenario: Profile with a user target
+
+- **WHEN** a profile contains at least one target resolving under `./User/`
+- **THEN** Fleet classifies the profile as user-scoped
+
+#### Scenario: Scope-less and obfuscated spellings cannot bypass classification
+
+- **WHEN** a profile expresses a `./User/` target using a spelling that the raw string form does not match literally, such as text split by CDATA sections, comments, or nested elements
+- **THEN** Fleet still classifies the profile as user-scoped, because classification operates on the same canonicalized LocURIs the delivery path produces
+
+#### Scenario: SCEP profiles are classified after atomic normalization
+
+- **WHEN** a SCEP profile is classified
+- **THEN** classification operates on the same atomic-wrapped bytes that delivery sends, so the nested commands inside the generated `Atomic` are inspected
+
+### Requirement: Observing the device's MDM user context
+
+Fleet SHALL read the OMA-DM generic alert `1224` carrying alert type `com.microsoft/MDM/LoginStatus` from incoming management sessions, and SHALL persist the reported value and its observation time on the enrollment. Fleet MUST treat an enrollment with no recorded observation as "never observed" rather than as an absence of user context.
+
+#### Scenario: Session reports an MDM user is signed in
+
+- **WHEN** a management session carries alert `1224` with type `com.microsoft/MDM/LoginStatus` and data `user`
+- **THEN** Fleet records the enrollment's user context as present, with the observation time
+
+#### Scenario: Session reports no active user
+
+- **WHEN** a management session carries alert `1224` with type `com.microsoft/MDM/LoginStatus` and data `none`
+- **THEN** Fleet records the enrollment's user context as absent, with the observation time
+
+#### Scenario: Session reports a signed-in user without an MDM account
+
+- **WHEN** a management session carries alert `1224` with type `com.microsoft/MDM/LoginStatus` and data `others`
+- **THEN** Fleet records that value, and MUST NOT treat it as user context present
+
+#### Scenario: Alert absent from the session
+
+- **WHEN** a management session carries no `com.microsoft/MDM/LoginStatus` alert
+- **THEN** Fleet leaves any previously recorded observation unchanged and does not record a new one
+
+#### Scenario: Alert arrives in the message that Fleet does not otherwise persist
+
+- **WHEN** the alert arrives in a message whose only status references the SyncML header, which Fleet does not store as a response
+- **THEN** Fleet still records the observed user context, because the record is written independently of response persistence
+
+#### Scenario: Alert is repeated in the authenticated message
+
+- **WHEN** Fleet answers a session's first message with an authentication challenge, and the device repeats its alerts in the following authenticated message
+- **THEN** Fleet records the observed user context from the authenticated message, and MUST NOT require alert processing on the unauthenticated challenge path
+
+### Requirement: Deferring user-scoped profiles when a user context can still arrive
+
+For an enrollment that has a bound MDM user identity and has not reported `user`, Fleet SHALL hold user-scoped profiles rather than delivering them. A held profile SHALL report status Pending with a detail explaining that Fleet is waiting for a user to sign in, and Fleet MUST NOT enqueue a command for it. Only a reported value of `user` SHALL release the hold: `others`, `none`, and the absence of any observation all keep the profile held. When a session subsequently reports `user`, Fleet SHALL deliver the held profile without operator action.
+
+#### Scenario: User-scoped profile assigned during OOBE
+
+- **WHEN** a user-scoped profile applies to a host whose enrollment has a UPN-backed user identity and whose latest session reported `others`, which is the value Windows reports during OOBE while the setup account is signed in
+- **THEN** Fleet does not enqueue the profile, and the profile reports Pending with a detail explaining that it is waiting for first sign-in
+
+#### Scenario: No user is signed in at all
+
+- **WHEN** the enrollment has a UPN-backed user identity and its latest session reported `none`
+- **THEN** Fleet holds the profile on the same terms as the `others` case
+
+#### Scenario: Enrollment has not reported yet
+
+- **WHEN** the enrollment has a UPN-backed user identity and no observation has been recorded
+- **THEN** Fleet holds the profile, because the hold releases on a positive `user` report rather than on the absence of a contrary one
+
+#### Scenario: Held profile delivers after first sign-in
+
+- **WHEN** a held user-scoped profile's enrollment reports user context present in a later session
+- **THEN** Fleet enqueues the profile on the next reconcile and the profile proceeds through the normal delivery and verification path
+
+#### Scenario: Host with user context present is not delayed
+
+- **WHEN** a user-scoped profile applies to a host whose enrollment has already reported user context present
+- **THEN** Fleet enqueues the profile immediately, with no hold
+
+### Requirement: Failing user-scoped profiles when no user identity is bound
+
+For an enrollment with no bound MDM user identity, where a user-scoped write can never succeed, Fleet SHALL fail the profile with an explanatory detail instead of holding it or resending it. Fleet MUST NOT leave such a profile Pending indefinitely, and MUST NOT resend it on subsequent reconciles.
+
+#### Scenario: User-scoped profile on an enrollment with no user identity
+
+- **WHEN** a user-scoped profile applies to a host whose enrollment has no bound MDM user identity, such as a programmatic fleetd enrollment
+- **THEN** the profile reports Failed with a detail stating that user-channel profiles require an enrollment that carries a user identity
+
+#### Scenario: Failure is not retried
+
+- **WHEN** a user-scoped profile has failed because the enrollment has no bound user identity
+- **THEN** Fleet does not resend the profile on subsequent reconciles, and the failure does not oscillate between Pending and Failed
+
+### Requirement: Retry accounting for user-context rejections
+
+A rejection of a user-scoped command SHALL NOT consume a profile's retry budget while Fleet is waiting for a user context that can still arrive. In all other states the existing retry accounting applies unchanged. The enrollment's user-context state, not the returned status code, SHALL determine whether the exemption applies, because no status code reliably indicates missing user context: 405 is returned both for a user-scope write before user context initializes and for a CSP node that is unsupported on the device's Windows edition. Fleet MUST also distinguish a rejection from an unrelated atomic rollback by examining the per-LocURI statuses rather than the enclosing `Atomic` status alone.
+
+#### Scenario: Pre-sign-in rejection does not spend a retry
+
+- **WHEN** a user-scoped profile is rejected with a user-context status such as 500 or 405 on its user-scoped LocURI, and the enrollment has a bound user identity with no observed user context
+- **THEN** the profile returns to Pending and its retry count is unchanged
+
+#### Scenario: Atomic rollback caused by an already-existing node still retries normally
+
+- **WHEN** a profile's `Atomic` returns 507 because a nested `Add` returned 418 while sibling commands returned 216
+- **THEN** Fleet applies its existing already-exists resend path and normal retry accounting, because the nested statuses show this is not a user-context rejection
+
+#### Scenario: Rejection after user context is present spends a retry
+
+- **WHEN** a user-scoped profile is rejected after the enrollment has reported user context present
+- **THEN** the existing retry accounting applies and the profile reaches Failed after the configured maximum retries
+
+#### Scenario: Unsupported CSP node is not mistaken for missing user context
+
+- **WHEN** a user-scoped profile targets a node that is unsupported on the device's Windows edition and is rejected with 405 while the enrollment has reported `user`
+- **THEN** normal retry accounting applies and the profile reaches Failed, because the exemption is keyed on the enrollment's state rather than on the 405 status
+
+### Requirement: Mixed-scope profiles are held or failed as a unit
+
+A profile containing both device-scoped and user-scoped targets SHALL be treated as user-scoped for delivery purposes. Fleet MUST NOT deliver its device-scoped portion separately.
+
+#### Scenario: Mixed-scope profile held before sign-in
+
+- **WHEN** a profile contains both `./Device/` and `./User/` targets and the enrollment has no observed user context but a bound user identity
+- **THEN** the whole profile is held, and none of its commands are enqueued
+
+#### Scenario: Mixed-scope profile delivered whole after sign-in
+
+- **WHEN** a held mixed-scope profile's enrollment reports user context present
+- **THEN** the whole profile is delivered in one command, preserving the atomicity its SCEP portion depends on
+
+### Requirement: Device-scoped profile delivery is unchanged
+
+Fleet SHALL deliver device-scoped profiles exactly as it does today, with no dependency on user context.
+
+#### Scenario: Device-scoped profile during OOBE
+
+- **WHEN** a device-scoped profile applies to a host whose enrollment has no observed user context
+- **THEN** Fleet enqueues and delivers it immediately, with unchanged status and retry behavior
+
+### Requirement: Documented user-channel support
+
+Fleet's documentation SHALL state which enrollment types support user-channel Windows profiles, that user-scoped profiles remain Pending until a user signs in on enrollments where user context can still arrive, and that they fail with an explanatory reason on enrollments with no bound user identity.
+
+#### Scenario: Administrator reads the custom settings documentation
+
+- **WHEN** an administrator consults the Windows custom settings documentation before assigning a `./User/` profile
+- **THEN** the documentation states the enrollment requirement, the Pending-until-sign-in behavior, and the mixed-scope hold rule

--- a/openspec/changes/defer-windows-user-scoped-profiles/tasks.md
+++ b/openspec/changes/defer-windows-user-scoped-profiles/tasks.md
@@ -1,0 +1,69 @@
+## 1. Scope classification
+
+- [ ] 1.1 Add a scope type and classifier in `server/fleet/` that returns device or user scope for Windows profile bytes, built on `ExtractLocURIsFromProfileBytes` over `WrapSCEPProfileInAtomic`-normalized bytes, treating any canonicalized target under `./User/` as user-scoped.
+- [ ] 1.2 Unit test the classifier against device-only, user-only, and mixed profiles, plus the obfuscation cases that motivated PR #49715: LocURI text split by CDATA, comments, and nested elements, and the scope-less `./Vendor/MSFT/` spelling.
+- [ ] 1.3 Create the migration with `make migration name=AddWindowsProfileScopeAndUserContext` adding a scope column to `mdm_windows_configuration_profiles` and the observed user-context value plus timestamp to `mdm_windows_enrollments`.
+- [ ] 1.4 Backfill the scope column for existing profiles in the migration Up function, using the same classifier, and add a migration test covering device, user, and mixed rows.
+- [ ] 1.5 Set the scope column on the profile create and update paths so newly saved profiles carry it, and confirm the batch and GitOps entry points are both covered.
+
+## 2. Observing user context from the OMA-DM session
+
+- [ ] 2.1 Add the `com.microsoft/MDM/LoginStatus` alert type constant and the `user`, `others`, `none` value constants to `server/mdm/microsoft/syncml/syncml.go`.
+- [ ] 2.2 Handle `syncml.CmdAlertClientEvent` ("1224") in `processIncomingAlertsCommands` and route LoginStatus items to a new handler; leave other 1224 alert types as no-ops. Read the alert from the authenticated message: the device repeats every alert in MsgID 2 after Fleet's challenge, so the early return on the challenge path stays as it is.
+- [ ] 2.3 Add the datastore method that persists the observed value and timestamp on the enrollment, and run `go test ./server/service/` afterwards so uninitialized mocks do not crash other tests.
+- [ ] 2.4 Ensure the observation is recorded even when the message is not otherwise persisted, since `ShouldBeTracked` returns false for a SyncHdr-only status and `MDMWindowsSaveResponse` is skipped for that message.
+- [ ] 2.5 Unit test the alert handler for each value, for a missing alert (previous observation preserved), and for a malformed alert item.
+
+## 3. Delivery gating in the reconciler
+
+- [ ] 3.1 Add a helper that resolves an enrollment's user-context state to present, can-arrive, or cannot-arrive, using the persisted observation and `microsoft_mdm.IsValidUPN(enroll_user_id)`.
+- [ ] 3.2 In the Windows profile reconcile path, skip enqueueing user-scoped profiles for can-arrive enrollments, keeping the profile row Pending with a detail explaining that Fleet is waiting for first sign-in and no command UUID.
+- [ ] 3.3 Verify the held row shape does not confuse the install and remove delta queries or `ReconcileWindowsProfilesStatus`, so a held profile is not treated as stuck or as needing a resend loop.
+- [ ] 3.4 Fail user-scoped profiles fast for cannot-arrive enrollments, with a detail stating that user-channel profiles require an enrollment carrying a user identity, and ensure the reconciler does not re-enqueue them on later ticks.
+- [ ] 3.5 Treat mixed-scope profiles as user-scoped throughout, so they hold or fail as a unit.
+- [ ] 3.6 Confirm device-scoped enqueue behavior is untouched by diffing reconciler behavior for a device-only profile set before and after the change.
+
+## 4. Retry accounting
+
+- [ ] 4.1 In `MDMWindowsSaveResponse`, skip the `retries` increment for a user-context rejection when the enrollment is in the can-arrive state, keeping existing accounting for all other states.
+- [ ] 4.2 Key the exemption on the enrollment's user-context state, not on the returned status code. A 405 means "user context not initialized" during OOBE and "node unsupported on this Windows edition" with a user signed in, so the code alone cannot carry the decision. Use per-LocURI statuses only to tell a rejection apart from an unrelated `Atomic` 507 rollback.
+- [ ] 4.3 Add a regression test proving the nested-418 path still works: a SCEP `Atomic` returning 507 with a nested `Add` 418 and sibling 216s must still go through `handleResendingAlreadyExistsCommands` and normal retry accounting.
+- [ ] 4.4 Add a test proving no resend loop exists in the cannot-arrive state.
+
+## 5. Integration tests
+
+- [ ] 5.1 Extend the Windows MDM test client so the LoginStatus alert value is settable per session; it already emits `user` in `pkg/mdm/mdmtest/windows.go`, so add `none` and `others` and the ability to omit the alert.
+- [ ] 5.2 Integration test the full defer-then-deliver flow: assign a user-scoped profile with no user context, assert Pending with the hold detail and no queued command, then report `LoginStatus=user` and assert the profile delivers and verifies.
+- [ ] 5.3 Integration test the cannot-arrive path: a non-UPN enrollment reports Failed with the explanatory detail and no repeated sends.
+- [ ] 5.4 Integration test that a device-scoped profile delivers normally in all three user-context states.
+- [ ] 5.5 Add a property test asserting that any profile whose delivered SyncML contains a canonicalized `./User/` target is classified user-scoped, alongside the existing Windows reconcile property tests.
+
+## 6. Hardware verification
+
+The 2026-08-14 Autopilot capture already answered whether the alert is emitted (yes, every session, MsgID 1 and 2, `others` during OOBE and `user` after sign-in), so the remaining runs are about the paths it did not exercise.
+
+- [ ] 6.1 Reproduce the bug itself, which the first Autopilot run did not: linkage must precede user context. Easiest case is a device whose host record already exists in Fleet so the reverse link resolves without waiting for a fresh fleetd enrollment. Capture the status a `./User/` write receives during the `others` window, which is still unmeasured on an Entra enrollment.
+- [ ] 6.2 Verify the fix end to end on that same setup: the profile stays Pending through OOBE with the hold detail, then delivers on first sign-in without operator action.
+- [ ] 6.3 Run a self-deploying or pre-provisioning Autopilot flow, where no user ever signs in. Confirm LoginStatus reports `none`, and decide from the result whether a hold that never releases should eventually convert into an explanatory failure.
+- [ ] 6.4 Re-run the `bl-fix-test` non-Entra case and confirm the new behavior is a fast, explanatory failure rather than the current 500, 507, one wasted retry sequence. Baseline for comparison: responses 565702 and 565703 in the dev database, 26 seconds apart, identical signature.
+- [ ] 6.5 For any user-scope test profile, use a node that is supported on the device's Windows edition. `Experience/AllowWindowsSpotlight` is unsupported on Pro and returns 405 regardless of user context; `Experience/AllowTailoredExperiencesWithDiagnosticData` is user-scoped and Pro-supported and was verified working.
+
+## 7. Separate issues found during measurement
+
+Neither belongs in this change, but both were found by the Autopilot capture and should be filed so they are not lost.
+
+- [ ] 7.1 File an issue: `docs/solutions/windows/configuration-profiles/disable Windows Spotlight features – [AllowWindowsSpotlight].xml` targets a node Microsoft documents as unsupported on Windows Pro. On Pro it returns 405, burns its single retry about 90 seconds later, and lands terminally Failed with no explanation. Fleet ships this profile as a recommended solution.
+- [ ] 7.2 File an issue: during ESP, one session ran 31 messages in roughly 100 seconds, with messages 3 onward repeating an identical bundle of two `Add=418` and six `Replace=200` every few hundred milliseconds. That is `handleResendingAlreadyExistsCommands` re-issuing commands the device had already acknowledged. It resolved on its own, and task 4.3 must not regress it further.
+
+## 8. Documentation and release notes
+
+- [ ] 8.1 Document the behavior in `articles/custom-os-settings.md` and `articles/creating-windows-csps.md`: which enrollment types support user-channel profiles, Pending until first sign-in, and the mixed-scope hold rule.
+- [ ] 8.2 Document the gate and where it sits in the management session in `docs/Contributing/architecture/mdm/windows-mdm-architecture.md`.
+- [ ] 8.3 Add a note to the header comment of `docs/solutions/windows/configuration-profiles/install Okta attestation certificate - [Bundle].xml`, since that profile is the one customers hit this with.
+- [ ] 8.4 Add a `changes/` entry describing the fix for the release notes.
+
+## 9. Gates
+
+- [ ] 9.1 Run `make lint-go-incremental` and fix findings.
+- [ ] 9.2 Run the affected suites: `go test ./server/fleet/...`, `MYSQL_TEST=1 go test ./server/datastore/mysql/...`, and `MYSQL_TEST=1 REDIS_TEST=1 go test ./server/service/...`.
+- [ ] 9.3 Run `make lint-go` before opening the PR, and build the PR description from `.github/pull_request_template.md`.


### PR DESCRIPTION
…r context is available

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #50196 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an OpenSpec configuration using the `spec-driven` schema.
  * Recorded the configuration creation date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->