### PR TITLE
Force rebuild of entire migration order sequence on fix

### DIFF
--- a/tools/migration-cleanup/CHANGELOG.md
+++ b/tools/migration-cleanup/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 2026-08-15
+
+- Replace the minimal id-shift SQL with a full rebuild of row ids into version
+  order (rebase above `MAX(id)`, then compact to `1..N`). This fixes down-moves
+  whose remapped rows sit at the table tail (the shift offset previously
+  computed to NULL and silently no-opped), supports up-moves and down-moves in
+  the same scope (previously collapsed into a single direction), and removes
+  the stale `AUTO_INCREMENT` collision risk after shifts.
+- Process rename commits oldest-first so chained renames (A -> B in one
+  commit, B -> C in a later one) resolve rows to the terminal version ID
+  instead of an intermediate one.
+- Rewrite the dry-run simulator to mirror the generated SQL exactly
+  (sequential remaps, dedup, sort-and-renumber) and report how many ordering
+  violations the rebuild fixes.
+
 ## 2026-08-07
 
 - Add `--since-commit <ref>` to scan `main` from a given commit forward.

--- a/tools/migration-cleanup/README.md
+++ b/tools/migration-cleanup/README.md
@@ -165,7 +165,7 @@ Found 11 migration renumber(s):
 ```
 
 The dry run for the broken local database reported the real duplicate row and
-the id rebuild the generated SQL would perform:
+the id rebuild that the generated SQL would perform:
 
 ```text
 migration_status_tables: duplicate version_id=20260522195224; would keep id=518, delete ids=[530]

--- a/tools/migration-cleanup/README.md
+++ b/tools/migration-cleanup/README.md
@@ -165,12 +165,11 @@ Found 11 migration renumber(s):
 ```
 
 The dry run for the broken local database reported the real duplicate row and
-the id shifts the generated SQL would perform:
+the id rebuild the generated SQL would perform:
 
 ```text
 migration_status_tables: duplicate version_id=20260522195224; would keep id=518, delete ids=[530]
-migration_status_tables: would make space by shifting 0 row(s) after version_id=20260522195235 by +12
-migration_status_tables: would shift 11 row(s) by +12
+migration_status_tables: would renumber 530 row id(s) into version order, fixing 11 ordering violation(s)
 Dry-run: SQL will apply cleanly.
 ```
 
@@ -194,11 +193,17 @@ Found 2 migration renumber(s):
   [tables] 20250918154557 -> 20250817154557
 ```
 
-For this shape, the generated SQL remaps those version IDs, removes duplicate
-status rows if present, computes the id increment from the current table state,
-and shifts affected rows with `ORDER BY id DESC`. The generated "make space"
-update may affect zero rows; that is expected when there are no later rows to
-move.
+For every shape, the generated SQL remaps the version IDs (in commit order, so
+chained renames resolve to the terminal ID), removes duplicate status rows if
+present, and then rebuilds every row id into version order: rows are first
+rebased above the current `MAX(id)` (collision-free in any update order) and
+then compacted down to ids `1..N`. Rebuilding the total order instead of
+computing a minimal shift handles moves up, moves down, mixed batches, and
+rows stranded at the table tail identically, and the SQL derives everything it
+needs (`MAX(id)`, `ROW_NUMBER()`) at execution time, so the same script is
+correct for any table state. Compaction keeps the final ids below the table's
+`AUTO_INCREMENT` counter, so future migration inserts cannot collide with
+moved rows.
 
 ## Notes
 

--- a/tools/migration-cleanup/main.go
+++ b/tools/migration-cleanup/main.go
@@ -7,10 +7,12 @@ import (
 	"fmt"
 	"log"
 	"log/slog"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -640,7 +642,7 @@ func buildSQL(tableName string, renames []migrationRename) []string {
 	// not advance, so future goose inserts cannot collide with shifted rows.
 	lines = append(lines,
 		fmt.Sprintf("SELECT MAX(id) INTO @rebase_%s FROM `%s`;", tableName, tableName),
-		fmt.Sprintf("CREATE TEMPORARY TABLE `_fix_order_%s` (id BIGINT UNSIGNED, rn BIGINT UNSIGNED);", tableName),
+		fmt.Sprintf("CREATE TEMPORARY TABLE `_fix_order_%s` (id BIGINT UNSIGNED PRIMARY KEY, rn BIGINT UNSIGNED);", tableName),
 		fmt.Sprintf("INSERT INTO `_fix_order_%s` (id, rn) SELECT id, ROW_NUMBER() OVER (ORDER BY version_id ASC, id ASC) FROM `%s`;", tableName, tableName),
 		fmt.Sprintf("UPDATE `%s` t JOIN `_fix_order_%s` o ON t.id = o.id SET t.id = @rebase_%s + o.rn;", tableName, tableName, tableName),
 		fmt.Sprintf("UPDATE `%s` t JOIN `_fix_order_%s` o ON t.id = @rebase_%s + o.rn SET t.id = o.rn;", tableName, tableName, tableName),
@@ -744,7 +746,8 @@ func simulateTableSQL(tableName string, rows []tableRow, renames []migrationRena
 		byVID[row.VersionID] = append(byVID[row.VersionID], row)
 	}
 	simulated = simulated[:0]
-	for vid, vidRows := range byVID {
+	for _, vid := range slices.Sorted(maps.Keys(byVID)) {
+		vidRows := byVID[vid]
 		sort.Slice(vidRows, func(i, j int) bool { return vidRows[i].ID < vidRows[j].ID })
 		keep := vidRows[0]
 		simulated = append(simulated, keep)
@@ -764,10 +767,14 @@ func simulateTableSQL(tableName string, rows []tableRow, renames []migrationRena
 		}
 		return simulated[i].ID < simulated[j].ID
 	})
+	renumbered := 0
 	for i := range simulated {
-		simulated[i].ID = int64(i + 1)
+		if simulated[i].ID != int64(i+1) {
+			renumbered++
+			simulated[i].ID = int64(i + 1)
+		}
 	}
-	messages = append(messages, fmt.Sprintf("  %s: would renumber %d row id(s) into version order, fixing %d ordering violation(s)", tableName, len(simulated), violations))
+	messages = append(messages, fmt.Sprintf("  %s: would renumber %d row id(s) into version order, fixing %d ordering violation(s)", tableName, renumbered, violations))
 	return simulated, messages, issues
 }
 

--- a/tools/migration-cleanup/main.go
+++ b/tools/migration-cleanup/main.go
@@ -58,11 +58,6 @@ type tableRow struct {
 	IsApplied bool  `db:"is_applied"`
 }
 
-type sqlStatements struct {
-	tableName           string
-	versionIDRemappings [][2]int64
-}
-
 type options struct {
 	checkout    string
 	branch      string
@@ -497,9 +492,11 @@ func getMergeBase(checkout, branch string) (string, error) {
 }
 
 // findRenameCommits returns commit SHAs in mergeBase..branch that contain
-// renames in the migration directories.
+// renames in the migration directories, oldest first. Commit order matters:
+// applying chained renames (A -> B in one commit, B -> C in a later one)
+// oldest-first moves rows through the chain to the terminal version ID.
 func findRenameCommits(checkout, branch, mergeBase string) ([]string, error) {
-	args := []string{"log", "-M", "--diff-filter=R", "--format=%H", mergeBase + ".." + branch, "--"}
+	args := []string{"log", "--reverse", "-M", "--diff-filter=R", "--format=%H", mergeBase + ".." + branch, "--"}
 	args = append(args, migrationDirs...)
 	out, err := git(checkout, args...)
 	if err != nil {
@@ -609,27 +606,21 @@ func generateStatementGroups(renames []migrationRename) map[string][]string {
 		if len(tableRenames) == 0 {
 			continue
 		}
-		stmts := computeSQLForTable(item.table, tableRenames)
-		groups[item.table] = buildSQL(item.table, stmts, tableRenames)
+		groups[item.table] = buildSQL(item.table, tableRenames)
 	}
 	return groups
 }
 
-// computeSQLForTable builds the version ID remapping statements for a table.
-func computeSQLForTable(tableName string, renames []migrationRename) sqlStatements {
-	stmts := sqlStatements{tableName: tableName}
-	for _, r := range renames {
-		stmts.versionIDRemappings = append(stmts.versionIDRemappings, [2]int64{r.oldVersionID, r.newVersionID})
-	}
-	return stmts
-}
-
-// buildSQL generates the full SQL for a table: version remaps, dedup cleanup,
-// and ID shifts to maintain ordering.
-func buildSQL(tableName string, stmts sqlStatements, renames []migrationRename) []string {
+// buildSQL generates the full SQL for a table: version remaps (in commit
+// order, so chained renames resolve to the terminal version ID), duplicate
+// cleanup, and a full rebuild of row ids into version order. Rebuilding the
+// total order instead of computing a minimal shift handles every renumber
+// shape identically: moves up, moves down, mixed batches in one scope, and
+// remapped rows stranded at the table tail.
+func buildSQL(tableName string, renames []migrationRename) []string {
 	lines := make([]string, 0)
-	for _, pair := range stmts.versionIDRemappings {
-		lines = append(lines, fmt.Sprintf("UPDATE `%s` SET version_id = %d WHERE version_id = %d;", tableName, pair[1], pair[0]))
+	for _, r := range renames {
+		lines = append(lines, fmt.Sprintf("UPDATE `%s` SET version_id = %d WHERE version_id = %d;", tableName, r.newVersionID, r.oldVersionID))
 	}
 	if len(renames) == 0 {
 		return lines
@@ -642,44 +633,18 @@ func buildSQL(tableName string, stmts sqlStatements, renames []migrationRename) 
 		fmt.Sprintf("DROP TEMPORARY TABLE `_fix_dups_%s`;", tableName),
 	)
 
-	minNewVID, maxNewVID := renames[0].newVersionID, renames[0].newVersionID
-	movesUp := false
-	for _, r := range renames {
-		if r.newVersionID < minNewVID {
-			minNewVID = r.newVersionID
-		}
-		if r.newVersionID > maxNewVID {
-			maxNewVID = r.newVersionID
-		}
-		if r.newVersionID > r.oldVersionID {
-			movesUp = true
-		}
-	}
-
-	varName := "increment_by_" + tableName
-	if !movesUp {
-		varName += "_shift"
-	}
-	maxMovedVar := "max_moved_down_" + tableName
-
-	lines = append(lines, fmt.Sprintf("SELECT (SELECT MAX(id) FROM `%s` WHERE id > (SELECT id FROM `%s` WHERE version_id = %d)) - (SELECT id FROM `%s` WHERE version_id = %d) + 1 INTO @%s;", tableName, tableName, maxNewVID, tableName, minNewVID, varName))
-
-	targetIDVar := "target_id_" + tableName
-	var whereClause string
-	if movesUp {
-		whereClause = fmt.Sprintf("WHERE version_id BETWEEN %d AND %d", minNewVID, maxNewVID)
-		lines = append(lines, fmt.Sprintf("SELECT %d INTO @%s;", maxNewVID, maxMovedVar))
-	} else {
-		// Extract the target row's id into a variable first so we don't reference
-		// the same table in a subquery inside an UPDATE (MySQL doesn't allow that).
-		lines = append(lines, fmt.Sprintf("SELECT id INTO @%s FROM `%s` WHERE version_id = %d;", targetIDVar, tableName, minNewVID))
-		whereClause = fmt.Sprintf("WHERE id < @%s AND version_id > %d", targetIDVar, maxNewVID)
-		lines = append(lines, fmt.Sprintf("SELECT MAX(version_id) INTO @%s FROM `%s` %s;", maxMovedVar, tableName, whereClause))
-	}
-
+	// Rebuild ids in two passes: rebase every row above the current MAX(id)
+	// (targets are all beyond existing ids, so no transient duplicate keys
+	// regardless of update order), then compact down to 1..N. Compacting keeps
+	// the final ids below the table's AUTO_INCREMENT counter, which UPDATEs do
+	// not advance, so future goose inserts cannot collide with shifted rows.
 	lines = append(lines,
-		fmt.Sprintf("UPDATE `%s` SET id = id + COALESCE(@%s, 0) WHERE version_id > @%s ORDER BY id DESC;", tableName, varName, maxMovedVar),
-		fmt.Sprintf("UPDATE `%s` SET id = id + COALESCE(@%s, 0) %s ORDER BY id DESC;", tableName, varName, whereClause),
+		fmt.Sprintf("SELECT MAX(id) INTO @rebase_%s FROM `%s`;", tableName, tableName),
+		fmt.Sprintf("CREATE TEMPORARY TABLE `_fix_order_%s` (id BIGINT UNSIGNED, rn BIGINT UNSIGNED);", tableName),
+		fmt.Sprintf("INSERT INTO `_fix_order_%s` (id, rn) SELECT id, ROW_NUMBER() OVER (ORDER BY version_id ASC, id ASC) FROM `%s`;", tableName, tableName),
+		fmt.Sprintf("UPDATE `%s` t JOIN `_fix_order_%s` o ON t.id = o.id SET t.id = @rebase_%s + o.rn;", tableName, tableName, tableName),
+		fmt.Sprintf("UPDATE `%s` t JOIN `_fix_order_%s` o ON t.id = @rebase_%s + o.rn SET t.id = o.rn;", tableName, tableName, tableName),
+		fmt.Sprintf("DROP TEMPORARY TABLE `_fix_order_%s`;", tableName),
 	)
 	return lines
 }
@@ -748,32 +713,30 @@ func verifyDryRun(renames []migrationRename, tableRows, dataRows []tableRow) (bo
 	return len(issues) == 0, append(messages, issues...)
 }
 
-// simulateTableSQL applies version remaps, dedup removal, and ID shifts to a
-// copy of the table rows, returning the simulated result plus messages and issues.
+// simulateTableSQL applies version remaps (sequentially, in the same order as
+// the generated SQL so chained renames resolve identically), duplicate
+// removal, and the version-order id rebuild to a copy of the table rows,
+// returning the simulated result plus messages and issues.
 func simulateTableSQL(tableName string, rows []tableRow, renames []migrationRename) ([]tableRow, []string, []string) {
 	var messages []string
 	var issues []string
-	renameMap := map[int64]int64{}
-	existing := map[int64]struct{}{}
-	for _, row := range rows {
-		existing[row.VersionID] = struct{}{}
-	}
+
+	simulated := make([]tableRow, len(rows))
+	copy(simulated, rows)
+
 	for _, r := range renames {
-		renameMap[r.oldVersionID] = r.newVersionID
-		if _, ok := existing[r.oldVersionID]; ok {
+		found := false
+		for i := range simulated {
+			if simulated[i].VersionID == r.oldVersionID {
+				simulated[i].VersionID = r.newVersionID
+				found = true
+			}
+		}
+		if found {
 			messages = append(messages, fmt.Sprintf("  %s: will remap %d -> %d", tableName, r.oldVersionID, r.newVersionID))
 		} else {
 			messages = append(messages, fmt.Sprintf("  %s: %d not present (UPDATE will be no-op)", tableName, r.oldVersionID))
 		}
-	}
-
-	simulated := make([]tableRow, 0, len(rows))
-	for _, row := range rows {
-		newVID := row.VersionID
-		if mapped, ok := renameMap[row.VersionID]; ok {
-			newVID = mapped
-		}
-		simulated = append(simulated, tableRow{ID: row.ID, VersionID: newVID, IsApplied: row.IsApplied})
 	}
 
 	byVID := map[int64][]tableRow{}
@@ -794,129 +757,37 @@ func simulateTableSQL(tableName string, rows []tableRow, renames []migrationRena
 		}
 	}
 
-	minNewVID, maxNewVID := renames[0].newVersionID, renames[0].newVersionID
-	movesUp := false
-	for _, r := range renames {
-		if r.newVersionID < minNewVID {
-			minNewVID = r.newVersionID
+	violations := countOrderingViolations(simulated)
+	sort.Slice(simulated, func(i, j int) bool {
+		if simulated[i].VersionID != simulated[j].VersionID {
+			return simulated[i].VersionID < simulated[j].VersionID
 		}
-		if r.newVersionID > maxNewVID {
-			maxNewVID = r.newVersionID
-		}
-		if r.newVersionID > r.oldVersionID {
-			movesUp = true
-		}
+		return simulated[i].ID < simulated[j].ID
+	})
+	for i := range simulated {
+		simulated[i].ID = int64(i + 1)
 	}
-
-	minRows := rowsForVID(simulated, minNewVID)
-	maxRows := rowsForVID(simulated, maxNewVID)
-	var targetRows []tableRow
-	if movesUp {
-		for _, row := range simulated {
-			if row.VersionID >= minNewVID && row.VersionID <= maxNewVID {
-				targetRows = append(targetRows, row)
-			}
-		}
-	} else {
-		if len(minRows) == 0 {
-			messages = append(messages, fmt.Sprintf("  %s: no row for min_new_vid=%d; id shift would affect 0 row(s)", tableName, minNewVID))
-			return simulated, messages, issues
-		}
-		for _, row := range simulated {
-			if row.ID < minRows[0].ID && row.VersionID > maxNewVID {
-				targetRows = append(targetRows, row)
-			}
-		}
-	}
-	if len(targetRows) == 0 {
-		messages = append(messages, fmt.Sprintf("  %s: id shift would affect 0 row(s)", tableName))
-		return simulated, messages, issues
-	}
-	if len(minRows) != 1 {
-		issues = append(issues, fmt.Sprintf("  %s: expected one row for min_new_vid=%d, found %d", tableName, minNewVID, len(minRows)))
-		return simulated, messages, issues
-	}
-	if len(maxRows) != 1 {
-		issues = append(issues, fmt.Sprintf("  %s: expected one row for max_new_vid=%d, found %d", tableName, maxNewVID, len(maxRows)))
-		return simulated, messages, issues
-	}
-
-	var idsAfterMax []int64
-	for _, row := range simulated {
-		if row.ID > maxRows[0].ID {
-			idsAfterMax = append(idsAfterMax, row.ID)
-		}
-	}
-	var offset int64
-	if len(idsAfterMax) == 0 {
-		messages = append(messages, fmt.Sprintf("  %s: generated offset would be NULL; COALESCE will shift by +0", tableName))
-		offset = 0
-	} else {
-		offset = maxInt64(idsAfterMax) - minRows[0].ID + 1
-		if offset <= 0 {
-			issues = append(issues, fmt.Sprintf("  %s: generated offset would be %d, expected a positive value", tableName, offset))
-			return simulated, messages, issues
-		}
-	}
-
-	maxMovedDownVID := targetRows[0].VersionID
-	for _, row := range targetRows {
-		if row.VersionID > maxMovedDownVID {
-			maxMovedDownVID = row.VersionID
-		}
-	}
-	spaceIDs := map[int64]struct{}{}
-	for _, row := range simulated {
-		if row.VersionID > maxMovedDownVID {
-			spaceIDs[row.ID] = struct{}{}
-		}
-	}
-	withSpace := shiftRows(simulated, spaceIDs, offset)
-	messages = append(messages, fmt.Sprintf("  %s: would make space by shifting %d row(s) after version_id=%d by +%d", tableName, len(spaceIDs), maxMovedDownVID, offset))
-
-	targetIDs := map[int64]struct{}{}
-	for _, row := range targetRows {
-		targetIDs[row.ID] = struct{}{}
-	}
-	shifted := shiftRows(withSpace, targetIDs, offset)
-	messages = append(messages, fmt.Sprintf("  %s: would shift %d row(s) by +%d", tableName, len(targetRows), offset))
-	return shifted, messages, issues
+	messages = append(messages, fmt.Sprintf("  %s: would renumber %d row id(s) into version order, fixing %d ordering violation(s)", tableName, len(simulated), violations))
+	return simulated, messages, issues
 }
 
-// rowsForVID returns all rows matching the given version ID.
-func rowsForVID(rows []tableRow, vid int64) []tableRow {
-	var out []tableRow
+// countOrderingViolations returns the number of adjacent applied-row pairs
+// (ordered by id) whose version_ids are out of order.
+func countOrderingViolations(rows []tableRow) int {
+	var applied []tableRow
 	for _, row := range rows {
-		if row.VersionID == vid {
-			out = append(out, row)
+		if row.IsApplied && row.VersionID > 0 {
+			applied = append(applied, row)
 		}
 	}
-	return out
-}
-
-// maxInt64 returns the maximum value from a slice of int64.
-func maxInt64(values []int64) int64 {
-	maxVal := values[0]
-	for _, val := range values[1:] {
-		if val > maxVal {
-			maxVal = val
+	sort.Slice(applied, func(i, j int) bool { return applied[i].ID < applied[j].ID })
+	violations := 0
+	for i := 0; i < len(applied)-1; i++ {
+		if applied[i].VersionID > applied[i+1].VersionID {
+			violations++
 		}
 	}
-	return maxVal
-}
-
-// shiftRows returns a copy of rows with IDs shifted by offset for rows whose
-// ID is in the given set.
-func shiftRows(rows []tableRow, ids map[int64]struct{}, offset int64) []tableRow {
-	shifted := make([]tableRow, 0, len(rows))
-	for _, row := range rows {
-		newID := row.ID
-		if _, ok := ids[row.ID]; ok {
-			newID += offset
-		}
-		shifted = append(shifted, tableRow{ID: newID, VersionID: row.VersionID, IsApplied: row.IsApplied})
-	}
-	return shifted
+	return violations
 }
 
 // validateFinalTableState checks the simulated table for duplicate IDs,

--- a/tools/migration-cleanup/sql_test.go
+++ b/tools/migration-cleanup/sql_test.go
@@ -1,0 +1,218 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func rename(old, newVID int64) migrationRename {
+	return migrationRename{
+		oldVersionID:  old,
+		newVersionID:  newVID,
+		migrationType: "tables",
+		commitSHA:     "abcdef123456",
+	}
+}
+
+// requireVersionOrder asserts that rows ordered by id have strictly
+// increasing version_ids, ids are contiguous from 1, and the final state
+// validator agrees.
+func requireVersionOrder(t *testing.T, rows []tableRow, wantVersions []int64) {
+	t.Helper()
+	require.Len(t, rows, len(wantVersions))
+	for i, row := range rows {
+		assert.Equal(t, int64(i+1), row.ID, "ids must be compacted to 1..N")
+		assert.Equal(t, wantVersions[i], row.VersionID, "version at position %d", i)
+	}
+	assert.Empty(t, validateFinalTableState(tableStatusName, rows))
+}
+
+// Down-move renumber where the moved rows sit mid-table and at the tail, the
+// shape of the 4.90.1 -> 4.91.0 re-timestamping applied to a database that
+// tracked main (rows applied between and after the moved migrations).
+func TestSimulateDownMoveAtTail(t *testing.T) {
+	rows := []tableRow{
+		{ID: 658, VersionID: 20260723181411, IsApplied: true},
+		{ID: 659, VersionID: 20260724134801, IsApplied: true},
+		{ID: 660, VersionID: 20260727083533, IsApplied: true},
+		{ID: 664, VersionID: 20260731100711, IsApplied: true}, // moves down, mid-table
+		{ID: 676, VersionID: 20260810192005, IsApplied: true},
+		{ID: 679, VersionID: 20260812170926, IsApplied: true}, // moves down, at tail
+	}
+	renames := []migrationRename{
+		rename(20260731100711, 20260723181412),
+		rename(20260812170926, 20260723181413),
+	}
+
+	simulated, _, issues := simulateTableSQL(tableStatusName, rows, renames)
+	require.Empty(t, issues)
+	requireVersionOrder(t, simulated, []int64{
+		20260723181411,
+		20260723181412,
+		20260723181413,
+		20260724134801,
+		20260727083533,
+		20260810192005,
+	})
+}
+
+// A database where the version remaps were already applied without reordering
+// ids, plus a duplicate row inserted by goose re-running an already-applied
+// migration. The remaps must no-op, the duplicate must be removed, and the
+// rebuild must still fix the ordering.
+func TestSimulateHalfFixedStateWithDuplicate(t *testing.T) {
+	rows := []tableRow{
+		{ID: 658, VersionID: 20260723181411, IsApplied: true},
+		{ID: 659, VersionID: 20260724134801, IsApplied: true},
+		{ID: 660, VersionID: 20260727083533, IsApplied: true},
+		{ID: 664, VersionID: 20260723181412, IsApplied: true}, // already remapped, stranded
+		{ID: 676, VersionID: 20260810192005, IsApplied: true},
+		{ID: 679, VersionID: 20260723181413, IsApplied: true}, // already remapped, stranded at tail
+		{ID: 680, VersionID: 20260724134801, IsApplied: true}, // duplicate from a failed re-run
+	}
+	renames := []migrationRename{
+		rename(20260731100711, 20260723181412),
+		rename(20260812170926, 20260723181413),
+	}
+
+	simulated, messages, issues := simulateTableSQL(tableStatusName, rows, renames)
+	require.Empty(t, issues)
+	joined := strings.Join(messages, "\n")
+	assert.Contains(t, joined, "20260731100711 not present")
+	assert.Contains(t, joined, "duplicate version_id=20260724134801; would keep id=659, delete ids=[680]")
+	requireVersionOrder(t, simulated, []int64{
+		20260723181411,
+		20260723181412,
+		20260723181413,
+		20260724134801,
+		20260727083533,
+		20260810192005,
+	})
+}
+
+// Up-move renumber, the shape of RC-cherry-pick timestamp bumps: rows applied
+// at old timestamps below migrations that already exist above them.
+func TestSimulateUpMove(t *testing.T) {
+	rows := []tableRow{
+		{ID: 1, VersionID: 100, IsApplied: true},
+		{ID: 2, VersionID: 150, IsApplied: true},
+		{ID: 3, VersionID: 160, IsApplied: true},
+		{ID: 4, VersionID: 200, IsApplied: true},
+	}
+	renames := []migrationRename{
+		rename(150, 250),
+		rename(160, 251),
+	}
+
+	simulated, _, issues := simulateTableSQL(tableStatusName, rows, renames)
+	require.Empty(t, issues)
+	requireVersionOrder(t, simulated, []int64{100, 200, 250, 251})
+}
+
+// Up-moves and down-moves in the same scope, which the previous
+// single-direction shift logic could not represent.
+func TestSimulateMixedDirections(t *testing.T) {
+	rows := []tableRow{
+		{ID: 1, VersionID: 100, IsApplied: true},
+		{ID: 2, VersionID: 130, IsApplied: true},
+		{ID: 3, VersionID: 200, IsApplied: true},
+		{ID: 4, VersionID: 300, IsApplied: true},
+	}
+	renames := []migrationRename{
+		rename(130, 250), // up
+		rename(300, 150), // down
+	}
+
+	simulated, _, issues := simulateTableSQL(tableStatusName, rows, renames)
+	require.Empty(t, issues)
+	requireVersionOrder(t, simulated, []int64{100, 150, 200, 250})
+}
+
+// Chained renames across two commits (A -> B, then B -> C) must land rows on
+// the terminal version regardless of whether the database applied A or B.
+// Renames arrive oldest-commit-first from findRenameCommits.
+func TestSimulateChainedRenames(t *testing.T) {
+	renames := []migrationRename{
+		rename(111, 222),
+		rename(222, 333),
+	}
+
+	for name, startVID := range map[string]int64{"applied at A": 111, "applied at B": 222} {
+		t.Run(name, func(t *testing.T) {
+			rows := []tableRow{
+				{ID: 1, VersionID: 50, IsApplied: true},
+				{ID: 2, VersionID: startVID, IsApplied: true},
+			}
+			simulated, _, issues := simulateTableSQL(tableStatusName, rows, renames)
+			require.Empty(t, issues)
+			requireVersionOrder(t, simulated, []int64{50, 333})
+		})
+	}
+}
+
+func TestCountOrderingViolations(t *testing.T) {
+	assert.Equal(t, 0, countOrderingViolations([]tableRow{
+		{ID: 1, VersionID: 10, IsApplied: true},
+		{ID: 2, VersionID: 20, IsApplied: true},
+	}))
+	assert.Equal(t, 2, countOrderingViolations([]tableRow{
+		{ID: 1, VersionID: 10, IsApplied: true},
+		{ID: 2, VersionID: 30, IsApplied: true},
+		{ID: 3, VersionID: 20, IsApplied: true}, // out of order
+		{ID: 4, VersionID: 40, IsApplied: true},
+		{ID: 5, VersionID: 15, IsApplied: true}, // out of order
+	}))
+}
+
+func TestBuildSQLStatements(t *testing.T) {
+	renames := []migrationRename{
+		rename(20260731100711, 20260723181412),
+		rename(20260812170926, 20260723181413),
+	}
+	lines := buildSQL(tableStatusName, renames)
+
+	// remaps first, in commit order
+	require.GreaterOrEqual(t, len(lines), 2)
+	assert.Equal(t, "UPDATE `migration_status_tables` SET version_id = 20260723181412 WHERE version_id = 20260731100711;", lines[0])
+	assert.Equal(t, "UPDATE `migration_status_tables` SET version_id = 20260723181413 WHERE version_id = 20260812170926;", lines[1])
+
+	joined := strings.Join(lines, "\n")
+	// dedup block
+	assert.Contains(t, joined, "_fix_dups_migration_status_tables")
+	// two-pass rebuild: rebase above MAX(id), then compact to 1..N
+	assert.Contains(t, joined, "SELECT MAX(id) INTO @rebase_migration_status_tables")
+	assert.Contains(t, joined, "ROW_NUMBER() OVER (ORDER BY version_id ASC, id ASC)")
+	assert.Contains(t, joined, "SET t.id = @rebase_migration_status_tables + o.rn;")
+	assert.Contains(t, joined, "ON t.id = @rebase_migration_status_tables + o.rn SET t.id = o.rn;")
+	// the fragile minimal-shift machinery must be gone
+	assert.NotContains(t, joined, "COALESCE")
+	assert.NotContains(t, joined, "increment_by")
+}
+
+func TestBuildSQLNoRenames(t *testing.T) {
+	assert.Empty(t, buildSQL(tableStatusName, nil))
+}
+
+// End-to-end dry-run verification over the real-world incident shape must
+// come back clean.
+func TestVerifyDryRunIncidentShape(t *testing.T) {
+	tableRows := []tableRow{
+		{ID: 658, VersionID: 20260723181411, IsApplied: true},
+		{ID: 659, VersionID: 20260724134801, IsApplied: true},
+		{ID: 660, VersionID: 20260727083533, IsApplied: true},
+		{ID: 664, VersionID: 20260723181412, IsApplied: true},
+		{ID: 676, VersionID: 20260810192005, IsApplied: true},
+		{ID: 679, VersionID: 20260723181413, IsApplied: true},
+		{ID: 680, VersionID: 20260724134801, IsApplied: true},
+	}
+	renames := []migrationRename{
+		rename(20260731100711, 20260723181412),
+		rename(20260812170926, 20260723181413),
+	}
+
+	clean, messages := verifyDryRun(renames, tableRows, nil)
+	assert.True(t, clean, "messages:\n%s", strings.Join(messages, "\n"))
+}


### PR DESCRIPTION
**Related issue:** N/A — improvement to the `tools/migration-cleanup` developer tool.

# Checklist for submitter

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Migration cleanup now processes rename histories in chronological order for more consistent results.
  * Duplicate versions are removed, and identifiers are rebuilt according to version order.
  * Complex rename scenarios, including chained and mixed-direction changes, are handled more reliably.
  * Dry-run results now more accurately reflect the changes that will be applied.
  * Ordering violations are reported before migrations are finalized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
