### PR TITLE
Unfreeze NVIDIA GeForce NOW (darwin)

### DIFF
--- a/ee/maintained-apps/inputs/homebrew/nvidia-geforce-now.json
+++ b/ee/maintained-apps/inputs/homebrew/nvidia-geforce-now.json
@@ -6,6 +6,5 @@
   "slug": "nvidia-geforce-now/darwin",
   "default_categories": [
     "Productivity"
-  ],
-  "frozen": true
+  ]
 }

--- a/ee/maintained-apps/outputs/nvidia-geforce-now/darwin.json
+++ b/ee/maintained-apps/outputs/nvidia-geforce-now/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "2.0.87.131",
+      "version": "2.0.87.134",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.nvidia.gfnpc.mall';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.nvidia.gfnpc.mall' AND version_compare(bundle_short_version, '2.0.87.131') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.nvidia.gfnpc.mall' AND version_compare(bundle_short_version, '2.0.87.134') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.nvidia.gfnpc.mall');"
       },
       "installer_url": "https://download.nvidia.com/gfnpc/GeForceNOW-release.dmg",


### PR DESCRIPTION
Automated unfreeze probe. Removes `"frozen": true` and regenerates the output manifest so
`test-fma-darwin-pr-only` can validate `nvidia-geforce-now/darwin` at its current upstream version.

Frozen since: 2026-08-11 (3e5fe9c033, "Update Fleet-maintained apps (#50939)")
Version: 2.0.87.131 -> 2.0.87.134

Draft until validation reports. Merge only if the FMA checks are green and the validate shard
actually ran for this slug.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYrC4reacydWPETB5r9YA8)_