### PR TITLE
Add allenhouchins as a docs/solutions maintainer (auto-approval)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -67,7 +67,7 @@ go.mod @fleetdm/go
 # (see website/config/custom.js for DRIs of other paths not listed here)
 ##############################################################################################
 /docs                                                   @rachaelshaw
-/docs/solutions                                         @ddribeiro
+/docs/solutions                                         @ddribeiro @allenhouchins
 /docs/Configuration                                     @rachaelshaw
 /docs/Contributing                                      @lukeheath @georgekarrv @sharon-fdm # « Contributing guidelines
 /docs/Contributing/product-groups/orchestration/understanding-host-vitals.md @sharon-fdm @getvictor @lucasmrod

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -67,7 +67,7 @@ go.mod @fleetdm/go
 # (see website/config/custom.js for DRIs of other paths not listed here)
 ##############################################################################################
 /docs                                                   @rachaelshaw
-/docs/solutions                                         @ddribeiro @allenhouchins
+/docs/solutions                                         @ddribeiro
 /docs/Configuration                                     @rachaelshaw
 /docs/Contributing                                      @lukeheath @georgekarrv @sharon-fdm # « Contributing guidelines
 /docs/Contributing/product-groups/orchestration/understanding-host-vitals.md @sharon-fdm @getvictor @lucasmrod

--- a/website/config/custom.js
+++ b/website/config/custom.js
@@ -233,6 +233,7 @@ module.exports.custom = {
     'docs': ['rachaelshaw', 'noahtalerman', 'eashaw'],// (default for docs)
     'docs/01-Using-Fleet/standard-query-library/standard-query-library.yml': ['rachaelshaw', 'noahtalerman', 'eashaw'],// (standard query library)
     '/docs/get-started/faq': ['ksatter', 'ddribeiro', 'zayhanlon'],
+    'docs/solutions': ['ddribeiro', 'allenhouchins'],
     'docs/REST API/rest-api.md': ['rachaelshaw', 'lukeheath'],// (standard query library)
     'schema': ['eashaw', 'lukeheath'],// (Osquery table schema)
     'ee/cis': ['lukeheath', 'sharon-fdm', 'lucasmrod', 'rachelElysia', 'rachaelshaw'],


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** NA

Adds `@allenhouchins` as a maintainer for `docs/solutions`, so their own changes to that path are auto-approved.

**What changed**

- `website/config/custom.js` — added `'docs/solutions': ['ddribeiro', 'allenhouchins']` to `githubRepoMaintainersByPath`.

**Notes for the reviewer**

- No `CODEOWNERS` change. This is deliberate: adding someone there would make their review *required* on every PR touching the path, which is not the intent here.
- `githubRepoMaintainersByPath` matching walks ancestral paths and grants on any match, so this new entry is purely additive — it does not shadow or narrow the existing `'docs'` entry (`rachaelshaw`, `noahtalerman`, `eashaw`), who remain maintainers of `docs/solutions` via the `docs` ancestor.
- `@ddribeiro` is carried over so the new entry doesn't remove anything they had through `docs`.
- Repo change-control settings only — no product code, config surface, or docs content.

# Checklist for submitter

Remaining template items (changes file, tests, migrations, config settings, fleetd) are NA — this PR only changes repo change-control settings.

## Testing

- [ ] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation ownership settings for the solutions documentation area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->