### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/franz/darwin.json
+++ b/ee/maintained-apps/outputs/franz/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "6.6.0",
+      "version": "6.7.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.meetfranz.franz';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.meetfranz.franz' AND version_compare(bundle_short_version, '6.6.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.meetfranz.franz' AND version_compare(bundle_short_version, '6.7.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.meetfranz.franz');"
       },
-      "installer_url": "https://github.com/meetfranz/franz-6/releases/download/v6.6.0/Franz-arm64.dmg",
+      "installer_url": "https://github.com/meetfranz/franz-6/releases/download/v6.7.0/Franz-arm64.dmg",
       "install_script_ref": "7e8d07b5",
       "uninstall_script_ref": "9366c954",
-      "sha256": "e6c8c9a4544fc49fab13e8e77382b3a6a5a74456dec35c4d925de19a99a6d22a",
+      "sha256": "5cf8e00465b0c823acfa72d22e6e4246eba70fdcd5750415b4537d39b767b593",
       "default_categories": [
         "Communication"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Franz macOS app to version 6.7.0.
  * Refreshed the installer download details and integrity checksum.
  * Installation and uninstallation behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->