### PR TITLE
Escape cask metadata in Homebrew Fleet-maintained-app script generation

### DIFF
--- a/changes/17171-homebrew-ingester-shell-escaping
+++ b/changes/17171-homebrew-ingester-shell-escaping
@@ -1,0 +1,1 @@
+- Fixed an issue where Homebrew cask metadata for a Fleet-maintained app (macOS) could reach the generated install/uninstall scripts without being escaped for shell use. All cask-controlled values interpolated into generated scripts are now escaped, so shell metacharacters in the metadata are treated as literal text.

--- a/ee/maintained-apps/ingesters/homebrew/scripts.go
+++ b/ee/maintained-apps/ingesters/homebrew/scripts.go
@@ -3,6 +3,7 @@ package homebrew
 import (
 	"fmt"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"sort"
 	"strings"
@@ -221,9 +222,9 @@ func shellSingleQuote(s string) string {
 
 // dqEscaper backslash-escapes the only four characters that keep a special
 // meaning inside a double-quoted shell string: backslash, dollar, backtick, and
-// double quote. Backslash is listed first so an escape we introduce isn't
-// re-escaped (strings.Replacer scans left to right in a single pass and never
-// reconsiders inserted text).
+// double quote. strings.Replacer makes a single pass and never rescans the
+// replacement text it inserts, so the escapes it introduces are not themselves
+// re-escaped (regardless of pair order).
 var dqEscaper = strings.NewReplacer(
 	`\`, `\\`,
 	`$`, `\$`,
@@ -242,6 +243,51 @@ var dqEscaper = strings.NewReplacer(
 // auto-update path) don't churn.
 func shellDoubleQuoteEscape(s string) string {
 	return dqEscaper.Replace(s)
+}
+
+// escapeCaskPath escapes a cask-supplied path for use inside a double-quoted
+// shell string while preserving a leading "$APPDIR" — the one cask variable the
+// generated scripts define and legitimately expand at runtime (every real
+// binary-artifact source is "$APPDIR/Foo.app/..."). Everything after the prefix
+// is data and gets escaped; paths without metacharacters come back unchanged.
+func escapeCaskPath(s string) string {
+	if s == "$APPDIR" {
+		return s
+	}
+	if rest, ok := strings.CutPrefix(s, "$APPDIR/"); ok {
+		return "$APPDIR/" + shellDoubleQuoteEscape(rest)
+	}
+	return shellDoubleQuoteEscape(s)
+}
+
+var inertBareword = regexp.MustCompile(`^[A-Za-z0-9_./+][A-Za-z0-9_./+-]*$`)
+
+// inertShellWord reports whether s is safe to emit as a single unquoted shell
+// word: an optional "$APPDIR" prefix followed only by filename-safe bytes, with
+// no leading dash that a command would parse as an option. Inert values keep
+// the generator's historical unquoted form: the auto-update job treats any byte
+// difference between a stored script and the manifest script as an admin
+// customization and pins the stored script (which names the old installer
+// file), so format churn would break auto-updates for every affected app.
+func inertShellWord(s string) bool {
+	if s == "$APPDIR" {
+		return true
+	}
+	if rest, ok := strings.CutPrefix(s, "$APPDIR/"); ok {
+		return inertBareword.MatchString(rest)
+	}
+	return inertBareword.MatchString(s)
+}
+
+// heredocInert reports whether s is pure data in an unquoted << EOF heredoc
+// body: nothing the shell expands there ($, backtick, backslash) and no line
+// equal to the delimiter, which would terminate the heredoc early and run the
+// remainder as commands.
+func heredocInert(s string) bool {
+	if strings.ContainsAny(s, "$`\\") {
+		return false
+	}
+	return !slices.Contains(strings.Split(s, "\n"), "EOF")
 }
 
 func processUninstallArtifact(u *brewUninstall, sb *scriptBuilder) {
@@ -458,33 +504,52 @@ func (s *scriptBuilder) InstallPkg(pkg string, choices ...[]brewPkgConfig) error
 	}
 
 	// The choice XML embeds cask-controlled strings (choiceIdentifier /
-	// choiceAttribute). Write it with a single-quoted printf argument rather than a
-	// heredoc: an unquoted heredoc shell-expands $(...) in the body, and even a
-	// quoted delimiter ('EOF') would still let a newline in the metadata smuggle in
-	// a line equal to the delimiter and end the heredoc early, running the rest as
-	// commands. Single-quoting the whole payload neutralizes both.
-	s.Writef(`
+	// choiceAttribute). An unquoted heredoc shell-expands $/backtick/backslash in
+	// its body, and a body line equal to the delimiter ends it early, running the
+	// remainder as commands. Keep the historical heredoc when the XML is inert on
+	// all those counts — every real cask today, so stored scripts don't churn (see
+	// inertShellWord) — and otherwise write the XML as a single-quoted printf
+	// literal, which the shell can't interpret.
+	if xml := string(choiceXML); heredocInert(xml) {
+		s.Writef(`
+CHOICE_XML=$(mktemp /tmp/choice_xml_XXX)
+
+cat << EOF > "$CHOICE_XML"
+%s
+EOF
+
+sudo installer -pkg "$TMPDIR/%s" -target / -applyChoiceChangesXML "$CHOICE_XML" || exit $?
+`, xml, pkg)
+	} else {
+		s.Writef(`
 CHOICE_XML=$(mktemp /tmp/choice_xml_XXX)
 
 printf '%%s\n' %s > "$CHOICE_XML"
 
 sudo installer -pkg "$TMPDIR/%s" -target / -applyChoiceChangesXML "$CHOICE_XML" || exit $?
-`, shellSingleQuote(string(choiceXML)), pkg)
+`, shellSingleQuote(xml), pkg)
+	}
 
 	return nil
 }
 
 // Symlink writes a command to create a symbolic link from 'source' to 'target'.
 func (s *scriptBuilder) Symlink(source, target string) {
-	// source/target are cask-controlled. Quote and escape them: the previous
-	// `mkdir -p %s` was unquoted (also broken for paths with spaces) and the ln
-	// arguments, though double-quoted, still allowed $(...) command substitution.
+	// source/target are cask-controlled: the ln arguments, though double-quoted,
+	// allowed $(...) command substitution, and the mkdir argument was unquoted.
+	// Inert paths keep the historical unquoted mkdir form so stored scripts don't
+	// churn (see inertShellWord); `--` stops a leading dash in a hostile path from
+	// being parsed as an option.
 	pathname := filepath.Dir(target)
 	if _, ok := s.pathsCreated[pathname]; !ok {
-		s.Writef(`mkdir -p "%s"`, shellDoubleQuoteEscape(pathname))
+		if inertShellWord(pathname) {
+			s.Writef("mkdir -p %s", pathname)
+		} else {
+			s.Writef(`mkdir -p -- "%s"`, escapeCaskPath(pathname))
+		}
 		s.pathsCreated[pathname] = struct{}{}
 	}
-	s.Writef(`/bin/ln -h -f -s -- "%s" "%s"`, shellDoubleQuoteEscape(source), shellDoubleQuoteEscape(target))
+	s.Writef(`/bin/ln -h -f -s -- "%s" "%s"`, escapeCaskPath(source), escapeCaskPath(target))
 }
 
 // String generates the final script as a string.

--- a/ee/maintained-apps/ingesters/homebrew/scripts.go
+++ b/ee/maintained-apps/ingesters/homebrew/scripts.go
@@ -44,7 +44,10 @@ func installScriptForApp(app inputApp, cask *brewCask) (string, error) {
 				if appItem.String == "" {
 					continue
 				}
-				appPath := appItem.String
+				// appPath is cask-controlled and interpolated inside double-quoted
+				// strings alongside "$APPDIR"/"$TMPDIR"; escape it so a payload like
+				// $(...) can't reach the root-privileged mv/cp/rm below.
+				appPath := shellDoubleQuoteEscape(appItem.String)
 				sb.Writef(`if [ -d "$APPDIR/%[1]s" ]; then
 	sudo mv "$APPDIR/%[1]s" "$TMPDIR/%[1]s.bkp" || exit $?
 fi`, appPath)
@@ -120,9 +123,11 @@ func uninstallScriptForApp(cask *brewCask) string {
 					}
 				}
 			}
-			// Remove all collected app paths
+			// Remove all collected app paths. appPath is cask-controlled and lands
+			// inside a double-quoted `sudo rm -rf` argument, so escape it to stop
+			// $(...)/backtick command substitution.
 			for _, appPath := range appPathsToRemove {
-				sb.RemoveFile(fmt.Sprintf(`"$APPDIR/%s"`, appPath))
+				sb.RemoveFile(fmt.Sprintf(`"$APPDIR/%s"`, shellDoubleQuoteEscape(appPath)))
 			}
 		case len(artifact.Binary) > 0:
 			if len(artifact.Binary) == 2 {
@@ -212,6 +217,31 @@ func sortUninstall(artifacts []*brewUninstall) {
 // prematurely close the quote and produce a syntax error.
 func shellSingleQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// dqEscaper backslash-escapes the only four characters that keep a special
+// meaning inside a double-quoted shell string: backslash, dollar, backtick, and
+// double quote. Backslash is listed first so an escape we introduce isn't
+// re-escaped (strings.Replacer scans left to right in a single pass and never
+// reconsiders inserted text).
+var dqEscaper = strings.NewReplacer(
+	`\`, `\\`,
+	`$`, `\$`,
+	"`", "\\`",
+	`"`, `\"`,
+)
+
+// shellDoubleQuoteEscape escapes s for safe interpolation inside an existing
+// double-quoted shell string. Cask metadata is attacker-influenced (it flows
+// verbatim from formulae.brew.sh into root-privileged generated scripts), so a
+// value like `$(...)` or a backtick must not be treated as command
+// substitution. Unlike shellSingleQuote this preserves a surrounding "$VAR"
+// (e.g. "$APPDIR"/"$TMPDIR") that legitimately needs to expand, and it leaves
+// values without shell metacharacters — the common case — byte-for-byte
+// unchanged, so the generated scripts (and their downstream comparisons in the
+// auto-update path) don't churn.
+func shellDoubleQuoteEscape(s string) string {
+	return dqEscaper.Replace(s)
 }
 
 func processUninstallArtifact(u *brewUninstall, sb *scriptBuilder) {
@@ -312,7 +342,10 @@ func processUninstallArtifact(u *brewUninstall, sb *scriptBuilder) {
 		}
 	} else if len(u.Script.String) > 0 {
 		addUserVar()
-		sb.Writef(`(cd /Users/$LOGGED_IN_USER && sudo -u "$LOGGED_IN_USER" '%s')`, u.Script.String)
+		// Quote via shellSingleQuote rather than a bare '%s': the cask-controlled
+		// value could otherwise close the quote with an embedded apostrophe and
+		// inject commands.
+		sb.Writef(`(cd /Users/$LOGGED_IN_USER && sudo -u "$LOGGED_IN_USER" %s)`, shellSingleQuote(u.Script.String))
 	}
 
 	process(u.PkgUtil, func(pkgID string) {
@@ -411,6 +444,9 @@ func (s *scriptBuilder) RemoveFile(file string) {
 //
 // Returns an error if generating the XML for choices fails.
 func (s *scriptBuilder) InstallPkg(pkg string, choices ...[]brewPkgConfig) error {
+	// pkg is cask-controlled and interpolated inside a double-quoted "$TMPDIR/..."
+	// argument; escape it so command substitution can't survive.
+	pkg = shellDoubleQuoteEscape(pkg)
 	if len(choices) == 0 {
 		s.Writef(`sudo installer -pkg "$TMPDIR/%s" -target / || exit $?`, pkg)
 		return nil
@@ -421,27 +457,34 @@ func (s *scriptBuilder) InstallPkg(pkg string, choices ...[]brewPkgConfig) error
 		return err
 	}
 
+	// The choice XML embeds cask-controlled strings (choiceIdentifier /
+	// choiceAttribute). Write it with a single-quoted printf argument rather than a
+	// heredoc: an unquoted heredoc shell-expands $(...) in the body, and even a
+	// quoted delimiter ('EOF') would still let a newline in the metadata smuggle in
+	// a line equal to the delimiter and end the heredoc early, running the rest as
+	// commands. Single-quoting the whole payload neutralizes both.
 	s.Writef(`
 CHOICE_XML=$(mktemp /tmp/choice_xml_XXX)
 
-cat << EOF > "$CHOICE_XML"
-%s
-EOF
+printf '%%s\n' %s > "$CHOICE_XML"
 
 sudo installer -pkg "$TMPDIR/%s" -target / -applyChoiceChangesXML "$CHOICE_XML" || exit $?
-`, choiceXML, pkg)
+`, shellSingleQuote(string(choiceXML)), pkg)
 
 	return nil
 }
 
 // Symlink writes a command to create a symbolic link from 'source' to 'target'.
 func (s *scriptBuilder) Symlink(source, target string) {
+	// source/target are cask-controlled. Quote and escape them: the previous
+	// `mkdir -p %s` was unquoted (also broken for paths with spaces) and the ln
+	// arguments, though double-quoted, still allowed $(...) command substitution.
 	pathname := filepath.Dir(target)
 	if _, ok := s.pathsCreated[pathname]; !ok {
-		s.Writef("mkdir -p %s", pathname)
+		s.Writef(`mkdir -p "%s"`, shellDoubleQuoteEscape(pathname))
 		s.pathsCreated[pathname] = struct{}{}
 	}
-	s.Writef(`/bin/ln -h -f -s -- "%s" "%s"`, source, target)
+	s.Writef(`/bin/ln -h -f -s -- "%s" "%s"`, shellDoubleQuoteEscape(source), shellDoubleQuoteEscape(target))
 }
 
 // String generates the final script as a string.

--- a/ee/maintained-apps/ingesters/homebrew/scripts_test.go
+++ b/ee/maintained-apps/ingesters/homebrew/scripts_test.go
@@ -109,7 +109,7 @@ fi`)
 func TestShellDoubleQuoteEscape(t *testing.T) {
 	// Values without shell metacharacters (the common case) must pass through
 	// unchanged so the generated scripts stay byte-identical to before.
-	require.Equal(t, ``, shellDoubleQuoteEscape(""))
+	require.Empty(t, shellDoubleQuoteEscape(""))
 	require.Equal(t, `plain`, shellDoubleQuoteEscape("plain"))
 	require.Equal(t, `Foo-1.0.pkg`, shellDoubleQuoteEscape("Foo-1.0.pkg"))
 	require.Equal(t, `Adobe Photoshop (2024).app`, shellDoubleQuoteEscape("Adobe Photoshop (2024).app"))

--- a/ee/maintained-apps/ingesters/homebrew/scripts_test.go
+++ b/ee/maintained-apps/ingesters/homebrew/scripts_test.go
@@ -121,8 +121,45 @@ func TestShellDoubleQuoteEscape(t *testing.T) {
 	require.Equal(t, `a\"b`, shellDoubleQuoteEscape(`a"b`))
 	require.Equal(t, `a\\b`, shellDoubleQuoteEscape(`a\b`))
 	require.Equal(t, "a\\`id\\`b", shellDoubleQuoteEscape("a`id`b"))
-	// Backslash is escaped first, so an already-escaped dollar isn't doubled.
-	require.Equal(t, `\$`, shellDoubleQuoteEscape("$"))
+	// Input is raw data, never "already escaped": a backslash-dollar sequence has
+	// each byte escaped independently, and the shell reads the result back as the
+	// literal input bytes.
+	require.Equal(t, `\\\$foo`, shellDoubleQuoteEscape(`\$foo`))
+}
+
+func TestEscapeCaskPath(t *testing.T) {
+	// A leading $APPDIR is the legitimate expansion every real binary-artifact
+	// source uses; it must survive unescaped, and inert paths must come back
+	// byte-identical.
+	require.Equal(t, `$APPDIR`, escapeCaskPath("$APPDIR"))
+	require.Equal(t, `$APPDIR/Zed.app/Contents/MacOS/cli`, escapeCaskPath("$APPDIR/Zed.app/Contents/MacOS/cli"))
+	require.Equal(t, `$APPDIR/Surge Dashboard.app`, escapeCaskPath("$APPDIR/Surge Dashboard.app"))
+	require.Equal(t, `zed`, escapeCaskPath("zed"))
+	// Everything after the prefix is data.
+	require.Equal(t, `$APPDIR/Foo\$(id).app`, escapeCaskPath("$APPDIR/Foo$(id).app"))
+	// A prefix that isn't exactly "$APPDIR/" (the shell would expand the longer
+	// variable name $APPDIRx instead) is escaped whole.
+	require.Equal(t, `\$APPDIRx/foo`, escapeCaskPath("$APPDIRx/foo"))
+	require.Equal(t, `\$(id)`, escapeCaskPath("$(id)"))
+}
+
+func TestInertShellWord(t *testing.T) {
+	for _, ok := range []string{".", "/usr/local/bin", "$APPDIR", "$APPDIR/Some", "a/b.c-d_e+f"} {
+		require.True(t, inertShellWord(ok), "input: %q", ok)
+	}
+	for _, bad := range []string{"", "-v", "--", "a b", "$(id)", "`id`", "$HOME", "$APPDIR/$(id)", "$APPDIR/a b", "~", `a\b`, `a"b`, "a'b", "a;b", "a\nb"} {
+		require.False(t, inertShellWord(bad), "input: %q", bad)
+	}
+}
+
+func TestHeredocInert(t *testing.T) {
+	require.True(t, heredocInert("<?xml version=\"1.0\"?>\n<string>com.example</string>"))
+	require.False(t, heredocInert("$(id)"))
+	require.False(t, heredocInert("`id`"))
+	require.False(t, heredocInert(`a\b`))
+	// A body line equal to the delimiter would terminate the heredoc early.
+	require.False(t, heredocInert("line1\nEOF\nline2"))
+	require.True(t, heredocInert("not EOF alone on a line"))
 }
 
 // TestInstallScriptNeutralizesCommandSubstitutionInAppPath guards against the
@@ -172,9 +209,9 @@ func TestInstallScriptNeutralizesCommandSubstitutionInPkg(t *testing.T) {
 
 // TestInstallScriptChoiceXMLIsNotShellExpanded guards against command
 // substitution and heredoc-terminator smuggling through cask-controlled pkg
-// choice metadata. The XML is written with a single-quoted printf argument, not
-// a heredoc, so neither $(...) in the body nor a newline-injected delimiter can
-// execute.
+// choice metadata. XML that isn't heredoc-inert is written with a single-quoted
+// printf argument, not a heredoc, so neither $(...) in the body nor a
+// newline-injected delimiter can execute.
 func TestInstallScriptChoiceXMLIsNotShellExpanded(t *testing.T) {
 	cask := &brewCask{
 		Artifacts: []*brewArtifact{
@@ -204,6 +241,36 @@ func TestInstallScriptChoiceXMLIsNotShellExpanded(t *testing.T) {
 	require.Contains(t, script, `-applyChoiceChangesXML "$CHOICE_XML" || exit $?`)
 }
 
+// TestInstallScriptChoiceXMLKeepsHeredocWhenInert pins the historical heredoc
+// form for metacharacter-free choice XML (every real cask today): the
+// auto-update job treats any byte change to a generated script as an admin
+// customization and pins the stored script, so the hardened printf form must
+// only appear when the XML actually needs it.
+func TestInstallScriptChoiceXMLKeepsHeredocWhenInert(t *testing.T) {
+	cask := &brewCask{
+		Artifacts: []*brewArtifact{
+			{Pkg: []optjson.StringOr[*brewPkgChoices]{
+				{String: "Foo-1.0.pkg"},
+				{IsOther: true, Other: &brewPkgChoices{Choices: []brewPkgConfig{
+					{ChoiceIdentifier: "com.microsoft.autoupdate", ChoiceAttribute: "selected", AttributeSetting: 0},
+				}}},
+			}},
+		},
+	}
+
+	script, err := installScriptForApp(inputApp{
+		Token:            "foo",
+		UniqueIdentifier: "com.example.Foo",
+		InstallerFormat:  "pkg",
+	}, cask)
+	require.NoError(t, err)
+	require.Contains(t, script, "cat << EOF > \"$CHOICE_XML\"\n<?xml")
+	// The marshaled plist ends with its own newline; the stored outputs have the
+	// same blank line before EOF, so this pins the historical bytes exactly.
+	require.Contains(t, script, "</array>\n</plist>\n\nEOF\n")
+	require.NotContains(t, script, `printf '%s\n'`)
+}
+
 // TestInstallScriptNeutralizesCommandSubstitutionInBinaryTarget covers the
 // symlink (binary artifact) sinks: both the mkdir and ln arguments are
 // cask-controlled.
@@ -223,9 +290,64 @@ func TestInstallScriptNeutralizesCommandSubstitutionInBinaryTarget(t *testing.T)
 		InstallerFormat:  "zip",
 	}, cask)
 	require.NoError(t, err)
-	require.Contains(t, script, `mkdir -p "/usr/local/bin"`)
+	// The parent dir is inert, so mkdir keeps its historical unquoted form.
+	require.Contains(t, script, "\nmkdir -p /usr/local/bin\n")
 	require.Contains(t, script, `/bin/ln -h -f -s -- "bin/foo" "/usr/local/bin/foo\$(id)"`)
 	require.NotContains(t, script, `"/usr/local/bin/foo$(id)"`)
+}
+
+// TestInstallScriptBinaryArtifactByteIdenticalForRealCasks pins the exact
+// historical output for the shapes every current binary-artifact cask uses
+// (zed/cursor-style bare target, surge-style $APPDIR target): any byte change
+// here reads as an admin customization to the auto-update job, which then pins
+// the stored script with its stale installer filename.
+func TestInstallScriptBinaryArtifactByteIdenticalForRealCasks(t *testing.T) {
+	cask := &brewCask{
+		Artifacts: []*brewArtifact{
+			{Binary: []optjson.StringOr[*brewBinaryTarget]{
+				{String: "$APPDIR/Zed.app/Contents/MacOS/cli"},
+				{IsOther: true, Other: &brewBinaryTarget{Target: "zed"}},
+			}},
+			{Binary: []optjson.StringOr[*brewBinaryTarget]{
+				{String: "$APPDIR/Surge.app/Contents/Applications/Surge Dashboard.app"},
+				{IsOther: true, Other: &brewBinaryTarget{Target: "$APPDIR/Surge Dashboard.app"}},
+			}},
+		},
+	}
+
+	script, err := installScriptForApp(inputApp{
+		Token:            "foo",
+		UniqueIdentifier: "com.example.Foo",
+		InstallerFormat:  "zip",
+	}, cask)
+	require.NoError(t, err)
+	require.Contains(t, script, "\nmkdir -p .\n")
+	require.Contains(t, script, "\n"+`/bin/ln -h -f -s -- "$APPDIR/Zed.app/Contents/MacOS/cli" "zed"`+"\n")
+	require.Contains(t, script, "\nmkdir -p $APPDIR\n")
+	require.Contains(t, script, `/bin/ln -h -f -s -- "$APPDIR/Surge.app/Contents/Applications/Surge Dashboard.app" "$APPDIR/Surge Dashboard.app"`)
+}
+
+// TestInstallScriptMkdirNotFooledByLeadingDash: a hostile target whose parent
+// directory starts with a dash must be treated as a pathname, not an option, so
+// the hardened branch adds `--`.
+func TestInstallScriptMkdirNotFooledByLeadingDash(t *testing.T) {
+	cask := &brewCask{
+		Artifacts: []*brewArtifact{
+			{Binary: []optjson.StringOr[*brewBinaryTarget]{
+				{String: "bin/foo"},
+				{IsOther: true, Other: &brewBinaryTarget{Target: "-v/foo"}},
+			}},
+		},
+	}
+
+	script, err := installScriptForApp(inputApp{
+		Token:            "foo",
+		UniqueIdentifier: "com.example.Foo",
+		InstallerFormat:  "zip",
+	}, cask)
+	require.NoError(t, err)
+	require.Contains(t, script, `mkdir -p -- "-v"`)
+	require.Contains(t, script, `/bin/ln -h -f -s -- "bin/foo" "-v/foo"`)
 }
 
 // TestUninstallScriptNeutralizesCommandSubstitutionInAppPath is the uninstall

--- a/ee/maintained-apps/ingesters/homebrew/scripts_test.go
+++ b/ee/maintained-apps/ingesters/homebrew/scripts_test.go
@@ -106,6 +106,166 @@ func TestInstallScriptAppCopyPropagatesAndRestores(t *testing.T) {
 fi`)
 }
 
+func TestShellDoubleQuoteEscape(t *testing.T) {
+	// Values without shell metacharacters (the common case) must pass through
+	// unchanged so the generated scripts stay byte-identical to before.
+	require.Equal(t, ``, shellDoubleQuoteEscape(""))
+	require.Equal(t, `plain`, shellDoubleQuoteEscape("plain"))
+	require.Equal(t, `Foo-1.0.pkg`, shellDoubleQuoteEscape("Foo-1.0.pkg"))
+	require.Equal(t, `Adobe Photoshop (2024).app`, shellDoubleQuoteEscape("Adobe Photoshop (2024).app"))
+	// Apostrophes are literal inside double quotes and must NOT be escaped.
+	require.Equal(t, `Cycling '74`, shellDoubleQuoteEscape("Cycling '74"))
+	// The four characters special inside double quotes are backslash-escaped.
+	require.Equal(t, `\$(id)`, shellDoubleQuoteEscape("$(id)"))
+	require.Equal(t, `\$HOME`, shellDoubleQuoteEscape("$HOME"))
+	require.Equal(t, `a\"b`, shellDoubleQuoteEscape(`a"b`))
+	require.Equal(t, `a\\b`, shellDoubleQuoteEscape(`a\b`))
+	require.Equal(t, "a\\`id\\`b", shellDoubleQuoteEscape("a`id`b"))
+	// Backslash is escaped first, so an already-escaped dollar isn't doubled.
+	require.Equal(t, `\$`, shellDoubleQuoteEscape("$"))
+}
+
+// TestInstallScriptNeutralizesCommandSubstitutionInAppPath guards against the
+// homebrew-ingester instance of the "cask metadata -> generated script -> root
+// RCE" class (GHSA-fv3p-h7wv-2jgm): a cask-controlled app path reaching the
+// double-quoted mv/cp/rm sinks must appear as literal text, not command
+// substitution.
+func TestInstallScriptNeutralizesCommandSubstitutionInAppPath(t *testing.T) {
+	cask := &brewCask{
+		Artifacts: []*brewArtifact{
+			{App: []optjson.StringOr[*brewAppTarget]{{String: `Foo$(touch /tmp/pwned).app`}}},
+		},
+	}
+
+	script, err := installScriptForApp(inputApp{
+		Token:            "foo",
+		UniqueIdentifier: "com.example.Foo",
+		InstallerFormat:  "dmg",
+	}, cask)
+	require.NoError(t, err)
+	// The payload survives verbatim but backslash-escaped, so the shell treats it
+	// as a filename rather than running `touch`.
+	require.Contains(t, script, `sudo mv "$APPDIR/Foo\$(touch /tmp/pwned).app" "$TMPDIR/Foo\$(touch /tmp/pwned).app.bkp" || exit $?`)
+	require.Contains(t, script, `sudo rm -rf "$APPDIR/Foo\$(touch /tmp/pwned).app"`)
+	// The unescaped (executable) form must not appear anywhere.
+	require.NotContains(t, script, `"$APPDIR/Foo$(touch /tmp/pwned).app"`)
+}
+
+// TestInstallScriptNeutralizesCommandSubstitutionInPkg is the pkg-filename
+// variant of the above.
+func TestInstallScriptNeutralizesCommandSubstitutionInPkg(t *testing.T) {
+	cask := &brewCask{
+		Artifacts: []*brewArtifact{
+			{Pkg: []optjson.StringOr[*brewPkgChoices]{{String: `Foo$(id).pkg`}}},
+		},
+	}
+
+	script, err := installScriptForApp(inputApp{
+		Token:            "foo",
+		UniqueIdentifier: "com.example.Foo",
+		InstallerFormat:  "pkg",
+	}, cask)
+	require.NoError(t, err)
+	require.Contains(t, script, `sudo installer -pkg "$TMPDIR/Foo\$(id).pkg" -target / || exit $?`)
+	require.NotContains(t, script, `"$TMPDIR/Foo$(id).pkg"`)
+}
+
+// TestInstallScriptChoiceXMLIsNotShellExpanded guards against command
+// substitution and heredoc-terminator smuggling through cask-controlled pkg
+// choice metadata. The XML is written with a single-quoted printf argument, not
+// a heredoc, so neither $(...) in the body nor a newline-injected delimiter can
+// execute.
+func TestInstallScriptChoiceXMLIsNotShellExpanded(t *testing.T) {
+	cask := &brewCask{
+		Artifacts: []*brewArtifact{
+			{Pkg: []optjson.StringOr[*brewPkgChoices]{
+				{String: "Foo-1.0.pkg"},
+				{IsOther: true, Other: &brewPkgChoices{Choices: []brewPkgConfig{
+					{ChoiceIdentifier: "$(touch /tmp/pwned)", ChoiceAttribute: "selected", AttributeSetting: 1},
+				}}},
+			}},
+		},
+	}
+
+	script, err := installScriptForApp(inputApp{
+		Token:            "foo",
+		UniqueIdentifier: "com.example.Foo",
+		InstallerFormat:  "pkg",
+	}, cask)
+	require.NoError(t, err)
+	// Written via printf with a single-quoted argument, never a heredoc whose body
+	// or delimiter the shell could interpret.
+	require.Contains(t, script, `printf '%s\n' '`)
+	require.NotContains(t, script, "cat << EOF")
+	require.NotContains(t, script, "\nEOF\n")
+	// The payload lands in the choices file as data, single-quoted.
+	require.Contains(t, script, "$(touch /tmp/pwned)")
+	// Install still runs after the file is written.
+	require.Contains(t, script, `-applyChoiceChangesXML "$CHOICE_XML" || exit $?`)
+}
+
+// TestInstallScriptNeutralizesCommandSubstitutionInBinaryTarget covers the
+// symlink (binary artifact) sinks: both the mkdir and ln arguments are
+// cask-controlled.
+func TestInstallScriptNeutralizesCommandSubstitutionInBinaryTarget(t *testing.T) {
+	cask := &brewCask{
+		Artifacts: []*brewArtifact{
+			{Binary: []optjson.StringOr[*brewBinaryTarget]{
+				{String: "bin/foo"},
+				{IsOther: true, Other: &brewBinaryTarget{Target: "/usr/local/bin/foo$(id)"}},
+			}},
+		},
+	}
+
+	script, err := installScriptForApp(inputApp{
+		Token:            "foo",
+		UniqueIdentifier: "com.example.Foo",
+		InstallerFormat:  "zip",
+	}, cask)
+	require.NoError(t, err)
+	require.Contains(t, script, `mkdir -p "/usr/local/bin"`)
+	require.Contains(t, script, `/bin/ln -h -f -s -- "bin/foo" "/usr/local/bin/foo\$(id)"`)
+	require.NotContains(t, script, `"/usr/local/bin/foo$(id)"`)
+}
+
+// TestUninstallScriptNeutralizesCommandSubstitutionInAppPath is the uninstall
+// counterpart: the cask-controlled app path reaches a double-quoted `sudo rm
+// -rf`.
+func TestUninstallScriptNeutralizesCommandSubstitutionInAppPath(t *testing.T) {
+	cask := &brewCask{
+		Artifacts: []*brewArtifact{
+			{App: []optjson.StringOr[*brewAppTarget]{{String: `Foo$(touch /tmp/pwned).app`}}},
+		},
+	}
+
+	script := uninstallScriptForApp(cask)
+	require.Contains(t, script, `sudo rm -rf "$APPDIR/Foo\$(touch /tmp/pwned).app"`)
+	require.NotContains(t, script, `"$APPDIR/Foo$(touch /tmp/pwned).app"`)
+}
+
+// TestUninstallScriptScriptDirectiveEscapesApostrophe guards the uninstall
+// `script` directive against an apostrophe breaking out of the single-quoted
+// command.
+func TestUninstallScriptScriptDirectiveEscapesApostrophe(t *testing.T) {
+	cask := &brewCask{
+		Artifacts: []*brewArtifact{
+			{
+				Uninstall: []*brewUninstall{
+					{
+						Script: optjson.StringOr[map[string]any]{
+							String: `/opt/x'; touch /tmp/pwned; '`,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	script := uninstallScriptForApp(cask)
+	require.Contains(t, script, `'\''`)
+	require.NotContains(t, script, `/opt/x'; touch /tmp/pwned; '`)
+}
+
 func TestShellSingleQuote(t *testing.T) {
 	for in, want := range map[string]string{
 		"":                      `''`,


### PR DESCRIPTION
**Related issue:** Resolves fleetdm/confidential#17171 (draft advisory `GHSA-fv3p-h7wv-2jgm`)

## What & why

The Fleet-maintained apps Homebrew ingester (`ee/maintained-apps/ingesters/homebrew/scripts.go`) interpolated cask-controlled metadata into the generated install/uninstall scripts through double-quoted and unquoted-heredoc contexts, where shell command substitution is not neutralized. The same "package metadata → generated script" hardening previously applied to the admin-upload and winget paths was never applied here.

This routes every cask-controlled interpolation site through explicit escaping or an inertness check:

- **`shellDoubleQuoteEscape` (new)** for values that sit inside an existing double-quoted string alongside `"$APPDIR"`/`"$TMPDIR"` (app copy `mv`/`cp`/`rm`, `sudo rm -rf` on uninstall, the `installer -pkg` filename). It backslash-escapes only the four characters that stay special inside double quotes (`\ $ ` `` ` `` `"`). Values without metacharacters — the common case — pass through **byte-for-byte unchanged**.
- **`escapeCaskPath` (new)** for the symlink (`binary` artifact) `ln` arguments: same escaping, but a leading literal `$APPDIR` is preserved because every real binary-artifact source is `"$APPDIR/Foo.app/..."` and legitimately expands at runtime. Everything after the prefix is treated as data.
- **`inertShellWord` (new)** gates the `mkdir` line for the symlink parent dir: inert paths (optional `$APPDIR` prefix + filename-safe bytes, no leading dash) keep the historical unquoted `mkdir -p <path>` form; anything else gets `mkdir -p -- "<escaped>"` (the `--` stops a leading dash being parsed as an option).
- **`heredocInert` (new)** gates the pkg choice XML: XML with no `$`/backtick/backslash and no line equal to the delimiter keeps the historical `cat << EOF` heredoc; anything else is written via `printf '%s\n' '<single-quoted xml>'`, which the shell can't interpret (an unquoted heredoc expands its body, and a body line equal to the delimiter ends it early and runs the remainder as commands).
- **`shellSingleQuote`** for the uninstall `script` directive (was a bare `'%s'` that an embedded apostrophe could break out of).

### Reviewer notes

- **Zero generated-output changes for real casks — verified by regeneration.** The FMA auto-update job treats any byte difference between a team's stored script and the manifest script as an admin customization and pins the stored script (which hardcodes the old installer filename), so gratuitous format churn would strand every affected app on a broken script (the #50097 failure mode). The hardened forms therefore only kick in when metadata actually contains shell metacharacters, which no current cask does. Verified by regenerating `zed`, `cursor`, `docker-desktop`, `surge`, `virtualbox`, and `microsoft-word` through the ingester: all install/uninstall script refs byte-identical except upstream version bumps (which only move the installer filename, already neutralized by `normalizeInstallerFilename`).
- **Why `$APPDIR` needs special handling on the symlink path:** unlike the other sinks, where `"$APPDIR/` is part of the Go template and only the suffix is cask data, the `binary` artifact's source/target strings *embed* `$APPDIR` (e.g. `"$APPDIR/Zed.app/Contents/MacOS/cli"`). Escaping them wholesale would emit `\$APPDIR` and break the symlink for all ~28 binary-artifact apps.
- **Why not `file.ValidatePackageIdentifiers` here (as on the winget path):** it rejects all shell metacharacters, which is fine for GUID product/upgrade codes but not for macOS app paths, which legitimately contain apostrophes (`Cycling '74`), spaces, and parentheses (`Adobe Photoshop (2024).app`). Correct quoting/escaping is the equivalent-strength control for this input class; the repo already relies on `shellSingleQuote` for exactly this reason.

## Testing

- [x] Added/updated automated tests — regression tests assert metacharacter payloads (`$(...)`, backtick, apostrophe, leading dash) appear **literally** in the generated scripts at each sink; byte-exact tests pin the historical output for the shapes every real cask uses (bare and `$APPDIR` symlink targets, inert choice XML); unit tests for `shellDoubleQuoteEscape`, `escapeCaskPath`, `inertShellWord`, and `heredocInert`.
- [x] QA'd all new/changed functionality manually
  - Regenerated six representative apps through the ingester and diffed the outputs (see reviewer notes); `bash -n` on generated scripts is valid; executed the choice-XML write path and confirmed a hostile payload is written as literal data and does not execute.

- [x] Changes file added in `changes/`.
- [x] Untrusted data interpolated into shell scripts is validated/escaped against shell metacharacters.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved security for macOS Homebrew installations and removals by safely handling special characters in app paths, package names, installer metadata, and binary targets.
  - Prevented shell metacharacters and leading-dash paths from being misinterpreted when generating installation or uninstallation scripts.
  - Preserved expected installer behavior and exit codes, including compatibility for existing casks and unusual file names or metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->