### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/altair-graphql-client/darwin.json
+++ b/ee/maintained-apps/outputs/altair-graphql-client/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "8.5.7",
+      "version": "8.5.9",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.xkoji.altair';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.xkoji.altair' AND version_compare(bundle_short_version, '8.5.7') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.xkoji.altair' AND version_compare(bundle_short_version, '8.5.9') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.xkoji.altair');"
       },
-      "installer_url": "https://github.com/imolorhe/altair/releases/download/v8.5.7/altair_8.5.7_arm64_mac.zip",
+      "installer_url": "https://github.com/imolorhe/altair/releases/download/v8.5.9/altair_8.5.9_arm64_mac.zip",
       "install_script_ref": "5c1a30ea",
       "uninstall_script_ref": "c196066e",
-      "sha256": "bf62986cbc4a481942a37d555a4b052252acddc45640ea406eb2fce96b33db1d",
+      "sha256": "5dbf5a58be50922965bc30d5ed5dc38ee3607b89b01c3777827aeab8a27d7d3c",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/apidog/darwin.json
+++ b/ee/maintained-apps/outputs/apidog/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "2.8.42",
+      "version": "2.8.43",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.apidog.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.apidog.app' AND version_compare(bundle_short_version, '2.8.42') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.apidog.app' AND version_compare(bundle_short_version, '2.8.43') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.apidog.app');"
       },
-      "installer_url": "https://file-assets.apidog.com/download/2.8.42/legacy-Apidog-macOS-arm64-2.8.42.dmg",
+      "installer_url": "https://file-assets.apidog.com/download/2.8.43/legacy-Apidog-macOS-arm64-2.8.43.dmg",
       "install_script_ref": "b5f530c0",
       "uninstall_script_ref": "b51190cf",
-      "sha256": "4b4efb3a7964ae08c1b5efde00ac87075852a79a07d09ec82b5a7d1b4ca2f3c4",
+      "sha256": "23cfdff973635c02f4fb71946da67d0f7ab1e181f7e6e70d7dbc28d648bbcf07",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/firefox@nightly/darwin.json
+++ b/ee/maintained-apps/outputs/firefox@nightly/darwin.json
@@ -7,10 +7,10 @@
         "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15626.8.15') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'org.mozilla.nightly');"
       },
-      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/08/2026-08-15-08-56-31-mozilla-central/firefox-156.0a1.en-US.mac.dmg",
+      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/08/2026-08-15-21-38-49-mozilla-central/firefox-156.0a1.en-US.mac.dmg",
       "install_script_ref": "d9c4cf87",
       "uninstall_script_ref": "0661f848",
-      "sha256": "8eea7080e58f93640c82c2e12065b7f8f385f848457bd0e9fe691048f797793d",
+      "sha256": "3db3a060bd501d7beda936d35793680afa021dc3d3ff5339aa20cc7b1aa78cb8",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/syncovery/darwin.json
+++ b/ee/maintained-apps/outputs/syncovery/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "11.16.0",
+      "version": "12.5.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.company.Syncovery';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.company.Syncovery' AND version_compare(bundle_short_version, '11.16.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.company.Syncovery' AND version_compare(bundle_short_version, '12.5.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.company.Syncovery');"
       },
-      "installer_url": "https://www.syncovery.com/release/SyncoveryMac11.16.0-Apple.dmg",
+      "installer_url": "https://www.syncovery.com/release/SyncoveryMac12.5.0-Apple.dmg",
       "install_script_ref": "2ad0e63a",
       "uninstall_script_ref": "04c1cc55",
-      "sha256": "c2b8937bba2cd44426dddb3ae45270194e1a86d88f763ed33d350818e4169fca",
+      "sha256": "137278b244c8f538dafe207f8712d0e224d9e354a5d1485de93a7ced225fe1ad",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated the macOS versions of Altair GraphQL Client, Apidog, Firefox Nightly, and Syncovery.
  - Refreshed installer download information and verification checksums to support the latest releases.
  - Syncovery is now updated to version 12.5.0, while Altair GraphQL Client, Apidog, and Firefox Nightly receive their respective current versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->