### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/firefox@nightly/darwin.json
+++ b/ee/maintained-apps/outputs/firefox@nightly/darwin.json
@@ -4,13 +4,13 @@
       "version": "156.0a1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15626.8.15') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15626.8.16') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'org.mozilla.nightly');"
       },
-      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/08/2026-08-15-21-38-49-mozilla-central/firefox-156.0a1.en-US.mac.dmg",
+      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/08/2026-08-16-08-38-33-mozilla-central/firefox-156.0a1.en-US.mac.dmg",
       "install_script_ref": "d9c4cf87",
       "uninstall_script_ref": "0661f848",
-      "sha256": "3db3a060bd501d7beda936d35793680afa021dc3d3ff5339aa20cc7b1aa78cb8",
+      "sha256": "53435ecdd6612b26d17f014b0d497cf6fe3f118b22b3fcf1c7d2d58fa50a41eb",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/gitify/darwin.json
+++ b/ee/maintained-apps/outputs/gitify/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "7.3.3",
+      "version": "7.4.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.gitify';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.gitify' AND version_compare(bundle_short_version, '7.3.3') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.gitify' AND version_compare(bundle_short_version, '7.4.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.electron.gitify');"
       },
-      "installer_url": "https://github.com/gitify-app/gitify/releases/download/v7.3.3/Gitify-7.3.3-universal-mac.zip",
+      "installer_url": "https://github.com/gitify-app/gitify/releases/download/v7.4.0/Gitify-7.4.0-universal-mac.zip",
       "install_script_ref": "335acee0",
       "uninstall_script_ref": "33618979",
-      "sha256": "eb753d0319e316b835f1758cbb9681ecec536b50d53fa3df9118416e348f05df",
+      "sha256": "e7058a71ebe94391254430a2dde90c9f5a84dbe1b37358fae5fc2a33ee06d327",
       "default_categories": [
         "Utilities"
       ]

--- a/ee/maintained-apps/outputs/hive-app/darwin.json
+++ b/ee/maintained-apps/outputs/hive-app/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.2.31",
+      "version": "1.2.33",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app' AND version_compare(bundle_short_version, '1.2.31') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app' AND version_compare(bundle_short_version, '1.2.33') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.hive.app');"
       },
-      "installer_url": "https://github.com/morapelker/hive/releases/download/v1.2.31/Hive-1.2.31-arm64.dmg",
+      "installer_url": "https://github.com/morapelker/hive/releases/download/v1.2.33/Hive-1.2.33-arm64.dmg",
       "install_script_ref": "3bd4ebe4",
       "uninstall_script_ref": "951b5587",
-      "sha256": "656b1a2e17c0b6539b1d39afa6b2a8f92511c6ba6d4ba5baa9c28c623d160bd4",
+      "sha256": "81b34c4da28026d5b8d5473ff89edbfd8d3f6cdbc11f2f503bb509c7d9f78406",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/marked-app/darwin.json
+++ b/ee/maintained-apps/outputs/marked-app/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "3.1.22",
+      "version": "3.1.23",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.brettterpstra.marked';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.brettterpstra.marked' AND version_compare(bundle_short_version, '3.1.22') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.brettterpstra.marked' AND version_compare(bundle_short_version, '3.1.23') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.brettterpstra.marked');"
       },
-      "installer_url": "https://updates.markedapp.com/updates/Marked%203.1.22-1206.zip",
+      "installer_url": "https://updates.markedapp.com/updates/Marked%203.1.23-1208.zip",
       "install_script_ref": "23ea6da3",
       "uninstall_script_ref": "57b4bcf2",
-      "sha256": "8905af0d7643d305943e4e95e26939bf16231e7674bb3ba374094069dce3f76d",
+      "sha256": "3e44622feeaafa30d435b90b026b92c4c70890d159446fc36f3779ae08994402",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/spokenly/darwin.json
+++ b/ee/maintained-apps/outputs/spokenly/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "2.27.16",
+      "version": "2.28.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'app.spokenly';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.spokenly' AND version_compare(bundle_short_version, '2.27.16') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.spokenly' AND version_compare(bundle_short_version, '2.28.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'app.spokenly');"
       },
-      "installer_url": "https://cdn.spokenly.app/releases/macos/Spokenly-2.27.16.dmg",
+      "installer_url": "https://cdn.spokenly.app/releases/macos/Spokenly-2.28.0.dmg",
       "install_script_ref": "11a51e11",
       "uninstall_script_ref": "99a71452",
-      "sha256": "8bc0840bd139eeb59c3d36e633927aa45e379b39a4f2d04a100aa4317c36c7dc",
+      "sha256": "b13469f8837425ce40a4d029d35889a3dfa7eb4ab405d107d89515f29934afc0",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/syncovery/darwin.json
+++ b/ee/maintained-apps/outputs/syncovery/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "12.5.0",
+      "version": "12.5.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.company.Syncovery';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.company.Syncovery' AND version_compare(bundle_short_version, '12.5.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.company.Syncovery' AND version_compare(bundle_short_version, '12.5.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.company.Syncovery');"
       },
-      "installer_url": "https://www.syncovery.com/release/SyncoveryMac12.5.0-Apple.dmg",
+      "installer_url": "https://www.syncovery.com/release/SyncoveryMac12.5.1-Apple.dmg",
       "install_script_ref": "2ad0e63a",
       "uninstall_script_ref": "04c1cc55",
-      "sha256": "137278b244c8f538dafe207f8712d0e224d9e354a5d1485de93a7ced225fe1ad",
+      "sha256": "3bf888150b2b959ff230ccc5214486b79a8f81f87ac5af01cffcb61ddc7ef88a",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Refreshed macOS installation metadata for Firefox Nightly, Gitify, Hive, Marked, Spokenly, and Syncovery.
  * Updated supported versions, installer links, and verification checksums to reference the latest builds.
  * Firefox Nightly now targets build 156.0a1; Gitify, Hive, Marked, Spokenly, and Syncovery also include their latest available releases.
  * Installation and uninstallation workflows remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->