### PR TITLE
Hide the toast details panel when the payload is empty

### DIFF
--- a/changes/50846-empty-toast-detail-panel.md
+++ b/changes/50846-empty-toast-detail-panel.md
@@ -1,0 +1,1 @@
+- Fixed error toasts showing an expandable "Raw response" panel containing an empty `{}` when the underlying error carried no details.

--- a/frontend/components/ToastNotification/ToastCard.tests.tsx
+++ b/frontend/components/ToastNotification/ToastCard.tests.tsx
@@ -1,0 +1,81 @@
+/**
+ * Tests ToastCard's expandable detail panel: which payloads are worth
+ * revealing and which are suppressed.
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import ToastCard from "./ToastCard";
+
+jest.mock("sonner", () => ({
+  toast: {
+    custom: jest.fn(),
+    dismiss: jest.fn(),
+  },
+  Toaster: () => null,
+}));
+
+const EXPAND_LABEL = "Expand error details";
+
+const renderCard = (detail?: unknown) =>
+  render(
+    <ToastCard
+      variant="error"
+      message="Couldn't upload. Please try again."
+      detail={detail}
+      toastId="test-id"
+    />
+  );
+
+describe("ToastCard", () => {
+  it("hides the details toggle when an Error is passed as the payload", () => {
+    // Regression test for #50846. An Error's own properties are
+    // non-enumerable, so JSON.stringify returns "{}" without throwing and
+    // the panel used to open on an empty object.
+    renderCard(new Error("unsupported file extension: dmg"));
+
+    expect(
+      screen.queryByRole("button", { name: EXPAND_LABEL })
+    ).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ["an empty object", {}],
+    ["an empty array", []],
+    ["null", null],
+    ["an empty string", ""],
+  ])("hides the details toggle for %s", (_label, detail) => {
+    renderCard(detail);
+
+    expect(
+      screen.queryByRole("button", { name: EXPAND_LABEL })
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides the details toggle when no payload is provided", () => {
+    renderCard();
+
+    expect(
+      screen.queryByRole("button", { name: EXPAND_LABEL })
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the details toggle when the payload has content", () => {
+    renderCard({ message: "unsupported file extension: dmg" });
+
+    expect(
+      screen.getByRole("button", { name: EXPAND_LABEL })
+    ).toBeInTheDocument();
+  });
+
+  it("reveals the payload when the toggle is clicked", async () => {
+    const user = userEvent.setup();
+    renderCard({ status: 422 });
+
+    await user.click(screen.getByRole("button", { name: EXPAND_LABEL }));
+
+    expect(screen.getByRole("region", { name: "Error details" })).toBeVisible();
+    expect(screen.getByText(/422/)).toBeInTheDocument();
+  });
+});

--- a/frontend/components/ToastNotification/ToastCard.tests.tsx
+++ b/frontend/components/ToastNotification/ToastCard.tests.tsx
@@ -45,6 +45,10 @@ describe("ToastCard", () => {
     ["an empty array", []],
     ["null", null],
     ["an empty string", ""],
+    // These have no JSON representation, so JSON.stringify returns undefined
+    // rather than throwing.
+    ["a function", () => "noop"],
+    ["a symbol", Symbol("token")],
   ])("hides the details toggle for %s", (_label, detail) => {
     renderCard(detail);
 

--- a/frontend/components/ToastNotification/ToastCard.tsx
+++ b/frontend/components/ToastNotification/ToastCard.tsx
@@ -78,8 +78,13 @@ const ToastCard = ({
   let detailText = "";
   if (detail !== undefined) {
     try {
-      detailText = JSON.stringify(detail, null, 2);
-      detailHtml = syntaxHighlight(detail);
+      // Values with no JSON representation (functions, symbols) return
+      // undefined here rather than throwing, so treat them as empty and skip
+      // the highlighter, which assumes a string.
+      detailText = JSON.stringify(detail, null, 2) ?? "";
+      if (detailText !== "") {
+        detailHtml = syntaxHighlight(detail);
+      }
     } catch {
       // Circular refs / non-serializable values — fall back to safe text.
       detailText = String(detail);

--- a/frontend/components/ToastNotification/ToastCard.tsx
+++ b/frontend/components/ToastNotification/ToastCard.tsx
@@ -39,6 +39,10 @@ const variantIcon: Record<
   error: { name: "error-outline", color: "status-error" },
 };
 
+// Serialized payloads that hold nothing worth revealing. Compared against the
+// pretty-printed JSON, so an empty object is "{}" rather than "{\n}".
+const EMPTY_DETAIL_TEXT = ["", "{}", "[]", "null", '""'];
+
 /**
  * `ToastCard` is the single source of truth for every toast variant. It is
  * rendered inside Sonner's headless `toast.custom()` wrapper — Sonner
@@ -56,7 +60,6 @@ const ToastCard = ({
   toastId,
 }: IToastCardProps): JSX.Element => {
   const [isOpen, setIsOpen] = useState(false);
-  const hasDetail = detail !== undefined;
   const icon = variantIcon[variant];
 
   const toggle = (): void => {
@@ -73,7 +76,7 @@ const ToastCard = ({
   // identical to the "Manage activity automations" modal's payload.
   let detailHtml = "";
   let detailText = "";
-  if (hasDetail) {
+  if (detail !== undefined) {
     try {
       detailText = JSON.stringify(detail, null, 2);
       detailHtml = syntaxHighlight(detail);
@@ -86,6 +89,13 @@ const ToastCard = ({
         .replace(/>/g, "&gt;");
     }
   }
+
+  // Callers pass caught errors straight through as `response`, and an `Error`'s
+  // own properties (message, stack) are non-enumerable, so JSON.stringify
+  // returns "{}" without throwing — the panel would open on an empty object.
+  // Treat a payload that carries nothing as no payload at all: the message
+  // already holds the error text, and an empty panel is worse than no panel.
+  const hasDetail = !EMPTY_DETAIL_TEXT.includes(detailText);
 
   // Capture when the toast first rendered. Snapshotted once via the lazy
   // initializer so the timestamp stays stable across re-renders (toggling


### PR DESCRIPTION
**Related issue:** Resolves #50846

Uploading a custom package with an unsupported extension shows an error toast whose expandable "Raw response" panel contains nothing but `{}`.

## Root cause

`ToastCard` decides whether to render the panel from the raw prop:

```ts
const hasDetail = detail !== undefined;
```

Callers pass a caught error straight through as `response` — `notify.error(`${e}`, { response: e })`. An `Error`'s own properties (`message`, `stack`) are non-enumerable, so `JSON.stringify` returns `"{}"` **without throwing**, which means the existing `catch` fallback never runs. The panel then opens on an empty object.

The issue points at `PackageForm.tsx`, but that's one instance of a general problem: roughly 177 call sites across the frontend pass a caught error as `response`, so any of them can produce this. Fixing it at the single reported call site would leave the rest.

## Changes

In `frontend/components/ToastNotification/ToastCard.tsx`, derive `hasDetail` from the *serialized* payload rather than the raw value, and treat payloads that carry nothing as no payload:

```ts
const EMPTY_DETAIL_TEXT = ["", "{}", "[]", "null", '""'];
...
const hasDetail = !EMPTY_DETAIL_TEXT.includes(detailText);
```

`hasDetail` already gates the chevron, the panel, and the card's `--open` class, so the toggle disappears entirely instead of revealing an empty block. This matches the first option in the issue: the message text already carries the error, so there's nothing to disclose.

Payloads with real content are untouched. Verified against the actual serializer:

| payload | `JSON.stringify(x, null, 2)` | panel |
| --- | --- | --- |
| `new Error("unsupported file extension: dmg")` | `"{}"` | hidden |
| `{}` / `[]` / `null` / `""` | `"{}"` / `"[]"` / `"null"` / `'""'` | hidden |
| `{ status: 422 }` | `"{\n  \"status\": 422\n}"` | shown |
| `{ message: "internal" }` | `"{\n  \"message\": \"internal\"\n}"` | shown |

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests

Added `ToastCard.tests.tsx` covering both directions:

- The toggle is hidden for an `Error`, `{}`, `[]`, `null`, `""`, and for no payload at all.
- The toggle is still shown, and still reveals the payload, when the detail has real content.

All five suppression cases were confirmed to fail against the unfixed component, and the three "still shows" cases pass either way — they exist to catch the fix over-suppressing real API responses. The existing `ToastNotification.tests.tsx` suite passes unchanged, so the `notify` API's response resolution is unaffected. `eslint`, `prettier`, and `tsc --noEmit` are clean.

- [ ] QA'd all new/changed functionality manually

Not done. Verified through the tests above and by checking the serializer's real output for each payload shape rather than assuming it. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Toast notifications no longer show an expandable details panel when the payload is empty, missing, or has no meaningful JSON representation.
  * Non-serializable details are handled more gracefully while preserving fallback display for serialization errors.

* **Tests**
  * Added coverage for hidden detail panels, visible details, and reveal behavior across supported payload types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->