### PR TITLE
remove extra target text in Apple OS updates

### DIFF
--- a/frontend/pages/ManageControlsPage/OSUpdates/components/AppleOSTargetForm/AppleOSTargetForm.tsx
+++ b/frontend/pages/ManageControlsPage/OSUpdates/components/AppleOSTargetForm/AppleOSTargetForm.tsx
@@ -293,7 +293,6 @@ const AppleOSTargetForm = ({
   return (
     <form className={baseClass} onSubmit={handleSubmit}>
       <DropdownWrapper
-        label="Target"
         name="target"
         options={TARGET_OPTIONS}
         value={target}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #51246 unreleased bug

<img width="722" height="312" alt="image" src="https://github.com/user-attachments/assets/28945da9-2f1f-4fe7-9fc7-510e73f6c052" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information. Unreleased bug

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed the redundant “Target” label from the Apple OS target dropdown for a cleaner interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->