### PR TITLE
Cancel a queued profile removal when the profile is added back

### DIFF
--- a/changes/49573-cancel-superseded-remove-profile
+++ b/changes/49573-cancel-superseded-remove-profile
@@ -1,0 +1,1 @@
+- Fixed an Apple configuration profile that was removed and then added back before the host came online being stripped from the host and reinstalled, instead of staying in place.

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -406,6 +406,12 @@ type MDMAppleProfilePayload struct {
 	IgnoreError       bool               `db:"ignore_error"`
 	Scope             PayloadScope       `db:"scope"`
 	DeviceEnrolledAt  *time.Time         `db:"device_enrolled_at"`
+	// CancelOnly marks a removal carried through the reconciler solely so its
+	// already-queued RemoveProfile command can be cancelled, because the same
+	// identifier is being installed again on the host under a different profile
+	// UUID. Delivering the removal would strip the profile the admin just asked
+	// for, so nothing is ever enqueued for these rows.
+	CancelOnly bool `db:"-"`
 }
 
 // DidNotInstallOnHost indicates whether this profile was not installed on the host (and

--- a/server/mdm/apple/reconcile.go
+++ b/server/mdm/apple/reconcile.go
@@ -54,6 +54,20 @@ func IsEligiblePlatform(platform string) bool {
 	return platform == "darwin" || platform == "ios" || platform == "ipados"
 }
 
+// profileChannelKey identifies where a profile is delivered on a host. The same
+// identifier on the system and user channels are independent installs delivered to
+// different enrollment IDs, so a removal on one channel must never be matched by an
+// install on the other.
+type profileChannelKey struct {
+	hostUUID   string
+	identifier string
+	scope      fleet.PayloadScope
+}
+
+func channelKey(p *fleet.MDMAppleProfilePayload) profileChannelKey {
+	return profileChannelKey{hostUUID: p.HostUUID, identifier: p.ProfileIdentifier, scope: p.Scope}
+}
+
 // ComputeReconcileDeltas evaluates desired profile state for each host in
 // the input set using the SHARED dispatcher, then diffs against current
 // host_mdm_apple_profiles rows to produce install and remove sets.
@@ -76,9 +90,7 @@ func ComputeReconcileDeltas(
 			currentByProfile[c.ProfileUUID] = c
 		}
 
-		// identifiers this host is (re)installing on this pass, used below to spot a
-		// stale removal that a new profile with the same identifier supersedes
-		installingIdentifiers := make(map[string]struct{})
+		installingChannels := make(map[profileChannelKey]struct{})
 
 		for _, p := range teamProfiles {
 			onHost := false
@@ -120,7 +132,7 @@ func ComputeReconcileDeltas(
 				prevCommandUUID = c.CommandUUID
 			}
 
-			installingIdentifiers[p.ProfileIdentifier] = struct{}{}
+			installingChannels[profileChannelKey{hostUUID: host.UUID, identifier: p.ProfileIdentifier, scope: p.Scope}] = struct{}{}
 
 			toInstall = append(toInstall, &fleet.MDMAppleProfilePayload{
 				ProfileUUID:       p.ProfileUUID,
@@ -141,14 +153,15 @@ func ComputeReconcileDeltas(
 				continue
 			}
 			// A removal already sent to the device is left alone so the reconciler
-			// doesn't queue it a second time. The exception is when the same
-			// identifier is being installed again: deleting and re-adding a profile
-			// mints a new profile UUID, so this row is never revisited on its own and
-			// its queued RemoveProfile would strip the profile the admin just asked
-			// for. Carry it through marked cancel-only.
+			// doesn't queue it a second time. The exception is when the same channel
+			// is being installed again: deleting and re-adding a profile mints a new
+			// profile UUID, so this row is never revisited on its own and its queued
+			// RemoveProfile would strip the profile the admin just asked for. Carry it
+			// through marked cancel-only.
 			var cancelOnly bool
 			if c.OperationType == fleet.MDMOperationTypeRemove && c.Status != nil {
-				if _, reinstalling := installingIdentifiers[c.ProfileIdentifier]; !reinstalling {
+				key := profileChannelKey{hostUUID: host.UUID, identifier: c.ProfileIdentifier, scope: c.Scope}
+				if _, reinstalling := installingChannels[key]; !reinstalling {
 					continue
 				}
 				cancelOnly = true
@@ -601,18 +614,21 @@ func ExecuteReconcileBatch(
 		}
 	}
 
-	// identifiers actually reaching an install here, after the callers' platform and
-	// scope filters have run. A cancel-only removal is honoured only if its install
-	// survived those filters; otherwise dropping the row is safer than stripping a
-	// profile the host is meant to keep.
-	installingByHost := make(map[string]struct{}, len(toInstall))
+	// built from toInstall as it arrives here, i.e. after the callers' platform and
+	// scope filters have already dropped whatever they drop
+	installingChannels := make(map[profileChannelKey]struct{}, len(toInstall))
 	for _, p := range toInstall {
-		installingByHost[p.HostUUID+"\x00"+p.ProfileIdentifier] = struct{}{}
+		installingChannels[channelKey(p)] = struct{}{}
 	}
 
 	for _, p := range toRemove {
 		if p.CancelOnly {
-			if _, ok := installingByHost[p.HostUUID+"\x00"+p.ProfileIdentifier]; ok {
+			// These rows exist only to retract a queued RemoveProfile, so honour that
+			// only while the install justifying it is still in this batch: the filters
+			// above can drop an install after the deltas were computed. Without it,
+			// leave the row untouched rather than queueing a removal for a profile the
+			// host is meant to keep.
+			if _, ok := installingChannels[channelKey(p)]; ok {
 				hostProfilesToCleanup = append(hostProfilesToCleanup, p)
 			}
 			continue

--- a/server/mdm/apple/reconcile.go
+++ b/server/mdm/apple/reconcile.go
@@ -76,6 +76,10 @@ func ComputeReconcileDeltas(
 			currentByProfile[c.ProfileUUID] = c
 		}
 
+		// identifiers this host is (re)installing on this pass, used below to spot a
+		// stale removal that a new profile with the same identifier supersedes
+		installingIdentifiers := make(map[string]struct{})
+
 		for _, p := range teamProfiles {
 			onHost := false
 			if c, ok := currentByProfile[p.ProfileUUID]; ok {
@@ -116,6 +120,8 @@ func ComputeReconcileDeltas(
 				prevCommandUUID = c.CommandUUID
 			}
 
+			installingIdentifiers[p.ProfileIdentifier] = struct{}{}
+
 			toInstall = append(toInstall, &fleet.MDMAppleProfilePayload{
 				ProfileUUID:       p.ProfileUUID,
 				ProfileIdentifier: p.ProfileIdentifier,
@@ -134,8 +140,18 @@ func ComputeReconcileDeltas(
 			if _, stillDesired := desired[profUUID]; stillDesired {
 				continue
 			}
+			// A removal already sent to the device is left alone so the reconciler
+			// doesn't queue it a second time. The exception is when the same
+			// identifier is being installed again: deleting and re-adding a profile
+			// mints a new profile UUID, so this row is never revisited on its own and
+			// its queued RemoveProfile would strip the profile the admin just asked
+			// for. Carry it through marked cancel-only.
+			var cancelOnly bool
 			if c.OperationType == fleet.MDMOperationTypeRemove && c.Status != nil {
-				continue
+				if _, reinstalling := installingIdentifiers[c.ProfileIdentifier]; !reinstalling {
+					continue
+				}
+				cancelOnly = true
 			}
 			if IsBrokenProfile(profUUID, profilesWithBrokenLabels) {
 				continue
@@ -156,6 +172,7 @@ func ComputeReconcileDeltas(
 				IgnoreError:       c.IgnoreError,
 				Scope:             c.Scope,
 				DeviceEnrolledAt:  host.DeviceEnrolledAt,
+				CancelOnly:        cancelOnly,
 			})
 		}
 	}
@@ -447,7 +464,9 @@ func ExecuteReconcileBatch(
 
 	for _, p := range toInstall {
 		if pp, ok := profileIntersection.GetMatchingProfileInCurrentState(p); ok && pp != nil {
-			if (pp.Status != nil && *pp.Status != fleet.MDMDeliveryFailed) && bytes.Equal(pp.Checksum, p.Checksum) {
+			// Never preserve the state of a cancel-only removal: it would stamp this
+			// install as "removing" and point it at the command we are about to delete.
+			if !pp.CancelOnly && (pp.Status != nil && *pp.Status != fleet.MDMDeliveryFailed) && bytes.Equal(pp.Checksum, p.Checksum) {
 				hp := &fleet.MDMAppleBulkUpsertHostProfilePayload{
 					ProfileUUID:       p.ProfileUUID,
 					HostUUID:          p.HostUUID,
@@ -582,7 +601,22 @@ func ExecuteReconcileBatch(
 		}
 	}
 
+	// identifiers actually reaching an install here, after the callers' platform and
+	// scope filters have run. A cancel-only removal is honoured only if its install
+	// survived those filters; otherwise dropping the row is safer than stripping a
+	// profile the host is meant to keep.
+	installingByHost := make(map[string]struct{}, len(toInstall))
+	for _, p := range toInstall {
+		installingByHost[p.HostUUID+"\x00"+p.ProfileIdentifier] = struct{}{}
+	}
+
 	for _, p := range toRemove {
+		if p.CancelOnly {
+			if _, ok := installingByHost[p.HostUUID+"\x00"+p.ProfileIdentifier]; ok {
+				hostProfilesToCleanup = append(hostProfilesToCleanup, p)
+			}
+			continue
+		}
 		if _, ok := profileIntersection.GetMatchingProfileInDesiredState(p); ok {
 			hostProfilesToCleanup = append(hostProfilesToCleanup, p)
 			continue

--- a/server/mdm/apple/reconcile_test.go
+++ b/server/mdm/apple/reconcile_test.go
@@ -2079,3 +2079,200 @@ func TestMDMAppleExecuteReconcileBatchSkipsHostBeingProcessed(t *testing.T) {
 	assert.Contains(t, pendingHosts, nonSetupHostUUID, "non setup host should still have profiles enqueued")
 	assert.Contains(t, pendingHosts, blockedHostUUID, "previously blocked host should now have profiles enqueued after key expiry")
 }
+
+// Deleting a profile and adding the same one back mints a new profile UUID, so the
+// host carries two rows for one identifier: the old one mid-removal and the new one
+// awaiting install. The queued RemoveProfile must be cancelled or it strips the
+// profile the admin just re-added. See issue #49573.
+func TestComputeReconcileDeltasCancelsSupersededRemoval(t *testing.T) {
+	host := &fleet.AppleHostReconcileInfo{
+		HostID: 1, UUID: "uuid-A", TeamID: nil, Platform: "darwin",
+		LabelUpdatedAt: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+	}
+	readded := &fleet.AppleProfileForReconcile{
+		ProfileUUID:       "aNewProfileUUID",
+		ProfileIdentifier: "com.example.wifi",
+		ProfileName:       "Wi-Fi",
+		TeamID:            0,
+		Checksum:          []byte("aaaa"),
+		IncludeMode:       fleet.AppleProfileIncludeNone,
+	}
+	// same identifier, different profile UUID, removal already sent to the device
+	staleRemoval := &fleet.MDMAppleProfilePayload{
+		ProfileUUID:       "aOldProfileUUID",
+		ProfileIdentifier: "com.example.wifi",
+		ProfileName:       "Wi-Fi",
+		HostUUID:          "uuid-A",
+		Checksum:          []byte("aaaa"),
+		OperationType:     fleet.MDMOperationTypeRemove,
+		Status:            &fleet.MDMDeliveryPending,
+		CommandUUID:       "remove-cmd",
+	}
+	current := map[string][]*fleet.MDMAppleProfilePayload{"uuid-A": {staleRemoval}}
+
+	t.Run("identifier re-added: removal carried through as cancel-only", func(t *testing.T) {
+		toInstall, toRemove := ComputeReconcileDeltas(
+			[]*fleet.AppleHostReconcileInfo{host}, nil,
+			current,
+			map[uint][]*fleet.AppleProfileForReconcile{0: {readded}},
+			map[string]struct{}{},
+		)
+
+		require.Len(t, toInstall, 1)
+		require.Equal(t, "aNewProfileUUID", toInstall[0].ProfileUUID)
+
+		require.Len(t, toRemove, 1)
+		require.Equal(t, "aOldProfileUUID", toRemove[0].ProfileUUID)
+		require.True(t, toRemove[0].CancelOnly)
+		require.Equal(t, "remove-cmd", toRemove[0].CommandUUID)
+	})
+
+	t.Run("identifier not re-added: removal still left alone", func(t *testing.T) {
+		toInstall, toRemove := ComputeReconcileDeltas(
+			[]*fleet.AppleHostReconcileInfo{host}, nil,
+			current,
+			map[uint][]*fleet.AppleProfileForReconcile{}, // nothing desired
+			map[string]struct{}{},
+		)
+
+		require.Empty(t, toInstall)
+		require.Empty(t, toRemove, "an in-flight removal must not be queued a second time")
+	})
+}
+
+// End of the same flow: the cancel-only removal must pull its queued command out
+// without ever sending a RemoveProfile, and must be dropped entirely when the
+// install that justified it did not survive the callers' filters.
+func TestMDMAppleExecuteReconcileBatchCancelOnlyRemoval(t *testing.T) {
+	const hostUUID = "uuid-A"
+	const identifier = "com.example.wifi"
+
+	newInstall := func() *fleet.MDMAppleProfilePayload {
+		return &fleet.MDMAppleProfilePayload{
+			ProfileUUID: "aNewProfileUUID", ProfileIdentifier: identifier, ProfileName: "Wi-Fi",
+			HostUUID: hostUUID, Scope: fleet.PayloadScopeSystem, Checksum: []byte("aaaa"),
+		}
+	}
+	cancelOnly := func() *fleet.MDMAppleProfilePayload {
+		return &fleet.MDMAppleProfilePayload{
+			ProfileUUID: "aOldProfileUUID", ProfileIdentifier: identifier, ProfileName: "Wi-Fi",
+			HostUUID: hostUUID, Scope: fleet.PayloadScopeSystem, Checksum: []byte("aaaa"),
+			OperationType: fleet.MDMOperationTypeRemove, Status: &fleet.MDMDeliveryPending,
+			CommandUUID: "remove-cmd", CancelOnly: true,
+		}
+	}
+
+	type results struct {
+		deletedCmds map[string][]string
+		enqueued    []string
+		cleanedUp   []*fleet.MDMAppleProfilePayload
+		upserted    []*fleet.MDMAppleBulkUpsertHostProfilePayload
+	}
+
+	run := func(t *testing.T, toInstall, toRemove []*fleet.MDMAppleProfilePayload) *results {
+		t.Helper()
+		res := &results{deletedCmds: map[string][]string{}}
+
+		mdmStorage := &mdmmock.MDMAppleStore{}
+		ds := new(mock.Store)
+		kv := new(mock.AdvancedKVStore)
+		pushFactory, _ := newMockAPNSPushProviderFactory()
+		cmdr := NewMDMAppleCommander(mdmStorage, nanomdm_pushsvc.New(mdmStorage, mdmStorage, pushFactory, stdlogfmt.New()))
+
+		kv.MGetFunc = func(ctx context.Context, keys []string) (map[string]*string, error) {
+			return map[string]*string{}, nil
+		}
+		ds.GetNanoMDMUserEnrollmentFunc = func(ctx context.Context, hostUUID string) (*fleet.NanoEnrollment, error) {
+			return nil, nil
+		}
+		ds.GetMDMAppleProfilesContentsFunc = func(ctx context.Context, uuids []string) (map[string]mobileconfig.Mobileconfig, error) {
+			return map[string]mobileconfig.Mobileconfig{"aNewProfileUUID": []byte("content")}, nil
+		}
+		ds.GetGroupedCertificateAuthoritiesFunc = func(ctx context.Context, includeSecrets bool) (*fleet.GroupedCertificateAuthorities, error) {
+			return &fleet.GroupedCertificateAuthorities{}, nil
+		}
+		ds.BulkDeleteMDMAppleHostsConfigProfilesFunc = func(ctx context.Context, payload []*fleet.MDMAppleProfilePayload) error {
+			res.cleanedUp = append(res.cleanedUp, payload...)
+			return nil
+		}
+		ds.BulkUpsertMDMAppleHostProfilesFunc = func(ctx context.Context, payload []*fleet.MDMAppleBulkUpsertHostProfilePayload) error {
+			res.upserted = append(res.upserted, payload...)
+			return nil
+		}
+
+		var mu sync.Mutex
+		mdmStorage.BulkDeleteHostUserCommandsWithoutResultsFunc = func(ctx context.Context, commandToIDs map[string][]string) error {
+			mu.Lock()
+			defer mu.Unlock()
+			for cmd, ids := range commandToIDs {
+				res.deletedCmds[cmd] = append(res.deletedCmds[cmd], ids...)
+			}
+			return nil
+		}
+		mdmStorage.EnqueueCommandFunc = func(ctx context.Context, id []string, cmd *mdm.CommandWithSubtype) (map[string]error, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			res.enqueued = append(res.enqueued, cmd.Command.Command.RequestType)
+			return nil, nil
+		}
+		mdmStorage.RetrievePushInfoFunc = func(ctx context.Context, tokens []string) (map[string]*mdm.Push, error) {
+			out := make(map[string]*mdm.Push, len(tokens))
+			for _, tok := range tokens {
+				out[tok] = &mdm.Push{Token: []byte(tok)}
+			}
+			return out, nil
+		}
+		mdmStorage.RetrievePushCertFunc = func(ctx context.Context, topic string) (*tls.Certificate, string, error) {
+			cert, err := tls.LoadX509KeyPair("../../service/testdata/server.pem", "../../service/testdata/server.key")
+			return &cert, "", err
+		}
+		mdmStorage.IsPushCertStaleFunc = func(ctx context.Context, topic string, staleToken string) (bool, error) {
+			return false, nil
+		}
+		mdmStorage.GetAllMDMConfigAssetsByNameFunc = func(ctx context.Context, names []fleet.MDMAssetName,
+			_ sqlx.QueryerContext,
+		) (map[fleet.MDMAssetName]fleet.MDMConfigAsset, error) {
+			certPEM, err := os.ReadFile("../../service/testdata/server.pem")
+			require.NoError(t, err)
+			keyPEM, err := os.ReadFile("../../service/testdata/server.key")
+			require.NoError(t, err)
+			return map[fleet.MDMAssetName]fleet.MDMConfigAsset{
+				fleet.MDMAssetCACert: {Value: certPEM},
+				fleet.MDMAssetCAKey:  {Value: keyPEM},
+			}, nil
+		}
+
+		appCfg := &fleet.AppConfig{}
+		appCfg.ServerSettings.ServerURL = "https://test.example.com"
+		appCfg.MDM.EnabledAndConfigured = true
+
+		_, err := ExecuteReconcileBatch(t.Context(), ds, cmdr, kv, slog.New(slog.DiscardHandler), appCfg, 0, toInstall, toRemove)
+		require.NoError(t, err)
+		return res
+	}
+
+	t.Run("install present: removal cancelled, no RemoveProfile sent", func(t *testing.T) {
+		res := run(t, []*fleet.MDMAppleProfilePayload{newInstall()}, []*fleet.MDMAppleProfilePayload{cancelOnly()})
+
+		require.Contains(t, res.deletedCmds, "remove-cmd")
+		require.Equal(t, []string{hostUUID}, res.deletedCmds["remove-cmd"])
+		require.Equal(t, []string{"InstallProfile"}, res.enqueued)
+
+		require.Len(t, res.cleanedUp, 1)
+		require.Equal(t, "aOldProfileUUID", res.cleanedUp[0].ProfileUUID)
+
+		// the re-added profile must be installed, not left carrying the removal's state
+		require.Len(t, res.upserted, 1)
+		require.Equal(t, "aNewProfileUUID", res.upserted[0].ProfileUUID)
+		require.Equal(t, fleet.MDMOperationTypeInstall, res.upserted[0].OperationType)
+		require.NotEmpty(t, res.upserted[0].CommandUUID)
+	})
+
+	t.Run("install filtered out: removal left untouched", func(t *testing.T) {
+		res := run(t, nil, []*fleet.MDMAppleProfilePayload{cancelOnly()})
+
+		require.Empty(t, res.deletedCmds, "nothing to supersede, so the queued command must stand")
+		require.Empty(t, res.enqueued, "a cancel-only row must never send a RemoveProfile")
+		require.Empty(t, res.cleanedUp)
+	})
+}

--- a/server/mdm/apple/reconcile_test.go
+++ b/server/mdm/apple/reconcile_test.go
@@ -2097,7 +2097,6 @@ func TestComputeReconcileDeltasCancelsSupersededRemoval(t *testing.T) {
 		Checksum:          []byte("aaaa"),
 		IncludeMode:       fleet.AppleProfileIncludeNone,
 	}
-	// same identifier, different profile UUID, removal already sent to the device
 	staleRemoval := &fleet.MDMAppleProfilePayload{
 		ProfileUUID:       "aOldProfileUUID",
 		ProfileIdentifier: "com.example.wifi",
@@ -2141,8 +2140,8 @@ func TestComputeReconcileDeltasCancelsSupersededRemoval(t *testing.T) {
 }
 
 // End of the same flow: the cancel-only removal must pull its queued command out
-// without ever sending a RemoveProfile, and must be dropped entirely when the
-// install that justified it did not survive the callers' filters.
+// without ever sending a RemoveProfile, and must be left untouched when the install
+// that justified it did not survive the callers' filters.
 func TestMDMAppleExecuteReconcileBatchCancelOnlyRemoval(t *testing.T) {
 	const hostUUID = "uuid-A"
 	const identifier = "com.example.wifi"
@@ -2275,4 +2274,45 @@ func TestMDMAppleExecuteReconcileBatchCancelOnlyRemoval(t *testing.T) {
 		require.Empty(t, res.enqueued, "a cancel-only row must never send a RemoveProfile")
 		require.Empty(t, res.cleanedUp)
 	})
+}
+
+// A profile re-added with a different PayloadScope lands on the other channel, so
+// the queued removal on the original channel still has to be delivered: the two are
+// separate installs with separate enrollment IDs.
+func TestComputeReconcileDeltasScopeChangeKeepsRemoval(t *testing.T) {
+	host := &fleet.AppleHostReconcileInfo{
+		HostID: 1, UUID: "uuid-A", TeamID: nil, Platform: "darwin",
+		LabelUpdatedAt: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+	}
+	readdedAsSystem := &fleet.AppleProfileForReconcile{
+		ProfileUUID:       "aNewProfileUUID",
+		ProfileIdentifier: "com.example.wifi",
+		ProfileName:       "Wi-Fi",
+		TeamID:            0,
+		Checksum:          []byte("aaaa"),
+		Scope:             fleet.PayloadScopeSystem,
+		IncludeMode:       fleet.AppleProfileIncludeNone,
+	}
+	staleUserRemoval := &fleet.MDMAppleProfilePayload{
+		ProfileUUID:       "aOldProfileUUID",
+		ProfileIdentifier: "com.example.wifi",
+		ProfileName:       "Wi-Fi",
+		HostUUID:          "uuid-A",
+		Checksum:          []byte("aaaa"),
+		Scope:             fleet.PayloadScopeUser,
+		OperationType:     fleet.MDMOperationTypeRemove,
+		Status:            &fleet.MDMDeliveryPending,
+		CommandUUID:       "remove-cmd",
+	}
+
+	toInstall, toRemove := ComputeReconcileDeltas(
+		[]*fleet.AppleHostReconcileInfo{host}, nil,
+		map[string][]*fleet.MDMAppleProfilePayload{"uuid-A": {staleUserRemoval}},
+		map[uint][]*fleet.AppleProfileForReconcile{0: {readdedAsSystem}},
+		map[string]struct{}{},
+	)
+
+	require.Len(t, toInstall, 1)
+	require.Equal(t, fleet.PayloadScopeSystem, toInstall[0].Scope)
+	require.Empty(t, toRemove, "a user-channel removal must not be cancelled by a system-channel install")
 }


### PR DESCRIPTION
**Related issue:** Resolves #49573

Deleting an Apple configuration profile and adding it back creates a new profile UUID, so the host ends up with two rows for one identifier: the old one mid-removal and the new one awaiting install. The reconciler leaves a row alone once its removal has been sent, so the queued `RemoveProfile` survived and the host stripped the profile before reinstalling it.

The stale removal is now carried through marked cancel-only, so its command is deleted from the queue instead of being delivered. That only happens when an install for the same identifier on the same host survives the platform and scope filters — otherwise we'd be sending a removal for a profile the host is meant to keep.

Verified on an ADE-enrolled Mac. With the host offline, delete the profile, wait for the removal to be queued, then add it back:

- before: `RemoveProfile` and `InstallProfile` both queued, and on reconnect the Mac removed the profile and reinstalled it a second later
- after: only `InstallProfile` is queued, the removal never reaches the Mac, and the profile stays in place

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where an Apple configuration profile removed and re-added before host startup could be incorrectly removed again.
  * Reinstalled profiles now remain in place while obsolete pending removal commands are canceled safely.
  * Existing removal behavior remains unchanged when no replacement profile is installed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->