### PR TITLE
Add VEX CVE exclusions for `fleetdm/fleetctl`

### DIFF
--- a/security/status.md
+++ b/security/status.md
@@ -358,24 +358,27 @@ Following is the vulnerability report of Fleet and its dependencies.
 
 ### [CVE-2026-56862](https://nvd.nist.gov/vuln/detail/CVE-2026-56862)
 - **Author:** @lucasmrod
-- **Status:** `affected`
-- **Products:** `fleetctl@v4.90.0`,`fleetctl@v4.89.2`,`fleetctl@v4.89.1`,`fleetctl@v4.89.0`,`pkg:golang/stdlib@1.26.5`
-- **Action statement:** `Low impact: denial-of-service (CPU exhaustion) on the host running fleetctl. crypto/tls did not limit the number of post-handshake messages (e.g., KeyUpdate) it accepts, so a hostile TLS peer (malicious/compromised Fleet server or MITM) can keep a fleetctl TLS connection busy indefinitely. fleetctl is a CLI client, so the impact is limited to hanging the operator's command, which can be interrupted; no code execution or data disclosure, and the Fleet server itself is unaffected. Upgrade to fleetctl 4.91.x (built with Go 1.26.6) when available.`
-- **Timestamp:** 2026-08-17 10:37:26
+- **Status:** `not_affected`
+- **Status notes:** CVE-2026-56862 (GO-2026-6090) is a denial-of-service (CPU exhaustion) in crypto/tls, which did not limit the number of post-handshake messages (e.g., KeyUpdate) it accepts. Triggering it requires a hostile TLS peer (malicious/compromised Fleet server or MITM), and such an attacker can already deny service trivially (e.g., by stalling the connection). fleetctl is a CLI client, so the worst case is hanging the operator's command, which can be interrupted; no code execution or data disclosure, and the Fleet server itself is unaffected. The next fleetctl release (4.91.x) will be built with Go 1.26.6, which includes the fix.
+- **Products:** `fleetctl`,`pkg:golang/stdlib`
+- **Justification:** `vulnerable_code_cannot_be_controlled_by_adversary`
+- **Timestamp:** 2026-08-17 11:03:23
 
 ### [CVE-2026-56860](https://nvd.nist.gov/vuln/detail/CVE-2026-56860)
 - **Author:** @lucasmrod
-- **Status:** `affected`
-- **Products:** `fleetctl@v4.90.0`,`fleetctl@v4.89.2`,`fleetctl@v4.89.1`,`fleetctl@v4.89.0`,`pkg:golang/stdlib@1.26.5`
-- **Action statement:** `Low impact: denial-of-service (high CPU due to quadratic complexity in net/url path resolution) on the host running fleetctl. fleetctl resolves URLs from server responses (e.g., HTTP redirects), so a hostile or compromised server (or MITM) returning a URL with a pathological path can stall the fleetctl invocation. fleetctl is a CLI client, so the impact is limited to hanging the operator's command, which can be interrupted; no code execution or data disclosure, and the Fleet server itself is unaffected. Upgrade to fleetctl 4.91.x (built with Go 1.26.6) when available.`
-- **Timestamp:** 2026-08-17 10:37:22
+- **Status:** `not_affected`
+- **Status notes:** CVE-2026-56860 (GO-2026-6218) is a denial-of-service (high CPU due to quadratic complexity) in net/url path resolution. fleetctl resolves URLs it is configured with by the operator and URLs from responses of the operator-chosen Fleet server; triggering it requires a hostile or compromised server (or MITM) returning a URL with a pathological path, and such an attacker can already deny service trivially (e.g., by stalling responses). fleetctl is a CLI client, so the worst case is hanging the operator's command, which can be interrupted; no code execution or data disclosure, and the Fleet server itself is unaffected. The next fleetctl release (4.91.x) will be built with Go 1.26.6, which includes the fix.
+- **Products:** `fleetctl`,`pkg:golang/stdlib`
+- **Justification:** `vulnerable_code_cannot_be_controlled_by_adversary`
+- **Timestamp:** 2026-08-17 11:03:19
 
 ### [CVE-2026-56859](https://nvd.nist.gov/vuln/detail/CVE-2026-56859)
 - **Author:** @lucasmrod
-- **Status:** `affected`
-- **Products:** `fleetctl@v4.90.0`,`fleetctl@v4.89.2`,`fleetctl@v4.89.1`,`fleetctl@v4.89.0`,`pkg:golang/stdlib@1.26.5`
-- **Action statement:** `Low impact: denial-of-service (panic via unbounded recursion in encoding/xml) on the host running fleetctl. fleetctl decodes XML from inputs that can be influenced by third parties: MDM command results returned by enrolled (possibly compromised) hosts (e.g. 'fleetctl get mdm-command-results'), Apple MDM command plists, and XML processed during fleetd package generation. A deeply nested XML document can crash the fleetctl invocation. fleetctl is a CLI client, so the impact is limited to aborting the operator's command; no code execution or data disclosure, and the Fleet server itself is unaffected. Upgrade to fleetctl 4.91.x (built with Go 1.26.6) when available.`
-- **Timestamp:** 2026-08-17 10:37:18
+- **Status:** `not_affected`
+- **Status notes:** CVE-2026-56859 (GO-2026-6088) is a denial-of-service (panic via unbounded recursion) in encoding/xml. fleetctl decodes XML from MDM command results relayed by the Fleet server (e.g. 'fleetctl get mdm-command-results'), Apple MDM command plists provided by the operator, and XML generated locally during fleetd package builds. Triggering it requires control of those sources (a compromised enrolled host or the Fleet server itself), and the worst case is crashing the operator's CLI invocation; no code execution or data disclosure, and the Fleet server itself is unaffected. The next fleetctl release (4.91.x) will be built with Go 1.26.6, which includes the fix.
+- **Products:** `fleetctl`,`pkg:golang/stdlib`
+- **Justification:** `vulnerable_code_cannot_be_controlled_by_adversary`
+- **Timestamp:** 2026-08-17 11:03:15
 
 ### [CVE-2026-56858](https://nvd.nist.gov/vuln/detail/CVE-2026-56858)
 - **Author:** @lucasmrod
@@ -483,10 +486,11 @@ Following is the vulnerability report of Fleet and its dependencies.
 
 ### [CVE-2026-39821](https://nvd.nist.gov/vuln/detail/CVE-2026-39821)
 - **Author:** @lucasmrod
-- **Status:** `affected`
-- **Products:** `fleetctl@v4.90.0`,`fleetctl@v4.89.2`,`fleetctl@v4.89.1`,`fleetctl@v4.89.0`,`pkg:golang/stdlib@1.26.5`
-- **Action statement:** `Low probability of exploit: golang.org/x/net/idna (used by the net/http client fleetctl uses for all API requests) fails to reject ASCII-only Punycode-encoded labels, which can cause a hostname to be interpreted differently than validated. Exploitation requires an attacker able to influence a hostname fleetctl connects to (e.g., a crafted URL in GitOps configuration or a crafted server response) so the request resolves to an unexpected host. fleetctl is a CLI client and only sends its API token to the operator-configured server URL, limiting practical impact. Upgrade to fleetctl 4.91.x (built with Go 1.26.6) when available.`
-- **Timestamp:** 2026-08-17 10:37:13
+- **Status:** `not_affected`
+- **Status notes:** CVE-2026-39821 (GO-2026-5026): golang.org/x/net/idna (used by the net/http client for all fleetctl API requests) fails to reject ASCII-only Punycode-encoded labels, which can cause a hostname to be interpreted differently than validated. The hostnames fleetctl connects to are operator-controlled (the configured Fleet server URL and URLs the operator provides, e.g. in GitOps configuration); an adversary would need to socially engineer the operator into using a crafted hostname. fleetctl is a CLI client and only sends its API token to the operator-configured server URL, so practical impact is negligible. The next fleetctl release (4.91.x) will be built with Go 1.26.6, which includes the fix.
+- **Products:** `fleetctl`,`pkg:golang/stdlib`
+- **Justification:** `vulnerable_code_cannot_be_controlled_by_adversary`
+- **Timestamp:** 2026-08-17 11:03:11
 
 ### [CVE-2026-34875](https://nvd.nist.gov/vuln/detail/CVE-2026-34875)
 - **Author:** @lucasmrod
@@ -514,10 +518,11 @@ Following is the vulnerability report of Fleet and its dependencies.
 
 ### [CVE-2026-33818](https://nvd.nist.gov/vuln/detail/CVE-2026-33818)
 - **Author:** @lucasmrod
-- **Status:** `affected`
-- **Products:** `fleetctl@v4.90.0`,`fleetctl@v4.89.2`,`fleetctl@v4.89.1`,`fleetctl@v4.89.0`,`pkg:golang/stdlib@1.26.5`
-- **Action statement:** `Low impact: denial-of-service (panic via stack exhaustion in encoding/asn1) on the host running fleetctl. fleetctl parses ASN.1 (X.509 certificates) from TLS handshakes, so a hostile TLS peer (malicious/compromised Fleet server or MITM) presenting a certificate with deeply nested ASN.1 structures can crash the fleetctl invocation. fleetctl is a CLI client, so the impact is limited to aborting the operator's command; no code execution or data disclosure, and the Fleet server itself is unaffected. Upgrade to fleetctl 4.91.x (built with Go 1.26.6) when available.`
-- **Timestamp:** 2026-08-17 10:37:08
+- **Status:** `not_affected`
+- **Status notes:** CVE-2026-33818 (GO-2026-5972) is a denial-of-service (panic via stack exhaustion) in encoding/asn1. fleetctl parses ASN.1 (X.509 certificates) from TLS handshakes, so triggering it requires a hostile TLS peer: a malicious/compromised Fleet server or a MITM presenting a certificate with deeply nested ASN.1 structures. Such an attacker can already deny service trivially (e.g., by dropping the connection), and fleetctl is a CLI client, so the worst case is aborting the operator's command; no code execution or data disclosure, and the Fleet server itself is unaffected. The next fleetctl release (4.91.x) will be built with Go 1.26.6, which includes the fix.
+- **Products:** `fleetctl`,`pkg:golang/stdlib`
+- **Justification:** `vulnerable_code_cannot_be_controlled_by_adversary`
+- **Timestamp:** 2026-08-17 11:03:06
 
 ### [CVE-2026-33810](https://nvd.nist.gov/vuln/detail/CVE-2026-33810)
 - **Author:** @lucasmrod

--- a/security/status.md
+++ b/security/status.md
@@ -356,6 +356,43 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2026-07-27 17:15:39
 
+### [CVE-2026-56862](https://nvd.nist.gov/vuln/detail/CVE-2026-56862)
+- **Author:** @lucasmrod
+- **Status:** `affected`
+- **Products:** `fleetctl@v4.90.0`,`fleetctl@v4.89.2`,`fleetctl@v4.89.1`,`fleetctl@v4.89.0`,`pkg:golang/stdlib@1.26.5`
+- **Action statement:** `Low impact: denial-of-service (CPU exhaustion) on the host running fleetctl. crypto/tls did not limit the number of post-handshake messages (e.g., KeyUpdate) it accepts, so a hostile TLS peer (malicious/compromised Fleet server or MITM) can keep a fleetctl TLS connection busy indefinitely. fleetctl is a CLI client, so the impact is limited to hanging the operator's command, which can be interrupted; no code execution or data disclosure, and the Fleet server itself is unaffected. Upgrade to fleetctl 4.91.x (built with Go 1.26.6) when available.`
+- **Timestamp:** 2026-08-17 10:37:26
+
+### [CVE-2026-56860](https://nvd.nist.gov/vuln/detail/CVE-2026-56860)
+- **Author:** @lucasmrod
+- **Status:** `affected`
+- **Products:** `fleetctl@v4.90.0`,`fleetctl@v4.89.2`,`fleetctl@v4.89.1`,`fleetctl@v4.89.0`,`pkg:golang/stdlib@1.26.5`
+- **Action statement:** `Low impact: denial-of-service (high CPU due to quadratic complexity in net/url path resolution) on the host running fleetctl. fleetctl resolves URLs from server responses (e.g., HTTP redirects), so a hostile or compromised server (or MITM) returning a URL with a pathological path can stall the fleetctl invocation. fleetctl is a CLI client, so the impact is limited to hanging the operator's command, which can be interrupted; no code execution or data disclosure, and the Fleet server itself is unaffected. Upgrade to fleetctl 4.91.x (built with Go 1.26.6) when available.`
+- **Timestamp:** 2026-08-17 10:37:22
+
+### [CVE-2026-56859](https://nvd.nist.gov/vuln/detail/CVE-2026-56859)
+- **Author:** @lucasmrod
+- **Status:** `affected`
+- **Products:** `fleetctl@v4.90.0`,`fleetctl@v4.89.2`,`fleetctl@v4.89.1`,`fleetctl@v4.89.0`,`pkg:golang/stdlib@1.26.5`
+- **Action statement:** `Low impact: denial-of-service (panic via unbounded recursion in encoding/xml) on the host running fleetctl. fleetctl decodes XML from inputs that can be influenced by third parties: MDM command results returned by enrolled (possibly compromised) hosts (e.g. 'fleetctl get mdm-command-results'), Apple MDM command plists, and XML processed during fleetd package generation. A deeply nested XML document can crash the fleetctl invocation. fleetctl is a CLI client, so the impact is limited to aborting the operator's command; no code execution or data disclosure, and the Fleet server itself is unaffected. Upgrade to fleetctl 4.91.x (built with Go 1.26.6) when available.`
+- **Timestamp:** 2026-08-17 10:37:18
+
+### [CVE-2026-56858](https://nvd.nist.gov/vuln/detail/CVE-2026-56858)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** CVE-2026-56858 (GO-2026-6091) is an escaping bug in html/template's JavaScript regular-expression context tracking that can lead to cross-site scripting when untrusted data is interpolated into a JavaScript regexp context of an HTML template rendered to a browser. fleetctl's only html/template usage is a fixed plain-text template that renders script results to the operator's terminal (cmd/fleetctl/fleetctl/scripts.go renderScriptResult); the template contains no HTML, script, or JavaScript regexp contexts, so the vulnerable escaping code path is never exercised, and the output is written to a terminal, not rendered by a browser. The next fleetctl release (4.91.x) will be built with Go 1.26.6, which includes the fix.
+- **Products:** `fleetctl`,`pkg:golang/stdlib`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-08-17 10:36:56
+
+### [CVE-2026-56853](https://nvd.nist.gov/vuln/detail/CVE-2026-56853)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** CVE-2026-56853 (GO-2026-6089) is a denial-of-service in the Go net/http server: ReadHeaderTimeout was not applied while checking for unencrypted HTTP/2 (h2c) connections, allowing a client to hold server connections open indefinitely. fleetctl is a CLI client and does not run an HTTP server. govulncheck on cmd/fleetctl (GOOS=linux, Go 1.26.5) confirms the vulnerable server-side symbols are not reachable; net/http is only linked for client use. Trivy flags it solely because the binary embeds the go1.26.5 toolchain. The next fleetctl release (4.91.x) will be built with Go 1.26.6, which includes the fix.
+- **Products:** `fleetctl`,`pkg:golang/stdlib`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-08-17 10:36:47
+
 ### [CVE-2026-56852](https://nvd.nist.gov/vuln/detail/CVE-2026-56852)
 - **Author:** @lucasmrod
 - **Status:** `not_affected`
@@ -380,6 +417,14 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2026-07-01 13:33:33
 
+### [CVE-2026-54399](https://nvd.nist.gov/vuln/detail/CVE-2026-54399)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** CVE-2026-54399 is a denial-of-service in Apache HttpComponents Core (httpcore5) when a Java HTTP server parses requests with excessive HTTP headers. The httpcore5 jar is present in the fleetdm/fleetctl image only as part of Apple Transporter (itms), which fleetctl invokes as a client tool to upload macOS packages to Apple. fleetctl is not a Java server and no Java HTTP server ever runs in the image, so the vulnerable server-side header-parsing code is never executed.
+- **Products:** `fleetctl`,`pkg:maven/org.apache.httpcomponents.core5/httpcore5`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-08-17 10:36:37
+
 ### [CVE-2026-46604](https://nvd.nist.gov/vuln/detail/CVE-2026-46604)
 - **Author:** @lucasmrod
 - **Status:** `not_affected`
@@ -395,6 +440,14 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Products:** `fleetctl`,`pkg:golang/golang.org/x/image`
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2026-07-27 14:10:31
+
+### [CVE-2026-46600](https://nvd.nist.gov/vuln/detail/CVE-2026-46600)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** CVE-2026-46600 (GO-2026-5942) is a panic in golang.org/x/net/dns/dnsmessage (vendored into the Go standard library net package) when parsing an invalid SVCB or HTTPS DNS resource record. govulncheck on cmd/fleetctl (GOOS=linux, Go 1.26.5) confirms the vulnerable symbols are never called: the Go resolver paths used by fleetctl's DNS lookups do not request or parse SVCB/HTTPS records. Trivy flags it solely because the binary embeds the go1.26.5 toolchain. The next fleetctl release (4.91.x) will be built with Go 1.26.6, which includes the fix.
+- **Products:** `fleetctl`,`pkg:golang/stdlib`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-08-17 10:36:51
 
 ### [CVE-2026-42504](https://nvd.nist.gov/vuln/detail/CVE-2026-42504)
 - **Author:** @lucasmrod
@@ -428,6 +481,13 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Justification:** `vulnerable_code_cannot_be_controlled_by_adversary`
 - **Timestamp:** 2026-04-27 17:38:09
 
+### [CVE-2026-39821](https://nvd.nist.gov/vuln/detail/CVE-2026-39821)
+- **Author:** @lucasmrod
+- **Status:** `affected`
+- **Products:** `fleetctl@v4.90.0`,`fleetctl@v4.89.2`,`fleetctl@v4.89.1`,`fleetctl@v4.89.0`,`pkg:golang/stdlib@1.26.5`
+- **Action statement:** `Low probability of exploit: golang.org/x/net/idna (used by the net/http client fleetctl uses for all API requests) fails to reject ASCII-only Punycode-encoded labels, which can cause a hostname to be interpreted differently than validated. Exploitation requires an attacker able to influence a hostname fleetctl connects to (e.g., a crafted URL in GitOps configuration or a crafted server response) so the request resolves to an unexpected host. fleetctl is a CLI client and only sends its API token to the operator-configured server URL, limiting practical impact. Upgrade to fleetctl 4.91.x (built with Go 1.26.6) when available.`
+- **Timestamp:** 2026-08-17 10:37:13
+
 ### [CVE-2026-34875](https://nvd.nist.gov/vuln/detail/CVE-2026-34875)
 - **Author:** @lucasmrod
 - **Status:** `not_affected`
@@ -451,6 +511,13 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Products:** `fleetctl`,`pkg:deb/debian/libgnutls30t64`
 - **Justification:** `vulnerable_code_cannot_be_controlled_by_adversary`
 - **Timestamp:** 2026-05-07 12:01:42
+
+### [CVE-2026-33818](https://nvd.nist.gov/vuln/detail/CVE-2026-33818)
+- **Author:** @lucasmrod
+- **Status:** `affected`
+- **Products:** `fleetctl@v4.90.0`,`fleetctl@v4.89.2`,`fleetctl@v4.89.1`,`fleetctl@v4.89.0`,`pkg:golang/stdlib@1.26.5`
+- **Action statement:** `Low impact: denial-of-service (panic via stack exhaustion in encoding/asn1) on the host running fleetctl. fleetctl parses ASN.1 (X.509 certificates) from TLS handshakes, so a hostile TLS peer (malicious/compromised Fleet server or MITM) presenting a certificate with deeply nested ASN.1 structures can crash the fleetctl invocation. fleetctl is a CLI client, so the impact is limited to aborting the operator's command; no code execution or data disclosure, and the Fleet server itself is unaffected. Upgrade to fleetctl 4.91.x (built with Go 1.26.6) when available.`
+- **Timestamp:** 2026-08-17 10:37:08
 
 ### [CVE-2026-33810](https://nvd.nist.gov/vuln/detail/CVE-2026-33810)
 - **Author:** @lucasmrod

--- a/security/vex/fleetctl/CVE-2026-33818.vex.json
+++ b/security/vex/fleetctl/CVE-2026-33818.vex.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
-  "@id": "https://openvex.dev/docs/public/vex-31a1c3aa665942713a27afc37253a6707940927ed960103728451b631e26d7fe",
+  "@id": "https://openvex.dev/docs/public/vex-c3b7c44da2ca7588614db53708bbf2b0b7afa2189aa81009a73d510cfdc20c3a",
   "author": "@lucasmrod",
   "version": 1,
   "statements": [
@@ -13,26 +13,17 @@
       },
       "products": [
         {
-          "@id": "fleetctl@v4.90.0"
+          "@id": "fleetctl"
         },
         {
-          "@id": "fleetctl@v4.89.2"
-        },
-        {
-          "@id": "fleetctl@v4.89.1"
-        },
-        {
-          "@id": "fleetctl@v4.89.0"
-        },
-        {
-          "@id": "pkg:golang/stdlib@1.26.5"
+          "@id": "pkg:golang/stdlib"
         }
       ],
-      "status": "affected",
-      "action_statement": "Low impact: denial-of-service (panic via stack exhaustion in encoding/asn1) on the host running fleetctl. fleetctl parses ASN.1 (X.509 certificates) from TLS handshakes, so a hostile TLS peer (malicious/compromised Fleet server or MITM) presenting a certificate with deeply nested ASN.1 structures can crash the fleetctl invocation. fleetctl is a CLI client, so the impact is limited to aborting the operator's command; no code execution or data disclosure, and the Fleet server itself is unaffected. Upgrade to fleetctl 4.91.x (built with Go 1.26.6) when available.",
-      "action_statement_timestamp": "2026-08-17T07:37:08.731608-03:00",
-      "timestamp": "2026-08-17T10:37:08.731608Z"
+      "status": "not_affected",
+      "status_notes": "CVE-2026-33818 (GO-2026-5972) is a denial-of-service (panic via stack exhaustion) in encoding/asn1. fleetctl parses ASN.1 (X.509 certificates) from TLS handshakes, so triggering it requires a hostile TLS peer: a malicious/compromised Fleet server or a MITM presenting a certificate with deeply nested ASN.1 structures. Such an attacker can already deny service trivially (e.g., by dropping the connection), and fleetctl is a CLI client, so the worst case is aborting the operator's command; no code execution or data disclosure, and the Fleet server itself is unaffected. The next fleetctl release (4.91.x) will be built with Go 1.26.6, which includes the fix.",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "timestamp": "2026-08-17T11:03:06.697677Z"
     }
   ],
-  "timestamp": "2026-08-17T10:37:08Z"
+  "timestamp": "2026-08-17T11:03:06Z"
 }

--- a/security/vex/fleetctl/CVE-2026-33818.vex.json
+++ b/security/vex/fleetctl/CVE-2026-33818.vex.json
@@ -1,0 +1,38 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-31a1c3aa665942713a27afc37253a6707940927ed960103728451b631e26d7fe",
+  "author": "@lucasmrod",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-33818",
+        "aliases": [
+          "https://pkg.go.dev/vuln/GO-2026-5972"
+        ]
+      },
+      "products": [
+        {
+          "@id": "fleetctl@v4.90.0"
+        },
+        {
+          "@id": "fleetctl@v4.89.2"
+        },
+        {
+          "@id": "fleetctl@v4.89.1"
+        },
+        {
+          "@id": "fleetctl@v4.89.0"
+        },
+        {
+          "@id": "pkg:golang/stdlib@1.26.5"
+        }
+      ],
+      "status": "affected",
+      "action_statement": "Low impact: denial-of-service (panic via stack exhaustion in encoding/asn1) on the host running fleetctl. fleetctl parses ASN.1 (X.509 certificates) from TLS handshakes, so a hostile TLS peer (malicious/compromised Fleet server or MITM) presenting a certificate with deeply nested ASN.1 structures can crash the fleetctl invocation. fleetctl is a CLI client, so the impact is limited to aborting the operator's command; no code execution or data disclosure, and the Fleet server itself is unaffected. Upgrade to fleetctl 4.91.x (built with Go 1.26.6) when available.",
+      "action_statement_timestamp": "2026-08-17T07:37:08.731608-03:00",
+      "timestamp": "2026-08-17T10:37:08.731608Z"
+    }
+  ],
+  "timestamp": "2026-08-17T10:37:08Z"
+}

--- a/security/vex/fleetctl/CVE-2026-39821.vex.json
+++ b/security/vex/fleetctl/CVE-2026-39821.vex.json
@@ -1,0 +1,38 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-0ed2e23ebef95d89f455035dcc1acc0934e4b46df6ecaeaded3ae356fa64751e",
+  "author": "@lucasmrod",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39821",
+        "aliases": [
+          "https://pkg.go.dev/vuln/GO-2026-5026"
+        ]
+      },
+      "products": [
+        {
+          "@id": "fleetctl@v4.90.0"
+        },
+        {
+          "@id": "fleetctl@v4.89.2"
+        },
+        {
+          "@id": "fleetctl@v4.89.1"
+        },
+        {
+          "@id": "fleetctl@v4.89.0"
+        },
+        {
+          "@id": "pkg:golang/stdlib@1.26.5"
+        }
+      ],
+      "status": "affected",
+      "action_statement": "Low probability of exploit: golang.org/x/net/idna (used by the net/http client fleetctl uses for all API requests) fails to reject ASCII-only Punycode-encoded labels, which can cause a hostname to be interpreted differently than validated. Exploitation requires an attacker able to influence a hostname fleetctl connects to (e.g., a crafted URL in GitOps configuration or a crafted server response) so the request resolves to an unexpected host. fleetctl is a CLI client and only sends its API token to the operator-configured server URL, limiting practical impact. Upgrade to fleetctl 4.91.x (built with Go 1.26.6) when available.",
+      "action_statement_timestamp": "2026-08-17T07:37:13.679905-03:00",
+      "timestamp": "2026-08-17T10:37:13.679905Z"
+    }
+  ],
+  "timestamp": "2026-08-17T10:37:13Z"
+}

--- a/security/vex/fleetctl/CVE-2026-39821.vex.json
+++ b/security/vex/fleetctl/CVE-2026-39821.vex.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
-  "@id": "https://openvex.dev/docs/public/vex-0ed2e23ebef95d89f455035dcc1acc0934e4b46df6ecaeaded3ae356fa64751e",
+  "@id": "https://openvex.dev/docs/public/vex-d59c7105de0635f2ee9ba5782236231bd6cbf8c028b03830992eae6e0f828923",
   "author": "@lucasmrod",
   "version": 1,
   "statements": [
@@ -13,26 +13,17 @@
       },
       "products": [
         {
-          "@id": "fleetctl@v4.90.0"
+          "@id": "fleetctl"
         },
         {
-          "@id": "fleetctl@v4.89.2"
-        },
-        {
-          "@id": "fleetctl@v4.89.1"
-        },
-        {
-          "@id": "fleetctl@v4.89.0"
-        },
-        {
-          "@id": "pkg:golang/stdlib@1.26.5"
+          "@id": "pkg:golang/stdlib"
         }
       ],
-      "status": "affected",
-      "action_statement": "Low probability of exploit: golang.org/x/net/idna (used by the net/http client fleetctl uses for all API requests) fails to reject ASCII-only Punycode-encoded labels, which can cause a hostname to be interpreted differently than validated. Exploitation requires an attacker able to influence a hostname fleetctl connects to (e.g., a crafted URL in GitOps configuration or a crafted server response) so the request resolves to an unexpected host. fleetctl is a CLI client and only sends its API token to the operator-configured server URL, limiting practical impact. Upgrade to fleetctl 4.91.x (built with Go 1.26.6) when available.",
-      "action_statement_timestamp": "2026-08-17T07:37:13.679905-03:00",
-      "timestamp": "2026-08-17T10:37:13.679905Z"
+      "status": "not_affected",
+      "status_notes": "CVE-2026-39821 (GO-2026-5026): golang.org/x/net/idna (used by the net/http client for all fleetctl API requests) fails to reject ASCII-only Punycode-encoded labels, which can cause a hostname to be interpreted differently than validated. The hostnames fleetctl connects to are operator-controlled (the configured Fleet server URL and URLs the operator provides, e.g. in GitOps configuration); an adversary would need to socially engineer the operator into using a crafted hostname. fleetctl is a CLI client and only sends its API token to the operator-configured server URL, so practical impact is negligible. The next fleetctl release (4.91.x) will be built with Go 1.26.6, which includes the fix.",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "timestamp": "2026-08-17T11:03:11.075198Z"
     }
   ],
-  "timestamp": "2026-08-17T10:37:13Z"
+  "timestamp": "2026-08-17T11:03:11Z"
 }

--- a/security/vex/fleetctl/CVE-2026-46600.vex.json
+++ b/security/vex/fleetctl/CVE-2026-46600.vex.json
@@ -1,0 +1,29 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-5840e95ae9275d64f07457bcbfc37565ab549342177c15e5890d1ca260654c2e",
+  "author": "@lucasmrod",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-46600",
+        "aliases": [
+          "https://pkg.go.dev/vuln/GO-2026-5942"
+        ]
+      },
+      "products": [
+        {
+          "@id": "fleetctl"
+        },
+        {
+          "@id": "pkg:golang/stdlib"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "CVE-2026-46600 (GO-2026-5942) is a panic in golang.org/x/net/dns/dnsmessage (vendored into the Go standard library net package) when parsing an invalid SVCB or HTTPS DNS resource record. govulncheck on cmd/fleetctl (GOOS=linux, Go 1.26.5) confirms the vulnerable symbols are never called: the Go resolver paths used by fleetctl's DNS lookups do not request or parse SVCB/HTTPS records. Trivy flags it solely because the binary embeds the go1.26.5 toolchain. The next fleetctl release (4.91.x) will be built with Go 1.26.6, which includes the fix.",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "timestamp": "2026-08-17T10:36:51.843374Z"
+    }
+  ],
+  "timestamp": "2026-08-17T10:36:51Z"
+}

--- a/security/vex/fleetctl/CVE-2026-54399.vex.json
+++ b/security/vex/fleetctl/CVE-2026-54399.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-91cdef5a0967fcae31a9fa071c76019a2c2c00b07af12c7aa9d3bf49540ece19",
+  "author": "@lucasmrod",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-54399"
+      },
+      "products": [
+        {
+          "@id": "fleetctl"
+        },
+        {
+          "@id": "pkg:maven/org.apache.httpcomponents.core5/httpcore5"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "CVE-2026-54399 is a denial-of-service in Apache HttpComponents Core (httpcore5) when a Java HTTP server parses requests with excessive HTTP headers. The httpcore5 jar is present in the fleetdm/fleetctl image only as part of Apple Transporter (itms), which fleetctl invokes as a client tool to upload macOS packages to Apple. fleetctl is not a Java server and no Java HTTP server ever runs in the image, so the vulnerable server-side header-parsing code is never executed.",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "timestamp": "2026-08-17T10:36:37.026023Z"
+    }
+  ],
+  "timestamp": "2026-08-17T10:36:37Z"
+}

--- a/security/vex/fleetctl/CVE-2026-56853.vex.json
+++ b/security/vex/fleetctl/CVE-2026-56853.vex.json
@@ -1,0 +1,29 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-0af718919c1705f3c200115365001b4698b4381156c61a072c267a6c3184accc",
+  "author": "@lucasmrod",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56853",
+        "aliases": [
+          "https://pkg.go.dev/vuln/GO-2026-6089"
+        ]
+      },
+      "products": [
+        {
+          "@id": "fleetctl"
+        },
+        {
+          "@id": "pkg:golang/stdlib"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "CVE-2026-56853 (GO-2026-6089) is a denial-of-service in the Go net/http server: ReadHeaderTimeout was not applied while checking for unencrypted HTTP/2 (h2c) connections, allowing a client to hold server connections open indefinitely. fleetctl is a CLI client and does not run an HTTP server. govulncheck on cmd/fleetctl (GOOS=linux, Go 1.26.5) confirms the vulnerable server-side symbols are not reachable; net/http is only linked for client use. Trivy flags it solely because the binary embeds the go1.26.5 toolchain. The next fleetctl release (4.91.x) will be built with Go 1.26.6, which includes the fix.",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "timestamp": "2026-08-17T10:36:47.478271Z"
+    }
+  ],
+  "timestamp": "2026-08-17T10:36:47Z"
+}

--- a/security/vex/fleetctl/CVE-2026-56858.vex.json
+++ b/security/vex/fleetctl/CVE-2026-56858.vex.json
@@ -1,0 +1,29 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-fafb7f4ea302046c86f7b127f70c9ed6791c740238854082d4a5287b751f1120",
+  "author": "@lucasmrod",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56858",
+        "aliases": [
+          "https://pkg.go.dev/vuln/GO-2026-6091"
+        ]
+      },
+      "products": [
+        {
+          "@id": "fleetctl"
+        },
+        {
+          "@id": "pkg:golang/stdlib"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "CVE-2026-56858 (GO-2026-6091) is an escaping bug in html/template's JavaScript regular-expression context tracking that can lead to cross-site scripting when untrusted data is interpolated into a JavaScript regexp context of an HTML template rendered to a browser. fleetctl's only html/template usage is a fixed plain-text template that renders script results to the operator's terminal (cmd/fleetctl/fleetctl/scripts.go renderScriptResult); the template contains no HTML, script, or JavaScript regexp contexts, so the vulnerable escaping code path is never exercised, and the output is written to a terminal, not rendered by a browser. The next fleetctl release (4.91.x) will be built with Go 1.26.6, which includes the fix.",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "timestamp": "2026-08-17T10:36:56.062475Z"
+    }
+  ],
+  "timestamp": "2026-08-17T10:36:56Z"
+}

--- a/security/vex/fleetctl/CVE-2026-56859.vex.json
+++ b/security/vex/fleetctl/CVE-2026-56859.vex.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
-  "@id": "https://openvex.dev/docs/public/vex-26a2d6fa71370874749c3f24e10c8a90812f11db24ccc321d86f61f6f6611043",
+  "@id": "https://openvex.dev/docs/public/vex-3f227d3d190304eacda724253f21034e6742a36b506b19670d46f178916c643c",
   "author": "@lucasmrod",
   "version": 1,
   "statements": [
@@ -13,26 +13,17 @@
       },
       "products": [
         {
-          "@id": "fleetctl@v4.90.0"
+          "@id": "fleetctl"
         },
         {
-          "@id": "fleetctl@v4.89.2"
-        },
-        {
-          "@id": "fleetctl@v4.89.1"
-        },
-        {
-          "@id": "fleetctl@v4.89.0"
-        },
-        {
-          "@id": "pkg:golang/stdlib@1.26.5"
+          "@id": "pkg:golang/stdlib"
         }
       ],
-      "status": "affected",
-      "action_statement": "Low impact: denial-of-service (panic via unbounded recursion in encoding/xml) on the host running fleetctl. fleetctl decodes XML from inputs that can be influenced by third parties: MDM command results returned by enrolled (possibly compromised) hosts (e.g. 'fleetctl get mdm-command-results'), Apple MDM command plists, and XML processed during fleetd package generation. A deeply nested XML document can crash the fleetctl invocation. fleetctl is a CLI client, so the impact is limited to aborting the operator's command; no code execution or data disclosure, and the Fleet server itself is unaffected. Upgrade to fleetctl 4.91.x (built with Go 1.26.6) when available.",
-      "action_statement_timestamp": "2026-08-17T07:37:18.037288-03:00",
-      "timestamp": "2026-08-17T10:37:18.037288Z"
+      "status": "not_affected",
+      "status_notes": "CVE-2026-56859 (GO-2026-6088) is a denial-of-service (panic via unbounded recursion) in encoding/xml. fleetctl decodes XML from MDM command results relayed by the Fleet server (e.g. 'fleetctl get mdm-command-results'), Apple MDM command plists provided by the operator, and XML generated locally during fleetd package builds. Triggering it requires control of those sources (a compromised enrolled host or the Fleet server itself), and the worst case is crashing the operator's CLI invocation; no code execution or data disclosure, and the Fleet server itself is unaffected. The next fleetctl release (4.91.x) will be built with Go 1.26.6, which includes the fix.",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "timestamp": "2026-08-17T11:03:15.316795Z"
     }
   ],
-  "timestamp": "2026-08-17T10:37:18Z"
+  "timestamp": "2026-08-17T11:03:15Z"
 }

--- a/security/vex/fleetctl/CVE-2026-56859.vex.json
+++ b/security/vex/fleetctl/CVE-2026-56859.vex.json
@@ -1,0 +1,38 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-26a2d6fa71370874749c3f24e10c8a90812f11db24ccc321d86f61f6f6611043",
+  "author": "@lucasmrod",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56859",
+        "aliases": [
+          "https://pkg.go.dev/vuln/GO-2026-6088"
+        ]
+      },
+      "products": [
+        {
+          "@id": "fleetctl@v4.90.0"
+        },
+        {
+          "@id": "fleetctl@v4.89.2"
+        },
+        {
+          "@id": "fleetctl@v4.89.1"
+        },
+        {
+          "@id": "fleetctl@v4.89.0"
+        },
+        {
+          "@id": "pkg:golang/stdlib@1.26.5"
+        }
+      ],
+      "status": "affected",
+      "action_statement": "Low impact: denial-of-service (panic via unbounded recursion in encoding/xml) on the host running fleetctl. fleetctl decodes XML from inputs that can be influenced by third parties: MDM command results returned by enrolled (possibly compromised) hosts (e.g. 'fleetctl get mdm-command-results'), Apple MDM command plists, and XML processed during fleetd package generation. A deeply nested XML document can crash the fleetctl invocation. fleetctl is a CLI client, so the impact is limited to aborting the operator's command; no code execution or data disclosure, and the Fleet server itself is unaffected. Upgrade to fleetctl 4.91.x (built with Go 1.26.6) when available.",
+      "action_statement_timestamp": "2026-08-17T07:37:18.037288-03:00",
+      "timestamp": "2026-08-17T10:37:18.037288Z"
+    }
+  ],
+  "timestamp": "2026-08-17T10:37:18Z"
+}

--- a/security/vex/fleetctl/CVE-2026-56860.vex.json
+++ b/security/vex/fleetctl/CVE-2026-56860.vex.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
-  "@id": "https://openvex.dev/docs/public/vex-4669ffcf46bc4f25645db4c9e427f7f3d2c829524543bcbf9cf237ddc74babcc",
+  "@id": "https://openvex.dev/docs/public/vex-f08f2c5663c4a8f83ef3c9761994f70c9f85e1540900fb8d6801e8cd3ab837af",
   "author": "@lucasmrod",
   "version": 1,
   "statements": [
@@ -13,26 +13,17 @@
       },
       "products": [
         {
-          "@id": "fleetctl@v4.90.0"
+          "@id": "fleetctl"
         },
         {
-          "@id": "fleetctl@v4.89.2"
-        },
-        {
-          "@id": "fleetctl@v4.89.1"
-        },
-        {
-          "@id": "fleetctl@v4.89.0"
-        },
-        {
-          "@id": "pkg:golang/stdlib@1.26.5"
+          "@id": "pkg:golang/stdlib"
         }
       ],
-      "status": "affected",
-      "action_statement": "Low impact: denial-of-service (high CPU due to quadratic complexity in net/url path resolution) on the host running fleetctl. fleetctl resolves URLs from server responses (e.g., HTTP redirects), so a hostile or compromised server (or MITM) returning a URL with a pathological path can stall the fleetctl invocation. fleetctl is a CLI client, so the impact is limited to hanging the operator's command, which can be interrupted; no code execution or data disclosure, and the Fleet server itself is unaffected. Upgrade to fleetctl 4.91.x (built with Go 1.26.6) when available.",
-      "action_statement_timestamp": "2026-08-17T07:37:22.809035-03:00",
-      "timestamp": "2026-08-17T10:37:22.809035Z"
+      "status": "not_affected",
+      "status_notes": "CVE-2026-56860 (GO-2026-6218) is a denial-of-service (high CPU due to quadratic complexity) in net/url path resolution. fleetctl resolves URLs it is configured with by the operator and URLs from responses of the operator-chosen Fleet server; triggering it requires a hostile or compromised server (or MITM) returning a URL with a pathological path, and such an attacker can already deny service trivially (e.g., by stalling responses). fleetctl is a CLI client, so the worst case is hanging the operator's command, which can be interrupted; no code execution or data disclosure, and the Fleet server itself is unaffected. The next fleetctl release (4.91.x) will be built with Go 1.26.6, which includes the fix.",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "timestamp": "2026-08-17T11:03:19.571291Z"
     }
   ],
-  "timestamp": "2026-08-17T10:37:22Z"
+  "timestamp": "2026-08-17T11:03:19Z"
 }

--- a/security/vex/fleetctl/CVE-2026-56860.vex.json
+++ b/security/vex/fleetctl/CVE-2026-56860.vex.json
@@ -1,0 +1,38 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-4669ffcf46bc4f25645db4c9e427f7f3d2c829524543bcbf9cf237ddc74babcc",
+  "author": "@lucasmrod",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56860",
+        "aliases": [
+          "https://pkg.go.dev/vuln/GO-2026-6218"
+        ]
+      },
+      "products": [
+        {
+          "@id": "fleetctl@v4.90.0"
+        },
+        {
+          "@id": "fleetctl@v4.89.2"
+        },
+        {
+          "@id": "fleetctl@v4.89.1"
+        },
+        {
+          "@id": "fleetctl@v4.89.0"
+        },
+        {
+          "@id": "pkg:golang/stdlib@1.26.5"
+        }
+      ],
+      "status": "affected",
+      "action_statement": "Low impact: denial-of-service (high CPU due to quadratic complexity in net/url path resolution) on the host running fleetctl. fleetctl resolves URLs from server responses (e.g., HTTP redirects), so a hostile or compromised server (or MITM) returning a URL with a pathological path can stall the fleetctl invocation. fleetctl is a CLI client, so the impact is limited to hanging the operator's command, which can be interrupted; no code execution or data disclosure, and the Fleet server itself is unaffected. Upgrade to fleetctl 4.91.x (built with Go 1.26.6) when available.",
+      "action_statement_timestamp": "2026-08-17T07:37:22.809035-03:00",
+      "timestamp": "2026-08-17T10:37:22.809035Z"
+    }
+  ],
+  "timestamp": "2026-08-17T10:37:22Z"
+}

--- a/security/vex/fleetctl/CVE-2026-56862.vex.json
+++ b/security/vex/fleetctl/CVE-2026-56862.vex.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
-  "@id": "https://openvex.dev/docs/public/vex-8631acf4714b0a98e2c439c38cf27c724d9a9df89eec123d9e26e840cc988f45",
+  "@id": "https://openvex.dev/docs/public/vex-d7d79d74c4d9bce4eed43e989c588cbf4df2c38cba438b5b46db100d1be0298d",
   "author": "@lucasmrod",
   "version": 1,
   "statements": [
@@ -13,26 +13,17 @@
       },
       "products": [
         {
-          "@id": "fleetctl@v4.90.0"
+          "@id": "fleetctl"
         },
         {
-          "@id": "fleetctl@v4.89.2"
-        },
-        {
-          "@id": "fleetctl@v4.89.1"
-        },
-        {
-          "@id": "fleetctl@v4.89.0"
-        },
-        {
-          "@id": "pkg:golang/stdlib@1.26.5"
+          "@id": "pkg:golang/stdlib"
         }
       ],
-      "status": "affected",
-      "action_statement": "Low impact: denial-of-service (CPU exhaustion) on the host running fleetctl. crypto/tls did not limit the number of post-handshake messages (e.g., KeyUpdate) it accepts, so a hostile TLS peer (malicious/compromised Fleet server or MITM) can keep a fleetctl TLS connection busy indefinitely. fleetctl is a CLI client, so the impact is limited to hanging the operator's command, which can be interrupted; no code execution or data disclosure, and the Fleet server itself is unaffected. Upgrade to fleetctl 4.91.x (built with Go 1.26.6) when available.",
-      "action_statement_timestamp": "2026-08-17T07:37:26.424623-03:00",
-      "timestamp": "2026-08-17T10:37:26.424623Z"
+      "status": "not_affected",
+      "status_notes": "CVE-2026-56862 (GO-2026-6090) is a denial-of-service (CPU exhaustion) in crypto/tls, which did not limit the number of post-handshake messages (e.g., KeyUpdate) it accepts. Triggering it requires a hostile TLS peer (malicious/compromised Fleet server or MITM), and such an attacker can already deny service trivially (e.g., by stalling the connection). fleetctl is a CLI client, so the worst case is hanging the operator's command, which can be interrupted; no code execution or data disclosure, and the Fleet server itself is unaffected. The next fleetctl release (4.91.x) will be built with Go 1.26.6, which includes the fix.",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "timestamp": "2026-08-17T11:03:23.543868Z"
     }
   ],
-  "timestamp": "2026-08-17T10:37:26Z"
+  "timestamp": "2026-08-17T11:03:23Z"
 }

--- a/security/vex/fleetctl/CVE-2026-56862.vex.json
+++ b/security/vex/fleetctl/CVE-2026-56862.vex.json
@@ -1,0 +1,38 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-8631acf4714b0a98e2c439c38cf27c724d9a9df89eec123d9e26e840cc988f45",
+  "author": "@lucasmrod",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56862",
+        "aliases": [
+          "https://pkg.go.dev/vuln/GO-2026-6090"
+        ]
+      },
+      "products": [
+        {
+          "@id": "fleetctl@v4.90.0"
+        },
+        {
+          "@id": "fleetctl@v4.89.2"
+        },
+        {
+          "@id": "fleetctl@v4.89.1"
+        },
+        {
+          "@id": "fleetctl@v4.89.0"
+        },
+        {
+          "@id": "pkg:golang/stdlib@1.26.5"
+        }
+      ],
+      "status": "affected",
+      "action_statement": "Low impact: denial-of-service (CPU exhaustion) on the host running fleetctl. crypto/tls did not limit the number of post-handshake messages (e.g., KeyUpdate) it accepts, so a hostile TLS peer (malicious/compromised Fleet server or MITM) can keep a fleetctl TLS connection busy indefinitely. fleetctl is a CLI client, so the impact is limited to hanging the operator's command, which can be interrupted; no code execution or data disclosure, and the Fleet server itself is unaffected. Upgrade to fleetctl 4.91.x (built with Go 1.26.6) when available.",
+      "action_statement_timestamp": "2026-08-17T07:37:26.424623-03:00",
+      "timestamp": "2026-08-17T10:37:26.424623Z"
+    }
+  ],
+  "timestamp": "2026-08-17T10:37:26Z"
+}


### PR DESCRIPTION
Fixes: https://github.com/fleetdm/fleet/actions/runs/32000621211.

New run: https://github.com/fleetdm/fleet/actions/runs/32023226868.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Added vulnerability assessments for multiple fleetctl and Go standard library security advisories.
  * Documented that most reviewed vulnerabilities do not affect fleetctl because the vulnerable code paths are not used.
  * Identified an XML recursion denial-of-service affecting fleetctl 4.89.0–4.90.0.
  * Recommended upgrading to fleetctl 4.91.x built with Go 1.26.6 for remediation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->