### PR TITLE
Add VEX exclusions for fleetdm/wix

### DIFF
--- a/security/status.md
+++ b/security/status.md
@@ -875,6 +875,14 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2026-07-01 13:31:34
 
+### [CVE-2026-53615](https://nvd.nist.gov/vuln/detail/CVE-2026-53615)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not probe block devices or parse partition tables (libblkid) when using fleetdm/wix to generate MSI packages.
+- **Products:** `wix`,`pkg:deb/debian/bsdutils`,`pkg:deb/debian/libblkid1`,`pkg:deb/debian/liblastlog2-2`,`pkg:deb/debian/libmount1`,`pkg:deb/debian/libsmartcols1`,`pkg:deb/debian/libuuid1`,`pkg:deb/debian/login`,`pkg:deb/debian/mount`,`pkg:deb/debian/util-linux`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-08-17 10:52:17
+
 ### [CVE-2026-5201](https://nvd.nist.gov/vuln/detail/CVE-2026-5201)
 - **Author:** @lucasmrod
 - **Status:** `not_affected`

--- a/security/vex/wix/CVE-2026-53615.vex.json
+++ b/security/vex/wix/CVE-2026-53615.vex.json
@@ -1,0 +1,50 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-04f146b658bca7989e6ead40fbaa3e86ddbe3ef66b423af4f30c94cc9cbc9fab",
+  "author": "@lucasmrod",
+  "timestamp": "2026-08-17T10:52:17.000000Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-53615"
+      },
+      "timestamp": "2026-08-17T10:52:17.000000Z",
+      "products": [
+        {
+          "@id": "wix"
+        },
+        {
+          "@id": "pkg:deb/debian/bsdutils"
+        },
+        {
+          "@id": "pkg:deb/debian/libblkid1"
+        },
+        {
+          "@id": "pkg:deb/debian/liblastlog2-2"
+        },
+        {
+          "@id": "pkg:deb/debian/libmount1"
+        },
+        {
+          "@id": "pkg:deb/debian/libsmartcols1"
+        },
+        {
+          "@id": "pkg:deb/debian/libuuid1"
+        },
+        {
+          "@id": "pkg:deb/debian/login"
+        },
+        {
+          "@id": "pkg:deb/debian/mount"
+        },
+        {
+          "@id": "pkg:deb/debian/util-linux"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not probe block devices or parse partition tables (libblkid) when using fleetdm/wix to generate MSI packages",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes: https://github.com/fleetdm/fleet/actions/runs/32000229926

New run: https://github.com/fleetdm/fleet/actions/runs/32022882816.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a security advisory documenting that the product is not affected by CVE-2026-53615.
  * Clarified that MSI generation does not probe block devices or parse partition tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->