### PR TITLE
Add big-table migration guidance to Claude database rules

### DIFF
--- a/.claude/rules/fleet-database.md
+++ b/.claude/rules/fleet-database.md
@@ -22,6 +22,21 @@ paths:
 - Test pattern: `applyUpToPrev(t)` → set up data → `applyNext(t, db)` → verify
 - Create with: `make migration name=YourChangeName`
 
+## Migrations on large tables
+Some tables hold hundreds of millions of rows in large deployments. A migration that scans or rewrites one of them can run for hours and block a customer's upgrade (this has happened in production). Any migration that reads or writes one of these tables needs extra scrutiny:
+
+- **One row per host**: `hosts`, `host_mdm`, `host_operating_system`, `host_disks`, `host_display_names`, `host_emails`, `host_issues`
+- **Many rows per host** (largest tables): `host_software`, `host_software_installed_paths`, `host_users`, `host_certificates`, `host_script_results`, `label_membership`, `policy_membership`, `scheduled_query_stats`, `host_mdm_apple_profiles`, `host_mdm_windows_profiles`, `host_mdm_managed_certificates`
+- **Software inventory**: `software`, `software_titles`, `software_cpe`, `software_cve`, `software_host_counts`, `software_titles_host_counts`
+- **Append-only event/queue tables**: `activities`, `upcoming_activities`, `nano_commands`, `nano_command_results`, `nano_enrollment_queue`, `windows_mdm_commands`, `windows_mdm_command_queue`, `windows_mdm_command_results`, `windows_mdm_responses`
+
+This list is not exhaustive — treat any table that scales with host count × per-host entities (software, certificates, profiles, query results) or that accumulates events/commands over time the same way.
+
+For migrations touching these tables:
+- Run `EXPLAIN` on every SELECT/UPDATE/DELETE and confirm it uses an index — never rely on the optimizer's default plan. Index statistics are often stale mid-migration, so the optimizer can silently pick a full table scan; consider `FORCE INDEX` on these tables when the right index exists. Do NOT apply `FORCE INDEX` as a blanket rule on small tables — it creates its own bugs.
+- Prefer batched updates (loop with LIMIT, log progress) over a single statement that touches every row.
+- Avoid DDL that rewrites the whole table (column type changes, etc.) when an online-safe alternative exists.
+
 ## Query Building
 - Use `goqu` (github.com/doug-martin/goqu/v9) for SQL query building
 - Pattern: `dialect.From(goqu.I("table_name")).Select(...).Where(...)`


### PR DESCRIPTION
**Related issue:** #50933

Adds a "Migrations on large tables" section to `.claude/rules/fleet-database.md` (the rules file that auto-loads for AI-assisted work on `server/datastore/**`), following up on [this discussion](https://github.com/fleetdm/fleet/issues/50933#issuecomment-5298737884).

Rather than a blanket `FORCE INDEX` rule, this puts extra scrutiny on migrations that read or write known-big tables:

- Lists the tables from the issue discussion (`hosts`, `host_software`, `host_certificates`, `activities`, `label_membership`, `policy_membership`, `windows_mdm_command_results`) plus others verified against `schema.sql` that share the same growth patterns (host-vitals tables, software inventory, MDM command/queue tables), grouped by why they're big.
- Adds a catch-all heuristic: any table scaling with host count × per-host entities, or accumulating events/commands over time, gets the same treatment.
- Guardrails: `EXPLAIN` every statement and confirm index use, consider `FORCE INDEX` on these tables (optimizer stats are often stale mid-migration), prefer batched updates with progress logging, avoid full-table-rewrite DDL when an online-safe alternative exists. Explicitly warns against blanket `FORCE INDEX` on small tables.

# Checklist for submitter

- [x] Documentation-only change to AI guidance rules; no code, tests, or migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
