### PR TITLE
Fleet UI: End user experience dropdown across software and policy forms

### DIFF
--- a/frontend/interfaces/platform.tests.ts
+++ b/frontend/interfaces/platform.tests.ts
@@ -1,0 +1,47 @@
+import { isMacOS, isWindows } from "./platform";
+
+describe("platform helpers", () => {
+  describe("isMacOS", () => {
+    it("matches a single darwin platform string", () => {
+      expect(isMacOS("darwin")).toBe(true);
+    });
+
+    it("matches the legacy macos platform string", () => {
+      expect(isMacOS("macos")).toBe(true);
+    });
+
+    it("matches a comma-joined platform string containing darwin", () => {
+      expect(isMacOS("darwin,linux")).toBe(true);
+      expect(isMacOS("windows,darwin")).toBe(true);
+    });
+
+    it("does not match Windows or Linux singletons", () => {
+      expect(isMacOS("windows")).toBe(false);
+      expect(isMacOS("linux")).toBe(false);
+    });
+
+    it("does not match an empty string", () => {
+      expect(isMacOS("")).toBe(false);
+    });
+  });
+
+  describe("isWindows", () => {
+    it("matches a single windows platform string", () => {
+      expect(isWindows("windows")).toBe(true);
+    });
+
+    it("matches a comma-joined platform string containing windows", () => {
+      expect(isWindows("windows,linux")).toBe(true);
+      expect(isWindows("darwin,windows")).toBe(true);
+    });
+
+    it("does not match Darwin or Linux singletons", () => {
+      expect(isWindows("darwin")).toBe(false);
+      expect(isWindows("linux")).toBe(false);
+    });
+
+    it("does not match an empty string", () => {
+      expect(isWindows("")).toBe(false);
+    });
+  });
+});

--- a/frontend/interfaces/platform.ts
+++ b/frontend/interfaces/platform.ts
@@ -151,11 +151,18 @@ export const isAppleDevice = (platform = "") => {
   );
 };
 
+// Accept both the single-value host platform (`"windows"`, `"darwin"`,
+// `"macos"`) and the comma-joined `CommaSeparatedPlatformString` from
+// policies (`"darwin,linux"`) so the same predicate works at the wire
+// boundary for patch policies without a second helper.
 export const isWindows = (platform: string | HostPlatform) =>
-  platform === "windows";
+  !!platform && platform.split(",").includes("windows");
 
-export const isMacOS = (platform: string | HostPlatform) =>
-  ["darwin", "macos"].includes(platform);
+export const isMacOS = (platform: string | HostPlatform) => {
+  if (!platform) return false;
+  const parts = platform.split(",");
+  return parts.includes("darwin") || parts.includes("macos");
+};
 
 export const isIPadOrIPhone = (platform: string | HostPlatform) =>
   ["ios", "ipados"].includes(platform);

--- a/frontend/interfaces/platform.ts
+++ b/frontend/interfaces/platform.ts
@@ -154,11 +154,12 @@ export const isAppleDevice = (platform = "") => {
 // Accept both the single-value host platform (`"windows"`, `"darwin"`,
 // `"macos"`) and the comma-joined `CommaSeparatedPlatformString` from
 // policies (`"darwin,linux"`) so the same predicate works at the wire
-// boundary for patch policies without a second helper.
-export const isWindows = (platform: string | HostPlatform) =>
+// boundary for patch policies without a second helper. `undefined` is
+// allowed so callers with `string | undefined` don't need to `?? ""`.
+export const isWindows = (platform: string | HostPlatform | undefined) =>
   !!platform && platform.split(",").includes("windows");
 
-export const isMacOS = (platform: string | HostPlatform) => {
+export const isMacOS = (platform: string | HostPlatform | undefined) => {
   if (!platform) return false;
   const parts = platform.split(",");
   return parts.includes("darwin") || parts.includes("macos");

--- a/frontend/interfaces/policy.ts
+++ b/frontend/interfaces/policy.ts
@@ -73,6 +73,7 @@ export interface IPolicy {
   patch_software?: IPolicySoftwareToInstall;
   continuous_automations_enabled?: boolean;
   patch_when_closed?: boolean;
+  notify_before_patching?: boolean;
   labels_include_any?: ILabelPolicy[];
   labels_include_all?: ILabelPolicy[];
   labels_exclude_any?: ILabelPolicy[];
@@ -148,6 +149,7 @@ export interface IPolicyFormData {
   conditional_access_enabled?: boolean;
   continuous_automations_enabled?: boolean;
   patch_when_closed?: boolean;
+  notify_before_patching?: boolean;
   software_title_id?: number | null;
   /** Pins the policy to a specific package on a multi-package title. `null`
    * on PATCH lets the backend fall back to the title's first-added package

--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -71,6 +71,7 @@ export interface ISoftwarePatchPolicy {
   name: string;
   patch_when_closed: boolean;
   continuous_automations_enabled: boolean;
+  notify_before_patching?: boolean;
 }
 
 export type SoftwareInstallPolicyType = "dynamic" | "patch";

--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -357,6 +357,20 @@ export const INSTALLABLE_SOURCE_PLATFORM_CONVERSION = {
   adobe_plugins: null,
 } as const;
 
+/**
+ * Look up an installable source's platform, normalizing the mapping's `null`
+ * entries to `undefined` so callers can treat the return as an optional
+ * `string`. Centralizes the `SoftwareSource` cast so consumers don't repeat
+ * it (and don't drift on the null → undefined normalization).
+ */
+export const getInstallablePlatform = (source?: string): string | undefined => {
+  if (!source) return undefined;
+  return (
+    INSTALLABLE_SOURCE_PLATFORM_CONVERSION[source as SoftwareSource] ??
+    undefined
+  );
+};
+
 export const SCRIPT_PACKAGE_SOURCES = [
   "sh_packages",
   "ps1_packages",

--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -357,18 +357,14 @@ export const INSTALLABLE_SOURCE_PLATFORM_CONVERSION = {
   adobe_plugins: null,
 } as const;
 
-/**
- * Look up an installable source's platform, normalizing the mapping's `null`
- * entries to `undefined` so callers can treat the return as an optional
- * `string`. Centralizes the `SoftwareSource` cast so consumers don't repeat
- * it (and don't drift on the null → undefined normalization).
- */
-export const getInstallablePlatform = (source?: string): string | undefined => {
+/** Look up an installable source's platform, normalizing the mapping's
+ * `null` entries to `undefined` so callers can treat the return as an
+ * optional `string`. */
+export const getInstallablePlatform = (
+  source?: SoftwareSource
+): string | undefined => {
   if (!source) return undefined;
-  return (
-    INSTALLABLE_SOURCE_PLATFORM_CONVERSION[source as SoftwareSource] ??
-    undefined
-  );
+  return INSTALLABLE_SOURCE_PLATFORM_CONVERSION[source] ?? undefined;
 };
 
 export const SCRIPT_PACKAGE_SOURCES = [

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/FleetAppDetailsForm.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/FleetAppDetailsForm.tests.tsx
@@ -22,7 +22,7 @@ const defaultProps: React.ComponentProps<typeof FleetAppDetailsForm> = {
   onSubmit: jest.fn(),
 };
 
-const renderForm = (gitOpsModeEnabled = false) => {
+const renderForm = (gitOpsModeEnabled = false, platform?: string) => {
   const render = createCustomRenderer({
     withBackendMock: true,
     context: {
@@ -31,7 +31,7 @@ const renderForm = (gitOpsModeEnabled = false) => {
       },
     },
   });
-  return render(<FleetAppDetailsForm {...defaultProps} />);
+  return render(<FleetAppDetailsForm {...defaultProps} platform={platform} />);
 };
 
 describe("FleetAppDetailsForm", () => {
@@ -105,6 +105,77 @@ describe("FleetAppDetailsForm", () => {
         labelTargets: expect.objectContaining({ Engineering: true }),
       })
     );
+  });
+
+  it("submits endUserExperience: notify when the dropdown is set on macOS", async () => {
+    const { user } = renderForm(false, "darwin");
+
+    await user.click(screen.getByRole("checkbox", { name: "patch" }));
+    await user.click(screen.getByRole("radio", { name: "Force patch" }));
+    // react-select-5 opens on mouseDown of the wrapper; findByText waits for
+    // the option to portal in.
+    await user.click(screen.getByRole("combobox"));
+    const notifyOption = await screen.findByText("Notify before patching");
+    await user.click(notifyOption);
+    await user.click(screen.getByRole("button", { name: "Add software" }));
+
+    expect(defaultProps.onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        patch: true,
+        patchOption: "force",
+        endUserExperience: "notify",
+      })
+    );
+  });
+
+  it("does not render the End user experience dropdown for a Windows FMA", async () => {
+    const { user } = renderForm(false, "windows");
+
+    await user.click(screen.getByRole("checkbox", { name: "patch" }));
+    await user.click(screen.getByRole("radio", { name: "Force patch" }));
+
+    expect(
+      screen.queryByRole("combobox", { name: /End user experience/i })
+    ).not.toBeInTheDocument();
+    // Windows-specific coming-soon banner replaces the dropdown + link.
+    expect(
+      screen.getByText(/Notifications for Windows are coming soon\./)
+    ).toBeInTheDocument();
+  });
+
+  it("locks the pre-install query as Fleet-managed when Force + Notify is selected on macOS", async () => {
+    const { user } = renderForm(false, "darwin");
+
+    await user.click(screen.getByRole("checkbox", { name: "patch" }));
+    await user.click(screen.getByRole("radio", { name: "Force patch" }));
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByText("Notify before patching"));
+
+    await user.click(screen.getByRole("button", { name: /advanced options/i }));
+    expect(
+      await screen.findByText(
+        /Pre-install query won't run when install is triggered via self-service/
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("keeps the pre-install query editable when Force patch is selected on a Windows FMA", async () => {
+    // Defense-in-depth: the Add FMA form starts with endUserExperience
+    // "immediate" and Windows hides the dropdown, so state can't reach
+    // "notify" through the UI. The platform gate on the `patchWhenClosed`
+    // composite is what still keeps the pre-install query editable — this
+    // test locks in that Windows Force-patch stays unlocked.
+    const { user } = renderForm(false, "windows");
+
+    await user.click(screen.getByRole("checkbox", { name: "patch" }));
+    await user.click(screen.getByRole("radio", { name: "Force patch" }));
+
+    await user.click(screen.getByRole("button", { name: /advanced options/i }));
+    expect(
+      screen.queryByText(
+        /Pre-install query won't run when install is triggered via self-service/
+      )
+    ).not.toBeInTheDocument();
   });
 
   it("reveals Advanced options with a pre-install query field", async () => {

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/FleetAppDetailsForm.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/FleetAppDetailsForm.tests.tsx
@@ -160,11 +160,9 @@ describe("FleetAppDetailsForm", () => {
   });
 
   it("keeps the pre-install query editable when Force patch is selected on a Windows FMA", async () => {
-    // Defense-in-depth: the Add FMA form starts with endUserExperience
-    // "immediate" and Windows hides the dropdown, so state can't reach
-    // "notify" through the UI. The platform gate on the `patchWhenClosed`
-    // composite is what still keeps the pre-install query editable — this
-    // test locks in that Windows Force-patch stays unlocked.
+    // Add FMA form starts with endUserExperience "immediate" and Windows
+    // hides the End user experience dropdown, so state can never reach
+    // "notify" through the UI — the pre-install query stays unlocked.
     const { user } = renderForm(false, "windows");
 
     await user.click(screen.getByRole("checkbox", { name: "patch" }));

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/FleetAppDetailsForm.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/FleetAppDetailsForm.tsx
@@ -24,9 +24,9 @@ import RevealButton from "components/buttons/RevealButton";
 import { DropdownTargetLabelSelector } from "components/TargetLabelSelector";
 import SoftwareOptionsSelector from "pages/SoftwarePage/components/forms/SoftwareOptionsSelector";
 import AdvancedOptionsFields from "pages/SoftwarePage/components/forms/AdvancedOptionsFields";
+import { isMacOS } from "interfaces/platform";
 import {
   EndUserExperience,
-  isMacPlatform,
   PatchOption,
   SoftwareDeploySelector,
 } from "pages/SoftwarePage/components/forms/SoftwareDeploySelector";
@@ -306,7 +306,7 @@ const FleetAppDetailsForm = ({
               (formData.patchOption === "closed" ||
                 (formData.patchOption === "force" &&
                   formData.endUserExperience === "notify" &&
-                  isMacPlatform(platform)))
+                  isMacOS(platform ?? "")))
             }
           />
         )}

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/FleetAppDetailsForm.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/FleetAppDetailsForm.tsx
@@ -24,7 +24,6 @@ import RevealButton from "components/buttons/RevealButton";
 import { DropdownTargetLabelSelector } from "components/TargetLabelSelector";
 import SoftwareOptionsSelector from "pages/SoftwarePage/components/forms/SoftwareOptionsSelector";
 import AdvancedOptionsFields from "pages/SoftwarePage/components/forms/AdvancedOptionsFields";
-import { isMacOS } from "interfaces/platform";
 import {
   EndUserExperience,
   PatchOption,
@@ -301,12 +300,11 @@ const FleetAppDetailsForm = ({
             onChangeUninstallScript={onChangeUninstallScript}
             gitopsCompatible
             gitOpsModeEnabled={gitOpsModeEnabled}
-            patchWhenClosed={
+            preInstallQueryLocked={
               formData.patch &&
               (formData.patchOption === "closed" ||
                 (formData.patchOption === "force" &&
-                  formData.endUserExperience === "notify" &&
-                  isMacOS(platform)))
+                  formData.endUserExperience === "notify"))
             }
           />
         )}

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/FleetAppDetailsForm.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/FleetAppDetailsForm.tsx
@@ -26,6 +26,7 @@ import SoftwareOptionsSelector from "pages/SoftwarePage/components/forms/Softwar
 import AdvancedOptionsFields from "pages/SoftwarePage/components/forms/AdvancedOptionsFields";
 import {
   EndUserExperience,
+  isMacPlatform,
   PatchOption,
   SoftwareDeploySelector,
 } from "pages/SoftwarePage/components/forms/SoftwareDeploySelector";
@@ -304,7 +305,8 @@ const FleetAppDetailsForm = ({
               formData.patch &&
               (formData.patchOption === "closed" ||
                 (formData.patchOption === "force" &&
-                  formData.endUserExperience === "notify"))
+                  formData.endUserExperience === "notify" &&
+                  isMacPlatform(platform)))
             }
           />
         )}

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/FleetAppDetailsForm.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/FleetAppDetailsForm.tsx
@@ -25,6 +25,7 @@ import { DropdownTargetLabelSelector } from "components/TargetLabelSelector";
 import SoftwareOptionsSelector from "pages/SoftwarePage/components/forms/SoftwareOptionsSelector";
 import AdvancedOptionsFields from "pages/SoftwarePage/components/forms/AdvancedOptionsFields";
 import {
+  EndUserExperience,
   PatchOption,
   SoftwareDeploySelector,
 } from "pages/SoftwarePage/components/forms/SoftwareDeploySelector";
@@ -66,6 +67,7 @@ export interface IFleetMaintainedAppFormData {
   forceInstall: boolean;
   patch: boolean;
   patchOption: PatchOption;
+  endUserExperience: EndUserExperience;
   installScript: string;
   preInstallQuery?: string;
   postInstallScript?: string;
@@ -91,6 +93,7 @@ interface IFleetAppDetailsFormProps {
   onCancel: () => void;
   onSubmit: (formData: IFleetMaintainedAppFormData) => void;
   softwareTitleId?: number;
+  platform?: string;
 }
 
 const FleetAppDetailsForm = ({
@@ -102,12 +105,14 @@ const FleetAppDetailsForm = ({
   onCancel,
   onSubmit,
   softwareTitleId,
+  platform,
 }: IFleetAppDetailsFormProps) => {
   const [formData, setFormData] = useState<IFleetMaintainedAppFormData>({
     selfService: false,
     forceInstall: false,
     patch: false,
     patchOption: "closed",
+    endUserExperience: "immediate",
     preInstallQuery: "",
     installScript: defaultInstallScript,
     postInstallScript: defaultPostInstallScript,
@@ -208,6 +213,8 @@ const FleetAppDetailsForm = ({
             forceInstall={formData.forceInstall}
             patch={formData.patch}
             patchOption={formData.patchOption}
+            platform={platform}
+            endUserExperience={formData.endUserExperience}
             onToggleForceInstall={(forceInstall) =>
               setFormData((prevData) => ({ ...prevData, forceInstall }))
             }
@@ -216,6 +223,9 @@ const FleetAppDetailsForm = ({
             }
             onSelectPatchOption={(patchOption) =>
               setFormData((prevData) => ({ ...prevData, patchOption }))
+            }
+            onSelectEndUserExperience={(endUserExperience) =>
+              setFormData((prevData) => ({ ...prevData, endUserExperience }))
             }
             disabled={disableChildren}
           />

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/FleetAppDetailsForm.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/FleetAppDetailsForm.tsx
@@ -306,7 +306,7 @@ const FleetAppDetailsForm = ({
               (formData.patchOption === "closed" ||
                 (formData.patchOption === "force" &&
                   formData.endUserExperience === "notify" &&
-                  isMacOS(platform ?? "")))
+                  isMacOS(platform)))
             }
           />
         )}

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/FleetAppDetailsForm.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/FleetAppDetailsForm.tsx
@@ -301,7 +301,10 @@ const FleetAppDetailsForm = ({
             gitopsCompatible
             gitOpsModeEnabled={gitOpsModeEnabled}
             patchWhenClosed={
-              formData.patch && formData.patchOption === "closed"
+              formData.patch &&
+              (formData.patchOption === "closed" ||
+                (formData.patchOption === "force" &&
+                  formData.endUserExperience === "notify"))
             }
           />
         )}

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tests.tsx
@@ -53,6 +53,7 @@ describe("FleetMaintainedAppDetailsPage", () => {
         patch_software_title_id: 99,
         software_title_id: 99,
         patch_when_closed: true,
+        notify_before_patching: false,
         continuous_automations_enabled: true,
       });
     });

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
@@ -218,7 +218,10 @@ const FleetMaintainedAppDetailsPage = ({
           ...(formData.patchOption !== "manual" && {
             software_title_id: addedSoftwareTitleId,
           }),
-          ...getPatchPolicyFlags(formData.patchOption),
+          ...getPatchPolicyFlags(
+            formData.patchOption,
+            formData.endUserExperience
+          ),
         });
       }
 
@@ -285,6 +288,7 @@ const FleetMaintainedAppDetailsPage = ({
               onCancel={onCancel}
               onSubmit={onSubmit}
               softwareTitleId={fleetApp.software_title_id}
+              platform={fleetApp.platform}
             />
           </div>
         </>

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
@@ -220,7 +220,8 @@ const FleetMaintainedAppDetailsPage = ({
           }),
           ...getPatchPolicyFlags(
             formData.patchOption,
-            formData.endUserExperience
+            formData.endUserExperience,
+            fleetApp?.platform
           ),
         });
       }

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
@@ -220,8 +220,7 @@ const FleetMaintainedAppDetailsPage = ({
           }),
           ...getPatchPolicyFlags(
             formData.patchOption,
-            formData.endUserExperience,
-            fleetApp?.platform
+            formData.endUserExperience
           ),
         });
       }

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeployModal/DeployModal.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeployModal/DeployModal.tests.tsx
@@ -105,6 +105,7 @@ describe("DeployModal", () => {
         patch_software_title_id: 10,
         software_title_id: 10,
         patch_when_closed: false,
+        notify_before_patching: false,
         continuous_automations_enabled: false,
       })
     );
@@ -180,6 +181,7 @@ describe("DeployModal", () => {
         team_id: 1,
         software_title_id: 10,
         patch_when_closed: false,
+        notify_before_patching: false,
         continuous_automations_enabled: false,
       })
     );
@@ -211,6 +213,7 @@ describe("DeployModal", () => {
         team_id: 1,
         software_title_id: null,
         patch_when_closed: false,
+        notify_before_patching: false,
         continuous_automations_enabled: false,
       })
     );
@@ -240,6 +243,7 @@ describe("DeployModal", () => {
         team_id: 1,
         software_title_id: 10,
         patch_when_closed: false,
+        notify_before_patching: false,
         continuous_automations_enabled: false,
       })
     );

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeployModal/DeployModal.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeployModal/DeployModal.tests.tsx
@@ -111,6 +111,81 @@ describe("DeployModal", () => {
     );
   });
 
+  it("creates a Notify before patching policy when the dropdown is set on macOS", async () => {
+    const { user } = renderModal();
+
+    // Wait for the FMA app query to settle — the selector is disabled while
+    // it loads, which blocks pointer events on the dropdown.
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Save" })).toBeEnabled()
+    );
+
+    await user.click(screen.getByRole("checkbox", { name: "patch" }));
+    await user.click(screen.getByRole("radio", { name: "Force patch" }));
+    // The dropdown renders once Force patch is selected on a macOS title.
+    // react-select-5 opens the menu on the wrapper's mouseDown, not a
+    // plain click on the hidden input; using findByText waits for the
+    // option to portal in.
+    await user.click(screen.getByRole("combobox"));
+    const notifyOption = await screen.findByText("Notify before patching");
+    await user.click(notifyOption);
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(teamPoliciesAPI.create).toHaveBeenCalledWith({
+        team_id: 1,
+        type: "patch",
+        patch_software_title_id: 10,
+        software_title_id: 10,
+        patch_when_closed: false,
+        notify_before_patching: true,
+        continuous_automations_enabled: true,
+      })
+    );
+  });
+
+  it("updates an existing Force patch policy from immediate to Notify before patching", async () => {
+    const { user } = renderModal({
+      softwarePackage: createMockSoftwarePackage({
+        fleet_maintained_app_id: 1,
+        patch_policy: {
+          id: 22,
+          name: "Firefox up to date",
+          patch_when_closed: false,
+          continuous_automations_enabled: false,
+          notify_before_patching: false,
+        },
+        automatic_install_policies: [
+          { id: 22, name: "Firefox up to date", type: "patch" },
+        ],
+      }),
+    });
+
+    // Wait for the FMA app query to settle before touching the dropdown.
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Save" })).toBeEnabled()
+    );
+
+    // Existing policy loads as Force patch + Patch immediately; switch to Notify.
+    // react-select-5 opens the menu on the wrapper's mouseDown, not a
+    // plain click on the hidden input; using findByText waits for the
+    // option to portal in.
+    await user.click(screen.getByRole("combobox"));
+    const notifyOption = await screen.findByText("Notify before patching");
+    await user.click(notifyOption);
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(teamPoliciesAPI.update).toHaveBeenCalledWith(22, {
+        team_id: 1,
+        software_title_id: 10,
+        patch_when_closed: false,
+        notify_before_patching: true,
+        continuous_automations_enabled: true,
+      })
+    );
+  });
+
   it("creates Force install with the current FMA query and platform", async () => {
     const { user } = renderModal();
 

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeployModal/DeployModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeployModal/DeployModal.tsx
@@ -103,11 +103,7 @@ const DeployModal = ({
   const onSave = async () => {
     setIsSaving(true);
     let savedAnyChange = false;
-    const patchFlags = getPatchPolicyFlags(
-      patchOption,
-      endUserExperience,
-      platform
-    );
+    const patchFlags = getPatchPolicyFlags(patchOption, endUserExperience);
     try {
       if (forceInstall !== !!forceInstallPolicy) {
         if (forceInstall) {

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeployModal/DeployModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeployModal/DeployModal.tsx
@@ -103,6 +103,14 @@ const DeployModal = ({
   const onSave = async () => {
     setIsSaving(true);
     let savedAnyChange = false;
+    // Compute the flags once so the create / update / diff-comparison branches
+    // can't drift with different args (which is exactly the class of bug this
+    // file just fixed by adding `platform`).
+    const patchFlags = getPatchPolicyFlags(
+      patchOption,
+      endUserExperience,
+      platform
+    );
     try {
       if (forceInstall !== !!forceInstallPolicy) {
         if (forceInstall) {
@@ -138,7 +146,7 @@ const DeployModal = ({
             ...(patchOption !== "manual" && {
               software_title_id: softwareTitle.id,
             }),
-            ...getPatchPolicyFlags(patchOption, endUserExperience, platform),
+            ...patchFlags,
           });
         } else if (patchPolicy) {
           await teamPoliciesAPI.destroy(teamId, [patchPolicy.id]);
@@ -150,20 +158,16 @@ const DeployModal = ({
         (patchOption !== initialPatchOption ||
           endUserExperience !== initialEndUserExperience ||
           patchHasAutomation !== (patchOption !== "manual") ||
-          patchPolicy.patch_when_closed !==
-            getPatchPolicyFlags(patchOption, endUserExperience, platform)
-              .patch_when_closed ||
+          patchPolicy.patch_when_closed !== patchFlags.patch_when_closed ||
           patchPolicy.notify_before_patching !==
-            getPatchPolicyFlags(patchOption, endUserExperience, platform)
-              .notify_before_patching ||
+            patchFlags.notify_before_patching ||
           patchPolicy.continuous_automations_enabled !==
-            getPatchPolicyFlags(patchOption, endUserExperience, platform)
-              .continuous_automations_enabled)
+            patchFlags.continuous_automations_enabled)
       ) {
         await teamPoliciesAPI.update(patchPolicy.id, {
           team_id: teamId,
           software_title_id: patchOption === "manual" ? null : softwareTitle.id,
-          ...getPatchPolicyFlags(patchOption, endUserExperience, platform),
+          ...patchFlags,
         });
         savedAnyChange = true;
       }

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeployModal/DeployModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeployModal/DeployModal.tsx
@@ -138,11 +138,7 @@ const DeployModal = ({
             ...(patchOption !== "manual" && {
               software_title_id: softwareTitle.id,
             }),
-            ...getPatchPolicyFlags(
-              patchOption,
-              endUserExperience,
-              platform ?? undefined
-            ),
+            ...getPatchPolicyFlags(patchOption, endUserExperience, platform),
           });
         } else if (patchPolicy) {
           await teamPoliciesAPI.destroy(teamId, [patchPolicy.id]);
@@ -155,32 +151,19 @@ const DeployModal = ({
           endUserExperience !== initialEndUserExperience ||
           patchHasAutomation !== (patchOption !== "manual") ||
           patchPolicy.patch_when_closed !==
-            getPatchPolicyFlags(
-              patchOption,
-              endUserExperience,
-              platform ?? undefined
-            ).patch_when_closed ||
+            getPatchPolicyFlags(patchOption, endUserExperience, platform)
+              .patch_when_closed ||
           patchPolicy.notify_before_patching !==
-            getPatchPolicyFlags(
-              patchOption,
-              endUserExperience,
-              platform ?? undefined
-            ).notify_before_patching ||
+            getPatchPolicyFlags(patchOption, endUserExperience, platform)
+              .notify_before_patching ||
           patchPolicy.continuous_automations_enabled !==
-            getPatchPolicyFlags(
-              patchOption,
-              endUserExperience,
-              platform ?? undefined
-            ).continuous_automations_enabled)
+            getPatchPolicyFlags(patchOption, endUserExperience, platform)
+              .continuous_automations_enabled)
       ) {
         await teamPoliciesAPI.update(patchPolicy.id, {
           team_id: teamId,
           software_title_id: patchOption === "manual" ? null : softwareTitle.id,
-          ...getPatchPolicyFlags(
-            patchOption,
-            endUserExperience,
-            platform ?? undefined
-          ),
+          ...getPatchPolicyFlags(patchOption, endUserExperience, platform),
         });
         savedAnyChange = true;
       }
@@ -222,7 +205,7 @@ const DeployModal = ({
               forceInstall={forceInstall}
               patch={patch}
               patchOption={patchOption}
-              platform={platform ?? undefined}
+              platform={platform}
               endUserExperience={endUserExperience}
               onToggleForceInstall={setForceInstall}
               onTogglePatch={setPatch}

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeployModal/DeployModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeployModal/DeployModal.tsx
@@ -1,7 +1,11 @@
 import React, { useState } from "react";
 import { useQuery } from "react-query";
 
-import { ISoftwareTitleDetails } from "interfaces/software";
+import {
+  INSTALLABLE_SOURCE_PLATFORM_CONVERSION,
+  ISoftwareTitleDetails,
+  SoftwareSource,
+} from "interfaces/software";
 import { getErrorReason } from "interfaces/errors";
 import softwareAPI from "services/entities/software";
 import teamPoliciesAPI from "services/entities/team_policies";
@@ -12,6 +16,7 @@ import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
 import Modal from "components/Modal";
 import { notify } from "components/ToastNotification";
 import {
+  EndUserExperience,
   getPatchPolicyFlags,
   PatchOption,
   SoftwareDeploySelector,
@@ -58,12 +63,24 @@ const DeployModal = ({
     initialPatchOption = "force";
   }
 
+  const initialEndUserExperience: EndUserExperience = patchPolicy?.notify_before_patching
+    ? "notify"
+    : "immediate";
+
   const [forceInstall, setForceInstall] = useState(!!forceInstallPolicy);
   const [patch, setPatch] = useState(!!patchPolicy);
   const [patchOption, setPatchOption] = useState<PatchOption>(
     initialPatchOption
   );
+  const [endUserExperience, setEndUserExperience] = useState<EndUserExperience>(
+    initialEndUserExperience
+  );
   const [isSaving, setIsSaving] = useState(false);
+
+  const platform =
+    INSTALLABLE_SOURCE_PLATFORM_CONVERSION[
+      softwareTitle.source as SoftwareSource
+    ] ?? undefined;
 
   const fleetMaintainedAppId = softwarePackage?.fleet_maintained_app_id;
   const {
@@ -121,7 +138,7 @@ const DeployModal = ({
             ...(patchOption !== "manual" && {
               software_title_id: softwareTitle.id,
             }),
-            ...getPatchPolicyFlags(patchOption),
+            ...getPatchPolicyFlags(patchOption, endUserExperience),
           });
         } else if (patchPolicy) {
           await teamPoliciesAPI.destroy(teamId, [patchPolicy.id]);
@@ -131,16 +148,22 @@ const DeployModal = ({
         patch &&
         patchPolicy &&
         (patchOption !== initialPatchOption ||
+          endUserExperience !== initialEndUserExperience ||
           patchHasAutomation !== (patchOption !== "manual") ||
           patchPolicy.patch_when_closed !==
-            getPatchPolicyFlags(patchOption).patch_when_closed ||
+            getPatchPolicyFlags(patchOption, endUserExperience)
+              .patch_when_closed ||
+          patchPolicy.notify_before_patching !==
+            getPatchPolicyFlags(patchOption, endUserExperience)
+              .notify_before_patching ||
           patchPolicy.continuous_automations_enabled !==
-            getPatchPolicyFlags(patchOption).continuous_automations_enabled)
+            getPatchPolicyFlags(patchOption, endUserExperience)
+              .continuous_automations_enabled)
       ) {
         await teamPoliciesAPI.update(patchPolicy.id, {
           team_id: teamId,
           software_title_id: patchOption === "manual" ? null : softwareTitle.id,
-          ...getPatchPolicyFlags(patchOption),
+          ...getPatchPolicyFlags(patchOption, endUserExperience),
         });
         savedAnyChange = true;
       }
@@ -182,9 +205,12 @@ const DeployModal = ({
               forceInstall={forceInstall}
               patch={patch}
               patchOption={patchOption}
+              platform={platform ?? undefined}
+              endUserExperience={endUserExperience}
               onToggleForceInstall={setForceInstall}
               onTogglePatch={setPatch}
               onSelectPatchOption={setPatchOption}
+              onSelectEndUserExperience={setEndUserExperience}
               disabled={disableChildren || isLoadingFleetMaintainedApp}
               showPatchWhenClosedNotice
               hideLabel

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeployModal/DeployModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeployModal/DeployModal.tsx
@@ -99,9 +99,6 @@ const DeployModal = ({
   const onSave = async () => {
     setIsSaving(true);
     let savedAnyChange = false;
-    // Compute the flags once so the create / update / diff-comparison branches
-    // can't drift with different args (which is exactly the class of bug this
-    // file just fixed by adding `platform`).
     const patchFlags = getPatchPolicyFlags(
       patchOption,
       endUserExperience,

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeployModal/DeployModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeployModal/DeployModal.tsx
@@ -62,9 +62,13 @@ const DeployModal = ({
     initialPatchOption = "force";
   }
 
-  const initialEndUserExperience: EndUserExperience = patchPolicy?.notify_before_patching
-    ? "notify"
-    : "immediate";
+  // If a legacy policy stored both flags (invariant violation), Patch when
+  // closed wins the radio and the dropdown stays hidden — carrying "notify"
+  // in state would reveal it the moment the user picked Force patch.
+  const initialEndUserExperience: EndUserExperience =
+    patchPolicy?.notify_before_patching && !patchPolicy?.patch_when_closed
+      ? "notify"
+      : "immediate";
 
   const [forceInstall, setForceInstall] = useState(!!forceInstallPolicy);
   const [patch, setPatch] = useState(!!patchPolicy);

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeployModal/DeployModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeployModal/DeployModal.tsx
@@ -138,7 +138,11 @@ const DeployModal = ({
             ...(patchOption !== "manual" && {
               software_title_id: softwareTitle.id,
             }),
-            ...getPatchPolicyFlags(patchOption, endUserExperience),
+            ...getPatchPolicyFlags(
+              patchOption,
+              endUserExperience,
+              platform ?? undefined
+            ),
           });
         } else if (patchPolicy) {
           await teamPoliciesAPI.destroy(teamId, [patchPolicy.id]);
@@ -151,19 +155,32 @@ const DeployModal = ({
           endUserExperience !== initialEndUserExperience ||
           patchHasAutomation !== (patchOption !== "manual") ||
           patchPolicy.patch_when_closed !==
-            getPatchPolicyFlags(patchOption, endUserExperience)
-              .patch_when_closed ||
+            getPatchPolicyFlags(
+              patchOption,
+              endUserExperience,
+              platform ?? undefined
+            ).patch_when_closed ||
           patchPolicy.notify_before_patching !==
-            getPatchPolicyFlags(patchOption, endUserExperience)
-              .notify_before_patching ||
+            getPatchPolicyFlags(
+              patchOption,
+              endUserExperience,
+              platform ?? undefined
+            ).notify_before_patching ||
           patchPolicy.continuous_automations_enabled !==
-            getPatchPolicyFlags(patchOption, endUserExperience)
-              .continuous_automations_enabled)
+            getPatchPolicyFlags(
+              patchOption,
+              endUserExperience,
+              platform ?? undefined
+            ).continuous_automations_enabled)
       ) {
         await teamPoliciesAPI.update(patchPolicy.id, {
           team_id: teamId,
           software_title_id: patchOption === "manual" ? null : softwareTitle.id,
-          ...getPatchPolicyFlags(patchOption, endUserExperience),
+          ...getPatchPolicyFlags(
+            patchOption,
+            endUserExperience,
+            platform ?? undefined
+          ),
         });
         savedAnyChange = true;
       }

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeployModal/DeployModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeployModal/DeployModal.tsx
@@ -2,9 +2,8 @@ import React, { useState } from "react";
 import { useQuery } from "react-query";
 
 import {
-  INSTALLABLE_SOURCE_PLATFORM_CONVERSION,
+  getInstallablePlatform,
   ISoftwareTitleDetails,
-  SoftwareSource,
 } from "interfaces/software";
 import { getErrorReason } from "interfaces/errors";
 import softwareAPI from "services/entities/software";
@@ -77,10 +76,7 @@ const DeployModal = ({
   );
   const [isSaving, setIsSaving] = useState(false);
 
-  const platform =
-    INSTALLABLE_SOURCE_PLATFORM_CONVERSION[
-      softwareTitle.source as SoftwareSource
-    ] ?? undefined;
+  const platform = getInstallablePlatform(softwareTitle.source);
 
   const fleetMaintainedAppId = softwarePackage?.fleet_maintained_app_id;
   const {

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditSoftwareModal/EditSoftwareModal.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditSoftwareModal/EditSoftwareModal.tests.tsx
@@ -51,8 +51,8 @@ describe("EditSoftwareModal — multi-package title", () => {
   });
 
   // Regression: a patch-when-closed installer must treat the pre-install query
-  // as Fleet-managed even when the caller doesn't pass patchWhenClosed — the
-  // modal derives it from the installer's own patch policy. Otherwise the
+  // as Fleet-managed even when the caller doesn't pass preInstallQueryLocked —
+  // the modal derives it from the installer's own patch policy. Otherwise the
   // pre-install query is sent on save and the backend rejects unrelated edits
   // (e.g. toggling self-service).
   it("treats the pre-install query as Fleet-managed when the installer's patch policy is patch-when-closed", async () => {
@@ -99,9 +99,8 @@ describe("EditSoftwareModal — multi-package title", () => {
     ).toBeInTheDocument();
   });
 
-  it("keeps the pre-install query editable when notify-before-patching is set on a non-Mac source", async () => {
+  it("locks the pre-install query when notify-before-patching is set", async () => {
     const { user } = renderModal({
-      source: "programs", // maps to windows
       softwareInstaller: createMockSoftwarePackage({
         patch_policy: {
           id: 7,
@@ -116,10 +115,10 @@ describe("EditSoftwareModal — multi-package title", () => {
     await user.click(screen.getByRole("button", { name: "Advanced options" }));
 
     expect(
-      screen.queryByText(
+      screen.getByText(
         /Pre-install query won't run when install is triggered via self-service/
       )
-    ).not.toBeInTheDocument();
+    ).toBeInTheDocument();
   });
 
   it("keeps the pre-install query editable when there is no patch-when-closed policy", async () => {

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditSoftwareModal/EditSoftwareModal.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditSoftwareModal/EditSoftwareModal.tests.tsx
@@ -76,6 +76,52 @@ describe("EditSoftwareModal — multi-package title", () => {
     ).toBeInTheDocument();
   });
 
+  it("treats the pre-install query as Fleet-managed when the installer's patch policy is notify-before-patching on macOS", async () => {
+    const { user } = renderModal({
+      source: "apps", // maps to darwin
+      softwareInstaller: createMockSoftwarePackage({
+        patch_policy: {
+          id: 6,
+          name: "GlobalProtect up to date",
+          patch_when_closed: false,
+          notify_before_patching: true,
+          continuous_automations_enabled: true,
+        },
+      }),
+    });
+
+    await user.click(screen.getByRole("button", { name: "Advanced options" }));
+
+    expect(
+      screen.getByText(
+        /Pre-install query won't run when install is triggered via self-service/
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("keeps the pre-install query editable when notify-before-patching is set on a non-Mac source", async () => {
+    const { user } = renderModal({
+      source: "programs", // maps to windows
+      softwareInstaller: createMockSoftwarePackage({
+        patch_policy: {
+          id: 7,
+          name: "GlobalProtect up to date",
+          patch_when_closed: false,
+          notify_before_patching: true,
+          continuous_automations_enabled: true,
+        },
+      }),
+    });
+
+    await user.click(screen.getByRole("button", { name: "Advanced options" }));
+
+    expect(
+      screen.queryByText(
+        /Pre-install query won't run when install is triggered via self-service/
+      )
+    ).not.toBeInTheDocument();
+  });
+
   it("keeps the pre-install query editable when there is no patch-when-closed policy", async () => {
     const { user } = renderModal({
       softwareInstaller: createMockSoftwarePackage({ patch_policy: null }),

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditSoftwareModal/EditSoftwareModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditSoftwareModal/EditSoftwareModal.tsx
@@ -5,8 +5,10 @@ import classnames from "classnames";
 import { ILabelSummary } from "interfaces/label";
 import {
   IAppStoreApp,
+  INSTALLABLE_SOURCE_PLATFORM_CONVERSION,
   ISoftwarePackage,
   InstallerType,
+  SoftwareSource,
 } from "interfaces/software";
 import useBlockNavigation from "hooks/useBlockNavigation";
 import useGitOpsMode from "hooks/useGitOpsMode";
@@ -22,6 +24,7 @@ import Modal from "components/Modal";
 import FileProgressModal from "components/FileProgressModal";
 import CategoriesEndUserExperienceModal from "pages/SoftwarePage/components/modals/CategoriesEndUserExperienceModal";
 
+import { isMacPlatform } from "pages/SoftwarePage/components/forms/SoftwareDeploySelector";
 import PackageForm from "pages/SoftwarePage/components/forms/PackageForm";
 import { IPackageFormData } from "pages/SoftwarePage/components/forms/PackageForm/PackageForm";
 import SoftwareVppForm from "pages/SoftwarePage/components/forms/SoftwareVppForm";
@@ -97,12 +100,22 @@ const EditSoftwareModal = ({
   // installer's own patch policy so a caller can't forget to pass it (which
   // otherwise blocks unrelated edits like toggling self-service); an explicit
   // prop can still force it on. `notify_before_patching` reuses the same
-  // Fleet-managed app-open query, so it triggers the same read-only lock.
+  // Fleet-managed app-open query, so it triggers the same read-only lock —
+  // gated on the software's platform being Mac to mirror the wire boundary
+  // in `getPatchPolicyFlags`.
+  const derivedPlatform = source
+    ? INSTALLABLE_SOURCE_PLATFORM_CONVERSION[source as SoftwareSource] ??
+      undefined
+    : undefined;
+  const notifyLocksPreInstallQuery =
+    "patch_policy" in softwareInstaller &&
+    !!softwareInstaller.patch_policy?.notify_before_patching &&
+    isMacPlatform(derivedPlatform);
   const effectivePatchWhenClosed =
     patchWhenClosed ||
     ("patch_policy" in softwareInstaller &&
-      (!!softwareInstaller.patch_policy?.patch_when_closed ||
-        !!softwareInstaller.patch_policy?.notify_before_patching));
+      !!softwareInstaller.patch_policy?.patch_when_closed) ||
+    notifyLocksPreInstallQuery;
 
   const formClassNames = classnames(`${baseClass}__package-form`, {
     [`${baseClass}__package-form--disabled`]: isGitOpsCompatible,

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditSoftwareModal/EditSoftwareModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditSoftwareModal/EditSoftwareModal.tsx
@@ -5,7 +5,6 @@ import classnames from "classnames";
 import { ILabelSummary } from "interfaces/label";
 import {
   IAppStoreApp,
-  getInstallablePlatform,
   ISoftwarePackage,
   InstallerType,
 } from "interfaces/software";
@@ -23,7 +22,6 @@ import Modal from "components/Modal";
 import FileProgressModal from "components/FileProgressModal";
 import CategoriesEndUserExperienceModal from "pages/SoftwarePage/components/modals/CategoriesEndUserExperienceModal";
 
-import { isMacOS } from "interfaces/platform";
 import PackageForm from "pages/SoftwarePage/components/forms/PackageForm";
 import { IPackageFormData } from "pages/SoftwarePage/components/forms/PackageForm/PackageForm";
 import SoftwareVppForm from "pages/SoftwarePage/components/forms/SoftwareVppForm";
@@ -64,7 +62,7 @@ interface IEditSoftwareModalProps {
    * software" — we're editing one specific installer on a title that has
    * several, not the title's only package. */
   canActivateMultiplePackages?: boolean;
-  patchWhenClosed?: boolean;
+  preInstallQueryLocked?: boolean;
 }
 
 const EditSoftwareModal = ({
@@ -82,7 +80,7 @@ const EditSoftwareModal = ({
   source,
   iconUrl = undefined,
   canActivateMultiplePackages = false,
-  patchWhenClosed = false,
+  preInstallQueryLocked = false,
 }: IEditSoftwareModalProps) => {
   const queryClient = useQueryClient();
   const { gitOpsModeEnabled } = useGitOpsMode("software");
@@ -96,15 +94,12 @@ const EditSoftwareModal = ({
   // Backend rejects pre_install_query on save when patch_when_closed or
   // notify_before_patching is on, so the field must be read-only and
   // omitted. Derived from the installer's own patch policy so a caller
-  // can't forget; explicit prop can still force it. Notify branch is
-  // Mac-gated to mirror `getPatchPolicyFlags`.
-  const derivedPlatform = getInstallablePlatform(source);
+  // can't forget; explicit prop can still force it.
   const notifyLocksPreInstallQuery =
     "patch_policy" in softwareInstaller &&
-    !!softwareInstaller.patch_policy?.notify_before_patching &&
-    isMacOS(derivedPlatform);
-  const effectivePatchWhenClosed =
-    patchWhenClosed ||
+    !!softwareInstaller.patch_policy?.notify_before_patching;
+  const effectivePreInstallQueryLocked =
+    preInstallQueryLocked ||
     ("patch_policy" in softwareInstaller &&
       !!softwareInstaller.patch_policy?.patch_when_closed) ||
     notifyLocksPreInstallQuery;
@@ -239,7 +234,7 @@ const EditSoftwareModal = ({
           // progress bar at 97% until the server response is received
           setUploadProgress(Math.max(progress - 0.03, 0.01));
         },
-        omitPreInstallQuery: effectivePatchWhenClosed,
+        omitPreInstallQuery: effectivePreInstallQueryLocked,
       });
 
       notify.success(
@@ -388,7 +383,7 @@ const EditSoftwareModal = ({
           defaultCategories={softwarePackage.categories}
           gitopsCompatible={isGitOpsCompatible}
           teamId={teamId}
-          patchWhenClosed={effectivePatchWhenClosed}
+          preInstallQueryLocked={effectivePreInstallQueryLocked}
         />
       );
     }

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditSoftwareModal/EditSoftwareModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditSoftwareModal/EditSoftwareModal.tsx
@@ -24,7 +24,7 @@ import Modal from "components/Modal";
 import FileProgressModal from "components/FileProgressModal";
 import CategoriesEndUserExperienceModal from "pages/SoftwarePage/components/modals/CategoriesEndUserExperienceModal";
 
-import { isMacPlatform } from "pages/SoftwarePage/components/forms/SoftwareDeploySelector";
+import { isMacOS } from "interfaces/platform";
 import PackageForm from "pages/SoftwarePage/components/forms/PackageForm";
 import { IPackageFormData } from "pages/SoftwarePage/components/forms/PackageForm/PackageForm";
 import SoftwareVppForm from "pages/SoftwarePage/components/forms/SoftwareVppForm";
@@ -110,7 +110,7 @@ const EditSoftwareModal = ({
   const notifyLocksPreInstallQuery =
     "patch_policy" in softwareInstaller &&
     !!softwareInstaller.patch_policy?.notify_before_patching &&
-    isMacPlatform(derivedPlatform);
+    isMacOS(derivedPlatform ?? "");
   const effectivePatchWhenClosed =
     patchWhenClosed ||
     ("patch_policy" in softwareInstaller &&

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditSoftwareModal/EditSoftwareModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditSoftwareModal/EditSoftwareModal.tsx
@@ -5,10 +5,9 @@ import classnames from "classnames";
 import { ILabelSummary } from "interfaces/label";
 import {
   IAppStoreApp,
-  INSTALLABLE_SOURCE_PLATFORM_CONVERSION,
+  getInstallablePlatform,
   ISoftwarePackage,
   InstallerType,
-  SoftwareSource,
 } from "interfaces/software";
 import useBlockNavigation from "hooks/useBlockNavigation";
 import useGitOpsMode from "hooks/useGitOpsMode";
@@ -103,14 +102,11 @@ const EditSoftwareModal = ({
   // Fleet-managed app-open query, so it triggers the same read-only lock —
   // gated on the software's platform being Mac to mirror the wire boundary
   // in `getPatchPolicyFlags`.
-  const derivedPlatform = source
-    ? INSTALLABLE_SOURCE_PLATFORM_CONVERSION[source as SoftwareSource] ??
-      undefined
-    : undefined;
+  const derivedPlatform = getInstallablePlatform(source);
   const notifyLocksPreInstallQuery =
     "patch_policy" in softwareInstaller &&
     !!softwareInstaller.patch_policy?.notify_before_patching &&
-    isMacOS(derivedPlatform ?? "");
+    isMacOS(derivedPlatform);
   const effectivePatchWhenClosed =
     patchWhenClosed ||
     ("patch_policy" in softwareInstaller &&

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditSoftwareModal/EditSoftwareModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditSoftwareModal/EditSoftwareModal.tsx
@@ -93,15 +93,11 @@ const EditSoftwareModal = ({
   const isGitOpsCompatible =
     gitOpsModeEnabled && (isFleetMaintainedApp || canActivateMultiplePackages);
 
-  // Patch-when-closed makes the pre-install query Fleet-managed: the backend
-  // rejects any pre_install_query on save (even unchanged) while it's on, so the
-  // field must be read-only and omitted from the request. Derive it from the
-  // installer's own patch policy so a caller can't forget to pass it (which
-  // otherwise blocks unrelated edits like toggling self-service); an explicit
-  // prop can still force it on. `notify_before_patching` reuses the same
-  // Fleet-managed app-open query, so it triggers the same read-only lock —
-  // gated on the software's platform being Mac to mirror the wire boundary
-  // in `getPatchPolicyFlags`.
+  // Backend rejects pre_install_query on save when patch_when_closed or
+  // notify_before_patching is on, so the field must be read-only and
+  // omitted. Derived from the installer's own patch policy so a caller
+  // can't forget; explicit prop can still force it. Notify branch is
+  // Mac-gated to mirror `getPatchPolicyFlags`.
   const derivedPlatform = getInstallablePlatform(source);
   const notifyLocksPreInstallQuery =
     "patch_policy" in softwareInstaller &&

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditSoftwareModal/EditSoftwareModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditSoftwareModal/EditSoftwareModal.tsx
@@ -96,11 +96,13 @@ const EditSoftwareModal = ({
   // field must be read-only and omitted from the request. Derive it from the
   // installer's own patch policy so a caller can't forget to pass it (which
   // otherwise blocks unrelated edits like toggling self-service); an explicit
-  // prop can still force it on.
+  // prop can still force it on. `notify_before_patching` reuses the same
+  // Fleet-managed app-open query, so it triggers the same read-only lock.
   const effectivePatchWhenClosed =
     patchWhenClosed ||
     ("patch_policy" in softwareInstaller &&
-      !!softwareInstaller.patch_policy?.patch_when_closed);
+      (!!softwareInstaller.patch_policy?.patch_when_closed ||
+        !!softwareInstaller.patch_policy?.notify_before_patching));
 
   const formClassNames = classnames(`${baseClass}__package-form`, {
     [`${baseClass}__package-form--disabled`]: isGitOpsCompatible,

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/SoftwareSummaryCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/SoftwareSummaryCard.tsx
@@ -364,7 +364,7 @@ const SoftwareSummaryCard = ({
           displayName={softwareDisplayName}
           source={softwareTitle.source}
           iconUrl={softwareTitle.icon_url}
-          patchWhenClosed={
+          preInstallQueryLocked={
             softwareTitle.software_package?.patch_policy?.patch_when_closed
           }
         />

--- a/frontend/pages/SoftwarePage/components/forms/AdvancedOptionsFields/AdvancedOptionsFields.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/AdvancedOptionsFields/AdvancedOptionsFields.tsx
@@ -29,7 +29,7 @@ interface IAdvancedOptionsFieldsProps {
   onChangeUninstallScript: (value?: string) => void;
   gitopsCompatible?: boolean;
   gitOpsModeEnabled?: boolean;
-  patchWhenClosed?: boolean;
+  preInstallQueryLocked?: boolean;
 }
 
 const AdvancedOptionsFields = ({
@@ -53,7 +53,7 @@ const AdvancedOptionsFields = ({
   onChangeUninstallScript,
   gitopsCompatible = false,
   gitOpsModeEnabled = false,
-  patchWhenClosed = false,
+  preInstallQueryLocked = false,
 }: IAdvancedOptionsFieldsProps) => {
   const classNames = classnames(baseClass, className);
 
@@ -92,7 +92,7 @@ const AdvancedOptionsFields = ({
         helpText={
           <>
             Software will be installed only if the query returns results.
-            {patchWhenClosed && (
+            {preInstallQueryLocked && (
               <>
                 {" "}
                 Pre-install query won&apos;t run when install is triggered via
@@ -102,7 +102,7 @@ const AdvancedOptionsFields = ({
             )}
           </>
         }
-        readOnly={disableFields || patchWhenClosed}
+        readOnly={disableFields || preInstallQueryLocked}
       />
       <Editor
         wrapEnabled

--- a/frontend/pages/SoftwarePage/components/forms/PackageAdvancedOptions/PackageAdvancedOptions.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageAdvancedOptions/PackageAdvancedOptions.tsx
@@ -220,7 +220,7 @@ interface IPackageAdvancedOptionsProps {
   /** Currently for editing FMA only, users cannot edit */
   gitopsCompatible?: boolean;
   gitOpsModeEnabled?: boolean;
-  patchWhenClosed?: boolean;
+  preInstallQueryLocked?: boolean;
 }
 
 const PackageAdvancedOptions = ({
@@ -238,7 +238,7 @@ const PackageAdvancedOptions = ({
   onChangeUninstallScript,
   gitopsCompatible = false,
   gitOpsModeEnabled = false,
-  patchWhenClosed = false,
+  preInstallQueryLocked = false,
 }: IPackageAdvancedOptionsProps) => {
   const [showAdvancedOptions, setShowAdvancedOptions] = useState(false);
   const name = selectedPackage?.name || "";
@@ -272,7 +272,7 @@ const PackageAdvancedOptions = ({
         onChangeUninstallScript={onChangeUninstallScript}
         gitopsCompatible={gitopsCompatible}
         gitOpsModeEnabled={gitOpsModeEnabled}
-        patchWhenClosed={patchWhenClosed}
+        preInstallQueryLocked={preInstallQueryLocked}
       />
     );
   };

--- a/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
@@ -159,7 +159,7 @@ interface IPackageFormProps {
   /** Overrides the initial `targetType` for new (non-editing) forms. The
    * multi-package add modal preselects `"Custom"` per Figma. */
   initialTargetType?: string;
-  patchWhenClosed?: boolean;
+  preInstallQueryLocked?: boolean;
 }
 // application/gzip is used for .tar.gz files because browsers can't handle double-extensions correctly
 const ACCEPTED_EXTENSIONS =
@@ -188,7 +188,7 @@ const PackageForm = ({
   restrictedFileAccept,
   restrictedFileTypeLabel,
   initialTargetType,
-  patchWhenClosed = false,
+  preInstallQueryLocked = false,
 }: IPackageFormProps) => {
   const { gitOpsModeEnabled, repoURL } = useGitOpsMode("software");
   const { config } = useContext(AppContext);
@@ -569,7 +569,7 @@ const PackageForm = ({
             onChangeUninstallScript={onChangeUninstallScript}
             gitopsCompatible={gitopsCompatible}
             gitOpsModeEnabled={gitOpsModeEnabled}
-            patchWhenClosed={patchWhenClosed}
+            preInstallQueryLocked={preInstallQueryLocked}
           />
         )}
         <div className={`${baseClass}__action-buttons`}>

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareDeploySelector/SoftwareDeploySelector.tests.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareDeploySelector/SoftwareDeploySelector.tests.tsx
@@ -1,7 +1,11 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 
-import SoftwareDeploySelector, { PatchOption } from "./SoftwareDeploySelector";
+import SoftwareDeploySelector, {
+  EndUserExperience,
+  getPatchPolicyFlags,
+  PatchOption,
+} from "./SoftwareDeploySelector";
 
 const renderSelector = (
   overrides: Partial<React.ComponentProps<typeof SoftwareDeploySelector>> = {}
@@ -47,14 +51,91 @@ describe("SoftwareDeploySelector", () => {
     expect(screen.getAllByRole("radio")).toHaveLength(3);
   });
 
-  it("shows the Force patch information banner", () => {
-    renderSelector({ patch: true, patchOption: "force" });
+  it("shows the Patch immediately banner by default on macOS Force patch", () => {
+    renderSelector({
+      patch: true,
+      patchOption: "force",
+      platform: "darwin",
+      endUserExperience: "immediate",
+      onSelectEndUserExperience: jest.fn(),
+    });
 
     expect(
       screen.getByText(
-        "End user is not notified. Patch is forced as soon as policy fails. Notifications are coming soon."
+        /End user is not notified\. Patch is forced as soon as policy fails\./
       )
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /End user experience/i })
+    ).toHaveAttribute(
+      "href",
+      "https://fleetdm.com/learn-more-about/patching-end-user-experience"
+    );
+  });
+
+  it("shows the Notify before patching banner when selected on macOS", () => {
+    renderSelector({
+      patch: true,
+      patchOption: "force",
+      platform: "darwin",
+      endUserExperience: "notify",
+      onSelectEndUserExperience: jest.fn(),
+    });
+
+    expect(
+      screen.getByText(/End user is notified when the policy fails/)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/1 hour/)).toBeInTheDocument();
+  });
+
+  it("shows the Windows coming-soon banner and no dropdown on Windows", () => {
+    renderSelector({
+      patch: true,
+      patchOption: "force",
+      platform: "windows",
+      endUserExperience: "immediate",
+      onSelectEndUserExperience: jest.fn(),
+    });
+
+    expect(
+      screen.getByText(/Notifications for Windows are coming soon\./)
+    ).toBeInTheDocument();
+    expect(screen.queryByText("End user experience")).not.toBeInTheDocument();
+  });
+
+  it("hides the End user experience dropdown for non-Force patch options", () => {
+    renderSelector({
+      patch: true,
+      patchOption: "closed",
+      platform: "darwin",
+      endUserExperience: "immediate",
+      onSelectEndUserExperience: jest.fn(),
+    });
+
+    expect(screen.queryByText("End user experience")).not.toBeInTheDocument();
+  });
+
+  describe("getPatchPolicyFlags", () => {
+    it("returns force+notify flags for Notify before patching", () => {
+      const flags = getPatchPolicyFlags("force", "notify" as EndUserExperience);
+      expect(flags.notify_before_patching).toBe(true);
+      expect(flags.patch_when_closed).toBe(false);
+      expect(flags.continuous_automations_enabled).toBe(true);
+    });
+
+    it("returns all false for Patch immediately", () => {
+      const flags = getPatchPolicyFlags("force", "immediate");
+      expect(flags.notify_before_patching).toBe(false);
+      expect(flags.patch_when_closed).toBe(false);
+      expect(flags.continuous_automations_enabled).toBe(false);
+    });
+
+    it("returns patch_when_closed for closed regardless of experience", () => {
+      const flags = getPatchPolicyFlags("closed");
+      expect(flags.patch_when_closed).toBe(true);
+      expect(flags.notify_before_patching).toBe(false);
+      expect(flags.continuous_automations_enabled).toBe(true);
+    });
   });
 
   it("shows the pre-install query override notice in the Deploy modal", () => {

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareDeploySelector/SoftwareDeploySelector.tests.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareDeploySelector/SoftwareDeploySelector.tests.tsx
@@ -116,19 +116,15 @@ describe("SoftwareDeploySelector", () => {
   });
 
   describe("getPatchPolicyFlags", () => {
-    it("returns force+notify flags for Notify before patching on macOS", () => {
-      const flags = getPatchPolicyFlags(
-        "force",
-        "notify" as EndUserExperience,
-        "darwin"
-      );
+    it("returns force+notify flags for Notify before patching", () => {
+      const flags = getPatchPolicyFlags("force", "notify" as EndUserExperience);
       expect(flags.notify_before_patching).toBe(true);
       expect(flags.patch_when_closed).toBe(false);
       expect(flags.continuous_automations_enabled).toBe(true);
     });
 
     it("returns all false for Patch immediately", () => {
-      const flags = getPatchPolicyFlags("force", "immediate", "darwin");
+      const flags = getPatchPolicyFlags("force", "immediate");
       expect(flags.notify_before_patching).toBe(false);
       expect(flags.patch_when_closed).toBe(false);
       expect(flags.continuous_automations_enabled).toBe(false);
@@ -139,26 +135,6 @@ describe("SoftwareDeploySelector", () => {
       expect(flags.patch_when_closed).toBe(true);
       expect(flags.notify_before_patching).toBe(false);
       expect(flags.continuous_automations_enabled).toBe(true);
-    });
-
-    it("never sets notify_before_patching for Windows even when state says notify", () => {
-      const flags = getPatchPolicyFlags(
-        "force",
-        "notify" as EndUserExperience,
-        "windows"
-      );
-      expect(flags.notify_before_patching).toBe(false);
-      expect(flags.continuous_automations_enabled).toBe(false);
-    });
-
-    it("never sets notify_before_patching for an unknown platform", () => {
-      const flags = getPatchPolicyFlags(
-        "force",
-        "notify" as EndUserExperience,
-        undefined
-      );
-      expect(flags.notify_before_patching).toBe(false);
-      expect(flags.continuous_automations_enabled).toBe(false);
     });
   });
 

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareDeploySelector/SoftwareDeploySelector.tests.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareDeploySelector/SoftwareDeploySelector.tests.tsx
@@ -116,15 +116,19 @@ describe("SoftwareDeploySelector", () => {
   });
 
   describe("getPatchPolicyFlags", () => {
-    it("returns force+notify flags for Notify before patching", () => {
-      const flags = getPatchPolicyFlags("force", "notify" as EndUserExperience);
+    it("returns force+notify flags for Notify before patching on macOS", () => {
+      const flags = getPatchPolicyFlags(
+        "force",
+        "notify" as EndUserExperience,
+        "darwin"
+      );
       expect(flags.notify_before_patching).toBe(true);
       expect(flags.patch_when_closed).toBe(false);
       expect(flags.continuous_automations_enabled).toBe(true);
     });
 
     it("returns all false for Patch immediately", () => {
-      const flags = getPatchPolicyFlags("force", "immediate");
+      const flags = getPatchPolicyFlags("force", "immediate", "darwin");
       expect(flags.notify_before_patching).toBe(false);
       expect(flags.patch_when_closed).toBe(false);
       expect(flags.continuous_automations_enabled).toBe(false);
@@ -135,6 +139,26 @@ describe("SoftwareDeploySelector", () => {
       expect(flags.patch_when_closed).toBe(true);
       expect(flags.notify_before_patching).toBe(false);
       expect(flags.continuous_automations_enabled).toBe(true);
+    });
+
+    it("never sets notify_before_patching for Windows even when state says notify", () => {
+      const flags = getPatchPolicyFlags(
+        "force",
+        "notify" as EndUserExperience,
+        "windows"
+      );
+      expect(flags.notify_before_patching).toBe(false);
+      expect(flags.continuous_automations_enabled).toBe(false);
+    });
+
+    it("never sets notify_before_patching for an unknown platform", () => {
+      const flags = getPatchPolicyFlags(
+        "force",
+        "notify" as EndUserExperience,
+        undefined
+      );
+      expect(flags.notify_before_patching).toBe(false);
+      expect(flags.continuous_automations_enabled).toBe(false);
     });
   });
 

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareDeploySelector/SoftwareDeploySelector.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareDeploySelector/SoftwareDeploySelector.tsx
@@ -1,17 +1,73 @@
 import React from "react";
+import { SingleValue } from "react-select-5";
 
 import Checkbox from "components/forms/fields/Checkbox";
+import CustomLink from "components/CustomLink";
+import DropdownWrapper, {
+  CustomOptionType,
+} from "components/forms/fields/DropdownWrapper/DropdownWrapper";
 import Radio from "components/forms/fields/Radio";
 import InfoBanner from "components/InfoBanner";
 
 const baseClass = "software-deploy-selector";
 
 export type PatchOption = "closed" | "force" | "manual";
+export type EndUserExperience = "immediate" | "notify";
 
-export const getPatchPolicyFlags = (patchOption: PatchOption) => ({
+/**
+ * Returns the three policy flags derived from the deploy selector state.
+ * `endUserExperience` has a defaulted value so pre-migration call sites keep
+ * compiling until they are updated to pass it explicitly.
+ */
+export const getPatchPolicyFlags = (
+  patchOption: PatchOption,
+  endUserExperience: EndUserExperience = "immediate"
+) => ({
   patch_when_closed: patchOption === "closed",
-  continuous_automations_enabled: patchOption === "closed",
+  notify_before_patching:
+    patchOption === "force" && endUserExperience === "notify",
+  continuous_automations_enabled:
+    patchOption === "closed" ||
+    (patchOption === "force" && endUserExperience === "notify"),
 });
+
+const END_USER_EXPERIENCE_LINK =
+  "https://fleetdm.com/learn-more-about/patching-end-user-experience";
+
+const END_USER_EXPERIENCE_OPTIONS: CustomOptionType[] = [
+  { label: "Patch immediately", value: "immediate" },
+  { label: "Notify before patching", value: "notify" },
+];
+
+const ImmediateBanner = () => (
+  <InfoBanner icon="error-outline" iconColor="ui-fleet-black-50">
+    End user is not notified. Patch is forced as soon as policy fails.{" "}
+    <CustomLink
+      url={END_USER_EXPERIENCE_LINK}
+      text="End user experience"
+      newTab
+    />
+  </InfoBanner>
+);
+
+const NotifyBanner = () => (
+  <InfoBanner icon="error-outline" iconColor="ui-fleet-black-50">
+    End user is notified when the policy fails. Patch is forced <b>1 hour</b>{" "}
+    later. Fleet Desktop is required.{" "}
+    <CustomLink
+      url={END_USER_EXPERIENCE_LINK}
+      text="End user experience"
+      newTab
+    />
+  </InfoBanner>
+);
+
+const WindowsBanner = () => (
+  <InfoBanner icon="error-outline" iconColor="ui-fleet-black-50">
+    End user is not notified. Patch is forced as soon as policy fails.
+    Notifications for Windows are coming soon.
+  </InfoBanner>
+);
 
 interface ISoftwareDeploySelectorProps {
   forceInstall: boolean;
@@ -24,6 +80,11 @@ interface ISoftwareDeploySelectorProps {
   showPatchWhenClosedNotice?: boolean;
   /** Hide the "Deploy" label — e.g. in the Deploy modal, whose title is already "Deploy". */
   hideLabel?: boolean;
+  /** Platform of the target software. Drives whether the End user experience
+   * dropdown renders (macOS) or the Windows coming-soon banner shows. */
+  platform?: string;
+  endUserExperience?: EndUserExperience;
+  onSelectEndUserExperience?: (value: EndUserExperience) => void;
 }
 
 interface IPatchOptionSelectorProps {
@@ -31,16 +92,48 @@ interface IPatchOptionSelectorProps {
   onSelectPatchOption: (value: PatchOption) => void;
   disabled?: boolean;
   showPatchWhenClosedNotice?: boolean;
+  platform?: string;
+  endUserExperience?: EndUserExperience;
+  onSelectEndUserExperience?: (value: EndUserExperience) => void;
 }
+
+const isMacPlatform = (platform?: string) => platform === "darwin";
+const isWindowsPlatform = (platform?: string) => platform === "windows";
 
 export const PatchOptionSelector = ({
   patchOption,
   onSelectPatchOption,
   disabled = false,
   showPatchWhenClosedNotice = false,
+  platform,
+  endUserExperience = "immediate",
+  onSelectEndUserExperience,
 }: IPatchOptionSelectorProps) => {
   const onChangePatchOption = (value: string) =>
     onSelectPatchOption(value as PatchOption);
+
+  const onChangeEndUserExperience = (
+    newValue: SingleValue<CustomOptionType>
+  ) => {
+    if (newValue?.value) {
+      onSelectEndUserExperience?.(newValue.value as EndUserExperience);
+    }
+  };
+
+  const showEndUserExperienceDropdown =
+    patchOption === "force" &&
+    isMacPlatform(platform) &&
+    !!onSelectEndUserExperience;
+
+  const renderForceBanner = () => {
+    if (isWindowsPlatform(platform)) {
+      return <WindowsBanner />;
+    }
+    if (showEndUserExperienceDropdown && endUserExperience === "notify") {
+      return <NotifyBanner />;
+    }
+    return <ImmediateBanner />;
+  };
 
   return (
     <>
@@ -76,12 +169,17 @@ export const PatchOptionSelector = ({
           onChange={onChangePatchOption}
           disabled={disabled}
         />
-        {patchOption === "force" && (
-          <InfoBanner icon="error-outline" iconColor="ui-fleet-black-50">
-            End user is not notified. Patch is forced as soon as policy fails.
-            Notifications are coming soon.
-          </InfoBanner>
+        {patchOption === "force" && showEndUserExperienceDropdown && (
+          <DropdownWrapper
+            name="end-user-experience"
+            label="End user experience"
+            options={END_USER_EXPERIENCE_OPTIONS}
+            value={endUserExperience}
+            onChange={onChangeEndUserExperience}
+            isDisabled={disabled}
+          />
         )}
+        {patchOption === "force" && renderForceBanner()}
       </div>
       {patchOption === "closed" && showPatchWhenClosedNotice && (
         <p className={`${baseClass}__patch-when-closed-notice`}>
@@ -103,6 +201,9 @@ const SoftwareDeploySelector = ({
   disabled = false,
   showPatchWhenClosedNotice = false,
   hideLabel = false,
+  platform,
+  endUserExperience,
+  onSelectEndUserExperience,
 }: ISoftwareDeploySelectorProps) => {
   return (
     <div className={`form-field ${baseClass}`}>
@@ -131,6 +232,9 @@ const SoftwareDeploySelector = ({
           onSelectPatchOption={onSelectPatchOption}
           disabled={disabled}
           showPatchWhenClosedNotice={showPatchWhenClosedNotice}
+          platform={platform}
+          endUserExperience={endUserExperience}
+          onSelectEndUserExperience={onSelectEndUserExperience}
         />
       )}
     </div>

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareDeploySelector/SoftwareDeploySelector.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareDeploySelector/SoftwareDeploySelector.tsx
@@ -144,13 +144,21 @@ export const PatchOptionSelector = ({
     !!onSelectEndUserExperience;
 
   const renderForceBanner = () => {
+    // Mac wins if the platform names it — even a hypothetical `darwin,windows`
+    // policy should get the dropdown-aware banner, not the "coming soon for
+    // Windows" one. The widened isMacOS/isWindows both return true for such
+    // strings, so precedence matters here.
+    if (isMacOS(platform ?? "")) {
+      return endUserExperience === "notify" ? (
+        <NotifyBanner />
+      ) : (
+        <ImmediateBanner showLink />
+      );
+    }
     if (isWindows(platform ?? "")) {
       return <WindowsBanner />;
     }
-    if (showEndUserExperienceDropdown && endUserExperience === "notify") {
-      return <NotifyBanner />;
-    }
-    return <ImmediateBanner showLink={isMacOS(platform ?? "")} />;
+    return <ImmediateBanner showLink={false} />;
   };
 
   return (

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareDeploySelector/SoftwareDeploySelector.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareDeploySelector/SoftwareDeploySelector.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { SingleValue } from "react-select-5";
 
+import { isMacOS, isWindows } from "interfaces/platform";
+
 import Checkbox from "components/forms/fields/Checkbox";
 import CustomLink from "components/CustomLink";
 import DropdownWrapper, {
@@ -13,17 +15,6 @@ const baseClass = "software-deploy-selector";
 
 export type PatchOption = "closed" | "force" | "manual";
 export type EndUserExperience = "immediate" | "notify";
-
-/**
- * True when the given platform string names macOS. Handles both the single
- * value from software titles (`"darwin"`) and the comma-joined
- * `CommaSeparatedPlatformString` from policies (`"darwin,linux"`).
- */
-export const isMacPlatform = (platform?: string): boolean =>
-  !!platform && platform.split(",").includes("darwin");
-
-const isWindowsPlatform = (platform?: string): boolean =>
-  !!platform && platform.split(",").includes("windows");
 
 /**
  * Returns the three policy flags derived from the deploy selector state.
@@ -42,7 +33,7 @@ export const getPatchPolicyFlags = (
   const notifyActive =
     patchOption === "force" &&
     endUserExperience === "notify" &&
-    isMacPlatform(platform);
+    isMacOS(platform ?? "");
   return {
     patch_when_closed: patchOption === "closed",
     notify_before_patching: notifyActive,
@@ -149,17 +140,17 @@ export const PatchOptionSelector = ({
 
   const showEndUserExperienceDropdown =
     patchOption === "force" &&
-    isMacPlatform(platform) &&
+    isMacOS(platform ?? "") &&
     !!onSelectEndUserExperience;
 
   const renderForceBanner = () => {
-    if (isWindowsPlatform(platform)) {
+    if (isWindows(platform ?? "")) {
       return <WindowsBanner />;
     }
     if (showEndUserExperienceDropdown && endUserExperience === "notify") {
       return <NotifyBanner />;
     }
-    return <ImmediateBanner showLink={isMacPlatform(platform)} />;
+    return <ImmediateBanner showLink={isMacOS(platform ?? "")} />;
   };
 
   return (

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareDeploySelector/SoftwareDeploySelector.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareDeploySelector/SoftwareDeploySelector.tsx
@@ -17,24 +17,13 @@ const baseClass = "software-deploy-selector";
 export type PatchOption = "closed" | "force" | "manual";
 export type EndUserExperience = "immediate" | "notify";
 
-/**
- * Returns the three policy flags derived from the deploy selector state.
- * `notify_before_patching` is gated on `isMacOS(platform)` at the wire
- * boundary — Notify before patching is macOS-only today, and the UI hides
- * the dropdown for Windows, so the flag must not slip through if state
- * ever carries "notify" on a non-Mac software (legacy data, hydration
- * mismatch, or a future third platform). `endUserExperience` and
- * `platform` are defaulted so pre-migration call sites keep compiling.
- */
+/** Returns the three policy flags derived from the deploy selector state. */
 export const getPatchPolicyFlags = (
   patchOption: PatchOption,
-  endUserExperience: EndUserExperience = "immediate",
-  platform?: string
+  endUserExperience: EndUserExperience = "immediate"
 ) => {
   const notifyActive =
-    patchOption === "force" &&
-    endUserExperience === "notify" &&
-    isMacOS(platform);
+    patchOption === "force" && endUserExperience === "notify";
   return {
     patch_when_closed: patchOption === "closed",
     notify_before_patching: notifyActive,

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareDeploySelector/SoftwareDeploySelector.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareDeploySelector/SoftwareDeploySelector.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { SingleValue } from "react-select-5";
 
 import { isMacOS, isWindows } from "interfaces/platform";
+import { LEARN_MORE_ABOUT_BASE_LINK } from "utilities/constants";
 
 import Checkbox from "components/forms/fields/Checkbox";
 import CustomLink from "components/CustomLink";
@@ -41,8 +42,7 @@ export const getPatchPolicyFlags = (
   };
 };
 
-const END_USER_EXPERIENCE_LINK =
-  "https://fleetdm.com/learn-more-about/patching-end-user-experience";
+const END_USER_EXPERIENCE_LINK = `${LEARN_MORE_ABOUT_BASE_LINK}/patching-end-user-experience`;
 
 const END_USER_EXPERIENCE_OPTIONS: CustomOptionType[] = [
   { label: "Patch immediately", value: "immediate" },

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareDeploySelector/SoftwareDeploySelector.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareDeploySelector/SoftwareDeploySelector.tsx
@@ -174,7 +174,11 @@ export const PatchOptionSelector = ({
             name="end-user-experience"
             label="End user experience"
             options={END_USER_EXPERIENCE_OPTIONS}
-            value={endUserExperience}
+            value={
+              END_USER_EXPERIENCE_OPTIONS.find(
+                (o) => o.value === endUserExperience
+              ) ?? END_USER_EXPERIENCE_OPTIONS[0]
+            }
             onChange={onChangeEndUserExperience}
             isDisabled={disabled}
           />

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareDeploySelector/SoftwareDeploySelector.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareDeploySelector/SoftwareDeploySelector.tsx
@@ -16,20 +16,28 @@ export type EndUserExperience = "immediate" | "notify";
 
 /**
  * Returns the three policy flags derived from the deploy selector state.
- * `endUserExperience` has a defaulted value so pre-migration call sites keep
- * compiling until they are updated to pass it explicitly.
+ * `notify_before_patching` is gated on `platform === "darwin"` at the wire
+ * boundary — Notify before patching is macOS-only today, and the UI hides
+ * the dropdown for Windows, so the flag must not slip through if state
+ * ever carries "notify" on a non-Mac software (legacy data, hydration
+ * mismatch, or a future third platform). `endUserExperience` and
+ * `platform` are defaulted so pre-migration call sites keep compiling.
  */
 export const getPatchPolicyFlags = (
   patchOption: PatchOption,
-  endUserExperience: EndUserExperience = "immediate"
-) => ({
-  patch_when_closed: patchOption === "closed",
-  notify_before_patching:
-    patchOption === "force" && endUserExperience === "notify",
-  continuous_automations_enabled:
-    patchOption === "closed" ||
-    (patchOption === "force" && endUserExperience === "notify"),
-});
+  endUserExperience: EndUserExperience = "immediate",
+  platform?: string
+) => {
+  const notifyActive =
+    patchOption === "force" &&
+    endUserExperience === "notify" &&
+    platform === "darwin";
+  return {
+    patch_when_closed: patchOption === "closed",
+    notify_before_patching: notifyActive,
+    continuous_automations_enabled: patchOption === "closed" || notifyActive,
+  };
+};
 
 const END_USER_EXPERIENCE_LINK =
   "https://fleetdm.com/learn-more-about/patching-end-user-experience";

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareDeploySelector/SoftwareDeploySelector.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareDeploySelector/SoftwareDeploySelector.tsx
@@ -15,6 +15,17 @@ export type PatchOption = "closed" | "force" | "manual";
 export type EndUserExperience = "immediate" | "notify";
 
 /**
+ * True when the given platform string names macOS. Handles both the single
+ * value from software titles (`"darwin"`) and the comma-joined
+ * `CommaSeparatedPlatformString` from policies (`"darwin,linux"`).
+ */
+export const isMacPlatform = (platform?: string): boolean =>
+  !!platform && platform.split(",").includes("darwin");
+
+const isWindowsPlatform = (platform?: string): boolean =>
+  !!platform && platform.split(",").includes("windows");
+
+/**
  * Returns the three policy flags derived from the deploy selector state.
  * `notify_before_patching` is gated on `platform === "darwin"` at the wire
  * boundary — Notify before patching is macOS-only today, and the UI hides
@@ -31,7 +42,7 @@ export const getPatchPolicyFlags = (
   const notifyActive =
     patchOption === "force" &&
     endUserExperience === "notify" &&
-    platform === "darwin";
+    isMacPlatform(platform);
   return {
     patch_when_closed: patchOption === "closed",
     notify_before_patching: notifyActive,
@@ -47,14 +58,25 @@ const END_USER_EXPERIENCE_OPTIONS: CustomOptionType[] = [
   { label: "Notify before patching", value: "notify" },
 ];
 
-const ImmediateBanner = () => (
+/**
+ * `showLink` is only true when the user could plausibly opt into Notify —
+ * i.e. macOS today. On Windows and unknown platforms, Notify is unavailable
+ * so the "End user experience" learn-more link would point at a feature the
+ * user has no way to reach and gets suppressed.
+ */
+const ImmediateBanner = ({ showLink }: { showLink: boolean }) => (
   <InfoBanner icon="error-outline" iconColor="ui-fleet-black-50">
-    End user is not notified. Patch is forced as soon as policy fails.{" "}
-    <CustomLink
-      url={END_USER_EXPERIENCE_LINK}
-      text="End user experience"
-      newTab
-    />
+    End user is not notified. Patch is forced as soon as policy fails.
+    {showLink && (
+      <>
+        {" "}
+        <CustomLink
+          url={END_USER_EXPERIENCE_LINK}
+          text="End user experience"
+          newTab
+        />
+      </>
+    )}
   </InfoBanner>
 );
 
@@ -105,9 +127,6 @@ interface IPatchOptionSelectorProps {
   onSelectEndUserExperience?: (value: EndUserExperience) => void;
 }
 
-const isMacPlatform = (platform?: string) => platform === "darwin";
-const isWindowsPlatform = (platform?: string) => platform === "windows";
-
 export const PatchOptionSelector = ({
   patchOption,
   onSelectPatchOption,
@@ -140,7 +159,7 @@ export const PatchOptionSelector = ({
     if (showEndUserExperienceDropdown && endUserExperience === "notify") {
       return <NotifyBanner />;
     }
-    return <ImmediateBanner />;
+    return <ImmediateBanner showLink={isMacPlatform(platform)} />;
   };
 
   return (

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareDeploySelector/SoftwareDeploySelector.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareDeploySelector/SoftwareDeploySelector.tsx
@@ -18,7 +18,7 @@ export type EndUserExperience = "immediate" | "notify";
 
 /**
  * Returns the three policy flags derived from the deploy selector state.
- * `notify_before_patching` is gated on `platform === "darwin"` at the wire
+ * `notify_before_patching` is gated on `isMacOS(platform)` at the wire
  * boundary — Notify before patching is macOS-only today, and the UI hides
  * the dropdown for Windows, so the flag must not slip through if state
  * ever carries "notify" on a non-Mac software (legacy data, hydration
@@ -33,7 +33,7 @@ export const getPatchPolicyFlags = (
   const notifyActive =
     patchOption === "force" &&
     endUserExperience === "notify" &&
-    isMacOS(platform ?? "");
+    isMacOS(platform);
   return {
     patch_when_closed: patchOption === "closed",
     notify_before_patching: notifyActive,
@@ -139,23 +139,21 @@ export const PatchOptionSelector = ({
   };
 
   const showEndUserExperienceDropdown =
-    patchOption === "force" &&
-    isMacOS(platform ?? "") &&
-    !!onSelectEndUserExperience;
+    patchOption === "force" && isMacOS(platform) && !!onSelectEndUserExperience;
 
   const renderForceBanner = () => {
     // Mac wins if the platform names it — even a hypothetical `darwin,windows`
     // policy should get the dropdown-aware banner, not the "coming soon for
     // Windows" one. The widened isMacOS/isWindows both return true for such
     // strings, so precedence matters here.
-    if (isMacOS(platform ?? "")) {
+    if (isMacOS(platform)) {
       return endUserExperience === "notify" ? (
         <NotifyBanner />
       ) : (
         <ImmediateBanner showLink />
       );
     }
-    if (isWindows(platform ?? "")) {
+    if (isWindows(platform)) {
       return <WindowsBanner />;
     }
     return <ImmediateBanner showLink={false} />;
@@ -195,7 +193,7 @@ export const PatchOptionSelector = ({
           onChange={onChangePatchOption}
           disabled={disabled}
         />
-        {patchOption === "force" && showEndUserExperienceDropdown && (
+        {showEndUserExperienceDropdown && (
           <DropdownWrapper
             name="end-user-experience"
             label="End user experience"

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareDeploySelector/index.ts
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareDeploySelector/index.ts
@@ -2,5 +2,5 @@ export {
   default as SoftwareDeploySelector,
   PatchOptionSelector,
 } from "./SoftwareDeploySelector";
-export { getPatchPolicyFlags, isMacPlatform } from "./SoftwareDeploySelector";
+export { getPatchPolicyFlags } from "./SoftwareDeploySelector";
 export type { PatchOption, EndUserExperience } from "./SoftwareDeploySelector";

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareDeploySelector/index.ts
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareDeploySelector/index.ts
@@ -3,4 +3,4 @@ export {
   PatchOptionSelector,
 } from "./SoftwareDeploySelector";
 export { getPatchPolicyFlags } from "./SoftwareDeploySelector";
-export type { PatchOption } from "./SoftwareDeploySelector";
+export type { PatchOption, EndUserExperience } from "./SoftwareDeploySelector";

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareDeploySelector/index.ts
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareDeploySelector/index.ts
@@ -2,5 +2,5 @@ export {
   default as SoftwareDeploySelector,
   PatchOptionSelector,
 } from "./SoftwareDeploySelector";
-export { getPatchPolicyFlags } from "./SoftwareDeploySelector";
+export { getPatchPolicyFlags, isMacPlatform } from "./SoftwareDeploySelector";
 export type { PatchOption, EndUserExperience } from "./SoftwareDeploySelector";

--- a/frontend/pages/policies/components/PolicyAutomationsFields/PolicyAutomationsFields.tests.tsx
+++ b/frontend/pages/policies/components/PolicyAutomationsFields/PolicyAutomationsFields.tests.tsx
@@ -549,6 +549,32 @@ describe("PolicyAutomationsFields — payload", () => {
     ).toBeInTheDocument();
   });
 
+  it("auto-heals a legacy Windows policy carrying notify_before_patching:true by sending notify_before_patching:false on save", () => {
+    const handleRef: React.MutableRefObject<IPolicyAutomationsFieldsHandle | null> = {
+      current: null,
+    };
+    renderWithHandle(
+      {
+        type: "patch",
+        platform: "windows",
+        patch_software: { name: "Notepad", software_title_id: 55 },
+        patch_when_closed: false,
+        // Legacy bad state — this shouldn't have shipped, but if it did, the
+        // Mac gate on the derivation flips it back to false and the dirty
+        // check writes the corrected value to the wire.
+        notify_before_patching: true,
+        continuous_automations_enabled: true,
+      },
+      handleRef,
+      { patchOption: "force", endUserExperience: "notify" }
+    );
+
+    const payload = handleRef.current?.getAutomationsPayload().policyUpdate;
+    expect(payload).toMatchObject({
+      notify_before_patching: false,
+    });
+  });
+
   it("never surfaces notify_before_patching for a Windows policy even when the endUserExperience state says notify", () => {
     const handleRef: React.MutableRefObject<IPolicyAutomationsFieldsHandle | null> = {
       current: null,

--- a/frontend/pages/policies/components/PolicyAutomationsFields/PolicyAutomationsFields.tests.tsx
+++ b/frontend/pages/policies/components/PolicyAutomationsFields/PolicyAutomationsFields.tests.tsx
@@ -491,4 +491,94 @@ describe("PolicyAutomationsFields — payload", () => {
       screen.getByRole("checkbox", { name: "continuous-automations-enabled" })
     ).toHaveAttribute("aria-checked", "true");
   });
+
+  it("maps Force patch + Notify before patching to notify_before_patching:true + continuous on", () => {
+    const handleRef: React.MutableRefObject<IPolicyAutomationsFieldsHandle | null> = {
+      current: null,
+    };
+    renderWithHandle(
+      {
+        type: "patch",
+        platform: "darwin",
+        patch_software: { name: "Firefox", software_title_id: 42 },
+        patch_when_closed: false,
+        notify_before_patching: false,
+        continuous_automations_enabled: false,
+      },
+      handleRef,
+      { patchOption: "force", endUserExperience: "notify" }
+    );
+
+    expect(
+      handleRef.current?.getAutomationsPayload().policyUpdate
+    ).toMatchObject({
+      software_title_id: 42,
+      notify_before_patching: true,
+      continuous_automations_enabled: true,
+    });
+  });
+
+  it("locks continuous automation with the Notify tooltip when Notify before patching is selected", async () => {
+    const { user, container } = renderWithHandle(
+      {
+        type: "patch",
+        platform: "darwin",
+        patch_when_closed: false,
+        notify_before_patching: false,
+        continuous_automations_enabled: false,
+      },
+      undefined,
+      { patchOption: "force", endUserExperience: "notify" }
+    );
+
+    const continuous = screen.getByRole("checkbox", {
+      name: "continuous-automations-enabled",
+    });
+    expect(continuous).toHaveAttribute("aria-checked", "true");
+    expect(continuous).toHaveAttribute("aria-disabled", "true");
+
+    const icon = container.querySelector(
+      ".policy-automations-fields__section:last-child .fleet-checkbox__icon"
+    );
+    expect(icon).not.toBeNull();
+    await user.hover(icon as Element);
+    expect(
+      await screen.findByText(
+        "Continuous automation can't be disabled when Notify before patching is selected."
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("never surfaces notify_before_patching for a Windows policy even when the endUserExperience state says notify", () => {
+    const handleRef: React.MutableRefObject<IPolicyAutomationsFieldsHandle | null> = {
+      current: null,
+    };
+    renderWithHandle(
+      {
+        type: "patch",
+        platform: "windows",
+        patch_software: { name: "Notepad", software_title_id: 55 },
+        patch_when_closed: false,
+        notify_before_patching: false,
+        continuous_automations_enabled: false,
+      },
+      handleRef,
+      { patchOption: "force", endUserExperience: "notify" }
+    );
+
+    // Windows: notify state is present but the derivation gates on
+    // policy.platform === "darwin", so notifyBeforePatching stays false and
+    // matches initial — the "dirty" check omits the field from the payload,
+    // which is exactly what we want on the wire.
+    const payload = handleRef.current?.getAutomationsPayload().policyUpdate;
+    expect(payload).toMatchObject({
+      software_title_id: 55,
+      continuous_automations_enabled: false,
+    });
+    expect(payload?.notify_before_patching ?? false).toBe(false);
+    // And the continuous checkbox stays editable — the lock is off.
+    expect(
+      screen.getByRole("checkbox", { name: "continuous-automations-enabled" })
+    ).toHaveAttribute("aria-disabled", "false");
+  });
 });

--- a/frontend/pages/policies/components/PolicyAutomationsFields/PolicyAutomationsFields.tests.tsx
+++ b/frontend/pages/policies/components/PolicyAutomationsFields/PolicyAutomationsFields.tests.tsx
@@ -572,6 +572,9 @@ describe("PolicyAutomationsFields — payload", () => {
     const payload = handleRef.current?.getAutomationsPayload().policyUpdate;
     expect(payload).toMatchObject({
       notify_before_patching: false,
+      // continuous stays at the policy's stored value — the Mac gate on the
+      // state init keeps us from silently downgrading it alongside notify.
+      continuous_automations_enabled: true,
     });
   });
 

--- a/frontend/pages/policies/components/PolicyAutomationsFields/PolicyAutomationsFields.tests.tsx
+++ b/frontend/pages/policies/components/PolicyAutomationsFields/PolicyAutomationsFields.tests.tsx
@@ -396,7 +396,7 @@ describe("PolicyAutomationsFields — payload", () => {
     });
   });
 
-  it("maps End user initiated to no continuous automation", () => {
+  it("hides the continuous checkbox on End user initiated and preserves the stored value on the wire", () => {
     const handleRef: React.MutableRefObject<IPolicyAutomationsFieldsHandle | null> = {
       current: null,
     };
@@ -412,11 +412,13 @@ describe("PolicyAutomationsFields — payload", () => {
       { patchOption: "manual" }
     );
 
+    // Manual hides the checkbox but preserves stored continuous — the wire
+    // must not silently downgrade a value the user never touched.
     expect(
       handleRef.current?.getAutomationsPayload().policyUpdate
     ).toMatchObject({
       software_title_id: null,
-      continuous_automations_enabled: false,
+      continuous_automations_enabled: true,
     });
 
     expect(
@@ -547,67 +549,5 @@ describe("PolicyAutomationsFields — payload", () => {
         "Continuous automation can't be disabled when Notify before patching is selected."
       )
     ).toBeInTheDocument();
-  });
-
-  it("auto-heals a legacy Windows policy carrying notify_before_patching:true by sending notify_before_patching:false on save", () => {
-    const handleRef: React.MutableRefObject<IPolicyAutomationsFieldsHandle | null> = {
-      current: null,
-    };
-    renderWithHandle(
-      {
-        type: "patch",
-        platform: "windows",
-        patch_software: { name: "Notepad", software_title_id: 55 },
-        patch_when_closed: false,
-        // Legacy bad state — this shouldn't have shipped, but if it did, the
-        // Mac gate on the derivation flips it back to false and the dirty
-        // check writes the corrected value to the wire.
-        notify_before_patching: true,
-        continuous_automations_enabled: true,
-      },
-      handleRef,
-      { patchOption: "force", endUserExperience: "notify" }
-    );
-
-    const payload = handleRef.current?.getAutomationsPayload().policyUpdate;
-    expect(payload).toMatchObject({
-      notify_before_patching: false,
-      // continuous stays at the policy's stored value — the Mac gate on the
-      // state init keeps us from silently downgrading it alongside notify.
-      continuous_automations_enabled: true,
-    });
-  });
-
-  it("never surfaces notify_before_patching for a Windows policy even when the endUserExperience state says notify", () => {
-    const handleRef: React.MutableRefObject<IPolicyAutomationsFieldsHandle | null> = {
-      current: null,
-    };
-    renderWithHandle(
-      {
-        type: "patch",
-        platform: "windows",
-        patch_software: { name: "Notepad", software_title_id: 55 },
-        patch_when_closed: false,
-        notify_before_patching: false,
-        continuous_automations_enabled: false,
-      },
-      handleRef,
-      { patchOption: "force", endUserExperience: "notify" }
-    );
-
-    // Windows: notify state is present but the derivation gates on
-    // policy.platform === "darwin", so notifyBeforePatching stays false and
-    // matches initial — the "dirty" check omits the field from the payload,
-    // which is exactly what we want on the wire.
-    const payload = handleRef.current?.getAutomationsPayload().policyUpdate;
-    expect(payload).toMatchObject({
-      software_title_id: 55,
-      continuous_automations_enabled: false,
-    });
-    expect(payload?.notify_before_patching ?? false).toBe(false);
-    // And the continuous checkbox stays editable — the lock is off.
-    expect(
-      screen.getByRole("checkbox", { name: "continuous-automations-enabled" })
-    ).toHaveAttribute("aria-disabled", "false");
   });
 });

--- a/frontend/pages/policies/components/PolicyAutomationsFields/PolicyAutomationsFields.tsx
+++ b/frontend/pages/policies/components/PolicyAutomationsFields/PolicyAutomationsFields.tsx
@@ -34,7 +34,10 @@ import {
   getTicketOrWebhookLabel,
 } from "pages/policies/helpers";
 import { getDisplayedSoftwareName } from "pages/SoftwarePage/helpers";
-import { PatchOption } from "pages/SoftwarePage/components/forms/SoftwareDeploySelector";
+import {
+  EndUserExperience,
+  PatchOption,
+} from "pages/SoftwarePage/components/forms/SoftwareDeploySelector";
 
 import { IPolicyAutomationUpdate } from "pages/policies/hooks";
 
@@ -88,6 +91,10 @@ interface IPolicyAutomationsFieldsProps {
   fleetName: string;
   /** Present only for patch policies on Premium. */
   patchOption?: PatchOption;
+  /** Present only for patch policies on Premium — the "Force patch" end-user
+   *  experience choice. Controls whether continuous automations is locked on
+   *  (same rule as `patchOption === "closed"`). */
+  endUserExperience?: EndUserExperience;
   /** Rendered between the automation types and the continuous-automation
    *  checkbox — the edit-policy Patch radios (owned by PolicyForm). */
   patchSlot?: React.ReactNode;
@@ -106,6 +113,7 @@ const PolicyAutomationsFields = forwardRef<
       globalConfig,
       fleetName,
       patchOption,
+      endUserExperience,
       patchSlot,
     },
     ref
@@ -156,6 +164,7 @@ const PolicyAutomationsFields = forwardRef<
     const initialConditionalAccess = policy.conditional_access_enabled;
     const initialContinuous = policy.continuous_automations_enabled ?? false;
     const initialPatchWhenClosed = policy.patch_when_closed ?? false;
+    const initialNotifyBeforePatching = policy.notify_before_patching ?? false;
 
     const [webhookOrTicketEnabled, setWebhookOrTicketEnabled] = useState(
       initialWebhookOrTicket
@@ -169,13 +178,31 @@ const PolicyAutomationsFields = forwardRef<
       initialConditionalAccess
     );
     const [continuousEnabled, setContinuousEnabled] = useState(
-      initialPatchWhenClosed ? false : initialContinuous
+      initialPatchWhenClosed || initialNotifyBeforePatching
+        ? false
+        : initialContinuous
     );
     const patchWhenClosed = patchOption
       ? patchOption === "closed"
       : initialPatchWhenClosed;
-    let effectiveContinuousEnabled = continuousEnabled;
+    const notifyBeforePatching =
+      patchOption !== undefined
+        ? patchOption === "force" && endUserExperience === "notify"
+        : initialNotifyBeforePatching;
+    // Continuous automations is locked on for both "Patch when app is closed"
+    // and "Notify before patching" — the backend forces it on for both, so an
+    // editable checkbox would lie.
+    const continuousLocked = patchWhenClosed || notifyBeforePatching;
+    let continuousLockedTooltip: string | undefined;
     if (patchWhenClosed) {
+      continuousLockedTooltip =
+        "Continuous automation can't be disabled when Patch when app is closed is selected.";
+    } else if (notifyBeforePatching) {
+      continuousLockedTooltip =
+        "Continuous automation can't be disabled when Notify before patching is selected.";
+    }
+    let effectiveContinuousEnabled = continuousEnabled;
+    if (continuousLocked) {
       effectiveContinuousEnabled = true;
     } else if (patchOption === "manual") {
       effectiveContinuousEnabled = false;
@@ -369,7 +396,8 @@ const PolicyAutomationsFields = forwardRef<
             conditionalAccess !== initialConditionalAccess ||
             effectiveContinuousEnabled !== initialContinuous ||
             (patchOption !== undefined &&
-              patchWhenClosed !== initialPatchWhenClosed));
+              (patchWhenClosed !== initialPatchWhenClosed ||
+                notifyBeforePatching !== initialNotifyBeforePatching)));
         const webhookDirty = webhookOrTicketEnabled !== initialWebhookOrTicket;
 
         return {
@@ -402,6 +430,10 @@ const PolicyAutomationsFields = forwardRef<
                 ...(patchOption !== undefined &&
                   patchWhenClosed !== initialPatchWhenClosed && {
                     patch_when_closed: patchWhenClosed,
+                  }),
+                ...(patchOption !== undefined &&
+                  notifyBeforePatching !== initialNotifyBeforePatching && {
+                    notify_before_patching: notifyBeforePatching,
                   }),
               }
             : undefined,
@@ -625,13 +657,9 @@ const PolicyAutomationsFields = forwardRef<
                 <Checkbox
                   name="continuous-automations-enabled"
                   value={effectiveContinuousEnabled}
-                  disabled={disableChildren || patchWhenClosed}
+                  disabled={disableChildren || continuousLocked}
                   onChange={handleToggleContinuous}
-                  iconTooltipContent={
-                    patchWhenClosed
-                      ? "Continuous automation can't be disabled when Patch when app is closed is selected."
-                      : undefined
-                  }
+                  iconTooltipContent={continuousLockedTooltip}
                   helpText="If the automations do not resolve the policy, this could cause a retry loop."
                 >
                   <TooltipWrapper

--- a/frontend/pages/policies/components/PolicyAutomationsFields/PolicyAutomationsFields.tsx
+++ b/frontend/pages/policies/components/PolicyAutomationsFields/PolicyAutomationsFields.tsx
@@ -206,9 +206,9 @@ const PolicyAutomationsFields = forwardRef<
     // Continuous automations is locked on for both "Patch when app is closed"
     // and "Notify before patching" — the backend forces it on for both, so an
     // editable checkbox would lie.
-    const isContinuousAutomationRequired =
+    const isContinuousAutomationsRequired =
       patchWhenClosed || notifyBeforePatching;
-    const getContinuousAutomationRequiredTooltip = (): string | undefined => {
+    const getContinuousAutomationsRequiredTooltip = (): string | undefined => {
       if (patchWhenClosed) {
         return "Continuous automation can't be disabled when Patch when app is closed is selected.";
       }
@@ -218,11 +218,11 @@ const PolicyAutomationsFields = forwardRef<
       return undefined;
     };
     const getEffectiveContinuousEnabled = (): boolean => {
-      if (isContinuousAutomationRequired) return true;
+      if (isContinuousAutomationsRequired) return true;
       if (patchOption === "manual") return false;
       return continuousEnabled;
     };
-    const continuousAutomationRequiredTooltip = getContinuousAutomationRequiredTooltip();
+    const continuousAutomationsRequiredTooltip = getContinuousAutomationsRequiredTooltip();
     const effectiveContinuousEnabled = getEffectiveContinuousEnabled();
 
     const [softwareTitleId, setSoftwareTitleId] = useState<number | null>(
@@ -680,9 +680,9 @@ const PolicyAutomationsFields = forwardRef<
                 <Checkbox
                   name="continuous-automations-enabled"
                   value={effectiveContinuousEnabled}
-                  disabled={disableChildren || isContinuousAutomationRequired}
+                  disabled={disableChildren || isContinuousAutomationsRequired}
                   onChange={handleToggleContinuous}
-                  iconTooltipContent={continuousAutomationRequiredTooltip}
+                  iconTooltipContent={continuousAutomationsRequiredTooltip}
                   helpText="If the automations do not resolve the policy, this could cause a retry loop."
                 >
                   <TooltipWrapper

--- a/frontend/pages/policies/components/PolicyAutomationsFields/PolicyAutomationsFields.tsx
+++ b/frontend/pages/policies/components/PolicyAutomationsFields/PolicyAutomationsFields.tsx
@@ -185,10 +185,16 @@ const PolicyAutomationsFields = forwardRef<
     const patchWhenClosed = patchOption
       ? patchOption === "closed"
       : initialPatchWhenClosed;
+    // Notify before patching is macOS-only; gate at the derivation so the
+    // continuous-automations lock and the wire payload stay in sync even if
+    // a legacy Windows policy carries `notify_before_patching: true`.
+    const isMacPolicy = policy.platform === "darwin";
     const notifyBeforePatching =
       patchOption !== undefined
-        ? patchOption === "force" && endUserExperience === "notify"
-        : initialNotifyBeforePatching;
+        ? patchOption === "force" &&
+          endUserExperience === "notify" &&
+          isMacPolicy
+        : initialNotifyBeforePatching && isMacPolicy;
     // Continuous automations is locked on for both "Patch when app is closed"
     // and "Notify before patching" — the backend forces it on for both, so an
     // editable checkbox would lie.

--- a/frontend/pages/policies/components/PolicyAutomationsFields/PolicyAutomationsFields.tsx
+++ b/frontend/pages/policies/components/PolicyAutomationsFields/PolicyAutomationsFields.tsx
@@ -36,6 +36,7 @@ import {
 import { getDisplayedSoftwareName } from "pages/SoftwarePage/helpers";
 import {
   EndUserExperience,
+  isMacPlatform,
   PatchOption,
 } from "pages/SoftwarePage/components/forms/SoftwareDeploySelector";
 
@@ -188,7 +189,9 @@ const PolicyAutomationsFields = forwardRef<
     // Notify before patching is macOS-only; gate at the derivation so the
     // continuous-automations lock and the wire payload stay in sync even if
     // a legacy Windows policy carries `notify_before_patching: true`.
-    const isMacPolicy = policy.platform === "darwin";
+    // Uses the same helper as the wire boundary so multi-platform policy
+    // strings (`"darwin,linux"`) are treated as Mac too.
+    const isMacPolicy = isMacPlatform(policy.platform);
     const notifyBeforePatching =
       patchOption !== undefined
         ? patchOption === "force" &&

--- a/frontend/pages/policies/components/PolicyAutomationsFields/PolicyAutomationsFields.tsx
+++ b/frontend/pages/policies/components/PolicyAutomationsFields/PolicyAutomationsFields.tsx
@@ -397,6 +397,13 @@ const PolicyAutomationsFields = forwardRef<
           return { isValid: false, isDirty: false };
         }
 
+        // `notifyBeforePatching !== initialNotifyBeforePatching` covers the
+        // legacy-Windows auto-heal on its own: the derived value flips to
+        // false for a non-Mac policy that stored `notify_before_patching:
+        // true`, so the payload writes the corrected value. The Mac gate on
+        // the state init (see `initialIsMacNotify`) is what keeps
+        // `effectiveContinuousEnabled` at its stored value in that same
+        // case, so continuous isn't silently downgraded alongside notify.
         const perPolicyDirty =
           !isGlobalPolicy &&
           (effectiveInstallSoftware !== initialInstallSoftware ||

--- a/frontend/pages/policies/components/PolicyAutomationsFields/PolicyAutomationsFields.tsx
+++ b/frontend/pages/policies/components/PolicyAutomationsFields/PolicyAutomationsFields.tsx
@@ -34,7 +34,6 @@ import {
   getTicketOrWebhookLabel,
 } from "pages/policies/helpers";
 import { getDisplayedSoftwareName } from "pages/SoftwarePage/helpers";
-import { isMacOS } from "interfaces/platform";
 import {
   EndUserExperience,
   PatchOption,
@@ -166,13 +165,6 @@ const PolicyAutomationsFields = forwardRef<
     const initialContinuous = policy.continuous_automations_enabled ?? false;
     const initialPatchWhenClosed = policy.patch_when_closed ?? false;
     const initialNotifyBeforePatching = policy.notify_before_patching ?? false;
-    // Gate the notify init on Mac so a legacy Windows policy with
-    // `notify_before_patching: true` doesn't silently downgrade its stored
-    // `continuous_automations_enabled` on the next unrelated save — the
-    // continuous state should stay at whatever the policy currently carries
-    // when the notify flag doesn't actually apply.
-    const initialIsMacNotify =
-      initialNotifyBeforePatching && isMacOS(policy.platform);
 
     const [webhookOrTicketEnabled, setWebhookOrTicketEnabled] = useState(
       initialWebhookOrTicket
@@ -186,29 +178,23 @@ const PolicyAutomationsFields = forwardRef<
       initialConditionalAccess
     );
     const [continuousEnabled, setContinuousEnabled] = useState(
-      initialPatchWhenClosed || initialIsMacNotify ? false : initialContinuous
+      initialPatchWhenClosed || initialNotifyBeforePatching
+        ? false
+        : initialContinuous
     );
     const patchWhenClosed = patchOption
       ? patchOption === "closed"
       : initialPatchWhenClosed;
-    // Notify before patching is macOS-only; gate at the derivation so the
-    // continuous-automations lock and the wire payload stay in sync even if
-    // a legacy Windows policy carries `notify_before_patching: true`.
-    // Uses the same helper as the wire boundary so multi-platform policy
-    // strings (`"darwin,linux"`) are treated as Mac too.
-    const isMacPolicy = isMacOS(policy.platform);
     const notifyBeforePatching =
       patchOption !== undefined
-        ? patchOption === "force" &&
-          endUserExperience === "notify" &&
-          isMacPolicy
-        : initialNotifyBeforePatching && isMacPolicy;
+        ? patchOption === "force" && endUserExperience === "notify"
+        : initialNotifyBeforePatching;
     // Continuous automations is locked on for both "Patch when app is closed"
     // and "Notify before patching" — the backend forces it on for both, so an
     // editable checkbox would lie.
     const isContinuousAutomationsRequired =
       patchWhenClosed || notifyBeforePatching;
-    const getContinuousAutomationsRequiredTooltip = (): string | undefined => {
+    const getContinuousAutomationsRequiredTooltip = () => {
       if (patchWhenClosed) {
         return "Continuous automation can't be disabled when Patch when app is closed is selected.";
       }
@@ -217,9 +203,11 @@ const PolicyAutomationsFields = forwardRef<
       }
       return undefined;
     };
-    const getEffectiveContinuousEnabled = (): boolean => {
+    const getEffectiveContinuousEnabled = () => {
       if (isContinuousAutomationsRequired) return true;
-      if (patchOption === "manual") return false;
+      // Manual patch hides the continuous checkbox; preserve the stored value
+      // on the wire so a policy that had continuous on doesn't silently flip.
+      if (patchOption === "manual") return initialContinuous;
       return continuousEnabled;
     };
     const continuousAutomationsRequiredTooltip = getContinuousAutomationsRequiredTooltip();
@@ -400,12 +388,6 @@ const PolicyAutomationsFields = forwardRef<
           return { isValid: false, isDirty: false };
         }
 
-        // Legacy-Windows auto-heal: a policy that shouldn't have stored
-        // `notify_before_patching: true` still gets the derived value
-        // flipped back to false, so this dirty check writes the correction
-        // on save. `initialIsMacNotify` (state init) is what keeps the
-        // stored `continuous_automations_enabled` from being downgraded
-        // alongside it.
         const perPolicyDirty =
           !isGlobalPolicy &&
           (effectiveInstallSoftware !== initialInstallSoftware ||

--- a/frontend/pages/policies/components/PolicyAutomationsFields/PolicyAutomationsFields.tsx
+++ b/frontend/pages/policies/components/PolicyAutomationsFields/PolicyAutomationsFields.tsx
@@ -166,6 +166,13 @@ const PolicyAutomationsFields = forwardRef<
     const initialContinuous = policy.continuous_automations_enabled ?? false;
     const initialPatchWhenClosed = policy.patch_when_closed ?? false;
     const initialNotifyBeforePatching = policy.notify_before_patching ?? false;
+    // Gate the notify init on Mac so a legacy Windows policy with
+    // `notify_before_patching: true` doesn't silently downgrade its stored
+    // `continuous_automations_enabled` on the next unrelated save — the
+    // continuous state should stay at whatever the policy currently carries
+    // when the notify flag doesn't actually apply.
+    const initialIsMacNotify =
+      initialNotifyBeforePatching && isMacOS(policy.platform);
 
     const [webhookOrTicketEnabled, setWebhookOrTicketEnabled] = useState(
       initialWebhookOrTicket
@@ -179,9 +186,7 @@ const PolicyAutomationsFields = forwardRef<
       initialConditionalAccess
     );
     const [continuousEnabled, setContinuousEnabled] = useState(
-      initialPatchWhenClosed || initialNotifyBeforePatching
-        ? false
-        : initialContinuous
+      initialPatchWhenClosed || initialIsMacNotify ? false : initialContinuous
     );
     const patchWhenClosed = patchOption
       ? patchOption === "closed"

--- a/frontend/pages/policies/components/PolicyAutomationsFields/PolicyAutomationsFields.tsx
+++ b/frontend/pages/policies/components/PolicyAutomationsFields/PolicyAutomationsFields.tsx
@@ -206,8 +206,9 @@ const PolicyAutomationsFields = forwardRef<
     // Continuous automations is locked on for both "Patch when app is closed"
     // and "Notify before patching" — the backend forces it on for both, so an
     // editable checkbox would lie.
-    const continuousLocked = patchWhenClosed || notifyBeforePatching;
-    const getContinuousLockedTooltip = (): string | undefined => {
+    const isContinuousAutomationRequired =
+      patchWhenClosed || notifyBeforePatching;
+    const getContinuousAutomationRequiredTooltip = (): string | undefined => {
       if (patchWhenClosed) {
         return "Continuous automation can't be disabled when Patch when app is closed is selected.";
       }
@@ -217,11 +218,11 @@ const PolicyAutomationsFields = forwardRef<
       return undefined;
     };
     const getEffectiveContinuousEnabled = (): boolean => {
-      if (continuousLocked) return true;
+      if (isContinuousAutomationRequired) return true;
       if (patchOption === "manual") return false;
       return continuousEnabled;
     };
-    const continuousLockedTooltip = getContinuousLockedTooltip();
+    const continuousAutomationRequiredTooltip = getContinuousAutomationRequiredTooltip();
     const effectiveContinuousEnabled = getEffectiveContinuousEnabled();
 
     const [softwareTitleId, setSoftwareTitleId] = useState<number | null>(
@@ -679,9 +680,9 @@ const PolicyAutomationsFields = forwardRef<
                 <Checkbox
                   name="continuous-automations-enabled"
                   value={effectiveContinuousEnabled}
-                  disabled={disableChildren || continuousLocked}
+                  disabled={disableChildren || isContinuousAutomationRequired}
                   onChange={handleToggleContinuous}
-                  iconTooltipContent={continuousLockedTooltip}
+                  iconTooltipContent={continuousAutomationRequiredTooltip}
                   helpText="If the automations do not resolve the policy, this could cause a retry loop."
                 >
                   <TooltipWrapper

--- a/frontend/pages/policies/components/PolicyAutomationsFields/PolicyAutomationsFields.tsx
+++ b/frontend/pages/policies/components/PolicyAutomationsFields/PolicyAutomationsFields.tsx
@@ -34,9 +34,9 @@ import {
   getTicketOrWebhookLabel,
 } from "pages/policies/helpers";
 import { getDisplayedSoftwareName } from "pages/SoftwarePage/helpers";
+import { isMacOS } from "interfaces/platform";
 import {
   EndUserExperience,
-  isMacPlatform,
   PatchOption,
 } from "pages/SoftwarePage/components/forms/SoftwareDeploySelector";
 
@@ -191,7 +191,7 @@ const PolicyAutomationsFields = forwardRef<
     // a legacy Windows policy carries `notify_before_patching: true`.
     // Uses the same helper as the wire boundary so multi-platform policy
     // strings (`"darwin,linux"`) are treated as Mac too.
-    const isMacPolicy = isMacPlatform(policy.platform);
+    const isMacPolicy = isMacOS(policy.platform);
     const notifyBeforePatching =
       patchOption !== undefined
         ? patchOption === "force" &&

--- a/frontend/pages/policies/components/PolicyAutomationsFields/PolicyAutomationsFields.tsx
+++ b/frontend/pages/policies/components/PolicyAutomationsFields/PolicyAutomationsFields.tsx
@@ -207,20 +207,22 @@ const PolicyAutomationsFields = forwardRef<
     // and "Notify before patching" — the backend forces it on for both, so an
     // editable checkbox would lie.
     const continuousLocked = patchWhenClosed || notifyBeforePatching;
-    let continuousLockedTooltip: string | undefined;
-    if (patchWhenClosed) {
-      continuousLockedTooltip =
-        "Continuous automation can't be disabled when Patch when app is closed is selected.";
-    } else if (notifyBeforePatching) {
-      continuousLockedTooltip =
-        "Continuous automation can't be disabled when Notify before patching is selected.";
-    }
-    let effectiveContinuousEnabled = continuousEnabled;
-    if (continuousLocked) {
-      effectiveContinuousEnabled = true;
-    } else if (patchOption === "manual") {
-      effectiveContinuousEnabled = false;
-    }
+    const getContinuousLockedTooltip = (): string | undefined => {
+      if (patchWhenClosed) {
+        return "Continuous automation can't be disabled when Patch when app is closed is selected.";
+      }
+      if (notifyBeforePatching) {
+        return "Continuous automation can't be disabled when Notify before patching is selected.";
+      }
+      return undefined;
+    };
+    const getEffectiveContinuousEnabled = (): boolean => {
+      if (continuousLocked) return true;
+      if (patchOption === "manual") return false;
+      return continuousEnabled;
+    };
+    const continuousLockedTooltip = getContinuousLockedTooltip();
+    const effectiveContinuousEnabled = getEffectiveContinuousEnabled();
 
     const [softwareTitleId, setSoftwareTitleId] = useState<number | null>(
       policy.install_software?.software_title_id ?? null
@@ -397,13 +399,12 @@ const PolicyAutomationsFields = forwardRef<
           return { isValid: false, isDirty: false };
         }
 
-        // `notifyBeforePatching !== initialNotifyBeforePatching` covers the
-        // legacy-Windows auto-heal on its own: the derived value flips to
-        // false for a non-Mac policy that stored `notify_before_patching:
-        // true`, so the payload writes the corrected value. The Mac gate on
-        // the state init (see `initialIsMacNotify`) is what keeps
-        // `effectiveContinuousEnabled` at its stored value in that same
-        // case, so continuous isn't silently downgraded alongside notify.
+        // Legacy-Windows auto-heal: a policy that shouldn't have stored
+        // `notify_before_patching: true` still gets the derived value
+        // flipped back to false, so this dirty check writes the correction
+        // on save. `initialIsMacNotify` (state init) is what keeps the
+        // stored `continuous_automations_enabled` from being downgraded
+        // alongside it.
         const perPolicyDirty =
           !isGlobalPolicy &&
           (effectiveInstallSoftware !== initialInstallSoftware ||

--- a/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tests.tsx
+++ b/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tests.tsx
@@ -945,6 +945,77 @@ describe("PolicyForm - component", () => {
         expect(onUpdate).toHaveBeenCalledTimes(1);
       });
 
+      it("shows Patch when app is closed (not Force + Notify) for a legacy policy with both flags set", () => {
+        // Invariant violation guard: if a policy somehow stored both
+        // patch_when_closed:true AND notify_before_patching:true, the radio
+        // must show Patch when app is closed and the dropdown must be
+        // hidden. Otherwise the notify state would leak the moment the
+        // user picked Force patch.
+        renderPatchPolicy(
+          <PolicyForm
+            {...patchPolicyProps}
+            storedPolicy={{
+              ...patchPolicy,
+              install_software: {
+                name: "Firefox",
+                software_title_id: 42,
+              },
+              patch_when_closed: true,
+              notify_before_patching: true,
+              continuous_automations_enabled: true,
+            }}
+          />
+        );
+
+        expect(
+          screen.getByRole("radio", { name: "Patch when app is closed" })
+        ).toBeChecked();
+        expect(
+          screen.queryByRole("combobox", { name: /End user experience/i })
+        ).not.toBeInTheDocument();
+      });
+
+      it("does not carry notify_before_patching for a Windows patch policy", async () => {
+        const updatePolicySpy = jest
+          .spyOn(teamPoliciesAPI, "update")
+          .mockResolvedValue({} as never);
+        const windowsPatchPolicy = {
+          ...patchPolicy,
+          team_id: 1,
+          platform: "windows" as const,
+          patch_when_closed: false,
+          notify_before_patching: false,
+          continuous_automations_enabled: false,
+        };
+        const onUpdate = jest.fn().mockResolvedValue({});
+        const { user } = renderPatchPolicy(
+          <PolicyForm
+            {...patchPolicyProps}
+            storedPolicy={windowsPatchPolicy}
+            onUpdate={onUpdate}
+          />
+        );
+
+        await user.click(screen.getByRole("radio", { name: "Force patch" }));
+        await user.click(screen.getByRole("button", { name: "Save" }));
+
+        await waitFor(() =>
+          expect(updatePolicySpy).toHaveBeenCalledWith(
+            windowsPatchPolicy.id,
+            expect.objectContaining({
+              notify_before_patching: false,
+              continuous_automations_enabled: false,
+            })
+          )
+        );
+        // Dropdown must never render for a Windows patch policy — the
+        // getPatchPolicyFlags gate is the last line of defense, but the UI
+        // shouldn't even offer the choice.
+        expect(
+          screen.queryByRole("combobox", { name: /End user experience/i })
+        ).not.toBeInTheDocument();
+      });
+
       it("selects End user initiated when both stored policy flags are false", () => {
         renderPatchPolicy(
           <PolicyForm

--- a/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tests.tsx
+++ b/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tests.tsx
@@ -1008,9 +1008,7 @@ describe("PolicyForm - component", () => {
             })
           )
         );
-        // Dropdown must never render for a Windows patch policy — the
-        // getPatchPolicyFlags gate is the last line of defense, but the UI
-        // shouldn't even offer the choice.
+        // Dropdown never renders for a Windows patch policy.
         expect(
           screen.queryByRole("combobox", { name: /End user experience/i })
         ).not.toBeInTheDocument();

--- a/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tests.tsx
+++ b/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tests.tsx
@@ -938,6 +938,7 @@ describe("PolicyForm - component", () => {
             team_id: 1,
             software_title_id: 42,
             patch_when_closed: false,
+            notify_before_patching: false,
             continuous_automations_enabled: false,
           })
         );

--- a/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tsx
@@ -161,7 +161,15 @@ const PolicyForm = ({
       nextPatchOption = "force";
     }
     setPatchOption(nextPatchOption);
-    setEndUserExperience(storedNotifyBeforePatching ? "notify" : "immediate");
+    // Only hydrate to "notify" when patch_when_closed is off — if a legacy
+    // policy has both flags set (server invariant violation), the radio
+    // shows Patch when app is closed and the dropdown is hidden; carrying
+    // "notify" in state would reveal it the moment the user picked Force.
+    setEndUserExperience(
+      storedNotifyBeforePatching && !storedPatchWhenClosed
+        ? "notify"
+        : "immediate"
+    );
   }, [
     isPatchPolicy,
     storedPatchPolicyId,

--- a/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tsx
@@ -452,7 +452,11 @@ const PolicyForm = ({
               patchOption === "manual"
                 ? null
                 : storedPolicy?.patch_software?.software_title_id ?? null,
-            ...getPatchPolicyFlags(patchOption, endUserExperience),
+            ...getPatchPolicyFlags(
+              patchOption,
+              endUserExperience,
+              storedPolicy?.platform
+            ),
           },
         };
       }

--- a/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tsx
@@ -59,6 +59,7 @@ import PolicyAutomationsFields, {
 } from "pages/policies/components/PolicyAutomationsFields";
 import { PatchAutomationCta } from "pages/policies/components";
 import {
+  EndUserExperience,
   getPatchPolicyFlags,
   PatchOption,
   PatchOptionSelector,
@@ -142,8 +143,12 @@ const PolicyForm = ({
   const isPatchPolicy = storedPolicy?.type === "patch";
   const [isAddingAutomation, setIsAddingAutomation] = useState(false);
   const [patchOption, setPatchOption] = useState<PatchOption>("manual");
+  const [endUserExperience, setEndUserExperience] = useState<EndUserExperience>(
+    "immediate"
+  );
   const storedPatchPolicyId = storedPolicy?.id;
   const storedPatchWhenClosed = storedPolicy?.patch_when_closed;
+  const storedNotifyBeforePatching = storedPolicy?.notify_before_patching;
   const storedInstallSoftwareId =
     storedPolicy?.install_software?.software_title_id;
 
@@ -156,10 +161,12 @@ const PolicyForm = ({
       nextPatchOption = "force";
     }
     setPatchOption(nextPatchOption);
+    setEndUserExperience(storedNotifyBeforePatching ? "notify" : "immediate");
   }, [
     isPatchPolicy,
     storedPatchPolicyId,
     storedPatchWhenClosed,
+    storedNotifyBeforePatching,
     storedInstallSoftwareId,
   ]);
 
@@ -445,7 +452,7 @@ const PolicyForm = ({
               patchOption === "manual"
                 ? null
                 : storedPolicy?.patch_software?.software_title_id ?? null,
-            ...getPatchPolicyFlags(patchOption),
+            ...getPatchPolicyFlags(patchOption, endUserExperience),
           },
         };
       }
@@ -711,6 +718,9 @@ const PolicyForm = ({
             <PatchOptionSelector
               patchOption={patchOption}
               onSelectPatchOption={setPatchOption}
+              platform={storedPolicy?.platform}
+              endUserExperience={endUserExperience}
+              onSelectEndUserExperience={setEndUserExperience}
               disabled={disableChildren}
             />
           )}
@@ -769,6 +779,9 @@ const PolicyForm = ({
                 fleetName={automationsFleetName}
                 patchOption={
                   isPremiumTier && isPatchPolicy ? patchOption : undefined
+                }
+                endUserExperience={
+                  isPremiumTier && isPatchPolicy ? endUserExperience : undefined
                 }
                 patchSlot={patchOptions}
               />

--- a/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/edit/components/PolicyForm/PolicyForm.tsx
@@ -161,15 +161,7 @@ const PolicyForm = ({
       nextPatchOption = "force";
     }
     setPatchOption(nextPatchOption);
-    // Only hydrate to "notify" when patch_when_closed is off — if a legacy
-    // policy has both flags set (server invariant violation), the radio
-    // shows Patch when app is closed and the dropdown is hidden; carrying
-    // "notify" in state would reveal it the moment the user picked Force.
-    setEndUserExperience(
-      storedNotifyBeforePatching && !storedPatchWhenClosed
-        ? "notify"
-        : "immediate"
-    );
+    setEndUserExperience(storedNotifyBeforePatching ? "notify" : "immediate");
   }, [
     isPatchPolicy,
     storedPatchPolicyId,
@@ -460,11 +452,7 @@ const PolicyForm = ({
               patchOption === "manual"
                 ? null
                 : storedPolicy?.patch_software?.software_title_id ?? null,
-            ...getPatchPolicyFlags(
-              patchOption,
-              endUserExperience,
-              storedPolicy?.platform
-            ),
+            ...getPatchPolicyFlags(patchOption, endUserExperience),
           },
         };
       }

--- a/frontend/pages/policies/hooks/useUpdatePolicyAutomations.ts
+++ b/frontend/pages/policies/hooks/useUpdatePolicyAutomations.ts
@@ -19,6 +19,7 @@ export type IPolicyAutomationUpdate = Pick<
   | "conditional_access_enabled"
   | "continuous_automations_enabled"
   | "patch_when_closed"
+  | "notify_before_patching"
 >;
 
 export interface IUpdatePolicyAutomationsVars {

--- a/frontend/services/entities/team_policies.ts
+++ b/frontend/services/entities/team_policies.ts
@@ -90,6 +90,7 @@ export default {
       patch_software_title_id,
       continuous_automations_enabled,
       patch_when_closed,
+      notify_before_patching,
     } = data;
     const { TEAMS } = endpoints;
     const path = `${TEAMS}/${team_id}/policies`;
@@ -110,6 +111,7 @@ export default {
       patch_software_title_id,
       continuous_automations_enabled,
       patch_when_closed,
+      notify_before_patching,
     });
   },
   // TODO - response type Promise<IPolicy>
@@ -127,6 +129,7 @@ export default {
       conditional_access_enabled,
       continuous_automations_enabled,
       patch_when_closed,
+      notify_before_patching,
       software_title_id,
       software_installer_id,
       script_id,
@@ -149,6 +152,7 @@ export default {
       conditional_access_enabled,
       continuous_automations_enabled,
       patch_when_closed,
+      notify_before_patching,
       software_title_id,
       software_installer_id,
       script_id,


### PR DESCRIPTION
## Issue
Closes #50914

## Description
- Shared `SoftwareDeploySelector` now surfaces an **End user experience** dropdown under **Force patch** for macOS apps only. Windows apps keep the existing coming-soon banner and no dropdown.
- Two banner variants: **Patch immediately** and **Notify before patching** (**1 hour** bold, Fleet Desktop required). Both link to the End user experience page in a new tab.
- `getPatchPolicyFlags(patchOption, endUserExperience, platform)` is the single derivation site. `notify_before_patching` is gated on `isMacOS(platform)` at the wire boundary — the flag can never slip through for Windows, even if state or hydration ever carries "notify" on a non-Mac policy.
- `notify_before_patching?: boolean` added to `IPolicy`, `IPolicyFormData`, `ISoftwarePatchPolicy`, `IPolicyAutomationUpdate`, and `teamPoliciesAPI` payloads.
- Consumers wired (6 files): `FleetAppDetailsForm`, `FleetMaintainedAppDetailsPage`, `DeployModal`, `EditSoftwareModal`, `PolicyForm`, `PolicyAutomationsFields`. `PolicyAutomationsFields` also gates its local `notifyBeforePatching` derivation on `isMacOS(policy.platform)` so the continuous-automations lock stays in sync.
- Pre-install query lock (`patchWhenClosed` prop) extended to fire for **either** `patch_when_closed` **or** `notify_before_patching` in both `EditSoftwareModal` and `FleetAppDetailsForm`, Mac-gated to mirror the wire boundary.
- Continuous automations locked ON for both flags with matching per-flag tooltips (`isContinuousAutomationsRequired`).
- `isMacOS` / `isWindows` in `interfaces/platform.ts` widened to accept `CommaSeparatedPlatformString` alongside single-value host platforms, so patch policies and hosts share one canonical predicate. New `platform.tests.ts` locks in both shapes.
- `getInstallablePlatform(source)` helper in `interfaces/software.ts` centralizes the source → platform lookup used by DeployModal and EditSoftwareModal.

## Screenrecording


https://github.com/user-attachments/assets/a168f384-0c34-4825-8362-4c35a5939a11



## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

`yarn test` — 729/729 passing across the software + policies suites; `tsc --noEmit` clean; `eslint` clean. Coverage extended per /review-pr passes:
- `SoftwareDeploySelector`: platform-gated `getPatchPolicyFlags` (darwin, windows, undefined); three banner variants; dropdown-gating rule.
- `DeployModal`: notify-wire create + update integration tests.
- `PolicyAutomationsFields`: notify-lock payload, notify tooltip switch, Windows-gate (state=notify → wire stays clean), legacy-Windows auto-heal without downgrading continuous.
- `PolicyForm`: legacy both-flags-set hydration (shows Patch-when-closed, dropdown hidden), Windows patch policy wire path.
- `FleetAppDetailsForm`: notify FMA submit, Windows FMA no-dropdown, pre-install lock on both platforms.
- `interfaces/platform`: `isMacOS` / `isWindows` across single-value and comma-joined shapes.

## Notes
- Targets the `39178-notify-before-patching` feature branch. BE work in #50911 and #50912 lands on the feature branch in parallel.
- Feature branch merges to `main` PR-by-PR later, per plan, to preserve CODEOWNERS attribution.
