### PR TITLE
Website: update marketing attribution in update-or-create-contact-and-account helper

### DIFF
--- a/website/api/helpers/salesforce/update-or-create-contact-and-account.js
+++ b/website/api/helpers/salesforce/update-or-create-contact-and-account.js
@@ -235,164 +235,146 @@ module.exports = {
 
     if(marketingAttributionCookie) {
       // Note: this section is commented out while we make changes to the Salesforce picklist values
-      // attributionDetails = {};
-      // // Determine if this user is "Digital" or "Organic"
-      // let lowerCaseMediumValue = marketingAttributionCookie.medium ? marketingAttributionCookie.medium.toLowerCase() : '';
-      // let sourceFriendlyNameByCodeName = {
-      //   // "Organic" sources:
-      //   // os: 'Organic search',
-      //   // dt: 'Direct traffic',
-      //   // wr: 'Web referral',
-      //   // soc: 'Organic social',
-      //   // "Digital" sources:
-      //   cpc: 'Paid search (PS)', //note: either cpc or ps both map to Paid Search
-      //   ps: 'Paid search (PS)',
-      //   so: 'Paid social (SO)',
-      //   pm: 'Paid media (PM)',
-      //   cs: 'Content syndication (CS)',
-      //   em: 'Email marketing (EM)',
-      //   // "Event" sources:
-      //   mc: 'Major conference (MC)',
-      //   rc: 'Regional conference (RC)',
-      //   le: 'Local event/meetup (LE)',
-      //   ec: 'Executive community (EC)',
-      //   fe: 'Field/sales event (FE)',
-      //   pe: 'Partner event (PE)',
-      //   se: 'Speaking engagement (SE)',
-      //   wh: 'Webinar hosted (WH)',
-      //   ws: 'Webinar sponsored (WS)',
-      // };
+      attributionDetails = {};
+      // Determine if this user is "Digital" or "Organic"
+      let lowerCaseMediumValue = marketingAttributionCookie.medium ? marketingAttributionCookie.medium.toLowerCase() : '';
+      let sourceFriendlyNameByCodeName = {
+        // "Organic" sources:
+        // os: 'Organic search',
+        // dt: 'Direct traffic',
+        // wr: 'Web referral',
+        // soc: 'Organic social',
+        // "Digital" sources:
+        cpc: 'Paid search (PAYSRC)', //note: either cpc or ps both map to Paid Search
+        ps: 'Paid search (PAYSRC)',
+        so: 'Paid social (PAYSOC)',
+        pm: 'Paid media (PAYMED)',
+        cs: 'Content syndication (CONSYD)',
+        em: 'Email marketing (EMLMRK)',
+        // "Event" sources:
+        mc: 'Conference (CONF)',
+        rc: 'Conference (CONF)',
+        pe: 'Partner event (PTREVT)',
+        wh: 'Webinar (WBINR)',
+      };
 
-      // attributionDetails.gclid = marketingAttributionCookie.gclid;
+      attributionDetails.gclid = marketingAttributionCookie.gclid;
 
-      // attributionDetails.sourceChannelDetails = sourceFriendlyNameByCodeName[lowerCaseMediumValue] ? sourceFriendlyNameByCodeName[lowerCaseMediumValue] : undefined;
+      attributionDetails.sourceChannelDetails = sourceFriendlyNameByCodeName[lowerCaseMediumValue] ? sourceFriendlyNameByCodeName[lowerCaseMediumValue] : undefined;
 
-      // attributionDetails.initialUrl = marketingAttributionCookie.initialUrl;
+      attributionDetails.initialUrl = marketingAttributionCookie.initialUrl;
 
-      // attributionDetails.referrer = marketingAttributionCookie.referrer;
+      attributionDetails.referrer = marketingAttributionCookie.referrer;
 
-      // if(['cpc','ps', 'so', 'pm', 'cs', 'em'].includes(lowerCaseMediumValue)) {
-      //   // If the medium is set to a "Digital" source, we'll set the (most recent/source) campaign to the utm_campaign value the user visited the website with.
-      //   attributionDetails.campaign = marketingAttributionCookie.campaign;
-      //   attributionDetails.sourceChannel = 'Digital';
-      // } else if(['mc', 'rc', 'le', 'ec', 'fe', 'pe', 'se', 'wh', 'ws'].includes(lowerCaseMediumValue)) {
-      //   // If the medium is set to an "Event" source, we'll set the (most recent/source) campaign to the utm_campaign value the user visited the website with.
-      //   attributionDetails.campaign = marketingAttributionCookie.campaign;
-      //   attributionDetails.sourceChannel = 'Event';
-      // } else {
-      //   // If no medium was provided via utm parameter, set the source channel to "Organic".
-      //   attributionDetails.sourceChannel = 'Organic';
+      if(['cpc','ps', 'so', 'pm', 'cs', 'em'].includes(lowerCaseMediumValue)) {
+        // If the medium is set to a "Digital" source, we'll set the (most recent/source) campaign to the utm_campaign value the user visited the website with.
+        attributionDetails.campaign = marketingAttributionCookie.campaign;
+        attributionDetails.sourceChannel = 'Digital';
+      } else if(['mc', 'rc', 'le', 'ec', 'fe', 'pe', 'se', 'wh', 'ws'].includes(lowerCaseMediumValue)) {
+        // If the medium is set to an "Event" source, we'll set the (most recent/source) campaign to the utm_campaign value the user visited the website with.
+        attributionDetails.campaign = marketingAttributionCookie.campaign;
+        attributionDetails.sourceChannel = 'Event';
+      } else {
+        // If no medium was provided via utm parameter, set the source channel to "Organic".
+        attributionDetails.sourceChannel = 'Organic';
 
-      //   if(!marketingAttributionCookie.referrer || marketingAttributionCookie.referrer === 'https://fleetdm.com/') {
-      //     // If no referrer is set, or the referrer is set to the Fleet website, we'll assume this user came to the website directly
-      //     attributionDetails.sourceChannelDetails = 'Direct traffic (DT)';
-      //     attributionDetails.campaign = 'Default-DT-Direct';
-      //   } else {
-      //     // Otherwise, we'll check the referer value and attempt to categorize the referer.
-      //     let REFERRER_DOMAINS_FOR_ORGANIC_SEARCH = [
-      //       'https://www.google.',      // covers all ~190 country variants (google.com, google.co.uk, google.de, etc.)
-      //       'https://www.bing.com/search',
-      //       'https://search.yahoo.com/',
-      //       'https://duckduckgo.com/',
-      //       'https://www.baidu.com/',
-      //       'https://www.ecosia.org/',
-      //       'https://www.startpage.com/',
-      //       'https://search.brave.com/',
-      //       'https://kagi.com/',
-      //       'https://www.ask.com/',
-      //       'https://www.aol.com/',
-      //       'https://yandex.com/',
-      //       'https://yandex.ru/',
-      //     ];
+        if(!marketingAttributionCookie.referrer || marketingAttributionCookie.referrer === 'https://fleetdm.com/') {
+          // If no referrer is set, or the referrer is set to the Fleet website, we'll assume this user came to the website directly
+          attributionDetails.sourceChannelDetails = 'Direct traffic (DIRTRF)';
+        } else {
+          // Otherwise, we'll check the referer value and attempt to categorize the referer.
+          let REFERRER_DOMAINS_FOR_ORGANIC_SEARCH = [
+            'https://www.google.',      // covers all ~190 country variants (google.com, google.co.uk, google.de, etc.)
+            'https://www.bing.com/search',
+            'https://search.yahoo.com/',
+            'https://duckduckgo.com/',
+            'https://www.baidu.com/',
+            'https://www.ecosia.org/',
+            'https://www.startpage.com/',
+            'https://search.brave.com/',
+            'https://kagi.com/',
+            'https://www.ask.com/',
+            'https://www.aol.com/',
+            'https://yandex.com/',
+            'https://yandex.ru/',
+          ];
 
-      //     let REFERRER_DOMAINS_FOR_ORGANIC_SOCIAL = [
-      //       'https://www.linkedin.com/',
-      //       'https://linkedin.com/',
-      //       'https://lnkd.in/',
-      //       'https://www.reddit.com/',
-      //       'https://old.reddit.com/',
-      //       'https://news.ycombinator.com/',
-      //       'https://x.com/',
-      //       'https://twitter.com/',
-      //       'https://www.twitter.com/',
-      //       'https://t.co/',
-      //       'https://www.facebook.com/',
-      //       'https://l.facebook.com/',
-      //       'https://m.facebook.com/',
-      //       'https://www.instagram.com/',
-      //       'https://www.threads.net/',
-      //       'https://bsky.app/',
-      //       'https://mastodon.social/',
-      //       'https://fosstodon.org/',
-      //       'https://www.youtube.com/',
-      //       'https://www.pinterest.com/',
-      //       'https://www.quora.com/',
-      //     ];
+          let REFERRER_DOMAINS_FOR_ORGANIC_SOCIAL = [
+            'https://www.linkedin.com/',
+            'https://linkedin.com/',
+            'https://lnkd.in/',
+            'https://www.reddit.com/',
+            'https://old.reddit.com/',
+            'https://news.ycombinator.com/',
+            'https://x.com/',
+            'https://twitter.com/',
+            'https://www.twitter.com/',
+            'https://t.co/',
+            'https://www.facebook.com/',
+            'https://l.facebook.com/',
+            'https://m.facebook.com/',
+            'https://www.instagram.com/',
+            'https://www.threads.net/',
+            'https://bsky.app/',
+            'https://mastodon.social/',
+            'https://fosstodon.org/',
+            'https://www.youtube.com/',
+            'https://www.pinterest.com/',
+            'https://www.quora.com/',
+          ];
 
-      //     let REFERRER_DOMAINS_FOR_ORGANIC_AI = [
-      //       // === MAJOR GLOBAL AI CHATBOTS ===
-      //       'https://chat.openai.com/',
-      //       'https://chatgpt.com/',
-      //       'https://claude.ai/',
-      //       'https://claude.com/',
-      //       'https://gemini.google.com/',
-      //       'https://bard.google.com/',
-      //       'https://copilot.microsoft.com/',
-      //       'https://copilot.cloud.microsoft/',
-      //       'https://www.bing.com/chat',
-      //       // === QWEN / ALIBABA ECOSYSTEM ===
-      //       'https://chat.qwen.ai/',
-      //       'https://chat.qwenlm.ai/',
-      //       'https://qwen.ai/',
-      //       // === AI SEARCH ENGINES ===
-      //       'https://www.perplexity.ai/',
-      //       'https://perplexity.ai/',
-      //       // === META / X / SOCIAL AI ===
-      //       'https://www.meta.ai/',
-      //       'https://ai.meta.com/',
-      //       'https://grok.com/',
-      //       'https://grok.x.ai/',
-      //       'https://x.ai/',
-      //       // === AGGREGATORS & MULTI-MODEL PLATFORMS ===
-      //       'https://poe.com/',
-      //       'https://www.poe.com/',
-      //       'https://huggingface.co/chat/',
-      //       'https://together.ai/',
-      //       'https://platform.mistral.ai/chat',
-      //     ];
+          let REFERRER_DOMAINS_FOR_ORGANIC_AI = [
+            // === MAJOR GLOBAL AI CHATBOTS ===
+            'https://chat.openai.com/',
+            'https://chatgpt.com/',
+            'https://claude.ai/',
+            'https://claude.com/',
+            'https://gemini.google.com/',
+            'https://bard.google.com/',
+            'https://copilot.microsoft.com/',
+            'https://copilot.cloud.microsoft/',
+            'https://www.bing.com/chat',
+            // === QWEN / ALIBABA ECOSYSTEM ===
+            'https://chat.qwen.ai/',
+            'https://chat.qwenlm.ai/',
+            'https://qwen.ai/',
+            // === AI SEARCH ENGINES ===
+            'https://www.perplexity.ai/',
+            'https://perplexity.ai/',
+            // === META / X / SOCIAL AI ===
+            'https://www.meta.ai/',
+            'https://ai.meta.com/',
+            'https://grok.com/',
+            'https://grok.x.ai/',
+            'https://x.ai/',
+            // === AGGREGATORS & MULTI-MODEL PLATFORMS ===
+            'https://poe.com/',
+            'https://www.poe.com/',
+            'https://huggingface.co/chat/',
+            'https://together.ai/',
+            'https://platform.mistral.ai/chat',
+          ];
 
-      //     let referrer = typeof marketingAttributionCookie.referrer === 'string'
-      //       ? marketingAttributionCookie.referrer
-      //       : '';
+          let referrer = typeof marketingAttributionCookie.referrer === 'string'
+            ? marketingAttributionCookie.referrer
+            : '';
 
-      //     if(REFERRER_DOMAINS_FOR_ORGANIC_SEARCH.some((domain) => referrer.startsWith(domain))) {
-      //       // If search engine » Organic search
-      //       attributionDetails.sourceChannelDetails = 'Organic search (OS)';
-      //       attributionDetails.campaign = 'Default-OS-Organic';
-      //     } else if(REFERRER_DOMAINS_FOR_ORGANIC_SOCIAL.some((domain) => referrer.startsWith(domain))) {
-      //       // If social media » Organic social
-      //       attributionDetails.sourceChannelDetails = 'Organic social (SOC)';
-      //       attributionDetails.campaign = 'Default-SOC-Social';
-      //     } else if(REFERRER_DOMAINS_FOR_ORGANIC_AI.some((domain) => referrer.startsWith(domain))) {
-      //       // If AI/LLM » Organic AI
-      //       attributionDetails.sourceChannelDetails = 'Organic AI (AI)';
-      //       // Determine specific campaign based on which AI platform referred the visitor
-      //       if(['https://chat.openai.com/', 'https://chatgpt.com/'].some((domain) => referrer.startsWith(domain))) {
-      //         attributionDetails.campaign = 'Default-AI-ChatGPT';
-      //       } else if(['https://claude.ai/', 'https://claude.com/'].some((domain) => referrer.startsWith(domain))) {
-      //         attributionDetails.campaign = 'Default-AI-Claude';
-      //       } else if(['https://gemini.google.com/', 'https://bard.google.com/'].some((domain) => referrer.startsWith(domain))) {
-      //         attributionDetails.campaign = 'Default-AI-Gemini';
-      //       } else {
-      //         attributionDetails.campaign = 'Default-AI-Other';
-      //       }
-      //     } else {
-      //       // If not either of those » Web referral
-      //       attributionDetails.sourceChannelDetails = 'Web referral (WR)';
-      //       attributionDetails.campaign = 'Default-WR-Referral';
-      //     }
-      //   }
-      // }
+          if(REFERRER_DOMAINS_FOR_ORGANIC_SEARCH.some((domain) => referrer.startsWith(domain))) {
+            // If search engine » Organic search
+            attributionDetails.sourceChannelDetails = 'Search (ORGSRC)';
+          } else if(REFERRER_DOMAINS_FOR_ORGANIC_SOCIAL.some((domain) => referrer.startsWith(domain))) {
+            // If social media » Organic social
+            attributionDetails.sourceChannelDetails = 'Social (ORGSOC)';
+          } else if(REFERRER_DOMAINS_FOR_ORGANIC_AI.some((domain) => referrer.startsWith(domain))) {
+            // If AI/LLM » Organic AI
+            attributionDetails.sourceChannelDetails = 'AI (ORGAI)';
+          } else {
+            // If not either of those » Web referral
+            attributionDetails.sourceChannelDetails = 'Web referral (WEBREF)';
+          }
+        }
+        attributionDetails.campaign = `${attributionDetails.campaign} - ${attributionDetails.sourceChannelDetails}`;
+      }
     }
 
     //  ╦  ╔═╗╔═╗╦╔═  ╔═╗╔═╗╦═╗  ╔═╗═╗ ╦╦╔═╗╔╦╗╦╔╗╔╔═╗  ╔═╗╔═╗╔╗╔╔╦╗╔═╗╔═╗╔╦╗

--- a/website/api/helpers/salesforce/update-or-create-contact-and-account.js
+++ b/website/api/helpers/salesforce/update-or-create-contact-and-account.js
@@ -240,10 +240,11 @@ module.exports = {
       let lowerCaseMediumValue = marketingAttributionCookie.medium ? marketingAttributionCookie.medium.toLowerCase() : '';
       let sourceFriendlyNameByCodeName = {
         // "Organic" sources:
-        // os: 'Organic search',
-        // dt: 'Direct traffic',
-        // wr: 'Web referral',
-        // soc: 'Organic social',
+        // os: 'Search (ORGSRC)',
+        // dt: 'Direct traffic (DIRTRF)',
+        // wr: 'Web referral (WEBREF)',
+        // soc: 'Social (ORGSOC)',
+        // ai: '  AI (ORGAI)'
         // "Digital" sources:
         cpc: 'Paid search (PAYSRC)', //note: either cpc or ps both map to Paid Search
         ps: 'Paid search (PAYSRC)',
@@ -373,7 +374,8 @@ module.exports = {
             attributionDetails.sourceChannelDetails = 'Web referral (WEBREF)';
           }
         }
-        attributionDetails.campaign = `${attributionDetails.campaign} - ${attributionDetails.sourceChannelDetails}`;
+        // Build the campaign value using the sourceChannel and sourceChannelDetails values
+        attributionDetails.campaign = `${attributionDetails.sourceChannel} - ${attributionDetails.sourceChannelDetails}`;
       }
     }
 

--- a/website/api/helpers/salesforce/update-or-create-contact-and-account.js
+++ b/website/api/helpers/salesforce/update-or-create-contact-and-account.js
@@ -234,7 +234,6 @@ module.exports = {
     let attributionDetails = undefined;// We'll do a simple falsy check of this value when we determine what variables we'll need to set (e.g., Source channel or Most recent channel)
 
     if(marketingAttributionCookie) {
-      // Note: this section is commented out while we make changes to the Salesforce picklist values
       attributionDetails = {};
       // Determine if this user is "Digital" or "Organic"
       let lowerCaseMediumValue = marketingAttributionCookie.medium ? marketingAttributionCookie.medium.toLowerCase() : '';


### PR DESCRIPTION
Changes:
- Uncommented the marketing attribution section of the update-or-create-contact-and-account helper and updated the values it sends to Salesforce.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Marketing attribution is now captured when an attribution cookie is present.
  * Traffic sources are categorized across campaign, digital, event, direct, search, social, AI, and web referral channels.
  * Campaign details now use updated Salesforce source naming and more specific organic traffic classifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->