### PR TITLE
Website: collect metrics for android management requests per enterprise ID.

### DIFF
--- a/website/api/controllers/android-proxy/create-android-enrollment-token.js
+++ b/website/api/controllers/android-proxy/create-android-enrollment-token.js
@@ -60,6 +60,7 @@ module.exports = {
       let androidManagementConnection = google.androidmanagement({version: 'v1', auth: androidManagementAuthClient});
       // [?]: https://googleapis.dev/nodejs/googleapis/latest/androidmanagement/classes/Resource$Enterprises$Enrollmenttokens.html#create
       sails.androidProxyApiRequestCount++;// Count this Android Management API request toward the per-minute total logged in api/hooks/custom/index.js.
+      sails.androidProxyApiRequestCountByEnterpriseId[androidEnterpriseId] = (sails.androidProxyApiRequestCountByEnterpriseId[androidEnterpriseId] || 0) + 1;// Count this request for the per-enterprise-per-minute total logged in api/hooks/custom/index.js.
       let enrollmentTokenCreateResponse = await androidManagementConnection.enterprises.enrollmentTokens.create({
         parent: `enterprises/${androidEnterpriseId}`,
         // Note: Typically, we use defined inputs instead of accessing req.body directly. This behavior should not be repeated in future Android proxy endpoints.

--- a/website/api/controllers/android-proxy/create-enterprise-webapp.js
+++ b/website/api/controllers/android-proxy/create-enterprise-webapp.js
@@ -78,6 +78,7 @@ module.exports = {
       let androidManagementConnection = google.androidmanagement({version: 'v1', auth: androidManagementAuthClient});
       // [?]: https://googleapis.dev/nodejs/googleapis/latest/androidmanagement/classes/Resource$Enterprises$Webapps.html#create
       sails.androidProxyApiRequestCount++;// Count this Android Management API request toward the per-minute total logged in api/hooks/custom/index.js.
+      sails.androidProxyApiRequestCountByEnterpriseId[androidEnterpriseId] = (sails.androidProxyApiRequestCountByEnterpriseId[androidEnterpriseId] || 0) + 1;// Count this request for the per-enterprise-per-minute total logged in api/hooks/custom/index.js.
       let createWebAppResponse = await androidManagementConnection.enterprises.webApps.create({
         parent: `enterprises/${androidEnterpriseId}`,
         requestBody: {

--- a/website/api/controllers/android-proxy/delete-android-device.js
+++ b/website/api/controllers/android-proxy/delete-android-device.js
@@ -68,6 +68,7 @@ module.exports = {
       let androidManagementConnection = google.androidmanagement({version: 'v1', auth: androidManagementAuthClient});
       // [?]: https://googleapis.dev/nodejs/googleapis/latest/androidmanagement/classes/Resource$Enterprises$Devices.html#delete
       sails.androidProxyApiRequestCount++;// Count this Android Management API request toward the per-minute total logged in api/hooks/custom/index.js.
+      sails.androidProxyApiRequestCountByEnterpriseId[androidEnterpriseId] = (sails.androidProxyApiRequestCountByEnterpriseId[androidEnterpriseId] || 0) + 1;// Count this request for the per-enterprise-per-minute total logged in api/hooks/custom/index.js.
       await androidManagementConnection.enterprises.devices.delete({
         name: `enterprises/${androidEnterpriseId}/devices/${deviceId}`,
       });

--- a/website/api/controllers/android-proxy/get-android-device-operation.js
+++ b/website/api/controllers/android-proxy/get-android-device-operation.js
@@ -78,6 +78,8 @@ module.exports = {
       let { google } = require('googleapis');
       let androidManagementConnection = google.androidmanagement({version: 'v1', auth: androidManagementAuthClient});
       // [?]: https://googleapis.dev/nodejs/googleapis/latest/androidmanagement/classes/Resource$Enterprises$Devices$Operations.html#get
+      sails.androidProxyApiRequestCount++;// Count this Android Management API request toward the per-minute total logged in api/hooks/custom/index.js.
+      sails.androidProxyApiRequestCountByEnterpriseId[androidEnterpriseId] = (sails.androidProxyApiRequestCountByEnterpriseId[androidEnterpriseId] || 0) + 1;// Count this request for the per-enterprise-per-minute total logged in api/hooks/custom/index.js.
       let getOperationResult = await androidManagementConnection.enterprises.devices.operations.get({
         name: `enterprises/${androidEnterpriseId}/devices/${deviceId}/operations/${operationId}`,
       });

--- a/website/api/controllers/android-proxy/get-android-device.js
+++ b/website/api/controllers/android-proxy/get-android-device.js
@@ -68,6 +68,7 @@ module.exports = {
       let androidManagementConnection = google.androidmanagement({version: 'v1', auth: androidManagementAuthClient});
       // [?]: https://googleapis.dev/nodejs/googleapis/latest/androidmanagement/classes/Resource$Enterprises$Devices.html#get
       sails.androidProxyApiRequestCount++;// Count this Android Management API request toward the per-minute total logged in api/hooks/custom/index.js.
+      sails.androidProxyApiRequestCountByEnterpriseId[androidEnterpriseId] = (sails.androidProxyApiRequestCountByEnterpriseId[androidEnterpriseId] || 0) + 1;// Count this request for the per-enterprise-per-minute total logged in api/hooks/custom/index.js.
       let getDeviceResult = await androidManagementConnection.enterprises.devices.get({
         name: `enterprises/${androidEnterpriseId}/devices/${deviceId}`,
       });

--- a/website/api/controllers/android-proxy/get-android-devices.js
+++ b/website/api/controllers/android-proxy/get-android-devices.js
@@ -75,6 +75,7 @@ module.exports = {
 
       // Get the Android devices list from Google
       sails.androidProxyApiRequestCount++;// Count this Android Management API request toward the per-minute total logged in api/hooks/custom/index.js.
+      sails.androidProxyApiRequestCountByEnterpriseId[androidEnterpriseId] = (sails.androidProxyApiRequestCountByEnterpriseId[androidEnterpriseId] || 0) + 1;// Count this request for the per-enterprise-per-minute total logged in api/hooks/custom/index.js.
       let devicesResponse = await androidManagementConnection.enterprises.devices.list({
         parent: `enterprises/${thisAndroidEnterprise.androidEnterpriseId}`,
         pageSize: pageSize,

--- a/website/api/controllers/android-proxy/get-android-enterprises.js
+++ b/website/api/controllers/android-proxy/get-android-enterprises.js
@@ -65,6 +65,7 @@ module.exports = {
         let tokenForNextPageOfEnterprises;
         await sails.helpers.flow.until(async ()=>{
           sails.androidProxyApiRequestCount++;// Count this Android Management API request toward the per-minute total logged in api/hooks/custom/index.js.
+          sails.androidProxyApiRequestCountByEnterpriseId[thisAndroidEnterprise.androidEnterpriseId] = (sails.androidProxyApiRequestCountByEnterpriseId[thisAndroidEnterprise.androidEnterpriseId] || 0) + 1;// Count this request for the per-enterprise-per-minute total logged in api/hooks/custom/index.js.
           let listEnterprisesResponse = await androidManagementConnection.enterprises.list({
             projectId: sails.config.custom.androidEnterpriseProjectId,
             pageSize: 100,

--- a/website/api/controllers/android-proxy/get-enterprise-applications.js
+++ b/website/api/controllers/android-proxy/get-enterprise-applications.js
@@ -66,6 +66,7 @@ module.exports = {
       let androidManagementConnection = google.androidmanagement({version: 'v1', auth: androidManagementAuthClient});
       // [?]: https://googleapis.dev/nodejs/googleapis/latest/androidmanagement/classes/Resource$Enterprises$Applications.html#get
       sails.androidProxyApiRequestCount++;// Count this Android Management API request toward the per-minute total logged in api/hooks/custom/index.js.
+      sails.androidProxyApiRequestCountByEnterpriseId[androidEnterpriseId] = (sails.androidProxyApiRequestCountByEnterpriseId[androidEnterpriseId] || 0) + 1;// Count this request for the per-enterprise-per-minute total logged in api/hooks/custom/index.js.
       let getApplicationsResult = await androidManagementConnection.enterprises.applications.get({
         name: `enterprises/${androidEnterpriseId}/applications/${applicationId}`,
       });

--- a/website/api/controllers/android-proxy/issue-command-on-android-device.js
+++ b/website/api/controllers/android-proxy/issue-command-on-android-device.js
@@ -165,6 +165,7 @@ module.exports = {
       let androidManagementConnection = google.androidmanagement({version: 'v1', auth: androidManagementAuthClient});
       // [?]: https://googleapis.dev/nodejs/googleapis/latest/androidmanagement/classes/Resource$Enterprises$Devices.html#issueCommand
       sails.androidProxyApiRequestCount++;// Count this Android Management API request toward the per-minute total logged in api/hooks/custom/index.js.
+      sails.androidProxyApiRequestCountByEnterpriseId[androidEnterpriseId] = (sails.androidProxyApiRequestCountByEnterpriseId[androidEnterpriseId] || 0) + 1;// Count this request for the per-enterprise-per-minute total logged in api/hooks/custom/index.js.
       let response = await androidManagementConnection.enterprises.devices.issueCommand({
         name: `enterprises/${androidEnterpriseId}/devices/${deviceId}`,
         requestBody: commandBody,

--- a/website/api/controllers/android-proxy/modify-android-device.js
+++ b/website/api/controllers/android-proxy/modify-android-device.js
@@ -70,6 +70,7 @@ module.exports = {
       let androidManagementConnection = google.androidmanagement({version: 'v1', auth: androidManagementAuthClient});
       // [?]: https://googleapis.dev/nodejs/googleapis/latest/androidmanagement/classes/Resource$Enterprises$Devices.html#patch
       sails.androidProxyApiRequestCount++;// Count this Android Management API request toward the per-minute total logged in api/hooks/custom/index.js.
+      sails.androidProxyApiRequestCountByEnterpriseId[androidEnterpriseId] = (sails.androidProxyApiRequestCountByEnterpriseId[androidEnterpriseId] || 0) + 1;// Count this request for the per-enterprise-per-minute total logged in api/hooks/custom/index.js.
       let patchDeviceResponse = await androidManagementConnection.enterprises.devices.patch({
         name: `enterprises/${androidEnterpriseId}/devices/${deviceId}`,
         // Note: Typically, we use defined inputs instead of accessing req.body directly. We forward req.body here to prevent previously set values from being overwritten by undefined values.

--- a/website/api/controllers/android-proxy/modify-android-policies.js
+++ b/website/api/controllers/android-proxy/modify-android-policies.js
@@ -68,6 +68,7 @@ module.exports = {
       let androidManagementConnection = google.androidmanagement({version: 'v1', auth: androidManagementAuthClient});
       // [?]: https://googleapis.dev/nodejs/googleapis/latest/androidmanagement/classes/Resource$Enterprises$Policies.html#patch
       sails.androidProxyApiRequestCount++;// Count this Android Management API request toward the per-minute total logged in api/hooks/custom/index.js.
+      sails.androidProxyApiRequestCountByEnterpriseId[androidEnterpriseId] = (sails.androidProxyApiRequestCountByEnterpriseId[androidEnterpriseId] || 0) + 1;// Count this request for the per-enterprise-per-minute total logged in api/hooks/custom/index.js.
       let patchPoliciesResponse = await androidManagementConnection.enterprises.policies.patch({
         name: `enterprises/${androidEnterpriseId}/policies/${policyId}`,
         // Note: Typically, we use defined inputs instead of accessing req.body directly. We forward req.body here to prevent previously set values from being overwritten by undefined values.

--- a/website/api/controllers/android-proxy/modify-enterprise-app-policy.js
+++ b/website/api/controllers/android-proxy/modify-enterprise-app-policy.js
@@ -80,6 +80,7 @@ module.exports = {
       let androidManagementConnection = google.androidmanagement({version: 'v1', auth: androidManagementAuthClient});
 
       sails.androidProxyApiRequestCount++;// Count this Android Management API request toward the per-minute total logged in api/hooks/custom/index.js.
+      sails.androidProxyApiRequestCountByEnterpriseId[androidEnterpriseId] = (sails.androidProxyApiRequestCountByEnterpriseId[androidEnterpriseId] || 0) + 1;// Count this request for the per-enterprise-per-minute total logged in api/hooks/custom/index.js.
       switch (googleAction) {
         case 'removePolicyApplications': {
           let response = await androidManagementConnection.enterprises.policies.removePolicyApplications({

--- a/website/api/hooks/custom/index.js
+++ b/website/api/hooks/custom/index.js
@@ -173,7 +173,7 @@ will be disabled and/or hidden in the UI.
               metric: 'android_proxy.amapi_request_count_by_enterprise',
               type: 1,
               interval: 60,
-              points: [{ timestamp: timestampInSeconds, value: perEnterpriseMetrics[enterpriseId] }],
+              points: [{ timestamp: timestampInSeconds, value: requestCountByEnterpriseId[enterpriseId] }],
               tags: [`dyno:${thisDyno}`, `android_enterprise_id:${enterpriseId}`],
             }));
             metricsToSendToDatadog = metricsToSendToDatadog.concat(perEnterpriseMetrics);

--- a/website/api/hooks/custom/index.js
+++ b/website/api/hooks/custom/index.js
@@ -173,15 +173,15 @@ will be disabled and/or hidden in the UI.
               metric: 'android_proxy.amapi_request_count_by_enterprise',
               type: 1,
               interval: 60,
-              points: [{ timestamp: timestampInSeconds, value: requestCountByEnterpriseId[enterpriseId] }],
+              points: [{ timestamp: timestampInSeconds, value: perEnterpriseMetrics[enterpriseId] }],
               tags: [`dyno:${thisDyno}`, `android_enterprise_id:${enterpriseId}`],
             }));
-            metricsToSendToDatadog = metricsToSendToDatadog.concat(perEnterpriseSeries);
+            metricsToSendToDatadog = metricsToSendToDatadog.concat(perEnterpriseMetrics);
 
             sails.helpers.http.post.with({
               url: 'https://api.us5.datadoghq.com/api/v2/series',
               data: {
-                series: metricsToSendToDatadoge
+                series: metricsToSendToDatadog
               },
               headers: {
                 'DD-API-KEY': sails.config.custom.datadogApiKey,

--- a/website/api/hooks/custom/index.js
+++ b/website/api/hooks/custom/index.js
@@ -143,10 +143,15 @@ will be disabled and/or hidden in the UI.
       // endpoint (api/controllers/android-proxy/*) increments this every time it makes a request to
       // Google, and the repeating timer below logs the count and resets it once a minute so we can monitor the number of requests the proxy is making.
       sails.androidProxyApiRequestCount = 0;
+      // Track AMAPI requests per Android enterprise ID (keyed by enterprise ID) so we can
+      // graph request volume per enterprise in Datadog. Reset every minute alongside the total.
+      sails.androidProxyApiRequestCountByEnterpriseId = {};
       if (sails.config.custom.androidEnterpriseServiceAccountEmailAddress && sails.config.custom.androidEnterpriseServiceAccountPrivateKey) {
         let logAndResetAndroidProxyApiRequestCount = ()=>{
           let requestCountInLastMinute = sails.androidProxyApiRequestCount;
           sails.androidProxyApiRequestCount = 0;// Reset for the next minute.
+          let requestCountByEnterpriseId = sails.androidProxyApiRequestCountByEnterpriseId;
+          sails.androidProxyApiRequestCountByEnterpriseId = {};// Reset for the next minute.
           if (requestCountInLastMinute === 0) {
             return;// Stay quiet on idle minutes so the metric lines are easy to grep.
           }
@@ -155,16 +160,28 @@ will be disabled and/or hidden in the UI.
           if (sails.config.environment === 'production' && sails.config.custom.datadogApiKey) {
             let timestampInSeconds = Math.floor(Date.now() / 1000);
             let thisDyno = process.env.DYNO;
+            // Create an array of metrics, and add the total request count.
+            let metricsToSendToDatadog = [{
+              metric: 'android_proxy.amapi_request_count',
+              type: 1,// count
+              interval: 60,
+              points: [{ timestamp: timestampInSeconds, value: requestCountInLastMinute }],
+              tags: [`dyno:${thisDyno}`],
+            }];
+
+            let perEnterpriseMetrics = Object.keys(requestCountByEnterpriseId).map((enterpriseId)=>({
+              metric: 'android_proxy.amapi_request_count_by_enterprise',
+              type: 1,
+              interval: 60,
+              points: [{ timestamp: timestampInSeconds, value: requestCountByEnterpriseId[enterpriseId] }],
+              tags: [`dyno:${thisDyno}`, `android_enterprise_id:${enterpriseId}`],
+            }));
+            metricsToSendToDatadog = metricsToSendToDatadog.concat(perEnterpriseSeries);
+
             sails.helpers.http.post.with({
               url: 'https://api.us5.datadoghq.com/api/v2/series',
               data: {
-                series: [{
-                  metric: 'android_proxy.amapi_request_count',
-                  type: 1,// count
-                  interval: 60,
-                  points: [{ timestamp: timestampInSeconds, value: requestCountInLastMinute }],
-                  tags: [`dyno:${thisDyno}`],
-                }],
+                series: metricsToSendToDatadoge
               },
               headers: {
                 'DD-API-KEY': sails.config.custom.datadogApiKey,


### PR DESCRIPTION
Changes:
- Updated Android proxy endpoints to track the number of requests made for an Android Enterprise ID in the past minute, and to send metrics about this usage to Datadog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-enterprise tracking for Android Management API requests across enrollment, device, enterprise, application, policy, and command operations.
  * Reporting now provides both overall request totals and enterprise-specific metrics.

* **Bug Fixes**
  * Improved consistency of request tracking across Android management workflows, including paginated requests and device operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->