### PR TITLE
Fix check-go-patch-release workflow: install the new Go version

### DIFF
--- a/.github/workflows/check-go-patch-release.yml
+++ b/.github/workflows/check-go-patch-release.yml
@@ -93,7 +93,11 @@ jobs:
         if: steps.check.outputs.update_needed == 'true'
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version-file: 'go.mod'
+          # Install the new Go version (not the one in go.mod): `make update-go`
+          # bumps the root go.mod first, and with setup-go's GOTOOLCHAIN=local the
+          # remaining `go run` invocations fail if the installed toolchain is older.
+          go-version: ${{ steps.check.outputs.new_version }}
+          check-latest: true
 
       - name: Update Go version
         if: steps.check.outputs.update_needed == 'true'


### PR DESCRIPTION
**Related issue:** Follow-up to #51239

Fixes the failing [check-go-patch-release workflow run](https://github.com/fleetdm/fleet/actions/runs/32076596930/job/95531039369).

The workflow installed Go with `go-version-file: 'go.mod'`, which installs the **current** version (1.26.5). `make update-go` then bumps the root `go.mod` first (it's the first entry in `UPDATE_GO_MODS`), so with `actions/setup-go@v6`'s default `GOTOOLCHAIN=local` all remaining `go run ./tools/tuf/replace` invocations failed with:

```
go: go.mod requires go >= 1.26.6 (running go 1.26.5; GOTOOLCHAIN=local)
```

This doesn't reproduce locally because `GOTOOLCHAIN` defaults to `auto` there, so Go transparently downloads the newer toolchain.

Fix: install the new patch version directly (`go-version: ${{ steps.check.outputs.new_version }}`) with `check-latest: true` so a stale runner toolchain cache doesn't resolve to an older version on release day.

# Checklist for submitter

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops

## Testing

- [ ] QA'd all new/changed functionality manually (will re-dispatch the workflow after merge to verify)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated checks to install and validate the detected latest Go patch release explicitly.
  * Improved reliability of Go version verification in the release workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->