### PR TITLE
Stop retrying VPP install details on a 404

### DIFF
--- a/changes/51347-vpp-details-no-retry-on-404.md
+++ b/changes/51347-vpp-details-no-retry-on-404.md
@@ -1,0 +1,1 @@
+- Fixed the VPP install details modal retrying the command results request four times when the result isn't available yet and the API returns a 404.

--- a/frontend/components/ActivityDetails/InstallDetails/VppInstallDetailsModal/VppInstallDetailsModal.tests.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/VppInstallDetailsModal/VppInstallDetailsModal.tests.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
 import { http, HttpResponse } from "msw";
 import {
   createCustomRenderer,
@@ -666,5 +667,47 @@ describe("VPP Install Details Modal", () => {
         /If the install finishes later, Fleet will update the status when the host is refetched/i
       )
     ).toBeInTheDocument();
+  });
+
+  it("does not retry the command results request when the API returns 404", async () => {
+    let requestCount = 0;
+    mockServer.use(
+      http.get(baseUrl("/commands/results"), () => {
+        requestCount += 1;
+        return HttpResponse.json({ message: "Not Found" }, { status: 404 });
+      })
+    );
+
+    // The shared test renderer sets `retry: false` for every query, which would
+    // hide the behavior under test. Render against a client that retries, so
+    // it's the modal's own retry rule that decides.
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: 3, retryDelay: 0, cacheTime: 0 } },
+    });
+
+    render(
+      <QueryClientProvider client={client}>
+        <VppInstallDetailsModal
+          details={{
+            fleetInstallStatus: "pending_install",
+            hostDisplayName: "Marko's MacBook Pro",
+            appName: "Keynote",
+            commandUuid: "missing-uuid",
+            platform: "darwin",
+          }}
+          onCancel={jest.fn()}
+        />
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => {
+      expect(requestCount).toBeGreaterThan(0);
+    });
+    // Leave room for retries to land if the rule isn't applied.
+    await new Promise((resolve) => {
+      setTimeout(resolve, 500);
+    });
+
+    expect(requestCount).toBe(1);
   });
 });

--- a/frontend/components/ActivityDetails/InstallDetails/VppInstallDetailsModal/VppInstallDetailsModal.tests.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/VppInstallDetailsModal/VppInstallDetailsModal.tests.tsx
@@ -700,12 +700,10 @@ describe("VPP Install Details Modal", () => {
       </QueryClientProvider>
     );
 
+    // Waiting on the settled UI rather than a timer: the query stays loading
+    // while retries are in flight, so this only resolves once they're done.
     await waitFor(() => {
-      expect(requestCount).toBeGreaterThan(0);
-    });
-    // Leave room for retries to land if the rule isn't applied.
-    await new Promise((resolve) => {
-      setTimeout(resolve, 500);
+      expect(screen.getByText(/when it comes online/i)).toBeInTheDocument();
     });
 
     expect(requestCount).toBe(1);

--- a/frontend/components/ActivityDetails/InstallDetails/VppInstallDetailsModal/VppInstallDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/VppInstallDetailsModal/VppInstallDetailsModal.tsx
@@ -21,6 +21,7 @@ import {
 import { ICommandResult } from "interfaces/command";
 import { isAndroid, isAppleDevice, isMacOS } from "interfaces/platform";
 import { secondsToDhms } from "utilities/helpers";
+import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
 
 import InventoryVersions from "pages/hosts/details/components/InventoryVersions";
 
@@ -413,7 +414,9 @@ export const VppInstallDetailsModal = ({
         : commandAPI.getCommandResults(commandUuid).then(responseHandler);
     },
     {
-      refetchOnWindowFocus: false,
+      // Brings in the shared retry rule, which skips 4xx. A 404 here means the
+      // result doesn't exist yet — a definitive answer, so don't retry it.
+      ...DEFAULT_USE_QUERY_OPTIONS,
       staleTime: 3000,
       // Pre-flight Fleet failures (e.g. unresolvable managed-config var) never
       // enqueue an MDM command, so there's no command result to fetch — the


### PR DESCRIPTION
**Related issue:** Resolves #51347

When the device hasn't acknowledged an install yet, `GET /commands/results` returns a 404. The modal issued four requests (initial + 3 retries) before settling on a state it could have shown after the first.

## Root cause

The query passed only three options:

```ts
{
  refetchOnWindowFocus: false,
  staleTime: 3000,
  enabled: !!commandUuid && !failureReason,
}
```

No `retry`, so react-query's default of three retries applied — hence exactly four requests.

Fleet already has a shared default for this, used by around 119 components:

```ts
export const DEFAULT_USE_QUERY_OPTIONS = {
  refetchOnWindowFocus: false,
  retry: (failureCount, error) => {
    const err = error as any;
    let isBadRequestErr = false;
    if (err.status !== undefined) {
      isBadRequestErr = err.status >= 400 && err.status < 500;
    }
    return failureCount < 4 && !isBadRequestErr;
  },
};
```

This query had simply never adopted it — the local `refetchOnWindowFocus: false` was a hand-rolled copy of one of its fields, without the retry rule.

## Changes

Spread the shared defaults instead:

```ts
{
  ...DEFAULT_USE_QUERY_OPTIONS,
  staleTime: 3000,
  enabled: !!commandUuid && !failureReason,
}
```

`refetchOnWindowFocus` comes from the defaults, so the local copy is removed. A 404 now resolves on the first response. Genuine failures (5xx, network errors) still retry as before, since the rule only short-circuits 4xx.

The sibling `SoftwareUninstallDetailsModal` solves the same problem with its own inline predicate (`err?.status !== 404 && failureCount < 3`). Using the shared defaults seemed preferable to adding a second hand-rolled variant, but happy to match that instead if you'd rather keep the two modals symmetrical.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests

Added a test that serves a 404 from `/commands/results` and asserts the endpoint is hit exactly once. Against the unfixed component it reports `Expected: 1, Received: 4`, matching the count in the issue.

One wrinkle worth flagging for review: the shared test renderer sets `retry: false` for every query, so a test written the usual way passes with or without the fix. The new test therefore renders against its own `QueryClient` with retries enabled, so it's the modal's own retry rule being exercised rather than the harness's. The other 29 tests in the file are unchanged and still pass, and `eslint`, `prettier`, and `tsc --noEmit` are clean.

- [ ] QA'd all new/changed functionality manually

Not done. Reproducing it needs a VPP app install pending device acknowledgement, which I can't set up without an Apple Business Manager connection and an enrolled host. The test above covers the request count directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the VPP installation details modal when command results are unavailable.
  * Prevented repeated requests and unnecessary retries after a “not found” response, resulting in a more reliable and responsive experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->