### PR TITLE
MDMStatusModal: use isFetching over isLoading to always show spinner first

### DIFF
--- a/frontend/pages/hosts/details/modals/MDMStatusModal/MDMStatusModal.tsx
+++ b/frontend/pages/hosts/details/modals/MDMStatusModal/MDMStatusModal.tsx
@@ -160,7 +160,7 @@ const MDMStatusModal = ({
 }: IMDMStatusModal) => {
   const {
     data: depAssignmentData,
-    isLoading: isLoadingDepAssignment,
+    isFetching: isLoadingDepAssignment,
     isError: isDepAssignmentError,
   } = useQuery<IDepAssignmentHostResponse, AxiosError>(
     ["dep-assignment", hostId],
@@ -304,7 +304,10 @@ const MDMStatusModal = ({
   };
 
   const renderProfileAssignmentList = () => {
-    if (isLoadingDepAssignment) {
+    if (
+      isLoadingDepAssignment ||
+      (!depAssignmentData && !isDepAssignmentError)
+    ) {
       return <Spinner />;
     }
 

--- a/frontend/pages/hosts/details/modals/MDMStatusModal/MDMStatusModal.tsx
+++ b/frontend/pages/hosts/details/modals/MDMStatusModal/MDMStatusModal.tsx
@@ -304,10 +304,7 @@ const MDMStatusModal = ({
   };
 
   const renderProfileAssignmentList = () => {
-    if (
-      isLoadingDepAssignment ||
-      (!depAssignmentData && !isDepAssignmentError)
-    ) {
+    if (isLoadingDepAssignment) {
       return <Spinner />;
     }
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #51392 

`isFetching` is `true` whenever a request is fetching, whereas `isLoading` is only true if there is no stale data and it's requesting data. Since we always want the live call to show and not cached stale the `isFetching` is correct here, another approach could have to been kill the cached data either onExit or part of the react-query caching options.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information. Unreleased bug

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MDM status loading indicators to remain accurate during background refreshes.
  * Preserved existing error handling and profile-assignment display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->