### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/camunda-modeler/darwin.json
+++ b/ee/maintained-apps/outputs/camunda-modeler/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "5.49.0",
+      "version": "5.50.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.camunda.CamundaModeler';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.camunda.CamundaModeler' AND version_compare(bundle_short_version, '5.49.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.camunda.CamundaModeler' AND version_compare(bundle_short_version, '5.50.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.camunda.CamundaModeler');"
       },
-      "installer_url": "https://downloads.camunda.cloud/release/camunda-modeler/5.49.0/camunda-modeler-5.49.0-mac-arm64.zip",
+      "installer_url": "https://downloads.camunda.cloud/release/camunda-modeler/5.50.1/camunda-modeler-5.50.1-mac-arm64.dmg",
       "install_script_ref": "0b5b9959",
       "uninstall_script_ref": "68ff5179",
-      "sha256": "858679164991a85fbf4977682319e9860ae7981a7c1ed15c2b16ff22425670bb",
+      "sha256": "aa6c69b1b5f562b1119da065cf65090c0af8de0eaab3f4f57f2cc3612d72a679",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/claude/darwin.json
+++ b/ee/maintained-apps/outputs/claude/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.32352.0",
+      "version": "1.32352.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.32352.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.32352.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.anthropic.claudefordesktop');"
       },
-      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.32352.0/Claude-e33b9a2c87bcb6d670dae34471d8b60f7aa790ae.zip",
+      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.32352.1/Claude-6c6aa595ae38b202d9e00c026dc94d3a6a42c332.zip",
       "install_script_ref": "6e4c028b",
       "uninstall_script_ref": "421baa98",
-      "sha256": "97fac11c171fdd11414c2a53ceae0757f7f8f1699a82101ee44aa8772af5061e",
+      "sha256": "cedb205cd433c8238d3b2cf959212b2fab149cadc55dbe125789d137c85b8a38",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/microsoft-edge/windows.json
+++ b/ee/maintained-apps/outputs/microsoft-edge/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "151.0.4129.78",
+      "version": "151.0.4129.93",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Microsoft Edge' AND publisher = 'Microsoft Corporation';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Microsoft Edge' AND publisher = 'Microsoft Corporation' AND version_compare(version, '151.0.4129.78') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Microsoft Edge' AND publisher = 'Microsoft Corporation' AND version_compare(version, '151.0.4129.93') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'msedge.exe');"
       },
-      "installer_url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/f5e477ef-f201-49dd-866a-8e25850421dd/MicrosoftEdgeEnterpriseX64.msi",
+      "installer_url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/672dd164-4c25-42a8-b3d3-d7274d6c3d5c/MicrosoftEdgeEnterpriseX64.msi",
       "install_script_ref": "22e48c46",
       "uninstall_script_ref": "e12e9902",
-      "sha256": "716b2549eedf4305b92d149186f878394c8d8b7b743db0eaaec773349ed3c273",
+      "sha256": "346748bde5c6ca71c15c7a800806c7899161b6e903c6b8ab069afcda38c5f41e",
       "default_categories": [
         "Browsers"
       ],

--- a/ee/maintained-apps/outputs/mullvad-browser/darwin.json
+++ b/ee/maintained-apps/outputs/mullvad-browser/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "15.0.19",
+      "version": "15.0.20",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'net.mullvad.mullvadbrowser';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.mullvad.mullvadbrowser' AND version_compare(bundle_short_version, '15.0.19') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.mullvad.mullvadbrowser' AND version_compare(bundle_short_version, '15.0.20') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'net.mullvad.mullvadbrowser');"
       },
-      "installer_url": "https://cdn.mullvad.net/browser/15.0.19/mullvad-browser-macos-15.0.19.dmg",
+      "installer_url": "https://cdn.mullvad.net/browser/15.0.20/mullvad-browser-macos-15.0.20.dmg",
       "install_script_ref": "30301c81",
       "uninstall_script_ref": "c44b0633",
-      "sha256": "10aa8b7f3e80a0841e19022107a2e55eee33b03e0afa1a13c416e39019c3f0b1",
+      "sha256": "0a5fabd16ba9b53bcc5a19bcc5ab6ff27d00d2e14f02d88dc756f75b8e0c1ab0",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/mullvad-browser/windows.json
+++ b/ee/maintained-apps/outputs/mullvad-browser/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "15.0.19",
+      "version": "15.0.20",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Mullvad Browser' AND publisher = 'Mullvad VPN';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Mullvad Browser' AND publisher = 'Mullvad VPN' AND version_compare(version, '15.0.19') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Mullvad Browser' AND publisher = 'Mullvad VPN' AND version_compare(version, '15.0.20') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'mullvad browser.exe');"
       },
-      "installer_url": "https://github.com/mullvad/mullvad-browser/releases/download/15.0.19/mullvad-browser-windows-x86_64-15.0.19.exe",
+      "installer_url": "https://github.com/mullvad/mullvad-browser/releases/download/15.0.20/mullvad-browser-windows-x86_64-15.0.20.exe",
       "install_script_ref": "de703749",
       "uninstall_script_ref": "77ded4aa",
-      "sha256": "1bcc69725207baaf414dbcdb7e844383bbb1b3a7e826194e563a154428db4bc7",
+      "sha256": "7eb168be0eb88a5517e8a80e162d6d90205c65472604e7c634036e473b83d193",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/postman/windows.json
+++ b/ee/maintained-apps/outputs/postman/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "12.23.8",
+      "version": "12.24.1",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.23.8') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.24.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'postman.exe');"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.23.8/windows_64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.24.1/windows_64",
       "install_script_ref": "8594f0bc",
       "uninstall_script_ref": "fd59d029",
-      "sha256": "00ae18ffc1b565a3a3bff0cdb54e42fe6f5dc2896feaf02893e075b9b0d8af2d",
+      "sha256": "e054256c2e2b840c2e6f95547832d1e3dad096faf6775bec691f318cfff00bf7",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/slack/windows.json
+++ b/ee/maintained-apps/outputs/slack/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "4.51.185",
+      "version": "4.51.191",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Slack' AND publisher = 'Slack Technologies Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Slack' AND publisher = 'Slack Technologies Inc.' AND version_compare(version, '4.51.185') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Slack' AND publisher = 'Slack Technologies Inc.' AND version_compare(version, '4.51.191') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'slack.exe');"
       },
-      "installer_url": "https://downloads.slack-edge.com/desktop-releases/windows/x64/4.51.185/Slack.msix",
+      "installer_url": "https://downloads.slack-edge.com/desktop-releases/windows/x64/4.51.191/Slack.msix",
       "install_script_ref": "8b41f934",
       "uninstall_script_ref": "034eae14",
-      "sha256": "6e9a1199b5a617f93142f796da3f5197b0a8af5addc998a30613f68a4f137dbd",
+      "sha256": "0b267d78189561bb44d7a8bba923e8f3524a388903677c18c64adcd76e160557",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/whatsapp/darwin.json
+++ b/ee/maintained-apps/outputs/whatsapp/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "26.33.12",
+      "version": "26.32.21",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp' AND version_compare(bundle_short_version, '26.33.12') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp' AND version_compare(bundle_short_version, '26.32.21') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'net.whatsapp.WhatsApp');"
       },
       "installer_url": "https://web.whatsapp.com/desktop/mac_native/release/?configuration=Release&src=whatsapp_downloads_page",


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated Camunda Modeler for macOS ARM64 to version 5.50.1, with a new DMG installer.
  - Updated Claude Desktop for macOS to version 1.32352.1.
  - Updated Microsoft Edge for Windows to version 151.0.4129.93.
  - Updated Mullvad Browser for macOS and Windows to version 15.0.20.
  - Updated Postman for Windows to version 12.24.1.
  - Updated Slack for Windows to version 4.51.191.
  - Updated WhatsApp for macOS to version 26.32.21.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->