### PR TITLE
Verify Apple Business assignment before deleting a host

### DIFF
--- a/changes/49268-verify-ab-assignment-before-delete
+++ b/changes/49268-verify-ab-assignment-before-delete
@@ -1,0 +1,1 @@
+- Fixed deleting a host that was released from Apple Business reporting success while the host record stayed in Fleet. Fleet now checks the assignment with Apple before deleting, and returns an error instead of reporting success if Apple can't be reached.

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -2632,6 +2632,24 @@ func (ds *Datastore) MarkHostDEPAssignmentDeleted(ctx context.Context, hostID ui
 	return ctxerr.Wrap(ctx, err, "mark host dep assignment deleted")
 }
 
+func (ds *Datastore) MarkHostDEPAssignmentsDeleted(ctx context.Context, hostIDs []uint) error {
+	if len(hostIDs) == 0 {
+		return nil
+	}
+
+	stmt, args, err := sqlx.In(`
+		UPDATE host_dep_assignments
+		SET deleted_at = NOW(), mdm_migration_deadline = NULL, mdm_migration_completed = NULL
+		WHERE host_id IN (?) AND deleted_at IS NULL`, hostIDs)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "building IN statement for marking host dep assignments deleted")
+	}
+	if _, err := ds.writer(ctx).ExecContext(ctx, stmt, args...); err != nil {
+		return ctxerr.Wrap(ctx, err, "mark host dep assignments deleted")
+	}
+	return nil
+}
+
 func (ds *Datastore) RestoreMDMApplePendingDEPHost(ctx context.Context, host *fleet.Host) error {
 	ac, err := ds.AppConfig(ctx)
 	if err != nil {

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2122,8 +2122,16 @@ type Datastore interface {
 	DeleteHostDEPAssignments(ctx context.Context, abmTokenID uint, serials []string) error
 
 	// MarkHostDEPAssignmentDeleted marks as deleted the host_dep_assignments entry for the provided host ID.
-	// Only use when we no longer have a host row, if we do use `DeleteHostDEPAssignments` instead.
+	//
+	// Prefer `DeleteHostDEPAssignments` when the host row still exists AND the pending-host
+	// cleanup it performs is wanted: that one also deletes pending host rows matching the
+	// serial, since a pending host no longer in ABM will never enroll. Callers that are
+	// deleting the host themselves, or that only have a host ID (an assignment whose ABM
+	// token was removed has no token to match on), want this one.
 	MarkHostDEPAssignmentDeleted(ctx context.Context, hostID uint) error
+
+	// MarkHostDEPAssignmentsDeleted is the batched form of MarkHostDEPAssignmentDeleted.
+	MarkHostDEPAssignmentsDeleted(ctx context.Context, hostIDs []uint) error
 
 	// UpdateHostDEPAssignProfileResponses receives a profile UUID and threes lists of serials, each representing
 	// one of the three possible responses, and updates the host_dep_assignments table with the corresponding responses. For each response, it also sets the ABM token id in the table to the provided value.

--- a/server/fleet/errors.go
+++ b/server/fleet/errors.go
@@ -27,6 +27,7 @@ var (
 	AppleABMDefaultTeamDeprecatedMessage         = "mdm.apple_bm_default_team has been deprecated. Please use the new mdm.apple_business key documented here: https://fleetdm.com/learn-more-about/apple-business-manager-gitops"
 	AppleOSVersionUnsupportedMessage             = "The minimum version isn't supported by Apple."
 	AppleOSVersionDeadlineInvalidMessage         = "The deadline isn't a valid date."
+	CantDeleteHostUnverifiedABMMessage           = "Couldn't delete host. Fleet couldn't reach Apple Business to check whether this host is still assigned. Please try again."
 	CantTurnOffMDMForWindowsHostsMessage         = "Can't turn off MDM for Windows hosts."
 	CantTurnOffMDMAlreadyTurnedOffMessage        = "Couldn't turn off MDM. This host already has MDM turned off."
 	CantTurnOffMDMForPersonalHostsMessage        = "Couldn't turn off MDM. This command isn't available for personal hosts."

--- a/server/mdm/nanodep/godep/device.go
+++ b/server/mdm/nanodep/godep/device.go
@@ -100,11 +100,26 @@ type DeviceDetails struct {
 	ResponseStatus string `json:"response_status"`
 }
 
-// GetDevicesDetails uses the Apple "Get Device Details" API endpoint to
+// GetDeviceDetails uses the Apple "Get Device Details" API endpoint to
 // retrieve the details (such as its assigned enrollment profile UUID) for the
 // specified device, identified by its serial number.
 // See https://developer.apple.com/documentation/devicemanagement/get_device_details
 func (c *Client) GetDeviceDetails(ctx context.Context, name, serialNumber string) (*DeviceDetails, error) {
+	devices, err := c.GetDevicesDetails(ctx, name, serialNumber)
+	if err != nil {
+		return nil, err
+	}
+	return devices[serialNumber], nil
+}
+
+// GetDevicesDetails is the multi-device form of GetDeviceDetails. Apple keys the
+// response by serial number and omits serials it has no record of, so callers
+// must not assume every requested serial comes back.
+//
+// Apple caps how many devices one request may carry; callers are responsible for
+// chunking (see apple_mdm.DEPSyncLimit).
+// See https://developer.apple.com/documentation/devicemanagement/get_device_details
+func (c *Client) GetDevicesDetails(ctx context.Context, name string, serialNumbers ...string) (map[string]*DeviceDetails, error) {
 	type request struct {
 		Devices []string `json:"devices"`
 	}
@@ -113,11 +128,11 @@ func (c *Client) GetDeviceDetails(ctx context.Context, name, serialNumber string
 	}
 	resp := new(response)
 	if err := c.doWithAfterHook(ctx, name, http.MethodPost, "/devices", request{
-		Devices: []string{serialNumber},
+		Devices: serialNumbers,
 	}, resp); err != nil {
 		return nil, err
 	}
-	return resp.Devices[serialNumber], nil
+	return resp.Devices, nil
 }
 
 type DeviceStatusResponse struct {

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1280,6 +1280,8 @@ type DeleteHostDEPAssignmentsFunc func(ctx context.Context, abmTokenID uint, ser
 
 type MarkHostDEPAssignmentDeletedFunc func(ctx context.Context, hostID uint) error
 
+type MarkHostDEPAssignmentsDeletedFunc func(ctx context.Context, hostIDs []uint) error
+
 type UpdateHostDEPAssignProfileResponsesFunc func(ctx context.Context, resp *godep.ProfileResponse, abmTokenID uint) error
 
 type UpdateHostDEPAssignProfileResponsesSameABMFunc func(ctx context.Context, resp *godep.ProfileResponse) error
@@ -4220,6 +4222,9 @@ type DataStore struct {
 
 	MarkHostDEPAssignmentDeletedFunc        MarkHostDEPAssignmentDeletedFunc
 	MarkHostDEPAssignmentDeletedFuncInvoked bool
+
+	MarkHostDEPAssignmentsDeletedFunc        MarkHostDEPAssignmentsDeletedFunc
+	MarkHostDEPAssignmentsDeletedFuncInvoked bool
 
 	UpdateHostDEPAssignProfileResponsesFunc        UpdateHostDEPAssignProfileResponsesFunc
 	UpdateHostDEPAssignProfileResponsesFuncInvoked bool
@@ -10202,6 +10207,13 @@ func (s *DataStore) MarkHostDEPAssignmentDeleted(ctx context.Context, hostID uin
 	s.MarkHostDEPAssignmentDeletedFuncInvoked = true
 	s.mu.Unlock()
 	return s.MarkHostDEPAssignmentDeletedFunc(ctx, hostID)
+}
+
+func (s *DataStore) MarkHostDEPAssignmentsDeleted(ctx context.Context, hostIDs []uint) error {
+	s.mu.Lock()
+	s.MarkHostDEPAssignmentsDeletedFuncInvoked = true
+	s.mu.Unlock()
+	return s.MarkHostDEPAssignmentsDeletedFunc(ctx, hostIDs)
 }
 
 func (s *DataStore) UpdateHostDEPAssignProfileResponses(ctx context.Context, resp *godep.ProfileResponse, abmTokenID uint) error {

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -613,6 +613,54 @@ func (svc *Service) DeleteHosts(ctx context.Context, ids []uint, filter *map[str
 	}
 
 	doDelete := func(hostIDs []uint, hosts []*fleet.Host) error {
+		// Settle Apple Business assignments before anything is written, so the
+		// activities below can never claim a deletion the restore path undoes.
+		checks, err := svc.checkDEPAssignmentsForDelete(ctx, hosts)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "checking dep assignments before bulk delete")
+		}
+
+		// Hosts Apple couldn't be asked about are left in place and reported; the
+		// rest of the batch still goes through.
+		skipped := make(map[uint]struct{})
+		var skippedNames []string
+		for _, host := range hosts {
+			if checks[host.ID].check == depDeleteUnverified {
+				skipped[host.ID] = struct{}{}
+				// A host ingested from Apple Business has no display name until it
+				// checks in, so fall back to the serial — which is how the admin
+				// would look it up in Apple Business anyway.
+				name := host.DisplayName()
+				if name == "" {
+					name = host.HardwareSerial
+				}
+				skippedNames = append(skippedNames, name)
+			}
+		}
+		if len(skipped) > 0 {
+			keptIDs := make([]uint, 0, len(hostIDs))
+			for _, id := range hostIDs {
+				if _, ok := skipped[id]; !ok {
+					keptIDs = append(keptIDs, id)
+				}
+			}
+			keptHosts := make([]*fleet.Host, 0, len(hosts))
+			for _, host := range hosts {
+				if _, ok := skipped[host.ID]; !ok {
+					keptHosts = append(keptHosts, host)
+				}
+			}
+			hostIDs, hosts = keptIDs, keptHosts
+		}
+
+		if err := svc.clearDisownedDEPAssignments(ctx, checks); err != nil {
+			return err
+		}
+
+		if len(hostIDs) == 0 {
+			return ctxerr.Wrap(ctx, unverifiedABMHostsError(checks, skippedNames), "deleting hosts")
+		}
+
 		if err := svc.ds.DeleteHosts(ctx, hostIDs); err != nil {
 			return err
 		}
@@ -660,6 +708,10 @@ func (svc *Service) DeleteHosts(ctx context.Context, ids []uint, filter *map[str
 			); err != nil {
 				return err
 			}
+		}
+
+		if len(skippedNames) > 0 {
+			return ctxerr.Wrap(ctx, unverifiedABMHostsError(checks, skippedNames), "deleting hosts")
 		}
 
 		return nil
@@ -1148,6 +1200,21 @@ func (svc *Service) DeleteHost(ctx context.Context, id uint) error {
 	// other team.
 	notFoundErr := ctxerr.Wrap(ctx, common_mysql.NotFound("Host").WithID(id), "get host for delete")
 	if err := svc.authz.AuthorizeOrNotFound(ctx, host, fleet.ActionWrite, notFoundErr); err != nil {
+		return err
+	}
+
+	// Settle the host's Apple Business assignment before anything is written, so
+	// the activity below can never claim a deletion that the restore path is
+	// about to undo.
+	checks, err := svc.checkDEPAssignmentsForDelete(ctx, []*fleet.Host{host})
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "checking dep assignment before delete")
+	}
+	if c := checks[host.ID]; c.check == depDeleteUnverified {
+		return ctxerr.Wrap(ctx,
+			fleet.NewBadGatewayError(fleet.CantDeleteHostUnverifiedABMMessage, c.appleErr), "deleting host")
+	}
+	if err := svc.clearDisownedDEPAssignments(ctx, checks); err != nil {
 		return err
 	}
 

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -658,7 +658,7 @@ func (svc *Service) DeleteHosts(ctx context.Context, ids []uint, filter *map[str
 		}
 
 		if len(hostIDs) == 0 {
-			return ctxerr.Wrap(ctx, unverifiedABMHostsError(checks, skippedNames), "deleting hosts")
+			return ctxerr.Wrap(ctx, unverifiedABMHostsError(checks, skippedNames, 0), "deleting hosts")
 		}
 
 		if err := svc.ds.DeleteHosts(ctx, hostIDs); err != nil {
@@ -711,7 +711,7 @@ func (svc *Service) DeleteHosts(ctx context.Context, ids []uint, filter *map[str
 		}
 
 		if len(skippedNames) > 0 {
-			return ctxerr.Wrap(ctx, unverifiedABMHostsError(checks, skippedNames), "deleting hosts")
+			return ctxerr.Wrap(ctx, unverifiedABMHostsError(checks, skippedNames, len(hostIDs)), "deleting hosts")
 		}
 
 		return nil

--- a/server/service/hosts_dep_verify.go
+++ b/server/service/hosts_dep_verify.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -33,6 +34,10 @@ const (
 	depDeleteUnverified
 )
 
+// errDEPLookupFailed is the cause recorded when Apple answered but reported that
+// it could not look the device up.
+var errDEPLookupFailed = errors.New("apple reported a failed device lookup")
+
 // depDeleteResult is what the check concluded for one host, plus the Apple-side
 // failure behind an unverified result so callers can surface it rather than
 // leaving it in the logs.
@@ -45,8 +50,11 @@ type depDeleteResult struct {
 // assigned to this Fleet instance, so a delete is not reported as successful
 // when the host is about to be restored from a stale assignment record.
 //
-// Apple-side failures are reported as depDeleteUnverified rather than returned
-// as errors; only problems reading Fleet's own state return an error.
+// Anything that leaves Fleet unable to get an answer about a host — Apple being
+// unreachable, Apple reporting a failed lookup, or its Apple Business token not
+// resolving — is reported as depDeleteUnverified for that host rather than failing
+// the whole call. Only failures to read the state this check is built on (app
+// config, the assignment rows) return an error.
 func (svc *Service) checkDEPAssignmentsForDelete(ctx context.Context, hosts []*fleet.Host) (map[uint]depDeleteResult, error) {
 	checks := make(map[uint]depDeleteResult, len(hosts))
 	for _, h := range hosts {
@@ -133,7 +141,13 @@ func (svc *Service) checkDEPAssignmentsForDelete(ctx context.Context, hosts []*f
 					svc.logger.WarnContext(ctx, "no DEP device details returned for serial",
 						"abm_token_id", tokenID, "host_id", e.hostID)
 				}
-				checks[e.hostID] = depDeleteResult{check: classifyDEPDeviceDetails(d)}
+				res := depDeleteResult{check: classifyDEPDeviceDetails(d)}
+				if res.check == depDeleteUnverified {
+					// Apple answered, so there is no transport error to carry — record
+					// why the host could not be verified rather than reporting no cause.
+					res.appleErr = errDEPLookupFailed
+				}
+				checks[e.hostID] = res
 			}
 		}
 	}
@@ -197,7 +211,11 @@ func (svc *Service) clearDisownedDEPAssignments(ctx context.Context, checks map[
 // unverifiedABMHostsError reports the hosts a bulk delete left in place because
 // Apple could not be asked about them, carrying one of the underlying Apple
 // failures so the cause is not lost.
-func unverifiedABMHostsError(checks map[uint]depDeleteResult, names []string) error {
+//
+// deleted is how many hosts the batch did remove, so a caller can tell a partial
+// delete from one that removed nothing and decide whether retrying the whole
+// request is safe.
+func unverifiedABMHostsError(checks map[uint]depDeleteResult, names []string, deleted int) error {
 	var appleErr error
 	for _, c := range checks {
 		if c.check == depDeleteUnverified && c.appleErr != nil {
@@ -205,8 +223,9 @@ func unverifiedABMHostsError(checks map[uint]depDeleteResult, names []string) er
 			break
 		}
 	}
-	return fleet.NewBadGatewayError(
-		fmt.Sprintf("%s Hosts: %s.", fleet.CantDeleteHostUnverifiedABMMessage, strings.Join(names, ", ")),
-		appleErr,
-	)
+	msg := fmt.Sprintf("%s Hosts: %s.", fleet.CantDeleteHostUnverifiedABMMessage, strings.Join(names, ", "))
+	if deleted > 0 {
+		msg = fmt.Sprintf("%s The other %d host(s) were deleted.", msg, deleted)
+	}
+	return fleet.NewBadGatewayError(msg, appleErr)
 }

--- a/server/service/hosts_dep_verify.go
+++ b/server/service/hosts_dep_verify.go
@@ -1,0 +1,212 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/contexts/license"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
+	"github.com/fleetdm/fleet/v4/server/mdm/nanodep/godep"
+)
+
+// depDeleteCheck is what Apple says about a host's Apple Business assignment
+// when a delete is requested.
+type depDeleteCheck int
+
+const (
+	// depDeleteNoAssignment means nothing could restore this host after the
+	// delete, so there is nothing to verify.
+	depDeleteNoAssignment depDeleteCheck = iota
+	// depDeleteDisowned means Apple no longer reports the device as assigned to
+	// us. Releasing a device from Apple Business never sends the deleted op_type
+	// that would clear Fleet's assignment record, so the record outlives the
+	// assignment and would otherwise restore the host forever.
+	depDeleteDisowned
+	// depDeleteAssigned means Apple still reports the device as ours, so
+	// restoring the host after the delete is correct.
+	depDeleteAssigned
+	// depDeleteUnverified means Apple gave no usable answer. Deleting would risk
+	// reporting a success that silently reverses, so callers refuse instead.
+	depDeleteUnverified
+)
+
+// depDeleteResult is what the check concluded for one host, plus the Apple-side
+// failure behind an unverified result so callers can surface it rather than
+// leaving it in the logs.
+type depDeleteResult struct {
+	check    depDeleteCheck
+	appleErr error
+}
+
+// checkDEPAssignmentsForDelete asks Apple whether the given hosts are still
+// assigned to this Fleet instance, so a delete is not reported as successful
+// when the host is about to be restored from a stale assignment record.
+//
+// Apple-side failures are reported as depDeleteUnverified rather than returned
+// as errors; only problems reading Fleet's own state return an error.
+func (svc *Service) checkDEPAssignmentsForDelete(ctx context.Context, hosts []*fleet.Host) (map[uint]depDeleteResult, error) {
+	checks := make(map[uint]depDeleteResult, len(hosts))
+	for _, h := range hosts {
+		checks[h.ID] = depDeleteResult{check: depDeleteNoAssignment}
+	}
+
+	// Mirrors the gates the restore path itself applies: if it cannot run, no
+	// host can come back and there is nothing worth asking Apple about.
+	if !license.IsPremium(ctx) || svc.depStorage == nil {
+		return checks, nil
+	}
+	appCfg, err := svc.ds.AppConfig(ctx)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "get app config for dep delete check")
+	}
+	if !appCfg.MDM.AppleBMEnabledAndConfigured {
+		return checks, nil
+	}
+
+	hostIDs := make([]uint, 0, len(hosts))
+	for _, h := range hosts {
+		hostIDs = append(hostIDs, h.ID)
+	}
+	assignments, err := svc.ds.GetHostDEPAssignmentsByHostIDs(ctx, hostIDs)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "get host dep assignments for delete check")
+	}
+	if len(assignments) == 0 {
+		return checks, nil
+	}
+
+	// Serials are looked up per Apple Business token, since each token addresses a
+	// different organization.
+	type pending struct {
+		hostID uint
+		serial string
+	}
+	byToken := make(map[uint][]pending)
+	for _, a := range assignments {
+		if a.ABMTokenID == nil || a.HardwareSerial == "" {
+			// An assignment with no token is left over from an Apple Business token
+			// that was removed from Fleet: there is no organization left to ask, and
+			// nothing can restore the host through it either. Treat it as released so
+			// the record is cleared rather than blocking the delete forever.
+			checks[a.HostID] = depDeleteResult{check: depDeleteDisowned}
+			continue
+		}
+		byToken[*a.ABMTokenID] = append(byToken[*a.ABMTokenID], pending{hostID: a.HostID, serial: a.HardwareSerial})
+	}
+
+	depClient := apple_mdm.NewDEPClient(svc.depStorage, svc.ds, svc.logger)
+	for tokenID, entries := range byToken {
+		token, err := svc.ds.GetABMTokenByID(ctx, tokenID)
+		if err != nil {
+			svc.logger.ErrorContext(ctx, "get ABM token for dep delete check", "abm_token_id", tokenID, "err", err)
+			for _, e := range entries {
+				checks[e.hostID] = depDeleteResult{check: depDeleteUnverified, appleErr: err}
+			}
+			continue
+		}
+
+		for start := 0; start < len(entries); start += apple_mdm.DEPSyncLimit {
+			end := min(start+apple_mdm.DEPSyncLimit, len(entries))
+			chunk := entries[start:end]
+
+			serials := make([]string, 0, len(chunk))
+			for _, e := range chunk {
+				serials = append(serials, e.serial)
+			}
+
+			details, err := depClient.GetDevicesDetails(ctx, token.OrganizationName, serials...)
+			if err != nil {
+				svc.logger.ErrorContext(ctx, "get DEP device details for delete check",
+					"abm_token_id", tokenID, "org_name", token.OrganizationName, "devices", len(serials), "err", err)
+				for _, e := range chunk {
+					checks[e.hostID] = depDeleteResult{check: depDeleteUnverified, appleErr: err}
+				}
+				continue
+			}
+
+			for _, e := range chunk {
+				d, answered := details[e.serial]
+				if !answered || d == nil {
+					svc.logger.WarnContext(ctx, "no DEP device details returned for serial",
+						"abm_token_id", tokenID, "host_id", e.hostID)
+				}
+				checks[e.hostID] = depDeleteResult{check: classifyDEPDeviceDetails(d)}
+			}
+		}
+	}
+
+	return checks, nil
+}
+
+// classifyDEPDeviceDetails turns Apple's per-device answer into a check. A nil
+// details means Apple replied without mentioning the serial at all.
+//
+// Blocking is reserved for Apple failing to answer — an unreachable API or a
+// FAILED lookup. Anything else is acted on: NOT_ACCESSIBLE means the device is no
+// longer ours, and both a readable answer and a silent one mean it still is.
+// Apple documents a per-serial status for everything asked about, so silence is
+// unexpected — but blocking on it would let one Apple quirk stop deletions
+// fleet-wide, a wider blast radius than the bug this guards against.
+func classifyDEPDeviceDetails(d *godep.DeviceDetails) depDeleteCheck {
+	if d == nil {
+		return depDeleteAssigned
+	}
+	switch godep.DeviceStatus(d.ResponseStatus) {
+	case godep.DeviceStatusNotAccessible:
+		return depDeleteDisowned
+	case godep.DeviceStatusFailed:
+		return depDeleteUnverified
+	}
+	return depDeleteAssigned
+}
+
+// clearDisownedDEPAssignments marks the assignment records Apple has disowned as
+// deleted — the same thing the DEP syncer does on a deleted op_type, which Apple
+// never sends on release. The restore path declines to recreate a host whose
+// assignment is marked deleted, so this is what makes the delete stick.
+//
+// Marks by host rather than DeleteHostDEPAssignments, which is keyed by Apple
+// Business token (so it cannot express an assignment that has lost its token) and
+// additionally deletes pending host rows — a side effect the delete path doesn't
+// want, since the host it was asked to delete is about to go anyway.
+//
+// Deliberately not in the same transaction as the host delete that follows. The
+// record is marked because Apple said the device is not ours, which holds whether
+// or not that delete then succeeds: a failed delete leaves the record more
+// accurate than it was, and the retry succeeds because no live assignment is left
+// to restore from.
+func (svc *Service) clearDisownedDEPAssignments(ctx context.Context, checks map[uint]depDeleteResult) error {
+	var hostIDs []uint
+	for hostID, c := range checks {
+		if c.check == depDeleteDisowned {
+			hostIDs = append(hostIDs, hostID)
+		}
+	}
+	if len(hostIDs) == 0 {
+		return nil
+	}
+	if err := svc.ds.MarkHostDEPAssignmentsDeleted(ctx, hostIDs); err != nil {
+		return ctxerr.Wrap(ctx, err, "clearing disowned dep assignments")
+	}
+	return nil
+}
+
+// unverifiedABMHostsError reports the hosts a bulk delete left in place because
+// Apple could not be asked about them, carrying one of the underlying Apple
+// failures so the cause is not lost.
+func unverifiedABMHostsError(checks map[uint]depDeleteResult, names []string) error {
+	var appleErr error
+	for _, c := range checks {
+		if c.check == depDeleteUnverified && c.appleErr != nil {
+			appleErr = c.appleErr
+			break
+		}
+	}
+	return fleet.NewBadGatewayError(
+		fmt.Sprintf("%s Hosts: %s.", fleet.CantDeleteHostUnverifiedABMMessage, strings.Join(names, ", ")),
+		appleErr,
+	)
+}

--- a/server/service/hosts_dep_verify_test.go
+++ b/server/service/hosts_dep_verify_test.go
@@ -1,0 +1,507 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/server/contexts/license"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
+	nanodep_client "github.com/fleetdm/fleet/v4/server/mdm/nanodep/client"
+	"github.com/fleetdm/fleet/v4/server/mdm/nanodep/godep"
+	"github.com/fleetdm/fleet/v4/server/mock"
+	nanodep_mock "github.com/fleetdm/fleet/v4/server/mock/nanodep"
+	"github.com/fleetdm/fleet/v4/server/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testABMTokenID = uint(9)
+
+// depVerifyEnv wires a service against a fake Apple DEP API. statusFor decides
+// what Apple answers for a given serial: an empty string omits it from the
+// response entirely.
+type depVerifyEnv struct {
+	svc      *Service
+	ctx      context.Context
+	ds       *mock.Store
+	requests func() int
+	// batchSizes reports how many serials each /devices request carried, in order.
+	batchSizes func() []int
+	// orgNames reports the Apple Business organizations the client authenticated as.
+	orgNames func() []string
+}
+
+func newDEPVerifyEnv(t *testing.T, statusFor func(serial string) string, failDevices bool) *depVerifyEnv {
+	t.Helper()
+
+	var mu sync.Mutex
+	var deviceRequests int
+	var batchSizes []int
+	var orgNames []string
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/session":
+			_, err := w.Write([]byte(`{"auth_session_token": "yoo"}`))
+			assert.NoError(t, err)
+		case "/devices":
+			mu.Lock()
+			deviceRequests++
+			mu.Unlock()
+
+			if failDevices {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+
+			var req struct {
+				Devices []string `json:"devices"`
+			}
+			assert.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+
+			mu.Lock()
+			batchSizes = append(batchSizes, len(req.Devices))
+			mu.Unlock()
+
+			devices := map[string]any{}
+			for _, serial := range req.Devices {
+				status := statusFor(serial)
+				if status == "" {
+					continue
+				}
+				devices[serial] = map[string]any{"serial_number": serial, "response_status": status}
+			}
+			assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{"devices": devices}))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(ts.Close)
+
+	depStorage := &nanodep_mock.Storage{}
+	depStorage.RetrieveAuthTokensFunc = func(ctx context.Context, name string) (*nanodep_client.OAuth1Tokens, error) {
+		return &nanodep_client.OAuth1Tokens{}, nil
+	}
+	depStorage.RetrieveConfigFunc = func(_ context.Context, name string) (*nanodep_client.Config, error) {
+		mu.Lock()
+		orgNames = append(orgNames, name)
+		mu.Unlock()
+		return &nanodep_client.Config{BaseURL: ts.URL}, nil
+	}
+
+	ds := new(mock.Store)
+	svc, ctx := newTestService(t, ds, nil, nil, &TestServerOpts{DEPStorage: depStorage})
+	ctx = test.UserContext(ctx, test.UserAdmin)
+	ctx = license.NewContext(ctx, &fleet.LicenseInfo{Tier: fleet.TierPremium})
+
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		ac := &fleet.AppConfig{}
+		ac.MDM.AppleBMEnabledAndConfigured = true
+		return ac, nil
+	}
+	ds.GetABMTokenByIDFunc = func(ctx context.Context, tokenID uint) (*fleet.ABMToken, error) {
+		return &fleet.ABMToken{ID: tokenID, OrganizationName: "org"}, nil
+	}
+	// The DEP client's after-hook runs on every request to keep the token's
+	// validity flags in sync.
+	ds.SetABMTokenInvalidForOrgNameFunc = func(ctx context.Context, orgName string, invalid bool) (bool, error) {
+		return false, nil
+	}
+	ds.IsABMTokenInvalidForOrgNameFunc = func(ctx context.Context, orgName string) (bool, error) {
+		return false, nil
+	}
+	ds.CountABMTokensWithTermsExpiredFunc = func(ctx context.Context) (int, error) {
+		return 0, nil
+	}
+
+	return &depVerifyEnv{
+		svc: svc.(validationMiddleware).Service.(*Service),
+		ctx: ctx,
+		ds:  ds,
+		requests: func() int {
+			mu.Lock()
+			defer mu.Unlock()
+			return deviceRequests
+		},
+		batchSizes: func() []int {
+			mu.Lock()
+			defer mu.Unlock()
+			return append([]int(nil), batchSizes...)
+		},
+		orgNames: func() []string {
+			mu.Lock()
+			defer mu.Unlock()
+			return append([]string(nil), orgNames...)
+		},
+	}
+}
+
+func liveAssignment(hostID uint, serial string) *fleet.HostDEPAssignment {
+	tok := testABMTokenID
+	return &fleet.HostDEPAssignment{HostID: hostID, ABMTokenID: &tok, HardwareSerial: serial}
+}
+
+func TestCheckDEPAssignmentsForDelete(t *testing.T) {
+	// Apple's answer for a serial decides whether the delete can stand. Only a
+	// failure to answer blocks it.
+	cases := []struct {
+		name   string
+		status string
+		want   depDeleteCheck
+	}{
+		{"released from Apple Business", "NOT_ACCESSIBLE", depDeleteDisowned},
+		{"still assigned", "SUCCESS", depDeleteAssigned},
+		{"apple reports the lookup failed", "FAILED", depDeleteUnverified},
+		{"apple omits the serial", "", depDeleteAssigned},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env := newDEPVerifyEnv(t, func(string) string { return tc.status }, false)
+			env.ds.GetHostDEPAssignmentsByHostIDsFunc = func(ctx context.Context, ids []uint) ([]*fleet.HostDEPAssignment, error) {
+				return []*fleet.HostDEPAssignment{liveAssignment(1, "SERIAL1")}, nil
+			}
+
+			checks, err := env.svc.checkDEPAssignmentsForDelete(env.ctx, []*fleet.Host{{ID: 1, HardwareSerial: "SERIAL1"}})
+			require.NoError(t, err)
+			require.Equal(t, tc.want, checks[1].check)
+		})
+	}
+
+	t.Run("apple unreachable blocks the delete", func(t *testing.T) {
+		env := newDEPVerifyEnv(t, func(string) string { return "SUCCESS" }, true)
+		env.ds.GetHostDEPAssignmentsByHostIDsFunc = func(ctx context.Context, ids []uint) ([]*fleet.HostDEPAssignment, error) {
+			return []*fleet.HostDEPAssignment{liveAssignment(1, "SERIAL1")}, nil
+		}
+
+		checks, err := env.svc.checkDEPAssignmentsForDelete(env.ctx, []*fleet.Host{{ID: 1, HardwareSerial: "SERIAL1"}})
+		require.NoError(t, err, "an Apple failure is a verdict, not an error")
+		require.Equal(t, depDeleteUnverified, checks[1].check)
+	})
+
+	t.Run("no live assignment means nothing to verify", func(t *testing.T) {
+		env := newDEPVerifyEnv(t, func(string) string { return "SUCCESS" }, false)
+		env.ds.GetHostDEPAssignmentsByHostIDsFunc = func(ctx context.Context, ids []uint) ([]*fleet.HostDEPAssignment, error) {
+			return nil, nil
+		}
+
+		checks, err := env.svc.checkDEPAssignmentsForDelete(env.ctx, []*fleet.Host{{ID: 1, HardwareSerial: "SERIAL1"}})
+		require.NoError(t, err)
+		require.Equal(t, depDeleteNoAssignment, checks[1].check)
+		require.Zero(t, env.requests(), "Apple must not be called for a host that cannot be restored")
+	})
+
+	// Removing an Apple Business token from Fleet nulls out abm_token_id on every
+	// assignment it owned (ON DELETE SET NULL). There is no organization left to
+	// ask, and nothing can restore the host through a token that is gone, so the
+	// record is cleared rather than the delete being blocked forever.
+	t.Run("assignment whose Apple Business token was removed", func(t *testing.T) {
+		env := newDEPVerifyEnv(t, func(string) string { return "SUCCESS" }, false)
+		env.ds.GetHostDEPAssignmentsByHostIDsFunc = func(ctx context.Context, ids []uint) ([]*fleet.HostDEPAssignment, error) {
+			return []*fleet.HostDEPAssignment{{HostID: 1, ABMTokenID: nil, HardwareSerial: "SERIAL1"}}, nil
+		}
+
+		checks, err := env.svc.checkDEPAssignmentsForDelete(env.ctx, []*fleet.Host{{ID: 1, HardwareSerial: "SERIAL1"}})
+		require.NoError(t, err)
+		require.Equal(t, depDeleteDisowned, checks[1].check)
+		require.Zero(t, env.requests(), "there is no organization to ask")
+	})
+
+	t.Run("free tier never calls apple", func(t *testing.T) {
+		env := newDEPVerifyEnv(t, func(string) string { return "SUCCESS" }, false)
+		env.ctx = license.NewContext(env.ctx, &fleet.LicenseInfo{Tier: fleet.TierFree})
+
+		checks, err := env.svc.checkDEPAssignmentsForDelete(env.ctx, []*fleet.Host{{ID: 1, HardwareSerial: "SERIAL1"}})
+		require.NoError(t, err)
+		require.Equal(t, depDeleteNoAssignment, checks[1].check)
+		require.Zero(t, env.requests())
+		require.False(t, env.ds.GetHostDEPAssignmentsByHostIDsFuncInvoked)
+	})
+
+	t.Run("serials are chunked to Apple's per-request ceiling", func(t *testing.T) {
+		total := apple_mdm.DEPSyncLimit + 50
+
+		env := newDEPVerifyEnv(t, func(string) string { return "NOT_ACCESSIBLE" }, false)
+		hosts := make([]*fleet.Host, 0, total)
+		assignments := make([]*fleet.HostDEPAssignment, 0, total)
+		for i := 1; i <= total; i++ {
+			serial := fmt.Sprintf("SERIAL%d", i)
+			hosts = append(hosts, &fleet.Host{ID: uint(i), HardwareSerial: serial}) //nolint:gosec // test data
+			assignments = append(assignments, liveAssignment(uint(i), serial))      //nolint:gosec // test data
+		}
+		env.ds.GetHostDEPAssignmentsByHostIDsFunc = func(ctx context.Context, ids []uint) ([]*fleet.HostDEPAssignment, error) {
+			return assignments, nil
+		}
+
+		checks, err := env.svc.checkDEPAssignmentsForDelete(env.ctx, hosts)
+		require.NoError(t, err)
+		require.Len(t, checks, total)
+		for _, h := range hosts {
+			require.Equal(t, depDeleteDisowned, checks[h.ID].check, "host %d", h.ID)
+		}
+		require.Equal(t, []int{apple_mdm.DEPSyncLimit, 50}, env.batchSizes(),
+			"serials must go out in batches, not one request per host")
+	})
+
+	t.Run("Apple Business not configured skips the check", func(t *testing.T) {
+		env := newDEPVerifyEnv(t, func(string) string { return "SUCCESS" }, false)
+		env.ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+			return &fleet.AppConfig{}, nil // AppleBMEnabledAndConfigured false
+		}
+
+		checks, err := env.svc.checkDEPAssignmentsForDelete(env.ctx, []*fleet.Host{{ID: 1, HardwareSerial: "SERIAL1"}})
+		require.NoError(t, err)
+		require.Equal(t, depDeleteNoAssignment, checks[1].check)
+		require.Zero(t, env.requests())
+	})
+
+	// Each Apple Business token authenticates as its own organization, so a serial
+	// must only ever be asked about under the token that owns it. Asking the wrong
+	// organization returns NOT_ACCESSIBLE, which would read as "released" and
+	// delete a perfectly healthy host.
+	t.Run("serials are asked under their own Apple Business token", func(t *testing.T) {
+		env := newDEPVerifyEnv(t, func(serial string) string {
+			if serial == "SERIAL-A" {
+				return "NOT_ACCESSIBLE"
+			}
+			return "SUCCESS"
+		}, false)
+
+		tokenA, tokenB := uint(1), uint(2)
+		env.ds.GetHostDEPAssignmentsByHostIDsFunc = func(ctx context.Context, ids []uint) ([]*fleet.HostDEPAssignment, error) {
+			return []*fleet.HostDEPAssignment{
+				{HostID: 1, ABMTokenID: &tokenA, HardwareSerial: "SERIAL-A"},
+				{HostID: 2, ABMTokenID: &tokenB, HardwareSerial: "SERIAL-B"},
+			}, nil
+		}
+		env.ds.GetABMTokenByIDFunc = func(ctx context.Context, tokenID uint) (*fleet.ABMToken, error) {
+			return &fleet.ABMToken{ID: tokenID, OrganizationName: fmt.Sprintf("org-%d", tokenID)}, nil
+		}
+
+		checks, err := env.svc.checkDEPAssignmentsForDelete(env.ctx, []*fleet.Host{
+			{ID: 1, HardwareSerial: "SERIAL-A"},
+			{ID: 2, HardwareSerial: "SERIAL-B"},
+		})
+		require.NoError(t, err)
+		require.Equal(t, depDeleteDisowned, checks[1].check)
+		require.Equal(t, depDeleteAssigned, checks[2].check)
+
+		require.Equal(t, 2, env.requests(), "one request per organization")
+		require.ElementsMatch(t, []string{"org-1", "org-2"}, env.orgNames())
+		require.Equal(t, []int{1, 1}, env.batchSizes(), "a token's serials must not leak into another token's request")
+	})
+}
+
+func TestDeleteHostVerifiesAppleBusinessAssignment(t *testing.T) {
+	// Wires the delete through to the MDM lifecycle, which is where the decision
+	// to recreate the host as a pending ADE host actually happens.
+	setupHost := func(env *depVerifyEnv) *bool { //nolint:revive // pointer lets subtests read the flag
+		var cleared bool
+
+		env.ds.HostLiteFunc = func(ctx context.Context, id uint) (*fleet.Host, error) {
+			return &fleet.Host{ID: id, HardwareSerial: "SERIAL1", Platform: "darwin"}, nil
+		}
+		env.ds.GetHostDEPAssignmentsByHostIDsFunc = func(ctx context.Context, ids []uint) ([]*fleet.HostDEPAssignment, error) {
+			return []*fleet.HostDEPAssignment{liveAssignment(1, "SERIAL1")}, nil
+		}
+		env.ds.DeleteHostFunc = func(ctx context.Context, hid uint) error { return nil }
+		env.ds.MarkHostDEPAssignmentsDeletedFunc = func(ctx context.Context, hostIDs []uint) error {
+			cleared = len(hostIDs) > 0
+			return nil
+		}
+		// What the lifecycle reads to decide whether to restore the host.
+		env.ds.GetHostDEPAssignmentFunc = func(ctx context.Context, hostID uint) (*fleet.HostDEPAssignment, error) {
+			a := liveAssignment(hostID, "SERIAL1")
+			if cleared {
+				a.DeletedAt = new(time.Now())
+			}
+			return a, nil
+		}
+		env.ds.ReconcileDuplicateDEPHostOnDeleteFunc = func(ctx context.Context, serial, platform string, deletedHostID uint) (bool, error) {
+			return false, nil
+		}
+		env.ds.RestoreMDMApplePendingDEPHostFunc = func(ctx context.Context, h *fleet.Host) error { return nil }
+		env.ds.NewJobFunc = func(ctx context.Context, job *fleet.Job) (*fleet.Job, error) { return job, nil }
+
+		return &cleared
+	}
+
+	t.Run("apple unreachable leaves the host in place", func(t *testing.T) {
+		env := newDEPVerifyEnv(t, func(string) string { return "SUCCESS" }, true)
+		setupHost(env)
+
+		err := env.svc.DeleteHost(env.ctx, 1)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), fleet.CantDeleteHostUnverifiedABMMessage)
+		require.False(t, env.ds.DeleteHostFuncInvoked, "nothing may be deleted when Apple can't be reached")
+
+		// An upstream Apple failure is not the caller's fault, so it must not come
+		// back as a 4xx telling them to fix their request.
+		var gwErr *fleet.GatewayError
+		require.ErrorAs(t, err, &gwErr)
+		require.Equal(t, http.StatusBadGateway, gwErr.StatusCode())
+	})
+
+	t.Run("released host stays deleted", func(t *testing.T) {
+		env := newDEPVerifyEnv(t, func(string) string { return "NOT_ACCESSIBLE" }, false)
+		cleared := setupHost(env)
+
+		require.NoError(t, env.svc.DeleteHost(env.ctx, 1))
+		require.True(t, env.ds.DeleteHostFuncInvoked)
+		require.True(t, *cleared, "the stale assignment must be marked deleted")
+		// The point of clearing the assignment: the lifecycle no longer recreates
+		// the host, so the "deleted" activity is not a lie.
+		require.False(t, env.ds.RestoreMDMApplePendingDEPHostFuncInvoked)
+	})
+
+	t.Run("still-assigned host is restored as before", func(t *testing.T) {
+		env := newDEPVerifyEnv(t, func(string) string { return "SUCCESS" }, false)
+		cleared := setupHost(env)
+
+		require.NoError(t, env.svc.DeleteHost(env.ctx, 1))
+		require.True(t, env.ds.DeleteHostFuncInvoked)
+		require.False(t, *cleared, "a device Apple still owns must keep its assignment")
+		require.True(t, env.ds.RestoreMDMApplePendingDEPHostFuncInvoked, "a device Apple still owns must keep coming back")
+	})
+}
+
+// A bulk delete must not be all-or-nothing: hosts Apple couldn't answer for are
+// left alone and reported, while the rest of the batch still goes through.
+func TestDeleteHostsSkipsHostsAppleCouldNotVerify(t *testing.T) {
+	const (
+		releasedHost   = uint(1) // Apple says it is not ours -> deleted for good
+		assignedHost   = uint(2) // Apple says it is ours -> deleted, then restored
+		unverifiedHost = uint(3) // Apple's lookup failed -> left in place
+	)
+	serials := map[uint]string{releasedHost: "SERIAL-REL", assignedHost: "SERIAL-ASG", unverifiedHost: "SERIAL-UNV"}
+
+	env := newDEPVerifyEnv(t, func(serial string) string {
+		switch serial {
+		case "SERIAL-REL":
+			return "NOT_ACCESSIBLE"
+		case "SERIAL-UNV":
+			return "FAILED"
+		default:
+			return "SUCCESS"
+		}
+	}, false)
+
+	var cleared []string
+	env.ds.HostLiteFunc = func(ctx context.Context, id uint) (*fleet.Host, error) {
+		return &fleet.Host{ID: id, HardwareSerial: serials[id], Platform: "darwin"}, nil
+	}
+	env.ds.ListHostsLiteByIDsFunc = func(ctx context.Context, ids []uint) ([]*fleet.Host, error) {
+		hosts := make([]*fleet.Host, 0, len(ids))
+		for _, id := range ids {
+			hosts = append(hosts, &fleet.Host{ID: id, HardwareSerial: serials[id], Platform: "darwin"})
+		}
+		return hosts, nil
+	}
+	env.ds.GetHostDEPAssignmentsByHostIDsFunc = func(ctx context.Context, ids []uint) ([]*fleet.HostDEPAssignment, error) {
+		out := make([]*fleet.HostDEPAssignment, 0, len(ids))
+		for _, id := range ids {
+			out = append(out, liveAssignment(id, serials[id]))
+		}
+		return out, nil
+	}
+	env.ds.MarkHostDEPAssignmentsDeletedFunc = func(ctx context.Context, hostIDs []uint) error {
+		for _, id := range hostIDs {
+			cleared = append(cleared, serials[id])
+		}
+		return nil
+	}
+	env.ds.GetHostDEPAssignmentFunc = func(ctx context.Context, hostID uint) (*fleet.HostDEPAssignment, error) {
+		a := liveAssignment(hostID, serials[hostID])
+		for _, s := range cleared {
+			if s == serials[hostID] {
+				a.DeletedAt = new(time.Now())
+			}
+		}
+		return a, nil
+	}
+	env.ds.ReconcileDuplicateDEPHostOnDeleteFunc = func(ctx context.Context, serial, platform string, deletedHostID uint) (bool, error) {
+		return false, nil
+	}
+	env.ds.RestoreMDMApplePendingDEPHostFunc = func(ctx context.Context, h *fleet.Host) error { return nil }
+	env.ds.NewJobFunc = func(ctx context.Context, job *fleet.Job) (*fleet.Job, error) { return job, nil }
+
+	var deleted []uint
+	env.ds.DeleteHostsFunc = func(ctx context.Context, ids []uint) error {
+		deleted = append(deleted, ids...)
+		return nil
+	}
+
+	err := env.svc.DeleteHosts(env.ctx, []uint{releasedHost, assignedHost, unverifiedHost}, nil)
+
+	// The caller is told which hosts were left behind, by name.
+	require.Error(t, err)
+	require.Contains(t, err.Error(), fleet.CantDeleteHostUnverifiedABMMessage)
+	require.Contains(t, err.Error(), serials[unverifiedHost])
+
+	require.ElementsMatch(t, []uint{releasedHost, assignedHost}, deleted,
+		"the rest of the batch must still be deleted")
+	require.Equal(t, []string{serials[releasedHost]}, cleared,
+		"only the released host's assignment may be cleared")
+}
+
+func TestClassifyDEPDeviceDetails(t *testing.T) {
+	// Only Apple failing to answer blocks a delete. Silence about a serial is
+	// unexpected but is read as "still ours", so one Apple quirk can't stop
+	// deletions across a fleet.
+	cases := []struct {
+		name    string
+		details *godep.DeviceDetails
+		want    depDeleteCheck
+	}{
+		{"not accessible", &godep.DeviceDetails{ResponseStatus: "NOT_ACCESSIBLE"}, depDeleteDisowned},
+		{"lookup failed", &godep.DeviceDetails{ResponseStatus: "FAILED"}, depDeleteUnverified},
+		{"success", &godep.DeviceDetails{ResponseStatus: "SUCCESS"}, depDeleteAssigned},
+		{"unrecognised status", &godep.DeviceDetails{ResponseStatus: "SOMETHING_NEW"}, depDeleteAssigned},
+		{"serial not mentioned at all", nil, depDeleteAssigned},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, classifyDEPDeviceDetails(tc.details))
+		})
+	}
+}
+
+// When Apple can't be reached for any host in the batch there is nothing left to
+// delete, so the caller gets the failure rather than a silent no-op.
+func TestDeleteHostsWhenNoHostCanBeVerified(t *testing.T) {
+	env := newDEPVerifyEnv(t, func(string) string { return "SUCCESS" }, true)
+
+	serials := map[uint]string{1: "SERIAL-A", 2: "SERIAL-B"}
+	env.ds.HostLiteFunc = func(ctx context.Context, id uint) (*fleet.Host, error) {
+		return &fleet.Host{ID: id, HardwareSerial: serials[id], Platform: "darwin"}, nil
+	}
+	env.ds.ListHostsLiteByIDsFunc = func(ctx context.Context, ids []uint) ([]*fleet.Host, error) {
+		return []*fleet.Host{
+			{ID: 1, HardwareSerial: serials[1], Platform: "darwin"},
+			{ID: 2, HardwareSerial: serials[2], Platform: "darwin"},
+		}, nil
+	}
+	env.ds.GetHostDEPAssignmentsByHostIDsFunc = func(ctx context.Context, ids []uint) ([]*fleet.HostDEPAssignment, error) {
+		return []*fleet.HostDEPAssignment{liveAssignment(1, serials[1]), liveAssignment(2, serials[2])}, nil
+	}
+	env.ds.MarkHostDEPAssignmentsDeletedFunc = func(ctx context.Context, hostIDs []uint) error { return nil }
+	env.ds.DeleteHostsFunc = func(ctx context.Context, ids []uint) error { return nil }
+
+	err := env.svc.DeleteHosts(env.ctx, []uint{1, 2}, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), serials[1])
+	require.Contains(t, err.Error(), serials[2])
+	require.False(t, env.ds.DeleteHostsFuncInvoked, "nothing may be deleted when no host could be verified")
+
+	var gwErr *fleet.GatewayError
+	require.ErrorAs(t, err, &gwErr)
+	require.Equal(t, http.StatusBadGateway, gwErr.StatusCode())
+}

--- a/server/service/hosts_dep_verify_test.go
+++ b/server/service/hosts_dep_verify_test.go
@@ -447,6 +447,9 @@ func TestDeleteHostsSkipsHostsAppleCouldNotVerify(t *testing.T) {
 
 	require.ElementsMatch(t, []uint{releasedHost, assignedHost}, deleted,
 		"the rest of the batch must still be deleted")
+	// A caller must be able to tell a partial delete from one that removed nothing,
+	// so it knows whether retrying the whole request is safe.
+	require.Contains(t, err.Error(), "The other 2 host(s) were deleted.")
 	require.Equal(t, []string{serials[releasedHost]}, cleared,
 		"only the released host's assignment may be cleared")
 }
@@ -499,6 +502,7 @@ func TestDeleteHostsWhenNoHostCanBeVerified(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), serials[1])
 	require.Contains(t, err.Error(), serials[2])
+	require.NotContains(t, err.Error(), "were deleted", "nothing was deleted, so the message must not imply otherwise")
 	require.False(t, env.ds.DeleteHostsFuncInvoked, "nothing may be deleted when no host could be verified")
 
 	var gwErr *fleet.GatewayError

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -1079,9 +1079,36 @@ func (s *integrationMDMTestSuite) TearDownTest() {
 	s.androidAPIClient.EnterprisesDevicesPatchFuncInvoked = false
 }
 
+// withDEPDeviceDetails answers Apple's "Get Device Details" endpoint, which host
+// deletion consults to tell a device released from Apple Business apart from one
+// Fleet still owns. Every requested serial is reported as still assigned, which is
+// the state these suites set up; without this the lookup fails and deletes are
+// refused. Tests needing a different answer should serve /devices themselves and
+// bypass this wrapper.
+func withDEPDeviceDetails(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/devices" {
+			handler.ServeHTTP(w, r)
+			return
+		}
+
+		var req struct {
+			Devices []string `json:"devices"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+
+		devices := make(map[string]any, len(req.Devices))
+		for _, serial := range req.Devices {
+			devices[serial] = map[string]any{"serial_number": serial, "response_status": "SUCCESS"}
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"devices": devices})
+	})
+}
+
 func (s *integrationMDMTestSuite) mockDEPResponse(orgName string, handler http.Handler) {
 	t := s.T()
-	srv := httptest.NewServer(handler)
+	srv := httptest.NewServer(withDEPDeviceDetails(handler))
 	err := s.depStorage.StoreConfig(context.Background(), orgName, &nanodep_client.Config{BaseURL: srv.URL})
 	depSvc := apple_mdm.NewDEPService(s.ds, s.depStorage, s.logger)
 	require.NoError(t, depSvc.CreateDefaultAutomaticProfile(context.Background()))

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -1095,14 +1095,21 @@ func withDEPDeviceDetails(handler http.Handler) http.Handler {
 		var req struct {
 			Devices []string `json:"devices"`
 		}
-		_ = json.NewDecoder(r.Body).Decode(&req)
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			// Fail loudly rather than answering an unreadable request, so a client
+			// regression shows up here instead of as a puzzling downstream result.
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
 
 		devices := make(map[string]any, len(req.Devices))
 		for _, serial := range req.Devices {
 			devices[serial] = map[string]any{"serial_number": serial, "response_status": "SUCCESS"}
 		}
 		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(map[string]any{"devices": devices})
+		if err := json.NewEncoder(w).Encode(map[string]any{"devices": devices}); err != nil {
+			panic(err)
+		}
 	})
 }
 


### PR DESCRIPTION
**Related issue:** Resolves #49268

Releasing a device from Apple Business never sends the `deleted` op_type that would clear its `host_dep_assignments` row, so the row outlives the assignment. Deleting the host then wrote a "host deleted" activity and immediately recreated the host as pending, and the only repair was setting `deleted_at` by hand.

Fleet now asks Apple whether the device is still assigned before deleting an ADE host:

- **Not assigned** — mark the assignment deleted first, the same thing the DEP syncer does on a `deleted` op_type, so the lifecycle declines to restore the host. An assignment left without an ABM token is treated the same way: there is no organization left to ask, and nothing that could restore through it.
- **Still assigned** — unchanged, the host is deleted and recreated as pending.
- **Apple unreachable** — the delete is refused (502) rather than reported as a success that reverses itself.

Hosts without a live ADE assignment, free tier, and deployments without Apple Business are unaffected and make no Apple call.

Bulk deletes ask Apple once per 200 serials per ABM token, grouped by token since each authenticates as a different organization. Hosts Apple could not be asked about are left in place and named in the error; the rest of the batch is still deleted.

## Notes for the reviewer

- **Bulk delete returns 202 after 30s** and finishes in a detached goroutine, so the skipped-hosts error may never reach the caller on large batches. Reporting partial results reliably would need a job/status surface, which felt out of scope here.
- **`MarkHostDEPAssignmentsDeleted` is used rather than `DeleteHostDEPAssignments`**, against the latter's doc comment. `DeleteHostDEPAssignments` is keyed by ABM token (so it cannot express an assignment that lost its token) and also deletes pending host rows matching the serial — a side effect this path does not want. The doc comment has been updated to explain when each applies.
- **The assignment is marked deleted before the host delete, outside a transaction.** This is deliberate: the record is marked because Apple said the device is not ours, which holds whether or not the delete then succeeds. A failed delete leaves the record more accurate than it was, and the retry succeeds because no live assignment remains.
- **The DEP test mock now answers Get Device Details.** Host deletion consults it in production; the suite's fake server did not serve it, so every ADE host delete was refused.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Host deletion now verifies Apple Business Manager assignments before proceeding.
  * Hosts with unverified assignments are protected from deletion, while eligible hosts continue to be deleted during bulk operations.
  * Apple connectivity or verification failures now return an error instead of reporting a successful deletion.
  * Disowned Apple assignments are cleared to prevent stale records from restoring deleted hosts.
  * Apple assignment checks now support multiple hosts efficiently during bulk deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->