### PR TITLE
Clarify package order and update labels in YAML docs

### DIFF
--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -694,7 +694,7 @@ If multiple packages target the same host, Fleet will install the one that was a
 
 > In GitOps, the first package added is the first one in the package YAML file's list on the initial run that adds the title's packages. Reordering the list on a later run doesn't change the order.
 >
-> You can preview the order of the packages in the UI. The first package in the list is always a fallback in case of a conflict.
+> You can preview the order of the packages in the UI. The first package in the list is always a fallback in case multiple packages are scoped to the same host.
 
 `fleets/fleet-name.yml`, or `fleets/unassigned.yml`
 
@@ -711,8 +711,8 @@ software:
   install_script:
     path: ../lib/software/santa-install-script.sh
   self_service: true
-  labels_include_all:
-    - macOS
+  labels_exclude_any:
+    - IT test team
 - url: https://github.com/northpolesec/santa/releases/download/2026.4/santa-2026.4.pkg
   install_script:
     path: ../lib/software/santa-install-script.sh
@@ -720,7 +720,6 @@ software:
   categories:
     - "💻 Productivity"
   labels_include_all:
-    - macOS
     - IT test team
 ```
 


### PR DESCRIPTION
- Example YAML was incorrect.
- Clarified what conflict means, it wasn't explicit.