### PR TITLE
Fix Clear passcode modal checkbox color mismatch

### DIFF
--- a/changes/clear-passcode-checkbox-color
+++ b/changes/clear-passcode-checkbox-color
@@ -1,0 +1,1 @@
+- Fixed the confirmation checkbox on the "Clear passcode" host modal rendering in green instead of red, so it now matches the destructive "Clear passcode" button.

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/ClearPasscodeModal/ClearPasscodeModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/ClearPasscodeModal/ClearPasscodeModal.tsx
@@ -86,6 +86,7 @@ const ClearPasscodeModal = ({
             wrapperClassName={`${baseClass}__clear-checkbox`}
             value={confirmChecked}
             onChange={(value: boolean) => setConfirmChecked(value)}
+            variant="danger"
           >
             I wish to clear the passcode for <b>{hostName}</b>
           </Checkbox>


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** N/A

## Summary

The confirmation checkbox in the "Clear passcode" host modal rendered in the default green color while its CTA button ("Clear passcode") is red (`alert` variant) — a mismatch. Sibling destructive modals (`WipeModal`, `ReleaseFromABModal`) already use the checkbox's `danger` variant to match their red CTA buttons; this was just missed on `ClearPasscodeModal`.

Audited every modal in the frontend that pairs a `Checkbox` with a destructive (`alert`-variant) button; `ClearPasscodeModal` was the only one with a mismatch.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually (verified the `danger` checkbox variant renders red via Storybook, matching the `alert` button color already used identically in `WipeModal`/`ReleaseFromABModal`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the “Clear passcode” confirmation checkbox to use the same danger styling as the action button.
  * Improved visual consistency in the confirmation modal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->