### PR TITLE
Let Save activate when adding a package in GitOps mode

### DIFF
--- a/changes/50953-gitops-add-package-save.md
+++ b/changes/50953-gitops-add-package-save.md
@@ -1,0 +1,1 @@
+- Fixed the **Save** button never activating when adding a package from the software title page while GitOps mode is enabled.

--- a/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tests.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tests.tsx
@@ -1,11 +1,12 @@
 import React from "react";
-import { screen } from "@testing-library/react";
+import { render as renderComponent, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { createCustomRenderer } from "test/test-utils";
 import { createMockSoftwarePackage } from "__mocks__/softwareMock";
 import { notify } from "components/ToastNotification";
 import { IConfig } from "interfaces/config";
+import { AppContext, IAppContext } from "context/app";
 
 import PackageForm from "./PackageForm";
 
@@ -172,6 +173,32 @@ describe("PackageForm", () => {
       // GitOps mode hides the selector, so the user can't pick labels. A
       // preselected "Custom" would leave Save disabled with nothing on screen
       // to explain why.
+      expect(screen.queryByLabelText("Custom")).not.toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Save" })).not.toBeDisabled();
+    });
+
+    it("normalizes the target when config arrives after mount", async () => {
+      // `config` is fetched asynchronously and App renders its children before
+      // it resolves, so GitOps mode is often unknown on the first render and
+      // the form mounts holding the preselected "Custom". Rendering through
+      // AppContext directly is what lets the config value change afterwards.
+      const renderWithConfig = (config: Partial<IConfig> | null) => (
+        <AppContext.Provider
+          value={({ config, isPremiumTier: true } as unknown) as IAppContext}
+        >
+          <PackageForm
+            {...BASE_PROPS}
+            multiPackageContext
+            initialTargetType="Custom"
+          />
+        </AppContext.Provider>
+      );
+
+      const { container, rerender } = renderComponent(renderWithConfig(null));
+      rerender(renderWithConfig(gitOpsConfig));
+
+      await selectFileOfSize(container, 1024);
+
       expect(screen.queryByLabelText("Custom")).not.toBeInTheDocument();
       expect(screen.getByRole("button", { name: "Save" })).not.toBeDisabled();
     });

--- a/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tests.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tests.tsx
@@ -162,6 +162,22 @@ describe("PackageForm", () => {
       },
     } as Partial<IConfig>;
 
+    // `config` is fetched asynchronously and App renders its children before it
+    // resolves, so GitOps mode is often unknown on the first render. Rendering
+    // through AppContext directly is what lets the config value change after
+    // mount, which `createCustomRenderer` fixes in place.
+    const renderWithConfig = (config: Partial<IConfig> | null) => (
+      <AppContext.Provider
+        value={({ config, isPremiumTier: true } as unknown) as IAppContext}
+      >
+        <PackageForm
+          {...BASE_PROPS}
+          multiPackageContext
+          initialTargetType="Custom"
+        />
+      </AppContext.Provider>
+    );
+
     it("enables Save even though the target selector is hidden", async () => {
       const { container } = renderForm(
         { multiPackageContext: true, initialTargetType: "Custom" },
@@ -178,28 +194,24 @@ describe("PackageForm", () => {
     });
 
     it("normalizes the target when config arrives after mount", async () => {
-      // `config` is fetched asynchronously and App renders its children before
-      // it resolves, so GitOps mode is often unknown on the first render and
-      // the form mounts holding the preselected "Custom". Rendering through
-      // AppContext directly is what lets the config value change afterwards.
-      const renderWithConfig = (config: Partial<IConfig> | null) => (
-        <AppContext.Provider
-          value={({ config, isPremiumTier: true } as unknown) as IAppContext}
-        >
-          <PackageForm
-            {...BASE_PROPS}
-            multiPackageContext
-            initialTargetType="Custom"
-          />
-        </AppContext.Provider>
-      );
-
       const { container, rerender } = renderComponent(renderWithConfig(null));
       rerender(renderWithConfig(gitOpsConfig));
 
       await selectFileOfSize(container, 1024);
 
       expect(screen.queryByLabelText("Custom")).not.toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Save" })).not.toBeDisabled();
+    });
+
+    it("enables Save when the file is chosen before config arrives", async () => {
+      // The reverse ordering of the previous test: validation is computed on
+      // file select against the still-preselected "Custom", so normalizing the
+      // target afterwards has to refresh validation too.
+      const { container, rerender } = renderComponent(renderWithConfig(null));
+
+      await selectFileOfSize(container, 1024);
+      rerender(renderWithConfig(gitOpsConfig));
+
       expect(screen.getByRole("button", { name: "Save" })).not.toBeDisabled();
     });
 

--- a/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tests.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tests.tsx
@@ -151,4 +151,43 @@ describe("PackageForm", () => {
       expect(screen.getByLabelText("All hosts")).toBeInTheDocument();
     });
   });
+
+  describe("GitOps mode with a preselected Custom target", () => {
+    const gitOpsConfig = {
+      gitops: {
+        gitops_mode_enabled: true,
+        repository_url: "https://example.com/repo",
+        exceptions: { labels: false, software: false, secrets: false },
+      },
+    } as Partial<IConfig>;
+
+    it("enables Save even though the target selector is hidden", async () => {
+      const { container } = renderForm(
+        { multiPackageContext: true, initialTargetType: "Custom" },
+        gitOpsConfig
+      );
+
+      await selectFileOfSize(container, 1024);
+
+      // GitOps mode hides the selector, so the user can't pick labels. A
+      // preselected "Custom" would leave Save disabled with nothing on screen
+      // to explain why.
+      expect(screen.queryByLabelText("Custom")).not.toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Save" })).not.toBeDisabled();
+    });
+
+    it("keeps requiring labels for a Custom target when GitOps mode is off", async () => {
+      const { container } = renderForm({
+        multiPackageContext: true,
+        initialTargetType: "Custom",
+      });
+
+      await selectFileOfSize(container, 1024);
+
+      // The selector is visible here, so the preselection stands and the
+      // existing "pick at least one label" rule still applies.
+      expect(screen.getByLabelText("Custom")).toBeChecked();
+      expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+    });
+  });
 });

--- a/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
@@ -234,14 +234,18 @@ const PackageForm = ({
     if (!gitOpsModeEnabled) {
       return;
     }
-    setFormData((prev) => {
-      const hasLabelTargets = Object.values(prev.labelTargets).some(Boolean);
-      if (prev.targetType !== "Custom" || hasLabelTargets) {
-        return prev;
-      }
-      return { ...prev, targetType: "All hosts" };
-    });
-  }, [gitOpsModeEnabled]);
+    const hasLabelTargets = Object.values(formData.labelTargets).some(Boolean);
+    if (formData.targetType !== "Custom" || hasLabelTargets) {
+      return;
+    }
+    const normalized = { ...formData, targetType: "All hosts" };
+    setFormData(normalized);
+    // Validation is held in state and only recomputed on change handlers, so
+    // it has to be refreshed here too — otherwise a file chosen before config
+    // resolved leaves behind a failure for the target we just normalized away,
+    // and Save stays disabled.
+    setFormValidation(generateFormValidation(normalized));
+  }, [gitOpsModeEnabled, formData]);
 
   const notifyTooLarge = () => {
     const errorPrefix = isEditingSoftware

--- a/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
@@ -208,14 +208,7 @@ const PackageForm = ({
     postInstallScript: defaultPostInstallScript || "",
     uninstallScript: defaultUninstallScript || "",
     selfService: defaultSelfService || false,
-    // GitOps mode hides the target selector, so a preselected "Custom" would
-    // demand labels the user has no way to pick and the form could never
-    // validate — leaving Save permanently disabled with nothing on screen to
-    // explain it. Targeting comes from YAML in that mode, so fall back to the
-    // normal default.
-    targetType:
-      (gitOpsModeEnabled ? undefined : initialTargetType) ??
-      getTargetType(defaultSoftware),
+    targetType: initialTargetType ?? getTargetType(defaultSoftware),
     customTarget: getCustomTarget(defaultSoftware),
     labelTargets: generateSelectedLabels(defaultSoftware),
     automaticInstall: false,
@@ -227,6 +220,28 @@ const PackageForm = ({
     isValid: false,
     software: { isValid: false },
   });
+
+  // GitOps mode hides the target selector, so a "Custom" target with no labels
+  // can never be satisfied: the picker that would fix it isn't rendered, and
+  // Save stays disabled with nothing on screen to explain why. Targeting comes
+  // from YAML in that mode, so normalize to the default instead.
+  //
+  // This runs as an effect rather than in the initial state because `config`
+  // loads asynchronously — GitOps mode often isn't known yet on first render.
+  // Rows that already carry labels (the edit flow) are left alone so their
+  // targeting isn't silently dropped.
+  useEffect(() => {
+    if (!gitOpsModeEnabled) {
+      return;
+    }
+    setFormData((prev) => {
+      const hasLabelTargets = Object.values(prev.labelTargets).some(Boolean);
+      if (prev.targetType !== "Custom" || hasLabelTargets) {
+        return prev;
+      }
+      return { ...prev, targetType: "All hosts" };
+    });
+  }, [gitOpsModeEnabled]);
 
   const notifyTooLarge = () => {
     const errorPrefix = isEditingSoftware

--- a/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
@@ -208,7 +208,14 @@ const PackageForm = ({
     postInstallScript: defaultPostInstallScript || "",
     uninstallScript: defaultUninstallScript || "",
     selfService: defaultSelfService || false,
-    targetType: initialTargetType ?? getTargetType(defaultSoftware),
+    // GitOps mode hides the target selector, so a preselected "Custom" would
+    // demand labels the user has no way to pick and the form could never
+    // validate — leaving Save permanently disabled with nothing on screen to
+    // explain it. Targeting comes from YAML in that mode, so fall back to the
+    // normal default.
+    targetType:
+      (gitOpsModeEnabled ? undefined : initialTargetType) ??
+      getTargetType(defaultSoftware),
     customTarget: getCustomTarget(defaultSoftware),
     labelTargets: generateSelectedLabels(defaultSoftware),
     automaticInstall: false,


### PR DESCRIPTION
**Related issue:** Resolves #50953

With GitOps mode enabled, adding a package from the software title page leaves **Save** permanently disabled. No error is shown, so there's nothing on screen indicating what's missing.

## Root cause

`AddPackageModal` preselects a `"Custom"` target, which is the intended design for the multi-package modal — every package on a title needs its own label scope.

`"Custom"` requires at least one label:

```ts
if (formData.targetType === "All hosts") return true;
// there must be at least one label target selected
```

But GitOps mode hides the selector that would let the user choose one:

```ts
const showTargetLabelSelector = !gitOpsModeEnabled && (...);
```

So the form waits on a field it never renders. Validation can't pass, `isSubmitDisabled` stays true, and because the field isn't shown there's no inline error either.

This is specific to that entry point: the **Add software** page passes no `initialTargetType`, so it defaults to `"All hosts"` and the same upload works there today. GitOps mode already treats package uploads as the deliberate exception to its read-only rule — a binary can't live in git — which is what the modal's own banner describes.

## Changes

Normalize the target to the default when GitOps mode is on and no labels are attached:

```ts
useEffect(() => {
  if (!gitOpsModeEnabled) {
    return;
  }
  const hasLabelTargets = Object.values(formData.labelTargets).some(Boolean);
  if (formData.targetType !== "Custom" || hasLabelTargets) {
    return;
  }
  const normalized = { ...formData, targetType: "All hosts" };
  setFormData(normalized);
  setFormValidation(generateFormValidation(normalized));
}, [gitOpsModeEnabled, formData]);
```

Targeting comes from YAML in GitOps mode, so `"All hosts"` is the coherent value to submit rather than a `"Custom"` target with no labels attached.

Two details worth calling out:

- **It's an effect rather than initial state.** `config` is fetched asynchronously and `App` renders its children before it resolves (`isLoading` starts `false` and is only ever set `false`), so the form can mount while GitOps mode still reads as off. Deriving this once in `useState` left that case broken — the preselected `"Custom"` would stick and the hidden selector couldn't clear it.
- **Rows that already carry labels are skipped.** Editing a package in GitOps mode legitimately has a `"Custom"` target with labels populated from the existing installer; resetting those would silently drop its targeting on save.
- **Validation is recomputed alongside it.** `formValidation` is held in state and otherwise only refreshed by the change handlers, so a file chosen before config resolved would keep a stale failure for the target that was just normalized away. The guard returns early once the target is normalized, so the `formData` dependency settles after one pass.

Outside GitOps mode nothing changes.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests

Four tests, covering both orderings of the async case:

- GitOps mode on: the selector is absent and **Save** is enabled after choosing a file.
- Config arriving *after* mount, file chosen afterwards.
- Config arriving *after* the file is chosen — the ordering that needs the validation recompute.
- GitOps mode off: `"Custom"` is still preselected and **Save** stays disabled until a label is picked — so the existing requirement isn't weakened.

The first three fail against the unfixed form, and the third fails on its own if only the validation recompute is removed. The fourth passes either way and exists to catch the fix over-reaching. The other 7 tests in the file are unchanged. `eslint`, `prettier`, and `tsc --noEmit` are clean.

- [ ] QA'd all new/changed functionality manually

Not done. Reproducing it needs GitOps mode enabled on a running instance; the tests exercise the form's validation state directly instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package target handling in GitOps mode.
  * Automatically defaults to “All hosts” when no custom label targets are selected.
  * Preserves existing custom targets when labels are configured.
  * Ensures form validation and Save availability update correctly when GitOps settings load asynchronously.
  * Maintains label validation behavior when GitOps mode is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->