### PR TITLE
Fleet UI: Align InfoBanner leading icon with first line of wrapped copy

### DIFF
--- a/frontend/components/InfoBanner/_styles.scss
+++ b/frontend/components/InfoBanner/_styles.scss
@@ -24,6 +24,11 @@
 
   &__leading-icon {
     flex-shrink: 0;
+    // Override .icon's `align-self: center` so a wrapping message keeps the
+    // icon lined up with the first line of text. The one-line-tall band
+    // centers the 16px svg on the first line of copy.
+    align-self: flex-start;
+    height: calc(#{$x-small} * #{$line-height});
   }
 
   &__info {

--- a/frontend/components/InfoBanner/_styles.scss
+++ b/frontend/components/InfoBanner/_styles.scss
@@ -25,9 +25,10 @@
   &__leading-icon {
     flex-shrink: 0;
     // Override .icon's `align-self: center` so a wrapping message keeps the
-    // icon lined up with the first line of text. The one-line-tall band
-    // centers the 16px svg on the first line of copy.
+    // icon lined up with the first line of text. The one-line-tall band +
+    // `align-items: center` centers the 16px svg on the first line of copy.
     align-self: flex-start;
+    align-items: center;
     height: calc(#{$x-small} * #{$line-height});
   }
 


### PR DESCRIPTION
## Issue
Closes #51395

## Description
- Bug fix (root cause): `.icon` carries `align-self: center` (frontend/components/Icon/_styles.scss:6), which was overriding the `.info-banner__icon` container's `align-items: flex-start` and pulling every InfoBanner leading icon back to the vertical center whenever the copy wrapped to more than one line (Andrey's "End user is not notified…" repro).
- Fix: give `.info-banner__leading-icon` its own `align-self: flex-start` plus a one-line-tall `height` so the 16px svg sits centered inside the first-line band and visually tracks the first line of copy no matter how many lines the message wraps to. Same technique as the toast icon fix in #50449.

## Screenrecording
- InfoBanner with a wrapping "End user is not notified…" message — showing icon aligning with the first line


https://github.com/user-attachments/assets/d288c1ac-d323-4773-a0d6-69c29c963705



## Testing

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved informational banner layouts with leading icons.
  * Icons now align with the first line of wrapped text and remain centered for single-line banners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->