### PR TITLE
Add "Compatibility" checkbox to the user story template

### DIFF
--- a/.github/ISSUE_TEMPLATE/story.md
+++ b/.github/ISSUE_TEMPLATE/story.md
@@ -37,6 +37,7 @@ It is [planned and ready](https://fleetdm.com/handbook/company/development-group
 - [ ] Changes to paid features or tiers: TODO  <!-- Specify changes in pricing-features-table.yml as a PR to reference docs release branch. Specify "Fleet Free" and/or "Fleet Premium" if there are no changes to the pricing page necessary. -->
 - [ ] My device and fleetdm.com/better changes: TODO <!-- If there are changes to the personal information Fleet can see on end user workstations, make sure wireframes include changes to the My device page. Also, specify changes as a PR to the fleetdm.com/better (aka Transparency page). Put "No changes" if there are no changes necessary. -->
 - [ ] Usage statistics: TODO <!-- Specify changes in the Fleet usage statistics guide as a PR to reference docs release branch. Put "No changes" if there are no changes necessary. -->
+- [ ] Compatibility: TODO <!-- If there are there are any breaking changes, outside of a major release, notify the Manager of Customer Support and Solutions Architecture. Put "No changes" if there are no changes necessary. -->
 - [ ] Other reference documentation changes: TODO <!-- Any other reference doc changes? Specify changes as a PR to reference docs release branch. Put "No changes" if there are no changes necessary. -->
 - [ ] First draft of test plan added
 - [ ] Once shipped, requester has been notified


### PR DESCRIPTION
Rarely, but sometimes, we make breaking changes outside of a major release:

<img width="657" height="634" alt="Screenshot 2026-08-18 at 11 58 14 AM" src="https://github.com/user-attachments/assets/27ea87a0-1a73-4dfa-8e27-1b71820bd01e" />

(https://fleetdm.com/docs/deploy/upgrading-fleet#compatibility)

- We made a breaking change this when this security vuln was reported: https://github.com/fleetdm/confidential/issues/16274
  - We got lucky and notified customers because @zayhanlon caught it: https://fleetdm.slack.com/archives/C062D0THVV1/p1783708428386089
- The story template will help us remember to notify @ddribeiro (Manager of Customer Support and Solutions Architecture)