### PR TITLE
Run only a fast Go test tier on draft PRs

### DIFF
--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -21,6 +21,7 @@ on:
       - 'frontend/templates/enroll-ota.html'
       - 'frontend/templates/windowsTOS.html'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - '**.go'
       - '**/testdata/**'
@@ -55,6 +56,7 @@ permissions:
 jobs:
   # ──────────────────────────────────────────────────────────────────────────────
   # Suites that do NOT need MySQL: run once with no database dimension.
+  # These always run, including on draft PRs.
   # ──────────────────────────────────────────────────────────────────────────────
   test-go-no-db:
     strategy:
@@ -69,13 +71,15 @@ jobs:
       SLACK_G_HELP_ENGINEERING_WEBHOOK_URL: ${{ github.event_name == 'schedule' && secrets.SLACK_G_HELP_ENGINEERING_WEBHOOK_URL || '' }}
 
   # ──────────────────────────────────────────────────────────────────────────
-  # Suites that need MySQL: always-run versions (every push/PR + cron).
+  # Suites that need MySQL: run on push + cron + non-draft PRs.
+  # Draft PRs run a fast tier only (fast, scripts, service); the full fan-out
+  # runs when the PR is marked ready for review.
   # make sure to update supported versions docs when MySQL versions change
   # ──────────────────────────────────────────────────────────────────────────
   test-go:
     strategy:
       matrix:
-        suite: ["integration-core", "integration-enterprise", "integration-mdm", "fleetctl", "main", "mysql", "service", "vuln"]
+        suite: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.draft) && '["service"]' || '["integration-core", "integration-enterprise", "integration-mdm", "fleetctl", "main", "mysql", "service", "vuln"]') }}
         mysql: ["mysql:8.0.44"]
     uses: ./.github/workflows/test-go-suite.yaml
     with:
@@ -250,7 +254,9 @@ jobs:
   upload-coverage:
     needs: [test-go-no-db, test-go, test-go-extended-mysql, test-go-extended-redis, test-go-nanomdm]
     # Run even if extended-mysql was skipped (non-cron) or individual suites failed.
-    if: always()
+    # Skipped on draft PRs: only the fast tier runs there, so uploading would
+    # produce a misleading partial coverage report.
+    if: ${{ always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) }}
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -135,6 +135,8 @@ jobs:
 
   # Based on https://github.com/micromdm/nanomdm/blob/main/.github/workflows/on-push-pr.yml#L87
   test-go-nanomdm:
+    # Skipped on draft PRs along with the rest of the non-fast tier.
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: 'ubuntu-latest'
     services:
       mysql:


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->

Reduces GitHub Actions spend by running only a fast tier of Go test suites on draft PRs.

`test-go.yaml` currently fans out to 10 `ubuntu-8core` jobs (~78 eight-core minutes) on every PR push. Over the last 14 days, 185 PRs produced 566 full-suite runs (avg 3.1 per PR). This workflow is the largest single contributor to our Linux 8-core Actions bill (~$2,500/month).

With this change:

- **Draft PRs** run `fast`, `scripts`, and `service` only (~11 eight-core minutes), giving quick compile and unit-test signal while iterating.
- **The full 10-suite fan-out** runs when a PR is opened as (or marked) ready for review, on every push to a non-draft PR, on pushes to `main`/`patch-*`/`prepare-*`, and on the nightly cron. Behavior for non-draft PRs is unchanged.
- The `ready_for_review` trigger type is added so marking a draft ready immediately kicks off the full suite on the current head commit.
- The Codecov upload is skipped on draft PRs so a fast-tier run doesn't report misleading partial backend coverage. Once the PR is ready, the full run uploads coverage as before.

The conditional matrix uses the same `fromJSON` pattern as `golangci-lint.yml`. `aggregate-result` still reflects pass/fail of whichever suites ran.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

## Testing

- [x] Manually verified workflow syntax with `actionlint`
- [ ] Verify on this PR (opened as draft) that only `fast`, `scripts`, and `service` suites run, then mark ready for review and verify the full fan-out runs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refined pull request validation to run for selected activity types.
  * Kept non-database test suites running for draft pull requests.
  * Limited draft validation to the service database suite, while retaining full database coverage for non-draft pull requests.
  * Skipped NanoMDM checks and coverage uploads for draft pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->