### PR TITLE
Raise HTTP server idle timeout above load balancer idle timeout to prevent 502s

### DIFF
--- a/changes/http-server-idle-timeout.md
+++ b/changes/http-server-idle-timeout.md
@@ -1,0 +1,1 @@
+- Increased the Fleet server's HTTP keep-alive idle timeout from 5 minutes to 930 seconds so it exceeds the load balancer idle timeout (905s in Fleet's reference terraform), eliminating intermittent 502s caused by the server closing idle connections the load balancer still considered live.

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -156,7 +156,10 @@ func (s *ServerConfig) DefaultHTTPServer(ctx context.Context, handler http.Handl
 		// requests could DDOS Fleet.
 		WriteTimeout:      40 * time.Second,
 		ReadHeaderTimeout: 5 * time.Second,
-		IdleTimeout:       5 * time.Minute,
+		// Must exceed the load balancer's idle timeout (905s in Fleet's
+		// terraform) so the LB closes idle connections first; the reverse
+		// ordering causes intermittent 502s.
+		IdleTimeout: 930 * time.Second,
 		MaxHeaderBytes:    1 << 18, // 0.25 MB (262144 bytes)
 		BaseContext: func(l net.Listener) context.Context {
 			return ctx


### PR DESCRIPTION
**Related issue:** N/A (root cause of intermittent 502s observed at the ALB)

## Summary

The Go HTTP server's keep-alive `IdleTimeout` was 5 minutes, while Fleet's terraform sets the ALB `idle_timeout` to 905 seconds. AWS requires the target's keep-alive timeout to exceed the load balancer's so the LB always closes idle connections first. With the ordering inverted, the server closes an idle keep-alive connection while the ALB still considers it live; a request routed onto that connection in the teardown window gets a TCP FIN/RST and the ALB returns a 502.

This matches the observed 502 distribution: a small trickle concentrated on the highest-volume agent endpoints (`/api/fleet/device/ping`, `/api/fleet/orbit/config`, `/api/fleet/orbit/ping`, `/api/v1/osquery/config`), including trivial no-op HEAD handlers that cannot fail at the application layer.

This raises `IdleTimeout` to 930 seconds, above the 905-second ALB idle timeout used across Fleet's reference terraform (`infrastructure/dogfood`, `infrastructure/loadtesting`, fleet-terraform).

Tradeoff: idle agent connections are now held up to ~15.5 minutes instead of 5, slightly increasing per-task file descriptor and memory footprint. Connections busier than the ALB timeout are unaffected, and the ALB still reaps at 905s, so the practical ceiling is the ALB's.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops

## Testing

- [ ] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually (pending: confirm 502 rate drops after deploy)

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results
