### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/anytype/darwin.json
+++ b/ee/maintained-apps/outputs/anytype/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "0.56.1",
+      "version": "0.56.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.anytype.anytype';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anytype.anytype' AND version_compare(bundle_short_version, '0.56.1') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anytype.anytype' AND version_compare(bundle_short_version, '0.56.4') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.anytype.anytype');"
       },
-      "installer_url": "https://anytype-release.fra1.cdn.digitaloceanspaces.com/Anytype-0.56.1-mac-arm64.dmg",
+      "installer_url": "https://anytype-release.fra1.cdn.digitaloceanspaces.com/Anytype-0.56.4-mac-arm64.dmg",
       "install_script_ref": "a0aaeeef",
       "uninstall_script_ref": "9bb6a998",
-      "sha256": "9f160b2ac424d13aa322b8c09619888b77fb68f7d0ecab2f0ba3f62831714f63",
+      "sha256": "10acf039ed3cfbb328a02b810606b3e2a9d4288ea16a937594b841a5e79658cf",
       "default_categories": [
         "Security"
       ]

--- a/ee/maintained-apps/outputs/cardhop/darwin.json
+++ b/ee/maintained-apps/outputs/cardhop/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "2.4.8",
+      "version": "2.4.9",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.flexibits.cardhop.mac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.flexibits.cardhop.mac' AND version_compare(bundle_short_version, '2.4.8') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.flexibits.cardhop.mac' AND version_compare(bundle_short_version, '2.4.9') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.flexibits.cardhop.mac');"
       },
-      "installer_url": "https://cdn.flexibits.com/Cardhop_2.4.8.zip",
+      "installer_url": "https://cdn.flexibits.com/Cardhop_2.4.9.zip",
       "install_script_ref": "d39decf1",
       "uninstall_script_ref": "3fc281ff",
-      "sha256": "cc826577b984d75b4d1cc95f8b9073cddc4be2883a0d385c887ffbe8bec1e3cd",
+      "sha256": "b7a8d149ca08f0a69282d5fc0b313102c69a856786814dae0110547fac043e21",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/element/darwin.json
+++ b/ee/maintained-apps/outputs/element/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.12.25",
+      "version": "1.12.26",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'im.riot.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'im.riot.app' AND version_compare(bundle_short_version, '1.12.25') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'im.riot.app' AND version_compare(bundle_short_version, '1.12.26') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'im.riot.app');"
       },
-      "installer_url": "https://packages.element.io/desktop/update/macos/Element-1.12.25-universal-mac.zip",
+      "installer_url": "https://packages.element.io/desktop/update/macos/Element-1.12.26-universal-mac.zip",
       "install_script_ref": "de37e84e",
       "uninstall_script_ref": "6e6ffb57",
-      "sha256": "4d202f20062633bcce4cc829b11d084d6261577c8731a40bc4b4fa54b1dc5562",
+      "sha256": "64d5a4a453f1c097ee00ef0c919e1b4abfe23709566653ffb68a61ea37922b50",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/jetbrains-toolbox/darwin.json
+++ b/ee/maintained-apps/outputs/jetbrains-toolbox/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "3.6.4",
+      "version": "3.7",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.toolbox';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.toolbox' AND version_compare(bundle_short_version, '3.6.4') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.toolbox' AND version_compare(bundle_short_version, '3.7') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.jetbrains.toolbox');"
       },
-      "installer_url": "https://download.jetbrains.com/toolbox/jetbrains-toolbox-3.6.4.86641-arm64.dmg",
+      "installer_url": "https://download.jetbrains.com/toolbox/jetbrains-toolbox-3.7.0.87111-arm64.dmg",
       "install_script_ref": "18687029",
       "uninstall_script_ref": "118b704f",
-      "sha256": "8cf9582e229a6d57b0d64c5df932745b45ae4fcd91d29fb22003f1b885446110",
+      "sha256": "f4ac42218e669869d60dedc743ba9ae0ca65d48c37009574dbeca9456cafcb6b",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/jetbrains-toolbox/windows.json
+++ b/ee/maintained-apps/outputs/jetbrains-toolbox/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "3.6.4.0",
+      "version": "3.7.0.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'JetBrains Toolbox' AND publisher = 'JetBrains';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'JetBrains Toolbox' AND publisher = 'JetBrains' AND version_compare(version, '3.6.4.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'JetBrains Toolbox' AND publisher = 'JetBrains' AND version_compare(version, '3.7.0.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) IN ('toolbox.exe','jetbrains-toolbox.exe'));"
       },
-      "installer_url": "https://download.jetbrains.com/toolbox/jetbrains-toolbox-3.6.4.86641.exe",
+      "installer_url": "https://download.jetbrains.com/toolbox/jetbrains-toolbox-3.7.0.87111.exe",
       "install_script_ref": "f635418b",
       "uninstall_script_ref": "a6821d8b",
-      "sha256": "a9157dc1d0b402550484841b6b1c0a57b6ec5cecf8f64346a5c48ab857cf1528",
+      "sha256": "9e044fe4db7ea15bccf0cab8f78033b6fd4e9042c7834e96402be5c2cbb09348",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/plex-media-server/darwin.json
+++ b/ee/maintained-apps/outputs/plex-media-server/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.43.3.10861",
+      "version": "1.43.3.10896",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.plexapp.plexmediaserver';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.plexapp.plexmediaserver' AND version_compare(bundle_short_version, '1.43.3.10861') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.plexapp.plexmediaserver' AND version_compare(bundle_short_version, '1.43.3.10896') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.plexapp.plexmediaserver');"
       },
-      "installer_url": "https://downloads.plex.tv/plex-media-server-new/1.43.3.10861-07dfddaeb/macos/PlexMediaServer-1.43.3.10861-07dfddaeb-universal.zip",
+      "installer_url": "https://downloads.plex.tv/plex-media-server-new/1.43.3.10896-cb3ebc72d/macos/PlexMediaServer-1.43.3.10896-cb3ebc72d-universal.zip",
       "install_script_ref": "87eb0241",
       "uninstall_script_ref": "2c6d641f",
-      "sha256": "bf6b1466dbef552457b49be68e54020198987ea498622ec7cf95ae8252b243ee",
+      "sha256": "185963b4043898a734db7b3d2b2845bc389492681544989550744edccb1a0e7b",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/sabnzbd/darwin.json
+++ b/ee/maintained-apps/outputs/sabnzbd/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "5.1.0",
+      "version": "5.1.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.sabnzbd.sabnzbd';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.sabnzbd.sabnzbd' AND version_compare(bundle_short_version, '5.1.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.sabnzbd.sabnzbd' AND version_compare(bundle_short_version, '5.1.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'org.sabnzbd.sabnzbd');"
       },
-      "installer_url": "https://github.com/sabnzbd/sabnzbd/releases/download/5.1.0/SABnzbd-5.1.0-macos.dmg",
+      "installer_url": "https://github.com/sabnzbd/sabnzbd/releases/download/5.1.1/SABnzbd-5.1.1-macos.dmg",
       "install_script_ref": "cef073f6",
       "uninstall_script_ref": "8b107d86",
-      "sha256": "ac7ba4bd3a561b07e82d7e3ab774f802c74c623cfab758026a0ecce0689b1777",
+      "sha256": "8014480e30488a8686861fe4dc57bce121a9726a7ca5acbb0329c2381e73b572",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/virtualbox/darwin.json
+++ b/ee/maintained-apps/outputs/virtualbox/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "7.2.14",
+      "version": "7.2.16",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.virtualbox.app.VirtualBox';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.virtualbox.app.VirtualBox' AND version_compare(bundle_short_version, '7.2.14') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.virtualbox.app.VirtualBox' AND version_compare(bundle_short_version, '7.2.16') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'org.virtualbox.app.VirtualBox');"
       },
-      "installer_url": "https://download.virtualbox.org/virtualbox/7.2.14/VirtualBox-7.2.14-174565-macOSArm64.dmg",
+      "installer_url": "https://download.virtualbox.org/virtualbox/7.2.16/VirtualBox-7.2.16-174877-macOSArm64.dmg",
       "install_script_ref": "815ae6bd",
       "uninstall_script_ref": "e04a5c15",
-      "sha256": "227a20af93f007a455a8ed44e012d6b0079140d1ec00f8fbd66efabaff556533",
+      "sha256": "43984f01e4dedd82a22d3c38d432a22f6df9bc2f5e5333a722b734c5bf8b6636",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/virtualbox/windows.json
+++ b/ee/maintained-apps/outputs/virtualbox/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "7.2.14",
+      "version": "7.2.16",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Oracle VirtualBox %' AND publisher = 'Oracle and/or its affiliates';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Oracle VirtualBox %' AND publisher = 'Oracle and/or its affiliates' AND version_compare(version, '7.2.14') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Oracle VirtualBox %' AND publisher = 'Oracle and/or its affiliates' AND version_compare(version, '7.2.16') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) LIKE 'virtualbox%');"
       },
-      "installer_url": "https://download.virtualbox.org/virtualbox/7.2.14/VirtualBox-7.2.14-174565-Win.exe",
+      "installer_url": "https://download.virtualbox.org/virtualbox/7.2.16/VirtualBox-7.2.16-174877-Win.exe",
       "install_script_ref": "556130e3",
       "uninstall_script_ref": "fb3c3d4d",
-      "sha256": "5fb111f32a15763d519bf9ef23e0111153521f641cde7460e5b8e895ca27a1d2",
+      "sha256": "9383a42bffa5c0ac4bc5f1c7d820478d84380d3a17b65aa9b43e6778cbdb615a",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/zed/darwin.json
+++ b/ee/maintained-apps/outputs/zed/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.15.0",
+      "version": "1.15.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed' AND version_compare(bundle_short_version, '1.15.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed' AND version_compare(bundle_short_version, '1.15.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'dev.zed.Zed');"
       },
-      "installer_url": "https://zed.dev/api/releases/stable/1.15.0/Zed-aarch64.dmg",
+      "installer_url": "https://zed.dev/api/releases/stable/1.15.1/Zed-aarch64.dmg",
       "install_script_ref": "bdea8414",
       "uninstall_script_ref": "0436e2d8",
-      "sha256": "670fdb3631dbacd0304b7c529fab0cd9c4dd5121e6077d9c4830c7c5fc651179",
+      "sha256": "5f7abefa7a5a0e614596b38b90f16849b8d6b36ee581ede057eb3190917e5437",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/zed/windows.json
+++ b/ee/maintained-apps/outputs/zed/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.15.0",
+      "version": "1.15.1",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Zed' AND publisher = 'Zed Industries';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Zed' AND publisher = 'Zed Industries' AND version_compare(version, '1.15.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Zed' AND publisher = 'Zed Industries' AND version_compare(version, '1.15.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'zed.exe');"
       },
-      "installer_url": "https://github.com/zed-industries/zed/releases/download/v1.15.0/Zed-x86_64.exe",
+      "installer_url": "https://github.com/zed-industries/zed/releases/download/v1.15.1/Zed-x86_64.exe",
       "install_script_ref": "e5193bc1",
       "uninstall_script_ref": "3b164442",
-      "sha256": "cfb4a1d9dd2e7959c4ebe29bb7436487a8766c4c3e086111fde5bb6fcf19766c",
+      "sha256": "ab46866589ec2518e065962afd13e88ce41f45e08f9fb921c21df75b682aad5b",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/zotero/windows.json
+++ b/ee/maintained-apps/outputs/zotero/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "9.0.6",
+      "version": "10.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Zotero' AND publisher = 'Corporation for Digital Scholarship';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Zotero' AND publisher = 'Corporation for Digital Scholarship' AND version_compare(version, '9.0.6') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Zotero' AND publisher = 'Corporation for Digital Scholarship' AND version_compare(version, '10.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'zotero.exe');"
       },
-      "installer_url": "https://download.zotero.org/client/release/9.0.6/Zotero-9.0.6_x64_setup.exe",
+      "installer_url": "https://download.zotero.org/client/release/10.0/Zotero-10.0_x64_setup.exe",
       "install_script_ref": "d29b62d2",
       "uninstall_script_ref": "599566de",
-      "sha256": "973bfc96a7af8b2949bbfdc46b220366b2b204942ac30d50aef9835eb152d31c",
+      "sha256": "efa961da61b2c179ccb9ce75b490a8ba9b92bba8592f90d78822bb503de52c71",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated macOS app versions for Anytype, Cardhop, Element, JetBrains Toolbox, Plex Media Server, SABnzbd, VirtualBox, and Zed.
  * Updated Windows versions for JetBrains Toolbox, VirtualBox, Zed, and Zotero.
  * Refreshed download links, version detection, and verification checksums to support the latest releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->