### PR TITLE
Disable WSTEP ROBO certificate renewal Fleet does not implement

### DIFF
--- a/changes/fix-wstep-robo-renewal
+++ b/changes/fix-wstep-robo-renewal
@@ -1,0 +1,1 @@
+- Fixed a bug where Windows hosts showed a failed enrollment state after the MDM certificate renewal window opened.

--- a/server/mdm/microsoft/syncml/syncml.go
+++ b/server/mdm/microsoft/syncml/syncml.go
@@ -235,9 +235,9 @@ const (
 	// Provisioning Doc Certificate Renewal Period (365 days)
 	WstepCertRenewalPeriodInDays = "365"
 
-	// Provisioning Doc Server ROBO auto certificate renewal.
-	// Set to "false" because Fleet does not implement the WSTEP ROBO
-	// renewal endpoint. Advertising "true" causes Windows to attempt
+	// WstepROBOSupport tells Windows whether Fleet supports ROBO auto
+	// certificate renewal. Set to "false" because Fleet does not implement
+	// the renewal endpoint. Advertising "true" causes Windows to attempt
 	// renewal, fail, and set EnrollmentState=3 on the host. See #50611.
 	WstepROBOSupport = "false"
 

--- a/server/mdm/microsoft/syncml/syncml.go
+++ b/server/mdm/microsoft/syncml/syncml.go
@@ -235,9 +235,11 @@ const (
 	// Provisioning Doc Certificate Renewal Period (365 days)
 	WstepCertRenewalPeriodInDays = "365"
 
-	// Provisioning Doc Server supports ROBO auto certificate renewal
-	// TODO: Add renewal support
-	WstepROBOSupport = "true"
+	// Provisioning Doc Server ROBO auto certificate renewal.
+	// Set to "false" because Fleet does not implement the WSTEP ROBO
+	// renewal endpoint. Advertising "true" causes Windows to attempt
+	// renewal, fail, and set EnrollmentState=3 on the host. See #50611.
+	WstepROBOSupport = "false"
 
 	// Provisioning Doc Server retry interval
 	WstepRenewRetryInterval = "4"

--- a/server/service/microsoft_mdm_test.go
+++ b/server/service/microsoft_mdm_test.go
@@ -83,6 +83,31 @@ func TestRequestSecurityTokenResponseCollectionSoapResponse(t *testing.T) {
 	require.Contains(t, string(outXML), fmt.Sprintf("base64binary\">%s</BinarySecurityToken>", provisionedToken))
 }
 
+func TestCertStoreProvisioningROBOSupportDisabled(t *testing.T) {
+	certStore := NewCertStoreProvisioningData(
+		"Device",
+		"AAAAAAAAAAAAAAAAAAAAAAAAA",
+		[]byte("identity-cert"),
+		"BBBBBBBBBBBBBBBBBBBBBBBBB",
+		[]byte("signed-cert"),
+	)
+	appConfig := NewApplicationProvisioningData("https://example.com/mdm/management", "device-id", "password")
+	dmClient := NewDMClientProvisioningData()
+
+	provDoc := NewProvisioningDoc(certStore, appConfig, dmClient)
+	encoded, err := provDoc.GetEncodedB64Representation()
+	require.NoError(t, err)
+
+	raw, err := base64.StdEncoding.DecodeString(encoded)
+	require.NoError(t, err)
+
+	// Fleet does not implement WSTEP ROBO renewal. The provisioning doc
+	// must advertise ROBOSupport=false so Windows does not attempt renewal
+	// and set EnrollmentState=3 on the host. See #50611.
+	require.Contains(t, string(raw), `name="ROBOSupport" value="false"`)
+	require.NotContains(t, string(raw), `name="ROBOSupport" value="true"`)
+}
+
 func TestGetPoliciesResponseSoapResponse(t *testing.T) {
 	minKey := "2048"
 	getPoliciesMsg, err := NewGetPoliciesResponse(minKey, "10", "20")

--- a/server/service/microsoft_mdm_test.go
+++ b/server/service/microsoft_mdm_test.go
@@ -81,29 +81,17 @@ func TestRequestSecurityTokenResponseCollectionSoapResponse(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, outXML)
 	require.Contains(t, string(outXML), fmt.Sprintf("base64binary\">%s</BinarySecurityToken>", provisionedToken))
-}
 
-func TestCertStoreProvisioningROBOSupportDisabled(t *testing.T) {
-	certStore := NewCertStoreProvisioningData(
-		"Device",
-		"AAAAAAAAAAAAAAAAAAAAAAAAA",
-		[]byte("identity-cert"),
-		"BBBBBBBBBBBBBBBBBBBBBBBBB",
-		[]byte("signed-cert"),
-	)
-	appConfig := NewApplicationProvisioningData("https://example.com/mdm/management", "device-id", "password")
-	dmClient := NewDMClientProvisioningData()
-
-	provDoc := NewProvisioningDoc(certStore, appConfig, dmClient)
+	// Verify the provisioning doc advertises ROBOSupport=false. Fleet does
+	// not implement WSTEP ROBO renewal; advertising "true" causes Windows
+	// to attempt renewal, fail, and set EnrollmentState=3. See #50611.
+	certStore := NewCertStoreProvisioningData("Device", "AA", []byte("id"), "BB", []byte("sc"))
+	appCfg := NewApplicationProvisioningData("https://example.com/mdm", "dev", "pw")
+	provDoc := NewProvisioningDoc(certStore, appCfg, NewDMClientProvisioningData())
 	encoded, err := provDoc.GetEncodedB64Representation()
 	require.NoError(t, err)
-
 	raw, err := base64.StdEncoding.DecodeString(encoded)
 	require.NoError(t, err)
-
-	// Fleet does not implement WSTEP ROBO renewal. The provisioning doc
-	// must advertise ROBOSupport=false so Windows does not attempt renewal
-	// and set EnrollmentState=3 on the host. See #50611.
 	require.Contains(t, string(raw), `name="ROBOSupport" value="false"`)
 	require.NotContains(t, string(raw), `name="ROBOSupport" value="true"`)
 }


### PR DESCRIPTION
**Related issue:** Resolves #50611

## Summary

Fleet's WSTEP provisioning document advertised `ROBOSupport=true` but never implemented the WSTEP ROBO renewal endpoint. Windows scheduled ROBO renewal every `RetryInterval` (4 days) after the renewal window opened (~185 days into the 365-day certificate lifetime). Every attempt failed (Fleet returned a SOAP fault), and Windows recorded:

- `RenewStatus = 3`
- `RenewErrorCode = -2145845048` (`0x801900C8`)
- `EnrollmentState = 3` (Microsoft defines this as "Not enrolled and there is enrollment failure record")

This made `EnrollmentState` useless as a health signal for every Windows host past the renewal window.

## Reproduction

Traced the full code path and confirmed with a unit test:

1. **Constant was `"true"`:** `server/mdm/microsoft/syncml/syncml.go:240` had `WstepROBOSupport = "true"` with a `// TODO: Add renewal support` comment.
2. **Provisioning doc delivers it to every Windows host:** `NewCertStoreProvisioningData()` at `server/service/microsoft_mdm.go:596-599` embeds `ROBOSupport`, `RenewPeriod=365`, and `RetryInterval=4` into the WSTEP provisioning XML sent during enrollment.
3. **No renewal endpoint exists:** Searched the entire `server/` directory. All enrollment renewal code is Apple SCEP. Zero ROBO renewal handling for Windows WSTEP.
4. **Downstream workarounds mask the problem:**
   - The detail query at `server/service/osquery_utils/queries.go:665` includes `EnrollmentState=3` in its filter.
   - Orbit at `orbit/pkg/update/execwinapi.go:27-30` treats any non-zero `EnrollmentState` as "active."

## Fix

Set `WstepROBOSupport` from `"true"` to `"false"` so Windows does not attempt renewal Fleet cannot service. This is Option 2 from the ticket ("the smaller change [that] immediately restores `EnrollmentState` as a usable health signal").

Tightening the two downstream workarounds (detail query `EnrollmentState IN` filter and orbit's non-zero check) is left as a follow-up per the ticket.

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

**Manual QA:** Verified the provisioning XML produced by `NewCertStoreProvisioningData()` now contains `ROBOSupport=false`. Existing enrollment tests (`TestRequestSecurityTokenResponseCollectionSoapResponse`, etc.) continue to pass.

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where Windows hosts could incorrectly appear to have failed enrollment when the MDM certificate renewal window opened.
  * Windows provisioning documents now consistently indicate that unsupported server-side certificate renewal is disabled.

* **Tests**
  * Expanded coverage to verify that Windows provisioning documents correctly report certificate renewal support as disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->