### PR TITLE
Policy automation resend config profile trigger

### DIFF
--- a/changes/40637-policy-automation-config-profile
+++ b/changes/40637-policy-automation-config-profile
@@ -1,0 +1,1 @@
+- Added support for resending a configuration profile on policy failure as part of a policy automation.

--- a/server/datastore/mysql/activities.go
+++ b/server/datastore/mysql/activities.go
@@ -36,6 +36,7 @@ var policyAutomationSuccessActivityTypes = []string{
 	"ran_automation_ticket",
 	"ran_automation_calendar_event",
 	"ran_automation_conditional_access",
+	"resent_configuration_profile",
 }
 
 var policyAutomationActivityTypes = func() []string {

--- a/server/datastore/mysql/activities_test.go
+++ b/server/datastore/mysql/activities_test.go
@@ -2908,6 +2908,53 @@ func testListPolicyAutomationActivities(t *testing.T, ds *Datastore) {
 		}
 	})
 
+	t.Run("profile resends appear, manual resends do not", func(t *testing.T) {
+		// A policy-triggered resend carries details.policy_id and is linked to the host, so it
+		// shows in the feed as a success. A manual resend records the same activity type with a
+		// null policy_id and must not appear under any policy.
+		resendPolicy, err := ds.NewGlobalPolicy(ctx, nil, fleet.PolicyPayload{Name: "resend-policy", Query: "SELECT 3"})
+		require.NoError(t, err)
+
+		require.NoError(t, activitySvc.NewActivity(ctx, nil, dummyActivity{
+			name: fleet.ActivityTypeResentConfigurationProfile{}.ActivityName(),
+			details: map[string]any{
+				"host_id":      h1.ID,
+				"profile_uuid": "a-profile-uuid",
+				"profile_name": "a profile",
+				"policy_id":    resendPolicy.ID,
+				"policy_name":  "resend-policy",
+			},
+			hostIDs: []uint{h1.ID},
+		}))
+		require.NoError(t, activitySvc.NewActivity(ctx, nil, dummyActivity{
+			name: fleet.ActivityTypeResentConfigurationProfile{}.ActivityName(),
+			details: map[string]any{
+				"host_id":      h1.ID,
+				"profile_uuid": "a-profile-uuid",
+				"profile_name": "a profile",
+				"policy_id":    nil,
+				"policy_name":  nil,
+			},
+			hostIDs: []uint{h1.ID},
+		}))
+
+		activities, _, err := ds.ListPolicyAutomationActivities(ctx, resendPolicy.ID, adminFilter, listOpts(), "")
+		require.NoError(t, err)
+		require.Len(t, activities, 1, "the manual resend must not be attributed to a policy")
+		require.Equal(t, fleet.ActivityTypeResentConfigurationProfile{}.ActivityName(), activities[0].Type)
+		require.Equal(t, h1.ID, activities[0].HostID)
+		require.Equal(t, "success", activities[0].Status)
+
+		// It is a success, so it is absent from the error-filtered feed.
+		activities, _, err = ds.ListPolicyAutomationActivities(ctx, resendPolicy.ID, adminFilter, listOpts(), "error")
+		require.NoError(t, err)
+		require.Empty(t, activities)
+
+		activities, _, err = ds.ListPolicyAutomationActivities(ctx, resendPolicy.ID, adminFilter, listOpts(), "success")
+		require.NoError(t, err)
+		require.Len(t, activities, 1)
+	})
+
 	t.Run("pagination", func(t *testing.T) {
 		activities, meta, err := ds.ListPolicyAutomationActivities(ctx, policy.ID, adminFilter, listOpts(fleet.ListOptions{PerPage: 3}), "")
 		require.NoError(t, err)

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -2934,7 +2934,7 @@ ON DUPLICATE KEY UPDATE
 	if result, err = tx.ExecContext(ctx, stmt, args...); err != nil {
 		if isMySQLForeignKey(err) {
 			if strings.Contains(err.Error(), "fk_policies_resend_apple_profile") {
-				return false, ctxerr.Wrap(ctx, &fleet.ConflictError{Message: "Couldn't delete. Policy automations uses one or more of the profiles being deleted. Please disable policy automations for the profiles being deleted and try again."})
+				return false, ctxerr.Wrap(ctx, &fleet.ConflictError{Message: "Couldn't delete. Policy automations use one or more of the profiles being deleted. Please disable policy automations for the profiles being deleted and try again."})
 			}
 		}
 		return false, ctxerr.Wrap(ctx, err, "delete obsolete profiles")

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -719,6 +719,11 @@ func deleteMDMAppleConfigProfileByIDOrUUID(ctx context.Context, tx sqlx.ExtConte
 	}
 	res, err := tx.ExecContext(ctx, stmt, arg)
 	if err != nil {
+		if isMySQLForeignKey(err) {
+			if strings.Contains(err.Error(), "fk_policies_resend_apple_profile") {
+				return ctxerr.Wrap(ctx, &fleet.ConflictError{Message: "Couldn't delete. Policy automations use this profile. Please disable policy automations for this profile and try again."})
+			}
+		}
 		return ctxerr.Wrap(ctx, err)
 	}
 
@@ -2927,6 +2932,11 @@ ON DUPLICATE KEY UPDATE
 		return false, ctxerr.Wrap(ctx, err, "build statement to delete obsolete profiles")
 	}
 	if result, err = tx.ExecContext(ctx, stmt, args...); err != nil {
+		if isMySQLForeignKey(err) {
+			if strings.Contains(err.Error(), "fk_policies_resend_apple_profile") {
+				return false, ctxerr.Wrap(ctx, &fleet.ConflictError{Message: "Couldn't delete. Policy automations uses one or more of the profiles being deleted. Please disable policy automations for the profiles being deleted and try again."})
+			}
+		}
 		return false, ctxerr.Wrap(ctx, err, "delete obsolete profiles")
 	}
 	if result != nil {

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -14886,7 +14886,7 @@ func testDeleteMDMAppleConfigProfileWithPolicyAutomation(t *testing.T, ds *Datas
 	// batch-setting a new set of profiles that would delete the profile used by the
 	// policy automation returns a conflict mentioning the profiles being deleted.
 	requireConflict(ds.BatchSetMDMAppleProfiles(ctx, &tm.ID, []*fleet.MDMAppleConfigProfile{generateAppleCP("B", "B", tm.ID)}),
-		"Couldn't delete. Policy automations uses one or more of the profiles being deleted. Please disable policy automations for the profiles being deleted and try again.")
+		"Couldn't delete. Policy automations use one or more of the profiles being deleted. Please disable policy automations for the profiles being deleted and try again.")
 
 	// profiles are still there
 	_, err = ds.GetMDMAppleConfigProfile(ctx, profA.ProfileUUID)

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -141,6 +141,7 @@ func TestMDMApple(t *testing.T) {
 		{"DeviceLocation", testDeviceLocation},
 		{"TestGetDEPAssignProfileExpiredCooldowns", testGetDEPAssignProfileExpiredCooldowns},
 		{"DeleteMDMAppleDeclarationByNameCancelsInstalls", testDeleteMDMAppleDeclarationByNameCancelsInstalls},
+		{"DeleteMDMAppleConfigProfileWithPolicyAutomation", testDeleteMDMAppleConfigProfileWithPolicyAutomation},
 		{"BatchSetMDMAppleDeclarationsCaseChange", testBatchSetMDMAppleDeclarationsCaseChange},
 		{"RecoveryLockPasswordSetAndGet", testRecoveryLockPasswordSetAndGet},
 		{"RecoveryLockPasswordBulkSet", testRecoveryLockPasswordBulkSet},
@@ -14850,4 +14851,56 @@ func testMDMAppleBatchCustomActivations(t *testing.T, ds *Datastore) {
 	_, err = ds.BatchSetMDMProfiles(ctx, nil, nil, nil, []*fleet.MDMAppleDeclaration{}, nil, nil)
 	require.NoError(t, err)
 	require.Zero(t, countActivations())
+}
+
+func testDeleteMDMAppleConfigProfileWithPolicyAutomation(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	tm, err := ds.NewTeam(ctx, &fleet.Team{Name: "apple-policy-automation"})
+	require.NoError(t, err)
+
+	profA, err := ds.NewMDMAppleConfigProfile(ctx, *generateAppleCP("A", "A", tm.ID), nil)
+	require.NoError(t, err)
+	profB, err := ds.NewMDMAppleConfigProfile(ctx, *generateAppleCP("B", "B", tm.ID), nil)
+	require.NoError(t, err)
+
+	pol, err := ds.NewTeamPolicy(ctx, tm.ID, nil, fleet.PolicyPayload{
+		Name:        "resend A",
+		Query:       "SELECT 1;",
+		Platform:    "darwin",
+		ProfileUUID: &profA.ProfileUUID,
+	})
+	require.NoError(t, err)
+
+	requireConflict := func(err error, wantMsg string) {
+		var conflictErr *fleet.ConflictError
+		require.ErrorAs(t, err, &conflictErr)
+		require.ErrorContains(t, err, wantMsg)
+	}
+
+	// deleting the profile used by the policy automation returns a conflict with a
+	// user-friendly message instead of the raw foreign key error.
+	requireConflict(ds.DeleteMDMAppleConfigProfile(ctx, profA.ProfileUUID),
+		"Couldn't delete. Policy automations use this profile. Please disable policy automations for this profile and try again.")
+
+	// batch-setting a new set of profiles that would delete the profile used by the
+	// policy automation returns a conflict mentioning the profiles being deleted.
+	requireConflict(ds.BatchSetMDMAppleProfiles(ctx, &tm.ID, []*fleet.MDMAppleConfigProfile{generateAppleCP("B", "B", tm.ID)}),
+		"Couldn't delete. Policy automations uses one or more of the profiles being deleted. Please disable policy automations for the profiles being deleted and try again.")
+
+	// profiles are still there
+	_, err = ds.GetMDMAppleConfigProfile(ctx, profA.ProfileUUID)
+	require.NoError(t, err)
+	_, err = ds.GetMDMAppleConfigProfile(ctx, profB.ProfileUUID)
+	require.NoError(t, err)
+
+	// once the policy automation is disabled, both deletes succeed
+	pol.ResendAppleProfileUUID = nil
+	pol.ResendWindowsProfileUUID = nil
+	require.NoError(t, ds.SavePolicy(ctx, pol, false, false))
+
+	require.NoError(t, ds.DeleteMDMAppleConfigProfile(ctx, profA.ProfileUUID))
+	require.NoError(t, ds.BatchSetMDMAppleProfiles(ctx, &tm.ID, nil))
+	_, err = ds.GetMDMAppleConfigProfile(ctx, profB.ProfileUUID)
+	require.ErrorIs(t, err, sql.ErrNoRows)
 }

--- a/server/datastore/mysql/microsoft_mdm.go
+++ b/server/datastore/mysql/microsoft_mdm.go
@@ -1956,6 +1956,11 @@ func (ds *Datastore) DeleteMDMWindowsConfigProfile(ctx context.Context, profileU
 func deleteMDMWindowsConfigProfile(ctx context.Context, tx sqlx.ExtContext, profileUUID string) error {
 	res, err := tx.ExecContext(ctx, `DELETE FROM mdm_windows_configuration_profiles WHERE profile_uuid=?`, profileUUID)
 	if err != nil {
+		if isMySQLForeignKey(err) {
+			if strings.Contains(err.Error(), "fk_policies_resend_windows_profile") {
+				return ctxerr.Wrap(ctx, &fleet.ConflictError{Message: "Couldn't delete. Policy automations use this profile. Please disable policy automations for this profile and try again."})
+			}
+		}
 		return ctxerr.Wrap(ctx, err)
 	}
 
@@ -3266,6 +3271,11 @@ ON DUPLICATE KEY UPDATE
 		stmt, args = deleteAllProfilesForTeam, []any{profTeamID}
 	}
 	if result, err = tx.ExecContext(ctx, stmt, args...); err != nil {
+		if isMySQLForeignKey(err) {
+			if strings.Contains(err.Error(), "fk_policies_resend_windows_profile") {
+				return false, nil, ctxerr.Wrap(ctx, &fleet.ConflictError{Message: "Couldn't delete. Policy automations uses one or more of the profiles being deleted. Please disable policy automations for the profiles being deleted and try again."})
+			}
+		}
 		return false, nil, ctxerr.Wrap(ctx, err, "delete obsolete profiles")
 	}
 	rows, _ := result.RowsAffected()

--- a/server/datastore/mysql/microsoft_mdm.go
+++ b/server/datastore/mysql/microsoft_mdm.go
@@ -3273,7 +3273,7 @@ ON DUPLICATE KEY UPDATE
 	if result, err = tx.ExecContext(ctx, stmt, args...); err != nil {
 		if isMySQLForeignKey(err) {
 			if strings.Contains(err.Error(), "fk_policies_resend_windows_profile") {
-				return false, nil, ctxerr.Wrap(ctx, &fleet.ConflictError{Message: "Couldn't delete. Policy automations uses one or more of the profiles being deleted. Please disable policy automations for the profiles being deleted and try again."})
+				return false, nil, ctxerr.Wrap(ctx, &fleet.ConflictError{Message: "Couldn't delete. Policy automations use one or more of the profiles being deleted. Please disable policy automations for the profiles being deleted and try again."})
 			}
 		}
 		return false, nil, ctxerr.Wrap(ctx, err, "delete obsolete profiles")

--- a/server/datastore/mysql/microsoft_mdm_test.go
+++ b/server/datastore/mysql/microsoft_mdm_test.go
@@ -38,6 +38,7 @@ func TestMDMWindows(t *testing.T) {
 		name string
 		fn   func(t *testing.T, ds *Datastore)
 	}{
+		{"TestDeleteMDMWindowsConfigProfileWithPolicyAutomation", testDeleteMDMWindowsConfigProfileWithPolicyAutomation},
 		{"TestMDMWindowsEnrolledDevices", testMDMWindowsEnrolledDevice},
 		{"TestMDMWindowsEnrollmentZTDRegistrationID", testMDMWindowsEnrollmentZTDRegistrationID},
 		{"TestMDMWindowsInsertCommandForHosts", testMDMWindowsInsertCommandForHosts},
@@ -61,7 +62,6 @@ func TestMDMWindows(t *testing.T) {
 		{"TestWindowsProfilesStatusRollup", testWindowsProfilesStatusRollup},
 		{"TestWindowsProfilesStatusReconcileBatching", testWindowsProfilesStatusReconcileBatching},
 		{"TestBatchSetMDMWindowsProfiles", testBatchSetMDMWindowsProfiles},
-		{"DeleteMDMWindowsConfigProfileWithPolicyAutomation", testDeleteMDMWindowsConfigProfileWithPolicyAutomation},
 		{"TestMDMWindowsProfileLabels", testMDMWindowsProfileLabels},
 		{"NewMDMWindowsConfigProfileSoftwareUpdateTracking", testNewMDMWindowsConfigProfileSoftwareUpdateTracking},
 		{"TestUpdateMDMWindowsConfigProfile", testUpdateMDMWindowsConfigProfile},
@@ -8293,7 +8293,7 @@ func testDeleteMDMWindowsConfigProfileWithPolicyAutomation(t *testing.T, ds *Dat
 		require.ErrorAs(t, err, &conflictErr)
 		require.ErrorContains(t, err, wantMsg)
 	}
-	const batchConflictMsg = "Couldn't delete. Policy automations uses one or more of the profiles being deleted. " +
+	const batchConflictMsg = "Couldn't delete. Policy automations use one or more of the profiles being deleted. " +
 		"Please disable policy automations for the profiles being deleted and try again."
 
 	// deleting the profile used by the policy automation returns a conflict with a

--- a/server/datastore/mysql/microsoft_mdm_test.go
+++ b/server/datastore/mysql/microsoft_mdm_test.go
@@ -61,6 +61,7 @@ func TestMDMWindows(t *testing.T) {
 		{"TestWindowsProfilesStatusRollup", testWindowsProfilesStatusRollup},
 		{"TestWindowsProfilesStatusReconcileBatching", testWindowsProfilesStatusReconcileBatching},
 		{"TestBatchSetMDMWindowsProfiles", testBatchSetMDMWindowsProfiles},
+		{"DeleteMDMWindowsConfigProfileWithPolicyAutomation", testDeleteMDMWindowsConfigProfileWithPolicyAutomation},
 		{"TestMDMWindowsProfileLabels", testMDMWindowsProfileLabels},
 		{"NewMDMWindowsConfigProfileSoftwareUpdateTracking", testNewMDMWindowsConfigProfileSoftwareUpdateTracking},
 		{"TestUpdateMDMWindowsConfigProfile", testUpdateMDMWindowsConfigProfile},
@@ -8253,4 +8254,73 @@ func testMDMWindowsEnrollmentZTDRegistrationID(t *testing.T, ds *Datastore) {
 	got, err := ds.MDMWindowsGetEnrolledDeviceWithDeviceID(ctx, deviceID)
 	require.NoError(t, err)
 	require.Equal(t, ztdID, got.ZTDRegistrationID, "a re-enrollment without a ZTDID keeps the stored one")
+}
+
+func testDeleteMDMWindowsConfigProfileWithPolicyAutomation(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	tm, err := ds.NewTeam(ctx, &fleet.Team{Name: "windows-policy-automation"})
+	require.NoError(t, err)
+
+	newProfile := func(name, locURI string) *fleet.MDMWindowsConfigProfile {
+		p := windowsConfigProfileForTest(t, name, locURI)
+		p.TeamID = &tm.ID
+		return p
+	}
+
+	profA, err := ds.NewMDMWindowsConfigProfile(ctx, *newProfile("A", "./Device/A"), nil)
+	require.NoError(t, err)
+	profB, err := ds.NewMDMWindowsConfigProfile(ctx, *newProfile("B", "./Device/B"), nil)
+	require.NoError(t, err)
+
+	pol, err := ds.NewTeamPolicy(ctx, tm.ID, nil, fleet.PolicyPayload{
+		Name:        "resend A",
+		Query:       "SELECT 1;",
+		Platform:    "windows",
+		ProfileUUID: &profA.ProfileUUID,
+	})
+	require.NoError(t, err)
+
+	batchSet := func(profiles []*fleet.MDMWindowsConfigProfile) error {
+		return ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
+			_, _, err := ds.batchSetMDMWindowsProfilesDB(ctx, tx, &tm.ID, profiles, nil)
+			return err
+		})
+	}
+
+	requireConflict := func(err error, wantMsg string) {
+		var conflictErr *fleet.ConflictError
+		require.ErrorAs(t, err, &conflictErr)
+		require.ErrorContains(t, err, wantMsg)
+	}
+	const batchConflictMsg = "Couldn't delete. Policy automations uses one or more of the profiles being deleted. " +
+		"Please disable policy automations for the profiles being deleted and try again."
+
+	// deleting the profile used by the policy automation returns a conflict with a
+	// user-friendly message instead of the raw foreign key error.
+	requireConflict(ds.DeleteMDMWindowsConfigProfile(ctx, profA.ProfileUUID),
+		"Couldn't delete. Policy automations use this profile. Please disable policy automations for this profile and try again.")
+
+	// batch-setting a new set of profiles that would delete the profile used by the
+	// policy automation returns a conflict mentioning the profiles being deleted.
+	requireConflict(batchSet([]*fleet.MDMWindowsConfigProfile{newProfile("B", "./Device/B")}), batchConflictMsg)
+
+	// the same applies when the batch deletes every profile of the team
+	requireConflict(batchSet(nil), batchConflictMsg)
+
+	// profiles are still there
+	_, err = ds.GetMDMWindowsConfigProfile(ctx, profA.ProfileUUID)
+	require.NoError(t, err)
+	_, err = ds.GetMDMWindowsConfigProfile(ctx, profB.ProfileUUID)
+	require.NoError(t, err)
+
+	// once the policy automation is disabled, both deletes succeed
+	pol.ResendAppleProfileUUID = nil
+	pol.ResendWindowsProfileUUID = nil
+	require.NoError(t, ds.SavePolicy(ctx, pol, false, false))
+
+	require.NoError(t, ds.DeleteMDMWindowsConfigProfile(ctx, profA.ProfileUUID))
+	require.NoError(t, batchSet(nil))
+	_, err = ds.GetMDMWindowsConfigProfile(ctx, profB.ProfileUUID)
+	require.ErrorIs(t, err, sql.ErrNoRows)
 }

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -2952,6 +2952,28 @@ func (ds *Datastore) GetPoliciesWithAssociatedVPP(ctx context.Context, teamID ui
 	return policies, nil
 }
 
+func (ds *Datastore) GetPoliciesWithAssociatedProfile(ctx context.Context, teamID uint, policyIDs []uint) ([]fleet.PolicyProfileData, error) {
+	if len(policyIDs) == 0 {
+		return nil, nil
+	}
+	query := `SELECT p.id AS policy_id, p.name AS policy_name,
+       COALESCE(p.resend_apple_profile_uuid, p.resend_windows_profile_uuid) AS profile_uuid,
+       COALESCE(macp.name, mwcp.name) AS profile_name
+FROM policies p
+LEFT JOIN mdm_apple_configuration_profiles macp ON macp.profile_uuid = p.resend_apple_profile_uuid
+LEFT JOIN mdm_windows_configuration_profiles mwcp ON mwcp.profile_uuid = p.resend_windows_profile_uuid
+WHERE p.team_id = ? AND (p.resend_apple_profile_uuid IS NOT NULL OR p.resend_windows_profile_uuid IS NOT NULL) AND p.id IN (?)`
+	query, args, err := sqlx.In(query, teamID, policyIDs)
+	if err != nil {
+		return nil, ctxerr.Wrapf(ctx, err, "build sqlx.In for get policies with associated profile")
+	}
+	var policies []fleet.PolicyProfileData
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &policies, query, args...); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "get policies with associated profile")
+	}
+	return policies, nil
+}
+
 func (ds *Datastore) GetPoliciesWithAssociatedScript(ctx context.Context, teamID uint, policyIDs []uint) ([]fleet.PolicyScriptData, error) {
 	if len(policyIDs) == 0 {
 		return nil, nil

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -83,6 +83,7 @@ func TestPolicies(t *testing.T) {
 		{"TestPoliciesTeamPoliciesWithResendProfile", testTeamPoliciesWithResendProfile},
 		{"TestPoliciesApplyPolicySpecsWithResendProfile", testApplyPolicySpecsWithResendProfile},
 		{"TestPoliciesResendProfileRejectsFleetManaged", testPoliciesResendProfileRejectsFleetManaged},
+		{"TestPoliciesGetPoliciesWithAssociatedProfile", testGetPoliciesWithAssociatedProfile},
 		{"TestPoliciesApplyPolicySpecsResendProfileChangeResetsStats", testApplyPolicySpecsResendProfileChangeResetsStats},
 		{"TestPoliciesSaveResendProfile", testSavePolicyResendProfile},
 		{"TestPoliciesResendProfileAutomationFilter", testResendProfileAutomationFilter},
@@ -5488,6 +5489,125 @@ func testPoliciesResendProfileRejectsFleetManaged(t *testing.T, ds *Datastore) {
 			ProfileUUID: &userProf.ProfileUUID,
 		}}))
 	})
+}
+
+func testGetPoliciesWithAssociatedProfile(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+
+	user1 := test.NewUser(t, ds, "Oscar", "oscar@example.com", true)
+	team1, err := ds.NewTeam(ctx, &fleet.Team{Name: "team get policies with profile"})
+	require.NoError(t, err)
+	team2, err := ds.NewTeam(ctx, &fleet.Team{Name: "other team get policies with profile"})
+	require.NoError(t, err)
+
+	appleProf, err := ds.NewMDMAppleConfigProfile(ctx, fleet.MDMAppleConfigProfile{
+		Name:         "get-apple-profile",
+		Identifier:   "com.example.get-apple-profile",
+		Mobileconfig: []byte("<plist></plist>"),
+		TeamID:       &team1.ID,
+	}, nil)
+	require.NoError(t, err)
+	winProf, err := ds.NewMDMWindowsConfigProfile(ctx, fleet.MDMWindowsConfigProfile{
+		Name:   "get-windows-profile",
+		SyncML: []byte("<Replace></Replace>"),
+		TeamID: &team1.ID,
+	}, nil)
+	require.NoError(t, err)
+	noTeamProf, err := ds.NewMDMAppleConfigProfile(ctx, fleet.MDMAppleConfigProfile{
+		Name:         "get-no-team-profile",
+		Identifier:   "com.example.get-no-team-profile",
+		Mobileconfig: []byte("<plist></plist>"),
+	}, nil)
+	require.NoError(t, err)
+
+	newPolicy := func(teamID uint, name string, profileUUID *string) *fleet.Policy {
+		p, err := ds.NewTeamPolicy(ctx, teamID, &user1.ID, fleet.PolicyPayload{
+			Name:        name,
+			Query:       "SELECT 1;",
+			ProfileUUID: profileUUID,
+		})
+		require.NoError(t, err)
+		return p
+	}
+
+	appleResendPolicy := newPolicy(team1.ID, "apple resend policy", &appleProf.ProfileUUID)
+	winResendPolicy := newPolicy(team1.ID, "windows resend policy", &winProf.ProfileUUID)
+	noResendPolicy := newPolicy(team1.ID, "no resend policy", nil)
+	noTeamResendPolicy := newPolicy(fleet.PolicyNoTeamID, "no team resend policy", &noTeamProf.ProfileUUID)
+
+	// No policy IDs requested: no query, no results.
+	got, err := ds.GetPoliciesWithAssociatedProfile(ctx, team1.ID, nil)
+	require.NoError(t, err)
+	require.Empty(t, got)
+
+	// An Apple resend policy returns the policy and profile names alongside the UUID; those
+	// are what the resend activity records.
+	got, err = ds.GetPoliciesWithAssociatedProfile(ctx, team1.ID, []uint{appleResendPolicy.ID})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, fleet.PolicyProfileData{
+		PolicyID:    appleResendPolicy.ID,
+		PolicyName:  "apple resend policy",
+		ProfileUUID: appleProf.ProfileUUID,
+		ProfileName: appleProf.Name,
+	}, got[0])
+
+	// A Windows resend policy resolves its name from the Windows profile table.
+	got, err = ds.GetPoliciesWithAssociatedProfile(ctx, team1.ID, []uint{winResendPolicy.ID})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, fleet.PolicyProfileData{
+		PolicyID:    winResendPolicy.ID,
+		PolicyName:  "windows resend policy",
+		ProfileUUID: winProf.ProfileUUID,
+		ProfileName: winProf.Name,
+	}, got[0])
+
+	// A policy without an associated profile is filtered out, even when asked for alongside
+	// policies that have one.
+	got, err = ds.GetPoliciesWithAssociatedProfile(ctx, team1.ID, []uint{noResendPolicy.ID})
+	require.NoError(t, err)
+	require.Empty(t, got)
+
+	got, err = ds.GetPoliciesWithAssociatedProfile(ctx, team1.ID, []uint{appleResendPolicy.ID, winResendPolicy.ID, noResendPolicy.ID})
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	byID := make(map[uint]fleet.PolicyProfileData, len(got))
+	for _, p := range got {
+		byID[p.PolicyID] = p
+	}
+	require.Equal(t, appleProf.ProfileUUID, byID[appleResendPolicy.ID].ProfileUUID)
+	require.Equal(t, winProf.ProfileUUID, byID[winResendPolicy.ID].ProfileUUID)
+
+	// The team ID scopes the lookup: a policy from another team is not returned even when its
+	// ID is requested, so a host can't have another team's profile resent.
+	got, err = ds.GetPoliciesWithAssociatedProfile(ctx, team2.ID, []uint{appleResendPolicy.ID, winResendPolicy.ID})
+	require.NoError(t, err)
+	require.Empty(t, got)
+
+	// "No team" policies live under PolicyNoTeamID and are not returned for a real team.
+	got, err = ds.GetPoliciesWithAssociatedProfile(ctx, fleet.PolicyNoTeamID, []uint{noTeamResendPolicy.ID})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, noTeamProf.ProfileUUID, got[0].ProfileUUID)
+	require.Equal(t, noTeamProf.Name, got[0].ProfileName)
+
+	got, err = ds.GetPoliciesWithAssociatedProfile(ctx, team1.ID, []uint{noTeamResendPolicy.ID})
+	require.NoError(t, err)
+	require.Empty(t, got)
+
+	// Renaming the profile or the policy is reflected on the next lookup, since both names are
+	// read through rather than copied onto the policy.
+	appleProf.Name = "get-apple-profile-renamed"
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		_, err := q.ExecContext(ctx, `UPDATE mdm_apple_configuration_profiles SET name = ? WHERE profile_uuid = ?`,
+			appleProf.Name, appleProf.ProfileUUID)
+		return err
+	})
+	got, err = ds.GetPoliciesWithAssociatedProfile(ctx, team1.ID, []uint{appleResendPolicy.ID})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, appleProf.Name, got[0].ProfileName)
 }
 
 func testApplyPolicySpecsWithResendProfile(t *testing.T, ds *Datastore) {

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -1199,10 +1199,16 @@ type ActivityTypeResentConfigurationProfile struct {
 	HostDisplayName *string `json:"host_display_name"`
 	ProfileName     string  `json:"profile_name"`
 	ProfileUUID     string  `json:"profile_uuid"`
+	PolicyID        *uint   `json:"policy_id"`   // null on manual resend
+	PolicyName      *string `json:"policy_name"` // null on manual resend
 }
 
 func (a ActivityTypeResentConfigurationProfile) ActivityName() string {
 	return "resent_configuration_profile"
+}
+
+func (a ActivityTypeResentConfigurationProfile) WasFromAutomation() bool {
+	return a.PolicyID != nil
 }
 
 type ActivityTypeResentConfigurationProfileBatch struct {

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -1211,6 +1211,16 @@ func (a ActivityTypeResentConfigurationProfile) WasFromAutomation() bool {
 	return a.PolicyID != nil
 }
 
+// HostIDs links the activity to the host whose profile was resent. Without it no
+// activity_host_past row is written, and the activity is invisible to every feed that joins
+// through that table — including the policy automation feed.
+func (a ActivityTypeResentConfigurationProfile) HostIDs() []uint {
+	if a.HostID == nil {
+		return nil
+	}
+	return []uint{*a.HostID}
+}
+
 type ActivityTypeResentConfigurationProfileBatch struct {
 	ProfileName string `json:"profile_name"`
 	ProfileUUID string `json:"profile_uuid"`

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1035,6 +1035,7 @@ type Datastore interface {
 	// GetPoliciesWithAssociatedVPP returns team policies that have an associated VPP app
 	GetPoliciesWithAssociatedVPP(ctx context.Context, teamID uint, policyIDs []uint) ([]PolicyVPPData, error)
 	GetPoliciesWithAssociatedScript(ctx context.Context, teamID uint, policyIDs []uint) ([]PolicyScriptData, error)
+	GetPoliciesWithAssociatedProfile(ctx context.Context, teamID uint, policyIDs []uint) ([]PolicyProfileData, error)
 	// ResetPolicyAutomationRetryAttemptsForHost marks all prior policy automation
 	// script/install attempts on this host as "old sequence" (attempt_number=0)
 	// for the given policies. Used when continuous_automations_enabled triggers

--- a/server/fleet/policies.go
+++ b/server/fleet/policies.go
@@ -621,6 +621,13 @@ type PolicyScriptData struct {
 	ContinuousAutomationsEnabled bool `db:"continuous_automations_enabled"`
 }
 
+type PolicyProfileData struct {
+	PolicyID    uint   `db:"policy_id"`
+	PolicyName  string `db:"policy_name"`
+	ProfileUUID string `db:"profile_uuid"`
+	ProfileName string `db:"profile_name"`
+}
+
 // PolicyLite is a stripped down version of the policy.
 type PolicyLite struct {
 	ID uint `db:"id"`

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -728,6 +728,8 @@ type GetPoliciesWithAssociatedVPPFunc func(ctx context.Context, teamID uint, pol
 
 type GetPoliciesWithAssociatedScriptFunc func(ctx context.Context, teamID uint, policyIDs []uint) ([]fleet.PolicyScriptData, error)
 
+type GetPoliciesWithAssociatedProfileFunc func(ctx context.Context, teamID uint, policyIDs []uint) ([]fleet.PolicyProfileData, error)
+
 type ResetPolicyAutomationRetryAttemptsForHostFunc func(ctx context.Context, hostID uint, policyIDs []uint) error
 
 type GetCalendarPoliciesFunc func(ctx context.Context, teamID uint) ([]fleet.PolicyCalendarData, error)
@@ -3402,6 +3404,9 @@ type DataStore struct {
 
 	GetPoliciesWithAssociatedScriptFunc        GetPoliciesWithAssociatedScriptFunc
 	GetPoliciesWithAssociatedScriptFuncInvoked bool
+
+	GetPoliciesWithAssociatedProfileFunc        GetPoliciesWithAssociatedProfileFunc
+	GetPoliciesWithAssociatedProfileFuncInvoked bool
 
 	ResetPolicyAutomationRetryAttemptsForHostFunc        ResetPolicyAutomationRetryAttemptsForHostFunc
 	ResetPolicyAutomationRetryAttemptsForHostFuncInvoked bool
@@ -8295,6 +8300,13 @@ func (s *DataStore) GetPoliciesWithAssociatedScript(ctx context.Context, teamID 
 	s.GetPoliciesWithAssociatedScriptFuncInvoked = true
 	s.mu.Unlock()
 	return s.GetPoliciesWithAssociatedScriptFunc(ctx, teamID, policyIDs)
+}
+
+func (s *DataStore) GetPoliciesWithAssociatedProfile(ctx context.Context, teamID uint, policyIDs []uint) ([]fleet.PolicyProfileData, error) {
+	s.mu.Lock()
+	s.GetPoliciesWithAssociatedProfileFuncInvoked = true
+	s.mu.Unlock()
+	return s.GetPoliciesWithAssociatedProfileFunc(ctx, teamID, policyIDs)
 }
 
 func (s *DataStore) ResetPolicyAutomationRetryAttemptsForHost(ctx context.Context, hostID uint, policyIDs []uint) error {

--- a/server/service/integration_mdm_profiles_test.go
+++ b/server/service/integration_mdm_profiles_test.go
@@ -507,7 +507,7 @@ func (s *integrationMDMTestSuite) TestAppleProfileManagement() {
 	s.checkMDMProfilesSummaries(t, &tm.ID, fleet.MDMProfilesSummary{Verifying: 1}, nil)
 	s.lastActivityMatches(
 		fleet.ActivityTypeResentConfigurationProfile{}.ActivityName(),
-		fmt.Sprintf(`{"host_id": %d, "host_display_name": %q, "profile_name": %q, "profile_uuid": %q}`, host.ID, host.DisplayName(), "name-"+mcUUID, mcUUID),
+		fmt.Sprintf(`{"host_id": %d, "host_display_name": %q, "profile_name": %q, "profile_uuid": %q, "policy_id": null, "policy_name": null}`, host.ID, host.DisplayName(), "name-"+mcUUID, mcUUID),
 		0)
 
 	// add a declaration to the team

--- a/server/service/integration_mdm_profiles_test.go
+++ b/server/service/integration_mdm_profiles_test.go
@@ -10499,3 +10499,166 @@ func (s *integrationMDMTestSuite) TestProfileEditCancelsUndeliveredInstallComman
 	require.Zero(t, mdmActiveCmdCount(t, s.ds, iOld), "undelivered install command still active after profile edit")
 	require.Equal(t, 1, mdmActiveCmdCount(t, s.ds, iNew), "new install command not active after profile edit")
 }
+
+// TestPolicyAutomationResendConfigurationProfile covers the policy automation that resends a
+// configuration profile when its policy starts failing on a host: the profile is queued for
+// redelivery, actually reaches the device, and the resend is recorded as a Fleet-initiated
+// activity naming the policy that triggered it. The activity is the only record of an automated
+// resend, so its payload is asserted in full.
+func (s *integrationMDMTestSuite) TestPolicyAutomationResendConfigurationProfile() {
+	t := s.T()
+	ctx := context.Background()
+
+	tm, err := s.ds.NewTeam(ctx, &fleet.Team{Name: t.Name()})
+	require.NoError(t, err)
+
+	host, mdmDevice := createHostThenEnrollMDM(s.ds, s.server.URL, t)
+	setupPusher(s, t, mdmDevice)
+	// Process the enrollment and drain the profiles it queues, so later payload checks see only
+	// what this test triggers.
+	s.awaitRunAppleMDMWorkerSchedule()
+	checkNextPayloads(t, mdmDevice, false)
+
+	// Add a profile to the team and move the host into it. The profile schedule throttles
+	// per-host reprocessing, so the key is cleared before each trigger.
+	mcUUID := "a" + uuid.NewString()
+	profName := "name-" + mcUUID
+	prof := mcBytesForTest(profName, "identifier-"+mcUUID, mcUUID)
+	mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		stmt := `INSERT INTO mdm_apple_configuration_profiles (profile_uuid, team_id, name, identifier, mobileconfig, checksum, uploaded_at) VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP);`
+		_, err := q.ExecContext(ctx, stmt, mcUUID, tm.ID, profName, "identifier-"+mcUUID, prof, test.MakeTestBytes())
+		return err
+	})
+	require.NoError(t, s.ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&tm.ID, []uint{host.ID})))
+
+	syncProfiles := func() {
+		require.NoError(t, s.keyValueStore.Delete(ctx, fleet.MDMProfileProcessingKeyPrefix+":"+host.UUID))
+		s.awaitTriggerProfileSchedule(t)
+	}
+	// Deliver the team's profiles, including this one. The payloads also cover the fleetd config
+	// and CA profiles swapped out by the team move, so they aren't asserted here.
+	syncProfiles()
+	checkNextPayloads(t, mdmDevice, false)
+
+	profileStatus := func() *fleet.MDMDeliveryStatus {
+		hostProfs, err := s.ds.GetHostMDMAppleProfiles(ctx, host.UUID)
+		require.NoError(t, err)
+		for _, p := range hostProfs {
+			if p.ProfileUUID == mcUUID {
+				return p.Status
+			}
+		}
+		t.Fatalf("profile %s not found on host %s", mcUUID, host.UUID)
+		return nil
+	}
+
+	// Mark it verified: a host that has drifted from a verified profile is what the automation
+	// exists for. (A pending or verifying profile is deliberately left alone.)
+	setProfileStatus := func(status fleet.MDMDeliveryStatus) {
+		mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+			stmt := `UPDATE host_mdm_apple_profiles SET status = ? WHERE profile_uuid = ? AND host_uuid = ?`
+			_, err := q.ExecContext(ctx, stmt, status, mcUUID, host.UUID)
+			return err
+		})
+	}
+	setProfileStatus(fleet.MDMDeliveryVerified)
+	require.Equal(t, &fleet.MDMDeliveryVerified, profileStatus())
+
+	// A policy that resends the profile when it fails, plus one with no profile attached, to
+	// confirm only the former triggers a resend.
+	newPolicy := func(name string, profileUUID *string) *fleet.Policy {
+		var resp fleet.TeamPolicyResponse
+		s.DoJSON("POST", fmt.Sprintf("/api/latest/fleet/teams/%d/policies", tm.ID), fleet.TeamPolicyRequest{
+			Name:        name,
+			Query:       "SELECT 1;",
+			Platform:    "darwin",
+			ProfileUUID: profileUUID,
+		}, http.StatusOK, &resp)
+		require.NotNil(t, resp.Policy)
+		return resp.Policy
+	}
+	resendPolicy := newPolicy("resend profile policy", &mcUUID)
+	require.NotNil(t, resendPolicy.ResendConfigurationProfile)
+	require.Equal(t, mcUUID, resendPolicy.ResendConfigurationProfile.UUID)
+	plainPolicy := newPolicy("plain policy", nil)
+
+	reportPolicies := func(results map[uint]*bool) {
+		distributedResp := submitDistributedQueryResultsResponse{}
+		s.DoJSON("POST", "/api/osquery/distributed/write",
+			genDistributedReqWithPolicyResults(host, results), http.StatusOK, &distributedResp)
+	}
+
+	// Both policies passing: nothing is resent, the profile stays verified.
+	reportPolicies(map[uint]*bool{resendPolicy.ID: new(true), plainPolicy.ID: new(true)})
+	require.Equal(t, &fleet.MDMDeliveryVerified, profileStatus())
+
+	// The policy with no profile failing: still nothing to resend.
+	reportPolicies(map[uint]*bool{resendPolicy.ID: new(true), plainPolicy.ID: new(false)})
+	require.Equal(t, &fleet.MDMDeliveryVerified, profileStatus())
+
+	// The resend policy fails: the profile is queued for redelivery. Its status is cleared to NULL
+	// in the DB, which the API reports as pending, and the resend is recorded.
+	reportPolicies(map[uint]*bool{resendPolicy.ID: new(false), plainPolicy.ID: new(true)})
+	require.Equal(t, &fleet.MDMDeliveryPending, profileStatus())
+
+	// The activity names the host, the profile and the policy that triggered the resend, and is
+	// attributed to Fleet rather than to a user.
+	s.lastActivityMatchesExtended(
+		fleet.ActivityTypeResentConfigurationProfile{}.ActivityName(),
+		fmt.Sprintf(`{"host_id": %d, "host_display_name": %q, "profile_name": %q, "profile_uuid": %q, "policy_id": %d, "policy_name": %q}`,
+			host.ID, host.DisplayName(), profName, mcUUID, resendPolicy.ID, resendPolicy.Name),
+		0,
+		new(true),
+	)
+
+	// The policy keeps failing on the next run, but it did not pass in between, so nothing is
+	// resent and no further activity is recorded.
+	lastActivityID := s.lastActivityMatches("", "", 0)
+	reportPolicies(map[uint]*bool{resendPolicy.ID: new(false)})
+	require.Equal(t, lastActivityID, s.lastActivityMatches("", "", 0),
+		"a policy that was already failing should not resend again")
+
+	// The profile really is redelivered to the device on the next profile schedule run.
+	syncProfiles()
+	installs, removes := checkNextPayloads(t, mdmDevice, false)
+	require.Len(t, installs, 1)
+	s.signedProfilesMatch([][]byte{prof}, installs)
+	require.Empty(t, removes)
+	require.Equal(t, &fleet.MDMDeliveryVerifying, profileStatus())
+
+	// Even with the profile back to verified — so nothing else would block a resend — a policy
+	// that was already failing still doesn't trigger one.
+	setProfileStatus(fleet.MDMDeliveryVerified)
+	reportPolicies(map[uint]*bool{resendPolicy.ID: new(false)})
+	require.Equal(t, lastActivityID, s.lastActivityMatches("", "", 0),
+		"a verified profile should not be resent for a policy that was already failing")
+	require.Equal(t, &fleet.MDMDeliveryVerified, profileStatus())
+
+	// Once the policy passes and fails again, the transition triggers another resend.
+	reportPolicies(map[uint]*bool{resendPolicy.ID: new(true)})
+	reportPolicies(map[uint]*bool{resendPolicy.ID: new(false)})
+	require.Equal(t, &fleet.MDMDeliveryPending, profileStatus())
+	s.lastActivityMatchesExtended(
+		fleet.ActivityTypeResentConfigurationProfile{}.ActivityName(),
+		fmt.Sprintf(`{"host_id": %d, "host_display_name": %q, "profile_name": %q, "profile_uuid": %q, "policy_id": %d, "policy_name": %q}`,
+			host.ID, host.DisplayName(), profName, mcUUID, resendPolicy.ID, resendPolicy.Name),
+		0,
+		new(true),
+	)
+
+	// A Windows profile on a policy failing on this macOS host resends nothing and records no
+	// activity: the host has no row for that profile, so the resend is rejected rather than
+	// recorded as something that happened.
+	winProf, err := s.ds.NewMDMWindowsConfigProfile(ctx, fleet.MDMWindowsConfigProfile{
+		Name:   "win-" + uuid.NewString(),
+		SyncML: []byte("<Replace></Replace>"),
+		TeamID: &tm.ID,
+	}, nil)
+	require.NoError(t, err)
+	winResendPolicy := newPolicy("windows resend profile policy", &winProf.ProfileUUID)
+
+	lastActivityID = s.lastActivityMatches("", "", 0)
+	reportPolicies(map[uint]*bool{winResendPolicy.ID: new(false)})
+	require.Equal(t, lastActivityID, s.lastActivityMatches("", "", 0),
+		"no activity should be recorded for a profile the host can't receive")
+}

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -1572,7 +1572,6 @@ func deleteMDMConfigProfileEndpoint(ctx context.Context, request interface{}, sv
 	if isAppleProfileUUID(req.ProfileUUID) { //nolint:gocritic // ignore ifElseChain
 		err = svc.DeleteMDMAppleConfigProfile(ctx, req.ProfileUUID)
 	} else if isAppleDeclarationUUID(req.ProfileUUID) {
-		// TODO: we could potentially combined with the other service methods
 		err = svc.DeleteMDMAppleDeclaration(ctx, req.ProfileUUID)
 	} else if isAndroidProfileUUID(req.ProfileUUID) {
 		err = svc.DeleteMDMAndroidConfigProfile(ctx, req.ProfileUUID)

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -3712,9 +3712,14 @@ func (svc *Service) ResendHostMDMProfile(ctx context.Context, hostID uint, profi
 		return ctxerr.Wrap(ctx, err, "authorizing profile team")
 	}
 
-	err = checkAndResendHostMDMProfile(ctx, svc, host, profileUUID, profileName)
+	err = nil
+	// A user asked for this resend, so everything goes back to them, rejection or not.
+	onError := func(innerErr error, _ bool) {
+		err = innerErr
+	}
+	checkAndResendHostMDMProfile(ctx, svc, host, onError, profileUUID, profileName, nil)
 	if err != nil {
-		return err
+		return ctxerr.Wrap(ctx, err, "checking and resending host mdm profile")
 	}
 
 	return nil
@@ -3726,44 +3731,66 @@ func (svc *Service) ResendDeviceHostMDMProfile(ctx context.Context, host *fleet.
 		return err
 	}
 
-	err = checkAndResendHostMDMProfile(ctx, svc, host, profileUUID, profileName)
+	err = nil
+	// A user asked for this resend, so everything goes back to them, rejection or not.
+	onError := func(innerErr error, _ bool) {
+		err = innerErr
+	}
+	checkAndResendHostMDMProfile(ctx, svc, host, onError, profileUUID, profileName, nil)
 	if err != nil {
-		return err
+		return ctxerr.Wrap(ctx, err, "checking and resending host mdm profile")
 	}
 
 	return nil
 }
 
-func checkAndResendHostMDMProfile(ctx context.Context, svc *Service, host *fleet.Host, profileUUID string, profileName string) error {
+type checkAndResendPolicyArgs struct {
+	PolicyID   uint
+	PolicyName string
+}
+
+func checkAndResendHostMDMProfile(ctx context.Context, svc *Service, host *fleet.Host, onError func(err error, rejected bool), profileUUID string, profileName string, policyArgs *checkAndResendPolicyArgs) {
 	status, err := svc.ds.GetHostMDMProfileInstallStatus(ctx, host.UUID, profileUUID)
 	if err != nil {
 		if fleet.IsNotFound(err) {
-			return ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("HostMDMProfile", "Unable to match profile to host.").WithStatus(http.StatusNotFound), "getting host mdm profile status")
+			onError(fleet.NewInvalidArgumentError("HostMDMProfile", "Unable to match profile to host.").WithStatus(http.StatusNotFound), true)
+			return
 		}
-		return ctxerr.Wrap(ctx, err, "getting host mdm profile status")
+		onError(ctxerr.Wrap(ctx, err, "getting host mdm profile status"), false)
+		return
 	}
 	if status == fleet.MDMDeliveryPending || status == fleet.MDMDeliveryVerifying {
-		return ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("HostMDMProfile", "Couldn’t resend. Configuration profiles with “pending” or “verifying” status can’t be resent.").WithStatus(http.StatusConflict), "check profile status")
+		onError(ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("HostMDMProfile", "Couldn’t resend. Configuration profiles with “pending” or “verifying” status can’t be resent.").WithStatus(http.StatusConflict), "check profile status"), true)
+		return
 	}
 	if status != fleet.MDMDeliveryFailed && status != fleet.MDMDeliveryVerified {
 		// this should never happen, but just in case
-		return ctxerr.Errorf(ctx, "unrecognized profile status %s", status)
+		onError(ctxerr.Errorf(ctx, "unrecognized profile status %s", status), false)
+		return
 	}
 
 	if err := svc.ds.ResendHostMDMProfile(ctx, host.UUID, profileUUID); err != nil {
-		return ctxerr.Wrap(ctx, err, "resending host mdm profile")
+		onError(ctxerr.Wrap(ctx, err, "resending host mdm profile"), false)
+		return
+	}
+
+	details := &fleet.ActivityTypeResentConfigurationProfile{
+		HostID:          &host.ID,
+		HostDisplayName: new(host.DisplayName()),
+		ProfileName:     profileName,
+		ProfileUUID:     profileUUID,
+	}
+
+	if policyArgs != nil {
+		details.PolicyID = &policyArgs.PolicyID
+		details.PolicyName = &policyArgs.PolicyName
 	}
 
 	if err := svc.NewActivity(
-		ctx, authz.UserFromContext(ctx), &fleet.ActivityTypeResentConfigurationProfile{
-			HostID:          &host.ID,
-			HostDisplayName: ptr.String(host.DisplayName()),
-			ProfileName:     profileName,
-			ProfileUUID:     profileUUID,
-		}); err != nil {
-		return ctxerr.Wrap(ctx, err, "logging activity for resend config profile")
+		ctx, authz.UserFromContext(ctx), details); err != nil {
+		onError(ctxerr.Wrap(ctx, err, "logging activity for resend config profile"), false)
+		return
 	}
-	return nil
 }
 
 // getPRofileToResendDetails returns the team ID and name of the profile to be resent.

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -1011,6 +1011,26 @@ func (svc *Service) hasSetupExperiencePendingOrRunningItems(ctx context.Context,
 // A host in setup experience is sent a subset of its in-scope policies, but it is checked against the full set: those
 // policies are legitimately the host's, so a result for one of them is worth keeping even if setup experience had not
 // asked for it yet.
+// summarizePolicyResults splits policy results into failing, passing and did-not-execute policy
+// IDs, sorted, so they can be logged readably: the results map holds *bool, which renders as
+// pointer addresses.
+func summarizePolicyResults(policyResults map[uint]*bool) (failing, passing, notExecuted []uint) {
+	for policyID, result := range policyResults {
+		switch {
+		case result == nil:
+			notExecuted = append(notExecuted, policyID)
+		case *result:
+			passing = append(passing, policyID)
+		default:
+			failing = append(failing, policyID)
+		}
+	}
+	for _, ids := range [][]uint{failing, passing, notExecuted} {
+		slices.Sort(ids)
+	}
+	return failing, passing, notExecuted
+}
+
 func (svc *Service) discardOutOfScopePolicyResults(ctx context.Context, host *fleet.Host, policyResults map[uint]*bool) error {
 	candidateIDs := make([]uint, 0, len(policyResults))
 	for policyID := range policyResults {
@@ -1380,6 +1400,16 @@ func (svc *Service) SubmitDistributedQueryResults(
 	// Keep separate from the block below: this can empty policyResults, and an empty (rather than absent) result set
 	// makes RecordPolicyQueryExecutions treat every stored policy_membership row for the host as stale.
 	if len(policyResults) > 0 {
+		failing, passing, notExecuted := summarizePolicyResults(policyResults)
+		svc.logger.DebugContext(ctx, "received policy results",
+			"host_id", host.ID,
+			"host_platform", host.Platform,
+			"team_id", ptr.ValOrZero(host.TeamID),
+			"failing", failing,
+			"passing", passing,
+			"not_executed", notExecuted,
+		)
+
 		if err := svc.discardOutOfScopePolicyResults(ctx, host, policyResults); err != nil {
 			// Drop this cycle's policy results instead of failing the whole write: the host reports them again on
 			// its next check-in, whereas the detail and additional results from this same payload are only written
@@ -1405,6 +1435,14 @@ func (svc *Service) SubmitDistributedQueryResults(
 		for _, id := range newFailing {
 			newFailingSet[id] = struct{}{}
 		}
+		// The automations below act on transitions, not on the raw results, so this is the line to
+		// check first when one of them doesn't fire for a policy that is reporting a failure.
+		svc.logger.DebugContext(ctx, "computed policy transitions",
+			"host_id", host.ID,
+			"new_failing", newFailing,
+			"new_passing", newPassing,
+			"results_in_scope", len(policyResults),
+		)
 
 		if err := processCalendarPolicies(ctx, svc.ds, ac, host, policyResults, svc.logger); err != nil {
 			logging.WithErr(ctx, err)
@@ -1416,6 +1454,10 @@ func (svc *Service) SubmitDistributedQueryResults(
 
 		if host.Platform == "darwin" || host.Platform == "windows" {
 			if err := svc.processConditionalAccessForNewlyFailingPolicies(ctx, host.ID, host.TeamID, host.OrbitNodeKey, host.Platform, policyResults); err != nil {
+				logging.WithErr(ctx, err)
+			}
+
+			if err := svc.processProfileResendsForNewlyFailingPolicies(ctx, host, policyResults, newFailingSet); err != nil {
 				logging.WithErr(ctx, err)
 			}
 		}
@@ -2568,6 +2610,95 @@ func (svc *Service) processVPPForNewlyFailingPolicies(
 
 		queuedAppInstalls[failingPolicyWithVPP.AdamID] = struct{}{}
 		logger.DebugContext(ctx, "vpp install request sent", "command_uuid", commandUUID)
+	}
+
+	return nil
+}
+
+func (svc *Service) processProfileResendsForNewlyFailingPolicies(
+	ctx context.Context,
+	host *fleet.Host,
+	incomingPolicyResults map[uint]*bool,
+	newFailingSet map[uint]struct{},
+) error {
+	var policyTeamID uint
+	if host.TeamID == nil {
+		policyTeamID = fleet.PolicyNoTeamID
+	} else {
+		policyTeamID = *host.TeamID
+	}
+
+	// Only trigger resend on pass->fail or fresh failures.
+	var newlyFailingPolicyIDs []uint
+	for policyID, policyResult := range incomingPolicyResults {
+		if policyResult == nil || *policyResult {
+			continue
+		}
+		if _, newlyFailing := newFailingSet[policyID]; !newlyFailing {
+			continue
+		}
+		newlyFailingPolicyIDs = append(newlyFailingPolicyIDs, policyID)
+	}
+	if len(newlyFailingPolicyIDs) == 0 {
+		return nil
+	}
+
+	policiesWithProfile, err := svc.ds.GetPoliciesWithAssociatedProfile(ctx, policyTeamID, newlyFailingPolicyIDs)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "failed to get policies with associated profile")
+	}
+	svc.logger.DebugContext(ctx, "looked up profiles to resend for newly failing policies",
+		"host_id", host.ID,
+		"team_id", policyTeamID,
+		"newly_failing", newlyFailingPolicyIDs,
+		"with_profile", len(policiesWithProfile),
+	)
+	if len(policiesWithProfile) == 0 {
+		return nil
+	}
+
+	for _, profile := range policiesWithProfile {
+		var reported bool
+		onError := func(innerErr error, rejected bool) {
+			reported = true
+			if rejected {
+				svc.logger.DebugContext(ctx, "skipping resend of MDM profile for host",
+					"host_id", host.ID,
+					"host_platform", host.Platform,
+					"policy_id", profile.PolicyID,
+					"profile_uuid", profile.ProfileUUID,
+					"err", innerErr,
+				)
+				return
+			}
+			svc.logger.ErrorContext(ctx, "failed to resend MDM profile for host",
+				"host_id", host.ID,
+				"policy_id", profile.PolicyID,
+				"profile_uuid", profile.ProfileUUID,
+				"err", innerErr,
+			)
+		}
+		svc.logger.DebugContext(ctx, "attempting resend of MDM profile for newly failing policy",
+			"host_id", host.ID,
+			"host_uuid", host.UUID,
+			"policy_id", profile.PolicyID,
+			"policy_name", profile.PolicyName,
+			"profile_uuid", profile.ProfileUUID,
+			"profile_name", profile.ProfileName,
+		)
+		checkAndResendHostMDMProfile(ctx, svc, host, onError, profile.ProfileUUID, profile.ProfileName, &checkAndResendPolicyArgs{
+			PolicyID:   profile.PolicyID,
+			PolicyName: profile.PolicyName,
+		})
+		if !reported {
+			// Nothing went to onError, so the profile is queued for the profile schedule to pick up
+			// and the activity is recorded.
+			svc.logger.DebugContext(ctx, "queued MDM profile for resend",
+				"host_id", host.ID,
+				"policy_id", profile.PolicyID,
+				"profile_uuid", profile.ProfileUUID,
+			)
+		}
 	}
 
 	return nil

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -546,6 +546,7 @@ func (svc *Service) getPackConfig(ctx context.Context, host *fleet.Host) (json.R
 
 	return raw, nil
 }
+
 func (svc *Service) GetClientConfig(ctx context.Context) (map[string]any, error) {
 	// skipauth: Authorization is currently for user endpoints only.
 	svc.authz.SkipAuthorization(ctx)
@@ -2621,6 +2622,11 @@ func (svc *Service) processProfileResendsForNewlyFailingPolicies(
 	incomingPolicyResults map[uint]*bool,
 	newFailingSet map[uint]struct{},
 ) error {
+	// While it's gated outside, we gate in here as well to avoid future callers not gating.
+	if host.Platform != "darwin" && host.Platform != "windows" {
+		return nil
+	}
+
 	var policyTeamID uint
 	if host.TeamID == nil {
 		policyTeamID = fleet.PolicyNoTeamID

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"os"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -22,6 +23,7 @@ import (
 	"github.com/WatchBeam/clock"
 	"github.com/fleetdm/fleet/v4/ee/pkg/hostidentity/types"
 	"github.com/fleetdm/fleet/v4/pkg/optjson"
+	activity_api "github.com/fleetdm/fleet/v4/server/activity/api"
 	"github.com/fleetdm/fleet/v4/server/authz"
 	"github.com/fleetdm/fleet/v4/server/config"
 	hostctx "github.com/fleetdm/fleet/v4/server/contexts/host"
@@ -3815,6 +3817,12 @@ func TestOutOfScopePolicyResultsAreDiscarded(t *testing.T) {
 		recordedResults = results
 		return nil, nil
 	}
+	// A failing policy on a macOS host reaches the profile resend automation, which is not what
+	// this test is about. The other automations skip this host on their own (no orbit node key,
+	// no license, no enterprise overrides); this one has no such gate.
+	ds.GetPoliciesWithAssociatedProfileFunc = func(ctx context.Context, teamID uint, policyIDs []uint) ([]fleet.PolicyProfileData, error) {
+		return nil, nil
+	}
 
 	ctx = hostctx.NewContext(ctx, host)
 
@@ -4060,6 +4068,12 @@ func TestPolicyWebhooks(t *testing.T) {
 		ID:       5,
 		Platform: "darwin",
 		Hostname: "test.hostname",
+	}
+
+	// A newly-failing policy on a macOS host reaches the profile resend automation, which this
+	// test isn't about.
+	ds.GetPoliciesWithAssociatedProfileFunc = func(ctx context.Context, teamID uint, policyIDs []uint) ([]fleet.PolicyProfileData, error) {
+		return nil, nil
 	}
 
 	lq.On("QueriesForHost", uint(5)).Return(map[string]string{}, nil)
@@ -5730,5 +5744,274 @@ func TestProcessSoftwareForNewlyFailingPoliciesSuppressedDuringSetupExperience(t
 		}
 		require.NoError(t, svcImpl.processSoftwareForNewlyFailingPolicies(ctx, hostID, nil, "windows", &orbitKey, "setup-host-uuid", failing, newlyFailing))
 		require.True(t, insertCalled, "outside setup experience the policy automation installs normally")
+	})
+}
+
+// TestProcessProfileResendsForNewlyFailingPolicies covers the policy automation that resends a
+// configuration profile when its policy fails on a host: which policies trigger a resend, and the
+// activity recorded for each one. The activity is the only record of an automated resend, so it
+// must carry the host, the profile and the policy that triggered it.
+func TestProcessProfileResendsForNewlyFailingPolicies(t *testing.T) {
+	const (
+		applePolicyID = uint(1)
+		winPolicyID   = uint(2)
+		noProfPolicy  = uint(3)
+	)
+	appleProfUUID := fleet.MDMAppleProfileUUIDPrefix + "apple-prof"
+	winProfUUID := fleet.MDMWindowsProfileUUIDPrefix + "windows-prof"
+
+	appleData := fleet.PolicyProfileData{
+		PolicyID:    applePolicyID,
+		PolicyName:  "apple policy",
+		ProfileUUID: appleProfUUID,
+		ProfileName: "apple profile",
+	}
+	winData := fleet.PolicyProfileData{
+		PolicyID:    winPolicyID,
+		PolicyName:  "windows policy",
+		ProfileUUID: winProfUUID,
+		ProfileName: "windows profile",
+	}
+
+	darwinHost := &fleet.Host{ID: 42, UUID: "host-uuid", Platform: "darwin", ComputerName: "Nancy's MacBook", Hostname: "nancy-mbp"}
+	windowsHost := &fleet.Host{ID: 43, UUID: "win-host-uuid", Platform: "windows", ComputerName: "WIN-BOX", Hostname: "win-box"}
+
+	// harness wires a service to a mock datastore reporting the given policy/profile associations,
+	// and records the resends performed and the activities logged.
+	type harness struct {
+		svc *Service
+		ctx context.Context
+		// statusFor decides what GetHostMDMProfileInstallStatus reports per profile UUID; a
+		// missing entry means the profile is not assigned to the host.
+		statusFor  map[string]fleet.MDMDeliveryStatus
+		resendErr  error
+		resent     []string
+		activities []fleet.ActivityTypeResentConfigurationProfile
+	}
+	setup := func(t *testing.T, assoc []fleet.PolicyProfileData) *harness {
+		t.Helper()
+		ds := new(mock.Store)
+		opts := &TestServerOpts{}
+		svc, ctx := newTestServiceWithConfig(t, ds, config.TestConfig(), nil, nil, opts)
+		h := &harness{
+			svc:       svc.(validationMiddleware).Service.(*Service),
+			ctx:       ctx,
+			statusFor: map[string]fleet.MDMDeliveryStatus{appleProfUUID: fleet.MDMDeliveryVerified, winProfUUID: fleet.MDMDeliveryVerified},
+		}
+
+		// Mirrors the real query's `id IN (?)`, so a policy the caller filtered out before the
+		// lookup can't come back from the mock anyway.
+		ds.GetPoliciesWithAssociatedProfileFunc = func(ctx context.Context, teamID uint, policyIDs []uint) ([]fleet.PolicyProfileData, error) {
+			var out []fleet.PolicyProfileData
+			for _, a := range assoc {
+				if slices.Contains(policyIDs, a.PolicyID) {
+					out = append(out, a)
+				}
+			}
+			return out, nil
+		}
+		ds.GetHostMDMProfileInstallStatusFunc = func(ctx context.Context, hostUUID, profUUID string) (fleet.MDMDeliveryStatus, error) {
+			status, ok := h.statusFor[profUUID]
+			if !ok {
+				return "", &notFoundErr{}
+			}
+			return status, nil
+		}
+		ds.ResendHostMDMProfileFunc = func(ctx context.Context, hostUUID, profUUID string) error {
+			if h.resendErr != nil {
+				return h.resendErr
+			}
+			h.resent = append(h.resent, profUUID)
+			return nil
+		}
+		opts.ActivityMock.NewActivityFunc = func(_ context.Context, user *activity_api.User, act activity_api.ActivityDetails) error {
+			// Fleet performs the resend, not a user.
+			require.Nil(t, user)
+			resentAct, ok := act.(*fleet.ActivityTypeResentConfigurationProfile)
+			require.True(t, ok, "unexpected activity type %T", act)
+			h.activities = append(h.activities, *resentAct)
+			return nil
+		}
+		return h
+	}
+
+	t.Run("failing policy resends its profile and records the activity", func(t *testing.T) {
+		h := setup(t, []fleet.PolicyProfileData{appleData})
+
+		require.NoError(t, h.svc.processProfileResendsForNewlyFailingPolicies(h.ctx, darwinHost,
+			map[uint]*bool{applePolicyID: new(false)}, map[uint]struct{}{applePolicyID: {}}))
+
+		require.Equal(t, []string{appleProfUUID}, h.resent)
+		require.Len(t, h.activities, 1)
+		require.Equal(t, fleet.ActivityTypeResentConfigurationProfile{
+			HostID:          new(darwinHost.ID),
+			HostDisplayName: new("Nancy's MacBook"),
+			ProfileName:     "apple profile",
+			ProfileUUID:     appleProfUUID,
+			PolicyID:        new(applePolicyID),
+			PolicyName:      new("apple policy"),
+		}, h.activities[0])
+		// The activity reports as automation-driven, which is what marks it Fleet-initiated
+		// rather than attributing it to a user.
+		require.True(t, h.activities[0].WasFromAutomation())
+	})
+
+	t.Run("policy that was already failing resends nothing", func(t *testing.T) {
+		// Only a pass→fail transition triggers a resend. A policy that keeps failing reports a
+		// failure on every run, so acting on those would resend once per policy run for as long
+		// as the host stays out of compliance.
+		h := setup(t, []fleet.PolicyProfileData{appleData})
+
+		require.NoError(t, h.svc.processProfileResendsForNewlyFailingPolicies(h.ctx, darwinHost,
+			map[uint]*bool{applePolicyID: new(false)}, map[uint]struct{}{}))
+
+		require.Empty(t, h.resent)
+		require.Empty(t, h.activities)
+	})
+
+	t.Run("only the newly failing policy of several resends", func(t *testing.T) {
+		otherAppleData := fleet.PolicyProfileData{
+			PolicyID:    winPolicyID,
+			PolicyName:  "second apple policy",
+			ProfileUUID: fleet.MDMAppleProfileUUIDPrefix + "apple-prof-2",
+			ProfileName: "second apple profile",
+		}
+		h := setup(t, []fleet.PolicyProfileData{appleData, otherAppleData})
+		h.statusFor[otherAppleData.ProfileUUID] = fleet.MDMDeliveryVerified
+
+		// Both policies report a failure, but only the second one just flipped.
+		require.NoError(t, h.svc.processProfileResendsForNewlyFailingPolicies(h.ctx, darwinHost,
+			map[uint]*bool{applePolicyID: new(false), winPolicyID: new(false)},
+			map[uint]struct{}{winPolicyID: {}}))
+
+		require.Equal(t, []string{otherAppleData.ProfileUUID}, h.resent)
+		require.Len(t, h.activities, 1)
+		require.Equal(t, new(winPolicyID), h.activities[0].PolicyID)
+	})
+
+	t.Run("passing and erroring policies resend nothing", func(t *testing.T) {
+		h := setup(t, []fleet.PolicyProfileData{appleData})
+
+		// A passing policy, and a policy whose query failed to execute (nil result).
+		require.NoError(t, h.svc.processProfileResendsForNewlyFailingPolicies(h.ctx, darwinHost,
+			map[uint]*bool{applePolicyID: new(true), winPolicyID: nil}, map[uint]struct{}{}))
+
+		require.Empty(t, h.resent)
+		require.Empty(t, h.activities)
+	})
+
+	t.Run("policy with no associated profile resends nothing", func(t *testing.T) {
+		h := setup(t, nil)
+
+		require.NoError(t, h.svc.processProfileResendsForNewlyFailingPolicies(h.ctx, darwinHost,
+			map[uint]*bool{noProfPolicy: new(false)}, map[uint]struct{}{noProfPolicy: {}}))
+
+		require.Empty(t, h.resent)
+		require.Empty(t, h.activities)
+	})
+
+	t.Run("profile the host doesn't have is skipped and records no activity", func(t *testing.T) {
+		// A policy can target more platforms than the profile it resends, so a Windows host can
+		// report a failure for a policy holding an Apple profile. The host has no row for that
+		// profile, so the resend is rejected as not-found and only the Windows profile goes out.
+		h := setup(t, []fleet.PolicyProfileData{appleData, winData})
+		delete(h.statusFor, appleProfUUID)
+
+		require.NoError(t, h.svc.processProfileResendsForNewlyFailingPolicies(h.ctx, windowsHost,
+			map[uint]*bool{applePolicyID: new(false), winPolicyID: new(false)}, map[uint]struct{}{applePolicyID: {}, winPolicyID: {}}))
+
+		require.Equal(t, []string{winProfUUID}, h.resent)
+		require.Len(t, h.activities, 1)
+		require.Equal(t, winProfUUID, h.activities[0].ProfileUUID)
+		require.Equal(t, new(winPolicyID), h.activities[0].PolicyID)
+	})
+
+	t.Run("delivery already in flight is skipped and records no activity", func(t *testing.T) {
+		// A resend from an earlier run leaves the profile pending, and the policy keeps failing
+		// until the profile is delivered and re-verified. Resending again would be pointless and
+		// would log a resend per policy run.
+		for _, status := range []fleet.MDMDeliveryStatus{fleet.MDMDeliveryPending, fleet.MDMDeliveryVerifying} {
+			t.Run(string(status), func(t *testing.T) {
+				h := setup(t, []fleet.PolicyProfileData{appleData})
+				h.statusFor[appleProfUUID] = status
+
+				require.NoError(t, h.svc.processProfileResendsForNewlyFailingPolicies(h.ctx, darwinHost,
+					map[uint]*bool{applePolicyID: new(false)}, map[uint]struct{}{applePolicyID: {}}))
+
+				require.Empty(t, h.resent)
+				require.Empty(t, h.activities)
+			})
+		}
+	})
+
+	t.Run("failed profile is resent", func(t *testing.T) {
+		h := setup(t, []fleet.PolicyProfileData{appleData})
+		h.statusFor[appleProfUUID] = fleet.MDMDeliveryFailed
+
+		require.NoError(t, h.svc.processProfileResendsForNewlyFailingPolicies(h.ctx, darwinHost,
+			map[uint]*bool{applePolicyID: new(false)}, map[uint]struct{}{applePolicyID: {}}))
+
+		require.Equal(t, []string{appleProfUUID}, h.resent)
+		require.Len(t, h.activities, 1)
+	})
+
+	t.Run("no activity when the resend fails", func(t *testing.T) {
+		h := setup(t, []fleet.PolicyProfileData{appleData})
+		h.resendErr = errors.New("resend boom")
+
+		// A failed resend is logged, not returned: one bad profile must not abort the rest of
+		// the distributed query results processing.
+		require.NoError(t, h.svc.processProfileResendsForNewlyFailingPolicies(h.ctx, darwinHost,
+			map[uint]*bool{applePolicyID: new(false)}, map[uint]struct{}{applePolicyID: {}}))
+
+		require.Empty(t, h.resent)
+		require.Empty(t, h.activities)
+	})
+
+	t.Run("one failing profile does not stop the others", func(t *testing.T) {
+		// Two Apple profiles resent for the same host in one run, the first of which can't be
+		// resent. Each successful resend gets its own activity, attributing every profile to the
+		// policy that triggered it.
+		otherAppleData := fleet.PolicyProfileData{
+			PolicyID:    winPolicyID,
+			PolicyName:  "second apple policy",
+			ProfileUUID: fleet.MDMAppleProfileUUIDPrefix + "apple-prof-2",
+			ProfileName: "second apple profile",
+		}
+		h := setup(t, []fleet.PolicyProfileData{appleData, otherAppleData})
+		h.statusFor[otherAppleData.ProfileUUID] = fleet.MDMDeliveryVerified
+		delete(h.statusFor, appleProfUUID)
+
+		require.NoError(t, h.svc.processProfileResendsForNewlyFailingPolicies(h.ctx, darwinHost,
+			map[uint]*bool{applePolicyID: new(false), winPolicyID: new(false)}, map[uint]struct{}{applePolicyID: {}, winPolicyID: {}}))
+
+		require.Equal(t, []string{otherAppleData.ProfileUUID}, h.resent)
+		require.Len(t, h.activities, 1)
+		require.NotNil(t, h.activities[0].PolicyName)
+		require.Equal(t, "second apple policy", *h.activities[0].PolicyName)
+	})
+
+	t.Run("host in no team looks up policies under the no-team ID", func(t *testing.T) {
+		ds := new(mock.Store)
+		opts := &TestServerOpts{}
+		svc, ctx := newTestServiceWithConfig(t, ds, config.TestConfig(), nil, nil, opts)
+		svcImpl := svc.(validationMiddleware).Service.(*Service)
+
+		var gotTeamID uint
+		ds.GetPoliciesWithAssociatedProfileFunc = func(ctx context.Context, teamID uint, policyIDs []uint) ([]fleet.PolicyProfileData, error) {
+			gotTeamID = teamID
+			return nil, nil
+		}
+
+		require.NoError(t, svcImpl.processProfileResendsForNewlyFailingPolicies(ctx,
+			&fleet.Host{ID: 1, UUID: "u", Platform: "darwin"},
+			map[uint]*bool{applePolicyID: new(false)}, map[uint]struct{}{applePolicyID: {}}))
+		require.Equal(t, fleet.PolicyNoTeamID, gotTeamID)
+
+		teamID := uint(7)
+		require.NoError(t, svcImpl.processProfileResendsForNewlyFailingPolicies(ctx,
+			&fleet.Host{ID: 1, UUID: "u", Platform: "darwin", TeamID: &teamID},
+			map[uint]*bool{applePolicyID: new(false)}, map[uint]struct{}{applePolicyID: {}}))
+		require.Equal(t, teamID, gotTeamID)
 	})
 }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #51270 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Policy automations can resend assigned Apple and Windows configuration profiles when policies begin failing.
  - Resend activity records now identify the triggering policy and associated host when available.
  - Policy and configuration-profile details are available together for clearer automation tracking.

- **Bug Fixes**
  - Prevented deletion of profiles still referenced by policy automations and added guidance to disable those automations before retrying.
  - Improved handling and reporting of resend failures and rejected profiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->