### PR TITLE
For R.C. - Fleet UI: Align InfoBanner leading icon with first line of wrapped copy (#51446)

### DIFF
--- a/frontend/components/InfoBanner/_styles.scss
+++ b/frontend/components/InfoBanner/_styles.scss
@@ -24,6 +24,12 @@
 
   &__leading-icon {
     flex-shrink: 0;
+    // Override .icon's `align-self: center` so a wrapping message keeps the
+    // icon lined up with the first line of text. The one-line-tall band +
+    // `align-items: center` centers the 16px svg on the first line of copy.
+    align-self: flex-start;
+    align-items: center;
+    height: calc(#{$x-small} * #{$line-height});
   }
 
   &__info {


### PR DESCRIPTION
## Issue
Closes #51395

## Description
- Previously merged into `main` with #51446
- This is for the 4.91.0 R.C.

## Testing
- [x] QA'd all new/changed functionality manually