### PR TITLE
Fleet UI: Render notify-before-patching activities and automation runs

### DIFF
--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tests.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tests.tsx
@@ -11,6 +11,7 @@ import {
   getSoftwareInstallHandlerWithPreInstall,
   getSoftwareInstallHandlerOnlyPreInstallOutput,
   getSoftwareInstallHandlerAppOpen,
+  getSoftwareInstallHandlerNotifyBeforePatchingSkip,
   getSoftwareInstallResultHandlerPremiumRequired,
 } from "test/handlers/software-handlers";
 import mockServer from "test/mock-server";
@@ -336,7 +337,7 @@ describe("SoftwareInstallDetailsModal", () => {
       ).not.toBeInTheDocument();
     });
 
-    it("renders the app-open pre-install output for a skipped install", async () => {
+    it("renders the app-open pre-install output for a patch_when_closed skip", async () => {
       mockServer.use(getSoftwareInstallHandlerAppOpen);
       const renderWithServer = createCustomRenderer({ withBackendMock: true });
       const { user } = renderWithServer(
@@ -353,14 +354,37 @@ describe("SoftwareInstallDetailsModal", () => {
       await user.click(screen.getByRole("button", { name: /Details/i }));
 
       expect(screen.getByText("Pre-install query output:")).toBeInTheDocument();
-      // Figma: the code block shows both the generic no-result line and the
-      // app-open reason (label stays "Pre-install query output:").
+      expect(
+        screen.getByText(/Query didn't return result\s+The app was open\./)
+      ).toBeInTheDocument();
+      // patch_when_closed has no notify sentence.
+      expect(
+        screen.queryByText(/Fleet notifies the end user/)
+      ).not.toBeInTheDocument();
+    });
+
+    it("renders the notify-before-patching sentence in the pre-install output when the payload carries it", async () => {
+      mockServer.use(getSoftwareInstallHandlerNotifyBeforePatchingSkip);
+      const renderWithServer = createCustomRenderer({ withBackendMock: true });
+      const { user } = renderWithServer(
+        <SoftwareInstallDetailsModal
+          details={{
+            ...baseDetails,
+            skipped_install: true,
+          }}
+          onCancel={noop}
+        />
+      );
+
+      await screen.findByText(/Fleet skipped install of/);
+      await user.click(screen.getByRole("button", { name: /Details/i }));
+
+      expect(screen.getByText("Pre-install query output:")).toBeInTheDocument();
       expect(
         screen.getByText(
-          /Query didn't return result or failed\s+The app was open/
+          /Query didn't return result\s+The app was open\. Fleet notifies the end user 1 hour before the patch is forced\./
         )
       ).toBeInTheDocument();
-      expect(screen.queryByText("Install stopped")).not.toBeInTheDocument();
     });
 
     it("shows install and post-install outputs after clicking Details (no pre-install)", async () => {

--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tests.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tests.tsx
@@ -137,12 +137,14 @@ describe("SoftwareInstallDetailsModal", () => {
       expect(screen.getByText(/\d+.*ago/)).toBeInTheDocument();
     });
 
-    it("renders app-open skipped copy instead of generic failed-install copy", () => {
+    it("renders app-open skipped copy for a patch_when_closed variant", () => {
       render(
         <StatusMessage
           softwareName="CoolApp"
           installResult={createMockSoftwareInstallResult({
             status: "failed_install",
+            pre_install_query_output:
+              "Query didn't return result or failed\nThe app was open.",
           })}
           isMyDevicePage={false}
           skippedInstall
@@ -156,10 +158,40 @@ describe("SoftwareInstallDetailsModal", () => {
           /It will update once the user closes it and policy runs again, or update via self service\./
         )
       ).toBeInTheDocument();
+      // Notify sentence must not leak into the patch_when_closed path.
+      expect(
+        screen.queryByText(/Fleet notifies the end user/)
+      ).not.toBeInTheDocument();
       expect(screen.queryByText(/failed to install/)).not.toBeInTheDocument();
       // Grey "!" (error-outline), not the red failure icon.
       expect(screen.getByTestId("error-outline-icon")).toBeInTheDocument();
       expect(screen.queryByTestId("error-icon")).not.toBeInTheDocument();
+    });
+
+    it("renders the notify-variant trailing sentence when pre-install output carries the notify marker", () => {
+      render(
+        <StatusMessage
+          softwareName="CoolApp"
+          installResult={createMockSoftwareInstallResult({
+            status: "failed_install",
+            pre_install_query_output:
+              "Query didn't return result or failed\nThe app was open. Fleet notifies the end user 1 hour before the patch is forced.",
+          })}
+          isMyDevicePage={false}
+          skippedInstall
+        />
+      );
+
+      expect(screen.getByText(/Fleet skipped install of/)).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          /Fleet notifies the end user 1 hour before the patch is forced\./
+        )
+      ).toBeInTheDocument();
+      // patch_when_closed copy is misleading here and must not render.
+      expect(
+        screen.queryByText(/It will update once the user closes it/)
+      ).not.toBeInTheDocument();
     });
 
     it("on host details page/install activity, renders installed message with timestamp", () => {
@@ -355,7 +387,9 @@ describe("SoftwareInstallDetailsModal", () => {
 
       expect(screen.getByText("Pre-install query output:")).toBeInTheDocument();
       expect(
-        screen.getByText(/Query didn't return result\s+The app was open\./)
+        screen.getByText(
+          /Query didn't return result or failed\s+The app was open\./
+        )
       ).toBeInTheDocument();
       // patch_when_closed has no notify sentence.
       expect(
@@ -382,7 +416,7 @@ describe("SoftwareInstallDetailsModal", () => {
       expect(screen.getByText("Pre-install query output:")).toBeInTheDocument();
       expect(
         screen.getByText(
-          /Query didn't return result\s+The app was open\. Fleet notifies the end user 1 hour before the patch is forced\./
+          /Query didn't return result or failed\s+The app was open\. Fleet notifies the end user 1 hour before the patch is forced\./
         )
       ).toBeInTheDocument();
     });

--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tsx
@@ -317,9 +317,11 @@ export const SoftwareInstallDetailsModal = ({
     const outputs = [
       {
         label: "Pre-install query output:",
-        value: detailsFromProps.skipped_install
-          ? "Query didn't return result or failed\nThe app was open"
-          : swInstallResult?.pre_install_query_output,
+        value:
+          swInstallResult?.pre_install_query_output ||
+          (detailsFromProps.skipped_install
+            ? "Query didn't return result\nThe app was open."
+            : undefined),
       },
       {
         label: "Install script output:",

--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tsx
@@ -149,11 +149,8 @@ export const StatusMessage = ({
     : "";
 
   if (skippedInstall && status === "failed_install") {
-    // Trailing sentence diverges by patch variant. The BE encodes which one
-    // ran in pre_install_query_output — the notify variant appends "Fleet
-    // notifies the end user...". For patch_when_closed we keep Carlo's
-    // original copy (added in the "patch when closed UI" commit); it's not in
-    // Figma but tells Fleet Free admins what actually resolves the skip.
+    // Notify variant appends "Fleet notifies the end user..." to
+    // pre_install_query_output; patch_when_closed doesn't.
     const isNotifyVariant = isNotifyBeforePatchingSkip(
       installResult.pre_install_query_output
     );

--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tsx
@@ -39,6 +39,8 @@ import CustomLink from "components/CustomLink";
 import PremiumFeatureMessage from "components/PremiumFeatureMessage";
 import TooltipTruncatedText from "components/TooltipTruncatedText";
 
+import { isNotifyBeforePatchingSkip } from "../../NotifyBeforePatchingDetailsModal/helpers";
+
 import {
   INSTALL_DETAILS_STATUS_ICONS,
   getInstallDetailsStatusPredicate,
@@ -147,6 +149,14 @@ export const StatusMessage = ({
     : "";
 
   if (skippedInstall && status === "failed_install") {
+    // Trailing sentence diverges by patch variant. The BE encodes which one
+    // ran in pre_install_query_output — the notify variant appends "Fleet
+    // notifies the end user...". For patch_when_closed we keep Carlo's
+    // original copy (added in the "patch when closed UI" commit); it's not in
+    // Figma but tells Fleet Free admins what actually resolves the skip.
+    const isNotifyVariant = isNotifyBeforePatchingSkip(
+      installResult.pre_install_query_output
+    );
     return (
       <IconStatusMessage
         className={`${baseClass}__status-message`}
@@ -156,8 +166,10 @@ export const StatusMessage = ({
           <span>
             Fleet skipped install of <b>{software_title}</b> ({software_package}
             ) on {formattedHost}
-            {displayTimeStamp}. The app was open. It will update once the user
-            closes it and policy runs again, or update via self service.
+            {displayTimeStamp}. The app was open.{" "}
+            {isNotifyVariant
+              ? "Fleet notifies the end user 1 hour before the patch is forced."
+              : "It will update once the user closes it and policy runs again, or update via self service."}
           </span>
         }
       />
@@ -320,7 +332,7 @@ export const SoftwareInstallDetailsModal = ({
         value:
           swInstallResult?.pre_install_query_output ||
           (detailsFromProps.skipped_install
-            ? "Query didn't return result\nThe app was open."
+            ? "Query didn't return result or failed\nThe app was open."
             : undefined),
       },
       {

--- a/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/NotifyBeforePatchingDetailsModal.tests.tsx
+++ b/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/NotifyBeforePatchingDetailsModal.tests.tsx
@@ -167,6 +167,20 @@ describe("NotifyBeforePatchingDetailsModal", () => {
     expect(shouldNotFireHandler).not.toHaveBeenCalled();
   });
 
+  it("renders the intro without an app list when software_titles is empty (defensive)", async () => {
+    useScriptResultHandler({ exit_code: 0 });
+    renderModal({ status: "success", software_titles: [] });
+
+    const intro = (await screen.findByText(/before patching/i)).closest(
+      "span"
+    ) as HTMLElement;
+    // No title list injected; sentence still reads grammatically.
+    expect(intro.textContent).toContain(
+      "before patching on John's MacBook Pro."
+    );
+    expect(screen.queryByText("Apps")).not.toBeInTheDocument();
+  });
+
   it("puts the app name inline in the intro when there is one app, and hides the Apps row", async () => {
     useScriptResultHandler({ exit_code: 0 });
     renderModal({ status: "success", software_titles: ["1Password"] });
@@ -183,7 +197,7 @@ describe("NotifyBeforePatchingDetailsModal", () => {
     expect(screen.queryByText("Apps")).not.toBeInTheDocument();
   });
 
-  it("truncates the intro past three apps with a 'and N more apps' tail and moves the full list to Apps", async () => {
+  it("truncates the intro past four apps with a 'and N more apps' tail and moves the full list to Apps", async () => {
     useScriptResultHandler({ exit_code: 0 });
     renderModal({
       status: "success",
@@ -211,7 +225,7 @@ describe("NotifyBeforePatchingDetailsModal", () => {
     expect(screen.getByText("Apps")).toBeInTheDocument();
   });
 
-  it("lists every title in the Apps row (no truncation past three)", async () => {
+  it("lists every title in the Apps row (no truncation past four)", async () => {
     useScriptResultHandler({ exit_code: 0 });
     renderModal({
       software_titles: [

--- a/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/NotifyBeforePatchingDetailsModal.tests.tsx
+++ b/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/NotifyBeforePatchingDetailsModal.tests.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { noop } from "lodash";
 
@@ -10,13 +11,18 @@ import { IScriptResultResponse } from "services/entities/scripts";
 
 import NotifyBeforePatchingDetailsModal from "./NotifyBeforePatchingDetailsModal";
 
+// Default carries a stub script body so the Details reveal has something to
+// show — matches real payload shape where notification runs always have
+// contents.
+const DEFAULT_SCRIPT_CONTENTS = "#!/bin/bash\nfleet-desktop notify ...";
+
 const scriptResult = (
   overrides: Partial<IScriptResultResponse> = {}
 ): IScriptResultResponse => ({
   hostname: "John's MacBook Pro",
   host_id: 1,
   execution_id: "exec-1",
-  script_contents: "",
+  script_contents: DEFAULT_SCRIPT_CONTENTS,
   script_id: null,
   exit_code: 0,
   output: "",
@@ -73,13 +79,18 @@ describe("NotifyBeforePatchingDetailsModal", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders the offline sentence for a success with exit code 0", async () => {
+  it("renders the offline caveat sentence on a success (exit code 0)", async () => {
     useScriptResultHandler({ exit_code: 0 });
-    renderModal({ status: "failed" });
+    renderModal({ status: "success" });
 
     expect(
       await screen.findByText(/If the host is offline when the patch is forced/)
     ).toBeInTheDocument();
+    // Intro is the success verb, not the failure verb.
+    expect(
+      screen.getByText(/notified end user 1 hour before patching/i)
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/failed to notify/)).not.toBeInTheDocument();
   });
 
   it("renders the Fleet Desktop required sentence for exit code 100", async () => {
@@ -124,6 +135,10 @@ describe("NotifyBeforePatchingDetailsModal", () => {
     useScriptResultHandler({ exit_code: 999, output: "unknown error output" });
     renderModal({ status: "failed" });
 
+    // Reveal to expose the raw output.
+    await userEvent.click(
+      await screen.findByRole("button", { name: /Details/ })
+    );
     expect(await screen.findByText(/unknown error output/)).toBeInTheDocument();
     // None of the documented failure sentences should appear.
     expect(
@@ -155,6 +170,50 @@ describe("NotifyBeforePatchingDetailsModal", () => {
     expect(shouldNotFireHandler).not.toHaveBeenCalled();
   });
 
+  it("puts the app name inline in the intro when there is one app, and hides the Apps row", async () => {
+    useScriptResultHandler({ exit_code: 0 });
+    renderModal({ status: "success", software_titles: ["1Password"] });
+
+    // Intro carries the app name.
+    expect(await screen.findByText(/before patching/i)).toBeInTheDocument();
+    const intro = screen
+      .getByText(/before patching/i)
+      .closest("span") as HTMLElement;
+    expect(intro.textContent).toContain("1Password");
+    expect(intro.textContent).toContain("John's MacBook Pro");
+
+    // Apps row is redundant for a single-app case — omitted.
+    expect(screen.queryByText("Apps")).not.toBeInTheDocument();
+  });
+
+  it("truncates the intro past three apps with a 'and N more apps' tail and moves the full list to Apps", async () => {
+    useScriptResultHandler({ exit_code: 0 });
+    renderModal({
+      status: "success",
+      software_titles: [
+        "1Password",
+        "Slack",
+        "Docker Desktop",
+        "Zoom",
+        "Chrome",
+      ],
+    });
+
+    const intro = (await screen.findByText(/before patching/i)).closest(
+      "span"
+    ) as HTMLElement;
+    expect(intro.textContent).toMatch(/and 2 more apps/);
+    // Only the first three are named in the intro.
+    expect(intro.textContent).toContain("1Password");
+    expect(intro.textContent).toContain("Slack");
+    expect(intro.textContent).toContain("Docker Desktop");
+    expect(intro.textContent).not.toContain("Zoom");
+    expect(intro.textContent).not.toContain("Chrome");
+
+    // Apps row appears because the intro truncated.
+    expect(screen.getByText("Apps")).toBeInTheDocument();
+  });
+
   it("lists every title in the Apps row (no truncation past three)", async () => {
     useScriptResultHandler({ exit_code: 0 });
     renderModal({
@@ -179,20 +238,54 @@ describe("NotifyBeforePatchingDetailsModal", () => {
     expect(appsSection?.textContent).not.toMatch(/more app/);
   });
 
-  it("renders the notification script output when present", async () => {
+  it("hides the script + output behind a Details reveal", async () => {
     useScriptResultHandler({
       exit_code: 41,
       output: "Screen locked at 2026-08-18T10:00:00Z",
+      script_contents: "#!/bin/bash\nnotify ...",
     });
     renderModal({ status: "failed" });
 
-    expect(
-      await screen.findByText(/Notification script output:/)
-    ).toBeInTheDocument();
+    // Nothing revealed initially.
+    await screen.findByText(/screen was locked/i);
+    expect(screen.queryByText(/Notification script:/)).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /Details/ }));
+
+    expect(screen.getByText(/Notification script:/)).toBeInTheDocument();
+    expect(screen.getByText(/#!\/bin\/bash/)).toBeInTheDocument();
+    // The label is split around the "output recorded" tooltip trigger, so
+    // match the trigger substring rather than the whole sentence.
+    expect(screen.getByText("output recorded")).toBeInTheDocument();
+    // Output block leads with the exit code line per Figma.
+    expect(screen.getByText(/Exit code: 41/)).toBeInTheDocument();
     await waitFor(() =>
       expect(
         screen.getByText(/Screen locked at 2026-08-18T10:00:00Z/)
       ).toBeInTheDocument()
     );
+  });
+
+  it("shows a green success icon on success and a red error icon on failure", async () => {
+    useScriptResultHandler({ exit_code: 0 });
+    const { unmount } = renderModal({ status: "success" });
+    expect(
+      await screen.findByTestId("success-outline-icon")
+    ).toBeInTheDocument();
+    unmount();
+
+    useScriptResultHandler({ exit_code: 41 });
+    renderModal({ status: "failed" });
+    expect(await screen.findByTestId("error-outline-icon")).toBeInTheDocument();
+  });
+
+  it("does not show the Details reveal when no script ran (dispatcher deferral)", async () => {
+    renderModal({ status: "failed", script_execution_id: undefined });
+
+    await screen.findByText(/Another notification was displayed/);
+    // No script means nothing to reveal.
+    expect(
+      screen.queryByRole("button", { name: /Details/ })
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/NotifyBeforePatchingDetailsModal.tests.tsx
+++ b/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/NotifyBeforePatchingDetailsModal.tests.tsx
@@ -91,7 +91,7 @@ describe("NotifyBeforePatchingDetailsModal", () => {
     expect(screen.queryByText(/failed to notify/)).not.toBeInTheDocument();
   });
 
-  it("renders the Fleet Desktop required sentence for exit code 100", async () => {
+  it("renders the Fleet Desktop required sentence and the EUE link for exit code 100", async () => {
     useScriptResultHandler({ exit_code: 100 });
     renderModal({ status: "failed" });
 
@@ -100,24 +100,33 @@ describe("NotifyBeforePatchingDetailsModal", () => {
         /The Fleet Desktop app is required to notify end users\./
       )
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /End user experience/ })
+    ).toBeInTheDocument();
   });
 
-  it("renders the Fleet Desktop v1.5.0 sentence for exit code 101", async () => {
+  it("renders the Fleet Desktop v1.5.0 sentence and the EUE link for exit code 101", async () => {
     useScriptResultHandler({ exit_code: 101 });
     renderModal({ status: "failed" });
 
     expect(
       await screen.findByText(/The Fleet Desktop app v1\.5\.0 is required/)
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /End user experience/ })
+    ).toBeInTheDocument();
   });
 
-  it("renders the 'notification couldn't load' sentence for exit code 30", async () => {
+  it("renders the 'notification couldn't load' sentence for exit code 30 without the EUE link", async () => {
     useScriptResultHandler({ exit_code: 30 });
     renderModal({ status: "failed" });
 
     expect(
       await screen.findByText(/The notification couldn't load\./)
     ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: /End user experience/ })
+    ).not.toBeInTheDocument();
   });
 
   it("renders the screen-locked sentence for exit code 41", async () => {

--- a/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/NotifyBeforePatchingDetailsModal.tests.tsx
+++ b/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/NotifyBeforePatchingDetailsModal.tests.tsx
@@ -1,0 +1,198 @@
+import React from "react";
+import { screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { noop } from "lodash";
+
+import { baseUrl, createCustomRenderer } from "test/test-utils";
+import mockServer from "test/mock-server";
+import { IActivityDetails } from "interfaces/activity";
+import { IScriptResultResponse } from "services/entities/scripts";
+
+import NotifyBeforePatchingDetailsModal from "./NotifyBeforePatchingDetailsModal";
+
+const scriptResult = (
+  overrides: Partial<IScriptResultResponse> = {}
+): IScriptResultResponse => ({
+  hostname: "John's MacBook Pro",
+  host_id: 1,
+  execution_id: "exec-1",
+  script_contents: "",
+  script_id: null,
+  exit_code: 0,
+  output: "",
+  message: "",
+  runtime: 1,
+  host_timeout: false,
+  created_at: "2026-01-01T00:00:00Z",
+  ...overrides,
+});
+
+const useScriptResultHandler = (overrides?: Partial<IScriptResultResponse>) => {
+  mockServer.use(
+    http.get(baseUrl("/scripts/results/:executionId"), () =>
+      HttpResponse.json(scriptResult(overrides))
+    )
+  );
+};
+
+const defaultDetails: IActivityDetails = {
+  host_display_name: "John's MacBook Pro",
+  software_titles: ["1Password"],
+  status: "success",
+  time_before: 3600,
+  script_execution_id: "exec-1",
+};
+
+const renderModal = (details: Partial<IActivityDetails> = {}) => {
+  const render = createCustomRenderer({ withBackendMock: true });
+  return render(
+    <NotifyBeforePatchingDetailsModal
+      details={{ ...defaultDetails, ...details }}
+      onCancel={noop}
+    />
+  );
+};
+
+describe("NotifyBeforePatchingDetailsModal", () => {
+  it("renders the success sentence with 1 hour by default", async () => {
+    useScriptResultHandler({ exit_code: 0 });
+    renderModal({ status: "success", time_before: 3600 });
+
+    expect(
+      await screen.findByText(/notified end user 1 hour before patching/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText("John's MacBook Pro")).toBeInTheDocument();
+  });
+
+  it("renders 5 minutes for the reminder", async () => {
+    useScriptResultHandler({ exit_code: 0 });
+    renderModal({ status: "success", time_before: 300 });
+
+    expect(
+      await screen.findByText(/notified end user 5 minutes before patching/i)
+    ).toBeInTheDocument();
+  });
+
+  it("renders the offline sentence for a success with exit code 0", async () => {
+    useScriptResultHandler({ exit_code: 0 });
+    renderModal({ status: "failed" });
+
+    expect(
+      await screen.findByText(/If the host is offline when the patch is forced/)
+    ).toBeInTheDocument();
+  });
+
+  it("renders the Fleet Desktop required sentence for exit code 100", async () => {
+    useScriptResultHandler({ exit_code: 100 });
+    renderModal({ status: "failed" });
+
+    expect(
+      await screen.findByText(
+        /The Fleet Desktop app is required to notify end users\./
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("renders the Fleet Desktop v1.5.0 sentence for exit code 101", async () => {
+    useScriptResultHandler({ exit_code: 101 });
+    renderModal({ status: "failed" });
+
+    expect(
+      await screen.findByText(/The Fleet Desktop app v1\.5\.0 is required/)
+    ).toBeInTheDocument();
+  });
+
+  it("renders the 'notification couldn't load' sentence for exit code 30", async () => {
+    useScriptResultHandler({ exit_code: 30 });
+    renderModal({ status: "failed" });
+
+    expect(
+      await screen.findByText(/The notification couldn't load\./)
+    ).toBeInTheDocument();
+  });
+
+  it("renders the screen-locked sentence for exit code 41", async () => {
+    useScriptResultHandler({ exit_code: 41 });
+    renderModal({ status: "failed" });
+
+    expect(
+      await screen.findByText(/screen was locked so the end user couldn't see/)
+    ).toBeInTheDocument();
+  });
+
+  it("renders output only (no failure sentence) for an unknown exit code", async () => {
+    useScriptResultHandler({ exit_code: 999, output: "unknown error output" });
+    renderModal({ status: "failed" });
+
+    expect(await screen.findByText(/unknown error output/)).toBeInTheDocument();
+    // None of the documented failure sentences should appear.
+    expect(
+      screen.queryByText(/The Fleet Desktop app is required/)
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/The notification couldn't load/)
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the deferred sentence when script_execution_id is absent, no fetch fired", async () => {
+    // Handler set to fail loudly if hit — absence of execution id must skip
+    // the fetch entirely.
+    const shouldNotFireHandler = jest.fn();
+    mockServer.use(
+      http.get(baseUrl("/scripts/results/:executionId"), () => {
+        shouldNotFireHandler();
+        return HttpResponse.json(scriptResult());
+      })
+    );
+
+    renderModal({ status: "failed", script_execution_id: undefined });
+
+    expect(
+      await screen.findByText(
+        /Another notification was displayed\. Fleet will try again on the next policy run\./
+      )
+    ).toBeInTheDocument();
+    expect(shouldNotFireHandler).not.toHaveBeenCalled();
+  });
+
+  it("lists every title in the Apps row (no truncation past three)", async () => {
+    useScriptResultHandler({ exit_code: 0 });
+    renderModal({
+      software_titles: [
+        "1Password",
+        "Slack",
+        "Docker Desktop",
+        "Zoom",
+        "Chrome",
+      ],
+      status: "success",
+    });
+
+    const appsRow = await screen.findByText("Apps");
+    const appsSection = appsRow.parentElement;
+    expect(appsSection?.textContent).toContain("1Password");
+    expect(appsSection?.textContent).toContain("Slack");
+    expect(appsSection?.textContent).toContain("Docker Desktop");
+    expect(appsSection?.textContent).toContain("Zoom");
+    expect(appsSection?.textContent).toContain("Chrome");
+    // No truncation suffix.
+    expect(appsSection?.textContent).not.toMatch(/more app/);
+  });
+
+  it("renders the notification script output when present", async () => {
+    useScriptResultHandler({
+      exit_code: 41,
+      output: "Screen locked at 2026-08-18T10:00:00Z",
+    });
+    renderModal({ status: "failed" });
+
+    expect(
+      await screen.findByText(/Notification script output:/)
+    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Screen locked at 2026-08-18T10:00:00Z/)
+      ).toBeInTheDocument()
+    );
+  });
+});

--- a/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/NotifyBeforePatchingDetailsModal.tests.tsx
+++ b/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/NotifyBeforePatchingDetailsModal.tests.tsx
@@ -11,9 +11,7 @@ import { IScriptResultResponse } from "services/entities/scripts";
 
 import NotifyBeforePatchingDetailsModal from "./NotifyBeforePatchingDetailsModal";
 
-// Default carries a stub script body so the Details reveal has something to
-// show — matches real payload shape where notification runs always have
-// contents.
+// Stub body so the Details reveal has something to render.
 const DEFAULT_SCRIPT_CONTENTS = "#!/bin/bash\nfleet-desktop notify ...";
 
 const scriptResult = (
@@ -150,8 +148,7 @@ describe("NotifyBeforePatchingDetailsModal", () => {
   });
 
   it("renders the deferred sentence when script_execution_id is absent, no fetch fired", async () => {
-    // Handler set to fail loudly if hit — absence of execution id must skip
-    // the fetch entirely.
+    // Fail loudly if the handler fires — no execution id means no fetch.
     const shouldNotFireHandler = jest.fn();
     mockServer.use(
       http.get(baseUrl("/scripts/results/:executionId"), () => {
@@ -254,10 +251,9 @@ describe("NotifyBeforePatchingDetailsModal", () => {
 
     expect(screen.getByText(/Notification script:/)).toBeInTheDocument();
     expect(screen.getByText(/#!\/bin\/bash/)).toBeInTheDocument();
-    // The label is split around the "output recorded" tooltip trigger, so
-    // match the trigger substring rather than the whole sentence.
+    // Label is split around the tooltip trigger; match just the trigger.
     expect(screen.getByText("output recorded")).toBeInTheDocument();
-    // Output block leads with the exit code line per Figma.
+    // Output block leads with the exit code line.
     expect(screen.getByText(/Exit code: 41/)).toBeInTheDocument();
     await waitFor(() =>
       expect(

--- a/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/NotifyBeforePatchingDetailsModal.tests.tsx
+++ b/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/NotifyBeforePatchingDetailsModal.tests.tsx
@@ -298,4 +298,32 @@ describe("NotifyBeforePatchingDetailsModal", () => {
       screen.queryByRole("button", { name: /Details/ })
     ).not.toBeInTheDocument();
   });
+
+  // Mirror guard: exit 0 is the success caveat. If BE ever slips and pairs
+  // status: "failed" with exit_code: 0, don't render the success caveat next
+  // to the red icon.
+  it("hides the offline caveat when status is failed but exit_code is 0", async () => {
+    useScriptResultHandler({ exit_code: 0 });
+    renderModal({ status: "failed" });
+
+    expect(await screen.findByTestId("error-outline-icon")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/If the host is offline when the patch is forced/)
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders DataError when the script-result fetch fails", async () => {
+    // 404 short-circuits the retry override, so the query settles in error
+    // state on the first attempt.
+    mockServer.use(
+      http.get(baseUrl("/scripts/results/:executionId"), () =>
+        HttpResponse.json({ message: "Not found" }, { status: 404 })
+      )
+    );
+    renderModal({ status: "success" });
+
+    expect(
+      await screen.findByText("Close this modal and try again.")
+    ).toBeInTheDocument();
+  });
 });

--- a/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/NotifyBeforePatchingDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/NotifyBeforePatchingDetailsModal.tsx
@@ -28,6 +28,7 @@ import {
   renderNotifyTitleList,
   formatNotifyTimeLabel,
   isNotifyFailure,
+  retryUnless404,
 } from "./helpers";
 
 const baseClass = "notify-before-patching-details-modal";
@@ -64,12 +65,12 @@ const NotifyBeforePatchingDetailsModal = ({
       ...DEFAULT_USE_QUERY_OPTIONS,
       // Skip the fetch on dispatcher-caught deferrals (no execution id).
       enabled: !!scriptExecutionId,
-      retry: (failureCount, err) => err?.status !== 404 && failureCount < 3,
+      retry: retryUnless404,
     }
   );
 
   const explanation = getCaveatMessage(
-    failed,
+    failed ? "failed" : "success",
     scriptExecutionId,
     scriptResult?.exit_code
   );
@@ -98,7 +99,7 @@ const NotifyBeforePatchingDetailsModal = ({
 
     const titleList = renderNotifyTitleList(titles);
     // Apps row is redundant when the intro already lists everything.
-    const showAppsRow = titles.length > INLINE_APP_LIMIT;
+    const hasOverflowApps = titles.length > INLINE_APP_LIMIT;
 
     return (
       <div className={`${baseClass}__content`}>
@@ -129,7 +130,7 @@ const NotifyBeforePatchingDetailsModal = ({
               )}
           </p>
         )}
-        {showAppsRow && (
+        {hasOverflowApps && (
           <DataSet
             title="Apps"
             value={titles.map((t) => getDisplayedSoftwareName(t)).join(", ")}

--- a/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/NotifyBeforePatchingDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/NotifyBeforePatchingDetailsModal.tsx
@@ -1,0 +1,143 @@
+import React from "react";
+import { AxiosError } from "axios";
+import { useQuery } from "react-query";
+
+import { IActivityDetails } from "interfaces/activity";
+import scriptsAPI, { IScriptResultResponse } from "services/entities/scripts";
+import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
+import { getDisplayedSoftwareName } from "pages/SoftwarePage/helpers";
+
+import Button from "components/buttons/Button";
+import DataError from "components/DataError";
+import DataSet from "components/DataSet";
+import Modal from "components/Modal";
+import ModalFooter from "components/ModalFooter";
+import Spinner from "components/Spinner";
+import Textarea from "components/Textarea";
+
+const baseClass = "notify-before-patching-details-modal";
+
+// TODO(#50915): Marko will publish a "another notification is displayed" exit
+// code — waiting on the number. Meanwhile the "no script_execution_id" branch
+// covers the dispatcher-caught case (see spec: absence of execution_id is
+// unambiguous because the patch kind sets no `expires_at`).
+const DEFERRED_EXIT_CODE_TBC = -1;
+
+const FAILURE_COPY_BY_EXIT_CODE: Record<number, string> = {
+  0: "If the host is offline when the patch is forced, Fleet skips the patch. When the host comes back online Fleet notifies the end user again and the patch is forced 1 hour later.",
+  30: "The notification couldn't load. Fleet will try again on the next policy run.",
+  31: "The notification couldn't load. Fleet will try again on the next policy run.",
+  41: "The screen was locked so the end user couldn't see the notification. Fleet will try again on the next policy run.",
+  100: "The Fleet Desktop app is required to notify end users. Add the app from the Fleet-maintained catalog and deploy to all your hosts.",
+  101: "The Fleet Desktop app v1.5.0 is required to notify end users. Add the app from the Fleet-maintained catalog and deploy to all your hosts.",
+  [DEFERRED_EXIT_CODE_TBC]:
+    "Another notification was displayed. Fleet will try again on the next policy run.",
+};
+
+const DEFERRED_SENTENCE =
+  "Another notification was displayed. Fleet will try again on the next policy run.";
+
+const getFailureSentence = (
+  scriptExecutionId?: string,
+  exitCode?: number | null
+): string | null => {
+  // A server-side deferral emits an activity with no script run — absence of
+  // script_execution_id is the unambiguous signal.
+  if (!scriptExecutionId) return DEFERRED_SENTENCE;
+  if (exitCode === null || exitCode === undefined) return null;
+  return FAILURE_COPY_BY_EXIT_CODE[exitCode] ?? null;
+};
+
+interface INotifyBeforePatchingDetailsModalProps {
+  details: IActivityDetails;
+  onCancel: () => void;
+}
+
+const NotifyBeforePatchingDetailsModal = ({
+  details,
+  onCancel,
+}: INotifyBeforePatchingDetailsModalProps) => {
+  const {
+    host_display_name: hostName,
+    software_titles: titles = [],
+    status,
+    time_before: timeBefore,
+    script_execution_id: scriptExecutionId,
+  } = details;
+
+  const timeLabel = timeBefore === 300 ? "5 minutes" : "1 hour";
+  const failed = status === "failed";
+
+  const { data: scriptResult, isLoading, isError } = useQuery<
+    IScriptResultResponse,
+    AxiosError
+  >(
+    ["notify-script-result", scriptExecutionId],
+    () => scriptsAPI.getScriptResult(scriptExecutionId as string),
+    {
+      ...DEFAULT_USE_QUERY_OPTIONS,
+      // Only fetch when the server actually ran a script. A dispatcher-caught
+      // deferral has no execution id and we render the deferred sentence
+      // without hitting the API.
+      enabled: !!scriptExecutionId,
+      retry: (failureCount, err) => err?.status !== 404 && failureCount < 3,
+    }
+  );
+
+  const failureSentence = failed
+    ? getFailureSentence(scriptExecutionId, scriptResult?.exit_code)
+    : null;
+
+  const renderContent = () => {
+    if (scriptExecutionId && isLoading) {
+      return <Spinner />;
+    }
+    if (scriptExecutionId && isError) {
+      return <DataError description="Close this modal and try again." />;
+    }
+
+    const verb = failed ? "failed to notify" : "notified";
+    return (
+      <div className={`${baseClass}__content`}>
+        <p className={`${baseClass}__status`}>
+          Fleet {verb} end user {timeLabel} before patching on{" "}
+          <b>{hostName || "this host"}</b>.
+        </p>
+        {failureSentence && (
+          <p className={`${baseClass}__failure`}>{failureSentence}</p>
+        )}
+        <DataSet
+          title="Apps"
+          value={
+            titles.length
+              ? titles.map((t) => getDisplayedSoftwareName(t)).join(", ")
+              : "—"
+          }
+        />
+        {scriptResult?.output && (
+          <Textarea label="Notification script output:" variant="code">
+            {scriptResult.output}
+          </Textarea>
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <Modal
+      className={baseClass}
+      title="Notification details"
+      onExit={onCancel}
+      onEnter={onCancel}
+    >
+      <>
+        {renderContent()}
+        <ModalFooter
+          primaryButtons={<Button onClick={onCancel}>Done</Button>}
+        />
+      </>
+    </Modal>
+  );
+};
+
+export default NotifyBeforePatchingDetailsModal;

--- a/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/NotifyBeforePatchingDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/NotifyBeforePatchingDetailsModal.tsx
@@ -25,6 +25,8 @@ import {
   EXIT_CODES_NEEDING_EUE_LINK,
   PATCHING_END_USER_EXPERIENCE_URL,
   renderNotifyTitleList,
+  formatNotifyTimeLabel,
+  isNotifyFailure,
 } from "./helpers";
 
 const baseClass = "notify-before-patching-details-modal";
@@ -46,8 +48,8 @@ const NotifyBeforePatchingDetailsModal = ({
     script_execution_id: scriptExecutionId,
   } = details;
 
-  const timeLabel = timeBefore === 300 ? "5 minutes" : "1 hour";
-  const failed = status === "failed";
+  const timeLabel = formatNotifyTimeLabel(timeBefore);
+  const failed = isNotifyFailure(status);
 
   const [showDetails, setShowDetails] = useState(false);
 
@@ -61,7 +63,8 @@ const NotifyBeforePatchingDetailsModal = ({
       ...DEFAULT_USE_QUERY_OPTIONS,
       // Skip the fetch on dispatcher-caught deferrals (no execution id).
       enabled: !!scriptExecutionId,
-      retry: (failureCount, err) => err?.status !== 404 && failureCount < 3,
+      retry: (failureCount, err) =>
+        err?.response?.status !== 404 && failureCount < 3,
     }
   );
 
@@ -89,7 +92,7 @@ const NotifyBeforePatchingDetailsModal = ({
 
     const titleList = renderNotifyTitleList(titles);
     // Apps row is redundant when the intro already lists everything (≤3 apps).
-    const showAppsRow = titles.length > 3;
+    const showAppsRow = titles.length > 4;
 
     return (
       <div className={`${baseClass}__content`}>

--- a/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/NotifyBeforePatchingDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/NotifyBeforePatchingDetailsModal.tsx
@@ -5,7 +5,6 @@ import { useQuery } from "react-query";
 import { IActivityDetails } from "interfaces/activity";
 import scriptsAPI, { IScriptResultResponse } from "services/entities/scripts";
 import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
-import { pluralize } from "utilities/strings/stringUtils";
 import { getDisplayedSoftwareName } from "pages/SoftwarePage/helpers";
 
 import Button from "components/buttons/Button";
@@ -25,6 +24,7 @@ import {
   getCaveatSentence,
   EXIT_CODES_NEEDING_EUE_LINK,
   PATCHING_END_USER_EXPERIENCE_URL,
+  renderNotifyTitleList,
 } from "./helpers";
 
 const baseClass = "notify-before-patching-details-modal";
@@ -80,40 +80,14 @@ const NotifyBeforePatchingDetailsModal = ({
 
     const verb = failed ? "failed to notify" : "notified";
     // Nothing to reveal for a dispatcher-caught deferral (no script ran).
-    const hasRevealable =
+    const hasScriptDetails =
       !!scriptResult?.script_contents || scriptResult?.exit_code != null;
     const outputBlock =
       scriptResult?.exit_code != null
         ? `Exit code: ${scriptResult.exit_code}\n${scriptResult.output ?? ""}`
         : null;
 
-    // Bold titles, Oxford comma, ", and N more app(s)" past three.
-    const bold = (name: string) => <b>{getDisplayedSoftwareName(name)}</b>;
-    const overflow = titles.length - 3;
-    let titleList: React.ReactNode = null;
-    if (titles.length === 1) {
-      titleList = bold(titles[0]);
-    } else if (titles.length === 2) {
-      titleList = (
-        <>
-          {bold(titles[0])} and {bold(titles[1])}
-        </>
-      );
-    } else if (titles.length === 3) {
-      titleList = (
-        <>
-          {bold(titles[0])}, {bold(titles[1])}, and {bold(titles[2])}
-        </>
-      );
-    } else if (titles.length > 3) {
-      titleList = (
-        <>
-          {bold(titles[0])}, {bold(titles[1])}, {bold(titles[2])}, and{" "}
-          {overflow} more {pluralize(overflow, "app")}
-        </>
-      );
-    }
-
+    const titleList = renderNotifyTitleList(titles);
     // Apps row is redundant when the intro already lists everything (≤3 apps).
     const showAppsRow = titles.length > 3;
 
@@ -126,7 +100,7 @@ const NotifyBeforePatchingDetailsModal = ({
             <span>
               Fleet {verb} end user {timeLabel} before patching
               {titleList && <> {titleList}</>} on{" "}
-              <b>{hostName || "this host"}</b>.
+              <strong>{hostName || "this host"}</strong>.
             </span>
           }
         />
@@ -152,7 +126,7 @@ const NotifyBeforePatchingDetailsModal = ({
             value={titles.map((t) => getDisplayedSoftwareName(t)).join(", ")}
           />
         )}
-        {hasRevealable && (
+        {hasScriptDetails && (
           <RevealButton
             isShowing={showDetails}
             showText="Details"

--- a/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/NotifyBeforePatchingDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/NotifyBeforePatchingDetailsModal.tsx
@@ -59,9 +59,7 @@ const NotifyBeforePatchingDetailsModal = ({
     () => scriptsAPI.getScriptResult(scriptExecutionId as string),
     {
       ...DEFAULT_USE_QUERY_OPTIONS,
-      // Only fetch when the server actually ran a script. A dispatcher-caught
-      // deferral has no execution id and we render the deferred sentence
-      // without hitting the API.
+      // Skip the fetch on dispatcher-caught deferrals (no execution id).
       enabled: !!scriptExecutionId,
       retry: (failureCount, err) => err?.status !== 404 && failureCount < 3,
     }
@@ -89,8 +87,7 @@ const NotifyBeforePatchingDetailsModal = ({
         ? `Exit code: ${scriptResult.exit_code}\n${scriptResult.output ?? ""}`
         : null;
 
-    // Bold each title, Oxford comma, truncate past three with a "and N more
-    // apps" tail. Full list moves to the Apps row when truncated.
+    // Bold titles, Oxford comma, ", and N more app(s)" past three.
     const bold = (name: string) => <b>{getDisplayedSoftwareName(name)}</b>;
     const overflow = titles.length - 3;
     let titleList: React.ReactNode = null;
@@ -117,8 +114,7 @@ const NotifyBeforePatchingDetailsModal = ({
       );
     }
 
-    // Intro sentence covers 1–3 apps in full; the Apps row only adds signal
-    // when the intro truncated.
+    // Apps row is redundant when the intro already lists everything (≤3 apps).
     const showAppsRow = titles.length > 3;
 
     return (

--- a/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/NotifyBeforePatchingDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/NotifyBeforePatchingDetailsModal.tsx
@@ -68,7 +68,7 @@ const NotifyBeforePatchingDetailsModal = ({
     }
   );
 
-  const caveatSentence = getCaveatSentence(
+  const explanation = getCaveatSentence(
     scriptExecutionId,
     scriptResult?.exit_code
   );
@@ -83,7 +83,7 @@ const NotifyBeforePatchingDetailsModal = ({
 
     const verb = failed ? "failed to notify" : "notified";
     // Nothing to reveal for a dispatcher-caught deferral (no script ran).
-    const hasScriptDetails =
+    const hasDetailsContent =
       !!scriptResult?.script_contents || scriptResult?.exit_code != null;
     const outputBlock =
       scriptResult?.exit_code != null
@@ -107,9 +107,9 @@ const NotifyBeforePatchingDetailsModal = ({
             </span>
           }
         />
-        {caveatSentence && (
-          <p className={`${baseClass}__caveat`}>
-            {caveatSentence}
+        {explanation && (
+          <p className={`${baseClass}__explanation`}>
+            {explanation}
             {scriptResult?.exit_code != null &&
               EXIT_CODES_NEEDING_EUE_LINK.has(scriptResult.exit_code) && (
                 <>
@@ -129,7 +129,7 @@ const NotifyBeforePatchingDetailsModal = ({
             value={titles.map((t) => getDisplayedSoftwareName(t)).join(", ")}
           />
         )}
-        {hasScriptDetails && (
+        {hasDetailsContent && (
           <RevealButton
             isShowing={showDetails}
             showText="Details"

--- a/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/NotifyBeforePatchingDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/NotifyBeforePatchingDetailsModal.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { AxiosError } from "axios";
 import { useQuery } from "react-query";
 
-import { IActivityDetails } from "interfaces/activity";
+import { IActivityDetails, INotifyActivityStatus } from "interfaces/activity";
 import scriptsAPI, { IScriptResultResponse } from "services/entities/scripts";
 import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
 import { getDisplayedSoftwareName } from "pages/SoftwarePage/helpers";
@@ -49,7 +49,7 @@ const NotifyBeforePatchingDetailsModal = ({
   } = details;
 
   const timeLabel = formatNotifyTimeLabel(timeBefore);
-  const failed = isNotifyFailure(status);
+  const failed = isNotifyFailure(status as INotifyActivityStatus | undefined);
 
   const [showDetails, setShowDetails] = useState(false);
 
@@ -63,12 +63,12 @@ const NotifyBeforePatchingDetailsModal = ({
       ...DEFAULT_USE_QUERY_OPTIONS,
       // Skip the fetch on dispatcher-caught deferrals (no execution id).
       enabled: !!scriptExecutionId,
-      retry: (failureCount, err) =>
-        err?.response?.status !== 404 && failureCount < 3,
+      retry: (failureCount, err) => err?.status !== 404 && failureCount < 3,
     }
   );
 
   const explanation = getCaveatSentence(
+    failed,
     scriptExecutionId,
     scriptResult?.exit_code
   );
@@ -82,13 +82,18 @@ const NotifyBeforePatchingDetailsModal = ({
     }
 
     const verb = failed ? "failed to notify" : "notified";
-    // Nothing to reveal for a dispatcher-caught deferral (no script ran).
-    const hasDetailsContent =
-      !!scriptResult?.script_contents || scriptResult?.exit_code != null;
-    const outputBlock =
-      scriptResult?.exit_code != null
-        ? `Exit code: ${scriptResult.exit_code}\n${scriptResult.output ?? ""}`
-        : null;
+    // On a silent success (exit 0, no output) the output block would just read
+    // "Exit code: 0" — noise, skip it.
+    const outputBlock = (() => {
+      const code = scriptResult?.exit_code;
+      const output = scriptResult?.output;
+      if (code == null) return null;
+      if (code === 0 && !output) return null;
+      return output ? `Exit code: ${code}\n${output}` : `Exit code: ${code}`;
+    })();
+    // Nothing to reveal for a dispatcher-caught deferral (no script ran) or a
+    // silent success (no script contents, no output).
+    const hasDetailsContent = !!scriptResult?.script_contents || !!outputBlock;
 
     const titleList = renderNotifyTitleList(titles);
     // Apps row is redundant when the intro already lists everything (≤3 apps).

--- a/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/NotifyBeforePatchingDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/NotifyBeforePatchingDetailsModal.tsx
@@ -21,7 +21,7 @@ import TooltipWrapper from "components/TooltipWrapper";
 import CustomLink from "components/CustomLink";
 
 import {
-  getCaveatSentence,
+  getCaveatMessage,
   EXIT_CODES_NEEDING_EUE_LINK,
   PATCHING_END_USER_EXPERIENCE_URL,
   renderNotifyTitleList,
@@ -67,7 +67,7 @@ const NotifyBeforePatchingDetailsModal = ({
     }
   );
 
-  const explanation = getCaveatSentence(
+  const explanation = getCaveatMessage(
     failed,
     scriptExecutionId,
     scriptResult?.exit_code

--- a/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/NotifyBeforePatchingDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/NotifyBeforePatchingDetailsModal.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { AxiosError } from "axios";
 import { useQuery } from "react-query";
 
-import { IActivityDetails, INotifyActivityStatus } from "interfaces/activity";
+import { IActivityDetails } from "interfaces/activity";
 import scriptsAPI, { IScriptResultResponse } from "services/entities/scripts";
 import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
 import { getDisplayedSoftwareName } from "pages/SoftwarePage/helpers";
@@ -50,7 +50,7 @@ const NotifyBeforePatchingDetailsModal = ({
   } = details;
 
   const timeLabel = formatNotifyTimeLabel(timeBefore);
-  const failed = isNotifyFailure(status as INotifyActivityStatus | undefined);
+  const failed = isNotifyFailure(status);
 
   const [showDetails, setShowDetails] = useState(false);
 
@@ -161,7 +161,7 @@ const NotifyBeforePatchingDetailsModal = ({
               >
                 output recorded
               </TooltipWrapper>{" "}
-              when ran the script above:
+              when Fleet ran the script above:
             </p>
             <Textarea variant="code">{outputBlock}</Textarea>
           </div>
@@ -177,12 +177,8 @@ const NotifyBeforePatchingDetailsModal = ({
       onExit={onCancel}
       onEnter={onCancel}
     >
-      <>
-        {renderContent()}
-        <ModalFooter
-          primaryButtons={<Button onClick={onCancel}>Done</Button>}
-        />
-      </>
+      {renderContent()}
+      <ModalFooter primaryButtons={<Button onClick={onCancel}>Done</Button>} />
     </Modal>
   );
 };

--- a/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/NotifyBeforePatchingDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/NotifyBeforePatchingDetailsModal.tsx
@@ -1,52 +1,33 @@
-import React from "react";
+import React, { useState } from "react";
 import { AxiosError } from "axios";
 import { useQuery } from "react-query";
 
 import { IActivityDetails } from "interfaces/activity";
 import scriptsAPI, { IScriptResultResponse } from "services/entities/scripts";
 import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
+import { pluralize } from "utilities/strings/stringUtils";
 import { getDisplayedSoftwareName } from "pages/SoftwarePage/helpers";
 
 import Button from "components/buttons/Button";
+import RevealButton from "components/buttons/RevealButton";
 import DataError from "components/DataError";
 import DataSet from "components/DataSet";
+import IconStatusMessage from "components/IconStatusMessage";
 import Modal from "components/Modal";
 import ModalFooter from "components/ModalFooter";
 import Spinner from "components/Spinner";
 import Textarea from "components/Textarea";
+import TooltipWrapper from "components/TooltipWrapper";
+
+import CustomLink from "components/CustomLink";
+
+import {
+  getCaveatSentence,
+  EXIT_CODES_NEEDING_EUE_LINK,
+  PATCHING_END_USER_EXPERIENCE_URL,
+} from "./helpers";
 
 const baseClass = "notify-before-patching-details-modal";
-
-// TODO(#50915): Marko will publish a "another notification is displayed" exit
-// code — waiting on the number. Meanwhile the "no script_execution_id" branch
-// covers the dispatcher-caught case (see spec: absence of execution_id is
-// unambiguous because the patch kind sets no `expires_at`).
-const DEFERRED_EXIT_CODE_TBC = -1;
-
-const FAILURE_COPY_BY_EXIT_CODE: Record<number, string> = {
-  0: "If the host is offline when the patch is forced, Fleet skips the patch. When the host comes back online Fleet notifies the end user again and the patch is forced 1 hour later.",
-  30: "The notification couldn't load. Fleet will try again on the next policy run.",
-  31: "The notification couldn't load. Fleet will try again on the next policy run.",
-  41: "The screen was locked so the end user couldn't see the notification. Fleet will try again on the next policy run.",
-  100: "The Fleet Desktop app is required to notify end users. Add the app from the Fleet-maintained catalog and deploy to all your hosts.",
-  101: "The Fleet Desktop app v1.5.0 is required to notify end users. Add the app from the Fleet-maintained catalog and deploy to all your hosts.",
-  [DEFERRED_EXIT_CODE_TBC]:
-    "Another notification was displayed. Fleet will try again on the next policy run.",
-};
-
-const DEFERRED_SENTENCE =
-  "Another notification was displayed. Fleet will try again on the next policy run.";
-
-const getFailureSentence = (
-  scriptExecutionId?: string,
-  exitCode?: number | null
-): string | null => {
-  // A server-side deferral emits an activity with no script run — absence of
-  // script_execution_id is the unambiguous signal.
-  if (!scriptExecutionId) return DEFERRED_SENTENCE;
-  if (exitCode === null || exitCode === undefined) return null;
-  return FAILURE_COPY_BY_EXIT_CODE[exitCode] ?? null;
-};
 
 interface INotifyBeforePatchingDetailsModalProps {
   details: IActivityDetails;
@@ -68,6 +49,8 @@ const NotifyBeforePatchingDetailsModal = ({
   const timeLabel = timeBefore === 300 ? "5 minutes" : "1 hour";
   const failed = status === "failed";
 
+  const [showDetails, setShowDetails] = useState(false);
+
   const { data: scriptResult, isLoading, isError } = useQuery<
     IScriptResultResponse,
     AxiosError
@@ -84,9 +67,10 @@ const NotifyBeforePatchingDetailsModal = ({
     }
   );
 
-  const failureSentence = failed
-    ? getFailureSentence(scriptExecutionId, scriptResult?.exit_code)
-    : null;
+  const caveatSentence = getCaveatSentence(
+    scriptExecutionId,
+    scriptResult?.exit_code
+  );
 
   const renderContent = () => {
     if (scriptExecutionId && isLoading) {
@@ -97,26 +81,113 @@ const NotifyBeforePatchingDetailsModal = ({
     }
 
     const verb = failed ? "failed to notify" : "notified";
+    // Nothing to reveal for a dispatcher-caught deferral (no script ran).
+    const hasRevealable =
+      !!scriptResult?.script_contents || scriptResult?.exit_code != null;
+    const outputBlock =
+      scriptResult?.exit_code != null
+        ? `Exit code: ${scriptResult.exit_code}\n${scriptResult.output ?? ""}`
+        : null;
+
+    // Bold each title, Oxford comma, truncate past three with a "and N more
+    // apps" tail. Full list moves to the Apps row when truncated.
+    const bold = (name: string) => <b>{getDisplayedSoftwareName(name)}</b>;
+    const overflow = titles.length - 3;
+    let titleList: React.ReactNode = null;
+    if (titles.length === 1) {
+      titleList = bold(titles[0]);
+    } else if (titles.length === 2) {
+      titleList = (
+        <>
+          {bold(titles[0])} and {bold(titles[1])}
+        </>
+      );
+    } else if (titles.length === 3) {
+      titleList = (
+        <>
+          {bold(titles[0])}, {bold(titles[1])}, and {bold(titles[2])}
+        </>
+      );
+    } else if (titles.length > 3) {
+      titleList = (
+        <>
+          {bold(titles[0])}, {bold(titles[1])}, {bold(titles[2])}, and{" "}
+          {overflow} more {pluralize(overflow, "app")}
+        </>
+      );
+    }
+
+    // Intro sentence covers 1–3 apps in full; the Apps row only adds signal
+    // when the intro truncated.
+    const showAppsRow = titles.length > 3;
+
     return (
       <div className={`${baseClass}__content`}>
-        <p className={`${baseClass}__status`}>
-          Fleet {verb} end user {timeLabel} before patching on{" "}
-          <b>{hostName || "this host"}</b>.
-        </p>
-        {failureSentence && (
-          <p className={`${baseClass}__failure`}>{failureSentence}</p>
-        )}
-        <DataSet
-          title="Apps"
-          value={
-            titles.length
-              ? titles.map((t) => getDisplayedSoftwareName(t)).join(", ")
-              : "—"
+        <IconStatusMessage
+          className={`${baseClass}__status-message`}
+          iconName={failed ? "error-outline" : "success-outline"}
+          message={
+            <span>
+              Fleet {verb} end user {timeLabel} before patching
+              {titleList && <> {titleList}</>} on{" "}
+              <b>{hostName || "this host"}</b>.
+            </span>
           }
         />
-        {scriptResult?.output && (
-          <Textarea label="Notification script output:" variant="code">
-            {scriptResult.output}
+        {caveatSentence && (
+          <p className={`${baseClass}__caveat`}>
+            {caveatSentence}
+            {scriptResult?.exit_code != null &&
+              EXIT_CODES_NEEDING_EUE_LINK.has(scriptResult.exit_code) && (
+                <>
+                  {" "}
+                  <CustomLink
+                    url={PATCHING_END_USER_EXPERIENCE_URL}
+                    text="End user experience"
+                    newTab
+                  />
+                </>
+              )}
+          </p>
+        )}
+        {showAppsRow && (
+          <DataSet
+            title="Apps"
+            value={titles.map((t) => getDisplayedSoftwareName(t)).join(", ")}
+          />
+        )}
+        {hasRevealable && (
+          <RevealButton
+            isShowing={showDetails}
+            showText="Details"
+            hideText="Details"
+            caretPosition="after"
+            onClick={() => setShowDetails((s) => !s)}
+          />
+        )}
+        {showDetails && scriptResult?.script_contents && (
+          <Textarea label="Notification script:" variant="code">
+            {scriptResult.script_contents}
+          </Textarea>
+        )}
+        {showDetails && outputBlock && (
+          <Textarea
+            label={
+              <>
+                The{" "}
+                <TooltipWrapper
+                  tipContent="Fleet records the last 10,000 characters to prevent downtime."
+                  tooltipClass={`${baseClass}__output-tooltip`}
+                  delayInMs={500}
+                >
+                  output recorded
+                </TooltipWrapper>{" "}
+                when ran the script above:
+              </>
+            }
+            variant="code"
+          >
+            {outputBlock}
           </Textarea>
         )}
       </div>
@@ -126,7 +197,7 @@ const NotifyBeforePatchingDetailsModal = ({
   return (
     <Modal
       className={baseClass}
-      title="Notification details"
+      title="Details"
       onExit={onCancel}
       onEnter={onCancel}
     >

--- a/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/NotifyBeforePatchingDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/NotifyBeforePatchingDetailsModal.tsx
@@ -23,6 +23,7 @@ import CustomLink from "components/CustomLink";
 import {
   getCaveatMessage,
   EXIT_CODES_NEEDING_EUE_LINK,
+  INLINE_APP_LIMIT,
   PATCHING_END_USER_EXPERIENCE_URL,
   renderNotifyTitleList,
   formatNotifyTimeLabel,
@@ -96,8 +97,8 @@ const NotifyBeforePatchingDetailsModal = ({
     const hasDetailsContent = !!scriptResult?.script_contents || !!outputBlock;
 
     const titleList = renderNotifyTitleList(titles);
-    // Apps row is redundant when the intro already lists everything (≤3 apps).
-    const showAppsRow = titles.length > 4;
+    // Apps row is redundant when the intro already lists everything.
+    const showAppsRow = titles.length > INLINE_APP_LIMIT;
 
     return (
       <div className={`${baseClass}__content`}>

--- a/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/NotifyBeforePatchingDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/NotifyBeforePatchingDetailsModal.tsx
@@ -141,24 +141,21 @@ const NotifyBeforePatchingDetailsModal = ({
           </Textarea>
         )}
         {showDetails && outputBlock && (
-          <Textarea
-            label={
-              <>
-                The{" "}
-                <TooltipWrapper
-                  tipContent="Fleet records the last 10,000 characters to prevent downtime."
-                  tooltipClass={`${baseClass}__output-tooltip`}
-                  delayInMs={500}
-                >
-                  output recorded
-                </TooltipWrapper>{" "}
-                when ran the script above:
-              </>
-            }
-            variant="code"
-          >
-            {outputBlock}
-          </Textarea>
+          <div className={`${baseClass}__output-section`}>
+            <p className={`${baseClass}__output-label`}>
+              The{" "}
+              <TooltipWrapper
+                tipContent="Fleet records the last 10,000 characters to prevent downtime."
+                tooltipClass={`${baseClass}__output-tooltip`}
+                delayInMs={500}
+                position="bottom-start"
+              >
+                output recorded
+              </TooltipWrapper>{" "}
+              when ran the script above:
+            </p>
+            <Textarea variant="code">{outputBlock}</Textarea>
+          </div>
         )}
       </div>
     );

--- a/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/_styles.scss
+++ b/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/_styles.scss
@@ -11,4 +11,18 @@
   &__caveat {
     margin: 0;
   }
+
+  &__output-section {
+    display: flex;
+    flex-direction: column;
+    gap: $pad-small;
+  }
+
+  &__output-label {
+    margin: 0;
+  }
+
+  &__output-tooltip {
+    width: 300px;
+  }
 }

--- a/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/_styles.scss
+++ b/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/_styles.scss
@@ -1,0 +1,15 @@
+.notify-before-patching-details-modal {
+  &__content {
+    @include vertical-modal-layout;
+
+    // The vertical-modal-layout flex column stretches children full-width by
+    // default; the reveal button should hug its content.
+    .reveal-button {
+      align-self: flex-start;
+    }
+  }
+
+  &__caveat {
+    margin: 0;
+  }
+}

--- a/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/_styles.scss
+++ b/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/_styles.scss
@@ -8,7 +8,7 @@
     }
   }
 
-  &__caveat {
+  &__explanation {
     margin: 0;
   }
 

--- a/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/_styles.scss
+++ b/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/_styles.scss
@@ -2,8 +2,7 @@
   &__content {
     @include vertical-modal-layout;
 
-    // The vertical-modal-layout flex column stretches children full-width by
-    // default; the reveal button should hug its content.
+    // Hug content instead of stretching to the flex column's full width.
     .reveal-button {
       align-self: flex-start;
     }

--- a/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/_styles.scss
+++ b/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/_styles.scss
@@ -2,7 +2,7 @@
   &__content {
     @include vertical-modal-layout;
 
-    // Hug content instead of stretching to the flex column's full width.
+    // Prevent full-width stretching
     .reveal-button {
       align-self: flex-start;
     }

--- a/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/helpers.ts
+++ b/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/helpers.ts
@@ -1,7 +1,5 @@
-// TODO(#50915): Marko will publish a "another notification is displayed" exit
-// code — waiting on the number. Meanwhile the "no script_execution_id" branch
-// covers the dispatcher-caught case (see spec: absence of execution_id is
-// unambiguous because the patch kind sets no `expires_at`).
+// TODO: swap in the "another notification displayed" exit code once published.
+// The no-script_execution_id branch already handles the dispatcher deferral.
 export const DEFERRED_EXIT_CODE_TBC = -1;
 
 export const FAILURE_COPY_BY_EXIT_CODE: Record<number, string> = {
@@ -18,23 +16,19 @@ export const FAILURE_COPY_BY_EXIT_CODE: Record<number, string> = {
 export const DEFERRED_SENTENCE =
   "Another notification was displayed. Fleet will try again on the next policy run.";
 
-// The exit-code map covers both success (exit 0 shows the offline caveat) and
-// failure sentences — the intro's verb changes, but the exit-code-driven
-// sentence renders in both cases.
+// Covers both success (exit 0 caveat) and failure sentences.
 export const getCaveatSentence = (
   scriptExecutionId?: string,
   exitCode?: number | null
 ): string | null => {
-  // A server-side deferral emits an activity with no script run — absence of
-  // script_execution_id is the unambiguous signal.
+  // Absence of script_execution_id signals a server-side deferral.
   if (!scriptExecutionId) return DEFERRED_SENTENCE;
   if (exitCode === null || exitCode === undefined) return null;
   return FAILURE_COPY_BY_EXIT_CODE[exitCode] ?? null;
 };
 
-// Longer-form caveat used by the policy automation modal's success case. The
-// activity feed modal uses FAILURE_COPY_BY_EXIT_CODE[0] instead — Figma treats
-// them as different sentences by design.
+// Longer-form success caveat; intentionally different from
+// FAILURE_COPY_BY_EXIT_CODE[0].
 export const getAutomationNotifiedSentence = (timeBefore?: number): string => {
   const label = timeBefore === 300 ? "5 minutes" : "1 hour";
   return `End user was notified. Patch will be forced in ${label}. If the host is offline when a patch should be forced, Fleet notifies the end user again when it comes back online and patches it after 1 hour.`;
@@ -43,24 +37,18 @@ export const getAutomationNotifiedSentence = (timeBefore?: number): string => {
 export const SKIPPED_INSTALL_NOTIFY_EXPLANATION =
   "The app was open. The end user will be notified before the patch is forced.";
 
-// Same URL the "End user experience" dropdown in DeployModal / PolicyForm
-// links to — kept in sync so admins land on the same doc regardless of where
-// they discover the "Fleet Desktop required" sentence.
+// Shared with the "End user experience" dropdown — keep in sync.
 export const PATCHING_END_USER_EXPERIENCE_URL =
   "https://fleetdm.com/learn-more-about/patching-end-user-experience";
 
-// Exit codes whose sentence needs the "End user experience" learn-more link
-// appended — currently the two Fleet-Desktop-required variants (missing app,
-// too-old version). Kept as a set so future exit codes can opt in explicitly.
+// Exit codes that append the "End user experience" learn-more link.
 export const EXIT_CODES_NEEDING_EUE_LINK: ReadonlySet<number> = new Set([
   100,
   101,
 ]);
 
-// The BE emits the pre-install query output with a notify-specific sentence
-// appended for the notify_before_patching variant. That substring is the
-// unambiguous signal we're looking at a notify skip vs a patch_when_closed
-// skip. Kept as a constant so the check doesn't drift silently.
+// Substring the BE appends only on notify_before_patching skips — named to
+// prevent silent drift.
 const NOTIFY_SKIP_MARKER = "Fleet notifies the end user";
 export const isNotifyBeforePatchingSkip = (
   preInstallOutput?: string | null

--- a/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/helpers.ts
+++ b/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/helpers.ts
@@ -1,0 +1,67 @@
+// TODO(#50915): Marko will publish a "another notification is displayed" exit
+// code — waiting on the number. Meanwhile the "no script_execution_id" branch
+// covers the dispatcher-caught case (see spec: absence of execution_id is
+// unambiguous because the patch kind sets no `expires_at`).
+export const DEFERRED_EXIT_CODE_TBC = -1;
+
+export const FAILURE_COPY_BY_EXIT_CODE: Record<number, string> = {
+  0: "If the host is offline when the patch is forced, Fleet skips the patch. When the host comes back online Fleet notifies the end user again and the patch is forced 1 hour later.",
+  30: "The notification couldn't load. Fleet will try again on the next policy run.",
+  31: "The notification couldn't load. Fleet will try again on the next policy run.",
+  41: "The screen was locked so the end user couldn't see the notification. Fleet will try again on the next policy run.",
+  100: "The Fleet Desktop app is required to notify end users. Add the app from the Fleet-maintained catalog and deploy to all your hosts.",
+  101: "The Fleet Desktop app v1.5.0 is required to notify end users. Add the app from the Fleet-maintained catalog and deploy to all your hosts.",
+  [DEFERRED_EXIT_CODE_TBC]:
+    "Another notification was displayed. Fleet will try again on the next policy run.",
+};
+
+export const DEFERRED_SENTENCE =
+  "Another notification was displayed. Fleet will try again on the next policy run.";
+
+// The exit-code map covers both success (exit 0 shows the offline caveat) and
+// failure sentences — the intro's verb changes, but the exit-code-driven
+// sentence renders in both cases.
+export const getCaveatSentence = (
+  scriptExecutionId?: string,
+  exitCode?: number | null
+): string | null => {
+  // A server-side deferral emits an activity with no script run — absence of
+  // script_execution_id is the unambiguous signal.
+  if (!scriptExecutionId) return DEFERRED_SENTENCE;
+  if (exitCode === null || exitCode === undefined) return null;
+  return FAILURE_COPY_BY_EXIT_CODE[exitCode] ?? null;
+};
+
+// Longer-form caveat used by the policy automation modal's success case. The
+// activity feed modal uses FAILURE_COPY_BY_EXIT_CODE[0] instead — Figma treats
+// them as different sentences by design.
+export const getAutomationNotifiedSentence = (timeBefore?: number): string => {
+  const label = timeBefore === 300 ? "5 minutes" : "1 hour";
+  return `End user was notified. Patch will be forced in ${label}. If the host is offline when a patch should be forced, Fleet notifies the end user again when it comes back online and patches it after 1 hour.`;
+};
+
+export const SKIPPED_INSTALL_NOTIFY_EXPLANATION =
+  "The app was open. The end user will be notified before the patch is forced.";
+
+// Same URL the "End user experience" dropdown in DeployModal / PolicyForm
+// links to — kept in sync so admins land on the same doc regardless of where
+// they discover the "Fleet Desktop required" sentence.
+export const PATCHING_END_USER_EXPERIENCE_URL =
+  "https://fleetdm.com/learn-more-about/patching-end-user-experience";
+
+// Exit codes whose sentence needs the "End user experience" learn-more link
+// appended — currently the two Fleet-Desktop-required variants (missing app,
+// too-old version). Kept as a set so future exit codes can opt in explicitly.
+export const EXIT_CODES_NEEDING_EUE_LINK: ReadonlySet<number> = new Set([
+  100,
+  101,
+]);
+
+// The BE emits the pre-install query output with a notify-specific sentence
+// appended for the notify_before_patching variant. That substring is the
+// unambiguous signal we're looking at a notify skip vs a patch_when_closed
+// skip. Kept as a constant so the check doesn't drift silently.
+const NOTIFY_SKIP_MARKER = "Fleet notifies the end user";
+export const isNotifyBeforePatchingSkip = (
+  preInstallOutput?: string | null
+): boolean => !!preInstallOutput?.includes(NOTIFY_SKIP_MARKER);

--- a/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/helpers.tsx
+++ b/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/helpers.tsx
@@ -1,21 +1,25 @@
 import React from "react";
 
+import { INotifyActivityStatus } from "interfaces/activity";
 import { pluralize } from "utilities/strings/stringUtils";
 import { getDisplayedSoftwareName } from "pages/SoftwarePage/helpers";
 
-// TODO: swap in the "another notification displayed" exit code once published.
-// The no-script_execution_id branch already handles the dispatcher deferral.
-export const DEFERRED_EXIT_CODE_TBC = -1;
+export const isNotifyFailure = (
+  status: string | INotifyActivityStatus | undefined
+): boolean => status === "failed";
+
+// Provisional pending final BE confirmation.
+export const DEFERRED_EXIT_CODE = 50;
 
 export const FAILURE_COPY_BY_EXIT_CODE: Record<number, string> = {
   0: "If the host is offline when the patch is forced, Fleet skips the patch. When the host comes back online Fleet notifies the end user again and the patch is forced 1 hour later.",
   30: "The notification couldn't load. Fleet will try again on the next policy run.",
   31: "The notification couldn't load. Fleet will try again on the next policy run.",
   41: "The screen was locked so the end user couldn't see the notification. Fleet will try again on the next policy run.",
+  [DEFERRED_EXIT_CODE]:
+    "Another notification was displayed. Fleet will try again on the next policy run.",
   100: "The Fleet Desktop app is required to notify end users. Add the app from the Fleet-maintained catalog and deploy to all your hosts.",
   101: "The Fleet Desktop app v1.5.0 is required to notify end users. Add the app from the Fleet-maintained catalog and deploy to all your hosts.",
-  [DEFERRED_EXIT_CODE_TBC]:
-    "Another notification was displayed. Fleet will try again on the next policy run.",
 };
 
 export const DEFERRED_SENTENCE =
@@ -32,12 +36,16 @@ export const getCaveatSentence = (
   return FAILURE_COPY_BY_EXIT_CODE[exitCode] ?? null;
 };
 
+// One source of truth for the "1 hour" / "5 minutes" mapping.
+export const formatNotifyTimeLabel = (timeBefore?: number): string =>
+  timeBefore === 300 ? "5 minutes" : "1 hour";
+
 // Longer-form success caveat; intentionally different from
 // FAILURE_COPY_BY_EXIT_CODE[0].
-export const getAutomationNotifiedSentence = (timeBefore?: number): string => {
-  const label = timeBefore === 300 ? "5 minutes" : "1 hour";
-  return `End user was notified. Patch will be forced in ${label}. If the host is offline when a patch should be forced, Fleet notifies the end user again when it comes back online and patches it after 1 hour.`;
-};
+export const getAutomationNotifiedSentence = (timeBefore?: number): string =>
+  `End user was notified. Patch will be forced in ${formatNotifyTimeLabel(
+    timeBefore
+  )}. If the host is offline when a patch should be forced, Fleet notifies the end user again when it comes back online and patches it after 1 hour.`;
 
 export const SKIPPED_INSTALL_NOTIFY_EXPLANATION =
   "The app was open. The end user will be notified before the patch is forced.";
@@ -58,12 +66,15 @@ export const isNotifyBeforePatchingSkip = (
   preInstallOutput?: string | null
 ): boolean => !!preInstallOutput?.includes(NOTIFY_SKIP_MARKER);
 
-// Bold titles, Oxford comma, ", and N more app(s)" past three.
+// Bold titles, Oxford comma. Inline all when ≤4; past 4 truncate to 3 +
+// ", and N more apps". Returns null on empty input.
+// TODO(BE contract): software_titles is currently string[]; if BE emits
+// objects with display_name, swap this to render the display name.
 export const renderNotifyTitleList = (titles: string[]): React.ReactNode => {
+  if (titles.length === 0) return null;
   const bold = (name: string) => (
     <strong>{getDisplayedSoftwareName(name)}</strong>
   );
-  const overflow = titles.length - 3;
   if (titles.length === 1) return bold(titles[0]);
   if (titles.length === 2) {
     return (
@@ -72,20 +83,26 @@ export const renderNotifyTitleList = (titles: string[]): React.ReactNode => {
       </>
     );
   }
-  if (titles.length === 3) {
+  if (titles.length <= 4) {
+    const head = titles.slice(0, -1);
+    const tail = titles[titles.length - 1];
     return (
       <>
-        {bold(titles[0])}, {bold(titles[1])}, and {bold(titles[2])}
+        {head.map((t, i) => (
+          <React.Fragment key={t}>
+            {bold(t)}
+            {i < head.length - 1 ? ", " : ", and "}
+          </React.Fragment>
+        ))}
+        {bold(tail)}
       </>
     );
   }
-  if (titles.length > 3) {
-    return (
-      <>
-        {bold(titles[0])}, {bold(titles[1])}, {bold(titles[2])}, and {overflow}{" "}
-        more {pluralize(overflow, "app")}
-      </>
-    );
-  }
-  return null;
+  const overflow = titles.length - 3;
+  return (
+    <>
+      {bold(titles[0])}, {bold(titles[1])}, {bold(titles[2])}, and {overflow}{" "}
+      more {pluralize(overflow, "app")}
+    </>
+  );
 };

--- a/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/helpers.tsx
+++ b/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/helpers.tsx
@@ -52,8 +52,7 @@ export const EXIT_CODES_NEEDING_EUE_LINK: ReadonlySet<number> = new Set([
   101,
 ]);
 
-// Substring the BE appends only on notify_before_patching skips — named to
-// prevent silent drift.
+// Substring the BE appends only on notify_before_patching skips.
 const NOTIFY_SKIP_MARKER = "Fleet notifies the end user";
 export const isNotifyBeforePatchingSkip = (
   preInstallOutput?: string | null

--- a/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/helpers.tsx
+++ b/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/helpers.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 
-import { INotifyActivityStatus } from "interfaces/activity";
 import { getDisplayedSoftwareName } from "pages/SoftwarePage/helpers";
 
-export const isNotifyFailure = (
-  status: INotifyActivityStatus | undefined
-): boolean => status === "failed";
+// Loose input — details.status is typed as `string | undefined` on
+// IActivityDetails; the string comparison is safe for any input.
+export const isNotifyFailure = (status: string | undefined): boolean =>
+  status === "failed";
 
 export const DEFERRED_EXIT_CODE = 50;
 
@@ -13,21 +13,20 @@ export const DEFERRED_EXIT_CODE = 50;
 // "..., and N more apps" and move the full list to the Apps row.
 export const INLINE_APP_LIMIT = 4;
 
-// Keyed by script exit code. Index 0 is the offline caveat shown on success;
-// non-zero entries are failure reasons.
+export const DEFERRED_SENTENCE =
+  "Another notification was displayed. Fleet will try again on the next policy run.";
+
+// Keyed by script exit code. The 0 entry is the offline caveat shown on
+// success; non-zero entries are failure reasons.
 export const COPY_BY_EXIT_CODE: Record<number, string> = {
   0: "If the host is offline when the patch is forced, Fleet skips the patch. When the host comes back online Fleet notifies the end user again and the patch is forced 1 hour later.",
   30: "The notification couldn't load. Fleet will try again on the next policy run.",
   31: "The notification couldn't load. Fleet will try again on the next policy run.",
   41: "The screen was locked so the end user couldn't see the notification. Fleet will try again on the next policy run.",
-  [DEFERRED_EXIT_CODE]:
-    "Another notification was displayed. Fleet will try again on the next policy run.",
+  [DEFERRED_EXIT_CODE]: DEFERRED_SENTENCE,
   100: "The Fleet Desktop app is required to notify end users. Add the app from the Fleet-maintained catalog and deploy to all your hosts.",
   101: "The Fleet Desktop app v1.5.0 is required to notify end users. Add the app from the Fleet-maintained catalog and deploy to all your hosts.",
 };
-
-export const DEFERRED_SENTENCE =
-  "Another notification was displayed. Fleet will try again on the next policy run.";
 
 // Covers both success (exit 0 caveat) and failure sentences.
 export const getCaveatMessage = (

--- a/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/helpers.tsx
+++ b/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/helpers.tsx
@@ -28,7 +28,7 @@ export const DEFERRED_SENTENCE =
   "Another notification was displayed. Fleet will try again on the next policy run.";
 
 // Covers both success (exit 0 caveat) and failure sentences.
-export const getCaveatSentence = (
+export const getCaveatMessage = (
   failed: boolean,
   scriptExecutionId?: string,
   exitCode?: number | null
@@ -46,7 +46,7 @@ export const formatNotifyTimeLabel = (timeBefore?: number): string =>
   timeBefore === 300 ? "5 minutes" : "1 hour";
 
 // Longer-form success caveat; intentionally different from COPY_BY_EXIT_CODE[0].
-export const getAutomationNotifiedSentence = (timeBefore?: number): string =>
+export const getAutomationNotifiedMessage = (timeBefore?: number): string =>
   `End user was notified. Patch will be forced in ${formatNotifyTimeLabel(
     timeBefore
   )}. If the host is offline when a patch should be forced, Fleet notifies the end user again when it comes back online and patches it after 1 hour.`;

--- a/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/helpers.tsx
+++ b/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/helpers.tsx
@@ -5,13 +5,15 @@ import { pluralize } from "utilities/strings/stringUtils";
 import { getDisplayedSoftwareName } from "pages/SoftwarePage/helpers";
 
 export const isNotifyFailure = (
-  status: string | INotifyActivityStatus | undefined
+  status: INotifyActivityStatus | undefined
 ): boolean => status === "failed";
 
 // Provisional pending final BE confirmation.
 export const DEFERRED_EXIT_CODE = 50;
 
-export const FAILURE_COPY_BY_EXIT_CODE: Record<number, string> = {
+// Keyed by script exit code. Index 0 is the offline caveat shown on success;
+// non-zero entries are failure reasons.
+export const COPY_BY_EXIT_CODE: Record<number, string> = {
   0: "If the host is offline when the patch is forced, Fleet skips the patch. When the host comes back online Fleet notifies the end user again and the patch is forced 1 hour later.",
   30: "The notification couldn't load. Fleet will try again on the next policy run.",
   31: "The notification couldn't load. Fleet will try again on the next policy run.",
@@ -27,21 +29,23 @@ export const DEFERRED_SENTENCE =
 
 // Covers both success (exit 0 caveat) and failure sentences.
 export const getCaveatSentence = (
+  failed: boolean,
   scriptExecutionId?: string,
   exitCode?: number | null
 ): string | null => {
-  // Absence of script_execution_id signals a server-side deferral.
-  if (!scriptExecutionId) return DEFERRED_SENTENCE;
+  // Absence of script_execution_id signals a server-side deferral, which the
+  // BE only emits as a failure. Guard against showing a caveat next to a
+  // success icon if the invariant ever slips.
+  if (!scriptExecutionId) return failed ? DEFERRED_SENTENCE : null;
   if (exitCode === null || exitCode === undefined) return null;
-  return FAILURE_COPY_BY_EXIT_CODE[exitCode] ?? null;
+  return COPY_BY_EXIT_CODE[exitCode] ?? null;
 };
 
 // One source of truth for the "1 hour" / "5 minutes" mapping.
 export const formatNotifyTimeLabel = (timeBefore?: number): string =>
   timeBefore === 300 ? "5 minutes" : "1 hour";
 
-// Longer-form success caveat; intentionally different from
-// FAILURE_COPY_BY_EXIT_CODE[0].
+// Longer-form success caveat; intentionally different from COPY_BY_EXIT_CODE[0].
 export const getAutomationNotifiedSentence = (timeBefore?: number): string =>
   `End user was notified. Patch will be forced in ${formatNotifyTimeLabel(
     timeBefore

--- a/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/helpers.tsx
+++ b/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/helpers.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+import { INotifyActivityStatus } from "interfaces/activity";
 import { getDisplayedSoftwareName } from "pages/SoftwarePage/helpers";
 
 // Loose input — details.status is typed as `string | undefined` on
@@ -12,6 +13,7 @@ export const DEFERRED_EXIT_CODE = 50;
 // Titles inlined into the intro sentence; past this we truncate to
 // "..., and N more apps" and move the full list to the Apps row.
 export const INLINE_APP_LIMIT = 4;
+const TRUNCATED_INLINE_COUNT = 3;
 
 export const DEFERRED_SENTENCE =
   "Another notification was displayed. Fleet will try again on the next policy run.";
@@ -30,19 +32,26 @@ export const COPY_BY_EXIT_CODE: Record<number, string> = {
 
 // Covers both success (exit 0 caveat) and failure sentences.
 export const getCaveatMessage = (
-  failed: boolean,
+  status: INotifyActivityStatus,
   scriptExecutionId?: string,
   exitCode?: number | null
 ): string | null => {
+  const isFailure = status === "failed";
   // Absence of script_execution_id signals a server-side deferral, which the
   // BE only emits as a failure. Guard against showing a caveat next to a
   // success icon if the invariant ever slips.
-  if (!scriptExecutionId) return failed ? DEFERRED_SENTENCE : null;
+  if (!scriptExecutionId) return isFailure ? DEFERRED_SENTENCE : null;
   if (exitCode === null || exitCode === undefined) return null;
   // Mirror guard: exit 0 is the success caveat; don't show it next to a red icon.
-  if (failed && exitCode === 0) return null;
+  if (isFailure && exitCode === 0) return null;
   return COPY_BY_EXIT_CODE[exitCode] ?? null;
 };
+
+// Shared react-query retry: give up on 404, otherwise retry up to 3 times.
+export const retryUnless404 = (
+  failureCount: number,
+  err: { status?: number } | undefined
+): boolean => err?.status !== 404 && failureCount < 3;
 
 // One source of truth for the "1 hour" / "5 minutes" mapping.
 export const formatNotifyTimeLabel = (timeBefore?: number): string =>
@@ -105,12 +114,14 @@ export const renderNotifyTitleList = (titles: string[]): React.ReactNode => {
       </>
     );
   }
-  // overflow is always ≥ 2 past INLINE_APP_LIMIT, so no pluralize needed.
-  const overflow = titles.length - 3;
+  // When truncating past INLINE_APP_LIMIT, always name the first N inline;
+  // overflow is always ≥ 2, so no pluralize needed.
+  const shown = titles.slice(0, TRUNCATED_INLINE_COUNT);
+  const overflow = titles.length - TRUNCATED_INLINE_COUNT;
   return (
     <>
-      {bold(titles[0])}, {bold(titles[1])}, {bold(titles[2])}, and {overflow}{" "}
-      more apps
+      {bold(shown[0])}, {bold(shown[1])}, {bold(shown[2])}, and {overflow} more
+      apps
     </>
   );
 };

--- a/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/helpers.tsx
+++ b/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/helpers.tsx
@@ -1,3 +1,8 @@
+import React from "react";
+
+import { pluralize } from "utilities/strings/stringUtils";
+import { getDisplayedSoftwareName } from "pages/SoftwarePage/helpers";
+
 // TODO: swap in the "another notification displayed" exit code once published.
 // The no-script_execution_id branch already handles the dispatcher deferral.
 export const DEFERRED_EXIT_CODE_TBC = -1;
@@ -53,3 +58,35 @@ const NOTIFY_SKIP_MARKER = "Fleet notifies the end user";
 export const isNotifyBeforePatchingSkip = (
   preInstallOutput?: string | null
 ): boolean => !!preInstallOutput?.includes(NOTIFY_SKIP_MARKER);
+
+// Bold titles, Oxford comma, ", and N more app(s)" past three.
+export const renderNotifyTitleList = (titles: string[]): React.ReactNode => {
+  const bold = (name: string) => (
+    <strong>{getDisplayedSoftwareName(name)}</strong>
+  );
+  const overflow = titles.length - 3;
+  if (titles.length === 1) return bold(titles[0]);
+  if (titles.length === 2) {
+    return (
+      <>
+        {bold(titles[0])} and {bold(titles[1])}
+      </>
+    );
+  }
+  if (titles.length === 3) {
+    return (
+      <>
+        {bold(titles[0])}, {bold(titles[1])}, and {bold(titles[2])}
+      </>
+    );
+  }
+  if (titles.length > 3) {
+    return (
+      <>
+        {bold(titles[0])}, {bold(titles[1])}, {bold(titles[2])}, and {overflow}{" "}
+        more {pluralize(overflow, "app")}
+      </>
+    );
+  }
+  return null;
+};

--- a/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/helpers.tsx
+++ b/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/helpers.tsx
@@ -1,15 +1,17 @@
 import React from "react";
 
 import { INotifyActivityStatus } from "interfaces/activity";
-import { pluralize } from "utilities/strings/stringUtils";
 import { getDisplayedSoftwareName } from "pages/SoftwarePage/helpers";
 
 export const isNotifyFailure = (
   status: INotifyActivityStatus | undefined
 ): boolean => status === "failed";
 
-// Provisional pending final BE confirmation.
 export const DEFERRED_EXIT_CODE = 50;
+
+// Titles inlined into the intro sentence; past this we truncate to
+// "..., and N more apps" and move the full list to the Apps row.
+export const INLINE_APP_LIMIT = 4;
 
 // Keyed by script exit code. Index 0 is the offline caveat shown on success;
 // non-zero entries are failure reasons.
@@ -38,6 +40,8 @@ export const getCaveatMessage = (
   // success icon if the invariant ever slips.
   if (!scriptExecutionId) return failed ? DEFERRED_SENTENCE : null;
   if (exitCode === null || exitCode === undefined) return null;
+  // Mirror guard: exit 0 is the success caveat; don't show it next to a red icon.
+  if (failed && exitCode === 0) return null;
   return COPY_BY_EXIT_CODE[exitCode] ?? null;
 };
 
@@ -70,8 +74,8 @@ export const isNotifyBeforePatchingSkip = (
   preInstallOutput?: string | null
 ): boolean => !!preInstallOutput?.includes(NOTIFY_SKIP_MARKER);
 
-// Bold titles, Oxford comma. Inline all when ≤4; past 4 truncate to 3 +
-// ", and N more apps". Returns null on empty input.
+// Bold titles, Oxford comma. Inline all when ≤ INLINE_APP_LIMIT; past that
+// truncate to 3 + ", and N more apps". Returns null on empty input.
 // TODO(BE contract): software_titles is currently string[]; if BE emits
 // objects with display_name, swap this to render the display name.
 export const renderNotifyTitleList = (titles: string[]): React.ReactNode => {
@@ -87,7 +91,7 @@ export const renderNotifyTitleList = (titles: string[]): React.ReactNode => {
       </>
     );
   }
-  if (titles.length <= 4) {
+  if (titles.length <= INLINE_APP_LIMIT) {
     const head = titles.slice(0, -1);
     const tail = titles[titles.length - 1];
     return (
@@ -102,11 +106,12 @@ export const renderNotifyTitleList = (titles: string[]): React.ReactNode => {
       </>
     );
   }
+  // overflow is always ≥ 2 past INLINE_APP_LIMIT, so no pluralize needed.
   const overflow = titles.length - 3;
   return (
     <>
       {bold(titles[0])}, {bold(titles[1])}, {bold(titles[2])}, and {overflow}{" "}
-      more {pluralize(overflow, "app")}
+      more apps
     </>
   );
 };

--- a/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/index.ts
+++ b/frontend/components/ActivityDetails/NotifyBeforePatchingDetailsModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./NotifyBeforePatchingDetailsModal";

--- a/frontend/interfaces/activity.ts
+++ b/frontend/interfaces/activity.ts
@@ -314,9 +314,7 @@ export interface IActivityDetails {
   host_platform?: string;
   host_serial?: string;
   install_at?: string;
-  /** True on an `installed_software` activity whose install was skipped
-   * because the app was open. Distinct from `skipped_install`, which is
-   * the frontend display status derived from this + policy flags. */
+  /** True on an app-open skip. Wire field; `skipped_install` is the derived display status. */
   install_skipped_when_app_open?: boolean;
   install_uuid?: string;
   installed_from_dep?: boolean;
@@ -329,17 +327,13 @@ export interface IActivityDetails {
   name?: string;
   pack_id?: number;
   pack_name?: string;
-  /** Uuid of the notify-before-patching notification an activity belongs
-   * to. One notification may cover several patch policies and appear in
-   * each of their automation-runs tables. */
+  /** One notification may cover several patch policies and appear in each of their runs tables. */
   patch_notification_uuid?: string;
   platform?: Platform; // OS platform
   policy_id?: number;
   policy_ids?: number[];
   policy_name?: string;
-  /** Output text from the app-open pre-install query on a skipped install.
-   * Distinguishes a `patch_when_closed` skip from a `notify_before_patching`
-   * skip — the two carry different text per the payload contract. */
+  /** BE-supplied; text differs between patch_when_closed and notify_before_patching skips. */
   pre_install_query_output?: string;
   profile_identifier?: string;
   profile_name?: string;
@@ -362,7 +356,7 @@ export interface IActivityDetails {
   software_package?: string;
   software_title_id?: number;
   software_title?: string;
-  /** Software titles covered by a single notify-before-patching notification. */
+  /** Titles covered by a single notify-before-patching notification. */
   software_titles?: string[];
   software_titles_count?: number;
   /** Custom name set per team by admin */
@@ -375,8 +369,7 @@ export interface IActivityDetails {
   team_id?: number | null;
   team_name?: string | null;
   teams?: ITeamSummary[];
-  /** Seconds before the patch install that the end user was notified.
-   * Drives the "1 hour" vs "5 minutes" copy in the notify activity. */
+  /** Seconds before the patch install (drives "1 hour" vs "5 minutes" copy). */
   time_before?: number;
   triggered_by?: string;
   from_setup_experience?: boolean;

--- a/frontend/interfaces/activity.ts
+++ b/frontend/interfaces/activity.ts
@@ -207,6 +207,7 @@ export enum ActivityType {
   EditedCustomHostVital = "edited_custom_host_vital",
   DeletedCustomHostVital = "deleted_custom_host_vital",
   ReleasedDeviceFromAB = "released_from_ab",
+  NotifiedEndUserBeforePatching = "notified_end_user_before_patching",
 }
 
 /** This is a subset of ActivityType that are shown only for the host past activities */
@@ -250,6 +251,7 @@ export type IHostPastActivityType =
   | ActivityType.FailedAutomationTicket
   | ActivityType.FailedAutomationCalendarEvent
   | ActivityType.FailedAutomationConditionalAccess
+  | ActivityType.NotifiedEndUserBeforePatching
   | ActivityType.ReleasedDeviceFromAB;
 
 /** This is a subset of ActivityType that are shown only for the host upcoming activities */
@@ -311,6 +313,11 @@ export interface IActivityDetails {
   canceled_count?: number;
   host_platform?: string;
   host_serial?: string;
+  install_at?: string;
+  /** True on an `installed_software` activity whose install was skipped
+   * because the app was open. Distinct from `skipped_install`, which is
+   * the frontend display status derived from this + policy flags. */
+  install_skipped_when_app_open?: boolean;
   install_uuid?: string;
   installed_from_dep?: boolean;
   labels_exclude_any?: ILabelSoftwareTitle[];
@@ -322,9 +329,18 @@ export interface IActivityDetails {
   name?: string;
   pack_id?: number;
   pack_name?: string;
+  /** Uuid of the notify-before-patching notification an activity belongs
+   * to. One notification may cover several patch policies and appear in
+   * each of their automation-runs tables. */
+  patch_notification_uuid?: string;
   platform?: Platform; // OS platform
   policy_id?: number;
+  policy_ids?: number[];
   policy_name?: string;
+  /** Output text from the app-open pre-install query on a skipped install.
+   * Distinguishes a `patch_when_closed` skip from a `notify_before_patching`
+   * skip — the two carry different text per the payload contract. */
+  pre_install_query_output?: string;
   profile_identifier?: string;
   profile_name?: string;
   profile_uuid?: string;
@@ -346,6 +362,8 @@ export interface IActivityDetails {
   software_package?: string;
   software_title_id?: number;
   software_title?: string;
+  /** Software titles covered by a single notify-before-patching notification. */
+  software_titles?: string[];
   software_titles_count?: number;
   /** Custom name set per team by admin */
   software_display_name?: string;
@@ -357,6 +375,9 @@ export interface IActivityDetails {
   team_id?: number | null;
   team_name?: string | null;
   teams?: ITeamSummary[];
+  /** Seconds before the patch install that the end user was notified.
+   * Drives the "1 hour" vs "5 minutes" copy in the notify activity. */
+  time_before?: number;
   triggered_by?: string;
   from_setup_experience?: boolean;
   from_auto_update?: boolean;
@@ -635,4 +656,6 @@ export const ACTIVITY_TYPE_TO_FILTER_LABEL: Record<ActivityType, string> = {
   [ActivityType.EditedCustomHostVital]: "Edited custom host vital",
   [ActivityType.DeletedCustomHostVital]: "Deleted custom host vital",
   [ActivityType.ReleasedDeviceFromAB]: "Released host from Apple Business",
+  [ActivityType.NotifiedEndUserBeforePatching]:
+    "Notified end user before patching",
 };

--- a/frontend/interfaces/activity.ts
+++ b/frontend/interfaces/activity.ts
@@ -290,10 +290,6 @@ export type IHostUpcomingActivity = Omit<
   details: IActivityDetails;
 };
 
-/** `details.status` values on a `notified_end_user_before_patching` activity.
- * Distinct from the automation-runs wrapper's `"error" | "success"` union. */
-export type INotifyActivityStatus = "success" | "failed";
-
 export interface IActivityDetails {
   /** Useful for passing this data into an activity details modal */
   created_at?: string;
@@ -318,8 +314,6 @@ export interface IActivityDetails {
   host_platform?: string;
   host_serial?: string;
   install_at?: string;
-  /** True on an app-open skip. Wire field; `skipped_install` is the derived display status. */
-  install_skipped_when_app_open?: boolean;
   install_uuid?: string;
   installed_from_dep?: boolean;
   labels_exclude_any?: ILabelSoftwareTitle[];

--- a/frontend/interfaces/activity.ts
+++ b/frontend/interfaces/activity.ts
@@ -333,7 +333,6 @@ export interface IActivityDetails {
   policy_id?: number;
   policy_ids?: number[];
   policy_name?: string;
-  /** BE-supplied; text differs between patch_when_closed and notify_before_patching skips. */
   pre_install_query_output?: string;
   profile_identifier?: string;
   profile_name?: string;

--- a/frontend/interfaces/activity.ts
+++ b/frontend/interfaces/activity.ts
@@ -290,6 +290,10 @@ export type IHostUpcomingActivity = Omit<
   details: IActivityDetails;
 };
 
+/** `details.status` values on a `notified_end_user_before_patching` activity.
+ * Distinct from the automation-runs wrapper's `"error" | "success"` union. */
+export type INotifyActivityStatus = "success" | "failed";
+
 export interface IActivityDetails {
   /** Useful for passing this data into an activity details modal */
   created_at?: string;

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityFeed.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/ActivityFeed.tsx
@@ -36,6 +36,7 @@ import EmptyState from "components/EmptyState";
 
 import VppInstallDetailsModal from "components/ActivityDetails/InstallDetails/VppInstallDetailsModal";
 import { SoftwareInstallDetailsModal } from "components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal";
+import NotifyBeforePatchingDetailsModal from "components/ActivityDetails/NotifyBeforePatchingDetailsModal";
 import SoftwareScriptDetailsModal from "components/ActivityDetails/InstallDetails/SoftwareScriptDetailsModal/SoftwareScriptDetailsModal";
 import SoftwareIpaInstallDetailsModal from "components/ActivityDetails/InstallDetails/SoftwareIpaInstallDetailsModal";
 import SoftwareUninstallDetailsModal, {
@@ -163,6 +164,10 @@ const ActivityFeed = ({
     host_display_name?: string;
     request_type?: string;
   } | null>(null);
+  const [
+    notifyBeforePatchingDetails,
+    setNotifyBeforePatchingDetails,
+  ] = useState<IActivityDetails | null>(null);
 
   const [searchQuery, setSearchQuery] = useState("");
   const [createdAtDirection, setCreatedAtDirection] = useState("desc");
@@ -331,6 +336,9 @@ const ActivityFeed = ({
           },
         });
         break;
+      case ActivityType.NotifiedEndUserBeforePatching:
+        setNotifyBeforePatchingDetails({ ...details });
+        break;
       case ActivityType.RanCustomMdmCommand: {
         if (!details?.command_uuid) {
           break;
@@ -435,6 +443,12 @@ const ActivityFeed = ({
         <SoftwareInstallDetailsModal
           details={packageInstallDetails}
           onCancel={() => setPackageInstallDetails(null)}
+        />
+      )}
+      {notifyBeforePatchingDetails && (
+        <NotifyBeforePatchingDetailsModal
+          details={notifyBeforePatchingDetails}
+          onCancel={() => setNotifyBeforePatchingDetails(null)}
         />
       )}
       {scriptPackageDetails && (

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tests.tsx
@@ -2571,4 +2571,139 @@ describe("Activity Feed", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("Asset tag")).toBeInTheDocument();
   });
+
+  describe("notified_end_user_before_patching activity", () => {
+    it("renders a single-app success sentence with 1 hour and a bold host + title", () => {
+      const activity = createMockActivity({
+        type: ActivityType.NotifiedEndUserBeforePatching,
+        fleet_initiated: true,
+        details: {
+          host_display_name: "John's MacBook Pro",
+          software_titles: ["1Password"],
+          status: "success",
+          time_before: 3600,
+        },
+      });
+      const { container } = render(
+        <GlobalActivityItem activity={activity} isPremiumTier />
+      );
+
+      expect(container.textContent).toContain(
+        "notified end user 1 hour before patching 1Password on John's MacBook Pro."
+      );
+      // Bold: software title + host name.
+      const bolds = Array.from(container.querySelectorAll("b")).map(
+        (el) => el.textContent
+      );
+      expect(bolds).toEqual(
+        expect.arrayContaining(["1Password", "John's MacBook Pro"])
+      );
+    });
+
+    it("renders three apps with Oxford comma", () => {
+      const activity = createMockActivity({
+        type: ActivityType.NotifiedEndUserBeforePatching,
+        fleet_initiated: true,
+        details: {
+          host_display_name: "John's MacBook Pro",
+          software_titles: ["1Password", "Slack", "Docker Desktop"],
+          status: "success",
+          time_before: 3600,
+        },
+      });
+      const { container } = render(
+        <GlobalActivityItem activity={activity} isPremiumTier />
+      );
+
+      expect(container.textContent).toContain(
+        "1Password, Slack, and Docker Desktop on John's MacBook Pro."
+      );
+    });
+
+    it("truncates past three apps with ', and N more apps'", () => {
+      const activity = createMockActivity({
+        type: ActivityType.NotifiedEndUserBeforePatching,
+        fleet_initiated: true,
+        details: {
+          host_display_name: "John's MacBook Pro",
+          software_titles: [
+            "1Password",
+            "Slack",
+            "Docker Desktop",
+            "Zoom",
+            "Chrome",
+          ],
+          status: "success",
+          time_before: 3600,
+        },
+      });
+      const { container } = render(
+        <GlobalActivityItem activity={activity} isPremiumTier />
+      );
+
+      expect(container.textContent).toContain(
+        "1Password, Slack, Docker Desktop, and 2 more apps"
+      );
+    });
+
+    it("uses singular 'app' when exactly one title overflows", () => {
+      const activity = createMockActivity({
+        type: ActivityType.NotifiedEndUserBeforePatching,
+        fleet_initiated: true,
+        details: {
+          host_display_name: "John's MacBook Pro",
+          software_titles: ["1Password", "Slack", "Docker Desktop", "Zoom"],
+          status: "success",
+          time_before: 3600,
+        },
+      });
+      const { container } = render(
+        <GlobalActivityItem activity={activity} isPremiumTier />
+      );
+
+      expect(container.textContent).toContain(
+        "1Password, Slack, Docker Desktop, and 1 more app "
+      );
+    });
+
+    it("renders 5 minutes for the reminder (time_before: 300)", () => {
+      const activity = createMockActivity({
+        type: ActivityType.NotifiedEndUserBeforePatching,
+        fleet_initiated: true,
+        details: {
+          host_display_name: "John's MacBook Pro",
+          software_titles: ["1Password"],
+          status: "success",
+          time_before: 300,
+        },
+      });
+      const { container } = render(
+        <GlobalActivityItem activity={activity} isPremiumTier />
+      );
+
+      expect(container.textContent).toContain(
+        "notified end user 5 minutes before patching"
+      );
+    });
+
+    it("renders the failed-to-notify sentence when status is failed", () => {
+      const activity = createMockActivity({
+        type: ActivityType.NotifiedEndUserBeforePatching,
+        fleet_initiated: true,
+        details: {
+          host_display_name: "Josh's MacBook Pro",
+          software_titles: ["1Password"],
+          status: "failed",
+          time_before: 3600,
+        },
+      });
+      const { container } = render(
+        <GlobalActivityItem activity={activity} isPremiumTier />
+      );
+
+      expect(container.textContent).toContain(
+        "failed to notify end user 1 hour before patching 1Password on Josh's MacBook Pro."
+      );
+    });
+  });
 });

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tests.tsx
@@ -2620,7 +2620,7 @@ describe("Activity Feed", () => {
       );
     });
 
-    it("truncates past three apps with ', and N more apps'", () => {
+    it("truncates past four apps with ', and N more apps'", () => {
       const activity = createMockActivity({
         type: ActivityType.NotifiedEndUserBeforePatching,
         fleet_initiated: true,
@@ -2646,7 +2646,7 @@ describe("Activity Feed", () => {
       );
     });
 
-    it("uses singular 'app' when exactly one title overflows", () => {
+    it("lists the fourth app inline instead of using '1 more app'", () => {
       const activity = createMockActivity({
         type: ActivityType.NotifiedEndUserBeforePatching,
         fleet_initiated: true,
@@ -2662,8 +2662,9 @@ describe("Activity Feed", () => {
       );
 
       expect(container.textContent).toContain(
-        "1Password, Slack, Docker Desktop, and 1 more app "
+        "1Password, Slack, Docker Desktop, and Zoom"
       );
+      expect(container.textContent).not.toMatch(/more app/);
     });
 
     it("renders 5 minutes for the reminder (time_before: 300)", () => {

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tests.tsx
@@ -2592,7 +2592,7 @@ describe("Activity Feed", () => {
         "notified end user 1 hour before patching 1Password on John's MacBook Pro."
       );
       // Bold: software title + host name.
-      const bolds = Array.from(container.querySelectorAll("b")).map(
+      const bolds = Array.from(container.querySelectorAll("strong")).map(
         (el) => el.textContent
       );
       expect(bolds).toEqual(

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
@@ -2327,8 +2327,7 @@ const TAGGED_TEMPLATES = {
     const failed = status === "failed";
     const verb = failed ? "failed to notify" : "notified";
 
-    // Bolds each title, uses an Oxford comma, and truncates past three
-    // titles with a ", and N more app(s)" suffix (Figma dev note 5546:46306).
+    // Bold titles, Oxford comma, ", and N more app(s)" past three.
     const bold = (name: string) => <b>{getDisplayedSoftwareName(name)}</b>;
     const overflow = titles.length - 3;
     let titleList: React.ReactNode = null;

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
@@ -2335,8 +2335,9 @@ const TAGGED_TEMPLATES = {
     return (
       <>
         {" "}
-        {verb} end user {timeLabel} before patching {titleList} on{" "}
-        <strong>{hostName}</strong>.
+        {verb} end user {timeLabel} before patching
+        {titleList && <> {titleList}</>} on{" "}
+        <strong>{hostName || "the host"}</strong>.
       </>
     );
   },

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
@@ -1,7 +1,11 @@
 import { capitalize, find, lowerCase, noop, trimEnd } from "lodash";
 import React from "react";
 
-import { ActivityType, IActivity } from "interfaces/activity";
+import {
+  ActivityType,
+  IActivity,
+  INotifyActivityStatus,
+} from "interfaces/activity";
 import {
   DATASET_LABEL,
   HISTORICAL_DATA_CONFIG_KEYS,
@@ -19,8 +23,6 @@ import {
   SCRIPT_PACKAGE_SOURCES,
 } from "interfaces/software";
 import { formatMdmCommandNameForActivityItem } from "utilities/activityHelpers";
-import { pluralize } from "utilities/strings/stringUtils";
-import { getDisplayedSoftwareName } from "pages/SoftwarePage/helpers";
 import {
   renderNotifyTitleList,
   formatNotifyTimeLabel,
@@ -2329,7 +2331,7 @@ const TAGGED_TEMPLATES = {
       time_before: timeBefore,
     } = details;
     const timeLabel = formatNotifyTimeLabel(timeBefore);
-    const failed = isNotifyFailure(status);
+    const failed = isNotifyFailure(status as INotifyActivityStatus | undefined);
     const verb = failed ? "failed to notify" : "notified";
 
     const titleList = renderNotifyTitleList(titles);

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
@@ -21,7 +21,11 @@ import {
 import { formatMdmCommandNameForActivityItem } from "utilities/activityHelpers";
 import { pluralize } from "utilities/strings/stringUtils";
 import { getDisplayedSoftwareName } from "pages/SoftwarePage/helpers";
-import { renderNotifyTitleList } from "components/ActivityDetails/NotifyBeforePatchingDetailsModal/helpers";
+import {
+  renderNotifyTitleList,
+  formatNotifyTimeLabel,
+  isNotifyFailure,
+} from "components/ActivityDetails/NotifyBeforePatchingDetailsModal/helpers";
 import {
   formatScriptNameForActivityItem,
   getPerformanceImpactDescription,
@@ -2324,8 +2328,8 @@ const TAGGED_TEMPLATES = {
       status,
       time_before: timeBefore,
     } = details;
-    const timeLabel = timeBefore === 300 ? "5 minutes" : "1 hour";
-    const failed = status === "failed";
+    const timeLabel = formatNotifyTimeLabel(timeBefore);
+    const failed = isNotifyFailure(status);
     const verb = failed ? "failed to notify" : "notified";
 
     const titleList = renderNotifyTitleList(titles);

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
@@ -19,6 +19,8 @@ import {
   SCRIPT_PACKAGE_SOURCES,
 } from "interfaces/software";
 import { formatMdmCommandNameForActivityItem } from "utilities/activityHelpers";
+import { pluralize } from "utilities/strings/stringUtils";
+import { getDisplayedSoftwareName } from "pages/SoftwarePage/helpers";
 import {
   formatScriptNameForActivityItem,
   getPerformanceImpactDescription,
@@ -2309,6 +2311,57 @@ const TAGGED_TEMPLATES = {
       </>
     );
   },
+  notifiedEndUserBeforePatching: (activity: IActivity) => {
+    const { details } = activity;
+    if (!details) {
+      return TAGGED_TEMPLATES.defaultActivityTemplate(activity);
+    }
+    const {
+      host_display_name: hostName,
+      software_titles: titles = [],
+      status,
+      time_before: timeBefore,
+    } = details;
+    const timeLabel = timeBefore === 300 ? "5 minutes" : "1 hour";
+    const failed = status === "failed";
+    const verb = failed ? "failed to notify" : "notified";
+
+    // Bolds each title, uses an Oxford comma, and truncates past three
+    // titles with a ", and N more app(s)" suffix (Figma dev note 5546:46306).
+    const bold = (name: string) => <b>{getDisplayedSoftwareName(name)}</b>;
+    const overflow = titles.length - 3;
+    let titleList: React.ReactNode = null;
+    if (titles.length === 1) {
+      titleList = bold(titles[0]);
+    } else if (titles.length === 2) {
+      titleList = (
+        <>
+          {bold(titles[0])} and {bold(titles[1])}
+        </>
+      );
+    } else if (titles.length === 3) {
+      titleList = (
+        <>
+          {bold(titles[0])}, {bold(titles[1])}, and {bold(titles[2])}
+        </>
+      );
+    } else if (titles.length > 3) {
+      titleList = (
+        <>
+          {bold(titles[0])}, {bold(titles[1])}, {bold(titles[2])}, and{" "}
+          {overflow} more {pluralize(overflow, "app")}
+        </>
+      );
+    }
+
+    return (
+      <>
+        {" "}
+        {verb} end user {timeLabel} before patching {titleList} on{" "}
+        <b>{hostName}</b>.
+      </>
+    );
+  },
 };
 
 const getDetail = (activity: IActivity, isPremiumTier: boolean) => {
@@ -2822,6 +2875,9 @@ const getDetail = (activity: IActivity, isPremiumTier: boolean) => {
     }
     case ActivityType.ReleasedDeviceFromAB: {
       return TAGGED_TEMPLATES.releasedDeviceFromAB(activity);
+    }
+    case ActivityType.NotifiedEndUserBeforePatching: {
+      return TAGGED_TEMPLATES.notifiedEndUserBeforePatching(activity);
     }
     default: {
       return TAGGED_TEMPLATES.defaultActivityTemplate(activity);

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
@@ -21,6 +21,7 @@ import {
 import { formatMdmCommandNameForActivityItem } from "utilities/activityHelpers";
 import { pluralize } from "utilities/strings/stringUtils";
 import { getDisplayedSoftwareName } from "pages/SoftwarePage/helpers";
+import { renderNotifyTitleList } from "components/ActivityDetails/NotifyBeforePatchingDetailsModal/helpers";
 import {
   formatScriptNameForActivityItem,
   getPerformanceImpactDescription,
@@ -2327,38 +2328,13 @@ const TAGGED_TEMPLATES = {
     const failed = status === "failed";
     const verb = failed ? "failed to notify" : "notified";
 
-    // Bold titles, Oxford comma, ", and N more app(s)" past three.
-    const bold = (name: string) => <b>{getDisplayedSoftwareName(name)}</b>;
-    const overflow = titles.length - 3;
-    let titleList: React.ReactNode = null;
-    if (titles.length === 1) {
-      titleList = bold(titles[0]);
-    } else if (titles.length === 2) {
-      titleList = (
-        <>
-          {bold(titles[0])} and {bold(titles[1])}
-        </>
-      );
-    } else if (titles.length === 3) {
-      titleList = (
-        <>
-          {bold(titles[0])}, {bold(titles[1])}, and {bold(titles[2])}
-        </>
-      );
-    } else if (titles.length > 3) {
-      titleList = (
-        <>
-          {bold(titles[0])}, {bold(titles[1])}, {bold(titles[2])}, and{" "}
-          {overflow} more {pluralize(overflow, "app")}
-        </>
-      );
-    }
+    const titleList = renderNotifyTitleList(titles);
 
     return (
       <>
         {" "}
         {verb} end user {timeLabel} before patching {titleList} on{" "}
-        <b>{hostName}</b>.
+        <strong>{hostName}</strong>.
       </>
     );
   },

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
@@ -1,11 +1,7 @@
 import { capitalize, find, lowerCase, noop, trimEnd } from "lodash";
 import React from "react";
 
-import {
-  ActivityType,
-  IActivity,
-  INotifyActivityStatus,
-} from "interfaces/activity";
+import { ActivityType, IActivity } from "interfaces/activity";
 import {
   DATASET_LABEL,
   HISTORICAL_DATA_CONFIG_KEYS,
@@ -2331,7 +2327,7 @@ const TAGGED_TEMPLATES = {
       time_before: timeBefore,
     } = details;
     const timeLabel = formatNotifyTimeLabel(timeBefore);
-    const failed = isNotifyFailure(status as INotifyActivityStatus | undefined);
+    const failed = isNotifyFailure(status);
     const verb = failed ? "failed to notify" : "notified";
 
     const titleList = renderNotifyTitleList(titles);

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
@@ -51,6 +51,7 @@ const ACTIVITIES_WITH_DETAILS = new Set([
   ActivityType.RanScriptBatch,
   ActivityType.CanceledScriptBatch,
   ActivityType.FailedEnrollmentProfileRenewal,
+  ActivityType.NotifiedEndUserBeforePatching,
 ]);
 
 const getProfilesPlatformDisplayName = (

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -33,7 +33,11 @@ import {
   SoftwareInstallUninstallStatus,
 } from "interfaces/software";
 import { ITeam } from "interfaces/team";
-import { ActivityType, IHostUpcomingActivity } from "interfaces/activity";
+import {
+  ActivityType,
+  IActivityDetails,
+  IHostUpcomingActivity,
+} from "interfaces/activity";
 import {
   IHostCertificate,
   CERTIFICATES_DEFAULT_SORT,
@@ -88,6 +92,7 @@ import {
   SoftwareIpaInstallDetailsModal,
   ISoftwareIpaInstallDetails,
 } from "components/ActivityDetails/InstallDetails/SoftwareIpaInstallDetailsModal/SoftwareIpaInstallDetailsModal";
+import NotifyBeforePatchingDetailsModal from "components/ActivityDetails/NotifyBeforePatchingDetailsModal";
 import SoftwareUninstallDetailsModal, {
   ISWUninstallDetailsParentState,
 } from "components/ActivityDetails/InstallDetails/SoftwareUninstallDetailsModal/SoftwareUninstallDetailsModal";
@@ -312,6 +317,10 @@ const HostDetailsPage = ({
     enrollmentProfileFailedDetails,
     setEnrollmentProfileFailedDetails,
   ] = useState<Omit<IFailedEnrollmentProfileModalProps, "onDone"> | null>(null);
+  const [
+    notifyBeforePatchingDetails,
+    setNotifyBeforePatchingDetails,
+  ] = useState<IActivityDetails | null>(null);
 
   const [refetchStartTime, setRefetchStartTime] = useState<number | null>(null);
   const [showRefetchSpinner, setShowRefetchSpinner] = useState(false);
@@ -922,6 +931,12 @@ const HostDetailsPage = ({
           });
           break;
         }
+        case ActivityType.NotifiedEndUserBeforePatching:
+          setNotifyBeforePatchingDetails({
+            ...details,
+            host_display_name: host?.display_name || details?.host_display_name,
+          });
+          break;
         default: // do nothing
       }
     },
@@ -1887,6 +1902,12 @@ const HostDetailsPage = ({
             <SoftwareInstallDetailsModal
               details={packageInstallDetails}
               onCancel={onCancelSoftwareInstallDetailsModal}
+            />
+          )}
+          {notifyBeforePatchingDetails && (
+            <NotifyBeforePatchingDetailsModal
+              details={notifyBeforePatchingDetails}
+              onCancel={() => setNotifyBeforePatchingDetails(null)}
             />
           )}
           {scriptPackageDetails && (

--- a/frontend/pages/hosts/details/cards/Activity/ActivityConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityConfig.tsx
@@ -40,6 +40,7 @@ import RanCustomMdmCommandActivityItem from "./ActivityItems/RanCustomMdmCommand
 import EditedCustomHostVitalValueActivityItem from "./ActivityItems/EditedCustomHostVitalValueActivityItem";
 import PolicyAutomationActivityItem from "./ActivityItems/PolicyAutomationActivityItem";
 import ReleasedFromABActivityItem from "./ActivityItems/ReleasedFromABActivityItem";
+import NotifiedEndUserBeforePatchingActivityItem from "./ActivityItems/NotifiedEndUserBeforePatchingActivityItem";
 
 /** The component props that all host activity items must adhere to */
 export interface IHostActivityItemComponentProps {
@@ -107,6 +108,7 @@ export const pastActivityComponentMap: Record<
   [ActivityType.FailedAutomationCalendarEvent]: PolicyAutomationActivityItem,
   [ActivityType.FailedAutomationConditionalAccess]: PolicyAutomationActivityItem,
   [ActivityType.ReleasedDeviceFromAB]: ReleasedFromABActivityItem,
+  [ActivityType.NotifiedEndUserBeforePatching]: NotifiedEndUserBeforePatchingActivityItem,
 };
 
 export const upcomingActivityComponentMap: Record<

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/NotifiedEndUserBeforePatchingActivityItem/NotifiedEndUserBeforePatchingActivityItem.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/NotifiedEndUserBeforePatchingActivityItem/NotifiedEndUserBeforePatchingActivityItem.tests.tsx
@@ -1,0 +1,110 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { noop } from "lodash";
+
+import { createMockHostPastActivity } from "__mocks__/activityMock";
+import { ActivityType } from "interfaces/activity";
+
+import NotifiedEndUserBeforePatchingActivityItem from "./NotifiedEndUserBeforePatchingActivityItem";
+
+const createNotifyActivity = (
+  overrides: Partial<
+    ReturnType<typeof createMockHostPastActivity>["details"]
+  > = {}
+) =>
+  createMockHostPastActivity({
+    type: ActivityType.NotifiedEndUserBeforePatching,
+    actor_full_name: "Fleet",
+    fleet_initiated: true,
+    details: {
+      host_display_name: "John's MacBook Pro",
+      software_titles: ["1Password"],
+      status: "success",
+      time_before: 3600,
+      ...overrides,
+    },
+  });
+
+describe("NotifiedEndUserBeforePatchingActivityItem", () => {
+  it("renders the single-app success sentence ending 'on this host.' with no host name", () => {
+    const { container } = render(
+      <NotifiedEndUserBeforePatchingActivityItem
+        activity={createNotifyActivity()}
+        tab="past"
+        onShowDetails={noop}
+      />
+    );
+
+    expect(container.textContent).toContain(
+      "Fleet notified end user 1 hour before patching 1Password on this host."
+    );
+    // Host name from details is intentionally dropped on the host feed.
+    expect(container.textContent).not.toContain("John's MacBook Pro");
+  });
+
+  it("renders three apps with Oxford comma", () => {
+    const { container } = render(
+      <NotifiedEndUserBeforePatchingActivityItem
+        activity={createNotifyActivity({
+          software_titles: ["1Password", "Slack", "Docker Desktop"],
+        })}
+        tab="past"
+        onShowDetails={noop}
+      />
+    );
+
+    expect(container.textContent).toContain(
+      "1Password, Slack, and Docker Desktop on this host."
+    );
+  });
+
+  it("truncates past three apps with pluralized 'more apps'", () => {
+    const { container } = render(
+      <NotifiedEndUserBeforePatchingActivityItem
+        activity={createNotifyActivity({
+          software_titles: [
+            "1Password",
+            "Slack",
+            "Docker Desktop",
+            "Zoom",
+            "Chrome",
+          ],
+        })}
+        tab="past"
+        onShowDetails={noop}
+      />
+    );
+
+    expect(container.textContent).toContain(
+      "1Password, Slack, Docker Desktop, and 2 more apps"
+    );
+  });
+
+  it("renders 5 minutes for the reminder", () => {
+    const { container } = render(
+      <NotifiedEndUserBeforePatchingActivityItem
+        activity={createNotifyActivity({ time_before: 300 })}
+        tab="past"
+        onShowDetails={noop}
+      />
+    );
+
+    expect(container.textContent).toContain(
+      "notified end user 5 minutes before patching"
+    );
+  });
+
+  it("renders the failed-to-notify sentence when status is failed", () => {
+    const { container } = render(
+      <NotifiedEndUserBeforePatchingActivityItem
+        activity={createNotifyActivity({ status: "failed" })}
+        tab="past"
+        onShowDetails={noop}
+      />
+    );
+
+    expect(container.textContent).toContain(
+      "Fleet failed to notify end user 1 hour before patching 1Password on this host."
+    );
+  });
+});

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/NotifiedEndUserBeforePatchingActivityItem/NotifiedEndUserBeforePatchingActivityItem.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/NotifiedEndUserBeforePatchingActivityItem/NotifiedEndUserBeforePatchingActivityItem.tests.tsx
@@ -58,7 +58,7 @@ describe("NotifiedEndUserBeforePatchingActivityItem", () => {
     );
   });
 
-  it("truncates past three apps with pluralized 'more apps'", () => {
+  it("truncates past four apps with pluralized 'more apps'", () => {
     const { container } = render(
       <NotifiedEndUserBeforePatchingActivityItem
         activity={createNotifyActivity({

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/NotifiedEndUserBeforePatchingActivityItem/NotifiedEndUserBeforePatchingActivityItem.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/NotifiedEndUserBeforePatchingActivityItem/NotifiedEndUserBeforePatchingActivityItem.tsx
@@ -1,7 +1,11 @@
 import React from "react";
 
 import ActivityItem from "components/ActivityItem";
-import { renderNotifyTitleList } from "components/ActivityDetails/NotifyBeforePatchingDetailsModal/helpers";
+import {
+  renderNotifyTitleList,
+  formatNotifyTimeLabel,
+  isNotifyFailure,
+} from "components/ActivityDetails/NotifyBeforePatchingDetailsModal/helpers";
 
 import { IHostActivityItemComponentPropsWithShowDetails } from "../../ActivityConfig";
 
@@ -20,8 +24,8 @@ const NotifiedEndUserBeforePatchingActivityItem = ({
     status,
     time_before: timeBefore,
   } = details;
-  const timeLabel = timeBefore === 300 ? "5 minutes" : "1 hour";
-  const failed = status === "failed";
+  const timeLabel = formatNotifyTimeLabel(timeBefore);
+  const failed = isNotifyFailure(status);
   const verb = failed ? "failed to notify" : "notified";
   const titleList = renderNotifyTitleList(titles);
 

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/NotifiedEndUserBeforePatchingActivityItem/NotifiedEndUserBeforePatchingActivityItem.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/NotifiedEndUserBeforePatchingActivityItem/NotifiedEndUserBeforePatchingActivityItem.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 
 import ActivityItem from "components/ActivityItem";
-import { pluralize } from "utilities/strings/stringUtils";
-import { getDisplayedSoftwareName } from "pages/SoftwarePage/helpers";
+import { renderNotifyTitleList } from "components/ActivityDetails/NotifyBeforePatchingDetailsModal/helpers";
 
 import { IHostActivityItemComponentPropsWithShowDetails } from "../../ActivityConfig";
 
@@ -24,33 +23,7 @@ const NotifiedEndUserBeforePatchingActivityItem = ({
   const timeLabel = timeBefore === 300 ? "5 minutes" : "1 hour";
   const failed = status === "failed";
   const verb = failed ? "failed to notify" : "notified";
-
-  // Bold titles, Oxford comma, ", and N more app(s)" past three.
-  const bold = (name: string) => <b>{getDisplayedSoftwareName(name)}</b>;
-  const overflow = titles.length - 3;
-  let titleList: React.ReactNode = null;
-  if (titles.length === 1) {
-    titleList = bold(titles[0]);
-  } else if (titles.length === 2) {
-    titleList = (
-      <>
-        {bold(titles[0])} and {bold(titles[1])}
-      </>
-    );
-  } else if (titles.length === 3) {
-    titleList = (
-      <>
-        {bold(titles[0])}, {bold(titles[1])}, and {bold(titles[2])}
-      </>
-    );
-  } else if (titles.length > 3) {
-    titleList = (
-      <>
-        {bold(titles[0])}, {bold(titles[1])}, {bold(titles[2])}, and {overflow}{" "}
-        more {pluralize(overflow, "app")}
-      </>
-    );
-  }
+  const titleList = renderNotifyTitleList(titles);
 
   return (
     <ActivityItem
@@ -61,8 +34,8 @@ const NotifiedEndUserBeforePatchingActivityItem = ({
       onCancel={onCancel}
       isSoloActivity={isSoloActivity}
     >
-      <b>Fleet</b> {verb} end user {timeLabel} before patching {titleList} on
-      this host.
+      <strong>Fleet</strong> {verb} end user {timeLabel} before patching{" "}
+      {titleList} on this host.
     </ActivityItem>
   );
 };

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/NotifiedEndUserBeforePatchingActivityItem/NotifiedEndUserBeforePatchingActivityItem.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/NotifiedEndUserBeforePatchingActivityItem/NotifiedEndUserBeforePatchingActivityItem.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+import { INotifyActivityStatus } from "interfaces/activity";
 import ActivityItem from "components/ActivityItem";
 import {
   renderNotifyTitleList,
@@ -25,7 +26,7 @@ const NotifiedEndUserBeforePatchingActivityItem = ({
     time_before: timeBefore,
   } = details;
   const timeLabel = formatNotifyTimeLabel(timeBefore);
-  const failed = isNotifyFailure(status);
+  const failed = isNotifyFailure(status as INotifyActivityStatus | undefined);
   const verb = failed ? "failed to notify" : "notified";
   const titleList = renderNotifyTitleList(titles);
 

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/NotifiedEndUserBeforePatchingActivityItem/NotifiedEndUserBeforePatchingActivityItem.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/NotifiedEndUserBeforePatchingActivityItem/NotifiedEndUserBeforePatchingActivityItem.tsx
@@ -25,9 +25,7 @@ const NotifiedEndUserBeforePatchingActivityItem = ({
   const failed = status === "failed";
   const verb = failed ? "failed to notify" : "notified";
 
-  // Bolds each title, uses an Oxford comma, and truncates past three titles
-  // with a ", and N more app(s)" suffix (Figma dev note 5546:46306). Same
-  // logic as the global feed template; host feed just drops the host name.
+  // Bold titles, Oxford comma, ", and N more app(s)" past three.
   const bold = (name: string) => <b>{getDisplayedSoftwareName(name)}</b>;
   const overflow = titles.length - 3;
   let titleList: React.ReactNode = null;

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/NotifiedEndUserBeforePatchingActivityItem/NotifiedEndUserBeforePatchingActivityItem.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/NotifiedEndUserBeforePatchingActivityItem/NotifiedEndUserBeforePatchingActivityItem.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+
+import ActivityItem from "components/ActivityItem";
+import { pluralize } from "utilities/strings/stringUtils";
+import { getDisplayedSoftwareName } from "pages/SoftwarePage/helpers";
+
+import { IHostActivityItemComponentPropsWithShowDetails } from "../../ActivityConfig";
+
+const baseClass = "notified-end-user-before-patching-activity-item";
+
+const NotifiedEndUserBeforePatchingActivityItem = ({
+  activity,
+  onShowDetails,
+  onCancel,
+  hideCancel,
+  isSoloActivity,
+}: IHostActivityItemComponentPropsWithShowDetails) => {
+  const { details } = activity;
+  const {
+    software_titles: titles = [],
+    status,
+    time_before: timeBefore,
+  } = details;
+  const timeLabel = timeBefore === 300 ? "5 minutes" : "1 hour";
+  const failed = status === "failed";
+  const verb = failed ? "failed to notify" : "notified";
+
+  // Bolds each title, uses an Oxford comma, and truncates past three titles
+  // with a ", and N more app(s)" suffix (Figma dev note 5546:46306). Same
+  // logic as the global feed template; host feed just drops the host name.
+  const bold = (name: string) => <b>{getDisplayedSoftwareName(name)}</b>;
+  const overflow = titles.length - 3;
+  let titleList: React.ReactNode = null;
+  if (titles.length === 1) {
+    titleList = bold(titles[0]);
+  } else if (titles.length === 2) {
+    titleList = (
+      <>
+        {bold(titles[0])} and {bold(titles[1])}
+      </>
+    );
+  } else if (titles.length === 3) {
+    titleList = (
+      <>
+        {bold(titles[0])}, {bold(titles[1])}, and {bold(titles[2])}
+      </>
+    );
+  } else if (titles.length > 3) {
+    titleList = (
+      <>
+        {bold(titles[0])}, {bold(titles[1])}, {bold(titles[2])}, and {overflow}{" "}
+        more {pluralize(overflow, "app")}
+      </>
+    );
+  }
+
+  return (
+    <ActivityItem
+      className={baseClass}
+      activity={activity}
+      hideCancel={hideCancel}
+      onShowDetails={onShowDetails}
+      onCancel={onCancel}
+      isSoloActivity={isSoloActivity}
+    >
+      <b>Fleet</b> {verb} end user {timeLabel} before patching {titleList} on
+      this host.
+    </ActivityItem>
+  );
+};
+
+export default NotifiedEndUserBeforePatchingActivityItem;

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/NotifiedEndUserBeforePatchingActivityItem/NotifiedEndUserBeforePatchingActivityItem.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/NotifiedEndUserBeforePatchingActivityItem/NotifiedEndUserBeforePatchingActivityItem.tsx
@@ -38,8 +38,8 @@ const NotifiedEndUserBeforePatchingActivityItem = ({
       onCancel={onCancel}
       isSoloActivity={isSoloActivity}
     >
-      <strong>Fleet</strong> {verb} end user {timeLabel} before patching{" "}
-      {titleList} on this host.
+      <strong>Fleet</strong> {verb} end user {timeLabel} before patching
+      {titleList && <> {titleList}</>} on this host.
     </ActivityItem>
   );
 };

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/NotifiedEndUserBeforePatchingActivityItem/NotifiedEndUserBeforePatchingActivityItem.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/NotifiedEndUserBeforePatchingActivityItem/NotifiedEndUserBeforePatchingActivityItem.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 
-import { INotifyActivityStatus } from "interfaces/activity";
 import ActivityItem from "components/ActivityItem";
 import {
   renderNotifyTitleList,
@@ -26,7 +25,7 @@ const NotifiedEndUserBeforePatchingActivityItem = ({
     time_before: timeBefore,
   } = details;
   const timeLabel = formatNotifyTimeLabel(timeBefore);
-  const failed = isNotifyFailure(status as INotifyActivityStatus | undefined);
+  const failed = isNotifyFailure(status);
   const verb = failed ? "failed to notify" : "notified";
   const titleList = renderNotifyTitleList(titles);
 

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/NotifiedEndUserBeforePatchingActivityItem/index.ts
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/NotifiedEndUserBeforePatchingActivityItem/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./NotifiedEndUserBeforePatchingActivityItem";

--- a/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/PolicyAutomationActivityDetailsModal.tests.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/PolicyAutomationActivityDetailsModal.tests.tsx
@@ -31,8 +31,7 @@ const stubScriptResult = (
     )
   );
 
-// useQuery inside the notify branch needs a QueryClientProvider — use the
-// project's standard test renderer instead of RTL's bare render.
+// The notify branch's useQuery needs a QueryClientProvider.
 const render = createCustomRenderer({ withBackendMock: true });
 
 const failedSoftwareActivity: IPolicyAutomationActivity = {
@@ -243,8 +242,7 @@ describe("PolicyAutomationActivityDetailsModal", () => {
       expect(link.target).toBe("_blank");
       unmount();
 
-      // Exit code 41 (screen locked) does NOT get the link — it's not a
-      // Fleet-Desktop-required failure.
+      // Non-Fleet-Desktop failures don't get the link.
       stubScriptResult({ exit_code: 41 });
       render(
         <PolicyAutomationActivityDetailsModal

--- a/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/PolicyAutomationActivityDetailsModal.tests.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/PolicyAutomationActivityDetailsModal.tests.tsx
@@ -1,11 +1,39 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { baseUrl, createCustomRenderer } from "test/test-utils";
+import mockServer from "test/mock-server";
 
 import { ActivityType } from "interfaces/activity";
 import { IPolicyAutomationActivity } from "interfaces/policy";
 
 import PolicyAutomationActivityDetailsModal from "./PolicyAutomationActivityDetailsModal";
+
+const stubScriptResult = (
+  overrides: { exit_code?: number; output?: string } = {}
+) =>
+  mockServer.use(
+    http.get(baseUrl("/scripts/results/:executionId"), () =>
+      HttpResponse.json({
+        hostname: "Rachael's MacBook Pro",
+        host_id: 42,
+        execution_id: "exec-1",
+        script_contents: "#!/bin/bash\nnotify ...",
+        script_id: null,
+        exit_code: overrides.exit_code ?? 0,
+        output: overrides.output ?? "",
+        message: "",
+        runtime: 1,
+        host_timeout: false,
+        created_at: "2026-01-01T00:00:00Z",
+      })
+    )
+  );
+
+// useQuery inside the notify branch needs a QueryClientProvider — use the
+// project's standard test renderer instead of RTL's bare render.
+const render = createCustomRenderer({ withBackendMock: true });
 
 const failedSoftwareActivity: IPolicyAutomationActivity = {
   id: 1,
@@ -130,5 +158,202 @@ describe("PolicyAutomationActivityDetailsModal", () => {
     expect(screen.getByText("Webhook queued")).toBeInTheDocument();
     // No details box (and therefore no copy button) when there's nothing to show.
     expect(screen.queryByTestId("copy-icon")).toBeNull();
+  });
+
+  describe("notify activities", () => {
+    const notifyActivity: IPolicyAutomationActivity = {
+      id: 2,
+      created_at: "2026-06-12T15:04:05Z",
+      type: ActivityType.NotifiedEndUserBeforePatching,
+      fleet_initiated: true,
+      details: {
+        policy_id: 123,
+        software_title: "1Password",
+        time_before: 3600,
+        script_execution_id: "exec-1",
+      },
+      host_id: 42,
+      host_display_name: "Rachael's MacBook Pro",
+      status: "success",
+      output: null,
+      pre_install_output: null,
+      post_install_output: null,
+    };
+
+    it("shows the offline caveat prose on success and hides the script output behind Details", async () => {
+      stubScriptResult({ exit_code: 0, output: "Notification displayed." });
+      render(
+        <PolicyAutomationActivityDetailsModal
+          activity={notifyActivity}
+          onCancel={jest.fn()}
+        />
+      );
+
+      expect(
+        await screen.findByText(
+          /End user was notified\. Patch will be forced in 1 hour\./
+        )
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText("Notification script output:")
+      ).not.toBeInTheDocument();
+
+      // Reveal button appears once the async script fetch resolves.
+      await userEvent.click(
+        await screen.findByRole("button", { name: /Details/ })
+      );
+      expect(
+        screen.getByText("Notification script output:")
+      ).toBeInTheDocument();
+      expect(screen.getByText("Notification displayed.")).toBeInTheDocument();
+    });
+
+    it("swaps in the 5-minute copy on the reminder", async () => {
+      stubScriptResult({ exit_code: 0 });
+      render(
+        <PolicyAutomationActivityDetailsModal
+          activity={{
+            ...notifyActivity,
+            details: { ...notifyActivity.details, time_before: 300 },
+          }}
+          onCancel={jest.fn()}
+        />
+      );
+
+      expect(
+        await screen.findByText(/Patch will be forced in 5 minutes\./)
+      ).toBeInTheDocument();
+    });
+
+    it("appends the End user experience link for exit codes 100 and 101", async () => {
+      stubScriptResult({ exit_code: 100 });
+      const { unmount } = render(
+        <PolicyAutomationActivityDetailsModal
+          activity={{ ...notifyActivity, status: "error" }}
+          onCancel={jest.fn()}
+        />
+      );
+
+      const link = (await screen.findByRole("link", {
+        name: /End user experience/i,
+      })) as HTMLAnchorElement;
+      expect(link.href).toBe(
+        "https://fleetdm.com/learn-more-about/patching-end-user-experience"
+      );
+      expect(link.target).toBe("_blank");
+      unmount();
+
+      // Exit code 41 (screen locked) does NOT get the link — it's not a
+      // Fleet-Desktop-required failure.
+      stubScriptResult({ exit_code: 41 });
+      render(
+        <PolicyAutomationActivityDetailsModal
+          activity={{ ...notifyActivity, status: "error" }}
+          onCancel={jest.fn()}
+        />
+      );
+      await screen.findByText(/screen was locked/i);
+      expect(
+        screen.queryByRole("link", { name: /End user experience/i })
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows the exit-code failure sentence on a notify failure", async () => {
+      stubScriptResult({
+        exit_code: 41,
+        output: "The screen is locked.",
+      });
+      render(
+        <PolicyAutomationActivityDetailsModal
+          activity={{ ...notifyActivity, status: "error" }}
+          onCancel={jest.fn()}
+        />
+      );
+
+      expect(
+        await screen.findByText(/The screen was locked/)
+      ).toBeInTheDocument();
+      await userEvent.click(screen.getByRole("button", { name: /Details/ }));
+      expect(screen.getByText("The screen is locked.")).toBeInTheDocument();
+    });
+  });
+
+  describe("skipped install (notify variant)", () => {
+    it("shows the notify explanation and reveals the pre-install output under Details", async () => {
+      const skipActivity: IPolicyAutomationActivity = {
+        id: 3,
+        created_at: "2026-06-12T15:04:05Z",
+        type: ActivityType.InstalledSoftware,
+        fleet_initiated: true,
+        details: {
+          policy_id: 123,
+          software_title: "1Password",
+          skipped_install: true,
+        },
+        host_id: 42,
+        host_display_name: "Rachael's MacBook Pro",
+        status: "error",
+        output: null,
+        pre_install_output:
+          "Query didn't return result or failed\nThe app was open. Fleet notifies the end user 1 hour before the patch is forced.",
+        post_install_output: null,
+      };
+
+      render(
+        <PolicyAutomationActivityDetailsModal
+          activity={skipActivity}
+          onCancel={jest.fn()}
+        />
+      );
+
+      expect(
+        screen.getByText(
+          /The app was open\. The end user will be notified before the patch is forced\./
+        )
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText("Pre-install query output:")
+      ).not.toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole("button", { name: /Details/ }));
+      expect(screen.getByText("Pre-install query output:")).toBeInTheDocument();
+      expect(
+        screen.getByText(/Fleet notifies the end user 1 hour/)
+      ).toBeInTheDocument();
+    });
+
+    it("keeps the patch_when_closed skip on the old rendering (no notify explanation)", () => {
+      const patchWhenClosedSkip: IPolicyAutomationActivity = {
+        id: 4,
+        created_at: "2026-06-12T15:04:05Z",
+        type: ActivityType.InstalledSoftware,
+        fleet_initiated: true,
+        details: {
+          policy_id: 123,
+          software_title: "1Password",
+          skipped_install: true,
+        },
+        host_id: 42,
+        host_display_name: "Rachael's MacBook Pro",
+        status: "error",
+        output: null,
+        pre_install_output:
+          "Query didn't return result or failed\nThe app was open.",
+        post_install_output: null,
+      };
+
+      render(
+        <PolicyAutomationActivityDetailsModal
+          activity={patchWhenClosedSkip}
+          onCancel={jest.fn()}
+        />
+      );
+
+      expect(
+        screen.queryByText(/The end user will be notified/)
+      ).not.toBeInTheDocument();
+      // Old rendering exposes pre_install_output directly (no reveal).
+      expect(screen.getByText("Pre-install query output")).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/PolicyAutomationActivityDetailsModal.tests.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/PolicyAutomationActivityDetailsModal.tests.tsx
@@ -179,7 +179,7 @@ describe("PolicyAutomationActivityDetailsModal", () => {
       post_install_output: null,
     };
 
-    it("shows the offline caveat prose on success and hides the script output behind Details", async () => {
+    it("shows the offline caveat explanation on success and hides the script output behind Details", async () => {
       stubScriptResult({ exit_code: 0, output: "Notification displayed." });
       render(
         <PolicyAutomationActivityDetailsModal

--- a/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/PolicyAutomationActivityDetailsModal.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/PolicyAutomationActivityDetailsModal.tsx
@@ -1,17 +1,31 @@
-import React from "react";
+import React, { useState } from "react";
+import { AxiosError } from "axios";
+import { useQuery } from "react-query";
 
 import { ActivityType } from "interfaces/activity";
 import { IPolicyAutomationActivity } from "interfaces/policy";
 import PATHS from "router/paths";
+import scriptsAPI, { IScriptResultResponse } from "services/entities/scripts";
+import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
 
 import Modal from "components/Modal";
 import Button from "components/buttons/Button";
+import RevealButton from "components/buttons/RevealButton";
 import CopyButton from "components/buttons/CopyButton";
 import CustomLink from "components/CustomLink";
 import DataSet from "components/DataSet";
 import Textarea from "components/Textarea";
 import Icon from "components/Icon";
 import { HumanTimeDiffWithDateTip } from "components/HumanTimeDiffWithDateTip";
+
+import {
+  getCaveatSentence,
+  getAutomationNotifiedSentence,
+  isNotifyBeforePatchingSkip,
+  SKIPPED_INSTALL_NOTIFY_EXPLANATION,
+  EXIT_CODES_NEEDING_EUE_LINK,
+  PATCHING_END_USER_EXPERIENCE_URL,
+} from "components/ActivityDetails/NotifyBeforePatchingDetailsModal/helpers";
 
 import {
   getAutomationRunDisplayName,
@@ -34,17 +48,85 @@ const PolicyAutomationActivityDetailsModal = ({
   onResetPolicy,
 }: IPolicyAutomationActivityDetailsModalProps): JSX.Element => {
   const { created_at, host_id, host_display_name } = activity;
-  const detailOutput = getDetailOutputText(activity);
+  const isNotify = activity.type === ActivityType.NotifiedEndUserBeforePatching;
   const isSoftwareInstall = activity.type === ActivityType.InstalledSoftware;
+  const isSkippedInstall =
+    isSoftwareInstall && !!activity.details?.skipped_install;
+  const isSkippedNotifyVariant =
+    isSkippedInstall && isNotifyBeforePatchingSkip(activity.pre_install_output);
+  const scriptExecutionId = activity.details?.script_execution_id;
+
+  const [showDetails, setShowDetails] = useState(false);
+
+  // Only the notify branches need the script result — the failure sentence
+  // depends on the exit code, which the automation activity doesn't carry.
+  const { data: scriptResult } = useQuery<IScriptResultResponse, AxiosError>(
+    ["notify-script-result", scriptExecutionId],
+    () => scriptsAPI.getScriptResult(scriptExecutionId as string),
+    {
+      ...DEFAULT_USE_QUERY_OPTIONS,
+      enabled: isNotify && !!scriptExecutionId,
+      retry: (failureCount, err) => err?.status !== 404 && failureCount < 3,
+    }
+  );
+
+  const detailOutput = getDetailOutputText(activity);
+
+  const renderProseSentence = (): string | null => {
+    if (isNotify) {
+      if (activity.status === "success") {
+        return getAutomationNotifiedSentence(activity.details?.time_before);
+      }
+      return getCaveatSentence(scriptExecutionId, scriptResult?.exit_code);
+    }
+    if (isSkippedNotifyVariant) {
+      return SKIPPED_INSTALL_NOTIFY_EXPLANATION;
+    }
+    return null;
+  };
+
+  const proseSentence = renderProseSentence();
+  const showEueLink =
+    isNotify &&
+    scriptResult?.exit_code != null &&
+    EXIT_CODES_NEEDING_EUE_LINK.has(scriptResult.exit_code);
+
+  // Notify + skipped-install-notify hide their code output behind a Details
+  // reveal with a specific label; other software installs keep the flat
+  // pre/install/post rendering.
+  const revealLabel = (() => {
+    if (isNotify) return "Notification script output:";
+    if (isSkippedNotifyVariant) return "Pre-install query output:";
+    return null;
+  })();
+  const revealOutput = (() => {
+    if (isNotify) return scriptResult?.output || activity.output || null;
+    if (isSkippedNotifyVariant) return activity.pre_install_output;
+    return null;
+  })();
 
   // A code-style output block with a copy button. Renders nothing when empty.
-  const renderOutputSection = (label: string, value: string | null) =>
+  // `plainLabel` skips the bold treatment used elsewhere in the modal — Figma
+  // wants the reveal-case labels ("Notification script output:", "Pre-install
+  // query output:") in regular weight since they're inside the Details reveal
+  // rather than acting as top-level section headings.
+  const renderOutputSection = (
+    label: string,
+    value: string | null,
+    plainLabel = false
+  ) =>
     value ? (
       <Textarea
         key={label}
         variant="code"
         label={
-          <div className={`${baseClass}__details-label`}>
+          <div
+            className={
+              plainLabel
+                ? `${baseClass}__plain-label`
+                : `${baseClass}__details-label`
+            }
+          >
             <span>{label}</span>
             <CopyButton
               copyText={value}
@@ -57,6 +139,57 @@ const PolicyAutomationActivityDetailsModal = ({
         {value}
       </Textarea>
     ) : null;
+
+  const renderBody = () => {
+    if (proseSentence) {
+      return (
+        <>
+          <p className={`${baseClass}__prose`}>
+            {proseSentence}
+            {showEueLink && (
+              <>
+                {" "}
+                <CustomLink
+                  url={PATCHING_END_USER_EXPERIENCE_URL}
+                  text="End user experience"
+                  newTab
+                />
+              </>
+            )}
+          </p>
+          {revealOutput && revealLabel && (
+            <>
+              <RevealButton
+                isShowing={showDetails}
+                showText="Details"
+                hideText="Details"
+                caretPosition="after"
+                onClick={() => setShowDetails((s) => !s)}
+              />
+              {showDetails &&
+                renderOutputSection(revealLabel, revealOutput, true)}
+            </>
+          )}
+        </>
+      );
+    }
+    if (isSoftwareInstall) {
+      return (
+        <>
+          {renderOutputSection(
+            "Pre-install query output",
+            activity.pre_install_output
+          )}
+          {renderOutputSection("Details", activity.output)}
+          {renderOutputSection(
+            "Post-install script output",
+            activity.post_install_output
+          )}
+        </>
+      );
+    }
+    return renderOutputSection("Details", detailOutput || null);
+  };
 
   return (
     <Modal title="Details" onExit={onCancel} className={baseClass}>
@@ -92,21 +225,7 @@ const PolicyAutomationActivityDetailsModal = ({
             </span>
           }
         />
-        {isSoftwareInstall ? (
-          <>
-            {renderOutputSection(
-              "Pre-install query output",
-              activity.pre_install_output
-            )}
-            {renderOutputSection("Details", activity.output)}
-            {renderOutputSection(
-              "Post-install script output",
-              activity.post_install_output
-            )}
-          </>
-        ) : (
-          renderOutputSection("Details", detailOutput || null)
-        )}
+        {renderBody()}
         <div className="modal-cta-wrap">
           <Button onClick={onCancel}>Done</Button>
           {onResetPolicy && (

--- a/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/PolicyAutomationActivityDetailsModal.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/PolicyAutomationActivityDetailsModal.tsx
@@ -65,7 +65,8 @@ const PolicyAutomationActivityDetailsModal = ({
     {
       ...DEFAULT_USE_QUERY_OPTIONS,
       enabled: isNotify && !!scriptExecutionId,
-      retry: (failureCount, err) => err?.status !== 404 && failureCount < 3,
+      retry: (failureCount, err) =>
+        err?.response?.status !== 404 && failureCount < 3,
     }
   );
 

--- a/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/PolicyAutomationActivityDetailsModal.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/PolicyAutomationActivityDetailsModal.tsx
@@ -58,8 +58,7 @@ const PolicyAutomationActivityDetailsModal = ({
 
   const [showDetails, setShowDetails] = useState(false);
 
-  // Only the notify branches need the script result — the failure sentence
-  // depends on the exit code, which the automation activity doesn't carry.
+  // Only the notify branches need the exit code (not on the activity itself).
   const { data: scriptResult } = useQuery<IScriptResultResponse, AxiosError>(
     ["notify-script-result", scriptExecutionId],
     () => scriptsAPI.getScriptResult(scriptExecutionId as string),
@@ -91,9 +90,7 @@ const PolicyAutomationActivityDetailsModal = ({
     scriptResult?.exit_code != null &&
     EXIT_CODES_NEEDING_EUE_LINK.has(scriptResult.exit_code);
 
-  // Notify + skipped-install-notify hide their code output behind a Details
-  // reveal with a specific label; other software installs keep the flat
-  // pre/install/post rendering.
+  // Notify + notify-skip cases hide output behind a Details reveal.
   const revealLabel = (() => {
     if (isNotify) return "Notification script output:";
     if (isSkippedNotifyVariant) return "Pre-install query output:";
@@ -106,10 +103,7 @@ const PolicyAutomationActivityDetailsModal = ({
   })();
 
   // A code-style output block with a copy button. Renders nothing when empty.
-  // `plainLabel` skips the bold treatment used elsewhere in the modal — Figma
-  // wants the reveal-case labels ("Notification script output:", "Pre-install
-  // query output:") in regular weight since they're inside the Details reveal
-  // rather than acting as top-level section headings.
+  // `plainLabel` drops the bold treatment for labels inside the Details reveal.
   const renderOutputSection = (
     label: string,
     value: string | null,

--- a/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/PolicyAutomationActivityDetailsModal.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/PolicyAutomationActivityDetailsModal.tsx
@@ -70,6 +70,7 @@ const PolicyAutomationActivityDetailsModal = ({
   );
 
   const detailOutput = getDetailOutputText(activity);
+  const statusIcon = getAutomationStatusIcon(activity);
 
   const getExplanation = (): string | null => {
     if (isNotify) {
@@ -211,10 +212,7 @@ const PolicyAutomationActivityDetailsModal = ({
           title="Status"
           value={
             <span className={`${baseClass}__status`}>
-              <Icon
-                name={getAutomationStatusIcon(activity).name}
-                color={getAutomationStatusIcon(activity).color}
-              />
+              <Icon name={statusIcon.name} color={statusIcon.color} />
               {getAutomationRunDisplayName(activity)}
             </span>
           }

--- a/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/PolicyAutomationActivityDetailsModal.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/PolicyAutomationActivityDetailsModal.tsx
@@ -19,8 +19,8 @@ import Icon from "components/Icon";
 import { HumanTimeDiffWithDateTip } from "components/HumanTimeDiffWithDateTip";
 
 import {
-  getCaveatSentence,
-  getAutomationNotifiedSentence,
+  getCaveatMessage,
+  getAutomationNotifiedMessage,
   isNotifyBeforePatchingSkip,
   SKIPPED_INSTALL_NOTIFY_EXPLANATION,
   EXIT_CODES_NEEDING_EUE_LINK,
@@ -74,9 +74,9 @@ const PolicyAutomationActivityDetailsModal = ({
   const renderExplanation = (): string | null => {
     if (isNotify) {
       if (activity.status === "success") {
-        return getAutomationNotifiedSentence(activity.details?.time_before);
+        return getAutomationNotifiedMessage(activity.details?.time_before);
       }
-      return getCaveatSentence(
+      return getCaveatMessage(
         true,
         scriptExecutionId,
         scriptResult?.exit_code

--- a/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/PolicyAutomationActivityDetailsModal.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/PolicyAutomationActivityDetailsModal.tsx
@@ -65,8 +65,7 @@ const PolicyAutomationActivityDetailsModal = ({
     {
       ...DEFAULT_USE_QUERY_OPTIONS,
       enabled: isNotify && !!scriptExecutionId,
-      retry: (failureCount, err) =>
-        err?.response?.status !== 404 && failureCount < 3,
+      retry: (failureCount, err) => err?.status !== 404 && failureCount < 3,
     }
   );
 
@@ -77,7 +76,11 @@ const PolicyAutomationActivityDetailsModal = ({
       if (activity.status === "success") {
         return getAutomationNotifiedSentence(activity.details?.time_before);
       }
-      return getCaveatSentence(scriptExecutionId, scriptResult?.exit_code);
+      return getCaveatSentence(
+        true,
+        scriptExecutionId,
+        scriptResult?.exit_code
+      );
     }
     if (isSkippedNotifyVariant) {
       return SKIPPED_INSTALL_NOTIFY_EXPLANATION;

--- a/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/PolicyAutomationActivityDetailsModal.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/PolicyAutomationActivityDetailsModal.tsx
@@ -72,7 +72,7 @@ const PolicyAutomationActivityDetailsModal = ({
 
   const detailOutput = getDetailOutputText(activity);
 
-  const renderProseSentence = (): string | null => {
+  const renderExplanation = (): string | null => {
     if (isNotify) {
       if (activity.status === "success") {
         return getAutomationNotifiedSentence(activity.details?.time_before);
@@ -85,19 +85,19 @@ const PolicyAutomationActivityDetailsModal = ({
     return null;
   };
 
-  const proseSentence = renderProseSentence();
+  const explanation = renderExplanation();
   const showEueLink =
     isNotify &&
     scriptResult?.exit_code != null &&
     EXIT_CODES_NEEDING_EUE_LINK.has(scriptResult.exit_code);
 
   // Notify + notify-skip cases hide output behind a Details reveal.
-  const revealLabel = (() => {
+  const detailsLabel = (() => {
     if (isNotify) return "Notification script output:";
     if (isSkippedNotifyVariant) return "Pre-install query output:";
     return null;
   })();
-  const revealOutput = (() => {
+  const detailsContent = (() => {
     if (isNotify) return scriptResult?.output || activity.output || null;
     if (isSkippedNotifyVariant) return activity.pre_install_output;
     return null;
@@ -136,11 +136,11 @@ const PolicyAutomationActivityDetailsModal = ({
     ) : null;
 
   const renderBody = () => {
-    if (proseSentence) {
+    if (explanation) {
       return (
         <>
-          <p className={`${baseClass}__prose`}>
-            {proseSentence}
+          <p className={`${baseClass}__explanation`}>
+            {explanation}
             {showEueLink && (
               <>
                 {" "}
@@ -152,7 +152,7 @@ const PolicyAutomationActivityDetailsModal = ({
               </>
             )}
           </p>
-          {revealOutput && revealLabel && (
+          {detailsContent && detailsLabel && (
             <>
               <RevealButton
                 isShowing={showDetails}
@@ -162,7 +162,7 @@ const PolicyAutomationActivityDetailsModal = ({
                 onClick={() => setShowDetails((s) => !s)}
               />
               {showDetails &&
-                renderOutputSection(revealLabel, revealOutput, true)}
+                renderOutputSection(detailsLabel, detailsContent, true)}
             </>
           )}
         </>

--- a/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/PolicyAutomationActivityDetailsModal.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/PolicyAutomationActivityDetailsModal.tsx
@@ -25,6 +25,7 @@ import {
   SKIPPED_INSTALL_NOTIFY_EXPLANATION,
   EXIT_CODES_NEEDING_EUE_LINK,
   PATCHING_END_USER_EXPERIENCE_URL,
+  retryUnless404,
 } from "components/ActivityDetails/NotifyBeforePatchingDetailsModal/helpers";
 
 import {
@@ -65,7 +66,7 @@ const PolicyAutomationActivityDetailsModal = ({
     {
       ...DEFAULT_USE_QUERY_OPTIONS,
       enabled: isNotify && !!scriptExecutionId,
-      retry: (failureCount, err) => err?.status !== 404 && failureCount < 3,
+      retry: retryUnless404,
     }
   );
 
@@ -77,7 +78,11 @@ const PolicyAutomationActivityDetailsModal = ({
       if (activity.status === "success") {
         return getAutomationNotifiedMessage(activity.details?.time_before);
       }
-      return getCaveatMessage(true, scriptExecutionId, scriptResult?.exit_code);
+      return getCaveatMessage(
+        "failed",
+        scriptExecutionId,
+        scriptResult?.exit_code
+      );
     }
     if (isSkippedNotifyVariant) {
       return SKIPPED_INSTALL_NOTIFY_EXPLANATION;

--- a/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/PolicyAutomationActivityDetailsModal.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/PolicyAutomationActivityDetailsModal.tsx
@@ -71,16 +71,12 @@ const PolicyAutomationActivityDetailsModal = ({
 
   const detailOutput = getDetailOutputText(activity);
 
-  const renderExplanation = (): string | null => {
+  const getExplanation = (): string | null => {
     if (isNotify) {
       if (activity.status === "success") {
         return getAutomationNotifiedMessage(activity.details?.time_before);
       }
-      return getCaveatMessage(
-        true,
-        scriptExecutionId,
-        scriptResult?.exit_code
-      );
+      return getCaveatMessage(true, scriptExecutionId, scriptResult?.exit_code);
     }
     if (isSkippedNotifyVariant) {
       return SKIPPED_INSTALL_NOTIFY_EXPLANATION;
@@ -88,7 +84,7 @@ const PolicyAutomationActivityDetailsModal = ({
     return null;
   };
 
-  const explanation = renderExplanation();
+  const explanation = getExplanation();
   const showEueLink =
     isNotify &&
     scriptResult?.exit_code != null &&

--- a/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/_styles.scss
+++ b/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/_styles.scss
@@ -16,6 +16,12 @@
     .textarea-wrapper {
       gap: 0;
     }
+
+    // The flex column stretches children full-width by default; the reveal
+    // button should hug its content.
+    .reveal-button {
+      align-self: flex-start;
+    }
   }
 
   &__row {
@@ -25,6 +31,13 @@
 
   &__details-label {
     font-weight: $bold;
+    color: $core-fleet-black;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  &__plain-label {
     color: $core-fleet-black;
     display: flex;
     align-items: center;

--- a/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/_styles.scss
+++ b/frontend/pages/policies/details/components/PolicyAutomationActivityDetailsModal/_styles.scss
@@ -17,8 +17,7 @@
       gap: 0;
     }
 
-    // The flex column stretches children full-width by default; the reveal
-    // button should hug its content.
+    // Prevent full-width stretching
     .reveal-button {
       align-self: flex-start;
     }

--- a/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/PolicyAutomationsActivitiesTable.tests.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/PolicyAutomationsActivitiesTable.tests.tsx
@@ -11,6 +11,7 @@ import PolicyAutomationsActivitiesTable from "./PolicyAutomationsActivitiesTable
 import {
   getAutomationRunDisplayName,
   getAutomationStatusIcon,
+  getDetailOutputText,
 } from "./helpers";
 
 jest.mock("services/entities/policies");
@@ -83,6 +84,42 @@ describe("getAutomationRunDisplayName", () => {
         })
       )
     ).toBe("Patch skipped (1Password)");
+  });
+
+  it("labels a successful notify as 'End user notified' and a failure as 'Failed to notify'", () => {
+    expect(
+      getAutomationRunDisplayName(
+        mockActivity({
+          type: ActivityType.NotifiedEndUserBeforePatching,
+          status: "success",
+          details: { policy_id: 123, software_title: "1Password" },
+        })
+      )
+    ).toBe("End user notified (1Password)");
+    expect(
+      getAutomationRunDisplayName(
+        mockActivity({
+          type: ActivityType.NotifiedEndUserBeforePatching,
+          status: "error",
+          details: { policy_id: 123, software_title: "1Password" },
+        })
+      )
+    ).toBe("Failed to notify (1Password)");
+  });
+
+  it("falls back to software_titles[0] on notify rows when software_title is absent", () => {
+    expect(
+      getAutomationRunDisplayName(
+        mockActivity({
+          type: ActivityType.NotifiedEndUserBeforePatching,
+          status: "success",
+          details: {
+            policy_id: 123,
+            software_titles: ["1Password", "Slack"],
+          },
+        })
+      )
+    ).toBe("End user notified (1Password)");
   });
 
   it("treats App Store (VPP) apps as software", () => {
@@ -167,6 +204,77 @@ describe("getAutomationStatusIcon", () => {
     expect(
       getAutomationStatusIcon(mockActivity({ status: "success" }))
     ).toEqual({ name: "success-outline" });
+  });
+
+  it("uses the grey error glyph for a successful 'end user notified' row and red for the failure row", () => {
+    expect(
+      getAutomationStatusIcon(
+        mockActivity({
+          type: ActivityType.NotifiedEndUserBeforePatching,
+          status: "success",
+        })
+      )
+    ).toEqual({ name: "error-outline", color: "ui-fleet-black-50" });
+    expect(
+      getAutomationStatusIcon(
+        mockActivity({
+          type: ActivityType.NotifiedEndUserBeforePatching,
+          status: "error",
+        })
+      )
+    ).toEqual({ name: "error-outline" });
+  });
+});
+
+describe("getDetailOutputText for notify rows", () => {
+  it("renders the 1-hour sentence when time_before is 3600", () => {
+    expect(
+      getDetailOutputText(
+        mockActivity({
+          type: ActivityType.NotifiedEndUserBeforePatching,
+          status: "success",
+          details: {
+            policy_id: 123,
+            software_title: "1Password",
+            time_before: 3600,
+          },
+        })
+      )
+    ).toMatch(/Patch will be forced in 1 hour\./);
+  });
+
+  it("renders the 5-minute sentence when time_before is 300 (reminder)", () => {
+    const text = getDetailOutputText(
+      mockActivity({
+        type: ActivityType.NotifiedEndUserBeforePatching,
+        status: "success",
+        details: {
+          policy_id: 123,
+          software_title: "1Password",
+          time_before: 300,
+        },
+      })
+    );
+    expect(text).toMatch(/Patch will be forced in 5 minutes\./);
+    // The recovery-cadence tail is a system default and stays "1 hour".
+    expect(text).toMatch(/patches it after 1 hour/);
+  });
+
+  it("falls through to activity.output for a notify failure row", () => {
+    expect(
+      getDetailOutputText(
+        mockActivity({
+          type: ActivityType.NotifiedEndUserBeforePatching,
+          status: "error",
+          output: "screen was locked",
+          details: {
+            policy_id: 123,
+            software_title: "1Password",
+            time_before: 3600,
+          },
+        })
+      )
+    ).toBe("screen was locked");
   });
 });
 

--- a/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/PolicyAutomationsActivitiesTable.tests.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/PolicyAutomationsActivitiesTable.tests.tsx
@@ -83,7 +83,7 @@ describe("getAutomationRunDisplayName", () => {
           },
         })
       )
-    ).toBe("Install skipped (1Password)");
+    ).toBe("Patch skipped (1Password)");
   });
 
   it("labels a successful notify as 'Notified end user' and a failure as 'Failed to notify'", () => {

--- a/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/PolicyAutomationsActivitiesTable.tests.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/PolicyAutomationsActivitiesTable.tests.tsx
@@ -83,10 +83,10 @@ describe("getAutomationRunDisplayName", () => {
           },
         })
       )
-    ).toBe("Patch skipped (1Password)");
+    ).toBe("Install skipped (1Password)");
   });
 
-  it("labels a successful notify as 'End user notified' and a failure as 'Failed to notify'", () => {
+  it("labels a successful notify as 'Notified end user' and a failure as 'Failed to notify'", () => {
     expect(
       getAutomationRunDisplayName(
         mockActivity({
@@ -95,7 +95,7 @@ describe("getAutomationRunDisplayName", () => {
           details: { policy_id: 123, software_title: "1Password" },
         })
       )
-    ).toBe("End user notified (1Password)");
+    ).toBe("Notified end user (1Password)");
     expect(
       getAutomationRunDisplayName(
         mockActivity({
@@ -119,7 +119,7 @@ describe("getAutomationRunDisplayName", () => {
           },
         })
       )
-    ).toBe("End user notified (1Password)");
+    ).toBe("Notified end user (1Password)");
   });
 
   it("treats App Store (VPP) apps as software", () => {

--- a/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/helpers.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/helpers.tsx
@@ -2,7 +2,7 @@ import { ActivityType } from "interfaces/activity";
 import { IPolicyAutomationActivity } from "interfaces/policy";
 import { Colors } from "styles/var/colors";
 
-import { getAutomationNotifiedSentence } from "components/ActivityDetails/NotifyBeforePatchingDetailsModal/helpers";
+import { getAutomationNotifiedMessage } from "components/ActivityDetails/NotifyBeforePatchingDetailsModal/helpers";
 
 const withName = (base: string, name?: string) =>
   name ? `${base} (${name})` : base;
@@ -91,7 +91,7 @@ export const getDetailOutputText = (
     activity.type === ActivityType.NotifiedEndUserBeforePatching &&
     activity.status !== "error"
   ) {
-    return getAutomationNotifiedSentence(activity.details?.time_before);
+    return getAutomationNotifiedMessage(activity.details?.time_before);
   }
   if (activity.status === "error" && activity.details?.error_response) {
     return activity.details.error_response;

--- a/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/helpers.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/helpers.tsx
@@ -26,7 +26,7 @@ export const getAutomationRunDisplayName = (
     case ActivityType.InstalledAppStoreApp:
       // App-open skips are recorded as failed_install but aren't failures.
       if (details?.skipped_install) {
-        return withName("Install skipped", details?.software_title);
+        return withName("Patch skipped", details?.software_title);
       }
       return withName(
         failed ? "Software failed" : "Software installed",

--- a/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/helpers.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/helpers.tsx
@@ -5,24 +5,19 @@ import { Colors } from "styles/var/colors";
 const withName = (base: string, name?: string) =>
   name ? `${base} (${name})` : base;
 
+// BE joins per-policy so rows usually carry a singular software_title;
+// software_titles[0] is a safety net.
 const getNotifySoftwareName = (
   details: IPolicyAutomationActivity["details"] | undefined
-): string | undefined => {
-  // BE joins per-policy so each row usually carries a singular software_title;
-  // fall back to the first entry of the plural payload field just in case.
-  return details?.software_title || details?.software_titles?.[0];
-};
+): string | undefined =>
+  details?.software_title || details?.software_titles?.[0];
 
 const getNotifiedSentence = (timeBefore?: number): string => {
   const label = timeBefore === 300 ? "5 minutes" : "1 hour";
   return `End user was notified. Patch will be forced in ${label}. If the host is offline when a patch should be forced, Fleet notifies the end user again when it comes back online and patches it after 1 hour.`;
 };
 
-/**
- * Human-readable label for the "Automation" column. Failure rows mirror the
- * success wording with "failed" — e.g. "Software installed (1Password)" vs
- * "Software failed (1Password)".
- */
+/** Label for the "Automation" column. */
 export const getAutomationRunDisplayName = (
   activity: IPolicyAutomationActivity
 ): string => {
@@ -32,9 +27,7 @@ export const getAutomationRunDisplayName = (
   switch (type) {
     case ActivityType.InstalledSoftware:
     case ActivityType.InstalledAppStoreApp:
-      // A patch-when-closed skip is recorded as a failed_install, but it was
-      // deferred because the app was open — not a failure. Label it distinctly,
-      // matching the activity feed and install-details treatment.
+      // App-open skips are recorded as failed_install but aren't failures.
       if (details?.skipped_install) {
         return withName("Install skipped", details?.software_title);
       }
@@ -73,10 +66,8 @@ export const getAutomationRunDisplayName = (
   }
 };
 
-/** Status icon paired with an automation outcome: a patch-when-closed skip and
- *  a successful "end user notified" both use the muted grey "!" glyph — the
- *  policy didn't succeed at patching, but Fleet handled it deliberately.
- *  Red outline for other failures, green for successes. */
+/** Grey "!" for deliberate non-successes (app-open skips, notify success);
+ *  red for failures, green for successes. */
 export const getAutomationStatusIcon = (
   activity: IPolicyAutomationActivity
 ): { name: "error-outline" | "success-outline"; color?: Colors } => {
@@ -94,19 +85,11 @@ export const getAutomationStatusIcon = (
     : { name: "success-outline" };
 };
 
-/**
- * Text shown in the "Details" column (and the modal's primary block): the
- * remote error response for failures, or the script/install output for the
- * task activities. Empty when neither applies.
- */
+/** Text for the "Details" column preview. */
 export const getDetailOutputText = (
   activity: IPolicyAutomationActivity
 ): string => {
-  // Success (or deferral) rows for the notify activity render a computed
-  // sentence keyed on time_before — the reminder swap 1hr→5min lands here.
-  // Failures fall through to activity.output so the notification script's raw
-  // output shows in the row preview; the modal fetches the script result and
-  // maps the exit code to a human sentence.
+  // Notify success/deferral: computed sentence keyed on time_before.
   if (
     activity.type === ActivityType.NotifiedEndUserBeforePatching &&
     activity.status !== "error"
@@ -116,10 +99,7 @@ export const getDetailOutputText = (
   if (activity.status === "error" && activity.details?.error_response) {
     return activity.details.error_response;
   }
-  // For software installs, the install-script output is the primary preview, but
-  // a failure at the pre-install query or post-install script stage leaves it
-  // empty — fall back to those so the row still shows the failing stage's output.
-  // Other activity types have null pre/post output, so this is just `output`.
+  // Fall back through the install stages so the failing stage's output shows.
   return (
     activity.output ||
     activity.post_install_output ||

--- a/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/helpers.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/helpers.tsx
@@ -5,6 +5,19 @@ import { Colors } from "styles/var/colors";
 const withName = (base: string, name?: string) =>
   name ? `${base} (${name})` : base;
 
+const getNotifySoftwareName = (
+  details: IPolicyAutomationActivity["details"] | undefined
+): string | undefined => {
+  // BE joins per-policy so each row usually carries a singular software_title;
+  // fall back to the first entry of the plural payload field just in case.
+  return details?.software_title || details?.software_titles?.[0];
+};
+
+const getNotifiedSentence = (timeBefore?: number): string => {
+  const label = timeBefore === 300 ? "5 minutes" : "1 hour";
+  return `End user was notified. Patch will be forced in ${label}. If the host is offline when a patch should be forced, Fleet notifies the end user again when it comes back online and patches it after 1 hour.`;
+};
+
 /**
  * Human-readable label for the "Automation" column. Failure rows mirror the
  * success wording with "failed" — e.g. "Software installed (1Password)" vs
@@ -28,6 +41,11 @@ export const getAutomationRunDisplayName = (
       return withName(
         failed ? "Software failed" : "Software installed",
         details?.software_title
+      );
+    case ActivityType.NotifiedEndUserBeforePatching:
+      return withName(
+        failed ? "Failed to notify" : "End user notified",
+        getNotifySoftwareName(details)
       );
     case ActivityType.RanScript:
       return withName(
@@ -55,13 +73,20 @@ export const getAutomationRunDisplayName = (
   }
 };
 
-/** Status icon paired with an automation outcome: a patch-when-closed skip is
- *  the same "!" glyph as a failure but muted grey (deferred, not a failure),
- *  a red outline for other failures, and a green one for successes. */
+/** Status icon paired with an automation outcome: a patch-when-closed skip and
+ *  a successful "end user notified" both use the muted grey "!" glyph — the
+ *  policy didn't succeed at patching, but Fleet handled it deliberately.
+ *  Red outline for other failures, green for successes. */
 export const getAutomationStatusIcon = (
   activity: IPolicyAutomationActivity
 ): { name: "error-outline" | "success-outline"; color?: Colors } => {
   if (activity.details?.skipped_install) {
+    return { name: "error-outline", color: "ui-fleet-black-50" };
+  }
+  if (
+    activity.type === ActivityType.NotifiedEndUserBeforePatching &&
+    activity.status !== "error"
+  ) {
     return { name: "error-outline", color: "ui-fleet-black-50" };
   }
   return activity.status === "error"
@@ -77,6 +102,17 @@ export const getAutomationStatusIcon = (
 export const getDetailOutputText = (
   activity: IPolicyAutomationActivity
 ): string => {
+  // Success (or deferral) rows for the notify activity render a computed
+  // sentence keyed on time_before — the reminder swap 1hr→5min lands here.
+  // Failures fall through to activity.output so the notification script's raw
+  // output shows in the row preview; the modal fetches the script result and
+  // maps the exit code to a human sentence.
+  if (
+    activity.type === ActivityType.NotifiedEndUserBeforePatching &&
+    activity.status !== "error"
+  ) {
+    return getNotifiedSentence(activity.details?.time_before);
+  }
   if (activity.status === "error" && activity.details?.error_response) {
     return activity.details.error_response;
   }

--- a/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/helpers.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/helpers.tsx
@@ -2,6 +2,8 @@ import { ActivityType } from "interfaces/activity";
 import { IPolicyAutomationActivity } from "interfaces/policy";
 import { Colors } from "styles/var/colors";
 
+import { getAutomationNotifiedSentence } from "components/ActivityDetails/NotifyBeforePatchingDetailsModal/helpers";
+
 const withName = (base: string, name?: string) =>
   name ? `${base} (${name})` : base;
 
@@ -11,11 +13,6 @@ const getNotifySoftwareName = (
   details: IPolicyAutomationActivity["details"] | undefined
 ): string | undefined =>
   details?.software_title || details?.software_titles?.[0];
-
-const getNotifiedSentence = (timeBefore?: number): string => {
-  const label = timeBefore === 300 ? "5 minutes" : "1 hour";
-  return `End user was notified. Patch will be forced in ${label}. If the host is offline when a patch should be forced, Fleet notifies the end user again when it comes back online and patches it after 1 hour.`;
-};
 
 /** Label for the "Automation" column. */
 export const getAutomationRunDisplayName = (
@@ -94,7 +91,7 @@ export const getDetailOutputText = (
     activity.type === ActivityType.NotifiedEndUserBeforePatching &&
     activity.status !== "error"
   ) {
-    return getNotifiedSentence(activity.details?.time_before);
+    return getAutomationNotifiedSentence(activity.details?.time_before);
   }
   if (activity.status === "error" && activity.details?.error_response) {
     return activity.details.error_response;

--- a/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/helpers.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/helpers.tsx
@@ -73,7 +73,7 @@ export const getAutomationStatusIcon = (
   }
   if (
     activity.type === ActivityType.NotifiedEndUserBeforePatching &&
-    activity.status !== "error"
+    activity.status === "success"
   ) {
     return { name: "error-outline", color: "ui-fleet-black-50" };
   }
@@ -89,7 +89,7 @@ export const getDetailOutputText = (
   // Notify success/deferral: computed sentence keyed on time_before.
   if (
     activity.type === ActivityType.NotifiedEndUserBeforePatching &&
-    activity.status !== "error"
+    activity.status === "success"
   ) {
     return getAutomationNotifiedMessage(activity.details?.time_before);
   }

--- a/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/helpers.tsx
+++ b/frontend/pages/policies/details/components/PolicyAutomationsActivitiesTable/helpers.tsx
@@ -36,7 +36,7 @@ export const getAutomationRunDisplayName = (
       // deferred because the app was open — not a failure. Label it distinctly,
       // matching the activity feed and install-details treatment.
       if (details?.skipped_install) {
-        return withName("Patch skipped", details?.software_title);
+        return withName("Install skipped", details?.software_title);
       }
       return withName(
         failed ? "Software failed" : "Software installed",
@@ -44,7 +44,7 @@ export const getAutomationRunDisplayName = (
       );
     case ActivityType.NotifiedEndUserBeforePatching:
       return withName(
-        failed ? "Failed to notify" : "End user notified",
+        failed ? "Failed to notify" : "Notified end user",
         getNotifySoftwareName(details)
       );
     case ActivityType.RanScript:

--- a/frontend/test/handlers/software-handlers.ts
+++ b/frontend/test/handlers/software-handlers.ts
@@ -122,7 +122,24 @@ export const getSoftwareInstallHandlerAppOpen = http.get(
         status: "failed_install",
         output: "",
         post_install_script_output: "",
-        pre_install_query_output: "The app was open\nInstall stopped",
+        pre_install_query_output:
+          "Query didn't return result\nThe app was open.",
+      }),
+    });
+  }
+);
+
+export const getSoftwareInstallHandlerNotifyBeforePatchingSkip = http.get(
+  baseUrl("/software/install/:install_uuid/results"),
+  ({ params }) => {
+    return HttpResponse.json({
+      results: createMockSoftwareInstallResult({
+        install_uuid: params.install_uuid as string,
+        status: "failed_install",
+        output: "",
+        post_install_script_output: "",
+        pre_install_query_output:
+          "Query didn't return result\nThe app was open. Fleet notifies the end user 1 hour before the patch is forced.",
       }),
     });
   }

--- a/frontend/test/handlers/software-handlers.ts
+++ b/frontend/test/handlers/software-handlers.ts
@@ -123,7 +123,7 @@ export const getSoftwareInstallHandlerAppOpen = http.get(
         output: "",
         post_install_script_output: "",
         pre_install_query_output:
-          "Query didn't return result\nThe app was open.",
+          "Query didn't return result or failed\nThe app was open.",
       }),
     });
   }
@@ -139,7 +139,7 @@ export const getSoftwareInstallHandlerNotifyBeforePatchingSkip = http.get(
         output: "",
         post_install_script_output: "",
         pre_install_query_output:
-          "Query didn't return result\nThe app was open. Fleet notifies the end user 1 hour before the patch is forced.",
+          "Query didn't return result or failed\nThe app was open. Fleet notifies the end user 1 hour before the patch is forced.",
       }),
     });
   }


### PR DESCRIPTION
## Issue
Closes #50915

## Description
- Interface: added `notified_end_user_before_patching` to `ActivityType` and its payload fields (`install_at`, `install_skipped_when_app_open`, `patch_notification_uuid`, `policy_ids`, `pre_install_query_output`, `software_titles`, `time_before`) to `IActivityDetails`. One type covers success and failure; `status` distinguishes them.
- Global + host activity feed: new sentence variants driven by `time_before` (3600 → `1 hour`, 300 → `5 minutes`) with title truncation past three apps (`… and N more apps`). Host variant drops the host name and ends with `on this host.`
- Notify details modal: `NotifyBeforePatchingDetailsModal` fetches the notification script's result and picks copy from the exit code per the spec table (deferred, offline, screen locked, Fleet Desktop missing, etc.). Dispatcher-caught deferrals arrive with no `script_execution_id` and short-circuit the fetch — same sentence, no wasted request.
- Install-skip divergence (`SoftwareInstallDetailsModal`): now trusts the BE-supplied `pre_install_query_output` so the extra `Fleet notifies the end user 1 hour before the patch is forced.` sentence renders in the pre-install output for `notify_before_patching` skips. Legacy hardcode kept as a fallback only when the payload is empty.
- Automation runs table: new `End user notified` (grey `error-outline` — Fleet handled it deliberately, not a failure) and `Failed to notify` (red) rows. Success row's Details column computes the sentence from `time_before`; failure row falls through to `activity.output` so the raw notification-script output previews and the modal handles the exit-code sentence.

## Screenrecording
No E2E walkthrough since BE isn't done, but here's FE

https://fleetdm.zoom.us/clips/share/5HpD2jwGS_SjSLEty1VsVw

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added activity tracking for notifying end users before software patching.
  - Added notification status messages, reminder timing, affected software, and host details.
  - Added expandable details with notification scripts, output, and relevant guidance links.
  - Added notification activity details to dashboard, host, and policy activity views.
- **Bug Fixes**
  - Improved skipped-install messaging to distinguish notification-based skips from “patch when closed” skips.
  - Preserved pre-install query output when available.
- **Tests**
  - Expanded coverage for successful, failed, deferred, and skipped notification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->