### PR TITLE
Fix fleetd package installs overwriting user-provided osquery.flags

### DIFF
--- a/orbit/changes/50720-flagfile-overwrite
+++ b/orbit/changes/50720-flagfile-overwrite
@@ -1,0 +1,1 @@
+* Fixed fleetd package installs silently overwriting user-provided `osquery.flags` with an empty file when the package was built without `--osquery-flagfile`.

--- a/orbit/pkg/packaging/packaging.go
+++ b/orbit/pkg/packaging/packaging.go
@@ -362,16 +362,11 @@ func writeMacOSSecret(opt Options, orbitRoot string) error {
 }
 
 func writeOsqueryFlagfile(opt Options, orbitRoot string) error {
-	path := filepath.Join(orbitRoot, "osquery.flags")
-
 	if opt.OsqueryFlagfile == "" {
-		// Write empty flagfile
-		if err := os.WriteFile(path, []byte(""), constant.DefaultFileMode); err != nil {
-			return fmt.Errorf("write empty flagfile: %w", err)
-		}
-
 		return nil
 	}
+
+	path := filepath.Join(orbitRoot, "osquery.flags")
 
 	if err := file.Copy(opt.OsqueryFlagfile, path, constant.DefaultFileMode); err != nil {
 		return fmt.Errorf("copy flagfile: %w", err)

--- a/orbit/pkg/packaging/packaging_test.go
+++ b/orbit/pkg/packaging/packaging_test.go
@@ -1,0 +1,47 @@
+package packaging
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWriteOsqueryFlagfile_OverwritesExistingFlags reproduces
+// https://github.com/fleetdm/fleet/issues/50720
+//
+// When a fleetd package is built WITHOUT --osquery-flagfile, the function
+// writes an empty osquery.flags into the package payload.  Installing that
+// package over an existing install silently replaces whatever flags the
+// operator had previously configured.
+func TestWriteOsqueryFlagfile_OverwritesExistingFlags(t *testing.T) {
+	orbitRoot := t.TempDir()
+	flagfilePath := filepath.Join(orbitRoot, "osquery.flags")
+
+	// ── Step 1: simulate an initial install that shipped real flags ──
+	// (equivalent to: fleetctl package --osquery-flagfile flagfile.txt)
+	srcFlagfile := filepath.Join(t.TempDir(), "flagfile.txt")
+	originalContent := "--verbose=true\n--extensions_autoload=/opt/ext/autoload.conf\n"
+	require.NoError(t, os.WriteFile(srcFlagfile, []byte(originalContent), 0o644))
+
+	err := writeOsqueryFlagfile(Options{OsqueryFlagfile: srcFlagfile}, orbitRoot)
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(flagfilePath)
+	require.NoError(t, err)
+	assert.Equal(t, originalContent, string(got),
+		"after first install the flagfile should contain the operator's flags")
+
+	// ── Step 2: simulate a second install built WITHOUT --osquery-flagfile ──
+	// This is the bug: the empty-flagfile branch overwrites the existing file.
+	err = writeOsqueryFlagfile(Options{OsqueryFlagfile: ""}, orbitRoot)
+	require.NoError(t, err)
+
+	got, err = os.ReadFile(flagfilePath)
+	require.NoError(t, err)
+
+	assert.Equal(t, originalContent, string(got),
+		"osquery.flags must not be overwritten when no flagfile is supplied")
+}


### PR DESCRIPTION
**Related issue:** Resolves https://github.com/fleetdm/fleet/issues/50720

## Problem

When Fleet server pushes a fleetd upgrade built without `--osquery-flagfile`, the packager writes an empty `osquery.flags` into the payload, which the installer extracts over the existing file on disk, silently wiping the admin's custom flags.

```mermaid
sequenceDiagram
    participant Admin
    participant Host as macOS host

    Admin->>Host: Install fleetd.pkg with custom osquery flags
    Note over Host: ✅ /opt/orbit/osquery.flags has flags, extensions load

    Admin->>Host: Fleet pushes fleetd upgrade (no --osquery-flagfile)
    Note over Host: ❌ osquery.flags overwritten with empty file, extensions gone
```

## Fix

Skip writing `osquery.flags` entirely when no flagfile is supplied, so the existing file on disk is preserved. Mirrors the guard `writeMacOSSecret` already uses for the same problem. Safe because Orbit handles a missing `osquery.flags` gracefully.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `orbit/changes/`.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops

## Testing

- [x] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually

## fleetd/orbit/Fleet Desktop

- [x] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [x] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))