### PR TITLE
Fix ActionsDropdown icon-trigger menu overlapping its button

### DIFF
--- a/frontend/components/ActionsDropdown/ActionsDropdown.tsx
+++ b/frontend/components/ActionsDropdown/ActionsDropdown.tsx
@@ -357,6 +357,21 @@ const ActionsDropdown = ({
         opacity: 0.5,
       }),
     }),
+    // With the Control nulled out, react-select's container collapses to 0x0
+    // and, as a flex item, sits vertically centered against the trigger button
+    // — so the menu's `top: 100%` lands mid-button.
+    // Stretch the container over the button instead, so the menu hangs off the button's
+    // edge in either placement.
+    // Pointer events are off so the overlay can't swallow the trigger's clicks;
+    // the menu turns them back on.
+    container: (provided) => ({
+      ...provided,
+      ...(hasIconTrigger && {
+        position: "absolute",
+        inset: 0,
+        pointerEvents: "none",
+      }),
+    }),
     menu: (provided) => ({
       ...provided,
       backgroundColor: COLORS["core-fleet-white"],
@@ -372,7 +387,11 @@ const ActionsDropdown = ({
       left: getLeftMenuAlign(menuAlign),
       right: getRightMenuAlign(menuAlign),
       animation: "fade-in 150ms ease-out",
-      ...(hasIconTrigger && { marginTop: "4px" }),
+      ...(hasIconTrigger && {
+        marginTop: "1px",
+        marginBottom: "1px",
+        pointerEvents: "auto",
+      }),
     }),
     // zIndex 999 (document-portal tier) so the portaled menu clears
     // .site-nav-container and Modal — ActionsDropdown can render inside a
@@ -416,8 +435,12 @@ const ActionsDropdown = ({
     }),
   };
 
+  const wrapperClassnames = classnames(`${baseClass}__wrapper`, {
+    [`${baseClass}__wrapper--icon-trigger`]: hasIconTrigger,
+  });
+
   return (
-    <div className={`${baseClass}__wrapper`} ref={wrapperRef}>
+    <div className={wrapperClassnames} ref={wrapperRef}>
       {isPrimary && renderPrimaryButton()}
       {hasIconTrigger && renderIconTriggerButton()}
       <Select<IDropdownOption, false>

--- a/frontend/components/ActionsDropdown/_styles.scss
+++ b/frontend/components/ActionsDropdown/_styles.scss
@@ -10,6 +10,12 @@
   display: flex;
   align-items: center;
 
+  // Anchors the absolutely positioned select container to the trigger button
+  // (see the `container` style in ActionsDropdown.tsx).
+  &--icon-trigger {
+    position: relative;
+  }
+
   button .children-wrapper {
     gap: $pad-small;
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #51393

The hosts page settings menu opens on top of its gear button. With react-select's Control nulled out for the icon trigger, the select container collapses to 0x0 and, as a vertically centered flex item, anchors the menu to the middle of the button rather than its bottom edge.

## Testing

- [x] QA'd all new/changed functionality manually

### Before

<img width="173" height="179" alt="Screenshot 2026-08-18 at 6 54 31 PM" src="https://github.com/user-attachments/assets/2415f9d5-d781-4d1d-b440-875a6524f1f9" />


### After

<img width="191" height="198" alt="Screenshot 2026-08-18 at 6 52 36 PM" src="https://github.com/user-attachments/assets/c6d97a00-4a18-4936-a66d-11d102cdfb99" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved icon-triggered dropdown positioning and interaction behavior.
  * Ensured dropdown menus align correctly with their trigger buttons.
  * Prevented the underlying select container from interfering with trigger interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->