### PR TITLE
List and view results of custom Android commands

### DIFF
--- a/changes/50733-android-custom-commands-list-results
+++ b/changes/50733-android-custom-commands-list-results
@@ -1,0 +1,1 @@
+- Added support for listing and viewing results of Android custom MDM commands via the API and fleetctl CLI.

--- a/cmd/fleetctl/fleetctl/mdm.go
+++ b/cmd/fleetctl/fleetctl/mdm.go
@@ -91,7 +91,7 @@ func mdmRunCommand() *cli.Command {
 			var (
 				hostUUIDs     []string
 				notFoundCount int
-				mdmPlatform   string // "darwin" or "windows"
+				mdmPlatform   string // "darwin", "windows", or "android"
 			)
 			for _, ident := range hostIdents {
 				host, err := client.HostByIdentifier(ident)
@@ -112,8 +112,11 @@ func mdmRunCommand() *cli.Command {
 				}
 
 				mdmHostPlatform := fleet.ClassicMDMPlatform(host.Platform)
+				if mdmHostPlatform == "" && fleet.IsAndroidPlatform(host.Platform) {
+					mdmHostPlatform = "android"
+				}
 				if mdmHostPlatform != mdmPlatform && mdmPlatform != "" {
-					return errors.New(`Command can't run on hosts with different platforms. Make sure the hosts specified in the "hosts" flag are either all macOS or all Windows hosts.`)
+					return errors.New(`Command can't run on hosts with different platforms. Make sure the hosts specified in the "hosts" flag are either all macOS, all Windows, or all Android hosts.`)
 				}
 				mdmPlatform = mdmHostPlatform
 
@@ -131,8 +134,11 @@ func mdmRunCommand() *cli.Command {
 
 			result, err := client.RunMDMCommand(hostUUIDs, payload, mdmPlatform)
 			if err != nil {
-				if errors.Is(err, service.ErrMissingLicense) && mdmPlatform == "windows" {
-					return errors.New(fleet.WindowsMDMRequiresPremiumCmdMessage)
+				if errors.Is(err, service.ErrMissingLicense) {
+					if mdmPlatform == "windows" {
+						return errors.New(fleet.WindowsMDMRequiresPremiumCmdMessage)
+					}
+					return errors.New("This command requires a Fleet Premium license.")
 				}
 
 				var sce kithttp.StatusCoder

--- a/cmd/fleetctl/fleetctl/mdm.go
+++ b/cmd/fleetctl/fleetctl/mdm.go
@@ -37,7 +37,7 @@ func mdmRunCommand() *cli.Command {
 	return &cli.Command{
 		Name:    "run-command",
 		Aliases: []string{"run_command"},
-		Usage:   "Run a custom MDM command on macOS and Windows hosts.",
+		Usage:   "Run a custom MDM command on macOS, Windows, and Android hosts.",
 		Flags: []cli.Flag{
 			contextFlag(),
 			debugFlag(),
@@ -48,7 +48,7 @@ func mdmRunCommand() *cli.Command {
 			},
 			&cli.StringFlag{
 				Name:     "payload",
-				Usage:    "A path to an XML file containing the raw MDM request payload.",
+				Usage:    "A path to a file containing the raw MDM request payload (XML for macOS/Windows, JSON for Android).",
 				Required: true,
 			},
 		},
@@ -134,10 +134,10 @@ func mdmRunCommand() *cli.Command {
 
 			result, err := client.RunMDMCommand(hostUUIDs, payload, mdmPlatform)
 			if err != nil {
-				if errors.Is(err, service.ErrMissingLicense) {
-					if mdmPlatform == "windows" {
-						return errors.New(fleet.WindowsMDMRequiresPremiumCmdMessage)
-					}
+				if errors.Is(err, service.ErrMissingLicense) && mdmPlatform == "windows" {
+					return errors.New(fleet.WindowsMDMRequiresPremiumCmdMessage)
+				}
+				if errors.Is(err, service.ErrMissingLicense) && mdmPlatform == "android" {
 					return errors.New("This command requires a Fleet Premium license.")
 				}
 

--- a/cmd/fleetctl/fleetctl/mdm.go
+++ b/cmd/fleetctl/fleetctl/mdm.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mdm/android"
 	"github.com/fleetdm/fleet/v4/server/service"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/urfave/cli/v2"
@@ -138,7 +139,7 @@ func mdmRunCommand() *cli.Command {
 					return errors.New(fleet.WindowsMDMRequiresPremiumCmdMessage)
 				}
 				if errors.Is(err, service.ErrMissingLicense) && mdmPlatform == "android" {
-					return errors.New("This command requires a Fleet Premium license.")
+					return errors.New(android.AndroidMDMRequiresPremiumCmdMessage)
 				}
 
 				var sce kithttp.StatusCoder

--- a/server/datastore/mysql/android.go
+++ b/server/datastore/mysql/android.go
@@ -1236,7 +1236,12 @@ func (ds *Datastore) GetMDMAndroidCommandResults(ctx context.Context, commandUUI
 		SELECT
 			c.host_uuid,
 			c.command_uuid,
-			c.status,
+			CASE c.status
+				WHEN 'pending' THEN 'Pending'
+				WHEN 'acknowledged' THEN 'Acknowledged'
+				WHEN 'error' THEN 'Error'
+				ELSE c.status
+			END AS status,
 			c.updated_at,
 			c.command_type AS request_type,
 			c.raw_command  AS payload,

--- a/server/datastore/mysql/android.go
+++ b/server/datastore/mysql/android.go
@@ -1229,6 +1229,34 @@ func (ds *Datastore) ClearPasscodeHostViaAndroidMDM(ctx context.Context, host *f
 	return ds.issueAndroidHostMDMRef(ctx, host, cmd, "clear_passcode_ref")
 }
 
+// GetMDMAndroidCommandResults returns the results for an Android command identified by commandUUID.
+// If hostUUID is non-empty, results are filtered to that host.
+func (ds *Datastore) GetMDMAndroidCommandResults(ctx context.Context, commandUUID string, hostUUID string) ([]*fleet.MDMCommandResult, error) {
+	query := `
+		SELECT
+			c.host_uuid,
+			c.command_uuid,
+			c.status,
+			c.updated_at,
+			c.command_type AS request_type,
+			c.raw_command  AS payload,
+			c.raw_result   AS result
+		FROM mdm_android_commands c
+		WHERE c.command_uuid = ?
+	`
+	args := []any{commandUUID}
+	if hostUUID != "" {
+		query += ` AND c.host_uuid = ?`
+		args = append(args, hostUUID)
+	}
+
+	var results []*fleet.MDMCommandResult
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &results, query, args...); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "get android command results")
+	}
+	return results, nil
+}
+
 // InsertMDMAndroidCommand inserts a row into mdm_android_commands without updating host_mdm_actions.
 // Used for custom commands that have no corresponding UI state (lock/wipe/passcode refs).
 func (ds *Datastore) InsertMDMAndroidCommand(ctx context.Context, cmd *android.MDMAndroidCommand) error {

--- a/server/datastore/mysql/mdm.go
+++ b/server/datastore/mysql/mdm.go
@@ -38,12 +38,13 @@ SELECT CASE
 	WHEN EXISTS (SELECT 1 FROM nano_commands WHERE command_uuid = ?) THEN 'darwin'
 	WHEN EXISTS (SELECT 1 FROM windows_mdm_commands WHERE command_uuid = ?) THEN 'windows'
 	WHEN EXISTS (SELECT 1 FROM mdm_android_commands WHERE command_uuid = ?) THEN 'android'
+	WHEN EXISTS (SELECT 1 FROM host_vpp_software_installs WHERE command_uuid = ? AND platform = 'android') THEN 'android'
 	ELSE ''
 END AS platform
 `
 
 	var p string
-	if err := sqlx.GetContext(ctx, ds.reader(ctx), &p, stmt, commandUUID, commandUUID, commandUUID); err != nil {
+	if err := sqlx.GetContext(ctx, ds.reader(ctx), &p, stmt, commandUUID, commandUUID, commandUUID, commandUUID); err != nil {
 		return "", err
 	}
 	if p == "" {
@@ -333,9 +334,13 @@ WHERE ` + whereTeam
 		)
 	}
 
-	if (dest[0].Platform == "windows" || fleet.IsAndroidPlatform(dest[0].Platform)) && len(listOpts.Filters.CommandStatuses) > 0 {
-		return nil, nil, nil, &fleet.BadRequestError{
-			Message: `Currently, "command_status" filter is only available for macOS, iOS, and iPadOS hosts.`,
+	if len(listOpts.Filters.CommandStatuses) > 0 {
+		for _, h := range dest {
+			if !fleet.ClassicMDMSupported(h.Platform) || h.Platform == "windows" {
+				return nil, nil, nil, &fleet.BadRequestError{
+					Message: `Currently, "command_status" filter is only available for macOS, iOS, and iPadOS hosts.`,
+				}
+			}
 		}
 	}
 

--- a/server/datastore/mysql/mdm.go
+++ b/server/datastore/mysql/mdm.go
@@ -37,7 +37,7 @@ func (ds *Datastore) GetMDMCommandPlatform(ctx context.Context, commandUUID stri
 SELECT CASE
 	WHEN EXISTS (SELECT 1 FROM nano_commands WHERE command_uuid = ?) THEN 'darwin'
 	WHEN EXISTS (SELECT 1 FROM windows_mdm_commands WHERE command_uuid = ?) THEN 'windows'
-	WHEN EXISTS (SELECT 1 FROM host_vpp_software_installs WHERE command_uuid = ? AND platform = 'android') THEN 'android'
+	WHEN EXISTS (SELECT 1 FROM mdm_android_commands WHERE command_uuid = ?) THEN 'android'
 	ELSE ''
 END AS platform
 `
@@ -53,7 +53,7 @@ END AS platform
 	return p, nil
 }
 
-// getMDMCommandsSubqueries returns the Apple and Windows command-list
+// getMDMCommandsSubqueries returns the Apple, Windows, and Android command-list
 // sub-statements separately. The caller is responsible for wrapping each
 // branch with the per-branch pagination (team filter, request_type filter,
 // cursor predicate, ORDER BY, inner LIMIT) before merging them with
@@ -62,7 +62,7 @@ END AS platform
 //
 // These subqueries are only used for the all-hosts listing; host-scoped
 // requests go through listMDMCommandsByHostIdentifier instead.
-func getMDMCommandsSubqueries() (appleStmt, windowsStmt string) {
+func getMDMCommandsSubqueries() (appleStmt, windowsStmt, androidStmt string) {
 	// Apple branch joins the underlying nano_* tables directly instead of
 	// going through the nano_view_queue VIEW. The view bakes
 	// "ORDER BY q.priority DESC, q.created_at" into its definition, which
@@ -134,7 +134,22 @@ WHERE NOT EXISTS (
 )
 `
 
-	return appleStmt, windowsStmt
+	androidStmt = `
+SELECT
+    c.host_uuid,
+    c.command_uuid,
+    c.status,
+    c.updated_at,
+    c.command_type AS request_type,
+    h.hostname,
+    h.team_id,
+    NULL AS name
+FROM mdm_android_commands c
+INNER JOIN hosts h ON h.uuid = c.host_uuid
+WHERE TRUE
+`
+
+	return appleStmt, windowsStmt, androidStmt
 }
 
 // mdmCommandsOrderAllowlist is the closed set of order_key values accepted
@@ -154,10 +169,10 @@ var mdmCommandsOrderAllowlist = common_mysql.OrderKeyAllowlist{
 // single-command lookups; the list-commands path builds its own form
 // (see getMDMCommandsSubqueries).
 func getCombinedMDMCommandsQuery() string {
-	appleStmt, windowsStmt := getMDMCommandsSubqueries()
+	appleStmt, windowsStmt, androidStmt := getMDMCommandsSubqueries()
 	return fmt.Sprintf(
-		`SELECT * FROM ((%s) UNION ALL (%s)) as combined_commands WHERE `,
-		appleStmt, windowsStmt,
+		`SELECT * FROM ((%s) UNION ALL (%s) UNION ALL (%s)) as combined_commands WHERE `,
+		appleStmt, windowsStmt, androidStmt,
 	)
 }
 
@@ -179,7 +194,7 @@ func (ds *Datastore) ListMDMCommands(
 		listOpts.OrderDirection = fleet.OrderDescending
 	}
 
-	appleStmt, windowsStmt := getMDMCommandsSubqueries()
+	appleStmt, windowsStmt, androidStmt := getMDMCommandsSubqueries()
 
 	// Per-branch pagination: without this, the UNION ALL would materialize every command on
 	// both sides before pagination, which times out at scale (#44170).
@@ -205,7 +220,7 @@ func (ds *Datastore) ListMDMCommands(
 
 	// Each branch needs its own params slice; sqlx.SelectContext binds
 	// placeholders left-to-right across the merged statement.
-	var appleParams, windowsParams []any
+	var appleParams, windowsParams, androidParams []any
 	var err error
 	if appleStmt, appleParams, err = paginateBranch(appleStmt, appleParams); err != nil {
 		return nil, nil, nil, ctxerr.Wrap(ctx, err, "paginate apple commands branch")
@@ -213,13 +228,17 @@ func (ds *Datastore) ListMDMCommands(
 	if windowsStmt, windowsParams, err = paginateBranch(windowsStmt, windowsParams); err != nil {
 		return nil, nil, nil, ctxerr.Wrap(ctx, err, "paginate windows commands branch")
 	}
+	if androidStmt, androidParams, err = paginateBranch(androidStmt, androidParams); err != nil {
+		return nil, nil, nil, ctxerr.Wrap(ctx, err, "paginate android commands branch")
+	}
 
 	mergedStmt := fmt.Sprintf(
-		"SELECT * FROM ((%s) UNION ALL (%s)) AS combined_commands",
-		appleStmt, windowsStmt,
+		"SELECT * FROM ((%s) UNION ALL (%s) UNION ALL (%s)) AS combined_commands",
+		appleStmt, windowsStmt, androidStmt,
 	)
 	mergedParams := append([]any{}, appleParams...)
 	mergedParams = append(mergedParams, windowsParams...)
+	mergedParams = append(mergedParams, androidParams...)
 
 	// Outer pagination: ORDER BY + LIMIT + OFFSET only. The cursor
 	// predicate is already applied inside each branch, so clear After
@@ -324,9 +343,9 @@ WHERE ` + whereTeam
 	// we can optimize the query by skipping the UNION ALL and using a single query targeted to the
 	// platform.
 
-	var appleStmt, winStmt string
-	var appleParams, winParams []any
-	var appleUUIDs, winUUIDs []string
+	var appleStmt, winStmt, androidStmt string
+	var appleParams, winParams, androidParams []any
+	var appleUUIDs, winUUIDs, androidUUIDs []string
 	byUUID := make(map[string]fleet.Host, len(dest)) // map UUID to host so that we can loop over command results to add hostname and team info and avoid joining hosts to commands in DB
 	for _, h := range dest {
 		if prev, ok := byUUID[h.UUID]; ok {
@@ -337,11 +356,13 @@ WHERE ` + whereTeam
 			)
 		}
 		byUUID[h.UUID] = h
-		switch fleet.ClassicMDMPlatform(h.Platform) {
-		case "darwin":
+		switch {
+		case fleet.ClassicMDMPlatform(h.Platform) == "darwin":
 			appleUUIDs = append(appleUUIDs, h.UUID)
-		case "windows":
+		case fleet.ClassicMDMPlatform(h.Platform) == "windows":
 			winUUIDs = append(winUUIDs, h.UUID)
+		case fleet.IsAndroidPlatform(h.Platform):
+			androidUUIDs = append(androidUUIDs, h.UUID)
 		}
 	}
 
@@ -459,32 +480,63 @@ WHERE
 		}
 	}
 
-	var listStmt, countStmt string
-	var params []any
-	// Wrap in `SELECT * FROM (...) u WHERE TRUE` so the cursor and ORDER BY
+	if len(androidUUIDs) > 0 {
+		androidParams = []any{androidUUIDs}
+		androidStmt = `
+SELECT
+    c.host_uuid,
+    c.command_uuid,
+    c.updated_at,
+    c.status,
+    CASE c.status
+        WHEN 'pending' THEN 'pending'
+        WHEN 'acknowledged' THEN 'ran'
+        WHEN 'error' THEN 'failed'
+        ELSE 'pending'
+    END AS command_status,
+    c.command_type AS request_type,
+    NULL AS name,
+    h.hostname
+FROM mdm_android_commands c
+INNER JOIN hosts h ON h.uuid = c.host_uuid
+WHERE c.host_uuid IN (?)`
+
+		if listOpts.Filters.RequestType != "" {
+			androidStmt += " AND c.command_type = ?"
+			androidParams = append(androidParams, listOpts.Filters.RequestType)
+		}
+		androidStmt, androidParams, err = sqlx.In(androidStmt, androidParams...)
+		if err != nil {
+			return nil, nil, nil, ctxerr.Wrap(ctx, err, "prepare query to list MDM commands for Android devices")
+		}
+	}
+
 	// predicates resolve against the unambiguous `u` projection — the inner
 	// branches join multiple tables that all expose `command_uuid` / `updated_at`.
 	// `WHERE TRUE` is required because the cursor helper picks AND vs WHERE by
 	// substring-matching "where", picks AND from the inner branches, and would
 	// otherwise emit a dangling `AND`. See https://github.com/fleetdm/fleet/issues/44422.
-	switch {
-	case len(appleUUIDs) > 0 && len(winUUIDs) > 0:
-		listStmt = fmt.Sprintf(`SELECT * FROM ((%s) UNION ALL (%s)) u WHERE TRUE`,
-			appleStmt, winStmt)
-		countStmt = fmt.Sprintf(`SELECT COUNT(1) FROM ((%s) UNION ALL (%s)) u`, appleStmt, winStmt)
+	var branches []string
+	var params []any
+	if len(appleUUIDs) > 0 {
+		branches = append(branches, "("+appleStmt+")")
 		params = append(params, appleParams...)
+	}
+	if len(winUUIDs) > 0 {
+		branches = append(branches, "("+winStmt+")")
 		params = append(params, winParams...)
-	case len(appleUUIDs) > 0:
-		listStmt = `SELECT * FROM (` + appleStmt + `) u WHERE TRUE`
-		countStmt = `SELECT COUNT(1) FROM (` + appleStmt + `) u`
-		params = appleParams
-	case len(winUUIDs) > 0:
-		listStmt = `SELECT * FROM (` + winStmt + `) u WHERE TRUE`
-		countStmt = `SELECT COUNT(1) FROM (` + winStmt + `) u`
-		params = winParams
-	default:
+	}
+	if len(androidUUIDs) > 0 {
+		branches = append(branches, "("+androidStmt+")")
+		params = append(params, androidParams...)
+	}
+	if len(branches) == 0 {
 		return []*fleet.MDMCommand{}, nil, nil, nil
 	}
+
+	unionAll := strings.Join(branches, " UNION ALL ")
+	listStmt := fmt.Sprintf(`SELECT * FROM (%s) u WHERE TRUE`, unionAll)
+	countStmt := fmt.Sprintf(`SELECT COUNT(1) FROM (%s) u`, unionAll)
 
 	// TODO: Maybe move this to the service method? What about pagination metadata?
 	if listOpts.OrderKey == "" {

--- a/server/datastore/mysql/mdm.go
+++ b/server/datastore/mysql/mdm.go
@@ -333,7 +333,7 @@ WHERE ` + whereTeam
 		)
 	}
 
-	if dest[0].Platform == "windows" && len(listOpts.Filters.CommandStatuses) > 0 {
+	if (dest[0].Platform == "windows" || fleet.IsAndroidPlatform(dest[0].Platform)) && len(listOpts.Filters.CommandStatuses) > 0 {
 		return nil, nil, nil, &fleet.BadRequestError{
 			Message: `Currently, "command_status" filter is only available for macOS, iOS, and iPadOS hosts.`,
 		}

--- a/server/datastore/mysql/mdm_test.go
+++ b/server/datastore/mysql/mdm_test.go
@@ -68,6 +68,8 @@ func TestMDMShared(t *testing.T) {
 		{"TestProfileHasACMEPayloadForCommand", testProfileHasACMEPayloadForCommand},
 		{"TestOktaCACleanupTargetForInstallCommand", testOktaCACleanupTargetForInstallCommand},
 		{"TestRenewMDMManagedCertificatesNullType", testRenewMDMManagedCertificatesNullType},
+		{"TestGetMDMCommandPlatformAndroid", testGetMDMCommandPlatformAndroid},
+		{"TestListMDMCommandsAndroid", testListMDMCommandsAndroid},
 	}
 
 	for _, c := range cases {
@@ -5989,4 +5991,93 @@ func testListMDMCommandsByHostIdentifier(t *testing.T, ds *Datastore) {
 		require.NoError(t, err)
 		require.Empty(t, commands)
 	})
+}
+
+func testGetMDMCommandPlatformAndroid(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	// Insert an Android command directly into mdm_android_commands.
+	cmdUUID := uuid.NewString()
+	_, err := ds.writer(ctx).ExecContext(ctx, `
+		INSERT INTO mdm_android_commands (command_uuid, host_uuid, operation_name, command_type, status)
+		VALUES (?, ?, ?, ?, ?)`,
+		cmdUUID, "host-uuid-platform", "enterprises/E/devices/D/operations/plat-1", "REBOOT", "pending")
+	require.NoError(t, err)
+
+	p, err := ds.GetMDMCommandPlatform(ctx, cmdUUID)
+	require.NoError(t, err)
+	assert.Equal(t, "android", p)
+
+	// Non-existent command returns not found.
+	_, err = ds.GetMDMCommandPlatform(ctx, "does-not-exist")
+	require.Error(t, err)
+	require.True(t, fleet.IsNotFound(err))
+}
+
+func testListMDMCommandsAndroid(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	// Create an Android host.
+	host, err := ds.NewHost(ctx, &fleet.Host{
+		Hostname:      "android-list-test",
+		OsqueryHostID: new("osquery-android-list"),
+		NodeKey:       new("node-key-android-list"),
+		UUID:          uuid.NewString(),
+		Platform:      "android",
+	})
+	require.NoError(t, err)
+
+	// Insert Android commands.
+	for i, cmdType := range []string{"REBOOT", "LOCK", "REBOOT"} {
+		status := "pending"
+		if i == 0 {
+			status = "acknowledged"
+		}
+		_, err := ds.writer(ctx).ExecContext(ctx, `
+			INSERT INTO mdm_android_commands (command_uuid, host_uuid, operation_name, command_type, status)
+			VALUES (?, ?, ?, ?, ?)`,
+			uuid.NewString(), host.UUID,
+			fmt.Sprintf("enterprises/E/devices/D/operations/list-%d", i),
+			cmdType, status)
+		require.NoError(t, err)
+	}
+
+	// List by host identifier (host-scoped path).
+	cmds, _, _, err := ds.ListMDMCommands(ctx, fleet.TeamFilter{User: &fleet.User{GlobalRole: new("admin")}}, &fleet.MDMCommandListOptions{
+		Filters:     fleet.MDMCommandFilters{HostIdentifier: host.UUID},
+		ListOptions: fleet.ListOptions{PerPage: 10},
+	})
+	require.NoError(t, err)
+	require.Len(t, cmds, 3)
+
+	// Verify all commands belong to our host.
+	for _, cmd := range cmds {
+		assert.Equal(t, host.UUID, cmd.HostUUID)
+		assert.NotEmpty(t, cmd.CommandUUID)
+		assert.NotEmpty(t, cmd.RequestType)
+	}
+
+	// Filter by request type.
+	cmds, _, _, err = ds.ListMDMCommands(ctx, fleet.TeamFilter{User: &fleet.User{GlobalRole: new("admin")}}, &fleet.MDMCommandListOptions{
+		Filters:     fleet.MDMCommandFilters{HostIdentifier: host.UUID, RequestType: "LOCK"},
+		ListOptions: fleet.ListOptions{PerPage: 10},
+	})
+	require.NoError(t, err)
+	require.Len(t, cmds, 1)
+	assert.Equal(t, "LOCK", cmds[0].RequestType)
+
+	// List all commands (non-host-scoped path) — should include our Android commands.
+	cmds, _, _, err = ds.ListMDMCommands(ctx, fleet.TeamFilter{User: &fleet.User{GlobalRole: new("admin")}}, &fleet.MDMCommandListOptions{
+		ListOptions: fleet.ListOptions{PerPage: 100},
+	})
+	require.NoError(t, err)
+
+	// Find our Android commands in the results.
+	var androidCount int
+	for _, cmd := range cmds {
+		if cmd.HostUUID == host.UUID {
+			androidCount++
+		}
+	}
+	assert.Equal(t, 3, androidCount, "expected 3 Android commands in all-hosts listing")
 }

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -4067,6 +4067,10 @@ type AndroidDatastore interface {
 	// Used for custom commands that have no corresponding UI state (lock/wipe/passcode refs).
 	InsertMDMAndroidCommand(ctx context.Context, cmd *android.MDMAndroidCommand) error
 
+	// GetMDMAndroidCommandResults returns the results for an Android command identified by commandUUID.
+	// If hostUUID is non-empty, results are filtered to that host.
+	GetMDMAndroidCommandResults(ctx context.Context, commandUUID string, hostUUID string) ([]*MDMCommandResult, error)
+
 	// ClearHostMDMActions deletes the host_mdm_actions row for the given host. Called on re-enrollment so stale
 	// lock/wipe/clear-passcode state from a previous enrollment cycle does not bleed into the new one.
 	ClearHostMDMActions(ctx context.Context, hostID uint) error

--- a/server/mdm/android/android.go
+++ b/server/mdm/android/android.go
@@ -113,6 +113,11 @@ const (
 	MDMAndroidCommandTypeWipe          MDMAndroidCommandType = "WIPE"
 )
 
+// AndroidMDMRequiresPremiumCmdMessage is the error message displayed by fleetctl mdm
+// run-command when a Premium license is required for an Android command. Keep in sync
+// with the androidMDMPremiumCommands set in server/service/mdm.go.
+const AndroidMDMRequiresPremiumCmdMessage = "Missing or invalid license. LOCK and RESET_PASSWORD commands are available in Fleet Premium only."
+
 // MDMAndroidCommandStatus is the lifecycle state of an MDMAndroidCommand row.
 type MDMAndroidCommandStatus string
 

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -2028,6 +2028,8 @@ type ClearPasscodeHostViaAndroidMDMFunc func(ctx context.Context, host *fleet.Ho
 
 type InsertMDMAndroidCommandFunc func(ctx context.Context, cmd *android.MDMAndroidCommand) error
 
+type GetMDMAndroidCommandResultsFunc func(ctx context.Context, commandUUID string, hostUUID string) ([]*fleet.MDMCommandResult, error)
+
 type ClearHostMDMActionsFunc func(ctx context.Context, hostID uint) error
 
 type GetLatestAppleMDMCommandOfTypeFunc func(ctx context.Context, hostUUID string, commandType string) (*fleet.MDMCommand, error)
@@ -5344,6 +5346,9 @@ type DataStore struct {
 
 	InsertMDMAndroidCommandFunc        InsertMDMAndroidCommandFunc
 	InsertMDMAndroidCommandFuncInvoked bool
+
+	GetMDMAndroidCommandResultsFunc        GetMDMAndroidCommandResultsFunc
+	GetMDMAndroidCommandResultsFuncInvoked bool
 
 	ClearHostMDMActionsFunc        ClearHostMDMActionsFunc
 	ClearHostMDMActionsFuncInvoked bool
@@ -12825,6 +12830,13 @@ func (s *DataStore) InsertMDMAndroidCommand(ctx context.Context, cmd *android.MD
 	s.InsertMDMAndroidCommandFuncInvoked = true
 	s.mu.Unlock()
 	return s.InsertMDMAndroidCommandFunc(ctx, cmd)
+}
+
+func (s *DataStore) GetMDMAndroidCommandResults(ctx context.Context, commandUUID string, hostUUID string) ([]*fleet.MDMCommandResult, error) {
+	s.mu.Lock()
+	s.GetMDMAndroidCommandResultsFuncInvoked = true
+	s.mu.Unlock()
+	return s.GetMDMAndroidCommandResultsFunc(ctx, commandUUID, hostUUID)
 }
 
 func (s *DataStore) ClearHostMDMActions(ctx context.Context, hostID uint) error {

--- a/server/service/client_mdm.go
+++ b/server/service/client_mdm.go
@@ -341,8 +341,11 @@ func (c *Client) RunMDMCommand(hostUUIDs []string, rawCmd []byte, forPlatform st
 		prepareFn = c.prepareAppleMDMCommand
 	case "windows":
 		prepareFn = c.prepareWindowsMDMCommand
+	case "android":
+		// Android commands are JSON; base64-encode as-is (no XML preparation needed).
+		prepareFn = func(b []byte) ([]byte, error) { return b, nil }
 	default:
-		return nil, fmt.Errorf("Invalid platform %q. You can only run MDM commands on Windows or Apple hosts.", forPlatform)
+		return nil, fmt.Errorf("Invalid platform %q. You can only run MDM commands on Windows, Apple, or Android hosts.", forPlatform)
 	}
 
 	rawCmd, err := prepareFn(rawCmd)

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -27156,8 +27156,6 @@ func (s *integrationMDMTestSuite) TestAndroidCustomCommandsListAndResults() {
 	t := s.T()
 	ctx := t.Context()
 
-	const longCommandDuration = "315360000s"
-
 	enterpriseID, err := s.ds.CreateEnterprise(ctx, s.users["admin1"].ID)
 	require.NoError(t, err)
 	require.NoError(t, s.ds.UpdateEnterprise(ctx, &android.EnterpriseDetails{
@@ -27256,4 +27254,9 @@ func (s *integrationMDMTestSuite) TestAndroidCustomCommandsListAndResults() {
 	p, err := s.ds.GetMDMCommandPlatform(ctx, cmdUUID)
 	require.NoError(t, err)
 	assert.Equal(t, "android", p)
+
+	// Verify command_status filter is rejected for Android hosts.
+	res := s.DoRaw("GET", fmt.Sprintf("/api/latest/fleet/commands?host_identifier=%s&command_status=ran", hostUUID), nil, http.StatusBadRequest)
+	errMsg := extractServerErrorText(res.Body)
+	require.Contains(t, errMsg, `"command_status" filter is only available for macOS, iOS, and iPadOS hosts`)
 }

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -27223,7 +27223,7 @@ func (s *integrationMDMTestSuite) TestAndroidCustomCommandsListAndResults() {
 	var resultsResp getMDMCommandResultsResponse
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/commands/results?command_uuid=%s", cmdUUID), nil, http.StatusOK, &resultsResp)
 	require.Len(t, resultsResp.Results, 1)
-	assert.Equal(t, "pending", resultsResp.Results[0].Status)
+	assert.Equal(t, "Pending", resultsResp.Results[0].Status)
 	assert.Equal(t, "REBOOT", resultsResp.Results[0].RequestType)
 
 	// Deliver a Pub/Sub COMMAND ack.
@@ -27247,7 +27247,7 @@ func (s *integrationMDMTestSuite) TestAndroidCustomCommandsListAndResults() {
 	// Verify command results now show acknowledged with raw_result.
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/commands/results?command_uuid=%s", cmdUUID), nil, http.StatusOK, &resultsResp)
 	require.Len(t, resultsResp.Results, 1)
-	assert.Equal(t, "acknowledged", resultsResp.Results[0].Status)
+	assert.Equal(t, "Acknowledged", resultsResp.Results[0].Status)
 	assert.NotEmpty(t, resultsResp.Results[0].Result, "raw_result should be populated after Pub/Sub ack")
 
 	// Verify GetMDMCommandPlatform returns "android".

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -27148,3 +27148,112 @@ func (s *integrationMDMTestSuite) TestHostNameTemplateTransferTeamToNoTeam() {
 	require.NoError(t, err)
 	require.Nil(t, cmd)
 }
+
+// TestAndroidCustomCommandsListAndResults exercises the full API flow for Android custom commands:
+// send a command via POST /commands/run, verify it appears in GET /commands (list), deliver a
+// Pub/Sub ack, and verify GET /commands/results returns the stored result.
+func (s *integrationMDMTestSuite) TestAndroidCustomCommandsListAndResults() {
+	t := s.T()
+	ctx := t.Context()
+
+	const longCommandDuration = "315360000s"
+
+	enterpriseID, err := s.ds.CreateEnterprise(ctx, s.users["admin1"].ID)
+	require.NoError(t, err)
+	require.NoError(t, s.ds.UpdateEnterprise(ctx, &android.EnterpriseDetails{
+		Enterprise:  android.Enterprise{ID: enterpriseID, EnterpriseID: "custom-cmd-fake"},
+		SignupName:  "fake",
+		SignupToken: "value",
+		TopicID:     "yep",
+	}))
+
+	const pubsubToken = "test-android-custom-cmd-pubsub-token"
+	require.NoError(t, s.ds.InsertOrReplaceMDMConfigAsset(ctx, fleet.MDMConfigAsset{
+		Name:  fleet.MDMAssetAndroidPubSubToken,
+		Value: []byte(pubsubToken),
+	}))
+
+	var (
+		issueCallsMu sync.Mutex
+		issueCounter int
+	)
+	s.androidAPIClient.EnterprisesDevicesIssueCommandFunc = func(_ context.Context, deviceName string, cmd *androidmanagement.Command) (*androidmanagement.Operation, error) {
+		issueCallsMu.Lock()
+		defer issueCallsMu.Unlock()
+		issueCounter++
+		opName := fmt.Sprintf("%s/operations/custom-op-%d", deviceName, issueCounter)
+		return &androidmanagement.Operation{Name: opName}, nil
+	}
+
+	coboHostID := createAndroidHostForTest(t, s.ds, nil, true)
+
+	// Get the host UUID for API calls.
+	var hostResp getHostResponse
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d", coboHostID), nil, http.StatusOK, &hostResp)
+	hostUUID := hostResp.Host.UUID
+
+	// Send a custom REBOOT command via the API.
+	rebootJSON := `{"type":"REBOOT"}`
+	encoded := base64.StdEncoding.EncodeToString([]byte(rebootJSON))
+	var runResp runMDMCommandResponse
+	s.DoJSON("POST", "/api/latest/fleet/commands/run", &runMDMCommandRequest{
+		Command:   encoded,
+		HostUUIDs: []string{hostUUID},
+	}, http.StatusOK, &runResp)
+
+	require.NotEmpty(t, runResp.CommandUUID)
+	require.Equal(t, "REBOOT", runResp.RequestType)
+	require.Equal(t, "android", runResp.Platform)
+
+	cmdUUID := runResp.CommandUUID
+
+	// Verify the command appears in GET /commands?host_identifier=<uuid>.
+	var listResp listMDMCommandsResponse
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/commands?host_identifier=%s", hostUUID), nil, http.StatusOK, &listResp)
+	var found bool
+	for _, cmd := range listResp.Results {
+		if cmd.CommandUUID == cmdUUID {
+			found = true
+			assert.Equal(t, "REBOOT", cmd.RequestType)
+			assert.Equal(t, hostUUID, cmd.HostUUID)
+			break
+		}
+	}
+	require.True(t, found, "expected the Android command to appear in the commands list")
+
+	// Verify command results show pending (no Pub/Sub ack yet).
+	var resultsResp getMDMCommandResultsResponse
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/commands/results?command_uuid=%s", cmdUUID), nil, http.StatusOK, &resultsResp)
+	require.Len(t, resultsResp.Results, 1)
+	assert.Equal(t, "pending", resultsResp.Results[0].Status)
+	assert.Equal(t, "REBOOT", resultsResp.Results[0].RequestType)
+
+	// Deliver a Pub/Sub COMMAND ack.
+	row, err := s.ds.GetMDMAndroidCommandByUUID(ctx, cmdUUID)
+	require.NoError(t, err)
+
+	ackOp := androidmanagement.Operation{
+		Name: row.OperationName,
+		Done: true,
+	}
+	body, err := json.Marshal(ackOp)
+	require.NoError(t, err)
+	req := android_service.PubSubPushRequest{
+		PubSubMessage: android.PubSubMessage{
+			Attributes: map[string]string{"notificationType": string(android.PubSubCommand)},
+			Data:       base64.StdEncoding.EncodeToString(body),
+		},
+	}
+	s.Do("POST", "/api/v1/fleet/android_enterprise/pubsub", &req, http.StatusOK, "token", pubsubToken)
+
+	// Verify command results now show acknowledged with raw_result.
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/commands/results?command_uuid=%s", cmdUUID), nil, http.StatusOK, &resultsResp)
+	require.Len(t, resultsResp.Results, 1)
+	assert.Equal(t, "acknowledged", resultsResp.Results[0].Status)
+	assert.NotEmpty(t, resultsResp.Results[0].Result, "raw_result should be populated after Pub/Sub ack")
+
+	// Verify GetMDMCommandPlatform returns "android".
+	p, err := s.ds.GetMDMCommandPlatform(ctx, cmdUUID)
+	require.NoError(t, err)
+	assert.Equal(t, "android", p)
+}

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -990,9 +990,7 @@ func (svc *Service) getMDMCommandResults(ctx context.Context, commandUUID string
 	case "windows":
 		results, err = svc.ds.GetMDMWindowsCommandResults(ctx, commandUUID, hostUUID)
 	case "android":
-		// TODO(mna): maybe in the future we'll store responses from AMAPI commands, but for
-		// now we don't (they are very large), just return an empty list.
-		results = []*fleet.MDMCommandResult{}
+		results, err = svc.ds.GetMDMAndroidCommandResults(ctx, commandUUID, hostUUID)
 	default:
 		// this should never happen, but just in case
 		svc.logger.DebugContext(ctx, "unknown MDM command platform", "platform", p)


### PR DESCRIPTION
**Related issue:** Resolves #50733

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for running Android MDM commands with JSON payloads.
  * Android commands can be submitted, listed, filtered, and tracked through completion in the API and fleetctl.
  * Android command results now include status, timestamps, command details, and raw output.
  * Mixed-platform command listings and validation now include Android.

* **Bug Fixes**
  * Android command results are now returned correctly.
  * Improved platform-specific license messaging for Windows and Android hosts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->