### PR TITLE
Fix perpetual "Update available" for OneDrive macOS FMA

### DIFF
--- a/cmd/maintained-apps/validate/darwin.go
+++ b/cmd/maintained-apps/validate/darwin.go
@@ -240,8 +240,10 @@ func appExists(ctx context.Context, logger *slog.Logger, appName, uniqueAppIdent
 			// might be newer than the installer version. For OneDrive, we only verify that
 			// the app exists rather than checking the version.
 			if uniqueAppIdentifier == "com.microsoft.OneDrive" {
-				logger.InfoContext(ctx, "OneDrive detected - skipping version check due to auto-update behavior")
-				return true, nil
+				if !checkVersionMatch(appVersion, result.Version, result.BundledVersion) {
+					logger.InfoContext(ctx, "OneDrive detected - version mismatch but app is installed, falling back to existence-only validation")
+					return true, nil
+				}
 			}
 
 			// GPG Suite's installer version (e.g., "2023.3") doesn't match the app bundle version

--- a/ee/maintained-apps/ingesters/homebrew/external_refs/main.go
+++ b/ee/maintained-apps/ingesters/homebrew/external_refs/main.go
@@ -42,6 +42,7 @@ var Funcs = map[string][]func(*maintained_apps.FMAManifestApp) (*maintained_apps
 	"grammarly-desktop/darwin":      {GrammarlyDesktopVersionShortener},
 	"logitune/darwin":               {LogiTunePKGInstaller},
 	"anka-virtualization/darwin":    {AnkaVersionShortener},
+	"onedrive/darwin":               {OneDriveVersionShortener},
 	"pd/darwin":                     {PdVersionTransformer},
 	"smallstepagent/darwin":         {SmallstepAgentVersionTransformer},
 	"sonos/darwin":                  {SonosVersionTransformer},

--- a/ee/maintained-apps/ingesters/homebrew/external_refs/version_shortener.go
+++ b/ee/maintained-apps/ingesters/homebrew/external_refs/version_shortener.go
@@ -38,6 +38,7 @@ var (
 	RoyalTSXVersionShortener            = makeVersionShortener(3) // "6.4.2.1000" → "6.4.2"
 	GrammarlyDesktopVersionShortener    = makeVersionShortener(3) // "1.160.0.0" → "1.160.0"
 	AnkaVersionShortener                = makeVersionShortener(3) // "3.8.6.212" → "3.8.6"
+	OneDriveVersionShortener            = makeVersionShortener(3) // "26.139.0720.0007" → "26.139.0720"
 )
 
 // SublimeVersionTransformer prepends "Build " to match what macOS reports as

--- a/ee/maintained-apps/ingesters/homebrew/external_refs/version_shortener_test.go
+++ b/ee/maintained-apps/ingesters/homebrew/external_refs/version_shortener_test.go
@@ -50,6 +50,7 @@ func TestMakeVersionShortenerKeep3(t *testing.T) {
 		{name: "citrix workspace", version: "25.11.1.42", slug: "citrix-workspace", expected: "25.11.1"},
 		{name: "grammarly desktop", version: "1.160.0.0", slug: "grammarly-desktop", expected: "1.160.0"},
 		{name: "anka virtualization", version: "3.8.6.212", slug: "anka-virtualization", expected: "3.8.6"},
+		{name: "onedrive", version: "26.139.0720.0007", slug: "onedrive", expected: "26.139.0720"},
 	}
 
 	for _, tc := range tcs {

--- a/ee/maintained-apps/outputs/onedrive/darwin.json
+++ b/ee/maintained-apps/outputs/onedrive/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "26.139.0720.0007",
+      "version": "26.139.0720",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.OneDrive';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.OneDrive' AND version_compare(bundle_short_version, '26.139.0720.0007') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.OneDrive' AND version_compare(bundle_short_version, '26.139.0720') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.microsoft.OneDrive');"
       },
       "installer_url": "https://oneclient.sfx.ms/Mac/Installers/26.139.0720.0007/universal/OneDrive.pkg",


### PR DESCRIPTION
OneDrive deployed and includes version details such as:

```
id="com.microsoft.OneDrive"
        CFBundleShortVersionString="26.139.0720"
        CFBundleVersion="26139.0720.0007"
```

Fleet's macOS inventory reports `bundle_short_version`, so the policy `version_compare('26.139.0720', '26.139.0720.0007') < 0` was **always** true —

resulting in a host that had just installed the exact package Fleet shipped was still flagged as out of date short after.

Similar to https://github.com/fleetdm/fleet/issues/42673


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OneDrive for macOS version validation to recognize supported version formats more reliably.
  * Updated version comparisons to use the normalized three-part version.
  * When an installed OneDrive version differs from the expected version, validation now falls back to confirming that the app is installed, reducing false validation failures.
* **Maintenance**
  * Updated OneDrive package metadata to reflect the normalized version format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->