### PR TITLE
Use human-friendly language in `fleetctl new` usage text

### DIFF
--- a/cmd/fleetctl/fleetctl/new.go
+++ b/cmd/fleetctl/fleetctl/new.go
@@ -56,7 +56,7 @@ func newCommand() *cli.Command {
 	)
 	return &cli.Command{
 		Name:        "new",
-		Usage:       "Scaffold a blank GitOps repository from templates",
+		Usage:       "Create starter GitOps files from templates",
 		UsageText:   "fleetctl new [options]",
 		Description: "Creates a starter GitOps repository structure from templates. Learn more about GitOps: https://fleetdm.com/learn-more-about/gitops",
 		Flags: []cli.Flag{


### PR DESCRIPTION
Originally proposed by Noah:
https://github.com/fleetdm/fleet/pull/51487#discussion_r3807976104

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `new` command description to clarify that it creates starter GitOps files from templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->