### PR TITLE
Cherry-pick #51494: Fix ActionsDropdown icon-trigger menu overlapping its button

### DIFF
--- a/frontend/components/ActionsDropdown/ActionsDropdown.tsx
+++ b/frontend/components/ActionsDropdown/ActionsDropdown.tsx
@@ -357,6 +357,21 @@ const ActionsDropdown = ({
         opacity: 0.5,
       }),
     }),
+    // With the Control nulled out, react-select's container collapses to 0x0
+    // and, as a flex item, sits vertically centered against the trigger button
+    // — so the menu's `top: 100%` lands mid-button.
+    // Stretch the container over the button instead, so the menu hangs off the button's
+    // edge in either placement.
+    // Pointer events are off so the overlay can't swallow the trigger's clicks;
+    // the menu turns them back on.
+    container: (provided) => ({
+      ...provided,
+      ...(hasIconTrigger && {
+        position: "absolute",
+        inset: 0,
+        pointerEvents: "none",
+      }),
+    }),
     menu: (provided) => ({
       ...provided,
       backgroundColor: COLORS["core-fleet-white"],
@@ -372,7 +387,11 @@ const ActionsDropdown = ({
       left: getLeftMenuAlign(menuAlign),
       right: getRightMenuAlign(menuAlign),
       animation: "fade-in 150ms ease-out",
-      ...(hasIconTrigger && { marginTop: "4px" }),
+      ...(hasIconTrigger && {
+        marginTop: "1px",
+        marginBottom: "1px",
+        pointerEvents: "auto",
+      }),
     }),
     // zIndex 999 (document-portal tier) so the portaled menu clears
     // .site-nav-container and Modal — ActionsDropdown can render inside a
@@ -416,8 +435,12 @@ const ActionsDropdown = ({
     }),
   };
 
+  const wrapperClassnames = classnames(`${baseClass}__wrapper`, {
+    [`${baseClass}__wrapper--icon-trigger`]: hasIconTrigger,
+  });
+
   return (
-    <div className={`${baseClass}__wrapper`} ref={wrapperRef}>
+    <div className={wrapperClassnames} ref={wrapperRef}>
       {isPrimary && renderPrimaryButton()}
       {hasIconTrigger && renderIconTriggerButton()}
       <Select<IDropdownOption, false>

--- a/frontend/components/ActionsDropdown/_styles.scss
+++ b/frontend/components/ActionsDropdown/_styles.scss
@@ -10,6 +10,12 @@
   display: flex;
   align-items: center;
 
+  // Anchors the absolutely positioned select container to the trigger button
+  // (see the `container` style in ActionsDropdown.tsx).
+  &--icon-trigger {
+    position: relative;
+  }
+
   button .children-wrapper {
     gap: $pad-small;
 


### PR DESCRIPTION
Cherry-pick of #51494 into the RC branch.