### PR TITLE
include mock APNS and Android in update-go automation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1064,7 +1064,7 @@ vex-report:
 	sh -c 'go run ./tools/vex-parser ./security/vex/wix >> security/status.md'
 
 # make update-go version=1.24.4
-UPDATE_GO_DOCKERFILES := ./Dockerfile-desktop-linux ./infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile ./tools/mdm/migration/mdmproxy/Dockerfile
+UPDATE_GO_DOCKERFILES := ./Dockerfile-desktop-linux ./infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile ./infrastructure/loadtesting/terraform/docker/apple-apns-mock.Dockerfile ./infrastructure/loadtesting/terraform/docker/android-amapi-mock.Dockerfile ./tools/mdm/migration/mdmproxy/Dockerfile
 UPDATE_GO_MODS := \
 	go.mod \
 	./tools/mdm/windows/bitlocker/go.mod \

--- a/infrastructure/loadtesting/terraform/docker/android-amapi-mock.Dockerfile
+++ b/infrastructure/loadtesting/terraform/docker/android-amapi-mock.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-alpine3.23@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f
+FROM golang:1.26.6-alpine3.23@sha256:e57c41c1d5864341031181b0db34b9a537bb5773eb6428e4e5bdaea0f9135406
 ARG TAG
 RUN apk add git
 RUN git clone -b $TAG --depth=1 --no-tags --progress --no-recurse-submodules https://github.com/fleetdm/fleet.git

--- a/infrastructure/loadtesting/terraform/docker/apple-apns-mock.Dockerfile
+++ b/infrastructure/loadtesting/terraform/docker/apple-apns-mock.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.5-alpine3.23@sha256:622e56dbc11a8cfe87cafa2331e9a201877271cbff918af53d3be315f3da88cc
+FROM golang:1.26.6-alpine3.23@sha256:e57c41c1d5864341031181b0db34b9a537bb5773eb6428e4e5bdaea0f9135406
 ARG TAG
 RUN apk add git
 RUN git clone -b "$TAG" --depth=1 --no-tags --progress --no-recurse-submodules https://github.com/fleetdm/fleet.git

--- a/infrastructure/loadtesting/terraform/docker/apple-apns-mock.Dockerfile
+++ b/infrastructure/loadtesting/terraform/docker/apple-apns-mock.Dockerfile
@@ -1,6 +1,3 @@
-# Must be >= the `go` directive in the cloned repo's go.mod. The official Go
-# images set GOTOOLCHAIN=local, so a lower version here does not silently
-# download a newer toolchain -- it fails the build.
 FROM golang:1.26.5-alpine3.23@sha256:622e56dbc11a8cfe87cafa2331e9a201877271cbff918af53d3be315f3da88cc
 ARG TAG
 RUN apk add git


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves nothing

# Checklist for submitter
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Apple APNS and Android AMAPI mock build environments to Go 1.26.6.
  * Refreshed the associated Alpine image references for improved build consistency.
  * Included both mock Dockerfiles in automated Go version update processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->