### PR TITLE
Disallow bypass_conditional_access on iOS/iPadOS

### DIFF
--- a/ee/server/service/devices.go
+++ b/ee/server/service/devices.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server"
+	authz_ctx "github.com/fleetdm/fleet/v4/server/contexts/authz"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	hostctx "github.com/fleetdm/fleet/v4/server/contexts/host"
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -106,6 +107,12 @@ func (svc *Service) TriggerMigrateMDMDevice(ctx context.Context, host *fleet.Hos
 func (svc *Service) BypassConditionalAccess(ctx context.Context, host *fleet.Host) error {
 	// this is not a user-authenticated endpoint
 	svc.authz.SkipAuthorization(ctx)
+
+	// iOS/iPadOS devices authenticate by UUID in the URL and don't participate in
+	// conditional access policies, so they can't bypass it.
+	if svc.authz.IsAuthenticatedWith(ctx, authz_ctx.AuthnDeviceURL) {
+		return fleet.NewUserMessageError(errors.New("conditional access bypass is not supported on this device"), http.StatusForbidden)
+	}
 
 	ac, err := svc.ds.AppConfig(ctx)
 	if err != nil {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves https://github.com/fleetdm/security/issues/15

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

No actual user-facing change as this endpoint was not used by the user-facing iOS/iPadOS self service page
- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Device-authenticated requests using the device URL are now correctly denied when conditional-access requirements apply.
  * Authorization context is now respected when evaluating conditional-access bypasses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->