### PR TITLE
Validate activities order_key against an allowlist

### DIFF
--- a/changes/activities-order-key-allowlist
+++ b/changes/activities-order-key-allowlist
@@ -1,0 +1,1 @@
+- Improved validation of the `order_key` parameter on `GET /api/v1/fleet/activities` and `GET /api/v1/fleet/hosts/{id}/activities`, rejecting unsupported sort keys.

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -508,7 +508,7 @@ Returns a list of the activities that have been performed in Fleet. For a compre
 |:--------------- |:------- |:----- |:------------------------------------------------------------|
 | page            | integer | query | Page number of the results to fetch.                                                                                          |
 | per_page        | integer | query | Results per page. Maximum is 10,000 records. If no pagination parameters are specified, defaults to 10,000.                    |
-| order_key       | string  | query | What to order results by. Can be any column in the `activities` table.                                                         |
+| order_key       | string  | query | What to order results by. Allowed fields are `id`, `created_at`, `user_id`, `activity_type`, `user_name`, `user_email`, `fleet_initiated`, and `streamed`.                                                         |
 | order_direction | string  | query | **Requires `order_key`**. The direction of the order given the order key. Options include `"asc"` and `"desc"`. Default is `"asc"`. |
 | after           | string  | query | The value to get results after. This needs `order_key` defined, as that's the column that would be used. |
 | query | string | query | Search query keywords. Searchable fields include `actor_full_name` and `actor_email`.
@@ -5908,7 +5908,7 @@ To wipe a macOS, iOS, iPadOS, or Windows host, the host must have MDM turned on.
 | id   | integer | path | **Required**. The host's ID. |
 | page | integer | query | Page number of the results to fetch.|
 | per_page | integer | query | Results per page. Maximum is 10,000 records. If no pagination parameters are specified, defaults to 10,000.|
-| order_key | string | query | What to order results by. Allowed fields are `id`, `created_at`, and `activity_type`. |
+| order_key | string | query | What to order results by. Allowed fields are `id`, `created_at`, `user_id`, `activity_type`, `user_name`, `user_email`, and `fleet_initiated`. |
 | order_direction | string | query | **Requires `order_key`**. The direction of the order given the order key. Options include `"asc"` and `"desc"`. Default is `"asc"`. |
 | after | string | query | The value to get results after. This needs `order_key` defined, as that's the column that would be used. |
 

--- a/server/activity/internal/mysql/activity.go
+++ b/server/activity/internal/mysql/activity.go
@@ -39,6 +39,33 @@ func (ds *Datastore) reader(ctx context.Context) *sqlx.DB {
 // Ensure Datastore implements types.Datastore
 var _ types.Datastore = (*Datastore)(nil)
 
+// activitiesAllowedOrderKeys maps the sortable order keys for ListActivities to their
+// SQL column expressions. Ordering is validated against this allowlist so a
+// caller can't sort by an arbitrary column (e.g. the details JSON) and use the
+// cursor as a binary-search oracle to read it.
+var activitiesAllowedOrderKeys = platform_mysql.OrderKeyAllowlist{
+	"id":              "a.id",
+	"created_at":      "a.created_at",
+	"user_id":         "a.user_id",
+	"activity_type":   "a.activity_type",
+	"user_name":       "a.user_name",
+	"user_email":      "a.user_email",
+	"fleet_initiated": "a.fleet_initiated",
+	"streamed":        "a.streamed",
+}
+
+// hostPastActivitiesAllowedOrderKeys is the equivalent allowlist for
+// ListHostPastActivities, whose id comes from the join table.
+var hostPastActivitiesAllowedOrderKeys = platform_mysql.OrderKeyAllowlist{
+	"id":              "ha.activity_id",
+	"created_at":      "a.created_at",
+	"user_id":         "a.user_id",
+	"activity_type":   "a.activity_type",
+	"user_name":       "a.user_name",
+	"user_email":      "a.user_email",
+	"fleet_initiated": "a.fleet_initiated",
+}
+
 // ListActivities returns a slice of activities performed across the organization.
 func (ds *Datastore) ListActivities(ctx context.Context, opt types.ListOptions) ([]*api.Activity, *api.PaginationMetadata, error) {
 	ctx, span := tracer.Start(ctx, "activity.mysql.ListActivities")
@@ -101,11 +128,14 @@ func (ds *Datastore) ListActivities(ctx context.Context, opt types.ListOptions) 
 		args = append(args, time.Now().UTC())
 	}
 
-	// Apply pagination using platform_mysql
-	activitiesQ, args = platform_mysql.AppendListOptionsWithParams(activitiesQ, args, &opt)
+	// Apply pagination, validating the order key against an allowlist.
+	activitiesQ, args, err := platform_mysql.AppendListOptionsWithParamsSecure(activitiesQ, args, &opt, activitiesAllowedOrderKeys)
+	if err != nil {
+		return nil, nil, ctxerr.Wrap(ctx, err, "apply list options")
+	}
 
 	var activities []*api.Activity
-	err := sqlx.SelectContext(ctx, ds.reader(ctx), &activities, activitiesQ, args...)
+	err = sqlx.SelectContext(ctx, ds.reader(ctx), &activities, activitiesQ, args...)
 	if err != nil {
 		return nil, nil, ctxerr.Wrap(ctx, err, "select activities")
 	}
@@ -176,7 +206,10 @@ func (ds *Datastore) ListHostPastActivities(ctx context.Context, hostID uint, op
 
 	args := []any{hostID}
 
-	stmt, args := platform_mysql.AppendListOptionsWithParams(listStmt, args, &opt)
+	stmt, args, err := platform_mysql.AppendListOptionsWithParamsSecure(listStmt, args, &opt, hostPastActivitiesAllowedOrderKeys)
+	if err != nil {
+		return nil, nil, ctxerr.Wrap(ctx, err, "apply list options")
+	}
 
 	var activities []*api.Activity
 	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &activities, stmt, args...); err != nil {

--- a/server/activity/internal/mysql/activity_test.go
+++ b/server/activity/internal/mysql/activity_test.go
@@ -286,6 +286,14 @@ func testListActivitiesOrdering(t *testing.T, env *testEnv) {
 	require.Len(t, activities, 3)
 	assert.Less(t, activities[0].ID, activities[1].ID)
 	assert.Less(t, activities[1].ID, activities[2].ID)
+
+	// The order key is validated against an allowlist: ordering by a column that
+	// isn't an allowed sort key (e.g. the details JSON) is rejected, so it can't
+	// be used as a cursor-based binary-search oracle to read it.
+	for _, badKey := range []string{"a.details", "details", "user_password"} {
+		_, _, err := env.ds.ListActivities(ctx, listOpts(withOrder(badKey, activityapi.OrderAscending)))
+		require.Error(t, err, "order key %q must be rejected", badKey)
+	}
 }
 
 func testListActivitiesCursorPagination(t *testing.T, env *testEnv) {
@@ -402,6 +410,13 @@ func testListHostPastActivities(t *testing.T, env *testEnv) {
 				require.NotNil(t, a.Details)
 			}
 		})
+	}
+
+	// Ordering by a column that isn't an allowed sort key (e.g. the details
+	// JSON) is rejected, so it can't be used as a cursor-based oracle.
+	for _, badKey := range []string{"a.details", "details", "user_password"} {
+		_, _, err := env.ds.ListHostPastActivities(ctx, hostID, listOpts(withOrder(badKey, activityapi.OrderAscending)))
+		require.Error(t, err, "order key %q must be rejected", badKey)
 	}
 }
 

--- a/server/activity/internal/service/service.go
+++ b/server/activity/internal/service/service.go
@@ -123,7 +123,8 @@ func (s *Service) ListHostPastActivities(ctx context.Context, hostID uint, opt a
 		return nil, nil, err
 	}
 
-	applyListOptionsDefaults(&opt, "a.created_at")
+	// Use the user-facing key; the datastore allowlist qualifies it to a.created_at.
+	applyListOptionsDefaults(&opt, "created_at")
 	// Convert public options to internal options
 	internalOpt := types.ListOptions{
 		ListOptions:     opt,

--- a/server/platform/mysql/list_options.go
+++ b/server/platform/mysql/list_options.go
@@ -95,7 +95,7 @@ func SanitizeColumn(col string) string {
 // If allowlist is empty, any non-empty order key will return an error.
 func AppendListOptionsWithParamsSecure(sql string, params []any, opts ListOptions, allowlist OrderKeyAllowlist) (string, []any, error) {
 	if allowlist == nil {
-		panic("AppendListOptionsWithParams: allowlist cannot be nil; use empty map to disallow all sorting")
+		panic("AppendListOptionsWithParamsSecure: allowlist cannot be nil; use empty map to disallow all sorting")
 	}
 
 	userOrderKey := opts.GetOrderKey()
@@ -169,62 +169,4 @@ func AppendListOptionsWithParamsSecure(sql string, params []any, opts ListOption
 	}
 
 	return sql, params, nil
-}
-
-// AppendListOptionsWithParams appends ORDER BY, LIMIT, and OFFSET clauses to a SQL string
-// based on the provided list options. It accepts existing query params and returns
-// the extended params slice.
-//
-// Deprecated: this method will be removed in favor of AppendListOptionsWithParamsSecure
-func AppendListOptionsWithParams(sql string, params []any, opts ListOptions) (string, []any) {
-	orderKey := SanitizeColumn(opts.GetOrderKey())
-	page := opts.GetPage()
-
-	if cursor := opts.GetCursorValue(); cursor != "" && orderKey != "" {
-		cursorSQL := " WHERE "
-		if strings.Contains(strings.ToLower(sql), "where") {
-			cursorSQL = " AND "
-		}
-		// Cursor value is always passed as string. MySQL automatically converts
-		// string to integer when comparing against integer columns.
-		// See: https://dev.mysql.com/doc/refman/8.0/en/type-conversion.html
-		params = append(params, cursor)
-		direction := ">" // ASC
-		if opts.IsDescending() {
-			direction = "<" // DESC
-		}
-		sql = fmt.Sprintf("%s %s %s %s ?", sql, cursorSQL, orderKey, direction)
-
-		// Cursor-based pagination supersedes page-based pagination
-		page = 0
-	}
-
-	if orderKey != "" {
-		direction := "ASC"
-		if opts.IsDescending() {
-			direction = "DESC"
-		}
-
-		sql = fmt.Sprintf("%s ORDER BY %s %s", sql, orderKey, direction)
-		if opts.GetSecondaryOrderKey() != "" {
-			dir := "ASC"
-			if opts.IsSecondaryDescending() {
-				dir = "DESC"
-			}
-			sql += fmt.Sprintf(`, %s %s`, SanitizeColumn(opts.GetSecondaryOrderKey()), dir)
-		}
-	}
-
-	limit := opts.GetPerPage()
-	if opts.WantsPaginationInfo() {
-		limit++
-	}
-	sql = fmt.Sprintf("%s LIMIT %d", sql, limit)
-
-	offset := opts.GetPerPage() * page
-	if offset > 0 {
-		sql = fmt.Sprintf("%s OFFSET %d", sql, offset)
-	}
-
-	return sql, params
 }

--- a/server/service/integration_apple_vpp_config_test.go
+++ b/server/service/integration_apple_vpp_config_test.go
@@ -617,7 +617,7 @@ func (s *integrationMDMTestSuite) TestVPPManagedConfigurationOnInstallCommand() 
 		// carrying the unresolvable variable as the reason.
 		var listActs listActivitiesResponse
 		s.DoJSON("GET", "/api/latest/fleet/activities", nil, http.StatusOK, &listActs,
-			"order_key", "a.id", "order_direction", "desc", "per_page", "10")
+			"order_key", "id", "order_direction", "desc", "per_page", "10")
 		var found bool
 		for _, act := range listActs.Activities {
 			if act.Type == (fleet.ActivityInstalledAppStoreApp{}).ActivityName() {

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -3999,7 +3999,7 @@ func (s *integrationTestSuite) TestListActivities() {
 	assert.Equal(t, fleet.ActivityTypeEditedPack{}.ActivityName(), listResp.Activities[0].Type)
 
 	listResp = listActivitiesResponse{}
-	s.DoJSON("GET", "/api/latest/fleet/activities", nil, http.StatusOK, &listResp, "per_page", "1", "order_key", "a.id", "after", "0")
+	s.DoJSON("GET", "/api/latest/fleet/activities", nil, http.StatusOK, &listResp, "per_page", "1", "order_key", "id", "after", "0")
 	require.Len(t, listResp.Activities, 1)
 	require.Nil(t, listResp.Meta)
 }

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -4165,7 +4165,7 @@ func (s *integrationEnterpriseTestSuite) listRecentExceptionActivities(activityT
 	t := s.T()
 	var listActivities listActivitiesResponse
 	s.DoJSON("GET", "/api/latest/fleet/activities", nil, http.StatusOK,
-		&listActivities, "order_key", "a.id", "order_direction", "desc", "per_page", "10")
+		&listActivities, "order_key", "id", "order_direction", "desc", "per_page", "10")
 	found := map[string]struct{}{}
 	for _, act := range listActivities.Activities {
 		if act.Type != activityType || act.Details == nil {
@@ -5213,7 +5213,7 @@ func (s *integrationEnterpriseTestSuite) TestMDMWindowsUpdates() {
 
 	// keep the last activity, to detect newly created ones
 	var activitiesResp listActivitiesResponse
-	s.DoJSON("GET", "/api/latest/fleet/activities", nil, http.StatusOK, &activitiesResp, "order_key", "a.id", "order_direction", "desc")
+	s.DoJSON("GET", "/api/latest/fleet/activities", nil, http.StatusOK, &activitiesResp, "order_key", "id", "order_direction", "desc")
 	var lastActivity uint
 	if len(activitiesResp.Activities) > 0 {
 		lastActivity = activitiesResp.Activities[0].ID
@@ -5231,7 +5231,7 @@ func (s *integrationEnterpriseTestSuite) TestMDMWindowsUpdates() {
 
 		// no activity got created
 		activitiesResp = listActivitiesResponse{}
-		s.DoJSON("GET", "/api/latest/fleet/activities", nil, http.StatusOK, &activitiesResp, "order_key", "a.id", "order_direction", "desc")
+		s.DoJSON("GET", "/api/latest/fleet/activities", nil, http.StatusOK, &activitiesResp, "order_key", "id", "order_direction", "desc")
 		require.Condition(t, func() bool {
 			return (lastActivity == 0 && len(activitiesResp.Activities) == 0) ||
 				(len(activitiesResp.Activities) > 0 && activitiesResp.Activities[0].ID == lastActivity)
@@ -5375,7 +5375,7 @@ func (s *integrationEnterpriseTestSuite) TestMDMAppleOSUpdates() {
 
 	// keep the last activity, to detect newly created ones
 	var activitiesResp listActivitiesResponse
-	s.DoJSON("GET", "/api/latest/fleet/activities", nil, http.StatusOK, &activitiesResp, "order_key", "a.id", "order_direction", "desc")
+	s.DoJSON("GET", "/api/latest/fleet/activities", nil, http.StatusOK, &activitiesResp, "order_key", "id", "order_direction", "desc")
 	var lastActivity uint
 	if len(activitiesResp.Activities) > 0 {
 		lastActivity = activitiesResp.Activities[0].ID
@@ -5393,7 +5393,7 @@ func (s *integrationEnterpriseTestSuite) TestMDMAppleOSUpdates() {
 
 		// no activity got created
 		activitiesResp = listActivitiesResponse{}
-		s.DoJSON("GET", "/api/latest/fleet/activities", nil, http.StatusOK, &activitiesResp, "order_key", "a.id", "order_direction", "desc")
+		s.DoJSON("GET", "/api/latest/fleet/activities", nil, http.StatusOK, &activitiesResp, "order_key", "id", "order_direction", "desc")
 		require.Condition(t, func() bool {
 			return (lastActivity == 0 && len(activitiesResp.Activities) == 0) ||
 				(len(activitiesResp.Activities) > 0 && activitiesResp.Activities[0].ID == lastActivity)
@@ -16690,7 +16690,7 @@ func (s *integrationEnterpriseTestSuite) TestSoftwareInstallerHostRequests() {
 
 	// Check activity feed
 	var activitiesResp listActivitiesResponse
-	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d/activities", h.ID), nil, http.StatusOK, &activitiesResp, "order_key", "a.id",
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d/activities", h.ID), nil, http.StatusOK, &activitiesResp, "order_key", "id",
 		"order_direction", "desc")
 	require.NotEmpty(t, activitiesResp.Activities)
 	assert.Equal(t, fleet.ActivityTypeUninstalledSoftware{}.ActivityName(), activitiesResp.Activities[0].Type)
@@ -16736,7 +16736,7 @@ func (s *integrationEnterpriseTestSuite) TestSoftwareInstallerHostRequests() {
 	require.False(t, hostRespFailedUninstall.Host.RefetchRequested, "RefetchRequested should be false after failed software uninstall")
 
 	// Check activity feed
-	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d/activities", h.ID), nil, http.StatusOK, &activitiesResp, "order_key", "a.id",
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d/activities", h.ID), nil, http.StatusOK, &activitiesResp, "order_key", "id",
 		"order_direction", "desc")
 	require.NotEmpty(t, activitiesResp.Activities)
 	assert.Equal(t, fleet.ActivityTypeUninstalledSoftware{}.ActivityName(), activitiesResp.Activities[0].Type)
@@ -16930,7 +16930,7 @@ func (s *integrationEnterpriseTestSuite) TestSelfServiceSoftwareInstallUninstall
 
 	// Check activity feed
 	var activitiesResp listActivitiesResponse
-	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d/activities", host1.ID), nil, http.StatusOK, &activitiesResp, "order_key", "a.id",
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d/activities", host1.ID), nil, http.StatusOK, &activitiesResp, "order_key", "id",
 		"order_direction", "desc")
 	require.NotEmpty(t, activitiesResp.Activities)
 	assert.Equal(t, fleet.ActivityTypeUninstalledSoftware{}.ActivityName(), activitiesResp.Activities[0].Type)

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -17296,7 +17296,7 @@ func (s *integrationMDMTestSuite) TestDigiCertConfig() {
 	// Check 3 added activities are present
 	var listActivities listActivitiesResponse
 	s.DoJSON("GET", "/api/latest/fleet/activities", nil, http.StatusOK,
-		&listActivities, "order_key", "a.id", "order_direction", "desc", "per_page", "10")
+		&listActivities, "order_key", "id", "order_direction", "desc", "per_page", "10")
 	require.True(t, len(listActivities.Activities) > 0)
 	activity := fleet.ActivityAddedDigiCert{}
 	caNames := make([]string, 0, 3)
@@ -17354,7 +17354,7 @@ func (s *integrationMDMTestSuite) TestDigiCertConfig() {
 
 		listActivities = listActivitiesResponse{}
 		s.DoJSON("GET", "/api/latest/fleet/activities", nil, http.StatusOK,
-			&listActivities, "order_key", "a.id", "order_direction", "desc", "per_page", "10")
+			&listActivities, "order_key", "id", "order_direction", "desc", "per_page", "10")
 		require.True(t, len(listActivities.Activities) > 0)
 		activity = fleet.ActivityAddedDigiCert{}
 		editActivity := fleet.ActivityEditedDigiCert{}
@@ -17395,7 +17395,7 @@ func (s *integrationMDMTestSuite) TestDigiCertConfig() {
 		// Check that 3 deleted activities are present
 		listActivities = listActivitiesResponse{}
 		s.DoJSON("GET", "/api/latest/fleet/activities", nil, http.StatusOK,
-			&listActivities, "order_key", "a.id", "order_direction", "desc", "per_page", "10")
+			&listActivities, "order_key", "id", "order_direction", "desc", "per_page", "10")
 		require.True(t, len(listActivities.Activities) > 0)
 		delActivity := fleet.ActivityDeletedDigiCert{}
 		caNames = make([]string, 0, 3)
@@ -18136,7 +18136,7 @@ func (s *integrationMDMTestSuite) TestCustomSCEPConfig() {
 	// Check 3 added activities are present
 	var listActivities listActivitiesResponse
 	s.DoJSON("GET", "/api/latest/fleet/activities", nil, http.StatusOK,
-		&listActivities, "order_key", "a.id", "order_direction", "desc", "per_page", "10")
+		&listActivities, "order_key", "id", "order_direction", "desc", "per_page", "10")
 	require.True(t, len(listActivities.Activities) > 0)
 	activity := fleet.ActivityAddedCustomSCEPProxy{}
 	caNames := make([]string, 0, 3)
@@ -18193,7 +18193,7 @@ func (s *integrationMDMTestSuite) TestCustomSCEPConfig() {
 
 	listActivities = listActivitiesResponse{}
 	s.DoJSON("GET", "/api/latest/fleet/activities", nil, http.StatusOK,
-		&listActivities, "order_key", "a.id", "order_direction", "desc", "per_page", "10")
+		&listActivities, "order_key", "id", "order_direction", "desc", "per_page", "10")
 	require.True(t, len(listActivities.Activities) > 0)
 	activity = fleet.ActivityAddedCustomSCEPProxy{}
 	editActivity := fleet.ActivityEditedCustomSCEPProxy{}
@@ -18233,7 +18233,7 @@ func (s *integrationMDMTestSuite) TestCustomSCEPConfig() {
 		// Check that 3 deleted activities are present
 		listActivities = listActivitiesResponse{}
 		s.DoJSON("GET", "/api/latest/fleet/activities", nil, http.StatusOK,
-			&listActivities, "order_key", "a.id", "order_direction", "desc", "per_page", "10")
+			&listActivities, "order_key", "id", "order_direction", "desc", "per_page", "10")
 		require.True(t, len(listActivities.Activities) > 0)
 		delActivity = fleet.ActivityDeletedCustomSCEPProxy{}
 		caNames = make([]string, 0, 3)
@@ -25279,7 +25279,7 @@ func (s *integrationMDMTestSuite) TestManagedLocalAccount() {
 		// Auto-rotation activity exists and is FleetInitiated.
 		var fleetActivities listActivitiesResponse
 		s.DoJSON("GET", "/api/latest/fleet/activities", nil, http.StatusOK, &fleetActivities,
-			"order_key", "a.id", "order_direction", "desc", "per_page", "20")
+			"order_key", "id", "order_direction", "desc", "per_page", "20")
 		rotateActivityName := fleet.ActivityTypeRotatedManagedLocalAccountPassword{}.ActivityName()
 		var sawFleetRotation bool
 		for _, a := range fleetActivities.Activities {

--- a/server/service/testing_client_test.go
+++ b/server/service/testing_client_test.go
@@ -735,7 +735,7 @@ func (ts *withServer) lastActivityMatches(name, details string, id uint) uint {
 func (ts *withServer) lastActivityMatchesExtended(name, details string, id uint, fleetInitiated *bool) uint {
 	t := ts.s.T()
 	var listActivities listActivitiesResponse
-	ts.DoJSON("GET", "/api/latest/fleet/activities", nil, http.StatusOK, &listActivities, "order_key", "a.id", "order_direction", "desc", "per_page", "1")
+	ts.DoJSON("GET", "/api/latest/fleet/activities", nil, http.StatusOK, &listActivities, "order_key", "id", "order_direction", "desc", "per_page", "1")
 	require.True(t, len(listActivities.Activities) > 0)
 
 	act := listActivities.Activities[0]
@@ -758,7 +758,7 @@ func (ts *withServer) lastActivityMatchesExtended(name, details string, id uint,
 func (ts *withServer) lastHostActivityMatches(hostID uint, name, details string, id uint) uint {
 	t := ts.s.T()
 	var listActivities listActivitiesResponse
-	ts.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d/activities", hostID), nil, http.StatusOK, &listActivities, "order_key", "a.id", "order_direction", "desc", "per_page", "10")
+	ts.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d/activities", hostID), nil, http.StatusOK, &listActivities, "order_key", "id", "order_direction", "desc", "per_page", "10")
 	require.NotEmpty(t, listActivities.Activities)
 
 	act := listActivities.Activities[0]
@@ -789,7 +789,7 @@ func (ts *withServer) lastActivityOfTypeMatches(name, details string, id uint) u
 
 	var listActivities listActivitiesResponse
 	ts.DoJSON("GET", "/api/latest/fleet/activities", nil, http.StatusOK,
-		&listActivities, "order_key", "a.id", "order_direction", "desc", "per_page", "10")
+		&listActivities, "order_key", "id", "order_direction", "desc", "per_page", "10")
 	require.True(t, len(listActivities.Activities) > 0)
 
 	for _, act := range listActivities.Activities {
@@ -814,7 +814,7 @@ func (ts *withServer) lastActivityOfTypeDoesNotMatch(name, details string, id ui
 
 	var listActivities listActivitiesResponse
 	ts.DoJSON("GET", "/api/latest/fleet/activities", nil, http.StatusOK,
-		&listActivities, "order_key", "a.id", "order_direction", "desc", "per_page", "10")
+		&listActivities, "order_key", "id", "order_direction", "desc", "per_page", "10")
 	require.True(t, len(listActivities.Activities) > 0)
 
 	for _, act := range listActivities.Activities {
@@ -835,7 +835,7 @@ func (ts *withServer) listActivities() []*fleet.Activity {
 	t := ts.s.T()
 	var resp listActivitiesResponse
 	ts.DoJSON("GET", "/api/latest/fleet/activities", nil, http.StatusOK, &resp,
-		"order_key", "a.id", "order_direction", "asc", "per_page", "10000")
+		"order_key", "id", "order_direction", "asc", "per_page", "10000")
 	require.NotNil(t, resp.Activities)
 	return resp.Activities
 }


### PR DESCRIPTION
**Related issue:** N/A

## Description

The activities list endpoints (`GET /api/v1/fleet/activities` and `GET /api/v1/fleet/hosts/{id}/activities`) applied the `order_key` parameter through the deprecated `AppendListOptionsWithParams` helper, which only regex-filters the column name and does not check it against an allowlist. This let a caller sort by (and cursor-paginate over) arbitrary columns, including ones not in the SELECT.

This routes both queries through `AppendListOptionsWithParamsSecure` with a per-query order-key allowlist, so only known sort keys are accepted and anything else returns a 422. It mirrors how the other list endpoints (hosts, labels, software, certificates, MDM commands) already validate their sort keys. This was the last remaining caller of the deprecated helper.

## Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements) — the sort key is validated against an allowlist and mapped to a fixed column expression; all values remain parameterized.

## Testing

- [x] Added/updated automated tests — per-query negative tests assert off-allowlist keys are rejected on both endpoints; existing ordering/cursor tests confirm legitimate `id`/`created_at` sorting and pagination still work.
- [x] QA'd all new/changed functionality manually — verified on a local instance: `order_key=a.details` now returns a 422 `invalid order_key`, while `id`/`created_at`/the default still return 200 with correct ordering.

cc @lukeheath for review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for activity sorting parameters.
  * Unsupported sort fields are now rejected for fleet and host activity requests.
  * Fixed host activity sorting behavior for the `created_at` field.
  * Prevented invalid sort inputs from affecting activity query processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->