### PR TITLE
Unfreeze Webex (darwin)

### DIFF
--- a/ee/maintained-apps/inputs/homebrew/webex.json
+++ b/ee/maintained-apps/inputs/homebrew/webex.json
@@ -5,6 +5,5 @@
   "installer_format": "dmg",
   "slug": "webex/darwin",
   "install_script_path": "ee/maintained-apps/inputs/homebrew/scripts/webex_install.sh",
-  "default_categories": ["Communication"],
-  "frozen": true
+  "default_categories": ["Communication"]
 }

--- a/ee/maintained-apps/outputs/webex/darwin.json
+++ b/ee/maintained-apps/outputs/webex/darwin.json
@@ -1,10 +1,11 @@
 {
   "versions": [
     {
-      "version": "46.7.0.35472",
+      "version": "46.8.0.35631",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'Cisco-Systems.Spark';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'Cisco-Systems.Spark' AND version_compare(bundle_short_version, '46.7.0.35472') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'Cisco-Systems.Spark' AND version_compare(bundle_short_version, '46.8.0.35631') < 0);",
+        "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'Cisco-Systems.Spark');"
       },
       "installer_url": "https://binaries.webex.com/webex-macos-apple-silicon/Webex.dmg",
       "install_script_ref": "8ff3811b",


### PR DESCRIPTION
Automated unfreeze probe. Removes `"frozen": true` and regenerates the output manifest so
test-fma-darwin-pr-only can validate webex/darwin at its current upstream version.

Frozen since: 2026-08-07
Version: 46.7.0.35472 -> 46.8.0.35631

Draft until validation reports. Merge only if the FMA checks are green and the validate shard
actually ran for this slug.

Note: the regenerated manifest also gains an `open` query. That comes from the current generator,
not from the upstream version bump — every FMA manifest regenerated today picks it up.

---
_Generated by [Claude Code](https://claude.ai/code/session_015fd7xhBY6asyihFpK5sZgV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated Webex for macOS detection to support version 46.8.0.35631.
  - Improved recognition of active Webex processes on macOS.
  - Removed a configuration restriction to keep Webex app handling current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->