### PR TITLE
Handbook: Add security issues as a work item type

### DIFF
--- a/handbook/company/product-groups.md
+++ b/handbook/company/product-groups.md
@@ -1157,6 +1157,8 @@ Product group boards are exclusively composed of the following types of work ite
 
 6. **Reliability issues**: These represent scaling, performance, or reliability concerns, including post-mortem action items, marked with the `reliability` label. Reliability issues are prioritized by severity by both product and engineering. They are used to track work that improves system stability, addresses incident follow-ups, and resolves operational risks.
 
+7. **Security issues**: These represent vulnerabilities, pen test findings, and security hardening work, marked with the `security` label. Security issues include items from penetration tests, vulnerability scans, and proactive security improvements. They are prioritized by severity and tracked alongside other work items on the product group board.
+
 > Product group boards do not accommodate any other type of ticket. By strictly adhering to these work items, we maintain an organized and focused workflow that consistently adds value for our users.
 
 ## Issue prioritization


### PR DESCRIPTION
Adds "Security issues" as item #7 in the Work items section of the product groups handbook. This covers pen test findings, vulnerability scan results, and security hardening work tracked with the `security` label.

# Checklist for submitter

- [x] No code changes (handbook only)