### PR TITLE
Update deprecated GitOps keys in dogfood config

### DIFF
--- a/it-and-security/default.yml
+++ b/it-and-security/default.yml
@@ -22,7 +22,7 @@ org_settings:
       idp_name: Okta
       metadata_url: "$DOGFOOD_OKTA_METADATA_URL_END_USERS"
     end_user_license_agreement: ../it-and-security/lib/macos/misc/eula.pdf
-    apple_business_manager:
+    apple_business:
       - organization_name: Fleet Device Management Inc.
         macos_fleet: "💻 Workstations"
         ios_fleet: "📱🏢 Employee-issued mobile devices"
@@ -42,8 +42,8 @@ org_settings:
           - "🧪 Testing & QA"
   org_info:
     contact_url: https://fleetdm.slack.com/archives/C09861YJUJ2
-    org_logo_url: ""
-    org_logo_url_light_background: ""
+    org_logo_url_dark_mode: ""
+    org_logo_url_light_mode: ""
     org_name: Fleet
   secrets:
     - secret: $DOGFOOD_GLOBAL_ENROLL_SECRET


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** NA

Renames three deprecated `org_settings` keys in the dogfood GitOps config (`it-and-security/default.yml`) that the GitOps run currently warns about:

| Deprecated | Current |
|---|---|
| `org_settings.org_info.org_logo_url` | `org_settings.org_info.org_logo_url_dark_mode` |
| `org_settings.org_info.org_logo_url_light_background` | `org_settings.org_info.org_logo_url_light_mode` |
| `org_settings.mdm.apple_business_manager` | `org_settings.mdm.apple_business` |

### Notes for the reviewer

- The nested ABM keys (`macos_fleet`, `ios_fleet`, `ipados_fleet`, `byod_fleet`) were already on their current names per the `renameto` tags on `MDMAppleABMAssignmentInfo` in `server/fleet/app.go`, so only the parent key changed.
- `checkABMTeamAssignments` in `cmd/fleetctl/fleetctl/gitops.go` looks up `apple_business` only — the deprecated name is migrated by `ApplyDeprecatedKeyMappings` before it runs — so the new spelling is what the code actually reads.
- Both logo values are empty strings. The conflict check in `server/fleet/app.go` only errors when the old and new logo keys are set to *different* values, so this is a straight rename with no behavior change.
- Only `it-and-security/default.yml` used these keys. Other matches in the repo are under `cmd/fleetctl/fleetctl/testdata/`, which intentionally exercises both the old and new names.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  Not applicable — this only touches Fleet's own dogfood GitOps config, no product change.

## Testing

- [x] QA'd all new/changed functionality manually

Verified the file still parses and that the renamed keys land where the server expects them (2 `apple_business` entries, no lingering `apple_business_manager`, `org_info` carrying `org_logo_url_dark_mode` / `org_logo_url_light_mode`). The real check is the dogfood GitOps run on merge, which should no longer emit the three deprecation warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Apple Business Manager configuration naming.
  * Added separate organization logo settings for light and dark modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->