### PR TITLE
Render duration log fields with time units instead of raw nanoseconds

### DIFF
--- a/changes/log-took-duration-units
+++ b/changes/log-took-duration-units
@@ -1,0 +1,1 @@
+- Changed duration fields in Fleet server logs (e.g. `took`) to render as human-readable strings with time units (e.g. `"1.116187ms"`) instead of raw nanosecond numbers. Log pipelines that parse these fields numerically will need to be updated.

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -138,7 +138,7 @@ func updateVulnHostCounts(ctx context.Context, ds fleet.Datastore, logger *slog.
 		span.RecordError(err)
 		return fmt.Errorf("updating vulnerability host counts: %w", err)
 	}
-	logger.InfoContext(ctx, "vulnerability host counts updated", "took", time.Since(start).Seconds())
+	logger.InfoContext(ctx, "vulnerability host counts updated", "took", time.Since(start))
 
 	return nil
 }

--- a/server/platform/logging/logging.go
+++ b/server/platform/logging/logging.go
@@ -87,6 +87,12 @@ func NewSlogLogger(opts Options) *slog.Logger {
 // replaceAttr customizes slog output to maintain backward compatibility
 // with go-kit/log format.
 func replaceAttr(groups []string, a slog.Attr) slog.Attr {
+	// Render durations with a unit (e.g. "1.116187ms") instead of raw
+	// nanoseconds. Applies inside groups too, unlike the key-based rules below.
+	if a.Value.Kind() == slog.KindDuration {
+		return slog.String(a.Key, a.Value.Duration().String())
+	}
+
 	// Only modify top-level attributes (not in groups)
 	if len(groups) > 0 {
 		return a

--- a/server/platform/logging/logging_test.go
+++ b/server/platform/logging/logging_test.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -102,6 +103,15 @@ func TestNewSlogLoggerBackwardCompatibility(t *testing.T) {
 
 		// RFC3339Nano would have decimal: 2024-01-15T10:00:00.123456789Z
 		assert.NotRegexp(t, `"ts":"[^"]+\.[0-9]+Z"`, output)
+	})
+
+	t.Run("renders durations with a time unit", func(t *testing.T) {
+		buf, logger := newTestLogger(t, Options{JSON: true})
+
+		logger.InfoContext(t.Context(), "test", "took", 1116187*time.Nanosecond)
+		output := buf.String()
+
+		assert.Contains(t, output, `"took":"1.116187ms"`)
 	})
 
 	t.Run("uses lowercase levels", func(t *testing.T) {


### PR DESCRIPTION
When running Fleet with `--logging_json` (all cloud instances), time.Duration fields in server logs (e.g. `took`) rendered as raw nanosecond numbers in JSON output, e.g. `"took":1116187`. They now render as human-readable strings with time units, e.g. `"took":"1.116187ms"`.

The conversion happens in the shared slog handler's `replaceAttr` hook (`server/platform/logging/logging.go`), so it covers every duration-valued attribute codebase-wide (HTTP middleware, SCEP, cron, endpoint logging). `cmd/fleet/cron.go` logged one `took` as `.Seconds()` (a float) and was switched to a plain duration for consistency.

Notes:
- This changes the JSON log schema: log pipelines that parse duration fields numerically will need updating (called out in the changes file).
- The OTEL log export path intentionally keeps typed duration values; only stderr JSON/text output is affected.
- The text handler already rendered durations with units, so dev-mode output is unchanged.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests.
- [x] QA'd all new/changed functionality manually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server logs by displaying duration values as human-readable time strings with units.
  * Updated vulnerability host-count logging to report elapsed time consistently.
  * Duration values within grouped log fields are now formatted consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->