### PR TITLE
Settings > Integrations > Calendar events: Copy button missing border

### DIFF
--- a/frontend/components/forms/fields/InputField/InputField.tsx
+++ b/frontend/components/forms/fields/InputField/InputField.tsx
@@ -128,7 +128,7 @@ const InputField = ({
       <div
         className={`${baseClass}__copy-wrapper ${baseClass}__copy-wrapper--text-area`}
       >
-        <CopyButton copyText={copyText} variant="subdued" size="small" />
+        <CopyButton copyText={copyText} variant="secondary" size="small" />
       </div>
     );
   };

--- a/frontend/components/forms/fields/InputField/_styles.scss
+++ b/frontend/components/forms/fields/InputField/_styles.scss
@@ -91,9 +91,7 @@
     align-items: center;
     gap: $pad-xsmall;
     position: absolute;
-    top: 3px; // vertically center
     right: 0;
-    margin: 1px 4px;
     background-color: $core-fleet-white;
 
     &--text-area {

--- a/frontend/pages/admin/IntegrationsPage/cards/Calendars/_styles.scss
+++ b/frontend/pages/admin/IntegrationsPage/cards/Calendars/_styles.scss
@@ -36,6 +36,15 @@
   &__oauth-scopes {
     @include vertical-form-layout;
     padding-bottom: $pad-large;
+    position: relative;
+
+    .input-field__input-container.copy-enabled {
+      padding-top: 4px;
+    }
+
+    .copy-button__button {
+      border: 1px solid $ui-fleet-black-25;
+    }
   }
 
   #oauth-scopes {

--- a/frontend/pages/admin/IntegrationsPage/cards/Calendars/_styles.scss
+++ b/frontend/pages/admin/IntegrationsPage/cards/Calendars/_styles.scss
@@ -40,10 +40,6 @@
     .input-field__input-container.copy-enabled {
       padding-top: 4px;
     }
-
-    .copy-button__button {
-      border: 1px solid $ui-fleet-black-25;
-    }
   }
 
   #oauth-scopes {

--- a/frontend/pages/admin/IntegrationsPage/cards/Calendars/_styles.scss
+++ b/frontend/pages/admin/IntegrationsPage/cards/Calendars/_styles.scss
@@ -36,7 +36,6 @@
   &__oauth-scopes {
     @include vertical-form-layout;
     padding-bottom: $pad-large;
-    position: relative;
 
     .input-field__input-container.copy-enabled {
       padding-top: 4px;


### PR DESCRIPTION
For the following bug:
- https://github.com/fleetdm/fleet/issues/51576

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved alignment of copy controls within input fields.
  * Refined spacing and padding for OAuth scope fields.
  * Updated copy button styling for a clearer, more consistent appearance.
  * Removed unnecessary borders and positioning adjustments from OAuth scope copy controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->