### PR TITLE
Require a team selection when validating report run targets

### DIFF
--- a/changes/17210-run-query-empty-team-targets
+++ b/changes/17210-run-query-empty-team-targets
@@ -1,1 +1,1 @@
-- Fixed authorization for running a live query against a global report so that an empty team selection requires global permission instead of being treated as an already-validated target list.
+- Fixed live query authorization so that an empty team selection is authorized like an omitted one.

--- a/changes/17210-run-query-empty-team-targets
+++ b/changes/17210-run-query-empty-team-targets
@@ -1,0 +1,1 @@
+- Fixed authorization for running a live query against a global report so that an empty team selection requires global permission instead of being treated as an already-validated target list.

--- a/server/authz/policy.rego
+++ b/server/authz/policy.rego
@@ -63,6 +63,19 @@ team_role_or_none(subject, team_id) = role {
 	true
 }
 
+# no_team_targets is true when a targeted query selects no teams. Clients send
+# this either as null (field omitted) or as an empty list, and both mean the
+# same thing: there are no team targets to check the subject's roles against.
+# Rules that instead validate a selection by counting matched teams must also
+# require count(...) > 0, since an empty list satisfies that count vacuously.
+no_team_targets(obj) {
+	is_null(obj.host_targets.teams)
+}
+
+no_team_targets(obj) {
+	count(obj.host_targets.teams) == 0
+}
+
 ##
 # Global config
 ##
@@ -563,6 +576,8 @@ allow {
 
   not is_null(object.host_targets.teams)
   ok_teams := { tmid | tmid := object.host_targets.teams[_]; team_role(subject, tmid) == [admin, maintainer, technician, observer_plus][_] }
+  # Reject the vacuous empty-list match; see no_team_targets.
+  count(object.host_targets.teams) > 0
   count(ok_teams) == count(object.host_targets.teams)
 }
 
@@ -578,6 +593,8 @@ allow {
 
   not is_null(object.host_targets.teams)
   ok_teams := { tmid | tmid := object.host_targets.teams[_]; team_role(subject, tmid) == [admin, maintainer, technician, observer_plus][_] }
+  # Reject the vacuous empty-list match; see no_team_targets.
+  count(object.host_targets.teams) > 0
   count(ok_teams) == count(object.host_targets.teams)
 }
 
@@ -594,7 +611,7 @@ allow {
   team_role(subject, subject.teams[_].id) == [admin, maintainer, technician, observer_plus][_]
 
   # and there are no team targets
-  is_null(object.host_targets.teams)
+  no_team_targets(object)
 }
 
 # Team admin, maintainer, technician, and observer_plus running a non-observers_can_run query that belongs to their team when no target teams are specified.
@@ -607,7 +624,7 @@ allow {
   team_role(subject, object.team_id) == [admin, maintainer, technician, observer_plus][_]
 
   # there are no team targets
-  is_null(object.host_targets.teams)
+  no_team_targets(object)
 }
 
 # Team admin, maintainer, technician, and observer_plus can run a new query.
@@ -638,6 +655,8 @@ allow {
   not is_null(object.team_id)
   not is_null(object.host_targets.teams)
   ok_teams := { tmid | tmid := object.host_targets.teams[_]; tmid == object.team_id }
+  # Reject the vacuous empty-list match; see no_team_targets.
+  count(object.host_targets.teams) > 0
   count(ok_teams) == count(object.host_targets.teams)
 }
 
@@ -649,7 +668,7 @@ allow {
   action = run
 
   not is_null(object.team_id)
-  is_null(object.host_targets.teams)
+  no_team_targets(object)
 }
 
 # Team admin, maintainer, technician, observer_plus and observer running a global observers_can_run query must have the targets
@@ -664,6 +683,8 @@ allow {
 
   not is_null(object.host_targets.teams)
   ok_teams := { tmid | tmid := object.host_targets.teams[_]; team_role(subject, tmid) == [admin, maintainer, technician, observer_plus, observer][_] }
+  # Reject the vacuous empty-list match; see no_team_targets.
+  count(object.host_targets.teams) > 0
   count(ok_teams) == count(object.host_targets.teams)
 }
 
@@ -679,6 +700,8 @@ allow {
 
   not is_null(object.host_targets.teams)
   ok_teams := { tmid | tmid := object.host_targets.teams[_]; team_role(subject, tmid) == [admin, maintainer, technician, observer_plus][_] } | { tmid | tmid := object.host_targets.teams[_]; tmid == object.team_id; team_role(subject, tmid) == observer }
+  # Reject the vacuous empty-list match; see no_team_targets.
+  count(object.host_targets.teams) > 0
   count(ok_teams) == count(object.host_targets.teams)
 }
 
@@ -695,7 +718,7 @@ allow {
   team_role(subject, subject.teams[_].id) == [admin, maintainer, technician, observer_plus, observer][_]
 
   # and there are no team targets
-  is_null(object.host_targets.teams)
+  no_team_targets(object)
 }
 
 # Team admin, maintainer, technician, observer_plus and observer running an observers_can_run query that belongs to their team and there are no target teams.
@@ -708,7 +731,7 @@ allow {
   team_role(subject, object.team_id) == [admin, maintainer, technician, observer_plus, observer][_]
 
   # there are no team targets
-  is_null(object.host_targets.teams)
+  no_team_targets(object)
 }
 
 ##

--- a/server/authz/policy_test.go
+++ b/server/authz/policy_test.go
@@ -1466,12 +1466,23 @@ func TestAuthorizeQuery(t *testing.T) {
 		HostTargets: fleet.HostTargets{TeamIDs: []uint{1, 2, 3}},
 		Query:       globalQuery,
 	}
+	// An explicitly empty team list means the same thing as omitting it: no
+	// teams were selected. It must therefore behave exactly like the "no
+	// targets" fixtures above, rather than passing the target check vacuously.
+	globalQueryEmptyTeamTargets := &fleet.TargetedQuery{
+		HostTargets: fleet.HostTargets{TeamIDs: []uint{}},
+		Query:       globalQuery,
+	}
 
 	globalObserverQuery := &fleet.Query{
 		ObserverCanRun: true,
 	}
 	globalObserverQueryEmptyTargets := &fleet.TargetedQuery{
 		Query: globalObserverQuery,
+	}
+	globalObserverQueryEmptyTeamTargets := &fleet.TargetedQuery{
+		HostTargets: fleet.HostTargets{TeamIDs: []uint{}},
+		Query:       globalObserverQuery,
 	}
 	globalObserverQueryTargetedToTeam1 := &fleet.TargetedQuery{
 		HostTargets: fleet.HostTargets{TeamIDs: []uint{1}},
@@ -1501,6 +1512,14 @@ func TestAuthorizeQuery(t *testing.T) {
 		AuthorID:       new(teamMaintainer.ID),
 		ObserverCanRun: false,
 		TeamID:         new(uint(1)),
+	}
+
+	// Team-scoped, non-observers-can-run report with an explicitly empty team
+	// selection. Running it is gated on holding a qualifying role on the
+	// report's own team, whether the selection is empty or omitted.
+	teamMaintQueryEmptyTeamTargets := &fleet.TargetedQuery{
+		HostTargets: fleet.HostTargets{TeamIDs: []uint{}},
+		Query:       teamMaintQuery,
 	}
 	globalAdminQuery := &fleet.Query{ID: 3, AuthorID: new(test.UserAdmin.ID), ObserverCanRun: false}
 	globalGitOpsQuery := &fleet.Query{ID: 4, AuthorID: new(test.UserGitOps.ID), ObserverCanRun: false}
@@ -1581,6 +1600,8 @@ func TestAuthorizeQuery(t *testing.T) {
 				{user: test.UserNoRoles, object: globalQuery, action: write, allow: false},
 				{user: test.UserNoRoles, object: teamAdminQuery, action: write, allow: false},
 				{user: test.UserNoRoles, object: globalQueryNoTargets, action: run, allow: false},
+				{user: test.UserNoRoles, object: globalQueryEmptyTeamTargets, action: run, allow: false},
+				{user: test.UserNoRoles, object: globalObserverQueryEmptyTeamTargets, action: run, allow: false},
 				{user: test.UserNoRoles, object: globalQueryTargetedToTeam1, action: run, allow: false},
 				{user: test.UserNoRoles, object: globalQuery, action: runNew, allow: false},
 				{user: test.UserNoRoles, object: globalObserverQuery, action: read, allow: false},
@@ -1690,6 +1711,8 @@ func TestAuthorizeQuery(t *testing.T) {
 				{user: test.UserAdmin, object: teamMaintQuery, action: write, allow: true},
 				{user: test.UserAdmin, object: globalAdminQuery, action: write, allow: true},
 				{user: test.UserAdmin, object: globalQueryNoTargets, action: run, allow: true},
+				{user: test.UserAdmin, object: globalQueryEmptyTeamTargets, action: run, allow: true},
+				{user: test.UserAdmin, object: globalObserverQueryEmptyTeamTargets, action: run, allow: true},
 				{user: test.UserAdmin, object: globalQueryTargetedToTeam1, action: run, allow: true},
 				{user: test.UserAdmin, object: globalQuery, action: runNew, allow: true},
 				{user: test.UserAdmin, object: globalObserverQuery, action: read, allow: true},
@@ -1725,6 +1748,11 @@ func TestAuthorizeQuery(t *testing.T) {
 			name: "Team observer can read and run observer_can_run only",
 			testCases: []authTestCase{
 				{user: teamObserver, object: globalQuery, action: read, allow: true},
+				// An empty team selection behaves the same as omitting it: it grants no
+				// extra reach, so it still requires a role that may run a global query.
+				{user: teamObserver, object: globalQueryEmptyTeamTargets, action: run, allow: false},
+				{user: teamObserver, object: teamMaintQueryEmptyTeamTargets, action: run, allow: false},
+				{user: teamObserver, object: globalObserverQueryEmptyTeamTargets, action: run, allow: true},
 				{user: teamObserver, object: globalQuery, action: write, allow: false},
 				{user: teamObserver, object: teamAdminQuery, action: write, allow: false},
 				{user: teamObserver, object: globalQueryNoTargets, action: run, allow: false},
@@ -1751,6 +1779,8 @@ func TestAuthorizeQuery(t *testing.T) {
 			name: "Team observer+ can read all queries, not write them, and can run any query",
 			testCases: []authTestCase{
 				{user: teamObserverPlus, object: globalQuery, action: read, allow: true},
+				{user: teamObserverPlus, object: globalQueryEmptyTeamTargets, action: run, allow: true},
+				{user: teamObserverPlus, object: globalObserverQueryEmptyTeamTargets, action: run, allow: true},
 				{user: teamObserverPlus, object: globalQuery, action: write, allow: false},
 				{user: teamObserverPlus, object: teamAdminQuery, action: write, allow: false},
 				{user: teamObserverPlus, object: globalQueryNoTargets, action: run, allow: true},
@@ -1779,6 +1809,8 @@ func TestAuthorizeQuery(t *testing.T) {
 				{user: teamTechnician, object: globalQuery, action: write, allow: false},
 				{user: teamTechnician, object: teamAdminQuery, action: write, allow: false},
 				{user: teamTechnician, object: globalQueryNoTargets, action: run, allow: true},
+				{user: teamTechnician, object: globalQueryEmptyTeamTargets, action: run, allow: true},
+				{user: teamTechnician, object: globalObserverQueryEmptyTeamTargets, action: run, allow: true},
 				{user: teamTechnician, object: globalQueryTargetedToTeam1, action: run, allow: true},
 				{user: teamTechnician, object: globalQuery, action: runNew, allow: true},
 				{user: teamTechnician, object: globalObserverQuery, action: read, allow: true},
@@ -1801,6 +1833,9 @@ func TestAuthorizeQuery(t *testing.T) {
 			name: "Team maintainer can read/write/run queries filtered on their team(s)",
 			testCases: []authTestCase{
 				{user: teamMaintainer, object: globalQuery, action: read, allow: true},
+				{user: teamMaintainer, object: globalQueryEmptyTeamTargets, action: run, allow: true},
+				{user: teamMaintainer, object: teamMaintQueryEmptyTeamTargets, action: run, allow: true},
+				{user: teamMaintainer, object: globalObserverQueryEmptyTeamTargets, action: run, allow: true},
 				{user: teamMaintainer, object: globalQuery, action: write, allow: false}, // query belongs to global domain.
 				{user: teamMaintainer, object: teamMaintQuery, action: write, allow: true},
 				{user: teamMaintainer, object: teamAdminQuery, action: write, allow: true},
@@ -1829,6 +1864,9 @@ func TestAuthorizeQuery(t *testing.T) {
 			name: "Team admin can read/write their own queries/run queries filtered on their team(s)",
 			testCases: []authTestCase{
 				{user: teamAdmin, object: globalQuery, action: read, allow: true},
+				{user: teamAdmin, object: globalQueryEmptyTeamTargets, action: run, allow: true},
+				{user: teamAdmin, object: teamMaintQueryEmptyTeamTargets, action: run, allow: true},
+				{user: teamAdmin, object: globalObserverQueryEmptyTeamTargets, action: run, allow: true},
 				{user: teamAdmin, object: globalQuery, action: write, allow: false}, // query belongs to global domain.
 				{user: teamAdmin, object: teamAdminQuery, action: write, allow: true},
 				{user: teamAdmin, object: teamMaintQuery, action: write, allow: true},
@@ -1863,9 +1901,12 @@ func TestAuthorizeQuery(t *testing.T) {
 				{user: teamGitOps, object: teamGitOpsQuery, action: write, allow: true},
 				{user: teamGitOps, object: globalGitOpsQuery, action: write, allow: false}, // cannot write a global query
 				{user: teamGitOps, object: globalQueryNoTargets, action: run, allow: false},
+				{user: teamGitOps, object: globalQueryEmptyTeamTargets, action: run, allow: false},
+				{user: teamGitOps, object: teamMaintQueryEmptyTeamTargets, action: run, allow: false},
 				{user: teamGitOps, object: globalQueryTargetedToTeam1, action: run, allow: false},
 				{user: teamGitOps, object: globalQuery, action: runNew, allow: false},
 				{user: teamGitOps, object: globalObserverQueryEmptyTargets, action: run, allow: false},
+				{user: teamGitOps, object: globalObserverQueryEmptyTeamTargets, action: run, allow: false},
 				{user: teamGitOps, object: globalObserverQueryTargetedToTeam1, action: run, allow: false},
 				{user: teamGitOps, object: globalObserverQueryTargetedToTeam1AndTeam2, action: run, allow: false},
 				{user: teamGitOps, object: globalObserverQueryTargetedToTeam2, action: run, allow: false},

--- a/server/authz/policy_test.go
+++ b/server/authz/policy_test.go
@@ -1618,11 +1618,13 @@ func TestAuthorizeQuery(t *testing.T) {
 				{user: test.UserObserver, object: globalQuery, action: write, allow: false},
 				{user: test.UserObserver, object: teamAdminQuery, action: write, allow: false},
 				{user: test.UserObserver, object: globalQueryNoTargets, action: run, allow: false},
+				{user: test.UserObserver, object: globalQueryEmptyTeamTargets, action: run, allow: false}, // same as no targets
 				{user: test.UserObserver, object: globalQueryTargetedToTeam1, action: run, allow: false},
 				{user: test.UserObserver, object: globalQuery, action: runNew, allow: false},
 				{user: test.UserObserver, object: globalObserverQuery, action: read, allow: true},
 				{user: test.UserObserver, object: globalObserverQuery, action: write, allow: false},
 				{user: test.UserObserver, object: globalObserverQueryEmptyTargets, action: run, allow: true},            // can run observer query
+				{user: test.UserObserver, object: globalObserverQueryEmptyTeamTargets, action: run, allow: true},        // same as no targets
 				{user: test.UserObserver, object: globalObserverQueryTargetedToTeam1, action: run, allow: true},         // can run observer query
 				{user: test.UserObserver, object: globalObserverQueryTargetedToTeam1AndTeam2, action: run, allow: true}, // can run observer query
 				{user: test.UserObserver, object: globalObserverQuery, action: runNew, allow: false},


### PR DESCRIPTION
**Related issue:** N/A

## Description

The authorization rules for running a report against selected teams validate the selection by comparing the number of teams the caller has a qualifying role on to the number of teams selected. An empty selection satisfied that comparison with nothing to validate, so it passed regardless of the caller's roles.

This treats an empty team selection the same as an omitted one — clients send both, and they mean the same thing — so it is evaluated by the rules that require a qualifying role. The rules that compare counts now also require a selection, so an empty list can no longer satisfy them.

Note that the web UI always sends an empty list rather than omitting the field, so the two spellings had to be made equivalent rather than rejecting the empty one; that path is covered by the added tests.

## Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`.

## Testing

- [x] Added/updated automated tests — the policy tests now cover an explicitly empty team selection alongside the existing omitted-selection cases, for global and team-scoped reports, asserting that it behaves identically to omitting the field for every role.
- [x] QA'd all new/changed functionality manually — verified on a local instance that running a saved global report with an empty team selection is authorized for a team maintainer (the UI path) and rejected for a team GitOps user, and that naming a team the caller has no role on is still rejected.


cc @lukeheath for review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected authorization for live queries when no teams are selected.
  * Empty team selections now follow the same access rules as omitted team targets.
  * Prevented empty team lists from being incorrectly treated as valid team matches.

* **Tests**
  * Added coverage for empty team selections across global, observer, and team-scoped access scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->