### PR TITLE
Flush NVD vulnerability matches in bounded chunks to cut vuln cron memory

### DIFF
--- a/changes/51508-vuln-processing-memory-optimization
+++ b/changes/51508-vuln-processing-memory-optimization
@@ -1,0 +1,1 @@
+- Reduced memory usage of the vulnerabilities cron by streaming NVD matches to the database in bounded chunks instead of holding every matched vulnerability in memory (8.5 GB → 2.1 GB peak on a 22.7M-match fleet), and inserts now start during matching so large fleets no longer exceed the vulnerability processing time limit.

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -859,9 +859,9 @@ func checkNVDVulnerabilities(
 	cveCtx, cveSpan := tracer.Start(ctx, "vuln.nvd.translate_cpe_to_cve")
 	vulns, err := nvd.TranslateCPEToCVE(cveCtx, ds, vulnPath, logger, collectVulns, startTime)
 	if err != nil {
+		// Partial results are still returned: their rows are already inserted,
+		// so dropping them here would suppress their automations forever.
 		errHandler(cveCtx, logger, "analyzing vulnerable software: CPE->CVE", err)
-		cveSpan.End()
-		return nil
 	}
 	cveSpan.End()
 

--- a/server/vulnerabilities/nvd/cve.go
+++ b/server/vulnerabilities/nvd/cve.go
@@ -337,6 +337,9 @@ var matchFlushSize = 100_000
 // across chunks the inserts are upserts on the unique key. Insert errors are
 // logged and sticky so callers can skip the stale-row deletes for the cycle.
 type vulnSink struct {
+	// mu guards every field below and is held for the datastore flush itself.
+	// This is intentional backpressure so matcher workers block while a
+	// chunk is being written instead of buffering ahead of a slow insert.
 	mu        sync.Mutex
 	ds        fleet.Datastore
 	logger    *slog.Logger
@@ -351,6 +354,12 @@ type vulnSink struct {
 }
 
 type vulnSinkResult struct {
+	// collected is only complete for a single successful process lifetime: if
+	// a previous run was killed after a chunk was inserted but before it
+	// returned, that chunk's pairs are already in the datastore and will be
+	// classified as not-new on the next run, so their automations are never
+	// retried. Same tradeoff as a mid-corpus feed error, just with no error to
+	// react to — accepted as out of scope for this run-scoped sink.
 	collected     []fleet.SoftwareVulnerability
 	totalSoftware int
 	totalOS       int

--- a/server/vulnerabilities/nvd/cve.go
+++ b/server/vulnerabilities/nvd/cve.go
@@ -18,7 +18,6 @@ import (
 	"github.com/fleetdm/fleet/v4/pkg/fleethttp"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/fleet"
-	"github.com/fleetdm/fleet/v4/server/ptr"
 	nvdsync "github.com/fleetdm/fleet/v4/server/vulnerabilities/nvd/sync"
 	"github.com/fleetdm/fleet/v4/server/vulnerabilities/nvd/tools/cvefeed"
 	feednvd "github.com/fleetdm/fleet/v4/server/vulnerabilities/nvd/tools/cvefeed/nvd"
@@ -272,61 +271,34 @@ func TranslateCPEToCVE(
 		return nil, err
 	}
 
-	// we are using a map here to remove any duplicates - a vulnerability can be present in more than one
-	// NVD feed file.
-	softwareVulns := make(map[string]fleet.SoftwareVulnerability)
-	osVulns := make(map[string]fleet.OSVulnerability)
+	sink := newVulnSink(ds, logger, collectVulns)
+	var feedErr error
 	for _, file := range files {
-
-		foundSoftwareVulns, foundOSVulns, err := checkCVEs(
+		if err := checkCVEs(
 			ctx,
 			logger,
 			interfaceParsed,
 			file,
 			knownNVDBugRules,
-		)
-		if err != nil {
-			return nil, err
+			sink,
+		); err != nil {
+			// Keep scanning the remaining files: earlier chunks are already
+			// committed, so aborting would drop their collected results and
+			// suppress their automations forever (the next run's inserts
+			// would classify them as already known).
+			logger.ErrorContext(ctx, "error checking cves", "file", file, "err", err)
+			if feedErr == nil {
+				feedErr = ctxerr.Wrap(ctx, err, "checking cves")
+			}
 		}
-
-		for _, e := range foundSoftwareVulns {
-			softwareVulns[e.Key()] = e
-		}
-		for _, e := range foundOSVulns {
-			osVulns[e.Key()] = e
-		}
 	}
-
-	// Batch insert software vulnerabilities.
-	allSoftwareVulns := make([]fleet.SoftwareVulnerability, 0, len(softwareVulns))
-	for _, vuln := range softwareVulns {
-		allSoftwareVulns = append(allSoftwareVulns, vuln)
-	}
-
-	newVulns, softwareInsertErr := ds.InsertSoftwareVulnerabilities(ctx, allSoftwareVulns, fleet.NVDSource)
-	if softwareInsertErr != nil {
-		logger.ErrorContext(ctx, "cpe processing error", "err", softwareInsertErr)
-	}
-	if !collectVulns {
-		newVulns = nil
-	}
-
-	// Batch insert OS vulnerabilities.
-	allOSVulns := make([]fleet.OSVulnerability, 0, len(osVulns))
-	for _, vuln := range osVulns {
-		allOSVulns = append(allOSVulns, vuln)
-	}
-	osInsertErr := false
-	if _, err := ds.InsertOSVulnerabilities(ctx, allOSVulns, fleet.NVDSource); err != nil {
-		logger.ErrorContext(ctx, "cpe processing error", "err", err)
-		osInsertErr = true
-	}
+	res := sink.flush(ctx)
 
 	// Detect corrupted/empty CVE feeds. If we had CPE/OS inputs to match against but produced
 	// zero results across every feed file, the feed is almost certainly empty or corrupted
 	// (e.g., a failed/corrupted artifact from GitHub) — skip the deletes so we don't wipe
 	// legitimate existing software_cve rows that will be re-matched on the next good sync.
-	feedProducedNoData := len(allSoftwareVulns) == 0 && len(allOSVulns) == 0
+	feedProducedNoData := res.totalSoftware == 0 && res.totalOS == 0
 
 	// Delete any stale vulnerabilities. A vulnerability is stale iff the last time it was
 	// updated was more than `2 * periodicity` ago. This assumes that the whole vulnerability
@@ -334,12 +306,14 @@ func TranslateCPEToCVE(
 	//
 	// This is used to get rid of false positives once they are fixed and no longer detected as vulnerabilities.
 	// Skip cleanup when the corresponding insert failed to avoid deleting data with nothing to replace it.
-	if softwareInsertErr == nil && !feedProducedNoData {
+	// With part of the corpus unread (feedErr), rows not re-matched this run
+	// can't be assumed stale, so skip the deletes entirely.
+	if feedErr == nil && res.softwareErr == nil && !feedProducedNoData {
 		if err = ds.DeleteOutOfDateVulnerabilities(ctx, fleet.NVDSource, startTime); err != nil {
 			logger.ErrorContext(ctx, "error deleting out of date vulnerabilities", "err", err)
 		}
 	}
-	if !osInsertErr && !feedProducedNoData {
+	if feedErr == nil && res.osErr == nil && !feedProducedNoData {
 		if err = ds.DeleteOutOfDateOSVulnerabilities(ctx, fleet.NVDSource, startTime); err != nil {
 			logger.ErrorContext(ctx, "error deleting out of date OS vulnerabilities", "err", err)
 		}
@@ -349,7 +323,132 @@ func TranslateCPEToCVE(
 			"software_cpes", len(parsed), "os_cpes", len(cpes), "feed_files", len(files))
 	}
 
-	return newVulns, nil
+	return res.collected, feedErr
+}
+
+// matchFlushSize is the default for how many buffered matches trigger a
+// datastore flush. A var so tests can lower it.
+var matchFlushSize = 100_000
+
+// vulnSink receives matched vulnerabilities from the checkCVEs workers and
+// flushes them to the datastore in bounded chunks, so matches never accumulate
+// in memory.
+// Duplicates are deduped within each chunk and in the collected results;
+// across chunks the inserts are upserts on the unique key. Insert errors are
+// logged and sticky so callers can skip the stale-row deletes for the cycle.
+type vulnSink struct {
+	mu        sync.Mutex
+	ds        fleet.Datastore
+	logger    *slog.Logger
+	collect   bool
+	flushSize int
+
+	softwareBuf []fleet.SoftwareVulnerability
+	osBuf       []fleet.OSVulnerability
+
+	collectedSeen map[string]struct{}
+	res           vulnSinkResult
+}
+
+type vulnSinkResult struct {
+	collected     []fleet.SoftwareVulnerability
+	totalSoftware int
+	totalOS       int
+	softwareErr   error
+	osErr         error
+}
+
+func newVulnSink(ds fleet.Datastore, logger *slog.Logger, collect bool) *vulnSink {
+	s := &vulnSink{ds: ds, logger: logger, collect: collect, flushSize: matchFlushSize}
+	if collect {
+		s.collectedSeen = make(map[string]struct{})
+	}
+	return s
+}
+
+func (s *vulnSink) addSoftware(ctx context.Context, v fleet.SoftwareVulnerability) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.softwareBuf = append(s.softwareBuf, v)
+	s.res.totalSoftware++
+	if len(s.softwareBuf) >= s.flushSize {
+		s.flushSoftwareLocked(ctx)
+	}
+}
+
+func (s *vulnSink) addOS(ctx context.Context, v fleet.OSVulnerability) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.osBuf = append(s.osBuf, v)
+	s.res.totalOS++
+	if len(s.osBuf) >= s.flushSize {
+		s.flushOSLocked(ctx)
+	}
+}
+
+func (s *vulnSink) flush(ctx context.Context) vulnSinkResult {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.flushSoftwareLocked(ctx)
+	s.flushOSLocked(ctx)
+	return s.res
+}
+
+func (s *vulnSink) flushSoftwareLocked(ctx context.Context) {
+	if len(s.softwareBuf) == 0 {
+		return
+	}
+	// Dedupe in place: a pair can be matched by more than one rule.
+	seen := make(map[string]struct{}, len(s.softwareBuf))
+	batch := s.softwareBuf[:0]
+	for _, v := range s.softwareBuf {
+		if _, ok := seen[v.Key()]; ok {
+			continue
+		}
+		seen[v.Key()] = struct{}{}
+		batch = append(batch, v)
+	}
+	s.softwareBuf = s.softwareBuf[:0]
+
+	newVulns, err := s.ds.InsertSoftwareVulnerabilities(ctx, batch, fleet.NVDSource)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "cpe processing error", "err", err)
+		s.res.softwareErr = err
+		return
+	}
+	if s.collect {
+		// The datastore's existence check reads from the replica, so a pair
+		// straddling a flush boundary can be reported as new twice under
+		// replication lag; collectedSeen keeps the collected results unique.
+		for _, v := range newVulns {
+			if _, ok := s.collectedSeen[v.Key()]; ok {
+				continue
+			}
+			s.collectedSeen[v.Key()] = struct{}{}
+			s.res.collected = append(s.res.collected, v)
+		}
+	}
+}
+
+func (s *vulnSink) flushOSLocked(ctx context.Context) {
+	if len(s.osBuf) == 0 {
+		return
+	}
+	seen := make(map[string]struct{}, len(s.osBuf))
+	batch := s.osBuf[:0]
+	for _, v := range s.osBuf {
+		if _, ok := seen[v.Key()]; ok {
+			continue
+		}
+		seen[v.Key()] = struct{}{}
+		batch = append(batch, v)
+	}
+	s.osBuf = s.osBuf[:0]
+
+	if _, err := s.ds.InsertOSVulnerabilities(ctx, batch, fleet.NVDSource); err != nil {
+		s.logger.ErrorContext(ctx, "cpe processing error", "err", err)
+		s.res.osErr = err
+	}
 }
 
 // GetMacOSCPEs translates all found macOS Operating Systems to CPEs.
@@ -419,10 +518,11 @@ func checkCVEs(
 	cpeItems []itemWithNVDMeta,
 	jsonFile string,
 	knownNVDBugRules CPEMatchingRules,
-) ([]fleet.SoftwareVulnerability, []fleet.OSVulnerability, error) {
+	sink *vulnSink,
+) error {
 	dict, err := cvefeed.LoadJSONDictionary(jsonFile)
 	if err != nil {
-		return nil, nil, err
+		return err
 	}
 
 	// Group dictionary by vendor using a map.
@@ -452,12 +552,8 @@ func checkCVEs(
 	}
 
 	CPEItemCh := make(chan itemWithNVDMeta)
-	var foundSoftwareVulns []fleet.SoftwareVulnerability
-	var foundOSVulns []fleet.OSVulnerability
 
 	var wg sync.WaitGroup
-	var softwareMu sync.Mutex
-	var osMu sync.Mutex
 
 	logger = logger.With("json_file", jsonFile)
 
@@ -523,26 +619,17 @@ func checkCVEs(
 							}
 
 							if _, ok := CPEItem.(softwareCPEWithNVDMeta); ok {
-								vuln := fleet.SoftwareVulnerability{
+								sink.addSoftware(ctx, fleet.SoftwareVulnerability{
 									SoftwareID:        CPEItem.GetID(),
 									CVE:               matches.CVE.ID(),
-									ResolvedInVersion: ptr.String(resolvedVersion),
-								}
-
-								softwareMu.Lock()
-								foundSoftwareVulns = append(foundSoftwareVulns, vuln)
-								softwareMu.Unlock()
+									ResolvedInVersion: new(resolvedVersion),
+								})
 							} else if _, ok := CPEItem.(osCPEWithNVDMeta); ok {
-
-								vuln := fleet.OSVulnerability{
+								sink.addOS(ctx, fleet.OSVulnerability{
 									OSID:              CPEItem.GetID(),
 									CVE:               matches.CVE.ID(),
-									ResolvedInVersion: ptr.String(resolvedVersion),
-								}
-
-								osMu.Lock()
-								foundOSVulns = append(foundOSVulns, vuln)
-								osMu.Unlock()
+									ResolvedInVersion: new(resolvedVersion),
+								})
 							}
 
 						}
@@ -564,7 +651,7 @@ func checkCVEs(
 	logger.DebugContext(ctx, "cpes pushed")
 	wg.Wait()
 
-	return foundSoftwareVulns, foundOSVulns, nil
+	return nil
 }
 
 var pythonVersionWithUpdate = regexp.MustCompile(`(alpha|beta|rc)(\d+)`)

--- a/server/vulnerabilities/nvd/cve_test.go
+++ b/server/vulnerabilities/nvd/cve_test.go
@@ -1,12 +1,14 @@
 package nvd
 
 import (
+	"compress/gzip"
 	"context"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -1386,4 +1388,170 @@ func TestExpandCPEAliases(t *testing.T) {
 			require.Equal(t, tc.expectedAliases, aliases)
 		})
 	}
+}
+
+// writeTestNVDFeedFile writes a minimal gzipped NVD 1.1 feed file with one item
+// per given CVE ID, each affecting testvendor:testprod versions below 2.0.
+func writeTestNVDFeedFile(t *testing.T, dir, name string, cveIDs ...string) {
+	t.Helper()
+	var items []string
+	for _, cveID := range cveIDs {
+		items = append(items, fmt.Sprintf(`{
+			"cve": {
+				"CVE_data_meta": {"ID": %q},
+				"description": {"description_data": [{"lang": "en", "value": "test vulnerability"}]}
+			},
+			"configurations": {
+				"CVE_data_version": "4.0",
+				"nodes": [{
+					"operator": "OR",
+					"cpe_match": [{
+						"vulnerable": true,
+						"cpe23Uri": "cpe:2.3:a:testvendor:testprod:*:*:*:*:*:*:*:*",
+						"versionEndExcluding": "2.0"
+					}]
+				}]
+			},
+			"impact": {},
+			"publishedDate": "2023-01-01T00:00Z",
+			"lastModifiedDate": "2023-01-01T00:00Z"
+		}`, cveID))
+	}
+	feed := fmt.Sprintf(`{
+		"CVE_data_type": "CVE",
+		"CVE_data_format": "MITRE",
+		"CVE_data_version": "4.0",
+		"CVE_Items": [%s]
+	}`, strings.Join(items, ","))
+
+	f, err := os.Create(filepath.Join(dir, name))
+	require.NoError(t, err)
+	gz := gzip.NewWriter(f)
+	_, err = gz.Write([]byte(feed))
+	require.NoError(t, err)
+	require.NoError(t, gz.Close())
+	require.NoError(t, f.Close())
+}
+
+func TestTranslateCPEToCVEFlushesMatchesInChunks(t *testing.T) {
+	// Not parallel: overrides the package-level flush threshold.
+	orig := matchFlushSize
+	matchFlushSize = 2
+	t.Cleanup(func() { matchFlushSize = orig })
+
+	ctx := t.Context()
+
+	vulnPath := t.TempDir()
+	writeTestNVDFeedFile(t, vulnPath, "nvdcve-1.1-2023.json.gz",
+		"CVE-2023-1111", "CVE-2023-2222", "CVE-2023-3333", "CVE-2023-4444", "CVE-2023-5555")
+	writeTestNVDFeedFile(t, vulnPath, "nvdcve-1.1-2024.json.gz", "CVE-2024-6666")
+
+	ds := new(mock.Store)
+	ds.ListSoftwareCPEsFunc = func(ctx context.Context) ([]fleet.SoftwareCPE, error) {
+		return []fleet.SoftwareCPE{
+			{ID: 1, SoftwareID: 10, CPE: "cpe:2.3:a:testvendor:testprod:1.0:*:*:*:*:*:*:*"},
+		}, nil
+	}
+	ds.ListOperatingSystemsForPlatformFunc = func(ctx context.Context, platform string) ([]fleet.OperatingSystem, error) {
+		return nil, nil
+	}
+
+	var insertCalls int
+	var inserted []fleet.SoftwareVulnerability
+	ds.InsertSoftwareVulnerabilitiesFunc = func(ctx context.Context, vulns []fleet.SoftwareVulnerability, src fleet.VulnerabilitySource) ([]fleet.SoftwareVulnerability, error) {
+		insertCalls++
+		inserted = append(inserted, vulns...)
+		return vulns, nil
+	}
+	ds.InsertOSVulnerabilitiesFunc = func(ctx context.Context, vulns []fleet.OSVulnerability, src fleet.VulnerabilitySource) (int64, error) {
+		return int64(len(vulns)), nil
+	}
+	ds.DeleteOutOfDateVulnerabilitiesFunc = func(ctx context.Context, source fleet.VulnerabilitySource, olderThan time.Time) error {
+		return nil
+	}
+	ds.DeleteOutOfDateOSVulnerabilitiesFunc = func(ctx context.Context, source fleet.VulnerabilitySource, olderThan time.Time) error {
+		return nil
+	}
+
+	collected, err := TranslateCPEToCVE(ctx, ds, vulnPath, slog.New(slog.DiscardHandler), true, time.Now().UTC().Add(-time.Hour))
+	require.NoError(t, err)
+
+	allCVEs := []string{
+		"CVE-2023-1111", "CVE-2023-2222", "CVE-2023-3333", "CVE-2023-4444", "CVE-2023-5555",
+		"CVE-2024-6666",
+	}
+
+	// Sanity: all CVEs from both feed files match the seeded CPE.
+	var cves []string
+	for _, v := range inserted {
+		require.Equal(t, uint(10), v.SoftwareID)
+		cves = append(cves, v.CVE)
+	}
+	require.ElementsMatch(t, allCVEs, cves)
+
+	// Matches must be flushed to the datastore in bounded chunks rather than
+	// accumulated for the whole corpus: holding every matched (software, CVE)
+	// pair in memory is what drove multi-GB peaks on large fleets. With a
+	// threshold of 2 and 6 matches, the sink flushes exactly 3 times.
+	require.Equal(t, 3, insertCalls)
+
+	// collectVulns keeps returning the newly inserted vulnerabilities.
+	var collectedCVEs []string
+	for _, v := range collected {
+		collectedCVEs = append(collectedCVEs, v.CVE)
+	}
+	require.ElementsMatch(t, allCVEs, collectedCVEs)
+
+	require.True(t, ds.DeleteOutOfDateVulnerabilitiesFuncInvoked)
+	require.True(t, ds.DeleteOutOfDateOSVulnerabilitiesFuncInvoked)
+}
+
+func TestTranslateCPEToCVEContinuesPastCorruptFeedFile(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	vulnPath := t.TempDir()
+	writeTestNVDFeedFile(t, vulnPath, "nvdcve-1.1-2023.json.gz", "CVE-2023-1111")
+	require.NoError(t, os.WriteFile(filepath.Join(vulnPath, "nvdcve-1.1-2024.json.gz"), []byte("not a gzip"), 0o644))
+	writeTestNVDFeedFile(t, vulnPath, "nvdcve-1.1-2025.json.gz", "CVE-2025-2222")
+
+	ds := new(mock.Store)
+	ds.ListSoftwareCPEsFunc = func(ctx context.Context) ([]fleet.SoftwareCPE, error) {
+		return []fleet.SoftwareCPE{
+			{ID: 1, SoftwareID: 10, CPE: "cpe:2.3:a:testvendor:testprod:1.0:*:*:*:*:*:*:*"},
+		}, nil
+	}
+	ds.ListOperatingSystemsForPlatformFunc = func(ctx context.Context, platform string) ([]fleet.OperatingSystem, error) {
+		return nil, nil
+	}
+	ds.InsertSoftwareVulnerabilitiesFunc = func(ctx context.Context, vulns []fleet.SoftwareVulnerability, src fleet.VulnerabilitySource) ([]fleet.SoftwareVulnerability, error) {
+		return vulns, nil
+	}
+	ds.InsertOSVulnerabilitiesFunc = func(ctx context.Context, vulns []fleet.OSVulnerability, src fleet.VulnerabilitySource) (int64, error) {
+		return int64(len(vulns)), nil
+	}
+	ds.DeleteOutOfDateVulnerabilitiesFunc = func(ctx context.Context, source fleet.VulnerabilitySource, olderThan time.Time) error {
+		return nil
+	}
+	ds.DeleteOutOfDateOSVulnerabilitiesFunc = func(ctx context.Context, source fleet.VulnerabilitySource, olderThan time.Time) error {
+		return nil
+	}
+
+	collected, err := TranslateCPEToCVE(ctx, ds, vulnPath, slog.New(slog.DiscardHandler), true, time.Now().UTC().Add(-time.Hour))
+
+	// The corrupted file is reported, but the scan continues: matches from the
+	// healthy files are still inserted and collected. Aborting instead would
+	// suppress their automations forever — earlier chunks are already
+	// committed, so the next run would classify them as already known.
+	require.Error(t, err)
+	var collectedCVEs []string
+	for _, v := range collected {
+		collectedCVEs = append(collectedCVEs, v.CVE)
+	}
+	require.ElementsMatch(t, []string{"CVE-2023-1111", "CVE-2025-2222"}, collectedCVEs)
+
+	// Stale-row deletes are skipped: with part of the corpus unread, rows not
+	// re-matched this run can't be assumed stale.
+	require.False(t, ds.DeleteOutOfDateVulnerabilitiesFuncInvoked)
+	require.False(t, ds.DeleteOutOfDateOSVulnerabilitiesFuncInvoked)
 }

--- a/server/vulnerabilities/nvd/cve_test.go
+++ b/server/vulnerabilities/nvd/cve_test.go
@@ -3,6 +3,7 @@ package nvd
 import (
 	"compress/gzip"
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -1390,33 +1391,40 @@ func TestExpandCPEAliases(t *testing.T) {
 	}
 }
 
-// writeTestNVDFeedFile writes a minimal gzipped NVD 1.1 feed file with one item
-// per given CVE ID, each affecting testvendor:testprod versions below 2.0.
-func writeTestNVDFeedFile(t *testing.T, dir, name string, cveIDs ...string) {
-	t.Helper()
-	var items []string
-	for _, cveID := range cveIDs {
-		items = append(items, fmt.Sprintf(`{
-			"cve": {
-				"CVE_data_meta": {"ID": %q},
-				"description": {"description_data": [{"lang": "en", "value": "test vulnerability"}]}
-			},
-			"configurations": {
-				"CVE_data_version": "4.0",
-				"nodes": [{
-					"operator": "OR",
-					"cpe_match": [{
-						"vulnerable": true,
-						"cpe23Uri": "cpe:2.3:a:testvendor:testprod:*:*:*:*:*:*:*:*",
-						"versionEndExcluding": "2.0"
-					}]
-				}]
-			},
-			"impact": {},
-			"publishedDate": "2023-01-01T00:00Z",
-			"lastModifiedDate": "2023-01-01T00:00Z"
-		}`, cveID))
+// nvdFeedItemJSON returns a single NVD CVE_Items entry vulnerable below the
+// given version, matching either a testvendor:testprod software CPE (kind
+// "software") or an apple macOS CPE (kind "os").
+func nvdFeedItemJSON(cveID, kind, versionEndExcluding string) string {
+	cpe23URI := "cpe:2.3:a:testvendor:testprod:*:*:*:*:*:*:*:*"
+	if kind == "os" {
+		cpe23URI = "cpe:2.3:o:apple:macos:*:*:*:*:*:*:*:*"
 	}
+	return fmt.Sprintf(`{
+		"cve": {
+			"CVE_data_meta": {"ID": %q},
+			"description": {"description_data": [{"lang": "en", "value": "test vulnerability"}]}
+		},
+		"configurations": {
+			"CVE_data_version": "4.0",
+			"nodes": [{
+				"operator": "OR",
+				"cpe_match": [{
+					"vulnerable": true,
+					"cpe23Uri": %q,
+					"versionEndExcluding": %q
+				}]
+			}]
+		},
+		"impact": {},
+		"publishedDate": "2023-01-01T00:00Z",
+		"lastModifiedDate": "2023-01-01T00:00Z"
+	}`, cveID, cpe23URI, versionEndExcluding)
+}
+
+// writeTestNVDFeedItems writes a minimal gzipped NVD 1.1 feed file containing
+// the given raw CVE_Items entries (see nvdFeedItemJSON).
+func writeTestNVDFeedItems(t *testing.T, dir, name string, items []string) {
+	t.Helper()
 	feed := fmt.Sprintf(`{
 		"CVE_data_type": "CVE",
 		"CVE_data_format": "MITRE",
@@ -1431,6 +1439,18 @@ func writeTestNVDFeedFile(t *testing.T, dir, name string, cveIDs ...string) {
 	require.NoError(t, err)
 	require.NoError(t, gz.Close())
 	require.NoError(t, f.Close())
+}
+
+// writeTestNVDFeedFile writes a minimal gzipped NVD 1.1 feed file with one
+// software item per given CVE ID, each affecting testvendor:testprod
+// versions below 2.0.
+func writeTestNVDFeedFile(t *testing.T, dir, name string, cveIDs ...string) {
+	t.Helper()
+	var items []string
+	for _, cveID := range cveIDs {
+		items = append(items, nvdFeedItemJSON(cveID, "software", "2.0"))
+	}
+	writeTestNVDFeedItems(t, dir, name, items)
 }
 
 func TestTranslateCPEToCVEFlushesMatchesInChunks(t *testing.T) {
@@ -1506,52 +1526,120 @@ func TestTranslateCPEToCVEFlushesMatchesInChunks(t *testing.T) {
 	require.True(t, ds.DeleteOutOfDateOSVulnerabilitiesFuncInvoked)
 }
 
-func TestTranslateCPEToCVEContinuesPastCorruptFeedFile(t *testing.T) {
+func TestTranslateCPEToCVESkipsStaleDeletesOnError(t *testing.T) {
 	t.Parallel()
-	ctx := t.Context()
 
-	vulnPath := t.TempDir()
-	writeTestNVDFeedFile(t, vulnPath, "nvdcve-1.1-2023.json.gz", "CVE-2023-1111")
-	require.NoError(t, os.WriteFile(filepath.Join(vulnPath, "nvdcve-1.1-2024.json.gz"), []byte("not a gzip"), 0o644))
-	writeTestNVDFeedFile(t, vulnPath, "nvdcve-1.1-2025.json.gz", "CVE-2025-2222")
+	for _, tc := range []struct {
+		name string
+		// setupFeed writes the feed file(s) for the case into dir.
+		setupFeed          func(t *testing.T, dir string)
+		softwareInsertErr  error
+		osInsertErr        error
+		wantErr            bool
+		wantCollectedCVEs  []string
+		wantSoftwareDelete bool
+		wantOSDelete       bool
+	}{
+		{
+			name: "feed file fails to load",
+			setupFeed: func(t *testing.T, dir string) {
+				writeTestNVDFeedFile(t, dir, "nvdcve-1.1-2023.json.gz", "CVE-2023-1111")
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "nvdcve-1.1-2024.json.gz"), []byte("not a gzip"), 0o644))
+				writeTestNVDFeedFile(t, dir, "nvdcve-1.1-2025.json.gz", "CVE-2025-2222")
+			},
+			// The corrupted file is reported, but the scan continues: matches
+			// from the healthy files are still inserted and collected.
+			// Aborting instead would suppress their automations forever —
+			// earlier chunks are already committed, so the next run would
+			// classify them as already known.
+			wantErr:           true,
+			wantCollectedCVEs: []string{"CVE-2023-1111", "CVE-2025-2222"},
+			// With part of the corpus unread, rows not re-matched this run
+			// can't be assumed stale, so both deletes are skipped.
+			wantSoftwareDelete: false,
+			wantOSDelete:       false,
+		},
+		{
+			name: "software insert fails",
+			setupFeed: func(t *testing.T, dir string) {
+				writeTestNVDFeedItems(t, dir, "nvdcve-1.1-2023.json.gz", []string{
+					nvdFeedItemJSON("CVE-2023-1111", "software", "2.0"),
+					nvdFeedItemJSON("CVE-2023-2222", "os", "16.0"),
+				})
+			},
+			softwareInsertErr: errors.New("insert failed"),
+			wantCollectedCVEs: nil,
+			// Each stream's delete is gated independently: only the software
+			// delete is skipped.
+			wantSoftwareDelete: false,
+			wantOSDelete:       true,
+		},
+		{
+			name: "os insert fails",
+			setupFeed: func(t *testing.T, dir string) {
+				writeTestNVDFeedItems(t, dir, "nvdcve-1.1-2023.json.gz", []string{
+					nvdFeedItemJSON("CVE-2023-1111", "software", "2.0"),
+					nvdFeedItemJSON("CVE-2023-2222", "os", "16.0"),
+				})
+			},
+			osInsertErr:       errors.New("insert failed"),
+			wantCollectedCVEs: []string{"CVE-2023-1111"},
+			// Only the OS delete is skipped.
+			wantSoftwareDelete: true,
+			wantOSDelete:       false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := t.Context()
 
-	ds := new(mock.Store)
-	ds.ListSoftwareCPEsFunc = func(ctx context.Context) ([]fleet.SoftwareCPE, error) {
-		return []fleet.SoftwareCPE{
-			{ID: 1, SoftwareID: 10, CPE: "cpe:2.3:a:testvendor:testprod:1.0:*:*:*:*:*:*:*"},
-		}, nil
-	}
-	ds.ListOperatingSystemsForPlatformFunc = func(ctx context.Context, platform string) ([]fleet.OperatingSystem, error) {
-		return nil, nil
-	}
-	ds.InsertSoftwareVulnerabilitiesFunc = func(ctx context.Context, vulns []fleet.SoftwareVulnerability, src fleet.VulnerabilitySource) ([]fleet.SoftwareVulnerability, error) {
-		return vulns, nil
-	}
-	ds.InsertOSVulnerabilitiesFunc = func(ctx context.Context, vulns []fleet.OSVulnerability, src fleet.VulnerabilitySource) (int64, error) {
-		return int64(len(vulns)), nil
-	}
-	ds.DeleteOutOfDateVulnerabilitiesFunc = func(ctx context.Context, source fleet.VulnerabilitySource, olderThan time.Time) error {
-		return nil
-	}
-	ds.DeleteOutOfDateOSVulnerabilitiesFunc = func(ctx context.Context, source fleet.VulnerabilitySource, olderThan time.Time) error {
-		return nil
-	}
+			vulnPath := t.TempDir()
+			tc.setupFeed(t, vulnPath)
 
-	collected, err := TranslateCPEToCVE(ctx, ds, vulnPath, slog.New(slog.DiscardHandler), true, time.Now().UTC().Add(-time.Hour))
+			ds := new(mock.Store)
+			ds.ListSoftwareCPEsFunc = func(ctx context.Context) ([]fleet.SoftwareCPE, error) {
+				return []fleet.SoftwareCPE{
+					{ID: 1, SoftwareID: 10, CPE: "cpe:2.3:a:testvendor:testprod:1.0:*:*:*:*:*:*:*"},
+				}, nil
+			}
+			ds.ListOperatingSystemsForPlatformFunc = func(ctx context.Context, platform string) ([]fleet.OperatingSystem, error) {
+				return []fleet.OperatingSystem{{ID: 20, Platform: "darwin", Version: "15.1"}}, nil
+			}
+			ds.InsertSoftwareVulnerabilitiesFunc = func(ctx context.Context, vulns []fleet.SoftwareVulnerability, src fleet.VulnerabilitySource) ([]fleet.SoftwareVulnerability, error) {
+				if tc.softwareInsertErr != nil {
+					return nil, tc.softwareInsertErr
+				}
+				return vulns, nil
+			}
+			ds.InsertOSVulnerabilitiesFunc = func(ctx context.Context, vulns []fleet.OSVulnerability, src fleet.VulnerabilitySource) (int64, error) {
+				if tc.osInsertErr != nil {
+					return 0, tc.osInsertErr
+				}
+				return int64(len(vulns)), nil
+			}
+			ds.DeleteOutOfDateVulnerabilitiesFunc = func(ctx context.Context, source fleet.VulnerabilitySource, olderThan time.Time) error {
+				return nil
+			}
+			ds.DeleteOutOfDateOSVulnerabilitiesFunc = func(ctx context.Context, source fleet.VulnerabilitySource, olderThan time.Time) error {
+				return nil
+			}
 
-	// The corrupted file is reported, but the scan continues: matches from the
-	// healthy files are still inserted and collected. Aborting instead would
-	// suppress their automations forever — earlier chunks are already
-	// committed, so the next run would classify them as already known.
-	require.Error(t, err)
-	var collectedCVEs []string
-	for _, v := range collected {
-		collectedCVEs = append(collectedCVEs, v.CVE)
+			collected, err := TranslateCPEToCVE(ctx, ds, vulnPath, slog.New(slog.DiscardHandler), true, time.Now().UTC().Add(-time.Hour))
+
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			var collectedCVEs []string
+			for _, v := range collected {
+				collectedCVEs = append(collectedCVEs, v.CVE)
+			}
+			require.ElementsMatch(t, tc.wantCollectedCVEs, collectedCVEs)
+
+			require.Equal(t, tc.wantSoftwareDelete, ds.DeleteOutOfDateVulnerabilitiesFuncInvoked)
+			require.Equal(t, tc.wantOSDelete, ds.DeleteOutOfDateOSVulnerabilitiesFuncInvoked)
+		})
 	}
-	require.ElementsMatch(t, []string{"CVE-2023-1111", "CVE-2025-2222"}, collectedCVEs)
-
-	// Stale-row deletes are skipped: with part of the corpus unread, rows not
-	// re-matched this run can't be assumed stale.
-	require.False(t, ds.DeleteOutOfDateVulnerabilitiesFuncInvoked)
-	require.False(t, ds.DeleteOutOfDateOSVulnerabilitiesFuncInvoked)
 }


### PR DESCRIPTION
Resolves #51508

TranslateCPEToCVE held every matched (software, CVE) pair from all NVD feed files in a map plus a full slice copy (~300 B/pair), so peak memory scaled with the fleet.

Matches now stream from the matcher goroutines into a vulnSink flushed every 100k matches, deduped per chunk and in the collected results; the (software_id, cve) upserts make cross-chunk duplicates safe, and the corrupted-feed and skip-deletes-on-insert-failure guards are preserved. A feed file that fails to load no longer aborts the scan: the remaining files are still processed (their rows are committed either way, so aborting would suppress their automations forever) and stale-row deletes are skipped for the cycle.

## Benchmark

 22,745,812 matched (software × CVE) pairs - 20,200 software items including 16k stale browser versions - same NVD feed files, same database, premium license, measured with /usr/bin/time -l.
  
Identical workload for both runs: 22,745,812 matched (software × CVE) pairs (20,200 software items, 16k stale browser versions), same NVD feed files, same database, premium license. Measured with `/usr/bin/time -l` (max RSS) plus 1s RSS sampling.

  |                    | Before (accumulate all matches)                                | After (chunked flush)                     |
  | ------------------ | -------------------------------------------------------------- | ----------------------------------------- |
  | Peak memory        | 8,549 MB                                                        | **2,024 MB (4.2× less)**                   |
  | Wall time          | >60 min — killed at the `vuln_processing` deadline              | **31.2 min — completed**                   |
  | Rows inserted      | 18.5M of 22.7M (partial; scanners after NVD silently skipped)   | all 22,745,812, exit 0                     |
  | RSS profile        | 2→6 GB in 15 s at the map→slice copy, plateau at 8.3 GB         | flat ~1.6 GB throughout (~1.9 GB tail)     |
  | Peak set by        | ~300 B × total matched pairs (scales with fleet)                | CVE-meta parse floor (independent of fleet) |
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vulnerability feed processing to continue after individual feed errors.
  * Preserves successfully collected vulnerability results when processing is incomplete.
  * Prevents stale vulnerability data from being removed when feed processing or validation fails.
  * Processes vulnerability updates in bounded batches for more reliable syncing.
* **Tests**
  * Added coverage for chunked updates, corrupt feed files, partial results, and stale-data protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->