### PR TITLE
Fix API endpoint catalog validation in mock-backed tests (unbreak main)

### DIFF
--- a/server/service/svctest/server.go
+++ b/server/service/svctest/server.go
@@ -81,14 +81,20 @@ func RunServerForTestsWithServiceWithDS(t *testing.T, ctx context.Context, ds fl
 		logger = opts[0].Logger
 	}
 
+	var extraInitFeatureRoutes []apiendpoints.FeatureRouteFunc
+
 	if len(opts) > 0 {
 		opts[0].FeatureRoutes = append(opts[0].FeatureRoutes, android_service.GetRoutes(svc, opts[0].AndroidModule))
+	} else {
+		// No opts (mock-backed tests): android routes aren't wired into the handler,
+		// but the endpointer only dereferences the android module when an endpoint is
+		// actually served, so surface a path-only stub to apiendpoints.Validate.
+		extraInitFeatureRoutes = append(extraInitFeatureRoutes, apiendpoints.FeatureRouteFunc(android_service.GetRoutes(svc, nil)))
 	}
 
 	// Activity routes. If DBConns is provided, wire the real bounded context into
 	// the main handler. Otherwise, build a path-only stub from the same registration
 	// code and surface it to apiendpoints.Validate for catalog validation only.
-	var extraInitFeatureRoutes []apiendpoints.FeatureRouteFunc
 	if len(opts) > 0 && opts[0].DBConns != nil {
 		legacyAuthorizer, err := authz.NewAuthorizer()
 		require.NoError(t, err)

--- a/server/service/testing_utils_test.go
+++ b/server/service/testing_utils_test.go
@@ -493,14 +493,20 @@ func RunServerForTestsWithServiceWithDS(t *testing.T, ctx context.Context, ds fl
 		logger = opts[0].Logger
 	}
 
+	var extraInitFeatureRoutes []apiendpoints.FeatureRouteFunc
+
 	if len(opts) > 0 {
 		opts[0].FeatureRoutes = append(opts[0].FeatureRoutes, android_service.GetRoutes(svc, opts[0].AndroidModule))
+	} else {
+		// No opts (mock-backed tests): android routes aren't wired into the handler,
+		// but the endpointer only dereferences the android module when an endpoint is
+		// actually served, so surface a path-only stub to apiendpoints.Validate.
+		extraInitFeatureRoutes = append(extraInitFeatureRoutes, apiendpoints.FeatureRouteFunc(android_service.GetRoutes(svc, nil)))
 	}
 
 	// Activity routes. If DBConns is provided, wire the real bounded context into
 	// the main handler. Otherwise, build a path-only stub from the same registration
 	// code and surface it to apiendpoints.Validate for catalog validation only.
-	var extraInitFeatureRoutes []apiendpoints.FeatureRouteFunc
 	if len(opts) > 0 && opts[0].DBConns != nil {
 		legacyAuthorizer, err := authz.NewAuthorizer()
 		require.NoError(t, err)


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->

- [X] QA'd all new/changed functionality manually.

Fixes the `service` and `fleetctl` Go test bundles failing on `main` since #51302 merged (see [this run](https://github.com/fleetdm/fleet/actions/runs/32330923674)):

```
error initializing API endpoints: the following API endpoints are unknown: [DELETE /api/v1/fleet/android_enterprise]
```

#51302 added `DELETE /api/v1/fleet/android_enterprise` to the `api_endpoints.yml` catalog, but the test harnesses (`server/service/testing_utils_test.go` and `server/service/svctest/server.go`) only register Android routes when test opts are passed. Tests that spin up the server without opts (mock-backed tests) never registered those routes, so `apiendpoints.Validate` failed during server setup for every such test.

This surfaces the Android routes to the validator as a path-only stub in the no-opts case, following the same pattern already used there for the activity and chart bounded contexts. This is safe because the Android endpointer only stores the module in closures at registration time — it's never dereferenced until an endpoint is actually served. Behavior when opts are passed is unchanged.

Verified locally: `TestLogin` and `TestNoHeaderErrorsDifferently` (`server/service`) and `TestApplyUserRoles`, `TestGitOpsGlobalGoogleWorkspaceCleared`, `TestGetAppleBM`, `TestGenerateMDMApple` (`cmd/fleetctl/fleetctl`) all pass; `make lint-go-incremental` reports 0 issues.

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests — test-harness-only change; fixes the failing `service` and `fleetctl` bundles


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Android feature routes are now recognized in test-server setups with or without configured options.
  * Validation-only Android route stubs are available when full route handlers are not configured.
  * Configured setups continue to serve Android routes through their handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->