### PR TITLE
Add UI to cancel pending Apple MDM commands

### DIFF
--- a/frontend/interfaces/activity.ts
+++ b/frontend/interfaces/activity.ts
@@ -144,6 +144,7 @@ export enum ActivityType {
   EditedActivityAutomations = "edited_activity_automations",
   DisabledActivityAutomations = "disabled_activity_automations",
   CanceledRunScript = "canceled_run_script",
+  CanceledMdmCommand = "canceled_mdm_command",
   CanceledInstallAppStoreApp = "canceled_install_app_store_app",
   CanceledInstallSoftware = "canceled_install_software",
   CanceledUninstallSoftware = "canceled_uninstall_software",
@@ -228,6 +229,7 @@ export type IHostPastActivityType =
   | ActivityType.UninstalledSoftware
   | ActivityType.InstalledAppStoreApp
   | ActivityType.CanceledRunScript
+  | ActivityType.CanceledMdmCommand
   | ActivityType.CanceledInstallAppStoreApp
   | ActivityType.CanceledInstallSoftware
   | ActivityType.CanceledUninstallSoftware
@@ -295,6 +297,8 @@ export interface IActivityDetails {
   bootstrap_package_name?: string;
   batch_execution_id?: string;
   command_uuid?: string;
+  /** The raw MDM request type of a canceled command, e.g. "DeviceLock" */
+  command_type?: string;
   host_uuid?: string;
   deadline_days?: number;
   deadline?: string;
@@ -429,6 +433,7 @@ export const ACTIVITY_TYPE_TO_FILTER_LABEL: Record<ActivityType, string> = {
     "Canceled activity: install App Store (VPP) app",
   canceled_install_software: "Canceled activity: install software",
   canceled_run_script: "Canceled activity: run script",
+  canceled_mdm_command: "Canceled activity: MDM command",
   canceled_uninstall_software: "Canceled activity: uninstall software",
   canceled_setup_experience: "Canceled setup experience",
   changed_macos_setup_assistant: "Edited macOS automatic enrollment profile",

--- a/frontend/interfaces/command.ts
+++ b/frontend/interfaces/command.ts
@@ -16,6 +16,27 @@ export interface ICommand {
 }
 
 /**
+ * Apple MDM command types that can be canceled while still pending delivery.
+ * Keep in sync with CancelableAppleMDMRequestTypes (server/fleet/apple_mdm.go).
+ */
+const CANCELABLE_REQUEST_TYPES = [
+  "DeviceLock",
+  "EraseDevice",
+  "ClearPasscode",
+  "EnableLostMode",
+] as const;
+
+/**
+ * Whether a command is eligible for cancellation. Deferred (NotNow) commands
+ * still list as pending and remain cancelable.
+ */
+export const isCancelableCommand = (command: ICommand): boolean =>
+  command.command_status === "pending" &&
+  (CANCELABLE_REQUEST_TYPES as readonly string[]).includes(
+    command.request_type
+  );
+
+/**
  * Shape of an mdm command result object returned by the Fleet API.
  */
 export interface ICommandResult {

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tests.tsx
@@ -2571,4 +2571,21 @@ describe("Activity Feed", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("Asset tag")).toBeInTheDocument();
   });
+
+  it("renders a canceled_mdm_command activity", () => {
+    const activity = createMockActivity({
+      type: ActivityType.CanceledMdmCommand,
+      details: {
+        command_type: "DeviceLock",
+        host_display_name: "Anna's MacBook Pro",
+      },
+    });
+    render(<GlobalActivityItem activity={activity} isPremiumTier />);
+
+    expect(
+      screen.getByText("canceled the pending", { exact: false })
+    ).toBeInTheDocument();
+    expect(screen.getByText("DeviceLock")).toBeInTheDocument();
+    expect(screen.getByText("Anna's MacBook Pro")).toBeInTheDocument();
+  });
 });

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
@@ -1831,6 +1831,16 @@ const TAGGED_TEMPLATES = {
       </>
     );
   },
+  canceledMdmCommand: (activity: IActivity) => {
+    const { command_type: commandType, host_display_name: hostName } =
+      activity.details || {};
+    return (
+      <>
+        {" "}
+        canceled the pending <b>{commandType}</b> command on <b>{hostName}</b>.
+      </>
+    );
+  },
   canceledInstallSoftware: (activity: IActivity) => {
     const {
       software_title: title,
@@ -2722,6 +2732,9 @@ const getDetail = (activity: IActivity, isPremiumTier: boolean) => {
     }
     case ActivityType.CanceledRunScript: {
       return TAGGED_TEMPLATES.canceledRunScript(activity);
+    }
+    case ActivityType.CanceledMdmCommand: {
+      return TAGGED_TEMPLATES.canceledMdmCommand(activity);
     }
     case ActivityType.CanceledInstallSoftware:
     case ActivityType.CanceledInstallAppStoreApp: {

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -1145,6 +1145,9 @@ const HostDetailsPage = ({
     // label counts.
     queryClient.invalidateQueries([{ scope: "host-upcoming-mdm-commands" }]);
     queryClient.invalidateQueries([{ scope: "host-past-mdm-commands" }]);
+    // the canceled_mdm_command activity renders from the past-activities
+    // feed, not the command queries
+    queryClient.invalidateQueries([{ scope: "past-activities" }]);
     // the device status chip ("Lock pending") is derived from host.mdm on the
     // host details query
     refetchHostDetails();

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -7,7 +7,7 @@ import React, {
 } from "react";
 import { timeAgo } from "utilities/date_format";
 import { Params, InjectedRouter } from "react-router/lib/Router";
-import { useQuery } from "react-query";
+import { useQuery, useQueryClient } from "react-query";
 import { useErrorHandler } from "react-error-boundary";
 import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
 import { pick } from "lodash";
@@ -155,6 +155,7 @@ import WipeModal from "./modals/WipeModal";
 import { parseHostSoftwareQueryParams } from "../cards/Software/HostSoftware";
 import { canShowMyDeviceButton, getErrorMessage } from "./helpers";
 import CancelActivityModal from "./modals/CancelActivityModal";
+import CancelCommandModal from "./modals/CancelCommandModal";
 import CertificateDetailsModal from "../modals/CertificateDetailsModal";
 import HostHeader from "../cards/HostHeader";
 import InventoryVersionsModal from "../modals/InventoryVersionsModal";
@@ -327,6 +328,8 @@ const HostDetailsPage = ({
   const [showRefetchSpinner, setShowRefetchSpinner] = useState(false);
   const [usersState, setUsersState] = useState<{ username: string }[]>([]);
   const [usersSearchString, setUsersSearchString] = useState("");
+  const queryClient = useQueryClient();
+
   const [
     hostMdmDeviceStatus,
     setHostMdmDeviceState,
@@ -339,6 +342,10 @@ const HostDetailsPage = ({
     selectedCancelActivity,
     setSelectedCancelActivity,
   ] = useState<IHostUpcomingActivity | null>(null);
+  const [
+    selectedCancelCommand,
+    setSelectedCancelCommand,
+  ] = useState<ICommand | null>(null);
 
   // activity states
   const [activeActivityTab, setActiveActivityTab] = useState<
@@ -1126,6 +1133,23 @@ const HostDetailsPage = ({
     );
   };
 
+  const onSuccessCancelCommand = () => {
+    // back to the first page: canceling the last command on a later page
+    // would otherwise strand the feed on an empty page
+    setActivityPage(0);
+    // invalidate by scope rather than the queries' bound refetch(): the
+    // refetch handles are tied to the page the user was on, while the page-0
+    // key that renders after the reset could still serve cached
+    // pre-cancellation data within the staleTime window. Invalidation covers
+    // every page of the scope, including the Upcoming tab badge and toggle
+    // label counts.
+    queryClient.invalidateQueries([{ scope: "host-upcoming-mdm-commands" }]);
+    queryClient.invalidateQueries([{ scope: "host-past-mdm-commands" }]);
+    // the device status chip ("Lock pending") is derived from host.mdm on the
+    // host details query
+    refetchHostDetails();
+  };
+
   const onSuccessCancelActivity = (activity: IHostUpcomingActivity) => {
     if (!host) return;
 
@@ -1336,20 +1360,29 @@ const HostDetailsPage = ({
     isHostTeamMaintainer ||
     isHostTeamObserverPlus;
 
-  const canManagePolicies =
+  // Careful adding boolean logic to this component: eslint's rules-of-hooks
+  // counts code paths and each &&/||/ternary doubles them; this component is
+  // large enough that a handful more overflows the counter and every hook
+  // gets flagged as "called conditionally". Reuse this const where the
+  // admin-or-maintainer check is needed.
+  const isAdminOrMaintainer =
     isGlobalAdmin ||
     isGlobalMaintainer ||
     isHostTeamAdmin ||
     isHostTeamMaintainer;
 
+  const canManagePolicies = isAdminOrMaintainer;
+
+  // Deliberately not reusing cancel-activity permissions: canceling MDM
+  // commands is authorized like sending them (mdm_command write), which
+  // differs from the unified queue's cancel_host_activity and is free to
+  // diverge.
+  const canCancelMDMCommands = isPremiumTier && isAdminOrMaintainer;
+
   // Technicians can open /controls but can't add anything once there — both
   // configuration profiles and the script library hide their add actions for
   // them — so the empty state's CTA would land them on a read-only page.
-  const canAddControls =
-    isGlobalAdmin ||
-    isGlobalMaintainer ||
-    isHostTeamAdmin ||
-    isHostTeamMaintainer;
+  const canAddControls = isAdminOrMaintainer;
 
   const bootstrapPackageData = {
     status: host?.mdm.setup_experience?.bootstrap_package_status,
@@ -1609,12 +1642,7 @@ const HostDetailsPage = ({
                       ? pastActivitiesIsError || pastMDMCommandsIsError
                       : upcomingActivitiesIsError || upcomingMDMCommandsIsError
                   }
-                  canCancelActivities={
-                    isGlobalAdmin ||
-                    isGlobalMaintainer ||
-                    isHostTeamAdmin ||
-                    isHostTeamMaintainer
-                  }
+                  canCancelActivities={isAdminOrMaintainer}
                   isUpcomingDisabled={isAndroidHost}
                   showMDMCommandsToggle={canGetMDMCommands}
                   showMDMCommands={showMDMCommands}
@@ -1636,6 +1664,9 @@ const HostDetailsPage = ({
                   onShowDetails={onShowActivityDetails}
                   onShowCommandDetails={setMdmCommandDetails}
                   onCancel={onCancelActivity}
+                  onCancelCommand={
+                    canCancelMDMCommands ? setSelectedCancelCommand : undefined
+                  }
                 />
                 <UserCard
                   className={defaultCardClass}
@@ -2089,6 +2120,14 @@ const HostDetailsPage = ({
               onCancelActivity={() => refetchUpcomingActivities()}
               onSuccessCancel={onSuccessCancelActivity}
               onExit={() => setSelectedCancelActivity(null)}
+            />
+          )}
+          {selectedCancelCommand && (
+            <CancelCommandModal
+              hostId={host.id}
+              command={selectedCancelCommand}
+              onSuccessCancel={onSuccessCancelCommand}
+              onExit={() => setSelectedCancelCommand(null)}
             />
           )}
           {selectedCertificate && (

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/CancelCommandModal/CancelCommandModal.tests.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/CancelCommandModal/CancelCommandModal.tests.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createCustomRenderer } from "test/test-utils";
+
+import { createMockCommand } from "__mocks__/commandMock";
+import commandsAPI from "services/entities/command";
+
+import CancelCommandModal from "./CancelCommandModal";
+
+describe("CancelCommandModal", () => {
+  const mockCommand = createMockCommand({
+    command_uuid: "cmd-uuid-1",
+    request_type: "DeviceLock",
+  });
+
+  const defaultProps = {
+    hostId: 7,
+    command: mockCommand,
+    onSuccessCancel: jest.fn(),
+    onExit: jest.fn(),
+  };
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("renders the title, body copy, and command preview", () => {
+    const render = createCustomRenderer({ withBackendMock: true });
+    render(<CancelCommandModal {...defaultProps} />);
+
+    expect(screen.getByText("Cancel upcoming command")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /If the activity is happening on the host it will still complete/i
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByText("DeviceLock")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Cancel command" })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Back" })).toBeInTheDocument();
+  });
+
+  it("cancels the command and fires onSuccessCancel on success", async () => {
+    const cancelSpy = jest
+      .spyOn(commandsAPI, "cancelHostCommand")
+      .mockResolvedValue(undefined);
+
+    const render = createCustomRenderer({ withBackendMock: true });
+    render(<CancelCommandModal {...defaultProps} />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Cancel command" })
+    );
+
+    await waitFor(() => {
+      expect(cancelSpy).toHaveBeenCalledWith(7, "cmd-uuid-1");
+    });
+    expect(defaultProps.onSuccessCancel).toHaveBeenCalledWith(mockCommand);
+    expect(defaultProps.onExit).toHaveBeenCalled();
+  });
+
+  it("does not fire onSuccessCancel when the API call fails", async () => {
+    jest
+      .spyOn(commandsAPI, "cancelHostCommand")
+      .mockRejectedValue({ status: 400 });
+
+    const render = createCustomRenderer({ withBackendMock: true });
+    render(<CancelCommandModal {...defaultProps} />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Cancel command" })
+    );
+
+    await waitFor(() => {
+      expect(defaultProps.onExit).toHaveBeenCalled();
+    });
+    expect(defaultProps.onSuccessCancel).not.toHaveBeenCalled();
+  });
+
+  it("closes without canceling when Back is clicked", async () => {
+    const cancelSpy = jest.spyOn(commandsAPI, "cancelHostCommand");
+
+    const render = createCustomRenderer({ withBackendMock: true });
+    render(<CancelCommandModal {...defaultProps} />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Back" }));
+
+    expect(defaultProps.onExit).toHaveBeenCalled();
+    expect(cancelSpy).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/CancelCommandModal/CancelCommandModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/CancelCommandModal/CancelCommandModal.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { noop } from "lodash";
+
+import { ICommand } from "interfaces/command";
+import commandsAPI from "services/entities/command";
+
+import { notify } from "components/ToastNotification";
+import Modal from "components/Modal";
+import Button from "components/buttons/Button";
+
+import CommandItem from "pages/hosts/details/cards/Activity/CommandItem/CommandItem";
+
+const baseClass = "cancel-command-modal";
+
+interface ICancelCommandModalProps {
+  hostId: number;
+  command: ICommand;
+  onSuccessCancel: (command: ICommand) => void;
+  onExit: () => void;
+}
+
+const CancelCommandModal = ({
+  hostId,
+  command,
+  onSuccessCancel,
+  onExit,
+}: ICancelCommandModalProps) => {
+  const [isCanceling, setIsCanceling] = React.useState(false);
+
+  const onAttemptCancel = async () => {
+    setIsCanceling(true);
+    try {
+      await commandsAPI.cancelHostCommand(hostId, command.command_uuid);
+      notify.success(
+        `Successfully canceled the ${command.request_type} command.`
+      );
+      onSuccessCancel(command);
+    } catch (err) {
+      notify.error(
+        `Couldn't cancel the ${command.request_type} command. Please try again.`,
+        { response: err }
+      );
+    }
+    onExit();
+  };
+
+  return (
+    <Modal
+      className={baseClass}
+      title="Cancel upcoming command"
+      onExit={onExit}
+      isContentDisabled={isCanceling}
+    >
+      <div className={`${baseClass}__content`}>
+        <p>
+          If the activity is happening on the host it will still complete.
+          Results won&apos;t appear in Fleet.
+        </p>
+        <CommandItem command={command} onShowDetails={noop} isSoloItem />
+      </div>
+      <div className="modal-cta-wrap">
+        <Button
+          disabled={isCanceling}
+          isLoading={isCanceling}
+          variant="alert"
+          onClick={onAttemptCancel}
+        >
+          Cancel command
+        </Button>
+        <Button onClick={onExit} variant="secondary">
+          Back
+        </Button>
+      </div>
+    </Modal>
+  );
+};
+
+export default CancelCommandModal;

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/CancelCommandModal/_styles.scss
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/CancelCommandModal/_styles.scss
@@ -1,0 +1,11 @@
+.cancel-command-modal {
+  &__content {
+    display: flex;
+    flex-direction: column;
+    gap: $pad-medium;
+
+    > p {
+      margin: 0;
+    }
+  }
+}

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/CancelCommandModal/index.ts
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/CancelCommandModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./CancelCommandModal";

--- a/frontend/pages/hosts/details/cards/Activity/Activity.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/Activity.tsx
@@ -21,7 +21,10 @@ import PastActivityFeed from "./PastActivityFeed";
 import UpcomingActivityFeed from "./UpcomingActivityFeed";
 import MDMCommandsToggle from "./MDMCommandsToggle";
 import CommandFeed from "./CommandFeed";
-import { ShowCommandDetailsHandler } from "./CommandItem/CommandItem";
+import {
+  CancelCommandHandler,
+  ShowCommandDetailsHandler,
+} from "./CommandItem/CommandItem";
 
 const baseClass = "host-activity-card";
 
@@ -62,6 +65,9 @@ interface IActivityProps {
   onShowDetails: ShowActivityDetailsHandler;
   onShowCommandDetails: ShowCommandDetailsHandler;
   onCancel: (activity: IHostUpcomingActivity) => void;
+  /** When provided, cancelable pending MDM commands in the Upcoming tab
+   * render a cancel button. */
+  onCancelCommand?: CancelCommandHandler;
   onShowMDMCommands: () => void;
   onHideMDMCommands: () => void;
 }
@@ -84,6 +90,7 @@ const Activity = ({
   onShowDetails,
   onShowCommandDetails,
   onCancel,
+  onCancelCommand,
   onShowMDMCommands,
   onHideMDMCommands,
 }: IActivityProps) => {
@@ -175,6 +182,7 @@ const Activity = ({
                 onShowDetails={onShowCommandDetails}
                 onNextPage={onNextPage}
                 onPreviousPage={onPreviousPage}
+                onCancelCommand={onCancelCommand}
               />
             ) : (
               <UpcomingActivityFeed

--- a/frontend/pages/hosts/details/cards/Activity/ActivityConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityConfig.tsx
@@ -22,6 +22,7 @@ import RotatedHostRecoveryLockPasswordActivityItem from "./ActivityItems/Rotated
 import InstalledSoftwareActivityItem from "./ActivityItems/InstalledSoftwareActivityItem";
 import InstalledAllSelfServiceSoftwareActivityItem from "./ActivityItems/InstalledAllSelfServiceSoftwareActivityItem";
 import CanceledRunScriptActivityItem from "./ActivityItems/CanceledRunScriptActivityItem";
+import CanceledMdmCommandActivityItem from "./ActivityItems/CanceledMdmCommandActivityItem";
 import CanceledInstallSoftwareActivityItem from "./ActivityItems/CanceledInstallSoftwareActivityItem";
 import CanceledSetupExperienceActivityItem from "./ActivityItems/CanceledSetupExperienceActivityItem";
 import CanceledUninstallSoftwareActivtyItem from "./ActivityItems/CanceledUninstallSoftwareActivtyItem";
@@ -82,6 +83,7 @@ export const pastActivityComponentMap: Record<
   [ActivityType.UninstalledSoftware]: InstalledSoftwareActivityItem,
   [ActivityType.InstalledAppStoreApp]: InstalledSoftwareActivityItem,
   [ActivityType.CanceledRunScript]: CanceledRunScriptActivityItem,
+  [ActivityType.CanceledMdmCommand]: CanceledMdmCommandActivityItem,
   [ActivityType.CanceledInstallSoftware]: CanceledInstallSoftwareActivityItem,
   [ActivityType.CanceledInstallAppStoreApp]: CanceledInstallSoftwareActivityItem,
   [ActivityType.CanceledUninstallSoftware]: CanceledUninstallSoftwareActivtyItem,

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledMdmCommandActivityItem/CanceledMdmCommandActivityItem.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledMdmCommandActivityItem/CanceledMdmCommandActivityItem.tests.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import { createMockHostPastActivity } from "__mocks__/activityMock";
+import { ActivityType } from "interfaces/activity";
+
+import CanceledMdmCommandActivityItem from "./CanceledMdmCommandActivityItem";
+
+describe("CanceledMdmCommandActivityItem", () => {
+  const mockActivity = createMockHostPastActivity({
+    type: ActivityType.CanceledMdmCommand,
+    details: { command_type: "DeviceLock" },
+  });
+
+  it("renders the activity content", () => {
+    render(
+      <CanceledMdmCommandActivityItem tab="past" activity={mockActivity} />
+    );
+
+    expect(screen.getByText("Test User")).toBeVisible();
+    expect(screen.getByText(/canceled the pending/i)).toBeVisible();
+    expect(screen.getByText("DeviceLock")).toBeVisible();
+    expect(screen.getByText(/command on this host/i)).toBeVisible();
+  });
+
+  it("does not render the cancel icon", () => {
+    render(
+      <CanceledMdmCommandActivityItem tab="past" activity={mockActivity} />
+    );
+
+    expect(screen.queryByTestId("close-icon")).not.toBeInTheDocument();
+  });
+
+  it("does not render the show details icon", () => {
+    render(
+      <CanceledMdmCommandActivityItem tab="past" activity={mockActivity} />
+    );
+
+    expect(screen.queryByTestId("info-outline-icon")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledMdmCommandActivityItem/CanceledMdmCommandActivityItem.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledMdmCommandActivityItem/CanceledMdmCommandActivityItem.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+
+import ActivityItem from "components/ActivityItem";
+
+import { IHostActivityItemComponentProps } from "../../ActivityConfig";
+
+const baseClass = "canceled-mdm-command-activity-item";
+
+const CanceledMdmCommandActivityItem = ({
+  activity,
+}: IHostActivityItemComponentProps) => {
+  return (
+    <ActivityItem
+      className={baseClass}
+      activity={activity}
+      hideCancel
+      hideShowDetails
+    >
+      <>
+        <b>{activity.actor_full_name}</b> canceled the pending{" "}
+        <b>{activity.details.command_type}</b> command on this host.
+      </>
+    </ActivityItem>
+  );
+};
+
+export default CanceledMdmCommandActivityItem;

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledMdmCommandActivityItem/index.ts
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledMdmCommandActivityItem/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./CanceledMdmCommandActivityItem";

--- a/frontend/pages/hosts/details/cards/Activity/CommandFeed/CommandFeed.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/CommandFeed/CommandFeed.tests.tsx
@@ -1,7 +1,10 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 
-import { createMockGetCommandsResponse } from "__mocks__/commandMock";
+import {
+  createMockCommand,
+  createMockGetCommandsResponse,
+} from "__mocks__/commandMock";
 
 import CommandFeed from "./CommandFeed";
 
@@ -72,5 +75,68 @@ describe("CommandFeed", () => {
 
     expect(screen.getByText("Previous")).toBeInTheDocument();
     expect(screen.getByText("Next")).toBeInTheDocument();
+  });
+
+  it("renders a cancel button only on cancelable pending commands when onCancelCommand is provided", () => {
+    const commands = createMockGetCommandsResponse({
+      results: [
+        createMockCommand({
+          command_uuid: "lock-uuid",
+          request_type: "DeviceLock",
+        }),
+        createMockCommand({
+          command_uuid: "profile-uuid",
+          request_type: "InstallProfile",
+        }),
+      ],
+    });
+
+    render(
+      <CommandFeed
+        commands={commands}
+        {...defaultProps}
+        onCancelCommand={jest.fn()}
+      />
+    );
+
+    expect(
+      screen.getAllByRole("button", { name: "cancel action" })
+    ).toHaveLength(1);
+  });
+
+  it("does not render cancel buttons on already-run commands even when onCancelCommand is provided", () => {
+    const commands = createMockGetCommandsResponse({
+      results: [
+        createMockCommand({
+          request_type: "DeviceLock",
+          command_status: "ran",
+          status: "Acknowledged",
+        }),
+      ],
+    });
+
+    render(
+      <CommandFeed
+        commands={commands}
+        {...defaultProps}
+        onCancelCommand={jest.fn()}
+      />
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "cancel action" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not render cancel buttons without onCancelCommand", () => {
+    const commands = createMockGetCommandsResponse({
+      results: [createMockCommand({ request_type: "DeviceLock" })],
+    });
+
+    render(<CommandFeed commands={commands} {...defaultProps} />);
+
+    expect(
+      screen.queryByRole("button", { name: "cancel action" })
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/pages/hosts/details/cards/Activity/CommandFeed/CommandFeed.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/CommandFeed/CommandFeed.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 
-import { ICommand } from "interfaces/command";
+import { ICommand, isCancelableCommand } from "interfaces/command";
 import { IGetCommandsResponse } from "services/entities/command";
 
 import Pagination from "components/Pagination";
 
 import EmptyFeed from "../EmptyFeed/EmptyFeed";
 import CommandItem, {
+  CancelCommandHandler,
   ShowCommandDetailsHandler,
 } from "../CommandItem/CommandItem";
 
@@ -18,6 +19,8 @@ interface ICommandFeedProps {
   onShowDetails: ShowCommandDetailsHandler;
   onNextPage: () => void;
   onPreviousPage: () => void;
+  /** When provided, cancelable pending commands render a cancel button. */
+  onCancelCommand?: CancelCommandHandler;
 }
 
 const CommandFeed = ({
@@ -26,6 +29,7 @@ const CommandFeed = ({
   onShowDetails,
   onNextPage,
   onPreviousPage,
+  onCancelCommand,
 }: ICommandFeedProps) => {
   const { meta, results } = commands;
   if (results === null || results.length === 0) {
@@ -47,6 +51,11 @@ const CommandFeed = ({
               key={`${command.command_uuid}+${command.host_uuid}`}
               command={command}
               onShowDetails={onShowDetails}
+              onCancel={
+                onCancelCommand && isCancelableCommand(command)
+                  ? onCancelCommand
+                  : undefined
+              }
             />
           );
         })}

--- a/frontend/pages/hosts/details/cards/Activity/CommandItem/CommandItem.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/CommandItem/CommandItem.tests.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { createMockCommand } from "__mocks__/commandMock";
+
+import CommandItem from "./CommandItem";
+
+describe("CommandItem", () => {
+  const mockOnShowDetails = jest.fn();
+  const mockOnCancel = jest.fn();
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders a cancel button when onCancel is provided", () => {
+    const command = createMockCommand({ request_type: "DeviceLock" });
+
+    render(
+      <CommandItem
+        command={command}
+        onShowDetails={mockOnShowDetails}
+        onCancel={mockOnCancel}
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: "cancel action" })
+    ).toBeInTheDocument();
+  });
+
+  it("does not render a cancel button without onCancel", () => {
+    const command = createMockCommand({ request_type: "DeviceLock" });
+
+    render(<CommandItem command={command} onShowDetails={mockOnShowDetails} />);
+
+    expect(
+      screen.queryByRole("button", { name: "cancel action" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders a cancel button on a deferred (NotNow) command", () => {
+    const command = createMockCommand({
+      request_type: "DeviceLock",
+      status: "NotNow",
+    });
+
+    render(
+      <CommandItem
+        command={command}
+        onShowDetails={mockOnShowDetails}
+        onCancel={mockOnCancel}
+      />
+    );
+
+    expect(screen.getByText(/is deferred/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "cancel action" })
+    ).toBeInTheDocument();
+  });
+
+  it("clicking cancel calls onCancel with the command and does not open details", async () => {
+    const command = createMockCommand({ request_type: "DeviceLock" });
+
+    render(
+      <CommandItem
+        command={command}
+        onShowDetails={mockOnShowDetails}
+        onCancel={mockOnCancel}
+      />
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "cancel action" })
+    );
+
+    expect(mockOnCancel).toHaveBeenCalledWith(command);
+    expect(mockOnShowDetails).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/pages/hosts/details/cards/Activity/CommandItem/CommandItem.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/CommandItem/CommandItem.tsx
@@ -13,9 +13,15 @@ const baseClass = "command-item";
  */
 export type ShowCommandDetailsHandler = (cmd: ICommand) => void;
 
+/** Handler that will cancel a pending command. */
+export type CancelCommandHandler = (cmd: ICommand) => void;
+
 interface ICommandItemProps {
   command: ICommand;
   onShowDetails: ShowCommandDetailsHandler;
+  /** When provided, the item renders a cancel button that calls it. */
+  onCancel?: CancelCommandHandler;
+  isSoloItem?: boolean;
 }
 
 const getStatusText = (command: ICommand): string => {
@@ -37,7 +43,12 @@ const getStatusText = (command: ICommand): string => {
   }
 };
 
-const CommandItem = ({ command, onShowDetails }: ICommandItemProps) => {
+const CommandItem = ({
+  command,
+  onShowDetails,
+  onCancel,
+  isSoloItem,
+}: ICommandItemProps) => {
   const { request_type, updated_at, name, status } = command;
 
   const statusText = getStatusText(command);
@@ -46,6 +57,13 @@ const CommandItem = ({ command, onShowDetails }: ICommandItemProps) => {
   const onShowCommandDetails = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
     onShowDetails(command);
+  };
+
+  const onCancelCommand = (e: React.MouseEvent<HTMLButtonElement>) => {
+    // the cancel button is nested inside the row's details button; without
+    // this the click would also open the command details modal
+    e.stopPropagation();
+    onCancel?.(command);
   };
 
   const activityText = name ? (
@@ -64,8 +82,11 @@ const CommandItem = ({ command, onShowDetails }: ICommandItemProps) => {
       className={baseClass}
       useFleetAvatar
       allowShowDetails
+      allowCancel={!!onCancel}
+      isSoloItem={isSoloItem}
       createdAt={new Date(updated_at)}
       onClickFeedItem={onShowCommandDetails}
+      onClickCancel={onCancelCommand}
     >
       {activityText}
     </FeedListItem>

--- a/frontend/pages/hosts/details/cards/Activity/CommandItem/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Activity/CommandItem/_styles.scss
@@ -1,0 +1,7 @@
+.command-item {
+  // Figma specs 8px between the info and cancel buttons on command rows;
+  // FeedListItem's default is $pad-medium, kept for activity rows.
+  .feed-list-item__details-actions {
+    gap: $pad-small;
+  }
+}

--- a/frontend/services/entities/command.ts
+++ b/frontend/services/entities/command.ts
@@ -65,4 +65,9 @@ export default {
     const url = `${COMMANDS_RESULTS}?command_uuid=${command_uuid}&host_identifier=${host_identifier}`;
     return sendRequest("GET", url);
   },
+
+  cancelHostCommand: (hostId: number, commandUUID: string): Promise<void> => {
+    const { HOST_CANCEL_MDM_COMMAND } = endpoints;
+    return sendRequest("DELETE", HOST_CANCEL_MDM_COMMAND(hostId, commandUUID));
+  },
 };

--- a/frontend/utilities/endpoints.ts
+++ b/frontend/utilities/endpoints.ts
@@ -96,6 +96,8 @@ export default {
   HOSTS_TRANSFER_BY_FILTER: `/${API_VERSION}/fleet/hosts/transfer/filter`,
   HOST_CUSTOM_HOST_VITAL: (hostId: number, vitalId: number) =>
     `/${API_VERSION}/fleet/hosts/${hostId}/custom_host_vitals/${vitalId}`,
+  HOST_CANCEL_MDM_COMMAND: (hostId: number, commandUUID: string) =>
+    `/${API_VERSION}/fleet/hosts/${hostId}/commands/${commandUUID}`,
   HOST_LOCK: (id: number) => `/${API_VERSION}/fleet/hosts/${id}/lock`,
   HOST_UNLOCK: (id: number) => `/${API_VERSION}/fleet/hosts/${id}/unlock`,
   HOST_WIPE: (id: number) => `/${API_VERSION}/fleet/hosts/${id}/wipe`,


### PR DESCRIPTION
**Related issue:** Resolves #51164

Adds a cancel button to eligible pending MDM command rows in the host's Activity card (lock, wipe, clear passcode, enable lost mode), with a confirmation modal, and renders the new `canceled_mdm_command` activity in the host and global activity feeds.


https://github.com/user-attachments/assets/12bb2206-cf8e-401d-b911-7a67173f9372


# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to cancel eligible pending MDM commands from a host’s activity feed.
  - Added a confirmation modal with command details, loading states, and success or error notifications.
  - Canceled commands now appear in host and global activity feeds with the command type, host, and canceling actor.
  - Added permission-aware cancellation controls for authorized administrators and maintainers.

- **Tests**
  - Added coverage for cancellation behavior, modal states, command eligibility, and activity display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->