### PR TITLE
Add VEX exclusions for fleetdm/fleetctl

### DIFF
--- a/security/status.md
+++ b/security/status.md
@@ -356,6 +356,22 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2026-07-27 17:15:39
 
+### [CVE-2026-56865](https://nvd.nist.gov/vuln/detail/CVE-2026-56865)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** CVE-2026-56865 (GO-2026-6179) is in golang.org/x/mod/sumdb/tlog (tileHashReader.ReadHashes): a malicious GOPROXY could forge sumdb tiles to bypass the GOSUMDB check and persist attacker-controlled module content to the local Go module cache. This code path is only used when downloading Go modules (e.g. by the go command). fleetctl only imports golang.org/x/mod/semver (version string parsing); the vulnerable sumdb packages are not compiled into the fleetctl binary and fleetctl never downloads or verifies Go modules at runtime.
+- **Products:** `fleetctl`,`pkg:golang/golang.org/x/mod`
+- **Justification:** `vulnerable_code_not_present`
+- **Timestamp:** 2026-08-20 09:04:44
+
+### [CVE-2026-56864](https://nvd.nist.gov/vuln/detail/CVE-2026-56864)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** CVE-2026-56864 (GO-2026-6180) is in golang.org/x/mod/sumdb (Client.Lookup): a malicious GOSUMDB could serve arbitrary module content not contained within the transparency log. This code path is only used when downloading Go modules (e.g. by the go command). fleetctl only imports golang.org/x/mod/semver (version string parsing); the vulnerable sumdb packages are not compiled into the fleetctl binary and fleetctl never downloads or verifies Go modules at runtime.
+- **Products:** `fleetctl`,`pkg:golang/golang.org/x/mod`
+- **Justification:** `vulnerable_code_not_present`
+- **Timestamp:** 2026-08-20 09:04:35
+
 ### [CVE-2026-56862](https://nvd.nist.gov/vuln/detail/CVE-2026-56862)
 - **Author:** @lucasmrod
 - **Status:** `not_affected`

--- a/security/vex/fleetctl/CVE-2026-56864.vex.json
+++ b/security/vex/fleetctl/CVE-2026-56864.vex.json
@@ -1,0 +1,29 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-8803c14fc85f89b2bb41110be86c033b7a3f00b17009ae985dd211d6c25d0835",
+  "author": "@lucasmrod",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56864",
+        "aliases": [
+          "https://pkg.go.dev/vuln/GO-2026-6180"
+        ]
+      },
+      "products": [
+        {
+          "@id": "fleetctl"
+        },
+        {
+          "@id": "pkg:golang/golang.org/x/mod"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "CVE-2026-56864 (GO-2026-6180) is in golang.org/x/mod/sumdb (Client.Lookup): a malicious GOSUMDB could serve arbitrary module content not contained within the transparency log. This code path is only used when downloading Go modules (e.g. by the go command). fleetctl only imports golang.org/x/mod/semver (version string parsing); the vulnerable sumdb packages are not compiled into the fleetctl binary and fleetctl never downloads or verifies Go modules at runtime.",
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2026-08-20T09:04:35.459442Z"
+    }
+  ],
+  "timestamp": "2026-08-20T09:04:35Z"
+}

--- a/security/vex/fleetctl/CVE-2026-56865.vex.json
+++ b/security/vex/fleetctl/CVE-2026-56865.vex.json
@@ -1,0 +1,29 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-fa01c1f335b52481ebabe740dba10e87103d38b2597172c35844cfd710504d66",
+  "author": "@lucasmrod",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-56865",
+        "aliases": [
+          "https://pkg.go.dev/vuln/GO-2026-6179"
+        ]
+      },
+      "products": [
+        {
+          "@id": "fleetctl"
+        },
+        {
+          "@id": "pkg:golang/golang.org/x/mod"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "CVE-2026-56865 (GO-2026-6179) is in golang.org/x/mod/sumdb/tlog (tileHashReader.ReadHashes): a malicious GOPROXY could forge sumdb tiles to bypass the GOSUMDB check and persist attacker-controlled module content to the local Go module cache. This code path is only used when downloading Go modules (e.g. by the go command). fleetctl only imports golang.org/x/mod/semver (version string parsing); the vulnerable sumdb packages are not compiled into the fleetctl binary and fleetctl never downloads or verifies Go modules at runtime.",
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2026-08-20T09:04:44.877626Z"
+    }
+  ],
+  "timestamp": "2026-08-20T09:04:44Z"
+}


### PR DESCRIPTION
Fixes: https://github.com/fleetdm/fleet/actions/runs/32338375227/job/96332250027.

New run: https://github.com/fleetdm/fleet/actions/runs/32352251256.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added security advisories documenting that `fleetctl` is not affected by CVE-2026-56864.
  * Added security advisories documenting that `fleetctl` is not affected by CVE-2026-56865.
  * Recorded the rationale that vulnerable code is not present in the compiled application or used at runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->