### PR TITLE
[DRAFT]: debug mock apns more

### DIFF
--- a/cmd/apple-apns-mock/e2e_test.go
+++ b/cmd/apple-apns-mock/e2e_test.go
@@ -523,8 +523,12 @@ func TestE2EStatsStartAtZero(t *testing.T) {
 
 	assert.Positive(t, stats.Goroutines)
 	assert.Positive(t, stats.FDLimit, "RLIMIT_NOFILE should always be readable")
-	assert.GreaterOrEqual(t, stats.OpenFDs, -1)
 	assert.GreaterOrEqual(t, stats.OSThreads, -1)
+
+	// Counting descriptors is opt-in because it costs tens of seconds at load,
+	// so a plain /stats must not carry it. Anything watching a running test
+	// polls this endpoint, and it has to stay cheap.
+	assert.Nil(t, stats.OpenFDs, "open_fds must be absent unless ?fds=1 asks for it")
 }
 
 func TestE2EKeepalive(t *testing.T) {

--- a/cmd/apple-apns-mock/e2e_test.go
+++ b/cmd/apple-apns-mock/e2e_test.go
@@ -506,7 +506,25 @@ func TestE2EHealthz(t *testing.T) {
 
 func TestE2EStatsStartAtZero(t *testing.T) {
 	srv := newTestServer(t)
-	assert.Equal(t, statsResponse{}, getStats(t, srv.URL))
+	stats := getStats(t, srv.URL)
+
+	// Only the push/connection counters start at zero. The resource fields
+	// report the live process, so they are asserted for plausibility rather
+	// than equality: goroutines and descriptors depend on the test binary, and
+	// os_threads/open_fds are -1 wherever /proc is absent (so, on macOS).
+	assert.Zero(t, stats.ActiveConnections)
+	assert.Zero(t, stats.TotalPushes)
+	assert.Zero(t, stats.DeliveredLive)
+	assert.Zero(t, stats.DeliveredOnConnect)
+	assert.Zero(t, stats.Stored)
+	assert.Zero(t, stats.Coalesced)
+	assert.Zero(t, stats.Expired)
+	assert.Zero(t, stats.AcceptErrors, "a fresh server must not have failed an accept")
+
+	assert.Positive(t, stats.Goroutines)
+	assert.Positive(t, stats.FDLimit, "RLIMIT_NOFILE should always be readable")
+	assert.GreaterOrEqual(t, stats.OpenFDs, -1)
+	assert.GreaterOrEqual(t, stats.OSThreads, -1)
 }
 
 func TestE2EKeepalive(t *testing.T) {

--- a/cmd/apple-apns-mock/handlers.go
+++ b/cmd/apple-apns-mock/handlers.go
@@ -374,15 +374,23 @@ type statsResponse struct {
 	// memory, so none of this shows up in container metrics.
 	AcceptErrors int    `json:"accept_errors"`
 	Goroutines   int    `json:"goroutines"`
-	OSThreads    int    `json:"os_threads"` // -1 where unavailable; the runtime kills the process past 10,000
-	OpenFDs      int    `json:"open_fds"`   // -1 where unavailable (no /proc)
-	FDLimit      uint64 `json:"fd_limit"`   // soft RLIMIT_NOFILE actually granted, which may not be what was asked for
+	OSThreads    int    `json:"os_threads"`         // -1 where unavailable; the runtime kills the process past 10,000
+	OpenFDs      *int   `json:"open_fds,omitempty"` // only with ?fds=1, see statsHandler. -1 where unavailable (no /proc)
+	FDLimit      uint64 `json:"fd_limit"`           // soft RLIMIT_NOFILE actually granted, which may not be what was asked for
 }
 
 // statsHandler serves GET /stats — the store's counters as JSON, for
 // watching a load test (connected clients, delivered vs stored vs coalesced
 // vs expired pushes).
-func statsHandler(w http.ResponseWriter, _ *http.Request, st *store) {
+//
+// Everything here is an atomic load or a single syscall, so polling it during a
+// run is free. open_fds is the exception and is opt-in behind ?fds=1: counting
+// descriptors walks /proc/self/fd, which is O(descriptors) and contends with
+// the file table every accept and close needs. At 140k streams that made this
+// endpoint take 30-60 seconds, and the contention was enough to push keepalive
+// writes past their write deadline, so polling /stats was itself tearing down
+// streams. Ask for the count when you need it, knowing what it costs.
+func statsHandler(w http.ResponseWriter, r *http.Request, st *store) {
 	w.Header().Set("Content-Type", "application/json")
 	stats := statsResponse{
 		ActiveConnections:  int(st.connected.Load()),
@@ -395,8 +403,10 @@ func statsHandler(w http.ResponseWriter, _ *http.Request, st *store) {
 		AcceptErrors:       int(st.acceptErrors.Load()),
 		Goroutines:         runtime.NumGoroutine(),
 		OSThreads:          osThreads(),
-		OpenFDs:            openFDs(),
 		FDLimit:            fdLimit(),
+	}
+	if r.URL.Query().Get("fds") == "1" {
+		stats.OpenFDs = new(openFDs())
 	}
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
@@ -414,30 +424,41 @@ func statsHandler(w http.ResponseWriter, _ *http.Request, st *store) {
 // 40k-connection run by 3x. Divide these by /stats active_connections for a
 // per-connection number that means something.
 type memStatsResponse struct {
-	Goroutines int    `json:"goroutines"`   // ~1 per live SSE stream, plus a handful of runtime and accept goroutines
-	OSThreads  int    `json:"os_threads"`   // not the goroutine count; the runtime kills the process past 10,000. -1 where unavailable
-	HeapBytes  uint64 `json:"heap_bytes"`   // heap objects; includes uncollected garbage unless ?gc=1
-	StackBytes uint64 `json:"stack_bytes"`  // goroutine stacks
-	InUseBytes uint64 `json:"in_use_bytes"` // everything the runtime holds minus what it has released to the OS
-	OpenFDs    int    `json:"open_fds"`     // one per live stream; the ceiling that stops new connections while existing ones keep working. -1 where unavailable
-	FDLimit    uint64 `json:"fd_limit"`     // soft RLIMIT_NOFILE actually granted, which is not always what the task definition asked for
+	Goroutines int    `json:"goroutines"`         // ~1 per live SSE stream, plus a handful of runtime and accept goroutines
+	OSThreads  int    `json:"os_threads"`         // not the goroutine count; the runtime kills the process past 10,000. -1 where unavailable
+	HeapBytes  uint64 `json:"heap_bytes"`         // heap objects; includes uncollected garbage unless ?gc=1
+	StackBytes uint64 `json:"stack_bytes"`        // goroutine stacks
+	InUseBytes uint64 `json:"in_use_bytes"`       // everything the runtime holds minus what it has released to the OS
+	OpenFDs    *int   `json:"open_fds,omitempty"` // only with ?fds=1; counting them costs 30-60s at 140k streams, see statsHandler
+	FDLimit    uint64 `json:"fd_limit"`           // soft RLIMIT_NOFILE actually granted, which is not always what the task definition asked for
 }
 
 func memStatsHandler(w http.ResponseWriter, r *http.Request) {
+	// ?gc=1 collects first so heap_bytes reflects live data rather than live
+	// data plus whatever garbage has accumulated since the last cycle. This
+	// endpoint has always documented the parameter; it just never acted on it.
+	if r.URL.Query().Get("gc") == "1" {
+		runtime.GC()
+	}
+
 	heap, stacks, inUse := runtimeMem()
 
-	w.Header().Set("Content-Type", "application/json")
-	enc := json.NewEncoder(w)
-	enc.SetIndent("", "  ")
-	if err := enc.Encode(memStatsResponse{
+	resp := memStatsResponse{
 		Goroutines: runtime.NumGoroutine(),
 		OSThreads:  osThreads(),
 		HeapBytes:  heap,
 		StackBytes: stacks,
 		InUseBytes: inUse,
-		OpenFDs:    openFDs(),
 		FDLimit:    fdLimit(),
-	}); err != nil {
+	}
+	if r.URL.Query().Get("fds") == "1" {
+		resp.OpenFDs = new(openFDs())
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(resp); err != nil {
 		http.Error(w, "Failed to encode memstats", http.StatusInternalServerError)
 		return
 	}

--- a/cmd/apple-apns-mock/handlers.go
+++ b/cmd/apple-apns-mock/handlers.go
@@ -424,13 +424,6 @@ type memStatsResponse struct {
 }
 
 func memStatsHandler(w http.ResponseWriter, r *http.Request) {
-	// ?gc=1 collects first so heap_bytes reflects live data rather than live
-	// data plus whatever garbage has accumulated since the last cycle. The
-	// endpoint has always documented this; it just never did it.
-	if r.URL.Query().Get("gc") == "1" {
-		runtime.GC()
-	}
-
 	heap, stacks, inUse := runtimeMem()
 
 	w.Header().Set("Content-Type", "application/json")

--- a/cmd/apple-apns-mock/handlers.go
+++ b/cmd/apple-apns-mock/handlers.go
@@ -11,7 +11,7 @@ import (
 	"net"
 	"net/http"
 	"runtime"
-	"runtime/metrics"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"time"
@@ -85,8 +85,22 @@ func eventsSSEHandler(w http.ResponseWriter, r *http.Request, st *store, logger 
 	// strings.Clone cuts the token loose from the request's URL string, which
 	// would otherwise keep it (and the buffer it was parsed from) alive for
 	// the life of the stream.
+	//
+	// The panic is recovered here rather than left to the runtime: this
+	// goroutine outlives the handler, so net/http's per-request recover no
+	// longer covers it, and one panicking stream would otherwise end the
+	// process and every other stream with it. streamEvents' own defers still
+	// run while unwinding, so the store stays consistent.
 	//nolint:gosec // G118: the request context is canceled the moment this handler returns, and returning is exactly what frees the per-connection buffers. The stream has to outlive it.
-	go streamEvents(conn, strings.Clone(token), st, logger, keepAlive, writeTimeout)
+	go func(token string) {
+		defer func() {
+			if r := recover(); r != nil {
+				logger.ErrorContext(context.Background(), "panic in SSE stream",
+					"token", token, "panic", r, "stack", string(debug.Stack()))
+			}
+		}()
+		streamEvents(conn, token, st, logger, keepAlive, writeTimeout)
+	}(strings.Clone(token))
 }
 
 // sseResponseHead is the 200 that eventsSSEHandler writes by hand after
@@ -354,6 +368,15 @@ type statsResponse struct {
 	Stored             int `json:"stored"`
 	Coalesced          int `json:"coalesced"`
 	Expired            int `json:"expired"`
+
+	// Resource counters. A process that has run out of descriptors, or that is
+	// failing to accept, keeps serving its existing streams with flat CPU and
+	// memory, so none of this shows up in container metrics.
+	AcceptErrors int    `json:"accept_errors"`
+	Goroutines   int    `json:"goroutines"`
+	OSThreads    int    `json:"os_threads"` // -1 where unavailable; the runtime kills the process past 10,000
+	OpenFDs      int    `json:"open_fds"`   // -1 where unavailable (no /proc)
+	FDLimit      uint64 `json:"fd_limit"`   // soft RLIMIT_NOFILE actually granted, which may not be what was asked for
 }
 
 // statsHandler serves GET /stats — the store's counters as JSON, for
@@ -369,6 +392,11 @@ func statsHandler(w http.ResponseWriter, _ *http.Request, st *store) {
 		Stored:             int(st.stored.Load()),
 		Coalesced:          int(st.coalesced.Load()),
 		Expired:            int(st.expired.Load()),
+		AcceptErrors:       int(st.acceptErrors.Load()),
+		Goroutines:         runtime.NumGoroutine(),
+		OSThreads:          osThreads(),
+		OpenFDs:            openFDs(),
+		FDLimit:            fdLimit(),
 	}
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
@@ -387,28 +415,35 @@ func statsHandler(w http.ResponseWriter, _ *http.Request, st *store) {
 // per-connection number that means something.
 type memStatsResponse struct {
 	Goroutines int    `json:"goroutines"`   // ~1 per live SSE stream, plus a handful of runtime and accept goroutines
+	OSThreads  int    `json:"os_threads"`   // not the goroutine count; the runtime kills the process past 10,000. -1 where unavailable
 	HeapBytes  uint64 `json:"heap_bytes"`   // heap objects; includes uncollected garbage unless ?gc=1
 	StackBytes uint64 `json:"stack_bytes"`  // goroutine stacks
 	InUseBytes uint64 `json:"in_use_bytes"` // everything the runtime holds minus what it has released to the OS
+	OpenFDs    int    `json:"open_fds"`     // one per live stream; the ceiling that stops new connections while existing ones keep working. -1 where unavailable
+	FDLimit    uint64 `json:"fd_limit"`     // soft RLIMIT_NOFILE actually granted, which is not always what the task definition asked for
 }
 
 func memStatsHandler(w http.ResponseWriter, r *http.Request) {
-	samples := []metrics.Sample{
-		{Name: "/memory/classes/heap/objects:bytes"},
-		{Name: "/memory/classes/heap/stacks:bytes"},
-		{Name: "/memory/classes/total:bytes"},
-		{Name: "/memory/classes/heap/released:bytes"},
+	// ?gc=1 collects first so heap_bytes reflects live data rather than live
+	// data plus whatever garbage has accumulated since the last cycle. The
+	// endpoint has always documented this; it just never did it.
+	if r.URL.Query().Get("gc") == "1" {
+		runtime.GC()
 	}
-	metrics.Read(samples)
+
+	heap, stacks, inUse := runtimeMem()
 
 	w.Header().Set("Content-Type", "application/json")
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	if err := enc.Encode(memStatsResponse{
 		Goroutines: runtime.NumGoroutine(),
-		HeapBytes:  samples[0].Value.Uint64(),
-		StackBytes: samples[1].Value.Uint64(),
-		InUseBytes: samples[2].Value.Uint64() - samples[3].Value.Uint64(),
+		OSThreads:  osThreads(),
+		HeapBytes:  heap,
+		StackBytes: stacks,
+		InUseBytes: inUse,
+		OpenFDs:    openFDs(),
+		FDLimit:    fdLimit(),
 	}); err != nil {
 		http.Error(w, "Failed to encode memstats", http.StatusInternalServerError)
 		return

--- a/cmd/apple-apns-mock/listener.go
+++ b/cmd/apple-apns-mock/listener.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net"
+	"sync/atomic"
+	"time"
+)
+
+// resilientListener keeps http.Server.Serve alive across accept failures.
+//
+// net/http retries only accept errors that report Temporary() -- EINTR,
+// EMFILE, ENFILE, EAGAIN, ETIMEDOUT -- and hands everything else back to
+// Serve, which returns it to main. ENOBUFS and ENOMEM are the ones that matter
+// at scale: the kernel can refuse an accept for reasons that clear a moment
+// later, and ending the process over a transient refusal drops every open SSE
+// stream and loses the whole load test.
+//
+// Failures are counted rather than only logged, because a process that cannot
+// accept looks identical to an idle one from the outside: flat CPU, flat
+// memory, and existing streams still being served.
+type resilientListener struct {
+	net.Listener
+
+	logger *slog.Logger
+	errs   *atomic.Int64
+}
+
+func (l *resilientListener) Accept() (net.Conn, error) {
+	// Same bounds net/http uses for the errors it retries itself.
+	const (
+		minDelay = 5 * time.Millisecond
+		maxDelay = time.Second
+	)
+
+	var delay time.Duration
+	for {
+		conn, err := l.Listener.Accept()
+		if err == nil {
+			return conn, nil
+		}
+		// A closed listener has to propagate: retrying it spins forever and
+		// Serve could never return.
+		if errors.Is(err, net.ErrClosed) {
+			return nil, err
+		}
+
+		total := l.errs.Add(1)
+		if delay == 0 {
+			delay = minDelay
+		} else {
+			delay = min(delay*2, maxDelay)
+		}
+		// Deliberately no file descriptor count here: this path can fire
+		// thousands of times a second at the shortest backoff, and counting
+		// 300k descriptors per attempt would itself become the problem. The
+		// periodic stats line carries that number.
+		l.logger.ErrorContext(context.Background(), "accept failed, retrying",
+			"error", err, "retry_in", delay, "accept_errors_total", total)
+		time.Sleep(delay)
+	}
+}

--- a/cmd/apple-apns-mock/listener_test.go
+++ b/cmd/apple-apns-mock/listener_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"sync/atomic"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubListener replays a scripted sequence of Accept results so a test can
+// drive resilientListener through failures that a real listener only produces
+// under load.
+type stubListener struct {
+	results []error // nil entries mean "hand back a connection"
+	accepts int
+}
+
+func (l *stubListener) Accept() (net.Conn, error) {
+	l.accepts++
+	if len(l.results) > 0 {
+		err := l.results[0]
+		l.results = l.results[1:]
+		if err != nil {
+			return nil, err
+		}
+	}
+	client, server := net.Pipe()
+	_ = client.Close()
+	return server, nil
+}
+
+func (l *stubListener) Close() error   { return nil }
+func (l *stubListener) Addr() net.Addr { return &net.TCPAddr{} }
+
+func newTestResilientListener(t *testing.T, results ...error) (*resilientListener, *stubListener, *atomic.Int64) {
+	t.Helper()
+	stub := &stubListener{results: results}
+	var errs atomic.Int64
+	return &resilientListener{
+		Listener: stub,
+		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		errs:     &errs,
+	}, stub, &errs
+}
+
+// opErr builds the shape a real accept failure arrives in, since
+// resilientListener has to survive whatever the kernel returns rather than
+// only the errors net/http already retries.
+func opErr(errno syscall.Errno) error {
+	return &net.OpError{Op: "accept", Net: "tcp", Err: os.NewSyscallError("accept", errno)}
+}
+
+// ENOBUFS and ENOMEM are the reason this type exists: net/http does not
+// consider them Temporary, so Serve used to return them and end the process,
+// dropping every live stream over a condition that clears by itself.
+func TestResilientListenerRetriesNonTemporaryErrors(t *testing.T) {
+	for name, errno := range map[string]syscall.Errno{
+		"ENOBUFS": syscall.ENOBUFS,
+		"ENOMEM":  syscall.ENOMEM,
+		"EMFILE":  syscall.EMFILE,
+	} {
+		t.Run(name, func(t *testing.T) {
+			lst, stub, errs := newTestResilientListener(t, opErr(errno), opErr(errno), nil)
+
+			conn, err := lst.Accept()
+			require.NoError(t, err, "accept must recover instead of surfacing the error")
+			require.NotNil(t, conn)
+			_ = conn.Close()
+
+			assert.Equal(t, 3, stub.accepts, "should have retried twice then succeeded")
+			assert.Equal(t, int64(2), errs.Load(), "both failures should be counted for /stats")
+		})
+	}
+}
+
+// A closed listener is the one error that must propagate: retrying it would
+// spin forever and Serve could never return.
+func TestResilientListenerPropagatesClosed(t *testing.T) {
+	lst, stub, errs := newTestResilientListener(t, net.ErrClosed)
+
+	_, err := lst.Accept()
+	require.ErrorIs(t, err, net.ErrClosed)
+	assert.Equal(t, 1, stub.accepts)
+	assert.Zero(t, errs.Load(), "shutdown is not an accept failure")
+}
+
+func TestResilientListenerPassesThroughSuccess(t *testing.T) {
+	lst, stub, errs := newTestResilientListener(t)
+
+	conn, err := lst.Accept()
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	_ = conn.Close()
+
+	assert.Equal(t, 1, stub.accepts, "a healthy accept must not retry")
+	assert.Zero(t, errs.Load())
+}

--- a/cmd/apple-apns-mock/main.go
+++ b/cmd/apple-apns-mock/main.go
@@ -46,7 +46,7 @@ func main() {
 		if r := recover(); r != nil {
 			logger.ErrorContext(ctx, "fatal: unrecovered panic in main",
 				"panic", r, "stack", string(debug.Stack()),
-				"connected", st.connected.Load(), "open_fds", openFDs(), "os_threads", osThreads())
+				"connected", st.connected.Load(), "os_threads", osThreads())
 			flushLogs()
 			os.Exit(2)
 		}
@@ -60,9 +60,14 @@ func main() {
 	signal.Notify(sigC, syscall.SIGTERM, syscall.SIGINT)
 	go func() {
 		sig := <-sigC
+		// Nothing expensive on this path. ECS sends SIGKILL a fixed interval
+		// after SIGTERM (30s by default), and counting descriptors takes tens
+		// of seconds at 140k streams, so sampling them here would get the
+		// process killed before flushLogs could ship the one line that proves
+		// the stop was orchestrator-initiated rather than a crash.
 		logger.ErrorContext(ctx, "received termination signal, exiting",
 			"signal", sig.String(), "connected", st.connected.Load(),
-			"open_fds", openFDs(), "os_threads", osThreads())
+			"os_threads", osThreads())
 		flushLogs()
 		os.Exit(128 + int(sig.(syscall.Signal)))
 	}()
@@ -122,7 +127,7 @@ func main() {
 	err = server.Serve(&resilientListener{Listener: lst, logger: logger, errs: &st.acceptErrors})
 	logger.ErrorContext(ctx, "server stopped serving", "error", err,
 		"connected", st.connected.Load(), "accept_errors", st.acceptErrors.Load(),
-		"open_fds", openFDs(), "os_threads", osThreads())
+		"os_threads", osThreads())
 	flushLogs()
 	os.Exit(1)
 }
@@ -140,11 +145,20 @@ func flushLogs() {
 // it, so a task killed while holding 140k streams left no record of what it
 // was doing.
 //
-// open_fds and os_threads earn their place: either can hit a hard ceiling
-// while CPU and memory stay flat, and neither appears in container metrics. A
-// descriptor limit stops new connections while existing streams keep working,
-// and passing the runtime's 10,000-thread limit is a fatal error rather than a
-// panic.
+// os_threads earns its place: it can hit a hard ceiling while CPU and memory
+// stay flat, it never appears in container metrics, and passing the runtime's
+// 10,000-thread limit is a fatal error rather than a panic. It is also cheap,
+// being one small read of /proc/self/status.
+//
+// Everything here has to stay cheap. openFDs is deliberately absent: walking
+// /proc/self/fd is O(descriptors) and contends with the file table that every
+// accept and close needs, which at 140k streams under an active ramp took
+// 30-60 seconds. On a 30s ticker that ran essentially continuously, starving
+// the accept path badly enough to fail a 6s health check -- the telemetry
+// causing the outage it was meant to explain. fd_limit is kept because it is a
+// single getrlimit and it answers the only question that mattered, whether the
+// platform actually granted the limit the task definition asked for. Ask for a
+// live count explicitly with GET /stats?fds=1, and expect it to be slow.
 func logStats(ctx context.Context, logger *slog.Logger, st *store) {
 	heap, stacks, inUse := runtimeMem()
 	logger.InfoContext(ctx, "stats",
@@ -158,7 +172,6 @@ func logStats(ctx context.Context, logger *slog.Logger, st *store) {
 		"accept_errors", st.acceptErrors.Load(),
 		"goroutines", runtime.NumGoroutine(),
 		"os_threads", osThreads(),
-		"open_fds", openFDs(),
 		"fd_limit", fdLimit(),
 		"heap_bytes", heap,
 		"stack_bytes", stacks,

--- a/cmd/apple-apns-mock/main.go
+++ b/cmd/apple-apns-mock/main.go
@@ -4,8 +4,13 @@ import (
 	"context"
 	"flag"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
+	"os/signal"
+	"runtime"
+	"runtime/debug"
+	"syscall"
 	"time"
 )
 
@@ -13,23 +18,61 @@ func main() {
 	ctx := context.Background()
 	listen := flag.String("listen", ":8378", "host:port to listen on")
 	sweepInterval := flag.Duration("sweep-interval", 10*time.Minute, "how often to sweep expired pending pushes")
+	statsInterval := flag.Duration("stats-interval", 30*time.Second, "how often to log connection, descriptor, thread and memory counts. Set to 0 to disable.")
 	keepAlive := flag.Duration("keep-alive", 30*time.Second, "how often to send SSE keep-alive pings. Set to 0 to disable.")
 	writeTimeout := flag.Duration("write-timeout", 10*time.Second, "deadline for a single SSE write; a device that stops reading is disconnected instead of pinning its token. Set to 0 to disable.")
 	defaultTTL := flag.Duration("default-ttl", 24*time.Hour, "how long to hold a push for a disconnected device when the request has no apns-expiration header (an explicit apns-expiration of 0 or a past time means deliver-now-or-discard)")
-	debug := flag.Bool("debug", false, "enable debug logging")
+	debugLog := flag.Bool("debug", false, "enable debug logging")
 
 	flag.Parse()
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: func() slog.Level {
-		if *debug {
+		if *debugLog {
 			return slog.LevelDebug
 		}
 		return slog.LevelInfo
 	}()}))
 
 	st := newStore(*defaultTTL, logger)
-	server := &http.Server{ReadHeaderTimeout: 10 *
-		time.Second, WriteTimeout: 0, IdleTimeout: 120 * time.Second, Handler: newMux(st, logger, *keepAlive, *writeTimeout), Addr: *listen}
+
+	// The runtime's default panic handler writes the stack and exits at once,
+	// fast enough that a batching log driver can lose the whole thing: a crash
+	// at 140k streams left nothing behind but an exit code. Log it ourselves
+	// and hold the process open long enough for the line to ship.
+	//
+	// This only covers main's own goroutine. Panics in the per-stream
+	// goroutines are recovered where they are started (see eventsSSEHandler).
+	defer func() {
+		if r := recover(); r != nil {
+			logger.ErrorContext(ctx, "fatal: unrecovered panic in main",
+				"panic", r, "stack", string(debug.Stack()),
+				"connected", st.connected.Load(), "open_fds", openFDs(), "os_threads", osThreads())
+			flushLogs()
+			os.Exit(2)
+		}
+	}()
+
+	// Being stopped by the orchestrator and dying on our own produced
+	// indistinguishable evidence, since neither left a log line. Recording the
+	// signal separates them: SIGTERM means something decided to replace us (a
+	// deployment, a failed health check), anything else means we broke.
+	sigC := make(chan os.Signal, 1)
+	signal.Notify(sigC, syscall.SIGTERM, syscall.SIGINT)
+	go func() {
+		sig := <-sigC
+		logger.ErrorContext(ctx, "received termination signal, exiting",
+			"signal", sig.String(), "connected", st.connected.Load(),
+			"open_fds", openFDs(), "os_threads", osThreads())
+		flushLogs()
+		os.Exit(128 + int(sig.(syscall.Signal)))
+	}()
+
+	server := &http.Server{
+		ReadHeaderTimeout: 10 * time.Second,
+		WriteTimeout:      0,
+		IdleTimeout:       120 * time.Second,
+		Handler:           newMux(st, logger, *keepAlive, *writeTimeout),
+	}
 
 	// SSE streams run on hijacked connections, where a keepalive write is the
 	// only thing that notices a client that went away (see streamEvents).
@@ -51,11 +94,76 @@ func main() {
 		}
 	}()
 
-	logger.InfoContext(ctx, "starting mock APNS server", "listen", *listen, "sweep_interval", *sweepInterval, "keep_alive", *keepAlive, "default_ttl", *defaultTTL)
-	err := server.ListenAndServe()
-	if err != nil {
-		panic(err)
+	if *statsInterval > 0 {
+		go func() {
+			ticker := time.NewTicker(*statsInterval)
+			defer ticker.Stop()
+			for range ticker.C {
+				logStats(ctx, logger, st)
+			}
+		}()
+	} else {
+		logger.WarnContext(ctx, "stats logging is disabled: a task that dies will leave no record of what it was holding")
 	}
+
+	lst, err := net.Listen("tcp", *listen)
+	if err != nil {
+		logger.ErrorContext(ctx, "failed to listen", "listen", *listen, "error", err)
+		flushLogs()
+		os.Exit(1)
+	}
+
+	logger.InfoContext(ctx, "starting mock APNS server", "listen", *listen, "sweep_interval", *sweepInterval,
+		"stats_interval", *statsInterval, "keep_alive", *keepAlive, "default_ttl", *defaultTTL,
+		"fd_limit", fdLimit(), "gomaxprocs", runtime.GOMAXPROCS(0))
+
+	// Serve rather than ListenAndServe, so accept failures go through
+	// resilientListener instead of ending the process (see listener.go).
+	err = server.Serve(&resilientListener{Listener: lst, logger: logger, errs: &st.acceptErrors})
+	logger.ErrorContext(ctx, "server stopped serving", "error", err,
+		"connected", st.connected.Load(), "accept_errors", st.acceptErrors.Load(),
+		"open_fds", openFDs(), "os_threads", osThreads())
+	flushLogs()
+	os.Exit(1)
+}
+
+// flushLogs gives a batching log driver time to ship what was just written.
+// Fargate's awslogs driver collects container output in batches, so a process
+// that exits immediately after logging its own cause of death can lose exactly
+// the line that explains it.
+func flushLogs() {
+	time.Sleep(2 * time.Second)
+}
+
+// logStats emits one line carrying everything needed to explain a death after
+// the fact. The server used to log only a 10-minute sweep with no numbers in
+// it, so a task killed while holding 140k streams left no record of what it
+// was doing.
+//
+// open_fds and os_threads earn their place: either can hit a hard ceiling
+// while CPU and memory stay flat, and neither appears in container metrics. A
+// descriptor limit stops new connections while existing streams keep working,
+// and passing the runtime's 10,000-thread limit is a fatal error rather than a
+// panic.
+func logStats(ctx context.Context, logger *slog.Logger, st *store) {
+	heap, stacks, inUse := runtimeMem()
+	logger.InfoContext(ctx, "stats",
+		"connected", st.connected.Load(),
+		"pushes_received", st.pushesReceived.Load(),
+		"delivered_live", st.deliveredLive.Load(),
+		"delivered_on_connect", st.deliveredOnConnect.Load(),
+		"stored", st.stored.Load(),
+		"coalesced", st.coalesced.Load(),
+		"expired", st.expired.Load(),
+		"accept_errors", st.acceptErrors.Load(),
+		"goroutines", runtime.NumGoroutine(),
+		"os_threads", osThreads(),
+		"open_fds", openFDs(),
+		"fd_limit", fdLimit(),
+		"heap_bytes", heap,
+		"stack_bytes", stacks,
+		"in_use_bytes", inUse,
+	)
 }
 
 func newMux(st *store, logger *slog.Logger, keepAlive, writeTimeout time.Duration) *http.ServeMux {

--- a/cmd/apple-apns-mock/procstats.go
+++ b/cmd/apple-apns-mock/procstats.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bufio"
+	"os"
+	"runtime/metrics"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// openFDs reports how many file descriptors the process holds, or -1 where
+// that cannot be determined (anywhere without /proc, so everywhere but Linux).
+//
+// One descriptor per live SSE stream makes this the number that decides how
+// many more connections the process can take, and nothing else reports it: a
+// container that has run out of descriptors holds its memory and CPU flat
+// while refusing every new connection, which looks like a healthy idle
+// process from the outside.
+func openFDs() int {
+	f, err := os.Open("/proc/self/fd")
+	if err != nil {
+		return -1
+	}
+	defer f.Close()
+
+	// Counted in chunks rather than with os.ReadDir so that 150k descriptors
+	// don't turn this into a 150k-element allocation on every call.
+	n := 0
+	for {
+		names, err := f.Readdirnames(4096)
+		n += len(names)
+		if err != nil || len(names) == 0 {
+			break
+		}
+	}
+	return n - 1 // f itself appears in the listing
+}
+
+// fdLimit reports the soft RLIMIT_NOFILE the process is actually running
+// under, which is the ceiling openFDs climbs toward. Worth logging next to the
+// count because the limit a task definition asks for and the limit the
+// platform grants are not always the same number, and the difference is
+// invisible until connections start failing.
+func fdLimit() uint64 {
+	var rl syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rl); err != nil {
+		return 0
+	}
+	return uint64(rl.Cur)
+}
+
+// runtimeMem reports what the Go runtime knows it is using. Deliberately not
+// RSS: on macOS pages the runtime has already released still count against the
+// process, which overstated a 40k-connection run by 3x.
+//
+// None of this covers the kernel's per-socket buffers, which are charged to
+// the same container memory limit at roughly a gigabyte per 150k sockets and
+// are something the Go runtime can neither see nor shrink. A task that looks
+// half idle by these numbers can still be close to its cgroup ceiling.
+func runtimeMem() (heap, stacks, inUse uint64) {
+	samples := []metrics.Sample{
+		{Name: "/memory/classes/heap/objects:bytes"},
+		{Name: "/memory/classes/heap/stacks:bytes"},
+		{Name: "/memory/classes/total:bytes"},
+		{Name: "/memory/classes/heap/released:bytes"},
+	}
+	metrics.Read(samples)
+	return samples[0].Value.Uint64(),
+		samples[1].Value.Uint64(),
+		samples[2].Value.Uint64() - samples[3].Value.Uint64()
+}
+
+// osThreads reports how many OS threads the process has, or -1 where that
+// cannot be determined. Not the same thing as the goroutine count, and the one
+// the Go runtime will kill the process over: exceeding its 10,000-thread limit
+// is a fatal error, not a panic, and it happens with CPU and memory both flat
+// because threads parked in syscalls burn neither. The runtime exposes no way
+// to read this, so it comes from /proc.
+func osThreads() int {
+	f, err := os.Open("/proc/self/status")
+	if err != nil {
+		return -1
+	}
+	defer f.Close()
+
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		rest, ok := strings.CutPrefix(sc.Text(), "Threads:")
+		if !ok {
+			continue
+		}
+		n, err := strconv.Atoi(strings.TrimSpace(rest))
+		if err != nil {
+			return -1
+		}
+		return n
+	}
+	return -1
+}

--- a/cmd/apple-apns-mock/store.go
+++ b/cmd/apple-apns-mock/store.go
@@ -61,6 +61,7 @@ type store struct {
 	stored             atomic.Int64 // number of pushes stored for later delivery (pending)
 	coalesced          atomic.Int64 // number of pushes that were coalesced (overwritten) by a later push
 	expired            atomic.Int64 // number of pushes that expired before delivery (pending)
+	acceptErrors       atomic.Int64 // number of accept failures the listener retried past (see listener.go)
 }
 
 // newStore initializes all shard maps up front (writing to a nil map


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
