### PR TITLE
Name the JSON field in the premium license error

### DIFF
--- a/changes/51365-premium-error-json-field-name
+++ b/changes/51365-premium-error-json-field-name
@@ -1,0 +1,1 @@
+- Fixed the error returned when a free-tier request sets a premium-only field so that it names the field as it appears in the request payload (for example `critical`) instead of Fleet's internal Go field name (for example `Critical`).

--- a/server/platform/endpointer/endpoint_utils.go
+++ b/server/platform/endpointer/endpoint_utils.go
@@ -85,6 +85,27 @@ func allFields(ifv reflect.Value) []fieldPair {
 	return fields
 }
 
+// requestFieldName returns the name a client uses for a struct field, so that
+// an error about a request refers to something the caller can find in the
+// payload they sent rather than to Fleet's internal Go field name.
+//
+// Falls back to the Go field name when the field carries no usable json tag,
+// which is the best available name in that case.
+func requestFieldName(sf reflect.StructField) string {
+	jsonTag, ok := sf.Tag.Lookup("json")
+	if !ok {
+		return sf.Name
+	}
+
+	// Strip options such as ",omitempty".
+	name, _, _ := strings.Cut(jsonTag, ",")
+	if name == "" || name == "-" {
+		return sf.Name
+	}
+
+	return name
+}
+
 // aliasRulesCache caches the result of ExtractAliasRules by reflect.Type so
 // that the reflection walk happens only once per struct type, not on every
 // request.
@@ -741,7 +762,7 @@ func MakeDecoder(
 					if val && !fp.V.IsZero() {
 						return nil, &platform_http.BadRequestError{Message: fmt.Sprintf(
 							"option %s requires a premium license",
-							fp.Sf.Name,
+							requestFieldName(fp.Sf),
 						)}
 					}
 					continue

--- a/server/platform/endpointer/endpoint_utils_test.go
+++ b/server/platform/endpointer/endpoint_utils_test.go
@@ -575,3 +575,83 @@ func TestMakeDecoderGzipBomb(t *testing.T) {
 		assert.Equal(t, int64(42), ple.MaxRequestSize, "MaxRequestSize from inner error must be preserved")
 	})
 }
+
+func TestRequestFieldName(t *testing.T) {
+	type tagged struct {
+		Plain     string `json:"plain"`
+		WithOpts  string `json:"with_opts,omitempty"`
+		Skipped   string `json:"-"`
+		OnlyOpts  string `json:","`
+		EmptyTag  string `json:""`
+		NoJSONTag string
+		OtherTags string `url:"other_tags"`
+	}
+
+	ty := reflect.TypeOf(tagged{})
+
+	for _, tc := range []struct {
+		field string
+		want  string
+	}{
+		{field: "Plain", want: "plain"},
+		{field: "WithOpts", want: "with_opts"},
+		// The rest have no name a client could have sent, so the Go field name
+		// is all that's left to report.
+		{field: "Skipped", want: "Skipped"},
+		{field: "OnlyOpts", want: "OnlyOpts"},
+		{field: "EmptyTag", want: "EmptyTag"},
+		{field: "NoJSONTag", want: "NoJSONTag"},
+		{field: "OtherTags", want: "OtherTags"},
+	} {
+		t.Run(tc.field, func(t *testing.T) {
+			sf, ok := ty.FieldByName(tc.field)
+			require.True(t, ok)
+			assert.Equal(t, tc.want, requestFieldName(sf))
+		})
+	}
+}
+
+type premiumGatedRequest struct {
+	Critical    bool   `json:"critical,omitempty" premium:"true"`
+	ProfileUUID string `json:"profile_uuid" premium:"true"`
+	Untagged    string `premium:"true"`
+	Free        string `json:"free"`
+}
+
+func TestMakeDecoderPremiumErrorNamesTheJSONField(t *testing.T) {
+	decode := MakeDecoder(premiumGatedRequest{}, defaultJSONUnmarshal, nil, nil, nil, nil, -1)
+
+	// No license in the context, so these decode as free-tier requests.
+	decodeBody := func(t *testing.T, body string) error {
+		t.Helper()
+		r := httptest.NewRequest("POST", "/", strings.NewReader(body))
+		_, err := decode(t.Context(), r)
+		return err
+	}
+
+	t.Run("names the field as the caller wrote it", func(t *testing.T) {
+		for _, tc := range []struct {
+			body string
+			want string
+		}{
+			{body: `{"critical":true}`, want: "option critical requires a premium license"},
+			{body: `{"profile_uuid":"abc"}`, want: "option profile_uuid requires a premium license"},
+		} {
+			err := decodeBody(t, tc.body)
+			require.Error(t, err)
+			// Naming the Go field sends the caller looking for a key that isn't
+			// in the payload they sent.
+			require.ErrorContains(t, err, tc.want)
+		}
+	})
+
+	t.Run("falls back to the Go field name when there is no json tag", func(t *testing.T) {
+		err := decodeBody(t, `{"Untagged":"x"}`)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "option Untagged requires a premium license")
+	})
+
+	t.Run("a field that is not premium gated still decodes", func(t *testing.T) {
+		require.NoError(t, decodeBody(t, `{"free":"ok"}`))
+	})
+}

--- a/server/platform/endpointer/endpoint_utils_test.go
+++ b/server/platform/endpointer/endpoint_utils_test.go
@@ -581,13 +581,13 @@ func TestRequestFieldName(t *testing.T) {
 		Plain     string `json:"plain"`
 		WithOpts  string `json:"with_opts,omitempty"`
 		Skipped   string `json:"-"`
-		OnlyOpts  string `json:","`
+		OnlyOpts  string `json:",omitempty"`
 		EmptyTag  string `json:""`
 		NoJSONTag string
 		OtherTags string `url:"other_tags"`
 	}
 
-	ty := reflect.TypeOf(tagged{})
+	ty := reflect.TypeFor[tagged]()
 
 	for _, tc := range []struct {
 		field string


### PR DESCRIPTION
**Related issue:** Resolves #51365

The endpoint decoder rejects a free-tier request that sets a `premium:"true"` field, but it built the message out of the Go struct field name:

```go
"option %s requires a premium license", fp.Sf.Name
```

So a caller who sent `{"critical": true}` was told `option Critical requires a premium license` — naming a key that does not appear in the payload they sent and does not appear in the API documentation either. All 29 `premium:"true"` fields currently in the tree carry a `json` tag, so every one of them reports the wrong name today.

This reports the json tag's field name instead, stripping options like `,omitempty`, and falls back to the Go field name when the field has no usable json tag (no tag, empty tag, or `-`) since there is no client-facing name to report in that case. The fallback follows the same `strings.Cut` handling already used by `extractAliasRulesRecursive` just below it.

Only the field name portion of the message changes. The two existing assertions on this message (`integration_core_test.go`) match on `"requires a premium license"` and are unaffected.

One case this does not fully resolve: `ResetAutomationRequest.TeamIDs` is `json:"team_ids"` with `renameto:"fleet_ids"`, so a caller who sends the newer `fleet_ids` is still told `option team_ids requires a premium license`. That is an accepted API key and a clear improvement on `TeamIDs`, but it is not literally what they sent. Reporting the alias the caller actually used would mean threading the rewriter's key mapping into this check — happy to do that here or in a follow-up if you'd prefer.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests

`TestRequestFieldName` covers the tag variants (plain, `,omitempty`, `-`, empty, absent, non-json tag). `TestMakeDecoderPremiumErrorNamesTheJSONField` drives `MakeDecoder` end to end on a free-tier context and asserts the message names `critical` / `profile_uuid`, that an untagged field still falls back to the Go name, and that a non-gated field decodes normally. Both were confirmed to fail with the change reverted.

- [x] QA'd all new/changed functionality manually

Ran a free-tier server (`fleet serve --dev`, no `--dev_license`) and hit the affected endpoints, comparing a build of this branch against the same build with the change reverted. The gate runs at decode time, before authentication, so these reproduce without credentials.

Before:

```
POST /api/latest/fleet/policies  {"critical":true}
  → option Critical requires a premium license
POST /api/latest/fleet/policies  {"labels_include_any":["x"]}
  → option LabelsIncludeAny requires a premium license
POST /api/latest/fleet/teams/1/policies  {"profile_uuid":"a-abc"}
  → option ProfileUUID requires a premium license
```

After:

```
POST /api/latest/fleet/policies  {"critical":true}
  → option critical requires a premium license
POST /api/latest/fleet/policies  {"labels_include_any":["x"]}
  → option labels_include_any requires a premium license
POST /api/latest/fleet/policies  {"labels_include_all":["x"]}
  → option labels_include_all requires a premium license
POST /api/latest/fleet/policies  {"labels_exclude_any":["x"]}
  → option labels_exclude_any requires a premium license
POST /api/latest/fleet/policies  {"labels_exclude_all":["x"]}
  → option labels_exclude_all requires a premium license
POST /api/latest/fleet/teams/1/policies  {"profile_uuid":"a-abc"}
  → option profile_uuid requires a premium license
POST /api/latest/fleet/automations/reset  {"team_ids":[1]}
  → option team_ids requires a premium license
```

As a control, a body with no premium field (`{"name":"qa","query":"SELECT 1"}`) still decodes and falls through to auth with 401 rather than being caught by the gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Premium-access validation errors now identify restricted fields using the names shown in request payloads.
  - Improved fallback messaging when a request field does not define a payload name, ensuring errors remain clear and actionable.
  - Requests using non-premium fields continue to be accepted without unnecessary validation errors.

- **Tests**
  - Added coverage confirming accurate field names in validation errors and correct handling of permitted fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->