### PR TITLE
Extend outbound address filtering to unspecified and NAT64 addresses

### DIFF
--- a/changes/17211-block-unspecified-outbound-addresses
+++ b/changes/17211-block-unspecified-outbound-addresses
@@ -1,0 +1,1 @@
+- Improved outbound address filtering to cover the unspecified addresses (`0.0.0.0` and `::`), the deprecated IPv4-compatible IPv6 form, and IPv4 addresses reached through a NAT64 prefix.

--- a/pkg/fleethttp/fleethttp.go
+++ b/pkg/fleethttp/fleethttp.go
@@ -60,17 +60,19 @@ var ErrPrivateNetworkBlocked = errors.New("connections to private network addres
 // --allow_private_network_integrations is set. No legitimate integration
 // should ever target these addresses.
 var alwaysBlockedCIDRs = parseCIDRs([]string{
+	"0.0.0.0/8",      // "this" network (RFC 1122); 0.0.0.0 itself routes to loopback
 	"127.0.0.0/8",    // loopback
 	"169.254.0.0/16", // link-local (includes cloud IMDS at 169.254.169.254)
-	"::1/128",        // IPv6 loopback
-	"fe80::/10",      // IPv6 link-local
+	// Covers the unspecified address (::), IPv6 loopback (::1) and the
+	// deprecated IPv4-compatible form (::a.b.c.d, e.g. ::127.0.0.1).
+	"::/96",
+	"fe80::/10", // IPv6 link-local
 })
 
 // privateNetworkCIDRs are blocked when private network blocking is enabled.
 // Customers with on-prem integrations (e.g. EJBCA, Jira, SCEP servers on
 // private networks) can disable this with --allow_private_network_integrations.
 var privateNetworkCIDRs = parseCIDRs([]string{
-	"0.0.0.0/8",       // "this" network (RFC 1122)
 	"10.0.0.0/8",      // RFC 1918 private
 	"100.64.0.0/10",   // shared address space (RFC 6598)
 	"172.16.0.0/12",   // RFC 1918 private
@@ -110,6 +112,29 @@ func ipInCIDRs(ip net.IP, cidrs []*net.IPNet) bool {
 	return false
 }
 
+// nat64WellKnownPrefix is the RFC 6052 prefix used to reach IPv4 hosts from an
+// IPv6-only network. Addresses under it carry an IPv4 address in their low 32
+// bits, so the embedded address is what has to be checked -- the prefix itself
+// carries public IPv4 traffic too and can't simply be listed as internal.
+//
+// RFC 6052 also allows a network-specific prefix, which is drawn from the
+// operator's own address space and so can't be recognized without being
+// configured: an address under one is indistinguishable from any other address
+// in that space, and treating every address whose low 32 bits look internal as
+// a translation would reject unrelated public addresses.
+var nat64WellKnownPrefix = parseCIDRs([]string{"64:ff9b::/96"})
+
+// embeddedIPv4 returns the IPv4 address carried by a NAT64 address, or nil if
+// the address doesn't carry one.
+func embeddedIPv4(ip net.IP) net.IP {
+	if !ipInCIDRs(ip, nat64WellKnownPrefix) {
+		return nil
+	}
+	// ipInCIDRs only matches a 16-byte address against an IPv6 range.
+	ip16 := ip.To16()
+	return net.IPv4(ip16[12], ip16[13], ip16[14], ip16[15])
+}
+
 // privateNetworkBlockingDialContext returns a DialContext function that blocks
 // connections to private/reserved IP addresses. It resolves DNS first, then
 // checks the resolved IP before connecting -- this catches DNS rebinding.
@@ -131,14 +156,21 @@ func privateNetworkBlockingDialContext(dialer *net.Dialer) func(ctx context.Cont
 		}
 
 		for _, ip := range ips {
-			// Tier 1: always blocked (loopback, cloud IMDS). Cannot be
-			// overridden with --server_allow_private_network_integrations.
-			if ipInCIDRs(ip.IP, alwaysBlockedCIDRs) {
-				return nil, fmt.Errorf("%w: %s resolves to %s", ErrPrivateNetworkBlocked, host, ip.IP)
-			}
-			// Tier 2: private networks. Only blocked in BlockingFull mode.
-			if mode == BlockingFull && ipInCIDRs(ip.IP, privateNetworkCIDRs) {
-				return nil, fmt.Errorf("%w: %s resolves to %s", ErrPrivateNetworkBlocked, host, ip.IP)
+			// A NAT64 address reaches the IPv4 address it carries, so check
+			// that one as well.
+			for _, check := range []net.IP{ip.IP, embeddedIPv4(ip.IP)} {
+				if check == nil {
+					continue
+				}
+				// Tier 1: always blocked (loopback, cloud IMDS). Cannot be
+				// overridden with --server_allow_private_network_integrations.
+				if ipInCIDRs(check, alwaysBlockedCIDRs) {
+					return nil, fmt.Errorf("%w: %s resolves to %s", ErrPrivateNetworkBlocked, host, ip.IP)
+				}
+				// Tier 2: private networks. Only blocked in BlockingFull mode.
+				if mode == BlockingFull && ipInCIDRs(check, privateNetworkCIDRs) {
+					return nil, fmt.Errorf("%w: %s resolves to %s", ErrPrivateNetworkBlocked, host, ip.IP)
+				}
 			}
 		}
 

--- a/pkg/fleethttp/fleethttp_test.go
+++ b/pkg/fleethttp/fleethttp_test.go
@@ -2,6 +2,8 @@ package fleethttp
 
 import (
 	"crypto/tls"
+	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -126,10 +128,13 @@ func TestAlwaysBlockedIPs(t *testing.T) {
 		ip      string
 		blocked bool
 	}{
+		{"0.0.0.0", true}, // unspecified; connects to loopback
 		{"127.0.0.1", true},
 		{"127.0.0.2", true},
 		{"169.254.169.254", true}, // AWS IMDS
 		{"169.254.0.1", true},
+		{"::", true},           // IPv6 unspecified; connects to loopback
+		{"::127.0.0.1", true},  // deprecated IPv4-compatible form
 		{"::1", true},          // IPv6 loopback
 		{"fe80::1", true},      // IPv6 link-local
 		{"8.8.8.8", false},     // public
@@ -145,6 +150,57 @@ func TestAlwaysBlockedIPs(t *testing.T) {
 	}
 }
 
+func TestNAT64EmbeddedIPv4(t *testing.T) {
+	// A NAT64 address reaches the IPv4 address it carries, so the embedded
+	// address decides whether it is blocked. The prefix itself carries public
+	// IPv4 traffic on IPv6-only networks and must stay reachable.
+	cases := []struct {
+		ip       string
+		embedded string
+	}{
+		{"64:ff9b::7f00:1", "127.0.0.1"},          // loopback
+		{"64:ff9b::a9fe:a9fe", "169.254.169.254"}, // cloud IMDS
+		{"64:ff9b::a00:1", "10.0.0.1"},            // RFC 1918
+		{"64:ff9b::808:808", "8.8.8.8"},           // public
+		{"2001:4860:4860::8888", ""},              // not NAT64
+	}
+	for _, c := range cases {
+		t.Run(c.ip, func(t *testing.T) {
+			ip := net.ParseIP(c.ip)
+			require.NotNil(t, ip)
+			got := embeddedIPv4(ip)
+			if c.embedded == "" {
+				assert.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			assert.Equal(t, c.embedded, got.String())
+		})
+	}
+
+	blocked := func(t *testing.T, target string, mode NetworkBlockingMode) error {
+		t.Helper()
+		setBlockingMode(t, mode)
+		_, err := NewClient(WithTimeout(3 * time.Second)).Get(target)
+		return err
+	}
+	t.Run("embedded internal address is blocked", func(t *testing.T) {
+		for _, ip := range []string{"64:ff9b::7f00:1", "64:ff9b::a9fe:a9fe"} {
+			err := blocked(t, "http://["+ip+"]:80/", BlockingPrivateAllowed)
+			require.ErrorIs(t, err, ErrPrivateNetworkBlocked, ip)
+		}
+		err := blocked(t, "http://[64:ff9b::a00:1]:80/", BlockingFull)
+		require.ErrorIs(t, err, ErrPrivateNetworkBlocked)
+	})
+	t.Run("embedded public address is not blocked", func(t *testing.T) {
+		// Reaching it may fail for unrelated reasons; it must not be the guard.
+		err := blocked(t, "http://[64:ff9b::808:808]:80/", BlockingFull)
+		if err != nil {
+			assert.NotErrorIs(t, err, ErrPrivateNetworkBlocked)
+		}
+	})
+}
+
 func TestPrivateNetworkCIDRs(t *testing.T) {
 	// These IPs are blocked when private network blocking is enabled.
 	cases := []struct {
@@ -156,8 +212,8 @@ func TestPrivateNetworkCIDRs(t *testing.T) {
 		{"172.16.0.1", true},
 		{"172.31.255.255", true},
 		{"192.168.1.1", true},
-		{"0.0.0.0", true},
 		{"fc00::1", true},     // IPv6 unique local
+		{"0.0.0.0", false},    // always-blocked instead, so not listed here
 		{"8.8.8.8", false},    // public
 		{"1.1.1.1", false},    // public
 		{"172.32.0.1", false}, // just outside 172.16.0.0/12
@@ -198,6 +254,47 @@ func TestPrivateNetworkBlockingDialContext(t *testing.T) {
 		client := NewClient(WithTimeout(5 * time.Second))
 		_, err := client.Get(ts.URL)
 		require.ErrorIs(t, err, ErrPrivateNetworkBlocked)
+	})
+
+	t.Run("unspecified address cannot reach a loopback-only service", func(t *testing.T) {
+		// Connecting to an unspecified address reaches services listening on
+		// loopback, so it has to be blocked like loopback itself.
+		const marker = "loopback-only"
+		cases := []struct {
+			bind        string
+			unspecified string
+		}{
+			{"127.0.0.1:0", "0.0.0.0"},
+			{"[::1]:0", "[::]"},
+		}
+		for _, c := range cases {
+			ln, err := net.Listen("tcp", c.bind)
+			if err != nil {
+				t.Skipf("cannot listen on %s: %v", c.bind, err)
+			}
+			t.Cleanup(func() { ln.Close() })
+			go http.Serve(ln, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { //nolint:errcheck // closed by cleanup
+				io.WriteString(w, marker) //nolint:errcheck
+			}))
+			url := fmt.Sprintf("http://%s:%d/", c.unspecified, ln.Addr().(*net.TCPAddr).Port)
+
+			// Without blocking the address does reach the loopback-only
+			// listener, so the assertions below test the guard rather than an
+			// address that was unreachable anyway.
+			setBlockingMode(t, BlockingDisabled)
+			resp, err := NewClient(WithTimeout(5 * time.Second)).Get(url)
+			require.NoError(t, err)
+			body, err := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			require.NoError(t, err)
+			require.Equal(t, marker, string(body))
+
+			for _, mode := range []NetworkBlockingMode{BlockingFull, BlockingPrivateAllowed} {
+				setBlockingMode(t, mode)
+				_, err := NewClient(WithTimeout(5 * time.Second)).Get(url)
+				require.ErrorIs(t, err, ErrPrivateNetworkBlocked, "%s in mode %v", url, mode)
+			}
+		}
 	})
 
 	t.Run("not blocked when blocking is not enabled", func(t *testing.T) {


### PR DESCRIPTION
**Related issue:** N/A

## Description

The outbound address filter matches a resolved IP against a list of internal ranges. A few address forms name an internal host without falling inside any of the listed ranges, so this adds them:

- The unspecified addresses, `0.0.0.0` and `::`. Connecting to either reaches services listening on loopback, so they belong with the other loopback forms.
- The deprecated IPv4-compatible form (`::a.b.c.d`). `::/96` covers it, along with `::` and `::1`.
- NAT64 addresses, which carry an IPv4 address in their low 32 bits and connect to that address.

The NAT64 handling is the part worth a closer look, since it's a check rather than another range in the list. The prefix carries ordinary public IPv4 traffic on IPv6-only networks, so it isn't filtered as a range; instead the embedded address is extracted and run through the same checks, so `64:ff9b::7f00:1` is filtered while `64:ff9b::808:808` is not.

## Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`.
- [x] Input data is properly validated — the filter runs on addresses resolved from the request, before the connection is made, and on every redirect hop since it sits in the dialer.

## Testing

- [x] Added/updated automated tests — list-membership cases for the new entries, a NAT64 test covering both an embedded internal address and an embedded public one, and a dial-level test that binds a loopback-only listener, confirms the unspecified address reaches it with filtering off, then checks both filtering modes. Reverting any one of the three changes fails a test.
- [x] QA'd all new/changed functionality manually — confirmed public destinations and a private-network receiver under `--server_allow_private_network_integrations` still work, including an end-to-end webhook delivery through the normal sender, and that the newly listed forms are filtered.

cc @lukeheath for review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved outbound network protection by blocking unspecified IPv4 and IPv6 addresses.
  * Added filtering for deprecated IPv4-compatible IPv6 addresses and IPv4 addresses embedded in NAT64 addresses.
  * Prevented connections to additional loopback, link-local, and private network destinations.
  * Ensured unspecified addresses cannot access loopback-only services under either network-blocking mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->