### PR TITLE
Product maturity (`~product-maturity`) stories come before other stories

### DIFF
--- a/handbook/company/product-groups.md
+++ b/handbook/company/product-groups.md
@@ -1169,7 +1169,8 @@ When selecting which issue to work on next, prioritize in the following order:
 3. **Customer activation blockers**: Issues with the `~activation-blocker` label.
 4. **Reliability issues**: Issues with the `reliability` label that the product group agreed to work on this release cycle.
 5. **Bugs**: Issues with the `bug` label, ordered by the [bug prioritization](#bug-prioritization) list below.
-6. **Other roadmap stories**: The remaining user stories in the group's **Ready** column.
+6. **Product maturity stories**: User stories with the `~product-maturity` label. Product maturity stories without customer labels are prioritized over non-maturity stories with customer labels.
+7. **Other stories**: The remaining user stories in the group's **Ready** column.
 
 ## Bug prioritization
 


### PR DESCRIPTION
- `~product-maturity` stories before stories with only `customer-*` labels. For example, [this story](https://github.com/fleetdm/fleet/issues/38864) gets prioritized before [this story](https://github.com/fleetdm/fleet/issues/47727).
- This aligns how we prioritize issues for _dev_ w/ how we prioritize issues for _drafting_.
