### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/hive-app/darwin.json
+++ b/ee/maintained-apps/outputs/hive-app/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.2.35",
+      "version": "1.2.36",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app' AND version_compare(bundle_short_version, '1.2.35') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app' AND version_compare(bundle_short_version, '1.2.36') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.hive.app');"
       },
-      "installer_url": "https://github.com/morapelker/hive/releases/download/v1.2.35/Hive-1.2.35-arm64.dmg",
+      "installer_url": "https://github.com/morapelker/hive/releases/download/v1.2.36/Hive-1.2.36-arm64.dmg",
       "install_script_ref": "3bd4ebe4",
       "uninstall_script_ref": "951b5587",
-      "sha256": "fbbf398d648f41f2212b0a70a4f0ba187e63bdf3842e6ff715b4ed827b6febf8",
+      "sha256": "02b4f76244419b1106e3fa5ca5026a61fd2e753ee789d7f73041df3c57c93728",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/jetbrains-toolbox/darwin.json
+++ b/ee/maintained-apps/outputs/jetbrains-toolbox/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "3.7",
+      "version": "3.7.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.toolbox';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.toolbox' AND version_compare(bundle_short_version, '3.7') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.toolbox' AND version_compare(bundle_short_version, '3.7.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.jetbrains.toolbox');"
       },
-      "installer_url": "https://download.jetbrains.com/toolbox/jetbrains-toolbox-3.7.0.87111-arm64.dmg",
+      "installer_url": "https://download.jetbrains.com/toolbox/jetbrains-toolbox-3.7.1.87197-arm64.dmg",
       "install_script_ref": "18687029",
       "uninstall_script_ref": "118b704f",
-      "sha256": "f4ac42218e669869d60dedc743ba9ae0ca65d48c37009574dbeca9456cafcb6b",
+      "sha256": "30d1c5b89d1236c67bbefc9defb707d4ac499867dbd553f417e47dcbd15f6f25",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/screenflick/darwin.json
+++ b/ee/maintained-apps/outputs/screenflick/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "3.3.2",
+      "version": "3.3.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.araeliumgroup.screenflick';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.araeliumgroup.screenflick' AND version_compare(bundle_short_version, '3.3.2') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.araeliumgroup.screenflick' AND version_compare(bundle_short_version, '3.3.3') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.araeliumgroup.screenflick');"
       },
-      "installer_url": "https://store.araelium.com/screenflick/downloads/versions/Screenflick3.3.2.zip",
+      "installer_url": "https://store.araelium.com/screenflick/downloads/versions/Screenflick3.3.3.zip",
       "install_script_ref": "8b696f48",
       "uninstall_script_ref": "14e4684b",
-      "sha256": "5902bd75e1bc8934ba44feca1801522ef943d70c02c56ce8cf61a30eab861619",
+      "sha256": "564768ebfd4db626c460824f4ccaac39de8f136afc715afc0c5e731b07acde46",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the macOS app definitions for Hive, JetBrains Toolbox, and Screenflick to their latest versions.
  * Refreshed installer links and verification checksums to support the updated releases.
  * Existing installation, uninstallation, and application detection behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->