### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/mace/darwin.json
+++ b/ee/maintained-apps/outputs/mace/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.1.2",
+      "version": "1.1.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.mace.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.mace.app' AND version_compare(bundle_short_version, '1.1.2') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.mace.app' AND version_compare(bundle_short_version, '1.1.3') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.mace.app');"
       },
-      "installer_url": "https://github.com/MACE-App/MACE/releases/download/v1.1.2/M.A.C.E.V1.1.2.dmg",
+      "installer_url": "https://github.com/MACE-App/MACE/releases/download/v1.1.3/M.A.C.E.V1.1.3.dmg",
       "install_script_ref": "6d62fdae",
       "uninstall_script_ref": "672b1fee",
-      "sha256": "f38e7911e119a98a7260e8da0ca55487b249c66d248b4bcf5cbf85a412027d57",
+      "sha256": "11a384a4cd4ca7587a818783e5d49e016abbc49811e9d02f982ae7d336879b73",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/opera/darwin.json
+++ b/ee/maintained-apps/outputs/opera/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "134.0",
+      "version": "135.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.operasoftware.Opera';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.operasoftware.Opera' AND version_compare(bundle_short_version, '134.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.operasoftware.Opera' AND version_compare(bundle_short_version, '135.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.operasoftware.Opera');"
       },
-      "installer_url": "https://get.geo.opera.com/pub/opera/desktop/134.0.5954.66/mac/Opera_134.0.5954.66_Setup.dmg",
+      "installer_url": "https://get.geo.opera.com/pub/opera/desktop/135.0.5973.41/mac/Opera_135.0.5973.41_Setup.dmg",
       "install_script_ref": "f2f3d814",
       "uninstall_script_ref": "bc37ca3d",
-      "sha256": "7e5eb1e50fd7dfaa825655c29bf1e8e084c1b48c406436d28cd67b2c1f5a0633",
+      "sha256": "12f5a0afe3d8544ca1a22eaa9c18da1547ae001eebb9f9ca08ddb1548243b7b4",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/whatsapp/darwin.json
+++ b/ee/maintained-apps/outputs/whatsapp/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "26.33.17",
+      "version": "26.33.19",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp' AND version_compare(bundle_short_version, '26.33.17') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp' AND version_compare(bundle_short_version, '26.33.19') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'net.whatsapp.WhatsApp');"
       },
       "installer_url": "https://web.whatsapp.com/desktop/mac_native/release/?configuration=Release&src=whatsapp_downloads_page",


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the macOS app definitions for MACE, Opera, and WhatsApp to their latest tracked versions.
  * Refreshed version checks, installer details, and integrity verification data where applicable.
  * Installation, uninstallation, and app launch behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->