### PR TITLE
Website: Update trial type given to users with a Fleet email.

### DIFF
--- a/website/api/controllers/entrance/signup.js
+++ b/website/api/controllers/entrance/signup.js
@@ -145,9 +145,9 @@ the account verification message.)`,
       isIcpUser = true;
     }//ﬁ
 
-    if(emailDomain === 'fleetdm.com') {
-      fleetPremiumTrialType = 'render trial';
-    }//ﬁ
+    // if(emailDomain === 'fleetdm.com') {
+    //   fleetPremiumTrialType = 'render trial';
+    // }//ﬁ
 
     let thirtyDaysFromNowAt = Date.now() + (1000 * 60 * 60 * 24 * 30);
     let trialLicenseKeyForThisUser = await sails.helpers.createLicenseKey.with({


### PR DESCRIPTION
Changes:
- Disabled Render trials for fleetdm.com email addresses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated signup trial classification to rely on employee-count enrichment instead of automatically assigning a trial based on the signup email domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->