### PR TITLE
Policy Automation resend config profile - GitOps

### DIFF
--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -1850,6 +1850,14 @@ func (cmd *GenerateGitopsCommand) generatePolicies(teamId *uint, filePath string
 				}
 			}
 		}
+
+		// handle profile automation
+		if policy.ResendConfigurationProfile != nil {
+			policySpec["resend_configuration_profile"] = map[string]any{
+				"name": policy.ResendConfigurationProfile.Name,
+			}
+		}
+
 		// Parse any labels.
 		if policy.LabelsIncludeAny != nil && cmd.AppConfig.License.IsPremium() {
 			policySpec["labels_include_any"] = fleet.LabelIdentsToNames(policy.LabelsIncludeAny)

--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -483,6 +483,20 @@ func (MockClient) GetPolicies(teamID *uint) ([]*fleet.Policy, error) {
 				SoftwareTitleID: 2,
 			},
 		},
+		{
+			PolicyData: fleet.PolicyData{
+				ID:          4,
+				Name:        "Team Profile policy",
+				Query:       "SELECT * FROM team_policy WHERE id = 4",
+				Resolution:  new("Nothing to do."),
+				Description: "This is a team policy with configuration profile automation",
+				Platform:    "darwin",
+				Type:        fleet.PolicyTypeDynamic,
+			},
+			ResendConfigurationProfile: &fleet.PolicyProfile{
+				Name: "Team Profile",
+			},
+		},
 	}
 	// Only add FMA and package install policies for actual teams, not unassigned.
 	if *teamID != 0 {

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -9261,3 +9261,69 @@ software:
 		"the license branch must fire rather than surfacing the raw client error")
 	require.Contains(t, err.Error(), filepath.Base(f.Name()), "the message must name the file being applied")
 }
+
+func TestGitOpsPolicyResendConfigurationProfile(t *testing.T) {
+	const (
+		macProfileUUID = "a-mac-profile-uuid"
+		macProfileName = "Password policy - require 10 characters"
+	)
+
+	ds, _, _ := testing_utils.SetupFullGitOpsPremiumServer(t)
+
+	ds.ListMDMConfigProfilesFunc = func(
+		ctx context.Context, teamID *uint, opt fleet.ListOptions,
+	) ([]*fleet.MDMConfigProfilePayload, *fleet.PaginationMetadata, error) {
+		return []*fleet.MDMConfigProfilePayload{
+			{ProfileUUID: macProfileUUID, TeamID: teamID, Name: macProfileName, Platform: "darwin"},
+		}, &fleet.PaginationMetadata{}, nil
+	}
+	ds.LabelIDsByNameFunc = func(ctx context.Context, names []string, filter fleet.TeamFilter) (map[string]uint, error) {
+		return map[string]uint{}, nil
+	}
+
+	var appliedSpecs []*fleet.PolicySpec
+	ds.ApplyPolicySpecsFunc = func(ctx context.Context, authorID uint, specs []*fleet.PolicySpec) error {
+		appliedSpecs = append(appliedSpecs, specs...)
+		return nil
+	}
+
+	tmpDir := t.TempDir()
+	profileContents, err := os.ReadFile("./testdata/gitops/lib/macos-password.mobileconfig")
+	require.NoError(t, err)
+	profilePath := filepath.Join(tmpDir, "password.mobileconfig")
+	require.NoError(t, os.WriteFile(profilePath, profileContents, 0o600))
+
+	teamYAMLPath := filepath.Join(tmpDir, "team.yml")
+	require.NoError(t, os.WriteFile(teamYAMLPath, fmt.Appendf(nil, `
+name: Resend Profile Team
+team_settings:
+  secrets:
+    - secret: "ABC"
+queries:
+agent_options:
+software:
+controls:
+  macos_settings:
+    custom_settings:
+      - path: %s
+policies:
+  - name: Resend policy
+    query: "SELECT 1"
+    platform: darwin
+    resend_configuration_profile:
+      name: %s
+  - name: Plain policy
+    query: "SELECT 2"
+`, profilePath, macProfileName), 0o600))
+
+	_, err = runAppNoChecks([]string{"gitops", "-f", teamYAMLPath})
+	require.NoError(t, err)
+
+	require.Len(t, appliedSpecs, 2)
+	require.Equal(t, "Resend policy", appliedSpecs[0].Name)
+	require.Equal(t, ptr.String(macProfileUUID), appliedSpecs[0].ProfileUUID)
+	// A policy without the key sends an empty UUID, which unsets any profile
+	// previously associated with it.
+	require.Equal(t, "Plain policy", appliedSpecs[1].Name)
+	require.Equal(t, ptr.String(""), appliedSpecs[1].ProfileUUID)
+}

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -9321,9 +9321,9 @@ policies:
 
 	require.Len(t, appliedSpecs, 2)
 	require.Equal(t, "Resend policy", appliedSpecs[0].Name)
-	require.Equal(t, ptr.String(macProfileUUID), appliedSpecs[0].ProfileUUID)
+	require.Equal(t, new(macProfileUUID), appliedSpecs[0].ProfileUUID)
 	// A policy without the key sends an empty UUID, which unsets any profile
 	// previously associated with it.
 	require.Equal(t, "Plain policy", appliedSpecs[1].Name)
-	require.Equal(t, ptr.String(""), appliedSpecs[1].ProfileUUID)
+	require.Equal(t, new(""), appliedSpecs[1].ProfileUUID)
 }

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/fleets/team-a-thumbsup.yml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/fleets/team-a-thumbsup.yml
@@ -95,6 +95,19 @@ policies:
   conditional_access_enabled: false
   continuous_automations_enabled: false
   critical: false
+  description: This is a team policy with configuration profile automation
+  name: Team Profile policy
+  platform: darwin
+  query: SELECT * FROM team_policy WHERE id = 4
+  resend_configuration_profile:
+    name: Team Profile
+  resolution: Nothing to do.
+  type: dynamic
+  webhooks_and_tickets_enabled: false
+- calendar_events_enabled: false
+  conditional_access_enabled: false
+  continuous_automations_enabled: false
+  critical: false
   description: This is a team policy with FMA install automation
   install_software:
     fleet_maintained_app_slug: fma1/darwin

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/fleets/unassigned.yml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/fleets/unassigned.yml
@@ -76,6 +76,19 @@ policies:
   resolution: Install the app
   type: dynamic
   webhooks_and_tickets_enabled: true
+- calendar_events_enabled: false
+  conditional_access_enabled: false
+  continuous_automations_enabled: false
+  critical: false
+  description: This is a team policy with configuration profile automation
+  name: Team Profile policy
+  platform: darwin
+  query: SELECT * FROM team_policy WHERE id = 4
+  resend_configuration_profile:
+    name: Team Profile
+  resolution: Nothing to do.
+  type: dynamic
+  webhooks_and_tickets_enabled: false
 settings:
   webhook_settings:
     failing_policies_webhook:

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -2024,61 +2024,59 @@ func parsePolicies(top map[string]json.RawMessage, result *GitOps, baseDir strin
 
 	// cast already parsed controls to it's type
 	macOSSettings, ok := result.Controls.MacOSSettings.(fleet.MacOSSettings)
-	if !ok {
-		// TODO: what to do here?
-	}
-	for _, item := range macOSSettings.CustomSettings {
-		// each entry has already been expanded so we can expect a single path
-		if item.Path == "" {
-			multiError = multierror.Append(multiError, errors.New("macos_settings.configuration_profiles[]: path is required for each profile"))
-			continue
-		}
+	if ok {
+		for _, item := range macOSSettings.CustomSettings {
+			// each entry has already been expanded so we can expect a single path
+			if item.Path == "" {
+				multiError = multierror.Append(multiError, errors.New("macos_settings.configuration_profiles[]: path is required for each profile"))
+				continue
+			}
 
-		if !strings.HasSuffix(item.Path, ".mobileconfig") {
-			// no-op and skip silently
-			continue
-		}
+			if !strings.HasSuffix(item.Path, ".mobileconfig") {
+				// no-op and skip silently
+				continue
+			}
 
-		// next we need to read the file, parse it and
-		fileBytes, err := resolveAndReturnFileBytes(item.Path)
-		if err != nil {
-			multiError = multierror.Append(multiError, fmt.Errorf("failed to resolve and read file %s: %v", item.Path, err))
-			continue
-		}
+			// next we need to read the file, parse it and
+			fileBytes, err := resolveAndReturnFileBytes(item.Path)
+			if err != nil {
+				multiError = multierror.Append(multiError, fmt.Errorf("failed to resolve and read file %s: %v", item.Path, err))
+				continue
+			}
 
-		// parse the file into XML .mobileconfig struct and lookup `PayloadDisplayName`
-		mc := mobileconfig.Mobileconfig(fileBytes)
-		parsed, err := mc.ParseConfigProfile()
-		if err != nil {
-			multiError = multierror.Append(multiError, fmt.Errorf("failed to parse mobileconfig file %s: %v", item.Path, err))
-			continue
-		}
-		if parsed.PayloadDisplayName == "" {
-			multiError = multierror.Append(multiError, fmt.Errorf("mobileconfig file %s is missing PayloadDisplayName", item.Path))
-			continue
-		}
+			// parse the file into XML .mobileconfig struct and lookup `PayloadDisplayName`
+			mc := mobileconfig.Mobileconfig(fileBytes)
+			parsed, err := mc.ParseConfigProfile()
+			if err != nil {
+				multiError = multierror.Append(multiError, fmt.Errorf("failed to parse mobileconfig file %s: %v", item.Path, err))
+				continue
+			}
+			if parsed.PayloadDisplayName == "" {
+				multiError = multierror.Append(multiError, fmt.Errorf("mobileconfig file %s is missing PayloadDisplayName", item.Path))
+				continue
+			}
 
-		definedProfileNames[parsed.PayloadDisplayName] = struct{}{}
+			definedProfileNames[parsed.PayloadDisplayName] = struct{}{}
+		}
 	}
 
 	windowsSettings, ok := result.Controls.WindowsSettings.(fleet.WindowsSettings)
-	if !ok {
-		// TODO: what to do here?
-	}
-	for _, item := range windowsSettings.CustomSettings.Value {
-		// each entry has already been expanded so we can expect a single path
-		if item.Path == "" {
-			multiError = multierror.Append(multiError, errors.New("windows_settings.configuration_profiles[]: path is required for each profile"))
-			continue
-		}
+	if ok {
+		for _, item := range windowsSettings.CustomSettings.Value {
+			// each entry has already been expanded so we can expect a single path
+			if item.Path == "" {
+				multiError = multierror.Append(multiError, errors.New("windows_settings.configuration_profiles[]: path is required for each profile"))
+				continue
+			}
 
-		if !strings.HasSuffix(item.Path, ".xml") {
-			// no-op and skip silently
-			continue
-		}
+			if !strings.HasSuffix(item.Path, ".xml") {
+				// no-op and skip silently
+				continue
+			}
 
-		// windows profile names come from the file name without the extension
-		definedProfileNames[strings.TrimSuffix(filepath.Base(item.Path), ".xml")] = struct{}{}
+			// windows profile names come from the file name without the extension
+			definedProfileNames[strings.TrimSuffix(filepath.Base(item.Path), ".xml")] = struct{}{}
+		}
 	}
 
 	// Validate unknown keys in policies section.

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -1714,6 +1714,15 @@ func resolveAndReturnFileBytes(path string) ([]byte, error) {
 	return fileBytes, nil
 }
 
+// blankFleetSecrets removes $FLEET_SECRET_* references from contents. Secrets are
+// only expanded server-side, so a placeholder left inside a <data> payload would
+// fail base64 decoding when the profile is parsed for validation.
+func blankFleetSecrets(contents []byte) []byte {
+	return []byte(fleet.MaybeExpand(string(contents), func(name string, _, _ int) (string, bool) {
+		return "", strings.HasPrefix(name, fleet.ServerSecretPrefix)
+	}))
+}
+
 // defaultAllowedExtensions is the default set of file extensions allowed for
 // glob expansion (YAML files). Entity types that need different extensions
 // (e.g. scripts) should override this in their GlobExpandOptions.
@@ -2045,7 +2054,7 @@ func parsePolicies(top map[string]json.RawMessage, result *GitOps, baseDir strin
 			}
 
 			// parse the file into XML .mobileconfig struct and lookup `PayloadDisplayName`
-			mc := mobileconfig.Mobileconfig(fileBytes)
+			mc := mobileconfig.Mobileconfig(blankFleetSecrets(fileBytes))
 			parsed, err := mc.ParseConfigProfile()
 			if err != nil {
 				multiError = multierror.Append(multiError, fmt.Errorf("failed to parse mobileconfig file %s: %v", item.Path, err))

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -2028,11 +2028,11 @@ func parsePolicies(top map[string]json.RawMessage, result *GitOps, baseDir strin
 		for _, item := range macOSSettings.CustomSettings {
 			// each entry has already been expanded so we can expect a single path
 			if item.Path == "" {
-				multiError = multierror.Append(multiError, errors.New("macos_settings.configuration_profiles[]: path is required for each profile"))
+				multiError = multierror.Append(multiError, errors.New("controls.macos_settings.configuration_profiles[]: path is required for each profile"))
 				continue
 			}
 
-			if !strings.HasSuffix(item.Path, ".mobileconfig") {
+			if !strings.EqualFold(filepath.Ext(item.Path), ".mobileconfig") {
 				// no-op and skip silently
 				continue
 			}
@@ -2065,11 +2065,11 @@ func parsePolicies(top map[string]json.RawMessage, result *GitOps, baseDir strin
 		for _, item := range windowsSettings.CustomSettings.Value {
 			// each entry has already been expanded so we can expect a single path
 			if item.Path == "" {
-				multiError = multierror.Append(multiError, errors.New("windows_settings.configuration_profiles[]: path is required for each profile"))
+				multiError = multierror.Append(multiError, errors.New("controls.windows_settings.configuration_profiles[]: path is required for each profile"))
 				continue
 			}
 
-			if !strings.HasSuffix(item.Path, ".xml") {
+			if !strings.EqualFold(filepath.Ext(item.Path), ".xml") {
 				// no-op and skip silently
 				continue
 			}
@@ -2129,6 +2129,10 @@ func parsePolicies(top map[string]json.RawMessage, result *GitOps, baseDir strin
 							}
 							if err := parsePolicyRunScript(filepath.Dir(*item.Path), parentFilePath, result.TeamName, pp, result.Controls.Scripts); err != nil {
 								multiError = multierror.Append(multiError, fmt.Errorf("failed to parse policy run_script %q: %v", pp.Name, err))
+								continue
+							}
+							if err := parsePolicyResendConfigurationProfile(filepath.Dir(*item.Path), parentFilePath, result.TeamName, pp, definedProfileNames); err != nil {
+								multiError = multierror.Append(multiError, fmt.Errorf("failed to parse policy resend_configuration_profile %q: %v", pp.Name, err))
 								continue
 							}
 							result.Policies = append(result.Policies, &pp.GitOpsPolicySpec)
@@ -2257,15 +2261,20 @@ func parsePolicyResendConfigurationProfile(baseDir string, parentFilePath string
 		return nil
 	}
 
-	if policy.ResendConfigurationProfile.Name != "" && teamName == nil {
+	if teamName == nil {
 		return errors.New("resend_configuration_profile can only be set on team policies")
 	}
 
-	if _, ok := definedProfiles[policy.ResendConfigurationProfile.Name]; !ok {
-		return fmt.Errorf("configuration profile %q was not defined in controls in %s", policy.ResendConfigurationProfile.Name, filepath.Base(parentFilePath))
+	name := strings.TrimSpace(policy.ResendConfigurationProfile.Name)
+	if name == "" {
+		return errors.New("resend_configuration_profile.name is required")
 	}
 
-	policy.ResendConfigurationProfileName = &policy.ResendConfigurationProfile.Name
+	if _, ok := definedProfiles[name]; !ok {
+		return fmt.Errorf("configuration profile %q was not defined in controls in %s", name, filepath.Base(parentFilePath))
+	}
+
+	policy.ResendConfigurationProfileName = &name
 
 	return nil
 }

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -2084,7 +2084,8 @@ func parsePolicies(top map[string]json.RawMessage, result *GitOps, baseDir strin
 			}
 
 			// windows profile names come from the file name without the extension
-			definedProfileNames[strings.TrimSuffix(filepath.Base(item.Path), ".xml")] = struct{}{}
+			base := filepath.Base(item.Path)
+			definedProfileNames[strings.TrimSuffix(base, filepath.Ext(base))] = struct{}{}
 		}
 	}
 

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -19,6 +19,7 @@ import (
 	"github.com/fleetdm/fleet/v4/pkg/optjson"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
+	"github.com/fleetdm/fleet/v4/server/mdm/apple/mobileconfig"
 	"github.com/fleetdm/fleet/v4/server/mdm/microsoft/syncml"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/ghodss/yaml"
@@ -224,15 +225,19 @@ type GitOpsPolicySpec struct {
 	fleet.PolicySpec
 	// Shadows PolicySpec.ContinuousAutomationsEnabled to tell whether the key was set
 	// explicitly vs. omitted, which patch_when_closed validation needs.
-	ContinuousAutomations optjson.Bool                           `json:"continuous_automations_enabled"`
-	RunScript             *PolicyRunScript                       `json:"run_script"`
-	InstallSoftware       optjson.BoolOr[*PolicyInstallSoftware] `json:"install_software"`
+	ContinuousAutomations      optjson.Bool                           `json:"continuous_automations_enabled"`
+	RunScript                  *PolicyRunScript                       `json:"run_script"`
+	InstallSoftware            optjson.BoolOr[*PolicyInstallSoftware] `json:"install_software"`
+	ResendConfigurationProfile *PolicyResendConfigurationProfile      `json:"resend_configuration_profile"`
 	// InstallSoftwareURL is populated after parsing the software installer yaml
 	// referenced by InstallSoftware.PackagePath.
 	InstallSoftwareURL string `json:"-"`
 	// RunScriptName is populated after confirming the script exists on both the file system
 	// and in the controls scripts list for the same team
 	RunScriptName *string `json:"-"`
+	// ResendConfigurationProfileName is populated after confirming the configuration profile exists on both the file system
+	// and in the controls configuration profiles list for the same team
+	ResendConfigurationProfileName *string `json:"-"`
 	// WebhooksAndTicketsEnabled indicates whether failing policy webhooks/tickets
 	// should be enabled for this policy. This is a gitops-only convenience that
 	// translates to adding the policy's ID to the failing_policies_webhook.policy_ids list.
@@ -248,6 +253,10 @@ type PolicyInstallSoftware struct {
 	AppStoreID             string `json:"app_store_id"`
 	HashSHA256             string `json:"hash_sha256"`
 	FleetMaintainedAppSlug string `json:"fleet_maintained_app_slug"`
+}
+
+type PolicyResendConfigurationProfile struct {
+	Name string `json:"name"`
 }
 
 type Query struct {
@@ -1692,6 +1701,19 @@ func resolveAndUpdateProfilePath(profile *fleet.MDMProfileSpec, result *GitOps) 
 	return nil
 }
 
+func resolveAndReturnFileBytes(path string) ([]byte, error) {
+	resolved, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve path %s: %v", path, err)
+	}
+	fileBytes, err := os.ReadFile(resolved)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file %s: %v", resolved, err)
+	}
+
+	return fileBytes, nil
+}
+
 // defaultAllowedExtensions is the default set of file extensions allowed for
 // glob expansion (YAML files). Entity types that need different extensions
 // (e.g. scripts) should override this in their GlobExpandOptions.
@@ -1997,6 +2019,68 @@ func parsePolicies(top map[string]json.RawMessage, result *GitOps, baseDir strin
 		multiError = multierror.Append(multiError, errs...)
 	}
 
+	// map of profile names that is defined in gitops
+	definedProfileNames := make(map[string]struct{})
+
+	// cast already parsed controls to it's type
+	macOSSettings, ok := result.Controls.MacOSSettings.(fleet.MacOSSettings)
+	if !ok {
+		// TODO: what to do here?
+	}
+	for _, item := range macOSSettings.CustomSettings {
+		// each entry has already been expanded so we can expect a single path
+		if item.Path == "" {
+			multiError = multierror.Append(multiError, errors.New("macos_settings.configuration_profiles[]: path is required for each profile"))
+			continue
+		}
+
+		if !strings.HasSuffix(item.Path, ".mobileconfig") {
+			// no-op and skip silently
+			continue
+		}
+
+		// next we need to read the file, parse it and
+		fileBytes, err := resolveAndReturnFileBytes(item.Path)
+		if err != nil {
+			multiError = multierror.Append(multiError, fmt.Errorf("failed to resolve and read file %s: %v", item.Path, err))
+			continue
+		}
+
+		// parse the file into XML .mobileconfig struct and lookup `PayloadDisplayName`
+		mc := mobileconfig.Mobileconfig(fileBytes)
+		parsed, err := mc.ParseConfigProfile()
+		if err != nil {
+			multiError = multierror.Append(multiError, fmt.Errorf("failed to parse mobileconfig file %s: %v", item.Path, err))
+			continue
+		}
+		if parsed.PayloadDisplayName == "" {
+			multiError = multierror.Append(multiError, fmt.Errorf("mobileconfig file %s is missing PayloadDisplayName", item.Path))
+			continue
+		}
+
+		definedProfileNames[parsed.PayloadDisplayName] = struct{}{}
+	}
+
+	windowsSettings, ok := result.Controls.WindowsSettings.(fleet.WindowsSettings)
+	if !ok {
+		// TODO: what to do here?
+	}
+	for _, item := range windowsSettings.CustomSettings.Value {
+		// each entry has already been expanded so we can expect a single path
+		if item.Path == "" {
+			multiError = multierror.Append(multiError, errors.New("windows_settings.configuration_profiles[]: path is required for each profile"))
+			continue
+		}
+
+		if !strings.HasSuffix(item.Path, ".xml") {
+			// no-op and skip silently
+			continue
+		}
+
+		// windows profile names come from the file name without the extension
+		definedProfileNames[strings.TrimSuffix(filepath.Base(item.Path), ".xml")] = struct{}{}
+	}
+
 	// Validate unknown keys in policies section.
 	multiError = multierror.Append(multiError, validateRawKeys(policiesRaw, reflect.TypeFor[[]Policy](), filePath, []string{"policies"})...)
 	for _, item := range policies {
@@ -2007,6 +2091,10 @@ func parsePolicies(top map[string]json.RawMessage, result *GitOps, baseDir strin
 			}
 			if err := parsePolicyRunScript(baseDir, parentFilePath, result.TeamName, &item, result.Controls.Scripts); err != nil {
 				multiError = multierror.Append(multiError, fmt.Errorf("failed to parse policy run_script %q: %v", item.Name, err))
+				continue
+			}
+			if err := parsePolicyResendConfigurationProfile(baseDir, parentFilePath, result.TeamName, &item, definedProfileNames); err != nil {
+				multiError = multierror.Append(multiError, fmt.Errorf("failed to parse policy resend_configuration_profile %q: %v", item.Name, err))
 				continue
 			}
 			result.Policies = append(result.Policies, &item.GitOpsPolicySpec)
@@ -2161,6 +2249,25 @@ func parsePolicyRunScript(baseDir string, parentFilePath string, teamName *strin
 
 	scriptName := filepath.Base(policy.RunScript.Path)
 	policy.RunScriptName = &scriptName
+
+	return nil
+}
+
+func parsePolicyResendConfigurationProfile(baseDir string, parentFilePath string, teamName *string, policy *Policy, definedProfiles map[string]struct{}) error {
+	if policy.ResendConfigurationProfile == nil {
+		policy.ResendConfigurationProfileName = new("") // unset the profile name
+		return nil
+	}
+
+	if policy.ResendConfigurationProfile.Name != "" && teamName == nil {
+		return errors.New("resend_configuration_profile can only be set on team policies")
+	}
+
+	if _, ok := definedProfiles[policy.ResendConfigurationProfile.Name]; !ok {
+		return fmt.Errorf("configuration profile %q was not defined in controls in %s", policy.ResendConfigurationProfile.Name, filepath.Base(parentFilePath))
+	}
+
+	policy.ResendConfigurationProfileName = &policy.ResendConfigurationProfile.Name
 
 	return nil
 }

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -5823,6 +5823,7 @@ controls:
 func TestGitOpsPolicyWithResendConfigurationProfile(t *testing.T) {
 	t.Parallel()
 
+	//nolint:gosec // G101: test fixture, not a real credential.
 	const passwordProfile = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -5841,7 +5842,7 @@ func TestGitOpsPolicyWithResendConfigurationProfile(t *testing.T) {
 	<integer>1</integer>
 </dict>
 </plist>
-` // nolint:gosec // This is a test file, not a real password profile.
+`
 
 	// writeConfig lays out a gitops dir holding one macOS and one Windows profile,
 	// then appends the given policies section to a team (or global) config.
@@ -5860,10 +5861,10 @@ func TestGitOpsPolicyWithResendConfigurationProfile(t *testing.T) {
 controls:
   macos_settings:
     custom_settings:
-      - path: ./lib/password.mobileconfig
+      - path: ./lib/password.MOBILECoNFIG
   windows_settings:
     custom_settings:
-      - path: ./lib/screenlock.xml
+      - path: ./lib/screenlock.XmL
 ` + policies
 
 		yamlPath := filepath.Join(dir, "gitops.yml")

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -3503,9 +3503,9 @@ func TestGitOpsGlobProfiles(t *testing.T) {
 		dir := t.TempDir()
 		profilesDir := filepath.Join(dir, "profiles")
 		require.NoError(t, os.MkdirAll(profilesDir, 0o755))
-		require.NoError(t, os.WriteFile(filepath.Join(profilesDir, "alpha.mobileconfig"), []byte("<plist></plist>"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(profilesDir, "alpha.mobileconfig"), []byte(emptyMCProfile), 0o644))
 		require.NoError(t, os.WriteFile(filepath.Join(profilesDir, "beta.json"), []byte("{}"), 0o644))
-		require.NoError(t, os.WriteFile(filepath.Join(profilesDir, "gamma.mobileconfig"), []byte("<plist></plist>"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(profilesDir, "gamma.mobileconfig"), []byte(emptyMCProfile), 0o644))
 
 		config := getGlobalConfig([]string{"controls"})
 		config += `controls:
@@ -3591,8 +3591,8 @@ func TestGitOpsGlobProfiles(t *testing.T) {
 		dir := t.TempDir()
 		profilesDir := filepath.Join(dir, "profiles")
 		require.NoError(t, os.MkdirAll(profilesDir, 0o755))
-		require.NoError(t, os.WriteFile(filepath.Join(profilesDir, "a.mobileconfig"), []byte("<plist></plist>"), 0o644))
-		require.NoError(t, os.WriteFile(filepath.Join(profilesDir, "b.mobileconfig"), []byte("<plist></plist>"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(profilesDir, "a.mobileconfig"), []byte(emptyMCProfile), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(profilesDir, "b.mobileconfig"), []byte(emptyMCProfile), 0o644))
 
 		config := getGlobalConfig([]string{"controls"})
 		config += `controls:
@@ -3687,7 +3687,7 @@ func TestGitOpsOSUpdatesProfileConflict(t *testing.T) {
 	t.Run("macos updates configured with non-conflicting profile is allowed", func(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()
-		require.NoError(t, os.WriteFile(filepath.Join(dir, "plain.mobileconfig"), []byte("<plist></plist>"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "plain.mobileconfig"), []byte(emptyMCProfile), 0o644))
 
 		config := getGlobalConfig([]string{"controls"})
 		config += `controls:
@@ -4282,7 +4282,7 @@ func TestControlsNewKeyNames(t *testing.T) {
 		dir := t.TempDir()
 		profileDir := filepath.Join(dir, "lib")
 		require.NoError(t, os.Mkdir(profileDir, 0o755))
-		require.NoError(t, os.WriteFile(filepath.Join(profileDir, "macos-password.mobileconfig"), []byte("<plist></plist>"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(profileDir, "macos-password.mobileconfig"), []byte(emptyMCProfile), 0o644))
 		require.NoError(t, os.WriteFile(filepath.Join(profileDir, "windows-screenlock.xml"), []byte("<xml/>"), 0o644))
 		require.NoError(t, os.WriteFile(filepath.Join(profileDir, "collect-fleetd-logs.sh"), []byte("#!/bin/bash"), 0o644))
 
@@ -4350,7 +4350,7 @@ org_settings:
 		dir := t.TempDir()
 		profileDir := filepath.Join(dir, "lib")
 		require.NoError(t, os.Mkdir(profileDir, 0o755))
-		require.NoError(t, os.WriteFile(filepath.Join(profileDir, "macos-password.mobileconfig"), []byte("<plist></plist>"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(profileDir, "macos-password.mobileconfig"), []byte(emptyMCProfile), 0o644))
 		require.NoError(t, os.WriteFile(filepath.Join(profileDir, "windows-screenlock.xml"), []byte("<xml/>"), 0o644))
 		require.NoError(t, os.WriteFile(filepath.Join(profileDir, "collect-fleetd-logs.sh"), []byte("#!/bin/bash"), 0o644))
 
@@ -5841,7 +5841,7 @@ func TestGitOpsPolicyWithResendConfigurationProfile(t *testing.T) {
 	<integer>1</integer>
 </dict>
 </plist>
-`
+` // nolint:gosec // This is a test file, not a real password profile.
 
 	// writeConfig lays out a gitops dir holding one macOS and one Windows profile,
 	// then appends the given policies section to a team (or global) config.
@@ -5887,10 +5887,10 @@ policies:
 `)
 		require.NoError(t, err)
 		require.Len(t, got.Policies, 3)
-		require.Equal(t, ptr.String("Password policy"), got.Policies[0].ResendConfigurationProfileName)
-		require.Equal(t, ptr.String("screenlock"), got.Policies[1].ResendConfigurationProfileName)
+		require.Equal(t, new("Password policy"), got.Policies[0].ResendConfigurationProfileName)
+		require.Equal(t, new("screenlock"), got.Policies[1].ResendConfigurationProfileName)
 		// Policies without the key get an empty name so the server unsets any existing profile.
-		require.Equal(t, ptr.String(""), got.Policies[2].ResendConfigurationProfileName)
+		require.Equal(t, new(""), got.Policies[2].ResendConfigurationProfileName)
 	})
 
 	t.Run("errors when the profile is not defined in controls", func(t *testing.T) {
@@ -5915,3 +5915,16 @@ policies:
 		require.ErrorContains(t, err, "resend_configuration_profile can only be set on team policies")
 	})
 }
+
+const emptyMCProfile = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadDisplayName</key>
+	<string>Empty Profile</string>
+	<key>PayloadIdentifier</key>
+	<string>empty-profile-identifier</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+</dict>
+</plist>`

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -5848,8 +5848,8 @@ func TestGitOpsPolicyWithResendConfigurationProfile(t *testing.T) {
 	writeConfig := func(t *testing.T, global bool, policies string) (*GitOps, error) {
 		dir := t.TempDir()
 		require.NoError(t, os.Mkdir(filepath.Join(dir, "lib"), 0o755))
-		require.NoError(t, os.WriteFile(filepath.Join(dir, "lib", "password.mobileconfig"), []byte(passwordProfile), 0o644))
-		require.NoError(t, os.WriteFile(filepath.Join(dir, "lib", "screenlock.xml"), []byte("<Replace></Replace>"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "lib", "password.MOBILECoNFIG"), []byte(passwordProfile), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "lib", "screenlock.XmL"), []byte("<Replace></Replace>"), 0o644))
 
 		exclude := []string{"controls", "policies"}
 		config := getTeamConfig(exclude)

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -5819,3 +5819,99 @@ controls:
 		require.Contains(t, err.Error(), "failed to read activation file")
 	})
 }
+
+func TestGitOpsPolicyWithResendConfigurationProfile(t *testing.T) {
+	t.Parallel()
+
+	const passwordProfile = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadDisplayName</key>
+	<string>Password policy</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleet.password</string>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>F7CF282E-D91B-44E9-922F-A719634F9C8E</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>
+`
+
+	// writeConfig lays out a gitops dir holding one macOS and one Windows profile,
+	// then appends the given policies section to a team (or global) config.
+	writeConfig := func(t *testing.T, global bool, policies string) (*GitOps, error) {
+		dir := t.TempDir()
+		require.NoError(t, os.Mkdir(filepath.Join(dir, "lib"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "lib", "password.mobileconfig"), []byte(passwordProfile), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "lib", "screenlock.xml"), []byte("<Replace></Replace>"), 0o644))
+
+		exclude := []string{"controls", "policies"}
+		config := getTeamConfig(exclude)
+		if global {
+			config = getGlobalConfig(exclude)
+		}
+		config += `
+controls:
+  macos_settings:
+    custom_settings:
+      - path: ./lib/password.mobileconfig
+  windows_settings:
+    custom_settings:
+      - path: ./lib/screenlock.xml
+` + policies
+
+		yamlPath := filepath.Join(dir, "gitops.yml")
+		require.NoError(t, os.WriteFile(yamlPath, []byte(config), 0o644))
+		return GitOpsFromFile(yamlPath, dir, nil, nopLogf)
+	}
+
+	t.Run("resolves macOS and Windows profile names defined in controls", func(t *testing.T) {
+		got, err := writeConfig(t, false, `
+policies:
+- name: Mac policy
+  query: SELECT 1;
+  resend_configuration_profile:
+    name: Password policy
+- name: Windows policy
+  query: SELECT 1;
+  resend_configuration_profile:
+    name: screenlock
+- name: No resend policy
+  query: SELECT 1;
+`)
+		require.NoError(t, err)
+		require.Len(t, got.Policies, 3)
+		require.Equal(t, ptr.String("Password policy"), got.Policies[0].ResendConfigurationProfileName)
+		require.Equal(t, ptr.String("screenlock"), got.Policies[1].ResendConfigurationProfileName)
+		// Policies without the key get an empty name so the server unsets any existing profile.
+		require.Equal(t, ptr.String(""), got.Policies[2].ResendConfigurationProfileName)
+	})
+
+	t.Run("errors when the profile is not defined in controls", func(t *testing.T) {
+		_, err := writeConfig(t, false, `
+policies:
+- name: Mac policy
+  query: SELECT 1;
+  resend_configuration_profile:
+    name: Not a profile
+`)
+		require.ErrorContains(t, err, `configuration profile "Not a profile" was not defined in controls`)
+	})
+
+	t.Run("errors on global policies", func(t *testing.T) {
+		_, err := writeConfig(t, true, `
+policies:
+- name: Mac policy
+  query: SELECT 1;
+  resend_configuration_profile:
+    name: Password policy
+`)
+		require.ErrorContains(t, err, "resend_configuration_profile can only be set on team policies")
+	})
+}

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -3607,9 +3607,10 @@ func (c *Client) doGitOpsPolicies(config *spec.GitOps, teamSoftwareInstallers []
 			if teamProfiles != nil {
 				return nil
 			}
+
 			profiles, err := c.ListConfigurationProfiles(teamID)
 			if err != nil {
-				return fmt.Errorf("error listing configuration profiles for team %d: %w", *teamID, err)
+				return fmt.Errorf("error listing configuration profiles: %w", err)
 			}
 			teamProfiles = make(map[string]string, len(profiles))
 			for _, profile := range profiles {
@@ -3627,7 +3628,7 @@ func (c *Client) doGitOpsPolicies(config *spec.GitOps, teamSoftwareInstallers []
 			}
 
 			if err := hydrateProfiles(); err != nil {
-				return fmt.Errorf("error hydrating configuration profiles for team %d: %w", *teamID, err)
+				return fmt.Errorf("error hydrating configuration profiles: %w", err)
 			}
 
 			profileUUID, ok := teamProfiles[*config.Policies[i].ResendConfigurationProfileName]

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -3602,6 +3602,44 @@ func (c *Client) doGitOpsPolicies(config *spec.GitOps, teamSoftwareInstallers []
 			config.Policies[i].ScriptID = &scriptID
 		}
 
+		var teamProfiles map[string]string
+		hydrateProfiles := func() error {
+			if teamProfiles != nil {
+				return nil
+			}
+			profiles, err := c.ListConfigurationProfiles(teamID)
+			if err != nil {
+				return fmt.Errorf("error listing configuration profiles for team %d: %w", *teamID, err)
+			}
+			teamProfiles = make(map[string]string, len(profiles))
+			for _, profile := range profiles {
+				teamProfiles[profile.Name] = profile.ProfileUUID
+			}
+			return nil
+		}
+		// assign profile UUIDs for policies with resend configuration profiles
+		for i := range config.Policies {
+			// default to empty string to unset, and then override if match is found
+			config.Policies[i].ProfileUUID = new("")
+
+			if config.Policies[i].ResendConfigurationProfileName == nil || *config.Policies[i].ResendConfigurationProfileName == "" {
+				continue
+			}
+
+			if err := hydrateProfiles(); err != nil {
+				return fmt.Errorf("error hydrating configuration profiles for team %d: %w", *teamID, err)
+			}
+
+			profileUUID, ok := teamProfiles[*config.Policies[i].ResendConfigurationProfileName]
+			if !ok {
+				if !dryRun { // this shouldn't happen
+					logFn("[!] reference to an unknown configuration profile: %s\n", *config.Policies[i].ResendConfigurationProfileName)
+				}
+				continue
+			}
+			config.Policies[i].ProfileUUID = &profileUUID
+		}
+
 		// Get patch policy title IDs for the team
 		for _, policy := range config.Policies {
 			if policy.Type == fleet.PolicyTypePatch {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #51271

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information. Part of another story PR

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - GitOps policies can resend a specified macOS or Windows configuration profile.
  - Profile references are resolved automatically when policies are applied.
  - Team policies support configuration profile names defined in GitOps configuration.

- **Bug Fixes**
  - Unresolved profile references are cleared and reported with a warning.
  - Invalid profile references and unsupported global-policy usage are rejected during validation.
  - Configuration profile filenames are recognized regardless of capitalization in their extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->