### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/adlock/darwin.json
+++ b/ee/maintained-apps/outputs/adlock/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "2.1.9.2",
+      "version": "2.1.9.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.hankuper.adlock.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hankuper.adlock.desktop' AND version_compare(bundle_short_version, '2.1.9.2') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hankuper.adlock.desktop' AND version_compare(bundle_short_version, '2.1.9.3') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.hankuper.adlock.desktop');"
       },
       "installer_url": "https://downloads.adlock.com/mac/AdLock_Installer.dmg",

--- a/ee/maintained-apps/outputs/arc/darwin.json
+++ b/ee/maintained-apps/outputs/arc/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.160.0",
+      "version": "1.161.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'company.thebrowser.Browser';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'company.thebrowser.Browser' AND version_compare(bundle_short_version, '1.160.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'company.thebrowser.Browser' AND version_compare(bundle_short_version, '1.161.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'company.thebrowser.Browser');"
       },
-      "installer_url": "https://releases.arc.net/release/Arc-1.160.0-85122.zip",
+      "installer_url": "https://releases.arc.net/release/Arc-1.161.0-85574.zip",
       "install_script_ref": "cbf109ae",
       "uninstall_script_ref": "a19b04fa",
-      "sha256": "12bc9de1803c39a72486a02f5b4701377123d224dfb4d7d1952359b14045e204",
+      "sha256": "e5580dfb9f640bf90a5574dbca734691a029cbdd73a3dd5004fd37fa1094d8c8",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/beeper/darwin.json
+++ b/ee/maintained-apps/outputs/beeper/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "4.3.34",
+      "version": "4.3.54",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.automattic.beeper.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.automattic.beeper.desktop' AND version_compare(bundle_short_version, '4.3.34') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.automattic.beeper.desktop' AND version_compare(bundle_short_version, '4.3.54') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.automattic.beeper.desktop');"
       },
-      "installer_url": "https://beeper-desktop.download.beeper.com/builds/Beeper-4.3.34-arm64-mac.zip",
+      "installer_url": "https://beeper-desktop.download.beeper.com/builds/Beeper-4.3.54-arm64-mac.zip",
       "install_script_ref": "403ed251",
       "uninstall_script_ref": "978d30f8",
-      "sha256": "9ac64e0f220e351e54faa7410a471ba6766d8d86642a6a235c05eda47aa982b0",
+      "sha256": "f7e87364a345b67f68d90c38748a961a75f10fcd3a058232210a5e9f9d105c7f",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/bruno/darwin.json
+++ b/ee/maintained-apps/outputs/bruno/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "4.0.0",
+      "version": "4.1.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.usebruno.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.usebruno.app' AND version_compare(bundle_short_version, '4.0.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.usebruno.app' AND version_compare(bundle_short_version, '4.1.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.usebruno.app');"
       },
-      "installer_url": "https://github.com/usebruno/bruno/releases/download/v4.0.0/bruno_4.0.0_arm64_mac.dmg",
+      "installer_url": "https://github.com/usebruno/bruno/releases/download/v4.1.0/bruno_4.1.0_arm64_mac.dmg",
       "install_script_ref": "c3c853d8",
       "uninstall_script_ref": "14f6d5fd",
-      "sha256": "533d435d1760f8ccdb98db24605335716710d346181659fb60956a7e4d529407",
+      "sha256": "31af43035099556492ce2196a87e88234caafdc897ccc2c9bfa62a321fc5df8e",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/chatgpt/darwin.json
+++ b/ee/maintained-apps/outputs/chatgpt/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "26.818.21641",
+      "version": "26.818.22352",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.chat';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.chat' AND version_compare(bundle_short_version, '26.818.21641') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.chat' AND version_compare(bundle_short_version, '26.818.22352') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.openai.chat');"
       },
-      "installer_url": "https://persistent.oaistatic.com/codex-app-prod/ChatGPT-darwin-arm64-26.818.21641.zip",
+      "installer_url": "https://persistent.oaistatic.com/codex-app-prod/ChatGPT-darwin-arm64-26.818.22352.zip",
       "install_script_ref": "cbce2d7d",
       "uninstall_script_ref": "678e6cf0",
-      "sha256": "4c448e4eae229088597f24152f03b8a3d881e91858fdc884284d5ce845fdeb36",
+      "sha256": "d1e06b880d5eedcafd5607c9bb69f76853ed138140c6b0eb9a85f61669a60f9f",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/codexbar/darwin.json
+++ b/ee/maintained-apps/outputs/codexbar/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "0.53.0",
+      "version": "0.54.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.steipete.codexbar';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.steipete.codexbar' AND version_compare(bundle_short_version, '0.53.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.steipete.codexbar' AND version_compare(bundle_short_version, '0.54.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.steipete.codexbar');"
       },
-      "installer_url": "https://github.com/steipete/CodexBar/releases/download/v0.53.0/CodexBar-macos-universal-0.53.0.zip",
+      "installer_url": "https://github.com/steipete/CodexBar/releases/download/v0.54.0/CodexBar-macos-universal-0.54.0.zip",
       "install_script_ref": "6993c93e",
       "uninstall_script_ref": "efcab822",
-      "sha256": "fd7673d36ca7a6cb35d27afc968b5ba671942402e781d5b8fcaf2c7cc531c16d",
+      "sha256": "8cbfa697eaa172901d86493954dbcd475062913dfb968060b9611f72a2ff1a76",
       "default_categories": [
         "Utilities"
       ]

--- a/ee/maintained-apps/outputs/firefox@nightly/darwin.json
+++ b/ee/maintained-apps/outputs/firefox@nightly/darwin.json
@@ -4,13 +4,13 @@
       "version": "156.0a1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15626.8.19') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15626.8.20') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'org.mozilla.nightly');"
       },
-      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/08/2026-08-19-21-08-08-mozilla-central/firefox-156.0a1.en-US.mac.dmg",
+      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/08/2026-08-20-09-27-44-mozilla-central/firefox-156.0a1.en-US.mac.dmg",
       "install_script_ref": "d9c4cf87",
       "uninstall_script_ref": "0661f848",
-      "sha256": "cc3aae13add72d738702b66edbe95a21b508639dd7ad7cc05ed2ccd2b77fb373",
+      "sha256": "a3c8784f32c7216383727523ee4d488695840b83a757f9c5003ebe61724f6ca3",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/granola/darwin.json
+++ b/ee/maintained-apps/outputs/granola/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "7.488.3",
+      "version": "7.498.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app' AND version_compare(bundle_short_version, '7.488.3') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app' AND version_compare(bundle_short_version, '7.498.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.granola.app');"
       },
-      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.488.3/Granola-7.488.3-mac-universal.dmg",
+      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.498.1/Granola-7.498.1-mac-universal.dmg",
       "install_script_ref": "08a593fa",
       "uninstall_script_ref": "903a1d58",
-      "sha256": "d405d6d873471043f2e117e8a030aa40cff5b7d3e494683aab86269b53751faf",
+      "sha256": "410aba51fbe6e65aca0ab8d0f25940a64aa94246d8920d16e6904916b02b0459",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/hive-app/darwin.json
+++ b/ee/maintained-apps/outputs/hive-app/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.2.36",
+      "version": "1.2.37",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app' AND version_compare(bundle_short_version, '1.2.36') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app' AND version_compare(bundle_short_version, '1.2.37') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.hive.app');"
       },
-      "installer_url": "https://github.com/morapelker/hive/releases/download/v1.2.36/Hive-1.2.36-arm64.dmg",
+      "installer_url": "https://github.com/morapelker/hive/releases/download/v1.2.37/Hive-1.2.37-arm64.dmg",
       "install_script_ref": "3bd4ebe4",
       "uninstall_script_ref": "951b5587",
-      "sha256": "02b4f76244419b1106e3fa5ca5026a61fd2e753ee789d7f73041df3c57c93728",
+      "sha256": "3842d7a3adffae70bd3935f50b8436415a93864d01072fd9a7a3e4ae3e264a0b",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/jami/darwin.json
+++ b/ee/maintained-apps/outputs/jami/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "2.41",
+      "version": "2.42",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'cx.ring';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'cx.ring' AND version_compare(bundle_short_version, '2.41') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'cx.ring' AND version_compare(bundle_short_version, '2.42') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'cx.ring');"
       },
-      "installer_url": "https://dl.jami.net/mac_osx/jami2026081410.dmg",
+      "installer_url": "https://dl.jami.net/mac_osx/jami2026082009.dmg",
       "install_script_ref": "656eb108",
       "uninstall_script_ref": "aff7c461",
-      "sha256": "05b22cb151ea25aa55865df1713c3760c3ad1068fcd969fde9f831060524be7c",
+      "sha256": "8e9e1990ce3af57629a619991c91f08c0518273facbed5b3fcdd736ef11fa6e6",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/trezor-suite/darwin.json
+++ b/ee/maintained-apps/outputs/trezor-suite/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "26.7.4",
+      "version": "26.8.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'io.trezor.TrezorSuite';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.trezor.TrezorSuite' AND version_compare(bundle_short_version, '26.7.4') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.trezor.TrezorSuite' AND version_compare(bundle_short_version, '26.8.2') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'io.trezor.TrezorSuite');"
       },
-      "installer_url": "https://data.trezor.io/suite/releases/desktop/latest/Trezor-Suite-26.7.4-mac-arm64.dmg",
+      "installer_url": "https://data.trezor.io/suite/releases/desktop/latest/Trezor-Suite-26.8.2-mac-arm64.dmg",
       "install_script_ref": "3f139099",
       "uninstall_script_ref": "9026a399",
-      "sha256": "606d6c00bc97e48c24dd1821c4568f822812f71a9204f324662ac3c18305b999",
+      "sha256": "99f511e73f6f10ec97b824e64c5906435b3abe20d092c0ac95362c195f352fc1",
       "default_categories": [
         "Security"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated macOS app definitions for AdLock, Arc, Beeper, Bruno, ChatGPT, CodexBar, Firefox Nightly, Granola, Hive, Jami, and Trezor Suite.
  * Updated minimum supported versions, installer links, and verification checksums where applicable.
  * Devices can now detect and install the latest supported releases for these applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->