### PR TITLE
Fix policies Software automation filter including patch policies

### DIFF
--- a/changes/44625-software-filter-patch-policies
+++ b/changes/44625-software-filter-patch-policies
@@ -1,0 +1,1 @@
+* Fixed the "Software" automation filter on the Policies page to no longer include patch policies. Added a dedicated "Patch" filter option.

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -97,6 +97,7 @@ export const DEFAULT_SORT_COLUMN = "name";
 
 const AUTOMATION_TYPES: AutomationType[] = [
   "software",
+  "patch",
   "scripts",
   "calendar",
   "conditional_access",
@@ -749,6 +750,11 @@ const ManagePolicyPage = ({
       label: "Software",
       value: "software",
       helpText: "Policies with software automation enabled.",
+    },
+    {
+      label: "Patch",
+      value: "patch",
+      helpText: "Patch policies for Fleet-maintained apps.",
     },
     {
       label: "Scripts",

--- a/frontend/services/entities/team_policies.ts
+++ b/frontend/services/entities/team_policies.ts
@@ -16,6 +16,7 @@ import { GlobalPoliciesAutomationType } from "./global_policies";
 
 export type AutomationType =
   | "software"
+  | "patch"
   | "scripts"
   | "calendar"
   | "conditional_access"

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -3162,6 +3162,8 @@ func (ds *Datastore) createAutomationClause(ctx context.Context, automationType 
 	switch automationType {
 	case fleet.PolicyAutomationTypeSoftware:
 		return " AND (p.software_installer_id IS NOT NULL OR p.vpp_apps_teams_id IS NOT NULL)", nil, nil
+	case fleet.PolicyAutomationTypePatch:
+		return " AND p.type = 'patch'", nil, nil
 	case fleet.PolicyAutomationTypeScripts:
 		return " AND p.script_id IS NOT NULL", nil, nil
 	case fleet.PolicyAutomationTypeCalendar:

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -3161,7 +3161,7 @@ func (ds *Datastore) createAutomationClause(ctx context.Context, automationType 
 
 	switch automationType {
 	case fleet.PolicyAutomationTypeSoftware:
-		return " AND (p.software_installer_id IS NOT NULL OR p.vpp_apps_teams_id IS NOT NULL OR p.type = 'patch')", nil, nil
+		return " AND (p.software_installer_id IS NOT NULL OR p.vpp_apps_teams_id IS NOT NULL)", nil, nil
 	case fleet.PolicyAutomationTypeScripts:
 		return " AND p.script_id IS NOT NULL", nil, nil
 	case fleet.PolicyAutomationTypeCalendar:

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -9365,14 +9365,26 @@ func testTeamPolicyAutomationFilter(t *testing.T, ds *Datastore) {
 		OrderDirection: fleet.OrderAscending,
 	}, "software", "")
 	require.NoError(t, err)
-	require.Len(t, merged, 3)
+	require.Len(t, merged, 2)
 	assert.Equal(t, teamInstallerPolicy.ID, merged[0].ID)
 	assert.Equal(t, teamAppStorePolicy.ID, merged[1].ID)
-	assert.Equal(t, teamPatchPolicy.ID, merged[2].ID)
 
 	mergedCount, err = ds.CountMergedTeamPolicies(ctx, 0, "", "software", "")
 	require.NoError(t, err)
-	assert.Equal(t, 3, mergedCount)
+	assert.Equal(t, 2, mergedCount)
+
+	// Test patch
+	merged, err = ds.ListMergedTeamPolicies(ctx, 0, fleet.ListOptions{
+		OrderKey:       "name",
+		OrderDirection: fleet.OrderAscending,
+	}, "patch", "")
+	require.NoError(t, err)
+	require.Len(t, merged, 1)
+	assert.Equal(t, teamPatchPolicy.ID, merged[0].ID)
+
+	mergedCount, err = ds.CountMergedTeamPolicies(ctx, 0, "", "patch", "")
+	require.NoError(t, err)
+	assert.Equal(t, 1, mergedCount)
 
 	// Test scripts
 	merged, err = ds.ListMergedTeamPolicies(ctx, 0, fleet.ListOptions{
@@ -9432,14 +9444,26 @@ func testTeamPolicyAutomationFilter(t *testing.T, ds *Datastore) {
 		OrderDirection: fleet.OrderAscending,
 	}, fleet.ListOptions{}, "software", "")
 	require.NoError(t, err)
-	require.Len(t, policies, 3)
+	require.Len(t, policies, 2)
 	assert.Equal(t, teamInstallerPolicy.ID, policies[0].ID)
 	assert.Equal(t, teamAppStorePolicy.ID, policies[1].ID)
-	assert.Equal(t, teamPatchPolicy.ID, policies[2].ID)
 
 	mergedCount, err = ds.CountPolicies(ctx, new(uint(0)), "", "software", "")
 	require.NoError(t, err)
-	assert.Equal(t, 3, mergedCount)
+	assert.Equal(t, 2, mergedCount)
+
+	// Test not merged patch
+	policies, _, err = ds.ListTeamPolicies(ctx, 0, fleet.ListOptions{
+		OrderKey:       "name",
+		OrderDirection: fleet.OrderAscending,
+	}, fleet.ListOptions{}, "patch", "")
+	require.NoError(t, err)
+	require.Len(t, policies, 1)
+	assert.Equal(t, teamPatchPolicy.ID, policies[0].ID)
+
+	mergedCount, err = ds.CountPolicies(ctx, new(uint(0)), "", "patch", "")
+	require.NoError(t, err)
+	assert.Equal(t, 1, mergedCount)
 }
 
 // testApplyPolicySpecNoSpuriousStatsReset verifies that re-applying a team

--- a/server/fleet/policies.go
+++ b/server/fleet/policies.go
@@ -899,6 +899,7 @@ type PolicyAutomationType string
 
 const (
 	PolicyAutomationTypeSoftware          PolicyAutomationType = "software"
+	PolicyAutomationTypePatch             PolicyAutomationType = "patch"
 	PolicyAutomationTypeScripts           PolicyAutomationType = "scripts"
 	PolicyAutomationTypeCalendar          PolicyAutomationType = "calendar"
 	PolicyAutomationTypeConditionalAccess PolicyAutomationType = "conditional_access"

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -1488,6 +1488,18 @@ func (s *integrationEnterpriseTestSuite) TestListTeamPoliciesAutomationTypeSoftw
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/fleets/%d/policies", team.ID), nil, http.StatusOK, &listResp, "merge_inherited", "true", "automation_type", "software")
 	require.Len(t, listResp.Policies, 1)
 	assert.Equal(t, installPolicy.Policy.ID, listResp.Policies[0].ID)
+
+	// List with automation_type=patch - should return only the patch policy
+	listResp = fleet.ListTeamPoliciesResponse{}
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/fleets/%d/policies", team.ID), nil, http.StatusOK, &listResp, "automation_type", "patch")
+	require.Len(t, listResp.Policies, 1)
+	assert.Equal(t, patchPolicy.Policy.ID, listResp.Policies[0].ID)
+
+	// List with merge_inherited and automation_type=patch
+	listResp = fleet.ListTeamPoliciesResponse{}
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/fleets/%d/policies", team.ID), nil, http.StatusOK, &listResp, "merge_inherited", "true", "automation_type", "patch")
+	require.Len(t, listResp.Policies, 1)
+	assert.Equal(t, patchPolicy.Policy.ID, listResp.Policies[0].ID)
 }
 
 func (s *integrationEnterpriseTestSuite) TestNoTeamPolicies() {

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -1477,21 +1477,17 @@ func (s *integrationEnterpriseTestSuite) TestListTeamPoliciesAutomationTypeSoftw
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/fleets/%d/policies", team.ID), nil, http.StatusOK, &listResp)
 	require.Len(t, listResp.Policies, 3)
 
-	// List with automation_type=software - should return install policy and patch policy only
+	// List with automation_type=software - should return only the install policy, not the patch policy
 	listResp = fleet.ListTeamPoliciesResponse{}
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/fleets/%d/policies", team.ID), nil, http.StatusOK, &listResp, "automation_type", "software")
-	require.Len(t, listResp.Policies, 2)
-	policyIDs := []uint{listResp.Policies[0].ID, listResp.Policies[1].ID}
-	assert.Contains(t, policyIDs, installPolicy.Policy.ID)
-	assert.Contains(t, policyIDs, patchPolicy.Policy.ID)
+	require.Len(t, listResp.Policies, 1)
+	assert.Equal(t, installPolicy.Policy.ID, listResp.Policies[0].ID)
 
 	// List with merge_inherited and automation_type=software
 	listResp = fleet.ListTeamPoliciesResponse{}
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/fleets/%d/policies", team.ID), nil, http.StatusOK, &listResp, "merge_inherited", "true", "automation_type", "software")
-	require.Len(t, listResp.Policies, 2)
-	policyIDs = []uint{listResp.Policies[0].ID, listResp.Policies[1].ID}
-	assert.Contains(t, policyIDs, installPolicy.Policy.ID)
-	assert.Contains(t, policyIDs, patchPolicy.Policy.ID)
+	require.Len(t, listResp.Policies, 1)
+	assert.Equal(t, installPolicy.Policy.ID, listResp.Policies[0].ID)
 }
 
 func (s *integrationEnterpriseTestSuite) TestNoTeamPolicies() {


### PR DESCRIPTION
**Related issue:** Resolves #44625

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually

## Changes

1. **Remove patch policies from "Software" filter** - Removed `OR p.type = 'patch'` from the SQL clause in `createAutomationClause` so the "Software" filter only matches policies with `software_installer_id` or `vpp_apps_teams_id`.

2. **Add dedicated "Patch" filter** - Added a new `PolicyAutomationTypePatch` (`automation_type=patch`) that matches `p.type = 'patch'`. Added the corresponding "Patch" option to the frontend dropdown with help text: "Patch policies for Fleet-maintained apps."

## Reproduction

Reproduced locally with a running Fleet server against a dev MySQL database.

**Setup:**
1. Created a team with two policies:
   - A regular policy (type=dynamic, no automation)
   - A patch policy (type=patch, with `patch_software_title_id` set)
2. Queried `GET /api/latest/fleet/fleets/{id}/policies?automation_type=software`

**Observed (bug):**
The patch policy was returned in the results. The SQL clause in `createAutomationClause` for `automation_type=software` was:
```sql
AND (p.software_installer_id IS NOT NULL OR p.vpp_apps_teams_id IS NOT NULL OR p.type = 'patch')
```
The `OR p.type = 'patch'` caused all patch policies to match the "Software" filter.

**Confirmed at the SQL level:**
```
-- Buggy filter returns the patch policy
SELECT id, name, type FROM policies p WHERE team_id=3
  AND (p.software_installer_id IS NOT NULL OR p.vpp_apps_teams_id IS NOT NULL OR p.type = 'patch');
-- Result: "Patch Policy - TestPatchApp" (incorrectly included)

-- Fixed filter correctly returns nothing (no software-install policies exist)
SELECT id, name, type FROM policies p WHERE team_id=3
  AND (p.software_installer_id IS NOT NULL OR p.vpp_apps_teams_id IS NOT NULL);
-- Result: empty (correct)
```

## Manual QA screenshots

**Dropdown with new "Patch" filter option (between Software and Scripts):**

<img width="1486" height="486" alt="All automations dropdown showing new Patch filter option" src="https://github.com/user-attachments/assets/07481ee1-770d-40f2-8005-4194dd38829f" />

**"Software" filter - shows only the software install policy (no patch policies):**

<img width="1483" height="282" alt="Software filter showing only SW Install - Chrome" src="https://github.com/user-attachments/assets/2dc2d5bd-d777-4eb5-a902-688a5888a4b3" />

**"Patch" filter - shows only patch policies:**

<img width="1483" height="350" alt="Patch filter showing Chrome Update and Slack Update patch policies" src="https://github.com/user-attachments/assets/ebe44acb-d9bb-4576-974a-f725bf6aec8f" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated **Patch** automation filter for Fleet-maintained app policies.
  * Software policy filtering now excludes patch policies, which can be viewed separately.
  * Patch filtering works consistently for team policies, including inherited policies.

* **Bug Fixes**
  * Corrected policy automation filtering and counts to distinguish software installation policies from patch policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->