### PR TITLE
Add server and agent compatibility policy to handbook

### DIFF
--- a/handbook/company/product-groups.md
+++ b/handbook/company/product-groups.md
@@ -413,11 +413,11 @@ All of the steps above happen prior to any breaking changes to stable features b
 
 ### Server and agent compatibility
 
-When a feature requires changes to both the Fleet server and the agent (fleetd), updating one component without the other must not break anything. The feature will not be available until both are updated, but hosts that have not yet upgraded continue to work as before.
+When a feature requires changes to both the Fleet server and the agent (fleetd), a version mismatch between the two must never break existing functionality. Because the server and agent are released independently, there will always be a window where one side is updated and the other is not. During that window the new feature simply will not work on hosts that are missing the update, but nothing that previously worked should break.
 
-This covers the current release and the one before it (for example, server version S with agent version A-1, or agent version A with server version S-1). For long-term compatibility rules, see the [Fleetd development and release strategy](https://fleetdm.com/docs/contributing/workflows/fleetd-development-and-release-strategy).
+This is not a long-term support guarantee. It applies to the immediate transition between consecutive releases (for example, server S with agent A-1, or agent A with server S-1). For long-term compatibility rules, see the [Fleetd development and release strategy](https://fleetdm.com/docs/contributing/workflows/fleetd-development-and-release-strategy).
 
-Server release notes must document when a feature requires a minimum agent version.
+Server release notes must call out when a feature requires a minimum agent version.
 
 
 #### API changes

--- a/handbook/company/product-groups.md
+++ b/handbook/company/product-groups.md
@@ -411,15 +411,6 @@ For product changes that cause breaking API or configuration changes or major im
 All of the steps above happen prior to any breaking changes to stable features being prioritized for implementation.
 
 
-### Server and agent compatibility
-
-When a feature requires changes to both the Fleet server and the agent (fleetd), a version mismatch between the two must never break existing functionality. Because the server and agent are released independently, there will always be a window where one side is updated and the other is not. During that window the new feature simply will not work on hosts that are missing the update, but nothing that previously worked should break.
-
-This is not a long-term support guarantee. It applies to the immediate transition between consecutive releases (for example, server S with agent A-1, or agent A with server S-1). For long-term compatibility rules, see the [Fleetd development and release strategy](https://fleetdm.com/docs/contributing/workflows/fleetd-development-and-release-strategy).
-
-Server release notes must call out when a feature requires a minimum agent version.
-
-
 #### API changes
 
 To maintain consistency, ensure perspective, and provide a single pair of eyes in the design of Fleet's REST API and API documentation, there is a single Directly Responsible Individual (DRI). The API design DRI will review and approve any alterations at the pull request stage, instead of making it a prerequisite during drafting of the story. You may tag the DRI in a GitHub issue with draft API specs in place to receive a review and feedback prior to implementation. Receiving a pre-review from the DRI is encouraged if the API changes introduce new endpoints, or substantially change existing endpoints.

--- a/handbook/company/product-groups.md
+++ b/handbook/company/product-groups.md
@@ -418,9 +418,9 @@ Features that require changes to both the Fleet server and the agent (fleetd) mu
 - **New server, old agent:** A feature introduced in Fleet server version X that relies on agent version Y must work for hosts running agent version Y or later. Hosts still on older agents will not have the feature, but nothing will break.
 - **Old server, new agent:** A host that upgrades to agent version Y while still connected to server version X-1 must not break. The new feature simply will not work until the server is also upgraded.
 
-Release notes for Fleet server version X must document when a feature requires a minimum agent version Y.
+This applies to the current release and the one immediately before it (e.g., server version X with agent version X or X-1). For long-term version compatibility rules, see the [Fleetd development and release strategy](https://fleetdm.com/docs/contributing/workflows/fleetd-development-and-release-strategy).
 
-See also: [Fleetd development and release strategy](https://fleetdm.com/docs/contributing/workflows/fleetd-development-and-release-strategy) for the agent release sequencing process.
+Release notes for Fleet server version X must document when a feature requires a minimum agent version Y.
 
 
 #### API changes

--- a/handbook/company/product-groups.md
+++ b/handbook/company/product-groups.md
@@ -411,6 +411,18 @@ For product changes that cause breaking API or configuration changes or major im
 All of the steps above happen prior to any breaking changes to stable features being prioritized for implementation.
 
 
+### Server and agent compatibility
+
+Features that require changes to both the Fleet server and the agent (fleetd) must be backward compatible in both directions:
+
+- **New server, old agent:** A feature introduced in Fleet server version X that relies on agent version Y must work for hosts running agent version Y or later and gracefully degrade for hosts on older agents. The feature will not be available on those hosts, but nothing will break.
+- **Old server, new agent:** A host that upgrades to agent version Y while still connected to server version X-1 must not break. The new feature simply will not work until the server is also upgraded.
+
+Release notes for Fleet server version X must document when a feature requires a minimum agent version Y.
+
+See also: [Fleetd development and release strategy](https://fleetdm.com/docs/contributing/workflows/fleetd-development-and-release-strategy) for the agent release sequencing process.
+
+
 #### API changes
 
 To maintain consistency, ensure perspective, and provide a single pair of eyes in the design of Fleet's REST API and API documentation, there is a single Directly Responsible Individual (DRI). The API design DRI will review and approve any alterations at the pull request stage, instead of making it a prerequisite during drafting of the story. You may tag the DRI in a GitHub issue with draft API specs in place to receive a review and feedback prior to implementation. Receiving a pre-review from the DRI is encouraged if the API changes introduce new endpoints, or substantially change existing endpoints.

--- a/handbook/company/product-groups.md
+++ b/handbook/company/product-groups.md
@@ -415,7 +415,7 @@ All of the steps above happen prior to any breaking changes to stable features b
 
 Features that require changes to both the Fleet server and the agent (fleetd) must be backward compatible in both directions:
 
-- **New server, old agent:** A feature introduced in Fleet server version X that relies on agent version Y must work for hosts running agent version Y or later and gracefully degrade for hosts on older agents. The feature will not be available on those hosts, but nothing will break.
+- **New server, old agent:** A feature introduced in Fleet server version X that relies on agent version Y must work for hosts running agent version Y or later. Hosts still on older agents will not have the feature, but nothing will break.
 - **Old server, new agent:** A host that upgrades to agent version Y while still connected to server version X-1 must not break. The new feature simply will not work until the server is also upgraded.
 
 Release notes for Fleet server version X must document when a feature requires a minimum agent version Y.

--- a/handbook/company/product-groups.md
+++ b/handbook/company/product-groups.md
@@ -413,14 +413,11 @@ All of the steps above happen prior to any breaking changes to stable features b
 
 ### Server and agent compatibility
 
-Features that require changes to both the Fleet server and the agent (fleetd) must be backward compatible in both directions:
+When a feature requires changes to both the Fleet server and the agent (fleetd), updating one component without the other must not break anything. The feature will not be available until both are updated, but hosts that have not yet upgraded continue to work as before.
 
-- **New server, old agent:** A feature introduced in Fleet server version X that relies on agent version Y must work for hosts running agent version Y or later. Hosts still on older agents will not have the feature, but nothing will break.
-- **Old server, new agent:** A host that upgrades to agent version Y while still connected to server version X-1 must not break. The new feature simply will not work until the server is also upgraded.
+This covers the current release and the one before it (for example, server version S with agent version A-1, or agent version A with server version S-1). For long-term compatibility rules, see the [Fleetd development and release strategy](https://fleetdm.com/docs/contributing/workflows/fleetd-development-and-release-strategy).
 
-This applies to the current release and the one immediately before it (e.g., server version X with agent version X or X-1). For long-term version compatibility rules, see the [Fleetd development and release strategy](https://fleetdm.com/docs/contributing/workflows/fleetd-development-and-release-strategy).
-
-Release notes for Fleet server version X must document when a feature requires a minimum agent version Y.
+Server release notes must document when a feature requires a minimum agent version.
 
 
 #### API changes

--- a/handbook/engineering/releases.md
+++ b/handbook/engineering/releases.md
@@ -231,7 +231,7 @@ When a feature requires changes to both the server and the agent, a version mism
 
 ### Test compatibility with the previous release
 
-We test and QA compatibility within one version of the counterpart. When a server release S includes a feature that depends on agent version A, we verify that server S does not break agents on version A-1. When an agent release A includes a feature that depends on server version S, we verify that agent A does not break when connected to server S-1.
+We test and QA each release against the previous version of its counterpart. When a new server version depends on a new agent feature, we verify that agents one version behind keep working. When a new agent version depends on a new server feature, we verify that the agent keeps working against a server one version behind.
 
 For long-term compatibility rules, see the [Fleetd development and release strategy](https://fleetdm.com/docs/contributing/workflows/fleetd-development-and-release-strategy). Server release notes must call out when a feature requires a minimum agent version.
 

--- a/handbook/engineering/releases.md
+++ b/handbook/engineering/releases.md
@@ -217,5 +217,24 @@ In these cases there are two differences in our pull request process:
 - Tickets are not moved to "Ready for release". Bugs are closed, and user stories are moved to the product drafting board's "Confirm and celebrate" column.
 
 
+## Server and agent compatibility
+
+The Fleet server and the agent (fleetd) are released independently. Because of this, there will always be hosts running a different version of the agent than the server expects, whether because the server was just upgraded, because the agent was auto-updated first, or because some hosts have not yet received the agent update.
+
+### Keep agents up to date
+
+Running old agents is discouraged. Customers should keep agents on the latest version. If immediate updates are not possible, establish a regular upgrade cadence rather than letting agents fall behind indefinitely.
+
+### Do not break across version boundaries
+
+When a feature requires changes to both the server and the agent, a version mismatch must not break existing functionality. The new feature will not work until both sides are updated, but nothing that previously worked should stop working. This applies in both directions: a newer server with an older agent, and a newer agent with an older server.
+
+### Test compatibility with the previous release
+
+We test and QA compatibility within one version of the counterpart. When a server release S includes a feature that depends on agent version A, we verify that server S does not break agents on version A-1. When an agent release A includes a feature that depends on server version S, we verify that agent A does not break when connected to server S-1.
+
+For long-term compatibility rules, see the [Fleetd development and release strategy](https://fleetdm.com/docs/contributing/workflows/fleetd-development-and-release-strategy). Server release notes must call out when a feature requires a minimum agent version.
+
+
 <meta name="maintainedBy" value="lukeheath">
 <meta name="description" value="Fleet's release process, including QA, release candidates, agent releases, and post-release tasks.">


### PR DESCRIPTION
Adds a "Server and agent compatibility" section to the product groups handbook page. This section documents the policy that features spanning both server and agent must be backward compatible in both directions: upgrading one side without the other should never break anything, the new feature just won't be available until both sides are updated.

**Related issue:** Closes https://github.com/fleetdm/fleet/issues/49288

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- ~Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.~ N/A (handbook/process change)

## Testing

- ~Added/updated automated tests~ N/A
- ~QA'd all new/changed functionality manually~ N/A (handbook content only)