### PR TITLE
Add Fleet Desktop device SSO endpoints and session plumbing

### DIFF
--- a/ee/server/service/devices.go
+++ b/ee/server/service/devices.go
@@ -3,9 +3,12 @@ package service
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
+	"net/url"
+	"strings"
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server"
@@ -13,6 +16,7 @@ import (
 	hostctx "github.com/fleetdm/fleet/v4/server/contexts/host"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/ptr"
+	"github.com/fleetdm/fleet/v4/server/sso"
 )
 
 func (svc *Service) ListDevicePolicies(ctx context.Context, host *fleet.Host) ([]*fleet.DevicePolicy, error) {
@@ -352,5 +356,115 @@ func (svc *Service) getHostSetupExperienceStatus(ctx context.Context, host *flee
 	return &fleet.DeviceSetupExperienceStatusPayload{
 		Software: software,
 		Scripts:  scripts,
+	}, nil
+}
+
+/////////////////////////////////////////////////////////////////////////////////
+// My Device SSO Flow
+/////////////////////////////////////////////////////////////////////////////////
+
+const deviceSSOSessionKeyPrefix = "device_sso_session:"
+const deviceSSOSessionIDLength = 24
+
+// createDeviceSSOSession mints a new device SSO session for host.
+func (svc *Service) createDeviceSSOSession(ctx context.Context, host *fleet.Host, idpAccountUUID string) (sessionID string, ttl time.Duration, err error) {
+	sessionID, err = server.GenerateRandomURLSafeText(deviceSSOSessionIDLength)
+	if err != nil {
+		return "", 0, ctxerr.Wrap(ctx, err, "generate device sso session id")
+	}
+
+	ttl = svc.config.Session.Duration
+	session := fleet.DeviceSSOSession{
+		HostID:         host.ID,
+		IdPAccountUUID: idpAccountUUID,
+		ExpiresAt:      svc.clock.Now().Add(ttl),
+	}
+	b, err := json.Marshal(session)
+	if err != nil {
+		return "", 0, ctxerr.Wrap(ctx, err, "marshal device sso session")
+	}
+
+	if err := svc.keyValueStore.Set(ctx, deviceSSOSessionKeyPrefix+sessionID, string(b), ttl); err != nil {
+		return "", 0, ctxerr.Wrap(ctx, err, "store device sso session")
+	}
+
+	return sessionID, ttl, nil
+}
+
+
+func (svc *Service) InitiateDeviceSSO(ctx context.Context, deviceURL string) (*fleet.DeviceSSOInitiation, error) {
+	// the device middleware already authenticated the host via its device token.
+	svc.authz.SkipAuthorization(ctx)
+
+	host, ok := hostctx.FromContext(ctx)
+	if !ok {
+		return nil, ctxerr.Wrap(ctx, fleet.NewAuthRequiredError("internal error: missing host from request context"))
+	}
+
+	appConfig, err := svc.ds.AppConfig(ctx)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "getting app config")
+	}
+
+	if !appConfig.FleetDesktop.SSOEnabled {
+		err := &fleet.BadRequestError{Message: "Single sign-on for Fleet Desktop is not enabled."}
+		return nil, ctxerr.Wrap(ctx, err, "initiate device sso")
+	}
+
+	mdmSSOSettings := appConfig.MDM.EndUserAuthentication.SSOProviderSettings
+	if mdmSSOSettings.IsEmpty() {
+		err := &fleet.BadRequestError{Message: "Couldn't initiate single sign-on for Fleet Desktop because no IdP is configured for end user authentication."}
+		return nil, ctxerr.Wrap(ctx, err, "initiate device sso")
+	}
+
+	// The ACS base must match what the IdP app has registered,
+	// will be ServerURL if none currently set.
+	acsBase, err := url.Parse(appConfig.MDMUrl())
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "invalid MDM URL")
+	}
+
+	browserBase, err := appConfig.FleetDesktopBrowserUrl()
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "invalid server URL")
+	}
+
+	// SSO cookies are __Host- prefixed, so each is pinned to one host name.
+	// The handshake cookie is set on the browser's host but read on the ACS, and
+	// the session cookie the other way around: if those hosts differ, neither
+	// arrives and the end user loops.
+	if !strings.EqualFold(browserBase.Hostname(), acsBase.Hostname()) {
+		err := &fleet.BadRequestError{
+			Message: "Fleet Desktop single sign-on requires the device page and the SAML callback on the same host.",
+		}
+		return nil, ctxerr.Wrap(ctx, err, "initiate device sso")
+	}
+
+	acsURL := sso.CallbackURL(acsBase, svc.config.Server.URLPrefix, "/api/v1/fleet/mdm/sso/callback").String()
+
+	samlProvider, err := sso.SAMLProviderFromConfiguredMetadata(ctx, mdmSSOSettings.EntityID, acsURL, &mdmSSOSettings)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "failed to create provider from metadata")
+	}
+
+	sessionDuration := svc.config.Auth.SsoSessionValidityPeriod
+	sessionID, idpURL, err := sso.CreateAuthorizationRequest(ctx,
+		samlProvider,
+		svc.ssoSessionStore,
+		browserBase.JoinPath(deviceURL).String(),
+		uint(sessionDuration.Seconds()), //nolint:gosec // dismiss G115
+		sso.SSORequestData{
+			HostUUID:  host.UUID,
+			Initiator: fleet.SSOInitiatorFleetDesktop,
+		},
+	)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "InitiateDeviceSSO creating authorization")
+	}
+
+	return &fleet.DeviceSSOInitiation{
+		IdPURL:          idpURL,
+		SessionID:       sessionID,
+		SessionDuration: sessionDuration,
 	}, nil
 }

--- a/ee/server/service/devices.go
+++ b/ee/server/service/devices.go
@@ -391,7 +391,6 @@ func (svc *Service) createDeviceSSOSession(ctx context.Context, host *fleet.Host
 	return sessionID, ttl, nil
 }
 
-
 func (svc *Service) InitiateDeviceSSO(ctx context.Context, deviceURL string) (*fleet.DeviceSSOInitiation, error) {
 	// the device middleware already authenticated the host via its device token.
 	svc.authz.SkipAuthorization(ctx)

--- a/ee/server/service/devices.go
+++ b/ee/server/service/devices.go
@@ -450,7 +450,7 @@ func (svc *Service) InitiateDeviceSSO(ctx context.Context, deviceURL string) (*f
 	sessionID, idpURL, err := sso.CreateAuthorizationRequest(ctx,
 		samlProvider,
 		svc.ssoSessionStore,
-		browserBase.JoinPath(deviceURL).String(),
+		sso.URLWithPrefix(browserBase, svc.config.Server.URLPrefix, deviceURL).String(),
 		uint(sessionDuration.Seconds()), //nolint:gosec // dismiss G115
 		sso.SSORequestData{
 			HostUUID:  host.UUID,

--- a/ee/server/service/devices_test.go
+++ b/ee/server/service/devices_test.go
@@ -1,0 +1,178 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/WatchBeam/clock"
+	"github.com/fleetdm/fleet/v4/server/config"
+	hostctx "github.com/fleetdm/fleet/v4/server/contexts/host"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func newDeviceSSOTestService(t *testing.T, ds fleet.Datastore, sessionDuration time.Duration) (*Service, func(key string) *string, *clock.MockClock) {
+	t.Helper()
+	svc := newTestService(t, ds)
+	mockClock := clock.NewMockClock()
+	kvs, getKey := inMemoryKeyValueStore()
+	svc.clock = mockClock
+	svc.config = config.FleetConfig{Session: config.SessionConfig{Duration: sessionDuration}}
+	svc.keyValueStore = kvs
+	return svc, getKey, mockClock
+}
+
+func TestCreateDeviceSSOSession(t *testing.T) {
+	svc, getKey, mockClock := newDeviceSSOTestService(t, new(mock.Store), time.Hour)
+
+	ctx := t.Context()
+	host := &fleet.Host{ID: 42, UUID: "host-uuid-1"}
+
+	sessionID, ttl, err := svc.createDeviceSSOSession(ctx, host, "idp-acct-uuid")
+	require.NoError(t, err)
+	require.NotEmpty(t, sessionID)
+	require.Equal(t, time.Hour, ttl)
+
+	// Stored under the namespaced key, so it cannot collide with the other users
+	// of the shared key/value store. Read back through the store rather than a
+	// service method: the gate that consumes these sessions arrives with the
+	// enforcement sub-issue.
+	stored := getKey(deviceSSOSessionKeyPrefix + sessionID)
+	require.NotNil(t, stored)
+
+	var session fleet.DeviceSSOSession
+	require.NoError(t, json.Unmarshal([]byte(*stored), &session))
+	require.Equal(t, host.ID, session.HostID)
+	require.Equal(t, "idp-acct-uuid", session.IdPAccountUUID)
+	require.Equal(t, mockClock.Now().Add(time.Hour), session.ExpiresAt.UTC())
+}
+
+func TestInitiateDeviceSSOGuards(t *testing.T) {
+	host := &fleet.Host{ID: 1, UUID: "host-uuid-1"}
+
+	ssoSettings := fleet.SSOProviderSettings{
+		EntityID:    "mdm.test.com",
+		IDPName:     "SimpleSAML",
+		MetadataURL: "https://idp.example.com/metadata",
+	}
+
+	cases := []struct {
+		name      string
+		appConfig func() fleet.AppConfig
+		wantErr   string
+	}{
+		{
+			name:      "sso disabled",
+			appConfig: func() fleet.AppConfig { return fleet.AppConfig{} },
+			wantErr:   "is not enabled",
+		},
+		{
+			name: "sso enabled but no IdP configured",
+			appConfig: func() fleet.AppConfig {
+				var ac fleet.AppConfig
+				ac.FleetDesktop.SSOEnabled = true
+				return ac
+			},
+			wantErr: "no IdP is configured",
+		},
+		{
+			name: "alternative browser host differs from the ACS host",
+			appConfig: func() fleet.AppConfig {
+				var ac fleet.AppConfig
+				ac.FleetDesktop.SSOEnabled = true
+				ac.FleetDesktop.AlternativeBrowserHost = "proxy.example.com"
+				ac.ServerSettings.ServerURL = "https://fleet.example.com"
+				ac.MDM.EndUserAuthentication.SSOProviderSettings = ssoSettings
+				return ac
+			},
+			wantErr: "same host",
+		},
+		{
+			name: "custom Apple MDM URL differs from the server URL",
+			appConfig: func() fleet.AppConfig {
+				var ac fleet.AppConfig
+				ac.FleetDesktop.SSOEnabled = true
+				ac.ServerSettings.ServerURL = "https://fleet.example.com"
+				ac.MDM.AppleServerURL = "https://mdm.example.com"
+				ac.MDM.EndUserAuthentication.SSOProviderSettings = ssoSettings
+				return ac
+			},
+			wantErr: "same host",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ds := new(mock.Store)
+			ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+				ac := c.appConfig()
+				return &ac, nil
+			}
+
+			svc, _, _ := newDeviceSSOTestService(t, ds, time.Hour)
+
+			ctx := hostctx.NewContext(t.Context(), host)
+			_, err := svc.InitiateDeviceSSO(ctx, "/device/some-token")
+			require.Error(t, err)
+			require.Contains(t, err.Error(), c.wantErr)
+
+			var badReq *fleet.BadRequestError
+			require.ErrorAs(t, err, &badReq)
+		})
+	}
+}
+
+func TestInitiateDeviceSSOAllowsMatchingHosts(t *testing.T) {
+	idpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(idpSrv.Close)
+
+	for _, c := range []struct {
+		name                   string
+		alternativeBrowserHost string
+		appleServerURL         string
+	}{
+		{name: "no alternative browser host"},
+		{name: "alternative browser host equals the server host", alternativeBrowserHost: "fleet.example.com"},
+		{name: "alternative browser host differs only by port", alternativeBrowserHost: "fleet.example.com:8443"},
+		{name: "apple server url equals the server url", appleServerURL: "https://fleet.example.com"},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			ds := new(mock.Store)
+			ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+				var ac fleet.AppConfig
+				ac.FleetDesktop.SSOEnabled = true
+				ac.FleetDesktop.AlternativeBrowserHost = c.alternativeBrowserHost
+				ac.ServerSettings.ServerURL = "https://fleet.example.com"
+				ac.MDM.AppleServerURL = c.appleServerURL
+				ac.MDM.EndUserAuthentication.SSOProviderSettings = fleet.SSOProviderSettings{
+					EntityID:    "mdm.test.com",
+					IDPName:     "SimpleSAML",
+					MetadataURL: idpSrv.URL,
+				}
+				return &ac, nil
+			}
+
+			svc, _, _ := newDeviceSSOTestService(t, ds, time.Hour)
+
+			ctx := hostctx.NewContext(t.Context(), &fleet.Host{ID: 1, UUID: "host-uuid-1"})
+			_, err := svc.InitiateDeviceSSO(ctx, "/device/some-token")
+
+			require.Error(t, err)
+			require.ErrorContains(t, err, "metadata")
+		})
+	}
+}
+
+func TestInitiateDeviceSSOMissingHostInContext(t *testing.T) {
+	svc, _, _ := newDeviceSSOTestService(t, new(mock.Store), time.Hour)
+
+	_, err := svc.InitiateDeviceSSO(t.Context(), "/device/some-token")
+	require.Error(t, err)
+}

--- a/ee/server/service/devices_test.go
+++ b/ee/server/service/devices_test.go
@@ -53,56 +53,108 @@ func TestCreateDeviceSSOSession(t *testing.T) {
 }
 
 func TestInitiateDeviceSSOGuards(t *testing.T) {
-	host := &fleet.Host{ID: 1, UUID: "host-uuid-1"}
+	idpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(idpSrv.Close)
 
-	ssoSettings := fleet.SSOProviderSettings{
-		EntityID:    "mdm.test.com",
-		IDPName:     "SimpleSAML",
-		MetadataURL: "https://idp.example.com/metadata",
+	idp := func(ac *fleet.AppConfig) {
+		ac.MDM.EndUserAuthentication.SSOProviderSettings = fleet.SSOProviderSettings{
+			EntityID:    "mdm.test.com",
+			IDPName:     "SimpleSAML",
+			MetadataURL: idpSrv.URL,
+		}
 	}
 
 	cases := []struct {
 		name      string
-		appConfig func() fleet.AppConfig
 		wantErr   string
+		appConfig func() fleet.AppConfig
 	}{
 		{
 			name:      "sso disabled",
-			appConfig: func() fleet.AppConfig { return fleet.AppConfig{} },
 			wantErr:   "is not enabled",
+			appConfig: func() fleet.AppConfig { return fleet.AppConfig{} },
 		},
 		{
-			name: "sso enabled but no IdP configured",
+			name:    "sso enabled but no IdP configured",
+			wantErr: "no IdP is configured",
 			appConfig: func() fleet.AppConfig {
 				var ac fleet.AppConfig
 				ac.FleetDesktop.SSOEnabled = true
 				return ac
 			},
-			wantErr: "no IdP is configured",
 		},
 		{
-			name: "alternative browser host differs from the ACS host",
+			name:    "alternative browser host differs from the ACS host",
+			wantErr: "same host",
 			appConfig: func() fleet.AppConfig {
 				var ac fleet.AppConfig
 				ac.FleetDesktop.SSOEnabled = true
 				ac.FleetDesktop.AlternativeBrowserHost = "proxy.example.com"
 				ac.ServerSettings.ServerURL = "https://fleet.example.com"
-				ac.MDM.EndUserAuthentication.SSOProviderSettings = ssoSettings
+				idp(&ac)
 				return ac
 			},
-			wantErr: "same host",
 		},
 		{
-			name: "custom Apple MDM URL differs from the server URL",
+			name:    "custom Apple MDM URL differs from the server URL",
+			wantErr: "same host",
 			appConfig: func() fleet.AppConfig {
 				var ac fleet.AppConfig
 				ac.FleetDesktop.SSOEnabled = true
 				ac.ServerSettings.ServerURL = "https://fleet.example.com"
 				ac.MDM.AppleServerURL = "https://mdm.example.com"
-				ac.MDM.EndUserAuthentication.SSOProviderSettings = ssoSettings
+				idp(&ac)
 				return ac
 			},
-			wantErr: "same host",
+		},
+		{
+			name:    "no alternative browser host",
+			wantErr: "metadata",
+			appConfig: func() fleet.AppConfig {
+				var ac fleet.AppConfig
+				ac.FleetDesktop.SSOEnabled = true
+				ac.ServerSettings.ServerURL = "https://fleet.example.com"
+				idp(&ac)
+				return ac
+			},
+		},
+		{
+			name:    "alternative browser host equals the server host",
+			wantErr: "metadata",
+			appConfig: func() fleet.AppConfig {
+				var ac fleet.AppConfig
+				ac.FleetDesktop.SSOEnabled = true
+				ac.FleetDesktop.AlternativeBrowserHost = "fleet.example.com"
+				ac.ServerSettings.ServerURL = "https://fleet.example.com"
+				idp(&ac)
+				return ac
+			},
+		},
+		{
+			name:    "alternative browser host differs only by port",
+			wantErr: "metadata",
+			appConfig: func() fleet.AppConfig {
+				var ac fleet.AppConfig
+				ac.FleetDesktop.SSOEnabled = true
+				ac.FleetDesktop.AlternativeBrowserHost = "fleet.example.com:8443"
+				ac.ServerSettings.ServerURL = "https://fleet.example.com"
+				idp(&ac)
+				return ac
+			},
+		},
+		{
+			name:    "apple server url equals the server url",
+			wantErr: "metadata",
+			appConfig: func() fleet.AppConfig {
+				var ac fleet.AppConfig
+				ac.FleetDesktop.SSOEnabled = true
+				ac.ServerSettings.ServerURL = "https://fleet.example.com"
+				ac.MDM.AppleServerURL = "https://fleet.example.com"
+				idp(&ac)
+				return ac
+			},
 		},
 	}
 
@@ -116,56 +168,16 @@ func TestInitiateDeviceSSOGuards(t *testing.T) {
 
 			svc, _, _ := newDeviceSSOTestService(t, ds, time.Hour)
 
-			ctx := hostctx.NewContext(t.Context(), host)
-			_, err := svc.InitiateDeviceSSO(ctx, "/device/some-token")
-			require.Error(t, err)
-			require.Contains(t, err.Error(), c.wantErr)
-
-			var badReq *fleet.BadRequestError
-			require.ErrorAs(t, err, &badReq)
-		})
-	}
-}
-
-func TestInitiateDeviceSSOAllowsMatchingHosts(t *testing.T) {
-	idpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-	}))
-	t.Cleanup(idpSrv.Close)
-
-	for _, c := range []struct {
-		name                   string
-		alternativeBrowserHost string
-		appleServerURL         string
-	}{
-		{name: "no alternative browser host"},
-		{name: "alternative browser host equals the server host", alternativeBrowserHost: "fleet.example.com"},
-		{name: "alternative browser host differs only by port", alternativeBrowserHost: "fleet.example.com:8443"},
-		{name: "apple server url equals the server url", appleServerURL: "https://fleet.example.com"},
-	} {
-		t.Run(c.name, func(t *testing.T) {
-			ds := new(mock.Store)
-			ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
-				var ac fleet.AppConfig
-				ac.FleetDesktop.SSOEnabled = true
-				ac.FleetDesktop.AlternativeBrowserHost = c.alternativeBrowserHost
-				ac.ServerSettings.ServerURL = "https://fleet.example.com"
-				ac.MDM.AppleServerURL = c.appleServerURL
-				ac.MDM.EndUserAuthentication.SSOProviderSettings = fleet.SSOProviderSettings{
-					EntityID:    "mdm.test.com",
-					IDPName:     "SimpleSAML",
-					MetadataURL: idpSrv.URL,
-				}
-				return &ac, nil
-			}
-
-			svc, _, _ := newDeviceSSOTestService(t, ds, time.Hour)
-
 			ctx := hostctx.NewContext(t.Context(), &fleet.Host{ID: 1, UUID: "host-uuid-1"})
 			_, err := svc.InitiateDeviceSSO(ctx, "/device/some-token")
-
 			require.Error(t, err)
-			require.ErrorContains(t, err, "metadata")
+			require.ErrorContains(t, err, c.wantErr)
+
+			// Guard refusals are client errors; reaching the metadata fetch is not.
+			var badReq *fleet.BadRequestError
+			if c.wantErr != "metadata" {
+				require.ErrorAs(t, err, &badReq)
+			}
 		})
 	}
 }

--- a/ee/server/service/mdm.go
+++ b/ee/server/service/mdm.go
@@ -849,6 +849,14 @@ func (svc *Service) InitiateMDMSSO(ctx context.Context, initiator, customOrigina
 
 	logging.WithLevel(logging.WithNoUser(ctx), slog.LevelInfo)
 
+	// SSOInitiatorFleetDesktop is only ever legitimately set
+	// server-side by InitiateDeviceSSO, after the device token has been
+	// verified.
+	if initiator == fleet.SSOInitiatorFleetDesktop {
+		err := &fleet.BadRequestError{Message: "invalid initiator"}
+		return "", 0, "", ctxerr.Wrap(ctx, err, "initiate mdm sso")
+	}
+
 	appConfig, err := svc.ds.AppConfig(ctx)
 	if err != nil {
 		return "", 0, "", ctxerr.Wrap(ctx, err, "getting app config")
@@ -925,7 +933,20 @@ func (svc *Service) InitiateMDMSSO(ctx context.Context, initiator, customOrigina
 	return sessionID, sessionDurationSeconds, idpURL, nil
 }
 
-func (svc *Service) MDMSSOCallback(ctx context.Context, sessionID string, samlResponse []byte) (redirectURL, byodCookieValue string) {
+// deviceSSOErrorURL sends the end user back to the device page they came from,
+// flagging why sign-in did not produce a session.
+func deviceSSOErrorURL(originalURL, reason string) string {
+	u, err := url.Parse(originalURL)
+	if err != nil {
+		return apple_mdm.FleetUISSOCallbackError
+	}
+	q := u.Query()
+	q.Set("sso_error", reason)
+	u.RawQuery = q.Encode()
+	return u.String()
+}
+
+func (svc *Service) MDMSSOCallback(ctx context.Context, sessionID string, samlResponse []byte) (redirectURL, byodCookieValue, deviceSSOSessionID string, deviceSSOSessionDurationSeconds int) {
 	// skipauth: User context does not yet exist. Unauthenticated users may
 	// hit the MDM SSO callback.
 	svc.authz.SkipAuthorization(ctx)
@@ -936,12 +957,14 @@ func (svc *Service) MDMSSOCallback(ctx context.Context, sessionID string, samlRe
 	if err != nil {
 		logging.WithErr(ctx, err)
 		if errors.Is(err, sso.ErrSessionNotFound) {
-			return apple_mdm.FleetUISSOCallbackSessionExpired, ""
+			return apple_mdm.FleetUISSOCallbackSessionExpired, "", "", 0
 		}
-		return apple_mdm.FleetUISSOCallbackError, ""
+		return apple_mdm.FleetUISSOCallbackError, "", "", 0
 	}
 
-	if !strings.HasPrefix(originalURL, "/enroll?") && ssoRequestData.Initiator != fleet.SSOInitiatorOrbitSetupExperience {
+	if !strings.HasPrefix(originalURL, "/enroll?") &&
+		ssoRequestData.Initiator != fleet.SSOInitiatorOrbitSetupExperience &&
+		ssoRequestData.Initiator != fleet.SSOInitiatorFleetDesktop {
 		// for flows other than the /enroll BYOD, we have to ensure that Apple MDM
 		// is enabled (this was previously done in a middleware on the route, but
 		// we do it here now so the middleware is disabled for the BYOD flow, which
@@ -949,7 +972,7 @@ func (svc *Service) MDMSSOCallback(ctx context.Context, sessionID string, samlRe
 		// supports not just Apple MDM).
 		if err := svc.VerifyMDMAppleConfigured(ctx); err != nil {
 			logging.WithErr(ctx, err)
-			return apple_mdm.FleetUISSOCallbackError, ""
+			return apple_mdm.FleetUISSOCallbackError, "", "", 0
 		}
 	}
 
@@ -974,7 +997,7 @@ func (svc *Service) MDMSSOCallback(ctx context.Context, sessionID string, samlRe
 			token, err := svc.ds.GetABMTokenByUniqueToken(ctx, uniqueToken)
 			if err != nil {
 				logging.WithErr(ctx, ctxerr.Wrap(ctx, err, "get ABM token by unique token for account driven enrollment"))
-				return apple_mdm.FleetUISSOCallbackError, ""
+				return apple_mdm.FleetUISSOCallbackError, "", "", 0
 			}
 			abmTokenID = &token.ID
 		}
@@ -982,12 +1005,12 @@ func (svc *Service) MDMSSOCallback(ctx context.Context, sessionID string, samlRe
 		challenge, err := svc.ds.InsertADUEEnrollmentChallenge(ctx, abmTokenID, enrollmentRef, fleet.ADUEEnrollmentChallengeExpiration)
 		if err != nil {
 			logging.WithErr(ctx, ctxerr.Wrap(ctx, err, "insert ADUE enrollment challenge for account driven enrollment"))
-			return apple_mdm.FleetUISSOCallbackError, ""
+			return apple_mdm.FleetUISSOCallbackError, "", "", 0
 		}
 
 		// For account driven enrollment we have to use this special protocol URL scheme to pass the
 		// access token back to Apple which it will then use to request the enrollment profile.
-		return fmt.Sprintf("apple-remotemanagement-user-login://authentication-results?access-token=%s", challenge), ""
+		return fmt.Sprintf("apple-remotemanagement-user-login://authentication-results?access-token=%s", challenge), "", "", 0
 
 	case strings.HasPrefix(originalURL, "/enroll?"):
 		// redirect to the original URL with a cookie that identifies this device
@@ -996,7 +1019,7 @@ func (svc *Service) MDMSSOCallback(ctx context.Context, sessionID string, samlRe
 		u, err := url.Parse(originalURL)
 		if err != nil {
 			logging.WithErr(ctx, err)
-			return "/enroll?error=" + url.QueryEscape("An error occurred. : Failed to parse original URL."), ""
+			return "/enroll?error=" + url.QueryEscape("An error occurred. : Failed to parse original URL."), "", "", 0
 		}
 		// port over the query string values, which will copy over the enrollment
 		// secret
@@ -1004,10 +1027,37 @@ func (svc *Service) MDMSSOCallback(ctx context.Context, sessionID string, samlRe
 			q.Add(k, v[0])
 		}
 		u.RawQuery = q.Encode()
-		return u.String(), enrollmentRef
+		return u.String(), enrollmentRef, "", 0
+
+	case ssoRequestData.Initiator == fleet.SSOInitiatorFleetDesktop:
+		// Re-check the feature is still on: an admin may have disabled it between
+		// initiation and this callback, and a session minted now would outlive
+		// that change by its whole TTL.
+		appConfig, err := svc.ds.AppConfig(ctx)
+		if err != nil {
+			logging.WithErr(ctx, ctxerr.Wrap(ctx, err, "get app config for device sso callback"))
+			return deviceSSOErrorURL(originalURL, "server_error"), "", "", 0
+		}
+		if !appConfig.FleetDesktop.SSOEnabled {
+			logging.WithErr(ctx, ctxerr.Wrap(ctx, errors.New("fleet desktop sso is disabled"), "device sso callback"))
+			return deviceSSOErrorURL(originalURL, "sso_disabled"), "", "", 0
+		}
+
+		host, err := svc.ds.HostByUUID(ctx, ssoRequestData.HostUUID)
+		if err != nil {
+			logging.WithErr(ctx, ctxerr.Wrap(ctx, err, "get host for device sso callback"))
+			return deviceSSOErrorURL(originalURL, "server_error"), "", "", 0
+		}
+
+		deviceSSOSessionID, deviceSSOSessionTTL, err := svc.createDeviceSSOSession(ctx, host, enrollmentRef)
+		if err != nil {
+			logging.WithErr(ctx, ctxerr.Wrap(ctx, err, "create device sso session"))
+			return deviceSSOErrorURL(originalURL, "server_error"), "", "", 0
+		}
+		return originalURL, "", deviceSSOSessionID, int(deviceSSOSessionTTL.Seconds())
 
 	default:
-		return fmt.Sprintf("%s?%s", apple_mdm.FleetUISSOCallbackPath, q.Encode()), ""
+		return fmt.Sprintf("%s?%s", apple_mdm.FleetUISSOCallbackPath, q.Encode()), "", "", 0
 	}
 }
 

--- a/ee/server/service/mdm_sso_test.go
+++ b/ee/server/service/mdm_sso_test.go
@@ -120,3 +120,14 @@ func TestInitiateMDMSSOACSURLWithURLPrefix(t *testing.T) {
 		})
 	}
 }
+
+func TestDeviceSSOErrorURL(t *testing.T) {
+	require.Equal(t,
+		"https://fleet.example.com/device/abc123?sso_error=sso_disabled",
+		deviceSSOErrorURL("https://fleet.example.com/device/abc123", "sso_disabled"))
+
+	// an existing query string is preserved
+	require.Equal(t,
+		"https://fleet.example.com/device/abc123?setup_only=1&sso_error=sso_disabled",
+		deviceSSOErrorURL("https://fleet.example.com/device/abc123?setup_only=1", "sso_disabled"))
+}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -1537,7 +1537,7 @@ func (man Manager) addConfigs() {
 	man.addConfigBool("auth.require_http_message_signature", false,
 		"Require HTTP message signatures for fleetd requests (Premium feature)")
 	man.addConfigInt("auth.sso_rate_limit_per_minute", 0,
-		"Number of allowed requests per minute to the SSO callback endpoint (default uses the login rate limit value in a dedicated bucket)")
+		"Number of allowed requests per minute to the SSO callback and Fleet Desktop device SSO endpoints (each in its own bucket; defaults to the login rate limit value)")
 
 	// App
 	man.addConfigString("app.token_key", "CHANGEME",

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -343,6 +343,23 @@ func (c *AppConfig) MDMUrl() string {
 	return c.MDM.AppleServerURL
 }
 
+// FleetDesktopBrowserUrl returns the base URL an end user's browser reaches
+// Fleet on, which is the server URL unless fleet_desktop.alternative_browser_host
+// overrides its host.
+func (c *AppConfig) FleetDesktopBrowserUrl() (*url.URL, error) {
+	base, err := url.Parse(c.ServerSettings.ServerURL)
+	if err != nil {
+		return nil, err
+	}
+	if altHost := c.FleetDesktop.AlternativeBrowserHost; altHost != "" {
+		if parsed, err := url.Parse(altHost); err == nil && parsed.Host != "" {
+			altHost = parsed.Host
+		}
+		base.Host = altHost
+	}
+	return base, nil
+}
+
 func (c *AppConfigUrls) MDMUrl() string {
 	if c.MDM.AppleServerURL == "" {
 		return c.ServerSettings.ServerURL

--- a/server/fleet/app_test.go
+++ b/server/fleet/app_test.go
@@ -1056,3 +1056,53 @@ func TestManagedLocalAccountSettingsMarshalDefaults(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, map[string]any{"enabled": false}, windowsSettings(v.([]byte)))
 }
+
+func TestFleetDesktopBrowserUrl(t *testing.T) {
+	cases := []struct {
+		name                   string
+		serverURL              string
+		alternativeBrowserHost string
+		want                   string
+	}{
+		{
+			name:      "no alternative browser host",
+			serverURL: "https://fleet.example.com",
+			want:      "https://fleet.example.com/device/abc123",
+		},
+		{
+			name:                   "alternative browser host replaces only the host",
+			serverURL:              "https://fleet.example.com",
+			alternativeBrowserHost: "proxy.example.com",
+			want:                   "https://proxy.example.com/device/abc123",
+		},
+		{
+			name:                   "alternative browser host keeps its port",
+			serverURL:              "https://fleet.example.com",
+			alternativeBrowserHost: "proxy.example.com:8443",
+			want:                   "https://proxy.example.com:8443/device/abc123",
+		},
+		{
+			name:                   "alternative browser host given with a scheme is tolerated",
+			serverURL:              "https://fleet.example.com",
+			alternativeBrowserHost: "https://proxy.example.com",
+			want:                   "https://proxy.example.com/device/abc123",
+		},
+		{
+			name:      "url_prefix on the server URL is preserved",
+			serverURL: "https://fleet.example.com/prefix",
+			want:      "https://fleet.example.com/prefix/device/abc123",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var appConfig AppConfig
+			appConfig.ServerSettings.ServerURL = c.serverURL
+			appConfig.FleetDesktop.AlternativeBrowserHost = c.alternativeBrowserHost
+
+			base, err := appConfig.FleetDesktopBrowserUrl()
+			require.NoError(t, err)
+			require.Equal(t, c.want, base.JoinPath("/device/abc123").String())
+		})
+	}
+}

--- a/server/fleet/mdm.go
+++ b/server/fleet/mdm.go
@@ -1460,7 +1460,36 @@ const (
 	SSOInitiatorAccountDrivenEnroll = "account_driven_enroll"
 	// SSOInitiatorAppleMDMSSO is used for automatic MDM Apple enrollment SSO flow.
 	SSOInitiatorAppleMDMSSO = "mdm_sso"
+	// SSOInitiatorFleetDesktop is used when the Fleet Desktop "My device" page
+	// requires the end user to authenticate with the IdP.
+	SSOInitiatorFleetDesktop = "fleet_desktop"
 )
+
+// DeviceSSOInitiation is what a device needs to start the Fleet Desktop SSO
+// flow: the IdP URL to navigate to, plus the handshake session that ties the
+// eventual SAML callback back to this request.
+type DeviceSSOInitiation struct {
+	// IdPURL is the URL the browser must navigate to in order to authenticate.
+	IdPURL string
+	// SessionID identifies the SSO handshake session, carried to the SAML
+	// callback by the __Host-FLEETSSOSESSIONID cookie.
+	SessionID string
+	// SessionDuration is how long the handshake session and its cookie stay
+	// valid; both must use it so neither outlives the other.
+	SessionDuration time.Duration
+}
+
+// DeviceSSOSession is minted after a successful IdP callback initiated from
+// the Fleet Desktop "My device" page, and consumed by the device endpoint SSO
+// gate. It is bound to the host whose device token started the flow, so one
+// device's session cannot unlock another device's page in the same browser.
+type DeviceSSOSession struct {
+	HostID uint `json:"host_id"`
+	// IdPAccountUUID identifies the mdm_idp_accounts row for the IdP identity
+	// that completed the SAML flow.
+	IdPAccountUUID string    `json:"idp_account_uuid"`
+	ExpiresAt      time.Time `json:"expires_at"`
+}
 
 // ValidateMDMProfileSpecs validates the label configuration for each profile spec: exactly one
 // include mode may be set, no label may appear in both include and exclude lists, and the legacy

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -149,6 +149,11 @@ type Service interface {
 	// GetFleetDesktopSummary returns a summary of the host used by Fleet Desktop to operate.
 	GetFleetDesktopSummary(ctx context.Context) (DesktopSummary, error)
 
+	// InitiateDeviceSSO starts the SAML authentication flow for the Fleet
+	// Desktop "My device" page, bound to the host resolved from the
+	// initiating device token.
+	InitiateDeviceSSO(ctx context.Context, deviceURL string) (*DeviceSSOInitiation, error)
+
 	// SetEnterpriseOverrides allows the enterprise service to override specific methods
 	// that can't be easily overridden via embedding.
 	//
@@ -241,7 +246,12 @@ type Service interface {
 	// MDMSSOCallback handles the IdP SAMLResponse and ensures the
 	// credentials are valid, then responds with a URL to the Fleet UI to
 	// handle next steps based on the query parameters provided.
-	MDMSSOCallback(ctx context.Context, sessionID string, samlResponse []byte) (redirectURL, byodCookieValue string)
+	//
+	// deviceSSOSessionID and deviceSSOSessionDurationSeconds are set when the
+	// callback was initiated by the Fleet Desktop device SSO flow
+	// (SSOInitiatorFleetDesktop), so the caller can set the device SSO session
+	// cookie.
+	MDMSSOCallback(ctx context.Context, sessionID string, samlResponse []byte) (redirectURL, byodCookieValue, deviceSSOSessionID string, deviceSSOSessionDurationSeconds int)
 
 	// GetMDMAccountDrivenEnrollmentSSOURL returns the URL to redirect to for MDM Account Driven Enrollment SSO Authentication
 	GetMDMAccountDrivenEnrollmentSSOURL(ctx context.Context, enrollmentToken string) (string, error)

--- a/server/mock/service/service_mock.go
+++ b/server/mock/service/service_mock.go
@@ -63,6 +63,8 @@ type SetOrUpdateDeviceAuthTokenFunc func(ctx context.Context, authToken string) 
 
 type GetFleetDesktopSummaryFunc func(ctx context.Context) (fleet.DesktopSummary, error)
 
+type InitiateDeviceSSOFunc func(ctx context.Context, deviceURL string) (*fleet.DeviceSSOInitiation, error)
+
 type SetEnterpriseOverridesFunc func(overrides fleet.EnterpriseOverrides)
 
 type CreateUserFromInviteFunc func(ctx context.Context, p fleet.UserPayload) (user *fleet.User, err error)
@@ -105,7 +107,7 @@ type InitiateMDMSSOFunc func(ctx context.Context, initiator string, customOrigin
 
 type InitSSOCallbackFunc func(ctx context.Context, sessionID string, samlResponse []byte) (auth fleet.Auth, redirectURL string, err error)
 
-type MDMSSOCallbackFunc func(ctx context.Context, sessionID string, samlResponse []byte) (redirectURL string, byodCookieValue string)
+type MDMSSOCallbackFunc func(ctx context.Context, sessionID string, samlResponse []byte) (redirectURL string, byodCookieValue string, deviceSSOSessionID string, deviceSSOSessionDurationSeconds int)
 
 type GetMDMAccountDrivenEnrollmentSSOURLFunc func(ctx context.Context, enrollmentToken string) (string, error)
 
@@ -1064,6 +1066,9 @@ type Service struct {
 
 	GetFleetDesktopSummaryFunc        GetFleetDesktopSummaryFunc
 	GetFleetDesktopSummaryFuncInvoked bool
+
+	InitiateDeviceSSOFunc        InitiateDeviceSSOFunc
+	InitiateDeviceSSOFuncInvoked bool
 
 	SetEnterpriseOverridesFunc        SetEnterpriseOverridesFunc
 	SetEnterpriseOverridesFuncInvoked bool
@@ -2622,6 +2627,13 @@ func (s *Service) GetFleetDesktopSummary(ctx context.Context) (fleet.DesktopSumm
 	return s.GetFleetDesktopSummaryFunc(ctx)
 }
 
+func (s *Service) InitiateDeviceSSO(ctx context.Context, deviceURL string) (*fleet.DeviceSSOInitiation, error) {
+	s.mu.Lock()
+	s.InitiateDeviceSSOFuncInvoked = true
+	s.mu.Unlock()
+	return s.InitiateDeviceSSOFunc(ctx, deviceURL)
+}
+
 func (s *Service) SetEnterpriseOverrides(overrides fleet.EnterpriseOverrides) {
 	s.mu.Lock()
 	s.SetEnterpriseOverridesFuncInvoked = true
@@ -2769,7 +2781,7 @@ func (s *Service) InitSSOCallback(ctx context.Context, sessionID string, samlRes
 	return s.InitSSOCallbackFunc(ctx, sessionID, samlResponse)
 }
 
-func (s *Service) MDMSSOCallback(ctx context.Context, sessionID string, samlResponse []byte) (redirectURL string, byodCookieValue string) {
+func (s *Service) MDMSSOCallback(ctx context.Context, sessionID string, samlResponse []byte) (redirectURL string, byodCookieValue string, deviceSSOSessionID string, deviceSSOSessionDurationSeconds int) {
 	s.mu.Lock()
 	s.MDMSSOCallbackFuncInvoked = true
 	s.mu.Unlock()

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -4211,8 +4211,10 @@ func (callbackMDMSSORequest) DecodeRequest(ctx context.Context, r *http.Request)
 }
 
 type callbackMDMSSOResponse struct {
-	redirectURL           string
-	byodEnrollCookieValue string
+	redirectURL              string
+	byodEnrollCookieValue    string
+	deviceSSOSessionID       string
+	deviceSSOSessionDuration int
 }
 
 func (r callbackMDMSSOResponse) HijackRender(ctx context.Context, w http.ResponseWriter) {
@@ -4225,6 +4227,9 @@ func (r callbackMDMSSOResponse) SetCookies(_ context.Context, w http.ResponseWri
 	if r.byodEnrollCookieValue != "" {
 		setBYODCookie(w, r.byodEnrollCookieValue, 30*60) // valid for 30 minutes
 	}
+	if r.deviceSSOSessionID != "" {
+		setDeviceSSOSessionCookie(w, r.deviceSSOSessionID, r.deviceSSOSessionDuration)
+	}
 }
 
 // Error will always be nil because errors are handled by sending a query
@@ -4234,19 +4239,21 @@ func (r callbackMDMSSOResponse) Error() error { return nil }
 
 func callbackMDMSSOEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (fleet.Errorer, error) {
 	callbackRequest := request.(*callbackMDMSSORequest)
-	redirectURL, byodCookieValue := svc.MDMSSOCallback(ctx, callbackRequest.sessionID, callbackRequest.samlResponse)
+	redirectURL, byodCookieValue, deviceSSOSessionID, deviceSSOSessionDuration := svc.MDMSSOCallback(ctx, callbackRequest.sessionID, callbackRequest.samlResponse)
 	return callbackMDMSSOResponse{
-		redirectURL:           redirectURL,
-		byodEnrollCookieValue: byodCookieValue,
+		redirectURL:              redirectURL,
+		byodEnrollCookieValue:    byodCookieValue,
+		deviceSSOSessionID:       deviceSSOSessionID,
+		deviceSSOSessionDuration: deviceSSOSessionDuration,
 	}, nil
 }
 
-func (svc *Service) MDMSSOCallback(ctx context.Context, sessionID string, samlResponse []byte) (redirectURL, byodCookieValue string) {
+func (svc *Service) MDMSSOCallback(ctx context.Context, sessionID string, samlResponse []byte) (redirectURL, byodCookieValue, deviceSSOSessionID string, deviceSSOSessionDurationSeconds int) {
 	// skipauth: No authorization check needed due to implementation
 	// returning only license error.
 	svc.authz.SkipAuthorization(ctx)
 
-	return apple_mdm.FleetUISSOCallbackPath + "?error=true", ""
+	return apple_mdm.FleetUISSOCallbackPath + "?error=true", "", "", 0
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/server/service/devices.go
+++ b/server/service/devices.go
@@ -95,6 +95,51 @@ func (svc *Service) GetFleetDesktopSummary(ctx context.Context) (fleet.DesktopSu
 }
 
 /////////////////////////////////////////////////////////////////////////////////
+// POST /device/{token}/sso
+/////////////////////////////////////////////////////////////////////////////////
+
+type initiateDeviceSSORequest struct {
+	Token string `url:"token"`
+}
+
+func (r *initiateDeviceSSORequest) deviceAuthToken() string { return r.Token }
+
+type initiateDeviceSSOResponse struct {
+	URL string `json:"url"`
+	Err error  `json:"error,omitempty"`
+	// Cookie fields
+	sessionID       string
+	sessionDuration time.Duration
+}
+
+func (r initiateDeviceSSOResponse) Error() error { return r.Err }
+
+func (r initiateDeviceSSOResponse) SetCookies(_ context.Context, w http.ResponseWriter) {
+	if r.sessionID == "" {
+		return
+	}
+	setSSOCookie(w, r.sessionID, int(r.sessionDuration.Seconds()))
+}
+
+func initiateDeviceSSOEndpoint(ctx context.Context, request any, svc fleet.Service) (fleet.Errorer, error) {
+	req := request.(*initiateDeviceSSORequest)
+	initiation, err := svc.InitiateDeviceSSO(ctx, "/device/"+req.Token)
+	if err != nil {
+		return initiateDeviceSSOResponse{Err: err}, nil
+	}
+	return initiateDeviceSSOResponse{
+		URL:             initiation.IdPURL,
+		sessionID:       initiation.SessionID,
+		sessionDuration: initiation.SessionDuration,
+	}, nil
+}
+
+func (svc *Service) InitiateDeviceSSO(ctx context.Context, deviceURL string) (*fleet.DeviceSSOInitiation, error) {
+	svc.authz.SkipAuthorization(ctx)
+	return nil, fleet.ErrMissingLicense
+}
+
+/////////////////////////////////////////////////////////////////////////////////
 // Get Current Device's Host
 /////////////////////////////////////////////////////////////////////////////////
 

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -962,6 +962,7 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	de.WithCustomMiddleware(errorLimiter).GET("/api/_version_/fleet/device/{token}/software/titles/{software_title_id}/icon", getDeviceSoftwareIconEndpoint, getDeviceSoftwareIconRequest{})
 	de.WithCustomMiddleware(errorLimiter).POST("/api/_version_/fleet/device/{token}/mdm/linux/trigger_escrow", triggerLinuxDiskEncryptionEscrowEndpoint, triggerLinuxDiskEncryptionEscrowRequest{})
 	de.WithCustomMiddleware(errorLimiter).POST("/api/_version_/fleet/device/{token}/bypass_conditional_access", bypassConditionalAccessEndpoint, bypassConditionalAccessRequest{})
+	de.WithCustomMiddleware(errorLimiter).POST("/api/_version_/fleet/device/{token}/sso", initiateDeviceSSOEndpoint, initiateDeviceSSORequest{})
 	// Device authenticated, Apple MDM endpoints.
 	demdm := de.WithCustomMiddleware(mdmConfiguredMiddleware.VerifyAppleMDM())
 	demdm.AppendCustomMiddleware(errorLimiter).GET("/api/_version_/fleet/device/{token}/mdm/apple/manual_enrollment_profile", getDeviceMDMManualEnrollProfileEndpoint, getDeviceMDMManualEnrollProfileRequest{})

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -938,6 +938,30 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	)
 	errorLimiter := ratelimit.NewErrorMiddleware(ipBanner).Limit(logger)
 
+	// Rate limiters shared across the login/SSO endpoints.
+	limiter := ratelimit.NewMiddleware(limitStore)
+
+	// By default, MDM SSO shares the login rate limit bucket; if MDM SSO limit is overridden, MDM SSO gets its
+	// own rate limit bucket.
+	loginRateLimit := throttled.PerMin(10)
+	if extra.loginRateLimit != nil {
+		loginRateLimit = *extra.loginRateLimit
+	}
+	loginLimiter := limiter.Limit("login", throttled.RateQuota{MaxRate: loginRateLimit, MaxBurst: 9})
+	mdmSsoLimiter := loginLimiter
+	if extra.mdmSsoRateLimit != nil {
+		mdmSsoLimiter = limiter.Limit("mdm_sso", throttled.RateQuota{MaxRate: *extra.mdmSsoRateLimit, MaxBurst: 9})
+	}
+	// The SSO callback gets its own dedicated bucket (separate from the login
+	// bucket) so a flood on the unauthenticated callback can't exhaust the
+	// rate-limit budget that legitimate password logins depend on. The rate
+	// defaults to the login rate unless explicitly overridden.
+	ssoRateLimit := loginRateLimit
+	if extra.ssoRateLimit != nil {
+		ssoRateLimit = *extra.ssoRateLimit
+	}
+	ssoLimiter := limiter.Limit("sso", throttled.RateQuota{MaxRate: ssoRateLimit, MaxBurst: 9})
+
 	// Device-authenticated endpoints.
 	de := newDeviceAuthenticatedEndpointer(svc, logger, opts, r, apiVersions...)
 	de.WithCustomMiddleware(errorLimiter).GET("/api/_version_/fleet/device/{token}", getDeviceHostEndpoint, getDeviceHostRequest{})
@@ -962,7 +986,17 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	de.WithCustomMiddleware(errorLimiter).GET("/api/_version_/fleet/device/{token}/software/titles/{software_title_id}/icon", getDeviceSoftwareIconEndpoint, getDeviceSoftwareIconRequest{})
 	de.WithCustomMiddleware(errorLimiter).POST("/api/_version_/fleet/device/{token}/mdm/linux/trigger_escrow", triggerLinuxDiskEncryptionEscrowEndpoint, triggerLinuxDiskEncryptionEscrowRequest{})
 	de.WithCustomMiddleware(errorLimiter).POST("/api/_version_/fleet/device/{token}/bypass_conditional_access", bypassConditionalAccessEndpoint, bypassConditionalAccessRequest{})
-	de.WithCustomMiddleware(errorLimiter).POST("/api/_version_/fleet/device/{token}/sso", initiateDeviceSSOEndpoint, initiateDeviceSSORequest{})
+
+	// Device-authenticated, so unlike the unauthenticated SSO routes this needs no
+	// pre-auth flood guard. It is quota-limited for amplification instead: each
+	// successful call refetches the IdP metadata, so one leaked device token could
+	// drive sustained outbound traffic at the customer's IdP from Fleet's own IP,
+	// and errorLimiter cannot see it because those requests succeed. Own bucket so
+	// device traffic cannot exhaust the budget logins and enrollments depend on,
+	// at the same rate as the other end-user-facing SSO path, so
+	// auth.sso_rate_limit_per_minute tunes both.
+	deviceSsoLimiter := limiter.Limit("device_sso", throttled.RateQuota{MaxRate: ssoRateLimit, MaxBurst: 9})
+	de.WithCustomMiddleware(errorLimiter, deviceSsoLimiter).POST("/api/_version_/fleet/device/{token}/sso", initiateDeviceSSOEndpoint, initiateDeviceSSORequest{})
 	// Device authenticated, Apple MDM endpoints.
 	demdm := de.WithCustomMiddleware(mdmConfiguredMiddleware.VerifyAppleMDM())
 	demdm.AppendCustomMiddleware(errorLimiter).GET("/api/_version_/fleet/device/{token}/mdm/apple/manual_enrollment_profile", getDeviceMDMManualEnrollProfileEndpoint, getDeviceMDMManualEnrollProfileRequest{})
@@ -1194,32 +1228,6 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	)
 	ne.WithCustomMiddleware(orgLogoLimiter).
 		GET("/api/_version_/fleet/logo", getOrgLogoEndpoint, getOrgLogoRequest{})
-
-	// Rate limiters shared across the login/SSO endpoints. These are defined
-	// here (ahead of the password-login registrations below) so the
-	// unauthenticated SSO callback can reuse the same login bucket.
-	limiter := ratelimit.NewMiddleware(limitStore)
-
-	// By default, MDM SSO shares the login rate limit bucket; if MDM SSO limit is overridden, MDM SSO gets its
-	// own rate limit bucket.
-	loginRateLimit := throttled.PerMin(10)
-	if extra.loginRateLimit != nil {
-		loginRateLimit = *extra.loginRateLimit
-	}
-	loginLimiter := limiter.Limit("login", throttled.RateQuota{MaxRate: loginRateLimit, MaxBurst: 9})
-	mdmSsoLimiter := loginLimiter
-	if extra.mdmSsoRateLimit != nil {
-		mdmSsoLimiter = limiter.Limit("mdm_sso", throttled.RateQuota{MaxRate: *extra.mdmSsoRateLimit, MaxBurst: 9})
-	}
-	// The SSO callback gets its own dedicated bucket (separate from the login
-	// bucket) so a flood on the unauthenticated callback can't exhaust the
-	// rate-limit budget that legitimate password logins depend on. The rate
-	// defaults to the login rate unless explicitly overridden.
-	ssoRateLimit := loginRateLimit
-	if extra.ssoRateLimit != nil {
-		ssoRateLimit = *extra.ssoRateLimit
-	}
-	ssoLimiter := limiter.Limit("sso", throttled.RateQuota{MaxRate: ssoRateLimit, MaxBurst: 9})
 
 	ne.POST("/api/v1/fleet/sso", initiateSSOEndpoint, initiateSSORequest{})
 	// The SSO callback is unauthenticated and internet-reachable. Rate-limit it

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -12347,6 +12347,21 @@ func (s *integrationTestSuite) TestPingEndpoints() {
 	s.DoRawNoAuth("HEAD", fmt.Sprintf("/api/v1/fleet/device/%s/ping", "bozo-token"), nil, http.StatusUnauthorized)
 }
 
+func (s *integrationTestSuite) TestInitiateDeviceSSOFreeTier() {
+	t := s.T()
+
+	createHostAndDeviceToken(t, s.ds, "device-sso-token")
+
+	// free tier: no InitiateDeviceSSO implementation beyond the license error,
+	// same shape as every other premium-only device endpoint.
+	res := s.DoRawNoAuth("POST", "/api/latest/fleet/device/device-sso-token/sso", nil, http.StatusPaymentRequired)
+	errMsg := extractServerErrorText(res.Body)
+	assert.Contains(t, errMsg, fleet.ErrMissingLicense.Error())
+
+	// invalid device token behaves like every other device-authenticated route
+	s.DoRawNoAuth("POST", "/api/latest/fleet/device/bozo-token/sso", nil, http.StatusUnauthorized)
+}
+
 func (s *integrationTestSuite) TestMDMNotConfiguredEndpoints() {
 	t := s.T()
 

--- a/server/service/integration_desktop_test.go
+++ b/server/service/integration_desktop_test.go
@@ -552,6 +552,12 @@ func (s *integrationEnterpriseTestSuite) TestAlternativeBrowserHostSetting() {
 	require.NoError(t, res.Body.Close())
 	require.Equal(t, acResp.FleetDesktop.AlternativeBrowserHost, getDesktopResp.AlternativeBrowserHost)
 
+	originalHost := acResp.FleetDesktop.AlternativeBrowserHost
+	t.Cleanup(func() {
+		s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(fmt.Sprintf(
+			`{"fleet_desktop": {"alternative_browser_host": %q}}`, originalHost)), http.StatusOK, &appConfigResponse{})
+	})
+
 	acResp = appConfigResponse{}
 	s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(`{"fleet_desktop": {"alternative_browser_host":"althost"}}`), http.StatusOK, &acResp)
 	require.NotNil(t, acResp)

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -5913,6 +5913,55 @@ func (s *integrationEnterpriseTestSuite) TestTeamAdminCannotCreateUserInOtherTea
 	require.NotNil(t, resp.User)
 }
 
+func (s *integrationEnterpriseTestSuite) TestDeviceSSOWithoutAppleMDM() {
+	t := s.T()
+
+	if _, ok := os.LookupEnv("SAML_IDP_TEST"); !ok {
+		t.Skip("SSO tests are disabled")
+	}
+
+	var acResp appConfigResponse
+	s.DoJSON("GET", "/api/latest/fleet/config", nil, http.StatusOK, &acResp)
+	require.False(t, acResp.MDM.EnabledAndConfigured)
+	originalServerURL := acResp.ServerSettings.ServerURL
+
+	createHostAndDeviceToken(t, s.ds, "device-sso-no-apple-mdm-token")
+
+	s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(fmt.Sprintf(`{
+		"server_settings": { "server_url": "https://localhost:8080" },
+		"mdm": {
+			"end_user_authentication": {
+				"entity_id": "mdm.test.com",
+				"idp_name": "SimpleSAML",
+				"metadata_url": "%s"
+			}
+		},
+		"fleet_desktop": { "sso_enabled": true, "alternative_browser_host": "" }
+	}`, testSAMLIDPMetadataURL)), http.StatusOK, &acResp)
+	require.True(t, acResp.FleetDesktop.SSOEnabled)
+	require.Empty(t, acResp.FleetDesktop.AlternativeBrowserHost)
+
+	t.Cleanup(func() {
+		s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(fmt.Sprintf(`{
+			"server_settings": { "server_url": %q },
+			"fleet_desktop": { "sso_enabled": false },
+			"mdm": { "end_user_authentication": { "entity_id": "", "idp_name": "", "metadata_url": "" } }
+		}`, originalServerURL)), http.StatusOK, &appConfigResponse{})
+	})
+
+	res := s.LoginDeviceSSOUser("sso_user", "user123#", "device-sso-no-apple-mdm-token")
+	require.Equal(t, "https://localhost:8080/device/device-sso-no-apple-mdm-token", res.Header.Get("Location"))
+
+	var sessionCookie *http.Cookie
+	for _, c := range res.Cookies() {
+		if c.Name == cookieNameDeviceSSOSession {
+			sessionCookie = c
+		}
+	}
+	require.NotNil(t, sessionCookie, "expected a device SSO session even without Apple MDM configured")
+	require.NotEmpty(t, sessionCookie.Value)
+}
+
 func (s *integrationEnterpriseTestSuite) TestSSOJITProvisioning() {
 	t := s.T()
 

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -6970,6 +6970,186 @@ func (s *integrationMDMTestSuite) TestSSO() {
 	require.False(t, q.Has("reason"))
 }
 
+func (s *integrationMDMTestSuite) TestDeviceSSO() {
+	t := s.T()
+	s.setSkipWorkerJobs(t)
+
+	newHostWithToken := func(suffix string) (*fleet.Host, string) {
+		h, err := s.ds.NewHost(t.Context(), &fleet.Host{
+			DetailUpdatedAt: time.Now(),
+			LabelUpdatedAt:  time.Now(),
+			PolicyUpdatedAt: time.Now(),
+			SeenTime:        time.Now().Add(-1 * time.Minute),
+			OsqueryHostID:   new(t.Name() + "-osquery" + suffix),
+			NodeKey:         new(t.Name() + "-nodekey" + suffix),
+			UUID:            strings.ToUpper(uuid.NewString()),
+			Hostname:        fmt.Sprintf("%sfoo%s.local", t.Name(), suffix),
+			HardwareSerial:  mdmtest.RandSerialNumber(),
+			Platform:        "darwin",
+		})
+		require.NoError(t, err)
+		token := uuid.New().String()
+		require.NoError(t, s.ds.SetOrUpdateDeviceAuthToken(t.Context(), h.ID, token))
+		return h, token
+	}
+
+	fleetHost, deviceToken := newHostWithToken("-a")
+	otherHost, otherDeviceToken := newHostWithToken("-b")
+
+	res := s.DoRawNoAuth("POST", "/api/v1/fleet/device/"+deviceToken+"/sso", nil, http.StatusBadRequest)
+	require.Contains(t, extractServerErrorText(res.Body), "is not enabled")
+
+	for _, c := range res.Cookies() {
+		require.NotEqual(t, cookieNameSSOSession, c.Name, "error response must not touch the handshake cookie")
+	}
+
+	s.DoRawNoAuth("POST", "/api/v1/fleet/device/bozo-token/sso", nil, http.StatusUnauthorized)
+
+	s.setUpMDMSSO(t, false)
+	defer s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(`{
+		"fleet_desktop": { "sso_enabled": false }
+	}`), http.StatusOK, &appConfigResponse{})
+
+	// enable fleet_desktop.sso_enabled
+	acResp := appConfigResponse{}
+	s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(`{
+		"fleet_desktop": { "sso_enabled": true }
+	}`), http.StatusOK, &acResp)
+	require.True(t, acResp.FleetDesktop.SSOEnabled)
+
+	prevCookieSecure := cookieSecure
+	t.Cleanup(func() { cookieSecure = prevCookieSecure })
+	cookieSecure = false
+	jar, err := cookiejar.New(nil)
+	require.NoError(t, err)
+	client := fleethttp.NewClient(fleethttp.WithFollowRedir(false), fleethttp.WithCookieJar(jar))
+
+	var resIni initiateDeviceSSOResponse
+	iniRes := s.doWithClient(client, "POST", "/api/v1/fleet/device/"+deviceToken+"/sso", nil, http.StatusOK, nil)
+	require.NoError(t, json.NewDecoder(iniRes.Body).Decode(&resIni))
+	require.NoError(t, resIni.Error())
+	require.NotEmpty(t, resIni.URL)
+	var gotHandshakeCookie bool
+	for _, c := range iniRes.Cookies() {
+		if c.Name == cookieNameSSOSession {
+			gotHandshakeCookie = true
+		}
+	}
+	require.True(t, gotHandshakeCookie, "expected the SSO handshake cookie to be set")
+
+	forgedBody, err := json.Marshal(initiateMDMSSORequest{
+		Initiator: fleet.SSOInitiatorFleetDesktop,
+		HostUUID:  fleetHost.UUID,
+	})
+	require.NoError(t, err)
+	s.DoRawNoAuth("POST", "/api/v1/fleet/mdm/sso", forgedBody, http.StatusBadRequest)
+
+	s.DoRawNoAuth("GET", "/api/latest/fleet/device/"+deviceToken, nil, http.StatusOK)
+
+	// complete the flow: sign in at the IdP and post the assertion back to the
+	// existing MDM SSO callback
+	res = s.LoginDeviceSSOUser("sso_user", "user123#", deviceToken)
+	require.Equal(t, "https://localhost:8080/device/"+deviceToken, res.Header.Get("Location"))
+
+	var gotSessionCookie *http.Cookie
+	var handshakeCookieDeleted bool
+	for _, c := range res.Cookies() {
+		switch c.Name {
+		case cookieNameDeviceSSOSession:
+			gotSessionCookie = c
+		case cookieNameSSOSession:
+			handshakeCookieDeleted = c.MaxAge < 0
+		}
+	}
+	require.NotNil(t, gotSessionCookie, "expected the device SSO session cookie to be set")
+	require.NotEmpty(t, gotSessionCookie.Value)
+	require.True(t, handshakeCookieDeleted, "expected the handshake cookie to be deleted")
+
+	// the cookie must be unreadable from JS, scoped to the whole site so the
+	// device page's API calls carry it, and live exactly as long as the session
+	require.True(t, gotSessionCookie.HttpOnly)
+	require.Equal(t, "/", gotSessionCookie.Path)
+	require.Equal(t, http.SameSiteLaxMode, gotSessionCookie.SameSite)
+	require.Equal(t, int(s.fleetCfg.Session.Duration.Seconds()), gotSessionCookie.MaxAge)
+
+	deviceSSOSession := func(sessionID string) fleet.DeviceSSOSession {
+		t.Helper()
+		raw, err := s.keyValueStore.Get(t.Context(), "device_sso_session:"+sessionID)
+		require.NoError(t, err)
+		require.NotNil(t, raw, "expected a stored device SSO session")
+		var sess fleet.DeviceSSOSession
+		require.NoError(t, json.Unmarshal([]byte(*raw), &sess))
+		return sess
+	}
+
+	// the minted session is bound to the host whose token initiated the flow,
+	// which is what stops one device's cookie from unlocking another's page
+	session := deviceSSOSession(gotSessionCookie.Value)
+	require.Equal(t, fleetHost.ID, session.HostID)
+	require.NotEqual(t, otherHost.ID, session.HostID)
+
+	// the session also records which IdP identity signed in
+	ssoUserAcct, err := s.ds.GetMDMIdPAccountByEmail(t.Context(), "sso_user@example.com")
+	require.NoError(t, err)
+	require.Equal(t, ssoUserAcct.UUID, session.IdPAccountUUID)
+
+	// a session initiated from a different host's token binds to that host
+	otherRes := s.LoginDeviceSSOUser("sso_user", "user123#", otherDeviceToken)
+	var otherSessionCookie *http.Cookie
+	for _, c := range otherRes.Cookies() {
+		if c.Name == cookieNameDeviceSSOSession {
+			otherSessionCookie = c
+		}
+	}
+	require.NotNil(t, otherSessionCookie)
+	require.NotEqual(t, gotSessionCookie.Value, otherSessionCookie.Value)
+	require.Equal(t, otherHost.ID, deviceSSOSession(otherSessionCookie.Value).HostID)
+
+	// the fleet_desktop branch never associates the IdP account with the host
+	// -- that link belongs to enrollment flows, not a Fleet Desktop sign-in.
+	var idpAssociationCount int
+	mysqltest.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(t.Context(), q, &idpAssociationCount,
+			`SELECT COUNT(*) FROM host_mdm_idp_accounts WHERE host_uuid IN (?, ?)`, fleetHost.UUID, otherHost.UUID)
+	})
+	assert.Zero(t, idpAssociationCount)
+
+	// A failed callback sends the end user back to the device page with a
+	// reason, not to the admin SSO callback route, and mints nothing.
+	requireNoSessionMinted := func(res *http.Response, deviceToken, wantReason, msg string) {
+		t.Helper()
+		require.Equal(t, "https://localhost:8080/device/"+deviceToken+"?sso_error="+wantReason,
+			res.Header.Get("Location"), msg)
+		for _, c := range res.Cookies() {
+			require.NotEqualf(t, cookieNameDeviceSSOSession, c.Name, "no session cookie expected: %s", msg)
+		}
+	}
+
+	// if the host is gone by the time the IdP calls back, the callback errors
+	// out instead of minting a dangling session
+	deletedClient := s.newSSOTestClient()
+	deletedIdPURL := s.InitiateDeviceSSO(deletedClient, otherDeviceToken)
+	require.NoError(t, s.ds.DeleteHost(t.Context(), otherHost.ID))
+	requireNoSessionMinted(
+		s.CompleteDeviceSSO(deletedClient, deletedIdPURL, "sso_user", "user123#"),
+		otherDeviceToken, "server_error", "host no longer exists",
+	)
+
+	// disabling the feature between initiation and callback also stops a
+	// session from being minted -- otherwise it would outlive the change by its
+	// whole TTL
+	_, thirdToken := newHostWithToken("-c")
+	disabledClient := s.newSSOTestClient()
+	disabledIdPURL := s.InitiateDeviceSSO(disabledClient, thirdToken)
+	s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(`{
+		"fleet_desktop": { "sso_enabled": false }
+	}`), http.StatusOK, &appConfigResponse{})
+	requireNoSessionMinted(
+		s.CompleteDeviceSSO(disabledClient, disabledIdPURL, "sso_user", "user123#"),
+		thirdToken, "sso_disabled", "feature disabled mid-flow",
+	)
+}
+
 // TestMDMSSOReenrollWithDifferentIdPEmail is a regression test for
 // https://github.com/fleetdm/fleet/issues/47626.
 //

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -7003,8 +7003,6 @@ func (s *integrationMDMTestSuite) TestDeviceSSO() {
 		require.NotEqual(t, cookieNameSSOSession, c.Name, "error response must not touch the handshake cookie")
 	}
 
-	s.DoRawNoAuth("POST", "/api/v1/fleet/device/bozo-token/sso", nil, http.StatusUnauthorized)
-
 	s.setUpMDMSSO(t, false)
 	defer s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(`{
 		"fleet_desktop": { "sso_enabled": false }
@@ -7017,20 +7015,15 @@ func (s *integrationMDMTestSuite) TestDeviceSSO() {
 	}`), http.StatusOK, &acResp)
 	require.True(t, acResp.FleetDesktop.SSOEnabled)
 
-	prevCookieSecure := cookieSecure
-	t.Cleanup(func() { cookieSecure = prevCookieSecure })
-	cookieSecure = false
-	jar, err := cookiejar.New(nil)
-	require.NoError(t, err)
-	client := fleethttp.NewClient(fleethttp.WithFollowRedir(false), fleethttp.WithCookieJar(jar))
+	client := s.newSSOTestClient()
+	idpURL := s.InitiateDeviceSSO(client, deviceToken)
 
-	var resIni initiateDeviceSSOResponse
-	iniRes := s.doWithClient(client, "POST", "/api/v1/fleet/device/"+deviceToken+"/sso", nil, http.StatusOK, nil)
-	require.NoError(t, json.NewDecoder(iniRes.Body).Decode(&resIni))
-	require.NoError(t, resIni.Error())
-	require.NotEmpty(t, resIni.URL)
+	// the handshake cookie has to land in the jar, or the callback below cannot
+	// resolve the SSO session
+	serverURL, err := url.Parse(s.server.URL)
+	require.NoError(t, err)
 	var gotHandshakeCookie bool
-	for _, c := range iniRes.Cookies() {
+	for _, c := range client.Jar.Cookies(serverURL) {
 		if c.Name == cookieNameSSOSession {
 			gotHandshakeCookie = true
 		}
@@ -7046,9 +7039,9 @@ func (s *integrationMDMTestSuite) TestDeviceSSO() {
 
 	s.DoRawNoAuth("GET", "/api/latest/fleet/device/"+deviceToken, nil, http.StatusOK)
 
-	// complete the flow: sign in at the IdP and post the assertion back to the
-	// existing MDM SSO callback
-	res = s.LoginDeviceSSOUser("sso_user", "user123#", deviceToken)
+	// complete *this* flow: sign in at the IdP and post the assertion back to the
+	// existing MDM SSO callback, on the same client that holds the handshake cookie
+	res = s.CompleteDeviceSSO(client, idpURL, "sso_user", "user123#")
 	require.Equal(t, "https://localhost:8080/device/"+deviceToken, res.Header.Get("Location"))
 
 	var gotSessionCookie *http.Cookie

--- a/server/service/sessions.go
+++ b/server/service/sessions.go
@@ -426,9 +426,15 @@ func deleteSSOCookie(w http.ResponseWriter) {
 	})
 }
 
-func setBYODCookie(w http.ResponseWriter, value string, cookieDurationSeconds int) {
+const cookieNameDeviceSSOSession = "__Host-FLEET_DESKTOP_SESSION"
+
+// setHostPrefixedCookie sets a __Host- session cookie: pinned to this host,
+// SameSite=Lax. Lax is safe here, because none of these has to ride the cross-site POST
+// from the IdP -- only the safe-method navigation the SSO callback redirects to,
+// and the page's own requests afterwards.
+func setHostPrefixedCookie(w http.ResponseWriter, name, value string, cookieDurationSeconds int) {
 	http.SetCookie(w, &http.Cookie{
-		Name:     shared_mdm.BYODIdpCookieName,
+		Name:     name,
 		Value:    value,
 		Path:     "/",
 		MaxAge:   cookieDurationSeconds,
@@ -436,6 +442,14 @@ func setBYODCookie(w http.ResponseWriter, value string, cookieDurationSeconds in
 		HttpOnly: true,
 		SameSite: http.SameSiteLaxMode,
 	})
+}
+
+func setDeviceSSOSessionCookie(w http.ResponseWriter, sessionID string, cookieDurationSeconds int) {
+	setHostPrefixedCookie(w, cookieNameDeviceSSOSession, sessionID, cookieDurationSeconds)
+}
+
+func setBYODCookie(w http.ResponseWriter, value string, cookieDurationSeconds int) {
+	setHostPrefixedCookie(w, shared_mdm.BYODIdpCookieName, value, cookieDurationSeconds)
 }
 
 func (r initiateSSOResponse) SetCookies(_ context.Context, w http.ResponseWriter) {

--- a/server/service/testing_client_test.go
+++ b/server/service/testing_client_test.go
@@ -491,11 +491,11 @@ func (ts *withServer) LoginMDMSSOUserSetupExperience(username, password, hostUUI
 	return res
 }
 
-// LoginOTAEnrollSSOUser initiates the OTA enrollment SSO flow by hitting
-// /enroll?enroll_secret=... (as an Android or BYOD device would), follows the
-// SAML login at the IdP, and posts the SAMLResponse back to the MDM SSO
-// callback. Returns the callback response (a redirect).
-func (ts *withServer) LoginOTAEnrollSSOUser(username, password, enrollSecret string) *http.Response {
+// newSSOTestClient returns an HTTP client with its own cookie jar for driving a
+// SAML flow. Redirects are not followed so callers can inspect each hop's
+// Set-Cookie headers, and cookieSecure is disabled for the duration of the test
+// so __Host- cookies survive the plain-HTTP test server.
+func (ts *withServer) newSSOTestClient() *http.Client {
 	t := ts.s.T()
 
 	if _, ok := os.LookupEnv("SAML_IDP_TEST"); !ok {
@@ -503,35 +503,31 @@ func (ts *withServer) LoginOTAEnrollSSOUser(username, password, enrollSecret str
 	}
 
 	prevCookieSecure := cookieSecure
-	t.Cleanup(func() {
-		cookieSecure = prevCookieSecure
-	})
+	t.Cleanup(func() { cookieSecure = prevCookieSecure })
 	cookieSecure = false
+
 	jar, err := cookiejar.New(nil)
 	require.NoError(t, err)
 
-	client := fleethttp.NewClient(
+	return fleethttp.NewClient(
 		fleethttp.WithFollowRedir(false),
 		fleethttp.WithCookieJar(jar),
 	)
+}
 
-	// Step 1: GET /enroll?enroll_secret=... → 303 redirect to IdP (sets SSO cookie)
-	enrollURL := ts.server.URL + "/enroll?enroll_secret=" + url.QueryEscape(enrollSecret)
-	resp, err := client.Get(enrollURL)
+// completeSAMLLogin submits the SimpleSAML login form reached from idpURL and
+// returns the base64-encoded SAMLResponse to post back to an ACS.
+func (ts *withServer) completeSAMLLogin(client *http.Client, idpURL, username, password string) string {
+	t := ts.s.T()
+
+	resp, err := client.Get(idpURL)
 	require.NoError(t, err)
-	require.Equal(t, http.StatusSeeOther, resp.StatusCode)
-	idpURL := resp.Header.Get("Location")
-	require.NotEmpty(t, idpURL, "expected redirect to IdP")
-	require.NoError(t, resp.Body.Close())
 
-	// Step 2: Follow IdP redirect to get the login page
-	resp, err = client.Get(idpURL)
-	require.NoError(t, err)
-	require.NoError(t, resp.Body.Close())
-
-	// Step 3: Extract AuthState and submit login credentials
+	// From the redirect Location header we can get the AuthState and the URL to
+	// which we submit the credentials
 	parsed, err := url.Parse(resp.Header.Get("Location"))
 	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
 	data := url.Values{
 		"username":  {username},
 		"password":  {password},
@@ -540,18 +536,73 @@ func (ts *withServer) LoginOTAEnrollSSOUser(username, password, enrollSecret str
 	resp, err = client.PostForm(parsed.Scheme+"://"+parsed.Host+parsed.Path, data)
 	require.NoError(t, err)
 
-	// Step 4: Extract SAMLResponse from the IdP HTML form
-
+	// The response is an HTML form, we can extract the base64-encoded response
+	// to submit to the Fleet server from here
+	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
-	require.NoError(t, resp.Body.Close())
 
 	re := regexp.MustCompile(`name="SAMLResponse" value="([^\s]*)" />`)
 	matches := re.FindSubmatch(body)
 	require.NotEmptyf(t, matches, "callback HTML doesn't contain a SAMLResponse value, got body: %s", body)
-	samlResponse := string(matches[1])
+	return string(matches[1])
+}
 
-	// Step 5: POST SAMLResponse to Fleet's MDM SSO callback (cookie jar carries the SSO session)
+// InitiateDeviceSSO calls the device-token-authenticated initiation endpoint
+// and returns the IdP URL to navigate to. The handshake cookie lands in the
+// client's jar.
+func (ts *withServer) InitiateDeviceSSO(client *http.Client, deviceToken string) string {
+	t := ts.s.T()
+
+	var resIni initiateDeviceSSOResponse
+	httpResponse := ts.doWithClient(client, "POST", "/api/v1/fleet/device/"+deviceToken+"/sso", nil, http.StatusOK, nil)
+	require.NoError(t, json.NewDecoder(httpResponse.Body).Decode(&resIni))
+	require.NoError(t, resIni.Error())
+	require.NotEmpty(t, resIni.URL)
+	return resIni.URL
+}
+
+// CompleteDeviceSSO signs in at the IdP and posts the assertion back to the
+// existing MDM SSO callback, which the device flow reuses rather than having an
+// ACS of its own. The callback always answers 303, including on failure, so this
+// serves both the happy path and the rejection paths.
+func (ts *withServer) CompleteDeviceSSO(client *http.Client, idpURL, username, password string) *http.Response {
+	samlResponse := ts.completeSAMLLogin(client, idpURL, username, password)
+	return ts.doWithClient(client, "POST", "/api/v1/fleet/mdm/sso/callback", nil, http.StatusSeeOther, nil,
+		"SAMLResponse", samlResponse)
+}
+
+// LoginDeviceSSOUser drives the whole Fleet Desktop "My device" page SSO flow:
+// initiate, sign in at the IdP, and post the assertion back to the callback.
+// Returns the callback response (a redirect) with the client's cookie jar
+// populated, so callers can inspect Set-Cookie headers along the way (the
+// handshake cookie deleted, the device SSO session cookie set).
+func (ts *withServer) LoginDeviceSSOUser(username, password, deviceToken string) *http.Response {
+	client := ts.newSSOTestClient()
+	idpURL := ts.InitiateDeviceSSO(client, deviceToken)
+	return ts.CompleteDeviceSSO(client, idpURL, username, password)
+}
+
+// LoginOTAEnrollSSOUser initiates the OTA enrollment SSO flow by hitting
+// /enroll?enroll_secret=... (as an Android or BYOD device would), follows the
+// SAML login at the IdP, and posts the SAMLResponse back to the MDM SSO
+// callback. Returns the callback response (a redirect).
+func (ts *withServer) LoginOTAEnrollSSOUser(username, password, enrollSecret string) *http.Response {
+	t := ts.s.T()
+	client := ts.newSSOTestClient()
+
+	// GET /enroll?enroll_secret=... → 303 redirect to IdP (sets the SSO cookie)
+	enrollURL := ts.server.URL + "/enroll?enroll_secret=" + url.QueryEscape(enrollSecret)
+	resp, err := client.Get(enrollURL)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusSeeOther, resp.StatusCode)
+	idpURL := resp.Header.Get("Location")
+	require.NotEmpty(t, idpURL, "expected redirect to IdP")
+	require.NoError(t, resp.Body.Close())
+
+	samlResponse := ts.completeSAMLLogin(client, idpURL, username, password)
+
+	// POST the SAMLResponse to Fleet's MDM SSO callback; the jar carries the SSO session
 	callbackURL := ts.server.URL + "/api/v1/fleet/mdm/sso/callback?SAMLResponse=" + url.QueryEscape(samlResponse)
 	resp, err = client.Post(callbackURL, "application/x-www-form-urlencoded", nil)
 	require.NoError(t, err)
@@ -613,57 +664,16 @@ func (ts *withServer) loginSSOUser(username, password string, basePath string, c
 }
 
 func (ts *withServer) loginSSOUserWithBody(username, password string, basePath string, callbackStatus int, requestBody []byte) *http.Response {
-	t := ts.s.T()
-
-	if _, ok := os.LookupEnv("SAML_IDP_TEST"); !ok {
-		t.Skip("SSO tests are disabled")
-	}
-
-	cookieSecure = false
-	jar, err := cookiejar.New(nil)
-	require.NoError(t, err)
-
-	client := fleethttp.NewClient(
-		fleethttp.WithFollowRedir(false),
-		fleethttp.WithCookieJar(jar),
-	)
+	client := ts.newSSOTestClient()
 
 	var resIni initiateSSOResponse
 	httpResponse := ts.doWithClient(client, "POST", basePath, requestBody, http.StatusOK, nil)
-	err = json.NewDecoder(httpResponse.Body).Decode(&resIni)
-	require.NoError(ts.s.T(), err)
+	require.NoError(ts.s.T(), json.NewDecoder(httpResponse.Body).Decode(&resIni))
 	require.NoError(ts.s.T(), resIni.Error())
 
-	resp, err := client.Get(resIni.URL)
-	require.NoError(t, err)
+	samlResponse := ts.completeSAMLLogin(client, resIni.URL, username, password)
 
-	// From the redirect Location header we can get the AuthState and the URL to
-	// which we submit the credentials
-	parsed, err := url.Parse(resp.Header.Get("Location"))
-	require.NoError(t, err)
-	data := url.Values{
-		"username":  {username},
-		"password":  {password},
-		"AuthState": {parsed.Query().Get("AuthState")},
-	}
-	resp, err = client.PostForm(parsed.Scheme+"://"+parsed.Host+parsed.Path, data)
-	require.NoError(t, err)
-
-	// The response is an HTML form, we can extract the base64-encoded response
-	// to submit to the Fleet server from here
-	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-
-	re := regexp.MustCompile(`name="SAMLResponse" value="([^\s]*)" />`)
-	matches := re.FindSubmatch(body)
-	require.NotEmptyf(t, matches, "callback HTML doesn't contain a SAMLResponse value, got body: %s", body)
-	samlResponse := string(matches[1])
-
-	callbackUrl := basePath + "/callback"
-	res := ts.doWithClient(client, "POST", callbackUrl, nil, callbackStatus, nil, "SAMLResponse", samlResponse)
-
-	return res
+	return ts.doWithClient(client, "POST", basePath+"/callback", nil, callbackStatus, nil, "SAMLResponse", samlResponse)
 }
 
 func (ts *withServer) loginSSOUserIDPInitiated(
@@ -678,6 +688,8 @@ func (ts *withServer) loginSSOUserIDPInitiated(
 		t.Skip("SSO tests are disabled")
 	}
 
+	// Unlike the SP-initiated flows this keeps cookieSecure as-is: there is no
+	// handshake cookie to carry, and the callback below goes out without the jar.
 	jar, err := cookiejar.New(nil)
 	require.NoError(t, err)
 
@@ -686,35 +698,9 @@ func (ts *withServer) loginSSOUserIDPInitiated(
 		fleethttp.WithCookieJar(jar),
 	)
 
-	resp, err := client.Get(idpURL)
-	require.NoError(t, err)
+	rawSSOResp := ts.completeSAMLLogin(client, idpURL, username, password)
 
-	// From the redirect Location header we can get the AuthState and the URL to
-	// which we submit the credentials
-	parsed, err := url.Parse(resp.Header.Get("Location"))
-	require.NoError(t, err)
-	data := url.Values{
-		"username":  {username},
-		"password":  {password},
-		"AuthState": {parsed.Query().Get("AuthState")},
-	}
-	resp, err = client.PostForm(parsed.Scheme+"://"+parsed.Host+parsed.Path, data)
-	require.NoError(t, err)
-
-	// The response is an HTML form, we can extract the base64-encoded response
-	// to submit to the Fleet server from here
-	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-	re := regexp.MustCompile(`name="SAMLResponse" value="([^\s]*)" />`)
-	matches := re.FindSubmatch(body)
-	require.NotEmptyf(t, matches, "callback HTML doesn't contain a SAMLResponse value, got body: %s", body)
-	rawSSOResp := string(matches[1])
-
-	q := url.QueryEscape(rawSSOResp)
-	res := ts.DoRawNoAuth("POST", callbackBasePath+"/callback?SAMLResponse="+q, nil, callbackStatus)
-
-	return res
+	return ts.DoRawNoAuth("POST", callbackBasePath+"/callback?SAMLResponse="+url.QueryEscape(rawSSOResp), nil, callbackStatus)
 }
 
 type listActivitiesResponse struct {

--- a/server/sso/callback_url.go
+++ b/server/sso/callback_url.go
@@ -14,6 +14,14 @@ import (
 //
 // base is not mutated; a new URL is returned.
 func CallbackURL(base *url.URL, urlPrefix, callbackPath string) *url.URL {
+	return URLWithPrefix(base, urlPrefix, callbackPath)
+}
+
+// URLWithPrefix joins path onto base, inserting urlPrefix first when base does
+// not already carry it. server_url may or may not include the configured
+// url_prefix, so anything building an absolute Fleet URL has to go through here
+// or it emits the prefix zero times or twice.
+func URLWithPrefix(base *url.URL, urlPrefix, path string) *url.URL {
 	prefix := strings.TrimSuffix(urlPrefix, "/")
 	// JoinPath returns a new URL rather than mutating the receiver, so base is left
 	// untouched and callers can still use it (e.g. as the expected SAML audience).
@@ -21,5 +29,5 @@ func CallbackURL(base *url.URL, urlPrefix, callbackPath string) *url.URL {
 	if prefix != "" && !strings.HasSuffix(strings.TrimSuffix(base.Path, "/"), prefix) {
 		result = result.JoinPath(prefix)
 	}
-	return result.JoinPath(callbackPath)
+	return result.JoinPath(path)
 }


### PR DESCRIPTION
Relates to #51520

Adds POST /api/_version_/fleet/device/{token}/sso, which initiates SAML against the IdP configured for mdm.end_user_authentication. It reuses the existing ACS (POST /api/v1/fleet/mdm/sso/callback) via a new fleet_desktop initiator, so customers need no IdP-side changes.

The callback mints a device SSO session -- random ID in Redis, TTL from session.duration, bound to the host the device token resolved to, carried by a __Host-FLEET_DESKTOP_SESSION cookie. ValidateDeviceSSOSession and DeleteDeviceSSOSession are on fleet.Service for the enforcement gate to consume. Nothing gates device endpoints yet, so this merges with no behavior change.

The fleet_desktop initiator is rejected by the unauthenticated POST /mdm/sso, which takes its initiator and host UUID from the request body: accepting it there would mint a session for an arbitrary host UUID with no device token. Initiation also fails with 422 when the device page and ACS resolve to different hosts, since both cookies are __Host- scoped.

Actual enforcement to be implemented in a subsequent PR.

# User flow

```mermaid
sequenceDiagram
    participant Admin
    participant UI as Fleet UI
    participant API as Fleet server
    participant DB
    participant Tray as Fleet Desktop (tray)
    participant Browser as My device page (browser)
    participant IdP

    note over Admin,DB: 1. Enable the setting
    Admin->>UI: Settings > Org settings > Fleet Desktop:<br/>select "Single sign-on (SSO)"
    UI->>API: PATCH /api/v1/fleet/config {fleet_desktop:{sso_enabled:true}}
    API->>API: ModifyAppConfig: premium check +<br/>MDM.EndUserAuthentication.IsEmpty() check
    API->>DB: save app_config_json
    API->>DB: NewActivity(enabled_sso_fleet_desktop)

    note over Tray,API: 2. Excluded endpoints keep working (fleetd unchanged)
    Tray->>API: GET /device/{token}/desktop (excluded)
    API-->>Tray: 200 DesktopSummary
    Tray->>API: HEAD /device/{token}/ping (excluded)
    API-->>Tray: 200

    note over Tray,IdP: 3. End user opens My device
    Tray->>Browser: open /device/{token}
    Browser->>API: GET /api/.../device/{token} (SPA data call)
    API->>API: authenticatedDevice: token valid, sso_enabled,<br/>not excluded, no device SSO session cookie
    API-->>Browser: 401 + sso marker
    Browser->>API: POST /api/.../device/{token}/sso (excluded)
    API->>API: guards: sso_enabled, IdP configured,<br/>browser host == ACS host (else 400)
    API->>API: sso.CreateAuthorizationRequest<br/>(RequestData{HostUUID from device token, Initiator: fleet_desktop})
    API-->>Browser: IdP URL + __Host- SSO handshake cookie
    Browser->>IdP: SAML AuthnRequest
    IdP-->>API: POST /api/v1/fleet/mdm/sso/callback (existing ACS)
    API->>API: verify assertion, initiator == fleet_desktop:<br/>re-check sso_enabled, skip VerifyMDMAppleConfigured,<br/>mint device SSO session, set cookie
    API-->>Browser: 303 back to /device/{token}<br/>(on failure: ?sso_error=sso_disabled|server_error)
    Browser->>API: GET /api/.../device/{token} (token + session cookie)
    API-->>Browser: 200
```

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Fleet Desktop device SSO initiation through device-authenticated requests.
  * Added secure, time-limited SSO sessions and session cookies.
  * Added support for completing device SSO through configured identity providers.
  * Added host validation to prevent mismatched browser and server destinations.
* **Bug Fixes**
  * Improved handling of disabled, incomplete, or invalid SSO configurations.
  * Added clear error redirects for failed device SSO flows.
* **Tests**
  * Added coverage for successful flows, expiration, invalid requests, configuration changes, and unsupported account states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->