### PR TITLE
Increase config profile size limit to 16 MB to accommodate large fonts

### DIFF
--- a/changes/28516-increase-config-profile-size-limit
+++ b/changes/28516-increase-config-profile-size-limit
@@ -1,0 +1,1 @@
+- Increased the maximum configuration profile file size from 1 MB to 16 MB to support delivering large fonts to macOS, iOS, and iPadOS hosts via configuration profiles.

--- a/changes/28516-increase-config-profile-size-limit
+++ b/changes/28516-increase-config-profile-size-limit
@@ -1,1 +1,2 @@
 - Increased the maximum configuration profile file size from 1 MB to 16 MB to support delivering large fonts to macOS, iOS, and iPadOS hosts via configuration profiles.
+- Limited activation file uploads for declaration profiles to 1 MB (instead of picking up the config profile limit change of 16 MB) and fixed the profile upload size limit to account for a profile and activation submitted together.

--- a/ee/server/service/mdm.go
+++ b/ee/server/service/mdm.go
@@ -1210,6 +1210,11 @@ func (svc *Service) MDMApplePreassignProfile(ctx context.Context, payload fleet.
 	if err := svc.authz.Authorize(ctx, &fleet.Team{}, fleet.ActionWrite); err != nil {
 		return ctxerr.Wrap(ctx, err)
 	}
+
+	if len(payload.Profile) > int(fleet.MaxProfileSize) {
+		return fleet.NewInvalidArgumentError("profile", fleet.MaxProfileSizeErrMsg)
+	}
+
 	if err := svc.profileMatcher.PreassignProfile(ctx, payload); err != nil {
 		return ctxerr.Wrap(ctx, err, "preassign profile")
 	}

--- a/ee/server/service/mdm_test.go
+++ b/ee/server/service/mdm_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"errors"
@@ -813,5 +814,58 @@ func TestMDMAppleEditedAppleOSUpdatesDeclaration(t *testing.T) {
 				require.Equal(t, p.declName, got.deleted)
 			})
 		}
+	})
+}
+
+// stubProfileMatcher is a minimal fleet.ProfileMatcher for exercising
+// MDMApplePreassignProfile without a real Redis-backed implementation.
+type stubProfileMatcher struct {
+	preassignProfileCalled bool
+}
+
+func (s *stubProfileMatcher) PreassignProfile(ctx context.Context, payload fleet.MDMApplePreassignProfilePayload) error {
+	s.preassignProfileCalled = true
+	return nil
+}
+
+func (s *stubProfileMatcher) RetrieveProfiles(ctx context.Context, externalHostIdentifier string) (fleet.MDMApplePreassignHostProfiles, error) {
+	return fleet.MDMApplePreassignHostProfiles{}, nil
+}
+
+func TestMDMApplePreassignProfileSizeLimit(t *testing.T) {
+	authorizer, err := authz.NewAuthorizer()
+	require.NoError(t, err)
+	ctx := test.UserContext(context.Background(), test.UserAdmin)
+
+	t.Run("oversized profile is rejected", func(t *testing.T) {
+		matcher := &stubProfileMatcher{}
+		svc := &Service{authz: authorizer, profileMatcher: matcher}
+
+		oversized := bytes.Repeat([]byte("a"), int(fleet.MaxProfileSize)+1)
+		err := svc.MDMApplePreassignProfile(ctx, fleet.MDMApplePreassignProfilePayload{
+			ExternalHostIdentifier: "test",
+			HostUUID:               "test",
+			Profile:                oversized,
+		})
+
+		require.Error(t, err)
+		var invalidArg *fleet.InvalidArgumentError
+		require.ErrorAs(t, err, &invalidArg)
+		require.Contains(t, err.Error(), fleet.MaxProfileSizeErrMsg)
+		require.False(t, matcher.preassignProfileCalled, "should reject before reaching the profile matcher")
+	})
+
+	t.Run("profile within the limit is accepted", func(t *testing.T) {
+		matcher := &stubProfileMatcher{}
+		svc := &Service{authz: authorizer, profileMatcher: matcher}
+
+		err := svc.MDMApplePreassignProfile(ctx, fleet.MDMApplePreassignProfilePayload{
+			ExternalHostIdentifier: "test",
+			HostUUID:               "test",
+			Profile:                []byte("<plist></plist>"),
+		})
+
+		require.NoError(t, err)
+		require.True(t, matcher.preassignProfileCalled)
 	})
 }

--- a/server/fleet/request.go
+++ b/server/fleet/request.go
@@ -10,15 +10,15 @@ const (
 	MaxFleetdErrorReportSize int64 = 5 * units.MiB
 	MaxScriptSize            int64 = 1.5 * units.MiB // 1.5 to allow for roughly 1MB content, and B64 encoding
 	MaxBatchScriptSize       int64 = 25 * units.MiB
-	MaxProfileSize           int64 = 1.5 * units.MiB // 1.5 to allow for roughly 1MB content, and B64 encoding
-	MaxBatchProfileSize      int64 = 25 * units.MiB
-	// MaxProfileSizeErrMsg reports the ~1MB content limit that MaxProfileSize
-	// enforces (the extra 0.5 MiB is base64 headroom, not usable content).
-	MaxProfileSizeErrMsg       = "maximum configuration profile file size is 1 MB"
-	MaxMDMAssetSize      int64 = 1.5 * units.MiB // 1.5 to allow for roughly 1MB content, and B64 encoding
-	MaxEULASize          int64 = 25 * units.MiB
-	MaxSoftwareBatchSize int64 = 25 * units.MiB // Takes multiple installers, with scripts and queries
-	MaxMDMCommandSize    int64 = 2 * units.MiB
+	MaxProfileSize           int64 = 16 * units.MB // kept under MEDIUMBLOB's 16,777,215-byte limit to avoid a column migration
+	// MaxProfileSizeBase64Encoded is for endpoints (e.g. preassign) that send the profile base64-encoded in JSON instead of raw multipart
+	MaxProfileSizeBase64Encoded int64 = (3 * MaxProfileSize) / 2
+	MaxBatchProfileSize         int64 = 25 * units.MiB
+	MaxProfileSizeErrMsg              = "Maximum configuration profile file size is 16 MB"
+	MaxMDMAssetSize             int64 = 1.5 * units.MiB // 1.5 to allow for roughly 1MB content, and B64 encoding
+	MaxEULASize                 int64 = 25 * units.MiB
+	MaxSoftwareBatchSize        int64 = 25 * units.MiB // Takes multiple installers, with scripts and queries
+	MaxMDMCommandSize           int64 = 2 * units.MiB
 	// MaxMultiScriptQuerySize, sets a max size for payloads that take multiple scripts and SQL queries.
 	MaxMultiScriptQuerySize int64 = 5 * units.MiB
 	MaxMicrosoftMDMSize     int64 = 2 * units.MiB

--- a/server/fleet/request.go
+++ b/server/fleet/request.go
@@ -15,10 +15,14 @@ const (
 	MaxProfileSizeBase64Encoded int64 = (3 * MaxProfileSize) / 2
 	MaxBatchProfileSize         int64 = 25 * units.MiB
 	MaxProfileSizeErrMsg              = "Maximum configuration profile file size is 16 MB"
-	MaxMDMAssetSize             int64 = 1.5 * units.MiB // 1.5 to allow for roughly 1MB content, and B64 encoding
-	MaxEULASize                 int64 = 25 * units.MiB
-	MaxSoftwareBatchSize        int64 = 25 * units.MiB // Takes multiple installers, with scripts and queries
-	MaxMDMCommandSize           int64 = 2 * units.MiB
+	MaxActivationSize           int64 = 1 * units.MB // activation declarations are small DDM predicates, not profile-sized
+	// MaxProfileRequestBodySize covers a Profile plus an optional Activation in
+	// the same multipart request, with headroom for boundaries and form fields.
+	MaxProfileRequestBodySize int64 = MaxProfileSize + MaxActivationSize + (256 * units.KiB)
+	MaxMDMAssetSize           int64 = 1.5 * units.MiB // 1.5 to allow for roughly 1MB content, and B64 encoding
+	MaxEULASize               int64 = 25 * units.MiB
+	MaxSoftwareBatchSize      int64 = 25 * units.MiB // Takes multiple installers, with scripts and queries
+	MaxMDMCommandSize         int64 = 2 * units.MiB
 	// MaxMultiScriptQuerySize, sets a max size for payloads that take multiple scripts and SQL queries.
 	MaxMultiScriptQuerySize int64 = 5 * units.MiB
 	MaxMicrosoftMDMSize     int64 = 2 * units.MiB

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -70,6 +70,7 @@ const (
 	ActivationUnsupportedManagementErrorMsg = "Activations are only supported for configuration declarations (com.apple.configuration.)."
 	ActivationEmptyFileErrorMsg             = "Activation must contain a declaration. To remove the activation, send an empty activation field."
 	ActivationConflictingPartsErrorMsg      = "Send either an activation file to replace it or an empty activation field to remove it, not both."
+	ActivationTooLargeErrorMsg              = "Maximum activation file size is 1 MB."
 	ActivationsDisabledErrorMsg             = "Custom activations aren't available. Set FLEET_MDM_ALLOW_CUSTOM_ACTIVATIONS=1 on the Fleet server to turn them on."
 )
 

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -3464,7 +3464,7 @@ func (svc *Service) BatchSetMDMAppleProfiles(ctx context.Context, tmID *uint, tm
 	profs := make([]*fleet.MDMAppleConfigProfile, 0, len(profiles))
 	byName, byIdent := make(map[string]bool, len(profiles)), make(map[string]bool, len(profiles))
 	for i, prof := range profiles {
-		if len(prof) > 1024*1024 {
+		if len(prof) > int(fleet.MaxProfileSize) {
 			return ctxerr.Wrap(ctx,
 				fleet.NewInvalidArgumentError(fmt.Sprintf("profiles[%d]", i), fleet.MaxProfileSizeErrMsg),
 			)

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -779,7 +779,7 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	// Deprecated: DELETE /mdm/apple/setup/eula/:token is now deprecated, replaced by the platform agnostic /mdm/setup/eula/:token
 	mdmAppleMW.DELETE("/api/_version_/fleet/mdm/apple/setup/eula/{token}", deleteMDMEULAEndpoint, deleteMDMEULARequest{})
 
-	mdmAppleMW.WithRequestBodySizeLimit(fleet.MaxProfileSize).POST("/api/_version_/fleet/mdm/apple/profiles/preassign", preassignMDMAppleProfileEndpoint, preassignMDMAppleProfileRequest{})
+	mdmAppleMW.WithRequestBodySizeLimit(fleet.MaxProfileSizeBase64Encoded).POST("/api/_version_/fleet/mdm/apple/profiles/preassign", preassignMDMAppleProfileEndpoint, preassignMDMAppleProfileRequest{})
 	mdmAppleMW.POST("/api/_version_/fleet/mdm/apple/profiles/match", matchMDMApplePreassignmentEndpoint, matchMDMApplePreassignmentRequest{})
 
 	// This section handles MDM "assets", specifically for Apple DDM.

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -845,9 +845,9 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 
 	// Deprecated: POST /mdm/profiles is now deprecated, replaced by the
 	// POST /configuration_profiles endpoint.
-	mdmAnyMW.WithRequestBodySizeLimit(fleet.MaxProfileSize).POST("/api/_version_/fleet/mdm/profiles", newMDMConfigProfileEndpoint, newMDMConfigProfileRequest{})
-	mdmAnyMW.WithRequestBodySizeLimit(fleet.MaxProfileSize).POST("/api/_version_/fleet/configuration_profiles", newMDMConfigProfileEndpoint, newMDMConfigProfileRequest{})
-	mdmAnyMW.WithRequestBodySizeLimit(fleet.MaxProfileSize).PATCH("/api/_version_/fleet/configuration_profiles/{profile_uuid}", updateMDMConfigProfileEndpoint, updateMDMConfigProfileRequest{})
+	mdmAnyMW.WithRequestBodySizeLimit(fleet.MaxProfileRequestBodySize).POST("/api/_version_/fleet/mdm/profiles", newMDMConfigProfileEndpoint, newMDMConfigProfileRequest{})
+	mdmAnyMW.WithRequestBodySizeLimit(fleet.MaxProfileRequestBodySize).POST("/api/_version_/fleet/configuration_profiles", newMDMConfigProfileEndpoint, newMDMConfigProfileRequest{})
+	mdmAnyMW.WithRequestBodySizeLimit(fleet.MaxProfileRequestBodySize).PATCH("/api/_version_/fleet/configuration_profiles/{profile_uuid}", updateMDMConfigProfileEndpoint, updateMDMConfigProfileRequest{})
 	// Batch needs to allow being called without any MDM enabled, to support deleting profiles, but will fail later if trying to add
 	ue.WithRequestBodySizeLimit(fleet.MaxBatchProfileSize).POST("/api/_version_/fleet/configuration_profiles/batch", batchModifyMDMConfigProfilesEndpoint, batchModifyMDMConfigProfilesRequest{})
 

--- a/server/service/integration_mdm_profiles_test.go
+++ b/server/service/integration_mdm_profiles_test.go
@@ -2385,7 +2385,7 @@ func (s *integrationMDMTestSuite) TestBatchSetMDMAppleProfiles() {
 	t := s.T()
 	ctx := context.Background()
 
-	bigString := strings.Repeat("a", 1024*1024+1)
+	bigString := strings.Repeat("a", int(fleet.MaxProfileSize)+1)
 
 	// create a new team
 	tm, err := s.ds.NewTeam(ctx, &fleet.Team{Name: "batch_set_mdm_profiles"})
@@ -2410,7 +2410,7 @@ func (s *integrationMDMTestSuite) TestBatchSetMDMAppleProfiles() {
 	// Profile is too big
 	resp := s.Do("POST", "/api/v1/fleet/mdm/apple/profiles/batch", batchSetMDMAppleProfilesRequest{Profiles: [][]byte{[]byte(bigString)}},
 		http.StatusUnprocessableEntity)
-	require.Contains(t, extractServerErrorText(resp.Body), "maximum configuration profile file size is 1 MB")
+	require.Contains(t, extractServerErrorText(resp.Body), "Maximum configuration profile file size is 16 MB")
 
 	// duplicate profile names
 	s.Do("POST", "/api/v1/fleet/mdm/apple/profiles/batch", batchSetMDMAppleProfilesRequest{Profiles: [][]byte{
@@ -5219,12 +5219,12 @@ func (s *integrationMDMTestSuite) TestBatchSetMDMProfiles() {
 	tm, err := s.ds.NewTeam(ctx, &fleet.Team{Name: "batch_set_mdm_profiles"})
 	require.NoError(t, err)
 
-	bigString := strings.Repeat("a", 1024*1024+1)
+	bigString := strings.Repeat("a", int(fleet.MaxProfileSize)+1)
 
 	// Profile is too big
 	resp := s.Do("POST", "/api/v1/fleet/mdm/profiles/batch", batchSetMDMProfilesRequest{Profiles: []fleet.MDMProfileBatchPayload{{Contents: []byte(bigString)}}},
 		http.StatusUnprocessableEntity)
-	require.Contains(t, extractServerErrorText(resp.Body), "Validation Failed: maximum configuration profile file size is 1 MB")
+	require.Contains(t, extractServerErrorText(resp.Body), "Validation Failed: Maximum configuration profile file size is 16 MB")
 
 	// invalid profile (bad mobileconfig)
 	resp = s.Do("POST", "/api/v1/fleet/mdm/profiles/batch", batchSetMDMProfilesRequest{Profiles: []fleet.MDMProfileBatchPayload{
@@ -5538,12 +5538,12 @@ func (s *integrationMDMTestSuite) TestBatchModifyMDMProfiles() {
 	tm, err := s.ds.NewTeam(ctx, &fleet.Team{Name: "batch_set_mdm_profiles"})
 	require.NoError(t, err)
 
-	bigString := strings.Repeat("a", 1024*1024+1)
+	bigString := strings.Repeat("a", int(fleet.MaxProfileSize)+1)
 
 	// Profile is too big
 	resp := s.Do("POST", "/api/latest/fleet/configuration_profiles/batch", batchModifyMDMConfigProfilesRequest{ConfigurationProfiles: []fleet.BatchModifyMDMConfigProfilePayload{{Profile: []byte(bigString)}}},
 		http.StatusUnprocessableEntity)
-	require.Contains(t, extractServerErrorText(resp.Body), "Validation Failed: maximum configuration profile file size is 1 MB")
+	require.Contains(t, extractServerErrorText(resp.Body), "Validation Failed: Maximum configuration profile file size is 16 MB")
 
 	// apply an empty set to no-team
 	s.Do("POST", "/api/latest/fleet/configuration_profiles/batch", batchModifyMDMConfigProfilesRequest{ConfigurationProfiles: nil}, http.StatusNoContent)

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -3396,7 +3396,7 @@ func validateProfiles(profiles map[int]fleet.MDMProfileBatchPayload) error {
 			return fleet.NewInvalidArgumentError("mdm", fmt.Sprintf(`Couldn't edit configuration_profiles. Label %q cannot appear in both include and exclude lists.`, overlap))
 		}
 
-		if len(profile.Contents) > 1024*1024 {
+		if len(profile.Contents) > int(fleet.MaxProfileSize) {
 			return fleet.NewInvalidArgumentError("mdm", fleet.MaxProfileSizeErrMsg)
 		}
 

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -1776,8 +1776,8 @@ func (newMDMConfigProfileRequest) DecodeRequest(ctx context.Context, r *http.Req
 	// determines the profile type.
 	if fhs, ok := r.MultipartForm.File["activation"]; ok && len(fhs) > 0 {
 		decoded.Activation = fhs[0]
-		if decoded.Activation.Size > fleet.MaxProfileSize {
-			return nil, fleet.NewInvalidArgumentError("activation", fleet.MaxProfileSizeErrMsg)
+		if decoded.Activation.Size > fleet.MaxActivationSize {
+			return nil, fleet.NewInvalidArgumentError("activation", ActivationTooLargeErrorMsg)
 		}
 	}
 
@@ -2004,8 +2004,8 @@ func (updateMDMConfigProfileRequest) DecodeRequest(ctx context.Context, r *http.
 		switch {
 		case decoded.Activation.Size == 0:
 			return nil, fleet.NewInvalidArgumentError("activation", ActivationEmptyFileErrorMsg)
-		case decoded.Activation.Size > fleet.MaxProfileSize:
-			return nil, fleet.NewInvalidArgumentError("activation", fleet.MaxProfileSizeErrMsg)
+		case decoded.Activation.Size > fleet.MaxActivationSize:
+			return nil, fleet.NewInvalidArgumentError("activation", ActivationTooLargeErrorMsg)
 		}
 	} else if hasActivationValue {
 		decoded.ActivationSet = true

--- a/server/service/mdm_test.go
+++ b/server/service/mdm_test.go
@@ -2011,6 +2011,13 @@ func TestUpdateMDMConfigProfileDecodeActivationFile(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), ActivationEmptyFileErrorMsg)
 	})
+
+	t.Run("an oversized file is rejected", func(t *testing.T) {
+		oversized := bytes.Repeat([]byte("a"), int(fleet.MaxActivationSize)+1)
+		_, err := updateMDMConfigProfileRequest{}.DecodeRequest(t.Context(), build(t, oversized))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), ActivationTooLargeErrorMsg)
+	})
 }
 
 func TestUpdateMDMConfigProfileDispatch(t *testing.T) {

--- a/server/service/mdm_test.go
+++ b/server/service/mdm_test.go
@@ -1844,7 +1844,7 @@ func TestUpdateMDMConfigProfileDecodeRequest(t *testing.T) {
 			name:        "oversized profile file is rejected",
 			profileUUID: "abc-123",
 			fileContent: oversizedFile,
-			wantErr:     "maximum configuration profile file size is 1 MB",
+			wantErr:     "Maximum configuration profile file size is 16 MB",
 		},
 		{
 			// The only way to say "remove the activation": multipart has no null.
@@ -2805,10 +2805,10 @@ func TestValidateProfiles(t *testing.T) {
 		{
 			name: "Too large profile",
 			profiles: []fleet.MDMProfileBatchPayload{
-				{Name: "hugeprofile", Contents: []byte(strings.Repeat("a", 1024*1024+1))},
+				{Name: "hugeprofile", Contents: []byte(strings.Repeat("a", int(fleet.MaxProfileSize)+1))},
 			},
 			wantErr: true,
-			errMsg:  "validation failed: mdm maximum configuration profile file size is 1 MB",
+			errMsg:  "validation failed: mdm Maximum configuration profile file size is 16 MB",
 		},
 	}
 


### PR DESCRIPTION
I decided not to go above a 16 MB limit, as a database migration would be required (see Claude comment below). Individual font files most likely won't be over 16 MB anyway. This limit would probably only be hit if a user tries to deploy multiple font styles in a single config profile. Two ways that can be solved:

1. Split them up into multiple config profiles.
2. Use a .pkg to deploy the fonts instead.

This also fixes two issues Copilot's review caught. Activations now have their own 1 MB limit instead of sharing the config profile's new 16 MB limit, and the upload size limit now accounts for profile and activation together.

Per Claude:

> Profile content is stored in a `MEDIUMBLOB` column, which can only hold up to ~16MB. Getting to 50MB+ means changing that column to a `LONGBLOB` (holds up to 4GB) via a database migration.
> 
> Above 64MB, extra effort comes from crossing MySQL's default packet-size setting (`max_allowed_packet`, which defaults to 64MB in MySQL 8.0) — above that, you're forcing customers to reconfigure their database, which means documentation and deployment risk.

**Related issue:** Resolves #28516

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.


## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

### Testing Before

<img width="535" height="131" alt="Screenshot 2026-08-20 at 10 51 20" src="https://github.com/user-attachments/assets/9d251776-8d16-4780-be39-0c608cc90adc" />

After increasing `default_max_request_body_size`:

<img width="517" height="59" alt="Screenshot 2026-08-20 at 14 47 43" src="https://github.com/user-attachments/assets/14ae21df-5fbf-4e9a-898a-cc3fefa7595d" />

### Testing After

<img width="539" height="140" alt="Screenshot 2026-08-20 at 13 40 30" src="https://github.com/user-attachments/assets/9221631f-f7df-42ef-b8c6-b50988aff07b" />

After increasing `default_max_request_body_size`:

<img width="530" height="61" alt="Screenshot 2026-08-20 at 13 41 32" src="https://github.com/user-attachments/assets/90b313f1-7d98-4521-8d2e-2abfd617b4fd" />

Tested with [Kaisei Decol](https://fonts.google.com/specimen/Kaisei+Decol).

<img width="713" height="622" alt="Screenshot 2026-08-20 at 13 16 06" src="https://github.com/user-attachments/assets/d63376df-0eef-4463-bc67-44d4e62421c1" />
<img width="499" height="560" alt="Screenshot 2026-08-20 at 13 16 40" src="https://github.com/user-attachments/assets/0832e409-c38b-44a1-94d7-c3cd3e008e0a" />
<img width="762" height="531" alt="Screenshot 2026-08-20 at 13 17 13" src="https://github.com/user-attachments/assets/adacaa5b-c8b1-474c-a0a1-2ed5c7e98d28" />

After removing the config profile, the fonts are automatically removed from the device.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased the maximum configuration profile size from 1 MB to 16 MB for macOS, iOS, and iPadOS profile delivery.
  * Enabled larger profile uploads in supported batch and preassignment workflows.

* **Bug Fixes**
  * Kept activation declaration files limited to 1 MB, with clearer validation messages.
  * Improved handling of requests that include both a configuration profile and activation file.
  * Added validation to reject oversized profiles before processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->