### PR TITLE
Fleet UI: Fix blank actor on failed VPP install activities

### DIFF
--- a/changes/45011-vpp-auto-update-activity-actor
+++ b/changes/45011-vpp-auto-update-activity-actor
@@ -1,0 +1,1 @@
+- Fixed activity feed attributing iPad VPP auto-update installs to an end user or admin instead of Fleet when the install terminally failed after all retries.

--- a/changes/45011-vpp-auto-update-activity-actor
+++ b/changes/45011-vpp-auto-update-activity-actor
@@ -1,1 +1,0 @@
-- Fixed activity feed attributing iPad VPP auto-update installs to an end user or admin instead of Fleet when the install terminally failed after all retries.

--- a/changes/46303-vpp-install-failed-actor-attribution
+++ b/changes/46303-vpp-install-failed-actor-attribution
@@ -1,0 +1,1 @@
+- Fixed activity feed rendering a blank actor for failed iPad VPP installs: auto-update terminal failures now attribute to Fleet, and any install whose initiating admin has since been deleted also renders "Fleet" instead of an empty name.

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tests.tsx
@@ -1981,6 +1981,23 @@ describe("Activity Feed", () => {
     expect(screen.queryByText("Some Admin")).toBeNull();
   });
 
+  it("renders Fleet as actor for a failed VPP install whose initiating admin has been deleted", () => {
+    const activity = createMockActivity({
+      type: ActivityType.InstalledAppStoreApp,
+      actor_full_name: undefined,
+      fleet_initiated: false,
+      details: {
+        software_title: "Google Meet",
+        host_display_name: "iPad",
+        status: "failed_install",
+      },
+    });
+
+    render(<GlobalActivityItem activity={activity} isPremiumTier />);
+    expect(screen.getByText("Fleet")).toBeInTheDocument();
+    expect(screen.getByText(/failed to install/)).toBeInTheDocument();
+  });
+
   it("renders script package ran status in InstalledSoftware activity", () => {
     const activity = createMockActivity({
       type: ActivityType.InstalledSoftware,

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tests.tsx
@@ -1962,6 +1962,25 @@ describe("Activity Feed", () => {
     expect(screen.getByText(/\(self service\)\./)).toBeInTheDocument();
   });
 
+  it("attributes VPP auto-update installs to Fleet even when the payload carries a stale actor", () => {
+    const activity = createMockActivity({
+      type: ActivityType.InstalledAppStoreApp,
+      actor_id: 1,
+      actor_full_name: "Some Admin",
+      fleet_initiated: false,
+      details: {
+        software_title: "Google Meet",
+        host_display_name: "iPad",
+        status: "installed",
+        from_auto_update: true,
+      },
+    });
+
+    render(<GlobalActivityItem activity={activity} isPremiumTier />);
+    expect(screen.getByText("Fleet")).toBeInTheDocument();
+    expect(screen.queryByText("Some Admin")).toBeNull();
+  });
+
   it("renders script package ran status in InstalledSoftware activity", () => {
     const activity = createMockActivity({
       type: ActivityType.InstalledSoftware,

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
@@ -2873,8 +2873,9 @@ const GlobalActivityItem = ({
         if (activity.details?.from_auto_update) return <b>Fleet </b>;
         // A missing actor here means the initiating admin has been deleted
         // since the install was queued (the LEFT JOIN on users returns nil).
-        // Fall back to Fleet so the sentence doesn't render as a blank actor.
-        if (!activity.actor_full_name) return <b>Fleet </b>;
+        // Trim so whitespace-only names also count as missing. Fall back to
+        // Fleet so the sentence doesn't render as a blank actor.
+        if (!activity.actor_full_name?.trim()) return <b>Fleet </b>;
         return DEFAULT_ACTOR_DISPLAY;
       case ActivityType.InstalledAllSelfServiceSoftware:
         // The template carries the "End user" subject for this roll-up.

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
@@ -2871,6 +2871,10 @@ const GlobalActivityItem = ({
         // says otherwise (e.g. legacy rows written before the fleet_initiated
         // flag was wired up).
         if (activity.details?.from_auto_update) return <b>Fleet </b>;
+        // A missing actor here means the initiating admin has been deleted
+        // since the install was queued (the LEFT JOIN on users returns nil).
+        // Fall back to Fleet so the sentence doesn't render as a blank actor.
+        if (!activity.actor_full_name) return <b>Fleet </b>;
         return DEFAULT_ACTOR_DISPLAY;
       case ActivityType.InstalledAllSelfServiceSoftware:
         // The template carries the "End user" subject for this roll-up.

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
@@ -2866,7 +2866,12 @@ const GlobalActivityItem = ({
         // Self-service activities render as a passive-voice sentence in the
         // template (e.g. "<title> was installed on <host> (self-service).")
         // without an actor prefix.
-        return activity.details?.self_service ? null : DEFAULT_ACTOR_DISPLAY;
+        if (activity.details?.self_service) return null;
+        // Auto-update installs are Fleet-initiated even if the stored actor
+        // says otherwise (e.g. legacy rows written before the fleet_initiated
+        // flag was wired up).
+        if (activity.details?.from_auto_update) return <b>Fleet </b>;
+        return DEFAULT_ACTOR_DISPLAY;
       case ActivityType.InstalledAllSelfServiceSoftware:
         // The template carries the "End user" subject for this roll-up.
         return null;

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/InstalledSoftwareActivityItem/InstalledSoftwareActivityItem.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/InstalledSoftwareActivityItem/InstalledSoftwareActivityItem.tests.tsx
@@ -51,4 +51,31 @@ describe("InstalledSoftwareActivityItem", () => {
     expect(screen.getByText(/failed to install/)).toBeInTheDocument();
     expect(screen.queryByText(/skipped install/)).not.toBeInTheDocument();
   });
+
+  it("attributes VPP auto-update installs to Fleet even when the payload carries a stale actor", () => {
+    const activity = createMockHostPastActivity({
+      type: ActivityType.InstalledAppStoreApp,
+      actor_full_name: "Some Admin",
+      fleet_initiated: false,
+      details: {
+        software_title: "Google Meet",
+        host_display_name: "iPad",
+        source: "ipados_apps",
+        status: "installed",
+        command_uuid: "cmd-1",
+        from_auto_update: true,
+      },
+    });
+
+    render(
+      <InstalledSoftwareActivityItem
+        activity={activity}
+        tab="past"
+        onShowDetails={noop}
+      />
+    );
+
+    expect(screen.getByText("Fleet")).toBeInTheDocument();
+    expect(screen.queryByText("Some Admin")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/InstalledSoftwareActivityItem/InstalledSoftwareActivityItem.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/InstalledSoftwareActivityItem/InstalledSoftwareActivityItem.tsx
@@ -26,6 +26,7 @@ const InstalledSoftwareActivityItem = ({
     software_title: title,
     source,
     from_setup_experience,
+    from_auto_update,
   } = details;
   const status =
     details.status === "failed" ? "failed_uninstall" : details.status;
@@ -81,6 +82,12 @@ const InstalledSoftwareActivityItem = ({
       status === "pending_uninstall" ? "will uninstall" : "will install";
   }
 
+  // Auto-update installs are always Fleet-initiated even when the payload
+  // carries a stale actor (e.g. a pre-fix retry that re-attributed to the
+  // admin who set up the schedule). Overriding here keeps rendering consistent
+  // with WasFromAutomation() on the backend.
+  const actor = from_auto_update ? "Fleet" : actorName ?? "Fleet";
+
   return (
     <ActivityItem
       className={baseClass}
@@ -90,8 +97,7 @@ const InstalledSoftwareActivityItem = ({
       onCancel={onCancel}
       isSoloActivity={isSoloActivity}
     >
-      <b>{actorName ?? "Fleet"}</b> {installedSoftwarePrefix} <b>{title}</b> on
-      this host
+      <b>{actor}</b> {installedSoftwarePrefix} <b>{title}</b> on this host
       {from_setup_experience ? " during setup experience" : ""}.
     </ActivityItem>
   );

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/InstalledSoftwareActivityItem/InstalledSoftwareActivityItem.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/InstalledSoftwareActivityItem/InstalledSoftwareActivityItem.tsx
@@ -86,8 +86,9 @@ const InstalledSoftwareActivityItem = ({
   // carries a stale actor (e.g. a pre-fix retry that re-attributed to the
   // admin who set up the schedule). A missing actor means the initiating
   // admin has been deleted since the install was queued (LEFT JOIN on users
-  // returns nil). Both cases render as "Fleet".
-  const actor = from_auto_update || !actorName ? "Fleet" : actorName;
+  // returns nil). Trim so whitespace-only names also count as missing. Both
+  // cases render as "Fleet".
+  const actor = from_auto_update || !actorName?.trim() ? "Fleet" : actorName;
 
   return (
     <ActivityItem

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/InstalledSoftwareActivityItem/InstalledSoftwareActivityItem.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/InstalledSoftwareActivityItem/InstalledSoftwareActivityItem.tsx
@@ -84,9 +84,10 @@ const InstalledSoftwareActivityItem = ({
 
   // Auto-update installs are always Fleet-initiated even when the payload
   // carries a stale actor (e.g. a pre-fix retry that re-attributed to the
-  // admin who set up the schedule). Overriding here keeps rendering consistent
-  // with WasFromAutomation() on the backend.
-  const actor = from_auto_update ? "Fleet" : actorName ?? "Fleet";
+  // admin who set up the schedule). A missing actor means the initiating
+  // admin has been deleted since the install was queued (LEFT JOIN on users
+  // returns nil). Both cases render as "Fleet".
+  const actor = from_auto_update || !actorName ? "Fleet" : actorName;
 
   return (
     <ActivityItem

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -5349,7 +5349,18 @@ func (svc *MDMAppleCheckinAndCommandService) CommandAndReportResults(r *mdm.Requ
 
 				return nil, ctxerr.Wrap(r.Context, err, "fetching data for installed app store app activity")
 			}
+			// Auto-update terminal failures land here (all retries exhausted), so
+			// we need to carry the from_auto_update flag onto the emitted activity
+			// alongside from_setup_experience. Without this, WasFromAutomation()
+			// returns false and the activity is attributed to actor_full_name
+			// instead of Fleet. The success path is handled separately in the
+			// InstalledApplicationList result handler.
+			fromAutoUpdate, err := svc.ds.IsAutoUpdateVPPInstall(r.Context, cmdResult.CommandUUID)
+			if err != nil {
+				return nil, ctxerr.Wrap(r.Context, err, "checking if failed vpp install is from auto update")
+			}
 			act.FromSetupExperience = fromSetupExperience
+			act.FromAutoUpdate = fromAutoUpdate
 			if err := svc.newActivityFn(r.Context, user, act); err != nil {
 				return nil, ctxerr.Wrap(r.Context, err, "creating activity for installed app store app")
 			}

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -5349,6 +5349,9 @@ func (svc *MDMAppleCheckinAndCommandService) CommandAndReportResults(r *mdm.Requ
 
 				return nil, ctxerr.Wrap(r.Context, err, "fetching data for installed app store app activity")
 			}
+			if act == nil {
+				return nil, nil
+			}
 			// Auto-update terminal failures land here (all retries exhausted), so
 			// we need to carry the from_auto_update flag onto the emitted activity
 			// alongside from_setup_experience. Without this, WasFromAutomation()

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -4317,7 +4317,7 @@ func TestMDMCommandAndReportResultsInstallApplicationAutoUpdateFailure(t *testin
 		hostUUID    = "HOST-UUID-AUTO"
 		commandUUID = "CMD-UUID-AUTO"
 	)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	ds := new(mock.Store)
 	var emitted *fleet.ActivityInstalledAppStoreApp

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -4233,6 +4233,9 @@ func TestMDMCommandAndReportResultsInstallApplicationAlreadyInstalled(t *testing
 		ds.MaybeUpdateSetupExperienceVPPStatusFunc = func(_ context.Context, _ string, _ string, _ fleet.SetupExperienceStatusResultStatus) (bool, error) {
 			return false, nil
 		}
+		ds.IsAutoUpdateVPPInstallFunc = func(_ context.Context, _ string) (bool, error) {
+			return false, nil
+		}
 		var activityCmdResult *mdm.CommandResults
 		ds.GetPastActivityDataForVPPAppInstallFunc = func(_ context.Context, c *mdm.CommandResults) (*fleet.User, *fleet.ActivityInstalledAppStoreApp, error) {
 			activityCmdResult = c
@@ -4300,6 +4303,73 @@ func TestMDMCommandAndReportResultsInstallApplicationAlreadyInstalled(t *testing
 		// Verification path NOT entered (status was not promoted).
 		require.False(t, ds.IsHostPendingMDMInstallVerificationFuncInvoked)
 	})
+}
+
+// TestMDMCommandAndReportResultsInstallApplicationAutoUpdateFailure covers the
+// iPad terminal-failure emission path in the InstallApplication handler.
+// Before #45011, this branch called GetPastActivityDataForVPPAppInstall and
+// emitted the activity without ever consulting IsAutoUpdateVPPInstall, so a
+// scheduled auto-update that terminally failed was attributed to actor_full_name
+// instead of Fleet. The InstalledApplicationList success handler already did
+// the right thing; this test locks in parity for the failure path.
+func TestMDMCommandAndReportResultsInstallApplicationAutoUpdateFailure(t *testing.T) {
+	const (
+		hostUUID    = "HOST-UUID-AUTO"
+		commandUUID = "CMD-UUID-AUTO"
+	)
+	ctx := context.Background()
+
+	ds := new(mock.Store)
+	var emitted *fleet.ActivityInstalledAppStoreApp
+	svc := MDMAppleCheckinAndCommandService{
+		ds:     ds,
+		logger: slog.New(slog.DiscardHandler),
+		newActivityFn: func(_ context.Context, _ *fleet.User, act fleet.ActivityDetails) error {
+			// Capture the emitted VPP-install activity so we can assert on the
+			// FromAutoUpdate flag downstream.
+			if a, ok := act.(*fleet.ActivityInstalledAppStoreApp); ok {
+				emitted = a
+			}
+			return nil
+		},
+	}
+
+	ds.GetMDMAppleCommandRequestTypeFunc = func(_ context.Context, cmd string) (string, error) {
+		require.Equal(t, commandUUID, cmd)
+		return "InstallApplication", nil
+	}
+	// Retry-exhausted install so we fall through to the failure-activity emission.
+	ds.GetHostVPPInstallByCommandUUIDFunc = func(_ context.Context, _ string) (*fleet.HostVPPSoftwareInstallLite, error) {
+		return &fleet.HostVPPSoftwareInstallLite{HostID: 1, RetryCount: fleet.MaxSoftwareInstallAttempts}, nil
+	}
+	ds.MaybeUpdateSetupExperienceVPPStatusFunc = func(_ context.Context, _ string, _ string, _ fleet.SetupExperienceStatusResultStatus) (bool, error) {
+		return false, nil
+	}
+	ds.IsAutoUpdateVPPInstallFunc = func(_ context.Context, cmd string) (bool, error) {
+		require.Equal(t, commandUUID, cmd)
+		return true, nil
+	}
+	ds.GetPastActivityDataForVPPAppInstallFunc = func(_ context.Context, _ *mdm.CommandResults) (*fleet.User, *fleet.ActivityInstalledAppStoreApp, error) {
+		return nil, &fleet.ActivityInstalledAppStoreApp{HostID: 1, Status: string(fleet.SoftwareInstallFailed)}, nil
+	}
+
+	_, err := svc.CommandAndReportResults(
+		&mdm.Request{Context: ctx, EnrollID: &mdm.EnrollID{Type: mdm.Device, ID: hostUUID}},
+		&mdm.CommandResults{
+			Enrollment:  mdm.Enrollment{UDID: hostUUID},
+			CommandUUID: commandUUID,
+			Status:      fleet.MDMAppleStatusError,
+			ErrorChain: []mdm.ErrorChain{
+				{ErrorCode: 9610, ErrorDomain: "MCMDMErrorDomain", USEnglishDescription: "Cannot establish a connection."},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	require.True(t, ds.IsAutoUpdateVPPInstallFuncInvoked)
+	require.True(t, ds.GetPastActivityDataForVPPAppInstallFuncInvoked)
+	require.NotNil(t, emitted)
+	require.True(t, emitted.FromAutoUpdate, "auto-update terminal failures must carry FromAutoUpdate so the activity is attributed to Fleet")
 }
 
 func TestMDMBatchSetAppleProfiles(t *testing.T) {


### PR DESCRIPTION
## Issue

Fixes #46303. Related to #45011.

## Description

> Two related Fleet-attribution bugs on the VPP install activity feed. Both showed up while investigating #45011. The literal string on the #45011 screenshot ("An end user installed…") has been unreachable in the codebase since #45659 on 2026-05-18, so that ticket's not what this PR closes. See the comment on #45011 for the full trace.

**#46303 (customer-eponym): failed VPP installs render with a blank actor.** `getPastActivityDataForVPPAppInstallDB` `LEFT JOIN`s on `users`, so when the initiating admin has since been deleted, `user_name` comes back nil, and the activity feed rendered " failed to install X on iPad." with no actor. Frontend now falls back to "Fleet" for InstalledAppStoreApp activities where `actor_full_name` is missing.

**Adjacent iPad auto-update gap.** The iPad `InstallApplication` terminal-failure emission at `server/service/apple_mdm.go` never set `act.FromAutoUpdate`. A scheduled auto-update that failed all retries emitted an activity where `WasFromAutomation()` returned false, `NewActivity` did not set `user_name = "Fleet"` or `fleet_initiated = 1`, and the frontend rendered a blank actor. The success path via `InstalledApplicationList` already set the flag correctly; this PR brings the failure path to parity, and adds a defensive `details.from_auto_update` check in both feeds so pre-4.80 rows without `fleet_initiated=1` also render "Fleet".

## Screenrecording

### When `fleet_initiated` auto update, actor will fill in as "Fleet" and set `fleet_initiated` to true if  `from_auto_update` is true

<img width="793" height="872" alt="Screenshot 2026-08-20 at 5 05 29 PM" src="https://github.com/user-attachments/assets/6a98798a-1e31-432f-a17c-b80d4d79d43d" />

### When `actor_full_name` is missing: defaults to "Fleet"

https://fleetdm.zoom.us/clips/share/a17yBbE_QVywJj4_TNRs7g

<img width="388" height="184" alt="Screenshot 2026-08-24 at 3 07 17 PM" src="https://github.com/user-attachments/assets/2bd4cbd5-7460-471c-bdf4-b2ef85429c5e" />


## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually
- [x] `go test -run TestMDMCommandAndReportResultsInstallApplication ./server/service/`: all pass, incl. new `TestMDMCommandAndReportResultsInstallApplicationAutoUpdateFailure`.
- [x] `yarn test --testPathPattern="InstalledSoftwareActivityItem|GlobalActivityItem"`: 154+3 passing, incl. new regression cases for `from_auto_update` and deleted-admin fallback.
- [x] `make lint-js`: 0 errors, 0 new warnings in touched files.

## Related

Also filed #51661 for the missing "auto-updates enabled" UI indicator on the Software title details page. Out of scope for this PR.

`Related to #45011`: the customer's original screenshot text likely reflects self-service installs, not auto-updates. Awaiting fresh repro before closing that ticket.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved activity attribution for failed VPP app installations.
  * Automatic VPP updates now display “Fleet” instead of a stale or blank actor.
  * Installations initiated by deleted administrators now correctly display “Fleet.”
  * Prevented blank actor labels in software installation activity entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->