### PR TITLE
Retry mysql 1615 errors

### DIFF
--- a/changes/50970-retry-mysql-1615-errors.md
+++ b/changes/50970-retry-mysql-1615-errors.md
@@ -1,0 +1,1 @@
+- Fixed host activity queue getting stuck due to database transactions not retrying when getting MySQL error 1615

--- a/server/platform/mysql/retry.go
+++ b/server/platform/mysql/retry.go
@@ -134,6 +134,8 @@ func RetryableError(err error) bool {
 		// Consider lock related errors to be retryable
 		case mysqlerr.ER_LOCK_DEADLOCK, mysqlerr.ER_LOCK_WAIT_TIMEOUT:
 			return true
+		case mysqlerr.ER_NEED_REPREPARE:
+			return true
 		}
 	}
 	if errors.Is(err, DoRetryErr) {

--- a/server/platform/mysql/retry_test.go
+++ b/server/platform/mysql/retry_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/VividCortex/mysqlerr"
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	gmysql "github.com/go-sql-driver/mysql"
 	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/assert"
@@ -139,6 +141,28 @@ func TestTransactionReadOnlyTriggersFatalError(t *testing.T) {
 			assert.True(t, IsReadOnlyError(err))
 			assert.True(t, handlerCalled.Load())
 			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func TestRetryableError(t *testing.T) {
+	cases := []struct {
+		name      string
+		err       error
+		retryable bool
+	}{
+		{"deadlock", &gmysql.MySQLError{Number: mysqlerr.ER_LOCK_DEADLOCK}, true},
+		{"lock wait timeout", &gmysql.MySQLError{Number: mysqlerr.ER_LOCK_WAIT_TIMEOUT}, true},
+		{"needs reprepare", &gmysql.MySQLError{Number: mysqlerr.ER_NEED_REPREPARE}, true},
+		{"needs reprepare wrapped by the datastore", ctxerr.Wrap(context.Background(), &gmysql.MySQLError{Number: mysqlerr.ER_NEED_REPREPARE}, "activate next activity"), true},
+		{"read only", readOnlyErr(), false},
+		{"duplicate entry", &gmysql.MySQLError{Number: mysqlerr.ER_DUP_ENTRY}, false},
+		{"not a mysql error", errors.New("some other failure"), false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			require.Equal(t, c.retryable, RetryableError(c.err))
 		})
 	}
 }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #50970

Fixes `WithRetryTxx` not retrying 1615 errors, but does not address the `windows_mdm_responses` migration that was failing because it doesn't use `WithRetryTxx`

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually
  - Tested artificially with a test. 
  - I also attempted to use a script to repeatedly run `FLUSH TABLES;` on my instance to artificially create 1615 errors. There were fewer 1615 errors showing up after the fix, but it's still possible:
    - Before: Attempted 5 installs, 29 `1615` errors logged
    - After: Attempted 5 installs, 8 `1615` errors logged

Specifically on the install results endpoint:
```
                    1615 on /api/fleet/orbit/software_install/result
pre-fix                            7
post-fix                           0
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic recovery from MySQL reprepare errors by retrying affected operations.
  * Added support for recognizing reprepare errors even when wrapped with additional error details.
  * Preserved existing handling for deadlocks and lock timeouts while excluding non-retryable errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->