### PR TITLE
Document Android re-enrollment state clearing

### DIFF
--- a/articles/android-mdm-setup.md
+++ b/articles/android-mdm-setup.md
@@ -47,6 +47,19 @@ Now you have managed Google domain with an Android Enterprise subscription. Opti
 
 Learn how to enroll Android hosts in the [enroll hosts guide](https://fleetdm.com/guides/enroll-hosts#ui).
 
+### Re-enrolling Android hosts
+
+An Android host re-enrolls after a wipe, or after an end user removes and re-adds the work profile. When it does, Fleet automatically:
+  - Cancels pending MDM commands
+  - Marks pending software installs as failed
+  - Clears dynamic label membership
+
+Manual, built-in, and host vitals labels stay in place, because they aren't tied to the previous enrollment. The re-enrollment reports the host's disk and operating system vitals again, so Fleet doesn't clear those either.
+
+This means you don't need to delete an Android host from Fleet before re-enrolling it.
+
+Fleet also clears the host's past activities. To keep them, turn on **Preserve host activities on re-enrollment** in **Settings > Organization settings > Advanced options**.
+
 ## Migration
 
 To migrate personal (BYOD) Android hosts from other MDM solution, first unenroll the host from your old solution. Then, share the enrollment page with your end users so they can enroll to Fleet. Unenrolling BYOD hosts will only remove/wipe the work profile (company data). Personal data won't be removed.

--- a/articles/enroll-hosts.md
+++ b/articles/enroll-hosts.md
@@ -170,7 +170,7 @@ In the Google Admin console:
 
 4. Select **Actions > Delete** to delete the host from Fleet.
 
-> Delete the host from Fleet before re-enrolling to clear labels, prevent pending actions, and avoid showing stale vitals. **Apple Business (AB) hosts are the exception**. Fleet automatically clears stale state on re-enrollment, so deletion isn't needed. See the [Apple MDM setup guide](https://fleetdm.com/guides/macos-mdm-setup#re-enrolling-ab-hosts) for details.
+> Delete the host from Fleet before re-enrolling to clear labels, prevent pending actions, and avoid showing stale vitals. **Apple Business (AB) hosts and Android hosts are the exception**. Fleet automatically clears stale state on re-enrollment, so deletion isn't needed. See the [Apple MDM setup guide](https://fleetdm.com/guides/macos-mdm-setup#re-enrolling-ab-hosts) and the [Android MDM setup guide](https://fleetdm.com/guides/android-mdm-setup#re-enrolling-android-hosts) for details.
 
 > The unenroll action on Android hosts sends a wipe command via the Android Management API. [Learn more](https://fleedtdm.com/docs/rest-api/rest-api#turn-off-hosts-mdm)
 

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -948,7 +948,7 @@ org_settings:
 The `activity_expiry_settings` section lets you define how to handle activities.
 - `activity_expiry_enabled` when enabled, allows automatic cleanup of activities (and associated live query data) older than the specified number of days. Activities linked to a host are preserved until the host is deleted.
 - `activity_expiry_window` the number of days to retain activity records, if activity expiry is enabled.
-- `preserve_host_activities_on_reenrollment` When enabled, preserves host activities after a wipe and re-enrollment. Supported for company-owned (AB) Apple hosts and Android hosts. **Delete activities > Max activity age** still applies. (Default: `false` on new Fleet instances. Fleet sets it to `true` when you upgrade an existing instance, so that prior behavior is preserved.)
+- `preserve_host_activities_on_reenrollment` when enabled, preserves host activities after a wipe and re-enrollment. Supported for company-owned (AB) Apple hosts and Android hosts. **Delete activities > Max activity age** still applies. (Default: `false` on new Fleet instances. Fleet sets it to `true` when you upgrade an existing instance, so that prior behavior is preserved.)
 
 #### Example
 

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -948,7 +948,7 @@ org_settings:
 The `activity_expiry_settings` section lets you define how to handle activities.
 - `activity_expiry_enabled` when enabled, allows automatic cleanup of activities (and associated live query data) older than the specified number of days. Activities linked to a host are preserved until the host is deleted.
 - `activity_expiry_window` the number of days to retain activity records, if activity expiry is enabled.
-- `preserve_host_activity_on_reenrollment` When enabled, preserves host activities after a wipe and re-enrollment. Currently only supported for company-owned (AB) Apple hosts. **Delete activities > Max activity age** still applies. (Default: `false`)
+- `preserve_host_activities_on_reenrollment` When enabled, preserves host activities after a wipe and re-enrollment. Supported for company-owned (AB) Apple hosts and Android hosts. **Delete activities > Max activity age** still applies. (Default: `false` on new Fleet instances. Fleet sets it to `true` when you upgrade an existing instance, so that prior behavior is preserved.)
 
 #### Example
 
@@ -957,7 +957,7 @@ org_settings:
   activity_expiry_settings:
     activity_expiry_enabled: true
     activity_expiry_window: 30
-    preserve_host_activity_on_reenrollment: true
+    preserve_host_activities_on_reenrollment: true
 ```
 
 ### org_info

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -1775,7 +1775,7 @@ None.
   "activity_expiry_settings": {
     "activity_expiry_enabled": false,
     "activity_expiry_window": 0,
-    "preserve_host_activity_on_reenrollment": false
+    "preserve_host_activities_on_reenrollment": false
   },
   "features": {
     "enable_host_users": true,
@@ -2166,7 +2166,7 @@ Modifies the Fleet's configuration with the supplied information.
   "activity_expiry_settings": {
     "activity_expiry_enabled": false,
     "activity_expiry_window": 0,
-    "preserve_host_activity_on_reenrollment": false
+    "preserve_host_activities_on_reenrollment": false
   },
   "features": {
     "enable_host_users": true,
@@ -2568,7 +2568,7 @@ Modifies the Fleet's configuration with the supplied information.
 | ---------------------             | ------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | activity_expiry_enabled           | boolean | When enabled, allows automatic cleanup of activities (and associated live report data) older than the specified number of days. Activities linked to a host are preserved until the host is deleted.    |
 | activity_expiry_window            | integer | The number of days to retain activity records, if activity expiry is enabled.                                                     |
-| preserve_host_activity_on_reenrollment | boolean | When enabled, preserves host activities after a wipe and re-enrollment. Currently only supported for company-owned (AB) Apple hosts. **Delete activities > Max activity age** still applies. (Default: `false`) |
+| preserve_host_activities_on_reenrollment | boolean | When enabled, preserves host activities after a wipe and re-enrollment. Supported for company-owned (AB) Apple hosts and Android hosts. **Delete activities > Max activity age** still applies. (Default: `false` on new Fleet instances. Fleet sets it to `true` when you upgrade an existing instance, so that prior behavior is preserved.) |
 
 <br/>
 
@@ -2579,7 +2579,7 @@ Modifies the Fleet's configuration with the supplied information.
   "activity_expiry_settings": {
     "activity_expiry_enabled": true,
     "activity_expiry_window": 90,
-    "preserve_host_activity_on_reenrollment": true,
+    "preserve_host_activities_on_reenrollment": true,
   }
 }
 ```

--- a/frontend/pages/admin/OrgSettingsPage/cards/Advanced/components/ActivityDataRetentionSection/ActivityDataRetentionSection.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Advanced/components/ActivityDataRetentionSection/ActivityDataRetentionSection.tsx
@@ -99,8 +99,8 @@ const ActivityDataRetentionSection = ({
               !disableChildren && (
                 <>
                   When enabled, preserves host activities after a wipe and
-                  re-enrollment. Currently only supported for company-owned (AB)
-                  Apple hosts.{" "}
+                  re-enrollment. Supported for company-owned (AB) Apple hosts
+                  and Android hosts.{" "}
                   <strong>Delete activities &gt; Max activity age </strong>
                   still applies.
                   <br />


### PR DESCRIPTION
**Related issue:** Resolves #50175

Documentation half of #43500. The backend landed in #51290 (merged as 64fd304), so the docs that told admins to work around the old behavior are now wrong.

#50175 predicted "no changes" for every reference-doc item. Three of them were wrong.

## Guides

`articles/enroll-hosts.md` named Apple Business hosts as the *only* exception to "delete the host from Fleet before re-enrolling". That deletion workaround is exactly what #43500 set out to remove for Android, so the note now names Android too and links to a new section.

`articles/android-mdm-setup.md` gains "Re-enrolling Android hosts", mirroring the "Re-enrolling AB hosts" section in the Apple guide. It states what the merged code actually does, which differs from the #50174 spec in three places:

- Only **dynamic** label membership is cleared. Manual, built-in, and host vitals membership are kept (`android.go`: `label_membership_type = Dynamic AND label_type != BuiltIn`).
- Host vitals are **not** cleared. The enrollment overwrites them, and deleting first is unsafe against a read replica.
- Pending installs are marked **failed**, not canceled, so the record stays visible in the host software list and the activity feed.

## Reference docs

No endpoints were added or modified. The `activity_expiry_settings` field description was inaccurate, in both `docs/REST API/rest-api.md` and `docs/Configuration/yaml-files.md`. It claimed the setting was "Currently only supported for company-owned (AB) Apple hosts", which Android now also honors.

**Two pre-existing errors are fixed on those same lines**, called out because they are not strictly Android work:

1. The key was documented as `preserve_host_activity_on_reenrollment`. The real key is `preserve_host_activities_on_reenrollment` (plural), per `server/fleet/app.go:1498`. There is no singular alias, so the documented name never worked.
2. The default was documented as a flat `false`. Migration `20260522195224` sets it from `usersCount > 0`, so it is `false` on a fresh install and `true` on an upgrade.

## Fleet UI

The tooltip in **Settings > Organization settings > Advanced options** carried the same "AB Apple hosts only" claim, so it is updated to match. This is the only non-docs file here; flagging it since it pulls frontend reviewers onto a docs branch.

Left alone: the tooltip still reads "(Default: Off)". Expanding the upgrade-vs-fresh nuance inside a tooltip seemed worse than the imprecision, but happy to change it if product disagrees.

## Confirmed as needing no changes

- **Audit log reference.** No new activity types. The reset emits the existing `installed_app_store_app` activity with `status: failed_install`, via `markAllPendingVPPInstallsAsFailedForHost`.
- **Usage statistics.** No new toggle.
- **Contributor API, permissions, GitOps generation.** Unaffected.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

Not applicable. The user-visible change shipped with #51290, which carries `changes/43500-clear-state-on-android-reenrollment`. This PR only corrects documentation.

## Testing

- [x] Added/updated automated tests

Not applicable, no logic changes. Nothing asserts the tooltip string. `prettier --check` passes on the modified `.tsx`.

- [ ] QA'd all new/changed functionality manually

Every documented behavior was verified by reading the merged implementation (`server/datastore/mysql/android.go`, `server/mdm/android/service/pubsub.go` at 64fd304) rather than by running a device. On-device QA is tracked in #50175 and still outstanding; it needs two Android devices on a server with Android MDM.

## Merge note

`docs/REST API/rest-api.md` has a pre-existing conflict between `docs-v4.92.0` and `main`, in the Microsoft Graph endpoints section. A trial merge of this branch produces the identical conflict as a trial merge of untouched `docs-v4.92.0`, so this PR does not add one. The edited lines are byte-identical on both branches.
