### PR TITLE
Fix flaky TestRotator race on cached mtime

### DIFF
--- a/orbit/pkg/token/readwriter_test.go
+++ b/orbit/pkg/token/readwriter_test.go
@@ -154,8 +154,18 @@ func TestRotator(t *testing.T) {
 	stop1 := rw.StartRotation()
 	stop2 := rw.StartRotation()
 
-	time.Sleep(150 * time.Millisecond)
-	require.Equal(t, int32(1), atomic.LoadInt32(&numUpdates)) // Atomic read
+	// Wait for the first rotation to complete.
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt32(&numUpdates) >= 1
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// Wait for the rotation's Write() to fully complete — mtime will
+	// be set to "now" by readFile() at the end of Write(). Without
+	// this, setting mtime to -2h below can be clobbered by the
+	// still-in-flight Write().
+	require.Eventually(t, func() bool {
+		return time.Since(rw.GetMtime()) < 30*time.Second
+	}, 5*time.Second, 10*time.Millisecond)
 
 	// Close the first stop channel, this should not stop the rotation.
 	stop1()
@@ -167,9 +177,10 @@ func TestRotator(t *testing.T) {
 	rw.mtime = time.Now().Add(-2 * time.Hour)
 	rw.mu.Unlock()
 
-	// Now wait enough time for the remote check to trigger a rotation.
-	time.Sleep(209 * time.Millisecond)
-	require.Equal(t, int32(2), atomic.LoadInt32(&numUpdates))      // Atomic read
+	// Wait for the second rotation.
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt32(&numUpdates) >= 2
+	}, 5*time.Second, 10*time.Millisecond)
 	require.Equal(t, int32(1), atomic.LoadInt32(&numRemoteChecks)) // Atomic read
 
 	// Reset the mtime one more time.


### PR DESCRIPTION
**Related issue:** Closes #45234

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- ~Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.~
  Not applicable (test-only change, no user-visible behavior change).

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops

## Testing

- [x] Added/updated automated tests

### Reproduction

On the original code, `go test -run TestRotator -count=100 ./orbit/pkg/token/` fails intermittently. On the fixed code, 100/100 pass consistently.

### What changed (test-only, no production code)

`TestRotator` races with in-flight `Rotate()`/`Write()` on the cached `mtime` field. `Write()` calls `remoteUpdate` first (incrementing `numUpdates`), then continues with file I/O that updates `mtime`. The test used `numUpdates` as a signal that rotation was complete, but the trailing `readFile()` in `Write()` could clobber the test's `-2h` mtime assignment with "now", preventing the next rotation from triggering.

Fixed by replacing fragile `time.Sleep` + `require.Equal` with:
- `require.Eventually` polling for `numUpdates` to reach the target value
- A second `require.Eventually` waiting for `mtime` to become recent, confirming `Write()` fully completed before the test sets mtime back to `-2h`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved rotation test reliability by waiting for asynchronous events instead of relying on fixed delays.
  * Added checks to ensure writes complete before subsequent rotation scenarios are evaluated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->