### PR TITLE
Show policies tab on my device page for Fleet free

### DIFF
--- a/ee/server/service/devices.go
+++ b/ee/server/service/devices.go
@@ -15,16 +15,6 @@ import (
 	"github.com/fleetdm/fleet/v4/server/ptr"
 )
 
-func (svc *Service) ListDevicePolicies(ctx context.Context, host *fleet.Host) ([]*fleet.DevicePolicy, error) {
-	policies, err := svc.ds.ListPoliciesForHost(ctx, host)
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "list policies for host")
-	}
-	// return the device-safe representation of the policies, which excludes
-	// the policy author's identity and the raw SQL query.
-	return fleet.HostPoliciesToDevicePolicies(policies), nil
-}
-
 // TriggerMigrateMDMDevice triggers the webhook associated with the MDM
 // migration to Fleet configuration. It is located in the ee package instead of
 // the server/webhooks one because it is a Fleet Premium only feature and for

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -104,6 +104,7 @@ const PREMIUM_TAB_PATHS = [
 const FREE_TAB_PATHS = [
   PATHS.DEVICE_USER_DETAILS,
   PATHS.DEVICE_USER_DETAILS_SOFTWARE,
+  PATHS.DEVICE_USER_DETAILS_POLICIES,
 ] as const;
 
 const DEFAULT_CERTIFICATES_PAGE_SIZE = 10;
@@ -761,13 +762,11 @@ const DeviceUserPage = ({
                     <TabText>Software</TabText>
                   </Tab>
                 )}
-                {isPremiumTier && (
-                  <Tab>
-                    <TabText count={failingPoliciesCount} countVariant="alert">
-                      Policies
-                    </TabText>
-                  </Tab>
-                )}
+                <Tab>
+                  <TabText count={failingPoliciesCount} countVariant="alert">
+                    Policies
+                  </TabText>
+                </Tab>
               </TabList>
               {isPremiumTier && isSoftwareEnabled && hasSelfService && (
                 <TabPanel>
@@ -843,24 +842,22 @@ const DeviceUserPage = ({
                   />
                 </TabPanel>
               )}
-              {isPremiumTier && (
-                <TabPanel>
-                  <PoliciesCard
-                    policies={host?.policies || []}
-                    isLoading={isLoadingDupDetails}
-                    deviceUser
-                    togglePolicyDetailsModal={togglePolicyDetailsModal}
-                    closePolicyDetailsModal={onCancelPolicyDetailsModal}
-                    hostPlatform={host?.platform || ""}
-                    conditionalAccessEnabled={
-                      globalConfig?.features?.enable_conditional_access
-                    }
-                    conditionalAccessBypassed={
-                      host?.conditional_access_bypassed
-                    }
-                  />
-                </TabPanel>
-              )}
+              <TabPanel>
+                <PoliciesCard
+                  policies={host?.policies || []}
+                  isLoading={isLoadingDupDetails}
+                  deviceUser
+                  togglePolicyDetailsModal={togglePolicyDetailsModal}
+                  closePolicyDetailsModal={onCancelPolicyDetailsModal}
+                  hostPlatform={host?.platform || ""}
+                  conditionalAccessEnabled={
+                    globalConfig?.features?.enable_conditional_access
+                  }
+                  conditionalAccessBypassed={
+                    host?.conditional_access_bypassed
+                  }
+                />
+              </TabPanel>
             </Tabs>
           </TabNav>
           {showEnrollMdmModal && host.dep_assigned_to_fleet ? (

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -853,9 +853,7 @@ const DeviceUserPage = ({
                   conditionalAccessEnabled={
                     globalConfig?.features?.enable_conditional_access
                   }
-                  conditionalAccessBypassed={
-                    host?.conditional_access_bypassed
-                  }
+                  conditionalAccessBypassed={host?.conditional_access_bypassed}
                 />
               </TabPanel>
             </Tabs>

--- a/server/service/devices.go
+++ b/server/service/devices.go
@@ -144,7 +144,7 @@ func getDeviceHostEndpoint(ctx context.Context, request interface{}, svc fleet.S
 	// must still load the full host details, as it returns more information
 	opts := fleet.HostDetailOptions{
 		IncludeCVEScores: false,
-		IncludePolicies:  false,
+		IncludePolicies:  true,
 		ExcludeSoftware:  req.ExcludeSoftware,
 	}
 	hostDetails, err := svc.GetHost(ctx, host.ID, opts)
@@ -506,11 +506,15 @@ func listDevicePoliciesEndpoint(ctx context.Context, request interface{}, svc fl
 }
 
 func (svc *Service) ListDevicePolicies(ctx context.Context, host *fleet.Host) ([]*fleet.DevicePolicy, error) {
-	// skipauth: No authorization check needed due to implementation returning
-	// only license error.
+	// skipauth: Authorization is not required. The host is authenticated via
+	// its device token, and the response only contains device-safe policy data.
 	svc.authz.SkipAuthorization(ctx)
 
-	return nil, fleet.ErrMissingLicense
+	policies, err := svc.ds.ListPoliciesForHost(ctx, host)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "list policies for host")
+	}
+	return fleet.HostPoliciesToDevicePolicies(policies), nil
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/server/service/integration_desktop_test.go
+++ b/server/service/integration_desktop_test.go
@@ -161,12 +161,12 @@ func (s *integrationTestSuite) TestDeviceAuthenticatedEndpoints() {
 	require.NotNil(t, getHostResp.License)
 	require.Equal(t, getHostResp.License.Tier, "free")
 
-	// device policies are not accessible for free endpoints
+	// device policies are accessible for free endpoints
 	listPoliciesResp := listDevicePoliciesResponse{}
-	res = s.DoRawNoAuth("GET", "/api/latest/fleet/device/"+token+"/policies", nil, http.StatusPaymentRequired)
-	require.NoError(t, json.NewDecoder(res.Body).Decode(&getHostResp))
+	res = s.DoRawNoAuth("GET", "/api/latest/fleet/device/"+token+"/policies", nil, http.StatusOK)
+	require.NoError(t, json.NewDecoder(res.Body).Decode(&listPoliciesResp))
 	require.NoError(t, res.Body.Close())
-	require.Nil(t, listPoliciesResp.Policies)
+	require.NotNil(t, listPoliciesResp.Policies)
 
 	// /device/desktop is not accessible for free endpoints
 	getDesktopResp := fleetDesktopResponse{}

--- a/server/service/integration_desktop_test.go
+++ b/server/service/integration_desktop_test.go
@@ -82,7 +82,7 @@ func (s *integrationTestSuite) TestDeviceAuthenticatedEndpoints() {
 	require.False(t, getHostResp.Host.RefetchRequested)
 	require.Equal(t, "http://example.com/logo", getHostResp.OrgLogoURL)
 	require.Equal(t, "http://example.com/contact", getHostResp.OrgContactURL)
-	require.Nil(t, getHostResp.Host.Policies)
+	require.NotNil(t, getHostResp.Host.Policies)
 	require.NotNil(t, getHostResp.Host.Batteries)
 	require.Equal(t, &fleet.HostBattery{CycleCount: 1, Health: "Normal"}, (*getHostResp.Host.Batteries)[0])
 	require.True(t, getHostResp.GlobalConfig.MDM.EnabledAndConfigured)


### PR DESCRIPTION
**Related issue:** Resolves #44945

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

## Reproduction

On a local Fleet instance running on **free tier**:

1. Navigate to `https://localhost:8082/device/{token}` (my device page)
2. **Before fix**: only "Details" and "Software" tabs are shown; "Policies" tab is missing
3. **After fix**: "Policies" tab appears alongside Details and Software, with failing policy count badge

### After fix (Fleet free, my device page)

<img width="1671" height="703" alt="My device page on Fleet free showing Details, Software, and Policies tabs with 1 failing policy badge" src="https://github.com/user-attachments/assets/93814e49-3358-4300-a787-2ed8ef506d1c" />

## Changes

**Backend** (`server/service/devices.go`):
- Set `IncludePolicies: true` in the device host endpoint so policies are returned in the response
- Moved `ListDevicePolicies` implementation from `ee/server/service/devices.go` to core, so the separate `/device/{token}/policies` API endpoint also works on free tier

**Frontend** (`DeviceUserPage.tsx`):
- Added `PATHS.DEVICE_USER_DETAILS_POLICIES` to `FREE_TAB_PATHS`
- Removed `isPremiumTier` conditional guard from the Policies tab header and panel

**Tests** (`integration_desktop_test.go`):
- Updated free-tier device test to expect 200 OK (was 402 Payment Required) from the policies endpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Device users on the free tier can now access the Policies tab and view policy details.
  * Device information now includes applicable host policies.
* **Bug Fixes**
  * The device policies endpoint now returns policy data successfully instead of reporting that the feature is unavailable.
  * Policy counts, details, and conditional-access behavior continue to display correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->