### PR TITLE
Update placeholder value in build-configuration-profiles-with-ai article

### DIFF
--- a/articles/build-configuration-profiles-with-ai.md
+++ b/articles/build-configuration-profiles-with-ai.md
@@ -161,7 +161,7 @@ Ask for the reasoning when the answer matters. "Check whether a DDM equivalent e
 
 Three contour behaviors are worth knowing, because each one turns a wrong input into a passing result:
 
-- **`--set` does not set payload fields.** It substitutes `{{placeholder}}` variables declared by a recipe. Passing `--set minLength=12` is accepted, silently dropped, and the profile still reports that schema validation passed. Field values belong in a recipe's `[profile.fields]` table. The scaffold lists optional fields as comments directly under `[[profile]]`, and keys left in that position are ignored the same way.
+- **`--set` does not set payload fields.** It substitutes <span v-pre>`{{placeholder}}`</span> variables declared by a recipe. Passing `--set minLength=12` is accepted, silently dropped, and the profile still reports that schema validation passed. Field values belong in a recipe's `[profile.fields]` table. The scaffold lists optional fields as comments directly under `[[profile]]`, and keys left in that position are ignored the same way.
 - **Validation without `--strict` accepts unknown keys.** An invented key is written into the profile and validation exits `0`. See step 5.
 - **DDM identifiers collide.** Contour derives an `Identifier` from the last component of the declaration type, so `passcode.settings` and `softwareupdate.settings` both produce `com.acme.settings`. Two declarations sharing one is a silent overwrite.
 


### PR DESCRIPTION
Changes:
- Wrapped a placeholder value in the "Build and validate configuration profiles with AI instead of a GUI" article in a `<span>` with `v-pre` to prevent the placeholder from being interpreted as a Vue template when rendered as HTML