### PR TITLE
Fix Windows reinstallation failure when MSI source is unavailable 

### DIFF
--- a/docs/solutions/windows/scripts/uninstall-fleetd-windows.ps1
+++ b/docs/solutions/windows/scripts/uninstall-fleetd-windows.ps1
@@ -87,16 +87,24 @@ function Force-Remove-Orbit {
 
     #Remove MSI product registration to prevent stale source path errors (error 1612)
     #when the original install source (e.g. a network share) is no longer available.
+    $packedGuids = @()
     Get-ChildItem "HKLM:\SOFTWARE\Classes\Installer\Products" -ErrorAction "SilentlyContinue" | ForEach-Object {
-      $productName = $_.GetValue("ProductName")
-      if ($productName -eq "Fleet osquery") {
-        $packedGuid = $_.PSChildName
+      if ($_.GetValue("ProductName") -eq "Fleet osquery") {
+        $packedGuids += $_.PSChildName
         Remove-Item $_.PSPath -Recurse -Force -ErrorAction "SilentlyContinue"
-        #Also remove from per-user installer data
-        Get-ChildItem "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData" -ErrorAction "SilentlyContinue" | ForEach-Object {
-          $productPath = Join-Path $_.PSPath "Products\$packedGuid"
-          if (Test-Path $productPath) {
-            Remove-Item $productPath -Recurse -Force -ErrorAction "SilentlyContinue"
+      }
+    }
+    #Also scan UserData directly in case the Products key was already removed by a previous run
+    Get-ChildItem "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData" -ErrorAction "SilentlyContinue" | ForEach-Object {
+      $productsPath = Join-Path $_.PSPath "Products"
+      if (Test-Path $productsPath) {
+        Get-ChildItem $productsPath -ErrorAction "SilentlyContinue" | ForEach-Object {
+          $instProps = Join-Path $_.PSPath "InstallProperties"
+          if ((Test-Path $instProps) -and ((Get-ItemProperty $instProps -ErrorAction "SilentlyContinue").DisplayName -eq "Fleet osquery")) {
+            $packedGuids += $_.PSChildName
+          }
+          if ($packedGuids -contains $_.PSChildName) {
+            Remove-Item $_.PSPath -Recurse -Force -ErrorAction "SilentlyContinue"
           }
         }
       }

--- a/docs/solutions/windows/scripts/uninstall-fleetd-windows.ps1
+++ b/docs/solutions/windows/scripts/uninstall-fleetd-windows.ps1
@@ -85,6 +85,23 @@ function Force-Remove-Orbit {
       }
     }
 
+    #Remove MSI product registration to prevent stale source path errors (error 1612)
+    #when the original install source (e.g. a network share) is no longer available.
+    Get-ChildItem "HKLM:\SOFTWARE\Classes\Installer\Products" -ErrorAction "SilentlyContinue" | ForEach-Object {
+      $productName = $_.GetValue("ProductName")
+      if ($productName -eq "Fleet osquery") {
+        $packedGuid = $_.PSChildName
+        Remove-Item $_.PSPath -Recurse -Force -ErrorAction "SilentlyContinue"
+        #Also remove from per-user installer data
+        Get-ChildItem "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData" -ErrorAction "SilentlyContinue" | ForEach-Object {
+          $productPath = Join-Path $_.PSPath "Products\$packedGuid"
+          if (Test-Path $productPath) {
+            Remove-Item $productPath -Recurse -Force -ErrorAction "SilentlyContinue"
+          }
+        }
+      }
+    }
+
     # Write success log
     "Fleetd successfully removed at $(Get-Date)" | Out-File -Append -FilePath "$env:TEMP\fleet_remove_log.txt"
   }

--- a/orbit/changes/48715-msi-cleanup
+++ b/orbit/changes/48715-msi-cleanup
@@ -1,0 +1,1 @@
+Fixed an issue where Windows hosts installed from a network path could not be uninstalled or reinstalled when the original source was unavailable.

--- a/orbit/pkg/packaging/windows_templates.go
+++ b/orbit/pkg/packaging/windows_templates.go
@@ -598,22 +598,6 @@ function Force-Remove-Orbit {
       }
     }
 
-    #Remove MSI product registration to prevent stale source path errors (error 1612)
-    #when the original install source (e.g. a network share) is no longer available.
-    Get-ChildItem "HKLM:\SOFTWARE\Classes\Installer\Products" -ErrorAction "SilentlyContinue" | ForEach-Object {
-      $productName = $_.GetValue("ProductName")
-      if ($productName -eq "Fleet osquery") {
-        $packedGuid = $_.PSChildName
-        Remove-Item $_.PSPath -Recurse -Force -ErrorAction "SilentlyContinue"
-        #Also remove from per-user installer data
-        Get-ChildItem "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData" -ErrorAction "SilentlyContinue" | ForEach-Object {
-          $productPath = Join-Path $_.PSPath "Products\$packedGuid"
-          if (Test-Path $productPath) {
-            Remove-Item $productPath -Recurse -Force -ErrorAction "SilentlyContinue"
-          }
-        }
-      }
-    }
   }
   catch {
     Write-Host "There was a problem running Force-Remove-Orbit" -ForegroundColor Red

--- a/orbit/pkg/packaging/windows_templates.go
+++ b/orbit/pkg/packaging/windows_templates.go
@@ -597,7 +597,6 @@ function Force-Remove-Orbit {
         return
       }
     }
-
   }
   catch {
     Write-Host "There was a problem running Force-Remove-Orbit" -ForegroundColor Red

--- a/orbit/pkg/packaging/windows_templates.go
+++ b/orbit/pkg/packaging/windows_templates.go
@@ -597,6 +597,23 @@ function Force-Remove-Orbit {
         return
       }
     }
+
+    #Remove MSI product registration to prevent stale source path errors (error 1612)
+    #when the original install source (e.g. a network share) is no longer available.
+    Get-ChildItem "HKLM:\SOFTWARE\Classes\Installer\Products" -ErrorAction "SilentlyContinue" | ForEach-Object {
+      $productName = $_.GetValue("ProductName")
+      if ($productName -eq "Fleet osquery") {
+        $packedGuid = $_.PSChildName
+        Remove-Item $_.PSPath -Recurse -Force -ErrorAction "SilentlyContinue"
+        #Also remove from per-user installer data
+        Get-ChildItem "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData" -ErrorAction "SilentlyContinue" | ForEach-Object {
+          $productPath = Join-Path $_.PSPath "Products\$packedGuid"
+          if (Test-Path $productPath) {
+            Remove-Item $productPath -Recurse -Force -ErrorAction "SilentlyContinue"
+          }
+        }
+      }
+    }
   }
   catch {
     Write-Host "There was a problem running Force-Remove-Orbit" -ForegroundColor Red


### PR DESCRIPTION
**Related issue:** Resolves https://github.com/fleetdm/fleet/issues/48715

## Summary

When Fleet is installed from a network/UNC path and the cached MSI in `C:\Windows\Installer\` is later removed (by disk cleanup, antivirus, Storage Sense, etc.), Windows cannot uninstall, repair, or reinstall Fleet because it tries to resolve the original source path which is no longer available. This results in **error 1612** ("The installation source for this product is not available").

The existing `uninstall-fleetd-windows.ps1` script and the embedded `installer_utils.ps1` both clean up the service, files, and `Uninstall` registry entries, but leave behind the **MSI product registration** in `HKLM:\SOFTWARE\Classes\Installer\Products\` and `HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\`. This ghost registration causes fresh installs to trigger the upgrade path, which then fails trying to access the dead network source.

## Changes

Adds MSI product registration cleanup to `Force-Remove-Orbit` in both:
- `docs/solutions/windows/scripts/uninstall-fleetd-windows.ps1` (standalone script)
- `orbit/pkg/packaging/windows_templates.go` (embedded `installer_utils.ps1`)

The new code searches `HKLM:\SOFTWARE\Classes\Installer\Products` for entries with `ProductName = "Fleet osquery"`, removes them, and also removes the corresponding entries from `HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\*\Products\`.

## How to reproduce

Tested on a **Windows 11 ARM VM** (NT 10.0.26200.0) via SSH.

### Step 1: Install Fleet from a network share (UNC path)

```powershell
# Create a local SMB share to simulate network install
New-Item -ItemType Directory -Path "C:\FleetShare" -Force
Copy-Item "C:\Users\Sharon\Downloads\fleet-osquery.msi" "C:\FleetShare\"
New-SmbShare -Name "FleetMSI" -Path "C:\FleetShare" -FullAccess "Everyone"

# Install from UNC path
msiexec /i "\\localhost\FleetMSI\fleet-osquery.msi" /quiet /norestart
```

Verified install source is the UNC path:
```
Name          Version InstallSource
----          ------- -------------
Fleet osquery 1.54.0  \\localhost\FleetMSI\
```

### Step 2: Simulate the failure conditions

```powershell
# Stop the service so we can remove the cached MSI
Stop-Service "Fleet osquery" -Force
Stop-Process -Name orbit -Force

# Remove cached MSI from C:\Windows\Installer\ (simulates disk cleanup/AV/Storage Sense)
# In our case it was C:\Windows\Installer\1ce3a86.msi (27MB)
Remove-Item "C:\Windows\Installer\1ce3a86.msi" -Force

# Remove the network share (simulates network path becoming unavailable)
Remove-SmbShare -Name "FleetMSI" -Force
Remove-Item -Path "C:\FleetShare" -Recurse -Force
```

### Step 3: Confirm the bug - uninstall fails with error 1612

```powershell
msiexec /x "{036C5F80-1E6A-48DA-AF2E-DCD1E3A67F88}" /quiet /norestart /l*v msi_uninstall.log
# Exit code: 1612
```

MSI log shows the source resolution failure:
```
SOURCEMGMT: Attempting to use LastUsedSource from source list.
SOURCEMGMT: Trying source C:\Users\Sharon\Downloads\.
SOURCEMGMT: Source is invalid due to missing/inaccessible package.
SOURCEMGMT: Processing net source list.
SOURCEMGMT: Trying source \\localhost\FleetMSI\.
ConnectToSource: CreatePath/CreateFilePath failed with: -2147483648 1314 -2147483648
SOURCEMGMT: net source '\\localhost\FleetMSI\' is invalid.
SOURCEMGMT: Processing media source list.
SOURCEMGMT: Source is invalid due to missing/inaccessible package.
SOURCEMGMT: Processing URL source list.
SOURCEMGMT: Failed to resolve source
MainEngineThread is returning 1612
```

Repair also fails with the same error:
```powershell
msiexec /fa "{036C5F80-1E6A-48DA-AF2E-DCD1E3A67F88}" /quiet /norestart
# Exit code: 1612
```

### Step 4: Confirm the uninstall script leaves ghost registration

After running the existing `Force-Remove-Orbit` logic (service deleted, `C:\Program Files\Orbit` removed, Uninstall registry cleaned), the MSI product registration is still present:

```
STILL REGISTERED: Fleet osquery at HKLM:\SOFTWARE\Classes\Installer\Products\08F5C630A6E1AD84FAE2CD1D3E6AF788
```

## How the fix was tested

### Step 5: Apply the fix and verify

Ran the updated `Force-Remove-Orbit` with the new MSI cleanup code:

```
=== NEW: Cleaning MSI product registration ===
Removed MSI product registration: 08F5C630A6E1AD84FAE2CD1D3E6AF788
Removed installer UserData: HKLM:\...\Installer\UserData\S-1-5-18\Products\08F5C630A6E1AD84FAE2CD1D3E6AF788

=== Verification ===
Ghost MSI registration exists: False (should be False)
```

Fresh install now succeeds:

```
=== Fresh install after fix ===
Install exit code: 0 (should be 0)
SUCCESS: Fleet osquery 1.54.0 installed from C:\Users\Sharon\Downloads\
```

> **Note on screenshots:** All reproduction and testing was done via SSH to a Windows VM. The evidence is command-line output and MSI log entries, where text output is more precise than terminal screenshots.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] QA'd all new/changed functionality manually

## fleetd/orbit/Fleet Desktop

- [x] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [x] Verified that fleetd runs on macOS, Linux and Windows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows uninstallation and reinstallation for hosts installed from network paths when the original installation source is unavailable.
  - Improved removal of lingering Fleet osquery installer data from machine-wide and per-user Windows records.
  - Uninstallation now identifies matching products more reliably and continues gracefully when some registry entries cannot be removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->