### PR TITLE
Website: Update input validation in create-license-key helper.

### DIFF
--- a/website/api/helpers/create-license-key.js
+++ b/website/api/helpers/create-license-key.js
@@ -12,6 +12,7 @@ module.exports = {
     numberOfHosts: {
       type: 'number',
       required: true,
+      min: 1,
     },
 
     organization: {


### PR DESCRIPTION
Changes:
- added `min: 1` to the numberOfHosts input in the createLicenseKey helper

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * License-key creation now requires at least one host, preventing invalid zero or negative host counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->