### PR TITLE
Fix dark mode background color on authentication pages

### DIFF
--- a/changes/fix-dark-mode-auth-card-bg
+++ b/changes/fix-dark-mode-auth-card-bg
@@ -1,0 +1,1 @@
+- Fixed incorrect background color on authentication pages (login, SSO, registration) in dark mode.

--- a/frontend/components/AuthenticationFormWrapper/_styles.scss
+++ b/frontend/components/AuthenticationFormWrapper/_styles.scss
@@ -10,6 +10,10 @@
   &__card {
     @include vertical-card-layout;
     width: 470px;
+
+    body.dark-mode &.card {
+      background-color: $core-fleet-white;
+    }
   }
 
   &__header-container {


### PR DESCRIPTION
**Related issue:** Resolves https://github.com/fleetdm/fleet/issues/48994

# Checklist for submitter

- [x] QA'd all new/changed functionality manually

## Changes

In dark mode, all pages using `AuthenticationFormWrapper` (login, SSO auth required/complete, registration, forgot password, etc.) showed an incorrect card background color. The card appeared as a lighter gray rectangle against the dark page background, creating an unintentional "box within a box" effect.

**Root cause:** The Card component's `__white` dark mode style uses `$ui-fleet-black-5` (`#25272d`), while the page background from the `gradient-background` mixin uses `$core-fleet-white` (`#1a1c21`). In light mode both are `#ffffff` so they match seamlessly, but in dark mode the two different grays create a visible mismatch.

**Fix:** Override the card background in the `AuthenticationFormWrapper` context to use `$core-fleet-white` in dark mode, matching the page background. This mirrors the light mode behavior where card and page share the same background color, with the card defined by its border.

## Reproduction

1. Start a Fleet server
2. Navigate to `/mdm/sso?initiator=setup_experience` (or `/login`, or `/mdm/sso/callback?initiator=setup_experience`)
3. Enable dark mode (system preference or browser DevTools)
4. Observe the card has a noticeably different background color than the page

## Screenshots

### Before (dark mode, authentication required)

![before-auth-required-dark](https://github.com/fleetdm/fleet/releases/download/untagged-b4336e082e2f310392ae/48994-auth-required-dark.png)

### After (dark mode, authentication required)

![after-auth-required-dark](https://github.com/fleetdm/fleet/releases/download/untagged-b4336e082e2f310392ae/48994-after-auth-required-dark.png)

### Before (dark mode, authentication complete)

![before-auth-complete-dark](https://github.com/fleetdm/fleet/releases/download/untagged-b4336e082e2f310392ae/48994-auth-complete-dark.png)

### After (dark mode, authentication complete)

![after-auth-complete-dark](https://github.com/fleetdm/fleet/releases/download/untagged-b4336e082e2f310392ae/48994-after-auth-complete-dark.png)

### Light mode (unchanged)

![after-auth-required-light](https://github.com/fleetdm/fleet/releases/download/untagged-b4336e082e2f310392ae/48994-after-auth-required-light.png)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected dark-mode background colors on authentication pages, including login, SSO, and registration.
  - Authentication form cards now display with the intended background color in dark mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->