### PR TITLE
Enforce Fleet Desktop SSO on device endpoints

### DIFF
--- a/changes/47116-fleet-desktop-sso-setting
+++ b/changes/47116-fleet-desktop-sso-setting
@@ -1,2 +1,3 @@
 - Added the `fleet_desktop.sso_enabled` (Fleet Premium) config setting, along with `enabled_sso_fleet_desktop`/`disabled_sso_fleet_desktop` activities and a `fleetDesktopSSOEnabled` usage statistic.
 - Added an "End user authentication" setting to Settings > Organization settings > Fleet Desktop to require end users to sign in via SSO before accessing the "My device" page.
+- Added the ability to require end users to sign in with an IdP before they can use Fleet Desktop's My Device page.

--- a/ee/server/service/devices.go
+++ b/ee/server/service/devices.go
@@ -427,11 +427,11 @@ func (svc *Service) RequireDeviceSSOSession(ctx context.Context, host *fleet.Hos
 
 	// Setup Experience opens the device page in a web view while Setup Assistant
 	// is still running, where the user won't be able to initiate the SSO flow.
-	awaitingConfiguration, err := svc.ds.GetHostAwaitingConfiguration(ctx, host.UUID)
-	if err != nil && !fleet.IsNotFound(err) {
+	inSetupExperience, err := fleet.HostIsInSetupExperience(ctx, svc.ds, host)
+	if err != nil {
 		return ctxerr.Wrap(ctx, err, "checking if host is in setup experience")
 	}
-	if awaitingConfiguration {
+	if inSetupExperience {
 		return nil
 	}
 

--- a/ee/server/service/devices.go
+++ b/ee/server/service/devices.go
@@ -391,6 +391,71 @@ func (svc *Service) createDeviceSSOSession(ctx context.Context, host *fleet.Host
 	return sessionID, ttl, nil
 }
 
+func (svc *Service) validateDeviceSSOSession(ctx context.Context, sessionID string) (*fleet.DeviceSSOSession, error) {
+	if sessionID == "" {
+		return nil, ctxerr.Wrap(ctx, fleet.NewAuthRequiredError("device sso session not found"))
+	}
+
+	val, err := svc.keyValueStore.Get(ctx, deviceSSOSessionKeyPrefix+sessionID)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "get device sso session")
+	}
+	if val == nil {
+		return nil, ctxerr.Wrap(ctx, fleet.NewAuthRequiredError("device sso session not found"))
+	}
+
+	var session fleet.DeviceSSOSession
+	if err := json.Unmarshal([]byte(*val), &session); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "unmarshal device sso session")
+	}
+
+	if !svc.clock.Now().Before(session.ExpiresAt) {
+		return nil, ctxerr.Wrap(ctx, fleet.NewAuthRequiredError("device sso session expired"))
+	}
+
+	return &session, nil
+}
+
+func (svc *Service) RequireDeviceSSOSession(ctx context.Context, host *fleet.Host, sessionID string) error {
+	appConfig, err := svc.ds.AppConfig(ctx)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "getting app config")
+	}
+	if !appConfig.FleetDesktop.SSOEnabled {
+		return nil
+	}
+
+	// Setup Experience opens the device page in a web view while Setup Assistant
+	// is still running, where the user won't be able to initiate the SSO flow.
+	awaitingConfiguration, err := svc.ds.GetHostAwaitingConfiguration(ctx, host.UUID)
+	if err != nil && !fleet.IsNotFound(err) {
+		return ctxerr.Wrap(ctx, err, "checking if host is in setup experience")
+	}
+	if awaitingConfiguration {
+		return nil
+	}
+
+	session, err := svc.validateDeviceSSOSession(ctx, sessionID)
+	var noSession *fleet.AuthRequiredError
+	switch {
+	case errors.As(err, &noSession):
+		svc.logger.DebugContext(ctx, "no device sso session for request", "host_id", host.ID, "err", err)
+	case err != nil:
+		// Anything else is the session store failing, not the end user being
+		// signed out.
+		return ctxerr.Wrap(ctx, err, "validating device sso session")
+	case session.HostID != host.ID:
+		// The session is bound to the host its device token minted it for, so one
+		// device's cookie cannot unlock another device's page in the same browser.
+		svc.logger.WarnContext(ctx, "device sso session belongs to another host",
+			"host_id", host.ID, "session_host_id", session.HostID)
+	default:
+		return nil
+	}
+
+	return ctxerr.Wrap(ctx, fleet.NewDeviceSSORequiredError("no device sso session"), "require device sso session")
+}
+
 func (svc *Service) InitiateDeviceSSO(ctx context.Context, deviceURL string) (*fleet.DeviceSSOInitiation, error) {
 	// the device middleware already authenticated the host via its device token.
 	svc.authz.SkipAuthorization(ctx)

--- a/ee/server/service/devices_test.go
+++ b/ee/server/service/devices_test.go
@@ -221,8 +221,8 @@ func TestInitiateDeviceSSOMissingHostInContext(t *testing.T) {
 }
 
 func TestRequireDeviceSSOSession(t *testing.T) {
-	host := &fleet.Host{ID: 1, UUID: "host-uuid-1"}
-	otherHost := &fleet.Host{ID: 2, UUID: "host-uuid-2"}
+	host := &fleet.Host{ID: 1, UUID: "host-uuid-1", Platform: "darwin"}
+	otherHost := &fleet.Host{ID: 2, UUID: "host-uuid-2", Platform: "darwin"}
 
 	// mintFor returns a session ID for h, or "" for the callers that stand in for
 	// a browser with no cookie yet.
@@ -239,7 +239,9 @@ func TestRequireDeviceSSOSession(t *testing.T) {
 	cases := []struct {
 		name                  string
 		ssoEnabled            bool
-		awaitingConfiguration bool
+		platform              string // defaults to darwin
+		awaitingConfiguration bool   // darwin only: the Setup Assistant flag
+		setupExperienceStatus fleet.SetupExperienceStatusResultStatus
 		session               sessionFor
 		advanceClock          time.Duration
 		wantSSORequired       bool
@@ -285,6 +287,31 @@ func TestRequireDeviceSSOSession(t *testing.T) {
 			session:               noSession,
 			wantSessionLookup:     true,
 		},
+		{
+			name:                  "linux host mid setup experience is exempt",
+			ssoEnabled:            true,
+			platform:              "ubuntu",
+			setupExperienceStatus: fleet.SetupExperienceStatusRunning,
+			session:               noSession,
+			wantSessionLookup:     true,
+		},
+		{
+			name:                  "windows host mid setup experience is exempt",
+			ssoEnabled:            true,
+			platform:              "windows",
+			setupExperienceStatus: fleet.SetupExperienceStatusPending,
+			session:               noSession,
+			wantSessionLookup:     true,
+		},
+		{
+			name:                  "linux host past setup experience requires sso",
+			ssoEnabled:            true,
+			platform:              "ubuntu",
+			setupExperienceStatus: fleet.SetupExperienceStatusSuccess,
+			session:               noSession,
+			wantSSORequired:       true,
+			wantSessionLookup:     true,
+		},
 	}
 
 	for _, c := range cases {
@@ -299,14 +326,25 @@ func TestRequireDeviceSSOSession(t *testing.T) {
 				require.Equal(t, host.UUID, hostUUID)
 				return c.awaitingConfiguration, nil
 			}
+			ds.ListSetupExperienceResultsByHostUUIDFunc = func(ctx context.Context, hostUUID string, teamID uint) ([]*fleet.SetupExperienceStatusResult, error) {
+				return []*fleet.SetupExperienceStatusResult{
+					{Name: "install something", Status: c.setupExperienceStatus, HostUUID: hostUUID, SoftwareInstallerID: new(uint(1))},
+				}, nil
+			}
 
 			svc, getKey, mockClock := newDeviceSSOTestService(t, ds, time.Hour)
 			ctx := t.Context()
 
+			caseHost := *host
+			if c.platform != "" {
+				caseHost.Platform = c.platform
+				caseHost.OsqueryHostID = new("osquery-id")
+			}
+
 			sessionID := c.session(t, svc, ctx)
 			mockClock.AddTime(c.advanceClock)
 
-			err := svc.RequireDeviceSSOSession(ctx, host, sessionID)
+			err := svc.RequireDeviceSSOSession(ctx, &caseHost, sessionID)
 
 			if c.wantSSORequired {
 				var ssoRequired *fleet.DeviceSSORequiredError
@@ -327,7 +365,7 @@ func TestRequireDeviceSSOSession(t *testing.T) {
 }
 
 func TestRequireDeviceSSOSessionSetupExperienceSurvivesStoreFailure(t *testing.T) {
-	host := &fleet.Host{ID: 1, UUID: "host-uuid-1"}
+	host := &fleet.Host{ID: 1, UUID: "host-uuid-1", Platform: "darwin"}
 
 	ds := new(mock.Store)
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
@@ -364,7 +402,7 @@ func TestRequireDeviceSSOSessionMissingSetupExperienceRow(t *testing.T) {
 	svc, _, _ := newDeviceSSOTestService(t, ds, time.Hour)
 
 	var ssoRequired *fleet.DeviceSSORequiredError
-	require.ErrorAs(t, svc.RequireDeviceSSOSession(t.Context(), &fleet.Host{ID: 1, UUID: "host-uuid-1"}, ""), &ssoRequired)
+	require.ErrorAs(t, svc.RequireDeviceSSOSession(t.Context(), &fleet.Host{ID: 1, UUID: "host-uuid-1", Platform: "darwin"}, ""), &ssoRequired)
 }
 
 func TestRequireDeviceSSOSessionStoreFailure(t *testing.T) {
@@ -385,7 +423,7 @@ func TestRequireDeviceSSOSessionStoreFailure(t *testing.T) {
 		},
 	}
 
-	err := svc.RequireDeviceSSOSession(t.Context(), &fleet.Host{ID: 1, UUID: "host-uuid-1"}, "some-session")
+	err := svc.RequireDeviceSSOSession(t.Context(), &fleet.Host{ID: 1, UUID: "host-uuid-1", Platform: "darwin"}, "some-session")
 
 	require.ErrorContains(t, err, "redis is down")
 	var ssoRequired *fleet.DeviceSSORequiredError

--- a/ee/server/service/devices_test.go
+++ b/ee/server/service/devices_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -13,6 +14,7 @@ import (
 	hostctx "github.com/fleetdm/fleet/v4/server/contexts/host"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mock"
+	redismock "github.com/fleetdm/fleet/v4/server/mock/redis"
 	"github.com/stretchr/testify/require"
 )
 
@@ -50,6 +52,35 @@ func TestCreateDeviceSSOSession(t *testing.T) {
 	require.Equal(t, host.ID, session.HostID)
 	require.Equal(t, "idp-acct-uuid", session.IdPAccountUUID)
 	require.Equal(t, mockClock.Now().Add(time.Hour), session.ExpiresAt.UTC())
+}
+
+func TestDeviceSSOSessionExpires(t *testing.T) {
+	svc, _, mockClock := newDeviceSSOTestService(t, new(mock.Store), time.Hour)
+
+	ctx := t.Context()
+	sessionID, _, err := svc.createDeviceSSOSession(ctx, &fleet.Host{ID: 42, UUID: "host-uuid-1"}, "idp-acct-uuid")
+	require.NoError(t, err)
+
+	// still valid just before the deadline
+	mockClock.AddTime(time.Hour - time.Second)
+	_, err = svc.validateDeviceSSOSession(ctx, sessionID)
+	require.NoError(t, err)
+
+	// the absolute deadline is enforced on read even though this store never
+	// drops the key, so a store that stops honoring TTLs can't keep the session
+	// alive.
+	mockClock.AddTime(2 * time.Second)
+	_, err = svc.validateDeviceSSOSession(ctx, sessionID)
+	require.Error(t, err)
+}
+
+func TestDeviceSSOSessionUnknownIDNotFound(t *testing.T) {
+	svc, _, _ := newDeviceSSOTestService(t, new(mock.Store), time.Hour)
+
+	for _, sessionID := range []string{"", "does-not-exist"} {
+		_, err := svc.validateDeviceSSOSession(t.Context(), sessionID)
+		require.Error(t, err)
+	}
 }
 
 func TestInitiateDeviceSSOGuards(t *testing.T) {
@@ -187,4 +218,176 @@ func TestInitiateDeviceSSOMissingHostInContext(t *testing.T) {
 
 	_, err := svc.InitiateDeviceSSO(t.Context(), "/device/some-token")
 	require.Error(t, err)
+}
+
+func TestRequireDeviceSSOSession(t *testing.T) {
+	host := &fleet.Host{ID: 1, UUID: "host-uuid-1"}
+	otherHost := &fleet.Host{ID: 2, UUID: "host-uuid-2"}
+
+	// mintFor returns a session ID for h, or "" for the callers that stand in for
+	// a browser with no cookie yet.
+	type sessionFor func(t *testing.T, svc *Service, ctx context.Context) string
+	noSession := func(*testing.T, *Service, context.Context) string { return "" }
+	sessionOf := func(h *fleet.Host) sessionFor {
+		return func(t *testing.T, svc *Service, ctx context.Context) string {
+			sessionID, _, err := svc.createDeviceSSOSession(ctx, h, "idp-acct-uuid")
+			require.NoError(t, err)
+			return sessionID
+		}
+	}
+
+	cases := []struct {
+		name                  string
+		ssoEnabled            bool
+		awaitingConfiguration bool
+		session               sessionFor
+		advanceClock          time.Duration
+		wantSSORequired       bool
+		wantSessionLookup     bool
+	}{
+		{
+			name:       "setting off allows the request",
+			ssoEnabled: false,
+			session:    noSession,
+		},
+		{
+			name:              "session bound to the host allows the request",
+			ssoEnabled:        true,
+			session:           sessionOf(host),
+			wantSessionLookup: true,
+		},
+		{
+			name:              "no session requires sso",
+			ssoEnabled:        true,
+			session:           noSession,
+			wantSSORequired:   true,
+			wantSessionLookup: true,
+		},
+		{
+			name:              "expired session requires sso",
+			ssoEnabled:        true,
+			session:           sessionOf(host),
+			advanceClock:      2 * time.Hour,
+			wantSSORequired:   true,
+			wantSessionLookup: true,
+		},
+		{
+			name:              "session minted for another host requires sso",
+			ssoEnabled:        true,
+			session:           sessionOf(otherHost),
+			wantSSORequired:   true,
+			wantSessionLookup: true,
+		},
+		{
+			name:                  "host in setup experience is exempt",
+			ssoEnabled:            true,
+			awaitingConfiguration: true,
+			session:               noSession,
+			wantSessionLookup:     true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ds := new(mock.Store)
+			ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+				var ac fleet.AppConfig
+				ac.FleetDesktop.SSOEnabled = c.ssoEnabled
+				return &ac, nil
+			}
+			ds.GetHostAwaitingConfigurationFunc = func(ctx context.Context, hostUUID string) (bool, error) {
+				require.Equal(t, host.UUID, hostUUID)
+				return c.awaitingConfiguration, nil
+			}
+
+			svc, getKey, mockClock := newDeviceSSOTestService(t, ds, time.Hour)
+			ctx := t.Context()
+
+			sessionID := c.session(t, svc, ctx)
+			mockClock.AddTime(c.advanceClock)
+
+			err := svc.RequireDeviceSSOSession(ctx, host, sessionID)
+
+			if c.wantSSORequired {
+				var ssoRequired *fleet.DeviceSSORequiredError
+				require.ErrorAs(t, err, &ssoRequired)
+			} else {
+				require.NoError(t, err)
+			}
+
+			// With the setting off nothing is looked up at all: no session read and
+			// no setup experience query, so a Fleet running without the feature
+			// pays nothing for it.
+			if !c.wantSessionLookup {
+				require.Nil(t, getKey(deviceSSOSessionKeyPrefix+sessionID))
+				require.False(t, ds.GetHostAwaitingConfigurationFuncInvoked)
+			}
+		})
+	}
+}
+
+func TestRequireDeviceSSOSessionSetupExperienceSurvivesStoreFailure(t *testing.T) {
+	host := &fleet.Host{ID: 1, UUID: "host-uuid-1"}
+
+	ds := new(mock.Store)
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		var ac fleet.AppConfig
+		ac.FleetDesktop.SSOEnabled = true
+		return &ac, nil
+	}
+	ds.GetHostAwaitingConfigurationFunc = func(ctx context.Context, hostUUID string) (bool, error) {
+		return true, nil
+	}
+
+	svc, _, _ := newDeviceSSOTestService(t, ds, time.Hour)
+	svc.keyValueStore = &redismock.KeyValueStore{
+		GetFunc: func(ctx context.Context, key string) (*string, error) {
+			return nil, errors.New("redis is down")
+		},
+	}
+
+	require.NoError(t, svc.RequireDeviceSSOSession(t.Context(), host, ""))
+}
+
+func TestRequireDeviceSSOSessionMissingSetupExperienceRow(t *testing.T) {
+	ds := new(mock.Store)
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		var ac fleet.AppConfig
+		ac.FleetDesktop.SSOEnabled = true
+		return &ac, nil
+	}
+	// Hosts that never ran setup experience have no row at all.
+	ds.GetHostAwaitingConfigurationFunc = func(ctx context.Context, hostUUID string) (bool, error) {
+		return false, &notFoundError{}
+	}
+
+	svc, _, _ := newDeviceSSOTestService(t, ds, time.Hour)
+
+	var ssoRequired *fleet.DeviceSSORequiredError
+	require.ErrorAs(t, svc.RequireDeviceSSOSession(t.Context(), &fleet.Host{ID: 1, UUID: "host-uuid-1"}, ""), &ssoRequired)
+}
+
+func TestRequireDeviceSSOSessionStoreFailure(t *testing.T) {
+	ds := new(mock.Store)
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		var ac fleet.AppConfig
+		ac.FleetDesktop.SSOEnabled = true
+		return &ac, nil
+	}
+	ds.GetHostAwaitingConfigurationFunc = func(ctx context.Context, hostUUID string) (bool, error) {
+		return false, nil
+	}
+
+	svc, _, _ := newDeviceSSOTestService(t, ds, time.Hour)
+	svc.keyValueStore = &redismock.KeyValueStore{
+		GetFunc: func(ctx context.Context, key string) (*string, error) {
+			return nil, errors.New("redis is down")
+		},
+	}
+
+	err := svc.RequireDeviceSSOSession(t.Context(), &fleet.Host{ID: 1, UUID: "host-uuid-1"}, "some-session")
+
+	require.ErrorContains(t, err, "redis is down")
+	var ssoRequired *fleet.DeviceSSORequiredError
+	require.NotErrorAs(t, err, &ssoRequired, "a broken session store must not read as a prompt to sign in")
 }

--- a/server/contexts/devicesso/devicesso.go
+++ b/server/contexts/devicesso/devicesso.go
@@ -1,0 +1,18 @@
+// Package devicesso provides a context key for the Fleet Desktop device SSO
+// session ID.
+package devicesso
+
+import "context"
+
+type key int
+
+const sessionIDKey key = 0
+
+func NewContext(ctx context.Context, sessionID string) context.Context {
+	return context.WithValue(ctx, sessionIDKey, sessionID)
+}
+
+func FromContext(ctx context.Context) string {
+	sessionID, _ := ctx.Value(sessionIDKey).(string)
+	return sessionID
+}

--- a/server/fleet/errors.go
+++ b/server/fleet/errors.go
@@ -186,6 +186,12 @@ type AuthRequiredError = platform_http.AuthRequiredError
 // NewAuthRequiredError is an alias for platform_http.NewAuthRequiredError.
 var NewAuthRequiredError = platform_http.NewAuthRequiredError
 
+// DeviceSSORequiredError is an alias for platform_http.DeviceSSORequiredError.
+type DeviceSSORequiredError = platform_http.DeviceSSORequiredError
+
+// NewDeviceSSORequiredError is an alias for platform_http.NewDeviceSSORequiredError.
+var NewDeviceSSORequiredError = platform_http.NewDeviceSSORequiredError
+
 // AuthHeaderRequiredError is an alias for platform_http.AuthHeaderRequiredError.
 type AuthHeaderRequiredError = platform_http.AuthHeaderRequiredError
 

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -154,6 +154,11 @@ type Service interface {
 	// initiating device token.
 	InitiateDeviceSSO(ctx context.Context, deviceURL string) (*DeviceSSOInitiation, error)
 
+	// RequireDeviceSSOSession enforces the Fleet Desktop SSO gate for the given host.
+	// When fleet_desktop.sso_enabled is off it allows the request; when it is on,
+	// sessionID must identify a live device SSO session minted for that host.
+	RequireDeviceSSOSession(ctx context.Context, host *Host, sessionID string) error
+
 	// SetEnterpriseOverrides allows the enterprise service to override specific methods
 	// that can't be easily overridden via embedding.
 	//

--- a/server/fleet/setup_experience.go
+++ b/server/fleet/setup_experience.go
@@ -1,6 +1,7 @@
 package fleet
 
 import (
+	"context"
 	"errors"
 	"fmt"
 )
@@ -275,6 +276,56 @@ func HostUUIDForSetupExperience(host *Host) (string, error) {
 		return "", errors.New("missing osquery_host_id")
 	}
 	return *host.OsqueryHostID, nil
+}
+
+// HostIsInSetupExperience reports whether the host is still working through
+// setup experience.
+func HostIsInSetupExperience(ctx context.Context, ds Datastore, host *Host) (bool, error) {
+	switch {
+	case host.Platform == string(MacOSPlatform):
+		inSetupExperience, err := ds.GetHostAwaitingConfiguration(ctx, host.UUID)
+		if err != nil && !IsNotFound(err) {
+			return false, fmt.Errorf("check if host is in setup experience: %w", err)
+		}
+		return inSetupExperience, nil
+
+	case IsLinux(host.Platform) || host.Platform == "windows":
+		hostUUID, err := HostUUIDForSetupExperience(host)
+		if err != nil {
+			return false, fmt.Errorf("get host's UUID for the setup experience: %w", err)
+		}
+		var teamID uint
+		if host.TeamID != nil {
+			teamID = *host.TeamID
+		}
+		inSetupExperience, err := hasSetupExperiencePendingOrRunningItems(ctx, ds, hostUUID, teamID)
+		if err != nil && !IsNotFound(err) {
+			return false, fmt.Errorf("check setup experience pending or running items: %w", err)
+		}
+		return inSetupExperience, nil
+
+	default:
+		return false, nil
+	}
+}
+
+func hasSetupExperiencePendingOrRunningItems(ctx context.Context, ds Datastore, hostUUID string, teamID uint) (bool, error) {
+	statuses, err := ds.ListSetupExperienceResultsByHostUUID(ctx, hostUUID, teamID)
+	if err != nil {
+		return false, fmt.Errorf("retrieving setup experience results: %w", err)
+	}
+
+	for _, status := range statuses {
+		if err := status.IsValid(); err != nil {
+			return false, fmt.Errorf("invalid row: %w", err)
+		}
+
+		switch status.Status {
+		case SetupExperienceStatusPending, SetupExperienceStatusRunning:
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 type SetupExperienceCount struct {

--- a/server/mock/service/service_mock.go
+++ b/server/mock/service/service_mock.go
@@ -65,6 +65,8 @@ type GetFleetDesktopSummaryFunc func(ctx context.Context) (fleet.DesktopSummary,
 
 type InitiateDeviceSSOFunc func(ctx context.Context, deviceURL string) (*fleet.DeviceSSOInitiation, error)
 
+type RequireDeviceSSOSessionFunc func(ctx context.Context, host *fleet.Host, sessionID string) error
+
 type SetEnterpriseOverridesFunc func(overrides fleet.EnterpriseOverrides)
 
 type CreateUserFromInviteFunc func(ctx context.Context, p fleet.UserPayload) (user *fleet.User, err error)
@@ -1069,6 +1071,9 @@ type Service struct {
 
 	InitiateDeviceSSOFunc        InitiateDeviceSSOFunc
 	InitiateDeviceSSOFuncInvoked bool
+
+	RequireDeviceSSOSessionFunc        RequireDeviceSSOSessionFunc
+	RequireDeviceSSOSessionFuncInvoked bool
 
 	SetEnterpriseOverridesFunc        SetEnterpriseOverridesFunc
 	SetEnterpriseOverridesFuncInvoked bool
@@ -2632,6 +2637,13 @@ func (s *Service) InitiateDeviceSSO(ctx context.Context, deviceURL string) (*fle
 	s.InitiateDeviceSSOFuncInvoked = true
 	s.mu.Unlock()
 	return s.InitiateDeviceSSOFunc(ctx, deviceURL)
+}
+
+func (s *Service) RequireDeviceSSOSession(ctx context.Context, host *fleet.Host, sessionID string) error {
+	s.mu.Lock()
+	s.RequireDeviceSSOSessionFuncInvoked = true
+	s.mu.Unlock()
+	return s.RequireDeviceSSOSessionFunc(ctx, host, sessionID)
 }
 
 func (s *Service) SetEnterpriseOverrides(overrides fleet.EnterpriseOverrides) {

--- a/server/platform/endpointer/endpoint_utils.go
+++ b/server/platform/endpointer/endpoint_utils.go
@@ -1056,6 +1056,14 @@ func (e *CommonEndpointer[H]) WithCustomMiddlewareAfterAuth(mws ...endpoint.Midd
 	return &ae
 }
 
+// AppendCustomMiddlewareAfterAuth adds to the after-auth middleware already set
+// on the endpointer instead of replacing it.
+func (e *CommonEndpointer[H]) AppendCustomMiddlewareAfterAuth(mws ...endpoint.Middleware) *CommonEndpointer[H] {
+	ae := *e
+	ae.CustomMiddlewareAfterAuth = append(slices.Clone(ae.CustomMiddlewareAfterAuth), mws...)
+	return &ae
+}
+
 func (e *CommonEndpointer[H]) UsePathPrefix() *CommonEndpointer[H] {
 	ae := *e
 	ae.usePathPrefix = true

--- a/server/platform/http/errors.go
+++ b/server/platform/http/errors.go
@@ -331,6 +331,34 @@ func (e *AuthRequiredError) IsClientError() bool {
 	return true
 }
 
+// DeviceSSORequiredError is returned by device endpoints when
+// fleet_desktop.sso_enabled is on and the request carries no valid device SSO
+// session. It answers 401 like an invalid device token does, but its encoded
+// body carries an sso_required marker so the "My device" page starts the SSO
+// flow instead of reporting an invalid URL.
+type DeviceSSORequiredError struct {
+	// internal is the reason that should only be logged internally
+	internal string
+
+	ErrorWithUUID
+}
+
+func NewDeviceSSORequiredError(internal string) *DeviceSSORequiredError {
+	return &DeviceSSORequiredError{internal: internal}
+}
+
+func (e *DeviceSSORequiredError) Error() string {
+	return "Single sign-on required"
+}
+
+func (e *DeviceSSORequiredError) Internal() string {
+	return e.internal
+}
+
+func (e *DeviceSSORequiredError) IsClientError() bool {
+	return true
+}
+
 // AuthHeaderRequiredError is returned when an authorization header is required.
 type AuthHeaderRequiredError struct {
 	// internal is the reason that should only be logged internally

--- a/server/service/devices.go
+++ b/server/service/devices.go
@@ -139,6 +139,10 @@ func (svc *Service) InitiateDeviceSSO(ctx context.Context, deviceURL string) (*f
 	return nil, fleet.ErrMissingLicense
 }
 
+func (svc *Service) RequireDeviceSSOSession(ctx context.Context, host *fleet.Host, sessionID string) error {
+	return nil
+}
+
 /////////////////////////////////////////////////////////////////////////////////
 // Get Current Device's Host
 /////////////////////////////////////////////////////////////////////////////////

--- a/server/service/devices_sso_gate_test.go
+++ b/server/service/devices_sso_gate_test.go
@@ -1,0 +1,151 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/server/contexts/certserial"
+	"github.com/fleetdm/fleet/v4/server/contexts/devicesso"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	svcmock "github.com/fleetdm/fleet/v4/server/mock/service"
+	"github.com/go-kit/kit/endpoint"
+	"github.com/stretchr/testify/require"
+)
+
+func newDeviceSSOGateTestService(host *fleet.Host) *svcmock.Service {
+	svc := new(svcmock.Service)
+	svc.AuthenticateDeviceFunc = func(ctx context.Context, token string) (*fleet.Host, bool, error) {
+		return host, false, nil
+	}
+	svc.AuthenticateDeviceByCertificateFunc = func(ctx context.Context, serial uint64, uuid string) (*fleet.Host, bool, error) {
+		return host, false, nil
+	}
+	svc.AuthenticateIDeviceByURLFunc = func(ctx context.Context, uuid string) (*fleet.Host, bool, error) {
+		return host, false, nil
+	}
+	return svc
+}
+
+func gatedDeviceChain(svc fleet.Service, endpointFn endpoint.Endpoint) endpoint.Endpoint {
+	return authenticatedDevice(svc, slog.New(slog.DiscardHandler), requireDeviceSSOSession(svc)(endpointFn))
+}
+
+func TestAuthenticatedDeviceSSOGate(t *testing.T) {
+	host := &fleet.Host{ID: 1, UUID: "host-uuid-1", Platform: "darwin"}
+	ssoRequired := fleet.NewDeviceSSORequiredError("no device sso session")
+
+	t.Run("gated endpoint passes the resolved host and the cookie session", func(t *testing.T) {
+		svc := newDeviceSSOGateTestService(host)
+		var gotSessionID string
+		var gotHost *fleet.Host
+		svc.RequireDeviceSSOSessionFunc = func(ctx context.Context, host *fleet.Host, sessionID string) error {
+			gotHost, gotSessionID = host, sessionID
+			return nil
+		}
+
+		mw := gatedDeviceChain(svc, func(ctx context.Context, request any) (any, error) {
+			return "success", nil
+		})
+
+		ctx := devicesso.NewContext(t.Context(), "session-id-from-cookie")
+		resp, err := mw(ctx, mockDeviceAuthRequest{Token: "device-token"})
+		require.NoError(t, err)
+		require.Equal(t, "success", resp)
+		require.Equal(t, "session-id-from-cookie", gotSessionID)
+		// the host the gate binds the session against is the one authentication
+		// resolved, not something it looks up for itself
+		require.Equal(t, host, gotHost)
+	})
+
+	// iOS/iPadOS reach the device API by client certificate or by device UUID in
+	// the URL rather than by rotating token; the gate runs after host resolution
+	// so it has to cover all three.
+	t.Run("gate covers certificate authentication", func(t *testing.T) {
+		svc := newDeviceSSOGateTestService(host)
+		svc.RequireDeviceSSOSessionFunc = func(ctx context.Context, host *fleet.Host, sessionID string) error {
+			return ssoRequired
+		}
+
+		mw := gatedDeviceChain(svc, func(ctx context.Context, request any) (any, error) {
+			return "success", nil
+		})
+
+		ctx := certserial.NewContext(t.Context(), 1234)
+		_, err := mw(ctx, mockDeviceAuthRequest{Token: host.UUID})
+		require.ErrorIs(t, err, ssoRequired)
+		require.True(t, svc.AuthenticateDeviceByCertificateFuncInvoked)
+	})
+
+	t.Run("gate covers device URL authentication", func(t *testing.T) {
+		svc := newDeviceSSOGateTestService(host)
+		svc.AuthenticateDeviceFunc = func(ctx context.Context, token string) (*fleet.Host, bool, error) {
+			return nil, false, newNotFoundError()
+		}
+		svc.RequireDeviceSSOSessionFunc = func(ctx context.Context, host *fleet.Host, sessionID string) error {
+			return ssoRequired
+		}
+
+		mw := gatedDeviceChain(svc, func(ctx context.Context, request any) (any, error) {
+			return "success", nil
+		})
+
+		_, err := mw(t.Context(), mockDeviceAuthRequest{Token: host.UUID})
+		require.ErrorIs(t, err, ssoRequired)
+		require.True(t, svc.AuthenticateIDeviceByURLFuncInvoked)
+	})
+
+	t.Run("an invalid token is rejected before the gate", func(t *testing.T) {
+		svc := new(svcmock.Service)
+		svc.AuthenticateDeviceFunc = func(ctx context.Context, token string) (*fleet.Host, bool, error) {
+			return nil, false, newNotFoundError()
+		}
+		svc.AuthenticateIDeviceByURLFunc = func(ctx context.Context, uuid string) (*fleet.Host, bool, error) {
+			return nil, false, newNotFoundError()
+		}
+		svc.RequireDeviceSSOSessionFunc = func(ctx context.Context, host *fleet.Host, sessionID string) error {
+			return nil
+		}
+
+		mw := gatedDeviceChain(svc, func(ctx context.Context, request any) (any, error) {
+			return "success", nil
+		})
+
+		_, err := mw(t.Context(), mockDeviceAuthRequest{Token: "bad-token"})
+		require.Error(t, err)
+		var ssoErr *fleet.DeviceSSORequiredError
+		require.NotErrorAs(t, err, &ssoErr, "a bad token must not tell the browser to sign in")
+		require.False(t, svc.RequireDeviceSSOSessionFuncInvoked)
+	})
+}
+
+func TestDeviceSSORequiredErrorResponse(t *testing.T) {
+	rr := httptest.NewRecorder()
+	encodeError(t.Context(), fleet.NewDeviceSSORequiredError("no device sso session"), rr)
+
+	require.Equal(t, http.StatusUnauthorized, rr.Code)
+
+	var body struct {
+		Message     string              `json:"message"`
+		Errors      []map[string]string `json:"errors"`
+		SSORequired bool                `json:"sso_required"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
+	require.True(t, body.SSORequired)
+	require.Equal(t, "Single sign-on required", body.Message)
+	require.Len(t, body.Errors, 1)
+
+	// The internal reason stays out of the response.
+	require.NotContains(t, rr.Body.String(), "no device sso session")
+}
+
+func TestNonSSOErrorResponseHasNoMarker(t *testing.T) {
+	rr := httptest.NewRecorder()
+	encodeError(t.Context(), fleet.NewAuthRequiredError("invalid device token"), rr)
+
+	require.Equal(t, http.StatusUnauthorized, rr.Code)
+	require.NotContains(t, rr.Body.String(), "sso_required")
+}

--- a/server/service/endpoint_middleware.go
+++ b/server/service/endpoint_middleware.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/fleetdm/fleet/v4/server/contexts/certserial"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/contexts/devicesso"
 	"github.com/fleetdm/fleet/v4/server/contexts/logging"
 	"github.com/fleetdm/fleet/v4/server/contexts/osqueryauth"
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -37,6 +38,16 @@ func extractCertSerialFromHeader(ctx context.Context, r *http.Request) context.C
 	}
 
 	return certserial.NewContext(ctx, serial)
+}
+
+// extractDeviceSSOSessionFromCookie stashes the Fleet Desktop device SSO session
+// ID in the context.
+func extractDeviceSSOSessionFromCookie(ctx context.Context, r *http.Request) context.Context {
+	cookie, err := r.Cookie(cookieNameDeviceSSOSession)
+	if err != nil {
+		return ctx
+	}
+	return devicesso.NewContext(ctx, cookie.Value)
 }
 
 func logJSON(ctx context.Context, logger *slog.Logger, v any, key string) {
@@ -66,7 +77,7 @@ func instrumentHostLogger(ctx context.Context, hostID uint, extras ...interface{
 // provided in the request, and attaches the corresponding host to the
 // context for the request.
 func authenticatedDevice(svc fleet.Service, logger *slog.Logger, next endpoint.Endpoint) endpoint.Endpoint {
-	authDeviceFunc := func(ctx context.Context, request interface{}) (interface{}, error) {
+	authDeviceFunc := func(ctx context.Context, request any) (any, error) {
 		identifier, err := getDeviceAuthToken(request)
 		if err != nil {
 			return nil, err
@@ -124,6 +135,31 @@ func authenticatedDevice(svc fleet.Service, logger *slog.Logger, next endpoint.E
 		return resp, nil
 	}
 	return middleware_log.Logged(authDeviceFunc)
+}
+
+// requireDeviceSSOSession enforces the Fleet Desktop SSO gate. It runs after
+// authenticatedDevice, so it applies however the host was identified: token,
+// client certificate or device UUID in the URL.
+//
+// Rejections count toward the device routes' error limiter like any other
+// failure. A browser only sees one before it starts the SSO flow, so sustained
+// volume here is a scanner rather than an end user.
+func requireDeviceSSOSession(svc fleet.Service) endpoint.Middleware {
+	return func(next endpoint.Endpoint) endpoint.Endpoint {
+		return func(ctx context.Context, request any) (any, error) {
+			host, ok := hostctx.FromContext(ctx)
+			if !ok {
+				return nil, ctxerr.Wrap(ctx, fleet.NewAuthRequiredError("internal error: missing host from request context"))
+			}
+
+			sessionID := devicesso.FromContext(ctx)
+			if err := svc.RequireDeviceSSOSession(ctx, host, sessionID); err != nil {
+				logging.WithErr(ctx, err)
+				return nil, err
+			}
+			return next(ctx, request)
+		}
+	}
 }
 
 func getDeviceAuthToken(r interface{}) (string, error) {

--- a/server/service/endpoint_utils.go
+++ b/server/service/endpoint_utils.go
@@ -210,17 +210,37 @@ func badRequestf(format string, a ...any) error {
 	}
 }
 
+// newDeviceAuthenticatedEndpointer returns the endpointer for device endpoints.
+// Its routes are subject to the Fleet Desktop SSO gate; see
+// newDeviceSSOExemptEndpointer for the exceptions.
 func newDeviceAuthenticatedEndpointer(svc fleet.Service, logger *slog.Logger, opts []kithttp.ServerOption, r *mux.Router,
 	versions ...string,
 ) *eu.CommonEndpointer[handlerFunc] {
+	return deviceAuthenticatedEndpointer(svc, logger, opts, r, true, versions...)
+}
+
+// newDeviceSSOExemptEndpointer returns an endpointer for the device endpoints
+// that stay reachable with fleet_desktop.sso_enabled on and no device SSO
+// session.
+func newDeviceSSOExemptEndpointer(svc fleet.Service, logger *slog.Logger, opts []kithttp.ServerOption, r *mux.Router,
+	versions ...string,
+) *eu.CommonEndpointer[handlerFunc] {
+	return deviceAuthenticatedEndpointer(svc, logger, opts, r, false, versions...)
+}
+
+func deviceAuthenticatedEndpointer(svc fleet.Service, logger *slog.Logger, opts []kithttp.ServerOption, r *mux.Router,
+	ssoGate bool, versions ...string,
+) *eu.CommonEndpointer[handlerFunc] {
 	// Extract certificate serial from X-Client-Cert-Serial header for certificate-based auth
 	opts = append(opts, kithttp.ServerBefore(extractCertSerialFromHeader))
+	// Make the Fleet Desktop device SSO session available to the auth middleware
+	opts = append(opts, kithttp.ServerBefore(extractDeviceSSOSessionFromCookie))
 	// Inject the fleet.CapabilitiesHeader header to the response for device endpoints
 	opts = append(opts, capabilitiesResponseFunc(fleet.GetServerDeviceCapabilities()))
 	// Add the capabilities reported by the device to the request context
 	opts = append(opts, capabilitiesContextFunc())
 
-	return &eu.CommonEndpointer[handlerFunc]{
+	ep := &eu.CommonEndpointer[handlerFunc]{
 		EP: &fleetEndpointer{
 			svc: svc,
 		},
@@ -233,6 +253,10 @@ func newDeviceAuthenticatedEndpointer(svc fleet.Service, logger *slog.Logger, op
 		Router:   r,
 		Versions: versions,
 	}
+	if !ssoGate {
+		return ep
+	}
+	return ep.AppendCustomMiddlewareAfterAuth(requireDeviceSSOSession(svc))
 }
 
 func newHostAuthenticatedEndpointer(svc fleet.Service, logger *slog.Logger, opts []kithttp.ServerOption, r *mux.Router,

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -965,15 +965,11 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	// Device-authenticated endpoints.
 	de := newDeviceAuthenticatedEndpointer(svc, logger, opts, r, apiVersions...)
 	de.WithCustomMiddleware(errorLimiter).GET("/api/_version_/fleet/device/{token}", getDeviceHostEndpoint, getDeviceHostRequest{})
-	de.WithCustomMiddleware(errorLimiter).GET("/api/_version_/fleet/device/{token}/desktop", getFleetDesktopEndpoint, getFleetDesktopRequest{})
-	de.WithCustomMiddleware(errorLimiter).HEAD("/api/_version_/fleet/device/{token}/ping", devicePingEndpoint, deviceAuthPingRequest{})
 	de.WithCustomMiddleware(errorLimiter).POST("/api/_version_/fleet/device/{token}/refetch", refetchDeviceHostEndpoint, refetchDeviceHostRequest{})
 	// Deprecated: Device mapping data is now included in host details endpoint
 	de.WithCustomMiddleware(errorLimiter).GET("/api/_version_/fleet/device/{token}/device_mapping", listDeviceHostDeviceMappingEndpoint, listDeviceHostDeviceMappingRequest{})
 	de.WithCustomMiddleware(errorLimiter).GET("/api/_version_/fleet/device/{token}/macadmins", getDeviceMacadminsDataEndpoint, getDeviceMacadminsDataRequest{})
 	de.WithCustomMiddleware(errorLimiter).GET("/api/_version_/fleet/device/{token}/policies", listDevicePoliciesEndpoint, listDevicePoliciesRequest{})
-	de.WithCustomMiddleware(errorLimiter).GET("/api/_version_/fleet/device/{token}/transparency", transparencyURL, transparencyURLRequest{})
-	de.WithCustomMiddleware(errorLimiter).WithRequestBodySizeLimit(fleet.MaxFleetdErrorReportSize).POST("/api/_version_/fleet/device/{token}/debug/errors", fleetdError, fleetdErrorRequest{})
 	de.WithCustomMiddleware(errorLimiter).GET("/api/_version_/fleet/device/{token}/software", getDeviceSoftwareEndpoint, getDeviceSoftwareRequest{})
 	de.WithCustomMiddleware(errorLimiter).POST("/api/_version_/fleet/device/{token}/software/install/{software_title_id}", submitSelfServiceSoftwareInstall, fleetSelfServiceSoftwareInstallRequest{})
 	de.WithCustomMiddleware(errorLimiter).POST("/api/_version_/fleet/device/{token}/software/install_all", submitSelfServiceSoftwareInstallAll, fleetSelfServiceSoftwareInstallAllRequest{})
@@ -987,6 +983,12 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	de.WithCustomMiddleware(errorLimiter).POST("/api/_version_/fleet/device/{token}/mdm/linux/trigger_escrow", triggerLinuxDiskEncryptionEscrowEndpoint, triggerLinuxDiskEncryptionEscrowRequest{})
 	de.WithCustomMiddleware(errorLimiter).POST("/api/_version_/fleet/device/{token}/bypass_conditional_access", bypassConditionalAccessEndpoint, bypassConditionalAccessRequest{})
 
+	// Endpoints exempt from the Fleet Desktop SSO gate.
+	deNoSSO := newDeviceSSOExemptEndpointer(svc, logger, opts, r, apiVersions...)
+	deNoSSO.WithCustomMiddleware(errorLimiter).GET("/api/_version_/fleet/device/{token}/desktop", getFleetDesktopEndpoint, getFleetDesktopRequest{})
+	deNoSSO.WithCustomMiddleware(errorLimiter).HEAD("/api/_version_/fleet/device/{token}/ping", devicePingEndpoint, deviceAuthPingRequest{})
+	deNoSSO.WithCustomMiddleware(errorLimiter).GET("/api/_version_/fleet/device/{token}/transparency", transparencyURL, transparencyURLRequest{})
+	deNoSSO.WithCustomMiddleware(errorLimiter).WithRequestBodySizeLimit(fleet.MaxFleetdErrorReportSize).POST("/api/_version_/fleet/device/{token}/debug/errors", fleetdError, fleetdErrorRequest{})
 	// Device-authenticated, so unlike the unauthenticated SSO routes this needs no
 	// pre-auth flood guard. It is quota-limited for amplification instead: each
 	// successful call refetches the IdP metadata, so one leaked device token could
@@ -996,13 +998,18 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	// at the same rate as the other end-user-facing SSO path, so
 	// auth.sso_rate_limit_per_minute tunes both.
 	deviceSsoLimiter := limiter.Limit("device_sso", throttled.RateQuota{MaxRate: ssoRateLimit, MaxBurst: 9})
-	de.WithCustomMiddleware(errorLimiter, deviceSsoLimiter).POST("/api/_version_/fleet/device/{token}/sso", initiateDeviceSSOEndpoint, initiateDeviceSSORequest{})
+	deNoSSO.WithCustomMiddleware(errorLimiter, deviceSsoLimiter).POST("/api/_version_/fleet/device/{token}/sso", initiateDeviceSSOEndpoint, initiateDeviceSSORequest{})
+	// migrate_mdm is posted by the tray app's "Migrate to Fleet" dialog with the
+	// device token alone (orbit/pkg/useraction -> DeviceClient.MigrateMDM), and it
+	// has no browser to complete an IdP round-trip in.
+	deNoSSOmdm := deNoSSO.WithCustomMiddleware(mdmConfiguredMiddleware.VerifyAppleMDM())
+	deNoSSOmdm.AppendCustomMiddleware(errorLimiter).POST("/api/_version_/fleet/device/{token}/migrate_mdm", migrateMDMDeviceEndpoint, deviceMigrateMDMRequest{})
+
 	// Device authenticated, Apple MDM endpoints.
 	demdm := de.WithCustomMiddleware(mdmConfiguredMiddleware.VerifyAppleMDM())
 	demdm.AppendCustomMiddleware(errorLimiter).GET("/api/_version_/fleet/device/{token}/mdm/apple/manual_enrollment_profile", getDeviceMDMManualEnrollProfileEndpoint, getDeviceMDMManualEnrollProfileRequest{})
 	demdm.AppendCustomMiddleware(errorLimiter).GET("/api/_version_/fleet/device/{token}/software/commands/{command_uuid}/results", getDeviceMDMCommandResultsEndpoint, getDeviceMDMCommandResultsRequest{})
 	demdm.AppendCustomMiddleware(errorLimiter).POST("/api/_version_/fleet/device/{token}/configuration_profiles/{profile_uuid}/resend", resendDeviceConfigurationProfileEndpoint, resendDeviceConfigurationProfileRequest{})
-	demdm.AppendCustomMiddleware(errorLimiter).POST("/api/_version_/fleet/device/{token}/migrate_mdm", migrateMDMDeviceEndpoint, deviceMigrateMDMRequest{})
 
 	// host-authenticated endpoints
 	//

--- a/server/service/integration_desktop_test.go
+++ b/server/service/integration_desktop_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"testing"
 	"time"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/datastore/redis"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/ptr"
+	"github.com/fleetdm/fleet/v4/server/test"
 
 	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
@@ -567,4 +569,139 @@ func (s *integrationEnterpriseTestSuite) TestAlternativeBrowserHostSetting() {
 	require.NoError(t, json.NewDecoder(res.Body).Decode(&getDesktopResp))
 	require.NoError(t, res.Body.Close())
 	require.Equal(t, "althost", getDesktopResp.AlternativeBrowserHost)
+}
+
+// requireSSORequired asserts whether res carries the marker the "My device" page
+// keys off of to start the Fleet Desktop SSO flow.
+func requireSSORequired(t *testing.T, res *http.Response, want bool) {
+	t.Helper()
+	defer res.Body.Close()
+
+	var body struct {
+		SSORequired bool `json:"sso_required"`
+	}
+	require.NoError(t, json.NewDecoder(res.Body).Decode(&body))
+	require.Equal(t, want, body.SSORequired)
+}
+
+// enableFleetDesktopSSO turns the setting on with a placeholder IdP, and turns
+// both back off when the test ends.
+func (s *integrationEnterpriseTestSuite) enableFleetDesktopSSO(metadataURL string) {
+	t := s.T()
+
+	t.Cleanup(func() {
+		s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(`{
+			"fleet_desktop": { "sso_enabled": false },
+			"mdm": { "end_user_authentication": { "entity_id": "", "idp_name": "", "metadata_url": "" } }
+		}`), http.StatusOK, &appConfigResponse{})
+	})
+
+	var acResp appConfigResponse
+	s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(fmt.Sprintf(`{
+		"mdm": {
+			"end_user_authentication": {
+				"entity_id": "mdm.test.com",
+				"idp_name": "SimpleSAML",
+				"metadata_url": %q
+			}
+		},
+		"fleet_desktop": { "sso_enabled": true }
+	}`, metadataURL)), http.StatusOK, &acResp)
+	require.True(t, acResp.FleetDesktop.SSOEnabled)
+}
+
+func (s *integrationEnterpriseTestSuite) TestFleetDesktopSSOGate() {
+	t := s.T()
+	ctx := t.Context()
+
+	token := "desktop_sso_gate_token"
+	host := createHostAndDeviceToken(t, s.ds, token)
+
+	// baseline: with the setting off the device page needs nothing but the token
+	s.DoRawNoAuth("GET", "/api/latest/fleet/device/"+token, nil, http.StatusOK).Body.Close()
+
+	s.enableFleetDesktopSSO("https://idp.example.com/metadata")
+
+	// no session cookie: the SPA is told to sign in rather than that its URL is bad
+	requireSSORequired(t, s.DoRawNoAuth("GET", "/api/latest/fleet/device/"+token, nil, http.StatusUnauthorized), true)
+	requireSSORequired(t, s.DoRawNoAuth("GET", "/api/latest/fleet/device/"+token+"/policies", nil, http.StatusUnauthorized), true)
+	requireSSORequired(t, s.DoRawNoAuth("GET", "/api/latest/fleet/device/"+token+"/software", nil, http.StatusUnauthorized), true)
+
+	// a session ID that matches nothing is no better than no cookie at all
+	requireSSORequired(t, s.DoRawWithHeaders("GET", "/api/latest/fleet/device/"+token, nil, http.StatusUnauthorized,
+		map[string]string{"Cookie": cookieNameDeviceSSOSession + "=not-a-session"}), true)
+
+	// an invalid token is still an invalid token: signing in would not fix it
+	requireSSORequired(t, s.DoRawNoAuth("GET", "/api/latest/fleet/device/no_such_token", nil, http.StatusUnauthorized), false)
+
+	// the exempt endpoints answer exactly as they do with the setting off
+	s.DoRawNoAuth("GET", "/api/latest/fleet/device/"+token+"/desktop", nil, http.StatusOK).Body.Close()
+	s.DoRawNoAuth("HEAD", "/api/latest/fleet/device/"+token+"/ping", nil, http.StatusOK).Body.Close()
+	s.DoRawNoAuth("GET", "/api/latest/fleet/device/"+token+"/transparency", nil, http.StatusTemporaryRedirect).Body.Close()
+	s.DoRawNoAuth("POST", "/api/latest/fleet/device/"+token+"/debug/errors", []byte("{}"), http.StatusOK).Body.Close()
+	// The tray app's migration dialog posts this with the token alone. Apple MDM is
+	// not configured in this suite, so it stops at that check -- which is the point:
+	// it got past the gate rather than being told to sign in.
+	requireSSORequired(t, s.DoRawNoAuth("POST", "/api/latest/fleet/device/"+token+"/migrate_mdm", nil, http.StatusBadRequest), false)
+
+	// the orbit endpoints authenticate on their own middleware and are untouched
+	s.DoRawNoAuth("POST", "/api/fleet/orbit/config", []byte(`{"orbit_node_key":"no_such_key"}`), http.StatusUnauthorized).Body.Close()
+
+	// a host still in Setup Experience is carved out: an IdP prompt inside Setup
+	// Assistant is the failure this feature exists to retire
+	require.NoError(t, s.ds.SetHostAwaitingConfiguration(ctx, host.UUID, true))
+	s.DoRawNoAuth("GET", "/api/latest/fleet/device/"+token, nil, http.StatusOK).Body.Close()
+
+	// and once Setup Experience is done, the next visit is gated again
+	require.NoError(t, s.ds.SetHostAwaitingConfiguration(ctx, host.UUID, false))
+	requireSSORequired(t, s.DoRawNoAuth("GET", "/api/latest/fleet/device/"+token, nil, http.StatusUnauthorized), true)
+}
+
+func (s *integrationEnterpriseTestSuite) TestFleetDesktopSSOGateEndToEnd() {
+	t := s.T()
+
+	if _, ok := os.LookupEnv("SAML_IDP_TEST"); !ok {
+		t.Skip("SSO tests are disabled")
+	}
+
+	token := "desktop_sso_e2e_token" //nolint:gosec // G101: test value, not a real credential
+	createHostAndDeviceToken(t, s.ds, token)
+
+	otherToken := "desktop_sso_e2e_other_token" //nolint:gosec // G101: test value, not a real credential
+	otherHost := test.NewHost(t, s.ds, t.Name()+"-other.local", "", t.Name()+"-other", uuid.New().String(), time.Now())
+	createDeviceTokenForHost(t, s.ds, otherHost.ID, otherToken)
+
+	var acResp appConfigResponse
+	s.DoJSON("GET", "/api/latest/fleet/config", nil, http.StatusOK, &acResp)
+	originalServerURL := acResp.ServerSettings.ServerURL
+	t.Cleanup(func() {
+		s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(fmt.Sprintf(
+			`{"server_settings": {"server_url": %q}}`, originalServerURL)), http.StatusOK, &appConfigResponse{})
+	})
+	s.DoJSON("PATCH", "/api/latest/fleet/config",
+		json.RawMessage(`{"server_settings": {"server_url": "https://localhost:8080"}}`), http.StatusOK, &acResp)
+
+	s.enableFleetDesktopSSO(testSAMLIDPMetadataURL)
+
+	// refused before signing in
+	requireSSORequired(t, s.DoRawNoAuth("GET", "/api/latest/fleet/device/"+token, nil, http.StatusUnauthorized), true)
+
+	res := s.LoginDeviceSSOUser("sso_user", "user123#", token)
+	var sessionCookie *http.Cookie
+	for _, c := range res.Cookies() {
+		if c.Name == cookieNameDeviceSSOSession {
+			sessionCookie = c
+		}
+	}
+	require.NotNil(t, sessionCookie)
+	require.NotEmpty(t, sessionCookie.Value)
+
+	// admitted with the session the callback minted
+	sessionHeader := map[string]string{"Cookie": cookieNameDeviceSSOSession + "=" + sessionCookie.Value}
+	s.DoRawWithHeaders("GET", "/api/latest/fleet/device/"+token, nil, http.StatusOK, sessionHeader).Body.Close()
+
+	// but only for the host it was minted for: the same browser holding this
+	// cookie cannot open another device's page
+	requireSSORequired(t, s.DoRawWithHeaders("GET", "/api/latest/fleet/device/"+otherToken, nil,
+		http.StatusUnauthorized, sessionHeader), true)
 }

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -7037,7 +7037,8 @@ func (s *integrationMDMTestSuite) TestDeviceSSO() {
 	require.NoError(t, err)
 	s.DoRawNoAuth("POST", "/api/v1/fleet/mdm/sso", forgedBody, http.StatusBadRequest)
 
-	s.DoRawNoAuth("GET", "/api/latest/fleet/device/"+deviceToken, nil, http.StatusOK)
+	// the gate is on, so the device page is refused until the end user signs in
+	requireSSORequired(t, s.DoRawNoAuth("GET", "/api/latest/fleet/device/"+deviceToken, nil, http.StatusUnauthorized), true)
 
 	// complete *this* flow: sign in at the IdP and post the assertion back to the
 	// existing MDM SSO callback, on the same client that holds the handshake cookie

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -959,45 +959,7 @@ func (svc *Service) labelQueriesForHost(ctx context.Context, host *fleet.Host) (
 }
 
 func (svc *Service) hostIsInSetupExperience(ctx context.Context, host *fleet.Host) (bool, error) {
-	switch {
-	case host.Platform == string(fleet.MacOSPlatform):
-		inSetupExperience, err := svc.ds.GetHostAwaitingConfiguration(ctx, host.UUID)
-		if err != nil && !fleet.IsNotFound(err) {
-			return false, ctxerr.Wrap(ctx, err, "check if host is in setup experience")
-		}
-		return inSetupExperience, nil
-	case fleet.IsLinux(host.Platform) || host.Platform == "windows":
-		hostUUID, err := fleet.HostUUIDForSetupExperience(host)
-		if err != nil {
-			return false, ctxerr.Wrap(ctx, err, "failed to get host's UUID for the setup experience")
-		}
-		inSetupExperience, err := svc.hasSetupExperiencePendingOrRunningItems(ctx, hostUUID, ptr.ValOrZero(host.TeamID))
-		if err != nil && !fleet.IsNotFound(err) {
-			return false, ctxerr.Wrap(ctx, err, "check setup experience pending or running items")
-		}
-		return inSetupExperience, nil
-	default:
-		return false, nil
-	}
-}
-
-func (svc *Service) hasSetupExperiencePendingOrRunningItems(ctx context.Context, hostUUID string, teamID uint) (bool, error) {
-	statuses, err := svc.ds.ListSetupExperienceResultsByHostUUID(ctx, hostUUID, teamID)
-	if err != nil {
-		return false, ctxerr.Wrap(ctx, err, "retrieving setup experience results")
-	}
-
-	for _, status := range statuses {
-		if err := status.IsValid(); err != nil {
-			return false, ctxerr.Wrap(ctx, err, "invalid row")
-		}
-
-		switch status.Status {
-		case fleet.SetupExperienceStatusPending, fleet.SetupExperienceStatusRunning:
-			return true, nil
-		}
-	}
-	return false, nil
+	return fleet.HostIsInSetupExperience(ctx, svc.ds, host)
 }
 
 // discardOutOfScopePolicyResults removes, in place, the results for policies that are not in scope for the host.

--- a/server/service/transport_error.go
+++ b/server/service/transport_error.go
@@ -6,14 +6,32 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/platform/endpointer"
 	platform_http "github.com/fleetdm/fleet/v4/server/platform/http"
 )
 
-// FleetErrorEncoder handles fleet-specific error encoding for MailError
-// and OsqueryError.
+// FleetErrorEncoder handles fleet-specific error encoding for
+// DeviceSSORequiredError, MailError and OsqueryError.
 func FleetErrorEncoder(ctx context.Context, err error, w http.ResponseWriter, enc *json.Encoder, jsonErr *endpointer.JsonError) bool {
 	switch e := err.(type) {
+	case *fleet.DeviceSSORequiredError:
+		// Used to distinguish a "you need to sign in with your IdP" scenario
+		// apart from a stale device token, which are both 401.
+		w.WriteHeader(http.StatusUnauthorized)
+		jsonErr.Message = e.Error()
+		jsonErr.Errors = []map[string]string{
+			{
+				"name":   "base",
+				"reason": e.Error(),
+			},
+		}
+		enc.Encode(deviceSSORequiredJSONError{ //nolint:errcheck
+			JsonError:   *jsonErr,
+			SSORequired: true,
+		})
+		return true
+
 	case MailError:
 		jsonErr.Message = "Mail Error"
 		jsonErr.Errors = []map[string]string{
@@ -54,6 +72,13 @@ func FleetErrorEncoder(ctx context.Context, err error, w http.ResponseWriter, en
 	}
 
 	return false
+}
+
+// deviceSSORequiredJSONError is the standard error envelope plus the marker the
+// "My device" page keys off of to start the Fleet Desktop SSO flow.
+type deviceSSORequiredJSONError struct {
+	endpointer.JsonError
+	SSORequired bool `json:"sso_required"`
 }
 
 // MailError is set when an error performing mail operations


### PR DESCRIPTION
Relates to #51521

With fleet_desktop.sso_enabled set, device API endpoints require a device SSO session in addition to the device token. Exemptions are implemented as a separate endpointer, not a path match in the middleware.

Rejections are 401 with "sso_required": true so the My device page can tell "sign in with your IdP" apart from a stale device token.

## Enforcement flow

```mermaid
  flowchart TD
      REQ["Device API request"] --> LIM["errorLimiter"]
      LIM --> AUTH["authenticatedDevice:<br/>resolve host from rotating token,<br/>client certificate, or device UUID"]
      AUTH -->|"cannot resolve"| BADTOK["401 Authentication required<br/>NO sso_required marker"]
      AUTH -->|"host stashed in hostctx"| CHAIN{"Is the gate middleware<br/>in this route's chain?<br/>decided at registration"}

      CHAIN -->|"absent: deNoSSO routes<br/>desktop, ping, debug/errors,<br/>transparency, sso, migrate_mdm"| EP["Endpoint runs"]
      CHAIN -->|"present: every other<br/>device route, by default"| ENABLED

      ENABLED{"fleet_desktop.sso_enabled?"}
      ENABLED -->|"false, or Fleet Free"| EP
      ENABLED -->|"true"| SETUP{"Host awaiting<br/>configuration?"}

      SETUP -->|"yes: mid Setup Assistant"| EP
      SETUP -->|"no"| SESS{"validateDeviceSSOSession<br/>on the cookie"}

      SESS -->|"session store failed"| ERR500["500<br/>not a prompt to sign in"]
      SESS -->|"absent or expired"| DENY
      SESS -->|"belongs to another host"| DENY
      SESS -->|"valid and bound to this host"| EP
  
      DENY["401 with sso_required: true"]
```


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [x] QA'd all new/changed functionality manually
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Fleet Desktop SSO protection for device endpoints.
  * Valid sessions are accepted across supported device authentication methods.
  * Setup Experience access remains available during device configuration.
  * SSO-required responses now return a clear `401` status with an identifying marker.
* **Bug Fixes**
  * Prevented invalid, expired, or mismatched sessions from bypassing SSO requirements.
  * Preserved access to designated SSO-exempt device endpoints.
* **Tests**
  * Added comprehensive coverage for routes, sessions, authentication methods, and setup flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->