### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/cribl-edge/windows.json
+++ b/ee/maintained-apps/outputs/cribl-edge/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "4.19.0",
+      "version": "4.19.2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Cribl Edge' AND publisher = 'Cribl, Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Cribl Edge' AND publisher = 'Cribl, Inc.' AND version_compare(version, '4.19.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Cribl Edge' AND publisher = 'Cribl, Inc.' AND version_compare(version, '4.19.2') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'cribl edge.exe');"
       },
-      "installer_url": "https://cdn.cribl.io/dl/4.19.0/cribl-4.19.0-0fbd6d34-win32-x64.msi",
+      "installer_url": "https://cdn.cribl.io/dl/4.19.2/cribl-4.19.2-89cac507-win32-x64.msi",
       "install_script_ref": "22e48c46",
       "uninstall_script_ref": "00e56c03",
-      "sha256": "dbdd46c9bab205ec6d4ba79336010d2a2a443d0cbcf0d7fc656d035642acf7e1",
+      "sha256": "a16ade6c4efce166a677cc94a9e4feac07e37d92eae4066bd28c37569f8c1363",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/directory-opus/windows.json
+++ b/ee/maintained-apps/outputs/directory-opus/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "13.24",
+      "version": "13.25",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Directory Opus' AND publisher = 'GPSoftware';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Directory Opus' AND publisher = 'GPSoftware' AND version_compare(version, '13.24') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Directory Opus' AND publisher = 'GPSoftware' AND version_compare(version, '13.25') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'directory opus.exe');"
       },
-      "installer_url": "https://cdn.gpsoft.com.au/files/Opus13/DOpusInstall-13.24.exe",
+      "installer_url": "https://cdn.gpsoft.com.au/files/Opus13/DOpusInstall-13.25.exe",
       "install_script_ref": "37fe3170",
       "uninstall_script_ref": "bc24b894",
-      "sha256": "b085fcbd1920a3f9e2fdb7eaa5e39c07084b598d739fd019a4cdb9c89e4ca63c",
+      "sha256": "41fdf3c800f61aebdeec054ab3e43f176a1798cda23c2a953cfc8bff7e6c4975",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated Cribl Edge for Windows to version 4.19.2.
  - Updated Directory Opus for Windows to version 13.25.
  - Refreshed the corresponding installer packages and verification details to support reliable downloads and installation.
  - Existing installation and uninstall behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->