### PR TITLE
osquery-perf: fetch-to-ack delay for testing MDM command cancellation

### DIFF
--- a/cmd/osquery-perf/README.md
+++ b/cmd/osquery-perf/README.md
@@ -124,6 +124,8 @@ go run agent.go --os_templates ipad_13.18,iphone_14.6 --host_count 10 --mdm_scep
 
 `mdm_apns_url` sets the mock APNs server URL for the simulated Apple MDM devices. It is required when using iPhone/iPad templates and required when using macOS templates with a non-zero `mdm_prob`.
 
+`mdm_cancelable_command_ack_delay` makes simulated Apple devices log when they fetch a cancelable MDM command (lock, wipe, clear passcode, enable lost mode) and wait the given duration before acknowledging it. This opens a window to cancel an already-delivered command (`DELETE /api/v1/fleet/hosts/:id/commands/:command_uuid`) and observe the server restoring the host's lock/wipe state when the acknowledgment arrives anyway. The default is 0 (acknowledge immediately, no behavior change).
+
 ### Apple Platform SSO (PSSO)
 
 A subset of macOS MDM agents can additionally exercise Apple Platform SSO: device

--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -372,10 +372,28 @@ type mdmAgent struct {
 	strings                    map[string]string
 	softwareVersionMap         map[rune]int // Maps first char to version option: 0=base, 1=alternate, 2-31=patch versions 0-29
 	mdmProfileFailureProb      float64
+	cancelableCmdAckDelay      time.Duration
 	osVersion                  string
 	supplementalOSVersionExtra string
 	isPersonalEnrollment       bool
 	apnsPushURL                string
+}
+
+// delayCancelableMDMAck holds the fetch→acknowledge window open for
+// cancelable MDM commands (lock, wipe, clear passcode, enable lost mode) so
+// that DELETE /api/v1/fleet/hosts/:id/commands/:command_uuid can be exercised
+// against a command the device has already fetched (#43181). No-op when the
+// delay is 0 or the command is not cancelable.
+func delayCancelableMDMAck(delay time.Duration, deviceDesc string, cmd *mdm.Command) {
+	if delay <= 0 || cmd == nil {
+		return
+	}
+	if _, ok := fleet.CancelableAppleMDMRequestTypes[cmd.Command.RequestType]; !ok {
+		return
+	}
+	log.Printf("%s: fetched %s command %s, waiting %s before acknowledging (cancel test window)",
+		deviceDesc, cmd.Command.RequestType, cmd.CommandUUID, delay)
+	time.Sleep(delay)
 }
 
 // stats, model, *serverURL, *mdmSCEPChallenge, *mdmCheckInInterval
@@ -589,6 +607,7 @@ type agent struct {
 	MDMCheckInInterval    time.Duration
 	DiskEncryptionEnabled bool
 	mdmProfileFailureProb float64
+	cancelableCmdAckDelay time.Duration
 	OSPatchLevel          int                 // For Linux patches
 	linuxKernels          []map[string]string // Pre-selected kernels for this agent
 	softwareVersionMap    map[rune]int        // Maps first char to version option: 0=base, 1=alternate, 2-31=patch versions 0-29
@@ -719,6 +738,7 @@ func newAgent(
 	linuxUniqueSoftwareTitle bool,
 	commonSoftwareNameSuffix string,
 	mdmProfileFailureProb float64,
+	cancelableCmdAckDelay time.Duration,
 	httpMessageSignatureProb float64,
 	httpMessageSignatureP384Prob float64,
 	psso pssoParams,
@@ -828,6 +848,7 @@ func newAgent(
 		cachedLastOpenedAt:       make(map[string]*time.Time),
 		commonSoftwareNameSuffix: commonSoftwareNameSuffix,
 		mdmProfileFailureProb:    mdmProfileFailureProb,
+		cancelableCmdAckDelay:    cancelableCmdAckDelay,
 		// Every 20th host (5%) withholds its issued SCEP certs to exercise the server's verification backstop (test-only failure).
 		withholdSCEPCert: agentIndex%20 == 0,
 
@@ -1495,6 +1516,8 @@ func (a *agent) runMacosMDMLoop() {
 	INNER_FOR_LOOP:
 		for mdmCommandPayload != nil {
 			a.stats.IncrementMDMCommandsReceived()
+			delayCancelableMDMAck(a.cancelableCmdAckDelay,
+				fmt.Sprintf("macOS agent %s", a.macMDMClient.SerialNumber), mdmCommandPayload)
 
 			switch mdmCommandPayload.Command.RequestType {
 			case "InstallProfile":
@@ -4102,6 +4125,7 @@ func (a *mdmAgent) runAppleIDeviceMDMLoop(mdmSCEPChallenge string) {
 
 		for mdmCommandPayload != nil {
 			a.stats.IncrementMDMCommandsReceived()
+			delayCancelableMDMAck(a.cancelableCmdAckDelay, deviceName, mdmCommandPayload)
 			switch mdmCommandPayload.Command.RequestType {
 			case "DeviceInformation":
 				if a.isPersonalEnrollment {
@@ -4308,6 +4332,7 @@ func main() {
 		mdmAPNSURL            = flag.String("mdm_apns_url", "", "APNS URL to check for MDM push notifications (e.g., http://localhost:8378) - required for Apple (macOS/iOS/iPadOS) MDM enrollments.")
 		mdmSCEPChallenge      = flag.String("mdm_scep_challenge", "", "SCEP challenge to use when running macOS MDM enroll")
 		mdmProfileFailureProb = flag.Float64("mdm_profile_failure_prob", 0.0, "Probability of an MDM profile to fail install [0, 1]")
+		mdmCancelableCommandAckDelay = flag.Duration("mdm_cancelable_command_ack_delay", 0, "Delay between fetching a cancelable MDM command (lock, wipe, clear passcode, enable lost mode) and acknowledging it, opening a window to test command cancellation")
 		mdmIOSBYODProb        = flag.Float64("mdm_ios_byod_prob", 0.0, "Probability of a simulated iOS/iPadOS device (os_templates iphone_14.6/ipad_13.18/iphone_17) reporting as a personal (BYOD) enrollment, which omits the newer device vitals fields from its DeviceInformation ack [0, 1]")
 
 		mdmPSSOProb      = flag.Float64("mdm_psso_prob", 0.0, "Probability of an MDM-enrolled macOS host also simulating Apple Platform SSO [0, 1]. Requires the Fleet server to have account provisioning configured and the PSSO profile assigned to the host")
@@ -4515,6 +4540,7 @@ func main() {
 				strings:               make(map[string]string),
 				softwareVersionMap:    make(map[rune]int),
 				mdmProfileFailureProb: *mdmProfileFailureProb,
+				cancelableCmdAckDelay: *mdmCancelableCommandAckDelay,
 				apnsPushURL:           *mdmAPNSURL,
 			}
 			go mobileDevice.runAppleIDeviceMDMLoop(*mdmSCEPChallenge)
@@ -4621,6 +4647,7 @@ func main() {
 			*linuxUniqueSoftwareTitle,
 			*commonSoftwareNameSuffix,
 			*mdmProfileFailureProb,
+			*mdmCancelableCommandAckDelay,
 			*httpMessageSignatureProb,
 			*httpMessageSignatureP384Prob,
 			pssoParams{

--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -4328,13 +4328,13 @@ func main() {
 		defaultSerialProb = flag.Float64("default_serial_prob", 0.05,
 			"Probability of osquery returning a default (-1) serial number. See: #19789")
 
-		mdmProb               = flag.Float64("mdm_prob", 0.0, "Probability of a host enrolling via Fleet MDM (applies for macOS and Windows hosts, implies orbit enrollment on Windows) [0, 1]")
-		mdmUserProb           = flag.Float64("mdm_user_prob", 0.0, "Probability of a host having an MDM user enrollment (compounds on mdm_prob) [0, 1]")
-		mdmAPNSURL            = flag.String("mdm_apns_url", "", "APNS URL to check for MDM push notifications (e.g., http://localhost:8378) - required for Apple (macOS/iOS/iPadOS) MDM enrollments.")
-		mdmSCEPChallenge      = flag.String("mdm_scep_challenge", "", "SCEP challenge to use when running macOS MDM enroll")
-		mdmProfileFailureProb = flag.Float64("mdm_profile_failure_prob", 0.0, "Probability of an MDM profile to fail install [0, 1]")
+		mdmProb                      = flag.Float64("mdm_prob", 0.0, "Probability of a host enrolling via Fleet MDM (applies for macOS and Windows hosts, implies orbit enrollment on Windows) [0, 1]")
+		mdmUserProb                  = flag.Float64("mdm_user_prob", 0.0, "Probability of a host having an MDM user enrollment (compounds on mdm_prob) [0, 1]")
+		mdmAPNSURL                   = flag.String("mdm_apns_url", "", "APNS URL to check for MDM push notifications (e.g., http://localhost:8378) - required for Apple (macOS/iOS/iPadOS) MDM enrollments.")
+		mdmSCEPChallenge             = flag.String("mdm_scep_challenge", "", "SCEP challenge to use when running macOS MDM enroll")
+		mdmProfileFailureProb        = flag.Float64("mdm_profile_failure_prob", 0.0, "Probability of an MDM profile to fail install [0, 1]")
 		mdmCancelableCommandAckDelay = flag.Duration("mdm_cancelable_command_ack_delay", 0, "Delay between fetching a cancelable MDM command (lock, wipe, clear passcode, enable lost mode) and acknowledging it, opening a window to test command cancellation")
-		mdmIOSBYODProb        = flag.Float64("mdm_ios_byod_prob", 0.0, "Probability of a simulated iOS/iPadOS device (os_templates iphone_14.6/ipad_13.18/iphone_17) reporting as a personal (BYOD) enrollment, which omits the newer device vitals fields from its DeviceInformation ack [0, 1]")
+		mdmIOSBYODProb               = flag.Float64("mdm_ios_byod_prob", 0.0, "Probability of a simulated iOS/iPadOS device (os_templates iphone_14.6/ipad_13.18/iphone_17) reporting as a personal (BYOD) enrollment, which omits the newer device vitals fields from its DeviceInformation ack [0, 1]")
 
 		mdmPSSOProb      = flag.Float64("mdm_psso_prob", 0.0, "Probability of an MDM-enrolled macOS host also simulating Apple Platform SSO [0, 1]. Requires the Fleet server to have account provisioning configured and the PSSO profile assigned to the host")
 		mdmPSSOClientID  = flag.String("mdm_psso_client_id", "", "Apple Platform SSO IdP/extension client ID. Must match the Fleet server's account provisioning config; PSSO is skipped when empty")

--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -382,8 +382,9 @@ type mdmAgent struct {
 // delayCancelableMDMAck holds the fetch→acknowledge window open for
 // cancelable MDM commands (lock, wipe, clear passcode, enable lost mode) so
 // that DELETE /api/v1/fleet/hosts/:id/commands/:command_uuid can be exercised
-// against a command the device has already fetched (#43181). No-op when the
-// delay is 0 or the command is not cancelable.
+// against a command the device has already fetched — Fleet cannot know a
+// command was delivered, so this window is the only way to test that race.
+// No-op when the delay is 0 or the command is not cancelable.
 func delayCancelableMDMAck(delay time.Duration, deviceDesc string, cmd *mdm.Command) {
 	if delay <= 0 || cmd == nil {
 		return

--- a/cmd/osquery-perf/agent_test.go
+++ b/cmd/osquery-perf/agent_test.go
@@ -201,3 +201,28 @@ func TestProcessQueryMDMConfigProfiles(t *testing.T) {
 	}
 	assert.True(t, sawSuccess)
 }
+
+func TestDelayCancelableMDMAck(t *testing.T) {
+	mkCmd := func(requestType string) *mdm.Command {
+		cmd := &mdm.Command{CommandUUID: "test-uuid"}
+		cmd.Command.RequestType = requestType
+		return cmd
+	}
+	elapsed := func(delay time.Duration, cmd *mdm.Command) time.Duration {
+		start := time.Now()
+		delayCancelableMDMAck(delay, "test device", cmd)
+		return time.Since(start)
+	}
+
+	// non-cancelable commands never wait, whatever the delay
+	assert.Less(t, elapsed(time.Hour, mkCmd("InstallProfile")), time.Second)
+	assert.Less(t, elapsed(time.Hour, nil), time.Second)
+
+	// a zero delay never waits, even for cancelable commands
+	for requestType := range fleet.CancelableAppleMDMRequestTypes {
+		assert.Less(t, elapsed(0, mkCmd(requestType)), time.Second)
+	}
+
+	// cancelable commands wait out the delay
+	assert.GreaterOrEqual(t, elapsed(20*time.Millisecond, mkCmd("DeviceLock")), 20*time.Millisecond)
+}


### PR DESCRIPTION
**Related issue:** For #43181 (QA tooling, per the test plan in #51163 — not intended to merge until QA is done with it)

Adds `--mdm_cancelable_command_ack_delay` to osquery-perf: simulated macOS and iOS/iPadOS devices log when they fetch a lock, wipe, clear passcode, or enable lost mode command and wait the given duration before acknowledging, opening a window to cancel an already-delivered command and observe the server's state restore.

Example: `go run ./cmd/osquery-perf --server_url ... --enroll_secret ... --mdm_prob 1.0 --mdm_cancelable_command_ack_delay 2m`

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] QA'd all new/changed functionality manually



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable acknowledgment delay for supported cancelable Apple MDM commands.
  * The delay can be set using the `mdm_cancelable_command_ack_delay` configuration option.
  * Applies to macOS and iOS/iPadOS MDM command processing when a positive delay is configured.

* **Bug Fixes**
  * Non-cancelable commands, empty commands, and zero-delay configurations continue without unnecessary waiting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->