### PR TITLE
Fix duplicate device mapping

### DIFF
--- a/changes/49914-duplicate-idp-device-mapping
+++ b/changes/49914-duplicate-idp-device-mapping
@@ -1,0 +1,1 @@
+- Fixed duplicate IdP device mapping ("2 users") shown for a host after it re-enrolled through ADE with end user authentication when its IdP username had previously been set manually. The enrollment now replaces the manually set mapping instead of adding a second one.

--- a/server/datastore/mysql/mdm.go
+++ b/server/datastore/mysql/mdm.go
@@ -2960,10 +2960,23 @@ func reconcileHostEmailsFromMdmIdpAccountsDB(ctx context.Context, tx sqlx.ExtCon
 		return nil, ctxerr.Wrap(ctx, err, "get host mdm idp account email")
 	}
 
+	// manually set IdP mappings (source "idp", written by
+	// SetOrUpdateIDPHostDeviceMapping) are reported by the API under the same
+	// "mdm_idp_accounts" source, so both sources form a single logical mapping
+	// and must be reconciled together to avoid duplicate device mappings.
 	var hostEmails []fleet.HostDeviceMapping
-	selectStmt := `SELECT id, host_id, email, source FROM host_emails WHERE host_id = ? AND source = ?`
-	if err := sqlx.SelectContext(ctx, tx, &hostEmails, selectStmt, hostID, fleet.DeviceMappingMDMIdpAccounts); err != nil {
+	selectStmt := `SELECT id, host_id, email, source FROM host_emails WHERE host_id = ? AND source IN (?, ?)`
+	if err := sqlx.SelectContext(ctx, tx, &hostEmails, selectStmt, hostID, fleet.DeviceMappingMDMIdpAccounts, fleet.DeviceMappingIDP); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "get host_emails")
+	}
+
+	var mdmIdpEmails, manualIdpEmails []fleet.HostDeviceMapping
+	for _, he := range hostEmails {
+		if he.Source == fleet.DeviceMappingIDP {
+			manualIdpEmails = append(manualIdpEmails, he)
+			continue
+		}
+		mdmIdpEmails = append(mdmIdpEmails, he)
 	}
 
 	// TODO: discuss email vs. username with Victor
@@ -2973,11 +2986,13 @@ func reconcileHostEmailsFromMdmIdpAccountsDB(ctx context.Context, tx sqlx.ExtCon
 		idpAccountUUID = idp.UUID
 	}
 
-	// if we don't have idp info, we can just delete any prior host mdm idp account emails
+	// if we don't have idp info, we can just delete any prior host mdm idp account
+	// emails; manually set mappings are left alone since they don't come from an
+	// enrollment
 	if idpEmail == "" {
-		if len(hostEmails) == 0 {
+		if len(mdmIdpEmails) == 0 {
 			// nothing to do
-			logger.InfoContext(ctx, "reconcile host emails: no mdm idp account and no host emails", "host_id", hostID, "account_uuid", idpAccountUUID)
+			logger.InfoContext(ctx, "reconcile host emails: no mdm idp account and no host emails", "host_id", hostID, "account_uuid", idpAccountUUID, "manual_idp_mappings", len(manualIdpEmails))
 			return nil, nil
 		}
 		// delete any prior host mdm idp account emails
@@ -2991,13 +3006,19 @@ func reconcileHostEmailsFromMdmIdpAccountsDB(ctx context.Context, tx sqlx.ExtCon
 	// analyze existing host emails to see if we have a match; we also want to handle potential
 	// duplicates because we don't have good constraints on the host_emails table
 	hits, misses := []fleet.HostDeviceMapping{}, []fleet.HostDeviceMapping{}
-	for _, he := range hostEmails {
+	for _, he := range mdmIdpEmails {
 		if he.Email == idp.Email {
 			hits = append(hits, he)
 		} else {
 			misses = append(misses, he)
 		}
 	}
+
+	// the authenticated IdP account supersedes any manually set mapping; otherwise the
+	// API would report both under the "mdm_idp_accounts" source as a duplicate device
+	// mapping. This mirrors SetOrUpdateIDPHostDeviceMapping, which deletes both sources
+	// before inserting.
+	misses = append(misses, manualIdpEmails...)
 
 	maxCapacity := len(misses)
 	if len(hits) > 1 {

--- a/server/datastore/mysql/mdm_idp_accounts_test.go
+++ b/server/datastore/mysql/mdm_idp_accounts_test.go
@@ -120,7 +120,7 @@ func testAssociateHostMDMIdPAccountTriggersReconciliation(t *testing.T, ds *Data
 // source (issue #49914: duplicate device mapping after EACS wipe and ADE
 // re-enrollment).
 func testReconcileSupersedesManuallySetIdPMapping(t *testing.T, ds *Datastore) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	idpAccount := &fleet.MDMIdPAccount{
 		Username: "sso.user",

--- a/server/datastore/mysql/mdm_idp_accounts_test.go
+++ b/server/datastore/mysql/mdm_idp_accounts_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mdm/android"
 	"github.com/fleetdm/fleet/v4/server/ptr"
+	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -20,6 +21,7 @@ func TestMDMIdPAccountsReconciliation(t *testing.T) {
 	}{
 		{"AssociateHostMDMIdPAccountTriggersReconciliation", testAssociateHostMDMIdPAccountTriggersReconciliation},
 		{"AndroidEnrollmentFlowWithIdP", testAndroidEnrollmentFlowWithIdP},
+		{"ReconcileSupersedesManuallySetIdPMapping", testReconcileSupersedesManuallySetIdPMapping},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -109,6 +111,153 @@ func testAssociateHostMDMIdPAccountTriggersReconciliation(t *testing.T, ds *Data
 			assert.Equal(t, "test.user@example.com", emails[0])
 		})
 	}
+}
+
+// testReconcileSupersedesManuallySetIdPMapping verifies that reconciling a
+// host's IdP association on (re-)enrollment replaces a manually set IdP
+// mapping (source "idp", written by SetOrUpdateIDPHostDeviceMapping) instead
+// of adding a second mapping reported under the same "mdm_idp_accounts" API
+// source (issue #49914: duplicate device mapping after EACS wipe and ADE
+// re-enrollment).
+func testReconcileSupersedesManuallySetIdPMapping(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+
+	idpAccount := &fleet.MDMIdPAccount{
+		Username: "sso.user",
+		Fullname: "SSO User",
+		Email:    "sso.user@example.com",
+	}
+	err := ds.InsertMDMIdPAccount(ctx, idpAccount)
+	require.NoError(t, err)
+
+	insertedAccount, err := ds.GetMDMIdPAccountByEmail(ctx, "sso.user@example.com")
+	require.NoError(t, err)
+	require.NotNil(t, insertedAccount)
+	idpAccount.UUID = insertedAccount.UUID
+
+	newDarwinHost := func(t *testing.T, uuid string) *fleet.Host {
+		h, err := ds.NewHost(ctx, &fleet.Host{
+			Hostname:      uuid + "-hostname",
+			UUID:          uuid,
+			Platform:      "darwin",
+			NodeKey:       new(uuid + "-key"),
+			OsqueryHostID: new(uuid + "-osquery"),
+		})
+		require.NoError(t, err)
+		require.NotZero(t, h.ID)
+		return h
+	}
+
+	countRawIdpRows := func(t *testing.T, hostID uint) int {
+		var count int
+		err := sqlx.GetContext(ctx, ds.writer(ctx), &count,
+			`SELECT COUNT(*) FROM host_emails WHERE host_id = ? AND source = ?`,
+			hostID, fleet.DeviceMappingIDP)
+		require.NoError(t, err)
+		return count
+	}
+
+	t.Run("manual mapping with different email", func(t *testing.T) {
+		host := newDarwinHost(t, "uuid-manual-diff")
+
+		err := ds.SetOrUpdateIDPHostDeviceMapping(ctx, host.ID, "someone.else@example.com")
+		require.NoError(t, err)
+
+		// enrollment reconciles the association and supersedes the manual mapping
+		err = ds.AssociateHostMDMIdPAccount(ctx, host.UUID, idpAccount.UUID)
+		require.NoError(t, err)
+
+		mappings, err := ds.ListHostDeviceMapping(ctx, host.ID)
+		require.NoError(t, err)
+		require.Len(t, mappings, 1)
+		assert.Equal(t, "sso.user@example.com", mappings[0].Email)
+		assert.Equal(t, fleet.DeviceMappingMDMIdpAccounts, mappings[0].Source)
+		assert.Zero(t, countRawIdpRows(t, host.ID))
+	})
+
+	t.Run("manual mapping with same email", func(t *testing.T) {
+		host := newDarwinHost(t, "uuid-manual-same")
+
+		err := ds.SetOrUpdateIDPHostDeviceMapping(ctx, host.ID, "sso.user@example.com")
+		require.NoError(t, err)
+
+		err = ds.AssociateHostMDMIdPAccount(ctx, host.UUID, idpAccount.UUID)
+		require.NoError(t, err)
+
+		mappings, err := ds.ListHostDeviceMapping(ctx, host.ID)
+		require.NoError(t, err)
+		require.Len(t, mappings, 1)
+		assert.Equal(t, "sso.user@example.com", mappings[0].Email)
+		assert.Equal(t, fleet.DeviceMappingMDMIdpAccounts, mappings[0].Source)
+		assert.Zero(t, countRawIdpRows(t, host.ID))
+	})
+
+	t.Run("correct mapping kept and stray manual mapping removed", func(t *testing.T) {
+		host := newDarwinHost(t, "uuid-hit-plus-manual")
+
+		// a correct enrollment row already exists alongside a stray manual row
+		// with a different email
+		_, err := ds.writer(ctx).ExecContext(ctx,
+			`INSERT INTO host_emails (host_id, email, source) VALUES (?, ?, ?), (?, ?, ?)`,
+			host.ID, "sso.user@example.com", fleet.DeviceMappingMDMIdpAccounts,
+			host.ID, "someone.else@example.com", fleet.DeviceMappingIDP)
+		require.NoError(t, err)
+
+		err = ds.AssociateHostMDMIdPAccount(ctx, host.UUID, idpAccount.UUID)
+		require.NoError(t, err)
+
+		mappings, err := ds.ListHostDeviceMapping(ctx, host.ID)
+		require.NoError(t, err)
+		require.Len(t, mappings, 1)
+		assert.Equal(t, "sso.user@example.com", mappings[0].Email)
+		assert.Equal(t, fleet.DeviceMappingMDMIdpAccounts, mappings[0].Source)
+		assert.Zero(t, countRawIdpRows(t, host.ID))
+	})
+
+	t.Run("existing duplicate mapping is healed on re-enrollment", func(t *testing.T) {
+		host := newDarwinHost(t, "uuid-dup")
+
+		// manufacture the duplicate state from #49914: a manual "idp" row alongside
+		// an enrollment "mdm_idp_accounts" row with the same email
+		_, err := ds.writer(ctx).ExecContext(ctx,
+			`INSERT INTO host_emails (host_id, email, source) VALUES (?, ?, ?), (?, ?, ?)`,
+			host.ID, "sso.user@example.com", fleet.DeviceMappingIDP,
+			host.ID, "sso.user@example.com", fleet.DeviceMappingMDMIdpAccounts)
+		require.NoError(t, err)
+
+		err = ds.AssociateHostMDMIdPAccount(ctx, host.UUID, idpAccount.UUID)
+		require.NoError(t, err)
+
+		mappings, err := ds.ListHostDeviceMapping(ctx, host.ID)
+		require.NoError(t, err)
+		require.Len(t, mappings, 1)
+		assert.Equal(t, "sso.user@example.com", mappings[0].Email)
+		assert.Equal(t, fleet.DeviceMappingMDMIdpAccounts, mappings[0].Source)
+		assert.Zero(t, countRawIdpRows(t, host.ID))
+	})
+
+	t.Run("manual mapping survives reconcile without idp account", func(t *testing.T) {
+		host := newDarwinHost(t, "uuid-manual-no-idp")
+
+		err := ds.SetOrUpdateIDPHostDeviceMapping(ctx, host.ID, "someone.else@example.com")
+		require.NoError(t, err)
+
+		// no host_mdm_idp_accounts association exists (e.g. re-enrollment without SSO)
+		err = ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
+			_, err := reconcileHostEmailsFromMdmIdpAccountsDB(ctx, tx, ds.logger, host.ID)
+			return err
+		})
+		require.NoError(t, err)
+
+		mappings, err := ds.ListHostDeviceMapping(ctx, host.ID)
+		require.NoError(t, err)
+		require.Len(t, mappings, 1)
+		assert.Equal(t, "someone.else@example.com", mappings[0].Email)
+		// a lone manual mapping is still reported under the translated
+		// "mdm_idp_accounts" source
+		assert.Equal(t, fleet.DeviceMappingMDMIdpAccounts, mappings[0].Source)
+		assert.Equal(t, 1, countRawIdpRows(t, host.ID))
+	})
 }
 
 // testAndroidEnrollmentFlowWithIdP tests the complete Android enrollment flow


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #49914

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed duplicate identity-provider device mappings after automated device re-enrollment with end-user authentication.
  - Existing manual mappings are now replaced when an authenticated account is detected.
  - Manual mappings are preserved when no authenticated identity-provider association exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->