### PR TITLE
Software: Return 4xx for invalid auto-update window on app_store_app PATCH

### DIFF
--- a/server/datastore/mysql/software_titles_test.go
+++ b/server/datastore/mysql/software_titles_test.go
@@ -2898,7 +2898,7 @@ func testUpdateAutoUpdateConfig(t *testing.T, ds *Datastore) {
 		AutoUpdateEndTime:   ptr.String(endTime),
 	})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Error parsing start time")
+	require.Contains(t, err.Error(), "auto_update_window_start must be in HH:MM")
 
 	// Attempt to enable auto-update with invalid end time.
 	startTime = "12:00"
@@ -2909,7 +2909,7 @@ func testUpdateAutoUpdateConfig(t *testing.T, ds *Datastore) {
 		AutoUpdateEndTime:   ptr.String(endTime),
 	})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Error parsing end time")
+	require.Contains(t, err.Error(), "auto_update_window_end must be in HH:MM")
 
 	// Attempt to enable auto-update with less than an hour between start and end time.
 	startTime = "12:00"

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -380,11 +381,12 @@ func (s SoftwareAutoUpdateSchedule) WindowIsValid() error {
 	return nil
 }
 
-// parseAutoUpdateHHMM parses a zero-padded 24-hour "HH:MM" window boundary.
-// time.Parse("15:04", ...) alone accepts unpadded values like "1:00", so the
-// five-character shape is enforced before parsing.
+var autoUpdateHHMMPattern = regexp.MustCompile(`^\d{1,2}:\d{2}$`)
+
+// parseAutoUpdateHHMM validates the 24-hour time shape and parses it. Unpadded hours
+// ("1:00") are accepted because the cron reader (isTimezoneInWindow) tolerates them.
 func parseAutoUpdateHHMM(s string) (time.Time, error) {
-	if len(s) != 5 || s[2] != ':' {
+	if !autoUpdateHHMMPattern.MatchString(s) {
 		return time.Time{}, errors.New("must be HH:MM")
 	}
 	return time.Parse("15:04", s)

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -359,26 +359,23 @@ type SoftwareAutoUpdateSchedule struct {
 
 func (s SoftwareAutoUpdateSchedule) WindowIsValid() error {
 	if s.AutoUpdateStartTime == nil || s.AutoUpdateEndTime == nil || *s.AutoUpdateStartTime == "" || *s.AutoUpdateEndTime == "" {
-		return errors.New("Start and end time must both be set")
+		return NewInvalidArgumentError("auto_update_window", "Start and end time must both be set")
 	}
-	// Validate that the times are in HH:MM format.
-	// Note that durations can be arbitrarily long, but parsing in this way
-	// automatically validates that the hours are between 0 and 23 and the minutes are between 0 and 59.
+	// Parsing as 15:04 also enforces hours 0-23 and minutes 0-59.
 	startDuration, err := time.Parse("15:04", *s.AutoUpdateStartTime)
 	if err != nil {
-		return fmt.Errorf("Error parsing start time: %w", err)
+		return NewInvalidArgumentError("auto_update_window_start", "must be in HH:MM (24-hour) format")
 	}
 	endDuration, err := time.Parse("15:04", *s.AutoUpdateEndTime)
 	if err != nil {
-		return fmt.Errorf("Error parsing end time: %w", err)
+		return NewInvalidArgumentError("auto_update_window_end", "must be in HH:MM (24-hour) format")
 	}
-	// Validate that the window is at least one hour long.
-	// If the end time is less than the start time, the window wraps to the next day, so we need to add 24 hours to the end time in that case.
+	// If end < start the window wraps past midnight.
 	if endDuration.Before(startDuration) {
 		endDuration = endDuration.Add(24 * time.Hour)
 	}
 	if endDuration.Sub(startDuration) < time.Hour {
-		return errors.New("The update window must be at least one hour long")
+		return NewInvalidArgumentError("auto_update_window", "The update window must be at least one hour long")
 	}
 
 	return nil

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -361,12 +361,11 @@ func (s SoftwareAutoUpdateSchedule) WindowIsValid() error {
 	if s.AutoUpdateStartTime == nil || s.AutoUpdateEndTime == nil || *s.AutoUpdateStartTime == "" || *s.AutoUpdateEndTime == "" {
 		return NewInvalidArgumentError("auto_update_window", "Start and end time must both be set")
 	}
-	// Parsing as 15:04 also enforces hours 0-23 and minutes 0-59.
-	startDuration, err := time.Parse("15:04", *s.AutoUpdateStartTime)
+	startDuration, err := parseAutoUpdateHHMM(*s.AutoUpdateStartTime)
 	if err != nil {
 		return NewInvalidArgumentError("auto_update_window_start", "must be in HH:MM (24-hour) format")
 	}
-	endDuration, err := time.Parse("15:04", *s.AutoUpdateEndTime)
+	endDuration, err := parseAutoUpdateHHMM(*s.AutoUpdateEndTime)
 	if err != nil {
 		return NewInvalidArgumentError("auto_update_window_end", "must be in HH:MM (24-hour) format")
 	}
@@ -379,6 +378,16 @@ func (s SoftwareAutoUpdateSchedule) WindowIsValid() error {
 	}
 
 	return nil
+}
+
+// parseAutoUpdateHHMM parses a zero-padded 24-hour "HH:MM" window boundary.
+// time.Parse("15:04", ...) alone accepts unpadded values like "1:00", so the
+// five-character shape is enforced before parsing.
+func parseAutoUpdateHHMM(s string) (time.Time, error) {
+	if len(s) != 5 || s[2] != ':' {
+		return time.Time{}, errors.New("must be HH:MM")
+	}
+	return time.Parse("15:04", s)
 }
 
 type SoftwareAutoUpdateScheduleFilter struct {

--- a/server/fleet/software_test.go
+++ b/server/fleet/software_test.go
@@ -1048,23 +1048,34 @@ func TestAutoUpdateScheduleValidation(t *testing.T) {
 			isValid: false,
 		},
 		{
-			name: "start time unpadded hour",
+			name: "start time unpadded hour accepted",
 			schedule: SoftwareAutoUpdateSchedule{
 				SoftwareAutoUpdateConfig: SoftwareAutoUpdateConfig{
-					AutoUpdateEnabled:   ptr.Bool(true),
-					AutoUpdateStartTime: ptr.String("1:00"),
-					AutoUpdateEndTime:   ptr.String("15:30"),
+					AutoUpdateEnabled:   new(true),
+					AutoUpdateStartTime: new("1:00"),
+					AutoUpdateEndTime:   new("15:30"),
 				},
 			},
-			isValid: false,
+			isValid: true,
 		},
 		{
-			name: "end time unpadded hour",
+			name: "end time unpadded hour accepted",
 			schedule: SoftwareAutoUpdateSchedule{
 				SoftwareAutoUpdateConfig: SoftwareAutoUpdateConfig{
-					AutoUpdateEnabled:   ptr.Bool(true),
-					AutoUpdateStartTime: ptr.String("14:30"),
-					AutoUpdateEndTime:   ptr.String("1:00"),
+					AutoUpdateEnabled:   new(true),
+					AutoUpdateStartTime: new("14:30"),
+					AutoUpdateEndTime:   new("1:00"),
+				},
+			},
+			isValid: true,
+		},
+		{
+			name: "start time with space rejected",
+			schedule: SoftwareAutoUpdateSchedule{
+				SoftwareAutoUpdateConfig: SoftwareAutoUpdateConfig{
+					AutoUpdateEnabled:   new(true),
+					AutoUpdateStartTime: new("20: 00"),
+					AutoUpdateEndTime:   new("22:00"),
 				},
 			},
 			isValid: false,

--- a/server/fleet/software_test.go
+++ b/server/fleet/software_test.go
@@ -1048,6 +1048,28 @@ func TestAutoUpdateScheduleValidation(t *testing.T) {
 			isValid: false,
 		},
 		{
+			name: "start time unpadded hour",
+			schedule: SoftwareAutoUpdateSchedule{
+				SoftwareAutoUpdateConfig: SoftwareAutoUpdateConfig{
+					AutoUpdateEnabled:   ptr.Bool(true),
+					AutoUpdateStartTime: ptr.String("1:00"),
+					AutoUpdateEndTime:   ptr.String("15:30"),
+				},
+			},
+			isValid: false,
+		},
+		{
+			name: "end time unpadded hour",
+			schedule: SoftwareAutoUpdateSchedule{
+				SoftwareAutoUpdateConfig: SoftwareAutoUpdateConfig{
+					AutoUpdateEnabled:   ptr.Bool(true),
+					AutoUpdateStartTime: ptr.String("14:30"),
+					AutoUpdateEndTime:   ptr.String("1:00"),
+				},
+			},
+			isValid: false,
+		},
+		{
 			name: "window is less than one hour",
 			schedule: SoftwareAutoUpdateSchedule{
 				SoftwareAutoUpdateConfig: SoftwareAutoUpdateConfig{


### PR DESCRIPTION
## Issue
Closes #51512

## Description
- Bug fix (root cause): `SoftwareAutoUpdateSchedule.WindowIsValid()` returned raw `errors.New` / `fmt.Errorf` values. Callers wrapped them with `ctxerr.Wrap`, so the endpoint layer never saw a typed client error and defaulted to 500. Malformed times (e.g. `"20: 00"`) tripped a validation branch that Fleet itself wrote, and still surfaced as a server error.
- Fix: `WindowIsValid()` now returns `fleet.NewInvalidArgumentError` for all four failure modes (both times missing, unparseable start, unparseable end, window under one hour). Types survive `ctxerr.Wrap` via `errors.Unwrap`, so the endpoint auto-maps to 422 without any per-call-site changes.
- Coverage: the same function is called from three sites, all now returning 4xx instead of 5xx:
  - `ee/server/service/vpp.go:1204` (`UpdateAppStoreApp`, the one filed)
  - `ee/server/service/vpp.go:624` (batch VPP add)
  - `server/datastore/mysql/software_titles.go:1465` (GitOps auto-update config)
- Message hygiene: replaced Go's `parsing time "20: 00" as "15:04": cannot parse " 00" as "04"` jargon with `must be in HH:MM (24-hour) format`.

## Screenrecording
- Postman: PATCH `/api/v1/fleet/software/titles/<id>/app_store_app` with malformed start time returns 422 (was 500); window-under-one-hour also returns 422.

### Before (500 error)

<img width="979" height="716" alt="Screenshot 2026-08-21 at 10 55 43 AM" src="https://github.com/user-attachments/assets/6abf247e-fc0b-4354-8892-b18a9b802aba" />


### After ✨ (422 error)

<img width="986" height="752" alt="Screenshot 2026-08-21 at 11 01 05 AM" src="https://github.com/user-attachments/assets/5d3b87c5-6748-4251-9aac-d7f5bafe794f" />
<img width="977" height="738" alt="Screenshot 2026-08-21 at 11 00 44 AM" src="https://github.com/user-attachments/assets/eac63595-834b-4549-9e84-61d9bd67ec39" />


## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved auto-update schedule validation messages by identifying which time field contains an invalid value.
  * Auto-update times now accept one- or two-digit hours with two-digit minutes, such as `1:00` or `01:00`.
  * Invalid spacing and malformed time values are rejected with clearer errors.
  * Clarified errors for missing times and windows shorter than one hour.
  * Preserved support for overnight schedules and valid duration checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->