### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/bettertouchtool/darwin.json
+++ b/ee/maintained-apps/outputs/bettertouchtool/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "6.745",
+      "version": "6.746",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.hegenberg.BetterTouchTool';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hegenberg.BetterTouchTool' AND version_compare(bundle_short_version, '6.745') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hegenberg.BetterTouchTool' AND version_compare(bundle_short_version, '6.746') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.hegenberg.BetterTouchTool');"
       },
-      "installer_url": "https://folivora.ai/releases/btt6.745-2026082102.zip",
+      "installer_url": "https://folivora.ai/releases/btt6.746-2026082105.zip",
       "install_script_ref": "17a00450",
       "uninstall_script_ref": "b0dc7152",
-      "sha256": "d7f8ce3f593b72894e740e1ab1290c41ccfa5024eb629cccad6f3419eab215ed",
+      "sha256": "1b0bca1e9e41adf1218ae8b1b27985099f2f5a940f3cf60a2089503812a2b011",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/cleanmymac/darwin.json
+++ b/ee/maintained-apps/outputs/cleanmymac/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "5.5.7",
+      "version": "5.6.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.macpaw.CleanMyMac5';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.macpaw.CleanMyMac5' AND version_compare(bundle_short_version, '5.5.7') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.macpaw.CleanMyMac5' AND version_compare(bundle_short_version, '5.6.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.macpaw.CleanMyMac5');"
       },
-      "installer_url": "https://updates.cleanmymac.com/com.macpaw.cleanmymac5/releases/CleanMyMac5_50507.0.2607220856.zip",
+      "installer_url": "https://updates.cleanmymac.com/com.macpaw.cleanmymac5/releases/CleanMyMac5_50600.0.2608201300.zip",
       "install_script_ref": "1f8e229d",
       "uninstall_script_ref": "f09da8a8",
-      "sha256": "fa0d0cb0a78340c5b33934e3963fe8eb561a1282a5fc557369420455a7c6c089",
+      "sha256": "12eb9308835820c26927f953a1bb8a186538004539282d06a6eb0d73a3955cb8",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/eclipse-temurin-jdk-21/windows.json
+++ b/ee/maintained-apps/outputs/eclipse-temurin-jdk-21/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "21.0.12.8",
+      "version": "21.0.12.101",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Eclipse Temurin JDK%' AND publisher = 'Eclipse Adoptium' AND version LIKE '21.%';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Eclipse Temurin JDK%' AND publisher = 'Eclipse Adoptium' AND version LIKE '21.%' AND version_compare(version, '21.0.12.8') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Eclipse Temurin JDK%' AND publisher = 'Eclipse Adoptium' AND version LIKE '21.%' AND version_compare(version, '21.0.12.101') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'eclipse temurin jdk 21.exe');"
       },
-      "installer_url": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.12+8/OpenJDK21U-jdk_x64_windows_hotspot_21.0.12_8.msi",
+      "installer_url": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.12.1+1/OpenJDK21U-jdk_x64_windows_hotspot_21.0.12.1_1.msi",
       "install_script_ref": "22e48c46",
       "uninstall_script_ref": "348786d4",
-      "sha256": "845a30ebafdb4cbc4aff9c9d65b574a3dd154fbc5ef7f9412cd26628ffa5c22d",
+      "sha256": "454cfd334b9ca91c96dd8c2de97fcef6b9f1f98be9172ff076711f1c6b44e4e0",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/eclipse-temurin-jre-21/windows.json
+++ b/ee/maintained-apps/outputs/eclipse-temurin-jre-21/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "21.0.12.8",
+      "version": "21.0.12.101",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Eclipse Temurin JRE%' AND publisher = 'Eclipse Adoptium' AND version LIKE '21.%';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Eclipse Temurin JRE%' AND publisher = 'Eclipse Adoptium' AND version LIKE '21.%' AND version_compare(version, '21.0.12.8') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Eclipse Temurin JRE%' AND publisher = 'Eclipse Adoptium' AND version LIKE '21.%' AND version_compare(version, '21.0.12.101') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'eclipse temurin jre 21.exe');"
       },
-      "installer_url": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.12+8/OpenJDK21U-jre_x64_windows_hotspot_21.0.12_8.msi",
+      "installer_url": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.12.1+1/OpenJDK21U-jre_x64_windows_hotspot_21.0.12.1_1.msi",
       "install_script_ref": "22e48c46",
       "uninstall_script_ref": "d0d67fb5",
-      "sha256": "173bd18e8a9e8100e5588a14c7f54496dc7a3af3bf18f992cd89ab058b45a994",
+      "sha256": "536eeb1dc3f743e5932a92e3549430fc75392c5d379101c1456a1c201aa6e66b",
       "default_categories": [
         "Developer tools"
       ],

--- a/ee/maintained-apps/outputs/google-chrome/darwin.json
+++ b/ee/maintained-apps/outputs/google-chrome/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "151.0.7922.170",
+      "version": "151.0.7922.174",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.Chrome';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.Chrome' AND version_compare(bundle_short_version, '151.0.7922.170') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.Chrome' AND version_compare(bundle_short_version, '151.0.7922.174') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.google.Chrome');"
       },
       "installer_url": "https://dl.google.com/dl/chrome/mac/universal/stable/gcem/GoogleChrome.pkg",

--- a/ee/maintained-apps/outputs/imageglass/windows.json
+++ b/ee/maintained-apps/outputs/imageglass/windows.json
@@ -1,24 +1,24 @@
 {
   "versions": [
     {
-      "version": "9.6.1.807",
+      "version": "10.0.4.819",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'ImageGlass' AND publisher = 'Duong Dieu Phap';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'ImageGlass' AND publisher = 'Duong Dieu Phap' AND version_compare(version, '9.6.1.807') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'ImageGlass' AND publisher = 'Duong Dieu Phap' AND version_compare(version, '10.0.4.819') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'imageglass.exe');"
       },
-      "installer_url": "https://github.com/d2phap/ImageGlass/releases/download/9.6.1.807/ImageGlass_9.6.1.807_x64.msi",
+      "installer_url": "https://github.com/d2phap/ImageGlass/releases/download/10.0.4.819/ImageGlass_10.0.4.819_win-x64.msi",
       "install_script_ref": "72349997",
-      "uninstall_script_ref": "132bf6ab",
-      "sha256": "1f08209adb9456860ac2a71a74395456ccdf1bd9fc640f43d44b3b34788ddc0a",
+      "uninstall_script_ref": "7be3c7fc",
+      "sha256": "2c3bbce3cb4114e55cbd7af90797a1a9debf9a3016f89a61ddcd235ef1388a16",
       "default_categories": [
         "Productivity"
       ],
-      "upgrade_code": "{877DB994-AB03-4025-B99D-41CE565E810B}"
+      "upgrade_code": "{E89561C1-5B73-481B-86F4-109283B7B230}"
     }
   ],
   "refs": {
-    "132bf6ab": "# Fleet uninstalls app by finding all related product codes for the specified upgrade code\n$inst = New-Object -ComObject \"WindowsInstaller.Installer\"\n$timeoutSeconds = 300  # 5 minute timeout per product\n\n# MSI exit codes that indicate success. 3010 = ERROR_SUCCESS_REBOOT_REQUIRED,\n# 1641 = ERROR_SUCCESS_REBOOT_INITIATED. Treat these as success rather than failure.\n$successCodes = @(0, 3010, 1641)\n\nforeach ($product_code in $inst.RelatedProducts('{877DB994-AB03-4025-B99D-41CE565E810B}')) {\n    $process = Start-Process msiexec -ArgumentList @(\"/quiet\", \"/x\", $product_code, \"/norestart\") -PassThru\n\n    # Wait for process with timeout\n    $completed = $process.WaitForExit($timeoutSeconds * 1000)\n\n    if (-not $completed) {\n        Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue\n        Exit 1603  # ERROR_UNINSTALL_FAILURE\n    }\n\n    # If the uninstall failed, bail\n    if ($successCodes -notcontains $process.ExitCode) {\n        Write-Output \"Uninstall for $($product_code) exited $($process.ExitCode)\"\n        Exit $process.ExitCode\n    }\n}\n\n# All uninstalls succeeded; exit success\nExit 0\n",
-    "72349997": "# Learn more about install scripts:\n# http://fleetdm.com/learn-more-about/install-scripts\n#\n# The ImageGlass MSI is dual-scope (ALLUSERS=2). Pass ALLUSERS=1 to force a\n# per-machine install under Fleet's SYSTEM context.\n\n$logFile = \"${env:TEMP}/fleet-install-software.log\"\n\ntry {\n\n$installProcess = Start-Process msiexec.exe `\n  -ArgumentList \"/quiet /norestart /lv `\"${logFile}`\" ALLUSERS=1 /i `\"${env:INSTALLER_PATH}`\"\" `\n  -PassThru -Verb RunAs -Wait\n\nGet-Content $logFile -Tail 500\n\nif ($installProcess.ExitCode -eq 3010 -or $installProcess.ExitCode -eq 1641) { Exit 0 }\nExit $installProcess.ExitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n"
+    "72349997": "# Learn more about install scripts:\n# http://fleetdm.com/learn-more-about/install-scripts\n#\n# The ImageGlass MSI is dual-scope (ALLUSERS=2). Pass ALLUSERS=1 to force a\n# per-machine install under Fleet's SYSTEM context.\n\n$logFile = \"${env:TEMP}/fleet-install-software.log\"\n\ntry {\n\n$installProcess = Start-Process msiexec.exe `\n  -ArgumentList \"/quiet /norestart /lv `\"${logFile}`\" ALLUSERS=1 /i `\"${env:INSTALLER_PATH}`\"\" `\n  -PassThru -Verb RunAs -Wait\n\nGet-Content $logFile -Tail 500\n\nif ($installProcess.ExitCode -eq 3010 -or $installProcess.ExitCode -eq 1641) { Exit 0 }\nExit $installProcess.ExitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n",
+    "7be3c7fc": "# Fleet uninstalls app by finding all related product codes for the specified upgrade code\n$inst = New-Object -ComObject \"WindowsInstaller.Installer\"\n$timeoutSeconds = 300  # 5 minute timeout per product\n\n# MSI exit codes that indicate success. 3010 = ERROR_SUCCESS_REBOOT_REQUIRED,\n# 1641 = ERROR_SUCCESS_REBOOT_INITIATED. Treat these as success rather than failure.\n$successCodes = @(0, 3010, 1641)\n\nforeach ($product_code in $inst.RelatedProducts('{E89561C1-5B73-481B-86F4-109283B7B230}')) {\n    $process = Start-Process msiexec -ArgumentList @(\"/quiet\", \"/x\", $product_code, \"/norestart\") -PassThru\n\n    # Wait for process with timeout\n    $completed = $process.WaitForExit($timeoutSeconds * 1000)\n\n    if (-not $completed) {\n        Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue\n        Exit 1603  # ERROR_UNINSTALL_FAILURE\n    }\n\n    # If the uninstall failed, bail\n    if ($successCodes -notcontains $process.ExitCode) {\n        Write-Output \"Uninstall for $($product_code) exited $($process.ExitCode)\"\n        Exit $process.ExitCode\n    }\n}\n\n# All uninstalls succeeded; exit success\nExit 0\n"
   }
 }

--- a/ee/maintained-apps/outputs/marked-app/darwin.json
+++ b/ee/maintained-apps/outputs/marked-app/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "3.1.25",
+      "version": "3.1.26",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.brettterpstra.marked';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.brettterpstra.marked' AND version_compare(bundle_short_version, '3.1.25') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.brettterpstra.marked' AND version_compare(bundle_short_version, '3.1.26') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.brettterpstra.marked');"
       },
-      "installer_url": "https://updates.markedapp.com/updates/Marked%203.1.25-1210.zip",
+      "installer_url": "https://updates.markedapp.com/updates/Marked%203.1.26-1211.zip",
       "install_script_ref": "23ea6da3",
       "uninstall_script_ref": "57b4bcf2",
-      "sha256": "6651310b94b84fb04eb455685f96a6eb9b14598c26395057359cf170617d9cf8",
+      "sha256": "8135ae81bb4b1de8c96b324fd6f8c2f687fa5d50ad1ef94d244514ffc175ac87",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/proton-drive/windows.json
+++ b/ee/maintained-apps/outputs/proton-drive/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "3.0.4",
+      "version": "3.0.5",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Proton Drive' AND publisher = 'Proton AG';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Proton Drive' AND publisher = 'Proton AG' AND version_compare(version, '3.0.4') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Proton Drive' AND publisher = 'Proton AG' AND version_compare(version, '3.0.5') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'proton drive.exe');"
       },
-      "installer_url": "https://proton.me/download/drive/windows/3.0.4/x64/Proton%20Drive%20Setup%203.0.4.exe",
+      "installer_url": "https://proton.me/download/drive/windows/3.0.5/x64/Proton%20Drive%20Setup%203.0.5.exe",
       "install_script_ref": "0bff62f0",
       "uninstall_script_ref": "149e6eb1",
-      "sha256": "dbf3c7780e4158495f36bc94a7a03194d5129b4a8dd95b1e068207e84603472c",
+      "sha256": "1987d65eb49588551e39d7bc4d290ad2c17e8753ab9a22a64ef5ae67e1bcf6a2",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/raycast/darwin.json
+++ b/ee/maintained-apps/outputs/raycast/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.104.25",
+      "version": "2.0.3.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.raycast.macos';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.raycast.macos' AND version_compare(bundle_short_version, '1.104.25') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.raycast.macos' AND version_compare(bundle_short_version, '2.0.3.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.raycast.macos');"
       },
-      "installer_url": "https://releases.raycast.com/releases/1.104.25/download?build=arm",
+      "installer_url": "https://x.raycast-releases.com/download?platform=macos&architecture=arm64&version=2.0.3.0",
       "install_script_ref": "f52a81be",
       "uninstall_script_ref": "cb893329",
-      "sha256": "972f6de210ffcacfa1feee095b8a30c7eeb972e914c876f65d37d218354a7067",
+      "sha256": "776d06bb4867784cce4344d4459c3d871fcb899ecfec7cb6590163b415cfeee0",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/rewritebar/darwin.json
+++ b/ee/maintained-apps/outputs/rewritebar/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "2.31.0",
+      "version": "2.32.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.m91michel.rewritebar';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.m91michel.rewritebar' AND version_compare(bundle_short_version, '2.31.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.m91michel.rewritebar' AND version_compare(bundle_short_version, '2.32.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.m91michel.rewritebar');"
       },
-      "installer_url": "https://rewritebar.com/download/v2.31.0.zip",
+      "installer_url": "https://rewritebar.com/download/v2.32.0.zip",
       "install_script_ref": "9638de12",
       "uninstall_script_ref": "44da42f4",
-      "sha256": "c8a924fec8fdd435fbff43e5cf1793fd106af2d513b34e1410c77c05617fc104",
+      "sha256": "9256229c00fc77e7238fd97157126e7f3b29114b32f631b02c7a4eb1c4627f0f",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/webcatalog/darwin.json
+++ b/ee/maintained-apps/outputs/webcatalog/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "77.9.1",
+      "version": "77.10.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.webcatalog.jordan';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.webcatalog.jordan' AND version_compare(bundle_short_version, '77.9.1') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.webcatalog.jordan' AND version_compare(bundle_short_version, '77.10.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.webcatalog.jordan');"
       },
-      "installer_url": "https://cdn-2.webcatalog.io/webcatalog/WebCatalog-77.9.1-universal.dmg",
+      "installer_url": "https://cdn-2.webcatalog.io/webcatalog/WebCatalog-77.10.0-universal.dmg",
       "install_script_ref": "23e707d7",
       "uninstall_script_ref": "6ca374e8",
-      "sha256": "13050b81f55d311fd465defc371cbfaa666650ca0b9bf038be2ce53b8b5cd3a2",
+      "sha256": "7d39085535a1af227b74e429253e101617a4146f1e0905810dc06402c07a1c44",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated BetterTouchTool, CleanMyMac, Marked, Proton Drive, RewriteBar, and WebCatalog to their latest available versions.
  * Updated Eclipse Temurin JDK 21 and JRE 21 for Windows.
  * Updated ImageGlass for Windows, including its installer and upgrade metadata.
  * Updated Google Chrome for macOS to version 151.0.7922.174.
  * Updated Raycast for macOS to version 2.0.3.0, including the ARM64 release.
  * Refreshed download links, version detection, and verification checksums where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->