### PR TITLE
Website: add missing Hawx case study card to /customers

### DIFF
--- a/website/views/pages/customers.ejs
+++ b/website/views/pages/customers.ejs
@@ -134,6 +134,11 @@
             <p>Faire secures Macs with CIS benchmarks and Fleet.</p>
             <a href="/case-study/faire">Read their story</a>
           </div>
+          <div purpose="article-card" @click="clickGotoCaseStudyLink('/case-study/hawx', $event)">
+            <img alt="Hawx logo" src="/images/hawx-logo-150x40@2x.png">
+            <p>Hawx gets field technicians productive on hour one with Fleet.</p>
+            <a href="/case-study/hawx">Read their story</a>
+          </div>
           <div purpose="article-card" @click="clickGotoCaseStudyLink('/case-study/mollie', $event)">
             <img alt="Mollie logo" src="/images/mollie-logo-136x40@2x.png">
             <p>Mollie manages endpoint compliance the same way it ships software.</p>


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** NA

The Hawx case study (`/case-study/hawx`, added in #50152) is the only one of the eight case study articles with no card in the `purpose="case-study-cards"` list on `/customers`, so it isn't reachable from that page. #50152 added `articles/hawx.md` and the logo image but never touched `customers.ejs` — unlike every other case study PR (for example #47494 for Mollie and #49448 for Primo), which added the card in the same PR.

This adds the missing card, using the already-committed `hawx-logo-150x40@2x.png` and a one-sentence summary drawn from the article title. Placement keeps the existing alphabetical run (faire → hawx → mollie → primo → stripe → thumbtack).

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  Not applicable — website-only change, consistent with prior case study PRs.

## Testing

Not rendered locally. Verified instead that:
- the markup is byte-identical to the neighboring cards apart from the slug, logo filename, alt text, and summary;
- `/case-study/hawx` resolves through the `GET /case-study/*` route in `website/config/routes.js` and `articles/hawx.md` carries `category: "case study"`;
- `website/assets/images/hawx-logo-150x40@2x.png` is committed and is 300x80 px, matching the `150x40@2x` naming convention used by the other card logos.

A screenshot from a reviewer running the site locally would be welcome.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Hawx case-study card to the Customers page.
  * Included the company logo, description, and links to its customer story.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->