### PR TITLE
Script to restore BitLocker protection.

### DIFF
--- a/docs/solutions/windows/scripts/restore-bitlocker-protection.ps1
+++ b/docs/solutions/windows/scripts/restore-bitlocker-protection.ps1
@@ -1,6 +1,12 @@
 # =============================================================================
 # Restore BitLocker protection on an already-encrypted Windows host
 #
+# Which protector this ends up with:
+#   - A host that already has any TPM-family protector (TPM, TPM+PIN, TPM+StartupKey, TPM+PIN+StartupKey) keeps it
+#     untouched; only protection is re-enabled.
+#   - A host with no TPM-family protector gets a TPM-only protector, which is what restores unattended boot.
+#   - A startup PIN is never enrolled, because a PIN has to be chosen by the end user.
+#
 # Non-destructive: never decrypts, never removes a protector, never reboots.
 #
 # Exit codes:
@@ -142,8 +148,13 @@ if ($tpmCount -eq 0) {
         Write-Output "step 1: a TPM protector already exists (added between the check and this call); continuing"
     } elseif ($r.ReturnValue -ne 0) {
         Write-Output ("FAIL: ProtectKeyWithTPM returned 0x{0:X8}." -f $r.ReturnValue)
-        Write-Output "      0x80310061 = FVE_E_POLICY_STARTUP_PIN_REQUIRED (policy requires a startup PIN;"
-        Write-Output "                   a TPM-only protector is not allowed, so a PIN must be enrolled instead)."
+        Write-Output "      0x80310066 = FVE_E_POLICY_STARTUP_TPM_NOT_ALLOWED (verified: this is what a"
+        Write-Output "                   require-startup-PIN policy returns) and"
+        Write-Output "      0x80310061 = FVE_E_POLICY_STARTUP_PIN_REQUIRED both mean policy forbids a"
+        Write-Output "                   TPM-only protector, for example when Fleet's disk encryption"
+        Write-Output "                   setting windows_require_bitlocker_pin is enabled for this host's"
+        Write-Output "                   team. A startup PIN has to be enrolled by the end user; an"
+        Write-Output "                   unattended script cannot choose one, so this needs an admin."
         Write-Output "      NOT calling EnableKeyProtectors: enabling protectors with no auto-unlock protector"
         Write-Output "      present would cause a recovery prompt at the next boot."
         exit 1

--- a/docs/solutions/windows/scripts/restore-bitlocker-protection.ps1
+++ b/docs/solutions/windows/scripts/restore-bitlocker-protection.ps1
@@ -1,0 +1,134 @@
+# =============================================================================
+# Restore BitLocker protection on an already-encrypted Windows host
+##
+# Non-destructive: never decrypts, never removes a protector, never reboots.
+#
+# Exit codes:
+#   0 = protection is On (or was already On)
+#   1 = could not safely restore; escalate (details on stdout)
+#   2 = a restart is pending; deliberately did NOT call EnableKeyProtectors
+# =============================================================================
+
+$ErrorActionPreference = 'Continue'
+
+function Get-Vol {
+    Get-WmiObject -Namespace 'root\CIMV2\Security\MicrosoftVolumeEncryption' `
+        -Class Win32_EncryptableVolume -Filter "DriveLetter='$($env:SystemDrive)'"
+}
+
+# TPM-family protector types: 1=TPM, 4=TPM+PIN, 5=TPM+StartupKey, 6=TPM+PIN+StartupKey.
+# Any of these lets the volume unseal at boot without human input (PIN variants
+# prompt for a PIN, which is by design and still not a recovery prompt).
+$TPM_FAMILY = 1, 4, 5, 6
+
+function Get-TpmProtectorCount {
+    $v = Get-Vol
+    $n = 0
+    foreach ($t in $TPM_FAMILY) {
+        $p = $v.GetKeyProtectors($t)
+        if ($p.ReturnValue -eq 0 -and $p.VolumeKeyProtectorID) { $n += @($p.VolumeKeyProtectorID).Count }
+    }
+    return $n
+}
+
+$vol = Get-Vol
+if (-not $vol) { Write-Output "FAIL: no encryptable volume for $env:SystemDrive"; exit 1 }
+
+$conv = $vol.GetConversionStatus().ConversionStatus   # 1 = FullyEncrypted
+$prot = $vol.GetProtectionStatus().ProtectionStatus   # 0 = off, 1 = on
+$tpmCount = Get-TpmProtectorCount
+$npCount = @((Get-Vol).GetKeyProtectors(3).VolumeKeyProtectorID).Count
+
+# Raw manage-bde is the only place the suspend reboot-count is exposed. The text
+# is localized, so only the parenthesised digit is parsed.
+$statusRaw = (manage-bde -status $env:SystemDrive 2>&1 | Out-String)
+$rebootCount = if ($statusRaw -match '\(\s*(\d+)\s') { [int]$matches[1] } else { $null }
+
+Write-Output "volume            : $env:SystemDrive"
+Write-Output "conversionStatus  : $conv (1 = FullyEncrypted)"
+Write-Output "protectionStatus  : $prot (0 = off, 1 = on)"
+Write-Output "tpmProtectors     : $tpmCount"
+Write-Output "recoveryPasswords : $npCount"
+Write-Output "suspendRebootCount: $(if ($null -ne $rebootCount) { $rebootCount } else { 'none (indefinite suspend, or protection is on)' })"
+
+if ($conv -ne 1) {
+    Write-Output "FAIL: volume is not FullyEncrypted (conversionStatus=$conv). Not a suspended-protection case; leaving it alone."
+    exit 1
+}
+
+if ($prot -eq 1 -and $tpmCount -gt 0) {
+    Write-Output "OK: protection already on with a TPM protector present. Nothing to do."
+    exit 0
+}
+
+# A volume that is On but has no TPM protector is a latent lockout: it cannot unseal at boot. Fix the protector even though protection is nominally on.
+if ($prot -eq 1 -and $tpmCount -eq 0) {
+    Write-Output "WARN: protection is on but NO TPM protector exists. This host will prompt for the recovery key at next boot."
+}
+
+if ($npCount -eq 0 -and $tpmCount -eq 0) {
+    Write-Output "FAIL: no key protectors at all. Escalate; do not attempt automated repair."
+    exit 1
+}
+
+# Step 1: ensure an auto-unlock protector exists BEFORE EnableKeyProtectors.
+if ($tpmCount -eq 0) {
+    Write-Output "step 1: no TPM-family protector -> adding a TPM protector"
+    $r = (Get-Vol).ProtectKeyWithTPM()
+    if ($r.ReturnValue -ne 0) {
+        Write-Output ("FAIL: ProtectKeyWithTPM returned 0x{0:X8}." -f $r.ReturnValue)
+        Write-Output "      0x80310061 = FVE_E_POLICY_STARTUP_PIN_REQUIRED (policy requires a startup PIN;"
+        Write-Output "                   a TPM-only protector is not allowed, so a PIN must be enrolled instead)."
+        Write-Output "      0x80310031 = FVE_E_PROTECTOR_EXISTS (already present)."
+        Write-Output "      NOT calling EnableKeyProtectors: enabling protectors with no auto-unlock protector"
+        Write-Output "      present would cause a recovery prompt at the next boot."
+        exit 1
+    }
+    Write-Output ("step 1: TPM protector added: {0}" -f $r.VolumeKeyProtectorID)
+} else {
+    Write-Output "step 1: TPM-family protector already present ($tpmCount)"
+}
+
+# Step 2: refuse to call EnableKeyProtectors while a restart is staged.
+$pendCbs = Test-Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending'
+$pendWu = Test-Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired'
+if ($pendCbs -or $pendWu) {
+    Write-Output "step 2: a restart is PENDING (CBS=$pendCbs WindowsUpdate=$pendWu). Not enabling protectors now."
+    if ($null -ne $rebootCount -and $rebootCount -gt 0) {
+        Write-Output "        This suspension carries a reboot count ($rebootCount), so the restart both applies the"
+        Write-Output "        staged update AND restores protection on its own. No need to re-run this script,"
+        Write-Output "        though re-running is harmless and will confirm the result."
+    } else {
+        Write-Output "        This suspension is INDEFINITE (no reboot count), so the restart will NOT restore"
+        Write-Output "        protection by itself. Restart this host, then RE-RUN this script to enable protectors."
+    }
+    Write-Output "        Either way the TPM protector checked/added in step 1 is already in place, so the"
+    Write-Output "        eventual EnableKeyProtectors call will have an auto-unlock protector."
+    exit 2
+}
+Write-Output "step 2: no pending restart"
+
+# Step 3: enable the key protectors.
+if ($prot -ne 1) {
+    Write-Output "step 3: calling EnableKeyProtectors to protect the key again"
+    $r = (Get-Vol).EnableKeyProtectors()
+    if ($r.ReturnValue -ne 0) {
+        Write-Output ("FAIL: EnableKeyProtectors returned 0x{0:X8}" -f $r.ReturnValue)
+        exit 1
+    }
+} else {
+    Write-Output "step 3: protection already on, no EnableKeyProtectors call needed"
+}
+
+Start-Sleep -Seconds 5
+$vol = Get-Vol
+$protAfter = $vol.GetProtectionStatus().ProtectionStatus
+$tpmAfter = Get-TpmProtectorCount
+Write-Output "result: protectionStatus=$protAfter tpmProtectors=$tpmAfter"
+
+if ($protAfter -eq 1 -and $tpmAfter -gt 0) {
+    Write-Output "OK: protection restored on $env:SystemDrive with an auto-unlock protector present."
+    exit 0
+}
+Write-Output "FAIL: protection is still not correctly restored. Escalate."
+exit 1

--- a/docs/solutions/windows/scripts/restore-bitlocker-protection.ps1
+++ b/docs/solutions/windows/scripts/restore-bitlocker-protection.ps1
@@ -53,18 +53,37 @@ function Invoke-VolumeMethod {
     return $r
 }
 
+# For read-only status calls, any non-zero ReturnValue means the answer is unusable. Acting on an unreadable state
+# is the exact failure this script exists to avoid, so stop rather than guess.
+function Invoke-VolumeQuery {
+    param(
+        [Parameter(Mandatory = $true)][string] $MethodName,
+        [hashtable] $Arguments
+    )
+    if ($Arguments) {
+        $r = Invoke-VolumeMethod -MethodName $MethodName -Arguments $Arguments
+    } else {
+        $r = Invoke-VolumeMethod -MethodName $MethodName
+    }
+    if ($r.ReturnValue -ne 0) {
+        Write-Output ("FAIL: $MethodName returned 0x{0:X8}; volume state is unreadable. Escalate." -f $r.ReturnValue)
+        exit 1
+    }
+    return $r
+}
+
 # TPM-family protector types: 1=TPM, 4=TPM+PIN, 5=TPM+StartupKey, 6=TPM+PIN+StartupKey. Any of these lets the
 # volume unseal at boot without human input (PIN variants prompt for a PIN, which is by design and still not a
 # recovery prompt).
 $TPM_FAMILY = 1, 4, 5, 6
 
+# Returned by ProtectKeyWithTPM when the protector is already present, which for this script's purposes means
+# success, not failure.
+$FVE_E_PROTECTOR_EXISTS = 0x80310031L
+
 function Get-ProtectorIdCount {
     param([Parameter(Mandatory = $true)][int] $Type)
-    $r = Invoke-VolumeMethod -MethodName 'GetKeyProtectors' -Arguments @{ KeyProtectorType = [uint32]$Type }
-    if ($r.ReturnValue -ne 0) {
-        Write-Output ("FAIL: GetKeyProtectors($Type) returned 0x{0:X8}; cannot enumerate protectors. Escalate." -f $r.ReturnValue)
-        exit 1
-    }
+    $r = Invoke-VolumeQuery -MethodName 'GetKeyProtectors' -Arguments @{ KeyProtectorType = [uint32]$Type }
     return @($r.VolumeKeyProtectorID).Count
 }
 
@@ -74,8 +93,8 @@ function Get-TpmProtectorCount {
     return $n
 }
 
-$conv = (Invoke-VolumeMethod -MethodName 'GetConversionStatus').ConversionStatus   # 1 = FullyEncrypted
-$prot = (Invoke-VolumeMethod -MethodName 'GetProtectionStatus').ProtectionStatus   # 0 = off, 1 = on
+$conv = (Invoke-VolumeQuery -MethodName 'GetConversionStatus').ConversionStatus   # 1 = FullyEncrypted
+$prot = (Invoke-VolumeQuery -MethodName 'GetProtectionStatus').ProtectionStatus   # 0 = off, 1 = on
 $tpmCount = Get-TpmProtectorCount
 $npCount = Get-ProtectorIdCount -Type 3
 # Protector type 0 means "every type"
@@ -84,7 +103,7 @@ $allCount = Get-ProtectorIdCount -Type 0
 # Raw manage-bde is the only place the suspend reboot-count is exposed. The text is localized, so only the
 # parenthesised digit is parsed.
 $statusRaw = (manage-bde -status $env:SystemDrive 2>&1 | Out-String)
-$rebootCount = if ($statusRaw -match '\(\s*(\d+)\s') { [int]$matches[1] } else { $null }
+$rebootCount = if ($statusRaw -match '\(\s*(\d+)') { [int]$matches[1] } else { $null }
 
 Write-Output "volume            : $env:SystemDrive"
 Write-Output "conversionStatus  : $conv (1 = FullyEncrypted)"
@@ -118,16 +137,19 @@ if ($allCount -eq 0) {
 if ($tpmCount -eq 0) {
     Write-Output "step 1: no TPM-family protector -> adding a TPM protector"
     $r = Invoke-VolumeMethod -MethodName 'ProtectKeyWithTPM'
-    if ($r.ReturnValue -ne 0) {
+    if ($r.ReturnValue -eq $FVE_E_PROTECTOR_EXISTS) {
+        # The desired state is already satisfied.
+        Write-Output "step 1: a TPM protector already exists (added between the check and this call); continuing"
+    } elseif ($r.ReturnValue -ne 0) {
         Write-Output ("FAIL: ProtectKeyWithTPM returned 0x{0:X8}." -f $r.ReturnValue)
         Write-Output "      0x80310061 = FVE_E_POLICY_STARTUP_PIN_REQUIRED (policy requires a startup PIN;"
         Write-Output "                   a TPM-only protector is not allowed, so a PIN must be enrolled instead)."
-        Write-Output "      0x80310031 = FVE_E_PROTECTOR_EXISTS (already present)."
         Write-Output "      NOT calling EnableKeyProtectors: enabling protectors with no auto-unlock protector"
         Write-Output "      present would cause a recovery prompt at the next boot."
         exit 1
+    } else {
+        Write-Output ("step 1: TPM protector added: {0}" -f $r.VolumeKeyProtectorID)
     }
-    Write-Output ("step 1: TPM protector added: {0}" -f $r.VolumeKeyProtectorID)
 } else {
     Write-Output "step 1: TPM-family protector already present ($tpmCount)"
 }
@@ -164,7 +186,7 @@ if ($prot -ne 1) {
 }
 
 Start-Sleep -Seconds 5
-$protAfter = (Invoke-VolumeMethod -MethodName 'GetProtectionStatus').ProtectionStatus
+$protAfter = (Invoke-VolumeQuery -MethodName 'GetProtectionStatus').ProtectionStatus
 $tpmAfter = Get-TpmProtectorCount
 Write-Output "result: protectionStatus=$protAfter tpmProtectors=$tpmAfter"
 

--- a/docs/solutions/windows/scripts/restore-bitlocker-protection.ps1
+++ b/docs/solutions/windows/scripts/restore-bitlocker-protection.ps1
@@ -1,6 +1,6 @@
 # =============================================================================
 # Restore BitLocker protection on an already-encrypted Windows host
-##
+#
 # Non-destructive: never decrypts, never removes a protector, never reboots.
 #
 # Exit codes:
@@ -9,38 +9,80 @@
 #   2 = a restart is pending; deliberately did NOT call EnableKeyProtectors
 # =============================================================================
 
+#Requires -RunAsAdministrator
+
 $ErrorActionPreference = 'Continue'
 
+$BL_NAMESPACE = 'root\CIMV2\Security\MicrosoftVolumeEncryption'
+
 function Get-Vol {
-    Get-WmiObject -Namespace 'root\CIMV2\Security\MicrosoftVolumeEncryption' `
-        -Class Win32_EncryptableVolume -Filter "DriveLetter='$($env:SystemDrive)'"
+    Get-CimInstance -Namespace $BL_NAMESPACE -ClassName Win32_EncryptableVolume `
+        -Filter "DriveLetter='$($env:SystemDrive)'"
 }
 
-# TPM-family protector types: 1=TPM, 4=TPM+PIN, 5=TPM+StartupKey, 6=TPM+PIN+StartupKey.
-# Any of these lets the volume unseal at boot without human input (PIN variants
-# prompt for a PIN, which is by design and still not a recovery prompt).
+# A null return from CIM means the lookup failed, which is NOT evidence about the volume's actual state, so it must
+# stop the script rather than be read as "no protectors" or "not encrypted".
+function Get-VolOrFail {
+    $v = Get-Vol
+    if (-not $v) {
+        Write-Output "FAIL: CIM returned no Win32_EncryptableVolume for $env:SystemDrive."
+        Write-Output "      Either the volume is not BitLocker-capable or the CIM query failed."
+        Write-Output "      Not treating this as a statement about the volume's state. Escalate."
+        exit 1
+    }
+    return $v
+}
+
+# Re-reads the volume on every call so state is never stale, and fails loudly if either the lookup or the method
+# call itself produces nothing.
+function Invoke-VolumeMethod {
+    param(
+        [Parameter(Mandatory = $true)][string] $MethodName,
+        [hashtable] $Arguments
+    )
+    $v = Get-VolOrFail
+    if ($Arguments) {
+        $r = Invoke-CimMethod -InputObject $v -MethodName $MethodName -Arguments $Arguments
+    } else {
+        $r = Invoke-CimMethod -InputObject $v -MethodName $MethodName
+    }
+    if ($null -eq $r) {
+        Write-Output "FAIL: $MethodName returned no result (CIM method call failed). Escalate."
+        exit 1
+    }
+    return $r
+}
+
+# TPM-family protector types: 1=TPM, 4=TPM+PIN, 5=TPM+StartupKey, 6=TPM+PIN+StartupKey. Any of these lets the
+# volume unseal at boot without human input (PIN variants prompt for a PIN, which is by design and still not a
+# recovery prompt).
 $TPM_FAMILY = 1, 4, 5, 6
 
-function Get-TpmProtectorCount {
-    $v = Get-Vol
-    $n = 0
-    foreach ($t in $TPM_FAMILY) {
-        $p = $v.GetKeyProtectors($t)
-        if ($p.ReturnValue -eq 0 -and $p.VolumeKeyProtectorID) { $n += @($p.VolumeKeyProtectorID).Count }
+function Get-ProtectorIdCount {
+    param([Parameter(Mandatory = $true)][int] $Type)
+    $r = Invoke-VolumeMethod -MethodName 'GetKeyProtectors' -Arguments @{ KeyProtectorType = [uint32]$Type }
+    if ($r.ReturnValue -ne 0) {
+        Write-Output ("FAIL: GetKeyProtectors($Type) returned 0x{0:X8}; cannot enumerate protectors. Escalate." -f $r.ReturnValue)
+        exit 1
     }
+    return @($r.VolumeKeyProtectorID).Count
+}
+
+function Get-TpmProtectorCount {
+    $n = 0
+    foreach ($t in $TPM_FAMILY) { $n += Get-ProtectorIdCount -Type $t }
     return $n
 }
 
-$vol = Get-Vol
-if (-not $vol) { Write-Output "FAIL: no encryptable volume for $env:SystemDrive"; exit 1 }
-
-$conv = $vol.GetConversionStatus().ConversionStatus   # 1 = FullyEncrypted
-$prot = $vol.GetProtectionStatus().ProtectionStatus   # 0 = off, 1 = on
+$conv = (Invoke-VolumeMethod -MethodName 'GetConversionStatus').ConversionStatus   # 1 = FullyEncrypted
+$prot = (Invoke-VolumeMethod -MethodName 'GetProtectionStatus').ProtectionStatus   # 0 = off, 1 = on
 $tpmCount = Get-TpmProtectorCount
-$npCount = @((Get-Vol).GetKeyProtectors(3).VolumeKeyProtectorID).Count
+$npCount = Get-ProtectorIdCount -Type 3
+# Protector type 0 means "every type"
+$allCount = Get-ProtectorIdCount -Type 0
 
-# Raw manage-bde is the only place the suspend reboot-count is exposed. The text
-# is localized, so only the parenthesised digit is parsed.
+# Raw manage-bde is the only place the suspend reboot-count is exposed. The text is localized, so only the
+# parenthesised digit is parsed.
 $statusRaw = (manage-bde -status $env:SystemDrive 2>&1 | Out-String)
 $rebootCount = if ($statusRaw -match '\(\s*(\d+)\s') { [int]$matches[1] } else { $null }
 
@@ -49,6 +91,7 @@ Write-Output "conversionStatus  : $conv (1 = FullyEncrypted)"
 Write-Output "protectionStatus  : $prot (0 = off, 1 = on)"
 Write-Output "tpmProtectors     : $tpmCount"
 Write-Output "recoveryPasswords : $npCount"
+Write-Output "allProtectors     : $allCount (every protector type)"
 Write-Output "suspendRebootCount: $(if ($null -ne $rebootCount) { $rebootCount } else { 'none (indefinite suspend, or protection is on)' })"
 
 if ($conv -ne 1) {
@@ -66,15 +109,15 @@ if ($prot -eq 1 -and $tpmCount -eq 0) {
     Write-Output "WARN: protection is on but NO TPM protector exists. This host will prompt for the recovery key at next boot."
 }
 
-if ($npCount -eq 0 -and $tpmCount -eq 0) {
-    Write-Output "FAIL: no key protectors at all. Escalate; do not attempt automated repair."
+if ($allCount -eq 0) {
+    Write-Output "FAIL: no key protectors of any type. Escalate; do not attempt automated repair."
     exit 1
 }
 
 # Step 1: ensure an auto-unlock protector exists BEFORE EnableKeyProtectors.
 if ($tpmCount -eq 0) {
     Write-Output "step 1: no TPM-family protector -> adding a TPM protector"
-    $r = (Get-Vol).ProtectKeyWithTPM()
+    $r = Invoke-VolumeMethod -MethodName 'ProtectKeyWithTPM'
     if ($r.ReturnValue -ne 0) {
         Write-Output ("FAIL: ProtectKeyWithTPM returned 0x{0:X8}." -f $r.ReturnValue)
         Write-Output "      0x80310061 = FVE_E_POLICY_STARTUP_PIN_REQUIRED (policy requires a startup PIN;"
@@ -111,7 +154,7 @@ Write-Output "step 2: no pending restart"
 # Step 3: enable the key protectors.
 if ($prot -ne 1) {
     Write-Output "step 3: calling EnableKeyProtectors to protect the key again"
-    $r = (Get-Vol).EnableKeyProtectors()
+    $r = Invoke-VolumeMethod -MethodName 'EnableKeyProtectors'
     if ($r.ReturnValue -ne 0) {
         Write-Output ("FAIL: EnableKeyProtectors returned 0x{0:X8}" -f $r.ReturnValue)
         exit 1
@@ -121,8 +164,7 @@ if ($prot -ne 1) {
 }
 
 Start-Sleep -Seconds 5
-$vol = Get-Vol
-$protAfter = $vol.GetProtectionStatus().ProtectionStatus
+$protAfter = (Invoke-VolumeMethod -MethodName 'GetProtectionStatus').ProtectionStatus
 $tpmAfter = Get-TpmProtectorCount
 Write-Output "result: protectionStatus=$protAfter tpmProtectors=$tpmAfter"
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #49401 

This is a workaround script for Windows hosts that lost BitLocker protection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a PowerShell utility to safely restore BitLocker protection on the system volume.
  * Requires administrator access and validates encryption, recovery configuration, and existing protectors.
  * Adds a TPM-based protector when needed and verifies the final protection state.
  * Detects pending restarts and startup-PIN constraints before enabling protection.
  * Provides clearer results for successful additions, existing protectors, policy errors, and restart-required conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->