### PR TITLE
Notify before patching - GitOps

### DIFF
--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -1806,6 +1806,7 @@ func (cmd *GenerateGitopsCommand) generatePolicies(teamId *uint, filePath string
 			}
 			policySpec["fleet_maintained_app_slug"] = fma.Slug
 			policySpec[jsonFieldName(t, "PatchWhenClosed")] = policy.PatchWhenClosed
+			policySpec[jsonFieldName(t, "NotifyBeforePatching")] = policy.NotifyBeforePatching
 		}
 		if policy.Type != "" {
 			policySpec["type"] = policy.Type

--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -2792,7 +2792,7 @@ func TestGeneratePolicies(t *testing.T) {
 	require.NoError(t, err)
 
 	// Compare.
-	require.Equal(t, expectedPolicies, generatedPolicies)
+	require.Equal(t, expectedTeamPolicies, generatedTeamPolicies)
 }
 
 func TestGenerateQueries(t *testing.T) {

--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -463,10 +463,25 @@ func (MockClient) GetPolicies(teamID *uint) ([]*fleet.Policy, error) {
 				Platform:                 "linux,windows",
 				ConditionalAccessEnabled: true,
 				Type:                     fleet.PolicyTypePatch,
-				PatchWhenClosed:          true,
+				NotifyBeforePatching:     true,
 			},
 			PatchSoftware: &fleet.PolicySoftwareTitle{
 				SoftwareTitleID: 8,
+			},
+		},
+		{
+			PolicyData: fleet.PolicyData{
+				ID:              6,
+				Name:            "Team patch when closed policy",
+				Query:           "SELECT * FROM team_policy WHERE id = 6",
+				Resolution:      new("Do a team thing"),
+				Description:     "This is a team patch policy that waits for the app to close",
+				Platform:        "windows",
+				Type:            fleet.PolicyTypePatch,
+				PatchWhenClosed: true,
+			},
+			PatchSoftware: &fleet.PolicySoftwareTitle{
+				SoftwareTitleID: 9,
 			},
 		},
 		{
@@ -680,6 +695,7 @@ func (MockClient) GetSoftwareTitleByID(ID uint, teamID *uint) (*fleet.SoftwareTi
 				}, {
 					LabelName: "Label B",
 				}},
+				// Mirrors the API, which returns the managed app open query while notify_before_patching is on.
 				PreInstallQuery:      "SELECT * FROM pre_install_query",
 				InstallScript:        "install",
 				PostInstallScript:    "postinstall",
@@ -690,6 +706,12 @@ func (MockClient) GetSoftwareTitleByID(ID uint, teamID *uint) (*fleet.SoftwareTi
 				Categories:           []string{"Browsers"},
 				BundleIdentifier:     "com.my.fma",
 				FleetMaintainedAppID: ptr.Uint(1),
+				PatchPolicy: &fleet.PatchPolicyData{
+					ID:                           2,
+					Name:                         "Team patch policy",
+					NotifyBeforePatching:         true,
+					ContinuousAutomationsEnabled: true,
+				},
 			},
 			IconUrl:          ptr.String("/api/icon1.png"),
 			BundleIdentifier: ptr.String("com.my.fma"),
@@ -2050,15 +2072,9 @@ func TestGenerateSoftware(t *testing.T) {
 		t.Fatalf("Expected file not found")
 	}
 
-	if fileContents, ok := cmd.FilesToWrite["lib/some-team/queries/my-fma-darwin-preinstallquery.yml"]; ok {
-		require.Equal(t, []map[string]any{{
-			"query": "SELECT * FROM pre_install_query",
-		}}, fileContents)
-	} else {
-		t.Fatalf("Expected file not found")
-	}
-
-	// The windows FMA is patch_when_closed, so its query is not written out.
+	// The darwin FMA is notify_before_patching and the windows FMA is patch_when_closed, so both
+	// hold Fleet's managed app open query and neither is written out.
+	require.NotContains(t, cmd.FilesToWrite, "lib/some-team/queries/my-fma-darwin-preinstallquery.yml")
 	require.NotContains(t, cmd.FilesToWrite, "lib/some-team/queries/my-windows-fma-windows-preinstallquery.yml")
 
 	if fileContents, ok := cmd.FilesToWrite["lib/some-team/software/my-setup-experience-app-android-config.json"]; ok {
@@ -2689,6 +2705,10 @@ func TestGeneratePolicies(t *testing.T) {
 			8: {
 				MaintainedAppID: 1,
 				Slug:            "fma1/darwin",
+			},
+			9: {
+				MaintainedAppID: 2,
+				Slug:            "fma2/windows",
 			},
 		},
 		ScriptList: map[uint]string{

--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -372,6 +372,17 @@ func (MockClient) ListSoftwareTitles(query string) ([]fleet.SoftwareTitleListRes
 					FleetMaintainedAppID: ptr.Uint(3),
 				},
 			},
+			{
+				ID:         11,
+				Name:       "My Notify FMA",
+				HashSHA256: new("notify-fma-package-hash"),
+				SoftwarePackage: &fleet.SoftwarePackageOrApp{
+					Name:                 "my-notify-fma.pkg",
+					Platform:             "darwin",
+					Version:              "1",
+					FleetMaintainedAppID: new(uint(4)),
+				},
+			},
 		}, nil
 	case "available_for_install=1&fleet_id=0&order_key=name":
 		return []fleet.SoftwareTitleListResult{}, nil
@@ -389,6 +400,7 @@ func (MockClient) ListFleetMaintainedApps(teamID uint) ([]fleet.MaintainedApp, e
 		{ID: 1, Slug: "fma1/darwin", Name: "My FMA", Platform: "darwin", UniqueIdentifier: "com.my.fma"},
 		{ID: 2, Slug: "fma2/windows", Name: "My Windows FMA", Platform: "windows", UniqueIdentifier: "My Windows FMA"},
 		{ID: 3, Slug: "fma3/windows", Name: "Version Locked Name 2.0", Platform: "windows", UniqueIdentifier: "Version Locked Name 2.0"},
+		{ID: 4, Slug: "fma4/darwin", Name: "My Notify FMA", Platform: "darwin", UniqueIdentifier: "com.my.notifyfma"},
 	}, nil
 }
 
@@ -463,7 +475,7 @@ func (MockClient) GetPolicies(teamID *uint) ([]*fleet.Policy, error) {
 				Platform:                 "linux,windows",
 				ConditionalAccessEnabled: true,
 				Type:                     fleet.PolicyTypePatch,
-				NotifyBeforePatching:     true,
+				PatchWhenClosed:          true,
 			},
 			PatchSoftware: &fleet.PolicySoftwareTitle{
 				SoftwareTitleID: 8,
@@ -471,17 +483,17 @@ func (MockClient) GetPolicies(teamID *uint) ([]*fleet.Policy, error) {
 		},
 		{
 			PolicyData: fleet.PolicyData{
-				ID:              6,
-				Name:            "Team patch when closed policy",
-				Query:           "SELECT * FROM team_policy WHERE id = 6",
-				Resolution:      new("Do a team thing"),
-				Description:     "This is a team patch policy that waits for the app to close",
-				Platform:        "windows",
-				Type:            fleet.PolicyTypePatch,
-				PatchWhenClosed: true,
+				ID:                           6,
+				Name:                         "My Notify FMA up to date",
+				Resolution:                   new("Install the latest version from self-service"),
+				Description:                  "This is a team patch policy that notifies before patching",
+				Platform:                     "darwin",
+				Type:                         fleet.PolicyTypePatch,
+				NotifyBeforePatching:         true,
+				ContinuousAutomationsEnabled: true,
 			},
 			PatchSoftware: &fleet.PolicySoftwareTitle{
-				SoftwareTitleID: 9,
+				SoftwareTitleID: 11,
 			},
 		},
 		{
@@ -695,7 +707,6 @@ func (MockClient) GetSoftwareTitleByID(ID uint, teamID *uint) (*fleet.SoftwareTi
 				}, {
 					LabelName: "Label B",
 				}},
-				// Mirrors the API, which returns the managed app open query while notify_before_patching is on.
 				PreInstallQuery:      "SELECT * FROM pre_install_query",
 				InstallScript:        "install",
 				PostInstallScript:    "postinstall",
@@ -706,12 +717,6 @@ func (MockClient) GetSoftwareTitleByID(ID uint, teamID *uint) (*fleet.SoftwareTi
 				Categories:           []string{"Browsers"},
 				BundleIdentifier:     "com.my.fma",
 				FleetMaintainedAppID: ptr.Uint(1),
-				PatchPolicy: &fleet.PatchPolicyData{
-					ID:                           2,
-					Name:                         "Team patch policy",
-					NotifyBeforePatching:         true,
-					ContinuousAutomationsEnabled: true,
-				},
 			},
 			IconUrl:          ptr.String("/api/icon1.png"),
 			BundleIdentifier: ptr.String("com.my.fma"),
@@ -757,6 +762,26 @@ func (MockClient) GetSoftwareTitleByID(ID uint, teamID *uint) (*fleet.SoftwareTi
 				Platform:             "windows",
 				FleetMaintainedAppID: ptr.Uint(3),
 				PinnedVersion:        new("^123"),
+			},
+		}, nil
+	case 11:
+		return &fleet.SoftwareTitle{
+			ID:   11,
+			Name: "My Notify FMA",
+			SoftwarePackage: &fleet.SoftwareInstaller{
+				InstallScript:        "install",
+				UninstallScript:      "uninstall",
+				Platform:             "darwin",
+				FleetMaintainedAppID: new(uint(4)),
+				// Mirrors the API, which returns the managed app open query while
+				// notify_before_patching is on.
+				PreInstallQuery: "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE name = 'My Notify FMA');",
+				PatchPolicy: &fleet.PatchPolicyData{
+					ID:                           6,
+					Name:                         "My Notify FMA up to date",
+					NotifyBeforePatching:         true,
+					ContinuousAutomationsEnabled: true,
+				},
 			},
 		}, nil
 	default:
@@ -1079,7 +1104,7 @@ func compareDirs(t *testing.T, sourceDir, targetDir string) {
 func configureFMAManifestServer(t *testing.T) {
 	manifestServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.Path, "apps.json") {
-			data := json.RawMessage(`{"version": 2, "apps": [{"name": "My FMA", "slug": "fma1/darwin", "platform": "darwin", "unique_identifier": "com.my.fma"}, {"name": "My Windows FMA", "slug": "fma2/windows", "platform": "windows", "unique_identifier": "My Windows FMA"}, {"name": "Version Locked Name 2.0", "slug": "fma3/windows", "platform": "windows", "unique_identifier": "Version Locked Name 2.0"}]}`)
+			data := json.RawMessage(`{"version": 2, "apps": [{"name": "My FMA", "slug": "fma1/darwin", "platform": "darwin", "unique_identifier": "com.my.fma"}, {"name": "My Windows FMA", "slug": "fma2/windows", "platform": "windows", "unique_identifier": "My Windows FMA"}, {"name": "Version Locked Name 2.0", "slug": "fma3/windows", "platform": "windows", "unique_identifier": "Version Locked Name 2.0"}, {"name": "My Notify FMA", "slug": "fma4/darwin", "platform": "darwin", "unique_identifier": "com.my.notifyfma"}]}`)
 			err := json.NewEncoder(w).Encode(data)
 			require.NoError(t, err)
 			return
@@ -2072,10 +2097,19 @@ func TestGenerateSoftware(t *testing.T) {
 		t.Fatalf("Expected file not found")
 	}
 
-	// The darwin FMA is notify_before_patching and the windows FMA is patch_when_closed, so both
-	// hold Fleet's managed app open query and neither is written out.
-	require.NotContains(t, cmd.FilesToWrite, "lib/some-team/queries/my-fma-darwin-preinstallquery.yml")
+	if fileContents, ok := cmd.FilesToWrite["lib/some-team/queries/my-fma-darwin-preinstallquery.yml"]; ok {
+		require.Equal(t, []map[string]any{{
+			"query": "SELECT * FROM pre_install_query",
+		}}, fileContents)
+	} else {
+		t.Fatalf("Expected file not found")
+	}
+
+	// The windows FMA is patch_when_closed, so its query is not written out.
 	require.NotContains(t, cmd.FilesToWrite, "lib/some-team/queries/my-windows-fma-windows-preinstallquery.yml")
+
+	// The notify FMA is notify_before_patching, so its query is not written out either.
+	require.NotContains(t, cmd.FilesToWrite, "lib/some-team/queries/my-notify-fma-darwin-preinstallquery.yml")
 
 	if fileContents, ok := cmd.FilesToWrite["lib/some-team/software/my-setup-experience-app-android-config.json"]; ok {
 		require.JSONEq(t, `{"managedConfiguration": "WORK_PROFILE_ALLOWED"}`, string(fileContents.([]byte)))
@@ -2706,9 +2740,9 @@ func TestGeneratePolicies(t *testing.T) {
 				MaintainedAppID: 1,
 				Slug:            "fma1/darwin",
 			},
-			9: {
-				MaintainedAppID: 2,
-				Slug:            "fma2/windows",
+			11: {
+				MaintainedAppID: 4,
+				Slug:            "fma4/darwin",
 			},
 		},
 		ScriptList: map[uint]string{

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamPolicies.yaml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamPolicies.yaml
@@ -17,13 +17,29 @@
   critical: false
   description: This is a team patch policy
   name: Team patch policy
-  patch_when_closed: true
+  notify_before_patching: true
+  patch_when_closed: false
   platform: linux,windows
   query: SELECT * FROM team_policy WHERE id = 1
   resolution: Do a team thing
   fleet_maintained_app_slug: "foo/darwin"
   type: patch
   conditional_access_enabled: true
+  conditional_access_bypass_enabled: false
+  webhooks_and_tickets_enabled: false
+- calendar_events_enabled: false
+  continuous_automations_enabled: false
+  critical: false
+  description: This is a team patch policy that waits for the app to close
+  name: Team patch when closed policy
+  notify_before_patching: false
+  patch_when_closed: true
+  platform: windows
+  query: SELECT * FROM team_policy WHERE id = 6
+  resolution: Do a team thing
+  fleet_maintained_app_slug: "foo/darwin"
+  type: patch
+  conditional_access_enabled: false
   conditional_access_bypass_enabled: false
   webhooks_and_tickets_enabled: false
 - calendar_events_enabled: false

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamPolicies.yaml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamPolicies.yaml
@@ -1,31 +1,41 @@
 - calendar_events_enabled: false
+  conditional_access_enabled: true
   continuous_automations_enabled: false
   critical: false
   description: This is a team policy
   name: Team Policy
   platform: linux,windows
-  query: SELECT * FROM team_policy WHERE id = 1
+  query: "SELECT * FROM team_policy WHERE id = 1"
   resolution: Do a team thing
   run_script:
     path: /path/to/script1.sh
   type: dynamic
-  conditional_access_enabled: true
-  conditional_access_bypass_enabled: true
   webhooks_and_tickets_enabled: false
 - calendar_events_enabled: false
+  conditional_access_enabled: true
   continuous_automations_enabled: false
   critical: false
   description: This is a team patch policy
+  fleet_maintained_app_slug: foo/darwin
   name: Team patch policy
   notify_before_patching: false
   patch_when_closed: true
   platform: linux,windows
-  query: SELECT * FROM team_policy WHERE id = 1
   resolution: Do a team thing
-  fleet_maintained_app_slug: "foo/darwin"
   type: patch
-  conditional_access_enabled: true
-  conditional_access_bypass_enabled: false
+  webhooks_and_tickets_enabled: false
+- calendar_events_enabled: false
+  conditional_access_enabled: false
+  continuous_automations_enabled: true
+  critical: false
+  description: This is a team patch policy that notifies before patching
+  fleet_maintained_app_slug: foo/darwin
+  name: My Notify FMA up to date
+  notify_before_patching: true
+  patch_when_closed: false
+  platform: darwin
+  resolution: Install the latest version from self-service
+  type: patch
   webhooks_and_tickets_enabled: false
 - calendar_events_enabled: false
   conditional_access_enabled: false
@@ -36,7 +46,33 @@
     app_store_id: "1234567890"
   name: Team VPP policy
   platform: darwin
-  query: SELECT * FROM team_policy WHERE id = 3
+  query: "SELECT * FROM team_policy WHERE id = 3"
   resolution: Install the app
+  type: dynamic
+  webhooks_and_tickets_enabled: false
+- calendar_events_enabled: false
+  conditional_access_enabled: false
+  continuous_automations_enabled: false
+  critical: false
+  description: This is a team policy with FMA install automation
+  install_software:
+    fleet_maintained_app_slug: fma1/darwin
+  name: Team FMA install policy
+  platform: darwin
+  query: "SELECT 1 FROM filevault_status WHERE status LIKE '%on%';"
+  resolution: Install the FMA
+  type: dynamic
+  webhooks_and_tickets_enabled: false
+- calendar_events_enabled: false
+  conditional_access_enabled: false
+  continuous_automations_enabled: false
+  critical: false
+  description: This is a team policy with custom package install automation
+  install_software:
+    hash_sha256: team-software-hash __TEAM_SOFTWARE_COMMENT_TOKEN__
+  name: Team package install policy
+  platform: linux,windows
+  query: "SELECT 1 FROM mounts WHERE path = '/' AND CAST(blocks_available AS REAL) / blocks > 0.10;"
+  resolution: Install the package
   type: dynamic
   webhooks_and_tickets_enabled: false

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamPolicies.yaml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamPolicies.yaml
@@ -17,29 +17,14 @@
   critical: false
   description: This is a team patch policy
   name: Team patch policy
-  notify_before_patching: true
-  patch_when_closed: false
+  notify_before_patching: false
+  patch_when_closed: true
   platform: linux,windows
   query: SELECT * FROM team_policy WHERE id = 1
   resolution: Do a team thing
   fleet_maintained_app_slug: "foo/darwin"
   type: patch
   conditional_access_enabled: true
-  conditional_access_bypass_enabled: false
-  webhooks_and_tickets_enabled: false
-- calendar_events_enabled: false
-  continuous_automations_enabled: false
-  critical: false
-  description: This is a team patch policy that waits for the app to close
-  name: Team patch when closed policy
-  notify_before_patching: false
-  patch_when_closed: true
-  platform: windows
-  query: SELECT * FROM team_policy WHERE id = 6
-  resolution: Do a team thing
-  fleet_maintained_app_slug: "foo/darwin"
-  type: patch
-  conditional_access_enabled: false
   conditional_access_bypass_enabled: false
   webhooks_and_tickets_enabled: false
 - calendar_events_enabled: false

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamSoftware.yaml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamSoftware.yaml
@@ -26,6 +26,8 @@ fleet_maintained_apps:
       - Label B
     post_install_script:
       path: ../lib/some-team/scripts/my-fma-darwin-postinstall.sh
+    pre_install_query:
+      path: ../lib/some-team/queries/my-fma-darwin-preinstallquery.yml
     self_service: true
   - slug: fma2/windows
     labels_include_all:
@@ -36,6 +38,7 @@ fleet_maintained_apps:
   - slug: fma3/windows
     self_service: true
     version: ^123
+  - slug: fma4/darwin
 app_store_apps:
   - app_store_id: "1234567890"
     labels_exclude_any:

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamSoftware.yaml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamSoftware.yaml
@@ -26,8 +26,6 @@ fleet_maintained_apps:
       - Label B
     post_install_script:
       path: ../lib/some-team/scripts/my-fma-darwin-postinstall.sh
-    pre_install_query:
-      path: ../lib/some-team/queries/my-fma-darwin-preinstallquery.yml
     self_service: true
   - slug: fma2/windows
     labels_include_all:

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/fleets/team-a-thumbsup.yml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/fleets/team-a-thumbsup.yml
@@ -73,11 +73,25 @@ policies:
   description: This is a team patch policy
   fleet_maintained_app_slug: foo/darwin
   name: Team patch policy
-  patch_when_closed: true
+  notify_before_patching: true
+  patch_when_closed: false
   platform: linux,windows
   resolution: Do a team thing
   type: patch
   webhooks_and_tickets_enabled: true
+- calendar_events_enabled: false
+  conditional_access_enabled: false
+  continuous_automations_enabled: false
+  critical: false
+  description: This is a team patch policy that waits for the app to close
+  fleet_maintained_app_slug: foo/darwin
+  name: Team patch when closed policy
+  notify_before_patching: false
+  patch_when_closed: true
+  platform: windows
+  resolution: Do a team thing
+  type: patch
+  webhooks_and_tickets_enabled: false
 - calendar_events_enabled: false
   conditional_access_enabled: false
   continuous_automations_enabled: false
@@ -205,8 +219,6 @@ software:
     - Label B
     post_install_script:
       path: "../lib/team-a-👍/scripts/my-fma-darwin-postinstall.sh"
-    pre_install_query:
-      path: "../lib/team-a-👍/queries/my-fma-darwin-preinstallquery.yml"
     self_service: true
     setup_experience: true
     slug: fma1/darwin

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/fleets/team-a-thumbsup.yml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/fleets/team-a-thumbsup.yml
@@ -73,23 +73,23 @@ policies:
   description: This is a team patch policy
   fleet_maintained_app_slug: foo/darwin
   name: Team patch policy
-  notify_before_patching: true
-  patch_when_closed: false
+  notify_before_patching: false
+  patch_when_closed: true
   platform: linux,windows
   resolution: Do a team thing
   type: patch
   webhooks_and_tickets_enabled: true
 - calendar_events_enabled: false
   conditional_access_enabled: false
-  continuous_automations_enabled: false
+  continuous_automations_enabled: true
   critical: false
-  description: This is a team patch policy that waits for the app to close
+  description: This is a team patch policy that notifies before patching
   fleet_maintained_app_slug: foo/darwin
-  name: Team patch when closed policy
-  notify_before_patching: false
-  patch_when_closed: true
-  platform: windows
-  resolution: Do a team thing
+  name: My Notify FMA up to date
+  notify_before_patching: true
+  patch_when_closed: false
+  platform: darwin
+  resolution: Install the latest version from self-service
   type: patch
   webhooks_and_tickets_enabled: false
 - calendar_events_enabled: false
@@ -219,6 +219,8 @@ software:
     - Label B
     post_install_script:
       path: "../lib/team-a-👍/scripts/my-fma-darwin-postinstall.sh"
+    pre_install_query:
+      path: "../lib/team-a-👍/queries/my-fma-darwin-preinstallquery.yml"
     self_service: true
     setup_experience: true
     slug: fma1/darwin
@@ -233,6 +235,7 @@ software:
   - self_service: true
     slug: fma3/windows
     version: "^123"
+  - slug: fma4/darwin
   packages:
   - categories:
     - Browsers

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/fleets/unassigned.yml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/fleets/unassigned.yml
@@ -58,11 +58,25 @@ policies:
   description: This is a team patch policy
   fleet_maintained_app_slug: foo/darwin
   name: Team patch policy
-  patch_when_closed: true
+  notify_before_patching: true
+  patch_when_closed: false
   platform: linux,windows
   resolution: Do a team thing
   type: patch
   webhooks_and_tickets_enabled: true
+- calendar_events_enabled: false
+  conditional_access_enabled: false
+  continuous_automations_enabled: false
+  critical: false
+  description: This is a team patch policy that waits for the app to close
+  fleet_maintained_app_slug: foo/darwin
+  name: Team patch when closed policy
+  notify_before_patching: false
+  patch_when_closed: true
+  platform: windows
+  resolution: Do a team thing
+  type: patch
+  webhooks_and_tickets_enabled: false
 - calendar_events_enabled: false
   conditional_access_enabled: false
   continuous_automations_enabled: false

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/fleets/unassigned.yml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/fleets/unassigned.yml
@@ -58,23 +58,23 @@ policies:
   description: This is a team patch policy
   fleet_maintained_app_slug: foo/darwin
   name: Team patch policy
-  notify_before_patching: true
-  patch_when_closed: false
+  notify_before_patching: false
+  patch_when_closed: true
   platform: linux,windows
   resolution: Do a team thing
   type: patch
   webhooks_and_tickets_enabled: true
 - calendar_events_enabled: false
   conditional_access_enabled: false
-  continuous_automations_enabled: false
+  continuous_automations_enabled: true
   critical: false
-  description: This is a team patch policy that waits for the app to close
+  description: This is a team patch policy that notifies before patching
   fleet_maintained_app_slug: foo/darwin
-  name: Team patch when closed policy
-  notify_before_patching: false
-  patch_when_closed: true
-  platform: windows
-  resolution: Do a team thing
+  name: My Notify FMA up to date
+  notify_before_patching: true
+  patch_when_closed: false
+  platform: darwin
+  resolution: Install the latest version from self-service
   type: patch
   webhooks_and_tickets_enabled: false
 - calendar_events_enabled: false

--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
@@ -3993,7 +3993,7 @@ reports:
     patch_when_closed: true`, slug))), 0o644))
 	fleetctltest.RunAppCheckErr(t, []string{
 		"gitops", "--config", fleetctlConfig.Name(), "-f", globalFile, "-f", teamFile,
-	}, `"continuous_automations_enabled" must be true when "patch_when_closed" is true`)
+	}, `If "patch_when_closed" is true, "continuous_automations_enabled" can't be set to false.`)
 }
 
 func (s *enterpriseIntegrationGitopsTestSuite) TestGitOpsRemovedFMAEmitsPolicyDeletedActivities() {

--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
@@ -3876,7 +3876,7 @@ func (s *enterpriseIntegrationGitopsTestSuite) setupDarwinFMA(t *testing.T) (slu
 	return slug, installerServer.URL
 }
 
-func (s *enterpriseIntegrationGitopsTestSuite) TestGitOpsPatchWhenClosed() {
+func (s *enterpriseIntegrationGitopsTestSuite) TestGitOpsPatchPolicyOptions() {
 	t := s.T()
 	ctx := context.Background()
 
@@ -3969,6 +3969,20 @@ reports:
 	require.Len(t, pols, 1)
 	require.Equal(t, firstID, pols[0].ID, "re-apply should be a no-op")
 	require.True(t, pols[0].PatchWhenClosed)
+	require.True(t, pols[0].ContinuousAutomationsEnabled)
+
+	// Switching the same policy to notify_before_patching flips both flags and keeps
+	// continuous automations auto-set on.
+	apply(fmt.Sprintf(`  - name: patch-policy
+    type: patch
+    fleet_maintained_app_slug: %s
+    notify_before_patching: true`, slug))
+	pols, err = s.DS.ListMergedTeamPolicies(ctx, team.ID, fleet.ListOptions{}, "", "")
+	require.NoError(t, err)
+	require.Len(t, pols, 1)
+	require.Equal(t, firstID, pols[0].ID)
+	require.True(t, pols[0].NotifyBeforePatching, "notify_before_patching should persist")
+	require.False(t, pols[0].PatchWhenClosed, "patch_when_closed should be cleared")
 	require.True(t, pols[0].ContinuousAutomationsEnabled)
 
 	// An explicit continuous_automations_enabled: false is rejected end-to-end.

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -1056,7 +1056,7 @@ func planPatchPolicy(payload *fleet.UpdateSoftwareInstallerPayload, installer *f
 	}
 
 	if notifyBeforePatchingFlag && installer.Platform != "darwin" {
-		return false, false, false, &fleet.BadRequestError{Message: `"notify_before_patching" is available for macOS Fleet-maintained apps. It's coming soon to Windows.`}
+		return false, false, false, &fleet.BadRequestError{Message: fleet.ErrPolicyNotifyBeforePatchingRequiresMacOS.Error()}
 	}
 
 	// The pre-install query is read-only only while a patch option will actually be in effect.

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -223,7 +223,7 @@ type Policy struct {
 type GitOpsPolicySpec struct {
 	fleet.PolicySpec
 	// Shadows PolicySpec.ContinuousAutomationsEnabled to tell whether the key was set
-	// explicitly vs. omitted, which patch_when_closed validation needs.
+	// explicitly vs. omitted, which the patch option validation needs.
 	ContinuousAutomations optjson.Bool                           `json:"continuous_automations_enabled"`
 	RunScript             *PolicyRunScript                       `json:"run_script"`
 	InstallSoftware       optjson.BoolOr[*PolicyInstallSoftware] `json:"install_software"`
@@ -2084,20 +2084,24 @@ func parsePolicies(top map[string]json.RawMessage, result *GitOps, baseDir strin
 			if item.FleetMaintainedAppSlug != "" {
 				patchSlugs = append(patchSlugs, item.FleetMaintainedAppSlug)
 			}
-			if item.PatchWhenClosed {
+			if item.PatchWhenClosed || item.NotifyBeforePatching {
+				patchOption := "patch_when_closed"
+				if item.NotifyBeforePatching {
+					patchOption = "notify_before_patching"
+				}
 				// Declarative: reject an explicit false instead of letting the datastore silently
 				// force it on; auto-set when omitted.
 				if item.ContinuousAutomations.Valid && !item.ContinuousAutomations.Value {
 					multiError = multierror.Append(multiError, fmt.Errorf(
-						`Couldn't apply policy %q: "continuous_automations_enabled" must be true when "patch_when_closed" is true.`, item.Name))
+						`Couldn't apply policy %q: "continuous_automations_enabled" must be true when %q is true.`, item.Name, patchOption))
 				} else {
 					item.ContinuousAutomationsEnabled = true
 				}
 				// Fleet manages the app-open query, so a user pre_install_query on the FMA is rejected.
 				if fma, ok := fmasBySlug[item.FleetMaintainedAppSlug]; ok && fma.PreInstallQuery.Path != "" {
 					multiError = multierror.Append(multiError, fmt.Errorf(
-						`Couldn't apply policy %q: "pre_install_query" can't be set on Fleet-maintained app %q when "patch_when_closed" is true; Fleet manages this query.`,
-						item.Name, item.FleetMaintainedAppSlug))
+						`Couldn't apply policy %q: "pre_install_query" can't be set on Fleet-maintained app %q when %q is true; Fleet manages this query.`,
+						item.Name, item.FleetMaintainedAppSlug, patchOption))
 				}
 			}
 		} else if item.FleetMaintainedAppSlug != "" {

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -2093,7 +2093,7 @@ func parsePolicies(top map[string]json.RawMessage, result *GitOps, baseDir strin
 				// force it on; auto-set when omitted.
 				if item.ContinuousAutomations.Valid && !item.ContinuousAutomations.Value {
 					multiError = multierror.Append(multiError, fmt.Errorf(
-						`Couldn't apply policy %q: "continuous_automations_enabled" must be true when %q is true.`, item.Name, patchOption))
+						`Couldn't apply policy %q: If %q is true, "continuous_automations_enabled" can't be set to false.`, item.Name, patchOption))
 				} else {
 					item.ContinuousAutomationsEnabled = true
 				}

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -2055,20 +2055,13 @@ func parsePolicies(top map[string]json.RawMessage, result *GitOps, baseDir strin
 	// Make sure team name is correct, and do additional validation
 	var patchSlugs []string
 	for _, item := range result.Policies {
-		if item.Name == "" {
-			multiError = multierror.Append(multiError, errors.New("policy name is required for each policy"))
-		} else {
-			item.Name = norm.NFC.String(item.Name)
-		}
+		item.Name = norm.NFC.String(item.Name)
 		// Reconcile the shadow value into the embedded field the apply path reads.
 		if item.ContinuousAutomations.Valid {
 			item.ContinuousAutomationsEnabled = item.ContinuousAutomations.Value
 		}
 		if item.Type == "" {
 			item.Type = fleet.PolicyTypeDynamic
-		}
-		if item.Query == "" && item.Type != fleet.PolicyTypePatch {
-			multiError = multierror.Append(multiError, errors.New("policy query is required for each policy"))
 		}
 		if item.Type == fleet.PolicyTypePatch {
 			if _, ok := fmasBySlug[item.FleetMaintainedAppSlug]; !ok {
@@ -2104,8 +2097,6 @@ func parsePolicies(top map[string]json.RawMessage, result *GitOps, baseDir strin
 						item.Name, item.FleetMaintainedAppSlug, patchOption))
 				}
 			}
-		} else if item.FleetMaintainedAppSlug != "" {
-			multiError = multierror.Append(multiError, errors.New("fleet_maintained_app_slug is only supported for patch policies"))
 		}
 		if result.TeamName != nil {
 			item.Team = *result.TeamName
@@ -2114,6 +2105,9 @@ func parsePolicies(top map[string]json.RawMessage, result *GitOps, baseDir strin
 		}
 		if item.CalendarEventsEnabled && result.IsNoTeam() {
 			multiError = multierror.Append(multiError, fmt.Errorf("calendar events are not supported on policies included in `%s`: %q", filepath.Base(parentFilePath), item.Name))
+		}
+		if err := item.Verify(); err != nil {
+			multiError = multierror.Append(multiError, fmt.Errorf("Couldn't apply policy %q: %w", item.Name, err))
 		}
 	}
 	duplicates := getDuplicateNames(

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -1259,13 +1259,13 @@ func TestInvalidGitOpsYaml(t *testing.T) {
 				config = getConfig([]string{"policies"})
 				config += "policies:\n  - query: SELECT 1;\n"
 				_, err = gitOpsFromString(t, config)
-				assert.ErrorContains(t, err, "policy name cannot be empty")
+				require.ErrorContains(t, err, "policy name cannot be empty")
 
 				// Policy query missing
 				config = getConfig([]string{"policies"})
 				config += "policies:\n  - name: Test Policy\n"
 				_, err = gitOpsFromString(t, config)
-				assert.ErrorContains(t, err, "policy query cannot be empty")
+				require.ErrorContains(t, err, "policy query cannot be empty")
 
 				// Invalid reports
 				config = getConfig([]string{"reports"})

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -5611,7 +5611,7 @@ policies:
 	}
 }
 
-func TestGitOpsPatchWhenClosed(t *testing.T) {
+func TestGitOpsPatchPolicyOptions(t *testing.T) {
 	t.Parallel()
 
 	const fmaSoftware = `
@@ -5703,6 +5703,46 @@ policies:
     fleet_maintained_app_slug: google-chrome/darwin
 `,
 			wantCA: new(false),
+		},
+		{
+			name:     "notify_before_patching with continuous_automations omitted auto-sets it true",
+			software: fmaSoftware,
+			policies: `
+policies:
+  - name: Chrome up to date
+    type: patch
+    platform: darwin
+    fleet_maintained_app_slug: google-chrome/darwin
+    notify_before_patching: true
+`,
+			wantCA: new(true),
+		},
+		{
+			name:     "notify_before_patching with explicit continuous_automations false is rejected",
+			software: fmaSoftware,
+			policies: `
+policies:
+  - name: Chrome up to date
+    type: patch
+    platform: darwin
+    fleet_maintained_app_slug: google-chrome/darwin
+    continuous_automations_enabled: false
+    notify_before_patching: true
+`,
+			wantErrs: []string{`"continuous_automations_enabled" must be true when "notify_before_patching" is true`},
+		},
+		{
+			name:     "notify_before_patching rejects a pre_install_query on the referenced FMA",
+			software: fmaSoftwareWithPreInstall,
+			policies: `
+policies:
+  - name: Chrome up to date
+    type: patch
+    platform: darwin
+    fleet_maintained_app_slug: google-chrome/darwin
+    notify_before_patching: true
+`,
+			wantErrs: []string{`"pre_install_query" can't be set on Fleet-maintained app "google-chrome/darwin" when "notify_before_patching" is true`},
 		},
 	}
 

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -5676,7 +5676,7 @@ policies:
     continuous_automations_enabled: false
     patch_when_closed: true
 `,
-			wantErrs: []string{`"continuous_automations_enabled" must be true when "patch_when_closed" is true`},
+			wantErrs: []string{`If "patch_when_closed" is true, "continuous_automations_enabled" can't be set to false.`},
 		},
 		{
 			name:     "patch_when_closed rejects a pre_install_query on the referenced FMA",
@@ -5729,7 +5729,7 @@ policies:
     continuous_automations_enabled: false
     notify_before_patching: true
 `,
-			wantErrs: []string{`"continuous_automations_enabled" must be true when "notify_before_patching" is true`},
+			wantErrs: []string{`If "notify_before_patching" is true, "continuous_automations_enabled" can't be set to false.`},
 		},
 		{
 			name:     "notify_before_patching rejects a pre_install_query on the referenced FMA",

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -1259,13 +1259,13 @@ func TestInvalidGitOpsYaml(t *testing.T) {
 				config = getConfig([]string{"policies"})
 				config += "policies:\n  - query: SELECT 1;\n"
 				_, err = gitOpsFromString(t, config)
-				assert.ErrorContains(t, err, "name is required")
+				assert.ErrorContains(t, err, "policy name cannot be empty")
 
 				// Policy query missing
 				config = getConfig([]string{"policies"})
 				config += "policies:\n  - name: Test Policy\n"
 				_, err = gitOpsFromString(t, config)
-				assert.ErrorContains(t, err, "query is required")
+				assert.ErrorContains(t, err, "policy query cannot be empty")
 
 				// Invalid reports
 				config = getConfig([]string{"reports"})
@@ -5578,7 +5578,7 @@ policies:
     fleet_maintained_app_slug: google-chrome/darwin
     install_software: true
 `,
-			wantErrs: []string{"fleet_maintained_app_slug is only supported for patch policies"},
+			wantErrs: []string{`"fleet_maintained_app_slug" is only supported for patch policies`},
 		},
 		{
 			name: "dynamic policy with install_software true and no slug is allowed (does nothing)",
@@ -5743,6 +5743,35 @@ policies:
     notify_before_patching: true
 `,
 			wantErrs: []string{`"pre_install_query" can't be set on Fleet-maintained app "google-chrome/darwin" when "notify_before_patching" is true`},
+		},
+		{
+			// PolicySpec.Verify runs during parsing, so a dry run rejects this too.
+			name:     "notify_before_patching on a dynamic policy is rejected",
+			software: fmaSoftware,
+			policies: `
+policies:
+  - name: Chrome installed
+    type: dynamic
+    query: SELECT 1;
+    platform: darwin
+    notify_before_patching: true
+`,
+			wantErrs: []string{`"notify_before_patching" is only supported for patch policies`},
+		},
+		{
+			// Caught during parsing so a dry run rejects it, not just a real apply.
+			name:     "notify_before_patching together with patch_when_closed is rejected",
+			software: fmaSoftware,
+			policies: `
+policies:
+  - name: Chrome up to date
+    type: patch
+    platform: darwin
+    fleet_maintained_app_slug: google-chrome/darwin
+    patch_when_closed: true
+    notify_before_patching: true
+`,
+			wantErrs: []string{`Only one of "patch_when_closed" or "notify_before_patching" can be set to true`},
 		},
 	}
 

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -1732,8 +1732,9 @@ func (ds *Datastore) ApplyPolicySpecs(ctx context.Context, authorID uint, specs 
 			type,
 			patch_software_title_id,
 			continuous_automations_enabled,
-			patch_when_closed
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, %s, ?, ?, ?, ?)
+			patch_when_closed,
+			notify_before_patching
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, %s, ?, ?, ?, ?, ?)
 		ON DUPLICATE KEY UPDATE
 			query = VALUES(query),
 			description = VALUES(description),
@@ -1749,7 +1750,8 @@ func (ds *Datastore) ApplyPolicySpecs(ctx context.Context, authorID uint, specs 
 			type = VALUES(type),
 			patch_software_title_id = VALUES(patch_software_title_id),
 			continuous_automations_enabled = VALUES(continuous_automations_enabled),
-			patch_when_closed = VALUES(patch_when_closed)
+			patch_when_closed = VALUES(patch_when_closed),
+			notify_before_patching = VALUES(notify_before_patching)
 		`, policiesChecksumComputedColumn(),
 		)
 		for teamID, teamPolicySpecs := range teamIDToPolicies {
@@ -1787,10 +1789,20 @@ func (ds *Datastore) ApplyPolicySpecs(ctx context.Context, authorID uint, specs 
 						return ctxerr.Wrap(ctx, err, "getting patch policy installer")
 					}
 
+					if spec.NotifyBeforePatching && installer.Platform != "darwin" {
+						return ctxerr.Wrap(ctx, &fleet.BadRequestError{
+							Message: fleet.ErrPolicyNotifyBeforePatchingRequiresMacOS.Error(),
+						})
+					}
+
 					// Defensive: this can only happen if this endpoint is being called not via gitops
 					// and batch software didn't get called before.
-					if spec.PatchWhenClosed && installer.PreInstallQuery != "" {
-						return ctxerr.Errorf(ctx, "policy %q: pre_install_query can't be set on Fleet-maintained app %q when patch_when_closed is true", spec.Name, spec.FleetMaintainedAppSlug)
+					if (spec.PatchWhenClosed || spec.NotifyBeforePatching) && installer.PreInstallQuery != "" {
+						patchOption := "patch_when_closed"
+						if spec.NotifyBeforePatching {
+							patchOption = "notify_before_patching"
+						}
+						return ctxerr.Errorf(ctx, "policy %q: pre_install_query can't be set on Fleet-maintained app %q when %s is true", spec.Name, spec.FleetMaintainedAppSlug, patchOption)
 					}
 
 					generated, err := patch_policy.GenerateFromInstaller(patch_policy.PolicyData{
@@ -1819,7 +1831,7 @@ func (ds *Datastore) ApplyPolicySpecs(ctx context.Context, authorID uint, specs 
 
 				// Continuous automations must be enabled so the patch policy keeps retrying the
 				// install until the app is closed.
-				if spec.PatchWhenClosed {
+				if spec.PatchWhenClosed || spec.NotifyBeforePatching {
 					spec.ContinuousAutomationsEnabled = true
 				}
 
@@ -1829,6 +1841,7 @@ func (ds *Datastore) ApplyPolicySpecs(ctx context.Context, authorID uint, specs 
 					spec.Name, spec.Query, spec.Description, authorID, spec.Resolution, teamID, spec.Platform, spec.Critical,
 					spec.CalendarEventsEnabled, softwareInstallerID, vppAppsTeamsID, scriptID, spec.ConditionalAccessEnabled,
 					spec.Type, patchSoftwareTitleIDArg, spec.ContinuousAutomationsEnabled, spec.PatchWhenClosed,
+					spec.NotifyBeforePatching,
 				)
 				if err != nil {
 					return ctxerr.Wrap(ctx, err, "exec ApplyPolicySpecs insert")

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -8393,6 +8393,7 @@ func testApplyPolicySpecsPatchWhenClosedRejectsPreInstallQuery(t *testing.T, ds 
 		}}
 	}
 
+	// The rejected batch wrote nothing.
 	assertNothingWritten := func() {
 		var count int
 		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
@@ -8411,7 +8412,7 @@ func testApplyPolicySpecsPatchWhenClosedRejectsPreInstallQuery(t *testing.T, ds 
 	require.ErrorContains(t, err, `pre_install_query can't be set on Fleet-maintained app "maintained2" when notify_before_patching is true`)
 	assertNothingWritten()
 
-	// The same spec applies with neither patch option set.
+	// The same spec applies without patch_when_closed or notify_before_patching.
 	require.NoError(t, ds.ApplyPolicySpecs(ctx, user1.ID, spec(false, false)))
 }
 
@@ -8466,7 +8467,7 @@ func testApplyPolicySpecsNotifyBeforePatchingRejectsWindows(t *testing.T, ds *Da
 	})
 	require.Zero(t, count)
 
-	// The same Windows patch policy applies without the flag.
+	// The same Windows patch policy applies without notify_before_patching.
 	require.NoError(t, ds.ApplyPolicySpecs(ctx, user1.ID, spec(false)))
 }
 

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -94,6 +94,7 @@ func TestPolicies(t *testing.T) {
 		{"TeamPatchPolicy", testTeamPatchPolicy},
 		{"ApplyPolicySpecsDynamicAndPatchSameFMA", testApplyPolicySpecsDynamicAndPatchSameFMA},
 		{"ApplyPolicySpecsPatchWhenClosedRejectsPreInstallQuery", testApplyPolicySpecsPatchWhenClosedRejectsPreInstallQuery},
+		{"ApplyPolicySpecsNotifyBeforePatchingRejectsWindows", testApplyPolicySpecsNotifyBeforePatchingRejectsWindows},
 		{"ApplyPolicySpecsRenamePatchPolicyRegression43687", testApplyPolicySpecsRenamePatchPolicyRegression43687},
 		{"TeamPolicyAutomationFilter", testTeamPolicyAutomationFilter},
 		{"BatchedPolicyMembershipCleanup", testBatchedPolicyMembershipCleanup},
@@ -8380,7 +8381,7 @@ func testApplyPolicySpecsPatchWhenClosedRejectsPreInstallQuery(t *testing.T, ds 
 	})
 	require.NoError(t, err)
 
-	spec := func(patchWhenClosed bool) []*fleet.PolicySpec {
+	spec := func(patchWhenClosed bool, notifyBeforePatching bool) []*fleet.PolicySpec {
 		return []*fleet.PolicySpec{{
 			Name:                   "patch-fma-when-closed",
 			Query:                  "SELECT 1;",
@@ -8388,21 +8389,84 @@ func testApplyPolicySpecsPatchWhenClosedRejectsPreInstallQuery(t *testing.T, ds 
 			Type:                   fleet.PolicyTypePatch,
 			FleetMaintainedAppSlug: "maintained2",
 			PatchWhenClosed:        patchWhenClosed,
+			NotifyBeforePatching:   notifyBeforePatching,
 		}}
 	}
 
-	// patch_when_closed is rejected while the package has its own pre-install query.
-	err = ds.ApplyPolicySpecs(ctx, user1.ID, spec(true))
-	require.ErrorContains(t, err, "pre_install_query can't be set on Fleet-maintained app")
+	assertNothingWritten := func() {
+		var count int
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			return sqlx.GetContext(ctx, q, &count, `SELECT COUNT(*) FROM policies WHERE name = ?`, "patch-fma-when-closed")
+		})
+		require.Zero(t, count)
+	}
 
-	// The rejected batch wrote nothing.
+	// patch_when_closed is rejected while the package has its own pre-install query.
+	err = ds.ApplyPolicySpecs(ctx, user1.ID, spec(true, false))
+	require.ErrorContains(t, err, `pre_install_query can't be set on Fleet-maintained app "maintained2" when patch_when_closed is true`)
+	assertNothingWritten()
+
+	// notify_before_patching is rejected for the same reason, and names itself in the error.
+	err = ds.ApplyPolicySpecs(ctx, user1.ID, spec(false, true))
+	require.ErrorContains(t, err, `pre_install_query can't be set on Fleet-maintained app "maintained2" when notify_before_patching is true`)
+	assertNothingWritten()
+
+	// The same spec applies with neither patch option set.
+	require.NoError(t, ds.ApplyPolicySpecs(ctx, user1.ID, spec(false, false)))
+}
+
+func testApplyPolicySpecsNotifyBeforePatchingRejectsWindows(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+	user1 := test.NewUser(t, ds, "Alice", "alice@example.com", true)
+	team1, err := ds.NewTeam(ctx, &fleet.Team{Name: "team-nbp-windows"})
+	require.NoError(t, err)
+
+	maintainedApp, err := ds.UpsertMaintainedApp(ctx, &fleet.MaintainedApp{
+		Name:             "MaintainedWin",
+		Slug:             "maintained-win",
+		Platform:         "windows",
+		UniqueIdentifier: "fleet.maintainedwin",
+	})
+	require.NoError(t, err)
+
+	_, _, err = ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+		InstallScript:        "hello",
+		StorageID:            "storage-nbp-windows",
+		Filename:             "maintained-win",
+		Title:                "MaintainedWin",
+		Version:              "1.0",
+		Source:               "programs",
+		Platform:             "windows",
+		BundleIdentifier:     "fleet.maintainedwin",
+		UserID:               user1.ID,
+		TeamID:               &team1.ID,
+		ValidatedLabels:      &fleet.LabelIdentsWithScope{},
+		FleetMaintainedAppID: &maintainedApp.ID,
+	})
+	require.NoError(t, err)
+
+	spec := func(notifyBeforePatching bool) []*fleet.PolicySpec {
+		return []*fleet.PolicySpec{{
+			Name:                   "patch-fma-notify",
+			Query:                  "SELECT 1;",
+			Team:                   team1.Name,
+			Type:                   fleet.PolicyTypePatch,
+			FleetMaintainedAppSlug: "maintained-win",
+			NotifyBeforePatching:   notifyBeforePatching,
+		}}
+	}
+
+	// notify_before_patching is macOS-only, so a Windows Fleet-maintained app is rejected.
+	err = ds.ApplyPolicySpecs(ctx, user1.ID, spec(true))
+	require.ErrorContains(t, err, fleet.ErrPolicyNotifyBeforePatchingRequiresMacOS.Error())
+
 	var count int
 	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
-		return sqlx.GetContext(ctx, q, &count, `SELECT COUNT(*) FROM policies WHERE name = ?`, "patch-fma-when-closed")
+		return sqlx.GetContext(ctx, q, &count, `SELECT COUNT(*) FROM policies WHERE name = ?`, "patch-fma-notify")
 	})
 	require.Zero(t, count)
 
-	// The same spec applies without patch_when_closed.
+	// The same Windows patch policy applies without the flag.
 	require.NoError(t, ds.ApplyPolicySpecs(ctx, user1.ID, spec(false)))
 }
 

--- a/server/fleet/policies.go
+++ b/server/fleet/policies.go
@@ -157,6 +157,7 @@ var (
 	errPolicyPatchWhenClosedRequiresPatch            = errors.New("\"patch_when_closed\" is only supported for patch policies")
 	errPolicyNotifyBeforePatchingRequiresPatch       = errors.New("\"notify_before_patching\" is only supported for patch policies")
 	ErrPolicyPatchOptionsMutuallyExclusive           = errors.New("Only one of \"patch_when_closed\" or \"notify_before_patching\" can be set to true")
+	ErrPolicyNotifyBeforePatchingRequiresMacOS       = errors.New("\"notify_before_patching\" is available for macOS Fleet-maintained apps. It's coming soon to Windows.")
 )
 
 // PolicyNoTeamID is the team ID of "No team" policies.
@@ -694,6 +695,8 @@ type PolicySpec struct {
 	ContinuousAutomationsEnabled bool `json:"continuous_automations_enabled"`
 	// PatchWhenClosed skips the install while the app is open, via the managed pre-install query.
 	PatchWhenClosed bool `json:"patch_when_closed"`
+	// NotifyBeforePatching skips the install while the app is open, and notifies the end user first.
+	NotifyBeforePatching bool `json:"notify_before_patching"`
 
 	Type                   string `json:"type"`
 	FleetMaintainedAppSlug string `json:"fleet_maintained_app_slug"`
@@ -752,6 +755,12 @@ func (p PolicySpec) Verify() error {
 	}
 	if p.PatchWhenClosed && p.Type != PolicyTypePatch {
 		return errPolicyPatchWhenClosedRequiresPatch
+	}
+	if p.NotifyBeforePatching && p.Type != PolicyTypePatch {
+		return errPolicyNotifyBeforePatchingRequiresPatch
+	}
+	if p.PatchWhenClosed && p.NotifyBeforePatching {
+		return ErrPolicyPatchOptionsMutuallyExclusive
 	}
 	return p.VerifyLabelScopes()
 }

--- a/server/fleet/policies.go
+++ b/server/fleet/policies.go
@@ -78,7 +78,7 @@ type PolicyPayload struct {
 
 	// PatchWhenClosed skips the install while the app is open, via the managed pre-install query.
 	PatchWhenClosed bool
-	// NotifyBeforePatching skips the install while the app is open, and notifies the end user first.
+	// NotifyBeforePatching skips the install while the app is open, and notifies the end user before installing.
 	NotifyBeforePatching bool
 }
 
@@ -135,7 +135,7 @@ type NewTeamPolicyPayload struct {
 	ContinuousAutomationsEnabled bool
 	// PatchWhenClosed skips the install while the app is open, via the managed pre-install query.
 	PatchWhenClosed bool
-	// NotifyBeforePatching skips the install while the app is open, and notifies the end user first.
+	// NotifyBeforePatching skips the install while the app is open, and notifies the end user before installing.
 	NotifyBeforePatching bool
 }
 
@@ -373,7 +373,7 @@ type ModifyPolicyPayload struct {
 	Type string `json:"-"`
 	// PatchWhenClosed skips the install while the app is open, via the managed pre-install query.
 	PatchWhenClosed *bool `json:"patch_when_closed" premium:"true"`
-	// NotifyBeforePatching skips the install while the app is open, and notifies the end user first.
+	// NotifyBeforePatching skips the install while the app is open, and notifies the end user before installing.
 	NotifyBeforePatching *bool `json:"notify_before_patching" premium:"true"`
 }
 
@@ -485,7 +485,7 @@ type PolicyData struct {
 
 	// PatchWhenClosed skips the install while the app is open, via the managed pre-install query.
 	PatchWhenClosed bool `json:"patch_when_closed" db:"patch_when_closed"`
-	// NotifyBeforePatching skips the install while the app is open, and notifies the end user first.
+	// NotifyBeforePatching skips the install while the app is open, and notifies the end user before installing.
 	NotifyBeforePatching bool `json:"notify_before_patching" db:"notify_before_patching"`
 
 	UpdateCreateTimestamps
@@ -695,7 +695,7 @@ type PolicySpec struct {
 	ContinuousAutomationsEnabled bool `json:"continuous_automations_enabled"`
 	// PatchWhenClosed skips the install while the app is open, via the managed pre-install query.
 	PatchWhenClosed bool `json:"patch_when_closed"`
-	// NotifyBeforePatching skips the install while the app is open, and notifies the end user first.
+	// NotifyBeforePatching skips the install while the app is open, and notifies the end user before installing.
 	NotifyBeforePatching bool `json:"notify_before_patching"`
 
 	Type                   string `json:"type"`

--- a/server/fleet/policies_test.go
+++ b/server/fleet/policies_test.go
@@ -110,6 +110,20 @@ func TestPolicySpecVerifyFleetMaintainedAppSlug(t *testing.T) {
 			name: "dynamic policy without slug is allowed",
 			spec: PolicySpec{Name: "Chrome installed", Team: "Workstations", Query: "SELECT 1;", Type: PolicyTypeDynamic},
 		},
+		{
+			name: "patch policy with notify_before_patching is allowed",
+			spec: PolicySpec{Name: "Chrome up to date", Team: "Workstations", Type: PolicyTypePatch, FleetMaintainedAppSlug: "google-chrome/darwin", NotifyBeforePatching: true},
+		},
+		{
+			name:    "dynamic policy with notify_before_patching is rejected",
+			spec:    PolicySpec{Name: "Chrome installed", Team: "Workstations", Query: "SELECT 1;", Type: PolicyTypeDynamic, NotifyBeforePatching: true},
+			wantErr: errPolicyNotifyBeforePatchingRequiresPatch,
+		},
+		{
+			name:    "patch policy with both patch options is rejected",
+			spec:    PolicySpec{Name: "Chrome up to date", Team: "Workstations", Type: PolicyTypePatch, FleetMaintainedAppSlug: "google-chrome/darwin", PatchWhenClosed: true, NotifyBeforePatching: true},
+			wantErr: ErrPolicyPatchOptionsMutuallyExclusive,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/server/service/global_policies.go
+++ b/server/service/global_policies.go
@@ -258,7 +258,6 @@ const (
 	errPolicyAllFleetsForContinuousAutomations           = "\"All fleets\" policy cannot have continuous_automations_enabled set"
 	errPatchWhenClosedRequiresContinuousAutomations      = "If \"patch_when_closed\" is true, \"continuous_automations_enabled\" can't be set to false."
 	errNotifyBeforePatchingRequiresContinuousAutomations = "If \"notify_before_patching\" is true, \"continuous_automations_enabled\" can't be set to false."
-	errNotifyBeforePatchingRequiresMacOS                 = "\"notify_before_patching\" is available for macOS Fleet-maintained apps. It's coming soon to Windows."
 )
 
 func modifyGlobalPolicyEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (fleet.Errorer, error) {
@@ -504,6 +503,11 @@ func (svc *Service) ApplyPolicySpecs(ctx context.Context, policies []*fleet.Poli
 
 		// PatchWhenClosed is premium-only.
 		if policy.PatchWhenClosed && !license.IsPremium(ctx) {
+			return fleet.ErrMissingLicense
+		}
+
+		// NotifyBeforePatching is premium-only.
+		if policy.NotifyBeforePatching && !license.IsPremium(ctx) {
 			return fleet.ErrMissingLicense
 		}
 

--- a/server/service/team_policies.go
+++ b/server/service/team_policies.go
@@ -326,7 +326,7 @@ func (svc *Service) newTeamPolicyPayloadToPolicyPayload(ctx context.Context, tea
 			return fleet.PolicyPayload{}, ctxerr.Wrap(ctx, err, "getting installer for notify before patching")
 		}
 		if installer.Platform != "darwin" {
-			return fleet.PolicyPayload{}, &fleet.BadRequestError{Message: errNotifyBeforePatchingRequiresMacOS}
+			return fleet.PolicyPayload{}, &fleet.BadRequestError{Message: fleet.ErrPolicyNotifyBeforePatchingRequiresMacOS.Error()}
 		}
 	}
 
@@ -743,7 +743,7 @@ func (svc *Service) modifyPolicy(ctx context.Context, teamID *uint, id uint, p f
 		return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{Message: fleet.ErrPolicyPatchOptionsMutuallyExclusive.Error()})
 	}
 	if notifyBeforePatching && policy.Platform != "darwin" {
-		return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{Message: errNotifyBeforePatchingRequiresMacOS})
+		return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{Message: fleet.ErrPolicyNotifyBeforePatchingRequiresMacOS.Error()})
 	}
 	// patch_when_closed needs continuous automations: reject an explicit false, otherwise force it on.
 	if patchWhenClosed && p.ContinuousAutomationsEnabled != nil && !*p.ContinuousAutomationsEnabled {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #50917 
- Adds GitOps support for the `patch when notify` type of patch policy
- Adds a call to PolicySpec.Verify() so that dry runs get the full validation for that struct. All the removed checks are covered by the verify method.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [x] Verified that the setting is exported via `fleetctl generate-gitops`
- [x] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [x] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for notifying users before macOS devices are patched.
  * GitOps-generated patch policies now preserve the pre-patch notification setting.
  * Enabling pre-patch notifications automatically enables continuous automations.

* **Bug Fixes**
  * Improved validation prevents incompatible patch options, unsupported platforms, licenses, and pre-install queries.
  * Policy updates now retain existing policy IDs and correctly apply notification settings.

* **Documentation**
  * Updated patch-policy field descriptions and validation messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->