### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/firefox@developer-edition/darwin.json
+++ b/ee/maintained-apps/outputs/firefox@developer-edition/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "155.0b2",
+      "version": "155.0b3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefoxdeveloperedition';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefoxdeveloperedition' AND version_compare(bundle_version, '15526.8.19') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefoxdeveloperedition' AND version_compare(bundle_version, '15526.8.21') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'org.mozilla.firefoxdeveloperedition');"
       },
-      "installer_url": "https://download-installer.cdn.mozilla.net/pub/devedition/releases/155.0b2/mac/en-US/Firefox%20155.0b2.dmg",
+      "installer_url": "https://download-installer.cdn.mozilla.net/pub/devedition/releases/155.0b3/mac/en-US/Firefox%20155.0b3.dmg",
       "install_script_ref": "b679ecd7",
       "uninstall_script_ref": "292c5733",
-      "sha256": "f223973170b8828e28db57dfbd3aa7b6c089b01a2098c23dc6dc43542bc9dde7",
+      "sha256": "4aaf57b8e160f8801ec870d9317635f44e4d82e21dbfcfafb0a7b520ee2b4018",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/localsend/darwin.json
+++ b/ee/maintained-apps/outputs/localsend/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.18.0",
+      "version": "1.18.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.localsend.localsendApp';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.localsend.localsendApp' AND version_compare(bundle_short_version, '1.18.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.localsend.localsendApp' AND version_compare(bundle_short_version, '1.18.2') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'org.localsend.localsendApp');"
       },
-      "installer_url": "https://github.com/localsend/localsend/releases/download/v1.18.0/LocalSend-1.18.0.dmg",
+      "installer_url": "https://github.com/localsend/localsend/releases/download/v1.18.2/LocalSend-1.18.2.dmg",
       "install_script_ref": "f3e3757e",
       "uninstall_script_ref": "59b942e3",
-      "sha256": "93ab884c2703a0fabd72611097b2616c0def86c4256cea2add7a0ff36dd76b3a",
+      "sha256": "126860d56f6f49b11845f601aac51de27a49b16d2b48102415da91e0e37e5155",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/opencode-desktop/darwin.json
+++ b/ee/maintained-apps/outputs/opencode-desktop/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.18.20",
+      "version": "1.18.21",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'ai.opencode.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'ai.opencode.desktop' AND version_compare(bundle_short_version, '1.18.20') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'ai.opencode.desktop' AND version_compare(bundle_short_version, '1.18.21') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'ai.opencode.desktop');"
       },
-      "installer_url": "https://github.com/anomalyco/opencode/releases/download/v1.18.20/opencode-desktop-mac-arm64.dmg",
+      "installer_url": "https://github.com/anomalyco/opencode/releases/download/v1.18.21/opencode-desktop-mac-arm64.dmg",
       "install_script_ref": "d2ce7b1a",
       "uninstall_script_ref": "99fcb3f1",
-      "sha256": "fae0de980927bbc6dee4655f71ef31c74628ecf408f2733be74597a75e3d3d61",
+      "sha256": "a04746b6b3961b5ca17a2eaedf8372ae82e9418c7b07742a9d8cff63ea73dfd7",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/raycast/darwin.json
+++ b/ee/maintained-apps/outputs/raycast/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "2.0.3.0",
+      "version": "2.0.5.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.raycast.macos';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.raycast.macos' AND version_compare(bundle_short_version, '2.0.3.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.raycast.macos' AND version_compare(bundle_short_version, '2.0.5.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.raycast.macos');"
       },
-      "installer_url": "https://x.raycast-releases.com/download?platform=macos&architecture=arm64&version=2.0.3.0",
+      "installer_url": "https://x.raycast-releases.com/download?platform=macos&architecture=arm64&version=2.0.5.0",
       "install_script_ref": "f52a81be",
       "uninstall_script_ref": "cb893329",
-      "sha256": "776d06bb4867784cce4344d4459c3d871fcb899ecfec7cb6590163b415cfeee0",
+      "sha256": "f3f1095464df4d5a8dfb853dbd3f384cba68d77ed15a70f662d153b582bbb47d",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/wechat/darwin.json
+++ b/ee/maintained-apps/outputs/wechat/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "4.1.13.10",
+      "version": "4.1.13.11",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.tencent.xinWeChat';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.tencent.xinWeChat' AND version_compare(bundle_short_version, '4.1.13.10') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.tencent.xinWeChat' AND version_compare(bundle_short_version, '4.1.13.11') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.tencent.xinWeChat');"
       },
-      "installer_url": "https://dldir1.qq.com/weixin/Universal/Mac/xWeChatMac_universal_4.1.13.10_269578.dmg",
+      "installer_url": "https://dldir1.qq.com/weixin/Universal/Mac/xWeChatMac_universal_4.1.13.11_269579.dmg",
       "install_script_ref": "f191200e",
       "uninstall_script_ref": "a5e852b0",
-      "sha256": "9240480327cdd21e66e9c0a58fe0e2d4444da625166871be37c8b8a02c3ad7a8",
+      "sha256": "8ac5734e173fb457c915a9fd56d8c360ca284328d765219feafb3ba7e767a09e",
       "default_categories": [
         "Communication"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the macOS Firefox Developer Edition package to version 155.0b3.
  * Updated LocalSend for macOS to version 1.18.2.
  * Updated OpenCode Desktop for macOS to version 1.18.21.
  * Updated Raycast for macOS to version 2.0.5.0.
  * Updated WeChat for macOS to version 4.1.13.11.
  * Installer verification and upgrade detection now target the latest releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->