### PR TITLE
Validate software list order keys against an allowlist

### DIFF
--- a/changes/17212-software-order-key-allowlist
+++ b/changes/17212-software-order-key-allowlist
@@ -1,0 +1,1 @@
+- Improved validation of the `order_key` parameter when listing software, rejecting sort keys that aren't supported instead of passing them through to the query.

--- a/server/datastore/mysql/mysql.go
+++ b/server/datastore/mysql/mysql.go
@@ -836,36 +836,52 @@ func (ds *Datastore) Close() error {
 }
 
 // appendListOptionsToSelect will apply the given list options to ds and
-// return the new select dataset.
-//
-// NOTE: This is a copy of appendListOptionsToSQL that uses the goqu package.
-func appendListOptionsToSelect(ds *goqu.SelectDataset, opts fleet.ListOptions) *goqu.SelectDataset {
-	ds = appendOrderByToSelect(ds, opts)
+// return the new select dataset. Order keys are validated against allowlist.
+func appendListOptionsToSelect(ds *goqu.SelectDataset, opts fleet.ListOptions, allowlist common_mysql.OrderKeyAllowlist) (*goqu.SelectDataset, error) {
+	ds, err := appendOrderByToSelect(ds, opts, allowlist)
+	if err != nil {
+		return nil, err
+	}
 	ds = appendLimitOffsetToSelect(ds, opts)
-	return ds
+	return ds, nil
 }
 
-func appendOrderByToSelect(ds *goqu.SelectDataset, opts fleet.ListOptions) *goqu.SelectDataset {
-	if opts.OrderKey != "" {
-		ordersKeys := strings.Split(opts.OrderKey, ",")
-		for _, key := range ordersKeys {
-			sanitized := common_mysql.SanitizeColumn(key)
-			if sanitized == "" {
-				continue
-			}
-
-			var orderedExpr exp.OrderedExpression
-			if opts.OrderDirection == fleet.OrderDescending {
-				orderedExpr = goqu.L(sanitized).Desc()
-			} else {
-				orderedExpr = goqu.L(sanitized).Asc()
-			}
-
-			ds = ds.OrderAppend(orderedExpr)
-		}
+// appendOrderByToSelect appends the requested ordering to ds. The order key is
+// validated against allowlist, which maps the keys a caller may sort by to the
+// column each one orders on, so that a caller can't sort by an arbitrary column
+// and read it back through the resulting order.
+//
+// The mapped columns are quoted as identifiers, so an allowlist used here must
+// map to bare column names rather than to a SQL expression.
+func appendOrderByToSelect(ds *goqu.SelectDataset, opts fleet.ListOptions, allowlist common_mysql.OrderKeyAllowlist) (*goqu.SelectDataset, error) {
+	if opts.OrderKey == "" {
+		return ds, nil
 	}
 
-	return ds
+	// An order key may name more than one column, e.g. "name,version".
+	for _, key := range strings.Split(opts.OrderKey, ",") {
+		column, ok := allowlist[key]
+		if !ok {
+			return nil, common_mysql.InvalidOrderKeyError{Key: key, Allowed: allowlist.AllowedKeys()}
+		}
+		sanitized := common_mysql.SanitizeColumn(column)
+		if sanitized == "" {
+			// Only reachable if an allowlist maps a key to something that
+			// isn't a column name at all.
+			continue
+		}
+
+		var orderedExpr exp.OrderedExpression
+		if opts.OrderDirection == fleet.OrderDescending {
+			orderedExpr = goqu.L(sanitized).Desc()
+		} else {
+			orderedExpr = goqu.L(sanitized).Asc()
+		}
+
+		ds = ds.OrderAppend(orderedExpr)
+	}
+
+	return ds, nil
 }
 
 func appendLimitOffsetToSelect(ds *goqu.SelectDataset, opts fleet.ListOptions) *goqu.SelectDataset {

--- a/server/datastore/mysql/mysql.go
+++ b/server/datastore/mysql/mysql.go
@@ -836,7 +836,7 @@ func (ds *Datastore) Close() error {
 }
 
 // appendListOptionsToSelect will apply the given list options to ds and
-// return the new select dataset. Order keys are validated against allowlist.
+// return the new select dataset.
 func appendListOptionsToSelect(ds *goqu.SelectDataset, opts fleet.ListOptions, allowlist common_mysql.OrderKeyAllowlist) (*goqu.SelectDataset, error) {
 	ds, err := appendOrderByToSelect(ds, opts, allowlist)
 	if err != nil {
@@ -846,18 +846,12 @@ func appendListOptionsToSelect(ds *goqu.SelectDataset, opts fleet.ListOptions, a
 	return ds, nil
 }
 
-// appendOrderByToSelect appends the requested ordering to ds. The order key is
-// validated against allowlist, which maps the keys a caller may sort by to the
-// column each one orders on, so that a caller can't sort by an arbitrary column
-// and read it back through the resulting order.
-//
-// The mapped columns are quoted as identifiers, so an allowlist used here must
-// map to bare column names rather than to a SQL expression.
+// appendOrderByToSelect appends the requested ordering to ds. Each query passes
+// its own allowlist, since the sortable columns differ per query; a key outside
+// it is rejected rather than reaching the ORDER BY. A nil allowlist rejects
+// every key. Mapped columns are quoted as identifiers, so they must be bare
+// column names rather than SQL expressions.
 func appendOrderByToSelect(ds *goqu.SelectDataset, opts fleet.ListOptions, allowlist common_mysql.OrderKeyAllowlist) (*goqu.SelectDataset, error) {
-	if allowlist == nil {
-		panic("appendOrderByToSelect: allowlist cannot be nil; use an empty map to disallow all sorting")
-	}
-
 	if opts.OrderKey == "" {
 		return ds, nil
 	}

--- a/server/datastore/mysql/mysql.go
+++ b/server/datastore/mysql/mysql.go
@@ -854,6 +854,10 @@ func appendListOptionsToSelect(ds *goqu.SelectDataset, opts fleet.ListOptions, a
 // The mapped columns are quoted as identifiers, so an allowlist used here must
 // map to bare column names rather than to a SQL expression.
 func appendOrderByToSelect(ds *goqu.SelectDataset, opts fleet.ListOptions, allowlist common_mysql.OrderKeyAllowlist) (*goqu.SelectDataset, error) {
+	if allowlist == nil {
+		panic("appendOrderByToSelect: allowlist cannot be nil; use an empty map to disallow all sorting")
+	}
+
 	if opts.OrderKey == "" {
 		return ds, nil
 	}

--- a/server/datastore/mysql/mysql.go
+++ b/server/datastore/mysql/mysql.go
@@ -863,7 +863,7 @@ func appendOrderByToSelect(ds *goqu.SelectDataset, opts fleet.ListOptions, allow
 	}
 
 	// An order key may name more than one column, e.g. "name,version".
-	for _, key := range strings.Split(opts.OrderKey, ",") {
+	for key := range strings.SplitSeq(opts.OrderKey, ",") {
 		key = strings.TrimSpace(key)
 		if key == "" {
 			continue

--- a/server/datastore/mysql/mysql.go
+++ b/server/datastore/mysql/mysql.go
@@ -860,15 +860,19 @@ func appendOrderByToSelect(ds *goqu.SelectDataset, opts fleet.ListOptions, allow
 
 	// An order key may name more than one column, e.g. "name,version".
 	for _, key := range strings.Split(opts.OrderKey, ",") {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
 		column, ok := allowlist[key]
 		if !ok {
 			return nil, common_mysql.InvalidOrderKeyError{Key: key, Allowed: allowlist.AllowedKeys()}
 		}
 		sanitized := common_mysql.SanitizeColumn(column)
 		if sanitized == "" {
-			// Only reachable if an allowlist maps a key to something that
-			// isn't a column name at all.
-			continue
+			// The allowlist maps this key to something that isn't a column
+			// name, which would silently drop it from the ordering.
+			return nil, fmt.Errorf("order key %q maps to an invalid column %q", key, column)
 		}
 
 		var orderedExpr exp.OrderedExpression

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -2053,6 +2053,13 @@ func canUseOptimizedListQuery(opts fleet.SoftwareListOptions) bool {
 	// Filters (VulnerableOnly / KnownExploit / MinimumCVSS / MaximumCVSS /
 	// MatchQuery) are now supported in the inner query via EXISTS pushdown —
 	// see buildOptimizedListSoftwareSQL.
+	// Asking to sort on hosts_count only makes sense when the counts are part
+	// of the query. Requests that don't name an order key still come here, so
+	// the default ordering is unchanged.
+	if opts.ListOptions.OrderKey != "" && !opts.WithHostCounts {
+		return false
+	}
+
 	return opts.HostID == nil &&
 		orderKey == "hosts_count" &&
 		!isMultiColumnSort(opts.ListOptions.OrderKey)

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -2034,8 +2034,10 @@ type softwareCVE struct {
 // canUseOptimizedListQuery determines if we can use the fast path query
 // that starts FROM software_host_counts instead of software.
 func canUseOptimizedListQuery(opts fleet.SoftwareListOptions) bool {
-	// Determine the effective order key
-	orderKey := opts.ListOptions.OrderKey
+	// Determine the effective order key. Trim first, so a key that the ordering
+	// helper accepts (it trims too) is routed the same way here rather than
+	// silently falling back to the slower path.
+	orderKey := strings.TrimSpace(opts.ListOptions.OrderKey)
 	if orderKey == "" {
 		orderKey = "hosts_count"
 	}
@@ -2056,13 +2058,13 @@ func canUseOptimizedListQuery(opts fleet.SoftwareListOptions) bool {
 	// Asking to sort on hosts_count only makes sense when the counts are part
 	// of the query. Requests that don't name an order key still come here, so
 	// the default ordering is unchanged.
-	if opts.ListOptions.OrderKey != "" && !opts.WithHostCounts {
+	if strings.TrimSpace(opts.ListOptions.OrderKey) != "" && !opts.WithHostCounts {
 		return false
 	}
 
 	return opts.HostID == nil &&
 		orderKey == "hosts_count" &&
-		!isMultiColumnSort(opts.ListOptions.OrderKey)
+		!isMultiColumnSort(orderKey)
 }
 
 // isMultiColumnSort checks if the order key contains multiple columns (comma-separated)

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -2485,7 +2485,7 @@ func selectSoftwareSQL(opts fleet.SoftwareListOptions) (string, []interface{}, e
 
 	// Pagination is a bit more complex here due to the join with software_cve table and aggregated columns from cve_meta table.
 	// Apply order by again after joining on sub query
-	allowedOrderKeys := softwareOrderKeys(opts.IncludeCVEScores)
+	allowedOrderKeys := softwareOrderKeys(opts)
 	ds, err := appendListOptionsToSelect(ds, opts.ListOptions, allowedOrderKeys)
 	if err != nil {
 		return "", nil, err
@@ -5472,8 +5472,11 @@ var softwareAllowedOrderKeys = common_mysql.OrderKeyAllowlist{
 	"application_id":    "application_id",
 	"upgrade_code":      "upgrade_code",
 	"generated_cpe":     "generated_cpe",
-	// hosts_count is only part of the query when host counts are requested,
-	// which the endpoints always do.
+}
+
+// softwareHostCountAllowedOrderKeys may only be sorted on when host counts are
+// requested, since that is when the query selects the column.
+var softwareHostCountAllowedOrderKeys = common_mysql.OrderKeyAllowlist{
 	"hosts_count": "hosts_count",
 }
 
@@ -5487,15 +5490,22 @@ var softwareCVEAllowedOrderKeys = common_mysql.OrderKeyAllowlist{
 }
 
 // softwareOrderKeys returns the keys the software list may be sorted by for the
-// given options. The result is only read, and may be the package-level list
+// given options, which decide whether the columns behind some of them are part
+// of the query. The result is only read, and may be the package-level list
 // itself, so callers must not modify it.
-func softwareOrderKeys(includeCVEScores bool) common_mysql.OrderKeyAllowlist {
-	if !includeCVEScores {
+func softwareOrderKeys(opts fleet.SoftwareListOptions) common_mysql.OrderKeyAllowlist {
+	if !opts.IncludeCVEScores && !opts.WithHostCounts {
 		return softwareAllowedOrderKeys
 	}
-	keys := make(common_mysql.OrderKeyAllowlist, len(softwareAllowedOrderKeys)+len(softwareCVEAllowedOrderKeys))
+	keys := make(common_mysql.OrderKeyAllowlist,
+		len(softwareAllowedOrderKeys)+len(softwareCVEAllowedOrderKeys)+len(softwareHostCountAllowedOrderKeys))
 	maps.Copy(keys, softwareAllowedOrderKeys)
-	maps.Copy(keys, softwareCVEAllowedOrderKeys)
+	if opts.IncludeCVEScores {
+		maps.Copy(keys, softwareCVEAllowedOrderKeys)
+	}
+	if opts.WithHostCounts {
+		maps.Copy(keys, softwareHostCountAllowedOrderKeys)
+	}
 	return keys
 }
 

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"regexp"
 	"sort"
 	"strconv"
@@ -2484,7 +2485,11 @@ func selectSoftwareSQL(opts fleet.SoftwareListOptions) (string, []interface{}, e
 
 	// Pagination is a bit more complex here due to the join with software_cve table and aggregated columns from cve_meta table.
 	// Apply order by again after joining on sub query
-	ds = appendListOptionsToSelect(ds, opts.ListOptions)
+	allowedOrderKeys := softwareOrderKeys(opts.IncludeCVEScores)
+	ds, err := appendListOptionsToSelect(ds, opts.ListOptions, allowedOrderKeys)
+	if err != nil {
+		return "", nil, err
+	}
 
 	// join on software_cve and cve_meta after apply pagination using the sub-query above
 	ds = dialect.From(ds.As("s")).
@@ -2540,7 +2545,10 @@ func selectSoftwareSQL(opts fleet.SoftwareListOptions) (string, []interface{}, e
 		)
 	}
 
-	ds = appendOrderByToSelect(ds, opts.ListOptions)
+	ds, err = appendOrderByToSelect(ds, opts.ListOptions, allowedOrderKeys)
+	if err != nil {
+		return "", nil, err
+	}
 
 	return ds.ToSQL()
 }
@@ -5437,6 +5445,58 @@ func promoteSoftwareTitleInHouseApp(softwareTitleRecord *hostSoftware) {
 			softwareTitleRecord.SoftwarePackage.LastInstall.InstalledAt = *softwareTitleRecord.LastInstallInstalledAt
 		}
 	}
+}
+
+// softwareAllowedOrderKeys are the keys the software list may be sorted by. They
+// are columns the list returns, so ordering on one can't reveal anything the
+// response doesn't already carry; the columns it omits are deliberately absent., mapped to the column each one orders on. Ordering is
+// validated against this list so that a caller can't sort by a column the
+// response doesn't return and read its values back through the ordering.
+// The keys match the documented sort fields, plus id and version which are
+// used for stable ordering.
+// The columns are unqualified because the ordering is applied at two levels of
+// the query, which reach the same output column through different aliases; the
+// output name resolves at both. They must also stay bare column names, since
+// this path quotes them as identifiers and would mangle a SQL expression.
+var softwareAllowedOrderKeys = common_mysql.OrderKeyAllowlist{
+	"id":                "id",
+	"name":              "name",
+	"version":           "version",
+	"source":            "source",
+	"bundle_identifier": "bundle_identifier",
+	"extension_id":      "extension_id",
+	"extension_for":     "extension_for",
+	"release":           "release",
+	"vendor":            "vendor",
+	"arch":              "arch",
+	"application_id":    "application_id",
+	"upgrade_code":      "upgrade_code",
+	"generated_cpe":     "generated_cpe",
+	// hosts_count is only part of the query when host counts are requested,
+	// which the endpoints always do.
+	"hosts_count": "hosts_count",
+}
+
+// softwareCVEAllowedOrderKeys may only be sorted on when vulnerability details
+// are included, since that is when the query selects those columns.
+var softwareCVEAllowedOrderKeys = common_mysql.OrderKeyAllowlist{
+	"cve_published":      "cve_published",
+	"cvss_score":         "cvss_score",
+	"epss_probability":   "epss_probability",
+	"cisa_known_exploit": "cisa_known_exploit",
+}
+
+// softwareOrderKeys returns the keys the software list may be sorted by for the
+// given options. The result is only read, and may be the package-level list
+// itself, so callers must not modify it.
+func softwareOrderKeys(includeCVEScores bool) common_mysql.OrderKeyAllowlist {
+	if !includeCVEScores {
+		return softwareAllowedOrderKeys
+	}
+	keys := make(common_mysql.OrderKeyAllowlist, len(softwareAllowedOrderKeys)+len(softwareCVEAllowedOrderKeys))
+	maps.Copy(keys, softwareAllowedOrderKeys)
+	maps.Copy(keys, softwareCVEAllowedOrderKeys)
+	return keys
 }
 
 // hostSoftwareAllowedOrderKeys is minimal: the service layer pins OrderKey to "name".

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -2034,10 +2034,10 @@ type softwareCVE struct {
 // canUseOptimizedListQuery determines if we can use the fast path query
 // that starts FROM software_host_counts instead of software.
 func canUseOptimizedListQuery(opts fleet.SoftwareListOptions) bool {
-	// Determine the effective order key. Trim first, so a key that the ordering
-	// helper accepts (it trims too) is routed the same way here rather than
-	// silently falling back to the slower path.
-	orderKey := strings.TrimSpace(opts.ListOptions.OrderKey)
+	// Trim to match the ordering helper, so a key it accepts isn't routed to the
+	// slower path over spacing alone.
+	requested := strings.TrimSpace(opts.ListOptions.OrderKey)
+	orderKey := requested
 	if orderKey == "" {
 		orderKey = "hosts_count"
 	}
@@ -2055,10 +2055,9 @@ func canUseOptimizedListQuery(opts fleet.SoftwareListOptions) bool {
 	// Filters (VulnerableOnly / KnownExploit / MinimumCVSS / MaximumCVSS /
 	// MatchQuery) are now supported in the inner query via EXISTS pushdown —
 	// see buildOptimizedListSoftwareSQL.
-	// Asking to sort on hosts_count only makes sense when the counts are part
-	// of the query. Requests that don't name an order key still come here, so
-	// the default ordering is unchanged.
-	if strings.TrimSpace(opts.ListOptions.OrderKey) != "" && !opts.WithHostCounts {
+	// The optimized path orders by hosts_count, so it can only serve a request
+	// that also returns the column. An absent key keeps the default ordering.
+	if requested != "" && !opts.WithHostCounts {
 		return false
 	}
 
@@ -5456,17 +5455,11 @@ func promoteSoftwareTitleInHouseApp(softwareTitleRecord *hostSoftware) {
 	}
 }
 
-// softwareAllowedOrderKeys are the keys the software list may be sorted by. They
-// are columns the list returns, so ordering on one can't reveal anything the
-// response doesn't already carry; the columns it omits are deliberately absent., mapped to the column each one orders on. Ordering is
-// validated against this list so that a caller can't sort by a column the
-// response doesn't return and read its values back through the ordering.
-// The keys match the documented sort fields, plus id and version which are
-// used for stable ordering.
-// The columns are unqualified because the ordering is applied at two levels of
-// the query, which reach the same output column through different aliases; the
-// output name resolves at both. They must also stay bare column names, since
-// this path quotes them as identifiers and would mangle a SQL expression.
+// softwareAllowedOrderKeys are the columns the software list may be sorted by:
+// the ones it returns, so ordering can't surface a value the response omits.
+// Columns are unqualified because the ordering is applied at two levels of the
+// query that reach them through different aliases, and must stay bare column
+// names because this path quotes them as identifiers.
 var softwareAllowedOrderKeys = common_mysql.OrderKeyAllowlist{
 	"id":                "id",
 	"name":              "name",
@@ -5483,14 +5476,12 @@ var softwareAllowedOrderKeys = common_mysql.OrderKeyAllowlist{
 	"generated_cpe":     "generated_cpe",
 }
 
-// softwareHostCountAllowedOrderKeys may only be sorted on when host counts are
-// requested, since that is when the query selects the column.
+// Sortable only when host counts are requested; that is when the query selects it.
 var softwareHostCountAllowedOrderKeys = common_mysql.OrderKeyAllowlist{
 	"hosts_count": "hosts_count",
 }
 
-// softwareCVEAllowedOrderKeys may only be sorted on when vulnerability details
-// are included, since that is when the query selects those columns.
+// Sortable only when vulnerability details are included, for the same reason.
 var softwareCVEAllowedOrderKeys = common_mysql.OrderKeyAllowlist{
 	"cve_published":      "cve_published",
 	"cvss_score":         "cvss_score",
@@ -5498,10 +5489,8 @@ var softwareCVEAllowedOrderKeys = common_mysql.OrderKeyAllowlist{
 	"cisa_known_exploit": "cisa_known_exploit",
 }
 
-// softwareOrderKeys returns the keys the software list may be sorted by for the
-// given options, which decide whether the columns behind some of them are part
-// of the query. The result is only read, and may be the package-level list
-// itself, so callers must not modify it.
+// softwareOrderKeys may return one of the package-level maps above, so the
+// result must not be modified.
 func softwareOrderKeys(opts fleet.SoftwareListOptions) common_mysql.OrderKeyAllowlist {
 	if !opts.IncludeCVEScores && !opts.WithHostCounts {
 		return softwareAllowedOrderKeys

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -562,6 +562,41 @@ func testSoftwareLoadSupportsTonsOfCVEs(t *testing.T, ds *Datastore) {
 	}
 }
 
+// TestCanUseOptimizedListQueryOrderKeys pins which requests take the covering-index
+// path. The ordering helper trims the key before validating it, so this has to trim
+// too: otherwise a key it accepts is routed to the slower path on whitespace alone.
+// hosts_count without WithHostCounts must stay off the optimized path, since that
+// path orders by a column the response does not return.
+func TestCanUseOptimizedListQueryOrderKeys(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		orderKey       string
+		withHostCounts bool
+		want           bool
+	}{
+		{"", false, true},                 // default ordering, unchanged
+		{"  ", false, true},               // trims to empty, so still the default
+		{"hosts_count", true, true},       // counts requested and returned
+		{" hosts_count ", true, true},     // same request, just spaced
+		{"hosts_count", false, false},     // counts not returned, so not sortable
+		{" hosts_count ", false, false},   // spacing must not get around that
+		{"name", true, false},             // not the covering index column
+		{"hosts_count,name", true, false}, // multi-column defeats the index
+		{" hosts_count , name ", true, false},
+	} {
+		name := fmt.Sprintf("%q/counts=%v", tc.orderKey, tc.withHostCounts)
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := canUseOptimizedListQuery(fleet.SoftwareListOptions{
+				ListOptions:    fleet.ListOptions{OrderKey: tc.orderKey},
+				WithHostCounts: tc.withHostCounts,
+			})
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
 func TestAppendOrderByToSelectRequiresAllowlist(t *testing.T) {
 	// A missing allowlist is a wiring mistake, not a request that should be
 	// refused, so it fails loudly rather than rejecting every order key.

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -1107,16 +1107,13 @@ func testSoftwareList(t *testing.T, ds *Datastore) {
 
 			_, _, err := ds.ListSoftware(context.Background(), opts)
 			require.Error(t, err, "SQL injection payload should be rejected: %s", payload)
-			// The payload names no supported sort key, so it is rejected before
-			// it reaches the query rather than by the database.
+			// Rejected before reaching the query.
 			require.Contains(t, err.Error(), "invalid order_key", "Expected order key rejection for payload: %s", payload)
 		}
 	})
 
 	t.Run("order key must be a supported sort key", func(t *testing.T) {
-		// These name real columns, so they would sort successfully if the order
-		// key were passed through. Sorting by a column the response doesn't
-		// return would expose its values through the resulting order.
+		// Real columns the response doesn't return: sortable only if unguarded.
 		for _, key := range []string{"s.id", "s.title_id", "s.application_id", "vendor_old", "checksum"} {
 			_, _, err := ds.ListSoftware(context.Background(), fleet.SoftwareListOptions{
 				ListOptions: fleet.ListOptions{OrderKey: key},
@@ -1126,10 +1123,8 @@ func testSoftwareList(t *testing.T, ds *Datastore) {
 		}
 
 		// Supported keys, including a multi-column key, keep working.
-		// Sorting on hosts_count alone is served by a separate query that builds
-		// its own ordering, so it is paired with a second key here to keep it on
-		// the path this list guards. It also needs the host counts to be part of
-		// the query, which is what the endpoints always ask for.
+		// hosts_count alone goes to the separate query, so pair it with a second
+		// key to stay on this path.
 		for _, key := range []string{"name", "generated_cpe", "cvss_score", "name,version", "hosts_count,name"} {
 			_, _, err := ds.ListSoftware(context.Background(), fleet.SoftwareListOptions{
 				ListOptions:      fleet.ListOptions{OrderKey: key},
@@ -1139,9 +1134,7 @@ func testSoftwareList(t *testing.T, ds *Datastore) {
 			require.NoError(t, err, "order key %q should be accepted", key)
 		}
 
-		// The vulnerability columns are only part of the query when scores are
-		// included, so sorting on them otherwise is rejected rather than being
-		// left to fail against the database.
+		// CVE columns are only selected when scores are included.
 		for _, key := range []string{"cvss_score", "cve_published", "epss_probability", "cisa_known_exploit"} {
 			_, _, err := ds.ListSoftware(context.Background(), fleet.SoftwareListOptions{
 				ListOptions: fleet.ListOptions{OrderKey: key},
@@ -1150,9 +1143,7 @@ func testSoftwareList(t *testing.T, ds *Datastore) {
 			require.Contains(t, err.Error(), "invalid order_key", "order key %q", key)
 		}
 
-		// hosts_count is likewise only sortable when the counts are part of the
-		// query. Sorting on it alone is served by the separate query, so this
-		// pairs it with a second key to reach the list, as above.
+		// Same for hosts_count, again paired to stay on this path.
 		for _, key := range []string{"hosts_count", "hosts_count,name"} {
 			_, _, err := ds.ListSoftware(context.Background(), fleet.SoftwareListOptions{
 				ListOptions: fleet.ListOptions{OrderKey: key},

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -583,9 +583,8 @@ func TestSoftwareOrderKeysCoverListedColumns(t *testing.T) {
 	}
 
 	sortable := softwareOrderKeys(fleet.SoftwareListOptions{IncludeCVEScores: true, WithHostCounts: true})
-	typ := reflect.TypeOf(fleet.Software{})
-	for i := range typ.NumField() {
-		field := typ.Field(i)
+	typ := reflect.TypeFor[fleet.Software]()
+	for field := range typ.Fields() {
 		column := field.Tag.Get("db")
 		if column == "" {
 			continue

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -562,6 +562,15 @@ func testSoftwareLoadSupportsTonsOfCVEs(t *testing.T, ds *Datastore) {
 	}
 }
 
+func TestAppendOrderByToSelectRequiresAllowlist(t *testing.T) {
+	// A missing allowlist is a wiring mistake, not a request that should be
+	// refused, so it fails loudly rather than rejecting every order key.
+	require.Panics(t, func() {
+		//nolint:errcheck // panics before returning
+		appendOrderByToSelect(dialect.From("software"), fleet.ListOptions{OrderKey: "name"}, nil)
+	})
+}
+
 // TestSoftwareOrderKeysCoverListedColumns fails when a column is added to the
 // software list without deciding whether it can be sorted on, so the decision
 // is made deliberately rather than by omission. A column that the list returns
@@ -1117,11 +1126,17 @@ func testSoftwareList(t *testing.T, ds *Datastore) {
 		// hosts_count is likewise only sortable when the counts are part of the
 		// query. Sorting on it alone is served by the separate query, so this
 		// pairs it with a second key to reach the list, as above.
-		_, _, err := ds.ListSoftware(context.Background(), fleet.SoftwareListOptions{
-			ListOptions: fleet.ListOptions{OrderKey: "hosts_count,name"},
-		})
-		require.Error(t, err, "hosts_count should be rejected without host counts")
-		require.Contains(t, err.Error(), "invalid order_key")
+		for _, key := range []string{"hosts_count", "hosts_count,name"} {
+			_, _, err := ds.ListSoftware(context.Background(), fleet.SoftwareListOptions{
+				ListOptions: fleet.ListOptions{OrderKey: key},
+			})
+			require.Error(t, err, "%q should be rejected without host counts", key)
+			require.Contains(t, err.Error(), "invalid order_key", "order key %q", key)
+		}
+
+		// Not naming an order key still uses the default ordering.
+		_, _, err := ds.ListSoftware(context.Background(), fleet.SoftwareListOptions{})
+		require.NoError(t, err)
 
 		// Whitespace and empty segments around a key are tolerated.
 

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -563,10 +563,7 @@ func testSoftwareLoadSupportsTonsOfCVEs(t *testing.T, ds *Datastore) {
 }
 
 // TestCanUseOptimizedListQueryOrderKeys pins which requests take the covering-index
-// path. The ordering helper trims the key before validating it, so this has to trim
-// too: otherwise a key it accepts is routed to the slower path on whitespace alone.
-// hosts_count without WithHostCounts must stay off the optimized path, since that
-// path orders by a column the response does not return.
+// path, including the spacing the ordering helper tolerates.
 func TestCanUseOptimizedListQueryOrderKeys(t *testing.T) {
 	t.Parallel()
 
@@ -598,19 +595,15 @@ func TestCanUseOptimizedListQueryOrderKeys(t *testing.T) {
 }
 
 func TestAppendOrderByToSelectRequiresAllowlist(t *testing.T) {
-	// A missing allowlist is a wiring mistake, not a request that should be
-	// refused, so it fails loudly rather than rejecting every order key.
-	require.Panics(t, func() {
-		//nolint:errcheck // panics before returning
-		appendOrderByToSelect(dialect.From("software"), fleet.ListOptions{OrderKey: "name"}, nil)
-	})
+	t.Parallel()
+
+	_, err := appendOrderByToSelect(dialect.From("software"), fleet.ListOptions{OrderKey: "name"}, nil)
+	require.Error(t, err, "a missing allowlist must reject every order key")
 }
 
 // TestSoftwareOrderKeysCoverListedColumns fails when a column is added to the
-// software list without deciding whether it can be sorted on, so the decision
-// is made deliberately rather than by omission. A column that the list returns
-// is safe to sort on; one it doesn't return would leak its values through the
-// order, and one the query doesn't select can't be ordered on at all.
+// software list without deciding whether it is sortable, so the decision is
+// made deliberately rather than by omission.
 func TestSoftwareOrderKeysCoverListedColumns(t *testing.T) {
 	// Returned by the list, but not selected by its query, so not sortable.
 	notSelected := map[string]struct{}{

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -573,7 +573,7 @@ func TestSoftwareOrderKeysCoverListedColumns(t *testing.T) {
 		"last_opened_at": {},
 	}
 
-	sortable := softwareOrderKeys(true)
+	sortable := softwareOrderKeys(fleet.SoftwareListOptions{IncludeCVEScores: true, WithHostCounts: true})
 	typ := reflect.TypeOf(fleet.Software{})
 	for i := range typ.NumField() {
 		field := typ.Field(i)
@@ -1112,6 +1112,24 @@ func testSoftwareList(t *testing.T, ds *Datastore) {
 			})
 			require.Error(t, err, "order key %q should be rejected without CVE scores", key)
 			require.Contains(t, err.Error(), "invalid order_key", "order key %q", key)
+		}
+
+		// hosts_count is likewise only sortable when the counts are part of the
+		// query. Sorting on it alone is served by the separate query, so this
+		// pairs it with a second key to reach the list, as above.
+		_, _, err := ds.ListSoftware(context.Background(), fleet.SoftwareListOptions{
+			ListOptions: fleet.ListOptions{OrderKey: "hosts_count,name"},
+		})
+		require.Error(t, err, "hosts_count should be rejected without host counts")
+		require.Contains(t, err.Error(), "invalid order_key")
+
+		// Whitespace and empty segments around a key are tolerated.
+
+		for _, key := range []string{" name , version ", "name,", ",name"} {
+			_, _, err := ds.ListSoftware(context.Background(), fleet.SoftwareListOptions{
+				ListOptions: fleet.ListOptions{OrderKey: key},
+			})
+			require.NoError(t, err, "order key %q should be accepted", key)
 		}
 
 		// ...and keys that don't depend on them work either way.

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"maps"
 	"math/rand"
+	"reflect"
 	std_slices "slices"
 	"sort"
 	"strconv"
@@ -561,6 +562,38 @@ func testSoftwareLoadSupportsTonsOfCVEs(t *testing.T, ds *Datastore) {
 	}
 }
 
+// TestSoftwareOrderKeysCoverListedColumns fails when a column is added to the
+// software list without deciding whether it can be sorted on, so the decision
+// is made deliberately rather than by omission. A column that the list returns
+// is safe to sort on; one it doesn't return would leak its values through the
+// order, and one the query doesn't select can't be ordered on at all.
+func TestSoftwareOrderKeysCoverListedColumns(t *testing.T) {
+	// Returned by the list, but not selected by its query, so not sortable.
+	notSelected := map[string]struct{}{
+		"last_opened_at": {},
+	}
+
+	sortable := softwareOrderKeys(true)
+	typ := reflect.TypeOf(fleet.Software{})
+	for i := range typ.NumField() {
+		field := typ.Field(i)
+		column := field.Tag.Get("db")
+		if column == "" {
+			continue
+		}
+		_, allowed := sortable[column]
+		_, skipped := notSelected[column]
+
+		if field.Tag.Get("json") == "-" {
+			assert.False(t, allowed, "%s is not returned by the list, so sorting on it would expose it", column)
+			continue
+		}
+		assert.True(t, allowed || skipped,
+			"%s is returned by the list: add it to softwareAllowedOrderKeys, or to notSelected here if the query doesn't select it",
+			column)
+	}
+}
+
 func testSoftwareList(t *testing.T, ds *Datastore) {
 	host1 := test.NewHost(t, ds, "host1", "", "host1key", "host1uuid", time.Now())
 	host2 := test.NewHost(t, ds, "host2", "", "host2key", "host2uuid", time.Now())
@@ -1037,8 +1070,56 @@ func testSoftwareList(t *testing.T, ds *Datastore) {
 			}
 
 			_, _, err := ds.ListSoftware(context.Background(), opts)
-			require.Error(t, err, "SQL injection payload should result in column error: %s", payload)
-			require.Contains(t, err.Error(), "Unknown column", "Expected column error for payload: %s", payload)
+			require.Error(t, err, "SQL injection payload should be rejected: %s", payload)
+			// The payload names no supported sort key, so it is rejected before
+			// it reaches the query rather than by the database.
+			require.Contains(t, err.Error(), "invalid order_key", "Expected order key rejection for payload: %s", payload)
+		}
+	})
+
+	t.Run("order key must be a supported sort key", func(t *testing.T) {
+		// These name real columns, so they would sort successfully if the order
+		// key were passed through. Sorting by a column the response doesn't
+		// return would expose its values through the resulting order.
+		for _, key := range []string{"s.id", "s.title_id", "s.application_id", "vendor_old", "checksum"} {
+			_, _, err := ds.ListSoftware(context.Background(), fleet.SoftwareListOptions{
+				ListOptions: fleet.ListOptions{OrderKey: key},
+			})
+			require.Error(t, err, "order key %q should be rejected", key)
+			require.Contains(t, err.Error(), "invalid order_key", "order key %q", key)
+		}
+
+		// Supported keys, including a multi-column key, keep working.
+		// Sorting on hosts_count alone is served by a separate query that builds
+		// its own ordering, so it is paired with a second key here to keep it on
+		// the path this list guards. It also needs the host counts to be part of
+		// the query, which is what the endpoints always ask for.
+		for _, key := range []string{"name", "generated_cpe", "cvss_score", "name,version", "hosts_count,name"} {
+			_, _, err := ds.ListSoftware(context.Background(), fleet.SoftwareListOptions{
+				ListOptions:      fleet.ListOptions{OrderKey: key},
+				IncludeCVEScores: true,
+				WithHostCounts:   true,
+			})
+			require.NoError(t, err, "order key %q should be accepted", key)
+		}
+
+		// The vulnerability columns are only part of the query when scores are
+		// included, so sorting on them otherwise is rejected rather than being
+		// left to fail against the database.
+		for _, key := range []string{"cvss_score", "cve_published", "epss_probability", "cisa_known_exploit"} {
+			_, _, err := ds.ListSoftware(context.Background(), fleet.SoftwareListOptions{
+				ListOptions: fleet.ListOptions{OrderKey: key},
+			})
+			require.Error(t, err, "order key %q should be rejected without CVE scores", key)
+			require.Contains(t, err.Error(), "invalid order_key", "order key %q", key)
+		}
+
+		// ...and keys that don't depend on them work either way.
+		for _, key := range []string{"name", "generated_cpe"} {
+			_, _, err := ds.ListSoftware(context.Background(), fleet.SoftwareListOptions{
+				ListOptions: fleet.ListOptions{OrderKey: key},
+			})
+			require.NoError(t, err, "order key %q should be accepted", key)
 		}
 	})
 

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -1493,6 +1493,10 @@ func (s *integrationTestSuite) TestVulnerableSoftware() {
 	s.DoJSON("GET", "/api/latest/fleet/software/count", countReq, http.StatusOK, &countResp, "vulnerable", "true", "order_key", "generated_cpe", "order_direction", "desc")
 	assert.Equal(t, 1, countResp.Count)
 
+	// an unsupported order_key returns 422
+	s.Do("GET", "/api/latest/fleet/software", nil, http.StatusUnprocessableEntity, "order_key", "vendor_old")
+	s.Do("GET", "/api/latest/fleet/software/versions", nil, http.StatusUnprocessableEntity, "order_key", "vendor_old")
+
 	// default sort, not only vulnerable
 	lsResp = listSoftwareResponse{}
 	s.DoJSON("GET", "/api/latest/fleet/software", nil, http.StatusOK, &lsResp)


### PR DESCRIPTION
**Related issue:** N/A

## Description

The software list builds its `ORDER BY` from the requested `order_key` after only stripping unexpected characters from it, so a caller can sort on any column the query can reach — including ones the response doesn't return, whose values can then be read back from the resulting order. An unrecognised name also reached the database, so the error it produced distinguished a real column from one that doesn't exist.

The key is now checked against the columns the list actually returns, and anything else is rejected before the query is built. Ordering on a listed column can't surface anything the response doesn't already carry.

The vulnerability columns (`cve_published`, `cvss_score`, `epss_probability`, `cisa_known_exploit`) are only part of the query when vulnerability details are requested, so they are only sortable then — otherwise sorting on them would have reached the database and failed there.

Sorting by `hosts_count` alone is served by a separate query that builds its own ordering and doesn't take a key from the request, so it is unaffected.

## Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements) — the sort key is now matched against a fixed list before any query is built.

## Testing

- [x] Added/updated automated tests — the datastore tests cover rejected keys (including real column names that the response omits), accepted keys including a multi-column one, and the vulnerability keys in both modes; an existing test that expected a database error for malformed keys now expects them to be rejected earlier. A separate test keeps the sortable list and the returned columns from drifting apart, so adding a column to the list is a deliberate decision either way. There are also HTTP-level assertions that an unsupported key returns 422 on `/software` and `/software/versions`.
- [x] QA'd all new/changed functionality manually — verified on a local instance that the documented sort fields, the multi-column form, and the keys used by existing clients all still return results in the right order, and that an unsupported key is refused with the supported ones listed.

cc @lukeheath for review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Software and software-version listings now reject unsupported sorting fields with a clear validation error.
  - Vulnerability and host-count sorting options are validated based on the requested data.
  - Explicit host-count sorting now falls back safely when host counts are unavailable.
  - Sorting input handles whitespace and empty entries more reliably.

- **Tests**
  - Added coverage for valid, multi-field, conditional, and rejected sorting requests, including fleet software and version endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->