### PR TITLE
[Doc] Update building-fleet.md to remove Rosetta 2 note

### DIFF
--- a/docs/Contributing/getting-started/building-fleet.md
+++ b/docs/Contributing/getting-started/building-fleet.md
@@ -112,12 +112,6 @@ To generate all necessary code (bundling JavaScript into Go, etc.), run the foll
 make generate
 ```
 
-If you are using a Mac computer with Apple Silicon and have not installed Rosetta 2, you will need to do so before running `make generate`. Otherwise, you may see the following error: `Unknown system error -86`
-
-```sh
-/usr/sbin/softwareupdate --install-rosetta --agree-to-license
-```
-
 #### Automatic rebuilding of the JavaScript bundle
 
 Usually, `make generate` takes the JavaScript code, bundles it into a single bundle via Webpack, and inlines that bundle into a generated Go source file so that all of the frontend code can be statically compiled into the binary. When you build the code after running `make generate`, include all of that JavaScript in the binary.


### PR DESCRIPTION
Removed instructions for installing Rosetta 2 on Mac.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #31471