### PR TITLE
Fleet UI: Suppress empty TooltipWrapper renders

### DIFF
--- a/frontend/components/TooltipWrapper/TooltipWrapper.stories.tsx
+++ b/frontend/components/TooltipWrapper/TooltipWrapper.stories.tsx
@@ -120,6 +120,25 @@ export const BalancedWithNestedMarkup: Story = {
   },
 };
 
+/** Hovering any of these triggers should render NO tooltip — no empty
+ * background flash, no arrow. Callers can pass a conditional `tipContent`
+ * without gating on `disableTooltip` themselves. */
+export const EmptyContentSuppressed: Story = {
+  render: () => (
+    <div style={{ display: "flex", gap: "4rem", alignItems: "flex-start" }}>
+      <TooltipWrapper tipContent="">Empty string</TooltipWrapper>
+      <TooltipWrapper tipContent={null}>Null</TooltipWrapper>
+      <TooltipWrapper tipContent={undefined}>Undefined</TooltipWrapper>
+      <TooltipWrapper tipContent={false && "hidden"}>
+        Falsy conditional
+      </TooltipWrapper>
+      <TooltipWrapper tipContent="Populated, for contrast">
+        Populated
+      </TooltipWrapper>
+    </div>
+  ),
+};
+
 /** Structural `<br />`s (list separators) are respected as forced breaks —
  * balance runs within each segment rather than across the whole flow. */
 export const BalancedWithForcedBreaks: Story = {

--- a/frontend/components/TooltipWrapper/TooltipWrapper.tests.tsx
+++ b/frontend/components/TooltipWrapper/TooltipWrapper.tests.tsx
@@ -20,6 +20,25 @@ describe("TooltipWrapper", () => {
     });
   });
 
+  it("does not render tooltip when tipContent is empty", async () => {
+    // Guarantees callers can pass a conditional/empty tipContent without
+    // the tooltip's empty background flashing on hover.
+    const { user } = renderWithSetup(
+      <TooltipWrapper tipContent="">
+        <span>Hover me</span>
+      </TooltipWrapper>
+    );
+
+    const anchor = screen.getByText("Hover me");
+    await user.hover(anchor);
+
+    // The tooltip's root gets role="tooltip"; hovering an empty-content wrapper
+    // must not mount one.
+    await waitFor(() => {
+      expect(screen.queryByRole("tooltip")).toBeNull();
+    });
+  });
+
   it("does not render tooltip when disableTooltip is true", async () => {
     const { user } = renderWithSetup(
       <TooltipWrapper tipContent="Tooltip text" disableTooltip>

--- a/frontend/components/TooltipWrapper/TooltipWrapper.tests.tsx
+++ b/frontend/components/TooltipWrapper/TooltipWrapper.tests.tsx
@@ -66,6 +66,26 @@ describe("TooltipWrapper", () => {
     expect(element).toHaveClass("component__tooltip-wrapper__underline");
   });
 
+  it("does not apply underline class when tipContent is empty", () => {
+    render(
+      <TooltipWrapper tipContent="">
+        <span>Hover me</span>
+      </TooltipWrapper>
+    );
+    const element = screen.getByText("Hover me").parentElement;
+    expect(element).not.toHaveClass("component__tooltip-wrapper__underline");
+  });
+
+  it("does not apply underline class when disableTooltip is true", () => {
+    render(
+      <TooltipWrapper tipContent="Tooltip text" disableTooltip>
+        <span>Hover me</span>
+      </TooltipWrapper>
+    );
+    const element = screen.getByText("Hover me").parentElement;
+    expect(element).not.toHaveClass("component__tooltip-wrapper__underline");
+  });
+
   it("does not apply underline class when underline is false", () => {
     render(
       <TooltipWrapper tipContent="Tooltip text" underline={false}>

--- a/frontend/components/TooltipWrapper/TooltipWrapper.tsx
+++ b/frontend/components/TooltipWrapper/TooltipWrapper.tsx
@@ -205,7 +205,7 @@ const TooltipWrapper = ({
       >
         {children}
       </div>
-      {!disableTooltip && (
+      {!disableTooltip && !!tipContent && (
         <ReactTooltip5
           className={tipClassNames}
           id={tipId}

--- a/frontend/components/TooltipWrapper/TooltipWrapper.tsx
+++ b/frontend/components/TooltipWrapper/TooltipWrapper.tsx
@@ -162,9 +162,11 @@ const TooltipWrapper = ({
     // [`${baseClass}__${wrapperCustomClass}`]: !!wrapperCustomClass,
   });
 
+  const willRenderTooltip = !disableTooltip && !!tipContent;
+
   const elementClassNames = classnames(`${baseClass}__element`, {
     // [`${baseClass}__${elementCustomClass}`]: !!elementCustomClass,
-    [`${baseClass}__underline`]: underline,
+    [`${baseClass}__underline`]: underline && willRenderTooltip,
   });
 
   const tipClassNames = classnames(`${baseClass}__tip-text`, tooltipClass, {
@@ -200,12 +202,12 @@ const TooltipWrapper = ({
         data-tip
         data-tooltip-id={tipId}
         style={
-          isMobileView && !disableTooltip ? { cursor: "pointer" } : undefined
+          isMobileView && willRenderTooltip ? { cursor: "pointer" } : undefined
         } // With mobile width, show pointer cursor on hover since tooltip won't show on hover
       >
         {children}
       </div>
-      {!disableTooltip && !!tipContent && (
+      {willRenderTooltip && (
         <ReactTooltip5
           className={tipClassNames}
           id={tipId}

--- a/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostInstallerActionCell/HostInstallerActionCell.tsx
+++ b/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostInstallerActionCell/HostInstallerActionCell.tsx
@@ -187,7 +187,6 @@ export const HostInstallerActionButton = ({
   <div className={`${baseClass}__item-action`}>
     <TooltipWrapper
       tipContent={tooltip}
-      disableTooltip={!tooltip}
       underline={false}
       showArrow
       position="top"


### PR DESCRIPTION
## Issue
Closes #51548
Follow-up to #51466 to prevent this UI bug from recurring across other callers.

## Description
`TooltipWrapper` still mounted the tooltip root (an empty styled background) when `tipContent` was falsy. Callers had to know to pass `disableTooltip={!tipContent}` themselves (e.g. `HostInstallerActionCell` did this in #51466). Gate the render on `!!tipContent` at the source so empty/nullish/false content never paints a tooltip. Also hides the underline (and mobile pointer cursor) whenever the tooltip is suppressed, and drops the now-redundant `disableTooltip={!tooltip}` guard from `HostInstallerActionCell`.

## Screenrecording


https://github.com/user-attachments/assets/c8d2296e-9bd2-4951-ae6a-b8203166a6e4



## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented empty or unavailable tooltip content from displaying a tooltip background when users hover.
  * Removed tooltip underline and cursor styling when no tooltip is available or tooltips are disabled.
  * Simplified tooltip behavior for host installer actions, ensuring styling and display remain consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->