### PR TITLE
Add Fleet Desktop SSO setting to organization settings UI

### DIFF
--- a/changes/47116-fleet-desktop-sso-setting
+++ b/changes/47116-fleet-desktop-sso-setting
@@ -1,1 +1,2 @@
 - Added the `fleet_desktop.sso_enabled` (Fleet Premium) config setting, along with `enabled_sso_fleet_desktop`/`disabled_sso_fleet_desktop` activities and a `fleetDesktopSSOEnabled` usage statistic.
+- Added an "End user authentication" setting to Settings > Organization settings > Fleet Desktop to require end users to sign in via SSO before accessing the "My device" page.

--- a/frontend/__mocks__/configMock.ts
+++ b/frontend/__mocks__/configMock.ts
@@ -226,6 +226,7 @@ const DEFAULT_CONFIG_MOCK: IConfig = {
   fleet_desktop: {
     transparency_url: "https://fleetdm.com/transparency",
     alternative_browser_host: "",
+    sso_enabled: false,
   },
   mdm: createMockMdmConfig(),
   gitops: {

--- a/frontend/interfaces/activity.ts
+++ b/frontend/interfaces/activity.ts
@@ -104,6 +104,8 @@ export enum ActivityType {
   DisabledWindowsMdm = "disabled_windows_mdm",
   EnabledGitOpsMode = "enabled_gitops_mode",
   DisabledGitOpsMode = "disabled_gitops_mode",
+  EnabledSSOFleetDesktop = "enabled_sso_fleet_desktop",
+  DisabledSSOFleetDesktop = "disabled_sso_fleet_desktop",
   EnabledGitOpsException = "enabled_gitops_exception",
   DisabledGitOpsException = "disabled_gitops_exception",
   EnabledWindowsMdmMigration = "enabled_windows_mdm_migration",
@@ -476,6 +478,7 @@ export const ACTIVITY_TYPE_TO_FILTER_LABEL: Record<ActivityType, string> = {
   disabled_macos_setup_end_user_auth:
     "Turned off end user authentication (setup experience)",
   disabled_macos_update_new_hosts: "Disabled OS updates for new macOS hosts",
+  disabled_sso_fleet_desktop: "Disabled single sign-on (SSO) for Fleet Desktop",
   disabled_vpp: "Disabled Volume Purchasing Program (VPP)",
   disabled_windows_mdm: "Turned off Windows MDM",
   disabled_windows_mdm_migration: "Turned off Windows MDM migration",
@@ -510,6 +513,7 @@ export const ACTIVITY_TYPE_TO_FILTER_LABEL: Record<ActivityType, string> = {
   enabled_macos_setup_end_user_auth:
     "Turned on end user authentication (setup experience)",
   enabled_macos_update_new_hosts: "Enabled OS updates for new macOS hosts",
+  enabled_sso_fleet_desktop: "Enabled single sign-on (SSO) for Fleet Desktop",
   enabled_vpp: "Enabled Volume Purchasing Program (VPP)",
   enabled_windows_mdm: "Turned on Windows MDM",
   enabled_windows_mdm_migration: "Turned on Windows MDM migration",

--- a/frontend/interfaces/config.ts
+++ b/frontend/interfaces/config.ts
@@ -139,6 +139,7 @@ export interface IDeviceGlobalConfig {
 export interface IFleetDesktopSettings {
   transparency_url: string;
   alternative_browser_host: string;
+  sso_enabled: boolean;
 }
 
 export interface IConfigFeatures {

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
@@ -1102,6 +1102,8 @@ const TAGGED_TEMPLATES = {
   },
   enabledGitOpsMode: () => "enabled GitOps mode in the UI.",
   disabledGitOpsMode: () => "disabled GitOps mode in the UI.",
+  ssoFleetDesktop: (state: string) =>
+    `${state} single sign-on (SSO) for Fleet Desktop.`,
   enabledGitOpsException: (activity: IActivity) => {
     const exception = activity.details?.exception ?? "";
     return `enabled the ${exception} exception for GitOps.`;
@@ -2545,6 +2547,12 @@ const getDetail = (activity: IActivity, isPremiumTier: boolean) => {
     }
     case ActivityType.DisabledGitOpsMode: {
       return TAGGED_TEMPLATES.disabledGitOpsMode();
+    }
+    case ActivityType.EnabledSSOFleetDesktop: {
+      return TAGGED_TEMPLATES.ssoFleetDesktop("enabled");
+    }
+    case ActivityType.DisabledSSOFleetDesktop: {
+      return TAGGED_TEMPLATES.ssoFleetDesktop("disabled");
     }
     case ActivityType.EnabledGitOpsException: {
       return TAGGED_TEMPLATES.enabledGitOpsException(activity);

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/Users.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/Users.tsx
@@ -3,12 +3,13 @@ import { useQuery } from "react-query";
 
 import configAPI from "services/entities/config";
 import teamsAPI, { ILoadTeamResponse } from "services/entities/teams";
-import { IConfig, IMdmConfig } from "interfaces/config";
+import { IConfig } from "interfaces/config";
 import { APP_CONTEXT_NO_TEAM_ID, ITeamConfig } from "interfaces/team";
 
 import Spinner from "components/Spinner";
 import SectionHeader from "components/SectionHeader";
 import CustomLink from "components/CustomLink";
+import { isEndUserIdPConfigured } from "utilities/permissions/permissions";
 import { LEARN_MORE_ABOUT_BASE_LINK } from "utilities/constants";
 import PageDescription from "components/PageDescription";
 import { EndUserLocalAccountType } from "interfaces/mdm";
@@ -108,14 +109,6 @@ const getLockEndUserInfo = (
   return teamConfig?.mdm?.setup_experience.lock_end_user_info ?? false;
 };
 
-const isIdPConfigured = ({
-  end_user_authentication: idp,
-}: Pick<IMdmConfig, "end_user_authentication">) => {
-  return (
-    !!idp.entity_id && !!idp.idp_name && (!!idp.metadata_url || !!idp.metadata)
-  );
-};
-
 const Users = ({ currentTeamId }: ISetupExperienceCardProps) => {
   const { data: globalConfig, isLoading: isLoadingGlobalConfig } = useQuery<
     IConfig,
@@ -164,7 +157,6 @@ const Users = ({ currentTeamId }: ISetupExperienceCardProps) => {
     if (!globalConfig || isLoadingGlobalConfig || isLoadingTeamConfig) {
       return <Spinner />;
     }
-    const mdmConfig = globalConfig.mdm;
     return (
       <UsersForm
         currentTeamId={currentTeamId}
@@ -177,7 +169,7 @@ const Users = ({ currentTeamId }: ISetupExperienceCardProps) => {
         defaultEnableManagedLocalAccountWindows={
           enableManagedLocalAccountWindows
         }
-        isIdPConfigured={isIdPConfigured(mdmConfig)}
+        isIdPConfigured={isEndUserIdPConfigured(globalConfig)}
       />
     );
   };

--- a/frontend/pages/admin/OrgSettingsPage/cards/FleetDesktop/FleetDesktop.tests.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/FleetDesktop/FleetDesktop.tests.tsx
@@ -2,14 +2,42 @@ import React from "react";
 import { screen, waitFor } from "@testing-library/react";
 import { renderWithSetup, createMockRouter } from "test/test-utils";
 
-import createMockConfig from "__mocks__/configMock";
+import { IConfig, IEndUserAuthentication } from "interfaces/config";
+
+import createMockConfig, { createMockMdmConfig } from "__mocks__/configMock";
 
 import FleetDesktop from "./FleetDesktop";
 
 import { DEFAULT_TRANSPARENCY_URL } from "../constants";
 
+const mdmWithIdP = (idp?: Partial<IEndUserAuthentication>) =>
+  createMockMdmConfig({
+    end_user_authentication: {
+      entity_id: "https://fleet.example.com",
+      idp_name: "Okta",
+      metadata: "",
+      metadata_url: "https://idp.example.com/metadata",
+      issuer_uri: "",
+      ...idp,
+    },
+  });
+
 describe("FleetDesktop", () => {
   const mockHandleSubmit = jest.fn();
+
+  const renderCard = ({
+    config,
+    isPremiumTier = true,
+  }: { config?: Partial<IConfig>; isPremiumTier?: boolean } = {}) =>
+    renderWithSetup(
+      <FleetDesktop
+        appConfig={createMockConfig(config)}
+        handleSubmit={mockHandleSubmit}
+        isPremiumTier={isPremiumTier}
+        isUpdatingSettings={false}
+        router={createMockRouter()}
+      />
+    );
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -17,33 +45,13 @@ describe("FleetDesktop", () => {
 
   describe("Rendering", () => {
     it("renders nothing when not premium tier", () => {
-      const mockConfig = createMockConfig();
-
-      const { container } = renderWithSetup(
-        <FleetDesktop
-          appConfig={mockConfig}
-          handleSubmit={mockHandleSubmit}
-          isPremiumTier={false}
-          isUpdatingSettings={false}
-          router={createMockRouter()}
-        />
-      );
+      const { container } = renderCard({ isPremiumTier: false });
 
       expect(container.firstChild).toBeNull();
     });
 
     it("renders the form when premium tier", () => {
-      const mockConfig = createMockConfig();
-
-      renderWithSetup(
-        <FleetDesktop
-          appConfig={mockConfig}
-          handleSubmit={mockHandleSubmit}
-          isPremiumTier
-          isUpdatingSettings={false}
-          router={createMockRouter()}
-        />
-      );
+      renderCard();
 
       expect(screen.getByText("Fleet Desktop")).toBeInTheDocument();
       expect(
@@ -52,22 +60,15 @@ describe("FleetDesktop", () => {
     });
 
     it("displays configured values from appConfig", () => {
-      const mockConfig = createMockConfig({
-        fleet_desktop: {
-          transparency_url: "https://custom.example.com/transparency",
-          alternative_browser_host: "browser.example.com",
+      renderCard({
+        config: {
+          fleet_desktop: {
+            transparency_url: "https://custom.example.com/transparency",
+            alternative_browser_host: "browser.example.com",
+            sso_enabled: false,
+          },
         },
       });
-
-      renderWithSetup(
-        <FleetDesktop
-          appConfig={mockConfig}
-          handleSubmit={mockHandleSubmit}
-          isPremiumTier
-          isUpdatingSettings={false}
-          router={createMockRouter()}
-        />
-      );
 
       expect(
         screen.getByDisplayValue("https://custom.example.com/transparency")
@@ -78,66 +79,152 @@ describe("FleetDesktop", () => {
     });
 
     it("displays default transparency URL when none is configured", () => {
-      const mockConfig = createMockConfig({
-        fleet_desktop: {
-          transparency_url: "",
-          alternative_browser_host: "",
+      renderCard({
+        config: {
+          fleet_desktop: {
+            transparency_url: "",
+            alternative_browser_host: "",
+            sso_enabled: false,
+          },
         },
       });
-
-      renderWithSetup(
-        <FleetDesktop
-          appConfig={mockConfig}
-          handleSubmit={mockHandleSubmit}
-          isPremiumTier
-          isUpdatingSettings={false}
-          router={createMockRouter()}
-        />
-      );
 
       expect(
         screen.getByDisplayValue(DEFAULT_TRANSPARENCY_URL)
       ).toBeInTheDocument();
     });
-  });
 
-  describe("GitOps Mode", () => {
-    it("disables inputs when gitops mode is enabled", () => {
-      const mockConfig = createMockConfig({
-        gitops: {
-          gitops_mode_enabled: true,
-          repository_url: "",
-          exceptions: { labels: false, software: false, secrets: true },
+    it("selects hourly token rotation by default", () => {
+      renderCard();
+
+      expect(
+        screen.getByRole("group", { name: "End user authentication" })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("radio", { name: /hourly token rotation/i })
+      ).toBeChecked();
+      expect(
+        screen.getByRole("radio", { name: /single sign-on/i })
+      ).not.toBeChecked();
+    });
+
+    it("selects single sign-on when sso_enabled is true", () => {
+      renderCard({
+        config: {
+          fleet_desktop: {
+            transparency_url: "",
+            alternative_browser_host: "",
+            sso_enabled: true,
+          },
+          mdm: mdmWithIdP(),
         },
       });
 
-      renderWithSetup(
-        <FleetDesktop
-          appConfig={mockConfig}
-          handleSubmit={mockHandleSubmit}
-          isPremiumTier
-          isUpdatingSettings={false}
-          router={createMockRouter()}
-        />
-      );
+      expect(
+        screen.getByRole("radio", { name: /single sign-on/i })
+      ).toBeChecked();
+      expect(
+        screen.getByRole("radio", { name: /hourly token rotation/i })
+      ).not.toBeChecked();
+    });
+  });
+
+  describe("End user authentication", () => {
+    // The SSO option needs an entity ID, an IdP name, and either inline
+    // metadata or a metadata URL — dropping any one of them closes the gate.
+    it.each([
+      { idp: {}, expectEnabled: true, when: "the IdP is fully configured" },
+      {
+        idp: { metadata: "<EntityDescriptor />", metadata_url: "" },
+        expectEnabled: true,
+        when: "the IdP carries inline metadata instead of a URL",
+      },
+      {
+        idp: { metadata: "", metadata_url: "" },
+        expectEnabled: false,
+        when: "the IdP has neither metadata nor a metadata URL",
+      },
+      {
+        idp: { entity_id: "" },
+        expectEnabled: false,
+        when: "the IdP is missing its entity ID",
+      },
+      {
+        idp: { idp_name: "" },
+        expectEnabled: false,
+        when: "the IdP is missing its name",
+      },
+      {
+        idp: { entity_id: "", idp_name: "", metadata: "", metadata_url: "" },
+        expectEnabled: false,
+        when: "no IdP is configured",
+      },
+    ])(
+      "single sign-on is enabled=$expectEnabled when $when",
+      ({ idp, expectEnabled }) => {
+        renderCard({ config: { mdm: mdmWithIdP(idp) } });
+
+        const ssoRadio = screen.getByRole("radio", {
+          name: /single sign-on/i,
+        });
+        if (expectEnabled) {
+          expect(ssoRadio).toBeEnabled();
+        } else {
+          expect(ssoRadio).toBeDisabled();
+        }
+      }
+    );
+
+    it("explains how to configure an IdP when none is configured", async () => {
+      const { user } = renderCard();
+
+      expect(
+        screen.getByRole("radio", { name: /hourly token rotation/i })
+      ).toBeEnabled();
+
+      await user.hover(screen.getByText("Single sign-on (SSO)"));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            "This setting requires an IdP configured in Settings > Integrations > Authentication (SSO) > End users."
+          )
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("GitOps Mode", () => {
+    const gitOpsEnabled = {
+      gitops_mode_enabled: true,
+      repository_url: "",
+      exceptions: { labels: false, software: false, secrets: true },
+    };
+
+    it("disables inputs when gitops mode is enabled", () => {
+      renderCard({ config: { gitops: gitOpsEnabled } });
 
       expect(screen.getByLabelText(/custom transparency url/i)).toBeDisabled();
+      expect(
+        screen.getByRole("radio", { name: /hourly token rotation/i })
+      ).toBeDisabled();
+      expect(
+        screen.getByRole("radio", { name: /single sign-on/i })
+      ).toBeDisabled();
+    });
+
+    it("disables the single sign-on radio in gitops mode even when an IdP is configured", () => {
+      renderCard({ config: { mdm: mdmWithIdP(), gitops: gitOpsEnabled } });
+
+      expect(
+        screen.getByRole("radio", { name: /single sign-on/i })
+      ).toBeDisabled();
     });
   });
 
   describe("Form Validation", () => {
     it("shows error for invalid transparency URL without protocol", async () => {
-      const mockConfig = createMockConfig();
-
-      const { user } = renderWithSetup(
-        <FleetDesktop
-          appConfig={mockConfig}
-          handleSubmit={mockHandleSubmit}
-          isPremiumTier
-          isUpdatingSettings={false}
-          router={createMockRouter()}
-        />
-      );
+      const { user } = renderCard();
 
       const input = screen.getByLabelText(/custom transparency url/i);
       await user.clear(input);
@@ -152,17 +239,7 @@ describe("FleetDesktop", () => {
     });
 
     it("accepts valid transparency URL with https protocol", async () => {
-      const mockConfig = createMockConfig();
-
-      const { user } = renderWithSetup(
-        <FleetDesktop
-          appConfig={mockConfig}
-          handleSubmit={mockHandleSubmit}
-          isPremiumTier
-          isUpdatingSettings={false}
-          router={createMockRouter()}
-        />
-      );
+      const { user } = renderCard();
 
       const input = screen.getByLabelText(/custom transparency url/i);
       await user.clear(input);
@@ -177,17 +254,7 @@ describe("FleetDesktop", () => {
     });
 
     it("shows error for invalid browser host", async () => {
-      const mockConfig = createMockConfig();
-
-      const { user } = renderWithSetup(
-        <FleetDesktop
-          appConfig={mockConfig}
-          handleSubmit={mockHandleSubmit}
-          isPremiumTier
-          isUpdatingSettings={false}
-          router={createMockRouter()}
-        />
-      );
+      const { user } = renderCard();
 
       const input = screen.getByLabelText(/browser host/i);
       await user.type(input, "not a valid hostname!");
@@ -201,17 +268,7 @@ describe("FleetDesktop", () => {
     });
 
     it("accepts valid browser hostname", async () => {
-      const mockConfig = createMockConfig();
-
-      const { user } = renderWithSetup(
-        <FleetDesktop
-          appConfig={mockConfig}
-          handleSubmit={mockHandleSubmit}
-          isPremiumTier
-          isUpdatingSettings={false}
-          router={createMockRouter()}
-        />
-      );
+      const { user } = renderCard();
 
       const input = screen.getByLabelText(/browser host/i);
       await user.type(input, "fleet.example.com");
@@ -225,17 +282,7 @@ describe("FleetDesktop", () => {
     });
 
     it("accepts hostnames with a port on alternative browser field", async () => {
-      const mockConfig = createMockConfig();
-
-      const { user } = renderWithSetup(
-        <FleetDesktop
-          appConfig={mockConfig}
-          handleSubmit={mockHandleSubmit}
-          isPremiumTier
-          isUpdatingSettings={false}
-          router={createMockRouter()}
-        />
-      );
+      const { user } = renderCard();
 
       const input = screen.getByLabelText(/browser host/i);
       await user.type(input, "fleet.example.com:9809");
@@ -249,17 +296,7 @@ describe("FleetDesktop", () => {
     });
 
     it("accepts IP addresses on browser alternative field", async () => {
-      const mockConfig = createMockConfig();
-
-      const { user } = renderWithSetup(
-        <FleetDesktop
-          appConfig={mockConfig}
-          handleSubmit={mockHandleSubmit}
-          isPremiumTier
-          isUpdatingSettings={false}
-          router={createMockRouter()}
-        />
-      );
+      const { user } = renderCard();
 
       const input = screen.getByLabelText(/browser host/i);
       await user.type(input, "182.190.1.1:9809");
@@ -275,22 +312,15 @@ describe("FleetDesktop", () => {
 
   describe("Form Submission", () => {
     it("calls handleSubmit with correct data structure", async () => {
-      const mockConfig = createMockConfig({
-        fleet_desktop: {
-          transparency_url: "",
-          alternative_browser_host: "",
+      const { user } = renderCard({
+        config: {
+          fleet_desktop: {
+            transparency_url: "",
+            alternative_browser_host: "",
+            sso_enabled: false,
+          },
         },
       });
-
-      const { user } = renderWithSetup(
-        <FleetDesktop
-          appConfig={mockConfig}
-          handleSubmit={mockHandleSubmit}
-          isPremiumTier
-          isUpdatingSettings={false}
-          router={createMockRouter()}
-        />
-      );
 
       const transparencyInput = screen.getByLabelText(
         /custom transparency url/i
@@ -308,22 +338,73 @@ describe("FleetDesktop", () => {
         fleet_desktop: {
           transparency_url: "https://custom.example.com",
           alternative_browser_host: "browser.example.com",
+          sso_enabled: false,
+        },
+      });
+    });
+
+    it("submits sso_enabled when single sign-on is selected", async () => {
+      const { user } = renderCard({
+        config: {
+          fleet_desktop: {
+            transparency_url: "https://custom.example.com",
+            alternative_browser_host: "browser.example.com",
+            sso_enabled: false,
+          },
+          mdm: mdmWithIdP(),
+        },
+      });
+
+      await user.click(screen.getByRole("radio", { name: /single sign-on/i }));
+
+      expect(
+        screen.getByRole("radio", { name: /single sign-on/i })
+      ).toBeChecked();
+
+      await user.click(screen.getByRole("button", { name: /save/i }));
+
+      expect(mockHandleSubmit).toHaveBeenCalledWith({
+        fleet_desktop: {
+          transparency_url: "https://custom.example.com",
+          alternative_browser_host: "browser.example.com",
+          sso_enabled: true,
+        },
+      });
+    });
+
+    it("submits sso_enabled as false when switching back to token rotation", async () => {
+      const { user } = renderCard({
+        config: {
+          fleet_desktop: {
+            transparency_url: "https://custom.example.com",
+            alternative_browser_host: "browser.example.com",
+            sso_enabled: true,
+          },
+          mdm: mdmWithIdP(),
+        },
+      });
+
+      await user.click(
+        screen.getByRole("radio", { name: /hourly token rotation/i })
+      );
+
+      expect(
+        screen.getByRole("radio", { name: /hourly token rotation/i })
+      ).toBeChecked();
+
+      await user.click(screen.getByRole("button", { name: /save/i }));
+
+      expect(mockHandleSubmit).toHaveBeenCalledWith({
+        fleet_desktop: {
+          transparency_url: "https://custom.example.com",
+          alternative_browser_host: "browser.example.com",
+          sso_enabled: false,
         },
       });
     });
 
     it("disables submit button when there are validation errors", async () => {
-      const mockConfig = createMockConfig();
-
-      const { user } = renderWithSetup(
-        <FleetDesktop
-          appConfig={mockConfig}
-          handleSubmit={mockHandleSubmit}
-          isPremiumTier
-          isUpdatingSettings={false}
-          router={createMockRouter()}
-        />
-      );
+      const { user } = renderCard();
 
       const input = screen.getByLabelText(/custom transparency url/i);
       await user.clear(input);

--- a/frontend/pages/admin/OrgSettingsPage/cards/FleetDesktop/FleetDesktop.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/FleetDesktop/FleetDesktop.tsx
@@ -2,10 +2,13 @@ import React, { useState } from "react";
 
 import { IInputFieldParseTarget } from "interfaces/form_field";
 
+import { isEndUserIdPConfigured } from "utilities/permissions/permissions";
+
 import SettingsSection from "pages/admin/components/SettingsSection";
 import PageDescription from "components/PageDescription";
 import Button from "components/buttons/Button";
 import InputField from "components/forms/fields/InputField";
+import Radio from "components/forms/fields/Radio";
 import validUrl from "components/forms/validators/valid_url";
 import validHostname from "components/forms/validators/valid_hostname";
 
@@ -15,9 +18,20 @@ import CustomLink from "components/CustomLink";
 import { DEFAULT_TRANSPARENCY_URL, IAppConfigFormProps } from "../constants";
 import TooltipWrapper from "../../../../../components/TooltipWrapper";
 
+const END_USER_AUTH_LABEL_ID = "end-user-authentication-label";
+
+const SSO_REQUIRES_IDP_TOOLTIP =
+  "This setting requires an IdP configured in Settings > Integrations > Authentication (SSO) > End users.";
+
+enum EndUserAuthType {
+  TOKEN_ROTATION = "token_rotation",
+  SSO = "sso",
+}
+
 interface IFleetDesktopFormData {
   transparencyURL: string;
   alternativeBrowserHost: string;
+  ssoEnabled: boolean;
 }
 interface IFleetDesktopFormErrors {
   transparencyURL?: string | null;
@@ -37,6 +51,7 @@ const FleetDesktop = ({
       appConfig.fleet_desktop?.transparency_url || DEFAULT_TRANSPARENCY_URL,
     alternativeBrowserHost:
       appConfig.fleet_desktop?.alternative_browser_host || "",
+    ssoEnabled: appConfig.fleet_desktop?.sso_enabled ?? false,
   });
 
   const [formErrors, setFormErrors] = useState<IFleetDesktopFormErrors>({});
@@ -51,6 +66,13 @@ const FleetDesktop = ({
       delete newErrors[name as keyof IFleetDesktopFormErrors];
       return newErrors;
     });
+  };
+
+  const onEndUserAuthChange = (value: string) => {
+    setFormData((prevFormData) => ({
+      ...prevFormData,
+      ssoEnabled: value === EndUserAuthType.SSO,
+    }));
   };
 
   const validateForm = () => {
@@ -92,6 +114,7 @@ const FleetDesktop = ({
       fleet_desktop: {
         transparency_url: formData.transparencyURL,
         alternative_browser_host: formData.alternativeBrowserHost,
+        sso_enabled: formData.ssoEnabled,
       },
     };
 
@@ -102,16 +125,13 @@ const FleetDesktop = ({
     return <></>;
   }
 
+  const isIdPConfigured = isEndUserIdPConfigured(appConfig);
+
   return (
     <SettingsSection title="Fleet Desktop">
       <PageDescription
         variant="right-panel"
-        content={
-          <>
-            Override the default transparency URL or browser host to customize
-            Fleet Desktop experience.
-          </>
-        }
+        content="Customize the Fleet Desktop experience."
       />
       <form onSubmit={onFormSubmit} autoComplete="off">
         <InputField
@@ -153,6 +173,46 @@ const FleetDesktop = ({
           disabled={gitOpsModeEnabled}
           helpText="If not set, Fleet Desktop uses your Fleet web address."
         />
+        <fieldset
+          className="form-field"
+          aria-labelledby={END_USER_AUTH_LABEL_ID}
+        >
+          <div className="form-field__label" id={END_USER_AUTH_LABEL_ID}>
+            End user authentication
+          </div>
+          <Radio
+            label="Hourly token rotation"
+            id="end-user-auth-token-rotation"
+            name="end-user-authentication"
+            value={EndUserAuthType.TOKEN_ROTATION}
+            checked={!formData.ssoEnabled}
+            disabled={gitOpsModeEnabled}
+            onChange={onEndUserAuthChange}
+          />
+          <Radio
+            label={
+              isIdPConfigured ? (
+                "Single sign-on (SSO)"
+              ) : (
+                <TooltipWrapper
+                  showArrow
+                  underline={false}
+                  position="right"
+                  tipOffset={12}
+                  tipContent={SSO_REQUIRES_IDP_TOOLTIP}
+                >
+                  Single sign-on (SSO)
+                </TooltipWrapper>
+              )
+            }
+            id="end-user-auth-sso"
+            name="end-user-authentication"
+            value={EndUserAuthType.SSO}
+            checked={formData.ssoEnabled}
+            disabled={gitOpsModeEnabled || !isIdPConfigured}
+            onChange={onEndUserAuthChange}
+          />
+        </fieldset>
         <GitOpsModeTooltipWrapper
           renderChildren={(disableChildren) => (
             <Button

--- a/frontend/utilities/permissions/permissions.tests.ts
+++ b/frontend/utilities/permissions/permissions.tests.ts
@@ -1,4 +1,6 @@
 import createMockUser from "__mocks__/userMock";
+import createMockConfig, { createMockMdmConfig } from "__mocks__/configMock";
+import { IEndUserAuthentication } from "interfaces/config";
 
 import permissions from ".";
 
@@ -234,5 +236,50 @@ describe("permissions - canDownloadSoftwareInstaller", () => {
       teams: [{ id: TEAM_ID, name: "Team 1", role }],
     });
     expect(permissions.canDownloadSoftwareInstaller(user, TEAM_ID)).toBe(false);
+  });
+});
+
+describe("permissions - isEndUserIdPConfigured", () => {
+  const configWithIdP = (idp?: Partial<IEndUserAuthentication>) =>
+    createMockConfig({
+      mdm: createMockMdmConfig({
+        end_user_authentication: {
+          entity_id: "https://fleet.example.com",
+          idp_name: "Okta",
+          metadata: "",
+          metadata_url: "https://idp.example.com/metadata",
+          issuer_uri: "",
+          ...idp,
+        },
+      }),
+    });
+
+  it("accepts an IdP with a metadata URL", () => {
+    expect(permissions.isEndUserIdPConfigured(configWithIdP())).toBe(true);
+  });
+
+  it("accepts an IdP with inline metadata instead of a URL", () => {
+    expect(
+      permissions.isEndUserIdPConfigured(
+        configWithIdP({ metadata: "<EntityDescriptor />", metadata_url: "" })
+      )
+    ).toBe(true);
+  });
+
+  it.each([
+    ["neither metadata nor a metadata URL", { metadata: "", metadata_url: "" }],
+    ["no entity ID", { entity_id: "" }],
+    ["no IdP name", { idp_name: "" }],
+  ] as [string, Partial<IEndUserAuthentication>][])(
+    "rejects an IdP with %s",
+    (_label, idp) => {
+      expect(permissions.isEndUserIdPConfigured(configWithIdP(idp))).toBe(
+        false
+      );
+    }
+  );
+
+  it("rejects an unconfigured IdP", () => {
+    expect(permissions.isEndUserIdPConfigured(createMockConfig())).toBe(false);
   });
 });

--- a/frontend/utilities/permissions/permissions.ts
+++ b/frontend/utilities/permissions/permissions.ts
@@ -25,6 +25,13 @@ export const isAndroidMdmEnabledAndConfigured = (config: IConfig): boolean => {
   return Boolean(config.mdm.android_enabled_and_configured);
 };
 
+export const isEndUserIdPConfigured = (config: IConfig): boolean => {
+  const idp = config.mdm.end_user_authentication;
+  return (
+    !!idp.entity_id && !!idp.idp_name && (!!idp.metadata_url || !!idp.metadata)
+  );
+};
+
 export const isGlobalAdmin = (user: IUser): boolean => {
   return user.global_role === "admin";
 };
@@ -234,6 +241,7 @@ export default {
   isMacMdmEnabledAndConfigured,
   isWindowsMdmEnabledAndConfigured,
   isAndroidMdmEnabledAndConfigured,
+  isEndUserIdPConfigured,
   isGlobalAdmin,
   isGlobalMaintainer,
   isGlobalObserver,


### PR DESCRIPTION
Resolves #51522

Adds an "End user authentication" radio group to Settings > Organization settings > Fleet Desktop, backed by the fleet_desktop.sso_enabled config field: "Hourly token rotation" (false, default) vs "Single sign-on (SSO)" (true).

The SSO option is disabled with an explanatory tooltip until an IdP is configured under mdm.end_user_authentication, and both options are disabled in GitOps mode alongside the card's other fields. A saved value of true still renders as selected if the IdP was later cleared, rather than being silently coerced back to token rotation.

The radios use a dedicated boolean setter instead of the card's onInputChange, which stringifies its value and would store a truthy "false".

Also registers enabled_sso_fleet_desktop and
disabled_sso_fleet_desktop in the activity feed.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Fleet Desktop end-user authentication settings with options for hourly token rotation or single sign-on (SSO).
  * SSO selection is available when an identity provider is configured, with guidance shown when setup is incomplete.
  * Added organization activity tracking for enabling or disabling Fleet Desktop SSO.

* **Bug Fixes**
  * Improved consistency when detecting whether end-user identity provider authentication is configured.

* **Tests**
  * Expanded coverage for SSO settings, validation, configuration requirements, and submission behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->