### PR TITLE
Website: Update MySQL service used by Fleet premium trial instances

### DIFF
--- a/website/scripts/manage-fleet-premium-trial-instances.js
+++ b/website/scripts/manage-fleet-premium-trial-instances.js
@@ -258,11 +258,14 @@ module.exports = {
             ownerId: sails.config.custom.renderOwnerId,
             type: 'private_service',
             name: povRecord.slug+'-fleet-mysql',
-            repo: 'https://github.com/render-examples/mysql',
-            autoDeploy: 'yes',
+            image: {
+              ownerId: sails.config.custom.renderOwnerId,
+              imagePath: 'docker.io/library/mysql:8.0.44'
+            },
+            autoDeploy: 'no',
             serviceDetails: {
               plan: 'standard',
-              runtime: 'docker',
+              runtime: 'image',
               disk: {
                 sizeGB: 5,
                 name: 'mysql',


### PR DESCRIPTION
Related to: https://github.com/fleetdm/confidential/issues/17317

Changes:
- updated the version of the MySQL service provisioned for Fleet Premium trial instances

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated MySQL service provisioning to use the MySQL 8.0.44 Docker image directly.
  * Disabled automatic deployments for these services.
  * Changed the deployment runtime to use the configured container image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->