### PR TITLE
Sign in to Fleet Desktop's My device page via SSO

### DIFF
--- a/ee/server/service/devices.go
+++ b/ee/server/service/devices.go
@@ -517,6 +517,7 @@ func (svc *Service) InitiateDeviceSSO(ctx context.Context, deviceURL string) (*f
 		svc.ssoSessionStore,
 		sso.URLWithPrefix(browserBase, svc.config.Server.URLPrefix, deviceURL).String(),
 		uint(sessionDuration.Seconds()), //nolint:gosec // dismiss G115
+		fleet.SSORelayState(fleet.SSOInitiatorFleetDesktop),
 		sso.SSORequestData{
 			HostUUID:  host.UUID,
 			Initiator: fleet.SSOInitiatorFleetDesktop,

--- a/ee/server/service/devices_test.go
+++ b/ee/server/service/devices_test.go
@@ -4,17 +4,18 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"net/http"
-	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
 	"github.com/WatchBeam/clock"
 	"github.com/fleetdm/fleet/v4/server/config"
 	hostctx "github.com/fleetdm/fleet/v4/server/contexts/host"
+	"github.com/fleetdm/fleet/v4/server/datastore/redis/redistest"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mock"
 	redismock "github.com/fleetdm/fleet/v4/server/mock/redis"
+	"github.com/fleetdm/fleet/v4/server/sso"
 	"github.com/stretchr/testify/require"
 )
 
@@ -83,25 +84,29 @@ func TestDeviceSSOSessionUnknownIDNotFound(t *testing.T) {
 	}
 }
 
-func TestInitiateDeviceSSOGuards(t *testing.T) {
-	idpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-	}))
-	t.Cleanup(idpSrv.Close)
+func TestInitiateDeviceSSO(t *testing.T) {
+	const devTok = "device-auth-token-abc123"
 
 	idp := func(ac *fleet.AppConfig) {
 		ac.MDM.EndUserAuthentication.SSOProviderSettings = fleet.SSOProviderSettings{
-			EntityID:    "mdm.test.com",
-			IDPName:     "SimpleSAML",
-			MetadataURL: idpSrv.URL,
+			EntityID: "fleet",
+			IDPName:  "TestIDP",
+			Metadata: mdmSSOTestMetadata,
 		}
 	}
 
 	cases := []struct {
 		name      string
-		wantErr   string
+		noHost    bool
 		appConfig func() fleet.AppConfig
+		wantErr   string
 	}{
+		{
+			name:      "no host resolved from the device token",
+			noHost:    true,
+			wantErr:   "Authentication required",
+			appConfig: func() fleet.AppConfig { return fleet.AppConfig{} },
+		},
 		{
 			name:      "sso disabled",
 			wantErr:   "is not enabled",
@@ -141,8 +146,7 @@ func TestInitiateDeviceSSOGuards(t *testing.T) {
 			},
 		},
 		{
-			name:    "no alternative browser host",
-			wantErr: "metadata",
+			name: "no alternative browser host",
 			appConfig: func() fleet.AppConfig {
 				var ac fleet.AppConfig
 				ac.FleetDesktop.SSOEnabled = true
@@ -152,8 +156,7 @@ func TestInitiateDeviceSSOGuards(t *testing.T) {
 			},
 		},
 		{
-			name:    "alternative browser host equals the server host",
-			wantErr: "metadata",
+			name: "alternative browser host equals the server host",
 			appConfig: func() fleet.AppConfig {
 				var ac fleet.AppConfig
 				ac.FleetDesktop.SSOEnabled = true
@@ -164,8 +167,7 @@ func TestInitiateDeviceSSOGuards(t *testing.T) {
 			},
 		},
 		{
-			name:    "alternative browser host differs only by port",
-			wantErr: "metadata",
+			name: "alternative browser host differs only by port",
 			appConfig: func() fleet.AppConfig {
 				var ac fleet.AppConfig
 				ac.FleetDesktop.SSOEnabled = true
@@ -176,8 +178,7 @@ func TestInitiateDeviceSSOGuards(t *testing.T) {
 			},
 		},
 		{
-			name:    "apple server url equals the server url",
-			wantErr: "metadata",
+			name: "apple server url equals the server url",
 			appConfig: func() fleet.AppConfig {
 				var ac fleet.AppConfig
 				ac.FleetDesktop.SSOEnabled = true
@@ -198,26 +199,40 @@ func TestInitiateDeviceSSOGuards(t *testing.T) {
 			}
 
 			svc, _, _ := newDeviceSSOTestService(t, ds, time.Hour)
+			svc.ssoSessionStore = sso.NewSessionStore(redistest.NopRedis())
 
-			ctx := hostctx.NewContext(t.Context(), &fleet.Host{ID: 1, UUID: "host-uuid-1"})
-			_, err := svc.InitiateDeviceSSO(ctx, "/device/some-token")
-			require.Error(t, err)
-			require.ErrorContains(t, err, c.wantErr)
-
-			// Guard refusals are client errors; reaching the metadata fetch is not.
-			var badReq *fleet.BadRequestError
-			if c.wantErr != "metadata" {
-				require.ErrorAs(t, err, &badReq)
+			ctx := t.Context()
+			if !c.noHost {
+				ctx = hostctx.NewContext(ctx, &fleet.Host{ID: 1, UUID: "host-uuid-1"})
 			}
+
+			initiation, err := svc.InitiateDeviceSSO(ctx, "/device/"+devTok)
+
+			if c.wantErr != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, c.wantErr)
+				if c.noHost {
+					var authRequired *fleet.AuthRequiredError
+					require.ErrorAs(t, err, &authRequired)
+				} else {
+					var badReq *fleet.BadRequestError
+					require.ErrorAs(t, err, &badReq)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotEmpty(t, initiation.IdPURL)
+
+			idpURL, err := url.Parse(initiation.IdPURL)
+			require.NoError(t, err)
+
+			require.Equal(t,
+				string(fleet.SSORelayState(fleet.SSOInitiatorFleetDesktop)),
+				idpURL.Query().Get("RelayState"))
+			require.NotContains(t, idpURL.RawQuery, devTok)
 		})
 	}
-}
-
-func TestInitiateDeviceSSOMissingHostInContext(t *testing.T) {
-	svc, _, _ := newDeviceSSOTestService(t, new(mock.Store), time.Hour)
-
-	_, err := svc.InitiateDeviceSSO(t.Context(), "/device/some-token")
-	require.Error(t, err)
 }
 
 func TestRequireDeviceSSOSession(t *testing.T) {

--- a/ee/server/service/mdm.go
+++ b/ee/server/service/mdm.go
@@ -921,6 +921,7 @@ func (svc *Service) InitiateMDMSSO(ctx context.Context, initiator, customOrigina
 	sessionID, idpURL, err = sso.CreateAuthorizationRequest(ctx,
 		samlProvider, svc.ssoSessionStore, originalURL,
 		uint(sessionDurationSeconds), //nolint:gosec // dismiss G115
+		fleet.SSORelayStateNone,
 		sso.SSORequestData{
 			HostUUID:  hostUUID,
 			Initiator: initiator,
@@ -965,7 +966,7 @@ func (svc *Service) MDMSSOCallback(ctx context.Context, sessionID string, samlRe
 	if !strings.HasPrefix(originalURL, "/enroll?") &&
 		ssoRequestData.Initiator != fleet.SSOInitiatorOrbitSetupExperience &&
 		ssoRequestData.Initiator != fleet.SSOInitiatorFleetDesktop {
-		// for flows other than the /enroll BYOD, we have to ensure that Apple MDM
+		// For flows other than the /enroll BYOD, we have to ensure that Apple MDM
 		// is enabled (this was previously done in a middleware on the route, but
 		// we do it here now so the middleware is disabled for the BYOD flow, which
 		// handles the MDM not enabled differently, via a custom error page, as it

--- a/ee/server/service/mdm_sso_test.go
+++ b/ee/server/service/mdm_sso_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/config"
 	"github.com/fleetdm/fleet/v4/server/datastore/redis/redistest"
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
 	"github.com/fleetdm/fleet/v4/server/mock"
 	"github.com/fleetdm/fleet/v4/server/sso"
 	"github.com/stretchr/testify/require"
@@ -52,6 +53,36 @@ func inflateMDMAuthnRequest(t *testing.T, s string) *saml.AuthnRequest {
 	return &req
 }
 
+func mdmSSOTestAppConfig(serverURL string, idpConfigured bool) *fleet.AppConfig {
+	ac := &fleet.AppConfig{ServerSettings: fleet.ServerSettings{ServerURL: serverURL}}
+	if idpConfigured {
+		ac.MDM.EndUserAuthentication.SSOProviderSettings = fleet.SSOProviderSettings{
+			EntityID: "fleet",
+			IDPName:  "TestIDP",
+			Metadata: mdmSSOTestMetadata,
+		}
+	}
+	return ac
+}
+
+func newMDMSSOTestService(t *testing.T, appConfig *fleet.AppConfig, cfg config.FleetConfig) *Service {
+	t.Helper()
+
+	authorizer, err := authz.NewAuthorizer()
+	require.NoError(t, err)
+
+	ds := new(mock.Store)
+	ds.AppConfigFunc = func(_ context.Context) (*fleet.AppConfig, error) { return appConfig, nil }
+
+	return &Service{
+		ds:              ds,
+		logger:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+		authz:           authorizer,
+		config:          cfg,
+		ssoSessionStore: sso.NewSessionStore(redistest.NopRedis()),
+	}
+}
+
 func TestInitiateMDMSSOACSURLWithURLPrefix(t *testing.T) {
 	// With url_prefix set, the MDM ACS callback URL must carry the subpath exactly
 	// once, regardless of whether server_url was configured with or without the
@@ -72,37 +103,12 @@ func TestInitiateMDMSSOACSURLWithURLPrefix(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ds := new(mock.Store)
-
-			authorizer, err := authz.NewAuthorizer()
-			require.NoError(t, err)
-
 			cfg := config.TestConfig()
 			cfg.Server.URLPrefix = "/apps/fleet"
 
-			svc := &Service{
-				ds:              ds,
-				logger:          slog.New(slog.NewTextHandler(io.Discard, nil)),
-				authz:           authorizer,
-				config:          cfg,
-				ssoSessionStore: sso.NewSessionStore(redistest.NopRedis()),
-			}
+			svc := newMDMSSOTestService(t, mdmSSOTestAppConfig(tc.serverURL, true), cfg)
 
-			appConfig := &fleet.AppConfig{
-				ServerSettings: fleet.ServerSettings{
-					ServerURL: tc.serverURL,
-				},
-			}
-			appConfig.MDM.EndUserAuthentication.SSOProviderSettings = fleet.SSOProviderSettings{
-				EntityID: "fleet",
-				IDPName:  "TestIDP",
-				Metadata: mdmSSOTestMetadata,
-			}
-			ds.AppConfigFunc = func(_ context.Context) (*fleet.AppConfig, error) {
-				return appConfig, nil
-			}
-
-			_, _, idpURL, err := svc.InitiateMDMSSO(context.Background(), "", "", "")
+			_, _, idpURL, err := svc.InitiateMDMSSO(t.Context(), "", "", "")
 			require.NoError(t, err)
 			require.NotEmpty(t, idpURL)
 
@@ -121,6 +127,28 @@ func TestInitiateMDMSSOACSURLWithURLPrefix(t *testing.T) {
 	}
 }
 
+func TestInitiateMDMSSOSetsNoRelayState(t *testing.T) {
+	svc := newMDMSSOTestService(t,
+		mdmSSOTestAppConfig("https://fleet.example.com", true), config.TestConfig())
+
+	for _, initiator := range []string{
+		fleet.SSOInitiatorOTAEnroll,
+		fleet.SSOInitiatorOrbitSetupExperience,
+		fleet.SSOInitiatorAppleMDMSSO,
+		fleet.SSOInitiatorAccountDrivenEnroll,
+		fleet.SSOInitiatorAccountDrivenEnroll + ":cf2b9a1e4d7c8f36b05e91a2d4c7e830f16b5a92",
+	} {
+		t.Run(initiator, func(t *testing.T) {
+			_, _, idpURL, err := svc.InitiateMDMSSO(t.Context(), initiator, "", "host-uuid-1")
+			require.NoError(t, err)
+
+			parsed, err := url.Parse(idpURL)
+			require.NoError(t, err)
+			require.Empty(t, parsed.Query().Get("RelayState"))
+		})
+	}
+}
+
 func TestDeviceSSOErrorURL(t *testing.T) {
 	require.Equal(t,
 		"https://fleet.example.com/device/abc123?sso_error=sso_disabled",
@@ -130,4 +158,42 @@ func TestDeviceSSOErrorURL(t *testing.T) {
 	require.Equal(t,
 		"https://fleet.example.com/device/abc123?setup_only=1&sso_error=sso_disabled",
 		deviceSSOErrorURL("https://fleet.example.com/device/abc123?setup_only=1", "sso_disabled"))
+}
+
+func TestMDMSSOCallbackEarlyFailureRedirects(t *testing.T) {
+	testCases := []struct {
+		name          string
+		idpConfigured bool
+		wantRedirect  string
+	}{
+		{
+			name:          "expired handshake",
+			idpConfigured: true,
+			wantRedirect:  "/mdm/sso/callback?error=true&reason=session_expired",
+		},
+		{
+			name:          "any other early failure",
+			idpConfigured: false,
+			wantRedirect:  "/mdm/sso/callback?error=true",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := newMDMSSOTestService(t,
+				mdmSSOTestAppConfig("https://fleet.example.com", tc.idpConfigured), config.TestConfig())
+			redirectURL, byodCookie, deviceSessionID, deviceSessionDuration := svc.MDMSSOCallback(
+				t.Context(), "does-not-exist", []byte("<x/>"))
+
+			require.Equal(t, tc.wantRedirect, redirectURL)
+			require.Empty(t, byodCookie)
+			require.Empty(t, deviceSessionID)
+			require.Zero(t, deviceSessionDuration)
+
+			require.Contains(t, []string{
+				apple_mdm.FleetUISSOCallbackError,
+				apple_mdm.FleetUISSOCallbackSessionExpired,
+			}, redirectURL, "early-failure redirect must be one the endpoint can rewrite")
+		})
+	}
 }

--- a/frontend/components/DeviceUserError/DeviceUserError.stories.tsx
+++ b/frontend/components/DeviceUserError/DeviceUserError.stories.tsx
@@ -1,9 +1,10 @@
 import { Meta, StoryObj } from "@storybook/react";
+import { action } from "@storybook/addon-actions";
 
 import DeviceUserError from "./DeviceUserError";
 
 const meta: Meta<typeof DeviceUserError> = {
-  title: "Components/Error messages/Device user error",
+  title: "Components/DeviceUserError",
   component: DeviceUserError,
 };
 
@@ -11,4 +12,29 @@ export default meta;
 
 type Story = StoryObj<typeof DeviceUserError>;
 
-export const Basic: Story = {};
+export const Default: Story = {};
+
+export const InvalidDeviceURL: Story = {
+  args: {
+    isAuthenticationError: true,
+  },
+};
+
+export const SSOSessionExpired: Story = {
+  args: {
+    ssoError: "session_expired",
+  },
+};
+
+export const SSOCallbackFailed: Story = {
+  args: {
+    ssoError: "callback_failed",
+  },
+};
+
+export const SSOSignInFailed: Story = {
+  args: {
+    ssoError: "sign_in_failed",
+    onRetry: action("retried"),
+  },
+};

--- a/frontend/components/DeviceUserError/DeviceUserError.tests.tsx
+++ b/frontend/components/DeviceUserError/DeviceUserError.tests.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import DeviceUserError from "./DeviceUserError";
 
 describe("DeviceUserError", () => {
@@ -25,6 +26,34 @@ describe("DeviceUserError", () => {
     expect(
       screen.getByText(/To access your device information, please click/i)
     ).toBeInTheDocument();
+  });
+
+  it("renders SSO failure copy, and its retry, ahead of the authentication error", async () => {
+    const onRetry = jest.fn();
+    render(
+      <DeviceUserError
+        isAuthenticationError
+        ssoError="sign_in_failed"
+        onRetry={onRetry}
+      />
+    );
+    expect(screen.getByText("Couldn't sign in.")).toBeInTheDocument();
+    expect(
+      screen.queryByText("This URL is invalid or expired.")
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Sign in again" })
+    );
+    expect(onRetry).toHaveBeenCalled();
+  });
+
+  it("omits the retry where the end user has no way to retry", () => {
+    render(<DeviceUserError ssoError="session_expired" />);
+    expect(
+      screen.getByText("Your sign-in session expired.")
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });
 
   it("renders authentication error message on mobile device", () => {

--- a/frontend/components/DeviceUserError/DeviceUserError.tsx
+++ b/frontend/components/DeviceUserError/DeviceUserError.tsx
@@ -3,8 +3,37 @@ import React from "react";
 import classNames from "classnames";
 import Icon from "components/Icon/Icon";
 import DataError from "components/DataError";
+import Button from "components/buttons/Button";
 
 const baseClass = "device-user-error";
+
+export type DeviceSSOErrorReason =
+  /** The handshake ran out before the IdP posted back. */
+  | "session_expired"
+  /** The IdP posted back, but the callback couldn't mint a session. */
+  | "callback_failed"
+  /** Fleet couldn't start the flow, or the round trip finished and still left
+   * no session behind. The end user acts on both the same way. */
+  | "sign_in_failed";
+
+const SSO_ERROR_COPY: Record<
+  DeviceSSOErrorReason,
+  { header: string; description: string }
+> = {
+  session_expired: {
+    header: "Your sign-in session expired.",
+    description: "Open Fleet Desktop and click “My device” to try again.",
+  },
+  callback_failed: {
+    header: "Couldn't finish signing in.",
+    description: "Open Fleet Desktop and click “My device” to try again.",
+  },
+  sign_in_failed: {
+    header: "Couldn't sign in.",
+    description:
+      "Your organization requires single sign-on to view this page. Try again, or contact your IT admin.",
+  },
+};
 
 interface IDeviceUserErrorProps {
   /** Modifies styling for mobile width (<768px) */
@@ -13,6 +42,8 @@ interface IDeviceUserErrorProps {
   isMobileDevice?: boolean;
   isAuthenticationError?: boolean;
   isErrorSetupSteps?: boolean;
+  ssoError?: DeviceSSOErrorReason;
+  onRetry?: () => void;
 }
 
 const DeviceUserError = ({
@@ -20,6 +51,8 @@ const DeviceUserError = ({
   isMobileDevice = false,
   isAuthenticationError = false,
   isErrorSetupSteps = false,
+  ssoError,
+  onRetry,
 }: IDeviceUserErrorProps): JSX.Element => {
   const wrapperClassnames = classNames(baseClass, {
     [`${baseClass}__mobile-view`]: isMobileView,
@@ -45,7 +78,16 @@ const DeviceUserError = ({
     );
   }
 
-  if (isAuthenticationError) {
+  if (ssoError) {
+    const { header, description } = SSO_ERROR_COPY[ssoError];
+    headerContent = (
+      <>
+        <Icon name="error" />
+        {header}
+      </>
+    );
+    descriptionContent = description;
+  } else if (isAuthenticationError) {
     headerContent = (
       <>
         <Icon name="error" />
@@ -72,6 +114,11 @@ const DeviceUserError = ({
           <span className={`${baseClass}__description`}>
             {descriptionContent}
           </span>
+          {onRetry && (
+            <div className={`${baseClass}__action`}>
+              <Button onClick={onRetry}>Sign in again</Button>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/components/DeviceUserError/_styles.scss
+++ b/frontend/components/DeviceUserError/_styles.scss
@@ -46,4 +46,8 @@
     text-align: center;
     line-height: $line-height;
   }
+  &__action {
+    display: flex;
+    justify-content: center;
+  }
 }

--- a/frontend/components/DeviceUserError/index.ts
+++ b/frontend/components/DeviceUserError/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./DeviceUserError";
+export type { DeviceSSOErrorReason } from "./DeviceUserError";

--- a/frontend/pages/DeviceUserSSOErrorPage/DeviceUserSSOErrorPage.tests.tsx
+++ b/frontend/pages/DeviceUserSSOErrorPage/DeviceUserSSOErrorPage.tests.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+
+import { createCustomRenderer, createMockRouter } from "test/test-utils";
+
+import DeviceUserSSOErrorPage from "./DeviceUserSSOErrorPage";
+
+const render = createCustomRenderer();
+
+const renderPage = (reason?: string) =>
+  render(
+    <DeviceUserSSOErrorPage
+      router={createMockRouter()}
+      params={{}}
+      routes={[]}
+      location={{
+        pathname: "/device/sso-error",
+        search: "",
+        query: reason ? { reason } : {},
+        hash: "",
+        action: "POP",
+        key: "",
+        state: undefined,
+      }}
+    />
+  );
+
+describe("DeviceUserSSOErrorPage", () => {
+  it("tells the end user their sign-in session ran out", () => {
+    renderPage("session_expired");
+
+    expect(
+      screen.getByText("Your sign-in session expired.")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Open Fleet Desktop and click/)
+    ).toBeInTheDocument();
+  });
+
+  it("falls back to the generic failure for any other reason", () => {
+    renderPage("error");
+
+    expect(screen.getByText("Couldn't finish signing in.")).toBeInTheDocument();
+  });
+});

--- a/frontend/pages/DeviceUserSSOErrorPage/DeviceUserSSOErrorPage.tsx
+++ b/frontend/pages/DeviceUserSSOErrorPage/DeviceUserSSOErrorPage.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { WithRouterProps } from "react-router";
+
+import DeviceUserError from "components/DeviceUserError";
+
+const baseClass = "device-user-sso-error-page";
+
+interface IDeviceUserSSOErrorQuery {
+  reason?: string;
+}
+
+const DeviceUserSSOErrorPage = ({
+  location: { query },
+}: WithRouterProps<object, IDeviceUserSSOErrorQuery>) => {
+  return (
+    <div className={`${baseClass} app-wrap`}>
+      <DeviceUserError
+        ssoError={
+          query.reason === "session_expired"
+            ? "session_expired"
+            : "callback_failed"
+        }
+      />
+    </div>
+  );
+};
+
+export default DeviceUserSSOErrorPage;

--- a/frontend/pages/DeviceUserSSOErrorPage/_styles.scss
+++ b/frontend/pages/DeviceUserSSOErrorPage/_styles.scss
@@ -1,0 +1,3 @@
+.device-user-sso-error-page {
+  justify-content: center;
+}

--- a/frontend/pages/DeviceUserSSOErrorPage/index.ts
+++ b/frontend/pages/DeviceUserSSOErrorPage/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DeviceUserSSOErrorPage";

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tests.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tests.tsx
@@ -8,7 +8,9 @@ import { createCustomRenderer, createMockRouter } from "test/test-utils";
 import createMockLicense from "__mocks__/licenseMock";
 import { notify } from "components/ToastNotification";
 
-import { IGetSetupExperienceStatusesResponse } from "services/entities/device_user";
+import deviceUserAPI, {
+  IGetSetupExperienceStatusesResponse,
+} from "services/entities/device_user";
 
 import { IHostPolicy } from "interfaces/policy";
 
@@ -18,6 +20,9 @@ import {
   defaultDeviceHandler,
   deviceSetupExperienceHandler,
   emptySetupExperienceHandler,
+  ssoRequiredDeviceCertificatesHandler,
+  ssoRequiredDeviceHandler,
+  unauthorizedDeviceHandler,
 } from "test/handlers/device-handler";
 import DeviceUserPage from "./DeviceUserPage";
 import PolicyDetailsModal from "../cards/Policies/HostPoliciesTable/PolicyDetailsModal";
@@ -45,23 +50,6 @@ const mockLocation = {
   },
   search: undefined,
 };
-
-// Required for tests that use useIsMobileWidth
-beforeAll(() => {
-  Object.defineProperty(window, "matchMedia", {
-    writable: true,
-    value: jest.fn().mockImplementation((query) => ({
-      matches: false,
-      media: query,
-      addEventListener: jest.fn(),
-      removeEventListener: jest.fn(),
-      addListener: jest.fn(), // for older APIs
-      removeListener: jest.fn(),
-      onchange: null,
-      dispatchEvent: jest.fn(),
-    })),
-  });
-});
 
 describe("Device User Page", () => {
   it("hides the software tab if the device has no software", async () => {
@@ -690,5 +678,144 @@ describe("Device User Page", () => {
         { timeout: 4000 }
       );
     }, 10000);
+  });
+});
+
+describe("Device User Page - Fleet Desktop SSO", () => {
+  let initiateDeviceSSO: jest.SpyInstance;
+
+  const pendingInitiation = () => new Promise<{ url: string }>(() => undefined);
+
+  const renderPage = (
+    query: Record<string, string> = {},
+    token = "testToken"
+  ) => {
+    const render = createCustomRenderer({ withBackendMock: true });
+    return render(
+      <DeviceUserPage
+        router={mockRouter}
+        params={{ device_auth_token: token }}
+        location={{
+          ...mockLocation,
+          query: { ...mockLocation.query, ...query },
+        }}
+      />
+    );
+  };
+
+  const expectRedirectingToIdP = async () =>
+    expect(
+      await screen.findByText(/Redirecting to your organization/)
+    ).toBeInTheDocument();
+
+  const expectManualRetry = async () =>
+    expect(
+      await screen.findByRole("button", { name: "Sign in again" })
+    ).toBeInTheDocument();
+
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    mockServer.use(defaultDeviceCertificatesHandler);
+    mockServer.use(emptySetupExperienceHandler);
+    initiateDeviceSSO = jest
+      .spyOn(deviceUserAPI, "initiateDeviceSSO")
+      .mockImplementation(pendingInitiation);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("initiates SSO when a device call reports sso_required", async () => {
+    mockServer.use(ssoRequiredDeviceHandler);
+
+    renderPage();
+
+    await expectRedirectingToIdP();
+    expect(initiateDeviceSSO).toHaveBeenCalledWith("testToken");
+  });
+
+  it("initiates when a query other than the details call is the one refused", async () => {
+    mockServer.use(defaultDeviceHandler);
+    mockServer.use(ssoRequiredDeviceCertificatesHandler);
+
+    renderPage();
+
+    await expectRedirectingToIdP();
+    expect(initiateDeviceSSO).toHaveBeenCalledWith("testToken");
+  });
+
+  it("renders the invalid URL error, and starts no SSO flow, for a 401 with no marker", async () => {
+    mockServer.use(unauthorizedDeviceHandler);
+
+    renderPage();
+
+    expect(
+      await screen.findByText("This URL is invalid or expired.")
+    ).toBeInTheDocument();
+    expect(initiateDeviceSSO).not.toHaveBeenCalled();
+  });
+
+  it("does not initiate a second time after a round-trip that left no session", async () => {
+    mockServer.use(ssoRequiredDeviceHandler);
+    window.sessionStorage.setItem("fleet-device-sso-attempt:testToken", "1");
+
+    renderPage();
+
+    await expectManualRetry();
+    expect(initiateDeviceSSO).not.toHaveBeenCalled();
+  });
+
+  it("does not auto-initiate when the attempt cannot be remembered", async () => {
+    mockServer.use(ssoRequiredDeviceHandler);
+    jest.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("blocked");
+    });
+    jest.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("blocked");
+    });
+
+    const { user } = renderPage();
+
+    const retry = await screen.findByRole("button", { name: "Sign in again" });
+    expect(initiateDeviceSSO).not.toHaveBeenCalled();
+
+    await user.click(retry);
+
+    await expectRedirectingToIdP();
+    expect(initiateDeviceSSO).toHaveBeenCalledWith("testToken");
+  });
+
+  it("does not auto-initiate when the callback reported a failure", async () => {
+    mockServer.use(ssoRequiredDeviceHandler);
+
+    renderPage({ sso_error: "server_error" });
+
+    await expectManualRetry();
+    expect(initiateDeviceSSO).not.toHaveBeenCalled();
+  });
+
+  it("does not auto-initiate during Setup Experience", async () => {
+    mockServer.use(ssoRequiredDeviceHandler);
+
+    renderPage({ setup_only: "1" });
+
+    await expectManualRetry();
+    expect(initiateDeviceSSO).not.toHaveBeenCalled();
+  });
+
+  it("renders a retryable error when the initiate call fails", async () => {
+    mockServer.use(ssoRequiredDeviceHandler);
+    initiateDeviceSSO.mockRejectedValueOnce(new Error("nope"));
+
+    const { user } = renderPage();
+
+    const retry = await screen.findByRole("button", { name: "Sign in again" });
+    expect(initiateDeviceSSO).toHaveBeenCalledTimes(1);
+
+    await user.click(retry);
+
+    await expectRedirectingToIdP();
+    expect(initiateDeviceSSO).toHaveBeenCalledTimes(2);
   });
 });

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -68,6 +68,7 @@ import {
   isIPad,
   isRecentlyEnrolled,
 } from "./helpers";
+import useDeviceSSO from "./useDeviceSSO";
 
 import PolicyDetailsModal from "../cards/Policies/HostPoliciesTable/PolicyDetailsModal";
 import AutoEnrollMdmModal from "./AutoEnrollMdmModal";
@@ -129,6 +130,7 @@ interface IDeviceUserPageProps {
       order_key?: string;
       order_direction?: "asc" | "desc";
       setup_only?: string;
+      sso_error?: string;
     };
     search?: string;
   };
@@ -211,6 +213,7 @@ const DeviceUserPage = ({
     data: deviceCertificates,
     isLoading: isLoadingDeviceCertificates,
     isError: isErrorDeviceCertificates,
+    error: deviceCertificatesError,
     refetch: refetchDeviceCertificates,
   } = useQuery<
     IGetDeviceCertificatesResponse,
@@ -271,7 +274,7 @@ const DeviceUserPage = ({
   const {
     data: dupDetails,
     isLoading: isLoadingDupDetails,
-    error: isDupDetailsError,
+    error: dupDetailsError,
     refetch: refetchDupDetails,
   } = useQuery<IDUPDetails, AxiosError>(
     ["host", deviceAuthToken],
@@ -364,7 +367,7 @@ const DeviceUserPage = ({
   );
 
   const isAuthenticationError =
-    isDupDetailsError && isDupDetailsError.status === 401;
+    dupDetailsError && dupDetailsError.status === 401;
 
   const {
     host,
@@ -413,6 +416,7 @@ const DeviceUserPage = ({
     data: setupStepStatuses,
     isLoading: isLoadingSetupSteps,
     isError: isErrorSetupSteps,
+    error: setupStepsError,
   } = useQuery<
     IGetSetupExperienceStatusesResponse,
     AxiosError,
@@ -460,6 +464,23 @@ const DeviceUserPage = ({
       select: (data) => data.enroll_url,
     }
   );
+
+  const {
+    isSSORequired,
+    isRedirecting: isRedirectingToSSO,
+    retry: retryDeviceSSO,
+  } = useDeviceSSO({
+    deviceAuthToken,
+    errors: [
+      dupDetailsError,
+      deviceCertificatesError,
+      setupStepsError,
+      mdmManualEnrollUrlError,
+    ],
+    ssoErrorParam: location.query.sso_error,
+    isSetupOnly: !!location.query.setup_only,
+    hasSession: !!dupDetails,
+  });
 
   const { bypassConditionalAccess } = deviceUserAPI;
 
@@ -962,6 +983,26 @@ const DeviceUserPage = ({
     );
   };
 
+  const renderDeviceSSOState = () => {
+    if (isRedirectingToSSO) {
+      return (
+        <div className={`${baseClass}__sso-redirect`} role="status">
+          <Spinner {...(isMobileView && { variant: "mobile" })} />
+          <span>Redirecting to your organization’s sign-in page…</span>
+        </div>
+      );
+    }
+
+    return (
+      <DeviceUserError
+        isMobileView={isMobileView}
+        isMobileDevice={isMobileDevice}
+        ssoError="sign_in_failed"
+        onRetry={retryDeviceSSO}
+      />
+    );
+  };
+
   const coreWrapperClassnames = classNames("core-wrapper", {
     "low-width-supported": !shouldShowUnsupportedScreen(location.pathname),
   });
@@ -969,6 +1010,26 @@ const DeviceUserPage = ({
   const siteNavContainerClassnames = classNames("site-nav-container", {
     "low-width-supported": !shouldShowUnsupportedScreen(location.pathname),
   });
+
+  // The SSO branch has to come first: a refused device call is an error to
+  // every query on the page, but one the end user can act on by signing in.
+  const renderDeviceUserBody = () => {
+    if (isSSORequired) {
+      return renderDeviceSSOState();
+    }
+    if (dupDetailsError || enrollUrlError) {
+      return (
+        <DeviceUserError
+          isMobileView={isMobileView}
+          isMobileDevice={isMobileDevice}
+          isAuthenticationError={!!isAuthenticationError}
+        />
+      );
+    }
+    return (
+      <div className={coreWrapperClassnames}>{renderDeviceUserPage()}</div>
+    );
+  };
 
   return (
     <div className="app-wrap">
@@ -1001,15 +1062,7 @@ const DeviceUserPage = ({
           )}
         </div>
       </nav>
-      {isDupDetailsError || enrollUrlError ? (
-        <DeviceUserError
-          isMobileView={isMobileView}
-          isMobileDevice={isMobileDevice}
-          isAuthenticationError={!!isAuthenticationError}
-        />
-      ) : (
-        <div className={coreWrapperClassnames}>{renderDeviceUserPage()}</div>
-      )}
+      {renderDeviceUserBody()}
       {showInfoModal && (
         <InfoModal
           onCancel={toggleInfoModal}

--- a/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
+++ b/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
@@ -17,6 +17,16 @@
   }
 }
 
+.device-user__sso-redirect {
+  @include vertical-page-layout;
+
+  align-items: center;
+  margin: $pad-xxxlarge 0;
+  color: $core-fleet-black;
+  font-size: $x-small;
+  text-align: center;
+}
+
 // styles specific to DeviceUserPage
 // for styles that should apply to both DeviceUserPage and HostDetailsPage (most of them),
 // update frontend/pages/hosts/details/_styles.scss/ `.host-details, .device-user {...}`

--- a/frontend/pages/hosts/details/DeviceUserPage/helpers.tests.ts
+++ b/frontend/pages/hosts/details/DeviceUserPage/helpers.tests.ts
@@ -1,5 +1,11 @@
 import { ISetupStep } from "interfaces/setup";
-import { isSoftwareScriptSetup } from "./helpers";
+import {
+  canAutoInitiateDeviceSSO,
+  clearDeviceSSOAttempt,
+  isSoftwareScriptSetup,
+  isSSORequiredError,
+  recordDeviceSSOAttempt,
+} from "./helpers";
 
 const setupStep = (source?: ISetupStep["source"]): ISetupStep => ({
   name: "test",
@@ -8,7 +14,7 @@ const setupStep = (source?: ISetupStep["source"]): ISetupStep => ({
   source,
 });
 
-describe("DeviceUserPage helpers - isSoftwareScriptSetup", () => {
+describe("isSoftwareScriptSetup", () => {
   it("returns true for script package sources (sh, ps1, py)", () => {
     expect(isSoftwareScriptSetup(setupStep("sh_packages"))).toBe(true);
     expect(isSoftwareScriptSetup(setupStep("ps1_packages"))).toBe(true);
@@ -21,5 +27,75 @@ describe("DeviceUserPage helpers - isSoftwareScriptSetup", () => {
 
   it("returns false when source is missing", () => {
     expect(isSoftwareScriptSetup(setupStep(undefined))).toBe(false);
+  });
+});
+
+describe("isSSORequiredError", () => {
+  it("recognizes a 401 carrying the sso_required marker", () => {
+    expect(
+      isSSORequiredError({ status: 401, data: { sso_required: true } })
+    ).toBe(true);
+  });
+
+  it("rejects a 401 without the marker, which means a stale device token", () => {
+    expect(isSSORequiredError({ status: 401, data: {} })).toBe(false);
+    expect(isSSORequiredError({ status: 401 })).toBe(false);
+    expect(
+      isSSORequiredError({ status: 401, data: { sso_required: false } })
+    ).toBe(false);
+  });
+
+  it("rejects the marker on any status other than 401", () => {
+    expect(
+      isSSORequiredError({ status: 500, data: { sso_required: true } })
+    ).toBe(false);
+  });
+
+  it("tolerates the shapes a failed request can reject with", () => {
+    expect(isSSORequiredError(undefined)).toBe(false);
+    expect(isSSORequiredError(null)).toBe(false);
+    expect(isSSORequiredError(new Error("Network Error"))).toBe(false);
+    expect(isSSORequiredError("send request: parse server error")).toBe(false);
+  });
+});
+
+describe("device SSO attempt flag", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("records and clears an attempt for one token at a time", () => {
+    expect(canAutoInitiateDeviceSSO("token-a")).toBe(true);
+
+    expect(recordDeviceSSOAttempt("token-a")).toBe(true);
+    expect(canAutoInitiateDeviceSSO("token-a")).toBe(false);
+    expect(canAutoInitiateDeviceSSO("token-b")).toBe(true);
+
+    expect(clearDeviceSSOAttempt("token-a")).toBe(true);
+    expect(canAutoInitiateDeviceSSO("token-a")).toBe(true);
+  });
+
+  it("suppresses automatic attempts, rather than granting fresh ones, when storage throws", () => {
+    (["getItem", "setItem", "removeItem"] as const).forEach((method) => {
+      jest.spyOn(Storage.prototype, method).mockImplementation(() => {
+        throw new Error("blocked");
+      });
+    });
+
+    expect(recordDeviceSSOAttempt("token-a")).toBe(false);
+    expect(clearDeviceSSOAttempt("token-a")).toBe(false);
+    expect(canAutoInitiateDeviceSSO("token-a")).toBe(false);
+  });
+
+  it("reports a write that doesn't stick as not recorded", () => {
+    jest
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => undefined);
+
+    expect(recordDeviceSSOAttempt("token-a")).toBe(false);
   });
 });

--- a/frontend/pages/hosts/details/DeviceUserPage/helpers.ts
+++ b/frontend/pages/hosts/details/DeviceUserPage/helpers.ts
@@ -77,3 +77,58 @@ export const isIPad = (navigator: Navigator) =>
 export const isMac = (navigator: Navigator) =>
   (/Macintosh/i.test(navigator.userAgent) && !isIPad) ||
   /Mac OS X/i.test(navigator.userAgent);
+
+interface IDeviceAPIError {
+  status?: number;
+  data?: { sso_required?: boolean };
+}
+
+export const isSSORequiredError = (error: unknown): boolean => {
+  const response = error as IDeviceAPIError | null | undefined;
+  return response?.status === 401 && response?.data?.sso_required === true;
+};
+
+const ssoAttemptKey = (deviceAuthToken: string) =>
+  `fleet-device-sso-attempt:${deviceAuthToken}`;
+
+/** One automatic trip to the IdP per token. Coming back still unauthenticated
+ * means the session cookie never stuck (blocked cookies, clock skew), and
+ * initiating again would bounce the end user between Fleet and the IdP forever.
+ *
+ * Unreadable storage also answers false, not just a spent attempt: the guard
+ * only works if the flag survives a full page navigation, so a browser that
+ * won't store it cannot be given automatic attempts at all. Access is guarded
+ * because browsers configured to block site data throw on it. That
+ * configuration usually blocks the SSO session cookie too, which is exactly
+ * when the loop would run. Signing in by hand still works; it just costs a
+ * click. */
+export const canAutoInitiateDeviceSSO = (deviceAuthToken: string): boolean => {
+  try {
+    return sessionStorage.getItem(ssoAttemptKey(deviceAuthToken)) === null;
+  } catch {
+    return false;
+  }
+};
+
+/** Returns whether the attempt will still be there after the trip to the IdP. */
+export const recordDeviceSSOAttempt = (deviceAuthToken: string): boolean => {
+  const key = ssoAttemptKey(deviceAuthToken);
+  try {
+    sessionStorage.setItem(key, "1");
+    return sessionStorage.getItem(key) !== null;
+  } catch {
+    return false;
+  }
+};
+
+/** Returns whether an automatic attempt is available again, so a browser that
+ * cannot store the flag is not handed a fresh automatic attempt by a
+ * successful load. */
+export const clearDeviceSSOAttempt = (deviceAuthToken: string): boolean => {
+  try {
+    sessionStorage.removeItem(ssoAttemptKey(deviceAuthToken));
+    return true;
+  } catch {
+    return false;
+  }
+};

--- a/frontend/pages/hosts/details/DeviceUserPage/useDeviceSSO.ts
+++ b/frontend/pages/hosts/details/DeviceUserPage/useDeviceSSO.ts
@@ -1,0 +1,107 @@
+import { useCallback, useEffect, useState } from "react";
+
+import deviceUserAPI from "services/entities/device_user";
+
+import {
+  canAutoInitiateDeviceSSO,
+  clearDeviceSSOAttempt,
+  isSSORequiredError,
+  recordDeviceSSOAttempt,
+} from "./helpers";
+
+interface IUseDeviceSSOOptions {
+  deviceAuthToken: string;
+  /** Errors from the page's device API queries; any one carrying the
+   * sso_required marker puts the whole page behind sign-in. */
+  errors: unknown[];
+  /** The `sso_error` query param the SSO callback redirects back with. */
+  ssoErrorParam?: string;
+  /** Whether the page was opened to show only the Setup Experience screen. */
+  isSetupOnly: boolean;
+  /** Whether the host-details call has succeeded, proving the current
+   * session works. */
+  hasSession: boolean;
+}
+
+interface IUseDeviceSSOResult {
+  isSSORequired: boolean;
+  /** True from the moment an sso_required refusal arrives until the browser
+   * leaves for the IdP (or the initiate call fails), so the terminal error
+   * never flashes on the way there. */
+  isRedirecting: boolean;
+  retry: () => void;
+}
+
+const useDeviceSSO = ({
+  deviceAuthToken,
+  errors,
+  ssoErrorParam,
+  isSetupOnly,
+  hasSession,
+}: IUseDeviceSSOOptions): IUseDeviceSSOResult => {
+  const [isNavigating, setIsNavigating] = useState(false);
+  const [canAutoInitiate, setCanAutoInitiate] = useState(() =>
+    canAutoInitiateDeviceSSO(deviceAuthToken)
+  );
+
+  const isSSORequired = errors.some(isSSORequiredError);
+
+  const redirectToIdP = useCallback(async () => {
+    setIsNavigating(true);
+    try {
+      const { url } = await deviceUserAPI.initiateDeviceSSO(deviceAuthToken);
+      window.location.href = url;
+    } catch {
+      setIsNavigating(false);
+    }
+  }, [deviceAuthToken]);
+
+  // The callback flags its own failures via ssoErrorParam on the way back
+  // here. Initiating again on that signal loops the end user between this
+  // page and the IdP, so the remaining attempts have to be theirs to make.
+  const autoInitiateAllowed =
+    canAutoInitiate &&
+    !ssoErrorParam &&
+    // The server exempts hosts still in Setup Experience; this keeps an IdP
+    // prompt out of Setup Assistant even if that exemption ever misses.
+    !isSetupOnly;
+
+  useEffect(() => {
+    if (isSSORequired && autoInitiateAllowed && !isNavigating) {
+      setCanAutoInitiate(false);
+      // An attempt the browser can't remember can't be allowed to run: the
+      // one-attempt guard only works if the flag survives the navigation.
+      if (recordDeviceSSOAttempt(deviceAuthToken)) {
+        redirectToIdP();
+      }
+    }
+  }, [
+    isSSORequired,
+    autoInitiateAllowed,
+    isNavigating,
+    deviceAuthToken,
+    redirectToIdP,
+  ]);
+
+  useEffect(() => {
+    // A page with a working session gives the next expiry its own automatic
+    // attempt.
+    if (hasSession && !isSSORequired) {
+      setCanAutoInitiate(clearDeviceSSOAttempt(deviceAuthToken));
+    }
+  }, [hasSession, isSSORequired, deviceAuthToken]);
+
+  const retry = useCallback(() => {
+    setCanAutoInitiate(false);
+    recordDeviceSSOAttempt(deviceAuthToken);
+    redirectToIdP();
+  }, [deviceAuthToken, redirectToIdP]);
+
+  return {
+    isSSORequired,
+    isRedirecting: isNavigating || (isSSORequired && autoInitiateAllowed),
+    retry,
+  };
+};
+
+export default useDeviceSSO;

--- a/frontend/router/index.tsx
+++ b/frontend/router/index.tsx
@@ -30,6 +30,7 @@ import MfaPage from "pages/MfaPage";
 import CoreLayout from "layouts/CoreLayout";
 import DashboardPage from "pages/DashboardPage";
 import DeviceUserPage from "pages/hosts/details/DeviceUserPage";
+import DeviceUserSSOErrorPage from "pages/DeviceUserSSOErrorPage";
 import EditPackPage from "pages/packs/EditPackPage";
 import EmailTokenRedirect from "components/EmailTokenRedirect";
 import ForgotPasswordPage from "pages/ForgotPasswordPage";
@@ -457,6 +458,7 @@ const routes = (
       </Route>
       <Route path="device">
         <IndexRedirect to=":device_auth_token" />
+        <Route path="sso-error" component={DeviceUserSSOErrorPage} />
         <Route component={DeviceUserPage}>
           <Route path=":device_auth_token" component={DeviceUserPage}>
             <Route path="self-service" component={DeviceUserPage} />

--- a/frontend/services/entities/device_user.ts
+++ b/frontend/services/entities/device_user.ts
@@ -63,6 +63,11 @@ export interface IGetSetupExperienceStatusesParams {
   token: string;
 }
 
+export interface IInitiateDeviceSSOResponse {
+  /** The IdP URL the browser must navigate to in order to sign in. */
+  url: string;
+}
+
 export default {
   loadHostDetails: ({
     token,
@@ -87,6 +92,18 @@ export default {
   refetch: (deviceAuthToken: string) => {
     const { DEVICE_USER_DETAILS } = endpoints;
     const path = `${DEVICE_USER_DETAILS}/${deviceAuthToken}/refetch`;
+
+    return sendRequest("POST", path);
+  },
+
+  /** Starts the Fleet Desktop SSO flow. Sets the SSO handshake cookie and
+   * returns the IdP URL to navigate to; the session cookie is set server-side
+   * when the IdP calls back. */
+  initiateDeviceSSO: (
+    deviceAuthToken: string
+  ): Promise<IInitiateDeviceSSOResponse> => {
+    const { DEVICE_USER_DETAILS } = endpoints;
+    const path = `${DEVICE_USER_DETAILS}/${deviceAuthToken}/sso`;
 
     return sendRequest("POST", path);
   },

--- a/frontend/test/handlers/device-handler.ts
+++ b/frontend/test/handlers/device-handler.ts
@@ -44,6 +44,33 @@ export const defaultDeviceHandler = http.get(baseUrl("/device/:token"), () =>
   HttpResponse.json(createDefaultDeviceResponse())
 );
 
+/** The device API answers 401 for an expired device token and, when Fleet
+ * Desktop SSO is on, for a request carrying no IdP session. Only the second
+ * carries the marker. */
+export const ssoRequiredDeviceHandler = http.get(
+  baseUrl("/device/:token"),
+  () =>
+    HttpResponse.json(
+      { message: "Single sign-on required", sso_required: true },
+      { status: 401 }
+    )
+);
+
+export const ssoRequiredDeviceCertificatesHandler = http.get(
+  baseUrl("/device/:token/certificates"),
+  () =>
+    HttpResponse.json(
+      { message: "Single sign-on required", sso_required: true },
+      { status: 401 }
+    )
+);
+
+export const unauthorizedDeviceHandler = http.get(
+  baseUrl("/device/:token"),
+  () =>
+    HttpResponse.json({ message: "Authentication required" }, { status: 401 })
+);
+
 export const customDeviceHandler = (overrides?: Partial<IDUPDetails>) =>
   http.get(baseUrl("/device/:token"), () =>
     HttpResponse.json({ ...createDefaultDeviceResponse(), ...overrides })

--- a/frontend/test/test-setup.ts
+++ b/frontend/test/test-setup.ts
@@ -3,6 +3,23 @@ import mockServer from "./mock-server";
 
 // Needed for testing react-tooltip-5
 window.CSS.supports = jest.fn();
+
+// JSDOM does not implement matchMedia, which useIsMobileWidth (DeviceUserPage)
+// calls unguarded on mount. Default to the desktop breakpoint; tests that need
+// mobile can override.
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: jest.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    addListener: jest.fn(), // for older APIs
+    removeListener: jest.fn(),
+    onchange: null,
+    dispatchEvent: jest.fn(),
+  })),
+});
 global.ResizeObserver = jest.fn().mockImplementation(() => ({
   observe: jest.fn(),
   unobserve: jest.fn(),

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -1752,10 +1752,8 @@ type FleetDesktopSettings struct {
 	// AlternativeBrowserHost if set, Fleet Desktop will use this to open any links;
 	// this is used in scenarios where we want Fleet Desktop traffic to use a custom proxy, for security reasons.
 	AlternativeBrowserHost string `json:"alternative_browser_host"`
-	// SSOEnabled records that end users should authenticate with the IdP
-	// configured in mdm.end_user_authentication, which must be set before this can
-	// be enabled. Nothing enforces it yet: the setting is only persisted and
-	// reported.
+	// SSOEnabled requires end users to authenticate with the IdP configured in
+	// mdm.end_user_authentication, which must be set before this can be enabled.
 	SSOEnabled bool `json:"sso_enabled"`
 }
 

--- a/server/fleet/mdm.go
+++ b/server/fleet/mdm.go
@@ -1465,6 +1465,32 @@ const (
 	SSOInitiatorFleetDesktop = "fleet_desktop"
 )
 
+// maxSSORelayStateLen is the cap the SAML 2.0 HTTP bindings put on RelayState.
+const maxSSORelayStateLen = 80
+
+// SSORelayState is a value Fleet asks the IdP to echo back with the SAML
+// assertion. It survives a callback whose SSO session can no longer be loaded
+type SSORelayState string
+
+// SSORelayStateNone leaves RelayState off the AuthnRequest entirely.
+const SSORelayStateNone = SSORelayState("")
+
+// ParseSSORelayState turns the raw RelayState an IdP posted back into the
+// initiator Fleet sent, or SSORelayStateNone when it echoed back nothing Fleet
+// recognizes.
+func ParseSSORelayState(raw string) SSORelayState {
+	if len(raw) > maxSSORelayStateLen {
+		return SSORelayStateNone
+	}
+	switch raw {
+	case SSOInitiatorOTAEnroll, SSOInitiatorOrbitSetupExperience,
+		SSOInitiatorAccountDrivenEnroll, SSOInitiatorAppleMDMSSO, SSOInitiatorFleetDesktop:
+		return SSORelayState(raw)
+	default:
+		return SSORelayStateNone
+	}
+}
+
 // DeviceSSOInitiation is what a device needs to start the Fleet Desktop SSO
 // flow: the IdP URL to navigate to, plus the handshake session that ties the
 // eventual SAML callback back to this request.

--- a/server/fleet/mdm_test.go
+++ b/server/fleet/mdm_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"regexp"
+	"strings"
 	"testing"
 
 	ctxabm "github.com/fleetdm/fleet/v4/server/contexts/apple_bm"
@@ -846,4 +847,28 @@ func TestFilterOutUserScopedProfiles(t *testing.T) {
 	filteredProfiles := fleet.FilterOutUserScopedProfiles(profilesToFilter)
 
 	require.ElementsMatch(t, filteredProfiles, []*fleet.MDMAppleProfilePayload{&systemScopedProfile})
+}
+
+func TestParseSSORelayState(t *testing.T) {
+	for _, initiator := range []string{
+		fleet.SSOInitiatorOTAEnroll,
+		fleet.SSOInitiatorOrbitSetupExperience,
+		fleet.SSOInitiatorAccountDrivenEnroll,
+		fleet.SSOInitiatorAppleMDMSSO,
+		fleet.SSOInitiatorFleetDesktop,
+	} {
+		require.Equal(t, fleet.SSORelayState(initiator), fleet.ParseSSORelayState(initiator))
+	}
+
+	for _, unknown := range []string{
+		"",
+		"FLEET_DESKTOP",
+		"fleet_desktop ",
+		"/device/abc123",
+		// The SAML bindings cap relay state at 80 bytes; a longer value is not
+		// something a conformant IdP echoed back.
+		strings.Repeat("a", 81),
+	} {
+		require.Empty(t, fleet.ParseSSORelayState(unknown), unknown)
+	}
 }

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -69,6 +69,15 @@ const (
 	// error gives the end user nothing to act on.
 	FleetUISSOCallbackSessionExpired = FleetUISSOCallbackError + "&reason=session_expired"
 
+	// FleetUIDeviceSSOError is where the Fleet Desktop SSO flow lands when the
+	// callback fails before loading the SSO session: the device-page counterpart
+	// of FleetUISSOCallbackError.
+	FleetUIDeviceSSOError = "/device/sso-error?reason=error"
+
+	// FleetUIDeviceSSOErrorSessionExpired is the device-page counterpart of
+	// FleetUISSOCallbackSessionExpired.
+	FleetUIDeviceSSOErrorSessionExpired = "/device/sso-error?reason=session_expired"
+
 	// FleetPayloadIdentifier is the value for the "<key>PayloadIdentifier</key>"
 	// used by Fleet MDM on the enrollment profile.
 	FleetPayloadIdentifier = "com.fleetdm.fleet.mdm.apple"

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -4192,6 +4192,7 @@ func (svc *Service) InitiateMDMSSO(ctx context.Context, initiator, customOrigina
 
 type callbackMDMSSORequest struct {
 	sessionID    string
+	relayState   fleet.SSORelayState
 	samlResponse []byte
 }
 
@@ -4200,12 +4201,13 @@ type callbackMDMSSORequest struct {
 // rare enough (malformed data coming from the SSO provider) so they shouldn't
 // affect many users.
 func (callbackMDMSSORequest) DecodeRequest(ctx context.Context, r *http.Request) (interface{}, error) {
-	sessionID, samlResponse, err := decodeCallbackRequest(ctx, r)
+	sessionID, samlResponse, relayState, err := decodeCallbackRequest(ctx, r)
 	if err != nil {
 		return nil, err
 	}
 	return &callbackMDMSSORequest{
 		sessionID:    sessionID,
+		relayState:   relayState,
 		samlResponse: samlResponse,
 	}, nil
 }
@@ -4240,6 +4242,18 @@ func (r callbackMDMSSOResponse) Error() error { return nil }
 func callbackMDMSSOEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (fleet.Errorer, error) {
 	callbackRequest := request.(*callbackMDMSSORequest)
 	redirectURL, byodCookieValue, deviceSSOSessionID, deviceSSOSessionDuration := svc.MDMSSOCallback(ctx, callbackRequest.sessionID, callbackRequest.samlResponse)
+
+	// Relay state is carried by the browser through the IdP and back, is used
+	// for distinguishing users comming from "My device".
+	if callbackRequest.relayState == fleet.SSOInitiatorFleetDesktop {
+		switch redirectURL {
+		case apple_mdm.FleetUISSOCallbackSessionExpired:
+			redirectURL = apple_mdm.FleetUIDeviceSSOErrorSessionExpired
+		case apple_mdm.FleetUISSOCallbackError:
+			redirectURL = apple_mdm.FleetUIDeviceSSOError
+		}
+	}
+
 	return callbackMDMSSOResponse{
 		redirectURL:              redirectURL,
 		byodEnrollCookieValue:    byodCookieValue,

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -7142,6 +7142,28 @@ func (s *integrationMDMTestSuite) TestDeviceSSO() {
 		s.CompleteDeviceSSO(disabledClient, disabledIdPURL, "sso_user", "user123#"),
 		thirdToken, "sso_disabled", "feature disabled mid-flow",
 	)
+
+	s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(`{
+		"fleet_desktop": { "sso_enabled": true }
+	}`), http.StatusOK, &appConfigResponse{})
+
+	_, fourthToken := newHostWithToken("-d")
+	expiredClient := s.newSSOTestClient()
+	expiredIdPURL := s.InitiateDeviceSSO(expiredClient, fourthToken)
+	s.ExpireSSOHandshake(expiredClient)
+	expiredRes := s.CompleteDeviceSSO(expiredClient, expiredIdPURL, "sso_user", "user123#")
+	require.Equal(t, "/device/sso-error?reason=session_expired", expiredRes.Header.Get("Location"))
+	for _, c := range expiredRes.Cookies() {
+		require.NotEqual(t, cookieNameDeviceSSOSession, c.Name)
+	}
+
+	_, fifthToken := newHostWithToken("-e")
+	forgedRelayClient := s.newSSOTestClient()
+	forgedRelayIdPURL := s.InitiateDeviceSSO(forgedRelayClient, fifthToken)
+	s.ExpireSSOHandshake(forgedRelayClient)
+	forgedRelayRes := s.CompleteDeviceSSOWithRelayState(forgedRelayClient, forgedRelayIdPURL,
+		"sso_user", "user123#", "https://evil.example.com")
+	require.Equal(t, "/mdm/sso/callback?error=true&reason=session_expired", forgedRelayRes.Header.Get("Location"))
 }
 
 // TestMDMSSOReenrollWithDifferentIdPEmail is a regression test for

--- a/server/service/sessions.go
+++ b/server/service/sessions.go
@@ -540,6 +540,7 @@ func (svc *Service) InitiateSSO(ctx context.Context, redirectURL string) (sessio
 	sessionID, idpURL, err = sso.CreateAuthorizationRequest(
 		ctx, samlProvider, svc.ssoSessionStore, redirectURL,
 		uint(sessionDurationSeconds), //nolint:gosec // dismiss G115
+		fleet.SSORelayStateNone,
 		sso.SSORequestData{},
 	)
 	if err != nil {
@@ -559,7 +560,8 @@ type callbackSSORequest struct {
 }
 
 func (c callbackSSORequest) DecodeRequest(ctx context.Context, r *http.Request) (interface{}, error) {
-	sessionID, samlResponse, err := decodeCallbackRequest(ctx, r)
+	// Admin login SSO doesn't set relay state, so there is none to read back.
+	sessionID, samlResponse, _, err := decodeCallbackRequest(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -572,6 +574,7 @@ func (c callbackSSORequest) DecodeRequest(ctx context.Context, r *http.Request) 
 func decodeCallbackRequest(ctx context.Context, r *http.Request) (
 	sessionID string,
 	decodedSAMLResponse []byte,
+	relayState fleet.SSORelayState,
 	err error,
 ) {
 	cs, err := r.Cookie(cookieNameSSOSession)
@@ -581,13 +584,13 @@ func decodeCallbackRequest(ctx context.Context, r *http.Request) (
 	case errors.Is(err, http.ErrNoCookie):
 		// SessionID cookie will be empty on IdP-initiated logins.
 	default:
-		return "", nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
+		return "", nil, fleet.SSORelayStateNone, ctxerr.Wrap(ctx, &fleet.BadRequestError{
 			Message: "failed to read SSO cookie session ID",
 		}, "cookie session ID in SSO callback")
 	}
 
 	if err := r.ParseForm(); err != nil {
-		return "", nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
+		return "", nil, fleet.SSORelayStateNone, ctxerr.Wrap(ctx, &fleet.BadRequestError{
 			Message:     "failed to parse form",
 			InternalErr: err,
 		}, "parse form in SSO callback")
@@ -595,7 +598,7 @@ func decodeCallbackRequest(ctx context.Context, r *http.Request) (
 
 	samlResponseValue := r.FormValue("SAMLResponse")
 	if samlResponseValue == "" {
-		return "", nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
+		return "", nil, fleet.SSORelayStateNone, ctxerr.Wrap(ctx, &fleet.BadRequestError{
 			Message: "missing SAMLResponse",
 		}, "missing SAMLResponse in SSO callback")
 	}
@@ -606,18 +609,18 @@ func decodeCallbackRequest(ctx context.Context, r *http.Request) (
 	// ?SAMLResponse= query argument. This guards both the regular and MDM SSO
 	// callbacks, which share this decoder.
 	if int64(len(samlResponseValue)) > fleet.MaxSSOCallbackSize {
-		return "", nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
+		return "", nil, fleet.SSORelayStateNone, ctxerr.Wrap(ctx, &fleet.BadRequestError{
 			Message: "SAMLResponse too large",
 		}, "SAMLResponse exceeds maximum size in SSO callback")
 	}
 	decodedSAMLResponseValue, err := sso.DecodeSAMLResponse(samlResponseValue)
 	if err != nil {
-		return "", nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
+		return "", nil, fleet.SSORelayStateNone, ctxerr.Wrap(ctx, &fleet.BadRequestError{
 			Message:     "failed to decode SAMLResponse",
 			InternalErr: err,
 		}, "decode SAMLResponse in SSO callback")
 	}
-	return sessionID, decodedSAMLResponseValue, nil
+	return sessionID, decodedSAMLResponseValue, fleet.ParseSSORelayState(r.FormValue("RelayState")), nil
 }
 
 type callbackSSOResponse struct {

--- a/server/service/sessions_test.go
+++ b/server/service/sessions_test.go
@@ -752,7 +752,7 @@ func TestDecodeCallbackRequestSAMLResponseSizeCap(t *testing.T) {
 		oversized := strings.Repeat("A", int(fleet.MaxSSOCallbackSize)+1)
 		r := httptest.NewRequest("POST", "/api/v1/fleet/sso/callback?SAMLResponse="+oversized, nil)
 
-		_, _, err := decodeCallbackRequest(t.Context(), r)
+		_, _, _, err := decodeCallbackRequest(t.Context(), r)
 		require.Error(t, err)
 		var bre *fleet.BadRequestError
 		require.ErrorAs(t, err, &bre)
@@ -765,8 +765,31 @@ func TestDecodeCallbackRequestSAMLResponseSizeCap(t *testing.T) {
 		r := httptest.NewRequest("POST", "/api/v1/fleet/sso/callback", strings.NewReader(form.Encode()))
 		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-		_, decoded, err := decodeCallbackRequest(t.Context(), r)
+		_, decoded, _, err := decodeCallbackRequest(t.Context(), r)
 		require.NoError(t, err)
 		require.Equal(t, "<x/>", string(decoded))
+	})
+}
+
+func TestDecodeCallbackRequestRelayState(t *testing.T) {
+	postWith := func(t *testing.T, form url.Values) fleet.SSORelayState {
+		t.Helper()
+		form.Set("SAMLResponse", base64.StdEncoding.EncodeToString([]byte("<x/>")))
+		r := httptest.NewRequest("POST", "/api/v1/fleet/mdm/sso/callback", strings.NewReader(form.Encode()))
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+		_, _, relayState, err := decodeCallbackRequest(t.Context(), r)
+		require.NoError(t, err)
+		return relayState
+	}
+
+	t.Run("a recognized value survives the form round trip", func(t *testing.T) {
+		require.Equal(t,
+			fleet.SSORelayState(fleet.SSOInitiatorFleetDesktop),
+			postWith(t, url.Values{"RelayState": {fleet.SSOInitiatorFleetDesktop}}))
+	})
+
+	t.Run("an absent RelayState decodes to empty", func(t *testing.T) {
+		require.Empty(t, postWith(t, url.Values{}))
 	})
 }

--- a/server/service/testing_client_test.go
+++ b/server/service/testing_client_test.go
@@ -569,7 +569,22 @@ func (ts *withServer) InitiateDeviceSSO(client *http.Client, deviceToken string)
 func (ts *withServer) CompleteDeviceSSO(client *http.Client, idpURL, username, password string) *http.Response {
 	samlResponse := ts.completeSAMLLogin(client, idpURL, username, password)
 	return ts.doWithClient(client, "POST", "/api/v1/fleet/mdm/sso/callback", nil, http.StatusSeeOther, nil,
-		"SAMLResponse", samlResponse)
+		"SAMLResponse", samlResponse, "RelayState", fleet.SSOInitiatorFleetDesktop)
+}
+
+func (ts *withServer) CompleteDeviceSSOWithRelayState(client *http.Client, idpURL, username, password, relayState string) *http.Response {
+	samlResponse := ts.completeSAMLLogin(client, idpURL, username, password)
+	return ts.doWithClient(client, "POST", "/api/v1/fleet/mdm/sso/callback", nil, http.StatusSeeOther, nil,
+		"SAMLResponse", samlResponse, "RelayState", relayState)
+}
+
+func (ts *withServer) ExpireSSOHandshake(client *http.Client) {
+	t := ts.s.T()
+	serverURL, err := url.Parse(ts.server.URL)
+	require.NoError(t, err)
+	client.Jar.SetCookies(serverURL, []*http.Cookie{
+		{Name: cookieNameSSOSession, Value: "expired-handshake-session-id", Path: "/"},
+	})
 }
 
 // LoginDeviceSSOUser drives the whole Fleet Desktop "My device" page SSO flow:

--- a/server/sso/authorization_request.go
+++ b/server/sso/authorization_request.go
@@ -10,6 +10,7 @@ import (
 	"github.com/crewjam/saml"
 	"github.com/fleetdm/fleet/v4/server"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/fleet"
 )
 
 const cacheLifetimeSeconds = uint(300) // in seconds (5 minutes)
@@ -35,6 +36,7 @@ func CreateAuthorizationRequest(
 	sessionStore SessionStore,
 	originalURL string,
 	sessionTTLSeconds uint,
+	relayState fleet.SSORelayState,
 	requestData SSORequestData,
 ) (sessionID string, idpURL string, err error) {
 	idpURL, err = getDestinationURL(samlProvider.IDPMetadata)
@@ -83,8 +85,7 @@ func CreateAuthorizationRequest(
 		return "", "", fmt.Errorf("caching SSO session while creating auth request: %w", err)
 	}
 
-	relayState := "" // Fleet currently doesn't use/set RelayState
-	idpRedirectURL, err := samlAuthRequest.Redirect(relayState, samlProvider)
+	idpRedirectURL, err := samlAuthRequest.Redirect(string(relayState), samlProvider)
 	if err != nil {
 		return "", "", ctxerr.Wrap(ctx, err, "generating redirect")
 	}

--- a/server/sso/authorization_request_test.go
+++ b/server/sso/authorization_request_test.go
@@ -47,6 +47,7 @@ func TestCreateAuthorizationRequest(t *testing.T) {
 		store,
 		"/redir",
 		0,
+		fleet.SSORelayStateNone,
 		SSORequestData{
 			HostUUID:  "host-uuid-123",
 			Initiator: "test_initiator",
@@ -85,6 +86,7 @@ func TestCreateAuthorizationRequest(t *testing.T) {
 		store,
 		"/redir",
 		sessionTTL,
+		fleet.SSORelayStateNone,
 		SSORequestData{},
 	)
 	require.NoError(t, err)
@@ -137,4 +139,47 @@ func (s *mockStore) expire(sessionID string) error {
 
 func (s *mockStore) Fullfill(sessionID string) (*Session, error) {
 	return s.session, nil
+}
+
+func TestCreateAuthorizationRequestRelayState(t *testing.T) {
+	metadata, err := xml.Marshal(&saml.EntityDescriptor{
+		EntityID: "test",
+		IDPSSODescriptors: []saml.IDPSSODescriptor{
+			{
+				SingleSignOnServices: []saml.Endpoint{
+					{Binding: saml.HTTPRedirectBinding, Location: "http://example.com"},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	samlProvider, err := SAMLProviderFromConfiguredMetadata(context.Background(),
+		"issuer",
+		"http://localhost:8001/api/v1/fleet/sso/callback",
+		&fleet.SSOProviderSettings{
+			IDPName:  "Fleet",
+			Metadata: string(metadata),
+		},
+	)
+	require.NoError(t, err)
+
+	relayStateFor := func(t *testing.T, relayState fleet.SSORelayState) string {
+		t.Helper()
+		_, idpURL, err := CreateAuthorizationRequest(context.Background(),
+			samlProvider,
+			&mockStore{},
+			"/redir",
+			0,
+			relayState,
+			SSORequestData{},
+		)
+		require.NoError(t, err)
+		parsed, err := url.Parse(idpURL)
+		require.NoError(t, err)
+		return parsed.Query().Get("RelayState")
+	}
+
+	require.Empty(t, relayStateFor(t, fleet.SSORelayStateNone))
+	require.Equal(t, fleet.SSOInitiatorFleetDesktop, relayStateFor(t, fleet.SSOInitiatorFleetDesktop))
 }


### PR DESCRIPTION
Relates to #51523

The device page now reads the sso_required marker off a 401 and starts the SSO flow instead of reporting an invalid URL. A plain 401 still means a stale device token and renders the existing error unchanged. Classification is centralized so a session that lapses mid-visit re-initiates from whichever device call happens to be refused next.

One automatic trip to the IdP per token, tracked in sessionStorage and cleared once the page loads. Coming back still unauthenticated means the session cookie never stuck (blocked cookies, clock skew), and initiating again would bounce the end user between Fleet and the IdP forever, so the second refusal is terminal with a manual retry. The sso_error the callback redirects with, and setup_only, suppress the automatic attempt for the same reason.

Callbacks that fail before the SSO session loads know neither the initiator nor the device page URL -- both live in the session -- so they landed Fleet Desktop end users on the admin callback error page. That is reachable in ordinary use: the handshake window spans an MFA push or a walk to a hardware token. InitiateDeviceSSO now sends the initiator as SAML RelayState, which the IdP echoes back, and the early failure path switches on it to /device/sso-error. The device auth token stays out of it: relay state reaches the IdP's request logs, and the bindings cap it at 80 bytes anyway. Fleet never redirects to relay state, only switches on it, and drops any value it did not send, so the four enrollment initiators keep today's behavior byte-for-byte and a non-conformant IdP degrades to it rather than breaking.

## Flow

```mermaid
sequenceDiagram
    autonumber
    actor User as End user
    participant Page as My device page (SPA)
    participant API as Fleet server
    participant IdP

    User->>Page: clicks "My device" in the tray, opens /device/{token}
    Page->>API: GET /device/{token} (and the page's other gated calls)

    alt Gate off, or a valid device SSO session cookie rides along
        API-->>Page: 200
        Note over Page: clears its browser sessionStorage flag<br/>fleet-device-sso-attempt:{token}, so a later<br/>expiry gets its own automatic attempt
        Page-->>User: renders normally
    else 401 with no marker
        API-->>Page: 401 (device token stale or invalid)
        Note over Page: the gate never ran, so an IdP round-trip<br/>cannot help -- initiation is token-authed too
        Page-->>User: "This URL is invalid or expired." (unchanged)
    else 401 carrying the sso_required marker
        API-->>Page: 401 + sso_required

        alt No attempt recorded yet, and no sso_error / setup_only in the URL
            Note over Page: isSSORequiredError matches on any of the four<br/>page-level queries, then records the sessionStorage flag

            alt The flag could not be stored (site data blocked)
                Note over Page: an attempt Fleet cannot remember is one it cannot<br/>count, and blocked storage usually means a blocked<br/>session cookie -- so no automatic trip is made
                Page-->>User: "Couldn't sign in." + Sign in again
            else Flag stored
            Page->>API: POST /device/{token}/sso

            alt Initiation refused (SSO off, no IdP, host mismatch, free tier)
                API-->>Page: 4xx
                Page-->>User: "Couldn't sign in." + Sign in again
            else Initiation accepted
                API-->>Page: {url} + __Host-FLEETSSOSESSIONID handshake cookie
                Page-->>User: "Redirecting to your organization's sign-in page..."
                Page->>IdP: window.location.href = url<br/>AuthnRequest, RelayState = fleet_desktop
                User->>IdP: authenticates (password, MFA push, hardware token)
                IdP->>API: POST /mdm/sso/callback<br/>SAMLResponse + RelayState echoed back

                alt Handshake session already gone (expired, or cookie missing)
                    Note over API: the session held both the initiator and the<br/>return URL, so only RelayState is left to switch on
                    API-->>Page: 303 /device/sso-error?reason=session_expired
                    Page-->>User: "Your sign-in session expired."
                else Session loaded, but the assertion did not verify
                    Note over API: the failure path discards the session's contents,<br/>so RelayState still does the routing here
                    API-->>Page: 303 /device/sso-error?reason=error
                    Page-->>User: "Couldn't finish signing in."
                else Session loaded, but no device session could be minted
                    Note over API: SSO disabled mid-flow, or host gone
                    API-->>Page: 303 /device/{token}?sso_error=sso_disabled|server_error
                    Note over Page: sso_error suppresses auto-initiate,<br/>otherwise this loops forever
                    Page-->>User: "Couldn't sign in." + Sign in again
                else Success
                    API-->>Page: 303 /device/{token}<br/>+ __Host-FLEET_DESKTOP_SESSION cookie
                    Page->>API: GET /device/{token} (token + session cookie)
                    API-->>Page: 200
                    Page-->>User: renders normally
                end
            end
            end
        else Attempt already recorded, flag unreadable, or sso_error / setup_only in the URL
            Note over Page: loop guard -- one automatic trip per token, the rest are<br/>the end user's to make. setup_only is defense in depth:<br/>the server already exempts Setup Experience calls
            Page-->>User: "Couldn't sign in." + Sign in again
        end
    end
```
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Fleet Desktop SSO initiation with secure relay-state handling.
  * Added automatic SSO recovery when device access requires authentication.
  * Added retryable “Sign in again” actions for failed SSO attempts.
  * Added dedicated device SSO error pages with session-expired and callback-failure guidance.
  * Improved redirects so device-originated SSO failures return to the appropriate device-facing page.

* **Bug Fixes**
  * Prevented repeated automatic SSO redirects and preserved existing behavior for unrelated authentication errors.
  * Ensured sensitive device tokens are excluded from identity-provider URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->