### PR TITLE
Flag setup-experience software installs as Fleet-initiated (#51622)

### DIFF
--- a/changes/51622-setup-experience-installs-fleet-initiated.md
+++ b/changes/51622-setup-experience-installs-fleet-initiated.md
@@ -1,0 +1,1 @@
+- Fixed software that Fleet installs during the setup experience being attributed to a user instead of to Fleet in the host's upcoming and past activities.

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -1390,10 +1390,12 @@ type HostSoftwareInstallOptions struct {
 }
 
 // IsFleetInitiated returns true if the software install is initiated by Fleet.
-// Software installs initiated via a policy are fleet-initiated (and we also
-// make sure SelfService is false, as this case is always user-initiated).
+// Policy automations, iOS/iPadOS scheduled updates and the setup experience are
+// all enqueued by Fleet rather than by a person, so all three are
+// fleet-initiated (and we also make sure SelfService is false, as this case is
+// always user-initiated).
 func (o HostSoftwareInstallOptions) IsFleetInitiated() bool {
-	return !o.SelfService && (o.PolicyID != nil || o.ForScheduledUpdates)
+	return !o.SelfService && (o.PolicyID != nil || o.ForScheduledUpdates || o.ForSetupExperience)
 }
 
 // Priority returns the upcoming activities queue priority to use for this

--- a/server/fleet/software_installer_test.go
+++ b/server/fleet/software_installer_test.go
@@ -475,3 +475,77 @@ func TestValidateTitlePackages(t *testing.T) {
 		})
 	}
 }
+
+func TestHostSoftwareInstallOptionsIsFleetInitiated(t *testing.T) {
+	// PolicyID, ForScheduledUpdates and ForSetupExperience are the three
+	// fleet-driven entry points, and every call site that sets one of them also
+	// sets SelfService: false.
+	//
+	// UserID is independent of all three: InsertSoftwareInstallRequest writes
+	// user_id and fleet_initiated as separate columns, so an install can carry
+	// an explicit user and still be Fleet-initiated. Only SelfService takes an
+	// install back out of the fleet-initiated set.
+	cases := []struct {
+		name string
+		opts HostSoftwareInstallOptions
+		want bool
+	}{
+		{
+			name: "host details install by an admin",
+			opts: HostSoftwareInstallOptions{},
+			want: false,
+		},
+		{
+			name: "self-service install by the end user",
+			opts: HostSoftwareInstallOptions{SelfService: true},
+			want: false,
+		},
+		{
+			name: "policy automation",
+			opts: HostSoftwareInstallOptions{PolicyID: ptr.Uint(1)},
+			want: true,
+		},
+		{
+			name: "iOS/iPadOS scheduled update",
+			opts: HostSoftwareInstallOptions{ForScheduledUpdates: true},
+			want: true,
+		},
+		{
+			name: "setup experience",
+			opts: HostSoftwareInstallOptions{ForSetupExperience: true},
+			want: true,
+		},
+		{
+			name: "setup experience install retried with an explicit user id",
+			opts: HostSoftwareInstallOptions{ForSetupExperience: true, UserID: ptr.Uint(2), WithRetries: true},
+			want: true,
+		},
+		{
+			name: "self-service wins over every fleet-driven flag",
+			opts: HostSoftwareInstallOptions{
+				SelfService:         true,
+				PolicyID:            ptr.Uint(1),
+				ForScheduledUpdates: true,
+				ForSetupExperience:  true,
+			},
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, tc.opts.IsFleetInitiated())
+		})
+	}
+
+	// Priority() reads ForSetupExperience on its own; IsFleetInitiated() reads it
+	// and also excludes self-service. So the two agree on a setup-experience
+	// install Fleet enqueues, and diverge on a self-service one -- which is
+	// intended: it keeps its place in the queue and still renders under the user.
+	setupExp := HostSoftwareInstallOptions{ForSetupExperience: true}
+	require.Equal(t, 100, setupExp.Priority())
+	require.True(t, setupExp.IsFleetInitiated())
+
+	selfServiceSetupExp := HostSoftwareInstallOptions{ForSetupExperience: true, SelfService: true}
+	require.Equal(t, 100, selfServiceSetupExp.Priority())
+	require.False(t, selfServiceSetupExp.IsFleetInitiated())
+}


### PR DESCRIPTION
Fixes #51622.

@MagnusHJensen diagnosed this one down to the line and wrote the patch in the
issue; this is that patch, plus the two things it needed before it could be
merged safely — an audit of what else the flag touches, and a test that fails
without it.

### The defect

`HostSoftwareInstallOptions.IsFleetInitiated()` returned `false` for installs
enqueued by the setup experience, so the row written to `upcoming_activities`
carried `fleet_initiated = 0`. The actor name comes off that column:

```sql
IF(ua.fleet_initiated, 'Fleet', COALESCE(u.name, ua.payload->>'$.user.name')) AS name
```

A setup-experience install has no user on either side of that `COALESCE` — it
is enqueued by the server, not by a person — so the activity rendered with no
actor rather than with "Fleet". That is the wording in the screenshot on the
issue.

### Why `ForSetupExperience` is unambiguously Fleet-initiated

Every call site that sets it also sets `SelfService: false` and attaches no
user:

| Call site | What enqueues it |
|---|---|
| `ee/server/service/setup_experience.go:338` | un-gated setup-experience installer item |
| `ee/server/service/setup_experience.go:368` | setup-experience VPP app |
| `ee/server/service/setup_experience.go:587` | `enqueueSetupExperienceSoftwareInstall` (policy-gated item, after the gate passes) |
| `ee/server/service/software_installers.go:1991` | `InstallInHouseAppForSetupExperience` (`.ipa`) |
| `server/worker/apple_mdm.go:657` | setup-experience VPP app from the Apple MDM worker |

The `!o.SelfService` guard is untouched, so nothing a user starts can be
reattributed to Fleet.

### Blast radius

`IsFleetInitiated()` has exactly three consumers, all of them supplying the
`fleet_initiated` column on the `upcoming_activities` insert:
`server/datastore/mysql/software_installers.go:1988`,
`server/datastore/mysql/in_house_apps.go:603` and
`server/datastore/mysql/vpp.go:1194`. No signature changed and nothing else
reads the method.

I checked the existing `require.False(..., FleetInitiated)` assertions in
`server/service/integration_enterprise_test.go` (~16860, ~16892, ~16921)
before touching this: all three are self-service installs, which the
`!o.SelfService` guard keeps at `false`. They are unaffected.

### Verification

Go toolchain 1.26.6. Exit codes read by redirecting to a file and echoing
`$?` on its own line, not through a pipe:

```
gofmt -l (both changed files)                    no output
go vet ./server/fleet/                           rc=0
go test ./server/fleet/                          rc=0   ok, 1.840s
go build ./server/... ./ee/server/...            rc=0
```

**Negative control.** With only the one-line change reverted and the test kept,
the failures are exactly the setup-experience rows and nothing else:

```
--- FAIL: .../setup_experience
--- FAIL: .../setup_experience_install_retried_with_an_explicit_user_id
    (and the Priority()/IsFleetInitiated() consistency assertion)
```

The other five rows — admin install, self-service, policy automation,
scheduled update, and self-service-beats-every-flag — pass both ways. Rows
that pass either way are what shows the change is scoped rather than broad.

I have **not** run the MySQL-backed datastore or integration suites; they need
a live MySQL and Redis that I do not have here. Everything above is what I
actually ran, and CI is the first run of those suites for this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Setup Experience software installations are now treated as Fleet-initiated when they aren’t self-service.
  * These installations receive the appropriate high priority, while self-service installations remain excluded.

* **Tests**
  * Added coverage for installation sources, retries, precedence rules, Setup Experience behavior, self-service exclusions, and priority assignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->