### PR TITLE
Retry ER_NEED_REPREPARE in the Windows MDM response backfill (#51707)

### DIFF
--- a/changes/51707-retry-need-reprepare-in-windows-mdm-response-backfill.md
+++ b/changes/51707-retry-need-reprepare-in-windows-mdm-response-backfill.md
@@ -1,0 +1,1 @@
+- Fixed an upgrade to 4.89.x aborting with `Error 1615 (HY000): Prepared statement needs to be re-prepared` while backfilling `windows_mdm_responses.raw_response_gz`. MySQL documents 1615 as the client's to re-execute, and it leaves the migration's transaction open, so the statement is now retried in place instead of failing the migration.

--- a/server/datastore/mysql/migrations/tables/20260626120000_CompressWindowsMDMResponsesColumn.go
+++ b/server/datastore/mysql/migrations/tables/20260626120000_CompressWindowsMDMResponsesColumn.go
@@ -28,7 +28,9 @@ func Up_20260626120000(tx *sql.Tx) error {
 		backfill := incrementalMigrationStep(
 			func(tx *sql.Tx) (uint64, error) {
 				var total uint64
-				err := tx.QueryRow(`SELECT COUNT(*) FROM windows_mdm_responses WHERE raw_response_gz IS NULL`).Scan(&total)
+				err := retryOnNeedReprepare(func() error {
+					return tx.QueryRow(`SELECT COUNT(*) FROM windows_mdm_responses WHERE raw_response_gz IS NULL`).Scan(&total)
+				})
 				return total, err
 			},
 			backfillWindowsMDMResponsesGz,
@@ -77,10 +79,21 @@ func backfillWindowsMDMResponsesGz(tx *sql.Tx, increment incrementCountFn) error
 			ID          uint64 `db:"id"`
 			RawResponse []byte `db:"raw_response"`
 		}
-		if err := txx.Select(&batch,
-			`SELECT id, raw_response FROM windows_mdm_responses
+		// Both statements in this loop run against windows_mdm_responses, whose
+		// metadata this very migration has just altered, so either can come back
+		// with ER_NEED_REPREPARE (#51707). Neither aborts the transaction, so both
+		// are re-executed in place rather than failing the upgrade.
+		if err := retryOnNeedReprepare(func() error {
+			// sqlx.Select appends, so a retry must not build on whatever the
+			// previous attempt left behind. ER_NEED_REPREPARE is raised before any
+			// row comes back, so today this only ever resets an empty slice; it is
+			// here so the closure stays safe to re-run if the retry set widens.
+			batch = batch[:0]
+			return txx.Select(&batch,
+				`SELECT id, raw_response FROM windows_mdm_responses
 			 WHERE id > ? AND raw_response_gz IS NULL
-			 ORDER BY id LIMIT ?`, lastID, batchSize); err != nil {
+			 ORDER BY id LIMIT ?`, lastID, batchSize)
+		}); err != nil {
 			return fmt.Errorf("selecting batch starting after id %d: %w", lastID, err)
 		}
 		if len(batch) == 0 {
@@ -96,7 +109,10 @@ func backfillWindowsMDMResponsesGz(tx *sql.Tx, increment incrementCountFn) error
 			if err := gw.Close(); err != nil {
 				return fmt.Errorf("closing gzip writer for response id %d: %w", row.ID, err)
 			}
-			if _, err := txx.Exec(`UPDATE windows_mdm_responses SET raw_response_gz = ? WHERE id = ?`, buf.Bytes(), row.ID); err != nil {
+			if err := retryOnNeedReprepare(func() error {
+				_, err := txx.Exec(`UPDATE windows_mdm_responses SET raw_response_gz = ? WHERE id = ?`, buf.Bytes(), row.ID)
+				return err
+			}); err != nil {
 				return fmt.Errorf("storing compressed response id %d: %w", row.ID, err)
 			}
 			increment()

--- a/server/datastore/mysql/migrations/tables/20260626120000_CompressWindowsMDMResponsesColumn_reprepare_test.go
+++ b/server/datastore/mysql/migrations/tables/20260626120000_CompressWindowsMDMResponsesColumn_reprepare_test.go
@@ -1,0 +1,133 @@
+package tables
+
+import (
+	"bytes"
+	"compress/gzip"
+	"database/sql/driver"
+	"io"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/VividCortex/mysqlerr"
+	"github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+)
+
+func deadlock() error {
+	return &mysql.MySQLError{Number: mysqlerr.ER_LOCK_DEADLOCK, Message: "Deadlock found when trying to get lock"}
+}
+
+// gzipOf matches a bound argument that gunzips to want, so the retried UPDATE is
+// checked for the right payload rather than just for having happened.
+type gzipOf struct {
+	t    *testing.T
+	want string
+}
+
+func (g gzipOf) Match(v driver.Value) bool {
+	b, ok := v.([]byte)
+	if !ok {
+		return false
+	}
+	zr, err := gzip.NewReader(bytes.NewReader(b))
+	if err != nil {
+		return false
+	}
+	defer zr.Close()
+	out, err := io.ReadAll(zr)
+	if err != nil {
+		return false
+	}
+	return string(out) == g.want
+}
+
+// TestBackfillWindowsMDMResponsesGzRetriesReprepare drives the real backfill
+// through sqlmock to prove the wiring, not just retryOnNeedReprepare in
+// isolation: an ER_NEED_REPREPARE on the reported statement ("storing
+// compressed response id ...", #51707) must be re-executed rather than abort
+// the upgrade, and the row must still end up compressed exactly once.
+func TestBackfillWindowsMDMResponsesGzRetriesReprepare(t *testing.T) {
+	shrinkReprepareBackoff(t)
+
+	const raw = "<SyncML><SyncBody><Status><Data>200</Data></Status></SyncBody></SyncML>"
+
+	batchRows := func() *sqlmock.Rows {
+		return sqlmock.NewRows([]string{"id", "raw_response"}).AddRow(int64(1), []byte(raw))
+	}
+	noRows := func() *sqlmock.Rows {
+		return sqlmock.NewRows([]string{"id", "raw_response"})
+	}
+
+	t.Run("the reported update is retried and the walk completes", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		mock.ExpectBegin()
+		mock.ExpectQuery("SELECT id, raw_response FROM windows_mdm_responses").WillReturnRows(batchRows())
+		mock.ExpectExec("UPDATE windows_mdm_responses SET raw_response_gz").
+			WithArgs(gzipOf{t, raw}, int64(1)).
+			WillReturnError(needReprepare())
+		mock.ExpectExec("UPDATE windows_mdm_responses SET raw_response_gz").
+			WithArgs(gzipOf{t, raw}, int64(1)).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+		// The walk moves past id 1 and stops on the empty batch.
+		mock.ExpectQuery("SELECT id, raw_response FROM windows_mdm_responses").WillReturnRows(noRows())
+
+		tx, err := db.Begin()
+		require.NoError(t, err)
+
+		increments := 0
+		require.NoError(t, backfillWindowsMDMResponsesGz(tx, func() { increments++ }))
+
+		require.NoError(t, mock.ExpectationsWereMet())
+		// The retry must not double-count the row it re-stored.
+		require.Equal(t, 1, increments)
+	})
+
+	t.Run("the batch select is retried too", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		mock.ExpectBegin()
+		mock.ExpectQuery("SELECT id, raw_response FROM windows_mdm_responses").WillReturnError(needReprepare())
+		mock.ExpectQuery("SELECT id, raw_response FROM windows_mdm_responses").WillReturnRows(batchRows())
+		mock.ExpectExec("UPDATE windows_mdm_responses SET raw_response_gz").WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectQuery("SELECT id, raw_response FROM windows_mdm_responses").WillReturnRows(noRows())
+
+		tx, err := db.Begin()
+		require.NoError(t, err)
+
+		increments := 0
+		require.NoError(t, backfillWindowsMDMResponsesGz(tx, func() { increments++ }))
+
+		require.NoError(t, mock.ExpectationsWereMet())
+		// The re-read batch is processed once. Note this does not exercise the
+		// batch = batch[:0] reset: a 1615 arrives before any row does, so the
+		// first attempt appends nothing. The reset is there for re-runnability,
+		// not for this path.
+		require.Equal(t, 1, increments)
+	})
+
+	// The negative control for the scope: an error the migration cannot retry in
+	// place must still abort, with the original message intact.
+	t.Run("a non-reprepare error still aborts", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		mock.ExpectBegin()
+		mock.ExpectQuery("SELECT id, raw_response FROM windows_mdm_responses").WillReturnRows(batchRows())
+		mock.ExpectExec("UPDATE windows_mdm_responses SET raw_response_gz").WillReturnError(deadlock())
+
+		tx, err := db.Begin()
+		require.NoError(t, err)
+
+		err = backfillWindowsMDMResponsesGz(tx, func() {})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "storing compressed response id 1")
+		require.Contains(t, err.Error(), "Deadlock found")
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+}

--- a/server/datastore/mysql/migrations/tables/retry.go
+++ b/server/datastore/mysql/migrations/tables/retry.go
@@ -1,0 +1,70 @@
+package tables
+
+import (
+	"errors"
+	"time"
+
+	"github.com/VividCortex/mysqlerr"
+	"github.com/cenkalti/backoff/v4"
+	"github.com/go-sql-driver/mysql"
+)
+
+// These bound how long a single statement will keep re-executing on
+// ER_NEED_REPREPARE. A reprepare normally succeeds on the first retry, so they
+// are deliberately much tighter than the one minute
+// platform/mysql.WithRetryTxx allows for lock contention: a migration holds its
+// transaction open for as long as it runs, and an upgrade that hangs is worse
+// than one that reports a clear error.
+//
+// can override in tests
+var (
+	reprepareMaxRetries      uint64 = 5
+	reprepareMaxElapsed             = 30 * time.Second
+	reprepareInitialInterval        = backoff.DefaultInitialInterval
+)
+
+// isNeedReprepare reports whether err is, or wraps, MySQL's ER_NEED_REPREPARE
+// (1615, "Prepared statement needs to be re-prepared").
+func isNeedReprepare(err error) bool {
+	var mysqlErr *mysql.MySQLError
+	if !errors.As(err, &mysqlErr) {
+		return false
+	}
+	return mysqlErr.Number == mysqlerr.ER_NEED_REPREPARE
+}
+
+// retryOnNeedReprepare re-runs fn, with exponential backoff, for as long as it
+// returns ER_NEED_REPREPARE. Any other error, including nil, is returned as-is
+// on the first attempt.
+//
+// A migration runs inside one transaction that goose owns, so it cannot use
+// platform/mysql.WithRetryTxx: that helper retries by rolling the transaction
+// back and beginning a new one, which from inside a migration would throw away
+// the work the migration has already done. The errors WithRetryTxx covers need
+// exactly that treatment -- ER_LOCK_DEADLOCK, for one, is only ever delivered
+// to the client after InnoDB has already rolled the transaction back, so there
+// is nothing left to retry in place.
+//
+// ER_NEED_REPREPARE is the exception, and it is why this helper is narrow
+// rather than a second copy of RetryableError. It means the table metadata a
+// prepared statement was built against changed and the server used up its
+// automatic reprepare attempts; the statement never ran, and the transaction is
+// still open and usable. MySQL documents it as the client's job to re-execute.
+// That makes it the one error a migration can retry where it stands.
+//
+// Callers must therefore keep fn a single statement, or at least idempotent
+// within the transaction: it can run more than once.
+func retryOnNeedReprepare(fn func() error) error {
+	operation := func() error {
+		err := fn()
+		if err != nil && !isNeedReprepare(err) {
+			return backoff.Permanent(err)
+		}
+		return err
+	}
+
+	expBo := backoff.NewExponentialBackOff()
+	expBo.InitialInterval = reprepareInitialInterval
+	expBo.MaxElapsedTime = reprepareMaxElapsed
+	return backoff.Retry(operation, backoff.WithMaxRetries(expBo, reprepareMaxRetries))
+}

--- a/server/datastore/mysql/migrations/tables/retry_test.go
+++ b/server/datastore/mysql/migrations/tables/retry_test.go
@@ -1,0 +1,103 @@
+package tables
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/VividCortex/mysqlerr"
+	"github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+)
+
+func needReprepare() error {
+	return &mysql.MySQLError{Number: mysqlerr.ER_NEED_REPREPARE, Message: "Prepared statement needs to be re-prepared"}
+}
+
+// shrinkReprepareBackoff keeps the retry tests to real backoff arithmetic
+// without the wall-clock waits, the same way progressInterval is overridden for
+// the migration-step tests.
+func shrinkReprepareBackoff(t *testing.T) {
+	t.Helper()
+	original := reprepareInitialInterval
+	reprepareInitialInterval = time.Millisecond
+	t.Cleanup(func() { reprepareInitialInterval = original })
+}
+
+func TestRetryOnNeedReprepare(t *testing.T) {
+	shrinkReprepareBackoff(t)
+
+	t.Run("success runs once", func(t *testing.T) {
+		calls := 0
+		require.NoError(t, retryOnNeedReprepare(func() error {
+			calls++
+			return nil
+		}))
+		require.Equal(t, 1, calls)
+	})
+
+	t.Run("reprepare then success", func(t *testing.T) {
+		calls := 0
+		require.NoError(t, retryOnNeedReprepare(func() error {
+			calls++
+			if calls == 1 {
+				return needReprepare()
+			}
+			return nil
+		}))
+		require.Equal(t, 2, calls)
+	})
+
+	t.Run("wrapped reprepare is still recognised", func(t *testing.T) {
+		calls := 0
+		require.NoError(t, retryOnNeedReprepare(func() error {
+			calls++
+			if calls == 1 {
+				return fmt.Errorf("storing compressed response id 7: %w", needReprepare())
+			}
+			return nil
+		}))
+		require.Equal(t, 2, calls)
+	})
+
+	t.Run("persistent reprepare gives up and returns the error", func(t *testing.T) {
+		calls := 0
+		err := retryOnNeedReprepare(func() error {
+			calls++
+			return needReprepare()
+		})
+		require.Error(t, err)
+		require.True(t, isNeedReprepare(err), "the caller must still see the MySQL error, not a backoff wrapper")
+		// One initial attempt plus reprepareMaxRetries retries, and no more:
+		// a migration that hangs is worse than one that reports a clear error.
+		require.Equal(t, int(1+reprepareMaxRetries), calls)
+	})
+
+	// The negative control for the narrow scope. Deadlock is retryable for
+	// platform/mysql.WithRetryTxx, which restarts the whole transaction. Inside a
+	// migration the transaction is already gone by the time the client sees it,
+	// so retrying in place would only fail again, more slowly.
+	t.Run("other mysql errors are not retried", func(t *testing.T) {
+		for _, number := range []uint16{mysqlerr.ER_LOCK_DEADLOCK, mysqlerr.ER_LOCK_WAIT_TIMEOUT, mysqlerr.ER_DUP_ENTRY} {
+			calls := 0
+			err := retryOnNeedReprepare(func() error {
+				calls++
+				return &mysql.MySQLError{Number: number}
+			})
+			require.Error(t, err)
+			require.Equal(t, 1, calls, "error %d must not be retried in place", number)
+		}
+	})
+
+	t.Run("non-mysql errors are not retried", func(t *testing.T) {
+		sentinel := errors.New("context canceled")
+		calls := 0
+		err := retryOnNeedReprepare(func() error {
+			calls++
+			return sentinel
+		})
+		require.ErrorIs(t, err, sentinel)
+		require.Equal(t, 1, calls)
+	})
+}


### PR DESCRIPTION
Fixes #51707.

### The failure

Upgrading to 4.89.x aborts on the first 4.89.x migration:

```
FAIL 20260626120000_CompressWindowsMDMResponsesColumn.go (backfilling raw_response_gz:
storing compressed response id <ID>: Error 1615 (HY000): Prepared statement needs to be
re-prepared), quitting migration.
```

### Why #51665 does not cover it

#51665 taught `platform/mysql.RetryableError` about `ER_NEED_REPREPARE`, which fixes every caller that goes through `WithRetryTxx`. A migration is not one of those callers, and — as the issue says — it cannot become one. `goose` owns the migration's transaction, and `WithRetryTxx` retries by rolling that transaction back and beginning a new one. From inside a migration that would discard the work the migration has already done.

### What this does instead

A narrow helper in the `tables` package, `retryOnNeedReprepare`, that re-runs a single statement **in place**, inside the transaction the migration is already holding.

That is safe for 1615 and, I would argue, only for 1615. The statement never ran and the transaction is still open and usable, which is exactly why MySQL documents re-executing as the client's job. The other errors `RetryableError` returns true for genuinely need a fresh transaction — `ER_LOCK_DEADLOCK` is only ever delivered to the client *after* InnoDB has already rolled the transaction back — so retrying those where they stand would just fail again, more slowly. **The helper therefore refuses them, and a test pins that**, so this cannot quietly drift into being a second copy of `RetryableError`.

Bounds are deliberately tighter than `WithRetryTxx`'s one minute: 5 retries / 30s max elapsed. A reprepare normally succeeds on the first retry, and an upgrade that hangs is worse than one that reports a clear error.

### Which statements are wrapped

All three the backfill runs against `windows_mdm_responses`:

| statement | why |
| --- | --- |
| `SELECT COUNT(*) ... WHERE raw_response_gz IS NULL` | sizes the progress bar |
| the batch `SELECT id, raw_response ...` | walks the table |
| `UPDATE ... SET raw_response_gz = ?` | **the one named in the report** |

Fixing only the `UPDATE` would leave the bug half-fixed: all three are prepared statements against a table this same migration has just altered with `ADD COLUMN`, which is precisely the metadata change that invalidates them.

The `ALTER`/`DROP`/`MODIFY` statements around the backfill are deliberately **not** wrapped — DDL is not executed as a prepared statement here, and those are the operations that *cause* 1615 elsewhere rather than suffering it.

### Testing

`server/datastore/mysql/migrations/tables/retry_test.go` covers the helper, and a second file drives the **real** `backfillWindowsMDMResponsesGz` through `sqlmock` so the wiring is tested and not just the helper:

- the reported `UPDATE` returns 1615, is re-executed, and the walk completes — with a `sqlmock` argument matcher asserting the retried write still gunzips back to the original envelope, and the progress counter still incrementing exactly once
- the batch `SELECT` returns 1615 and is re-issued
- **negative control:** `ER_LOCK_DEADLOCK` on the same `UPDATE` still aborts, with `storing compressed response id 1` and `Deadlock found` both intact in the error

Measured negative control on the fix itself: unwrapping the `UPDATE` fails `the reported update is retried and the walk completes` and nothing else in the package moves. Restored, `go test` rc=0 (`ok`, 0.044s), `go vet` rc=0, `gofmt` clean, `go build ./server/... ./cmd/...` rc=0 on go1.26.7.

The backoff interval is overridable in tests the same way `progressInterval` already is, so these run in ~20ms rather than burning real backoff.

### What I could not verify here

**I have no MySQL instance, so I could not run the DB-backed migration tests** — `TestUp_20260626120000` and the other 44 in that package all fail locally with `dial tcp [::1]:3307: connect: connection refused`, including migrations this branch does not touch. The tests I added are `sqlmock`-only by necessity and run green. I also have not reproduced the original 1615 with the `FLUSH TABLES` loop from #51665. If CI or a reviewer turns up anything red, I will fix it free and same-day.

### One judgement call worth flagging

The issue says Fleet should "retry it in the migration loop". I read that as the loop *inside* the migration, which is what this does. If you would rather have the retry at the runner level — `goose` re-running a whole failed migration — say so and I will rewrite it that way; this migration is already resumable (the `raw_response_gz IS NULL` filter), so that shape is available, but it is a much larger blast radius for the same bug and I did not want to assume it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Windows MDM response migration when MySQL requests statement re-preparation.
  * Automatically retries eligible database operations without losing migration progress.
  * Preserves existing error handling for unrelated database failures.

* **Tests**
  * Added coverage for successful retries, retry exhaustion, wrapped errors, and non-retryable failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->