### PR TITLE
Treat a bare $FLEET_SECRET_ as text, not a variable reference

### DIFF
--- a/changes/46992-bare-fleet-secret-prefix
+++ b/changes/46992-bare-fleet-secret-prefix
@@ -1,0 +1,1 @@
+* Fixed `fleetctl gitops` failing with `environment variable "FLEET_SECRET_" not set` when a profile or script mentions the bare `$FLEET_SECRET_` prefix in a comment. A token that is only the prefix names no variable, so it is now left as literal text instead of being looked up, and it no longer appears as an unnamed entry in the set of secrets a document embeds.

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -352,6 +352,12 @@ func expandEnv(s string, secretMode secretHandling) (string, error) {
 		switch {
 		case strings.HasPrefix(env, preventEscapingPrefix):
 			return "$" + strings.TrimPrefix(env, preventEscapingPrefix), true
+		case env == fleet.ServerSecretPrefix:
+			// A bare "$FLEET_SECRET_" names no secret, so it is documentation prose
+			// rather than a reference. Expansion runs over the whole file and has no
+			// notion of comments, so this must be left untouched here: rejecting it
+			// fails a gitops run over a sentence, and there is nothing to expand.
+			return "", false
 		case strings.HasPrefix(strings.ToUpper(env), fleet.ServerVarPrefix):
 			// Don't expand fleet vars -- they will be expanded on the server
 			return "", false
@@ -459,7 +465,9 @@ func LookupEnvSecrets(s string, secretsMap map[string]string) error {
 
 	var err *multierror.Error
 	_ = fleet.MaybeExpand(s, func(env string, startPos, endPos int) (string, bool) {
-		if strings.HasPrefix(env, fleet.ServerSecretPrefix) {
+		// env == ServerSecretPrefix is a bare "$FLEET_SECRET_" with an empty name
+		// after the prefix — prose, not a reference. See ContainsPrefixVars.
+		if strings.HasPrefix(env, fleet.ServerSecretPrefix) && env != fleet.ServerSecretPrefix {
 			// lookup the secret and save it, but don't replace
 			v, ok := lookupEnv(env)
 			if !ok {

--- a/pkg/spec/spec_test.go
+++ b/pkg/spec/spec_test.go
@@ -190,6 +190,15 @@ func TestExpandEnv(t *testing.T) {
 		{map[string]string{"foo": "", "$": "2"}, `${$}${foo}var`, `2var`, nil},
 		{map[string]string{}, `${foo}var`, ``, checkMultiErrors(t, `environment variable "foo" not set; if you intended the literal string ${foo} then please escape it as \${foo}.`)},
 		{map[string]string{}, `foo PREVENT_ESCAPING_bar $ FLEET_VAR_`, `foo PREVENT_ESCAPING_bar $ FLEET_VAR_`, nil}, // nothing to replace
+		// A bare "$FLEET_SECRET_" is prose, not a misplaced secret reference: it is
+		// left alone rather than rejected as "only allowed in profiles and scripts".
+		{map[string]string{}, `# $FLEET_SECRET_ is the prefix`, `# $FLEET_SECRET_ is the prefix`, nil},
+		{map[string]string{}, `${FLEET_SECRET_}`, `${FLEET_SECRET_}`, nil},
+		{
+			map[string]string{},
+			`$FLEET_SECRET_ but $FLEET_SECRET_REAL is a reference`, ``,
+			checkMultiErrors(t, `environment variables with "FLEET_SECRET_" prefix are only allowed in profiles and scripts: "FLEET_SECRET_REAL"`),
+		},
 		{
 			map[string]string{"foo": "BAR"},
 			`\$FLEET_VAR_$foo \${FLEET_VAR_$foo} \${FLEET_VAR_${foo}2}`,
@@ -240,6 +249,15 @@ func TestLookupEnvSecrets(t *testing.T) {
 			checkMultiErrors(t, "environment variable \"FLEET_SECRET_foo\" not set"),
 		},
 		{map[string]string{"FLEET_SECRET_foo": "test&123"}, `<Add>$FLEET_SECRET_foo</Add>`, map[string]string{"FLEET_SECRET_foo": "test&123"}, nil},
+		// A bare "$FLEET_SECRET_" names no secret and must not be looked up.
+		{map[string]string{}, `$FLEET_SECRET_`, map[string]string{}, nil},
+		{map[string]string{}, `${FLEET_SECRET_}`, map[string]string{}, nil},
+		{
+			map[string]string{"FLEET_SECRET_foo": "1"},
+			"<!-- $FLEET_SECRET_ is the prefix -->\n<Data>$FLEET_SECRET_foo</Data>",
+			map[string]string{"FLEET_SECRET_foo": "1"},
+			nil,
+		},
 	} {
 		// save the current env before clearing it.
 		testutils.SaveEnv(t)
@@ -256,6 +274,36 @@ func TestLookupEnvSecrets(t *testing.T) {
 		}
 		require.Equal(t, tc.expResult, secretsMap)
 	}
+}
+
+// TestBareSecretPrefixInComment walks the three functions a `fleetctl gitops` run
+// applies to a profile, in the order server/service/client.go applies them, over a
+// document that mentions the secret prefix in a comment and uses a real, registered
+// secret in the same file. Before the fix LookupEnvSecrets rejected the run with
+// `environment variable "FLEET_SECRET_" not set` and ContainsPrefixVars reported an
+// unnamed secret alongside the real one.
+func TestBareSecretPrefixInComment(t *testing.T) {
+	const doc = `<!-- Delivered via $FLEET_SECRET_ (registered via gitops, kept out of git). -->
+<Data>$FLEET_SECRET_MY_REAL_SECRET</Data>`
+
+	testutils.SaveEnv(t)
+	os.Clearenv()
+	require.NoError(t, os.Setenv("FLEET_SECRET_MY_REAL_SECRET", "s3kr1t"))
+
+	// 1. Secrets are collected from the raw file. The comment is not a reference.
+	secretsMap := make(map[string]string)
+	require.NoError(t, LookupEnvSecrets(doc, secretsMap))
+	require.Equal(t, map[string]string{"FLEET_SECRET_MY_REAL_SECRET": "s3kr1t"}, secretsMap)
+
+	// 2. Non-secret expansion runs over the whole file and leaves both alone.
+	expanded, err := ExpandEnvBytesIgnoreSecrets([]byte(doc))
+	require.NoError(t, err)
+	require.Equal(t, doc, string(expanded))
+
+	// 3. The set of secrets the server is asked to resolve carries no empty name.
+	require.Equal(t,
+		[]string{"MY_REAL_SECRET"},
+		fleet.ContainsPrefixVars(string(expanded), fleet.ServerSecretPrefix))
 }
 
 // TestExpandEnvBytesIncludingSecrets tests that FLEET_SECRET_ variables are expanded when using ExpandEnvBytesIncludingSecrets

--- a/server/fleet/fleet_vars.go
+++ b/server/fleet/fleet_vars.go
@@ -12,9 +12,20 @@ const (
 // ContainsPrefixVars scans a string for variables in the form of $VAR
 // and ${VAR} that begin with prefix, and return an array of those
 // variables with the prefix removed.
+//
+// A token that is exactly the prefix, such as a bare "$FLEET_SECRET_" written as
+// prose in a comment, is not a reference and is skipped: getShellName stops at the
+// first non-word byte, so the name left after the prefix is empty and no secret or
+// Fleet variable can be named "". Without this, the empty name reaches callers that
+// treat the result as the set of variables a document embeds, and they then look up
+// and report a nameless one. nameTemplateSecretRegexp already encodes the same rule
+// by requiring `\w+` after the prefix.
 func ContainsPrefixVars(text, prefix string) []string {
 	vars := []string{}
 	gather := func(variable string) string {
+		if variable == prefix {
+			return ""
+		}
 		if strings.HasPrefix(variable, prefix) {
 			vars = append(vars, strings.TrimPrefix(variable, prefix))
 		}

--- a/server/fleet/fleet_vars_test.go
+++ b/server/fleet/fleet_vars_test.go
@@ -23,6 +23,65 @@ ${FLEET_SECRET_QUX}
 	require.Contains(t, secrets, "QUX")
 }
 
+// A token that is exactly the prefix names nothing: getShellName stops at the first
+// non-word byte, so "$FLEET_SECRET_ " leaves an empty name after the prefix. Callers
+// treat this result as the set of variables a document embeds and then look each one
+// up, so an empty entry becomes a nameless missing secret.
+func TestContainsPrefixVarsBarePrefix(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		text    string
+		prefix  string
+		expVars []string
+	}{
+		{
+			name:    "bare secret prefix in an XML comment is not a reference",
+			text:    "<!-- Delivered via $FLEET_SECRET_ (registered via gitops). -->\n<Data>$FLEET_SECRET_REAL</Data>",
+			prefix:  ServerSecretPrefix,
+			expVars: []string{"REAL"},
+		},
+		{
+			name:    "braced bare secret prefix is not a reference",
+			text:    "# ${FLEET_SECRET_} is the prefix\necho ${FLEET_SECRET_REAL}",
+			prefix:  ServerSecretPrefix,
+			expVars: []string{"REAL"},
+		},
+		{
+			name:    "bare secret prefix on its own yields no variables",
+			text:    "$FLEET_SECRET_ and $FLEET_SECRET_ again",
+			prefix:  ServerSecretPrefix,
+			expVars: []string{},
+		},
+		{
+			name:    "bare server var prefix is not a reference",
+			text:    "# $FLEET_VAR_ is the prefix\n$FLEET_VAR_HOST_END_USER_IDP_USERNAME",
+			prefix:  ServerVarPrefix,
+			expVars: []string{"HOST_END_USER_IDP_USERNAME"},
+		},
+		{
+			name:    "bare host secret prefix is not a reference",
+			text:    "# $FLEET_HOST_SECRET_ is the prefix\n$FLEET_HOST_SECRET_REAL",
+			prefix:  HostSecretPrefix,
+			expVars: []string{"REAL"},
+		},
+		{
+			// This row passes on unmodified main too — it pins the namespace
+			// separation the fix must not disturb, not the fix itself. Every other
+			// row above fails without the guard.
+			name:    "a named secret is not reported under the host prefix",
+			text:    "$FLEET_SECRET_REAL",
+			prefix:  HostSecretPrefix,
+			expVars: []string{},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			vars := ContainsPrefixVars(tc.text, tc.prefix)
+			require.Equal(t, tc.expVars, vars)
+			require.NotContains(t, vars, "", "an empty variable name reached the caller")
+		})
+	}
+}
+
 func TestMaybeExpand(t *testing.T) {
 	script := `
 This is $OTHER_VAR, $ $$ $* ${} in a sentence with${ALSO_OTHER_VAR}in the middle.


### PR DESCRIPTION
Fixes #46992.

## Reproduced on unmodified `main` (f3bba33), with the reported error string

```go
doc := "<!-- Delivered via $FLEET_SECRET_ (registered via gitops). -->\n<Data>$FLEET_SECRET_MY_REAL_SECRET</Data>"
os.Setenv("FLEET_SECRET_MY_REAL_SECRET", "s3kr1t")

spec.LookupEnvSecrets(doc, m)  // -> environment variable "FLEET_SECRET_" not set
fleet.ContainsPrefixVars(doc, fleet.ServerSecretPrefix)  // -> []string{"", "MY_REAL_SECRET"}
```

## One correction to the issue's own diagnosis

The report puts the root cause in `ExpandEnvBytes` / `expandEnv` (`pkg/spec/spec.go`). The
error string identifies a different function: `expandEnv`'s message carries the
`; if you intended the literal string ... escape it as \$...` hint, and the reported one
does not. The message in the issue is `LookupEnvSecrets`'s, at `pkg/spec/spec.go:466` on
`main`. `ExpandEnvBytesIgnoreSecrets` — the call a profile actually goes through — returns
no error at all here; I measured that too.

That matters for the fix: a profile that never touches `fleetctl gitops` (uploaded through
the API or the UI) passes the client silently and carries the same empty name to the server.

## Why not "skip comments"

The issue offers two directions. Skipping comment regions would need a parser per format —
`.mobileconfig`, Windows SyncML, Android/DDM JSON, shell, YAML — and expansion here is
deliberately format-agnostic; a wrong guess about where a comment ends would silently skip a
**real** secret. So this takes the second direction, at the token: `$FLEET_SECRET_` with an
empty name is not a reference in any format.

`nameTemplateSecretRegexp` (`server/fleet/name_template.go:74`) already encodes exactly that
rule with `\w+`. This applies it in the three places that did not have it.

## The half the report does not have

`ContainsPrefixVars` returning `""` is read by four subsystems as "the set of variables this
document embeds". Read from source on `main`:

| Site | What the empty name does today |
| --- | --- |
| `server/datastore/mysql/secret_variables.go:381` (`expandEmbeddedSecrets`) | asks `GetSecretVariables` for a secret named `""`, then returns `MissingSecretsError{[""]}` — a delivery-time failure naming nothing |
| `server/datastore/mysql/secret_variables.go:487` (`ValidateEmbeddedSecrets`) | same, at save time |
| `server/service/mdm.go:2658` | a dry run **excludes** the profile from validation, believing it carries secrets |
| `server/fleet/apple_profiles.go:45` | routes the profile down the secret command path it does not need |
| `server/fleet/name_template.go:142` | a name template is rejected 422 with a missing secret that has no name |

I could not run the MySQL-backed ones (see "not run" below), so those two rows are read, not
measured, and I have not claimed otherwise.

## Deliberately not changed

`server/fleet/windows_mdm.go:122` tests `bytes.Contains(m.SyncML, []byte(ServerSecretPrefix))`
and so is also true for a bare prefix — but the line above it already documents that
tolerance and its consequence, so it is a decision, not this defect. Left alone.

## Tests, and the negative control for each hunk

`server/fleet/fleet_vars_test.go` `TestContainsPrefixVarsBarePrefix`, and rows added to
`TestExpandEnv` / `TestLookupEnvSecrets` plus `TestBareSecretPrefixInComment` in
`pkg/spec/spec_test.go`, which walks the three functions in the order
`server/service/client.go` applies them to a profile.

Each hunk was reverted on its own and the suite re-run:

| Reverted | Result |
| --- | --- |
| the `ContainsPrefixVars` guard | 5 of the 6 `TestContainsPrefixVarsBarePrefix` rows fail |
| the `expandEnv` `secretsReject` case | only `TestExpandEnv` fails |
| the `LookupEnvSecrets` guard | only `TestLookupEnvSecrets` and `TestBareSecretPrefixInComment` fail |

The sixth `ContainsPrefixVars` row passes both ways and the test says so in a comment: it
pins the secret/host-secret namespace separation the change must not disturb, not the change
itself.

The `expandEnv` case is a **second surface the issue does not report** — a bare
`$FLEET_SECRET_` in the gitops YAML itself, which `secretsReject` rejects as "only allowed in
profiles and scripts". It is one function from the reported one and shares the cause; I have
flagged it rather than folded it in silently.

## Ran

`go build ./server/... ./pkg/... ./cmd/... ./ee/...` rc=0 · `go vet ./pkg/spec/ ./server/fleet/`
rc=0 · `gofmt` clean · `go test ./pkg/spec/ ./server/fleet/` rc=0 · `go test ./server/mdm/...`
green. go1.26.7.

## Not run

There is no MySQL on the machine that produced this, so nothing under
`server/datastore/mysql` was exercised — the two datastore rows in the table above are read
from source. No changes were made in `ee/`.

---

Contributed by an autonomous AI agent; no human reviewed the diff. Happy to change the shape
if you would rather have the guard inside `MaybeExpand`/`getShellName` than at the three call
sites.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Bare `$FLEET_SECRET_` prefixes in comments, prose, and placeholders are no longer treated as missing secret references.
  - Prevented unnamed secret entries from appearing during `fleetctl gitops`.
  - Valid secret variables continue to be detected, validated, and resolved correctly.
  - Similar handling now applies to other variable prefixes, avoiding empty variable names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->