### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/antinote/darwin.json
+++ b/ee/maintained-apps/outputs/antinote/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "2.0.8",
+      "version": "2.0.9",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.chabomakers.Antinote';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.chabomakers.Antinote' AND version_compare(bundle_short_version, '2.0.8') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.chabomakers.Antinote' AND version_compare(bundle_short_version, '2.0.9') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.chabomakers.Antinote');"
       },
-      "installer_url": "https://antinote.io/updates/Antinote_2.0.8.dmg",
+      "installer_url": "https://antinote.io/updates/Antinote_2.0.9.dmg",
       "install_script_ref": "3be1a226",
       "uninstall_script_ref": "2d505ef1",
-      "sha256": "d336f18bec9bf09c3f976ebd2b6220a26a373e9dd0dfbc3a6c6edea469af847e",
+      "sha256": "ed8a8990a646961e93aeba8277bb12ddb4aed1b7c46c4c5387b77a30e7bd830d",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/bettertouchtool/darwin.json
+++ b/ee/maintained-apps/outputs/bettertouchtool/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "6.747",
+      "version": "6.748",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.hegenberg.BetterTouchTool';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hegenberg.BetterTouchTool' AND version_compare(bundle_short_version, '6.747') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hegenberg.BetterTouchTool' AND version_compare(bundle_short_version, '6.748') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.hegenberg.BetterTouchTool');"
       },
-      "installer_url": "https://folivora.ai/releases/btt6.747-2026082206.zip",
+      "installer_url": "https://folivora.ai/releases/btt6.748-2026082207.zip",
       "install_script_ref": "17a00450",
       "uninstall_script_ref": "b0dc7152",
-      "sha256": "ef2d21e45793b834a6d471f45c28ffb5ff1e87dd4b22b0d838c4c121d0f92134",
+      "sha256": "1d736e396d457d73931c6b124248550223e67178f92698b706b49583f9fa366f",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/drawio/darwin.json
+++ b/ee/maintained-apps/outputs/drawio/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "31.3.1",
+      "version": "31.3.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jgraph.drawio.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jgraph.drawio.desktop' AND version_compare(bundle_short_version, '31.3.1') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jgraph.drawio.desktop' AND version_compare(bundle_short_version, '31.3.2') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.jgraph.drawio.desktop');"
       },
-      "installer_url": "https://github.com/jgraph/drawio-desktop/releases/download/v31.3.1/draw.io-arm64-31.3.1.dmg",
+      "installer_url": "https://github.com/jgraph/drawio-desktop/releases/download/v31.3.2/draw.io-arm64-31.3.2.dmg",
       "install_script_ref": "dfbabf21",
       "uninstall_script_ref": "a088fe93",
-      "sha256": "f102bb381509fb3bce4e5bd692f1a329eb2b288dffc54d0f4a01df8f45ec52dc",
+      "sha256": "b6eda7e82bc09454274c03533bce30de170dfdee278ddf5e3c966d021fa16aee",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/firefox@nightly/darwin.json
+++ b/ee/maintained-apps/outputs/firefox@nightly/darwin.json
@@ -4,13 +4,13 @@
       "version": "156.0a1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15626.8.21') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15626.8.22') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'org.mozilla.nightly');"
       },
-      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/08/2026-08-21-21-37-23-mozilla-central/firefox-156.0a1.en-US.mac.dmg",
+      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/08/2026-08-22-10-20-29-mozilla-central/firefox-156.0a1.en-US.mac.dmg",
       "install_script_ref": "d9c4cf87",
       "uninstall_script_ref": "0661f848",
-      "sha256": "8799605a81e7e262377798bb0972bab54bf99c513a0f8fc1ffbd0cccbdda4428",
+      "sha256": "20250db83e03d37bb08bbf0784e8a07503be85d3c72a41285c9237eb4fbdf778",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/netnewswire/darwin.json
+++ b/ee/maintained-apps/outputs/netnewswire/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "7.1.2",
+      "version": "7.1.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.ranchero.NetNewsWire-Evergreen';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.ranchero.NetNewsWire-Evergreen' AND version_compare(bundle_short_version, '7.1.2') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.ranchero.NetNewsWire-Evergreen' AND version_compare(bundle_short_version, '7.1.3') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.ranchero.NetNewsWire-Evergreen');"
       },
-      "installer_url": "https://github.com/Ranchero-Software/NetNewsWire/releases/download/mac-7.1.2/NetNewsWire7.1.2.zip",
+      "installer_url": "https://github.com/Ranchero-Software/NetNewsWire/releases/download/mac-7.1.3/NetNewsWire7.1.3.zip",
       "install_script_ref": "c0cd566a",
       "uninstall_script_ref": "01498874",
-      "sha256": "c6f45a4cd4c3377754ee1c112e44e27fb53f471d4d53edaac700e9f4d8ba2c1c",
+      "sha256": "b266ec3e76c118279f10a172ae740dd6feae1a69142025c44a659344c6b27367",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/notepadexe/darwin.json
+++ b/ee/maintained-apps/outputs/notepadexe/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.5.16",
+      "version": "1.5.17",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'best.swift.Notepad';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'best.swift.Notepad' AND version_compare(bundle_short_version, '1.5.16') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'best.swift.Notepad' AND version_compare(bundle_short_version, '1.5.17') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'best.swift.Notepad');"
       },
-      "installer_url": "https://github.com/notepadhq/notepadexe-public/releases/download/1.5.16/Notepad.zip",
+      "installer_url": "https://github.com/notepadhq/notepadexe-public/releases/download/1.5.17/Notepad.zip",
       "install_script_ref": "7bdbf044",
       "uninstall_script_ref": "abe56690",
-      "sha256": "b6666510d4e60cf837e3f602850e1ae43ff00c96d6203e68aa047dfbe2501488",
+      "sha256": "727b8e37abc51b846889c40f212a8c299658bf4250a70f19d98d4e982653e1fa",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/openmtp/darwin.json
+++ b/ee/maintained-apps/outputs/openmtp/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "3.2.25",
+      "version": "3.3.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'io.ganeshrvel.openmtp';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.ganeshrvel.openmtp' AND version_compare(bundle_short_version, '3.2.25') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'io.ganeshrvel.openmtp' AND version_compare(bundle_short_version, '3.3.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'io.ganeshrvel.openmtp');"
       },
-      "installer_url": "https://github.com/ganeshrvel/openmtp/releases/download/v3.2.25/openmtp-3.2.25-mac-arm64.zip",
+      "installer_url": "https://github.com/ganeshrvel/openmtp/releases/download/v3.3.0/openmtp-3.3.0-mac-arm64.zip",
       "install_script_ref": "185c2d48",
       "uninstall_script_ref": "9e24e1c9",
-      "sha256": "68f5acbe27c403943d025565ea404922a44fdead05d9708978295033267802dd",
+      "sha256": "71c8ea9a7efa0a39bf443e56f79a88c2b2068d90d614761dc27584816d1f64ee",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/telegram/windows.json
+++ b/ee/maintained-apps/outputs/telegram/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "7.1.0",
+      "version": "7.1.1",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Telegram Desktop' AND publisher = 'Telegram FZ-LLC';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Telegram Desktop' AND publisher = 'Telegram FZ-LLC' AND version_compare(version, '7.1.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Telegram Desktop' AND publisher = 'Telegram FZ-LLC' AND version_compare(version, '7.1.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'telegram.exe');"
       },
-      "installer_url": "https://github.com/telegramdesktop/tdesktop/releases/download/v7.1.0/tsetup-x64.7.1.0.exe",
+      "installer_url": "https://github.com/telegramdesktop/tdesktop/releases/download/v7.1.1/tsetup-x64.7.1.1.exe",
       "install_script_ref": "0b88a95e",
       "uninstall_script_ref": "42311f1b",
-      "sha256": "07d8b90f04889ad1f05b9ea65146a48244e59ca82932d548a72b749d3cc803ef",
+      "sha256": "a051010c3ebe29ce07d77129e4764d09e72d65dfb6a1e834fe7c9128ea208a96",
       "default_categories": [
         "Communication"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated macOS app definitions for Antinote, BetterTouchTool, draw.io, Firefox Nightly, NetNewsWire, Notepad.exe, and OpenMTP to their latest versions.
  * Updated the Windows Telegram Desktop definition to version 7.1.1.
  * Refreshed installer download links and verification checksums for all updated apps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->