### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/codexbar/darwin.json
+++ b/ee/maintained-apps/outputs/codexbar/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "0.54.0",
+      "version": "0.54.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.steipete.codexbar';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.steipete.codexbar' AND version_compare(bundle_short_version, '0.54.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.steipete.codexbar' AND version_compare(bundle_short_version, '0.54.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.steipete.codexbar');"
       },
-      "installer_url": "https://github.com/steipete/CodexBar/releases/download/v0.54.0/CodexBar-macos-universal-0.54.0.zip",
+      "installer_url": "https://github.com/steipete/CodexBar/releases/download/v0.54.1/CodexBar-macos-universal-0.54.1.zip",
       "install_script_ref": "6993c93e",
       "uninstall_script_ref": "efcab822",
-      "sha256": "8cbfa697eaa172901d86493954dbcd475062913dfb968060b9611f72a2ff1a76",
+      "sha256": "b9bd49b356b6a193d8b556302d1b31c7c4d7682ecb6347b0d73309e778fdd6ce",
       "default_categories": [
         "Utilities"
       ]

--- a/ee/maintained-apps/outputs/dax-studio/windows.json
+++ b/ee/maintained-apps/outputs/dax-studio/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "3.5.2",
+      "version": "3.6.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'DAX Studio %' AND publisher = 'DAX Studio';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'DAX Studio %' AND publisher = 'DAX Studio' AND version_compare(version, '3.5.2') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'DAX Studio %' AND publisher = 'DAX Studio' AND version_compare(version, '3.6.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'daxstudio.exe');"
       },
-      "installer_url": "https://github.com/DaxStudio/DaxStudio/releases/download/v3.5.2/DaxStudio_3_5_2_setup.exe",
+      "installer_url": "https://github.com/DaxStudio/DaxStudio/releases/download/v3.6.0/DaxStudio_3_6_0_setup.exe",
       "install_script_ref": "efa942ae",
       "uninstall_script_ref": "23e6b8df",
-      "sha256": "19745500cea14beca2aebdd48e0f09f9903f2e46e3f57eac215f33b0c8c8bae7",
+      "sha256": "61b8cef9743eccdfb3486aca5bdd6ef339e20bdd63c552d2eafb5f19a108944f",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/hive-app/darwin.json
+++ b/ee/maintained-apps/outputs/hive-app/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.2.37",
+      "version": "1.2.38",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app' AND version_compare(bundle_short_version, '1.2.37') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hive.app' AND version_compare(bundle_short_version, '1.2.38') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.hive.app');"
       },
-      "installer_url": "https://github.com/morapelker/hive/releases/download/v1.2.37/Hive-1.2.37-arm64.dmg",
+      "installer_url": "https://github.com/morapelker/hive/releases/download/v1.2.38/Hive-1.2.38-arm64.dmg",
       "install_script_ref": "3bd4ebe4",
       "uninstall_script_ref": "951b5587",
-      "sha256": "3842d7a3adffae70bd3935f50b8436415a93864d01072fd9a7a3e4ae3e264a0b",
+      "sha256": "11d5bc6fa5efb88be443426708ad20b883f1f311b08a453875e004e7b7eeae59",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/stats/darwin.json
+++ b/ee/maintained-apps/outputs/stats/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "3.0.11",
+      "version": "3.0.12",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'eu.exelban.Stats';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'eu.exelban.Stats' AND version_compare(bundle_short_version, '3.0.11') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'eu.exelban.Stats' AND version_compare(bundle_short_version, '3.0.12') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'eu.exelban.Stats');"
       },
-      "installer_url": "https://github.com/exelban/stats/releases/download/v3.0.11/Stats.dmg",
+      "installer_url": "https://github.com/exelban/stats/releases/download/v3.0.12/Stats.dmg",
       "install_script_ref": "f0bd0f4d",
       "uninstall_script_ref": "46b4651c",
-      "sha256": "a22f75a04d23e76c0404a5108f4ac9facec975460d764aae80295a63d771e05b",
+      "sha256": "683e73573d8d31e5b3b07f7e817091a2e9d63a62a6cf9a8710b3770d3c1573e8",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/tableplus/darwin.json
+++ b/ee/maintained-apps/outputs/tableplus/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "26.9.10",
+      "version": "26.9.12",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.tinyapp.TablePlus';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.tinyapp.TablePlus' AND version_compare(bundle_short_version, '26.9.10') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.tinyapp.TablePlus' AND version_compare(bundle_short_version, '26.9.12') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.tinyapp.TablePlus');"
       },
-      "installer_url": "https://files.tableplus.com/macos/768/TablePlus.dmg",
+      "installer_url": "https://files.tableplus.com/macos/770/TablePlus.dmg",
       "install_script_ref": "b7b75762",
       "uninstall_script_ref": "19abdcd7",
-      "sha256": "8c9c37957e686abb41a7d091c016b369469febcfb2539c2dd2afaec416a4e176",
+      "sha256": "36df6cec348460becd51d1bc09e2497fd995eac749c9ebe74d1a4e83ef2d6aea",
       "default_categories": [
         "Developer tools"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated CodexBar for macOS to version 0.54.1.
  * Updated DAX Studio for Windows to version 3.6.0.
  * Updated Hive for macOS to version 1.2.38.
  * Updated Stats for macOS to version 3.0.12.
  * Updated TablePlus for macOS to version 26.9.12.
  * Updated installer links and verification data to support the latest releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->