### PR TITLE
Allowing "Unassigned" to set default Windows fleet.

### DIFF
--- a/cmd/fleetctl/fleetctl/gitops.go
+++ b/cmd/fleetctl/fleetctl/gitops.go
@@ -1339,7 +1339,7 @@ func checkWindowsEnrollmentAssignment(config *spec.GitOps, fleetClient *service.
 		return "", false, nil
 	}
 	name, _ := weMap["default_fleet"].(string)
-	if name == "" {
+	if name == "" || fleet.IsUnassignedFleetName(name) {
 		return "", false, nil
 	}
 	// normalize for Unicode support

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -4711,12 +4711,13 @@ software:
 	workstations := team("💻 Workstations")
 
 	cases := []struct {
-		name             string
-		cfgs             []string
-		extraArgs        []string
-		seedTeamName     string
-		dryRunAssertion  func(t *testing.T, out string, defaultTeamID *uint, err error)
-		realRunAssertion func(t *testing.T, out string, defaultTeamID *uint, err error)
+		name              string
+		cfgs              []string
+		extraArgs         []string
+		seedTeamName      string
+		seedTeamIsDefault bool
+		dryRunAssertion   func(t *testing.T, out string, defaultTeamID *uint, err error)
+		realRunAssertion  func(t *testing.T, out string, defaultTeamID *uint, err error)
 	}{
 		{
 			name: "delete-other-fleets cannot delete the default fleet",
@@ -4787,6 +4788,28 @@ software:
 			},
 		},
 		{
+			name: "Unassigned is accepted and clears",
+			cfgs: []string{
+				global(`windows_enrollment:
+      default_fleet: "Unassigned"`),
+				workstations,
+			},
+			seedTeamName:      "Seeded fleet",
+			seedTeamIsDefault: true,
+			dryRunAssertion: func(t *testing.T, out string, defaultTeamID *uint, err error) {
+				require.NoError(t, err)
+				assert.NotNil(t, defaultTeamID, "dry run must not clear the default fleet")
+				assert.NotContains(t, out, "would apply Windows enrollment default fleet",
+					"Unassigned names no fleet, so the apply must not be deferred")
+				assert.Contains(t, out, "[!] gitops dry run succeeded")
+			},
+			realRunAssertion: func(t *testing.T, out string, defaultTeamID *uint, err error) {
+				require.NoError(t, err)
+				assert.Nil(t, defaultTeamID)
+				assert.Contains(t, out, "[!] gitops succeeded")
+			},
+		},
+		{
 			name: "omitted key is a no-op",
 			cfgs: []string{
 				global(""),
@@ -4840,13 +4863,16 @@ software:
 				return nil
 			}
 
+			// Track the persisted default fleet, overriding the helper's stateful default so the test can assert on it directly.
+			var defaultTeamID *uint
+
 			if tt.seedTeamName != "" {
 				seeded := &fleet.Team{ID: 99, Name: tt.seedTeamName}
 				savedTeams[tt.seedTeamName] = &seeded
+				if tt.seedTeamIsDefault {
+					defaultTeamID = &seeded.ID
+				}
 			}
-
-			// Track the persisted default fleet, overriding the helper's stateful default so the test can assert on it directly.
-			var defaultTeamID *uint
 			ds.GetWindowsEnrollmentDefaultFleetFunc = func(ctx context.Context) (*uint, string, error) {
 				if defaultTeamID == nil {
 					return nil, "", nil

--- a/server/fleet/teams.go
+++ b/server/fleet/teams.go
@@ -49,6 +49,11 @@ func IsReservedTeamName(name string) bool {
 		normalizedName == "unassigned" || normalizedName == "all fleets"
 }
 
+// IsUnassignedFleetName checks if the name provided is the display name of the "Unassigned" pseudo-fleet, i.e. hosts with no fleet (case-insensitive).
+func IsUnassignedFleetName(name string) bool {
+	return strings.ToLower(name) == "unassigned"
+}
+
 type TeamPayload struct {
 	Name               *string              `json:"name"`
 	Description        *string              `json:"description"`

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -1052,8 +1052,8 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 		return nil, ctxerr.Wrap(ctx, invalid)
 	}
 
-	// Normalize the stored JSON to the canonical fleet name when one was resolved.
-	if windowsEnrollmentDefined && windowsEnrollmentFleetName != "" {
+	// Normalize the stored JSON to the canonical fleet name, or to "" when the default was cleared.
+	if windowsEnrollmentDefined {
 		appConfig.MDM.WindowsEnrollment = optjson.Any[fleet.WindowsEnrollment]{
 			Set: true, Valid: true,
 			Value: fleet.WindowsEnrollment{DefaultFleet: windowsEnrollmentFleetName},
@@ -2371,7 +2371,7 @@ func (svc *Service) validateWindowsEnrollment(
 	}
 
 	name := newMDM.WindowsEnrollment.Value.DefaultFleet
-	if name == "" {
+	if name == "" || fleet.IsUnassignedFleetName(name) {
 		// Explicitly clearing the default; allowed on any tier.
 		return true, nil, "", nil
 	}

--- a/server/service/appconfig_test.go
+++ b/server/service/appconfig_test.go
@@ -3521,28 +3521,66 @@ func TestModifyAppConfigWindowsEnrollment(t *testing.T) {
 		expectSet      bool
 		expectSetTo    *uint
 		expectActivity bool
+		// expectStoredName is the default_fleet value the saved app config JSON must carry
+		expectStoredName string
 	}
 	testCases := []testCase{
 		{
-			name:           "set to existing fleet",
-			licenseTier:    fleet.TierPremium,
-			payload:        `{"mdm":{"windows_enrollment":{"default_fleet":"Workstations"}}}`,
-			expectSet:      true,
-			expectSetTo:    &teamID,
-			expectActivity: true,
+			name:             "set to existing fleet",
+			licenseTier:      fleet.TierPremium,
+			payload:          `{"mdm":{"windows_enrollment":{"default_fleet":"Workstations"}}}`,
+			expectSet:        true,
+			expectSetTo:      &teamID,
+			expectActivity:   true,
+			expectStoredName: "Workstations",
 		},
 		{
-			name:           "unchanged value writes nothing",
-			licenseTier:    fleet.TierPremium,
-			payload:        `{"mdm":{"windows_enrollment":{"default_fleet":"Workstations"}}}`,
-			currentTeamID:  &teamID,
-			expectSet:      false,
-			expectActivity: false,
+			name:             "unchanged value writes nothing",
+			licenseTier:      fleet.TierPremium,
+			payload:          `{"mdm":{"windows_enrollment":{"default_fleet":"Workstations"}}}`,
+			currentTeamID:    &teamID,
+			expectSet:        false,
+			expectActivity:   false,
+			expectStoredName: "Workstations",
 		},
 		{
 			name:           "clear with empty string",
 			licenseTier:    fleet.TierPremium,
 			payload:        `{"mdm":{"windows_enrollment":{"default_fleet":""}}}`,
+			currentTeamID:  &teamID,
+			expectSet:      true,
+			expectSetTo:    nil,
+			expectActivity: true,
+		},
+		{
+			name:           "clear with Unassigned",
+			licenseTier:    fleet.TierPremium,
+			payload:        `{"mdm":{"windows_enrollment":{"default_fleet":"Unassigned"}}}`,
+			currentTeamID:  &teamID,
+			expectSet:      true,
+			expectSetTo:    nil,
+			expectActivity: true,
+		},
+		{
+			name:           "clear with Unassigned in a different case",
+			licenseTier:    fleet.TierPremium,
+			payload:        `{"mdm":{"windows_enrollment":{"default_fleet":"unassigned"}}}`,
+			currentTeamID:  &teamID,
+			expectSet:      true,
+			expectSetTo:    nil,
+			expectActivity: true,
+		},
+		{
+			name:           "clear with Unassigned when already cleared writes nothing",
+			licenseTier:    fleet.TierPremium,
+			payload:        `{"mdm":{"windows_enrollment":{"default_fleet":"Unassigned"}}}`,
+			expectSet:      false,
+			expectActivity: false,
+		},
+		{
+			name:           "clear with Unassigned allowed without premium",
+			licenseTier:    fleet.TierFree,
+			payload:        `{"mdm":{"windows_enrollment":{"default_fleet":"Unassigned"}}}`,
 			currentTeamID:  &teamID,
 			expectSet:      true,
 			expectSetTo:    nil,
@@ -3561,12 +3599,13 @@ func TestModifyAppConfigWindowsEnrollment(t *testing.T) {
 			expectErr:   "missing or invalid license",
 		},
 		{
-			name:           "unchanged value tolerated without premium",
-			licenseTier:    fleet.TierFree,
-			payload:        `{"mdm":{"windows_enrollment":{"default_fleet":"Workstations"}}}`,
-			currentTeamID:  &teamID,
-			expectSet:      false,
-			expectActivity: false,
+			name:             "unchanged value tolerated without premium",
+			licenseTier:      fleet.TierFree,
+			payload:          `{"mdm":{"windows_enrollment":{"default_fleet":"Workstations"}}}`,
+			currentTeamID:    &teamID,
+			expectSet:        false,
+			expectActivity:   false,
+			expectStoredName: "Workstations",
 		},
 		{
 			name:           "omitted key is a no-op",
@@ -3660,6 +3699,8 @@ func TestModifyAppConfigWindowsEnrollment(t *testing.T) {
 			} else {
 				require.NotContains(t, activities, "edited_windows_enrollment_default_fleet")
 			}
+			require.Equal(t, tc.expectStoredName, dsAppConfig.MDM.WindowsEnrollment.Value.DefaultFleet,
+				"the app config JSON must store the canonical fleet name")
 		})
 	}
 }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #51743 

Fixing unreleased bug.

# Checklist for submitter

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows enrollment fleet assignment handling for the reserved “Unassigned” fleet.
  * Assigning “Unassigned” now clears the configured default fleet, including case-insensitive variations.
  * Fleet names are stored consistently using their canonical form.
  * Dry-run operations preserve the existing default fleet without applying changes.
  * Empty fleet assignments continue to clear the configured default fleet as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->