### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/keystore-explorer/darwin.json
+++ b/ee/maintained-apps/outputs/keystore-explorer/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "5.6.1",
+      "version": "5.7.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.kse.keystore-explorer';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.kse.keystore-explorer' AND version_compare(bundle_short_version, '5.6.1') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.kse.keystore-explorer' AND version_compare(bundle_short_version, '5.7.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'org.kse.keystore-explorer');"
       },
-      "installer_url": "https://github.com/kaikramer/keystore-explorer/releases/download/v5.6.1/kse-561-arm64.dmg",
+      "installer_url": "https://github.com/kaikramer/keystore-explorer/releases/download/v5.7.0/kse-570-arm64.dmg",
       "install_script_ref": "cfac5836",
       "uninstall_script_ref": "6d59af2d",
-      "sha256": "693e325e59173a14a1aedf4eb581ed24b6ddb0e8bb4037893312606eb23fab7b",
+      "sha256": "59ffae1f70f3e4a2eb6d25b4169ee8b7b528d5638dec27b2b60a3287b61f0499",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/notepadexe/darwin.json
+++ b/ee/maintained-apps/outputs/notepadexe/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.5.17",
+      "version": "1.5.18",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'best.swift.Notepad';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'best.swift.Notepad' AND version_compare(bundle_short_version, '1.5.17') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'best.swift.Notepad' AND version_compare(bundle_short_version, '1.5.18') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'best.swift.Notepad');"
       },
-      "installer_url": "https://github.com/notepadhq/notepadexe-public/releases/download/1.5.17/Notepad.zip",
+      "installer_url": "https://github.com/notepadhq/notepadexe-public/releases/download/1.5.18/Notepad.zip",
       "install_script_ref": "7bdbf044",
       "uninstall_script_ref": "abe56690",
-      "sha256": "727b8e37abc51b846889c40f212a8c299658bf4250a70f19d98d4e982653e1fa",
+      "sha256": "64d59e588fea7cf3eff0b67c25c90fc5b7471f328e20b4fab0d96505060f703a",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/stats/darwin.json
+++ b/ee/maintained-apps/outputs/stats/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "3.0.12",
+      "version": "3.0.13",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'eu.exelban.Stats';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'eu.exelban.Stats' AND version_compare(bundle_short_version, '3.0.12') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'eu.exelban.Stats' AND version_compare(bundle_short_version, '3.0.13') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'eu.exelban.Stats');"
       },
-      "installer_url": "https://github.com/exelban/stats/releases/download/v3.0.12/Stats.dmg",
+      "installer_url": "https://github.com/exelban/stats/releases/download/v3.0.13/Stats.dmg",
       "install_script_ref": "f0bd0f4d",
       "uninstall_script_ref": "46b4651c",
-      "sha256": "683e73573d8d31e5b3b07f7e817091a2e9d63a62a6cf9a8710b3770d3c1573e8",
+      "sha256": "be8841586446a9a1e80d4c4fd0c434d8f1182b460ca728c82dd465c1b0c23415",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the macOS Keystore Explorer package to version 5.7.0.
  * Updated the macOS Notepad.exe package to version 1.5.18.
  * Updated the macOS Stats package to version 3.0.13.
  * Refreshed installer download details and integrity checksums for all three applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->