### PR TITLE
update metrics tool and submit mock apns loadtest metrics

### DIFF
--- a/tools/loadtest/metrics/README.md
+++ b/tools/loadtest/metrics/README.md
@@ -24,6 +24,10 @@ against each other to catch regressions release-over-release.
 
 # 1h lookback, filed under the mdm category
 ./collect-metrics.sh --workspace 483applemdm --interval 1h --category mdm
+
+# annotate what the run was exercising
+./collect-metrics.sh --workspace 483applemdm --category mdm \
+  --note "300k hosts, APNs push storm at t+40m"
 ```
 
 Key flags (`--help` for the full list):
@@ -33,6 +37,7 @@ Key flags (`--help` for the full list):
 | `-w, --workspace` | Terraform workspace name (required). AWS resource names are derived from it. |
 | `-i, --interval`  | Lookback window: `<N>h`, `<N>m`, or a bare integer (hours). Default `3h`. |
 | `-c, --category`  | File the run under a category: `baseline` \| `migration` \| `mdm`. |
+| `-n, --note`      | Free-form note about the run, embedded as `metadata.note`. Shown in the synopsis and dashboard; never compared. |
 | `-o, --output`    | Override the output file path. |
 | `-r, --region`    | AWS region. Default `us-east-2`. |
 
@@ -40,8 +45,41 @@ Output lands in `runs/[<category>/]<workspace>/<workspace>-<timestamp>-<interval
 alongside a matching `.md` synopsis.
 
 > The `--workspace` value is not free-form — `collect-metrics.sh` derives AWS resource
-> names from it (`fleet-<ws>-backend`, `fleetdm-<ws>-mysql`, `fleet-<ws>-redis`, …), so it
-> must match the actual Terraform workspace.
+> names from it (`fleet-<ws>-backend`, `fleetdm-<ws>-mysql`, `fleet-<ws>-redis`,
+> `fleet-<ws>-apns-mock`, …), so it must match the actual Terraform workspace.
+
+### MDM runs
+
+Two extra sections appear when the deployment enabled Apple MDM
+(`var.enable_apple_mdm`); both are absent otherwise, and `compare-metrics.sh` drops
+sections with no data.
+
+`apns_mock` covers the [mock APNs server](../../../cmd/apple-apns-mock), which scales
+horizontally (`var.apple_apns_mock_instance_count`):
+
+- `cpu_utilization` / `memory_utilization` — Sum(Utilized)/Sum(Reserved) across every
+  running task, i.e. the service-wide average.
+- `per_task` — the mean and hottest single container. Worth watching alongside the
+  average: one saturated task drops every SSE stream it holds while the service-wide
+  figure still looks healthy. A large `spread_pct` means the ALB is not distributing
+  connections evenly.
+- `network` — RX/TX bytes. Held SSE streams make traffic volume a better throughput
+  proxy here than the ALB's request count.
+- `container_health` — abnormal stops and start spread, scoped to this service. An
+  OOM-killed task disconnects its devices, which then reconnect elsewhere.
+
+`apns_mock_redis` covers the mock's dedicated ElastiCache. Load tracks the push rate and
+instance count rather than the connection count — each task holds one subscribe
+connection plus a small command pool:
+
+- `cpu_utilization` — `EngineCPUUtilization`. Redis runs commands on one thread, so this
+  saturates well before host CPU does.
+- `curr_items` — pending pushes awaiting claim, plus one stats key per instance. A rising
+  floor means devices are not connecting to collect them.
+- `evictions` — must stay at zero. An eviction is a pending push dropped before its
+  device reconnected.
+- `string_based_cmds` / `pubsub_based_cmds` — SET/GETDEL/INCR and PUBLISH/SUBSCRIBE
+  volume, the push throughput as Redis saw it.
 
 ## Comparing runs
 
@@ -74,6 +112,8 @@ network, nothing leaves the browser.
   via the raw-path input.
 - Runs are selectable individually, grouped by category; baselines are selected by
   default since migration/MDM runs exercise different workloads.
+- A run collected with `--note` shows that note under its entry in the run list and in
+  the detail-chart tooltip. Notes are display-only — never charted or diffed.
 
 The dashboard's metric registry mirrors the definitions in `compare-metrics.sh` — keep
 them in sync when adding metrics.

--- a/tools/loadtest/metrics/collect-metrics.sh
+++ b/tools/loadtest/metrics/collect-metrics.sh
@@ -10,6 +10,8 @@
 #   -i, --interval RANGE  Lookback interval. Accepts <N>h, <N>m, or a bare integer (treated as hours). Default: 3h
 #   -c, --category CAT    Run category for filing output: baseline | migration | mdm.
 #                         Files output under runs/<category>/<workspace>/. Omit to use runs/<workspace>/.
+#   -n, --note TEXT       Free-form note about this collection (e.g. what was being exercised).
+#                         Embedded as metadata.note; omitted from the JSON when not given.
 #   -o, --output FILE     Output file path (default: runs/[<category>/]<workspace>/<workspace>-<date>Z-<interval>.json)
 #   -r, --region REGION   AWS region (default: us-east-2)
 #   -h, --help            Show this help message
@@ -29,7 +31,7 @@ for cmd in aws jq; do
 done
 
 usage() {
-  sed -n '3,15p' "$0" | sed 's/^# \?//'
+  sed -n '3,17p' "$0" | sed 's/^# \?//'
   exit "${1:-0}"
 }
 
@@ -41,12 +43,14 @@ OUTPUT=""
 REGION="us-east-2"
 INTERVAL_INPUT="3h"
 CATEGORY=""
+NOTE=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     -w|--workspace)  WORKSPACE="$2"; shift 2 ;;
     -i|--interval)   INTERVAL_INPUT="$2"; shift 2 ;;
     -c|--category)   CATEGORY="$2"; shift 2 ;;
+    -n|--note)       NOTE="$2"; shift 2 ;;
     -o|--output)     OUTPUT="$2"; shift 2 ;;
     -r|--region)     REGION="$2"; shift 2 ;;
     -h|--help)       usage 0 ;;
@@ -73,6 +77,20 @@ if [[ -n "$CATEGORY" ]]; then
     baseline|migration|mdm) ;;
     *) echo "Error: --category must be one of: baseline, migration, mdm. Got: '$CATEGORY'" >&2; exit 1 ;;
   esac
+fi
+
+# The note is free-form prose, but it is embedded in JSON that gets committed and
+# rendered in the dashboard, so reject control characters (newlines included) and
+# cap the length to keep runs greppable and the run list legible.
+if [[ -n "$NOTE" ]]; then
+  if [[ "$NOTE" == *$'\n'* || "$NOTE" =~ [[:cntrl:]] ]]; then
+    echo "Error: --note must be a single line without control characters." >&2
+    exit 1
+  fi
+  if [[ "${#NOTE}" -gt 500 ]]; then
+    echo "Error: --note must be 500 characters or fewer (got ${#NOTE})." >&2
+    exit 1
+  fi
 fi
 
 # Parse interval: accept "<N>h", "<N>m", or a bare integer (interpreted as hours).
@@ -175,19 +193,22 @@ ECS_SERVICE_ARNS=$(echo "$ECS_SERVICES_JSON" | jq -r '.serviceArns[]')
 
 FLEET_SERVICE=""
 OSQUERY_PERF_SERVICE=""
+APNS_MOCK_SERVICE=""
 LOADTEST_SERVICES=()
 
 for arn in $ECS_SERVICE_ARNS; do
   svc=$(basename "$arn")
   case "$svc" in
-    fleet)          FLEET_SERVICE="$svc" ;;
-    osquery_perf)   OSQUERY_PERF_SERVICE="$svc" ;;
-    loadtest-*)     LOADTEST_SERVICES+=("$svc") ;;
+    fleet)               FLEET_SERVICE="$svc" ;;
+    osquery_perf)        OSQUERY_PERF_SERVICE="$svc" ;;
+    *apple-apns-mock)    APNS_MOCK_SERVICE="$svc" ;;
+    loadtest-*)          LOADTEST_SERVICES+=("$svc") ;;
   esac
 done
 
 echo "  Fleet Service: ${FLEET_SERVICE:-<not found>}"
 echo "  osquery-perf Service: ${OSQUERY_PERF_SERVICE:-<not found>}"
+echo "  apns-mock Service: ${APNS_MOCK_SERVICE:-<not found>}"
 echo "  Loadtest Services: ${#LOADTEST_SERVICES[@]} found"
 
 # RDS — try both naming patterns
@@ -256,6 +277,24 @@ if [[ -n "$REDIS_REPLICATION_GROUP" ]]; then
   echo "  Redis Nodes: ${REDIS_NODE_IDS[*]:-<none>}"
 fi
 
+# The mock APNs server runs its own ElastiCache rather than sharing Fleet's, so
+# a full-fleet push wave does not perturb the system under test. Only exists
+# when the deployment enabled Apple MDM.
+APNS_REDIS_REPLICATION_GROUP=""
+if aws elasticache describe-replication-groups --replication-group-id "${PREFIX}-apns-mock" --region "$REGION" \
+     --query "ReplicationGroups[0].ReplicationGroupId" --output text 2>/dev/null | grep -q .; then
+  APNS_REDIS_REPLICATION_GROUP="${PREFIX}-apns-mock"
+fi
+
+APNS_REDIS_NODE_IDS=()
+if [[ -n "$APNS_REDIS_REPLICATION_GROUP" ]]; then
+  while IFS= read -r nid; do
+    [[ -n "$nid" ]] && APNS_REDIS_NODE_IDS+=("$nid")
+  done < <(aws elasticache describe-replication-groups --replication-group-id "$APNS_REDIS_REPLICATION_GROUP" --region "$REGION" \
+    --query "ReplicationGroups[0].MemberClusters[]" --output json 2>/dev/null | jq -r '.[]')
+fi
+echo "  apns-mock Redis: ${APNS_REDIS_REPLICATION_GROUP:-<not found>} (${APNS_REDIS_NODE_IDS[*]:-<none>})"
+
 # ALB discovery
 ALB_ARN_SUFFIX=""
 ALB_TG_ARN_SUFFIX=""
@@ -264,7 +303,7 @@ ALB_ARN=$(aws elbv2 describe-load-balancers --region "$REGION" --output json 2>/
   | head -1)
 if [[ -n "$ALB_ARN" ]]; then
   # Extract the suffix after "app/" for CloudWatch dimensions
-  ALB_ARN_SUFFIX=$(echo "$ALB_ARN" | grep -o 'app/.*')
+  ALB_ARN_SUFFIX=$(echo "$ALB_ARN" | grep -o '\(app\|net\)/.*')
   echo "  ALB: $ALB_ARN_SUFFIX"
 
   # Find the target group for the fleet service
@@ -393,6 +432,91 @@ collect_ecs_utilization() {
         data_coverage: (length / $max_points * 100 | round / 100)
       }
     else null end'
+}
+
+# collect_ecs_per_task <cluster> <service> <utilized_metric> <reserved_metric>
+# Container Insights emits one datapoint per task per period, so at the service
+# dimension Average is the mean task and Maximum is the hottest. Both divided by
+# the per-task reservation give the spread across containers, which the
+# service-wide Sum/Sum figure in collect_ecs_utilization averages away. A large
+# spread means the load balancer is not distributing evenly.
+collect_ecs_per_task() {
+  local cluster="$1" service="$2" util_metric="$3" resv_metric="$4"
+  local dims="Name=ClusterName,Value=$cluster Name=ServiceName,Value=$service"
+
+  local util_raw resv_raw
+  util_raw=$(get_metric "ECS/ContainerInsights" "$util_metric" "$dims" 300 Average Maximum)
+  resv_raw=$(get_metric "ECS/ContainerInsights" "$resv_metric" "$dims" 300 Average)
+
+  jq -n --argjson util "$util_raw" --argjson resv "$resv_raw" '
+    ([($resv.Datapoints // [])[].Average] | if length > 0 then (add / length) else null end) as $reserved |
+    [($util.Datapoints // [])[].Average] as $avgs |
+    [($util.Datapoints // [])[].Maximum] as $maxs |
+    if $reserved == null or $reserved <= 0 or ($avgs | length) == 0 then null
+    else
+      (($avgs | add / length) / $reserved * 100) as $a |
+      (($maxs | max) / $reserved * 100) as $m |
+      {
+        avg_pct: ($a * 100 | round / 100),
+        max_pct: ($m * 100 | round / 100),
+        spread_pct: (($m - $a) * 100 | round / 100)
+      }
+    end'
+}
+
+# collect_service_health <cluster> <service>
+# Abnormal stops and start spread scoped to one service. Unlike the
+# cluster-wide loadtest check further down, this filters by service so a
+# restart elsewhere in the cluster is not attributed here.
+collect_service_health() {
+  local cluster="$1" service="$2"
+  local stopped stopped_arns details abnormal=0
+
+  stopped=$(aws ecs list-tasks --cluster "$cluster" --service-name "$service" --desired-status STOPPED \
+    --region "$REGION" --output json 2>/dev/null || echo '{"taskArns":[]}')
+  stopped_arns=$(echo "$stopped" | jq -r '.taskArns[]' | head -50)
+
+  if [[ -n "$stopped_arns" ]]; then
+    details=$(aws ecs describe-tasks --cluster "$cluster" --tasks $stopped_arns \
+      --region "$REGION" --output json 2>/dev/null || echo '{"tasks":[]}')
+    # Both sides are truncated to whole seconds so the CLI's fractional-offset
+    # timestamps compare correctly against START_TIME/END_TIME.
+    abnormal=$(echo "$details" | jq --arg s "$START_TIME" --arg e "$END_TIME" '
+      [.tasks[] | select(.stoppedAt)
+        | select((.stoppedAt | .[0:19]) >= ($s | .[0:19]))
+        | select((.stoppedAt | .[0:19]) <= ($e | .[0:19]))
+        | select([.containers[]? | select(.exitCode > 0)] | length > 0)] | length')
+  fi
+
+  local running running_arns
+  running=$(aws ecs list-tasks --cluster "$cluster" --service-name "$service" --desired-status RUNNING \
+    --region "$REGION" --output json 2>/dev/null || echo '{"taskArns":[]}')
+  running_arns=$(echo "$running" | jq -r '.taskArns[]')
+
+  details='{"tasks":[]}'
+  if [[ -n "$running_arns" ]]; then
+    details=$(aws ecs describe-tasks --cluster "$cluster" --tasks $running_arns \
+      --region "$REGION" --output json 2>/dev/null || echo '{"tasks":[]}')
+  fi
+
+  echo "$details" | jq --arg now "$TIMESTAMP" --argjson abnormal "${abnormal:-0}" '
+    [.tasks[] | select(.startedAt) | {
+      task_id: (.taskArn | split("/") | last),
+      started_at: .startedAt,
+      uptime_min: ((($now | .[0:19] | strptime("%Y-%m-%dT%H:%M:%S") | mktime) -
+                    (.startedAt | .[0:19] | strptime("%Y-%m-%dT%H:%M:%S") | mktime)) / 60
+                   | . * 100 | round / 100)
+    }] | sort_by(.started_at) as $tasks |
+    (if ($tasks | length) > 1
+     then (($tasks | first.uptime_min) - ($tasks | last.uptime_min)) * 100 | round / 100
+     else 0 end) as $spread |
+    {
+      abnormal_stops: $abnormal,
+      running_tasks: ($tasks | length),
+      start_spread_min: $spread,
+      start_spread_alert: ($spread > 10),
+      tasks: $tasks
+    }' 2>/dev/null || echo '{"abnormal_stops": null, "running_tasks": null}'
 }
 
 # ---------------------------------------------------------------------------
@@ -531,6 +655,72 @@ elif [[ ${#LOADTEST_SERVICES[@]} -gt 0 ]]; then
     --arg desired "$lt_desired" \
     --arg count "${#LOADTEST_SERVICES[@]}" \
     '{cpu_utilization: $cpu, memory_utilization: $mem, task_counts: {runningCount: ($running|tonumber), desiredCount: ($desired|tonumber), serviceCount: ($count|tonumber)}}')
+fi
+
+# ---------------------------------------------------------------------------
+# Collect ECS apple-apns-mock metrics
+#
+# The service only exists when the deployment enabled Apple MDM, so an empty
+# object here means "not deployed", not "collection failed".
+#
+# The mock scales horizontally (var.apple_apns_mock_instance_count), so
+# cpu_utilization/memory_utilization are Sum(Utilized)/Sum(Reserved) across
+# every running task -- the service-wide average. per_task carries the mean and
+# hottest single task alongside it, because one saturated container behind a
+# healthy-looking average still drops the SSE streams it holds.
+# ---------------------------------------------------------------------------
+APNS_MOCK_METRICS="{}"
+if [[ -n "$APNS_MOCK_SERVICE" ]]; then
+  echo "  apns-mock: CPU Utilization (Container Insights)..."
+  apnsm_cpu=$(collect_ecs_utilization "$ECS_CLUSTER" "$APNS_MOCK_SERVICE" "CpuUtilized" "CpuReserved")
+
+  echo "  apns-mock: Memory Utilization (Container Insights)..."
+  apnsm_mem=$(collect_ecs_utilization "$ECS_CLUSTER" "$APNS_MOCK_SERVICE" "MemoryUtilized" "MemoryReserved")
+
+  echo "  apns-mock: Per-task CPU/Memory spread..."
+  apnsm_cpu_task=$(collect_ecs_per_task "$ECS_CLUSTER" "$APNS_MOCK_SERVICE" "CpuUtilized" "CpuReserved")
+  apnsm_mem_task=$(collect_ecs_per_task "$ECS_CLUSTER" "$APNS_MOCK_SERVICE" "MemoryUtilized" "MemoryReserved")
+
+  # Every SSE stream is a held connection, so network volume tracks the fan-out
+  # rather than the request count the ALB reports.
+  echo "  apns-mock: Network RX/TX (Container Insights)..."
+  apnsm_rx=$(collect_metric "ECS/ContainerInsights" "NetworkRxBytes" \
+    "Name=ClusterName,Value=$ECS_CLUSTER Name=ServiceName,Value=$APNS_MOCK_SERVICE" Sum Average)
+  apnsm_tx=$(collect_metric "ECS/ContainerInsights" "NetworkTxBytes" \
+    "Name=ClusterName,Value=$ECS_CLUSTER Name=ServiceName,Value=$APNS_MOCK_SERVICE" Sum Average)
+
+  apnsm_tasks=$(aws ecs describe-services --cluster "$ECS_CLUSTER" --services "$APNS_MOCK_SERVICE" --region "$REGION" \
+    --query "services[0].{runningCount:runningCount,desiredCount:desiredCount}" --output json 2>/dev/null || echo '{}')
+
+  # An OOM-killed task takes every stream it held with it, and the devices
+  # reconnect elsewhere, so a restart shows up as a step change in the
+  # remaining tasks rather than an obvious failure.
+  echo "  apns-mock: Container health..."
+  apnsm_health=$(collect_service_health "$ECS_CLUSTER" "$APNS_MOCK_SERVICE")
+
+  apnsm_running=$(echo "$apnsm_tasks" | jq -r '.runningCount // 0')
+  apnsm_stops=$(echo "$apnsm_health" | jq -r '.abnormal_stops // 0')
+  echo "  apns-mock: $apnsm_running running tasks, $apnsm_stops abnormal stops"
+
+  APNS_MOCK_METRICS=$(jq -n \
+    --argjson cpu "$apnsm_cpu" \
+    --argjson mem "$apnsm_mem" \
+    --argjson cpu_task "$apnsm_cpu_task" \
+    --argjson mem_task "$apnsm_mem_task" \
+    --argjson rx "$apnsm_rx" \
+    --argjson tx "$apnsm_tx" \
+    --argjson tasks "$apnsm_tasks" \
+    --argjson health "$apnsm_health" \
+    --arg service "$APNS_MOCK_SERVICE" \
+    '{
+      service: $service,
+      cpu_utilization: $cpu,
+      memory_utilization: $mem,
+      per_task: {cpu: $cpu_task, memory: $mem_task},
+      network: {network_rx_bytes: $rx, network_tx_bytes: $tx},
+      task_counts: $tasks,
+      container_health: $health
+    }')
 fi
 
 # ---------------------------------------------------------------------------
@@ -735,7 +925,7 @@ if [[ -n "$RDS_WRITER_DBI_RESOURCE_ID" ]]; then
     --identifier "$RDS_WRITER_DBI_RESOURCE_ID" \
     --start-time "$START_TIME" \
     --end-time "$END_TIME" \
-    --period-in-seconds 3600 \
+    --period-in-seconds 300 \
     --metric-queries '[{"Metric":"db.load.avg","GroupBy":{"Group":"db.sql_tokenized","Limit":5}}]' \
     --region "$REGION" \
     --output json 2>/dev/null || echo '{}')
@@ -757,7 +947,7 @@ if [[ ${#RDS_READER_DBI_RESOURCE_IDS[@]} -gt 0 ]]; then
       --identifier "$rid" \
       --start-time "$START_TIME" \
       --end-time "$END_TIME" \
-      --period-in-seconds 3600 \
+      --period-in-seconds 300 \
       --metric-queries '[{"Metric":"db.load.avg","GroupBy":{"Group":"db.sql_tokenized","Limit":5}}]' \
       --region "$REGION" \
       --output json 2>/dev/null || echo '{}')
@@ -835,6 +1025,85 @@ if [[ ${#REDIS_NODE_IDS[@]} -gt 0 ]]; then
   done
   REDIS_METRICS="$redis_arr"
   REDIS_EXT="$redis_ext_arr"
+fi
+
+# ---------------------------------------------------------------------------
+# Collect ElastiCache metrics for the mock APNs server's dedicated Redis
+#
+# Every push costs a SET plus a PUBLISH on the receiving instance and a GETDEL
+# on the instance holding the stream, and the announcement fans out to every
+# instance. Load here therefore tracks the push rate and the instance count,
+# not the connection count -- each mock task holds only one subscribe
+# connection plus a small command pool.
+# ---------------------------------------------------------------------------
+APNS_REDIS_METRICS="[]"
+if [[ ${#APNS_REDIS_NODE_IDS[@]} -gt 0 ]]; then
+  apns_redis_arr="[]"
+  apns_redis_idx=1
+  for node_id in "${APNS_REDIS_NODE_IDS[@]}"; do
+    apns_redis_label="apns-redis-${apns_redis_idx}"
+    echo "  $apns_redis_label: CPU, Memory, Connections, Items, Commands..."
+
+    # Redis executes commands on one thread, so EngineCPUUtilization saturates
+    # well before the host-level CPUUtilization does.
+    ar_cpu=$(collect_metric "AWS/ElastiCache" "EngineCPUUtilization" \
+      "Name=CacheClusterId,Value=$node_id" Average Maximum Minimum)
+
+    ar_mem=$(collect_metric "AWS/ElastiCache" "DatabaseMemoryUsagePercentage" \
+      "Name=CacheClusterId,Value=$node_id" Average Maximum Minimum)
+
+    ar_conns=$(collect_metric "AWS/ElastiCache" "CurrConnections" \
+      "Name=CacheClusterId,Value=$node_id" Average Maximum)
+
+    # Pending pushes waiting to be claimed, plus one stats key per instance.
+    # A rising floor means devices are not connecting to collect them.
+    ar_items=$(collect_metric "AWS/ElastiCache" "CurrItems" \
+      "Name=CacheClusterId,Value=$node_id" Average Maximum)
+
+    # Any eviction is a pending push silently dropped before its device
+    # reconnected, so this must stay at zero.
+    ar_evictions=$(collect_metric "AWS/ElastiCache" "Evictions" \
+      "Name=CacheClusterId,Value=$node_id" Sum Maximum)
+
+    # SET/GETDEL/INCR land in StringBasedCmds; PUBLISH/SUBSCRIBE in
+    # PubSubBasedCmds. Together they are the push throughput as Redis saw it.
+    ar_string_cmds=$(collect_metric "AWS/ElastiCache" "StringBasedCmds" \
+      "Name=CacheClusterId,Value=$node_id" Sum Average)
+
+    ar_pubsub_cmds=$(collect_metric "AWS/ElastiCache" "PubSubBasedCmds" \
+      "Name=CacheClusterId,Value=$node_id" Sum Average)
+
+    # Grows with the instance count: every announcement is delivered to every
+    # subscribed instance.
+    ar_net_out=$(collect_metric "AWS/ElastiCache" "NetworkBytesOut" \
+      "Name=CacheClusterId,Value=$node_id" Sum Average)
+
+    apns_node_obj=$(jq -n \
+      --arg node "$apns_redis_label" \
+      --argjson cpu "$ar_cpu" \
+      --argjson mem "$ar_mem" \
+      --argjson conns "$ar_conns" \
+      --argjson items "$ar_items" \
+      --argjson evictions "$ar_evictions" \
+      --argjson string_cmds "$ar_string_cmds" \
+      --argjson pubsub_cmds "$ar_pubsub_cmds" \
+      --argjson net_out "$ar_net_out" \
+      '{
+        node: $node,
+        cpu_utilization: $cpu,
+        memory_utilization: $mem,
+        curr_connections: $conns,
+        curr_items: $items,
+        evictions: $evictions,
+        string_based_cmds: $string_cmds,
+        pubsub_based_cmds: $pubsub_cmds,
+        network_bytes_out: $net_out
+      }')
+    apns_redis_arr=$(echo "$apns_redis_arr" | jq --argjson obj "$apns_node_obj" '. + [$obj]')
+
+    apns_redis_idx=$((apns_redis_idx + 1))
+  done
+  APNS_REDIS_METRICS="$apns_redis_arr"
 fi
 
 # ---------------------------------------------------------------------------
@@ -1228,15 +1497,18 @@ jq -n \
   --arg collected_at "$TIMESTAMP" \
   --arg region "$REGION" \
   --arg interval "${INTERVAL_LABEL}" \
+  --arg note "$NOTE" \
   --arg start_time "$START_TIME" \
   --arg end_time "$END_TIME" \
   --argjson fleet_server "$FLEET_SERVER_METRICS" \
   --argjson loadtest_containers "$LOADTEST_METRICS" \
+  --argjson apns_mock "$APNS_MOCK_METRICS" \
   --argjson rds_writer "$RDS_WRITER_METRICS" \
   --argjson rds_readers "$RDS_READER_METRICS" \
   --argjson rds_pi_writer "$RDS_PI_WRITER" \
   --argjson rds_pi_readers "$RDS_PI_READERS" \
   --argjson redis "$REDIS_METRICS" \
+  --argjson apns_mock_redis "$APNS_REDIS_METRICS" \
   --argjson alb "$ALB_METRICS" \
   --argjson fleet_server_errors "$LOGS_ERRORS" \
   --argjson rds_writer_ext "$RDS_WRITER_EXT" \
@@ -1245,15 +1517,18 @@ jq -n \
   --argjson network "$NETWORK_METRICS" \
   --argjson container_health "$CONTAINER_HEALTH" \
   '{
-    metadata: {
+    # note is only present when --note was passed, so un-annotated runs stay
+    # byte-identical to before.
+    metadata: ({
       workspace: $workspace,
       collected_at: $collected_at,
       region: $region,
       interval: $interval,
       time_window: {start: $start_time, end: $end_time}
-    },
+    } + (if $note == "" then {} else {note: $note} end)),
     fleet_server: $fleet_server,
     loadtest_containers: $loadtest_containers,
+    apns_mock: $apns_mock,
     rds_writer: $rds_writer,
     rds_readers: $rds_readers,
     rds_performance_insights: {
@@ -1261,6 +1536,7 @@ jq -n \
       readers: $rds_pi_readers
     },
     redis: $redis,
+    apns_mock_redis: $apns_mock_redis,
     alb: $alb,
     fleet_server_errors: $fleet_server_errors,
     rds_writer_extended: $rds_writer_ext,
@@ -1282,6 +1558,7 @@ echo ""
 echo "- **Collected:** ${TIMESTAMP}"
 echo "- **Interval:** ${INTERVAL_LABEL}"
 echo "- **Window:** ${START_TIME} to ${END_TIME}"
+[[ -n "$NOTE" ]] && echo "- **Note:** ${NOTE}"
 echo ""
 echo "## Summary (${INTERVAL_LABEL} averages)"
 echo ""
@@ -1300,6 +1577,49 @@ if jq -e '.loadtest_containers.task_counts' "$OUTPUT" >/dev/null 2>&1; then
   lt_mem_avg=$(jq -r '.loadtest_containers.memory_utilization.Average // "N/A"' "$OUTPUT")
   lt_running=$(jq -r '.loadtest_containers.task_counts.runningCount // "N/A"' "$OUTPUT")
   printf "Loadtest:      CPU=%s%%  Mem=%s%%  Containers=%s\n" "$lt_cpu_avg" "$lt_mem_avg" "$lt_running"
+fi
+
+if jq -e '.apns_mock.task_counts' "$OUTPUT" >/dev/null 2>&1; then
+  apnsm_cpu_avg=$(jq -r '.apns_mock.cpu_utilization.Average // "N/A"' "$OUTPUT")
+  apnsm_mem_avg=$(jq -r '.apns_mock.memory_utilization.Average // "N/A"' "$OUTPUT")
+  apnsm_running=$(jq -r '.apns_mock.task_counts.runningCount // "N/A"' "$OUTPUT")
+  printf "apns-mock:     CPU=%s%%  Mem=%s%%  Containers=%s  (averaged across containers)\n" \
+    "$apnsm_cpu_avg" "$apnsm_mem_avg" "$apnsm_running"
+
+  apnsm_tcpu_avg=$(jq -r '.apns_mock.per_task.cpu.avg_pct // "N/A"' "$OUTPUT")
+  apnsm_tcpu_max=$(jq -r '.apns_mock.per_task.cpu.max_pct // "N/A"' "$OUTPUT")
+  apnsm_tmem_avg=$(jq -r '.apns_mock.per_task.memory.avg_pct // "N/A"' "$OUTPUT")
+  apnsm_tmem_max=$(jq -r '.apns_mock.per_task.memory.max_pct // "N/A"' "$OUTPUT")
+  printf "               PerTask CPU avg=%s%% max=%s%%   Mem avg=%s%% max=%s%%\n" \
+    "$apnsm_tcpu_avg" "$apnsm_tcpu_max" "$apnsm_tmem_avg" "$apnsm_tmem_max"
+
+  apnsm_rx_mb=$(jq -r '.apns_mock.network.network_rx_bytes.Sum // "N/A" | if type == "number" then (. / 1048576 * 100 | round / 100 | tostring) + "MB" else . end' "$OUTPUT")
+  apnsm_tx_mb=$(jq -r '.apns_mock.network.network_tx_bytes.Sum // "N/A" | if type == "number" then (. / 1048576 * 100 | round / 100 | tostring) + "MB" else . end' "$OUTPUT")
+  apnsm_h_stops=$(jq -r '.apns_mock.container_health.abnormal_stops // 0' "$OUTPUT")
+  apnsm_h_spread=$(jq -r '.apns_mock.container_health.start_spread_min // "N/A"' "$OUTPUT")
+  printf "               RX=%s  TX=%s  AbnormalStops=%s  StartSpread=%smin" \
+    "$apnsm_rx_mb" "$apnsm_tx_mb" "$apnsm_h_stops" "$apnsm_h_spread"
+  if [[ "$(jq -r '.apns_mock.container_health.start_spread_alert // false' "$OUTPUT")" == "true" ]]; then
+    printf "  ⚠ STAGGERED STARTS"
+  fi
+  printf "\n"
+fi
+
+if jq -e '.apns_mock_redis[0].cpu_utilization' "$OUTPUT" >/dev/null 2>&1; then
+  ar_cpu_avg=$(jq -r '.apns_mock_redis[0].cpu_utilization.Average // "N/A"' "$OUTPUT")
+  ar_cpu_max=$(jq -r '.apns_mock_redis[0].cpu_utilization.Maximum // "N/A"' "$OUTPUT")
+  ar_mem_avg=$(jq -r '.apns_mock_redis[0].memory_utilization.Average // "N/A"' "$OUTPUT")
+  ar_conns_avg=$(jq -r '.apns_mock_redis[0].curr_connections.Average // "N/A"' "$OUTPUT")
+  ar_items_avg=$(jq -r '.apns_mock_redis[0].curr_items.Average // "N/A"' "$OUTPUT")
+  ar_evict=$(jq -r '.apns_mock_redis[0].evictions.Sum // 0' "$OUTPUT")
+  printf "apns Redis:    CPU=%s%% (max %s%%)  Mem=%s%%  Conns=%s  PendingItems=%s  Evictions=%s\n" \
+    "$ar_cpu_avg" "$ar_cpu_max" "$ar_mem_avg" "$ar_conns_avg" "$ar_items_avg" "$ar_evict"
+
+  ar_str_cmds=$(jq -r '.apns_mock_redis[0].string_based_cmds.Sum // "N/A"' "$OUTPUT")
+  ar_ps_cmds=$(jq -r '.apns_mock_redis[0].pubsub_based_cmds.Sum // "N/A"' "$OUTPUT")
+  ar_net_out=$(jq -r '.apns_mock_redis[0].network_bytes_out.Sum // "N/A" | if type == "number" then (. / 1048576 * 100 | round / 100 | tostring) + "MB" else . end' "$OUTPUT")
+  printf "               StringCmds=%s  PubSubCmds=%s  NetOut=%s\n" \
+    "$ar_str_cmds" "$ar_ps_cmds" "$ar_net_out"
 fi
 
 if jq -e '.rds_writer.cpu_utilization' "$OUTPUT" >/dev/null 2>&1; then
@@ -1419,6 +1739,15 @@ echo '```'
 #   Redis Memory              < 70% avg
 #   Loadtest CPU              < 90% avg
 #   Loadtest Memory           < 90% avg
+#   apns-mock CPU             < 90% avg (service-wide)
+#   apns-mock Memory          < 80% avg (service-wide)
+#   apns-mock hottest task CPU < 95%
+#   apns-mock hottest task Mem < 90%
+#   apns-mock Abnormal Stops   == 0
+#   apns-mock Start Spread    < 10 min
+#   apns-mock Redis CPU       < 80% avg
+#   apns-mock Redis Memory    < 70% avg
+#   apns-mock Redis Evictions  == 0
 #   Fleet Server Errors       == 0
 #   IOPS Utilization          < 80% avg
 #   Container Abnormal Stops   == 0
@@ -1462,6 +1791,25 @@ check_threshold "Redis CPU avg"            '.redis[0].cpu_utilization.Average'  
 check_threshold "Redis Memory avg"         '.redis[0].memory_utilization.Average'         lt 70
 check_threshold "Loadtest CPU avg"         '.loadtest_containers.cpu_utilization.Average'  lt 90
 check_threshold "Loadtest Memory avg"      '.loadtest_containers.memory_utilization.Average' lt 90
+
+# apns-mock — no-ops when the service was not deployed (check_threshold skips nulls).
+# Memory is held tighter than the loadtest containers: GOMEMLIMIT sits at 90% of the
+# task limit, and an OOM kill drops every open SSE stream at once.
+check_threshold "apns-mock CPU avg"        '.apns_mock.cpu_utilization.Average'            lt 90
+check_threshold "apns-mock Memory avg"     '.apns_mock.memory_utilization.Average'         lt 80
+
+# The service-wide averages above hide a single saturated container, which is
+# the failure that actually matters: it drops every SSE stream it was holding.
+check_threshold "apns-mock hottest task CPU"    '.apns_mock.per_task.cpu.max_pct'          lt 95
+check_threshold "apns-mock hottest task Memory" '.apns_mock.per_task.memory.max_pct'       lt 90
+check_threshold "apns-mock Abnormal Stops"      '.apns_mock.container_health.abnormal_stops'   eq 0
+check_threshold "apns-mock Start Spread (min)"  '.apns_mock.container_health.start_spread_min' lt 10
+
+# The mock's dedicated Redis. An eviction is a pending push dropped before its
+# device reconnected, so it is never acceptable.
+check_threshold "apns-mock Redis CPU avg"    '.apns_mock_redis[0].cpu_utilization.Average'    lt 80
+check_threshold "apns-mock Redis Memory avg" '.apns_mock_redis[0].memory_utilization.Average' lt 70
+check_threshold "apns-mock Redis Evictions"  '.apns_mock_redis[0].evictions.Sum'              eq 0
 
 # Check each reader
 for reader_label in $(jq -r '.rds_readers[].instance // empty' "$OUTPUT" 2>/dev/null); do

--- a/tools/loadtest/metrics/compare-metrics.sh
+++ b/tools/loadtest/metrics/compare-metrics.sh
@@ -184,6 +184,35 @@ METRIC_DEFS=(
   ".redis[0].memory_utilization.Average|Redis Memory|%|15|30|false|lt|70"
 )
 
+# apple-apns-mock (MDM runs only). Absent from non-MDM runs; compare_metric_set
+# drops any def that is null in the last two files and suppresses the whole
+# section when nothing has data, so no extra guard is needed here.
+# cpu/memory are the service-wide averages across every running container;
+# per_task.*.max_pct is the hottest single one, which the average hides.
+APNS_MOCK_DEFS=(
+  ".apns_mock.cpu_utilization.Average|apns-mock CPU|%|15|30|false|lt|90"
+  ".apns_mock.memory_utilization.Average|apns-mock Memory|%|15|30|false|lt|80"
+  ".apns_mock.per_task.cpu.max_pct|apns-mock CPU (hottest task)|%|20|40|false|lt|95"
+  ".apns_mock.per_task.memory.max_pct|apns-mock Memory (hottest task)|%|20|40|false|lt|90"
+  ".apns_mock.task_counts.runningCount|apns-mock Containers||0|0|false||"
+  ".apns_mock.network.network_tx_bytes.Sum|apns-mock Network TX|bytes|50|100|false||"
+  ".apns_mock.container_health.abnormal_stops|apns-mock Stops||0|0|true|eq|0"
+)
+
+# The mock's dedicated Redis. Load tracks the push rate and instance count, not
+# the connection count -- each task holds one subscribe connection plus a small
+# pool. An eviction is a pending push dropped before its device reconnected.
+APNS_REDIS_DEFS=(
+  ".apns_mock_redis[0].cpu_utilization.Average|apns Redis CPU|%|20|40|false|lt|80"
+  ".apns_mock_redis[0].cpu_utilization.Maximum|apns Redis CPU (max)|%|20|40|false||"
+  ".apns_mock_redis[0].memory_utilization.Average|apns Redis Memory|%|15|30|false|lt|70"
+  ".apns_mock_redis[0].curr_connections.Average|apns Redis Conns||50|100|false||"
+  ".apns_mock_redis[0].curr_items.Average|apns Redis Pending Items||50|100|false||"
+  ".apns_mock_redis[0].evictions.Sum|apns Redis Evictions||0|0|true|eq|0"
+  ".apns_mock_redis[0].string_based_cmds.Sum|apns Redis String Cmds||50|100|false||"
+  ".apns_mock_redis[0].pubsub_based_cmds.Sum|apns Redis PubSub Cmds||50|100|false||"
+)
+
 # ALB metrics
 ALB_DEFS=(
   ".alb.target_response_time.Average|ALB Latency|s|50|100|false||"
@@ -478,6 +507,8 @@ echo "$separator"
 compare_metric_set "Fleet Server" "${METRIC_DEFS[@]:0:3}"
 compare_metric_set "RDS Writer" "${METRIC_DEFS[@]:3:5}"
 compare_metric_set "Redis" "${METRIC_DEFS[@]:8:2}"
+compare_metric_set "apns-mock" "${APNS_MOCK_DEFS[@]}"
+compare_metric_set "apns-mock Redis" "${APNS_REDIS_DEFS[@]}"
 compare_metric_set "ALB" "${ALB_DEFS[@]}"
 compare_metric_set "RDS Writer (extended)" "${RDS_WRITER_EXT_DEFS[@]}"
 compare_metric_set "Aurora Replication" "${RDS_READER_EXT_DEFS[@]}"

--- a/tools/loadtest/metrics/dashboard.html
+++ b/tools/loadtest/metrics/dashboard.html
@@ -60,6 +60,7 @@
   .run-item { display: flex; align-items: baseline; gap: 7px; padding: 2px 0; }
   .run-item label { cursor: pointer; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .run-item .date { color: var(--muted); font-size: 12px; }
+  .run-note { color: var(--muted); font-size: 12px; font-style: italic; margin: 0 0 4px 24px; white-space: normal; }
   .cat-toggle { font-size: 12px; color: var(--accent); cursor: pointer; background: none; border: none; padding: 0 4px; }
 
   main { flex: 1; padding: 18px 22px; overflow-x: hidden; }
@@ -192,6 +193,25 @@ const REGISTRY = [
   { group: 'Loadtest', name: 'Loadtest Memory', path: 'loadtest_containers.memory_utilization.Average', unit: '%', warn: 20, alert: 40, abs: 90, floor: 5 },
   { group: 'Loadtest', name: 'Loadtest Containers', path: 'loadtest_containers.task_counts.runningCount', unit: '', dir: 'info' },
 
+  // CPU/Memory are service-wide averages across every running container; the
+  // hottest-task rows are what reveal an unevenly loaded instance.
+  { group: 'apns-mock', name: 'apns-mock CPU', path: 'apns_mock.cpu_utilization.Average', unit: '%', warn: 15, alert: 30, abs: 90, floor: 5 },
+  { group: 'apns-mock', name: 'apns-mock Memory', path: 'apns_mock.memory_utilization.Average', unit: '%', warn: 15, alert: 30, abs: 80, floor: 5 },
+  { group: 'apns-mock', name: 'apns-mock CPU (hottest task)', path: 'apns_mock.per_task.cpu.max_pct', unit: '%', warn: 20, alert: 40, abs: 95, floor: 5 },
+  { group: 'apns-mock', name: 'apns-mock Memory (hottest task)', path: 'apns_mock.per_task.memory.max_pct', unit: '%', warn: 20, alert: 40, abs: 90, floor: 5 },
+  { group: 'apns-mock', name: 'apns-mock Containers', path: 'apns_mock.task_counts.runningCount', unit: '', dir: 'info' },
+  { group: 'apns-mock', name: 'apns-mock Traffic TX/h', path: 'apns_mock.network.network_tx_bytes.Sum', unit: 'bytes', dir: 'info', rate: true },
+  { group: 'apns-mock', name: 'apns-mock Stops', path: 'apns_mock.container_health.abnormal_stops', unit: '', zero: true },
+
+  { group: 'apns-mock Redis', name: 'apns Redis CPU', path: 'apns_mock_redis.0.cpu_utilization.Average', unit: '%', warn: 20, alert: 40, abs: 80, floor: 5 },
+  { group: 'apns-mock Redis', name: 'apns Redis CPU (max)', path: 'apns_mock_redis.0.cpu_utilization.Maximum', unit: '%', warn: 20, alert: 40, floor: 5 },
+  { group: 'apns-mock Redis', name: 'apns Redis Memory', path: 'apns_mock_redis.0.memory_utilization.Average', unit: '%', warn: 15, alert: 30, abs: 70, floor: 5 },
+  { group: 'apns-mock Redis', name: 'apns Redis Conns', path: 'apns_mock_redis.0.curr_connections.Average', unit: '', warn: 50, alert: 100, floor: 5 },
+  { group: 'apns-mock Redis', name: 'apns Redis Pending Items', path: 'apns_mock_redis.0.curr_items.Average', unit: '', warn: 50, alert: 100, floor: 100 },
+  { group: 'apns-mock Redis', name: 'apns Redis Evictions/h', path: 'apns_mock_redis.0.evictions.Sum', unit: '', zero: true, rate: true },
+  { group: 'apns-mock Redis', name: 'apns Redis String Cmds/h', path: 'apns_mock_redis.0.string_based_cmds.Sum', unit: '', dir: 'info', rate: true },
+  { group: 'apns-mock Redis', name: 'apns Redis PubSub Cmds/h', path: 'apns_mock_redis.0.pubsub_based_cmds.Sum', unit: '', dir: 'info', rate: true },
+
   { group: 'RDS Writer', name: 'Writer CPU', path: 'rds_writer.cpu_utilization.Average', unit: '%', warn: 15, alert: 30, abs: 80, floor: 5 },
   { group: 'RDS Writer', name: 'Writer Connections', path: 'rds_writer.database_connections.Average', unit: '', warn: 50, alert: 100, floor: 50 },
   { group: 'RDS Writer', name: 'Writer Read IOPS', path: 'rds_writer.read_iops.Average', unit: '', warn: 50, alert: 100, floor: 200 },
@@ -237,7 +257,7 @@ const REGISTRY = [
 
 /* ============================ state ============================ */
 const state = {
-  runs: [],                 // {id, workspace, category, collectedAt, interval, hours, data}
+  runs: [],                 // {id, workspace, category, collectedAt, interval, hours, note, data}
   selected: new Set(),      // run ids
   metric: REGISTRY[0],      // registry entry or {name, path, raw:true}
   view: 'overview',
@@ -387,6 +407,9 @@ async function ingestFiles(fileRecs) {
     state.runs.push({
       id, workspace: ws, collectedAt: ts, interval,
       hours: intervalHours(interval),
+      // Optional free-form annotation from `collect-metrics.sh --note`; absent on
+      // un-annotated runs. Displayed only — never charted or compared.
+      note: typeof data.metadata.note === 'string' ? data.metadata.note.trim() : '',
       category: inferCategory(relPath, ws, data.metadata.category),
       data,
     });
@@ -456,9 +479,16 @@ function renderRunList() {
       dt.className = 'date';
       dt.textContent = r.collectedAt.slice(0, 10) + ' · ' + r.interval;
       lb.appendChild(dt);
-      lb.title = r.workspace + ' — collected ' + r.collectedAt + ' (' + r.interval + ' window)';
+      lb.title = r.workspace + ' — collected ' + r.collectedAt + ' (' + r.interval + ' window)'
+        + (r.note ? '\n\n' + r.note : '');
       div.append(cb, lb);
       el.appendChild(div);
+      if (r.note) {
+        const nt = document.createElement('div');
+        nt.className = 'run-note';
+        nt.textContent = r.note;
+        el.appendChild(nt);
+      }
     }
   }
 }
@@ -660,6 +690,12 @@ function renderDetail() {
       tip.appendChild(trun);
       tip.append(p.run.collectedAt + ' · ' + p.run.interval + ' window');
       tip.appendChild(document.createElement('br'));
+      if (p.run.note) {
+        const tn = document.createElement('em');
+        tn.textContent = p.run.note;
+        tip.appendChild(tn);
+        tip.appendChild(document.createElement('br'));
+      }
       tip.append(m.name + ': ');
       const val = document.createElement('b');
       val.textContent = fmtVal(p.value, m.unit);

--- a/tools/loadtest/metrics/runs/mdm/mock-apns/mock-apns-2026-08-21-171402Z-1h.json
+++ b/tools/loadtest/metrics/runs/mdm/mock-apns/mock-apns-2026-08-21-171402Z-1h.json
@@ -1,0 +1,836 @@
+{
+  "metadata": {
+    "workspace": "mock-apns",
+    "collected_at": "2026-08-21T17:14:02Z",
+    "region": "us-east-2",
+    "interval": "1h",
+    "time_window": {
+      "start": "2026-08-21T16:14:02Z",
+      "end": "2026-08-21T17:14:02Z"
+    },
+    "note": "15 mins after 76k enrolled with 2 profiles on the enrolling team"
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 71.37,
+      "Minimum": 48.58,
+      "Maximum": 80.61,
+      "Unit": "Percent",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 5.58,
+      "Minimum": 3.79,
+      "Maximum": 6.66,
+      "Unit": "Percent",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 40,
+      "desiredCount": 40
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 9.91,
+      "Minimum": 8.95,
+      "Maximum": 10.58,
+      "Unit": "Percent",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 9.02,
+      "Minimum": 6.62,
+      "Maximum": 10.65,
+      "Unit": "Percent",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 38,
+      "desiredCount": 38
+    }
+  },
+  "apns_mock": {
+    "service": "fleet-mock-apns-apple-apns-mock",
+    "cpu_utilization": {
+      "Average": 3.82,
+      "Minimum": 3.36,
+      "Maximum": 4.28,
+      "Unit": "Percent",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 13.26,
+      "Minimum": 6.79,
+      "Maximum": 16,
+      "Unit": "Percent",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "per_task": {
+      "cpu": {
+        "avg_pct": 3.82,
+        "max_pct": 7.83,
+        "spread_pct": 4.01
+      },
+      "memory": {
+        "avg_pct": 13.26,
+        "max_pct": 16.16,
+        "spread_pct": 2.9
+      }
+    },
+    "network": {
+      "network_rx_bytes": {
+        "Timestamp": "2026-08-21T18:14:00+02:00",
+        "Average": 333849.14,
+        "Sum": 40061897,
+        "Unit": "Bytes/Second",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "network_tx_bytes": {
+        "Timestamp": "2026-08-21T18:14:00+02:00",
+        "Average": 345965.82,
+        "Sum": 41515898,
+        "Unit": "Bytes/Second",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      }
+    },
+    "task_counts": {
+      "runningCount": 2,
+      "desiredCount": 2
+    },
+    "container_health": {
+      "abnormal_stops": 0,
+      "running_tasks": 2,
+      "start_spread_min": 21.17,
+      "start_spread_alert": true,
+      "tasks": [
+        {
+          "task_id": "b5c169a022734b6baaba4b2029274dd0",
+          "started_at": "2026-08-21T17:10:49.867000+02:00",
+          "uptime_min": 3.22
+        },
+        {
+          "task_id": "39f68e1f39b643d89fa05d54efbfd2b8",
+          "started_at": "2026-08-21T17:31:59.630000+02:00",
+          "uptime_min": -17.95
+        }
+      ]
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Timestamp": "2026-08-21T18:14:00+02:00",
+      "Average": 34.7,
+      "Minimum": 17.19,
+      "Maximum": 50.12,
+      "Unit": "Percent",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "database_connections": {
+      "Timestamp": "2026-08-21T18:14:00+02:00",
+      "Average": 508.62,
+      "Minimum": 252,
+      "Maximum": 809,
+      "Unit": "Count",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "read_iops": {
+      "Timestamp": "2026-08-21T18:14:00+02:00",
+      "Average": 0.02,
+      "Maximum": 0.45,
+      "Unit": "Count/Second",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "write_iops": {
+      "Timestamp": "2026-08-21T18:14:00+02:00",
+      "Average": 3222.44,
+      "Maximum": 3663.6,
+      "Unit": "Count/Second",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "deadlocks": {
+      "Timestamp": "2026-08-21T18:14:00+02:00",
+      "Average": 0,
+      "Sum": 0,
+      "Maximum": 0,
+      "Unit": "Count/Second",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    }
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-21T18:14:00+02:00",
+        "Average": 29.51,
+        "Minimum": 16.73,
+        "Maximum": 40.77,
+        "Unit": "Percent",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-08-21T18:14:00+02:00",
+        "Average": 191.18,
+        "Minimum": 141,
+        "Maximum": 220,
+        "Unit": "Count",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-08-21T18:14:00+02:00",
+        "Average": 103.98,
+        "Maximum": 687.78,
+        "Unit": "Count/Second",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-08-21T18:14:00+02:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      }
+    },
+    {
+      "instance": "reader-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-21T18:14:00+02:00",
+        "Average": 30.52,
+        "Minimum": 18.2,
+        "Maximum": 38.6,
+        "Unit": "Percent",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-08-21T18:14:00+02:00",
+        "Average": 193.52,
+        "Minimum": 145,
+        "Maximum": 234,
+        "Unit": "Count",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-08-21T18:14:00+02:00",
+        "Average": 103.54,
+        "Maximum": 674.91,
+        "Unit": "Count/Second",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-08-21T18:14:00+02:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "rds_performance_insights": {
+    "writer": [
+      {
+        "rank": 1,
+        "sql": "COMMIT",
+        "load_avg": 4.41
+      },
+      {
+        "rank": 2,
+        "sql": "SELECT COUNT ( * ) FROM `identity_certificates` WHERE NAME = ? ",
+        "load_avg": 0.6
+      },
+      {
+        "rank": 3,
+        "sql": "INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... */ , ( ?, ... ",
+        "load_avg": 0.29
+      },
+      {
+        "rank": 4,
+        "sql": "INSERT INTO `identity_serials` ( ) VALUES ( )",
+        "load_avg": 0.13
+      },
+      {
+        "rank": 5,
+        "sql": "SELECT NAME , `id` , CHECKSUM , `title_id` , `bundle_identifier` , SOURCE , `upgrade_code` FROM `software` WHERE CHECKSUM IN ( ?, ... ",
+        "load_avg": 0.08
+      }
+    ],
+    "readers": [
+      {
+        "instance": "reader-1",
+        "top_sql": [
+          {
+            "rank": 1,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` IS NULL AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` .",
+            "load_avg": 0.18
+          },
+          {
+            "rank": 2,
+            "sql": "SELECT `hm` . `host_id` , `hm` . `enrolled` , `hm` . `server_url` , `hm` . `installed_from_dep` , `hm` . `mdm_id` , `hm` . `is_personal_enrollment` , `hm` . `managed_apple_id` , COALESCE ( `hm` . `is_server` , FALSE ) AS `is_server` , COALESCE ( `mdms` . NAME , ? ) AS NAME , `hdep` . `assign_profile_response` AS `dep_profile_assign_status` , CASE WHEN `hm` . `enrolled` = ? AND `h` . `platform` = ? THEN EXISTS ( SELECT ? FROM `mdm_windows_enrollments` `mwe` WHERE `mwe` . `host_uuid` = `h` . `uuid",
+            "load_avg": 0.18
+          },
+          {
+            "rank": 3,
+            "sql": "SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` JOIN `label_membership` `lm` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . `target_id` = `lm` . `label_id` AND `pt` . TYPE = ? ) WHERE `lm` . `host_id` = ? AND NOT `p` . `disabled` AND `p` . `pack_type` IS NULL ) UNION ALL ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . TYPE = ? AND `pt` . `target_id` = ? ) WHERE NOT `p` . `disabled` AND `p` . ",
+            "load_avg": 0.16
+          },
+          {
+            "rank": 4,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` = ? AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` . `id",
+            "load_avg": 0.12
+          },
+          {
+            "rank": 5,
+            "sql": "SELECT `id` , `host_id` , `execution_id` , `script_id` , `created_at` FROM ( SELECT `ua` . `id` , `ua` . `host_id` , `ua` . `execution_id` , `sua` . `script_id` , `ua` . `priority` , `ua` . `created_at` , IF ( `ua` . `activated_at` IS NULL , ?, ... ) AS `topmost` FROM `upcoming_activities` `ua` LEFT JOIN `script_upcoming_activities` `sua` ON `ua` . `id` = `sua` . `upcoming_activity_id` WHERE `ua` . `host_id` = ? AND `ua` . `activity_type` IN (...) AND `ua` . `activated_at` IS NOT NULL ORDER BY `",
+            "load_avg": 0.11
+          }
+        ]
+      },
+      {
+        "instance": "reader-2",
+        "top_sql": [
+          {
+            "rank": 1,
+            "sql": "SELECT ? AS `team_id` , ? AS `global_stats` , `combined_results` . `cve` , COUNT ( * ) AS `host_count` FROM ( SELECT `sc` . `cve` , `hs` . `host_id` FROM `software_cve` `sc` INNER JOIN `host_software` `hs` ON `sc` . `software_id` = `hs` . `software_id` WHERE `sc` . `cve` IN (...) UNION SELECT `osv` . `cve` , `hos` . `host_id` FROM `operating_system_vulnerabilities` `osv` INNER JOIN `host_operating_system` `hos` ON `hos` . `os_id` = `osv` . `operating_system_id` WHERE `osv` . `cve` IN (...) ) AS ",
+            "load_avg": 0.2
+          },
+          {
+            "rank": 2,
+            "sql": "SELECT `hm` . `host_id` , `hm` . `enrolled` , `hm` . `server_url` , `hm` . `installed_from_dep` , `hm` . `mdm_id` , `hm` . `is_personal_enrollment` , `hm` . `managed_apple_id` , COALESCE ( `hm` . `is_server` , FALSE ) AS `is_server` , COALESCE ( `mdms` . NAME , ? ) AS NAME , `hdep` . `assign_profile_response` AS `dep_profile_assign_status` , CASE WHEN `hm` . `enrolled` = ? AND `h` . `platform` = ? THEN EXISTS ( SELECT ? FROM `mdm_windows_enrollments` `mwe` WHERE `mwe` . `host_uuid` = `h` . `uuid",
+            "load_avg": 0.18
+          },
+          {
+            "rank": 3,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` IS NULL AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` .",
+            "load_avg": 0.17
+          },
+          {
+            "rank": 4,
+            "sql": "SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` JOIN `label_membership` `lm` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . `target_id` = `lm` . `label_id` AND `pt` . TYPE = ? ) WHERE `lm` . `host_id` = ? AND NOT `p` . `disabled` AND `p` . `pack_type` IS NULL ) UNION ALL ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . TYPE = ? AND `pt` . `target_id` = ? ) WHERE NOT `p` . `disabled` AND `p` . ",
+            "load_avg": 0.17
+          },
+          {
+            "rank": 5,
+            "sql": "SELECT `h` . `team_id` AS `team_id` , ? AS `global_stats` , `combined_results` . `cve` , COUNT ( * ) AS `host_count` FROM ( SELECT `sc` . `cve` , `hs` . `host_id` FROM `software_cve` `sc` INNER JOIN `host_software` `hs` ON `sc` . `software_id` = `hs` . `software_id` WHERE `sc` . `cve` IN (...) UNION SELECT `osv` . `cve` , `hos` . `host_id` FROM `operating_system_vulnerabilities` `osv` INNER JOIN `host_operating_system` `hos` ON `hos` . `os_id` = `osv` . `operating_system_id` WHERE `osv` . `cve` ",
+            "load_avg": 0.16
+          }
+        ]
+      }
+    ]
+  },
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-21T18:14:00+02:00",
+        "Average": 42.84,
+        "Minimum": 22.41,
+        "Maximum": 51.42,
+        "Unit": "Percent",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-08-21T18:14:00+02:00",
+        "Average": 2.88,
+        "Minimum": 1.23,
+        "Maximum": 3.59,
+        "Unit": "Percent",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-21T18:14:00+02:00",
+        "Average": 5.88,
+        "Minimum": 3.46,
+        "Maximum": 6.84,
+        "Unit": "Percent",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-08-21T18:14:00+02:00",
+        "Average": 2.83,
+        "Minimum": 1.18,
+        "Maximum": 3.55,
+        "Unit": "Percent",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-3",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-21T18:14:00+02:00",
+        "Average": 6.28,
+        "Minimum": 3.72,
+        "Maximum": 7.33,
+        "Unit": "Percent",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-08-21T18:14:00+02:00",
+        "Average": 2.83,
+        "Minimum": 1.18,
+        "Maximum": 3.55,
+        "Unit": "Percent",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "apns_mock_redis": [
+    {
+      "node": "apns-redis-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-21T18:14:00+02:00",
+        "Average": 0.55,
+        "Minimum": 0.15,
+        "Maximum": 1.4,
+        "Unit": "Percent",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-08-21T18:14:00+02:00",
+        "Average": 0.19,
+        "Minimum": 0.19,
+        "Maximum": 0.2,
+        "Unit": "Percent",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "curr_connections": {
+        "Timestamp": "2026-08-21T18:14:00+02:00",
+        "Average": 22.17,
+        "Maximum": 23,
+        "Unit": "Count",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "curr_items": {
+        "Timestamp": "2026-08-21T18:14:00+02:00",
+        "Average": 10.05,
+        "Maximum": 426,
+        "Unit": "Count",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-08-21T18:14:00+02:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "string_based_cmds": {
+        "Timestamp": "2026-08-21T18:14:00+02:00",
+        "Average": 13724.52,
+        "Sum": 823471,
+        "Unit": "Count",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "pubsub_based_cmds": {
+        "Timestamp": "2026-08-21T18:14:00+02:00",
+        "Average": 6847.4,
+        "Sum": 410844,
+        "Unit": "Count",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "network_bytes_out": {
+        "Timestamp": "2026-08-21T18:14:00+02:00",
+        "Average": 4871916.25,
+        "Sum": 292314975,
+        "Unit": "Bytes",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "alb": {
+    "target_response_time": {
+      "Timestamp": "2026-08-21T18:14:00+02:00",
+      "Average": 0,
+      "Minimum": 0,
+      "Maximum": 24.46,
+      "Unit": "Seconds",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "http_5xx_count": null,
+    "request_count": {
+      "Timestamp": "2026-08-21T18:14:00+02:00",
+      "Sum": 101746072,
+      "Unit": "Count",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "processed_bytes": {
+      "Timestamp": "2026-08-21T18:14:00+02:00",
+      "Sum": 210869335543,
+      "Unit": "Bytes",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    }
+  },
+  "fleet_server_errors": {
+    "error_count": 227.0,
+    "sample_messages": [
+      "{\"ts\":\"2026-08-21T15:03:33Z\",\"level\":\"warn\",\"msg\":\"could not connect to db\",\"err\":\"dial tcp: lookup fleet-mock-apns.cluster-c1oznuzxq7g2.us-east-2.rds.amazonaws.com on 10.12.0.2:53: no such host\",\"sleep_interval\":\"11s\"}",
+      "{\"ts\":\"2026-08-21T15:03:29Z\",\"level\":\"warn\",\"msg\":\"could not connect to db\",\"err\":\"dial tcp: lookup fleet-mock-apns.cluster-c1oznuzxq7g2.us-east-2.rds.amazonaws.com on 10.12.0.2:53: no such host\",\"sleep_interval\":\"11s\"}",
+      "{\"ts\":\"2026-08-21T15:03:23Z\",\"level\":\"warn\",\"msg\":\"could not connect to db\",\"err\":\"dial tcp: lookup fleet-mock-apns.cluster-c1oznuzxq7g2.us-east-2.rds.amazonaws.com on 10.12.0.2:53: no such host\",\"sleep_interval\":\"10s\"}",
+      "{\"ts\":\"2026-08-21T15:03:20Z\",\"level\":\"warn\",\"msg\":\"could not connect to db\",\"err\":\"dial tcp: lookup fleet-mock-apns.cluster-c1oznuzxq7g2.us-east-2.rds.amazonaws.com on 10.12.0.2:53: no such host\",\"sleep_interval\":\"7s\"}",
+      "{\"ts\":\"2026-08-21T15:03:19Z\",\"level\":\"warn\",\"msg\":\"could not connect to db\",\"err\":\"dial tcp: lookup fleet-mock-apns.cluster-c1oznuzxq7g2.us-east-2.rds.amazonaws.com on 10.12.0.2:53: no such host\",\"sleep_interval\":\"10s\"}",
+      "{\"ts\":\"2026-08-21T15:03:14Z\",\"level\":\"warn\",\"msg\":\"could not connect to db\",\"err\":\"dial tcp: lookup fleet-mock-apns.cluster-c1oznuzxq7g2.us-east-2.rds.amazonaws.com on 10.12.0.2:53: no such host\",\"sleep_interval\":\"6s\"}",
+      "{\"ts\":\"2026-08-21T15:03:14Z\",\"level\":\"warn\",\"msg\":\"could not connect to db\",\"err\":\"dial tcp: lookup fleet-mock-apns.cluster-c1oznuzxq7g2.us-east-2.rds.amazonaws.com on 10.12.0.2:53: no such host\",\"sleep_interval\":\"9s\"}",
+      "{\"ts\":\"2026-08-21T15:03:10Z\",\"level\":\"warn\",\"msg\":\"could not connect to db\",\"err\":\"dial tcp 10.12.23.30:3306: connect: connection refused\",\"sleep_interval\":\"5s\"}",
+      "{\"ts\":\"2026-08-21T15:03:10Z\",\"level\":\"warn\",\"msg\":\"could not connect to db\",\"err\":\"dial tcp 10.12.23.30:3306: connect: connection refused\",\"sleep_interval\":\"3s\"}",
+      "{\"ts\":\"2026-08-21T15:03:10Z\",\"level\":\"warn\",\"msg\":\"could not connect to db\",\"err\":\"dial tcp 10.12.23.30:3306: connect: connection refused\",\"sleep_interval\":\"5s\"}"
+    ]
+  },
+  "rds_writer_extended": {
+    "freeable_memory": {
+      "Timestamp": "2026-08-21T18:14:00+02:00",
+      "Average": 29497777766.4,
+      "Minimum": 29243908096,
+      "Unit": "Bytes",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "buffer_cache_hit_ratio": {
+      "Timestamp": "2026-08-21T18:14:00+02:00",
+      "Average": 100,
+      "Minimum": 100,
+      "Unit": "Percent",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "volume_bytes_used": {
+      "Timestamp": "2026-08-21T18:14:00+02:00",
+      "Average": 20722958336,
+      "Maximum": 20722958336,
+      "Unit": "Bytes",
+      "data_points": 6,
+      "max_points": 12,
+      "data_coverage": 0.5
+    },
+    "select_latency": {
+      "Timestamp": "2026-08-21T18:14:00+02:00",
+      "Average": 1.73,
+      "Maximum": 7.99,
+      "Unit": "Milliseconds",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "insert_latency": {
+      "Timestamp": "2026-08-21T18:14:00+02:00",
+      "Average": 2.43,
+      "Maximum": 4.78,
+      "Unit": "Milliseconds",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "dml_latency": {
+      "Timestamp": "2026-08-21T18:14:00+02:00",
+      "Average": 1.55,
+      "Maximum": 2.72,
+      "Unit": "Milliseconds",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "threads_running": {
+      "average": 6.18,
+      "maximum": 11.31,
+      "vcpus": 16
+    },
+    "iops_utilization": {
+      "instance_class": "db.r6g.4xlarge",
+      "max_iops": 20000,
+      "read_iops_avg": 0.02,
+      "write_iops_avg": 3222.44,
+      "total_iops_avg": 3222.46,
+      "utilization_pct": 16.11
+    }
+  },
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-08-21T18:14:00+02:00",
+        "Average": 6.2,
+        "Maximum": 13,
+        "Unit": "Milliseconds",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-08-21T18:14:00+02:00",
+        "Average": 30484863658.67,
+        "Minimum": 30255128576,
+        "Unit": "Bytes",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-08-21T18:14:00+02:00",
+        "Average": 99.97,
+        "Minimum": 99.86,
+        "Unit": "Percent",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-08-21T18:14:00+02:00",
+        "Average": 0.34,
+        "Maximum": 0.66,
+        "Unit": "Milliseconds",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "iops_utilization": {
+        "instance_class": "db.r6g.4xlarge",
+        "max_iops": 20000,
+        "read_iops_avg": 103.98,
+        "write_iops_avg": 0,
+        "total_iops_avg": 103.98,
+        "utilization_pct": 0.52
+      },
+      "threads_running": {
+        "average": 2.09,
+        "maximum": 3.39,
+        "vcpus": 16
+      }
+    },
+    {
+      "instance": "reader-2",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-08-21T18:14:00+02:00",
+        "Average": 6.37,
+        "Maximum": 15,
+        "Unit": "Milliseconds",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-08-21T18:14:00+02:00",
+        "Average": 30517444471.47,
+        "Minimum": 30331543552,
+        "Unit": "Bytes",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-08-21T18:14:00+02:00",
+        "Average": 99.97,
+        "Minimum": 99.86,
+        "Unit": "Percent",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-08-21T18:14:00+02:00",
+        "Average": 0.36,
+        "Maximum": 0.93,
+        "Unit": "Milliseconds",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "iops_utilization": {
+        "instance_class": "db.r6g.4xlarge",
+        "max_iops": 20000,
+        "read_iops_avg": 103.54,
+        "write_iops_avg": 0,
+        "total_iops_avg": 103.54,
+        "utilization_pct": 0.52
+      },
+      "threads_running": {
+        "average": 2.35,
+        "maximum": 3.15,
+        "vcpus": 16
+      }
+    }
+  ],
+  "redis_extended": [
+    {
+      "node": "redis-1",
+      "curr_connections": {
+        "Timestamp": "2026-08-21T18:14:00+02:00",
+        "Average": 299.88,
+        "Maximum": 1238,
+        "Unit": "Count",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-08-21T18:14:00+02:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": {
+        "Timestamp": "2026-08-21T18:14:00+02:00",
+        "Average": 83.27,
+        "Minimum": 75.07,
+        "Unit": "Percent",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "curr_connections": {
+        "Timestamp": "2026-08-21T18:14:00+02:00",
+        "Average": 5.53,
+        "Maximum": 6,
+        "Unit": "Count",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-08-21T18:14:00+02:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    },
+    {
+      "node": "redis-3",
+      "curr_connections": {
+        "Timestamp": "2026-08-21T18:14:00+02:00",
+        "Average": 6,
+        "Maximum": 6,
+        "Unit": "Count",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-08-21T18:14:00+02:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 12,
+        "max_points": 12,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    }
+  ],
+  "network": {
+    "network_rx_bytes": {
+      "Timestamp": "2026-08-21T18:14:00+02:00",
+      "Average": 1464874.58,
+      "Sum": 3515698987,
+      "Unit": "Bytes/Second",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    },
+    "network_tx_bytes": {
+      "Timestamp": "2026-08-21T18:14:00+02:00",
+      "Average": 505747.86,
+      "Sum": 1213794867,
+      "Unit": "Bytes/Second",
+      "data_points": 12,
+      "max_points": 12,
+      "data_coverage": 1
+    }
+  },
+  "container_health": {
+    "abnormal_stops": 0,
+    "running_tasks": 38,
+    "oldest_start": null,
+    "newest_start": null,
+    "start_spread_min": null,
+    "start_spread_alert": false,
+    "tasks": []
+  }
+}

--- a/tools/loadtest/metrics/runs/mdm/mock-apns/mock-apns-2026-08-21-171402Z-1h.md
+++ b/tools/loadtest/metrics/runs/mdm/mock-apns/mock-apns-2026-08-21-171402Z-1h.md
@@ -1,0 +1,63 @@
+# Metrics Synopsis: mock-apns
+
+- **Collected:** 2026-08-21T17:14:02Z
+- **Interval:** 1h
+- **Window:** 2026-08-21T16:14:02Z to 2026-08-21T17:14:02Z
+- **Note:** 15 mins after 76k enrolled with 2 profiles on the enrolling team
+
+## Summary (1h averages)
+
+```
+Fleet Server:  CPU=71.37%  Mem=5.58%  Containers=40
+Loadtest:      CPU=9.91%  Mem=9.02%  Containers=38
+apns-mock:     CPU=3.82%  Mem=13.26%  Containers=2  (averaged across containers)
+               PerTask CPU avg=3.82% max=7.83%   Mem avg=13.26% max=16.16%
+               RX=38.21MB  TX=39.59MB  AbnormalStops=0  StartSpread=21.17min  ⚠ STAGGERED STARTS
+apns Redis:    CPU=0.55% (max 1.4%)  Mem=0.19%  Conns=22.17  PendingItems=10.05  Evictions=0
+               StringCmds=823471  PubSubCmds=410844  NetOut=278.77MB
+RDS Writer:    CPU=34.7%  Connections=508.62  Deadlocks=0
+RDS reader-1:  CPU=29.51%  Connections=191.18
+RDS reader-2:  CPU=30.52%  Connections=193.52
+Redis:         CPU=42.84%  Mem=2.88%
+
+Top SQL (writer):
+  #1 load=4.41  COMMIT
+  #2 load=0.6  SELECT COUNT ( * ) FROM `identity_certificates` WHERE NAME = ? 
+  #3 load=0.29  INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... 
+  #4 load=0.13  INSERT INTO `identity_serials` ( ) VALUES ( )
+  #5 load=0.08  SELECT NAME , `id` , CHECKSUM , `title_id` , `bundle_identifier` , SOURCE , `upg
+
+Top SQL (reader-1):
+  #1 load=0.18  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #2 load=0.18  SELECT `hm` . `host_id` , `hm` . `enrolled` , `hm` . `server_url` , `hm` . `inst
+  #3 load=0.16  SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pa
+  #4 load=0.12  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #5 load=0.11  SELECT `id` , `host_id` , `execution_id` , `script_id` , `created_at` FROM ( SEL
+
+Top SQL (reader-2):
+  #1 load=0.2  SELECT ? AS `team_id` , ? AS `global_stats` , `combined_results` . `cve` , COUNT
+  #2 load=0.18  SELECT `hm` . `host_id` , `hm` . `enrolled` , `hm` . `server_url` , `hm` . `inst
+  #3 load=0.17  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #4 load=0.17  SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pa
+  #5 load=0.16  SELECT `h` . `team_id` AS `team_id` , ? AS `global_stats` , `combined_results` .
+ALB:           Latency=0s  5xx=0  Requests=101746072  Traffic=201100.67MB
+Fleet Errors:  Count=227.0
+RDS Writer:    FreeMem=27.47GB  CacheHit=100%  Disk=19.3GB  Threads=6.18  IOPS=16.11%
+               SelectLat=1.73ms  InsertLat=2.43ms
+RDS reader-1: FreeMem=28.39GB  CacheHit=99.97%  ReplicaLag=6.2ms  Threads=2.09  IOPS=0.52%
+               SelectLat=0.34ms
+RDS reader-2: FreeMem=28.42GB  CacheHit=99.97%  ReplicaLag=6.37ms  Threads=2.35  IOPS=0.52%
+               SelectLat=0.36ms
+Redis:         Connections=299.88  Evictions=0  CacheHit=83.27%
+Network:       RX=3352.83MB  TX=1157.56MB
+Containers:    Running=38  AbnormalStops=0  StartSpread=N/Amin
+```
+
+## Threshold Checks
+
+```
+  🔴 ALERT: apns-mock Start Spread (min) = 21.17 (expected < 10)
+  🔴 ALERT: Fleet Server Errors = 227.0 (expected 0)
+
+  ⚠ 2 alert(s) detected
+```

--- a/tools/loadtest/metrics/runs/mdm/mock-apns/mock-apns-2026-08-21-172709Z-20m.json
+++ b/tools/loadtest/metrics/runs/mdm/mock-apns/mock-apns-2026-08-21-172709Z-20m.json
@@ -1,0 +1,739 @@
+{
+  "metadata": {
+    "workspace": "mock-apns",
+    "collected_at": "2026-08-21T17:27:09Z",
+    "region": "us-east-2",
+    "interval": "20m",
+    "time_window": {
+      "start": "2026-08-21T17:07:09Z",
+      "end": "2026-08-21T17:27:09Z"
+    },
+    "note": "76k enrolled with 2 profiles on the enrolling team"
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 80.55,
+      "Minimum": 79.77,
+      "Maximum": 80.91,
+      "Unit": "Percent",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 6.74,
+      "Minimum": 6.53,
+      "Maximum": 6.99,
+      "Unit": "Percent",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 40,
+      "desiredCount": 40
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 9.88,
+      "Minimum": 9.86,
+      "Maximum": 9.91,
+      "Unit": "Percent",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 10.66,
+      "Minimum": 10.65,
+      "Maximum": 10.66,
+      "Unit": "Percent",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 38,
+      "desiredCount": 38
+    }
+  },
+  "apns_mock": {
+    "service": "fleet-mock-apns-apple-apns-mock",
+    "cpu_utilization": {
+      "Average": 3.38,
+      "Minimum": 3.35,
+      "Maximum": 3.41,
+      "Unit": "Percent",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 15.68,
+      "Minimum": 15.66,
+      "Maximum": 15.71,
+      "Unit": "Percent",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "per_task": {
+      "cpu": {
+        "avg_pct": 3.38,
+        "max_pct": 4.3,
+        "spread_pct": 0.92
+      },
+      "memory": {
+        "avg_pct": 15.68,
+        "max_pct": 15.77,
+        "spread_pct": 0.1
+      }
+    },
+    "network": {
+      "network_rx_bytes": {
+        "Timestamp": "2026-08-21T19:07:00+02:00",
+        "Average": 342025.6,
+        "Sum": 13681024,
+        "Unit": "Bytes/Second",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "network_tx_bytes": {
+        "Timestamp": "2026-08-21T19:07:00+02:00",
+        "Average": 374299.1,
+        "Sum": 14971964,
+        "Unit": "Bytes/Second",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      }
+    },
+    "task_counts": {
+      "runningCount": 2,
+      "desiredCount": 2
+    },
+    "container_health": {
+      "abnormal_stops": 0,
+      "running_tasks": 2,
+      "start_spread_min": 21.16,
+      "start_spread_alert": true,
+      "tasks": [
+        {
+          "task_id": "b5c169a022734b6baaba4b2029274dd0",
+          "started_at": "2026-08-21T17:10:49.867000+02:00",
+          "uptime_min": 16.33
+        },
+        {
+          "task_id": "39f68e1f39b643d89fa05d54efbfd2b8",
+          "started_at": "2026-08-21T17:31:59.630000+02:00",
+          "uptime_min": -4.83
+        }
+      ]
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Timestamp": "2026-08-21T19:07:00+02:00",
+      "Average": 23.27,
+      "Minimum": 19.43,
+      "Maximum": 30.62,
+      "Unit": "Percent",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "database_connections": {
+      "Timestamp": "2026-08-21T19:07:00+02:00",
+      "Average": 393.55,
+      "Minimum": 320,
+      "Maximum": 421,
+      "Unit": "Count",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "read_iops": {
+      "Timestamp": "2026-08-21T19:07:00+02:00",
+      "Average": 0.01,
+      "Maximum": 0.03,
+      "Unit": "Count/Second",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "write_iops": {
+      "Timestamp": "2026-08-21T19:07:00+02:00",
+      "Average": 2786.04,
+      "Maximum": 3466.13,
+      "Unit": "Count/Second",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "deadlocks": {
+      "Timestamp": "2026-08-21T19:07:00+02:00",
+      "Average": 0,
+      "Sum": 0,
+      "Maximum": 0,
+      "Unit": "Count/Second",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    }
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-21T19:07:00+02:00",
+        "Average": 33.66,
+        "Minimum": 30.18,
+        "Maximum": 47.24,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-08-21T19:07:00+02:00",
+        "Average": 178.95,
+        "Minimum": 141,
+        "Maximum": 395,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-08-21T19:07:00+02:00",
+        "Average": 39.83,
+        "Maximum": 208.11,
+        "Unit": "Count/Second",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-08-21T19:07:00+02:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      }
+    },
+    {
+      "instance": "reader-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-21T19:07:00+02:00",
+        "Average": 35.86,
+        "Minimum": 29.23,
+        "Maximum": 41.87,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-08-21T19:07:00+02:00",
+        "Average": 178.35,
+        "Minimum": 152,
+        "Maximum": 318,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-08-21T19:07:00+02:00",
+        "Average": 99.46,
+        "Maximum": 674.91,
+        "Unit": "Count/Second",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-08-21T19:07:00+02:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "rds_performance_insights": {
+    "writer": [],
+    "readers": [
+      {
+        "instance": "reader-1",
+        "top_sql": []
+      },
+      {
+        "instance": "reader-2",
+        "top_sql": []
+      }
+    ]
+  },
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-21T19:07:00+02:00",
+        "Average": 51.3,
+        "Minimum": 50.76,
+        "Maximum": 52.3,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-08-21T19:07:00+02:00",
+        "Average": 3.58,
+        "Minimum": 3.58,
+        "Maximum": 3.59,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-21T19:07:00+02:00",
+        "Average": 6.82,
+        "Minimum": 6.68,
+        "Maximum": 6.93,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-08-21T19:07:00+02:00",
+        "Average": 3.54,
+        "Minimum": 3.54,
+        "Maximum": 3.55,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-3",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-21T19:07:00+02:00",
+        "Average": 7.31,
+        "Minimum": 7.12,
+        "Maximum": 7.45,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-08-21T19:07:00+02:00",
+        "Average": 3.54,
+        "Minimum": 3.54,
+        "Maximum": 3.55,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "apns_mock_redis": [
+    {
+      "node": "apns-redis-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-21T19:07:00+02:00",
+        "Average": 0.16,
+        "Minimum": 0.13,
+        "Maximum": 0.18,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-08-21T19:07:00+02:00",
+        "Average": 0.19,
+        "Minimum": 0.19,
+        "Maximum": 0.19,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "curr_connections": {
+        "Timestamp": "2026-08-21T19:07:00+02:00",
+        "Average": 14.15,
+        "Maximum": 22,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "curr_items": {
+        "Timestamp": "2026-08-21T19:07:00+02:00",
+        "Average": 3.05,
+        "Maximum": 4,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-08-21T19:07:00+02:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "string_based_cmds": {
+        "Timestamp": "2026-08-21T19:07:00+02:00",
+        "Average": 1437.45,
+        "Sum": 28749,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "pubsub_based_cmds": {
+        "Timestamp": "2026-08-21T19:07:00+02:00",
+        "Average": 706.65,
+        "Sum": 14133,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "network_bytes_out": {
+        "Timestamp": "2026-08-21T19:07:00+02:00",
+        "Average": 1204260.1,
+        "Sum": 24085202,
+        "Unit": "Bytes",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "alb": {
+    "target_response_time": {
+      "Timestamp": "2026-08-21T19:07:00+02:00",
+      "Average": 0,
+      "Minimum": 0,
+      "Maximum": 7.29,
+      "Unit": "Seconds",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "http_5xx_count": null,
+    "request_count": {
+      "Timestamp": "2026-08-21T19:07:00+02:00",
+      "Sum": 42118201,
+      "Unit": "Count",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "processed_bytes": {
+      "Timestamp": "2026-08-21T19:07:00+02:00",
+      "Sum": 84521891915,
+      "Unit": "Bytes",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    }
+  },
+  "fleet_server_errors": {
+    "error_count": 0.0,
+    "sample_messages": []
+  },
+  "rds_writer_extended": {
+    "freeable_memory": {
+      "Timestamp": "2026-08-21T19:07:00+02:00",
+      "Average": 29324116582.4,
+      "Minimum": 29181132800,
+      "Unit": "Bytes",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "buffer_cache_hit_ratio": {
+      "Timestamp": "2026-08-21T19:07:00+02:00",
+      "Average": 100,
+      "Minimum": 100,
+      "Unit": "Percent",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "volume_bytes_used": null,
+    "select_latency": {
+      "Timestamp": "2026-08-21T19:07:00+02:00",
+      "Average": 2.26,
+      "Maximum": 7.99,
+      "Unit": "Milliseconds",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "insert_latency": {
+      "Timestamp": "2026-08-21T19:07:00+02:00",
+      "Average": 4.05,
+      "Maximum": 4.6,
+      "Unit": "Milliseconds",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "dml_latency": {
+      "Timestamp": "2026-08-21T19:07:00+02:00",
+      "Average": 2.3,
+      "Maximum": 2.55,
+      "Unit": "Milliseconds",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "threads_running": {
+      "average": 2.17,
+      "maximum": 2.67,
+      "vcpus": 16
+    },
+    "iops_utilization": {
+      "instance_class": "db.r6g.4xlarge",
+      "max_iops": 20000,
+      "read_iops_avg": 0.01,
+      "write_iops_avg": 2786.04,
+      "total_iops_avg": 2786.05,
+      "utilization_pct": 13.93
+    }
+  },
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-08-21T19:07:00+02:00",
+        "Average": 6.6,
+        "Maximum": 14,
+        "Unit": "Milliseconds",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-08-21T19:07:00+02:00",
+        "Average": 30498787328,
+        "Minimum": 30391132160,
+        "Unit": "Bytes",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-08-21T19:07:00+02:00",
+        "Average": 99.99,
+        "Minimum": 99.97,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-08-21T19:07:00+02:00",
+        "Average": 0.31,
+        "Maximum": 0.41,
+        "Unit": "Milliseconds",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "iops_utilization": {
+        "instance_class": "db.r6g.4xlarge",
+        "max_iops": 20000,
+        "read_iops_avg": 39.83,
+        "write_iops_avg": 0,
+        "total_iops_avg": 39.83,
+        "utilization_pct": 0.2
+      },
+      "threads_running": {
+        "average": 2.19,
+        "maximum": 2.5,
+        "vcpus": 16
+      }
+    },
+    {
+      "instance": "reader-2",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-08-21T19:07:00+02:00",
+        "Average": 6.8,
+        "Maximum": 15,
+        "Unit": "Milliseconds",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-08-21T19:07:00+02:00",
+        "Average": 30464575692.8,
+        "Minimum": 30368956416,
+        "Unit": "Bytes",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-08-21T19:07:00+02:00",
+        "Average": 99.98,
+        "Minimum": 99.86,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-08-21T19:07:00+02:00",
+        "Average": 0.38,
+        "Maximum": 0.85,
+        "Unit": "Milliseconds",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "iops_utilization": {
+        "instance_class": "db.r6g.4xlarge",
+        "max_iops": 20000,
+        "read_iops_avg": 99.46,
+        "write_iops_avg": 0,
+        "total_iops_avg": 99.46,
+        "utilization_pct": 0.5
+      },
+      "threads_running": {
+        "average": 2.82,
+        "maximum": 3.37,
+        "vcpus": 16
+      }
+    }
+  ],
+  "redis_extended": [
+    {
+      "node": "redis-1",
+      "curr_connections": {
+        "Timestamp": "2026-08-21T19:07:00+02:00",
+        "Average": 285.25,
+        "Maximum": 551,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-08-21T19:07:00+02:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": {
+        "Timestamp": "2026-08-21T19:07:00+02:00",
+        "Average": 85.63,
+        "Minimum": 85.43,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "curr_connections": {
+        "Timestamp": "2026-08-21T19:07:00+02:00",
+        "Average": 5.45,
+        "Maximum": 6,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-08-21T19:07:00+02:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    },
+    {
+      "node": "redis-3",
+      "curr_connections": {
+        "Timestamp": "2026-08-21T19:07:00+02:00",
+        "Average": 6,
+        "Maximum": 6,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-08-21T19:07:00+02:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    }
+  ],
+  "network": {
+    "network_rx_bytes": {
+      "Timestamp": "2026-08-21T19:07:00+02:00",
+      "Average": 1727400.96,
+      "Sum": 1381920766,
+      "Unit": "Bytes/Second",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "network_tx_bytes": {
+      "Timestamp": "2026-08-21T19:07:00+02:00",
+      "Average": 562244.13,
+      "Sum": 449795300,
+      "Unit": "Bytes/Second",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    }
+  },
+  "container_health": {
+    "abnormal_stops": 0,
+    "running_tasks": 38,
+    "oldest_start": null,
+    "newest_start": null,
+    "start_spread_min": null,
+    "start_spread_alert": false,
+    "tasks": []
+  }
+}

--- a/tools/loadtest/metrics/runs/mdm/mock-apns/mock-apns-2026-08-21-172709Z-20m.md
+++ b/tools/loadtest/metrics/runs/mdm/mock-apns/mock-apns-2026-08-21-172709Z-20m.md
@@ -1,0 +1,46 @@
+# Metrics Synopsis: mock-apns
+
+- **Collected:** 2026-08-21T17:27:09Z
+- **Interval:** 20m
+- **Window:** 2026-08-21T17:07:09Z to 2026-08-21T17:27:09Z
+- **Note:** 76k enrolled with 2 profiles on the enrolling team
+
+## Summary (20m averages)
+
+```
+Fleet Server:  CPU=80.55%  Mem=6.74%  Containers=40
+Loadtest:      CPU=9.88%  Mem=10.66%  Containers=38
+apns-mock:     CPU=3.38%  Mem=15.68%  Containers=2  (averaged across containers)
+               PerTask CPU avg=3.38% max=4.3%   Mem avg=15.68% max=15.77%
+               RX=13.05MB  TX=14.28MB  AbnormalStops=0  StartSpread=21.16min  ⚠ STAGGERED STARTS
+apns Redis:    CPU=0.16% (max 0.18%)  Mem=0.19%  Conns=14.15  PendingItems=3.05  Evictions=0
+               StringCmds=28749  PubSubCmds=14133  NetOut=22.97MB
+RDS Writer:    CPU=23.27%  Connections=393.55  Deadlocks=0
+RDS reader-1:  CPU=33.66%  Connections=178.95
+RDS reader-2:  CPU=35.86%  Connections=178.35
+Redis:         CPU=51.3%  Mem=3.58%
+
+Top SQL (reader-1):
+
+Top SQL (reader-2):
+ALB:           Latency=0s  5xx=0  Requests=42118201  Traffic=80606.36MB
+Fleet Errors:  Count=0.0
+RDS Writer:    FreeMem=27.31GB  CacheHit=100%  Disk=N/A  Threads=2.17  IOPS=13.93%
+               SelectLat=2.26ms  InsertLat=4.05ms
+RDS reader-1: FreeMem=28.4GB  CacheHit=99.99%  ReplicaLag=6.6ms  Threads=2.19  IOPS=0.2%
+               SelectLat=0.31ms
+RDS reader-2: FreeMem=28.37GB  CacheHit=99.98%  ReplicaLag=6.8ms  Threads=2.82  IOPS=0.5%
+               SelectLat=0.38ms
+Redis:         Connections=285.25  Evictions=0  CacheHit=85.63%
+Network:       RX=1317.9MB  TX=428.96MB
+Containers:    Running=38  AbnormalStops=0  StartSpread=N/Amin
+```
+
+## Threshold Checks
+
+```
+  🔴 ALERT: Fleet Server CPU avg = 80.55 (expected < 80)
+  🔴 ALERT: apns-mock Start Spread (min) = 21.16 (expected < 10)
+
+  ⚠ 2 alert(s) detected
+```

--- a/tools/loadtest/metrics/runs/mdm/mock-apns/mock-apns-2026-08-21-174828Z-20m.json
+++ b/tools/loadtest/metrics/runs/mdm/mock-apns/mock-apns-2026-08-21-174828Z-20m.json
@@ -1,0 +1,835 @@
+{
+  "metadata": {
+    "workspace": "mock-apns",
+    "collected_at": "2026-08-21T17:48:28Z",
+    "region": "us-east-2",
+    "interval": "20m",
+    "time_window": {
+      "start": "2026-08-21T17:28:28Z",
+      "end": "2026-08-21T17:48:28Z"
+    },
+    "note": "76k enrolled adding 3 profiles to all hosts"
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 82.27,
+      "Minimum": 80.03,
+      "Maximum": 84.29,
+      "Unit": "Percent",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 7.91,
+      "Minimum": 6.86,
+      "Maximum": 8.95,
+      "Unit": "Percent",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 40,
+      "desiredCount": 40
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 10.77,
+      "Minimum": 9.86,
+      "Maximum": 12.23,
+      "Unit": "Percent",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 11.15,
+      "Minimum": 10.68,
+      "Maximum": 11.66,
+      "Unit": "Percent",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 38,
+      "desiredCount": 38
+    }
+  },
+  "apns_mock": {
+    "service": "fleet-mock-apns-apple-apns-mock",
+    "cpu_utilization": {
+      "Average": 4.86,
+      "Minimum": 3.33,
+      "Maximum": 6.88,
+      "Unit": "Percent",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 17.6,
+      "Minimum": 15.66,
+      "Maximum": 20.01,
+      "Unit": "Percent",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "per_task": {
+      "cpu": {
+        "avg_pct": 4.86,
+        "max_pct": 9.37,
+        "spread_pct": 4.51
+      },
+      "memory": {
+        "avg_pct": 17.6,
+        "max_pct": 20.75,
+        "spread_pct": 3.15
+      }
+    },
+    "network": {
+      "network_rx_bytes": {
+        "Timestamp": "2026-08-21T19:28:00+02:00",
+        "Average": 452559,
+        "Sum": 18102360,
+        "Unit": "Bytes/Second",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "network_tx_bytes": {
+        "Timestamp": "2026-08-21T19:28:00+02:00",
+        "Average": 466141.2,
+        "Sum": 18645648,
+        "Unit": "Bytes/Second",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      }
+    },
+    "task_counts": {
+      "runningCount": 2,
+      "desiredCount": 2
+    },
+    "container_health": {
+      "abnormal_stops": 0,
+      "running_tasks": 2,
+      "start_spread_min": 21.17,
+      "start_spread_alert": true,
+      "tasks": [
+        {
+          "task_id": "b5c169a022734b6baaba4b2029274dd0",
+          "started_at": "2026-08-21T17:10:49.867000+02:00",
+          "uptime_min": 37.65
+        },
+        {
+          "task_id": "39f68e1f39b643d89fa05d54efbfd2b8",
+          "started_at": "2026-08-21T17:31:59.630000+02:00",
+          "uptime_min": 16.48
+        }
+      ]
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Timestamp": "2026-08-21T19:28:00+02:00",
+      "Average": 24.85,
+      "Minimum": 17.02,
+      "Maximum": 34.95,
+      "Unit": "Percent",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "database_connections": {
+      "Timestamp": "2026-08-21T19:28:00+02:00",
+      "Average": 508.9,
+      "Minimum": 194,
+      "Maximum": 806,
+      "Unit": "Count",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "read_iops": {
+      "Timestamp": "2026-08-21T19:28:00+02:00",
+      "Average": 0,
+      "Maximum": 0.02,
+      "Unit": "Count/Second",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "write_iops": {
+      "Timestamp": "2026-08-21T19:28:00+02:00",
+      "Average": 2752.27,
+      "Maximum": 3163.23,
+      "Unit": "Count/Second",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "deadlocks": {
+      "Timestamp": "2026-08-21T19:28:00+02:00",
+      "Average": 0,
+      "Sum": 0,
+      "Maximum": 0,
+      "Unit": "Count/Second",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    }
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-21T19:28:00+02:00",
+        "Average": 43.63,
+        "Minimum": 35.31,
+        "Maximum": 51.54,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-08-21T19:28:00+02:00",
+        "Average": 365.45,
+        "Minimum": 332,
+        "Maximum": 394,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-08-21T19:28:00+02:00",
+        "Average": 57.62,
+        "Maximum": 107.52,
+        "Unit": "Count/Second",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-08-21T19:28:00+02:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      }
+    },
+    {
+      "instance": "reader-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-21T19:28:00+02:00",
+        "Average": 25.49,
+        "Minimum": 19.17,
+        "Maximum": 34.47,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-08-21T19:28:00+02:00",
+        "Average": 281.25,
+        "Minimum": 247,
+        "Maximum": 318,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-08-21T19:28:00+02:00",
+        "Average": 44.54,
+        "Maximum": 107.61,
+        "Unit": "Count/Second",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-08-21T19:28:00+02:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "rds_performance_insights": {
+    "writer": [
+      {
+        "rank": 1,
+        "sql": "COMMIT",
+        "load_avg": 2.92
+      },
+      {
+        "rank": 2,
+        "sql": "INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... */ , ( ?, ... ",
+        "load_avg": 0.81
+      },
+      {
+        "rank": 3,
+        "sql": "SELECT `c` . `command_uuid` , `c` . `request_type` , `c` . `command` , `c` . `subtype` FROM `nano_enrollment_queue` AS `q` INNER JOIN `nano_commands` AS `c` ON `q` . `command_uuid` = `c` . `command_uuid` LEFT JOIN `nano_command_results` `r` ON `r` . `command_uuid` = `q` . `command_uuid` AND `r` . `id` = `q` . `id` AND ( `r` . `status` != ? OR FALSE ) WHERE `q` . `id` = ? AND `q` . `active` = ? AND `r` . `status` IS NULL ORDER BY `q` . `priority` DESC , `q` . `created_at` LIMIT ?",
+        "load_avg": 0.14
+      },
+      {
+        "rank": 4,
+        "sql": "UPDATE `host_mdm_actions` `hma` JOIN HOSTS `h` ON `hma` . `host_id` = `h` . `id` SET `hma` . `unlock_ref` = NULL , `hma` . `lock_ref` = NULL , `hma` . `unlock_pin` = NULL WHERE `h` . `uuid` = ? AND ( ( `hma` . `unlock_ref` IS NOT NULL AND `hma` . `unlock_pin` IS NOT NULL AND `h` . `platform` = ? AND ( `STR_TO_DATE` ( `hma` . `unlock_ref` , ? ) IS NULL OR `STR_TO_DATE` ( `hma` . `unlock_ref` , ? ) <= UTC_TIMESTAMP ( ) - INTERVAL ? MINUTE ) ) OR ( `hma` . `unlock_ref` IS NOT NULL AND ( `h` . `plat",
+        "load_avg": 0.08
+      },
+      {
+        "rank": 5,
+        "sql": "INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... */ , ( ? ",
+        "load_avg": 0.05
+      }
+    ],
+    "readers": [
+      {
+        "instance": "reader-1",
+        "top_sql": [
+          {
+            "rank": 1,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` IS NULL AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` .",
+            "load_avg": 0.4
+          },
+          {
+            "rank": 2,
+            "sql": "SELECT `hm` . `host_id` , `hm` . `enrolled` , `hm` . `server_url` , `hm` . `installed_from_dep` , `hm` . `mdm_id` , `hm` . `is_personal_enrollment` , `hm` . `managed_apple_id` , COALESCE ( `hm` . `is_server` , FALSE ) AS `is_server` , COALESCE ( `mdms` . NAME , ? ) AS NAME , `hdep` . `assign_profile_response` AS `dep_profile_assign_status` , CASE WHEN `hm` . `enrolled` = ? AND `h` . `platform` = ? THEN EXISTS ( SELECT ? FROM `mdm_windows_enrollments` `mwe` WHERE `mwe` . `host_uuid` = `h` . `uuid",
+            "load_avg": 0.39
+          },
+          {
+            "rank": 3,
+            "sql": "SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` JOIN `label_membership` `lm` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . `target_id` = `lm` . `label_id` AND `pt` . TYPE = ? ) WHERE `lm` . `host_id` = ? AND NOT `p` . `disabled` AND `p` . `pack_type` IS NULL ) UNION ALL ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . TYPE = ? AND `pt` . `target_id` = ? ) WHERE NOT `p` . `disabled` AND `p` . ",
+            "load_avg": 0.32
+          },
+          {
+            "rank": 4,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` = ? AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` . `id",
+            "load_avg": 0.26
+          },
+          {
+            "rank": 5,
+            "sql": "SELECT `id` , `host_id` , `execution_id` , `script_id` , `created_at` FROM ( SELECT `ua` . `id` , `ua` . `host_id` , `ua` . `execution_id` , `sua` . `script_id` , `ua` . `priority` , `ua` . `created_at` , IF ( `ua` . `activated_at` IS NULL , ?, ... ) AS `topmost` FROM `upcoming_activities` `ua` LEFT JOIN `script_upcoming_activities` `sua` ON `ua` . `id` = `sua` . `upcoming_activity_id` WHERE `ua` . `host_id` = ? AND `ua` . `activity_type` IN (...) AND `ua` . `activated_at` IS NOT NULL ORDER BY `",
+            "load_avg": 0.22
+          }
+        ]
+      },
+      {
+        "instance": "reader-2",
+        "top_sql": [
+          {
+            "rank": 1,
+            "sql": "SELECT `hm` . `host_id` , `hm` . `enrolled` , `hm` . `server_url` , `hm` . `installed_from_dep` , `hm` . `mdm_id` , `hm` . `is_personal_enrollment` , `hm` . `managed_apple_id` , COALESCE ( `hm` . `is_server` , FALSE ) AS `is_server` , COALESCE ( `mdms` . NAME , ? ) AS NAME , `hdep` . `assign_profile_response` AS `dep_profile_assign_status` , CASE WHEN `hm` . `enrolled` = ? AND `h` . `platform` = ? THEN EXISTS ( SELECT ? FROM `mdm_windows_enrollments` `mwe` WHERE `mwe` . `host_uuid` = `h` . `uuid",
+            "load_avg": 0.21
+          },
+          {
+            "rank": 2,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` IS NULL AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` .",
+            "load_avg": 0.2
+          },
+          {
+            "rank": 3,
+            "sql": "SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` JOIN `label_membership` `lm` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . `target_id` = `lm` . `label_id` AND `pt` . TYPE = ? ) WHERE `lm` . `host_id` = ? AND NOT `p` . `disabled` AND `p` . `pack_type` IS NULL ) UNION ALL ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . TYPE = ? AND `pt` . `target_id` = ? ) WHERE NOT `p` . `disabled` AND `p` . ",
+            "load_avg": 0.18
+          },
+          {
+            "rank": 4,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` = ? AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` . `id",
+            "load_avg": 0.13
+          },
+          {
+            "rank": 5,
+            "sql": "SELECT `sc` . `cve` , `hs` . `host_id` FROM `software_cve` `sc` JOIN `host_software` `hs` ON `hs` . `software_id` = `sc` . `software_id` WHERE `sc` . `cve` IN ( ?, ... ",
+            "load_avg": 0.12
+          }
+        ]
+      }
+    ]
+  },
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-21T19:28:00+02:00",
+        "Average": 51.18,
+        "Minimum": 50.66,
+        "Maximum": 52.54,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-08-21T19:28:00+02:00",
+        "Average": 3.59,
+        "Minimum": 3.58,
+        "Maximum": 3.6,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-21T19:28:00+02:00",
+        "Average": 6.78,
+        "Minimum": 6.63,
+        "Maximum": 6.9,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-08-21T19:28:00+02:00",
+        "Average": 3.54,
+        "Minimum": 3.54,
+        "Maximum": 3.55,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-3",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-21T19:28:00+02:00",
+        "Average": 7.28,
+        "Minimum": 7.11,
+        "Maximum": 7.4,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-08-21T19:28:00+02:00",
+        "Average": 3.54,
+        "Minimum": 3.54,
+        "Maximum": 3.55,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "apns_mock_redis": [
+    {
+      "node": "apns-redis-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-21T19:28:00+02:00",
+        "Average": 0.78,
+        "Minimum": 0.13,
+        "Maximum": 1.9,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-08-21T19:28:00+02:00",
+        "Average": 0.19,
+        "Minimum": 0.19,
+        "Maximum": 0.19,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "curr_connections": {
+        "Timestamp": "2026-08-21T19:28:00+02:00",
+        "Average": 17.7,
+        "Maximum": 23,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "curr_items": {
+        "Timestamp": "2026-08-21T19:28:00+02:00",
+        "Average": 3,
+        "Maximum": 3,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-08-21T19:28:00+02:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "string_based_cmds": {
+        "Timestamp": "2026-08-21T19:28:00+02:00",
+        "Average": 23459,
+        "Sum": 469180,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "pubsub_based_cmds": {
+        "Timestamp": "2026-08-21T19:28:00+02:00",
+        "Average": 11717.4,
+        "Sum": 234348,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "network_bytes_out": {
+        "Timestamp": "2026-08-21T19:28:00+02:00",
+        "Average": 7482586.35,
+        "Sum": 149651727,
+        "Unit": "Bytes",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "alb": {
+    "target_response_time": {
+      "Timestamp": "2026-08-21T19:28:00+02:00",
+      "Average": 0,
+      "Minimum": 0,
+      "Maximum": 1.79,
+      "Unit": "Seconds",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "http_5xx_count": {
+      "Timestamp": "2026-08-21T19:28:00+02:00",
+      "Sum": 472,
+      "Unit": "Count",
+      "data_points": 1,
+      "max_points": 4,
+      "data_coverage": 0.25
+    },
+    "request_count": {
+      "Timestamp": "2026-08-21T19:28:00+02:00",
+      "Sum": 42752257,
+      "Unit": "Count",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "processed_bytes": {
+      "Timestamp": "2026-08-21T19:28:00+02:00",
+      "Sum": 86795561382,
+      "Unit": "Bytes",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    }
+  },
+  "fleet_server_errors": {
+    "error_count": 1175.0,
+    "sample_messages": [
+      "{\"ts\":\"2026-08-21T15:48:28Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":\"130.966042ms\",\"host_id\":566,\"ip_addr\":\"10.12.2.123\",\"x_for_ip_addr\":\"10.12.2.123\",\"ingestion-err\":\"ingesting query mdm_macos_software_update_id: directIngestMDMMacOSSoftwareUpdateID empty software update device ID\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-08-21T15:48:28Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":\"200.724263ms\",\"host_id\":612,\"ip_addr\":\"10.12.3.174\",\"x_for_ip_addr\":\"10.12.3.174\",\"ingestion-err\":\"ingesting query mdm_macos_software_update_id: directIngestMDMMacOSSoftwareUpdateID empty software update device ID\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-08-21T15:48:28Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":\"173.697755ms\",\"host_id\":563,\"ip_addr\":\"10.12.2.236\",\"x_for_ip_addr\":\"10.12.2.236\",\"ingestion-err\":\"ingesting query mdm_macos_software_update_id: directIngestMDMMacOSSoftwareUpdateID empty software update device ID\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-08-21T15:48:28Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":\"449.684878ms\",\"host_id\":610,\"ip_addr\":\"10.12.2.123\",\"x_for_ip_addr\":\"10.12.2.123\",\"ingestion-err\":\"ingesting query mdm_macos_software_update_id: directIngestMDMMacOSSoftwareUpdateID empty software update device ID\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-08-21T15:48:28Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":\"174.178758ms\",\"host_id\":562,\"ip_addr\":\"10.12.2.123\",\"x_for_ip_addr\":\"10.12.2.123\",\"ingestion-err\":\"ingesting query mdm_macos_software_update_id: directIngestMDMMacOSSoftwareUpdateID empty software update device ID\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-08-21T15:48:28Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":\"144.514569ms\",\"host_id\":611,\"ip_addr\":\"10.12.2.236\",\"x_for_ip_addr\":\"10.12.2.236\",\"ingestion-err\":\"ingesting query mdm_macos_software_update_id: directIngestMDMMacOSSoftwareUpdateID empty software update device ID\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-08-21T15:48:28Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":\"98.161584ms\",\"host_id\":609,\"ip_addr\":\"10.12.1.206\",\"x_for_ip_addr\":\"10.12.1.206\",\"ingestion-err\":\"ingesting query mdm_macos_software_update_id: directIngestMDMMacOSSoftwareUpdateID empty software update device ID\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-08-21T15:48:28Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":\"433.028513ms\",\"host_id\":608,\"ip_addr\":\"10.12.3.174\",\"x_for_ip_addr\":\"10.12.3.174\",\"ingestion-err\":\"ingesting query mdm_macos_software_update_id: directIngestMDMMacOSSoftwareUpdateID empty software update device ID\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-08-21T15:48:27Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":\"458.250102ms\",\"host_id\":607,\"ip_addr\":\"10.12.2.236\",\"x_for_ip_addr\":\"10.12.2.236\",\"ingestion-err\":\"ingesting query mdm_macos_software_update_id: directIngestMDMMacOSSoftwareUpdateID empty software update device ID\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-08-21T15:48:27Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":\"115.315674ms\",\"host_id\":561,\"ip_addr\":\"10.12.1.206\",\"x_for_ip_addr\":\"10.12.1.206\",\"ingestion-err\":\"ingesting query mdm_macos_software_update_id: directIngestMDMMacOSSoftwareUpdateID empty software update device ID\",\"err\":\"error in query ingestion\"}"
+    ]
+  },
+  "rds_writer_extended": {
+    "freeable_memory": {
+      "Timestamp": "2026-08-21T19:28:00+02:00",
+      "Average": 29244308480,
+      "Minimum": 29068533760,
+      "Unit": "Bytes",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "buffer_cache_hit_ratio": {
+      "Timestamp": "2026-08-21T19:28:00+02:00",
+      "Average": 100,
+      "Minimum": 100,
+      "Unit": "Percent",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "volume_bytes_used": null,
+    "select_latency": {
+      "Timestamp": "2026-08-21T19:28:00+02:00",
+      "Average": 0.83,
+      "Maximum": 0.91,
+      "Unit": "Milliseconds",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "insert_latency": {
+      "Timestamp": "2026-08-21T19:28:00+02:00",
+      "Average": 3.57,
+      "Maximum": 5.34,
+      "Unit": "Milliseconds",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "dml_latency": {
+      "Timestamp": "2026-08-21T19:28:00+02:00",
+      "Average": 2.03,
+      "Maximum": 2.89,
+      "Unit": "Milliseconds",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "threads_running": {
+      "average": 4.01,
+      "maximum": 7.75,
+      "vcpus": 16
+    },
+    "iops_utilization": {
+      "instance_class": "db.r6g.4xlarge",
+      "max_iops": 20000,
+      "read_iops_avg": 0,
+      "write_iops_avg": 2752.27,
+      "total_iops_avg": 2752.27,
+      "utilization_pct": 13.76
+    }
+  },
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-08-21T19:28:00+02:00",
+        "Average": 7.9,
+        "Maximum": 20,
+        "Unit": "Milliseconds",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-08-21T19:28:00+02:00",
+        "Average": 30360515584,
+        "Minimum": 30250328064,
+        "Unit": "Bytes",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-08-21T19:28:00+02:00",
+        "Average": 99.99,
+        "Minimum": 99.98,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-08-21T19:28:00+02:00",
+        "Average": 0.3,
+        "Maximum": 0.36,
+        "Unit": "Milliseconds",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "iops_utilization": {
+        "instance_class": "db.r6g.4xlarge",
+        "max_iops": 20000,
+        "read_iops_avg": 57.62,
+        "write_iops_avg": 0,
+        "total_iops_avg": 57.62,
+        "utilization_pct": 0.29
+      },
+      "threads_running": {
+        "average": 3.13,
+        "maximum": 3.83,
+        "vcpus": 16
+      }
+    },
+    {
+      "instance": "reader-2",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-08-21T19:28:00+02:00",
+        "Average": 7.1,
+        "Maximum": 17,
+        "Unit": "Milliseconds",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-08-21T19:28:00+02:00",
+        "Average": 30465900953.6,
+        "Minimum": 30419324928,
+        "Unit": "Bytes",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-08-21T19:28:00+02:00",
+        "Average": 99.99,
+        "Minimum": 99.97,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-08-21T19:28:00+02:00",
+        "Average": 0.35,
+        "Maximum": 0.93,
+        "Unit": "Milliseconds",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "iops_utilization": {
+        "instance_class": "db.r6g.4xlarge",
+        "max_iops": 20000,
+        "read_iops_avg": 44.54,
+        "write_iops_avg": 0,
+        "total_iops_avg": 44.54,
+        "utilization_pct": 0.22
+      },
+      "threads_running": {
+        "average": 1.84,
+        "maximum": 2.27,
+        "vcpus": 16
+      }
+    }
+  ],
+  "redis_extended": [
+    {
+      "node": "redis-1",
+      "curr_connections": {
+        "Timestamp": "2026-08-21T19:28:00+02:00",
+        "Average": 349.45,
+        "Maximum": 749,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-08-21T19:28:00+02:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": {
+        "Timestamp": "2026-08-21T19:28:00+02:00",
+        "Average": 84.96,
+        "Minimum": 83.52,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "curr_connections": {
+        "Timestamp": "2026-08-21T19:28:00+02:00",
+        "Average": 5.95,
+        "Maximum": 7,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-08-21T19:28:00+02:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    },
+    {
+      "node": "redis-3",
+      "curr_connections": {
+        "Timestamp": "2026-08-21T19:28:00+02:00",
+        "Average": 6,
+        "Maximum": 6,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-08-21T19:28:00+02:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    }
+  ],
+  "network": {
+    "network_rx_bytes": {
+      "Timestamp": "2026-08-21T19:28:00+02:00",
+      "Average": 1784450.76,
+      "Sum": 1427560609,
+      "Unit": "Bytes/Second",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "network_tx_bytes": {
+      "Timestamp": "2026-08-21T19:28:00+02:00",
+      "Average": 597477.2,
+      "Sum": 477981757,
+      "Unit": "Bytes/Second",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    }
+  },
+  "container_health": {
+    "abnormal_stops": 0,
+    "running_tasks": 38,
+    "oldest_start": null,
+    "newest_start": null,
+    "start_spread_min": null,
+    "start_spread_alert": false,
+    "tasks": []
+  }
+}

--- a/tools/loadtest/metrics/runs/mdm/mock-apns/mock-apns-2026-08-21-174828Z-20m.md
+++ b/tools/loadtest/metrics/runs/mdm/mock-apns/mock-apns-2026-08-21-174828Z-20m.md
@@ -1,0 +1,64 @@
+# Metrics Synopsis: mock-apns
+
+- **Collected:** 2026-08-21T17:48:28Z
+- **Interval:** 20m
+- **Window:** 2026-08-21T17:28:28Z to 2026-08-21T17:48:28Z
+- **Note:** 76k enrolled adding 3 profiles to all hosts
+
+## Summary (20m averages)
+
+```
+Fleet Server:  CPU=82.27%  Mem=7.91%  Containers=40
+Loadtest:      CPU=10.77%  Mem=11.15%  Containers=38
+apns-mock:     CPU=4.86%  Mem=17.6%  Containers=2  (averaged across containers)
+               PerTask CPU avg=4.86% max=9.37%   Mem avg=17.6% max=20.75%
+               RX=17.26MB  TX=17.78MB  AbnormalStops=0  StartSpread=21.17min  ⚠ STAGGERED STARTS
+apns Redis:    CPU=0.78% (max 1.9%)  Mem=0.19%  Conns=17.7  PendingItems=3  Evictions=0
+               StringCmds=469180  PubSubCmds=234348  NetOut=142.72MB
+RDS Writer:    CPU=24.85%  Connections=508.9  Deadlocks=0
+RDS reader-1:  CPU=43.63%  Connections=365.45
+RDS reader-2:  CPU=25.49%  Connections=281.25
+Redis:         CPU=51.18%  Mem=3.59%
+
+Top SQL (writer):
+  #1 load=2.92  COMMIT
+  #2 load=0.81  INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... 
+  #3 load=0.14  SELECT `c` . `command_uuid` , `c` . `request_type` , `c` . `command` , `c` . `su
+  #4 load=0.08  UPDATE `host_mdm_actions` `hma` JOIN HOSTS `h` ON `hma` . `host_id` = `h` . `id`
+  #5 load=0.05  INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... 
+
+Top SQL (reader-1):
+  #1 load=0.4  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #2 load=0.39  SELECT `hm` . `host_id` , `hm` . `enrolled` , `hm` . `server_url` , `hm` . `inst
+  #3 load=0.32  SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pa
+  #4 load=0.26  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #5 load=0.22  SELECT `id` , `host_id` , `execution_id` , `script_id` , `created_at` FROM ( SEL
+
+Top SQL (reader-2):
+  #1 load=0.21  SELECT `hm` . `host_id` , `hm` . `enrolled` , `hm` . `server_url` , `hm` . `inst
+  #2 load=0.2  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #3 load=0.18  SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pa
+  #4 load=0.13  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #5 load=0.12  SELECT `sc` . `cve` , `hs` . `host_id` FROM `software_cve` `sc` JOIN `host_softw
+ALB:           Latency=0s  5xx=472  Requests=42752257  Traffic=82774.7MB
+Fleet Errors:  Count=1175.0
+RDS Writer:    FreeMem=27.24GB  CacheHit=100%  Disk=N/A  Threads=4.01  IOPS=13.76%
+               SelectLat=0.83ms  InsertLat=3.57ms
+RDS reader-1: FreeMem=28.28GB  CacheHit=99.99%  ReplicaLag=7.9ms  Threads=3.13  IOPS=0.29%
+               SelectLat=0.3ms
+RDS reader-2: FreeMem=28.37GB  CacheHit=99.99%  ReplicaLag=7.1ms  Threads=1.84  IOPS=0.22%
+               SelectLat=0.35ms
+Redis:         Connections=349.45  Evictions=0  CacheHit=84.96%
+Network:       RX=1361.43MB  TX=455.84MB
+Containers:    Running=38  AbnormalStops=0  StartSpread=N/Amin
+```
+
+## Threshold Checks
+
+```
+  🔴 ALERT: Fleet Server CPU avg = 82.27 (expected < 80)
+  🔴 ALERT: apns-mock Start Spread (min) = 21.17 (expected < 10)
+  🔴 ALERT: Fleet Server Errors = 1175.0 (expected 0)
+
+  ⚠ 3 alert(s) detected
+```

--- a/tools/loadtest/metrics/runs/mdm/mock-apns/mock-apns-2026-08-21-184317Z-20m.json
+++ b/tools/loadtest/metrics/runs/mdm/mock-apns/mock-apns-2026-08-21-184317Z-20m.json
@@ -1,0 +1,828 @@
+{
+  "metadata": {
+    "workspace": "mock-apns",
+    "collected_at": "2026-08-21T18:43:17Z",
+    "region": "us-east-2",
+    "interval": "20m",
+    "time_window": {
+      "start": "2026-08-21T18:23:17Z",
+      "end": "2026-08-21T18:43:17Z"
+    },
+    "note": "76k enrolled adding 5 profiles to all hosts (total 10 profiles)"
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 83.14,
+      "Minimum": 79.78,
+      "Maximum": 87.29,
+      "Unit": "Percent",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 10.14,
+      "Minimum": 9.12,
+      "Maximum": 10.76,
+      "Unit": "Percent",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 40,
+      "desiredCount": 40
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 11.71,
+      "Minimum": 9.98,
+      "Maximum": 14.24,
+      "Unit": "Percent",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 11.84,
+      "Minimum": 11.4,
+      "Maximum": 12.6,
+      "Unit": "Percent",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 38,
+      "desiredCount": 38
+    }
+  },
+  "apns_mock": {
+    "service": "fleet-mock-apns-apple-apns-mock",
+    "cpu_utilization": {
+      "Average": 5.69,
+      "Minimum": 3.3,
+      "Maximum": 8.79,
+      "Unit": "Percent",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 18.09,
+      "Minimum": 15.85,
+      "Maximum": 20.68,
+      "Unit": "Percent",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "per_task": {
+      "cpu": {
+        "avg_pct": 5.69,
+        "max_pct": 12.89,
+        "spread_pct": 7.2
+      },
+      "memory": {
+        "avg_pct": 18.09,
+        "max_pct": 20.78,
+        "spread_pct": 2.68
+      }
+    },
+    "network": {
+      "network_rx_bytes": {
+        "Timestamp": "2026-08-21T20:23:00+02:00",
+        "Average": 525520.82,
+        "Sum": 21020833,
+        "Unit": "Bytes/Second",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "network_tx_bytes": {
+        "Timestamp": "2026-08-21T20:23:00+02:00",
+        "Average": 523153.28,
+        "Sum": 20926131,
+        "Unit": "Bytes/Second",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      }
+    },
+    "task_counts": {
+      "runningCount": 2,
+      "desiredCount": 2
+    },
+    "container_health": {
+      "abnormal_stops": 0,
+      "running_tasks": 2,
+      "start_spread_min": 21.17,
+      "start_spread_alert": true,
+      "tasks": [
+        {
+          "task_id": "b5c169a022734b6baaba4b2029274dd0",
+          "started_at": "2026-08-21T17:10:49.867000+02:00",
+          "uptime_min": 92.47
+        },
+        {
+          "task_id": "39f68e1f39b643d89fa05d54efbfd2b8",
+          "started_at": "2026-08-21T17:31:59.630000+02:00",
+          "uptime_min": 71.3
+        }
+      ]
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Timestamp": "2026-08-21T20:23:00+02:00",
+      "Average": 29.15,
+      "Minimum": 17.97,
+      "Maximum": 47.64,
+      "Unit": "Percent",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "database_connections": {
+      "Timestamp": "2026-08-21T20:23:00+02:00",
+      "Average": 691.35,
+      "Minimum": 622,
+      "Maximum": 813,
+      "Unit": "Count",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "read_iops": {
+      "Timestamp": "2026-08-21T20:23:00+02:00",
+      "Average": 0,
+      "Maximum": 0.02,
+      "Unit": "Count/Second",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "write_iops": {
+      "Timestamp": "2026-08-21T20:23:00+02:00",
+      "Average": 2781.05,
+      "Maximum": 3406.34,
+      "Unit": "Count/Second",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "deadlocks": {
+      "Timestamp": "2026-08-21T20:23:00+02:00",
+      "Average": 0,
+      "Sum": 0,
+      "Maximum": 0,
+      "Unit": "Count/Second",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    }
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-21T20:23:00+02:00",
+        "Average": 38,
+        "Minimum": 29.64,
+        "Maximum": 46.11,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-08-21T20:23:00+02:00",
+        "Average": 273.65,
+        "Minimum": 172,
+        "Maximum": 382,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-08-21T20:23:00+02:00",
+        "Average": 87.34,
+        "Maximum": 195.68,
+        "Unit": "Count/Second",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-08-21T20:23:00+02:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      }
+    },
+    {
+      "instance": "reader-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-21T20:23:00+02:00",
+        "Average": 39.49,
+        "Minimum": 26.06,
+        "Maximum": 49.52,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-08-21T20:23:00+02:00",
+        "Average": 294.3,
+        "Minimum": 161,
+        "Maximum": 431,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-08-21T20:23:00+02:00",
+        "Average": 93.68,
+        "Maximum": 327.22,
+        "Unit": "Count/Second",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-08-21T20:23:00+02:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "rds_performance_insights": {
+    "writer": [
+      {
+        "rank": 1,
+        "sql": "COMMIT",
+        "load_avg": 3.72
+      },
+      {
+        "rank": 2,
+        "sql": "INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... */ , ( ?, ... ",
+        "load_avg": 0.84
+      },
+      {
+        "rank": 3,
+        "sql": "SELECT `c` . `command_uuid` , `c` . `request_type` , `c` . `command` , `c` . `subtype` FROM `nano_enrollment_queue` AS `q` INNER JOIN `nano_commands` AS `c` ON `q` . `command_uuid` = `c` . `command_uuid` LEFT JOIN `nano_command_results` `r` ON `r` . `command_uuid` = `q` . `command_uuid` AND `r` . `id` = `q` . `id` AND ( `r` . `status` != ? OR FALSE ) WHERE `q` . `id` = ? AND `q` . `active` = ? AND `r` . `status` IS NULL ORDER BY `q` . `priority` DESC , `q` . `created_at` LIMIT ?",
+        "load_avg": 0.21
+      },
+      {
+        "rank": 4,
+        "sql": "INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... */ , ( ? ",
+        "load_avg": 0.12
+      },
+      {
+        "rank": 5,
+        "sql": "UPDATE `host_mdm_actions` `hma` JOIN HOSTS `h` ON `hma` . `host_id` = `h` . `id` SET `hma` . `unlock_ref` = NULL , `hma` . `lock_ref` = NULL , `hma` . `unlock_pin` = NULL WHERE `h` . `uuid` = ? AND ( ( `hma` . `unlock_ref` IS NOT NULL AND `hma` . `unlock_pin` IS NOT NULL AND `h` . `platform` = ? AND ( `STR_TO_DATE` ( `hma` . `unlock_ref` , ? ) IS NULL OR `STR_TO_DATE` ( `hma` . `unlock_ref` , ? ) <= UTC_TIMESTAMP ( ) - INTERVAL ? MINUTE ) ) OR ( `hma` . `unlock_ref` IS NOT NULL AND ( `h` . `plat",
+        "load_avg": 0.08
+      }
+    ],
+    "readers": [
+      {
+        "instance": "reader-1",
+        "top_sql": [
+          {
+            "rank": 1,
+            "sql": "SELECT `hm` . `host_id` , `hm` . `enrolled` , `hm` . `server_url` , `hm` . `installed_from_dep` , `hm` . `mdm_id` , `hm` . `is_personal_enrollment` , `hm` . `managed_apple_id` , COALESCE ( `hm` . `is_server` , FALSE ) AS `is_server` , COALESCE ( `mdms` . NAME , ? ) AS NAME , `hdep` . `assign_profile_response` AS `dep_profile_assign_status` , CASE WHEN `hm` . `enrolled` = ? AND `h` . `platform` = ? THEN EXISTS ( SELECT ? FROM `mdm_windows_enrollments` `mwe` WHERE `mwe` . `host_uuid` = `h` . `uuid",
+            "load_avg": 0.31
+          },
+          {
+            "rank": 2,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` IS NULL AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` .",
+            "load_avg": 0.29
+          },
+          {
+            "rank": 3,
+            "sql": "SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` JOIN `label_membership` `lm` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . `target_id` = `lm` . `label_id` AND `pt` . TYPE = ? ) WHERE `lm` . `host_id` = ? AND NOT `p` . `disabled` AND `p` . `pack_type` IS NULL ) UNION ALL ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . TYPE = ? AND `pt` . `target_id` = ? ) WHERE NOT `p` . `disabled` AND `p` . ",
+            "load_avg": 0.28
+          },
+          {
+            "rank": 4,
+            "sql": "SELECT `s` . `id` , `s` . NAME , `s` . `version` , `s` . SOURCE , `s` . `bundle_identifier` , `s` . RELEASE , `s` . `arch` , `s` . `vendor` , `s` . `extension_for` , `s` . `extension_id` , `s` . `title_id` , COALESCE ( `sc` . `cpe` , ? ) AS `generated_cpe` FROM `software` `s` LEFT JOIN `software_cpe` `sc` ON ( `s` . `id` = `sc` . `software_id` ) WHERE `s` . SOURCE NOT IN (...) ",
+            "load_avg": 0.24
+          },
+          {
+            "rank": 5,
+            "sql": "SELECT ? AS `team_id` , ? AS `global_stats` , `combined_results` . `cve` , COUNT ( * ) AS `host_count` FROM ( SELECT `sc` . `cve` , `hs` . `host_id` FROM `software_cve` `sc` INNER JOIN `host_software` `hs` ON `sc` . `software_id` = `hs` . `software_id` WHERE `sc` . `cve` IN (...) UNION SELECT `osv` . `cve` , `hos` . `host_id` FROM `operating_system_vulnerabilities` `osv` INNER JOIN `host_operating_system` `hos` ON `hos` . `os_id` = `osv` . `operating_system_id` WHERE `osv` . `cve` IN (...) ) AS ",
+            "load_avg": 0.22
+          }
+        ]
+      },
+      {
+        "instance": "reader-2",
+        "top_sql": [
+          {
+            "rank": 1,
+            "sql": "SELECT `hm` . `host_id` , `hm` . `enrolled` , `hm` . `server_url` , `hm` . `installed_from_dep` , `hm` . `mdm_id` , `hm` . `is_personal_enrollment` , `hm` . `managed_apple_id` , COALESCE ( `hm` . `is_server` , FALSE ) AS `is_server` , COALESCE ( `mdms` . NAME , ? ) AS NAME , `hdep` . `assign_profile_response` AS `dep_profile_assign_status` , CASE WHEN `hm` . `enrolled` = ? AND `h` . `platform` = ? THEN EXISTS ( SELECT ? FROM `mdm_windows_enrollments` `mwe` WHERE `mwe` . `host_uuid` = `h` . `uuid",
+            "load_avg": 0.34
+          },
+          {
+            "rank": 2,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` IS NULL AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` .",
+            "load_avg": 0.3
+          },
+          {
+            "rank": 3,
+            "sql": "SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` JOIN `label_membership` `lm` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . `target_id` = `lm` . `label_id` AND `pt` . TYPE = ? ) WHERE `lm` . `host_id` = ? AND NOT `p` . `disabled` AND `p` . `pack_type` IS NULL ) UNION ALL ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . TYPE = ? AND `pt` . `target_id` = ? ) WHERE NOT `p` . `disabled` AND `p` . ",
+            "load_avg": 0.28
+          },
+          {
+            "rank": 4,
+            "sql": "SELECT `sc` . `cve` , `hs` . `host_id` FROM `software_cve` `sc` JOIN `host_software` `hs` ON `hs` . `software_id` = `sc` . `software_id` WHERE `sc` . `cve` IN ( ?, ... ",
+            "load_avg": 0.2
+          },
+          {
+            "rank": 5,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` = ? AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` . `id",
+            "load_avg": 0.2
+          }
+        ]
+      }
+    ]
+  },
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-21T20:23:00+02:00",
+        "Average": 51.37,
+        "Minimum": 50.83,
+        "Maximum": 54.04,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-08-21T20:23:00+02:00",
+        "Average": 3.59,
+        "Minimum": 3.58,
+        "Maximum": 3.61,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-21T20:23:00+02:00",
+        "Average": 6.76,
+        "Minimum": 6.6,
+        "Maximum": 6.86,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-08-21T20:23:00+02:00",
+        "Average": 3.54,
+        "Minimum": 3.54,
+        "Maximum": 3.54,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-3",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-21T20:23:00+02:00",
+        "Average": 7.26,
+        "Minimum": 7.06,
+        "Maximum": 7.36,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-08-21T20:23:00+02:00",
+        "Average": 3.54,
+        "Minimum": 3.54,
+        "Maximum": 3.54,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "apns_mock_redis": [
+    {
+      "node": "apns-redis-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-21T20:23:00+02:00",
+        "Average": 1.09,
+        "Minimum": 0.08,
+        "Maximum": 2.73,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-08-21T20:23:00+02:00",
+        "Average": 0.19,
+        "Minimum": 0.19,
+        "Maximum": 0.2,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "curr_connections": {
+        "Timestamp": "2026-08-21T20:23:00+02:00",
+        "Average": 16.45,
+        "Maximum": 23,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "curr_items": {
+        "Timestamp": "2026-08-21T20:23:00+02:00",
+        "Average": 136.65,
+        "Maximum": 861,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-08-21T20:23:00+02:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "string_based_cmds": {
+        "Timestamp": "2026-08-21T20:23:00+02:00",
+        "Average": 38024,
+        "Sum": 760480,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "pubsub_based_cmds": {
+        "Timestamp": "2026-08-21T20:23:00+02:00",
+        "Average": 19000,
+        "Sum": 380000,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "network_bytes_out": {
+        "Timestamp": "2026-08-21T20:23:00+02:00",
+        "Average": 11697172.6,
+        "Sum": 233943452,
+        "Unit": "Bytes",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "alb": {
+    "target_response_time": {
+      "Timestamp": "2026-08-21T20:23:00+02:00",
+      "Average": 0,
+      "Minimum": 0,
+      "Maximum": 3.54,
+      "Unit": "Seconds",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "http_5xx_count": null,
+    "request_count": {
+      "Timestamp": "2026-08-21T20:23:00+02:00",
+      "Sum": 43168242,
+      "Unit": "Count",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "processed_bytes": {
+      "Timestamp": "2026-08-21T20:23:00+02:00",
+      "Sum": 93183013478,
+      "Unit": "Bytes",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    }
+  },
+  "fleet_server_errors": {
+    "error_count": 56506.0,
+    "sample_messages": [
+      "{\"ts\":\"2026-08-21T16:43:17Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":\"184.811348ms\",\"host_id\":66341,\"ip_addr\":\"10.12.3.239\",\"x_for_ip_addr\":\"10.12.3.239\",\"ingestion-err\":\"ingesting query mdm_macos_software_update_id: directIngestMDMMacOSSoftwareUpdateID empty software update device ID\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-08-21T16:43:17Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":\"174.611202ms\",\"host_id\":66507,\"ip_addr\":\"10.12.2.96\",\"x_for_ip_addr\":\"10.12.2.96\",\"ingestion-err\":\"ingesting query mdm_macos_software_update_id: directIngestMDMMacOSSoftwareUpdateID empty software update device ID\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-08-21T16:43:17Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":\"269.85384ms\",\"host_id\":66505,\"ip_addr\":\"10.12.1.141\",\"x_for_ip_addr\":\"10.12.1.141\",\"ingestion-err\":\"ingesting query mdm_macos_software_update_id: directIngestMDMMacOSSoftwareUpdateID empty software update device ID\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-08-21T16:43:17Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":\"342.253215ms\",\"host_id\":66332,\"ip_addr\":\"10.12.1.141\",\"x_for_ip_addr\":\"10.12.1.141\",\"ingestion-err\":\"ingesting query mdm_macos_software_update_id: directIngestMDMMacOSSoftwareUpdateID empty software update device ID\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-08-21T16:43:17Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":\"395.026529ms\",\"host_id\":66503,\"ip_addr\":\"10.12.2.170\",\"x_for_ip_addr\":\"10.12.2.170\",\"ingestion-err\":\"ingesting query mdm_macos_software_update_id: directIngestMDMMacOSSoftwareUpdateID empty software update device ID\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-08-21T16:43:17Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":\"304.79537ms\",\"host_id\":66333,\"ip_addr\":\"10.12.1.11\",\"x_for_ip_addr\":\"10.12.1.11\",\"ingestion-err\":\"ingesting query mdm_macos_software_update_id: directIngestMDMMacOSSoftwareUpdateID empty software update device ID\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-08-21T16:43:17Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":\"198.480209ms\",\"host_id\":66335,\"ip_addr\":\"10.12.3.47\",\"x_for_ip_addr\":\"10.12.3.47\",\"ingestion-err\":\"ingesting query mdm_macos_software_update_id: directIngestMDMMacOSSoftwareUpdateID empty software update device ID\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-08-21T16:43:17Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":\"234.14535ms\",\"host_id\":66331,\"ip_addr\":\"10.12.2.170\",\"x_for_ip_addr\":\"10.12.2.170\",\"ingestion-err\":\"ingesting query mdm_macos_software_update_id: directIngestMDMMacOSSoftwareUpdateID empty software update device ID\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-08-21T16:43:17Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":\"359.571817ms\",\"host_id\":66500,\"ip_addr\":\"10.12.3.162\",\"x_for_ip_addr\":\"10.12.3.162\",\"ingestion-err\":\"ingesting query mdm_macos_software_update_id: directIngestMDMMacOSSoftwareUpdateID empty software update device ID\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-08-21T16:43:17Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":\"245.274687ms\",\"host_id\":66329,\"ip_addr\":\"10.12.3.254\",\"x_for_ip_addr\":\"10.12.3.254\",\"ingestion-err\":\"ingesting query mdm_macos_software_update_id: directIngestMDMMacOSSoftwareUpdateID empty software update device ID\",\"err\":\"error in query ingestion\"}"
+    ]
+  },
+  "rds_writer_extended": {
+    "freeable_memory": {
+      "Timestamp": "2026-08-21T20:23:00+02:00",
+      "Average": 29015995801.6,
+      "Minimum": 28719599616,
+      "Unit": "Bytes",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "buffer_cache_hit_ratio": {
+      "Timestamp": "2026-08-21T20:23:00+02:00",
+      "Average": 100,
+      "Minimum": 100,
+      "Unit": "Percent",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "volume_bytes_used": null,
+    "select_latency": {
+      "Timestamp": "2026-08-21T20:23:00+02:00",
+      "Average": 0.88,
+      "Maximum": 1.31,
+      "Unit": "Milliseconds",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "insert_latency": {
+      "Timestamp": "2026-08-21T20:23:00+02:00",
+      "Average": 3.65,
+      "Maximum": 5.07,
+      "Unit": "Milliseconds",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "dml_latency": {
+      "Timestamp": "2026-08-21T20:23:00+02:00",
+      "Average": 2.02,
+      "Maximum": 2.64,
+      "Unit": "Milliseconds",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "threads_running": {
+      "average": 5.53,
+      "maximum": 10.45,
+      "vcpus": 16
+    },
+    "iops_utilization": {
+      "instance_class": "db.r6g.4xlarge",
+      "max_iops": 20000,
+      "read_iops_avg": 0,
+      "write_iops_avg": 2781.05,
+      "total_iops_avg": 2781.05,
+      "utilization_pct": 13.91
+    }
+  },
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-08-21T20:23:00+02:00",
+        "Average": 6,
+        "Maximum": 17,
+        "Unit": "Milliseconds",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-08-21T20:23:00+02:00",
+        "Average": 30348615270.4,
+        "Minimum": 30250835968,
+        "Unit": "Bytes",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-08-21T20:23:00+02:00",
+        "Average": 99.98,
+        "Minimum": 99.96,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-08-21T20:23:00+02:00",
+        "Average": 0.38,
+        "Maximum": 0.79,
+        "Unit": "Milliseconds",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "iops_utilization": {
+        "instance_class": "db.r6g.4xlarge",
+        "max_iops": 20000,
+        "read_iops_avg": 87.34,
+        "write_iops_avg": 0,
+        "total_iops_avg": 87.34,
+        "utilization_pct": 0.44
+      },
+      "threads_running": {
+        "average": 3.19,
+        "maximum": 4.27,
+        "vcpus": 16
+      }
+    },
+    {
+      "instance": "reader-2",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-08-21T20:23:00+02:00",
+        "Average": 6.6,
+        "Maximum": 9,
+        "Unit": "Milliseconds",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-08-21T20:23:00+02:00",
+        "Average": 30386368512,
+        "Minimum": 30283665408,
+        "Unit": "Bytes",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-08-21T20:23:00+02:00",
+        "Average": 99.99,
+        "Minimum": 99.96,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-08-21T20:23:00+02:00",
+        "Average": 0.35,
+        "Maximum": 0.65,
+        "Unit": "Milliseconds",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "iops_utilization": {
+        "instance_class": "db.r6g.4xlarge",
+        "max_iops": 20000,
+        "read_iops_avg": 93.68,
+        "write_iops_avg": 0,
+        "total_iops_avg": 93.68,
+        "utilization_pct": 0.47
+      },
+      "threads_running": {
+        "average": 2.87,
+        "maximum": 4.27,
+        "vcpus": 16
+      }
+    }
+  ],
+  "redis_extended": [
+    {
+      "node": "redis-1",
+      "curr_connections": {
+        "Timestamp": "2026-08-21T20:23:00+02:00",
+        "Average": 542.45,
+        "Maximum": 1336,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-08-21T20:23:00+02:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": {
+        "Timestamp": "2026-08-21T20:23:00+02:00",
+        "Average": 84.35,
+        "Minimum": 82.16,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "curr_connections": {
+        "Timestamp": "2026-08-21T20:23:00+02:00",
+        "Average": 5.4,
+        "Maximum": 6,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-08-21T20:23:00+02:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    },
+    {
+      "node": "redis-3",
+      "curr_connections": {
+        "Timestamp": "2026-08-21T20:23:00+02:00",
+        "Average": 6,
+        "Maximum": 6,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-08-21T20:23:00+02:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    }
+  ],
+  "network": {
+    "network_rx_bytes": {
+      "Timestamp": "2026-08-21T20:23:00+02:00",
+      "Average": 1895557.48,
+      "Sum": 1516445986,
+      "Unit": "Bytes/Second",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "network_tx_bytes": {
+      "Timestamp": "2026-08-21T20:23:00+02:00",
+      "Average": 669426.62,
+      "Sum": 535541295,
+      "Unit": "Bytes/Second",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    }
+  },
+  "container_health": {
+    "abnormal_stops": 0,
+    "running_tasks": 38,
+    "oldest_start": null,
+    "newest_start": null,
+    "start_spread_min": null,
+    "start_spread_alert": false,
+    "tasks": []
+  }
+}

--- a/tools/loadtest/metrics/runs/mdm/mock-apns/mock-apns-2026-08-21-184317Z-20m.md
+++ b/tools/loadtest/metrics/runs/mdm/mock-apns/mock-apns-2026-08-21-184317Z-20m.md
@@ -1,0 +1,64 @@
+# Metrics Synopsis: mock-apns
+
+- **Collected:** 2026-08-21T18:43:17Z
+- **Interval:** 20m
+- **Window:** 2026-08-21T18:23:17Z to 2026-08-21T18:43:17Z
+- **Note:** 76k enrolled adding 5 profiles to all hosts (total 10 profiles)
+
+## Summary (20m averages)
+
+```
+Fleet Server:  CPU=83.14%  Mem=10.14%  Containers=40
+Loadtest:      CPU=11.71%  Mem=11.84%  Containers=38
+apns-mock:     CPU=5.69%  Mem=18.09%  Containers=2  (averaged across containers)
+               PerTask CPU avg=5.69% max=12.89%   Mem avg=18.09% max=20.78%
+               RX=20.05MB  TX=19.96MB  AbnormalStops=0  StartSpread=21.17min  ⚠ STAGGERED STARTS
+apns Redis:    CPU=1.09% (max 2.73%)  Mem=0.19%  Conns=16.45  PendingItems=136.65  Evictions=0
+               StringCmds=760480  PubSubCmds=380000  NetOut=223.11MB
+RDS Writer:    CPU=29.15%  Connections=691.35  Deadlocks=0
+RDS reader-1:  CPU=38%  Connections=273.65
+RDS reader-2:  CPU=39.49%  Connections=294.3
+Redis:         CPU=51.37%  Mem=3.59%
+
+Top SQL (writer):
+  #1 load=3.72  COMMIT
+  #2 load=0.84  INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... 
+  #3 load=0.21  SELECT `c` . `command_uuid` , `c` . `request_type` , `c` . `command` , `c` . `su
+  #4 load=0.12  INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... 
+  #5 load=0.08  UPDATE `host_mdm_actions` `hma` JOIN HOSTS `h` ON `hma` . `host_id` = `h` . `id`
+
+Top SQL (reader-1):
+  #1 load=0.31  SELECT `hm` . `host_id` , `hm` . `enrolled` , `hm` . `server_url` , `hm` . `inst
+  #2 load=0.29  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #3 load=0.28  SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pa
+  #4 load=0.24  SELECT `s` . `id` , `s` . NAME , `s` . `version` , `s` . SOURCE , `s` . `bundle_
+  #5 load=0.22  SELECT ? AS `team_id` , ? AS `global_stats` , `combined_results` . `cve` , COUNT
+
+Top SQL (reader-2):
+  #1 load=0.34  SELECT `hm` . `host_id` , `hm` . `enrolled` , `hm` . `server_url` , `hm` . `inst
+  #2 load=0.3  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #3 load=0.28  SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pa
+  #4 load=0.2  SELECT `sc` . `cve` , `hs` . `host_id` FROM `software_cve` `sc` JOIN `host_softw
+  #5 load=0.2  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+ALB:           Latency=0s  5xx=0  Requests=43168242  Traffic=88866.25MB
+Fleet Errors:  Count=56506.0
+RDS Writer:    FreeMem=27.02GB  CacheHit=100%  Disk=N/A  Threads=5.53  IOPS=13.91%
+               SelectLat=0.88ms  InsertLat=3.65ms
+RDS reader-1: FreeMem=28.26GB  CacheHit=99.98%  ReplicaLag=6ms  Threads=3.19  IOPS=0.44%
+               SelectLat=0.38ms
+RDS reader-2: FreeMem=28.3GB  CacheHit=99.99%  ReplicaLag=6.6ms  Threads=2.87  IOPS=0.47%
+               SelectLat=0.35ms
+Redis:         Connections=542.45  Evictions=0  CacheHit=84.35%
+Network:       RX=1446.2MB  TX=510.73MB
+Containers:    Running=38  AbnormalStops=0  StartSpread=N/Amin
+```
+
+## Threshold Checks
+
+```
+  🔴 ALERT: Fleet Server CPU avg = 83.14 (expected < 80)
+  🔴 ALERT: apns-mock Start Spread (min) = 21.17 (expected < 10)
+  🔴 ALERT: Fleet Server Errors = 56506.0 (expected 0)
+
+  ⚠ 3 alert(s) detected
+```

--- a/tools/loadtest/metrics/runs/mdm/mock-apns/mock-apns-2026-08-21-193108Z-20m.json
+++ b/tools/loadtest/metrics/runs/mdm/mock-apns/mock-apns-2026-08-21-193108Z-20m.json
@@ -1,0 +1,828 @@
+{
+  "metadata": {
+    "workspace": "mock-apns",
+    "collected_at": "2026-08-21T19:31:08Z",
+    "region": "us-east-2",
+    "interval": "20m",
+    "time_window": {
+      "start": "2026-08-21T19:11:08Z",
+      "end": "2026-08-21T19:31:08Z"
+    },
+    "note": "76k enrolled deleting all 10 profiles (total 0)"
+  },
+  "fleet_server": {
+    "cpu_utilization": {
+      "Average": 80.35,
+      "Minimum": 80.11,
+      "Maximum": 80.8,
+      "Unit": "Percent",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 10.69,
+      "Minimum": 10.3,
+      "Maximum": 11.06,
+      "Unit": "Percent",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 40,
+      "desiredCount": 40
+    }
+  },
+  "loadtest_containers": {
+    "cpu_utilization": {
+      "Average": 9.93,
+      "Minimum": 9.79,
+      "Maximum": 10.07,
+      "Unit": "Percent",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 11.34,
+      "Minimum": 11.31,
+      "Maximum": 11.38,
+      "Unit": "Percent",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "task_counts": {
+      "runningCount": 38,
+      "desiredCount": 38
+    }
+  },
+  "apns_mock": {
+    "service": "fleet-mock-apns-apple-apns-mock",
+    "cpu_utilization": {
+      "Average": 3.41,
+      "Minimum": 3.24,
+      "Maximum": 3.72,
+      "Unit": "Percent",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "memory_utilization": {
+      "Average": 15.93,
+      "Minimum": 15.81,
+      "Maximum": 16.21,
+      "Unit": "Percent",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "per_task": {
+      "cpu": {
+        "avg_pct": 3.41,
+        "max_pct": 7.63,
+        "spread_pct": 4.22
+      },
+      "memory": {
+        "avg_pct": 15.93,
+        "max_pct": 16.63,
+        "spread_pct": 0.69
+      }
+    },
+    "network": {
+      "network_rx_bytes": {
+        "Timestamp": "2026-08-21T21:11:00+02:00",
+        "Average": 344207.65,
+        "Sum": 13768306,
+        "Unit": "Bytes/Second",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "network_tx_bytes": {
+        "Timestamp": "2026-08-21T21:11:00+02:00",
+        "Average": 375669.88,
+        "Sum": 15026795,
+        "Unit": "Bytes/Second",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      }
+    },
+    "task_counts": {
+      "runningCount": 2,
+      "desiredCount": 2
+    },
+    "container_health": {
+      "abnormal_stops": 0,
+      "running_tasks": 2,
+      "start_spread_min": 21.17,
+      "start_spread_alert": true,
+      "tasks": [
+        {
+          "task_id": "b5c169a022734b6baaba4b2029274dd0",
+          "started_at": "2026-08-21T17:10:49.867000+02:00",
+          "uptime_min": 140.32
+        },
+        {
+          "task_id": "39f68e1f39b643d89fa05d54efbfd2b8",
+          "started_at": "2026-08-21T17:31:59.630000+02:00",
+          "uptime_min": 119.15
+        }
+      ]
+    }
+  },
+  "rds_writer": {
+    "instance": "writer",
+    "cpu_utilization": {
+      "Timestamp": "2026-08-21T21:11:00+02:00",
+      "Average": 22.98,
+      "Minimum": 17.18,
+      "Maximum": 34.55,
+      "Unit": "Percent",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "database_connections": {
+      "Timestamp": "2026-08-21T21:11:00+02:00",
+      "Average": 508.3,
+      "Minimum": 393,
+      "Maximum": 811,
+      "Unit": "Count",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "read_iops": {
+      "Timestamp": "2026-08-21T21:11:00+02:00",
+      "Average": 0,
+      "Maximum": 0.02,
+      "Unit": "Count/Second",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "write_iops": {
+      "Timestamp": "2026-08-21T21:11:00+02:00",
+      "Average": 2647.22,
+      "Maximum": 3283.48,
+      "Unit": "Count/Second",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "deadlocks": {
+      "Timestamp": "2026-08-21T21:11:00+02:00",
+      "Average": 0.02,
+      "Sum": 0.38,
+      "Maximum": 0.38,
+      "Unit": "Count/Second",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    }
+  },
+  "rds_readers": [
+    {
+      "instance": "reader-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-21T21:11:00+02:00",
+        "Average": 29.48,
+        "Minimum": 22.16,
+        "Maximum": 43.86,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-08-21T21:11:00+02:00",
+        "Average": 383.45,
+        "Minimum": 379,
+        "Maximum": 392,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-08-21T21:11:00+02:00",
+        "Average": 28.94,
+        "Maximum": 137.55,
+        "Unit": "Count/Second",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-08-21T21:11:00+02:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      }
+    },
+    {
+      "instance": "reader-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-21T21:11:00+02:00",
+        "Average": 41.82,
+        "Minimum": 34.07,
+        "Maximum": 47.85,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "database_connections": {
+        "Timestamp": "2026-08-21T21:11:00+02:00",
+        "Average": 422.9,
+        "Minimum": 421,
+        "Maximum": 429,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "read_iops": {
+        "Timestamp": "2026-08-21T21:11:00+02:00",
+        "Average": 42.8,
+        "Maximum": 144.45,
+        "Unit": "Count/Second",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "write_iops": {
+        "Timestamp": "2026-08-21T21:11:00+02:00",
+        "Average": 0,
+        "Maximum": 0,
+        "Unit": "Count/Second",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "rds_performance_insights": {
+    "writer": [
+      {
+        "rank": 1,
+        "sql": "DELETE FROM `host_mdm_apple_profiles` WHERE `host_uuid` = ? AND `command_uuid` = ? ",
+        "load_avg": 4.51
+      },
+      {
+        "rank": 2,
+        "sql": "INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... */ , ( ?, ... ",
+        "load_avg": 3.66
+      },
+      {
+        "rank": 3,
+        "sql": "COMMIT",
+        "load_avg": 1.75
+      },
+      {
+        "rank": 4,
+        "sql": "UPDATE `host_mdm_apple_profiles` SET `detail` = ? , STATUS = ? WHERE `host_uuid` = ? AND STATUS IN (...) AND `operation_type` = ? AND `profile_identifier` IN (...) ",
+        "load_avg": 1.52
+      },
+      {
+        "rank": 5,
+        "sql": "INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... */ , ( ? ",
+        "load_avg": 0.68
+      }
+    ],
+    "readers": [
+      {
+        "instance": "reader-1",
+        "top_sql": [
+          {
+            "rank": 1,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` IS NULL AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` .",
+            "load_avg": 0.27
+          },
+          {
+            "rank": 2,
+            "sql": "SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` JOIN `label_membership` `lm` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . `target_id` = `lm` . `label_id` AND `pt` . TYPE = ? ) WHERE `lm` . `host_id` = ? AND NOT `p` . `disabled` AND `p` . `pack_type` IS NULL ) UNION ALL ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . TYPE = ? AND `pt` . `target_id` = ? ) WHERE NOT `p` . `disabled` AND `p` . ",
+            "load_avg": 0.23
+          },
+          {
+            "rank": 3,
+            "sql": "SELECT `hm` . `host_id` , `hm` . `enrolled` , `hm` . `server_url` , `hm` . `installed_from_dep` , `hm` . `mdm_id` , `hm` . `is_personal_enrollment` , `hm` . `managed_apple_id` , COALESCE ( `hm` . `is_server` , FALSE ) AS `is_server` , COALESCE ( `mdms` . NAME , ? ) AS NAME , `hdep` . `assign_profile_response` AS `dep_profile_assign_status` , CASE WHEN `hm` . `enrolled` = ? AND `h` . `platform` = ? THEN EXISTS ( SELECT ? FROM `mdm_windows_enrollments` `mwe` WHERE `mwe` . `host_uuid` = `h` . `uuid",
+            "load_avg": 0.22
+          },
+          {
+            "rank": 4,
+            "sql": "SELECT `id` , `host_id` , `execution_id` , `script_id` , `created_at` FROM ( SELECT `ua` . `id` , `ua` . `host_id` , `ua` . `execution_id` , `sua` . `script_id` , `ua` . `priority` , `ua` . `created_at` , IF ( `ua` . `activated_at` IS NULL , ?, ... ) AS `topmost` FROM `upcoming_activities` `ua` LEFT JOIN `script_upcoming_activities` `sua` ON `ua` . `id` = `sua` . `upcoming_activity_id` WHERE `ua` . `host_id` = ? AND `ua` . `activity_type` IN (...) AND `ua` . `activated_at` IS NOT NULL ORDER BY `",
+            "load_avg": 0.17
+          },
+          {
+            "rank": 5,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` = ? AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` . `id",
+            "load_avg": 0.16
+          }
+        ]
+      },
+      {
+        "instance": "reader-2",
+        "top_sql": [
+          {
+            "rank": 1,
+            "sql": "SELECT `hm` . `host_id` , `hm` . `enrolled` , `hm` . `server_url` , `hm` . `installed_from_dep` , `hm` . `mdm_id` , `hm` . `is_personal_enrollment` , `hm` . `managed_apple_id` , COALESCE ( `hm` . `is_server` , FALSE ) AS `is_server` , COALESCE ( `mdms` . NAME , ? ) AS NAME , `hdep` . `assign_profile_response` AS `dep_profile_assign_status` , CASE WHEN `hm` . `enrolled` = ? AND `h` . `platform` = ? THEN EXISTS ( SELECT ? FROM `mdm_windows_enrollments` `mwe` WHERE `mwe` . `host_uuid` = `h` . `uuid",
+            "load_avg": 0.37
+          },
+          {
+            "rank": 2,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` IS NULL AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` .",
+            "load_avg": 0.32
+          },
+          {
+            "rank": 3,
+            "sql": "SELECT COUNT ( DISTINCTROW `hs` . `host_id` ) , `h` . `team_id` , ? AS `global_stats` , `st` . `id` AS `software_title_id` FROM `software_titles` `st` JOIN `software` `s` ON `s` . `title_id` = `st` . `id` JOIN `host_software` `hs` ON `hs` . `software_id` = `s` . `id` INNER JOIN HOSTS `h` ON `hs` . `host_id` = `h` . `id` WHERE `h` . `team_id` IS NOT NULL AND `hs` . `software_id` > ? GROUP BY `st` . `id` , `h` . `team_id`",
+            "load_avg": 0.3
+          },
+          {
+            "rank": 4,
+            "sql": "SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` JOIN `label_membership` `lm` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . `target_id` = `lm` . `label_id` AND `pt` . TYPE = ? ) WHERE `lm` . `host_id` = ? AND NOT `p` . `disabled` AND `p` . `pack_type` IS NULL ) UNION ALL ( SELECT `p` . * FROM `packs` `p` JOIN `pack_targets` `pt` ON ( `p` . `id` = `pt` . `pack_id` AND `pt` . TYPE = ? AND `pt` . `target_id` = ? ) WHERE NOT `p` . `disabled` AND `p` . ",
+            "load_avg": 0.28
+          },
+          {
+            "rank": 5,
+            "sql": "SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , `q` . `platform` , `q` . `min_osquery_version` , `q` . `automations_enabled` , `q` . `logging_type` , `q` . `discard_data` FROM `queries` `q` WHERE `q` . `saved` = TRUE AND ( `q` . `schedule_interval` > ? AND `team_id` = ? AND ( `q` . `automations_enabled` OR ( NOT `q` . `discard_data` AND NOT ? AND `q` . `logging_type` = ? ) ) ) AND ( NOT EXISTS ( SELECT ? FROM `query_labels` `ql` WHERE `ql` . `query_id` = `q` . `id",
+            "load_avg": 0.23
+          }
+        ]
+      }
+    ]
+  },
+  "redis": [
+    {
+      "node": "redis-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-21T21:11:00+02:00",
+        "Average": 51.26,
+        "Minimum": 50.93,
+        "Maximum": 53.31,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-08-21T21:11:00+02:00",
+        "Average": 3.59,
+        "Minimum": 3.58,
+        "Maximum": 3.61,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-21T21:11:00+02:00",
+        "Average": 6.78,
+        "Minimum": 6.65,
+        "Maximum": 6.88,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-08-21T21:11:00+02:00",
+        "Average": 3.54,
+        "Minimum": 3.53,
+        "Maximum": 3.56,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-3",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-21T21:11:00+02:00",
+        "Average": 7.25,
+        "Minimum": 7.1,
+        "Maximum": 7.35,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-08-21T21:11:00+02:00",
+        "Average": 3.54,
+        "Minimum": 3.53,
+        "Maximum": 3.55,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "apns_mock_redis": [
+    {
+      "node": "apns-redis-1",
+      "cpu_utilization": {
+        "Timestamp": "2026-08-21T21:11:00+02:00",
+        "Average": 0.16,
+        "Minimum": 0.12,
+        "Maximum": 0.93,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "memory_utilization": {
+        "Timestamp": "2026-08-21T21:11:00+02:00",
+        "Average": 0.19,
+        "Minimum": 0.19,
+        "Maximum": 0.19,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "curr_connections": {
+        "Timestamp": "2026-08-21T21:11:00+02:00",
+        "Average": 13.15,
+        "Maximum": 22,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "curr_items": {
+        "Timestamp": "2026-08-21T21:11:00+02:00",
+        "Average": 3,
+        "Maximum": 3,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-08-21T21:11:00+02:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "string_based_cmds": {
+        "Timestamp": "2026-08-21T21:11:00+02:00",
+        "Average": 1924,
+        "Sum": 38480,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "pubsub_based_cmds": {
+        "Timestamp": "2026-08-21T21:11:00+02:00",
+        "Average": 950,
+        "Sum": 19000,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "network_bytes_out": {
+        "Timestamp": "2026-08-21T21:11:00+02:00",
+        "Average": 1348668.5,
+        "Sum": 26973370,
+        "Unit": "Bytes",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      }
+    }
+  ],
+  "alb": {
+    "target_response_time": {
+      "Timestamp": "2026-08-21T21:11:00+02:00",
+      "Average": 0.01,
+      "Minimum": 0,
+      "Maximum": 26.37,
+      "Unit": "Seconds",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "http_5xx_count": null,
+    "request_count": {
+      "Timestamp": "2026-08-21T21:11:00+02:00",
+      "Sum": 42166297,
+      "Unit": "Count",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "processed_bytes": {
+      "Timestamp": "2026-08-21T21:11:00+02:00",
+      "Sum": 84761003710,
+      "Unit": "Bytes",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    }
+  },
+  "fleet_server_errors": {
+    "error_count": 30897.0,
+    "sample_messages": [
+      "{\"ts\":\"2026-08-21T17:31:08Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":\"121.196091ms\",\"host_id\":48278,\"ip_addr\":\"10.12.1.141\",\"x_for_ip_addr\":\"10.12.1.141\",\"ingestion-err\":\"ingesting query mdm_macos_software_update_id: directIngestMDMMacOSSoftwareUpdateID empty software update device ID\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-08-21T17:31:08Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":\"387.545608ms\",\"host_id\":46934,\"ip_addr\":\"10.12.1.96\",\"x_for_ip_addr\":\"10.12.1.96\",\"ingestion-err\":\"ingesting query mdm_macos_software_update_id: directIngestMDMMacOSSoftwareUpdateID empty software update device ID\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-08-21T17:31:08Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":\"293.684121ms\",\"host_id\":48271,\"ip_addr\":\"10.12.3.162\",\"x_for_ip_addr\":\"10.12.3.162\",\"ingestion-err\":\"ingesting query mdm_macos_software_update_id: directIngestMDMMacOSSoftwareUpdateID empty software update device ID\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-08-21T17:31:08Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":\"232.331579ms\",\"host_id\":47740,\"ip_addr\":\"10.12.2.208\",\"x_for_ip_addr\":\"10.12.2.208\",\"ingestion-err\":\"ingesting query mdm_macos_software_update_id: directIngestMDMMacOSSoftwareUpdateID empty software update device ID\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-08-21T17:31:08Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":\"141.189261ms\",\"host_id\":50130,\"ip_addr\":\"10.12.3.79\",\"x_for_ip_addr\":\"10.12.3.79\",\"ingestion-err\":\"ingesting query mdm_macos_software_update_id: directIngestMDMMacOSSoftwareUpdateID empty software update device ID\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-08-21T17:31:08Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":\"144.13518ms\",\"host_id\":48272,\"ip_addr\":\"10.12.3.98\",\"x_for_ip_addr\":\"10.12.3.98\",\"ingestion-err\":\"ingesting query mdm_macos_software_update_id: directIngestMDMMacOSSoftwareUpdateID empty software update device ID\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-08-21T17:31:08Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":\"168.886015ms\",\"host_id\":49588,\"ip_addr\":\"10.12.3.254\",\"x_for_ip_addr\":\"10.12.3.254\",\"ingestion-err\":\"ingesting query mdm_macos_software_update_id: directIngestMDMMacOSSoftwareUpdateID empty software update device ID\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-08-21T17:31:08Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":\"244.872737ms\",\"host_id\":50118,\"ip_addr\":\"10.12.3.98\",\"x_for_ip_addr\":\"10.12.3.98\",\"ingestion-err\":\"ingesting query mdm_macos_software_update_id: directIngestMDMMacOSSoftwareUpdateID empty software update device ID\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-08-21T17:31:08Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":\"148.26059ms\",\"host_id\":48529,\"ip_addr\":\"10.12.1.119\",\"x_for_ip_addr\":\"10.12.1.119\",\"ingestion-err\":\"ingesting query mdm_macos_software_update_id: directIngestMDMMacOSSoftwareUpdateID empty software update device ID\",\"err\":\"error in query ingestion\"}",
+      "{\"ts\":\"2026-08-21T17:31:08Z\",\"level\":\"error\",\"component\":\"http\",\"method\":\"POST\",\"uri\":\"/api/osquery/distributed/write\",\"took\":\"177.757753ms\",\"host_id\":44806,\"ip_addr\":\"10.12.3.156\",\"x_for_ip_addr\":\"10.12.3.156\",\"ingestion-err\":\"ingesting query mdm_macos_software_update_id: directIngestMDMMacOSSoftwareUpdateID empty software update device ID\",\"err\":\"error in query ingestion\"}"
+    ]
+  },
+  "rds_writer_extended": {
+    "freeable_memory": {
+      "Timestamp": "2026-08-21T21:11:00+02:00",
+      "Average": 28838670336,
+      "Minimum": 27334221824,
+      "Unit": "Bytes",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "buffer_cache_hit_ratio": {
+      "Timestamp": "2026-08-21T21:11:00+02:00",
+      "Average": 100,
+      "Minimum": 100,
+      "Unit": "Percent",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "volume_bytes_used": null,
+    "select_latency": {
+      "Timestamp": "2026-08-21T21:11:00+02:00",
+      "Average": 1.2,
+      "Maximum": 5.57,
+      "Unit": "Milliseconds",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "insert_latency": {
+      "Timestamp": "2026-08-21T21:11:00+02:00",
+      "Average": 17.2,
+      "Maximum": 127.86,
+      "Unit": "Milliseconds",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "dml_latency": {
+      "Timestamp": "2026-08-21T21:11:00+02:00",
+      "Average": 12.43,
+      "Maximum": 92.74,
+      "Unit": "Milliseconds",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "threads_running": {
+      "average": 6.89,
+      "maximum": 21.75,
+      "vcpus": 16
+    },
+    "iops_utilization": {
+      "instance_class": "db.r6g.4xlarge",
+      "max_iops": 20000,
+      "read_iops_avg": 0,
+      "write_iops_avg": 2647.22,
+      "total_iops_avg": 2647.22,
+      "utilization_pct": 13.24
+    }
+  },
+  "rds_readers_extended": [
+    {
+      "instance": "reader-1",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-08-21T21:11:00+02:00",
+        "Average": 6.5,
+        "Maximum": 10,
+        "Unit": "Milliseconds",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-08-21T21:11:00+02:00",
+        "Average": 30279001088,
+        "Minimum": 29851484160,
+        "Unit": "Bytes",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-08-21T21:11:00+02:00",
+        "Average": 99.99,
+        "Minimum": 99.98,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-08-21T21:11:00+02:00",
+        "Average": 0.32,
+        "Maximum": 0.51,
+        "Unit": "Milliseconds",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "iops_utilization": {
+        "instance_class": "db.r6g.4xlarge",
+        "max_iops": 20000,
+        "read_iops_avg": 28.94,
+        "write_iops_avg": 0,
+        "total_iops_avg": 28.94,
+        "utilization_pct": 0.14
+      },
+      "threads_running": {
+        "average": 2.1,
+        "maximum": 3.08,
+        "vcpus": 16
+      }
+    },
+    {
+      "instance": "reader-2",
+      "aurora_replica_lag": {
+        "Timestamp": "2026-08-21T21:11:00+02:00",
+        "Average": 8.4,
+        "Maximum": 15,
+        "Unit": "Milliseconds",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "freeable_memory": {
+        "Timestamp": "2026-08-21T21:11:00+02:00",
+        "Average": 30253409894.4,
+        "Minimum": 30199418880,
+        "Unit": "Bytes",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "buffer_cache_hit_ratio": {
+        "Timestamp": "2026-08-21T21:11:00+02:00",
+        "Average": 99.99,
+        "Minimum": 99.97,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "select_latency": {
+        "Timestamp": "2026-08-21T21:11:00+02:00",
+        "Average": 0.38,
+        "Maximum": 0.89,
+        "Unit": "Milliseconds",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "iops_utilization": {
+        "instance_class": "db.r6g.4xlarge",
+        "max_iops": 20000,
+        "read_iops_avg": 42.8,
+        "write_iops_avg": 0,
+        "total_iops_avg": 42.8,
+        "utilization_pct": 0.21
+      },
+      "threads_running": {
+        "average": 3.32,
+        "maximum": 3.87,
+        "vcpus": 16
+      }
+    }
+  ],
+  "redis_extended": [
+    {
+      "node": "redis-1",
+      "curr_connections": {
+        "Timestamp": "2026-08-21T21:11:00+02:00",
+        "Average": 398.05,
+        "Maximum": 1030,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-08-21T21:11:00+02:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": {
+        "Timestamp": "2026-08-21T21:11:00+02:00",
+        "Average": 84.13,
+        "Minimum": 82.19,
+        "Unit": "Percent",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      }
+    },
+    {
+      "node": "redis-2",
+      "curr_connections": {
+        "Timestamp": "2026-08-21T21:11:00+02:00",
+        "Average": 5.45,
+        "Maximum": 6,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-08-21T21:11:00+02:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    },
+    {
+      "node": "redis-3",
+      "curr_connections": {
+        "Timestamp": "2026-08-21T21:11:00+02:00",
+        "Average": 6,
+        "Maximum": 6,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "evictions": {
+        "Timestamp": "2026-08-21T21:11:00+02:00",
+        "Sum": 0,
+        "Maximum": 0,
+        "Unit": "Count",
+        "data_points": 4,
+        "max_points": 4,
+        "data_coverage": 1
+      },
+      "cache_hit_rate": null
+    }
+  ],
+  "network": {
+    "network_rx_bytes": {
+      "Timestamp": "2026-08-21T21:11:00+02:00",
+      "Average": 1761639.78,
+      "Sum": 1409311826,
+      "Unit": "Bytes/Second",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    },
+    "network_tx_bytes": {
+      "Timestamp": "2026-08-21T21:11:00+02:00",
+      "Average": 562328.6,
+      "Sum": 449862879,
+      "Unit": "Bytes/Second",
+      "data_points": 4,
+      "max_points": 4,
+      "data_coverage": 1
+    }
+  },
+  "container_health": {
+    "abnormal_stops": 0,
+    "running_tasks": 38,
+    "oldest_start": null,
+    "newest_start": null,
+    "start_spread_min": null,
+    "start_spread_alert": false,
+    "tasks": []
+  }
+}

--- a/tools/loadtest/metrics/runs/mdm/mock-apns/mock-apns-2026-08-21-193108Z-20m.md
+++ b/tools/loadtest/metrics/runs/mdm/mock-apns/mock-apns-2026-08-21-193108Z-20m.md
@@ -1,0 +1,65 @@
+# Metrics Synopsis: mock-apns
+
+- **Collected:** 2026-08-21T19:31:08Z
+- **Interval:** 20m
+- **Window:** 2026-08-21T19:11:08Z to 2026-08-21T19:31:08Z
+- **Note:** 76k enrolled deleting all 10 profiles (total 0)
+
+## Summary (20m averages)
+
+```
+Fleet Server:  CPU=80.35%  Mem=10.69%  Containers=40
+Loadtest:      CPU=9.93%  Mem=11.34%  Containers=38
+apns-mock:     CPU=3.41%  Mem=15.93%  Containers=2  (averaged across containers)
+               PerTask CPU avg=3.41% max=7.63%   Mem avg=15.93% max=16.63%
+               RX=13.13MB  TX=14.33MB  AbnormalStops=0  StartSpread=21.17min  ⚠ STAGGERED STARTS
+apns Redis:    CPU=0.16% (max 0.93%)  Mem=0.19%  Conns=13.15  PendingItems=3  Evictions=0
+               StringCmds=38480  PubSubCmds=19000  NetOut=25.72MB
+RDS Writer:    CPU=22.98%  Connections=508.3  Deadlocks=0.38
+RDS reader-1:  CPU=29.48%  Connections=383.45
+RDS reader-2:  CPU=41.82%  Connections=422.9
+Redis:         CPU=51.26%  Mem=3.59%
+
+Top SQL (writer):
+  #1 load=4.51  DELETE FROM `host_mdm_apple_profiles` WHERE `host_uuid` = ? AND `command_uuid` =
+  #2 load=3.66  INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... 
+  #3 load=1.75  COMMIT
+  #4 load=1.52  UPDATE `host_mdm_apple_profiles` SET `detail` = ? , STATUS = ? WHERE `host_uuid`
+  #5 load=0.68  INSERT INTO `host_seen_times` ( `host_id` , `seen_time` ) VALUES (...) /* , ... 
+
+Top SQL (reader-1):
+  #1 load=0.27  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #2 load=0.23  SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pa
+  #3 load=0.22  SELECT `hm` . `host_id` , `hm` . `enrolled` , `hm` . `server_url` , `hm` . `inst
+  #4 load=0.17  SELECT `id` , `host_id` , `execution_id` , `script_id` , `created_at` FROM ( SEL
+  #5 load=0.16  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+
+Top SQL (reader-2):
+  #1 load=0.37  SELECT `hm` . `host_id` , `hm` . `enrolled` , `hm` . `server_url` , `hm` . `inst
+  #2 load=0.32  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+  #3 load=0.3  SELECT COUNT ( DISTINCTROW `hs` . `host_id` ) , `h` . `team_id` , ? AS `global_s
+  #4 load=0.28  SELECT DISTINCTROW `packs` . * FROM ( ( SELECT `p` . * FROM `packs` `p` JOIN `pa
+  #5 load=0.23  SELECT `q` . NAME , `q` . QUERY , `q` . `team_id` , `q` . `schedule_interval` , 
+ALB:           Latency=0.01s  5xx=0  Requests=42166297  Traffic=80834.39MB
+Fleet Errors:  Count=30897.0
+RDS Writer:    FreeMem=26.86GB  CacheHit=100%  Disk=N/A  Threads=6.89  IOPS=13.24%
+               SelectLat=1.2ms  InsertLat=17.2ms
+RDS reader-1: FreeMem=28.2GB  CacheHit=99.99%  ReplicaLag=6.5ms  Threads=2.1  IOPS=0.14%
+               SelectLat=0.32ms
+RDS reader-2: FreeMem=28.18GB  CacheHit=99.99%  ReplicaLag=8.4ms  Threads=3.32  IOPS=0.21%
+               SelectLat=0.38ms
+Redis:         Connections=398.05  Evictions=0  CacheHit=84.13%
+Network:       RX=1344.02MB  TX=429.02MB
+Containers:    Running=38  AbnormalStops=0  StartSpread=N/Amin
+```
+
+## Threshold Checks
+
+```
+  🔴 ALERT: Fleet Server CPU avg = 80.35 (expected < 80)
+  🔴 ALERT: RDS Writer Deadlocks = 0.38 (expected 0)
+  🔴 ALERT: apns-mock Start Spread (min) = 21.17 (expected < 10)
+  🔴 ALERT: Fleet Server Errors = 30897.0 (expected 0)
+
+  ⚠ 4 alert(s) detected
+```


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves nothing, but part of the mock APNS work

# Checklist for submitter


## Testing

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional run notes, with support for JSON and Markdown output.
  - Added monitoring for APNS mock services and their dedicated Redis instance, including utilization, health, networking, connections, and command activity.
  - Added service health and per-task utilization reporting.
  - Improved load-test summaries, threshold checks, and load balancer metric support.
  - Updated the dashboard to display run notes and APNS mock metrics.

- **Data**
  - Added several regional APNS mock load-test metric snapshots covering service, database, cache, traffic, and error measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->