### PR TITLE
Install updates when apps are closed

### DIFF
--- a/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
+++ b/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
@@ -4,6 +4,7 @@
   type: patch
   fleet_maintained_app_slug: google-chrome/darwin
   install_software: false
+  patch_when_closed: true
   labels_include_any:
     - Macs with Google Chrome installed
 - name: 1Password up to date (macOS)
@@ -12,6 +13,7 @@
   type: patch
   fleet_maintained_app_slug: 1password/darwin
   install_software: true
+  patch_when_closed: true
   labels_include_any:
     - Macs with 1Password installed
 - name: Brave Browser up to date
@@ -20,6 +22,7 @@
   type: patch
   fleet_maintained_app_slug: brave-browser/darwin
   install_software: false
+  patch_when_closed: true
   labels_include_any:
     - Macs with Brave Browser installed
 - name: Docker Desktop up to date
@@ -28,6 +31,7 @@
   type: patch
   fleet_maintained_app_slug: docker-desktop/darwin
   install_software: false
+  patch_when_closed: true
   labels_include_any:
     - Macs with Docker Desktop installed
 - name: Firefox up to date (macOS)
@@ -36,6 +40,7 @@
   type: patch
   fleet_maintained_app_slug: firefox/darwin
   install_software: false
+  patch_when_closed: true
   calendar_events_enabled: true
   labels_include_any:
     - Macs with Firefox installed
@@ -45,6 +50,7 @@
   type: patch
   fleet_maintained_app_slug: visual-studio-code/darwin
   install_software: false
+  patch_when_closed: true
   labels_include_any:
     - Macs with Visual Studio Code installed
 - name: Slack up to date (macOS)
@@ -53,6 +59,7 @@
   type: patch
   fleet_maintained_app_slug: slack/darwin
   install_software: false
+  patch_when_closed: true
   labels_include_any:
     - Macs with Slack installed
 - name: Zoom up to date (macOS)
@@ -61,6 +68,7 @@
   type: patch
   fleet_maintained_app_slug: zoom/darwin
   install_software: false
+  patch_when_closed: true
   labels_include_any:
     - Macs with Zoom installed
 - name: Okta Verify up to date (macOS)
@@ -69,6 +77,7 @@
   type: patch
   fleet_maintained_app_slug: okta-verify/darwin
   install_software: true
+  patch_when_closed: true
   labels_include_any:
     - Macs with Okta Verify installed
 - name: Santa up to date
@@ -77,6 +86,7 @@
   type: patch
   fleet_maintained_app_slug: santa/darwin
   install_software: true
+  patch_when_closed: true
   labels_include_any:
     - Macs with Santa installed
 - name: Fleet Desktop up to date
@@ -85,6 +95,7 @@
   type: patch
   fleet_maintained_app_slug: fleet-desktop/darwin
   install_software: true
+  patch_when_closed: true
   labels_include_any:
     - Macs with Fleet Desktop.app installed
 - name: Claude up to date (macOS)
@@ -93,6 +104,7 @@
   type: patch
   fleet_maintained_app_slug: claude/darwin
   install_software: false
+  patch_when_closed: true
   labels_include_any:
     - Macs with Claude installed
 - name: AWS VPN Client up to date
@@ -101,6 +113,7 @@
   type: patch
   fleet_maintained_app_slug: aws-vpn-client/darwin
   install_software: false
+  patch_when_closed: true
   labels_include_any:
     - Macs with AWS VPN Client installed
 - name: GitHub Desktop up to date
@@ -109,6 +122,7 @@
   type: patch
   fleet_maintained_app_slug: github/darwin
   install_software: false
+  patch_when_closed: true
   labels_include_any:
     - Macs with GitHub Desktop installed
 - name: UTM up to date
@@ -117,6 +131,7 @@
   type: patch
   fleet_maintained_app_slug: utm/darwin
   install_software: false
+  patch_when_closed: true
   labels_include_any:
     - Macs with UTM installed
 - name: Postman up to date
@@ -125,6 +140,7 @@
   type: patch
   fleet_maintained_app_slug: postman/darwin
   install_software: false
+  patch_when_closed: true
   labels_include_any:
     - Macs with Postman installed
 - name: Grammarly Desktop up to date
@@ -133,6 +149,7 @@
   type: patch
   fleet_maintained_app_slug: grammarly-desktop/darwin
   install_software: false
+  patch_when_closed: true
   labels_include_any:
     - Macs with Grammarly Desktop installed
 - name: iTerm2 up to date
@@ -141,6 +158,7 @@
   type: patch
   fleet_maintained_app_slug: iterm2/darwin
   install_software: false
+  patch_when_closed: true
   labels_include_any:
     - Macs with iTerm2 installed
 - name: Sublime Text up to date
@@ -149,6 +167,7 @@
   type: patch
   fleet_maintained_app_slug: sublime-text/darwin
   install_software: false
+  patch_when_closed: true
   labels_include_any:
     - Macs with Sublime Text installed
 - name: Parallels Desktop up to date
@@ -157,6 +176,7 @@
   type: patch
   fleet_maintained_app_slug: parallels/darwin
   install_software: false
+  patch_when_closed: true
   labels_include_any:
     - Macs with Parallels Desktop installed
 - name: Loom up to date
@@ -165,6 +185,7 @@
   type: patch
   fleet_maintained_app_slug: loom/darwin
   install_software: false
+  patch_when_closed: true
   labels_include_any:
     - Macs with Loom installed
 - name: Spotify up to date
@@ -173,6 +194,7 @@
   type: patch
   fleet_maintained_app_slug: spotify/darwin
   install_software: false
+  patch_when_closed: true
   labels_include_any:
     - Macs with Spotify installed
 - name: Rectangle up to date
@@ -181,6 +203,7 @@
   type: patch
   fleet_maintained_app_slug: rectangle/darwin
   install_software: false
+  patch_when_closed: true
   labels_include_any:
     - Macs with Rectangle installed
 - name: Logi Options+ up to date
@@ -189,6 +212,7 @@
   type: patch
   fleet_maintained_app_slug: logi-options+/darwin
   install_software: false
+  patch_when_closed: true
   labels_include_any:
     - Macs with Logi Options+ installed
 - name: Figma up to date
@@ -197,6 +221,7 @@
   type: patch
   fleet_maintained_app_slug: figma/darwin
   install_software: false
+  patch_when_closed: true
   labels_include_any:
     - Macs with Figma installed
 - name: WhatsApp up to date
@@ -205,6 +230,7 @@
   type: patch
   fleet_maintained_app_slug: whatsapp/darwin
   install_software: false
+  patch_when_closed: true
   labels_include_any:
     - Macs with WhatsApp installed
 - name: Android Studio up to date
@@ -213,6 +239,7 @@
   type: patch
   fleet_maintained_app_slug: android-studio/darwin
   install_software: false
+  patch_when_closed: true
   labels_include_any:
     - Macs with Android Studio installed
 - name: Zed up to date
@@ -221,6 +248,7 @@
   type: patch
   fleet_maintained_app_slug: zed/darwin
   install_software: false
+  patch_when_closed: true
   labels_include_any:
     - Macs with Zed installed
 - name: Obsidian up to date
@@ -229,6 +257,7 @@
   type: patch
   fleet_maintained_app_slug: obsidian/darwin
   install_software: false
+  patch_when_closed: true
   labels_include_any:
     - Macs with Obsidian installed
 - name: Google Drive up to date
@@ -237,6 +266,7 @@
   type: patch
   fleet_maintained_app_slug: google-drive/darwin
   install_software: false
+  patch_when_closed: true
   labels_include_any:
     - Macs with Google Drive installed
 - name: Cursor up to date
@@ -245,6 +275,7 @@
   type: patch
   fleet_maintained_app_slug: cursor/darwin
   install_software: false
+  patch_when_closed: true
   labels_include_any:
     - Macs with Cursor installed
 - name: Nudge up to date
@@ -253,6 +284,7 @@
   type: patch
   fleet_maintained_app_slug: nudge/darwin
   install_software: true
+  patch_when_closed: true
   labels_include_any:
     - Macs with Nudge installed
 - name: Adobe Acrobat Reader up to date (macOS)
@@ -262,6 +294,7 @@
   type: patch
   fleet_maintained_app_slug: adobe-acrobat-reader/darwin
   install_software: true
+  patch_when_closed: true
   labels_include_any:
     - Macs with Adobe Acrobat Reader installed
 - name: Adobe Acrobat Pro up to date
@@ -271,5 +304,6 @@
   type: patch
   fleet_maintained_app_slug: adobe-acrobat-pro/darwin
   install_software: true
+  patch_when_closed: true
   labels_include_any:
     - Macs with Adobe Acrobat Pro installed

--- a/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
+++ b/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
@@ -13,7 +13,6 @@
   type: patch
   fleet_maintained_app_slug: 1password/darwin
   install_software: true
-  patch_when_closed: true
   labels_include_any:
     - Macs with 1Password installed
 - name: Brave Browser up to date
@@ -77,7 +76,6 @@
   type: patch
   fleet_maintained_app_slug: okta-verify/darwin
   install_software: true
-  patch_when_closed: true
   labels_include_any:
     - Macs with Okta Verify installed
 - name: Santa up to date
@@ -86,7 +84,6 @@
   type: patch
   fleet_maintained_app_slug: santa/darwin
   install_software: true
-  patch_when_closed: true
   labels_include_any:
     - Macs with Santa installed
 - name: Fleet Desktop up to date
@@ -95,7 +92,6 @@
   type: patch
   fleet_maintained_app_slug: fleet-desktop/darwin
   install_software: true
-  patch_when_closed: true
   labels_include_any:
     - Macs with Fleet Desktop.app installed
 - name: Claude up to date (macOS)
@@ -284,7 +280,6 @@
   type: patch
   fleet_maintained_app_slug: nudge/darwin
   install_software: true
-  patch_when_closed: true
   labels_include_any:
     - Macs with Nudge installed
 - name: Adobe Acrobat Reader up to date (macOS)
@@ -294,7 +289,6 @@
   type: patch
   fleet_maintained_app_slug: adobe-acrobat-reader/darwin
   install_software: true
-  patch_when_closed: true
   labels_include_any:
     - Macs with Adobe Acrobat Reader installed
 - name: Adobe Acrobat Pro up to date
@@ -304,6 +298,5 @@
   type: patch
   fleet_maintained_app_slug: adobe-acrobat-pro/darwin
   install_software: true
-  patch_when_closed: true
   labels_include_any:
     - Macs with Adobe Acrobat Pro installed

--- a/it-and-security/lib/windows/policies/patch-fleet-maintained-apps.yml
+++ b/it-and-security/lib/windows/policies/patch-fleet-maintained-apps.yml
@@ -4,6 +4,7 @@
   type: patch
   fleet_maintained_app_slug: slack/windows
   install_software: false
+  patch_when_closed: true
   labels_include_any:
     - x86 Windows hosts with Slack installed
 - name: 1Password up to date (Windows)
@@ -12,6 +13,7 @@
   type: patch
   fleet_maintained_app_slug: 1password/windows
   install_software: true
+  patch_when_closed: true
   labels_include_any:
     - x86 Windows hosts with 1Password installed
 - name: Claude up to date (Windows)
@@ -20,6 +22,7 @@
   type: patch
   fleet_maintained_app_slug: claude/windows
   install_software: false
+  patch_when_closed: true
   labels_include_any:
     - x86 Windows hosts with Claude installed
 - name: Firefox up to date (Windows)
@@ -28,6 +31,7 @@
   type: patch
   fleet_maintained_app_slug: firefox/windows
   install_software: false
+  patch_when_closed: true
   labels_include_any:
     - x86 Windows hosts with Firefox installed
 - name: Google Chrome up to date (Windows)
@@ -36,6 +40,7 @@
   type: patch
   fleet_maintained_app_slug: google-chrome/windows
   install_software: false
+  patch_when_closed: true
   labels_include_any:
     - x86 Windows hosts with Google Chrome installed
 - name: Zoom up to date (Windows)
@@ -44,6 +49,7 @@
   type: patch
   fleet_maintained_app_slug: zoom/windows
   install_software: false
+  patch_when_closed: true
   labels_include_any:
     - x86 Windows hosts with Zoom installed
 - name: Visual Studio Code up to date (Windows)
@@ -52,6 +58,7 @@
   type: patch
   fleet_maintained_app_slug: visual-studio-code/windows
   install_software: false
+  patch_when_closed: true
   labels_include_any:
     - x86 Windows hosts with Visual Studio Code installed
 - name: Okta Verify up to date (Windows)
@@ -60,6 +67,7 @@
   type: patch
   fleet_maintained_app_slug: okta-verify/windows
   install_software: true
+  patch_when_closed: true
   labels_include_any:
     - x86 Windows hosts with Okta Verify installed
 - name: Adobe Acrobat Reader up to date (Windows)
@@ -69,5 +77,6 @@
   type: patch
   fleet_maintained_app_slug: adobe-acrobat-reader/windows
   install_software: true
+  patch_when_closed: true
   labels_include_any:
     - x86 Windows hosts with Adobe Acrobat Reader installed

--- a/it-and-security/lib/windows/policies/patch-fleet-maintained-apps.yml
+++ b/it-and-security/lib/windows/policies/patch-fleet-maintained-apps.yml
@@ -13,7 +13,6 @@
   type: patch
   fleet_maintained_app_slug: 1password/windows
   install_software: true
-  patch_when_closed: true
   labels_include_any:
     - x86 Windows hosts with 1Password installed
 - name: Claude up to date (Windows)
@@ -67,7 +66,6 @@
   type: patch
   fleet_maintained_app_slug: okta-verify/windows
   install_software: true
-  patch_when_closed: true
   labels_include_any:
     - x86 Windows hosts with Okta Verify installed
 - name: Adobe Acrobat Reader up to date (Windows)
@@ -77,6 +75,5 @@
   type: patch
   fleet_maintained_app_slug: adobe-acrobat-reader/windows
   install_software: true
-  patch_when_closed: true
   labels_include_any:
     - x86 Windows hosts with Adobe Acrobat Reader installed


### PR DESCRIPTION
UPDATE: @noahtalerman: Closed this b/c we would need to use the RC version of fleetctl. Instead we can use the UI for now because it's easier.

---

Dogfooding for the following improvement (story):
- https://github.com/fleetdm/fleet/issues/39962


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Fleet-maintained applications installed by users on macOS can now be patched automatically when closed.
  * On Windows, Slack, Claude, Firefox, Google Chrome, Zoom, and Visual Studio Code can now be patched automatically when closed.
  * Patch behavior remains unchanged for IT-managed macOS applications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->