### PR TITLE
New bookmark: #g-byod

### DIFF
--- a/it-and-security/lib/macos/configuration-profiles/google-chrome-managed-bookmarks.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/google-chrome-managed-bookmarks.mobileconfig
@@ -524,6 +524,12 @@
                         </dict>
                         <dict>
                             <key>name</key>
+                            <string>🤖 Kanban board (#g-byod)</string>
+                            <key>url</key>
+                            <string>https://github.com/orgs/fleetdm/projects/112</string>
+                        </dict>
+                        <dict>
+                            <key>name</key>
                             <string>🪄 Current sprint (#g-orchestration)</string>
                             <key>url</key>
                             <string>https://github.com/orgs/fleetdm/projects/71</string>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Kanban board bookmark to the managed Google Chrome bookmarks under Engineering.
  * Links directly to the relevant project board for easier access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->