### PR TITLE
Keep Enrollment ID on the host page after a BYOD host unenrolls

### DIFF
--- a/changes/50884-enrollment-id-after-unenroll.md
+++ b/changes/50884-enrollment-id-after-unenroll.md
@@ -1,2 +1,2 @@
 - Fixed the host details Vitals card replacing **Enrollment ID** with an empty **Serial number** after a personal (BYOD) Android host is unenrolled.
-- Added `mdm.is_personal_enrollment` to host API responses. Unlike `mdm.enrollment_status`, it stays `true` after the host unenrolls.
+- Added `mdm.is_personal_enrollment` to host API responses, reporting whether the last MDM enrollment Fleet recorded for the host was personal (BYOD). Unlike `mdm.enrollment_status`, it is not cleared when the host unenrolls.

--- a/changes/50884-enrollment-id-after-unenroll.md
+++ b/changes/50884-enrollment-id-after-unenroll.md
@@ -1,0 +1,2 @@
+- Fixed the host details Vitals card replacing **Enrollment ID** with an empty **Serial number** after a personal (BYOD) Android host is unenrolled.
+- Added `mdm.is_personal_enrollment` to host API responses. Unlike `mdm.enrollment_status`, it stays `true` after the host unenrolls.

--- a/cmd/fleetctl/fleetctl/testdata/expectedHostDetailResponseJson.json
+++ b/cmd/fleetctl/fleetctl/testdata/expectedHostDetailResponseJson.json
@@ -48,6 +48,7 @@
       "encryption_key_archived": false,
       "encryption_key_available": false,
       "enrollment_status": null,
+      "is_personal_enrollment": false,
       "name": "",
       "pending_action": "",
       "server_url": null

--- a/cmd/fleetctl/fleetctl/testdata/expectedHostDetailResponseYaml.yml
+++ b/cmd/fleetctl/fleetctl/testdata/expectedHostDetailResponseYaml.yml
@@ -47,6 +47,7 @@ spec:
     encryption_key_archived: false
     encryption_key_available: false
     enrollment_status: null
+    is_personal_enrollment: false
     name: ""
     pending_action: ""
     server_url: null

--- a/cmd/fleetctl/fleetctl/testdata/expectedListHostsJson.json
+++ b/cmd/fleetctl/fleetctl/testdata/expectedListHostsJson.json
@@ -50,6 +50,7 @@
             "dep_profile_error": false,
             "encryption_key_available": false,
             "enrollment_status": null,
+            "is_personal_enrollment": false,
             "name": "",
             "server_url": null
         },
@@ -124,6 +125,7 @@
             "dep_profile_error": false,
             "encryption_key_available": false,
             "enrollment_status": null,
+            "is_personal_enrollment": false,
             "name": "",
             "server_url": null
         },

--- a/cmd/fleetctl/fleetctl/testdata/expectedListHostsMDM.json
+++ b/cmd/fleetctl/fleetctl/testdata/expectedListHostsMDM.json
@@ -51,6 +51,7 @@
         "dep_profile_error": false,
         "encryption_key_available": false,
         "enrollment_status": null,
+        "is_personal_enrollment": false,
         "name": "",
         "server_url": null
       },
@@ -125,6 +126,7 @@
         "dep_profile_error": false,
         "encryption_key_available": false,
         "enrollment_status": null,
+        "is_personal_enrollment": false,
         "name": "",
         "server_url": null
       },

--- a/cmd/fleetctl/fleetctl/testdata/expectedListHostsYaml.yml
+++ b/cmd/fleetctl/fleetctl/testdata/expectedListHostsYaml.yml
@@ -45,6 +45,7 @@ spec:
     dep_profile_error: false
     encryption_key_available: false
     enrollment_status: null
+    is_personal_enrollment: false
     name: ""
     server_url: null
   memory: 0
@@ -115,6 +116,7 @@ spec:
     dep_profile_error: false
     encryption_key_available: false
     enrollment_status: null
+    is_personal_enrollment: false
     name: ""
     server_url: null
   memory: 0

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -4220,6 +4220,7 @@ Returns the information of the specified host.
     "mdm": {
       "encryption_key_available": true,
       "enrollment_status": "On (manual)",
+      "is_personal_enrollment": false,
       "name": "Fleet",
       "connected_to_fleet": true,
       "server_url": "https://acme.com/mdm/apple/mdm",
@@ -4286,6 +4287,8 @@ Returns the information of the specified host.
 > - `scripts_enabled: null` means this agent is not a fleetd agent, or this agent is version <=1.23.0 which is not collecting the scripts enabled info
 
 > Note: [Get human-device mapping](https://github.com/fleetdm/fleet/blob/62dc32454f6a40e81fe229abdfc370d3bf7a56c6/docs/REST%20API/rest-api.md?plain=1#L3518) is deprecated as of Fleet 4.67.0. It is maintained for backwards compatibility. Please use the [Get host](#get-host) endpoint to get human-device mapping.
+
+> Note: ⁠`mdm.is_personal_enrollment` reports whether the host's most recent MDM enrollment was personal (BYOD). Unlike ⁠`mdm.enrollment_status`, it stays ⁠`true` after the host unenrolls.
 
 > Note: For iOS, iPadOS, and Android hosts with ⁠`mdm.enrollment_status` set to "On (personal)", ⁠`hardware_serial` and ⁠`uuid` represent a temporary enrollment ID. For Android work profile, this is what Google calls an [enterprise-specific ID](https://developer.android.com/work/versions/android-12#:~:text=An%20enrollment%2Dspecific%20ID%20provides%20a%20unique%20ID%20that%20identifies%20the%20work%20profile%20enrollment%20in%20a%20particular%20organization%2C%20and%20will%20remain%20stable%20across%20factory%20resets).
 
@@ -4710,6 +4713,7 @@ X-Client-Cert-Serial: <fleet_identity_scep_cert_serial>
     "mdm": {
       "encryption_key_available": true,
       "enrollment_status": "On (manual)",
+      "is_personal_enrollment": false,
       "name": "Fleet",
       "connected_to_fleet": true,
       "server_url": "https://acme.com/mdm/apple/mdm",

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -3650,6 +3650,7 @@ To filter Windows hosts using `os_name` and `os_version`, set `os_name` to the f
       "mdm": {
         "encryption_key_available": false,
         "enrollment_status": "Pending",
+        "is_personal_enrollment": false,
         "dep_profile_error": true,
         "name": "Fleet",
         "server_url": "https://example.fleetdm.com/mdm/apple/mdm",
@@ -4288,7 +4289,7 @@ Returns the information of the specified host.
 
 > Note: [Get human-device mapping](https://github.com/fleetdm/fleet/blob/62dc32454f6a40e81fe229abdfc370d3bf7a56c6/docs/REST%20API/rest-api.md?plain=1#L3518) is deprecated as of Fleet 4.67.0. It is maintained for backwards compatibility. Please use the [Get host](#get-host) endpoint to get human-device mapping.
 
-> Note: ⁠`mdm.is_personal_enrollment` reports whether the host's most recent MDM enrollment was personal (BYOD). Unlike ⁠`mdm.enrollment_status`, it stays ⁠`true` after the host unenrolls.
+> Note: `mdm.is_personal_enrollment` reports whether the last MDM enrollment Fleet recorded for the host was personal (BYOD). Unlike `mdm.enrollment_status`, it is not cleared when the host unenrolls, so it stays `true` for an unenrolled Android or Apple mobile host. On macOS and Windows, MDM state is re-reported by the agent, which resets the field once the enrollment profile is gone.
 
 > Note: For iOS, iPadOS, and Android hosts with ⁠`mdm.enrollment_status` set to "On (personal)", ⁠`hardware_serial` and ⁠`uuid` represent a temporary enrollment ID. For Android work profile, this is what Google calls an [enterprise-specific ID](https://developer.android.com/work/versions/android-12#:~:text=An%20enrollment%2Dspecific%20ID%20provides%20a%20unique%20ID%20that%20identifies%20the%20work%20profile%20enrollment%20in%20a%20particular%20organization%2C%20and%20will%20remain%20stable%20across%20factory%20resets).
 
@@ -4482,6 +4483,7 @@ In Fleet, hostnames are fully qualified domain names (FQDNs). `hostname` (e.g. j
     "mdm": {
       "encryption_key_available": false,
       "enrollment_status": null,
+      "is_personal_enrollment": false,
       "name": "",
       "server_url": null,
       "device_status": "unlocked",
@@ -6834,6 +6836,7 @@ If `mdm_id`, `mdm_name`, `mdm_enrollment_status`, `os_settings`, or `os_settings
       "mdm": {
         "encryption_key_available": false,
         "enrollment_status": null,
+        "is_personal_enrollment": false,
         "name": "",
         "server_url": null
       }

--- a/frontend/__mocks__/mdmMock.ts
+++ b/frontend/__mocks__/mdmMock.ts
@@ -51,6 +51,7 @@ export const createMockMdmProfile = (
 const DEFAULT_HOST_MDM_DATA: IHostMdmData = {
   encryption_key_available: false,
   enrollment_status: "On (automatic)",
+  is_personal_enrollment: false,
   server_url: "http://mdmsolution.com",
   name: "MDM Solution",
   id: 1,

--- a/frontend/interfaces/host.ts
+++ b/frontend/interfaces/host.ts
@@ -178,9 +178,11 @@ export interface IHostMdmData {
   encryption_key_archived?: boolean;
   enrollment_status: MdmEnrollmentStatus | null;
   /**
-   * is_personal_enrollment reports whether the host's most recent MDM enrollment
-   * was personal (BYOD). Unlike enrollment_status it stays true after the host
-   * unenrolls, so BYOD-only UI doesn't flip back once the host is unenrolled.
+   * is_personal_enrollment reports whether the last MDM enrollment Fleet recorded
+   * for the host was personal (BYOD). Unlike enrollment_status it is not cleared
+   * on unenrollment, so BYOD-only UI doesn't flip back once the host unenrolls.
+   * That holds for Android and Apple mobile hosts; on macOS and Windows the fleetd
+   * detail queries re-ingest MDM state and can reset it once the profile is gone.
    */
   is_personal_enrollment?: boolean;
   dep_profile_error?: boolean;

--- a/frontend/interfaces/host.ts
+++ b/frontend/interfaces/host.ts
@@ -177,6 +177,12 @@ export interface IHostMdmData {
    */
   encryption_key_archived?: boolean;
   enrollment_status: MdmEnrollmentStatus | null;
+  /**
+   * is_personal_enrollment reports whether the host's most recent MDM enrollment
+   * was personal (BYOD). Unlike enrollment_status it stays true after the host
+   * unenrolls, so BYOD-only UI doesn't flip back once the host is unenrolled.
+   */
+  is_personal_enrollment?: boolean;
   dep_profile_error?: boolean;
   name?: string;
   id?: number;

--- a/frontend/interfaces/mdm.ts
+++ b/frontend/interfaces/mdm.ts
@@ -347,11 +347,12 @@ export const isBYODAccountDrivenUserEnrollment = (
   return enrollmentStatus === "On (manual - personal)";
 };
 
-/** Whether the host's most recent MDM enrollment was personal (BYOD), including
- * hosts that have since unenrolled. `is_personal_enrollment` survives unenrollment
- * while `enrollment_status` flips to "Off", so UI that identifies a BYOD device
- * (which never reports a serial number) must not rely on the status alone. The
- * status is still checked as a fallback for payloads that predate the field. */
+/** Whether the host's last recorded MDM enrollment was personal (BYOD), including
+ * hosts that have since unenrolled. `is_personal_enrollment` is not cleared on
+ * unenrollment while `enrollment_status` flips to "Off", so UI that identifies a
+ * BYOD device (which never reports a serial number) must not rely on the status
+ * alone. The status is still checked because not every host payload carries the
+ * flag: only queries built on the server's shared host-MDM select populate it. */
 export const wasBYODEnrolled = (
   enrollmentStatus: MdmEnrollmentStatus | null,
   isPersonalEnrollment?: boolean

--- a/frontend/interfaces/mdm.ts
+++ b/frontend/interfaces/mdm.ts
@@ -347,6 +347,21 @@ export const isBYODAccountDrivenUserEnrollment = (
   return enrollmentStatus === "On (manual - personal)";
 };
 
+/** Whether the host's most recent MDM enrollment was personal (BYOD), including
+ * hosts that have since unenrolled. `is_personal_enrollment` survives unenrollment
+ * while `enrollment_status` flips to "Off", so UI that identifies a BYOD device
+ * (which never reports a serial number) must not rely on the status alone. The
+ * status is still checked as a fallback for payloads that predate the field. */
+export const wasBYODEnrolled = (
+  enrollmentStatus: MdmEnrollmentStatus | null,
+  isPersonalEnrollment?: boolean
+) => {
+  return (
+    isPersonalEnrollment === true ||
+    isBYODAccountDrivenUserEnrollment(enrollmentStatus)
+  );
+};
+
 /** This check is the device is enrolled via Automated Device Enrollment (ADE, also known as DEP)
  * This was previously known as automatic enrollment but was updatd to company owned. Here we check
  * for both to current and legacy enrollment status */

--- a/frontend/pages/hosts/details/cards/Vitals/Vitals.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Vitals/Vitals.tests.tsx
@@ -52,6 +52,70 @@ describe("Vitals Card component", () => {
     expect(screen.queryByText("Public IP address")).not.toBeInTheDocument();
   });
 
+  it("keeps Enrollment ID for a personally enrolled Android host after it unenrolls", () => {
+    const mockHost = createMockHost({
+      platform: "android",
+      hardware_model: "Pixel 6",
+      hardware_serial: "",
+      uuid: "enrollment-id-12345",
+      mdm: createMockHostMdmData({
+        enrollment_status: "Off",
+        is_personal_enrollment: true,
+      }),
+    });
+
+    render(<Vitals vitalsData={mockHost} mdm={mockHost.mdm} />);
+
+    expect(screen.getByText("Enrollment ID")).toBeInTheDocument();
+    expect(screen.getAllByText("enrollment-id-12345")[0]).toBeInTheDocument();
+    expect(screen.queryByText("Serial number")).not.toBeInTheDocument();
+  });
+
+  it("renders Serial number for an unenrolled Android host that was not personally enrolled", () => {
+    const mockHost = createMockHost({
+      platform: "android",
+      hardware_model: "Pixel 6",
+      hardware_serial: "1234567890",
+      mdm: createMockHostMdmData({
+        enrollment_status: "Off",
+        is_personal_enrollment: false,
+      }),
+    });
+
+    render(<Vitals vitalsData={mockHost} mdm={mockHost.mdm} />);
+
+    expect(screen.getByText("Serial number")).toBeInTheDocument();
+    expect(screen.getByText("1234567890")).toBeInTheDocument();
+    expect(screen.queryByText("Enrollment ID")).not.toBeInTheDocument();
+  });
+
+  it("tells the user the Enrollment ID is stable for personal Android hosts", async () => {
+    const mockHost = createMockHost({
+      platform: "android",
+      hardware_serial: "",
+      uuid: "enrollment-id-12345",
+      mdm: createMockHostMdmData({
+        enrollment_status: "Off",
+        is_personal_enrollment: true,
+      }),
+    });
+    const customRender = createCustomRenderer({});
+
+    const { user } = customRender(
+      <Vitals vitalsData={mockHost} mdm={mockHost.mdm} />
+    );
+
+    await user.hover(screen.getByText("Enrollment ID"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          /For personal \(BYOD\) Android hosts, this enrollment ID is stable across unenroll\/re-enroll cycles\./i
+        )
+      ).toBeInTheDocument();
+    });
+  });
+
   it("renders Enrollment ID and Hardware model for personally enrolled iOS hosts", () => {
     const mockHost = createMockHost({
       platform: "ios",

--- a/frontend/pages/hosts/details/cards/Vitals/Vitals.tsx
+++ b/frontend/pages/hosts/details/cards/Vitals/Vitals.tsx
@@ -748,6 +748,9 @@ const Vitals = ({
   onEditCustomHostVital,
 }: IVitalsProps) => {
   const isIosOrIpadosHost = isIPadOrIPhone(vitalsData.platform);
+  // Unlike the Enrollment ID row, this keys off the *current* enrollment status on
+  // purpose: the cap exists because a personally-enrolled device reports few vitals
+  // right now, not because of how it was once enrolled.
   const showExpandedVitals =
     isIosOrIpadosHost &&
     !isBYODAccountDrivenUserEnrollment(mdm?.enrollment_status ?? null);

--- a/frontend/pages/hosts/details/cards/Vitals/Vitals.tsx
+++ b/frontend/pages/hosts/details/cards/Vitals/Vitals.tsx
@@ -12,6 +12,7 @@ import {
 } from "interfaces/platform";
 import {
   isBYODAccountDrivenUserEnrollment,
+  wasBYODEnrolled,
   MDM_ENROLLMENT_STATUS_UI_MAP,
 } from "interfaces/mdm";
 import { ROLLING_ARCH_LINUX_VERSIONS } from "interfaces/software";
@@ -363,15 +364,20 @@ export const buildHostVitals = ({
   }
 
   // Device identity
-  if (mdm && isBYODAccountDrivenUserEnrollment(mdm.enrollment_status)) {
-    //  Personal (BYOD) devices do not report their serial numbers, so show the enrollment id instead.
+  if (
+    mdm &&
+    wasBYODEnrolled(mdm.enrollment_status, mdm.is_personal_enrollment)
+  ) {
+    //  Personal (BYOD) devices do not report their serial numbers, so show the enrollment id
+    //  instead. This holds after the host unenrolls too, hence wasBYODEnrolled rather than the
+    //  current enrollment status.
     vitals.push({
       sortKey: "Enrollment ID",
       element: (
         <DataSet
           key="enrollment-id"
           title={
-            <TooltipWrapper tipContent="Enrollment ID is a unique identifier for personal hosts. Personal (BYOD) devices don't report their serial numbers. The Enrollment ID changes with each enrollment.">
+            <TooltipWrapper tipContent="Enrollment ID is a unique identifier for personal hosts. Personal (BYOD) devices don't report their serial numbers. For personal (BYOD) Android hosts, this enrollment ID is stable across unenroll/re-enroll cycles.">
               Enrollment ID
             </TooltipWrapper>
           }

--- a/server/datastore/mysql/android_test.go
+++ b/server/datastore/mysql/android_test.go
@@ -63,6 +63,7 @@ func TestAndroid(t *testing.T) {
 		{"NewAndroidHostWithIdP", testNewAndroidHostWithIdP},
 		{"AndroidBYODDetection", testAndroidBYODDetection},
 		{"SetAndroidHostUnenrolled", testSetAndroidHostUnenrolled},
+		{"AndroidPersonalEnrollmentSurvivesUnenroll", testAndroidPersonalEnrollmentSurvivesUnenroll},
 		{"SetAndroidHostEnrolled", testSetAndroidHostEnrolled},
 		{"AndroidPubSubDedupState", testAndroidPubSubDedupState},
 		{"BulkSetAndroidHostsUnenrolled", testBulkSetAndroidHostsUnenrolled},
@@ -3635,6 +3636,49 @@ func testAndroidPubSubDedupState(t *testing.T, ds *Datastore) {
 
 	err = ds.SetAndroidPubSubDedupState(testCtx(), 999999, "msg-x", &t2)
 	require.True(t, fleet.IsNotFound(err), "set on a missing android_devices row must surface NotFound, got %v", err)
+}
+
+// The host details response must keep reporting a personal (BYOD) enrollment after the
+// host unenrolls: BYOD devices never report a serial number, so the UI identifies them by
+// their enrollment ID and has nothing to fall back on once enrollment_status flips to "Off".
+func testAndroidPersonalEnrollmentSurvivesUnenroll(t *testing.T, ds *Datastore) {
+	ctx := testCtx()
+	test.AddBuiltinLabels(t, ds)
+
+	byod, err := ds.NewAndroidHost(ctx, createAndroidHost("enterprise-byod-"+uuid.NewString()), false)
+	require.NoError(t, err)
+	companyOwned, err := ds.NewAndroidHost(ctx, createAndroidHost("enterprise-cobo-"+uuid.NewString()), true)
+	require.NoError(t, err)
+
+	loadMDM := func(hostID uint) *fleet.MDMHostData {
+		h, err := ds.Host(ctx, hostID)
+		require.NoError(t, err)
+		return &h.MDM
+	}
+
+	byodMDM := loadMDM(byod.Host.ID)
+	assert.True(t, byodMDM.IsPersonalEnrollment)
+	require.NotNil(t, byodMDM.EnrollmentStatus)
+	assert.Equal(t, fleet.MDMEnrollmentStatusPersonal, *byodMDM.EnrollmentStatus)
+
+	companyOwnedMDM := loadMDM(companyOwned.Host.ID)
+	assert.False(t, companyOwnedMDM.IsPersonalEnrollment)
+
+	for _, hostID := range []uint{byod.Host.ID, companyOwned.Host.ID} {
+		didUnenroll, err := ds.SetAndroidHostUnenrolled(ctx, hostID)
+		require.NoError(t, err)
+		require.True(t, didUnenroll)
+	}
+
+	byodMDM = loadMDM(byod.Host.ID)
+	assert.True(t, byodMDM.IsPersonalEnrollment)
+	require.NotNil(t, byodMDM.EnrollmentStatus)
+	assert.Equal(t, fleet.MDMEnrollmentStatusOff, *byodMDM.EnrollmentStatus)
+
+	companyOwnedMDM = loadMDM(companyOwned.Host.ID)
+	assert.False(t, companyOwnedMDM.IsPersonalEnrollment)
+	require.NotNil(t, companyOwnedMDM.EnrollmentStatus)
+	assert.Equal(t, fleet.MDMEnrollmentStatusOff, *companyOwnedMDM.EnrollmentStatus)
 }
 
 func testSetAndroidHostUnenrolled(t *testing.T, ds *Datastore) {

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -1005,6 +1005,11 @@ func queryStatsToScheduledQueryStats(queriesStats []fleet.QueryStats, packName s
 const hostMDMSelect = `,
 	JSON_OBJECT(
 		'enrollment_status', hmdm.enrollment_status,
+		'is_personal_enrollment',
+		CASE
+			WHEN hmdm.is_personal_enrollment = 1 THEN CAST(TRUE AS JSON)
+			ELSE CAST(FALSE AS JSON)
+		END,
 		'dep_profile_error',
 		CASE
 			WHEN hdep.assign_profile_response IN ('` + string(fleet.DEPAssignProfileResponseFailed) + `', '` + string(fleet.DEPAssignProfileResponseThrottled) + `') THEN CAST(TRUE AS JSON)

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -94,6 +94,7 @@ func TestHosts(t *testing.T) {
 		{"ListMDM", testHostsListMDM},
 		{"ListMDMAndroid", testHostsListMDMAndroid},
 		{"SelectHostMDM", testHostMDMSelect},
+		{"SelectHostMDMIsPersonalEnrollment", testHostMDMSelectIsPersonalEnrollment},
 		{"ListMunkiIssueID", testHostsListMunkiIssueID},
 		{"Enroll", testHostsEnroll},
 		{"LoadHostByNodeKey", testHostsLoadHostByNodeKey},
@@ -2185,6 +2186,71 @@ func testHostsListMDMAndroid(t *testing.T, ds *Datastore) {
 		MDMNameFilter:             ptr.String(fleet.WellKnownMDMFleet),
 	}, 3)
 	require.Len(t, hosts, 3, "Should have 2 Android + 1 darwin personal hosts with Fleet MDM")
+}
+
+// is_personal_enrollment rides along in the hostMDMSelect JSON object, so it has to hold
+// up across every query built on that fragment, including for hosts that have no host_mdm
+// row at all. It is deliberately not cleared when a host unenrolls: BYOD devices report no
+// serial number, so the UI identifies them by enrollment ID even after enrollment ends.
+func testHostMDMSelectIsPersonalEnrollment(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+	const mdmServerURL = "https://mdm.example.com"
+
+	h, err := ds.NewHost(ctx, &fleet.Host{
+		DetailUpdatedAt: time.Now(),
+		LabelUpdatedAt:  time.Now(),
+		PolicyUpdatedAt: time.Now(),
+		SeenTime:        time.Now(),
+		OsqueryHostID:   new("personal-enrollment-osquery-id"),
+		NodeKey:         new("personal-enrollment-node-key"),
+		UUID:            "personal-enrollment-uuid",
+		Hostname:        "personal-enrollment-hostname",
+	})
+	require.NoError(t, err)
+
+	// assertIsPersonal checks every read path that embeds hostMDMSelect.
+	assertIsPersonal := func(t *testing.T, want bool) {
+		t.Helper()
+
+		byID, err := ds.Host(ctx, h.ID)
+		require.NoError(t, err)
+		assert.Equal(t, want, byID.MDM.IsPersonalEnrollment, "ds.Host")
+
+		byIdentifier, err := ds.HostByIdentifier(ctx, h.UUID)
+		require.NoError(t, err)
+		assert.Equal(t, want, byIdentifier.MDM.IsPersonalEnrollment, "ds.HostByIdentifier")
+
+		listed, err := ds.ListHosts(ctx, fleet.TeamFilter{User: test.UserAdmin}, fleet.HostListOptions{})
+		require.NoError(t, err)
+		require.Len(t, listed, 1)
+		assert.Equal(t, want, listed[0].MDM.IsPersonalEnrollment, "ds.ListHosts")
+	}
+
+	// A host that has never been MDM-enrolled has no host_mdm row, so the column reads
+	// NULL and must surface as false rather than blowing up the JSON unmarshal.
+	t.Run("never MDM enrolled", func(t *testing.T) {
+		assertIsPersonal(t, false)
+	})
+
+	t.Run("personal enrollment", func(t *testing.T) {
+		require.NoError(t, ds.SetOrUpdateMDMData(ctx, h.ID, false, true, mdmServerURL, false, fleet.WellKnownMDMFleet, "", true))
+		assertIsPersonal(t, true)
+	})
+
+	t.Run("stays set after unenrollment", func(t *testing.T) {
+		require.NoError(t, ds.SetOrUpdateMDMData(ctx, h.ID, false, false, mdmServerURL, false, fleet.WellKnownMDMFleet, "", true))
+
+		byID, err := ds.Host(ctx, h.ID)
+		require.NoError(t, err)
+		require.NotNil(t, byID.MDM.EnrollmentStatus)
+		require.Equal(t, fleet.MDMEnrollmentStatusOff, *byID.MDM.EnrollmentStatus)
+		assertIsPersonal(t, true)
+	})
+
+	t.Run("company owned re-enrollment clears it", func(t *testing.T) {
+		require.NoError(t, ds.SetOrUpdateMDMData(ctx, h.ID, false, true, mdmServerURL, false, fleet.WellKnownMDMFleet, "", false))
+		assertIsPersonal(t, false)
+	})
 }
 
 func testHostMDMSelect(t *testing.T, ds *Datastore) {

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -643,6 +643,11 @@ type MDMHostData struct {
 	// EnrollmentStatus is a string representation of state derived from
 	// booleans stored in the host_mdm table, loaded by JOIN in datastore
 	EnrollmentStatus *string `json:"enrollment_status" db:"-" csv:"mdm.enrollment_status"`
+	// IsPersonalEnrollment reports whether the host's most recent MDM enrollment was
+	// personal (BYOD). Unlike EnrollmentStatus, it survives unenrollment: host_mdm keeps
+	// the column set so consumers can still tell a BYOD device apart afterwards (BYOD
+	// devices never report a serial number, so the UI has nothing else to identify them by).
+	IsPersonalEnrollment bool `json:"is_personal_enrollment" db:"-" csv:"-"`
 	// DEPProfileError is a boolean representing whether Fleet received a "FAILED" response when
 	// attempting to assign a DEP profile for the host.
 	// See https://developer.apple.com/documentation/devicemanagement/assignprofileresponse

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -643,10 +643,16 @@ type MDMHostData struct {
 	// EnrollmentStatus is a string representation of state derived from
 	// booleans stored in the host_mdm table, loaded by JOIN in datastore
 	EnrollmentStatus *string `json:"enrollment_status" db:"-" csv:"mdm.enrollment_status"`
-	// IsPersonalEnrollment reports whether the host's most recent MDM enrollment was
-	// personal (BYOD). Unlike EnrollmentStatus, it survives unenrollment: host_mdm keeps
-	// the column set so consumers can still tell a BYOD device apart afterwards (BYOD
-	// devices never report a serial number, so the UI has nothing else to identify them by).
+	// IsPersonalEnrollment reports whether the last MDM enrollment Fleet recorded for the
+	// host was personal (BYOD). Unlike EnrollmentStatus it is not cleared on unenrollment,
+	// so consumers can still tell a BYOD device apart afterwards (BYOD devices never report
+	// a serial number, so the UI has nothing else to identify them by). That only holds for
+	// platforms where MDM state comes from the MDM protocol - Android and Apple mobile. On
+	// macOS and Windows the fleetd detail queries re-ingest MDM state, and
+	// directIngestMDMMac/directIngestMDMWindows pass false once the profile is gone.
+	//
+	// Deliberately not a CSV column: the hosts report is a stable user-facing format and
+	// this field is only needed by the UI.
 	IsPersonalEnrollment bool `json:"is_personal_enrollment" db:"-" csv:"-"`
 	// DEPProfileError is a boolean representing whether Fleet received a "FAILED" response when
 	// attempting to assign a DEP profile for the host.
@@ -1603,6 +1609,9 @@ func (h *HostMDM) MarshalJSON() ([]byte, error) {
 	if h.IsServer {
 		return []byte("null"), nil
 	}
+	// NOTE: this is the macadmins/host MDM payload, deliberately narrower than
+	// MDMHostData (which the host endpoints return). It intentionally does not carry
+	// is_personal_enrollment; add it here only if a consumer of this endpoint needs it.
 	var jsonMDM struct {
 		EnrollmentStatus string `json:"enrollment_status"`
 		ServerURL        string `json:"server_url"`

--- a/server/fleet/hosts_test.go
+++ b/server/fleet/hosts_test.go
@@ -544,6 +544,23 @@ func TestIsPlaceholderHardwareSerial(t *testing.T) {
 	}
 }
 
+// The frontend keys the host page's Enrollment ID row off this exact field name, so pin
+// the wire format: MDMHostData is scanned from a JSON_OBJECT built in SQL, which makes a
+// silent rename easy to miss.
+func TestMDMHostDataIsPersonalEnrollmentJSON(t *testing.T) {
+	for _, want := range []bool{true, false} {
+		b, err := json.Marshal(MDMHostData{IsPersonalEnrollment: want})
+		require.NoError(t, err)
+		require.Contains(t, string(b), fmt.Sprintf(`"is_personal_enrollment":%t`, want))
+	}
+
+	// It is also the key the datastore's JSON_OBJECT emits, so round-tripping through
+	// Scan has to land on the same field.
+	var data MDMHostData
+	require.NoError(t, data.Scan([]byte(`{"is_personal_enrollment": true}`)))
+	require.True(t, data.IsPersonalEnrollment)
+}
+
 func TestHostMDMHostNameSettingJSON(t *testing.T) {
 	// Omitted entirely when there is no enforcement (host_name is a nil pointer
 	// with omitempty), matching the recovery-lock treatment for ineligible hosts.


### PR DESCRIPTION
**Related issue:** Resolves #50884

The host details Vitals card picked between the **Enrollment ID** and **Serial number** rows from `mdm.enrollment_status`, which flips to `"Off"` when a host unenrolls. Personal (BYOD) Android devices never report a serial number, so unenrolling one replaced its enrollment ID with an empty serial.

`host_mdm.is_personal_enrollment` already survives unenrollment (neither `SetAndroidHostUnenrolled` nor `MDMTurnOff` clears it) but was never sent to the client. This exposes it as `mdm.is_personal_enrollment` on host responses and keys the row off it, falling back to the enrollment status.

The tooltip is updated to the copy agreed in the issue thread:

> Enrollment ID is a unique identifier for personal hosts. Personal (BYOD) devices don't report their serial numbers. For personal (BYOD) Android hosts, this enrollment ID is stable across unenroll/re-enroll cycles.

### Scope

Two other surfaces flip on the same lost signal and are **intentionally left alone** here — the hosts-list "Serial number" column (`HostTableConfig.tsx`) and `showExpandedVitals` in `Vitals.tsx`. They need their own issues if we want them changed.

### A note on the new field's guarantee

`is_personal_enrollment` is not cleared on unenrollment, so it stays `true` for unenrolled Android and Apple mobile hosts. It is **not** a permanent record on macOS/Windows: the fleetd detail queries re-ingest MDM state, and `directIngestMDMMac`/`directIngestMDMWindows` pass `false` once the enrollment profile is gone. The docs and comments say so explicitly rather than promising more than the column delivers.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually

**Not yet QA'd on a real device** — I don't have a BYOD Android host to enroll. Needs a reviewer with one; the manual plan is below.

## Frontend

- [x] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.

Unenrolled personal (BYOD) Android host, Vitals card.

**Before** — the identity row falls back to **Serial number**, which a BYOD Android device never reports, so it renders empty:

<!-- DROP THE "before" IMAGE ON THE LINE BELOW -->
<img width="2496" height="1178" alt="samsung-enrolled" src="https://github.com/user-attachments/assets/e344a3ff-c874-4592-a837-1864c592ddc0" />
<img width="2478" height="1006" alt="samsung-unenrolled" src="https://github.com/user-attachments/assets/5b8a53b8-da9b-4ac1-88ce-60e064d65d13" />
<img width="1174" height="472" alt="samsung-hover2" src="https://github.com/user-attachments/assets/da5eb4b3-1771-4de3-a04d-a2185739e3e9" />


**After** — the row stays **Enrollment ID** and keeps its value, with MDM status still `Off`:

<!-- DROP THE "after" IMAGE ON THE LINE BELOW -->


These are renders of the `Vitals` component through this repo's Storybook, driven by the exact `mdm` payloads the API returns for that host - not captures from a live device. The "before" is faithful rather than staged: prior to this change the API sent no `is_personal_enrollment` field at all, so the card fell through to Serial number on `enrollment_status: "Off"`, and rendering with the field absent reproduces `main`'s output through the same component.

End-to-end QA on a real BYOD Android device is still outstanding, hence the unticked box above.

## Automated test coverage

| Test | Covers |
|---|---|
| `Vitals.tests.tsx` (3 new) | Unenrolled BYOD Android keeps **Enrollment ID**; unenrolled COBO Android still shows **Serial number**; the new tooltip sentence renders |
| `TestAndroid/AndroidPersonalEnrollmentSurvivesUnenroll` | BYOD vs COBO Android hosts through `SetAndroidHostUnenrolled`, asserting isolation between the two |
| `TestHosts/SelectHostMDMIsPersonalEnrollment` | The no-`host_mdm`-row branch, plus `ds.Host` / `HostByIdentifier` / `ListHosts` |
| `TestMDMHostDataIsPersonalEnrollmentJSON` | Pins the `is_personal_enrollment` wire name through marshal and `Scan` |

Verified locally: `yarn test` (Vitals + VitalsModal, 78), `tsc --noEmit`, eslint, `make lint-go-incremental` (0 issues), `go test ./server/fleet/...`, the fleetctl golden tests, and `MYSQL_TEST=1` runs of `TestHosts/{SelectHostMDM,SelectHostMDMIsPersonalEnrollment,ListMDM,ListMDMAndroid,UnenrollFromMDM,HostMDMAndMunki}`, `TestAndroid/AndroidPersonalEnrollmentSurvivesUnenroll` and `TestLabels`.

The Android test was confirmed to fail without the SQL change, on both the enrolled and post-unenroll assertions.

## Manual test plan

1. Enroll a BYOD (work profile) Android device. Host page → Vitals shows **Enrollment ID** with the enterprise-specific ID.
2. Hover it — the tooltip ends "...this enrollment ID is stable across unenroll/re-enroll cycles."
3. Host actions → **Unenroll**. On `main` the row becomes **Serial number** with an empty value; on this branch it stays **Enrollment ID** with the same value.
4. `GET /api/v1/fleet/hosts/<id>` returns `mdm.is_personal_enrollment: true`.
5. Re-enroll the same device: same enrollment ID, status back to `On (manual - personal)`.
6. Regression: a company-owned (COBO) Android host still shows **Serial number**, both enrolled and after unenroll.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Host details now identify devices that were personally enrolled (BYOD), including after unenrollment.
  * Android Enrollment IDs remain available across personal unenrollment and re-enrollment.
  * Added clearer guidance explaining stable personal Android Enrollment IDs.
  * Host data responses now include the personal-enrollment status.

* **Bug Fixes**
  * Improved enrollment and serial-number display for unenrolled Android devices based on their enrollment history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
