### PR TITLE
Fix SCIM user not remapped when PUT device_mapping email unchanged

### DIFF
--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -2574,19 +2574,19 @@ func (svc *Service) SetHostDeviceMapping(ctx context.Context, hostID uint, email
 		// Check if the email has changed; if not, skip the email update
 		// and activity log but still reconcile the SCIM mapping below
 		// (it may be stale from a prior silent failure).
-		emailUnchanged := false
+		emailChanged := true
 		emails, err := svc.ds.GetHostEmails(ctx, host.UUID, fleet.DeviceMappingIDP)
 		if err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "get host emails for idempotency check")
 		}
 		for _, e := range emails {
 			if strings.EqualFold(e, email) {
-				emailUnchanged = true
+				emailChanged = false
 				break
 			}
 		}
 
-		if !emailUnchanged {
+		if emailChanged {
 			// Store the IDP username for display (accept any value)
 			// This will appear in the host details API under the idp_username field
 			if err := svc.ds.SetOrUpdateIDPHostDeviceMapping(ctx, hostID, email); err != nil {

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -2571,34 +2571,39 @@ func (svc *Service) SetHostDeviceMapping(ctx context.Context, hostID uint, email
 			return nil, ctxerr.Wrap(ctx, err, "get host for activity")
 		}
 
-		// Check if the email has changed; if not, return early to avoid
-		// unnecessary database updates and profile resends.
+		// Check if the email has changed; if not, skip the email update
+		// and activity log but still reconcile the SCIM mapping below
+		// (it may be stale from a prior silent failure).
+		emailUnchanged := false
 		emails, err := svc.ds.GetHostEmails(ctx, host.UUID, fleet.DeviceMappingIDP)
 		if err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "get host emails for idempotency check")
 		}
 		for _, e := range emails {
 			if strings.EqualFold(e, email) {
-				return svc.ds.ListHostDeviceMapping(ctx, hostID)
+				emailUnchanged = true
+				break
 			}
 		}
 
-		// Store the IDP username for display (accept any value)
-		// This will appear in the host details API under the idp_username field
-		if err := svc.ds.SetOrUpdateIDPHostDeviceMapping(ctx, hostID, email); err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "set IDP device mapping")
-		}
+		if !emailUnchanged {
+			// Store the IDP username for display (accept any value)
+			// This will appear in the host details API under the idp_username field
+			if err := svc.ds.SetOrUpdateIDPHostDeviceMapping(ctx, hostID, email); err != nil {
+				return nil, ctxerr.Wrap(ctx, err, "set IDP device mapping")
+			}
 
-		if err := svc.NewActivity(
-			ctx,
-			authz.UserFromContext(ctx),
-			fleet.ActivityTypeEditedHostIdpData{
-				HostID:          host.ID,
-				HostDisplayName: host.DisplayName(),
-				HostIdPUsername: email,
-			},
-		); err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "create updated host idp activity")
+			if err := svc.NewActivity(
+				ctx,
+				authz.UserFromContext(ctx),
+				fleet.ActivityTypeEditedHostIdpData{
+					HostID:          host.ID,
+					HostDisplayName: host.DisplayName(),
+					HostIdPUsername: email,
+				},
+			); err != nil {
+				return nil, ctxerr.Wrap(ctx, err, "create updated host idp activity")
+			}
 		}
 
 		// Check if the user is a valid SCIM user to manage the join table

--- a/server/service/hosts_test.go
+++ b/server/service/hosts_test.go
@@ -5238,7 +5238,7 @@ func TestSetHostDeviceMapping(t *testing.T) {
 		assert.Equal(t, fleet.DeviceMappingMDMIdpAccounts, result[0].Source)
 	})
 
-	t.Run("IDP source same email returns early without updates", func(t *testing.T) {
+	t.Run("IDP source same email skips email update but still reconciles SCIM mapping", func(t *testing.T) {
 		ds := new(mock.Store)
 		svc, ctx := newTestService(t, ds, nil, nil, &TestServerOpts{License: &fleet.LicenseInfo{Tier: fleet.TierPremium}})
 
@@ -5251,6 +5251,12 @@ func TestSetHostDeviceMapping(t *testing.T) {
 		ds.ListHostDeviceMappingFunc = func(ctx context.Context, hostID uint) ([]*fleet.HostDeviceMapping, error) {
 			return []*fleet.HostDeviceMapping{{HostID: hostID, Email: "user@example.com", Source: fleet.DeviceMappingIDP}}, nil
 		}
+		ds.ScimUserByUserNameOrEmailFunc = func(ctx context.Context, userName, email string) (*fleet.ScimUser, error) {
+			return &fleet.ScimUser{ID: 2, UserName: "user@example.com"}, nil
+		}
+		ds.SetOrUpdateHostSCIMUserMappingFunc = func(ctx context.Context, hostID uint, scimUserID uint) ([]fleet.ActivityTypeResentCertificate, error) {
+			return nil, nil
+		}
 
 		userCtx := test.UserContext(ctx, test.UserAdmin)
 		result, err := svc.SetHostDeviceMapping(userCtx, 1, "user@example.com", fleet.DeviceMappingIDP)
@@ -5259,9 +5265,11 @@ func TestSetHostDeviceMapping(t *testing.T) {
 		require.Len(t, result, 1)
 		assert.Equal(t, "user@example.com", result[0].Email)
 
-		// These should NOT be invoked because the email hasn't changed
+		// Email update should NOT be invoked because the email hasn't changed
 		require.False(t, ds.SetOrUpdateIDPHostDeviceMappingFuncInvoked)
-		require.False(t, ds.SetOrUpdateHostSCIMUserMappingFuncInvoked)
+		// But SCIM mapping SHOULD still be reconciled (fixes #46624)
+		require.True(t, ds.ScimUserByUserNameOrEmailFuncInvoked)
+		require.True(t, ds.SetOrUpdateHostSCIMUserMappingFuncInvoked)
 	})
 
 	t.Run("IDP source different email proceeds with update", func(t *testing.T) {

--- a/server/service/hosts_test.go
+++ b/server/service/hosts_test.go
@@ -5255,6 +5255,8 @@ func TestSetHostDeviceMapping(t *testing.T) {
 			return &fleet.ScimUser{ID: 2, UserName: "user@example.com"}, nil
 		}
 		ds.SetOrUpdateHostSCIMUserMappingFunc = func(ctx context.Context, hostID uint, scimUserID uint) ([]fleet.ActivityTypeResentCertificate, error) {
+			require.Equal(t, uint(1), hostID)
+			require.Equal(t, uint(2), scimUserID)
 			return nil, nil
 		}
 


### PR DESCRIPTION
**Related issue:** Resolves #46624

## Problem

When an IT admin reassigns a device to a different person using
`PUT /hosts/:id/device_mapping` with a new IdP email, the device mapping
API shows the new email correctly, but the host details page keeps showing
the **old** person's IdP info (username, full name, groups, etc.).

This happens because the PUT handler updates the email in `host_emails`
but the SCIM user association in `host_scim_user` stays pinned to the
original user. The handler has an idempotency check: if the email in
`host_emails` already matches the request, it returns early and skips
everything, including the SCIM remapping. Since the SCIM update errors
are silently swallowed (logged at DEBUG only), a failed SCIM update on
a prior call leaves the mapping stale, and every subsequent PUT with
the same email hits the early return without retrying.

The workaround is DELETE + PUT, which clears the stale state first.

## Fix

The idempotency early return now only skips the email write and the
activity log. The SCIM user lookup and `host_scim_user` upsert always
run, so a stale mapping gets corrected.

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually
- [x] Confirmed that the fix is not expected to adversely impact load test results

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved host identity mapping reconciliation when an email address remains unchanged.
  * Ensured associated SCIM mappings are still reconciled correctly.
  * Prevented unnecessary identity updates and activity entries when no email change occurs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->