### PR TITLE
Update Firefox for Windows FMA

### DIFF
--- a/changes/51786-firefox-windows-fma-stale-version.md
+++ b/changes/51786-firefox-windows-fma-stale-version.md
@@ -1,0 +1,1 @@
+- Updated the Mozilla Firefox Windows Fleet-maintained app to 154.0.

--- a/changes/51786-firefox-windows-fma-stale-version.md
+++ b/changes/51786-firefox-windows-fma-stale-version.md
@@ -1,1 +1,0 @@
-- Updated the Mozilla Firefox Windows Fleet-maintained app to 154.0.

--- a/ee/maintained-apps/inputs/winget/firefox.json
+++ b/ee/maintained-apps/inputs/winget/firefox.json
@@ -8,5 +8,6 @@
   "installer_arch": "x64",
   "installer_type": "exe",
   "installer_scope": "machine",
-  "default_categories": ["Browsers"]
+  "default_categories": ["Browsers"],
+  "frozen": true
 }

--- a/ee/maintained-apps/outputs/firefox/windows.json
+++ b/ee/maintained-apps/outputs/firefox/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "153.0.4",
+      "version": "154.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Mozilla Firefox (x64 en-US)' AND publisher = 'Mozilla';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Mozilla Firefox (x64 en-US)' AND publisher = 'Mozilla' AND version_compare(version, '153.0.4') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Mozilla Firefox (x64 en-US)' AND publisher = 'Mozilla' AND version_compare(version, '154.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'mozilla firefox.exe');"
       },
-      "installer_url": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/153.0.4/win64/en-US/Firefox%20Setup%20153.0.4.exe",
+      "installer_url": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/154.0/win64/en-US/Firefox%20Setup%20154.0.exe",
       "install_script_ref": "80fb9175",
       "uninstall_script_ref": "ae547434",
-      "sha256": "6eba9f98ad90c016fd3db19feecf77469eb99e861358578ee90c4d9c3a481aae",
+      "sha256": "6b3c996d27b50dca8e5b6dd2956233cc6bf4720cea3f0847a9423c2cd6759e73",
       "default_categories": [
         "Browsers"
       ]


### PR DESCRIPTION
This pull request updates the maintained Firefox application to the latest version and introduces a configuration change to its metadata. The main changes are grouped below:

Firefox version update:

* Updated the Firefox installer and detection logic in `windows.json` to use version `154.0` instead of `153.0.4`, including the new installer URL, SHA256 hash, and version comparison for patch status.

Configuration and metadata:

* Added `"frozen": true` to `firefox.json` in the Winget inputs, indicating that this app's configuration is now locked and should not be automatically updated by tooling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the Firefox Windows package to version 154.0.
  * Refreshed the download source, patched-version information, and integrity checksum.
  * Marked the Firefox Winget app definition as frozen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->