### PR TITLE
Unfreeze Adobe Acrobat Pro (darwin)

### DIFF
--- a/ee/maintained-apps/inputs/homebrew/adobe-acrobat-pro.json
+++ b/ee/maintained-apps/inputs/homebrew/adobe-acrobat-pro.json
@@ -4,6 +4,5 @@
   "token": "adobe-acrobat-pro",
   "installer_format": "dmg",
   "slug": "adobe-acrobat-pro/darwin",
-  "default_categories": ["Productivity"],
-  "frozen": true
+  "default_categories": ["Productivity"]
 }

--- a/ee/maintained-apps/outputs/adobe-acrobat-pro/darwin.json
+++ b/ee/maintained-apps/outputs/adobe-acrobat-pro/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "26.001.21771",
+      "version": "26.001.21789",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.adobe.Acrobat.Pro';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.adobe.Acrobat.Pro' AND version_compare(bundle_short_version, '26.001.21771') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.adobe.Acrobat.Pro' AND version_compare(bundle_short_version, '26.001.21789') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.adobe.Acrobat.Pro');"
       },
       "installer_url": "https://trials.adobe.com/AdobeProducts/APRO/Acrobat_HelpX/osx10/Acrobat_DC_Web_WWMUI.dmg",


### PR DESCRIPTION
Automated unfreeze probe. Removes `"frozen": true` and regenerates the output manifest so
test-fma-darwin-pr-only can validate `adobe-acrobat-pro/darwin` at its current upstream version.

Frozen since: 2026-08-11
Version: 26.001.21771 -> 26.001.21789

Draft until validation reports. Merge only if the FMA checks are green and the validate shard
actually ran for this slug.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QNCXZEbVvbrBt2vqpPpMTN)_