### PR TITLE
Set SkipUserStatusPage=true in ESP release commands

### DIFF
--- a/changes/51380-esp-skip-user-status-page
+++ b/changes/51380-esp-skip-user-status-page
@@ -1,0 +1,1 @@
+- Fixed an issue where a second user signing in to a Windows device that was already enrolled via Autopilot would get stuck on the "Account setup" Enrollment Status Page for up to 3 hours.

--- a/server/service/microsoft_mdm.go
+++ b/server/service/microsoft_mdm.go
@@ -2964,14 +2964,17 @@ func buildESPBlockCommands(provID, errorText, blockButtons string) []*mdm_types.
 }
 
 // buildESPReleaseCommands builds SyncML commands that release the device from the ESP. The release path advances
-// DevicePreparation to "complete" and signals ServerHasFinishedProvisioning at both Device and User scopes to
-// complete both the Device setup and Account setup phases of the ESP so Windows proceeds to login.
+// DevicePreparation to "complete", signals ServerHasFinishedProvisioning at both Device and User scopes to
+// complete both the Device setup and Account setup phases, and sets SkipUserStatusPage=true so that subsequent
+// user logins skip the Account setup ESP phase (#51380).
 func buildESPReleaseCommands(provID string) []*mdm_types.SyncMLCmd {
 	cmds := []*mdm_types.SyncMLCmd{
 		newSyncMLCmdInt(fleet.CmdReplace,
 			fmt.Sprintf("./Device/Vendor/MSFT/EnrollmentStatusTracking/DevicePreparation/PolicyProviders/%s/InstallationState", provID), "3"),
 		newSyncMLCmdBool(fleet.CmdReplace,
 			fmt.Sprintf("./Device/Vendor/MSFT/DMClient/Provider/%s/FirstSyncStatus/ServerHasFinishedProvisioning", provID), "true"),
+		newSyncMLCmdBool(fleet.CmdReplace,
+			fmt.Sprintf("./Device/Vendor/MSFT/DMClient/Provider/%s/FirstSyncStatus/SkipUserStatusPage", provID), "true"),
 	}
 	for _, cmd := range cmds {
 		cmd.CmdID = mdm_types.CmdID{Value: uuid.New().String()}

--- a/server/service/microsoft_mdm_property_test.go
+++ b/server/service/microsoft_mdm_property_test.go
@@ -371,11 +371,11 @@ func TestPBT_HandleESPRelease(t *testing.T) {
 			// SkipUserStatusPage must be set to true so subsequent user logins don't trigger a fresh
 			// Account setup ESP phase (#51380).
 			skipCmd := pbtFindCmdByLocURI(cmds, "SkipUserStatusPage")
-			assert.NotNilf(rt, skipCmd, "release path must include SkipUserStatusPage=true (#51380)")
-			if skipCmd != nil && len(skipCmd.Items) > 0 && skipCmd.Items[0].Data != nil {
-				assert.Equalf(rt, "true", skipCmd.Items[0].Data.Content,
-					"SkipUserStatusPage must be true in release commands")
-			}
+			require.NotNilf(rt, skipCmd, "release path must include SkipUserStatusPage=true (#51380)")
+			require.NotEmptyf(rt, skipCmd.Items, "SkipUserStatusPage command must have Items")
+			require.NotNilf(rt, skipCmd.Items[0].Data, "SkipUserStatusPage Item must have Data")
+			assert.Equalf(rt, "true", skipCmd.Items[0].Data.Content,
+				"SkipUserStatusPage must be true in release commands")
 		}
 
 		// Cancel-block invariants. The cancel block fires iff (timedOut || (observedHasFailure && requireAll))

--- a/server/service/microsoft_mdm_property_test.go
+++ b/server/service/microsoft_mdm_property_test.go
@@ -368,10 +368,12 @@ func TestPBT_HandleESPRelease(t *testing.T) {
 					"setup has been displayed")
 			assert.Nilf(rt, pbtFindCmdByLocURI(cmds, "BlockInStatusPage"),
 				"release path must NOT include BlockInStatusPage")
-			// SkipUserStatusPage must be set to true so subsequent user logins don't trigger a fresh
-			// Account setup ESP phase (#51380).
+			// SkipUserStatusPage must be set to true at Device scope so subsequent user logins don't
+			// trigger a fresh Account setup ESP phase (#51380).
 			skipCmd := pbtFindCmdByLocURI(cmds, "SkipUserStatusPage")
 			require.NotNilf(rt, skipCmd, "release path must include SkipUserStatusPage=true (#51380)")
+			assert.Containsf(rt, skipCmd.GetTargetURI(), "/Device/",
+				"SkipUserStatusPage must be at Device scope, not User scope")
 			require.NotEmptyf(rt, skipCmd.Items, "SkipUserStatusPage command must have Items")
 			require.NotNilf(rt, skipCmd.Items[0].Data, "SkipUserStatusPage Item must have Data")
 			assert.Equalf(rt, "true", skipCmd.Items[0].Data.Content,

--- a/server/service/microsoft_mdm_property_test.go
+++ b/server/service/microsoft_mdm_property_test.go
@@ -368,6 +368,14 @@ func TestPBT_HandleESPRelease(t *testing.T) {
 					"setup has been displayed")
 			assert.Nilf(rt, pbtFindCmdByLocURI(cmds, "BlockInStatusPage"),
 				"release path must NOT include BlockInStatusPage")
+			// SkipUserStatusPage must be set to true so subsequent user logins don't trigger a fresh
+			// Account setup ESP phase (#51380).
+			skipCmd := pbtFindCmdByLocURI(cmds, "SkipUserStatusPage")
+			assert.NotNilf(rt, skipCmd, "release path must include SkipUserStatusPage=true (#51380)")
+			if skipCmd != nil && len(skipCmd.Items) > 0 && skipCmd.Items[0].Data != nil {
+				assert.Equalf(rt, "true", skipCmd.Items[0].Data.Content,
+					"SkipUserStatusPage must be true in release commands")
+			}
 		}
 
 		// Cancel-block invariants. The cancel block fires iff (timedOut || (observedHasFailure && requireAll))

--- a/server/service/microsoft_mdm_test.go
+++ b/server/service/microsoft_mdm_test.go
@@ -3558,6 +3558,8 @@ func TestESPReleaseIncludesSkipUserStatusPage(t *testing.T) {
 		uri := cmd.GetTargetURI()
 		if strings.Contains(uri, "SkipUserStatusPage") {
 			found = true
+			assert.Contains(t, uri, "/Device/",
+				"SkipUserStatusPage must be at Device scope, not User scope")
 			require.NotNil(t, cmd.Items, "SkipUserStatusPage command must have Items")
 			require.NotEmpty(t, cmd.Items, "SkipUserStatusPage command must have at least one Item")
 			require.NotNil(t, cmd.Items[0].Data, "SkipUserStatusPage Item must have Data")

--- a/server/service/microsoft_mdm_test.go
+++ b/server/service/microsoft_mdm_test.go
@@ -3545,3 +3545,27 @@ func TestIsFleetdPresentOnDevice(t *testing.T) {
 		})
 	}
 }
+
+// TestESPReleaseIncludesSkipUserStatusPage verifies that the ESP release
+// commands set SkipUserStatusPage=true so that subsequent user logins on an
+// already-enrolled device skip the Account setup ESP phase (#51380).
+func TestESPReleaseIncludesSkipUserStatusPage(t *testing.T) {
+	const provID = "test-provider"
+	cmds := buildESPReleaseCommands(provID)
+
+	var found bool
+	for _, cmd := range cmds {
+		uri := cmd.GetTargetURI()
+		if strings.Contains(uri, "SkipUserStatusPage") {
+			found = true
+			require.NotNil(t, cmd.Items, "SkipUserStatusPage command must have Items")
+			require.NotEmpty(t, cmd.Items, "SkipUserStatusPage command must have at least one Item")
+			require.NotNil(t, cmd.Items[0].Data, "SkipUserStatusPage Item must have Data")
+			assert.Equal(t, "true", cmd.Items[0].Data.Content,
+				"SkipUserStatusPage must be set to true in release commands")
+		}
+	}
+	assert.True(t, found,
+		"release commands must include SkipUserStatusPage=true; without it, a second user "+
+			"signing in to an already-enrolled device hits a fresh Account setup ESP that hangs (#51380)")
+}


### PR DESCRIPTION
**Related issue:** Resolves #51380

> PR description generated by Claude.

## Reproduction

When a Windows device completes Autopilot enrollment with user A, Fleet sends ESP release commands that set `ServerHasFinishedProvisioning=true` at both Device and User scope. However, the `SkipUserStatusPage` CSP setting (set to `false` during the hold phase) is never flipped to `true` during release.

When user B signs in to the same device for the first time, Windows sees `SkipUserStatusPage=false` and starts a fresh "Account setup" ESP phase. Fleet has already finished provisioning and does not respond to this new ESP session, so all four subcategories sit at "Identifying" indefinitely until the 3-hour `TimeOutUntilSyncFailure` timeout expires.

**Reproduced via unit test**: `TestESPReleaseIncludesSkipUserStatusPage` calls `buildESPReleaseCommands()` and asserts that the returned SyncML commands include `SkipUserStatusPage=true`. Before the fix, this test fails because the command is missing. After the fix, it passes.

**Windows VM check**: SSH'd into a Windows 11 VM (`fleet-winvm`) to inspect the `HKLM\SOFTWARE\Microsoft\Enrollments` registry tree. The VM is not Autopilot-enrolled so no FirstSyncStatus keys exist, confirming that full end-to-end reproduction requires Autopilot infrastructure (Entra-joined device, Fleet as MDM authority, two user accounts). This is a QA task.

## Fix

Added `SkipUserStatusPage=true` to `buildESPReleaseCommands()` in `server/service/microsoft_mdm.go`. This command is sent alongside the existing `ServerHasFinishedProvisioning=true` and `InstallationState=3` commands when Fleet releases the device from the ESP. It tells Windows to skip the Account setup page for all subsequent user logins after the initial enrollment is complete.

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops

## Testing

- [x] Added/updated automated tests
  - `TestESPReleaseIncludesSkipUserStatusPage`: unit test asserting `SkipUserStatusPage=true` is present in release commands
  - `TestPBT_HandleESPRelease`: updated property-based test to assert the new invariant across 100 randomized scenarios
- [ ] QA'd all new/changed functionality manually
  - Needs end-to-end QA with Autopilot-enrolled Windows device: enroll as user A, complete ESP, sign out, sign in as user B, verify no Account setup ESP appears

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where secondary users signing in to Windows devices enrolled through Autopilot could remain stuck on the “Account setup” screen for up to three hours.
  * Subsequent user sign-ins now skip the unnecessary Enrollment Status Page setup phase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->