### PR TITLE
Fleet UI: Show success toast after saving Deploy modal changes

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeployModal/DeployModal.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeployModal/DeployModal.tests.tsx
@@ -271,54 +271,6 @@ describe("DeployModal", () => {
     });
   });
 
-  it("fires a success toast when a patch radio change is saved (#51640)", async () => {
-    const successSpy = jest.spyOn(notify, "success");
-    const { user } = renderModal({
-      softwarePackage: createMockSoftwarePackage({
-        fleet_maintained_app_id: 1,
-        patch_policy: {
-          id: 22,
-          name: "Firefox up to date",
-          patch_when_closed: true,
-          continuous_automations_enabled: false,
-        },
-        automatic_install_policies: [],
-      }),
-    });
-
-    await user.click(screen.getByRole("radio", { name: "Force patch" }));
-    await user.click(screen.getByRole("button", { name: "Save" }));
-
-    await waitFor(() =>
-      expect(successSpy).toHaveBeenCalledWith(
-        "Successfully updated deploy options."
-      )
-    );
-  });
-
-  it("stays quiet when Save is clicked with no changes", async () => {
-    const successSpy = jest.spyOn(notify, "success");
-    const { user } = renderModal({
-      softwarePackage: createMockSoftwarePackage({
-        fleet_maintained_app_id: 1,
-        patch_policy: {
-          id: 22,
-          name: "Firefox up to date",
-          patch_when_closed: true,
-          continuous_automations_enabled: true,
-        },
-        automatic_install_policies: [
-          { id: 22, name: "Firefox up to date", type: "patch" },
-        ],
-      }),
-    });
-
-    await user.click(screen.getByRole("button", { name: "Save" }));
-
-    await waitFor(() => expect(teamPoliciesAPI.update).not.toHaveBeenCalled());
-    expect(successSpy).not.toHaveBeenCalled();
-  });
-
   it("warns about a partial save, then closes and refreshes so retry uses fresh policy state", async () => {
     const onExit = jest.fn();
     const onSuccess = jest.fn();

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeployModal/DeployModal.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeployModal/DeployModal.tests.tsx
@@ -271,6 +271,54 @@ describe("DeployModal", () => {
     });
   });
 
+  it("fires a success toast when a patch radio change is saved (#51640)", async () => {
+    const successSpy = jest.spyOn(notify, "success");
+    const { user } = renderModal({
+      softwarePackage: createMockSoftwarePackage({
+        fleet_maintained_app_id: 1,
+        patch_policy: {
+          id: 22,
+          name: "Firefox up to date",
+          patch_when_closed: true,
+          continuous_automations_enabled: false,
+        },
+        automatic_install_policies: [],
+      }),
+    });
+
+    await user.click(screen.getByRole("radio", { name: "Force patch" }));
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(successSpy).toHaveBeenCalledWith(
+        "Successfully updated deploy options."
+      )
+    );
+  });
+
+  it("stays quiet when Save is clicked with no changes", async () => {
+    const successSpy = jest.spyOn(notify, "success");
+    const { user } = renderModal({
+      softwarePackage: createMockSoftwarePackage({
+        fleet_maintained_app_id: 1,
+        patch_policy: {
+          id: 22,
+          name: "Firefox up to date",
+          patch_when_closed: true,
+          continuous_automations_enabled: true,
+        },
+        automatic_install_policies: [
+          { id: 22, name: "Firefox up to date", type: "patch" },
+        ],
+      }),
+    });
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(teamPoliciesAPI.update).not.toHaveBeenCalled());
+    expect(successSpy).not.toHaveBeenCalled();
+  });
+
   it("warns about a partial save, then closes and refreshes so retry uses fresh policy state", async () => {
     const onExit = jest.fn();
     const onSuccess = jest.fn();

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeployModal/DeployModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeployModal/DeployModal.tsx
@@ -145,6 +145,9 @@ const DeployModal = ({
         savedAnyChange = true;
       }
 
+      if (savedAnyChange) {
+        notify.success("Successfully updated deploy options.");
+      }
       onSuccess();
       onExit();
     } catch (error) {


### PR DESCRIPTION
## Issue
Closes #51640

## Description
- Bug fix (root cause): the FMA Deploy modal's `onSave` only fired `notify.error` on failure. The success path called `onSuccess()` + `onExit()` with no toast, so users had no confirmation that a patch radio change (e.g. "Patch when app is closed" → "Force patch") actually saved, even though it did.
- Fire `notify.success("Successfully updated deploy options.")` on the success path, gated on `savedAnyChange` so clicking Save with no edits stays quiet instead of lying to the user.

## Screenrecording
- Changing the patch radio in Actions → Deploy now shows a success toast


https://github.com/user-attachments/assets/7b33f12f-e181-4c59-bc47-457ec1294876



## Testing

- [ ] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a success notification when deploy options are updated successfully.
  * Notifications now appear only when changes are actually saved.
  * Preserved existing error notifications for partial or complete save failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->