### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/acorn/darwin.json
+++ b/ee/maintained-apps/outputs/acorn/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "8.6.1",
+      "version": "8.6.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.flyingmeat.Acorn8';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.flyingmeat.Acorn8' AND version_compare(bundle_short_version, '8.6.1') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.flyingmeat.Acorn8' AND version_compare(bundle_short_version, '8.6.2') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.flyingmeat.Acorn8');"
       },
-      "installer_url": "https://flyingmeat.com/download/Acorn-8.6.1.zip",
+      "installer_url": "https://flyingmeat.com/download/Acorn-8.6.2.zip",
       "install_script_ref": "905a9e15",
       "uninstall_script_ref": "d8d84d04",
-      "sha256": "8784aa59f29e7451776054ee21ec69dbe433298195bfc21ca47574f50573ecf4",
+      "sha256": "ab1fe1d1c18b74a2686c44c366e13f6ae4450d20e227dbb56b04fbd1df5c83f8",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/airbuddy/darwin.json
+++ b/ee/maintained-apps/outputs/airbuddy/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "3.0",
+      "version": "3.0.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'codes.rambo.AirBuddy';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'codes.rambo.AirBuddy' AND version_compare(bundle_short_version, '3.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'codes.rambo.AirBuddy' AND version_compare(bundle_short_version, '3.0.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'codes.rambo.AirBuddy');"
       },
-      "installer_url": "https://su.airbuddy.app/lleMaylxgd/AirBuddy_v3.0-953.dmg",
+      "installer_url": "https://su.airbuddy.app/lleMaylxgd/AirBuddy_v3.0.1-1008.dmg",
       "install_script_ref": "d2a86d92",
       "uninstall_script_ref": "a18b7e7a",
-      "sha256": "ed22f4e08a91bc1c4081893bd9571e0286c25e6e31d502b8a6ae7b93fef37038",
+      "sha256": "0c8e2b7349629f8176d7af8d2460cd06e37d1721edff6a925109914b53992700",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/devolutions-launcher/windows.json
+++ b/ee/maintained-apps/outputs/devolutions-launcher/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "2026.2.17.0",
+      "version": "2026.2.18.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Devolutions Launcher' AND publisher = 'Devolutions inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Devolutions Launcher' AND publisher = 'Devolutions inc.' AND version_compare(version, '2026.2.17.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Devolutions Launcher' AND publisher = 'Devolutions inc.' AND version_compare(version, '2026.2.18.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'devolutions launcher.exe');"
       },
-      "installer_url": "https://cdn.devolutions.net/download/Setup.Devolutions.Launcher.2026.2.17.0.msi",
+      "installer_url": "https://cdn.devolutions.net/download/Setup.Devolutions.Launcher.2026.2.18.0.msi",
       "install_script_ref": "22e48c46",
       "uninstall_script_ref": "532bd615",
-      "sha256": "797ae6dbde3ae3bf1b10f95a768fcd8b1d54c7d997d79cf7c76707d0b70e2c94",
+      "sha256": "249479415a756ba68a14a08db444e68ffa8a15ccb938f2e8204e0dfe9a6782c0",
       "default_categories": [
         "Productivity"
       ],

--- a/ee/maintained-apps/outputs/firefox@developer-edition/darwin.json
+++ b/ee/maintained-apps/outputs/firefox@developer-edition/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "155.0b3",
+      "version": "155.0b4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefoxdeveloperedition';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefoxdeveloperedition' AND version_compare(bundle_version, '15526.8.21') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefoxdeveloperedition' AND version_compare(bundle_version, '15526.8.24') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'org.mozilla.firefoxdeveloperedition');"
       },
-      "installer_url": "https://download-installer.cdn.mozilla.net/pub/devedition/releases/155.0b3/mac/en-US/Firefox%20155.0b3.dmg",
+      "installer_url": "https://download-installer.cdn.mozilla.net/pub/devedition/releases/155.0b4/mac/en-US/Firefox%20155.0b4.dmg",
       "install_script_ref": "b679ecd7",
       "uninstall_script_ref": "292c5733",
-      "sha256": "4aaf57b8e160f8801ec870d9317635f44e4d82e21dbfcfafb0a7b520ee2b4018",
+      "sha256": "1c07b8bbe6c2b591e4b0f96b46bd4a5508b9395b56d305f3c1b727e99b8e7b88",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/firefox@nightly/darwin.json
+++ b/ee/maintained-apps/outputs/firefox@nightly/darwin.json
@@ -4,13 +4,13 @@
       "version": "156.0a1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15626.8.23') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15626.8.24') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'org.mozilla.nightly');"
       },
-      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/08/2026-08-23-21-38-25-mozilla-central/firefox-156.0a1.en-US.mac.dmg",
+      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/08/2026-08-24-09-34-07-mozilla-central/firefox-156.0a1.en-US.mac.dmg",
       "install_script_ref": "d9c4cf87",
       "uninstall_script_ref": "0661f848",
-      "sha256": "0285f856d70363ac282972df8f47530c92a1f889089fb067ec21637671abba49",
+      "sha256": "13747a3fa39d965e96d35898baea1444f7e0f24adff2623d9bf1159853052e0e",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/grammarly-desktop/darwin.json
+++ b/ee/maintained-apps/outputs/grammarly-desktop/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.185.0",
+      "version": "1.186.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama' AND version_compare(bundle_short_version, '1.185.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama' AND version_compare(bundle_short_version, '1.186.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.grammarly.ProjectLlama');"
       },
-      "installer_url": "https://download-mac.grammarly.com/versions/1.185.0.0/Grammarly.dmg",
+      "installer_url": "https://download-mac.grammarly.com/versions/1.186.0.0/Grammarly.dmg",
       "install_script_ref": "8274b7dd",
       "uninstall_script_ref": "7dff0961",
-      "sha256": "f0450899a396272d4ac6c277857227026f29ed23ac22bbae96ff6055cb329aee",
+      "sha256": "acf85974e5ec1c5f16f794c26ceddf36efd11ee4e61ea1cec747c109f60a7a6b",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/keyboardcleantool/darwin.json
+++ b/ee/maintained-apps/outputs/keyboardcleantool/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "8.1",
+      "version": "8.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.hegenberg.KeyboardCleanTool';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hegenberg.KeyboardCleanTool' AND version_compare(bundle_short_version, '8.1') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hegenberg.KeyboardCleanTool' AND version_compare(bundle_short_version, '8.2') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.hegenberg.KeyboardCleanTool');"
       },
-      "installer_url": "https://folivora.ai/releases/KeyboardCleanTool-8.1.zip",
+      "installer_url": "https://folivora.ai/releases/KeyboardCleanTool-8.2.zip",
       "install_script_ref": "5082bf17",
       "uninstall_script_ref": "4fb4840e",
-      "sha256": "1c5f6b20021235031323c2d7398fdc3a5e47f27e9671e8a81714ac408912a8e0",
+      "sha256": "c85b7342bce59cc3f76a3689aa92405f1b672f93f697c0775a178a8b255b6191",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/opencode-desktop/darwin.json
+++ b/ee/maintained-apps/outputs/opencode-desktop/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.18.21",
+      "version": "1.18.22",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'ai.opencode.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'ai.opencode.desktop' AND version_compare(bundle_short_version, '1.18.21') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'ai.opencode.desktop' AND version_compare(bundle_short_version, '1.18.22') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'ai.opencode.desktop');"
       },
-      "installer_url": "https://github.com/anomalyco/opencode/releases/download/v1.18.21/opencode-desktop-mac-arm64.dmg",
+      "installer_url": "https://github.com/anomalyco/opencode/releases/download/v1.18.22/opencode-desktop-mac-arm64.dmg",
       "install_script_ref": "d2ce7b1a",
       "uninstall_script_ref": "99fcb3f1",
-      "sha256": "a04746b6b3961b5ca17a2eaedf8372ae82e9418c7b07742a9d8cff63ea73dfd7",
+      "sha256": "7fa35c86befd1d4c93f72e14e63b5a4ebcf49a48472fbf4aba381b2095963960",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/rive/darwin.json
+++ b/ee/maintained-apps/outputs/rive/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "0.8.5520",
+      "version": "0.8.5581",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'app.rive.editor';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.rive.editor' AND version_compare(bundle_short_version, '0.8.5520') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.rive.editor' AND version_compare(bundle_short_version, '0.8.5581') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'app.rive.editor');"
       },
-      "installer_url": "https://releases.rive.app/macos/0.8.5520/Rive.dmg",
+      "installer_url": "https://releases.rive.app/macos/0.8.5581/Rive.dmg",
       "install_script_ref": "9555d3e0",
       "uninstall_script_ref": "8f862785",
-      "sha256": "4d27033604d34d7a23bd9da4afc31544dcb181dc18366b4dcc5805fc863d4def",
+      "sha256": "22ecee0581994725606a83a38ac97766f4e9813475d3f495eb364115933bbbd8",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/zed/darwin.json
+++ b/ee/maintained-apps/outputs/zed/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.16.1",
+      "version": "1.16.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed' AND version_compare(bundle_short_version, '1.16.1') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed' AND version_compare(bundle_short_version, '1.16.2') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'dev.zed.Zed');"
       },
-      "installer_url": "https://zed.dev/api/releases/stable/1.16.1/Zed-aarch64.dmg",
+      "installer_url": "https://zed.dev/api/releases/stable/1.16.2/Zed-aarch64.dmg",
       "install_script_ref": "bdea8414",
       "uninstall_script_ref": "0436e2d8",
-      "sha256": "985f1a5944f45389627afb728e82f5010a5814c0eeab06977b06ffa87cac7498",
+      "sha256": "4bad0834d3542391de86b309c8e920b37e69887915df80d53de0aa119ea1e14d",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/zed/windows.json
+++ b/ee/maintained-apps/outputs/zed/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.16.1",
+      "version": "1.16.2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Zed' AND publisher = 'Zed Industries';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Zed' AND publisher = 'Zed Industries' AND version_compare(version, '1.16.1') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Zed' AND publisher = 'Zed Industries' AND version_compare(version, '1.16.2') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'zed.exe');"
       },
-      "installer_url": "https://github.com/zed-industries/zed/releases/download/v1.16.1/Zed-x86_64.exe",
+      "installer_url": "https://github.com/zed-industries/zed/releases/download/v1.16.2/Zed-x86_64.exe",
       "install_script_ref": "e5193bc1",
       "uninstall_script_ref": "3b164442",
-      "sha256": "7dbc0b8a5ecb1588ee2ee21afe95a07e2507eabdd138483af1f539c9367273c5",
+      "sha256": "ae0fe9d17b938bdec82658b09d3e42009d25cd3e7845eed149e6049552d58ac6",
       "default_categories": [
         "Developer tools"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated maintained app packages to their latest available versions, including Acorn, AirBuddy, Devolutions Launcher, Firefox Developer Edition, Firefox Nightly, Grammarly Desktop, KeyboardCleanTool, OpenCode Desktop, Rive, and Zed.
  * Refreshed macOS and Windows download metadata to ensure installations retrieve the correct release files.
  * Updated version detection and integrity verification for each refreshed package.
  * Existing installation, uninstallation, and app detection behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->