### PR TITLE
Cherry-pick #51014: Fixing minor SCEP proxy issues

### DIFF
--- a/changes/16882-scep-proxy-windows-challenge
+++ b/changes/16882-scep-proxy-windows-challenge
@@ -1,0 +1,1 @@
+- Fixed the SCEP proxy so that Windows profiles using a custom SCEP proxy certificate authority have their one-time Fleet challenge validated before a PKIOperation request is forwarded to the certificate authority. Requests with a missing, incorrect, or expired challenge are now rejected.

--- a/changes/16884-scep-proxy-removed-windows-profiles
+++ b/changes/16884-scep-proxy-removed-windows-profiles
@@ -1,0 +1,1 @@
+- Fixed the SCEP proxy so that a Windows profile pending removal can no longer be used to relay SCEP requests to the configured certificate authority, and so that proxy error responses no longer include the certificate authority's URL.

--- a/ee/server/service/scep/scep_proxy.go
+++ b/ee/server/service/scep/scep_proxy.go
@@ -233,9 +233,20 @@ func (svc *scepProxyService) GetCACaps(ctx context.Context, identifier string) (
 	}
 	res, err := client.GetCACaps(ctx)
 	if err != nil {
-		return res, ctxerr.Wrapf(ctx, err, "Could not GetCACaps from SCEP server %s", scepURL)
+		svc.debugLogger.ErrorContext(ctx, "SCEP proxy GetCACaps failed", "scep_url", scepURL, "err", err)
+		return res, sanitizeUpstreamError(ctx, err, "Could not GetCACaps from SCEP server")
 	}
 	return res, nil
+}
+
+// sanitizeUpstreamError converts an error from the upstream CA into one that is safe to hand back to the SCEP client. The proxy route is
+// unauthenticated and the transport writes the error text straight into the response body, so the CA URL and the
+// CA's response body must stay in the logs only. A deadline-exceeded cause is preserved because the endpoint maps it to a 408.
+func sanitizeUpstreamError(ctx context.Context, err error, message string) error {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return ctxerr.Wrap(ctx, context.DeadlineExceeded, message)
+	}
+	return ctxerr.New(ctx, message)
 }
 
 // GetCACert returns the CA certificate(s) from SCEP server.
@@ -252,7 +263,8 @@ func (svc *scepProxyService) GetCACert(ctx context.Context, message string, iden
 	}
 	res, num, err := client.GetCACert(ctx, message)
 	if err != nil {
-		return res, num, ctxerr.Wrapf(ctx, err, "Could not GetCACert from SCEP server %s", scepURL)
+		svc.debugLogger.ErrorContext(ctx, "SCEP proxy GetCACert failed", "scep_url", scepURL, "err", err)
+		return res, num, sanitizeUpstreamError(ctx, err, "Could not GetCACert from SCEP server")
 	}
 	return res, num, nil
 }
@@ -273,8 +285,8 @@ func (svc *scepProxyService) PKIOperation(ctx context.Context, data []byte, iden
 	res, err := client.PKIOperation(ctx, data)
 	if err != nil {
 		svc.recordWindowsSCEPProxyFailure(ctx, identifier, "PKIOperation", err)
-		return res, ctxerr.Wrapf(ctx, err,
-			"Could not do PKIOperation on SCEP server %s", scepURL)
+		svc.debugLogger.ErrorContext(ctx, "SCEP proxy PKIOperation failed", "scep_url", scepURL, "err", err)
+		return res, sanitizeUpstreamError(ctx, err, "Could not do PKIOperation on SCEP server")
 	}
 	return res, nil
 }
@@ -499,11 +511,6 @@ func (svc *scepProxyService) validateIdentifier(ctx context.Context, identifier 
 			}
 		}
 
-		if strings.HasPrefix(certReq.GetProfileUUID(), fleet.MDMWindowsProfileUUIDPrefix) {
-			// TODO: Early return for Windows profiles as they do not support resending yet.
-			return scepURL, nil
-		}
-
 		if checkChallenge {
 			if err := svc.handleFleetChallenge(ctx, fleetChallenge, hostUUID, profileUUID); err != nil {
 				// FIXME: The layered logging implementation of the scepProxyService not
@@ -558,10 +565,18 @@ func (svc *scepProxyService) GetNextCACert(_ context.Context) ([]byte, error) {
 func (svc *scepProxyService) handleFleetChallenge(ctx context.Context, fleetChallenge string, hostUUID string, profileUUID string) error {
 	var errs []error
 
+	// ResendHostCertificateProfile only touches the Apple tables, so a Windows profile whose challenge was rejected would never be resent
+	// and would stay stuck. Route Windows through the platform-aware resend. (Android resends are a separate pre-existing gap: its SCEP
+	// flow is backed by certificate templates rather than a host profile row, so it is left on the existing path here.)
+	resendProfile := svc.ds.ResendHostCertificateProfile
+	if strings.HasPrefix(profileUUID, fleet.MDMWindowsProfileUUIDPrefix) {
+		resendProfile = svc.ds.ResendHostMDMProfile
+	}
+
 	if err := svc.ds.ConsumeChallenge(ctx, fleetChallenge); err != nil {
 		errs = append(errs, ctxerr.Wrap(ctx, err, "custom scep proxy: validating challenge"))
 		// FIXME: See comment in datastore method regarding how we resend profiles with dynamic content
-		if err := svc.ds.ResendHostCertificateProfile(ctx, hostUUID, profileUUID); err != nil {
+		if err := resendProfile(ctx, hostUUID, profileUUID); err != nil {
 			errs = append(errs, ctxerr.Wrap(ctx, err, "custom scep proxy: resending host mdm profile"))
 		}
 	}

--- a/ee/server/service/scep/scep_proxy_test.go
+++ b/ee/server/service/scep/scep_proxy_test.go
@@ -746,7 +746,89 @@ func TestValidateIdentifier(t *testing.T) {
 		ds.ResendHostCertificateProfileFuncInvoked = false
 	})
 
-	t.Run("Custom SCEP Windows profile skips challenge check", func(t *testing.T) {
+	// Windows custom SCEP profiles carry the same one-time Fleet challenge as Apple ones, so PKIOperation must consume and validate it
+	// rather than forwarding to the CA on the strength of the identifier alone.
+	t.Run("Custom SCEP Windows profile enforces challenge check", func(t *testing.T) {
+		newDS := func() *mock.DataStore {
+			ds := new(mock.DataStore)
+			ds.GetGroupedCertificateAuthoritiesFunc = func(ctx context.Context, includeSecrets bool) (*fleet.GroupedCertificateAuthorities, error) {
+				return &fleet.GroupedCertificateAuthorities{
+					CustomScepProxy: []fleet.CustomSCEPProxyCA{
+						{Name: "my-custom-ca", URL: "https://custom-scep.example.com/scep"},
+					},
+				}, nil
+			}
+			verifyingStatus := fleet.MDMDeliveryVerifying
+			ds.GetWindowsHostMDMCertificateProfileFunc = func(ctx context.Context, hostUUID, profileUUID, caName string) (*fleet.HostMDMCertificateProfile, error) {
+				return &fleet.HostMDMCertificateProfile{
+					HostUUID:    hostUUID,
+					ProfileUUID: profileUUID,
+					Status:      &verifyingStatus,
+					Type:        fleet.CAConfigCustomSCEPProxy,
+					CAName:      "my-custom-ca",
+				}, nil
+			}
+			return ds
+		}
+
+		t.Run("valid challenge is accepted and consumed", func(t *testing.T) {
+			ds := newDS()
+			ds.ConsumeChallengeFunc = func(ctx context.Context, challenge string) error {
+				assert.Equal(t, "valid-challenge", challenge)
+				return nil
+			}
+			svc := newTestService(ds)
+
+			identifier := makeIdentifier("host-uuid", "w-profile-uuid", "my-custom-ca", "valid-challenge")
+			scepURL, err := svc.validateIdentifier(ctx, identifier, true)
+			require.NoError(t, err)
+			assert.Equal(t, "https://custom-scep.example.com/scep", scepURL)
+			assert.True(t, ds.ConsumeChallengeFuncInvoked)
+		})
+
+		for _, tc := range []struct {
+			name       string
+			identifier string
+		}{
+			{name: "missing challenge", identifier: makeIdentifier("host-uuid", "w-profile-uuid", "my-custom-ca", "")},
+			{name: "arbitrary challenge", identifier: makeIdentifier("host-uuid", "w-profile-uuid", "my-custom-ca", "wrong123")},
+		} {
+			t.Run(tc.name+" is rejected", func(t *testing.T) {
+				ds := newDS()
+				ds.ConsumeChallengeFunc = func(ctx context.Context, challenge string) error {
+					return sql.ErrNoRows // challenge not found
+				}
+				// Windows profiles must be resent through the platform-aware path, not the Apple-only one.
+				ds.ResendHostMDMProfileFunc = func(ctx context.Context, hostUUID, profileUUID string) error {
+					assert.Equal(t, "host-uuid", hostUUID)
+					assert.Equal(t, "w-profile-uuid", profileUUID)
+					return nil
+				}
+				svc := newTestService(ds)
+
+				_, err := svc.validateIdentifier(ctx, tc.identifier, true)
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "custom scep challenge failed")
+				assert.True(t, ds.ResendHostMDMProfileFuncInvoked)
+				assert.False(t, ds.ResendHostCertificateProfileFuncInvoked, "Windows profiles must not use the Apple-only resend")
+			})
+		}
+
+		// GetCACaps/GetCACert legitimately precede the challenge, so they must keep working.
+		t.Run("non-PKIOperation requests do not require a challenge", func(t *testing.T) {
+			ds := newDS()
+			svc := newTestService(ds)
+
+			identifier := makeIdentifier("host-uuid", "w-profile-uuid", "my-custom-ca", "")
+			scepURL, err := svc.validateIdentifier(ctx, identifier, false)
+			require.NoError(t, err)
+			assert.Equal(t, "https://custom-scep.example.com/scep", scepURL)
+			assert.False(t, ds.ConsumeChallengeFuncInvoked)
+		})
+	})
+
+	// A profile in "remove" no longer resolves in the datastore, so the proxy rejects the identifier without contacting the CA.
+	t.Run("Custom SCEP Windows removed profile is rejected", func(t *testing.T) {
 		ds := new(mock.DataStore)
 		ds.GetGroupedCertificateAuthoritiesFunc = func(ctx context.Context, includeSecrets bool) (*fleet.GroupedCertificateAuthorities, error) {
 			return &fleet.GroupedCertificateAuthorities{
@@ -755,27 +837,16 @@ func TestValidateIdentifier(t *testing.T) {
 				},
 			}, nil
 		}
-		verifiedStatus := fleet.MDMDeliveryVerified
 		ds.GetWindowsHostMDMCertificateProfileFunc = func(ctx context.Context, hostUUID, profileUUID, caName string) (*fleet.HostMDMCertificateProfile, error) {
-			return &fleet.HostMDMCertificateProfile{
-				HostUUID:    hostUUID,
-				ProfileUUID: profileUUID,
-				Status:      &verifiedStatus,
-				Type:        fleet.CAConfigCustomSCEPProxy,
-				CAName:      "my-custom-ca",
-			}, nil
-		}
-		// ConsumeChallenge should NOT be called for Windows profiles
-		ds.ConsumeChallengeFunc = func(ctx context.Context, challenge string) error {
-			return nil
+			return nil, nil
 		}
 		svc := newTestService(ds)
 
-		identifier := makeIdentifier("host-uuid", "w-profile-uuid", "my-custom-ca", "test-challenge")
-		scepURL, err := svc.validateIdentifier(ctx, identifier, true) // checkChallenge=true but should be skipped
-		require.NoError(t, err)
-		assert.Equal(t, "https://custom-scep.example.com/scep", scepURL)
-		assert.False(t, ds.ConsumeChallengeFuncInvoked, "ConsumeChallenge should not be called for Windows profiles")
+		identifier := makeIdentifier("host-uuid", "w-profile-uuid", "my-custom-ca", "")
+		_, err := svc.validateIdentifier(ctx, identifier, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown identifier in URL path")
+		assert.NotContains(t, err.Error(), "custom-scep.example.com", "rejection must not leak the upstream CA URL")
 	})
 
 	t.Run("datastore error getting CAs", func(t *testing.T) {

--- a/server/datastore/mysql/microsoft_mdm.go
+++ b/server/datastore/mysql/microsoft_mdm.go
@@ -3380,6 +3380,8 @@ func (ds *Datastore) WipeHostViaWindowsMDM(ctx context.Context, host *fleet.Host
 	})
 }
 
+// GetWindowsHostMDMCertificateProfile returns the certificate profile backing a SCEP proxy identifier. Only profiles being
+// installed are returned.
 func (ds *Datastore) GetWindowsHostMDMCertificateProfile(ctx context.Context, hostUUID string,
 	profileUUID string, caName string,
 ) (*fleet.HostMDMCertificateProfile, error) {
@@ -3399,9 +3401,10 @@ func (ds *Datastore) GetWindowsHostMDMCertificateProfile(ctx context.Context, ho
 	JOIN host_mdm_managed_certificates hmmc
 		ON hmwp.host_uuid = hmmc.host_uuid AND hmwp.profile_uuid = hmmc.profile_uuid
 	WHERE
-		hmmc.host_uuid = ? AND hmmc.profile_uuid = ? AND hmmc.ca_name = ?`
+		hmmc.host_uuid = ? AND hmmc.profile_uuid = ? AND hmmc.ca_name = ? AND hmwp.operation_type = ?`
 	var profile fleet.HostMDMCertificateProfile
-	if err := sqlx.GetContext(ctx, ds.reader(ctx), &profile, stmt, hostUUID, profileUUID, caName); err != nil {
+	if err := sqlx.GetContext(ctx, ds.reader(ctx), &profile, stmt, hostUUID, profileUUID, caName,
+		fleet.MDMOperationTypeInstall); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
 		}

--- a/server/datastore/mysql/microsoft_mdm_test.go
+++ b/server/datastore/mysql/microsoft_mdm_test.go
@@ -5529,6 +5529,31 @@ func testWindowsMDMManagedSCEPCertificates(t *testing.T, ds *Datastore) {
 			require.NoError(t, err)
 			require.NotNil(t, profile)
 
+			// A profile being removed must no longer resolve, so its identifier can't be replayed against the unauthenticated SCEP proxy.
+			t.Run("profile being removed is not returned", func(t *testing.T) {
+				upsertOperationType := func(operationType fleet.MDMOperationType) {
+					err := ds.BulkUpsertMDMWindowsHostProfiles(ctx, []*fleet.MDMWindowsBulkUpsertHostProfilePayload{
+						{
+							ProfileUUID:   initialCP.ProfileUUID,
+							ProfileName:   initialCP.Name,
+							HostUUID:      host.UUID,
+							Status:        &fleet.MDMDeliveryPending,
+							OperationType: operationType,
+							CommandUUID:   "command-uuid",
+							Checksum:      []byte("checksum"),
+						},
+					})
+					require.NoError(t, err)
+				}
+				// Restore the install operation so the subtests that follow see the original state.
+				defer upsertOperationType(fleet.MDMOperationTypeInstall)
+
+				upsertOperationType(fleet.MDMOperationTypeRemove)
+				removedProfile, err := ds.GetWindowsHostMDMCertificateProfile(ctx, host.UUID, initialCP.ProfileUUID, caName)
+				require.NoError(t, err)
+				assert.Nil(t, removedProfile)
+			})
+
 			serial := "8ABADCAFEF684D6348F5EC95AEFF468F237A9D75"
 
 			t.Run("Non renewal scenario 1 - validity window > 30 days but not yet time to renew", func(t *testing.T) {

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -16706,19 +16706,23 @@ func (s *integrationMDMTestSuite) runSCEPProxyTestWithOptionalSuffix(suffix stri
 	})
 	require.NoError(t, err)
 
+	// The proxy route is unauthenticated, so upstream failures must not disclose the CA URL to the caller.
 	res = s.DoRawWithHeaders("GET", apple_mdm.SCEPProxyPath+identifier+suffix, nil, http.StatusInternalServerError, nil, "operation", "GetCACaps")
 	errBody, err = io.ReadAll(res.Body)
 	require.NoError(t, err)
 	assert.Contains(t, string(errBody), "Could not GetCACaps from SCEP server")
+	assert.NotContains(t, string(errBody), testServer.URL)
 	res = s.DoRawWithHeaders("GET", apple_mdm.SCEPProxyPath+identifier+suffix, nil, http.StatusInternalServerError, nil, "operation", "GetCACert")
 	errBody, err = io.ReadAll(res.Body)
 	require.NoError(t, err)
 	assert.Contains(t, string(errBody), "Could not GetCACert from SCEP server")
+	assert.NotContains(t, string(errBody), testServer.URL)
 	res = s.DoRawWithHeaders("GET", apple_mdm.SCEPProxyPath+identifier+suffix, nil, http.StatusInternalServerError, nil, "operation",
 		"PKIOperation", "message", message)
 	errBody, err = io.ReadAll(res.Body)
 	require.NoError(t, err)
 	assert.Contains(t, string(errBody), "Could not do PKIOperation on SCEP server")
+	assert.NotContains(t, string(errBody), testServer.URL)
 
 	// Test timeout error
 	ndesTimeoutServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -17000,19 +17004,23 @@ func (s *integrationMDMTestSuite) runSmallstepSCEPProxyTestWithOptionalSuffix(su
 	})
 	require.NoError(t, err)
 
+	// The proxy route is unauthenticated, so upstream failures must not disclose the CA URL to the caller.
 	res = s.DoRawWithHeaders("GET", apple_mdm.SCEPProxyPath+identifier+suffix, nil, http.StatusInternalServerError, nil, "operation", "GetCACaps")
 	errBody, err = io.ReadAll(res.Body)
 	require.NoError(t, err)
 	assert.Contains(t, string(errBody), "Could not GetCACaps from SCEP server")
+	assert.NotContains(t, string(errBody), testServer.URL)
 	res = s.DoRawWithHeaders("GET", apple_mdm.SCEPProxyPath+identifier+suffix, nil, http.StatusInternalServerError, nil, "operation", "GetCACert")
 	errBody, err = io.ReadAll(res.Body)
 	require.NoError(t, err)
 	assert.Contains(t, string(errBody), "Could not GetCACert from SCEP server")
+	assert.NotContains(t, string(errBody), testServer.URL)
 	res = s.DoRawWithHeaders("GET", apple_mdm.SCEPProxyPath+identifier+suffix, nil, http.StatusInternalServerError, nil, "operation",
 		"PKIOperation", "message", message)
 	errBody, err = io.ReadAll(res.Body)
 	require.NoError(t, err)
 	assert.Contains(t, string(errBody), "Could not do PKIOperation on SCEP server")
+	assert.NotContains(t, string(errBody), testServer.URL)
 
 	// Test timeout error
 	ndesTimeoutServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
Cherry-pick of #51014 (commit fd1b0f9) into the 4.91.0 RC branch.

Fixes fleetdm/confidential#16882.