### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/acorn/darwin.json
+++ b/ee/maintained-apps/outputs/acorn/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "8.6.1",
+      "version": "8.6.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.flyingmeat.Acorn8';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.flyingmeat.Acorn8' AND version_compare(bundle_short_version, '8.6.1') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.flyingmeat.Acorn8' AND version_compare(bundle_short_version, '8.6.2') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.flyingmeat.Acorn8');"
       },
-      "installer_url": "https://flyingmeat.com/download/Acorn-8.6.1.zip",
+      "installer_url": "https://flyingmeat.com/download/Acorn-8.6.2.zip",
       "install_script_ref": "905a9e15",
       "uninstall_script_ref": "d8d84d04",
-      "sha256": "8784aa59f29e7451776054ee21ec69dbe433298195bfc21ca47574f50573ecf4",
+      "sha256": "ab1fe1d1c18b74a2686c44c366e13f6ae4450d20e227dbb56b04fbd1df5c83f8",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/airbuddy/darwin.json
+++ b/ee/maintained-apps/outputs/airbuddy/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "3.0",
+      "version": "3.0.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'codes.rambo.AirBuddy';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'codes.rambo.AirBuddy' AND version_compare(bundle_short_version, '3.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'codes.rambo.AirBuddy' AND version_compare(bundle_short_version, '3.0.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'codes.rambo.AirBuddy');"
       },
-      "installer_url": "https://su.airbuddy.app/lleMaylxgd/AirBuddy_v3.0-953.dmg",
+      "installer_url": "https://su.airbuddy.app/lleMaylxgd/AirBuddy_v3.0.1-1008.dmg",
       "install_script_ref": "d2a86d92",
       "uninstall_script_ref": "a18b7e7a",
-      "sha256": "ed22f4e08a91bc1c4081893bd9571e0286c25e6e31d502b8a6ae7b93fef37038",
+      "sha256": "0c8e2b7349629f8176d7af8d2460cd06e37d1721edff6a925109914b53992700",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/antinote/darwin.json
+++ b/ee/maintained-apps/outputs/antinote/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "2.0.9",
+      "version": "2.0.10",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.chabomakers.Antinote';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.chabomakers.Antinote' AND version_compare(bundle_short_version, '2.0.9') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.chabomakers.Antinote' AND version_compare(bundle_short_version, '2.0.10') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.chabomakers.Antinote');"
       },
-      "installer_url": "https://antinote.io/updates/Antinote_2.0.9.dmg",
+      "installer_url": "https://antinote.io/updates/Antinote_2.0.10.dmg",
       "install_script_ref": "3be1a226",
       "uninstall_script_ref": "2d505ef1",
-      "sha256": "ed8a8990a646961e93aeba8277bb12ddb4aed1b7c46c4c5387b77a30e7bd830d",
+      "sha256": "8402aae2a57547cd919055c4f78c47f22c9d644b19d29b5662970519565b1240",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/beekeeper-studio/windows.json
+++ b/ee/maintained-apps/outputs/beekeeper-studio/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "6.0.4",
+      "version": "6.0.5",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Beekeeper Studio' AND publisher = 'Beekeeper Studio Team';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Beekeeper Studio' AND publisher = 'Beekeeper Studio Team' AND version_compare(version, '6.0.4') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Beekeeper Studio' AND publisher = 'Beekeeper Studio Team' AND version_compare(version, '6.0.5') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'beekeeper studio.exe');"
       },
-      "installer_url": "https://github.com/beekeeper-studio/beekeeper-studio/releases/download/v6.0.4/Beekeeper-Studio-Setup-6.0.4.exe",
+      "installer_url": "https://github.com/beekeeper-studio/beekeeper-studio/releases/download/v6.0.5/Beekeeper-Studio-Setup-6.0.5.exe",
       "install_script_ref": "13334753",
       "uninstall_script_ref": "44e6f772",
-      "sha256": "16513ed784fcdb3f98fc133ef712956eae93c5b24ba19e5c47677460813fc197",
+      "sha256": "6ed20cfc1f6ca0efa75c8769477e394e17f7f33c753adc77eb892269ee7ca1f4",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/cursor/darwin.json
+++ b/ee/maintained-apps/outputs/cursor/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "3.17.8",
+      "version": "3.17.19",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92' AND version_compare(bundle_short_version, '3.17.8') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92' AND version_compare(bundle_short_version, '3.17.19') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.todesktop.230313mzl4w4u92');"
       },
-      "installer_url": "https://downloads.cursor.com/production/2fdd31c9f33f7fbe501f2d57772dc5bf64b63621/darwin/arm64/Cursor-darwin-arm64.zip",
+      "installer_url": "https://downloads.cursor.com/production/ae3a2b7231dd56194447fe4570dfdc61640b1e9a/darwin/arm64/Cursor-darwin-arm64.zip",
       "install_script_ref": "1ae48b55",
       "uninstall_script_ref": "03b9aece",
-      "sha256": "18bf12490fca6c05933d30e26dab1f7059b3a39bff8b24f6ba4657670d65f03f",
+      "sha256": "c40531f78738995619cfd49c76fee59c917f97cbb86fb13c3207b8018ed24ef9",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/devolutions-launcher/windows.json
+++ b/ee/maintained-apps/outputs/devolutions-launcher/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "2026.2.17.0",
+      "version": "2026.2.18.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Devolutions Launcher' AND publisher = 'Devolutions inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Devolutions Launcher' AND publisher = 'Devolutions inc.' AND version_compare(version, '2026.2.17.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Devolutions Launcher' AND publisher = 'Devolutions inc.' AND version_compare(version, '2026.2.18.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'devolutions launcher.exe');"
       },
-      "installer_url": "https://cdn.devolutions.net/download/Setup.Devolutions.Launcher.2026.2.17.0.msi",
+      "installer_url": "https://cdn.devolutions.net/download/Setup.Devolutions.Launcher.2026.2.18.0.msi",
       "install_script_ref": "22e48c46",
       "uninstall_script_ref": "532bd615",
-      "sha256": "797ae6dbde3ae3bf1b10f95a768fcd8b1d54c7d997d79cf7c76707d0b70e2c94",
+      "sha256": "249479415a756ba68a14a08db444e68ffa8a15ccb938f2e8204e0dfe9a6782c0",
       "default_categories": [
         "Productivity"
       ],

--- a/ee/maintained-apps/outputs/discord/darwin.json
+++ b/ee/maintained-apps/outputs/discord/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "0.0.408",
+      "version": "0.0.409",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.hnc.Discord';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hnc.Discord' AND version_compare(bundle_short_version, '0.0.408') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hnc.Discord' AND version_compare(bundle_short_version, '0.0.409') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.hnc.Discord');"
       },
-      "installer_url": "https://dl.discordapp.net/apps/osx/0.0.408/Discord.dmg",
+      "installer_url": "https://dl.discordapp.net/apps/osx/0.0.409/Discord.dmg",
       "install_script_ref": "43ce350f",
       "uninstall_script_ref": "450a6520",
-      "sha256": "9b6ad2542f786610d4d8627f8ce04bb289d7401900c6044cfaaf7382719bea3d",
+      "sha256": "caf8473d7f702fd67e09ccda55a05934675a5f464ae9bfca6d4b534f6d6cc511",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/discord/windows.json
+++ b/ee/maintained-apps/outputs/discord/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.0.9254",
+      "version": "1.0.9255",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Discord' AND publisher = 'Discord Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Discord' AND publisher = 'Discord Inc.' AND version_compare(version, '1.0.9254') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Discord' AND publisher = 'Discord Inc.' AND version_compare(version, '1.0.9255') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'discord.exe');"
       },
-      "installer_url": "https://stable.dl2.discordapp.net/distro/app/stable/win/x64/1.0.9254/DiscordSetup.exe",
+      "installer_url": "https://dl.discordapp.net/distro/app/stable/win/x64/1.0.9255/DiscordSetup.exe",
       "install_script_ref": "fd04e860",
       "uninstall_script_ref": "73fc6eff",
-      "sha256": "8433e35f12de8faec4e1589ad3c0c04d28eaf4bfd0d239d50409132b9e0650bf",
+      "sha256": "b8e30ae2f0f16780351bdc5cd9a518c917c9086f13d3c420aa9bef581908bb90",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/firefox@developer-edition/darwin.json
+++ b/ee/maintained-apps/outputs/firefox@developer-edition/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "155.0b3",
+      "version": "155.0b4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefoxdeveloperedition';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefoxdeveloperedition' AND version_compare(bundle_version, '15526.8.21') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefoxdeveloperedition' AND version_compare(bundle_version, '15526.8.24') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'org.mozilla.firefoxdeveloperedition');"
       },
-      "installer_url": "https://download-installer.cdn.mozilla.net/pub/devedition/releases/155.0b3/mac/en-US/Firefox%20155.0b3.dmg",
+      "installer_url": "https://download-installer.cdn.mozilla.net/pub/devedition/releases/155.0b4/mac/en-US/Firefox%20155.0b4.dmg",
       "install_script_ref": "b679ecd7",
       "uninstall_script_ref": "292c5733",
-      "sha256": "4aaf57b8e160f8801ec870d9317635f44e4d82e21dbfcfafb0a7b520ee2b4018",
+      "sha256": "1c07b8bbe6c2b591e4b0f96b46bd4a5508b9395b56d305f3c1b727e99b8e7b88",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/firefox@nightly/darwin.json
+++ b/ee/maintained-apps/outputs/firefox@nightly/darwin.json
@@ -4,13 +4,13 @@
       "version": "156.0a1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15626.8.23') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.nightly' AND version_compare(bundle_version, '15626.8.24') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'org.mozilla.nightly');"
       },
-      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/08/2026-08-23-21-38-25-mozilla-central/firefox-156.0a1.en-US.mac.dmg",
+      "installer_url": "https://ftp.mozilla.org/pub/firefox/nightly/2026/08/2026-08-24-09-34-07-mozilla-central/firefox-156.0a1.en-US.mac.dmg",
       "install_script_ref": "d9c4cf87",
       "uninstall_script_ref": "0661f848",
-      "sha256": "0285f856d70363ac282972df8f47530c92a1f889089fb067ec21637671abba49",
+      "sha256": "13747a3fa39d965e96d35898baea1444f7e0f24adff2623d9bf1159853052e0e",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/grammarly-desktop/darwin.json
+++ b/ee/maintained-apps/outputs/grammarly-desktop/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.185.0",
+      "version": "1.186.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama' AND version_compare(bundle_short_version, '1.185.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama' AND version_compare(bundle_short_version, '1.186.0') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.grammarly.ProjectLlama');"
       },
-      "installer_url": "https://download-mac.grammarly.com/versions/1.185.0.0/Grammarly.dmg",
+      "installer_url": "https://download-mac.grammarly.com/versions/1.186.0.0/Grammarly.dmg",
       "install_script_ref": "8274b7dd",
       "uninstall_script_ref": "7dff0961",
-      "sha256": "f0450899a396272d4ac6c277857227026f29ed23ac22bbae96ff6055cb329aee",
+      "sha256": "acf85974e5ec1c5f16f794c26ceddf36efd11ee4e61ea1cec747c109f60a7a6b",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/keyboardcleantool/darwin.json
+++ b/ee/maintained-apps/outputs/keyboardcleantool/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "8.1",
+      "version": "8.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.hegenberg.KeyboardCleanTool';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hegenberg.KeyboardCleanTool' AND version_compare(bundle_short_version, '8.1') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hegenberg.KeyboardCleanTool' AND version_compare(bundle_short_version, '8.2') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.hegenberg.KeyboardCleanTool');"
       },
-      "installer_url": "https://folivora.ai/releases/KeyboardCleanTool-8.1.zip",
+      "installer_url": "https://folivora.ai/releases/KeyboardCleanTool-8.2.zip",
       "install_script_ref": "5082bf17",
       "uninstall_script_ref": "4fb4840e",
-      "sha256": "1c5f6b20021235031323c2d7398fdc3a5e47f27e9671e8a81714ac408912a8e0",
+      "sha256": "c85b7342bce59cc3f76a3689aa92405f1b672f93f697c0775a178a8b255b6191",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/loom/darwin.json
+++ b/ee/maintained-apps/outputs/loom/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "0.369.2",
+      "version": "0.370.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.loom.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.loom.desktop' AND version_compare(bundle_short_version, '0.369.2') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.loom.desktop' AND version_compare(bundle_short_version, '0.370.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.loom.desktop');"
       },
-      "installer_url": "https://packages.loom.com/desktop-packages/Loom-0.369.2-arm64.dmg",
+      "installer_url": "https://packages.loom.com/desktop-packages/Loom-0.370.1-arm64.dmg",
       "install_script_ref": "53e2b898",
       "uninstall_script_ref": "1a901a1f",
-      "sha256": "74efa3d0c9c2da2085648a366542e248b3903ab1df5dd408c5c850da7598faf2",
+      "sha256": "ba9da95761a2542a5036e35222b9c2232bfdff3b6b6d076d35298306f70c8dac",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/loom/windows.json
+++ b/ee/maintained-apps/outputs/loom/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "0.369.2",
+      "version": "0.370.1",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Loom' AND publisher = 'Loom, Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Loom' AND publisher = 'Loom, Inc.' AND version_compare(version, '0.369.2') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Loom' AND publisher = 'Loom, Inc.' AND version_compare(version, '0.370.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'loom.exe');"
       },
-      "installer_url": "https://cdn.loom.com/desktop-packages/Loom%20Setup%200.369.2.exe",
+      "installer_url": "https://cdn.loom.com/desktop-packages/Loom%20Setup%200.370.1.exe",
       "install_script_ref": "77327cbf",
       "uninstall_script_ref": "b012f1e7",
-      "sha256": "3fd22588b29dece0a19b305ebdce0532e498e6f06239e64e9a299a2d519b87e4",
+      "sha256": "eccecab628ddf357ad96675e705de0f62739bb69067d8189fe5f5078133f7e77",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/opencode-desktop/darwin.json
+++ b/ee/maintained-apps/outputs/opencode-desktop/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.18.21",
+      "version": "1.18.22",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'ai.opencode.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'ai.opencode.desktop' AND version_compare(bundle_short_version, '1.18.21') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'ai.opencode.desktop' AND version_compare(bundle_short_version, '1.18.22') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'ai.opencode.desktop');"
       },
-      "installer_url": "https://github.com/anomalyco/opencode/releases/download/v1.18.21/opencode-desktop-mac-arm64.dmg",
+      "installer_url": "https://github.com/anomalyco/opencode/releases/download/v1.18.22/opencode-desktop-mac-arm64.dmg",
       "install_script_ref": "d2ce7b1a",
       "uninstall_script_ref": "99fcb3f1",
-      "sha256": "a04746b6b3961b5ca17a2eaedf8372ae82e9418c7b07742a9d8cff63ea73dfd7",
+      "sha256": "7fa35c86befd1d4c93f72e14e63b5a4ebcf49a48472fbf4aba381b2095963960",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/pastebot/darwin.json
+++ b/ee/maintained-apps/outputs/pastebot/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "3.0",
+      "version": "3.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.tapbots.Pastebot2Mac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.tapbots.Pastebot2Mac' AND version_compare(bundle_short_version, '3.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.tapbots.Pastebot2Mac' AND version_compare(bundle_short_version, '3.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.tapbots.Pastebot2Mac');"
       },
-      "installer_url": "https://tapbots.net/pastebot3/Pastebot.30000.dmg",
+      "installer_url": "https://tapbots.net/pastebot3/Pastebot.31000.dmg",
       "install_script_ref": "0c5e941b",
       "uninstall_script_ref": "85f0a84b",
-      "sha256": "22fd4d29482c0c04012ecbbdd918ca60b372d79dd7caabb2eb4671e9ddd69862",
+      "sha256": "7142a6644756cde5c7cca2b83585c13225cc0756ad2a3bc020ea2dbace85cd02",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/rive/darwin.json
+++ b/ee/maintained-apps/outputs/rive/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "0.8.5520",
+      "version": "0.8.5581",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'app.rive.editor';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.rive.editor' AND version_compare(bundle_short_version, '0.8.5520') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'app.rive.editor' AND version_compare(bundle_short_version, '0.8.5581') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'app.rive.editor');"
       },
-      "installer_url": "https://releases.rive.app/macos/0.8.5520/Rive.dmg",
+      "installer_url": "https://releases.rive.app/macos/0.8.5581/Rive.dmg",
       "install_script_ref": "9555d3e0",
       "uninstall_script_ref": "8f862785",
-      "sha256": "4d27033604d34d7a23bd9da4afc31544dcb181dc18366b4dcc5805fc863d4def",
+      "sha256": "22ecee0581994725606a83a38ac97766f4e9813475d3f495eb364115933bbbd8",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/superhuman/darwin.json
+++ b/ee/maintained-apps/outputs/superhuman/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1041.0.32",
+      "version": "1041.0.34",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.superhuman.mail';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.superhuman.mail' AND version_compare(bundle_short_version, '1041.0.32') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.superhuman.mail' AND version_compare(bundle_short_version, '1041.0.34') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'com.superhuman.mail');"
       },
-      "installer_url": "https://storage.googleapis.com/download.superhuman.com/supertron-update/Superhuman-1041.0.32-arm64-latest-mac.zip",
+      "installer_url": "https://storage.googleapis.com/download.superhuman.com/supertron-update/Superhuman-1041.0.34-arm64-latest-mac.zip",
       "install_script_ref": "7e74bd96",
       "uninstall_script_ref": "1809183d",
-      "sha256": "771dc034520a9dc4648d98504210989eeabbdb963a1df7902c580faa004e85fd",
+      "sha256": "7d85bebeedf2c779ee25e156a33641b662a78644a35492630274a0927e0d8192",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/telegram/darwin.json
+++ b/ee/maintained-apps/outputs/telegram/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "12.9",
+      "version": "12.10",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'ru.keepcoder.Telegram';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'ru.keepcoder.Telegram' AND version_compare(bundle_short_version, '12.9') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'ru.keepcoder.Telegram' AND version_compare(bundle_short_version, '12.10') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'ru.keepcoder.Telegram');"
       },
-      "installer_url": "https://osx.telegram.org/updates/Telegram-12.9.282555.app.zip",
+      "installer_url": "https://osx.telegram.org/updates/Telegram-12.10.282985.app.zip",
       "install_script_ref": "53a37daf",
       "uninstall_script_ref": "c15d54aa",
-      "sha256": "4407eac056c74363059418cef3be024f3f2f8135bb85b12ee511b21c92269f47",
+      "sha256": "609cf5bbed3106f919ed6145f5122f125ded88086ee6e3aeac705d03d705248d",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/tower/windows.json
+++ b/ee/maintained-apps/outputs/tower/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "13.1.576",
+      "version": "13.2.579",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Tower' AND publisher = 'saas.group';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Tower' AND publisher = 'saas.group' AND version_compare(version, '13.1.576') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Tower' AND publisher = 'saas.group' AND version_compare(version, '13.2.579') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'tower.exe');"
       },
-      "installer_url": "https://www.git-tower.com/apps/tower3-win/576-01812649/Tower-13.1.576.msi",
+      "installer_url": "https://www.git-tower.com/apps/tower3-win/579-85d525c8/Tower-13.2.579.msi",
       "install_script_ref": "22e48c46",
       "uninstall_script_ref": "1c38382b",
-      "sha256": "6ceb4dcb29c54f0063a6b07a39820dd5d06327e3c2517be10f1d45f9d4b093c4",
+      "sha256": "2ba4872f6209db220d28c9c6be18e59cde491db65220b1dc94f315dec5febbd6",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/zed/darwin.json
+++ b/ee/maintained-apps/outputs/zed/darwin.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.16.1",
+      "version": "1.16.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed' AND version_compare(bundle_short_version, '1.16.1') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed' AND version_compare(bundle_short_version, '1.16.2') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps a JOIN processes p ON substr(p.path, 1, LENGTH(a.path) + 1) = concat(a.path, '/') WHERE a.bundle_identifier = 'dev.zed.Zed');"
       },
-      "installer_url": "https://zed.dev/api/releases/stable/1.16.1/Zed-aarch64.dmg",
+      "installer_url": "https://zed.dev/api/releases/stable/1.16.2/Zed-aarch64.dmg",
       "install_script_ref": "bdea8414",
       "uninstall_script_ref": "0436e2d8",
-      "sha256": "985f1a5944f45389627afb728e82f5010a5814c0eeab06977b06ffa87cac7498",
+      "sha256": "4bad0834d3542391de86b309c8e920b37e69887915df80d53de0aa119ea1e14d",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/zed/windows.json
+++ b/ee/maintained-apps/outputs/zed/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "1.16.1",
+      "version": "1.16.2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Zed' AND publisher = 'Zed Industries';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Zed' AND publisher = 'Zed Industries' AND version_compare(version, '1.16.1') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Zed' AND publisher = 'Zed Industries' AND version_compare(version, '1.16.2') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'zed.exe');"
       },
-      "installer_url": "https://github.com/zed-industries/zed/releases/download/v1.16.1/Zed-x86_64.exe",
+      "installer_url": "https://github.com/zed-industries/zed/releases/download/v1.16.2/Zed-x86_64.exe",
       "install_script_ref": "e5193bc1",
       "uninstall_script_ref": "3b164442",
-      "sha256": "7dbc0b8a5ecb1588ee2ee21afe95a07e2507eabdd138483af1f539c9367273c5",
+      "sha256": "ae0fe9d17b938bdec82658b09d3e42009d25cd3e7845eed149e6049552d58ac6",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/zotero/windows.json
+++ b/ee/maintained-apps/outputs/zotero/windows.json
@@ -1,16 +1,16 @@
 {
   "versions": [
     {
-      "version": "10.0",
+      "version": "10.0.1",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Zotero' AND publisher = 'Corporation for Digital Scholarship';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Zotero' AND publisher = 'Corporation for Digital Scholarship' AND version_compare(version, '10.0') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Zotero' AND publisher = 'Corporation for Digital Scholarship' AND version_compare(version, '10.0.1') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'zotero.exe');"
       },
-      "installer_url": "https://download.zotero.org/client/release/10.0/Zotero-10.0_x64_setup.exe",
+      "installer_url": "https://download.zotero.org/client/release/10.0.1/Zotero-10.0.1_x64_setup.exe",
       "install_script_ref": "d29b62d2",
       "uninstall_script_ref": "599566de",
-      "sha256": "efa961da61b2c179ccb9ce75b490a8ba9b92bba8592f90d78822bb503de52c71",
+      "sha256": "4b0f508ef28bff9a7b6cc2299eb18f2431d966d91a462ce29e5bc609d5e07036",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated maintained app packages to their latest releases across macOS and Windows.
  - macOS updates include Acorn, AirBuddy, Antinote, Cursor, Discord, Firefox Developer Edition, Firefox Nightly, Grammarly Desktop, KeyboardCleanTool, Loom, OpenCode Desktop, Pastebot, Rive, Superhuman, Telegram, and Zed.
  - Windows updates include Beekeeper Studio, Devolutions Launcher, Discord, Loom, Tower, Zed, and Zotero.
  - Updated download sources, version detection, and integrity checks to support reliable installation and upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->