### PR TITLE
Per-platform disk encryption: platform-specific reads (#51258, 3/5)

### DIFF
--- a/changes/51258-per-platform-disk-encryption-reads
+++ b/changes/51258-per-platform-disk-encryption-reads
@@ -1,0 +1,1 @@
+- Disk encryption enforcement, key escrow, and status reporting now follow each platform's own disk encryption setting instead of the combined value.

--- a/changes/51258-per-platform-disk-encryption-reads
+++ b/changes/51258-per-platform-disk-encryption-reads
@@ -1,1 +1,0 @@
-- Disk encryption enforcement, key escrow, and status reporting now follow each platform's own disk encryption setting instead of the combined value.

--- a/ee/server/service/devices.go
+++ b/ee/server/service/devices.go
@@ -249,7 +249,7 @@ func (svc *Service) validateReadyForLinuxEscrow(ctx context.Context, host *fleet
 	}
 
 	if host.TeamID == nil {
-		if !ac.MDM.EnableDiskEncryption.Value {
+		if !ac.MDM.LinuxSettings.EnableEscrowDiskEncryptionKey.Value {
 			return &fleet.BadRequestError{Message: "Disk encryption is not enabled for hosts not assigned to a fleet."}
 		}
 	} else {
@@ -257,7 +257,7 @@ func (svc *Service) validateReadyForLinuxEscrow(ctx context.Context, host *fleet
 		if err != nil {
 			return err
 		}
-		if !tc.EnableDiskEncryption {
+		if !tc.DiskEncryptionConfig().LinuxEscrowEnabled {
 			return &fleet.BadRequestError{Message: "Disk encryption is not enabled for this host's fleet."}
 		}
 	}

--- a/ee/server/service/mdm.go
+++ b/ee/server/service/mdm.go
@@ -1415,7 +1415,7 @@ func (svc *Service) GetMDMDiskEncryptionSummary(ctx context.Context, teamID *uin
 	}
 
 	var linux fleet.MDMLinuxDiskEncryptionSummary
-	if diskEncryptionConfig.Enabled {
+	if diskEncryptionConfig.LinuxEscrowEnabled {
 		linux, err = svc.ds.GetLinuxDiskEncryptionSummary(ctx, teamID)
 		if err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "getting linux disk encryption summary")

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -2543,10 +2543,13 @@ func (svc *Service) updateTeamMDMDiskEncryption(ctx context.Context, tm *fleet.T
 	}
 
 	if didUpdateEncryption || didUpdateRequirePIN {
-		if didUpdateEncryption && !tm.Config.MDM.EnableDiskEncryption && tm.Config.MDM.RequireBitLockerPIN {
+		// the PIN requirement is a BitLocker feature, so it's judged against
+		// the Windows setting, not the all-platforms aggregate
+		windowsEncryptionOn := tm.Config.MDM.WindowsSettings.EnableDiskEncryption.Value
+		if didUpdateEncryption && !windowsEncryptionOn && tm.Config.MDM.RequireBitLockerPIN {
 			return ctxerr.New(ctx, fleet.CantDisableDiskEncryptionIfPINRequiredErrMsg)
 		}
-		if !didUpdateEncryption && !tm.Config.MDM.EnableDiskEncryption && tm.Config.MDM.RequireBitLockerPIN {
+		if !didUpdateEncryption && !windowsEncryptionOn && tm.Config.MDM.RequireBitLockerPIN {
 			return ctxerr.New(ctx, fleet.CantEnablePINRequiredIfDiskEncryptionEnabled)
 		}
 

--- a/server/datastore/mysql/app_configs.go
+++ b/server/datastore/mysql/app_configs.go
@@ -312,19 +312,13 @@ func (ds *Datastore) GetConfigEnableDiskEncryption(ctx context.Context, teamID *
 		if err != nil {
 			return fleet.DiskEncryptionConfig{}, err
 		}
-		return fleet.DiskEncryptionConfig{
-			Enabled:              tc.EnableDiskEncryption,
-			BitLockerPINRequired: tc.RequireBitLockerPIN,
-		}, nil
+		return tc.DiskEncryptionConfig(), nil
 	}
 	ac, err := ds.AppConfig(ctx)
 	if err != nil {
 		return fleet.DiskEncryptionConfig{}, err
 	}
-	return fleet.DiskEncryptionConfig{
-		Enabled:              ac.MDM.EnableDiskEncryption.Value,
-		BitLockerPINRequired: ac.MDM.RequireBitLockerPIN.Value,
-	}, nil
+	return ac.MDM.DiskEncryptionConfig(), nil
 }
 
 func (ds *Datastore) ApplyYaraRules(ctx context.Context, rules []fleet.YaraRule) error {

--- a/server/datastore/mysql/app_configs_test.go
+++ b/server/datastore/mysql/app_configs_test.go
@@ -462,7 +462,7 @@ func testGetConfigEnableDiskEncryption(t *testing.T, ds *Datastore) {
 
 	diskEncryptionConfig, err := ds.GetConfigEnableDiskEncryption(ctx, nil)
 	require.NoError(t, err)
-	require.False(t, diskEncryptionConfig.Enabled)
+	require.Equal(t, fleet.DiskEncryptionConfig{}, diskEncryptionConfig)
 
 	// Enable disk encryption for no team. The flat toggle is virtual so
 	// the per-platform fields are what gets written.
@@ -480,7 +480,13 @@ func testGetConfigEnableDiskEncryption(t *testing.T, ds *Datastore) {
 
 	diskEncryptionConfig, err = ds.GetConfigEnableDiskEncryption(ctx, nil)
 	require.NoError(t, err)
-	require.True(t, diskEncryptionConfig.Enabled)
+	require.Equal(t, fleet.DiskEncryptionConfig{
+		MacOSEnabled:         true,
+		MacOSEscrowEnabled:   true,
+		WindowsEnabled:       true,
+		BitLockerPINRequired: true,
+		LinuxEscrowEnabled:   true,
+	}, diskEncryptionConfig)
 
 	// a mixed state reads the flat toggle as false
 	ac.MDM.LinuxSettings.EnableEscrowDiskEncryptionKey = optjson.SetBool(false)
@@ -490,6 +496,17 @@ func testGetConfigEnableDiskEncryption(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	require.False(t, ac.MDM.EnableDiskEncryption.Value)
 	require.True(t, ac.MDM.MacOSSettings.EnableDiskEncryption.Value)
+
+	// the per-platform read reflects the mixed state as-is
+	diskEncryptionConfig, err = ds.GetConfigEnableDiskEncryption(ctx, nil)
+	require.NoError(t, err)
+	require.Equal(t, fleet.DiskEncryptionConfig{
+		MacOSEnabled:         true,
+		MacOSEscrowEnabled:   true,
+		WindowsEnabled:       true,
+		BitLockerPINRequired: true,
+		LinuxEscrowEnabled:   false,
+	}, diskEncryptionConfig)
 
 	// restore the uniform state for the assertions below
 	ac.MDM.LinuxSettings.EnableEscrowDiskEncryptionKey = optjson.SetBool(true)
@@ -507,7 +524,7 @@ func testGetConfigEnableDiskEncryption(t *testing.T, ds *Datastore) {
 
 	diskEncryptionConfig, err = ds.GetConfigEnableDiskEncryption(ctx, &team1.ID)
 	require.NoError(t, err)
-	require.False(t, diskEncryptionConfig.Enabled)
+	require.Equal(t, fleet.DiskEncryptionConfig{}, diskEncryptionConfig)
 
 	// Enable disk encryption for the team
 	tm.Config.MDM.MacOSSettings.EnableDiskEncryption = optjson.SetBool(true)
@@ -526,8 +543,13 @@ func testGetConfigEnableDiskEncryption(t *testing.T, ds *Datastore) {
 
 	diskEncryptionConfig, err = ds.GetConfigEnableDiskEncryption(ctx, &team1.ID)
 	require.NoError(t, err)
-	require.True(t, diskEncryptionConfig.Enabled)
-	require.True(t, diskEncryptionConfig.BitLockerPINRequired)
+	require.Equal(t, fleet.DiskEncryptionConfig{
+		MacOSEnabled:         true,
+		MacOSEscrowEnabled:   true,
+		WindowsEnabled:       true,
+		BitLockerPINRequired: true,
+		LinuxEscrowEnabled:   true,
+	}, diskEncryptionConfig)
 }
 
 func testIsEnrollSecretAvailable(t *testing.T, ds *Datastore) {

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -1790,7 +1790,7 @@ func (ds *Datastore) filterHostsByOSSettingsStatus(ctx context.Context, sql stri
 	// Linux has only disk encryption to report as OS setting, so only include the
 	// supported linux platforms if disk encryption is enabled.
 	includeLinuxCond := "FALSE"
-	if diskEncryptionConfig.Enabled {
+	if diskEncryptionConfig.LinuxEscrowEnabled {
 		includeLinuxCond = `(h.platform = 'ubuntu' OR h.platform = 'zorin' OR h.os_version LIKE 'Fedora%%')`
 	}
 
@@ -1840,7 +1840,7 @@ AND (
 	paramsWindows = append(paramsWindows, profilesStatusArgs...)
 
 	bitlockerStatus := `''`
-	if diskEncryptionConfig.Enabled {
+	if diskEncryptionConfig.WindowsEnabled {
 		// Count "BitLocker action required" as pending for profile status.
 		bitlockerStatus = fmt.Sprintf(`
             CASE WHEN (%s) THEN
@@ -1937,31 +1937,31 @@ func (ds *Datastore) filterHostsByOSSettingsDiskEncryptionStatus(ctx context.Con
 
 	switch opt.OSSettingsDiskEncryptionFilter {
 	case fleet.DiskEncryptionVerified:
-		if diskEncryptionConfig.Enabled {
+		if diskEncryptionConfig.WindowsEnabled {
 			whereWindows = ds.whereBitLockerStatus(ctx, fleet.DiskEncryptionVerified, diskEncryptionConfig.BitLockerPINRequired)
 		}
 		subqueryMacOS, subqueryParams = subqueryFileVaultVerified()
 
 	case fleet.DiskEncryptionVerifying:
-		if diskEncryptionConfig.Enabled {
+		if diskEncryptionConfig.WindowsEnabled {
 			whereWindows = ds.whereBitLockerStatus(ctx, fleet.DiskEncryptionVerifying, diskEncryptionConfig.BitLockerPINRequired)
 		}
 		subqueryMacOS, subqueryParams = subqueryFileVaultVerifying()
 
 	case fleet.DiskEncryptionActionRequired:
-		if diskEncryptionConfig.Enabled {
+		if diskEncryptionConfig.WindowsEnabled {
 			whereWindows = ds.whereBitLockerStatus(ctx, fleet.DiskEncryptionActionRequired, diskEncryptionConfig.BitLockerPINRequired)
 		}
 		subqueryMacOS, subqueryParams = subqueryFileVaultActionRequired()
 
 	case fleet.DiskEncryptionEnforcing:
-		if diskEncryptionConfig.Enabled {
+		if diskEncryptionConfig.WindowsEnabled {
 			whereWindows = ds.whereBitLockerStatus(ctx, fleet.DiskEncryptionEnforcing, diskEncryptionConfig.BitLockerPINRequired)
 		}
 		subqueryMacOS, subqueryParams = subqueryFileVaultEnforcing()
 
 	case fleet.DiskEncryptionFailed:
-		if diskEncryptionConfig.Enabled {
+		if diskEncryptionConfig.WindowsEnabled {
 			whereWindows = ds.whereBitLockerStatus(ctx, fleet.DiskEncryptionFailed, diskEncryptionConfig.BitLockerPINRequired)
 		}
 		subqueryMacOS, subqueryParams = subqueryFileVaultFailed()
@@ -1976,7 +1976,7 @@ func (ds *Datastore) filterHostsByOSSettingsDiskEncryptionStatus(ctx context.Con
 	}
 
 	// Linux hosts have disk encryption statuses only if it is enabled.
-	if diskEncryptionConfig.Enabled {
+	if diskEncryptionConfig.LinuxEscrowEnabled {
 		whereLinux = fmt.Sprintf(`(%s) = ?`, sqlCaseLinuxDiskEncryptionStatus())
 		subqueryParams = append(subqueryParams, opt.OSSettingsDiskEncryptionFilter)
 	}

--- a/server/datastore/mysql/microsoft_mdm.go
+++ b/server/datastore/mysql/microsoft_mdm.go
@@ -1806,7 +1806,7 @@ func (ds *Datastore) GetMDMWindowsBitLockerSummary(ctx context.Context, teamID *
 	if err != nil {
 		return nil, err
 	}
-	if !diskEncryptionConfig.Enabled {
+	if !diskEncryptionConfig.WindowsEnabled {
 		return &fleet.MDMWindowsBitLockerSummary{}, nil
 	}
 
@@ -1883,7 +1883,7 @@ func (ds *Datastore) GetMDMWindowsBitLockerStatus(ctx context.Context, host *fle
 	if err != nil {
 		return nil, err
 	}
-	if !diskEncryptionConfig.Enabled {
+	if !diskEncryptionConfig.WindowsEnabled {
 		return nil, nil
 	}
 
@@ -2365,7 +2365,7 @@ func (ds *Datastore) GetMDMWindowsProfilesSummary(ctx context.Context, teamID *u
 	}
 
 	var counts []statusCounts
-	if !diskEncryptionConfig.Enabled {
+	if !diskEncryptionConfig.WindowsEnabled {
 		counts, err = getMDMWindowsStatusCountsProfilesOnlyDB(ctx, ds, teamID)
 	} else {
 		counts, err = getMDMWindowsStatusCountsProfilesAndBitLockerDB(ctx, ds, teamID, diskEncryptionConfig.BitLockerPINRequired)

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -310,10 +310,16 @@ type MDM struct {
 }
 
 type DiskEncryptionConfig struct {
-	// Enabled indicates if disk encryption is enabled.
-	Enabled bool
+	// MacOSEnabled indicates if FileVault enforcement is enabled for macOS hosts.
+	MacOSEnabled bool
+	// MacOSEscrowEnabled indicates if recovery key escrow is enabled for macOS hosts.
+	MacOSEscrowEnabled bool
+	// WindowsEnabled indicates if BitLocker enforcement is enabled for Windows hosts.
+	WindowsEnabled bool
 	// BitLockerPINRequired indicates if a PIN is required for BitLocker disk encryption.
 	BitLockerPINRequired bool
+	// LinuxEscrowEnabled indicates if LUKS key escrow is enabled for Linux hosts.
+	LinuxEscrowEnabled bool
 }
 
 // DiskEncryptionSettingsAllEnabled returns the AND of the four per-platform
@@ -324,6 +330,18 @@ func (m *MDM) DiskEncryptionSettingsAllEnabled() bool {
 		m.MacOSSettings.EnableEscrowDiskEncryptionKey.Value &&
 		m.WindowsSettings.EnableDiskEncryption.Value &&
 		m.LinuxSettings.EnableEscrowDiskEncryptionKey.Value
+}
+
+// DiskEncryptionConfig returns the global effective per-platform disk
+// encryption settings.
+func (m *MDM) DiskEncryptionConfig() DiskEncryptionConfig {
+	return DiskEncryptionConfig{
+		MacOSEnabled:         m.MacOSSettings.EnableDiskEncryption.Value,
+		MacOSEscrowEnabled:   m.MacOSSettings.EnableEscrowDiskEncryptionKey.Value,
+		WindowsEnabled:       m.WindowsSettings.EnableDiskEncryption.Value,
+		BitLockerPINRequired: m.RequireBitLockerPIN.Value,
+		LinuxEscrowEnabled:   m.LinuxSettings.EnableEscrowDiskEncryptionKey.Value,
+	}
 }
 
 // normalizeDiskEncryptionSettings makes every serialization (API responses,

--- a/server/fleet/teams.go
+++ b/server/fleet/teams.go
@@ -512,6 +512,21 @@ func (t *TeamMDM) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// DiskEncryptionConfig returns the team's effective per-platform disk
+// encryption settings.
+func (t *TeamMDM) DiskEncryptionConfig() DiskEncryptionConfig {
+	if t == nil {
+		return DiskEncryptionConfig{}
+	}
+	return DiskEncryptionConfig{
+		MacOSEnabled:         t.MacOSSettings.EnableDiskEncryption.Value,
+		MacOSEscrowEnabled:   t.MacOSSettings.EnableEscrowDiskEncryptionKey.Value,
+		WindowsEnabled:       t.WindowsSettings.EnableDiskEncryption.Value,
+		BitLockerPINRequired: t.RequireBitLockerPIN,
+		LinuxEscrowEnabled:   t.LinuxSettings.EnableEscrowDiskEncryptionKey.Value,
+	}
+}
+
 // Copy returns a deep copy of the TeamMDM.
 func (t *TeamMDM) Copy() *TeamMDM {
 	if t == nil {

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -2386,14 +2386,16 @@ func (svc *Service) validateMDM(
 		invalid.Append("mdm.enable_turn_on_windows_mdm_manually", "Couldn't enable Turn on Windows MDM Manually, Windows MDM migration is also enabled. Please enable only one.")
 	}
 
-	if !mdm.EnableDiskEncryption.Value {
+	// the PIN requirement is a BitLocker feature, so it's judged against the
+	// Windows setting, not the all-platforms aggregate
+	if !mdm.WindowsSettings.EnableDiskEncryption.Value {
 		switch {
-		case !oldMdm.EnableDiskEncryption.Value && mdm.RequireBitLockerPIN.Value:
+		case !oldMdm.WindowsSettings.EnableDiskEncryption.Value && mdm.RequireBitLockerPIN.Value:
 			invalid.Append(
 				"mdm.windows_require_bitlocker_pin",
 				fleet.CantEnablePINRequiredIfDiskEncryptionEnabled,
 			)
-		case oldMdm.EnableDiskEncryption.Value && mdm.RequireBitLockerPIN.Value:
+		case oldMdm.WindowsSettings.EnableDiskEncryption.Value && mdm.RequireBitLockerPIN.Value:
 			invalid.Append(
 				"mdm.enable_disk_encryption",
 				fleet.CantDisableDiskEncryptionIfPINRequiredErrMsg,

--- a/server/service/appconfig_test.go
+++ b/server/service/appconfig_test.go
@@ -1473,12 +1473,16 @@ func TestMDMConfig(t *testing.T) {
 		{
 			name:        "try to disable disk encryption with TPM PIN enabled",
 			licenseTier: "premium",
+			// validateMDM sees the merged config, where a flat toggle write has
+			// already fanned out to the per-platform fields
 			oldMDM: fleet.MDM{
 				EnableDiskEncryption: optjson.SetBool(true),
+				WindowsSettings:      fleet.WindowsSettings{EnableDiskEncryption: optjson.SetBool(true)},
 				RequireBitLockerPIN:  optjson.SetBool(true),
 			},
 			newMDM: fleet.MDM{
 				EnableDiskEncryption: optjson.SetBool(false),
+				WindowsSettings:      fleet.WindowsSettings{EnableDiskEncryption: optjson.SetBool(false)},
 				RequireBitLockerPIN:  optjson.SetBool(true),
 			},
 			expectedError: fleet.CantDisableDiskEncryptionIfPINRequiredErrMsg,
@@ -1501,10 +1505,12 @@ func TestMDMConfig(t *testing.T) {
 			licenseTier: "premium",
 			oldMDM: fleet.MDM{
 				EnableDiskEncryption: optjson.SetBool(true),
+				WindowsSettings:      fleet.WindowsSettings{EnableDiskEncryption: optjson.SetBool(true)},
 				RequireBitLockerPIN:  optjson.SetBool(false),
 			},
 			newMDM: fleet.MDM{
 				EnableDiskEncryption: optjson.SetBool(false),
+				WindowsSettings:      fleet.WindowsSettings{EnableDiskEncryption: optjson.SetBool(false)},
 				RequireBitLockerPIN:  optjson.SetBool(true),
 			},
 			expectedError: fleet.CantDisableDiskEncryptionIfPINRequiredErrMsg,

--- a/server/service/devices_test.go
+++ b/server/service/devices_test.go
@@ -633,7 +633,10 @@ func TestTriggerLinuxDiskEncryptionEscrow(t *testing.T) {
 		require.ErrorContains(t, err, "Disk encryption is not enabled for this host's fleet.")
 
 		// valid platform, team, host disk is not encrypted or unknown encryption state
-		teamConfig = &fleet.TeamMDM{EnableDiskEncryption: true}
+		teamConfig = &fleet.TeamMDM{
+			EnableDiskEncryption: true,
+			LinuxSettings:        fleet.LinuxSettings{EnableEscrowDiskEncryptionKey: optjson.SetBool(true)},
+		}
 		err = svc.TriggerLinuxDiskEncryptionEscrow(ctx, host)
 		require.ErrorContains(t, err, "Host's disk is not encrypted. Please encrypt your disk first.")
 		host.DiskEncryptionEnabled = ptr.Bool(false)
@@ -659,7 +662,10 @@ func TestTriggerLinuxDiskEncryptionEscrow(t *testing.T) {
 			return false
 		}
 		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
-			return &fleet.AppConfig{MDM: fleet.MDM{EnableDiskEncryption: optjson.SetBool(true)}}, nil
+			return &fleet.AppConfig{MDM: fleet.MDM{
+				EnableDiskEncryption: optjson.SetBool(true),
+				LinuxSettings:        fleet.LinuxSettings{EnableEscrowDiskEncryptionKey: optjson.SetBool(true)},
+			}}, nil
 		}
 		ds.GetHostOrbitInfoFunc = func(ctx context.Context, id uint) (*fleet.HostOrbitInfo, error) {
 			return &fleet.HostOrbitInfo{Version: "1.36.0", DesktopVersion: ptr.String("42")}, nil

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -2023,7 +2023,7 @@ func (svc *Service) getHostDetails(ctx context.Context, host *fleet.Host, opts f
 		if err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "get host disk encryption enabled setting")
 		}
-		if diskEncryptionConfig.Enabled {
+		if diskEncryptionConfig.LinuxEscrowEnabled {
 			status, err := svc.LinuxHostDiskEncryptionStatus(ctx, *host)
 			if err != nil {
 				return nil, ctxerr.Wrap(ctx, err, "get host disk encryption status")

--- a/server/service/hosts_test.go
+++ b/server/service/hosts_test.go
@@ -5002,13 +5002,25 @@ func TestSetDiskEncryptionNotifications(t *testing.T) {
 				ctx = capabilities.NewContext(ctx, &r)
 			}
 
+			// "configured" means configured for every platform; per-platform
+			// gating has its own cases below the table-driven run
+			var diskEncryption fleet.DiskEncryptionConfig
+			if tt.diskEncryptionConfigured {
+				diskEncryption = fleet.DiskEncryptionConfig{
+					MacOSEnabled:       true,
+					MacOSEscrowEnabled: true,
+					WindowsEnabled:     true,
+					LinuxEscrowEnabled: true,
+				}
+			}
+
 			notifs := &fleet.OrbitConfigNotifications{}
 			err := svc.setDiskEncryptionNotifications(
 				ctx,
 				notifs,
 				tt.host,
 				tt.appConfig,
-				tt.diskEncryptionConfigured,
+				diskEncryption,
 				tt.isConnectedToFleetMDM,
 				tt.mdmInfo,
 			)
@@ -5021,6 +5033,47 @@ func TestSetDiskEncryptionNotifications(t *testing.T) {
 			require.Equal(t, tt.expectedNotifications.RotateDiskEncryptionKey, notifs.RotateDiskEncryptionKey)
 		})
 	}
+
+	t.Run("notifications follow the host platform's setting, not the aggregate", func(t *testing.T) {
+		appConfig := &fleet.AppConfig{MDM: fleet.MDM{EnabledAndConfigured: true, WindowsEnabledAndConfigured: true}}
+		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+			return appConfig, nil
+		}
+		ds.GetHostDiskEncryptionKeyFunc = func(ctx context.Context, id uint) (*fleet.HostDiskEncryptionKey, error) {
+			return nil, newNotFoundError()
+		}
+		r := http.Request{
+			Header: http.Header{fleet.CapabilitiesHeader: []string{string(fleet.CapabilityEscrowBuddy)}},
+		}
+		ctx := capabilities.NewContext(ctx, &r)
+
+		windowsHost := &fleet.Host{ID: 1, Platform: "windows", DiskEncryptionEnabled: new(false), OsqueryHostID: new("foo")}
+		macHost := &fleet.Host{ID: 2, Platform: "darwin", OsqueryHostID: new("foo")}
+		mdmInfo := &fleet.HostMDM{IsServer: false}
+
+		// only Windows configured: the Windows host is notified even though the
+		// aggregate (AND of the four settings) is off
+		notifs := &fleet.OrbitConfigNotifications{}
+		err := svc.setDiskEncryptionNotifications(ctx, notifs, windowsHost, appConfig,
+			fleet.DiskEncryptionConfig{WindowsEnabled: true}, true, mdmInfo)
+		require.NoError(t, err)
+		require.True(t, notifs.EnforceBitLockerEncryption)
+
+		// only macOS configured: the Windows host is not notified
+		notifs = &fleet.OrbitConfigNotifications{}
+		err = svc.setDiskEncryptionNotifications(ctx, notifs, windowsHost, appConfig,
+			fleet.DiskEncryptionConfig{MacOSEnabled: true, MacOSEscrowEnabled: true}, true, mdmInfo)
+		require.NoError(t, err)
+		require.False(t, notifs.EnforceBitLockerEncryption)
+
+		// only Windows configured: the macOS host's key-fetch path is skipped
+		// entirely, so no rotation is requested
+		notifs = &fleet.OrbitConfigNotifications{}
+		err = svc.setDiskEncryptionNotifications(ctx, notifs, macHost, appConfig,
+			fleet.DiskEncryptionConfig{WindowsEnabled: true}, true, mdmInfo)
+		require.NoError(t, err)
+		require.False(t, notifs.RotateDiskEncryptionKey)
+	})
 }
 
 func TestGetHostDetailsExcludeSoftwareFlag(t *testing.T) {

--- a/server/service/linux_mdm.go
+++ b/server/service/linux_mdm.go
@@ -53,7 +53,7 @@ func (svc *Service) GetMDMLinuxProfilesSummary(ctx context.Context, teamId *uint
 	diskEncryptionConfig, err := svc.ds.GetConfigEnableDiskEncryption(ctx, teamId)
 	if err != nil {
 		return summary, ctxerr.Wrap(ctx, err)
-	} else if !diskEncryptionConfig.Enabled {
+	} else if !diskEncryptionConfig.LinuxEscrowEnabled {
 		return summary, nil
 	}
 

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -4113,8 +4113,9 @@ func (svc *Service) UploadMDMAppleAPNSCert(ctx context.Context, cert io.ReadSeek
 		return nil
 	}
 
-	// Enable FileVault escrow if no-team already has disk encryption enforced
-	if appCfg.MDM.EnableDiskEncryption.Value {
+	// Enable FileVault escrow if no-team already has a macOS disk encryption
+	// setting on: the FileVault profile covers enforcement and escrow as a pair
+	if appCfg.MDM.MacOSSettings.EnableDiskEncryption.Value || appCfg.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey.Value {
 		// Delete the file vault profile first, to ensure we get updated keys.
 		if err := svc.EnterpriseOverrides.MDMAppleDisableFileVaultAndEscrow(ctx, nil); err != nil && !fleet.IsNotFound(err) {
 			return ctxerr.Wrap(ctx, err, "delete no-team FileVault profile")
@@ -4137,7 +4138,7 @@ func (svc *Service) UploadMDMAppleAPNSCert(ctx context.Context, cert io.ReadSeek
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "retrieving encryption enforcement status for team")
 		}
-		if diskEncryptionConfig.Enabled {
+		if diskEncryptionConfig.MacOSEnabled || diskEncryptionConfig.MacOSEscrowEnabled {
 			// Delete the file vault profile first, to ensure we get updated keys.
 			if err := svc.EnterpriseOverrides.MDMAppleDisableFileVaultAndEscrow(ctx, &team.ID); err != nil && !fleet.IsNotFound(err) {
 				return ctxerr.Wrap(ctx, err, "delete team FileVault profile")

--- a/server/service/mdm_test.go
+++ b/server/service/mdm_test.go
@@ -1293,7 +1293,12 @@ func TestGetMDMDiskEncryptionSummary(t *testing.T) {
 		return fleet.MDMLinuxDiskEncryptionSummary{Verified: 1, ActionRequired: 2, Failed: 3}, nil
 	}
 	ds.GetConfigEnableDiskEncryptionFunc = func(ctx context.Context, teamID *uint) (fleet.DiskEncryptionConfig, error) {
-		return fleet.DiskEncryptionConfig{Enabled: true}, nil
+		return fleet.DiskEncryptionConfig{
+			MacOSEnabled:       true,
+			MacOSEscrowEnabled: true,
+			WindowsEnabled:     true,
+			LinuxEscrowEnabled: true,
+		}, nil
 	}
 
 	// Test that the summary properly combines the results of the two methods
@@ -3961,10 +3966,10 @@ func TestUploadMDMAppleAPNSCertReplacesFileVaultProfile(t *testing.T) {
 
 	ds.GetConfigEnableDiskEncryptionFunc = func(ctx context.Context, teamID *uint) (fleet.DiskEncryptionConfig, error) {
 		if *teamID == 1 {
-			return fleet.DiskEncryptionConfig{Enabled: true}, nil
+			return fleet.DiskEncryptionConfig{MacOSEnabled: true, MacOSEscrowEnabled: true}, nil
 		}
 
-		return fleet.DiskEncryptionConfig{Enabled: false}, nil
+		return fleet.DiskEncryptionConfig{}, nil
 	}
 
 	deleteCalls := uint(0)

--- a/server/service/mdm_test.go
+++ b/server/service/mdm_test.go
@@ -3940,6 +3940,10 @@ func TestUploadMDMAppleAPNSCertReplacesFileVaultProfile(t *testing.T) {
 			MDM: fleet.MDM{
 				EnabledAndConfigured: false,
 				EnableDiskEncryption: optjson.SetBool(true),
+				MacOSSettings: fleet.MacOSSettings{
+					EnableDiskEncryption:          optjson.SetBool(true),
+					EnableEscrowDiskEncryptionKey: optjson.SetBool(true),
+				},
 			},
 		}, nil
 	}

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -753,7 +753,7 @@ func (svc *Service) GetOrbitConfig(ctx context.Context) (fleet.OrbitConfig, erro
 			&notifs,
 			host,
 			appConfig,
-			mdmConfig.EnableDiskEncryption,
+			mdmConfig.DiskEncryptionConfig(),
 			isConnectedToFleetMDM,
 			mdmInfo,
 		)
@@ -834,7 +834,7 @@ func (svc *Service) GetOrbitConfig(ctx context.Context) (fleet.OrbitConfig, erro
 		&notifs,
 		host,
 		appConfig,
-		appConfig.MDM.EnableDiskEncryption.Value,
+		appConfig.MDM.DiskEncryptionConfig(),
 		isConnectedToFleetMDM,
 		mdmInfo,
 	)
@@ -959,15 +959,25 @@ func (svc *Service) setDiskEncryptionNotifications(
 	notifs *fleet.OrbitConfigNotifications,
 	host *fleet.Host,
 	appConfig *fleet.AppConfig,
-	diskEncryptionConfigured bool,
+	diskEncryption fleet.DiskEncryptionConfig,
 	isConnectedToFleetMDM bool,
 	mdmInfo *fleet.HostMDM,
 ) error {
+	// each platform's notifications are gated on that platform's own settings;
+	// the FileVault/Escrow Buddy flow treats the macOS pair as one unit until
+	// the per-payload split ships
+	var platformConfigured bool
+	switch host.FleetPlatform() {
+	case "darwin":
+		platformConfigured = diskEncryption.MacOSEnabled || diskEncryption.MacOSEscrowEnabled
+	case "windows":
+		platformConfigured = diskEncryption.WindowsEnabled
+	}
 	anyMDMConfigured := appConfig.MDM.EnabledAndConfigured || appConfig.MDM.WindowsEnabledAndConfigured
 	if !anyMDMConfigured ||
 		!isConnectedToFleetMDM ||
 		!host.IsOsqueryEnrolled() ||
-		!diskEncryptionConfigured {
+		!platformConfigured {
 		return nil
 	}
 

--- a/server/service/orbit_test.go
+++ b/server/service/orbit_test.go
@@ -191,6 +191,7 @@ func TestOrbitLUKSDataSave(t *testing.T) {
 		svc, ctx := newTestService(t, ds, nil, nil, opts)
 		host := &fleet.Host{
 			OsqueryHostID: ptr.String("test"),
+			Platform:      "ubuntu",
 			ID:            1,
 		}
 		ctx = test.HostContext(ctx, host)
@@ -199,6 +200,7 @@ func TestOrbitLUKSDataSave(t *testing.T) {
 			return &fleet.AppConfig{
 				MDM: fleet.MDM{
 					EnableDiskEncryption: optjson.SetBool(true),
+					LinuxSettings:        fleet.LinuxSettings{EnableEscrowDiskEncryptionKey: optjson.SetBool(true)},
 				},
 			}, nil
 		}
@@ -279,6 +281,7 @@ func TestOrbitLUKSDataSave(t *testing.T) {
 		svc, ctx := newTestService(t, ds, nil, nil, opts)
 		host := &fleet.Host{
 			OsqueryHostID: new("test"),
+			Platform:      "ubuntu",
 			ID:            1,
 		}
 		ctx = test.HostContext(ctx, host)
@@ -287,6 +290,7 @@ func TestOrbitLUKSDataSave(t *testing.T) {
 			return &fleet.AppConfig{
 				MDM: fleet.MDM{
 					EnableDiskEncryption: optjson.SetBool(true),
+					LinuxSettings:        fleet.LinuxSettings{EnableEscrowDiskEncryptionKey: optjson.SetBool(true)},
 				},
 			}, nil
 		}
@@ -352,6 +356,7 @@ func TestOrbitLUKSDataSave(t *testing.T) {
 		license := &fleet.LicenseInfo{Tier: fleet.TierPremium}
 		host := &fleet.Host{
 			OsqueryHostID: ptr.String("test"),
+			Platform:      "ubuntu",
 			ID:            1,
 		}
 
@@ -359,6 +364,7 @@ func TestOrbitLUKSDataSave(t *testing.T) {
 			return &fleet.AppConfig{
 				MDM: fleet.MDM{
 					EnableDiskEncryption: optjson.SetBool(true),
+					LinuxSettings:        fleet.LinuxSettings{EnableEscrowDiskEncryptionKey: optjson.SetBool(true)},
 				},
 			}, nil
 		}

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -816,7 +816,10 @@ func (svc *Service) loadHostDetailQueryConfig(ctx context.Context, host *fleet.H
 	}
 
 	var mdmTeamConfig *fleet.TeamMDM
-	if appConfig != nil && (appConfig.MDM.EnabledAndConfigured || appConfig.MDM.WindowsEnabledAndConfigured) && host.TeamID != nil {
+	// LUKS key escrow needs no MDM, so Linux hosts need their fleet's config
+	// even when no MDM platform is configured
+	if appConfig != nil && host.TeamID != nil &&
+		(appConfig.MDM.EnabledAndConfigured || appConfig.MDM.WindowsEnabledAndConfigured || host.FleetPlatform() == "linux") {
 		mdmTeamConfig, err = svc.ds.TeamMDMConfig(ctx, *host.TeamID)
 		if err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "reading MDM Team Config")

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -1544,7 +1544,7 @@ func TestHostDetailQueriesTeamBitLockerPIN(t *testing.T) {
 	}
 
 	globalRequiresPIN := false
-	teamMDMConfig := fleet.TeamMDM{EnableDiskEncryption: true, RequireBitLockerPIN: true}
+	teamMDMConfig := fleet.TeamMDM{EnableDiskEncryption: true, WindowsSettings: fleet.WindowsSettings{EnableDiskEncryption: optjson.SetBool(true)}, RequireBitLockerPIN: true}
 
 	ds := new(mock.Store)
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
@@ -1552,6 +1552,7 @@ func TestHostDetailQueriesTeamBitLockerPIN(t *testing.T) {
 		appConfig.MDM.WindowsEnabledAndConfigured = true // Apple MDM stays unconfigured
 		if globalRequiresPIN {
 			appConfig.MDM.EnableDiskEncryption = optjson.SetBool(true)
+			appConfig.MDM.WindowsSettings.EnableDiskEncryption = optjson.SetBool(true)
 			appConfig.MDM.RequireBitLockerPIN = optjson.SetBool(true)
 		}
 		return appConfig, nil
@@ -1589,7 +1590,7 @@ func TestHostDetailQueriesTeamBitLockerPIN(t *testing.T) {
 
 	// The reverse: the global config requiring a PIN must not leak to a host whose team does not.
 	globalRequiresPIN = true
-	teamMDMConfig = fleet.TeamMDM{EnableDiskEncryption: true}
+	teamMDMConfig = fleet.TeamMDM{EnableDiskEncryption: true, WindowsSettings: fleet.WindowsSettings{EnableDiskEncryption: optjson.SetBool(true)}}
 	queries, _, err = svc.detailQueriesForHost(t.Context(), &host)
 	require.NoError(t, err)
 	for _, queryName := range pinQueryNames {

--- a/server/service/osquery_utils/disk_encryption_helpers.go
+++ b/server/service/osquery_utils/disk_encryption_helpers.go
@@ -8,8 +8,11 @@ import (
 )
 
 // IsDiskEncryptionEnabledForHost checks if disk encryption is enabled for the
-// host team or globally if the host is not assigned to a team.
+// host's platform, in the host's team or globally if the host is not assigned
+// to a team.
 func IsDiskEncryptionEnabledForHost(ctx context.Context, logger *slog.Logger, ds fleet.Datastore, host *fleet.Host) bool {
+	var cfg fleet.DiskEncryptionConfig
+
 	// team
 	if host.TeamID != nil {
 		teamMDM, err := ds.TeamMDMConfig(ctx, *host.TeamID)
@@ -24,17 +27,30 @@ func IsDiskEncryptionEnabledForHost(ctx context.Context, logger *slog.Logger, ds
 		if teamMDM == nil {
 			return false
 		}
-		return teamMDM.EnableDiskEncryption
+		cfg = teamMDM.DiskEncryptionConfig()
+	} else {
+		// global
+		appConfig, err := ds.AppConfig(ctx)
+		if err != nil {
+			logger.DebugContext(ctx, "failed to get app config for disk encryption check",
+				"host_id", host.ID,
+				"err", err,
+			)
+			return false
+		}
+		cfg = appConfig.MDM.DiskEncryptionConfig()
 	}
 
-	// global
-	appConfig, err := ds.AppConfig(ctx)
-	if err != nil {
-		logger.DebugContext(ctx, "failed to get app config for disk encryption check",
-			"host_id", host.ID,
-			"err", err,
-		)
+	// the FileVault flow treats the macOS pair as one unit until the
+	// per-payload split ships
+	switch host.FleetPlatform() {
+	case "darwin":
+		return cfg.MacOSEnabled || cfg.MacOSEscrowEnabled
+	case "windows":
+		return cfg.WindowsEnabled
+	case "linux":
+		return cfg.LinuxEscrowEnabled
+	default:
 		return false
 	}
-	return appConfig.MDM.EnableDiskEncryption.Value
 }

--- a/server/service/osquery_utils/disk_encryption_helpers_test.go
+++ b/server/service/osquery_utils/disk_encryption_helpers_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/fleetdm/fleet/v4/pkg/optjson"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mock"
-	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/stretchr/testify/require"
 )
 
@@ -16,105 +15,126 @@ func TestIsDiskEncryptionEnabledForHost(t *testing.T) {
 	ctx := context.Background()
 	logger := slog.New(slog.DiscardHandler)
 
-	t.Run("team has disk encryption enabled", func(t *testing.T) {
+	// a mixed state: macOS and Windows on, Linux off
+	mixedTeamMDM := &fleet.TeamMDM{
+		MacOSSettings: fleet.MacOSSettings{
+			EnableDiskEncryption:          optjson.SetBool(true),
+			EnableEscrowDiskEncryptionKey: optjson.SetBool(true),
+		},
+		WindowsSettings: fleet.WindowsSettings{
+			EnableDiskEncryption: optjson.SetBool(true),
+		},
+		LinuxSettings: fleet.LinuxSettings{
+			EnableEscrowDiskEncryptionKey: optjson.SetBool(false),
+		},
+	}
+	mixedGlobalMDM := fleet.MDM{
+		MacOSSettings: fleet.MacOSSettings{
+			EnableDiskEncryption:          optjson.SetBool(true),
+			EnableEscrowDiskEncryptionKey: optjson.SetBool(true),
+		},
+		WindowsSettings: fleet.WindowsSettings{
+			EnableDiskEncryption: optjson.SetBool(true),
+		},
+		LinuxSettings: fleet.LinuxSettings{
+			EnableEscrowDiskEncryptionKey: optjson.SetBool(false),
+		},
+	}
+
+	for _, tc := range []struct {
+		name     string
+		platform string
+		want     bool
+	}{
+		{"darwin follows the macOS pair", "darwin", true},
+		{"windows follows the windows setting", "windows", true},
+		{"linux follows the linux escrow setting", "ubuntu", false},
+		{"unknown platform is never enabled", "chrome", false},
+	} {
+		t.Run("team "+tc.name, func(t *testing.T) {
+			ds := new(mock.Store)
+			host := &fleet.Host{ID: 1, TeamID: new(uint(1)), Platform: tc.platform}
+
+			ds.TeamMDMConfigFunc = func(ctx context.Context, teamID uint) (*fleet.TeamMDM, error) {
+				require.Equal(t, uint(1), teamID)
+				return mixedTeamMDM, nil
+			}
+
+			require.Equal(t, tc.want, IsDiskEncryptionEnabledForHost(ctx, logger, ds, host))
+			require.True(t, ds.TeamMDMConfigFuncInvoked)
+			require.False(t, ds.AppConfigFuncInvoked, "Global config should not be checked when host is on a team")
+		})
+
+		t.Run("global "+tc.name, func(t *testing.T) {
+			ds := new(mock.Store)
+			host := &fleet.Host{ID: 1, TeamID: nil, Platform: tc.platform}
+
+			ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+				return &fleet.AppConfig{MDM: mixedGlobalMDM}, nil
+			}
+
+			require.Equal(t, tc.want, IsDiskEncryptionEnabledForHost(ctx, logger, ds, host))
+			require.True(t, ds.AppConfigFuncInvoked)
+		})
+	}
+
+	t.Run("macOS pair: escrow alone is enough", func(t *testing.T) {
 		ds := new(mock.Store)
-		host := &fleet.Host{ID: 1, TeamID: ptr.Uint(1)}
+		host := &fleet.Host{ID: 1, TeamID: new(uint(1)), Platform: "darwin"}
 
 		ds.TeamMDMConfigFunc = func(ctx context.Context, teamID uint) (*fleet.TeamMDM, error) {
-			require.Equal(t, uint(1), teamID)
 			return &fleet.TeamMDM{
-				EnableDiskEncryption: true,
+				MacOSSettings: fleet.MacOSSettings{
+					EnableEscrowDiskEncryptionKey: optjson.SetBool(true),
+				},
 			}, nil
 		}
 
-		result := IsDiskEncryptionEnabledForHost(ctx, logger, ds, host)
-		require.True(t, result)
-		require.True(t, ds.TeamMDMConfigFuncInvoked)
+		require.True(t, IsDiskEncryptionEnabledForHost(ctx, logger, ds, host))
 	})
 
 	t.Run("team has disk encryption disabled", func(t *testing.T) {
 		ds := new(mock.Store)
-		host := &fleet.Host{ID: 1, TeamID: ptr.Uint(1)}
+		host := &fleet.Host{ID: 1, TeamID: new(uint(1)), Platform: "darwin"}
 
 		ds.TeamMDMConfigFunc = func(ctx context.Context, teamID uint) (*fleet.TeamMDM, error) {
-			return &fleet.TeamMDM{
-				EnableDiskEncryption: false,
-			}, nil
+			return &fleet.TeamMDM{}, nil
 		}
 
-		result := IsDiskEncryptionEnabledForHost(ctx, logger, ds, host)
-		require.False(t, result)
+		require.False(t, IsDiskEncryptionEnabledForHost(ctx, logger, ds, host))
 		require.True(t, ds.TeamMDMConfigFuncInvoked)
 	})
 
-	t.Run("team has disk encryption disabled even when global is enabled", func(t *testing.T) {
+	t.Run("nil team config returns false", func(t *testing.T) {
 		ds := new(mock.Store)
-		host := &fleet.Host{ID: 1, TeamID: ptr.Uint(1)}
+		host := &fleet.Host{ID: 1, TeamID: new(uint(1)), Platform: "darwin"}
 
 		ds.TeamMDMConfigFunc = func(ctx context.Context, teamID uint) (*fleet.TeamMDM, error) {
-			return &fleet.TeamMDM{
-				EnableDiskEncryption: false,
-			}, nil
+			return nil, nil
 		}
 
-		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
-			require.Fail(t, "AppConfig should not be called when host has a team")
-			return &fleet.AppConfig{
-				MDM: fleet.MDM{
-					EnableDiskEncryption: optjson.SetBool(true),
-				},
-			}, nil
-		}
-
-		result := IsDiskEncryptionEnabledForHost(ctx, logger, ds, host)
-		require.False(t, result, "Team setting should take precedence over global setting")
-		require.True(t, ds.TeamMDMConfigFuncInvoked)
-		require.False(t, ds.AppConfigFuncInvoked, "Global config should not be checked when host is on a team")
-	})
-
-	t.Run("global disk encryption enabled (no team)", func(t *testing.T) {
-		ds := new(mock.Store)
-		host := &fleet.Host{ID: 1, TeamID: nil}
-
-		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
-			return &fleet.AppConfig{
-				MDM: fleet.MDM{
-					EnableDiskEncryption: optjson.SetBool(true),
-				},
-			}, nil
-		}
-
-		result := IsDiskEncryptionEnabledForHost(ctx, logger, ds, host)
-		require.True(t, result)
-		require.True(t, ds.AppConfigFuncInvoked)
-	})
-
-	t.Run("global disk encryption disabled (no team)", func(t *testing.T) {
-		ds := new(mock.Store)
-		host := &fleet.Host{ID: 1, TeamID: nil}
-
-		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
-			return &fleet.AppConfig{
-				MDM: fleet.MDM{
-					EnableDiskEncryption: optjson.SetBool(false),
-				},
-			}, nil
-		}
-
-		result := IsDiskEncryptionEnabledForHost(ctx, logger, ds, host)
-		require.False(t, result)
-		require.True(t, ds.AppConfigFuncInvoked)
+		require.False(t, IsDiskEncryptionEnabledForHost(ctx, logger, ds, host))
 	})
 
 	t.Run("error getting team config returns false", func(t *testing.T) {
 		ds := new(mock.Store)
-		host := &fleet.Host{ID: 1, TeamID: ptr.Uint(1)}
+		host := &fleet.Host{ID: 1, TeamID: new(uint(1)), Platform: "darwin"}
 
 		ds.TeamMDMConfigFunc = func(ctx context.Context, teamID uint) (*fleet.TeamMDM, error) {
 			return nil, &fleet.Error{Message: "db error"}
 		}
 
-		result := IsDiskEncryptionEnabledForHost(ctx, logger, ds, host)
-		require.False(t, result)
+		require.False(t, IsDiskEncryptionEnabledForHost(ctx, logger, ds, host))
+	})
+
+	t.Run("error getting app config returns false", func(t *testing.T) {
+		ds := new(mock.Store)
+		host := &fleet.Host{ID: 1, TeamID: nil, Platform: "darwin"}
+
+		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+			return nil, &fleet.Error{Message: "db error"}
+		}
+
+		require.False(t, IsDiskEncryptionEnabledForHost(ctx, logger, ds, host))
 	})
 }

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -3728,7 +3728,12 @@ func GetDetailQueries(
 		generatedMap["conditional_access_microsoft_device_id_windows"] = windowsEntraIDDetails
 	}
 
-	if appConfig != nil && appConfig.MDM.LinuxSettings.EnableEscrowDiskEncryptionKey.Value {
+	// the host fleet's setting is effective when the host is on a fleet
+	luksEscrowEnabled := appConfig != nil && appConfig.MDM.LinuxSettings.EnableEscrowDiskEncryptionKey.Value
+	if teamMDMConfig != nil {
+		luksEscrowEnabled = teamMDMConfig.LinuxSettings.EnableEscrowDiskEncryptionKey.Value
+	}
+	if luksEscrowEnabled {
 		luksVerifyQuery.DirectIngestFunc = luksVerifyQueryIngester(func(privateKey string) func(string) (string, error) {
 			return func(encrypted string) (string, error) {
 				return mdm.DecodeAndDecrypt(encrypted, privateKey)

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -3705,13 +3705,13 @@ func GetDetailQueries(
 
 		// Add TPM PIN Queries iff Win MDM is enabled and ready to go
 		if appConfig.MDM.WindowsEnabledAndConfigured {
-			enableDiskEncryption := appConfig.MDM.EnableDiskEncryption.Value
+			enableDiskEncryption := appConfig.MDM.WindowsSettings.EnableDiskEncryption.Value
 			requireTPMPin := appConfig.MDM.RequireBitLockerPIN.Value
 
 			// If the host is part of a team, we need to look at the related team config
 			// instead of the App config ...
 			if teamMDMConfig != nil {
-				enableDiskEncryption = teamMDMConfig.EnableDiskEncryption
+				enableDiskEncryption = teamMDMConfig.WindowsSettings.EnableDiskEncryption.Value
 				requireTPMPin = teamMDMConfig.RequireBitLockerPIN
 			}
 
@@ -3728,7 +3728,7 @@ func GetDetailQueries(
 		generatedMap["conditional_access_microsoft_device_id_windows"] = windowsEntraIDDetails
 	}
 
-	if appConfig != nil && appConfig.MDM.EnableDiskEncryption.Value {
+	if appConfig != nil && appConfig.MDM.LinuxSettings.EnableEscrowDiskEncryptionKey.Value {
 		luksVerifyQuery.DirectIngestFunc = luksVerifyQueryIngester(func(privateKey string) func(string) (string, error) {
 			return func(encrypted string) (string, error) {
 				return mdm.DecodeAndDecrypt(encrypted, privateKey)

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -638,6 +638,9 @@ func TestGetDetailQueries(t *testing.T) {
 				MDM: fleet.MDM{
 					WindowsEnabledAndConfigured: true,
 					EnableDiskEncryption:        optjson.SetBool(true),
+					WindowsSettings: fleet.WindowsSettings{
+						EnableDiskEncryption: optjson.SetBool(true),
+					},
 				},
 			},
 		},
@@ -647,7 +650,28 @@ func TestGetDetailQueries(t *testing.T) {
 				MDM: fleet.MDM{
 					WindowsEnabledAndConfigured: true,
 					EnableDiskEncryption:        optjson.SetBool(true),
-					RequireBitLockerPIN:         optjson.SetBool(true),
+					WindowsSettings: fleet.WindowsSettings{
+						EnableDiskEncryption: optjson.SetBool(true),
+					},
+					RequireBitLockerPIN: optjson.SetBool(true),
+				},
+			},
+			want: maps.Keys(tpmPINQueries),
+		},
+		{
+			name: "TPM PIN queries follow the windows setting, not the aggregate",
+			ac: fleet.AppConfig{
+				MDM: fleet.MDM{
+					WindowsEnabledAndConfigured: true,
+					// aggregate off because linux escrow is off, but windows on
+					EnableDiskEncryption: optjson.SetBool(false),
+					WindowsSettings: fleet.WindowsSettings{
+						EnableDiskEncryption: optjson.SetBool(true),
+					},
+					LinuxSettings: fleet.LinuxSettings{
+						EnableEscrowDiskEncryptionKey: optjson.SetBool(false),
+					},
+					RequireBitLockerPIN: optjson.SetBool(true),
 				},
 			},
 			want: maps.Keys(tpmPINQueries),
@@ -2457,12 +2481,16 @@ func TestDirectIngestDiskEncryptionKeyDarwin(t *testing.T) {
 	ds := new(mock.Store)
 	ctx := t.Context()
 	logger := slog.New(slog.DiscardHandler)
-	host := &fleet.Host{ID: 1}
+	host := &fleet.Host{ID: 1, Platform: "darwin"}
 
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
 		return &fleet.AppConfig{
 			MDM: fleet.MDM{
 				EnableDiskEncryption: optjson.SetBool(true),
+				MacOSSettings: fleet.MacOSSettings{
+					EnableDiskEncryption:          optjson.SetBool(true),
+					EnableEscrowDiskEncryptionKey: optjson.SetBool(true),
+				},
 			},
 		}, nil
 	}

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -689,6 +689,35 @@ func TestGetDetailQueries(t *testing.T) {
 	}
 }
 
+func TestLUKSVerifyQueryFollowsEffectiveLinuxEscrowSetting(t *testing.T) {
+	globalOn := &fleet.AppConfig{MDM: fleet.MDM{
+		LinuxSettings: fleet.LinuxSettings{EnableEscrowDiskEncryptionKey: optjson.SetBool(true)},
+	}}
+	globalOff := &fleet.AppConfig{MDM: fleet.MDM{
+		LinuxSettings: fleet.LinuxSettings{EnableEscrowDiskEncryptionKey: optjson.SetBool(false)},
+	}}
+	teamOn := &fleet.TeamMDM{LinuxSettings: fleet.LinuxSettings{EnableEscrowDiskEncryptionKey: optjson.SetBool(true)}}
+	teamOff := &fleet.TeamMDM{LinuxSettings: fleet.LinuxSettings{EnableEscrowDiskEncryptionKey: optjson.SetBool(false)}}
+
+	for _, tc := range []struct {
+		name string
+		ac   *fleet.AppConfig
+		team *fleet.TeamMDM
+		want bool
+	}{
+		{"global on, no team", globalOn, nil, true},
+		{"global off, no team", globalOff, nil, false},
+		{"the team setting overrides global on", globalOn, teamOff, false},
+		{"the team setting overrides global off", globalOff, teamOn, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := GetDetailQueries(t.Context(), config.FleetConfig{}, tc.ac, nil, Integrations{}, tc.team)
+			_, ok := got["luks_verify"]
+			require.Equal(t, tc.want, ok)
+		})
+	}
+}
+
 func TestDiskSpaceDarwinLegacyQueryExcludesGigsAll(t *testing.T) {
 	queries := GetDetailQueries(t.Context(), config.FleetConfig{}, nil, nil, Integrations{}, nil)
 


### PR DESCRIPTION
**Related issue:** #51258

Third PR of #51258 (story #48654): reads become per-platform. Stacked on #51777 (settings model). Follow-up PRs: precedence/conflict write semantics, `POST /disk_encryption` reshape, `edited_disk_encryption_settings` activity.

- Every disk encryption reader now consults its own platform's setting instead of the combined (AND) value: BitLocker enforcement/summaries and the TPM PIN queries read `windows_settings.enable_disk_encryption`, LUKS escrow paths read `linux_settings.enable_escrow_disk_encryption_key`, FileVault reads use the macOS pair (either setting on = profile on; per-payload conditionality is #51259). `DiskEncryptionConfig` carries the five per-platform values, and the orbit notifications and host key-escrow ingestion gate on the host's platform.
- This is the first behavior-changing PR of the stack: a mixed configuration now enforces per-platform. Example: `windows_settings.enable_disk_encryption: true` with everything else off previously enforced nothing (combined value false); now Windows hosts get BitLocker enforcement, key escrow, and status reporting while macOS/Linux stay untouched. Uniform configurations (everything the UI or the flat toggle produces, and everything the #51701 migration produces) behave exactly as before.
- The BitLocker PIN invariants ("can't require PIN without disk encryption") are judged against the Windows setting, as promised on the #51777 review thread.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disk-encryption status and enforcement now correctly follow each platform’s settings for macOS, Windows, and Linux.
  * Linux host details, escrow summaries, and verification queries now appear only when Linux key escrow is enabled.
  * Windows BitLocker PIN validation and notifications now use Windows-specific encryption settings.
  * macOS FileVault escrow handling and notifications now recognize encryption and escrow settings independently.
  * Improved accuracy for team-level and global disk-encryption configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->