### PR TITLE
Apply iOS and iPadOS update settings when GitOps creates a fleet

### DIFF
--- a/changes/51773-gitops-team-create-ios-updates
+++ b/changes/51773-gitops-team-create-ios-updates
@@ -1,0 +1,1 @@
+- Fixed `fleetctl gitops` silently dropping `ios_updates` and `ipados_updates` when it creates a new fleet. Previously these were only applied on a second run, once the fleet already existed.

--- a/changes/51773-gitops-team-create-ios-updates
+++ b/changes/51773-gitops-team-create-ios-updates
@@ -1,1 +1,1 @@
-- Fixed `fleetctl gitops` silently dropping `ios_updates` and `ipados_updates` when it creates a new fleet. Previously these were only applied on a second run, once the fleet already existed.
+- Fixed `fleetctl gitops` silently dropping `ios_updates` and `ipados_updates` when it creates a new fleet.

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -1735,6 +1735,8 @@ func (svc *Service) createTeamFromSpec(
 				EnableRecoveryLockPassword: spec.MDM.EnableRecoveryLockPassword.Value,
 				RequireBitLockerPIN:        spec.MDM.RequireBitLockerPIN.Value,
 				MacOSUpdates:               spec.MDM.MacOSUpdates,
+				IOSUpdates:                 spec.MDM.IOSUpdates,
+				IPadOSUpdates:              spec.MDM.IPadOSUpdates,
 				WindowsUpdates:             spec.MDM.WindowsUpdates,
 				MacOSSettings:              macOSSettings,
 				MacOSSetup:                 macOSSetup,

--- a/ee/server/service/teams_test.go
+++ b/ee/server/service/teams_test.go
@@ -1990,3 +1990,73 @@ func TestApplyTeamSpecsOSUpdatesValidation(t *testing.T) {
 		})
 	}
 }
+
+// GitOps creating a brand-new team has to persist the Apple OS update settings
+// the same way editing an existing one does; they were previously dropped.
+func TestApplyTeamSpecsCreateAppliesAppleOSUpdates(t *testing.T) {
+	ds := new(mock.Store)
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return &fleet.AppConfig{}, nil
+	}
+	ds.TeamByNameFunc = func(ctx context.Context, name string) (*fleet.Team, error) {
+		return nil, &notFoundError{}
+	}
+	ds.TeamConflictsWithNameFunc = func(ctx context.Context, name string, excludeID uint) (*fleet.Team, error) {
+		return nil, nil
+	}
+	ds.IsEnrollSecretAvailableFunc = func(ctx context.Context, secret string, newB bool, teamID *uint) (bool, error) {
+		return true, nil
+	}
+
+	var created *fleet.Team
+	ds.NewTeamFunc = func(ctx context.Context, team *fleet.Team) (*fleet.Team, error) {
+		created = team
+		team.ID = 1
+		return team, nil
+	}
+
+	authorizer, err := authz.NewAuthorizer()
+	require.NoError(t, err)
+
+	svc := &Service{
+		ds: ds,
+		config: config.FleetConfig{
+			Server: config.ServerConfig{PrivateKey: "something"},
+		},
+		authz: authorizer,
+	}
+	mockSvc := &svcmock.Service{}
+	mockSvc.NewActivityFunc = func(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails) error {
+		return nil
+	}
+	svc.Service = mockSvc
+
+	ctx := test.UserContext(t.Context(), &fleet.User{ID: 1, GlobalRole: new(fleet.RoleAdmin)})
+
+	spec := &fleet.TeamSpec{Name: "Engineering"}
+	spec.MDM.MacOSUpdates = fleet.AppleOSUpdateSettings{
+		MinimumVersion: optjson.SetString("15.0"),
+		Deadline:       optjson.SetString("2026-09-01"),
+	}
+	spec.MDM.IOSUpdates = fleet.AppleOSUpdateSettings{
+		MinimumVersion: optjson.SetString("18.1"),
+		Deadline:       optjson.SetString("2026-09-02"),
+	}
+	spec.MDM.IPadOSUpdates = fleet.AppleOSUpdateSettings{
+		MinimumVersion: optjson.SetString("18.2"),
+		Deadline:       optjson.SetString("2026-09-03"),
+	}
+
+	_, err = svc.ApplyTeamSpecs(ctx, []*fleet.TeamSpec{spec}, fleet.ApplyTeamSpecOptions{})
+	require.NoError(t, err)
+	require.True(t, ds.NewTeamFuncInvoked)
+	require.NotNil(t, created)
+
+	// macOS already worked; it's here so a regression that drops all of them is
+	// distinguishable from one that drops only the iOS/iPadOS pair.
+	require.Equal(t, "15.0", created.Config.MDM.MacOSUpdates.MinimumVersion.Value)
+	require.Equal(t, "18.1", created.Config.MDM.IOSUpdates.MinimumVersion.Value)
+	require.Equal(t, "2026-09-02", created.Config.MDM.IOSUpdates.Deadline.Value)
+	require.Equal(t, "18.2", created.Config.MDM.IPadOSUpdates.MinimumVersion.Value)
+	require.Equal(t, "2026-09-03", created.Config.MDM.IPadOSUpdates.Deadline.Value)
+}


### PR DESCRIPTION
**Related issue:** Resolves #51773

`editTeamFromSpec()` reads `ios_updates` and `ipados_updates` off the spec and assigns them, but `createTeamFromSpec()` builds the new fleet's `fleet.TeamMDM` with only `MacOSUpdates` and `WindowsUpdates`:

```go
MDM: fleet.TeamMDM{
	MacOSUpdates:   spec.MDM.MacOSUpdates,
	WindowsUpdates: spec.MDM.WindowsUpdates,
	...
```

So a `fleetctl gitops` run that created the fleet reported success and silently dropped both settings. Running gitops a second time — against the now-existing fleet — took the edit path and applied them, which is what made this look intermittent.

The two fields are copied straight through, matching how the two that already worked are handled. `createTeamFromSpec` doesn't validate the macOS or Windows update settings either, so no validation was added here; that would be a separate change applying to all four.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests

`TestApplyTeamSpecsCreateAppliesAppleOSUpdates` drives `ApplyTeamSpecs` down the create path (fleet doesn't exist yet), captures the fleet handed to `NewTeam`, and asserts all three Apple settings land. With the change reverted it fails exactly as reported:

```
Error: Not equal:
       expected: "18.1"
       actual  : ""
```

The macOS assertion passes either way, so a regression that drops all of them stays distinguishable from one that drops only the iOS/iPadOS pair.

- [ ] QA'd all new/changed functionality manually

Not manually QA'd: exercising it end to end needs a gitops run against a fleet that doesn't exist yet plus Apple MDM configured. The unit test drives the same `ApplyTeamSpecs` entry point `fleetctl gitops` calls.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * New fleets created with `fleetctl gitops` now correctly apply iOS and iPadOS update settings.
  * Apple OS update requirements, including minimum versions and deadlines, are now preserved for newly created fleets across macOS, iOS, and iPadOS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->