### PR TITLE
Per-platform disk encryption: write semantics and POST /disk_encryption (#51258, 4/5)

### DIFF
--- a/changes/51258-per-platform-disk-encryption-writes
+++ b/changes/51258-per-platform-disk-encryption-writes
@@ -1,0 +1,3 @@
+- Added `macos_settings`, `windows_settings`, and `linux_settings` objects to `POST /api/v1/fleet/disk_encryption`, and conflict validation (422) when a request changes the deprecated `enable_disk_encryption` and a per-platform setting to disagreeing values.
+- Fixed the BitLocker PIN requirement being ignored for hosts without a fleet when set via `POST /api/v1/fleet/disk_encryption`.
+- Fixed config saves failing on a downgraded (free) license when disk encryption settings were still enabled from a premium license.

--- a/changes/51258-per-platform-disk-encryption-writes
+++ b/changes/51258-per-platform-disk-encryption-writes
@@ -1,3 +1,0 @@
-- Added `macos_settings`, `windows_settings`, and `linux_settings` objects to `POST /api/v1/fleet/disk_encryption`, and conflict validation (422) when a request changes the deprecated `enable_disk_encryption` and a per-platform setting to disagreeing values.
-- Fixed the BitLocker PIN requirement being ignored for hosts without a fleet when set via `POST /api/v1/fleet/disk_encryption`.
-- Fixed config saves failing on a downgraded (free) license when disk encryption settings were still enabled from a premium license.

--- a/cmd/fleetctl/fleetctl/apply_test.go
+++ b/cmd/fleetctl/fleetctl/apply_test.go
@@ -231,6 +231,17 @@ func withDiskEncryptionDefaults(m fleet.TeamMDM) fleet.TeamMDM {
 	return m
 }
 
+// withCreateDefaults adds the defaults only team creation persists on top of
+// withDiskEncryptionDefaults: the canonical BitLocker PIN home is stored as
+// explicit false for new teams, while edits leave an absent value untouched.
+func withCreateDefaults(m fleet.TeamMDM) fleet.TeamMDM {
+	m = withDiskEncryptionDefaults(m)
+	if !m.WindowsSettings.RequireBitLockerPIN.Valid {
+		m.WindowsSettings.RequireBitLockerPIN = optjson.SetBool(false)
+	}
+	return m
+}
+
 func TestApplyTeamSpecs(t *testing.T) {
 	license := &fleet.LicenseInfo{Tier: fleet.TierPremium, Expiration: time.Now().Add(24 * time.Hour)}
 	_, ds := testing_utils.RunServerWithMockedDS(t, &service.TestServerOpts{License: license})
@@ -382,7 +393,7 @@ spec:
 	assert.JSONEq(t, string(agentOpts), string(*teamsByName["team2"].Config.AgentOptions))
 	assert.JSONEq(t, string(newAgentOpts), string(*teamsByName["team1"].Config.AgentOptions))
 	assert.Equal(t, []*fleet.EnrollSecret{{Secret: "AAA"}}, enrolledSecretsCalled[uint(42)])
-	assert.Equal(t, withDiskEncryptionDefaults(fleet.TeamMDM{
+	assert.Equal(t, withCreateDefaults(fleet.TeamMDM{
 		MacOSSetup: fleet.MacOSSetup{
 			EnableReleaseDeviceManually: optjson.SetBool(false),
 			EnableManagedLocalAccount:   optjson.SetBool(false),

--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -497,7 +497,7 @@ func (cmd *GenerateGitopsCommand) Run() error {
 		mdmConfig := fleet.TeamMDM{
 			EnableDiskEncryption:       cmd.AppConfig.MDM.EnableDiskEncryption.Value,
 			EnableRecoveryLockPassword: cmd.AppConfig.MDM.EnableRecoveryLockPassword.Value,
-			RequireBitLockerPIN:        cmd.AppConfig.MDM.RequireBitLockerPIN.Value,
+			RequireBitLockerPIN:        cmd.AppConfig.MDM.BitLockerPINRequired(),
 			HostNameTemplate:           cmd.AppConfig.MDM.HostNameTemplate.Value,
 			MacOSUpdates:               cmd.AppConfig.MDM.MacOSUpdates,
 			IOSUpdates:                 cmd.AppConfig.MDM.IOSUpdates,

--- a/cmd/fleetctl/fleetctl/testdata/expectedGetConfigAppConfigJson.json
+++ b/cmd/fleetctl/fleetctl/testdata/expectedGetConfigAppConfigJson.json
@@ -157,8 +157,9 @@
       "windows_migration_enabled": false,
       "enable_turn_on_windows_mdm_manually": false,
       "windows_entra_tenant_ids": null,
-      "windows_entra_client_ids": null,"microsoft_graph_credential_invalid":false,
-      "windows_require_bitlocker_pin": null,
+      "windows_entra_client_ids": null,
+      "microsoft_graph_credential_invalid": false,
+      "windows_require_bitlocker_pin": false,
       "apple_require_hardware_attestation": false,
       "macos_migration": {
         "enable": false,
@@ -210,7 +211,8 @@
         "configuration_profiles": null,
         "managed_local_account_settings": {
           "enabled": false
-        }
+        },
+        "require_bitlocker_pin": false
       },
       "linux_settings": {
         "enable_escrow_disk_encryption_key": false

--- a/cmd/fleetctl/fleetctl/testdata/expectedGetConfigAppConfigTeamMaintainerJson.json
+++ b/cmd/fleetctl/fleetctl/testdata/expectedGetConfigAppConfigTeamMaintainerJson.json
@@ -104,7 +104,7 @@
       "enable_disk_encryption": false,
       "name_template": null,
       "enable_recovery_lock_password": false,
-      "windows_require_bitlocker_pin": null,
+      "windows_require_bitlocker_pin": false,
       "macos_updates": {
         "minimum_version": null,
         "deadline": null,
@@ -130,7 +130,8 @@
       "windows_migration_enabled": false,
       "enable_turn_on_windows_mdm_manually": false,
       "windows_entra_tenant_ids": null,
-      "windows_entra_client_ids": null,"microsoft_graph_credential_invalid":false,
+      "windows_entra_client_ids": null,
+      "microsoft_graph_credential_invalid": false,
       "apple_require_hardware_attestation": false,
       "macos_migration": {
         "enable": false,
@@ -182,7 +183,8 @@
         "configuration_profiles": null,
         "managed_local_account_settings": {
           "enabled": false
-        }
+        },
+        "require_bitlocker_pin": false
       },
       "linux_settings": {
         "enable_escrow_disk_encryption_key": false

--- a/cmd/fleetctl/fleetctl/testdata/expectedGetConfigAppConfigTeamMaintainerYaml.yml
+++ b/cmd/fleetctl/fleetctl/testdata/expectedGetConfigAppConfigTeamMaintainerYaml.yml
@@ -48,7 +48,7 @@ spec:
     enable_disk_encryption: false
     name_template: null
     enable_recovery_lock_password: false
-    windows_require_bitlocker_pin: null
+    windows_require_bitlocker_pin: false
     windows_migration_enabled: false
     enable_turn_on_windows_mdm_manually: false
     windows_entra_tenant_ids: null
@@ -113,6 +113,7 @@ spec:
       software:
     windows_enrollment: null
     windows_settings:
+      require_bitlocker_pin: false
       custom_settings: null
       enable_disk_encryption: false
       configuration_profiles: null

--- a/cmd/fleetctl/fleetctl/testdata/expectedGetConfigAppConfigYaml.yml
+++ b/cmd/fleetctl/fleetctl/testdata/expectedGetConfigAppConfigYaml.yml
@@ -48,7 +48,7 @@ spec:
     enable_disk_encryption: false
     name_template: null
     enable_recovery_lock_password: false
-    windows_require_bitlocker_pin: null
+    windows_require_bitlocker_pin: false
     windows_migration_enabled: false
     enable_turn_on_windows_mdm_manually: false
     windows_entra_tenant_ids: null
@@ -113,6 +113,7 @@ spec:
       software:
     windows_enrollment: null
     windows_settings:
+      require_bitlocker_pin: false
       custom_settings: null
       enable_disk_encryption: false
       configuration_profiles: null

--- a/cmd/fleetctl/fleetctl/testdata/expectedGetConfigIncludeServerConfigJson.json
+++ b/cmd/fleetctl/fleetctl/testdata/expectedGetConfigIncludeServerConfigJson.json
@@ -82,9 +82,10 @@
       "enable_disk_encryption": false,
       "name_template": null,
       "enable_recovery_lock_password": false,
-      "windows_require_bitlocker_pin": null,
+      "windows_require_bitlocker_pin": false,
       "windows_entra_tenant_ids": null,
-      "windows_entra_client_ids": null,"microsoft_graph_credential_invalid":false,
+      "windows_entra_client_ids": null,
+      "microsoft_graph_credential_invalid": false,
       "macos_updates": {
         "minimum_version": null,
         "deadline": null,
@@ -160,7 +161,8 @@
         "configuration_profiles": null,
         "managed_local_account_settings": {
           "enabled": false
-        }
+        },
+        "require_bitlocker_pin": false
       },
       "linux_settings": {
         "enable_escrow_disk_encryption_key": false

--- a/cmd/fleetctl/fleetctl/testdata/expectedGetConfigIncludeServerConfigYaml.yml
+++ b/cmd/fleetctl/fleetctl/testdata/expectedGetConfigIncludeServerConfigYaml.yml
@@ -48,7 +48,7 @@ spec:
     enable_disk_encryption: false
     name_template: null
     enable_recovery_lock_password: false
-    windows_require_bitlocker_pin: null
+    windows_require_bitlocker_pin: false
     windows_migration_enabled: false
     enable_turn_on_windows_mdm_manually: false
     apple_require_hardware_attestation: false
@@ -113,6 +113,7 @@ spec:
       software:
     windows_enrollment: null
     windows_settings:
+      require_bitlocker_pin: false
       custom_settings: null
       enable_disk_encryption: false
       configuration_profiles: null

--- a/cmd/fleetctl/fleetctl/testdata/expectedGetTeamsJson.json
+++ b/cmd/fleetctl/fleetctl/testdata/expectedGetTeamsJson.json
@@ -79,7 +79,8 @@
           "enable_disk_encryption": false,
           "managed_local_account_settings": {
             "enabled": false
-          }
+          },
+          "require_bitlocker_pin": false
         },
         "windows_updates": {
           "deadline_days": null,
@@ -177,7 +178,8 @@
           "enable_disk_encryption": false,
           "managed_local_account_settings": {
             "enabled": false
-          }
+          },
+          "require_bitlocker_pin": false
         },
         "windows_updates": {
           "deadline_days": null,
@@ -296,7 +298,8 @@
           "enable_disk_encryption": false,
           "managed_local_account_settings": {
             "enabled": false
-          }
+          },
+          "require_bitlocker_pin": false
         },
         "windows_updates": {
           "deadline_days": 7,
@@ -409,7 +412,8 @@
           "enable_disk_encryption": false,
           "managed_local_account_settings": {
             "enabled": false
-          }
+          },
+          "require_bitlocker_pin": false
         },
         "windows_updates": {
           "deadline_days": 7,

--- a/cmd/fleetctl/fleetctl/testdata/expectedGetTeamsYaml.yml
+++ b/cmd/fleetctl/fleetctl/testdata/expectedGetTeamsYaml.yml
@@ -62,6 +62,7 @@ spec:
         enable_disk_encryption: false
         managed_local_account_settings:
           enabled: false
+        require_bitlocker_pin: false
       windows_updates:
         deadline_days: null
         grace_period_days: null
@@ -132,6 +133,7 @@ spec:
         enable_disk_encryption: false
         managed_local_account_settings:
           enabled: false
+        require_bitlocker_pin: false
       windows_updates:
         deadline_days: null
         grace_period_days: null
@@ -215,6 +217,7 @@ spec:
         enable_disk_encryption: false
         managed_local_account_settings:
           enabled: false
+        require_bitlocker_pin: false
       windows_updates:
         deadline_days: 7
         grace_period_days: 3
@@ -294,6 +297,7 @@ spec:
         enable_disk_encryption: false
         managed_local_account_settings:
           enabled: false
+        require_bitlocker_pin: false
       windows_updates:
         deadline_days: 7
         grace_period_days: 3

--- a/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedAppConfigEmpty.yml
+++ b/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedAppConfigEmpty.yml
@@ -48,7 +48,7 @@ spec:
     enable_disk_encryption: false
     name_template: null
     enable_recovery_lock_password: false
-    windows_require_bitlocker_pin: null
+    windows_require_bitlocker_pin: false
     windows_migration_enabled: false
     enable_turn_on_windows_mdm_manually: false
     windows_entra_tenant_ids: null
@@ -69,6 +69,7 @@ spec:
       enable_escrow_disk_encryption_key: false
     windows_enrollment: null
     windows_settings:
+      require_bitlocker_pin: false
       custom_settings: null
       enable_disk_encryption: false
       configuration_profiles: null

--- a/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedAppConfigSet.yml
+++ b/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedAppConfigSet.yml
@@ -48,7 +48,7 @@ spec:
     enable_disk_encryption: false
     name_template: null
     enable_recovery_lock_password: false
-    windows_require_bitlocker_pin: null
+    windows_require_bitlocker_pin: false
     windows_migration_enabled: false
     enable_turn_on_windows_mdm_manually: false
     windows_entra_tenant_ids: null
@@ -69,6 +69,7 @@ spec:
       enable_escrow_disk_encryption_key: false
     windows_enrollment: null
     windows_settings:
+      require_bitlocker_pin: false
       custom_settings: null
       enable_disk_encryption: false
       configuration_profiles: null

--- a/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedTeam1And2Empty.yml
+++ b/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedTeam1And2Empty.yml
@@ -25,6 +25,7 @@ spec:
         enable_disk_encryption: false
         enable_escrow_disk_encryption_key: false
       windows_settings:
+        require_bitlocker_pin: false
         configuration_profiles: null
         enable_disk_encryption: false
         managed_local_account_settings:
@@ -95,6 +96,7 @@ spec:
         enable_disk_encryption: false
         enable_escrow_disk_encryption_key: false
       windows_settings:
+        require_bitlocker_pin: false
         custom_settings: null
         enable_disk_encryption: false
         managed_local_account_settings:
@@ -169,6 +171,7 @@ spec:
         enable_disk_encryption: false
         enable_escrow_disk_encryption_key: false
       windows_settings:
+        require_bitlocker_pin: false
         configuration_profiles: null
         enable_disk_encryption: false
         managed_local_account_settings:
@@ -231,6 +234,7 @@ spec:
         enable_disk_encryption: false
         enable_escrow_disk_encryption_key: false
       windows_settings:
+        require_bitlocker_pin: false
         custom_settings: null
         enable_disk_encryption: false
         managed_local_account_settings:

--- a/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedTeam1And2Set.yml
+++ b/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedTeam1And2Set.yml
@@ -25,6 +25,7 @@ spec:
         enable_disk_encryption: false
         enable_escrow_disk_encryption_key: false
       windows_settings:
+        require_bitlocker_pin: false
         configuration_profiles: null
         enable_disk_encryption: false
         managed_local_account_settings:
@@ -95,6 +96,7 @@ spec:
         enable_disk_encryption: false
         enable_escrow_disk_encryption_key: false
       windows_settings:
+        require_bitlocker_pin: false
         custom_settings: null
         enable_disk_encryption: false
         managed_local_account_settings:
@@ -169,6 +171,7 @@ spec:
         enable_disk_encryption: false
         enable_escrow_disk_encryption_key: false
       windows_settings:
+        require_bitlocker_pin: false
         configuration_profiles: null
         enable_disk_encryption: false
         managed_local_account_settings:
@@ -233,6 +236,7 @@ spec:
         enable_disk_encryption: false
         enable_escrow_disk_encryption_key: false
       windows_settings:
+        require_bitlocker_pin: false
         custom_settings: null
         enable_disk_encryption: false
         managed_local_account_settings:

--- a/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedTeam1Empty.yml
+++ b/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedTeam1Empty.yml
@@ -61,6 +61,7 @@ spec:
         deadline_days: null
         grace_period_days: null
       windows_settings:
+        require_bitlocker_pin: false
         configuration_profiles: null
         enable_disk_encryption: false
         managed_local_account_settings:
@@ -131,6 +132,7 @@ spec:
         deadline_days: null
         grace_period_days: null
       windows_settings:
+        require_bitlocker_pin: false
         custom_settings: null
         enable_disk_encryption: false
         managed_local_account_settings:

--- a/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedTeam1Set.yml
+++ b/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedTeam1Set.yml
@@ -24,6 +24,7 @@ spec:
         enable_disk_encryption: false
         enable_escrow_disk_encryption_key: false
       windows_settings:
+        require_bitlocker_pin: false
         configuration_profiles: null
         enable_disk_encryption: false
         managed_local_account_settings:
@@ -94,6 +95,7 @@ spec:
         enable_disk_encryption: false
         enable_escrow_disk_encryption_key: false
       windows_settings:
+        require_bitlocker_pin: false
         custom_settings: null
         enable_disk_encryption: false
         managed_local_account_settings:

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -385,15 +385,14 @@ func (svc *Service) ModifyTeam(ctx context.Context, teamID uint, payload fleet.T
 		}
 
 		// the deprecated top-level windows_require_bitlocker_pin mirrors the
-		// canonical windows_settings.require_bitlocker_pin home; whichever the
-		// request changes wins
-		incomingPIN := payload.MDM.RequireBitLockerPIN
-		if payload.MDM.WindowsSettings != nil && payload.MDM.WindowsSettings.RequireBitLockerPIN.Valid {
-			canonical := payload.MDM.WindowsSettings.RequireBitLockerPIN
-			oldPIN := team.Config.MDM.DiskEncryptionConfig().BitLockerPINRequired
-			if !incomingPIN.Valid || incomingPIN.Value == oldPIN || canonical.Value != oldPIN {
-				incomingPIN = canonical
-			}
+		// canonical windows_settings.require_bitlocker_pin home
+		var canonicalPIN optjson.Bool
+		if payload.MDM.WindowsSettings != nil {
+			canonicalPIN = payload.MDM.WindowsSettings.RequireBitLockerPIN
+		}
+		incomingPIN, err := fleet.ResolveBitLockerPINAlias(payload.MDM.RequireBitLockerPIN, canonicalPIN)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err)
 		}
 		if incomingPIN.Valid {
 			team.Config.MDM.RequireBitLockerPIN = incomingPIN.Value
@@ -1706,14 +1705,12 @@ func (svc *Service) createTeamFromSpec(
 	windowsSettings.EnableDiskEncryption = optjson.SetBool(windowsSettings.EnableDiskEncryption.Value)
 	// the deprecated top-level windows_require_bitlocker_pin mirrors the
 	// canonical windows_settings.require_bitlocker_pin home
-	requireBitLockerPIN := spec.MDM.RequireBitLockerPIN.Value
-	if windowsSettings.RequireBitLockerPIN.Valid {
-		if spec.MDM.RequireBitLockerPIN.Valid && spec.MDM.RequireBitLockerPIN.Value != windowsSettings.RequireBitLockerPIN.Value {
-			return nil, ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("mdm.windows_require_bitlocker_pin",
-				"conflicts with windows_settings.require_bitlocker_pin"))
-		}
-		requireBitLockerPIN = windowsSettings.RequireBitLockerPIN.Value
+	resolvedPIN, err := fleet.ResolveBitLockerPINAlias(
+		spec.MDM.RequireBitLockerPIN, windowsSettings.RequireBitLockerPIN)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err)
 	}
+	requireBitLockerPIN := resolvedPIN.Value
 	windowsSettings.RequireBitLockerPIN = optjson.SetBool(requireBitLockerPIN)
 	// the BitLocker PIN requires the Windows disk encryption setting; a new
 	// fleet has no previous state, so this is always the "enabling the PIN" case
@@ -2066,15 +2063,11 @@ func (svc *Service) editTeamFromSpec(
 	}
 
 	// the deprecated top-level windows_require_bitlocker_pin mirrors the
-	// canonical windows_settings.require_bitlocker_pin home; whichever the
-	// spec changes wins
-	incomingPIN := spec.MDM.RequireBitLockerPIN
-	if spec.MDM.WindowsSettings.RequireBitLockerPIN.Valid {
-		canonical := spec.MDM.WindowsSettings.RequireBitLockerPIN
-		if !incomingPIN.Valid || incomingPIN.Value == oldDiskEncryption.BitLockerPINRequired ||
-			canonical.Value != oldDiskEncryption.BitLockerPINRequired {
-			incomingPIN = canonical
-		}
+	// canonical windows_settings.require_bitlocker_pin home
+	incomingPIN, err := fleet.ResolveBitLockerPINAlias(
+		spec.MDM.RequireBitLockerPIN, spec.MDM.WindowsSettings.RequireBitLockerPIN)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err)
 	}
 	if incomingPIN.Valid {
 		team.Config.MDM.RequireBitLockerPIN = incomingPIN.Value

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -1618,7 +1618,8 @@ func (svc *Service) createTeamFromSpec(
 	}
 
 	var macOSSettings fleet.MacOSSettings
-	if err := svc.applyTeamMacOSSettings(ctx, spec, &macOSSettings); err != nil {
+	macOSSetFields, err := svc.applyTeamMacOSSettings(ctx, spec, &macOSSettings)
+	if err != nil {
 		return nil, err
 	}
 	macOSSetup := spec.MDM.MacOSSetup
@@ -1655,23 +1656,36 @@ func (svc *Service) createTeamFromSpec(
 		macOSSetup.LockEndUserInfo = optjson.SetBool(macOSSetup.EnableEndUserAuthentication)
 	}
 
-	// resolve the per-platform disk encryption settings for the new team.
-	// The deprecated flat toggle wins when provided (it fans out to every
-	// per-platform setting, preserving its historical semantics); absent
-	// settings default to explicit false.
+	// resolve the per-platform disk encryption settings for the new team:
+	// absent settings default to false; the deprecated flat toggle fans out to
+	// every per-platform setting and conflicts with per-platform values that
+	// disagree.
+	if spec.MDM.EnableDiskEncryption.Valid {
+		v := spec.MDM.EnableDiskEncryption.Value
+		conflict := (macOSSetFields["enable_disk_encryption"] && macOSSettings.EnableDiskEncryption.Value != v) ||
+			(macOSSetFields["enable_escrow_disk_encryption_key"] && macOSSettings.EnableEscrowDiskEncryptionKey.Value != v) ||
+			(spec.MDM.WindowsSettings.EnableDiskEncryption.Valid && spec.MDM.WindowsSettings.EnableDiskEncryption.Value != v) ||
+			(spec.MDM.LinuxSettings.EnableEscrowDiskEncryptionKey.Valid && spec.MDM.LinuxSettings.EnableEscrowDiskEncryptionKey.Value != v)
+		if conflict {
+			return nil, ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("mdm.enable_disk_encryption",
+				"conflicts with per-platform disk encryption settings"))
+		}
+		macOSSettings.EnableDiskEncryption = optjson.SetBool(v)
+		macOSSettings.EnableEscrowDiskEncryptionKey = optjson.SetBool(v)
+	}
+	// store explicit booleans so absent keys read as false declaratively
 	macOSSettings.EnableDiskEncryption = optjson.SetBool(macOSSettings.EnableDiskEncryption.Value)
 	macOSSettings.EnableEscrowDiskEncryptionKey = optjson.SetBool(macOSSettings.EnableEscrowDiskEncryptionKey.Value)
 	windowsSettings := spec.MDM.WindowsSettings
+	if spec.MDM.EnableDiskEncryption.Valid {
+		windowsSettings.EnableDiskEncryption = spec.MDM.EnableDiskEncryption
+	}
 	windowsSettings.EnableDiskEncryption = optjson.SetBool(windowsSettings.EnableDiskEncryption.Value)
 	linuxSettings := spec.MDM.LinuxSettings
-	linuxSettings.EnableEscrowDiskEncryptionKey = optjson.SetBool(linuxSettings.EnableEscrowDiskEncryptionKey.Value)
 	if spec.MDM.EnableDiskEncryption.Valid {
-		v := optjson.SetBool(spec.MDM.EnableDiskEncryption.Value)
-		macOSSettings.EnableDiskEncryption = v
-		macOSSettings.EnableEscrowDiskEncryptionKey = v
-		windowsSettings.EnableDiskEncryption = v
-		linuxSettings.EnableEscrowDiskEncryptionKey = v
+		linuxSettings.EnableEscrowDiskEncryptionKey = spec.MDM.EnableDiskEncryption
 	}
+	linuxSettings.EnableEscrowDiskEncryptionKey = optjson.SetBool(linuxSettings.EnableEscrowDiskEncryptionKey.Value)
 	macOSDiskEncryptionOn := macOSSettings.EnableDiskEncryption.Value || macOSSettings.EnableEscrowDiskEncryptionKey.Value
 	anyDiskEncryptionOn := macOSDiskEncryptionOn || windowsSettings.EnableDiskEncryption.Value ||
 		linuxSettings.EnableEscrowDiskEncryptionKey.Value
@@ -1947,11 +1961,9 @@ func (svc *Service) editTeamFromSpec(
 		}
 	}
 
-	oldMacOSDiskEncryption := team.Config.MDM.MacOSSettings.EnableDiskEncryption.Value
-	oldMacOSEscrowDiskEncryptionKey := team.Config.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey.Value
-	oldWindowsDiskEncryption := team.Config.MDM.WindowsSettings.EnableDiskEncryption.Value
-	oldLinuxEscrowDiskEncryptionKey := team.Config.MDM.LinuxSettings.EnableEscrowDiskEncryptionKey.Value
-	if err := svc.applyTeamMacOSSettings(ctx, spec, &team.Config.MDM.MacOSSettings); err != nil {
+	oldDiskEncryption := team.Config.MDM.DiskEncryptionConfig()
+	macOSSetFields, err := svc.applyTeamMacOSSettings(ctx, spec, &team.Config.MDM.MacOSSettings)
+	if err != nil {
 		return err
 	}
 
@@ -1964,29 +1976,49 @@ func (svc *Service) editTeamFromSpec(
 		team.Config.MDM.LinuxSettings.EnableEscrowDiskEncryptionKey = spec.MDM.LinuxSettings.EnableEscrowDiskEncryptionKey
 	}
 
-	// the deprecated flat toggle wins when provided: it fans out to every
-	// per-platform setting, preserving its historical semantics
+	// the deprecated flat toggle fans out to every per-platform setting. It
+	// reads as the AND of the four, so "the spec changes it" is measured
+	// against that; a per-platform value the spec changes wins over an
+	// unchanged flat toggle, and both changed to disagreeing values is a
+	// conflict. This mirrors the app config PATCH-merge semantics.
 	if spec.MDM.EnableDiskEncryption.Valid {
-		v := optjson.SetBool(spec.MDM.EnableDiskEncryption.Value)
-		team.Config.MDM.MacOSSettings.EnableDiskEncryption = v
-		team.Config.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey = v
-		team.Config.MDM.WindowsSettings.EnableDiskEncryption = v
-		team.Config.MDM.LinuxSettings.EnableEscrowDiskEncryptionKey = v
+		v := spec.MDM.EnableDiskEncryption.Value
+		legacyChanged := v != (oldDiskEncryption.MacOSEnabled && oldDiskEncryption.MacOSEscrowEnabled &&
+			oldDiskEncryption.WindowsEnabled && oldDiskEncryption.LinuxEscrowEnabled)
+		for _, f := range []struct {
+			provided bool
+			merged   *optjson.Bool
+			old      bool
+		}{
+			{macOSSetFields["enable_disk_encryption"], &team.Config.MDM.MacOSSettings.EnableDiskEncryption, oldDiskEncryption.MacOSEnabled},
+			{macOSSetFields["enable_escrow_disk_encryption_key"], &team.Config.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey, oldDiskEncryption.MacOSEscrowEnabled},
+			{spec.MDM.WindowsSettings.EnableDiskEncryption.Valid, &team.Config.MDM.WindowsSettings.EnableDiskEncryption, oldDiskEncryption.WindowsEnabled},
+			{spec.MDM.LinuxSettings.EnableEscrowDiskEncryptionKey.Valid, &team.Config.MDM.LinuxSettings.EnableEscrowDiskEncryptionKey, oldDiskEncryption.LinuxEscrowEnabled},
+		} {
+			providedChanged := f.provided && f.merged.Value != f.old
+			switch {
+			case providedChanged && legacyChanged && f.merged.Value != v:
+				return ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("mdm.enable_disk_encryption",
+					"conflicts with per-platform disk encryption settings"))
+			case providedChanged:
+				// the per-platform value wins, already merged
+			case legacyChanged || !f.provided:
+				*f.merged = optjson.SetBool(v)
+			}
+		}
 	}
 
+	newDiskEncryption := team.Config.MDM.DiskEncryptionConfig()
+	didUpdateMacOSDiskEncryption := newDiskEncryption.MacOSEnabled != oldDiskEncryption.MacOSEnabled ||
+		newDiskEncryption.MacOSEscrowEnabled != oldDiskEncryption.MacOSEscrowEnabled
 	// the flat toggle is virtual: keep the stored value consistent
-	team.Config.MDM.EnableDiskEncryption = team.Config.MDM.MacOSSettings.EnableDiskEncryption.Value &&
-		team.Config.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey.Value &&
-		team.Config.MDM.WindowsSettings.EnableDiskEncryption.Value &&
-		team.Config.MDM.LinuxSettings.EnableEscrowDiskEncryptionKey.Value
+	team.Config.MDM.EnableDiskEncryption = newDiskEncryption.MacOSEnabled && newDiskEncryption.MacOSEscrowEnabled &&
+		newDiskEncryption.WindowsEnabled && newDiskEncryption.LinuxEscrowEnabled
 
-	didUpdateMacOSDiskEncryption := team.Config.MDM.MacOSSettings.EnableDiskEncryption.Value != oldMacOSDiskEncryption ||
-		team.Config.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey.Value != oldMacOSEscrowDiskEncryptionKey
-
-	enablingDiskEncryption := (team.Config.MDM.MacOSSettings.EnableDiskEncryption.Value && !oldMacOSDiskEncryption) ||
-		(team.Config.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey.Value && !oldMacOSEscrowDiskEncryptionKey) ||
-		(team.Config.MDM.WindowsSettings.EnableDiskEncryption.Value && !oldWindowsDiskEncryption) ||
-		(team.Config.MDM.LinuxSettings.EnableEscrowDiskEncryptionKey.Value && !oldLinuxEscrowDiskEncryptionKey)
+	enablingDiskEncryption := (newDiskEncryption.MacOSEnabled && !oldDiskEncryption.MacOSEnabled) ||
+		(newDiskEncryption.MacOSEscrowEnabled && !oldDiskEncryption.MacOSEscrowEnabled) ||
+		(newDiskEncryption.WindowsEnabled && !oldDiskEncryption.WindowsEnabled) ||
+		(newDiskEncryption.LinuxEscrowEnabled && !oldDiskEncryption.LinuxEscrowEnabled)
 	if enablingDiskEncryption && svc.config.Server.PrivateKey == "" {
 		return ctxerr.New(ctx, "Missing required private key. Learn how to configure the private key here: https://fleetdm.com/learn-more-about/fleet-server-private-key")
 	}
@@ -2276,7 +2308,7 @@ func (svc *Service) editTeamFromSpec(
 		// only the off<->on transition of the pair creates or deletes it.
 		macOSDiskEncryptionOn := team.Config.MDM.MacOSSettings.EnableDiskEncryption.Value ||
 			team.Config.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey.Value
-		macOSDiskEncryptionWasOn := oldMacOSDiskEncryption || oldMacOSEscrowDiskEncryptionKey
+		macOSDiskEncryptionWasOn := oldDiskEncryption.MacOSEnabled || oldDiskEncryption.MacOSEscrowEnabled
 		var act fleet.ActivityDetails
 		switch {
 		case macOSDiskEncryptionOn && !macOSDiskEncryptionWasOn:
@@ -2452,16 +2484,16 @@ func (svc *Service) validateTeamCalendarIntegrations(
 	return nil
 }
 
-func (svc *Service) applyTeamMacOSSettings(ctx context.Context, spec *fleet.TeamSpec, applyUpon *fleet.MacOSSettings) error {
+func (svc *Service) applyTeamMacOSSettings(ctx context.Context, spec *fleet.TeamSpec, applyUpon *fleet.MacOSSettings) (map[string]bool, error) {
 	oldCustomSettings := applyUpon.CustomSettings
 	setFields, err := applyUpon.FromMap(spec.MDM.MacOSSettings)
 	if err != nil {
-		return fleet.NewUserMessageError(err, http.StatusBadRequest)
+		return nil, fleet.NewUserMessageError(err, http.StatusBadRequest)
 	}
 
 	appCfg, err := svc.ds.AppConfig(ctx)
 	if err != nil {
-		return ctxerr.Wrap(ctx, err, "apply team macos settings")
+		return nil, ctxerr.Wrap(ctx, err, "apply team macos settings")
 	}
 
 	customSettingsChanged := setFields["custom_settings"] &&
@@ -2483,12 +2515,12 @@ func (svc *Service) applyTeamMacOSSettings(ctx context.Context, spec *fleet.Team
 		if !appCfg.MDM.EnabledAndConfigured {
 			// TODO: Address potential edge cases when teams that previously utilized MDM features
 			// are edited later edited when MDM disabled
-			return ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError(fmt.Sprintf("apple_settings.%s", field),
+			return nil, ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError(fmt.Sprintf("apple_settings.%s", field),
 				`Couldn't update apple_settings because MDM features aren't turned on in Fleet. Use fleetctl generate mdm-apple and then fleet serve with mdm configuration to turn on MDM features.`))
 		}
 	}
 
-	return nil
+	return setFields, nil
 }
 
 // unmarshalWithGlobalDefaults unmarshals features from a team spec, and
@@ -2508,81 +2540,79 @@ func unmarshalWithGlobalDefaults(b *json.RawMessage) (fleet.Features, error) {
 	return *defaults, nil
 }
 
-func (svc *Service) updateTeamMDMDiskEncryption(ctx context.Context, tm *fleet.Team, enable *bool, requireBitLockerPIN *bool) error {
-	var didUpdateEncryption bool
-	var didUpdateRequirePIN bool
-	var macOSFileVaultWasOn bool
-	if enable != nil {
-		// the deprecated flat toggle fans out to every per-platform disk
-		// encryption setting
-		macOSFileVaultWasOn = tm.Config.MDM.MacOSSettings.EnableDiskEncryption.Value ||
-			tm.Config.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey.Value
-		changed := tm.Config.MDM.MacOSSettings.EnableDiskEncryption.Value != *enable ||
-			tm.Config.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey.Value != *enable ||
-			tm.Config.MDM.WindowsSettings.EnableDiskEncryption.Value != *enable ||
-			tm.Config.MDM.LinuxSettings.EnableEscrowDiskEncryptionKey.Value != *enable
-		if changed {
-			if *enable && svc.config.Server.PrivateKey == "" {
-				return ctxerr.New(ctx, "Missing required private key. Learn how to configure the private key here: https://fleetdm.com/learn-more-about/fleet-server-private-key")
-			}
+func (svc *Service) updateTeamMDMDiskEncryption(ctx context.Context, tm *fleet.Team, changes fleet.DiskEncryptionSettingsChanges, requireBitLockerPIN *bool) error {
+	oldDiskEncryption := tm.Config.MDM.DiskEncryptionConfig()
 
-			v := optjson.SetBool(*enable)
-			tm.Config.MDM.MacOSSettings.EnableDiskEncryption = v
-			tm.Config.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey = v
-			tm.Config.MDM.WindowsSettings.EnableDiskEncryption = v
-			tm.Config.MDM.LinuxSettings.EnableEscrowDiskEncryptionKey = v
-			tm.Config.MDM.EnableDiskEncryption = *enable
-			didUpdateEncryption = true
+	enabling := false
+	apply := func(dst *optjson.Bool, v *bool) bool {
+		if v == nil || dst.Value == *v {
+			return false
 		}
+		enabling = enabling || *v
+		*dst = optjson.SetBool(*v)
+		return true
 	}
-	if requireBitLockerPIN != nil {
-		if tm.Config.MDM.RequireBitLockerPIN != *requireBitLockerPIN {
-			tm.Config.MDM.RequireBitLockerPIN = *requireBitLockerPIN
-			didUpdateRequirePIN = true
-		}
+	macOSChanged := apply(&tm.Config.MDM.MacOSSettings.EnableDiskEncryption, changes.MacOSEnable)
+	macOSChanged = apply(&tm.Config.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey, changes.MacOSEscrow) || macOSChanged
+	windowsChanged := apply(&tm.Config.MDM.WindowsSettings.EnableDiskEncryption, changes.WindowsEnable)
+	linuxChanged := apply(&tm.Config.MDM.LinuxSettings.EnableEscrowDiskEncryptionKey, changes.LinuxEscrow)
+	// the PIN is updated outside of apply: it doesn't enable key escrow, so it
+	// must not trigger the private-key requirement
+	pinChanged := requireBitLockerPIN != nil && tm.Config.MDM.RequireBitLockerPIN != *requireBitLockerPIN
+	if pinChanged {
+		tm.Config.MDM.RequireBitLockerPIN = *requireBitLockerPIN
 	}
 
-	if didUpdateEncryption || didUpdateRequirePIN {
-		// the PIN requirement is a BitLocker feature, so it's judged against
-		// the Windows setting, not the all-platforms aggregate
-		windowsEncryptionOn := tm.Config.MDM.WindowsSettings.EnableDiskEncryption.Value
-		if didUpdateEncryption && !windowsEncryptionOn && tm.Config.MDM.RequireBitLockerPIN {
+	if !macOSChanged && !windowsChanged && !linuxChanged && !pinChanged {
+		return nil
+	}
+
+	if enabling && svc.config.Server.PrivateKey == "" {
+		return ctxerr.New(ctx, "Missing required private key. Learn how to configure the private key here: https://fleetdm.com/learn-more-about/fleet-server-private-key")
+	}
+
+	// the BitLocker PIN requires the Windows disk encryption setting
+	newDiskEncryption := tm.Config.MDM.DiskEncryptionConfig()
+	if tm.Config.MDM.RequireBitLockerPIN && !newDiskEncryption.WindowsEnabled {
+		if oldDiskEncryption.WindowsEnabled {
 			return ctxerr.New(ctx, fleet.CantDisableDiskEncryptionIfPINRequiredErrMsg)
 		}
-		if !didUpdateEncryption && !windowsEncryptionOn && tm.Config.MDM.RequireBitLockerPIN {
-			return ctxerr.New(ctx, fleet.CantEnablePINRequiredIfDiskEncryptionEnabled)
-		}
+		return ctxerr.New(ctx, fleet.CantEnablePINRequiredIfDiskEncryptionEnabled)
+	}
 
-		if _, err := svc.ds.SaveTeam(ctx, tm); err != nil {
+	// the flat toggle is virtual: keep the stored value consistent
+	tm.Config.MDM.EnableDiskEncryption = newDiskEncryption.MacOSEnabled && newDiskEncryption.MacOSEscrowEnabled &&
+		newDiskEncryption.WindowsEnabled && newDiskEncryption.LinuxEscrowEnabled
+
+	if _, err := svc.ds.SaveTeam(ctx, tm); err != nil {
+		return err
+	}
+
+	if macOSChanged {
+		appCfg, err := svc.ds.AppConfig(ctx)
+		if err != nil {
 			return err
 		}
-
-		if didUpdateEncryption {
-			appCfg, err := svc.ds.AppConfig(ctx)
-			if err != nil {
-				return err
+		// the FileVault profile covers enforcement and escrow as a whole:
+		// only the off<->on transition of the macOS pair creates or deletes
+		// it
+		macOSDiskEncryptionOn := newDiskEncryption.MacOSEnabled || newDiskEncryption.MacOSEscrowEnabled
+		macOSDiskEncryptionWasOn := oldDiskEncryption.MacOSEnabled || oldDiskEncryption.MacOSEscrowEnabled
+		if appCfg.MDM.EnabledAndConfigured && macOSDiskEncryptionOn != macOSDiskEncryptionWasOn {
+			var act fleet.ActivityDetails
+			if macOSDiskEncryptionOn {
+				act = fleet.ActivityTypeEnabledMacosDiskEncryption{TeamID: &tm.ID, TeamName: &tm.Name}
+				if err := svc.MDMAppleEnableFileVaultAndEscrow(ctx, &tm.ID); err != nil {
+					return ctxerr.Wrap(ctx, err, "enable team filevault and escrow")
+				}
+			} else {
+				act = fleet.ActivityTypeDisabledMacosDiskEncryption{TeamID: &tm.ID, TeamName: &tm.Name}
+				if err := svc.MDMAppleDisableFileVaultAndEscrow(ctx, &tm.ID); err != nil && !fleet.IsNotFound(err) {
+					return ctxerr.Wrap(ctx, err, "disable team filevault and escrow")
+				}
 			}
-			// the FileVault profile can cover both enforcement and key
-			// escrow, so only the off<->on transition of the macOS pair
-			// creates or deletes it
-			macOSDiskEncryptionOn := tm.Config.MDM.MacOSSettings.EnableDiskEncryption.Value ||
-				tm.Config.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey.Value
-			if appCfg.MDM.EnabledAndConfigured && macOSDiskEncryptionOn != macOSFileVaultWasOn {
-				var act fleet.ActivityDetails
-				if macOSDiskEncryptionOn {
-					act = fleet.ActivityTypeEnabledMacosDiskEncryption{TeamID: &tm.ID, TeamName: &tm.Name}
-					if err := svc.MDMAppleEnableFileVaultAndEscrow(ctx, &tm.ID); err != nil {
-						return ctxerr.Wrap(ctx, err, "enable team filevault and escrow")
-					}
-				} else {
-					act = fleet.ActivityTypeDisabledMacosDiskEncryption{TeamID: &tm.ID, TeamName: &tm.Name}
-					if err := svc.MDMAppleDisableFileVaultAndEscrow(ctx, &tm.ID); err != nil && !fleet.IsNotFound(err) {
-						return ctxerr.Wrap(ctx, err, "disable team filevault and escrow")
-					}
-				}
-				if err := svc.NewActivity(ctx, authz.UserFromContext(ctx), act); err != nil {
-					return ctxerr.Wrap(ctx, err, "create activity for team macos disk encryption")
-				}
+			if err := svc.NewActivity(ctx, authz.UserFromContext(ctx), act); err != nil {
+				return ctxerr.Wrap(ctx, err, "create activity for team macos disk encryption")
 			}
 		}
 	}

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -379,8 +379,20 @@ func (svc *Service) ModifyTeam(ctx context.Context, teamID uint, payload fleet.T
 			team.Config.MDM.EnableRecoveryLockPassword = payload.MDM.EnableRecoveryLockPassword.Value
 		}
 
-		if payload.MDM.RequireBitLockerPIN.Valid {
-			team.Config.MDM.RequireBitLockerPIN = payload.MDM.RequireBitLockerPIN.Value
+		// the deprecated top-level windows_require_bitlocker_pin mirrors the
+		// canonical windows_settings.require_bitlocker_pin home; whichever the
+		// request changes wins
+		incomingPIN := payload.MDM.RequireBitLockerPIN
+		if payload.MDM.WindowsSettings != nil && payload.MDM.WindowsSettings.RequireBitLockerPIN.Valid {
+			canonical := payload.MDM.WindowsSettings.RequireBitLockerPIN
+			oldPIN := team.Config.MDM.DiskEncryptionConfig().BitLockerPINRequired
+			if !incomingPIN.Valid || incomingPIN.Value == oldPIN || canonical.Value != oldPIN {
+				incomingPIN = canonical
+			}
+		}
+		if incomingPIN.Valid {
+			team.Config.MDM.RequireBitLockerPIN = incomingPIN.Value
+			team.Config.MDM.WindowsSettings.RequireBitLockerPIN = optjson.SetBool(incomingPIN.Value)
 		}
 
 		if payload.MDM.HostNameTemplate.Set {
@@ -1681,6 +1693,17 @@ func (svc *Service) createTeamFromSpec(
 		windowsSettings.EnableDiskEncryption = spec.MDM.EnableDiskEncryption
 	}
 	windowsSettings.EnableDiskEncryption = optjson.SetBool(windowsSettings.EnableDiskEncryption.Value)
+	// the deprecated top-level windows_require_bitlocker_pin mirrors the
+	// canonical windows_settings.require_bitlocker_pin home
+	requireBitLockerPIN := spec.MDM.RequireBitLockerPIN.Value
+	if windowsSettings.RequireBitLockerPIN.Valid {
+		if spec.MDM.RequireBitLockerPIN.Valid && spec.MDM.RequireBitLockerPIN.Value != windowsSettings.RequireBitLockerPIN.Value {
+			return nil, ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("mdm.windows_require_bitlocker_pin",
+				"conflicts with windows_settings.require_bitlocker_pin"))
+		}
+		requireBitLockerPIN = windowsSettings.RequireBitLockerPIN.Value
+	}
+	windowsSettings.RequireBitLockerPIN = optjson.SetBool(requireBitLockerPIN)
 	linuxSettings := spec.MDM.LinuxSettings
 	if spec.MDM.EnableDiskEncryption.Valid {
 		linuxSettings.EnableEscrowDiskEncryptionKey = spec.MDM.EnableDiskEncryption
@@ -1782,7 +1805,7 @@ func (svc *Service) createTeamFromSpec(
 			MDM: fleet.TeamMDM{
 				EnableDiskEncryption:       enableDiskEncryption,
 				EnableRecoveryLockPassword: spec.MDM.EnableRecoveryLockPassword.Value,
-				RequireBitLockerPIN:        spec.MDM.RequireBitLockerPIN.Value,
+				RequireBitLockerPIN:        requireBitLockerPIN,
 				MacOSUpdates:               spec.MDM.MacOSUpdates,
 				IOSUpdates:                 spec.MDM.IOSUpdates,
 				IPadOSUpdates:              spec.MDM.IPadOSUpdates,
@@ -2023,8 +2046,20 @@ func (svc *Service) editTeamFromSpec(
 		return ctxerr.New(ctx, "Missing required private key. Learn how to configure the private key here: https://fleetdm.com/learn-more-about/fleet-server-private-key")
 	}
 
-	if spec.MDM.RequireBitLockerPIN.Valid {
-		team.Config.MDM.RequireBitLockerPIN = spec.MDM.RequireBitLockerPIN.Value
+	// the deprecated top-level windows_require_bitlocker_pin mirrors the
+	// canonical windows_settings.require_bitlocker_pin home; whichever the
+	// spec changes wins
+	incomingPIN := spec.MDM.RequireBitLockerPIN
+	if spec.MDM.WindowsSettings.RequireBitLockerPIN.Valid {
+		canonical := spec.MDM.WindowsSettings.RequireBitLockerPIN
+		if !incomingPIN.Valid || incomingPIN.Value == oldDiskEncryption.BitLockerPINRequired ||
+			canonical.Value != oldDiskEncryption.BitLockerPINRequired {
+			incomingPIN = canonical
+		}
+	}
+	if incomingPIN.Valid {
+		team.Config.MDM.RequireBitLockerPIN = incomingPIN.Value
+		team.Config.MDM.WindowsSettings.RequireBitLockerPIN = optjson.SetBool(incomingPIN.Value)
 	}
 
 	var didUpdateRecoveryLockPassword bool
@@ -2558,9 +2593,12 @@ func (svc *Service) updateTeamMDMDiskEncryption(ctx context.Context, tm *fleet.T
 	linuxChanged := apply(&tm.Config.MDM.LinuxSettings.EnableEscrowDiskEncryptionKey, changes.LinuxEscrow)
 	// the PIN is updated outside of apply: it doesn't enable key escrow, so it
 	// must not trigger the private-key requirement
-	pinChanged := requireBitLockerPIN != nil && tm.Config.MDM.RequireBitLockerPIN != *requireBitLockerPIN
-	if pinChanged {
+	pinChanged := requireBitLockerPIN != nil && oldDiskEncryption.BitLockerPINRequired != *requireBitLockerPIN
+	if requireBitLockerPIN != nil {
+		// the deprecated top-level key mirrors the canonical
+		// windows_settings.require_bitlocker_pin home
 		tm.Config.MDM.RequireBitLockerPIN = *requireBitLockerPIN
+		tm.Config.MDM.WindowsSettings.RequireBitLockerPIN = optjson.SetBool(*requireBitLockerPIN)
 	}
 
 	if !macOSChanged && !windowsChanged && !linuxChanged && !pinChanged {
@@ -2573,7 +2611,7 @@ func (svc *Service) updateTeamMDMDiskEncryption(ctx context.Context, tm *fleet.T
 
 	// the BitLocker PIN requires the Windows disk encryption setting
 	newDiskEncryption := tm.Config.MDM.DiskEncryptionConfig()
-	if tm.Config.MDM.RequireBitLockerPIN && !newDiskEncryption.WindowsEnabled {
+	if newDiskEncryption.BitLockerPINRequired && !newDiskEncryption.WindowsEnabled {
 		if oldDiskEncryption.WindowsEnabled {
 			return ctxerr.New(ctx, fleet.CantDisableDiskEncryptionIfPINRequiredErrMsg)
 		}

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -2636,8 +2636,8 @@ func (svc *Service) updateTeamMDMDiskEncryption(ctx context.Context, tm *fleet.T
 
 	// the BitLocker PIN requires the Windows disk encryption setting
 	newDiskEncryption := tm.Config.MDM.DiskEncryptionConfig()
-	if _, msg := fleet.BitLockerPINRequirementError(oldDiskEncryption.WindowsEnabled, newDiskEncryption); msg != "" {
-		return ctxerr.New(ctx, msg)
+	if field, msg := fleet.BitLockerPINRequirementError(oldDiskEncryption.WindowsEnabled, newDiskEncryption); msg != "" {
+		return ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError(field, msg))
 	}
 
 	// the flat toggle is virtual: keep the stored value consistent

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -341,6 +341,11 @@ func (svc *Service) ModifyTeam(ctx context.Context, teamID uint, payload fleet.T
 			}
 		}
 
+		// captured before the disk encryption merges below overwrite it, so the
+		// BitLocker PIN validation can tell "turning encryption off" apart from
+		// "turning the PIN on"
+		oldWindowsDiskEncryption := team.Config.MDM.WindowsSettings.EnableDiskEncryption.Value
+
 		if payload.MDM.EnableDiskEncryption.Valid {
 			// the deprecated flat toggle fans out to every per-platform disk
 			// encryption setting
@@ -393,6 +398,12 @@ func (svc *Service) ModifyTeam(ctx context.Context, teamID uint, payload fleet.T
 		if incomingPIN.Valid {
 			team.Config.MDM.RequireBitLockerPIN = incomingPIN.Value
 			team.Config.MDM.WindowsSettings.RequireBitLockerPIN = optjson.SetBool(incomingPIN.Value)
+		}
+
+		// the BitLocker PIN requires the Windows disk encryption setting
+		if field, msg := fleet.BitLockerPINRequirementError(oldWindowsDiskEncryption,
+			team.Config.MDM.DiskEncryptionConfig()); msg != "" {
+			return nil, fleet.NewInvalidArgumentError(field, msg)
 		}
 
 		if payload.MDM.HostNameTemplate.Set {
@@ -1704,6 +1715,14 @@ func (svc *Service) createTeamFromSpec(
 		requireBitLockerPIN = windowsSettings.RequireBitLockerPIN.Value
 	}
 	windowsSettings.RequireBitLockerPIN = optjson.SetBool(requireBitLockerPIN)
+	// the BitLocker PIN requires the Windows disk encryption setting; a new
+	// fleet has no previous state, so this is always the "enabling the PIN" case
+	if field, msg := fleet.BitLockerPINRequirementError(false, fleet.DiskEncryptionConfig{
+		WindowsEnabled:       windowsSettings.EnableDiskEncryption.Value,
+		BitLockerPINRequired: requireBitLockerPIN,
+	}); msg != "" {
+		return nil, ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError(field, msg))
+	}
 	linuxSettings := spec.MDM.LinuxSettings
 	if spec.MDM.EnableDiskEncryption.Valid {
 		linuxSettings.EnableEscrowDiskEncryptionKey = spec.MDM.EnableDiskEncryption
@@ -2060,6 +2079,12 @@ func (svc *Service) editTeamFromSpec(
 	if incomingPIN.Valid {
 		team.Config.MDM.RequireBitLockerPIN = incomingPIN.Value
 		team.Config.MDM.WindowsSettings.RequireBitLockerPIN = optjson.SetBool(incomingPIN.Value)
+	}
+
+	// the BitLocker PIN requires the Windows disk encryption setting
+	if field, msg := fleet.BitLockerPINRequirementError(oldDiskEncryption.WindowsEnabled,
+		team.Config.MDM.DiskEncryptionConfig()); msg != "" {
+		return ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError(field, msg))
 	}
 
 	var didUpdateRecoveryLockPassword bool
@@ -2611,11 +2636,8 @@ func (svc *Service) updateTeamMDMDiskEncryption(ctx context.Context, tm *fleet.T
 
 	// the BitLocker PIN requires the Windows disk encryption setting
 	newDiskEncryption := tm.Config.MDM.DiskEncryptionConfig()
-	if newDiskEncryption.BitLockerPINRequired && !newDiskEncryption.WindowsEnabled {
-		if oldDiskEncryption.WindowsEnabled {
-			return ctxerr.New(ctx, fleet.CantDisableDiskEncryptionIfPINRequiredErrMsg)
-		}
-		return ctxerr.New(ctx, fleet.CantEnablePINRequiredIfDiskEncryptionEnabled)
+	if _, msg := fleet.BitLockerPINRequirementError(oldDiskEncryption.WindowsEnabled, newDiskEncryption); msg != "" {
+		return ctxerr.New(ctx, msg)
 	}
 
 	// the flat toggle is virtual: keep the stored value consistent

--- a/ee/server/service/teams_test.go
+++ b/ee/server/service/teams_test.go
@@ -910,10 +910,18 @@ func TestUpdateTeamMDMDiskEncryption(t *testing.T) {
 			},
 		}
 
+		// the flat toggle fans out to every per-platform setting, as
+		// ResolvePerPlatform does for the endpoint payload
+		changes := fleet.DiskEncryptionSettingsChanges{
+			MacOSEnable:   tC.diskEncryption,
+			MacOSEscrow:   tC.diskEncryption,
+			WindowsEnable: tC.diskEncryption,
+			LinuxEscrow:   tC.diskEncryption,
+		}
 		err := svc.updateTeamMDMDiskEncryption(
 			ctx,
 			&team,
-			tC.diskEncryption,
+			changes,
 			tC.requireTPMPIN,
 		)
 

--- a/server/datastore/mysql/app_configs_test.go
+++ b/server/datastore/mysql/app_configs_test.go
@@ -471,6 +471,7 @@ func testGetConfigEnableDiskEncryption(t *testing.T, ds *Datastore) {
 	ac.MDM.WindowsSettings.EnableDiskEncryption = optjson.SetBool(true)
 	ac.MDM.LinuxSettings.EnableEscrowDiskEncryptionKey = optjson.SetBool(true)
 	ac.MDM.RequireBitLockerPIN = optjson.SetBool(true)
+	ac.MDM.WindowsSettings.RequireBitLockerPIN = optjson.SetBool(true)
 	err = ds.SaveAppConfig(ctx, ac)
 	require.NoError(t, err)
 	ac, err = ds.AppConfig(ctx)
@@ -532,6 +533,7 @@ func testGetConfigEnableDiskEncryption(t *testing.T, ds *Datastore) {
 	tm.Config.MDM.WindowsSettings.EnableDiskEncryption = optjson.SetBool(true)
 	tm.Config.MDM.LinuxSettings.EnableEscrowDiskEncryptionKey = optjson.SetBool(true)
 	tm.Config.MDM.RequireBitLockerPIN = true
+	tm.Config.MDM.WindowsSettings.RequireBitLockerPIN = optjson.SetBool(true)
 	tm, err = ds.SaveTeam(ctx, tm)
 	require.NoError(t, err)
 	require.NotNil(t, tm)

--- a/server/datastore/mysql/microsoft_mdm_test.go
+++ b/server/datastore/mysql/microsoft_mdm_test.go
@@ -675,6 +675,7 @@ func testMDMWindowsDiskEncryption(t *testing.T, ds *Datastore) {
 		t.Run("BitLocker profile status with PIN required", func(t *testing.T) {
 			// Turn on Bitlocker requirement
 			ac.MDM.RequireBitLockerPIN = optjson.SetBool(true)
+			ac.MDM.WindowsSettings.RequireBitLockerPIN = optjson.SetBool(true)
 			require.NoError(t, ds.SaveAppConfig(ctx, ac))
 			ac, err = ds.AppConfig(ctx)
 			require.NoError(t, err)
@@ -714,6 +715,7 @@ func testMDMWindowsDiskEncryption(t *testing.T, ds *Datastore) {
 
 			// Reset "RequireBitLockerPIN" to false
 			ac.MDM.RequireBitLockerPIN = optjson.SetBool(false)
+			ac.MDM.WindowsSettings.RequireBitLockerPIN = optjson.SetBool(false)
 			require.NoError(t, ds.SaveAppConfig(ctx, ac))
 			ac, err = ds.AppConfig(ctx)
 			require.NoError(t, err)

--- a/server/datastore/mysql/teams_test.go
+++ b/server/datastore/mysql/teams_test.go
@@ -919,6 +919,7 @@ func testTeamsMDMConfig(t *testing.T, ds *Datastore) {
 				CustomSettings:              optjson.SetSlice([]fleet.MDMProfileSpec{{Path: "foo"}, {Path: "bar"}}),
 				ManagedLocalAccountSettings: fleet.ManagedLocalAccountSettings{Enabled: optjson.SetBool(false)},
 				EnableDiskEncryption:        optjson.SetBool(false),
+				RequireBitLockerPIN:         optjson.SetBool(false),
 			},
 			AndroidSettings: fleet.AndroidSettings{
 				CustomSettings: optjson.SetSlice([]fleet.MDMProfileSpec{{Path: "baz"}, {Path: "qux"}}),

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -435,6 +435,30 @@ func (m *MDM) DiskEncryptionConfig() DiskEncryptionConfig {
 	}
 }
 
+// ResolveBitLockerPINAlias resolves the deprecated windows_require_bitlocker_pin
+// key against its canonical windows_settings.require_bitlocker_pin home for the
+// config and fleet-spec shapes. Both keys may be sent when they agree, and the
+// canonical one is authoritative; disagreeing values are rejected.
+//
+// This is stricter than the deprecated mdm.enable_disk_encryption toggle, which
+// resolves by which value the request changed: that toggle is derived from the
+// four per-platform settings, so a round-tripped document always carries a value
+// that may legitimately disagree with a per-platform edit. This pair is always
+// mirrored, so a disagreement can only be a contradiction.
+//
+// The returned value is invalid when neither key carries one, meaning "leave the
+// stored value alone".
+func ResolveBitLockerPINAlias(deprecated, canonical optjson.Bool) (optjson.Bool, error) {
+	if canonical.Valid && deprecated.Valid && canonical.Value != deprecated.Value {
+		return optjson.Bool{}, NewInvalidArgumentError("mdm.windows_require_bitlocker_pin",
+			"conflicts with mdm.windows_settings.require_bitlocker_pin")
+	}
+	if canonical.Valid {
+		return canonical, nil
+	}
+	return deprecated, nil
+}
+
 // BitLockerPINRequirementError reports requiring a BitLocker PIN while Windows
 // disk encryption is off, returning the offending field and message, or empty
 // strings when the pair is valid. Turning encryption off blames the encryption

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -286,6 +286,8 @@ type MDM struct {
 
 	EnableRecoveryLockPassword optjson.Bool `json:"enable_recovery_lock_password"`
 
+	// RequireBitLockerPIN is deprecated: use
+	// WindowsSettings.RequireBitLockerPIN, which it mirrors.
 	RequireBitLockerPIN optjson.Bool `json:"windows_require_bitlocker_pin"`
 
 	WindowsSettings WindowsSettings `json:"windows_settings"`
@@ -333,6 +335,7 @@ type MacOSDiskEncryptionSettingsPayload struct {
 // by POST /disk_encryption. Nil fields mean "don't change".
 type WindowsDiskEncryptionSettingsPayload struct {
 	EnableDiskEncryption *bool `json:"enable_disk_encryption"`
+	RequireBitLockerPIN  *bool `json:"require_bitlocker_pin"`
 }
 
 // LinuxDiskEncryptionSettingsPayload is the linux_settings object accepted by
@@ -361,6 +364,21 @@ type DiskEncryptionSettingsChanges struct {
 	MacOSEscrow   *bool
 	WindowsEnable *bool
 	LinuxEscrow   *bool
+}
+
+// ResolveBitLockerPIN resolves the deprecated windows_require_bitlocker_pin
+// field against its canonical windows_settings.require_bitlocker_pin home:
+// both may be sent when they agree, and the canonical one wins.
+func (p MDMDiskEncryptionSettingsPayload) ResolveBitLockerPIN() (*bool, error) {
+	if p.WindowsSettings == nil || p.WindowsSettings.RequireBitLockerPIN == nil {
+		return p.RequireBitLockerPIN, nil
+	}
+	if p.RequireBitLockerPIN != nil && *p.RequireBitLockerPIN != *p.WindowsSettings.RequireBitLockerPIN {
+		return nil, NewInvalidArgumentError(
+			"windows_require_bitlocker_pin", "conflicts with windows_settings.require_bitlocker_pin",
+		)
+	}
+	return p.WindowsSettings.RequireBitLockerPIN, nil
 }
 
 // ResolvePerPlatform applies the deprecated-key fan-out and conflict rules:
@@ -412,9 +430,19 @@ func (m *MDM) DiskEncryptionConfig() DiskEncryptionConfig {
 		MacOSEnabled:         m.MacOSSettings.EnableDiskEncryption.Value,
 		MacOSEscrowEnabled:   m.MacOSSettings.EnableEscrowDiskEncryptionKey.Value,
 		WindowsEnabled:       m.WindowsSettings.EnableDiskEncryption.Value,
-		BitLockerPINRequired: m.RequireBitLockerPIN.Value,
+		BitLockerPINRequired: m.BitLockerPINRequired(),
 		LinuxEscrowEnabled:   m.LinuxSettings.EnableEscrowDiskEncryptionKey.Value,
 	}
+}
+
+// BitLockerPINRequired returns the effective BitLocker PIN requirement: the
+// canonical windows_settings.require_bitlocker_pin when set, falling back to
+// the deprecated top-level key.
+func (m *MDM) BitLockerPINRequired() bool {
+	if m.WindowsSettings.RequireBitLockerPIN.Valid {
+		return m.WindowsSettings.RequireBitLockerPIN.Value
+	}
+	return m.RequireBitLockerPIN.Value
 }
 
 // normalizeDiskEncryptionSettings makes every serialization (API responses,
@@ -432,6 +460,23 @@ func (m *MDM) normalizeDiskEncryptionSettings() {
 		&m.LinuxSettings.EnableEscrowDiskEncryptionKey,
 	)
 	m.EnableDiskEncryption = optjson.SetBool(flat)
+	m.RequireBitLockerPIN, m.WindowsSettings.RequireBitLockerPIN = normalizeBitLockerPINFields(
+		m.RequireBitLockerPIN, m.WindowsSettings.RequireBitLockerPIN)
+}
+
+// normalizeBitLockerPINFields keeps the deprecated windows_require_bitlocker_pin
+// key and its canonical windows_settings.require_bitlocker_pin home in sync on
+// serialization: the canonical value wins when set, the deprecated one fills in
+// otherwise, and both default to explicit false.
+func normalizeBitLockerPINFields(deprecated, canonical optjson.Bool) (optjson.Bool, optjson.Bool) {
+	switch {
+	case canonical.Valid:
+		return optjson.SetBool(canonical.Value), canonical
+	case deprecated.Valid:
+		return deprecated, optjson.SetBool(deprecated.Value)
+	default:
+		return optjson.SetBool(false), optjson.SetBool(false)
+	}
 }
 
 // normalizeDiskEncryptionFields is the virtual-flat-key rule shared by
@@ -1530,6 +1575,11 @@ func (c *AppConfig) assignDeprecatedFields() {
 			}
 		}
 	}
+	// the BitLocker PIN's canonical home inherits the deprecated top-level key
+	// the same way when absent from the document
+	if !c.MDM.WindowsSettings.RequireBitLockerPIN.Set && c.MDM.RequireBitLockerPIN.Valid {
+		c.MDM.WindowsSettings.RequireBitLockerPIN = optjson.SetBool(c.MDM.RequireBitLockerPIN.Value)
+	}
 
 	// ensure the legacy configs are always nil
 	c.DeprecatedHostSettings = nil
@@ -2366,6 +2416,10 @@ type WindowsSettings struct {
 
 	// EnableDiskEncryption enforces BitLocker on Windows hosts.
 	EnableDiskEncryption optjson.Bool `json:"enable_disk_encryption"`
+
+	// RequireBitLockerPIN requires end users on Windows hosts to set a
+	// BitLocker PIN. Requires EnableDiskEncryption.
+	RequireBitLockerPIN optjson.Bool `json:"require_bitlocker_pin"`
 }
 
 // LinuxSettings contains MDM-related settings specific to Linux hosts.

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -444,9 +444,9 @@ func BitLockerPINRequirementError(oldWindowsEnabled bool, cfg DiskEncryptionConf
 		return "", ""
 	}
 	if oldWindowsEnabled {
-		return "mdm.enable_disk_encryption", CantDisableDiskEncryptionIfPINRequiredErrMsg
+		return "mdm.windows_settings.enable_disk_encryption", CantDisableDiskEncryptionIfPINRequiredErrMsg
 	}
-	return "mdm.windows_require_bitlocker_pin", CantEnablePINRequiredIfDiskEncryptionEnabled
+	return "mdm.windows_settings.require_bitlocker_pin", CantEnablePINRequiredIfDiskEncryptionEnabled
 }
 
 // BitLockerPINRequired returns the effective BitLocker PIN requirement: the

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -322,6 +322,79 @@ type DiskEncryptionConfig struct {
 	LinuxEscrowEnabled bool
 }
 
+// MacOSDiskEncryptionSettingsPayload is the macos_settings object accepted by
+// POST /disk_encryption. Nil fields mean "don't change".
+type MacOSDiskEncryptionSettingsPayload struct {
+	EnableDiskEncryption          *bool `json:"enable_disk_encryption"`
+	EnableEscrowDiskEncryptionKey *bool `json:"enable_escrow_disk_encryption_key"`
+}
+
+// WindowsDiskEncryptionSettingsPayload is the windows_settings object accepted
+// by POST /disk_encryption. Nil fields mean "don't change".
+type WindowsDiskEncryptionSettingsPayload struct {
+	EnableDiskEncryption *bool `json:"enable_disk_encryption"`
+}
+
+// LinuxDiskEncryptionSettingsPayload is the linux_settings object accepted by
+// POST /disk_encryption. Nil fields mean "don't change".
+type LinuxDiskEncryptionSettingsPayload struct {
+	EnableEscrowDiskEncryptionKey *bool `json:"enable_escrow_disk_encryption_key"`
+}
+
+// MDMDiskEncryptionSettingsPayload carries a POST /disk_encryption update
+// through the service layer. The deprecated flat EnableDiskEncryption fans out
+// to every per-platform setting; ResolvePerPlatform applies the fan-out and
+// conflict rules and returns the effective per-platform values.
+type MDMDiskEncryptionSettingsPayload struct {
+	// EnableDiskEncryption is deprecated: when set it applies to all platforms.
+	EnableDiskEncryption *bool
+	RequireBitLockerPIN  *bool
+	MacOSSettings        *MacOSDiskEncryptionSettingsPayload
+	WindowsSettings      *WindowsDiskEncryptionSettingsPayload
+	LinuxSettings        *LinuxDiskEncryptionSettingsPayload
+}
+
+// DiskEncryptionSettingsChanges holds the effective per-platform disk
+// encryption values of a settings write. Nil means "leave unchanged".
+type DiskEncryptionSettingsChanges struct {
+	MacOSEnable   *bool
+	MacOSEscrow   *bool
+	WindowsEnable *bool
+	LinuxEscrow   *bool
+}
+
+// ResolvePerPlatform applies the deprecated-key fan-out and conflict rules:
+// the legacy flat value fans out to every per-platform setting, and any
+// per-platform value explicitly sent alongside it must agree with it.
+func (p MDMDiskEncryptionSettingsPayload) ResolvePerPlatform() (DiskEncryptionSettingsChanges, error) {
+	var changes DiskEncryptionSettingsChanges
+	if p.MacOSSettings != nil {
+		changes.MacOSEnable = p.MacOSSettings.EnableDiskEncryption
+		changes.MacOSEscrow = p.MacOSSettings.EnableEscrowDiskEncryptionKey
+	}
+	if p.WindowsSettings != nil {
+		changes.WindowsEnable = p.WindowsSettings.EnableDiskEncryption
+	}
+	if p.LinuxSettings != nil {
+		changes.LinuxEscrow = p.LinuxSettings.EnableEscrowDiskEncryptionKey
+	}
+	if p.EnableDiskEncryption != nil {
+		legacy := *p.EnableDiskEncryption
+		for _, v := range []*bool{changes.MacOSEnable, changes.MacOSEscrow, changes.WindowsEnable, changes.LinuxEscrow} {
+			if v != nil && *v != legacy {
+				return DiskEncryptionSettingsChanges{}, NewInvalidArgumentError(
+					"enable_disk_encryption", "conflicts with per-platform disk encryption settings",
+				)
+			}
+		}
+		changes.MacOSEnable = &legacy
+		changes.MacOSEscrow = &legacy
+		changes.WindowsEnable = &legacy
+		changes.LinuxEscrow = &legacy
+	}
+	return changes, nil
+}
+
 // DiskEncryptionSettingsAllEnabled returns the AND of the four per-platform
 // disk encryption settings — the value the deprecated flat
 // mdm.enable_disk_encryption key reports.

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -435,6 +435,20 @@ func (m *MDM) DiskEncryptionConfig() DiskEncryptionConfig {
 	}
 }
 
+// BitLockerPINRequirementError reports requiring a BitLocker PIN while Windows
+// disk encryption is off, returning the offending field and message, or empty
+// strings when the pair is valid. Turning encryption off blames the encryption
+// field; turning the PIN on blames the PIN field.
+func BitLockerPINRequirementError(oldWindowsEnabled bool, cfg DiskEncryptionConfig) (field, msg string) {
+	if !cfg.BitLockerPINRequired || cfg.WindowsEnabled {
+		return "", ""
+	}
+	if oldWindowsEnabled {
+		return "mdm.enable_disk_encryption", CantDisableDiskEncryptionIfPINRequiredErrMsg
+	}
+	return "mdm.windows_require_bitlocker_pin", CantEnablePINRequiredIfDiskEncryptionEnabled
+}
+
 // BitLockerPINRequired returns the effective BitLocker PIN requirement: the
 // canonical windows_settings.require_bitlocker_pin when set, falling back to
 // the deprecated top-level key.

--- a/server/fleet/app_test.go
+++ b/server/fleet/app_test.go
@@ -1076,3 +1076,46 @@ func TestManagedLocalAccountSettingsMarshalDefaults(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, map[string]any{"enabled": false}, windowsSettings(v.([]byte)))
 }
+
+func TestBitLockerPINAliasSync(t *testing.T) {
+	t.Run("marshal mirrors the deprecated key and its canonical home", func(t *testing.T) {
+		for _, tc := range []struct {
+			name string
+			mdm  MDM
+			want bool
+		}{
+			{"deprecated only", MDM{RequireBitLockerPIN: optjson.SetBool(true)}, true},
+			{"canonical only", MDM{WindowsSettings: WindowsSettings{RequireBitLockerPIN: optjson.SetBool(true)}}, true},
+			{"canonical wins", MDM{
+				RequireBitLockerPIN: optjson.SetBool(false),
+				WindowsSettings:     WindowsSettings{RequireBitLockerPIN: optjson.SetBool(true)},
+			}, true},
+			{"neither defaults to false", MDM{}, false},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				b, err := json.Marshal(&AppConfig{MDM: tc.mdm})
+				require.NoError(t, err)
+				var doc map[string]any
+				require.NoError(t, json.Unmarshal(b, &doc))
+				mdm := doc["mdm"].(map[string]any)
+				require.Equal(t, tc.want, mdm["windows_require_bitlocker_pin"])
+				require.Equal(t, tc.want, mdm["windows_settings"].(map[string]any)["require_bitlocker_pin"])
+			})
+		}
+	})
+
+	t.Run("unmarshal fills the canonical home from a legacy document", func(t *testing.T) {
+		var ac AppConfig
+		require.NoError(t, json.Unmarshal([]byte(`{"mdm": {"windows_require_bitlocker_pin": true}}`), &ac))
+		require.True(t, ac.MDM.WindowsSettings.RequireBitLockerPIN.Value)
+		require.True(t, ac.MDM.BitLockerPINRequired())
+
+		// an explicitly present canonical value is never overridden
+		ac = AppConfig{}
+		require.NoError(t, json.Unmarshal([]byte(`{"mdm": {
+			"windows_require_bitlocker_pin": true,
+			"windows_settings": {"require_bitlocker_pin": false}
+		}}`), &ac))
+		require.False(t, ac.MDM.BitLockerPINRequired())
+	})
+}

--- a/server/fleet/app_test.go
+++ b/server/fleet/app_test.go
@@ -1139,14 +1139,14 @@ func TestBitLockerPINRequirementError(t *testing.T) {
 		{
 			name:      "enabling the PIN without encryption blames the PIN field",
 			cfg:       DiskEncryptionConfig{BitLockerPINRequired: true},
-			wantField: "mdm.windows_require_bitlocker_pin",
+			wantField: "mdm.windows_settings.require_bitlocker_pin",
 			wantMsg:   CantEnablePINRequiredIfDiskEncryptionEnabled,
 		},
 		{
 			name:              "disabling encryption while the PIN is required blames the encryption field",
 			oldWindowsEnabled: true,
 			cfg:               DiskEncryptionConfig{BitLockerPINRequired: true},
-			wantField:         "mdm.enable_disk_encryption",
+			wantField:         "mdm.windows_settings.enable_disk_encryption",
 			wantMsg:           CantDisableDiskEncryptionIfPINRequiredErrMsg,
 		},
 	} {

--- a/server/fleet/app_test.go
+++ b/server/fleet/app_test.go
@@ -1119,3 +1119,41 @@ func TestBitLockerPINAliasSync(t *testing.T) {
 		require.False(t, ac.MDM.BitLockerPINRequired())
 	})
 }
+
+func TestBitLockerPINRequirementError(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		oldWindowsEnabled bool
+		cfg               DiskEncryptionConfig
+		wantField         string
+		wantMsg           string
+	}{
+		{
+			name: "PIN with encryption on is valid",
+			cfg:  DiskEncryptionConfig{WindowsEnabled: true, BitLockerPINRequired: true},
+		},
+		{
+			name: "no PIN with encryption off is valid",
+			cfg:  DiskEncryptionConfig{},
+		},
+		{
+			name:      "enabling the PIN without encryption blames the PIN field",
+			cfg:       DiskEncryptionConfig{BitLockerPINRequired: true},
+			wantField: "mdm.windows_require_bitlocker_pin",
+			wantMsg:   CantEnablePINRequiredIfDiskEncryptionEnabled,
+		},
+		{
+			name:              "disabling encryption while the PIN is required blames the encryption field",
+			oldWindowsEnabled: true,
+			cfg:               DiskEncryptionConfig{BitLockerPINRequired: true},
+			wantField:         "mdm.enable_disk_encryption",
+			wantMsg:           CantDisableDiskEncryptionIfPINRequiredErrMsg,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			field, msg := BitLockerPINRequirementError(tc.oldWindowsEnabled, tc.cfg)
+			require.Equal(t, tc.wantField, field)
+			require.Equal(t, tc.wantMsg, msg)
+		})
+	}
+}

--- a/server/fleet/app_test.go
+++ b/server/fleet/app_test.go
@@ -1157,3 +1157,56 @@ func TestBitLockerPINRequirementError(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveBitLockerPINAlias(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		deprecated optjson.Bool
+		canonical  optjson.Bool
+		want       optjson.Bool
+		wantErr    bool
+	}{
+		{name: "neither provided leaves the stored value alone"},
+		{
+			name:       "deprecated only",
+			deprecated: optjson.SetBool(true),
+			want:       optjson.SetBool(true),
+		},
+		{
+			name:      "canonical only",
+			canonical: optjson.SetBool(true),
+			want:      optjson.SetBool(true),
+		},
+		{
+			name:       "both agreeing is accepted, as a round-tripped document sends",
+			deprecated: optjson.SetBool(true),
+			canonical:  optjson.SetBool(true),
+			want:       optjson.SetBool(true),
+		},
+		{
+			name:       "explicit null on the canonical key falls back to the deprecated one",
+			deprecated: optjson.SetBool(true),
+			canonical:  optjson.Bool{Set: true},
+			want:       optjson.SetBool(true),
+		},
+		{
+			name:       "disagreeing values are rejected",
+			deprecated: optjson.SetBool(false),
+			canonical:  optjson.SetBool(true),
+			wantErr:    true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ResolveBitLockerPINAlias(tc.deprecated, tc.canonical)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want.Valid, got.Valid)
+			if tc.want.Valid {
+				require.Equal(t, tc.want.Value, got.Value)
+			}
+		})
+	}
+}

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -24,7 +24,7 @@ type EnterpriseOverrides struct {
 	TeamByIDOrName func(ctx context.Context, id *uint, name *string) (*Team, error)
 	// UpdateTeamMDMDiskEncryption is the team-specific service method for when
 	// a team ID is provided to the UpdateMDMDiskEncryption method.
-	UpdateTeamMDMDiskEncryption   func(ctx context.Context, tm *Team, enable *bool, requireBitLockerPIN *bool) error
+	UpdateTeamMDMDiskEncryption   func(ctx context.Context, tm *Team, changes DiskEncryptionSettingsChanges, requireBitLockerPIN *bool) error
 	UpdateTeamMDMHostNameTemplate func(ctx context.Context, tm *Team, nameTemplate string) error
 
 	// ApplyHostNameTemplateChange reconciles host-name enforcement rows and emits
@@ -1105,9 +1105,9 @@ type Service interface {
 	// profile for the given team.
 	MDMAppleDisableFileVaultAndEscrow(ctx context.Context, teamID *uint) error
 
-	// UpdateMDMDiskEncryption updates the disk encryption setting for a
+	// UpdateMDMDiskEncryption updates the disk encryption settings for a
 	// specified team or for hosts with no team.
-	UpdateMDMDiskEncryption(ctx context.Context, teamID *uint, enableDiskEncryption *bool, requireBitLockerPIN *bool) error
+	UpdateMDMDiskEncryption(ctx context.Context, teamID *uint, payload MDMDiskEncryptionSettingsPayload) error
 
 	// UpdateMDMHostNameTemplate updates the host name template for the specified
 	// fleet. An empty template clears the setting; clearing never renames hosts.

--- a/server/fleet/teams.go
+++ b/server/fleet/teams.go
@@ -119,6 +119,9 @@ type TeamPayloadMDM struct {
 // TeamPayloadWindowsSettings is the subset of windows_settings fields settable via the team PATCH endpoint.
 type TeamPayloadWindowsSettings struct {
 	ManagedLocalAccountSettings ManagedLocalAccountSettings `json:"managed_local_account_settings"`
+	// RequireBitLockerPIN is the canonical home of the deprecated top-level
+	// windows_require_bitlocker_pin key.
+	RequireBitLockerPIN optjson.Bool `json:"require_bitlocker_pin"`
 }
 
 // Team is the data representation for the "Team" concept (group of hosts and
@@ -483,6 +486,13 @@ func (t TeamMDM) MarshalJSON() ([]byte, error) {
 		&t.WindowsSettings.EnableDiskEncryption,
 		&t.LinuxSettings.EnableEscrowDiskEncryptionKey,
 	)
+	// keep the deprecated windows_require_bitlocker_pin key in sync with its
+	// canonical windows_settings.require_bitlocker_pin home
+	if t.WindowsSettings.RequireBitLockerPIN.Valid {
+		t.RequireBitLockerPIN = t.WindowsSettings.RequireBitLockerPIN.Value
+	} else {
+		t.WindowsSettings.RequireBitLockerPIN = optjson.SetBool(t.RequireBitLockerPIN)
+	}
 	// the alias type has no methods, so marshaling it avoids infinite recursion
 	type alias TeamMDM
 	return json.Marshal(alias(t))
@@ -509,6 +519,11 @@ func (t *TeamMDM) UnmarshalJSON(b []byte) error {
 			*f = optjson.SetBool(t.EnableDiskEncryption)
 		}
 	}
+	// the BitLocker PIN's canonical home inherits the deprecated top-level key
+	// the same way when absent from the document
+	if !t.WindowsSettings.RequireBitLockerPIN.Set {
+		t.WindowsSettings.RequireBitLockerPIN = optjson.SetBool(t.RequireBitLockerPIN)
+	}
 	return nil
 }
 
@@ -518,11 +533,15 @@ func (t *TeamMDM) DiskEncryptionConfig() DiskEncryptionConfig {
 	if t == nil {
 		return DiskEncryptionConfig{}
 	}
+	pinRequired := t.RequireBitLockerPIN
+	if t.WindowsSettings.RequireBitLockerPIN.Valid {
+		pinRequired = t.WindowsSettings.RequireBitLockerPIN.Value
+	}
 	return DiskEncryptionConfig{
 		MacOSEnabled:         t.MacOSSettings.EnableDiskEncryption.Value,
 		MacOSEscrowEnabled:   t.MacOSSettings.EnableEscrowDiskEncryptionKey.Value,
 		WindowsEnabled:       t.WindowsSettings.EnableDiskEncryption.Value,
-		BitLockerPINRequired: t.RequireBitLockerPIN,
+		BitLockerPINRequired: pinRequired,
 		LinuxEscrowEnabled:   t.LinuxSettings.EnableEscrowDiskEncryptionKey.Value,
 	}
 }

--- a/server/mock/service/service_mock.go
+++ b/server/mock/service/service_mock.go
@@ -673,7 +673,7 @@ type MDMAppleEnableFileVaultAndEscrowFunc func(ctx context.Context, teamID *uint
 
 type MDMAppleDisableFileVaultAndEscrowFunc func(ctx context.Context, teamID *uint) error
 
-type UpdateMDMDiskEncryptionFunc func(ctx context.Context, teamID *uint, enableDiskEncryption *bool, requireBitLockerPIN *bool) error
+type UpdateMDMDiskEncryptionFunc func(ctx context.Context, teamID *uint, payload fleet.MDMDiskEncryptionSettingsPayload) error
 
 type UpdateMDMHostNameTemplateFunc func(ctx context.Context, fleetID *uint, nameTemplate string) error
 
@@ -4757,11 +4757,11 @@ func (s *Service) MDMAppleDisableFileVaultAndEscrow(ctx context.Context, teamID 
 	return s.MDMAppleDisableFileVaultAndEscrowFunc(ctx, teamID)
 }
 
-func (s *Service) UpdateMDMDiskEncryption(ctx context.Context, teamID *uint, enableDiskEncryption *bool, requireBitLockerPIN *bool) error {
+func (s *Service) UpdateMDMDiskEncryption(ctx context.Context, teamID *uint, payload fleet.MDMDiskEncryptionSettingsPayload) error {
 	s.mu.Lock()
 	s.UpdateMDMDiskEncryptionFuncInvoked = true
 	s.mu.Unlock()
-	return s.UpdateMDMDiskEncryptionFunc(ctx, teamID, enableDiskEncryption, requireBitLockerPIN)
+	return s.UpdateMDMDiskEncryptionFunc(ctx, teamID, payload)
 }
 
 func (s *Service) UpdateMDMHostNameTemplate(ctx context.Context, fleetID *uint, nameTemplate string) error {

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -845,27 +845,16 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 		appConfig.MDM.EnableDiskEncryption = oldAppConfig.MDM.EnableDiskEncryption
 	}
 
-	// The deprecated windows_require_bitlocker_pin key mirrors its canonical
-	// windows_settings.require_bitlocker_pin home; whichever the request
-	// changes wins. A one-boolean pair can't be changed to disagreeing values
-	// (changed means "not the stored value"), so no conflict is possible.
-	{
-		oldPIN := oldAppConfig.MDM.BitLockerPINRequired()
-		canonical := newAppConfig.MDM.WindowsSettings.RequireBitLockerPIN
-		deprecated := newAppConfig.MDM.RequireBitLockerPIN
-		switch {
-		case canonical.Valid && canonical.Value != oldPIN:
-			appConfig.MDM.RequireBitLockerPIN = optjson.SetBool(canonical.Value)
-			appConfig.MDM.WindowsSettings.RequireBitLockerPIN = optjson.SetBool(canonical.Value)
-		case deprecated.Valid && deprecated.Value != oldPIN:
-			appConfig.MDM.RequireBitLockerPIN = optjson.SetBool(deprecated.Value)
-			appConfig.MDM.WindowsSettings.RequireBitLockerPIN = optjson.SetBool(deprecated.Value)
-		case canonical.Valid || deprecated.Valid:
-			appConfig.MDM.RequireBitLockerPIN = optjson.SetBool(oldPIN)
-			appConfig.MDM.WindowsSettings.RequireBitLockerPIN = optjson.SetBool(oldPIN)
-		}
-		// absent or explicit null passes through: the stored values were the
-		// base of the merge
+	// the deprecated windows_require_bitlocker_pin key mirrors its canonical
+	// windows_settings.require_bitlocker_pin home. Absent or explicit-null
+	// keys pass through: the stored values were the base of the merge.
+	if pin, err := fleet.ResolveBitLockerPINAlias(
+		newAppConfig.MDM.RequireBitLockerPIN, newAppConfig.MDM.WindowsSettings.RequireBitLockerPIN,
+	); err != nil {
+		return nil, ctxerr.Wrap(ctx, err)
+	} else if pin.Valid {
+		appConfig.MDM.RequireBitLockerPIN = optjson.SetBool(pin.Value)
+		appConfig.MDM.WindowsSettings.RequireBitLockerPIN = optjson.SetBool(pin.Value)
 	}
 
 	// Apple account provisioning (Platform SSO): the IdP client secret is never

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -2430,19 +2430,10 @@ func (svc *Service) validateMDM(
 
 	// the PIN requirement is a BitLocker feature, so it's judged against the
 	// Windows setting, not the all-platforms aggregate
-	if !mdm.WindowsSettings.EnableDiskEncryption.Value {
-		switch {
-		case !oldMdm.WindowsSettings.EnableDiskEncryption.Value && mdm.BitLockerPINRequired():
-			invalid.Append(
-				"mdm.windows_require_bitlocker_pin",
-				fleet.CantEnablePINRequiredIfDiskEncryptionEnabled,
-			)
-		case oldMdm.WindowsSettings.EnableDiskEncryption.Value && mdm.BitLockerPINRequired():
-			invalid.Append(
-				"mdm.enable_disk_encryption",
-				fleet.CantDisableDiskEncryptionIfPINRequiredErrMsg,
-			)
-		}
+	if field, msg := fleet.BitLockerPINRequirementError(
+		oldMdm.WindowsSettings.EnableDiskEncryption.Value, mdm.DiskEncryptionConfig(),
+	); msg != "" {
+		invalid.Append(field, msg)
 	}
 
 	return nil

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -845,6 +845,29 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 		appConfig.MDM.EnableDiskEncryption = oldAppConfig.MDM.EnableDiskEncryption
 	}
 
+	// The deprecated windows_require_bitlocker_pin key mirrors its canonical
+	// windows_settings.require_bitlocker_pin home; whichever the request
+	// changes wins. A one-boolean pair can't be changed to disagreeing values
+	// (changed means "not the stored value"), so no conflict is possible.
+	{
+		oldPIN := oldAppConfig.MDM.BitLockerPINRequired()
+		canonical := newAppConfig.MDM.WindowsSettings.RequireBitLockerPIN
+		deprecated := newAppConfig.MDM.RequireBitLockerPIN
+		switch {
+		case canonical.Valid && canonical.Value != oldPIN:
+			appConfig.MDM.RequireBitLockerPIN = optjson.SetBool(canonical.Value)
+			appConfig.MDM.WindowsSettings.RequireBitLockerPIN = optjson.SetBool(canonical.Value)
+		case deprecated.Valid && deprecated.Value != oldPIN:
+			appConfig.MDM.RequireBitLockerPIN = optjson.SetBool(deprecated.Value)
+			appConfig.MDM.WindowsSettings.RequireBitLockerPIN = optjson.SetBool(deprecated.Value)
+		case canonical.Valid || deprecated.Valid:
+			appConfig.MDM.RequireBitLockerPIN = optjson.SetBool(oldPIN)
+			appConfig.MDM.WindowsSettings.RequireBitLockerPIN = optjson.SetBool(oldPIN)
+		}
+		// absent or explicit null passes through: the stored values were the
+		// base of the merge
+	}
+
 	// Apple account provisioning (Platform SSO): the IdP client secret is never
 	// persisted in the AppConfig JSON — it's stored encrypted in
 	// mdm_config_assets. Capture the caller-supplied secret here, validate, then
@@ -2409,12 +2432,12 @@ func (svc *Service) validateMDM(
 	// Windows setting, not the all-platforms aggregate
 	if !mdm.WindowsSettings.EnableDiskEncryption.Value {
 		switch {
-		case !oldMdm.WindowsSettings.EnableDiskEncryption.Value && mdm.RequireBitLockerPIN.Value:
+		case !oldMdm.WindowsSettings.EnableDiskEncryption.Value && mdm.BitLockerPINRequired():
 			invalid.Append(
 				"mdm.windows_require_bitlocker_pin",
 				fleet.CantEnablePINRequiredIfDiskEncryptionEnabled,
 			)
-		case oldMdm.WindowsSettings.EnableDiskEncryption.Value && mdm.RequireBitLockerPIN.Value:
+		case oldMdm.WindowsSettings.EnableDiskEncryption.Value && mdm.BitLockerPINRequired():
 			invalid.Append(
 				"mdm.enable_disk_encryption",
 				fleet.CantDisableDiskEncryptionIfPINRequiredErrMsg,

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -779,9 +779,11 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 
 	// The per-platform disk encryption settings follow PATCH-merge semantics:
 	// a field explicitly set to null keeps its stored value (as if not
-	// provided). The deprecated flat mdm.enable_disk_encryption wins when
-	// provided: it fans out to every per-platform setting, preserving its
-	// historical semantics.
+	// provided). The deprecated flat mdm.enable_disk_encryption fans out to
+	// all four per-platform settings; precedence between the flat toggle and
+	// a per-platform value sent in the same request goes to whichever the
+	// request actually changes, and changing both to disagreeing values is a
+	// conflict.
 	//
 	// TODO: move this logic to the AppConfig unmarshaller? we need to do
 	// this because we unmarshal twice into appConfig:
@@ -789,6 +791,9 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 	// 1. To get the JSON value from the database
 	// 2. To update fields with the incoming values
 	legacyDiskEncryption := newAppConfig.MDM.EnableDiskEncryption
+	// the flat toggle reads as the AND of the four per-platform settings, so
+	// "the request changes it" is measured against that
+	legacyDiskEncryptionChanged := legacyDiskEncryption.Valid && legacyDiskEncryption.Value != oldAppConfig.MDM.DiskEncryptionSettingsAllEnabled()
 	anyDiskEncryptionSet := legacyDiskEncryption.Valid
 	enablingDiskEncryption := false
 	for _, f := range []struct {
@@ -801,8 +806,19 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 		{newAppConfig.MDM.WindowsSettings.EnableDiskEncryption, &appConfig.MDM.WindowsSettings.EnableDiskEncryption, oldAppConfig.MDM.WindowsSettings.EnableDiskEncryption},
 		{newAppConfig.MDM.LinuxSettings.EnableEscrowDiskEncryptionKey, &appConfig.MDM.LinuxSettings.EnableEscrowDiskEncryptionKey, oldAppConfig.MDM.LinuxSettings.EnableEscrowDiskEncryptionKey},
 	} {
+		incomingChanged := f.incoming.Valid && f.incoming.Value != f.old.Value
 		switch {
-		case legacyDiskEncryption.Valid:
+		case incomingChanged && legacyDiskEncryptionChanged && f.incoming.Value != legacyDiskEncryption.Value:
+			// both the deprecated toggle and this per-platform setting are
+			// being changed, to disagreeing values
+			return nil, ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError(
+				"mdm.enable_disk_encryption", "conflicts with per-platform disk encryption settings"))
+		case incomingChanged:
+			*f.merged = f.incoming
+		case legacyDiskEncryption.Valid && (legacyDiskEncryptionChanged || !f.incoming.Valid):
+			// the deprecated toggle fans out: it wins over per-platform
+			// values the request carries but does not change (the common
+			// GET-modify-PATCH round-trip) and fills in absent ones
 			*f.merged = optjson.SetBool(legacyDiskEncryption.Value)
 		case f.incoming.Valid:
 			*f.merged = f.incoming
@@ -2037,16 +2053,19 @@ func (svc *Service) validateMDM(
 	overwrite bool,
 ) error {
 	if !lic.IsPremium() {
-		if mdm.MacOSSettings.EnableDiskEncryption.Value {
+		// gated on newly enabling (not the stored value) so a downgraded
+		// license with settings still on can save unrelated config changes
+		// and turn the settings off
+		if mdm.MacOSSettings.EnableDiskEncryption.Value && !oldMdm.MacOSSettings.EnableDiskEncryption.Value {
 			invalid.Append("apple_settings.enable_disk_encryption", ErrMissingLicense.Error())
 		}
-		if mdm.MacOSSettings.EnableEscrowDiskEncryptionKey.Value {
+		if mdm.MacOSSettings.EnableEscrowDiskEncryptionKey.Value && !oldMdm.MacOSSettings.EnableEscrowDiskEncryptionKey.Value {
 			invalid.Append("apple_settings.enable_escrow_disk_encryption_key", ErrMissingLicense.Error())
 		}
-		if mdm.WindowsSettings.EnableDiskEncryption.Value {
+		if mdm.WindowsSettings.EnableDiskEncryption.Value && !oldMdm.WindowsSettings.EnableDiskEncryption.Value {
 			invalid.Append("windows_settings.enable_disk_encryption", ErrMissingLicense.Error())
 		}
-		if mdm.LinuxSettings.EnableEscrowDiskEncryptionKey.Value {
+		if mdm.LinuxSettings.EnableEscrowDiskEncryptionKey.Value && !oldMdm.LinuxSettings.EnableEscrowDiskEncryptionKey.Value {
 			invalid.Append("linux_settings.enable_escrow_disk_encryption_key", ErrMissingLicense.Error())
 		}
 	}

--- a/server/service/appconfig_test.go
+++ b/server/service/appconfig_test.go
@@ -1228,6 +1228,7 @@ func TestMDMConfig(t *testing.T) {
 			WindowsSettings: fleet.WindowsSettings{
 				CustomSettings:              optjson.Slice[fleet.MDMProfileSpec]{Set: true, Value: []fleet.MDMProfileSpec{}},
 				ManagedLocalAccountSettings: fleet.ManagedLocalAccountSettings{Enabled: optjson.SetBool(false)},
+				RequireBitLockerPIN:         optjson.Bool{Set: true},
 			},
 			AndroidSettings: fleet.AndroidSettings{
 				CustomSettings: optjson.Slice[fleet.MDMProfileSpec]{Set: true, Value: []fleet.MDMProfileSpec{}},

--- a/server/service/appconfig_test.go
+++ b/server/service/appconfig_test.go
@@ -3744,3 +3744,116 @@ func TestModifyAppConfigWindowsEnrollment(t *testing.T) {
 		})
 	}
 }
+
+func TestDiskEncryptionPrecedence(t *testing.T) {
+	admin := &fleet.User{GlobalRole: new(fleet.RoleAdmin)}
+
+	// stored state: windows on, everything else off (the flat toggle reads as
+	// the AND of the four, so it's false)
+	mixedStored := func() fleet.MDM {
+		return fleet.MDM{
+			EnableDiskEncryption: optjson.SetBool(false),
+			MacOSSettings: fleet.MacOSSettings{
+				EnableDiskEncryption:          optjson.SetBool(false),
+				EnableEscrowDiskEncryptionKey: optjson.SetBool(false),
+			},
+			WindowsSettings: fleet.WindowsSettings{EnableDiskEncryption: optjson.SetBool(true)},
+			LinuxSettings:   fleet.LinuxSettings{EnableEscrowDiskEncryptionKey: optjson.SetBool(false)},
+		}
+	}
+	allOff := func() fleet.MDM {
+		m := mixedStored()
+		m.WindowsSettings.EnableDiskEncryption = optjson.SetBool(false)
+		return m
+	}
+
+	for _, tc := range []struct {
+		name          string
+		stored        fleet.MDM
+		payload       string
+		expectedError string
+		check         func(t *testing.T, mdm fleet.MDM)
+	}{
+		{
+			name:   "changing flat and per-platform to disagreeing values conflicts",
+			stored: mixedStored(),
+			payload: `{"mdm": {"enable_disk_encryption": true,
+				"windows_settings": {"enable_disk_encryption": false}}}`,
+			expectedError: "conflicts with per-platform disk encryption settings",
+		},
+		{
+			name:   "per-platform change wins over an unchanged flat toggle",
+			stored: allOff(),
+			payload: `{"mdm": {"enable_disk_encryption": false,
+				"windows_settings": {"enable_disk_encryption": true}}}`,
+			check: func(t *testing.T, mdm fleet.MDM) {
+				require.True(t, mdm.WindowsSettings.EnableDiskEncryption.Value)
+				require.False(t, mdm.MacOSSettings.EnableDiskEncryption.Value)
+				require.False(t, mdm.LinuxSettings.EnableEscrowDiskEncryptionKey.Value)
+				require.False(t, mdm.EnableDiskEncryption.Value)
+			},
+		},
+		{
+			name:   "changed flat toggle wins over restated per-platform values",
+			stored: mixedStored(),
+			payload: `{"mdm": {"enable_disk_encryption": true,
+				"windows_settings": {"enable_disk_encryption": true}}}`,
+			check: func(t *testing.T, mdm fleet.MDM) {
+				require.True(t, mdm.MacOSSettings.EnableDiskEncryption.Value)
+				require.True(t, mdm.MacOSSettings.EnableEscrowDiskEncryptionKey.Value)
+				require.True(t, mdm.WindowsSettings.EnableDiskEncryption.Value)
+				require.True(t, mdm.LinuxSettings.EnableEscrowDiskEncryptionKey.Value)
+				require.True(t, mdm.EnableDiskEncryption.Value)
+			},
+		},
+		{
+			name:    "flat toggle alone fans out over a mixed stored state",
+			stored:  mixedStored(),
+			payload: `{"mdm": {"enable_disk_encryption": false}}`,
+			check: func(t *testing.T, mdm fleet.MDM) {
+				require.False(t, mdm.WindowsSettings.EnableDiskEncryption.Value)
+				require.False(t, mdm.EnableDiskEncryption.Value)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ds := new(mock.Store)
+			cfg := config.TestConfig()
+			cfg.Server.PrivateKey = "test-private-key-not-used-by-mock"
+			svc, ctx := newTestServiceWithConfig(t, ds, cfg, nil, nil, &TestServerOpts{License: &fleet.LicenseInfo{Tier: fleet.TierPremium}})
+			ctx = viewer.NewContext(ctx, viewer.Viewer{User: admin})
+
+			dsAppConfig := &fleet.AppConfig{
+				OrgInfo:        fleet.OrgInfo{OrgName: "Test"},
+				ServerSettings: fleet.ServerSettings{ServerURL: "https://example.org"},
+				MDM:            tc.stored,
+			}
+			ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+				return dsAppConfig, nil
+			}
+			ds.SaveAppConfigFunc = func(ctx context.Context, conf *fleet.AppConfig) error {
+				*dsAppConfig = *conf
+				return nil
+			}
+			ds.TeamByNameFunc = func(ctx context.Context, name string) (*fleet.Team, error) {
+				return nil, sql.ErrNoRows
+			}
+			ds.ListABMTokensFunc = func(ctx context.Context) ([]*fleet.ABMToken, error) {
+				return []*fleet.ABMToken{}, nil
+			}
+			ds.ListVPPTokensFunc = func(ctx context.Context) ([]*fleet.VPPTokenDB, error) {
+				return []*fleet.VPPTokenDB{}, nil
+			}
+
+			modified, err := svc.ModifyAppConfig(ctx, []byte(tc.payload), fleet.ApplySpecOptions{})
+			if tc.expectedError != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tc.expectedError)
+				return
+			}
+			require.NoError(t, err)
+			tc.check(t, modified.MDM)
+			tc.check(t, dsAppConfig.MDM)
+		})
+	}
+}

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -3670,13 +3670,15 @@ func (r updateMDMAppleSettingsResponse) Status() int { return http.StatusNoConte
 // team endpoints only allow write access to admins.
 func updateMDMAppleSettingsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (fleet.Errorer, error) {
 	req := request.(*updateMDMAppleSettingsRequest)
-	if err := svc.UpdateMDMDiskEncryption(ctx, req.MDMAppleSettingsPayload.TeamID, req.MDMAppleSettingsPayload.EnableDiskEncryption, nil); err != nil {
+	if err := svc.UpdateMDMDiskEncryption(ctx, req.MDMAppleSettingsPayload.TeamID, fleet.MDMDiskEncryptionSettingsPayload{
+		EnableDiskEncryption: req.MDMAppleSettingsPayload.EnableDiskEncryption,
+	}); err != nil {
 		return updateMDMAppleSettingsResponse{Err: err}, nil
 	}
 	return updateMDMAppleSettingsResponse{}, nil
 }
 
-func (svc *Service) updateAppConfigMDMDiskEncryption(ctx context.Context, enabled *bool) error {
+func (svc *Service) updateAppConfigMDMDiskEncryption(ctx context.Context, changes fleet.DiskEncryptionSettingsChanges, requireBitLockerPIN *bool) error {
 	// appconfig is only used internally, it's fine to read it unobfuscated
 	// (svc.AppConfigObfuscated must not be used because the write-only users
 	// such as gitops will fail to access it).
@@ -3685,55 +3687,71 @@ func (svc *Service) updateAppConfigMDMDiskEncryption(ctx context.Context, enable
 		return err
 	}
 
-	var didUpdateDiskEncryption bool
-	var macOSDiskEncryptionWasOn bool
-	if enabled != nil {
-		// the deprecated flat toggle fans out to every per-platform disk
-		// encryption setting
-		macOSDiskEncryptionWasOn = ac.MDM.MacOSSettings.EnableDiskEncryption.Value ||
-			ac.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey.Value
-		changed := ac.MDM.MacOSSettings.EnableDiskEncryption.Value != *enabled ||
-			ac.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey.Value != *enabled ||
-			ac.MDM.WindowsSettings.EnableDiskEncryption.Value != *enabled ||
-			ac.MDM.LinuxSettings.EnableEscrowDiskEncryptionKey.Value != *enabled
-		if changed {
-			if *enabled && svc.config.Server.PrivateKey == "" {
-				return ctxerr.New(ctx, "Missing required private key. Learn how to configure the private key here: https://fleetdm.com/learn-more-about/fleet-server-private-key")
-			}
+	oldWindowsDiskEncryption := ac.MDM.WindowsSettings.EnableDiskEncryption.Value
+	macOSDiskEncryptionWasOn := ac.MDM.MacOSSettings.EnableDiskEncryption.Value || ac.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey.Value
 
-			v := optjson.SetBool(*enabled)
-			ac.MDM.MacOSSettings.EnableDiskEncryption = v
-			ac.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey = v
-			ac.MDM.WindowsSettings.EnableDiskEncryption = v
-			ac.MDM.LinuxSettings.EnableEscrowDiskEncryptionKey = v
-			ac.MDM.EnableDiskEncryption = v
-			didUpdateDiskEncryption = true
+	enabling := false
+	apply := func(dst *optjson.Bool, v *bool) bool {
+		if v == nil || dst.Value == *v {
+			return false
 		}
+		enabling = enabling || *v
+		*dst = optjson.SetBool(*v)
+		return true
 	}
-	if didUpdateDiskEncryption {
-		if err := svc.ds.SaveAppConfig(ctx, ac); err != nil {
-			return err
+	macOSChanged := apply(&ac.MDM.MacOSSettings.EnableDiskEncryption, changes.MacOSEnable)
+	macOSChanged = apply(&ac.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey, changes.MacOSEscrow) || macOSChanged
+	windowsChanged := apply(&ac.MDM.WindowsSettings.EnableDiskEncryption, changes.WindowsEnable)
+	linuxChanged := apply(&ac.MDM.LinuxSettings.EnableEscrowDiskEncryptionKey, changes.LinuxEscrow)
+	// the PIN is updated outside of apply: it doesn't enable key escrow, so it
+	// must not trigger the private-key requirement (mirrors the team path)
+	pinChanged := requireBitLockerPIN != nil && ac.MDM.RequireBitLockerPIN.Value != *requireBitLockerPIN
+	if pinChanged {
+		ac.MDM.RequireBitLockerPIN = optjson.SetBool(*requireBitLockerPIN)
+	}
+
+	if !macOSChanged && !windowsChanged && !linuxChanged && !pinChanged {
+		return nil
+	}
+
+	if enabling && svc.config.Server.PrivateKey == "" {
+		return ctxerr.New(ctx, "Missing required private key. Learn how to configure the private key here: https://fleetdm.com/learn-more-about/fleet-server-private-key")
+	}
+
+	// the BitLocker PIN requires the Windows disk encryption setting
+	if !ac.MDM.WindowsSettings.EnableDiskEncryption.Value && ac.MDM.RequireBitLockerPIN.Value {
+		if oldWindowsDiskEncryption {
+			return ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("mdm.enable_disk_encryption", fleet.CantDisableDiskEncryptionIfPINRequiredErrMsg))
 		}
-		// The FileVault profile covers enforcement and escrow as a whole: only
-		// the off<->on transition of the macOS pair creates or deletes it.
-		macOSDiskEncryptionOn := ac.MDM.MacOSSettings.EnableDiskEncryption.Value ||
-			ac.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey.Value
-		if ac.MDM.EnabledAndConfigured && macOSDiskEncryptionOn != macOSDiskEncryptionWasOn { // if macOS MDM is configured, set up FileVault escrow
-			var act fleet.ActivityDetails
-			if macOSDiskEncryptionOn {
-				act = fleet.ActivityTypeEnabledMacosDiskEncryption{}
-				if err := svc.EnterpriseOverrides.MDMAppleEnableFileVaultAndEscrow(ctx, nil); err != nil {
-					return ctxerr.Wrap(ctx, err, "enable no-team filevault and escrow")
-				}
-			} else {
-				act = fleet.ActivityTypeDisabledMacosDiskEncryption{}
-				if err := svc.EnterpriseOverrides.MDMAppleDisableFileVaultAndEscrow(ctx, nil); err != nil && !fleet.IsNotFound(err) {
-					return ctxerr.Wrap(ctx, err, "disable no-team filevault and escrow")
-				}
+		return ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("mdm.windows_require_bitlocker_pin", fleet.CantEnablePINRequiredIfDiskEncryptionEnabled))
+	}
+
+	// the flat toggle is virtual: keep the stored value consistent
+	ac.MDM.EnableDiskEncryption = optjson.SetBool(ac.MDM.DiskEncryptionSettingsAllEnabled())
+
+	if err := svc.ds.SaveAppConfig(ctx, ac); err != nil {
+		return err
+	}
+
+	// The FileVault profile covers enforcement and escrow as a whole: only
+	// the off<->on transition of the macOS pair creates or deletes it.
+	macOSDiskEncryptionOn := ac.MDM.MacOSSettings.EnableDiskEncryption.Value ||
+		ac.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey.Value
+	if ac.MDM.EnabledAndConfigured && macOSDiskEncryptionOn != macOSDiskEncryptionWasOn { // if macOS MDM is configured, set up FileVault escrow
+		var act fleet.ActivityDetails
+		if macOSDiskEncryptionOn {
+			act = fleet.ActivityTypeEnabledMacosDiskEncryption{}
+			if err := svc.EnterpriseOverrides.MDMAppleEnableFileVaultAndEscrow(ctx, nil); err != nil {
+				return ctxerr.Wrap(ctx, err, "enable no-team filevault and escrow")
 			}
-			if err := svc.NewActivity(ctx, authz.UserFromContext(ctx), act); err != nil {
-				return ctxerr.Wrap(ctx, err, "create activity for app config macos disk encryption")
+		} else {
+			act = fleet.ActivityTypeDisabledMacosDiskEncryption{}
+			if err := svc.EnterpriseOverrides.MDMAppleDisableFileVaultAndEscrow(ctx, nil); err != nil && !fleet.IsNotFound(err) {
+				return ctxerr.Wrap(ctx, err, "disable no-team filevault and escrow")
 			}
+		}
+		if err := svc.NewActivity(ctx, authz.UserFromContext(ctx), act); err != nil {
+			return ctxerr.Wrap(ctx, err, "create activity for app config macos disk encryption")
 		}
 	}
 	return nil

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -3722,11 +3722,8 @@ func (svc *Service) updateAppConfigMDMDiskEncryption(ctx context.Context, change
 	}
 
 	// the BitLocker PIN requires the Windows disk encryption setting
-	if !ac.MDM.WindowsSettings.EnableDiskEncryption.Value && ac.MDM.BitLockerPINRequired() {
-		if oldWindowsDiskEncryption {
-			return ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("mdm.enable_disk_encryption", fleet.CantDisableDiskEncryptionIfPINRequiredErrMsg))
-		}
-		return ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("mdm.windows_require_bitlocker_pin", fleet.CantEnablePINRequiredIfDiskEncryptionEnabled))
+	if field, msg := fleet.BitLockerPINRequirementError(oldWindowsDiskEncryption, ac.MDM.DiskEncryptionConfig()); msg != "" {
+		return ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError(field, msg))
 	}
 
 	// the flat toggle is virtual: keep the stored value consistent

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -3705,9 +3705,12 @@ func (svc *Service) updateAppConfigMDMDiskEncryption(ctx context.Context, change
 	linuxChanged := apply(&ac.MDM.LinuxSettings.EnableEscrowDiskEncryptionKey, changes.LinuxEscrow)
 	// the PIN is updated outside of apply: it doesn't enable key escrow, so it
 	// must not trigger the private-key requirement (mirrors the team path)
-	pinChanged := requireBitLockerPIN != nil && ac.MDM.RequireBitLockerPIN.Value != *requireBitLockerPIN
-	if pinChanged {
+	pinChanged := requireBitLockerPIN != nil && ac.MDM.BitLockerPINRequired() != *requireBitLockerPIN
+	if requireBitLockerPIN != nil {
+		// the deprecated top-level key mirrors the canonical
+		// windows_settings.require_bitlocker_pin home
 		ac.MDM.RequireBitLockerPIN = optjson.SetBool(*requireBitLockerPIN)
+		ac.MDM.WindowsSettings.RequireBitLockerPIN = optjson.SetBool(*requireBitLockerPIN)
 	}
 
 	if !macOSChanged && !windowsChanged && !linuxChanged && !pinChanged {
@@ -3719,7 +3722,7 @@ func (svc *Service) updateAppConfigMDMDiskEncryption(ctx context.Context, change
 	}
 
 	// the BitLocker PIN requires the Windows disk encryption setting
-	if !ac.MDM.WindowsSettings.EnableDiskEncryption.Value && ac.MDM.RequireBitLockerPIN.Value {
+	if !ac.MDM.WindowsSettings.EnableDiskEncryption.Value && ac.MDM.BitLockerPINRequired() {
 		if oldWindowsDiskEncryption {
 			return ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("mdm.enable_disk_encryption", fleet.CantDisableDiskEncryptionIfPINRequiredErrMsg))
 		}

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -5061,7 +5061,7 @@ func TestUpdateMDMAppleSettings(t *testing.T) {
 			}
 			ctx = license.NewContext(ctx, &fleet.LicenseInfo{Tier: tier})
 
-			err := svc.UpdateMDMDiskEncryption(ctx, tt.teamID, nil, nil)
+			err := svc.UpdateMDMDiskEncryption(ctx, tt.teamID, fleet.MDMDiskEncryptionSettingsPayload{})
 			if tt.wantErr == "" {
 				require.NoError(t, err)
 				return

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -2836,7 +2836,15 @@ func (c *Client) DoGitOps(
 		defaultPerPlatformKey := func(parent, key string) {
 			m, ok := mdmAppConfig[parent].(map[string]any)
 			if !ok {
+				// the parent may hold a typed default (e.g. fleet.MacOSSettings
+				// with an empty custom_settings): convert it instead of
+				// replacing it so those defaults are preserved
 				m = map[string]any{}
+				if existing, present := mdmAppConfig[parent]; present && existing != nil {
+					if b, err := json.Marshal(existing); err == nil {
+						_ = json.Unmarshal(b, &m)
+					}
+				}
 				mdmAppConfig[parent] = m
 			}
 			// an explicit null means the same as absent: reset to false (the

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -2839,7 +2839,9 @@ func (c *Client) DoGitOps(
 				m = map[string]any{}
 				mdmAppConfig[parent] = m
 			}
-			if _, ok := m[key]; !ok {
+			// an explicit null means the same as absent: reset to false (the
+			// server would treat null as "keep the stored value")
+			if v, ok := m[key]; !ok || v == nil {
 				m[key] = false
 			}
 		}
@@ -2871,7 +2873,7 @@ func (c *Client) DoGitOps(
 			windowsDiskEncryption = windowsEnable
 		}
 		if !windowsDiskEncryption && requireBitLockerPIN {
-			return nil, errors.New("enable_disk_encryption cannot be false if windows_require_bitlocker_pin is true")
+			return nil, errors.New("enable_disk_encryption (or windows_settings.enable_disk_encryption) cannot be false if windows_require_bitlocker_pin is true")
 		}
 
 		mdmAppConfig["enable_recovery_lock_password"] = enableRecoveryLockPassword

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -2822,68 +2822,11 @@ func (c *Client) DoGitOps(
 		if incoming.Controls.RequireBitLockerPIN != nil {
 			requireBitLockerPIN = incoming.Controls.RequireBitLockerPIN.(bool)
 		}
-
-		// per-platform disk encryption settings: read a key from the config,
-		// or default an absent one to false so the config stays declarative
-		perPlatformKey := func(parent, key string) (value, present bool) {
-			m, ok := mdmAppConfig[parent].(map[string]any)
-			if !ok {
-				return false, false
-			}
-			v, ok := m[key].(bool)
-			return v, ok
-		}
-		defaultPerPlatformKey := func(parent, key string) {
-			m, ok := mdmAppConfig[parent].(map[string]any)
-			if !ok {
-				// the parent may hold a typed default (e.g. fleet.MacOSSettings
-				// with an empty custom_settings): convert it instead of
-				// replacing it so those defaults are preserved
-				m = map[string]any{}
-				if existing, present := mdmAppConfig[parent]; present && existing != nil {
-					if b, err := json.Marshal(existing); err == nil {
-						_ = json.Unmarshal(b, &m)
-					}
-				}
-				mdmAppConfig[parent] = m
-			}
-			// an explicit null means the same as absent: reset to false (the
-			// server would treat null as "keep the stored value")
-			if v, ok := m[key]; !ok || v == nil {
-				m[key] = false
-			}
-		}
-		_, macOSEnablePresent := perPlatformKey("macos_settings", "enable_disk_encryption")
-		_, macOSEscrowPresent := perPlatformKey("macos_settings", "enable_escrow_disk_encryption_key")
-		windowsEnable, windowsEnablePresent := perPlatformKey("windows_settings", "enable_disk_encryption")
-		_, linuxEscrowPresent := perPlatformKey("linux_settings", "enable_escrow_disk_encryption_key")
-		anyPerPlatformPresent := macOSEnablePresent || macOSEscrowPresent || windowsEnablePresent || linuxEscrowPresent
-
-		switch {
-		case anyPerPlatformPresent && incoming.Controls.EnableDiskEncryption == nil:
-			// per-platform form: absent settings reset to explicit false, and
-			// the deprecated flat key is not sent — the server would treat it
-			// as an authoritative fan-out and stomp the per-platform values
-			defaultPerPlatformKey("macos_settings", "enable_disk_encryption")
-			defaultPerPlatformKey("macos_settings", "enable_escrow_disk_encryption_key")
-			defaultPerPlatformKey("windows_settings", "enable_disk_encryption")
-			defaultPerPlatformKey("linux_settings", "enable_escrow_disk_encryption_key")
-		default:
-			// legacy form (or both, which the server conflict-checks): the
-			// flat key fans out server-side, filling absent per-platform keys
-			mdmAppConfig["enable_disk_encryption"] = enableDiskEncryption
+		if !enableDiskEncryption && requireBitLockerPIN {
+			return nil, errors.New("enable_disk_encryption cannot be false if windows_require_bitlocker_pin is true")
 		}
 
-		// the PIN is a BitLocker feature: the Windows per-platform setting
-		// satisfies the requirement even when the flat toggle is off
-		windowsDiskEncryption := enableDiskEncryption
-		if windowsEnablePresent {
-			windowsDiskEncryption = windowsEnable
-		}
-		if !windowsDiskEncryption && requireBitLockerPIN {
-			return nil, errors.New("enable_disk_encryption (or windows_settings.enable_disk_encryption) cannot be false if windows_require_bitlocker_pin is true")
-		}
-
+		mdmAppConfig["enable_disk_encryption"] = enableDiskEncryption
 		mdmAppConfig["enable_recovery_lock_password"] = enableRecoveryLockPassword
 		mdmAppConfig["windows_require_bitlocker_pin"] = requireBitLockerPIN
 

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -2822,11 +2822,58 @@ func (c *Client) DoGitOps(
 		if incoming.Controls.RequireBitLockerPIN != nil {
 			requireBitLockerPIN = incoming.Controls.RequireBitLockerPIN.(bool)
 		}
-		if !enableDiskEncryption && requireBitLockerPIN {
+
+		// per-platform disk encryption settings: read a key from the config,
+		// or default an absent one to false so the config stays declarative
+		perPlatformKey := func(parent, key string) (value, present bool) {
+			m, ok := mdmAppConfig[parent].(map[string]any)
+			if !ok {
+				return false, false
+			}
+			v, ok := m[key].(bool)
+			return v, ok
+		}
+		defaultPerPlatformKey := func(parent, key string) {
+			m, ok := mdmAppConfig[parent].(map[string]any)
+			if !ok {
+				m = map[string]any{}
+				mdmAppConfig[parent] = m
+			}
+			if _, ok := m[key]; !ok {
+				m[key] = false
+			}
+		}
+		_, macOSEnablePresent := perPlatformKey("macos_settings", "enable_disk_encryption")
+		_, macOSEscrowPresent := perPlatformKey("macos_settings", "enable_escrow_disk_encryption_key")
+		windowsEnable, windowsEnablePresent := perPlatformKey("windows_settings", "enable_disk_encryption")
+		_, linuxEscrowPresent := perPlatformKey("linux_settings", "enable_escrow_disk_encryption_key")
+		anyPerPlatformPresent := macOSEnablePresent || macOSEscrowPresent || windowsEnablePresent || linuxEscrowPresent
+
+		switch {
+		case anyPerPlatformPresent && incoming.Controls.EnableDiskEncryption == nil:
+			// per-platform form: absent settings reset to explicit false, and
+			// the deprecated flat key is not sent — the server would treat it
+			// as an authoritative fan-out and stomp the per-platform values
+			defaultPerPlatformKey("macos_settings", "enable_disk_encryption")
+			defaultPerPlatformKey("macos_settings", "enable_escrow_disk_encryption_key")
+			defaultPerPlatformKey("windows_settings", "enable_disk_encryption")
+			defaultPerPlatformKey("linux_settings", "enable_escrow_disk_encryption_key")
+		default:
+			// legacy form (or both, which the server conflict-checks): the
+			// flat key fans out server-side, filling absent per-platform keys
+			mdmAppConfig["enable_disk_encryption"] = enableDiskEncryption
+		}
+
+		// the PIN is a BitLocker feature: the Windows per-platform setting
+		// satisfies the requirement even when the flat toggle is off
+		windowsDiskEncryption := enableDiskEncryption
+		if windowsEnablePresent {
+			windowsDiskEncryption = windowsEnable
+		}
+		if !windowsDiskEncryption && requireBitLockerPIN {
 			return nil, errors.New("enable_disk_encryption cannot be false if windows_require_bitlocker_pin is true")
 		}
 
-		mdmAppConfig["enable_disk_encryption"] = enableDiskEncryption
 		mdmAppConfig["enable_recovery_lock_password"] = enableRecoveryLockPassword
 		mdmAppConfig["windows_require_bitlocker_pin"] = requireBitLockerPIN
 

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -103,6 +103,17 @@ func withDiskEncryptionDefaults(m fleet.TeamMDM) fleet.TeamMDM {
 	return m
 }
 
+// withCreateDefaults adds the defaults only fleet creation persists on top of
+// withDiskEncryptionDefaults: the canonical BitLocker PIN home is stored as
+// explicit false for new fleets, while edits leave an absent value untouched.
+func withCreateDefaults(m fleet.TeamMDM) fleet.TeamMDM {
+	m = withDiskEncryptionDefaults(m)
+	if !m.WindowsSettings.RequireBitLockerPIN.Valid {
+		m.WindowsSettings.RequireBitLockerPIN = optjson.SetBool(false)
+	}
+	return m
+}
+
 func TestIntegrationsEnterprise(t *testing.T) {
 	testingSuite := new(integrationEnterpriseTestSuite)
 	testingSuite.withServer.s = &testingSuite.Suite
@@ -335,7 +346,7 @@ func (s *integrationEnterpriseTestSuite) TestTeamSpecs() {
 		AdditionalQueries:       new(json.RawMessage(`{"foo": "bar"}`)),
 		HistoricalData:          fleet.HistoricalDataSettings{Uptime: true, Vulnerabilities: true},
 	}, team.Config.Features)
-	require.Equal(t, withDiskEncryptionDefaults(fleet.TeamMDM{
+	require.Equal(t, withCreateDefaults(fleet.TeamMDM{
 		MacOSUpdates: fleet.AppleOSUpdateSettings{
 			MinimumVersion: optjson.SetString("14.6.1"),
 			Deadline:       optjson.SetString("2021-01-01"),
@@ -471,7 +482,7 @@ func (s *integrationEnterpriseTestSuite) TestTeamSpecs() {
 	team, err = s.ds.TeamByName(context.Background(), teamName)
 	require.NoError(t, err)
 	require.Equal(t, applyResp.TeamIDsByName[teamName], team.ID)
-	require.Equal(t, withDiskEncryptionDefaults(fleet.TeamMDM{
+	require.Equal(t, withCreateDefaults(fleet.TeamMDM{
 		MacOSUpdates: fleet.AppleOSUpdateSettings{
 			MinimumVersion: optjson.SetString("14.6.1"),
 			Deadline:       optjson.SetString("2021-01-01"),
@@ -515,7 +526,7 @@ func (s *integrationEnterpriseTestSuite) TestTeamSpecs() {
 	// get the team via the GET endpoint, check that it properly returns the mdm settings
 	var getTmResp getTeamResponse
 	s.DoJSON("GET", "/api/latest/fleet/teams/"+fmt.Sprint(team.ID), nil, http.StatusOK, &getTmResp)
-	require.Equal(t, withDiskEncryptionDefaults(fleet.TeamMDM{
+	require.Equal(t, withCreateDefaults(fleet.TeamMDM{
 		MacOSUpdates: fleet.AppleOSUpdateSettings{
 			MinimumVersion: optjson.SetString("14.6.1"),
 			Deadline:       optjson.SetString("2021-01-01"),
@@ -561,7 +572,7 @@ func (s *integrationEnterpriseTestSuite) TestTeamSpecs() {
 	s.DoJSON("GET", "/api/latest/fleet/teams", nil, http.StatusOK, &listTmResp, "query", teamName)
 	require.True(t, len(listTmResp.Teams) > 0)
 	require.Equal(t, team.ID, listTmResp.Teams[0].ID)
-	require.Equal(t, withDiskEncryptionDefaults(fleet.TeamMDM{
+	require.Equal(t, withCreateDefaults(fleet.TeamMDM{
 		MacOSUpdates: fleet.AppleOSUpdateSettings{
 			MinimumVersion: optjson.SetString("14.6.1"),
 			Deadline:       optjson.SetString("2021-01-01"),
@@ -3913,7 +3924,7 @@ func (s *integrationEnterpriseTestSuite) TestWindowsUpdatesTeamConfig() {
 	// settings.
 	var getTmResp getTeamResponse
 	s.DoJSON("GET", "/api/latest/fleet/teams/"+fmt.Sprint(team.ID), nil, http.StatusOK, &getTmResp)
-	require.Equal(t, withDiskEncryptionDefaults(fleet.TeamMDM{
+	require.Equal(t, withCreateDefaults(fleet.TeamMDM{
 		MacOSUpdates: fleet.AppleOSUpdateSettings{
 			MinimumVersion: optjson.String{Set: true},
 			Deadline:       optjson.String{Set: true},

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -4721,7 +4721,7 @@ func (s *integrationEnterpriseTestSuite) TestLinuxDiskEncryption() {
 	require.Nil(t, getHostResp.Host.MDM.OSSettings)
 
 	// turn on disk encryption enforcement
-	s.Do("POST", "/api/latest/fleet/disk_encryption", updateDiskEncryptionRequest{EnableDiskEncryption: true}, http.StatusNoContent)
+	s.Do("POST", "/api/latest/fleet/disk_encryption", updateDiskEncryptionRequest{EnableDiskEncryption: new(true)}, http.StatusNoContent)
 
 	// should be populated after disk encryption is turned on
 	// from host details
@@ -4804,7 +4804,7 @@ func (s *integrationEnterpriseTestSuite) TestLinuxDiskEncryption() {
 	require.Equal(t, fleet.MDMProfilesSummary{}, profileSummary.MDMProfilesSummary)
 
 	// turn on disk encryption enforcement for team
-	s.Do("POST", "/api/latest/fleet/disk_encryption", updateDiskEncryptionRequest{TeamID: teamID, EnableDiskEncryption: true}, http.StatusNoContent)
+	s.Do("POST", "/api/latest/fleet/disk_encryption", updateDiskEncryptionRequest{TeamID: teamID, EnableDiskEncryption: new(true)}, http.StatusNoContent)
 
 	// should show the Linux host as pending
 	s.DoJSON("GET", "/api/latest/fleet/configuration_profiles/summary", getMDMProfilesSummaryRequest{TeamID: teamID}, http.StatusOK, &profileSummary)

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -3124,6 +3124,14 @@ func (s *integrationMDMTestSuite) TestBitLockerPINRequiresWindowsDiskEncryption(
 		},
 	}, http.StatusUnprocessableEntity)
 	assert.Contains(t, extractServerErrorText(res.Body), fleet.CantDisableDiskEncryptionIfPINRequiredErrMsg)
+
+	// the disk_encryption endpoint reports the same validation failure as a 422
+	// rather than a server error
+	res = s.Do("POST", "/api/latest/fleet/disk_encryption", updateDiskEncryptionRequest{
+		TeamID:          new(team.ID),
+		WindowsSettings: &fleet.WindowsDiskEncryptionSettingsPayload{EnableDiskEncryption: new(false)},
+	}, http.StatusUnprocessableEntity)
+	assert.Contains(t, extractServerErrorText(res.Body), fleet.CantDisableDiskEncryptionIfPINRequiredErrMsg)
 }
 
 func (s *integrationMDMTestSuite) TestDiskEncryptionEndpointPerPlatform() {

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -2283,41 +2283,53 @@ func (s *integrationMDMTestSuite) TestMDMAppleUnenroll() {
 func (s *integrationMDMTestSuite) TestMDMDiskEncryptionSettingBackwardsCompat() {
 	t := s.T()
 
+	// the deprecated flat toggle reads as the AND of the four per-platform
+	// settings; a legacy-only write fans out to all of them
 	acResp := appConfigResponse{}
 	s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(`{
 		"mdm": { "enable_disk_encryption": false }
   }`), http.StatusOK, &acResp)
 	assert.False(t, acResp.MDM.EnableDiskEncryption.Value)
 
-	// the deprecated flat toggle wins when provided: it fans out to every
-	// per-platform setting
+	// a per-platform change wins over an unchanged flat toggle sent alongside
+	// it: macOS enforcement turns on, the flat toggle still reads false (not
+	// all platforms are on) and the FileVault profile exists
 	acResp = appConfigResponse{}
 	s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(`{
 	  "mdm": { "enable_disk_encryption": false, "macos_settings": {"enable_disk_encryption": true} }
-  }`), http.StatusOK, &acResp)
-	assert.False(t, acResp.MDM.EnableDiskEncryption.Value)
-	assert.False(t, acResp.MDM.MacOSSettings.EnableDiskEncryption.Value)
-
-	s.assertConfigProfilesByIdentifier(nil, mobileconfig.FleetFileVaultPayloadIdentifier, false)
-
-	// without the flat toggle, macos_settings.enable_disk_encryption is the
-	// canonical macOS enforcement setting (no longer an alias of the flat
-	// toggle): it turns on macOS enforcement only, so the flat toggle (the AND
-	// of the per-platform settings) still reads false
-	acResp = appConfigResponse{}
-	s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(`{
-	  "mdm": { "macos_settings": {"enable_disk_encryption": true} }
   }`), http.StatusOK, &acResp)
 	assert.False(t, acResp.MDM.EnableDiskEncryption.Value)
 	assert.True(t, acResp.MDM.MacOSSettings.EnableDiskEncryption.Value)
+	assert.False(t, acResp.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey.Value)
 	s.assertConfigProfilesByIdentifier(nil, mobileconfig.FleetFileVaultPayloadIdentifier, true)
 
-	// new config takes precedence over old config again
+	// changing the flat toggle and a per-platform setting to disagreeing
+	// values in one request is a conflict
+	res := s.Do("PATCH", "/api/latest/fleet/config", json.RawMessage(`{
+	  "mdm": { "enable_disk_encryption": true, "macos_settings": {"enable_disk_encryption": false} }
+  }`), http.StatusUnprocessableEntity)
+	errMsg := extractServerErrorText(res.Body)
+	assert.Contains(t, errMsg, "conflicts with per-platform disk encryption settings")
+
+	// changing the flat toggle fans out to every per-platform setting, winning
+	// over per-platform values it does not change
 	acResp = appConfigResponse{}
 	s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(`{
-	  "mdm": { "enable_disk_encryption": false, "macos_settings": {"enable_disk_encryption": true} }
+	  "mdm": { "enable_disk_encryption": true }
+  }`), http.StatusOK, &acResp)
+	assert.True(t, acResp.MDM.EnableDiskEncryption.Value)
+	assert.True(t, acResp.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey.Value)
+	assert.True(t, acResp.MDM.WindowsSettings.EnableDiskEncryption.Value)
+	assert.True(t, acResp.MDM.LinuxSettings.EnableEscrowDiskEncryptionKey.Value)
+	s.assertConfigProfilesByIdentifier(nil, mobileconfig.FleetFileVaultPayloadIdentifier, true)
+
+	// turning the flat toggle off turns everything off and removes the profile
+	acResp = appConfigResponse{}
+	s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(`{
+	  "mdm": { "enable_disk_encryption": false }
   }`), http.StatusOK, &acResp)
 	assert.False(t, acResp.MDM.EnableDiskEncryption.Value)
+	assert.False(t, acResp.MDM.MacOSSettings.EnableDiskEncryption.Value)
 	s.assertConfigProfilesByIdentifier(nil, mobileconfig.FleetFileVaultPayloadIdentifier, false)
 
 	// unrelated change doesn't affect the disk encryption setting
@@ -2344,55 +2356,65 @@ func (s *integrationMDMTestSuite) TestMDMDiskEncryptionSettingBackwardsCompat() 
 	// after creation, disk encryption is off
 	checkTeamDiskEncryption(false, false)
 
-	// the deprecated flat toggle wins when provided: it fans out to every
-	// per-platform setting
+	// a per-platform change wins over an unchanged flat toggle sent alongside it
 	teamSpecs := applyTeamSpecsRequest{Specs: []*fleet.TeamSpec{{
 		Name: team.Name,
 		MDM: fleet.TeamSpecMDM{
 			EnableDiskEncryption: optjson.SetBool(false),
-			MacOSSettings:        map[string]interface{}{"enable_disk_encryption": true},
-		},
-	}}}
-	s.Do("POST", "/api/latest/fleet/spec/teams", teamSpecs, http.StatusOK)
-	checkTeamDiskEncryption(false, false)
-	s.assertConfigProfilesByIdentifier(ptr.Uint(team.ID), mobileconfig.FleetFileVaultPayloadIdentifier, false)
-
-	// without the flat toggle, macos_settings.enable_disk_encryption is the
-	// canonical macOS enforcement setting: it turns on macOS enforcement only,
-	// so the flat toggle (the AND of the per-platform settings) reads false
-	teamSpecs = applyTeamSpecsRequest{Specs: []*fleet.TeamSpec{{
-		Name: team.Name,
-		MDM: fleet.TeamSpecMDM{
-			MacOSSettings: map[string]interface{}{"enable_disk_encryption": true},
+			MacOSSettings:        map[string]any{"enable_disk_encryption": true},
 		},
 	}}}
 	s.Do("POST", "/api/latest/fleet/spec/teams", teamSpecs, http.StatusOK)
 	checkTeamDiskEncryption(false, true)
-	s.assertConfigProfilesByIdentifier(ptr.Uint(team.ID), mobileconfig.FleetFileVaultPayloadIdentifier, true)
+	s.assertConfigProfilesByIdentifier(new(team.ID), mobileconfig.FleetFileVaultPayloadIdentifier, true)
 
-	// the flat toggle wins again, resetting the macOS enforcement setting
+	// changing the flat toggle fans out over per-platform values it does not change
 	teamSpecs = applyTeamSpecsRequest{Specs: []*fleet.TeamSpec{{
 		Name: team.Name,
 		MDM: fleet.TeamSpecMDM{
 			EnableDiskEncryption: optjson.SetBool(false),
-			MacOSSettings:        map[string]interface{}{"enable_disk_encryption": true},
+			MacOSSettings:        map[string]any{"enable_disk_encryption": true},
+		},
+	}}}
+	s.Do("POST", "/api/latest/fleet/spec/teams", teamSpecs, http.StatusOK)
+	checkTeamDiskEncryption(false, true) // no change: same spec re-applied
+	s.assertConfigProfilesByIdentifier(new(team.ID), mobileconfig.FleetFileVaultPayloadIdentifier, true)
+
+	// changing the flat toggle and a per-platform setting to disagreeing
+	// values in one request is a conflict
+	teamSpecs = applyTeamSpecsRequest{Specs: []*fleet.TeamSpec{{
+		Name: team.Name,
+		MDM: fleet.TeamSpecMDM{
+			EnableDiskEncryption: optjson.SetBool(true),
+			MacOSSettings:        map[string]any{"enable_disk_encryption": false},
+		},
+	}}}
+	res = s.Do("POST", "/api/latest/fleet/spec/teams", teamSpecs, http.StatusUnprocessableEntity)
+	errMsg = extractServerErrorText(res.Body)
+	assert.Contains(t, errMsg, "conflicts with per-platform disk encryption settings")
+
+	// a legacy-only write fans out to all platforms
+	teamSpecs = applyTeamSpecsRequest{Specs: []*fleet.TeamSpec{{
+		Name: team.Name,
+		MDM: fleet.TeamSpecMDM{
+			EnableDiskEncryption: optjson.SetBool(false),
 		},
 	}}}
 	s.Do("POST", "/api/latest/fleet/spec/teams", teamSpecs, http.StatusOK)
 	checkTeamDiskEncryption(false, false)
-	s.assertConfigProfilesByIdentifier(ptr.Uint(team.ID), mobileconfig.FleetFileVaultPayloadIdentifier, false)
+	s.assertConfigProfilesByIdentifier(new(team.ID), mobileconfig.FleetFileVaultPayloadIdentifier, false)
 
 	// unrelated change doesn't affect the disk encryption setting
 	teamSpecs = applyTeamSpecsRequest{Specs: []*fleet.TeamSpec{{
 		Name: team.Name,
 		MDM: fleet.TeamSpecMDM{
 			EnableDiskEncryption: optjson.SetBool(false),
-			MacOSSettings:        map[string]interface{}{"custom_settings": []interface{}{"A", "B"}},
+			MacOSSettings:        map[string]any{"custom_settings": []any{"A", "B"}},
 		},
 	}}}
 	s.Do("POST", "/api/latest/fleet/spec/teams", teamSpecs, http.StatusOK)
 	checkTeamDiskEncryption(false, false)
-	s.assertConfigProfilesByIdentifier(ptr.Uint(team.ID), mobileconfig.FleetFileVaultPayloadIdentifier, false)
+	s.assertConfigProfilesByIdentifier(new(team.ID), mobileconfig.FleetFileVaultPayloadIdentifier, false)
 }
 
 func (s *integrationMDMTestSuite) TestDiskEncryptionSharedSetting() {
@@ -3105,7 +3127,7 @@ func (s *integrationMDMTestSuite) TestAppConfigMDMAppleDiskEncryption() {
 
 	// use the MDM disk encryption endpoint to set it to true
 	s.Do("POST", "/api/latest/fleet/disk_encryption",
-		updateDiskEncryptionRequest{EnableDiskEncryption: true}, http.StatusNoContent)
+		updateDiskEncryptionRequest{EnableDiskEncryption: new(true)}, http.StatusNoContent)
 	enabledDiskActID = s.lastActivityMatches(fleet.ActivityTypeEnabledMacosDiskEncryption{}.ActivityName(),
 		`{"team_id": null, "team_name": null, "fleet_id": null, "fleet_name": null}`, 0)
 
@@ -3150,13 +3172,13 @@ func (s *integrationMDMTestSuite) TestAppConfigMDMAppleDiskEncryption() {
 
 	// flip and verify the value
 	s.Do("POST", "/api/latest/fleet/disk_encryption",
-		updateDiskEncryptionRequest{EnableDiskEncryption: false}, http.StatusNoContent)
+		updateDiskEncryptionRequest{EnableDiskEncryption: new(false)}, http.StatusNoContent)
 	acResp = appConfigResponse{}
 	s.DoJSON("GET", "/api/latest/fleet/config", nil, http.StatusOK, &acResp)
 	assert.False(t, acResp.MDM.EnableDiskEncryption.Value)
 
 	s.Do("POST", "/api/latest/fleet/disk_encryption",
-		updateDiskEncryptionRequest{EnableDiskEncryption: true}, http.StatusNoContent)
+		updateDiskEncryptionRequest{EnableDiskEncryption: new(true)}, http.StatusNoContent)
 	acResp = appConfigResponse{}
 	s.DoJSON("GET", "/api/latest/fleet/config", nil, http.StatusOK, &acResp)
 	assert.True(t, acResp.MDM.EnableDiskEncryption.Value)
@@ -3508,7 +3530,7 @@ func (s *integrationMDMTestSuite) TestTeamsMDMAppleDiskEncryption() {
 
 	// use the MDM settings endpoint to set it to true
 	s.Do("POST", "/api/latest/fleet/disk_encryption",
-		updateDiskEncryptionRequest{TeamID: ptr.Uint(team.ID), EnableDiskEncryption: true}, http.StatusNoContent)
+		updateDiskEncryptionRequest{TeamID: new(team.ID), EnableDiskEncryption: new(true)}, http.StatusNoContent)
 	lastDiskActID = s.lastActivityOfTypeMatches(fleet.ActivityTypeEnabledMacosDiskEncryption{}.ActivityName(),
 		fmt.Sprintf(`{"team_id": %d, "team_name": %q, "fleet_id": %d, "fleet_name": %q}`, team.ID, teamName, team.ID, teamName), 0)
 
@@ -3534,7 +3556,7 @@ func (s *integrationMDMTestSuite) TestTeamsMDMAppleDiskEncryption() {
 
 	// use the MDM settings endpoint with an unknown team id
 	s.Do("POST", "/api/latest/fleet/disk_encryption",
-		updateDiskEncryptionRequest{TeamID: ptr.Uint(9999), EnableDiskEncryption: true}, http.StatusNotFound)
+		updateDiskEncryptionRequest{TeamID: new(uint(9999)), EnableDiskEncryption: new(true)}, http.StatusNotFound)
 
 	// mdm/apple/settings works for windows as well as it's being used by
 	// clients (UI) this way
@@ -3555,13 +3577,13 @@ func (s *integrationMDMTestSuite) TestTeamsMDMAppleDiskEncryption() {
 
 	// flip and verify the value
 	s.Do("POST", "/api/latest/fleet/disk_encryption",
-		updateDiskEncryptionRequest{TeamID: ptr.Uint(team.ID), EnableDiskEncryption: false}, http.StatusNoContent)
+		updateDiskEncryptionRequest{TeamID: new(team.ID), EnableDiskEncryption: new(false)}, http.StatusNoContent)
 	teamResp = getTeamResponse{}
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/teams/%d", team.ID), nil, http.StatusOK, &teamResp)
 	require.False(t, teamResp.Team.Config.MDM.EnableDiskEncryption)
 
 	s.Do("POST", "/api/latest/fleet/disk_encryption",
-		updateDiskEncryptionRequest{TeamID: ptr.Uint(team.ID), EnableDiskEncryption: true}, http.StatusNoContent)
+		updateDiskEncryptionRequest{TeamID: new(team.ID), EnableDiskEncryption: new(true)}, http.StatusNoContent)
 	teamResp = getTeamResponse{}
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/teams/%d", team.ID), nil, http.StatusOK, &teamResp)
 	require.True(t, teamResp.Team.Config.MDM.EnableDiskEncryption)
@@ -20451,7 +20473,7 @@ func (s *integrationMDMTestSuite) TestNonMDWindowsHostsIgnoredInDiskEncryptionSt
 	require.NoError(t, err)
 
 	// first a quick stats check without disk encryption
-	s.Do("POST", "/api/latest/fleet/disk_encryption", updateDiskEncryptionRequest{EnableDiskEncryption: false}, http.StatusNoContent)
+	s.Do("POST", "/api/latest/fleet/disk_encryption", updateDiskEncryptionRequest{EnableDiskEncryption: new(false)}, http.StatusNoContent)
 	acResp := appConfigResponse{}
 	s.DoJSON("GET", "/api/latest/fleet/config", nil, http.StatusOK, &acResp)
 	assert.False(t, acResp.MDM.EnableDiskEncryption.Value)
@@ -20460,7 +20482,7 @@ func (s *integrationMDMTestSuite) TestNonMDWindowsHostsIgnoredInDiskEncryptionSt
 	s.checkMDMDiskEncryptionSummaries(t, nil, fleet.MDMDiskEncryptionSummary{}, false)
 
 	// enable disk encryption
-	s.Do("POST", "/api/latest/fleet/disk_encryption", updateDiskEncryptionRequest{EnableDiskEncryption: true}, http.StatusNoContent)
+	s.Do("POST", "/api/latest/fleet/disk_encryption", updateDiskEncryptionRequest{EnableDiskEncryption: new(true)}, http.StatusNoContent)
 	acResp = appConfigResponse{}
 	s.DoJSON("GET", "/api/latest/fleet/config", nil, http.StatusOK, &acResp)
 	assert.True(t, acResp.MDM.EnableDiskEncryption.Value)
@@ -20542,7 +20564,7 @@ func (s *integrationMDMTestSuite) TestLinuxHostsIgnoredInOSSettingsStats() {
 	require.NoError(t, err)
 
 	// ensure disk encryption is disabled
-	s.Do("POST", "/api/latest/fleet/disk_encryption", updateDiskEncryptionRequest{EnableDiskEncryption: false}, http.StatusNoContent)
+	s.Do("POST", "/api/latest/fleet/disk_encryption", updateDiskEncryptionRequest{EnableDiskEncryption: new(false)}, http.StatusNoContent)
 	acResp := appConfigResponse{}
 	s.DoJSON("GET", "/api/latest/fleet/config", nil, http.StatusOK, &acResp)
 	assert.False(t, acResp.MDM.EnableDiskEncryption.Value)
@@ -20573,7 +20595,7 @@ func (s *integrationMDMTestSuite) TestLinuxHostsIgnoredInOSSettingsStats() {
 	}
 
 	// now turn disk encryption on
-	s.Do("POST", "/api/latest/fleet/disk_encryption", updateDiskEncryptionRequest{EnableDiskEncryption: true}, http.StatusNoContent)
+	s.Do("POST", "/api/latest/fleet/disk_encryption", updateDiskEncryptionRequest{EnableDiskEncryption: new(true)}, http.StatusNoContent)
 	acResp = appConfigResponse{}
 	s.DoJSON("GET", "/api/latest/fleet/config", nil, http.StatusOK, &acResp)
 	assert.True(t, acResp.MDM.EnableDiskEncryption.Value)

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -3071,6 +3071,61 @@ func (s *integrationMDMTestSuite) TestWindowsMDMGetEncryptionKey() {
 	require.True(t, *detailsResp.Host.MDM.EncryptionKeyArchived)
 }
 
+// TestBitLockerPINRequiresWindowsDiskEncryption covers the fleet write paths
+// that previously persisted a PIN requirement without Windows disk encryption.
+func (s *integrationMDMTestSuite) TestBitLockerPINRequiresWindowsDiskEncryption() {
+	t := s.T()
+
+	var createResp teamResponse
+	s.DoJSON("POST", "/api/latest/fleet/teams", &fleet.Team{Name: t.Name()}, http.StatusOK, &createResp)
+	team := createResp.Team
+
+	// PATCH the fleet: the PIN alone, with Windows disk encryption off
+	res := s.Do("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", team.ID), fleet.TeamPayload{
+		MDM: &fleet.TeamPayloadMDM{RequireBitLockerPIN: optjson.SetBool(true)},
+	}, http.StatusUnprocessableEntity)
+	assert.Contains(t, extractServerErrorText(res.Body), fleet.CantEnablePINRequiredIfDiskEncryptionEnabled)
+
+	// creating a fleet from a spec with the PIN but no Windows disk encryption
+	res = s.Do("POST", "/api/latest/fleet/spec/teams", applyTeamSpecsRequest{Specs: []*fleet.TeamSpec{{
+		Name: t.Name() + "-created",
+		MDM:  fleet.TeamSpecMDM{RequireBitLockerPIN: optjson.SetBool(true)},
+	}}}, http.StatusUnprocessableEntity)
+	assert.Contains(t, extractServerErrorText(res.Body), fleet.CantEnablePINRequiredIfDiskEncryptionEnabled)
+
+	// editing an existing fleet via spec, same story
+	res = s.Do("POST", "/api/latest/fleet/spec/teams", applyTeamSpecsRequest{Specs: []*fleet.TeamSpec{{
+		Name: team.Name,
+		MDM:  fleet.TeamSpecMDM{RequireBitLockerPIN: optjson.SetBool(true)},
+	}}}, http.StatusUnprocessableEntity)
+	assert.Contains(t, extractServerErrorText(res.Body), fleet.CantEnablePINRequiredIfDiskEncryptionEnabled)
+
+	// the PIN together with Windows disk encryption is accepted
+	s.Do("POST", "/api/latest/fleet/spec/teams", applyTeamSpecsRequest{Specs: []*fleet.TeamSpec{{
+		Name: team.Name,
+		MDM: fleet.TeamSpecMDM{
+			RequireBitLockerPIN: optjson.SetBool(true),
+			WindowsSettings:     fleet.WindowsSettings{EnableDiskEncryption: optjson.SetBool(true)},
+		},
+	}}}, http.StatusOK)
+	var teamResp getTeamResponse
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/teams/%d", team.ID), nil, http.StatusOK, &teamResp)
+	assert.True(t, teamResp.Team.Config.MDM.WindowsSettings.RequireBitLockerPIN.Value)
+	assert.True(t, teamResp.Team.Config.MDM.WindowsSettings.EnableDiskEncryption.Value)
+
+	// turning encryption off while the PIN stays required is rejected, blaming
+	// the encryption field
+	res = s.Do("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", team.ID), fleet.TeamPayload{
+		MDM: &fleet.TeamPayloadMDM{
+			WindowsSettings: &fleet.TeamPayloadWindowsSettings{
+				RequireBitLockerPIN: optjson.SetBool(true),
+			},
+			EnableDiskEncryption: optjson.SetBool(false),
+		},
+	}, http.StatusUnprocessableEntity)
+	assert.Contains(t, extractServerErrorText(res.Body), fleet.CantDisableDiskEncryptionIfPINRequiredErrMsg)
+}
+
 func (s *integrationMDMTestSuite) TestDiskEncryptionEndpointPerPlatform() {
 	t := s.T()
 

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -3114,6 +3114,24 @@ func (s *integrationMDMTestSuite) TestDiskEncryptionEndpointPerPlatform() {
 	assert.True(t, acResp.MDM.MacOSSettings.EnableDiskEncryption.Value)
 	assert.True(t, acResp.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey.Value)
 	assert.True(t, acResp.MDM.LinuxSettings.EnableEscrowDiskEncryptionKey.Value)
+
+	// the BitLocker PIN is settable via its canonical windows_settings home,
+	// and the response mirrors the deprecated top-level key
+	s.Do("POST", "/api/latest/fleet/disk_encryption", updateDiskEncryptionRequest{
+		WindowsSettings: &fleet.WindowsDiskEncryptionSettingsPayload{RequireBitLockerPIN: new(true)},
+	}, http.StatusNoContent)
+	acResp = appConfigResponse{}
+	s.DoJSON("GET", "/api/latest/fleet/config", nil, http.StatusOK, &acResp)
+	assert.True(t, acResp.MDM.WindowsSettings.RequireBitLockerPIN.Value)
+	assert.True(t, acResp.MDM.RequireBitLockerPIN.Value)
+
+	// the deprecated PIN key conflicting with its canonical home is rejected
+	res = s.Do("POST", "/api/latest/fleet/disk_encryption", updateDiskEncryptionRequest{
+		RequireBitLockerPIN: new(false),
+		WindowsSettings:     &fleet.WindowsDiskEncryptionSettingsPayload{RequireBitLockerPIN: new(true)},
+	}, http.StatusUnprocessableEntity)
+	errMsg = extractServerErrorText(res.Body)
+	assert.Contains(t, errMsg, "conflicts with windows_settings.require_bitlocker_pin")
 }
 
 func (s *integrationMDMTestSuite) TestAppConfigMDMAppleDiskEncryption() {

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -3071,6 +3071,51 @@ func (s *integrationMDMTestSuite) TestWindowsMDMGetEncryptionKey() {
 	require.True(t, *detailsResp.Host.MDM.EncryptionKeyArchived)
 }
 
+func (s *integrationMDMTestSuite) TestDiskEncryptionEndpointPerPlatform() {
+	t := s.T()
+
+	// a single per-platform object changes only that platform
+	s.Do("POST", "/api/latest/fleet/disk_encryption", updateDiskEncryptionRequest{
+		WindowsSettings: &fleet.WindowsDiskEncryptionSettingsPayload{EnableDiskEncryption: new(true)},
+	}, http.StatusNoContent)
+	acResp := appConfigResponse{}
+	s.DoJSON("GET", "/api/latest/fleet/config", nil, http.StatusOK, &acResp)
+	assert.True(t, acResp.MDM.WindowsSettings.EnableDiskEncryption.Value)
+	assert.False(t, acResp.MDM.MacOSSettings.EnableDiskEncryption.Value)
+	assert.False(t, acResp.MDM.LinuxSettings.EnableEscrowDiskEncryptionKey.Value)
+	assert.False(t, acResp.MDM.EnableDiskEncryption.Value)
+
+	// nil objects leave other platforms untouched
+	s.Do("POST", "/api/latest/fleet/disk_encryption", updateDiskEncryptionRequest{
+		MacOSSettings: &fleet.MacOSDiskEncryptionSettingsPayload{EnableEscrowDiskEncryptionKey: new(true)},
+	}, http.StatusNoContent)
+	acResp = appConfigResponse{}
+	s.DoJSON("GET", "/api/latest/fleet/config", nil, http.StatusOK, &acResp)
+	assert.True(t, acResp.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey.Value)
+	assert.False(t, acResp.MDM.MacOSSettings.EnableDiskEncryption.Value)
+	assert.True(t, acResp.MDM.WindowsSettings.EnableDiskEncryption.Value)
+
+	// the deprecated flat toggle conflicts with a disagreeing per-platform value
+	res := s.Do("POST", "/api/latest/fleet/disk_encryption", updateDiskEncryptionRequest{
+		EnableDiskEncryption: new(true),
+		LinuxSettings:        &fleet.LinuxDiskEncryptionSettingsPayload{EnableEscrowDiskEncryptionKey: new(false)},
+	}, http.StatusUnprocessableEntity)
+	errMsg := extractServerErrorText(res.Body)
+	assert.Contains(t, errMsg, "conflicts with per-platform disk encryption settings")
+
+	// the flat toggle with agreeing per-platform values fans out to all four
+	s.Do("POST", "/api/latest/fleet/disk_encryption", updateDiskEncryptionRequest{
+		EnableDiskEncryption: new(true),
+		WindowsSettings:      &fleet.WindowsDiskEncryptionSettingsPayload{EnableDiskEncryption: new(true)},
+	}, http.StatusNoContent)
+	acResp = appConfigResponse{}
+	s.DoJSON("GET", "/api/latest/fleet/config", nil, http.StatusOK, &acResp)
+	assert.True(t, acResp.MDM.EnableDiskEncryption.Value)
+	assert.True(t, acResp.MDM.MacOSSettings.EnableDiskEncryption.Value)
+	assert.True(t, acResp.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey.Value)
+	assert.True(t, acResp.MDM.LinuxSettings.EnableEscrowDiskEncryptionKey.Value)
+}
+
 func (s *integrationMDMTestSuite) TestAppConfigMDMAppleDiskEncryption() {
 	t := s.T()
 

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -935,6 +935,8 @@ func (s *integrationMDMTestSuite) TearDownTest() {
 	appCfg.MDM.MacOSSettings.EnableDiskEncryption = optjson.SetBool(false)
 	appCfg.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey = optjson.SetBool(false)
 	appCfg.MDM.WindowsSettings.EnableDiskEncryption = optjson.SetBool(false)
+	appCfg.MDM.WindowsSettings.RequireBitLockerPIN = optjson.SetBool(false)
+	appCfg.MDM.RequireBitLockerPIN = optjson.SetBool(false)
 	appCfg.MDM.LinuxSettings.EnableEscrowDiskEncryptionKey = optjson.SetBool(false)
 	// ensure enable release manually is false
 	appCfg.MDM.MacOSSetup.EnableReleaseDeviceManually = optjson.SetBool(false)
@@ -3132,6 +3134,65 @@ func (s *integrationMDMTestSuite) TestBitLockerPINRequiresWindowsDiskEncryption(
 		WindowsSettings: &fleet.WindowsDiskEncryptionSettingsPayload{EnableDiskEncryption: new(false)},
 	}, http.StatusUnprocessableEntity)
 	assert.Contains(t, extractServerErrorText(res.Body), fleet.CantDisableDiskEncryptionIfPINRequiredErrMsg)
+}
+
+// TestBitLockerPINAliasConflict covers the deprecated windows_require_bitlocker_pin
+// key disagreeing with its canonical windows_settings home across write paths.
+func (s *integrationMDMTestSuite) TestBitLockerPINAliasConflict() {
+	t := s.T()
+	const conflictErr = "conflicts with mdm.windows_settings.require_bitlocker_pin"
+
+	var createResp teamResponse
+	s.DoJSON("POST", "/api/latest/fleet/teams", &fleet.Team{Name: t.Name()}, http.StatusOK, &createResp)
+	team := createResp.Team
+
+	// global config: disagreeing values are rejected rather than silently
+	// resolved to one of them
+	res := s.Do("PATCH", "/api/latest/fleet/config", json.RawMessage(`{"mdm": {
+	  "windows_require_bitlocker_pin": false,
+	  "windows_settings": {"enable_disk_encryption": true, "require_bitlocker_pin": true}
+	}}`), http.StatusUnprocessableEntity)
+	assert.Contains(t, extractServerErrorText(res.Body), conflictErr)
+
+	// agreeing values are accepted: a round-tripped document carries both
+	acResp := appConfigResponse{}
+	s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(`{"mdm": {
+	  "windows_require_bitlocker_pin": true,
+	  "windows_settings": {"enable_disk_encryption": true, "require_bitlocker_pin": true}
+	}}`), http.StatusOK, &acResp)
+	assert.True(t, acResp.MDM.WindowsSettings.RequireBitLockerPIN.Value)
+	assert.True(t, acResp.MDM.RequireBitLockerPIN.Value)
+
+	// PATCH the fleet
+	res = s.Do("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", team.ID), fleet.TeamPayload{
+		MDM: &fleet.TeamPayloadMDM{
+			RequireBitLockerPIN: optjson.SetBool(false),
+			WindowsSettings: &fleet.TeamPayloadWindowsSettings{
+				RequireBitLockerPIN: optjson.SetBool(true),
+			},
+		},
+	}, http.StatusUnprocessableEntity)
+	assert.Contains(t, extractServerErrorText(res.Body), conflictErr)
+
+	// editing a fleet from a spec
+	res = s.Do("POST", "/api/latest/fleet/spec/teams", applyTeamSpecsRequest{Specs: []*fleet.TeamSpec{{
+		Name: team.Name,
+		MDM: fleet.TeamSpecMDM{
+			RequireBitLockerPIN: optjson.SetBool(false),
+			WindowsSettings:     fleet.WindowsSettings{RequireBitLockerPIN: optjson.SetBool(true)},
+		},
+	}}}, http.StatusUnprocessableEntity)
+	assert.Contains(t, extractServerErrorText(res.Body), conflictErr)
+
+	// creating a fleet from a spec
+	res = s.Do("POST", "/api/latest/fleet/spec/teams", applyTeamSpecsRequest{Specs: []*fleet.TeamSpec{{
+		Name: t.Name() + "-created",
+		MDM: fleet.TeamSpecMDM{
+			RequireBitLockerPIN: optjson.SetBool(false),
+			WindowsSettings:     fleet.WindowsSettings{RequireBitLockerPIN: optjson.SetBool(true)},
+		},
+	}}}, http.StatusUnprocessableEntity)
+	assert.Contains(t, extractServerErrorText(res.Body), conflictErr)
 }
 
 func (s *integrationMDMTestSuite) TestDiskEncryptionEndpointPerPlatform() {

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -3539,14 +3539,19 @@ func (svc *Service) UpdateMDMDiskEncryption(ctx context.Context, teamID *uint, p
 		return ctxerr.Wrap(ctx, err)
 	}
 
+	requireBitLockerPIN, err := payload.ResolveBitLockerPIN()
+	if err != nil {
+		return ctxerr.Wrap(ctx, err)
+	}
+
 	if teamID != nil {
 		tm, err := svc.EnterpriseOverrides.TeamByIDOrName(ctx, teamID, nil)
 		if err != nil {
 			return err
 		}
-		return svc.EnterpriseOverrides.UpdateTeamMDMDiskEncryption(ctx, tm, changes, payload.RequireBitLockerPIN)
+		return svc.EnterpriseOverrides.UpdateTeamMDMDiskEncryption(ctx, tm, changes, requireBitLockerPIN)
 	}
-	return svc.updateAppConfigMDMDiskEncryption(ctx, changes, payload.RequireBitLockerPIN)
+	return svc.updateAppConfigMDMDiskEncryption(ctx, changes, requireBitLockerPIN)
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -3483,9 +3483,14 @@ func (svc *Service) ListMDMConfigProfiles(ctx context.Context, teamID *uint, opt
 ////////////////////////////////////////////////////////////////////////////////
 
 type updateDiskEncryptionRequest struct {
-	TeamID               *uint `json:"team_id" renameto:"fleet_id"`
-	EnableDiskEncryption bool  `json:"enable_disk_encryption"`
-	RequireBitLockerPIN  bool  `json:"windows_require_bitlocker_pin"`
+	TeamID *uint `json:"team_id" renameto:"fleet_id"`
+	// EnableDiskEncryption is deprecated: when provided it applies to every
+	// per-platform setting. Use the per-platform objects instead.
+	EnableDiskEncryption *bool                                       `json:"enable_disk_encryption"`
+	RequireBitLockerPIN  *bool                                       `json:"windows_require_bitlocker_pin"`
+	MacOSSettings        *fleet.MacOSDiskEncryptionSettingsPayload   `json:"macos_settings"`
+	WindowsSettings      *fleet.WindowsDiskEncryptionSettingsPayload `json:"windows_settings"`
+	LinuxSettings        *fleet.LinuxDiskEncryptionSettingsPayload   `json:"linux_settings"`
 }
 
 type updateMDMDiskEncryptionResponse struct {
@@ -3498,13 +3503,20 @@ func (r updateMDMDiskEncryptionResponse) Status() int { return http.StatusNoCont
 
 func updateDiskEncryptionEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (fleet.Errorer, error) {
 	req := request.(*updateDiskEncryptionRequest)
-	if err := svc.UpdateMDMDiskEncryption(ctx, req.TeamID, &req.EnableDiskEncryption, &req.RequireBitLockerPIN); err != nil {
+	payload := fleet.MDMDiskEncryptionSettingsPayload{
+		EnableDiskEncryption: req.EnableDiskEncryption,
+		RequireBitLockerPIN:  req.RequireBitLockerPIN,
+		MacOSSettings:        req.MacOSSettings,
+		WindowsSettings:      req.WindowsSettings,
+		LinuxSettings:        req.LinuxSettings,
+	}
+	if err := svc.UpdateMDMDiskEncryption(ctx, req.TeamID, payload); err != nil {
 		return updateMDMDiskEncryptionResponse{Err: err}, nil
 	}
 	return updateMDMDiskEncryptionResponse{}, nil
 }
 
-func (svc *Service) UpdateMDMDiskEncryption(ctx context.Context, teamID *uint, enableDiskEncryption *bool, requireBitLockerPIN *bool) error {
+func (svc *Service) UpdateMDMDiskEncryption(ctx context.Context, teamID *uint, payload fleet.MDMDiskEncryptionSettingsPayload) error {
 	// TODO(mna): this should all move to the ee package when we remove the
 	// `PATCH /api/v1/fleet/mdm/apple/settings` endpoint, but for now it's better
 	// leave here so both endpoints can reuse the same logic.
@@ -3522,14 +3534,19 @@ func (svc *Service) UpdateMDMDiskEncryption(ctx context.Context, teamID *uint, e
 		return ctxerr.Wrap(ctx, err)
 	}
 
+	changes, err := payload.ResolvePerPlatform()
+	if err != nil {
+		return ctxerr.Wrap(ctx, err)
+	}
+
 	if teamID != nil {
 		tm, err := svc.EnterpriseOverrides.TeamByIDOrName(ctx, teamID, nil)
 		if err != nil {
 			return err
 		}
-		return svc.EnterpriseOverrides.UpdateTeamMDMDiskEncryption(ctx, tm, enableDiskEncryption, requireBitLockerPIN)
+		return svc.EnterpriseOverrides.UpdateTeamMDMDiskEncryption(ctx, tm, changes, payload.RequireBitLockerPIN)
 	}
-	return svc.updateAppConfigMDMDiskEncryption(ctx, enableDiskEncryption)
+	return svc.updateAppConfigMDMDiskEncryption(ctx, changes, payload.RequireBitLockerPIN)
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/server/service/mdm_test.go
+++ b/server/service/mdm_test.go
@@ -5369,3 +5369,100 @@ func TestRunMDMCommandAndroid(t *testing.T) {
 		require.ErrorContains(t, err, "Android MDM isn't turned on")
 	})
 }
+
+func TestUpdateAppConfigMDMDiskEncryptionPINOnly(t *testing.T) {
+	// enabling only the BitLocker PIN doesn't enable key escrow, so it must
+	// not require the server private key
+	ds := new(mock.Store)
+	// construct the concrete Service directly to reach the unexported method;
+	// it performs no authorization or license checks of its own
+	svc := &Service{ds: ds} // no server private key configured
+	svc.SetActivityService(&mock.MockActivityService{
+		NewActivityFunc: func(_ context.Context, _ *activity_api.User, activity activity_api.ActivityDetails) error {
+			t.Fatalf("no activity expected for a PIN-only change, got %s", activity.ActivityName())
+			return nil
+		},
+	})
+	ctx := test.UserContext(t.Context(), test.UserAdmin)
+
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return &fleet.AppConfig{
+			MDM: fleet.MDM{
+				WindowsEnabledAndConfigured: true,
+				WindowsSettings: fleet.WindowsSettings{
+					EnableDiskEncryption: optjson.SetBool(true),
+				},
+			},
+		}, nil
+	}
+	var savedConfig *fleet.AppConfig
+	ds.SaveAppConfigFunc = func(ctx context.Context, info *fleet.AppConfig) error {
+		savedConfig = info
+		return nil
+	}
+
+	err := svc.updateAppConfigMDMDiskEncryption(ctx, fleet.DiskEncryptionSettingsChanges{}, new(true))
+	require.NoError(t, err)
+	require.NotNil(t, savedConfig)
+	require.True(t, savedConfig.MDM.RequireBitLockerPIN.Value)
+}
+
+func TestResolvePerPlatformDiskEncryptionPayload(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		payload fleet.MDMDiskEncryptionSettingsPayload
+		want    fleet.DiskEncryptionSettingsChanges
+		wantErr bool
+	}{
+		{
+			name:    "empty payload changes nothing",
+			payload: fleet.MDMDiskEncryptionSettingsPayload{},
+			want:    fleet.DiskEncryptionSettingsChanges{},
+		},
+		{
+			name:    "flat toggle fans out to all four",
+			payload: fleet.MDMDiskEncryptionSettingsPayload{EnableDiskEncryption: new(true)},
+			want: fleet.DiskEncryptionSettingsChanges{
+				MacOSEnable: new(true), MacOSEscrow: new(true), WindowsEnable: new(true), LinuxEscrow: new(true),
+			},
+		},
+		{
+			name: "per-platform values pass through",
+			payload: fleet.MDMDiskEncryptionSettingsPayload{
+				MacOSSettings:   &fleet.MacOSDiskEncryptionSettingsPayload{EnableDiskEncryption: new(true)},
+				WindowsSettings: &fleet.WindowsDiskEncryptionSettingsPayload{EnableDiskEncryption: new(false)},
+			},
+			want: fleet.DiskEncryptionSettingsChanges{
+				MacOSEnable: new(true), WindowsEnable: new(false),
+			},
+		},
+		{
+			name: "flat agreeing with per-platform fans out",
+			payload: fleet.MDMDiskEncryptionSettingsPayload{
+				EnableDiskEncryption: new(true),
+				WindowsSettings:      &fleet.WindowsDiskEncryptionSettingsPayload{EnableDiskEncryption: new(true)},
+			},
+			want: fleet.DiskEncryptionSettingsChanges{
+				MacOSEnable: new(true), MacOSEscrow: new(true), WindowsEnable: new(true), LinuxEscrow: new(true),
+			},
+		},
+		{
+			name: "flat conflicting with per-platform errors",
+			payload: fleet.MDMDiskEncryptionSettingsPayload{
+				EnableDiskEncryption: new(true),
+				LinuxSettings:        &fleet.LinuxDiskEncryptionSettingsPayload{EnableEscrowDiskEncryptionKey: new(false)},
+			},
+			wantErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.payload.ResolvePerPlatform()
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/server/service/mdm_test.go
+++ b/server/service/mdm_test.go
@@ -5466,3 +5466,48 @@ func TestResolvePerPlatformDiskEncryptionPayload(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveBitLockerPINPayload(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		payload fleet.MDMDiskEncryptionSettingsPayload
+		want    *bool
+		wantErr bool
+	}{
+		{"neither provided", fleet.MDMDiskEncryptionSettingsPayload{}, nil, false},
+		{"deprecated only", fleet.MDMDiskEncryptionSettingsPayload{RequireBitLockerPIN: new(true)}, new(true), false},
+		{
+			"canonical only",
+			fleet.MDMDiskEncryptionSettingsPayload{
+				WindowsSettings: &fleet.WindowsDiskEncryptionSettingsPayload{RequireBitLockerPIN: new(true)},
+			},
+			new(true), false,
+		},
+		{
+			"both agreeing",
+			fleet.MDMDiskEncryptionSettingsPayload{
+				RequireBitLockerPIN: new(false),
+				WindowsSettings:     &fleet.WindowsDiskEncryptionSettingsPayload{RequireBitLockerPIN: new(false)},
+			},
+			new(false), false,
+		},
+		{
+			"both disagreeing conflicts",
+			fleet.MDMDiskEncryptionSettingsPayload{
+				RequireBitLockerPIN: new(true),
+				WindowsSettings:     &fleet.WindowsDiskEncryptionSettingsPayload{RequireBitLockerPIN: new(false)},
+			},
+			nil, true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.payload.ResolveBitLockerPIN()
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -3706,13 +3706,13 @@ func GetDetailQueries(
 		// Add TPM PIN Queries iff Win MDM is enabled and ready to go
 		if appConfig.MDM.WindowsEnabledAndConfigured {
 			enableDiskEncryption := appConfig.MDM.WindowsSettings.EnableDiskEncryption.Value
-			requireTPMPin := appConfig.MDM.RequireBitLockerPIN.Value
+			requireTPMPin := appConfig.MDM.BitLockerPINRequired()
 
 			// If the host is part of a team, we need to look at the related team config
 			// instead of the App config ...
 			if teamMDMConfig != nil {
 				enableDiskEncryption = teamMDMConfig.WindowsSettings.EnableDiskEncryption.Value
-				requireTPMPin = teamMDMConfig.RequireBitLockerPIN
+				requireTPMPin = teamMDMConfig.DiskEncryptionConfig().BitLockerPINRequired
 			}
 
 			if enableDiskEncryption && requireTPMPin {

--- a/tools/cloner-check/generated_files/appconfig.txt
+++ b/tools/cloner-check/generated_files/appconfig.txt
@@ -215,6 +215,7 @@ github.com/fleetdm/fleet/v4/pkg/optjson/Slice[github.com/fleetdm/fleet/v4/server
 github.com/fleetdm/fleet/v4/server/fleet/WindowsSettings	ManagedLocalAccountSettings	fleet.ManagedLocalAccountSettings
 github.com/fleetdm/fleet/v4/server/fleet/ManagedLocalAccountSettings	Enabled	optjson.Bool
 github.com/fleetdm/fleet/v4/server/fleet/WindowsSettings	EnableDiskEncryption	optjson.Bool
+github.com/fleetdm/fleet/v4/server/fleet/WindowsSettings	RequireBitLockerPIN	optjson.Bool
 github.com/fleetdm/fleet/v4/server/fleet/MDM	VolumePurchasingProgram	optjson.Slice[github.com/fleetdm/fleet/v4/server/fleet.MDMAppleVolumePurchasingProgramInfo]
 github.com/fleetdm/fleet/v4/pkg/optjson/Slice[github.com/fleetdm/fleet/v4/server/fleet.MDMAppleVolumePurchasingProgramInfo]	Set	bool
 github.com/fleetdm/fleet/v4/pkg/optjson/Slice[github.com/fleetdm/fleet/v4/server/fleet.MDMAppleVolumePurchasingProgramInfo]	Valid	bool

--- a/tools/cloner-check/generated_files/teamconfig.txt
+++ b/tools/cloner-check/generated_files/teamconfig.txt
@@ -90,6 +90,7 @@ github.com/fleetdm/fleet/v4/pkg/optjson/Slice[github.com/fleetdm/fleet/v4/server
 github.com/fleetdm/fleet/v4/server/fleet/WindowsSettings	ManagedLocalAccountSettings	fleet.ManagedLocalAccountSettings
 github.com/fleetdm/fleet/v4/server/fleet/ManagedLocalAccountSettings	Enabled	optjson.Bool
 github.com/fleetdm/fleet/v4/server/fleet/WindowsSettings	EnableDiskEncryption	optjson.Bool
+github.com/fleetdm/fleet/v4/server/fleet/WindowsSettings	RequireBitLockerPIN	optjson.Bool
 github.com/fleetdm/fleet/v4/server/fleet/TeamMDM	AndroidSettings	fleet.AndroidSettings
 github.com/fleetdm/fleet/v4/server/fleet/AndroidSettings	CustomSettings	optjson.Slice[github.com/fleetdm/fleet/v4/server/fleet.MDMProfileSpec]
 github.com/fleetdm/fleet/v4/server/fleet/AndroidSettings	Certificates	optjson.Slice[github.com/fleetdm/fleet/v4/server/fleet.CertificateTemplateSpec]

--- a/tools/cloner-check/generated_files/teammdm.txt
+++ b/tools/cloner-check/generated_files/teammdm.txt
@@ -58,6 +58,7 @@ github.com/fleetdm/fleet/v4/pkg/optjson/Slice[github.com/fleetdm/fleet/v4/server
 github.com/fleetdm/fleet/v4/server/fleet/WindowsSettings	ManagedLocalAccountSettings	fleet.ManagedLocalAccountSettings
 github.com/fleetdm/fleet/v4/server/fleet/ManagedLocalAccountSettings	Enabled	optjson.Bool
 github.com/fleetdm/fleet/v4/server/fleet/WindowsSettings	EnableDiskEncryption	optjson.Bool
+github.com/fleetdm/fleet/v4/server/fleet/WindowsSettings	RequireBitLockerPIN	optjson.Bool
 github.com/fleetdm/fleet/v4/server/fleet/TeamMDM	AndroidSettings	fleet.AndroidSettings
 github.com/fleetdm/fleet/v4/server/fleet/AndroidSettings	CustomSettings	optjson.Slice[github.com/fleetdm/fleet/v4/server/fleet.MDMProfileSpec]
 github.com/fleetdm/fleet/v4/server/fleet/AndroidSettings	Certificates	optjson.Slice[github.com/fleetdm/fleet/v4/server/fleet.CertificateTemplateSpec]


### PR DESCRIPTION
**Related issue:** #51258

Fourth PR of #51258 (story #48654): the write surface. Stacked on #51846 (per-platform reads). Remaining PR: the `edited_disk_encryption_settings` activity swap.

- `POST /disk_encryption` accepts optional `macos_settings`, `windows_settings`, and `linux_settings` objects (nil field = don't change); the deprecated flat `enable_disk_encryption` fans out to all four and 422s if a per-platform value sent alongside disagrees. Also fixes the BitLocker PIN being silently dropped for "no team" and no longer requiring the server private key for a PIN-only change.
- `PATCH /config` and fleet specs replace the interim flat-wins rule with precedence-by-change: whichever side of the request actually differs from the stored state applies; changing both to disagreeing values is a 422. This keeps GitOps files that still carry the old flat key from resetting per-platform values on re-apply.
- The fleetctl GitOps client keeps configs declarative in per-platform form: when a YAML uses any per-platform disk encryption key, absent ones are reset to explicit false and the flat default is not injected (it would fan out server-side and stomp the per-platform intent); its BitLocker PIN pre-check now accepts the Windows key.
- The disk encryption license gates fire only when a setting is newly enabled, so a downgraded license can still save unrelated config changes and turn settings off (addresses the review note on #51777).

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configure disk encryption independently for macOS, Windows, and Linux.
  * Windows settings now include a canonical BitLocker PIN requirement option.
  * Configuration output consistently displays BitLocker PIN requirements as explicit values.

* **Bug Fixes**
  * Synchronized legacy and canonical BitLocker PIN settings across configuration formats.
  * Added validation for conflicting encryption or PIN settings.
  * Prevented BitLocker PIN requirements when Windows disk encryption is disabled.
  * Improved handling of partial updates and platform-specific overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->