### PR TITLE
Per-platform disk encryption: edited_disk_encryption_settings activity (#51258, 5/5)

### DIFF
--- a/changes/51258-per-platform-disk-encryption-activity
+++ b/changes/51258-per-platform-disk-encryption-activity
@@ -1,1 +1,0 @@
-- Added the `edited_disk_encryption_settings` activity, generated once per platform whose disk encryption settings changed; the `enabled_macos_disk_encryption` and `disabled_macos_disk_encryption` activities are no longer generated.

--- a/changes/51258-per-platform-disk-encryption-activity
+++ b/changes/51258-per-platform-disk-encryption-activity
@@ -1,0 +1,1 @@
+- Added the `edited_disk_encryption_settings` activity, generated once per platform whose disk encryption settings changed; the `enabled_macos_disk_encryption` and `disabled_macos_disk_encryption` activities are no longer generated.

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -239,6 +239,9 @@ func (svc *Service) ModifyTeam(ctx context.Context, teamID uint, payload fleet.T
 		windowsUpdatesUpdated           bool
 		macOSDiskEncryptionUpdated      bool
 		macOSFileVaultWasOn             bool
+		macOSSettingsChanged            bool
+		windowsSettingsChanged          bool
+		linuxSettingsChanged            bool
 		recoveryLockPasswordUpdated     bool
 		macOSEnableEndUserAuthUpdated   bool
 		macOSManagedLocalAccountUpdated bool
@@ -361,13 +364,17 @@ func (svc *Service) ModifyTeam(ctx context.Context, teamID uint, payload fleet.T
 			if diskEncryptionUpdated && v && svc.config.Server.PrivateKey == "" {
 				return nil, ctxerr.New(ctx, "Missing required private key. Learn how to configure the private key here: https://fleetdm.com/learn-more-about/fleet-server-private-key")
 			}
-			// The Apple FileVault profile and macOS-named activity only apply when Apple MDM is configured.
+			// The Apple FileVault profile only applies when Apple MDM is configured.
 			// On Windows-only deployments the flag still controls BitLocker enforcement via the Windows MDM path.
 			// The FileVault profile covers enforcement and escrow as a whole, so only the
 			// off<->on transition of the pair creates or deletes it.
 			macOSFileVaultWasOn = team.Config.MDM.MacOSSettings.EnableDiskEncryption.Value ||
 				team.Config.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey.Value
 			macOSDiskEncryptionUpdated = macOSFileVaultWasOn != v && appCfg.MDM.EnabledAndConfigured
+			macOSSettingsChanged = team.Config.MDM.MacOSSettings.EnableDiskEncryption.Value != v ||
+				team.Config.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey.Value != v
+			windowsSettingsChanged = team.Config.MDM.WindowsSettings.EnableDiskEncryption.Value != v
+			linuxSettingsChanged = team.Config.MDM.LinuxSettings.EnableEscrowDiskEncryptionKey.Value != v
 			team.Config.MDM.MacOSSettings.EnableDiskEncryption = optjson.SetBool(v)
 			team.Config.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey = optjson.SetBool(v)
 			team.Config.MDM.WindowsSettings.EnableDiskEncryption = optjson.SetBool(v)
@@ -394,7 +401,11 @@ func (svc *Service) ModifyTeam(ctx context.Context, teamID uint, payload fleet.T
 		if err != nil {
 			return nil, ctxerr.Wrap(ctx, err)
 		}
+		oldPIN := team.Config.MDM.DiskEncryptionConfig().BitLockerPINRequired
 		if incomingPIN.Valid {
+			if incomingPIN.Value != oldPIN {
+				windowsSettingsChanged = true
+			}
 			team.Config.MDM.RequireBitLockerPIN = incomingPIN.Value
 			team.Config.MDM.WindowsSettings.RequireBitLockerPIN = optjson.SetBool(incomingPIN.Value)
 		}
@@ -696,20 +707,33 @@ func (svc *Service) ModifyTeam(ctx context.Context, teamID uint, payload fleet.T
 		}
 	}
 	if macOSDiskEncryptionUpdated {
-		var act fleet.ActivityDetails
 		if !macOSFileVaultWasOn {
-			act = fleet.ActivityTypeEnabledMacosDiskEncryption{TeamID: &team.ID, TeamName: &team.Name}
 			if err := svc.MDMAppleEnableFileVaultAndEscrow(ctx, &team.ID); err != nil {
 				return nil, ctxerr.Wrap(ctx, err, "enable team filevault and escrow")
 			}
 		} else {
-			act = fleet.ActivityTypeDisabledMacosDiskEncryption{TeamID: &team.ID, TeamName: &team.Name}
 			if err := svc.MDMAppleDisableFileVaultAndEscrow(ctx, &team.ID); err != nil && !fleet.IsNotFound(err) {
 				return nil, ctxerr.Wrap(ctx, err, "disable team filevault and escrow")
 			}
 		}
-		if err := svc.NewActivity(ctx, authz.UserFromContext(ctx), act); err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "create activity for team macos disk encryption")
+	}
+	for _, pc := range []struct {
+		platform string
+		changed  bool
+	}{
+		{"macos", macOSSettingsChanged},
+		{"windows", windowsSettingsChanged},
+		{"linux", linuxSettingsChanged},
+	} {
+		if !pc.changed {
+			continue
+		}
+		if err := svc.NewActivity(ctx, authz.UserFromContext(ctx), fleet.ActivityTypeEditedDiskEncryptionSettings{
+			FleetID:   &team.ID,
+			FleetName: &team.Name,
+			Platform:  pc.platform,
+		}); err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "create activity for team disk encryption settings")
 		}
 	}
 	if recoveryLockPasswordUpdated {
@@ -1871,17 +1895,28 @@ func (svc *Service) createTeamFromSpec(
 
 	// The FileVault profile can cover both enforcement and key escrow.
 	if macOSDiskEncryptionOn && appCfg.MDM.EnabledAndConfigured {
-		// TODO: Are we missing an activity or anything else for BitLocker here?
 		if err := svc.MDMAppleEnableFileVaultAndEscrow(ctx, &tm.ID); err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "enable team filevault and escrow")
 		}
-
-		if err := svc.NewActivity(
-			ctx,
-			authz.UserFromContext(ctx),
-			fleet.ActivityTypeEnabledMacosDiskEncryption{TeamID: &tm.ID, TeamName: &tm.Name},
-		); err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "create activity for team macos disk encryption")
+	}
+	// a new team starts with everything off, so any enabled platform is a change
+	for _, pc := range []struct {
+		platform string
+		changed  bool
+	}{
+		{"macos", macOSDiskEncryptionOn},
+		{"windows", windowsSettings.EnableDiskEncryption.Value || spec.MDM.RequireBitLockerPIN.Value},
+		{"linux", linuxSettings.EnableEscrowDiskEncryptionKey.Value},
+	} {
+		if !pc.changed {
+			continue
+		}
+		if err := svc.NewActivity(ctx, authz.UserFromContext(ctx), fleet.ActivityTypeEditedDiskEncryptionSettings{
+			FleetID:   &tm.ID,
+			FleetName: &tm.Name,
+			Platform:  pc.platform,
+		}); err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "create activity for team disk encryption settings")
 		}
 	}
 
@@ -2050,6 +2085,8 @@ func (svc *Service) editTeamFromSpec(
 	newDiskEncryption := team.Config.MDM.DiskEncryptionConfig()
 	didUpdateMacOSDiskEncryption := newDiskEncryption.MacOSEnabled != oldDiskEncryption.MacOSEnabled ||
 		newDiskEncryption.MacOSEscrowEnabled != oldDiskEncryption.MacOSEscrowEnabled
+	didUpdateWindowsDiskEncryption := newDiskEncryption.WindowsEnabled != oldDiskEncryption.WindowsEnabled
+	didUpdateLinuxDiskEncryption := newDiskEncryption.LinuxEscrowEnabled != oldDiskEncryption.LinuxEscrowEnabled
 	// the flat toggle is virtual: keep the stored value consistent
 	team.Config.MDM.EnableDiskEncryption = newDiskEncryption.MacOSEnabled && newDiskEncryption.MacOSEscrowEnabled &&
 		newDiskEncryption.WindowsEnabled && newDiskEncryption.LinuxEscrowEnabled
@@ -2070,6 +2107,9 @@ func (svc *Service) editTeamFromSpec(
 		return ctxerr.Wrap(ctx, err)
 	}
 	if incomingPIN.Valid {
+		if incomingPIN.Value != oldDiskEncryption.BitLockerPINRequired {
+			didUpdateWindowsDiskEncryption = true
+		}
 		team.Config.MDM.RequireBitLockerPIN = incomingPIN.Value
 		team.Config.MDM.WindowsSettings.RequireBitLockerPIN = optjson.SetBool(incomingPIN.Value)
 	}
@@ -2356,29 +2396,38 @@ func (svc *Service) editTeamFromSpec(
 	}
 
 	if appCfg.MDM.EnabledAndConfigured && didUpdateMacOSDiskEncryption {
-		// TODO: Are we missing an activity or anything else for BitLocker here?
 		// The FileVault profile can cover both enforcement and key escrow, so
 		// only the off<->on transition of the pair creates or deletes it.
-		macOSDiskEncryptionOn := team.Config.MDM.MacOSSettings.EnableDiskEncryption.Value ||
-			team.Config.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey.Value
+		macOSDiskEncryptionOn := newDiskEncryption.MacOSEnabled || newDiskEncryption.MacOSEscrowEnabled
 		macOSDiskEncryptionWasOn := oldDiskEncryption.MacOSEnabled || oldDiskEncryption.MacOSEscrowEnabled
-		var act fleet.ActivityDetails
 		switch {
 		case macOSDiskEncryptionOn && !macOSDiskEncryptionWasOn:
-			act = fleet.ActivityTypeEnabledMacosDiskEncryption{TeamID: &team.ID, TeamName: &team.Name}
 			if err := svc.MDMAppleEnableFileVaultAndEscrow(ctx, &team.ID); err != nil {
 				return ctxerr.Wrap(ctx, err, "enable team filevault and escrow")
 			}
 		case !macOSDiskEncryptionOn && macOSDiskEncryptionWasOn:
-			act = fleet.ActivityTypeDisabledMacosDiskEncryption{TeamID: &team.ID, TeamName: &team.Name}
 			if err := svc.MDMAppleDisableFileVaultAndEscrow(ctx, &team.ID); err != nil && !fleet.IsNotFound(err) {
 				return ctxerr.Wrap(ctx, err, "disable team filevault and escrow")
 			}
 		}
-		if act != nil {
-			if err := svc.NewActivity(ctx, authz.UserFromContext(ctx), act); err != nil {
-				return ctxerr.Wrap(ctx, err, "create activity for team macos disk encryption")
-			}
+	}
+	for _, pc := range []struct {
+		platform string
+		changed  bool
+	}{
+		{"macos", didUpdateMacOSDiskEncryption},
+		{"windows", didUpdateWindowsDiskEncryption},
+		{"linux", didUpdateLinuxDiskEncryption},
+	} {
+		if !pc.changed {
+			continue
+		}
+		if err := svc.NewActivity(ctx, authz.UserFromContext(ctx), fleet.ActivityTypeEditedDiskEncryptionSettings{
+			FleetID:   &team.ID,
+			FleetName: &team.Name,
+			Platform:  pc.platform,
+		}); err != nil {
+			return ctxerr.Wrap(ctx, err, "create activity for team disk encryption settings")
 		}
 	}
 
@@ -2611,15 +2660,17 @@ func (svc *Service) updateTeamMDMDiskEncryption(ctx context.Context, tm *fleet.T
 	linuxChanged := apply(&tm.Config.MDM.LinuxSettings.EnableEscrowDiskEncryptionKey, changes.LinuxEscrow)
 	// the PIN is updated outside of apply: it doesn't enable key escrow, so it
 	// must not trigger the private-key requirement
-	pinChanged := requireBitLockerPIN != nil && oldDiskEncryption.BitLockerPINRequired != *requireBitLockerPIN
 	if requireBitLockerPIN != nil {
+		if oldDiskEncryption.BitLockerPINRequired != *requireBitLockerPIN {
+			windowsChanged = true
+		}
 		// the deprecated top-level key mirrors the canonical
 		// windows_settings.require_bitlocker_pin home
 		tm.Config.MDM.RequireBitLockerPIN = *requireBitLockerPIN
 		tm.Config.MDM.WindowsSettings.RequireBitLockerPIN = optjson.SetBool(*requireBitLockerPIN)
 	}
 
-	if !macOSChanged && !windowsChanged && !linuxChanged && !pinChanged {
+	if !macOSChanged && !windowsChanged && !linuxChanged {
 		return nil
 	}
 
@@ -2646,27 +2697,41 @@ func (svc *Service) updateTeamMDMDiskEncryption(ctx context.Context, tm *fleet.T
 		if err != nil {
 			return err
 		}
-		// the FileVault profile covers enforcement and escrow as a whole:
-		// only the off<->on transition of the macOS pair creates or deletes
-		// it
+		// the FileVault profile can cover both enforcement and key escrow,
+		// so only the off<->on transition of the macOS pair creates or
+		// deletes it
 		macOSDiskEncryptionOn := newDiskEncryption.MacOSEnabled || newDiskEncryption.MacOSEscrowEnabled
 		macOSDiskEncryptionWasOn := oldDiskEncryption.MacOSEnabled || oldDiskEncryption.MacOSEscrowEnabled
 		if appCfg.MDM.EnabledAndConfigured && macOSDiskEncryptionOn != macOSDiskEncryptionWasOn {
-			var act fleet.ActivityDetails
 			if macOSDiskEncryptionOn {
-				act = fleet.ActivityTypeEnabledMacosDiskEncryption{TeamID: &tm.ID, TeamName: &tm.Name}
 				if err := svc.MDMAppleEnableFileVaultAndEscrow(ctx, &tm.ID); err != nil {
 					return ctxerr.Wrap(ctx, err, "enable team filevault and escrow")
 				}
 			} else {
-				act = fleet.ActivityTypeDisabledMacosDiskEncryption{TeamID: &tm.ID, TeamName: &tm.Name}
 				if err := svc.MDMAppleDisableFileVaultAndEscrow(ctx, &tm.ID); err != nil && !fleet.IsNotFound(err) {
 					return ctxerr.Wrap(ctx, err, "disable team filevault and escrow")
 				}
 			}
-			if err := svc.NewActivity(ctx, authz.UserFromContext(ctx), act); err != nil {
-				return ctxerr.Wrap(ctx, err, "create activity for team macos disk encryption")
-			}
+		}
+	}
+
+	for _, pc := range []struct {
+		platform string
+		changed  bool
+	}{
+		{"macos", macOSChanged},
+		{"windows", windowsChanged},
+		{"linux", linuxChanged},
+	} {
+		if !pc.changed {
+			continue
+		}
+		if err := svc.NewActivity(ctx, authz.UserFromContext(ctx), fleet.ActivityTypeEditedDiskEncryptionSettings{
+			FleetID:   &tm.ID,
+			FleetName: &tm.Name,
+			Platform:  pc.platform,
+		}); err != nil {
+			return ctxerr.Wrap(ctx, err, "create activity for team disk encryption settings")
 		}
 	}
 	return nil

--- a/frontend/interfaces/activity.ts
+++ b/frontend/interfaces/activity.ts
@@ -407,7 +407,6 @@ export interface IActivityDetails {
   fleet_id?: number | null;
   fleet_name?: string | null;
   dataset?: string;
-  platform?: string;
 }
 
 /**

--- a/frontend/interfaces/activity.ts
+++ b/frontend/interfaces/activity.ts
@@ -89,10 +89,14 @@ export enum ActivityType {
   EditedAndroidProfile = "edited_android_profile",
   EditedAndroidCertificate = "edited_android_certificate",
   ResentCertificate = "resent_certificate",
-  // Note: This activity is generated for all platforms.
+  // Deprecated: superseded by EditedDiskEncryptionSettings; kept so
+  // historical activities still render. Was generated for all platforms.
   EnabledMacDiskEncryption = "enabled_macos_disk_encryption",
-  // Note: This activity is generated for all platforms.
+  // Deprecated: superseded by EditedDiskEncryptionSettings; kept so
+  // historical activities still render. Was generated for all platforms.
   DisabledMacDiskEncryption = "disabled_macos_disk_encryption",
+  // Generated once per platform whose disk encryption settings changed.
+  EditedDiskEncryptionSettings = "edited_disk_encryption_settings",
   AddedBootstrapPackage = "added_bootstrap_package",
   DeletedBootstrapPackage = "deleted_bootstrap_package",
   ChangedMacOSSetupAssistant = "changed_macos_setup_assistant",
@@ -403,6 +407,7 @@ export interface IActivityDetails {
   fleet_id?: number | null;
   fleet_name?: string | null;
   dataset?: string;
+  platform?: string;
 }
 
 /**
@@ -497,6 +502,7 @@ export const ACTIVITY_TYPE_TO_FILTER_LABEL: Record<ActivityType, string> = {
   edited_custom_scep_proxy: "Edited certificate authority (CA): custom SCEP",
   edited_declaration_profile: "Edited declaration (DDM) profiles",
   edited_digicert: "Edited certificate authority (CA): DigiCert",
+  edited_disk_encryption_settings: "Edited disk encryption settings",
   edited_ios_min_version: "OS updates: edited iOS",
   edited_ipados_min_version: "OS updates: edited iPadOS",
   edited_macos_min_version: "OS updates: edited macOS",

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tests.tsx
@@ -656,6 +656,21 @@ describe("Activity Feed", () => {
     expect(screen.getByText(" fleet.", { exact: false })).toBeInTheDocument();
   });
 
+  it("renders an 'edited_disk_encryption_settings' type activity with a missing platform", () => {
+    const activity = createMockActivity({
+      type: ActivityType.EditedDiskEncryptionSettings,
+      details: { fleet_name: "Alphas" },
+    });
+    render(<GlobalActivityItem activity={activity} isPremiumTier />);
+
+    expect(
+      screen.getByText(
+        "edited disk encryption settings for unknown hosts assigned to the",
+        { exact: false }
+      )
+    ).toBeInTheDocument();
+  });
+
   it("renders an 'edited_disk_encryption_settings' type activity for hosts that are unassigned.", () => {
     const activity = createMockActivity({
       type: ActivityType.EditedDiskEncryptionSettings,

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tests.tsx
@@ -639,6 +639,38 @@ describe("Activity Feed", () => {
     expect(forAllTeams).toBeNull();
   });
 
+  it("renders an 'edited_disk_encryption_settings' type activity for a fleet", () => {
+    const activity = createMockActivity({
+      type: ActivityType.EditedDiskEncryptionSettings,
+      details: { fleet_name: "Alphas", platform: "windows" },
+    });
+    render(<GlobalActivityItem activity={activity} isPremiumTier />);
+
+    expect(
+      screen.getByText(
+        "edited disk encryption settings for Windows hosts assigned to the",
+        { exact: false }
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByText("Alphas")).toBeInTheDocument();
+    expect(screen.getByText(" fleet.", { exact: false })).toBeInTheDocument();
+  });
+
+  it("renders an 'edited_disk_encryption_settings' type activity for hosts that are unassigned.", () => {
+    const activity = createMockActivity({
+      type: ActivityType.EditedDiskEncryptionSettings,
+      details: { platform: "linux" },
+    });
+    render(<GlobalActivityItem activity={activity} isPremiumTier />);
+
+    expect(
+      screen.getByText(
+        "edited disk encryption settings for Linux hosts that are unassigned."
+      )
+    ).toBeInTheDocument();
+    expect(screen.queryByText("assigned to the")).toBeNull();
+  });
+
   it("renders an 'enabled_macos_disk_encryption' type activity for a team", () => {
     // Test deprecated activity type
     const activity = createMockActivity({

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
@@ -911,6 +911,21 @@ const TAGGED_TEMPLATES = {
     const suffix = getHostTeamAssignmentSuffix(activity.details?.team_name);
     return <>removed disk encryption enforcement for hosts {suffix}.</>;
   },
+  editedDiskEncryptionSettings: (activity: IActivity) => {
+    const platformDisplay =
+      {
+        macos: "macOS",
+        windows: "Windows",
+        linux: "Linux",
+      }[activity.details?.platform ?? ""] ?? "";
+    const suffix = getHostTeamAssignmentSuffix(activity.details?.fleet_name);
+    return (
+      <>
+        {" "}
+        edited disk encryption settings for {platformDisplay} hosts{suffix}.
+      </>
+    );
+  },
   enabledRecoveryLockPasswords: (activity: IActivity) => {
     const suffix = getHostTeamAssignmentSuffix(activity.details?.team_name);
     return <>enforced Recovery Lock passwords for hosts {suffix}.</>;
@@ -2523,6 +2538,9 @@ const getDetail = (activity: IActivity, isPremiumTier: boolean) => {
     // Note: This activity is generated for all platforms.
     case ActivityType.DisabledMacDiskEncryption: {
       return TAGGED_TEMPLATES.disabledEncryption(activity);
+    }
+    case ActivityType.EditedDiskEncryptionSettings: {
+      return TAGGED_TEMPLATES.editedDiskEncryptionSettings(activity);
     }
     case ActivityType.EnabledRecoveryLockPasswords: {
       return TAGGED_TEMPLATES.enabledRecoveryLockPasswords(activity);

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
@@ -912,16 +912,19 @@ const TAGGED_TEMPLATES = {
     return <>removed disk encryption enforcement for hosts {suffix}.</>;
   },
   editedDiskEncryptionSettings: (activity: IActivity) => {
-    const platformDisplay =
-      {
-        macos: "macOS",
-        windows: "Windows",
-        linux: "Linux",
-      }[activity.details?.platform ?? ""] ?? "";
+    // this activity's platform detail is "macos" | "windows" | "linux" — the
+    // settings-key naming, not the osquery-style "darwin" of other activities
+    const platform = (activity.details?.platform as string | undefined) ?? "";
+    const displayNames: Record<string, string> = {
+      macos: "macOS",
+      windows: "Windows",
+      linux: "Linux",
+    };
+    // fall back to the raw value so an unexpected platform degrades visibly
+    const platformDisplay = displayNames[platform] ?? platform;
     const suffix = getHostTeamAssignmentSuffix(activity.details?.fleet_name);
     return (
       <>
-        {" "}
         edited disk encryption settings for {platformDisplay} hosts{suffix}.
       </>
     );

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
@@ -914,14 +914,17 @@ const TAGGED_TEMPLATES = {
   editedDiskEncryptionSettings: (activity: IActivity) => {
     // this activity's platform detail is "macos" | "windows" | "linux" — the
     // settings-key naming, not the osquery-style "darwin" of other activities
-    const platform = (activity.details?.platform as string | undefined) ?? "";
+    const platform = activity.details?.platform as string | undefined;
     const displayNames: Record<string, string> = {
       macos: "macOS",
       windows: "Windows",
       linux: "Linux",
     };
-    // fall back to the raw value so an unexpected platform degrades visibly
-    const platformDisplay = displayNames[platform] ?? platform;
+    // an unexpected value renders as-is and a missing one as "unknown", so
+    // either degrades visibly rather than leaving a gap in the sentence
+    const platformDisplay = platform
+      ? displayNames[platform] ?? platform
+      : "unknown";
     const suffix = getHostTeamAssignmentSuffix(activity.details?.fleet_name);
     return (
       <>

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -645,6 +645,9 @@ func (a ActivityTypeDeletedMacosSetupAssistant) ActivityName() string {
 	return "deleted_macos_setup_assistant"
 }
 
+// ActivityTypeEnabledMacosDiskEncryption is deprecated, superseded by
+// ActivityTypeEditedDiskEncryptionSettings; kept only so historical
+// activities still render.
 type ActivityTypeEnabledMacosDiskEncryption struct {
 	TeamID   *uint   `json:"team_id" renameto:"fleet_id"`
 	TeamName *string `json:"team_name" renameto:"fleet_name"`
@@ -654,6 +657,9 @@ func (a ActivityTypeEnabledMacosDiskEncryption) ActivityName() string {
 	return "enabled_macos_disk_encryption"
 }
 
+// ActivityTypeDisabledMacosDiskEncryption is deprecated, superseded by
+// ActivityTypeEditedDiskEncryptionSettings; kept only so historical
+// activities still render.
 type ActivityTypeDisabledMacosDiskEncryption struct {
 	TeamID   *uint   `json:"team_id" renameto:"fleet_id"`
 	TeamName *string `json:"team_name" renameto:"fleet_name"`
@@ -661,6 +667,20 @@ type ActivityTypeDisabledMacosDiskEncryption struct {
 
 func (a ActivityTypeDisabledMacosDiskEncryption) ActivityName() string {
 	return "disabled_macos_disk_encryption"
+}
+
+// ActivityTypeEditedDiskEncryptionSettings is recorded once per platform whose
+// effective disk encryption settings changed. It replaces the deprecated
+// ActivityTypeEnabledMacosDiskEncryption / ActivityTypeDisabledMacosDiskEncryption
+// pair.
+type ActivityTypeEditedDiskEncryptionSettings struct {
+	FleetID   *uint   `json:"fleet_id"`
+	FleetName *string `json:"fleet_name"`
+	Platform  string  `json:"platform"` // "macos" | "windows" | "linux"
+}
+
+func (a ActivityTypeEditedDiskEncryptionSettings) ActivityName() string {
+	return "edited_disk_encryption_settings"
 }
 
 type ActivityTypeSetHostRecoveryLockPassword struct {

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -1635,30 +1635,44 @@ func (svc *Service) processSavedAppConfigChanges(
 		}
 	}
 
-	// The FileVault profile covers enforcement and escrow as a whole: it
-	// exists whenever either macOS setting is on, so only the off<->on
-	// transition of the pair creates or deletes it.
-	macOSDiskEncryptionOn := appConfig.MDM.MacOSSettings.EnableDiskEncryption.Value ||
-		appConfig.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey.Value
-	macOSDiskEncryptionWasOn := oldAppConfig.MDM.MacOSSettings.EnableDiskEncryption.Value ||
-		oldAppConfig.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey.Value
-	if macOSDiskEncryptionOn != macOSDiskEncryptionWasOn {
-		if oldAppConfig.MDM.EnabledAndConfigured {
-			var act fleet.ActivityDetails
-			if macOSDiskEncryptionOn {
-				act = fleet.ActivityTypeEnabledMacosDiskEncryption{}
-				if err := svc.EnterpriseOverrides.MDMAppleEnableFileVaultAndEscrow(ctx, nil); err != nil {
-					return ctxerr.Wrap(ctx, err, "enable no-team filevault and escrow")
-				}
-			} else {
-				act = fleet.ActivityTypeDisabledMacosDiskEncryption{}
-				if err := svc.EnterpriseOverrides.MDMAppleDisableFileVaultAndEscrow(ctx, nil); err != nil && !fleet.IsNotFound(err) {
-					return ctxerr.Wrap(ctx, err, "disable no-team filevault and escrow")
-				}
+	macOSDiskEncryptionChanged := oldAppConfig.MDM.MacOSSettings.EnableDiskEncryption.Value != appConfig.MDM.MacOSSettings.EnableDiskEncryption.Value ||
+		oldAppConfig.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey.Value != appConfig.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey.Value
+	windowsDiskEncryptionChanged := oldAppConfig.MDM.WindowsSettings.EnableDiskEncryption.Value != appConfig.MDM.WindowsSettings.EnableDiskEncryption.Value ||
+		oldAppConfig.MDM.RequireBitLockerPIN.Value != appConfig.MDM.RequireBitLockerPIN.Value
+	linuxDiskEncryptionChanged := oldAppConfig.MDM.LinuxSettings.EnableEscrowDiskEncryptionKey.Value != appConfig.MDM.LinuxSettings.EnableEscrowDiskEncryptionKey.Value
+
+	if macOSDiskEncryptionChanged && oldAppConfig.MDM.EnabledAndConfigured {
+		// The FileVault profile can cover both enforcement and key escrow, so
+		// only the off<->on transition of the pair creates or deletes it.
+		macOSDiskEncryptionOn := appConfig.MDM.MacOSSettings.EnableDiskEncryption.Value || appConfig.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey.Value
+		macOSDiskEncryptionWasOn := oldAppConfig.MDM.MacOSSettings.EnableDiskEncryption.Value || oldAppConfig.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey.Value
+		switch {
+		case macOSDiskEncryptionOn && !macOSDiskEncryptionWasOn:
+			if err := svc.EnterpriseOverrides.MDMAppleEnableFileVaultAndEscrow(ctx, nil); err != nil {
+				return ctxerr.Wrap(ctx, err, "enable no-team filevault and escrow")
 			}
-			if err := svc.NewActivity(ctx, authz.UserFromContext(ctx), act); err != nil {
-				return ctxerr.Wrap(ctx, err, "create activity for app config macos disk encryption")
+		case !macOSDiskEncryptionOn && macOSDiskEncryptionWasOn:
+			if err := svc.EnterpriseOverrides.MDMAppleDisableFileVaultAndEscrow(ctx, nil); err != nil && !fleet.IsNotFound(err) {
+				return ctxerr.Wrap(ctx, err, "disable no-team filevault and escrow")
 			}
+		}
+	}
+
+	for _, pc := range []struct {
+		platform string
+		changed  bool
+	}{
+		{"macos", macOSDiskEncryptionChanged},
+		{"windows", windowsDiskEncryptionChanged},
+		{"linux", linuxDiskEncryptionChanged},
+	} {
+		if !pc.changed {
+			continue
+		}
+		if err := svc.NewActivity(ctx, authz.UserFromContext(ctx), fleet.ActivityTypeEditedDiskEncryptionSettings{
+			Platform: pc.platform,
+		}); err != nil {
+			return ctxerr.Wrap(ctx, err, "create activity for app config disk encryption settings")
 		}
 	}
 

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -3705,15 +3705,17 @@ func (svc *Service) updateAppConfigMDMDiskEncryption(ctx context.Context, change
 	linuxChanged := apply(&ac.MDM.LinuxSettings.EnableEscrowDiskEncryptionKey, changes.LinuxEscrow)
 	// the PIN is updated outside of apply: it doesn't enable key escrow, so it
 	// must not trigger the private-key requirement (mirrors the team path)
-	pinChanged := requireBitLockerPIN != nil && ac.MDM.BitLockerPINRequired() != *requireBitLockerPIN
 	if requireBitLockerPIN != nil {
+		if ac.MDM.BitLockerPINRequired() != *requireBitLockerPIN {
+			windowsChanged = true
+		}
 		// the deprecated top-level key mirrors the canonical
 		// windows_settings.require_bitlocker_pin home
 		ac.MDM.RequireBitLockerPIN = optjson.SetBool(*requireBitLockerPIN)
 		ac.MDM.WindowsSettings.RequireBitLockerPIN = optjson.SetBool(*requireBitLockerPIN)
 	}
 
-	if !macOSChanged && !windowsChanged && !linuxChanged && !pinChanged {
+	if !macOSChanged && !windowsChanged && !linuxChanged {
 		return nil
 	}
 
@@ -3733,25 +3735,38 @@ func (svc *Service) updateAppConfigMDMDiskEncryption(ctx context.Context, change
 		return err
 	}
 
-	// The FileVault profile covers enforcement and escrow as a whole: only
-	// the off<->on transition of the macOS pair creates or deletes it.
-	macOSDiskEncryptionOn := ac.MDM.MacOSSettings.EnableDiskEncryption.Value ||
-		ac.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey.Value
-	if ac.MDM.EnabledAndConfigured && macOSDiskEncryptionOn != macOSDiskEncryptionWasOn { // if macOS MDM is configured, set up FileVault escrow
-		var act fleet.ActivityDetails
-		if macOSDiskEncryptionOn {
-			act = fleet.ActivityTypeEnabledMacosDiskEncryption{}
+	if macOSChanged && ac.MDM.EnabledAndConfigured { // if macOS MDM is configured, set up FileVault escrow
+		// the FileVault profile can cover both enforcement and key escrow,
+		// so only the off<->on transition of the macOS pair creates or
+		// deletes it
+		macOSDiskEncryptionOn := ac.MDM.MacOSSettings.EnableDiskEncryption.Value || ac.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey.Value
+		switch {
+		case macOSDiskEncryptionOn && !macOSDiskEncryptionWasOn:
 			if err := svc.EnterpriseOverrides.MDMAppleEnableFileVaultAndEscrow(ctx, nil); err != nil {
 				return ctxerr.Wrap(ctx, err, "enable no-team filevault and escrow")
 			}
-		} else {
-			act = fleet.ActivityTypeDisabledMacosDiskEncryption{}
+		case !macOSDiskEncryptionOn && macOSDiskEncryptionWasOn:
 			if err := svc.EnterpriseOverrides.MDMAppleDisableFileVaultAndEscrow(ctx, nil); err != nil && !fleet.IsNotFound(err) {
 				return ctxerr.Wrap(ctx, err, "disable no-team filevault and escrow")
 			}
 		}
-		if err := svc.NewActivity(ctx, authz.UserFromContext(ctx), act); err != nil {
-			return ctxerr.Wrap(ctx, err, "create activity for app config macos disk encryption")
+	}
+
+	for _, pc := range []struct {
+		platform string
+		changed  bool
+	}{
+		{"macos", macOSChanged},
+		{"windows", windowsChanged},
+		{"linux", linuxChanged},
+	} {
+		if !pc.changed {
+			continue
+		}
+		if err := svc.NewActivity(ctx, authz.UserFromContext(ctx), fleet.ActivityTypeEditedDiskEncryptionSettings{
+			Platform: pc.platform,
+		}); err != nil {
+			return ctxerr.Wrap(ctx, err, "create activity for app config disk encryption settings")
 		}
 	}
 	return nil

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -3788,6 +3788,27 @@ func (s *integrationMDMTestSuite) TestTeamsMDMAppleDiskEncryption() {
 	teamResp = getTeamResponse{}
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/teams/%d", team.ID), nil, http.StatusOK, &teamResp)
 	require.True(t, teamResp.Team.Config.MDM.EnableDiskEncryption)
+
+	// changing a single per-platform setting via a team spec generates one
+	// activity for that platform only
+	teamSpecs = applyTeamSpecsRequest{Specs: []*fleet.TeamSpec{{
+		Name: team.Name,
+		MDM: fleet.TeamSpecMDM{
+			LinuxSettings: fleet.LinuxSettings{
+				EnableEscrowDiskEncryptionKey: optjson.SetBool(false),
+			},
+		},
+	}}}
+	s.Do("POST", "/api/latest/fleet/spec/teams", teamSpecs, http.StatusOK)
+	linuxActID := s.lastActivityOfTypeMatches(fleet.ActivityTypeEditedDiskEncryptionSettings{}.ActivityName(),
+		fmt.Sprintf(`{"fleet_id": %d, "fleet_name": %q, "platform": "linux"}`, team.ID, team.Name), 0)
+
+	// a PIN-only change counts as a windows settings change
+	s.Do("POST", "/api/latest/fleet/disk_encryption",
+		updateDiskEncryptionRequest{TeamID: new(team.ID), RequireBitLockerPIN: new(true)}, http.StatusNoContent)
+	winActID := s.lastActivityOfTypeMatches(fleet.ActivityTypeEditedDiskEncryptionSettings{}.ActivityName(),
+		fmt.Sprintf(`{"fleet_id": %d, "fleet_name": %q, "platform": "windows"}`, team.ID, team.Name), 0)
+	require.Greater(t, winActID, linuxActID)
 }
 
 func (s *integrationMDMTestSuite) TestTeamsMDMRecoveryLockPassword() {

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -3267,8 +3267,24 @@ func (s *integrationMDMTestSuite) TestAppConfigMDMAppleDiskEncryption() {
 		"mdm": { "enable_disk_encryption": true }
   }`), http.StatusOK, &acResp)
 	assert.True(t, acResp.MDM.EnableDiskEncryption.Value)
-	enabledDiskActID := s.lastActivityMatches(fleet.ActivityTypeEnabledMacosDiskEncryption{}.ActivityName(),
-		`{"team_id": null, "team_name": null, "fleet_id": null, "fleet_name": null}`, 0)
+	enabledDiskActID := s.lastActivityMatches(fleet.ActivityTypeEditedDiskEncryptionSettings{}.ActivityName(),
+		`{"fleet_id": null, "fleet_name": null, "platform": "linux"}`, 0)
+
+	// a legacy flat-toggle write emits one activity per platform
+	var listActivities listActivitiesResponse
+	s.DoJSON("GET", "/api/latest/fleet/activities", nil, http.StatusOK, &listActivities,
+		"order_key", "id", "order_direction", "desc", "per_page", "3")
+	require.Len(t, listActivities.Activities, 3)
+	gotPlatforms := make([]string, 0, 3)
+	for _, act := range listActivities.Activities {
+		require.Equal(t, fleet.ActivityTypeEditedDiskEncryptionSettings{}.ActivityName(), act.Type)
+		var details struct {
+			Platform string `json:"platform"`
+		}
+		require.NoError(t, json.Unmarshal(*act.Details, &details))
+		gotPlatforms = append(gotPlatforms, details.Platform)
+	}
+	require.ElementsMatch(t, []string{"macos", "windows", "linux"}, gotPlatforms)
 
 	// will have generated the macos config profile
 	s.assertConfigProfilesByIdentifier(nil, mobileconfig.FleetFileVaultPayloadIdentifier, true)
@@ -3286,7 +3302,7 @@ func (s *integrationMDMTestSuite) TestAppConfigMDMAppleDiskEncryption() {
 		}`), http.StatusOK, &acResp)
 	assert.True(t, acResp.MDM.EnableDiskEncryption.Value)
 	assert.Equal(t, []fleet.MDMProfileSpec{{Path: "a"}}, acResp.MDM.MacOSSettings.CustomSettings)
-	s.lastActivityMatches(fleet.ActivityTypeEnabledMacosDiskEncryption{}.ActivityName(),
+	s.lastActivityMatches(fleet.ActivityTypeEditedDiskEncryptionSettings{}.ActivityName(),
 		``, enabledDiskActID)
 
 	// patch with false, would reset it but this is a dry-run
@@ -3296,7 +3312,7 @@ func (s *integrationMDMTestSuite) TestAppConfigMDMAppleDiskEncryption() {
 		  }`), http.StatusOK, &acResp, "dry_run", "true")
 	assert.True(t, acResp.MDM.EnableDiskEncryption.Value)
 	assert.Equal(t, []fleet.MDMProfileSpec{{Path: "a"}}, acResp.MDM.MacOSSettings.CustomSettings)
-	s.lastActivityMatches(fleet.ActivityTypeEnabledMacosDiskEncryption{}.ActivityName(),
+	s.lastActivityMatches(fleet.ActivityTypeEditedDiskEncryptionSettings{}.ActivityName(),
 		``, enabledDiskActID)
 
 	// patch with false, resets it
@@ -3306,8 +3322,8 @@ func (s *integrationMDMTestSuite) TestAppConfigMDMAppleDiskEncryption() {
 		  }`), http.StatusOK, &acResp)
 	assert.False(t, acResp.MDM.EnableDiskEncryption.Value)
 	assert.Equal(t, []fleet.MDMProfileSpec{{Path: "b"}}, acResp.MDM.MacOSSettings.CustomSettings)
-	s.lastActivityMatches(fleet.ActivityTypeDisabledMacosDiskEncryption{}.ActivityName(),
-		`{"team_id": null, "team_name": null, "fleet_id": null, "fleet_name": null}`, 0)
+	s.lastActivityMatches(fleet.ActivityTypeEditedDiskEncryptionSettings{}.ActivityName(),
+		`{"fleet_id": null, "fleet_name": null, "platform": "linux"}`, 0)
 
 	// will have deleted the macos config profile
 	s.assertConfigProfilesByIdentifier(nil, mobileconfig.FleetFileVaultPayloadIdentifier, false)
@@ -3315,8 +3331,8 @@ func (s *integrationMDMTestSuite) TestAppConfigMDMAppleDiskEncryption() {
 	// use the MDM disk encryption endpoint to set it to true
 	s.Do("POST", "/api/latest/fleet/disk_encryption",
 		updateDiskEncryptionRequest{EnableDiskEncryption: new(true)}, http.StatusNoContent)
-	enabledDiskActID = s.lastActivityMatches(fleet.ActivityTypeEnabledMacosDiskEncryption{}.ActivityName(),
-		`{"team_id": null, "team_name": null, "fleet_id": null, "fleet_name": null}`, 0)
+	enabledDiskActID = s.lastActivityMatches(fleet.ActivityTypeEditedDiskEncryptionSettings{}.ActivityName(),
+		`{"fleet_id": null, "fleet_name": null, "platform": "linux"}`, 0)
 
 	// will have created the macos config profile
 	s.assertConfigProfilesByIdentifier(nil, mobileconfig.FleetFileVaultPayloadIdentifier, true)
@@ -3329,7 +3345,7 @@ func (s *integrationMDMTestSuite) TestAppConfigMDMAppleDiskEncryption() {
 	// call update endpoint with no changes
 	s.Do("PATCH", "/api/latest/fleet/mdm/apple/settings",
 		fleet.MDMAppleSettingsPayload{}, http.StatusNoContent)
-	s.lastActivityMatches(fleet.ActivityTypeEnabledMacosDiskEncryption{}.ActivityName(),
+	s.lastActivityMatches(fleet.ActivityTypeEditedDiskEncryptionSettings{}.ActivityName(),
 		``, enabledDiskActID)
 
 	// the macos config profile still exists
@@ -3593,7 +3609,7 @@ func (s *integrationMDMTestSuite) TestTeamsMDMAppleDiskEncryption() {
 	team = createTeamResp.Team
 
 	// no macos config profile yet
-	s.assertConfigProfilesByIdentifier(ptr.Uint(team.ID), mobileconfig.FleetFileVaultPayloadIdentifier, false)
+	s.assertConfigProfilesByIdentifier(new(team.ID), mobileconfig.FleetFileVaultPayloadIdentifier, false)
 
 	// apply with disk encryption
 	teamSpecs := applyTeamSpecsRequest{Specs: []*fleet.TeamSpec{{
@@ -3603,11 +3619,11 @@ func (s *integrationMDMTestSuite) TestTeamsMDMAppleDiskEncryption() {
 		},
 	}}}
 	s.Do("POST", "/api/latest/fleet/spec/teams", teamSpecs, http.StatusOK)
-	lastDiskActID := s.lastActivityOfTypeMatches(fleet.ActivityTypeEnabledMacosDiskEncryption{}.ActivityName(),
-		fmt.Sprintf(`{"team_id": %d, "team_name": %q, "fleet_id": %d, "fleet_name": %q}`, team.ID, teamName, team.ID, teamName), 0)
+	lastDiskActID := s.lastActivityOfTypeMatches(fleet.ActivityTypeEditedDiskEncryptionSettings{}.ActivityName(),
+		fmt.Sprintf(`{"fleet_id": %d, "fleet_name": %q, "platform": "linux"}`, team.ID, teamName), 0)
 
 	// macos config profile created
-	s.assertConfigProfilesByIdentifier(ptr.Uint(team.ID), mobileconfig.FleetFileVaultPayloadIdentifier, true)
+	s.assertConfigProfilesByIdentifier(new(team.ID), mobileconfig.FleetFileVaultPayloadIdentifier, true)
 
 	// retrieving the team returns the disk encryption setting
 	var teamResp getTeamResponse
@@ -3618,7 +3634,7 @@ func (s *integrationMDMTestSuite) TestTeamsMDMAppleDiskEncryption() {
 	teamSpecs = applyTeamSpecsRequest{Specs: []*fleet.TeamSpec{{
 		Name: teamName,
 		MDM: fleet.TeamSpecMDM{
-			MacOSSettings: map[string]interface{}{"enable_disk_encryption": 123},
+			MacOSSettings: map[string]any{"enable_disk_encryption": 123},
 		},
 	}}}
 	res := s.Do("POST", "/api/latest/fleet/spec/teams", teamSpecs, http.StatusBadRequest)
@@ -3630,15 +3646,15 @@ func (s *integrationMDMTestSuite) TestTeamsMDMAppleDiskEncryption() {
 		http.StatusUnprocessableEntity, "team_id", fmt.Sprint(team.ID), "team_name", team.Name)
 
 	// the configuration profile is still there
-	s.assertConfigProfilesByIdentifier(ptr.Uint(team.ID), mobileconfig.FleetFileVaultPayloadIdentifier, true)
+	s.assertConfigProfilesByIdentifier(new(team.ID), mobileconfig.FleetFileVaultPayloadIdentifier, true)
 
 	// apply without disk encryption settings specified and unrelated field,
 	// should not replace existing disk encryption
 	teamSpecs = applyTeamSpecsRequest{Specs: []*fleet.TeamSpec{{
 		Name: teamName,
 		MDM: fleet.TeamSpecMDM{
-			MacOSSettings: map[string]interface{}{
-				"custom_settings": []map[string]interface{}{
+			MacOSSettings: map[string]any{
+				"custom_settings": []map[string]any{
 					{"path": "a"},
 				},
 			},
@@ -3649,7 +3665,7 @@ func (s *integrationMDMTestSuite) TestTeamsMDMAppleDiskEncryption() {
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/teams/%d", team.ID), nil, http.StatusOK, &teamResp)
 	require.True(t, teamResp.Team.Config.MDM.EnableDiskEncryption)
 	require.Equal(t, []fleet.MDMProfileSpec{{Path: "a"}}, teamResp.Team.Config.MDM.MacOSSettings.CustomSettings)
-	s.lastActivityOfTypeMatches(fleet.ActivityTypeEnabledMacosDiskEncryption{}.ActivityName(),
+	s.lastActivityOfTypeMatches(fleet.ActivityTypeEditedDiskEncryptionSettings{}.ActivityName(),
 		``, lastDiskActID)
 
 	// apply with false would clear the existing setting, but dry-run
@@ -3663,15 +3679,13 @@ func (s *integrationMDMTestSuite) TestTeamsMDMAppleDiskEncryption() {
 	teamResp = getTeamResponse{}
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/teams/%d", team.ID), nil, http.StatusOK, &teamResp)
 	require.True(t, teamResp.Team.Config.MDM.EnableDiskEncryption)
-	s.lastActivityOfTypeMatches(fleet.ActivityTypeEnabledMacosDiskEncryption{}.ActivityName(),
+	s.lastActivityOfTypeMatches(fleet.ActivityTypeEditedDiskEncryptionSettings{}.ActivityName(),
 		``, lastDiskActID)
 
 	// apply with false clears the existing setting
 	teamSpecs = applyTeamSpecsRequest{Specs: []*fleet.TeamSpec{{
 		Name: teamName,
 		MDM: fleet.TeamSpecMDM{
-			// both macOS settings must be cleared: the FileVault profile
-			// exists whenever either is on
 			MacOSSettings: map[string]any{"enable_disk_encryption": false, "enable_escrow_disk_encryption_key": false},
 		},
 	}}}
@@ -3679,11 +3693,11 @@ func (s *integrationMDMTestSuite) TestTeamsMDMAppleDiskEncryption() {
 	teamResp = getTeamResponse{}
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/teams/%d", team.ID), nil, http.StatusOK, &teamResp)
 	require.False(t, teamResp.Team.Config.MDM.EnableDiskEncryption)
-	s.lastActivityOfTypeMatches(fleet.ActivityTypeDisabledMacosDiskEncryption{}.ActivityName(),
-		fmt.Sprintf(`{"team_id": %d, "team_name": %q, "fleet_id": %d, "fleet_name": %q}`, team.ID, teamName, team.ID, teamName), 0)
+	s.lastActivityOfTypeMatches(fleet.ActivityTypeEditedDiskEncryptionSettings{}.ActivityName(),
+		fmt.Sprintf(`{"fleet_id": %d, "fleet_name": %q, "platform": "macos"}`, team.ID, teamName), 0)
 
 	// macos config profile deleted
-	s.assertConfigProfilesByIdentifier(ptr.Uint(team.ID), mobileconfig.FleetFileVaultPayloadIdentifier, false)
+	s.assertConfigProfilesByIdentifier(new(team.ID), mobileconfig.FleetFileVaultPayloadIdentifier, false)
 
 	// modify team's disk encryption via ModifyTeam endpoint
 	var modResp teamResponse
@@ -3693,11 +3707,11 @@ func (s *integrationMDMTestSuite) TestTeamsMDMAppleDiskEncryption() {
 		},
 	}, http.StatusOK, &modResp)
 	require.True(t, modResp.Team.Config.MDM.EnableDiskEncryption)
-	s.lastActivityOfTypeMatches(fleet.ActivityTypeEnabledMacosDiskEncryption{}.ActivityName(),
-		fmt.Sprintf(`{"team_id": %d, "team_name": %q, "fleet_id": %d, "fleet_name": %q}`, team.ID, teamName, team.ID, teamName), 0)
+	s.lastActivityOfTypeMatches(fleet.ActivityTypeEditedDiskEncryptionSettings{}.ActivityName(),
+		fmt.Sprintf(`{"fleet_id": %d, "fleet_name": %q, "platform": "macos"}`, team.ID, teamName), 0)
 
 	// macos config profile created
-	s.assertConfigProfilesByIdentifier(ptr.Uint(team.ID), mobileconfig.FleetFileVaultPayloadIdentifier, true)
+	s.assertConfigProfilesByIdentifier(new(team.ID), mobileconfig.FleetFileVaultPayloadIdentifier, true)
 
 	// modify team's disk encryption and description via ModifyTeam endpoint
 	modResp = teamResponse{}
@@ -3709,20 +3723,20 @@ func (s *integrationMDMTestSuite) TestTeamsMDMAppleDiskEncryption() {
 	}, http.StatusOK, &modResp)
 	require.False(t, modResp.Team.Config.MDM.EnableDiskEncryption)
 	require.Equal(t, "foobar", modResp.Team.Description)
-	s.lastActivityOfTypeMatches(fleet.ActivityTypeDisabledMacosDiskEncryption{}.ActivityName(),
-		fmt.Sprintf(`{"team_id": %d, "team_name": %q, "fleet_id": %d, "fleet_name": %q}`, team.ID, teamName, team.ID, teamName), 0)
+	s.lastActivityOfTypeMatches(fleet.ActivityTypeEditedDiskEncryptionSettings{}.ActivityName(),
+		fmt.Sprintf(`{"fleet_id": %d, "fleet_name": %q, "platform": "linux"}`, team.ID, teamName), 0)
 
 	// macos config profile deleted
-	s.assertConfigProfilesByIdentifier(ptr.Uint(team.ID), mobileconfig.FleetFileVaultPayloadIdentifier, false)
+	s.assertConfigProfilesByIdentifier(new(team.ID), mobileconfig.FleetFileVaultPayloadIdentifier, false)
 
 	// use the MDM settings endpoint to set it to true
 	s.Do("POST", "/api/latest/fleet/disk_encryption",
 		updateDiskEncryptionRequest{TeamID: new(team.ID), EnableDiskEncryption: new(true)}, http.StatusNoContent)
-	lastDiskActID = s.lastActivityOfTypeMatches(fleet.ActivityTypeEnabledMacosDiskEncryption{}.ActivityName(),
-		fmt.Sprintf(`{"team_id": %d, "team_name": %q, "fleet_id": %d, "fleet_name": %q}`, team.ID, teamName, team.ID, teamName), 0)
+	lastDiskActID = s.lastActivityOfTypeMatches(fleet.ActivityTypeEditedDiskEncryptionSettings{}.ActivityName(),
+		fmt.Sprintf(`{"fleet_id": %d, "fleet_name": %q, "platform": "linux"}`, team.ID, teamName), 0)
 
 	// macos config profile created
-	s.assertConfigProfilesByIdentifier(ptr.Uint(team.ID), mobileconfig.FleetFileVaultPayloadIdentifier, true)
+	s.assertConfigProfilesByIdentifier(new(team.ID), mobileconfig.FleetFileVaultPayloadIdentifier, true)
 
 	teamResp = getTeamResponse{}
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/teams/%d", team.ID), nil, http.StatusOK, &teamResp)
@@ -3730,12 +3744,12 @@ func (s *integrationMDMTestSuite) TestTeamsMDMAppleDiskEncryption() {
 
 	// use the MDM settings endpoint with no changes
 	s.Do("PATCH", "/api/latest/fleet/mdm/apple/settings",
-		fleet.MDMAppleSettingsPayload{TeamID: ptr.Uint(team.ID)}, http.StatusNoContent)
-	s.lastActivityOfTypeMatches(fleet.ActivityTypeEnabledMacosDiskEncryption{}.ActivityName(),
+		fleet.MDMAppleSettingsPayload{TeamID: new(team.ID)}, http.StatusNoContent)
+	s.lastActivityOfTypeMatches(fleet.ActivityTypeEditedDiskEncryptionSettings{}.ActivityName(),
 		``, lastDiskActID)
 
 	// macos config profile still exists
-	s.assertConfigProfilesByIdentifier(ptr.Uint(team.ID), mobileconfig.FleetFileVaultPayloadIdentifier, true)
+	s.assertConfigProfilesByIdentifier(new(team.ID), mobileconfig.FleetFileVaultPayloadIdentifier, true)
 
 	teamResp = getTeamResponse{}
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/teams/%d", team.ID), nil, http.StatusOK, &teamResp)

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -4133,8 +4133,10 @@ func (svc *Service) UploadMDMAppleAPNSCert(ctx context.Context, cert io.ReadSeek
 		return nil
 	}
 
-	// Enable FileVault escrow if no-team already has a macOS disk encryption
-	// setting on: the FileVault profile covers enforcement and escrow as a pair
+	// Enable FileVault escrow if no-team already has macOS disk encryption
+	// settings on. No activity is recorded: the settings themselves didn't
+	// change, the profile is (re)created as a side effect of turning on Apple
+	// MDM.
 	if appCfg.MDM.MacOSSettings.EnableDiskEncryption.Value || appCfg.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey.Value {
 		// Delete the file vault profile first, to ensure we get updated keys.
 		if err := svc.EnterpriseOverrides.MDMAppleDisableFileVaultAndEscrow(ctx, nil); err != nil && !fleet.IsNotFound(err) {
@@ -4142,9 +4144,6 @@ func (svc *Service) UploadMDMAppleAPNSCert(ctx context.Context, cert io.ReadSeek
 		}
 		if err := svc.EnterpriseOverrides.MDMAppleEnableFileVaultAndEscrow(ctx, nil); err != nil {
 			return ctxerr.Wrap(ctx, err, "enable no-team FileVault escrow")
-		}
-		if err := svc.NewActivity(ctx, authz.UserFromContext(ctx), fleet.ActivityTypeEnabledMacosDiskEncryption{}); err != nil {
-			return ctxerr.Wrap(ctx, err, "create activity for enabling no-team macOS disk encryption")
 		}
 	}
 	// Enable FileVault escrow for teams that already have disk encryption enforced
@@ -4165,9 +4164,6 @@ func (svc *Service) UploadMDMAppleAPNSCert(ctx context.Context, cert io.ReadSeek
 			}
 			if err := svc.EnterpriseOverrides.MDMAppleEnableFileVaultAndEscrow(ctx, &team.ID); err != nil {
 				return ctxerr.Wrap(ctx, err, "enable FileVault escrow for team")
-			}
-			if err := svc.NewActivity(ctx, authz.UserFromContext(ctx), fleet.ActivityTypeEnabledMacosDiskEncryption{TeamID: &team.ID, TeamName: &team.Name}); err != nil {
-				return ctxerr.Wrap(ctx, err, "create activity for enabling macOS disk encryption for team")
 			}
 		}
 	}

--- a/server/service/mdm_test.go
+++ b/server/service/mdm_test.go
@@ -5382,6 +5382,9 @@ func TestUpdateAppConfigMDMDiskEncryptionPINOnly(t *testing.T) {
 			// the PIN is a Windows disk encryption setting, so its change is
 			// recorded as a windows settings edit
 			require.Equal(t, fleet.ActivityTypeEditedDiskEncryptionSettings{}.ActivityName(), activity.ActivityName())
+			edited, ok := activity.(fleet.ActivityTypeEditedDiskEncryptionSettings)
+			require.True(t, ok)
+			require.Equal(t, "windows", edited.Platform)
 			return nil
 		},
 	})

--- a/server/service/mdm_test.go
+++ b/server/service/mdm_test.go
@@ -3955,8 +3955,6 @@ func TestUploadMDMAppleAPNSCertReplacesFileVaultProfile(t *testing.T) {
 
 	newActivityCalls := 0
 	opts.ActivityMock.NewActivityFunc = func(_ context.Context, _ *activity_api.User, activity activity_api.ActivityDetails) error {
-		act := fleet.ActivityTypeEnabledMacosDiskEncryption{}
-		require.Equal(t, act.ActivityName(), activity.ActivityName())
 		newActivityCalls++
 		return nil
 	}
@@ -4011,7 +4009,9 @@ func TestUploadMDMAppleAPNSCertReplacesFileVaultProfile(t *testing.T) {
 
 	require.EqualValues(t, 2, newProfileCalls)
 	require.EqualValues(t, 2, deleteCalls)
-	require.EqualValues(t, 2, newActivityCalls) // Only enabled Disk encryption activities, we don't want to log disable right before enabling.
+	// no activities: the settings didn't change, the FileVault profile is
+	// (re)created as a side effect of turning on Apple MDM
+	require.Equal(t, 0, newActivityCalls)
 }
 
 func TestNewMDMProfilePremiumOnlyAndroid(t *testing.T) {
@@ -5379,7 +5379,9 @@ func TestUpdateAppConfigMDMDiskEncryptionPINOnly(t *testing.T) {
 	svc := &Service{ds: ds} // no server private key configured
 	svc.SetActivityService(&mock.MockActivityService{
 		NewActivityFunc: func(_ context.Context, _ *activity_api.User, activity activity_api.ActivityDetails) error {
-			t.Fatalf("no activity expected for a PIN-only change, got %s", activity.ActivityName())
+			// the PIN is a Windows disk encryption setting, so its change is
+			// recorded as a windows settings edit
+			require.Equal(t, fleet.ActivityTypeEditedDiskEncryptionSettings{}.ActivityName(), activity.ActivityName())
 			return nil
 		},
 	})

--- a/tools/dibble/pkg/seed/activities.go
+++ b/tools/dibble/pkg/seed/activities.go
@@ -271,7 +271,11 @@ var activityTemplatesByCategory = map[string][]fleet.ActivityDetails{
 		fleet.ActivityTypeEditedIPadOSMinVersion{},
 		fleet.ActivityTypeEnabledMacosDiskEncryption{},
 		fleet.ActivityTypeDisabledMacosDiskEncryption{},
+		// one per platform: the activity is emitted per changed platform, so
+		// seeding all three shows what the feed actually looks like
 		fleet.ActivityTypeEditedDiskEncryptionSettings{Platform: "macos"},
+		fleet.ActivityTypeEditedDiskEncryptionSettings{Platform: "windows"},
+		fleet.ActivityTypeEditedDiskEncryptionSettings{Platform: "linux"},
 		fleet.ActivityTypeEnabledRecoveryLockPasswords{},
 		fleet.ActivityTypeDisabledRecoveryLockPasswords{},
 		fleet.ActivityTypeEditedHostNameTemplate{},

--- a/tools/dibble/pkg/seed/activities.go
+++ b/tools/dibble/pkg/seed/activities.go
@@ -271,6 +271,7 @@ var activityTemplatesByCategory = map[string][]fleet.ActivityDetails{
 		fleet.ActivityTypeEditedIPadOSMinVersion{},
 		fleet.ActivityTypeEnabledMacosDiskEncryption{},
 		fleet.ActivityTypeDisabledMacosDiskEncryption{},
+		fleet.ActivityTypeEditedDiskEncryptionSettings{Platform: "macos"},
 		fleet.ActivityTypeEnabledRecoveryLockPasswords{},
 		fleet.ActivityTypeDisabledRecoveryLockPasswords{},
 		fleet.ActivityTypeEditedHostNameTemplate{},


### PR DESCRIPTION
**Related issue:** #51258

Last PR of #51258 (story #48654). Stacked on #51849 (write semantics).

- Disk encryption changes now generate one `edited_disk_encryption_settings` activity per platform whose settings changed (`platform`: `macos`/`windows`/`linux`, plus the fleet), across every write path: `PATCH /config`, `POST /disk_encryption`, fleet specs, fleet create/edit, and `PATCH /fleets/{id}`. A BitLocker PIN change counts as a Windows settings change.
- The `enabled_macos_disk_encryption` / `disabled_macos_disk_encryption` activities are no longer generated (they fired even for Windows/Linux-driven changes of the old single toggle). The types and their UI rendering are kept so historical activities still display.
- Re-uploading an APNS certificate no longer logs an "enabled disk encryption" activity: the settings don't change there, the FileVault profile re-creation is a side effect of turning on Apple MDM.
- The activity feed renders the new activity ("edited disk encryption settings for Windows hosts assigned to the X fleet."). Screenshot: N/A for now — a single new one-line feed message; will attach one during manual QA.
- `docs/Contributing/reference/audit-logs.md` is intentionally untouched: the new activity and deprecation notes are already merged on the `docs-v4.92.0` branch (#50236).

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Activity feeds now show disk-encryption setting changes separately for macOS, Windows, and Linux.
  - Events include the affected platform and, when applicable, the associated fleet and host scope.
  - Windows BitLocker PIN changes are now included in disk-encryption activity tracking.
  - New teams record enabled platform disk-encryption settings in activity history.

- **Bug Fixes**
  - Avoided recording activities when disk-encryption settings remain unchanged.
  - Preserved accurate macOS FileVault enablement and disablement behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->