### PR TITLE
collapse name field into top level key for profile policy automation

### DIFF
--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -1853,9 +1853,7 @@ func (cmd *GenerateGitopsCommand) generatePolicies(teamId *uint, filePath string
 
 		// handle profile automation
 		if policy.ResendConfigurationProfile != nil {
-			policySpec["resend_configuration_profile"] = map[string]any{
-				"name": policy.ResendConfigurationProfile.Name,
-			}
+			policySpec["resend_configuration_profile"] = policy.ResendConfigurationProfile.Name
 		}
 
 		// Parse any labels.

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -9336,8 +9336,7 @@ policies:
   - name: Resend policy
     query: "SELECT 1"
     platform: darwin
-    resend_configuration_profile:
-      name: %s
+    resend_configuration_profile: %s
   - name: Plain policy
     query: "SELECT 2"
 `, profilePath, macProfileName), 0o600))

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/fleets/team-a-thumbsup.yml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/fleets/team-a-thumbsup.yml
@@ -99,8 +99,7 @@ policies:
   name: Team Profile policy
   platform: darwin
   query: SELECT * FROM team_policy WHERE id = 4
-  resend_configuration_profile:
-    name: Team Profile
+  resend_configuration_profile: Team Profile
   resolution: Nothing to do.
   type: dynamic
   webhooks_and_tickets_enabled: false

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/fleets/unassigned.yml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/fleets/unassigned.yml
@@ -84,8 +84,7 @@ policies:
   name: Team Profile policy
   platform: darwin
   query: SELECT * FROM team_policy WHERE id = 4
-  resend_configuration_profile:
-    name: Team Profile
+  resend_configuration_profile: Team Profile
   resolution: Nothing to do.
   type: dynamic
   webhooks_and_tickets_enabled: false

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -228,7 +228,7 @@ type GitOpsPolicySpec struct {
 	ContinuousAutomations      optjson.Bool                           `json:"continuous_automations_enabled"`
 	RunScript                  *PolicyRunScript                       `json:"run_script"`
 	InstallSoftware            optjson.BoolOr[*PolicyInstallSoftware] `json:"install_software"`
-	ResendConfigurationProfile *string                                `json:"resend_configuration_profile"`
+	ResendConfigurationProfile string                                 `json:"resend_configuration_profile"`
 	// InstallSoftwareURL is populated after parsing the software installer yaml
 	// referenced by InstallSoftware.PackagePath.
 	InstallSoftwareURL string `json:"-"`
@@ -250,10 +250,6 @@ type PolicyInstallSoftware struct {
 	AppStoreID             string `json:"app_store_id"`
 	HashSHA256             string `json:"hash_sha256"`
 	FleetMaintainedAppSlug string `json:"fleet_maintained_app_slug"`
-}
-
-type PolicyResendConfigurationProfile struct {
-	Name string `json:"name"`
 }
 
 type Query struct {
@@ -2098,7 +2094,7 @@ func parsePolicies(top map[string]json.RawMessage, result *GitOps, baseDir strin
 				multiError = multierror.Append(multiError, fmt.Errorf("failed to parse policy run_script %q: %v", item.Name, err))
 				continue
 			}
-			if err := parsePolicyResendConfigurationProfile(baseDir, parentFilePath, result.TeamName, &item, definedProfileNames); err != nil {
+			if err := parsePolicyResendConfigurationProfile(parentFilePath, result.TeamName, &item, definedProfileNames); err != nil {
 				multiError = multierror.Append(multiError, fmt.Errorf("failed to parse policy resend_configuration_profile %q: %v", item.Name, err))
 				continue
 			}
@@ -2138,7 +2134,7 @@ func parsePolicies(top map[string]json.RawMessage, result *GitOps, baseDir strin
 								multiError = multierror.Append(multiError, fmt.Errorf("failed to parse policy run_script %q: %v", pp.Name, err))
 								continue
 							}
-							if err := parsePolicyResendConfigurationProfile(filepath.Dir(*item.Path), parentFilePath, result.TeamName, pp, definedProfileNames); err != nil {
+							if err := parsePolicyResendConfigurationProfile(parentFilePath, result.TeamName, pp, definedProfileNames); err != nil {
 								multiError = multierror.Append(multiError, fmt.Errorf("failed to parse policy resend_configuration_profile %q: %v", pp.Name, err))
 								continue
 							}
@@ -2262,27 +2258,19 @@ func parsePolicyRunScript(baseDir string, parentFilePath string, teamName *strin
 	return nil
 }
 
-func parsePolicyResendConfigurationProfile(baseDir string, parentFilePath string, teamName *string, policy *Policy, definedProfiles map[string]struct{}) error {
-	if policy.ResendConfigurationProfile == nil {
-		// unset
-		policy.ResendConfigurationProfile = new("")
-		return nil
-	}
-
+func parsePolicyResendConfigurationProfile(parentFilePath string, teamName *string, policy *Policy, definedProfiles map[string]struct{}) error {
 	if teamName == nil {
 		return errors.New("resend_configuration_profile can only be set on team policies")
 	}
 
-	name := strings.TrimSpace(*policy.ResendConfigurationProfile)
-	if name == "" {
-		return errors.New("resend_configuration_profile is required")
-	}
+	name := strings.TrimSpace(policy.ResendConfigurationProfile)
 
-	if _, ok := definedProfiles[name]; !ok {
+	// name == "" is unsetting.
+	if _, ok := definedProfiles[name]; !ok && name != "" {
 		return fmt.Errorf("configuration profile %q was not defined in controls in %s", name, filepath.Base(parentFilePath))
 	}
 
-	policy.ResendConfigurationProfile = &name
+	policy.ResendConfigurationProfile = name
 
 	return nil
 }

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -2259,7 +2259,7 @@ func parsePolicyRunScript(baseDir string, parentFilePath string, teamName *strin
 }
 
 func parsePolicyResendConfigurationProfile(parentFilePath string, teamName *string, policy *Policy, definedProfiles map[string]struct{}) error {
-	if teamName == nil {
+	if teamName == nil && policy.ResendConfigurationProfile != "" {
 		return errors.New("resend_configuration_profile can only be set on team policies")
 	}
 

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -228,16 +228,13 @@ type GitOpsPolicySpec struct {
 	ContinuousAutomations      optjson.Bool                           `json:"continuous_automations_enabled"`
 	RunScript                  *PolicyRunScript                       `json:"run_script"`
 	InstallSoftware            optjson.BoolOr[*PolicyInstallSoftware] `json:"install_software"`
-	ResendConfigurationProfile *PolicyResendConfigurationProfile      `json:"resend_configuration_profile"`
+	ResendConfigurationProfile *string                                `json:"resend_configuration_profile"`
 	// InstallSoftwareURL is populated after parsing the software installer yaml
 	// referenced by InstallSoftware.PackagePath.
 	InstallSoftwareURL string `json:"-"`
 	// RunScriptName is populated after confirming the script exists on both the file system
 	// and in the controls scripts list for the same team
 	RunScriptName *string `json:"-"`
-	// ResendConfigurationProfileName is populated after confirming the configuration profile exists on both the file system
-	// and in the controls configuration profiles list for the same team
-	ResendConfigurationProfileName *string `json:"-"`
 	// WebhooksAndTicketsEnabled indicates whether failing policy webhooks/tickets
 	// should be enabled for this policy. This is a gitops-only convenience that
 	// translates to adding the policy's ID to the failing_policies_webhook.policy_ids list.
@@ -2267,7 +2264,8 @@ func parsePolicyRunScript(baseDir string, parentFilePath string, teamName *strin
 
 func parsePolicyResendConfigurationProfile(baseDir string, parentFilePath string, teamName *string, policy *Policy, definedProfiles map[string]struct{}) error {
 	if policy.ResendConfigurationProfile == nil {
-		policy.ResendConfigurationProfileName = new("") // unset the profile name
+		// unset
+		policy.ResendConfigurationProfile = new("")
 		return nil
 	}
 
@@ -2275,16 +2273,16 @@ func parsePolicyResendConfigurationProfile(baseDir string, parentFilePath string
 		return errors.New("resend_configuration_profile can only be set on team policies")
 	}
 
-	name := strings.TrimSpace(policy.ResendConfigurationProfile.Name)
+	name := strings.TrimSpace(*policy.ResendConfigurationProfile)
 	if name == "" {
-		return errors.New("resend_configuration_profile.name is required")
+		return errors.New("resend_configuration_profile is required")
 	}
 
 	if _, ok := definedProfiles[name]; !ok {
 		return fmt.Errorf("configuration profile %q was not defined in controls in %s", name, filepath.Base(parentFilePath))
 	}
 
-	policy.ResendConfigurationProfileName = &name
+	policy.ResendConfigurationProfile = &name
 
 	return nil
 }

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -5886,10 +5886,10 @@ policies:
 `)
 		require.NoError(t, err)
 		require.Len(t, got.Policies, 3)
-		require.Equal(t, new("Password policy"), got.Policies[0].ResendConfigurationProfile)
-		require.Equal(t, new("screenlock"), got.Policies[1].ResendConfigurationProfile)
+		require.Equal(t, "Password policy", got.Policies[0].ResendConfigurationProfile)
+		require.Equal(t, "screenlock", got.Policies[1].ResendConfigurationProfile)
 		// Policies without the key get an empty name so the server unsets any existing profile.
-		require.Equal(t, new(""), got.Policies[2].ResendConfigurationProfile)
+		require.Equal(t, "", got.Policies[2].ResendConfigurationProfile)
 	})
 
 	t.Run("errors when the profile is not defined in controls", func(t *testing.T) {

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -5877,21 +5877,19 @@ controls:
 policies:
 - name: Mac policy
   query: SELECT 1;
-  resend_configuration_profile:
-    name: Password policy
+  resend_configuration_profile: Password policy
 - name: Windows policy
   query: SELECT 1;
-  resend_configuration_profile:
-    name: screenlock
+  resend_configuration_profile: screenlock
 - name: No resend policy
   query: SELECT 1;
 `)
 		require.NoError(t, err)
 		require.Len(t, got.Policies, 3)
-		require.Equal(t, new("Password policy"), got.Policies[0].ResendConfigurationProfileName)
-		require.Equal(t, new("screenlock"), got.Policies[1].ResendConfigurationProfileName)
+		require.Equal(t, new("Password policy"), got.Policies[0].ResendConfigurationProfile)
+		require.Equal(t, new("screenlock"), got.Policies[1].ResendConfigurationProfile)
 		// Policies without the key get an empty name so the server unsets any existing profile.
-		require.Equal(t, new(""), got.Policies[2].ResendConfigurationProfileName)
+		require.Equal(t, new(""), got.Policies[2].ResendConfigurationProfile)
 	})
 
 	t.Run("errors when the profile is not defined in controls", func(t *testing.T) {
@@ -5899,8 +5897,7 @@ policies:
 policies:
 - name: Mac policy
   query: SELECT 1;
-  resend_configuration_profile:
-    name: Not a profile
+  resend_configuration_profile: Not a profile
 `)
 		require.ErrorContains(t, err, `configuration profile "Not a profile" was not defined in controls`)
 	})
@@ -5910,8 +5907,7 @@ policies:
 policies:
 - name: Mac policy
   query: SELECT 1;
-  resend_configuration_profile:
-    name: Password policy
+  resend_configuration_profile: Password policy
 `)
 		require.ErrorContains(t, err, "resend_configuration_profile can only be set on team policies")
 	})

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -5889,7 +5889,7 @@ policies:
 		require.Equal(t, "Password policy", got.Policies[0].ResendConfigurationProfile)
 		require.Equal(t, "screenlock", got.Policies[1].ResendConfigurationProfile)
 		// Policies without the key get an empty name so the server unsets any existing profile.
-		require.Equal(t, "", got.Policies[2].ResendConfigurationProfile)
+		require.Empty(t, got.Policies[2].ResendConfigurationProfile)
 	})
 
 	t.Run("errors when the profile is not defined in controls", func(t *testing.T) {

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -3623,7 +3623,7 @@ func (c *Client) doGitOpsPolicies(config *spec.GitOps, teamSoftwareInstallers []
 			// default to empty string to unset, and then override if match is found
 			config.Policies[i].ProfileUUID = new("")
 
-			if config.Policies[i].ResendConfigurationProfile == nil || *config.Policies[i].ResendConfigurationProfile == "" {
+			if config.Policies[i].ResendConfigurationProfile == "" {
 				continue
 			}
 
@@ -3631,10 +3631,10 @@ func (c *Client) doGitOpsPolicies(config *spec.GitOps, teamSoftwareInstallers []
 				return fmt.Errorf("error hydrating configuration profiles: %w", err)
 			}
 
-			profileUUID, ok := teamProfiles[*config.Policies[i].ResendConfigurationProfile]
+			profileUUID, ok := teamProfiles[config.Policies[i].ResendConfigurationProfile]
 			if !ok {
 				if !dryRun { // this shouldn't happen
-					logFn("[!] reference to an unknown configuration profile: %s\n", *config.Policies[i].ResendConfigurationProfile)
+					logFn("[!] reference to an unknown configuration profile: %s\n", config.Policies[i].ResendConfigurationProfile)
 				}
 				continue
 			}

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -3623,7 +3623,7 @@ func (c *Client) doGitOpsPolicies(config *spec.GitOps, teamSoftwareInstallers []
 			// default to empty string to unset, and then override if match is found
 			config.Policies[i].ProfileUUID = new("")
 
-			if config.Policies[i].ResendConfigurationProfileName == nil || *config.Policies[i].ResendConfigurationProfileName == "" {
+			if config.Policies[i].ResendConfigurationProfile == nil || *config.Policies[i].ResendConfigurationProfile == "" {
 				continue
 			}
 
@@ -3631,10 +3631,10 @@ func (c *Client) doGitOpsPolicies(config *spec.GitOps, teamSoftwareInstallers []
 				return fmt.Errorf("error hydrating configuration profiles: %w", err)
 			}
 
-			profileUUID, ok := teamProfiles[*config.Policies[i].ResendConfigurationProfileName]
+			profileUUID, ok := teamProfiles[*config.Policies[i].ResendConfigurationProfile]
 			if !ok {
 				if !dryRun { // this shouldn't happen
-					logFn("[!] reference to an unknown configuration profile: %s\n", *config.Policies[i].ResendConfigurationProfileName)
+					logFn("[!] reference to an unknown configuration profile: %s\n", *config.Policies[i].ResendConfigurationProfile)
 				}
 				continue
 			}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves follow up from YAML changes after feature work.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information. Part of a story with a change file.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitOps policies now use a simpler string format to specify a configuration profile for resending.

* **Bug Fixes**
  * Improved handling of resend configuration profiles during policy deployment.
  * Generated policy YAML and validation now consistently use profile names directly.
  * Empty profile values are handled correctly, while invalid values are rejected appropriately.
  * Updated policy examples and validation coverage to reflect the new format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->