### PR TITLE
Document host deletion and host expiry behavior

### DIFF
--- a/articles/apple-mdm-setup.md
+++ b/articles/apple-mdm-setup.md
@@ -266,16 +266,6 @@ This means you **do not need to delete** an AB host from Fleet before re-enrolli
 
 > For AB hosts, you do not need to delete the host from Fleet before re-enrolling. Fleet automatically clears pending and completed commands, scripts, software installs, and labels when the host re-enrolls. See [Re-enrolling AB hosts](#re-enrolling-ab-hosts).
 
-### AB hosts that look stale but are never removed
-
-Host expiry never removes a host assigned to Fleet in AB, no matter how long ago it last reported vitals. This includes hosts that are still **Pending** because they haven't enrolled yet. The exemption lifts once the device is released or reassigned in AB.
-
-**Last fetched** also isn't what host expiry measures. iOS and iPadOS hosts report vitals over MDM, so a host can show a stale **Last fetched** while it's still checking in. See [Why aren't my hosts being deleted after the host expiry window?](https://fleetdm.com/docs/get-started/faq#why-arent-my-hosts-being-deleted-after-the-host-expiry-window) in the FAQ.
-
-### AB hosts that come back after being deleted
-
-Deleting a host in Fleet doesn't change its assignment in AB. A host still assigned to Fleet comes back as **Pending** right after you delete it. To remove it for good, release or reassign the device in AB first, then delete the host in Fleet.
-
 <meta name="category" value="guides">
 <meta name="authorGitHubUsername" value="zhumo">
 <meta name="authorFullName" value="Mo Zhu">

--- a/articles/apple-mdm-setup.md
+++ b/articles/apple-mdm-setup.md
@@ -266,6 +266,16 @@ This means you **do not need to delete** an AB host from Fleet before re-enrolli
 
 > For AB hosts, you do not need to delete the host from Fleet before re-enrolling. Fleet automatically clears pending and completed commands, scripts, software installs, and labels when the host re-enrolls. See [Re-enrolling AB hosts](#re-enrolling-ab-hosts).
 
+### AB hosts that look stale but are never removed
+
+Host expiry never removes a host assigned to Fleet in AB, no matter how long ago it last reported vitals. This includes hosts that are still **Pending** because they haven't enrolled yet. The exemption lifts once the device is released or reassigned in AB.
+
+**Last fetched** also isn't what host expiry measures. iOS and iPadOS hosts report vitals over MDM, so a host can show a stale **Last fetched** while it's still checking in. See [Why aren't my hosts being deleted after the host expiry window?](https://fleetdm.com/docs/get-started/faq#why-arent-my-hosts-being-deleted-after-the-host-expiry-window) in the FAQ.
+
+### AB hosts that come back after being deleted
+
+Deleting a host in Fleet doesn't change its assignment in AB. A host still assigned to Fleet comes back as **Pending** right after you delete it. To remove it for good, release or reassign the device in AB first, then delete the host in Fleet.
+
 <meta name="category" value="guides">
 <meta name="authorGitHubUsername" value="zhumo">
 <meta name="authorFullName" value="Mo Zhu">

--- a/articles/enroll-hosts.md
+++ b/articles/enroll-hosts.md
@@ -174,6 +174,20 @@ In the Google Admin console:
 
 > The unenroll action on Android hosts sends a wipe command via the Android Management API. [Learn more](https://fleedtdm.com/docs/rest-api/rest-api#turn-off-hosts-mdm)
 
+## Delete a host
+
+Deleting a host removes it from Fleet. It does not unenroll the device or change anything in Apple Business (AB). The MDM enrollment and the management profile stay on the device. The device also stays assigned to Fleet in AB.
+
+Because that assignment is still in place, deleting a host assigned to Fleet in AB brings it straight back as a **Pending** host. To remove it for good, release or reassign the device in AB first, then delete the host in Fleet. If Fleet can't reach AB to check the assignment, the delete fails. Retry once AB is reachable.
+
+Deleting a host also cancels its upcoming activities and removes Fleet's record of the MDM commands it has already sent. Delete a host while a wipe or another command is still in flight, and Fleet can no longer report whether that command completed.
+
+To decommission a host:
+
+1. Unenroll or [wipe the host](https://fleetdm.com/guides/lock-wipe-hosts#wipe-a-host) in Fleet, and confirm it finished.
+2. For Apple hosts, release or reassign the device in AB.
+3. Delete the host in Fleet.
+
 ## Debugging
 
 If you're running into issues when enrolling hosts, the best practice is to look for errors in the fleetd logs. See our [troubleshooting guide](https://fleetdm.com/guides/fleet-troubleshooting-for-it-admins) for more info.

--- a/articles/lock-wipe-hosts.md
+++ b/articles/lock-wipe-hosts.md
@@ -59,11 +59,11 @@ Example URL:
    - **macOS, Windows, iOS, iPadOS**: The host will be marked with a "Wipe pending" badge. Once the wipe command is acknowledged by the host, the badge will update to "Wiped".
    - **Linux**: No "Wipe pending" or "Wiped" badge is shown. See [Linux wipe behavior](#linux-wipe-behavior) below for details.
 
-Wiping a host silently cancels all of its upcoming activities — no canceled activity entries are added to the host's activity history.
+Wiping a host silently cancels all of its upcoming activities. No canceled activity entries are added to the host's activity history.
 
 When wiping and re-installing the operating system (OS) on a host, delete the host from Fleet before you re-enroll it. If you re-enroll without deleting, Fleet won't escrow a new disk encryption key.
 
-Wait until the wipe finishes before deleting the host. Deleting a host removes Fleet's record of the commands it has already sent. Delete while the wipe is still pending, and Fleet can no longer report whether the wipe completed.
+Wait for the wipe to finish before deleting the host. Deleting a host removes Fleet's record of the commands it has already sent. If you delete while the wipe is still pending, Fleet can't confirm whether it finished.
 
 If you're gifting a company-owned Apple host, or you want to prevent a host from automatically re-enrolling to Fleet for some other reason, first release the host from Apple Business (AB) and then delete the host in Fleet. Deleting in Fleet doesn't change the assignment in AB, so a host still assigned to Fleet comes back as a **Pending** host.
 

--- a/articles/lock-wipe-hosts.md
+++ b/articles/lock-wipe-hosts.md
@@ -61,11 +61,11 @@ Example URL:
 
 Wiping a host silently cancels all of its upcoming activities — no canceled activity entries are added to the host's activity history.
 
-Wiping a host silently cancels all of its upcoming activities — no canceled activity entries are added to the host's activity history.
-
 When wiping and re-installing the operating system (OS) on a host, delete the host from Fleet before you re-enroll it. If you re-enroll without deleting, Fleet won't escrow a new disk encryption key.
 
-If you're gifting a company-owned macOS host or you want to prevent the host from automatically re-enrolling to Fleet for some other reason, first release the host from Apple Business (AB) and then delete the host in Fleet.
+Wait until the wipe finishes before deleting the host. Deleting a host removes Fleet's record of the commands it has already sent. Delete while the wipe is still pending, and Fleet can no longer report whether the wipe completed.
+
+If you're gifting a company-owned Apple host, or you want to prevent a host from automatically re-enrolling to Fleet for some other reason, first release the host from Apple Business (AB) and then delete the host in Fleet. Deleting in Fleet doesn't change the assignment in AB, so a host still assigned to Fleet comes back as a **Pending** host.
 
 For Windows hosts, Fleet uses the [doWipeProtected](https://learn.microsoft.com/en-us/windows/client-management/mdm/remotewipe-csp#dowipeprotected) command by default. According to Microsoft, this leaves the host [unable to boot](https://learn.microsoft.com/en-us/windows/client-management/mdm/remotewipe-csp#:~:text=In%20some%20device%20configurations%2C%20this%20command%20may%20leave%20the%20device%20unable%20to%20boot.). However, it is possible to use the [doWipe command via the API](https://fleetdm.com/docs/rest-api/rest-api#parameters57).
 

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -917,6 +917,22 @@ If this setting is not defined in your YAML files, unlike all other settings, it
 
 Can be configured for "All fleets" (`org_settings`) and specific fleets (`settings`).
 
+#### How host expiry works
+
+`host_expiry_window` does nothing on its own. `host_expiry_enabled` must be set to `true` in `org_settings` or on the fleet.
+
+Setting `host_expiry_enabled: false` on a fleet means "use the setting from `org_settings`". It does not exempt the fleet. To apply host expiry to only some fleets, leave it off in `org_settings` and turn it on for those fleets.
+
+Fleet measures the window from the host's most recent check-in. A check-in is either an osquery check-in from Fleet's agent (fleetd) or an MDM check-in, whichever is more recent. For a host that has never checked in, Fleet uses **Last fetched** instead, then the date the host was added to Fleet.
+
+**Last fetched** is the last time the host reported vitals, which is not the same as a check-in. A host that reports vitals infrequently but still checks in won't expire. This is common on iOS and iPadOS hosts, which report vitals over MDM.
+
+Hosts assigned to Fleet in Apple Business are never expired. This covers macOS, iOS, and iPadOS hosts, including hosts that are still **Pending** because they haven't enrolled yet. Windows hosts assigned to Fleet in Windows Autopilot are exempt the same way. The exemption lifts once the host is unassigned or released in Apple Business. Manually enrolled hosts and BYOD hosts aren't exempt.
+
+Host expiry runs hourly. Expired hosts appear in the activity feed as host deletions.
+
+For help troubleshooting hosts that aren't being deleted, see the [FAQ](https://fleetdm.com/docs/get-started/faq#why-arent-my-hosts-being-deleted-after-the-host-expiry-window).
+
 #### Example
 
 ```yaml

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -917,21 +917,11 @@ If this setting is not defined in your YAML files, unlike all other settings, it
 
 Can be configured for "All fleets" (`org_settings`) and specific fleets (`settings`).
 
-#### How host expiry works
+`host_expiry_window` does nothing unless `host_expiry_enabled` is `true` in `org_settings` or on the fleet.
 
-`host_expiry_window` does nothing on its own. `host_expiry_enabled` must be set to `true` in `org_settings` or on the fleet.
+Setting `host_expiry_enabled: false` on a fleet tells that fleet to use the `org_settings` value. It doesn't exempt the fleet. To apply host expiry to only some fleets, leave it off in `org_settings` and turn it on for those fleets.
 
-Setting `host_expiry_enabled: false` on a fleet means "use the setting from `org_settings`". It does not exempt the fleet. To apply host expiry to only some fleets, leave it off in `org_settings` and turn it on for those fleets.
-
-Fleet measures the window from the host's most recent check-in. A check-in is either an osquery check-in from Fleet's agent (fleetd) or an MDM check-in, whichever is more recent. For a host that has never checked in, Fleet uses **Last fetched** instead, then the date the host was added to Fleet.
-
-**Last fetched** is the last time the host reported vitals, which is not the same as a check-in. A host that reports vitals infrequently but still checks in won't expire. This is common on iOS and iPadOS hosts, which report vitals over MDM.
-
-Hosts assigned to Fleet in Apple Business are never expired. This covers macOS, iOS, and iPadOS hosts, including hosts that are still **Pending** because they haven't enrolled yet. Windows hosts assigned to Fleet in Windows Autopilot are exempt the same way. The exemption lifts once the host is unassigned or released in Apple Business. Manually enrolled hosts and BYOD hosts aren't exempt.
-
-Host expiry runs hourly. Expired hosts appear in the activity feed as host deletions.
-
-For help troubleshooting hosts that aren't being deleted, see the [FAQ](https://fleetdm.com/docs/get-started/faq#why-arent-my-hosts-being-deleted-after-the-host-expiry-window).
+Fleet measures the window from the host's last check-in, not from **Last fetched**. Host expiry skips hosts assigned to Fleet in Apple Business or Windows Autopilot. If hosts aren't expiring as expected, see the [FAQ](https://fleetdm.com/docs/get-started/faq#why-arent-my-hosts-being-deleted-after-the-host-expiry-window).
 
 #### Example
 

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -921,7 +921,7 @@ Can be configured for "All fleets" (`org_settings`) and specific fleets (`settin
 
 Setting `host_expiry_enabled: false` on a fleet tells that fleet to use the `org_settings` value. It doesn't exempt the fleet. To apply host expiry to only some fleets, leave it off in `org_settings` and turn it on for those fleets.
 
-Fleet measures the window from the host's last check-in, not from **Last fetched**. Host expiry skips hosts assigned to Fleet in Apple Business or Windows Autopilot. If hosts aren't expiring as expected, see the [FAQ](https://fleetdm.com/docs/get-started/faq#why-arent-my-hosts-being-deleted-after-the-host-expiry-window).
+Fleet measures the window from the host's last check-in, not from **Last fetched**. Host expiry skips hosts assigned to Fleet in Apple Business or Windows Autopilot. If hosts aren't expiring as expected, see [Why aren't my hosts being deleted after the host expiry window?](https://fleetdm.com/docs/get-started/faq#why-arent-my-hosts-being-deleted-after-the-host-expiry-window) in the FAQ.
 
 #### Example
 

--- a/docs/Get started/FAQ.md
+++ b/docs/Get started/FAQ.md
@@ -355,7 +355,7 @@ Some hosts are exempt from host expiry, and the window isn't measured against th
 
 * Has it run yet? Host expiry runs hourly. Expired hosts appear in the activity feed as host deletions. That's the quickest way to confirm host expiry is running. You can also trigger a run with `fleetctl trigger --name=cleanups_then_aggregation`.
 
-For more detail on host expiry settings, see the [YAML files documentation](https://fleetdm.com/docs/configuration/yaml-files#host-expiry-settings).
+For the settings themselves, see [`host_expiry_settings`](https://fleetdm.com/docs/configuration/yaml-files#host-expiry-settings) in the YAML files reference.
 
 ### How does Fleet deal with IP duplication?
 

--- a/docs/Get started/FAQ.md
+++ b/docs/Get started/FAQ.md
@@ -345,9 +345,9 @@ If your device is showing up as an offline host in the Fleet instance, and you'r
 
 ### Why aren't my hosts being deleted after the host expiry window?
 
-Some hosts are exempt from host expiry. The window also isn't measured against the timestamp in the **Last fetched** column. Check the following:
+Some hosts are exempt from host expiry, and the window isn't measured against the **Last fetched** column. Check the following:
 
-* Is the host assigned to Fleet in Apple Business or Windows Autopilot? Those hosts are never expired, on any platform. This includes hosts that are still **Pending** because they haven't enrolled yet. Fleet keeps them so they can enroll when the device is set up. The exemption lifts once the host is unassigned or released in Apple Business.
+* Is the host assigned to Fleet in Apple Business or Windows Autopilot? Host expiry skips those hosts, on any platform. This includes hosts that are still **Pending** because they haven't enrolled yet. Fleet keeps them so they can enroll when the device is set up. The exemption lifts once the host is unassigned or released in Apple Business.
 
 * Is the host still checking in? Fleet measures the window from the host's most recent check-in. A check-in is either an osquery check-in from Fleet's agent (fleetd) or an MDM check-in, whichever is more recent. **Last fetched** is a different timestamp. It's the last time the host reported vitals, so a host can show a stale **Last fetched** and still be checking in. That host won't expire. This is common on iOS and iPadOS hosts, which report vitals over MDM.
 

--- a/docs/Get started/FAQ.md
+++ b/docs/Get started/FAQ.md
@@ -343,6 +343,20 @@ If your device is showing up as an offline host in the Fleet instance, and you'r
 
 * Try unenrolling and re-enrolling the host. You can do this by uninstalling osquery on the host and then enrolling your device again using one of the [recommended methods](https://fleetdm.com/docs/using-fleet/adding-hosts).
 
+### Why aren't my hosts being deleted after the host expiry window?
+
+Some hosts are exempt from host expiry. The window also isn't measured against the timestamp in the **Last fetched** column. Check the following:
+
+* Is the host assigned to Fleet in Apple Business or Windows Autopilot? Those hosts are never expired, on any platform. This includes hosts that are still **Pending** because they haven't enrolled yet. Fleet keeps them so they can enroll when the device is set up. The exemption lifts once the host is unassigned or released in Apple Business.
+
+* Is the host still checking in? Fleet measures the window from the host's most recent check-in. A check-in is either an osquery check-in from Fleet's agent (fleetd) or an MDM check-in, whichever is more recent. **Last fetched** is a different timestamp. It's the last time the host reported vitals, so a host can show a stale **Last fetched** and still be checking in. That host won't expire. This is common on iOS and iPadOS hosts, which report vitals over MDM.
+
+* Is host expiry turned on? Setting a window isn't enough. Turn on host expiry in **Settings > Organization settings > Advanced options**, or on the fleet. Turning it off on a fleet doesn't exempt that fleet. It tells the fleet to use the organization setting instead.
+
+* Has it run yet? Host expiry runs hourly. Expired hosts appear in the activity feed as host deletions. That's the quickest way to confirm host expiry is running. You can also trigger a run with `fleetctl trigger --name=cleanups_then_aggregation`.
+
+For more detail on host expiry settings, see the [YAML files documentation](https://fleetdm.com/docs/configuration/yaml-files#host-expiry-settings).
+
 ### How does Fleet deal with IP duplication?
 
 Fleet relies on UUIDs, so any overlap with host IP addresses should not cause a problem. The only time this might be an issue is if you are running a query that involves a specific IP address that exists in multiple locations, as it might return multiple results - [Fleet's teams feature](https://fleetdm.com/docs/using-fleet/teams) can be used to restrict queries to specific hosts.


### PR DESCRIPTION
**Related issue:** Resolves #

# Checklist for submitter

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Summary

This PR adds comprehensive documentation about host deletion and host expiry behavior across multiple documentation files:

1. **`articles/enroll-hosts.md`** — Added new "Delete a host" section explaining:
   - What deletion does (removes from Fleet, doesn't unenroll or change AB assignment)
   - Why deleted hosts come back as Pending if still assigned in AB
   - Impact on activities and MDM command records
   - Proper decommissioning workflow (unenroll/wipe → release in AB → delete)

2. **`docs/Get started/FAQ.md`** — Added new FAQ entry "Why aren't my hosts being deleted after the host expiry window?" covering:
   - Hosts exempt from expiry (those assigned in AB or Windows Autopilot, including Pending hosts)
   - Distinction between check-in and "Last fetched" timestamps
   - How to verify host expiry is enabled and running
   - Reference to YAML configuration

3. **`articles/lock-wipe-hosts.md`** — Clarified wipe behavior:
   - Removed duplicate sentence about canceled activities
   - Added warning to wait for wipe to complete before deleting
   - Expanded guidance on releasing from AB before deletion
   - Clarified that deletion doesn't change AB assignment

4. **`docs/Configuration/yaml-files.md`** — Enhanced `host_expiry_settings` documentation:
   - Clarified that `host_expiry_window` requires `host_expiry_enabled: true`
   - Explained fleet-level setting behavior (false = use org setting, not exempt)
   - Documented that expiry measures from last check-in, not "Last fetched"
   - Listed hosts exempt from expiry
   - Cross-referenced FAQ for troubleshooting

These changes improve clarity around a potentially confusing workflow where hosts can reappear after deletion if still assigned in Apple Business, and provide better guidance on host lifecycle management.
