### PR TITLE
make osquery-perf report software update device id

### DIFF
--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -3545,6 +3545,13 @@ func (a *agent) processQuery(name, query string, cachedResults *cachedResults) (
 		// only mdm_config_profiles_darwin_with_user runs. Report no results
 		// and no status, as osquery does for queries whose discovery fails.
 		return true, nil, nil, nil, nil
+	case name == hostDetailQueryPrefix+"mdm_macos_software_update_id":
+		return true, []map[string]string{
+			{
+				"key":   "compatible",
+				"value": "VMA2MACOSAP", // report an osquery-perf host as a VM
+			},
+		}, &statusOK, nil, nil
 	case name == hostDetailQueryPrefix+"mdm_config_profiles_darwin_with_user":
 		ss := statusOK
 		if rand.Intn(10) > 0 { // 90% success


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves nothing, but in a loadtest I saw this error a lot of times on the Fleet server. That was a miss on the impl. story.

# Checklist for submitter

## Testing

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for software update detail queries on simulated macOS hosts.
  * Results now correctly identify virtual machines and provide the appropriate compatibility information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->