### PR TITLE
Handbook: use AI to help you communicate, not to communicate for you

### DIFF
--- a/handbook/company/communications.md
+++ b/handbook/company/communications.md
@@ -349,6 +349,20 @@ In practice, this means:
 The bottom line: don't put your name on something you haven't actually reviewed. That applies to AI-generated work the same as anything else.
 
 
+### Use AI to help you communicate, not to communicate for you
+
+There's a difference between using AI to produce work and using AI to talk to people. Documentation, reports, announcements, and other content meant to inform many people are work products. Use AI to draft and improve them as much as you like, as long as you review and own the result.
+
+Direct conversation is different. When a teammate messages you on Slack or emails you, they expect to be talking to you. AI-generated replies are easy to spot, and once someone suspects they're chatting with a bot instead of a colleague, trust erodes quickly and is hard to earn back. Conversations are how we build relationships at an all-remote company, and they only work if there's a person on both ends.
+
+What this means in practice:
+
+- When you're talking directly with someone, the words should be yours. It's fine to use AI to think through a problem, check your grammar, or tighten something you wrote. It's not fine to paste an AI's response as your own.
+- If English isn't your first language, AI is a great tool for polishing your writing, and we encourage it. Keep your own voice, though. Your teammates would rather read your imperfect words than an AI's perfect ones.
+
+If a conversation matters enough to have, it matters enough to have yourself.
+
+
 ### Protect customer and confidential information
 
 This is a hard rule: do not input confidential or private information into personal AI tools.


### PR DESCRIPTION
**Related issue:** NA (handbook change)

Adds a new "Use AI to help you communicate, not to communicate for you" subsection to the AI usage guidelines on the Communications handbook page.

We encourage AI for work products (docs, reports, announcements), but direct Slack and email conversations should come from the person, not an AI responding on their behalf. This draws that line and addresses the "am I even talking to a human?" experience some teammates have run into.

# Checklist for submitter

- [x] Handbook-only change. No code, tests, migrations, or config affected.
