### PR TITLE
Remove jq from fleet Docker image

### DIFF
--- a/changes/17168-remove-jq-from-docker-image
+++ b/changes/17168-remove-jq-from-docker-image
@@ -1,0 +1,1 @@
+- Removed the unused `jq` binary from the `fleetdm/fleet` Docker image to reduce the image's attack surface and prevent SBOM scanners from flagging `jq` CVEs.

--- a/tools/fleet-docker/Dockerfile
+++ b/tools/fleet-docker/Dockerfile
@@ -9,7 +9,6 @@ LABEL org.opencontainers.image.url="https://fleetdm.com"
 LABEL org.opencontainers.image.documentation="https://fleetdm.com/docs"
 
 RUN apk --update add ca-certificates
-RUN apk --no-cache add jq
 RUN apk --no-cache upgrade openssl libcrypto3 libssl3
 
 # Create fleet group and user


### PR DESCRIPTION
**Related issue:** Resolves https://github.com/fleetdm/confidential/issues/17168

Removes `jq` from the `fleetdm/fleet` production Docker image. It was added years ago but nothing in the image uses it: the image runs the static `fleet` binary directly (`CMD ["fleet", "serve"]`), and nothing in the repo (Helm chart, Terraform, CI workflows, docs) execs `jq` inside the container. Removing it shrinks the image's attack surface and stops customer SBOM scanners from flagging `jq` CVEs against the image.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [ ] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the unused `jq` utility from the Fleet Docker image, reducing unnecessary image contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->