### PR TITLE
Cherry-pick #51865: Reduce lock contention on installed paths DELETE

### DIFF
--- a/changes/49805-installed-paths-delete-outside-tx
+++ b/changes/49805-installed-paths-delete-outside-tx
@@ -1,1 +1,1 @@
-- Reduced database lock contention during software installed paths updates by moving batched DELETEs outside the transaction so each batch auto-commits independently.
+- Reduced database lock contention during software installed paths updates by reordering operations: INSERT new paths first (in a transaction), then DELETE old paths outside the transaction so each batch auto-commits independently.

--- a/changes/49805-installed-paths-delete-outside-tx
+++ b/changes/49805-installed-paths-delete-outside-tx
@@ -1,0 +1,1 @@
+- Reduced database lock contention during software installed paths updates by moving batched DELETEs outside the transaction so each batch auto-commits independently.

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -227,16 +227,21 @@ func (ds *Datastore) UpdateHostSoftwareInstalledPaths(
 		return nil
 	}
 
-	return ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
-		if err := deleteHostSoftwareInstalledPaths(ctx, tx, toD); err != nil {
-			return err
-		}
+	// Delete stale installed paths outside the transaction so each batched
+	// DELETE auto-commits independently and releases row locks immediately.
+	// This prevents lock convoys when many hosts update paths concurrently
+	// (see #49805). The installed_paths table is informational; if the
+	// subsequent INSERT fails, the next hourly check-in will re-populate.
+	if err := deleteHostSoftwareInstalledPaths(ctx, ds.writer(ctx), toD); err != nil {
+		return err
+	}
 
-		if err := insertHostSoftwareInstalledPaths(ctx, tx, toI); err != nil {
-			return err
-		}
-
+	if len(toI) == 0 {
 		return nil
+	}
+
+	return ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
+		return insertHostSoftwareInstalledPaths(ctx, tx, toI)
 	})
 }
 

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -227,22 +227,22 @@ func (ds *Datastore) UpdateHostSoftwareInstalledPaths(
 		return nil
 	}
 
-	// Delete stale installed paths outside the transaction so each batched
-	// DELETE auto-commits independently and releases row locks immediately.
-	// This prevents lock convoys when many hosts update paths concurrently
-	// (see #49805). The installed_paths table is informational; if the
-	// subsequent INSERT fails, the next hourly check-in will re-populate.
-	if err := deleteHostSoftwareInstalledPaths(ctx, ds.writer(ctx), toD); err != nil {
-		return err
+	// INSERT new paths first (in a transaction), then DELETE old paths outside
+	// the transaction (auto-commit per batch). This order ensures safe failure:
+	//   - If INSERT fails: old paths remain, no data lost.
+	//   - If DELETE fails after INSERT: temporary duplicates, cleaned up on
+	//     next agent check-in. No unique constraint on (host_id, software_id).
+	// Moving DELETE outside the transaction releases row locks per batch instead
+	// of accumulating them, preventing lock convoys during concurrent updates.
+	if len(toI) > 0 {
+		if err := ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
+			return insertHostSoftwareInstalledPaths(ctx, tx, toI)
+		}); err != nil {
+			return err
+		}
 	}
 
-	if len(toI) == 0 {
-		return nil
-	}
-
-	return ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
-		return insertHostSoftwareInstalledPaths(ctx, tx, toI)
-	})
+	return deleteHostSoftwareInstalledPaths(ctx, ds.writer(ctx), toD)
 }
 
 // getHostSoftwareInstalledPaths returns all HostSoftwareInstalledPath for the given hostID.


### PR DESCRIPTION
> Generated by Claude Code on behalf of @sharon-fdm.

Cherry-pick of https://github.com/fleetdm/fleet/pull/51865 into the 4.91.0 RC branch.

Addresses row_lock_wait contention on `host_software_installed_paths` DELETE observed during Andrey's migration load test (4.90 to 4.91). Reorders operations to INSERT first (in transaction), then DELETE outside the transaction (auto-commit per batch).

For full details see the original PR: https://github.com/fleetdm/fleet/pull/51865

- [x] QA'd all new/changed functionality manually