### PR TITLE
Make software title details versions table sortable by version

### DIFF
--- a/changes/44057-sort-software-versions-by-version
+++ b/changes/44057-sort-software-versions-by-version
@@ -1,0 +1,1 @@
+- Added the ability to sort the versions table by version on the Software details page.

--- a/frontend/components/TableContainer/DataTable/DataTable.tsx
+++ b/frontend/components/TableContainer/DataTable/DataTable.tsx
@@ -267,12 +267,11 @@ const DataTable = ({
             b: { values: Record<string, unknown[]> },
             id: string
           ) => sort.hostPolicyStatus(a.values[id], b.values[id]),
-
           version: (
             a: { values: Record<string, unknown> },
             b: { values: Record<string, unknown> },
             id: string
-          ) => sort.versionAsc(a.values[id] as string, b.values[id] as string),
+          ) => sort.versionAsc(a.values[id], b.values[id]),
         }),
         []
       ),

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/TitleVersionsTable/TitleVersionsTable.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/TitleVersionsTable/TitleVersionsTable.tests.tsx
@@ -7,12 +7,13 @@ import TitleVersionsTable from "./TitleVersionsTable";
 const mockRouter = createMockRouter();
 
 describe("TitleVersionsTable", () => {
-  // Deliberately ordered so that host count, lexical, and numeric version
-  // orderings are all different, and 1.2.10 vs 1.2.9 catches a lexical sort.
+  // Deliberately ordered so that the input order, host count order, and
+  // lexical and numeric version orderings are all different, and
+  // 1.2.10 vs 1.2.9 catches a lexical sort.
   const unsortedVersions = [
-    { id: 1, version: "1.2.9", vulnerabilities: [], hosts_count: 3 },
-    { id: 2, version: "1.2.2", vulnerabilities: [], hosts_count: 2 },
-    { id: 3, version: "1.2.10", vulnerabilities: [], hosts_count: 1 },
+    { id: 1, version: "1.2.9", vulnerabilities: [], hosts_count: 1 },
+    { id: 2, version: "1.2.2", vulnerabilities: [], hosts_count: 3 },
+    { id: 3, version: "1.2.10", vulnerabilities: [], hosts_count: 2 },
   ];
 
   const renderTable = (data = unsortedVersions) =>
@@ -36,7 +37,7 @@ describe("TitleVersionsTable", () => {
   it("sorts by host count by default", () => {
     renderTable();
 
-    expect(renderedVersions()).toEqual(["1.2.9", "1.2.2", "1.2.10"]);
+    expect(renderedVersions()).toEqual(["1.2.2", "1.2.10", "1.2.9"]);
   });
 
   it("sorts by version number when the Version header is clicked", async () => {

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/TitleVersionsTable/TitleVersionsTable.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/TitleVersionsTable/TitleVersionsTable.tests.tsx
@@ -1,12 +1,68 @@
 import React from "react";
-import { screen, render } from "@testing-library/react";
-import { createMockRouter } from "test/test-utils";
+import { screen, render, within } from "@testing-library/react";
+import { createMockRouter, renderWithSetup } from "test/test-utils";
 import { ISoftwareTitleVersion } from "interfaces/software";
 import TitleVersionsTable from "./TitleVersionsTable";
 
 const mockRouter = createMockRouter();
 
 describe("TitleVersionsTable", () => {
+  // Deliberately ordered so that host count, lexical, and numeric version
+  // orderings are all different, and 1.2.10 vs 1.2.9 catches a lexical sort.
+  const unsortedVersions = [
+    { id: 1, version: "1.2.9", vulnerabilities: [], hosts_count: 3 },
+    { id: 2, version: "1.2.2", vulnerabilities: [], hosts_count: 2 },
+    { id: 3, version: "1.2.10", vulnerabilities: [], hosts_count: 1 },
+  ];
+
+  const renderTable = (data = unsortedVersions) =>
+    renderWithSetup(
+      <TitleVersionsTable
+        router={mockRouter}
+        data={data}
+        isLoading={false}
+        teamIdForApi={42}
+        isIPadOSOrIOSApp={false}
+        countsUpdatedAt="2024-05-08T12:00:00Z"
+      />
+    );
+
+  const renderedVersions = () =>
+    screen
+      .getAllByRole("row")
+      .slice(1) // the first row is the header
+      .map((row) => within(row).getAllByRole("cell")[0].textContent);
+
+  it("sorts by host count by default", () => {
+    renderTable();
+
+    expect(renderedVersions()).toEqual(["1.2.9", "1.2.2", "1.2.10"]);
+  });
+
+  it("sorts by version number when the Version header is clicked", async () => {
+    const { user } = renderTable();
+    const versionHeader = screen.getByRole("button", { name: "Version" });
+
+    await user.click(versionHeader);
+    expect(renderedVersions()).toEqual(["1.2.2", "1.2.9", "1.2.10"]);
+
+    await user.click(versionHeader);
+    expect(renderedVersions()).toEqual(["1.2.10", "1.2.9", "1.2.2"]);
+  });
+
+  it("treats trailing zero segments as the same version", async () => {
+    // Distinguishes the "version" sortType from react-table's default sort,
+    // which would order 14.3 ahead of 14.3.0 instead of leaving them tied.
+    const { user } = renderTable([
+      { id: 1, version: "14.3.0", vulnerabilities: [], hosts_count: 1 },
+      { id: 2, version: "14.3", vulnerabilities: [], hosts_count: 2 },
+    ]);
+
+    await user.click(screen.getByRole("button", { name: "Version" }));
+
+    expect(renderedVersions()).toEqual(["14.3.0", "14.3"]);
+  });
+
   it("renders version names as links and footer info", () => {
     const versions = [
       { id: 10, version: "1.2.3", vulnerabilities: [] },

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/TitleVersionsTable/TitleVersionsTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/TitleVersionsTable/TitleVersionsTable.tsx
@@ -17,7 +17,7 @@ import LastUpdatedText from "components/LastUpdatedText";
 
 import generateSoftwareTitleVersionsTableConfig from "./TitleVersionsTableConfig";
 
-const DEFAULT_SORT_HEADER = "version";
+const DEFAULT_SORT_HEADER = "hosts_count";
 const DEFAULT_SORT_DIRECTION = "desc";
 const DEFAULT_PAGE_SIZE = 10;
 

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/TitleVersionsTable/TitleVersionsTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/TitleVersionsTable/TitleVersionsTableConfig.tsx
@@ -5,10 +5,11 @@ import PATHS from "router/paths";
 import { getPathWithQueryParams } from "utilities/url";
 
 import {
+  IHeaderProps,
   INumberCellProps,
   IStringCellProps,
 } from "interfaces/datatable_config";
-import { CellProps, HeaderProps } from "react-table";
+import { CellProps } from "react-table";
 
 import TextCell from "components/TableContainer/DataTable/TextCell";
 import HeaderCell from "components/TableContainer/DataTable/HeaderCell";
@@ -26,7 +27,7 @@ type IVersionCellProps = IStringCellProps<ISoftwareTitleVersion>;
 type IVulnCellProps = CellProps<ISoftwareTitleVersion, string[] | null>;
 type IHostCountCellProps = INumberCellProps<ISoftwareTitleVersion>;
 type IViewAllHostsLinkProps = CellProps<ISoftwareTitleVersion>;
-type IVersionHeaderProps = HeaderProps<ISoftwareTitleVersion>;
+type IVersionHeaderProps = IHeaderProps<ISoftwareTitleVersion>;
 
 const generateSoftwareTitleVersionsTableConfig = ({
   teamId,

--- a/frontend/utilities/helpers.tests.tsx
+++ b/frontend/utilities/helpers.tests.tsx
@@ -52,43 +52,6 @@ describe("helpers utilities", () => {
       expect(compareVersions("14.3", "14.3.0")).toEqual(0);
       expect(compareVersions("14", "14.0.0")).toEqual(0);
     });
-
-    it("compares segments numerically instead of lexically, regardless of digit count", () => {
-      expect(compareVersions("26.6", "26.10")).toEqual(-1);
-      expect(compareVersions("26.10", "26.6")).toEqual(1);
-      expect(compareVersions("150.0.7871.213", "150.0.7871.185")).toEqual(1);
-      expect(compareVersions("10.0.26200.8875", "10.0.9200.100")).toEqual(1);
-    });
-
-    it("treats a version with a non-numeric first segment as older than any comparable version", () => {
-      expect(compareVersions("rolling", "26.6")).toEqual(-1);
-      expect(compareVersions("26.6", "rolling")).toEqual(1);
-      expect(compareVersions("rolling", "rolling")).toEqual(0);
-      // Narrow case that a whole-segment-count-matching NaN tie used to get wrong:
-      // a single bare numeric segment vs. a single non-numeric one.
-      expect(compareVersions("rolling", "14")).toEqual(-1);
-      expect(compareVersions("14", "rolling")).toEqual(1);
-    });
-
-    it("compares Windows feature-update codenames by year and half", () => {
-      expect(compareVersions("21H2", "22H1")).toEqual(-1);
-      expect(compareVersions("22H1", "21H2")).toEqual(1);
-      expect(compareVersions("22H1", "22H2")).toEqual(-1);
-      expect(compareVersions("23H1", "21H2")).toEqual(1);
-      expect(compareVersions("21H2", "21H2")).toEqual(0);
-    });
-
-    it("leaves suffixed Fleet-maintained-app versions with a numeric first segment unchanged", () => {
-      // A non-numeric trailing segment (e.g. a Homebrew revision suffix) is
-      // coerced to 0 by the `|| 0` fallback below, same as a missing
-      // segment — this is pre-existing behavior this change doesn't alter,
-      // since only the *first* segment's numeric-ness is checked up front.
-      expect(compareVersions("2.26.7_1", "2.26.7")).toEqual(-1);
-      expect(compareVersions("114.0.4-release", "114.0.4")).toEqual(-1);
-      // A differing leading numeric segment still compares correctly even
-      // with a non-numeric suffix present.
-      expect(compareVersions("2.27.0_1", "2.26.7_1")).toEqual(1);
-    });
   });
 
   describe("willExpireWithinXDays function", () => {

--- a/frontend/utilities/helpers.tsx
+++ b/frontend/utilities/helpers.tsx
@@ -93,39 +93,10 @@ export const removeOSPrefix = (version: string): string => {
   return version.replace(/^(macOS |iOS |iPadOS )/i, "");
 };
 
-// Windows feature-update codename, e.g. "21H2", "23H1" — one of the two
-// documented shapes of an OS version string (the other being dot-separated
-// numbers). Treated as a [year, half] version for comparison purposes.
-const WINDOWS_FEATURE_UPDATE_PATTERN = /^(\d{2})H([12])$/;
-
-/** Returns 1 if first version is newer, -1 if first version is older, and 0 if equal.
- * Splits on "." and compares segments numerically (so multi-digit segments sort
- * correctly, e.g. "26.10" > "26.6"), except a Windows feature-update codename
- * (e.g. "21H2") is compared as [year, half] instead. A segment that isn't a
- * number (e.g. a build-metadata suffix like "7_1") ties for that position and
- * falls through to the next segment, same as a missing segment — this keeps
- * real-world suffixed versions (Fleet-maintained-app versions in particular)
- * comparing sanely instead of failing outright. Only when a version's *first*
- * segment isn't a number at all (e.g. Arch Linux's "rolling") is it treated as
- * non-comparable, sorting before any version that is. */
+/** Returns 1 if first version is newer, -1 if first version is older, and 0 if equal  */
 export const compareVersions = (version1: string, version2: string) => {
-  const toParts = (version: string): number[] => {
-    const windowsMatch = version.match(WINDOWS_FEATURE_UPDATE_PATTERN);
-    if (windowsMatch) {
-      return [Number(windowsMatch[1]), Number(windowsMatch[2])];
-    }
-    return version.split(".").map(Number);
-  };
-
-  const v1Parts = toParts(version1);
-  const v2Parts = toParts(version2);
-
-  const v1IsVersionLike = !Number.isNaN(v1Parts[0]);
-  const v2IsVersionLike = !Number.isNaN(v2Parts[0]);
-
-  if (!v1IsVersionLike && !v2IsVersionLike) return 0;
-  if (!v1IsVersionLike) return -1;
-  if (!v2IsVersionLike) return 1;
+  const v1Parts = version1.split(".").map(Number);
+  const v2Parts = version2.split(".").map(Number);
 
   const maxLength = Math.max(v1Parts.length, v2Parts.length);
 

--- a/frontend/utilities/sort/sort_functions.tests.ts
+++ b/frontend/utilities/sort/sort_functions.tests.ts
@@ -1,16 +1,16 @@
 import sort from "./sort_functions";
 
 describe("versionAsc function", () => {
-  it("delegates to compareVersions for numeric segments", () => {
+  it("compares version segments numerically", () => {
     expect(sort.versionAsc("26.6", "26.10")).toEqual(-1);
     expect(sort.versionAsc("26.10", "26.6")).toEqual(1);
     expect(sort.versionAsc("26.6", "26.6")).toEqual(0);
   });
 
-  it("coerces non-string values instead of throwing", () => {
-    expect(sort.versionAsc((null as unknown) as string, "26.6")).toEqual(-1);
-    expect(sort.versionAsc((undefined as unknown) as string, "26.6")).toEqual(
-      -1
-    );
+  it("sorts a missing version before any real version", () => {
+    expect(sort.versionAsc(null, "26.6")).toEqual(-1);
+    expect(sort.versionAsc(undefined, "26.6")).toEqual(-1);
+    expect(sort.versionAsc("26.6", null)).toEqual(1);
+    expect(sort.versionAsc(null, undefined)).toEqual(0);
   });
 });

--- a/frontend/utilities/sort/sort_functions.ts
+++ b/frontend/utilities/sort/sort_functions.ts
@@ -58,8 +58,12 @@ const hasLength = (a: unknown[], b: unknown[]): number => {
   return 0;
 };
 
-const versionAsc = (a: string, b: string): number =>
-  compareVersions(String(a ?? ""), String(b ?? ""));
+// A missing version becomes "", which sorts before any real version.
+const versionAsc = (a: unknown, b: unknown): number =>
+  compareVersions(
+    typeof a === "string" ? a : "",
+    typeof b === "string" ? b : ""
+  );
 
 const POLICY_STATUS_PRECEDENCE = ["actionRequired", "fail", "pass"];
 


### PR DESCRIPTION
Follow up for https://github.com/fleetdm/fleet/pull/50743

Relates to #44057

- Added missing changes file (changes/44057-sort-software-versions-by-version)
- Restored default sorting order to hosts_count
- Removed WINDOWS_FEATURE_UPDATE_PATTERN and the toParts wrapper it required
- Removed the first-segment-NaN sentinel from compareVersions
- Reverted the compareVersions doc comment, which described the substitution of non-numeric segments as a tie-and-fall-through
- Removed four redundant tests from helpers.tests.tsx that passed identically before the change
- Changed versionAsc to accept unknown, dropping the casts it forced in DataTable and its own tests
- Removed a stray blank line in DataTable's sortTypes
- Renamed the versionAsc tests to describe behavior, and added the missing reverse and both-missing cases
- Replaced the local HeaderProps alias with the canonical IHeaderProps from interfaces/datatable_config
- Added table tests for the default order, click-to-sort in both directions, and the sortType wiring

https://github.com/user-attachments/assets/796967fd-6b29-4420-84f9-fdf1c9f48e42


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added sorting by software version on the Software details page.
  - Version sorting supports ascending and descending order, including versions with trailing zeros.

- **Bug Fixes**
  - Improved handling of missing or non-text version values during sorting.
  - Preserved host-count sorting as the table’s default sort order.
  - Simplified version comparison for more consistent results across displayed versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->