### PR TITLE
Patch when closed: Throttle continuous re-fires after app-open skip

### DIFF
--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -2728,8 +2728,6 @@ WHERE
 		return nil, ctxerr.Wrap(ctx, err, "get latest upcoming install")
 	}
 
-	// A pending row never has a resolved skip reason; the caller only reads SkipReason for
-	// completed rows and the zero value already spells "not a skip", so nothing to populate.
 	return &hostLastInstall, nil
 }
 

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -2710,8 +2710,7 @@ func (ds *Datastore) getLatestUpcomingInstall(ctx context.Context, hostID, insta
 SELECT
 	execution_id,
 	'pending_install' AS status,
-	updated_at,
-	0 AS was_app_open_skip
+	updated_at
 FROM
 	upcoming_activities
 WHERE
@@ -2729,23 +2728,32 @@ WHERE
 		return nil, ctxerr.Wrap(ctx, err, "get latest upcoming install")
 	}
 
+	// A pending row never has a resolved skip reason; the caller only reads SkipReason for
+	// completed rows and the zero value already spells "not a skip", so nothing to populate.
 	return &hostLastInstall, nil
 }
 
+// pastInstallRow carries the raw signals fleet.ClassifySoftwareInstallSkipReason needs
+// so the "what counts as a skip" invariant lives in one Go function rather than in the
+// SQL of getLatestPastInstall.
+type pastInstallRow struct {
+	fleet.HostLastInstallData
+	PatchWhenClosed       bool `db:"patch_when_closed"`
+	PreInstallOutputEmpty bool `db:"pre_install_output_empty"`
+}
+
 func (ds *Datastore) getLatestPastInstall(ctx context.Context, hostID, installerID uint) (*fleet.HostLastInstallData, error) {
-	var hostLastInstall fleet.HostLastInstallData
-	// was_app_open_skip is true only when the row is a patch-when-closed policy install
-	// whose managed pre-install query returned no rows (empty pre_install_query_output).
-	// The generated status column already treats that as failed_install, so we don't need
-	// to gate on status here.
+	var row pastInstallRow
+	// Return the raw signals only; classification is a Go call so we can unit test all
+	// combinations and grep for the invariant in one place.
 	stmt := `
 SELECT
 	hsi.execution_id,
 	hsi.status,
 	hsi.updated_at,
-	(COALESCE(p.patch_when_closed, 0) = 1
-		AND hsi.pre_install_query_output IS NOT NULL
-		AND hsi.pre_install_query_output = '') AS was_app_open_skip
+	COALESCE(p.patch_when_closed, 0) AS patch_when_closed,
+	(hsi.pre_install_query_output IS NOT NULL
+		AND hsi.pre_install_query_output = '') AS pre_install_output_empty
 FROM
 	host_software_installs hsi
 	LEFT JOIN policies p ON p.id = hsi.policy_id
@@ -2758,11 +2766,12 @@ WHERE
 		WHERE
 			hsi.host_id = ? AND hsi.software_installer_id = ? AND hsi.canceled = 0)`
 
-	if err := sqlx.GetContext(ctx, ds.reader(ctx), &hostLastInstall, stmt, hostID, installerID); err != nil {
+	if err := sqlx.GetContext(ctx, ds.reader(ctx), &row, stmt, hostID, installerID); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "get latest past install")
 	}
 
-	return &hostLastInstall, nil
+	row.SkipReason = fleet.ClassifySoftwareInstallSkipReason(row.Status, row.PatchWhenClosed, row.PreInstallOutputEmpty)
+	return &row.HostLastInstallData, nil
 }
 
 func (ds *Datastore) CleanupUnusedSoftwareInstallers(ctx context.Context, softwareInstallStore fleet.SoftwareInstallerStore, removeCreatedBefore time.Time) error {

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -2710,7 +2710,8 @@ func (ds *Datastore) getLatestUpcomingInstall(ctx context.Context, hostID, insta
 SELECT
 	execution_id,
 	'pending_install' AS status,
-	updated_at
+	updated_at,
+	0 AS was_app_open_skip
 FROM
 	upcoming_activities
 WHERE
@@ -2733,15 +2734,23 @@ WHERE
 
 func (ds *Datastore) getLatestPastInstall(ctx context.Context, hostID, installerID uint) (*fleet.HostLastInstallData, error) {
 	var hostLastInstall fleet.HostLastInstallData
+	// was_app_open_skip is true only when the row is a patch-when-closed policy install
+	// whose managed pre-install query returned no rows (empty pre_install_query_output).
+	// The generated status column already treats that as failed_install, so we don't need
+	// to gate on status here.
 	stmt := `
 SELECT
-	execution_id,
-	status,
-	updated_at
+	hsi.execution_id,
+	hsi.status,
+	hsi.updated_at,
+	(COALESCE(p.patch_when_closed, 0) = 1
+		AND hsi.pre_install_query_output IS NOT NULL
+		AND hsi.pre_install_query_output = '') AS was_app_open_skip
 FROM
-	host_software_installs
+	host_software_installs hsi
+	LEFT JOIN policies p ON p.id = hsi.policy_id
 WHERE
-	id = (
+	hsi.id = (
 		SELECT
 			MAX(hsi.id)
 		FROM

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -47,6 +47,7 @@ func TestSoftwareInstallers(t *testing.T) {
 		{"DeleteSoftwareInstallerRepointsPolicies", testDeleteSoftwareInstallerRepointsPolicies},
 		{"testDeletePendingSoftwareInstallsForPolicy", testDeletePendingSoftwareInstallsForPolicy},
 		{"GetHostLastInstallData", testGetHostLastInstallData},
+		{"GetHostLastInstallDataAppOpenSkip", testGetHostLastInstallDataAppOpenSkip},
 		{"GetOrGenerateSoftwareInstallerTitleID", testGetOrGenerateSoftwareInstallerTitleID},
 		{"BatchSetSoftwareInstallersScopedViaLabels", testBatchSetSoftwareInstallersScopedViaLabels},
 		{"MatchOrCreateSoftwareInstallerWithAutomaticPolicies", testMatchOrCreateSoftwareInstallerWithAutomaticPolicies},
@@ -3252,6 +3253,9 @@ func testGetHostLastInstallData(t *testing.T, ds *Datastore) {
 	require.Equal(t, installUUID3, host1LastInstall.ExecutionID)
 	require.NotNil(t, host1LastInstall.Status)
 	require.Equal(t, fleet.SoftwareInstallFailed, *host1LastInstall.Status)
+	// Ordinary install-script failure (no patch policy involved) must not be flagged
+	// as an app-open skip: the WasAppOpenSkip flag is scoped to patch-when-closed.
+	require.False(t, host1LastInstall.WasAppOpenSkip)
 
 	// No installations on host2.
 	host2LastInstall, err := ds.GetHostLastInstallData(ctx, host2.ID, softwareInstallerID1)
@@ -3260,6 +3264,92 @@ func testGetHostLastInstallData(t *testing.T, ds *Datastore) {
 	host2LastInstall, err = ds.GetHostLastInstallData(ctx, host2.ID, softwareInstallerID2)
 	require.NoError(t, err)
 	require.Nil(t, host2LastInstall)
+}
+
+// testGetHostLastInstallDataAppOpenSkip verifies that a patch-when-closed policy install
+// that came back with an empty pre-install output (app open) surfaces WasAppOpenSkip=true
+// on GetHostLastInstallData, so the continuous-automation throttle can dampen re-fires
+// while the app remains open. An empty pre-install output on a NON patch-when-closed
+// policy install must not flip the flag.
+func testGetHostLastInstallDataAppOpenSkip(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+	user := test.NewUser(t, ds, "Author", "author-appopen-skip@example.com", true)
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "app-open-skip-team"})
+	require.NoError(t, err)
+	host := test.NewHost(t, ds, "aos-host", "aos-1", "aos-key", "aos-uuid", time.Now())
+	require.NoError(t, ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&team.ID, []uint{host.ID})))
+
+	tfr, err := fleet.NewTempFileReader(strings.NewReader("hello"), t.TempDir)
+	require.NoError(t, err)
+	installerID, titleID, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+		InstallScript:   "install",
+		InstallerFile:   tfr,
+		StorageID:       "aos-installer",
+		Filename:        "aos.pkg",
+		Title:           "AOS",
+		Source:          "apps",
+		Platform:        "darwin",
+		TeamID:          &team.ID,
+		UserID:          user.ID,
+		ValidatedLabels: &fleet.LabelIdentsWithScope{},
+	})
+	require.NoError(t, err)
+
+	// createPolicy makes a team policy tied to the installer's title, optionally patch-when-closed.
+	// patch_when_closed is set directly since NewTeamPolicy doesn't expose it on this simplified path.
+	createPolicy := func(patchWhenClosed bool) uint {
+		p, err := ds.NewTeamPolicy(ctx, team.ID, &user.ID, fleet.PolicyPayload{
+			Name:  "policy-" + uuid.NewString(),
+			Query: "SELECT 1;",
+		})
+		require.NoError(t, err)
+		if patchWhenClosed {
+			ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+				_, err := q.ExecContext(ctx, `UPDATE policies SET patch_when_closed = 1 WHERE id = ?`, p.ID)
+				return err
+			})
+		}
+		return p.ID
+	}
+
+	// queueAndReportSkip queues a policy-triggered install for the host and reports an
+	// empty pre_install_query_output (app-open signal from orbit) so the row lands as
+	// failed_install with the flag pre-conditions met.
+	queueAndReportSkip := func(policyID uint) string {
+		exec, err := ds.InsertSoftwareInstallRequest(ctx, host.ID, installerID, fleet.HostSoftwareInstallOptions{PolicyID: &policyID})
+		require.NoError(t, err)
+		_, err = ds.activateNextUpcomingActivity(ctx, ds.writer(ctx), host.ID, "")
+		require.NoError(t, err)
+		_, err = ds.SetHostSoftwareInstallResult(ctx, &fleet.HostSoftwareInstallResultPayload{
+			HostID:                    host.ID,
+			InstallUUID:               exec,
+			PreInstallConditionOutput: new(""),
+		}, new(0))
+		require.NoError(t, err)
+		return exec
+	}
+
+	// patch-when-closed policy + empty pre-install output => flagged as app-open skip.
+	pwcExec := queueAndReportSkip(createPolicy(true))
+	last, err := ds.GetHostLastInstallData(ctx, host.ID, installerID)
+	require.NoError(t, err)
+	require.NotNil(t, last)
+	require.Equal(t, pwcExec, last.ExecutionID)
+	require.NotNil(t, last.Status)
+	require.Equal(t, fleet.SoftwareInstallFailed, *last.Status)
+	require.True(t, last.WasAppOpenSkip, "patch-when-closed empty pre-install output must flag as app-open skip")
+
+	// Ordinary patch policy (no patch_when_closed) + empty pre-install output => NOT flagged.
+	// Regression guard for the intentional carve-out: the flag is scoped to patch-when-closed
+	// so ordinary empty pre_install_query results still fail normally and still retry.
+	ordinaryExec := queueAndReportSkip(createPolicy(false))
+	last, err = ds.GetHostLastInstallData(ctx, host.ID, installerID)
+	require.NoError(t, err)
+	require.NotNil(t, last)
+	require.Equal(t, ordinaryExec, last.ExecutionID)
+	require.False(t, last.WasAppOpenSkip, "ordinary empty pre-install output must not flag as app-open skip")
+
+	_ = titleID
 }
 
 func testGetOrGenerateSoftwareInstallerTitleID(t *testing.T, ds *Datastore) {

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -3253,9 +3253,9 @@ func testGetHostLastInstallData(t *testing.T, ds *Datastore) {
 	require.Equal(t, installUUID3, host1LastInstall.ExecutionID)
 	require.NotNil(t, host1LastInstall.Status)
 	require.Equal(t, fleet.SoftwareInstallFailed, *host1LastInstall.Status)
-	// Ordinary install-script failure (no patch policy involved) must not be flagged
-	// as an app-open skip: the WasAppOpenSkip flag is scoped to patch-when-closed.
-	require.False(t, host1LastInstall.WasAppOpenSkip)
+	// Ordinary install-script failure (no patch policy involved) resolves to no skip
+	// reason: the app-open classification is scoped to patch-when-closed.
+	require.Equal(t, fleet.SoftwareInstallSkipReasonNone, host1LastInstall.SkipReason)
 
 	// No installations on host2.
 	host2LastInstall, err := ds.GetHostLastInstallData(ctx, host2.ID, softwareInstallerID1)
@@ -3267,10 +3267,11 @@ func testGetHostLastInstallData(t *testing.T, ds *Datastore) {
 }
 
 // testGetHostLastInstallDataAppOpenSkip verifies that a patch-when-closed policy install
-// that came back with an empty pre-install output (app open) surfaces WasAppOpenSkip=true
-// on GetHostLastInstallData, so the continuous-automation throttle can dampen re-fires
-// while the app remains open. An empty pre-install output on a NON patch-when-closed
-// policy install must not flip the flag.
+// that came back with an empty pre-install output (app open) surfaces
+// SkipReason=SoftwareInstallSkipReasonAppOpen on GetHostLastInstallData, so the
+// continuous-automation throttle can dampen re-fires while the app remains open. An
+// empty pre-install output on a NON patch-when-closed policy install must resolve to no
+// skip reason so it still fails and retries normally.
 func testGetHostLastInstallDataAppOpenSkip(t *testing.T, ds *Datastore) {
 	ctx := t.Context()
 	user := test.NewUser(t, ds, "Author", "author-appopen-skip@example.com", true)
@@ -3329,7 +3330,7 @@ func testGetHostLastInstallDataAppOpenSkip(t *testing.T, ds *Datastore) {
 		return exec
 	}
 
-	// patch-when-closed policy + empty pre-install output => flagged as app-open skip.
+	// patch-when-closed policy + empty pre-install output => classified as app-open skip.
 	pwcExec := queueAndReportSkip(createPolicy(true))
 	last, err := ds.GetHostLastInstallData(ctx, host.ID, installerID)
 	require.NoError(t, err)
@@ -3337,17 +3338,18 @@ func testGetHostLastInstallDataAppOpenSkip(t *testing.T, ds *Datastore) {
 	require.Equal(t, pwcExec, last.ExecutionID)
 	require.NotNil(t, last.Status)
 	require.Equal(t, fleet.SoftwareInstallFailed, *last.Status)
-	require.True(t, last.WasAppOpenSkip, "patch-when-closed empty pre-install output must flag as app-open skip")
+	require.Equal(t, fleet.SoftwareInstallSkipReasonAppOpen, last.SkipReason, "patch-when-closed empty pre-install output must classify as app-open skip")
 
-	// Ordinary patch policy (no patch_when_closed) + empty pre-install output => NOT flagged.
-	// Regression guard for the intentional carve-out: the flag is scoped to patch-when-closed
-	// so ordinary empty pre_install_query results still fail normally and still retry.
+	// Ordinary patch policy (no patch_when_closed) + empty pre-install output => no skip.
+	// Regression guard for the intentional carve-out: the classifier is scoped to
+	// patch-when-closed so ordinary empty pre_install_query results still fail normally
+	// and still retry.
 	ordinaryExec := queueAndReportSkip(createPolicy(false))
 	last, err = ds.GetHostLastInstallData(ctx, host.ID, installerID)
 	require.NoError(t, err)
 	require.NotNil(t, last)
 	require.Equal(t, ordinaryExec, last.ExecutionID)
-	require.False(t, last.WasAppOpenSkip, "ordinary empty pre-install output must not flag as app-open skip")
+	require.Equal(t, fleet.SoftwareInstallSkipReasonNone, last.SkipReason, "ordinary empty pre-install output must not classify as app-open skip")
 }
 
 func testGetOrGenerateSoftwareInstallerTitleID(t *testing.T, ds *Datastore) {

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -3281,7 +3281,7 @@ func testGetHostLastInstallDataAppOpenSkip(t *testing.T, ds *Datastore) {
 
 	tfr, err := fleet.NewTempFileReader(strings.NewReader("hello"), t.TempDir)
 	require.NoError(t, err)
-	installerID, titleID, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+	installerID, _, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
 		InstallScript:   "install",
 		InstallerFile:   tfr,
 		StorageID:       "aos-installer",
@@ -3348,8 +3348,6 @@ func testGetHostLastInstallDataAppOpenSkip(t *testing.T, ds *Datastore) {
 	require.NotNil(t, last)
 	require.Equal(t, ordinaryExec, last.ExecutionID)
 	require.False(t, last.WasAppOpenSkip, "ordinary empty pre-install output must not flag as app-open skip")
-
-	_ = titleID
 }
 
 func testGetOrGenerateSoftwareInstallerTitleID(t *testing.T, ds *Datastore) {

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -3296,20 +3296,13 @@ func testGetHostLastInstallDataAppOpenSkip(t *testing.T, ds *Datastore) {
 	})
 	require.NoError(t, err)
 
-	// createPolicy makes a team policy tied to the installer's title, optionally patch-when-closed.
-	// patch_when_closed is set directly since NewTeamPolicy doesn't expose it on this simplified path.
 	createPolicy := func(patchWhenClosed bool) uint {
 		p, err := ds.NewTeamPolicy(ctx, team.ID, &user.ID, fleet.PolicyPayload{
-			Name:  "policy-" + uuid.NewString(),
-			Query: "SELECT 1;",
+			Name:            "policy-" + uuid.NewString(),
+			Query:           "SELECT 1;",
+			PatchWhenClosed: patchWhenClosed,
 		})
 		require.NoError(t, err)
-		if patchWhenClosed {
-			ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
-				_, err := q.ExecContext(ctx, `UPDATE policies SET patch_when_closed = 1 WHERE id = ?`, p.ID)
-				return err
-			})
-		}
 		return p.ID
 	}
 

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -471,6 +471,12 @@ type HostLastInstallData struct {
 	// requests the host refetch; it is used to throttle continuous policy automation
 	// re-installs (see continuousAutomationOnCooldown).
 	UpdatedAt time.Time `db:"updated_at"`
+	// WasAppOpenSkip is true when the last install ended in an app-open skip on a
+	// patch-when-closed policy (managed pre-install query returned no rows). The row
+	// is stored as failed_install but semantically it's a hold, so the continuous-
+	// automation throttle treats it like a success to avoid re-firing on every
+	// distributed_write while the app stays open.
+	WasAppOpenSkip bool `db:"was_app_open_skip"`
 }
 
 // HostSoftwareInstaller represents a software installer package that has been installed on a host.

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -460,6 +460,41 @@ func (s SoftwareInstallerStatus) IsValid() bool {
 	}
 }
 
+// SoftwareInstallSkipReason classifies why a software install ended without running
+// the install script. A skip is stored on the failed_install row (empty payload
+// signals from orbit), but semantically it's a hold, not a retryable failure.
+type SoftwareInstallSkipReason string
+
+const (
+	// SoftwareInstallSkipReasonNone means the row is not a skip: either it succeeded,
+	// it is still pending, or it failed for a reason that consumes a retry attempt.
+	SoftwareInstallSkipReasonNone SoftwareInstallSkipReason = ""
+	// SoftwareInstallSkipReasonAppOpen means the row is a patch-when-closed install
+	// whose managed app-open query returned rows on the host (app is running). The
+	// install did not run; the next continuous-automation cycle re-fires.
+	SoftwareInstallSkipReasonAppOpen SoftwareInstallSkipReason = "app_open"
+)
+
+// ClassifySoftwareInstallSkipReason returns the skip reason for a completed install
+// row based on the three fields that determine it. Keeping this in Go instead of SQL
+// means the "what counts as an app-open skip" invariant lives in one place with
+// exhaustive unit test coverage.
+//
+//   - status must be failed_install for a skip (a nil or non-failed status is never a skip).
+//   - patchWhenClosed gates the app-open reason to policies that opted into it, so an
+//     ordinary empty pre_install_query result on an unrelated policy is not misclassified.
+//   - preInstallOutputEmpty distinguishes the pre-install signal from an install-script
+//     failure, whose failed_install status is not a skip.
+func ClassifySoftwareInstallSkipReason(status *SoftwareInstallerStatus, patchWhenClosed, preInstallOutputEmpty bool) SoftwareInstallSkipReason {
+	if status == nil || *status != SoftwareInstallFailed {
+		return SoftwareInstallSkipReasonNone
+	}
+	if patchWhenClosed && preInstallOutputEmpty {
+		return SoftwareInstallSkipReasonAppOpen
+	}
+	return SoftwareInstallSkipReasonNone
+}
+
 // HostLastInstallData contains data for the last installation of a package on a host.
 type HostLastInstallData struct {
 	// ExecutionID is the installation ID of the package on the host.
@@ -471,12 +506,10 @@ type HostLastInstallData struct {
 	// requests the host refetch; it is used to throttle continuous policy automation
 	// re-installs (see continuousAutomationOnCooldown).
 	UpdatedAt time.Time `db:"updated_at"`
-	// WasAppOpenSkip is true when the last install ended in an app-open skip on a
-	// patch-when-closed policy (managed pre-install query returned no rows). The row
-	// is stored as failed_install but semantically it's a hold, so the continuous-
-	// automation throttle treats it like a success to avoid re-firing on every
-	// distributed_write while the app stays open.
-	WasAppOpenSkip bool `db:"was_app_open_skip"`
+	// SkipReason classifies why the install ended without running (empty for success,
+	// pending, or ordinary failure). Callers use it to decide whether to throttle a
+	// continuous-automation re-fire, or to log the reason for a skipped run.
+	SkipReason SoftwareInstallSkipReason
 }
 
 // HostSoftwareInstaller represents a software installer package that has been installed on a host.

--- a/server/fleet/software_installer_test.go
+++ b/server/fleet/software_installer_test.go
@@ -475,3 +475,67 @@ func TestValidateTitlePackages(t *testing.T) {
 		})
 	}
 }
+
+func TestClassifySoftwareInstallSkipReason(t *testing.T) {
+	failed := SoftwareInstallFailed
+	installed := SoftwareInstalled
+	pending := SoftwareInstallPending
+
+	cases := []struct {
+		name                  string
+		status                *SoftwareInstallerStatus
+		patchWhenClosed       bool
+		preInstallOutputEmpty bool
+		want                  SoftwareInstallSkipReason
+	}{
+		{
+			name:                  "patch-when-closed with empty pre-install output classifies as app-open skip",
+			status:                &failed,
+			patchWhenClosed:       true,
+			preInstallOutputEmpty: true,
+			want:                  SoftwareInstallSkipReasonAppOpen,
+		},
+		{
+			name:                  "empty pre-install output on a non-patch-when-closed policy is a plain failure",
+			status:                &failed,
+			patchWhenClosed:       false,
+			preInstallOutputEmpty: true,
+			want:                  SoftwareInstallSkipReasonNone,
+		},
+		{
+			name:                  "patch-when-closed with non-empty pre-install output is an install-script failure",
+			status:                &failed,
+			patchWhenClosed:       true,
+			preInstallOutputEmpty: false,
+			want:                  SoftwareInstallSkipReasonNone,
+		},
+		{
+			name:                  "successful install is never a skip",
+			status:                &installed,
+			patchWhenClosed:       true,
+			preInstallOutputEmpty: true,
+			want:                  SoftwareInstallSkipReasonNone,
+		},
+		{
+			name:                  "pending install is never a skip",
+			status:                &pending,
+			patchWhenClosed:       true,
+			preInstallOutputEmpty: true,
+			want:                  SoftwareInstallSkipReasonNone,
+		},
+		{
+			name:                  "nil status (row without a resolved terminal state) is never a skip",
+			status:                nil,
+			patchWhenClosed:       true,
+			preInstallOutputEmpty: true,
+			want:                  SoftwareInstallSkipReasonNone,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ClassifySoftwareInstallSkipReason(tc.status, tc.patchWhenClosed, tc.preInstallOutputEmpty)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -1215,7 +1215,7 @@ func (s *integrationTestSuite) TestTranslator() {
 
 func (s *integrationTestSuite) TestSoftwareChecksumReconciliation() {
 	t := s.T()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	newHost := func(suffix string) *fleet.Host {
 		h, err := s.ds.NewHost(ctx, &fleet.Host{

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -1860,16 +1860,23 @@ func (svc *Service) SaveHostSoftwareInstallResult(ctx context.Context, result *f
 		return err
 	}
 
-	// A patch-when-closed policy install whose managed app-open query returned no result means the
-	// app was open: a skip, not a failure. Key on the policy flag, not empty output, so an ordinary
-	// empty pre_install_query on a non-managed policy still fails and counts toward the retry cap.
-	isAppOpenSkip := false
-	if result.Status() == fleet.SoftwareInstallFailed &&
-		result.PreInstallConditionOutput != nil && *result.PreInstallConditionOutput == "" {
+	// Classify the incoming result: an app-open skip on a patch-when-closed policy is
+	// treated as a hold, not a retryable failure. Route through the shared classifier so
+	// the read path (throttle) and write path here share one definition of "what counts
+	// as a skip." Guard the DB lookup on status = failed to avoid an extra fetch on
+	// success/pending rows.
+	skipReason := fleet.SoftwareInstallSkipReasonNone
+	if result.Status() == fleet.SoftwareInstallFailed {
 		if cur, curErr := svc.ds.GetSoftwareInstallResults(ctx, result.InstallUUID); curErr == nil && cur != nil {
-			isAppOpenSkip = cur.PolicyID != nil && cur.PatchWhenClosed
+			status := result.Status()
+			skipReason = fleet.ClassifySoftwareInstallSkipReason(
+				&status,
+				cur.PolicyID != nil && cur.PatchWhenClosed,
+				result.PreInstallConditionOutput != nil && *result.PreInstallConditionOutput == "",
+			)
 		}
 	}
+	isAppOpenSkip := skipReason == fleet.SoftwareInstallSkipReasonAppOpen
 
 	// Check if a non-policy install failure will be retried so we can skip
 	// updating setup experience status during intermediate retries.

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -2405,15 +2405,22 @@ func (svc *Service) processSoftwareForNewlyFailingPolicies(
 		// retry path (see shouldRetryPolicyAutomationSoftwareInstall).
 		// See continuousAutomationOnCooldown.
 		if !newlyFailing && failingPolicyWithInstaller.ContinuousAutomationsEnabled &&
-			hostLastInstall != nil && hostLastInstall.Status != nil &&
-			(*hostLastInstall.Status == fleet.SoftwareInstalled || hostLastInstall.WasAppOpenSkip) &&
-			svc.continuousAutomationOnCooldown(hostLastInstall.UpdatedAt) {
-			logger.InfoContext(ctx, "skipping continuous policy automation install; within policy update interval cooldown",
-				"last_install_execution_id", hostLastInstall.ExecutionID,
-				"last_install_at", hostLastInstall.UpdatedAt,
-				"was_app_open_skip", hostLastInstall.WasAppOpenSkip,
-			)
-			continue
+			hostLastInstall != nil && hostLastInstall.Status != nil {
+			var throttleReason string
+			switch {
+			case *hostLastInstall.Status == fleet.SoftwareInstalled:
+				throttleReason = "recent_success"
+			case hostLastInstall.SkipReason == fleet.SoftwareInstallSkipReasonAppOpen:
+				throttleReason = "app_open_skip"
+			}
+			if throttleReason != "" && svc.continuousAutomationOnCooldown(hostLastInstall.UpdatedAt) {
+				logger.InfoContext(ctx, "skipping continuous policy automation install; within policy update interval cooldown",
+					"last_install_execution_id", hostLastInstall.ExecutionID,
+					"last_install_at", hostLastInstall.UpdatedAt,
+					"reason", throttleReason,
+				)
+				continue
+			}
 		}
 
 		// On a continuous re-fire (policy still failing), reset prior

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -2242,12 +2242,16 @@ func (svc *Service) registerFlippedPolicies(ctx context.Context, hostID uint, ho
 // last fired (queued an install) at lastFiredAt should be skipped on this run.
 //
 // Continuous automations re-fire on every failing policy result, not just on
-// pass→fail transitions. A successful install requests a host vitals refetch, and a
-// refetch makes policies re-run immediately (bypassing the policy update interval).
-// If the policy keeps failing, that creates a tight install→refetch→re-run→install
-// loop. We throttle continuous re-fires to at most once per policy update interval so
-// a perpetually-failing policy retries on the next interval (~1h) instead of
-// continuously. A zero lastFiredAt (no prior automation install) is never on cooldown.
+// pass→fail transitions. Two cases produce a rapid re-fire loop the caller wants to
+// dampen to at most once per policy update interval:
+//   - A successful install requests a host vitals refetch, and a refetch makes policies
+//     re-run immediately (bypassing the policy update interval). If the policy keeps
+//     failing, that creates a tight install→refetch→re-run→install loop.
+//   - A patch-when-closed app-open skip leaves the policy failing without triggering
+//     a refetch, but any refetch from another source (manual, another automation) will
+//     re-fire the policy and queue another skip immediately.
+//
+// A zero lastFiredAt (no prior automation install) is never on cooldown.
 func (svc *Service) continuousAutomationOnCooldown(lastFiredAt time.Time) bool {
 	if lastFiredAt.IsZero() {
 		return false
@@ -2389,20 +2393,25 @@ func (svc *Service) processSoftwareForNewlyFailingPolicies(
 		}
 
 		// Throttle continuous policy automation re-installs: if this policy fired only
-		// because continuous_automations_enabled is set (not a pass→fail transition)
-		// and we already queued a successful install within the policy update interval,
-		// skip it. This prevents a tight install→refetch→re-run loop when the install
-		// succeeds but never makes the policy pass. We only throttle on a successful
-		// install because only success requests the refetch that drives the loop; failed
-		// installs are retried via the dedicated retry path (see
-		// shouldRetryPolicyAutomationSoftwareInstall). See continuousAutomationOnCooldown.
+		// because continuous_automations_enabled is set (not a pass→fail transition),
+		// skip re-firing while the last install completed within the policy update
+		// interval. Two throttled cases:
+		//   - Successful install: prevents a tight install→refetch→re-run loop, since
+		//     success is what requests the refetch that drives the loop.
+		//   - App-open skip on a patch-when-closed policy: the skip is a hold until
+		//     the user closes the app, not a retryable failure, so we wait one policy
+		//     cycle instead of re-firing on every distributed_write.
+		// Ordinary failed installs skip this throttle: they retry via the dedicated
+		// retry path (see shouldRetryPolicyAutomationSoftwareInstall).
+		// See continuousAutomationOnCooldown.
 		if !newlyFailing && failingPolicyWithInstaller.ContinuousAutomationsEnabled &&
 			hostLastInstall != nil && hostLastInstall.Status != nil &&
-			*hostLastInstall.Status == fleet.SoftwareInstalled &&
+			(*hostLastInstall.Status == fleet.SoftwareInstalled || hostLastInstall.WasAppOpenSkip) &&
 			svc.continuousAutomationOnCooldown(hostLastInstall.UpdatedAt) {
 			logger.InfoContext(ctx, "skipping continuous policy automation install; within policy update interval cooldown",
 				"last_install_execution_id", hostLastInstall.ExecutionID,
 				"last_install_at", hostLastInstall.UpdatedAt,
+				"was_app_open_skip", hostLastInstall.WasAppOpenSkip,
 			)
 			continue
 		}

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -5597,32 +5597,32 @@ func TestProcessSoftwareForNewlyFailingPoliciesContinuousCooldown(t *testing.T) 
 	installed := fleet.SoftwareInstalled
 	failedInstall := fleet.SoftwareInstallFailed
 
-	setLastInstall := func(status *fleet.SoftwareInstallerStatus, updatedAt time.Time, wasAppOpenSkip bool) {
+	setLastInstall := func(status *fleet.SoftwareInstallerStatus, updatedAt time.Time, skipReason fleet.SoftwareInstallSkipReason) {
 		ds.GetHostLastInstallDataFunc = func(ctx context.Context, hostID, installerID uint) (*fleet.HostLastInstallData, error) {
 			return &fleet.HostLastInstallData{
-				ExecutionID:    "prev-exec",
-				Status:         status,
-				UpdatedAt:      updatedAt,
-				WasAppOpenSkip: wasAppOpenSkip,
+				ExecutionID: "prev-exec",
+				Status:      status,
+				UpdatedAt:   updatedAt,
+				SkipReason:  skipReason,
 			}, nil
 		}
 	}
 
 	// Continuous re-fire with a recent successful install => throttled.
 	insertCalled = false
-	setLastInstall(&installed, now.Add(-10*time.Minute), false)
+	setLastInstall(&installed, now.Add(-10*time.Minute), fleet.SoftwareInstallSkipReasonNone)
 	require.NoError(t, svcImpl.processSoftwareForNewlyFailingPolicies(ctx, hostID, nil, "darwin", &orbitKey, "", failing, noNewlyFailing))
 	require.False(t, insertCalled, "continuous install should be throttled within the policy update interval")
 
 	// Continuous re-fire after the interval elapsed => fires.
 	insertCalled = false
-	setLastInstall(&installed, now.Add(-2*time.Hour), false)
+	setLastInstall(&installed, now.Add(-2*time.Hour), fleet.SoftwareInstallSkipReasonNone)
 	require.NoError(t, svcImpl.processSoftwareForNewlyFailingPolicies(ctx, hostID, nil, "darwin", &orbitKey, "", failing, noNewlyFailing))
 	require.True(t, insertCalled, "continuous install should fire once the cooldown elapses")
 
 	// Newly failing (pass→fail) bypasses the cooldown even with a recent install.
 	insertCalled = false
-	setLastInstall(&installed, now.Add(-1*time.Minute), false)
+	setLastInstall(&installed, now.Add(-1*time.Minute), fleet.SoftwareInstallSkipReasonNone)
 	require.NoError(t, svcImpl.processSoftwareForNewlyFailingPolicies(ctx, hostID, nil, "darwin", &orbitKey, "", failing, map[uint]struct{}{policyID: {}}))
 	require.True(t, insertCalled, "newly-failing install should fire regardless of cooldown")
 
@@ -5630,27 +5630,13 @@ func TestProcessSoftwareForNewlyFailingPoliciesContinuousCooldown(t *testing.T) 
 	// request the refetch that drives the loop, and failures are retried via the
 	// dedicated retry path.
 	insertCalled = false
-	setLastInstall(&failedInstall, now.Add(-1*time.Minute), false)
+	setLastInstall(&failedInstall, now.Add(-1*time.Minute), fleet.SoftwareInstallSkipReasonNone)
 	require.NoError(t, svcImpl.processSoftwareForNewlyFailingPolicies(ctx, hostID, nil, "darwin", &orbitKey, "", failing, noNewlyFailing))
 	require.True(t, insertCalled, "continuous install should fire when the recent install failed")
 
-	// A recent patch-when-closed app-open skip within the interval => throttled.
-	// The skip is a hold until the user closes the app, not a retryable failure, so we
-	// wait one policy cycle instead of re-firing on every distributed_write.
-	insertCalled = false
-	setLastInstall(&failedInstall, now.Add(-1*time.Minute), true)
-	require.NoError(t, svcImpl.processSoftwareForNewlyFailingPolicies(ctx, hostID, nil, "darwin", &orbitKey, "", failing, noNewlyFailing))
-	require.False(t, insertCalled, "app-open skip should throttle continuous re-fires within the policy update interval")
-
-	// After the cooldown elapses, an app-open skip stops throttling => fires again.
-	insertCalled = false
-	setLastInstall(&failedInstall, now.Add(-2*time.Hour), true)
-	require.NoError(t, svcImpl.processSoftwareForNewlyFailingPolicies(ctx, hostID, nil, "darwin", &orbitKey, "", failing, noNewlyFailing))
-	require.True(t, insertCalled, "continuous install should fire again once the app-open cooldown elapses")
-
 	// A recent install with nil status (installed then removed) does not throttle.
 	insertCalled = false
-	setLastInstall(nil, now.Add(-1*time.Minute), false)
+	setLastInstall(nil, now.Add(-1*time.Minute), fleet.SoftwareInstallSkipReasonNone)
 	require.NoError(t, svcImpl.processSoftwareForNewlyFailingPolicies(ctx, hostID, nil, "darwin", &orbitKey, "", failing, noNewlyFailing))
 	require.True(t, insertCalled, "continuous install should fire when the recent install has no resolved status")
 
@@ -5661,6 +5647,22 @@ func TestProcessSoftwareForNewlyFailingPoliciesContinuousCooldown(t *testing.T) 
 	}
 	require.NoError(t, svcImpl.processSoftwareForNewlyFailingPolicies(ctx, hostID, nil, "darwin", &orbitKey, "", failing, noNewlyFailing))
 	require.True(t, insertCalled, "install should fire when there is no prior install")
+
+	// Sequenced check that the throttle both engages AND releases on the same skip row:
+	// T=0 skip → T=30min re-fire throttled → T=61min re-fire queues a fresh install. Proves
+	// the throttle actually releases on the same row rather than testing engage and release
+	// on two separately-configured rows as the isolated cases above do.
+	setLastInstall(&failedInstall, now, fleet.SoftwareInstallSkipReasonAppOpen)
+
+	insertCalled = false
+	mockClock.AddTime(30 * time.Minute)
+	require.NoError(t, svcImpl.processSoftwareForNewlyFailingPolicies(ctx, hostID, nil, "darwin", &orbitKey, "", failing, noNewlyFailing))
+	require.False(t, insertCalled, "app-open skip 30m in must still be throttling continuous re-fires")
+
+	insertCalled = false
+	mockClock.AddTime(31 * time.Minute)
+	require.NoError(t, svcImpl.processSoftwareForNewlyFailingPolicies(ctx, hostID, nil, "darwin", &orbitKey, "", failing, noNewlyFailing))
+	require.True(t, insertCalled, "app-open skip 61m in must have released the throttle so the next cycle can queue")
 }
 
 // TestProcessVPPForNewlyFailingPoliciesContinuousCooldown is the VPP analog of

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -5649,20 +5649,42 @@ func TestProcessSoftwareForNewlyFailingPoliciesContinuousCooldown(t *testing.T) 
 	require.True(t, insertCalled, "install should fire when there is no prior install")
 
 	// Sequenced check that the throttle both engages AND releases on the same skip row:
-	// T=0 skip → T=30min re-fire throttled → T=70min re-fire queues a fresh install. Proves
-	// the throttle actually releases on the same row rather than testing engage and release
-	// on two separately-configured rows as the isolated cases above do.
-	setLastInstall(&failedInstall, now, fleet.SoftwareInstallSkipReasonAppOpen)
+	// T=0 skip → T=30min re-fire throttled → T=70min re-fire queues a fresh install.
+	// Proves the throttle actually releases on the same row rather than testing engage
+	// and release on two separately-configured rows as the isolated cases above do.
+	//
+	// Isolate to a sub-test with its own mock clock so time advancement stays scoped:
+	// the cases above (and any added below) reference `now` captured at T=0 and would
+	// break silently if this block left the shared clock 70min in the future.
+	t.Run("app-open skip throttles then releases on the same row", func(t *testing.T) {
+		subClock := clock.NewMockClock()
+		subSvc, subCtx := newTestServiceWithConfig(t, ds, config.TestConfig(), nil, nil, &TestServerOpts{Clock: subClock})
+		subSvcImpl := subSvc.(validationMiddleware).Service.(*Service)
+		subNow := subClock.Now()
 
-	insertCalled = false
-	mockClock.AddTime(30 * time.Minute)
-	require.NoError(t, svcImpl.processSoftwareForNewlyFailingPolicies(ctx, hostID, nil, "darwin", &orbitKey, "", failing, noNewlyFailing))
-	require.False(t, insertCalled, "app-open skip 30m in must still be throttling continuous re-fires")
+		// Sub-test overrides GetHostLastInstallDataFunc to seed an app-open skip; restore
+		// on exit so mock state doesn't leak to any case added after this block.
+		prevGetHostLastInstall := ds.GetHostLastInstallDataFunc
+		defer func() { ds.GetHostLastInstallDataFunc = prevGetHostLastInstall }()
+		ds.GetHostLastInstallDataFunc = func(ctx context.Context, hostID, installerID uint) (*fleet.HostLastInstallData, error) {
+			return &fleet.HostLastInstallData{
+				ExecutionID: "prev-exec",
+				Status:      &failedInstall,
+				UpdatedAt:   subNow,
+				SkipReason:  fleet.SoftwareInstallSkipReasonAppOpen,
+			}, nil
+		}
 
-	insertCalled = false
-	mockClock.AddTime(40 * time.Minute)
-	require.NoError(t, svcImpl.processSoftwareForNewlyFailingPolicies(ctx, hostID, nil, "darwin", &orbitKey, "", failing, noNewlyFailing))
-	require.True(t, insertCalled, "app-open skip 70m in must have released the throttle so the next cycle can queue")
+		insertCalled = false
+		subClock.AddTime(30 * time.Minute)
+		require.NoError(t, subSvcImpl.processSoftwareForNewlyFailingPolicies(subCtx, hostID, nil, "darwin", &orbitKey, "", failing, noNewlyFailing))
+		require.False(t, insertCalled, "app-open skip 30m in must still be throttling continuous re-fires")
+
+		insertCalled = false
+		subClock.AddTime(40 * time.Minute)
+		require.NoError(t, subSvcImpl.processSoftwareForNewlyFailingPolicies(subCtx, hostID, nil, "darwin", &orbitKey, "", failing, noNewlyFailing))
+		require.True(t, insertCalled, "app-open skip 70m in must have released the throttle so the next cycle can queue")
+	})
 }
 
 // TestProcessVPPForNewlyFailingPoliciesContinuousCooldown is the VPP analog of

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -5597,40 +5597,60 @@ func TestProcessSoftwareForNewlyFailingPoliciesContinuousCooldown(t *testing.T) 
 	installed := fleet.SoftwareInstalled
 	failedInstall := fleet.SoftwareInstallFailed
 
-	setLastInstall := func(status *fleet.SoftwareInstallerStatus, updatedAt time.Time) {
+	setLastInstall := func(status *fleet.SoftwareInstallerStatus, updatedAt time.Time, wasAppOpenSkip bool) {
 		ds.GetHostLastInstallDataFunc = func(ctx context.Context, hostID, installerID uint) (*fleet.HostLastInstallData, error) {
-			return &fleet.HostLastInstallData{ExecutionID: "prev-exec", Status: status, UpdatedAt: updatedAt}, nil
+			return &fleet.HostLastInstallData{
+				ExecutionID:    "prev-exec",
+				Status:         status,
+				UpdatedAt:      updatedAt,
+				WasAppOpenSkip: wasAppOpenSkip,
+			}, nil
 		}
 	}
 
 	// Continuous re-fire with a recent successful install => throttled.
 	insertCalled = false
-	setLastInstall(&installed, now.Add(-10*time.Minute))
+	setLastInstall(&installed, now.Add(-10*time.Minute), false)
 	require.NoError(t, svcImpl.processSoftwareForNewlyFailingPolicies(ctx, hostID, nil, "darwin", &orbitKey, "", failing, noNewlyFailing))
 	require.False(t, insertCalled, "continuous install should be throttled within the policy update interval")
 
 	// Continuous re-fire after the interval elapsed => fires.
 	insertCalled = false
-	setLastInstall(&installed, now.Add(-2*time.Hour))
+	setLastInstall(&installed, now.Add(-2*time.Hour), false)
 	require.NoError(t, svcImpl.processSoftwareForNewlyFailingPolicies(ctx, hostID, nil, "darwin", &orbitKey, "", failing, noNewlyFailing))
 	require.True(t, insertCalled, "continuous install should fire once the cooldown elapses")
 
 	// Newly failing (pass→fail) bypasses the cooldown even with a recent install.
 	insertCalled = false
-	setLastInstall(&installed, now.Add(-1*time.Minute))
+	setLastInstall(&installed, now.Add(-1*time.Minute), false)
 	require.NoError(t, svcImpl.processSoftwareForNewlyFailingPolicies(ctx, hostID, nil, "darwin", &orbitKey, "", failing, map[uint]struct{}{policyID: {}}))
 	require.True(t, insertCalled, "newly-failing install should fire regardless of cooldown")
 
-	// A recent FAILED install does not throttle: only successful installs request the
-	// refetch that drives the loop, and failures are retried via the dedicated path.
+	// A recent ordinary failed install does not throttle: only successful installs
+	// request the refetch that drives the loop, and failures are retried via the
+	// dedicated retry path.
 	insertCalled = false
-	setLastInstall(&failedInstall, now.Add(-1*time.Minute))
+	setLastInstall(&failedInstall, now.Add(-1*time.Minute), false)
 	require.NoError(t, svcImpl.processSoftwareForNewlyFailingPolicies(ctx, hostID, nil, "darwin", &orbitKey, "", failing, noNewlyFailing))
 	require.True(t, insertCalled, "continuous install should fire when the recent install failed")
 
+	// A recent patch-when-closed app-open skip within the interval => throttled.
+	// The skip is a hold until the user closes the app, not a retryable failure, so we
+	// wait one policy cycle instead of re-firing on every distributed_write.
+	insertCalled = false
+	setLastInstall(&failedInstall, now.Add(-1*time.Minute), true)
+	require.NoError(t, svcImpl.processSoftwareForNewlyFailingPolicies(ctx, hostID, nil, "darwin", &orbitKey, "", failing, noNewlyFailing))
+	require.False(t, insertCalled, "app-open skip should throttle continuous re-fires within the policy update interval")
+
+	// After the cooldown elapses, an app-open skip stops throttling => fires again.
+	insertCalled = false
+	setLastInstall(&failedInstall, now.Add(-2*time.Hour), true)
+	require.NoError(t, svcImpl.processSoftwareForNewlyFailingPolicies(ctx, hostID, nil, "darwin", &orbitKey, "", failing, noNewlyFailing))
+	require.True(t, insertCalled, "continuous install should fire again once the app-open cooldown elapses")
+
 	// A recent install with nil status (installed then removed) does not throttle.
 	insertCalled = false
-	setLastInstall(nil, now.Add(-1*time.Minute))
+	setLastInstall(nil, now.Add(-1*time.Minute), false)
 	require.NoError(t, svcImpl.processSoftwareForNewlyFailingPolicies(ctx, hostID, nil, "darwin", &orbitKey, "", failing, noNewlyFailing))
 	require.True(t, insertCalled, "continuous install should fire when the recent install has no resolved status")
 

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -5649,7 +5649,7 @@ func TestProcessSoftwareForNewlyFailingPoliciesContinuousCooldown(t *testing.T) 
 	require.True(t, insertCalled, "install should fire when there is no prior install")
 
 	// Sequenced check that the throttle both engages AND releases on the same skip row:
-	// T=0 skip → T=30min re-fire throttled → T=61min re-fire queues a fresh install. Proves
+	// T=0 skip → T=30min re-fire throttled → T=70min re-fire queues a fresh install. Proves
 	// the throttle actually releases on the same row rather than testing engage and release
 	// on two separately-configured rows as the isolated cases above do.
 	setLastInstall(&failedInstall, now, fleet.SoftwareInstallSkipReasonAppOpen)
@@ -5660,9 +5660,9 @@ func TestProcessSoftwareForNewlyFailingPoliciesContinuousCooldown(t *testing.T) 
 	require.False(t, insertCalled, "app-open skip 30m in must still be throttling continuous re-fires")
 
 	insertCalled = false
-	mockClock.AddTime(31 * time.Minute)
+	mockClock.AddTime(40 * time.Minute)
 	require.NoError(t, svcImpl.processSoftwareForNewlyFailingPolicies(ctx, hostID, nil, "darwin", &orbitKey, "", failing, noNewlyFailing))
-	require.True(t, insertCalled, "app-open skip 61m in must have released the throttle so the next cycle can queue")
+	require.True(t, insertCalled, "app-open skip 70m in must have released the throttle so the next cycle can queue")
 }
 
 // TestProcessVPPForNewlyFailingPoliciesContinuousCooldown is the VPP analog of


### PR DESCRIPTION
> [!IMPORTANT]
> **DO NOT REVIEW YET** — I still need to test the fix locally and review it myself before this is ready. Please hold off on all reviews until I mark this ready.

## Issue
Closes #51820

## Description
- Bug fix (root cause): a patch-when-closed policy install that returned because the app was open stored as `failed_install` and correctly cleared the retry ladder, but the continuous policy automation cooldown in `processSoftwareForNewlyFailingPolicies` only engaged for `SoftwareInstalled`. Any refetch (manual, or from another automation) would re-fire the policy and queue another skip immediately, producing a rapid burst of "Fleet skipped install" activities while the app stayed open.
- Fix: expose a `WasAppOpenSkip` flag on `HostLastInstallData` (patch-when-closed policy + empty `pre_install_query_output`) and treat it like a successful install for the cooldown so the automation waits one `policy_update_interval` before firing again. Ordinary failed installs still bypass the throttle and retry via the dedicated retry path.

## Screenrecording
- Continuous automation re-firing behavior against a running app

Only 1 activity shows up for failing a patch when app is closed fails due to app being open

https://github.com/user-attachments/assets/082b96c5-87bd-4ee9-8248-d494a7bf0307

On refetch, it doesn't requeue to try to patch when app is closes

https://github.com/user-attachments/assets/568053fa-9109-41e8-8050-539bb4b845f9


## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually