### PR TITLE
Repoint the IntelliJ IDEA CE software catalog redirect at IntelliJ IDEA

### DIFF
--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -1079,7 +1079,7 @@ module.exports.routes = {
   'GET /software-catalog/imazing': '/software-catalog/imazing-darwin',
   'GET /software-catalog/imazing-profile-editor': '/software-catalog/imazing-darwin',
   'GET /software-catalog/insomnia': '/software-catalog/insomnia-darwin',
-  'GET /software-catalog/intellij-idea-ce': '/software-catalog/intellij-idea-ce-darwin',
+  'GET /software-catalog/intellij-idea-ce': '/software-catalog/intellij-idea-darwin',
   'GET /software-catalog/intellij-idea': '/software-catalog/intellij-idea-darwin',
   'GET /software-catalog/little-snitch': '/software-catalog/little-snitch-darwin',
   'GET /software-catalog/intune-company-portal': '/software-catalog/intune-company-portal-darwin',


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** NA — website follow-up to #51886

## What changed

```diff
-  'GET /software-catalog/intellij-idea-ce': '/software-catalog/intellij-idea-ce-darwin',
+  'GET /software-catalog/intellij-idea-ce': '/software-catalog/intellij-idea-darwin',
```

## Why

JetBrains unified the IntelliJ IDEA distribution starting with 2025.3 — the Community and Ultimate editions now ship as a single installer, and the last Community-only release was 2025.2.6. #51886 retires the IntelliJ IDEA CE Fleet-maintained app on both platforms as a result, which removes its two entries from `ee/maintained-apps/outputs/apps.json`.

The website builds `sails.config.builtStaticContent.appLibrary` from that file, and `api/controllers/docs/view-app-details.js` throws `notFound` for any identifier missing from it. So once #51886 merges, the existing redirect sends visitors to `intellij-idea-ce-darwin`, which is a 404.

Pointing it at the unified IntelliJ IDEA page keeps the old URL working and lands people on the product that actually succeeds CE. This follows the existing cross-app alias precedent a few lines up:

```js
'GET /software-catalog/imazing-profile-editor': '/software-catalog/imazing-darwin',
```

## Notes for reviewers

- **Split out of #51886 deliberately.** `website/config/routes.js` is owned by @eashaw per `website/config/custom.js`, so keeping it separate avoids blocking an FMA manifest change on a website review.
- **Merge order:** this is only *needed* once #51886 lands, but it's harmless before then — `intellij-idea-darwin` exists on `main` today, so the redirect is valid either way. No ordering constraint.
- **Alternative considered:** deleting the redirect line outright. That also resolves the dangling target, but turns a working URL into a 404 rather than sending people somewhere useful. Happy to switch if you'd rather retire the URL entirely.
- Branched off `main`, not off #51886 — the two PRs touch disjoint files and won't conflict.

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

  The redirect target is a hardcoded relative path — no user input, no open-redirect surface.

## Testing

- [x] QA'd all new/changed functionality manually

- `node -e "require('./website/config/routes.js')"` — parses.
- Confirmed `intellij-idea/darwin` is present in `ee/maintained-apps/outputs/apps.json` on `main`, so `intellij-idea-darwin` resolves in `appLibrary` today and after #51886.
- Traced the 404: `routes.js` catch-all `GET /software-catalog/:appIdentifier` → `docs/view-app-details` → `_.find(appLibrary, {identifier})` → `throw 'notFound'`.

No `changes/` file — website redirect only, no user-visible Fleet product change.

Not applicable: automated tests, frontend screenshots, database migrations, new Fleet configuration settings, fleetd/orbit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the IntelliJ IDEA Community Edition redirect to point to the appropriate software catalog page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->