### PR TITLE
Consolidate the IntelliJ IDEA open-query overrides (drop CE, rename Ultimate)

### DIFF
--- a/pkg/patch_policy/patch_policy.go
+++ b/pkg/patch_policy/patch_policy.go
@@ -209,7 +209,7 @@ var windowsOpenQueryOverrides = map[string]string{ //nolint:gosec // G101 false 
 	"GoLand":                       "IN ('goland.exe','goland64.exe')",
 	"Google Antigravity IDE":       "= 'antigravity.exe'",
 	"Google Chrome":                "= 'chrome.exe'",
-	"IntelliJ IDEA Ultimate":       "IN ('idea.exe','idea64.exe')",
+	"IntelliJ IDEA":                "IN ('idea.exe','idea64.exe')",
 	"JetBrains Toolbox":            "IN ('toolbox.exe','jetbrains-toolbox.exe')",
 	"KNIME Analytics Platform":     "= 'knime.exe'",
 	"Lenovo Dock Manager":          "= 'dockmgr.exe'",

--- a/pkg/patch_policy/patch_policy.go
+++ b/pkg/patch_policy/patch_policy.go
@@ -209,7 +209,6 @@ var windowsOpenQueryOverrides = map[string]string{ //nolint:gosec // G101 false 
 	"GoLand":                       "IN ('goland.exe','goland64.exe')",
 	"Google Antigravity IDE":       "= 'antigravity.exe'",
 	"Google Chrome":                "= 'chrome.exe'",
-	"IntelliJ IDEA CE":             "IN ('idea.exe','idea64.exe')",
 	"IntelliJ IDEA Ultimate":       "IN ('idea.exe','idea64.exe')",
 	"JetBrains Toolbox":            "IN ('toolbox.exe','jetbrains-toolbox.exe')",
 	"KNIME Analytics Platform":     "= 'knime.exe'",


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** NA — cleanup follow-up to #51886

## What changed

```diff
 	"Google Chrome":                "= 'chrome.exe'",
-	"IntelliJ IDEA CE":             "IN ('idea.exe','idea64.exe')",
 	"IntelliJ IDEA Ultimate":       "IN ('idea.exe','idea64.exe')",
```

## Why

JetBrains unified the IntelliJ IDEA distribution starting with 2025.3 — the Community and Ultimate editions now ship as a single installer, and the last Community-only release was 2025.2.6. #51886 retires the IntelliJ IDEA CE Fleet-maintained app on both platforms.

`windowsOpenQueryOverrides` is keyed by FMA name and read only by the winget ingester, via `GenerateOpenQuery("windows", "", out.Name)`. With no FMA named `IntelliJ IDEA CE`, the entry is unreachable.

I checked the whole map rather than just this one key — after #51886 it's the only dead entry, so this is the complete cleanup, not a sample:

```
51 override keys, 433 Windows FMAs
keys with no matching Windows FMA (1):
    IntelliJ IDEA CE
```

## ⚠️ Merge this BEFORE #51886

**This supersedes the earlier "merge after #51886" note — the order is now reversed**, because all `windowsOpenQueryOverrides` edits moved into this PR.

The ingester resolves the override by FMA name (`GenerateOpenQuery("windows", "", out.Name)`). #51886 renames the FMA to `IntelliJ IDEA` and commits a regenerated manifest whose open query is `IN ('idea.exe','idea64.exe')` — which is only what the ingester produces once the renamed key here is on `main`. So this lands first, then #51886.

### Known transient window

Between this merging and #51886 merging, `main` has the new key but the FMAs still carry their old names, so a regeneration in that gap produces fallback open queries:

| FMA (old name, still on main) | Open query in the gap |
|---|---|
| IntelliJ IDEA Ultimate | `= 'intellij idea ultimate.exe'` |
| IntelliJ IDEA CE | `= 'intellij idea ce.exe'` |

Neither process exists, so the pre-install "app is closed" check would pass unconditionally and Fleet could install over a running IDE. #51886 resolves both — it renames the one and deletes the other.

**How long is the gap?** `ingest-maintained-apps.yml` runs on a 4-hourly cron, and also on any push to `main` touching `ee/maintained-apps/**`. This PR touches only `pkg/`, so merging it does *not* trigger an immediate ingest — the exposure is bounded by the cron. Merging the two PRs back to back keeps it at zero in practice.

I went with this order because the alternative is worse: with #51886 first, its committed manifest would be wrong on arrival, *and* merging it fires the path-triggered ingest immediately rather than waiting on the cron.

## Notes for reviewers

- Generation-time only. The override is baked into manifests when the ingester runs; nothing reads this map at query time, so no already-shipped manifest changes as a result of this PR.
- `IntelliJ IDEA Ultimate` keeps its identical `IN ('idea.exe','idea64.exe')` entry — the unified installer still runs as `idea64.exe`, so the surviving FMA is unaffected.
- Branched off `main`. Touches a different file from #51886 and #51888, so no conflicts between the three.

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

  Deletion only — no new query construction. The surrounding `escapeSQLLiteral` handling is untouched.

## Testing

- [x] QA'd all new/changed functionality manually

- `go test ./pkg/patch_policy/... ./ee/maintained-apps/...` — passing.
- `go build ./pkg/patch_policy/...` — clean.
- `gofmt -l pkg/patch_policy/` — clean. Map alignment is unchanged; the removed key was shorter than the `"Microsoft Visual Studio Code"` key that sets the column width.
- Audited all 51 override keys against the 433 Windows FMAs in `apps.json` to confirm `IntelliJ IDEA CE` is the only unreachable entry. The audit was run on the #51886 branch, where the CE FMA is already removed — that's what makes it show as dead. On `main` today the map has no dead keys at all.
- `gofmt -l pkg/patch_policy/` — clean. Alignment is unchanged; the column is set by `"Microsoft Visual Studio Code"`, which is longer than either key touched here.

No `changes/` file — dead-code removal with no user-visible behavior change.

Not applicable: automated tests, frontend screenshots, database migrations, new Fleet configuration settings, fleetd/orbit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consolidated Windows process-name handling for IntelliJ IDEA editions.
  * IntelliJ IDEA Ultimate and Community Edition now use the same override.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

