### PR TITLE
Use canonical EPSS feed URL (epss.empiricalsecurity.com)

### DIFF
--- a/changes/28807-change-epss-vuln-url.md
+++ b/changes/28807-change-epss-vuln-url.md
@@ -1,0 +1,1 @@
+- Updated the EPSS scores feed to download from its new canonical URL (`epss.empiricalsecurity.com`) instead of relying on the redirect from the old host (`epss.cyentia.com`).

--- a/server/vulnerabilities/nvd/sync.go
+++ b/server/vulnerabilities/nvd/sync.go
@@ -65,7 +65,7 @@ func Sync(ctx context.Context, opts SyncOptions, logger *slog.Logger) error {
 }
 
 const (
-	epssFeedsURL = "https://epss.cyentia.com"
+	epssFeedsURL = "https://epss.empiricalsecurity.com"
 	epssFilename = "epss_scores-current.csv.gz"
 )
 


### PR DESCRIPTION
Resolves #28807

The EPSS feed moved from epss.cyentia.com to epss.empiricalsecurity.com; stop relying on the third-party redirect.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the EPSS feed connection to use the provider’s current service address, ensuring vulnerability data synchronization continues to work reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->