### PR TITLE
Batch scheduled query name lookups when processing result logs

### DIFF
--- a/changes/17233-osquery-result-batch-query-lookup
+++ b/changes/17233-osquery-result-batch-query-lookup
@@ -1,0 +1,1 @@
+* Reduced database load when processing osquery result logs by resolving scheduled query names in a single batch lookup instead of one query per result.

--- a/server/datastore/cached_mysql/cached_mysql.go
+++ b/server/datastore/cached_mysql/cached_mysql.go
@@ -459,6 +459,12 @@ func (ds *cachedMysql) QueryByName(ctx context.Context, teamID *uint, name strin
 	return query, nil
 }
 
+// QueriesByName delegates straight to the underlying store: a batch lookup is
+// already a single round-trip, so there is nothing for the per-name cache to add.
+func (ds *cachedMysql) QueriesByName(ctx context.Context, names []fleet.TeamScopedQueryName) (map[string]*fleet.Query, error) {
+	return ds.Datastore.QueriesByName(ctx, names)
+}
+
 func (ds *cachedMysql) ResultCountForQuery(ctx context.Context, queryID uint) (int, error) {
 	key := fmt.Sprintf(queryResultsCountKey, queryID)
 

--- a/server/datastore/mysql/queries.go
+++ b/server/datastore/mysql/queries.go
@@ -201,27 +201,7 @@ func (ds *Datastore) QueryByName(
 	teamID *uint,
 	name string,
 ) (*fleet.Query, error) {
-	stmt := `
-		SELECT
-			id,
-			team_id,
-			name,
-			description,
-			query,
-			author_id,
-			saved,
-			observer_can_run,
-			schedule_interval,
-			platform,
-			min_osquery_version,
-			automations_enabled,
-			logging_type,
-			discard_data,
-			created_at,
-			updated_at
-		FROM queries
-		WHERE name = ?
-	`
+	stmt := `SELECT` + queryColumns + `FROM queries WHERE name = ?`
 	args := []interface{}{name}
 	whereClause := " AND team_id_char = ''"
 	if teamID != nil {
@@ -244,6 +224,92 @@ func (ds *Datastore) QueryByName(
 	}
 
 	return &query, nil
+}
+
+// queryColumns are the queries-table columns loaded by name lookups.
+const queryColumns = `
+	id,
+	team_id,
+	name,
+	description,
+	query,
+	author_id,
+	saved,
+	observer_can_run,
+	schedule_interval,
+	platform,
+	min_osquery_version,
+	automations_enabled,
+	logging_type,
+	discard_data,
+	created_at,
+	updated_at
+`
+
+// queriesByNameBatchSize bounds the tuple count per QueriesByName lookup. Each
+// tuple uses 2 bind params, so this keeps a statement well under MySQL's 65535
+// placeholder ceiling and the range optimizer's memory budget. A var so tests
+// can force the multi-batch path. See QueriesByName.
+var queriesByNameBatchSize = 1000
+
+// QueriesByName resolves multiple (team, name) pairs in one or more batched
+// lookups. The returned map is keyed by TeamScopedQueryName.Key() and contains
+// only the pairs that exist. It does NOT populate Query.Packs (callers needing
+// packs must load them separately); the result path that uses this only reads
+// query id/logging fields, and skipping the pack join keeps the lookup a single
+// indexed read per batch.
+func (ds *Datastore) QueriesByName(
+	ctx context.Context,
+	names []fleet.TeamScopedQueryName,
+) (map[string]*fleet.Query, error) {
+	result := make(map[string]*fleet.Query, len(names))
+	if len(names) == 0 {
+		return result, nil
+	}
+
+	// Dedupe on (team_id_char, name) up front so a submission repeating a name
+	// costs nothing extra, then resolve in bounded batches.
+	seen := make(map[string]struct{}, len(names))
+	deduped := make([]fleet.TeamScopedQueryName, 0, len(names))
+	for _, n := range names {
+		key := n.Key()
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		deduped = append(deduped, n)
+	}
+
+	for chunk := range slices.Chunk(deduped, queriesByNameBatchSize) {
+		var placeholders strings.Builder
+		args := make([]any, 0, len(chunk)*2)
+		for _, n := range chunk {
+			teamIDChar := ""
+			if n.TeamID != nil {
+				teamIDChar = fmt.Sprint(*n.TeamID)
+			}
+			if placeholders.Len() > 0 {
+				placeholders.WriteString(",")
+			}
+			placeholders.WriteString("(?,?)")
+			// Column order matches idx_name_team_id_unq (name, team_id_char) so
+			// the row-constructor IN uses the unique index as a range scan.
+			args = append(args, n.Name, teamIDChar)
+		}
+
+		stmt := `SELECT` + queryColumns + `FROM queries WHERE (name, team_id_char) IN (` + placeholders.String() + `)`
+		var queries []*fleet.Query
+		if err := sqlx.SelectContext(ctx, ds.reader(ctx), &queries, stmt, args...); err != nil {
+			// Return what earlier chunks resolved alongside the error. Callers that
+			// treat a failure as "nothing resolved" would otherwise turn one failing
+			// chunk into an empty result for the whole set.
+			return result, ctxerr.Wrap(ctx, err, "selecting queries by name")
+		}
+		for _, q := range queries {
+			result[fleet.TeamScopedQueryName{TeamID: q.TeamID, Name: q.Name}.Key()] = q
+		}
+	}
+	return result, nil
 }
 
 // queryLabelScopeStmt scopes a query to a host by label, as AND clauses ready to append to

--- a/server/datastore/mysql/queries_test.go
+++ b/server/datastore/mysql/queries_test.go
@@ -311,6 +311,57 @@ func testQueriesGetByName(t *testing.T, ds *Datastore) {
 	_, err = ds.QueryByName(context.Background(), &teamRocket.ID, "xxx")
 	require.Error(t, err)
 	require.True(t, fleet.IsNotFound(err))
+
+	// QueriesByName resolves many (team, name) pairs in one lookup, keeps global
+	// and same-named team queries distinct, and omits names that don't exist.
+	got, err := ds.QueriesByName(context.Background(), []fleet.TeamScopedQueryName{
+		{TeamID: nil, Name: "q1"},              // global q1
+		{TeamID: &teamRocket.ID, Name: "q1"},   // team q1, same name
+		{TeamID: nil, Name: "nope"},            // missing
+		{TeamID: &teamRocket.ID, Name: "nope"}, // missing
+		{TeamID: nil, Name: "q1"},              // duplicate of the first
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+
+	globalHit := got[fleet.TeamScopedQueryName{TeamID: nil, Name: "q1"}.Key()]
+	require.NotNil(t, globalHit)
+	require.Equal(t, globalQ.ID, globalHit.ID)
+	require.Nil(t, globalHit.TeamID)
+
+	teamHit := got[fleet.TeamScopedQueryName{TeamID: &teamRocket.ID, Name: "q1"}.Key()]
+	require.NotNil(t, teamHit)
+	require.Equal(t, teamRocketQ.ID, teamHit.ID)
+	require.Equal(t, teamRocket.ID, *teamHit.TeamID)
+
+	// A name that exists on one team must not resolve when requested for another
+	// team: the tuple scoping must be exact, not name-only.
+	teamB, err := ds.NewTeam(context.Background(), &fleet.Team{Name: "Team B", Description: "b"})
+	require.NoError(t, err)
+	crossTeam, err := ds.QueriesByName(context.Background(), []fleet.TeamScopedQueryName{
+		{TeamID: &teamB.ID, Name: "q1"}, // q1 exists globally and on teamRocket, not teamB
+	})
+	require.NoError(t, err)
+	require.Empty(t, crossTeam)
+
+	// Forcing a tiny batch size exercises the multi-chunk path: every existing
+	// pair must still resolve across chunk boundaries.
+	defer func(orig int) { queriesByNameBatchSize = orig }(queriesByNameBatchSize)
+	queriesByNameBatchSize = 1
+	chunked, err := ds.QueriesByName(context.Background(), []fleet.TeamScopedQueryName{
+		{TeamID: nil, Name: "q1"},
+		{TeamID: &teamRocket.ID, Name: "q1"},
+		{TeamID: nil, Name: "nope"},
+	})
+	require.NoError(t, err)
+	require.Len(t, chunked, 2)
+	require.NotNil(t, chunked[fleet.TeamScopedQueryName{TeamID: nil, Name: "q1"}.Key()])
+	require.NotNil(t, chunked[fleet.TeamScopedQueryName{TeamID: &teamRocket.ID, Name: "q1"}.Key()])
+
+	// Empty input must not hit the DB and returns an empty map.
+	empty, err := ds.QueriesByName(context.Background(), nil)
+	require.NoError(t, err)
+	require.Empty(t, empty)
 }
 
 func testQueriesDeleteMany(t *testing.T, ds *Datastore) {

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -136,6 +136,10 @@ type Datastore interface {
 	// QueryByName looks up a query by name on a team. If teamID is nil, then the query is looked up in
 	// the 'global' team.
 	QueryByName(ctx context.Context, teamID *uint, name string) (*Query, error)
+	// QueriesByName resolves multiple (team, name) pairs in a single lookup. The
+	// returned map is keyed by TeamScopedQueryName.Key() and contains only the
+	// pairs that exist; absent pairs are simply not in the map.
+	QueriesByName(ctx context.Context, names []TeamScopedQueryName) (map[string]*Query, error)
 	// QueriesPerHost returns the IDs of the saved queries that are scheduled for the given host,
 	// applying the same scoping ListScheduledQueriesForAgents uses to build the host's schedule.
 	// Both global and team queries are returned; teamID is the host's team, nil if it has none.

--- a/server/fleet/queries.go
+++ b/server/fleet/queries.go
@@ -49,6 +49,24 @@ type QueryPayload struct {
 	LabelsIncludeAll []string `json:"labels_include_all"`
 }
 
+// TeamScopedQueryName identifies a saved query by team and name, for batch
+// resolution. A nil TeamID means the global team.
+type TeamScopedQueryName struct {
+	TeamID *uint
+	Name   string
+}
+
+// Key returns the canonical map key for this team-scoped name. It mirrors the
+// team_id_char column (string(team_id), or "" when team_id is NULL) so a nil
+// TeamID and the global team collapse to the same key.
+func (t TeamScopedQueryName) Key() string {
+	tc := ""
+	if t.TeamID != nil {
+		tc = fmt.Sprint(*t.TeamID)
+	}
+	return tc + "\x00" + t.Name
+}
+
 // Query represents a osquery query to run on devices.
 //
 // - If Interval is 0 or AutomationsEnabled is false, then the query is disabled from running as

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -118,6 +118,8 @@ type HasLabelScopedScheduledQueriesFunc func(ctx context.Context, teamID *uint, 
 
 type QueryByNameFunc func(ctx context.Context, teamID *uint, name string) (*fleet.Query, error)
 
+type QueriesByNameFunc func(ctx context.Context, names []fleet.TeamScopedQueryName) (map[string]*fleet.Query, error)
+
 type QueriesPerHostFunc func(ctx context.Context, hostID uint, teamID *uint) ([]uint, error)
 
 type ObserverCanRunQueryFunc func(ctx context.Context, queryID uint) (bool, error)
@@ -2499,6 +2501,9 @@ type DataStore struct {
 
 	QueryByNameFunc        QueryByNameFunc
 	QueryByNameFuncInvoked bool
+
+	QueriesByNameFunc        QueriesByNameFunc
+	QueriesByNameFuncInvoked bool
 
 	QueriesPerHostFunc        QueriesPerHostFunc
 	QueriesPerHostFuncInvoked bool
@@ -6190,6 +6195,13 @@ func (s *DataStore) QueryByName(ctx context.Context, teamID *uint, name string) 
 	s.QueryByNameFuncInvoked = true
 	s.mu.Unlock()
 	return s.QueryByNameFunc(ctx, teamID, name)
+}
+
+func (s *DataStore) QueriesByName(ctx context.Context, names []fleet.TeamScopedQueryName) (map[string]*fleet.Query, error) {
+	s.mu.Lock()
+	s.QueriesByNameFuncInvoked = true
+	s.mu.Unlock()
+	return s.QueriesByNameFunc(ctx, names)
 }
 
 func (s *DataStore) QueriesPerHost(ctx context.Context, hostID uint, teamID *uint) ([]uint, error) {

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -3294,6 +3294,13 @@ func submitLogsEndpoint(ctx context.Context, request interface{}, svc fleet.Serv
 // needs the query IDs to check them against the host's schedule either way. queryReportsDisabled
 // only suppresses injecting `query_id` into the raw logs, to keep the payload reaching the logging
 // destination unchanged for deployments that disable reports.
+// maxDistinctQueryNamesPerSubmission bounds how many distinct query names a
+// single result submission will resolve. It sits far above any realistic host
+// schedule (global plus one team's scheduled queries) and exists only to cap the
+// work a compromised/malicious host can force, since the request body size is
+// unbounded in header-auth mode. A var so tests can force the cap cheaply.
+var maxDistinctQueryNamesPerSubmission = 10000
+
 func (svc *Service) preProcessOsqueryResults(
 	ctx context.Context,
 	osqueryResults []json.RawMessage,
@@ -3329,32 +3336,106 @@ func (svc *Service) preProcessOsqueryResults(
 	}
 
 	queriesDBData = make(map[string]*fleet.Query)
+
+	// A host controls the result names it sends, and each name needs its query
+	// looked up. Parse every distinct name once and resolve them all in a single
+	// batch lookup, so a submission carrying many (or many repeated non-existent)
+	// names costs one query instead of one round-trip per result entry.
+	type parsedName struct {
+		scope fleet.TeamScopedQueryName
+		ok    bool
+		// capped marks a name left unresolved because the submission hit the
+		// distinct-name cap, as opposed to one Fleet does not know. The two must
+		// stay distinguishable: unknown names pass through, capped ones drop.
+		capped bool
+	}
+	parsedByRaw := make(map[string]parsedName)
+	var toResolve []fleet.TeamScopedQueryName
+	seenScope := make(map[string]struct{})
+	var cappedNames int
+	for _, queryResult := range unmarshaledResults {
+		if queryResult == nil {
+			continue
+		}
+		if _, done := parsedByRaw[queryResult.QueryName]; done {
+			continue
+		}
+		teamID, queryName, err := getQueryNameAndTeamIDFromResult(queryResult.QueryName)
+		if errors.Is(err, fleet.ErrLegacyQueryPack) {
+			// Legacy query. Cannot be stored and cannot infer team ID, but still
+			// used by some customers.
+			parsedByRaw[queryResult.QueryName] = parsedName{}
+			continue
+		}
+		if err != nil {
+			svc.logger.DebugContext(ctx, "querying name and team ID from result", "err", err)
+			parsedByRaw[queryResult.QueryName] = parsedName{}
+			continue
+		}
+		scope := fleet.TeamScopedQueryName{TeamID: teamID, Name: queryName}
+		parsedByRaw[queryResult.QueryName] = parsedName{scope: scope, ok: true}
+		if _, dup := seenScope[scope.Key()]; !dup {
+			// Bound the number of distinct names resolved per submission,
+			// independent of any request body-size limit (which does not apply in
+			// header-auth mode). A real host's schedule is far below this; names
+			// past the cap are treated as unresolved, so results still stream to
+			// the log destination but skip report attribution.
+			if len(toResolve) >= maxDistinctQueryNamesPerSubmission {
+				cappedNames++
+				parsedByRaw[queryResult.QueryName] = parsedName{capped: true}
+				continue
+			}
+			seenScope[scope.Key()] = struct{}{}
+			toResolve = append(toResolve, scope)
+		}
+	}
+	// Count the names actually dropped rather than comparing against the cap, so
+	// a submission that lands exactly on it does not report a breach it didn't
+	// cause.
+	if cappedNames > 0 {
+		var hostID uint
+		if host, ok := hostctx.FromContext(ctx); ok && host != nil {
+			hostID = host.ID
+		}
+		svc.logger.WarnContext(ctx, "osquery result submission exceeded distinct query name cap; excess names left unresolved",
+			"host_id", hostID, "cap", maxDistinctQueryNamesPerSubmission, "unresolved", cappedNames)
+	}
+
+	resolved, err := svc.ds.QueriesByName(ctx, toResolve)
+	if err != nil {
+		// Keep whatever resolved before the failure, so one failing chunk doesn't
+		// leave the whole submission unresolved. Names still unresolved here are
+		// treated as unknown to Fleet, which passes their results through to the
+		// log destination without a schedule check.
+		svc.logger.ErrorContext(ctx, "batch loading queries by name", "err", err)
+		if resolved == nil {
+			resolved = map[string]*fleet.Query{}
+		}
+	}
+
 	for i, queryResult := range unmarshaledResults {
 		if queryResult == nil {
 			// These are results that could not be unmarshaled.
 			continue
 		}
-		teamID, queryName, err := getQueryNameAndTeamIDFromResult(queryResult.QueryName)
-		if errors.Is(err, fleet.ErrLegacyQueryPack) {
-			// Legacy query. Cannot be stored and cannot
-			// infer team ID, but still used by some customers
+		parsed := parsedByRaw[queryResult.QueryName]
+		if parsed.capped {
+			// Fail closed. A name Fleet declined to resolve must not inherit the
+			// pass-through that names Fleet genuinely doesn't know get below,
+			// otherwise filling the cap with junk would launder results for a
+			// real query past the host's schedule check.
+			unmarshaledResults[i] = nil
 			continue
 		}
-		if err != nil {
-			svc.logger.DebugContext(ctx, "querying name and team ID from result", "err", err)
+		if !parsed.ok {
 			continue
 		}
-
-		existingQuery, foundQuery := queriesDBData[queryResult.QueryName]
+		existingQuery, foundQuery := resolved[parsed.scope.Key()]
 		if !foundQuery {
-			query, err := svc.ds.QueryByName(ctx, teamID, queryName)
-			if err != nil {
-				svc.logger.DebugContext(ctx, "loading query by name", "err", err, "team", teamID, "name", queryName)
-				continue
-			}
-			queriesDBData[queryResult.QueryName] = query
-			existingQuery = query
+			// Name does not exist on this team.
+			continue
 		}
+		queriesDBData[queryResult.QueryName] = existingQuery
 
 		if queryReportsDisabled {
 			continue

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -44,6 +44,179 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// queriesByNameFromQueryByName adapts a per-name QueryByName stub into the batch
+// QueriesByName that the result path now uses, so existing tests keep their
+// per-name stub logic. A stub that returns an error for a name (not found) leaves
+// it absent from the map, matching the real batch behavior.
+func queriesByNameFromQueryByName(
+	fn func(ctx context.Context, teamID *uint, name string) (*fleet.Query, error),
+) func(ctx context.Context, names []fleet.TeamScopedQueryName) (map[string]*fleet.Query, error) {
+	return func(ctx context.Context, names []fleet.TeamScopedQueryName) (map[string]*fleet.Query, error) {
+		out := make(map[string]*fleet.Query, len(names))
+		for _, n := range names {
+			q, err := fn(ctx, n.TeamID, n.Name)
+			if err != nil {
+				continue
+			}
+			out[n.Key()] = q
+		}
+		return out, nil
+	}
+}
+
+// setUpBatchResultLogsTest wires the minimum for SubmitResultLogs to reach
+// preProcessOsqueryResults, returning the unwrapped *Service and the store.
+func setUpBatchResultLogsTest(t *testing.T) (*Service, context.Context, *mock.Store) {
+	ds := new(mock.Store)
+	svc, ctx := newTestService(t, ds, nil, nil)
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return &fleet.AppConfig{}, nil
+	}
+	ds.QueriesPerHostFunc = func(ctx context.Context, hostID uint, teamID *uint) ([]uint, error) {
+		return nil, nil
+	}
+	ds.OverwriteQueryResultRowsFunc = func(ctx context.Context, rows []*fleet.ScheduledQueryResultRow, maxQueryReportRows int) (int, error) {
+		return len(rows), nil
+	}
+	serv := ((svc.(validationMiddleware)).Service).(*Service)
+	serv.osqueryLogWriter = &OsqueryLogger{Result: &testJSONLogger{}}
+	ctx = hostctx.NewContext(ctx, &fleet.Host{ID: 1})
+	return serv, ctx, ds
+}
+
+func globalResults(n int) []json.RawMessage {
+	results := make([]json.RawMessage, 0, n)
+	for i := range n {
+		results = append(results, json.RawMessage(fmt.Sprintf(
+			`{"snapshot":[{"a":"b"}],"action":"snapshot","name":"pack/Global/q%d","hostIdentifier":"h","calendarTime":"Tue Jan 10 20:08:51 2017 UTC","unixTime":1484078931}`, i)))
+	}
+	return results
+}
+
+// TestSubmitResultLogsBatchesQueryLookups pins the DoS fix: a submission with
+// many distinct query names must resolve in a single batched lookup, and must
+// never fall back to a per-name QueryByName (left nil so a regression panics).
+func TestSubmitResultLogsBatchesQueryLookups(t *testing.T) {
+	serv, ctx, ds := setUpBatchResultLogsTest(t)
+
+	var batchCalls int
+	ds.QueriesByNameFunc = func(ctx context.Context, names []fleet.TeamScopedQueryName) (map[string]*fleet.Query, error) {
+		batchCalls++
+		return map[string]*fleet.Query{}, nil
+	}
+
+	require.NoError(t, serv.SubmitResultLogs(ctx, globalResults(50)))
+	require.Equal(t, 1, batchCalls, "50 distinct names must resolve in a single batched lookup")
+	require.False(t, ds.QueryByNameFuncInvoked, "batched result path must not fall back to per-name QueryByName")
+}
+
+// TestSubmitResultLogsBatchLookupError verifies a batch-lookup failure is
+// swallowed (results pass through unmodified) rather than crashing or erroring.
+func TestSubmitResultLogsBatchLookupError(t *testing.T) {
+	serv, ctx, ds := setUpBatchResultLogsTest(t)
+	ds.QueriesByNameFunc = func(ctx context.Context, names []fleet.TeamScopedQueryName) (map[string]*fleet.Query, error) {
+		return nil, errors.New("db unavailable")
+	}
+	require.NoError(t, serv.SubmitResultLogs(ctx, globalResults(5)))
+}
+
+// TestSubmitResultLogsCapsDistinctNames verifies the per-submission distinct-name
+// cap bounds how many names reach the datastore.
+func TestSubmitResultLogsCapsDistinctNames(t *testing.T) {
+	defer func(orig int) { maxDistinctQueryNamesPerSubmission = orig }(maxDistinctQueryNamesPerSubmission)
+	maxDistinctQueryNamesPerSubmission = 10
+
+	serv, ctx, ds := setUpBatchResultLogsTest(t)
+	var maxSeen int
+	ds.QueriesByNameFunc = func(ctx context.Context, names []fleet.TeamScopedQueryName) (map[string]*fleet.Query, error) {
+		maxSeen = len(names)
+		return map[string]*fleet.Query{}, nil
+	}
+
+	require.NoError(t, serv.SubmitResultLogs(ctx, globalResults(100)))
+	require.LessOrEqual(t, maxSeen, 10, "distinct names passed to the datastore must be capped")
+}
+
+// TestSubmitResultLogsCappedNamesDoNotBypassScheduleCheck pins the cap to failing
+// closed. A name left unresolved by the cap must not be treated like one Fleet
+// doesn't know: those pass through to the log destination without a schedule
+// check, so inheriting that would let a host fill the cap with junk names and
+// launder a forged result for a query it was never scheduled to run.
+func TestSubmitResultLogsCappedNamesDoNotBypassScheduleCheck(t *testing.T) {
+	defer func(o int) { maxDistinctQueryNamesPerSubmission = o }(maxDistinctQueryNamesPerSubmission)
+	maxDistinctQueryNamesPerSubmission = 2
+
+	// forged names a real Fleet query; the host below is scheduled for nothing.
+	const forged = `{"snapshot":[{"forged":"true"}],"action":"snapshot","name":"pack/Global/report_query","hostIdentifier":"h","unixTime":1484078931}`
+
+	run := func(t *testing.T, fillCap bool) int {
+		ds := new(mock.Store)
+		svc, ctx := newTestService(t, ds, nil, nil)
+		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) { return &fleet.AppConfig{}, nil }
+		ds.QueriesByNameFunc = func(ctx context.Context, names []fleet.TeamScopedQueryName) (map[string]*fleet.Query, error) {
+			out := make(map[string]*fleet.Query, len(names))
+			for _, n := range names {
+				out[n.Key()] = &fleet.Query{ID: 42, Name: n.Name, Logging: fleet.LoggingSnapshot, AutomationsEnabled: true}
+			}
+			return out, nil
+		}
+		ds.QueriesPerHostFunc = func(ctx context.Context, hostID uint, teamID *uint) ([]uint, error) { return nil, nil }
+		ds.OverwriteQueryResultRowsFunc = func(ctx context.Context, rows []*fleet.ScheduledQueryResultRow, m int) (int, error) {
+			return len(rows), nil
+		}
+		logDest := &testJSONLogger{}
+		serv := ((svc.(validationMiddleware)).Service).(*Service)
+		serv.osqueryLogWriter = &OsqueryLogger{Result: logDest}
+		ctx = hostctx.NewContext(ctx, &fleet.Host{ID: 1})
+
+		var results []json.RawMessage
+		if fillCap {
+			results = append(results, globalResults(maxDistinctQueryNamesPerSubmission)...)
+		}
+		results = append(results, json.RawMessage(forged))
+		require.NoError(t, serv.SubmitResultLogs(ctx, results))
+		return len(logDest.logs)
+	}
+
+	require.Equal(t, 0, run(t, false), "unscheduled query must be dropped when under the cap")
+	require.Equal(t, 0, run(t, true), "filling the cap must not let an unscheduled query through")
+}
+
+// TestSubmitResultLogsCapWarningOnlyWhenNamesDropped pins the cap's warning to
+// names actually left unresolved: a submission landing exactly on the cap uses
+// every slot without breaching it and must not report one.
+func TestSubmitResultLogsCapWarningOnlyWhenNamesDropped(t *testing.T) {
+	defer func(orig int) { maxDistinctQueryNamesPerSubmission = orig }(maxDistinctQueryNamesPerSubmission)
+	maxDistinctQueryNamesPerSubmission = 10
+
+	for _, tc := range []struct {
+		name        string
+		distinct    int
+		wantWarning bool
+	}{
+		{"under the cap", 9, false},
+		{"exactly at the cap", 10, false},
+		{"over the cap", 11, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := new(bytes.Buffer)
+			serv, ctx, ds := setUpBatchResultLogsTest(t)
+			serv.logger = slog.New(slog.NewJSONHandler(buf, nil))
+
+			var seen int
+			ds.QueriesByNameFunc = func(ctx context.Context, names []fleet.TeamScopedQueryName) (map[string]*fleet.Query, error) {
+				seen = len(names)
+				return map[string]*fleet.Query{}, nil
+			}
+
+			require.NoError(t, serv.SubmitResultLogs(ctx, globalResults(tc.distinct)))
+			require.Equal(t, min(tc.distinct, 10), seen)
+			require.Equal(t, tc.wantWarning, strings.Contains(buf.String(), "distinct query name cap"),
+				"warning presence should track names actually dropped; log was: %s", buf.String())
+		})
+	}
+}
+
 func TestGetClientConfig(t *testing.T) {
 	ds := new(mock.Store)
 
@@ -728,6 +901,7 @@ func TestSubmitResultLogsToLogDestination(t *testing.T) {
 			return nil, newNotFoundError()
 		}
 	}
+	ds.QueriesByNameFunc = queriesByNameFromQueryByName(ds.QueryByNameFunc)
 	ds.QueriesPerHostFunc = func(ctx context.Context, hostID uint, teamID *uint) ([]uint, error) {
 		// Mirrors the IDs returned by QueryByNameFunc above. Team 1 queries are never
 		// scheduled here because no host in this test belongs to team 1.
@@ -1022,6 +1196,7 @@ func TestSubmitResultLogsToQueryResultsWithEmptySnapShot(t *testing.T) {
 			Logging:     fleet.LoggingSnapshot,
 		}, nil
 	}
+	ds.QueriesByNameFunc = queriesByNameFromQueryByName(ds.QueryByNameFunc)
 
 	ds.QueriesPerHostFunc = func(ctx context.Context, hostID uint, teamID *uint) ([]uint, error) {
 		return []uint{1}, nil
@@ -1077,6 +1252,7 @@ func TestSubmitResultLogsToQueryResultsDoesNotCountNullDataRows(t *testing.T) {
 			Logging:     fleet.LoggingSnapshot,
 		}, nil
 	}
+	ds.QueriesByNameFunc = queriesByNameFromQueryByName(ds.QueryByNameFunc)
 
 	ds.QueriesPerHostFunc = func(ctx context.Context, hostID uint, teamID *uint) ([]uint, error) {
 		return []uint{1}, nil
@@ -1131,6 +1307,7 @@ func TestSubmitResultLogsQueryNotScheduledForHost(t *testing.T) {
 				AutomationsEnabled: true,
 			}, nil
 		}
+		ds.QueriesByNameFunc = queriesByNameFromQueryByName(ds.QueryByNameFunc)
 		ds.QueriesPerHostFunc = func(ctx context.Context, hostID uint, teamID *uint) ([]uint, error) {
 			if !scheduledForHost {
 				return nil, nil
@@ -1187,6 +1364,7 @@ func TestSubmitResultLogsQueryNotScheduledForHost(t *testing.T) {
 		ds.QueryByNameFunc = func(ctx context.Context, teamID *uint, name string) (*fleet.Query, error) {
 			return nil, newNotFoundError()
 		}
+		ds.QueriesByNameFunc = queriesByNameFromQueryByName(ds.QueryByNameFunc)
 
 		results := newResults()
 		require.NoError(t, svc.SubmitResultLogs(ctx, results))
@@ -1271,6 +1449,7 @@ func TestSubmitResultLogsFail(t *testing.T) {
 			Name:               name,
 		}, nil
 	}
+	ds.QueriesByNameFunc = queriesByNameFromQueryByName(ds.QueryByNameFunc)
 	ds.QueriesPerHostFunc = func(ctx context.Context, hostID uint, teamID *uint) ([]uint, error) {
 		return []uint{1}, nil
 	}


### PR DESCRIPTION
**Related issue:** N/A

## Description

`preProcessOsqueryResults` resolved every osquery result entry's query name with its own `QueryByName` call. The request-local dedupe map is only written on a *successful* lookup, so a name that doesn't resolve is re-queried for every entry carrying it — a submission with many result entries becomes that many sequential read-replica round-trips, even when the names repeat.

This parses and dedupes the names once, then resolves them through a new batched `QueriesByName` datastore method.

Notes on the implementation:

- Lookups are chunked, 1000 pairs each. Every pair costs 2 bind params, so an unbounded `IN` would run into MySQL's 65535 placeholder ceiling at around 32k names and fail the query outright. Same batching shape as `activities.go`.
- Column order in the tuple is `(name, team_id_char)` to match `idx_name_team_id_unq`, so the row-constructor `IN` can use the unique index. `EXPLAIN` on a 10k-row table gives `range` on `idx_name_team_id_unq` with `Using index`.
- The batch doesn't load packs. This path only reads query id and logging fields, so skipping the join keeps each chunk to a single indexed read. It also stays clear of `loadPacksForQueries`, which keys its map by name alone — two same-named queries on different teams would overwrite each other there. That can't happen today since every other caller passes a single query, but it would if the batch method loaded packs.
- There's a cap on distinct names resolved per submission. Batching bounds the round-trips but not the input, and `/api/osquery/log` isn't subject to a body-size limit in header-auth mode. The cap sits far above any real host schedule.
- Names left unresolved by that cap are dropped rather than passed through. Worth calling out because it's easy to get backwards: a name Fleet doesn't recognise is deliberately passed through to the logging destination, to support osquery nodes configured outside Fleet. Capped names must not land in that same bucket, or a submission that fills the cap would carry results past `dropResultsNotScheduledForHost`. They're tracked separately and nilled out, which is what `TestSubmitResultLogsCappedNamesDoNotBypassScheduleCheck` pins.
- If a chunk fails, the pairs resolved by earlier chunks are kept instead of discarded. Returning an empty map there would send an entire submission through as unrecognised, which is a much bigger behaviour change than the one failing chunk warrants.

Measured on a local instance, one `POST /api/osquery/log` with 50k result entries: **38.8s → 0.42s**, and flat rather than linear in entry count.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, automated tests simulate multiple hosts and test for host isolation

- [x] QA'd all new/changed functionality manually

New tests:

- `TestSubmitResultLogsBatchesQueryLookups` — many distinct names resolve in a single batched lookup. `QueryByNameFunc` is deliberately left nil so a regression to per-name lookups panics rather than passing quietly.
- `TestSubmitResultLogsCappedNamesDoNotBypassScheduleCheck` — a submission that fills the cap doesn't carry a result for an unscheduled query through to the logging destination.
- `TestSubmitResultLogsBatchLookupError` — a batch failure is swallowed and results pass through.
- `TestSubmitResultLogsCapsDistinctNames` and `TestSubmitResultLogsCapWarningOnlyWhenNamesDropped` — the cap bounds what reaches the datastore, and the warning tracks names actually dropped rather than firing on a submission that lands exactly on the cap.
- `testQueriesGetByName` additions — global vs same-named team query stay distinct, a name on one team doesn't resolve for another, missing names are omitted, duplicates dedupe, and a forced batch size of 1 exercises the multi-chunk path.

Each of the behaviour changes above was checked by reverting it and confirming the matching test fails, so they pin the behaviour rather than just describing it.

Manual QA on a local instance: submitted result logs at 1/1k/10k/50k entries before and after, confirmed latency is flat after the change, and confirmed normal scheduled-query reporting still records results and query IDs.

- [x] Confirmed that the fix is not expected to adversely impact load test results


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Reduced database load when processing osquery result logs by resolving scheduled query names in batches.
  - Reuses query lookups for repeated results within a submission.

- **Reliability**
  - Continues processing when individual names are invalid or batch lookups fail.
  - Limits distinct scheduled-query lookups per submission to 10,000 and safely excludes additional names.

- **Bug Fixes**
  - Preserves correct handling of global and team-scoped queries, including duplicate and missing names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->