### PR TITLE
update wipe modal with extra copy

### DIFF
--- a/changes/51298-update-wipe-modal
+++ b/changes/51298-update-wipe-modal
@@ -1,0 +1,1 @@
+- Updated wipe modal for Apple and Windows hosts to call out deleting may remove the Wipe Pending status.

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/WipeModal/WipeModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/WipeModal/WipeModal.tsx
@@ -8,7 +8,7 @@ import Modal from "components/Modal";
 import Button from "components/buttons/Button";
 import Checkbox from "components/forms/fields/Checkbox";
 import CustomLink from "components/CustomLink";
-import { isAndroid } from "interfaces/platform";
+import { isAndroid, isAppleDevice } from "interfaces/platform";
 
 const baseClass = "wipe-modal";
 
@@ -34,6 +34,7 @@ const WipeModal = ({
   const [lockChecked, setLockChecked] = React.useState(false);
   const [isWiping, setIsWiping] = React.useState(false);
   const isAndroidHost = isAndroid(hostPlatform);
+  const isAppleHost = isAppleDevice(hostPlatform);
 
   const onWipe = async () => {
     setIsWiping(true);
@@ -63,6 +64,12 @@ const WipeModal = ({
     <Modal className={baseClass} title="Wipe" onExit={onClose}>
       <div className={`${baseClass}__modal-content`}>
         {!isLinuxHost && <p>All content will be erased on this host.</p>}
+        {(isWindowsHost || isAppleHost) && (
+          <p>
+            Deleting the host before the wipe executes may hide the Wipe Pending
+            status, but it will still be wiped on MDM check-in.
+          </p>
+        )}
         {isWindowsHost && (
           <p>
             To use the host again, you will have to do a Windows reinstall from


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #51298 

macOS:
<img width="691" height="407" alt="image" src="https://github.com/user-attachments/assets/a49756b2-ecab-477e-bb6e-7b66df83904d" />

Windows:
<img width="709" height="440" alt="image" src="https://github.com/user-attachments/assets/1ad636ce-e76b-47e0-86a8-044e377d3011" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually

## Frontend

- [x] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the host wipe confirmation message for Windows and Apple devices.
  - Warns that wiping may remove the “Wipe Pending” status from view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->