### PR TITLE
Remove `withRetryTxx` on `host_sofware_installed_paths` inserts/deletions

### DIFF
--- a/changes/51892-reduce-thundering-herd-upon-locks
+++ b/changes/51892-reduce-thundering-herd-upon-locks
@@ -1,0 +1,1 @@
+* Reduced database load when software installed-path updates hit lock contention: the transaction now fails fast instead of retrying, and the host's next software report reconciles the paths.

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -227,7 +227,12 @@ func (ds *Datastore) UpdateHostSoftwareInstalledPaths(
 		return nil
 	}
 
-	return ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
+	// Not using withRetryTxx on purpose.
+	// If we use withRetryTxx, when this table is contended, retrying parks connections
+	// on the same locks for up to another lock-wait timeout each, multiplying the load.
+	// Failing fast is safe because the delta is recomputed from scratch on the
+	// host's next software report.
+	return ds.withTx(ctx, func(tx sqlx.ExtContext) error {
 		if err := deleteHostSoftwareInstalledPaths(ctx, tx, toD); err != nil {
 			return err
 		}


### PR DESCRIPTION
Resolves #51892 (@juan-fdz-hawa will convert `ReconcileSoftwareChecksums` into an offline migration on a separate PR)

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [X] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [X] Confirmed that the fix is not expected to adversely impact load test results
- [X] Alerted the release DRI if additional load testing is needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Reduced database load when software inventory updates encounter lock contention.
  - Updates now fail fast instead of repeatedly retrying against locked records.
  - The next software report automatically reconciles any paths not updated during contention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->