### PR TITLE
Draft YAML and REST API spec for multiple app configs per software title

### DIFF
--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -623,14 +623,23 @@ software:
       auto_update_enabled: true
       auto_update_window_start: "00:00"
       auto_update_window_end: "04:00"
-      configuration:
-        path: ../lib/software/zoom-config.xml
+      configurations:
+        - labels_include_any:
+            - Product
+          path: ../lib/software/zoom-config-product.xml
+        - labels_include_any:
+            - Marketing
+          path: ../lib/software/zoom-config-marketing.xml
+        - path: ../lib/software/zoom-config-default.xml
     - app_store_id: "us.zoom.videomeetings"
       platform: android
       self_service: true
       setup_experience: true
-      configuration:
-        path: ../lib/software/zoom-config.json
+      configurations:
+        - labels_include_all:
+            - Sales
+          path: ../lib/software/zoom-config-sales.json
+        - path: ../lib/software/zoom-config-default.json
   fleet_maintained_apps:
     - slug: slack/darwin
       version: "4.47.65"
@@ -786,9 +795,13 @@ software:
   + For Apple App Store apps, make sure to include only the ID itself, and not the `id` prefix shown in the URL. The ID must be wrapped in quotes as shown in the example so that it is processed as a string.
 - `platform` is the platform of the app (`darwin`, `ios`, `ipados`, or `android`). If not specified, and `app_store_id` is Apple App Store ID, one app for each of the Apple App Store app's supported platforms is added. For example, adding [Bear](https://apps.apple.com/us/app/bear-markdown-notes/id1016366447) (supported on iOS and iPadOS) adds both the iOS and iPadOS apps to your software that's available to install in Fleet.
 - `icon.path` is a relative path to the PNG icon that will be displayed in Fleet and on **Fleet Desktop > Self-service** instead of the default icon the icon sourced from Apple. It must be a square PNG with dimensions between 120x120 px and 1024x1024 px. Custom icons will only override the icon for the software title and fleet where they are added.
-- `configuration.path` is the app managed configuration. For iOS and iPadOS apps it is in XML format, and for Android Play Store apps it is in JSON format. Currently only supported for iOS, iPadOS, and Android.
+- `configurations` is a list of one or more managed app configurations for this app. For iOS and iPadOS apps each configuration is in XML format, and for Android Play Store apps it is in JSON format. Currently only supported for iOS, iPadOS, and Android.
+  + Each entry has a `path` to the configuration file, and optionally one of `labels_include_any`, `labels_include_all`, or `labels_exclude_any` to scope that specific configuration to a subset of the hosts the app is installed on (e.g. give one IdP group a different VPN configuration than another). These per-configuration labels are independent of the app-level `labels_include_any`/`labels_include_all`/`labels_exclude_any` documented above, which control whether the app is installed on a host at all.
+  + An entry with no label fields is the default and matches any host not matched by an earlier entry. Fleet evaluates entries in list order and applies the first matching one, so an unscoped default entry should be listed last.
+  + Up to 10 configurations are supported per app (same limit as [multiple versions of the same software](#packages)).
   + Android: `managedConfiguration` and `workProfileWidgets` are supported from [Android application policy](https://developers.google.com/android/management/reference/rest/v1/enterprises.policies#ApplicationPolicy).
   + Configuration keys vary by app. Refer to the app vendor's documentation for available managed configuration options. For example, see [Zoom's Android managed configuration](https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0064790), [Zoom's iOS managed configuration](https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0064102), or [GlobalProtect's Android configuration](https://docs.paloaltonetworks.com/globalprotect/10-1/globalprotect-admin/mobile-endpoint-management/manage-the-globalprotect-app-using-other-third-party-mdms/configure-the-globalprotect-app-for-android).
+  + `configuration.path` (deprecated, use `configurations`) sets a single unscoped configuration — equivalent to a `configurations` entry with no label fields. Can't be set together with `configurations`.
 - `auto_update_enabled` enables automatic updates for the app (default: `false`). Only supported for iOS and iPadOS App Store (VPP) apps.
 - `auto_update_window_start` is the start of the daily maintenance window during which Fleet will apply automatic updates, formatted as `HH:MM` in the host's local time (e.g. `"00:00"`). Required when `auto_update_enabled` is `true`. Must be wrapped in quotes so it is processed as a string.
 - `auto_update_window_end` is the end of the daily maintenance window, formatted as `HH:MM` in the host's local time (e.g. `"04:00"`). Required when `auto_update_enabled` is `true`. If the end time is earlier than the start time, the window wraps to the next day (e.g. `"22:00"` to `"02:00"`). Must be wrapped in quotes so it is processed as a string.

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -13262,7 +13262,8 @@ Add Apple App Store or Google Play store app. Apple apps must be added in Apple 
 | labels_include_all        | array     | body | Target hosts that have all labels, specified by label name, in the array. |
 | labels_include_any        | array     | body | Target hosts that have any label, specified by label name, in the array. |
 | labels_exclude_any | array | form | Target hosts that don't have any label, specified by label name, in the array. |
-| configuration | object | form | The app's managed configuration. For iOS and iPadOS apps it is in XML format, and for Android Play Store apps it is in JSON format. Currently only supported for iOS, iPadOS, and Android. |
+| configuration | object | form | _Deprecated. Use `configurations`._ The app's managed configuration, applied to every host the app is installed on. Equivalent to a single `configurations` entry with no label fields. Can't be specified together with `configurations`. |
+| configurations | array | form | A list of one or more managed app configurations. For iOS and iPadOS apps each `configuration` is in XML format, and for Android Play Store apps it is in JSON format. Currently only supported for iOS, iPadOS, and Android. Each entry is an object with a `configuration` value and, optionally, one of `labels_include_any`, `labels_include_all`, or `labels_exclude_any` to scope that configuration to a subset of the hosts the app is installed on. These per-configuration labels are independent of the top-level `labels_include_any`/`labels_include_all`/`labels_exclude_any` above, which control whether the app installs on a host at all. An entry with no label fields is the default, applied to hosts that don't match any other entry — Fleet applies the first matching entry in list order, so list the default last. Up to 10 entries are supported. |
 
 Only one of `labels_include_all`, `labels_include_any` or `labels_exclude_any` can be specified. If none are specified, all hosts are targeted.
 
@@ -13280,6 +13281,29 @@ Only one of `labels_include_all`, `labels_include_any` or `labels_exclude_any` c
   "team_id": 2,
   "platform": "ipados",
   "self_service": true
+}
+```
+
+##### Request body with multiple label-scoped configurations
+
+```json
+{
+  "app_store_id": "546505307",
+  "team_id": 2,
+  "platform": "ios",
+  "configurations": [
+    {
+      "labels_include_any": ["Product"],
+      "configuration": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>...<!-- Product config -->"
+    },
+    {
+      "labels_include_any": ["Marketing"],
+      "configuration": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>...<!-- Marketing config -->"
+    },
+    {
+      "configuration": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>...<!-- default config -->"
+    }
+  ]
 }
 ```
 
@@ -13328,11 +13352,12 @@ Modify an Apple App Store (VPP) or a Google Play app's options.
 | labels_include_all        | array     | body | Target hosts that have all labels, specified by label name, in the array. |
 | labels_include_any        | array     | body | Target hosts that have any label, specified by label name, in the array. |
 | labels_exclude_any | array | body | Target hosts that don't have any label, specified by label name, in the array. |
-| configuration | object | body | The app's managed configuration. For iOS and iPadOS apps it is in XML format, and for Android Play Store apps it is in JSON format. Currently only supported for iOS, iPadOS, and Android. |
+| configuration | object | body | _Deprecated. Use `configurations`._ The app's managed configuration, applied to every host the app is installed on. Equivalent to a single `configurations` entry with no label fields. Can't be specified together with `configurations`. |
+| configurations | array | body | A list of one or more managed app configurations. For iOS and iPadOS apps each `configuration` is in XML format, and for Android Play Store apps it is in JSON format. Currently only supported for iOS, iPadOS, and Android. Each entry is an object with a `configuration` value and, optionally, one of `labels_include_any`, `labels_include_all`, or `labels_exclude_any` to scope that configuration to a subset of the hosts the app is installed on. These per-configuration labels are independent of the top-level `labels_include_any`/`labels_include_all`/`labels_exclude_any` above, which control whether the app installs on a host at all. An entry with no label fields is the default, applied to hosts that don't match any other entry — Fleet applies the first matching entry in list order, so list the default last. Up to 10 entries are supported. Passing `configurations` replaces the app's entire set of configurations. |
 
 Only one of `labels_include_all`, `labels_include_any` or `labels_exclude_any` can be specified. If none are specified, all hosts are targeted.
 
-`configuration` only supports `managedConfiguration` and `workProfileWidgets` from [Android application policy](https://developers.google.com/android/management/reference/rest/v1/enterprises.policies#ApplicationPolicy). Configuration keys vary by app. Refer to the app vendor's documentation for available managed configuration options. For example, see [Zoom's Android managed configuration](https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0064790) or [GlobalProtect's Android configuration](https://docs.paloaltonetworks.com/globalprotect/10-1/globalprotect-admin/mobile-endpoint-management/manage-the-globalprotect-app-using-other-third-party-mdms/configure-the-globalprotect-app-for-android).
+Each configuration only supports `managedConfiguration` and `workProfileWidgets` from [Android application policy](https://developers.google.com/android/management/reference/rest/v1/enterprises.policies#ApplicationPolicy). Configuration keys vary by app. Refer to the app vendor's documentation for available managed configuration options. For example, see [Zoom's Android managed configuration](https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0064790) or [GlobalProtect's Android configuration](https://docs.paloaltonetworks.com/globalprotect/10-1/globalprotect-admin/mobile-endpoint-management/manage-the-globalprotect-app-using-other-third-party-mdms/configure-the-globalprotect-app-for-android).
 
 #### Example
 
@@ -13348,6 +13373,27 @@ Only one of `labels_include_all`, `labels_include_any` or `labels_exclude_any` c
   "labels_include_any": [
     "Product",
     "Marketing"
+  ]
+}
+```
+
+##### Request body with multiple label-scoped configurations
+
+```json
+{
+  "team_id": 2,
+  "configurations": [
+    {
+      "labels_include_any": ["Product"],
+      "configuration": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>...<!-- Product config -->"
+    },
+    {
+      "labels_include_any": ["Marketing"],
+      "configuration": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>...<!-- Marketing config -->"
+    },
+    {
+      "configuration": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>...<!-- default config -->"
+    }
   ]
 }
 ```
@@ -13374,6 +13420,29 @@ Only one of `labels_include_all`, `labels_include_any` or `labels_exclude_any` c
       {
         "name": "Marketing",
         "id": 17
+      }
+    ],
+    "configurations": [
+      {
+        "labels_include_any": [
+          {
+            "name": "Product",
+            "id": 12
+          }
+        ],
+        "configuration": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>...<!-- Product config -->"
+      },
+      {
+        "labels_include_any": [
+          {
+            "name": "Marketing",
+            "id": 17
+          }
+        ],
+        "configuration": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>...<!-- Marketing config -->"
+      },
+      {
+        "configuration": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>...<!-- default config -->"
       }
     ],
     "automatic_install_policies": [


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** #47904

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] N/A — docs-only spec change, no user-visible behavior yet.

- [x] N/A — no code in this PR.
- [x] N/A — no code in this PR.
- [x] N/A — no code in this PR.

## Testing

- [x] N/A — docs-only.

- [x] N/A — docs-only.

## Frontend

- [x] N/A — no frontend changes.

## Database migrations

- [x] N/A — no migrations in this PR.

## New Fleet configuration settings

- [x] N/A — not a new Fleet configuration setting.

## fleetd/orbit/Fleet Desktop

- [x] N/A — no fleetd/orbit/Fleet Desktop changes.

## Summary

Drafts the **YAML changes** and **REST API changes** checklist items for #47904 ("Add multiple managed app configurations per software title"), so engineering has a concrete API/YAML shape to build against.

- Adds a `configurations` list to `app_store_apps` (GitOps YAML) and to the `POST /api/v1/fleet/software/app_store_apps` / `PATCH /api/v1/fleet/software/titles/:id/app_store_app` REST endpoints, replacing the current singular `configuration` field (kept, deprecated, for backward compatibility).
- Each entry in `configurations` carries its own managed app config plus an optional `labels_include_any`/`labels_include_all`/`labels_exclude_any` scope — independent of the existing app-level label fields, which control whether the app installs on a host at all, not which config it gets.
- Conflict resolution mirrors the existing `packages` precedent (multiple label-scoped installers per software title): Fleet applies the **first matching entry in list order**; an entry with no label fields is the default and should be listed last.
- Capped at 10 configurations per app, matching the existing `packages`-per-title limit.

No backend/frontend code changes — this is a docs-only spec PR. Full implementation (DB migration, datastore/service layer for VPP + Android, new per-host label-matching logic in the MDM install-command path, GitOps client changes) is separate follow-up engineering work.