### PR TITLE
Keep SCEP enrollment secrets out of the Android device logs

### DIFF
--- a/android/app/src/main/java/com/fleetdm/agent/ApiClient.kt
+++ b/android/app/src/main/java/com/fleetdm/agent/ApiClient.kt
@@ -626,7 +626,18 @@ data class GetCertificateTemplateResponse(
 
     @Transient
     val signatureAlgorithm: String = "SHA256withRSA",
-)
+) {
+    // Both challenges are enrollment secrets: scepChallenge is the CA's challenge password and
+    // fleetChallenge authenticates a single request to Fleet's SCEP proxy. The generated data class
+    // toString() prints them, so any log line interpolating a template hands them to logcat.
+    override fun toString(): String = "GetCertificateTemplateResponse(" +
+        "id=$id, name=$name, certificateAuthorityId=$certificateAuthorityId, " +
+        "certificateAuthorityName=$certificateAuthorityName, createdAt=$createdAt, " +
+        "subjectName=$subjectName, subjectAlternativeName=$subjectAlternativeName, " +
+        "certificateAuthorityType=$certificateAuthorityType, status=$status, " +
+        "scepChallenge=${scepChallenge.redacted()}, fleetChallenge=${fleetChallenge.redacted()}, " +
+        "keyLength=$keyLength, signatureAlgorithm=$signatureAlgorithm)"
+}
 
 /**
  * Builds the SCEP proxy URL for this certificate template.

--- a/android/app/src/main/java/com/fleetdm/agent/ApiClient.kt
+++ b/android/app/src/main/java/com/fleetdm/agent/ApiClient.kt
@@ -42,7 +42,10 @@ val Context.prefDataStore: DataStore<Preferences> by preferencesDataStore(name =
 /**
  * Result of fetching a certificate template, including the computed SCEP URL.
  */
-data class CertificateTemplateResult(val template: GetCertificateTemplateResponse, val scepUrl: String)
+data class CertificateTemplateResult(val template: GetCertificateTemplateResponse, val scepUrl: String) {
+    // scepUrl ends with a one-time challenge, so keep it out of the generated toString().
+    override fun toString(): String = "CertificateTemplateResult(template=$template, scepUrl=${scepUrl.redactSecrets()})"
+}
 
 /**
  * Interface for certificate-related API operations.
@@ -355,7 +358,8 @@ object ApiClient : CertificateApiClient {
             body = UpdateCertificateStatusRequest(
                 status = status,
                 operationType = operationType,
-                detail = detail,
+                // Details come from exception messages, which can carry the SCEP proxy challenge.
+                detail = detail?.redactSecrets(),
                 notAfter = notAfter?.toISO8601String(),
                 notBefore = notBefore?.toISO8601String(),
                 serialNumber = serialNumber?.toString(16), // hex
@@ -643,4 +647,4 @@ data class GetCertificateTemplateResponse(
  * Builds the SCEP proxy URL for this certificate template.
  */
 fun GetCertificateTemplateResponse.buildScepUrl(serverUrl: String, hostUUID: String): String =
-    "$serverUrl/mdm/scep/proxy/$hostUUID,g$id,$certificateAuthorityType,${fleetChallenge ?: ""}"
+    "$serverUrl$SCEP_PROXY_PATH$hostUUID,g$id,$certificateAuthorityType,${fleetChallenge ?: ""}"

--- a/android/app/src/main/java/com/fleetdm/agent/CertificateOrchestrator.kt
+++ b/android/app/src/main/java/com/fleetdm/agent/CertificateOrchestrator.kt
@@ -741,7 +741,7 @@ class CertificateOrchestrator(
         )
 
         // Step 5: Perform enrollment
-        Log.d(TAG, "Starting SCEP enrollment for certificate: ${template.name}: $template")
+        Log.d(TAG, "Starting SCEP enrollment for certificate: $template")
         val result = handler.handleEnrollment(template, scepUrl)
 
         when (result) {

--- a/android/app/src/main/java/com/fleetdm/agent/FleetLog.kt
+++ b/android/app/src/main/java/com/fleetdm/agent/FleetLog.kt
@@ -11,7 +11,8 @@ import java.time.Instant
  * Persistent error logger that writes to internal storage alongside the normal logcat output.
  *
  * Call [initialize] once in Application.onCreate(). Then use [e] wherever you would call
- * Log.e — it writes to logcat AND appends to fleet_errors.log in filesDir.
+ * Log.e — it writes to logcat AND appends to fleet_errors.log in filesDir. Messages and stack
+ * traces are passed through [redactSecrets] first, so enrollment secrets stay out of both.
  * The log file is capped at 512 KB; when it exceeds that size the current file is renamed
  * to fleet_errors.log.1 and a fresh file is started.
  */
@@ -27,14 +28,18 @@ object FleetLog {
     }
 
     fun e(tag: String, msg: String, throwable: Throwable? = null) {
-        Log.e(tag, msg, throwable)
-        appendToFile(tag, msg, throwable)
+        val message = msg.redactSecrets()
+        // Render the throwable ourselves rather than handing it to Log.e: Log.e prints the whole
+        // cause chain, and causes raised by the HTTP stack can carry the SCEP proxy URL's challenge.
+        val stackTrace = throwable?.stackTraceToString()?.trimEnd()?.redactSecrets()
+        Log.e(tag, if (stackTrace == null) message else "$message\n$stackTrace")
+        appendToFile(tag, message, stackTrace)
     }
 
     fun readErrors(): String = logFile?.takeIf { it.exists() }?.readText() ?: ""
 
     @Synchronized
-    private fun appendToFile(tag: String, msg: String, throwable: Throwable?) {
+    private fun appendToFile(tag: String, msg: String, stackTrace: String?) {
         val file = logFile ?: return
         try {
             if (file.exists() && file.length() > MAX_SIZE_BYTES) {
@@ -48,12 +53,7 @@ object FleetLog {
             val timestamp = Instant.now().toString()
             val sb = StringBuilder()
             sb.append("$timestamp E $tag $msg\n")
-            throwable?.let { t ->
-                sb.append("    $t\n")
-                t.stackTrace.forEach { element ->
-                    sb.append("      at $element\n")
-                }
-            }
+            stackTrace?.let { sb.append(it.prependIndent("    ")).append("\n") }
             file.appendText(sb.toString())
         } catch (e: Exception) {
             Log.e(TAG, "Failed to write to log file: ${e.message}")

--- a/android/app/src/main/java/com/fleetdm/agent/FleetLog.kt
+++ b/android/app/src/main/java/com/fleetdm/agent/FleetLog.kt
@@ -43,6 +43,10 @@ object FleetLog {
      * a throwable splits for us; passing pre-rendered text doesn't, it truncates.
      */
     private fun logChunked(tag: String, text: String) {
+        if (text.length <= MAX_LOGCAT_CHUNK_CHARS) {
+            Log.e(tag, text)
+            return
+        }
         val pieces = text.lineSequence().flatMap { line ->
             if (line.length <= MAX_LOGCAT_CHUNK_CHARS) sequenceOf(line) else line.chunked(MAX_LOGCAT_CHUNK_CHARS).asSequence()
         }
@@ -57,7 +61,9 @@ object FleetLog {
             }
             chunk.append(piece)
         }
-        Log.e(tag, chunk.toString())
+        if (chunk.isNotEmpty()) {
+            Log.e(tag, chunk.toString())
+        }
     }
 
     // Redacted on the way out too: a file written by an older build may still hold secrets.

--- a/android/app/src/main/java/com/fleetdm/agent/FleetLog.kt
+++ b/android/app/src/main/java/com/fleetdm/agent/FleetLog.kt
@@ -21,6 +21,9 @@ object FleetLog {
     private const val LOG_FILE_NAME = "fleet_errors.log"
     private const val MAX_SIZE_BYTES = 512 * 1024L // 512 KB
 
+    // logcat drops whatever a single entry carries past ~4 KB of payload.
+    private const val MAX_LOGCAT_CHUNK_CHARS = 3000
+
     @Volatile private var logFile: File? = null
 
     fun initialize(context: Context) {
@@ -28,15 +31,37 @@ object FleetLog {
     }
 
     fun e(tag: String, msg: String, throwable: Throwable? = null) {
-        val message = msg.redactSecrets()
         // Render the throwable ourselves rather than handing it to Log.e: Log.e prints the whole
         // cause chain, and causes raised by the HTTP stack can carry the SCEP proxy URL's challenge.
-        val stackTrace = throwable?.stackTraceToString()?.trimEnd()?.redactSecrets()
-        Log.e(tag, if (stackTrace == null) message else "$message\n$stackTrace")
+        val (message, stackTrace) = renderLogEntry(msg, throwable)
+        logChunked(tag, if (stackTrace == null) message else "$message\n$stackTrace")
         appendToFile(tag, message, stackTrace)
     }
 
-    fun readErrors(): String = logFile?.takeIf { it.exists() }?.readText() ?: ""
+    /**
+     * Writes [text] to logcat, split across entries so a long stack trace isn't cut off. Log.e with
+     * a throwable splits for us; passing pre-rendered text doesn't, it truncates.
+     */
+    private fun logChunked(tag: String, text: String) {
+        val pieces = text.lineSequence().flatMap { line ->
+            if (line.length <= MAX_LOGCAT_CHUNK_CHARS) sequenceOf(line) else line.chunked(MAX_LOGCAT_CHUNK_CHARS).asSequence()
+        }
+        val chunk = StringBuilder()
+        pieces.forEach { piece ->
+            if (chunk.isNotEmpty() && chunk.length + piece.length + 1 > MAX_LOGCAT_CHUNK_CHARS) {
+                Log.e(tag, chunk.toString())
+                chunk.setLength(0)
+            }
+            if (chunk.isNotEmpty()) {
+                chunk.append('\n')
+            }
+            chunk.append(piece)
+        }
+        Log.e(tag, chunk.toString())
+    }
+
+    // Redacted on the way out too: a file written by an older build may still hold secrets.
+    fun readErrors(): String = (logFile?.takeIf { it.exists() }?.readText() ?: "").redactSecrets()
 
     @Synchronized
     private fun appendToFile(tag: String, msg: String, stackTrace: String?) {

--- a/android/app/src/main/java/com/fleetdm/agent/FleetLog.kt
+++ b/android/app/src/main/java/com/fleetdm/agent/FleetLog.kt
@@ -21,8 +21,8 @@ object FleetLog {
     private const val LOG_FILE_NAME = "fleet_errors.log"
     private const val MAX_SIZE_BYTES = 512 * 1024L // 512 KB
 
-    // logcat drops whatever a single entry carries past ~4 KB of payload.
-    private const val MAX_LOGCAT_CHUNK_CHARS = 3000
+    // logcat drops whatever a single entry carries past ~4 KB of payload, measured in bytes.
+    private const val MAX_LOGCAT_CHUNK_BYTES = 3000
 
     @Volatile private var logFile: File? = null
 
@@ -38,32 +38,8 @@ object FleetLog {
         appendToFile(tag, message, stackTrace)
     }
 
-    /**
-     * Writes [text] to logcat, split across entries so a long stack trace isn't cut off. Log.e with
-     * a throwable splits for us; passing pre-rendered text doesn't, it truncates.
-     */
     private fun logChunked(tag: String, text: String) {
-        if (text.length <= MAX_LOGCAT_CHUNK_CHARS) {
-            Log.e(tag, text)
-            return
-        }
-        val pieces = text.lineSequence().flatMap { line ->
-            if (line.length <= MAX_LOGCAT_CHUNK_CHARS) sequenceOf(line) else line.chunked(MAX_LOGCAT_CHUNK_CHARS).asSequence()
-        }
-        val chunk = StringBuilder()
-        pieces.forEach { piece ->
-            if (chunk.isNotEmpty() && chunk.length + piece.length + 1 > MAX_LOGCAT_CHUNK_CHARS) {
-                Log.e(tag, chunk.toString())
-                chunk.setLength(0)
-            }
-            if (chunk.isNotEmpty()) {
-                chunk.append('\n')
-            }
-            chunk.append(piece)
-        }
-        if (chunk.isNotEmpty()) {
-            Log.e(tag, chunk.toString())
-        }
+        chunkForLogcat(text, MAX_LOGCAT_CHUNK_BYTES).forEach { Log.e(tag, it) }
     }
 
     // Redacted on the way out too: a file written by an older build may still hold secrets.
@@ -90,4 +66,75 @@ object FleetLog {
             Log.e(TAG, "Failed to write to log file: ${e.message}")
         }
     }
+}
+
+/**
+ * Splits [text] into pieces of at most [maxBytes] UTF-8 bytes, breaking at line boundaries where it
+ * can. Log.e with a throwable splits a long trace across entries for us; pre-rendered text is
+ * truncated instead, and the limit logcat applies is a byte count, so measuring characters would
+ * still lose the tail of non-ASCII text.
+ */
+internal fun chunkForLogcat(text: String, maxBytes: Int): List<String> {
+    if (text.utf8Size() <= maxBytes) {
+        return listOf(text)
+    }
+
+    val chunks = mutableListOf<String>()
+    var current = StringBuilder()
+    var currentBytes = 0
+    for (piece in text.lineSequence().flatMap { splitByUtf8Bytes(it, maxBytes) }) {
+        val pieceBytes = piece.utf8Size()
+        if (current.isNotEmpty() && currentBytes + 1 + pieceBytes > maxBytes) {
+            chunks.add(current.toString())
+            current = StringBuilder()
+            currentBytes = 0
+        }
+        if (current.isNotEmpty()) {
+            current.append('\n')
+            currentBytes++
+        }
+        current.append(piece)
+        currentBytes += pieceBytes
+    }
+    if (current.isNotEmpty()) {
+        chunks.add(current.toString())
+    }
+    return chunks
+}
+
+/** Splits one line into pieces of at most [maxBytes] UTF-8 bytes, never mid-character. */
+private fun splitByUtf8Bytes(line: String, maxBytes: Int): Sequence<String> {
+    if (line.utf8Size() <= maxBytes) {
+        return sequenceOf(line)
+    }
+    return sequence {
+        val piece = StringBuilder()
+        var pieceBytes = 0
+        var index = 0
+        while (index < line.length) {
+            val codePoint = line.codePointAt(index)
+            val width = Character.charCount(codePoint)
+            val size = utf8Size(codePoint)
+            if (pieceBytes + size > maxBytes) {
+                yield(piece.toString())
+                piece.setLength(0)
+                pieceBytes = 0
+            }
+            piece.append(line, index, index + width)
+            pieceBytes += size
+            index += width
+        }
+        if (piece.isNotEmpty()) {
+            yield(piece.toString())
+        }
+    }
+}
+
+private fun String.utf8Size(): Int = toByteArray(Charsets.UTF_8).size
+
+private fun utf8Size(codePoint: Int): Int = when {
+    codePoint < 0x80 -> 1
+    codePoint < 0x800 -> 2
+    codePoint < 0x10000 -> 3
+    else -> 4
 }

--- a/android/app/src/main/java/com/fleetdm/agent/FleetLog.kt
+++ b/android/app/src/main/java/com/fleetdm/agent/FleetLog.kt
@@ -82,21 +82,26 @@ internal fun chunkForLogcat(text: String, maxBytes: Int): List<String> {
     val chunks = mutableListOf<String>()
     var current = StringBuilder()
     var currentBytes = 0
+    // Tracked separately from the builder's length: an empty line is a piece too, and dropping it
+    // because it added no characters would silently delete blank lines from the text.
+    var started = false
     for (piece in text.lineSequence().flatMap { splitByUtf8Bytes(it, maxBytes) }) {
         val pieceBytes = piece.utf8Size()
-        if (current.isNotEmpty() && currentBytes + 1 + pieceBytes > maxBytes) {
+        if (started && currentBytes + 1 + pieceBytes > maxBytes) {
             chunks.add(current.toString())
             current = StringBuilder()
             currentBytes = 0
+            started = false
         }
-        if (current.isNotEmpty()) {
+        if (started) {
             current.append('\n')
             currentBytes++
         }
         current.append(piece)
         currentBytes += pieceBytes
+        started = true
     }
-    if (current.isNotEmpty()) {
+    if (started) {
         chunks.add(current.toString())
     }
     return chunks

--- a/android/app/src/main/java/com/fleetdm/agent/LogRedaction.kt
+++ b/android/app/src/main/java/com/fleetdm/agent/LogRedaction.kt
@@ -21,8 +21,10 @@ private const val NON_SECRET_IDENTIFIER_FIELDS = 3
 
 // Challenges as they appear in a certificate template JSON body. kotlinx.serialization quotes the
 // offending input in its decoding errors, so a body that fails to parse can reach a log line. The
-// closing quote is optional because that quoted input may be cut off mid-value.
-private val JSON_CHALLENGE_FIELD = Regex("\"(scep_challenge|fleet_challenge)\"\\s*:\\s*\"[^\"]*(\"|$)")
+// value is matched as a JSON string, escapes included, so a challenge holding a quote doesn't cut
+// the match short. The closing quote is optional because the quoted input may be cut off mid-value.
+private val JSON_CHALLENGE_FIELD =
+    Regex("\"(scep_challenge|fleet_challenge)\"\\s*:\\s*\"[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*\\\\?(\"|$)")
 
 /**
  * Strips enrollment secrets from text on its way to a log, log file, or status detail.

--- a/android/app/src/main/java/com/fleetdm/agent/LogRedaction.kt
+++ b/android/app/src/main/java/com/fleetdm/agent/LogRedaction.kt
@@ -1,12 +1,17 @@
 package com.fleetdm.agent
 
 /** Stands in for a secret that must not reach logs. */
-const val REDACTED = "<redacted>"
+internal const val REDACTED = "<redacted>"
 
-// Fleet SCEP proxy URLs carry a one-time challenge as the last field of the comma-separated path
-// identifier ("{hostUUID},g{templateID},{caType},{challenge}"). jScep appends a query string to it,
-// so the identifier ends at the first "?" or whitespace.
-private val SCEP_PROXY_IDENTIFIER = Regex("""(/mdm/scep/proxy/)([^/?\s]+)""")
+/** Path of Fleet's SCEP proxy. Its URLs end with a one-time challenge. */
+internal const val SCEP_PROXY_PATH = "/mdm/scep/proxy/"
+
+// A SCEP proxy URL ends with the comma-separated identifier
+// "{hostUUID},g{templateID},{caType},{challenge}". jScep appends a query string, and whatever
+// message carries the URL often quotes or brackets it, so the identifier stops at the first "?",
+// whitespace, or closing delimiter. Dots stay allowed: a host UUID may contain one, and stopping
+// short of it would leave the challenge in the text.
+private val SCEP_PROXY_IDENTIFIER = Regex("""(${Regex.escape(SCEP_PROXY_PATH)})([^/?\s"'<>)\]}]+)""")
 
 // Commas are percent-encoded in some Fleet-generated SCEP URLs.
 private val IDENTIFIER_FIELD_SEPARATOR = Regex(""",|%2C""", RegexOption.IGNORE_CASE)
@@ -14,30 +19,48 @@ private val IDENTIFIER_FIELD_SEPARATOR = Regex(""",|%2C""", RegexOption.IGNORE_C
 // hostUUID, template ID and CA type are safe to log; everything after them is the challenge.
 private const val NON_SECRET_IDENTIFIER_FIELDS = 3
 
+// Challenges as they appear in a certificate template JSON body. kotlinx.serialization quotes the
+// offending input in its decoding errors, so a body that fails to parse can reach a log line. The
+// closing quote is optional because that quoted input may be cut off mid-value.
+private val JSON_CHALLENGE_FIELD = Regex("\"(scep_challenge|fleet_challenge)\"\\s*:\\s*\"[^\"]*(\"|$)")
+
 /**
  * Strips enrollment secrets from text on its way to a log, log file, or status detail.
  *
- * Redacts the challenge in Fleet SCEP proxy URLs, which reach us inside exception messages thrown
- * by the HTTP stack and jScep. Anyone with a USB cable can read logcat, so a challenge that lands
- * there is a challenge anyone can use.
+ * Redacts the challenge in Fleet SCEP proxy URLs and in certificate template JSON, both of which
+ * reach us inside exception messages thrown by the HTTP and serialization stacks. Anyone with a USB
+ * cable can read logcat, so a challenge that lands there is a challenge anyone can use.
  */
-fun String.redactSecrets(): String = SCEP_PROXY_IDENTIFIER.replace(this) { match ->
+internal fun String.redactSecrets(): String = redactScepProxyUrls().redactJsonChallenges()
+
+private fun String.redactScepProxyUrls(): String = SCEP_PROXY_IDENTIFIER.replace(this) { match ->
     val (prefix, identifier) = match.destructured
     val separators = IDENTIFIER_FIELD_SEPARATOR.findAll(identifier).take(NON_SECRET_IDENTIFIER_FIELDS).toList()
     val challengeStart = separators.lastOrNull()?.range?.last?.plus(1) ?: identifier.length
     if (separators.size < NON_SECRET_IDENTIFIER_FIELDS || challengeStart == identifier.length) {
-        // No challenge field, or it is empty: nothing to hide.
+        // Identifiers with fewer fields carry no challenge, and neither does an empty last field.
         match.value
     } else {
         prefix + identifier.take(challengeStart) + REDACTED
     }
 }
 
+private fun String.redactJsonChallenges(): String = JSON_CHALLENGE_FIELD.replace(this) { match ->
+    "\"${match.groupValues[1]}\":\"$REDACTED\""
+}
+
 /**
  * Renders a nullable secret for a log message: whether it is set stays visible, its value does not.
  */
-fun String?.redacted(): String = when {
+internal fun String?.redacted(): String = when {
     this == null -> "null"
     isEmpty() -> "\"\""
     else -> REDACTED
 }
+
+/**
+ * Builds the redacted text [FleetLog] writes for one entry: the message, and the stack trace of the
+ * throwable (cause chain included) when there is one.
+ */
+internal fun renderLogEntry(msg: String, throwable: Throwable?): Pair<String, String?> =
+    msg.redactSecrets() to throwable?.stackTraceToString()?.trimEnd()?.redactSecrets()

--- a/android/app/src/main/java/com/fleetdm/agent/LogRedaction.kt
+++ b/android/app/src/main/java/com/fleetdm/agent/LogRedaction.kt
@@ -1,0 +1,43 @@
+package com.fleetdm.agent
+
+/** Stands in for a secret that must not reach logs. */
+const val REDACTED = "<redacted>"
+
+// Fleet SCEP proxy URLs carry a one-time challenge as the last field of the comma-separated path
+// identifier ("{hostUUID},g{templateID},{caType},{challenge}"). jScep appends a query string to it,
+// so the identifier ends at the first "?" or whitespace.
+private val SCEP_PROXY_IDENTIFIER = Regex("""(/mdm/scep/proxy/)([^/?\s]+)""")
+
+// Commas are percent-encoded in some Fleet-generated SCEP URLs.
+private val IDENTIFIER_FIELD_SEPARATOR = Regex(""",|%2C""", RegexOption.IGNORE_CASE)
+
+// hostUUID, template ID and CA type are safe to log; everything after them is the challenge.
+private const val NON_SECRET_IDENTIFIER_FIELDS = 3
+
+/**
+ * Strips enrollment secrets from text on its way to a log, log file, or status detail.
+ *
+ * Redacts the challenge in Fleet SCEP proxy URLs, which reach us inside exception messages thrown
+ * by the HTTP stack and jScep. Anyone with a USB cable can read logcat, so a challenge that lands
+ * there is a challenge anyone can use.
+ */
+fun String.redactSecrets(): String = SCEP_PROXY_IDENTIFIER.replace(this) { match ->
+    val (prefix, identifier) = match.destructured
+    val separators = IDENTIFIER_FIELD_SEPARATOR.findAll(identifier).take(NON_SECRET_IDENTIFIER_FIELDS).toList()
+    val challengeStart = separators.lastOrNull()?.range?.last?.plus(1) ?: identifier.length
+    if (separators.size < NON_SECRET_IDENTIFIER_FIELDS || challengeStart == identifier.length) {
+        // No challenge field, or it is empty: nothing to hide.
+        match.value
+    } else {
+        prefix + identifier.take(challengeStart) + REDACTED
+    }
+}
+
+/**
+ * Renders a nullable secret for a log message: whether it is set stays visible, its value does not.
+ */
+fun String?.redacted(): String = when {
+    this == null -> "null"
+    isEmpty() -> "\"\""
+    else -> REDACTED
+}

--- a/android/app/src/main/java/com/fleetdm/agent/scep/ScepClientImpl.kt
+++ b/android/app/src/main/java/com/fleetdm/agent/scep/ScepClientImpl.kt
@@ -1,6 +1,7 @@
 package com.fleetdm.agent.scep
 
 import com.fleetdm.agent.GetCertificateTemplateResponse
+import com.fleetdm.agent.redactSecrets
 import org.bouncycastle.asn1.DERPrintableString
 import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers
 import org.bouncycastle.asn1.x500.X500Name
@@ -72,7 +73,7 @@ class ScepClientImpl : ScepClient {
             val server = try {
                 URL(scepUrl)
             } catch (e: Exception) {
-                throw ScepNetworkException("Invalid SCEP URL: $scepUrl", e)
+                throw ScepNetworkException("Invalid SCEP URL: ${scepUrl.redactSecrets()}", e)
             }
 
             // OptimisticCertificateVerifier is used intentionally because:

--- a/android/app/src/test/java/com/fleetdm/agent/FleetLogChunkingTest.kt
+++ b/android/app/src/test/java/com/fleetdm/agent/FleetLogChunkingTest.kt
@@ -1,0 +1,81 @@
+package com.fleetdm.agent
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * logcat caps an entry's payload in bytes, so a stack trace has to be split by encoded size --
+ * counting characters would still lose the tail of non-ASCII text.
+ */
+class FleetLogChunkingTest {
+
+    private fun utf8Size(text: String) = text.toByteArray(Charsets.UTF_8).size
+
+    @Test
+    fun `text within the limit stays one chunk`() {
+        assertEquals(listOf("short message"), chunkForLogcat("short message", 100))
+        assertEquals(listOf(""), chunkForLogcat("", 100))
+    }
+
+    @Test
+    fun `long text is split at line boundaries with nothing lost`() {
+        val lines = (1..40).map { "line $it: at com.fleetdm.agent.Something.method(Something.kt:$it)" }
+        val text = lines.joinToString("\n")
+
+        val chunks = chunkForLogcat(text, 200)
+
+        assertTrue(chunks.size > 1)
+        chunks.forEach { assertTrue(utf8Size(it) <= 200) }
+        assertEquals(text, chunks.joinToString("\n"))
+    }
+
+    @Test
+    fun `chunks respect the byte limit for multibyte text`() {
+        // Three bytes per character in UTF-8: a character-counting split would blow the limit.
+        val text = "私はテストです".repeat(60)
+
+        val chunks = chunkForLogcat(text, 120)
+
+        assertTrue(chunks.size > 1)
+        chunks.forEach { assertTrue("chunk was ${utf8Size(it)} bytes", utf8Size(it) <= 120) }
+        assertEquals(text, chunks.joinToString(""))
+    }
+
+    @Test
+    fun `a single overlong line is split without losing anything`() {
+        val text = "a".repeat(500)
+
+        val chunks = chunkForLogcat(text, 100)
+
+        assertEquals(5, chunks.size)
+        assertEquals(text, chunks.joinToString(""))
+    }
+
+    @Test
+    fun `surrogate pairs are never split`() {
+        val text = "🔐".repeat(50) // U+1F510, four UTF-8 bytes each
+
+        val chunks = chunkForLogcat(text, 30)
+
+        assertTrue(chunks.size > 1)
+        chunks.forEach {
+            assertTrue(utf8Size(it) <= 30)
+            // A split surrogate pair would not survive an encode/decode round trip.
+            assertEquals(it, String(it.toByteArray(Charsets.UTF_8), Charsets.UTF_8))
+        }
+        assertEquals(text, chunks.joinToString(""))
+    }
+
+    @Test
+    fun `mixed line lengths keep every line intact where they fit`() {
+        val text = "short\n" + "x".repeat(250) + "\nshort again"
+
+        val chunks = chunkForLogcat(text, 100)
+
+        chunks.forEach { assertTrue(utf8Size(it) <= 100) }
+        assertTrue(chunks.first().startsWith("short"))
+        assertTrue(chunks.last().endsWith("short again"))
+        assertEquals(text.filterNot { it == '\n' }, chunks.joinToString("").filterNot { it == '\n' })
+    }
+}

--- a/android/app/src/test/java/com/fleetdm/agent/FleetLogChunkingTest.kt
+++ b/android/app/src/test/java/com/fleetdm/agent/FleetLogChunkingTest.kt
@@ -68,6 +68,27 @@ class FleetLogChunkingTest {
     }
 
     @Test
+    fun `an empty line at a chunk boundary survives`() {
+        val line = "x".repeat(300)
+        val text = "$line\n\nnext"
+
+        val chunks = chunkForLogcat(text, 300)
+
+        assertTrue(chunks.size > 1)
+        assertEquals(text, chunks.joinToString("\n"))
+    }
+
+    @Test
+    fun `a leading empty line survives`() {
+        val text = "\n" + "a".repeat(90) + "\n" + "b".repeat(90)
+
+        val chunks = chunkForLogcat(text, 100)
+
+        assertTrue(chunks.size > 1)
+        assertEquals(text, chunks.joinToString("\n"))
+    }
+
+    @Test
     fun `mixed line lengths keep every line intact where they fit`() {
         val text = "short\n" + "x".repeat(250) + "\nshort again"
 

--- a/android/app/src/test/java/com/fleetdm/agent/LogRedactionTest.kt
+++ b/android/app/src/test/java/com/fleetdm/agent/LogRedactionTest.kt
@@ -194,6 +194,28 @@ class LogRedactionTest {
     }
 
     @Test
+    fun `redactSecrets hides a challenge containing an escaped quote`() {
+        // The JSON value is pass\"word-s3cr3t: a quote escaped inside the challenge itself.
+        val body = """JSON input: {"certificate":{"scep_challenge":"pass\"word-s3cr3t","status":"delivered"}}"""
+
+        val redacted = body.redactSecrets()
+
+        assertFalse(redacted.contains("word-s3cr3t"))
+        assertTrue(redacted.contains("\"scep_challenge\":\"$REDACTED\""))
+        assertTrue(redacted.contains("\"status\":\"delivered\""))
+    }
+
+    @Test
+    fun `redactSecrets hides a challenge cut off on an escape`() {
+        val truncated = "JSON input: {\"certificate\":{\"fleet_challenge\":\"fleet-s3cr\\"
+
+        val redacted = truncated.redactSecrets()
+
+        assertFalse(redacted.contains("fleet-s3cr"))
+        assertTrue(redacted.endsWith("\"fleet_challenge\":\"$REDACTED\""))
+    }
+
+    @Test
     fun `renderLogEntry redacts the message and the whole cause chain`() {
         val cause = java.io.FileNotFoundException(proxyUrl)
         val throwable = Exception("Error connecting to server", cause)

--- a/android/app/src/test/java/com/fleetdm/agent/LogRedactionTest.kt
+++ b/android/app/src/test/java/com/fleetdm/agent/LogRedactionTest.kt
@@ -1,0 +1,133 @@
+package com.fleetdm.agent
+
+import com.fleetdm.agent.testutil.TestCertificateTemplateFactory
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The SCEP challenge and the Fleet challenge are enrollment secrets, and anyone who can plug the
+ * device into a computer can read logcat. These tests pin down that neither reaches a log line.
+ */
+class LogRedactionTest {
+
+    private val proxyUrl = "https://fleet.example.com/mdm/scep/proxy/host-uuid-1234,g7,NDES,s3cr3t-challenge"
+
+    @Test
+    fun `certificate template toString hides both challenges`() {
+        val template = TestCertificateTemplateFactory.create(
+            scepChallenge = "scep-s3cr3t",
+            fleetChallenge = "fleet-s3cr3t",
+        )
+
+        val logged = template.toString()
+
+        assertFalse(logged.contains("scep-s3cr3t"))
+        assertFalse(logged.contains("fleet-s3cr3t"))
+        assertTrue(logged.contains("scepChallenge=$REDACTED"))
+        assertTrue(logged.contains("fleetChallenge=$REDACTED"))
+    }
+
+    @Test
+    fun `certificate template toString keeps troubleshooting fields`() {
+        val template = TestCertificateTemplateFactory.create(id = 42, name = "wifi-cert", status = "delivered")
+
+        val logged = template.toString()
+
+        assertTrue(logged.contains("id=42"))
+        assertTrue(logged.contains("name=wifi-cert"))
+        assertTrue(logged.contains("status=delivered"))
+        assertTrue(logged.contains("subjectName=CN=Test,O=FleetDM"))
+    }
+
+    @Test
+    fun `certificate template toString distinguishes missing from set challenges`() {
+        val template = GetCertificateTemplateResponse(
+            id = 1,
+            name = "test-cert",
+            certificateAuthorityId = 1,
+            certificateAuthorityName = "Test CA",
+            createdAt = "2024-01-01T00:00:00Z",
+            subjectName = "CN=Test",
+            certificateAuthorityType = "SCEP",
+            status = "delivered",
+            scepChallenge = null,
+            fleetChallenge = "",
+        )
+
+        val logged = template.toString()
+
+        assertTrue(logged.contains("scepChallenge=null"))
+        assertTrue(logged.contains("""fleetChallenge=""""))
+        assertFalse(logged.contains(REDACTED))
+    }
+
+    @Test
+    fun `redactSecrets hides the challenge in a scep proxy url`() {
+        assertEquals(
+            "https://fleet.example.com/mdm/scep/proxy/host-uuid-1234,g7,NDES,$REDACTED",
+            proxyUrl.redactSecrets(),
+        )
+    }
+
+    @Test
+    fun `redactSecrets keeps the query string appended by jscep`() {
+        val withQuery = "$proxyUrl?operation=PKIOperation&message=abc123"
+
+        assertEquals(
+            "https://fleet.example.com/mdm/scep/proxy/host-uuid-1234,g7,NDES,$REDACTED?operation=PKIOperation&message=abc123",
+            withQuery.redactSecrets(),
+        )
+    }
+
+    @Test
+    fun `redactSecrets hides a percent encoded challenge`() {
+        val encoded = "https://fleet.example.com/mdm/scep/proxy/host-uuid-1234%2Cg7%2CNDES%2Cs3cr3t-challenge"
+
+        assertEquals(
+            "https://fleet.example.com/mdm/scep/proxy/host-uuid-1234%2Cg7%2CNDES%2C$REDACTED",
+            encoded.redactSecrets(),
+        )
+    }
+
+    @Test
+    fun `redactSecrets hides the challenge inside a wrapped exception message`() {
+        val cause = java.io.FileNotFoundException(proxyUrl)
+        val wrapped = Exception("Error connecting to server", cause)
+
+        val rendered = wrapped.stackTraceToString().redactSecrets()
+
+        assertFalse(rendered.contains("s3cr3t-challenge"))
+        assertTrue(rendered.contains("host-uuid-1234,g7,NDES,$REDACTED"))
+    }
+
+    @Test
+    fun `redactSecrets leaves urls without a challenge alone`() {
+        val noChallenge = "https://fleet.example.com/mdm/scep/proxy/host-uuid-1234,g7,NDES"
+        val emptyChallenge = "https://fleet.example.com/mdm/scep/proxy/host-uuid-1234,g7,NDES,"
+
+        assertEquals(noChallenge, noChallenge.redactSecrets())
+        assertEquals(emptyChallenge, emptyChallenge.redactSecrets())
+    }
+
+    @Test
+    fun `redactSecrets leaves unrelated text alone`() {
+        val unrelated = "DNS resolution failed for GET /api/fleetd/certificates/7: fleet.example.com"
+        val malformed = "Invalid SCEP URL: http://[invalid"
+
+        assertEquals(unrelated, unrelated.redactSecrets())
+        assertEquals(malformed, malformed.redactSecrets())
+    }
+
+    @Test
+    fun `redactSecrets redacts every proxy url in the text`() {
+        val twoUrls = "first $proxyUrl then https://fleet.example.com/mdm/scep/proxy/other-uuid,g8,DIGICERT,other-secret"
+
+        val redacted = twoUrls.redactSecrets()
+
+        assertFalse(redacted.contains("s3cr3t-challenge"))
+        assertFalse(redacted.contains("other-secret"))
+        assertTrue(redacted.contains("other-uuid,g8,DIGICERT,$REDACTED"))
+    }
+}

--- a/android/app/src/test/java/com/fleetdm/agent/LogRedactionTest.kt
+++ b/android/app/src/test/java/com/fleetdm/agent/LogRedactionTest.kt
@@ -3,6 +3,7 @@ package com.fleetdm.agent
 import com.fleetdm.agent.testutil.TestCertificateTemplateFactory
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -59,8 +60,34 @@ class LogRedactionTest {
         val logged = template.toString()
 
         assertTrue(logged.contains("scepChallenge=null"))
-        assertTrue(logged.contains("""fleetChallenge=""""))
+        assertTrue(logged.contains("fleetChallenge=\"\""))
         assertFalse(logged.contains(REDACTED))
+    }
+
+    @Test
+    fun `certificate template result toString hides the url challenge`() {
+        val template = TestCertificateTemplateFactory.create(fleetChallenge = "fleet-s3cr3t")
+        val result = CertificateTemplateResult(
+            template = template,
+            scepUrl = template.buildScepUrl(serverUrl = "https://fleet.example.com", hostUUID = "host-uuid-1234"),
+        )
+
+        val logged = result.toString()
+
+        assertFalse(logged.contains("fleet-s3cr3t"))
+        assertTrue(logged.contains("host-uuid-1234,g1,SCEP,$REDACTED"))
+    }
+
+    @Test
+    fun `redactSecrets hides the challenge in a url built by buildScepUrl`() {
+        val template = TestCertificateTemplateFactory.create(fleetChallenge = "fleet-s3cr3t")
+
+        val url = template.buildScepUrl(serverUrl = "https://fleet.example.com", hostUUID = "host-uuid-1234")
+        val redacted = url.redactSecrets()
+
+        assertTrue(url.contains("fleet-s3cr3t"))
+        assertFalse(redacted.contains("fleet-s3cr3t"))
+        assertTrue(redacted.endsWith(REDACTED))
     }
 
     @Test
@@ -89,6 +116,16 @@ class LogRedactionTest {
             "https://fleet.example.com/mdm/scep/proxy/host-uuid-1234%2Cg7%2CNDES%2C$REDACTED",
             encoded.redactSecrets(),
         )
+    }
+
+    @Test
+    fun `redactSecrets keeps a closing delimiter after the url`() {
+        val quoted = "{\"url\":\"$proxyUrl\"}"
+
+        val redacted = quoted.redactSecrets()
+
+        assertFalse(redacted.contains("s3cr3t-challenge"))
+        assertEquals("{\"url\":\"https://fleet.example.com/mdm/scep/proxy/host-uuid-1234,g7,NDES,$REDACTED\"}", redacted)
     }
 
     @Test
@@ -129,5 +166,52 @@ class LogRedactionTest {
         assertFalse(redacted.contains("s3cr3t-challenge"))
         assertFalse(redacted.contains("other-secret"))
         assertTrue(redacted.contains("other-uuid,g8,DIGICERT,$REDACTED"))
+    }
+
+    @Test
+    fun `redactSecrets hides challenges quoted from a certificate template body`() {
+        val body = "{\"certificate\":{\"id\":7,\"name\":\"wifi-cert\"," +
+            "\"scep_challenge\":\"scep-s3cr3t\",\"fleet_challenge\": \"fleet-s3cr3t\",\"status\":\"delivered\"}}"
+        val decodingError = "Unexpected JSON token at offset 210: Expected quotation mark\nJSON input: $body"
+
+        val redacted = decodingError.redactSecrets()
+
+        assertFalse(redacted.contains("scep-s3cr3t"))
+        assertFalse(redacted.contains("fleet-s3cr3t"))
+        assertTrue(redacted.contains("\"scep_challenge\":\"$REDACTED\""))
+        assertTrue(redacted.contains("\"fleet_challenge\":\"$REDACTED\""))
+        assertTrue(redacted.contains("\"name\":\"wifi-cert\""))
+    }
+
+    @Test
+    fun `redactSecrets hides a challenge cut off mid value`() {
+        val truncated = "JSON input: {\"certificate\":{\"name\":\"wifi-cert\",\"fleet_challenge\":\"fleet-s3cr"
+
+        val redacted = truncated.redactSecrets()
+
+        assertFalse(redacted.contains("fleet-s3cr"))
+        assertTrue(redacted.endsWith("\"fleet_challenge\":\"$REDACTED\""))
+    }
+
+    @Test
+    fun `renderLogEntry redacts the message and the whole cause chain`() {
+        val cause = java.io.FileNotFoundException(proxyUrl)
+        val throwable = Exception("Error connecting to server", cause)
+
+        val (message, stackTrace) = renderLogEntry("Certificate enrollment failed for $proxyUrl", throwable)
+
+        assertFalse(message.contains("s3cr3t-challenge"))
+        assertTrue(message.endsWith("host-uuid-1234,g7,NDES,$REDACTED"))
+        assertFalse(stackTrace!!.contains("s3cr3t-challenge"))
+        assertTrue(stackTrace.contains("Caused by"))
+        assertTrue(stackTrace.contains("host-uuid-1234,g7,NDES,$REDACTED"))
+    }
+
+    @Test
+    fun `renderLogEntry has no stack trace without a throwable`() {
+        val (message, stackTrace) = renderLogEntry("plain message", null)
+
+        assertEquals("plain message", message)
+        assertNull(stackTrace)
     }
 }

--- a/android/app/src/test/java/com/fleetdm/agent/scep/ScepClientImplTest.kt
+++ b/android/app/src/test/java/com/fleetdm/agent/scep/ScepClientImplTest.kt
@@ -1,5 +1,6 @@
 package com.fleetdm.agent.scep
 
+import com.fleetdm.agent.REDACTED
 import com.fleetdm.agent.testutil.TestCertificateTemplateFactory
 import org.bouncycastle.asn1.DERIA5String
 import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers
@@ -44,6 +45,20 @@ class ScepClientImplTest {
             fail("Expected ScepNetworkException to be thrown")
         } catch (e: ScepNetworkException) {
             assertTrue(e.message?.contains("Invalid SCEP URL") == true)
+        }
+    }
+
+    @Test
+    fun `enroll with malformed URL does not leak the challenge in the error`() = runTest {
+        val template = TestCertificateTemplateFactory.create()
+        val malformedUrl = "htp:/[invalid/mdm/scep/proxy/host-uuid,g7,NDES,s3cr3t-challenge"
+
+        try {
+            scepClient.enroll(template, malformedUrl)
+            fail("Expected ScepNetworkException to be thrown")
+        } catch (e: ScepNetworkException) {
+            assertFalse(e.message?.contains("s3cr3t-challenge") == true)
+            assertTrue(e.message?.contains("host-uuid,g7,NDES,$REDACTED") == true)
         }
     }
 

--- a/android/changes/17177-android-scep-challenge-logs
+++ b/android/changes/17177-android-scep-challenge-logs
@@ -1,0 +1,1 @@
+* Stopped the Android agent from writing SCEP enrollment secrets to the device logs. The certificate template's SCEP challenge and Fleet challenge are now redacted in logcat, in the on-device error log, and in certificate status details reported to Fleet.


### PR DESCRIPTION
**Related issue:** Resolves https://github.com/fleetdm/confidential/issues/17177

The Android agent printed the SCEP challenge to logcat, so anyone who could plug the device into a computer could read a live enrollment secret out of Android Studio.

The enrollment log line in `CertificateOrchestrator` interpolates the whole certificate template, and the generated data class `toString()` includes `scep_challenge` (the CA challenge password) and `fleet_challenge` (Fleet's one-time SCEP proxy secret, consumed server-side via `ConsumeChallenge`).

Fixed at the sources rather than at the one log line, since the same data reaches logs several ways:

- `GetCertificateTemplateResponse.toString()` and `CertificateTemplateResult.toString()` redact the challenges, so any log line that interpolates a template or its SCEP URL is safe. `null`, empty and set challenges stay distinguishable for troubleshooting.
- New `LogRedaction.kt` strips the challenge from Fleet SCEP proxy URLs (`/mdm/scep/proxy/{hostUUID},g{templateID},{caType},{challenge}`, literal or percent-encoded commas) and from `scep_challenge`/`fleet_challenge` fields in certificate template JSON, which kotlinx.serialization quotes back in its decoding errors.
- `ScepClientImpl` redacts the URL before putting it in a `ScepNetworkException` message, which reaches both logcat and the certificate status `detail` reported to Fleet. The status `detail` is also redacted at the sink in `ApiClient.updateCertificateStatus` so this doesn't depend on every throw site behaving.
- `FleetLog.e` renders the throwable itself and redacts it, instead of handing it to `Log.e(tag, msg, throwable)` — which prints the whole cause chain, and jscep wraps `HttpURLConnection` exceptions whose messages can contain the full request URL. Output is chunked across logcat entries so long traces aren't truncated. `readErrors()` redacts on read too, so a log file written by an older build can't surface secrets on the debug screen.

Two behavior changes worth noting for review:

- `fleet_errors.log` now records full `Caused by:` chains, where it previously kept only the outermost throwable's frames. More useful, but entries are larger, so the 512 KB cap rotates sooner and the file holds less history.
- `jscep` logs the proxy URL itself at slf4j DEBUG. That's inert today because the bundled `slf4j-simple` defaults to INFO, but redaction can't intercept it if anyone lowers the level.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests

New `LogRedactionTest` (17 cases) covers the redacted `toString()`s, the URL redactor (query string appended by jscep, percent-encoded commas, multiple URLs in one string, closing delimiters, identifiers with no challenge or an empty one, unrelated text), the JSON cases including a value cut off mid-string, and the pure part of `FleetLog`'s rendering against a nested cause chain. `ScepClientImplTest` gained a case asserting the malformed-URL error carries no challenge. There is also a test that runs `buildScepUrl` output through the redactor, so the two can't drift apart.

`./gradlew :app:testDebugUnitTest :app:spotlessCheck :app:detekt` — 101 tests, 0 failures (5 SCEP integration tests skipped, no live SCEP server).

- [ ] QA'd all new/changed functionality manually

To verify on a device: enroll a certificate template through Android MDM, then `adb logcat | grep -i fleet`. The `Starting SCEP enrollment for certificate:` line should show `scepChallenge=<redacted>, fleetChallenge=<redacted>`, and no line should contain the values in `certificate_templates.scep_challenge` / `host_certificate_templates.fleet_challenge`. Point the template at an unreachable CA to confirm the failure's stack trace shows `...,g7,NDES,<redacted>`.

## fleetd/orbit/Fleet Desktop

- [x] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes

Android agent only; no Go, server, or frontend changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * SCEP and Fleet enrollment secrets are now hidden from device logs, error reports, malformed URL messages, and certificate status details.
  * Non-sensitive certificate and diagnostic information remains available for troubleshooting.
* **Improvements**
  * Logcat and stored log entries now handle long messages and stack traces more reliably while applying secret redaction.
* **Documentation**
  * Added release documentation describing improved protection for Android SCEP enrollment secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->