### PR TITLE
Fall back to older winget versions when the newest has no matching installer

### DIFF
--- a/ee/maintained-apps/ingesters/homebrew/ingester.go
+++ b/ee/maintained-apps/ingesters/homebrew/ingester.go
@@ -84,7 +84,7 @@ func IngestApps(ctx context.Context, logger *slog.Logger, inputsPath, slugFilter
 
 		outApp, err := i.ingestOne(ctx, input)
 		if err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "ingesting homebrew app")
+			return nil, ctxerr.Wrapf(ctx, err, "ingesting homebrew app %s", input.Slug)
 		}
 
 		manifestApps = append(manifestApps, outApp)

--- a/ee/maintained-apps/ingesters/winget/ingester.go
+++ b/ee/maintained-apps/ingesters/winget/ingester.go
@@ -100,7 +100,7 @@ func IngestApps(ctx context.Context, logger *slog.Logger, inputsPath string, slu
 					"name", input.Name, "err", err)
 				continue
 			}
-			return nil, ctxerr.Wrap(ctx, err, "ingesting winget app")
+			return nil, ctxerr.Wrapf(ctx, err, "ingesting winget app %s", input.Slug)
 		}
 
 		manifestApps = append(manifestApps, outApp)
@@ -161,132 +161,17 @@ func wingetVersionManifestDirs(contents []*github.RepositoryContent) []*github.R
 	return out
 }
 
-func (i *wingetIngester) ingestOne(ctx context.Context, input inputApp) (*maintained_apps.FMAManifestApp, error) {
-	// this is the path within the winget GitHub repo where the manifests are located
-	dirPath := path.Join(
-		"manifests",
-		strings.ToLower(input.PackageIdentifier[:1]),
-		strings.ReplaceAll(input.PackageIdentifier, ".", "/"),
-	)
+// maxInstallerFallbackVersions bounds how far back ingestOne walks when a package's
+// newest versions carry no installer matching the input's arch/type/scope. Upstream
+// blips (a release that ships MSIX only, a Scope that flips machine->user) clear
+// within a version or two, while a misconfigured input never matches at all; without
+// a bound that input would burn a pair of GitHub API calls per historical version.
+const maxInstallerFallbackVersions = 5
 
-	_, repoContents, _, err := i.githubClient.Repositories.GetContents(ctx,
-		"microsoft",
-		"winget-pkgs",
-		dirPath,
-		i.ghClientOpts,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("get data from winget repo: %w", err)
-	}
-
-	versionDirs := wingetVersionManifestDirs(repoContents)
-	if len(versionDirs) == 0 {
-		return nil, ctxerr.NewWithData(ctx, "no version manifest directories found under package path", map[string]any{
-			"path": dirPath,
-		})
-	}
-
-	// sort the list of directories in descending order
-	slices.SortFunc(versionDirs, func(a, b *github.RepositoryContent) int { return feednvd.SmartVerCmp(b.GetName(), a.GetName()) })
-
-	// Try version directories in descending order. Some packages have nested
-	// grouping directories (e.g. "2020/20.001.30002") that look like version
-	// dirs but don't contain manifest files at the expected depth. Skip those
-	// and fall through to the next candidate.
-	var m installerManifest
-	var l localeManifest
-	var versionFound bool
-	for _, versionDir := range versionDirs {
-		vName := versionDir.GetName()
-		if vName == "" {
-			continue
-		}
-
-		installerManifestPath := path.Join(
-			dirPath,
-			vName,
-			fmt.Sprintf("%s.installer.yaml", input.PackageIdentifier),
-		)
-
-		fileContents, _, _, err := i.githubClient.Repositories.GetContents(ctx,
-			"microsoft",
-			"winget-pkgs",
-			installerManifestPath,
-			i.ghClientOpts,
-		)
-		if err != nil {
-			// only a genuine 404 may fall through to an older version dir
-			if ghErr, ok := errors.AsType[*github.ErrorResponse](err); ok &&
-				ghErr.Response != nil && ghErr.Response.StatusCode == http.StatusNotFound {
-				i.logger.DebugContext(ctx, "installer manifest not found, trying next version", "version", vName, "err", err)
-				continue
-			}
-			return nil, ctxerr.Wrap(ctx, err, "getting winget installer manifest file contents")
-		}
-
-		contents, err := fileContents.GetContent()
-		if err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "extracting installer manifest file contents")
-		}
-
-		if err := yaml.Unmarshal([]byte(contents), &m); err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "unmarshaling winget manifest")
-		}
-
-		localeManifestPath := path.Join(dirPath, vName, fmt.Sprintf("%s.locale.en-US.yaml", input.PackageIdentifier))
-		fileContents, _, _, err = i.githubClient.Repositories.GetContents(ctx,
-			"microsoft",
-			"winget-pkgs",
-			localeManifestPath,
-			i.ghClientOpts,
-		)
-		if err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "getting winget manifest locale file contents")
-		}
-
-		contents, err = fileContents.GetContent()
-		if err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "getting locale manifest contents")
-		}
-
-		if err := yaml.Unmarshal([]byte(contents), &l); err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "unmarshaling winget locale manifest")
-		}
-
-		versionFound = true
-		break
-	}
-
-	if !versionFound {
-		return nil, ctxerr.NewWithData(ctx, "no valid version manifest found for app", map[string]any{
-			"path": dirPath,
-		})
-	}
-
-	var out maintained_apps.FMAManifestApp
+// selectInstaller returns the entry in m whose architecture, installer type, scope and
+// locale match what the input asks for, or nil when the manifest carries no such entry.
+func (i *wingetIngester) selectInstaller(ctx context.Context, input inputApp, m installerManifest) *installer {
 	var selectedInstaller *installer
-	var installScript, uninstallScript string
-	productCode := m.ProductCode
-
-	// if we have a provided install script, use that
-	if input.InstallScriptPath != "" {
-		scriptBytes, err := os.ReadFile(input.InstallScriptPath)
-		if err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "reading provided install script file")
-		}
-
-		installScript = string(scriptBytes)
-	}
-
-	if input.UninstallScriptPath != "" {
-		scriptBytes, err := os.ReadFile(input.UninstallScriptPath)
-		if err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "reading provided uninstall script file")
-		}
-
-		uninstallScript = string(scriptBytes)
-	}
-
 	for _, installer := range m.Installers {
 		i.logger.DebugContext(ctx, "checking installer", "arch", installer.Architecture, "type", installer.InstallerType, "locale", installer.InstallerLocale, "scope", installer.Scope)
 		installerType := m.InstallerType
@@ -345,8 +230,7 @@ func (i *wingetIngester) ingestOne(ctx context.Context, input inputApp) (*mainta
 			urlExt := strings.Trim(filepath.Ext(installer.InstallerURL), ".")
 			if urlExt == input.InstallerType {
 				// Perfect match - URL extension matches desired type
-				selectedInstaller = &installer
-				break
+				return &installer
 			}
 			// Keep as fallback candidate if we haven't found a perfect match yet
 			if selectedInstaller == nil {
@@ -356,8 +240,167 @@ func (i *wingetIngester) ingestOne(ctx context.Context, input inputApp) (*mainta
 
 	}
 
-	if selectedInstaller == nil {
-		return nil, ctxerr.New(ctx, "failed to find installer for app")
+	return selectedInstaller
+}
+
+func (i *wingetIngester) ingestOne(ctx context.Context, input inputApp) (*maintained_apps.FMAManifestApp, error) {
+	// this is the path within the winget GitHub repo where the manifests are located
+	dirPath := path.Join(
+		"manifests",
+		strings.ToLower(input.PackageIdentifier[:1]),
+		strings.ReplaceAll(input.PackageIdentifier, ".", "/"),
+	)
+
+	_, repoContents, _, err := i.githubClient.Repositories.GetContents(ctx,
+		"microsoft",
+		"winget-pkgs",
+		dirPath,
+		i.ghClientOpts,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get data from winget repo: %w", err)
+	}
+
+	versionDirs := wingetVersionManifestDirs(repoContents)
+	if len(versionDirs) == 0 {
+		return nil, ctxerr.NewWithData(ctx, "no version manifest directories found under package path", map[string]any{
+			"path": dirPath,
+		})
+	}
+
+	// sort the list of directories in descending order
+	slices.SortFunc(versionDirs, func(a, b *github.RepositoryContent) int { return feednvd.SmartVerCmp(b.GetName(), a.GetName()) })
+
+	// Try version directories in descending order. Some packages have nested
+	// grouping directories (e.g. "2020/20.001.30002") that look like version
+	// dirs but don't contain manifest files at the expected depth. Skip those
+	// and fall through to the next candidate. A version whose manifest carries no
+	// installer matching this input falls through the same way, since upstream
+	// sometimes drops our arch/type/scope combination for a release or two.
+	var m installerManifest
+	var l localeManifest
+	var selectedInstaller *installer
+	var versionFound bool
+	var mismatchedVersions []string
+	for _, versionDir := range versionDirs {
+		if len(mismatchedVersions) >= maxInstallerFallbackVersions {
+			break
+		}
+
+		vName := versionDir.GetName()
+		if vName == "" {
+			continue
+		}
+
+		installerManifestPath := path.Join(
+			dirPath,
+			vName,
+			fmt.Sprintf("%s.installer.yaml", input.PackageIdentifier),
+		)
+
+		fileContents, _, _, err := i.githubClient.Repositories.GetContents(ctx,
+			"microsoft",
+			"winget-pkgs",
+			installerManifestPath,
+			i.ghClientOpts,
+		)
+		if err != nil {
+			// only a genuine 404 may fall through to an older version dir
+			if ghErr, ok := errors.AsType[*github.ErrorResponse](err); ok &&
+				ghErr.Response != nil && ghErr.Response.StatusCode == http.StatusNotFound {
+				i.logger.DebugContext(ctx, "installer manifest not found, trying next version", "version", vName, "err", err)
+				continue
+			}
+			return nil, ctxerr.Wrap(ctx, err, "getting winget installer manifest file contents")
+		}
+
+		contents, err := fileContents.GetContent()
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "extracting installer manifest file contents")
+		}
+
+		var vm installerManifest
+		if err := yaml.Unmarshal([]byte(contents), &vm); err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "unmarshaling winget manifest")
+		}
+
+		candidate := i.selectInstaller(ctx, input, vm)
+		if candidate == nil {
+			i.logger.DebugContext(ctx, "no installer matching input in winget manifest, trying next version",
+				"version", vName, "arch", input.InstallerArch,
+				"type", input.InstallerType, "scope", input.InstallerScope)
+			mismatchedVersions = append(mismatchedVersions, vName)
+			continue
+		}
+
+		localeManifestPath := path.Join(dirPath, vName, fmt.Sprintf("%s.locale.en-US.yaml", input.PackageIdentifier))
+		fileContents, _, _, err = i.githubClient.Repositories.GetContents(ctx,
+			"microsoft",
+			"winget-pkgs",
+			localeManifestPath,
+			i.ghClientOpts,
+		)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "getting winget manifest locale file contents")
+		}
+
+		contents, err = fileContents.GetContent()
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "getting locale manifest contents")
+		}
+
+		if err := yaml.Unmarshal([]byte(contents), &l); err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "unmarshaling winget locale manifest")
+		}
+
+		m = vm
+		selectedInstaller = candidate
+		versionFound = true
+		break
+	}
+
+	if !versionFound {
+		if len(mismatchedVersions) > 0 {
+			return nil, ctxerr.NewWithData(ctx, "failed to find installer for app", map[string]any{
+				"path":             dirPath,
+				"arch":             input.InstallerArch,
+				"installer_type":   input.InstallerType,
+				"scope":            input.InstallerScope,
+				"versions_checked": mismatchedVersions,
+			})
+		}
+
+		return nil, ctxerr.NewWithData(ctx, "no valid version manifest found for app", map[string]any{
+			"path": dirPath,
+		})
+	}
+
+	if len(mismatchedVersions) > 0 {
+		i.logger.WarnContext(ctx, "ingesting an older version: newer winget manifests had no matching installer",
+			"name", input.Name, "version", m.PackageVersion, "skipped_versions", mismatchedVersions)
+	}
+
+	var out maintained_apps.FMAManifestApp
+	var installScript, uninstallScript string
+	productCode := m.ProductCode
+
+	// if we have a provided install script, use that
+	if input.InstallScriptPath != "" {
+		scriptBytes, err := os.ReadFile(input.InstallScriptPath)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "reading provided install script file")
+		}
+
+		installScript = string(scriptBytes)
+	}
+
+	if input.UninstallScriptPath != "" {
+		scriptBytes, err := os.ReadFile(input.UninstallScriptPath)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "reading provided uninstall script file")
+		}
+
+		uninstallScript = string(scriptBytes)
 	}
 
 	if input.InstallerType == installerTypeMSI && input.InstallerScope == machineScope {

--- a/ee/maintained-apps/ingesters/winget/ingester_test.go
+++ b/ee/maintained-apps/ingesters/winget/ingester_test.go
@@ -3,6 +3,7 @@ package winget
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -616,6 +617,79 @@ func newTwoVersionServer(t *testing.T, latestInstallerStatus int) *httptest.Serv
 	}))
 }
 
+// newMismatchedInstallerServer serves a package whose newest version dirs publish only
+// an MSIX installer while an older version still publishes the machine-scope MSI. This
+// is the shape ImageGlass took when its winget manifest went MSIX-only for a release.
+// The MSI lives in version "1.0"; every version in msixVersions gets an MSIX-only manifest.
+func newMismatchedInstallerServer(t *testing.T, msixVersions []string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeYAMLContent := func(v any) {
+			bytes, err := yaml.Marshal(v)
+			if err != nil {
+				t.Errorf("marshaling fixture: %v", err)
+				return
+			}
+			str := string(bytes)
+			content := &github.RepositoryContent{Name: new("Foo"), Content: &str}
+			if err := json.NewEncoder(w).Encode(content); err != nil {
+				t.Errorf("encoding fixture: %v", err)
+			}
+		}
+
+		if r.URL.Path == "/repos/microsoft/winget-pkgs/contents/manifests/f/Foo" {
+			content := []github.RepositoryContent{{Name: new("1.0"), Type: new("dir")}}
+			for _, v := range msixVersions {
+				content = append(content, github.RepositoryContent{Name: new(v), Type: new("dir")})
+			}
+			if err := json.NewEncoder(w).Encode(content); err != nil {
+				t.Errorf("encoding fixture: %v", err)
+			}
+			return
+		}
+
+		for _, v := range msixVersions {
+			if r.URL.Path == fmt.Sprintf("/repos/microsoft/winget-pkgs/contents/manifests/f/Foo/%s/Foo.installer.yaml", v) {
+				writeYAMLContent(installerManifest{
+					InstallerType:  "msix",
+					PackageVersion: v,
+					Installers: []installer{
+						{Architecture: "x64", InstallerURL: fmt.Sprintf("https://example.com/foo-%s.msix", v)},
+						{Architecture: "arm64", InstallerURL: fmt.Sprintf("https://example.com/foo-%s-arm.msix", v)},
+					},
+				})
+				return
+			}
+		}
+
+		switch r.URL.Path {
+		case "/repos/microsoft/winget-pkgs/contents/manifests/f/Foo/1.0/Foo.installer.yaml":
+			writeYAMLContent(installerManifest{
+				ProductCode:    "{ABCDEF}",
+				InstallerType:  "msi",
+				PackageVersion: "1.0",
+				Installers: []installer{
+					{
+						Architecture:  "x64",
+						InstallerType: "msi",
+						Scope:         "machine",
+						ProductCode:   "{ABCDEF}",
+						InstallerURL:  "https://example.com/foo-1.0.msi",
+					},
+				},
+			})
+
+		case "/repos/microsoft/winget-pkgs/contents/manifests/f/Foo/1.0/Foo.locale.en-US.yaml":
+			writeYAMLContent(localeManifest{PackageName: "foo", Publisher: "Bar, Inc."})
+
+		default:
+			w.WriteHeader(http.StatusBadRequest)
+			// Locale manifests for skipped versions are never fetched: the installer
+			// match is decided before we spend a second API call on the version.
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+	}))
+}
+
 func TestIngestOneVersionWalk(t *testing.T) {
 	ctx := context.Background()
 	input := inputApp{
@@ -663,6 +737,30 @@ func TestIngestOneVersionWalk(t *testing.T) {
 		require.Error(t, err)
 		require.ErrorContains(t, err, "504")
 		require.True(t, isTransientGitHubError(err), "the caller must recognize this error and skip the app")
+	})
+
+	t.Run("latest version without a matching installer falls through to the next", func(t *testing.T) {
+		srv := newMismatchedInstallerServer(t, []string{"2.0"})
+		t.Cleanup(srv.Close)
+
+		out, err := newIngester(srv).ingestOne(ctx, input)
+		require.NoError(t, err)
+		require.Equal(t, "1.0", out.Version)
+		require.Equal(t, "https://example.com/foo-1.0.msi", out.InstallerURL)
+	})
+
+	t.Run("the fallback walk is bounded so a misconfigured input fails fast", func(t *testing.T) {
+		// Enough MSIX-only versions to exhaust the budget before the walk reaches the
+		// "1.0" MSI it would otherwise have matched.
+		var msix []string
+		for v := maxInstallerFallbackVersions + 1; v >= 2; v-- {
+			msix = append(msix, fmt.Sprintf("%d.0", v))
+		}
+		srv := newMismatchedInstallerServer(t, msix)
+		t.Cleanup(srv.Close)
+
+		_, err := newIngester(srv).ingestOne(ctx, input)
+		require.ErrorContains(t, err, "failed to find installer for app")
 	})
 }
 

--- a/ee/maintained-apps/outputs/imageglass/windows.json
+++ b/ee/maintained-apps/outputs/imageglass/windows.json
@@ -1,24 +1,24 @@
 {
   "versions": [
     {
-      "version": "10.0.4.819",
+      "version": "9.6.1.807",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'ImageGlass' AND publisher = 'Duong Dieu Phap';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'ImageGlass' AND publisher = 'Duong Dieu Phap' AND version_compare(version, '10.0.4.819') < 0);",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'ImageGlass' AND publisher = 'Duong Dieu Phap' AND version_compare(version, '9.6.1.807') < 0);",
         "open": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE LOWER(name) = 'imageglass.exe');"
       },
-      "installer_url": "https://github.com/d2phap/ImageGlass/releases/download/10.0.4.819/ImageGlass_10.0.4.819_win-x64.msi",
+      "installer_url": "https://github.com/d2phap/ImageGlass/releases/download/9.6.1.807/ImageGlass_9.6.1.807_x64.msi",
       "install_script_ref": "72349997",
-      "uninstall_script_ref": "7be3c7fc",
-      "sha256": "2c3bbce3cb4114e55cbd7af90797a1a9debf9a3016f89a61ddcd235ef1388a16",
+      "uninstall_script_ref": "132bf6ab",
+      "sha256": "1f08209adb9456860ac2a71a74395456ccdf1bd9fc640f43d44b3b34788ddc0a",
       "default_categories": [
         "Productivity"
       ],
-      "upgrade_code": "{E89561C1-5B73-481B-86F4-109283B7B230}"
+      "upgrade_code": "{877DB994-AB03-4025-B99D-41CE565E810B}"
     }
   ],
   "refs": {
-    "72349997": "# Learn more about install scripts:\n# http://fleetdm.com/learn-more-about/install-scripts\n#\n# The ImageGlass MSI is dual-scope (ALLUSERS=2). Pass ALLUSERS=1 to force a\n# per-machine install under Fleet's SYSTEM context.\n\n$logFile = \"${env:TEMP}/fleet-install-software.log\"\n\ntry {\n\n$installProcess = Start-Process msiexec.exe `\n  -ArgumentList \"/quiet /norestart /lv `\"${logFile}`\" ALLUSERS=1 /i `\"${env:INSTALLER_PATH}`\"\" `\n  -PassThru -Verb RunAs -Wait\n\nGet-Content $logFile -Tail 500\n\nif ($installProcess.ExitCode -eq 3010 -or $installProcess.ExitCode -eq 1641) { Exit 0 }\nExit $installProcess.ExitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n",
-    "7be3c7fc": "# Fleet uninstalls app by finding all related product codes for the specified upgrade code\n$inst = New-Object -ComObject \"WindowsInstaller.Installer\"\n$timeoutSeconds = 300  # 5 minute timeout per product\n\n# MSI exit codes that indicate success. 3010 = ERROR_SUCCESS_REBOOT_REQUIRED,\n# 1641 = ERROR_SUCCESS_REBOOT_INITIATED. Treat these as success rather than failure.\n$successCodes = @(0, 3010, 1641)\n\nforeach ($product_code in $inst.RelatedProducts('{E89561C1-5B73-481B-86F4-109283B7B230}')) {\n    $process = Start-Process msiexec -ArgumentList @(\"/quiet\", \"/x\", $product_code, \"/norestart\") -PassThru\n\n    # Wait for process with timeout\n    $completed = $process.WaitForExit($timeoutSeconds * 1000)\n\n    if (-not $completed) {\n        Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue\n        Exit 1603  # ERROR_UNINSTALL_FAILURE\n    }\n\n    # If the uninstall failed, bail\n    if ($successCodes -notcontains $process.ExitCode) {\n        Write-Output \"Uninstall for $($product_code) exited $($process.ExitCode)\"\n        Exit $process.ExitCode\n    }\n}\n\n# All uninstalls succeeded; exit success\nExit 0\n"
+    "132bf6ab": "# Fleet uninstalls app by finding all related product codes for the specified upgrade code\n$inst = New-Object -ComObject \"WindowsInstaller.Installer\"\n$timeoutSeconds = 300  # 5 minute timeout per product\n\n# MSI exit codes that indicate success. 3010 = ERROR_SUCCESS_REBOOT_REQUIRED,\n# 1641 = ERROR_SUCCESS_REBOOT_INITIATED. Treat these as success rather than failure.\n$successCodes = @(0, 3010, 1641)\n\nforeach ($product_code in $inst.RelatedProducts('{877DB994-AB03-4025-B99D-41CE565E810B}')) {\n    $process = Start-Process msiexec -ArgumentList @(\"/quiet\", \"/x\", $product_code, \"/norestart\") -PassThru\n\n    # Wait for process with timeout\n    $completed = $process.WaitForExit($timeoutSeconds * 1000)\n\n    if (-not $completed) {\n        Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue\n        Exit 1603  # ERROR_UNINSTALL_FAILURE\n    }\n\n    # If the uninstall failed, bail\n    if ($successCodes -notcontains $process.ExitCode) {\n        Write-Output \"Uninstall for $($product_code) exited $($process.ExitCode)\"\n        Exit $process.ExitCode\n    }\n}\n\n# All uninstalls succeeded; exit success\nExit 0\n",
+    "72349997": "# Learn more about install scripts:\n# http://fleetdm.com/learn-more-about/install-scripts\n#\n# The ImageGlass MSI is dual-scope (ALLUSERS=2). Pass ALLUSERS=1 to force a\n# per-machine install under Fleet's SYSTEM context.\n\n$logFile = \"${env:TEMP}/fleet-install-software.log\"\n\ntry {\n\n$installProcess = Start-Process msiexec.exe `\n  -ArgumentList \"/quiet /norestart /lv `\"${logFile}`\" ALLUSERS=1 /i `\"${env:INSTALLER_PATH}`\"\" `\n  -PassThru -Verb RunAs -Wait\n\nGet-Content $logFile -Tail 500\n\nif ($installProcess.ExitCode -eq 3010 -or $installProcess.ExitCode -eq 1641) { Exit 0 }\nExit $installProcess.ExitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n"
   }
 }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** NA

The `Ingest maintained apps` workflow has been failing on every run:

```
{"level":"INFO","msg":"ingesting winget app","name":"ImageGlass"}
panic: ingesting winget app: failed to find installer for app
```

## Root cause

Not a Fleet bug — an upstream flip. On 2026-08-25 winget replaced
`manifests/d/DuongDieuPhap/ImageGlass/10.0.4.819/` with `10.0.819.0/`
([winget-pkgs#422524](https://github.com/microsoft/winget-pkgs/pull/422524)), and the new manifest
publishes **MSIX only** (x64 + arm64, no MSI). Our input pins `installer_type: msi` /
`installer_scope: machine`, so no installer matched, `ingestOne` returned
`failed to find installer for app`, and `cmd/maintained-apps/main.go` panicked on it — killing the
run for every app.

The vendor's side of it: for release `10.0.4.819` they renamed the free MSI asset to
`ImageGlass_10.0.4.819_win-x64_pro-business.msi`, so **the installer URL we currently ship 404s**.
The app was broken independently of the panic. Their next release (`10.0.5.825`) ships a plain
`.msi` again, so the input is still correct and there was nothing to align it to — the usual fix for
this error (diff the manifests, correct the input) doesn't apply.

## What changed

Installer selection now happens **inside** the version-dir walk. A version whose manifest carries no
installer matching the input's arch/type/scope falls through to the next-oldest version, the same way
a missing manifest (404) already did. Bounded at `maxInstallerFallbackVersions = 5` so a genuinely
misconfigured input still fails fast instead of walking years of history and burning GitHub API
calls; a WARN names the skipped versions whenever a fallback is used.

- The selection logic itself is unchanged — lifted verbatim into `(*wingetIngester).selectInstaller`.
  Most of the ingester diff is that move.
- Locale manifests are only fetched once a version matches, so a skipped version now costs one API
  call instead of two.
- Both ingesters name the failing slug in the error, so it no longer has to be inferred from the last
  `ingesting winget app` log line.

**ImageGlass falls back to `9.6.1.807`**, and the regenerated output is byte-identical to what shipped
at 6e41bf603d ("Validate all Fleet-maintained apps") — the last version that passed Windows
validation. Its installer URL returns 200. Once winget publishes a 10.x manifest with the MSI, the
ingester picks it back up on its own with no further action.

## Notes for reviewers

- **This is a version downgrade for a shipped app** (10.0.4.819 → 9.6.1.807). The alternative is
  continuing to ship a 404. Hosts already on 10.x still read as patched
  (`NOT EXISTS (version < 9.6.1.807)`), and the exists/patched queries are unchanged because both
  manifests carry the same `PackageName`/`Publisher`.
- A full ingest run turned up **56 other apps with version bumps** that had been stuck behind the
  panic. I left those out to keep this focused — the scheduled job will publish them in its own PR
  once this lands.

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

Two subtests added to `TestIngestOneVersionWalk`, covering the fallback and its bound, alongside the
existing 404/429/504 walk cases.

Manual verification:

- `go run ./cmd/maintained-apps -slug imageglass/windows` falls back to 9.6.1.807 and emits output
  byte-identical to the last validated manifest; its installer URL returns 200, the previously
  shipped 10.0.4.819 URL returns 404.
- A **full ingest run now completes with exit 0** (~430 winget + ~400 homebrew apps). ImageGlass was
  the only app hitting the new fallback path.
- `go test ./ee/maintained-apps/...`, `go vet`, and `gofmt` are clean. I could not run the repo
  linter locally — `make lint-go-incremental` can't clone golangci-lint in my sandbox, and my local
  binary is built with Go 1.25 against a 1.26 module. Leaving that to CI.
