### PR TITLE
remove mention of osquery for verifying DDM profiles

### DIFF
--- a/changes/51448-remove-osquery-from-ddm
+++ b/changes/51448-remove-osquery-from-ddm
@@ -1,0 +1,1 @@
+- Removed mention of osquery when viewing a DDM profile that is verifying.

--- a/frontend/pages/hosts/details/cards/Controls/ControlDetailsModal/ControlDetailsModal.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Controls/ControlDetailsModal/ControlDetailsModal.tests.tsx
@@ -383,5 +383,27 @@ describe("ControlDetailsModal", () => {
       ).toBeInTheDocument();
       expect(screen.getByText(detail)).toBeInTheDocument();
     });
+
+    it("does not mention osquery for ddm verifying controls", () => {
+      renderModal({
+        control: createMockHostMdmProfile({
+          name: "DeviceLock",
+          platform: "darwin",
+          operation_type: "install",
+          status: "verifying",
+          detail: "Some detail about the verifying status",
+          profile_uuid: `dbogus-uuid`,
+        }),
+      });
+
+      expect(
+        screen.getByText(/acknowledged the MDM command to apply/, {
+          selector: "span",
+        })
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText(/verifying with osquery/)
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/pages/hosts/details/cards/Controls/ControlDetailsModal/ControlDetailsModal.tsx
+++ b/frontend/pages/hosts/details/cards/Controls/ControlDetailsModal/ControlDetailsModal.tsx
@@ -78,6 +78,7 @@ const ControlDetailsModal = ({
           settingName: control.name,
           isDiskEncryptionProfile: isDiskEncryptionProfile(control.name),
           isDeviceUser,
+          profileUUID: control.profile_uuid,
         });
   };
 

--- a/frontend/pages/hosts/details/cards/Controls/statusDisplayConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Controls/statusDisplayConfig.tsx
@@ -33,6 +33,8 @@ export interface IControlMessageProps {
   isDiskEncryptionProfile: boolean;
   /** True on the My device page, where the end user reads the message. */
   isDeviceUser: boolean;
+  /** UUID of the profile associated with the control. Can be used with prefix checks to determine the type of profile. */
+  profileUUID: string;
 }
 
 export type ControlMessage =
@@ -141,7 +143,10 @@ const MAC_PROFILE_VERIFYING_DISPLAY_CONFIG: ProfileDisplayOption = {
     ) : (
       <>
         <b>{props.hostDisplayName}</b> acknowledged the MDM command to apply{" "}
-        <b>{props.settingName}</b>. Fleet is verifying with osquery.
+        <b>{props.settingName}</b>.{" "}
+        {!props.profileUUID.startsWith("d") && ( // do not show osquery for DDM profiles.
+          <>Fleet is verifying with osquery.</>
+        )}
       </>
     ),
 };

--- a/frontend/pages/hosts/details/cards/Controls/statusDisplayConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Controls/statusDisplayConfig.tsx
@@ -144,12 +144,10 @@ const MAC_PROFILE_VERIFYING_DISPLAY_CONFIG: ProfileDisplayOption = {
     ) : (
       <>
         <b>{props.hostDisplayName}</b> acknowledged the MDM command to apply{" "}
-        <b>{props.settingName}</b>.{" "}
-        {
-          !isDDMProfile({ profile_uuid: props.profileUUID }) && (
-            <>Fleet is verifying with osquery.</>
-          ) // do not show osquery for DDM profiles.
-        }
+        <b>{props.settingName}</b>.
+        {!isDDMProfile({ profile_uuid: props.profileUUID }) && (
+          <> Fleet is verifying with osquery.</>
+        )}
       </>
     ),
 };

--- a/frontend/pages/hosts/details/cards/Controls/statusDisplayConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Controls/statusDisplayConfig.tsx
@@ -8,6 +8,7 @@ import {
   ProfileOperationType,
   RecoveryLockPasswordStatus,
 } from "interfaces/mdm";
+import { isDDMProfile } from "services/entities/mdm";
 
 import { IconNames } from "components/icons";
 
@@ -144,9 +145,11 @@ const MAC_PROFILE_VERIFYING_DISPLAY_CONFIG: ProfileDisplayOption = {
       <>
         <b>{props.hostDisplayName}</b> acknowledged the MDM command to apply{" "}
         <b>{props.settingName}</b>.{" "}
-        {!props.profileUUID.startsWith("d") && ( // do not show osquery for DDM profiles.
-          <>Fleet is verifying with osquery.</>
-        )}
+        {
+          !isDDMProfile({ profile_uuid: props.profileUUID }) && (
+            <>Fleet is verifying with osquery.</>
+          ) // do not show osquery for DDM profiles.
+        }
       </>
     ),
 };

--- a/frontend/services/entities/mdm.ts
+++ b/frontend/services/entities/mdm.ts
@@ -2,7 +2,6 @@ import {
   EndUserLocalAccountType,
   IBootstrapPackageAggregate,
   IBootstrapPackageMetadata,
-  IHostMdmProfile,
   IMdmAsset,
   IMdmProfile,
   IMdmSSOResponse,
@@ -76,7 +75,7 @@ export interface IUploadAssetResponse {
   asset_uuid: string;
 }
 
-export const isDDMProfile = (profile: IMdmProfile | IHostMdmProfile) => {
+export const isDDMProfile = (profile: Pick<IMdmProfile, "profile_uuid">) => {
   return profile.profile_uuid.startsWith("d");
 };
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #51448

DDM profile
<img width="695" height="286" alt="image" src="https://github.com/user-attachments/assets/9a77b5e0-41f0-40d6-8ec6-93bde34c4cb9" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

## Frontend

- [x] Attached a screenshot or screen recording of each user-visible change. For changes to existing UI, show the before and after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated macOS DDM control verification messages to acknowledge MDM commands without displaying unrelated osquery text.
  * Preserved existing verification messaging for non-DDM profiles.

* **Tests**
  * Added regression coverage for the corrected DDM verification message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->