### PR TITLE
fix racy coordinator test

### DIFF
--- a/cmd/apple-apns-mock/coordinator_test.go
+++ b/cmd/apple-apns-mock/coordinator_test.go
@@ -54,6 +54,31 @@ func expectNoPingOn(t *testing.T, sub *subscriber, wait time.Duration) {
 	}
 }
 
+// waitAnnouncementsHandled blocks until this node's subscription has handled
+// every announcement published so far: a marker ping for a token it holds
+// cannot arrive ahead of them, because Redis delivers to a subscriber in
+// publish order.
+//
+// A test that pushes to an offline device and then subscribes needs it.
+// Otherwise the push's own announcement can be dispatched in the window
+// between Subscribe registering the stream and its claim, and dispatch wins
+// the GETDEL — the device still gets the ping, down the live stream, but not
+// by the path under test.
+func waitAnnouncementsHandled(t *testing.T, c *coordinator) {
+	t.Helper()
+	const marker = "ffffff"
+	sub, _ := c.reg.subscribe(marker, 0)
+	before := c.reg.deliveredLive.Load()
+
+	// Inline, so the marker needs no pending key. deliveredLive is bumped
+	// after the ping is queued, so wait on the counter, not on sub.ch.
+	require.NoError(t, c.publish(t.Context(), pushMsg{Token: marker, Inline: []byte(`{"mdm":"marker"}`)}))
+	waitFor(t, func() bool { return c.reg.deliveredLive.Load() > before })
+
+	c.reg.unsubscribe(marker, sub)
+	c.reg.deliveredLive.Add(-1) // the marker is not a delivery under test
+}
+
 func pendingValue(t *testing.T, c *coordinator, token string) []byte {
 	t.Helper()
 	conn := c.pool.Get()
@@ -117,6 +142,7 @@ func TestCoordinatorOfflinePushClaimedOnConnect(t *testing.T) {
 
 	require.NoError(t, pusher.Push(t.Context(), "aabb01", []byte(`{"mdm":"waited"}`), time.Time{}))
 	require.NotEmpty(t, pendingValue(t, pusher, "aabb01"), "nobody holds it, so it waits in Redis")
+	waitAnnouncementsHandled(t, holder)
 
 	// The device turns up on a different instance than the one pushed to.
 	_, pending := holder.Subscribe(t.Context(), "aabb01")
@@ -133,6 +159,7 @@ func TestCoordinatorOfflinePushesCoalesce(t *testing.T) {
 	for _, m := range []string{"m1", "m2", "m3"} {
 		require.NoError(t, c.Push(t.Context(), "aabb01", []byte(`{"mdm":"`+m+`"}`), time.Time{}))
 	}
+	waitAnnouncementsHandled(t, c)
 
 	_, pending := c.Subscribe(t.Context(), "aabb01")
 	require.NotNil(t, pending)


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves nothing, but I saw the test was racy.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

## Testing

- [x] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved push notification claim-race test reliability.
  * Ensured pending announcements are fully processed before validating live-stream delivery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->