### PR TITLE
Accept per-platform disk encryption settings on PATCH /fleets/{id}

### DIFF
--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -344,43 +344,86 @@ func (svc *Service) ModifyTeam(ctx context.Context, teamID uint, payload fleet.T
 			}
 		}
 
-		// captured before the disk encryption merges below overwrite it, so the
-		// BitLocker PIN validation can tell "turning encryption off" apart from
-		// "turning the PIN on"
-		oldWindowsDiskEncryption := team.Config.MDM.WindowsSettings.EnableDiskEncryption.Value
-
-		if payload.MDM.EnableDiskEncryption.Valid {
-			// the deprecated flat toggle fans out to every per-platform disk
-			// encryption setting
-			v := payload.MDM.EnableDiskEncryption.Value
-			diskEncryptionUpdated := team.Config.MDM.MacOSSettings.EnableDiskEncryption.Value != v ||
-				team.Config.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey.Value != v ||
-				team.Config.MDM.WindowsSettings.EnableDiskEncryption.Value != v ||
-				team.Config.MDM.LinuxSettings.EnableEscrowDiskEncryptionKey.Value != v
-			if diskEncryptionUpdated && !appCfg.MDM.EnabledAndConfigured && !appCfg.MDM.WindowsEnabledAndConfigured {
-				return nil, fleet.NewInvalidArgumentError("mdm.enable_disk_encryption",
-					"Couldn't update mdm.enable_disk_encryption because neither Apple MDM nor Windows MDM is turned on in Fleet.")
-			}
-			if diskEncryptionUpdated && v && svc.config.Server.PrivateKey == "" {
-				return nil, ctxerr.New(ctx, "Missing required private key. Learn how to configure the private key here: https://fleetdm.com/learn-more-about/fleet-server-private-key")
-			}
-			// The Apple FileVault profile only applies when Apple MDM is configured.
-			// On Windows-only deployments the flag still controls BitLocker enforcement via the Windows MDM path.
-			// The FileVault profile covers enforcement and escrow as a whole, so only the
-			// off<->on transition of the pair creates or deletes it.
-			macOSFileVaultWasOn = team.Config.MDM.MacOSSettings.EnableDiskEncryption.Value ||
-				team.Config.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey.Value
-			macOSDiskEncryptionUpdated = macOSFileVaultWasOn != v && appCfg.MDM.EnabledAndConfigured
-			macOSSettingsChanged = team.Config.MDM.MacOSSettings.EnableDiskEncryption.Value != v ||
-				team.Config.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey.Value != v
-			windowsSettingsChanged = team.Config.MDM.WindowsSettings.EnableDiskEncryption.Value != v
-			linuxSettingsChanged = team.Config.MDM.LinuxSettings.EnableEscrowDiskEncryptionKey.Value != v
-			team.Config.MDM.MacOSSettings.EnableDiskEncryption = optjson.SetBool(v)
-			team.Config.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey = optjson.SetBool(v)
-			team.Config.MDM.WindowsSettings.EnableDiskEncryption = optjson.SetBool(v)
-			team.Config.MDM.LinuxSettings.EnableEscrowDiskEncryptionKey = optjson.SetBool(v)
-			team.Config.MDM.EnableDiskEncryption = v
+		// The per-platform disk encryption settings follow PATCH-merge semantics:
+		// an absent field, or one explicitly set to null, keeps its stored value.
+		// The deprecated flat mdm.enable_disk_encryption fans out to all four;
+		// precedence between the flat toggle and a per-platform value sent in the
+		// same request goes to whichever the request actually changes, and
+		// changing both to disagreeing values is a conflict. Mirrors PATCH /config.
+		var incomingMacOSEnable, incomingMacOSEscrow, incomingWindowsEnable, incomingLinuxEscrow optjson.Bool
+		if payload.MDM.MacOSSettings != nil {
+			incomingMacOSEnable = payload.MDM.MacOSSettings.EnableDiskEncryption
+			incomingMacOSEscrow = payload.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey
 		}
+		if payload.MDM.WindowsSettings != nil {
+			incomingWindowsEnable = payload.MDM.WindowsSettings.EnableDiskEncryption
+		}
+		if payload.MDM.LinuxSettings != nil {
+			incomingLinuxEscrow = payload.MDM.LinuxSettings.EnableEscrowDiskEncryptionKey
+		}
+
+		oldDiskEncryption := team.Config.MDM.DiskEncryptionConfig()
+		legacyDiskEncryption := payload.MDM.EnableDiskEncryption
+		// the flat toggle reads as the AND of the four per-platform settings, so
+		// "the request changes it" is measured against that
+		legacyDiskEncryptionChanged := legacyDiskEncryption.Valid &&
+			legacyDiskEncryption.Value != oldDiskEncryption.AllEnabled()
+		var diskEncryptionUpdated, enablingDiskEncryption bool
+		for _, f := range []struct {
+			incoming optjson.Bool
+			target   *optjson.Bool
+			old      bool
+		}{
+			{incomingMacOSEnable, &team.Config.MDM.MacOSSettings.EnableDiskEncryption, oldDiskEncryption.MacOSEnabled},
+			{incomingMacOSEscrow, &team.Config.MDM.MacOSSettings.EnableEscrowDiskEncryptionKey, oldDiskEncryption.MacOSEscrowEnabled},
+			{incomingWindowsEnable, &team.Config.MDM.WindowsSettings.EnableDiskEncryption, oldDiskEncryption.WindowsEnabled},
+			{incomingLinuxEscrow, &team.Config.MDM.LinuxSettings.EnableEscrowDiskEncryptionKey, oldDiskEncryption.LinuxEscrowEnabled},
+		} {
+			incomingChanged := f.incoming.Valid && f.incoming.Value != f.old
+			switch {
+			case incomingChanged && legacyDiskEncryptionChanged && f.incoming.Value != legacyDiskEncryption.Value:
+				// both the deprecated toggle and this per-platform setting are
+				// being changed, to disagreeing values
+				return nil, fleet.NewInvalidArgumentError("mdm.enable_disk_encryption",
+					"conflicts with per-platform disk encryption settings")
+			case incomingChanged:
+				*f.target = f.incoming
+			case legacyDiskEncryption.Valid && (legacyDiskEncryptionChanged || !f.incoming.Valid):
+				// the deprecated toggle fans out: it wins over per-platform values
+				// the request carries but does not change (the common
+				// GET-modify-PATCH round-trip) and fills in absent ones
+				*f.target = optjson.SetBool(legacyDiskEncryption.Value)
+			case f.incoming.Valid:
+				*f.target = f.incoming
+			}
+			diskEncryptionUpdated = diskEncryptionUpdated || f.target.Value != f.old
+			enablingDiskEncryption = enablingDiskEncryption || (f.target.Value && !f.old)
+		}
+
+		if diskEncryptionUpdated && !appCfg.MDM.EnabledAndConfigured && !appCfg.MDM.WindowsEnabledAndConfigured {
+			return nil, fleet.NewInvalidArgumentError("mdm.enable_disk_encryption",
+				"Couldn't update mdm.enable_disk_encryption because neither Apple MDM nor Windows MDM is turned on in Fleet.")
+		}
+		if enablingDiskEncryption && svc.config.Server.PrivateKey == "" {
+			return nil, ctxerr.New(ctx, "Missing required private key. Learn how to configure the private key here: https://fleetdm.com/learn-more-about/fleet-server-private-key")
+		}
+
+		newDiskEncryption := team.Config.MDM.DiskEncryptionConfig()
+		// The Apple FileVault profile only applies when Apple MDM is configured.
+		// On Windows-only deployments the settings still control BitLocker
+		// enforcement via the Windows MDM path. The FileVault profile covers
+		// enforcement and escrow as a whole, so only the off<->on transition of
+		// the pair creates or deletes it.
+		macOSFileVaultWasOn = oldDiskEncryption.MacOSEnabled || oldDiskEncryption.MacOSEscrowEnabled
+		macOSFileVaultIsOn := newDiskEncryption.MacOSEnabled || newDiskEncryption.MacOSEscrowEnabled
+		macOSDiskEncryptionUpdated = macOSFileVaultWasOn != macOSFileVaultIsOn && appCfg.MDM.EnabledAndConfigured
+		macOSSettingsChanged = newDiskEncryption.MacOSEnabled != oldDiskEncryption.MacOSEnabled ||
+			newDiskEncryption.MacOSEscrowEnabled != oldDiskEncryption.MacOSEscrowEnabled
+		windowsSettingsChanged = newDiskEncryption.WindowsEnabled != oldDiskEncryption.WindowsEnabled
+		linuxSettingsChanged = newDiskEncryption.LinuxEscrowEnabled != oldDiskEncryption.LinuxEscrowEnabled
+		// the flat toggle is virtual (the AND of the four); recompute it so
+		// validation and the saved JSON see the effective value
+		team.Config.MDM.EnableDiskEncryption = newDiskEncryption.AllEnabled()
 
 		if payload.MDM.EnableRecoveryLockPassword.Valid {
 			recoveryLockPasswordUpdated = team.Config.MDM.EnableRecoveryLockPassword != payload.MDM.EnableRecoveryLockPassword.Value
@@ -410,8 +453,10 @@ func (svc *Service) ModifyTeam(ctx context.Context, teamID uint, payload fleet.T
 			team.Config.MDM.WindowsSettings.RequireBitLockerPIN = optjson.SetBool(incomingPIN.Value)
 		}
 
-		// the BitLocker PIN requires the Windows disk encryption setting
-		if field, msg := fleet.BitLockerPINRequirementError(oldWindowsDiskEncryption,
+		// the BitLocker PIN requires the Windows disk encryption setting; the
+		// pre-merge value tells "turning encryption off" apart from "turning the
+		// PIN on"
+		if field, msg := fleet.BitLockerPINRequirementError(oldDiskEncryption.WindowsEnabled,
 			team.Config.MDM.DiskEncryptionConfig()); msg != "" {
 			return nil, fleet.NewInvalidArgumentError(field, msg)
 		}

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -324,6 +324,13 @@ type DiskEncryptionConfig struct {
 	LinuxEscrowEnabled bool
 }
 
+// AllEnabled returns the AND of the four per-platform disk encryption settings
+// — the value the deprecated flat enable_disk_encryption key reports. The
+// BitLocker PIN is a modifier of Windows enforcement, not one of the four.
+func (c DiskEncryptionConfig) AllEnabled() bool {
+	return c.MacOSEnabled && c.MacOSEscrowEnabled && c.WindowsEnabled && c.LinuxEscrowEnabled
+}
+
 // MacOSDiskEncryptionSettingsPayload is the macos_settings object accepted by
 // POST /disk_encryption. Nil fields mean "don't change".
 type MacOSDiskEncryptionSettingsPayload struct {
@@ -417,10 +424,7 @@ func (p MDMDiskEncryptionSettingsPayload) ResolvePerPlatform() (DiskEncryptionSe
 // disk encryption settings — the value the deprecated flat
 // mdm.enable_disk_encryption key reports.
 func (m *MDM) DiskEncryptionSettingsAllEnabled() bool {
-	return m.MacOSSettings.EnableDiskEncryption.Value &&
-		m.MacOSSettings.EnableEscrowDiskEncryptionKey.Value &&
-		m.WindowsSettings.EnableDiskEncryption.Value &&
-		m.LinuxSettings.EnableEscrowDiskEncryptionKey.Value
+	return m.DiskEncryptionConfig().AllEnabled()
 }
 
 // DiskEncryptionConfig returns the global effective per-platform disk

--- a/server/fleet/teams.go
+++ b/server/fleet/teams.go
@@ -111,9 +111,20 @@ type TeamPayloadMDM struct {
 	MacOSSetup       *MacOSSetup    `json:"macos_setup"`
 	HostNameTemplate optjson.String `json:"name_template"`
 
-	// WindowsSettings exposes only the managed local account surface on the team PATCH endpoint;
+	// MacOSSettings exposes only the disk encryption surface on the team PATCH endpoint;
 	// configuration profiles are managed through their own endpoints.
+	MacOSSettings *TeamPayloadMacOSSettings `json:"macos_settings" renameto:"apple_settings"`
+	// WindowsSettings exposes only the managed local account and disk encryption surfaces
+	// on the team PATCH endpoint; configuration profiles are managed through their own endpoints.
 	WindowsSettings *TeamPayloadWindowsSettings `json:"windows_settings"`
+	LinuxSettings   *TeamPayloadLinuxSettings   `json:"linux_settings"`
+}
+
+// TeamPayloadMacOSSettings is the subset of macos_settings (apple_settings) fields
+// settable via the team PATCH endpoint.
+type TeamPayloadMacOSSettings struct {
+	EnableDiskEncryption          optjson.Bool `json:"enable_disk_encryption"`
+	EnableEscrowDiskEncryptionKey optjson.Bool `json:"enable_escrow_disk_encryption_key"`
 }
 
 // TeamPayloadWindowsSettings is the subset of windows_settings fields settable via the team PATCH endpoint.
@@ -121,7 +132,13 @@ type TeamPayloadWindowsSettings struct {
 	ManagedLocalAccountSettings ManagedLocalAccountSettings `json:"managed_local_account_settings"`
 	// RequireBitLockerPIN is the canonical home of the deprecated top-level
 	// windows_require_bitlocker_pin key.
-	RequireBitLockerPIN optjson.Bool `json:"require_bitlocker_pin"`
+	RequireBitLockerPIN  optjson.Bool `json:"require_bitlocker_pin"`
+	EnableDiskEncryption optjson.Bool `json:"enable_disk_encryption"`
+}
+
+// TeamPayloadLinuxSettings is the subset of linux_settings fields settable via the team PATCH endpoint.
+type TeamPayloadLinuxSettings struct {
+	EnableEscrowDiskEncryptionKey optjson.Bool `json:"enable_escrow_disk_encryption_key"`
 }
 
 // Team is the data representation for the "Team" concept (group of hosts and

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -3258,6 +3258,163 @@ func (s *integrationMDMTestSuite) TestDiskEncryptionEndpointPerPlatform() {
 	assert.Contains(t, errMsg, "conflicts with windows_settings.require_bitlocker_pin")
 }
 
+// TestTeamPatchPerPlatformDiskEncryption covers the per-platform disk encryption
+// keys on PATCH /fleets/{id}. The bodies are raw JSON on purpose: the endpoint
+// silently drops keys its payload struct doesn't carry, which a typed request
+// would hide.
+func (s *integrationMDMTestSuite) TestTeamPatchPerPlatformDiskEncryption() {
+	t := s.T()
+
+	tm, err := s.ds.NewTeam(t.Context(), &fleet.Team{Name: t.Name()})
+	require.NoError(t, err)
+	path := fmt.Sprintf("/api/latest/fleet/fleets/%d", tm.ID)
+
+	patch := func(body string, wantStatus int) fleet.TeamMDM {
+		var resp teamResponse
+		s.DoJSON("PATCH", path, json.RawMessage(body), wantStatus, &resp)
+		return resp.Team.Config.MDM
+	}
+
+	// the deprecated flat toggle still fans out to all four
+	mdm := patch(`{"mdm":{"enable_disk_encryption":true}}`, http.StatusOK)
+	require.True(t, mdm.EnableDiskEncryption)
+	require.True(t, mdm.MacOSSettings.EnableDiskEncryption.Value)
+	require.True(t, mdm.MacOSSettings.EnableEscrowDiskEncryptionKey.Value)
+	require.True(t, mdm.WindowsSettings.EnableDiskEncryption.Value)
+	require.True(t, mdm.LinuxSettings.EnableEscrowDiskEncryptionKey.Value)
+	s.assertConfigProfilesByIdentifier(new(tm.ID), mobileconfig.FleetFileVaultPayloadIdentifier, true)
+
+	// turning macOS enforcement off while keeping escrow on: the per-platform
+	// keys reach their own settings and leave the other platforms alone
+	mdm = patch(`{"mdm":{
+		"apple_settings":  {"enable_disk_encryption": false, "enable_escrow_disk_encryption_key": true},
+		"windows_settings": {"enable_disk_encryption": true},
+		"linux_settings":  {"enable_escrow_disk_encryption_key": true}
+	}}`, http.StatusOK)
+	require.False(t, mdm.MacOSSettings.EnableDiskEncryption.Value)
+	require.True(t, mdm.MacOSSettings.EnableEscrowDiskEncryptionKey.Value)
+	require.True(t, mdm.WindowsSettings.EnableDiskEncryption.Value)
+	require.True(t, mdm.LinuxSettings.EnableEscrowDiskEncryptionKey.Value)
+	// the flat toggle is the AND of the four, so it now reads false
+	require.False(t, mdm.EnableDiskEncryption)
+	// only macOS changed, so only macOS gets an activity
+	s.lastActivityOfTypeMatches(fleet.ActivityTypeEditedDiskEncryptionSettings{}.ActivityName(),
+		fmt.Sprintf(`{"fleet_id": %d, "fleet_name": %q, "platform": "macos"}`, tm.ID, tm.Name), 0)
+	// escrow is still on, so the FileVault profile stays in place
+	s.assertConfigProfilesByIdentifier(new(tm.ID), mobileconfig.FleetFileVaultPayloadIdentifier, true)
+
+	// the deprecated macos_settings name works the same as apple_settings
+	mdm = patch(`{"mdm":{"macos_settings":{"enable_escrow_disk_encryption_key": false}}}`, http.StatusOK)
+	require.False(t, mdm.MacOSSettings.EnableEscrowDiskEncryptionKey.Value)
+	// both halves of the macOS pair are now off, so the profile goes away
+	s.assertConfigProfilesByIdentifier(new(tm.ID), mobileconfig.FleetFileVaultPayloadIdentifier, false)
+
+	// both names in the same request is a conflict
+	res := s.Do("PATCH", path, json.RawMessage(`{"mdm":{
+		"macos_settings": {"enable_disk_encryption": true},
+		"apple_settings": {"enable_disk_encryption": true}
+	}}`), http.StatusBadRequest)
+	require.Contains(t, extractServerErrorText(res.Body), `Specify only one of "macos_settings" or "apple_settings"`)
+
+	// a per-platform key omitted from the body keeps its stored value, and an
+	// explicit null does too
+	mdm = patch(`{"mdm":{"linux_settings":{"enable_escrow_disk_encryption_key": null}}}`, http.StatusOK)
+	require.True(t, mdm.LinuxSettings.EnableEscrowDiskEncryptionKey.Value)
+	require.True(t, mdm.WindowsSettings.EnableDiskEncryption.Value)
+
+	// changing the flat toggle and a per-platform key to disagreeing values is a
+	// conflict. Windows is on here, so setting it off is a real change, as is
+	// the flat toggle going on
+	res = s.Do("PATCH", path, json.RawMessage(`{"mdm":{
+		"enable_disk_encryption": true,
+		"windows_settings": {"enable_disk_encryption": false}
+	}}`), http.StatusUnprocessableEntity)
+	require.Contains(t, extractServerErrorText(res.Body), "conflicts with per-platform disk encryption settings")
+
+	// the GET-modify-PATCH round trip is not a conflict: only the flat toggle
+	// changes, and the per-platform values the request carries match what is
+	// already stored, so the toggle wins and fans out
+	mdm = patch(`{"mdm":{
+		"enable_disk_encryption": true,
+		"apple_settings": {"enable_disk_encryption": false, "enable_escrow_disk_encryption_key": false},
+		"windows_settings": {"enable_disk_encryption": true},
+		"linux_settings": {"enable_escrow_disk_encryption_key": true}
+	}}`, http.StatusOK)
+	require.True(t, mdm.EnableDiskEncryption)
+	require.True(t, mdm.MacOSSettings.EnableDiskEncryption.Value)
+	require.True(t, mdm.MacOSSettings.EnableEscrowDiskEncryptionKey.Value)
+
+	// precedence the other way round: everything is on, so only the
+	// per-platform key changes and it wins over the carried flat toggle
+	mdm = patch(`{"mdm":{
+		"enable_disk_encryption": true,
+		"apple_settings": {"enable_disk_encryption": false}
+	}}`, http.StatusOK)
+	require.False(t, mdm.MacOSSettings.EnableDiskEncryption.Value)
+	require.True(t, mdm.MacOSSettings.EnableEscrowDiskEncryptionKey.Value)
+	require.False(t, mdm.EnableDiskEncryption)
+
+	// with Windows enforcement off, turning the PIN on is rejected
+	patch(`{"mdm":{"windows_settings":{"enable_disk_encryption": false}}}`, http.StatusOK)
+	res = s.Do("PATCH", path, json.RawMessage(`{"mdm":{"windows_settings":{"require_bitlocker_pin": true}}}`),
+		http.StatusUnprocessableEntity)
+	require.Contains(t, extractServerErrorText(res.Body), fleet.CantEnablePINRequiredIfDiskEncryptionEnabled)
+
+	// the PIN alongside Windows enforcement is accepted, and turning enforcement
+	// off afterwards is rejected while the PIN is still required
+	mdm = patch(`{"mdm":{"windows_settings":{"enable_disk_encryption": true, "require_bitlocker_pin": true}}}`, http.StatusOK)
+	require.True(t, mdm.WindowsSettings.RequireBitLockerPIN.Value)
+	require.True(t, mdm.RequireBitLockerPIN)
+	res = s.Do("PATCH", path, json.RawMessage(`{"mdm":{"windows_settings":{"enable_disk_encryption": false}}}`),
+		http.StatusUnprocessableEntity)
+	require.Contains(t, extractServerErrorText(res.Body), fleet.CantDisableDiskEncryptionIfPINRequiredErrMsg)
+
+	// a request that changes nothing emits no activity
+	before := s.lastActivityMatches("", "", 0)
+	patch(`{"mdm":{"windows_settings":{"enable_disk_encryption": true}}}`, http.StatusOK)
+	require.Equal(t, before, s.lastActivityMatches("", "", 0))
+
+	// the GET response carries every per-platform key, so a GET-modify-PATCH
+	// round trip can see them. The macOS object comes back under its new
+	// apple_settings name only, though requests accept either name.
+	res = s.Do("GET", fmt.Sprintf("/api/latest/fleet/fleets/%d", tm.ID), nil, http.StatusOK)
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	var raw struct {
+		Fleet struct {
+			MDM struct {
+				EnableDiskEncryption *bool `json:"enable_disk_encryption"`
+				AppleSettings        *struct {
+					EnableDiskEncryption          *bool `json:"enable_disk_encryption"`
+					EnableEscrowDiskEncryptionKey *bool `json:"enable_escrow_disk_encryption_key"`
+				} `json:"apple_settings"`
+				MacOSSettings *struct {
+					EnableDiskEncryption *bool `json:"enable_disk_encryption"`
+				} `json:"macos_settings"`
+				WindowsSettings *struct {
+					EnableDiskEncryption *bool `json:"enable_disk_encryption"`
+					RequireBitLockerPIN  *bool `json:"require_bitlocker_pin"`
+				} `json:"windows_settings"`
+				LinuxSettings *struct {
+					EnableEscrowDiskEncryptionKey *bool `json:"enable_escrow_disk_encryption_key"`
+				} `json:"linux_settings"`
+			} `json:"mdm"`
+		} `json:"fleet"`
+	}
+	require.NoError(t, json.Unmarshal(body, &raw))
+	gotMDM := raw.Fleet.MDM
+	require.NotNil(t, gotMDM.EnableDiskEncryption)
+	require.NotNil(t, gotMDM.AppleSettings)
+	require.NotNil(t, gotMDM.AppleSettings.EnableDiskEncryption)
+	require.NotNil(t, gotMDM.AppleSettings.EnableEscrowDiskEncryptionKey)
+	require.Nil(t, gotMDM.MacOSSettings, "the response uses the apple_settings name only")
+	require.NotNil(t, gotMDM.WindowsSettings)
+	require.NotNil(t, gotMDM.WindowsSettings.EnableDiskEncryption)
+	require.NotNil(t, gotMDM.WindowsSettings.RequireBitLockerPIN)
+	require.NotNil(t, gotMDM.LinuxSettings)
+	require.NotNil(t, gotMDM.LinuxSettings.EnableEscrowDiskEncryptionKey)
+}
+
 func (s *integrationMDMTestSuite) TestAppConfigMDMAppleDiskEncryption() {
 	t := s.T()
 


### PR DESCRIPTION
**Related issue:** Resolves #51258

`PATCH /fleets/{id}` only carried the deprecated flat `enable_disk_encryption` toggle and the BitLocker PIN, so `apple_settings`, `linux_settings` and `windows_settings.enable_disk_encryption` were silently dropped there. Unknown JSON keys aren't rejected, so a request setting them returned 200 with no effect.

- Added the per-platform keys to `TeamPayloadMDM` (`macos_settings` / `apple_settings`, `linux_settings`, and `enable_disk_encryption` on `windows_settings`).
- `ModifyTeam` now resolves them against the flat toggle with the same precedence-by-change and conflict rules as `PATCH /config`, and drives the FileVault profile and the per-platform activities off the resolved values.
- Added `DiskEncryptionConfig.AllEnabled()` so both endpoints measure the virtual flat toggle the same way.

The other write paths (`PATCH /config`, `POST /disk_encryption`, GitOps fleet spec) were already correct.

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

No changes file: `changes/51258-per-platform-disk-encryption-settings` already covers this unreleased feature.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

`TestTeamPatchPerPlatformDiskEncryption` covers flat fan-out, per-platform writes, both macOS key names, the both-names 400, explicit null, the conflict 422 in both precedence directions, the PIN/Windows dependency both ways, activity platforms and counts, and the GET response shape.

Manually QA'd against a dev server with a script driving 43 assertions over the same paths, checking HTTP status, resulting state and emitted activities for each.

For unreleased bug fixes in a release candidate:

- [x] Confirmed that the fix is not expected to adversely impact load test results

## New Fleet configuration settings

These are not new settings — they already exist on the GitOps fleet spec and on `PATCH /config`; this PR only adds them to the fleet PATCH endpoint. Following the GitOps-enabled checklist for completeness:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops` — **no**, see below.
- [x] Verified the setting is documented in a separate PR to the GitOps documentation
- [x] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [x] Verified that any relevant UI is disabled when GitOps mode is enabled

`fleetctl generate-gitops` exports only the deprecated flat `enable_disk_encryption` (`generate_gitops.go:498` and `:1481`), so a config with disagreeing per-platform values round-trips lossily: it exports as the AND of the four, and re-applying that YAML fans the flat value back out to all of them. Pre-existing on main, out of scope here — filing separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Team disk-encryption settings can now be updated independently for macOS, Windows, and Linux.
  * Windows disk-encryption and BitLocker PIN options are now available through team settings.
  * Partial updates preserve settings that are omitted or explicitly left unchanged.
  * Existing flat disk-encryption settings remain supported for compatibility.

* **Bug Fixes**
  * Improved handling of conflicting encryption settings and BitLocker PIN validation.
  * Disk-encryption status now accurately reflects all supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->