### PR TITLE
Escape values interpolated into the conditional access Apple profile

### DIFF
--- a/changes/17245-conditional-access-profile-escaping
+++ b/changes/17245-conditional-access-profile-escaping
@@ -1,0 +1,1 @@
+* Escaped values interpolated into the conditional access Apple configuration profile so a value containing markup is carried as literal text.

--- a/server/service/conditional_access_idp.go
+++ b/server/service/conditional_access_idp.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/json"
 	"encoding/pem"
 	"fmt"
 	"net/http"
@@ -17,6 +18,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/contexts/logging"
 	"github.com/fleetdm/fleet/v4/server/dev_mode"
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mdm/apple/mobileconfig"
 	"github.com/google/uuid"
 )
 
@@ -31,7 +33,7 @@ const conditionalAccessAppleProfileTemplate = `<?xml version="1.0" encoding="UTF
             <key>PayloadCertificateFileName</key>
             <string>conditional_access_ca.der</string>
             <key>PayloadContent</key>
-            <data>{{.CACertBase64}}</data>
+            <data>{{ xml .CACertBase64 }}</data>
             <key>PayloadDescription</key>
             <string>Fleet conditional access CA certificate</string>
             <key>PayloadDisplayName</key>
@@ -41,7 +43,7 @@ const conditionalAccessAppleProfileTemplate = `<?xml version="1.0" encoding="UTF
             <key>PayloadType</key>
             <string>com.apple.security.root</string>
             <key>PayloadUUID</key>
-            <string>{{.CACertUUID}}</string>
+            <string>{{ xml .CACertUUID }}</string>
             <key>PayloadVersion</key>
             <integer>1</integer>
         </dict>
@@ -50,9 +52,9 @@ const conditionalAccessAppleProfileTemplate = `<?xml version="1.0" encoding="UTF
 			<key>PayloadContent</key>
 			<dict>
 				<key>URL</key>
-				<string>{{.SCEPURL}}</string>
+				<string>{{ xml .SCEPURL }}</string>
 				<key>Challenge</key>
-				<string>{{.Challenge}}</string>
+				<string>{{ xml .Challenge }}</string>
 				<key>Keysize</key>
 				<integer>2048</integer>
 				<key>Key Type</key>
@@ -68,7 +70,7 @@ const conditionalAccessAppleProfileTemplate = `<?xml version="1.0" encoding="UTF
 					<array>
 						<array>
 							<string>CN</string>
-							<string>{{.CertificateCN}}</string>
+							<string>{{ xml .CertificateCN }}</string>
 						</array>
 					</array>
 					<array>
@@ -104,16 +106,16 @@ const conditionalAccessAppleProfileTemplate = `<?xml version="1.0" encoding="UTF
 			<key>PayloadType</key>
 			<string>com.apple.security.scep</string>
 			<key>PayloadUUID</key>
-			<string>{{.SCEPPayloadUUID}}</string>
+			<string>{{ xml .SCEPPayloadUUID }}</string>
 			<key>PayloadVersion</key>
 			<integer>1</integer>
 		</dict>
         <!-- Identity preference for mTLS endpoint -->
         <dict>
             <key>Name</key>
-            <string>{{.MTLSURL}}</string>
+            <string>{{ xml .MTLSURL }}</string>
             <key>PayloadCertificateUUID</key>
-            <string>{{.SCEPPayloadUUID}}</string>
+            <string>{{ xml .SCEPPayloadUUID }}</string>
             <key>PayloadDescription</key>
             <string>Identity preference for mTLS endpoints</string>
             <key>PayloadDisplayName</key>
@@ -123,7 +125,7 @@ const conditionalAccessAppleProfileTemplate = `<?xml version="1.0" encoding="UTF
             <key>PayloadType</key>
             <string>com.apple.security.identitypreference</string>
             <key>PayloadUUID</key>
-            <string>{{.IdentityPrefUUID}}</string>
+            <string>{{ xml .IdentityPrefUUID }}</string>
             <key>PayloadVersion</key>
             <integer>1</integer>
         </dict>
@@ -136,7 +138,7 @@ const conditionalAccessAppleProfileTemplate = `<?xml version="1.0" encoding="UTF
             <key>PayloadIdentifier</key>
             <string>com.fleetdm.chrome.certs</string>
             <key>PayloadUUID</key>
-            <string>{{.ChromeConfigUUID}}</string>
+            <string>{{ xml .ChromeConfigUUID }}</string>
             <key>PayloadDisplayName</key>
             <string>Chrome mTLS auto-select</string>
             <key>PayloadContent</key>
@@ -153,7 +155,7 @@ const conditionalAccessAppleProfileTemplate = `<?xml version="1.0" encoding="UTF
                                 <key>AutoSelectCertificateForUrls</key>
                                 <array>
                                     <!-- MUST be stringified JSON -->
-                                    <string>{"pattern":"{{.MTLSURL}}","filter":{"SUBJECT":{"CN":"{{.CertificateCN}}"}}}</string>
+                                    <string>{"pattern":"{{ jsonString .MTLSURL }}","filter":{"SUBJECT":{"CN":"{{ jsonString .CertificateCN }}"}}}</string>
                                 </array>
                             </dict>
                         </dict>
@@ -177,15 +179,38 @@ const conditionalAccessAppleProfileTemplate = `<?xml version="1.0" encoding="UTF
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>
-	<string>{{.RootPayloadUUID}}</string>
+	<string>{{ xml .RootPayloadUUID }}</string>
 	<key>PayloadVersion</key>
 	<integer>1</integer>
 </dict>
 </plist>
 `
 
-var conditionalAccessAppleProfileTemplateParsed = template.Must(template.New("conditionalAccessAppleProfile").Parse(
-	conditionalAccessAppleProfileTemplate))
+// jsonString renders s as the contents of a JSON string, without the
+// surrounding quotes. The Chrome payload above carries stringified JSON inside
+// an XML text node, where XML escaping is the wrong layer: a quote escaped as
+// &#34; is decoded back to " before Chrome parses the value as JSON, so it has
+// to be escaped as JSON instead. encoding/json also escapes <, > and & as
+// \uXXXX, which keeps the result safe in the XML text node it sits in.
+func jsonString(s string) (string, error) {
+	b, err := json.Marshal(s)
+	if err != nil {
+		return "", err
+	}
+	return string(b[1 : len(b)-1]), nil
+}
+
+// Every interpolation in the template above must go through one of these, or a
+// value carrying markup becomes structure rather than text.
+var conditionalAccessProfileFuncMap = map[string]any{
+	"xml":        mobileconfig.XMLEscapeString,
+	"jsonString": jsonString,
+}
+
+var conditionalAccessAppleProfileTemplateParsed = template.Must(
+	template.New("conditionalAccessAppleProfile").
+		Funcs(conditionalAccessProfileFuncMap).
+		Parse(conditionalAccessAppleProfileTemplate))
 
 // fleetConditionalAccessNamespace is a custom UUID namespace for Fleet Okta conditional access profiles.
 // Generated using: uuid.NewSHA1(uuid.NameSpaceURL, []byte("https://fleetdm.com/learn-more-about/okta-conditional-access"))

--- a/server/service/conditional_access_idp_xml_test.go
+++ b/server/service/conditional_access_idp_xml_test.go
@@ -1,0 +1,184 @@
+package service
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"howett.net/plist"
+)
+
+// renderConditionalAccessProfile executes the profile template directly, so these
+// tests cover the template and its escaping without the surrounding service setup.
+func renderConditionalAccessProfile(t *testing.T, d appleProfileTemplateData) string {
+	t.Helper()
+	var buf bytes.Buffer
+	require.NoError(t, conditionalAccessAppleProfileTemplateParsed.Execute(&buf, d))
+	return buf.String()
+}
+
+// scepPayload parses the rendered profile and returns the SCEP payload's inner
+// dictionary, so assertions can be made against the values a device would apply
+// rather than against the escaped markup.
+func conditionalAccessSCEPPayload(t *testing.T, profile string) map[string]any {
+	t.Helper()
+	var root struct {
+		PayloadContent []map[string]any `plist:"PayloadContent"`
+	}
+	_, err := plist.Unmarshal([]byte(profile), &root)
+	require.NoError(t, err, "rendered profile must be a well-formed plist")
+
+	for _, p := range root.PayloadContent {
+		if p["PayloadType"] == "com.apple.security.scep" {
+			inner, ok := p["PayloadContent"].(map[string]any)
+			require.True(t, ok, "SCEP payload should carry a dictionary")
+			return inner
+		}
+	}
+	t.Fatal("no SCEP payload found in profile")
+	return nil
+}
+
+func conditionalAccessProfileFixture() appleProfileTemplateData {
+	return appleProfileTemplateData{
+		CACertBase64:     "dGVzdC1jZXJ0aWZpY2F0ZQ==",
+		SCEPURL:          "https://fleet.example.com/api/fleet/conditional_access/scep",
+		Challenge:        "abc123-normal-enroll-secret",
+		CertificateCN:    "fleet-conditional-access",
+		MTLSURL:          "https://fleet.example.com/mtls",
+		CACertUUID:       "00000000-0000-0000-0000-000000000001",
+		SCEPPayloadUUID:  "00000000-0000-0000-0000-000000000002",
+		IdentityPrefUUID: "00000000-0000-0000-0000-000000000003",
+		ChromeConfigUUID: "00000000-0000-0000-0000-000000000004",
+		RootPayloadUUID:  "00000000-0000-0000-0000-000000000005",
+	}
+}
+
+// TestConditionalAccessProfileEscapesInterpolatedValues checks that a value
+// carrying XML markup becomes literal text rather than structure: the parsed
+// profile gains no keys, and the value survives intact.
+func TestConditionalAccessProfileEscapesInterpolatedValues(t *testing.T) {
+	t.Parallel()
+
+	payload := `secret</string><key>Injected</key><string>true</string><key>Ignored</key><string>`
+	d := conditionalAccessProfileFixture()
+	d.Challenge = payload
+
+	scep := conditionalAccessSCEPPayload(t, renderConditionalAccessProfile(t, d))
+
+	require.NotContains(t, scep, "Injected", "an interpolated value must not add keys to the payload")
+	require.NotContains(t, scep, "Ignored")
+	require.Equal(t, payload, scep["Challenge"], "the value must survive as literal text")
+}
+
+// TestConditionalAccessProfileChallengeRoundTrips covers the other half of
+// escaping: a benign enroll secret containing XML metacharacters must reach the
+// device byte-for-byte, or it would no longer match as a SCEP challenge.
+func TestConditionalAccessProfileChallengeRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	for _, secret := range []string{
+		"p@ss&word<123>",
+		`quote"and'apostrophe`,
+		"amp&only",
+		"plain-secret-no-specials",
+	} {
+		t.Run(secret, func(t *testing.T) {
+			t.Parallel()
+			d := conditionalAccessProfileFixture()
+			d.Challenge = secret
+			scep := conditionalAccessSCEPPayload(t, renderConditionalAccessProfile(t, d))
+			require.Equal(t, secret, scep["Challenge"])
+		})
+	}
+}
+
+// TestConditionalAccessProfileChromePolicyIsValidJSON covers the one payload that
+// carries stringified JSON inside an XML text node. XML escaping is the wrong
+// layer there: a quote escaped as &#34; decodes back to " before Chrome parses
+// the value, so a quote-bearing URL would break out of the JSON string.
+func TestConditionalAccessProfileChromePolicyIsValidJSON(t *testing.T) {
+	t.Parallel()
+
+	d := conditionalAccessProfileFixture()
+	d.MTLSURL = `https://fleet.example.com/mtls?x=","filter":{"SUBJECT":{"CN":"HIJACKED`
+
+	var root struct {
+		PayloadContent []map[string]any `plist:"PayloadContent"`
+	}
+	_, err := plist.Unmarshal([]byte(renderConditionalAccessProfile(t, d)), &root)
+	require.NoError(t, err)
+
+	var policy string
+	for _, p := range root.PayloadContent {
+		if p["PayloadType"] != "com.apple.ManagedClient.preferences" {
+			continue
+		}
+		chrome := p["PayloadContent"].(map[string]any)["com.google.Chrome"].(map[string]any)
+		forced := chrome["Forced"].([]any)
+		settings := forced[0].(map[string]any)["mcx_preference_settings"].(map[string]any)
+		policy = settings["AutoSelectCertificateForUrls"].([]any)[0].(string)
+	}
+	require.NotEmpty(t, policy, "Chrome auto-select policy should be present")
+
+	var decoded struct {
+		Pattern string `json:"pattern"`
+		Filter  struct {
+			Subject struct {
+				CN string `json:"CN"`
+			} `json:"SUBJECT"`
+		} `json:"filter"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(policy), &decoded),
+		"policy must stay valid JSON: %s", policy)
+	require.Equal(t, d.MTLSURL, decoded.Pattern, "URL must survive as a literal JSON string value")
+	require.Equal(t, d.CertificateCN, decoded.Filter.Subject.CN,
+		"a URL must not be able to overwrite the certificate filter")
+}
+
+// TestConditionalAccessProfileEscapesEveryField is a drift guard: it walks the
+// template data by reflection and fails if any field reaches the profile
+// unescaped. A field added later that forgets its escaping func fails here
+// rather than shipping an injectable interpolation.
+func TestConditionalAccessProfileEscapesEveryField(t *testing.T) {
+	t.Parallel()
+
+	const marker = `<INJECTED-MARKER/>`
+	// The template escapes as XML in most places and as JSON inside the Chrome
+	// policy, so accept either encoding of the marker.
+	escapedForms := []string{`&lt;INJECTED-MARKER/&gt;`, `<INJECTED-MARKER/>`}
+
+	fields := reflect.TypeFor[appleProfileTemplateData]()
+	require.Positive(t, fields.NumField())
+
+	for i := range fields.NumField() {
+		f := fields.Field(i)
+		require.Equal(t, reflect.String, f.Type.Kind(),
+			"%s is not a string; this guard only covers string fields and needs updating", f.Name)
+
+		t.Run(f.Name, func(t *testing.T) {
+			t.Parallel()
+
+			d := conditionalAccessProfileFixture()
+			reflect.ValueOf(&d).Elem().Field(i).SetString(marker)
+			got := renderConditionalAccessProfile(t, d)
+
+			require.NotContains(t, got, marker,
+				"%s reaches the profile unescaped; wrap its interpolation with an escaping func", f.Name)
+
+			var found bool
+			for _, form := range escapedForms {
+				if strings.Contains(got, form) {
+					found = true
+					break
+				}
+			}
+			require.True(t, found,
+				"%s never appears in the profile: either it is unused and should be removed from the struct, "+
+					"or its interpolation is missing from the template", f.Name)
+		})
+	}
+}


### PR DESCRIPTION
**Related issue:** N/A

## Description

The conditional access Apple configuration profile is rendered from a `text/template`, and its values were interpolated into the plist markup unescaped. A value containing markup therefore became structure rather than text. The enroll secret used as the SCEP challenge is admin-set free text with no character restrictions, so a secret containing `</string><key>…` added key/value pairs to the profile delivered to enrolled devices, and left the challenge truncated so it no longer matched for enrollment.

Fleet already solved this for its other Apple profile templates: `mobileconfig.XMLEscapeString` is registered as an `xml` template func and used as `{{ .Field | xml }}` in `server/mdm/apple/mobileconfig/profiles.go`. This template was the one that didn't, so this brings it in line rather than introducing a new approach. All 13 interpolation sites now go through it.

Two things worth pointing out for review:

**The Chrome payload needed different handling.** It carries stringified JSON inside an XML text node (there's a `<!-- MUST be stringified JSON -->` comment above it). XML escaping is the wrong layer there — a quote escaped as `&#34;` is decoded back to `"` by the plist parser before Chrome parses the value as JSON, so it would still break out of the JSON string. Those two interpolations go through `encoding/json` instead, which escapes the quote as `\"` and also emits `<`, `>` and `&` as `\uXXXX`, keeping the result safe in the XML text node it sits in. `CertificateCN` is a constant, but `MTLSURL` derives from the server URL, and `url.String()` reproduces a query string verbatim, so a quote can reach it.

**Escaping preserves the value.** That matters as much as the escaping: the challenge has to arrive at the device byte-for-byte or SCEP enrollment stops matching. `TestConditionalAccessProfileChallengeRoundTrips` covers secrets containing `&`, `<`, `>`, `"` and `'`.

Verified against a running instance: profile generation returns the same 200 with the value intact, and parsing the delivered profile with a plist parser shows the expected key set.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, automated tests simulate multiple hosts and test for host isolation

- [x] QA'd all new/changed functionality manually

New tests, all asserting against the parsed plist rather than the rendered markup, so they don't pin the exact output of the escaper:

- `TestConditionalAccessProfileEscapesInterpolatedValues` — a value containing markup adds no keys to the parsed payload and survives as literal text.
- `TestConditionalAccessProfileChallengeRoundTrips` — enroll secrets containing XML metacharacters reach the device unchanged.
- `TestConditionalAccessProfileChromePolicyIsValidJSON` — the Chrome policy stays valid JSON and a URL can't overwrite the certificate filter.
- `TestConditionalAccessProfileEscapesEveryField` — a reflection drift guard over the template data; a field added later without escaping fails here rather than shipping.

Each was checked by reverting the corresponding change and confirming the test fails, so they pin the behaviour rather than describing it. Removing the escaping from one field produces `Challenge reaches the profile unescaped`; switching the Chrome payload back to XML escaping produces a JSON parse failure showing the rewritten certificate filter.

Manual QA on a local instance: set a global enroll secret containing `<`, `>`, `&` and `"`, fetched `/api/latest/fleet/conditional_access/idp/apple/profile`, and confirmed with a plist parser that the SCEP payload carries only its expected keys and that `Challenge` comes back as the full original string.

- [x] Confirmed that the fix is not expected to adversely impact load test results


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Apple conditional-access configuration profiles so values containing markup are preserved as literal text.
  - Ensured embedded Chrome certificate-selection policies remain valid when values include special characters.

- **Tests**
  - Added comprehensive validation for escaped profile values, challenge round-tripping, and policy formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->